### PR TITLE
fix(doctor): scope state dir scan to current home

### DIFF
--- a/src/commands/doctor-state-integrity.linux-storage.test.ts
+++ b/src/commands/doctor-state-integrity.linux-storage.test.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   detectLinuxSdBackedStateDir,
+  findOtherStateDirs,
   formatLinuxSdBackedStateDirWarning,
 } from "./doctor-state-integrity.js";
 
@@ -12,6 +13,34 @@ function encodeMountInfoPath(value: string): string {
     .replace(/\t/g, "\\011")
     .replace(/ /g, "\\040");
 }
+
+describe("findOtherStateDirs", () => {
+  it("only checks the current account default state dir", () => {
+    const probedDirs: string[] = [];
+
+    const result = findOtherStateDirs("/var/lib/openclaw", {
+      defaultStateDir: "/home/alice/.openclaw",
+      existsDir: (dir) => {
+        probedDirs.push(dir);
+        return true;
+      },
+    });
+
+    expect(result).toEqual(["/home/alice/.openclaw"]);
+    expect(probedDirs).toEqual(["/home/alice/.openclaw"]);
+  });
+
+  it("does not report the active default state dir as an extra state dir", () => {
+    const result = findOtherStateDirs("/home/alice/.openclaw", {
+      defaultStateDir: "/home/alice/.openclaw",
+      existsDir: () => {
+        throw new Error("default state dir should not be probed when it is active");
+      },
+    });
+
+    expect(result).toEqual([]);
+  });
+});
 
 describe("detectLinuxSdBackedStateDir", () => {
   it("detects state dir on mmc-backed mount", () => {

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -232,37 +232,25 @@ function countJsonlLines(filePath: string): number {
   }
 }
 
-function findOtherStateDirs(stateDir: string): string[] {
+export function findOtherStateDirs(
+  stateDir: string,
+  deps?: {
+    defaultStateDir?: string;
+    existsDir?: (dir: string) => boolean;
+  },
+): string[] {
   const resolvedState = path.resolve(stateDir);
-  const roots =
-    process.platform === "darwin" ? ["/Users"] : process.platform === "linux" ? ["/home"] : [];
-  const found: string[] = [];
-  for (const root of roots) {
-    let entries: fs.Dirent[];
-    try {
-      entries = fs.readdirSync(root, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-    for (const entry of entries) {
-      if (!entry.isDirectory()) {
-        continue;
-      }
-      if (entry.name.startsWith(".")) {
-        continue;
-      }
-      const candidates = [".openclaw"].map((dir) => path.resolve(root, entry.name, dir));
-      for (const candidate of candidates) {
-        if (candidate === resolvedState) {
-          continue;
-        }
-        if (existsDir(candidate)) {
-          found.push(candidate);
-        }
-      }
-    }
+  const defaultStateDir = path.resolve(
+    deps?.defaultStateDir ?? path.join(os.homedir(), ".openclaw"),
+  );
+  if (defaultStateDir === resolvedState) {
+    return [];
   }
-  return found;
+  const dirExists = deps?.existsDir ?? existsDir;
+  if (!dirExists(defaultStateDir)) {
+    return [];
+  }
+  return [defaultStateDir];
 }
 
 function isPathUnderRoot(targetPath: string, rootPath: string): boolean {
@@ -823,12 +811,7 @@ export async function noteStateIntegrity(
   }
 
   const extraStateDirs = new Set<string>();
-  if (path.resolve(stateDir) !== path.resolve(defaultStateDir)) {
-    if (existsDir(defaultStateDir)) {
-      extraStateDirs.add(defaultStateDir);
-    }
-  }
-  for (const other of findOtherStateDirs(stateDir)) {
+  for (const other of findOtherStateDirs(stateDir, { defaultStateDir })) {
     extraStateDirs.add(other);
   }
   if (extraStateDirs.size > 0) {


### PR DESCRIPTION
## Summary

- Problem: `openclaw doctor` state-integrity checks enumerated sibling account homes under `/home` or `/Users` while looking for extra `.openclaw` state dirs.
- Why it matters: the warning can disclose other users' OpenClaw state paths and can flag backup/snapshot home directories as active state split risks.
- What changed: the extra-state-dir check is scoped to the current account's default `.openclaw` path only.
- What did NOT change: doctor still warns when the active `OPENCLAW_STATE_DIR` differs from the current account's default `.openclaw` and that default exists.
- Review refresh: this head removes the unrelated cron/channel CI-stabilization commits that were previously inherited from #82519; the PR diff now contains only Doctor state-integrity code and tests.

## Change Type (select all)

- [x] Bug fix
- [x] Security hardening

## Scope (select all touched areas)

- [x] Memory / storage
- [x] UI / DX

## Linked Issue/PR

- Closes #68170
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

Behavior addressed: `openclaw doctor` no longer scans sibling OS account homes while checking for multiple OpenClaw state directories, preventing cross-user path disclosure and backup-home false positives in the doctor warning.

Real environment tested: macOS local workstation, Node v24.14.1, pnpm v11.1.0, OpenClaw source checkout at PR head `9a62758a724f`.

Exact steps or command run after this patch:

```sh
node --import tsx --eval "import { findOtherStateDirs } from './src/commands/doctor-state-integrity.ts'; const probes: string[] = []; const result = findOtherStateDirs('/var/lib/openclaw', { defaultStateDir: '/home/alice/.openclaw', existsDir: (dir) => { probes.push(dir); return true; } }); console.log(JSON.stringify({ result, probes }, null, 2));"
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-82495-doctor-only-2 node scripts/run-vitest.mjs src/commands/doctor-state-integrity.linux-storage.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json src/commands/doctor-state-integrity.ts src/commands/doctor-state-integrity.linux-storage.test.ts
git diff --check origin/main..HEAD
git diff --name-only origin/main...HEAD
```

Evidence after fix: terminal output captured after running the local OpenClaw checkout:

```text
$ node --import tsx --eval "...findOtherStateDirs..."
{
  "result": [
    "/home/alice/.openclaw"
  ],
  "probes": [
    "/home/alice/.openclaw"
  ]
}

$ OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-82495-doctor-only-2 node scripts/run-vitest.mjs src/commands/doctor-state-integrity.linux-storage.test.ts
Test Files  1 passed (1)
Tests  8 passed (8)
Duration  5.76s

$ node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json src/commands/doctor-state-integrity.ts src/commands/doctor-state-integrity.linux-storage.test.ts
Found 0 warnings and 0 errors.
Finished in 1.9s on 2 files with 216 rules using 1 threads.

$ git diff --check origin/main..HEAD
(no output)

$ git diff --name-only origin/main...HEAD
src/commands/doctor-state-integrity.linux-storage.test.ts
src/commands/doctor-state-integrity.ts
```

Observed result after fix: the actual helper output shows only `/home/alice/.openclaw` in both `result` and `probes`. There is no `/home/*` or `/Users/*` sibling enumeration path left, the current-account default-state warning remains available, and the PR head no longer carries cron or channel changes.

What was not tested: live Linux multi-user host doctor output, because no real sibling user directories were created on the test machine.

## Root Cause (if applicable)

- Root cause: `findOtherStateDirs` used platform home roots (`/home` and `/Users`) as discovery roots rather than the current account's default state dir.
- Missing detection / guardrail: existing tests covered storage warnings but not the directory-probe scope for multiple state-dir detection.
- Contributing context: the warning was intended to catch split state for one user, but the implementation expanded that into sibling account discovery.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/commands/doctor-state-integrity.linux-storage.test.ts`
- Scenario the test should lock in: extra state-dir detection probes only the current account default state dir and does not report it when it is already active.
- Why this is the smallest reliable guardrail: the regression was in the helper's directory-probe target, so an injected `existsDir` probe precisely catches accidental sibling-home enumeration without requiring real OS users.

## User-visible / Behavior Changes

`openclaw doctor` no longer reports `.openclaw` directories from sibling OS accounts or backup-like home directories. It still reports the current account's default `.openclaw` when the active state dir is elsewhere.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): Yes
- If any `Yes`, explain risk + mitigation: data access scope is reduced. Doctor state-integrity checks no longer enumerate sibling account home directories looking for `.openclaw` folders.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node v24.14.1, pnpm v11.1.0
- Model/provider: N/A
- Integration/channel (if any): CLI doctor state-integrity check
- Relevant config (redacted): temporary local OpenClaw source checkout; no secrets involved

### Steps

1. Run the helper from the PR head with a custom active state dir and an injected current-account default state dir.
2. Run the focused doctor state-integrity test file.
3. Run oxlint over the touched files.
4. Run `git diff --check origin/main..HEAD`.
5. Confirm the PR diff contains only the Doctor implementation and test files.

### Expected

- Extra state-dir detection probes only the current account default `.openclaw` path.
- The active default state dir is not reported as extra.
- Focused tests, lint, and whitespace checks pass.
- No unrelated cron/channel changes are included in this PR head.

### Actual

- Helper output included only `/home/alice/.openclaw` in `result` and `probes`.
- Focused test file passed: 1 file / 8 tests.
- oxlint passed: 0 warnings / 0 errors.
- `git diff --check origin/main..HEAD` produced no output.
- `git diff --name-only origin/main...HEAD` lists only `src/commands/doctor-state-integrity.ts` and `src/commands/doctor-state-integrity.linux-storage.test.ts`.

## Evidence

- [x] Trace/log snippets