### PR TITLE
Fix /acp spawn cwd inheritance for target agent workspaces

### DIFF
--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -541,7 +541,7 @@ function isMissingPathError(error: unknown): boolean {
   return code === "ENOENT" || code === "ENOTDIR";
 }
 
-async function resolveRuntimeCwdForAcpSpawn(params: {
+export async function resolveRuntimeCwdForAcpSpawn(params: {
   resolvedCwd?: string;
   explicitCwd?: string;
 }): Promise<string | undefined> {

--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs/promises";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AcpRuntimeError } from "../../acp/runtime/errors.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -95,6 +96,27 @@ vi.mock("../../agents/acp-spawn.js", () => ({
     params.cfg?.agents?.defaults?.sandbox?.mode === "all"
       ? 'Sandboxed sessions cannot spawn ACP sessions because runtime="acp" runs on the host. Use runtime="subagent" from sandboxed sessions.'
       : undefined,
+  resolveRuntimeCwdForAcpSpawn: async (params: {
+    explicitCwd?: string;
+    resolvedCwd?: string;
+  }) => {
+    if (params.explicitCwd) {
+      return params.resolvedCwd;
+    }
+    if (!params.resolvedCwd) {
+      return undefined;
+    }
+    try {
+      await fs.access(params.resolvedCwd);
+      return params.resolvedCwd;
+    } catch (error) {
+      const code = error instanceof Error ? (error as NodeJS.ErrnoException).code : undefined;
+      if (code === "ENOENT" || code === "ENOTDIR") {
+        return undefined;
+      }
+      throw error;
+    }
+  },
 }));
 
 vi.mock("../../config/sessions.js", async () => {
@@ -1171,13 +1193,49 @@ describe("/acp command", () => {
       backendSessionId: "acpx-2",
     });
 
+    const workspace = await fs.mkdtemp("/tmp/openclaw-codex-");
+    try {
+      const cfg = {
+        ...baseCfg,
+        agents: {
+          list: [
+            {
+              id: "codex",
+              workspace,
+            },
+          ],
+        },
+      } satisfies OpenClawConfig;
+
+      const result = await runDiscordAcpCommand("/acp spawn codex", cfg);
+
+      expect(result?.reply?.text).toContain("Spawned ACP session agent:codex:acp:");
+      expectMockCallFields(hoisted.ensureSessionMock, {
+        agent: "codex",
+        mode: "persistent",
+        cwd: workspace,
+      });
+    } finally {
+      await fs.rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to the backend default cwd when the inherited target workspace is missing", async () => {
+    hoisted.ensureSessionMock.mockResolvedValueOnce({
+      sessionKey: "agent:codex:acp:s3",
+      backend: "acpx",
+      runtimeSessionName: "agent:codex:acp:s3:runtime",
+      agentSessionId: "codex-inner-3",
+      backendSessionId: "acpx-3",
+    });
+
     const cfg = {
       ...baseCfg,
       agents: {
         list: [
           {
             id: "codex",
-            workspace: "/home/bob/codex-workspace",
+            workspace: "/home/bob/codex-workspace-missing",
           },
         ],
       },
@@ -1189,7 +1247,7 @@ describe("/acp command", () => {
     expectMockCallFields(hoisted.ensureSessionMock, {
       agent: "codex",
       mode: "persistent",
-      cwd: "/home/bob/codex-workspace",
+      cwd: undefined,
     });
   });
 

--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -1,4 +1,6 @@
 import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AcpRuntimeError } from "../../acp/runtime/errors.js";
 import type { OpenClawConfig } from "../../config/config.js";
@@ -1193,7 +1195,7 @@ describe("/acp command", () => {
       backendSessionId: "acpx-2",
     });
 
-    const workspace = await fs.mkdtemp("/tmp/openclaw-codex-");
+    const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-"));
     try {
       const cfg = {
         ...baseCfg,

--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -1162,6 +1162,37 @@ describe("/acp command", () => {
     expect(seededWithoutEntry?.runtimeSessionName).toContain(":runtime");
   });
 
+  it("inherits the target agent workspace when /acp spawn omits --cwd", async () => {
+    hoisted.ensureSessionMock.mockResolvedValueOnce({
+      sessionKey: "agent:codex:acp:s2",
+      backend: "acpx",
+      runtimeSessionName: "agent:codex:acp:s2:runtime",
+      agentSessionId: "codex-inner-2",
+      backendSessionId: "acpx-2",
+    });
+
+    const cfg = {
+      ...baseCfg,
+      agents: {
+        list: [
+          {
+            id: "codex",
+            workspace: "/home/bob/codex-workspace",
+          },
+        ],
+      },
+    } satisfies OpenClawConfig;
+
+    const result = await runDiscordAcpCommand("/acp spawn codex", cfg);
+
+    expect(result?.reply?.text).toContain("Spawned ACP session agent:codex:acp:");
+    expectMockCallFields(hoisted.ensureSessionMock, {
+      agent: "codex",
+      mode: "persistent",
+      cwd: "/home/bob/codex-workspace",
+    });
+  });
+
   it("persists ACP spawn labels without a nested gateway self-call", async () => {
     const params = createDiscordParams("/acp spawn codex --bind here --label inbox");
 

--- a/src/auto-reply/reply/commands-acp/lifecycle.ts
+++ b/src/auto-reply/reply/commands-acp/lifecycle.ts
@@ -536,7 +536,7 @@ export async function handleAcpSpawnAction(
     return stopWithText(
       collectAcpErrorText({
         error,
-        fallbackCode: "cwd_resolution_failed",
+        fallbackCode: "ACP_SESSION_INIT_FAILED",
         fallbackMessage: "Could not resolve ACP session workspace.",
       }),
     );

--- a/src/auto-reply/reply/commands-acp/lifecycle.ts
+++ b/src/auto-reply/reply/commands-acp/lifecycle.ts
@@ -15,7 +15,10 @@ import {
   resolveAcpSessionCwd,
   resolveAcpThreadSessionDetailLines,
 } from "../../../acp/runtime/session-identifiers.js";
-import { resolveAcpSpawnRuntimePolicyError } from "../../../agents/acp-spawn.js";
+import {
+  resolveAcpSpawnRuntimePolicyError,
+  resolveRuntimeCwdForAcpSpawn,
+} from "../../../agents/acp-spawn.js";
 import { resolveSpawnedWorkspaceInheritance } from "../../../agents/spawned-context.js";
 import { getChannelPlugin, normalizeChannelId } from "../../../channels/plugins/index.js";
 import {
@@ -523,6 +526,21 @@ export async function handleAcpSpawnAction(
     requesterSessionKey: params.sessionKey,
     explicitWorkspaceDir: spawn.cwd,
   });
+  let runtimeCwd: string | undefined;
+  try {
+    runtimeCwd = await resolveRuntimeCwdForAcpSpawn({
+      resolvedCwd,
+      explicitCwd: spawn.cwd,
+    });
+  } catch (error) {
+    return stopWithText(
+      collectAcpErrorText({
+        error,
+        fallbackCode: "cwd_resolution_failed",
+        fallbackMessage: "Could not resolve ACP session workspace.",
+      }),
+    );
+  }
 
   let initializedBackend = "";
   let initializedMeta: SessionAcpMeta | undefined;
@@ -533,7 +551,7 @@ export async function handleAcpSpawnAction(
       sessionKey,
       agent: spawn.agentId,
       mode: spawn.mode,
-      cwd: resolvedCwd,
+      cwd: runtimeCwd,
     });
     initializedRuntime = {
       runtime: initialized.runtime,

--- a/src/auto-reply/reply/commands-acp/lifecycle.ts
+++ b/src/auto-reply/reply/commands-acp/lifecycle.ts
@@ -16,6 +16,7 @@ import {
   resolveAcpThreadSessionDetailLines,
 } from "../../../acp/runtime/session-identifiers.js";
 import { resolveAcpSpawnRuntimePolicyError } from "../../../agents/acp-spawn.js";
+import { resolveSpawnedWorkspaceInheritance } from "../../../agents/spawned-context.js";
 import { getChannelPlugin, normalizeChannelId } from "../../../channels/plugins/index.js";
 import {
   resolveThreadBindingIntroText,
@@ -516,6 +517,12 @@ export async function handleAcpSpawnAction(
 
   const acpManager = getAcpSessionManager();
   const sessionKey = `agent:${spawn.agentId}:acp:${randomUUID()}`;
+  const resolvedCwd = resolveSpawnedWorkspaceInheritance({
+    config: params.cfg,
+    targetAgentId: spawn.agentId,
+    requesterSessionKey: params.sessionKey,
+    explicitWorkspaceDir: spawn.cwd,
+  });
 
   let initializedBackend = "";
   let initializedMeta: SessionAcpMeta | undefined;
@@ -526,7 +533,7 @@ export async function handleAcpSpawnAction(
       sessionKey,
       agent: spawn.agentId,
       mode: spawn.mode,
-      cwd: spawn.cwd,
+      cwd: resolvedCwd,
     });
     initializedRuntime = {
       runtime: initialized.runtime,

--- a/test/scripts/crabbox-wrapper.test.ts
+++ b/test/scripts/crabbox-wrapper.test.ts
@@ -424,7 +424,12 @@ describe.concurrent("scripts/crabbox-wrapper", () => {
     const result = runWrapper(
       "provider: hetzner, aws, local-container, blacksmith-testbox, or cloudflare\n",
       ["run", "--target", "windows", "--", "echo ok"],
-      { env: { CRABBOX_PROVIDER: "aws" } },
+      {
+        env: {
+          CRABBOX_PROVIDER: "aws",
+          OPENCLAW_CRABBOX_ALLOW_DIRECT_AWS: "1",
+        },
+      },
     );
 
     expect(result.status).toBe(0);
@@ -442,7 +447,12 @@ describe.concurrent("scripts/crabbox-wrapper", () => {
     const result = runWrapper(
       azureProviderHelp,
       ["run", "--id", "cbx_existing", "--target", "windows", "--", "echo ok"],
-      { env: { CRABBOX_PROVIDER: "aws" } },
+      {
+        env: {
+          CRABBOX_PROVIDER: "aws",
+          OPENCLAW_CRABBOX_ALLOW_DIRECT_AWS: "1",
+        },
+      },
     );
 
     expect(result.status).toBe(0);


### PR DESCRIPTION
## Summary

Fix `/acp spawn` so ACP sessions inherit the target agent's workspace instead of falling back to the global default workspace when no explicit `--cwd` is provided.

This ensures cross-agent ACP spawns such as:

- `/acp spawn codex --mode persistent --thread auto`
- `/acp spawn opencode --mode persistent --thread auto`

start in the correct per-agent workspace.

## Motivation

Before this change, the `/acp spawn` command path passed the raw `spawn.cwd` value into ACP session initialization. Since `spawn.cwd` only reflects an explicit CLI `--cwd` flag, it is usually `undefined`.

As a result, ACP sessions could initialize in the global workspace rather than the workspace configured for the selected harness/agent.

## Implementation

- Resolve the spawned workspace before ACP session initialization.
- Reuse the existing workspace inheritance logic already used by other spawn flows.
- Preserve the existing fallback behavior for missing inherited workspaces.
- Pass the resolved runtime cwd into ACP runtime initialization instead of the raw optional CLI value.

## Behavior Change

### Before
- `/acp spawn codex ...` could start in `/home/thomas/.openclaw/workspace`
- `/acp spawn opencode ...` could also start in `/home/thomas/.openclaw/workspace`

### After
- `/acp spawn codex ...` uses the codex workspace when no explicit `--cwd` is given
- `/acp spawn opencode ...` uses the opencode workspace when no explicit `--cwd` is given
- An explicit `--cwd` still takes precedence
- A missing inherited workspace still falls back to the backend default cwd

## Related Issues

- #58420
- #58423

## Validation

- `./node_modules/.bin/vitest run src/auto-reply/reply/commands-acp.test.ts src/agents/acp-spawn.test.ts`
- Result: `3 passed`, `156 tests passed`

## Real behavior proof

**Behavior or issue addressed:** `/acp spawn` should inherit the target agent's workspace when `--cwd` is omitted, while preserving explicit `--cwd` precedence and the backend-default fallback for missing inherited workspaces.

**Real environment tested:** OpenClaw running locally on Ubuntu 24.04.4 LTS, connected to the live gateway at `ws://127.0.0.1:18789`, using PR branch `fix/acp-spawn-cwd-inheritance` at commit `1fd4c096614182702f337f123ddc79c6a10bc612`.

**Exact steps or command run after the patch:** I connected a live `GatewayClient` to the running gateway, sent `/acp spawn codex --mode persistent --thread auto`, waited for the run to complete, and then sent `/acp status` in the same conversation to verify the spawned session runtime cwd.

**Evidence after fix:**
```text
SPAWN_REPLY ✅ Spawned ACP session agent:codex:acp:956464aa-a0ea-4627-b848-6ddfeee7dac4 (persistent, backend acpx). Bound this conversation to agent:codex:acp:956464aa-a0ea-4627-b848-6ddfeee7dac4.
STATUS_REPLY ACP status:
-----
session: agent:codex:acp:956464aa-a0ea-4627-b848-6ddfeee7dac4
backend: acpx
agent: codex
acpx session id: 019e2f25-b8af-7803-974d-a0a6eb7c0f88
acpx record id: agent:codex:acp:956464aa-a0ea-4627-b848-6ddfeee7dac4
sessionMode: persistent
state: idle
runtimeOptions: cwd=/home/thomas/.openclaw/workspace-codex
runtimeDetails: {"cwd":"/home/thomas/.openclaw/workspace-codex","lastUsedAt":"2026-05-16T04:57:41.840Z","closed":false}
```

**Observed result after fix:** The spawned Codex ACP session reported `runtimeOptions: cwd=/home/thomas/.openclaw/workspace-codex` and `runtimeDetails.cwd=/home/thomas/.openclaw/workspace-codex`, which matches the target harness workspace instead of the global default workspace.

**What was not tested:** A separate live `opencode` transcript was not captured in the proof run; the shared command-path fix is still covered by the focused ACP regression tests and the same workspace inheritance logic.

## Notes

- The command-path fix now shares the same cwd resolution guard as direct ACP spawn.
- The regression tests cover both the inherited-workspace path and the missing-workspace fallback path.
- The new regression test uses `os.tmpdir()` so it remains portable.
