### PR TITLE
fix(gateway): abort gmail watcher reload starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Telegram: persist polling updates through restart replay so queued same-topic messages resume in order instead of losing context after a gateway restart. (#82256) Thanks @VACInc.
+- Gateway/Gmail: abort in-flight Gmail watcher startup and hot-reload restarts before shutdown so reloads cannot spawn `gog serve` after the Gateway is closing. Thanks @frankekn.
 - MCP plugin tools: forward host MCP `tools/call` `AbortSignal` through `createPluginToolsMcpHandlers().callTool` into plugin `tool.execute`, so host cancellation actually cancels in-flight plugin tool calls instead of letting them run to completion. Fixes #82424. (#82443) Thanks @joshavant.
 - Media: ignore image MIME and filename hints when bytes sniff as generic containers, so zip/octet-stream payloads mislabeled as images do not become local image media or keep image file extensions when staged.
 - Update/doctor: avoid materializing `groupAllowFrom` for channel schemas that reject it, so package-swap doctor repairs do not fail on externalized Slack configs.

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -312,6 +312,7 @@ export function createGatewayCloseHandler(params: {
         await shutdownStep("plugin-services", () => params.pluginServices!.stop(), warnings);
       }
       await shutdownStep("plugin-state-store", () => closePluginStateSqliteStore(), warnings);
+      await shutdownStep("config-reloader", () => params.configReloader.stop(), warnings);
       await shutdownStep("gmail-watcher", () => stopGmailWatcherOnDemand(), warnings);
       params.cron.stop();
       params.heartbeatRunner.stop();
@@ -361,7 +362,6 @@ export function createGatewayCloseHandler(params: {
         recordShutdownWarning(warnings, "ws-clients");
       }
       params.clients.clear();
-      await shutdownStep("config-reloader", () => params.configReloader.stop(), warnings);
       const wsClients = params.wss.clients ?? new Set();
       const closePromise = new Promise<void>((resolve) => params.wss.close(() => resolve()));
       const websocketGraceTimeout = createTimeoutRace(

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -436,6 +436,118 @@ describe("gateway Gmail hot reload handlers", () => {
 
     expect(restartSignal?.aborted).toBe(true);
   });
+
+  it("does not start a Gmail restart after the managed reloader stops before hot reload applies", async () => {
+    const writeListenerRef: { current: ((event: ConfigWriteNotification) => void) | null } = {
+      current: null,
+    };
+    let releaseSecrets: (() => void) | undefined;
+    let secretsEntered: (() => void) | undefined;
+    const secretsStarted = new Promise<void>((resolve) => {
+      secretsEntered = resolve;
+    });
+    const releaseSecretsPromise = new Promise<void>((resolve) => {
+      releaseSecrets = resolve;
+    });
+    const initialConfig = createGmailConfig("old@example.com");
+    const nextConfig = createGmailConfig("next@example.com");
+    const reloader = startManagedGatewayConfigReloader({
+      minimalTestGateway: false,
+      initialConfig,
+      initialCompareConfig: initialConfig,
+      initialInternalWriteHash: null,
+      watchPath: "/tmp/openclaw.json",
+      readSnapshot: vi.fn(async () => ({
+        path: "/tmp/openclaw.json",
+        exists: true,
+        raw: "{}",
+        parsed: {},
+        sourceConfig: nextConfig,
+        resolved: nextConfig,
+        valid: true,
+        runtimeConfig: nextConfig,
+        config: nextConfig,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+        hash: "hash-next",
+      })) as never,
+      promoteSnapshot: vi.fn(async () => true) as never,
+      subscribeToWrites: ((listener: (event: ConfigWriteNotification) => void) => {
+        writeListenerRef.current = listener;
+        return () => {
+          if (writeListenerRef.current === listener) {
+            writeListenerRef.current = null;
+          }
+        };
+      }) as never,
+      deps: {} as never,
+      broadcast: vi.fn(),
+      getState: () => ({
+        hooksConfig: {} as never,
+        hookClientIpConfig: {} as never,
+        heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
+        cronState: {
+          cron: { start: vi.fn(async () => {}), stop: vi.fn() },
+          storePath: "/tmp/cron.json",
+          cronEnabled: false,
+        } as never,
+        channelHealthMonitor: null,
+      }),
+      setState: vi.fn(),
+      startChannel: vi.fn(async () => {}),
+      stopChannel: vi.fn(async () => {}),
+      reloadPlugins: vi.fn(
+        async (): Promise<GatewayPluginReloadResult> => ({
+          restartChannels: new Set(),
+          activeChannels: new Set(),
+        }),
+      ),
+      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      logChannels: { info: vi.fn(), error: vi.fn() },
+      logCron: { error: vi.fn() },
+      logReload: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      channelManager: {} as never,
+      activateRuntimeSecrets: vi.fn(async (config: OpenClawConfig) => {
+        secretsEntered?.();
+        await releaseSecretsPromise;
+        return {
+          sourceConfig: config,
+          config,
+          authStores: [],
+          warnings: [],
+          webTools: {},
+        };
+      }) as never,
+      resolveSharedGatewaySessionGenerationForConfig: () => undefined,
+      sharedGatewaySessionGenerationState: { current: undefined, required: null },
+      clients: [],
+    });
+    const registeredWriteListener = writeListenerRef.current;
+    if (!registeredWriteListener) {
+      throw new Error("Expected config write listener to be registered");
+    }
+
+    registeredWriteListener({
+      configPath: "/tmp/openclaw.json",
+      sourceConfig: nextConfig,
+      runtimeConfig: nextConfig,
+      persistedHash: "hash-next",
+      revision: 1,
+      fingerprint: "runtime-hash-next",
+      sourceFingerprint: "source-hash-next",
+      writtenAtMs: Date.now(),
+    });
+    await secretsStarted;
+
+    const stopPromise = reloader.stop();
+    releaseSecrets?.();
+    await stopPromise;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(hoisted.stopGmailWatcher).not.toHaveBeenCalled();
+    expect(hoisted.startGmailWatcherWithLogs).not.toHaveBeenCalled();
+  });
 });
 
 describe("gateway plugin hot reload handlers", () => {

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -1,11 +1,31 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { ChannelKind } from "./config-reload-plan.js";
+import type { ConfigWriteNotification } from "../config/config.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { ChannelKind, GatewayReloadPlan } from "./config-reload-plan.js";
 import type { GatewayPluginReloadResult } from "./server-reload-handlers.js";
-import { createGatewayReloadHandlers } from "./server-reload-handlers.js";
+import {
+  createGatewayReloadHandlers,
+  startManagedGatewayConfigReloader,
+} from "./server-reload-handlers.js";
+
+type GmailWatcherRestartParams = {
+  cfg: OpenClawConfig;
+  log: {
+    info: (msg: string) => void;
+    warn: (msg: string) => void;
+    error: (msg: string) => void;
+  };
+  onSkipped?: () => void;
+  isCancelled?: () => boolean;
+  signal?: AbortSignal;
+};
+
+type StartGmailWatcherWithLogs = (params: GmailWatcherRestartParams) => Promise<void>;
+type StopGmailWatcher = () => Promise<void>;
 
 const hoisted = vi.hoisted(() => ({
-  startGmailWatcherWithLogs: vi.fn(async () => {}),
-  stopGmailWatcher: vi.fn(async () => {}),
+  startGmailWatcherWithLogs: vi.fn<StartGmailWatcherWithLogs>(async () => {}),
+  stopGmailWatcher: vi.fn<StopGmailWatcher>(async () => {}),
   activeTaskCount: { value: 0 },
   activeTaskBlockers: [] as Array<{
     taskId: string;
@@ -172,6 +192,31 @@ describe("gateway restart deferral preflight", () => {
 });
 
 describe("gateway Gmail hot reload handlers", () => {
+  function createGmailReloadPlan(): GatewayReloadPlan {
+    return {
+      changedPaths: ["hooks.gmail.account"],
+      restartGateway: false,
+      restartReasons: [],
+      hotReasons: ["hooks.gmail.account"],
+      reloadHooks: false,
+      restartGmailWatcher: true,
+      restartCron: false,
+      restartHeartbeat: false,
+      restartHealthMonitor: false,
+      reloadPlugins: false,
+      restartChannels: new Set<ChannelKind>(),
+      disposeMcpRuntimes: false,
+      noopPaths: [],
+    };
+  }
+
+  function createGmailConfig(account: string): OpenClawConfig {
+    return {
+      gateway: { reload: { debounceMs: 0 } },
+      hooks: { enabled: true, gmail: { account } },
+    };
+  }
+
   it("stops queued post-ready sidecars before restarting Gmail watcher", async () => {
     const stopPostReadySidecars = vi.fn();
     const { applyHotReload } = createGatewayReloadHandlers({
@@ -231,6 +276,165 @@ describe("gateway Gmail hot reload handlers", () => {
     expect(hoisted.startGmailWatcherWithLogs).toHaveBeenCalledWith(
       expect.objectContaining({ cfg: nextConfig }),
     );
+  });
+
+  it("passes a cancellable signal to Gmail watcher restarts", async () => {
+    const abortController = new AbortController();
+    const clearGmailRestartAbortController = vi.fn();
+    const { applyHotReload } = createGatewayReloadHandlers({
+      deps: {} as never,
+      broadcast: vi.fn(),
+      getState: () => ({
+        hooksConfig: {} as never,
+        hookClientIpConfig: {} as never,
+        heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
+        cronState: {
+          cron: { start: vi.fn(async () => {}), stop: vi.fn() },
+          storePath: "/tmp/cron.json",
+          cronEnabled: false,
+        } as never,
+        channelHealthMonitor: null,
+      }),
+      setState: vi.fn(),
+      startChannel: vi.fn(async () => {}),
+      stopChannel: vi.fn(async () => {}),
+      reloadPlugins: vi.fn(
+        async (): Promise<GatewayPluginReloadResult> => ({
+          restartChannels: new Set(),
+          activeChannels: new Set(),
+        }),
+      ),
+      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      logChannels: { info: vi.fn(), error: vi.fn() },
+      logCron: { error: vi.fn() },
+      logReload: { info: vi.fn(), warn: vi.fn() },
+      createHealthMonitor: () => null,
+      createGmailRestartAbortController: () => abortController,
+      clearGmailRestartAbortController,
+    });
+    const nextConfig = createGmailConfig("next@example.com");
+
+    await applyHotReload(createGmailReloadPlan(), nextConfig);
+
+    const [restartParams] = hoisted.startGmailWatcherWithLogs.mock.calls[0] ?? [];
+    expect(restartParams).toMatchObject({ cfg: nextConfig });
+    expect(restartParams?.signal).toBe(abortController.signal);
+    expect(restartParams?.isCancelled?.()).toBe(false);
+    abortController.abort();
+    expect(restartParams?.isCancelled?.()).toBe(true);
+    expect(clearGmailRestartAbortController).toHaveBeenCalledWith(abortController);
+  });
+
+  it("aborts an in-flight managed Gmail restart when the reloader stops", async () => {
+    const writeListenerRef: { current: ((event: ConfigWriteNotification) => void) | null } = {
+      current: null,
+    };
+    let restartSignal: AbortSignal | undefined;
+    let restartEntered: (() => void) | undefined;
+    const restartStarted = new Promise<void>((resolve) => {
+      restartEntered = resolve;
+    });
+    hoisted.startGmailWatcherWithLogs.mockImplementationOnce(
+      async (params: GmailWatcherRestartParams) => {
+        restartSignal = params.signal;
+        restartEntered?.();
+        await new Promise<void>((resolve) => {
+          params.signal?.addEventListener("abort", () => resolve(), { once: true });
+        });
+      },
+    );
+    const initialConfig = createGmailConfig("old@example.com");
+    const nextConfig = createGmailConfig("next@example.com");
+    const readSnapshot = vi.fn(async () => ({
+      path: "/tmp/openclaw.json",
+      exists: true,
+      raw: "{}",
+      parsed: {},
+      sourceConfig: nextConfig,
+      resolved: nextConfig,
+      valid: true,
+      runtimeConfig: nextConfig,
+      config: nextConfig,
+      issues: [],
+      warnings: [],
+      legacyIssues: [],
+      hash: "hash-next",
+    }));
+    const reloader = startManagedGatewayConfigReloader({
+      minimalTestGateway: false,
+      initialConfig,
+      initialCompareConfig: initialConfig,
+      initialInternalWriteHash: null,
+      watchPath: "/tmp/openclaw.json",
+      readSnapshot: readSnapshot as never,
+      promoteSnapshot: vi.fn(async () => true) as never,
+      subscribeToWrites: ((listener: (event: ConfigWriteNotification) => void) => {
+        writeListenerRef.current = listener;
+        return () => {
+          if (writeListenerRef.current === listener) {
+            writeListenerRef.current = null;
+          }
+        };
+      }) as never,
+      deps: {} as never,
+      broadcast: vi.fn(),
+      getState: () => ({
+        hooksConfig: {} as never,
+        hookClientIpConfig: {} as never,
+        heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
+        cronState: {
+          cron: { start: vi.fn(async () => {}), stop: vi.fn() },
+          storePath: "/tmp/cron.json",
+          cronEnabled: false,
+        } as never,
+        channelHealthMonitor: null,
+      }),
+      setState: vi.fn(),
+      startChannel: vi.fn(async () => {}),
+      stopChannel: vi.fn(async () => {}),
+      reloadPlugins: vi.fn(
+        async (): Promise<GatewayPluginReloadResult> => ({
+          restartChannels: new Set(),
+          activeChannels: new Set(),
+        }),
+      ),
+      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      logChannels: { info: vi.fn(), error: vi.fn() },
+      logCron: { error: vi.fn() },
+      logReload: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      channelManager: {} as never,
+      activateRuntimeSecrets: vi.fn(async (config: OpenClawConfig) => ({
+        sourceConfig: config,
+        config,
+        authStores: [],
+        warnings: [],
+        webTools: {},
+      })) as never,
+      resolveSharedGatewaySessionGenerationForConfig: () => undefined,
+      sharedGatewaySessionGenerationState: { current: undefined, required: null },
+      clients: [],
+    });
+    const registeredWriteListener = writeListenerRef.current;
+    if (!registeredWriteListener) {
+      throw new Error("Expected config write listener to be registered");
+    }
+
+    registeredWriteListener({
+      configPath: "/tmp/openclaw.json",
+      sourceConfig: nextConfig,
+      runtimeConfig: nextConfig,
+      persistedHash: "hash-next",
+      revision: 1,
+      fingerprint: "runtime-hash-next",
+      sourceFingerprint: "source-hash-next",
+      writtenAtMs: Date.now(),
+    });
+    await restartStarted;
+    expect(restartSignal?.aborted).toBe(false);
+
+    await reloader.stop();
+
+    expect(restartSignal?.aborted).toBe(true);
   });
 });
 

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -347,25 +347,29 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
       params.stopPostReadySidecars?.();
       const restartAbortController =
         params.createGmailRestartAbortController?.() ?? new AbortController();
-      const [{ stopGmailWatcher }, { startGmailWatcherWithLogs }] = await Promise.all([
-        import("../hooks/gmail-watcher.js"),
-        import("../hooks/gmail-watcher-lifecycle.js"),
-      ]);
       try {
-        await stopGmailWatcher().catch((err) => {
-          params.logHooks.warn(`gmail watcher stop failed during reload: ${String(err)}`);
-        });
         if (!restartAbortController.signal.aborted) {
-          await startGmailWatcherWithLogs({
-            cfg: nextConfig,
-            log: params.logHooks,
-            isCancelled: () => restartAbortController.signal.aborted,
-            signal: restartAbortController.signal,
-            onSkipped: () =>
-              params.logHooks.info(
-                "skipping gmail watcher restart (OPENCLAW_SKIP_GMAIL_WATCHER=1)",
-              ),
-          });
+          const [{ stopGmailWatcher }, { startGmailWatcherWithLogs }] = await Promise.all([
+            import("../hooks/gmail-watcher.js"),
+            import("../hooks/gmail-watcher-lifecycle.js"),
+          ]);
+          if (!restartAbortController.signal.aborted) {
+            await stopGmailWatcher().catch((err) => {
+              params.logHooks.warn(`gmail watcher stop failed during reload: ${String(err)}`);
+            });
+          }
+          if (!restartAbortController.signal.aborted) {
+            await startGmailWatcherWithLogs({
+              cfg: nextConfig,
+              log: params.logHooks,
+              isCancelled: () => restartAbortController.signal.aborted,
+              signal: restartAbortController.signal,
+              onSkipped: () =>
+                params.logHooks.info(
+                  "skipping gmail watcher restart (OPENCLAW_SKIP_GMAIL_WATCHER=1)",
+                ),
+            });
+          }
         }
       } finally {
         params.clearGmailRestartAbortController?.(restartAbortController);
@@ -497,10 +501,21 @@ export function startManagedGatewayConfigReloader(params: ManagedGatewayConfigRe
     return { stop: async () => {} };
   }
 
+  let stopped = false;
   let activeGmailRestartAbortController: GatewayGmailRestartAbortController | null = null;
   const abortActiveGmailRestart = () => {
     activeGmailRestartAbortController?.abort();
     activeGmailRestartAbortController = null;
+  };
+  const createGmailRestartAbortController = (): GatewayGmailRestartAbortController => {
+    abortActiveGmailRestart();
+    const abortController = new AbortController();
+    if (stopped) {
+      abortController.abort();
+      return abortController;
+    }
+    activeGmailRestartAbortController = abortController;
+    return abortController;
   };
   const { applyHotReload, requestGatewayRestart } = createGatewayReloadHandlers({
     deps: params.deps,
@@ -515,12 +530,7 @@ export function startManagedGatewayConfigReloader(params: ManagedGatewayConfigRe
     logChannels: params.logChannels,
     logCron: params.logCron,
     logReload: params.logReload,
-    createGmailRestartAbortController: () => {
-      abortActiveGmailRestart();
-      const abortController = new AbortController();
-      activeGmailRestartAbortController = abortController;
-      return abortController;
-    },
+    createGmailRestartAbortController,
     clearGmailRestartAbortController: (abortController) => {
       if (activeGmailRestartAbortController === abortController) {
         activeGmailRestartAbortController = null;
@@ -636,6 +646,7 @@ export function startManagedGatewayConfigReloader(params: ManagedGatewayConfigRe
   });
   return {
     stop: async () => {
+      stopped = true;
       abortActiveGmailRestart();
       await configReloader.stop();
     },

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -59,6 +59,11 @@ type GatewayReloadLog = {
   warn: (msg: string) => void;
 };
 
+type GatewayGmailRestartAbortController = {
+  abort: () => void;
+  signal: AbortSignal;
+};
+
 export type GatewayPluginReloadResult = {
   restartChannels: ReadonlySet<ChannelKind>;
   activeChannels: ReadonlySet<ChannelKind>;
@@ -113,6 +118,8 @@ type GatewayReloadHandlerParams = {
   logCron: { error: (msg: string) => void };
   logReload: GatewayReloadLog;
   createHealthMonitor: (config: OpenClawConfig) => ChannelHealthMonitor | null;
+  createGmailRestartAbortController?: () => GatewayGmailRestartAbortController;
+  clearGmailRestartAbortController?: (controller: GatewayGmailRestartAbortController) => void;
   onCronRestart?: () => void;
 };
 
@@ -338,19 +345,31 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
 
     if (plan.restartGmailWatcher) {
       params.stopPostReadySidecars?.();
+      const restartAbortController =
+        params.createGmailRestartAbortController?.() ?? new AbortController();
       const [{ stopGmailWatcher }, { startGmailWatcherWithLogs }] = await Promise.all([
         import("../hooks/gmail-watcher.js"),
         import("../hooks/gmail-watcher-lifecycle.js"),
       ]);
-      await stopGmailWatcher().catch((err) => {
-        params.logHooks.warn(`gmail watcher stop failed during reload: ${String(err)}`);
-      });
-      await startGmailWatcherWithLogs({
-        cfg: nextConfig,
-        log: params.logHooks,
-        onSkipped: () =>
-          params.logHooks.info("skipping gmail watcher restart (OPENCLAW_SKIP_GMAIL_WATCHER=1)"),
-      });
+      try {
+        await stopGmailWatcher().catch((err) => {
+          params.logHooks.warn(`gmail watcher stop failed during reload: ${String(err)}`);
+        });
+        if (!restartAbortController.signal.aborted) {
+          await startGmailWatcherWithLogs({
+            cfg: nextConfig,
+            log: params.logHooks,
+            isCancelled: () => restartAbortController.signal.aborted,
+            signal: restartAbortController.signal,
+            onSkipped: () =>
+              params.logHooks.info(
+                "skipping gmail watcher restart (OPENCLAW_SKIP_GMAIL_WATCHER=1)",
+              ),
+          });
+        }
+      } finally {
+        params.clearGmailRestartAbortController?.(restartAbortController);
+      }
     }
 
     if (channelsToRestart.size > 0) {
@@ -478,6 +497,11 @@ export function startManagedGatewayConfigReloader(params: ManagedGatewayConfigRe
     return { stop: async () => {} };
   }
 
+  let activeGmailRestartAbortController: GatewayGmailRestartAbortController | null = null;
+  const abortActiveGmailRestart = () => {
+    activeGmailRestartAbortController?.abort();
+    activeGmailRestartAbortController = null;
+  };
   const { applyHotReload, requestGatewayRestart } = createGatewayReloadHandlers({
     deps: params.deps,
     broadcast: params.broadcast,
@@ -491,6 +515,17 @@ export function startManagedGatewayConfigReloader(params: ManagedGatewayConfigRe
     logChannels: params.logChannels,
     logCron: params.logCron,
     logReload: params.logReload,
+    createGmailRestartAbortController: () => {
+      abortActiveGmailRestart();
+      const abortController = new AbortController();
+      activeGmailRestartAbortController = abortController;
+      return abortController;
+    },
+    clearGmailRestartAbortController: (abortController) => {
+      if (activeGmailRestartAbortController === abortController) {
+        activeGmailRestartAbortController = null;
+      }
+    },
     ...(params.onCronRestart ? { onCronRestart: params.onCronRestart } : {}),
     createHealthMonitor: (config) =>
       startGatewayChannelHealthMonitor({
@@ -499,7 +534,7 @@ export function startManagedGatewayConfigReloader(params: ManagedGatewayConfigRe
       }),
   });
 
-  return startGatewayConfigReloader({
+  const configReloader = startGatewayConfigReloader({
     initialConfig: params.initialConfig,
     initialCompareConfig: params.initialCompareConfig,
     initialInternalWriteHash: params.initialInternalWriteHash,
@@ -599,4 +634,10 @@ export function startManagedGatewayConfigReloader(params: ManagedGatewayConfigRe
     },
     watchPath: params.watchPath,
   });
+  return {
+    stop: async () => {
+      abortActiveGmailRestart();
+      await configReloader.stop();
+    },
+  };
 }


### PR DESCRIPTION
## Summary

- Problem: #82395 fixed queued startup Gmail sidecars, but config hot reload could still own an in-flight Gmail restart without a shutdown abort signal.
- Why it matters: shutdown could stop the current watcher while a reload-started watcher was still inside `gog watch`/startup, then that stale path could continue toward `gog serve` after Gateway close started.
- What changed: reload-owned Gmail restarts now receive an abort signal, managed config reloader stop aborts the active restart, and shutdown stops the config reloader before stopping the current Gmail watcher.
- What did NOT change: no public config, protocol, or plugin contract changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #82395
- [x] This PR fixes a bug or regression

Original PR by @samzong handled queued startup-sidecar cancellation. This maintainer follow-up covers the remaining config hot-reload restart path after #82395 landed.

## Real behavior proof (required for external PRs)

N/A: maintainer follow-up with targeted regression coverage.

## Root Cause (if applicable)

- Root cause: `startManagedGatewayConfigReloader().stop()` did not abort an active Gmail restart started by config hot reload, and `createGatewayReloadHandlers()` called `startGmailWatcherWithLogs()` without `signal` / `isCancelled`.
- Missing detection / guardrail: tests covered queued startup sidecars, but not reload-owned in-flight Gmail restarts during shutdown.
- Contributing context: shutdown stopped the Gmail watcher before stopping the config reloader, leaving reload-owned restart work too late in the close sequence.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Seam / integration test
- Target test or file: `src/gateway/server-reload-handlers.test.ts`
- Scenario the test should lock in: managed config reloader aborts an active Gmail restart when stopped.
- Why this is the smallest reliable guardrail: it exercises the managed reloader callback path that owns the race without requiring real Gmail or Tailscale credentials.
- Existing test that already covers this (if any): none for reload-owned restarts.

## User-visible / Behavior Changes

Gateway shutdown now cancels config hot-reload-owned Gmail watcher restarts before stopping the current watcher, preventing stale reload work from starting `gog serve` after close begins.

## Diagram (if applicable)

```text
Before:
[config hot reload] -> [Gmail restart without abort signal]
[shutdown] -> [stop current watcher] -> [reload restart may continue]

After:
[shutdown] -> [stop config reloader / abort active Gmail restart] -> [stop current watcher]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): Gateway Gmail watcher
- Relevant config (redacted): test fixture config only

### Steps

1. Trigger a managed config hot reload that restarts Gmail watcher.
2. Keep `startGmailWatcherWithLogs()` in flight.
3. Stop the managed config reloader.

### Expected

- The in-flight Gmail restart signal is aborted before shutdown continues.

### Actual

- Before this patch, the reload-owned restart had no abort signal to observe.

## Evidence

- [x] Failing test/log before + passing after

`OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree pnpm test src/gateway/server-reload-handlers.test.ts`

`OPENCLAW_HEAVY_CHECK_LOCK_SCOPE=worktree pnpm check:changed`

## Human Verification (required)

- Verified scenarios: focused Gmail reload-handler regression test and changed-file gate.
- Edge cases checked: abort state is exposed to `startGmailWatcherWithLogs()` and managed reloader stop aborts an active restart.
- What you did **not** verify: live Gmail/Tailscale credentials.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: aborting reload-owned Gmail startup may skip a restart when shutdown races with config reload.
  - Mitigation: shutdown is already closing the Gateway, so skipping that stale restart is the intended lifecycle behavior.
