### PR TITLE
fix(config): warn for missing official memory slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ Docs: https://docs.openclaw.ai
 - Voice calls: persist rejected inbound-call replay keys so duplicate carrier webhook retries stay ignored after a Gateway restart.
 - Config/doctor: copy fallback-enabled channel `allowFrom` entries into explicit `groupAllowFrom` allowlists during `openclaw doctor --fix`, preserving current group access without adding runtime fallback-transition flags.
 - Config/doctor: replace source-only official Brave and Slack plugin installs from trusted catalog metadata during `openclaw doctor --fix`, unblocking externalized stock plugin recovery after upgrade. (#82425) Thanks @joshavant.
+- Config/memory: warn instead of rejecting configs that select the official external `memory-lancedb` slot before the plugin is installed, with an explicit no-persistent-memory startup warning and install hint. Fixes #82428. (#82438) Thanks @giodl73-repo.
 - Agents/bootstrap: ignore stale completed root `BOOTSTRAP.md` context after workspace setup cleanup fails, preventing channel agent turns from treating it as a directory. (#82463) Thanks @joshavant.
 - Update/doctor: re-enable the Codex plugin during `openclaw doctor --fix` when configured OpenAI agent models require the Codex runtime, preventing upgraded configs from failing with an unregistered Codex harness. Fixes #82368. (#82502) Thanks @joshavant.
 - Configure: show one OpenAI provider entry with ChatGPT/Codex sign-in and API key choices, and keep browsed Codex models in the saved `/model` picker allowlist.

--- a/docs/plugins/memory-lancedb.md
+++ b/docs/plugins/memory-lancedb.md
@@ -1,20 +1,32 @@
 ---
-summary: "Configure the bundled LanceDB memory plugin, including local Ollama-compatible embeddings"
+summary: "Configure the official external LanceDB memory plugin, including local Ollama-compatible embeddings"
 read_when:
-  - You are configuring the bundled memory-lancedb plugin
+  - You are configuring the memory-lancedb plugin
   - You want LanceDB-backed long-term memory with auto-recall or auto-capture
   - You are using local OpenAI-compatible embeddings such as Ollama
 title: "Memory LanceDB"
 sidebarTitle: "Memory LanceDB"
 ---
 
-`memory-lancedb` is a bundled memory plugin that stores long-term memory in
+`memory-lancedb` is an official external memory plugin that stores long-term memory in
 LanceDB and uses embeddings for recall. It can automatically recall relevant
 memories before a model turn and capture important facts after a response.
 
 Use it when you want a local vector database for memory, need an
 OpenAI-compatible embedding endpoint, or want to keep a memory database outside
 the default built-in memory store.
+
+## Installation
+
+Install `memory-lancedb` before setting `plugins.slots.memory = "memory-lancedb"`:
+
+```bash
+openclaw plugins install @openclaw/memory-lancedb
+```
+
+The plugin is published to npm and is not bundled into the OpenClaw runtime image.
+The installer writes the plugin entry and switches the memory slot when no other
+plugin owns it.
 
 <Note>
 `memory-lancedb` is an active memory plugin. Enable it by selecting the memory

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -330,6 +330,33 @@ describe("config plugin validation", () => {
     ).toBe(false);
   });
 
+  it("warns instead of failing when an official external memory slot plugin is not installed", () => {
+    const res = validateConfigObjectWithPlugins(
+      {
+        agents: { list: [{ id: "pi" }] },
+        plugins: {
+          slots: { memory: "memory-lancedb" },
+          entries: { "memory-lancedb": { enabled: true } },
+        },
+      },
+      {
+        env: suiteEnv(),
+        pluginMetadataSnapshot: {
+          manifestRegistry: {
+            plugins: [],
+            diagnostics: [],
+          },
+        },
+      },
+    );
+
+    expect(res.ok).toBe(true);
+    const message =
+      "plugin not installed: memory-lancedb — install the official external plugin with: openclaw plugins install @openclaw/memory-lancedb";
+    expectPathMessage(res.warnings, "plugins.slots.memory", message);
+    expectPathMessage(res.warnings, "plugins.entries.memory-lancedb", message);
+  });
+
   it.runIf(process.platform !== "win32")(
     "reports configured blocked plugins without stale not-found wording",
     async () => {

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -357,6 +357,53 @@ describe("config plugin validation", () => {
     expectPathMessage(res.warnings, "plugins.entries.memory-lancedb", message);
   });
 
+  it("keeps blocked official external memory slot plugins fatal", () => {
+    const res = validateConfigObjectWithPlugins(
+      {
+        agents: { list: [{ id: "pi" }] },
+        plugins: {
+          slots: { memory: "memory-lancedb" },
+          entries: { "memory-lancedb": { enabled: true } },
+        },
+      },
+      {
+        env: suiteEnv(),
+        pluginMetadataSnapshot: {
+          manifestRegistry: {
+            plugins: [],
+            diagnostics: [
+              {
+                level: "warn",
+                pluginId: "memory-lancedb",
+                message: "blocked plugin candidate: fixture safety block",
+              },
+            ],
+          },
+        },
+      },
+    );
+
+    expect(res.ok).toBe(false);
+    if (res.ok) {
+      return;
+    }
+    expectPathMessageIncludes(
+      res.issues,
+      "plugins.slots.memory",
+      "plugin present but blocked: memory-lancedb",
+    );
+    expectPathMessageIncludes(
+      res.warnings,
+      "plugins.entries.memory-lancedb",
+      "plugin present but blocked: memory-lancedb",
+    );
+    expect(
+      res.warnings?.some((warning) =>
+        warning.message.includes("plugin not installed: memory-lancedb"),
+      ),
+    ).toBe(false);
+  });
+
   it.runIf(process.platform !== "win32")(
     "reports configured blocked plugins without stale not-found wording",
     async () => {

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -351,10 +351,77 @@ describe("config plugin validation", () => {
     );
 
     expect(res.ok).toBe(true);
+    const slotMessage =
+      "plugin not installed: memory-lancedb — gateway will run without persistent memory until installed; install the official external plugin with: openclaw plugins install @openclaw/memory-lancedb";
+    const entryMessage =
+      "plugin not installed: memory-lancedb — install the official external plugin with: openclaw plugins install @openclaw/memory-lancedb";
+    expectPathMessage(res.warnings, "plugins.slots.memory", slotMessage);
+    expectPathMessage(res.warnings, "plugins.entries.memory-lancedb", entryMessage);
+  });
+
+  it("keeps no-persistent-memory wording scoped to the selected missing memory slot", () => {
+    const res = validateConfigObjectWithPlugins(
+      {
+        agents: { list: [{ id: "pi" }] },
+        plugins: {
+          slots: { memory: "none" },
+          entries: { "memory-lancedb": { enabled: true } },
+          allow: ["memory-lancedb"],
+        },
+      },
+      {
+        env: suiteEnv(),
+        pluginMetadataSnapshot: {
+          manifestRegistry: {
+            plugins: [],
+            diagnostics: [],
+          },
+        },
+      },
+    );
+
+    expect(res.ok).toBe(true);
     const message =
       "plugin not installed: memory-lancedb — install the official external plugin with: openclaw plugins install @openclaw/memory-lancedb";
-    expectPathMessage(res.warnings, "plugins.slots.memory", message);
     expectPathMessage(res.warnings, "plugins.entries.memory-lancedb", message);
+    expectPathMessage(res.warnings, "plugins.allow", message);
+    expect(
+      (res.warnings ?? []).some((warning) =>
+        warning.message.includes("gateway will run without persistent memory"),
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps official external non-memory plugins fatal in the memory slot", () => {
+    const res = validateConfigObjectWithPlugins(
+      {
+        agents: { list: [{ id: "pi" }] },
+        plugins: {
+          slots: { memory: "brave" },
+          entries: { brave: { enabled: true } },
+        },
+      },
+      {
+        env: suiteEnv(),
+        pluginMetadataSnapshot: {
+          manifestRegistry: {
+            plugins: [],
+            diagnostics: [],
+          },
+        },
+      },
+    );
+
+    expect(res.ok).toBe(false);
+    if (res.ok) {
+      return;
+    }
+    expectPathMessage(res.issues, "plugins.slots.memory", "plugin not found: brave");
+    expectPathMessage(
+      res.warnings,
+      "plugins.entries.brave",
+      "plugin not installed: brave — install the official external plugin with: openclaw plugins install @openclaw/brave-plugin",
+    );
   });
 
   it("keeps blocked official external memory slot plugins fatal", () => {

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -1557,7 +1557,9 @@ function validateConfigObjectWithPluginsBase(
     memorySlot.trim() &&
     !knownIds.has(memorySlot)
   ) {
-    pushMissingPluginIssue("plugins.slots.memory", memorySlot);
+    pushMissingPluginIssue("plugins.slots.memory", memorySlot, {
+      warnOnly: Boolean(formatMissingOfficialExternalPluginWarning(memorySlot)),
+    });
   }
 
   let selectedMemoryPluginId: string | null = null;

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -1557,8 +1557,11 @@ function validateConfigObjectWithPluginsBase(
     memorySlot.trim() &&
     !knownIds.has(memorySlot)
   ) {
+    const isMissingOfficialExternalMemorySlot = Boolean(
+      formatMissingOfficialExternalPluginWarning(memorySlot),
+    );
     pushMissingPluginIssue("plugins.slots.memory", memorySlot, {
-      warnOnly: Boolean(formatMissingOfficialExternalPluginWarning(memorySlot)),
+      warnOnly: isMissingOfficialExternalMemorySlot && !findBlockedPluginDiagnostic(memorySlot),
     });
   }
 

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -98,7 +98,10 @@ function formatConfigPath(segments: readonly ConfigPathSegment[]): string {
   return segments.join(".");
 }
 
-function formatMissingOfficialExternalPluginWarning(pluginId: string): string | null {
+function formatMissingOfficialExternalPluginWarning(
+  pluginId: string,
+  opts?: { selectedMissingMemorySlot?: boolean },
+): string | null {
   const catalogEntry = getOfficialExternalPluginCatalogEntry(pluginId);
   if (!catalogEntry) {
     return null;
@@ -110,6 +113,9 @@ function formatMissingOfficialExternalPluginWarning(pluginId: string): string | 
     install?.defaultChoice === "clawhub" ? (clawhubSpec ?? npmSpec) : (npmSpec ?? clawhubSpec);
   if (!installSpec) {
     return null;
+  }
+  if (pluginId === "memory-lancedb" && opts?.selectedMissingMemorySlot) {
+    return `plugin not installed: ${pluginId} — gateway will run without persistent memory until installed; install the official external plugin with: openclaw plugins install ${installSpec}`;
   }
   return `plugin not installed: ${pluginId} — install the official external plugin with: openclaw plugins install ${installSpec}`;
 }
@@ -1455,7 +1461,7 @@ function validateConfigObjectWithPluginsBase(
   const pushMissingPluginIssue = (
     path: string,
     pluginId: string,
-    opts?: { warnOnly?: boolean; officialInstallHint?: boolean },
+    opts?: { warnOnly?: boolean; officialInstallHint?: boolean; missingMessage?: string | null },
   ) => {
     if (LEGACY_REMOVED_PLUGIN_IDS.has(pluginId)) {
       warnings.push({
@@ -1476,7 +1482,8 @@ function validateConfigObjectWithPluginsBase(
       return;
     }
     if (opts?.warnOnly && opts.officialInstallHint !== false) {
-      const externalInstallWarning = formatMissingOfficialExternalPluginWarning(pluginId);
+      const externalInstallWarning =
+        opts.missingMessage ?? formatMissingOfficialExternalPluginWarning(pluginId);
       if (externalInstallWarning) {
         warnings.push({
           path,
@@ -1557,11 +1564,18 @@ function validateConfigObjectWithPluginsBase(
     memorySlot.trim() &&
     !knownIds.has(memorySlot)
   ) {
-    const isMissingOfficialExternalMemorySlot = Boolean(
-      formatMissingOfficialExternalPluginWarning(memorySlot),
-    );
+    const isMissingOfficialExternalMemorySlot =
+      memorySlot === "memory-lancedb" &&
+      Boolean(
+        formatMissingOfficialExternalPluginWarning(memorySlot, {
+          selectedMissingMemorySlot: true,
+        }),
+      );
     pushMissingPluginIssue("plugins.slots.memory", memorySlot, {
       warnOnly: isMissingOfficialExternalMemorySlot && !findBlockedPluginDiagnostic(memorySlot),
+      missingMessage: formatMissingOfficialExternalPluginWarning(memorySlot, {
+        selectedMissingMemorySlot: true,
+      }),
     });
   }
 


### PR DESCRIPTION
## Summary

- Treat a missing official external memory slot plugin as a config warning with the catalog install hint instead of a startup-blocking validation issue.
- Preserve the hard validation failure for unknown/non-catalog missing memory slot IDs.
- Update the `memory-lancedb` docs to make the npm install step explicit before slot configuration.
- Repair a current-main doctor test fixture type shape that blocks the core test typecheck on the rebased branch.

Fixes #82428.

## Tests

- `CI=1 node scripts/run-vitest.mjs src/flows/doctor-health-contributions.test.ts src/config/config.plugin-validation.test.ts src/config/recovery-policy.test.ts src/gateway/server-startup-config.recovery.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/config/validation.ts src/config/config.plugin-validation.test.ts docs/plugins/memory-lancedb.md src/flows/doctor-health-contributions.test.ts`
- `git diff --check`
- `pnpm check:changed`

## Real behavior proof

Behavior or issue addressed:
Configuring `plugins.slots.memory = "memory-lancedb"` before installing `@openclaw/memory-lancedb` no longer makes config validation reject the config with `plugins.slots.memory: plugin not found: memory-lancedb`. It now reports the official external plugin install warning, while unknown missing memory slot IDs still hard-fail.

Real environment tested:
Ubuntu 24.04 WSL source checkout at `/root/src/openclaw-branches/base` on branch `fix-missing-memory-slot-82428`, using a source-level harness that calls the real `validateConfigObjectWithPlugins()` validator with an empty plugin manifest registry to represent `memory-lancedb` not installed. The before comparison used a detached `origin/main` worktree with the same harness and shared local dependencies.

Exact steps or command run after this patch:
1. Ran `validateConfigObjectWithPlugins({ agents: { list: [{ id: "pi" }] }, plugins: { slots: { memory: "memory-lancedb" } } }, { pluginMetadataSnapshot: { manifestRegistry: { plugins: [], diagnostics: [] } } })` against a detached `origin/main` worktree.
2. Ran the same `validateConfigObjectWithPlugins()` input against this branch.
3. Ran the focused config/startup tests and changed-file gate listed above.

Evidence after fix:
Before (`origin/main`) returned:

```json
{
  "ok": false,
  "warnings": [],
  "issues": [
    {
      "path": "plugins.slots.memory",
      "message": "plugin not found: memory-lancedb"
    }
  ]
}
```

After this patch returned:

```json
{
  "ok": true,
  "warnings": [
    {
      "path": "plugins.slots.memory",
      "message": "plugin not installed: memory-lancedb — install the official external plugin with: openclaw plugins install @openclaw/memory-lancedb"
    }
  ],
  "issues": []
}
```

Observed result after fix:
The missing official external memory slot no longer produces an invalid config result, so the gateway startup config validation path can proceed while surfacing the actionable install command. The existing unknown-slot regression coverage still proves `plugins.slots.memory = "missing-slot"` fails with `plugin not found: missing-slot`.

What was not tested:
No full Docker restart loop was launched. The proof uses the real config validator source path with a mocked empty plugin registry snapshot rather than starting a gateway container.
