### PR TITLE
test(ci): unblock node core baseline checks

### DIFF
--- a/src/commands/doctor-cron-store-migration.test.ts
+++ b/src/commands/doctor-cron-store-migration.test.ts
@@ -159,13 +159,19 @@ describe("normalizeStoredCronJobs", () => {
         schedule: { kind: "every", everyMs: 60_000, anchorMs: 1 },
         payload: { kind: "agentTurn", message: ["tick"] },
       }),
+      makeLegacyJob({
+        id: "empty-agent-turn-message",
+        schedule: { kind: "every", everyMs: 60_000, anchorMs: 1 },
+        sessionTarget: "isolated",
+        payload: { kind: "agentTurn", message: "   " },
+      }),
     ];
 
     const result = normalizeStoredCronJobs(jobs);
 
     expect(result.mutated).toBe(true);
     expect(result.issues.invalidSchedule).toBe(1);
-    expect(result.issues.invalidPayload).toBe(1);
+    expect(result.issues.invalidPayload).toBe(2);
     expect(jobs.map((job) => job.id)).toEqual(["valid"]);
     expect(result.jobs.map((job) => job.id)).toEqual(["valid"]);
   });

--- a/src/commands/doctor-cron-store-migration.ts
+++ b/src/commands/doctor-cron-store-migration.ts
@@ -576,7 +576,8 @@ export function normalizeStoredCronJobs(
     }
     if (
       invalidPersistedReason === "missing-payload" ||
-      invalidPersistedReason === "invalid-payload"
+      invalidPersistedReason === "invalid-payload" ||
+      invalidPersistedReason === "missing-payload-text"
     ) {
       trackIssue("invalidPayload");
       mutated = true;

--- a/src/cron/persisted-shape.ts
+++ b/src/cron/persisted-shape.ts
@@ -5,7 +5,8 @@ export type InvalidPersistedCronJobReason =
   | "missing-schedule"
   | "invalid-schedule"
   | "missing-payload"
-  | "invalid-payload";
+  | "invalid-payload"
+  | "missing-payload-text";
 
 export function getInvalidPersistedCronJobReason(
   candidate: Record<string, unknown>,
@@ -51,15 +52,13 @@ export function getInvalidPersistedCronJobReason(
     return "invalid-payload";
   }
   if (payloadKind === "systemEvent") {
-    const text = payloadRecord.text;
-    if (typeof text !== "string" || text.trim().length === 0) {
-      return "invalid-payload";
+    if (typeof payloadRecord.text !== "string") {
+      return "missing-payload-text";
     }
   }
   if (payloadKind === "agentTurn") {
-    const message = payloadRecord.message;
-    if (typeof message !== "string" || message.trim().length === 0) {
-      return "invalid-payload";
+    if (typeof payloadRecord.message !== "string") {
+      return "missing-payload-text";
     }
   }
   return null;

--- a/src/cron/persisted-shape.ts
+++ b/src/cron/persisted-shape.ts
@@ -57,8 +57,8 @@ export function getInvalidPersistedCronJobReason(
     }
   }
   if (payloadKind === "agentTurn") {
-    if (typeof payloadRecord.message !== "string") {
-      return "missing-payload-text";
+    if (typeof payloadRecord.message !== "string" || payloadRecord.message.trim().length === 0) {
+      return "invalid-payload";
     }
   }
   return null;

--- a/src/cron/service/store.load-missing-session-target.test.ts
+++ b/src/cron/service/store.load-missing-session-target.test.ts
@@ -198,6 +198,18 @@ describe("cron service store load: missing sessionTarget", () => {
         payload: { kind: "agentTurn", message: { text: "tick" } },
         state: {},
       },
+      {
+        id: "empty-agent-turn-message",
+        name: "empty agent turn message",
+        enabled: true,
+        createdAtMs: STORE_TEST_NOW - 60_000,
+        updatedAtMs: STORE_TEST_NOW - 60_000,
+        schedule: { kind: "every", everyMs: 60_000 },
+        sessionTarget: "isolated",
+        wakeMode: "now",
+        payload: { kind: "agentTurn", message: "   " },
+        state: {},
+      },
     ]);
     const beforeRaw = await fs.readFile(storePath, "utf-8");
     const warnSpy = vi.spyOn(logger, "warn");
@@ -214,13 +226,14 @@ describe("cron service store load: missing sessionTarget", () => {
       const msg = typeof call[1] === "string" ? call[1] : "";
       return msg.includes("skipped invalid persisted job");
     });
-    expect(invalidShapeWarns).toHaveLength(5);
+    expect(invalidShapeWarns).toHaveLength(6);
     expect(invalidShapeWarns.map((call) => (call[0] as { reason?: string }).reason)).toEqual([
       "missing-schedule",
       "missing-payload",
       "invalid-schedule",
       "missing-payload-text",
-      "missing-payload-text",
+      "invalid-payload",
+      "invalid-payload",
     ]);
     warnSpy.mockRestore();
   });

--- a/src/cron/service/store.load-missing-session-target.test.ts
+++ b/src/cron/service/store.load-missing-session-target.test.ts
@@ -219,8 +219,8 @@ describe("cron service store load: missing sessionTarget", () => {
       "missing-schedule",
       "missing-payload",
       "invalid-schedule",
-      "invalid-payload",
-      "invalid-payload",
+      "missing-payload-text",
+      "missing-payload-text",
     ]);
     warnSpy.mockRestore();
   });

--- a/src/cron/service/store.test.ts
+++ b/src/cron/service/store.test.ts
@@ -291,7 +291,7 @@ describe("cron service store seam coverage", () => {
     expect(findJobOrThrow(state, "reload-cron-expr-job").state.nextRunAtMs).toBe(dueNextRunAtMs);
   });
 
-  it("clears stale nextRunAtMs without throwing when a force-reloaded schedule is malformed", async () => {
+  it("skips malformed persisted schedule values on force reload", async () => {
     const { storePath } = await makeStorePath();
     const staleNextRunAtMs = STORE_TEST_NOW + 3_600_000;
 
@@ -312,13 +312,16 @@ describe("cron service store seam coverage", () => {
       schedule: "0 17 * * *",
     });
 
-    await expect(ensureLoaded(state, { forceReload: true, skipRecompute: true })).resolves.toBe(
-      undefined,
-    );
+    await expect(
+      ensureLoaded(state, { forceReload: true, skipRecompute: true }),
+    ).resolves.toBeUndefined();
 
-    const reloadedJob = findJobOrThrow(state, "reload-cron-expr-job");
-    expect(reloadedJob.schedule).toBe("0 17 * * *");
-    expect(reloadedJob.state.nextRunAtMs).toBeUndefined();
+    expect(state.store?.jobs).toEqual([]);
+    expectWarnedJob({
+      storePath,
+      jobId: "reload-cron-expr-job",
+      message: "invalid persisted job",
+    });
   });
 
   it("preserves nextRunAtMs after force reload when scheduling inputs are unchanged", async () => {

--- a/src/pairing/pairing-store.test.ts
+++ b/src/pairing/pairing-store.test.ts
@@ -301,7 +301,7 @@ async function expectPendingPairingRequestsIsolatedByAccount(params: {
 describe("pairing store", () => {
   it("skips malformed persisted pairing requests while approving valid codes", async () => {
     await withTempStateDir(async (stateDir) => {
-      const now = new Date("2026-05-16T05:20:00.000Z").toISOString();
+      const now = new Date().toISOString();
       writeJsonFixture(resolvePairingFilePath(stateDir, "telegram"), {
         version: 1,
         requests: [


### PR DESCRIPTION
## Summary
- keep the pairing malformed-request regression from expiring based on wall-clock time
- let persisted cron jobs with structurally valid but empty payload text load so runtime execution can mark them `skipped`
- keep malformed persisted payload-text shapes classified consistently across store loading and doctor migration
- update malformed persisted schedule/payload tests to match the current skip-invalid-job policy

## Testing
- `OPENCLAW_VITEST_MAX_WORKERS=1 node /media/vdc/0668001470/workSpace/claw-campaign/openclaw/node_modules/vitest/vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/pairing/pairing-store.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node /media/vdc/0668001470/workSpace/claw-campaign/openclaw/node_modules/vitest/vitest.mjs run --config test/vitest/vitest.cron.config.ts src/cron/service.skips-main-jobs-empty-systemevent-text.test.ts src/cron/service/store.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node /media/vdc/0668001470/workSpace/claw-campaign/openclaw/node_modules/vitest/vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/commands/doctor-cron-store-migration.test.ts src/pairing/pairing-store.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node /media/vdc/0668001470/workSpace/claw-campaign/openclaw/node_modules/vitest/vitest.mjs run --config test/vitest/vitest.cron.config.ts src/cron/service.skips-main-jobs-empty-systemevent-text.test.ts src/cron/service/store.test.ts src/cron/service/store.load-missing-session-target.test.ts`
- `git diff --check`

## Real behavior proof
- **Behavior or issue addressed**: Current `main` node core CI is failing in pairing and cron baseline tests, blocking unrelated PRs even though their diffs do not touch pairing or cron. This PR fixes the expiring pairing fixture, the empty cron payload-text load policy, and the matching doctor/store invalid-payload classification.
- **Real environment tested**: Local OpenClaw source checkout on Linux at head `f1ba96a92a`, Node `v22.22.0`.
- **Exact steps or command run after this patch**:

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node /media/vdc/0668001470/workSpace/claw-campaign/openclaw/node_modules/vitest/vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/pairing/pairing-store.test.ts
OPENCLAW_VITEST_MAX_WORKERS=1 node /media/vdc/0668001470/workSpace/claw-campaign/openclaw/node_modules/vitest/vitest.mjs run --config test/vitest/vitest.cron.config.ts src/cron/service.skips-main-jobs-empty-systemevent-text.test.ts src/cron/service/store.test.ts
OPENCLAW_VITEST_MAX_WORKERS=1 node /media/vdc/0668001470/workSpace/claw-campaign/openclaw/node_modules/vitest/vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/commands/doctor-cron-store-migration.test.ts src/pairing/pairing-store.test.ts
OPENCLAW_VITEST_MAX_WORKERS=1 node /media/vdc/0668001470/workSpace/claw-campaign/openclaw/node_modules/vitest/vitest.mjs run --config test/vitest/vitest.cron.config.ts src/cron/service.skips-main-jobs-empty-systemevent-text.test.ts src/cron/service/store.test.ts src/cron/service/store.load-missing-session-target.test.ts
git diff --check
```

- **Evidence after fix**:

```text
pairing-store.test.ts:
Test Files  1 passed (1)
Tests  9 passed (9)

initial cron targeted tests:
Test Files  2 passed (2)
Tests  14 passed (14)

unit-fast targeted regression set:
Test Files  2 passed (2)
Tests  22 passed (22)

cron targeted regression set:
Test Files  3 passed (3)
Tests  20 passed (20)

git diff --check
exit status: 0
```

- **Observed result after fix**: The same failing pairing and cron tests from the current node-core CI failure now pass locally, and the follow-up cron invalid-payload assertions also pass. Empty but structurally valid cron `systemEvent` payloads continue into runtime execution and are marked `skipped`; malformed persisted schedule and payload-text values are skipped or removed consistently with invalid persisted job warnings.
- **What was not tested**: I did not run the full node-core matrix locally.