### PR TITLE
fix: forward MCP tool abort signals

### DIFF
--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -299,7 +299,9 @@ describe("doctor health contributions", () => {
 
       await contribution.run({
         cfg: {},
+        cfgForPersistence: {},
         configResult: { cfg: {} },
+        configPath: "/tmp/fake-openclaw.json",
         sourceConfigValid: true,
         prompter: buildDoctorPrompter(true),
         runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
@@ -319,7 +321,9 @@ describe("doctor health contributions", () => {
 
       await contribution.run({
         cfg: {},
+        cfgForPersistence: {},
         configResult: { cfg: {} },
+        configPath: "/tmp/fake-openclaw.json",
         sourceConfigValid: true,
         prompter: buildDoctorPrompter(true),
         runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },

--- a/src/mcp/plugin-tools-handlers.cancel.test.ts
+++ b/src/mcp/plugin-tools-handlers.cancel.test.ts
@@ -1,0 +1,69 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { describe, expect, it } from "vitest";
+import type { AnyAgentTool } from "../agents/tools/common.js";
+import { createToolsMcpServer } from "./tools-stdio-server.js";
+
+describe("plugin tools MCP cancellation", () => {
+  it("forwards host cancellation to tool.execute", async () => {
+    let resolveObservedSignal: (signal: AbortSignal | undefined) => void;
+    const observedSignal = new Promise<AbortSignal | undefined>((resolve) => {
+      resolveObservedSignal = resolve;
+    });
+    let abortObserved = false;
+
+    const tool = {
+      name: "probe_cancel",
+      description: "Probe cancellation forwarding",
+      parameters: { type: "object", properties: {} },
+      execute: async (_toolCallId: string, _params: unknown, signal?: AbortSignal) => {
+        resolveObservedSignal(signal);
+        await new Promise<void>((resolve, reject) => {
+          if (!signal) {
+            reject(new Error("tool.execute did not receive AbortSignal"));
+            return;
+          }
+          if (signal.aborted) {
+            abortObserved = true;
+            resolve();
+            return;
+          }
+          signal.addEventListener(
+            "abort",
+            () => {
+              abortObserved = true;
+              resolve();
+            },
+            { once: true },
+          );
+        });
+        return { content: [{ type: "text", text: "done" }] };
+      },
+    } as unknown as AnyAgentTool;
+
+    const server = createToolsMcpServer({ name: "test", tools: [tool] });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "test-client", version: "0.0.0" }, { capabilities: {} });
+
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+    try {
+      const controller = new AbortController();
+      const callPromise = client.callTool({ name: "probe_cancel", arguments: {} }, undefined, {
+        signal: controller.signal,
+      });
+      const signal = await observedSignal;
+
+      expect(signal).toBeInstanceOf(AbortSignal);
+      expect(signal?.aborted).toBe(false);
+
+      controller.abort();
+
+      await expect(callPromise).rejects.toBeDefined();
+      expect(abortObserved).toBe(true);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+});

--- a/src/mcp/plugin-tools-handlers.ts
+++ b/src/mcp/plugin-tools-handlers.ts
@@ -42,7 +42,7 @@ export function createPluginToolsMcpHandlers(tools: AnyAgentTool[]) {
         inputSchema: resolveJsonSchemaForTool(tool),
       })),
     }),
-    callTool: async (params: CallPluginToolParams) => {
+    callTool: async (params: CallPluginToolParams, signal?: AbortSignal) => {
       const tool = toolMap.get(params.name);
       if (!tool) {
         return {
@@ -51,7 +51,7 @@ export function createPluginToolsMcpHandlers(tools: AnyAgentTool[]) {
         };
       }
       try {
-        const result = await tool.execute(`mcp-${Date.now()}`, params.arguments ?? {});
+        const result = await tool.execute(`mcp-${Date.now()}`, params.arguments ?? {}, signal);
         const rawContent =
           result && typeof result === "object" && "content" in result
             ? (result as { content?: unknown }).content

--- a/src/mcp/tools-stdio-server.ts
+++ b/src/mcp/tools-stdio-server.ts
@@ -14,8 +14,8 @@ export function createToolsMcpServer(params: { name: string; tools: AnyAgentTool
   );
 
   server.setRequestHandler(ListToolsRequestSchema, handlers.listTools);
-  server.setRequestHandler(CallToolRequestSchema, async (request) => {
-    return await handlers.callTool(request.params);
+  server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
+    return await handlers.callTool(request.params, extra.signal);
   });
 
   return server;


### PR DESCRIPTION
## Summary

- Problem: the MCP plugin tools stdio server ignored the host-provided request `AbortSignal` when dispatching `tools/call`.
- Why it matters: cancelled MCP tool calls kept running inside plugin `tool.execute(...)` instead of observing host cancellation.
- What changed: the stdio server forwards MCP handler `extra.signal` through `createPluginToolsMcpHandlers(...).callTool(...)` and into `tool.execute(...)`.
- What did NOT change (scope boundary): no tool approval policy, hook behavior, or plugin manifest contract changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #82424
- Related #82426
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: MCP plugin tool cancellation now reaches the in-flight plugin `tool.execute(...)` call.
- Real environment tested: Crabbox AWS Linux host running OpenClaw from `main`, using the built MCP plugin tools stdio server over a real `StdioClientTransport` child process.
- Exact steps or command run after this patch: built the repo in Crabbox, spawned `dist/mcp/plugin-tools-serve.js` with an injected probe tool, called the tool through an MCP client with an aborting request signal, and compared sideband probe output before and after the patch.
- Evidence after fix: Crabbox run `run_caccc1747346`; sideband showed `signalDefined: true`, `signalIsAbortSignal: true`, `abortObserved: true`, `signalAbortedAtEnd: true`.
- Observed result after fix: the client request abort still rejected with the expected MCP abort error, and the plugin tool received and observed the same cancellation signal while executing.
- What was not tested: non-stdio MCP transports and every bundled plugin implementation.
- Before evidence: Crabbox run `run_388253d140c1` on `main` at `639107b7db559c4d937fdcd05ac7d78a88dc4555`; sideband showed `signalDefined: false`, `signalIsAbortSignal: false`, `abortObserved: false`, `signalAbortedAtEnd: false`.

## Root Cause (if applicable)

- Root cause: the MCP SDK passes request cancellation through the handler `extra.signal`, but the stdio server handler only accepted the request object and dropped `extra` before reaching plugin tool execution.
- Missing detection / guardrail: there was no MCP client/server cancellation regression test for plugin tool calls.
- Contributing context (if known): `AgentTool.execute(...)` already accepts an optional `AbortSignal`, so the fix is to preserve the existing dependency contract across the MCP server boundary.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/mcp/plugin-tools-handlers.cancel.test.ts`
- Scenario the test should lock in: an MCP client cancels an in-flight `tools/call`, and the plugin tool receives an `AbortSignal` that becomes aborted.
- Why this is the smallest reliable guardrail: it exercises the MCP SDK client/server request path with in-memory transport while avoiding process and network flake.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Cancelled MCP plugin tool calls can now be observed by plugin tools through their existing `AbortSignal` argument.

## Diagram (if applicable)

```text
Before:
MCP client cancel -> SDK handler extra.signal -> dropped -> tool.execute(..., undefined)

After:
MCP client cancel -> SDK handler extra.signal -> handlers.callTool(..., signal) -> tool.execute(..., signal)
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Crabbox AWS Linux; local macOS for focused tests/lint.
- Runtime/container: Node 22.22.2 and pnpm 11.1.0 in Crabbox AWS; local repo Node/pnpm environment for focused checks.
- Model/provider: N/A.
- Integration/channel (if any): MCP plugin tools stdio server.
- Relevant config (redacted): no credentials used.

### Steps

1. Reproduce on `main` by spawning the built MCP plugin tools stdio server with an injected long-running probe tool.
2. Call the probe tool through an MCP client and abort the request while it is in flight.
3. Apply this patch, rebuild, and repeat the same stdio MCP call.
4. Run focused local regression tests and touched-file format/lint checks.

### Expected

- The in-flight plugin tool receives an `AbortSignal` and observes abort when the MCP client cancels the call.

### Actual

- Before this patch, the plugin tool received no signal.
- After this patch, the plugin tool receives and observes the aborted signal.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Focused commands run after rebase:

```bash
node scripts/run-vitest.mjs src/mcp/plugin-tools-handlers.cancel.test.ts src/mcp/plugin-tools-serve.test.ts
node_modules/.bin/oxfmt --check --threads=1 src/mcp/tools-stdio-server.ts src/mcp/plugin-tools-handlers.ts src/mcp/plugin-tools-handlers.cancel.test.ts
node scripts/run-oxlint.mjs src/mcp/tools-stdio-server.ts src/mcp/plugin-tools-handlers.ts src/mcp/plugin-tools-handlers.cancel.test.ts
git diff --check HEAD~1..HEAD
```

All passed.

## Human Verification (required)

- Verified scenarios: broken `main` repro in Crabbox AWS, patched Crabbox AWS stdio behavior, focused MCP cancellation regression test, touched-file formatting and lint.
- Edge cases checked: unknown tool path remains covered by existing plugin tools server tests; no-signal direct handler path remains covered by existing tests.
- What you did **not** verify: non-stdio MCP transports and full release CI.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a plugin may ignore the signal.
  - Mitigation: this preserves the existing optional `tool.execute(..., signal)` contract; plugins that ignore cancellation keep current behavior.
