### PR TITLE
fix(agents): enable reasoning-only turn retry for Bedrock Converse models

### DIFF
--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -1398,6 +1398,38 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     expect(retryInstruction).toBe(REASONING_ONLY_RETRY_INSTRUCTION);
   });
 
+  it("retries signed reasoning-only Bedrock Converse turns with a visible-answer continuation instruction", () => {
+    const retryInstruction = resolveReasoningOnlyRetryInstruction({
+      provider: "amazon-bedrock",
+      modelId: "openai.gpt-oss-120b-1:0",
+      modelApi: "bedrock-converse-stream",
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "amazon-bedrock",
+          model: "openai.gpt-oss-120b-1:0",
+          content: [
+            {
+              type: "text",
+              text: "",
+            },
+            {
+              type: "thinking",
+              thinking: "internal reasoning about calling web_search",
+              thinkingSignature: "",
+            },
+          ],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    });
+
+    expect(retryInstruction).toBe(REASONING_ONLY_RETRY_INSTRUCTION);
+  });
+
   it("retries unsigned-thinking Ollama turns via the empty-response path", () => {
     const retryInstruction = resolveEmptyResponseRetryInstruction({
       provider: "ollama",

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -619,9 +619,11 @@ function shouldApplyNonVisibleTurnRetryGuard(params: {
   if (shouldApplyPlanningOnlyRetryGuard(params)) {
     return true;
   }
+  const normalizedModelApi = normalizeLowercaseStringOrEmpty(params.modelApi ?? "");
   if (
-    normalizeLowercaseStringOrEmpty(params.modelApi ?? "") === "openai-completions" ||
-    normalizeLowercaseStringOrEmpty(params.modelApi ?? "") === "anthropic-messages"
+    normalizedModelApi === "openai-completions" ||
+    normalizedModelApi === "anthropic-messages" ||
+    normalizedModelApi === "bedrock-converse-stream"
   ) {
     return true;
   }


### PR DESCRIPTION
## Summary

When a Bedrock Converse model returns a turn containing only thinking content with empty visible text (`stopReason: "stop"`), the non-visible turn retry guard in `shouldApplyNonVisibleTurnRetryGuard` skipped it because `bedrock-converse-stream` was not in the allowed `modelApi` list. This caused the run to complete as `finalStatus: "success"` with zero deliverable content, surfacing the generic "⚠️ Something went wrong" fallback instead of retrying with a visible-answer continuation instruction.

## Related Issue

Closes #82394

## Changes

- **`src/agents/pi-embedded-runner/run/incomplete-turn.ts`**: Added `bedrock-converse-stream` to the `shouldApplyNonVisibleTurnRetryGuard` modelApi allowlist, alongside the existing `openai-completions` and `anthropic-messages` entries. Also extracted the repeated `normalizeLowercaseStringOrEmpty` call into a local variable.
- **`src/agents/pi-embedded-runner/run.incomplete-turn.test.ts`**: Added test case verifying that reasoning-only Bedrock Converse turns (matching the exact content structure from the issue report: empty text block + signed thinking block with `thinkingSignature: ""`) produce a retry instruction.

## Root Cause

`shouldApplyNonVisibleTurnRetryGuard` gates which providers/modelApis get reasoning-only and empty-response retry logic. It checked for `anthropic-messages`, `openai-completions`, strict-agentic providers (OpenAI/Gemini), and Ollama — but not `bedrock-converse-stream`. Bedrock Converse uses the same Anthropic-style message format and can produce identical thinking-only turns, so it should have the same retry behavior.

## Testing

```
npx vitest run src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
# 2 test files, 188 tests passed (0 failed)
```

## Real behavior proof

**Behavior or issue addressed**: Bedrock Converse reasoning-only turns (empty text + signed thinking block) now correctly trigger the non-visible turn retry guard instead of falling through as an empty "success" with no deliverable content.

**Real environment tested**: Node.js v24.14.1 on Linux 6.17.0-22-generic (x64), vitest test runner against the actual `resolveReasoningOnlyRetryInstruction` and `shouldApplyNonVisibleTurnRetryGuard` functions from this PR's branch.

**Exact steps or command run after this patch**:

```bash
cd ~/repos/forks/openclaw
git checkout fix/thinking-only-empty-turn-detection
npx vitest run src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
```

The new test case `"retries signed reasoning-only Bedrock Converse turns with a visible-answer continuation instruction"` exercises the exact scenario from issue #82394:
1. Constructs a Bedrock Converse assistant message with `provider: "amazon-bedrock"`, `modelApi: "bedrock-converse-stream"`, containing `[{type: "text", text: ""}, {type: "thinking", thinking: "...", thinkingSignature: ""}]`
2. Calls `resolveReasoningOnlyRetryInstruction()` which internally invokes `shouldApplyNonVisibleTurnRetryGuard()`
3. Before fix: returns `null` (guard rejects `bedrock-converse-stream` → no retry → empty success)
4. After fix: returns `REASONING_ONLY_RETRY_INSTRUCTION` (guard accepts `bedrock-converse-stream` → retry fires)

**Evidence after fix**:

```
 ✓ agents-core src/agents/pi-embedded-runner/run.incomplete-turn.test.ts (94 tests) 3779ms
 ✓ agents-pi-embedded src/agents/pi-embedded-runner/run.incomplete-turn.test.ts (94 tests) 3654ms
 Test Files  2 passed (2)
      Tests  188 passed (188)
```

**Observed result after fix**: `resolveReasoningOnlyRetryInstruction` correctly returns the retry instruction for `bedrock-converse-stream` modelApi with reasoning-only content, matching the existing behavior for `anthropic-messages` and `openai-completions`. All 188 existing + new tests pass with zero regressions.

**What was not tested**: Live Bedrock Converse API call (no `amazon-bedrock` credentials available). The fix is a one-line allowlist addition following the exact same pattern as the existing `anthropic-messages` entry, and Bedrock Converse is already treated as Anthropic-family in other parts of the codebase (e.g., `transcript-policy.ts:67`). The unit test uses the exact content structure from the issue report.