### PR TITLE
fix(gateway): abort chat runs owned by disconnecting WS connection

### DIFF
--- a/src/gateway/server/ws-connection.test.ts
+++ b/src/gateway/server/ws-connection.test.ts
@@ -116,6 +116,7 @@ async function connectTestWs(
         unsubscribeAllSessionEvents: vi.fn(),
         nodeRegistry: { unregister: vi.fn() },
         nodeUnsubscribeAll: vi.fn(),
+        chatAbortControllers: new Map(),
       }) as never,
     ...params.options,
   });
@@ -292,6 +293,7 @@ describe("attachGatewayWsConnectionHandler", () => {
           unsubscribeAllSessionEvents: vi.fn(),
           nodeRegistry: { unregister },
           nodeUnsubscribeAll: vi.fn(),
+          chatAbortControllers: new Map(),
         }) as never,
     });
 
@@ -322,5 +324,99 @@ describe("attachGatewayWsConnectionHandler", () => {
     expect(unregister).toHaveBeenCalledTimes(1);
     expect(upsertPresenceMock).not.toHaveBeenCalled();
     expect(broadcastPresenceSnapshotMock).not.toHaveBeenCalled();
+  });
+
+  it("aborts chatAbortControllers entries whose ownerConnId matches the closing conn", async () => {
+    const chatAbortControllers = new Map<
+      string,
+      {
+        controller: AbortController;
+        sessionId: string;
+        sessionKey: string;
+        startedAtMs: number;
+        expiresAtMs: number;
+        ownerConnId?: string;
+      }
+    >();
+    const broadcast = vi.fn();
+    const removeChatRun = vi.fn((sessionId: string, clientRunId: string, sessionKey?: string) => ({
+      sessionKey: sessionKey ?? sessionId,
+      clientRunId,
+    }));
+    const requestContext = {
+      unsubscribeAllSessionEvents: vi.fn(),
+      nodeRegistry: { unregister: vi.fn(() => null) },
+      nodeUnsubscribeAll: vi.fn(),
+      chatAbortControllers,
+      chatRunBuffers: new Map<string, string>(),
+      chatDeltaSentAt: new Map<string, number>(),
+      chatDeltaLastBroadcastLen: new Map<string, number>(),
+      chatDeltaLastBroadcastText: new Map<string, string>(),
+      agentDeltaSentAt: new Map<string, number>(),
+      bufferedAgentEvents: new Map<string, unknown>(),
+      chatAbortedRuns: new Map<string, number>(),
+      removeChatRun,
+      agentRunSeq: new Map<string, number>(),
+      broadcast,
+      nodeSendToSession: vi.fn(),
+    };
+
+    const { passed, socket } = await connectTestWs({
+      options: {
+        buildRequestContext: () => requestContext as never,
+      },
+    });
+    const handlerParams = passed as {
+      setClient: (client: unknown) => boolean;
+      connId: string;
+    };
+    expect(
+      handlerParams.setClient({
+        socket,
+        connect: { client: { id: "openclaw-control-ui", mode: "webchat" } },
+        connId: handlerParams.connId,
+        usesSharedGatewayAuth: false,
+      }),
+    ).toBe(true);
+
+    const closingConnId = handlerParams.connId;
+    const otherConnId = "conn-other";
+    const controllerA = new AbortController();
+    const controllerB = new AbortController();
+    const controllerC = new AbortController();
+    chatAbortControllers.set("run-A", {
+      controller: controllerA,
+      sessionId: "session-1",
+      sessionKey: "sk-1",
+      startedAtMs: Date.now(),
+      expiresAtMs: Date.now() + 60_000,
+      ownerConnId: closingConnId,
+    });
+    chatAbortControllers.set("run-B", {
+      controller: controllerB,
+      sessionId: "session-1",
+      sessionKey: "sk-1",
+      startedAtMs: Date.now(),
+      expiresAtMs: Date.now() + 60_000,
+      ownerConnId: closingConnId,
+    });
+    chatAbortControllers.set("run-C", {
+      controller: controllerC,
+      sessionId: "session-2",
+      sessionKey: "sk-2",
+      startedAtMs: Date.now(),
+      expiresAtMs: Date.now() + 60_000,
+      ownerConnId: otherConnId,
+    });
+
+    socket.emit("close", 1000, Buffer.from("client left"));
+
+    expect(controllerA.signal.aborted).toBe(true);
+    expect(controllerB.signal.aborted).toBe(true);
+    expect(controllerC.signal.aborted).toBe(false);
+    expect(chatAbortControllers.has("run-A")).toBe(false);
+    expect(chatAbortControllers.has("run-B")).toBe(false);
+    expect(chatAbortControllers.has("run-C")).toBe(true);
+    expect(removeChatRun).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -11,6 +11,7 @@ import { truncateUtf16Safe } from "../../utils.js";
 import { isWebchatClient } from "../../utils/message-channel.js";
 import type { AuthRateLimiter } from "../auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "../auth.js";
+import { abortChatRunById } from "../chat-abort.js";
 import { resolvePreauthHandshakeTimeoutMs } from "../handshake-timeouts.js";
 import { resolveHostedPluginSurfaceUrl } from "../hosted-plugin-surface-url.js";
 import type { GatewayMethodRegistry } from "../methods/registry.js";
@@ -392,6 +393,15 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       }
       const context = buildRequestContext();
       context.unsubscribeAllSessionEvents(connId);
+      for (const [runId, entry] of context.chatAbortControllers) {
+        if (entry.ownerConnId === connId) {
+          abortChatRunById(context, {
+            runId,
+            sessionKey: entry.sessionKey,
+            stopReason: "owner-disconnect",
+          });
+        }
+      }
       let currentDisconnectedNodeId: string | null = null;
       if (client?.connect?.role === "node") {
         currentDisconnectedNodeId = context.nodeRegistry.unregister(connId);

--- a/src/gateway/server/ws-connection.ts
+++ b/src/gateway/server/ws-connection.ts
@@ -395,6 +395,9 @@ export function attachGatewayWsConnectionHandler(params: AttachGatewayWsConnecti
       context.unsubscribeAllSessionEvents(connId);
       for (const [runId, entry] of context.chatAbortControllers) {
         if (entry.ownerConnId === connId) {
+          logWsControl.info(
+            `aborting chat run on owner disconnect conn=${connId} runId=${runId} sessionKey=${entry.sessionKey}`,
+          );
           abortChatRunById(context, {
             runId,
             sessionKey: entry.sessionKey,


### PR DESCRIPTION
## Summary

- Problem: the gateway WS connection's `close` handler in `src/gateway/server/ws-connection.ts` cleans up session events / node registry / presence / node-wake state but never iterates `chatAbortControllers` looking for entries owned by the closing conn (`ownerConnId === connId`). `registerChatAbortController` stores `ownerConnId` specifically for the abort-authorization check (`canRequesterAbortChatRun`); nothing else consumes it on disconnect.
- Why it matters: when a client disconnects mid-chat (ws.close), the in-flight chat runner keeps invoking the LLM, running tools, and broadcasting deltas into a closed socket until the maintenance sweep (`expiresAtMs`, `minMs=2min`) times it out. End users pay tokens and tools mutate external state long after they intended to cancel.
- What changed: on socket close, iterate `chatAbortControllers` and call `abortChatRunById(context, { runId, sessionKey, stopReason: "owner-disconnect" })` for each entry whose `ownerConnId` matches the closing conn. `abortChatRunById` already handles idempotency, broadcast, `removeChatRun`, and cancelled lifecycle events. An operator-visible log line is also emitted so the disconnect-driven abort is distinguishable from maintenance-sweep timeout or explicit RPC abort.
- What did NOT change (scope boundary): `chatAbortControllers` registration / authorization / maintenance-sweep paths are untouched; the abort here uses the existing `abortChatRunById` contract, so cross-connection abort policy and partial-state persistence are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #82484
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed**: Without this patch, `src/gateway/server/ws-connection.ts:354-424` close handler ignores `chatAbortControllers`. The in-flight chat runner registered via `registerChatAbortController` keeps running after the owner WS disconnects — LLM HTTP fetch continues, tools execute, external API calls fire, and partial results may be persisted. With this patch, the close handler aborts the matching entry's controller (and logs the abort), so the chat runner observes `signal.aborted` and tears down cleanly.
- **Real environment tested**: macOS (darwin arm64), Node.js, OpenClaw worktree built via `pnpm install --frozen-lockfile && pnpm build`. End-to-end test spawns the production bundle `openclaw.mjs gateway run --auth none --bind loopback --port <p> --allow-unconfigured` against an isolated `OPENCLAW_HOME`, with `<state-dir>/identity/device.json` + `device-auth.json` + `devices/paired.json` pre-seeded (ed25519 keypair) and a mock OpenAI server in `hold-then-complete` mode (12s stream hold). An audit ws probe completes the connect handshake (v2 device signature), sends `chat.send`, waits 5s, and closes the WebSocket.
- **Exact steps or command run after this patch**:

```text
$ pnpm install --frozen-lockfile && pnpm build  (single worktree, fix toggled in-place)
$ # spawn mock OpenAI (mock_openai_cand038.mjs, MOCK_MODE=hold-then-complete, hold=12s)
$ # spawn gateway: openclaw gateway run --auth none --bind loopback --port <p> --allow-unconfigured
$ # wait for [gateway] ready in stdout
$ # spawn audit ws probe (tsx): connect.challenge, device-payload v2 signed, connect, hello-ok, chat.send, wait 5s, ws.close
$ # wait POST_CLOSE_WAIT_SEC (18s) for hold + propagation
$ # parse MOCK_REQUEST_LOG + SUT stderr; assert chat_ack + (pre_send_blocked or abort_observed) per trial
```

- **Evidence after fix**:

Same worktree, same `pnpm install` lockfile, same build infrastructure. Only `src/gateway/server/ws-connection.ts` toggled between the upstream/main version (no patch) and the patched version (this PR). 5 trials each.

```text
[Build A] without this patch (upstream/main 0eef4c49f6):
  trials:                  5
  chat_ack_trials:         5
  chain_works_trials:      5   <- gateway POSTs LLM /v1/responses
  abort_observed_trials:   0   <- no mid-stream cancellation
  pre_send_blocked_trials: 0

[Build B] with this patch (same worktree, fix re-applied):
  trials:                  5
  chat_ack_trials:         5
  chain_works_trials:      0   <- gateway never POSTs LLM
  abort_observed_trials:   0
  pre_send_blocked_trials: 5   <- chat ack received, but LLM POST skipped

[Mechanism check] gateway stderr in the with-patch build (3 trials):
  sut_abort_log_found:     3/3
  log line: "aborting chat run on owner disconnect conn=<uuid> runId=<uuid> sessionKey=<key>"
```

- **Observed result after fix**: Without the patch, 5/5 trials reach the LLM and 0/5 propagate abort, evidencing the defect (mock observes `request_started`, `hold_started`, and no `client_disconnected`). With the patch, 5/5 trials reach `chat.send` ack but 0/5 ever POST the LLM endpoint — the new close-handler abort loop fires `controller.abort()` before the chat runner dispatches the fetch. The new info log line emitted from inside the abort loop is observed in 3/3 follow-up trials, directly attesting that the new loop entered, not some unrelated path.
- **What was not tested**: cross-connection abort sharing (one connId's close affecting another's chat), subagent/tool-call chains beyond the LLM fetch, and the natural mid-stream cancel mode (where the runner has already dispatched the LLM POST before ws.close arrives). The maintenance-sweep timeout fallback (>2min `expiresAtMs` floor) still exists as a second-line safety net but is not the primary path measured here.

## Root Cause (if applicable)

- Root cause: `registerChatAbortController` records the owning conn in the entry's `ownerConnId` field, but the only consumer was `canRequesterAbortChatRun` — i.e. the field gated which requester could send the abort RPC. The disconnect path itself never used the field, so a closing conn left its own runs un-aborted. The maintenance interval's `expiresAtMs` sweep eventually timed them out, but with a `minMs=2min` floor plus `graceMs=60s` plus the configured runtime timeout, that delay let tokens and tool side-effects accumulate.
- Missing detection / guardrail: a close-handler loop that mirrored the existing `unsubscribeAllSessionEvents(connId)` pattern but for `chatAbortControllers`, calling `abortChatRunById` for each `ownerConnId === connId` entry.
- Contributing context (if known): `GatewayRequestContext` already exposes the full `ChatAbortOps` surface (`chatAbortControllers`, `broadcast`, `removeChatRun`, etc.), so no plumbing change was required.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server/ws-connection.test.ts`
- Scenario the test should lock in: a ws connection close fires `abortChatRunById` for every `chatAbortControllers` entry whose `ownerConnId` matches the closing conn, and leaves entries owned by other conns intact.
- Why this is the smallest reliable guardrail: it uses the existing `connectTestWs` harness in the file, injects a shared `chatAbortControllers` Map via `buildRequestContext`, and asserts on signal state + Map contents — no real ws server, no real chat runner.
- Existing test that already covers this (if any): None — existing tests cover handshake / presence / generic plugin surface but not the close-handler abort path.

## User-visible / Behavior Changes

- When a WS client disconnects, any in-flight chat run it owned is aborted immediately rather than after the maintenance sweep. End users see a `stopReason: "owner-disconnect"` lifecycle event for those runs.
- New info log line `aborting chat run on owner disconnect conn=... runId=... sessionKey=...` from the `ws-control` subsystem when the new loop fires.

## Diagram (if applicable)

```text
Before:
  ws.close -> close handler -> session/node/presence cleanup
                            -> chatAbortControllers untouched
                            -> chat runner keeps invoking LLM and tools
                            -> maintenance sweep aborts run after expiresAtMs (minMs=2min)

After:
  ws.close -> close handler -> session/node/presence cleanup
                            -> for each chatAbortControllers entry where ownerConnId == connId:
                                 logWsControl.info("aborting chat run on owner disconnect ...")
                                 abortChatRunById(context, { runId, sessionKey, stopReason: "owner-disconnect" })
                            -> chat runner observes signal.aborted, cancels in-flight LLM/tool work
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No` (the change only cancels in-flight work earlier)
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 15.4 (darwin arm64)
- Runtime/container: Node.js via `pnpm build` (production bundle)
- Model/provider: mock OpenAI server (`hold-then-complete` mode, hold=12s)
- Integration/channel (if any): N/A (audit ws probe only)
- Relevant config (redacted): `--auth none --bind loopback --port <p> --allow-unconfigured`

### Steps

1. Build worktree with `pnpm install --frozen-lockfile && pnpm build`.
2. Spawn mock OpenAI server.
3. Boot gateway; wait for ready marker.
4. Audit ws probe: device-pair connect, `chat.send`, wait 5s, ws.close.
5. Wait 18s for hold + propagation.
6. Read mock `MOCK_REQUEST_LOG`, count `request_started` / `hold_started` / `client_disconnected`; grep gateway stderr for the new abort log line.

### Expected

- Without patch: `mock_request_started=1`, `mock_hold_started=1`, `mock_client_disconnected=[]` per trial.
- With patch: `mock_request_started=0` per trial, and `sut_abort_log_found=true`.

### Actual

- 5/5 trials matched expected on both builds (see Real behavior proof block).

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

## Human Verification (required)

- Verified scenarios: 5 trials with-fix + 5 trials without-fix in the same worktree (toggle); follow-up 3 trials with abort log assert in gateway stderr; unit test in `ws-connection.test.ts`.
- Edge cases checked: entries owned by other conns are not aborted (unit test); empty `chatAbortControllers` is a no-op (existing tests still pass with the new loop).
- What you did **not** verify: high-latency LLM cases where the runner has already dispatched the fetch before ws.close arrives — the existing fetch's `AbortSignal` plumbing should still propagate the abort mid-stream, but the e2e scenario as written hits the pre-send window in 5/5 trials.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- Risk: a user briefly disconnects and reconnects expecting to pick up the result — the new abort would prevent that. Mitigation: even without this patch, the closed socket swallows broadcast results and the reconnected client has a new `connId` that no longer matches `ownerConnId`, so the historical reconnect path was already losing the result.
- Risk: `abortChatRunById` broadcasts to other connections about the canceled run; if a single sessionKey is shared across devices the other device sees a `cancelled` event. Mitigation: this matches the existing semantics of the abort RPC; only the source of the abort differs.

🤖 AI-assisted: drafted with Claude Code (claude-opus-4-7).
