### PR TITLE
fix: trim final text chunk whitespace

### DIFF
--- a/extensions/matrix/runtime-api.test.ts
+++ b/extensions/matrix/runtime-api.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { chunkTextForOutbound } from "./runtime-api.js";
+
+describe("Matrix runtime API chunkTextForOutbound", () => {
+  it("trims trailing whitespace from the final over-limit chunk", () => {
+    expect(chunkTextForOutbound("alpha beta ", 8)).toEqual(["alpha", "beta"]);
+  });
+});

--- a/extensions/matrix/runtime-api.ts
+++ b/extensions/matrix/runtime-api.ts
@@ -56,17 +56,27 @@ export type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 export type { WizardPrompter } from "openclaw/plugin-sdk/setup";
 
 export function chunkTextForOutbound(text: string, limit: number): string[] {
+  if (!text) {
+    return [text];
+  }
+  if (limit <= 0 || text.length <= limit) {
+    return [text];
+  }
   const chunks: string[] = [];
   let remaining = text;
   while (remaining.length > limit) {
     const window = remaining.slice(0, limit);
     const splitAt = Math.max(window.lastIndexOf("\n"), window.lastIndexOf(" "));
     const breakAt = splitAt > 0 ? splitAt : limit;
-    chunks.push(remaining.slice(0, breakAt).trimEnd());
+    const chunk = remaining.slice(0, breakAt).trimEnd();
+    if (chunk.length > 0) {
+      chunks.push(chunk);
+    }
     remaining = remaining.slice(breakAt).trimStart();
   }
-  if (remaining.length > 0 || text.length === 0) {
-    chunks.push(remaining);
+  const finalChunk = remaining.trimEnd();
+  if (finalChunk.length > 0) {
+    chunks.push(finalChunk);
   }
   return chunks;
 }

--- a/src/markdown/ir.chunking.test.ts
+++ b/src/markdown/ir.chunking.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { chunkMarkdownIR, markdownToIR } from "./ir.js";
+
+describe("chunkMarkdownIR", () => {
+  it("preserves styled trailing whitespace in the final chunk", () => {
+    const ir = markdownToIR("```\n123456789\n```");
+
+    expect(ir.text).toBe("123456789\n");
+
+    const chunks = chunkMarkdownIR(ir, 7);
+
+    expect(chunks.map((chunk) => chunk.text)).toEqual(["1234567", "89\n"]);
+    expect(chunks.at(-1)?.styles).toEqual([{ start: 0, end: 3, style: "code_block" }]);
+  });
+});

--- a/src/markdown/ir.ts
+++ b/src/markdown/ir.ts
@@ -936,6 +936,22 @@ function sliceLinkSpans(spans: MarkdownLinkSpan[], start: number, end: number): 
   return sliced;
 }
 
+function expandFinalChunkEndForTrailingStyles(
+  spans: MarkdownStyleSpan[],
+  start: number,
+  end: number,
+  maxLength: number,
+): number {
+  let expandedEnd = end;
+  for (const span of spans) {
+    if (span.end <= expandedEnd || span.start > expandedEnd || span.end <= start) {
+      continue;
+    }
+    expandedEnd = Math.min(maxLength, span.end);
+  }
+  return expandedEnd;
+}
+
 export function sliceMarkdownIR(ir: MarkdownIR, start: number, end: number): MarkdownIR {
   return {
     text: ir.text.slice(start, end),
@@ -1032,9 +1048,14 @@ export function chunkMarkdownIR(ir: MarkdownIR, limit: number): MarkdownIR[] {
       }
     }
     const start = cursor;
-    const end = Math.min(ir.text.length, start + chunk.length);
+    const rawEnd = Math.min(ir.text.length, start + chunk.length);
+    const end =
+      index === chunks.length - 1
+        ? expandFinalChunkEndForTrailingStyles(ir.styles, start, rawEnd, ir.text.length)
+        : rawEnd;
+    const text = end === rawEnd ? chunk : ir.text.slice(start, end);
     results.push({
-      text: chunk,
+      text,
       styles: sliceStyleSpans(ir.styles, start, end),
       links: sliceLinkSpans(ir.links, start, end),
     });

--- a/src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts
+++ b/src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts
@@ -152,7 +152,7 @@ const RUNTIME_API_EXPORT_GUARDS: Record<string, readonly string[]> = {
     'export type { PluginRuntime, RuntimeLogger } from "openclaw/plugin-sdk/plugin-runtime";',
     'export type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";',
     'export type { WizardPrompter } from "openclaw/plugin-sdk/setup";',
-    'export function chunkTextForOutbound(text: string, limit: number): string[] { const chunks: string[] = []; let remaining = text; while (remaining.length > limit) { const window = remaining.slice(0, limit); const splitAt = Math.max(window.lastIndexOf("\\n"), window.lastIndexOf(" ")); const breakAt = splitAt > 0 ? splitAt : limit; chunks.push(remaining.slice(0, breakAt).trimEnd()); remaining = remaining.slice(breakAt).trimStart(); } if (remaining.length > 0 || text.length === 0) { chunks.push(remaining); } return chunks; }',
+    'export function chunkTextForOutbound(text: string, limit: number): string[] { if (!text) { return [text]; } if (limit <= 0 || text.length <= limit) { return [text]; } const chunks: string[] = []; let remaining = text; while (remaining.length > limit) { const window = remaining.slice(0, limit); const splitAt = Math.max(window.lastIndexOf("\\n"), window.lastIndexOf(" ")); const breakAt = splitAt > 0 ? splitAt : limit; const chunk = remaining.slice(0, breakAt).trimEnd(); if (chunk.length > 0) { chunks.push(chunk); } remaining = remaining.slice(breakAt).trimStart(); } const finalChunk = remaining.trimEnd(); if (finalChunk.length > 0) { chunks.push(finalChunk); } return chunks; }',
   ],
   [bundledPluginFile({
     rootDir: ROOT_DIR,

--- a/src/shared/text-chunking.test.ts
+++ b/src/shared/text-chunking.test.ts
@@ -37,4 +37,11 @@ describe("shared/text-chunking", () => {
       "def",
     ]);
   });
+
+  it("trims trailing whitespace from the final chunk", () => {
+    expect(chunkTextByBreakResolver("abcd ef  ", 5, (window) => window.lastIndexOf(" "))).toEqual([
+      "abcd",
+      "ef",
+    ]);
+  });
 });

--- a/src/shared/text-chunking.ts
+++ b/src/shared/text-chunking.ts
@@ -28,7 +28,10 @@ export function chunkTextByBreakResolver(
     remaining = remaining.slice(nextStart).trimStart();
   }
   if (remaining.length) {
-    chunks.push(remaining);
+    const finalChunk = remaining.trimEnd();
+    if (finalChunk.length > 0) {
+      chunks.push(finalChunk);
+    }
   }
   return chunks;
 }


### PR DESCRIPTION
## Summary
- Trim trailing whitespace before emitting the shared final text chunk.
- Keep Markdown IR final styled whitespace (for example code-block trailing newlines) when chunking after the shared trim.
- Align the Matrix runtime outbound chunker and its runtime-api guardrail with the same final-residual trimming behavior.
- Add regressions for shared text chunking, Markdown IR chunking, and Matrix runtime chunking.

## Test Plan
- `node scripts/run-vitest.mjs src/markdown/ir.chunking.test.ts extensions/matrix/runtime-api.test.ts`
- `node scripts/run-vitest.mjs src/shared/text-chunking.test.ts src/markdown/ir.chunking.test.ts src/markdown/render-aware-chunking.test.ts extensions/matrix/runtime-api.test.ts extensions/matrix/src/outbound.test.ts src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts`
- `pnpm check:changed --staged`

## Real behavior proof
Behavior addressed: over-limit text with a trailing-space residual no longer emits a final chunk with trailing whitespace, while Markdown IR code-block chunking still preserves the styled trailing newline needed by renderers.

Real environment tested: local PR repair worktree on this branch, Node 22.18.0, dependencies installed with `pnpm install --frozen-lockfile`.

Exact steps or command run after this patch:
```bash
node scripts/run-vitest.mjs src/markdown/ir.chunking.test.ts extensions/matrix/runtime-api.test.ts
node scripts/run-vitest.mjs src/shared/text-chunking.test.ts src/markdown/ir.chunking.test.ts src/markdown/render-aware-chunking.test.ts extensions/matrix/runtime-api.test.ts extensions/matrix/src/outbound.test.ts src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts
pnpm check:changed --staged
```

Evidence after fix:
```text
src/markdown/ir.chunking.test.ts: 1 test passed
extensions/matrix/runtime-api.test.ts: 1 test passed
Relevant broader Vitest run: 6 files passed, 28 tests passed
check:changed --staged: lanes core, coreTests, extensions, extensionTests all completed successfully; oxlint reported 0 warnings and 0 errors
```

Observed result after fix: Matrix `chunkTextForOutbound("alpha beta ", 8)` returns `["alpha", "beta"]`, and `chunkMarkdownIR(markdownToIR("```\n123456789\n```"), 7)` returns final chunk text `"89\n"` with the `code_block` style spanning the newline.

What was not tested: full repository CI had just restarted after the push and was still running when this PR body was updated.

## Risk/Notes
- Low-to-moderate risk: the shared trim is narrow, but Markdown IR needs explicit preservation of styled trailing whitespace so rendered code fences remain balanced.
- Matrix keeps its lightweight runtime copy aligned with the shared behavior and guardrail expectations.

Closes #64036
