### PR TITLE
fix: broadcast tool result transcript updates

### DIFF
--- a/src/agents/session-tool-result-guard.transcript-events.test.ts
+++ b/src/agents/session-tool-result-guard.transcript-events.test.ts
@@ -166,7 +166,59 @@ describe("guardSessionManager transcript updates", () => {
     } as AgentMessage);
 
     expect(getBranchSpy).toHaveBeenCalledTimes(1);
-    expect(updates.map((update) => update.messageSeq)).toEqual([2, 4]);
+    expect(updates.map((update) => update.messageSeq)).toEqual([2, 3, 4]);
+    expect(updates.map((update) => (update.message as { role?: string }).role)).toEqual([
+      "assistant",
+      "toolResult",
+      "assistant",
+    ]);
     getBranchSpy.mockRestore();
+  });
+
+  it("broadcasts synthetic tool result messages flushed before assistant text", () => {
+    const updates: SessionTranscriptUpdate[] = [];
+    listeners.push(onSessionTranscriptUpdate((update) => updates.push(update)));
+
+    const sm = SessionManager.inMemory();
+    const sessionFile = "/tmp/openclaw-session-message-events.jsonl";
+    Object.assign(sm, {
+      getSessionFile: () => sessionFile,
+    });
+
+    const guarded = guardSessionManager(sm, {
+      agentId: "main",
+      sessionKey: "agent:main:worker",
+    });
+    const appendMessage = guarded.appendMessage.bind(guarded) as unknown as (
+      message: AgentMessage,
+    ) => void;
+
+    appendMessage({
+      role: "assistant",
+      content: [{ type: "toolCall", id: "call_missing", name: "read", arguments: {} }],
+      timestamp: Date.now(),
+    } as AgentMessage);
+    appendMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "final after missing result" }],
+      timestamp: Date.now(),
+    } as AgentMessage);
+
+    expect(updates.map((update) => (update.message as { role?: string }).role)).toEqual([
+      "assistant",
+      "toolResult",
+      "assistant",
+    ]);
+    expect(updates[1]).toMatchObject({
+      sessionFile,
+      sessionKey: "agent:main:worker",
+      message: {
+        role: "toolResult",
+        toolCallId: "call_missing",
+        toolName: "read",
+      },
+      messageId: expect.any(String),
+      messageSeq: 2,
+    });
   });
 });

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -609,6 +609,19 @@ export function installSessionToolResultGuard(
       }),
     };
   };
+  const appendMessageAndEmitTranscriptUpdate = (message: AgentMessage): string => {
+    const { entryId, messageSeq, sessionFile } = appendMessageAndCacheTranscriptSeq(message);
+    if (sessionFile) {
+      emitSessionTranscriptUpdate({
+        sessionFile,
+        sessionKey: opts?.sessionKey,
+        message,
+        messageId: entryId,
+        ...(messageSeq !== undefined ? { messageSeq } : {}),
+      });
+    }
+    return entryId;
+  };
 
   /**
    * Run the before_message_write hook. Returns the (possibly modified) message,
@@ -647,7 +660,7 @@ export function installSessionToolResultGuard(
           }),
         );
         if (flushed) {
-          appendMessageAndCacheTranscriptSeq(
+          appendMessageAndEmitTranscriptUpdate(
             capToolResultForPersistence(flushed, maxToolResultChars, redactionConfig),
           );
         }
@@ -701,9 +714,9 @@ export function installSessionToolResultGuard(
       if (!persisted) {
         return undefined;
       }
-      return appendMessageAndCacheTranscriptSeq(
+      return appendMessageAndEmitTranscriptUpdate(
         capToolResultForPersistence(persisted, maxToolResultChars, redactionConfig),
-      ).entryId;
+      );
     }
 
     // Skip tool call extraction for aborted/errored assistant messages.
@@ -755,20 +768,7 @@ export function installSessionToolResultGuard(
       suppressNextUserMessagePersistence = false;
       return undefined;
     }
-    const {
-      entryId: result,
-      messageSeq,
-      sessionFile,
-    } = appendMessageAndCacheTranscriptSeq(finalMessage);
-    if (sessionFile) {
-      emitSessionTranscriptUpdate({
-        sessionFile,
-        sessionKey: opts?.sessionKey,
-        message: finalMessage,
-        messageId: typeof result === "string" ? result : undefined,
-        ...(messageSeq !== undefined ? { messageSeq } : {}),
-      });
-    }
+    const result = appendMessageAndEmitTranscriptUpdate(finalMessage);
 
     if (toolCalls.length > 0) {
       pendingState.trackToolCalls(toolCalls);


### PR DESCRIPTION
## Summary

- Problem: `toolResult` messages were persisted to session JSONL but did not emit transcript update events.
- Why it matters: Realtime clients could see tool calls start, but miss completion updates until session history was reloaded.
- What changed: Real and synthetic `toolResult` persistence now uses the same append + transcript update path as other transcript messages.
- What did NOT change (scope boundary): No tool execution behavior, transcript schema, auth, network routing, or UI rendering behavior was changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Tool result messages were not emitted as realtime transcript updates after being written to the session transcript.
- Real environment tested: Local OpenClaw source checkout on macOS, Node.js project dependencies installed with pnpm.
- Exact steps or command run after this patch:
```bash
pnpm exec vitest run --config test/vitest/vitest.agents-core.config.ts src/agents/session-tool-result-guard.transcript-events.test.ts
```
- Evidence after fix:

```text
✓ agents-core src/agents/session-tool-result-guard.transcript-events.test.ts (5 tests) 23ms

Test Files  1 passed (1)
Tests       5 passed (5)
```
- Observed result after fix: The regression test now observes transcript updates for real `toolResult` messages and synthetic flushed `toolResult` messages.
- What was not tested: A full mobile/remote realtime client flow against this exact branch was not tested.
- Before evidence (optional but encouraged): Before this change, the existing test expected sequence updates `[2, 4]`, showing the persisted real `toolResult` at sequence `3` was not broadcast.

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: The `toolResult` append paths called the raw append helper and cached transcript sequence state, but skipped `emitSessionTranscriptUpdate`.
- Missing detection / guardrail: Existing transcript update tests covered non-tool messages and sequence caching, but did not assert that persisted `toolResult` entries are broadcast.
- Contributing context (if known): Reloading history still showed the tool result because it was persisted correctly, which hid the realtime broadcast gap.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/session-tool-result-guard.transcript-events.test.ts`
- Scenario the test should lock in: Real and synthetic `toolResult` messages emit transcript update events with the expected message role and transcript sequence.
- Why this is the smallest reliable guardrail: The bug is in the session manager append/broadcast layer, so testing that layer directly catches the regression without requiring a full gateway/client setup.
- Existing test that already covers this (if any): Existing tests covered non-tool transcript updates and sequence caching, but not `toolResult` broadcasts.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Realtime clients can receive tool completion transcript updates without requiring a session history reload.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[tool result persisted] -> [session JSONL updated] -> [no realtime transcript event]

After:
[tool result persisted] -> [session JSONL updated] -> [session.message transcript event] -> [realtime clients update]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Local Node.js checkout with pnpm dependencies
- Model/provider: N/A
- Integration/channel (if any): Session transcript realtime update path
- Relevant config (redacted): N/A

### Steps

1. Append an assistant message containing a tool call through a guarded session manager.
2. Append a matching `toolResult`.
3. Observe transcript update listener events.
4. Repeat with a missing tool result so the guard flushes a synthetic `toolResult`.

### Expected

- Real `toolResult` messages emit transcript update events.
- Synthetic flushed `toolResult` messages emit transcript update events.
- Transcript sequence numbers remain contiguous.

### Actual

- Matches expected after this patch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```text
pnpm exec vitest run --config test/vitest/vitest.agents-core.config.ts src/agents/session-tool-result-guard.transcript-events.test.ts

✓ src/agents/session-tool-result-guard.transcript-events.test.ts (5 tests)
Test Files  1 passed (1)
Tests       5 passed (5)
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Real `toolResult` append emits a transcript update.
  - Synthetic missing `toolResult` flush emits a transcript update.
  - Transcript sequence numbers include tool results and remain ordered.
- Edge cases checked:
  - Existing no-session-file case still avoids sequence resolution.
  - Existing consecutive-message sequence cache behavior remains covered.
- What you did **not** verify:
  - Full mobile/remote UI realtime rendering against this branch.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Realtime listeners will now receive additional `toolResult` transcript events that were previously only visible after history reload.
  - Mitigation: These events represent already-persisted transcript messages and use the same transcript update shape as other messages, including `messageId` and `messageSeq`.

