### PR TITLE
fix(feishu): stream CardKit text deltas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Update/doctor: avoid materializing `groupAllowFrom` for channel schemas that reject it, so package-swap doctor repairs do not fail on externalized Slack configs.
-- Feishu: send CardKit streaming cards as delivered deltas and retry failed updates, preventing duplicated or dropped streamed text. Fixes #82417. Thanks @hclsys.
+- Feishu: send CardKit streaming cards as delivered deltas and retry failed updates, preventing duplicated or dropped streamed text. Fixes #82417. (#82419) Thanks @hclsys.
 - Gateway/media: prevent image filenames from overriding generic non-image byte sniffing, so zip/octet-stream payloads mislabeled as images are offloaded or rejected before they become inline image attachments.
 - Plugins/web search: downgrade stale optional provider installs to warnings so Gateway and doctor repair paths keep running after startup provider selection. Refs #82313. Thanks @crackmac.
 - Telegram/Gateway: route targeted Telegram `/stop@bot` messages onto the control lane without cached bot metadata and match gateway stop requests across raw/canonical session aliases. (#82298) Thanks @VACInc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Update/doctor: avoid materializing `groupAllowFrom` for channel schemas that reject it, so package-swap doctor repairs do not fail on externalized Slack configs.
-- Feishu: send CardKit streaming cards as delivered deltas and retry failed updates, preventing duplicated or dropped streamed text. Fixes #82417. (#82419) Thanks @hclsys.
 - Gateway/media: prevent image filenames from overriding generic non-image byte sniffing, so zip/octet-stream payloads mislabeled as images are offloaded or rejected before they become inline image attachments.
 - Plugins/web search: downgrade stale optional provider installs to warnings so Gateway and doctor repair paths keep running after startup provider selection. Refs #82313. Thanks @crackmac.
 - Telegram/Gateway: route targeted Telegram `/stop@bot` messages onto the control lane without cached bot metadata and match gateway stop requests across raw/canonical session aliases. (#82298) Thanks @VACInc.
@@ -98,6 +97,7 @@ Docs: https://docs.openclaw.ai
 - Providers: preserve required `reasoning_content` replay for Kimi K2.6/K2 thinking and MiMo V2.6 OpenAI-compatible tool-call follow-up turns while keeping the stock OpenAI/Qwen strip path intact. Fixes #82139. Thanks @yimao.
 - Memory search: stop using chokidar write-stability polling for memory and QMD watchers so large Markdown extraPath trees no longer build up regular file descriptors; changed files now settle through the existing debounced sync queue. Fixes #77327 and #78224. (#81802) Thanks @frankekn, @loyur, and @JanPlessow.
 - Message tool: rename the Discord channel-create schema field exposed to models from `type` to `channelType`, avoiding NVIDIA NIM JSON Schema parser failures while still accepting legacy `type` tool calls. (#78920) Thanks @YashSaliya.
+- Feishu: send CardKit streaming cards as delivered deltas and retry failed updates, preventing duplicated or dropped streamed text. Fixes #82417. (#82419) Thanks @hclsys.
 
 ## 2026.5.14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Update/doctor: avoid materializing `groupAllowFrom` for channel schemas that reject it, so package-swap doctor repairs do not fail on externalized Slack configs.
+- Feishu: send CardKit streaming cards as delivered deltas and retry failed updates, preventing duplicated or dropped streamed text. Fixes #82417. Thanks @hclsys.
 - Gateway/media: prevent image filenames from overriding generic non-image byte sniffing, so zip/octet-stream payloads mislabeled as images are offloaded or rejected before they become inline image attachments.
 - Plugins/web search: downgrade stale optional provider installs to warnings so Gateway and doctor repair paths keep running after startup provider selection. Refs #82313. Thanks @crackmac.
 - Telegram/Gateway: route targeted Telegram `/stop@bot` messages onto the control lane without cached bot metadata and match gateway stop requests across raw/canonical session aliases. (#82298) Thanks @VACInc.

--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -57,10 +57,14 @@ describe("FeishuStreamingSession", () => {
     updateBodies: string[],
     failedContentUpdateIndexes: ReadonlySet<number> = new Set<number>(),
     replaceBodies: string[] = [],
+    failedContentUpdateStatuses: ReadonlyMap<number, number> = new Map<number, number>(),
+    failedReplaceStatuses: ReadonlyMap<number, number> = new Map<number, number>(),
   ): void {
     fetchWithSsrFGuardMock.mockImplementation(
       async ({ url, init }: { url: string; init?: { body?: string } }) => {
         const release = vi.fn(async () => {});
+        let ok = true;
+        let status = 200;
         if (url.includes("/auth/")) {
           return {
             response: {
@@ -81,12 +85,24 @@ describe("FeishuStreamingSession", () => {
           if (failedContentUpdateIndexes.has(updateIndex)) {
             throw new Error(`content update ${updateIndex} failed`);
           }
+          const failedStatus = failedContentUpdateStatuses.get(updateIndex);
+          if (failedStatus !== undefined) {
+            ok = false;
+            status = failedStatus;
+          }
         } else if (url.includes("/elements/content")) {
+          const replaceIndex = replaceBodies.length;
           replaceBodies.push(init?.body ?? "");
+          const failedStatus = failedReplaceStatuses.get(replaceIndex);
+          if (failedStatus !== undefined) {
+            ok = false;
+            status = failedStatus;
+          }
         }
         return {
           response: {
-            ok: true,
+            ok,
+            status,
             json: async () => ({ code: 0, msg: "ok" }),
           },
           release,
@@ -200,6 +216,44 @@ describe("FeishuStreamingSession", () => {
     });
   });
 
+  it("retries unsent suffix content after a non-OK delta update", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(3_500);
+    const updateBodies: string[] = [];
+    mockFetches(updateBodies, new Set<number>(), [], new Map([[0, 429]]));
+
+    const session = new FeishuStreamingSession({} as never, {
+      appId: "app_non_ok_delta_retry",
+      appSecret: "secret",
+    });
+    setStreamingSessionInternals(session, {
+      state: {
+        cardId: "card_5",
+        messageId: "om_5",
+        sequence: 1,
+        currentText: "hello",
+        sentText: "hello",
+        hasNote: false,
+      },
+      lastUpdateTime: 2_000,
+    });
+
+    await session.update("hello world");
+    await session.update("hello world!");
+
+    expect(updateBodies).toHaveLength(2);
+    expect(JSON.parse(updateBodies[0] ?? "{}")).toEqual({
+      content: " world",
+      sequence: 2,
+      uuid: "s_card_5_2",
+    });
+    expect(JSON.parse(updateBodies[1] ?? "{}")).toEqual({
+      content: " world!",
+      sequence: 3,
+      uuid: "s_card_5_3",
+    });
+  });
+
   it("replaces content when final text removes transient streamed status", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(4_000);
@@ -244,6 +298,49 @@ describe("FeishuStreamingSession", () => {
       sequence: 2,
       uuid: "r_card_4_2",
     });
+  });
+
+  it("logs a final replacement failure when CardKit returns non-OK", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(4_500);
+    const updateBodies: string[] = [];
+    const replaceBodies: string[] = [];
+    mockFetches(
+      updateBodies,
+      new Set<number>(),
+      replaceBodies,
+      new Map<number, number>(),
+      new Map([[0, 500]]),
+    );
+    const log = vi.fn();
+
+    const session = new FeishuStreamingSession(
+      {} as never,
+      {
+        appId: "app_final_rewrite_non_ok",
+        appSecret: "secret",
+      },
+      log,
+    );
+    setStreamingSessionInternals(session, {
+      state: {
+        cardId: "card_6",
+        messageId: "om_6",
+        sequence: 1,
+        currentText: "working\n\nfinal answer",
+        sentText: "working\n\nfinal answer",
+        hasNote: false,
+      },
+      lastUpdateTime: 3_000,
+    });
+
+    await session.close("final answer");
+
+    expect(updateBodies).toHaveLength(0);
+    expect(replaceBodies).toHaveLength(1);
+    expect(log).toHaveBeenCalledWith(
+      "Final replace failed: Error: Replace card content failed with HTTP 500",
+    );
   });
 });
 

--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -56,6 +56,7 @@ describe("FeishuStreamingSession", () => {
   function mockFetches(
     updateBodies: string[],
     failedContentUpdateIndexes: ReadonlySet<number> = new Set<number>(),
+    replaceBodies: string[] = [],
   ): void {
     fetchWithSsrFGuardMock.mockImplementation(
       async ({ url, init }: { url: string; init?: { body?: string } }) => {
@@ -80,6 +81,8 @@ describe("FeishuStreamingSession", () => {
           if (failedContentUpdateIndexes.has(updateIndex)) {
             throw new Error(`content update ${updateIndex} failed`);
           }
+        } else if (url.includes("/elements/content")) {
+          replaceBodies.push(init?.body ?? "");
         }
         return {
           response: {
@@ -194,6 +197,52 @@ describe("FeishuStreamingSession", () => {
       content: " world!",
       sequence: 3,
       uuid: "s_card_3_3",
+    });
+  });
+
+  it("replaces content when final text removes transient streamed status", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(4_000);
+    const updateBodies: string[] = [];
+    const replaceBodies: string[] = [];
+    mockFetches(updateBodies, new Set<number>(), replaceBodies);
+
+    const session = new FeishuStreamingSession({} as never, {
+      appId: "app_final_rewrite",
+      appSecret: "secret",
+    });
+    setStreamingSessionInternals(session, {
+      state: {
+        cardId: "card_4",
+        messageId: "om_4",
+        sequence: 1,
+        currentText: "🔎 Web Search\n\nfinal answer",
+        sentText: "🔎 Web Search\n\nfinal answer",
+        hasNote: false,
+      },
+      lastUpdateTime: 3_000,
+    });
+
+    await session.close("final answer");
+
+    expect(updateBodies).toHaveLength(0);
+    expect(replaceBodies).toHaveLength(1);
+    const replacePayload = JSON.parse(replaceBodies[0] ?? "{}") as {
+      element?: string;
+      sequence?: number;
+      uuid?: string;
+    };
+    expect({
+      ...replacePayload,
+      element: JSON.parse(replacePayload.element ?? "{}"),
+    }).toEqual({
+      element: {
+        tag: "markdown",
+        content: "final answer",
+        element_id: "content",
+      },
+      sequence: 2,
+      uuid: "r_card_4_2",
     });
   });
 });

--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -17,6 +17,7 @@ type StreamingSessionState = {
   messageId: string;
   sequence: number;
   currentText: string;
+  sentText: string;
   hasNote: boolean;
 };
 
@@ -26,7 +27,7 @@ function setStreamingSessionInternals(
     state: StreamingSessionState;
     lastUpdateTime?: number;
   },
-) {
+): void {
   const internals = session as unknown as {
     state: StreamingSessionState;
     lastUpdateTime: number;
@@ -52,7 +53,10 @@ describe("FeishuStreamingSession", () => {
     vi.useRealTimers();
   });
 
-  function mockFetches(updateBodies: string[]) {
+  function mockFetches(
+    updateBodies: string[],
+    failedContentUpdateIndexes: ReadonlySet<number> = new Set<number>(),
+  ): void {
     fetchWithSsrFGuardMock.mockImplementation(
       async ({ url, init }: { url: string; init?: { body?: string } }) => {
         const release = vi.fn(async () => {});
@@ -71,7 +75,11 @@ describe("FeishuStreamingSession", () => {
           };
         }
         if (url.includes("/elements/content/content")) {
+          const updateIndex = updateBodies.length;
           updateBodies.push(init?.body ?? "");
+          if (failedContentUpdateIndexes.has(updateIndex)) {
+            throw new Error(`content update ${updateIndex} failed`);
+          }
         }
         return {
           response: {
@@ -100,6 +108,7 @@ describe("FeishuStreamingSession", () => {
         messageId: "om_1",
         sequence: 1,
         currentText: "hello",
+        sentText: "hello",
         hasNote: false,
       },
       lastUpdateTime: 1_000,
@@ -134,6 +143,7 @@ describe("FeishuStreamingSession", () => {
         messageId: "om_2",
         sequence: 1,
         currentText: "hello",
+        sentText: "hello",
         hasNote: false,
       },
       lastUpdateTime: 2_000,
@@ -146,6 +156,44 @@ describe("FeishuStreamingSession", () => {
       content: "!",
       sequence: 2,
       uuid: "s_card_2_2",
+    });
+  });
+
+  it("retries unsent suffix content after a failed delta update", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(3_000);
+    const updateBodies: string[] = [];
+    mockFetches(updateBodies, new Set([0]));
+
+    const session = new FeishuStreamingSession({} as never, {
+      appId: "app_failed_delta_retry",
+      appSecret: "secret",
+    });
+    setStreamingSessionInternals(session, {
+      state: {
+        cardId: "card_3",
+        messageId: "om_3",
+        sequence: 1,
+        currentText: "hello",
+        sentText: "hello",
+        hasNote: false,
+      },
+      lastUpdateTime: 2_000,
+    });
+
+    await session.update("hello world");
+    await session.update("hello world!");
+
+    expect(updateBodies).toHaveLength(2);
+    expect(JSON.parse(updateBodies[0] ?? "{}")).toEqual({
+      content: " world",
+      sequence: 2,
+      uuid: "s_card_3_2",
+    });
+    expect(JSON.parse(updateBodies[1] ?? "{}")).toEqual({
+      content: " world!",
+      sequence: 3,
+      uuid: "s_card_3_3",
     });
   });
 });

--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -112,7 +112,7 @@ describe("FeishuStreamingSession", () => {
 
     expect(updateBodies).toHaveLength(1);
     expect(JSON.parse(updateBodies[0] ?? "{}")).toEqual({
-      content: "hello small",
+      content: " small",
       sequence: 2,
       uuid: "s_card_1_2",
     });
@@ -143,7 +143,7 @@ describe("FeishuStreamingSession", () => {
 
     expect(updateBodies).toHaveLength(1);
     expect(JSON.parse(updateBodies[0] ?? "{}")).toEqual({
-      content: "hello!",
+      content: "!",
       sequence: 2,
       uuid: "s_card_2_2",
     });

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -359,6 +359,42 @@ export class FeishuStreamingSession {
     }
   }
 
+  private async replaceCardContent(
+    text: string,
+    onError?: (error: unknown) => void,
+  ): Promise<boolean> {
+    if (!this.state) {
+      return false;
+    }
+    const apiBase = resolveApiBase(this.creds.domain);
+    this.state.sequence += 1;
+    try {
+      const { release } = await fetchWithSsrFGuard({
+        url: `${apiBase}/cardkit/v1/cards/${this.state.cardId}/elements/content`,
+        init: {
+          method: "PUT",
+          headers: {
+            Authorization: `Bearer ${await getToken(this.creds)}`,
+            "Content-Type": "application/json",
+            "User-Agent": getFeishuUserAgent(),
+          },
+          body: JSON.stringify({
+            element: JSON.stringify({ tag: "markdown", content: text, element_id: "content" }),
+            sequence: this.state.sequence,
+            uuid: `r_${this.state.cardId}_${this.state.sequence}`,
+          }),
+        },
+        policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
+        auditContext: "feishu.streaming-card.replace",
+      });
+      await release();
+      return true;
+    } catch (error) {
+      onError?.(error);
+      return false;
+    }
+  }
+
   private clearFlushTimer(): void {
     if (this.flushTimer) {
       clearTimeout(this.flushTimer);
@@ -464,14 +500,14 @@ export class FeishuStreamingSession {
     await this.queue;
 
     const pendingMerged = mergeStreamingText(this.state.currentText, this.pendingText ?? undefined);
-    const text = finalText ? mergeStreamingText(pendingMerged, finalText) : pendingMerged;
+    const text = finalText ?? pendingMerged;
     const apiBase = resolveApiBase(this.creds.domain);
 
     // Only send final update if content differs from what's already displayed
     if (text && text !== this.state.sentText) {
-      const sent = await this.updateCardContent(
-        resolveStreamingCardAppendContent(this.state.sentText, text),
-      );
+      const sent = text.startsWith(this.state.sentText)
+        ? await this.updateCardContent(resolveStreamingCardAppendContent(this.state.sentText, text))
+        : await this.replaceCardContent(text);
       this.state.currentText = text;
       if (sent) {
         this.state.sentText = text;

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -333,7 +333,7 @@ export class FeishuStreamingSession {
     const apiBase = resolveApiBase(this.creds.domain);
     this.state.sequence += 1;
     try {
-      const { release } = await fetchWithSsrFGuard({
+      const { response, release } = await fetchWithSsrFGuard({
         url: `${apiBase}/cardkit/v1/cards/${this.state.cardId}/elements/content/content`,
         init: {
           method: "PUT",
@@ -352,6 +352,10 @@ export class FeishuStreamingSession {
         auditContext: "feishu.streaming-card.update",
       });
       await release();
+      if (!response.ok) {
+        onError?.(new Error(`Update card content failed with HTTP ${response.status}`));
+        return false;
+      }
       return true;
     } catch (error) {
       onError?.(error);
@@ -369,7 +373,7 @@ export class FeishuStreamingSession {
     const apiBase = resolveApiBase(this.creds.domain);
     this.state.sequence += 1;
     try {
-      const { release } = await fetchWithSsrFGuard({
+      const { response, release } = await fetchWithSsrFGuard({
         url: `${apiBase}/cardkit/v1/cards/${this.state.cardId}/elements/content`,
         init: {
           method: "PUT",
@@ -388,6 +392,10 @@ export class FeishuStreamingSession {
         auditContext: "feishu.streaming-card.replace",
       });
       await release();
+      if (!response.ok) {
+        onError?.(new Error(`Replace card content failed with HTTP ${response.status}`));
+        return false;
+      }
       return true;
     } catch (error) {
       onError?.(error);
@@ -506,8 +514,13 @@ export class FeishuStreamingSession {
     // Only send final update if content differs from what's already displayed
     if (text && text !== this.state.sentText) {
       const sent = text.startsWith(this.state.sentText)
-        ? await this.updateCardContent(resolveStreamingCardAppendContent(this.state.sentText, text))
-        : await this.replaceCardContent(text);
+        ? await this.updateCardContent(
+            resolveStreamingCardAppendContent(this.state.sentText, text),
+            (e) => this.log?.(`Final update failed: ${String(e)}`),
+          )
+        : await this.replaceCardContent(text, (e) =>
+            this.log?.(`Final replace failed: ${String(e)}`),
+          );
       this.state.currentText = text;
       if (sent) {
         this.state.sentText = text;

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -129,6 +129,16 @@ function shouldPushStreamingUpdate(previousText: string, nextText: string): bool
   return nextText.length - previousText.length >= STREAMING_SIGNIFICANT_DELTA_CHARS;
 }
 
+function resolveStreamingCardAppendContent(previousText: string, nextText: string): string {
+  if (!nextText || nextText === previousText) {
+    return "";
+  }
+  if (!previousText) {
+    return nextText;
+  }
+  return nextText.startsWith(previousText) ? nextText.slice(previousText.length) : nextText;
+}
+
 export function mergeStreamingText(
   previousText: string | undefined,
   nextText: string | undefined,
@@ -205,7 +215,7 @@ export class FeishuStreamingSession {
 
     const apiBase = resolveApiBase(this.creds.domain);
     const elements: Record<string, unknown>[] = [
-      { tag: "markdown", content: "⏳ Thinking...", element_id: "content" },
+      { tag: "markdown", content: "", element_id: "content" },
     ];
     if (options?.note) {
       elements.push({ tag: "hr" });
@@ -391,9 +401,13 @@ export class FeishuStreamingSession {
       if (!mergedText || mergedText === this.state.currentText) {
         return;
       }
+      const appendContent = resolveStreamingCardAppendContent(this.state.currentText, mergedText);
+      if (!appendContent) {
+        return;
+      }
       this.pendingText = null;
       this.state.currentText = mergedText;
-      await this.updateCardContent(mergedText, (e) => this.log?.(`Update failed: ${String(e)}`));
+      await this.updateCardContent(appendContent, (e) => this.log?.(`Update failed: ${String(e)}`));
     });
     await this.queue;
   }
@@ -442,7 +456,7 @@ export class FeishuStreamingSession {
 
     // Only send final update if content differs from what's already displayed
     if (text && text !== this.state.currentText) {
-      await this.updateCardContent(text);
+      await this.updateCardContent(resolveStreamingCardAppendContent(this.state.currentText, text));
       this.state.currentText = text;
     }
 

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -14,6 +14,7 @@ type CardState = {
   messageId: string;
   sequence: number;
   currentText: string;
+  sentText: string;
   hasNote: boolean;
 };
 
@@ -316,39 +317,46 @@ export class FeishuStreamingSession {
       messageId: sendRes.data.message_id,
       sequence: 1,
       currentText: "",
+      sentText: "",
       hasNote: !!options?.note,
     };
     this.log?.(`Started streaming: cardId=${cardId}, messageId=${sendRes.data.message_id}`);
   }
 
-  private async updateCardContent(text: string, onError?: (error: unknown) => void): Promise<void> {
+  private async updateCardContent(
+    text: string,
+    onError?: (error: unknown) => void,
+  ): Promise<boolean> {
     if (!this.state) {
-      return;
+      return false;
     }
     const apiBase = resolveApiBase(this.creds.domain);
     this.state.sequence += 1;
-    await fetchWithSsrFGuard({
-      url: `${apiBase}/cardkit/v1/cards/${this.state.cardId}/elements/content/content`,
-      init: {
-        method: "PUT",
-        headers: {
-          Authorization: `Bearer ${await getToken(this.creds)}`,
-          "Content-Type": "application/json",
-          "User-Agent": getFeishuUserAgent(),
+    try {
+      const { release } = await fetchWithSsrFGuard({
+        url: `${apiBase}/cardkit/v1/cards/${this.state.cardId}/elements/content/content`,
+        init: {
+          method: "PUT",
+          headers: {
+            Authorization: `Bearer ${await getToken(this.creds)}`,
+            "Content-Type": "application/json",
+            "User-Agent": getFeishuUserAgent(),
+          },
+          body: JSON.stringify({
+            content: text,
+            sequence: this.state.sequence,
+            uuid: `s_${this.state.cardId}_${this.state.sequence}`,
+          }),
         },
-        body: JSON.stringify({
-          content: text,
-          sequence: this.state.sequence,
-          uuid: `s_${this.state.cardId}_${this.state.sequence}`,
-        }),
-      },
-      policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
-      auditContext: "feishu.streaming-card.update",
-    })
-      .then(async ({ release }) => {
-        await release();
-      })
-      .catch((error) => onError?.(error));
+        policy: { allowedHostnames: resolveAllowedHostnames(this.creds.domain) },
+        auditContext: "feishu.streaming-card.update",
+      });
+      await release();
+      return true;
+    } catch (error) {
+      onError?.(error);
+      return false;
+    }
   }
 
   private clearFlushTimer(): void {
@@ -401,13 +409,18 @@ export class FeishuStreamingSession {
       if (!mergedText || mergedText === this.state.currentText) {
         return;
       }
-      const appendContent = resolveStreamingCardAppendContent(this.state.currentText, mergedText);
+      const appendContent = resolveStreamingCardAppendContent(this.state.sentText, mergedText);
       if (!appendContent) {
         return;
       }
       this.pendingText = null;
       this.state.currentText = mergedText;
-      await this.updateCardContent(appendContent, (e) => this.log?.(`Update failed: ${String(e)}`));
+      const sent = await this.updateCardContent(appendContent, (e) =>
+        this.log?.(`Update failed: ${String(e)}`),
+      );
+      if (sent && this.state) {
+        this.state.sentText = mergedText;
+      }
     });
     await this.queue;
   }
@@ -455,9 +468,14 @@ export class FeishuStreamingSession {
     const apiBase = resolveApiBase(this.creds.domain);
 
     // Only send final update if content differs from what's already displayed
-    if (text && text !== this.state.currentText) {
-      await this.updateCardContent(resolveStreamingCardAppendContent(this.state.currentText, text));
+    if (text && text !== this.state.sentText) {
+      const sent = await this.updateCardContent(
+        resolveStreamingCardAppendContent(this.state.sentText, text),
+      );
       this.state.currentText = text;
+      if (sent) {
+        this.state.sentText = text;
+      }
     }
 
     // Update note with final model/provider info


### PR DESCRIPTION
## Real behavior proof

- **Behavior or issue addressed:** Feishu CardKit streaming updates were sent as the full accumulated assistant text on every `/elements/content/content` PUT. On clients where that endpoint appends streamed content, updates like `A`, `AB`, `ABC` render as `AABABC`. Fixes #82417.
- **Real environment tested:** Local OpenClaw checkout on commit `a7c06bcfc11a5c9b993b5c716c237eab3fcbfffa`, Node/Vitest through the repo toolchain, exercising `FeishuStreamingSession.update()` and the exact CardKit content-update request body emitted by `extensions/feishu/src/streaming-card.ts` with the network guard mocked at the Feishu HTTP boundary.
- **Exact steps or command run after this patch:**

```bash
pnpm exec oxfmt --check --threads=1 extensions/feishu/src/streaming-card.ts extensions/feishu/src/streaming-card.test.ts
node scripts/run-vitest.mjs extensions/feishu/src/streaming-card.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json extensions/feishu/src/streaming-card.ts extensions/feishu/src/streaming-card.test.ts
git diff --check
```

- **Evidence after fix:** Terminal output from the focused Feishu streaming test run:

```text
RUN  v4.1.6 /home/chenglunhu/code/openclaw

Test Files  1 passed (1)
Tests  9 passed (9)
```

Focused assertions now verify the emitted CardKit update payloads send only the appended suffix:

```json
{"content":" small","sequence":2,"uuid":"s_card_1_2"}
{"content":"!","sequence":2,"uuid":"s_card_2_2"}
```

- **Observed result after fix:** For accumulated snapshots, OpenClaw still tracks the full logical streaming text internally, but the CardKit streaming endpoint receives only the new suffix. The initial streaming content element is blank, so the first streamed chunk does not append after the old `Thinking...` placeholder.
- **What was not tested:** I did not send a live Feishu message through the public Feishu API because this environment has no Feishu app credentials/chat configured. The local proof verifies the exact request body generated immediately before `fetchWithSsrFGuard` sends the CardKit update.

## Implementation notes

- `extensions/feishu/src/streaming-card.ts`
  - Adds a small append-content resolver for CardKit streaming updates.
  - Keeps `state.currentText` as the full logical accumulated text.
  - Sends only the suffix delta to `/cardkit/v1/cards/{card_id}/elements/content/content`.
  - Starts the streaming markdown element empty instead of with `Thinking...`, avoiding a stale placeholder prefix in append-mode clients.
- `extensions/feishu/src/streaming-card.test.ts`
  - Updates the throttled and natural-boundary streaming tests to assert suffix-only CardKit content.

## Pre-implement audits

- **Audit A (existing helper):** No existing CardKit delta helper found. Reused existing `mergeStreamingText` for full logical text and added a private suffix resolver for the CardKit append payload.
- **Audit B (shared callers):** `updateCardContent` is private to `FeishuStreamingSession`; public `update()`/`close()` contracts are preserved.
- **Audit C (broader rival):** No open rival PR references #82417. Broad/old Feishu streaming PRs exist, but none target this CardKit full-accumulated append bug or have maintainer-bot endorsement for this issue.