### PR TITLE
fix(agents): ignore stale bootstrap after setup

### DIFF
--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -16,7 +16,11 @@ import {
   resolveBootstrapFilesForRun,
   resolveContextInjectionMode,
 } from "./bootstrap-files.js";
-import type { WorkspaceBootstrapFile } from "./workspace.js";
+import {
+  DEFAULT_BOOTSTRAP_FILENAME,
+  DEFAULT_IDENTITY_FILENAME,
+  type WorkspaceBootstrapFile,
+} from "./workspace.js";
 
 function registerExtraBootstrapFileHook() {
   registerInternalHook("agent:bootstrap", (event) => {
@@ -179,6 +183,53 @@ describe("resolveBootstrapContextForRun", () => {
     const contextFileNames = new Set(result.contextFiles.map((file) => path.basename(file.path)));
     expect(contextFileNames.has("BOOTSTRAP.md")).toBe(true);
     expect(contextFileNames.has("AGENTS.md")).toBe(true);
+  });
+
+  it("excludes stale BOOTSTRAP.md after workspace setup is complete", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    await fs.mkdir(path.join(workspaceDir, ".openclaw"), { recursive: true });
+    await fs.writeFile(
+      path.join(workspaceDir, ".openclaw", "workspace-state.json"),
+      JSON.stringify(
+        {
+          version: 1,
+          bootstrapSeededAt: "2026-05-15T02:50:29.000Z",
+          setupCompletedAt: "2026-05-15T03:00:00.000Z",
+        },
+        null,
+        2,
+      ) + "\n",
+      "utf8",
+    );
+    await fs.writeFile(path.join(workspaceDir, DEFAULT_BOOTSTRAP_FILENAME), "stale ritual", "utf8");
+    await fs.writeFile(
+      path.join(workspaceDir, DEFAULT_IDENTITY_FILENAME),
+      "# IDENTITY.md\n",
+      "utf8",
+    );
+
+    const result = await resolveBootstrapContextForRun({ workspaceDir });
+
+    expect(result.bootstrapFiles.map((file) => file.name)).not.toContain(
+      DEFAULT_BOOTSTRAP_FILENAME,
+    );
+    expect(result.contextFiles.map((file) => path.basename(file.path))).not.toContain(
+      DEFAULT_BOOTSTRAP_FILENAME,
+    );
+  });
+
+  it("keeps BOOTSTRAP.md when workspace setup state cannot be read", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    await fs.mkdir(path.join(workspaceDir, ".openclaw"), { recursive: true });
+    await fs.mkdir(path.join(workspaceDir, ".openclaw", "workspace-state.json"));
+    await fs.writeFile(path.join(workspaceDir, DEFAULT_BOOTSTRAP_FILENAME), "ritual", "utf8");
+
+    const result = await resolveBootstrapContextForRun({ workspaceDir });
+
+    expect(result.bootstrapFiles.map((file) => file.name)).toContain(DEFAULT_BOOTSTRAP_FILENAME);
+    expect(result.contextFiles.map((file) => path.basename(file.path))).toContain(
+      DEFAULT_BOOTSTRAP_FILENAME,
+    );
   });
 
   it("uses heartbeat-only bootstrap files in lightweight heartbeat mode", async () => {

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { makeTempWorkspace, writeWorkspaceFile } from "../test-helpers/workspace.js";
 import {
   DEFAULT_AGENTS_FILENAME,
@@ -264,6 +264,36 @@ describe("ensureAgentWorkspace", () => {
     expect(state.setupCompletedAt).toMatch(/\d{4}-\d{2}-\d{2}T/);
     await expect(resolveWorkspaceBootstrapStatus(tempDir)).resolves.toBe("complete");
     await expect(isWorkspaceBootstrapPending(tempDir)).resolves.toBe(false);
+  });
+
+  it("records stale bootstrap completion when BOOTSTRAP.md cleanup fails", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+    await writeWorkspaceFile({
+      dir: tempDir,
+      name: DEFAULT_IDENTITY_FILENAME,
+      content: "# IDENTITY.md\n\n- **Name:** Example\n",
+    });
+
+    const cleanupError = Object.assign(new Error("immutable bootstrap"), { code: "EPERM" });
+    const rmSpy = vi.spyOn(fs, "rm").mockRejectedValueOnce(cleanupError);
+    try {
+      const result = await reconcileWorkspaceBootstrapCompletion(tempDir);
+
+      expect(result.repaired).toBe(true);
+      expect(result.bootstrapExists).toBe(true);
+      expect(result.cleanupFailed).toBe(true);
+      await expect(
+        fs.access(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME)),
+      ).resolves.toBeUndefined();
+      const state = await readWorkspaceState(tempDir);
+      expect(state.bootstrapSeededAt).toMatch(/\d{4}-\d{2}-\d{2}T/);
+      expect(state.setupCompletedAt).toMatch(/\d{4}-\d{2}-\d{2}T/);
+      await expect(resolveWorkspaceBootstrapStatus(tempDir)).resolves.toBe("complete");
+      await expect(isWorkspaceBootstrapPending(tempDir)).resolves.toBe(false);
+    } finally {
+      rmSpy.mockRestore();
+    }
   });
 
   it("uses SOUL.md customization as stale bootstrap completion evidence", async () => {

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { openRootFile } from "../infra/boundary-file-read.js";
 import { pathExists } from "../infra/fs-safe.js";
 import { replaceFileAtomic } from "../infra/replace-file.js";
+import { logWarn } from "../logger.js";
 import {
   CANONICAL_ROOT_MEMORY_FILENAME,
   exactWorkspaceEntryExists,
@@ -258,6 +259,7 @@ type WorkspaceBootstrapCompletionReconcileResult = {
   repaired: boolean;
   bootstrapExists: boolean;
   state: WorkspaceSetupState;
+  cleanupFailed?: boolean;
 };
 
 async function reconcileWorkspaceBootstrapCompletionState(params: {
@@ -293,15 +295,39 @@ async function reconcileWorkspaceBootstrapCompletionState(params: {
     return { repaired: false, bootstrapExists, state: params.state };
   }
 
+  async function removeStaleBootstrapFile(): Promise<boolean> {
+    try {
+      await fs.rm(params.bootstrapPath, { force: true });
+      const removed = !(await pathExists(params.bootstrapPath));
+      if (!removed) {
+        logWarn(
+          `workspace bootstrap: setup completion was recorded, but stale ${DEFAULT_BOOTSTRAP_FILENAME} still exists at ${params.bootstrapPath}`,
+        );
+      }
+      return removed;
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      logWarn(
+        `workspace bootstrap: setup completion was recorded, but stale ${DEFAULT_BOOTSTRAP_FILENAME} cleanup failed at ${params.bootstrapPath}: ${detail}`,
+      );
+      return false;
+    }
+  }
+
   const now = new Date().toISOString();
   const repairedState: WorkspaceSetupState = {
     ...params.state,
     bootstrapSeededAt: params.state.bootstrapSeededAt ?? now,
     setupCompletedAt: now,
   };
-  await fs.rm(params.bootstrapPath, { force: true });
   await writeWorkspaceSetupState(params.statePath, repairedState);
-  return { repaired: true, bootstrapExists: false, state: repairedState };
+  const removed = await removeStaleBootstrapFile();
+  return {
+    repaired: true,
+    bootstrapExists: !removed,
+    state: repairedState,
+    cleanupFailed: !removed,
+  };
 }
 
 function resolveWorkspaceStatePath(dir: string): string {
@@ -612,6 +638,15 @@ export async function ensureAgentWorkspace(params?: {
   };
 }
 
+async function shouldLoadLegacyBootstrapFile(resolvedDir: string): Promise<boolean> {
+  try {
+    return !(await isWorkspaceSetupCompleted(resolvedDir));
+  } catch {
+    // Match agents.files.list: if state cannot be read, keep BOOTSTRAP.md visible.
+    return true;
+  }
+}
+
 export async function loadWorkspaceBootstrapFiles(dir: string): Promise<WorkspaceBootstrapFile[]> {
   const resolvedDir = resolveUserPath(dir);
 
@@ -643,15 +678,19 @@ export async function loadWorkspaceBootstrapFiles(dir: string): Promise<Workspac
       name: DEFAULT_HEARTBEAT_FILENAME,
       filePath: path.join(resolvedDir, DEFAULT_HEARTBEAT_FILENAME),
     },
-    {
+  ];
+
+  if (await shouldLoadLegacyBootstrapFile(resolvedDir)) {
+    entries.push({
       name: DEFAULT_BOOTSTRAP_FILENAME,
       filePath: path.join(resolvedDir, DEFAULT_BOOTSTRAP_FILENAME),
-    },
-    {
-      name: DEFAULT_MEMORY_FILENAME,
-      filePath: path.join(resolvedDir, DEFAULT_MEMORY_FILENAME),
-    },
-  ];
+    });
+  }
+
+  entries.push({
+    name: DEFAULT_MEMORY_FILENAME,
+    filePath: path.join(resolvedDir, DEFAULT_MEMORY_FILENAME),
+  });
 
   const result: WorkspaceBootstrapFile[] = [];
   for (const entry of entries) {


### PR DESCRIPTION
## Summary

Fixes #82291 by making completed workspace setup state authoritative before stale `BOOTSTRAP.md` cleanup runs.

When an upgraded workspace has completed setup evidence but the legacy `BOOTSTRAP.md` file cannot be removed, OpenClaw now records setup completion, logs the cleanup failure, and stops loading that leftover file into bootstrap context. This keeps message processing out of bootstrap-pending mode without hiding `BOOTSTRAP.md` when setup state cannot be read.

## Tests

- `CI=1 node scripts/run-vitest.mjs src/agents/workspace.test.ts src/agents/bootstrap-files.test.ts src/agents/pi-embedded-runner/run/attempt.spawn-workspace.bootstrap-routing.test.ts src/auto-reply/reply/session-reset-prompt.test.ts src/gateway/server-methods/agents-mutate.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/agents/workspace.ts src/agents/workspace.test.ts src/agents/bootstrap-files.test.ts`
- `git diff --check`
- `pnpm check:changed`

## Real behavior proof

- Behavior or issue addressed: Upgraded workspaces can contain a regular legacy `workspace/BOOTSTRAP.md` with the immutable bit set. On current `origin/main`, stale bootstrap reconciliation attempts to remove that file before recording setup completion, and `fs.rm` fails with `ENOTDIR: not a directory, scandir '<workspace>/BOOTSTRAP.md'`. The workspace stays bootstrap-pending and `BOOTSTRAP.md` remains injected into bootstrap context, matching the inbound-message failure in #82291.

- Real environment tested: WSL Ubuntu 24.04 Linux filesystem, OpenClaw source checkout, real temporary workspace, and a real immutable regular `BOOTSTRAP.md` created with `chattr +i`. No provider credentials or live Slack/Telegram send were used.

- Exact steps or command run after this patch: `bash /mnt/c/Users/giodl/.copilot/session-state/435dd9c5-809a-41f6-ad19-59c820aba914/proof-82291-immutable.sh`

  The script fresh-cloned `https://github.com/openclaw/openclaw.git` at `main` for the before case, cloned this branch for the after case, created a temp workspace, wrote completed-profile evidence in `IDENTITY.md`, set `chattr +i` on the regular `BOOTSTRAP.md`, then called `reconcileWorkspaceBootstrapCompletion`, `resolveWorkspaceBootstrapStatus`, `isWorkspaceBootstrapPending`, `loadWorkspaceBootstrapFiles`, and `resolveBootstrapContextForRun`.

- Evidence after fix: Terminal output from the WSL Ubuntu 24.04 immutable-file proof showed `origin/main` reproducing the reported `ENOTDIR` failure and this branch passing after the fix.

  Before (`origin/main`) failed with the reported error shape:

  ```json
  {
    "lsattr": "----i---------e------- /tmp/openclaw-82291-immutable-2lUolY/BOOTSTRAP.md",
    "reconcileThrew": true,
    "reconcileError": "ENOTDIR: not a directory, scandir '/tmp/openclaw-82291-immutable-2lUolY/BOOTSTRAP.md'",
    "status": "pending",
    "pending": true,
    "bootstrapStillExists": true,
    "includesBootstrapFile": true,
    "includesBootstrapContext": true
  }
  ```

  After this patch passed:

  ```json
  {
    "lsattr": "----i---------e------- /tmp/openclaw-82291-immutable-jXVPTY/BOOTSTRAP.md",
    "reconcileThrew": false,
    "reconcileResult": {
      "repaired": true,
      "bootstrapExists": true,
      "state": {
        "version": 1,
        "bootstrapSeededAt": "2026-05-16T03:14:33.998Z",
        "setupCompletedAt": "2026-05-16T03:14:34.062Z"
      },
      "cleanupFailed": true
    },
    "status": "complete",
    "pending": false,
    "bootstrapStillExists": true,
    "includesBootstrapFile": false,
    "includesBootstrapContext": false
  }
  ```

- Observed result after fix: The stale immutable `BOOTSTRAP.md` can remain on disk, but workspace setup is recorded as complete, bootstrap is no longer pending, and the stale file is no longer loaded into bootstrap files or Project Context. If workspace setup state cannot be read, bootstrap loading still falls back to including `BOOTSTRAP.md` instead of silently hiding it.

- What was not tested: I did not send a live Slack or Telegram message and did not run the Docker image from the issue report. The filesystem failure was reproduced with the same Linux immutable-bit behavior and the same `ENOTDIR ... BOOTSTRAP.md` error in a real OpenClaw source checkout.