### PR TITLE
fix(discord): avoid model picker map spread

### DIFF
--- a/extensions/discord/src/monitor/model-picker.view.ts
+++ b/extensions/discord/src/monitor/model-picker.view.ts
@@ -370,12 +370,17 @@ function buildModelRows(params: {
             modelIndex: params.pendingModelIndex,
             userId: params.userId,
           }),
-          options: runtimeChoices.map((choice) => ({
-            label: choice.label,
-            value: choice.id,
-            default: choice.id === selectedRuntime,
-            ...(choice.description ? { description: choice.description } : {}),
-          })),
+          options: runtimeChoices.map((choice) => {
+            const option: APISelectMenuOption = {
+              label: choice.label,
+              value: choice.id,
+              default: choice.id === selectedRuntime,
+            };
+            if (choice.description) {
+              option.description = choice.description;
+            }
+            return option;
+          }),
           placeholder: "Select runtime",
         }),
       ]),


### PR DESCRIPTION
## Summary
- Replace the Discord model-picker runtime-option spread-in-map with a direct option object assignment.
- Keep the rendered select option shape unchanged while satisfying the new oxlint no-map-spread rule.

## Verification
- node scripts/run-bundled-extension-oxlint.mjs
- node scripts/run-vitest.mjs extensions/discord/src/monitor/model-picker.test.ts
- git diff --check origin/main...HEAD

## Real behavior proof
Behavior addressed: the bundled extension lint shard failed on current main with oxc(no-map-spread) in extensions/discord/src/monitor/model-picker.view.ts when checking the real Discord extension source.
Real environment tested: local OpenClaw checkout at fix/discord-model-picker-map-spread with repo dependencies installed via pnpm install.
Exact steps or command run after this patch: ran node scripts/run-bundled-extension-oxlint.mjs, node scripts/run-vitest.mjs extensions/discord/src/monitor/model-picker.test.ts, and git diff --check origin/main...HEAD.
Evidence after fix: copied terminal output from the local OpenClaw checkout:
```text
$ node scripts/run-bundled-extension-oxlint.mjs
Found 0 warnings and 0 errors.
Finished in 12.4s on 5357 files with 216 rules using 1 threads.

$ node scripts/run-vitest.mjs extensions/discord/src/monitor/model-picker.test.ts
Test Files  1 passed (1)
Tests  28 passed (28)
```
Observed result after fix: the runtime select options are built with the same label/value/default fields, optional descriptions are still present when provided, and the bundled-extension lint shard no longer rejects the Discord model picker source.
What was not tested: full CI; it is still running on the PR.
