### PR TITLE
fix: repair source-only official plugin installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 - Trajectory export: skip and report malformed session/runtime JSONL rows in `manifest.json` instead of letting wrong-shaped session rows crash support bundle export.
 - Voice calls: persist rejected inbound-call replay keys so duplicate carrier webhook retries stay ignored after a Gateway restart.
 - Config/doctor: copy fallback-enabled channel `allowFrom` entries into explicit `groupAllowFrom` allowlists during `openclaw doctor --fix`, preserving current group access without adding runtime fallback-transition flags.
+- Config/doctor: replace source-only official Brave and Slack plugin installs from trusted catalog metadata during `openclaw doctor --fix`, unblocking externalized stock plugin recovery after upgrade. (#82425) Thanks @joshavant.
 - Configure: show one OpenAI provider entry with ChatGPT/Codex sign-in and API key choices, and keep browsed Codex models in the saved `/model` picker allowlist.
 - Agents/model fallback: preserve auto fallback chains across deferred config reloads when session fallback provenance survives but `modelOverrideSource` is missing. Fixes #81982. Thanks @joshavant.
 - Hooks: raise bounded gateway lifecycle hook wait budgets to 5 seconds for shutdown and 10 seconds for pre-restart, giving short restart notification handlers time to finish before shutdown continues. (#82273) Thanks @bryanbaer.

--- a/extensions/brave/package.json
+++ b/extensions/brave/package.json
@@ -17,7 +17,8 @@
     "install": {
       "npmSpec": "@openclaw/brave-plugin",
       "defaultChoice": "npm",
-      "minHostVersion": ">=2026.4.10"
+      "minHostVersion": ">=2026.4.10",
+      "allowInvalidConfigRecovery": true
     },
     "compat": {
       "pluginApi": ">=2026.5.16"

--- a/extensions/slack/package.json
+++ b/extensions/slack/package.json
@@ -61,7 +61,8 @@
     "install": {
       "npmSpec": "@openclaw/slack",
       "defaultChoice": "npm",
-      "minHostVersion": ">=2026.5.12-beta.1"
+      "minHostVersion": ">=2026.5.12-beta.1",
+      "allowInvalidConfigRecovery": true
     },
     "compat": {
       "pluginApi": ">=2026.5.16"

--- a/scripts/lib/official-external-channel-catalog.json
+++ b/scripts/lib/official-external-channel-catalog.json
@@ -412,7 +412,8 @@
         "install": {
           "npmSpec": "@openclaw/slack",
           "defaultChoice": "npm",
-          "minHostVersion": ">=2026.5.12-beta.1"
+          "minHostVersion": ">=2026.5.12-beta.1",
+          "allowInvalidConfigRecovery": true
         }
       }
     },

--- a/scripts/lib/official-external-plugin-catalog.json
+++ b/scripts/lib/official-external-plugin-catalog.json
@@ -45,7 +45,8 @@
         "install": {
           "npmSpec": "@openclaw/brave-plugin",
           "defaultChoice": "npm",
-          "minHostVersion": ">=2026.4.10"
+          "minHostVersion": ">=2026.4.10",
+          "allowInvalidConfigRecovery": true
         }
       }
     },

--- a/src/cli/plugins-install-command.ts
+++ b/src/cli/plugins-install-command.ts
@@ -491,7 +491,13 @@ function isAllowedPluginRecoveryIssue(
       issue.message.includes("plugin path not found")) ||
     (issue.path === "plugins" &&
       typeof issue.message === "string" &&
-      issue.message.includes("requires compiled runtime output"))
+      issue.message.includes("requires compiled runtime output")) ||
+    (issue.path === `plugins.entries.${pluginId}` &&
+      typeof issue.message === "string" &&
+      issue.message.includes("requires compiled runtime output")) ||
+    (issue.path === "tools.web.search.provider" &&
+      typeof issue.message === "string" &&
+      issue.message.includes(`plugin "${pluginId}"`))
   );
 }
 

--- a/src/cli/plugins-install-config.test.ts
+++ b/src/cli/plugins-install-config.test.ts
@@ -179,6 +179,42 @@ describe("loadConfigForInstall", () => {
     expect(result).toEqual({ config: snapshotCfg, baseHash: "abc" });
   });
 
+  it("allows Brave official plugin reinstall recovery from source-only runtime shadows", async () => {
+    const snapshotCfg = {
+      plugins: { installs: { brave: { source: "clawhub", installPath: "/bad/brave" } } },
+    } as unknown as OpenClawConfig;
+    readConfigFileSnapshotMock.mockResolvedValue(
+      makeSnapshot({
+        parsed: { plugins: { installs: { brave: {} } } },
+        config: snapshotCfg,
+        issues: [
+          {
+            path: "plugins.entries.brave",
+            message:
+              "plugin brave: installed plugin package requires compiled runtime output for TypeScript entry index.ts: expected ./dist/index.js.",
+          },
+          {
+            path: "tools.web.search.provider",
+            message:
+              'web_search provider is not available: brave (install or enable plugin "brave", then run openclaw doctor --fix)',
+          },
+        ],
+      }),
+    );
+
+    const request = resolvePluginInstallRequestContext({
+      rawSpec: "@openclaw/brave-plugin",
+    });
+    if (!request.ok) {
+      throw new Error(request.error);
+    }
+
+    expect(request.request.allowInvalidConfigRecovery).toBe(true);
+    const result = await loadConfigForInstall(request.request);
+    expect(collectChannelDoctorStaleConfigMutationsMock).toHaveBeenCalledWith(snapshotCfg);
+    expect(result).toEqual({ config: snapshotCfg, baseHash: "abc" });
+  });
+
   it("allows explicit repo-checkout bundled-plugin reinstall recovery", async () => {
     const snapshotCfg = { plugins: {} } as OpenClawConfig;
     readConfigFileSnapshotMock.mockResolvedValue(

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -313,10 +313,34 @@ describe("registerPreActionHooks", () => {
     expect(ensurePluginRegistryLoadedMock).not.toHaveBeenCalled();
   });
 
-  it("only allows invalid config for explicit Discord reinstall requests", async () => {
+  it("only allows invalid config for explicit official recovery reinstall requests", async () => {
     await runPreAction({
       parseArgv: ["plugins", "install", "@openclaw/discord"],
       processArgv: ["node", "openclaw", "plugins", "install", "@openclaw/discord"],
+    });
+
+    expect(ensureConfigReadyMock).toHaveBeenCalledWith({
+      runtime: runtimeMock,
+      commandPath: ["plugins", "install"],
+      allowInvalid: true,
+    });
+
+    vi.clearAllMocks();
+    await runPreAction({
+      parseArgv: ["plugins", "install", "@openclaw/brave-plugin"],
+      processArgv: ["node", "openclaw", "plugins", "install", "@openclaw/brave-plugin"],
+    });
+
+    expect(ensureConfigReadyMock).toHaveBeenCalledWith({
+      runtime: runtimeMock,
+      commandPath: ["plugins", "install"],
+      allowInvalid: true,
+    });
+
+    vi.clearAllMocks();
+    await runPreAction({
+      parseArgv: ["plugins", "install", "@openclaw/slack"],
+      processArgv: ["node", "openclaw", "plugins", "install", "@openclaw/slack"],
     });
 
     expect(ensureConfigReadyMock).toHaveBeenCalledWith({

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -51,6 +51,7 @@ const mocks = vi.hoisted(() => ({
     (entry: { label?: string; id?: string }) => entry.label ?? entry.id ?? "plugin",
   ),
   resolveDefaultPluginExtensionsDir: vi.fn(() => "/tmp/openclaw-plugins"),
+  resolveDefaultPluginNpmDir: vi.fn(() => "/tmp/openclaw-npm"),
   resolvePluginInstallDir: vi.fn(
     (pluginId: string, extensionsDir = "/tmp/openclaw-plugins") => `${extensionsDir}/${pluginId}`,
   ),
@@ -102,6 +103,7 @@ vi.mock("../../../plugins/installed-plugin-index.js", async (importOriginal) => 
 
 vi.mock("../../../plugins/install-paths.js", () => ({
   resolveDefaultPluginExtensionsDir: mocks.resolveDefaultPluginExtensionsDir,
+  resolveDefaultPluginNpmDir: mocks.resolveDefaultPluginNpmDir,
   resolvePluginInstallDir: mocks.resolvePluginInstallDir,
   validatePluginId: mocks.validatePluginId,
 }));
@@ -153,6 +155,8 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue({});
     mocks.listChannelPluginCatalogEntries.mockReturnValue([]);
     mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([]);
+    mocks.resolveDefaultPluginExtensionsDir.mockReturnValue("/tmp/openclaw-plugins");
+    mocks.resolveDefaultPluginNpmDir.mockReturnValue("/tmp/openclaw-npm");
     mocks.resolveProviderInstallCatalogEntries.mockReturnValue([]);
     mocks.installPluginFromClawHub.mockResolvedValue({
       ok: true,
@@ -2185,6 +2189,430 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       env: {},
     });
     expect(result.changes).toEqual(['Repaired missing configured plugin "brave".']);
+  });
+
+  it("replaces a configured official web search plugin when its installed package is source-only", async () => {
+    const extensionsDir = path.join(makeTempDir(), "extensions");
+    const installDir = path.join(extensionsDir, "brave");
+    mocks.resolveDefaultPluginExtensionsDir.mockReturnValue(extensionsDir);
+    fs.mkdirSync(installDir, { recursive: true });
+    fs.writeFileSync(path.join(installDir, "package.json"), JSON.stringify({ name: "brave" }));
+    const records = {
+      brave: {
+        source: "clawhub",
+        spec: "clawhub:@openclaw/brave-plugin@2026.5.1-beta.1",
+        installPath: installDir,
+        clawhubPackage: "@openclaw/brave-plugin",
+        clawhubChannel: "official",
+        clawhubUrl: "https://clawhub.ai",
+      },
+    };
+    mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
+    mocks.loadPluginMetadataSnapshot.mockReturnValue({
+      plugins: [],
+      diagnostics: [
+        {
+          level: "error",
+          pluginId: "brave",
+          message:
+            "installed plugin package requires compiled runtime output for TypeScript entry index.ts: expected ./dist/index.js, ./dist/index.mjs, ./dist/index.cjs, index.js, index.mjs, index.cjs.",
+        },
+      ],
+    });
+    mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([
+      {
+        id: "brave",
+        label: "Brave",
+        install: {
+          npmSpec: "@openclaw/brave-plugin",
+          defaultChoice: "npm",
+        },
+        openclaw: {
+          plugin: { id: "brave", label: "Brave" },
+          webSearchProviders: [
+            {
+              id: "brave",
+              label: "Brave Search",
+              hint: "Brave Search",
+              envVars: ["BRAVE_API_KEY"],
+              placeholder: "BSA...",
+              signupUrl: "https://example.test/brave",
+            },
+          ],
+        },
+      },
+    ]);
+    mocks.installPluginFromNpmSpec.mockResolvedValueOnce({
+      ok: true,
+      pluginId: "brave",
+      targetDir: "/tmp/openclaw-plugins/brave",
+      version: "2026.5.12",
+      npmResolution: {
+        name: "@openclaw/brave-plugin",
+        version: "2026.5.12",
+        resolvedSpec: "@openclaw/brave-plugin@2026.5.12",
+        integrity: "sha512-brave",
+        resolvedAt: "2026-05-01T00:00:00.000Z",
+      },
+    });
+
+    const { repairMissingConfiguredPluginInstalls } =
+      await import("./missing-configured-plugin-install.js");
+    const result = await repairMissingConfiguredPluginInstalls({
+      cfg: {
+        tools: {
+          web: {
+            search: {
+              provider: "brave",
+            },
+          },
+        },
+      },
+      env: {},
+    });
+
+    expect(mocks.updateNpmInstalledPlugins).not.toHaveBeenCalled();
+    expect(fs.existsSync(installDir)).toBe(false);
+    expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
+      spec: expectedNpmInstallSpec("@openclaw/brave-plugin"),
+      expectedPluginId: "brave",
+      trustedSourceLinkedOfficialInstall: true,
+      mode: "update",
+    });
+    const persistedRecords = mockCallArg(
+      mocks.writePersistedInstalledPluginIndexInstallRecords,
+    ) as Record<string, unknown>;
+    expectRecordFields(persistedRecords.brave, {
+      source: "npm",
+      spec: "@openclaw/brave-plugin",
+      installPath: "/tmp/openclaw-plugins/brave",
+      version: "2026.5.12",
+    });
+    expect(result).toEqual({
+      changes: [
+        `Installed missing configured plugin "brave" from ${expectedNpmInstallSpec("@openclaw/brave-plugin")}.`,
+      ],
+      warnings: [],
+      records: persistedRecords,
+    });
+  });
+
+  it("replaces a configured official channel plugin when only its channel is configured", async () => {
+    const extensionsDir = path.join(makeTempDir(), "extensions");
+    const installDir = path.join(extensionsDir, "slack");
+    mocks.resolveDefaultPluginExtensionsDir.mockReturnValue(extensionsDir);
+    fs.mkdirSync(installDir, { recursive: true });
+    fs.writeFileSync(path.join(installDir, "package.json"), JSON.stringify({ name: "slack" }));
+    const records = {
+      slack: {
+        source: "clawhub",
+        spec: "clawhub:@openclaw/slack@2026.5.12-beta.1",
+        installPath: installDir,
+        clawhubPackage: "@openclaw/slack",
+        clawhubChannel: "official",
+        clawhubUrl: "https://clawhub.ai",
+      },
+    };
+    mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
+    mocks.loadPluginMetadataSnapshot.mockReturnValue({
+      plugins: [],
+      diagnostics: [
+        {
+          level: "error",
+          pluginId: "slack",
+          message:
+            "installed plugin package requires compiled runtime output for TypeScript entry index.ts: expected ./dist/index.js.",
+        },
+      ],
+    });
+    mocks.listChannelPluginCatalogEntries.mockReturnValue([
+      {
+        id: "slack",
+        pluginId: "slack",
+        meta: { label: "Slack" },
+        install: {
+          npmSpec: "@openclaw/slack",
+          defaultChoice: "npm",
+        },
+        trustedSourceLinkedOfficialInstall: true,
+      },
+    ]);
+    mocks.installPluginFromNpmSpec.mockResolvedValueOnce({
+      ok: true,
+      pluginId: "slack",
+      targetDir: "/tmp/openclaw-npm/node_modules/@openclaw/slack",
+      version: "2026.5.12",
+      npmResolution: {
+        name: "@openclaw/slack",
+        version: "2026.5.12",
+        resolvedSpec: "@openclaw/slack@2026.5.12",
+        integrity: "sha512-slack",
+        resolvedAt: "2026-05-01T00:00:00.000Z",
+      },
+    });
+
+    const { repairMissingConfiguredPluginInstalls } =
+      await import("./missing-configured-plugin-install.js");
+    const result = await repairMissingConfiguredPluginInstalls({
+      cfg: {
+        channels: {
+          slack: {
+            enabled: true,
+            botToken: "xoxb-test",
+          },
+        },
+      },
+      env: {},
+    });
+
+    expect(mocks.updateNpmInstalledPlugins).not.toHaveBeenCalled();
+    expect(fs.existsSync(installDir)).toBe(false);
+    expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
+      spec: expectedNpmInstallSpec("@openclaw/slack"),
+      expectedPluginId: "slack",
+      trustedSourceLinkedOfficialInstall: true,
+      mode: "update",
+    });
+    expect(result.changes).toEqual([
+      `Installed missing configured plugin "slack" from ${expectedNpmInstallSpec("@openclaw/slack")}.`,
+    ]);
+  });
+
+  it("does not delete an arbitrary recorded path when replacing a broken official plugin", async () => {
+    const installDir = makeTempDir();
+    fs.writeFileSync(path.join(installDir, "package.json"), JSON.stringify({ name: "brave" }));
+    const records = {
+      brave: {
+        source: "clawhub",
+        spec: "clawhub:@openclaw/brave-plugin@2026.5.1-beta.1",
+        installPath: installDir,
+        clawhubPackage: "@openclaw/brave-plugin",
+        clawhubChannel: "official",
+        clawhubUrl: "https://clawhub.ai",
+      },
+    };
+    mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
+    mocks.loadPluginMetadataSnapshot.mockReturnValue({
+      plugins: [],
+      diagnostics: [
+        {
+          level: "error",
+          pluginId: "brave",
+          message:
+            "installed plugin package requires compiled runtime output for TypeScript entry index.ts: expected ./dist/index.js.",
+        },
+      ],
+    });
+    mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([
+      {
+        id: "brave",
+        label: "Brave",
+        install: {
+          npmSpec: "@openclaw/brave-plugin",
+          defaultChoice: "npm",
+        },
+        openclaw: {
+          plugin: { id: "brave", label: "Brave" },
+          webSearchProviders: [
+            {
+              id: "brave",
+              label: "Brave Search",
+              hint: "Brave Search",
+              envVars: ["BRAVE_API_KEY"],
+              placeholder: "BSA...",
+              signupUrl: "https://example.test/brave",
+            },
+          ],
+        },
+      },
+    ]);
+    mocks.installPluginFromNpmSpec.mockResolvedValueOnce({
+      ok: true,
+      pluginId: "brave",
+      targetDir: "/tmp/openclaw-plugins/brave",
+      version: "2026.5.12",
+      npmResolution: {
+        name: "@openclaw/brave-plugin",
+        version: "2026.5.12",
+        resolvedSpec: "@openclaw/brave-plugin@2026.5.12",
+        integrity: "sha512-brave",
+        resolvedAt: "2026-05-01T00:00:00.000Z",
+      },
+    });
+
+    const { repairMissingConfiguredPluginInstalls } =
+      await import("./missing-configured-plugin-install.js");
+    await repairMissingConfiguredPluginInstalls({
+      cfg: {
+        tools: {
+          web: {
+            search: {
+              provider: "brave",
+            },
+          },
+        },
+      },
+      env: {},
+    });
+
+    expect(fs.existsSync(installDir)).toBe(true);
+    expect(mocks.installPluginFromNpmSpec).toHaveBeenCalled();
+  });
+
+  it("keeps a broken official install record when replacement install fails", async () => {
+    const extensionsDir = path.join(makeTempDir(), "extensions");
+    const installDir = path.join(extensionsDir, "brave");
+    mocks.resolveDefaultPluginExtensionsDir.mockReturnValue(extensionsDir);
+    fs.mkdirSync(installDir, { recursive: true });
+    fs.writeFileSync(path.join(installDir, "package.json"), JSON.stringify({ name: "brave" }));
+    const records = {
+      brave: {
+        source: "clawhub",
+        spec: "clawhub:@openclaw/brave-plugin@2026.5.1-beta.1",
+        installPath: installDir,
+        clawhubPackage: "@openclaw/brave-plugin",
+        clawhubChannel: "official",
+        clawhubUrl: "https://clawhub.ai",
+      },
+    };
+    mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
+    mocks.loadPluginMetadataSnapshot.mockReturnValue({
+      plugins: [],
+      diagnostics: [
+        {
+          level: "error",
+          pluginId: "brave",
+          message:
+            "installed plugin package requires compiled runtime output for TypeScript entry index.ts: expected ./dist/index.js.",
+        },
+      ],
+    });
+    mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([
+      {
+        id: "brave",
+        label: "Brave",
+        install: {
+          npmSpec: "@openclaw/brave-plugin",
+          defaultChoice: "npm",
+        },
+        openclaw: {
+          plugin: { id: "brave", label: "Brave" },
+          webSearchProviders: [
+            {
+              id: "brave",
+              label: "Brave Search",
+              hint: "Brave Search",
+              envVars: ["BRAVE_API_KEY"],
+              placeholder: "BSA...",
+              signupUrl: "https://example.test/brave",
+            },
+          ],
+        },
+      },
+    ]);
+    mocks.installPluginFromNpmSpec.mockResolvedValueOnce({
+      ok: false,
+      error: "network unavailable",
+    });
+
+    const { repairMissingConfiguredPluginInstalls } =
+      await import("./missing-configured-plugin-install.js");
+    const result = await repairMissingConfiguredPluginInstalls({
+      cfg: {
+        tools: {
+          web: {
+            search: {
+              provider: "brave",
+            },
+          },
+        },
+      },
+      env: {},
+    });
+
+    expect(fs.existsSync(installDir)).toBe(true);
+    expect(mocks.writePersistedInstalledPluginIndexInstallRecords).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      changes: [],
+      warnings: [
+        `Failed to install missing configured plugin "brave" from ${expectedNpmInstallSpec("@openclaw/brave-plugin")}: network unavailable`,
+      ],
+      records,
+    });
+  });
+
+  it("does not replace a non-official install that collides with an official plugin id", async () => {
+    const extensionsDir = path.join(makeTempDir(), "extensions");
+    const installDir = path.join(extensionsDir, "brave");
+    mocks.resolveDefaultPluginExtensionsDir.mockReturnValue(extensionsDir);
+    fs.mkdirSync(installDir, { recursive: true });
+    fs.writeFileSync(path.join(installDir, "package.json"), JSON.stringify({ name: "brave" }));
+    const records = {
+      brave: {
+        source: "path",
+        sourcePath: installDir,
+        installPath: installDir,
+      },
+    };
+    mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
+    mocks.loadPluginMetadataSnapshot.mockReturnValue({
+      plugins: [],
+      diagnostics: [
+        {
+          level: "error",
+          pluginId: "brave",
+          message:
+            "installed plugin package requires compiled runtime output for TypeScript entry index.ts: expected ./dist/index.js.",
+        },
+      ],
+    });
+    mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([
+      {
+        id: "brave",
+        label: "Brave",
+        install: {
+          npmSpec: "@openclaw/brave-plugin",
+          defaultChoice: "npm",
+        },
+        openclaw: {
+          plugin: { id: "brave", label: "Brave" },
+          webSearchProviders: [
+            {
+              id: "brave",
+              label: "Brave Search",
+              hint: "Brave Search",
+              envVars: ["BRAVE_API_KEY"],
+              placeholder: "BSA...",
+              signupUrl: "https://example.test/brave",
+            },
+          ],
+        },
+      },
+    ]);
+
+    const { repairMissingConfiguredPluginInstalls } =
+      await import("./missing-configured-plugin-install.js");
+    const result = await repairMissingConfiguredPluginInstalls({
+      cfg: {
+        tools: {
+          web: {
+            search: {
+              provider: "brave",
+            },
+          },
+        },
+      },
+      env: {},
+    });
+
+    expect(fs.existsSync(installDir)).toBe(true);
+    expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
+    expect(mocks.updateNpmInstalledPlugins).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      changes: [],
+      warnings: [],
+      records,
+    });
   });
 
   it("installs a configured external web search plugin from provider-only config", async () => {

--- a/src/commands/doctor/shared/missing-configured-plugin-install.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.ts
@@ -1,4 +1,5 @@
 import { existsSync } from "node:fs";
+import { rm } from "node:fs/promises";
 import path from "node:path";
 import { collectConfiguredAgentHarnessRuntimes } from "../../../agents/harness-runtimes.js";
 import {
@@ -23,6 +24,7 @@ import {
   resolveNpmInstallSpecsForUpdateChannel,
 } from "../../../plugins/install-channel-specs.js";
 import {
+  resolveDefaultPluginNpmDir,
   resolveDefaultPluginExtensionsDir,
   resolvePluginInstallDir,
 } from "../../../plugins/install-paths.js";
@@ -85,6 +87,7 @@ const MISSING_CHANNEL_CONFIG_DESCRIPTOR_DIAGNOSTIC = "without channelConfigs met
 const REPAIRABLE_PACKAGE_ENTRY_DIAGNOSTIC_MARKERS = [
   "extension entry escapes package directory",
   "extension entry unreadable",
+  "requires compiled runtime output",
 ] as const;
 
 function shouldFallbackClawHubToNpm(result: { ok: false; code?: string }): boolean {
@@ -529,6 +532,68 @@ function collectInstalledPluginIdsWithRepairablePackageDiagnostics(params: {
   return pluginIds;
 }
 
+function isConfiguredPluginRepairTarget(params: {
+  pluginId: string;
+  configuredPluginIds: ReadonlySet<string>;
+  configuredChannelIds: ReadonlySet<string>;
+  configuredChannelOwnerPluginIds: ReadonlyMap<string, ReadonlySet<string>>;
+}): boolean {
+  if (params.configuredPluginIds.has(params.pluginId)) {
+    return true;
+  }
+  if (params.configuredChannelIds.has(params.pluginId)) {
+    return true;
+  }
+  for (const ownerIds of params.configuredChannelOwnerPluginIds.values()) {
+    if (ownerIds.has(params.pluginId)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function collectOfficialReplacementInstallCandidates(params: {
+  cfg: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  repairablePluginIds: ReadonlySet<string>;
+  configuredPluginIds: ReadonlySet<string>;
+  configuredChannelIds: ReadonlySet<string>;
+  configuredChannelOwnerPluginIds: ReadonlyMap<string, ReadonlySet<string>>;
+  blockedPluginIds?: ReadonlySet<string>;
+}): Map<string, DownloadableInstallCandidate> {
+  const repairableConfiguredPluginIds = new Set(
+    [...params.repairablePluginIds].filter((pluginId) =>
+      isConfiguredPluginRepairTarget({
+        pluginId,
+        configuredPluginIds: params.configuredPluginIds,
+        configuredChannelIds: params.configuredChannelIds,
+        configuredChannelOwnerPluginIds: params.configuredChannelOwnerPluginIds,
+      }),
+    ),
+  );
+  if (repairableConfiguredPluginIds.size === 0) {
+    return new Map();
+  }
+  const candidates = collectDownloadableInstallCandidates({
+    cfg: params.cfg,
+    env: params.env,
+    missingPluginIds: repairableConfiguredPluginIds,
+    configuredPluginIds: params.configuredPluginIds,
+    configuredChannelIds: params.configuredChannelIds,
+    configuredChannelOwnerPluginIds: params.configuredChannelOwnerPluginIds,
+    blockedPluginIds: params.blockedPluginIds,
+  });
+  return new Map(
+    candidates
+      .filter(
+        (candidate) =>
+          repairableConfiguredPluginIds.has(candidate.pluginId) &&
+          candidate.trustedSourceLinkedOfficialInstall,
+      )
+      .map((candidate) => [candidate.pluginId, candidate] as const),
+  );
+}
+
 function forceNpmInstallRecordRepair(record: PluginInstallRecord): PluginInstallRecord {
   if (record.source !== "npm") {
     return record;
@@ -549,6 +614,114 @@ function isInstalledRecordMissingOnDisk(
   }
   const resolved = resolveUserPath(installPath, env);
   return !existsSync(path.join(resolved, "package.json"));
+}
+
+function pathsEqual(left: string, right: string): boolean {
+  return path.resolve(left) === path.resolve(right);
+}
+
+function resolveNpmPackageInstallPath(params: { packageName: string; npmRoot: string }): string {
+  return path.join(params.npmRoot, "node_modules", ...params.packageName.split("/"));
+}
+
+function collectCandidateOfficialPackageNames(
+  candidate: DownloadableInstallCandidate,
+): Set<string> {
+  const names = new Set<string>();
+  const npmName = candidate.npmSpec ? parseRegistryNpmSpec(candidate.npmSpec)?.name : undefined;
+  const clawhubName = candidate.clawhubSpec
+    ? parseClawHubPluginSpec(candidate.clawhubSpec)?.name
+    : undefined;
+  if (npmName) {
+    names.add(npmName);
+  }
+  if (clawhubName) {
+    names.add(clawhubName);
+  }
+  return names;
+}
+
+function collectInstalledRecordPackageNames(record: PluginInstallRecord): Set<string> {
+  const names = new Set<string>();
+  if (record.source === "npm") {
+    const specName = record.spec ? parseRegistryNpmSpec(record.spec)?.name : undefined;
+    const resolvedSpecName = record.resolvedSpec
+      ? parseRegistryNpmSpec(record.resolvedSpec)?.name
+      : undefined;
+    for (const value of [record.resolvedName, specName, resolvedSpecName]) {
+      if (value) {
+        names.add(value);
+      }
+    }
+  }
+  if (record.source === "clawhub") {
+    const specName = record.spec ? parseClawHubPluginSpec(record.spec)?.name : undefined;
+    for (const value of [record.clawhubPackage, specName]) {
+      if (value) {
+        names.add(value);
+      }
+    }
+  }
+  return names;
+}
+
+function isTrustedOfficialInstallRecordForCandidate(params: {
+  record: PluginInstallRecord | undefined;
+  candidate: DownloadableInstallCandidate;
+}): boolean {
+  const record = params.record;
+  if (!record) {
+    return false;
+  }
+  if (record.source !== "npm" && record.source !== "clawhub") {
+    return false;
+  }
+  if (record.source === "clawhub" && record.clawhubChannel !== "official") {
+    return false;
+  }
+  const candidatePackageNames = collectCandidateOfficialPackageNames(params.candidate);
+  if (candidatePackageNames.size === 0) {
+    return false;
+  }
+  for (const installedPackageName of collectInstalledRecordPackageNames(record)) {
+    if (candidatePackageNames.has(installedPackageName)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function resolveSafeBrokenOfficialInstallRemovalPath(params: {
+  pluginId: string;
+  candidate: DownloadableInstallCandidate;
+  record: PluginInstallRecord | undefined;
+  env: NodeJS.ProcessEnv;
+}): string | null {
+  const installPath = params.record?.installPath?.trim();
+  if (!installPath) {
+    return null;
+  }
+  const resolvedInstallPath = resolveUserPath(installPath, params.env);
+  try {
+    const extensionsDir = resolveDefaultPluginExtensionsDir(params.env);
+    const expectedExtensionPath = resolvePluginInstallDir(params.pluginId, extensionsDir);
+    if (pathsEqual(resolvedInstallPath, expectedExtensionPath)) {
+      return resolvedInstallPath;
+    }
+  } catch {
+    // Ignore malformed plugin ids here; the installer will surface the real failure.
+  }
+  const parsedNpmSpec = params.candidate.npmSpec
+    ? parseRegistryNpmSpec(params.candidate.npmSpec)
+    : null;
+  if (!parsedNpmSpec?.name) {
+    return null;
+  }
+  const expectedNpmPath = resolveNpmPackageInstallPath({
+    packageName: parsedNpmSpec.name,
+    npmRoot: resolveDefaultPluginNpmDir(params.env),
+  });
+  return pathsEqual(resolvedInstallPath, expectedNpmPath) ? resolvedInstallPath : null;
 }
 
 function recordMatchesBundledPackage(
@@ -589,6 +762,7 @@ async function installCandidate(params: {
   candidate: DownloadableInstallCandidate;
   records: Record<string, PluginInstallRecord>;
   updateChannel?: UpdateChannel;
+  mode?: "install" | "update";
 }): Promise<{
   records: Record<string, PluginInstallRecord>;
   changes: string[];
@@ -616,7 +790,7 @@ async function installCandidate(params: {
       spec: clawhubInstallSpec,
       extensionsDir,
       expectedPluginId: candidate.pluginId,
-      mode: "install",
+      mode: params.mode ?? "install",
     });
     if (clawhubResult.ok) {
       const pluginId = clawhubResult.pluginId;
@@ -664,7 +838,7 @@ async function installCandidate(params: {
     ...(candidate.trustedSourceLinkedOfficialInstall
       ? { trustedSourceLinkedOfficialInstall: true }
       : {}),
-    mode: "install",
+    mode: params.mode ?? "install",
   });
   if (!result.ok) {
     return {
@@ -815,6 +989,16 @@ async function repairMissingPluginInstalls(params: {
       snapshot,
       installRecords: records,
     });
+  const officialReplacementInstallCandidates = collectOfficialReplacementInstallCandidates({
+    cfg: params.cfg,
+    env,
+    repairablePluginIds: installedPluginIdsWithRepairablePackageDiagnostics,
+    configuredPluginIds: params.pluginIds,
+    configuredChannelIds: params.channelIds,
+    configuredChannelOwnerPluginIds,
+    blockedPluginIds: params.blockedPluginIds,
+  });
+  const officialReplacementPluginIds = new Set(officialReplacementInstallCandidates.keys());
   const changes: string[] = [];
   const warnings: string[] = [];
   const deferredPluginIds = new Set<string>();
@@ -860,6 +1044,7 @@ async function repairMissingPluginInstalls(params: {
   const missingRecordedPluginIds = Object.keys(records).filter(
     (pluginId) =>
       !deferredPluginIds.has(pluginId) &&
+      !officialReplacementPluginIds.has(pluginId) &&
       Object.hasOwn(nextRecords, pluginId) &&
       !bundledPluginsById.has(pluginId) &&
       ((params.pluginIds.has(pluginId) &&
@@ -925,10 +1110,11 @@ async function repairMissingPluginInstalls(params: {
       );
     }),
   );
+  const installCandidatePluginIds = new Set([...missingPluginIds, ...officialReplacementPluginIds]);
   for (const candidate of collectDownloadableInstallCandidates({
     cfg: params.cfg,
     env,
-    missingPluginIds,
+    missingPluginIds: installCandidatePluginIds,
     configuredPluginIds: params.pluginIds,
     configuredChannelIds: params.channelIds,
     configuredChannelOwnerPluginIds,
@@ -940,16 +1126,63 @@ async function repairMissingPluginInstalls(params: {
     if (bundledPluginsById.has(candidate.pluginId)) {
       continue;
     }
+    const shouldReplaceBrokenOfficialInstall = officialReplacementPluginIds.has(candidate.pluginId);
+    if (shouldReplaceBrokenOfficialInstall && !candidate.trustedSourceLinkedOfficialInstall) {
+      continue;
+    }
+    const record = nextRecords[candidate.pluginId];
+    if (
+      shouldReplaceBrokenOfficialInstall &&
+      !isTrustedOfficialInstallRecordForCandidate({ record, candidate })
+    ) {
+      continue;
+    }
     const hasUsableRecord =
       Object.hasOwn(nextRecords, candidate.pluginId) &&
       !isInstalledRecordMissingOnDisk(nextRecords[candidate.pluginId], env);
-    if (knownIds.has(candidate.pluginId) && hasUsableRecord) {
+    if (
+      !shouldReplaceBrokenOfficialInstall &&
+      knownIds.has(candidate.pluginId) &&
+      hasUsableRecord
+    ) {
       continue;
     }
-    if (hasUsableRecord) {
+    if (!shouldReplaceBrokenOfficialInstall && hasUsableRecord) {
       continue;
     }
-    const installed = await installCandidate({ candidate, records: nextRecords, updateChannel });
+    const removalPath = shouldReplaceBrokenOfficialInstall
+      ? resolveSafeBrokenOfficialInstallRemovalPath({
+          pluginId: candidate.pluginId,
+          candidate,
+          record,
+          env,
+        })
+      : null;
+    const previousRecords = nextRecords;
+    const installed = await installCandidate({
+      candidate,
+      records: nextRecords,
+      updateChannel,
+      mode: shouldReplaceBrokenOfficialInstall ? "update" : "install",
+    });
+    if (shouldReplaceBrokenOfficialInstall) {
+      const installedRecord = installed.records[candidate.pluginId];
+      const replacementSucceeded = installed.records !== previousRecords;
+      if (
+        replacementSucceeded &&
+        removalPath &&
+        (!installedRecord?.installPath ||
+          !pathsEqual(resolveUserPath(installedRecord.installPath, env), removalPath))
+      ) {
+        try {
+          await rm(removalPath, { recursive: true, force: true });
+        } catch (error) {
+          warnings.push(
+            `Failed to remove broken installed plugin "${candidate.pluginId}" at ${removalPath}: ${String(error)}`,
+          );
+        }
+      }
+    }
     nextRecords = installed.records;
     changes.push(...installed.changes);
     warnings.push(...installed.warnings);

--- a/src/plugins/official-external-plugin-catalog.test.ts
+++ b/src/plugins/official-external-plugin-catalog.test.ts
@@ -44,6 +44,21 @@ describe("official external plugin catalog", () => {
     );
   });
 
+  it("allows invalid-config recovery for externalized stock plugins", () => {
+    expect(resolveOfficialExternalPluginInstall(expectCatalogEntry("brave"))).toMatchObject({
+      npmSpec: "@openclaw/brave-plugin",
+      allowInvalidConfigRecovery: true,
+    });
+    expect(resolveOfficialExternalPluginInstall(expectCatalogEntry("slack"))).toMatchObject({
+      npmSpec: "@openclaw/slack",
+      allowInvalidConfigRecovery: true,
+    });
+    expect(resolveOfficialExternalPluginInstall(expectCatalogEntry("discord"))).toMatchObject({
+      npmSpec: "@openclaw/discord",
+      allowInvalidConfigRecovery: true,
+    });
+  });
+
   it("lists Matrix as an official external ClawHub channel after cutover", () => {
     const ids = new Set<string>();
     for (const entry of listOfficialExternalPluginCatalogEntries()) {


### PR DESCRIPTION
Summary
- Repairs configured official external plugin installs when the installed package only contains TypeScript source and no compiled runtime output.
- Allows invalid-config reinstall recovery for externalized stock Brave and Slack installs.
- Adds catalog metadata and regression coverage for Brave web search and Slack channel repair paths, including provenance and failure-preservation cases.

Verification
- `node scripts/run-vitest.mjs src/commands/doctor/shared/missing-configured-plugin-install.test.ts src/cli/plugins-install-config.test.ts src/cli/program/preaction.test.ts src/plugins/official-external-plugin-catalog.test.ts`
- Packaged local E2E with a real packed `openclaw-2026.5.16.tgz` installed into an isolated prefix, seeded source-only official Brave install, `openclaw doctor --fix --non-interactive`, post-repair `openclaw config validate`, and install-record assertions.
- AWS Crabbox packaged E2E: run `run_c1bef99ee105`, lease `cbx_b51c44bf1af6` (`harbor-prawn`), exit `0`.
- `env CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_TEST_PROJECTS_PARALLEL=6 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 pnpm check:changed`

Behavior addressed: `openclaw doctor --fix` now replaces broken source-only official Brave/Slack installs from trusted official install metadata when the configured plugin/channel still needs that owner.
Real environment tested: AWS Crabbox Linux host using the rebased feature branch, with a freshly packed `openclaw-2026.5.16.tgz` installed into an isolated npm prefix and isolated `HOME`, `OPENCLAW_HOME`, `OPENCLAW_STATE_DIR`, and `OPENCLAW_CONFIG_PATH`.
Exact steps or command run after this patch: installed Node 22/pnpm on the AWS host, ran `pnpm install --frozen-lockfile`, packed the checkout, installed the packed CLI, seeded a tracked source-only `brave` package install with `openclaw.extensions` pointing at `src/index.ts`, ran `openclaw doctor --fix --non-interactive`, then ran `openclaw config validate` and inspected `.openclaw/plugins/installs.json`.
Evidence after fix: doctor output included the compiled-runtime diagnostic and `Installed missing configured plugin "brave" from @openclaw/brave-plugin.`; the repaired record is `source: npm`, `spec: @openclaw/brave-plugin`, `resolvedName: @openclaw/brave-plugin`, version `2026.5.12`, with `dist/index.js` present.
Observed result after fix: the source-only install path was removed, the official npm package was installed, post-repair config validation passed, and the AWS Crabbox command exited `0`.
What was not tested: live Brave Search API calls; this validates install/config/doctor recovery and plugin runtime payload repair, not provider credentialed search execution.

Fixes #82301
