### PR TITLE
fix: preserve reasoning_content replay from thinking blocks in anthropic-messages transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ Docs: https://docs.openclaw.ai
 - Image generation: raise Google, OpenRouter, and xAI hosted provider default timeouts to 180 seconds so slow hosted image requests have more time to complete. (#75337)
 - Agents/auth: redact OAuth refresh failure causes against in-memory, attempted, and reloaded credentials before generic token masking while ensuring failed ACP dispatch cleanup closes initialized runtimes.
 - Google/Gemini CLI OAuth: add provider-owned refresh support for `google-gemini-cli` so expired Gemini CLI tokens refresh in OpenClaw instead of falling through to the generic unknown-provider path. Fixes #42541. Thanks @jason-allen-oneal.
+- Agents/Anthropic transport: replay `reasoning_content` from compatible thinking blocks for Xiaomi/MiMo-style Anthropic Messages routes, preventing follow-up turns from losing required reasoning context. Fixes #81261. Thanks @Sunnyone2three.
 - Telegram: cache successful startup bot identity by account and token fingerprint for up to 24 hours, so restarts can skip redundant `getMe` probes during Telegram API slow periods without permanently pinning renamed bots. Refs #82525.
 - Gateway/sessions: discard stale metadata when recreating dead main session rows, so replacement sessions do not inherit old labels or transcript paths.
 - Codex app-server: mark native context compaction completion events as successful, preventing false "Compaction incomplete" notices after successful Codex-managed compaction. Fixes #82470. (#81593) Thanks @Kyzcreig.

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -581,6 +581,238 @@ describe("anthropic transport stream", () => {
     expect(result.usage.output).toBe(9);
   });
 
+  it("captures OpenAI-style reasoning_content deltas from Anthropic-compatible streams", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      createSseResponse([
+        {
+          type: "message_start",
+          message: { id: "msg_1", usage: { input_tokens: 6, output_tokens: 0 } },
+        },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { content: "", reasoning_content: "Need " },
+        },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { content: "", reasoning_content: "context." },
+        },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { content: "Visible answer.", reasoning_content: "" },
+        },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { content: " Continued.", reasoning_content: null },
+        },
+        {
+          type: "content_block_stop",
+          index: 0,
+        },
+        {
+          type: "message_delta",
+          delta: { stop_reason: "end_turn" },
+          usage: { input_tokens: 6, output_tokens: 2 },
+        },
+      ]),
+    );
+    const model = makeAnthropicTransportModel({
+      id: "mimo-v2.5",
+      name: "MiMo V2.5",
+      provider: "xiaomi-token-plan-ams",
+      baseUrl: "https://token-plan-ams.xiaomimimo.com/anthropic",
+    });
+
+    const firstResult = await runTransportStream(
+      model,
+      {
+        messages: [{ role: "user", content: "think" }],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-xiaomi-test",
+        reasoning: "high",
+      } as AnthropicStreamOptions,
+    );
+
+    expect(firstResult.content).toEqual([
+      {
+        type: "thinking",
+        thinking: "Need context.",
+        thinkingSignature: "reasoning_content",
+      },
+      {
+        type: "text",
+        text: "Visible answer. Continued.",
+      },
+    ]);
+
+    await runTransportStream(
+      model,
+      {
+        messages: [
+          { role: "user", content: "think" },
+          {
+            ...firstResult,
+            timestamp: 0,
+          },
+          { role: "user", content: "continue" },
+        ],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-xiaomi-test",
+        reasoning: "high",
+      } as AnthropicStreamOptions,
+    );
+
+    const assistantMessage = findRecord(
+      latestAnthropicRequest().payload.messages,
+      (record) => record.role === "assistant",
+    );
+    expect(assistantMessage.reasoning_content).toBe("Need context.");
+    expect(assistantMessage.content).toEqual([
+      {
+        type: "thinking",
+        thinking: "Need context.",
+        signature: "reasoning_content",
+      },
+      { type: "text", text: "Visible answer. Continued." },
+    ]);
+  });
+
+  it("captures reasoning_content after compatible streams start a text block", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      createSseResponse([
+        {
+          type: "message_start",
+          message: { id: "msg_1", usage: { input_tokens: 6, output_tokens: 0 } },
+        },
+        {
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "text", text: "" },
+        },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { content: "Visible ", reasoning_content: "Need " },
+        },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { content: "answer.", reasoning_content: null },
+        },
+        {
+          type: "content_block_stop",
+          index: 0,
+        },
+        {
+          type: "message_delta",
+          delta: { stop_reason: "end_turn" },
+          usage: { input_tokens: 6, output_tokens: 2 },
+        },
+      ]),
+    );
+
+    const result = await runTransportStream(
+      makeAnthropicTransportModel({
+        id: "mimo-v2.5",
+        name: "MiMo V2.5",
+        provider: "xiaomi-token-plan-ams",
+        baseUrl: "https://token-plan-ams.xiaomimimo.com/anthropic",
+      }),
+      {
+        messages: [{ role: "user", content: "think" }],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-xiaomi-test",
+        reasoning: "high",
+      } as AnthropicStreamOptions,
+    );
+
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: "Visible answer.",
+      },
+      {
+        type: "thinking",
+        thinking: "Need ",
+        thinkingSignature: "reasoning_content",
+      },
+    ]);
+  });
+
+  it("preserves native text_delta chunks that also carry reasoning_content", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      createSseResponse([
+        {
+          type: "message_start",
+          message: { id: "msg_1", usage: { input_tokens: 6, output_tokens: 0 } },
+        },
+        {
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "text", text: "" },
+        },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: {
+            type: "text_delta",
+            content: "Visible ",
+            text: "Visible ",
+            reasoning_content: "Need ",
+          },
+        },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "text_delta", text: "answer." },
+        },
+        {
+          type: "content_block_stop",
+          index: 0,
+        },
+        {
+          type: "message_delta",
+          delta: { stop_reason: "end_turn" },
+          usage: { input_tokens: 6, output_tokens: 2 },
+        },
+      ]),
+    );
+
+    const result = await runTransportStream(
+      makeAnthropicTransportModel({
+        id: "mimo-v2.5",
+        name: "MiMo V2.5",
+        provider: "xiaomi-token-plan-ams",
+        baseUrl: "https://token-plan-ams.xiaomimimo.com/anthropic",
+      }),
+      {
+        messages: [{ role: "user", content: "think" }],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-xiaomi-test",
+        reasoning: "high",
+      } as AnthropicStreamOptions,
+    );
+
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: "Visible answer.",
+      },
+      {
+        type: "thinking",
+        thinking: "Need ",
+        thinkingSignature: "reasoning_content",
+      },
+    ]);
+  });
+
   it("recovers orphan text deltas when an Anthropic-compatible provider omits block start", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([
@@ -728,6 +960,285 @@ describe("anthropic transport stream", () => {
       (record) => record.type === "tool_use" && record.name === "lookup",
     );
     expect(toolUse.input).toEqual({});
+  });
+
+  it("replays reasoning_content from compatible Anthropic thinking blocks", async () => {
+    await runTransportStream(
+      makeAnthropicTransportModel({
+        id: "mimo-v2.6-pro",
+        name: "MiMo V2.6 Pro",
+        provider: "xiaomi",
+        baseUrl: "https://token-plan-ams.xiaomimimo.com/anthropic",
+      }),
+      {
+        messages: [
+          { role: "user", content: "hello" },
+          {
+            role: "assistant",
+            provider: "xiaomi",
+            api: "anthropic-messages",
+            model: "mimo-v2.6-pro",
+            stopReason: "stop",
+            timestamp: 0,
+            content: [
+              {
+                type: "thinking",
+                thinking: "Need to answer politely.",
+                thinkingSignature: "reasoning_content",
+              },
+              { type: "text", text: "Hello!" },
+              {
+                type: "thinking",
+                thinking: "Then ask a follow-up.",
+                thinkingSignature: "reasoning_content",
+              },
+            ],
+          },
+          { role: "user", content: "again" },
+        ],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-xiaomi-test",
+        reasoning: "high",
+      } as AnthropicStreamOptions,
+    );
+
+    const assistantMessage = findRecord(
+      latestAnthropicRequest().payload.messages,
+      (record) => record.role === "assistant",
+    );
+    expect(assistantMessage.reasoning_content).toBe(
+      "Need to answer politely.\nThen ask a follow-up.",
+    );
+    expect(assistantMessage).not.toHaveProperty("reasoning");
+    expect(assistantMessage).not.toHaveProperty("reasoning_text");
+    expect(assistantMessage.content).toEqual([
+      {
+        type: "thinking",
+        thinking: "Need to answer politely.",
+        signature: "reasoning_content",
+      },
+      { type: "text", text: "Hello!" },
+      {
+        type: "thinking",
+        thinking: "Then ask a follow-up.",
+        signature: "reasoning_content",
+      },
+    ]);
+  });
+
+  it("backfills empty reasoning_content for compatible Anthropic tool-use replays", async () => {
+    await runTransportStream(
+      makeAnthropicTransportModel({
+        id: "mimo-v2.6-pro",
+        name: "MiMo V2.6 Pro",
+        provider: "xiaomi",
+        baseUrl: "https://token-plan-ams.xiaomimimo.com/anthropic",
+      }),
+      {
+        messages: [
+          { role: "user", content: "look this up" },
+          {
+            role: "assistant",
+            provider: "xiaomi",
+            api: "anthropic-messages",
+            model: "mimo-v2.6-pro",
+            stopReason: "toolUse",
+            timestamp: 0,
+            content: [{ type: "toolCall", id: "call_1", name: "lookup", arguments: {} }],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_1",
+            content: [{ type: "text", text: "found" }],
+            isError: false,
+          },
+          { role: "user", content: "continue" },
+        ],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-xiaomi-test",
+        reasoning: "high",
+      } as AnthropicStreamOptions,
+    );
+
+    const assistantMessage = findRecord(
+      latestAnthropicRequest().payload.messages,
+      (record) => record.role === "assistant",
+    );
+    expect(assistantMessage.reasoning_content).toBe("");
+    expect(assistantMessage.content).toEqual([
+      { type: "tool_use", id: "call_1", name: "lookup", input: {} },
+    ]);
+  });
+
+  it("backfills empty reasoning_content for compatible Anthropic text replays", async () => {
+    await runTransportStream(
+      makeAnthropicTransportModel({
+        id: "mimo-v2.6-pro",
+        name: "MiMo V2.6 Pro",
+        provider: "xiaomi",
+        baseUrl: "https://token-plan-ams.xiaomimimo.com/anthropic",
+      }),
+      {
+        messages: [
+          { role: "user", content: "hello" },
+          {
+            role: "assistant",
+            provider: "xiaomi",
+            api: "anthropic-messages",
+            model: "mimo-v2.6-pro",
+            stopReason: "stop",
+            timestamp: 0,
+            content: [{ type: "text", text: "Hello!" }],
+          },
+          { role: "user", content: "again" },
+        ],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-xiaomi-test",
+        reasoning: "high",
+      } as AnthropicStreamOptions,
+    );
+
+    const assistantMessage = findRecord(
+      latestAnthropicRequest().payload.messages,
+      (record) => record.role === "assistant",
+    );
+    expect(assistantMessage.reasoning_content).toBe("");
+    expect(assistantMessage.content).toEqual([{ type: "text", text: "Hello!" }]);
+  });
+
+  it("does not backfill reasoning_content for generic Anthropic-compatible tool-use replays", async () => {
+    await runTransportStream(
+      makeAnthropicTransportModel({
+        id: "claude-sonnet-4-6",
+        name: "Claude Sonnet 4.6",
+        provider: "gateway",
+        baseUrl: "https://gateway.example.com/anthropic",
+      }),
+      {
+        messages: [
+          { role: "user", content: "look this up" },
+          {
+            role: "assistant",
+            provider: "gateway",
+            api: "anthropic-messages",
+            model: "claude-sonnet-4-6",
+            stopReason: "toolUse",
+            timestamp: 0,
+            content: [{ type: "toolCall", id: "call_1", name: "lookup", arguments: {} }],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "call_1",
+            content: [{ type: "text", text: "found" }],
+            isError: false,
+          },
+          { role: "user", content: "continue" },
+        ],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-gateway-test",
+        reasoning: "high",
+      } as AnthropicStreamOptions,
+    );
+
+    const assistantMessage = findRecord(
+      latestAnthropicRequest().payload.messages,
+      (record) => record.role === "assistant",
+    );
+    expect(assistantMessage).not.toHaveProperty("reasoning_content");
+    expect(assistantMessage.content).toEqual([
+      { type: "tool_use", id: "call_1", name: "lookup", input: {} },
+    ]);
+  });
+
+  it("does not replay reasoning_content when compatible Anthropic thinking is disabled", async () => {
+    await runTransportStream(
+      makeAnthropicTransportModel({
+        id: "mimo-v2.6-pro",
+        name: "MiMo V2.6 Pro",
+        provider: "xiaomi",
+        baseUrl: "https://token-plan-ams.xiaomimimo.com/anthropic",
+      }),
+      {
+        messages: [
+          { role: "user", content: "hello" },
+          {
+            role: "assistant",
+            provider: "xiaomi",
+            api: "anthropic-messages",
+            model: "mimo-v2.6-pro",
+            stopReason: "stop",
+            timestamp: 0,
+            content: [
+              {
+                type: "thinking",
+                thinking: "Need to answer politely.",
+                thinkingSignature: "reasoning_content",
+              },
+              { type: "text", text: "Hello!" },
+            ],
+          },
+          { role: "user", content: "again" },
+        ],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-xiaomi-test",
+      } as AnthropicStreamOptions,
+    );
+
+    const assistantMessage = findRecord(
+      latestAnthropicRequest().payload.messages,
+      (record) => record.role === "assistant",
+    );
+    expect(latestAnthropicRequest().payload.thinking).toEqual({ type: "disabled" });
+    expect(assistantMessage).not.toHaveProperty("reasoning_content");
+    expect(assistantMessage.content).toEqual([{ type: "text", text: "Hello!" }]);
+  });
+
+  it("does not replay synthetic reasoning_content to native Anthropic models", async () => {
+    await runTransportStream(
+      makeAnthropicTransportModel({
+        id: "claude-sonnet-4-6",
+        name: "Claude Sonnet 4.6",
+        provider: "anthropic",
+        baseUrl: "https://api.anthropic.com",
+      }),
+      {
+        messages: [
+          { role: "user", content: "hello" },
+          {
+            role: "assistant",
+            provider: "anthropic",
+            api: "anthropic-messages",
+            model: "claude-sonnet-4-6",
+            stopReason: "stop",
+            timestamp: 0,
+            content: [
+              {
+                type: "thinking",
+                thinking: "Private replay text.",
+                thinkingSignature: "reasoning_content",
+              },
+              { type: "text", text: "Visible reply." },
+            ],
+          },
+          { role: "user", content: "again" },
+        ],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+      } as AnthropicStreamOptions,
+    );
+
+    const assistantMessage = findRecord(
+      latestAnthropicRequest().payload.messages,
+      (record) => record.role === "assistant",
+    );
+    expect(assistantMessage).not.toHaveProperty("reasoning_content");
+    expect(assistantMessage.content).toEqual([{ type: "text", text: "Visible reply." }]);
   });
 
   it.each([

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -341,6 +341,7 @@ function convertAnthropicMessages(
     }
     if (msg.role === "assistant") {
       const blocks: Array<Record<string, unknown>> = [];
+      let reasoningContent: string | undefined;
       for (const block of msg.content) {
         if (block.type === "text") {
           if (block.text.trim().length > 0) {
@@ -373,6 +374,7 @@ function convertAnthropicMessages(
               thinking: sanitizeTransportPayloadText(block.thinking),
               signature: block.thinkingSignature,
             });
+            if (block.thinkingSignature === "reasoning_content") reasoningContent = block.thinking;
           }
           continue;
         }
@@ -387,8 +389,7 @@ function convertAnthropicMessages(
       }
       if (blocks.length > 0) {
         const assistantMsg: Record<string, unknown> = { role: "assistant", content: blocks };
-        if (typeof msg.reasoning_content === "string" && msg.reasoning_content.length > 0)
-          assistantMsg.reasoning_content = msg.reasoning_content;
+        if (reasoningContent) assistantMsg.reasoning_content = reasoningContent;
         params.push(assistantMsg);
       }
       continue;

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -207,6 +207,12 @@ function isKimiAnthropicProvider(provider: string | undefined): boolean {
   return /^kimi(?:-|$)/.test(normalizeLowercaseStringOrEmpty(provider ?? ""));
 }
 
+function supportsReasoningContentReplay(
+  model: Pick<AnthropicTransportModel, "provider" | "baseUrl">,
+): boolean {
+  return resolveProviderEndpoint(model.baseUrl).endpointClass === "xiaomi-native";
+}
+
 function buildAnthropicBetaHeader(
   model: AnthropicTransportModel,
   betaFeatures: readonly string[],
@@ -288,8 +294,10 @@ function convertAnthropicMessages(
   messages: Context["messages"],
   model: AnthropicTransportModel,
   isOAuthToken: boolean,
+  options?: { allowReasoningContentReplay?: boolean },
 ) {
   const params: Array<Record<string, unknown>> = [];
+  const allowReasoningContentReplay = options?.allowReasoningContentReplay === true;
   const transformedMessages = transformTransportMessages(messages, model, normalizeToolCallId);
   for (let i = 0; i < transformedMessages.length; i += 1) {
     const msg = transformedMessages[i];
@@ -341,7 +349,7 @@ function convertAnthropicMessages(
     }
     if (msg.role === "assistant") {
       const blocks: Array<Record<string, unknown>> = [];
-      let reasoningContent: string | undefined;
+      const reasoningContent: string[] = [];
       for (const block of msg.content) {
         if (block.type === "text") {
           if (block.text.trim().length > 0) {
@@ -369,12 +377,23 @@ function convertAnthropicMessages(
               text: sanitizeTransportPayloadText(block.thinking),
             });
           } else {
+            const thinking = sanitizeTransportPayloadText(block.thinking);
+            if (block.thinkingSignature === "reasoning_content") {
+              if (allowReasoningContentReplay) {
+                blocks.push({
+                  type: "thinking",
+                  thinking,
+                  signature: block.thinkingSignature,
+                });
+                reasoningContent.push(thinking);
+              }
+              continue;
+            }
             blocks.push({
               type: "thinking",
-              thinking: sanitizeTransportPayloadText(block.thinking),
+              thinking,
               signature: block.thinkingSignature,
             });
-            if (block.thinkingSignature === "reasoning_content") reasoningContent = block.thinking;
           }
           continue;
         }
@@ -389,7 +408,11 @@ function convertAnthropicMessages(
       }
       if (blocks.length > 0) {
         const assistantMsg: Record<string, unknown> = { role: "assistant", content: blocks };
-        if (reasoningContent) assistantMsg.reasoning_content = reasoningContent;
+        if (reasoningContent.length > 0) {
+          assistantMsg.reasoning_content = reasoningContent.join("\n");
+        } else if (allowReasoningContentReplay) {
+          assistantMsg.reasoning_content = "";
+        }
         params.push(assistantMsg);
       }
       continue;
@@ -764,7 +787,10 @@ function buildAnthropicParams(
   const params: Record<string, unknown> = {
     model: model.id,
     messages: ensureNonEmptyAnthropicMessages(
-      convertAnthropicMessages(context.messages, model, isOAuthToken),
+      convertAnthropicMessages(context.messages, model, isOAuthToken, {
+        allowReasoningContentReplay:
+          supportsReasoningContentReplay(model) && options?.thinkingEnabled === true,
+      }),
     ),
     max_tokens: maxTokens,
     stream: true,
@@ -920,6 +946,117 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
         );
         stream.push({ type: "start", partial: output as never });
         const blocks = output.content;
+        const allowReasoningContentReplay =
+          supportsReasoningContentReplay(model) && transportOptions.thinkingEnabled === true;
+        const reasoningContentThinkingBlocks = new Map<number, number>();
+        const reasoningContentTextBlocks = new Map<number, number>();
+        const eventIndexKey = (eventIndex: unknown) =>
+          typeof eventIndex === "number" ? eventIndex : -1;
+        const appendReasoningContentThinkingDelta = (
+          eventIndex: unknown,
+          rawText: unknown,
+        ): boolean => {
+          if (typeof rawText !== "string") {
+            return false;
+          }
+          const text = sanitizeTransportPayloadText(rawText);
+          if (text.length === 0) {
+            return false;
+          }
+          const key = eventIndexKey(eventIndex);
+          let contentIndex = reasoningContentThinkingBlocks.get(key);
+          let block =
+            contentIndex === undefined
+              ? undefined
+              : (output.content[contentIndex] as TransportContentBlock | undefined);
+          if (!block || block.type !== "thinking") {
+            block = { type: "thinking", thinking: "", thinkingSignature: "reasoning_content" };
+            output.content.push(block);
+            contentIndex = output.content.length - 1;
+            reasoningContentThinkingBlocks.set(key, contentIndex);
+            stream.push({
+              type: "thinking_start",
+              contentIndex,
+              partial: output as never,
+            });
+          }
+          block.thinking += text;
+          block.thinkingSignature = "reasoning_content";
+          stream.push({
+            type: "thinking_delta",
+            contentIndex,
+            delta: text,
+            partial: output as never,
+          });
+          return true;
+        };
+        const appendReasoningContentTextDelta = (
+          eventIndex: unknown,
+          rawText: unknown,
+        ): boolean => {
+          if (typeof rawText !== "string") {
+            return false;
+          }
+          const text = sanitizeTransportPayloadText(rawText);
+          if (text.length === 0) {
+            return false;
+          }
+          const key = eventIndexKey(eventIndex);
+          let contentIndex = reasoningContentTextBlocks.get(key);
+          let block =
+            contentIndex === undefined
+              ? undefined
+              : (output.content[contentIndex] as TransportContentBlock | undefined);
+          if (!block || block.type !== "text") {
+            block = { type: "text", text: "" };
+            output.content.push(block);
+            contentIndex = output.content.length - 1;
+            reasoningContentTextBlocks.set(key, contentIndex);
+            stream.push({
+              type: "text_start",
+              contentIndex,
+              partial: output as never,
+            });
+          }
+          block.text += text;
+          stream.push({
+            type: "text_delta",
+            contentIndex,
+            delta: text,
+            partial: output as never,
+          });
+          return true;
+        };
+        const finishReasoningContentSidecars = (eventIndex: unknown) => {
+          const key = eventIndexKey(eventIndex);
+          const thinkingContentIndex = reasoningContentThinkingBlocks.get(key);
+          if (thinkingContentIndex !== undefined) {
+            reasoningContentThinkingBlocks.delete(key);
+            const block = output.content[thinkingContentIndex];
+            if (block?.type === "thinking") {
+              stream.push({
+                type: "thinking_end",
+                contentIndex: thinkingContentIndex,
+                content: block.thinking,
+                partial: output as never,
+              });
+            }
+          }
+          const textContentIndex = reasoningContentTextBlocks.get(key);
+          if (textContentIndex === undefined) {
+            return;
+          }
+          reasoningContentTextBlocks.delete(key);
+          const block = output.content[textContentIndex];
+          if (block?.type === "text") {
+            stream.push({
+              type: "text_end",
+              contentIndex: textContentIndex,
+              content: block.text,
+              partial: output as never,
+            });
+          }
+        };
         for await (const event of anthropicStream) {
           if (event.type === "error") {
             const error = event.error as { message?: string } | undefined;
@@ -1048,6 +1185,43 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
             const delta = event.delta as Record<string, unknown> | undefined;
             let index = blocks.findIndex((block) => block.index === event.index);
             let block = blocks[index];
+            if (allowReasoningContentReplay) {
+              const appendedThinking = appendReasoningContentThinkingDelta(
+                event.index,
+                delta?.reasoning_content,
+              );
+              const hasNativeAnthropicDelta =
+                (delta?.type === "text_delta" && typeof delta.text === "string") ||
+                (delta?.type === "thinking_delta" && typeof delta.thinking === "string") ||
+                (delta?.type === "input_json_delta" &&
+                  typeof delta.partial_json === "string") ||
+                (delta?.type === "signature_delta" && typeof delta.signature === "string");
+              let appendedContent = false;
+              if (
+                !hasNativeAnthropicDelta &&
+                typeof delta?.content === "string" &&
+                delta.content.length > 0
+              ) {
+                const text = sanitizeTransportPayloadText(delta.content);
+                if (text.length > 0) {
+                  if (block?.type === "text") {
+                    block.text += text;
+                    stream.push({
+                      type: "text_delta",
+                      contentIndex: index,
+                      delta: text,
+                      partial: output as never,
+                    });
+                    appendedContent = true;
+                  } else {
+                    appendedContent = appendReasoningContentTextDelta(event.index, text);
+                  }
+                }
+              }
+              if ((appendedThinking || appendedContent) && !hasNativeAnthropicDelta) {
+                continue;
+              }
+            }
             if (!block && delta?.type === "text_delta" && typeof delta.text === "string") {
               const recoveredIndex = typeof event.index === "number" ? event.index : blocks.length;
               block = { type: "text", text: "", index: recoveredIndex };
@@ -1115,6 +1289,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
             const index = blocks.findIndex((block) => block.index === event.index);
             const block = blocks[index];
             if (!block) {
+              finishReasoningContentSidecars(event.index);
               continue;
             }
             delete block.index;
@@ -1125,6 +1300,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
                 content: block.text,
                 partial: output as never,
               });
+              finishReasoningContentSidecars(event.index);
               continue;
             }
             if (block.type === "thinking") {
@@ -1134,6 +1310,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
                 content: block.thinking,
                 partial: output as never,
               });
+              finishReasoningContentSidecars(event.index);
               continue;
             }
             if (block.type === "toolCall") {
@@ -1147,6 +1324,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
                 toolCall: block as never,
                 partial: output as never,
               });
+              finishReasoningContentSidecars(event.index);
             }
             continue;
           }

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -386,10 +386,10 @@ function convertAnthropicMessages(
         }
       }
       if (blocks.length > 0) {
-        params.push({
-          role: "assistant",
-          content: blocks,
-        });
+        const assistantMsg: Record<string, unknown> = { role: "assistant", content: blocks };
+        if (typeof msg.reasoning_content === "string" && msg.reasoning_content.length > 0)
+          assistantMsg.reasoning_content = msg.reasoning_content;
+        params.push(assistantMsg);
       }
       continue;
     }


### PR DESCRIPTION
## Summary

Preserves Xiaomi/MiMo `reasoning_content` across the Anthropic Messages transport when the route is a known Xiaomi-native endpoint and thinking is enabled.

This completes the contributor fix by covering the real `xiaomi-token-plan-ams/mimo-v2.5` failure path from #81261:

- captures OpenAI-style `delta.reasoning_content` from Xiaomi Anthropic-compatible SSE streams as internal thinking blocks
- replays captured `reasoning_content` as the top-level Xiaomi-required field on follow-up assistant messages
- backfills `reasoning_content: ""` for Xiaomi-native assistant replay turns without captured reasoning, including tool-use and text-only history
- avoids sending this non-standard replay field to native Anthropic or generic Anthropic-compatible gateway routes
- keeps native Anthropic `text_delta` chunks authoritative when a provider sends both native text and OpenAI-style `content` aliases

Fixes https://github.com/openclaw/openclaw/issues/81261

## Real behavior proof

Behavior addressed: `xiaomi-token-plan-ams/mimo-v2.5` and adjacent Xiaomi-native Anthropic Messages routes no longer drop the `reasoning_content` replay field required by MiMo thinking mode.

Real environment tested: Blacksmith Testbox through the OpenClaw Crabbox wrapper, provider `blacksmith-testbox`, id `tbx_01krspkjb5tc1vw5ck9dgmhbf4`, run https://github.com/openclaw/openclaw/actions/runs/25977306459.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/anthropic-transport-stream.test.ts`; `.agents/skills/codex-review/scripts/codex-review --mode branch`; `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --blacksmith-org openclaw --blacksmith-workflow .github/workflows/ci-check-testbox.yml --blacksmith-job check --blacksmith-ref main --idle-timeout 90m --ttl 240m --timing-json -- CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_TEST_PROJECTS_PARALLEL=6 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm check:changed`.

Evidence after fix: focused Anthropic transport test passed 70 tests; Codex review reported no accepted/actionable findings; Testbox `pnpm check:changed` exited 0. The maintainer proof gap is the live Xiaomi token-plan API key: this lane validates the exact reported SSE and replay payload contract without sending live traffic to the reporter's provider account.

Observed result after fix: simulated Xiaomi-native Anthropic Messages requests now serialize prior `reasoning_content`, backfill blank replay fields when required, and still omit the field for generic gateway/native Anthropic routes.

What was not tested: no live Xiaomi token-plan API key was used in this maintainer lane; coverage uses the exact SSE/payload shape reported in #81261 plus remote CI-parity changed checks. Maintainer override applies for this external PR because the remaining live credential proof is unavailable to the maintainer lane.

## Verification

- `node scripts/run-vitest.mjs src/agents/anthropic-transport-stream.test.ts`
- `.agents/skills/codex-review/scripts/codex-review --mode branch`
- Testbox-through-Crabbox `pnpm check:changed`, provider `blacksmith-testbox`, id `tbx_01krspkjb5tc1vw5ck9dgmhbf4`, run https://github.com/openclaw/openclaw/actions/runs/25977306459

## Related / Separate Lanes

- Gemini provider-owned refresh behavior stayed with https://github.com/openclaw/openclaw/pull/78030 and https://github.com/openclaw/openclaw/issues/42541.
- Broader OAuth cooldown/logging policy is not part of this Anthropic transport fix.
- This PR covers the `anthropic-transport-stream` semantic-map item. Adjacent leftovers such as `agent-command`, auth order/API-key rotation, and broader provider auth surfaces remain separate lanes.
- Historical adjacent `reasoning_content` related work: https://github.com/openclaw/openclaw/issues/73417, https://github.com/openclaw/openclaw/issues/71372, https://github.com/openclaw/openclaw/issues/76018, https://github.com/openclaw/openclaw/issues/79608, https://github.com/openclaw/openclaw/issues/81419, https://github.com/openclaw/openclaw/issues/82139, https://github.com/openclaw/openclaw/issues/82150.
