### PR TITLE
fix(gateway): quiet startup 1013 pre-connect closes [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 - CLI/dashboard: probe Gateway readiness before handing out the dashboard URL, prompting to start or install the managed service when the Gateway is stopped and printing recovery commands instead of opening a dead browser tab.
 - CLI: hide decorative startup and status emoji on terminals that are unlikely to render them correctly, keeping semantic message and identity emoji intact.
 - CLI/gateway: recover the Linux user systemd bus environment when `openclaw dashboard` starts the Gateway from stripped desktop shells such as VNC terminals.
+- Gateway/WebSocket: log expected startup `1013 gateway starting` retry closes at debug instead of warn while preserving WARN for unexpected pre-connect failures. Fixes #76361. (#82457) Thanks @IWhatsskill.
 - CLI/context engines: bootstrap and finalize non-legacy context engines for CLI turns while preserving transcript snapshots and deferred maintenance ownership. (#81869) Thanks @sahilsatralkar.
 - Telegram: persist polling updates through restart replay so queued same-topic messages resume in order instead of losing context after a gateway restart. (#82256) Thanks @VACInc.
 - Gateway/Gmail: abort in-flight Gmail watcher startup and hot-reload restarts before shutdown so reloads cannot spawn `gog serve` after the Gateway is closing. Thanks @frankekn.

--- a/src/gateway/protocol/startup-unavailable.ts
+++ b/src/gateway/protocol/startup-unavailable.ts
@@ -1,4 +1,7 @@
 export const GATEWAY_STARTUP_UNAVAILABLE_REASON = "startup-sidecars";
+export const GATEWAY_STARTUP_PENDING_CLOSE_CAUSE = "startup-sidecars-pending";
+export const GATEWAY_STARTUP_CLOSE_CODE = 1013;
+export const GATEWAY_STARTUP_CLOSE_REASON = "gateway starting";
 export const GATEWAY_STARTUP_RETRY_AFTER_MS = 500;
 const GATEWAY_STARTUP_RETRY_MIN_MS = 100;
 const GATEWAY_STARTUP_RETRY_MAX_MS = 2_000;

--- a/src/gateway/server/ws-connection.startup.test.ts
+++ b/src/gateway/server/ws-connection.startup.test.ts
@@ -3,7 +3,12 @@ import { describe, expect, it, vi } from "vitest";
 import type { WebSocketServer } from "ws";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../protocol/client-info.js";
 import { PROTOCOL_VERSION } from "../protocol/index.js";
-import { GATEWAY_STARTUP_UNAVAILABLE_REASON } from "../protocol/startup-unavailable.js";
+import {
+  GATEWAY_STARTUP_CLOSE_CODE,
+  GATEWAY_STARTUP_CLOSE_REASON,
+  GATEWAY_STARTUP_PENDING_CLOSE_CAUSE,
+  GATEWAY_STARTUP_UNAVAILABLE_REASON,
+} from "../protocol/startup-unavailable.js";
 import { attachGatewayWsConnectionHandler } from "./ws-connection.js";
 
 function createLogger() {
@@ -51,6 +56,7 @@ describe("attachGatewayWsConnectionHandler startup readiness", () => {
       headers: { host: "127.0.0.1:19001" },
       socket: { localAddress: "127.0.0.1" },
     };
+    const logWsControl = createLogger();
 
     attachGatewayWsConnectionHandler({
       wss,
@@ -64,7 +70,7 @@ describe("attachGatewayWsConnectionHandler startup readiness", () => {
       refreshHealthSnapshot: vi.fn(async () => ({}) as never),
       logGateway: createLogger() as never,
       logHealth: createLogger() as never,
-      logWsControl: createLogger() as never,
+      logWsControl: logWsControl as never,
       extraHandlers: {},
       broadcast: vi.fn(),
       buildRequestContext: () => createRequestContext() as never,
@@ -134,7 +140,25 @@ describe("attachGatewayWsConnectionHandler startup readiness", () => {
     expect(response?.error?.retryAfterMs).toBe(500);
     expect(response?.error?.details).toEqual({ reason: GATEWAY_STARTUP_UNAVAILABLE_REASON });
     await vi.waitFor(() => {
-      expect(socket.close).toHaveBeenCalledWith(1013, "gateway starting");
+      expect(socket.close).toHaveBeenCalledWith(
+        GATEWAY_STARTUP_CLOSE_CODE,
+        GATEWAY_STARTUP_CLOSE_REASON,
+      );
     });
+    expect(logWsControl.debug).toHaveBeenCalledWith(
+      expect.stringContaining("closed before connect"),
+      expect.objectContaining({
+        cause: GATEWAY_STARTUP_PENDING_CLOSE_CAUSE,
+        handshake: "failed",
+      }),
+    );
+    expect(logWsControl.debug).toHaveBeenCalledWith(
+      expect.stringContaining(`code=${GATEWAY_STARTUP_CLOSE_CODE}`),
+      expect.anything(),
+    );
+    expect(logWsControl.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("closed before connect"),
+      expect.anything(),
+    );
   });
 });

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -16,6 +16,10 @@ import { resolveHostedPluginSurfaceUrl } from "../hosted-plugin-surface-url.js";
 import type { GatewayMethodRegistry } from "../methods/registry.js";
 import { isLoopbackAddress } from "../net.js";
 import type { PluginNodeCapabilitySurface } from "../plugin-node-capability.js";
+import {
+  GATEWAY_STARTUP_CLOSE_CODE,
+  GATEWAY_STARTUP_PENDING_CLOSE_CAUSE,
+} from "../protocol/startup-unavailable.js";
 import { MAX_PAYLOAD_BYTES, MAX_PREAUTH_PAYLOAD_BYTES } from "../server-constants.js";
 import { clearNodeWakeState } from "../server-methods/nodes-wake-state.js";
 import type { GatewayRequestContext, GatewayRequestHandlers } from "../server-methods/types.js";
@@ -377,9 +381,12 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
         ...closeMeta,
       };
       if (!client) {
-        const logFn = isNoisySwiftPmHelperClose(requestUserAgent, remoteAddr)
-          ? logWsControl.debug
-          : logWsControl.warn;
+        const isExpectedStartupRetryClose =
+          closeCause === GATEWAY_STARTUP_PENDING_CLOSE_CAUSE && code === GATEWAY_STARTUP_CLOSE_CODE;
+        const logFn =
+          isNoisySwiftPmHelperClose(requestUserAgent, remoteAddr) || isExpectedStartupRetryClose
+            ? logWsControl.debug
+            : logWsControl.warn;
         logFn(
           `closed before connect conn=${connId} peer=${endpoint ?? "n/a"} remote=${remoteAddr ?? "?"} fwd=${logForwardedFor || "n/a"} origin=${logOrigin || "n/a"} host=${logHost || "n/a"} ua=${logUserAgent || "n/a"} code=${code ?? "n/a"} reason=${logReason || "n/a"}`,
           closeContext,

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -99,6 +99,9 @@ import {
 } from "../../protocol/index.js";
 import {
   gatewayStartupUnavailableDetails,
+  GATEWAY_STARTUP_CLOSE_CODE,
+  GATEWAY_STARTUP_CLOSE_REASON,
+  GATEWAY_STARTUP_PENDING_CLOSE_CAUSE,
   GATEWAY_STARTUP_RETRY_AFTER_MS,
 } from "../../protocol/startup-unavailable.js";
 import { parseGatewayRole } from "../../role-policy.js";
@@ -514,7 +517,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
         };
 
         if (isStartupPending?.()) {
-          markHandshakeFailure("startup-sidecars-pending");
+          markHandshakeFailure(GATEWAY_STARTUP_PENDING_CLOSE_CAUSE);
           await sendFrame({
             type: "res",
             id: frame.id,
@@ -525,7 +528,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
               details: gatewayStartupUnavailableDetails(),
             }),
           }).catch(() => {});
-          queueMicrotask(() => close(1013, "gateway starting"));
+          queueMicrotask(() => close(GATEWAY_STARTUP_CLOSE_CODE, GATEWAY_STARTUP_CLOSE_REASON));
           return;
         }
 


### PR DESCRIPTION
## Summary

- Downgrade only the gateway-owned `startup-sidecars-pending` pre-connect close with code `1013` from warn to debug.
- Preserve WARN for other pre-connect failures.
- Add a focused startup-readiness regression assertion and changelog entry.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #76361
- Related context: #77189 and #78428 are closed and unmerged prior attempts; #82029 and #60536 are adjacent WebSocket logging PRs but do not cover this startup-sidecars `1013` path.
- [x] This PR fixes a bug or regression

## Real behavior proof

- Behavior or issue addressed: expected gateway startup retry closes no longer emit warning-level `closed before connect` log noise.
- Real environment tested: local OpenClaw source checkout, Node 24, real `WebSocketServer` plus real `WebSocket` client against the production `attachGatewayWsConnectionHandler`, with `isStartupPending()` forced true.
- Exact steps or command run after this patch: a temporary local proof script exercised the production handler over a real local WebSocket connection, then was removed before the final diff.
- Evidence after fix:

```json
{
  "proof": "gateway-startup-1013-log-level",
  "ok": true,
  "close": {
    "code": 1013,
    "reason": "gateway starting"
  },
  "response": {
    "ok": false,
    "errorCode": "UNAVAILABLE",
    "retryable": true,
    "retryAfterMs": 500,
    "details": {
      "reason": "startup-sidecars"
    }
  },
  "logs": {
    "debugClosedBeforeConnect": 1,
    "warnClosedBeforeConnect": 0,
    "startupCauseAtDebug": true,
    "handshakeAtDebug": "failed"
  }
}
```

- Observed result after fix: the client still receives retryable `UNAVAILABLE` and closes with `1013 gateway starting`, while the matching pre-connect close log goes to debug and not warn.
- What was not tested: a full Control UI browser restart. The proof covers the real local gateway WebSocket handler path without external services or secrets.

## Root Cause

- Root cause: the pre-connect close logger treated the gateway's own startup retry close like an unexpected pre-connect failure.
- Missing detection / guardrail: the startup readiness test already asserted the retryable response and `1013` close, but not the matching log level.
- Contributing context: reconnecting clients can hit the startup-sidecars window during gateway restart, so expected retry churn looked like operator-warning noise.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server/ws-connection.startup.test.ts`
- Scenario the test should lock in: `startup-sidecars-pending` still returns retryable `UNAVAILABLE` and closes with `1013`, but the matching `closed before connect` log is debug, not warn.
- Why this is the smallest reliable guardrail: the existing startup readiness test already drives the exact startup-pending pre-connect path.
- Existing test that already covers this: the same test covered the response and close contract before this PR.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Expected gateway startup retry closes stop appearing as warning-level log noise. Client retry behavior, protocol, auth, and config stay unchanged.

## Diagram

```text
Before:
startup-sidecars-pending connect -> retryable UNAVAILABLE -> 1013 close -> WARN

After:
startup-sidecars-pending connect -> retryable UNAVAILABLE -> 1013 close -> debug
```

## Security Impact

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: local Windows desktop workspace
- Runtime/container: local Node workspace
- Model/provider: N/A
- Integration/channel: Gateway WebSocket startup path
- Relevant config: no new config

### Steps

1. Force gateway startup readiness to pending.
2. Connect a WebSocket client and send a `connect` request.
3. Observe the retryable startup response, `1013 gateway starting` close, and websocket control log level.

### Expected

- Startup-pending clients receive retryable `UNAVAILABLE`.
- The server closes with `1013 gateway starting`.
- The matching gateway-owned pre-connect close logs at debug.
- Other pre-connect failures still warn.

### Actual

- Before this patch, the expected startup retry close went through the generic pre-connect WARN branch.

## Evidence

- [x] Focused regression test
- [x] Adjacent gateway tests
- [x] Real local WebSocket proof
- [ ] Screenshot/recording
- [ ] Perf numbers

## Human Verification

- Verified scenarios: focused startup readiness test, adjacent gateway/client test set, real local WebSocket server/client proof, formatting, diff check, leak/template scan.
- Edge cases checked: the demotion is gated on server-owned `startup-sidecars-pending` plus code `1013`; unrelated pre-connect failures keep the existing WARN path.
- What you did not verify: full Control UI browser restart.

## Review Conversations

- [x] No review conversations addressed yet.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a real startup issue could be less visible at warning level.
- Mitigation: only the expected gateway-owned `startup-sidecars-pending` + `1013` close is demoted; all other pre-connect closes still warn.

## Local Validation

- `node scripts/run-vitest.mjs src/gateway/server/ws-connection.startup.test.ts` -> 3 files passed, 3 tests passed
- `node scripts/run-vitest.mjs src/gateway/server/ws-connection.test.ts src/gateway/client.test.ts ui/src/ui/gateway.node.test.ts` -> 6 files passed, 129 tests passed
- `pnpm exec oxfmt --check --threads=1 src/gateway/server/ws-connection.ts src/gateway/server/ws-connection.startup.test.ts CHANGELOG.md`
- `git diff --check`
- `node scripts/check-changed.mjs`
- `node scripts/crabbox-wrapper.mjs run --shell -- "pnpm check:changed"` could not run in this desktop workspace because the selected local `crabbox` binary failed its basic `--version/--help` sanity check before invoking the command.
