### PR TITLE
test(acpx): cover built MCP server config

### DIFF
--- a/extensions/acpx/src/config.test.ts
+++ b/extensions/acpx/src/config.test.ts
@@ -1,14 +1,60 @@
 import fs from "node:fs";
 import { createRequire } from "node:module";
+import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 import { resolveAcpxPluginConfig, resolveAcpxPluginRoot } from "./config.js";
 
 const requireFromTest = createRequire(import.meta.url);
 const TSX_IMPORT = requireFromTest.resolve("tsx");
 
-function expectedSourceMcpServerArgs(entrypoint: string): string[] {
-  return ["--import", TSX_IMPORT, path.resolve(entrypoint)];
+type TestOpenClawLayout = {
+  moduleUrl: string;
+  openClawRoot: string;
+  pluginToolsDistEntry: string;
+  openClawToolsDistEntry: string;
+};
+
+function expectedSourceMcpServerArgs(openClawRoot: string, entrypoint: string): string[] {
+  return ["--import", TSX_IMPORT, path.join(openClawRoot, entrypoint)];
+}
+
+function withTestOpenClawLayout<T>(
+  run: (layout: TestOpenClawLayout) => T,
+  options: { builtMcpEntries?: Array<"plugin-tools" | "openclaw-tools"> } = {},
+): T {
+  const openClawRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-acpx-config-"));
+  const pluginRoot = path.join(openClawRoot, "extensions", "acpx");
+  fs.mkdirSync(path.join(pluginRoot, "src"), { recursive: true });
+  fs.writeFileSync(path.join(pluginRoot, "openclaw.plugin.json"), "{}");
+  fs.writeFileSync(path.join(pluginRoot, "package.json"), "{}");
+
+  const pluginToolsDistEntry = path.join(openClawRoot, "dist", "mcp", "plugin-tools-serve.js");
+  const openClawToolsDistEntry = path.join(openClawRoot, "dist", "mcp", "openclaw-tools-serve.js");
+  const distEntries = new Map([
+    ["plugin-tools", pluginToolsDistEntry],
+    ["openclaw-tools", openClawToolsDistEntry],
+  ] as const);
+  for (const entryName of options?.builtMcpEntries ?? []) {
+    const entry = distEntries.get(entryName);
+    if (!entry) {
+      continue;
+    }
+    fs.mkdirSync(path.dirname(entry), { recursive: true });
+    fs.writeFileSync(entry, "");
+  }
+
+  try {
+    return run({
+      moduleUrl: pathToFileURL(path.join(pluginRoot, "src", "config.js")).href,
+      openClawRoot,
+      pluginToolsDistEntry,
+      openClawToolsDistEntry,
+    });
+  } finally {
+    fs.rmSync(openClawRoot, { recursive: true, force: true });
+  }
 }
 
 describe("embedded acpx plugin config", () => {
@@ -154,33 +200,81 @@ describe("embedded acpx plugin config", () => {
   });
 
   it("injects the built-in plugin-tools MCP server only when explicitly enabled", () => {
-    const resolved = resolveAcpxPluginConfig({
-      rawConfig: {
-        pluginToolsMcpBridge: true,
-      },
-      workspaceDir: "/tmp/openclaw-acpx",
-    });
+    withTestOpenClawLayout(({ moduleUrl, openClawRoot }) => {
+      const resolved = resolveAcpxPluginConfig({
+        rawConfig: {
+          pluginToolsMcpBridge: true,
+        },
+        workspaceDir: "/tmp/openclaw-acpx",
+        moduleUrl,
+      });
 
-    const server = resolved.mcpServers["openclaw-plugin-tools"];
-    expect(server).toEqual({
-      command: process.execPath,
-      args: expectedSourceMcpServerArgs("src/mcp/plugin-tools-serve.ts"),
+      const server = resolved.mcpServers["openclaw-plugin-tools"];
+      expect(server).toEqual({
+        command: process.execPath,
+        args: expectedSourceMcpServerArgs(openClawRoot, "src/mcp/plugin-tools-serve.ts"),
+      });
     });
   });
 
-  it("injects the built-in OpenClaw tools MCP server only when explicitly enabled", () => {
-    const resolved = resolveAcpxPluginConfig({
-      rawConfig: {
-        openClawToolsMcpBridge: true,
-      },
-      workspaceDir: "/tmp/openclaw-acpx",
-    });
+  it("uses the built plugin-tools MCP server when the dist entry exists", () => {
+    withTestOpenClawLayout(
+      ({ moduleUrl, pluginToolsDistEntry }) => {
+        const resolved = resolveAcpxPluginConfig({
+          rawConfig: {
+            pluginToolsMcpBridge: true,
+          },
+          workspaceDir: "/tmp/openclaw-acpx",
+          moduleUrl,
+        });
 
-    const server = resolved.mcpServers["openclaw-tools"];
-    expect(server).toEqual({
-      command: process.execPath,
-      args: expectedSourceMcpServerArgs("src/mcp/openclaw-tools-serve.ts"),
+        const server = resolved.mcpServers["openclaw-plugin-tools"];
+        expect(server).toEqual({
+          command: process.execPath,
+          args: [pluginToolsDistEntry],
+        });
+      },
+      { builtMcpEntries: ["plugin-tools"] },
+    );
+  });
+
+  it("injects the built-in OpenClaw tools MCP server only when explicitly enabled", () => {
+    withTestOpenClawLayout(({ moduleUrl, openClawRoot }) => {
+      const resolved = resolveAcpxPluginConfig({
+        rawConfig: {
+          openClawToolsMcpBridge: true,
+        },
+        workspaceDir: "/tmp/openclaw-acpx",
+        moduleUrl,
+      });
+
+      const server = resolved.mcpServers["openclaw-tools"];
+      expect(server).toEqual({
+        command: process.execPath,
+        args: expectedSourceMcpServerArgs(openClawRoot, "src/mcp/openclaw-tools-serve.ts"),
+      });
     });
+  });
+
+  it("uses the built OpenClaw tools MCP server when the dist entry exists", () => {
+    withTestOpenClawLayout(
+      ({ moduleUrl, openClawToolsDistEntry }) => {
+        const resolved = resolveAcpxPluginConfig({
+          rawConfig: {
+            openClawToolsMcpBridge: true,
+          },
+          workspaceDir: "/tmp/openclaw-acpx",
+          moduleUrl,
+        });
+
+        const server = resolved.mcpServers["openclaw-tools"];
+        expect(server).toEqual({
+          command: process.execPath,
+          args: [openClawToolsDistEntry],
+        });
+      },
+      { builtMcpEntries: ["openclaw-tools"] },
+    );
   });
 
   it("resolves the plugin root from shared dist chunk paths", () => {

--- a/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
@@ -829,7 +829,7 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
       }
       const firstContent = message.content[0];
       return typeof firstContent === "object" && firstContent !== null && "text" in firstContent
-        ? String(firstContent.text)
+        ? firstContent.text
         : "";
     });
     expect(retryAssembleMessageTexts).toEqual(["successor compacted context"]);


### PR DESCRIPTION
## Summary

- Problem: the ACPX config test always expected the source `tsx` MCP server entry, but the resolver intentionally prefers `dist/mcp/*.js` when built entries exist.
- Why it matters: this made `extensions/acpx/src/config.test.ts` environment-sensitive and matches the failure tracked in #80431.
- What changed: the ACPX test now builds a temporary OpenClaw layout and verifies both source fallback and dist-present MCP server resolution.
- CI unblock note: current `main` also had a redundant `String(firstContent.text)` in `extensions/codex/src/app-server/run-attempt.context-engine.test.ts` that failed `check-lint`; this PR removes that no-op conversion in a separate commit.
- What did NOT change: no ACPX runtime behavior, manifest schema, config defaults, bundled MCP server code, or Codex app behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #80431
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: ACPX config coverage now matches the resolver contract for both source fallback and built `dist/mcp/*.js` MCP server entries.
- Real environment tested: native Windows PowerShell checkout on branch `dev/vino/acpx-mcp-server-config-test`, Node `v24.13.0`, Corepack `pnpm@11.1.0`.
- Exact steps or command run after this patch: `node --import tsx --input-type=module` direct ACPX config resolver probe; `node scripts/run-vitest.mjs extensions/acpx/src/config.test.ts`; `corepack pnpm exec oxfmt --check --threads=1 extensions/acpx/src/config.test.ts extensions/codex/src/app-server/run-attempt.context-engine.test.ts`; `node scripts/run-oxlint-shards.mjs --threads=8`; `git diff --check`; `codex review --uncommitted`.
- Evidence after fix: copied console output from the direct `node --import tsx --input-type=module` ACPX resolver probe:

```text
source: {"command":"C:\\Program Files\\nodejs\\node.exe","args":["--import","C:\\Users\\vinot\\code\\openclaw\\node_modules\\tsx\\dist\\loader.mjs","C:\\Users\\vinot\\AppData\\Local\\Temp\\openclaw-acpx-proof-source-lSNpLj\\src\\mcp\\plugin-tools-serve.ts"]}
dist: {"command":"C:\\Program Files\\nodejs\\node.exe","args":["C:\\Users\\vinot\\AppData\\Local\\Temp\\openclaw-acpx-proof-dist-zch1c1\\dist\\mcp\\plugin-tools-serve.js"]}
```

Focused ACPX Vitest output reported `Test Files 1 passed (1)` and `Tests 16 passed (16)`; oxfmt reported `All matched files use the correct format`; `node scripts/run-oxlint-shards.mjs --threads=8` reported `Found 0 warnings and 0 errors` for core, extensions, and scripts; `git diff --check` produced no output; Codex review reported no actionable correctness issue.
- Observed result after fix: the real resolver probe selected the source `tsx` entry without a dist artifact and the built `dist/mcp/plugin-tools-serve.js` entry when that artifact existed; the matching ACPX config test passes with hermetic fixtures for both paths; the CI-equivalent oxlint shard no longer reports the redundant Codex test conversion.
- What was not tested: full `pnpm test extensions/acpx`, live ACPX runtime, packaged build output, and a local Windows pass of the Codex context-engine test file. The Codex line is a lint-only no-op conversion cleanup, and CI Linux checks are the intended proof for that file.
- Before evidence (optional but encouraged): issue #80431 includes the failing output where the test expected `node --import ... src/mcp/plugin-tools-serve.ts` while the resolver returned `node ... dist/mcp/plugin-tools-serve.js`; the PR's first CI run showed `check-lint` failing on `typescript(no-unnecessary-type-conversion)` for `String(firstContent.text)`.

## Root Cause (if applicable)

- Root cause: the ACPX test asserted the source MCP server entry unconditionally, while `resolvePluginToolsMcpServerConfig` and the matching OpenClaw tools resolver intentionally prefer built dist entries when those files exist.
- Missing detection / guardrail: there was no test fixture for the dist-present path, so the suite depended on whether the local checkout had build artifacts.
- Contributing context (if known): the failure was reported from a broad local rerun where `dist/mcp/plugin-tools-serve.js` existed.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/acpx/src/config.test.ts`
- Scenario the test should lock in: ACPX MCP bridge config resolves source entries when dist entries are absent and built entries when dist entries exist.
- Why this is the smallest reliable guardrail: it exercises the resolver through `resolveAcpxPluginConfig` without requiring a real build artifact in the checkout.
- Existing test that already covers this (if any): the previous test covered only the source expectation and was environment-sensitive.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows, native PowerShell
- Runtime/container: Node `v24.13.0`, Corepack `pnpm@11.1.0`
- Model/provider: N/A
- Integration/channel (if any): ACPX plugin config tests
- Relevant config (redacted): N/A

### Steps

1. Install dependencies with `corepack pnpm install` after `pnpm` was not present on PATH.
2. Run a direct `node --import tsx --input-type=module` ACPX resolver probe for source and dist layouts.
3. Run `node scripts/run-vitest.mjs extensions/acpx/src/config.test.ts`.
4. Run `corepack pnpm exec oxfmt --check --threads=1 extensions/acpx/src/config.test.ts extensions/codex/src/app-server/run-attempt.context-engine.test.ts`.
5. Run `node scripts/run-oxlint-shards.mjs --threads=8`.
6. Run `git diff --check`.
7. Run `codex review --uncommitted`.

### Expected

- The ACPX config resolver and test cover source fallback and built MCP server entries without depending on existing checkout build artifacts.
- The inherited Codex test helper does not contain a no-op type conversion that fails oxlint.

### Actual

- The direct resolver probe printed source and dist outputs for the expected paths, `extensions/acpx/src/config.test.ts` passed with 16 tests, formatting passed, and oxlint passed across the same core/extensions/scripts shards used by CI.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: plugin-tools MCP source fallback, plugin-tools MCP built dist selection, OpenClaw tools MCP source fallback, and OpenClaw tools MCP built dist selection via `resolveAcpxPluginConfig`.
- Edge cases checked: temporary layout cleanup runs in `finally`; no real checkout `dist` files are required for the tests.
- What you did **not** verify: full ACPX extension suite, live ACPX process startup, package build, or a local Windows pass of the Codex context-engine test file.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No bot review conversations existed for this PR before creation.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.