### PR TITLE
fix(compaction): treat 'phase: end' without completed flag as success (#82470)

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -2599,6 +2599,61 @@ describe("runAgentTurnWithFallback", () => {
     });
   });
 
+  it("treats compaction end without an explicit completed flag as success (#82470)", async () => {
+    // Codex app-server contextCompaction bridge emits `{ phase: "end" }`
+    // without a `completed` boolean. Before #82470 this fell into the
+    // "incomplete" branch and surfaced "🧹 Compaction incomplete" even when
+    // the native compaction succeeded. The consumer now treats missing
+    // `completed` as success and only surfaces "incomplete" when the
+    // emitter explicitly sets `completed: false`.
+    const onBlockReply = vi.fn();
+    state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
+      await params.onAgentEvent?.({ stream: "compaction", data: { phase: "start" } });
+      await params.onAgentEvent?.({ stream: "compaction", data: { phase: "end" } });
+      return { payloads: [{ text: "final" }], meta: {} };
+    });
+
+    const followupRun = createFollowupRun();
+    followupRun.run.config = {
+      agents: { defaults: { compaction: { notifyUser: true } } },
+    };
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun,
+      sessionCtx: {
+        Provider: "whatsapp",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: { onBlockReply },
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: async () => false,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+    });
+
+    expect(result.kind).toBe("success");
+    expectBlockReplyCall(onBlockReply, 0, {
+      text: "🧹 Compacting context...",
+      isCompactionNotice: true,
+    });
+    expectBlockReplyCall(onBlockReply, 1, {
+      text: "🧹 Compaction complete",
+      isCompactionNotice: true,
+    });
+  });
+
   it("emits an incomplete compaction notice when compaction ends without completing", async () => {
     const onBlockReply = vi.fn();
     state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1977,7 +1977,13 @@ export async function runAgentTurnWithFallback(params: {
                       }
                     }
                     if (phase === "end") {
-                      const completed = evt.data?.completed === true;
+                      // Treat `completed: undefined` as success: not every
+                      // backend that emits `phase: "end"` populates the flag
+                      // (e.g. Codex app-server `contextCompaction` bridge emits
+                      // `{ phase: "end" }` without `completed`). Only treat the
+                      // run as incomplete when the emitter explicitly sets
+                      // `completed: false`. See #82470.
+                      const completed = evt.data?.completed !== false;
                       if (completed) {
                         attemptCompactionCount += 1;
                         if (params.opts?.onCompactionEnd) {


### PR DESCRIPTION
## Real behavior proof

- **Behavior or issue addressed:** Codex app-server `contextCompaction` bridge emits `{ stream: "compaction", data: { phase: "end" } }` with no `completed` boolean. The consumer in `src/auto-reply/reply/agent-runner-execution.ts:1980` required strict `completed === true`, so the bridge's end event was misclassified as incomplete and the user saw a spurious "🧹 Compaction incomplete" notice even when the native compaction succeeded. Fixes #82470.
- **Root cause:** Predicate `evt.data?.completed === true` is strictly true-only; every other shape (including `undefined`, the case the Codex bridge produces) falls into the incomplete branch.
- **Fix surface:** Single line in `agent-runner-execution.ts` — change `completed === true` to `completed !== false` so that missing `completed` defaults to success. Emitters that need to force the incomplete branch keep doing so by explicitly setting `completed: false`.
- **Existing-helper check (vincentkoc #57341):** No helper introduced. Predicate sharpened in place.
- **Shared-helper caller check (steipete #60623):** `sendCompactionNotice("incomplete")` has a single caller at line 1997, unchanged by this PR. The pi-embedded path at `pi-embedded-subscribe.handlers.compaction.ts:142,146` explicitly emits `completed: hasResult && !wasAborted` so its incomplete-case behavior (an explicit `false`) remains intact under the new predicate. The hook-message path at `pi-embedded-runner/run.ts:1094` only sets `completed: true` for `after` events and omits the flag for `before` (start) events, which never reach the end-phase branch — unaffected.
- **Broader-fix rival scan (steipete #68270):** No rival PR open on this surface as of cycle start. The narrower fix is in the consumer, not in the Codex bridge emitter (which is in a bundled dist code path the issue references but whose source location is outside this PR's scope).
- **Live verification:** Added `agent-runner-execution.test.ts` regression case "treats compaction end without an explicit completed flag as success (#82470)". The test simulates the Codex app-server pattern: `{ phase: "start" }` then `{ phase: "end" }` with no `completed` field, and asserts "🧹 Compaction complete" is sent (not "incomplete"). Mirrors the existing test #2602 which keeps asserting `completed: false` → "incomplete".
- **Backward compatibility:** Three observed emitter shapes:
  - `completed: true` → success (unchanged)
  - `completed: false` → incomplete (unchanged — covered by test #2602)
  - omitted → was incomplete, now success (this fix)
  Only the third shape changes behavior, and only in the direction the bridge actually intended.