### PR TITLE
fix(infra): drop duplicated "restart" word in restart-sentinel summary

### DIFF
--- a/src/infra/restart-sentinel.test.ts
+++ b/src/infra/restart-sentinel.test.ts
@@ -197,7 +197,8 @@ describe("restart sentinel", () => {
     const textA = formatRestartSentinelMessage(payloadA);
     const textB = formatRestartSentinelMessage(payloadB);
     expect(textA).toBe(textB);
-    expect(textA).toContain("Gateway restart restart ok");
+    expect(textA).toContain("Gateway restart ok");
+    expect(textA).not.toContain("Gateway restart restart");
     expect(textA).not.toContain('"ts"');
   });
 

--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -245,7 +245,8 @@ export function summarizeRestartSentinel(payload: RestartSentinelPayload): strin
   const kind = payload.kind;
   const status = payload.status;
   const mode = payload.stats?.mode ? ` (${payload.stats.mode})` : "";
-  return `Gateway restart ${kind} ${status}${mode}`.trim();
+  const kindSegment = kind === "restart" ? "" : ` ${kind}`;
+  return `Gateway restart${kindSegment} ${status}${mode}`.trim();
 }
 
 export function trimLogTail(input?: string | null, maxChars = 8000) {


### PR DESCRIPTION
## Summary

- **Problem:** Restart-event chat messages emit the word `restart` twice when `payload.kind === "restart"`, producing strings like `Gateway restart restart ok (gateway.restart)`. This is the most common `kind` value (every `/restart` from a chat client) so it's the dominant user-visible form.
- **Why it matters:** Every interactive gateway restart surfaces the doubled word in the chat reply. Cosmetic, but it's the first line a user sees after their own restart command, so it reads as a bug in the agent's output.
- **What changed:** `summarizeRestartSentinel` keeps the hardcoded `Gateway restart ` prefix for the other `kind` values (`config-apply`, `config-patch`, `update`), which already read naturally with it. When `kind === "restart"`, the now-redundant suffix segment is omitted. The `config-auto-recovery` early return is untouched.
- **What did NOT change (scope boundary):** `formatRestartSentinelMessage`, the `config-auto-recovery` special case, the payload shape, the sentinel file format, and the `payload.stats.mode` field semantics are all unchanged. No new config knobs. No API changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** Doubled word in the chat reply after a gateway restart driven by `/restart` from a chat client. Reply read `Gateway restart restart ok (gateway.restart)` instead of `Gateway restart ok (gateway.restart)`.
- **Real environment tested:** OpenClaw 2026.4.24 (commit cbcfdf6) on macOS 25.3.0, gateway run as a launchd LaunchAgent (`ai.openclaw.gateway`), Telegram channel as the chat client. Patched the same template inline in the installed `dist/restart-sentinel-*.js` bundle and ran `openclaw gateway restart` to recycle the process.
- **Exact steps or command run after this patch:**
  1. `openclaw gateway restart` (launchd recycle; new PID confirmed via `pgrep -f openclaw-gateway`)
  2. `openclaw gateway health` (returned OK)
  3. Re-imported the live `summarizeRestartSentinel` against the same payload that produced the bug.
- **Evidence after fix:**
  ```
  $ openclaw gateway restart --json
  {"action":"restart","ok":true,"result":"restarted","service":{"label":"LaunchAgent","loaded":true}}

  $ openclaw gateway health
  Gateway Health
  OK (16798ms)
  iMessage: ok
  Telegram: starting
  WhatsApp: linked

  $ node --input-type=module -e "import { l as f } from '.../restart-sentinel-*.js'; \
      console.log(f({ kind: 'restart', status: 'ok', stats: { mode: 'gateway.restart' } }));"
  Gateway restart ok (gateway.restart)
  ```
  Telegram chat post-restart shows the same single-word output.
- **Observed result after fix:** Chat reply reads `Gateway restart ok (gateway.restart)`. Other `kind` values (verified via the unit test matrix below) still read with the `Gateway restart <kind>` framing they had before.
- **What was not tested:** Did not exercise an actual `config-auto-recovery` event end-to-end (the special-case branch is unchanged by this PR and the existing unit test still asserts its output). Did not run the full `pnpm test` lane — only the targeted file plus `pnpm check:test-types`.
- **Before evidence:** Original Telegram reply on the same host before patching read `Gateway restart restart ok (gateway.restart)` (visible in the gateway's chat log).

## Root Cause (if applicable)

- **Root cause:** The template literal in `summarizeRestartSentinel` hardcodes the word `restart` in the prefix and then interpolates `payload.kind` directly after it. When `kind === "restart"`, the prefix and the interpolation collide. The other four `kind` values in the union don't collide, which is why the bug only surfaces for the `restart` kind (the most common one).
- **Missing detection / guardrail:** The existing test for this path (`formats restart messages without volatile timestamps`) asserted `toContain("Gateway restart restart ok")` — codifying the doubled output as expected behavior. A `.not.toContain("Gateway restart restart")` guard would have flagged it.
- **Contributing context (if known):** The prefix `Gateway restart ` reads naturally for `config-apply`, `config-patch`, and `update` ("Gateway restart update skipped"), so dropping the prefix entirely would regress those. Hence the `kind === "restart"` carve-out rather than a blanket prefix removal.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:** `src/infra/restart-sentinel.test.ts`, the `formats restart messages without volatile timestamps` case.
- **Scenario the test should lock in:** When `kind === "restart"`, the summary line must not contain `"Gateway restart restart"`.
- **Why this is the smallest reliable guardrail:** The bug is a pure string-template defect with no external dependencies. A single positive (`toContain("Gateway restart ok")`) plus a single negative (`not.toContain("Gateway restart restart")`) on the existing test scenario covers both the fix and the regression.
- **Existing test that already covers this:** The same test previously asserted the doubled output verbatim; this PR flips the assertion to the correct expected output and adds the negative guard.
- **If no new test is added, why not:** N/A — assertion is updated in place.

## User-visible / Behavior Changes

Chat reply after a `/restart`-style gateway restart now reads `Gateway restart ok (...)` instead of `Gateway restart restart ok (...)`. Restart event summary for other `kind` values (`config-apply`, `config-patch`, `update`) and the `config-auto-recovery` early return are unchanged.

## Diagram (if applicable)

```text
Before:
payload.kind = "restart"          ─► "Gateway restart restart ok (gateway.restart)"
payload.kind = "config-patch"     ─► "Gateway restart config-patch error (patch)"
payload.kind = "update"           ─► "Gateway restart update skipped"
payload.kind = "config-auto-recovery" ─► "Gateway auto-recovery"

After:
payload.kind = "restart"          ─► "Gateway restart ok (gateway.restart)"        // de-duped
payload.kind = "config-patch"     ─► "Gateway restart config-patch error (patch)"  // unchanged
payload.kind = "update"           ─► "Gateway restart update skipped"              // unchanged
payload.kind = "config-auto-recovery" ─► "Gateway auto-recovery"                   // unchanged
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 25.3.0 (Darwin)
- Runtime/container: Node 24 on a homebrew-installed `openclaw` 2026.4.24, gateway under launchd
- Model/provider: N/A (string formatting only)
- Integration/channel: Telegram (also reproduces on any channel that surfaces the restart-sentinel message)
- Relevant config (redacted): default

### Steps

1. From any chat channel, send `/restart` (or otherwise trigger a sentinel with `payload.kind === "restart"`).
2. Observe the next system message from the gateway after it comes back up.

### Expected

- `Gateway restart ok (gateway.restart)`

### Actual (before this PR)

- `Gateway restart restart ok (gateway.restart)`

## Evidence

- [x] Failing test/log before + passing after — existing test previously asserted `"Gateway restart restart ok"` literally; flipped to `"Gateway restart ok"` + a `.not.toContain` guard, 20/20 pass post-change.
- [x] Trace/log snippets — see `Real behavior proof` section above (gateway restart JSON, health probe, live bundle output).
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- **Verified scenarios:**
  - Ran `pnpm vitest run src/infra/restart-sentinel.test.ts` → 20/20 pass after the change.
  - Ran `pnpm check:test-types` — the only errors reported are in `src/flows/doctor-health-contributions.test.ts` (a `DoctorHealthFlowContext` cast mismatch that is currently failing on `main` as well; not touched by this PR).
  - Applied the equivalent edit to the installed bundle on a live machine, restarted the gateway via `openclaw gateway restart`, confirmed `summarizeRestartSentinel` output via direct Node import and via the next Telegram exchange.
  - Verified the four other `kind` values (`config-apply`, `config-patch`, `update`, `config-auto-recovery`) still produce their previous summary strings.
- **Edge cases checked:** Restart with `status === "failed"` and a `stats.mode`; restart without `stats`; the existing `config-auto-recovery` early return; the existing `config-patch` formatted message with reason + doctor hint.
- **What you did not verify:** A full `pnpm test` run, end-to-end of a real `config-auto-recovery` event, and any non-Telegram channel beyond the targeted unit suite.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- **Risk:** Downstream tooling parses the summary string and depends on the literal word `restart` appearing twice when `kind === "restart"`.
  - **Mitigation:** Extremely unlikely — the string is a human-readable status line displayed in chat, not a stable machine-parsable contract. Other `kind` values already produce single-word output (`Gateway restart update skipped`), so consumers cannot have been relying on the doubled form across the matrix.
