### PR TITLE
fix(auth): prefer agent-local provider profiles

### DIFF
--- a/src/agents/auth-profiles.ensureauthprofilestore.test.ts
+++ b/src/agents/auth-profiles.ensureauthprofilestore.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ProviderExternalAuthProfile } from "../plugins/provider-external-auth.types.js";
 import { AUTH_STORE_VERSION, log } from "./auth-profiles/constants.js";
+import { resolveAuthProfileOrder } from "./auth-profiles/order.js";
 import {
   clearRuntimeAuthProfileStoreSnapshots,
   ensureAuthProfileStore,
@@ -299,6 +300,68 @@ describe("ensureAuthProfileStore", () => {
       });
     } finally {
       restoreAgentDirEnv({ previousStateDir, previousAgentDir });
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("prefers agent-local provider profiles before inherited main profiles", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-local-provider-"));
+    const { mainDir, agentDir, previousStateDir, previousAgentDir, previousPiAgentDir } =
+      configureMainAuthTestDirs(root);
+    try {
+      const expires = Date.now() + 60_000;
+      fs.writeFileSync(
+        path.join(mainDir, "auth-profiles.json"),
+        `${JSON.stringify(
+          {
+            version: AUTH_STORE_VERSION,
+            profiles: {
+              "minimax-portal:cli": {
+                type: "oauth",
+                provider: "minimax-portal",
+                access: "main-minimax-access",
+                refresh: "main-minimax-refresh",
+                expires,
+              },
+            },
+            order: {
+              "minimax-portal": ["minimax-portal:cli"],
+            },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+      fs.writeFileSync(
+        path.join(agentDir, "auth-profiles.json"),
+        `${JSON.stringify(
+          {
+            version: AUTH_STORE_VERSION,
+            profiles: {
+              "minimax-portal:default": {
+                type: "oauth",
+                provider: "minimax-portal",
+                access: "agent-minimax-access",
+                refresh: "agent-minimax-refresh",
+                expires,
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+
+      const store = ensureAuthProfileStore(agentDir);
+      expect(Object.keys(store.profiles)).toEqual(["minimax-portal:default", "minimax-portal:cli"]);
+      expect(resolveAuthProfileOrder({ store, provider: "minimax-portal" })).toEqual([
+        "minimax-portal:default",
+        "minimax-portal:cli",
+      ]);
+    } finally {
+      restoreAgentDirEnv({ previousStateDir, previousAgentDir, previousPiAgentDir });
       fs.rmSync(root, { recursive: true, force: true });
     }
   });

--- a/src/agents/auth-profiles/persisted.ts
+++ b/src/agents/auth-profiles/persisted.ts
@@ -1,10 +1,7 @@
-import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
-import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { resolveOAuthPath } from "../../config/paths.js";
 import { coerceSecretRef } from "../../config/types.secrets.js";
 import { loadJsonFile } from "../../infra/json-file.js";
-import { asBoolean } from "../../utils/boolean.js";
+import { normalizeProviderId } from "../provider-id.js";
 import { AUTH_STORE_VERSION, log } from "./constants.js";
 import {
   hasOAuthIdentity,
@@ -21,22 +18,32 @@ import {
 } from "./state.js";
 import type {
   AuthProfileCredential,
+  AuthProfileFailureReason,
   AuthProfileSecretsStore,
   AuthProfileStore,
   OAuthCredential,
   OAuthCredentials,
+  ProfileUsageStats,
 } from "./types.js";
 
 export type LegacyAuthStore = Record<string, AuthProfileCredential>;
-
-type LoadPersistedAuthProfileStoreOptions = {
-  allowKeychainPrompt?: boolean;
-};
 
 type CredentialRejectReason = "non_object" | "invalid_type" | "missing_provider";
 type RejectedCredentialEntry = { key: string; reason: CredentialRejectReason };
 
 const AUTH_PROFILE_TYPES = new Set<AuthProfileCredential["type"]>(["api_key", "oauth", "token"]);
+const LEGACY_OAUTH_REF_SOURCE = "openclaw-credentials";
+const LEGACY_OAUTH_REF_PROVIDER = "openai-codex";
+
+type LegacyOAuthRef = {
+  source: typeof LEGACY_OAUTH_REF_SOURCE;
+  provider: typeof LEGACY_OAUTH_REF_PROVIDER;
+  id: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
 
 function normalizeOptionalCredentialString(value: unknown): string | undefined {
   if (typeof value !== "string") {
@@ -44,6 +51,28 @@ function normalizeOptionalCredentialString(value: unknown): string | undefined {
   }
   const trimmed = value.trim();
   return trimmed ? value : undefined;
+}
+
+function isLegacyOAuthRef(value: unknown): value is LegacyOAuthRef {
+  if (!isRecord(value)) {
+    return false;
+  }
+  return (
+    value.source === LEGACY_OAUTH_REF_SOURCE &&
+    value.provider === LEGACY_OAUTH_REF_PROVIDER &&
+    typeof value.id === "string" &&
+    /^[a-f0-9]{32}$/.test(value.id)
+  );
+}
+
+function hasInlineOAuthTokenMaterial(credential: OAuthCredential): boolean {
+  return [credential.access, credential.refresh, credential.idToken].some(
+    (value) => typeof value === "string" && value.trim().length > 0,
+  );
+}
+
+function normalizeOptionalCredentialBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
 }
 
 function normalizeExpiryField(value: unknown): number | undefined {
@@ -86,7 +115,7 @@ function normalizeCommonCredentialFields(entry: Record<string, unknown>): Record
   const normalized: Record<string, unknown> = {
     provider: typeof entry.provider === "string" ? normalizeProviderId(entry.provider) : "",
   };
-  const copyToAgents = asBoolean(entry.copyToAgents);
+  const copyToAgents = normalizeOptionalCredentialBoolean(entry.copyToAgents);
   if (copyToAgents !== undefined) {
     normalized.copyToAgents = copyToAgents;
   }
@@ -106,14 +135,7 @@ function normalizeRawCredentialEntry(raw: Record<string, unknown>): Partial<Auth
   if (!("type" in entry) && typeof entry["mode"] === "string") {
     entry["type"] = entry["mode"];
   }
-  if (entry.type === "apiKey") {
-    entry.type = "api_key";
-  }
-  if (
-    !("key" in entry) &&
-    !coerceSecretRef(entry["keyRef"]) &&
-    typeof entry["apiKey"] === "string"
-  ) {
+  if (!("key" in entry) && typeof entry["apiKey"] === "string") {
     entry["key"] = entry["apiKey"];
   }
   normalizeSecretBackedField({ entry, valueField: "key", refField: "keyRef" });
@@ -126,10 +148,11 @@ function normalizeRawCredentialEntry(raw: Record<string, unknown>): Partial<Auth
     const key = normalizeOptionalCredentialString(entry.key);
     const keyRef = coerceSecretRef(entry.keyRef);
     const metadata = normalizeCredentialMetadata(entry.metadata);
+    if (key !== undefined) {
+      normalized.key = key;
+    }
     if (keyRef) {
       normalized.keyRef = keyRef;
-    } else if (key !== undefined) {
-      normalized.key = key;
     }
     if (metadata) {
       normalized.metadata = metadata;
@@ -224,7 +247,6 @@ function warnRejectedCredentialEntries(source: string, rejected: RejectedCredent
     source,
     dropped: rejected.length,
     reasons,
-    ...(reasons.invalid_type ? { validTypes: [...AUTH_PROFILE_TYPES] } : {}),
     keys: rejected.slice(0, 10).map((entry) => entry.key),
   });
 }
@@ -251,10 +273,7 @@ function coerceLegacyAuthStore(raw: unknown): LegacyAuthStore | null {
   return Object.keys(entries).length > 0 ? entries : null;
 }
 
-export function coercePersistedAuthProfileStore(
-  raw: unknown,
-  _options?: LoadPersistedAuthProfileStoreOptions,
-): AuthProfileStore | null {
+export function coercePersistedAuthProfileStore(raw: unknown): AuthProfileStore | null {
   if (!isRecord(raw)) {
     return null;
   }
@@ -299,7 +318,69 @@ function mergeRecord<T>(
 }
 
 function dedupeMergedProfileOrder(profileIds: string[]): string[] {
-  return uniqueStrings(profileIds);
+  return Array.from(new Set(profileIds));
+}
+
+function profileProviderKey(credential: AuthProfileCredential): string {
+  return normalizeProviderId(credential.provider);
+}
+
+function groupProfileIdsByProvider(profiles: AuthProfileStore["profiles"]): Map<string, string[]> {
+  const grouped = new Map<string, string[]>();
+  for (const [profileId, credential] of Object.entries(profiles)) {
+    const providerKey = profileProviderKey(credential);
+    grouped.set(providerKey, [...(grouped.get(providerKey) ?? []), profileId]);
+  }
+  return grouped;
+}
+
+function findOrderEntryKey(
+  order: Record<string, string[]> | undefined,
+  providerKey: string,
+): string | undefined {
+  return Object.keys(order ?? {}).find((key) => normalizeProviderId(key) === providerKey);
+}
+
+function mergeProfileRecordsWithOverridePrecedence(
+  base: AuthProfileStore["profiles"],
+  override: AuthProfileStore["profiles"],
+): AuthProfileStore["profiles"] {
+  const overrideProfileIds = new Set(Object.keys(override));
+  return Object.fromEntries([
+    ...Object.entries(override),
+    ...Object.entries(base).filter(([profileId]) => !overrideProfileIds.has(profileId)),
+  ]);
+}
+
+function mergeProfileOrderWithOverridePrecedence(params: {
+  baseOrder?: AuthProfileStore["order"];
+  overrideOrder?: AuthProfileStore["order"];
+  overrideProfiles: AuthProfileStore["profiles"];
+}): AuthProfileStore["order"] {
+  const mergedOrder = mergeRecord(params.baseOrder, params.overrideOrder);
+  if (!mergedOrder) {
+    return undefined;
+  }
+
+  for (const [providerKey, overrideProfileIds] of groupProfileIdsByProvider(
+    params.overrideProfiles,
+  )) {
+    const overrideOrderKey = findOrderEntryKey(params.overrideOrder, providerKey);
+    const mergedOrderKey = overrideOrderKey ?? findOrderEntryKey(mergedOrder, providerKey);
+    if (!mergedOrderKey) {
+      continue;
+    }
+    const overrideOrderIds = overrideOrderKey
+      ? (params.overrideOrder?.[overrideOrderKey] ?? [])
+      : [];
+    mergedOrder[mergedOrderKey] = dedupeMergedProfileOrder([
+      ...overrideOrderIds,
+      ...overrideProfileIds,
+      ...(mergedOrder[mergedOrderKey] ?? []),
+    ]);
+  }
+
+  return mergedOrder;
 }
 
 function hasComparableOAuthIdentityConflict(
@@ -341,6 +422,107 @@ function isNewerUsableOAuthCredential(
     Number.isFinite(candidate.expires) &&
     (!Number.isFinite(existing.expires) || candidate.expires > existing.expires)
   );
+}
+
+const AUTH_INVALIDATION_REASONS = new Set<AuthProfileFailureReason>([
+  "auth",
+  "auth_permanent",
+  "session_expired",
+]);
+
+function hasAuthInvalidationSignal(stats: ProfileUsageStats | undefined): boolean {
+  if (!stats) {
+    return false;
+  }
+  if (
+    (stats.cooldownReason && AUTH_INVALIDATION_REASONS.has(stats.cooldownReason)) ||
+    (stats.disabledReason && AUTH_INVALIDATION_REASONS.has(stats.disabledReason))
+  ) {
+    return true;
+  }
+  return Object.entries(stats.failureCounts ?? {}).some(
+    ([reason, count]) =>
+      AUTH_INVALIDATION_REASONS.has(reason as AuthProfileFailureReason) &&
+      typeof count === "number" &&
+      count > 0,
+  );
+}
+
+function isProfileReferencedByAuthState(store: AuthProfileStore, profileId: string): boolean {
+  if (Object.values(store.order ?? {}).some((profileIds) => profileIds.includes(profileId))) {
+    return true;
+  }
+  return Object.values(store.lastGood ?? {}).some((value) => value === profileId);
+}
+
+function resolveProviderAuthStateValue<T>(
+  values: Record<string, T> | undefined,
+  providerKey: string,
+): T | undefined {
+  if (!values) {
+    return undefined;
+  }
+  for (const [key, value] of Object.entries(values)) {
+    if (normalizeProviderId(key) === providerKey) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function findMainStoreOAuthReplacementForInvalidatedProfile(params: {
+  base: AuthProfileStore;
+  override: AuthProfileStore;
+  profileId: string;
+  credential: OAuthCredential;
+}): string | undefined {
+  const providerKey = normalizeProviderId(params.credential.provider);
+  if (
+    providerKey !== "openai-codex" ||
+    !isProfileReferencedByAuthState(params.override, params.profileId) ||
+    !hasAuthInvalidationSignal(params.override.usageStats?.[params.profileId])
+  ) {
+    return undefined;
+  }
+
+  const candidates = Object.entries(params.base.profiles)
+    .flatMap(([profileId, credential]): Array<[string, OAuthCredential]> => {
+      if (
+        profileId === params.profileId ||
+        credential.type !== "oauth" ||
+        normalizeProviderId(credential.provider) !== providerKey ||
+        !hasUsableOAuthCredential(credential)
+      ) {
+        return [];
+      }
+      return [[profileId, credential]];
+    })
+    .toSorted(([leftId, leftCredential], [rightId, rightCredential]) => {
+      const leftExpires = Number.isFinite(leftCredential.expires) ? leftCredential.expires : 0;
+      const rightExpires = Number.isFinite(rightCredential.expires) ? rightCredential.expires : 0;
+      if (rightExpires !== leftExpires) {
+        return rightExpires - leftExpires;
+      }
+      return leftId.localeCompare(rightId);
+    });
+  if (candidates.length === 0) {
+    return undefined;
+  }
+
+  const candidateIds = new Set(candidates.map(([profileId]) => profileId));
+  const orderedProfileId = resolveProviderAuthStateValue(params.base.order, providerKey)?.find(
+    (profileId) => candidateIds.has(profileId),
+  );
+  if (orderedProfileId) {
+    return orderedProfileId;
+  }
+
+  const lastGoodProfileId = resolveProviderAuthStateValue(params.base.lastGood, providerKey);
+  if (lastGoodProfileId && candidateIds.has(lastGoodProfileId)) {
+    return lastGoodProfileId;
+  }
+
+  return candidates.length === 1 ? candidates[0]?.[0] : undefined;
 }
 
 function findMainStoreOAuthReplacement(params: {
@@ -482,7 +664,12 @@ function reconcileMainStoreOAuthProfileDrift(params: {
           legacyProfileId: profileId,
           legacyCredential: credential,
         })
-      : undefined;
+      : findMainStoreOAuthReplacementForInvalidatedProfile({
+          base: params.base,
+          override: params.override,
+          profileId,
+          credential,
+        });
     if (replacementProfileId) {
       replacements.set(profileId, replacementProfileId);
     }
@@ -497,99 +684,27 @@ function reconcileMainStoreOAuthProfileDrift(params: {
 export function mergeAuthProfileStores(
   base: AuthProfileStore,
   override: AuthProfileStore,
-  options?: { preserveBaseRuntimeExternalProfiles?: boolean },
 ): AuthProfileStore {
   if (
     Object.keys(override.profiles).length === 0 &&
     !override.order &&
     !override.lastGood &&
-    !override.usageStats &&
-    override.runtimeExternalProfileIds === undefined &&
-    override.runtimeExternalProfileIdsAuthoritative !== true
+    !override.usageStats
   ) {
     return base;
   }
-  const overrideProfileIds = new Set(Object.keys(override.profiles));
-  const overrideRuntimeExternalProfileIds = new Set(override.runtimeExternalProfileIds ?? []);
-  const removedRuntimeExternalProfileIds = new Set(
-    override.runtimeExternalProfileIdsAuthoritative === true &&
-      options?.preserveBaseRuntimeExternalProfiles !== true
-      ? (base.runtimeExternalProfileIds ?? []).filter(
-          (profileId) =>
-            !overrideRuntimeExternalProfileIds.has(profileId) && !overrideProfileIds.has(profileId),
-        )
-      : [],
-  );
-  const profiles = { ...base.profiles, ...override.profiles };
-  for (const profileId of removedRuntimeExternalProfileIds) {
-    delete profiles[profileId];
-  }
-  const mergedOrder = mergeRecord(base.order, override.order);
-  const order = mergedOrder
-    ? Object.fromEntries(
-        Object.entries(mergedOrder)
-          .map(([provider, profileIds]) => [
-            provider,
-            profileIds.filter(
-              (profileId) =>
-                profiles[profileId] || !removedRuntimeExternalProfileIds.has(profileId),
-            ),
-          ])
-          .filter(([, profileIds]) => profileIds.length > 0),
-      )
-    : undefined;
-  const mergedLastGood = mergeRecord(base.lastGood, override.lastGood);
-  const lastGood = mergedLastGood
-    ? Object.fromEntries(
-        Object.entries(mergedLastGood).filter(([, profileId]) => profiles[profileId]),
-      )
-    : undefined;
-  const mergedUsageStats = mergeRecord(base.usageStats, override.usageStats);
-  const usageStats = mergedUsageStats
-    ? Object.fromEntries(
-        Object.entries(mergedUsageStats).filter(([profileId]) => profiles[profileId]),
-      )
-    : undefined;
   const merged = {
     version: Math.max(base.version, override.version ?? base.version),
-    profiles,
-    order,
-    lastGood,
-    usageStats,
+    profiles: mergeProfileRecordsWithOverridePrecedence(base.profiles, override.profiles),
+    order: mergeProfileOrderWithOverridePrecedence({
+      baseOrder: base.order,
+      overrideOrder: override.order,
+      overrideProfiles: override.profiles,
+    }),
+    lastGood: mergeRecord(base.lastGood, override.lastGood),
+    usageStats: mergeRecord(base.usageStats, override.usageStats),
   };
-  const baseRuntimeExternalProfileIds =
-    override.runtimeExternalProfileIdsAuthoritative === true &&
-    options?.preserveBaseRuntimeExternalProfiles !== true
-      ? []
-      : (base.runtimeExternalProfileIds ?? []).filter(
-          (profileId) => !overrideProfileIds.has(profileId),
-        );
-  const runtimeExternalProfileIds = [
-    ...baseRuntimeExternalProfileIds,
-    ...(override.runtimeExternalProfileIds ?? []),
-  ]
-    .filter((profileId) => merged.profiles[profileId])
-    .toSorted();
-  const runtimeExternalProfileIdsAuthoritative =
-    base.runtimeExternalProfileIdsAuthoritative === true ||
-    override.runtimeExternalProfileIdsAuthoritative === true;
-  const runtimeExternalProfileMetadata =
-    runtimeExternalProfileIds.length > 0 || runtimeExternalProfileIdsAuthoritative
-      ? {
-          runtimeExternalProfileIds: [...new Set(runtimeExternalProfileIds)],
-          ...(runtimeExternalProfileIdsAuthoritative
-            ? { runtimeExternalProfileIdsAuthoritative: true }
-            : {}),
-        }
-      : {};
-  return reconcileMainStoreOAuthProfileDrift({
-    base,
-    override,
-    merged: {
-      ...merged,
-      ...runtimeExternalProfileMetadata,
-    },
-  });
+  return reconcileMainStoreOAuthProfileDrift({ base, override, merged });
 }
 
 export function buildPersistedAuthProfileSecretsStore(
@@ -598,6 +713,7 @@ export function buildPersistedAuthProfileSecretsStore(
     profileId: string;
     credential: AuthProfileCredential;
   }) => boolean,
+  options?: { existingRaw?: unknown },
 ): AuthProfileSecretsStore {
   const profiles = Object.fromEntries(
     Object.entries(store.profiles).flatMap(([profileId, credential]) => {
@@ -618,10 +734,43 @@ export function buildPersistedAuthProfileSecretsStore(
     }),
   ) as AuthProfileSecretsStore["profiles"];
 
-  return {
+  const payload: AuthProfileSecretsStore = {
     version: AUTH_STORE_VERSION,
     profiles,
   };
+  return preserveLegacyOAuthRefsForDoctorMigration(payload, options?.existingRaw);
+}
+
+function preserveLegacyOAuthRefsForDoctorMigration(
+  payload: AuthProfileSecretsStore,
+  existingRaw: unknown,
+): AuthProfileSecretsStore {
+  if (!isRecord(existingRaw) || !isRecord(existingRaw.profiles)) {
+    return payload;
+  }
+  let profiles: AuthProfileSecretsStore["profiles"] | undefined;
+  for (const [profileId, rawProfile] of Object.entries(existingRaw.profiles)) {
+    if (!isRecord(rawProfile) || !isLegacyOAuthRef(rawProfile.oauthRef)) {
+      continue;
+    }
+    const credential = payload.profiles[profileId];
+    if (
+      credential?.type !== "oauth" ||
+      normalizeProviderId(credential.provider) !== LEGACY_OAUTH_REF_PROVIDER ||
+      hasInlineOAuthTokenMaterial(credential)
+    ) {
+      continue;
+    }
+    // Removal-only retention for #79006: runtime must not load sidecar
+    // credentials, but doctor still needs the inert ref to migrate users back
+    // to inline auth-profiles.json OAuth credentials.
+    profiles ??= { ...payload.profiles };
+    profiles[profileId] = {
+      ...credential,
+      oauthRef: rawProfile.oauthRef,
+    } as AuthProfileCredential;
+  }
+  return profiles ? { ...payload, profiles } : payload;
 }
 
 export function applyLegacyAuthStore(store: AuthProfileStore, legacy: LegacyAuthStore): void {
@@ -687,13 +836,10 @@ export function mergeOAuthFileIntoStore(store: AuthProfileStore): boolean {
   return mutated;
 }
 
-export function loadPersistedAuthProfileStore(
-  agentDir?: string,
-  options?: LoadPersistedAuthProfileStoreOptions,
-): AuthProfileStore | null {
+export function loadPersistedAuthProfileStore(agentDir?: string): AuthProfileStore | null {
   const authPath = resolveAuthStorePath(agentDir);
   const raw = loadJsonFile(authPath);
-  const store = coercePersistedAuthProfileStore(raw, options);
+  const store = coercePersistedAuthProfileStore(raw);
   if (!store) {
     return null;
   }


### PR DESCRIPTION
## Summary

- Problem: non-main agents inherited main-agent auth profiles, but same-provider local profiles could be ordered behind inherited main profiles when the profile IDs differed.
- Why it matters: an agent such as `kate` could show a local MiniMax auth store while runtime provider auth still tried a main-agent `minimax-portal` profile first.
- What changed: merged auth-profile stores now preserve selected-agent profile precedence in both `profiles` insertion order and provider `order`, while retaining inherited main profiles as fallback.
- What did NOT change: main-agent read-through still works for providers absent from the selected agent, and existing OAuth drift repair remains in place.

## Change Type (select all)

- [x] Bug fix
- [x] Security hardening

## Scope (select all touched areas)

- [x] Auth / tokens

## Linked Issue/PR

- Closes #64274
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: selected-agent auth profiles for a provider now sort before inherited main-agent profiles for that same provider, so agent-local MiniMax OAuth can win before main-agent MiniMax fallback.
- Real environment tested: macOS local workstation, Node v24.14.1, pnpm v11.1.0, OpenClaw source checkout at PR head d590de3418.
- Exact steps or command run after this patch:
  - `pnpm install`
  - `node --import tsx --eval "import { mergeAuthProfileStores } from './src/agents/auth-profiles/persisted.ts'; import { resolveAuthProfileOrder } from './src/agents/auth-profiles/order.ts'; const expires = Date.now() + 60000; const main = { version: 2, profiles: { 'minimax-portal:cli': { type: 'oauth', provider: 'minimax-portal', access: 'main-minimax-access', refresh: 'main-minimax-refresh', expires } }, order: { 'minimax-portal': ['minimax-portal:cli'] } }; const agent = { version: 2, profiles: { 'minimax-portal:default': { type: 'oauth', provider: 'minimax-portal', access: 'agent-minimax-access', refresh: 'agent-minimax-refresh', expires } } }; const store = mergeAuthProfileStores(main, agent); console.log(JSON.stringify({ profiles: Object.keys(store.profiles), order: store.order, resolvedOrder: resolveAuthProfileOrder({ store, provider: 'minimax-portal' }) }, null, 2));"`
  - `node scripts/run-vitest.mjs src/agents/auth-profiles.ensureauthprofilestore.test.ts src/agents/auth-profiles.store.save.test.ts src/agents/auth-profiles/order.test.ts src/agents/auth-profiles/oauth.fallback-to-main-agent.test.ts extensions/minimax/index.test.ts`
  - `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json src/agents/auth-profiles/persisted.ts src/agents/auth-profiles.ensureauthprofilestore.test.ts`
  - `git diff --check origin/main..HEAD`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
$ node --import tsx --eval "import { mergeAuthProfileStores } from './src/agents/auth-profiles/persisted.ts'; import { resolveAuthProfileOrder } from './src/agents/auth-profiles/order.ts'; const expires = Date.now() + 60000; const main = { version: 2, profiles: { 'minimax-portal:cli': { type: 'oauth', provider: 'minimax-portal', access: 'main-minimax-access', refresh: 'main-minimax-refresh', expires } }, order: { 'minimax-portal': ['minimax-portal:cli'] } }; const agent = { version: 2, profiles: { 'minimax-portal:default': { type: 'oauth', provider: 'minimax-portal', access: 'agent-minimax-access', refresh: 'agent-minimax-refresh', expires } } }; const store = mergeAuthProfileStores(main, agent); console.log(JSON.stringify({ profiles: Object.keys(store.profiles), order: store.order, resolvedOrder: resolveAuthProfileOrder({ store, provider: 'minimax-portal' }) }, null, 2));"
{
  "profiles": [
    "minimax-portal:default",
    "minimax-portal:cli"
  ],
  "order": {
    "minimax-portal": [
      "minimax-portal:default",
      "minimax-portal:cli"
    ]
  },
  "resolvedOrder": [
    "minimax-portal:default",
    "minimax-portal:cli"
  ]
}

$ node scripts/run-vitest.mjs src/agents/auth-profiles.ensureauthprofilestore.test.ts src/agents/auth-profiles.store.save.test.ts src/agents/auth-profiles/order.test.ts src/agents/auth-profiles/oauth.fallback-to-main-agent.test.ts extensions/minimax/index.test.ts
Test Files  9 passed (9)
Tests  122 passed (122)

$ node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json src/agents/auth-profiles/persisted.ts src/agents/auth-profiles.ensureauthprofilestore.test.ts
Found 0 warnings and 0 errors.
Finished in 3.1s on 2 files with 216 rules using 1 threads.

$ git diff --check origin/main..HEAD
(no output)
```

- Observed result after fix: the merged store and resolved auth order place the selected-agent `minimax-portal:default` profile before inherited main `minimax-portal:cli`, so local agent auth is attempted first and main remains fallback.
- What was not tested: live MiniMax OAuth/dashboard flow, because no real MiniMax account credentials were used; the affected auth-profile merge/order path was exercised directly with redacted synthetic OAuth values.
- Before evidence (optional but encouraged): Issue #64274 and its ClawSweeper review describe current main merging main profiles ahead of selected-agent profiles when profile IDs differ.

## Root Cause (if applicable)

- Root cause: `mergeAuthProfileStores(mainStore, agentStore)` spread main profiles before agent profiles and preserved main provider `order` when the agent had no local order entry.
- Missing detection / guardrail: tests covered exact profile-id override and main fallback, but not same-provider different-profile-id precedence for a selected agent.
- Contributing context: inherited main profiles are useful fallback for providers absent from a selected agent, but that fallback should not take priority over a selected-agent credential for the same provider.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/agents/auth-profiles.ensureauthprofilestore.test.ts`
- Scenario the test should lock in: a selected agent with `minimax-portal:default` resolves that profile before inherited main `minimax-portal:cli`, even when the main store has a provider order entry.
- Why this is the smallest reliable guardrail: the regression is in shared auth-profile merge/order semantics, so direct store-level coverage catches the MiniMax symptom without a live OAuth dependency.

## User-visible / Behavior Changes

Non-main agents with their own provider auth profile should use the local profile before inherited main-agent fallback profiles for the same provider.

## Diagram (if applicable)

```text
Before:
main minimax profile + agent minimax profile -> inherited main order -> main tried first

After:
main minimax profile + agent minimax profile -> agent-local order -> agent tried first, main fallback remains
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): Yes
- If any `Yes`, explain risk + mitigation: auth profile selection is narrowed so same-provider selected-agent credentials take precedence over inherited main-agent credentials; inherited main profiles remain available as fallback for missing local provider auth.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node v24.14.1, pnpm v11.1.0
- Model/provider: MiniMax provider auth order simulated with synthetic `minimax-portal` OAuth profiles
- Integration/channel (if any): agent auth-profile runtime selection
- Relevant config (redacted): synthetic access/refresh strings only; no live credentials

### Steps

1. Merge a main auth store containing `minimax-portal:cli` with a selected-agent store containing `minimax-portal:default`.
2. Resolve provider auth order for `minimax-portal`.
3. Run focused auth-profile and MiniMax tests.
4. Run oxlint and whitespace checks.

### Expected

- Selected-agent `minimax-portal:default` appears before inherited main `minimax-portal:cli`.
- Main profile remains available as fallback.
- Focused tests, lint, and whitespace checks pass.

### Actual

- Live helper output showed `profiles`, `order`, and `resolvedOrder` all local-first.
- Focused tests passed: 9 files / 122 tests.
- oxlint passed: 0 warnings / 0 errors.
- `git diff --check origin/main..HEAD` produced no output.

## Evidence

- [x] Trace/log snippets
