### PR TITLE
fix(codex-app-server): mark contextCompaction end event as completed

### DIFF
--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -1008,6 +1008,10 @@ describe("CodexAppServerEventProjector", () => {
     expect(findAgentEvent(onAgentEvent, { stream: "compaction", phase: "start" }).data.itemId).toBe(
       "compact-1",
     );
+    const compactionEnd = findAgentEvent(onAgentEvent, { stream: "compaction", phase: "end" }).data;
+    expect(compactionEnd.itemId).toBe("compact-1");
+    expect(compactionEnd.completed).toBe(true);
+    expect(compactionEnd.backend).toBe("codex-app-server");
     expect(result.toolMetas).toEqual([{ toolName: "sessions_send" }]);
     expect(result.messagesSnapshot.map((message) => message.role)).toEqual([
       "user",

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -530,6 +530,7 @@ export class CodexAppServerEventProjector {
           threadId: this.threadId,
           turnId: this.turnId,
           itemId,
+          completed: true,
         },
       });
     }


### PR DESCRIPTION
## Summary

Fixes #82470.

The Codex app-server native `contextCompaction` completion event was being misclassified by downstream consumers as "Compaction incomplete", because the consumer requires `completed: true` on the `phase: "end"` event, but the emit site in `handleItemCompleted` never set it.

### Root cause (credit to the reporter — they pinpointed it exactly)

From the issue:

> When `handleItemCompleted` is reached for a `contextCompaction` item, the compaction has actually completed successfully (Codex app-server signaled item completion). So the emitted event should set `completed: true`.

The consumer in `src/auto-reply/reply/agent-runner-execution.ts`:

```ts
if (phase === "end") {
  const completed = evt.data?.completed === true;
  if (completed) {
    // success path → "🧹 Compaction complete"
  } else if (hookMessages.length > 0) {
    // hook-driven path
  } else if (shouldNotifyUserAboutCompaction) {
    await sendCompactionNotice("incomplete");  // ← users saw this for SUCCESSFUL native compaction
  }
}
```

is correct as written. The fix is on the emitter side.

### Change

One-line addition in `extensions/codex/src/app-server/event-projector.ts` (`handleItemCompleted`, `contextCompaction` branch):

```ts
this.emitAgentEvent({
  stream: "compaction",
  data: {
    phase: "end",
    backend: "codex-app-server",
    threadId: this.threadId,
    turnId: this.turnId,
    itemId,
    completed: true,   // ← added
  },
});
```

Plus an extended assertion in `event-projector.test.ts` covering the `phase: "end"` event for `contextCompaction`.

### Files changed
- `extensions/codex/src/app-server/event-projector.ts` (+1)
- `extensions/codex/src/app-server/event-projector.test.ts` (+4)

### Tests
- `node scripts/run-vitest.mjs run extensions/codex/src/app-server/event-projector.test.ts` → 41/41 passed
- `node scripts/run-vitest.mjs run extensions/codex/src/app-server/compact.test.ts` → 14/14 passed
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json` → clean (exit 0)

Closes #82470.
