### PR TITLE
fix: Canvas WebSocket creation in browser context silently swallows...

### DIFF
--- a/extensions/canvas/src/host/a2ui-shared.ts
+++ b/extensions/canvas/src/host/a2ui-shared.ts
@@ -22,49 +22,17 @@ export function injectCanvasLiveReload(html: string): string {
   const snippet = `
 <script>
 (() => {
-  const CANVAS_LIVE_RELOAD_ERROR_EVENT = "openclaw:canvas-live-reload-error";
-
   // Cross-platform action bridge helper.
   // Works on:
   // - iOS: window.webkit.messageHandlers.openclawCanvasA2UIAction.postMessage(...)
   // - Android: window.openclawCanvasA2UIAction.postMessage(...)
   const handlerNames = ["openclawCanvasA2UIAction"];
   let liveReloadErrorReported = false;
-  function describeError(err) {
-    if (
-      err &&
-      typeof err === "object" &&
-      "message" in err &&
-      typeof err.message === "string" &&
-      err.message
-    ) {
-      return err.message;
-    }
-    if (err && typeof err === "object") {
-      const parts = ["WebSocket connection failed"];
-      if ("code" in err && err.code) parts.push("code=" + String(err.code));
-      if ("reason" in err && err.reason) parts.push(String(err.reason));
-      return parts.join(": ");
-    }
-    return String(err);
-  }
   function reportCanvasLiveReloadError(err) {
     if (liveReloadErrorReported) return;
     liveReloadErrorReported = true;
-    const message = describeError(err);
     try {
       console.error("OpenClaw canvas live reload unavailable:", err);
-    } catch {}
-    try {
-      document.documentElement?.setAttribute("data-openclaw-live-reload", "error");
-      document.documentElement?.setAttribute("data-openclaw-live-reload-error", message);
-    } catch {}
-    try {
-      globalThis.dispatchEvent?.(
-        new CustomEvent(CANVAS_LIVE_RELOAD_ERROR_EVENT, {
-          detail: { message },
-        }),
-      );
     } catch {}
   }
   function postToNode(payload) {
@@ -111,7 +79,8 @@ export function injectCanvasLiveReload(html: string): string {
       reportCanvasLiveReloadError(ev);
     };
     ws.onclose = (ev) => {
-      reportCanvasLiveReloadError(ev);
+      // Normal and page-going-away closes are expected; surface every failure code.
+      if (ev.code !== 1000 && ev.code !== 1001) reportCanvasLiveReloadError(ev);
     };
   } catch (err) {
     reportCanvasLiveReloadError(err);

--- a/extensions/canvas/src/host/a2ui-shared.ts
+++ b/extensions/canvas/src/host/a2ui-shared.ts
@@ -22,11 +22,51 @@ export function injectCanvasLiveReload(html: string): string {
   const snippet = `
 <script>
 (() => {
+  const CANVAS_LIVE_RELOAD_ERROR_EVENT = "openclaw:canvas-live-reload-error";
+
   // Cross-platform action bridge helper.
   // Works on:
   // - iOS: window.webkit.messageHandlers.openclawCanvasA2UIAction.postMessage(...)
   // - Android: window.openclawCanvasA2UIAction.postMessage(...)
   const handlerNames = ["openclawCanvasA2UIAction"];
+  let liveReloadErrorReported = false;
+  function describeError(err) {
+    if (
+      err &&
+      typeof err === "object" &&
+      "message" in err &&
+      typeof err.message === "string" &&
+      err.message
+    ) {
+      return err.message;
+    }
+    if (err && typeof err === "object") {
+      const parts = ["WebSocket connection failed"];
+      if ("code" in err && err.code) parts.push("code=" + String(err.code));
+      if ("reason" in err && err.reason) parts.push(String(err.reason));
+      return parts.join(": ");
+    }
+    return String(err);
+  }
+  function reportCanvasLiveReloadError(err) {
+    if (liveReloadErrorReported) return;
+    liveReloadErrorReported = true;
+    const message = describeError(err);
+    try {
+      console.error("OpenClaw canvas live reload unavailable:", err);
+    } catch {}
+    try {
+      document.documentElement?.setAttribute("data-openclaw-live-reload", "error");
+      document.documentElement?.setAttribute("data-openclaw-live-reload-error", message);
+    } catch {}
+    try {
+      globalThis.dispatchEvent?.(
+        new CustomEvent(CANVAS_LIVE_RELOAD_ERROR_EVENT, {
+          detail: { message },
+        }),
+      );
+    } catch {}
+  }
   function postToNode(payload) {
     try {
       const raw = typeof payload === "string" ? payload : JSON.stringify(payload);
@@ -67,7 +107,15 @@ export function injectCanvasLiveReload(html: string): string {
     ws.onmessage = (ev) => {
       if (String(ev.data || "") === "reload") location.reload();
     };
-  } catch {}
+    ws.onerror = (ev) => {
+      reportCanvasLiveReloadError(ev);
+    };
+    ws.onclose = (ev) => {
+      reportCanvasLiveReloadError(ev);
+    };
+  } catch (err) {
+    reportCanvasLiveReloadError(err);
+  }
 })();
 </script>
 `.trim();

--- a/extensions/canvas/src/host/a2ui-shared.ts
+++ b/extensions/canvas/src/host/a2ui-shared.ts
@@ -28,6 +28,8 @@ export function injectCanvasLiveReload(html: string): string {
   // - Android: window.openclawCanvasA2UIAction.postMessage(...)
   const handlerNames = ["openclawCanvasA2UIAction"];
   let liveReloadErrorReported = false;
+  let pageUnloading = false;
+  globalThis.addEventListener?.("pagehide", () => { pageUnloading = true; }, { once: true });
   function reportCanvasLiveReloadError(err) {
     if (liveReloadErrorReported) return;
     liveReloadErrorReported = true;
@@ -79,8 +81,9 @@ export function injectCanvasLiveReload(html: string): string {
       reportCanvasLiveReloadError(ev);
     };
     ws.onclose = (ev) => {
-      // Normal and page-going-away closes are expected; surface every failure code.
-      if (ev.code !== 1000 && ev.code !== 1001) reportCanvasLiveReloadError(ev);
+      if (ev.code !== 1000 && !(ev.code === 1001 && pageUnloading)) {
+        reportCanvasLiveReloadError(ev);
+      }
     };
   } catch (err) {
     reportCanvasLiveReloadError(err);

--- a/extensions/canvas/src/host/server.test.ts
+++ b/extensions/canvas/src/host/server.test.ts
@@ -126,6 +126,37 @@ function extractInjectedScript(html: string): string {
   return match[1];
 }
 
+type MockLiveReloadSocket = {
+  onclose?: (event: { code: number; reason: string }) => void;
+  onerror?: (event: Error) => void;
+  onmessage?: (event: { data?: string }) => void;
+};
+
+function runInjectedScript(WebSocket: (this: MockLiveReloadSocket) => void) {
+  const consoleError = vi.fn();
+  const runtime: Record<string, unknown> = {
+    URLSearchParams,
+    WebSocket,
+    console: { error: consoleError },
+    encodeURIComponent,
+    location: {
+      host: "control.example",
+      protocol: "https:",
+      reload: vi.fn(),
+      search: "",
+    },
+  };
+  runtime.window = runtime;
+  runtime.self = runtime;
+  runtime.globalThis = runtime;
+  vm.createContext(runtime);
+  vm.runInContext(
+    extractInjectedScript(injectCanvasLiveReload("<html><body>Hello</body></html>")),
+    runtime,
+  );
+  return consoleError;
+}
+
 describe("canvas host", () => {
   const quietRuntime = {
     ...defaultRuntime,
@@ -204,130 +235,52 @@ describe("canvas host", () => {
   });
 
   it("reports websocket initialization errors instead of swallowing them silently", () => {
-    const html = injectCanvasLiveReload("<html><body>Hello</body></html>");
-    const script = extractInjectedScript(html);
-    const consoleError = vi.fn();
-    const dispatchEvent = vi.fn();
-    const documentElementAttributes = new Map<string, string>();
-    const document = {
-      documentElement: {
-        setAttribute(name: string, value: string) {
-          documentElementAttributes.set(name, value);
-        },
-      },
-    };
     function ThrowingWebSocket(): never {
       throw new TypeError("constructor failed");
     }
-    class TestCustomEvent {
-      readonly type: string;
-      readonly detail: unknown;
-
-      constructor(type: string, init?: { detail?: unknown }) {
-        this.type = type;
-        this.detail = init?.detail;
-      }
-    }
-    const runtime: Record<string, unknown> = {
-      URLSearchParams,
-      WebSocket: ThrowingWebSocket,
-      CustomEvent: TestCustomEvent,
-      console: { error: consoleError },
-      document,
-      dispatchEvent,
-      encodeURIComponent,
-      location: {
-        host: "control.example",
-        protocol: "https:",
-        reload: vi.fn(),
-        search: "",
-      },
-    };
-    runtime.window = runtime;
-    runtime.self = runtime;
-    runtime.globalThis = runtime;
-
-    vm.createContext(runtime);
-    vm.runInContext(script, runtime);
+    const consoleError = runInjectedScript(ThrowingWebSocket);
 
     expect(consoleError).toHaveBeenCalledTimes(1);
-    expect(consoleError.mock.calls[0]?.[0]).toBe("OpenClaw canvas live reload unavailable:");
-    expect(documentElementAttributes.get("data-openclaw-live-reload")).toBe("error");
-    expect(documentElementAttributes.get("data-openclaw-live-reload-error")).toBe(
-      "constructor failed",
+    expect(consoleError).toHaveBeenCalledWith(
+      "OpenClaw canvas live reload unavailable:",
+      expect.objectContaining({ message: "constructor failed" }),
     );
-    expect(dispatchEvent).toHaveBeenCalledTimes(1);
-    expect(dispatchEvent.mock.calls[0]?.[0]).toMatchObject({
-      detail: { message: "constructor failed" },
-      type: "openclaw:canvas-live-reload-error",
-    });
   });
 
   it("reports asynchronous websocket connection errors once", () => {
-    const html = injectCanvasLiveReload("<html><body>Hello</body></html>");
-    const script = extractInjectedScript(html);
-    const consoleError = vi.fn();
-    const dispatchEvent = vi.fn();
-    const documentElementAttributes = new Map<string, string>();
-    const document = {
-      documentElement: {
-        setAttribute(name: string, value: string) {
-          documentElementAttributes.set(name, value);
-        },
-      },
-    };
-    type MockSocket = {
-      onclose?: (event: { code: number; reason: string }) => void;
-      onerror?: (event: Error) => void;
-      onmessage?: (event: { data?: string }) => void;
-    };
-    const sockets: MockSocket[] = [];
-    function CapturingWebSocket(this: MockSocket): void {
+    const sockets: MockLiveReloadSocket[] = [];
+    function CapturingWebSocket(this: MockLiveReloadSocket): void {
       sockets.push(this);
     }
-    class TestCustomEvent {
-      readonly type: string;
-      readonly detail: unknown;
-
-      constructor(type: string, init?: { detail?: unknown }) {
-        this.type = type;
-        this.detail = init?.detail;
-      }
-    }
-    const runtime: Record<string, unknown> = {
-      URLSearchParams,
-      WebSocket: CapturingWebSocket,
-      CustomEvent: TestCustomEvent,
-      console: { error: consoleError },
-      document,
-      dispatchEvent,
-      encodeURIComponent,
-      location: {
-        host: "control.example",
-        protocol: "https:",
-        reload: vi.fn(),
-        search: "",
-      },
-    };
-    runtime.window = runtime;
-    runtime.self = runtime;
-    runtime.globalThis = runtime;
-
-    vm.createContext(runtime);
-    vm.runInContext(script, runtime);
+    const consoleError = runInjectedScript(CapturingWebSocket);
 
     expect(sockets).toHaveLength(1);
     sockets[0]?.onerror?.(new Error("connect failed"));
     sockets[0]?.onclose?.({ code: 1006, reason: "abnormal closure" });
 
     expect(consoleError).toHaveBeenCalledTimes(1);
-    expect(documentElementAttributes.get("data-openclaw-live-reload")).toBe("error");
-    expect(documentElementAttributes.get("data-openclaw-live-reload-error")).toBe("connect failed");
-    expect(dispatchEvent).toHaveBeenCalledTimes(1);
-    expect(dispatchEvent.mock.calls[0]?.[0]).toMatchObject({
-      detail: { message: "connect failed" },
-      type: "openclaw:canvas-live-reload-error",
+  });
+
+  it("does not report a normal close after connecting", () => {
+    const sockets: MockLiveReloadSocket[] = [];
+    const consoleError = runInjectedScript(function (this: MockLiveReloadSocket) {
+      sockets.push(this);
     });
+
+    sockets[0]?.onclose?.({ code: 1001, reason: "page closed" });
+
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it("reports an abnormal close without a preceding error event", () => {
+    const sockets: MockLiveReloadSocket[] = [];
+    const consoleError = runInjectedScript(function (this: MockLiveReloadSocket) {
+      sockets.push(this);
+    });
+
+    sockets[0]?.onclose?.({ code: 1011, reason: "server error" });
+
+    expect(consoleError).toHaveBeenCalledTimes(1);
   });
 
   it("creates a default index.html when missing", async () => {

--- a/extensions/canvas/src/host/server.test.ts
+++ b/extensions/canvas/src/host/server.test.ts
@@ -134,9 +134,13 @@ type MockLiveReloadSocket = {
 
 function runInjectedScript(WebSocket: (this: MockLiveReloadSocket) => void) {
   const consoleError = vi.fn();
+  let pagehide: (() => void) | undefined;
   const runtime: Record<string, unknown> = {
     URLSearchParams,
     WebSocket,
+    addEventListener: (event: string, listener: () => void) => {
+      if (event === "pagehide") pagehide = listener;
+    },
     console: { error: consoleError },
     encodeURIComponent,
     location: {
@@ -154,7 +158,7 @@ function runInjectedScript(WebSocket: (this: MockLiveReloadSocket) => void) {
     extractInjectedScript(injectCanvasLiveReload("<html><body>Hello</body></html>")),
     runtime,
   );
-  return consoleError;
+  return { consoleError, pagehide: () => pagehide?.() };
 }
 
 describe("canvas host", () => {
@@ -238,7 +242,7 @@ describe("canvas host", () => {
     function ThrowingWebSocket(): never {
       throw new TypeError("constructor failed");
     }
-    const consoleError = runInjectedScript(ThrowingWebSocket);
+    const { consoleError } = runInjectedScript(ThrowingWebSocket);
 
     expect(consoleError).toHaveBeenCalledTimes(1);
     expect(consoleError).toHaveBeenCalledWith(
@@ -252,7 +256,7 @@ describe("canvas host", () => {
     function CapturingWebSocket(this: MockLiveReloadSocket): void {
       sockets.push(this);
     }
-    const consoleError = runInjectedScript(CapturingWebSocket);
+    const { consoleError } = runInjectedScript(CapturingWebSocket);
 
     expect(sockets).toHaveLength(1);
     sockets[0]?.onerror?.(new Error("connect failed"));
@@ -263,10 +267,11 @@ describe("canvas host", () => {
 
   it("does not report a normal close after connecting", () => {
     const sockets: MockLiveReloadSocket[] = [];
-    const consoleError = runInjectedScript(function (this: MockLiveReloadSocket) {
+    const { consoleError, pagehide } = runInjectedScript(function (this: MockLiveReloadSocket) {
       sockets.push(this);
     });
 
+    pagehide();
     sockets[0]?.onclose?.({ code: 1001, reason: "page closed" });
 
     expect(consoleError).not.toHaveBeenCalled();
@@ -274,7 +279,7 @@ describe("canvas host", () => {
 
   it("reports an abnormal close without a preceding error event", () => {
     const sockets: MockLiveReloadSocket[] = [];
-    const consoleError = runInjectedScript(function (this: MockLiveReloadSocket) {
+    const { consoleError } = runInjectedScript(function (this: MockLiveReloadSocket) {
       sockets.push(this);
     });
 

--- a/extensions/canvas/src/host/server.test.ts
+++ b/extensions/canvas/src/host/server.test.ts
@@ -4,6 +4,7 @@ import type { IncomingMessage } from "node:http";
 import os from "node:os";
 import path from "node:path";
 import type { Duplex } from "node:stream";
+import vm from "node:vm";
 import { defaultRuntime } from "openclaw/plugin-sdk/runtime-env";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -117,6 +118,14 @@ async function captureA2uiFixtureResponse(
   return await captureHttpResponse(createA2uiHttpRequestHandler({ rootDir }), url, method);
 }
 
+function extractInjectedScript(html: string): string {
+  const match = html.match(/<script>([\s\S]+)<\/script>/);
+  if (!match?.[1]) {
+    throw new Error("expected injected canvas live reload script");
+  }
+  return match[1];
+}
+
 describe("canvas host", () => {
   const quietRuntime = {
     ...defaultRuntime,
@@ -192,6 +201,133 @@ describe("canvas host", () => {
     expect(out).toContain("location.reload");
     expect(out).toContain("openclawCanvasA2UIAction");
     expect(out).toContain("openclawSendUserAction");
+  });
+
+  it("reports websocket initialization errors instead of swallowing them silently", () => {
+    const html = injectCanvasLiveReload("<html><body>Hello</body></html>");
+    const script = extractInjectedScript(html);
+    const consoleError = vi.fn();
+    const dispatchEvent = vi.fn();
+    const documentElementAttributes = new Map<string, string>();
+    const document = {
+      documentElement: {
+        setAttribute(name: string, value: string) {
+          documentElementAttributes.set(name, value);
+        },
+      },
+    };
+    function ThrowingWebSocket(): never {
+      throw new TypeError("constructor failed");
+    }
+    class TestCustomEvent {
+      readonly type: string;
+      readonly detail: unknown;
+
+      constructor(type: string, init?: { detail?: unknown }) {
+        this.type = type;
+        this.detail = init?.detail;
+      }
+    }
+    const runtime: Record<string, unknown> = {
+      URLSearchParams,
+      WebSocket: ThrowingWebSocket,
+      CustomEvent: TestCustomEvent,
+      console: { error: consoleError },
+      document,
+      dispatchEvent,
+      encodeURIComponent,
+      location: {
+        host: "control.example",
+        protocol: "https:",
+        reload: vi.fn(),
+        search: "",
+      },
+    };
+    runtime.window = runtime;
+    runtime.self = runtime;
+    runtime.globalThis = runtime;
+
+    vm.createContext(runtime);
+    vm.runInContext(script, runtime);
+
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(consoleError.mock.calls[0]?.[0]).toBe("OpenClaw canvas live reload unavailable:");
+    expect(documentElementAttributes.get("data-openclaw-live-reload")).toBe("error");
+    expect(documentElementAttributes.get("data-openclaw-live-reload-error")).toBe(
+      "constructor failed",
+    );
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0]?.[0]).toMatchObject({
+      detail: { message: "constructor failed" },
+      type: "openclaw:canvas-live-reload-error",
+    });
+  });
+
+  it("reports asynchronous websocket connection errors once", () => {
+    const html = injectCanvasLiveReload("<html><body>Hello</body></html>");
+    const script = extractInjectedScript(html);
+    const consoleError = vi.fn();
+    const dispatchEvent = vi.fn();
+    const documentElementAttributes = new Map<string, string>();
+    const document = {
+      documentElement: {
+        setAttribute(name: string, value: string) {
+          documentElementAttributes.set(name, value);
+        },
+      },
+    };
+    type MockSocket = {
+      onclose?: (event: { code: number; reason: string }) => void;
+      onerror?: (event: Error) => void;
+      onmessage?: (event: { data?: string }) => void;
+    };
+    const sockets: MockSocket[] = [];
+    function CapturingWebSocket(this: MockSocket): void {
+      sockets.push(this);
+    }
+    class TestCustomEvent {
+      readonly type: string;
+      readonly detail: unknown;
+
+      constructor(type: string, init?: { detail?: unknown }) {
+        this.type = type;
+        this.detail = init?.detail;
+      }
+    }
+    const runtime: Record<string, unknown> = {
+      URLSearchParams,
+      WebSocket: CapturingWebSocket,
+      CustomEvent: TestCustomEvent,
+      console: { error: consoleError },
+      document,
+      dispatchEvent,
+      encodeURIComponent,
+      location: {
+        host: "control.example",
+        protocol: "https:",
+        reload: vi.fn(),
+        search: "",
+      },
+    };
+    runtime.window = runtime;
+    runtime.self = runtime;
+    runtime.globalThis = runtime;
+
+    vm.createContext(runtime);
+    vm.runInContext(script, runtime);
+
+    expect(sockets).toHaveLength(1);
+    sockets[0]?.onerror?.(new Error("connect failed"));
+    sockets[0]?.onclose?.({ code: 1006, reason: "abnormal closure" });
+
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(documentElementAttributes.get("data-openclaw-live-reload")).toBe("error");
+    expect(documentElementAttributes.get("data-openclaw-live-reload-error")).toBe("connect failed");
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0]?.[0]).toMatchObject({
+      detail: { message: "connect failed" },
+      type: "openclaw:canvas-live-reload-error",
+    });
   });
 
   it("creates a default index.html when missing", async () => {

--- a/extensions/canvas/src/host/server.test.ts
+++ b/extensions/canvas/src/host/server.test.ts
@@ -139,7 +139,9 @@ function runInjectedScript(WebSocket: (this: MockLiveReloadSocket) => void) {
     URLSearchParams,
     WebSocket,
     addEventListener: (event: string, listener: () => void) => {
-      if (event === "pagehide") pagehide = listener;
+      if (event === "pagehide") {
+        pagehide = listener;
+      }
     },
     console: { error: consoleError },
     encodeURIComponent,


### PR DESCRIPTION
Closes #82504

## What Problem This Solves

Canvas injects a small WebSocket client into served pages for live reload. Constructor failures, network errors, and unexpected socket closes were swallowed, so live reload could stop with no operator-visible clue.

## Why This Change Was Made

The injected page now emits one deduplicated browser-console diagnostic for:

- synchronous WebSocket construction failure;
- asynchronous socket error;
- any non-normal close while the page remains active.

Code 1001 is suppressed only after a real `pagehide` event, distinguishing page teardown from a server restart. The earlier PR version’s DOM attributes and custom global event were removed: no consumer existed, and they expanded the page contract without improving operator diagnostics.

No VNC is involved. The relevant surface is the Canvas page’s browser console.

## User Impact

- Broken Canvas live reload becomes diagnosable in browser developer tools.
- Normal close and navigation teardown stay quiet.
- Page DOM, action bridge, reload behavior, and network policy remain unchanged.

## Evidence

- Blacksmith Testbox: `extensions/canvas/src/host/server.test.ts`, 9/9 passed: https://github.com/openclaw/openclaw/actions/runs/29186530221
- Fresh full-stack autoreview: clean, 0.92 confidence.
- Exact current diff: 21 production insertions / 1 deletion; the original PR proposed 49 production insertions / 1 deletion.
- Canonical formatting and `git diff --check`: passed.

Real Gateway plus browser-agent console proof remains the final pre-merge gate.

This PR is AI-assisted. Original report and patch by @coygeek; maintainer refactor preserves contributor credit.
