### PR TITLE
fix: detect cron minute fields containing zero

### DIFF
--- a/src/cron/stagger.test.ts
+++ b/src/cron/stagger.test.ts
@@ -15,6 +15,16 @@ describe("cron stagger helpers", () => {
     expect(isRecurringTopOfHourCronExpr("15 * * * *")).toBe(false);
   });
 
+  it("detects top-of-hour schedules when the minute field includes zero", () => {
+    expect(isRecurringTopOfHourCronExpr("* * * * *")).toBe(true);
+    expect(isRecurringTopOfHourCronExpr("*/15 * * * *")).toBe(true);
+    expect(isRecurringTopOfHourCronExpr("0,30 * * * *")).toBe(true);
+    expect(isRecurringTopOfHourCronExpr("0-30 * * * *")).toBe(true);
+    expect(isRecurringTopOfHourCronExpr("0 */15 * * * *")).toBe(true);
+    expect(isRecurringTopOfHourCronExpr("5,30 * * * *")).toBe(false);
+    expect(isRecurringTopOfHourCronExpr("5-10 * * * *")).toBe(false);
+  });
+
   it("normalizes explicit stagger values", () => {
     expect(normalizeCronStaggerMs("30000")).toBe(30_000);
     expect(normalizeCronStaggerMs(42.8)).toBe(42);

--- a/src/cron/stagger.ts
+++ b/src/cron/stagger.ts
@@ -6,15 +6,45 @@ function parseCronFields(expr: string) {
   return expr.trim().split(/\s+/).filter(Boolean);
 }
 
+function cronFieldIncludesValue(field: string, value: number): boolean {
+  return field.split(",").some((part) => cronFieldPartIncludesValue(part.trim(), value));
+}
+
+function cronFieldPartIncludesValue(part: string, value: number): boolean {
+  if (!part) {
+    return false;
+  }
+  const [rangePart, stepPart] = part.split("/", 2);
+  if (stepPart !== undefined) {
+    const step = Number(stepPart);
+    if (!Number.isInteger(step) || step <= 0) {
+      return false;
+    }
+  }
+  if (rangePart === "*") {
+    return true;
+  }
+  const rangeMatch = /^(\d+)-(\d+)$/.exec(rangePart);
+  if (rangeMatch) {
+    const start = Number(rangeMatch[1]);
+    const end = Number(rangeMatch[2]);
+    if (!Number.isInteger(start) || !Number.isInteger(end) || start > end) {
+      return false;
+    }
+    return start <= value && value <= end;
+  }
+  return Number(rangePart) === value;
+}
+
 export function isRecurringTopOfHourCronExpr(expr: string) {
   const fields = parseCronFields(expr);
   if (fields.length === 5) {
     const [minuteField, hourField] = fields;
-    return minuteField === "0" && hourField.includes("*");
+    return cronFieldIncludesValue(minuteField, 0) && hourField.includes("*");
   }
   if (fields.length === 6) {
     const [secondField, minuteField, hourField] = fields;
-    return secondField === "0" && minuteField === "0" && hourField.includes("*");
+    return secondField === "0" && cronFieldIncludesValue(minuteField, 0) && hourField.includes("*");
   }
   return false;
 }


### PR DESCRIPTION
## Summary
- Parse comma-separated, stepped, wildcard, and range minute fields when detecting top-of-hour cron schedules.
- Preserve existing 5-field and 6-field behavior while recognizing minute fields that include 0.
- Add regression coverage for */n, list, wildcard, and range minute fields.

## Test Plan
- pnpm test src/cron/stagger.test.ts
- pnpm check:changed --staged

Closes #51587