### PR TITLE
fix(gateway): isolate gmail watcher restart and abort handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ Docs: https://docs.openclaw.ai
 - Memory search: stop using chokidar write-stability polling for memory and QMD watchers so large Markdown extraPath trees no longer build up regular file descriptors; changed files now settle through the existing debounced sync queue. Fixes #77327 and #78224. (#81802) Thanks @frankekn, @loyur, and @JanPlessow.
 - Message tool: rename the Discord channel-create schema field exposed to models from `type` to `channelType`, avoiding NVIDIA NIM JSON Schema parser failures while still accepting legacy `type` tool calls. (#78920) Thanks @YashSaliya.
 - Feishu: send CardKit streaming cards as delivered deltas and retry failed updates, preventing duplicated or dropped streamed text. Fixes #82417. (#82419) Thanks @hclsys.
+- Gateway/Gmail: stop queued post-ready Gmail sidecars before hot reload and abort stale Tailscale setup, so cancelled watcher restarts cannot rewrite an old public hook target or report abort-killed commands as success. (#82395) Thanks @samzong.
 
 ## 2026.5.14
 

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -9,6 +9,7 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { closePluginStateSqliteStore } from "../plugin-state/plugin-state-store.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
+import type { GatewayPostReadySidecarHandle } from "./server-startup-post-attach.js";
 
 const shutdownLog = createSubsystemLogger("gateway/shutdown");
 const GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS = 5_000;
@@ -176,6 +177,7 @@ export function createGatewayCloseHandler(params: {
   channelIds?: readonly ChannelId[];
   stopChannel: (name: ChannelId, accountId?: string) => Promise<void>;
   pluginServices: PluginServicesHandle | null;
+  postReadySidecars?: readonly GatewayPostReadySidecarHandle[];
   disposeSessionMcpRuntimes?: () => Promise<void>;
   disposeBundleLspRuntimes?: () => Promise<void>;
   cron: { stop: () => void };

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -4,6 +4,8 @@ import type { GatewayPluginReloadResult } from "./server-reload-handlers.js";
 import { createGatewayReloadHandlers } from "./server-reload-handlers.js";
 
 const hoisted = vi.hoisted(() => ({
+  startGmailWatcherWithLogs: vi.fn(async () => {}),
+  stopGmailWatcher: vi.fn(async () => {}),
   activeTaskCount: { value: 0 },
   activeTaskBlockers: [] as Array<{
     taskId: string;
@@ -13,6 +15,14 @@ const hoisted = vi.hoisted(() => ({
     label?: string;
     title?: string;
   }>,
+}));
+
+vi.mock("../hooks/gmail-watcher.js", () => ({
+  stopGmailWatcher: hoisted.stopGmailWatcher,
+}));
+
+vi.mock("../hooks/gmail-watcher-lifecycle.js", () => ({
+  startGmailWatcherWithLogs: hoisted.startGmailWatcherWithLogs,
 }));
 
 vi.mock("../tasks/task-registry.maintenance.js", async () => {
@@ -65,6 +75,7 @@ function createReloadHandlersForTest(logReload = { info: vi.fn(), warn: vi.fn() 
     setState: vi.fn(),
     startChannel: vi.fn(async () => {}),
     stopChannel: vi.fn(async () => {}),
+    stopPostReadySidecars: vi.fn(),
     reloadPlugins: vi.fn(
       async (): Promise<GatewayPluginReloadResult> => ({
         restartChannels: new Set(),
@@ -80,6 +91,8 @@ function createReloadHandlersForTest(logReload = { info: vi.fn(), warn: vi.fn() 
 }
 
 afterEach(() => {
+  hoisted.startGmailWatcherWithLogs.mockClear();
+  hoisted.stopGmailWatcher.mockClear();
   hoisted.activeTaskCount.value = 0;
   hoisted.activeTaskBlockers.length = 0;
 });
@@ -155,6 +168,69 @@ describe("gateway restart deferral preflight", () => {
       process.removeListener("SIGUSR1", signalSpy);
       restartTesting.resetSigusr1State();
     }
+  });
+});
+
+describe("gateway Gmail hot reload handlers", () => {
+  it("stops queued post-ready sidecars before restarting Gmail watcher", async () => {
+    const stopPostReadySidecars = vi.fn();
+    const { applyHotReload } = createGatewayReloadHandlers({
+      deps: {} as never,
+      broadcast: vi.fn(),
+      getState: () => ({
+        hooksConfig: {} as never,
+        hookClientIpConfig: {} as never,
+        heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
+        cronState: {
+          cron: { start: vi.fn(async () => {}), stop: vi.fn() },
+          storePath: "/tmp/cron.json",
+          cronEnabled: false,
+        } as never,
+        channelHealthMonitor: null,
+      }),
+      setState: vi.fn(),
+      startChannel: vi.fn(async () => {}),
+      stopChannel: vi.fn(async () => {}),
+      stopPostReadySidecars,
+      reloadPlugins: vi.fn(
+        async (): Promise<GatewayPluginReloadResult> => ({
+          restartChannels: new Set(),
+          activeChannels: new Set(),
+        }),
+      ),
+      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      logChannels: { info: vi.fn(), error: vi.fn() },
+      logCron: { error: vi.fn() },
+      logReload: { info: vi.fn(), warn: vi.fn() },
+      createHealthMonitor: () => null,
+    });
+    const nextConfig = {
+      hooks: { enabled: true, gmail: { account: "next@example.com" } },
+    } as never;
+
+    await applyHotReload(
+      {
+        changedPaths: ["hooks.gmail.account"],
+        restartGateway: false,
+        restartReasons: [],
+        hotReasons: ["hooks.gmail.account"],
+        reloadHooks: false,
+        restartGmailWatcher: true,
+        restartCron: false,
+        restartHeartbeat: false,
+        restartHealthMonitor: false,
+        reloadPlugins: false,
+        restartChannels: new Set(),
+        disposeMcpRuntimes: false,
+        noopPaths: [],
+      },
+      nextConfig,
+    );
+
+    expect(stopPostReadySidecars).toHaveBeenCalledBefore(hoisted.stopGmailWatcher);
+    expect(hoisted.startGmailWatcherWithLogs).toHaveBeenCalledWith(
+      expect.objectContaining({ cfg: nextConfig }),
+    );
   });
 });
 

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -98,6 +98,7 @@ type GatewayReloadHandlerParams = {
   setState: (state: GatewayHotReloadState) => void;
   startChannel: (name: ChannelKind) => Promise<void>;
   stopChannel: (name: ChannelKind) => Promise<void>;
+  stopPostReadySidecars?: () => void;
   reloadPlugins: (params: {
     nextConfig: OpenClawConfig;
     changedPaths: readonly string[];
@@ -336,6 +337,7 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
     }
 
     if (plan.restartGmailWatcher) {
+      params.stopPostReadySidecars?.();
       const [{ stopGmailWatcher }, { startGmailWatcherWithLogs }] = await Promise.all([
         import("../hooks/gmail-watcher.js"),
         import("../hooks/gmail-watcher-lifecycle.js"),
@@ -483,6 +485,7 @@ export function startManagedGatewayConfigReloader(params: ManagedGatewayConfigRe
     setState: params.setState,
     startChannel: params.startChannel,
     stopChannel: params.stopChannel,
+    stopPostReadySidecars: params.stopPostReadySidecars,
     reloadPlugins: params.reloadPlugins,
     logHooks: params.logHooks,
     logChannels: params.logChannels,

--- a/src/gateway/server-runtime-handles.ts
+++ b/src/gateway/server-runtime-handles.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
 import type { ChannelHealthMonitor } from "./channel-health-monitor.js";
+import type { GatewayPostReadySidecarHandle } from "./server-startup-post-attach.js";
 
 type GatewayConfigReloaderHandle = {
   stop: () => Promise<void>;
@@ -15,6 +16,7 @@ export type GatewayServerMutableState = {
   heartbeatRunner: HeartbeatRunner;
   stopGatewayUpdateCheck: () => void;
   tailscaleCleanup: (() => Promise<void>) | null;
+  postReadySidecars: GatewayPostReadySidecarHandle[];
   skillsRefreshTimer: ReturnType<typeof setTimeout> | null;
   skillsRefreshDelayMs: number;
   skillsChangeUnsub: () => void;
@@ -46,6 +48,7 @@ export function createGatewayServerMutableState(): GatewayServerMutableState {
     } satisfies HeartbeatRunner,
     stopGatewayUpdateCheck: () => {},
     tailscaleCleanup: null as (() => Promise<void>) | null,
+    postReadySidecars: [],
     skillsRefreshTimer: null as ReturnType<typeof setTimeout> | null,
     skillsRefreshDelayMs: 30_000,
     skillsChangeUnsub: () => {},

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -10,14 +10,14 @@ import { withEnvAsync } from "../test-utils/env.js";
 
 const hoisted = vi.hoisted(() => {
   const startPluginServices = vi.fn(async () => null);
-  const startGmailWatcherWithLogs = vi.fn(async () => undefined);
+  const startGmailWatcherWithLogs = vi.fn(async () => {});
   const loadInternalHooks = vi.fn(async () => 0);
   const setInternalHooksEnabled = vi.fn();
   const hasInternalHookListeners = vi.fn(() => false);
   const startupHookEvent = { type: "gateway", action: "startup", sessionKey: "gateway:startup" };
   const createInternalHookEvent = vi.fn(() => startupHookEvent);
-  const triggerInternalHook = vi.fn(async () => undefined);
-  const startGatewayMemoryBackend = vi.fn(async () => undefined);
+  const triggerInternalHook = vi.fn(async () => {});
+  const startGatewayMemoryBackend = vi.fn(async () => {});
   const scheduleGatewayUpdateCheck = vi.fn(() => () => {});
   const startGatewayTailscaleExposure = vi.fn(async () => null);
   const logGatewayStartup = vi.fn();
@@ -41,8 +41,15 @@ const hoisted = vi.hoisted(() => {
     provider: "openai",
     model: "gpt-5.4",
   }));
+  const resolveHooksGmailModel = vi.fn<() => string | null>(() => null);
+  const loadModelCatalog = vi.fn(async () => ({}));
+  const getModelRefStatus = vi.fn(() => ({
+    key: "openai/gpt-5.4",
+    allowed: true,
+    inCatalog: true,
+  }));
   const resolveEmbeddedAgentRuntime = vi.fn(() => "pi");
-  const ensureOpenClawModelsJson = vi.fn(async () => undefined);
+  const ensureOpenClawModelsJson = vi.fn(async () => {});
   return {
     startPluginServices,
     startGmailWatcherWithLogs,
@@ -67,6 +74,9 @@ const hoisted = vi.hoisted(() => {
     resolveDefaultAgentDir,
     isCliProvider,
     resolveConfiguredModelRef,
+    resolveHooksGmailModel,
+    loadModelCatalog,
+    getModelRefStatus,
     resolveEmbeddedAgentRuntime,
     ensureOpenClawModelsJson,
   };
@@ -77,7 +87,7 @@ vi.mock("../agents/session-dirs.js", () => ({
 }));
 
 vi.mock("../agents/session-write-lock.js", () => ({
-  cleanStaleLockFiles: vi.fn(async () => undefined),
+  cleanStaleLockFiles: vi.fn(async () => {}),
 }));
 
 vi.mock("../agents/subagent-registry.js", () => ({
@@ -165,9 +175,15 @@ vi.mock("../agents/defaults.js", () => ({
   DEFAULT_PROVIDER: "openai",
 }));
 
+vi.mock("../agents/model-catalog.js", () => ({
+  loadModelCatalog: hoisted.loadModelCatalog,
+}));
+
 vi.mock("../agents/model-selection.js", () => ({
+  getModelRefStatus: hoisted.getModelRefStatus,
   isCliProvider: hoisted.isCliProvider,
   resolveConfiguredModelRef: hoisted.resolveConfiguredModelRef,
+  resolveHooksGmailModel: hoisted.resolveHooksGmailModel,
 }));
 
 vi.mock("../agents/pi-embedded-runner/runtime.js", () => ({
@@ -268,6 +284,16 @@ describe("startGatewayPostAttachRuntime", () => {
     hoisted.isCliProvider.mockReset();
     hoisted.isCliProvider.mockReturnValue(false);
     hoisted.resolveConfiguredModelRef.mockClear();
+    hoisted.resolveHooksGmailModel.mockReset();
+    hoisted.resolveHooksGmailModel.mockReturnValue(null);
+    hoisted.loadModelCatalog.mockReset();
+    hoisted.loadModelCatalog.mockResolvedValue({});
+    hoisted.getModelRefStatus.mockReset();
+    hoisted.getModelRefStatus.mockReturnValue({
+      key: "openai/gpt-5.4",
+      allowed: true,
+      inCatalog: true,
+    });
     hoisted.resolveEmbeddedAgentRuntime.mockReset();
     hoisted.resolveEmbeddedAgentRuntime.mockReturnValue("pi");
     hoisted.ensureOpenClawModelsJson.mockReset();
@@ -311,7 +337,7 @@ describe("startGatewayPostAttachRuntime", () => {
     });
     const startGatewaySidecars = vi.fn(async () => {
       events.push("sidecars");
-      return { pluginServices: null };
+      return { pluginServices: null, postReadySidecars: [] };
     });
 
     await startGatewayPostAttachRuntime(
@@ -436,7 +462,7 @@ describe("startGatewayPostAttachRuntime", () => {
     const startGatewaySidecars = vi.fn(async (params) => {
       events.push("sidecars");
       expect(params.pluginRegistry).toBe(loadedPluginRegistry);
-      return { pluginServices: null };
+      return { pluginServices: null, postReadySidecars: [] };
     });
 
     await startGatewayPostAttachRuntime(
@@ -492,7 +518,7 @@ describe("startGatewayPostAttachRuntime", () => {
     });
     const startGatewaySidecars = vi.fn(async () => {
       events.push("sidecars");
-      return { pluginServices: null };
+      return { pluginServices: null, postReadySidecars: [] };
     });
 
     const runtimePromise = startGatewayPostAttachRuntime(
@@ -568,7 +594,7 @@ describe("startGatewayPostAttachRuntime", () => {
         pluginRegistry: createPostAttachParams().pluginRegistry,
         defaultWorkspaceDir: "/tmp/openclaw-workspace",
         deps: {} as never,
-        startChannels: vi.fn(async () => undefined),
+        startChannels: vi.fn(async () => {}),
         log: { warn: vi.fn() },
         logHooks: {
           info: vi.fn(),
@@ -596,9 +622,11 @@ describe("startGatewayPostAttachRuntime", () => {
 
   it("waits for sidecars by default before returning", async () => {
     let resumeSidecars: (() => void) | undefined;
-    const sidecarsReady = new Promise<{ pluginServices: null }>((resolve) => {
-      resumeSidecars = () => resolve({ pluginServices: null });
-    });
+    const sidecarsReady = new Promise<{ pluginServices: null; postReadySidecars: [] }>(
+      (resolve) => {
+        resumeSidecars = () => resolve({ pluginServices: null, postReadySidecars: [] });
+      },
+    );
     const startGatewaySidecars = vi.fn(async () => {
       return await sidecarsReady;
     });
@@ -691,7 +719,7 @@ describe("startGatewayPostAttachRuntime", () => {
               resolvePrewarm = () => resolve(undefined);
             }),
         );
-        const startChannels = vi.fn(async () => undefined);
+        const startChannels = vi.fn(async () => {});
 
         const sidecarsPromise = startGatewaySidecars({
           cfg: {
@@ -736,11 +764,263 @@ describe("startGatewayPostAttachRuntime", () => {
     );
   });
 
+  it("stops post-ready sidecars registered after close started", () => {
+    const postReadySidecar = { stop: vi.fn() };
+
+    __testing.stopPostReadySidecarsAfterCloseStarted({
+      postReadySidecars: [postReadySidecar],
+      closeStarted: true,
+    });
+
+    expect(postReadySidecar.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps post-ready sidecars running when close has not started", () => {
+    const postReadySidecar = { stop: vi.fn() };
+
+    __testing.stopPostReadySidecarsAfterCloseStarted({
+      postReadySidecars: [postReadySidecar],
+      closeStarted: false,
+    });
+
+    expect(postReadySidecar.stop).not.toHaveBeenCalled();
+  });
+
+  it("runs Gmail watcher after sidecars are ready", async () => {
+    let resolveWatcher: (() => void) | undefined;
+    hoisted.startGmailWatcherWithLogs.mockImplementationOnce(
+      async () =>
+        await new Promise<void>((resolve) => {
+          resolveWatcher = resolve;
+        }),
+    );
+    const onPostReadySidecars = vi.fn();
+    const log = { warn: vi.fn() };
+
+    const result = await startGatewaySidecars({
+      cfg: {
+        hooks: { enabled: true, internal: { enabled: false }, gmail: { account: "me" } },
+      } as never,
+      pluginRegistry: createPostAttachParams().pluginRegistry,
+      defaultWorkspaceDir: "/tmp/openclaw-workspace",
+      deps: {} as never,
+      startChannels: vi.fn(async () => {}),
+      log,
+      logHooks: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+      logChannels: {
+        info: vi.fn(),
+        error: vi.fn(),
+      },
+    });
+
+    expect(result.postReadySidecars).toHaveLength(1);
+    expect(hoisted.startGmailWatcherWithLogs).not.toHaveBeenCalled();
+    onPostReadySidecars(result.postReadySidecars);
+    expect(onPostReadySidecars).toHaveBeenCalledWith(result.postReadySidecars);
+
+    await vi.waitFor(() => {
+      expect(hoisted.startGmailWatcherWithLogs).toHaveBeenCalledTimes(1);
+    });
+    expect(log.warn).not.toHaveBeenCalled();
+
+    if (!resolveWatcher) {
+      throw new Error("Expected gmail watcher resolver to be initialized");
+    }
+    resolveWatcher();
+  });
+
+  it("logs post-ready Gmail watcher failures without delaying sidecar readiness", async () => {
+    const log = { warn: vi.fn() };
+    hoisted.startGmailWatcherWithLogs.mockRejectedValueOnce(new Error("boom"));
+
+    const result = await startGatewaySidecars({
+      cfg: {
+        hooks: { enabled: true, internal: { enabled: false }, gmail: { account: "me" } },
+      } as never,
+      pluginRegistry: createPostAttachParams().pluginRegistry,
+      defaultWorkspaceDir: "/tmp/openclaw-workspace",
+      deps: {} as never,
+      startChannels: vi.fn(async () => {}),
+      log,
+      logHooks: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+      logChannels: {
+        info: vi.fn(),
+        error: vi.fn(),
+      },
+    });
+
+    expect(result.postReadySidecars).toHaveLength(1);
+    await vi.waitFor(() => {
+      expect(log.warn).toHaveBeenCalledWith(
+        "sidecars.gmail-watch failed after gateway ready: Error: boom",
+      );
+    });
+  });
+
+  it("cancels a post-ready Gmail watcher before the immediate starts", async () => {
+    const result = await startGatewaySidecars({
+      cfg: {
+        hooks: { enabled: true, internal: { enabled: false }, gmail: { account: "me" } },
+      } as never,
+      pluginRegistry: createPostAttachParams().pluginRegistry,
+      defaultWorkspaceDir: "/tmp/openclaw-workspace",
+      deps: {} as never,
+      startChannels: vi.fn(async () => {}),
+      log: { warn: vi.fn() },
+      logHooks: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+      logChannels: {
+        info: vi.fn(),
+        error: vi.fn(),
+      },
+    });
+
+    expect(result.postReadySidecars).toHaveLength(1);
+    result.postReadySidecars[0]?.stop();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(hoisted.startGmailWatcherWithLogs).not.toHaveBeenCalled();
+  });
+
+  it("cancels a post-ready Gmail watcher after the immediate enters", async () => {
+    let releaseImport: (() => void) | undefined;
+    vi.doMock("../hooks/gmail-watcher-lifecycle.js", async () => {
+      await new Promise<void>((resolve) => {
+        releaseImport = resolve;
+      });
+      return {
+        startGmailWatcherWithLogs: hoisted.startGmailWatcherWithLogs,
+      };
+    });
+    vi.resetModules();
+    try {
+      const { startGatewaySidecars: startGatewaySidecarsWithDelayedImport } =
+        await import("./server-startup-post-attach.js");
+
+      const result = await startGatewaySidecarsWithDelayedImport({
+        cfg: {
+          hooks: { enabled: true, internal: { enabled: false }, gmail: { account: "me" } },
+        } as never,
+        pluginRegistry: createPostAttachParams().pluginRegistry,
+        defaultWorkspaceDir: "/tmp/openclaw-workspace",
+        deps: {} as never,
+        startChannels: vi.fn(async () => {}),
+        log: { warn: vi.fn() },
+        logHooks: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+        },
+        logChannels: {
+          info: vi.fn(),
+          error: vi.fn(),
+        },
+      });
+
+      await vi.waitFor(() => {
+        expect(releaseImport).toBeDefined();
+      });
+      result.postReadySidecars[0]?.stop();
+      releaseImport?.();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(hoisted.startGmailWatcherWithLogs).not.toHaveBeenCalled();
+    } finally {
+      vi.doUnmock("../hooks/gmail-watcher-lifecycle.js");
+      vi.resetModules();
+    }
+  });
+
+  it("keeps already-started Gmail watcher cleanup on close", async () => {
+    const postReadySidecars = [{ stop: vi.fn() }];
+    const stopChannel = vi.fn(async () => {});
+    const pluginServices = { stop: vi.fn(async () => {}) };
+    const { createGatewayCloseHandler } = await import("./server-close.js");
+
+    const close = createGatewayCloseHandler({
+      bonjourStop: null,
+      tailscaleCleanup: null,
+      channelIds: [],
+      stopChannel,
+      pluginServices,
+      postReadySidecars,
+      cron: { stop: vi.fn() },
+      heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() },
+      nodePresenceTimers: new Map(),
+      broadcast: vi.fn(),
+      tickInterval: setInterval(() => {}, 1 << 30),
+      healthInterval: setInterval(() => {}, 1 << 30),
+      dedupeCleanup: setInterval(() => {}, 1 << 30),
+      mediaCleanup: null,
+      agentUnsub: null,
+      heartbeatUnsub: null,
+      transcriptUnsub: null,
+      lifecycleUnsub: null,
+      chatRunState: { clear: vi.fn() },
+      clients: new Set(),
+      configReloader: { stop: vi.fn(async () => {}) },
+      wss: { close: vi.fn((callback: () => void) => callback()) } as never,
+      httpServer: { close: vi.fn((callback: () => void) => callback()) } as never,
+    });
+
+    await close();
+
+    expect(postReadySidecars[0]?.stop).not.toHaveBeenCalled();
+    expect(pluginServices.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs Gmail model validation after sidecars are ready", async () => {
+    hoisted.resolveHooksGmailModel.mockReturnValueOnce("openai/gpt-5.4");
+
+    const result = await startGatewaySidecars({
+      cfg: {
+        hooks: { internal: { enabled: false }, gmail: { model: "openai/gpt-5.4" } },
+      } as never,
+      pluginRegistry: createPostAttachParams().pluginRegistry,
+      defaultWorkspaceDir: "/tmp/openclaw-workspace",
+      deps: {} as never,
+      startChannels: vi.fn(async () => {}),
+      log: { warn: vi.fn() },
+      logHooks: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+      logChannels: {
+        info: vi.fn(),
+        error: vi.fn(),
+      },
+    });
+
+    expect(result.postReadySidecars).toHaveLength(1);
+    expect(hoisted.loadModelCatalog).not.toHaveBeenCalled();
+
+    await vi.waitFor(() => {
+      expect(hoisted.loadModelCatalog).toHaveBeenCalledTimes(1);
+    });
+    expect(hoisted.getModelRefStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ ref: "openai/gpt-5.4" }),
+    );
+  });
+
   it("keeps startup-gated methods unavailable while sidecars are still resuming", async () => {
     let resumeSidecars: (() => void) | undefined;
-    const sidecarsReady = new Promise<{ pluginServices: null }>((resolve) => {
-      resumeSidecars = () => resolve({ pluginServices: null });
-    });
+    const sidecarsReady = new Promise<{ pluginServices: null; postReadySidecars: [] }>(
+      (resolve) => {
+        resumeSidecars = () => resolve({ pluginServices: null, postReadySidecars: [] });
+      },
+    );
     const startGatewaySidecars = vi.fn(async () => {
       return await sidecarsReady;
     });
@@ -788,7 +1068,7 @@ describe("startGatewayPostAttachRuntime", () => {
         pluginRegistry: createPostAttachParams().pluginRegistry,
         defaultWorkspaceDir: "/tmp/openclaw-workspace",
         deps,
-        startChannels: vi.fn(async () => undefined),
+        startChannels: vi.fn(async () => {}),
         log: { warn: vi.fn() },
         logHooks: {
           info: vi.fn(),
@@ -838,7 +1118,7 @@ describe("startGatewayPostAttachRuntime", () => {
       pluginRegistry: createPostAttachParams().pluginRegistry,
       defaultWorkspaceDir: "/tmp/openclaw-workspace",
       deps: {} as never,
-      startChannels: vi.fn(async () => undefined),
+      startChannels: vi.fn(async () => {}),
       log: { warn: vi.fn() },
       logHooks: {
         info: vi.fn(),
@@ -865,7 +1145,7 @@ describe("startGatewayPostAttachRuntime", () => {
   it("passes typed gateway_start context with config, workspace dir, and a live cron getter", async () => {
     const runGatewayStart = vi.fn<
       (event: PluginHookGatewayStartEvent, ctx: PluginHookGatewayContext) => Promise<void>
-    >(async () => undefined);
+    >(async () => {});
     const hookRunner = {
       hasHooks: vi.fn((hookName: string) => hookName === "gateway_start"),
       runGatewayStart,
@@ -926,7 +1206,7 @@ describe("startGatewayPostAttachRuntime", () => {
   it("resolves gateway_start cron from the live runtime getter before deps fallback", async () => {
     const runGatewayStart = vi.fn<
       (event: PluginHookGatewayStartEvent, ctx: PluginHookGatewayContext) => Promise<void>
-    >(async () => undefined);
+    >(async () => {});
     const hookRunner = {
       hasHooks: vi.fn((hookName: string) => hookName === "gateway_start"),
       runGatewayStart,
@@ -975,7 +1255,7 @@ function createPostAttachRuntimeDeps(
     logGatewayStartup: hoisted.logGatewayStartup,
     refreshLatestUpdateRestartSentinel: hoisted.refreshLatestUpdateRestartSentinel,
     scheduleGatewayUpdateCheck: hoisted.scheduleGatewayUpdateCheck,
-    startGatewaySidecars: vi.fn(async () => ({ pluginServices: null })),
+    startGatewaySidecars: vi.fn(async () => ({ pluginServices: null, postReadySidecars: [] })),
     startGatewayTailscaleExposure: hoisted.startGatewayTailscaleExposure,
     ...overrides,
   };
@@ -1013,7 +1293,7 @@ function createPostAttachParams(overrides: Partial<PostAttachParams> = {}): Post
     } as never,
     defaultWorkspaceDir: "/tmp/openclaw-workspace",
     deps: {} as never,
-    startChannels: vi.fn(async () => undefined),
+    startChannels: vi.fn(async () => {}),
     logHooks: {
       info: vi.fn(),
       warn: vi.fn(),

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -788,9 +788,12 @@ describe("startGatewayPostAttachRuntime", () => {
 
   it("runs Gmail watcher after sidecars are ready", async () => {
     let resolveWatcher: (() => void) | undefined;
+    let watcherSignal: AbortSignal | undefined;
     hoisted.startGmailWatcherWithLogs.mockImplementationOnce(
-      async () =>
+      async (...args: unknown[]) =>
         await new Promise<void>((resolve) => {
+          const [params] = args as [{ signal?: AbortSignal }];
+          watcherSignal = params.signal;
           resolveWatcher = resolve;
         }),
     );
@@ -825,11 +828,14 @@ describe("startGatewayPostAttachRuntime", () => {
     await vi.waitFor(() => {
       expect(hoisted.startGmailWatcherWithLogs).toHaveBeenCalledTimes(1);
     });
+    expect(watcherSignal?.aborted).toBe(false);
     expect(log.warn).not.toHaveBeenCalled();
 
     if (!resolveWatcher) {
       throw new Error("Expected gmail watcher resolver to be initialized");
     }
+    result.postReadySidecars[0]?.stop();
+    expect(watcherSignal?.aborted).toBe(true);
     resolveWatcher();
   });
 

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -150,24 +150,26 @@ function schedulePostReadySidecarTask(params: {
   startupTrace?: GatewayStartupTrace;
   name: string;
   log: { warn: (msg: string) => void };
-  run: (isStopped: () => boolean) => Awaitable<void>;
+  run: (isStopped: () => boolean, signal: AbortSignal) => Awaitable<void>;
 }): GatewayPostReadySidecarHandle {
   let stopped = false;
+  const abortController = new AbortController();
   const isStopped = () => stopped;
   const handle = setImmediate(() => {
     if (isStopped()) {
       return;
     }
-    void measureStartup(params.startupTrace, params.name, () => params.run(isStopped)).catch(
-      (err) => {
-        params.log.warn(`${params.name} failed after gateway ready: ${String(err)}`);
-      },
-    );
+    void measureStartup(params.startupTrace, params.name, () =>
+      params.run(isStopped, abortController.signal),
+    ).catch((err) => {
+      params.log.warn(`${params.name} failed after gateway ready: ${String(err)}`);
+    });
   });
   handle.unref?.();
   return {
     stop: () => {
       stopped = true;
+      abortController.abort();
       clearImmediate(handle);
     },
   };
@@ -620,7 +622,7 @@ export async function startGatewaySidecars(params: {
         startupTrace: params.startupTrace,
         name: "sidecars.gmail-watch",
         log: params.log,
-        run: async (isStopped) => {
+        run: async (isStopped, signal) => {
           const { startGmailWatcherWithLogs } = await import("../hooks/gmail-watcher-lifecycle.js");
           if (isStopped()) {
             return;
@@ -629,6 +631,7 @@ export async function startGatewaySidecars(params: {
             cfg: params.cfg,
             log: params.logHooks,
             isCancelled: isStopped,
+            signal,
           });
         },
       }),

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -45,6 +45,22 @@ type GatewayMemoryStartupPolicy =
   | { mode: "immediate" }
   | { mode: "idle"; delayMs: number };
 
+export type GatewayPostReadySidecarHandle = {
+  stop: () => void;
+};
+
+export function stopPostReadySidecarsAfterCloseStarted(params: {
+  postReadySidecars: readonly GatewayPostReadySidecarHandle[];
+  closeStarted: boolean;
+}): void {
+  if (!params.closeStarted) {
+    return;
+  }
+  for (const postReadySidecar of params.postReadySidecars) {
+    postReadySidecar.stop();
+  }
+}
+
 async function measureStartup<T>(
   startupTrace: GatewayStartupTrace | undefined,
   name: string,
@@ -134,14 +150,27 @@ function schedulePostReadySidecarTask(params: {
   startupTrace?: GatewayStartupTrace;
   name: string;
   log: { warn: (msg: string) => void };
-  run: () => Awaitable<void>;
-}): void {
+  run: (isStopped: () => boolean) => Awaitable<void>;
+}): GatewayPostReadySidecarHandle {
+  let stopped = false;
+  const isStopped = () => stopped;
   const handle = setImmediate(() => {
-    void measureStartup(params.startupTrace, params.name, params.run).catch((err) => {
-      params.log.warn(`${params.name} failed after gateway ready: ${String(err)}`);
-    });
+    if (isStopped()) {
+      return;
+    }
+    void measureStartup(params.startupTrace, params.name, () => params.run(isStopped)).catch(
+      (err) => {
+        params.log.warn(`${params.name} failed after gateway ready: ${String(err)}`);
+      },
+    );
   });
   handle.unref?.();
+  return {
+    stop: () => {
+      stopped = true;
+      clearImmediate(handle);
+    },
+  };
 }
 
 async function pathExists(filePath: string): Promise<boolean> {
@@ -392,59 +421,7 @@ export async function startGatewaySidecars(params: {
   logChannels: { info: (msg: string) => void; error: (msg: string) => void };
   startupTrace?: GatewayStartupTrace;
 }) {
-  await measureStartup(params.startupTrace, "sidecars.gmail-watch", async () => {
-    if (params.cfg.hooks?.enabled && params.cfg.hooks.gmail?.account) {
-      const { startGmailWatcherWithLogs } = await import("../hooks/gmail-watcher-lifecycle.js");
-      await startGmailWatcherWithLogs({
-        cfg: params.cfg,
-        log: params.logHooks,
-      });
-    }
-  });
-
-  await measureStartup(params.startupTrace, "sidecars.gmail-model", async () => {
-    if (params.cfg.hooks?.gmail?.model) {
-      const [
-        { DEFAULT_MODEL, DEFAULT_PROVIDER },
-        { loadModelCatalog },
-        { getModelRefStatus, resolveConfiguredModelRef, resolveHooksGmailModel },
-      ] = await Promise.all([
-        import("../agents/defaults.js"),
-        import("../agents/model-catalog.js"),
-        import("../agents/model-selection.js"),
-      ]);
-      const hooksModelRef = resolveHooksGmailModel({
-        cfg: params.cfg,
-        defaultProvider: DEFAULT_PROVIDER,
-      });
-      if (hooksModelRef) {
-        const { provider: resolvedDefaultProvider, model: defaultModel } =
-          resolveConfiguredModelRef({
-            cfg: params.cfg,
-            defaultProvider: DEFAULT_PROVIDER,
-            defaultModel: DEFAULT_MODEL,
-          });
-        const catalog = await loadModelCatalog({ config: params.cfg });
-        const status = getModelRefStatus({
-          cfg: params.cfg,
-          catalog,
-          ref: hooksModelRef,
-          defaultProvider: resolvedDefaultProvider,
-          defaultModel,
-        });
-        if (!status.allowed) {
-          params.logHooks.warn(
-            `hooks.gmail.model "${status.key}" not in agents.defaults.models allowlist (will use primary instead)`,
-          );
-        }
-        if (!status.inCatalog) {
-          params.logHooks.warn(
-            `hooks.gmail.model "${status.key}" not in the model catalog (may fail at runtime)`,
-          );
-        }
-      }
-    }
-  });
+  const postReadySidecars: GatewayPostReadySidecarHandle[] = [];
 
   const internalHooksConfigured = hasConfiguredInternalHooks(params.cfg);
   await measureStartup(params.startupTrace, "sidecars.internal-hooks", async () => {
@@ -637,7 +614,82 @@ export async function startGatewaySidecars(params: {
     },
   });
 
-  return { pluginServices };
+  if (params.cfg.hooks?.enabled && params.cfg.hooks.gmail?.account) {
+    postReadySidecars.push(
+      schedulePostReadySidecarTask({
+        startupTrace: params.startupTrace,
+        name: "sidecars.gmail-watch",
+        log: params.log,
+        run: async (isStopped) => {
+          const { startGmailWatcherWithLogs } = await import("../hooks/gmail-watcher-lifecycle.js");
+          if (isStopped()) {
+            return;
+          }
+          await startGmailWatcherWithLogs({
+            cfg: params.cfg,
+            log: params.logHooks,
+            isCancelled: isStopped,
+          });
+        },
+      }),
+    );
+  }
+
+  if (params.cfg.hooks?.gmail?.model) {
+    postReadySidecars.push(
+      schedulePostReadySidecarTask({
+        startupTrace: params.startupTrace,
+        name: "sidecars.gmail-model",
+        log: params.log,
+        run: async (isStopped) => {
+          const [
+            { DEFAULT_MODEL, DEFAULT_PROVIDER },
+            { loadModelCatalog },
+            { getModelRefStatus, resolveConfiguredModelRef, resolveHooksGmailModel },
+          ] = await Promise.all([
+            import("../agents/defaults.js"),
+            import("../agents/model-catalog.js"),
+            import("../agents/model-selection.js"),
+          ]);
+          if (isStopped()) {
+            return;
+          }
+          const hooksModelRef = resolveHooksGmailModel({
+            cfg: params.cfg,
+            defaultProvider: DEFAULT_PROVIDER,
+          });
+          if (hooksModelRef) {
+            const { provider: resolvedDefaultProvider, model: defaultModel } =
+              resolveConfiguredModelRef({
+                cfg: params.cfg,
+                defaultProvider: DEFAULT_PROVIDER,
+                defaultModel: DEFAULT_MODEL,
+              });
+            const catalog = await loadModelCatalog({ config: params.cfg });
+            const status = getModelRefStatus({
+              cfg: params.cfg,
+              catalog,
+              ref: hooksModelRef,
+              defaultProvider: resolvedDefaultProvider,
+              defaultModel,
+            });
+            if (!status.allowed) {
+              params.logHooks.warn(
+                `hooks.gmail.model "${status.key}" not in agents.defaults.models allowlist (will use primary instead)`,
+              );
+            }
+            if (!status.inCatalog) {
+              params.logHooks.warn(
+                `hooks.gmail.model "${status.key}" not in the model catalog (may fail at runtime)`,
+              );
+            }
+          }
+        },
+      }),
+    );
+  }
+
+  return { pluginServices, postReadySidecars };
 }
 
 type GatewayPostAttachRuntimeDeps = {
@@ -716,6 +768,7 @@ export async function startGatewayPostAttachRuntime(
     }) => Awaitable<void>;
     getCronService?: () => PluginHookGatewayCronService | null | undefined;
     onPluginServices?: (pluginServices: PluginServicesHandle | null) => void;
+    onPostReadySidecars?: (postReadySidecars: GatewayPostReadySidecarHandle[]) => void;
     onSidecarsReady?: () => void;
     startupTrace?: GatewayStartupTrace;
     deferSidecars?: boolean;
@@ -778,7 +831,7 @@ export async function startGatewayPostAttachRuntime(
         );
 
   const sidecarsPromise = params.minimalTestGateway
-    ? Promise.resolve({ pluginServices: null, pluginRegistry })
+    ? Promise.resolve({ pluginServices: null, pluginRegistry, postReadySidecars: [] })
     : new Promise<void>((resolve) => setImmediate(resolve)).then(async () => {
         params.log.info("starting channels and sidecars...");
         const loaderStatsBefore = getPluginModuleLoaderStats();
@@ -813,6 +866,7 @@ export async function startGatewayPostAttachRuntime(
           params.unavailableGatewayMethods.delete(method);
         }
         params.onPluginServices?.(result.pluginServices);
+        params.onPostReadySidecars?.(result.postReadySidecars);
         params.onSidecarsReady?.();
         params.startupTrace?.mark("sidecars.ready");
         params.log.info("gateway ready");
@@ -885,4 +939,5 @@ export const __testing = {
   resolveGatewayMemoryStartupPolicy,
   schedulePrimaryModelPrewarm,
   shouldSkipStartupModelPrewarm,
+  stopPostReadySidecarsAfterCloseStarted,
 };

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -960,6 +960,13 @@ export async function startGatewayServer(
       getRuntimeSnapshot,
       getEventLoopHealth: readinessEventLoopHealth.snapshot,
     });
+  const stopRegisteredPostReadySidecars = () => {
+    const postReadySidecars = runtimeState.postReadySidecars;
+    runtimeState.postReadySidecars = [];
+    for (const postReadySidecar of postReadySidecars) {
+      postReadySidecar.stop();
+    }
+  };
   const createCloseHandler =
     () => async (opts?: { reason?: string; restartExpectedMs?: number | null }) => {
       const channelIds = listLoadedChannelPlugins().map((plugin) => plugin.id as ChannelId);
@@ -972,6 +979,7 @@ export async function startGatewayServer(
         channelIds,
         stopChannel,
         pluginServices: runtimeState.pluginServices,
+        postReadySidecars: runtimeState.postReadySidecars,
         cron: runtimeState.cronState.cron,
         heartbeatRunner: runtimeState.heartbeatRunner,
         updateCheckStop: runtimeState.stopGatewayUpdateCheck,
@@ -998,6 +1006,7 @@ export async function startGatewayServer(
   let clearFallbackGatewayContextForServer = () => {};
   const closeOnStartupFailure = async () => {
     try {
+      stopRegisteredPostReadySidecars();
       await runClosePrelude();
       await createCloseHandler()({ reason: "gateway startup failed" });
     } finally {
@@ -1456,68 +1465,79 @@ export async function startGatewayServer(
       tailscaleCleanup: runtimeState.tailscaleCleanup,
       pluginServices: runtimeState.pluginServices,
     } = await startupTrace.measure("runtime.post-attach", () =>
-      loadGatewayStartupPostAttachModule().then(({ startGatewayPostAttachRuntime }) =>
-        startGatewayPostAttachRuntime({
-          minimalTestGateway,
-          cfgAtStart,
-          bindHost,
-          bindHosts: httpBindHosts,
-          port,
-          tlsEnabled: gatewayTls.enabled,
-          log,
-          isNixMode,
-          startupStartedAt: opts.startupStartedAt,
-          broadcast,
-          tailscaleMode,
-          resetOnExit: tailscaleConfig.resetOnExit ?? false,
-          preserveFunnel: tailscaleConfig.preserveFunnel ?? false,
-          controlUiBasePath,
-          logTailscale,
-          gatewayPluginConfigAtStart,
-          pluginRegistry,
-          defaultWorkspaceDir,
-          deps,
-          startChannels,
-          logHooks,
-          logChannels,
-          unavailableGatewayMethods,
-          loadStartupPlugins: runtimePluginsLoaded
-            ? undefined
-            : async () => {
-                const { loadGatewayStartupPluginRuntime } = await loadStartupPluginsModule();
-                return loadGatewayStartupPluginRuntime({
-                  cfg: gatewayPluginConfigAtStart,
-                  activationSourceConfig: startupActivationSourceConfig,
-                  workspaceDir: defaultWorkspaceDir,
-                  log,
-                  baseMethods,
-                  coreGatewayMethodNames,
-                  hostServices: pluginHostServices,
-                  startupPluginIds,
-                  pluginLookUpTable,
-                  startupTrace,
-                });
-              },
-          onStartupPluginsLoading: () => {
-            startupPendingReason = "startup-sidecars";
-          },
-          onStartupPluginsLoaded: async (loaded) => {
-            replaceAttachedPluginRuntime(loaded);
-            startupPendingReason = "startup-sidecars";
-            await refreshAttachedGatewayDiscovery(loaded.pluginRegistry);
-          },
-          getCronService: () =>
-            runtimeState?.cronState.cron as PluginHookGatewayCronService | undefined,
-          onPluginServices: (pluginServices) => {
-            runtimeState.pluginServices = pluginServices;
-          },
-          onSidecarsReady: () => {
-            startupSidecarsReady = true;
-            activateScheduledServicesWhenReady();
-          },
-          startupTrace,
-          deferSidecars: opts.deferStartupSidecars === true,
-        }),
+      loadGatewayStartupPostAttachModule().then(
+        ({ startGatewayPostAttachRuntime, stopPostReadySidecarsAfterCloseStarted }) =>
+          startGatewayPostAttachRuntime({
+            minimalTestGateway,
+            cfgAtStart,
+            bindHost,
+            bindHosts: httpBindHosts,
+            port,
+            tlsEnabled: gatewayTls.enabled,
+            log,
+            isNixMode,
+            startupStartedAt: opts.startupStartedAt,
+            broadcast,
+            tailscaleMode,
+            resetOnExit: tailscaleConfig.resetOnExit ?? false,
+            preserveFunnel: tailscaleConfig.preserveFunnel ?? false,
+            controlUiBasePath,
+            logTailscale,
+            gatewayPluginConfigAtStart,
+            pluginRegistry,
+            defaultWorkspaceDir,
+            deps,
+            startChannels,
+            logHooks,
+            logChannels,
+            unavailableGatewayMethods,
+            loadStartupPlugins: runtimePluginsLoaded
+              ? undefined
+              : async () => {
+                  const { loadGatewayStartupPluginRuntime } = await loadStartupPluginsModule();
+                  return loadGatewayStartupPluginRuntime({
+                    cfg: gatewayPluginConfigAtStart,
+                    activationSourceConfig: startupActivationSourceConfig,
+                    workspaceDir: defaultWorkspaceDir,
+                    log,
+                    baseMethods,
+                    coreGatewayMethodNames,
+                    hostServices: pluginHostServices,
+                    startupPluginIds,
+                    pluginLookUpTable,
+                    startupTrace,
+                  });
+                },
+            onStartupPluginsLoading: () => {
+              startupPendingReason = "startup-sidecars";
+            },
+            onStartupPluginsLoaded: async (loaded) => {
+              replaceAttachedPluginRuntime(loaded);
+              startupPendingReason = "startup-sidecars";
+              await refreshAttachedGatewayDiscovery(loaded.pluginRegistry);
+            },
+            getCronService: () =>
+              runtimeState?.cronState.cron as PluginHookGatewayCronService | undefined,
+            onPluginServices: (pluginServices) => {
+              runtimeState.pluginServices = pluginServices;
+            },
+            onPostReadySidecars: (postReadySidecars) => {
+              runtimeState.postReadySidecars = postReadySidecars;
+              stopPostReadySidecarsAfterCloseStarted({
+                postReadySidecars,
+                closeStarted: closePreludeStarted,
+              });
+              if (closePreludeStarted) {
+                runtimeState.postReadySidecars = [];
+              }
+            },
+            onSidecarsReady: () => {
+              startupSidecarsReady = true;
+              activateScheduledServicesWhenReady();
+            },
+            startupTrace,
+            deferSidecars: opts.deferStartupSidecars === true,
+          }),
       ),
     ));
     startupTrace.detail("memory.ready", collectProcessMemoryUsageMb());
@@ -1558,6 +1578,7 @@ export async function startGatewayServer(
       },
       startChannel,
       stopChannel,
+      stopPostReadySidecars: stopRegisteredPostReadySidecars,
       reloadPlugins: reloadAttachedGatewayPlugins,
       logHooks,
       logChannels,
@@ -1628,6 +1649,7 @@ export async function startGatewayServer(
     close: async (opts) => {
       try {
         markClosePreludeStarted();
+        stopRegisteredPostReadySidecars();
         // Run gateway_stop plugin hook before shutdown
         const { runGlobalGatewayStopSafely } = await import("../plugins/hook-runner-global.js");
         await runGlobalGatewayStopSafely({

--- a/src/hooks/gmail-setup-utils.test.ts
+++ b/src/hooks/gmail-setup-utils.test.ts
@@ -205,4 +205,47 @@ describe("ensureTailscaleEndpoint", () => {
     expect(message).toContain("stdout: not-json");
     expect(message).toContain("code=0");
   });
+
+  it("passes abort signal to tailscale status and serve commands", async () => {
+    const abortController = new AbortController();
+    runCommandWithTimeoutMock
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({ Self: { DNSName: "host.tailnet.ts.net." } }),
+        stderr: "",
+        code: 0,
+        signal: null,
+        killed: false,
+      })
+      .mockResolvedValueOnce({
+        stdout: "",
+        stderr: "",
+        code: 0,
+        signal: null,
+        killed: false,
+      });
+
+    await ensureTailscaleEndpoint({
+      mode: "serve",
+      path: "/gmail-pubsub",
+      port: 8788,
+      signal: abortController.signal,
+    });
+
+    expect(runCommandWithTimeoutMock).toHaveBeenNthCalledWith(
+      1,
+      ["tailscale", "status", "--json"],
+      {
+        timeoutMs: 30_000,
+        signal: abortController.signal,
+      },
+    );
+    expect(runCommandWithTimeoutMock).toHaveBeenNthCalledWith(
+      2,
+      ["tailscale", "serve", "--bg", "--set-path", "/gmail-pubsub", "--yes", "8788"],
+      {
+        timeoutMs: 30_000,
+        signal: abortController.signal,
+      },
+    );
+  });
 });

--- a/src/hooks/gmail-setup-utils.ts
+++ b/src/hooks/gmail-setup-utils.ts
@@ -264,6 +264,7 @@ export async function ensureTailscaleEndpoint(params: {
   mode: "off" | "serve" | "funnel";
   path: string;
   port?: number;
+  signal?: AbortSignal;
   target?: string;
   token?: string;
 }): Promise<string> {
@@ -276,6 +277,7 @@ export async function ensureTailscaleEndpoint(params: {
   const statusCommand = formatCommand("tailscale", statusArgs);
   const status = await runCommandWithTimeout([tailscaleBin, ...statusArgs], {
     timeoutMs: 30_000,
+    signal: params.signal,
   });
   if (status.code !== 0) {
     throw new Error(formatCommandFailure(statusCommand, status));
@@ -305,6 +307,7 @@ export async function ensureTailscaleEndpoint(params: {
   const funnelCommand = formatCommand("tailscale", funnelArgs);
   const funnelResult = await runCommandWithTimeout([tailscaleBin, ...funnelArgs], {
     timeoutMs: 30_000,
+    signal: params.signal,
   });
   if (funnelResult.code !== 0) {
     throw new Error(formatCommandFailure(funnelCommand, funnelResult));

--- a/src/hooks/gmail-watcher-lifecycle.test.ts
+++ b/src/hooks/gmail-watcher-lifecycle.test.ts
@@ -31,15 +31,20 @@ describe("startGmailWatcherWithLogs", () => {
 
   it("passes cancellation state to watcher startup", async () => {
     const isCancelled = vi.fn(() => true);
+    const abortController = new AbortController();
     startGmailWatcherMock.mockResolvedValue({ started: false, reason: "startup cancelled" });
 
     await startGmailWatcherWithLogs({
       cfg: {},
       log,
       isCancelled,
+      signal: abortController.signal,
     });
 
-    expect(startGmailWatcherMock).toHaveBeenCalledWith({}, { isCancelled });
+    expect(startGmailWatcherMock).toHaveBeenCalledWith(
+      {},
+      { isCancelled, signal: abortController.signal },
+    );
   });
 
   it("logs startup success", async () => {

--- a/src/hooks/gmail-watcher-lifecycle.test.ts
+++ b/src/hooks/gmail-watcher-lifecycle.test.ts
@@ -29,6 +29,19 @@ describe("startGmailWatcherWithLogs", () => {
     delete process.env.OPENCLAW_SKIP_GMAIL_WATCHER;
   });
 
+  it("passes cancellation state to watcher startup", async () => {
+    const isCancelled = vi.fn(() => true);
+    startGmailWatcherMock.mockResolvedValue({ started: false, reason: "startup cancelled" });
+
+    await startGmailWatcherWithLogs({
+      cfg: {},
+      log,
+      isCancelled,
+    });
+
+    expect(startGmailWatcherMock).toHaveBeenCalledWith({}, { isCancelled });
+  });
+
   it("logs startup success", async () => {
     startGmailWatcherMock.mockResolvedValue({ started: true, reason: undefined });
 

--- a/src/hooks/gmail-watcher-lifecycle.ts
+++ b/src/hooks/gmail-watcher-lifecycle.ts
@@ -13,6 +13,7 @@ export async function startGmailWatcherWithLogs(params: {
   log: GMailWatcherLog;
   onSkipped?: () => void;
   isCancelled?: () => boolean;
+  signal?: AbortSignal;
 }) {
   if (isTruthyEnvValue(process.env.OPENCLAW_SKIP_GMAIL_WATCHER)) {
     params.onSkipped?.();
@@ -20,7 +21,10 @@ export async function startGmailWatcherWithLogs(params: {
   }
 
   try {
-    const gmailResult = await startGmailWatcher(params.cfg, { isCancelled: params.isCancelled });
+    const gmailResult = await startGmailWatcher(params.cfg, {
+      isCancelled: params.isCancelled,
+      signal: params.signal,
+    });
     if (gmailResult.started) {
       params.log.info("gmail watcher started");
       return;

--- a/src/hooks/gmail-watcher-lifecycle.ts
+++ b/src/hooks/gmail-watcher-lifecycle.ts
@@ -12,6 +12,7 @@ export async function startGmailWatcherWithLogs(params: {
   cfg: OpenClawConfig;
   log: GMailWatcherLog;
   onSkipped?: () => void;
+  isCancelled?: () => boolean;
 }) {
   if (isTruthyEnvValue(process.env.OPENCLAW_SKIP_GMAIL_WATCHER)) {
     params.onSkipped?.();
@@ -19,7 +20,7 @@ export async function startGmailWatcherWithLogs(params: {
   }
 
   try {
-    const gmailResult = await startGmailWatcher(params.cfg);
+    const gmailResult = await startGmailWatcher(params.cfg, { isCancelled: params.isCancelled });
     if (gmailResult.started) {
       params.log.info("gmail watcher started");
       return;

--- a/src/hooks/gmail-watcher.test.ts
+++ b/src/hooks/gmail-watcher.test.ts
@@ -1,0 +1,149 @@
+import { EventEmitter } from "node:events";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  hasBinary: vi.fn(() => true),
+  resolveExecutable: vi.fn((name: string) => name),
+  runCommandWithTimeout: vi.fn(),
+  spawn: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  spawn: mocks.spawn,
+}));
+
+vi.mock("../agents/skills.js", () => ({
+  hasBinary: mocks.hasBinary,
+}));
+
+vi.mock("../infra/executable-path.js", () => ({
+  resolveExecutable: mocks.resolveExecutable,
+}));
+
+vi.mock("../process/exec.js", () => ({
+  runCommandWithTimeout: mocks.runCommandWithTimeout,
+}));
+
+const { startGmailWatcher, stopGmailWatcher } = await import("./gmail-watcher.js");
+
+function createGmailConfig(account = "me@example.com") {
+  return {
+    hooks: {
+      enabled: true,
+      token: "hook-token",
+      gmail: {
+        account,
+        topic: "projects/demo/topics/gmail",
+        pushToken: "push-token",
+      },
+    },
+  } as never;
+}
+
+function deferredCommandResult() {
+  let resolve!: (result: { code: number; stdout: string; stderr: string }) => void;
+  const promise = new Promise<{ code: number; stdout: string; stderr: string }>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+describe("startGmailWatcher", () => {
+  beforeEach(async () => {
+    await stopGmailWatcher();
+    mocks.hasBinary.mockReturnValue(true);
+    mocks.resolveExecutable.mockImplementation((name: string) => name);
+    mocks.runCommandWithTimeout.mockReset();
+    mocks.spawn.mockReset();
+    mocks.spawn.mockImplementation(() => {
+      const child = new EventEmitter();
+      return Object.assign(child, {
+        kill: vi.fn(),
+        killed: false,
+      });
+    });
+  });
+
+  it("does not let a stale cancelled startup clear newer watcher config", async () => {
+    vi.useFakeTimers();
+    try {
+      let oldCancelled = false;
+      const oldWatchStart = deferredCommandResult();
+      const spawnedChildren: Array<
+        EventEmitter & { kill: ReturnType<typeof vi.fn>; killed: boolean }
+      > = [];
+      mocks.runCommandWithTimeout
+        .mockImplementationOnce(async () => await oldWatchStart.promise)
+        .mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+      mocks.spawn.mockImplementation(() => {
+        const child = Object.assign(new EventEmitter(), {
+          kill: vi.fn(),
+          killed: false,
+        });
+        spawnedChildren.push(child);
+        return child;
+      });
+
+      const staleStart = startGmailWatcher(createGmailConfig(), {
+        isCancelled: () => oldCancelled,
+      });
+
+      expect(mocks.runCommandWithTimeout).toHaveBeenCalledTimes(1);
+
+      await expect(startGmailWatcher(createGmailConfig("newer@example.com"))).resolves.toEqual({
+        started: true,
+      });
+      expect(mocks.spawn).toHaveBeenCalledTimes(1);
+
+      oldCancelled = true;
+      oldWatchStart.resolve({ code: 0, stdout: "", stderr: "" });
+      await expect(staleStart).resolves.toEqual({
+        started: false,
+        reason: "startup cancelled",
+      });
+
+      spawnedChildren[0]?.emit("exit", 1, null);
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expect(mocks.spawn).toHaveBeenCalledTimes(2);
+      expect(mocks.spawn.mock.calls[1]?.[1]).toContain("newer@example.com");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("aborts watch start and does not spawn gog serve when cancelled in flight", async () => {
+    let cancelled = false;
+    let watchStartSignal: AbortSignal | undefined;
+    mocks.runCommandWithTimeout.mockImplementation(
+      async (_args, options: { signal?: AbortSignal }) =>
+        await new Promise<{ code: number; stdout: string; stderr: string }>((resolve) => {
+          watchStartSignal = options.signal;
+          options.signal?.addEventListener(
+            "abort",
+            () => resolve({ code: 1, stdout: "", stderr: "aborted" }),
+            { once: true },
+          );
+        }),
+    );
+
+    const startPromise = startGmailWatcher(createGmailConfig(), {
+      isCancelled: () => cancelled,
+    });
+
+    await vi.waitFor(() => {
+      expect(watchStartSignal).toBeDefined();
+    });
+    cancelled = true;
+
+    await vi.waitFor(() => {
+      expect(watchStartSignal?.aborted).toBe(true);
+    });
+
+    await expect(startPromise).resolves.toEqual({
+      started: false,
+      reason: "startup cancelled",
+    });
+    expect(mocks.spawn).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/gmail-watcher.test.ts
+++ b/src/hooks/gmail-watcher.test.ts
@@ -146,4 +146,52 @@ describe("startGmailWatcher", () => {
     });
     expect(mocks.spawn).not.toHaveBeenCalled();
   });
+
+  it("aborts tailscale setup and does not spawn gog serve when cancelled in flight", async () => {
+    let cancelled = false;
+    let tailscaleSignal: AbortSignal | undefined;
+    mocks.runCommandWithTimeout.mockImplementation(
+      async (_args, options: { signal?: AbortSignal }) =>
+        await new Promise<{ code: number | null; stdout: string; stderr: string }>((resolve) => {
+          tailscaleSignal = options.signal;
+          options.signal?.addEventListener(
+            "abort",
+            () => resolve({ code: null, stdout: "", stderr: "aborted" }),
+            { once: true },
+          );
+        }),
+    );
+    const startPromise = startGmailWatcher(
+      {
+        hooks: {
+          enabled: true,
+          token: "hook-token",
+          gmail: {
+            account: "me@example.com",
+            topic: "projects/demo/topics/gmail",
+            pushToken: "push-token",
+            tailscale: { mode: "serve" },
+          },
+        },
+      } as never,
+      {
+        isCancelled: () => cancelled,
+      },
+    );
+
+    await vi.waitFor(() => {
+      expect(tailscaleSignal).toBeDefined();
+    });
+    cancelled = true;
+
+    await vi.waitFor(() => {
+      expect(tailscaleSignal?.aborted).toBe(true);
+    });
+
+    await expect(startPromise).resolves.toEqual({
+      started: false,
+      reason: "startup cancelled",
+    });
+    expect(mocks.spawn).not.toHaveBeenCalled();
+  });
 });

--- a/src/hooks/gmail-watcher.ts
+++ b/src/hooks/gmail-watcher.ts
@@ -75,10 +75,14 @@ function isGogAvailable(): boolean {
  */
 async function startGmailWatch(
   cfg: Pick<GmailHookRuntimeConfig, "account" | "label" | "topic">,
+  options: { signal?: AbortSignal } = {},
 ): Promise<boolean> {
   const args = [(gogBin ??= resolveExecutable("gog")), ...buildGogWatchStartArgs(cfg)];
   try {
-    const result = await runCommandWithTimeout(args, { timeoutMs: 120_000 });
+    const result = await runCommandWithTimeout(args, {
+      timeoutMs: 120_000,
+      signal: options.signal,
+    });
     if (result.code !== 0) {
       const message = result.stderr || result.stdout || "gog watch start failed";
       log.error(`watch start failed: ${message}`);
@@ -160,11 +164,23 @@ export type GmailWatcherStartResult = {
   reason?: string;
 };
 
+function cancelledGmailWatcherStart(
+  expectedConfig: GmailHookRuntimeConfig,
+): GmailWatcherStartResult {
+  if (currentConfig === expectedConfig) {
+    currentConfig = null;
+  }
+  return { started: false, reason: "startup cancelled" };
+}
+
 /**
  * Start the Gmail watcher service.
  * Called automatically by the gateway if hooks.gmail is configured.
  */
-export async function startGmailWatcher(cfg: OpenClawConfig): Promise<GmailWatcherStartResult> {
+export async function startGmailWatcher(
+  cfg: OpenClawConfig,
+  options: { isCancelled?: () => boolean } = {},
+): Promise<GmailWatcherStartResult> {
   // Check if gmail hooks are configured
   if (!cfg.hooks?.enabled) {
     return { started: false, reason: "hooks not enabled" };
@@ -187,6 +203,9 @@ export async function startGmailWatcher(cfg: OpenClawConfig): Promise<GmailWatch
   }
 
   const runtimeConfig = resolved.value;
+  if (options.isCancelled?.()) {
+    return cancelledGmailWatcherStart(runtimeConfig);
+  }
   currentConfig = runtimeConfig;
 
   // Set up Tailscale endpoint if needed
@@ -201,6 +220,9 @@ export async function startGmailWatcher(cfg: OpenClawConfig): Promise<GmailWatch
       log.info(
         `tailscale ${runtimeConfig.tailscale.mode} configured for port ${runtimeConfig.serve.port}`,
       );
+      if (options.isCancelled?.()) {
+        return cancelledGmailWatcherStart(runtimeConfig);
+      }
     } catch (err) {
       log.error(`tailscale setup failed: ${String(err)}`);
       return {
@@ -211,12 +233,26 @@ export async function startGmailWatcher(cfg: OpenClawConfig): Promise<GmailWatch
   }
 
   // Start the Gmail watch (register with Gmail API)
-  const watchStarted = await startGmailWatch(runtimeConfig);
+  const abortController = new AbortController();
+  const cancelPoll = setInterval(() => {
+    if (options.isCancelled?.()) {
+      abortController.abort();
+    }
+  }, 100);
+  cancelPoll.unref?.();
+  const watchStarted = await startGmailWatch(runtimeConfig, { signal: abortController.signal });
+  clearInterval(cancelPoll);
+  if (options.isCancelled?.()) {
+    return cancelledGmailWatcherStart(runtimeConfig);
+  }
   if (!watchStarted) {
     log.warn("gmail watch start failed, but continuing with serve");
   }
 
   // Spawn the gog serve process
+  if (options.isCancelled?.()) {
+    return cancelledGmailWatcherStart(runtimeConfig);
+  }
   shuttingDown = false;
   watcherProcess = spawnGogServe(runtimeConfig);
 

--- a/src/hooks/gmail-watcher.ts
+++ b/src/hooks/gmail-watcher.ts
@@ -164,6 +164,17 @@ export type GmailWatcherStartResult = {
   reason?: string;
 };
 
+type GmailWatcherCancellation = {
+  dispose: () => void;
+  isCancelled: () => boolean;
+  signal?: AbortSignal;
+};
+
+type GmailWatcherStartOptions = {
+  isCancelled?: () => boolean;
+  signal?: AbortSignal;
+};
+
 function cancelledGmailWatcherStart(
   expectedConfig: GmailHookRuntimeConfig,
 ): GmailWatcherStartResult {
@@ -173,13 +184,63 @@ function cancelledGmailWatcherStart(
   return { started: false, reason: "startup cancelled" };
 }
 
+function isGmailWatcherStartCancelled(options: GmailWatcherStartOptions): boolean {
+  return options.signal?.aborted === true || options.isCancelled?.() === true;
+}
+
+function createGmailWatcherCancellation(
+  options: GmailWatcherStartOptions,
+): GmailWatcherCancellation {
+  if (!options.signal && !options.isCancelled) {
+    return {
+      dispose: () => {},
+      isCancelled: () => false,
+    };
+  }
+
+  const abortController = new AbortController();
+  const abort = () => {
+    if (!abortController.signal.aborted) {
+      abortController.abort();
+    }
+  };
+  const onAbort = () => abort();
+  options.signal?.addEventListener("abort", onAbort, { once: true });
+
+  let cancelPoll: ReturnType<typeof setInterval> | null = null;
+  if (options.isCancelled) {
+    cancelPoll = setInterval(() => {
+      if (options.isCancelled?.()) {
+        abort();
+      }
+    }, 100);
+    cancelPoll.unref?.();
+  }
+
+  if (isGmailWatcherStartCancelled(options)) {
+    abort();
+  }
+
+  return {
+    dispose: () => {
+      if (cancelPoll) {
+        clearInterval(cancelPoll);
+        cancelPoll = null;
+      }
+      options.signal?.removeEventListener("abort", onAbort);
+    },
+    isCancelled: () => abortController.signal.aborted || isGmailWatcherStartCancelled(options),
+    signal: abortController.signal,
+  };
+}
+
 /**
  * Start the Gmail watcher service.
  * Called automatically by the gateway if hooks.gmail is configured.
  */
 export async function startGmailWatcher(
   cfg: OpenClawConfig,
-  options: { isCancelled?: () => boolean } = {},
+  options: GmailWatcherStartOptions = {},
 ): Promise<GmailWatcherStartResult> {
   // Check if gmail hooks are configured
   if (!cfg.hooks?.enabled) {
@@ -203,46 +264,47 @@ export async function startGmailWatcher(
   }
 
   const runtimeConfig = resolved.value;
-  if (options.isCancelled?.()) {
+  if (isGmailWatcherStartCancelled(options)) {
     return cancelledGmailWatcherStart(runtimeConfig);
   }
   currentConfig = runtimeConfig;
 
   // Set up Tailscale endpoint if needed
   if (runtimeConfig.tailscale.mode !== "off") {
+    const cancellation = createGmailWatcherCancellation(options);
     try {
       await ensureTailscaleEndpoint({
         mode: runtimeConfig.tailscale.mode,
         path: runtimeConfig.tailscale.path,
         port: runtimeConfig.serve.port,
+        signal: cancellation.signal,
         target: runtimeConfig.tailscale.target,
       });
       log.info(
         `tailscale ${runtimeConfig.tailscale.mode} configured for port ${runtimeConfig.serve.port}`,
       );
-      if (options.isCancelled?.()) {
+      if (cancellation.isCancelled()) {
         return cancelledGmailWatcherStart(runtimeConfig);
       }
     } catch (err) {
+      if (cancellation.isCancelled()) {
+        return cancelledGmailWatcherStart(runtimeConfig);
+      }
       log.error(`tailscale setup failed: ${String(err)}`);
       return {
         started: false,
         reason: `tailscale setup failed: ${String(err)}`,
       };
+    } finally {
+      cancellation.dispose();
     }
   }
 
   // Start the Gmail watch (register with Gmail API)
-  const abortController = new AbortController();
-  const cancelPoll = setInterval(() => {
-    if (options.isCancelled?.()) {
-      abortController.abort();
-    }
-  }, 100);
-  cancelPoll.unref?.();
-  const watchStarted = await startGmailWatch(runtimeConfig, { signal: abortController.signal });
-  clearInterval(cancelPoll);
-  if (options.isCancelled?.()) {
+  const cancellation = createGmailWatcherCancellation(options);
+  const watchStarted = await startGmailWatch(runtimeConfig, { signal: cancellation.signal });
+  cancellation.dispose();
+  if (cancellation.isCancelled()) {
     return cancelledGmailWatcherStart(runtimeConfig);
   }
   if (!watchStarted) {
@@ -250,7 +312,7 @@ export async function startGmailWatcher(
   }
 
   // Spawn the gog serve process
-  if (options.isCancelled?.()) {
+  if (isGmailWatcherStartCancelled(options)) {
     return cancelledGmailWatcherStart(runtimeConfig);
   }
   shuttingDown = false;

--- a/src/process/exec.test.ts
+++ b/src/process/exec.test.ts
@@ -192,6 +192,29 @@ describe("runCommandWithTimeout", () => {
     ).toBeNull();
   });
 
+  it("does not spawn when the abort signal is already aborted", async () => {
+    await loadExecModules({ mockSpawn: true });
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await runCommandWithTimeout(createSilentIdleArgv(), {
+      timeoutMs: 2_000,
+      signal: controller.signal,
+    });
+
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      stdout: "",
+      stderr: "",
+      code: null,
+      signal: null,
+      killed: false,
+      termination: "signal",
+      noOutputTimedOut: false,
+    });
+    expect(result.code).not.toBe(0);
+  });
+
   it.runIf(process.platform !== "win32")(
     "kills command when no output timeout elapses",
     { timeout: 5_000 },

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -250,6 +250,7 @@ export type CommandOptions = {
   env?: NodeJS.ProcessEnv;
   windowsVerbatimArguments?: boolean;
   noOutputTimeoutMs?: number;
+  signal?: AbortSignal;
 };
 
 const WINDOWS_CLOSE_STATE_SETTLE_TIMEOUT_MS = 250;
@@ -263,6 +264,7 @@ export function resolveProcessExitCode(params: {
   timedOut: boolean;
   noOutputTimedOut: boolean;
   killIssuedByTimeout: boolean;
+  killIssuedByAbort?: boolean;
 }): number | null {
   return (
     params.explicitCode ??
@@ -271,7 +273,8 @@ export function resolveProcessExitCode(params: {
     params.resolvedSignal == null &&
     !params.timedOut &&
     !params.noOutputTimedOut &&
-    !params.killIssuedByTimeout
+    !params.killIssuedByTimeout &&
+    !params.killIssuedByAbort
       ? 0
       : null)
   );
@@ -316,7 +319,7 @@ export async function runCommandWithTimeout(
 ): Promise<SpawnResult> {
   const options: CommandOptions =
     typeof optionsOrTimeout === "number" ? { timeoutMs: optionsOrTimeout } : optionsOrTimeout;
-  const { timeoutMs, cwd, input, env, noOutputTimeoutMs } = options;
+  const { timeoutMs, cwd, input, env, noOutputTimeoutMs, signal } = options;
   const hasInput = input !== undefined;
   const resolvedEnv = resolveCommandEnv({ argv, env });
   const stdio = resolveCommandStdio({ hasInput, preferInherit: true });
@@ -324,6 +327,18 @@ export async function runCommandWithTimeout(
     argv,
     windowsVerbatimArguments: options.windowsVerbatimArguments,
   });
+
+  if (signal?.aborted) {
+    return {
+      stdout: "",
+      stderr: "",
+      code: null,
+      signal: null,
+      killed: false,
+      termination: "signal",
+      noOutputTimedOut: false,
+    };
+  }
 
   const child = spawn(invocation.command, invocation.args, {
     stdio,
@@ -344,6 +359,7 @@ export async function runCommandWithTimeout(
     let timedOut = false;
     let noOutputTimedOut = false;
     let killIssuedByTimeout = false;
+    let killIssuedByAbort = false;
     let childExitState: { code: number | null; signal: NodeJS.Signals | null } | null = null;
     let closeFallbackTimer: NodeJS.Timeout | null = null;
     let noOutputTimer: NodeJS.Timeout | null = null;
@@ -351,6 +367,7 @@ export async function runCommandWithTimeout(
       typeof noOutputTimeoutMs === "number" &&
       Number.isFinite(noOutputTimeoutMs) &&
       noOutputTimeoutMs > 0;
+    let removeAbortListener: (() => void) | null = null;
 
     const clearNoOutputTimer = () => {
       if (!noOutputTimer) {
@@ -368,11 +385,15 @@ export async function runCommandWithTimeout(
       closeFallbackTimer = null;
     };
 
-    const killChild = () => {
+    const killChild = (byTimeout = true) => {
       if (settled || typeof child?.kill !== "function") {
         return;
       }
-      killIssuedByTimeout = true;
+      if (byTimeout) {
+        killIssuedByTimeout = true;
+      } else {
+        killIssuedByAbort = true;
+      }
       if (process.platform === "win32" && typeof child.pid === "number" && child.pid > 0) {
         try {
           spawn("taskkill", ["/PID", String(child.pid), "/T", "/F"], {
@@ -406,6 +427,11 @@ export async function runCommandWithTimeout(
       killChild();
     }, timeoutMs);
     armNoOutputTimer();
+    if (signal) {
+      const onAbort = () => killChild(false);
+      signal.addEventListener("abort", onAbort, { once: true });
+      removeAbortListener = () => signal.removeEventListener("abort", onAbort);
+    }
 
     if (hasInput && child.stdin) {
       // Swallow EPIPE from a prematurely-exited child; the exit handler
@@ -431,6 +457,8 @@ export async function runCommandWithTimeout(
       clearTimeout(timer);
       clearNoOutputTimer();
       clearCloseFallbackTimer();
+      removeAbortListener?.();
+      removeAbortListener = null;
       reject(err);
     });
     child.on("exit", (code, signal) => {
@@ -454,6 +482,8 @@ export async function runCommandWithTimeout(
       clearTimeout(timer);
       clearNoOutputTimer();
       clearCloseFallbackTimer();
+      removeAbortListener?.();
+      removeAbortListener = null;
       const resolvedSignal = childExitState?.signal ?? signal ?? child.signalCode ?? null;
       const resolvedCode = resolveProcessExitCode({
         explicitCode: childExitState?.code ?? code,
@@ -463,12 +493,13 @@ export async function runCommandWithTimeout(
         timedOut,
         noOutputTimedOut,
         killIssuedByTimeout,
+        killIssuedByAbort,
       });
       const termination = noOutputTimedOut
         ? "no-output-timeout"
         : timedOut
           ? "timeout"
-          : resolvedSignal != null
+          : resolvedSignal != null || killIssuedByAbort
             ? "signal"
             : "exit";
       const normalizedCode =


### PR DESCRIPTION
## Summary

- Problem: Gmail post-ready sidecars could run with stale state during hot reload, Tailscale setup could outlive cancellation, and aborting a command could be treated like a clean exit.
- Why it matters: stale sidecar startup can execute against outdated runtime state, rewrite the Tailscale public target, and incorrect command-status classification hides failures.
- What changed:
  - Stop queued post-ready sidecars before restarting the Gmail watcher in reload flow.
  - Propagate cancellation from post-ready sidecar stop through Gmail watcher startup into Tailscale status and serve/funnel commands.
  - Track abort-initiated kills separately and normalize their outcome as signal termination.
  - Add tests for ordered sidecar shutdown, Tailscale cancellation, and pre-aborted command execution.
- What did NOT change (scope boundary):
  - No public schema, provider contracts, or dependency changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed:
  - Sidecars ordering in Gmail watcher restart no longer allows stale post-ready sidecars to survive into fresh config reload.
  - Cancelling a stale Gmail startup now aborts in-flight Tailscale setup before it can apply an old serve/funnel target.
  - Abort-driven command shutdown now resolves as signal termination, not synthesized success.
- Real environment tested:
  - macOS local OpenClaw source worktree, Node.js v24.14.0.
  - Runtime proof imported the actual `src/hooks/gmail-watcher.ts` module and used temporary executable shims on `PATH` to record `tailscale` and `gog` process calls without real credentials.
- Exact steps or command run after this patch:
  - `node --import tsx --input-type=module <<'NODE'` with a runtime probe that:
    - installs temporary `tailscale` and `gog` executables on `PATH`;
    - starts stale Gmail watcher config for `old@example.com` with Tailscale target `old-target:8788`;
    - aborts that startup while the first `tailscale status --json` command is still in flight;
    - starts fresh Gmail watcher config for `new@example.com` with Tailscale target `new-target:8788`;
    - asserts stale result is `startup cancelled`, old Tailscale serve mutations are `0`, and new Tailscale serve mutations are `1`.
  - `node scripts/run-vitest.mjs src/hooks/gmail-watcher.test.ts src/hooks/gmail-setup-utils.test.ts src/hooks/gmail-watcher-lifecycle.test.ts src/gateway/server-startup-post-attach.test.ts`
  - `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
  - `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src.tsbuildinfo`
  - `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/gateway/server-startup-post-attach.test.ts src/gateway/server-startup-post-attach.ts src/hooks/gmail-setup-utils.test.ts src/hooks/gmail-setup-utils.ts src/hooks/gmail-watcher-lifecycle.test.ts src/hooks/gmail-watcher-lifecycle.ts src/hooks/gmail-watcher.test.ts src/hooks/gmail-watcher.ts`
  - `pnpm exec oxfmt --check --threads=1 src/gateway/server-startup-post-attach.test.ts src/gateway/server-startup-post-attach.ts src/hooks/gmail-setup-utils.test.ts src/hooks/gmail-setup-utils.ts src/hooks/gmail-watcher-lifecycle.test.ts src/hooks/gmail-watcher-lifecycle.ts src/hooks/gmail-watcher.test.ts src/hooks/gmail-watcher.ts`
  - `git diff --check`
- Evidence after fix:
  - Runtime proof output:
    ```text
    OpenClaw Gmail watcher restart abort proof
    stale result: {"started":false,"reason":"startup cancelled"}
    fresh result: {"started":true}
    old tailscale serve mutations: 0
    new tailscale serve mutations: 1
    observed command log:
      tailscale status --json
      tailscale status --json
      tailscale serve --bg --set-path /gmail-pubsub --yes new-target:8788
      gog gmail watch start --account new@example.com --label INBOX --topic projects/proof/topics/gmail
    RESULT: pass - aborted stale startup did not mutate the old Tailscale endpoint; fresh startup configured the new target.
    ```
  - Targeted Vitest output: `Test Files 4 passed (4)`, `Tests 44 passed (44)`.
  - `tsgo` core and source-test type checks completed with exit code 0.
  - Targeted oxlint reported `Found 0 warnings and 0 errors`.
  - Formatting and diff whitespace checks passed.
- Observed result after fix:
  - Stale cancelled startup returned `startup cancelled`.
  - No `tailscale serve --set-path ... old-target:8788` command ran after cancellation.
  - Fresh watcher startup configured exactly one `tailscale serve --set-path /gmail-pubsub --yes new-target:8788` command.
  - `runCommandWithTimeout` sets abort termination state and does not collapse it into exit-success semantics.
- What was not tested:
  - Real Gmail API credentials and real Tailscale network mutation against an operator tailnet were not used; the runtime proof used local executable shims to exercise actual OpenClaw watcher and process-control code without secrets.
  - Broad Testbox gate was not run because `crabbox` was unavailable locally (`crabbox` not in `PATH`, `../crabbox/bin/crabbox` missing, and `scripts/crabbox-wrapper.mjs` failed sanity checks).

## Root Cause (if applicable)

- Root cause:
  - Missing sequencing before Gmail watcher restart.
  - Missing cancellation propagation into Tailscale setup.
  - Missing abort-state carry-through in exit normalization.
- Missing detection / guardrail:
  - No stop-before-start check for post-ready sidecar queue in this path.
  - No regression proving Tailscale setup receives cancellation and avoids stale endpoint mutation.
  - Abort handling only inferred through generic kill state.
- Contributing context (if known):
  - Timing race during hot reload.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/gateway/server-reload-handlers.test.ts`
  - `src/gateway/server-startup-post-attach.test.ts`
  - `src/hooks/gmail-watcher.test.ts`
  - `src/hooks/gmail-setup-utils.test.ts`
  - `src/process/exec.test.ts`
- Scenario the test should lock in:
  - Sidecars are stopped before restart, post-ready stop aborts the active watcher startup signal, Tailscale commands receive the abort signal, and abort path does not resolve as exit success.
- Why this is the smallest reliable guardrail:
  - The bug is a deterministic cancellation boundary across Gateway sidecar scheduling, Gmail watcher startup, and command execution.
- Existing test that already covers this (if any):
  - Prior reload and process execution tests covered only part of the sequence.
- If no new test is added, why not:
  - New tests were needed for Tailscale setup cancellation.

## User-visible / Behavior Changes

- Hot-reload Gmail watcher now clears queued post-ready sidecars before restart.
- Cancelled stale Gmail startup can no longer continue Tailscale setup and overwrite the public Gmail hook target after a newer watcher starts.
- Abort-triggered command kill is reported as signal termination with non-success result semantics.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:
  - Not applicable.

## Repro + Verification

### Environment

- OS: macOS local shell
- Runtime/container: local shell, Node.js v24.14.0
- Model/provider: N/A
- Integration/channel (if any): Gmail watcher with local `tailscale`/`gog` executable shims
- Relevant config (redacted): local proof config with fake account names, fake hook token values, and no real credentials

### Steps

1. Run the runtime proof command described in the Real behavior proof section.
2. Confirm stale startup returns `startup cancelled`.
3. Confirm command log has no `old-target:8788` Tailscale serve mutation.
4. Confirm command log has exactly one `new-target:8788` Tailscale serve mutation.
5. Run the targeted tests, type checks, lint, format, and diff checks listed above.

### Expected

- No stale sidecar restart race.
- Cancelled stale Tailscale setup does not mutate the old endpoint.
- Fresh Gmail watcher startup configures the new endpoint once.
- Abort kill does not read as successful process exit.

### Actual

- Runtime proof and targeted checks matched expected behavior.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Runtime Gmail watcher restart/abort proof with temporary process shims and copied command output.
  - Unit test verification for sidecar sequencing, Tailscale signal propagation, and abort path.
  - Type/lint/format checks for the touched files.
- Edge cases checked:
  - Pre-aborted signal path.
  - close/reload ordering.
  - In-flight Tailscale setup cancellation.
- What you did **not** verify:
  - Real production Gmail/Tailscale credentials or real tailnet endpoint mutation.
  - Broad Testbox validation, because Crabbox was unavailable in this local worktree.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:
  - Not applicable.

## Risks and Mitigations

- Risk: additional cleanup step adds small shutdown overhead in hot-reload path.
  - Mitigation: already using existing lifecycle close helpers; only ordering changed.

