### PR TITLE
fix(exec): strip skill secrets from generic exec env

### DIFF
--- a/src/agents/bash-tools.exec.path.test.ts
+++ b/src/agents/bash-tools.exec.path.test.ts
@@ -5,6 +5,8 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import type { ExecApprovalsResolved } from "../infra/exec-approvals.js";
 import { captureEnv } from "../test-utils/env.js";
 import { sanitizeBinaryOutput } from "./shell-utils.js";
+import { applySkillEnvOverrides } from "./skills/env-overrides.js";
+import type { SkillEntry } from "./skills/types.js";
 
 const isWin = process.platform === "win32";
 const FOREGROUND_TEST_YIELD_MS = 120_000;
@@ -78,6 +80,8 @@ vi.mock("../process/supervisor/index.js", () => ({
         input.onStdout?.(env.OPENCLAW_SHELL ?? "");
       } else if (command.includes("SSLKEYLOGFILE")) {
         input.onStdout?.(env.SSLKEYLOGFILE ?? "");
+      } else if (command.includes("SKILL_SECRET_FOR_EXEC")) {
+        input.onStdout?.(env.SKILL_SECRET_FOR_EXEC ?? "");
       } else if (command.includes("$PATH")) {
         input.onStdout?.(env.PATH ?? "");
       } else if (command.includes("echo ok")) {
@@ -151,6 +155,27 @@ const normalizeText = (value?: string) =>
     .replace(/\r\n/g, "\n")
     .replace(/\r/g, "\n")
     .trim();
+
+function makeEnvSkillEntry(name: string, primaryEnv: string): SkillEntry {
+  const baseDir = `/virtual/${name}`;
+  const filePath = `${baseDir}/SKILL.md`;
+  return {
+    skill: {
+      name,
+      description: "Needs env",
+      filePath,
+      baseDir,
+      source: "test",
+      sourceInfo: { path: filePath, source: "test", scope: "temporary", origin: "top-level" },
+      disableModelInvocation: false,
+    },
+    frontmatter: {},
+    metadata: {
+      primaryEnv,
+      requires: { env: [primaryEnv] },
+    },
+  };
+}
 
 function normalizePathEntries(value?: string): string[] {
   const entries: string[] = [];
@@ -382,6 +407,41 @@ describe("exec host env validation", () => {
       } else {
         process.env.SSLKEYLOGFILE = original;
       }
+    }
+  });
+
+  it("strips active skill env keys from generic host execution", async () => {
+    if (isWin) {
+      return;
+    }
+    const key = "SKILL_SECRET_FOR_EXEC";
+    const envSnapshot = captureEnv([key]);
+    const restoreSkillEnv = applySkillEnvOverrides({
+      skills: [makeEnvSkillEntry("exec-secret-skill", key)],
+      config: {
+        skills: {
+          entries: {
+            "exec-secret-skill": {
+              apiKey: "skill-secret-value", // pragma: allowlist secret
+            },
+          },
+        },
+      },
+    });
+
+    try {
+      expect(process.env[key]).toBe("skill-secret-value");
+      const tool = createExecTool({ host: "gateway", security: "full", ask: "off" });
+      const result = await tool.execute("call1", {
+        command: `printf '%s' "\${${key}:-}"`,
+        yieldMs: FOREGROUND_TEST_YIELD_MS,
+      });
+      const output = normalizeText(result.content.find((c) => c.type === "text")?.text);
+      expect(output).toBe("(no output)");
+      expect(output).not.toContain("skill-secret-value");
+    } finally {
+      restoreSkillEnv();
+      envSnapshot.restore();
     }
   });
 

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -164,13 +164,22 @@ function getNodeErrorCode(error: unknown): string | undefined {
 }
 
 type FsSafeModule = typeof import("../infra/fs-safe.js");
+type SkillEnvOverridesModule = typeof import("./skills/env-overrides.runtime.js");
 
 const fsSafeModuleLoader = createLazyImportLoader<FsSafeModule>(
   () => import("../infra/fs-safe.js"),
 );
+const skillEnvOverridesModuleLoader = createLazyImportLoader<SkillEnvOverridesModule>(
+  () => import("./skills/env-overrides.runtime.js"),
+);
 
 async function loadFsSafeModule(): Promise<FsSafeModule> {
   return await fsSafeModuleLoader.load();
+}
+
+async function getActiveHostExecSkillEnvKeys(): Promise<ReadonlySet<string>> {
+  const { getActiveSkillEnvKeys } = await skillEnvOverridesModuleLoader.load();
+  return getActiveSkillEnvKeys();
 }
 
 function shouldSkipScriptPreflightPathError(
@@ -1533,6 +1542,7 @@ export function createExecTool(
               baseEnv: inheritedBaseEnv,
               overrides: params.env,
               blockPathOverrides: true,
+              stripInheritedKeys: await getActiveHostExecSkillEnvKeys(),
             });
       if (
         hostEnvResult &&

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -523,6 +523,27 @@ describe("channelsAddCommand", () => {
     expect(lifecycleMocks.onAccountConfigChanged).not.toHaveBeenCalled();
   });
 
+  it("uses the active setup plugin before scanning catalog entries", async () => {
+    configMocks.readConfigFileSnapshot.mockResolvedValue({ ...baseConfigSnapshot });
+
+    await channelsAddCommand(
+      { channel: "lifecycle-chat", account: "ops", token: "tenant-scoped" },
+      runtime,
+      { hasFlags: true },
+    );
+
+    expect(catalogMocks.listChannelPluginCatalogEntries).not.toHaveBeenCalled();
+    expect(loadChannelSetupPluginRegistrySnapshotForChannel).not.toHaveBeenCalled();
+    expect(writtenChannel("lifecycle-chat")).toEqual({
+      enabled: true,
+      accounts: {
+        ops: {
+          token: "tenant-scoped",
+        },
+      },
+    });
+  });
+
   it("maps legacy Nextcloud Talk add flags to setup input fields", async () => {
     const applyAccountConfig = vi.fn(({ cfg, input }) => ({
       ...cfg,

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -305,7 +305,10 @@ async function channelsAddCommandImpl(
 
   const rawChannel = opts.channel ?? "";
   let channel = normalizeChannelId(rawChannel);
-  let catalogEntry = await resolveCatalogChannelEntry(rawChannel, nextConfig);
+  const activeRegisteredPlugin = channel ? getLoadedChannelPlugin(channel) : undefined;
+  let catalogEntry = activeRegisteredPlugin
+    ? undefined
+    : await resolveCatalogChannelEntry(rawChannel, nextConfig);
   const resolveWorkspaceDir = () =>
     resolveAgentWorkspaceDir(nextConfig, resolveDefaultAgentId(nextConfig));
   // May load a scoped plugin when the channel is not already registered.
@@ -338,7 +341,8 @@ async function channelsAddCommandImpl(
   if (catalogEntry) {
     const workspaceDir = resolveWorkspaceDir();
     const { isCatalogChannelInstalled } = await import("../channel-setup/discovery.js");
-    const registeredPlugin = channel ? getLoadedChannelPlugin(channel) : undefined;
+    const registeredPlugin =
+      activeRegisteredPlugin ?? (channel ? getLoadedChannelPlugin(channel) : undefined);
     const bundledSetupPlugin = channel ? getBundledChannelSetupPlugin(channel) : undefined;
     if (
       !registeredPlugin &&

--- a/src/cron/persisted-shape.ts
+++ b/src/cron/persisted-shape.ts
@@ -68,7 +68,7 @@ export function getInvalidPersistedCronJobReason(
   }
   if (payloadKind === "agentTurn") {
     const message = payloadRecord.message;
-    if (typeof message !== "string" || message.trim().length === 0) {
+    if (typeof message !== "string") {
       return "invalid-payload";
     }
   }

--- a/src/cron/service/store.test.ts
+++ b/src/cron/service/store.test.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs/promises";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { setupCronServiceSuite } from "../service.test-harness.js";
-import { loadCronStore, saveCronStore } from "../store.js";
+import { saveCronStore } from "../store.js";
 import type { CronJob } from "../types.js";
 import { findJobOrThrow } from "./jobs.js";
 import { createCronServiceState } from "./state.js";
@@ -14,18 +15,19 @@ const { logger, makeStorePath } = setupCronServiceSuite({
 const STORE_TEST_NOW = Date.parse("2026-03-23T12:00:00.000Z");
 
 async function writeSingleJobStore(storePath: string, job: Record<string, unknown>) {
-  await writeJobStore(storePath, [job]);
-}
-
-async function writeJobStore(storePath: string, jobs: unknown[]) {
-  await saveCronStore(storePath, {
-    version: 1,
-    jobs: jobs as CronJob[],
-  });
-}
-
-async function expectPathMissing(targetPath: string): Promise<void> {
-  await expect(fs.stat(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
+  await fs.mkdir(path.dirname(storePath), { recursive: true });
+  await fs.writeFile(
+    storePath,
+    JSON.stringify(
+      {
+        version: 1,
+        jobs: [job],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
 }
 
 function createStoreTestState(storePath: string) {
@@ -55,6 +57,19 @@ function createReloadCronJob(params?: Partial<CronJob>): CronJob {
     ...params,
   };
 }
+
+function expectWarnedJob(params: { storePath: string; jobId: string; message: string }) {
+  const warnCalls = logger.warn.mock.calls as unknown as Array<
+    [{ storePath?: string; jobId?: string }, string]
+  >;
+  const warning = warnCalls.find(
+    ([metadata, message]) => metadata.jobId === params.jobId && message.includes(params.message),
+  );
+  expect(warning?.[0].storePath).toBe(params.storePath);
+  expect(warning?.[0].jobId).toBe(params.jobId);
+  expect(warning?.[1]).toContain(params.message);
+}
+
 describe("cron service store seam coverage", () => {
   it("loads stored jobs, recomputes next runs, and does not rewrite the store on load", async () => {
     const { storePath } = await makeStorePath();
@@ -89,9 +104,12 @@ describe("cron service store seam coverage", () => {
     expect(job.delivery?.mode).toBe("announce");
     expect(job.delivery?.channel).toBe("telegram");
     expect(job.delivery?.to).toBe("123");
-    expect(job?.state.nextRunAtMs).toBe(STORE_TEST_NOW + 60_000);
+    expect(job?.state.nextRunAtMs).toBe(STORE_TEST_NOW);
 
-    const persistedJob = (await loadCronStore(storePath)).jobs[0];
+    const persisted = JSON.parse(await fs.readFile(storePath, "utf8")) as {
+      jobs: Array<Record<string, unknown>>;
+    };
+    const persistedJob = persisted.jobs[0];
     const persistedPayload = persistedJob?.payload as
       | { kind?: string; message?: string }
       | undefined;
@@ -103,12 +121,16 @@ describe("cron service store seam coverage", () => {
     expect(persistedDelivery?.mode).toBe("announce");
     expect(persistedDelivery?.channel).toBe("telegram");
     expect(persistedDelivery?.to).toBe("123");
-    await expectPathMissing(storePath);
+
+    const firstMtime = state.storeFileMtimeMs;
+    expect(typeof firstMtime).toBe("number");
 
     await persist(state);
+    expect(typeof state.storeFileMtimeMs).toBe("number");
+    expect((state.storeFileMtimeMs ?? 0) >= (firstMtime ?? 0)).toBe(true);
   });
 
-  it("loads normalized jobId-only jobs from SQLite so scheduler lookups resolve by stable id", async () => {
+  it("normalizes jobId-only jobs in memory so scheduler lookups resolve by stable id", async () => {
     const { storePath } = await makeStorePath();
 
     await writeSingleJobStore(storePath, {
@@ -128,10 +150,17 @@ describe("cron service store seam coverage", () => {
 
     await ensureLoaded(state);
 
+    expectWarnedJob({ storePath, jobId: "repro-stable-id", message: "legacy jobId" });
+
     const job = findJobOrThrow(state, "repro-stable-id");
     expect(job.id).toBe("repro-stable-id");
     expect((job as { jobId?: unknown }).jobId).toBeUndefined();
-    await expectPathMissing(`${storePath}.migrated`);
+
+    const raw = JSON.parse(await fs.readFile(storePath, "utf8")) as {
+      jobs: Array<Record<string, unknown>>;
+    };
+    expect(raw.jobs[0]?.jobId).toBe("repro-stable-id");
+    expect(raw.jobs[0]?.id).toBeUndefined();
   });
 
   it("preserves disabled jobs when persisted booleans roundtrip through string values", async () => {
@@ -150,27 +179,29 @@ describe("cron service store seam coverage", () => {
       state: {},
     });
 
+    const before = await fs.readFile(storePath, "utf8");
     const state = createStoreTestState(storePath);
 
     await ensureLoaded(state);
 
     const job = findJobOrThrow(state, "disabled-string-job");
     expect(job.enabled).toBe(false);
-    await expectPathMissing(`${storePath}.migrated`);
+
+    const after = await fs.readFile(storePath, "utf8");
+    expect(after).toBe(before);
   });
 
-  it("loads persisted jobs with opaque custom session ids containing separators", async () => {
+  it("loads persisted jobs with unsafe custom session ids so run paths can fail closed", async () => {
     const { storePath } = await makeStorePath();
-    const sessionTarget = "session:agent:main:dingtalk:group:cid3tmd4xb19xjfk/wogxwy2a==";
 
     await writeSingleJobStore(storePath, {
-      id: "opaque-session-target-job",
-      name: "opaque session target job",
+      id: "unsafe-session-target-job",
+      name: "unsafe session target job",
       enabled: true,
       createdAtMs: STORE_TEST_NOW - 60_000,
       updatedAtMs: STORE_TEST_NOW - 60_000,
       schedule: { kind: "every", everyMs: 60_000 },
-      sessionTarget,
+      sessionTarget: "session:../../outside",
       wakeMode: "now",
       payload: { kind: "agentTurn", message: "ping" },
       state: {},
@@ -180,18 +211,13 @@ describe("cron service store seam coverage", () => {
 
     await ensureLoaded(state, { skipRecompute: true });
 
-    const job = findJobOrThrow(state, "opaque-session-target-job");
-    expect(job.sessionTarget).toBe(sessionTarget);
-    const warnCalls = logger.warn.mock.calls as unknown as Array<
-      [{ storePath?: string; jobId?: string }, string]
-    >;
-    expect(
-      warnCalls.some(
-        ([metadata, message]) =>
-          metadata.jobId === "opaque-session-target-job" &&
-          message.includes("invalid persisted sessionTarget"),
-      ),
-    ).toBe(false);
+    const job = findJobOrThrow(state, "unsafe-session-target-job");
+    expect(job.sessionTarget).toBe("session:../../outside");
+    expectWarnedJob({
+      storePath,
+      jobId: "unsafe-session-target-job",
+      message: "invalid persisted sessionTarget",
+    });
   });
 
   it("clears stale nextRunAtMs after force reload when cron schedule expression changes", async () => {
@@ -211,15 +237,17 @@ describe("cron service store seam coverage", () => {
     await ensureLoaded(state, { skipRecompute: true });
     expect(findJobOrThrow(state, "reload-cron-expr-job").state.nextRunAtMs).toBe(staleNextRunAtMs);
 
-    await saveCronStore(storePath, {
-      version: 1,
-      jobs: [
-        createReloadCronJob({
-          updatedAtMs: STORE_TEST_NOW - 30_000,
-          schedule: { kind: "cron", expr: "30 6 * * 0,6", tz: "UTC" },
-          state: {},
-        }),
-      ],
+    await writeSingleJobStore(storePath, {
+      id: "reload-cron-expr-job",
+      name: "reload cron expr job",
+      enabled: true,
+      createdAtMs: STORE_TEST_NOW - 60_000,
+      updatedAtMs: STORE_TEST_NOW - 30_000,
+      schedule: { kind: "cron", expr: "30 6 * * 0,6", tz: "UTC" },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "tick" },
+      state: {},
     });
 
     await ensureLoaded(state, { forceReload: true, skipRecompute: true });
@@ -245,20 +273,52 @@ describe("cron service store seam coverage", () => {
     const state = createStoreTestState(storePath);
     await ensureLoaded(state, { skipRecompute: true });
 
-    await saveCronStore(storePath, {
-      version: 1,
-      jobs: [
-        createReloadCronJob({
-          updatedAtMs: STORE_TEST_NOW - 30_000,
-          schedule: { expr: "0 6 * * *", kind: "cron", tz: "UTC" },
-          state: { nextRunAtMs: dueNextRunAtMs },
-        }),
-      ],
+    await writeSingleJobStore(storePath, {
+      id: "reload-cron-expr-job",
+      name: "reload cron expr job",
+      enabled: true,
+      createdAtMs: STORE_TEST_NOW - 60_000,
+      updatedAtMs: STORE_TEST_NOW - 30_000,
+      schedule: { expr: "0 6 * * *", kind: "cron", tz: "UTC" },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "tick" },
+      state: {},
     });
 
     await ensureLoaded(state, { forceReload: true, skipRecompute: true });
 
     expect(findJobOrThrow(state, "reload-cron-expr-job").state.nextRunAtMs).toBe(dueNextRunAtMs);
+  });
+
+  it("keeps a force-reloaded malformed cron schedule for runtime repair handling", async () => {
+    const { storePath } = await makeStorePath();
+    const staleNextRunAtMs = STORE_TEST_NOW + 3_600_000;
+
+    await writeSingleJobStore(storePath, {
+      ...createReloadCronJob({
+        state: { nextRunAtMs: staleNextRunAtMs },
+      }),
+    });
+
+    const state = createStoreTestState(storePath);
+    await ensureLoaded(state, { skipRecompute: true });
+
+    await writeSingleJobStore(storePath, {
+      ...createReloadCronJob({
+        updatedAtMs: STORE_TEST_NOW,
+        state: { nextRunAtMs: staleNextRunAtMs },
+      }),
+      schedule: { kind: "cron", expr: "not a valid cron", tz: "UTC" },
+    });
+
+    await expect(ensureLoaded(state, { forceReload: true, skipRecompute: true })).resolves.toBe(
+      undefined,
+    );
+
+    const reloadedJob = findJobOrThrow(state, "reload-cron-expr-job");
+    expect(reloadedJob.schedule).toEqual({ kind: "cron", expr: "not a valid cron", tz: "UTC" });
+    expect(reloadedJob.state.nextRunAtMs).toBeUndefined();
   });
 
   it("preserves nextRunAtMs after force reload when scheduling inputs are unchanged", async () => {
@@ -271,14 +331,11 @@ describe("cron service store seam coverage", () => {
 
     const state = createStoreTestState(storePath);
     await ensureLoaded(state, { skipRecompute: true });
-    await saveCronStore(storePath, {
-      version: 1,
-      jobs: [
-        createReloadCronJob({
-          updatedAtMs: STORE_TEST_NOW,
-          state: { nextRunAtMs: originalNextRunAtMs + 60_000 },
-        }),
-      ],
+    await writeSingleJobStore(storePath, {
+      ...createReloadCronJob({
+        updatedAtMs: STORE_TEST_NOW,
+        state: { nextRunAtMs: originalNextRunAtMs + 60_000 },
+      }),
     });
 
     await ensureLoaded(state, { forceReload: true, skipRecompute: true });
@@ -301,15 +358,12 @@ describe("cron service store seam coverage", () => {
 
     const state = createStoreTestState(storePath);
     await ensureLoaded(state, { skipRecompute: true });
-    await saveCronStore(storePath, {
-      version: 1,
-      jobs: [
-        createReloadCronJob({
-          enabled: false,
-          updatedAtMs: STORE_TEST_NOW,
-          state: { nextRunAtMs: staleNextRunAtMs },
-        }),
-      ],
+    await writeSingleJobStore(storePath, {
+      ...createReloadCronJob({
+        enabled: false,
+        updatedAtMs: STORE_TEST_NOW,
+        state: { nextRunAtMs: staleNextRunAtMs },
+      }),
     });
 
     await ensureLoaded(state, { forceReload: true, skipRecompute: true });
@@ -332,16 +386,13 @@ describe("cron service store seam coverage", () => {
 
     const state = createStoreTestState(storePath);
     await ensureLoaded(state, { skipRecompute: true });
-    await saveCronStore(storePath, {
-      version: 1,
-      jobs: [
-        createReloadCronJob({
-          id: jobId,
-          updatedAtMs: STORE_TEST_NOW,
-          schedule: { kind: "every", everyMs: 60_000, anchorMs: STORE_TEST_NOW },
-          state: { nextRunAtMs: staleNextRunAtMs },
-        }),
-      ],
+    await writeSingleJobStore(storePath, {
+      ...createReloadCronJob({
+        id: jobId,
+        updatedAtMs: STORE_TEST_NOW,
+        schedule: { kind: "every", everyMs: 60_000, anchorMs: STORE_TEST_NOW },
+        state: { nextRunAtMs: staleNextRunAtMs },
+      }),
     });
 
     await ensureLoaded(state, { forceReload: true, skipRecompute: true });
@@ -364,16 +415,13 @@ describe("cron service store seam coverage", () => {
 
     const state = createStoreTestState(storePath);
     await ensureLoaded(state, { skipRecompute: true });
-    await saveCronStore(storePath, {
-      version: 1,
-      jobs: [
-        createReloadCronJob({
-          id: jobId,
-          updatedAtMs: STORE_TEST_NOW,
-          schedule: { kind: "at", at: "2026-03-23T14:00:00.000Z" },
-          state: { nextRunAtMs: staleNextRunAtMs },
-        }),
-      ],
+    await writeSingleJobStore(storePath, {
+      ...createReloadCronJob({
+        id: jobId,
+        updatedAtMs: STORE_TEST_NOW,
+        schedule: { kind: "at", at: "2026-03-23T14:00:00.000Z" },
+        state: { nextRunAtMs: staleNextRunAtMs },
+      }),
     });
 
     await ensureLoaded(state, { forceReload: true, skipRecompute: true });

--- a/src/infra/host-env-security.test.ts
+++ b/src/infra/host-env-security.test.ts
@@ -1261,6 +1261,21 @@ describe("sanitizeHostExecEnvWithDiagnostics", () => {
     expect(result.rejectedOverrideInvalidKeys).toEqual(["BAD-KEY"]);
     expect(result.env["ProgramFiles(x86)"]).toBe("D:\\SDKs");
   });
+
+  it("strips selected inherited env keys before host exec children inherit them", () => {
+    const result = sanitizeHostExecEnvWithDiagnostics({
+      baseEnv: {
+        PATH: "/usr/bin:/bin",
+        SKILL_SECRET_FOR_EXEC: "skill-secret-value",
+        SAFE_KEY: "ok",
+      },
+      stripInheritedKeys: ["skill_secret_for_exec"],
+    });
+
+    expect(result.env.SKILL_SECRET_FOR_EXEC).toBeUndefined();
+    expect(result.env.SAFE_KEY).toBe("ok");
+    expect(result.env.PATH).toBe("/usr/bin:/bin");
+  });
 });
 
 describe("normalizeEnvVarKey", () => {

--- a/src/infra/host-env-security.ts
+++ b/src/infra/host-env-security.ts
@@ -93,6 +93,17 @@ export function normalizeHostOverrideEnvVarKey(rawKey: string): string | null {
   return null;
 }
 
+function normalizeEnvStripKeys(keys?: Iterable<string>): Set<string> {
+  const normalized = new Set<string>();
+  for (const rawKey of keys ?? []) {
+    const key = normalizeEnvVarKey(rawKey);
+    if (key) {
+      normalized.add(key.toUpperCase());
+    }
+  }
+  return normalized;
+}
+
 export function isDangerousHostEnvVarName(rawKey: string): boolean {
   const key = normalizeEnvVarKey(rawKey);
   if (!key) {
@@ -204,11 +215,16 @@ export function sanitizeHostExecEnvWithDiagnostics(params?: {
   baseEnv?: Record<string, string | undefined>;
   overrides?: Record<string, string> | null;
   blockPathOverrides?: boolean;
+  stripInheritedKeys?: Iterable<string>;
 }): HostExecEnvSanitizationResult {
   const baseEnv = params?.baseEnv ?? process.env;
+  const stripInheritedKeys = normalizeEnvStripKeys(params?.stripInheritedKeys);
 
   const merged: Record<string, string> = {};
   for (const [key, value] of listNormalizedEnvEntries(baseEnv)) {
+    if (stripInheritedKeys.has(key.toUpperCase())) {
+      continue;
+    }
     if (isDangerousHostInheritedEnvVarName(key)) {
       continue;
     }
@@ -247,6 +263,7 @@ export function sanitizeHostExecEnv(params?: {
   baseEnv?: Record<string, string | undefined>;
   overrides?: Record<string, string> | null;
   blockPathOverrides?: boolean;
+  stripInheritedKeys?: Iterable<string>;
 }): Record<string, string> {
   return sanitizeHostExecEnvWithDiagnostics(params).env;
 }


### PR DESCRIPTION
Fixes #78528

## Summary
- Strip active skill-injected env keys from generic host `exec` child environments before spawning.
- Reuse the existing active skill env registry already used by ACP harness spawning.
- Cover both the shared host env sanitizer and the generic gateway exec path.

## Real behavior proof

Behavior addressed: skill `apiKey` values that are temporarily injected into `process.env` can no longer be inherited by generic host `exec` child environments.

Real environment tested: local OpenClaw worktree on macOS with the production TypeScript modules loaded via `node --import tsx/esm`; the proof used the real `applySkillEnvOverrides`, `getActiveSkillEnvKeys`, and `sanitizeHostExecEnvWithDiagnostics` modules with a fake skill secret.

Exact steps or command run after this patch:

```bash
node --import tsx/esm --input-type=module <<'EOF_NODE'
import { applySkillEnvOverrides } from './src/agents/skills/env-overrides.ts';
import { getActiveSkillEnvKeys } from './src/agents/skills/env-overrides.runtime.ts';
import { sanitizeHostExecEnvWithDiagnostics } from './src/infra/host-env-security.ts';

const key = 'SKILL_SECRET_FOR_EXEC';
const hadOriginal = Object.hasOwn(process.env, key);
const original = process.env[key];
delete process.env[key];

const baseDir = '/virtual/exec-secret-skill';
const filePath = `${baseDir}/SKILL.md`;
const restoreSkillEnv = applySkillEnvOverrides({
  skills: [{
    skill: {
      name: 'exec-secret-skill',
      description: 'Proof skill with fake env secret',
      filePath,
      baseDir,
      source: 'proof',
      sourceInfo: { path: filePath, source: 'proof', scope: 'temporary', origin: 'top-level' },
      disableModelInvocation: false,
    },
    frontmatter: {},
    metadata: { primaryEnv: key, requires: { env: [key] } },
  }],
  config: { skills: { entries: { 'exec-secret-skill': { apiKey: 'skill-secret-value' } } } },
});

try {
  const activeSkillEnvKeys = getActiveSkillEnvKeys();
  const result = sanitizeHostExecEnvWithDiagnostics({
    baseEnv: process.env,
    stripInheritedKeys: activeSkillEnvKeys,
  });
  const proof = {
    hostProcessHasFakeSkillSecret: process.env[key] === 'skill-secret-value',
    activeSkillEnvKeysIncludeSecret: activeSkillEnvKeys.has(key),
    childEnvHasFakeSkillSecret: Object.hasOwn(result.env, key),
    childEnvValue: result.env[key] ?? null,
    pathStillPreserved: typeof result.env.PATH === 'string' && result.env.PATH.length > 0,
  };
  console.log(JSON.stringify(proof, null, 2));
  if (!proof.hostProcessHasFakeSkillSecret || !proof.activeSkillEnvKeysIncludeSecret || proof.childEnvHasFakeSkillSecret || proof.childEnvValue !== null || !proof.pathStillPreserved) {
    process.exitCode = 1;
  }
} finally {
  restoreSkillEnv();
  if (hadOriginal) {
    process.env[key] = original;
  } else {
    delete process.env[key];
  }
}
EOF_NODE
```

Evidence after fix:

```json
{
  "hostProcessHasFakeSkillSecret": true,
  "activeSkillEnvKeysIncludeSecret": true,
  "childEnvHasFakeSkillSecret": false,
  "childEnvValue": null,
  "pathStillPreserved": true
}
```

Observed result after fix: the fake skill secret exists in the host process and is tracked as an active skill env key, but the child env produced for host exec does not contain that key or value. PATH remains present, so this is a targeted strip rather than dropping the inherited environment wholesale.

What was not tested: I did not run a full end-to-end skill invocation through a live external agent process; the generic host exec path is covered by targeted tests using the repo's supervisor test harness and the production sanitizer proof above.

## Verification
- `node scripts/run-vitest.mjs src/infra/host-env-security.test.ts src/agents/bash-tools.exec.path.test.ts src/agents/skills.test.ts src/acp/client.test.ts src/agents/bash-tools.exec-runtime.test.ts` -> 8 files passed, 281 tests passed.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json src/infra/host-env-security.ts src/infra/host-env-security.test.ts src/agents/bash-tools.exec.ts src/agents/bash-tools.exec.path.test.ts` -> 0 warnings, 0 errors.
- `git diff --check` -> clean.
