### PR TITLE
Agents: skip omitted replay image data URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/OpenAI Responses: skip replaying omitted persisted images as inline `data:` URLs and replace them with placeholder text, preventing follow-up turns from failing on invalid base64 image payloads.
 - Update/doctor: avoid materializing `groupAllowFrom` for channel schemas that reject it, so package-swap doctor repairs do not fail on externalized Slack configs.
 - Gateway/media: prevent image filenames from overriding generic non-image byte sniffing, so zip/octet-stream payloads mislabeled as images are offloaded or rejected before they become inline image attachments.
 - Plugins/web search: downgrade stale optional provider installs to warnings so Gateway and doctor repair paths keep running after startup provider selection. Refs #82313. Thanks @crackmac.

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -2025,6 +2025,104 @@ describe("openai transport stream", () => {
     ]);
   });
 
+  it("replaces omitted user images with placeholder text during Responses replay", () => {
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        baseUrl: "https://chatgpt.com/backend-api",
+        reasoning: true,
+        input: ["text", "image"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-codex-responses">,
+      {
+        systemPrompt: "system",
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "FTL" },
+              { type: "image", mimeType: "image/jpeg", bytes: 40340, omitted: true },
+            ],
+          },
+        ],
+        tools: [],
+      } as never,
+      undefined,
+    ) as {
+      input?: Array<{ role?: string; content?: Array<{ type?: string; text?: string }> }>;
+    };
+
+    expect(params.input).toEqual([
+      {
+        role: "user",
+        content: [
+          { type: "input_text", text: "FTL" },
+          { type: "input_text", text: "[User sent an image omitted from persisted context.]" },
+        ],
+      },
+    ]);
+  });
+
+  it("replaces omitted tool images with placeholder text during Responses replay", () => {
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        baseUrl: "https://chatgpt.com/backend-api",
+        reasoning: true,
+        input: ["text", "image"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-codex-responses">,
+      {
+        systemPrompt: "system",
+        messages: [
+          {
+            role: "assistant",
+            content: [{ type: "toolCall", id: "call_1|fc_1", name: "read", arguments: {} }],
+          },
+          {
+            role: "toolResult",
+            toolName: "read",
+            toolCallId: "call_1|fc_1",
+            content: [
+              { type: "text", text: "looks good" },
+              { type: "image", mimeType: "image/png", bytes: 2048, omitted: true },
+            ],
+          },
+        ],
+        tools: [],
+      } as never,
+      undefined,
+    ) as {
+      input?: Array<
+        | { type?: string; call_id?: string; output?: string }
+        | { type?: string; call_id?: string; output?: Array<{ type?: string; text?: string }> }
+      >;
+    };
+
+    expect(params.input).toHaveLength(2);
+    expect(params.input?.[0]).toMatchObject({
+      type: "function_call",
+      call_id: "call_1",
+      name: "read",
+      arguments: "{}",
+    });
+    expect(params.input?.[1]).toEqual({
+      type: "function_call_output",
+      call_id: "call_1",
+      output: "looks good\n(tool returned an image omitted from persisted context)",
+    });
+  });
+
   it("does not infer high reasoning when Pi passes thinking off", () => {
     const params = buildOpenAIResponsesParams(
       {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -456,7 +456,14 @@ function countOmittedImages(content: unknown): number {
   }
   let count = 0;
   for (const item of content) {
-    if (item && typeof item === "object" && item.type === "image" && item.omitted === true) {
+    if (
+      item &&
+      typeof item === "object" &&
+      "type" in item &&
+      item.type === "image" &&
+      "omitted" in item &&
+      item.omitted === true
+    ) {
       count += 1;
     }
   }
@@ -530,17 +537,17 @@ function convertResponsesMessages(
         });
       } else {
         const omittedImages = countOmittedImages(msg.content);
-        const content = msg.content
-          .flatMap((item) => {
-            if (item.type === "text") {
-              return [{ type: "input_text", text: sanitizeTransportPayloadText(item.text) }];
-            }
-            const imagePart = toReplayableInputImagePart(item);
-            return imagePart ? [imagePart] : [];
-          })
-          .filter(
-            (item) => model.input.includes("image") || item.type !== "input_image",
-          ) as ResponseInputMessageContentList;
+        const content: ResponseInputMessageContentList = [];
+        for (const item of msg.content) {
+          if (item.type === "text") {
+            content.push({ type: "input_text", text: sanitizeTransportPayloadText(item.text) });
+            continue;
+          }
+          const imagePart = toReplayableInputImagePart(item);
+          if (imagePart && (model.input.includes("image") || imagePart.type !== "input_image")) {
+            content.push(imagePart);
+          }
+        }
         if (omittedImages > 0) {
           content.push({
             type: "input_text",
@@ -618,10 +625,13 @@ function convertResponsesMessages(
         .filter((item) => item.type === "text")
         .map((item) => item.text)
         .join("\n");
-      const imageOutput = msg.content.flatMap((item) => {
+      const imageOutput: ResponseFunctionCallOutputItemList = [];
+      for (const item of msg.content) {
         const imagePart = toReplayableInputImagePart(item);
-        return imagePart ? [imagePart] : [];
-      });
+        if (imagePart) {
+          imageOutput.push(imagePart);
+        }
+      }
       const omittedImages = countOmittedImages(msg.content);
       const omittedNotice =
         omittedImages > 0

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -431,6 +431,38 @@ function parseTextSignature(
   return { id: signature };
 }
 
+function toReplayableInputImagePart(item: {
+  type?: string;
+  data?: string;
+  mimeType?: string;
+}): ResponseInputMessageContentList[number] | undefined {
+  if (item.type !== "image" || typeof item.data !== "string") {
+    return undefined;
+  }
+  const data = item.data.trim();
+  if (!data) {
+    return undefined;
+  }
+  return {
+    type: "input_image",
+    detail: "auto",
+    image_url: `data:${item.mimeType ?? "image/jpeg"};base64,${data}`,
+  };
+}
+
+function countOmittedImages(content: unknown): number {
+  if (!Array.isArray(content)) {
+    return 0;
+  }
+  let count = 0;
+  for (const item of content) {
+    if (item && typeof item === "object" && item.type === "image" && item.omitted === true) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
 function convertResponsesMessages(
   model: Model<Api>,
   context: Context,
@@ -497,17 +529,27 @@ function convertResponsesMessages(
           content: [{ type: "input_text", text: sanitizeTransportPayloadText(msg.content) }],
         });
       } else {
-        const content = (
-          msg.content.map((item) =>
-            item.type === "text"
-              ? { type: "input_text", text: sanitizeTransportPayloadText(item.text) }
-              : {
-                  type: "input_image",
-                  detail: "auto",
-                  image_url: `data:${item.mimeType};base64,${item.data}`,
-                },
-          ) as ResponseInputMessageContentList
-        ).filter((item) => model.input.includes("image") || item.type !== "input_image");
+        const omittedImages = countOmittedImages(msg.content);
+        const content = msg.content
+          .flatMap((item) => {
+            if (item.type === "text") {
+              return [{ type: "input_text", text: sanitizeTransportPayloadText(item.text) }];
+            }
+            const imagePart = toReplayableInputImagePart(item);
+            return imagePart ? [imagePart] : [];
+          })
+          .filter(
+            (item) => model.input.includes("image") || item.type !== "input_image",
+          ) as ResponseInputMessageContentList;
+        if (omittedImages > 0) {
+          content.push({
+            type: "input_text",
+            text:
+              omittedImages === 1
+                ? "[User sent an image omitted from persisted context.]"
+                : `[User sent ${omittedImages} images omitted from persisted context.]`,
+          });
+        }
         if (content.length > 0) {
           messages.push({ role: "user", content });
         }
@@ -576,26 +618,36 @@ function convertResponsesMessages(
         .filter((item) => item.type === "text")
         .map((item) => item.text)
         .join("\n");
-      const hasImages = msg.content.some((item) => item.type === "image");
+      const imageOutput = msg.content.flatMap((item) => {
+        const imagePart = toReplayableInputImagePart(item);
+        return imagePart ? [imagePart] : [];
+      });
+      const omittedImages = countOmittedImages(msg.content);
+      const omittedNotice =
+        omittedImages > 0
+          ? omittedImages === 1
+            ? "(tool returned an image omitted from persisted context)"
+            : `(tool returned ${omittedImages} images omitted from persisted context)`
+          : "";
+      const textOutput = textResult
+        ? [{ type: "input_text", text: sanitizeTransportPayloadText(textResult) }]
+        : [];
       const [callId] = msg.toolCallId.split("|");
       messages.push({
         type: "function_call_output",
         call_id: callId,
         output:
-          hasImages && model.input.includes("image")
+          imageOutput.length > 0 && model.input.includes("image")
             ? ([
-                ...(textResult
-                  ? [{ type: "input_text", text: sanitizeTransportPayloadText(textResult) }]
-                  : []),
-                ...msg.content
-                  .filter((item) => item.type === "image")
-                  .map((item) => ({
-                    type: "input_image",
-                    detail: "auto",
-                    image_url: `data:${item.mimeType};base64,${item.data}`,
-                  })),
+                ...textOutput,
+                ...imageOutput,
+                ...(omittedNotice ? [{ type: "input_text", text: omittedNotice }] : []),
               ] as ResponseFunctionCallOutputItemList)
-            : sanitizeTransportPayloadText(textResult || "(see attached image)"),
+            : sanitizeTransportPayloadText(
+                textResult && omittedNotice
+                  ? `${textResult}\n${omittedNotice}`
+                  : textResult || omittedNotice || "(see attached image)",
+              ),
       });
     }
     msgIndex += 1;


### PR DESCRIPTION
Why
Follow-up turns could replay omitted persisted images as inline data URLs with undefined base64, causing OpenAI Responses requests to fail with invalid image_url payload errors.

What changed
- skip replaying image blocks unless persisted base64 data is actually present
- replace omitted user/tool images with placeholder text so replay preserves context without sending invalid image_url values
- add regression tests for omitted user image replay and omitted tool image replay
- add a changelog entry for the fix

How
- targeted vitest: `pnpm exec vitest run src/agents/openai-transport-stream.test.ts`
- types: `pnpm tsgo:prod`
- test types: `pnpm tsgo:test`

Real behavior proof
- The same transport fix is already live in the running gateway hotfix bundle used to stop the production Slack failure.
- Running gateway after hotfix:
  ```
  ● openclaw-gateway.service - OpenClaw Gateway (secrets via 1Password op run)
       Active: active (running) since Fri 2026-05-15 23:25:34 CDT
  ```
- Live bundle evidence from the deployed hotfix copy:
  ```
  962:function toReplayableInputImagePart(item) {
  972:function countOmittedImages(content) {
  1014:            const omittedImages = countOmittedImages(msg.content);
  1020:                const imagePart = toReplayableInputImagePart(item);
  1073:                const imagePart = toReplayableInputImagePart(item);
  1076:            const omittedImages = countOmittedImages(msg.content);
  ```
- The failing path previously serialized omitted images as `data:${item.mimeType};base64,${item.data}`; after the hotfix, the live bundle now routes replay through the helper above instead of emitting invalid inline image payloads.

Bead: OC-ofp1x
