### PR TITLE
Fix doctor repair for disabled Codex runtime plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Docs: https://docs.openclaw.ai
 - Config/doctor: copy fallback-enabled channel `allowFrom` entries into explicit `groupAllowFrom` allowlists during `openclaw doctor --fix`, preserving current group access without adding runtime fallback-transition flags.
 - Config/doctor: replace source-only official Brave and Slack plugin installs from trusted catalog metadata during `openclaw doctor --fix`, unblocking externalized stock plugin recovery after upgrade. (#82425) Thanks @joshavant.
 - Agents/bootstrap: ignore stale completed root `BOOTSTRAP.md` context after workspace setup cleanup fails, preventing channel agent turns from treating it as a directory. (#82463) Thanks @joshavant.
+- Update/doctor: re-enable the Codex plugin during `openclaw doctor --fix` when configured OpenAI agent models require the Codex runtime, preventing upgraded configs from failing with an unregistered Codex harness. Fixes #82368. (#82502) Thanks @joshavant.
 - Configure: show one OpenAI provider entry with ChatGPT/Codex sign-in and API key choices, and keep browsed Codex models in the saved `/model` picker allowlist.
 - Agents/model fallback: preserve auto fallback chains across deferred config reloads when session fallback provenance survives but `modelOverrideSource` is missing. Fixes #81982. Thanks @joshavant.
 - Hooks: raise bounded gateway lifecycle hook wait budgets to 5 seconds for shutdown and 10 seconds for pre-restart, giving short restart notification handlers time to finish before shutdown continues. (#82273) Thanks @bryanbaer.

--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -1714,8 +1714,9 @@ describe("doctor config flow", () => {
     expect(
       ((browser.profiles as Record<string, { driver?: string }>)?.chromeLive ?? {}).driver,
     ).toBe("existing-session");
-    expect(result.cfg.plugins?.allow).toEqual(["telegram", "browser"]);
+    expect(result.cfg.plugins?.allow).toEqual(["telegram", "browser", "codex"]);
     expect(result.cfg.plugins?.entries?.browser?.enabled).toBe(true);
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
   });
 
   it("preserves commitments config on repair", async () => {

--- a/src/commands/doctor/shared/codex-route-warnings.test.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.test.ts
@@ -2331,6 +2331,26 @@ describe("collectCodexRouteWarnings", () => {
     expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
   });
 
+  it("keeps Codex disabled when no agent routes are configured", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          allow: ["brave"],
+          entries: {
+            brave: { enabled: true },
+            codex: { enabled: false },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([]);
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(false);
+    expect(result.cfg.plugins?.allow).toEqual(["brave"]);
+  });
+
   it("re-enables the Codex plugin when defaults configure only non-Codex fallbacks", () => {
     const result = maybeRepairCodexRoutes({
       cfg: {

--- a/src/commands/doctor/shared/codex-route-warnings.test.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.test.ts
@@ -134,6 +134,33 @@ describe("collectCodexRouteWarnings", () => {
     expect(warnings).toStrictEqual([]);
   });
 
+  it("warns when Codex runtime routes are configured while the Codex plugin is disabled", () => {
+    const warnings = collectCodexRouteWarnings({
+      cfg: {
+        plugins: {
+          entries: {
+            codex: { enabled: false },
+          },
+        },
+        agents: {
+          defaults: {
+            model: {
+              primary: "gpt-5.5",
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+    });
+
+    expect(warnings).toStrictEqual([
+      [
+        "- Codex runtime is selected, but the Codex plugin is disabled.",
+        "- agents.defaults.model.primary: gpt-5.5 resolves to openai/gpt-5.5 with Codex runtime while the Codex plugin is disabled by config.",
+        "- Run `openclaw doctor --fix`: it enables plugins.entries.codex, or set the affected OpenAI models to a PI runtime policy.",
+      ].join("\n"),
+    ]);
+  });
+
   it("warns when Codex runtime has OpenClaw compaction summarizer overrides", () => {
     const warnings = collectCodexRouteWarnings({
       cfg: {
@@ -1968,6 +1995,884 @@ describe("collectCodexRouteWarnings", () => {
       id: "codex",
     });
     expect(result.changes.join("\n")).toContain("agentRuntime.id");
+  });
+
+  it("re-enables the Codex plugin when default OpenAI routes use Codex runtime", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          allow: ["openai"],
+          entries: {
+            openai: { enabled: true },
+            codex: { enabled: false },
+          },
+        },
+        agents: {
+          defaults: {
+            model: {
+              primary: "gpt-5.5",
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([
+      "Enabled plugins.entries.codex because configured agent routes use Codex runtime.",
+      "Added codex to plugins.allow because configured agent routes use Codex runtime.",
+    ]);
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
+    expect(result.cfg.plugins?.allow).toEqual(["openai", "codex"]);
+    expect(
+      resolveAgentHarnessPolicy({
+        provider: "openai",
+        modelId: "gpt-5.5",
+        config: result.cfg,
+      }).runtime,
+    ).toBe("codex");
+  });
+
+  it("re-enables the Codex plugin when a default heartbeat model uses Codex runtime", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          entries: {
+            codex: { enabled: false },
+          },
+        },
+        agents: {
+          defaults: {
+            model: "anthropic/claude-sonnet-4-6",
+            heartbeat: {
+              model: "gpt-5.5",
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([
+      "Enabled plugins.entries.codex because configured agent routes use Codex runtime.",
+    ]);
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
+  });
+
+  it("re-enables the Codex plugin when a default subagent model uses Codex runtime", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          entries: {
+            codex: { enabled: false },
+          },
+        },
+        agents: {
+          defaults: {
+            model: "anthropic/claude-sonnet-4-6",
+            subagents: {
+              model: {
+                primary: "gpt-5.5",
+              },
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([
+      "Enabled plugins.entries.codex because configured agent routes use Codex runtime.",
+    ]);
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
+  });
+
+  it("re-enables the Codex plugin when an agent inherits a default heartbeat model that uses Codex runtime", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          entries: {
+            codex: { enabled: false },
+          },
+        },
+        agents: {
+          defaults: {
+            heartbeat: {
+              model: "gpt-5.5",
+            },
+          },
+          list: [
+            {
+              id: "research",
+              model: "anthropic/claude-sonnet-4-6",
+            },
+          ],
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([
+      "Enabled plugins.entries.codex because configured agent routes use Codex runtime.",
+    ]);
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
+  });
+
+  it("re-enables the Codex plugin when an agent model alias resolves to OpenAI", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          entries: {
+            codex: { enabled: false },
+          },
+        },
+        agents: {
+          defaults: {
+            model: "xiaomi/mimo-v2-pro-mit",
+            models: {
+              "openai/xiaomi/mimo-v2-pro-mit": {
+                alias: "xiaomi/mimo-v2-pro-mit",
+              },
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([
+      "Enabled plugins.entries.codex because configured agent routes use Codex runtime.",
+    ]);
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
+  });
+
+  it("keeps the Codex plugin disabled when a bare alias resolves through a non-OpenAI default provider", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          entries: {
+            codex: { enabled: false },
+          },
+        },
+        agents: {
+          defaults: {
+            model: "anthropic/claude-sonnet-4-6",
+            models: {
+              "claude-opus-4-6": {
+                alias: "opus",
+              },
+            },
+            subagents: {
+              model: "opus",
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([]);
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(false);
+  });
+
+  it("keeps the Codex plugin disabled when a bare alias inherits a default provider from the primary alias", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          entries: {
+            codex: { enabled: false },
+          },
+        },
+        agents: {
+          defaults: {
+            model: "sonnet",
+            models: {
+              "anthropic/claude-sonnet-4-6": {
+                alias: "sonnet",
+              },
+              "claude-opus-4-6": {
+                alias: "opus",
+              },
+            },
+            subagents: {
+              model: "opus",
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([]);
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(false);
+  });
+
+  it("keeps the Codex plugin disabled when an auth-profiled bare alias resolves outside OpenAI", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          entries: {
+            codex: { enabled: false },
+          },
+        },
+        agents: {
+          defaults: {
+            model: "fast@work",
+            models: {
+              "anthropic/claude-sonnet-4-6": {
+                alias: "fast",
+              },
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([]);
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(false);
+  });
+
+  it("re-enables the Codex plugin when a per-agent-only bare alias falls back to OpenAI", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          entries: {
+            codex: { enabled: false },
+          },
+        },
+        agents: {
+          list: [
+            {
+              id: "worker",
+              model: "fast",
+              models: {
+                "anthropic/claude-sonnet-4-6": {
+                  alias: "fast",
+                },
+              },
+            },
+          ],
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([
+      "Enabled plugins.entries.codex because configured agent routes use Codex runtime.",
+    ]);
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
+  });
+
+  it("re-enables the Codex plugin when a listed-agent bare primary ignores per-agent provider metadata", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          entries: {
+            codex: { enabled: false },
+          },
+        },
+        agents: {
+          list: [
+            {
+              id: "worker",
+              model: "claude-sonnet-4-6",
+              models: {
+                "anthropic/claude-sonnet-4-6": {},
+              },
+            },
+          ],
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([
+      "Enabled plugins.entries.codex because configured agent routes use Codex runtime.",
+    ]);
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
+  });
+
+  it("re-enables the Codex plugin when defaults inherit the implicit OpenAI model", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          entries: {
+            codex: { enabled: false },
+          },
+        },
+        agents: {
+          defaults: {
+            models: {
+              "anthropic/claude-sonnet-4-6": {
+                alias: "sonnet",
+              },
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([
+      "Enabled plugins.entries.codex because configured agent routes use Codex runtime.",
+    ]);
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
+  });
+
+  it("re-enables the Codex plugin when defaults configure only non-Codex fallbacks", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          entries: {
+            codex: { enabled: false },
+          },
+        },
+        agents: {
+          defaults: {
+            model: {
+              fallbacks: ["anthropic/claude-sonnet-4-6"],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([
+      "Enabled plugins.entries.codex because configured agent routes use Codex runtime.",
+    ]);
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
+  });
+
+  it("keeps Codex disabled when implicit defaults resolve to a configured provider", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          entries: {
+            codex: { enabled: false },
+          },
+        },
+        models: {
+          providers: {
+            anthropic: {
+              models: [{ id: "claude-sonnet-4-6" }],
+            },
+          },
+        },
+        agents: {
+          defaults: {},
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([]);
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(false);
+  });
+
+  it("keeps Codex disabled for unused OpenAI model-map metadata", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          entries: {
+            codex: { enabled: false },
+          },
+        },
+        agents: {
+          defaults: {
+            model: "anthropic/claude-sonnet-4-6",
+            models: {
+              "openai/gpt-5.5": {
+                alias: "gpt",
+              },
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([]);
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(false);
+  });
+
+  it("re-enables Codex for model-map runtime policies even when the primary is non-Codex", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          entries: {
+            codex: { enabled: false },
+          },
+        },
+        agents: {
+          defaults: {
+            model: "anthropic/claude-sonnet-4-6",
+            models: {
+              "openai/gpt-5.5": {
+                agentRuntime: { id: "codex" },
+              },
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([
+      "Enabled plugins.entries.codex because configured agent routes use Codex runtime.",
+    ]);
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
+  });
+
+  it("re-enables Codex for default model-map runtime policies inherited by listed agents", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          entries: {
+            codex: { enabled: false },
+          },
+        },
+        agents: {
+          defaults: {
+            models: {
+              "openai/gpt-5.5": {
+                agentRuntime: { id: "codex" },
+              },
+            },
+          },
+          list: [
+            {
+              id: "worker",
+              model: "anthropic/claude-sonnet-4-6",
+            },
+          ],
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([
+      "Enabled plugins.entries.codex because configured agent routes use Codex runtime.",
+    ]);
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
+  });
+
+  it("keeps Codex disabled when openrouter:auto resolves outside OpenAI", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          entries: {
+            codex: { enabled: false },
+          },
+        },
+        agents: {
+          defaults: {
+            model: "openrouter:auto",
+          },
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([]);
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(false);
+  });
+
+  it("keeps Codex disabled when a bare alias inherits an OpenRouter compat primary provider", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          entries: {
+            codex: { enabled: false },
+          },
+        },
+        agents: {
+          defaults: {
+            model: "openrouter:auto",
+            models: {
+              "claude-sonnet-4-6": {
+                alias: "sonnet",
+              },
+            },
+            subagents: {
+              model: "sonnet",
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([]);
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(false);
+  });
+
+  it("keeps Codex disabled when an alias resolves to an OpenRouter compat model", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          entries: {
+            codex: { enabled: false },
+          },
+        },
+        agents: {
+          defaults: {
+            model: "router-auto",
+            models: {
+              "openrouter:auto": {
+                alias: "router-auto",
+              },
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([]);
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(false);
+  });
+
+  it("re-enables the Codex plugin when a channel model override uses Codex runtime", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          entries: {
+            codex: { enabled: false },
+          },
+        },
+        agents: {
+          defaults: {
+            model: "anthropic/claude-sonnet-4-6",
+          },
+        },
+        channels: {
+          modelByChannel: {
+            telegram: {
+              default: "gpt-5.5",
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([
+      "Enabled plugins.entries.codex because configured agent routes use Codex runtime.",
+    ]);
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
+  });
+
+  it("uses normalized runtime agent ids when checking model runtime policy", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          entries: {
+            codex: { enabled: false },
+          },
+        },
+        agents: {
+          list: [
+            {
+              id: "",
+              model: "gpt-5.5",
+              models: {
+                "openai/gpt-5.5": {
+                  agentRuntime: { id: "pi" },
+                },
+              },
+            },
+          ],
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([]);
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(false);
+  });
+
+  it("does not make an empty plugin allowlist restrictive when re-enabling Codex", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          allow: [],
+          entries: {
+            codex: { enabled: false },
+          },
+        },
+        agents: {
+          defaults: {
+            model: "gpt-5.5",
+          },
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.changes).toStrictEqual([
+      "Enabled plugins.entries.codex because configured agent routes use Codex runtime.",
+    ]);
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
+    expect(result.cfg.plugins?.allow).toEqual([]);
+  });
+
+  it("adds Codex to a non-empty plugin allowlist when OpenAI routes require Codex runtime", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          allow: ["openai"],
+          entries: {
+            openai: { enabled: true },
+          },
+        },
+        agents: {
+          defaults: {
+            model: "gpt-5.5",
+          },
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([
+      "Enabled plugins.entries.codex because configured agent routes use Codex runtime.",
+      "Added codex to plugins.allow because configured agent routes use Codex runtime.",
+    ]);
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
+    expect(result.cfg.plugins?.allow).toEqual(["openai", "codex"]);
+  });
+
+  it("treats bundled discovery compat allowlists as restrictive for the Codex harness", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          allow: ["openai"],
+          bundledDiscovery: "compat",
+          entries: {
+            openai: { enabled: true },
+          },
+        },
+        agents: {
+          defaults: {
+            model: "gpt-5.5",
+          },
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([
+      "Enabled plugins.entries.codex because configured agent routes use Codex runtime.",
+      "Added codex to plugins.allow because configured agent routes use Codex runtime.",
+    ]);
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
+    expect(result.cfg.plugins?.allow).toEqual(["openai", "codex"]);
+  });
+
+  it("adds Codex to bundled discovery compat allowlists when re-enabling Codex", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          allow: ["openai"],
+          bundledDiscovery: "compat",
+          entries: {
+            codex: { enabled: false },
+          },
+        },
+        agents: {
+          defaults: {
+            model: "gpt-5.5",
+          },
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([
+      "Enabled plugins.entries.codex because configured agent routes use Codex runtime.",
+      "Added codex to plugins.allow because configured agent routes use Codex runtime.",
+    ]);
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
+    expect(result.cfg.plugins?.allow).toEqual(["openai", "codex"]);
+  });
+
+  it("keeps the Codex plugin disabled when OpenAI routes explicitly use the PI runtime", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          entries: {
+            codex: { enabled: false },
+          },
+        },
+        models: {
+          providers: {
+            openai: {
+              agentRuntime: { id: "pi" },
+              models: [],
+            },
+          },
+        },
+        agents: {
+          defaults: {
+            model: "gpt-5.5",
+          },
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([]);
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(false);
+    expect(
+      resolveAgentHarnessPolicy({
+        provider: "openai",
+        modelId: "gpt-5.5",
+        config: result.cfg,
+      }).runtime,
+    ).toBe("pi");
+  });
+
+  it("keeps the Codex plugin disabled when an auth-profiled OpenAI route explicitly uses the PI runtime", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          entries: {
+            codex: { enabled: false },
+          },
+        },
+        agents: {
+          defaults: {
+            model: "openai/gpt-5.5@work",
+            models: {
+              "openai/gpt-5.5": {
+                agentRuntime: { id: "pi" },
+              },
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([]);
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(false);
+  });
+
+  it("keeps the Codex plugin disabled when a bare model resolves to a configured provider", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          entries: {
+            codex: { enabled: false },
+          },
+        },
+        models: {
+          providers: {
+            "qwen-dashscope": {
+              models: [{ id: "qwen-max" }],
+            },
+          },
+        },
+        agents: {
+          defaults: {
+            model: "qwen-max",
+          },
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([]);
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(false);
+  });
+
+  it("keeps the Codex plugin disabled when a bare model case-insensitively resolves to a configured provider", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          entries: {
+            codex: { enabled: false },
+          },
+        },
+        models: {
+          providers: {
+            "qwen-dashscope": {
+              models: [{ id: "Qwen-Max" }],
+            },
+          },
+        },
+        agents: {
+          defaults: {
+            model: "qwen-max",
+          },
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([]);
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(false);
+  });
+
+  it("re-enables the Codex plugin when a provider-prefixed catalog model does not claim a bare model", () => {
+    const result = maybeRepairCodexRoutes({
+      cfg: {
+        plugins: {
+          entries: {
+            codex: { enabled: false },
+          },
+        },
+        models: {
+          providers: {
+            "qwen-dashscope": {
+              models: [{ id: "qwen-dashscope/qwen-max" }],
+            },
+          },
+        },
+        agents: {
+          defaults: {
+            model: "qwen-max",
+          },
+        },
+      } as unknown as OpenClawConfig,
+      shouldRepair: true,
+    });
+
+    expect(result.warnings).toStrictEqual([]);
+    expect(result.changes).toStrictEqual([
+      "Enabled plugins.entries.codex because configured agent routes use Codex runtime.",
+    ]);
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
   });
 
   it("keeps repaired OpenAI refs on Codex runtime even when the OpenAI provider is otherwise PI/API-key routed", () => {

--- a/src/commands/doctor/shared/codex-route-warnings.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.ts
@@ -1089,6 +1089,7 @@ function collectDisabledCodexPluginRouteHits(cfg: OpenClawConfig): DisabledCodex
     path: "agents.defaults",
   });
   if (
+    cfg.agents &&
     !hasAgentPrimaryModelConfig(defaults) &&
     !defaultRefs.some(
       (ref) =>

--- a/src/commands/doctor/shared/codex-route-warnings.ts
+++ b/src/commands/doctor/shared/codex-route-warnings.ts
@@ -1,14 +1,19 @@
 import fs from "node:fs";
+import { resolveConfiguredProviderFallback } from "../../../agents/configured-provider-fallback.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../../agents/defaults.js";
+import { splitTrailingAuthProfile } from "../../../agents/model-ref-profile.js";
+import { normalizeConfiguredProviderCatalogModelId } from "../../../agents/model-ref-shared.js";
 import { resolveModelRuntimePolicy } from "../../../agents/model-runtime-policy.js";
 import { openAIProviderUsesCodexRuntimeByDefault } from "../../../agents/openai-codex-routing.js";
 import { normalizeEmbeddedAgentRuntime } from "../../../agents/pi-embedded-runner/runtime.js";
+import { normalizeProviderId } from "../../../agents/provider-id.js";
 import { AGENT_MODEL_CONFIG_KEYS } from "../../../config/model-refs.js";
 import { loadSessionStore, updateSessionStore } from "../../../config/sessions/store.js";
 import { resolveAllAgentSessionStoreTargetsSync } from "../../../config/sessions/targets.js";
 import type { SessionEntry } from "../../../config/sessions/types.js";
 import type { AgentRuntimePolicyConfig } from "../../../config/types.agents-shared.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { normalizeAgentId } from "../../../routing/session-key.js";
 
 type CodexRouteHit = {
   path: string;
@@ -29,6 +34,11 @@ type LegacyLosslessCompactionConfig = {
   providerValue: string;
   modelPath?: string;
   modelValue?: string;
+};
+type DisabledCodexPluginRouteHit = {
+  path: string;
+  modelRef: string;
+  canonicalModel: string;
 };
 type SharedDefaultCompactionOverrideConsumers = Record<CompactionOverrideKey, boolean>;
 
@@ -214,21 +224,227 @@ function modelRefUsesCodexRuntime(params: {
   agentId?: string;
 }): boolean {
   const effectiveModelRef = params.modelRef?.trim() || `${DEFAULT_PROVIDER}/${DEFAULT_MODEL}`;
-  const canonicalModel =
-    toCanonicalOpenAIModelRef(effectiveModelRef) ??
-    normalizeDefaultProviderModelRef(effectiveModelRef);
   if (isOpenAICodexModelRef(effectiveModelRef)) {
     return true;
   }
   return canonicalOpenAIModelUsesCodexRuntime({
     cfg: params.cfg,
-    modelRef: canonicalModel,
+    modelRef: resolveRuntimeModelRef({
+      cfg: params.cfg,
+      modelRef: effectiveModelRef,
+      agentId: params.agentId,
+    }),
     agentId: params.agentId,
   });
 }
 
+function resolveRuntimeModelRef(params: {
+  cfg: OpenClawConfig;
+  modelRef: string;
+  agentId?: string;
+}): string {
+  const effectiveModelRef =
+    normalizeProviderModelRefAuthProfile(params.modelRef) ?? `${DEFAULT_PROVIDER}/${DEFAULT_MODEL}`;
+  const legacyCodexModel = toCanonicalOpenAIModelRef(effectiveModelRef);
+  if (legacyCodexModel) {
+    return legacyCodexModel;
+  }
+  return (
+    resolveKnownCompatModelAliasRef(effectiveModelRef) ??
+    resolveConfiguredModelAliasRef({
+      cfg: params.cfg,
+      modelRef: effectiveModelRef,
+      agentId: params.agentId,
+    }) ??
+    resolveConfiguredBareModelRef({
+      cfg: params.cfg,
+      modelRef: effectiveModelRef,
+      agentId: params.agentId,
+    }) ??
+    normalizeDefaultProviderModelRef(effectiveModelRef)
+  );
+}
+
+function normalizeProviderModelRefAuthProfile(modelRef: string): string | undefined {
+  const trimmed = modelRef.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return splitTrailingAuthProfile(trimmed).model || trimmed;
+}
+
+function resolveKnownCompatModelAliasRef(modelRef: string): string | undefined {
+  const normalized = normalizeString(modelRef);
+  if (!normalized?.startsWith("openrouter:")) {
+    return undefined;
+  }
+  const modelId = normalized.slice("openrouter:".length).trim();
+  return modelId ? `openrouter/openrouter/${modelId}` : undefined;
+}
+
+function resolveConfiguredModelAliasRef(params: {
+  cfg: OpenClawConfig;
+  modelRef: string;
+  agentId?: string;
+}): string | undefined {
+  const aliasKey = normalizeString(params.modelRef);
+  if (!aliasKey) {
+    return undefined;
+  }
+  const defaultProvider = resolveDefaultProviderForAliasContext({
+    cfg: params.cfg,
+    agentId: params.agentId,
+  });
+  return resolveAliasFromModelsMap(
+    asMutableRecord(params.cfg.agents?.defaults?.models),
+    aliasKey,
+    defaultProvider,
+  );
+}
+
+function resolveDefaultProviderForAliasContext(params: {
+  cfg: OpenClawConfig;
+  agentId?: string;
+}): string {
+  const primaryModelRef =
+    readModelConfigPrimaryRef(findAgentById(params.cfg, params.agentId)?.model) ??
+    readModelConfigPrimaryRef(params.cfg.agents?.defaults?.model);
+  if (primaryModelRef) {
+    const effectivePrimaryModelRef =
+      normalizeProviderModelRefAuthProfile(primaryModelRef) ?? primaryModelRef;
+    const legacyCodexModel = toCanonicalOpenAIModelRef(effectivePrimaryModelRef);
+    const compatModelRef = resolveKnownCompatModelAliasRef(effectivePrimaryModelRef);
+    const primaryAliasRef = resolveAliasFromModelsMap(
+      asMutableRecord(params.cfg.agents?.defaults?.models),
+      normalizeString(effectivePrimaryModelRef) ?? "",
+      DEFAULT_PROVIDER,
+    );
+    const parsed =
+      parseModelRef(
+        primaryAliasRef ?? compatModelRef ?? legacyCodexModel ?? effectivePrimaryModelRef,
+      ) ??
+      parseModelRef(
+        resolveConfiguredBareModelRef({
+          cfg: params.cfg,
+          modelRef: effectivePrimaryModelRef,
+          agentId: params.agentId,
+        }) ?? "",
+      );
+    return normalizeProviderId(parsed?.provider ?? DEFAULT_PROVIDER) || DEFAULT_PROVIDER;
+  }
+  const implicit = parseModelRef(resolveImplicitDefaultAgentModelRef(params.cfg));
+  return normalizeProviderId(implicit?.provider ?? DEFAULT_PROVIDER) || DEFAULT_PROVIDER;
+}
+
+function findAgentById(
+  cfg: OpenClawConfig,
+  agentId: string | undefined,
+): MutableRecord | undefined {
+  if (!agentId) {
+    return undefined;
+  }
+  const normalizedAgentId = normalizeAgentId(agentId);
+  const agents = Array.isArray(cfg.agents?.list) ? cfg.agents.list : [];
+  return agents
+    .map((agent) => asMutableRecord(agent))
+    .find(
+      (agent) =>
+        normalizeAgentId(typeof agent?.id === "string" ? agent.id : undefined) ===
+        normalizedAgentId,
+    );
+}
+
+function resolveAliasFromModelsMap(
+  models: MutableRecord | undefined,
+  aliasKey: string,
+  defaultProvider: string,
+): string | undefined {
+  for (const [modelRef, entry] of Object.entries(models ?? {})) {
+    if (normalizeString(asMutableRecord(entry)?.alias) !== aliasKey) {
+      continue;
+    }
+    const compatRef = resolveKnownCompatModelAliasRef(modelRef);
+    if (compatRef) {
+      return compatRef;
+    }
+    return modelRef.includes("/")
+      ? normalizeDefaultProviderModelRef(modelRef)
+      : `${defaultProvider}/${modelRef}`;
+  }
+  return undefined;
+}
+
+function resolveConfiguredBareModelRef(params: {
+  cfg: OpenClawConfig;
+  modelRef: string;
+  agentId?: string;
+}): string | undefined {
+  const modelId = params.modelRef.trim();
+  if (!modelId || modelId.includes("/")) {
+    return undefined;
+  }
+  const matches = new Set<string>();
+  const pushModelMapMatches = (models: MutableRecord | undefined) => {
+    for (const key of Object.keys(models ?? {})) {
+      const parsed = parseModelRef(key);
+      if (parsed?.modelId === modelId) {
+        matches.add(`${parsed.provider}/${parsed.modelId}`);
+      }
+    }
+  };
+  pushModelMapMatches(asMutableRecord(params.cfg.agents?.defaults?.models));
+  for (const [provider, providerConfig] of Object.entries(params.cfg.models?.providers ?? {})) {
+    for (const model of providerConfig?.models ?? []) {
+      if (providerCatalogModelMatches(provider, model?.id, modelId)) {
+        matches.add(`${normalizeProviderId(provider)}/${modelId}`);
+      }
+    }
+  }
+  return matches.size === 1 ? [...matches][0] : undefined;
+}
+
+function providerCatalogModelMatches(
+  provider: string,
+  catalogModelId: string | undefined,
+  modelId: string,
+): boolean {
+  const rawId = catalogModelId?.trim();
+  if (!rawId) {
+    return false;
+  }
+  const normalizedId = normalizeConfiguredProviderCatalogModelId(provider, rawId);
+  if (normalizedId === modelId) {
+    return true;
+  }
+  return normalizeString(normalizedId) === normalizeString(modelId);
+}
+
 function normalizeDefaultProviderModelRef(modelRef: string): string {
   return modelRef.includes("/") ? modelRef : `${DEFAULT_PROVIDER}/${modelRef}`;
+}
+
+function normalizeProviderModelRef(provider: string, modelId: string): string {
+  const normalizedProvider = normalizeProviderId(provider);
+  const normalizedModelId = normalizeConfiguredProviderCatalogModelId(normalizedProvider, modelId);
+  const slash = normalizedModelId.indexOf("/");
+  if (
+    slash > 0 &&
+    normalizeProviderId(normalizedModelId.slice(0, slash)) === normalizedProvider &&
+    slash < normalizedModelId.length - 1
+  ) {
+    return `${normalizedProvider}/${normalizedModelId.slice(slash + 1)}`;
+  }
+  return `${normalizedProvider}/${normalizedModelId}`;
+}
+
+function resolveImplicitDefaultAgentModelRef(cfg: OpenClawConfig): string {
+  const fallbackProvider = resolveConfiguredProviderFallback({
+    cfg,
+    defaultProvider: DEFAULT_PROVIDER,
+  });
+  return fallbackProvider
+    ? normalizeProviderModelRef(fallbackProvider.provider, fallbackProvider.model)
+    : `${DEFAULT_PROVIDER}/${DEFAULT_MODEL}`;
 }
 
 function agentUsesCodexRuntimeForCompaction(params: {
@@ -772,6 +988,235 @@ function collectConfigModelRefs(cfg: OpenClawConfig, env?: NodeJS.ProcessEnv): C
   return hits;
 }
 
+function pluginIdListIncludes(value: unknown, pluginId: string): boolean {
+  return Array.isArray(value) && value.some((entry) => normalizeString(entry) === pluginId);
+}
+
+function codexPluginAllowlistIsRestrictive(cfg: OpenClawConfig): boolean {
+  const allow = cfg.plugins?.allow;
+  return Array.isArray(allow) && allow.length > 0 && !pluginIdListIncludes(allow, "codex");
+}
+
+function isCodexPluginUnavailableByConfig(cfg: OpenClawConfig): boolean {
+  if (codexPluginIsBlockedOutsideEntry(cfg)) {
+    return true;
+  }
+  if (asMutableRecord(asMutableRecord(cfg.plugins?.entries)?.codex)?.enabled === false) {
+    return true;
+  }
+  return codexPluginAllowlistIsRestrictive(cfg);
+}
+
+function codexPluginIsBlockedOutsideEntry(cfg: OpenClawConfig): boolean {
+  if (cfg.plugins?.enabled === false) {
+    return true;
+  }
+  return pluginIdListIncludes(cfg.plugins?.deny, "codex");
+}
+
+function collectAgentRuntimeModelRefs(params: {
+  agent: unknown;
+  path: string;
+  fallbackModelRefs?: ReadonlyArray<{ path: string; modelRef: string }>;
+  inheritedModelRefs?: ReadonlyArray<{ path: string; modelRef: string }>;
+}): Array<{ path: string; modelRef: string }> {
+  const refs: Array<{ path: string; modelRef: string }> = [];
+  const agent = asMutableRecord(params.agent);
+  if (agent && Object.prototype.hasOwnProperty.call(agent, "model")) {
+    collectModelConfigRefs({
+      refs,
+      path: `${params.path}.model`,
+      value: agent.model,
+    });
+  }
+  if (!hasAgentPrimaryModelConfig(agent) && params.fallbackModelRefs) {
+    refs.push(...params.fallbackModelRefs);
+  }
+  collectStringModelConfigRef({
+    refs,
+    path: `${params.path}.heartbeat.model`,
+    value: asMutableRecord(agent?.heartbeat)?.model,
+  });
+  collectModelConfigRefs({
+    refs,
+    path: `${params.path}.subagents.model`,
+    value: asMutableRecord(agent?.subagents)?.model,
+  });
+  if (params.inheritedModelRefs) {
+    refs.push(...params.inheritedModelRefs);
+  }
+  collectCodexRuntimeModelPolicyRefs({
+    refs,
+    path: `${params.path}.models`,
+    models: agent?.models,
+  });
+  return refs;
+}
+
+function hasAgentPrimaryModelConfig(agent: unknown): boolean {
+  const record = asMutableRecord(agent);
+  return Boolean(record && readModelConfigPrimaryRef(record.model));
+}
+
+function collectChannelAgentRuntimeModelRefs(
+  cfg: OpenClawConfig,
+): Array<{ path: string; modelRef: string }> {
+  const refs: Array<{ path: string; modelRef: string }> = [];
+  const channelsModelByChannel = asMutableRecord(cfg.channels?.modelByChannel);
+  for (const [channelId, channelMapValue] of Object.entries(channelsModelByChannel ?? {})) {
+    const channelMap = asMutableRecord(channelMapValue);
+    if (!channelMap) {
+      continue;
+    }
+    for (const [targetId, modelRef] of Object.entries(channelMap)) {
+      collectStringModelConfigRef({
+        refs,
+        path: `channels.modelByChannel.${channelId}.${targetId}`,
+        value: modelRef,
+      });
+    }
+  }
+  return refs;
+}
+
+function collectDisabledCodexPluginRouteHits(cfg: OpenClawConfig): DisabledCodexPluginRouteHit[] {
+  if (!isCodexPluginUnavailableByConfig(cfg)) {
+    return [];
+  }
+  const defaults = cfg.agents?.defaults;
+  const defaultRefs = collectAgentRuntimeModelRefs({
+    agent: defaults,
+    path: "agents.defaults",
+  });
+  if (
+    !hasAgentPrimaryModelConfig(defaults) &&
+    !defaultRefs.some(
+      (ref) =>
+        resolveRuntimeModelRef({ cfg, modelRef: ref.modelRef }) ===
+        resolveImplicitDefaultAgentModelRef(cfg),
+    )
+  ) {
+    defaultRefs.push({
+      path: "agents.defaults.model",
+      modelRef: resolveImplicitDefaultAgentModelRef(cfg),
+    });
+  }
+
+  const agents = Array.isArray(cfg.agents?.list) ? cfg.agents.list : [];
+  const inheritedDefaultAuxRefs = defaultRefs.filter(
+    (ref) =>
+      ref.path === "agents.defaults.heartbeat.model" ||
+      ref.path.startsWith("agents.defaults.subagents.model"),
+  );
+  const inheritedDefaultModelPolicyRefs = defaultRefs.filter((ref) =>
+    ref.path.startsWith("agents.defaults.models."),
+  );
+  const inheritedDefaultModelRefs = defaultRefs.filter(
+    (ref) =>
+      !inheritedDefaultAuxRefs.includes(ref) && !inheritedDefaultModelPolicyRefs.includes(ref),
+  );
+  const candidateRefs: Array<{ path: string; modelRef: string; agentId?: string }> =
+    agents.length === 0 ? [...defaultRefs] : [];
+  candidateRefs.push(...collectChannelAgentRuntimeModelRefs(cfg));
+  for (const [index, agent] of agents.entries()) {
+    const agentRecord = asMutableRecord(agent);
+    if (!agentRecord) {
+      continue;
+    }
+    const pathId =
+      typeof agentRecord.id === "string" && agentRecord.id.trim()
+        ? agentRecord.id.trim()
+        : String(index);
+    const agentId = normalizeAgentId(
+      typeof agentRecord.id === "string" ? agentRecord.id : undefined,
+    );
+    const inheritedModelRefs = inheritedDefaultAuxRefs.filter((ref) => {
+      if (ref.path === "agents.defaults.heartbeat.model") {
+        return !normalizeString(asMutableRecord(agentRecord.heartbeat)?.model);
+      }
+      if (ref.path.startsWith("agents.defaults.subagents.model")) {
+        return !readModelConfigPrimaryRef(asMutableRecord(agentRecord.subagents)?.model);
+      }
+      return true;
+    });
+    inheritedModelRefs.push(...inheritedDefaultModelPolicyRefs);
+    for (const ref of collectAgentRuntimeModelRefs({
+      agent: agentRecord,
+      path: `agents.list.${pathId}`,
+      fallbackModelRefs: inheritedDefaultModelRefs,
+      inheritedModelRefs,
+    })) {
+      candidateRefs.push({ ...ref, agentId });
+    }
+  }
+
+  const hits: DisabledCodexPluginRouteHit[] = [];
+  const seen = new Set<string>();
+  for (const ref of candidateRefs) {
+    const canonicalModel = resolveRuntimeModelRef({
+      cfg,
+      modelRef: ref.modelRef,
+      agentId: ref.agentId,
+    });
+    if (
+      !modelRefUsesCodexRuntime({
+        cfg,
+        modelRef: ref.modelRef,
+        agentId: ref.agentId,
+      })
+    ) {
+      continue;
+    }
+    const key = `${ref.agentId ?? ""}\0${ref.path}\0${canonicalModel}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    hits.push({ path: ref.path, modelRef: ref.modelRef, canonicalModel });
+  }
+  return hits;
+}
+
+function enableCodexPluginForRequiredRoutes(params: {
+  cfg: OpenClawConfig;
+  routeHits: DisabledCodexPluginRouteHit[];
+}): { cfg: OpenClawConfig; changes: string[] } {
+  if (params.routeHits.length === 0 || codexPluginIsBlockedOutsideEntry(params.cfg)) {
+    return { cfg: params.cfg, changes: [] };
+  }
+  const cfg = structuredClone(params.cfg);
+  const plugins = asMutableRecord(cfg.plugins) ?? {};
+  if (cfg.plugins !== plugins) {
+    cfg.plugins = plugins;
+  }
+  const entries = asMutableRecord(plugins.entries) ?? {};
+  if (plugins.entries !== entries) {
+    plugins.entries = entries;
+  }
+  const codexEntry = asMutableRecord(entries.codex) ?? {};
+  const changes: string[] = [];
+  if (codexEntry.enabled !== true) {
+    entries.codex = {
+      ...codexEntry,
+      enabled: true,
+    };
+    changes.push(
+      "Enabled plugins.entries.codex because configured agent routes use Codex runtime.",
+    );
+  } else if (entries.codex !== codexEntry) {
+    entries.codex = codexEntry;
+  }
+  if (
+    Array.isArray(plugins.allow) &&
+    plugins.allow.length > 0 &&
+    !plugins.allow.some((id) => normalizeString(id) === "codex")
+  ) {
+    plugins.allow = [...plugins.allow, "codex"];
+    changes.push("Added codex to plugins.allow because configured agent routes use Codex runtime.");
+  }
+  return { cfg, changes };
+}
+
 function rewriteStringModelSlot(params: {
   hits: CodexRouteHit[];
   container: MutableRecord | undefined;
@@ -893,6 +1338,68 @@ function modelConfigContainsRef(value: unknown, modelRef: string): boolean {
     Array.isArray(record.fallbacks) &&
     record.fallbacks.some((entry) => typeof entry === "string" && entry.trim() === modelRef)
   );
+}
+
+function collectModelConfigRefs(params: {
+  refs: Array<{ path: string; modelRef: string }>;
+  path: string;
+  value: unknown;
+}): void {
+  if (typeof params.value === "string") {
+    collectStringModelConfigRef(params);
+    return;
+  }
+  const record = asMutableRecord(params.value);
+  if (!record) {
+    return;
+  }
+  if (typeof record.primary === "string" && record.primary.trim()) {
+    params.refs.push({ path: `${params.path}.primary`, modelRef: record.primary.trim() });
+  }
+  if (Array.isArray(record.fallbacks)) {
+    for (const [index, entry] of record.fallbacks.entries()) {
+      if (typeof entry === "string" && entry.trim()) {
+        params.refs.push({ path: `${params.path}.fallbacks.${index}`, modelRef: entry.trim() });
+      }
+    }
+  }
+}
+
+function collectStringModelConfigRef(params: {
+  refs: Array<{ path: string; modelRef: string }>;
+  path: string;
+  value: unknown;
+}): void {
+  if (typeof params.value !== "string") {
+    return;
+  }
+  const modelRef = params.value.trim();
+  if (modelRef) {
+    params.refs.push({ path: params.path, modelRef });
+  }
+}
+
+function collectCodexRuntimeModelPolicyRefs(params: {
+  refs: Array<{ path: string; modelRef: string }>;
+  path: string;
+  models: unknown;
+}): void {
+  const record = asMutableRecord(params.models);
+  if (!record) {
+    return;
+  }
+  for (const [modelRef, entry] of Object.entries(record)) {
+    const trimmed = modelRef.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const runtime = normalizeEmbeddedAgentRuntime(
+      normalizeString(asMutableRecord(asMutableRecord(entry)?.agentRuntime)?.id),
+    );
+    if (runtime === "codex") {
+      params.refs.push({ path: `${params.path}.${trimmed}`, modelRef: trimmed });
+    }
+  }
 }
 
 function agentExplicitlyReferencesCanonicalModel(agent: unknown, modelRef: string): boolean {
@@ -1914,11 +2421,29 @@ function formatLegacyLosslessCompactionWarning(params: {
   ].join("\n");
 }
 
+function formatDisabledCodexPluginWarning(params: {
+  hits: DisabledCodexPluginRouteHit[];
+  blockedOutsideEntry: boolean;
+}): string {
+  const fixHint = params.blockedOutsideEntry
+    ? "- Enable plugin loading and remove `codex` from plugins.deny, or set the affected OpenAI models to a PI runtime policy."
+    : "- Run `openclaw doctor --fix`: it enables plugins.entries.codex, or set the affected OpenAI models to a PI runtime policy.";
+  return [
+    "- Codex runtime is selected, but the Codex plugin is disabled.",
+    ...params.hits.map(
+      (hit) =>
+        `- ${hit.path}: ${hit.modelRef} resolves to ${hit.canonicalModel} with Codex runtime while the Codex plugin is disabled by config.`,
+    ),
+    fixHint,
+  ].join("\n");
+}
+
 export function collectCodexRouteWarnings(params: {
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
 }): string[] {
   const hits = collectConfigModelRefs(params.cfg, params.env);
+  const disabledCodexPluginHits = collectDisabledCodexPluginRouteHits(params.cfg);
   const ignoreLegacyAgentRuntimePins = configRepairWouldClearLegacyRuntimePins(params);
   const legacyLosslessCompactionConfigs = collectLegacyLosslessCompactionConfigs({
     ...params,
@@ -1974,6 +2499,14 @@ export function collectCodexRouteWarnings(params: {
       }),
     );
   }
+  if (disabledCodexPluginHits.length > 0) {
+    warnings.push(
+      formatDisabledCodexPluginWarning({
+        hits: disabledCodexPluginHits,
+        blockedOutsideEntry: codexPluginIsBlockedOutsideEntry(params.cfg),
+      }),
+    );
+  }
   const preservedSharedDefaultHits = unsupportedCompactionOverrides.filter(
     (hit) =>
       hit.path.startsWith("agents.defaults.compaction.") &&
@@ -2012,6 +2545,7 @@ export function maybeRepairCodexRoutes(params: {
   codexRuntimeReady?: boolean;
 }): { cfg: OpenClawConfig; warnings: string[]; changes: string[] } {
   const hits = collectConfigModelRefs(params.cfg, params.env);
+  const disabledCodexPluginHits = collectDisabledCodexPluginRouteHits(params.cfg);
   const ignoreLegacyAgentRuntimePins = configRepairWouldClearLegacyRuntimePins(params);
   const unsupportedCompactionOverrides = collectUnsupportedCodexCompactionOverrides({
     cfg: params.cfg,
@@ -2025,6 +2559,7 @@ export function maybeRepairCodexRoutes(params: {
   });
   if (
     hits.length === 0 &&
+    disabledCodexPluginHits.length === 0 &&
     unsupportedCompactionOverrides.length === 0 &&
     legacyLosslessCompactionConfigs.length === 0
   ) {
@@ -2041,7 +2576,11 @@ export function maybeRepairCodexRoutes(params: {
     cfg: params.cfg,
     env: params.env,
   });
-  const warnings = collectCodexRouteWarnings({ cfg: repaired.cfg, env: params.env });
+  const codexPluginRepair = enableCodexPluginForRequiredRoutes({
+    cfg: repaired.cfg,
+    routeHits: collectDisabledCodexPluginRouteHits(repaired.cfg),
+  });
+  const warnings = collectCodexRouteWarnings({ cfg: codexPluginRepair.cfg, env: params.env });
   const changes =
     repaired.changes.length > 0
       ? [
@@ -2051,13 +2590,14 @@ export function maybeRepairCodexRoutes(params: {
         ]
       : [];
   return {
-    cfg: repaired.cfg,
+    cfg: codexPluginRepair.cfg,
     warnings,
     changes: [
       ...changes,
       ...repaired.runtimePolicyChanges,
       ...repaired.runtimePinChanges,
       ...repaired.unsupportedCompactionChanges,
+      ...codexPluginRepair.changes,
     ],
   };
 }


### PR DESCRIPTION
## Summary

Fixes #82368 by teaching `openclaw doctor --fix` to repair configs where OpenAI/Codex-runtime agent routes require the Codex plugin but `plugins.entries.codex` or `plugins.allow` makes that harness unavailable.

The repair enables `plugins.entries.codex` and adds `codex` to an existing non-empty allowlist only when configured routes actually resolve to Codex runtime. It preserves PI-routed OpenAI configs and non-Codex alias/provider cases.

## Verification

- `git diff --check`
- `./node_modules/.bin/tsgo -p tsconfig.core.json --pretty false --noEmit`
- `node scripts/run-vitest.mjs src/commands/doctor/shared/codex-route-warnings.test.ts` (90 tests)
- `codex review --uncommitted`
- Crabbox AWS E2E: `run_36941cbccbb1`

## Real Behavior Proof

Behavior addressed: upgraded configs with `plugins.entries.codex.enabled: false` and default OpenAI/Codex-runtime models failed at runtime with `Requested agent harness "codex" is not registered`.

Real environment tested: Crabbox AWS Linux, lease `cbx_554d34f93f0f`, run `run_36941cbccbb1`.

Exact steps or command run after this patch: created a temp config with local gateway auth, `plugins.entries.codex.enabled: false`, and `agents.defaults.model.primary: gpt-5.5`; ran `node scripts/run-node.mjs doctor --fix --non-interactive`; started `node scripts/run-node.mjs gateway`; piped `hello` into `node scripts/run-node.mjs agent --gateway-url http://127.0.0.1:19868 --gateway-token issue-82368-token`.

Evidence after fix: `doctor --fix` wrote `plugins.entries.codex.enabled: true`; the gateway/agent logs did not contain `Requested agent harness "codex" is not registered`.

Observed result after fix: agent command reached the expected no-provider-credentials/runtime boundary with `missingHarness: false` instead of the reported missing-harness failure.

What was not tested: a successful live OpenAI model completion; no OpenAI API key was needed to prove this missing-harness failure was fixed.
