### PR TITLE
fix(telegram): fall back to presentation when interactive lacks text (#82404)

### DIFF
--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -759,6 +759,7 @@ export async function deliverReplies(params: {
       resolveTelegramInteractiveTextFallback({
         text: reply?.text,
         interactive: reply?.interactive,
+        presentation: (reply as { presentation?: unknown } | undefined)?.presentation,
       }) ??
       reply?.text ??
       "";

--- a/extensions/telegram/src/interactive-fallback.test.ts
+++ b/extensions/telegram/src/interactive-fallback.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { resolveTelegramInteractiveTextFallback } from "./interactive-fallback.js";
+
+describe("resolveTelegramInteractiveTextFallback presentation fallback (#82404)", () => {
+  it("uses presentation text blocks when interactive lacks text", () => {
+    const text = resolveTelegramInteractiveTextFallback({
+      text: undefined,
+      interactive: undefined,
+      presentation: {
+        title: "Daily Digest",
+        blocks: [{ type: "text", text: "Three new tickets need review." }],
+      },
+    });
+    expect(text?.trim()).toBeTruthy();
+    expect(text).toContain("Three new tickets");
+  });
+
+  it("uses presentation button labels when only buttons are present", () => {
+    const text = resolveTelegramInteractiveTextFallback({
+      text: undefined,
+      interactive: undefined,
+      presentation: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [
+              { value: "approve", label: "Approve" },
+              { value: "reject", label: "Reject" },
+            ],
+          },
+        ],
+      },
+    });
+    expect(text?.trim()).toBeTruthy();
+    expect(text).toContain("Approve");
+    expect(text).toContain("Reject");
+  });
+
+  it("prefers top-level text when both text and presentation are present", () => {
+    const text = resolveTelegramInteractiveTextFallback({
+      text: "Top level wins",
+      interactive: undefined,
+      presentation: {
+        blocks: [{ type: "text", text: "Should be ignored" }],
+      },
+    });
+    expect(text).toBe("Top level wins");
+  });
+
+  it("returns undefined when there is genuinely no content anywhere", () => {
+    const text = resolveTelegramInteractiveTextFallback({
+      text: undefined,
+      interactive: undefined,
+      presentation: undefined,
+    });
+    expect(text).toBeUndefined();
+  });
+});

--- a/extensions/telegram/src/interactive-fallback.ts
+++ b/extensions/telegram/src/interactive-fallback.ts
@@ -1,6 +1,7 @@
 import {
   interactiveReplyToPresentation,
   normalizeInteractiveReply,
+  normalizeMessagePresentation,
   renderMessagePresentationFallbackText,
   resolveInteractiveTextFallback,
 } from "openclaw/plugin-sdk/interactive-runtime";
@@ -8,6 +9,7 @@ import {
 export function resolveTelegramInteractiveTextFallback(params: {
   text?: string | null;
   interactive?: unknown;
+  presentation?: unknown;
 }): string | undefined {
   const interactive = normalizeInteractiveReply(params.interactive);
   const text = resolveInteractiveTextFallback({
@@ -17,13 +19,28 @@ export function resolveTelegramInteractiveTextFallback(params: {
   if (text?.trim()) {
     return text;
   }
+  // Fallback to the original presentation when the interactive path produced
+  // no usable text (e.g. presentation-only payloads where renderPresentation
+  // upstream returned an interactive without text blocks, or presentations
+  // that did not survive normalization). Without this, Telegram rejects the
+  // send with "Message must be non-empty for Telegram sends".
+  const presentation = normalizeMessagePresentation(params.presentation);
+  if (presentation) {
+    const directFallback = renderMessagePresentationFallbackText({
+      text: params.text ?? undefined,
+      presentation,
+    });
+    if (directFallback.trim()) {
+      return directFallback;
+    }
+  }
   if (!interactive) {
     return text;
   }
-  const presentation = interactiveReplyToPresentation(interactive);
-  if (!presentation) {
+  const reconstructed = interactiveReplyToPresentation(interactive);
+  if (!reconstructed) {
     return text;
   }
-  const fallback = renderMessagePresentationFallbackText({ presentation });
+  const fallback = renderMessagePresentationFallbackText({ presentation: reconstructed });
   return fallback.trim() ? fallback : text;
 }

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -120,6 +120,7 @@ export async function sendTelegramPayloadMessages(params: {
     resolveTelegramInteractiveTextFallback({
       text: params.payload.text,
       interactive: params.payload.interactive,
+      presentation: params.payload.presentation,
     }) ?? "";
   const mediaUrls = resolvePayloadMediaUrls(params.payload);
   const buttons = resolveTelegramInlineButtons({


### PR DESCRIPTION
## Real behavior proof

- **Behavior or issue addressed:** Telegram outbound rejects presentation-only payloads with `"Message must be non-empty for Telegram sends"` when the rendered `text` is empty and the interactive conversion contains no text blocks (for example, button-only presentations, or presentations that did not survive upstream normalization). Fixes #82404.
- **Real environment tested:** Local OpenClaw checkout on commit `2534b03d7a234156fa6b2f01d2119f6a981654ec`, Node/tsx through the repo toolchain, running the patched Telegram fallback resolver from `extensions/telegram/src/interactive-fallback.ts`. No Telegram token or external network call was used; this is a direct runtime invocation of the send-path text resolver that prevents Telegram's empty-message rejection.
- **Exact steps or command run after this patch:**

```bash
pnpm exec tsx --input-type=module -e 'import { resolveTelegramInteractiveTextFallback } from "./extensions/telegram/src/interactive-fallback.ts"; const cases=[{name:"button-only presentation",input:{text:undefined,interactive:undefined,presentation:{blocks:[{type:"buttons",buttons:[{value:"approve",label:"Approve"},{value:"reject",label:"Reject"}]}]}}},{name:"text-block presentation",input:{text:undefined,interactive:undefined,presentation:{blocks:[{type:"text",text:"Three new tickets need review."}]}}},{name:"top-level text precedence",input:{text:"Top level wins",interactive:undefined,presentation:{blocks:[{type:"text",text:"Should be ignored"}]}}}]; console.log(JSON.stringify(cases.map((c)=>({name:c.name,telegramFallback:resolveTelegramInteractiveTextFallback(c.input)})),null,2));'
```

- **Evidence after fix:** Terminal output from the patched resolver:

```json
[
  {
    "name": "button-only presentation",
    "telegramFallback": "- Approve\n- Reject"
  },
  {
    "name": "text-block presentation",
    "telegramFallback": "Three new tickets need review."
  },
  {
    "name": "top-level text precedence",
    "telegramFallback": "Top level wins"
  }
]
```

- **Observed result after fix:** Presentation-only button and text-block payloads now resolve to non-empty Telegram fallback text before the send path reaches the empty-message guard. Existing top-level text still wins, so already-rendered payloads keep prior behavior.
- **What was not tested:** I did not send a live Telegram bot message against the public Telegram API because this environment has no Telegram bot token/chat configured. The proof above exercises the exact patched resolver used by `sendTelegramPayloadMessages` and `deliverReplies`; live network delivery remains untested.

## Root cause and fix surface

- **Root cause:** `sendTelegramPayloadMessages` and `registerTelegramReplyDelivery` call `resolveTelegramInteractiveTextFallback({ text, interactive })` only — `payload.presentation` is never consulted. When `renderPresentation` upstream stripped or mishandled the original presentation, both `text` and the interactive fallback are empty, so the send is dropped.
- **Fix surface:**
  - `extensions/telegram/src/interactive-fallback.ts` — accept optional `presentation` and, when interactive yields no text, render the fallback directly from the original presentation via the existing `renderMessagePresentationFallbackText` helper (handles text/context blocks, button labels, and select option labels — see `src/interactive/payload.ts:348`).
  - `extensions/telegram/src/outbound-adapter.ts` — pass `payload.presentation` to the resolver at line 119.
  - `extensions/telegram/src/bot/delivery.replies.ts` — pass `reply.presentation` at line 758.
- **Existing-helper check (vincentkoc #57341):** Reuses `renderMessagePresentationFallbackText` and `normalizeMessagePresentation` from `openclaw/plugin-sdk/interactive-runtime` (both already exported in `src/plugin-sdk/interactive-runtime.ts:32,36`). No new normalization or text-extraction logic introduced.
- **Shared-helper caller check (steipete #60623):** `resolveTelegramInteractiveTextFallback` is imported in 4 places (`outbound-adapter.ts`, `bot/delivery.replies.ts`, `action-runtime.ts`, plus its own test). The new `presentation` parameter is optional and defaults to undefined, so all existing call sites remain semantically unchanged. The two hot call sites get the new field passed through; `action-runtime.ts` already runs presentation rendering directly upstream (line 158) so it does not need the parameter.
- **Broader-fix rival scan (steipete #68270):** No rival PR open on this issue surface as of cycle start.
- **Local verification:**
  - `pnpm exec oxfmt --check --threads=1 extensions/telegram/src/interactive-fallback.ts extensions/telegram/src/interactive-fallback.test.ts extensions/telegram/src/outbound-adapter.ts extensions/telegram/src/bot/delivery.replies.ts`
  - `node scripts/run-vitest.mjs extensions/telegram/src/interactive-fallback.test.ts`
  - `git diff --check`
- **Backward compatibility:** The new parameter is optional; payloads without presentation behave exactly as before. The presentation fallback only fires when `text` is absent and interactive yields no text, so existing presentation-rendered payloads where upstream already populated `text` are not affected.