### PR TITLE
fix(mcp): forward host AbortSignal to plugin tools execute (#82424)

### DIFF
--- a/src/mcp/plugin-tools-handlers.signal.test.ts
+++ b/src/mcp/plugin-tools-handlers.signal.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import type { AnyAgentTool } from "../agents/tools/common.js";
+import { createPluginToolsMcpHandlers } from "./plugin-tools-handlers.js";
+
+function buildSignalProbeTool(): {
+  tool: AnyAgentTool;
+  observed: { signalDefined: boolean; abortObserved: boolean; signalAbortedAtEnd: boolean };
+} {
+  const observed = {
+    signalDefined: false,
+    abortObserved: false,
+    signalAbortedAtEnd: false,
+  };
+  const tool = {
+    name: "probe-cancel",
+    description: "echoes whether the host AbortSignal was received",
+    parameters: { type: "object", properties: {} },
+    execute: async (
+      _toolCallId: string,
+      _params: unknown,
+      signal?: AbortSignal,
+    ): Promise<{ content: Array<{ type: "text"; text: string }> }> => {
+      observed.signalDefined = signal !== undefined;
+      if (signal) {
+        const onAbort = () => {
+          observed.abortObserved = true;
+        };
+        signal.addEventListener("abort", onAbort, { once: true });
+        await new Promise<void>((resolve) => {
+          if (signal.aborted) {
+            resolve();
+            return;
+          }
+          signal.addEventListener("abort", () => resolve(), { once: true });
+          setTimeout(resolve, 50);
+        });
+        signal.removeEventListener("abort", onAbort);
+        observed.signalAbortedAtEnd = signal.aborted;
+      }
+      return { content: [{ type: "text", text: "ok" }] };
+    },
+  } as unknown as AnyAgentTool;
+  return { tool, observed };
+}
+
+describe("plugin tools MCP handlers forward AbortSignal (#82424)", () => {
+  it("invokes tool.execute with a defined AbortSignal", async () => {
+    const { tool, observed } = buildSignalProbeTool();
+    const handlers = createPluginToolsMcpHandlers([tool]);
+
+    const controller = new AbortController();
+    await handlers.callTool({ name: "probe-cancel", arguments: {} }, { signal: controller.signal });
+
+    expect(observed.signalDefined).toBe(true);
+  });
+
+  it("propagates abort() to the in-flight tool", async () => {
+    const { tool, observed } = buildSignalProbeTool();
+    const handlers = createPluginToolsMcpHandlers([tool]);
+
+    const controller = new AbortController();
+    const pending = handlers.callTool(
+      { name: "probe-cancel", arguments: {} },
+      { signal: controller.signal },
+    );
+    setTimeout(() => controller.abort(), 10);
+    await pending;
+
+    expect(observed.abortObserved).toBe(true);
+    expect(observed.signalAbortedAtEnd).toBe(true);
+  });
+
+  it("works without a signal (backward compatibility)", async () => {
+    const { tool, observed } = buildSignalProbeTool();
+    const handlers = createPluginToolsMcpHandlers([tool]);
+
+    await handlers.callTool({ name: "probe-cancel", arguments: {} });
+
+    expect(observed.signalDefined).toBe(false);
+  });
+});

--- a/src/mcp/plugin-tools-handlers.ts
+++ b/src/mcp/plugin-tools-handlers.ts
@@ -11,6 +11,10 @@ type CallPluginToolParams = {
   arguments?: unknown;
 };
 
+type CallPluginToolOptions = {
+  signal?: AbortSignal;
+};
+
 function resolveJsonSchemaForTool(tool: AnyAgentTool): Record<string, unknown> {
   const params = tool.parameters;
   if (params && typeof params === "object" && "type" in params) {
@@ -42,7 +46,7 @@ export function createPluginToolsMcpHandlers(tools: AnyAgentTool[]) {
         inputSchema: resolveJsonSchemaForTool(tool),
       })),
     }),
-    callTool: async (params: CallPluginToolParams) => {
+    callTool: async (params: CallPluginToolParams, options?: CallPluginToolOptions) => {
       const tool = toolMap.get(params.name);
       if (!tool) {
         return {
@@ -51,7 +55,13 @@ export function createPluginToolsMcpHandlers(tools: AnyAgentTool[]) {
         };
       }
       try {
-        const result = await tool.execute(`mcp-${Date.now()}`, params.arguments ?? {});
+        // Propagate the MCP SDK's per-request AbortSignal so tools can observe
+        // host-side cancellation (notifications/cancelled or transport close).
+        const result = await tool.execute(
+          `mcp-${Date.now()}`,
+          params.arguments ?? {},
+          options?.signal,
+        );
         const rawContent =
           result && typeof result === "object" && "content" in result
             ? (result as { content?: unknown }).content

--- a/src/mcp/tools-stdio-server.ts
+++ b/src/mcp/tools-stdio-server.ts
@@ -14,8 +14,10 @@ export function createToolsMcpServer(params: { name: string; tools: AnyAgentTool
   );
 
   server.setRequestHandler(ListToolsRequestSchema, handlers.listTools);
-  server.setRequestHandler(CallToolRequestSchema, async (request) => {
-    return await handlers.callTool(request.params);
+  server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
+    // Forward the SDK's per-request AbortSignal so in-flight tool.execute can
+    // observe notifications/cancelled and transport close from the host.
+    return await handlers.callTool(request.params, { signal: extra?.signal });
   });
 
   return server;


### PR DESCRIPTION
## Real behavior proof

- **Behavior or issue addressed:** The standalone plugin-tools MCP server (`createToolsMcpServer` + `createPluginToolsMcpHandlers`) dropped the SDK's per-request `RequestHandlerExtra.signal`, so `tool.execute` could not observe host-side cancellation via `notifications/cancelled` or stdio transport close. The probe harness in the issue records `signalDefined: false` and `abortObserved: false` against `upstream/main` at `3b663ad1c1`. Fixes #82424.
- **Root cause:** `src/mcp/tools-stdio-server.ts:17-19` registers `setRequestHandler(CallToolRequestSchema, async (request) => …)` without binding `extra`, and `src/mcp/plugin-tools-handlers.ts:54` calls `tool.execute(toolCallId, args)` with no third argument. The `AnyAgentTool` contract at `src/agents/tools/common.ts:22-28` already documents an optional `signal?: AbortSignal` parameter, so the wiring gap is purely on the server side.
- **Fix surface:**
  - `src/mcp/tools-stdio-server.ts` — accept `extra` from the MCP SDK and pass `{ signal: extra?.signal }` to `handlers.callTool`.
  - `src/mcp/plugin-tools-handlers.ts` — accept an optional `{ signal }` argument and forward it as the third positional parameter to `tool.execute`.
- **Existing-helper check (vincentkoc #57341):** No new helper introduced. The existing `AnyAgentTool.execute(toolCallId, params, signal?, onUpdate?)` contract is reused exactly as documented.
- **Shared-helper caller check (steipete #60623):** `createPluginToolsMcpHandlers` is called from `tools-stdio-server.ts`, `openclaw-tools-serve.test.ts`, and `plugin-tools-serve.test.ts`. The new `options` parameter is optional and defaults to `undefined` → all existing call sites (including the no-signal owner-only-cron test) keep working unchanged. The single hot caller (`tools-stdio-server.ts`) is updated to thread the signal.
- **Broader-fix rival scan (steipete #68270):** No rival PR open on this surface as of cycle start. The fix is narrowly scoped to two files plus a regression test; broader cancellation work (e.g. per-tool cancellation propagation to spawned children) is out of scope for this issue.
- **Live verification:** Added `src/mcp/plugin-tools-handlers.signal.test.ts` with 3 focused cases that mirror the issue's probe harness:
  - `tool.execute` receives a defined `AbortSignal`,
  - `controller.abort()` mid-flight propagates and `signal.aborted` is `true` on the tool side,
  - no-signal call still works (backward compatibility for non-MCP callers).
- **Backward compatibility:** `callTool`'s second argument and `tool.execute`'s third argument are both optional. Tools that ignore the signal continue to work; tools that already use the signal now actually receive it.