### PR TITLE
fix(cron): preserve skipped empty main jobs

### DIFF
--- a/src/cron/persisted-shape.ts
+++ b/src/cron/persisted-shape.ts
@@ -52,13 +52,13 @@ export function getInvalidPersistedCronJobReason(
   }
   if (payloadKind === "systemEvent") {
     const text = payloadRecord.text;
-    if (typeof text !== "string" || text.trim().length === 0) {
+    if (typeof text !== "string") {
       return "invalid-payload";
     }
   }
   if (payloadKind === "agentTurn") {
     const message = payloadRecord.message;
-    if (typeof message !== "string" || message.trim().length === 0) {
+    if (typeof message !== "string") {
       return "invalid-payload";
     }
   }

--- a/src/cron/service/store.test.ts
+++ b/src/cron/service/store.test.ts
@@ -291,7 +291,7 @@ describe("cron service store seam coverage", () => {
     expect(findJobOrThrow(state, "reload-cron-expr-job").state.nextRunAtMs).toBe(dueNextRunAtMs);
   });
 
-  it("clears stale nextRunAtMs without throwing when a force-reloaded schedule is malformed", async () => {
+  it("skips malformed force-reloaded schedules without throwing", async () => {
     const { storePath } = await makeStorePath();
     const staleNextRunAtMs = STORE_TEST_NOW + 3_600_000;
 
@@ -316,9 +316,15 @@ describe("cron service store seam coverage", () => {
       undefined,
     );
 
-    const reloadedJob = findJobOrThrow(state, "reload-cron-expr-job");
-    expect(reloadedJob.schedule).toBe("0 17 * * *");
-    expect(reloadedJob.state.nextRunAtMs).toBeUndefined();
+    expect(state.store?.jobs).toEqual([]);
+    expect(() => findJobOrThrow(state, "reload-cron-expr-job")).toThrow(
+      /unknown cron job id: reload-cron-expr-job/,
+    );
+    expectWarnedJob({
+      storePath,
+      jobId: "reload-cron-expr-job",
+      message: "skipped invalid persisted job",
+    });
   });
 
   it("preserves nextRunAtMs after force reload when scheduling inputs are unchanged", async () => {


### PR DESCRIPTION
## Summary
- Keep persisted cron payload validation structural so runtime-created whitespace `systemEvent` jobs reload and record `skipped` instead of disappearing before execution.
- Align the force-reload malformed-schedule store test with the current skip-invalid-persisted-jobs contract and assert the repair warning.

## Verification
- `node scripts/run-vitest.mjs src/cron/service.skips-main-jobs-empty-systemevent-text.test.ts src/cron/service/store.test.ts`
- `node scripts/run-vitest.mjs src/cron/service.skips-main-jobs-empty-systemevent-text.test.ts src/cron/service/store.test.ts src/cron/service/store.load-missing-session-target.test.ts src/cron/service.store-load-invalid-main-job.test.ts`
- `git diff --check`

## Real behavior proof
Behavior addressed: A cron job created with whitespace-only main `systemEvent` text should survive persisted reload long enough for the execution path to mark it `skipped`; malformed persisted schedule shapes should still be skipped without throwing.
Real environment tested: Local OpenClaw checkout on `fix/cron-runtime-shared-ci`.
Exact steps or command run after this patch: Ran the two CI-failing cron test files, then reran them with adjacent persisted cron store loader coverage.
Evidence after fix: Terminal output from the local OpenClaw checkout:
```text
$ node scripts/run-vitest.mjs src/cron/service.skips-main-jobs-empty-systemevent-text.test.ts src/cron/service/store.test.ts
Test Files  2 passed (2)
Tests  14 passed (14)

$ node scripts/run-vitest.mjs src/cron/service.skips-main-jobs-empty-systemevent-text.test.ts src/cron/service/store.test.ts src/cron/service/store.load-missing-session-target.test.ts src/cron/service.store-load-invalid-main-job.test.ts
Test Files  4 passed (4)
Tests  21 passed (21)

$ git diff --check
(no output)
```
Observed result after fix: Empty main `systemEvent` jobs now keep their skipped status behavior, while malformed persisted schedule reloads are skipped and warn instead of being retained with stale runtime state.
What was not tested: Full CI; GitHub Actions will run on this PR.
