### PR TITLE
feat(gateway): add restart trace instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 - Agents/skills: cache hydrated `resolvedSkills` across warm gateway turns while keying reuse by the redacted effective config, reducing redundant skill snapshot rebuilds without crossing config-gated skill boundaries. (#81451) Thanks @solodmd.
 - Telegram/group chat: add opt-in `messages.groupChat.ambientTurns: "room_event"` handling so always-on ambient chatter can run as quiet room context and speak visibly only via the message tool. (#81317) Thanks @obviyus.
 - Codex/context engines: bind thread-bootstrap projection epochs to Codex app-server threads, carry redacted tool-result context into fresh threads, and rotate backend threads when projection state changes. (#82351) Thanks @jalehman.
+- Gateway: add opt-in restart trace logs for restart signal, active-work drain, close, next-start, ready, and memory spans. (#82396) Thanks @samzong.
 
 ### Fixes
 

--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -122,9 +122,10 @@ openclaw gateway restart --force
 Inline `--password` can be exposed in local process listings. Prefer `--password-file`, env, or a SecretRef-backed `gateway.auth.password`.
 </Warning>
 
-### Startup profiling
+### Gateway profiling
 
 - Set `OPENCLAW_GATEWAY_STARTUP_TRACE=1` to log phase timings during Gateway startup, including per-phase `eventLoopMax` delay and plugin lookup-table timings for installed-index, manifest registry, startup planning, and owner-map work.
+- Set `OPENCLAW_GATEWAY_RESTART_TRACE=1` to log restart-scoped `restart trace:` lines for restart signal handling, active-work drain, shutdown phases, next start, ready timing, and memory metrics.
 - Set `OPENCLAW_DIAGNOSTICS=timeline` with `OPENCLAW_DIAGNOSTICS_TIMELINE_PATH=<path>` to write a best-effort JSONL startup diagnostics timeline for external QA harnesses. You can also enable the flag with `diagnostics.flags: ["timeline"]` in config; the path is still env-provided. Add `OPENCLAW_DIAGNOSTICS_EVENT_LOOP=1` to include event-loop samples.
 - Run `pnpm test:startup:gateway -- --runs 5 --warmup 1` to benchmark Gateway startup. The benchmark records first process output, `/healthz`, `/readyz`, startup trace timings, event-loop delay, and plugin lookup-table timing details.
 

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -51,10 +51,14 @@ const waitForActiveTasks = vi.fn(async (_timeoutMs?: number) => ({ drained: true
 const resetAllLanes = vi.fn();
 const reloadTaskRegistryFromStore = vi.fn();
 const restartGatewayProcessWithFreshPid = vi.fn<
-  () => { mode: "spawned" | "supervised" | "disabled" | "failed"; pid?: number; detail?: string }
+  (_opts?: { env?: NodeJS.ProcessEnv }) => {
+    mode: "spawned" | "supervised" | "disabled" | "failed";
+    pid?: number;
+    detail?: string;
+  }
 >(() => ({ mode: "disabled" }));
 const respawnGatewayProcessForUpdate = vi.fn<
-  () => {
+  (_opts?: { env?: NodeJS.ProcessEnv }) => {
     mode: "spawned" | "supervised" | "disabled" | "failed";
     pid?: number;
     detail?: string;
@@ -110,8 +114,10 @@ vi.mock("../../infra/restart.js", () => ({
 }));
 
 vi.mock("../../infra/process-respawn.js", () => ({
-  respawnGatewayProcessForUpdate: () => respawnGatewayProcessForUpdate(),
-  restartGatewayProcessWithFreshPid: () => restartGatewayProcessWithFreshPid(),
+  respawnGatewayProcessForUpdate: (opts?: { env?: NodeJS.ProcessEnv }) =>
+    respawnGatewayProcessForUpdate(opts),
+  restartGatewayProcessWithFreshPid: (opts?: { env?: NodeJS.ProcessEnv }) =>
+    restartGatewayProcessWithFreshPid(opts),
 }));
 
 vi.mock("../../infra/restart-sentinel.js", () => ({
@@ -664,34 +670,47 @@ describe("runGatewayLoop", () => {
   it("releases the lock before exiting on spawned restart", async () => {
     vi.clearAllMocks();
     peekGatewaySigusr1RestartReason.mockReturnValue(undefined);
+    const originalTraceEnv = process.env.OPENCLAW_GATEWAY_RESTART_TRACE;
+    process.env.OPENCLAW_GATEWAY_RESTART_TRACE = "1";
 
-    await withIsolatedSignals(async ({ captureSignal }) => {
-      const lockRelease = vi.fn(async () => {});
-      acquireGatewayLock.mockResolvedValueOnce({
-        release: lockRelease,
+    try {
+      await withIsolatedSignals(async ({ captureSignal }) => {
+        const lockRelease = vi.fn(async () => {});
+        acquireGatewayLock.mockResolvedValueOnce({
+          release: lockRelease,
+        });
+
+        // Override process-respawn to return "spawned" mode
+        restartGatewayProcessWithFreshPid.mockReturnValueOnce({
+          mode: "spawned",
+          pid: 9999,
+        });
+
+        const exitCallOrder: string[] = [];
+        const { runtime, exited } = await createSignaledLoopHarness(exitCallOrder);
+        const sigusr1 = captureSignal("SIGUSR1");
+        lockRelease.mockImplementation(async () => {
+          exitCallOrder.push("lockRelease");
+        });
+
+        sigusr1();
+
+        await exited;
+        expect(lockRelease).toHaveBeenCalledTimes(1);
+        expect(runtime.exit).toHaveBeenCalledWith(0);
+        expect(exitCallOrder).toEqual(["lockRelease", "exit"]);
+        const [respawnOpts] = restartGatewayProcessWithFreshPid.mock.calls[0] ?? [];
+        expect(respawnOpts?.env?.OPENCLAW_GATEWAY_RESTART_TRACE_STARTED_AT_MS).toMatch(/^\d/u);
+        expect(respawnOpts?.env?.OPENCLAW_GATEWAY_RESTART_TRACE_LAST_AT_MS).toMatch(/^\d/u);
+        expect(writeGatewayRestartHandoffSync).not.toHaveBeenCalled();
       });
-
-      // Override process-respawn to return "spawned" mode
-      restartGatewayProcessWithFreshPid.mockReturnValueOnce({
-        mode: "spawned",
-        pid: 9999,
-      });
-
-      const exitCallOrder: string[] = [];
-      const { runtime, exited } = await createSignaledLoopHarness(exitCallOrder);
-      const sigusr1 = captureSignal("SIGUSR1");
-      lockRelease.mockImplementation(async () => {
-        exitCallOrder.push("lockRelease");
-      });
-
-      sigusr1();
-
-      await exited;
-      expect(lockRelease).toHaveBeenCalledTimes(1);
-      expect(runtime.exit).toHaveBeenCalledWith(0);
-      expect(exitCallOrder).toEqual(["lockRelease", "exit"]);
-      expect(writeGatewayRestartHandoffSync).not.toHaveBeenCalled();
-    });
+    } finally {
+      if (originalTraceEnv === undefined) {
+        delete process.env.OPENCLAW_GATEWAY_RESTART_TRACE;
+      } else {
+        process.env.OPENCLAW_GATEWAY_RESTART_TRACE = originalTraceEnv;
+      }
+    }
   });
 
   it("waits briefly before exiting on launchd supervised restart", async () => {

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from "node:crypto";
 import net from "node:net";
 import {
+  captureGatewayRestartTraceHandoff,
+  createGatewayRestartTraceHandoffEnv,
   measureGatewayRestartTrace,
   markGatewayRestartTrace,
   startGatewayRestartTrace,
@@ -152,7 +154,10 @@ export async function runGatewayLoop(params: {
     } = await loadGatewayLifecycleRuntimeModule();
 
     if (isUpdateRestart) {
-      const respawn = respawnGatewayProcessForUpdate();
+      const restartTraceHandoff = captureGatewayRestartTraceHandoff();
+      const respawn = respawnGatewayProcessForUpdate({
+        env: createGatewayRestartTraceHandoffEnv(restartTraceHandoff),
+      });
       if (respawn.mode === "spawned") {
         const port = params.lockPort;
         const healthy =
@@ -186,17 +191,18 @@ export async function runGatewayLoop(params: {
       }
       if (respawn.mode === "supervised") {
         const supervisorMode = detectRespawnSupervisor(process.env, process.platform);
-        writeGatewayRestartHandoffSync({
-          restartKind: "update-process",
-          reason: restartReason,
-          processInstanceId,
-          supervisorMode: supervisorMode ?? "external",
-        });
         markGatewayRestartTrace("restart.full-process-handoff", [
           ["kind", "update-process"],
           ["mode", respawn.mode],
           ["supervisorMode", supervisorMode ?? "external"],
         ]);
+        writeGatewayRestartHandoffSync({
+          restartKind: "update-process",
+          reason: restartReason,
+          processInstanceId,
+          supervisorMode: supervisorMode ?? "external",
+          restartTrace: captureGatewayRestartTraceHandoff(),
+        });
         gatewayLog.info("restart mode: update process respawn (supervisor restart)");
         if (supervisorMode === "launchd") {
           await new Promise((resolve) => {
@@ -227,7 +233,10 @@ export async function runGatewayLoop(params: {
     }
 
     // Release the lock BEFORE spawning so the child can acquire it immediately.
-    const respawn = restartGatewayProcessWithFreshPid();
+    const restartTraceHandoff = captureGatewayRestartTraceHandoff();
+    const respawn = restartGatewayProcessWithFreshPid({
+      env: createGatewayRestartTraceHandoffEnv(restartTraceHandoff),
+    });
     if (respawn.mode === "spawned" || respawn.mode === "supervised") {
       const supervisorMode =
         respawn.mode === "supervised"
@@ -237,20 +246,21 @@ export async function runGatewayLoop(params: {
         respawn.mode === "spawned"
           ? `spawned pid ${respawn.pid ?? "unknown"}`
           : "supervisor restart";
-      if (respawn.mode === "supervised") {
-        writeGatewayRestartHandoffSync({
-          restartKind: "full-process",
-          reason: restartReason,
-          processInstanceId,
-          supervisorMode: supervisorMode ?? "external",
-        });
-      }
       markGatewayRestartTrace("restart.full-process-handoff", [
         ["kind", "full-process"],
         ["mode", respawn.mode],
         ["pid", respawn.mode === "spawned" ? (respawn.pid ?? "unknown") : "none"],
         ["supervisorMode", supervisorMode ?? "none"],
       ]);
+      if (respawn.mode === "supervised") {
+        writeGatewayRestartHandoffSync({
+          restartKind: "full-process",
+          reason: restartReason,
+          processInstanceId,
+          supervisorMode: supervisorMode ?? "external",
+          restartTrace: captureGatewayRestartTraceHandoff(),
+        });
+      }
       gatewayLog.info(`restart mode: full process restart (${modeLabel})`);
       if (supervisorMode === "launchd") {
         // A short clean-exit pause keeps rapid SIGUSR1/config restarts from

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -1,5 +1,10 @@
 import { randomUUID } from "node:crypto";
 import net from "node:net";
+import {
+  measureGatewayRestartTrace,
+  markGatewayRestartTrace,
+  startGatewayRestartTrace,
+} from "../../gateway/restart-trace.js";
 import type { startGatewayServer } from "../../gateway/server.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { acquireGatewayLock } from "../../infra/gateway-lock.js";
@@ -187,6 +192,11 @@ export async function runGatewayLoop(params: {
           processInstanceId,
           supervisorMode: supervisorMode ?? "external",
         });
+        markGatewayRestartTrace("restart.full-process-handoff", [
+          ["kind", "update-process"],
+          ["mode", respawn.mode],
+          ["supervisorMode", supervisorMode ?? "external"],
+        ]);
         gatewayLog.info("restart mode: update process respawn (supervisor restart)");
         if (supervisorMode === "launchd") {
           await new Promise((resolve) => {
@@ -235,6 +245,12 @@ export async function runGatewayLoop(params: {
           supervisorMode: supervisorMode ?? "external",
         });
       }
+      markGatewayRestartTrace("restart.full-process-handoff", [
+        ["kind", "full-process"],
+        ["mode", respawn.mode],
+        ["pid", respawn.mode === "spawned" ? (respawn.pid ?? "unknown") : "none"],
+        ["supervisorMode", supervisorMode ?? "none"],
+      ]);
       gatewayLog.info(`restart mode: full process restart (${modeLabel})`);
       if (supervisorMode === "launchd") {
         // A short clean-exit pause keeps rapid SIGUSR1/config restarts from
@@ -301,6 +317,14 @@ export async function runGatewayLoop(params: {
     shuttingDown = true;
     const isRestart = action === "restart";
     gatewayLog.info(`received ${signal}; ${isRestart ? "restarting" : "shutting down"}`);
+    if (isRestart) {
+      startGatewayRestartTrace("restart.signal.received", [
+        ["signal", signal],
+        ["reason", restartReason ?? signal],
+        ["force", restartIntent?.force === true],
+        ["waitMs", restartIntent?.waitMs ?? "default"],
+      ]);
+    }
 
     let forceExitTimer: ReturnType<typeof setTimeout> | null = null;
     const armForceExitTimer = (forceExitMs: number) => {
@@ -365,105 +389,124 @@ export async function runGatewayLoop(params: {
         // On restart, wait for in-flight agent turns to finish before
         // tearing down the server so buffered messages are delivered.
         if (isRestart) {
-          const {
-            abortEmbeddedPiRun,
-            getInspectableActiveTaskRestartBlockers,
-            getActiveEmbeddedRunCount,
-            getActiveTaskCount,
-            markGatewayDraining,
-            waitForActiveEmbeddedRuns,
-            waitForActiveTasks,
-          } = await loadGatewayLifecycleRuntimeModule();
-          const formatTaskBlockers = () => {
-            const blockers = getInspectableActiveTaskRestartBlockers();
-            if (blockers.length === 0) {
-              return null;
-            }
-            const shown = blockers
-              .slice(0, 8)
-              .map((task) =>
-                [
-                  `taskId=${task.taskId}`,
-                  task.runId ? `runId=${task.runId}` : null,
-                  `status=${task.status}`,
-                  `runtime=${task.runtime}`,
-                  task.label ? `label=${task.label}` : null,
-                  task.title ? `title=${task.title.slice(0, 80)}` : null,
-                ]
-                  .filter((value): value is string => Boolean(value))
-                  .join(" "),
-              );
-            const omitted = blockers.length - shown.length;
-            return omitted > 0 ? `${shown.join("; ")}; +${omitted} more` : shown.join("; ");
-          };
-          const createStillPendingDrainLogger = () =>
-            setInterval(() => {
-              gatewayLog.warn(
-                `still draining ${getActiveTaskCount()} active task(s) and ${getActiveEmbeddedRunCount()} active embedded run(s) before restart`,
-              );
-            }, RESTART_DRAIN_STILL_PENDING_WARN_MS);
-
-          // Reject new enqueues immediately during the drain window so
-          // sessions get an explicit restart error instead of silent task loss.
-          markGatewayDraining();
-          const activeTasks = getActiveTaskCount();
-          const activeRuns = getActiveEmbeddedRunCount();
-
-          // Best-effort abort for compacting runs so long compaction operations
-          // don't hold session write locks across restart boundaries.
-          if (activeRuns > 0) {
-            abortEmbeddedPiRun(undefined, { mode: "compacting" });
-          }
-
-          if (activeTasks > 0 || activeRuns > 0) {
-            const taskBlockers = formatTaskBlockers();
-            gatewayLog.info(
-              `draining ${activeTasks} active task(s) and ${activeRuns} active embedded run(s) before restart ${formatRestartDrainBudget()}`,
-            );
-            if (taskBlockers) {
-              gatewayLog.warn(`restart blocked by active background task run(s): ${taskBlockers}`);
-            }
-            if (restartIntent?.force) {
-              gatewayLog.warn("forced restart requested; skipping active work drain");
-              abortEmbeddedPiRun(undefined, { mode: "all" });
-            } else {
-              const activeRunDrainWaitMs = resolveActiveRunDrainWaitMs(activeRuns);
-              const stillPendingDrainLogger = createStillPendingDrainLogger();
-              let abortedAfterRunGrace = false;
-              let tasksDrain: { drained: boolean } = { drained: true };
-              let runsDrain: { drained: boolean } = { drained: true };
-              try {
-                const tasksDrainPromise =
-                  activeTasks > 0
-                    ? waitForActiveTasks(restartDrainTimeoutMs)
-                    : Promise.resolve({ drained: true });
-                runsDrain =
-                  activeRuns > 0
-                    ? await waitForActiveEmbeddedRuns(activeRunDrainWaitMs)
-                    : { drained: true };
-                if (!runsDrain.drained && activeRuns > 0) {
-                  gatewayLog.warn(
-                    "active embedded run drain grace reached; aborting active run(s) before restart",
+          let activeTasksAtDrainStart = 0;
+          let activeRunsAtDrainStart = 0;
+          let drainTimedOut = false;
+          await measureGatewayRestartTrace(
+            "restart.drain",
+            async () => {
+              const {
+                abortEmbeddedPiRun,
+                getInspectableActiveTaskRestartBlockers,
+                getActiveEmbeddedRunCount,
+                getActiveTaskCount,
+                markGatewayDraining,
+                waitForActiveEmbeddedRuns,
+                waitForActiveTasks,
+              } = await loadGatewayLifecycleRuntimeModule();
+              const formatTaskBlockers = () => {
+                const blockers = getInspectableActiveTaskRestartBlockers();
+                if (blockers.length === 0) {
+                  return null;
+                }
+                const shown = blockers
+                  .slice(0, 8)
+                  .map((task) =>
+                    [
+                      `taskId=${task.taskId}`,
+                      task.runId ? `runId=${task.runId}` : null,
+                      `status=${task.status}`,
+                      `runtime=${task.runtime}`,
+                      task.label ? `label=${task.label}` : null,
+                      task.title ? `title=${task.title.slice(0, 80)}` : null,
+                    ]
+                      .filter((value): value is string => Boolean(value))
+                      .join(" "),
                   );
-                  abortEmbeddedPiRun(undefined, { mode: "all" });
-                  abortedAfterRunGrace = true;
-                }
-                tasksDrain = await tasksDrainPromise;
-              } finally {
-                clearInterval(stillPendingDrainLogger);
+                const omitted = blockers.length - shown.length;
+                return omitted > 0 ? `${shown.join("; ")}; +${omitted} more` : shown.join("; ");
+              };
+              const createStillPendingDrainLogger = () =>
+                setInterval(() => {
+                  gatewayLog.warn(
+                    `still draining ${getActiveTaskCount()} active task(s) and ${getActiveEmbeddedRunCount()} active embedded run(s) before restart`,
+                  );
+                }, RESTART_DRAIN_STILL_PENDING_WARN_MS);
+
+              // Reject new enqueues immediately during the drain window so
+              // sessions get an explicit restart error instead of silent task loss.
+              markGatewayDraining();
+              const activeTasks = getActiveTaskCount();
+              const activeRuns = getActiveEmbeddedRunCount();
+              activeTasksAtDrainStart = activeTasks;
+              activeRunsAtDrainStart = activeRuns;
+
+              // Best-effort abort for compacting runs so long compaction operations
+              // don't hold session write locks across restart boundaries.
+              if (activeRuns > 0) {
+                abortEmbeddedPiRun(undefined, { mode: "compacting" });
               }
-              if (tasksDrain.drained && runsDrain.drained) {
-                gatewayLog.info("all active work drained");
-              } else {
-                gatewayLog.warn("drain timeout reached; proceeding with restart");
-                // Final best-effort abort to avoid carrying active runs into the
-                // next lifecycle when drain time budget is exhausted.
-                if (!abortedAfterRunGrace) {
+
+              if (activeTasks > 0 || activeRuns > 0) {
+                const taskBlockers = formatTaskBlockers();
+                gatewayLog.info(
+                  `draining ${activeTasks} active task(s) and ${activeRuns} active embedded run(s) before restart ${formatRestartDrainBudget()}`,
+                );
+                if (taskBlockers) {
+                  gatewayLog.warn(
+                    `restart blocked by active background task run(s): ${taskBlockers}`,
+                  );
+                }
+                if (restartIntent?.force) {
+                  gatewayLog.warn("forced restart requested; skipping active work drain");
                   abortEmbeddedPiRun(undefined, { mode: "all" });
+                } else {
+                  const activeRunDrainWaitMs = resolveActiveRunDrainWaitMs(activeRuns);
+                  const stillPendingDrainLogger = createStillPendingDrainLogger();
+                  let abortedAfterRunGrace = false;
+                  let tasksDrain: { drained: boolean } = { drained: true };
+                  let runsDrain: { drained: boolean } = { drained: true };
+                  try {
+                    const tasksDrainPromise =
+                      activeTasks > 0
+                        ? waitForActiveTasks(restartDrainTimeoutMs)
+                        : Promise.resolve({ drained: true });
+                    runsDrain =
+                      activeRuns > 0
+                        ? await waitForActiveEmbeddedRuns(activeRunDrainWaitMs)
+                        : { drained: true };
+                    if (!runsDrain.drained && activeRuns > 0) {
+                      gatewayLog.warn(
+                        "active embedded run drain grace reached; aborting active run(s) before restart",
+                      );
+                      abortEmbeddedPiRun(undefined, { mode: "all" });
+                      abortedAfterRunGrace = true;
+                    }
+                    tasksDrain = await tasksDrainPromise;
+                  } finally {
+                    clearInterval(stillPendingDrainLogger);
+                  }
+                  if (tasksDrain.drained && runsDrain.drained) {
+                    gatewayLog.info("all active work drained");
+                  } else {
+                    drainTimedOut = true;
+                    gatewayLog.warn("drain timeout reached; proceeding with restart");
+                    // Final best-effort abort to avoid carrying active runs into the
+                    // next lifecycle when drain time budget is exhausted.
+                    if (!abortedAfterRunGrace) {
+                      abortEmbeddedPiRun(undefined, { mode: "all" });
+                    }
+                  }
                 }
               }
-            }
-          }
+            },
+            () => [
+              ["activeTasks", activeTasksAtDrainStart],
+              ["activeRuns", activeRunsAtDrainStart],
+              ["timedOut", drainTimedOut],
+              ["force", restartIntent?.force === true],
+            ],
+          );
         }
 
         armCloseForceExitTimerForIndefiniteRestart();
@@ -557,6 +600,7 @@ export async function runGatewayLoop(params: {
       resetAllLanes();
       resetGatewayRestartStateForInProcessRestart();
       reloadTaskRegistryFromStore();
+      markGatewayRestartTrace("restart.next-start");
     });
 
     // Keep process alive; SIGUSR1 triggers an in-process restart (no supervisor required).

--- a/src/gateway/restart-trace.test.ts
+++ b/src/gateway/restart-trace.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { createGatewayRestartTraceHandoffEnv } from "./restart-trace.js";
+
+describe("gateway restart trace handoff", () => {
+  it("keeps timing for slow but valid drains", () => {
+    const startedAt = Date.now() - 305_000;
+    const lastAt = startedAt + 300_000;
+
+    expect(
+      createGatewayRestartTraceHandoffEnv({
+        startedAt,
+        lastAt,
+      }),
+    ).toStrictEqual({
+      OPENCLAW_GATEWAY_RESTART_TRACE_STARTED_AT_MS: String(startedAt),
+      OPENCLAW_GATEWAY_RESTART_TRACE_LAST_AT_MS: String(lastAt),
+    });
+  });
+});

--- a/src/gateway/restart-trace.ts
+++ b/src/gateway/restart-trace.ts
@@ -3,15 +3,26 @@ import { isTruthyEnvValue } from "../infra/env.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
 const restartTraceLog = createSubsystemLogger("gateway");
+const RESTART_TRACE_HANDOFF_STARTED_AT_ENV = "OPENCLAW_GATEWAY_RESTART_TRACE_STARTED_AT_MS";
+const RESTART_TRACE_HANDOFF_LAST_AT_ENV = "OPENCLAW_GATEWAY_RESTART_TRACE_LAST_AT_MS";
+const RESTART_TRACE_HANDOFF_MAX_AGE_MS = 10 * 60_000;
 
 type RestartTraceMetricValue = boolean | number | string | null | undefined;
 type RestartTraceMetrics =
   | Readonly<Record<string, RestartTraceMetricValue>>
   | ReadonlyArray<readonly [string, RestartTraceMetricValue]>;
+export type GatewayRestartTraceHandoff = {
+  startedAt: number;
+  lastAt: number;
+};
 
 let startedAt = 0;
 let lastAt = 0;
 let active = false;
+
+function nowMs(): number {
+  return performance.timeOrigin + performance.now();
+}
 
 function isRestartTraceEnabled(): boolean {
   return isTruthyEnvValue(process.env.OPENCLAW_GATEWAY_RESTART_TRACE);
@@ -91,7 +102,7 @@ export function startGatewayRestartTrace(name: string, metrics?: RestartTraceMet
     active = false;
     return;
   }
-  const now = performance.now();
+  const now = nowMs();
   startedAt = now;
   lastAt = now;
   active = true;
@@ -106,7 +117,7 @@ export function markGatewayRestartTrace(name: string, metrics?: RestartTraceMetr
   if (!isGatewayRestartTraceActive()) {
     return;
   }
-  const now = performance.now();
+  const now = nowMs();
   emitRestartTrace(name, now - lastAt, now - startedAt, metrics);
   lastAt = now;
 }
@@ -124,11 +135,11 @@ export async function measureGatewayRestartTrace<T>(
   if (!isGatewayRestartTraceActive()) {
     return await run();
   }
-  const before = performance.now();
+  const before = nowMs();
   try {
     return await run();
   } finally {
-    const now = performance.now();
+    const now = nowMs();
     emitRestartTrace(
       name,
       now - before,
@@ -147,7 +158,7 @@ export function recordGatewayRestartTrace(
   if (!isGatewayRestartTraceActive() || !Number.isFinite(durationMs)) {
     return;
   }
-  const now = performance.now();
+  const now = nowMs();
   emitRestartTrace(name, Math.max(0, durationMs), now - startedAt, metrics);
   lastAt = now;
 }
@@ -181,6 +192,87 @@ export function collectGatewayProcessMemoryUsageMb(): ReadonlyArray<readonly [st
     ["externalMb", toMb(usage.external)],
     ["arrayBuffersMb", toMb(usage.arrayBuffers)],
   ];
+}
+
+function normalizeRestartTraceHandoff(value: unknown): GatewayRestartTraceHandoff | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+  const record = value as { startedAt?: unknown; lastAt?: unknown };
+  if (
+    typeof record.startedAt !== "number" ||
+    !Number.isFinite(record.startedAt) ||
+    typeof record.lastAt !== "number" ||
+    !Number.isFinite(record.lastAt) ||
+    record.startedAt <= 0 ||
+    record.lastAt < record.startedAt ||
+    record.lastAt - record.startedAt > RESTART_TRACE_HANDOFF_MAX_AGE_MS
+  ) {
+    return null;
+  }
+  const now = nowMs();
+  if (record.startedAt > now || now - record.startedAt > RESTART_TRACE_HANDOFF_MAX_AGE_MS) {
+    return null;
+  }
+  return {
+    startedAt: record.startedAt,
+    lastAt: record.lastAt,
+  };
+}
+
+export function captureGatewayRestartTraceHandoff(): GatewayRestartTraceHandoff | undefined {
+  if (!isGatewayRestartTraceActive()) {
+    return undefined;
+  }
+  return { startedAt, lastAt };
+}
+
+export function createGatewayRestartTraceHandoffEnv(
+  handoff: GatewayRestartTraceHandoff | undefined = captureGatewayRestartTraceHandoff(),
+): NodeJS.ProcessEnv | undefined {
+  const normalized = normalizeRestartTraceHandoff(handoff);
+  if (!normalized) {
+    return undefined;
+  }
+  return {
+    [RESTART_TRACE_HANDOFF_STARTED_AT_ENV]: String(normalized.startedAt),
+    [RESTART_TRACE_HANDOFF_LAST_AT_ENV]: String(normalized.lastAt),
+  };
+}
+
+export function resumeGatewayRestartTraceFromHandoff(
+  handoff: unknown,
+  metrics?: RestartTraceMetrics,
+): boolean {
+  if (!isRestartTraceEnabled() || active) {
+    return false;
+  }
+  const normalized = normalizeRestartTraceHandoff(handoff);
+  if (!normalized) {
+    return false;
+  }
+  startedAt = normalized.startedAt;
+  lastAt = normalized.lastAt;
+  active = true;
+  markGatewayRestartTrace("restart.process-resume", metrics);
+  return true;
+}
+
+export function resumeGatewayRestartTraceFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+  metrics?: RestartTraceMetrics,
+): boolean {
+  const startedRaw = env[RESTART_TRACE_HANDOFF_STARTED_AT_ENV];
+  const lastRaw = env[RESTART_TRACE_HANDOFF_LAST_AT_ENV];
+  delete env[RESTART_TRACE_HANDOFF_STARTED_AT_ENV];
+  delete env[RESTART_TRACE_HANDOFF_LAST_AT_ENV];
+  return resumeGatewayRestartTraceFromHandoff(
+    {
+      startedAt: Number(startedRaw),
+      lastAt: Number(lastRaw),
+    },
+    metrics,
+  );
 }
 
 export function resetGatewayRestartTraceForTest(): void {

--- a/src/gateway/restart-trace.ts
+++ b/src/gateway/restart-trace.ts
@@ -1,0 +1,190 @@
+import { performance } from "node:perf_hooks";
+import { isTruthyEnvValue } from "../infra/env.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const restartTraceLog = createSubsystemLogger("gateway");
+
+type RestartTraceMetricValue = boolean | number | string | null | undefined;
+type RestartTraceMetrics =
+  | Readonly<Record<string, RestartTraceMetricValue>>
+  | ReadonlyArray<readonly [string, RestartTraceMetricValue]>;
+
+let startedAt = 0;
+let lastAt = 0;
+let active = false;
+
+function isRestartTraceEnabled(): boolean {
+  return isTruthyEnvValue(process.env.OPENCLAW_GATEWAY_RESTART_TRACE);
+}
+
+function normalizeMetricEntries(
+  metrics?: RestartTraceMetrics,
+): Array<readonly [string, RestartTraceMetricValue]> {
+  if (!metrics) {
+    return [];
+  }
+  return Array.isArray(metrics) ? [...metrics] : Object.entries(metrics);
+}
+
+function formatMetricKey(key: string): string {
+  const normalized = key.replace(/[^A-Za-z0-9]/gu, "");
+  if (!normalized) {
+    return "metric";
+  }
+  return /^[A-Za-z]/u.test(normalized) ? normalized : `metric${normalized}`;
+}
+
+function formatMetricValue(value: RestartTraceMetricValue): string | null {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value.toFixed(1) : null;
+  }
+  if (typeof value === "boolean") {
+    return value ? "true" : "false";
+  }
+  if (value === null) {
+    return "null";
+  }
+  if (typeof value === "string") {
+    const normalized = value
+      .trim()
+      .replace(/\s+/gu, "_")
+      .replace(/[^A-Za-z0-9_.:/-]/gu, "_")
+      .slice(0, 120);
+    return normalized || null;
+  }
+  return null;
+}
+
+function formatMetrics(metrics?: RestartTraceMetrics): string {
+  const parts: string[] = [];
+  for (const [key, value] of normalizeMetricEntries(metrics)) {
+    const formatted = formatMetricValue(value);
+    if (formatted === null) {
+      continue;
+    }
+    parts.push(`${formatMetricKey(key)}=${formatted}`);
+  }
+  return parts.length > 0 ? ` ${parts.join(" ")}` : "";
+}
+
+function emitRestartTrace(
+  name: string,
+  durationMs: number,
+  totalMs: number,
+  metrics?: RestartTraceMetrics,
+) {
+  restartTraceLog.info(
+    `restart trace: ${name} ${durationMs.toFixed(1)}ms total=${totalMs.toFixed(1)}ms${formatMetrics(metrics)}`,
+  );
+}
+
+function emitRestartTraceDetail(name: string, metrics: RestartTraceMetrics): void {
+  const formatted = formatMetrics(metrics).trim();
+  if (!formatted) {
+    return;
+  }
+  restartTraceLog.info(`restart trace: ${name} ${formatted}`);
+}
+
+export function startGatewayRestartTrace(name: string, metrics?: RestartTraceMetrics): void {
+  if (!isRestartTraceEnabled()) {
+    active = false;
+    return;
+  }
+  const now = performance.now();
+  startedAt = now;
+  lastAt = now;
+  active = true;
+  emitRestartTrace(name, 0, 0, metrics);
+}
+
+function isGatewayRestartTraceActive(): boolean {
+  return isRestartTraceEnabled() && active;
+}
+
+export function markGatewayRestartTrace(name: string, metrics?: RestartTraceMetrics): void {
+  if (!isGatewayRestartTraceActive()) {
+    return;
+  }
+  const now = performance.now();
+  emitRestartTrace(name, now - lastAt, now - startedAt, metrics);
+  lastAt = now;
+}
+
+export function finishGatewayRestartTrace(name: string, metrics?: RestartTraceMetrics): void {
+  markGatewayRestartTrace(name, metrics);
+  active = false;
+}
+
+export async function measureGatewayRestartTrace<T>(
+  name: string,
+  run: () => Promise<T> | T,
+  metrics?: RestartTraceMetrics | (() => RestartTraceMetrics | undefined),
+): Promise<T> {
+  if (!isGatewayRestartTraceActive()) {
+    return await run();
+  }
+  const before = performance.now();
+  try {
+    return await run();
+  } finally {
+    const now = performance.now();
+    emitRestartTrace(
+      name,
+      now - before,
+      now - startedAt,
+      typeof metrics === "function" ? metrics() : metrics,
+    );
+    lastAt = now;
+  }
+}
+
+export function recordGatewayRestartTrace(
+  name: string,
+  durationMs: number,
+  metrics?: RestartTraceMetrics,
+): void {
+  if (!isGatewayRestartTraceActive() || !Number.isFinite(durationMs)) {
+    return;
+  }
+  const now = performance.now();
+  emitRestartTrace(name, Math.max(0, durationMs), now - startedAt, metrics);
+  lastAt = now;
+}
+
+export function recordGatewayRestartTraceSpan(
+  name: string,
+  durationMs: number,
+  totalMs: number,
+  metrics?: RestartTraceMetrics,
+): void {
+  if (!isGatewayRestartTraceActive() || !Number.isFinite(durationMs) || !Number.isFinite(totalMs)) {
+    return;
+  }
+  emitRestartTrace(name, Math.max(0, durationMs), Math.max(0, totalMs), metrics);
+}
+
+export function recordGatewayRestartTraceDetail(name: string, metrics: RestartTraceMetrics): void {
+  if (!isGatewayRestartTraceActive()) {
+    return;
+  }
+  emitRestartTraceDetail(name, metrics);
+}
+
+export function collectGatewayProcessMemoryUsageMb(): ReadonlyArray<readonly [string, number]> {
+  const usage = process.memoryUsage();
+  const toMb = (bytes: number) => bytes / 1024 / 1024;
+  return [
+    ["rssMb", toMb(usage.rss)],
+    ["heapTotalMb", toMb(usage.heapTotal)],
+    ["heapUsedMb", toMb(usage.heapUsed)],
+    ["externalMb", toMb(usage.external)],
+    ["arrayBuffersMb", toMb(usage.arrayBuffers)],
+  ];
+}
+
+export function resetGatewayRestartTraceForTest(): void {
+  startedAt = 0;
+  lastAt = 0;
+  active = false;
+}

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -66,11 +66,18 @@ vi.mock("../logging/subsystem.js", () => ({
 }));
 
 const { createGatewayCloseHandler } = await import("./server-close.js");
+const {
+  finishGatewayRestartTrace,
+  recordGatewayRestartTraceSpan,
+  resetGatewayRestartTraceForTest,
+  startGatewayRestartTrace,
+} = await import("./restart-trace.js");
 type GatewayCloseHandlerParams = Parameters<typeof createGatewayCloseHandler>[0];
 type GatewayCloseClient = GatewayCloseHandlerParams["clients"] extends Set<infer T> ? T : never;
 type DrainActiveSessionsForShutdown = NonNullable<
   GatewayCloseHandlerParams["drainActiveSessionsForShutdown"]
 >;
+const originalRestartTraceEnv = process.env.OPENCLAW_GATEWAY_RESTART_TRACE;
 
 function firstMockCall<T extends readonly unknown[]>(mock: { mock: { calls: readonly T[] } }) {
   return mock.mock.calls[0];
@@ -132,6 +139,12 @@ describe("createGatewayCloseHandler", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    resetGatewayRestartTraceForTest();
+    if (originalRestartTraceEnv === undefined) {
+      delete process.env.OPENCLAW_GATEWAY_RESTART_TRACE;
+    } else {
+      process.env.OPENCLAW_GATEWAY_RESTART_TRACE = originalRestartTraceEnv;
+    }
   });
 
   it("completes a clean shutdown with a ShutdownResult", async () => {
@@ -166,6 +179,97 @@ describe("createGatewayCloseHandler", () => {
     expect(shutdownEvent?.context?.restartExpectedMs).toBe(123);
     expect(preRestartEvent?.context?.reason).toBe("gateway restarting");
     expect(preRestartEvent?.context?.restartExpectedMs).toBe(123);
+  });
+
+  it("emits parseable restart close trace spans when enabled", async () => {
+    process.env.OPENCLAW_GATEWAY_RESTART_TRACE = "1";
+    const drainActiveSessionsForShutdown = vi.fn<DrainActiveSessionsForShutdown>(async () => ({
+      emittedSessionIds: [],
+      timedOut: false,
+    }));
+    const pluginServices = {
+      stop: vi.fn(async () => undefined),
+    };
+    const close = createGatewayCloseHandler(
+      createGatewayCloseTestDeps({
+        channelIds: ["telegram"],
+        drainActiveSessionsForShutdown,
+        pluginServices: pluginServices as never,
+      }),
+    );
+
+    startGatewayRestartTrace("restart.signal.received", [["reason", "test restart"]]);
+    await close({ reason: "gateway restarting", restartExpectedMs: 123 });
+
+    const messages = mocks.logInfo.mock.calls.map(([message]) => String(message));
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(
+          /^restart trace: restart\.close\.gateway-shutdown-hook [0-9.]+ms total=[0-9.]+ms reason=gateway_restarting$/u,
+        ),
+        expect.stringMatching(
+          /^restart trace: restart\.close\.gateway-pre-restart-hook [0-9.]+ms total=[0-9.]+ms reason=gateway_restarting$/u,
+        ),
+        expect.stringMatching(
+          /^restart trace: restart\.close\.session-end-drain [0-9.]+ms total=[0-9.]+ms reason=gateway_restarting$/u,
+        ),
+        expect.stringMatching(
+          /^restart trace: restart\.close\.channels [0-9.]+ms total=[0-9.]+ms reason=gateway_restarting$/u,
+        ),
+        expect.stringMatching(
+          /^restart trace: restart\.close\.bundle-runtimes [0-9.]+ms total=[0-9.]+ms reason=gateway_restarting$/u,
+        ),
+        expect.stringMatching(
+          /^restart trace: restart\.close\.plugin-services [0-9.]+ms total=[0-9.]+ms reason=gateway_restarting$/u,
+        ),
+        expect.stringMatching(
+          /^restart trace: restart\.close\.gmail-watcher [0-9.]+ms total=[0-9.]+ms reason=gateway_restarting$/u,
+        ),
+        expect.stringMatching(
+          /^restart trace: restart\.close\.websocket-server [0-9.]+ms total=[0-9.]+ms reason=gateway_restarting$/u,
+        ),
+        expect.stringMatching(
+          /^restart trace: restart\.close\.http-server [0-9.]+ms total=[0-9.]+ms reason=gateway_restarting$/u,
+        ),
+      ]),
+    );
+    expect(
+      messages.some(
+        (message) =>
+          /^restart trace: restart\.close\.total [0-9.]+ms total=[0-9.]+ms /u.test(message) &&
+          message.includes("restartExpectedMs=123.0") &&
+          message.includes("rssMb="),
+      ),
+    ).toBe(true);
+  });
+
+  it("emits restart ready child spans without shortening the parent ready span", async () => {
+    process.env.OPENCLAW_GATEWAY_RESTART_TRACE = "1";
+
+    startGatewayRestartTrace("restart.signal.received", [["reason", "test restart"]]);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    recordGatewayRestartTraceSpan("restart.ready.runtime.post-attach", 12, 40, [
+      ["eventLoopMax", "1.0ms"],
+    ]);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    finishGatewayRestartTrace("restart.ready");
+
+    const messages = mocks.logInfo.mock.calls.map(([message]) => String(message));
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(
+          /^restart trace: restart\.ready\.runtime\.post-attach 12\.0ms total=40\.0ms eventLoopMax=1\.0ms$/u,
+        ),
+      ]),
+    );
+    const parentReadyLine = messages.find((message) =>
+      /^restart trace: restart\.ready [0-9.]+ms total=[0-9.]+ms$/u.test(message),
+    );
+    expect(parentReadyLine).toBeDefined();
+    const parentDuration = Number(
+      /^restart trace: restart\.ready ([0-9.]+)ms/u.exec(parentReadyLine ?? "")?.[1],
+    );
+    expect(parentDuration).toBeGreaterThan(30);
   });
 
   it("continues shutdown and records a warning when gateway shutdown hook stalls", async () => {

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -9,6 +9,11 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { closePluginStateSqliteStore } from "../plugin-state/plugin-state-store.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
+import {
+  collectGatewayProcessMemoryUsageMb,
+  measureGatewayRestartTrace,
+  recordGatewayRestartTrace,
+} from "./restart-trace.js";
 import type { GatewayPostReadySidecarHandle } from "./server-startup-post-attach.js";
 
 const shutdownLog = createSubsystemLogger("gateway/shutdown");
@@ -211,76 +216,89 @@ export function createGatewayCloseHandler(params: {
   }): Promise<ShutdownResult> => {
     const start = Date.now();
     const warnings: string[] = [];
+    const reasonRaw = normalizeOptionalString(opts?.reason) ?? "";
+    const reason = reasonRaw || "gateway stopping";
+    const restartExpectedMs =
+      typeof opts?.restartExpectedMs === "number" && Number.isFinite(opts.restartExpectedMs)
+        ? Math.max(0, Math.floor(opts.restartExpectedMs))
+        : null;
+    const measureCloseStep = <T>(name: string, run: () => Promise<T> | T) =>
+      measureGatewayRestartTrace(`restart.close.${name}`, run, [["reason", reason]]);
     try {
-      const reasonRaw = normalizeOptionalString(opts?.reason) ?? "";
-      const reason = reasonRaw || "gateway stopping";
-      const restartExpectedMs =
-        typeof opts?.restartExpectedMs === "number" && Number.isFinite(opts.restartExpectedMs)
-          ? Math.max(0, Math.floor(opts.restartExpectedMs))
-          : null;
       shutdownLog.info(`shutdown started: ${reason}`);
 
-      await shutdownStep(
-        "gateway:shutdown",
-        async () => {
-          const shutdownEvent = createInternalHookEvent("gateway", "shutdown", "gateway:shutdown", {
-            reason,
-            restartExpectedMs,
-          });
-          const result = await triggerGatewayLifecycleHookWithTimeout({
-            event: shutdownEvent,
-            hookName: "gateway:shutdown",
-            timeoutMs: GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS,
-          });
-          if (result === "timeout") {
-            recordShutdownWarning(warnings, "gateway:shutdown");
-          }
-        },
-        warnings,
-      );
-      if (restartExpectedMs !== null) {
-        await shutdownStep(
-          "gateway:pre-restart",
+      await measureCloseStep("gateway-shutdown-hook", () =>
+        shutdownStep(
+          "gateway:shutdown",
           async () => {
-            const preRestartEvent = createInternalHookEvent(
+            const shutdownEvent = createInternalHookEvent(
               "gateway",
-              "pre-restart",
-              "gateway:pre-restart",
+              "shutdown",
+              "gateway:shutdown",
               {
                 reason,
                 restartExpectedMs,
               },
             );
             const result = await triggerGatewayLifecycleHookWithTimeout({
-              event: preRestartEvent,
-              hookName: "gateway:pre-restart",
-              timeoutMs: GATEWAY_PRE_RESTART_HOOK_TIMEOUT_MS,
+              event: shutdownEvent,
+              hookName: "gateway:shutdown",
+              timeoutMs: GATEWAY_SHUTDOWN_HOOK_TIMEOUT_MS,
             });
             if (result === "timeout") {
-              recordShutdownWarning(warnings, "gateway:pre-restart");
+              recordShutdownWarning(warnings, "gateway:shutdown");
             }
           },
           warnings,
+        ),
+      );
+      if (restartExpectedMs !== null) {
+        await measureCloseStep("gateway-pre-restart-hook", () =>
+          shutdownStep(
+            "gateway:pre-restart",
+            async () => {
+              const preRestartEvent = createInternalHookEvent(
+                "gateway",
+                "pre-restart",
+                "gateway:pre-restart",
+                {
+                  reason,
+                  restartExpectedMs,
+                },
+              );
+              const result = await triggerGatewayLifecycleHookWithTimeout({
+                event: preRestartEvent,
+                hookName: "gateway:pre-restart",
+                timeoutMs: GATEWAY_PRE_RESTART_HOOK_TIMEOUT_MS,
+              });
+              if (result === "timeout") {
+                recordShutdownWarning(warnings, "gateway:pre-restart");
+              }
+            },
+            warnings,
+          ),
         );
       }
       if (params.drainActiveSessionsForShutdown) {
-        await shutdownStep(
-          "session-end-drain",
-          async () => {
-            const drainReason: "shutdown" | "restart" =
-              restartExpectedMs !== null ? "restart" : "shutdown";
-            const result = await params.drainActiveSessionsForShutdown!({
-              reason: drainReason,
-              totalTimeoutMs: ACTIVE_SESSIONS_SHUTDOWN_DRAIN_TIMEOUT_MS,
-            });
-            if (result.timedOut) {
-              shutdownLog.warn(
-                `session-end-drain timed out after ${ACTIVE_SESSIONS_SHUTDOWN_DRAIN_TIMEOUT_MS}ms after ${result.emittedSessionIds.length} sessions; continuing shutdown`,
-              );
-              recordShutdownWarning(warnings, "session-end-drain");
-            }
-          },
-          warnings,
+        await measureCloseStep("session-end-drain", () =>
+          shutdownStep(
+            "session-end-drain",
+            async () => {
+              const drainReason: "shutdown" | "restart" =
+                restartExpectedMs !== null ? "restart" : "shutdown";
+              const result = await params.drainActiveSessionsForShutdown!({
+                reason: drainReason,
+                totalTimeoutMs: ACTIVE_SESSIONS_SHUTDOWN_DRAIN_TIMEOUT_MS,
+              });
+              if (result.timedOut) {
+                shutdownLog.warn(
+                  `session-end-drain timed out after ${ACTIVE_SESSIONS_SHUTDOWN_DRAIN_TIMEOUT_MS}ms after ${result.emittedSessionIds.length} sessions; continuing shutdown`,
+                );
+                recordShutdownWarning(warnings, "session-end-drain");
+              }
+            },
+            warnings,
+          ),
         );
       }
       if (params.bonjourStop) {
@@ -289,31 +307,41 @@ export function createGatewayCloseHandler(params: {
       if (params.tailscaleCleanup) {
         await shutdownStep("tailscale", () => params.tailscaleCleanup!(), warnings);
       }
-      const channelIds = params.channelIds ?? listChannelPlugins().map((plugin) => plugin.id);
-      for (const channelId of channelIds) {
-        await shutdownStep(`channel/${channelId}`, () => params.stopChannel(channelId), warnings);
-      }
+      await measureCloseStep("channels", async () => {
+        const channelIds = params.channelIds ?? listChannelPlugins().map((plugin) => plugin.id);
+        for (const channelId of channelIds) {
+          await shutdownStep(`channel/${channelId}`, () => params.stopChannel(channelId), warnings);
+        }
+      });
       await shutdownStep("agent-harnesses", () => disposeRegisteredAgentHarnesses(), warnings);
-      await Promise.all([
-        disposeRuntimeWithShutdownGrace({
-          label: "bundle-mcp",
-          dispose: params.disposeSessionMcpRuntimes ?? disposeAllSessionMcpRuntimes,
-          graceMs: MCP_RUNTIME_CLOSE_GRACE_MS,
-          warnings,
-        }),
-        disposeRuntimeWithShutdownGrace({
-          label: "bundle-lsp",
-          dispose: params.disposeBundleLspRuntimes ?? disposeAllBundleLspRuntimesOnDemand,
-          graceMs: LSP_RUNTIME_CLOSE_GRACE_MS,
-          warnings,
-        }),
-      ]);
+      await measureCloseStep("bundle-runtimes", async () => {
+        await Promise.all([
+          disposeRuntimeWithShutdownGrace({
+            label: "bundle-mcp",
+            dispose: params.disposeSessionMcpRuntimes ?? disposeAllSessionMcpRuntimes,
+            graceMs: MCP_RUNTIME_CLOSE_GRACE_MS,
+            warnings,
+          }),
+          disposeRuntimeWithShutdownGrace({
+            label: "bundle-lsp",
+            dispose: params.disposeBundleLspRuntimes ?? disposeAllBundleLspRuntimesOnDemand,
+            graceMs: LSP_RUNTIME_CLOSE_GRACE_MS,
+            warnings,
+          }),
+        ]);
+      });
       if (params.pluginServices) {
-        await shutdownStep("plugin-services", () => params.pluginServices!.stop(), warnings);
+        await measureCloseStep("plugin-services", () =>
+          shutdownStep("plugin-services", () => params.pluginServices!.stop(), warnings),
+        );
       }
       await shutdownStep("plugin-state-store", () => closePluginStateSqliteStore(), warnings);
-      await shutdownStep("config-reloader", () => params.configReloader.stop(), warnings);
-      await shutdownStep("gmail-watcher", () => stopGmailWatcherOnDemand(), warnings);
+      await measureCloseStep("config-reloader", () =>
+        shutdownStep("config-reloader", () => params.configReloader.stop(), warnings),
+      );
+      await measureCloseStep("gmail-watcher", () =>
+        shutdownStep("gmail-watcher", () => stopGmailWatcherOnDemand(), warnings),
+      );
       params.cron.stop();
       params.heartbeatRunner.stop();
       await shutdownStep(
@@ -362,108 +390,112 @@ export function createGatewayCloseHandler(params: {
         recordShutdownWarning(warnings, "ws-clients");
       }
       params.clients.clear();
-      const wsClients = params.wss.clients ?? new Set();
-      const closePromise = new Promise<void>((resolve) => params.wss.close(() => resolve()));
-      const websocketGraceTimeout = createTimeoutRace(
-        WEBSOCKET_CLOSE_GRACE_MS,
-        () => false as const,
-      );
-      const closedWithinGrace = await Promise.race([
-        closePromise.then(() => true),
-        websocketGraceTimeout.promise,
-      ]);
-      websocketGraceTimeout.clear();
-      if (!closedWithinGrace) {
-        shutdownLog.warn(
-          `websocket server close exceeded ${WEBSOCKET_CLOSE_GRACE_MS}ms; forcing shutdown continuation with ${wsClients.size} tracked client(s)`,
+      await measureCloseStep("websocket-server", async () => {
+        const wsClients = params.wss.clients ?? new Set();
+        const closePromise = new Promise<void>((resolve) => params.wss.close(() => resolve()));
+        const websocketGraceTimeout = createTimeoutRace(
+          WEBSOCKET_CLOSE_GRACE_MS,
+          () => false as const,
         );
-        recordShutdownWarning(warnings, "websocket-server");
-        for (const client of wsClients) {
-          try {
-            client.terminate();
-          } catch {
-            /* ignore */
-          }
-        }
-        const websocketForceTimeout = createTimeoutRace(WEBSOCKET_CLOSE_FORCE_CONTINUE_MS, () => {
-          shutdownLog.warn(
-            `websocket server close still pending after ${WEBSOCKET_CLOSE_FORCE_CONTINUE_MS}ms force window; continuing shutdown`,
-          );
-        });
-        await Promise.race([closePromise, websocketForceTimeout.promise]);
-        websocketForceTimeout.clear();
-      }
-      const servers =
-        params.httpServers && params.httpServers.length > 0
-          ? params.httpServers
-          : [params.httpServer];
-      for (let i = 0; i < servers.length; i++) {
-        const httpServer = servers[i] as HttpServer & {
-          closeAllConnections?: () => void;
-          closeIdleConnections?: () => void;
-        };
-        const label = servers.length > 1 ? `http-server[${i}]` : "http-server";
-        if (typeof httpServer.closeIdleConnections === "function") {
-          httpServer.closeIdleConnections();
-        }
-        const closePromise = new Promise<void>((resolve, reject) =>
-          httpServer.close((err) => {
-            if (!err || isServerNotRunningError(err)) {
-              resolve();
-              return;
-            }
-            reject(err);
-          }),
-        );
-        void closePromise.catch(() => undefined);
-        const httpGraceTimeout = createTimeoutRace(HTTP_CLOSE_GRACE_MS, () => false as const);
         const closedWithinGrace = await Promise.race([
-          closePromise.then(
-            () => true,
-            (err: unknown) => {
-              throw err;
-            },
-          ),
-          httpGraceTimeout.promise,
-        ]).catch((err: unknown) => {
-          const detail = err instanceof Error ? err.message : String(err);
-          shutdownLog.warn(`${label}: ${detail}`);
-          recordShutdownWarning(warnings, label);
-          return true;
-        });
-        httpGraceTimeout.clear();
+          closePromise.then(() => true),
+          websocketGraceTimeout.promise,
+        ]);
+        websocketGraceTimeout.clear();
         if (!closedWithinGrace) {
           shutdownLog.warn(
-            `${label} close exceeded ${HTTP_CLOSE_GRACE_MS}ms; forcing connection shutdown and waiting for close`,
+            `websocket server close exceeded ${WEBSOCKET_CLOSE_GRACE_MS}ms; forcing shutdown continuation with ${wsClients.size} tracked client(s)`,
           );
-          recordShutdownWarning(warnings, label);
-          httpServer.closeAllConnections?.();
-          const httpForceTimeout = createTimeoutRace(
-            HTTP_CLOSE_FORCE_WAIT_MS,
-            () => false as const,
+          recordShutdownWarning(warnings, "websocket-server");
+          for (const client of wsClients) {
+            try {
+              client.terminate();
+            } catch {
+              /* ignore */
+            }
+          }
+          const websocketForceTimeout = createTimeoutRace(WEBSOCKET_CLOSE_FORCE_CONTINUE_MS, () => {
+            shutdownLog.warn(
+              `websocket server close still pending after ${WEBSOCKET_CLOSE_FORCE_CONTINUE_MS}ms force window; continuing shutdown`,
+            );
+          });
+          await Promise.race([closePromise, websocketForceTimeout.promise]);
+          websocketForceTimeout.clear();
+        }
+      });
+      await measureCloseStep("http-server", async () => {
+        const servers =
+          params.httpServers && params.httpServers.length > 0
+            ? params.httpServers
+            : [params.httpServer];
+        for (let i = 0; i < servers.length; i++) {
+          const httpServer = servers[i] as HttpServer & {
+            closeAllConnections?: () => void;
+            closeIdleConnections?: () => void;
+          };
+          const label = servers.length > 1 ? `http-server[${i}]` : "http-server";
+          if (typeof httpServer.closeIdleConnections === "function") {
+            httpServer.closeIdleConnections();
+          }
+          const closePromise = new Promise<void>((resolve, reject) =>
+            httpServer.close((err) => {
+              if (!err || isServerNotRunningError(err)) {
+                resolve();
+                return;
+              }
+              reject(err);
+            }),
           );
-          const closedAfterForce = await Promise.race([
+          void closePromise.catch(() => undefined);
+          const httpGraceTimeout = createTimeoutRace(HTTP_CLOSE_GRACE_MS, () => false as const);
+          const closedWithinGrace = await Promise.race([
             closePromise.then(
               () => true,
               (err: unknown) => {
                 throw err;
               },
             ),
-            httpForceTimeout.promise,
+            httpGraceTimeout.promise,
           ]).catch((err: unknown) => {
             const detail = err instanceof Error ? err.message : String(err);
             shutdownLog.warn(`${label}: ${detail}`);
             recordShutdownWarning(warnings, label);
             return true;
           });
-          httpForceTimeout.clear();
-          if (!closedAfterForce) {
-            throw new Error(
-              `${label} close still pending after forced connection shutdown (${HTTP_CLOSE_FORCE_WAIT_MS}ms)`,
+          httpGraceTimeout.clear();
+          if (!closedWithinGrace) {
+            shutdownLog.warn(
+              `${label} close exceeded ${HTTP_CLOSE_GRACE_MS}ms; forcing connection shutdown and waiting for close`,
             );
+            recordShutdownWarning(warnings, label);
+            httpServer.closeAllConnections?.();
+            const httpForceTimeout = createTimeoutRace(
+              HTTP_CLOSE_FORCE_WAIT_MS,
+              () => false as const,
+            );
+            const closedAfterForce = await Promise.race([
+              closePromise.then(
+                () => true,
+                (err: unknown) => {
+                  throw err;
+                },
+              ),
+              httpForceTimeout.promise,
+            ]).catch((err: unknown) => {
+              const detail = err instanceof Error ? err.message : String(err);
+              shutdownLog.warn(`${label}: ${detail}`);
+              recordShutdownWarning(warnings, label);
+              return true;
+            });
+            httpForceTimeout.clear();
+            if (!closedAfterForce) {
+              throw new Error(
+                `${label} close still pending after forced connection shutdown (${HTTP_CLOSE_FORCE_WAIT_MS}ms)`,
+              );
+            }
           }
         }
-      }
+      });
     } finally {
       try {
         params.releasePluginRouteRegistry?.();
@@ -481,6 +513,11 @@ export function createGatewayCloseHandler(params: {
       shutdownLog.info(`shutdown completed cleanly in ${durationMs}ms`);
     }
 
+    recordGatewayRestartTrace("restart.close.total", durationMs, [
+      ["reason", reason],
+      ["restartExpectedMs", restartExpectedMs ?? "none"],
+      ...collectGatewayProcessMemoryUsageMb(),
+    ]);
     return { durationMs, warnings };
   };
 }

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -32,6 +32,7 @@ import {
 } from "../infra/diagnostics-timeline.js";
 import { isTruthyEnvValue, isVitestRuntimeEnv, logAcceptedEnvOption } from "../infra/env.js";
 import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
+import { readGatewayRestartHandoffSync } from "../infra/restart-handoff.js";
 import { setGatewaySigusr1RestartPolicy, setPreRestartDeferralCheck } from "../infra/restart.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import type { VoiceWakeRoutingConfig } from "../infra/voicewake-routing.js";
@@ -78,6 +79,8 @@ import {
   finishGatewayRestartTrace,
   recordGatewayRestartTraceDetail,
   recordGatewayRestartTraceSpan,
+  resumeGatewayRestartTraceFromEnv,
+  resumeGatewayRestartTraceFromHandoff,
 } from "./restart-trace.js";
 import { resolveGatewayControlUiRootState } from "./server-control-ui-root.js";
 import { createLazyGatewayCronState } from "./server-cron-lazy.js";
@@ -539,6 +542,14 @@ export async function startGatewayServer(
     key: "OPENCLAW_RAW_STREAM_PATH",
     description: "raw stream log path override",
   });
+  if (!resumeGatewayRestartTraceFromEnv(process.env, [["source", "env"]])) {
+    const restartHandoff = readGatewayRestartHandoffSync();
+    resumeGatewayRestartTraceFromHandoff(restartHandoff?.restartTrace, [
+      ["source", restartHandoff?.source],
+      ["restartKind", restartHandoff?.restartKind],
+      ["supervisorMode", restartHandoff?.supervisorMode],
+    ]);
+  }
   const startupTrace = createGatewayStartupTrace();
   const startupConfigModulePromise = import("./server-startup-config.js");
   const reloadHandlersModulePromise = import("./server-reload-handlers.js");

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -73,6 +73,12 @@ import {
   listChannelPluginConfigTargetIds,
   pluginConfigTargetsChanged,
 } from "./plugin-channel-reload-targets.js";
+import {
+  collectGatewayProcessMemoryUsageMb,
+  finishGatewayRestartTrace,
+  recordGatewayRestartTraceDetail,
+  recordGatewayRestartTraceSpan,
+} from "./restart-trace.js";
 import { resolveGatewayControlUiRootState } from "./server-control-ui-root.js";
 import { createLazyGatewayCronState } from "./server-cron-lazy.js";
 import { applyGatewayLaneConcurrency } from "./server-lanes.js";
@@ -296,13 +302,14 @@ function createGatewayStartupTrace() {
     eventLoopSample: ReturnType<typeof takeEventLoopSample>,
     extras: ReadonlyArray<readonly [string, number | string]> = [],
   ) => {
+    const metrics = [
+      ["eventLoopMax", `${(eventLoopSample?.maxMs ?? 0).toFixed(1)}ms`] as const,
+      ...extras,
+    ];
+    recordGatewayRestartTraceSpan(`restart.ready.${name}`, durationMs, totalMs, metrics);
     if (logEnabled) {
-      const metrics = [
-        `eventLoopMax=${(eventLoopSample?.maxMs ?? 0).toFixed(1)}ms`,
-        ...extras.map(([key, value]) => formatMetric(key, value)),
-      ].join(" ");
       log.info(
-        `startup trace: ${name} ${durationMs.toFixed(1)}ms total=${totalMs.toFixed(1)}ms ${metrics}`,
+        `startup trace: ${name} ${durationMs.toFixed(1)}ms total=${totalMs.toFixed(1)}ms ${metrics.map(([key, value]) => formatMetric(key, value)).join(" ")}`,
       );
     }
   };
@@ -333,6 +340,7 @@ function createGatewayStartupTrace() {
     },
     detail(name: string, metrics: ReadonlyArray<readonly [string, number | string]>) {
       const attributes = Object.fromEntries(metrics);
+      recordGatewayRestartTraceDetail(`restart.ready.${name}`, metrics);
       if (logEnabled) {
         log.info(
           `startup trace: ${name} ${metrics.map(([key, value]) => formatMetric(key, value)).join(" ")}`,
@@ -417,18 +425,6 @@ function formatRuntimeGatewayAuthTokenWarning(): string {
     "In Nix mode, set gateway.auth.token in your Nix-managed OpenClaw config and rebuild.",
     "For the first-party Nix flow, see https://github.com/openclaw/nix-openclaw#quick-start and https://docs.openclaw.ai/install/nix.",
   ].join(" ");
-}
-
-function collectProcessMemoryUsageMb(): ReadonlyArray<readonly [string, number]> {
-  const usage = process.memoryUsage();
-  const toMb = (bytes: number) => bytes / 1024 / 1024;
-  return [
-    ["rssMb", toMb(usage.rss)],
-    ["heapTotalMb", toMb(usage.heapTotal)],
-    ["heapUsedMb", toMb(usage.heapUsed)],
-    ["externalMb", toMb(usage.external)],
-    ["arrayBuffersMb", toMb(usage.arrayBuffers)],
-  ];
 }
 
 async function stopTaskRegistryMaintenanceOnDemand(): Promise<void> {
@@ -1540,8 +1536,9 @@ export async function startGatewayServer(
           }),
       ),
     ));
-    startupTrace.detail("memory.ready", collectProcessMemoryUsageMb());
+    startupTrace.detail("memory.ready", collectGatewayProcessMemoryUsageMb());
     startupTrace.mark("ready");
+    finishGatewayRestartTrace("restart.ready", collectGatewayProcessMemoryUsageMb());
     postAttachRuntimeReturned = true;
     activateScheduledServicesWhenReady();
 
@@ -1632,11 +1629,11 @@ export async function startGatewayServer(
         logCron,
         log,
         recordPostReadyMemory: () => {
-          startupTrace.detail("memory.post-ready", collectProcessMemoryUsageMb());
+          startupTrace.detail("memory.post-ready", collectGatewayProcessMemoryUsageMb());
         },
       });
     } else {
-      startupTrace.detail("memory.post-ready", collectProcessMemoryUsageMb());
+      startupTrace.detail("memory.post-ready", collectGatewayProcessMemoryUsageMb());
     }
   } catch (err) {
     await closeOnStartupFailure();

--- a/src/infra/process-respawn.ts
+++ b/src/infra/process-respawn.ts
@@ -16,16 +16,22 @@ type GatewayRespawnResult = {
 type GatewayUpdateRespawnResult = GatewayRespawnResult & {
   child?: ChildProcess;
 };
+type GatewayRespawnOptions = {
+  env?: NodeJS.ProcessEnv;
+};
 
 function isTruthy(value: string | undefined): boolean {
   const normalized = normalizeOptionalLowercaseString(value);
   return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
 }
 
-function spawnDetachedGatewayProcess(): { child: ChildProcess; pid?: number } {
+function spawnDetachedGatewayProcess(opts: GatewayRespawnOptions = {}): {
+  child: ChildProcess;
+  pid?: number;
+} {
   const args = [...process.execArgv, ...process.argv.slice(1)];
   const child = spawn(process.execPath, args, {
-    env: process.env,
+    env: opts.env ? { ...process.env, ...opts.env } : process.env,
     detached: true,
     stdio: "inherit",
   });
@@ -39,7 +45,9 @@ function spawnDetachedGatewayProcess(): { child: ChildProcess; pid?: number } {
  * - OPENCLAW_NO_RESPAWN=1: caller should keep in-process restart behavior (tests/dev)
  * - otherwise: spawn detached child with current argv/execArgv, then caller exits
  */
-export function restartGatewayProcessWithFreshPid(): GatewayRespawnResult {
+export function restartGatewayProcessWithFreshPid(
+  opts: GatewayRespawnOptions = {},
+): GatewayRespawnResult {
   if (isTruthy(process.env.OPENCLAW_NO_RESPAWN)) {
     return { mode: "disabled" };
   }
@@ -75,7 +83,7 @@ export function restartGatewayProcessWithFreshPid(): GatewayRespawnResult {
   }
 
   try {
-    const { pid } = spawnDetachedGatewayProcess();
+    const { pid } = spawnDetachedGatewayProcess(opts);
     return { mode: "spawned", pid };
   } catch (err) {
     const detail = formatErrorMessage(err);
@@ -91,7 +99,9 @@ export function restartGatewayProcessWithFreshPid(): GatewayRespawnResult {
  * unmanaged Windows installs because there is no safe in-process fallback once
  * the installed package contents have been replaced.
  */
-export function respawnGatewayProcessForUpdate(): GatewayUpdateRespawnResult {
+export function respawnGatewayProcessForUpdate(
+  opts: GatewayRespawnOptions = {},
+): GatewayUpdateRespawnResult {
   if (isTruthy(process.env.OPENCLAW_NO_RESPAWN)) {
     return { mode: "disabled", detail: "OPENCLAW_NO_RESPAWN" };
   }
@@ -109,7 +119,7 @@ export function respawnGatewayProcessForUpdate(): GatewayUpdateRespawnResult {
     return { mode: "supervised" };
   }
   try {
-    const { child, pid } = spawnDetachedGatewayProcess();
+    const { child, pid } = spawnDetachedGatewayProcess(opts);
     return { mode: "spawned", pid, child };
   } catch (err) {
     return {

--- a/src/infra/restart-handoff.test.ts
+++ b/src/infra/restart-handoff.test.ts
@@ -73,6 +73,56 @@ describe("gateway restart handoff", () => {
     expect(persisted?.reason).toBe("plugin source changed");
   });
 
+  it("persists restart trace timing for supervised process handoff", () => {
+    const env = createHandoffEnv();
+
+    const handoff = expectWrittenHandoff({
+      env,
+      pid: 12_345,
+      restartKind: "full-process",
+      supervisorMode: "launchd",
+      createdAt: 1_000,
+      restartTrace: {
+        startedAt: 10_000,
+        lastAt: 10_250,
+      },
+    });
+
+    expect(handoff.restartTrace).toStrictEqual({
+      startedAt: 10_000,
+      lastAt: 10_250,
+    });
+    expect(readGatewayRestartHandoffSync(env, 1_500)?.restartTrace).toStrictEqual({
+      startedAt: 10_000,
+      lastAt: 10_250,
+    });
+  });
+
+  it("keeps restart trace timing for slow but valid drains", () => {
+    const env = createHandoffEnv();
+
+    const handoff = expectWrittenHandoff({
+      env,
+      pid: 12_345,
+      restartKind: "full-process",
+      supervisorMode: "launchd",
+      createdAt: 1_000,
+      restartTrace: {
+        startedAt: 10_000,
+        lastAt: 310_000,
+      },
+    });
+
+    expect(handoff.restartTrace).toStrictEqual({
+      startedAt: 10_000,
+      lastAt: 310_000,
+    });
+    expect(readGatewayRestartHandoffSync(env, 1_500)?.restartTrace).toStrictEqual({
+      startedAt: 10_000,
+      lastAt: 310_000,
+    });
+  });
+
   it("consumes a fresh handoff by exited pid instead of current process pid", () => {
     const env = createHandoffEnv();
 

--- a/src/infra/restart-handoff.ts
+++ b/src/infra/restart-handoff.ts
@@ -8,6 +8,7 @@ export const GATEWAY_SUPERVISOR_RESTART_HANDOFF_FILENAME =
   "gateway-supervisor-restart-handoff.json";
 export const GATEWAY_SUPERVISOR_RESTART_HANDOFF_KIND = "gateway-supervisor-restart-handoff";
 const GATEWAY_RESTART_HANDOFF_TTL_MS = 60_000;
+const GATEWAY_RESTART_TRACE_HANDOFF_MAX_DURATION_MS = 10 * 60_000;
 const GATEWAY_RESTART_HANDOFF_MAX_BYTES = 4096;
 const MAX_INTENT_ID_LENGTH = 120;
 const MAX_PROCESS_INSTANCE_ID_LENGTH = 120;
@@ -37,6 +38,10 @@ export type GatewayRestartHandoff = {
   source: GatewayRestartHandoffSource;
   restartKind: GatewayRestartHandoffRestartKind;
   supervisorMode: GatewayRestartHandoffSupervisorMode;
+  restartTrace?: {
+    startedAt: number;
+    lastAt: number;
+  };
 };
 
 function formatShortDuration(ms: number): string {
@@ -130,6 +135,30 @@ function normalizeTtlMs(value: number | undefined): number {
   return Math.min(Math.floor(value), GATEWAY_RESTART_HANDOFF_TTL_MS);
 }
 
+function normalizeRestartTraceHandoff(
+  value: unknown,
+): GatewayRestartHandoff["restartTrace"] | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as { startedAt?: unknown; lastAt?: unknown };
+  if (
+    typeof record.startedAt !== "number" ||
+    !Number.isFinite(record.startedAt) ||
+    typeof record.lastAt !== "number" ||
+    !Number.isFinite(record.lastAt) ||
+    record.startedAt <= 0 ||
+    record.lastAt < record.startedAt ||
+    record.lastAt - record.startedAt > GATEWAY_RESTART_TRACE_HANDOFF_MAX_DURATION_MS
+  ) {
+    return undefined;
+  }
+  return {
+    startedAt: record.startedAt,
+    lastAt: record.lastAt,
+  };
+}
+
 function normalizeSource(
   source: GatewayRestartHandoffSource | undefined,
   reason: string | undefined,
@@ -218,6 +247,7 @@ function parseGatewayRestartHandoff(raw: string): GatewayRestartHandoff | null {
   if (parsed.processInstanceId !== undefined && typeof parsed.processInstanceId !== "string") {
     return null;
   }
+  const restartTrace = normalizeRestartTraceHandoff(parsed.restartTrace);
 
   const processInstanceId = normalizeText(parsed.processInstanceId, MAX_PROCESS_INSTANCE_ID_LENGTH);
   const reason = normalizeText(parsed.reason, MAX_REASON_LENGTH);
@@ -233,6 +263,7 @@ function parseGatewayRestartHandoff(raw: string): GatewayRestartHandoff | null {
     source: parsed.source,
     restartKind: parsed.restartKind,
     supervisorMode: parsed.supervisorMode,
+    ...(restartTrace ? { restartTrace } : {}),
   };
 }
 
@@ -257,6 +288,7 @@ export function writeGatewayRestartHandoffSync(opts: {
   source?: GatewayRestartHandoffSource;
   restartKind: GatewayRestartHandoffRestartKind;
   supervisorMode?: GatewayRestartHandoffSupervisorMode | null;
+  restartTrace?: GatewayRestartHandoff["restartTrace"];
   ttlMs?: number;
   createdAt?: number;
 }): GatewayRestartHandoff | null {
@@ -277,6 +309,7 @@ export function writeGatewayRestartHandoffSync(opts: {
   const ttlMs = normalizeTtlMs(opts.ttlMs);
   const reason = normalizeText(opts.reason, MAX_REASON_LENGTH);
   const processInstanceId = normalizeText(opts.processInstanceId, MAX_PROCESS_INSTANCE_ID_LENGTH);
+  const restartTrace = normalizeRestartTraceHandoff(opts.restartTrace);
   const payload: GatewayRestartHandoff = {
     kind: GATEWAY_SUPERVISOR_RESTART_HANDOFF_KIND,
     version: 1,
@@ -289,6 +322,7 @@ export function writeGatewayRestartHandoffSync(opts: {
     source: normalizeSource(opts.source, reason),
     restartKind: opts.restartKind,
     supervisorMode,
+    ...(restartTrace ? { restartTrace } : {}),
   };
 
   let tmpPath: string | undefined;


### PR DESCRIPTION
## Summary

- Problem: Gateway restarts had no restart-scoped trace that showed where time was spent across drain, shutdown, next start, and ready phases.
- Why it matters: Slow or degraded restarts were hard to diagnose from logs because close-path and startup timings were split across generic shutdown/startup output.
- What changed: Add `OPENCLAW_GATEWAY_RESTART_TRACE` support for parseable restart trace lines, covering restart signal, active-work drain, close-path phases, next start, ready spans, and memory metrics.
- What did NOT change (scope boundary): This does not add a standalone benchmark script, change restart budgets, change auth/config behavior, or change the gateway protocol.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A
- [ ] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

Behavior addressed: With `OPENCLAW_GATEWAY_RESTART_TRACE=1`, a real dev gateway restart now emits parseable restart trace spans and still recovers `/healthz` and `/readyz`.

Real environment tested: Local macOS checkout on branch `gw-restart-trace-bench`, commit `8129cdd78a`, Node `v24.14.0`, built `dist/entry.js` from this patch, dev gateway on loopback port `19984`.

Exact steps or command run after this patch: Started `node dist/entry.js --dev gateway run --auth none --bind loopback --port 19984 --force --allow-unconfigured --verbose` with `OPENCLAW_GATEWAY_RESTART_TRACE=1 OPENCLAW_NO_RESPAWN=1 FORCE_COLOR=0`, probed `/healthz` and `/readyz`, sent `SIGUSR1`, waited for restart trace lines, then probed `/healthz` and `/readyz` again.

Evidence after fix:
```text
{
  "initialHealthz": 200,
  "initialReadyz": 200,
  "postRestartHealthz": 200,
  "postRestartReadyz": 200,
  "startupMs": 2342,
  "signalLine": "restart trace: restart.signal.received 0.0ms total=0.0ms signal=SIGUSR1 reason=SIGUSR1 force=false waitMs=default",
  "closeLine": "restart trace: restart.close.total 58.0ms total=67.0ms reason=gateway_restarting restartExpectedMs=1500.0 rssMb=648.4 heapTotalMb=441.8 heapUsedMb=332.9 externalMb=7.1 arrayBuffersMb=0.5",
  "nextStartLine": "restart trace: restart.next-start 2.3ms total=69.3ms",
  "readyLine": "restart trace: restart.ready 362.1ms total=431.3ms rssMb=653.1 heapTotalMb=452.8 heapUsedMb=358.7 externalMb=7.1 arrayBuffersMb=0.5"
}
```

Observed result after fix: The gateway returned HTTP 200 before and after restart, emitted restart signal, close total, next-start, and ready trace lines, and shut down cleanly after the proof run.

What was not tested: Full-process respawn trace output, Linux/WSL2 runtime proof, and broad Testbox/Crabbox gates.

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: N/A. This is an observability feature, not a bug/regression fix.
- Missing detection / guardrail: Restart trace output did not previously have focused tests for parseable close and ready spans.
- Contributing context (if known): Existing startup trace and shutdown logs exposed related facts, but not as one restart-scoped timeline.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server-close.test.ts`, with existing restart path coverage in `src/cli/gateway-cli/run-loop.test.ts`.
- Scenario the test should lock in: Enabling `OPENCLAW_GATEWAY_RESTART_TRACE` emits parseable close-path spans and ready child spans without shortening the parent ready span.
- Why this is the smallest reliable guardrail: The formatter and close/ready trace hooks can be verified without starting every channel/plugin runtime.
- Existing test that already covers this (if any): Existing run-loop tests cover restart drain, restart intent, SIGUSR1, and respawn behavior.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

When `OPENCLAW_GATEWAY_RESTART_TRACE=1` is set, gateway restart logs include parseable `restart trace:` lines for drain, close, next-start, and ready timing. Default logging is unchanged when the env var is unset.

## Diagram (if applicable)

```text
Before:
SIGUSR1 restart -> drain/close/startup logs split across generic lifecycle output

After:
SIGUSR1 restart -> restart.signal -> restart.drain -> restart.close.* -> restart.next-start -> restart.ready -> health/ready recovered
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node `v24.14.0`, local `dist/entry.js`
- Model/provider: N/A
- Integration/channel (if any): None; dev gateway only
- Relevant config (redacted): `--dev --auth none --bind loopback --port 19984 --allow-unconfigured`, `OPENCLAW_GATEWAY_RESTART_TRACE=1`, `OPENCLAW_NO_RESPAWN=1`

### Steps

1. Run `node scripts/run-vitest.mjs src/gateway/server-close.test.ts src/cli/gateway-cli/run-loop.test.ts`.
2. Start the dev gateway from `dist/entry.js` with restart tracing enabled.
3. Probe `/healthz` and `/readyz`.
4. Send `SIGUSR1`.
5. Confirm restart trace lines and probe `/healthz` and `/readyz` again.

### Expected

- Targeted tests pass.
- Gateway stays recoverable after restart.
- Restart trace logs include signal, close total, next-start, and ready timing.

### Actual

- `node scripts/run-vitest.mjs src/gateway/server-close.test.ts src/cli/gateway-cli/run-loop.test.ts`: passed, 2 files / 45 tests.
- Runtime proof returned HTTP 200 for initial and post-restart `/healthz` and `/readyz`.
- Runtime proof emitted parseable restart trace lines shown above.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Targeted restart tests passed; local dev gateway restarted in-process with trace enabled and recovered health/readiness.
- Edge cases checked: Close-path trace span format, ready child span format, parent ready span duration, memory metric formatting.
- What you did **not** verify: Full-process respawn, Linux/WSL2, broad Testbox/Crabbox, and production managed service restart.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) Yes, optional `OPENCLAW_GATEWAY_RESTART_TRACE=1` enables restart trace logging.
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Wrapping shutdown phases for measurement could accidentally perturb close ordering.
  - Mitigation: The implementation preserves the existing close sequence and targeted shutdown/restart tests passed.
- Risk: Trace output could become noisy when enabled.
  - Mitigation: It is behind `OPENCLAW_GATEWAY_RESTART_TRACE`; default behavior is unchanged.
