### PR TITLE
fix(browser): reject credentialed navigation URLs

### DIFF
--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -1298,6 +1298,19 @@ describe("browser tool url alias support", () => {
     expect(opts.profile).toBeUndefined();
   });
 
+  it("rejects embedded credentials before opening a tab", async () => {
+    const tool = createBrowserTool();
+    await expect(
+      tool.execute?.("call-1", {
+        action: "open",
+        url: "https://user:secret@example.com/path",
+      }),
+    ).rejects.toThrow("embedded credentials");
+
+    expect(browserClientMocks.browserOpenTab).not.toHaveBeenCalled();
+    expect(gatewayMocks.callGatewayTool).not.toHaveBeenCalled();
+  });
+
   it("tracks opened tabs when session context is available", async () => {
     browserClientMocks.browserOpenTab.mockResolvedValueOnce({
       targetId: "tab-123",
@@ -1352,6 +1365,20 @@ describe("browser tool url alias support", () => {
     expect(request.url).toBe("https://example.com");
     expect(request.targetId).toBe("tab-1");
     expect(request.profile).toBeUndefined();
+  });
+
+  it("rejects embedded credentials before navigating a tab", async () => {
+    const tool = createBrowserTool();
+    await expect(
+      tool.execute?.("call-1", {
+        action: "navigate",
+        url: "https://user:secret@example.com/path",
+        targetId: "tab-1",
+      }),
+    ).rejects.toThrow("embedded credentials");
+
+    expect(browserActionsMocks.browserNavigate).not.toHaveBeenCalled();
+    expect(gatewayMocks.callGatewayTool).not.toHaveBeenCalled();
   });
 
   it("keeps targetUrl required error label when both params are missing", async () => {

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -51,6 +51,7 @@ import { DEFAULT_BROWSER_SCREENSHOT_TIMEOUT_MS } from "./browser/constants.js";
 import { normalizeBrowserScreenshot } from "./browser/screenshot.js";
 import { describeBrowserScreenshot, neutralizeMediaDirectives } from "./browser/vision.js";
 import { wrapExternalContent } from "./sdk-security-runtime.js";
+import { assertNoBrowserNavigationUrlUserInfo } from "./browser/navigation-url-userinfo.js";
 
 const browserToolDeps = {
   browserAct,
@@ -150,10 +151,11 @@ function readOptionalTargetAndTimeout(params: Record<string, unknown>) {
 }
 
 function readTargetUrlParam(params: Record<string, unknown>) {
-  return (
+  const targetUrl =
     readStringParam(params, "targetUrl") ??
-    readStringParam(params, "url", { required: true, label: "targetUrl" })
-  );
+    readStringParam(params, "url", { required: true, label: "targetUrl" });
+  assertNoBrowserNavigationUrlUserInfo(targetUrl);
+  return targetUrl;
 }
 
 const LEGACY_BROWSER_ACT_REQUEST_KEYS = [

--- a/extensions/browser/src/browser/navigation-guard.test.ts
+++ b/extensions/browser/src/browser/navigation-guard.test.ts
@@ -251,6 +251,36 @@ describe("browser navigation guard", () => {
     ).rejects.toBeInstanceOf(InvalidBrowserNavigationUrlError);
   });
 
+  it("blocks network URLs with embedded credentials before lookup", async () => {
+    const lookupFn = createLookupFn("93.184.216.34");
+    await expect(
+      assertBrowserNavigationAllowed({
+        url: "https://user:secret@example.com/private",
+        lookupFn,
+      }),
+    ).rejects.toThrow("embedded credentials");
+    await expect(
+      assertBrowserNavigationAllowed({
+        url: "https://user:secret@example.com/private",
+        lookupFn,
+      }),
+    ).rejects.not.toThrow("secret");
+    expect(lookupFn).not.toHaveBeenCalled();
+  });
+
+  it("redacts URL credentials from invalid URL diagnostics", async () => {
+    await expect(
+      assertBrowserNavigationAllowed({
+        url: "https://user:secret@",
+      }),
+    ).rejects.toThrow("https://[redacted]@");
+    await expect(
+      assertBrowserNavigationAllowed({
+        url: "https://user:secret@",
+      }),
+    ).rejects.not.toThrow("secret");
+  });
+
   it("validates final network URLs after navigation", async () => {
     const lookupFn = createLookupFn("127.0.0.1");
     await expect(

--- a/extensions/browser/src/browser/navigation-guard.ts
+++ b/extensions/browser/src/browser/navigation-guard.ts
@@ -6,6 +6,11 @@ import {
   type SsrFPolicy,
 } from "../infra/net/ssrf.js";
 import { matchesHostnameAllowlist, normalizeHostname } from "../sdk-security-runtime.js";
+import {
+  BROWSER_NAVIGATION_USERINFO_BLOCKED_MESSAGE,
+  hasBrowserNavigationUrlUserInfo,
+  redactBrowserNavigationUrlForDiagnostics,
+} from "./navigation-url-userinfo.js";
 
 const NETWORK_NAVIGATION_PROTOCOLS = new Set(["http:", "https:"]);
 const SAFE_NON_NETWORK_URLS = new Set(["about:blank"]);
@@ -102,7 +107,9 @@ export async function assertBrowserNavigationAllowed(
   try {
     parsed = new URL(rawUrl);
   } catch {
-    throw new InvalidBrowserNavigationUrlError(`Invalid URL: ${rawUrl}`);
+    throw new InvalidBrowserNavigationUrlError(
+      `Invalid URL: ${redactBrowserNavigationUrlForDiagnostics(rawUrl)}`,
+    );
   }
 
   if (!NETWORK_NAVIGATION_PROTOCOLS.has(parsed.protocol)) {
@@ -112,6 +119,10 @@ export async function assertBrowserNavigationAllowed(
     throw new InvalidBrowserNavigationUrlError(
       `Navigation blocked: unsupported protocol "${parsed.protocol}"`,
     );
+  }
+
+  if (hasBrowserNavigationUrlUserInfo(parsed)) {
+    throw new InvalidBrowserNavigationUrlError(BROWSER_NAVIGATION_USERINFO_BLOCKED_MESSAGE);
   }
 
   // Browser proxy routing hides the final connect target from this process.

--- a/extensions/browser/src/browser/navigation-url-userinfo.ts
+++ b/extensions/browser/src/browser/navigation-url-userinfo.ts
@@ -1,0 +1,36 @@
+const NAVIGATION_USERINFO_PROTOCOLS = new Set(["http:", "https:"]);
+
+export const BROWSER_NAVIGATION_USERINFO_BLOCKED_MESSAGE =
+  "Navigation blocked: URLs with embedded credentials are not supported";
+
+export function hasBrowserNavigationUrlUserInfo(parsed: URL): boolean {
+  return (
+    NAVIGATION_USERINFO_PROTOCOLS.has(parsed.protocol) &&
+    (parsed.username.length > 0 || parsed.password.length > 0)
+  );
+}
+
+export function assertNoBrowserNavigationUrlUserInfo(url: string): void {
+  try {
+    if (hasBrowserNavigationUrlUserInfo(new URL(url.trim()))) {
+      throw new Error(BROWSER_NAVIGATION_USERINFO_BLOCKED_MESSAGE);
+    }
+  } catch (err) {
+    if (err instanceof Error && err.message === BROWSER_NAVIGATION_USERINFO_BLOCKED_MESSAGE) {
+      throw err;
+    }
+  }
+}
+
+export function redactBrowserNavigationUrlForDiagnostics(url: string): string {
+  try {
+    const parsed = new URL(url);
+    if (hasBrowserNavigationUrlUserInfo(parsed)) {
+      parsed.username = "";
+      parsed.password = "";
+    }
+    return parsed.toString();
+  } catch {
+    return url.replace(/([a-z][a-z0-9+.-]*:\/\/)([^/?#\s@]+)@/gi, "$1[redacted]@");
+  }
+}


### PR DESCRIPTION
## Summary
- Reject HTTP(S) browser navigation URLs that contain embedded username/password credentials before the browser tool sends them to a local browser client or remote browser proxy.
- Enforce the same credentialed-URL block in the browser navigation guard before Playwright/Chrome MCP navigation reaches Chromium.
- Redact credential-like userinfo from invalid URL diagnostics so error text does not echo secrets.

Closes #55365

## Real behavior proof (required for external PRs)
Behavior addressed: browser open/navigate requests no longer pass HTTP(S) URLs with embedded credentials such as `https://user:secret@example.com/path` through to the browser proxy, local browser client, Playwright, or Chromium. Invalid URL diagnostics also redact credential-like userinfo instead of echoing the raw secret-bearing input.

Real environment tested: macOS local workstation, Node v24.14.1, pnpm v11.1.0, OpenClaw built from source at PR head 28c0451762.

Exact steps or command run after this patch:
node scripts/run-vitest.mjs extensions/browser/src/browser/navigation-guard.test.ts extensions/browser/src/browser-tool.test.ts extensions/browser/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/browser/src/browser/navigation-url-userinfo.ts extensions/browser/src/browser/navigation-guard.ts extensions/browser/src/browser/navigation-guard.test.ts extensions/browser/src/browser-tool.ts extensions/browser/src/browser-tool.test.ts
git diff --check origin/main..HEAD

Evidence after fix:
$ node scripts/run-vitest.mjs extensions/browser/src/browser/navigation-guard.test.ts extensions/browser/src/browser-tool.test.ts extensions/browser/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts
Test Files  3 passed (3)
Tests  84 passed (84)

$ node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/browser/src/browser/navigation-url-userinfo.ts extensions/browser/src/browser/navigation-guard.ts extensions/browser/src/browser/navigation-guard.test.ts extensions/browser/src/browser-tool.ts extensions/browser/src/browser-tool.test.ts
Found 0 warnings and 0 errors.
Finished in 3.0s on 5 files with 216 rules using 1 threads.

$ git diff --check origin/main..HEAD
(no output)

Observed result after fix: the focused tests prove credentialed network navigation URLs are rejected before DNS lookup, before direct browser open/navigate calls, and before gateway proxy dispatch. The same test set also proves invalid URL errors redact `https://user:secret@` as `https://[redacted]@` and do not include the secret.

What was not tested: live navigation against a real Chromium instance and remote browser-node proxy transport on Linux/Windows.

## Verification
- `node scripts/run-vitest.mjs extensions/browser/src/browser/navigation-guard.test.ts extensions/browser/src/browser-tool.test.ts extensions/browser/src/browser/pw-tools-core.snapshot.navigate-guard.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/browser/src/browser/navigation-url-userinfo.ts extensions/browser/src/browser/navigation-guard.ts extensions/browser/src/browser/navigation-guard.test.ts extensions/browser/src/browser-tool.ts extensions/browser/src/browser-tool.test.ts`
- `git diff --check origin/main..HEAD`
