### PR TITLE
fix: allow codex network inside openclaw sandbox

### DIFF
--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -6,6 +6,7 @@ import {
   CODEX_PLUGIN_ENTRY_CONFIG_KEYS,
   CODEX_PLUGINS_CONFIG_KEYS,
   codexAppServerStartOptionsKey,
+  codexSandboxPolicyForTurn,
   readCodexPluginConfig,
   resolveCodexAppServerRuntimeOptions,
   resolveCodexComputerUseConfig,
@@ -103,6 +104,24 @@ describe("Codex app-server config", () => {
     });
 
     expect(runtime.start).not.toHaveProperty("clearEnv");
+  });
+
+  it("keeps workspace-write network denied unless an OpenClaw sandbox wrapper opts in", () => {
+    expect(codexSandboxPolicyForTurn("workspace-write", "/work")).toEqual({
+      type: "workspaceWrite",
+      writableRoots: ["/work"],
+      networkAccess: false,
+      excludeTmpdirEnvVar: false,
+      excludeSlashTmp: false,
+    });
+
+    expect(codexSandboxPolicyForTurn("workspace-write", "/work", { networkAccess: true })).toEqual({
+      type: "workspaceWrite",
+      writableRoots: ["/work"],
+      networkAccess: true,
+      excludeTmpdirEnvVar: false,
+      excludeSlashTmp: false,
+    });
   });
 
   it("normalizes app-server environment variables to clear", () => {

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -104,6 +104,7 @@ export type CodexAppServerRuntimeOptions = {
   turnCompletionIdleTimeoutMs: number;
   approvalPolicy: CodexAppServerEffectiveApprovalPolicy;
   sandbox: CodexAppServerSandboxMode;
+  workspaceWriteNetworkAccess?: boolean;
   approvalsReviewer: CodexAppServerApprovalsReviewer;
   serviceTier?: CodexServiceTier;
 };
@@ -473,6 +474,7 @@ export function codexAppServerStartOptionsKey(
 export function codexSandboxPolicyForTurn(
   mode: CodexAppServerSandboxMode,
   cwd: string,
+  options: { networkAccess?: boolean } = {},
 ): CodexSandboxPolicy {
   if (mode === "danger-full-access") {
     return { type: "dangerFullAccess" };
@@ -483,7 +485,7 @@ export function codexSandboxPolicyForTurn(
   return {
     type: "workspaceWrite",
     writableRoots: [cwd],
-    networkAccess: false,
+    networkAccess: options.networkAccess === true,
     excludeTmpdirEnvVar: false,
     excludeSlashTmp: false,
   };

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -6125,6 +6125,7 @@ describe("runCodexAppServerAttempt", () => {
     expect(sandboxed).not.toBe(appServer);
     expect(sandboxed.approvalPolicy).toBe("never");
     expect(sandboxed.sandbox).toBe("workspace-write");
+    expect(sandboxed.workspaceWriteNetworkAccess).toBe(true);
 
     expect(__testing.restrictCodexAppServerSandboxForOpenClawSandbox(appServer, null)).toBe(
       appServer,

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -426,6 +426,7 @@ function restrictCodexAppServerSandboxForOpenClawSandbox(
   return {
     ...appServer,
     sandbox: "workspace-write",
+    workspaceWriteNetworkAccess: true,
   };
 }
 

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -627,7 +627,9 @@ export function buildTurnStartParams(
     cwd: options.cwd,
     approvalPolicy: options.appServer.approvalPolicy,
     approvalsReviewer: options.appServer.approvalsReviewer,
-    sandboxPolicy: codexSandboxPolicyForTurn(options.appServer.sandbox, options.cwd),
+    sandboxPolicy: codexSandboxPolicyForTurn(options.appServer.sandbox, options.cwd, {
+      networkAccess: options.appServer.workspaceWriteNetworkAccess === true,
+    }),
     model: params.modelId,
     ...(options.appServer.serviceTier ? { serviceTier: options.appServer.serviceTier } : {}),
     effort: resolveReasoningEffort(params.thinkLevel, params.modelId),

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -430,6 +430,7 @@ async function runBoundTurn(params: {
         sandboxPolicy: codexSandboxPolicyForTurn(
           binding.sandbox ?? runtime.sandbox,
           binding.cwd || params.data.workspaceDir,
+          { networkAccess: runtime.workspaceWriteNetworkAccess === true },
         ),
         ...(binding.model ? { model: binding.model } : {}),
         ...((binding.serviceTier ?? runtime.serviceTier)


### PR DESCRIPTION
## Summary
- Problem: Codex hook turns that are already wrapped by OpenClaw's sandbox are downgraded from `danger-full-access` to `workspace-write`, but Codex native `workspaceWrite` policy always disables network.
- Why it matters: Docker-sandboxed OpenClaw hooks can have a valid allowlisted egress path, but deterministic callback helpers still fail with `fetch failed` before they can call back.
- What changed: carry an internal `workspaceWriteNetworkAccess` flag when OpenClaw clamps a sandboxed `danger-full-access` turn, and use it only when building the Codex turn sandbox policy.
- What did NOT change (scope boundary): default `workspace-write` still has network denied unless OpenClaw has already enabled its own sandbox wrapper.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Codex native tool execution in an OpenClaw Docker-sandboxed hook could not reach an allowlisted Worker callback endpoint and returned `fetch failed`.
- Real environment tested: dedicated FINN incident-triage runtime on Vultr, OpenClaw `2026.5.12 (f066dd2)`, Codex app-server with OpenAI Codex `gpt-5.5`.
- Exact steps or command run after this patch: hot-patched the installed Codex/OpenClaw config bundles to emit `workspaceWrite.networkAccess=true` for OpenClaw-sandboxed turns, restarted the gateway, then forced a production Atlas runtime heartbeat.
- Evidence after fix: copied live output from the production incident-triage runtime heartbeat after the hotpatch:
  ```text
  request_id=e2431289-354a-491a-9eb3-cf312114d088
  worker_health_timestamp=2026-05-16T04:48:05.636Z
  last_processed_status=complete
  last_processed_at=2026-05-16 04:46:41
  processing=0
  stale_processing=0
  runtime_result=HEARTBEAT_OK
  openclaw_service=active
  openclaw_gateway=ok
  ```
- Observed result after fix: the deterministic helper reached Notion, BigQuery, MySQL, and the Worker callback path.
- What was not tested: full run of `run-attempt.test.ts`; one unrelated test timed out after 120s in this local worktree.
- Before evidence: prior heartbeat attempts returned `fetch failed` from Codex tool execution even when Docker sandbox curl/fetch succeeded.

## Root Cause (if applicable)

- Root cause: OpenClaw correctly prevents raw Codex `danger-full-access` inside its sandbox by clamping to `workspace-write`, but the Codex sandbox policy builder also forced `networkAccess=false`, double-blocking network that OpenClaw's Docker sandbox already controls.
- Missing detection / guardrail: no unit coverage for preserving network when the OpenClaw sandbox wrapper owns egress policy.
- Contributing context (if known): the production heartbeat helper needs outbound callback access, while Docker egress remains allowlisted by Squid/DOCKER-USER rules.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/codex/src/app-server/config.test.ts`, `extensions/codex/src/app-server/run-attempt.test.ts`.
- Scenario the test should lock in: default workspace-write denies network; OpenClaw sandbox clamp explicitly opts in to network for the native Codex turn policy.
- Why this is the smallest reliable guardrail: the regression was policy construction, not provider/model behavior.
- Existing test that already covers this (if any): N/A.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Docker-sandboxed Codex hook turns can use network when OpenClaw has already taken responsibility for sandbox egress controls. Default workspace-write remains network-denied.

## Diagram (if applicable)

```text
Before:
OpenClaw sandbox hook -> Codex workspaceWrite(network=false) -> callback fetch fails

After:
OpenClaw sandbox hook -> Codex workspaceWrite(network=true) -> Docker/Squid egress policy -> callback succeeds
```

## Security Impact (required)

- New permissions/capabilities? (Yes)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (Yes)
- Command/tool execution surface changed? (Yes)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation: network is enabled only for the internally marked OpenClaw-sandbox wrapper path; normal `workspace-write` stays denied, and OpenClaw Docker/Squid/iptables policy remains the egress control.

## Repro + Verification

### Environment

- OS: Linux runtime host
- Runtime/container: OpenClaw Docker-sandboxed hook session
- Model/provider: OpenAI Codex `gpt-5.5`
- Integration/channel (if any): Atlas Worker callback heartbeat
- Relevant config (redacted): `agents.defaults.sandbox.mode=non-main`, callback token redacted

### Steps

1. Run a Docker-sandboxed hook that invokes a deterministic helper using Codex native exec.
2. Have the helper call an allowlisted HTTPS callback endpoint.
3. Observe callback completion.

### Expected

- Codex tool network is allowed only because OpenClaw sandbox policy is active, and callback completes.

### Actual

- Before this fix: `fetch failed`.
- After this fix: callback completed and heartbeat returned `HEARTBEAT_OK`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: production incident-triage heartbeat callback completed after live hotpatch; unit config test passed; targeted clamp test passed.
- Edge cases checked: default workspace-write still denies network.
- What you did **not** verify: full `run-attempt.test.ts` suite, due unrelated local timeout in `does not expose OpenClaw Tool Search controls through Codex dynamic tools`.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps: N/A.

## Risks and Mitigations

- Risk: accidentally enabling network outside OpenClaw-managed sandbox turns.
  - Mitigation: the opt-in flag is only set by the OpenClaw sandbox clamp path; default `workspace-write` remains `networkAccess=false`.
