### PR TITLE
fix(codex): release raw assistant app-server completions [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/media: prevent image filenames from overriding generic non-image byte sniffing, so zip/octet-stream payloads mislabeled as images are offloaded or rejected before they become inline image attachments.
 - Plugins/web search: downgrade stale optional provider installs to warnings so Gateway and doctor repair paths keep running after startup provider selection. Refs #82313. Thanks @crackmac.
 - Telegram/Gateway: route targeted Telegram `/stop@bot` messages onto the control lane without cached bot metadata and match gateway stop requests across raw/canonical session aliases. (#82298) Thanks @VACInc.
+- Codex app-server: release quiet pre-tool turns after a completed raw assistant response item when `turn/completed` never arrives, preventing finished model output from waiting for the terminal idle timeout without releasing post-tool progress. Fixes #82343. Thanks @McoreD.
 - MS Teams/media: sniff inline `data:image/*` attachment bytes before staging them, skipping payloads that are not actually images.
 - WebChat/media: require trusted local-media provenance before preserving local audio reply paths for display, so untrusted audio-looking paths go through normal staging and read-policy checks.
 - Agents/tool media: preserve trusted local-media provenance when merging generated tool attachments into final reply payloads, so trusted audio/media survives outbound display normalization.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Codex app-server: release raw assistant completions when `turn/completed` is missing while keeping commentary/status items as progress, preventing completed Codex runs from hanging until timeout. Fixes #82343. (#82403) Thanks @IWhatsskill.
 - CLI/status: show plain empty-state messages instead of empty Channels and Sessions tables when no channels or sessions exist.
 - CLI/context engines: bootstrap and finalize non-legacy context engines for CLI turns while preserving transcript snapshots and deferred maintenance ownership. (#81869) Thanks @sahilsatralkar.
 - Telegram: persist polling updates through restart replay so queued same-topic messages resume in order instead of losing context after a gateway restart. (#82256) Thanks @VACInc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ Docs: https://docs.openclaw.ai
 - Gateway/media: prevent image filenames from overriding generic non-image byte sniffing, so zip/octet-stream payloads mislabeled as images are offloaded or rejected before they become inline image attachments.
 - Plugins/web search: downgrade stale optional provider installs to warnings so Gateway and doctor repair paths keep running after startup provider selection. Refs #82313. Thanks @crackmac.
 - Telegram/Gateway: route targeted Telegram `/stop@bot` messages onto the control lane without cached bot metadata and match gateway stop requests across raw/canonical session aliases. (#82298) Thanks @VACInc.
-- Codex app-server: release quiet pre-tool turns after a completed raw assistant response item when `turn/completed` never arrives, preventing finished model output from waiting for the terminal idle timeout without releasing post-tool progress. Fixes #82343. Thanks @McoreD.
 - MS Teams/media: sniff inline `data:image/*` attachment bytes before staging them, skipping payloads that are not actually images.
 - WebChat/media: require trusted local-media provenance before preserving local audio reply paths for display, so untrusted audio-looking paths go through normal staging and read-policy checks.
 - Agents/tool media: preserve trusted local-media provenance when merging generated tool attachments into final reply payloads, so trusted audio/media survives outbound display normalization.

--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -264,16 +264,13 @@ native turn.
 Most non-terminal notifications for the same turn disarm that short watchdog
 because Codex has proven the turn is still alive. Raw `custom_tool_call_output`
 completions keep the short post-tool watchdog armed because they are the
-turn-scoped tool-result handoff. When Codex emits a completed `agentMessage` item
-and then goes quiet without `turn/completed`, OpenClaw treats the assistant
-output as effectively complete, best-effort interrupts the native Codex turn, and
-releases the session lane. The same fallback applies to a raw assistant
-`rawResponseItem/completed` item only before the turn has crossed an OpenClaw
-dynamic-tool handoff, so post-tool raw assistant progress keeps waiting for
-`turn/completed` or the terminal watchdog. The longer terminal watchdog
-continues to protect genuinely stuck turns. Timeout diagnostics include the last
-app-server notification method and, for raw assistant response items, the item
-type, role, id, and a bounded assistant text preview.
+turn-scoped tool-result handoff. Completed `agentMessage` items and pre-tool raw
+assistant `rawResponseItem/completed` items arm the assistant-output release: if
+Codex then goes quiet without `turn/completed`, OpenClaw best-effort interrupts
+the native turn and releases the session lane. Post-tool raw assistant progress
+keeps waiting for `turn/completed` or the terminal watchdog. Timeout diagnostics
+include the last app-server notification method and, for raw assistant response
+items, the item type, role, id, and a bounded assistant text preview.
 
 ## Model discovery
 

--- a/docs/plugins/codex-harness-reference.md
+++ b/docs/plugins/codex-harness-reference.md
@@ -261,12 +261,19 @@ interrupts the Codex turn, records a diagnostic timeout, and releases the
 OpenClaw session lane so follow-up chat messages are not queued behind a stale
 native turn.
 
-Any non-terminal notification for the same turn, including
-`rawResponseItem/completed`, disarms that short watchdog because Codex has
-proven the turn is still alive. The longer terminal watchdog continues to
-protect genuinely stuck turns. Timeout diagnostics include the last app-server
-notification method and, for raw assistant response items, the item type, role,
-id, and a bounded assistant text preview.
+Most non-terminal notifications for the same turn disarm that short watchdog
+because Codex has proven the turn is still alive. Raw `custom_tool_call_output`
+completions keep the short post-tool watchdog armed because they are the
+turn-scoped tool-result handoff. When Codex emits a completed `agentMessage` item
+and then goes quiet without `turn/completed`, OpenClaw treats the assistant
+output as effectively complete, best-effort interrupts the native Codex turn, and
+releases the session lane. The same fallback applies to a raw assistant
+`rawResponseItem/completed` item only before the turn has crossed an OpenClaw
+dynamic-tool handoff, so post-tool raw assistant progress keeps waiting for
+`turn/completed` or the terminal watchdog. The longer terminal watchdog
+continues to protect genuinely stuck turns. Timeout diagnostics include the last
+app-server notification method and, for raw assistant response items, the item
+type, role, id, and a bounded assistant text preview.
 
 ## Model discovery
 

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -536,18 +536,21 @@ eventually finish the native turn with `turn/completed`. If the app-server goes
 quiet for `appServer.turnCompletionIdleTimeoutMs`, OpenClaw best-effort
 interrupts the Codex turn, records a diagnostic timeout, and releases the
 OpenClaw session lane so follow-up chat messages are not queued behind a stale
-native turn. Most non-terminal notifications for the same turn, including raw
-assistant `rawResponseItem/completed` items, disarm that short watchdog because
-Codex has proven the turn is still alive; raw `custom_tool_call_output`
-completions keep the short post-tool watchdog armed because they are the
-turn-scoped tool-result handoff. The longer terminal watchdog continues to
-protect genuinely stuck turns. Global app-server notifications, such as
-rate-limit updates, do not reset turn-idle progress. When Codex emits a completed
-`agentMessage` item and then goes quiet without `turn/completed`, OpenClaw treats
-the assistant output as effectively complete, best-effort interrupts the native
-Codex turn, and releases the session lane. Timeout diagnostics include the last
-app-server notification method and, for raw assistant response items, the item
-type, role, id, and a bounded assistant text preview.
+native turn. Most non-terminal notifications for the same turn disarm that short
+watchdog because Codex has proven the turn is still alive; raw
+`custom_tool_call_output` completions keep the short post-tool watchdog armed
+because they are the turn-scoped tool-result handoff. The longer terminal
+watchdog continues to protect genuinely stuck turns. Global app-server
+notifications, such as rate-limit updates, do not reset turn-idle progress. When
+Codex emits a completed `agentMessage` item and then goes quiet without
+`turn/completed`, OpenClaw treats the assistant output as effectively complete,
+best-effort interrupts the native Codex turn, and releases the session lane. The
+same fallback applies to a raw assistant `rawResponseItem/completed` item only
+before the turn has crossed an OpenClaw dynamic-tool handoff, so post-tool raw
+assistant progress keeps waiting for `turn/completed` or the terminal watchdog.
+Timeout diagnostics include the last app-server notification method and, for raw
+assistant response items, the item type, role, id, and a bounded assistant text
+preview.
 
 Environment overrides remain available for local testing:
 

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -539,18 +539,15 @@ OpenClaw session lane so follow-up chat messages are not queued behind a stale
 native turn. Most non-terminal notifications for the same turn disarm that short
 watchdog because Codex has proven the turn is still alive; raw
 `custom_tool_call_output` completions keep the short post-tool watchdog armed
-because they are the turn-scoped tool-result handoff. The longer terminal
-watchdog continues to protect genuinely stuck turns. Global app-server
-notifications, such as rate-limit updates, do not reset turn-idle progress. When
-Codex emits a completed `agentMessage` item and then goes quiet without
-`turn/completed`, OpenClaw treats the assistant output as effectively complete,
-best-effort interrupts the native Codex turn, and releases the session lane. The
-same fallback applies to a raw assistant `rawResponseItem/completed` item only
-before the turn has crossed an OpenClaw dynamic-tool handoff, so post-tool raw
-assistant progress keeps waiting for `turn/completed` or the terminal watchdog.
-Timeout diagnostics include the last app-server notification method and, for raw
-assistant response items, the item type, role, id, and a bounded assistant text
-preview.
+because they are the turn-scoped tool-result handoff. Global app-server
+notifications, such as rate-limit updates, do not reset turn-idle progress.
+Completed `agentMessage` items and pre-tool raw assistant
+`rawResponseItem/completed` items arm the assistant-output release: if Codex then
+goes quiet without `turn/completed`, OpenClaw best-effort interrupts the native
+turn and releases the session lane. Post-tool raw assistant progress keeps
+waiting for `turn/completed` or the terminal watchdog. Timeout diagnostics
+include the last app-server notification method and, for raw assistant response
+items, the item type, role, id, and a bounded assistant text preview.
 
 Environment overrides remain available for local testing:
 

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -709,8 +709,15 @@ export class CodexAppServerEventProjector {
       return;
     }
     const itemId = readString(item, "id") ?? `raw-assistant-${this.assistantItemOrder.length + 1}`;
+    const phase = readString(item, "phase");
+    if (phase) {
+      this.assistantPhaseByItem.set(itemId, phase);
+    }
     this.rememberAssistantItem(itemId);
     this.assistantTextByItem.set(itemId, text);
+    if (phase === "commentary") {
+      this.emitCommentaryProgress({ itemId, text });
+    }
   }
 
   private recordNativeGeneratedMedia(item: CodexThreadItem | undefined): void {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1993,6 +1993,92 @@ describe("runCodexAppServerAttempt", () => {
     expect(request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
   });
 
+  it("does not release post-native-tool raw assistant progress after the assistant idle timeout", async () => {
+    let notify: (notification: CodexServerNotification) => Promise<void> = async () => undefined;
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-1");
+      }
+      if (method === "turn/start") {
+        return turnStartResult("turn-1", "inProgress");
+      }
+      return {};
+    });
+    setCodexAppServerClientFactoryForTest(
+      async () =>
+        ({
+          request,
+          addNotificationHandler: (handler: typeof notify) => {
+            notify = handler;
+            return () => undefined;
+          },
+          addRequestHandler: () => () => undefined,
+        }) as never,
+    );
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.timeoutMs = 60_000;
+
+    const run = runCodexAppServerAttempt(params, {
+      turnCompletionIdleTimeoutMs: 100,
+      turnAssistantCompletionIdleTimeoutMs: 5,
+      turnTerminalIdleTimeoutMs: 500,
+    });
+    await vi.waitFor(
+      () =>
+        expect(request).toHaveBeenCalledWith("turn/start", expect.anything(), expect.anything()),
+      { interval: 1 },
+    );
+    await notify({
+      method: "item/started",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: { type: "commandExecution", id: "cmd-1", status: "inProgress" },
+      },
+    });
+    await notify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: { type: "commandExecution", id: "cmd-1", status: "completed" },
+      },
+    });
+    await notify({
+      method: "rawResponseItem/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          type: "message",
+          id: "raw-status-1",
+          role: "assistant",
+          content: [{ type: "output_text", text: "I'm summarizing command output." }],
+        },
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
+
+    await notify({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        turn: { id: "turn-1", status: "completed" },
+      },
+    });
+
+    const result = await run;
+    expect(result.aborted).toBe(false);
+    expect(result.timedOut).toBe(false);
+    expect(result.promptError).toBeNull();
+    expect(request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
+  });
+
   it("logs raw assistant item context when the terminal watchdog fires", async () => {
     let notify: (notification: CodexServerNotification) => Promise<void> = async () => undefined;
     let handleRequest:

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -1901,6 +1901,98 @@ describe("runCodexAppServerAttempt", () => {
     expect(request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
   });
 
+  it("does not release post-tool raw assistant progress after the assistant idle timeout", async () => {
+    let notify: (notification: CodexServerNotification) => Promise<void> = async () => undefined;
+    let handleRequest:
+      | ((request: { id: string; method: string; params?: unknown }) => Promise<unknown>)
+      | undefined;
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-1");
+      }
+      if (method === "turn/start") {
+        return turnStartResult("turn-1", "inProgress");
+      }
+      return {};
+    });
+    setCodexAppServerClientFactoryForTest(
+      async () =>
+        ({
+          request,
+          addNotificationHandler: (handler: typeof notify) => {
+            notify = handler;
+            return () => undefined;
+          },
+          addRequestHandler: (
+            handler: (request: {
+              id: string;
+              method: string;
+              params?: unknown;
+            }) => Promise<unknown>,
+          ) => {
+            handleRequest = handler;
+            return () => undefined;
+          },
+        }) as never,
+    );
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.timeoutMs = 60_000;
+
+    const run = runCodexAppServerAttempt(params, {
+      turnCompletionIdleTimeoutMs: 50,
+      turnAssistantCompletionIdleTimeoutMs: 5,
+      turnTerminalIdleTimeoutMs: 500,
+    });
+    await vi.waitFor(() => expect(handleRequest).toBeTypeOf("function"), { interval: 1 });
+
+    const toolResult = (await handleRequest?.({
+      id: "request-tool-1",
+      method: "item/tool/call",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-1",
+        namespace: null,
+        tool: "message",
+        arguments: { action: "send", text: "already sent" },
+      },
+    })) as { success?: boolean };
+    expect(toolResult.success).toBe(false);
+    await notify({
+      method: "rawResponseItem/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          type: "message",
+          id: "raw-status-1",
+          role: "assistant",
+          content: [{ type: "output_text", text: "I'm writing the report now." }],
+        },
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
+
+    await notify({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        turn: { id: "turn-1", status: "completed" },
+      },
+    });
+
+    const result = await run;
+    expect(result.aborted).toBe(false);
+    expect(result.timedOut).toBe(false);
+    expect(result.promptError).toBeNull();
+    expect(request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
+  });
+
   it("logs raw assistant item context when the terminal watchdog fires", async () => {
     let notify: (notification: CodexServerNotification) => Promise<void> = async () => undefined;
     let handleRequest:
@@ -2435,7 +2527,7 @@ describe("runCodexAppServerAttempt", () => {
     });
   });
 
-  it("does not release the session after only a raw assistant response item", async () => {
+  it("releases the session after a raw assistant response item without turn completion", async () => {
     let notify: (notification: CodexServerNotification) => Promise<void> = async () => undefined;
     const request = vi.fn(async (method: string) => {
       if (method === "thread/start") {
@@ -2485,18 +2577,31 @@ describe("runCodexAppServerAttempt", () => {
         },
       },
     });
-    await new Promise((resolve) => setTimeout(resolve, 20));
 
     const result = await run;
     expect({
       aborted: result.aborted,
       timedOut: result.timedOut,
       promptError: result.promptError,
+      assistantTexts: result.assistantTexts,
     }).toEqual({
-      aborted: true,
-      timedOut: true,
-      promptError: "codex app-server turn idle timed out waiting for turn/completed",
+      aborted: false,
+      timedOut: false,
+      promptError: null,
+      assistantTexts: ["Done."],
     });
+    await vi.waitFor(
+      () =>
+        expect(request).toHaveBeenCalledWith(
+          "turn/interrupt",
+          {
+            threadId: "thread-1",
+            turnId: "turn-1",
+          },
+          { timeoutMs: 5_000 },
+        ),
+      { interval: 1 },
+    );
   });
 
   it("keeps waiting when a current-turn item is still active", async () => {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2613,6 +2613,82 @@ describe("runCodexAppServerAttempt", () => {
     });
   });
 
+  it("does not release or return commentary raw assistant response items", async () => {
+    let notify: (notification: CodexServerNotification) => Promise<void> = async () => undefined;
+    const request = vi.fn(async (method: string) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-1");
+      }
+      if (method === "turn/start") {
+        return turnStartResult("turn-1", "inProgress");
+      }
+      return {};
+    });
+    setCodexAppServerClientFactoryForTest(
+      async () =>
+        ({
+          request,
+          addNotificationHandler: (handler: typeof notify) => {
+            notify = handler;
+            return () => undefined;
+          },
+          addRequestHandler: () => () => undefined,
+        }) as never,
+    );
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.timeoutMs = 200;
+
+    const run = runCodexAppServerAttempt(params, {
+      turnAssistantCompletionIdleTimeoutMs: 5,
+    });
+    await vi.waitFor(
+      () =>
+        expect(request).toHaveBeenCalledWith("turn/start", expect.anything(), expect.anything()),
+      { interval: 1 },
+    );
+    await notify({
+      method: "rawResponseItem/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        item: {
+          type: "message",
+          id: "raw-commentary-1",
+          role: "assistant",
+          phase: "commentary",
+          content: [{ type: "output_text", text: "I am checking the workspace." }],
+        },
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(request).not.toHaveBeenCalledWith("turn/interrupt", expect.anything());
+    await notify({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        turn: { id: "turn-1", status: "completed" },
+      },
+    });
+
+    const result = await run;
+    expect({
+      aborted: result.aborted,
+      timedOut: result.timedOut,
+      promptError: result.promptError,
+      assistantTexts: result.assistantTexts,
+    }).toEqual({
+      aborted: false,
+      timedOut: false,
+      promptError: null,
+      assistantTexts: [],
+    });
+  });
+
   it("releases the session after a raw assistant response item without turn completion", async () => {
     let notify: (notification: CodexServerNotification) => Promise<void> = async () => undefined;
     const request = vi.fn(async (method: string) => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -3130,6 +3130,7 @@ function isRawAssistantCompletionNotification(notification: CodexServerNotificat
     item &&
     readString(item, "type") === "message" &&
     readString(item, "role") === "assistant" &&
+    readString(item, "phase") !== "commentary" &&
     readRawAssistantTextPreview(item),
   );
 }

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1394,6 +1394,9 @@ export async function runCodexAppServerAttempt(
       activeOpenClawDynamicToolCallIds,
     );
     const rawToolOutputCompletion = isRawToolOutputCompletionNotification(notification);
+    const rawAssistantCompletionCanRelease =
+      isRawAssistantCompletionNotification(notification) &&
+      activeOpenClawDynamicToolCallIds.size === 0;
     const shouldRearmCompletionIdleWatchAfterLastCurrentTurnItem =
       isCurrentTurnNotification &&
       notification.method === "item/completed" &&
@@ -1409,7 +1412,10 @@ export async function runCodexAppServerAttempt(
       disarmTurnAssistantCompletionIdleWatch();
     } else if (isTurnCompletion) {
       disarmTurnAssistantCompletionIdleWatch();
-    } else if (isCurrentTurnNotification && isCompletedAssistantNotification(notification)) {
+    } else if (
+      isCurrentTurnNotification &&
+      (isCompletedAssistantNotification(notification) || rawAssistantCompletionCanRelease)
+    ) {
       armTurnAssistantCompletionIdleWatch(describeNotificationActivity(notification));
     } else if (unblockedAssistantCompletionRelease) {
       armTurnAssistantCompletionIdleWatch(describeNotificationActivity(notification));
@@ -3074,6 +3080,19 @@ function isRawToolOutputCompletionNotification(notification: CodexServerNotifica
   }
   const item = isJsonObject(notification.params.item) ? notification.params.item : undefined;
   return item ? readString(item, "type") === "custom_tool_call_output" : false;
+}
+
+function isRawAssistantCompletionNotification(notification: CodexServerNotification): boolean {
+  if (notification.method !== "rawResponseItem/completed" || !isJsonObject(notification.params)) {
+    return false;
+  }
+  const item = isJsonObject(notification.params.item) ? notification.params.item : undefined;
+  return Boolean(
+    item &&
+    readString(item, "type") === "message" &&
+    readString(item, "role") === "assistant" &&
+    readRawAssistantTextPreview(item),
+  );
 }
 
 function readRawAssistantTextPreview(item: JsonObject): string | undefined {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1068,6 +1068,7 @@ export async function runCodexAppServerAttempt(
   let activeAppServerTurnRequests = 0;
   const activeOpenClawDynamicToolCallIds = new Set<string>();
   const activeTurnItemIds = new Set<string>();
+  let turnCrossedToolHandoff = false;
 
   const clearTurnCompletionIdleTimer = () => {
     if (turnCompletionIdleTimer) {
@@ -1394,15 +1395,22 @@ export async function runCodexAppServerAttempt(
       activeOpenClawDynamicToolCallIds,
     );
     const rawToolOutputCompletion = isRawToolOutputCompletionNotification(notification);
-    const rawAssistantCompletionCanRelease =
-      isRawAssistantCompletionNotification(notification) &&
-      activeOpenClawDynamicToolCallIds.size === 0;
+    if (
+      isCurrentTurnNotification &&
+      (rawToolOutputCompletion || isNativeToolProgressNotification(notification))
+    ) {
+      turnCrossedToolHandoff = true;
+    }
+    const assistantCompletionCanRelease = isAssistantCompletionReleaseNotification(
+      notification,
+      turnCrossedToolHandoff,
+    );
     const shouldRearmCompletionIdleWatchAfterLastCurrentTurnItem =
       isCurrentTurnNotification &&
       notification.method === "item/completed" &&
       activeTurnItemIds.size === 0 &&
       !trackedDynamicToolCompletion &&
-      !isCompletedAssistantNotification(notification);
+      !assistantCompletionCanRelease;
     if (isCurrentTurnNotification && notification.method === "error") {
       if (isRetryableErrorNotification(notification.params)) {
         disarmTurnCompletionIdleWatch();
@@ -1412,10 +1420,7 @@ export async function runCodexAppServerAttempt(
       disarmTurnAssistantCompletionIdleWatch();
     } else if (isTurnCompletion) {
       disarmTurnAssistantCompletionIdleWatch();
-    } else if (
-      isCurrentTurnNotification &&
-      (isCompletedAssistantNotification(notification) || rawAssistantCompletionCanRelease)
-    ) {
+    } else if (isCurrentTurnNotification && assistantCompletionCanRelease) {
       armTurnAssistantCompletionIdleWatch(describeNotificationActivity(notification));
     } else if (unblockedAssistantCompletionRelease) {
       armTurnAssistantCompletionIdleWatch(describeNotificationActivity(notification));
@@ -1549,6 +1554,7 @@ export async function runCodexAppServerAttempt(
         return undefined;
       }
       armCompletionWatchOnResponse = true;
+      turnCrossedToolHandoff = true;
       activeOpenClawDynamicToolCallIds.add(call.callId);
       trajectoryRecorder?.recordEvent("tool.call", {
         threadId: call.threadId,
@@ -3033,6 +3039,16 @@ function isCompletedAssistantNotification(notification: CodexServerNotification)
   );
 }
 
+function isAssistantCompletionReleaseNotification(
+  notification: CodexServerNotification,
+  turnCrossedToolHandoff: boolean,
+): boolean {
+  if (isCompletedAssistantNotification(notification)) {
+    return true;
+  }
+  return !turnCrossedToolHandoff && isRawAssistantCompletionNotification(notification);
+}
+
 function shouldDisarmAssistantCompletionIdleWatch(notification: CodexServerNotification): boolean {
   if (!isJsonObject(notification.params)) {
     return false;
@@ -3080,6 +3096,29 @@ function isRawToolOutputCompletionNotification(notification: CodexServerNotifica
   }
   const item = isJsonObject(notification.params.item) ? notification.params.item : undefined;
   return item ? readString(item, "type") === "custom_tool_call_output" : false;
+}
+
+function isNativeToolProgressNotification(notification: CodexServerNotification): boolean {
+  if (
+    notification.method !== "item/started" &&
+    notification.method !== "item/completed" &&
+    notification.method !== "item/updated"
+  ) {
+    return false;
+  }
+  if (!isJsonObject(notification.params)) {
+    return false;
+  }
+  const item = isJsonObject(notification.params.item) ? notification.params.item : undefined;
+  switch (item ? readString(item, "type") : undefined) {
+    case "commandExecution":
+    case "fileChange":
+    case "mcpToolCall":
+    case "webSearch":
+      return true;
+    default:
+      return false;
+  }
 }
 
 function isRawAssistantCompletionNotification(notification: CodexServerNotification): boolean {


### PR DESCRIPTION
## Summary

- Problem: Codex app-server turns can emit a completed raw assistant `rawResponseItem/completed` with final text but never send `turn/completed`, leaving OpenClaw waiting for the terminal idle timeout.
- Why it matters: channel delivery stays blocked even though the model output is already available, matching the stalled Discord/Telegram delivery shape in #82343.
- What changed: pre-tool raw assistant message completions now arm the existing completed-assistant idle release path, so OpenClaw best-effort interrupts the native Codex turn and releases the session lane with the captured assistant text.
- What did NOT change (scope boundary): raw tool-output watchdog behavior, active request/item guards, abort-marker handling, channel delivery, and SecretRef delivery resolution are unchanged.

## Change Type

- [x] Bug fix
- [x] Docs

## Scope

- [x] Gateway / orchestration
- [x] Integrations

## Linked Issue/PR

- Fixes #82343
- [x] This PR fixes a bug or regression

## Real behavior proof

- Behavior or issue addressed: a pre-tool completed raw assistant response item without `turn/completed` releases the Codex app-server run, while post-tool raw assistant progress does not release the turn early.
- Real environment tested: local Windows OpenClaw source checkout, local `codex` CLI logged in with ChatGPT, real Codex app-server using `gpt-5.5`, and the real `runCodexAppServerAttempt` path. Workspace and `CODEX_HOME` are redacted below.
- Exact steps or command run after this patch: `node --import tsx C:\tmp\openclaw-real-run-attempt-proof.mjs`
- Evidence after fix: the probe used a redacting local proxy around real app-server notifications. It dropped `agentMessage` notifications to isolate the raw fallback, dropped `turn/completed` only for the final-raw scenario, and delayed `turn/completed` by 1000ms after post-tool raw assistant progress.

```json
{
  "ok": true,
  "model": "gpt-5.5",
  "workspace": "<redacted-temp-workspace>",
  "codexHome": "<redacted-codex-home>",
  "finalRawWithoutTurnCompleted": {
    "passed": true,
    "proof": {
      "sawRawAssistant": true,
      "droppedTurnCompleted": 1,
      "interruptRequests": 1
    },
    "result": {
      "aborted": false,
      "timedOut": false,
      "promptError": null,
      "assistantTexts": ["REAL_OPENCLAW_RAW_FINAL_PROOF"]
    }
  },
  "postToolRawAssistantProgress": {
    "passed": true,
    "proof": {
      "sawToolRequest": true,
      "sawPostToolRawAssistant": true,
      "delayedAfterPostToolRawAssistantMs": 1000,
      "interruptRequests": 0
    },
    "result": {
      "aborted": false,
      "timedOut": false,
      "promptError": null,
      "assistantTexts": ["REAL_OPENCLAW_TOOL_DONE_PROOF"]
    }
  }
}
```

- Observed result after fix: the final raw assistant path releases with captured assistant text after the terminal event is withheld, and the post-tool raw assistant path waits for `turn/completed` without issuing `turn/interrupt`.
- What was not tested: live Discord/Telegram credentials or real channel delivery; this proof exercises the local Codex app-server/OpenClaw run-attempt boundary only.

## Root Cause

- Root cause: `event-projector` already captured assistant text from raw assistant `rawResponseItem/completed` notifications, but `run-attempt` only released completion on `turn/completed`, abort markers, or completed `agentMessage` items.
- Missing detection / guardrail: the completed-assistant idle release did not recognize pre-tool raw assistant message completions as equivalent final assistant output, while post-tool raw assistant progress still needed to stay behind the dynamic-tool handoff guard.
- Contributing context: adjacent watchdog fixes covered raw tool-output silence and completed `agentMessage` silence, but left the raw assistant final-output path waiting for the terminal watchdog.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Seam / integration test
- Target test or file: `extensions/codex/src/app-server/run-attempt.test.ts`
- Scenario the test should lock in: a pre-tool raw assistant `rawResponseItem/completed` with final text and no `turn/completed` releases the run with the captured assistant text; post-tool raw assistant progress does not release before `turn/completed`.
- Why this is the smallest reliable guardrail: the bug is in the app-server attempt completion/watchdog boundary, not in channel delivery or the event projector.
- Existing test that already covers this: `extensions/codex/src/app-server/event-projector.test.ts` already proves raw assistant text extraction; this PR adds the missing run-attempt release coverage.

## User-visible / Behavior Changes

Codex app-server turns that have already produced pre-tool final raw assistant text can deliver instead of waiting for the terminal idle timeout when `turn/completed` never arrives.

## Diagram

```text
Before:
raw assistant completed -> text captured -> wait for turn/completed -> terminal idle timeout

After:
pre-tool raw assistant completed -> text captured -> completed-assistant release -> channel delivery can proceed
post-tool raw assistant progress -> wait for turn/completed -> channel delivery can proceed
```

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Windows local development checkout
- Runtime/container: local Node with `tsx`
- Model/provider: real local Codex app-server, `gpt-5.5`
- Integration/channel: real Codex app-server embedded-run path through `runCodexAppServerAttempt`
- Relevant config (redacted): workspace path and `CODEX_HOME`

### Steps

1. Start a real local Codex app-server through the OpenClaw app-server attempt path.
2. In the final-raw scenario, observe current-turn `rawResponseItem/completed` for assistant output and drop `turn/completed` in the local redacting proxy.
3. In the post-tool scenario, force a real message tool call, observe post-tool raw assistant text, and delay `turn/completed` for 1000ms.

### Expected

- OpenClaw releases the pre-tool final raw assistant attempt with captured assistant text and does not mark the turn timed out.
- OpenClaw does not release post-tool raw assistant progress through the raw assistant fallback; it waits for `turn/completed`.

### Actual

- Before this patch, OpenClaw waited for `turn/completed` until the terminal idle timeout in the final-raw scenario.
- ClawSweeper also found that the first patch could let post-tool raw assistant progress trigger the completed-assistant release. This revision blocks that path while dynamic tool calls have occurred in the turn.

## Evidence

- [x] Failing test/log before + passing after
- [x] Real local app-server behavior proof after the fix

## Human Verification

- Verified scenarios:
  - pre-tool raw assistant completion without `turn/completed` releases with assistant text
  - raw assistant progress after a dynamic tool response still waits for `turn/completed`
  - real local Codex app-server path preserves both behaviors through `runCodexAppServerAttempt`
  - raw tool-output watchdog behavior remains covered
  - active current-turn item guard still blocks release
  - interrupted turn marker behavior remains covered
- Edge cases checked:
  - event projector still extracts raw assistant response items
  - formatting, lint, and whitespace checks pass
- What you did **not** verify:
  - live channel delivery with real Discord/Telegram credentials

## Review Conversations

- [x] ClawSweeper's P2 blocker is addressed in code, tests, and this PR body.
- [x] I left the bot review unresolved pending ClawSweeper re-review.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- Risk: treating an interim raw assistant status message as final too early.
  - Mitigation: only arm the raw assistant completion release before any OpenClaw dynamic-tool handoff in the turn, reuse the completed-assistant idle release instead of immediate completion, and keep active app-server request/current-turn item guards in place. New coverage confirms raw assistant progress after a dynamic tool response still waits for `turn/completed`.
