### PR TITLE
Fix Codex context engine lint

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.context-engine.test.ts
@@ -829,7 +829,7 @@ describe("runCodexAppServerAttempt context-engine lifecycle", () => {
       }
       const firstContent = message.content[0];
       return typeof firstContent === "object" && firstContent !== null && "text" in firstContent
-        ? String(firstContent.text)
+        ? firstContent.text
         : "";
     });
     expect(retryAssembleMessageTexts).toEqual(["successor compacted context"]);


### PR DESCRIPTION
Summary:
- Remove a redundant `String(...)` conversion in the Codex context-engine test.
- Unblocks repo-wide extension lint on current main.

Verification:
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/codex/src/app-server/run-attempt.context-engine.test.ts`
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.context-engine.test.ts`
- `git diff --check HEAD~1..HEAD`

## Real behavior proof

Behavior addressed: this test-only change removes the no-unnecessary-type-conversion lint violation in the Codex context-engine test without changing the asserted context-engine behavior.

Real environment tested: local OpenClaw checkout on macOS, branch `fix/codex-context-engine-lint`, focused Codex test file and extension lint runner.

Exact steps or command run after this patch: ran targeted extension lint, the focused Codex context-engine Vitest file, and whitespace diff check.

Evidence after fix:
```text
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/codex/src/app-server/run-attempt.context-engine.test.ts
Found 0 warnings and 0 errors.

node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.context-engine.test.ts
Test Files  1 passed (1)
Tests  13 passed (13)
```

Observed result after fix: the lint violation is gone and the focused context-engine test still passes.

What was not tested: full repository lint/test suite.
