### PR TITLE
fix(ui): show manual compact progress

### DIFF
--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -146,6 +146,8 @@ function makeHost(overrides?: Partial<ChatHost>): ChatHost {
     chatModelSwitchPromises: {},
     chatModelsLoading: false,
     chatModelCatalog: [],
+    compactionStatus: null,
+    compactionClearTimer: null,
     refreshSessionsAfterChat: new Set<string>(),
     toolStreamById: new Map(),
     toolStreamOrder: [],
@@ -1113,6 +1115,85 @@ describe("handleSendChat", () => {
     const feedback = requireRecord(host.chatMessages[0], "feedback message");
     expect(feedback.role).toBe("system");
     expect(feedback.content).toBe("Command `/think` failed unexpectedly.");
+  });
+
+  it("shows the compaction indicator while manual /compact is in flight", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    const compact = createDeferred<Awaited<ReturnType<ExecuteSlashCommand>>>();
+    executeSlashCommandMock.mockReturnValue(compact.promise);
+    const requestUpdate = vi.fn();
+    const host = makeHost({
+      client: { request: vi.fn() } as unknown as ChatHost["client"],
+      chatMessage: "/compact",
+      connected: true,
+      requestUpdate,
+    });
+
+    try {
+      const send = handleSendChat(host);
+      await Promise.resolve();
+
+      expect(host.compactionStatus).toEqual({
+        phase: "active",
+        runId: null,
+        startedAt: 10_000,
+        completedAt: null,
+      });
+      expect(requestUpdate).toHaveBeenCalledTimes(1);
+
+      vi.setSystemTime(12_000);
+      compact.resolve({
+        content: "Context compacted successfully.",
+        manualCompactionOutcome: "compacted",
+      });
+      await send;
+
+      expect(host.compactionStatus).toEqual({
+        phase: "complete",
+        runId: null,
+        startedAt: 10_000,
+        completedAt: 12_000,
+      });
+      expect(requestUpdate).toHaveBeenCalledTimes(2);
+
+      vi.advanceTimersByTime(4_999);
+      expect(host.compactionStatus?.phase).toBe("complete");
+
+      vi.advanceTimersByTime(1);
+      expect(host.compactionStatus).toBeNull();
+      expect(host.compactionClearTimer).toBeNull();
+      expect(requestUpdate).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears the manual compaction indicator when /compact is skipped", async () => {
+    const compact = createDeferred<Awaited<ReturnType<ExecuteSlashCommand>>>();
+    executeSlashCommandMock.mockReturnValue(compact.promise);
+    const requestUpdate = vi.fn();
+    const host = makeHost({
+      client: { request: vi.fn() } as unknown as ChatHost["client"],
+      chatMessage: "/compact",
+      connected: true,
+      requestUpdate,
+    });
+
+    const send = handleSendChat(host);
+    await Promise.resolve();
+
+    expect(host.compactionStatus?.phase).toBe("active");
+
+    compact.resolve({
+      content: "Compaction skipped: no transcript.",
+      manualCompactionOutcome: "skipped",
+    });
+    await send;
+
+    expect(host.compactionStatus).toBeNull();
+    expect(host.compactionClearTimer).toBeNull();
+    expect(requestUpdate).toHaveBeenCalledTimes(2);
   });
 
   it("sends /btw immediately while a main run is active without queueing it", async () => {

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -1,6 +1,6 @@
 import { setLastActiveSessionKey } from "./app-last-active-session.ts";
 import { scheduleChatScroll, resetChatScroll } from "./app-scroll.ts";
-import { resetToolStream } from "./app-tool-stream.ts";
+import { resetToolStream, type CompactionStatus } from "./app-tool-stream.ts";
 import {
   cloneChatAttachmentsMetadata,
   discardChatAttachmentDataUrls,
@@ -65,6 +65,8 @@ export type ChatHost = ChatInputHistoryState & {
   chatModelSwitchPromises?: Record<string, Promise<boolean>>;
   chatModelsLoading: boolean;
   chatModelCatalog: ModelCatalogEntry[];
+  compactionStatus?: CompactionStatus | null;
+  compactionClearTimer?: ReturnType<typeof globalThis.setTimeout> | number | null;
   sessionsResult?: SessionsListResult | null;
   updateComplete?: Promise<unknown>;
   requestUpdate?: () => void;
@@ -86,6 +88,7 @@ export type ChatAbortOptions = {
 
 export const CHAT_SESSIONS_ACTIVE_MINUTES = 120;
 export const CHAT_SESSIONS_REFRESH_LIMIT = 100;
+const MANUAL_COMPACTION_TOAST_DURATION_MS = 5000;
 export {
   handleChatDraftChange,
   handleChatInputHistoryKey,
@@ -93,6 +96,56 @@ export {
   resetChatInputHistoryNavigation,
 };
 export type { ChatInputHistoryKeyInput, ChatInputHistoryKeyResult };
+
+function clearManualCompactionTimer(host: ChatHost) {
+  if (host.compactionClearTimer != null) {
+    globalThis.clearTimeout(host.compactionClearTimer);
+    host.compactionClearTimer = null;
+  }
+}
+
+function beginManualCompactionIndicator(host: ChatHost) {
+  clearManualCompactionTimer(host);
+  host.compactionStatus = {
+    phase: "active",
+    runId: null,
+    startedAt: Date.now(),
+    completedAt: null,
+  };
+  host.requestUpdate?.();
+}
+
+function finishManualCompactionIndicator(
+  host: ChatHost,
+  outcome: "compacted" | "skipped" | "failed" | undefined,
+) {
+  clearManualCompactionTimer(host);
+  if (outcome === "compacted") {
+    const completedAt = Date.now();
+    host.compactionStatus = {
+      phase: "complete",
+      runId: null,
+      startedAt: host.compactionStatus?.startedAt ?? null,
+      completedAt,
+    };
+    host.compactionClearTimer = globalThis.setTimeout(() => {
+      const current = host.compactionStatus;
+      if (
+        current?.phase !== "complete" ||
+        current.runId !== null ||
+        current.completedAt !== completedAt
+      ) {
+        return;
+      }
+      host.compactionStatus = null;
+      host.compactionClearTimer = null;
+      host.requestUpdate?.();
+    }, MANUAL_COMPACTION_TOAST_DURATION_MS);
+  } else {
+    host.compactionStatus = null;
+  }
+  host.requestUpdate?.();
+}
 
 export function isChatBusy(host: ChatHost) {
   return host.chatSending || Boolean(host.chatRunId);
@@ -687,16 +740,27 @@ async function dispatchSlashCommand(
 
   const targetSessionKey = host.sessionKey;
   let result: Awaited<ReturnType<typeof executeSlashCommand>>;
+  const showManualCompactionIndicator = name === "compact";
+  if (showManualCompactionIndicator) {
+    beginManualCompactionIndicator(host);
+  }
   try {
     result = await executeSlashCommand(host.client, targetSessionKey, name, args, {
       chatModelCatalog: host.chatModelCatalog,
       sessionsResult: host.sessionsResult,
     });
   } catch (err) {
+    if (showManualCompactionIndicator) {
+      finishManualCompactionIndicator(host, "failed");
+    }
     host.lastError = String(err);
     injectCommandResult(host, `Command \`/${name}\` failed unexpectedly.`);
     scheduleChatScroll(host as unknown as Parameters<typeof scheduleChatScroll>[0]);
     return;
+  }
+
+  if (showManualCompactionIndicator) {
+    finishManualCompactionIndicator(host, result.manualCompactionOutcome);
   }
 
   if (result.content) {

--- a/ui/src/ui/chat/slash-command-executor.node.test.ts
+++ b/ui/src/ui/chat/slash-command-executor.node.test.ts
@@ -35,6 +35,77 @@ function expectNoRequestCall(request: ReturnType<typeof vi.fn>, method: string) 
   expect(request.mock.calls.some(([calledMethod]) => calledMethod === method)).toBe(false);
 }
 
+describe("executeSlashCommand /compact", () => {
+  it("reports compacted outcome for successful manual compaction", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.compact") {
+        return {
+          compacted: true,
+          result: { tokensBefore: 12_000, tokensAfter: 4_000 },
+        };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "agent:main:main",
+      "compact",
+      "",
+    );
+
+    expect(result).toEqual({
+      content: "Context compacted successfully (12,000 -> 4,000 tokens).",
+      action: "refresh",
+      manualCompactionOutcome: "compacted",
+    });
+    expect(request).toHaveBeenCalledWith("sessions.compact", { key: "agent:main:main" });
+  });
+
+  it("reports skipped outcome when manual compaction is skipped", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.compact") {
+        return { compacted: false, reason: "below threshold" };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "agent:main:main",
+      "compact",
+      "",
+    );
+
+    expect(result).toEqual({
+      content: "Compaction skipped: below threshold",
+      action: "refresh",
+      manualCompactionOutcome: "skipped",
+    });
+  });
+
+  it("reports failed outcome when manual compaction fails", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "sessions.compact") {
+        throw new Error("boom");
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "agent:main:main",
+      "compact",
+      "",
+    );
+
+    expect(result).toEqual({
+      content: "Compaction failed: Error: boom",
+      manualCompactionOutcome: "failed",
+    });
+  });
+});
+
 describe("executeSlashCommand /kill", () => {
   it("aborts every sub-agent session for /kill all", async () => {
     const request = vi.fn(async (method: string, _payload?: unknown) => {

--- a/ui/src/ui/chat/slash-command-executor.ts
+++ b/ui/src/ui/chat/slash-command-executor.ts
@@ -56,6 +56,8 @@ export type SlashCommandResult = {
   trackRunId?: string;
   /** When set, the caller should surface a visible pending item tied to the current run. */
   pendingCurrentRun?: boolean;
+  /** Manual compaction outcome so the UI can reconcile its in-flight indicator. */
+  manualCompactionOutcome?: "compacted" | "skipped" | "failed";
 };
 
 export type SlashCommandContext = {
@@ -174,14 +176,26 @@ async function executeCompact(
         typeof before === "number" && typeof after === "number"
           ? ` (${before.toLocaleString()} -> ${after.toLocaleString()} tokens)`
           : "";
-      return { content: `Context compacted successfully${tokenSummary}.`, action: "refresh" };
+      return {
+        content: `Context compacted successfully${tokenSummary}.`,
+        action: "refresh",
+        manualCompactionOutcome: "compacted",
+      };
     }
     if (typeof result?.reason === "string" && result.reason.trim()) {
-      return { content: `Compaction skipped: ${result.reason}`, action: "refresh" };
+      return {
+        content: `Compaction skipped: ${result.reason}`,
+        action: "refresh",
+        manualCompactionOutcome: "skipped",
+      };
     }
-    return { content: "Compaction skipped.", action: "refresh" };
+    return {
+      content: "Compaction skipped.",
+      action: "refresh",
+      manualCompactionOutcome: "skipped",
+    };
   } catch (err) {
-    return { content: `Compaction failed: ${String(err)}` };
+    return { content: `Compaction failed: ${String(err)}`, manualCompactionOutcome: "failed" };
   }
 }
 


### PR DESCRIPTION
## Summary

- Show the existing Control UI compaction indicator immediately when manual `/compact` starts.
- Keep the indicator visible as `Compacting context...` while `sessions.compact` is in flight.
- Reconcile the indicator to a short `Context compacted` toast on success, or clear it for skipped/failed manual compactions.
- Add focused coverage for manual compact in-flight, compacted, skipped, and failed outcomes.

## Tests

- `CI=1 node scripts/run-vitest.mjs ui/src/ui/app-chat.test.ts ui/src/ui/chat/slash-command-executor.node.test.ts ui/src/ui/chat/run-controls.test.ts ui/src/ui/app-tool-stream.node.test.ts`
- `pnpm exec oxfmt --check --threads=1 ui/src/ui/app-chat.ts ui/src/ui/app-chat.test.ts ui/src/ui/chat/slash-command-executor.ts ui/src/ui/chat/slash-command-executor.node.test.ts`
- `git diff --check`
- `pnpm check:changed`

## Real behavior proof

Behavior or issue addressed: WebControl manual `/compact` previously awaited `sessions.compact` without setting the existing `compactionStatus`, so the Control UI had no visible in-progress compaction indicator while manual compaction was running.

Real environment tested: WSL Ubuntu 24.04 OpenClaw source checkout on branch `fix-manual-compact-indicator-82407` at commit `c65dc7f762`, Node v24.15.0. The proof harness imported the real Control UI `handleSendChat()` and slash-command execution path, using a deferred fake Gateway client only for the RPC boundary.

Exact steps or command run after this patch: Ran this source-level Control UI dispatch harness from the repository root: `node --import tsx` importing `./ui/src/ui/app-chat.ts`, creating a host with `chatMessage: "/compact"`, making `sessions.compact` return a deferred promise, checking `host.compactionStatus` before resolving the RPC, then resolving `{ compacted: true, result: { tokensBefore: 12000, tokensAfter: 4000 } }` and checking `host.compactionStatus` again.

Evidence after fix:

```text
during_rpc {"phase":"active","runId":null,"startedAt":1778903286851,"completedAt":null}
requests_during_rpc [{"method":"sessions.compact","payload":{"key":"agent:main:main"}}]
after_rpc {"phase":"complete","runId":null,"startedAt":1778903286851,"completedAt":1778903286881}
request_updates 3
```

Observed result after fix: The real manual `/compact` dispatch path sets `compactionStatus.phase` to `active` before the awaited `sessions.compact` RPC resolves, so the existing `renderCompactionIndicator()` surface can show `Compacting context...`; after a compacted response it transitions to `complete` for the existing short success toast.

What was not tested: A live browser session against a real long-running Gateway compaction was not run; validation used the real Control UI source path with a deferred Gateway RPC harness plus focused UI/unit gates.
