### PR TITLE
fix(config): warn for stale web search providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gateway/media: prevent image filenames from overriding generic non-image byte sniffing, so zip/octet-stream payloads mislabeled as images are offloaded or rejected before they become inline image attachments.
+- Plugins/web search: downgrade stale optional provider installs to warnings so Gateway and doctor repair paths keep running after startup provider selection. Refs #82313. Thanks @crackmac.
 - MS Teams/media: sniff inline `data:image/*` attachment bytes before staging them, skipping payloads that are not actually images.
 - Update: let package-swap `doctor --fix` persist core config repairs while plugin schemas are still converging, preventing update failures on externalized channel configs.
 - Telegram: let authorized text `/stop` commands use the fast-abort path before queued agent work, so active turns stop immediately instead of processing the abort after the turn finishes. Fixes #82162. Thanks @civiltox.

--- a/src/config/config.web-search-provider.test.ts
+++ b/src/config/config.web-search-provider.test.ts
@@ -481,6 +481,41 @@ describe("web search provider config", () => {
     expectAllowedValuesInclude(issue, ["brave"]);
   });
 
+  it("warns for installable provider ids when stale plugin config is present", () => {
+    const res = validateConfigObjectWithPlugins(
+      {
+        ...buildWebSearchProviderConfig({
+          provider: "brave",
+        }),
+        plugins: {
+          entries: {
+            brave: {
+              config: {
+                webSearch: {},
+              },
+            },
+          },
+        },
+      },
+      {
+        pluginMetadataSnapshot: {
+          manifestRegistry: {
+            plugins: [],
+            diagnostics: [],
+          },
+        },
+      },
+    );
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) {
+      return;
+    }
+    const warning = findValidationMessage(res.warnings, "tools.web.search.provider");
+    expect(warning.message).toContain("web_search provider is not available: brave");
+    expect(warning.message).toContain('configured plugin "brave" is unavailable');
+  });
+
   it("rejects unknown provider ids without plugin evidence", () => {
     const res = validateConfigObjectWithPlugins({
       tools: {

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -1052,35 +1052,40 @@ function validateConfigObjectWithPluginsBase(
     ].toSorted((left, right) => left.localeCompare(right));
   };
 
+  const hasPluginEvidenceForWebSearchProvider = (
+    ...pluginOrProviderIds: readonly string[]
+  ): boolean => {
+    const candidateIds = new Set(
+      pluginOrProviderIds.map((id) => normalizePluginId(id)).filter((id) => id.length > 0),
+    );
+    if (candidateIds.size === 0) {
+      return false;
+    }
+    const matches = (pluginId: string) => candidateIds.has(normalizePluginId(pluginId));
+    const pluginConfig = config.plugins;
+    if (Array.isArray(pluginConfig?.allow) && pluginConfig.allow.some(matches)) {
+      return true;
+    }
+    if (isRecord(pluginConfig?.entries) && Object.keys(pluginConfig.entries).some(matches)) {
+      return true;
+    }
+    if (isRecord(pluginConfig?.installs) && Object.keys(pluginConfig.installs).some(matches)) {
+      return true;
+    }
+    for (const pluginId of candidateIds) {
+      if (ensureInstalledPluginRecordIds().has(pluginId)) {
+        return true;
+      }
+    }
+    return false;
+  };
+
   const hasStalePluginEvidenceForUnknownWebSearchProvider = (providerId: string): boolean => {
     const normalizedProviderId = normalizePluginId(providerId);
     if (!normalizedProviderId || ensureKnownIds().has(normalizedProviderId)) {
       return false;
     }
-    const pluginConfig = config.plugins;
-    if (
-      Array.isArray(pluginConfig?.allow) &&
-      pluginConfig.allow.some((pluginId) => normalizePluginId(pluginId) === normalizedProviderId)
-    ) {
-      return true;
-    }
-    if (
-      isRecord(pluginConfig?.entries) &&
-      Object.keys(pluginConfig.entries).some(
-        (pluginId) => normalizePluginId(pluginId) === normalizedProviderId,
-      )
-    ) {
-      return true;
-    }
-    if (
-      isRecord(pluginConfig?.installs) &&
-      Object.keys(pluginConfig.installs).some(
-        (pluginId) => normalizePluginId(pluginId) === normalizedProviderId,
-      )
-    ) {
-      return true;
-    }
-    return ensureInstalledPluginRecordIds().has(normalizedProviderId);
+    return hasPluginEvidenceForWebSearchProvider(providerId);
   };
 
   const validateWebSearchProvider = () => {
@@ -1102,11 +1107,19 @@ function validateConfigObjectWithPluginsBase(
       (entry) => entry.provider.id === trimmed,
     );
     if (installCatalogEntry) {
-      issues.push({
+      const issue = {
         path,
         message: `web_search provider is not available: ${trimmed} (install or enable plugin "${installCatalogEntry.pluginId}", then run openclaw doctor --fix)`,
         allowedValues: collectKnownWebSearchProviderIds(),
-      });
+      };
+      if (hasPluginEvidenceForWebSearchProvider(trimmed, installCatalogEntry.pluginId)) {
+        warnings.push({
+          ...issue,
+          message: `web_search provider is not available: ${trimmed} (configured plugin "${installCatalogEntry.pluginId}" is unavailable; Gateway will ignore this optional provider until the plugin is installed/enabled or openclaw doctor --fix repairs the config)`,
+        });
+        return;
+      }
+      issues.push(issue);
       return;
     }
     const allowedValues = collectKnownWebSearchProviderIds();


### PR DESCRIPTION
## Summary
- Build on #82376's Gateway startup-provider selection by fixing the remaining validation/repair safety path from #82313.
- Keep typo/unknown provider validation strict, but downgrade stale or unavailable optional installed web_search provider state to warnings when plugin evidence exists.
- Add regression coverage for install-catalog providers such as Brave when stale plugin config exists but the active manifest registry is unavailable.

## Verification
- `node scripts/run-vitest.mjs src/config/config.web-search-provider.test.ts src/plugins/channel-plugin-ids.test.ts`
- `node_modules/.bin/oxfmt --check --threads=1 src/config/validation.ts src/config/config.web-search-provider.test.ts CHANGELOG.md`
- `git diff --check origin/main...HEAD`
- Testbox `tbx_01krq7p5tc54wz5f51st96dvwf`: exact-branch `pnpm check:changed` against `4984167c` passed before the changelog wording cleanup; rerunning on `16d9c1f`.

## Real behavior proof
Behavior addressed: after #82376, configured external web_search providers are started during Gateway startup, but validation could still treat an installed/stale optional web_search provider as fatal when the active manifest registry is unavailable.

Before fix, `tools.web.search.provider: "brave"` with Brave plugin evidence and an empty active manifest registry still produced a fatal `web_search provider is not available: brave` issue.

After fix, that same validation path returns `ok: true` with warnings, preserving Gateway and doctor repair paths while still rejecting provider typos when there is no plugin evidence.

What was not tested: live Brave API search execution; this PR covers validation/repair behavior and relies on #82376 for startup-provider loading.

## Links
Refs #82313
Builds on #82376
