### PR TITLE
catalog(brave,slack): allowInvalidConfigRecovery for install repair (refs #82301)

### DIFF
--- a/scripts/lib/official-external-channel-catalog.json
+++ b/scripts/lib/official-external-channel-catalog.json
@@ -412,7 +412,8 @@
         "install": {
           "npmSpec": "@openclaw/slack",
           "defaultChoice": "npm",
-          "minHostVersion": ">=2026.5.12-beta.1"
+          "minHostVersion": ">=2026.5.12-beta.1",
+          "allowInvalidConfigRecovery": true
         }
       }
     },

--- a/scripts/lib/official-external-plugin-catalog.json
+++ b/scripts/lib/official-external-plugin-catalog.json
@@ -45,7 +45,8 @@
         "install": {
           "npmSpec": "@openclaw/brave-plugin",
           "defaultChoice": "npm",
-          "minHostVersion": ">=2026.4.10"
+          "minHostVersion": ">=2026.4.10",
+          "allowInvalidConfigRecovery": true
         }
       }
     },


### PR DESCRIPTION
## Summary

Adds `allowInvalidConfigRecovery: true` to the catalog entries for `@openclaw/brave-plugin` (plugin catalog) and `@openclaw/slack` (channel catalog), matching the existing setting on `@openclaw/discord` and `@openclaw/matrix`.

## Why

Operators upgrading from a pre-externalization release (e.g. 2026.4.29) to 2026.5.12 hit a catch-22 with `brave` and `slack` references in `openclaw.json`:

1. Gateways crash-loop after the upgrade with `web_search provider is not available: brave (install or enable plugin "brave", then run openclaw doctor --fix)` or the equivalent slack channel error.
2. The fix path — `openclaw plugins install @openclaw/brave-plugin` (or `@openclaw/slack`) — is itself blocked by the same config validator:

   ```
   OpenClaw config is invalid
   File: ~/.openclaw/openclaw.json
     - tools.web.search.provider: web_search provider is not available: brave
   Fix: openclaw doctor --fix
   ```

3. `openclaw doctor --fix`'s configured-plugin install repair (`runReleaseConfiguredPluginInstallsHealth` → `repairMissingPluginInstallsForIds`) early-returns on `!ctx.sourceConfigValid`, so doctor doesn't install the missing plugin either. Detailed reproduction in #82301.

`@openclaw/discord` and `@openclaw/matrix` already opt into `allowInvalidConfigRecovery`, which lets `plugins install` for those plugins bypass invalid-config validation specifically. Discord users upgrading from a pre-externalization release would have no catch-22 today. Brave and Slack just haven't been retrofitted yet.

This is a strictly narrower change than what #82301 requests (which proposes relaxing the doctor gate). It only affects `plugins install` for these two specific entries; the broader invalid-config policy is unchanged, the doctor gate is unchanged, no other catalog entries change.

## Test plan

- [x] Both edited JSONs parse cleanly (verified locally with `json.loads`)
- [x] Diff matches the pattern used by `@openclaw/discord` and `@openclaw/matrix` in the same files
- [ ] Manual verification by maintainer: against a 2026.5.12 host whose `openclaw.json` references `brave` or `slack` as a missing externalized plugin, `openclaw plugins install @openclaw/brave-plugin` / `@openclaw/slack` should succeed instead of bouncing off `OpenClaw config is invalid`. (I have a reproduction environment if useful.)

## Relationship to #82301

This PR doesn't close #82301 — that issue's broader ask (let `runReleaseConfiguredPluginInstallsHealth` install missing externalized plugins even when source config is invalid) remains the right fix for the general case, including any future plugins that get externalized without this opt-in. But for the specific brave/slack regression that real operators are hitting today, this opt-in is sufficient and surgically scoped.
