### PR TITLE
Fix stale bootstrap file breaking channel agent turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Docs: https://docs.openclaw.ai
 - Voice calls: persist rejected inbound-call replay keys so duplicate carrier webhook retries stay ignored after a Gateway restart.
 - Config/doctor: copy fallback-enabled channel `allowFrom` entries into explicit `groupAllowFrom` allowlists during `openclaw doctor --fix`, preserving current group access without adding runtime fallback-transition flags.
 - Config/doctor: replace source-only official Brave and Slack plugin installs from trusted catalog metadata during `openclaw doctor --fix`, unblocking externalized stock plugin recovery after upgrade. (#82425) Thanks @joshavant.
+- Agents/bootstrap: ignore stale completed root `BOOTSTRAP.md` context after workspace setup cleanup fails, preventing channel agent turns from treating it as a directory. (#82463) Thanks @joshavant.
 - Configure: show one OpenAI provider entry with ChatGPT/Codex sign-in and API key choices, and keep browsed Codex models in the saved `/model` picker allowlist.
 - Agents/model fallback: preserve auto fallback chains across deferred config reloads when session fallback provenance survives but `modelOverrideSource` is missing. Fixes #81982. Thanks @joshavant.
 - Hooks: raise bounded gateway lifecycle hook wait budgets to 5 seconds for shutdown and 10 seconds for pre-restart, giving short restart notification handlers time to finish before shutdown continues. (#82273) Thanks @bryanbaer.

--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -81,6 +81,21 @@ function registerDuplicateBootstrapFileHook() {
   });
 }
 
+function registerBootstrapFileHook(relativePath = "BOOTSTRAP.md") {
+  registerInternalHook("agent:bootstrap", (event) => {
+    const context = event.context as AgentBootstrapHookContext;
+    context.bootstrapFiles = [
+      ...context.bootstrapFiles,
+      {
+        name: "BOOTSTRAP.md",
+        path: path.join(context.workspaceDir, relativePath),
+        content: "stale ritual",
+        missing: false,
+      },
+    ];
+  });
+}
+
 async function createHeartbeatAgentsWorkspace() {
   const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
   await fs.writeFile(path.join(workspaceDir, "HEARTBEAT.md"), "check inbox", "utf8");
@@ -148,6 +163,124 @@ describe("resolveBootstrapFilesForRun", () => {
     const agentsContextFiles = context.contextFiles.filter((file) => file.path === agentsPath);
     expect(agentsContextFiles).toHaveLength(1);
     expect(agentsContextFiles[0]?.content).toBe("workspace rules");
+  });
+
+  it("ignores stale workspace BOOTSTRAP.md once setup is completed", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    await fs.mkdir(path.join(workspaceDir, ".openclaw"), { recursive: true });
+    await fs.writeFile(
+      path.join(workspaceDir, ".openclaw", "workspace-state.json"),
+      `${JSON.stringify({
+        version: 1,
+        bootstrapSeededAt: "2026-05-16T00:00:00.000Z",
+        setupCompletedAt: "2026-05-16T00:00:01.000Z",
+      })}\n`,
+      "utf8",
+    );
+    await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "rules", "utf8");
+    await fs.writeFile(path.join(workspaceDir, "BOOTSTRAP.md"), "stale ritual", "utf8");
+
+    const files = await resolveBootstrapFilesForRun({ workspaceDir });
+
+    expect(files.map((file) => file.name)).toContain("AGENTS.md");
+    expect(files.map((file) => file.name)).not.toContain("BOOTSTRAP.md");
+  });
+
+  it("keeps BOOTSTRAP.md when setup state cannot be read", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    await fs.mkdir(path.join(workspaceDir, ".openclaw", "workspace-state.json"), {
+      recursive: true,
+    });
+    await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "rules", "utf8");
+    await fs.writeFile(path.join(workspaceDir, "BOOTSTRAP.md"), "ritual", "utf8");
+
+    const files = await resolveBootstrapFilesForRun({ workspaceDir });
+
+    expect(files.map((file) => file.name)).toContain("BOOTSTRAP.md");
+  });
+
+  it("does not let hooks re-add stale root BOOTSTRAP.md after setup is completed", async () => {
+    registerBootstrapFileHook();
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    await fs.mkdir(path.join(workspaceDir, ".openclaw"), { recursive: true });
+    await fs.writeFile(
+      path.join(workspaceDir, ".openclaw", "workspace-state.json"),
+      `${JSON.stringify({
+        version: 1,
+        bootstrapSeededAt: "2026-05-16T00:00:00.000Z",
+        setupCompletedAt: "2026-05-16T00:00:01.000Z",
+      })}\n`,
+      "utf8",
+    );
+    await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "rules", "utf8");
+    await fs.writeFile(path.join(workspaceDir, "BOOTSTRAP.md"), "stale ritual", "utf8");
+
+    const files = await resolveBootstrapFilesForRun({ workspaceDir });
+
+    expect(files.map((file) => file.name)).not.toContain("BOOTSTRAP.md");
+  });
+
+  it("ignores stale root BOOTSTRAP.md for home-relative workspace paths", async () => {
+    registerBootstrapFileHook();
+    const parentDir = await makeTempWorkspace("openclaw-bootstrap-home-");
+    const workspaceDir = path.join(parentDir, "workspace");
+    await fs.mkdir(path.join(workspaceDir, ".openclaw"), { recursive: true });
+    await fs.writeFile(
+      path.join(workspaceDir, ".openclaw", "workspace-state.json"),
+      `${JSON.stringify({
+        version: 1,
+        bootstrapSeededAt: "2026-05-16T00:00:00.000Z",
+        setupCompletedAt: "2026-05-16T00:00:01.000Z",
+      })}\n`,
+      "utf8",
+    );
+    await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "rules", "utf8");
+    await fs.writeFile(path.join(workspaceDir, "BOOTSTRAP.md"), "stale ritual", "utf8");
+
+    const previousOpenClawHome = process.env.OPENCLAW_HOME;
+    process.env.OPENCLAW_HOME = parentDir;
+    try {
+      const files = await resolveBootstrapFilesForRun({ workspaceDir: "~/workspace" });
+
+      expect(files.map((file) => file.name)).toContain("AGENTS.md");
+      expect(files.map((file) => file.name)).not.toContain("BOOTSTRAP.md");
+    } finally {
+      if (previousOpenClawHome === undefined) {
+        delete process.env.OPENCLAW_HOME;
+      } else {
+        process.env.OPENCLAW_HOME = previousOpenClawHome;
+      }
+    }
+  });
+
+  it("keeps hook-added nested BOOTSTRAP.md after setup is completed", async () => {
+    registerBootstrapFileHook(path.join("packages", "core", "BOOTSTRAP.md"));
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    await fs.mkdir(path.join(workspaceDir, ".openclaw"), { recursive: true });
+    await fs.mkdir(path.join(workspaceDir, "packages", "core"), { recursive: true });
+    await fs.writeFile(
+      path.join(workspaceDir, ".openclaw", "workspace-state.json"),
+      `${JSON.stringify({
+        version: 1,
+        bootstrapSeededAt: "2026-05-16T00:00:00.000Z",
+        setupCompletedAt: "2026-05-16T00:00:01.000Z",
+      })}\n`,
+      "utf8",
+    );
+    await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "rules", "utf8");
+    await fs.writeFile(path.join(workspaceDir, "BOOTSTRAP.md"), "stale ritual", "utf8");
+    await fs.writeFile(
+      path.join(workspaceDir, "packages", "core", "BOOTSTRAP.md"),
+      "package ritual",
+      "utf8",
+    );
+
+    const files = await resolveBootstrapFilesForRun({ workspaceDir });
+
+    expect(files.map((file) => path.relative(workspaceDir, file.path))).toContain(
+      path.join("packages", "core", "BOOTSTRAP.md"),
+    );
+    expect(files.map((file) => file.path)).not.toContain(path.join(workspaceDir, "BOOTSTRAP.md"));
   });
 });
 

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import type { AgentContextInjection } from "../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
+import { resolveUserPath } from "../utils.js";
 import { resolveAgentConfig, resolveSessionAgentIds } from "./agent-scope.js";
 import { getOrLoadBootstrapFiles } from "./bootstrap-cache.js";
 import { applyBootstrapHookOverrides } from "./bootstrap-hooks.js";
@@ -15,7 +16,9 @@ import {
 } from "./pi-embedded-helpers.js";
 import {
   DEFAULT_HEARTBEAT_FILENAME,
+  DEFAULT_BOOTSTRAP_FILENAME,
   filterBootstrapFilesForSession,
+  isWorkspaceSetupCompleted,
   isWorkspaceBootstrapPending,
   loadWorkspaceBootstrapFiles,
   type WorkspaceBootstrapFile,
@@ -158,7 +161,7 @@ function sanitizeBootstrapFiles(
   workspaceDir: string,
   warn?: (message: string) => void,
 ): WorkspaceBootstrapFile[] {
-  const workspaceRoot = path.resolve(workspaceDir);
+  const workspaceRoot = resolveUserPath(workspaceDir);
   const seenPaths = new Set<string>();
   const sanitized: WorkspaceBootstrapFile[] = [];
   for (const file of files) {
@@ -171,7 +174,9 @@ function sanitizeBootstrapFiles(
     }
     const resolvedPath = path.isAbsolute(pathValue)
       ? path.resolve(pathValue)
-      : path.resolve(workspaceRoot, pathValue);
+      : pathValue.startsWith("~")
+        ? resolveUserPath(pathValue)
+        : path.resolve(workspaceRoot, pathValue);
     const dedupeKey = path.normalize(path.relative(workspaceRoot, resolvedPath));
     if (seenPaths.has(dedupeKey)) {
       continue;
@@ -234,6 +239,41 @@ function filterHeartbeatBootstrapFile(
   return files.filter((file) => file.name !== DEFAULT_HEARTBEAT_FILENAME);
 }
 
+function filterCompletedWorkspaceBootstrapFile(
+  files: WorkspaceBootstrapFile[],
+  setupCompleted: boolean,
+  workspaceDir: string,
+): WorkspaceBootstrapFile[] {
+  if (!setupCompleted) {
+    return files;
+  }
+  const workspaceRoot = resolveUserPath(workspaceDir);
+  const rootBootstrapPath = path.join(workspaceRoot, DEFAULT_BOOTSTRAP_FILENAME);
+  return files.filter((file) => {
+    if (file.name !== DEFAULT_BOOTSTRAP_FILENAME) {
+      return true;
+    }
+    const pathValue = normalizeOptionalString(file.path);
+    if (!pathValue) {
+      return true;
+    }
+    const resolvedPath = path.isAbsolute(pathValue)
+      ? path.resolve(pathValue)
+      : pathValue.startsWith("~")
+        ? resolveUserPath(pathValue)
+        : path.resolve(workspaceRoot, pathValue);
+    return resolvedPath !== rootBootstrapPath;
+  });
+}
+
+async function isWorkspaceSetupCompletedForContext(workspaceDir: string): Promise<boolean> {
+  try {
+    return await isWorkspaceSetupCompleted(workspaceDir);
+  } catch {
+    return false;
+  }
+}
+
 export async function resolveBootstrapFilesForRun(params: {
   workspaceDir: string;
   config?: OpenClawConfig;
@@ -246,6 +286,7 @@ export async function resolveBootstrapFilesForRun(params: {
 }): Promise<WorkspaceBootstrapFile[]> {
   const excludeHeartbeatBootstrapFile = shouldExcludeHeartbeatBootstrapFile(params);
   const sessionKey = params.sessionKey ?? params.sessionId;
+  const workspaceSetupCompleted = await isWorkspaceSetupCompletedForContext(params.workspaceDir);
   const rawFiles = params.sessionKey
     ? await getOrLoadBootstrapFiles({
         workspaceDir: params.workspaceDir,
@@ -253,7 +294,11 @@ export async function resolveBootstrapFilesForRun(params: {
       })
     : await loadWorkspaceBootstrapFiles(params.workspaceDir);
   const bootstrapFiles = applyContextModeFilter({
-    files: filterBootstrapFilesForSession(rawFiles, sessionKey),
+    files: filterCompletedWorkspaceBootstrapFile(
+      filterBootstrapFilesForSession(rawFiles, sessionKey),
+      workspaceSetupCompleted,
+      params.workspaceDir,
+    ),
     contextMode: params.contextMode,
     runKind: params.runKind,
   });
@@ -266,8 +311,13 @@ export async function resolveBootstrapFilesForRun(params: {
     sessionId: params.sessionId,
     agentId: params.agentId,
   });
+  const filteredUpdated = filterCompletedWorkspaceBootstrapFile(
+    updated,
+    workspaceSetupCompleted,
+    params.workspaceDir,
+  );
   return sanitizeBootstrapFiles(
-    filterHeartbeatBootstrapFile(updated, excludeHeartbeatBootstrapFile),
+    filterHeartbeatBootstrapFile(filteredUpdated, excludeHeartbeatBootstrapFile),
     params.workspaceDir,
     params.warn,
   );

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { makeTempWorkspace, writeWorkspaceFile } from "../test-helpers/workspace.js";
 import {
   DEFAULT_AGENTS_FILENAME,
@@ -254,6 +254,35 @@ describe("ensureAgentWorkspace", () => {
     expect(state.setupCompletedAt).toMatch(/\d{4}-\d{2}-\d{2}T/);
     await expect(resolveWorkspaceBootstrapStatus(tempDir)).resolves.toBe("complete");
     await expect(isWorkspaceBootstrapPending(tempDir)).resolves.toBe(false);
+  });
+
+  it("records stale bootstrap completion when BOOTSTRAP.md cleanup fails", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+    await writeWorkspaceFile({
+      dir: tempDir,
+      name: DEFAULT_IDENTITY_FILENAME,
+      content: "# IDENTITY.md\n\n- **Name:** Example\n",
+    });
+    const bootstrapPath = path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME);
+    const rmSpy = vi
+      .spyOn(fs, "rm")
+      .mockRejectedValueOnce(Object.assign(new Error("not a directory"), { code: "ENOTDIR" }));
+
+    try {
+      const result = await reconcileWorkspaceBootstrapCompletion(tempDir);
+
+      expect(result.repaired).toBe(true);
+      expect(result.bootstrapExists).toBe(true);
+      expect(rmSpy).toHaveBeenCalledWith(bootstrapPath, { force: true });
+      await expect(fs.access(bootstrapPath)).resolves.toBeUndefined();
+      const state = await readWorkspaceState(tempDir);
+      expect(state.setupCompletedAt).toMatch(/\d{4}-\d{2}-\d{2}T/);
+      await expect(resolveWorkspaceBootstrapStatus(tempDir)).resolves.toBe("complete");
+      await expect(isWorkspaceBootstrapPending(tempDir)).resolves.toBe(false);
+    } finally {
+      rmSpy.mockRestore();
+    }
   });
 
   it("uses SOUL.md customization as stale bootstrap completion evidence", async () => {

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -299,9 +299,14 @@ async function reconcileWorkspaceBootstrapCompletionState(params: {
     bootstrapSeededAt: params.state.bootstrapSeededAt ?? now,
     setupCompletedAt: now,
   };
-  await fs.rm(params.bootstrapPath, { force: true });
   await writeWorkspaceSetupState(params.statePath, repairedState);
-  return { repaired: true, bootstrapExists: false, state: repairedState };
+  try {
+    await fs.rm(params.bootstrapPath, { force: true });
+    return { repaired: true, bootstrapExists: false, state: repairedState };
+  } catch {
+    // Completion state is authoritative; stale BOOTSTRAP cleanup is best-effort.
+    return { repaired: true, bootstrapExists: true, state: repairedState };
+  }
 }
 
 function resolveWorkspaceStatePath(dir: string): string {


### PR DESCRIPTION
## Summary

- Problem: completed workspaces can retain a stale root `BOOTSTRAP.md` that fails cleanup, and later inbound channel turns can treat that file as pending bootstrap context.
- Why it matters: a regular stale `BOOTSTRAP.md` can break agent-mode message processing with `ENOTDIR` when the agent runtime tries to scan it as a workspace source.
- What changed: workspace bootstrap completion state is recorded before best-effort stale-file cleanup, and completed workspaces filter only the stale workspace-root `BOOTSTRAP.md` from bootstrap context.
- What did NOT change: nested `BOOTSTRAP.md` files and unreadable workspace state keep their previous behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #82291
- [x] This PR fixes a bug or regression

## Real behavior proof

Behavior addressed: agent-mode channel inbound no longer fails when a completed workspace still has a stale regular `BOOTSTRAP.md` that cleanup cannot remove.

Real environment tested: AWS Crabbox Linux lease `cbx_c3899c818c6a`, Docker E2E runner, packaged OpenClaw tarball from this branch, ClickClack fixture in `replyMode: "agent"`, mock OpenAI Responses API.

Exact steps or command run after this patch: packaged this branch, installed the package in the Docker E2E runner, started Gateway and ClickClack, seeded `~/.openclaw/workspace/BOOTSTRAP.md` as a stale regular file, removed write permission from the workspace directory so cleanup could not remove it, sent ClickClack inbound `Return marker OPENCLAW_E2E_OK_82291`, and asserted the reply plus workspace state.

Evidence after fix: Crabbox run `run_b039ba0b164f` printed `workspace setupCompletedAt=2026-05-16T05:33:57.079Z`, `Issue 82291 agent-mode ClickClack E2E passed: stale BOOTSTRAP.md remained, setup state completed, inbound reply delivered.`, and `Issue 82291 Crabbox Docker E2E passed.`

Observed result after fix: the stale `BOOTSTRAP.md` remained in place, workspace setup state recorded `setupCompletedAt`, the ClickClack reply contained `OPENCLAW_E2E_OK_82291`, mock OpenAI `/v1/responses` was exercised, and gateway logs did not contain `ENOTDIR` for `BOOTSTRAP.md`.

What was not tested: real Telegram or Slack credentials were not used; ClickClack fixture covered the same agent-mode channel inbound path without external secrets.

Before evidence: Crabbox run `run_91655d775a85` on current main reproduced `[clickclack] [default] channel exited: ENOTDIR: not a directory, scandir '/home/appuser/.openclaw/workspace/BOOTSTRAP.md'` with no outbound reply.

## Root Cause

- Root cause: stale bootstrap repair wrote completion state only after deleting root `BOOTSTRAP.md`; when cleanup failed, the workspace stayed bootstrap-pending and later agent turns could include the stale root bootstrap file as runtime context.
- Missing detection / guardrail: there was no regression coverage for cleanup failure after completion evidence, nor for completed workspaces suppressing only the root stale bootstrap file after hooks.
- Contributing context: channel agent turns can run after legacy upgrades with old workspace files still present and not removable by the runtime user.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/workspace.test.ts`, `src/agents/bootstrap-files.test.ts`, and Crabbox run `run_b039ba0b164f`.
- Scenario the test should lock in: completed workspace state stays authoritative when stale `BOOTSTRAP.md` cleanup fails, and completed workspaces filter only the workspace-root stale `BOOTSTRAP.md` from bootstrap context.
- Why this is the smallest reliable guardrail: the unit tests cover the state/filtering contracts directly, and the Crabbox proof covers the packaged channel inbound path that reproduced the issue.
- Existing test that already covers this (if any): none before this PR.

## User-visible / Behavior Changes

Users with completed workspaces and stale root `BOOTSTRAP.md` files should no longer see inbound agent-mode messages fail because cleanup could not remove the stale file.

## Diagram

```text
Before:
completed workspace + stale BOOTSTRAP cleanup failure -> pending bootstrap context -> channel inbound failure

After:
completed workspace + stale BOOTSTRAP cleanup failure -> completion state persisted -> stale root bootstrap suppressed -> inbound reply delivered
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local edit loop, AWS Crabbox Linux E2E
- Runtime/container: Node 22 local tests; Docker E2E runner for packaged proof
- Model/provider: mock OpenAI Responses API
- Integration/channel: ClickClack fixture in agent reply mode
- Relevant config (redacted): ClickClack configured with env token ref and `messages.groupChat.visibleReplies: "automatic"` for visible E2E assertion

### Steps

1. Seed completed-workspace evidence with stale root `BOOTSTRAP.md` and workspace state without `setupCompletedAt`.
2. Force stale `BOOTSTRAP.md` cleanup to fail by removing workspace-directory write permission.
3. Start Gateway and send ClickClack inbound in agent mode.

### Expected

- The inbound turn completes, records workspace setup completion, avoids `ENOTDIR`, and delivers the reply.

### Actual

- Matches expected in Crabbox run `run_b039ba0b164f`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: focused local Vitest coverage, Codex dirty-diff review, current-main Crabbox reproduction, and patched packaged Crabbox E2E proof.
- Edge cases checked: unreadable workspace state preserves `BOOTSTRAP.md`, hooks cannot re-add stale root `BOOTSTRAP.md`, nested hook-added `BOOTSTRAP.md` remains available, and `~`-relative paths normalize correctly.
- What you did not verify: live Telegram or Slack credentials.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.
