### PR TITLE
fix(proxy): add clientSocket error handler and use destroy() in CONNECT tunnel

### DIFF
--- a/src/proxy-capture/proxy-server.ts
+++ b/src/proxy-capture/proxy-server.ts
@@ -209,7 +209,23 @@ export async function startDebugProxyServer(params: {
         path: req.url ?? "",
         errorText: error.message,
       });
-      clientSocket.end();
+      clientSocket.destroy();
+    });
+    clientSocket.on("error", (error) => {
+      store.recordEvent({
+        sessionId: params.settings.sessionId,
+        ts: Date.now(),
+        sourceScope: "openclaw",
+        sourceProcess: params.settings.sourceProcess,
+        protocol: "connect",
+        direction: "local",
+        kind: "error",
+        flowId,
+        host: hostname,
+        path: req.url ?? "",
+        errorText: error.message,
+      });
+      upstreamSocket.destroy();
     });
   });
 


### PR DESCRIPTION
## Problem

The CONNECT tunnel handler in `src/proxy-capture/proxy-server.ts` pipes `clientSocket` and `upstreamSocket` together but only registered an `error` event handler on the upstream socket.

When a client disconnects abruptly (e.g. ECONNRESET, broken pipe), the `clientSocket` emits an `error` event with no handler registered. Node.js treats unhandled socket errors as uncaught exceptions, which crashes the proxy server process.

Fixes #82442

## Changes

**1. Add `clientSocket.on('error', ...)` handler**
Symmetric with the upstream socket handler — logs the disconnect event to the capture store and calls `upstreamSocket.destroy()` to clean up the other end of the pipe.

**2. Change `clientSocket.end()` → `clientSocket.destroy()` in the upstream error handler**
`end()` only sends a FIN and waits for the remote end to acknowledge — it leaves the socket half-open and does not abort in-progress reads. `destroy()` immediately closes the socket and is the correct call for error cleanup on piped sockets.

## Before / After

```typescript
// Before: only upstream gets an error handler
upstreamSocket.on("error", (error) => {
  // ... log ...
  clientSocket.end();  // ← wrong: FIN only, not full cleanup
});
// clientSocket has no error handler → crash on ECONNRESET

// After: both sockets handled symmetrically
upstreamSocket.on("error", (error) => {
  // ... log ...
  clientSocket.destroy();  // ← correct: immediate full cleanup
});
clientSocket.on("error", (error) => {
  // ... log ...
  upstreamSocket.destroy();  // ← new: symmetric cleanup
});
```

## Testing

Existing `parseConnectTarget` unit tests pass (`vitest run src/proxy-capture/proxy-server.test.ts`). Manual repro: start proxy with `OPENCLAW_DEBUG_PROXY_ENABLED=1`, initiate a CONNECT tunnel, `kill -9` the client process — before this fix the proxy crashes; after, it logs the error and continues.