### PR TITLE
fix(openai-compat): map unregistered-harness errors to 503 with actionable message

### DIFF
--- a/src/gateway/openai-compat-errors.ts
+++ b/src/gateway/openai-compat-errors.ts
@@ -50,6 +50,36 @@ function messageForReason(params: {
   return params.rawError?.trim() || params.message.trim() || "request failed";
 }
 
+// Matches the error thrown by src/agents/harness/selection.ts when a forced runtime
+// (e.g. `agents.defaults.agentRuntime.id` or a per-request override) names a
+// harness plugin that isn't registered. Surfacing this as a generic 500 hides the
+// actionable cause from clients; map it to 503 service_unavailable with a message
+// that points operators at the relevant config knobs. (See issue #82437.)
+const HARNESS_NOT_REGISTERED_RE = /Requested agent harness "([^"]+)" is not registered\./;
+
+export function resolveUnregisteredHarnessError(err: unknown): OpenAiCompatError | undefined {
+  const message = err instanceof Error ? err.message : typeof err === "string" ? err : undefined;
+  if (!message) {
+    return undefined;
+  }
+  const match = HARNESS_NOT_REGISTERED_RE.exec(message);
+  if (!match) {
+    return undefined;
+  }
+  const harnessId = match[1];
+  return {
+    status: 503,
+    error: {
+      message:
+        `Requested agent harness "${harnessId}" is not registered. ` +
+        `Ensure the harness plugin is installed and enabled ` +
+        `(e.g. \`plugins.entries.${harnessId}.enabled = true\`), ` +
+        `or set \`agents.defaults.agentRuntime.id\` to a registered harness.`,
+      type: "service_unavailable",
+    },
+  };
+}
+
 export function resolveOpenAiCompatError(err: unknown): OpenAiCompatError | undefined {
   const described = describeFailoverError(err);
   const reason = described.reason;

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -1435,6 +1435,77 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
     expect(agentCommand).toHaveBeenCalledTimes(1);
   });
 
+  it("maps unregistered-harness errors to 503 with actionable message (#82437)", async () => {
+    const port = enabledPort;
+
+    agentCommand.mockClear();
+    agentCommand.mockRejectedValueOnce(
+      new Error('Requested agent harness "codex" is not registered.') as never,
+    );
+
+    const res = await postChatCompletions(port, {
+      stream: false,
+      model: "openclaw",
+      messages: [{ role: "user", content: "hi" }],
+    });
+
+    expect(res.status).toBe(503);
+    const json = (await res.json()) as { error?: { type?: string; message?: string } };
+    expect(json.error?.type).toBe("service_unavailable");
+    expect(json.error?.message).toContain('Requested agent harness "codex" is not registered');
+    expect(json.error?.message).toContain("plugins.entries.codex.enabled");
+    expect(json.error?.message).toContain("agents.defaults.agentRuntime.id");
+  });
+
+  it("emits actionable unregistered-harness message in SSE stream and finishes cleanly (#82437)", async () => {
+    const port = enabledPort;
+
+    agentCommand.mockClear();
+    agentCommand.mockRejectedValueOnce(
+      new Error('Requested agent harness "codex" is not registered.') as never,
+    );
+
+    const res = await postChatCompletions(port, {
+      stream: true,
+      model: "openclaw",
+      messages: [{ role: "user", content: "hi" }],
+    });
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    const dataLines = parseSseDataLines(text);
+    expect(dataLines[dataLines.length - 1]).toBe("[DONE]");
+
+    const chunks = dataLines
+      .filter((d) => d !== "[DONE]")
+      .map((d) => JSON.parse(d) as Record<string, unknown>);
+
+    const protocolError = chunks.find(
+      (chunk) =>
+        typeof chunk.error === "object" &&
+        ((chunk.error as { type?: unknown }).type ?? "") === "service_unavailable",
+    );
+    if (!protocolError) {
+      throw new Error("expected service_unavailable protocol error in stream");
+    }
+    const protocolMessage = String((protocolError.error as { message?: unknown }).message ?? "");
+    expect(protocolMessage).toContain('Requested agent harness "codex" is not registered');
+    expect(protocolMessage).toContain("plugins.entries.codex.enabled");
+
+    const contentDelta = chunks
+      .flatMap((c) => (c.choices as Array<Record<string, unknown>> | undefined) ?? [])
+      .map((choice) => (choice.delta as Record<string, unknown> | undefined)?.content)
+      .find((content): content is string => typeof content === "string" && content.length > 0);
+    expect(contentDelta).toBeDefined();
+    expect(contentDelta).toContain('Requested agent harness "codex" is not registered');
+    expect(contentDelta).toContain("plugins.entries.codex.enabled");
+
+    // Stream must close cleanly with finish_reason=stop, not just dangle.
+    const stopChoice = chunks
+      .flatMap((c) => (c.choices as Array<Record<string, unknown>> | undefined) ?? [])
+      .find((choice) => choice.finish_reason === "stop");
+    expect(stopChoice).toBeDefined();
+  });
+
   it("forwards response_format into streamParams", async () => {
     const port = enabledPort;
     const mockAgentOnce = (payloads: Array<{ text: string }>) => {

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -46,7 +46,11 @@ import {
   resolveOpenAiCompatibleHttpSenderIsOwner,
 } from "./http-utils.js";
 import { normalizeInputHostnameAllowlist } from "./input-allowlist.js";
-import { resolveOpenAiCompatError, validateOpenAiSamplingParams } from "./openai-compat-errors.js";
+import {
+  resolveOpenAiCompatError,
+  resolveUnregisteredHarnessError,
+  validateOpenAiSamplingParams,
+} from "./openai-compat-errors.js";
 
 type OpenAiHttpOptions = {
   auth: ResolvedGatewayAuth;
@@ -1036,6 +1040,11 @@ export async function handleOpenAiHttpRequest(
         });
         return true;
       }
+      const unregisteredHarness = resolveUnregisteredHarnessError(err);
+      if (unregisteredHarness) {
+        sendJson(res, unregisteredHarness.status, { error: unregisteredHarness.error });
+        return true;
+      }
       const mapped = resolveOpenAiCompatError(err);
       if (mapped) {
         sendJson(res, mapped.status, { error: mapped.error });
@@ -1212,6 +1221,27 @@ export async function handleOpenAiHttpRequest(
         writeSse(res, {
           error: { message: "invalid tool configuration", type: "invalid_request_error" },
         });
+        writeDone(res);
+        res.end();
+        return;
+      }
+      const unregisteredHarness = resolveUnregisteredHarnessError(err);
+      if (unregisteredHarness) {
+        closed = true;
+        stopWatchingDisconnect();
+        unsubscribe();
+        if (!wroteRole) {
+          wroteRole = true;
+          writeAssistantRoleChunk(res, { runId, model });
+        }
+        writeAssistantContentChunk(res, {
+          runId,
+          model,
+          content: unregisteredHarness.error.message,
+          finishReason: "stop",
+        });
+        wroteStopChunk = true;
+        writeSse(res, { error: unregisteredHarness.error });
         writeDone(res);
         res.end();
         return;


### PR DESCRIPTION
Closes #82437

## Root cause

In v2026.5.12, `POST /v1/chat/completions` returns a bare `500 {"error":{"message":"internal error","type":"api_error"}}` whenever the gateway can't find a runtime harness named in the request/config (e.g. `codex`). The underlying error message — `Requested agent harness "<id>" is not registered.` from `src/agents/harness/selection.ts:101` — is explicit and actionable, but the generic catch in `openai-http.ts` masks it.

This makes the failure look like a transient server bug rather than what it actually is: a misconfiguration the operator can fix.

## Fix

Add a small helper `resolveUnregisteredHarnessError` in `src/gateway/openai-compat-errors.ts` that:

- Detects the `Requested agent harness "<id>" is not registered.` shape via regex.
- Maps it to `503 service_unavailable` (the harness *might* come online once the plugin is installed/enabled, so 503 fits better than 4xx).
- Returns an actionable message that names the harness id and points at the two relevant config knobs (`plugins.entries.<id>.enabled` and `agents.defaults.agentRuntime.id`).

Wire it into both catch blocks in `src/gateway/openai-http.ts` (non-streaming around line 1031, streaming around line 1207), placed right after the existing `isClientToolNameConflictError` check and before `resolveOpenAiCompatError`. For the streaming path the actionable message is also emitted as a content delta (replacing the prior `"Error: internal error"` fallback for this specific case), so OpenAI-style clients that only render `choices[0].delta.content` still see the real reason. The SSE protocol error chunk is also emitted (mirroring how nearby "mapped" errors are streamed), then `[DONE]` and `res.end()` close the stream cleanly.

## Files changed

- `src/gateway/openai-compat-errors.ts` — add `resolveUnregisteredHarnessError` helper.
- `src/gateway/openai-http.ts` — wire helper into both non-streaming and streaming catch blocks.
- `src/gateway/openai-http.test.ts` — add one non-streaming and one streaming regression test.

## Before / after

**Before (non-streaming):**

```
HTTP/1.1 500 Internal Server Error
content-type: application/json

{"error":{"message":"internal error","type":"api_error"}}
```

**After (non-streaming):**

```
HTTP/1.1 503 Service Unavailable
content-type: application/json

{
  "error": {
    "message": "Requested agent harness \"codex\" is not registered. Ensure the harness plugin is installed and enabled (e.g. `plugins.entries.codex.enabled = true`), or set `agents.defaults.agentRuntime.id` to a registered harness.",
    "type": "service_unavailable"
  }
}
```

**After (streaming, abbreviated):**

```
data: {"id":"...","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}], ...}
data: {"id":"...","choices":[{"index":0,"delta":{"content":"Requested agent harness \"codex\" is not registered. Ensure the harness plugin is installed and enabled (e.g. `plugins.entries.codex.enabled = true`), or set `agents.defaults.agentRuntime.id` to a registered harness."},"finish_reason":"stop"}], ...}
data: {"error":{"message":"Requested agent harness \"codex\" is not registered. ...","type":"service_unavailable"}}
data: [DONE]
```

## Tests

```
node scripts/run-vitest.mjs run src/gateway/openai-http.test.ts
```

Result: `2 passed (2)` / `36 passed (36)` across both gateway-server and gateway-client lanes, including the two new tests:

- `maps unregistered-harness errors to 503 with actionable message (#82437)`
- `emits actionable unregistered-harness message in SSE stream and finishes cleanly (#82437)`

Typecheck:

```
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src.tsbuildinfo
```

Exit 0, no diagnostics.

## Not in scope

The reporter's "Expected Behavior" item #3 asks for `/readyz` (or similar) to fail-fast when a forced harness is missing at startup. That's a larger change touching readiness and the runtime registry boundary, and is intentionally **deferred to a separate PR**. This PR only fixes the surface error mapping — the actual `throw` in `src/agents/harness/selection.ts` is unchanged, and no harness selection, plugin loading, readiness, or config-schema logic was touched.
