### PR TITLE
fix(android): make chat links tappable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Codex app-server: limit canonical OpenAI Codex app-server attribution rewrites to local transcript and trajectory records, leaving runtime/tool routing on the selected OpenAI model metadata so OpenAI API-key backup profiles keep their billing path.
+- Android/chat: make bare and markdown URLs in chat messages tappable by preserving Compose URL annotations in rendered markdown. Fixes #82187. (#82392) Thanks @neeravmakwana.
 - Codex app-server: release raw assistant completions when `turn/completed` is missing while keeping commentary/status items as progress, preventing completed Codex runs from hanging until timeout. Fixes #82343. (#82403) Thanks @IWhatsskill.
 - Agents/sessions: remove the transient `*.bak-<pid>-<ts>` backup written by `repairSessionFileIfNeeded` once the atomic replace succeeds, so a stuck session with a persistently malformed JSONL line no longer accumulates one snapshot per repair invocation. Fixes #80960. (#80969) Thanks @100yenadmin. Co-authored by @tynamite.
 - CLI/status: show plain empty-state messages instead of empty Channels and Sessions tables when no channels or sessions exist.

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMarkdown.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatMarkdown.kt
@@ -30,13 +30,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withLink
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -499,19 +502,12 @@ private fun AnnotatedString.Builder.appendInlineNode(
         }
       }
       is Link -> {
-        withStyle(
-          SpanStyle(
-            color = linkColor,
-            textDecoration = TextDecoration.Underline,
-          ),
-        ) {
-          appendInlineNode(
-            current.firstChild,
-            inlineCodeBg = inlineCodeBg,
-            inlineCodeColor = inlineCodeColor,
-            linkColor = linkColor,
-          )
-        }
+        appendLinkNode(
+          link = current,
+          inlineCodeBg = inlineCodeBg,
+          inlineCodeColor = inlineCodeColor,
+          linkColor = linkColor,
+        )
       }
       is MarkdownImage -> {
         val alt = buildPlainText(current.firstChild)
@@ -527,11 +523,67 @@ private fun AnnotatedString.Builder.appendInlineNode(
         }
       }
       else -> {
-        appendInlineNode(current.firstChild, inlineCodeBg = inlineCodeBg, inlineCodeColor = inlineCodeColor, linkColor = linkColor)
+        appendInlineNode(
+          current.firstChild,
+          inlineCodeBg = inlineCodeBg,
+          inlineCodeColor = inlineCodeColor,
+          linkColor = linkColor,
+        )
       }
     }
     current = current.next
   }
+}
+
+private fun AnnotatedString.Builder.appendLinkNode(
+  link: Link,
+  inlineCodeBg: Color,
+  inlineCodeColor: Color,
+  linkColor: Color,
+) {
+  val destination = link.destination?.trim().orEmpty()
+  val linkStyle =
+    SpanStyle(
+      color = linkColor,
+      textDecoration = TextDecoration.Underline,
+    )
+  if (destination.isEmpty()) {
+    withStyle(linkStyle) {
+      appendInlineNode(
+        link.firstChild,
+        inlineCodeBg = inlineCodeBg,
+        inlineCodeColor = inlineCodeColor,
+        linkColor = linkColor,
+      )
+    }
+    return
+  }
+
+  withLink(LinkAnnotation.Url(url = destination, styles = TextLinkStyles(style = linkStyle))) {
+    appendInlineNode(
+      link.firstChild,
+      inlineCodeBg = inlineCodeBg,
+      inlineCodeColor = inlineCodeColor,
+      linkColor = linkColor,
+    )
+  }
+}
+
+internal fun buildChatInlineMarkdown(
+  text: String,
+  linkColor: Color = Color.Blue,
+): AnnotatedString {
+  val document = markdownParser.parse(text) as Document
+  val paragraph = document.firstChild as? Paragraph ?: return AnnotatedString("")
+  return buildInlineMarkdown(
+    paragraph.firstChild,
+    InlineStyles(
+      inlineCodeBg = Color.Transparent,
+      inlineCodeColor = Color.Unspecified,
+      linkColor = linkColor,
+      baseCallout = TextStyle.Default,
+    ),
+  )
 }
 
 private fun buildPlainText(start: Node?): String {

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatMarkdownTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatMarkdownTest.kt
@@ -1,0 +1,42 @@
+package ai.openclaw.app.ui.chat
+
+import androidx.compose.ui.text.LinkAnnotation
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ChatMarkdownTest {
+  @Test
+  fun bareUrlsCarryClickableUrlAnnotations() {
+    val url = "https://www.amazon.it/GAZEBO-CANOPY-ACCIAIO-BIANCO-IMPERMEABILE/dp/B01G5R9FCK"
+
+    val annotated = buildChatInlineMarkdown("Open $url")
+
+    assertEquals("Open $url", annotated.text)
+    val links = annotated.getLinkAnnotations(0, annotated.length)
+    assertEquals(1, links.size)
+    assertEquals(5, links.single().start)
+    assertEquals(5 + url.length, links.single().end)
+    assertEquals(url, (links.single().item as LinkAnnotation.Url).url)
+  }
+
+  @Test
+  fun markdownLinksUseLabelTextAndDestinationUrl() {
+    val annotated = buildChatInlineMarkdown("Open [docs](https://docs.openclaw.ai/help/testing) now")
+
+    assertEquals("Open docs now", annotated.text)
+    val links = annotated.getLinkAnnotations(0, annotated.length)
+    assertEquals(1, links.size)
+    assertEquals(5, links.single().start)
+    assertEquals(9, links.single().end)
+    assertEquals("https://docs.openclaw.ai/help/testing", (links.single().item as LinkAnnotation.Url).url)
+  }
+
+  @Test
+  fun plainTextDoesNotAddLinkAnnotations() {
+    val annotated = buildChatInlineMarkdown("No link here")
+
+    assertEquals("No link here", annotated.text)
+    assertTrue(annotated.getLinkAnnotations(0, annotated.length).isEmpty())
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes #82187 by preserving Compose URL annotations for CommonMark link nodes in Android chat markdown.
- Adds focused Android unit coverage for bare autolinks, explicit markdown links, and non-link text.

## Root Cause
Android chat already parsed bare URLs and markdown links through CommonMark, but `ChatMarkdown` rendered `Link` nodes as plain styled spans. The rendered `Text` had underline/color styling, but no `LinkAnnotation.Url`, so Compose had no URL metadata or tap behavior to open the link.

## Why This Is Safe
The change stays inside the Android chat markdown inline renderer and keeps the existing CommonMark parser, link text, and visual styling behavior. It adds URL metadata to the same ranges that were already parsed as links, so non-link text and image/code rendering remain unchanged.

## Security / Runtime Controls
No auth, session routing, gateway, agent, tool permission, or message trust controls change. Link opening remains a user-initiated Android UI action from rendered chat text; this PR does not grant assistant messages any new runtime execution capability.

## Verification
- `git diff --check`
- `ANDROID_HOME="$HOME/Library/Android/sdk" ./gradlew :app:testPlayDebugUnitTest --tests ai.openclaw.app.ui.chat.ChatMarkdownTest`
- `CI=true PATH="/tmp/openclaw-swiftlint-shim:$PATH" pnpm check:changed`

## Real Behavior Proof
Behavior addressed: Android chat message link text now carries Compose URL annotations so tapped links can be handled by Compose/Android URI handling.
Real environment tested: Local macOS source checkout with Android Gradle unit test environment; no physical Android device or emulator smoke was run.
Exact steps or command run after this patch: `ANDROID_HOME="$HOME/Library/Android/sdk" ./gradlew :app:testPlayDebugUnitTest --tests ai.openclaw.app.ui.chat.ChatMarkdownTest`
Evidence after fix: The focused test asserts bare URL and markdown-link text, annotation ranges, and destination URLs using `AnnotatedString.getLinkAnnotations`.
Observed result after fix: Test passed.
What was not tested: Manual tap-through in the official Android app on a physical device or emulator.

## Out Of Scope
- Broader chat bubble copy/text selection behavior remains tracked separately by #57754.
- No changes to markdown block layout, images, code blocks, gateway chat transport, or Android session routing.

AI-assisted: yes.

Made with [Cursor](https://cursor.com)