### PR TITLE
fix(plugins): suppress hook-pack fallback noise when plugin lacks compiled runtime

### DIFF
--- a/src/cli/plugins-cli.install.test.ts
+++ b/src/cli/plugins-cli.install.test.ts
@@ -1482,6 +1482,32 @@ describe("plugins cli install", () => {
     expect(runtimeErrors.at(-1)).not.toContain("Also not a valid hook pack");
   });
 
+  it("does not append hook-pack fallback details when the plugin lacks compiled runtime output", async () => {
+    // Regression for #82454: third-party plugins declaring openclaw.extensions
+    // but shipping only TypeScript source produced a confusing dual error
+    // ("compiled runtime output" + "Also not a valid hook pack"). The first
+    // error already names the real problem, so the hook-pack fallback line is
+    // noise.
+    loadConfig.mockReturnValue({} as OpenClawConfig);
+    mockClawHubPackageNotFound("@sider-ai/chrome-openclaw-sider");
+    installPluginFromNpmSpec.mockResolvedValue({
+      ok: false,
+      error:
+        "package install requires compiled runtime output for TypeScript entry ./index.ts: expected ./dist/index.js, ./dist/index.mjs, ./dist/index.cjs, ./index.js, ./index.mjs, ./index.cjs. This is a plugin packaging issue, not a local config problem; update or reinstall the plugin after the publisher ships compiled JavaScript, or disable/uninstall the plugin until then. TypeScript source fallback is only supported for source checkouts and local development paths.",
+    });
+    installHooksFromNpmSpec.mockResolvedValue({
+      ok: false,
+      error: "package.json missing openclaw.hooks",
+    });
+
+    await expect(
+      runPluginsCommand(["plugins", "install", "@sider-ai/chrome-openclaw-sider"]),
+    ).rejects.toThrow("__exit__:1");
+
+    expect(runtimeErrors.at(-1)).toContain("requires compiled runtime output");
+    expect(runtimeErrors.at(-1)).not.toContain("Also not a valid hook pack");
+  });
+
   it("passes the install logger to the --link dry-run probe", async () => {
     const localPluginDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-link-plugin-"));
     const cfg = {

--- a/src/cli/plugins-command-helpers.ts
+++ b/src/cli/plugins-command-helpers.ts
@@ -187,7 +187,20 @@ export function formatPluginInstallWithHookFallbackError(
   ) {
     return formattedPluginError;
   }
+  if (isUnambiguousPluginPackagingError(pluginError)) {
+    return formattedPluginError;
+  }
   return `${formattedPluginError}\nAlso not a valid hook pack: ${formattedHookError}`;
+}
+
+// Errors that clearly identify the package as an OpenClaw plugin (e.g. it
+// declared openclaw.extensions) but failed plugin-specific validation. In
+// those cases, the hook-pack fallback can never succeed, so appending
+// "Also not a valid hook pack" only adds noise — see #82454 where a third-
+// party plugin shipping TypeScript source with no compiled output produced
+// two confusing errors instead of one actionable one.
+function isUnambiguousPluginPackagingError(pluginError: string): boolean {
+  return pluginError.includes("requires compiled runtime output for TypeScript entry");
 }
 
 const MISSING_GIT_FOR_NPM_DEPENDENCY_HINT =


### PR DESCRIPTION
## Summary

Fixes #82454. When a third-party plugin declares `openclaw.extensions` with a TypeScript entry (e.g. `./index.ts`) but ships no compiled JavaScript, the install command produced two confusing errors back-to-back:

```
package install requires compiled runtime output for TypeScript entry ./index.ts: expected ./dist/index.js, ./dist/index.mjs, ./dist/index.cjs, ./index.js, ./index.mjs, ./index.cjs.
Also not a valid hook pack: Error: package.json missing openclaw.hooks
```

The first error already names the real problem (the publisher needs to ship compiled JS). The second is noise — a package that declared `openclaw.extensions` is unambiguously trying to be a plugin, and the hook-pack fallback can never succeed for it.

This change extends the existing suppression list in `formatPluginInstallWithHookFallbackError` (which already silences the fallback for `plugin already exists` and managed-extensions boundary errors) to also drop the fallback tail for the `requires compiled runtime output` error.

The underlying packaging problem is in the third-party plugin (it needs to publish compiled JavaScript). This PR is purely about making the error message we already emit actionable instead of doubled up. Surface area is minimal; no resolver behavior changes.

## Changes

- `src/cli/plugins-command-helpers.ts`: add `isUnambiguousPluginPackagingError` check in `formatPluginInstallWithHookFallbackError`; suppress the `Also not a valid hook pack` tail when the plugin failure is a missing-compiled-runtime error.
- `src/cli/plugins-cli.install.test.ts`: regression test mirroring the existing `Invalid path: must stay within extensions directory` / `plugin already exists` suppression tests.

## Testing

- `vitest run src/cli/plugins-cli.install.test.ts src/plugins/install.test.ts src/hooks/install.test.ts` — 212 tests, all green, including the new regression test.

## Notes

- I considered the alternate fix (have the resolver follow `package.json#main`/`exports` for packages publishing outside `./dist/`) but rejected it: the orchestrator confirmed `@sider-ai/chrome-openclaw-sider` is not on the public npm registry and the reproduction shows the published package ships only TypeScript source with `openclaw.extensions: ["./index.ts"]`. Even if we follow `main`, there is no compiled artifact to resolve. The right fix is to keep the strict resolver check (already actionable on its own) and stop appending a second, misleading error.

Fixes #82454
