### PR TITLE
Fix session reset files and ACPX orphan reaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Docs: https://docs.openclaw.ai
 - Providers/embeddings: reject malformed successful OpenAI-compatible, Google Gemini, and Amazon Bedrock embedding responses instead of silently returning empty or coerced vectors.
 - Providers/catalogs: reject malformed successful LM Studio, GitHub Copilot, DeepInfra, Vercel AI Gateway, and Kilocode model-list responses with provider-owned errors instead of raw parser/type failures or silent fallback catalogs.
 - Providers/polling: reject array, null, or scalar successful operation status responses with provider-owned malformed JSON errors instead of waiting until timeout.
+- ACPX/Codex: reap plugin-local Codex ACP adapter orphans on startup after wrapper crashes while keeping direct adapter commands out of launch-lease injection. Fixes #82364. (#82459) Thanks @joshavant.
 - Telegram: send presentation-only payloads by rendering fallback text and inline buttons instead of treating them as empty. Fixes #82404. (#82449) Thanks @joshavant.
 - Trajectory export: skip and report malformed session/runtime JSONL rows in `manifest.json` instead of letting wrong-shaped session rows crash support bundle export.
 - Voice calls: persist rejected inbound-call replay keys so duplicate carrier webhook retries stay ignored after a Gateway restart.

--- a/extensions/acpx/src/process-reaper.test.ts
+++ b/extensions/acpx/src/process-reaper.test.ts
@@ -1,7 +1,9 @@
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { OPENCLAW_ACPX_LEASE_ID_ARG, OPENCLAW_GATEWAY_INSTANCE_ID_ARG } from "./process-lease.js";
 import {
   cleanupOpenClawOwnedAcpxProcessTree,
+  isOpenClawLeaseAwareAcpxProcessCommand,
   isOpenClawOwnedAcpxProcessCommand,
   reapStaleOpenClawOwnedAcpxOrphans,
   type AcpxProcessInfo,
@@ -13,6 +15,12 @@ const CODEX_WRAPPER_COMMAND_WITH_LEASE = `${CODEX_WRAPPER_COMMAND} ${OPENCLAW_AC
 const CLAUDE_WRAPPER_COMMAND = `node ${WRAPPER_ROOT}/claude-agent-acp-wrapper.mjs`;
 const PLUGIN_DEPS_CODEX_COMMAND =
   "node /tmp/openclaw/plugin-runtime-deps/node_modules/@zed-industries/codex-acp/bin/codex-acp.js";
+const LOCAL_NODE_MODULES_CODEX_COMMAND = `node ${path.resolve(
+  "node_modules/@zed-industries/codex-acp/bin/codex-acp.js",
+)}`;
+const LOCAL_NODE_MODULES_CODEX_PLATFORM_COMMAND = path.resolve(
+  "node_modules/@zed-industries/codex-acp-linux-x64/bin/codex-acp",
+);
 
 function cleanupDeps(processes: AcpxProcessInfo[]) {
   const killed: Array<{ pid: number; signal: NodeJS.Signals }> = [];
@@ -64,11 +72,37 @@ describe("process reaper", () => {
     ).toBe(false);
   });
 
+  it("only treats generated wrappers as launch-lease aware", () => {
+    expect(
+      isOpenClawLeaseAwareAcpxProcessCommand({
+        command: CODEX_WRAPPER_COMMAND,
+        wrapperRoot: WRAPPER_ROOT,
+      }),
+    ).toBe(true);
+    expect(
+      isOpenClawLeaseAwareAcpxProcessCommand({ command: LOCAL_NODE_MODULES_CODEX_COMMAND }),
+    ).toBe(false);
+    expect(isOpenClawLeaseAwareAcpxProcessCommand({ command: PLUGIN_DEPS_CODEX_COMMAND })).toBe(
+      false,
+    );
+  });
+
   it("recognizes OpenClaw plugin-runtime-deps ACP adapter children", () => {
     expect(isOpenClawOwnedAcpxProcessCommand({ command: PLUGIN_DEPS_CODEX_COMMAND })).toBe(true);
     expect(isOpenClawOwnedAcpxProcessCommand({ command: "npx @zed-industries/codex-acp" })).toBe(
       false,
     );
+  });
+
+  it("recognizes plugin-local ACP adapter package paths without trusting arbitrary installs", () => {
+    expect(isOpenClawOwnedAcpxProcessCommand({ command: LOCAL_NODE_MODULES_CODEX_COMMAND })).toBe(
+      true,
+    );
+    expect(
+      isOpenClawOwnedAcpxProcessCommand({
+        command: "node /tmp/other-project/node_modules/@zed-industries/codex-acp/bin/codex-acp.js",
+      }),
+    ).toBe(false);
   });
 
   it("kills an owned recorded process tree children first", async () => {
@@ -258,6 +292,28 @@ describe("process reaper", () => {
         (entry) => entry.pid,
       ),
     ).toEqual([402, 401, 400, 404, 403, 405]);
+  });
+
+  it("reaps plugin-local Codex ACP adapter orphans when the generated wrapper is already gone", async () => {
+    const { deps, killed } = cleanupDeps([
+      { pid: 500, ppid: 1, command: LOCAL_NODE_MODULES_CODEX_COMMAND },
+      { pid: 501, ppid: 500, command: LOCAL_NODE_MODULES_CODEX_PLATFORM_COMMAND },
+    ]);
+
+    const result = await reapStaleOpenClawOwnedAcpxOrphans({
+      wrapperRoot: WRAPPER_ROOT,
+      deps,
+    });
+
+    expect(result.skippedReason).toBeUndefined();
+    expect(result.inspectedPids).toEqual([500, 501]);
+    expect(
+      collectMatching(
+        killed,
+        (entry) => entry.signal === "SIGTERM",
+        (entry) => entry.pid,
+      ),
+    ).toEqual([501, 500]);
   });
 
   it("keeps startup scans quiet when process listing is unavailable", async () => {

--- a/extensions/acpx/src/process-reaper.ts
+++ b/extensions/acpx/src/process-reaper.ts
@@ -1,13 +1,27 @@
 import { execFile } from "node:child_process";
+import { createRequire } from "node:module";
+import path from "node:path";
 import { promisify } from "node:util";
 import { OPENCLAW_ACPX_LEASE_ID_ARG, OPENCLAW_GATEWAY_INSTANCE_ID_ARG } from "./process-lease.js";
 
 const execFileAsync = promisify(execFile);
+const requireFromHere = createRequire(import.meta.url);
 const GENERATED_WRAPPER_BASENAMES = new Set([
   "codex-acp-wrapper.mjs",
   "claude-agent-acp-wrapper.mjs",
 ]);
 const OPENCLAW_PLUGIN_DEPS_MARKER = "/plugin-runtime-deps/";
+const OWNED_ACP_PACKAGE_NAMES = [
+  "@zed-industries/codex-acp",
+  "@zed-industries/codex-acp-darwin-arm64",
+  "@zed-industries/codex-acp-darwin-x64",
+  "@zed-industries/codex-acp-linux-arm64",
+  "@zed-industries/codex-acp-linux-x64",
+  "@zed-industries/codex-acp-win32-arm64",
+  "@zed-industries/codex-acp-win32-x64",
+  "@agentclientprotocol/claude-agent-acp",
+  "acpx",
+];
 const ACP_PACKAGE_MARKERS = [
   "/@zed-industries/codex-acp/",
   "/@agentclientprotocol/claude-agent-acp/",
@@ -42,6 +56,22 @@ function normalizePathLike(value: string): string {
   return value.replaceAll("\\", "/");
 }
 
+function resolvePackageRoot(packageName: string): string | undefined {
+  try {
+    return normalizePathLike(path.dirname(requireFromHere.resolve(`${packageName}/package.json`)));
+  } catch {
+    return undefined;
+  }
+}
+
+const OWNED_ACP_PACKAGE_ROOTS = OWNED_ACP_PACKAGE_NAMES.map(resolvePackageRoot).filter(
+  (root): root is string => Boolean(root),
+);
+
+function commandBelongsToResolvedAcpPackage(command: string): boolean {
+  return OWNED_ACP_PACKAGE_ROOTS.some((root) => command.includes(`${root}/`));
+}
+
 function commandMentionsGeneratedWrapper(command: string): boolean {
   return Array.from(GENERATED_WRAPPER_BASENAMES).some((basename) => command.includes(basename));
 }
@@ -54,6 +84,21 @@ function commandWrapperBelongsToRoot(command: string, wrapperRoot: string | unde
   const normalizedRoot = normalizePathLike(wrapperRoot).replace(/\/+$/, "");
   return Array.from(GENERATED_WRAPPER_BASENAMES).some((basename) =>
     normalizedCommand.includes(`${normalizedRoot}/${basename}`),
+  );
+}
+
+export function isOpenClawLeaseAwareAcpxProcessCommand(params: {
+  command: string | undefined;
+  wrapperRoot?: string;
+}): boolean {
+  const command = params.command?.trim();
+  if (!command) {
+    return false;
+  }
+  const normalized = normalizePathLike(command);
+  return (
+    commandMentionsGeneratedWrapper(normalized) &&
+    commandWrapperBelongsToRoot(normalized, params.wrapperRoot)
   );
 }
 
@@ -147,8 +192,16 @@ export function isOpenClawOwnedAcpxProcessCommand(params: {
     return false;
   }
   const normalized = normalizePathLike(command);
-  if (commandMentionsGeneratedWrapper(normalized)) {
-    return commandWrapperBelongsToRoot(normalized, params.wrapperRoot);
+  if (
+    isOpenClawLeaseAwareAcpxProcessCommand({
+      command: normalized,
+      wrapperRoot: params.wrapperRoot,
+    })
+  ) {
+    return true;
+  }
+  if (commandBelongsToResolvedAcpPackage(normalized)) {
+    return true;
   }
   if (!normalized.includes(OPENCLAW_PLUGIN_DEPS_MARKER)) {
     return false;

--- a/extensions/acpx/src/runtime.test.ts
+++ b/extensions/acpx/src/runtime.test.ts
@@ -16,6 +16,9 @@ const DOCUMENTED_OPENCLAW_BRIDGE_COMMAND =
 const CODEX_ACP_COMMAND = "npx @zed-industries/codex-acp@0.13.0";
 const CODEX_ACP_WRAPPER_COMMAND = `node "/tmp/openclaw/acpx/codex-acp-wrapper.mjs"`;
 const CODEX_ACP_WRAPPER_COMMAND_WITH_LEASE = `${CODEX_ACP_WRAPPER_COMMAND} ${OPENCLAW_ACPX_LEASE_ID_ARG} lease-close ${OPENCLAW_GATEWAY_INSTANCE_ID_ARG} gateway-test`;
+const LOCAL_NODE_MODULES_CODEX_COMMAND = `node "${path.resolve(
+  "node_modules/@zed-industries/codex-acp/bin/codex-acp.js",
+)}"`;
 
 function makeRuntime(
   baseStore: TestSessionStore,
@@ -902,6 +905,50 @@ describe("AcpxRuntime fresh reset wrapper", () => {
     expect(savedRecords[0]?.agentCommand).toBe(CODEX_ACP_WRAPPER_COMMAND);
     expect(savedRecords[0]?.openclawGatewayInstanceId).toBe("gateway-test");
     expect(savedRecords[0]?.openclawLeaseId).toBe(lease?.leaseId);
+  });
+
+  it("does not create launch leases for direct plugin-local ACP adapter commands", async () => {
+    const launchCommands: string[] = [];
+    const baseStore: TestSessionStore = {
+      load: vi.fn(async () => undefined),
+      save: vi.fn(async () => {}),
+    };
+    const leaseStore = makeLeaseStore();
+    const { runtime, delegate, wrappedStore } = makeRuntime(baseStore, {
+      openclawGatewayInstanceId: "gateway-test",
+      openclawProcessLeaseStore: leaseStore.store,
+      openclawWrapperRoot: "/tmp/openclaw/acpx",
+      agentRegistry: {
+        resolve: (agentName: string) =>
+          agentName === "codex" ? LOCAL_NODE_MODULES_CODEX_COMMAND : agentName,
+        list: () => ["codex"],
+      },
+    });
+    vi.spyOn(delegate, "ensureSession").mockImplementation(async (input) => {
+      const command = (
+        runtime as unknown as { scopedAgentRegistry: { resolve(agent: string): string } }
+      ).scopedAgentRegistry.resolve("codex");
+      launchCommands.push(command);
+      await wrappedStore.save({
+        name: input.sessionKey,
+        agentCommand: command,
+        pid: 777,
+      });
+      return {
+        sessionKey: input.sessionKey,
+        backend: "acpx",
+        runtimeSessionName: input.sessionKey,
+      };
+    });
+
+    await runtime.ensureSession({
+      sessionKey: "agent:codex:acp:binding:test",
+      agent: "codex",
+      mode: "persistent",
+    });
+
+    expect(leaseStore.store.save).not.toHaveBeenCalled();
+    expect(launchCommands).toEqual([LOCAL_NODE_MODULES_CODEX_COMMAND]);
   });
 
   it("keeps reusable persistent ACP launch commands stable across ensures", async () => {

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -27,6 +27,7 @@ import {
 } from "./process-lease.js";
 import {
   cleanupOpenClawOwnedAcpxProcessTree,
+  isOpenClawLeaseAwareAcpxProcessCommand,
   isOpenClawOwnedAcpxProcessCommand,
   type AcpxProcessCleanupDeps,
 } from "./process-reaper.js";
@@ -785,7 +786,7 @@ export class AcpxRuntime implements AcpRuntime {
       !this.wrapperRoot ||
       !this.gatewayInstanceId ||
       !this.processLeaseStore ||
-      !isOpenClawOwnedAcpxProcessCommand({
+      !isOpenClawLeaseAwareAcpxProcessCommand({
         command: params.command,
         wrapperRoot: this.wrapperRoot,
       })

--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -28,7 +28,6 @@ import {
 import {
   cleanupOpenClawOwnedAcpxProcessTree,
   isOpenClawLeaseAwareAcpxProcessCommand,
-  isOpenClawOwnedAcpxProcessCommand,
   type AcpxProcessCleanupDeps,
 } from "./process-reaper.js";
 

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -1,5 +1,4 @@
 import crypto from "node:crypto";
-import fs from "node:fs";
 import path from "node:path";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { canExecRequestNode } from "../../agents/exec-defaults.js";
@@ -13,8 +12,10 @@ import { ensureSkillsWatcher } from "../../agents/skills/refresh.js";
 import { hydrateResolvedSkills } from "../../agents/skills/snapshot-hydration.js";
 import { stableStringify } from "../../agents/stable-stringify.js";
 import {
+  canonicalizeAbsoluteSessionFilePath,
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
+  rewriteSessionFileForNewSessionId,
   type SessionEntry,
   updateSessionStore,
 } from "../../config/sessions.js";
@@ -469,54 +470,4 @@ function resolveCompactionSessionFile(params: {
     normalizedRewrittenSessionFile ? { sessionFile: normalizedRewrittenSessionFile } : undefined,
     pathOpts,
   );
-}
-
-function canonicalizeAbsoluteSessionFilePath(filePath: string): string {
-  const resolved = path.resolve(filePath);
-  const missingSegments: string[] = [];
-  let cursor = resolved;
-  while (true) {
-    try {
-      return path.join(fs.realpathSync(cursor), ...missingSegments.toReversed());
-    } catch {
-      const parent = path.dirname(cursor);
-      if (parent === cursor) {
-        return resolved;
-      }
-      missingSegments.push(path.basename(cursor));
-      cursor = parent;
-    }
-  }
-}
-
-function rewriteSessionFileForNewSessionId(params: {
-  sessionFile?: string;
-  previousSessionId: string;
-  nextSessionId: string;
-}): string | undefined {
-  const trimmed = normalizeOptionalString(params.sessionFile);
-  if (!trimmed) {
-    return undefined;
-  }
-  const base = path.basename(trimmed);
-  if (!base.endsWith(".jsonl")) {
-    return undefined;
-  }
-  const withoutExt = base.slice(0, -".jsonl".length);
-  if (withoutExt === params.previousSessionId) {
-    return path.join(path.dirname(trimmed), `${params.nextSessionId}.jsonl`);
-  }
-  if (withoutExt.startsWith(`${params.previousSessionId}-topic-`)) {
-    return path.join(
-      path.dirname(trimmed),
-      `${params.nextSessionId}${base.slice(params.previousSessionId.length)}`,
-    );
-  }
-  const forkMatch = withoutExt.match(
-    /^(\d{4}-\d{2}-\d{2}T[\w-]+(?:Z|[+-]\d{2}(?:-\d{2})?)?)_(.+)$/,
-  );
-  if (forkMatch?.[2] === params.previousSessionId) {
-    return path.join(path.dirname(trimmed), `${forkMatch[1]}_${params.nextSessionId}.jsonl`);
-  }
-  return undefined;
 }

--- a/src/config/sessions.ts
+++ b/src/config/sessions.ts
@@ -12,6 +12,7 @@ export * from "./sessions/store.js";
 export * from "./sessions/types.js";
 export * from "./sessions/transcript.js";
 export * from "./sessions/session-file.js";
+export * from "./sessions/session-file-rotation.js";
 export * from "./sessions/delivery-info.js";
 export * from "./sessions/disk-budget.js";
 export * from "./sessions/targets.js";

--- a/src/config/sessions/session-file-rotation.ts
+++ b/src/config/sessions/session-file-rotation.ts
@@ -1,0 +1,53 @@
+import fs from "node:fs";
+import path from "node:path";
+import { normalizeOptionalString } from "../../shared/string-coerce.js";
+
+export function rewriteSessionFileForNewSessionId(params: {
+  sessionFile?: string;
+  previousSessionId: string;
+  nextSessionId: string;
+}): string | undefined {
+  const trimmed = normalizeOptionalString(params.sessionFile);
+  if (!trimmed) {
+    return undefined;
+  }
+  const base = path.basename(trimmed);
+  if (!base.endsWith(".jsonl")) {
+    return undefined;
+  }
+  const withoutExt = base.slice(0, -".jsonl".length);
+  if (withoutExt === params.previousSessionId) {
+    return path.join(path.dirname(trimmed), `${params.nextSessionId}.jsonl`);
+  }
+  if (withoutExt.startsWith(`${params.previousSessionId}-topic-`)) {
+    return path.join(
+      path.dirname(trimmed),
+      `${params.nextSessionId}${base.slice(params.previousSessionId.length)}`,
+    );
+  }
+  const forkMatch = withoutExt.match(
+    /^(\d{4}-\d{2}-\d{2}T[\w-]+(?:Z|[+-]\d{2}(?:-\d{2})?)?)_(.+)$/,
+  );
+  if (forkMatch?.[2] === params.previousSessionId) {
+    return path.join(path.dirname(trimmed), `${forkMatch[1]}_${params.nextSessionId}.jsonl`);
+  }
+  return undefined;
+}
+
+export function canonicalizeAbsoluteSessionFilePath(filePath: string): string {
+  const resolved = path.resolve(filePath);
+  const missingSegments: string[] = [];
+  let cursor = resolved;
+  while (true) {
+    try {
+      return path.join(fs.realpathSync(cursor), ...missingSegments.toReversed());
+    } catch {
+      const parent = path.dirname(cursor);
+      if (parent === cursor) {
+        return resolved;
+      }
+      missingSegments.push(path.basename(cursor));
+      cursor = parent;
+    }
+  }
+}

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -473,6 +473,23 @@ describe("session store writer queue", () => {
     expect(store["agent:main:unsafe-id"]).toBeUndefined();
   });
 
+  it("keeps metadata-only canonical sessions without treating their ids as transcript ids", async () => {
+    const { storePath } = await makeTmpStore({
+      "agent:main:metadata": {
+        sessionId: "agent:main:metadata",
+        updatedAt: Date.now(),
+        groupActivation: "always",
+      },
+    } as unknown as Record<string, SessionEntry>);
+
+    const store = loadSessionStore(storePath, { skipCache: true });
+
+    expect(store["agent:main:metadata"]).toMatchObject({
+      groupActivation: "always",
+    });
+    expect(store["agent:main:metadata"]?.sessionId).toBeUndefined();
+  });
+
   it("skips session store disk writes when payload is unchanged", async () => {
     const key = "agent:main:no-op-save";
     const { storePath } = await makeTmpStore({

--- a/src/config/sessions/store-entry-shape.ts
+++ b/src/config/sessions/store-entry-shape.ts
@@ -1,4 +1,3 @@
-import { validateSessionId } from "./paths.js";
 import type { SessionEntry } from "./types.js";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -9,12 +8,14 @@ function isSafeSessionId(value: unknown): value is string {
   if (typeof value !== "string") {
     return false;
   }
-  try {
-    validateSessionId(value);
-    return true;
-  } catch {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > 255) {
     return false;
   }
+  if (trimmed.includes("/") || trimmed.includes("\\") || trimmed === "." || trimmed === "..") {
+    return false;
+  }
+  return /^[A-Za-z0-9][A-Za-z0-9._:@-]*$/.test(trimmed);
 }
 
 function normalizeOptionalTimestamp(value: unknown): number | undefined {

--- a/src/config/sessions/store-entry-shape.ts
+++ b/src/config/sessions/store-entry-shape.ts
@@ -25,14 +25,19 @@ function normalizeOptionalTimestamp(value: unknown): number | undefined {
 }
 
 export function normalizePersistedSessionEntryShape(value: unknown): SessionEntry | undefined {
-  if (!isRecord(value) || !isSafeSessionId(value.sessionId)) {
+  if (!isRecord(value)) {
     return undefined;
   }
 
   let next = value as unknown as SessionEntry;
-  const sessionId = value.sessionId.trim();
-  if (sessionId !== value.sessionId) {
-    next = { ...next, sessionId };
+  if (value.sessionId !== undefined) {
+    if (!isSafeSessionId(value.sessionId)) {
+      return undefined;
+    }
+    const sessionId = value.sessionId.trim();
+    if (sessionId !== value.sessionId) {
+      next = { ...next, sessionId };
+    }
   }
 
   if (value.sessionFile !== undefined && typeof value.sessionFile !== "string") {

--- a/src/config/sessions/store-entry-shape.ts
+++ b/src/config/sessions/store-entry-shape.ts
@@ -1,3 +1,4 @@
+import { validateSessionId } from "./paths.js";
 import type { SessionEntry } from "./types.js";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -18,6 +19,14 @@ function isSafeSessionId(value: unknown): value is string {
   return /^[A-Za-z0-9][A-Za-z0-9._:@-]*$/.test(trimmed);
 }
 
+function normalizeTranscriptSessionId(value: string): string | undefined {
+  try {
+    return validateSessionId(value);
+  } catch {
+    return undefined;
+  }
+}
+
 function normalizeOptionalTimestamp(value: unknown): number | undefined {
   if (value === undefined) {
     return undefined;
@@ -31,12 +40,17 @@ export function normalizePersistedSessionEntryShape(value: unknown): SessionEntr
   }
 
   let next = value as unknown as SessionEntry;
+  const sessionFile = typeof value.sessionFile === "string" ? value.sessionFile.trim() : undefined;
   if (value.sessionId !== undefined) {
     if (!isSafeSessionId(value.sessionId)) {
       return undefined;
     }
     const sessionId = value.sessionId.trim();
-    if (sessionId !== value.sessionId) {
+    const transcriptSessionId = normalizeTranscriptSessionId(sessionId);
+    if (!transcriptSessionId && !sessionFile) {
+      const { sessionId: _dropSessionId, ...rest } = next;
+      next = rest as SessionEntry;
+    } else if (sessionId !== value.sessionId) {
       next = { ...next, sessionId };
     }
   }

--- a/src/gateway/server.sessions.reset-models.test.ts
+++ b/src/gateway/server.sessions.reset-models.test.ts
@@ -93,6 +93,52 @@ test("sessions.reset drops cached skills snapshot so /new rebuilds visible skill
   expect(store["agent:main:main"]?.skillsSnapshot).toBeUndefined();
 });
 
+test("sessions.reset rotates generated topic transcript files with the new session id", async () => {
+  const { dir, storePath } = await createSessionStoreDir();
+  const previousSessionId = "11111111-1111-4111-8111-111111111111";
+  const previousSessionFile = path.join(dir, `${previousSessionId}-topic-456.jsonl`);
+  await fs.writeFile(previousSessionFile, `${JSON.stringify({ role: "user", content: "old" })}\n`);
+
+  await writeSessionStore({
+    entries: {
+      "agent:main:telegram:group:123:topic:456": sessionStoreEntry(previousSessionId, {
+        sessionFile: previousSessionFile,
+      }),
+    },
+  });
+
+  const reset = await directSessionReq<{
+    ok: true;
+    key: string;
+    entry: {
+      sessionId: string;
+      sessionFile?: string;
+    };
+  }>("sessions.reset", {
+    key: "agent:main:telegram:group:123:topic:456",
+  });
+
+  expect(reset.ok).toBe(true);
+  const nextSessionId = reset.payload?.entry.sessionId;
+  const nextSessionFile = reset.payload?.entry.sessionFile;
+  if (!nextSessionId || !nextSessionFile) {
+    throw new Error("expected reset session id and file");
+  }
+  expect(nextSessionId).not.toBe(previousSessionId);
+  expect(path.basename(nextSessionFile)).toBe(`${nextSessionId}-topic-456.jsonl`);
+
+  const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+    string,
+    {
+      sessionId?: string;
+      sessionFile?: string;
+    }
+  >;
+  const persistedEntry = store["agent:main:telegram:group:123:topic:456"];
+  expect(persistedEntry?.sessionId).toBe(nextSessionId);
+  expect(path.basename(persistedEntry?.sessionFile ?? "")).toBe(`${nextSessionId}-topic-456.jsonl`);
+});
+
 test("sessions.reset preserves legacy explicit model overrides without modelOverrideSource", async () => {
   const { storePath } = await createSessionStoreDir();
   testState.agentConfig = {

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -23,6 +23,10 @@ import {
 } from "../config/sessions.js";
 import { resolveSessionFilePath, resolveSessionFilePathOptions } from "../config/sessions/paths.js";
 import { resolveResetPreservedSelection } from "../config/sessions/reset-preserved-selection.js";
+import {
+  canonicalizeAbsoluteSessionFilePath,
+  rewriteSessionFileForNewSessionId,
+} from "../config/sessions/session-file-rotation.js";
 import type { SessionAcpMeta } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { logVerbose } from "../globals.js";
@@ -57,6 +61,35 @@ import {
 } from "./session-utils.js";
 
 const ACP_RUNTIME_CLEANUP_TIMEOUT_MS = 15_000;
+
+function resolveResetSessionFile(params: {
+  nextSessionId: string;
+  currentEntry?: SessionEntry;
+  storePath: string;
+  agentId: string;
+}): string {
+  const currentEntry = params.currentEntry;
+  const rewrittenSessionFile = currentEntry?.sessionId
+    ? rewriteSessionFileForNewSessionId({
+        sessionFile: currentEntry.sessionFile,
+        previousSessionId: currentEntry.sessionId,
+        nextSessionId: params.nextSessionId,
+      })
+    : undefined;
+  const normalizedRewrittenSessionFile =
+    rewrittenSessionFile && path.isAbsolute(rewrittenSessionFile)
+      ? canonicalizeAbsoluteSessionFilePath(rewrittenSessionFile)
+      : rewrittenSessionFile;
+  const preservedSessionFile = normalizedRewrittenSessionFile ?? currentEntry?.sessionFile;
+  return resolveSessionFilePath(
+    params.nextSessionId,
+    preservedSessionFile ? { sessionFile: preservedSessionFile } : undefined,
+    resolveSessionFilePathOptions({
+      storePath: params.storePath,
+      agentId: params.agentId,
+    }),
+  );
+}
 
 function stripRuntimeModelState(entry?: SessionEntry): SessionEntry | undefined {
   if (!entry) {
@@ -683,14 +716,12 @@ export async function performGatewaySessionReset(params: {
     oldSessionFile = currentEntry?.sessionFile;
     const now = Date.now();
     const nextSessionId = randomUUID();
-    const sessionFile = resolveSessionFilePath(
+    const sessionFile = resolveResetSessionFile({
       nextSessionId,
-      currentEntry?.sessionFile ? { sessionFile: currentEntry.sessionFile } : undefined,
-      resolveSessionFilePathOptions({
-        storePath,
-        agentId: sessionAgentId,
-      }),
-    );
+      currentEntry,
+      storePath,
+      agentId: sessionAgentId,
+    });
     const nextEntry: SessionEntry = {
       sessionId: nextSessionId,
       sessionFile,


### PR DESCRIPTION
## Summary

- Rotate reset transcript files with per-session topic suffixes so reset-model flows preserve prior conversation state in the expected file.
- Reap plugin-local ACP adapter orphans on ACPX startup after a generated wrapper crash.
- Keep direct ACP adapter commands out of OpenClaw launch-lease argument injection.

Fixes #82364

## Verification

- `env CI=1 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 node scripts/run-vitest.mjs extensions/acpx/src/process-reaper.test.ts extensions/acpx/src/runtime.test.ts --run --reporter=verbose`
- `git diff --check`
- `codex review --uncommitted`
- Crabbox AWS run `run_01d90f447321`
- Crabbox AWS run `run_0101eefa2e9a` for Bug A reset transcript proof
- Crabbox AWS run `run_12fb81ab2664` for Bug B live Codex/auth plus orphan reap proof

## Real behavior proof

Behavior addressed: Bug A reset transcript rotation and Bug B ACPX/Codex orphan process cleanup for #82364.
Real environment tested: Raw AWS Crabbox Linux leases with Node v22.22.2 and pnpm 11.1.0 installed directly on the lease; Bug B used a real `OPENAI_API_KEY` forwarded through Crabbox env-profile redaction.
Exact steps or command run after this patch: Bug A ran the focused gateway reset regression for `sessions.reset rotates generated topic transcript files with the new session id`. Bug B ran `acpx codex exec` with `OPENAI_API_KEY` and `ACPX_AUTH_OPENAI_API_KEY`, then started the real plugin-local `@zed-industries/codex-acp` launcher/platform binary, forced the platform adapter into the observed PID 1 orphan shape, and invoked `reapStaleOpenClawOwnedAcpxOrphans`.
Evidence after fix: Bug A Crabbox run `run_0101eefa2e9a` passed the reset regression. Bug B Crabbox run `run_12fb81ab2664` observed live Codex output `OPENCLAW_BUG_B_LIVE_OK`, then observed orphan candidate `{"pid":3640,"ppid":1,"command":"$PWD/node_modules/@zed-industries/codex-acp-linux-x64/bin/codex-acp"}` and reaper result `{"inspectedPids":[3490,3640],"terminatedPids":[3490,3640]}`.
Observed result after fix: Bug A persisted a reset topic session with a new session id and matching topic transcript filename; Bug B ended with `remaining targeted processes after reap: []` and `BUG_B_LIVE_REPRO_PROOF_OK`.
What was not tested: This did not replay the original Telegram production incident end-to-end; Bug B proves live Codex auth plus the orphaned ACP adapter cleanup path rather than the exact original failed-initialize timing.
