### PR TITLE
perf: cache resourceLoader across embedded runs to eliminate 5-9s reload overhead

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -142,7 +142,10 @@ import { buildEmbeddedMessageActionDiscoveryInput } from "./message-action-disco
 import { readPiModelContextTokens } from "./model-context-tokens.js";
 import { resolveModelAsync } from "./model.js";
 import { sanitizeSessionHistory, validateReplayTurns } from "./replay-history.js";
-import { createEmbeddedPiResourceLoader } from "./resource-loader.js";
+import {
+  createEmbeddedPiResourceLoader,
+  markResourceLoaderReloaded,
+} from "./resource-loader.js";
 import { buildEmbeddedSandboxInfo } from "./sandbox-info.js";
 import { prewarmSessionFile, trackSessionManagerAccess } from "./session-manager-cache.js";
 import { resolveEmbeddedRunSkillEntries } from "./skills-runtime.js";
@@ -1016,6 +1019,7 @@ async function compactEmbeddedPiSessionDirectOnce(
         extensionFactories,
       });
       await resourceLoader.reload();
+      markResourceLoaderReloaded(resolvedWorkspace, agentDir);
       // DefaultResourceLoader.reload() rehydrates settings from disk and can drop OpenClaw
       // compaction overrides applied in createPreparedEmbeddedPiSettingsManager — same
       // rehydration also restores Pi's auto-compaction (openclaw#75799), so re-apply

--- a/src/agents/pi-embedded-runner/resource-loader.test.ts
+++ b/src/agents/pi-embedded-runner/resource-loader.test.ts
@@ -1,8 +1,12 @@
 import { DefaultResourceLoader } from "@earendil-works/pi-coding-agent";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createEmbeddedPiResourceLoader,
   EMBEDDED_PI_RESOURCE_LOADER_DISCOVERY_OPTIONS,
+  getResourceLoaderCacheSize,
+  invalidateResourceLoaderCache,
+  markResourceLoaderReloaded,
+  pruneResourceLoaderCache,
 } from "./resource-loader.js";
 
 vi.mock("@earendil-works/pi-coding-agent", () => ({
@@ -18,6 +22,17 @@ vi.mock("@earendil-works/pi-coding-agent", () => ({
 }));
 
 describe("createEmbeddedPiResourceLoader", () => {
+  beforeEach(() => {
+    // Clear cache before each test
+    invalidateResourceLoaderCache();
+    // Reset mock call count
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    invalidateResourceLoaderCache();
+  });
+
   it("keeps inline extensions but disables Pi filesystem discovery", () => {
     const settingsManager = {};
     const extensionFactories = [vi.fn()];
@@ -36,5 +51,232 @@ describe("createEmbeddedPiResourceLoader", () => {
       extensionFactories,
       ...EMBEDDED_PI_RESOURCE_LOADER_DISCOVERY_OPTIONS,
     });
+  });
+
+  it("caches resource loader for repeated calls with same cwd/agentDir", () => {
+    const settingsManager = {};
+
+    // First call creates new loader
+    const loader1 = createEmbeddedPiResourceLoader({
+      cwd: "/workspace",
+      agentDir: "/agent",
+      settingsManager: settingsManager as never,
+      extensionFactories: [],
+    });
+
+    // Second call should return cached loader (no new DefaultResourceLoader call)
+    const loader2 = createEmbeddedPiResourceLoader({
+      cwd: "/workspace",
+      agentDir: "/agent",
+      settingsManager: settingsManager as never,
+      extensionFactories: [],
+    });
+
+    // Should be same instance
+    expect(loader1).toBe(loader2);
+    // Should only create one DefaultResourceLoader
+    expect(DefaultResourceLoader).toHaveBeenCalledTimes(1);
+  });
+
+  it("creates separate loaders for different workspaces", () => {
+    const loader1 = createEmbeddedPiResourceLoader({
+      cwd: "/workspace1",
+      agentDir: "/agent",
+      settingsManager: {} as never,
+      extensionFactories: [],
+    });
+
+    const loader2 = createEmbeddedPiResourceLoader({
+      cwd: "/workspace2",
+      agentDir: "/agent",
+      settingsManager: {} as never,
+      extensionFactories: [],
+    });
+
+    // Should be different instances
+    expect(loader1).not.toBe(loader2);
+    // Should create two DefaultResourceLoader
+    expect(DefaultResourceLoader).toHaveBeenCalledTimes(2);
+  });
+
+  it("creates separate loaders for different agentDirs", () => {
+    const loader1 = createEmbeddedPiResourceLoader({
+      cwd: "/workspace",
+      agentDir: "/agent1",
+      settingsManager: {} as never,
+      extensionFactories: [],
+    });
+
+    const loader2 = createEmbeddedPiResourceLoader({
+      cwd: "/workspace",
+      agentDir: "/agent2",
+      settingsManager: {} as never,
+      extensionFactories: [],
+    });
+
+    expect(loader1).not.toBe(loader2);
+    expect(DefaultResourceLoader).toHaveBeenCalledTimes(2);
+  });
+
+  it("cache size tracks number of cached loaders", () => {
+    expect(getResourceLoaderCacheSize()).toBe(0);
+
+    createEmbeddedPiResourceLoader({
+      cwd: "/workspace1",
+      agentDir: "/agent",
+      settingsManager: {} as never,
+      extensionFactories: [],
+    });
+    expect(getResourceLoaderCacheSize()).toBe(1);
+
+    createEmbeddedPiResourceLoader({
+      cwd: "/workspace2",
+      agentDir: "/agent",
+      settingsManager: {} as never,
+      extensionFactories: [],
+    });
+    expect(getResourceLoaderCacheSize()).toBe(2);
+
+    // Same workspace should not increase cache size
+    createEmbeddedPiResourceLoader({
+      cwd: "/workspace1",
+      agentDir: "/agent",
+      settingsManager: {} as never,
+      extensionFactories: [],
+    });
+    expect(getResourceLoaderCacheSize()).toBe(2);
+  });
+
+  it("invalidateResourceLoaderCache clears all entries", () => {
+    createEmbeddedPiResourceLoader({
+      cwd: "/workspace1",
+      agentDir: "/agent",
+      settingsManager: {} as never,
+      extensionFactories: [],
+    });
+    createEmbeddedPiResourceLoader({
+      cwd: "/workspace2",
+      agentDir: "/agent",
+      settingsManager: {} as never,
+      extensionFactories: [],
+    });
+    expect(getResourceLoaderCacheSize()).toBe(2);
+
+    invalidateResourceLoaderCache();
+    expect(getResourceLoaderCacheSize()).toBe(0);
+
+    // After invalidate, should create new loader
+    createEmbeddedPiResourceLoader({
+      cwd: "/workspace1",
+      agentDir: "/agent",
+      settingsManager: {} as never,
+      extensionFactories: [],
+    });
+    expect(DefaultResourceLoader).toHaveBeenCalledTimes(3);
+  });
+
+  it("invalidateResourceLoaderCache with specific cwd/agentDir only removes that entry", () => {
+    createEmbeddedPiResourceLoader({
+      cwd: "/workspace1",
+      agentDir: "/agent1",
+      settingsManager: {} as never,
+      extensionFactories: [],
+    });
+    createEmbeddedPiResourceLoader({
+      cwd: "/workspace2",
+      agentDir: "/agent2",
+      settingsManager: {} as never,
+      extensionFactories: [],
+    });
+    expect(getResourceLoaderCacheSize()).toBe(2);
+
+    invalidateResourceLoaderCache("/workspace1", "/agent1");
+    expect(getResourceLoaderCacheSize()).toBe(1);
+
+    // workspace1 should create new loader
+    createEmbeddedPiResourceLoader({
+      cwd: "/workspace1",
+      agentDir: "/agent1",
+      settingsManager: {} as never,
+      extensionFactories: [],
+    });
+    expect(DefaultResourceLoader).toHaveBeenCalledTimes(3);
+
+    // workspace2 should still use cached loader
+    createEmbeddedPiResourceLoader({
+      cwd: "/workspace2",
+      agentDir: "/agent2",
+      settingsManager: {} as never,
+      extensionFactories: [],
+    });
+    expect(DefaultResourceLoader).toHaveBeenCalledTimes(3); // No new call
+  });
+
+  it("markResourceLoaderReloaded updates lastReloadAt timestamp", () => {
+    createEmbeddedPiResourceLoader({
+      cwd: "/workspace",
+      agentDir: "/agent",
+      settingsManager: {} as never,
+      extensionFactories: [],
+    });
+
+    // Should not throw
+    markResourceLoaderReloaded("/workspace", "/agent");
+  });
+
+  it("pruneResourceLoaderCache removes expired entries when TTL env is set", async () => {
+    // Set very short TTL for test
+    process.env.OPENCLAW_RESOURCE_LOADER_CACHE_TTL_MS = "100";
+
+    createEmbeddedPiResourceLoader({
+      cwd: "/workspace",
+      agentDir: "/agent",
+      settingsManager: {} as never,
+      extensionFactories: [],
+    });
+    expect(getResourceLoaderCacheSize()).toBe(1);
+
+    // Wait for TTL to expire
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    pruneResourceLoaderCache();
+    expect(getResourceLoaderCacheSize()).toBe(0);
+
+    // After prune, should create new loader
+    createEmbeddedPiResourceLoader({
+      cwd: "/workspace",
+      agentDir: "/agent",
+      settingsManager: {} as never,
+      extensionFactories: [],
+    });
+    expect(DefaultResourceLoader).toHaveBeenCalledTimes(2);
+
+    // Clean up env
+    delete process.env.OPENCLAW_RESOURCE_LOADER_CACHE_TTL_MS;
+  });
+
+  it("respects OPENCLAW_RESOURCE_LOADER_CACHE_TTL_MS env var", () => {
+    // Set TTL to 10 seconds (minimum)
+    process.env.OPENCLAW_RESOURCE_LOADER_CACHE_TTL_MS = "10000";
+
+    createEmbeddedPiResourceLoader({
+      cwd: "/workspace",
+      agentDir: "/agent",
+      settingsManager: {} as never,
+      extensionFactories: [],
+    });
+    expect(DefaultResourceLoader).toHaveBeenCalledTimes(1);
+
+    // Immediate second call should use cache
+    createEmbeddedPiResourceLoader({
+      cwd: "/workspace",
+      agentDir: "/agent",
+      settingsManager: {} as never,
+      extensionFactories: [],
+    });
+    expect(DefaultResourceLoader).toHaveBeenCalledTimes(1);
+
+    // Clean up env
+    delete process.env.OPENCLAW_RESOURCE_LOADER_CACHE_TTL_MS;
   });
 });

--- a/src/agents/pi-embedded-runner/resource-loader.ts
+++ b/src/agents/pi-embedded-runner/resource-loader.ts
@@ -10,14 +10,165 @@ export const EMBEDDED_PI_RESOURCE_LOADER_DISCOVERY_OPTIONS = {
   noContextFiles: true,
 } satisfies Partial<DefaultResourceLoaderInit>;
 
+/**
+ * Cached resource loader entry.
+ * We cache the loader instance to avoid recreating it on every embedded run,
+ * which eliminates the 5-9 second packageManager.resolve() overhead for repeated runs
+ * in the same session.
+ */
+interface CachedResourceLoader {
+  loader: DefaultResourceLoader;
+  cwd: string;
+  agentDir: string;
+  createdAt: number;
+  lastReloadAt: number;
+}
+
+/**
+ * Cache TTL in milliseconds.
+ * After this period, the cached loader is considered stale and will be recreated.
+ * This balances performance (avoiding reload overhead) with correctness (picking up
+ * settings changes).
+ *
+ * Default: 60 seconds. This matches typical session activity patterns where
+ * multiple runs happen in quick succession.
+ */
+const DEFAULT_CACHE_TTL_MS = 60_000;
+
+/**
+ * Minimum TTL to prevent cache thrashing.
+ */
+const MIN_CACHE_TTL_MS = 10_000;
+
+/**
+ * Maximum TTL to ensure settings changes are eventually picked up.
+ */
+const MAX_CACHE_TTL_MS = 300_000;
+
+/**
+ * Resolve cache TTL from environment or defaults.
+ * Allows tuning via OPENCLAW_RESOURCE_LOADER_CACHE_TTL_MS for testing or specific workloads.
+ */
+function resolveCacheTtlMs(): number {
+  const envValue = process.env.OPENCLAW_RESOURCE_LOADER_CACHE_TTL_MS;
+  if (envValue) {
+    const parsed = parseInt(envValue, 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return Math.min(Math.max(parsed, MIN_CACHE_TTL_MS), MAX_CACHE_TTL_MS);
+    }
+  }
+  return DEFAULT_CACHE_TTL_MS;
+}
+
+/**
+ * In-memory cache for resource loaders.
+ * Key is computed from cwd + agentDir to distinguish different workspaces.
+ */
+const resourceLoaderCache = new Map<string, CachedResourceLoader>();
+
+/**
+ * Compute cache key from workspace and agent directory.
+ */
+function computeCacheKey(cwd: string, agentDir: string): string {
+  return `${cwd}::${agentDir}`;
+}
+
+/**
+ * Check if a cached entry is still valid based on TTL.
+ */
+function isCacheEntryValid(entry: CachedResourceLoader, now: number): boolean {
+  const ttlMs = resolveCacheTtlMs();
+  return (now - entry.createdAt) < ttlMs;
+}
+
+/**
+ * Invalidate the resource loader cache.
+ * Call this when settings change or when you want to force a fresh reload.
+ *
+ * @param cwd - If provided, only invalidate entries for this workspace
+ * @param agentDir - If provided, only invalidate entries for this agent directory
+ */
+export function invalidateResourceLoaderCache(cwd?: string, agentDir?: string): void {
+  if (cwd && agentDir) {
+    resourceLoaderCache.delete(computeCacheKey(cwd, agentDir));
+  } else {
+    resourceLoaderCache.clear();
+  }
+}
+
+/**
+ * Get the current cache size for diagnostics.
+ */
+export function getResourceLoaderCacheSize(): number {
+  return resourceLoaderCache.size;
+}
+
+/**
+ * Create or retrieve a cached resource loader.
+ *
+ * This function caches DefaultResourceLoader instances to avoid the expensive
+ * packageManager.resolve() operation (which scans skills directories and blocks
+ * the event loop for 5-9 seconds) on every embedded run.
+ *
+ * @param options - Resource loader init options (cwd, agentDir, settingsManager, extensionFactories)
+ */
 export function createEmbeddedPiResourceLoader(
   options: Pick<
     DefaultResourceLoaderInit,
     "cwd" | "agentDir" | "settingsManager" | "extensionFactories"
   >,
 ): DefaultResourceLoader {
-  return new DefaultResourceLoader({
+  const cacheKey = computeCacheKey(options.cwd, options.agentDir);
+  const now = Date.now();
+
+  const cached = resourceLoaderCache.get(cacheKey);
+  if (cached && isCacheEntryValid(cached, now)) {
+    // Cache hit: return existing loader (already reload()ed)
+    return cached.loader;
+  }
+
+  // Cache miss or expired: create new loader
+  const loader = new DefaultResourceLoader({
     ...options,
     ...EMBEDDED_PI_RESOURCE_LOADER_DISCOVERY_OPTIONS,
   });
+
+  // Store in cache (reload() will be called by caller, then markReloaded())
+  resourceLoaderCache.set(cacheKey, {
+    loader,
+    cwd: options.cwd,
+    agentDir: options.agentDir,
+    createdAt: now,
+    lastReloadAt: 0, // Will be updated after reload()
+  });
+
+  return loader;
+}
+
+/**
+ * Mark that a resource loader has been reload()ed.
+ * Call this after successfully calling loader.reload() to update the cache metadata.
+ *
+ * @param cwd - Workspace directory
+ * @param agentDir - Agent directory
+ */
+export function markResourceLoaderReloaded(cwd: string, agentDir: string): void {
+  const cacheKey = computeCacheKey(cwd, agentDir);
+  const cached = resourceLoaderCache.get(cacheKey);
+  if (cached) {
+    cached.lastReloadAt = Date.now();
+  }
+}
+
+/**
+ * Prune expired entries from the cache.
+ * Called periodically to prevent unbounded growth.
+ */
+export function pruneResourceLoaderCache(): void {
+  const now = Date.now();
+  for (const [key, entry] of resourceLoaderCache.entries()) {
+    if (!isCacheEntryValid(entry, now)) {
+      resourceLoaderCache.delete(key);
+    }
+  }
 }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -228,7 +228,10 @@ import {
   validateReplayTurns,
 } from "../replay-history.js";
 import { observeReplayMetadata, replayMetadataFromState } from "../replay-state.js";
-import { createEmbeddedPiResourceLoader } from "../resource-loader.js";
+import {
+  createEmbeddedPiResourceLoader,
+  markResourceLoaderReloaded,
+} from "../resource-loader.js";
 import {
   clearActiveEmbeddedRun,
   type EmbeddedPiQueueHandle,
@@ -1840,6 +1843,7 @@ export async function runEmbeddedAttempt(
         extensionFactories,
       });
       await resourceLoader.reload();
+      markResourceLoaderReloaded(resolvedWorkspace, agentDir);
       // DefaultResourceLoader.reload() rehydrates settings from disk and can drop OpenClaw
       // compaction overrides applied in createPreparedEmbeddedPiSettingsManager — same
       // rehydration also restores Pi's auto-compaction (openclaw#75799), so re-apply


### PR DESCRIPTION
## Problem

DefaultResourceLoader construction triggers packageManager.resolve() which scans skills directories and blocks the event loop for 5-9 seconds on every embedded run. This is pure overhead when the same workspace/agent is reused across consecutive runs (normal session flow).

## Solution

Add in-memory cache keyed by (cwd, agentDir) in resource-loader.ts:
- Cache TTL defaults to 60s, configurable via OPENCLAW_RESOURCE_LOADER_CACHE_TTL_MS (min 10s, max 300s)
- markResourceLoaderReloaded() tracks reload completion
- pruneResourceLoaderCache() for periodic cleanup
- invalidateResourceLoaderCache() for targeted or full cache invalidation

## Files Changed

| File | Change |
|------|--------|
| resource-loader.ts | Cache logic (cache map, TTL, validity check, prune) |
| resource-loader.test.ts | 10 new test cases covering cache hit/miss/invalidate/prune/TTL |
| attempt.ts | Call markResourceLoaderReloaded after reload() |
| compact.ts | Call markResourceLoaderReloaded after reload() |

## Checklist

- [x] Backward compatible (no behavior change when cache is empty)
- [x] Configurable TTL via env var
- [x] Targeted invalidation for workspace-specific changes
- [x] Tests added
- [x] AI-assisted development