### PR TITLE
fix: change post-compaction prose to instruct task continuation instead of restart

### DIFF
--- a/src/auto-reply/reply/post-compaction-context.ts
+++ b/src/auto-reply/reply/post-compaction-context.ts
@@ -146,11 +146,16 @@ export async function readPostCompactionContext(
     // "Session Startup" sequence explicitly. When custom sections are configured,
     // use generic prose — referencing a hardcoded "Session Startup" sequence
     // would be misleading for deployments that use different section names.
+    // IMPORTANT: The prose must instruct the agent to CONTINUE the unfinished task,
+    // not to restart or reinitialize. The compaction summary contains task progress.
     const prose = isDefaultSections
-      ? "Session was just compacted. The conversation summary above is a hint, NOT a substitute for your startup sequence. " +
-        "Run your Session Startup sequence - read the required files before responding to the user."
-      : `Session was just compacted. The conversation summary above is a hint, NOT a substitute for your full startup sequence. ` +
-        `Re-read the sections injected below (${displayNames.join(", ")}) and follow your configured startup procedure before responding to the user.`;
+      ? "Session was just compacted. The conversation summary above contains task progress. " +
+        "CONTINUE the unfinished task immediately using the summary context. " +
+        "Do NOT restart, reinitialize, or execute any startup sequence."
+      : `Session was just compacted. The conversation summary above contains task progress. ` +
+        `CONTINUE the unfinished task immediately using the summary context. ` +
+        `Do NOT restart, reinitialize, or execute any startup procedure. ` +
+        `The injected sections (${displayNames.join(", ")}) provide additional guidance for task continuation.`;
 
     const sectionLabel = isDefaultSections
       ? "Critical rules from AGENTS.md:"


### PR DESCRIPTION
## Problem

After compaction, the injected system message instructs agents to "Run your Session Startup sequence" or "follow your configured startup procedure", causing agents to **restart/reinitialize** instead of **continuing the unfinished task**.

This is a critical bug that leads to:
- Task interruption after every compaction
- Loss of task context and progress
- Agent executing unnecessary startup sequences
- User frustration and wasted work

**Real behavior proof:**
Every time compaction occurs, the agent stops working on the task and starts reading files (MEMORY.md, SOUL.md, USER.md, etc.) instead of continuing the task.

## Root Cause

The prose in `post-compaction-context.ts` line 105-111:

```typescript
const prose = isDefaultSections
  ? "Run your Session Startup sequence - read the required files before responding to the user."
  : "follow your configured startup procedure before responding to the user.";
```

Both versions instruct the agent to execute startup/restart behavior, not task continuation.

## Solution

Change the prose to explicitly instruct **task continuation**:

```typescript
const prose = isDefaultSections
  ? "CONTINUE the unfinished task immediately using the summary context. Do NOT restart, reinitialize, or execute any startup sequence."
  : "CONTINUE the unfinished task immediately using the summary context. Do NOT restart, reinitialize, or execute any startup procedure.";
```

## Expected Impact

| Before | After |
|--------|-------|
| Agent restarts after compaction | Agent continues task seamlessly |
| Task progress lost | Task progress preserved in summary |
| User must re-explain task | Agent uses summary context |

## Files Changed

- `src/auto-reply/reply/post-compaction-context.ts`: prose for both default and custom sections

## Checklist

- [x] Bug fix with real behavior proof
- [x] Source code analysis completed
- [x] AI-assisted development marked