### PR TITLE
fix(feishu): restore visible replies for text commands in DMs

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -162,12 +162,6 @@ function buildDefaultResolveRoute(): ResolvedAgentRoute {
   };
 }
 
-function _createUnboundConfiguredRoute(
-  route: NonNullable<ConfiguredBindingRoute>["route"],
-): ConfiguredBindingRoute {
-  return { bindingResolution: null, route };
-}
-
 function createFeishuBotRuntime(overrides: DeepPartial<PluginRuntime> = {}): PluginRuntime {
   return {
     channel: {

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -186,6 +186,7 @@ function createFeishuBotRuntime(overrides: DeepPartial<PluginRuntime> = {}): Plu
       },
       commands: {
         shouldComputeCommandAuthorized: vi.fn(() => false),
+        isControlCommandMessage: vi.fn(() => false),
         resolveCommandAuthorizedFromAuthorizers: vi.fn(() => false),
       },
       pairing: {
@@ -607,6 +608,7 @@ describe("handleFeishuMessage command authorization", () => {
   );
   const mockResolveCommandAuthorizedFromAuthorizers = vi.fn(() => false);
   const mockShouldComputeCommandAuthorized = vi.fn(() => true);
+  const mockIsControlCommandMessage = vi.fn(() => false);
   const mockReadAllowFromStore = vi.fn().mockResolvedValue([]);
   const mockUpsertPairingRequest = vi.fn().mockResolvedValue({ code: "ABCDEFGH", created: false });
   const mockBuildPairingReply = vi.fn(() => "Pairing response");
@@ -621,6 +623,7 @@ describe("handleFeishuMessage command authorization", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockShouldComputeCommandAuthorized.mockReset().mockReturnValue(true);
+    mockIsControlCommandMessage.mockReset().mockReturnValue(false);
     mockGetMessageFeishu.mockReset().mockResolvedValue(null);
     mockListFeishuThreadMessages.mockReset().mockResolvedValue([]);
     mockReadSessionUpdatedAt.mockReturnValue(undefined);
@@ -665,6 +668,7 @@ describe("handleFeishuMessage command authorization", () => {
           },
           commands: {
             shouldComputeCommandAuthorized: mockShouldComputeCommandAuthorized,
+            isControlCommandMessage: mockIsControlCommandMessage,
             resolveCommandAuthorizedFromAuthorizers: mockResolveCommandAuthorizedFromAuthorizers,
           },
           pairing: {
@@ -1059,6 +1063,7 @@ describe("handleFeishuMessage command authorization", () => {
 
   it("computes group command authorization from group allowFrom", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(true);
+    mockIsControlCommandMessage.mockReturnValue(true);
     mockResolveCommandAuthorizedFromAuthorizers.mockReturnValue(false);
 
     const cfg: ClawdbotConfig = {
@@ -1142,6 +1147,7 @@ describe("handleFeishuMessage command authorization", () => {
 
   it("falls back to top-level allowFrom for group command authorization", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(true);
+    mockIsControlCommandMessage.mockReturnValue(true);
     mockResolveCommandAuthorizedFromAuthorizers.mockReturnValue(true);
 
     const cfg: ClawdbotConfig = {
@@ -1186,6 +1192,47 @@ describe("handleFeishuMessage command authorization", () => {
     expect(context.CommandAuthorized).toBe(true);
     expect(context.CommandSource).toBe("text");
     expect(context.SenderId).toBe("ou-admin");
+  });
+
+  it("does not mark inline slash-like text as a text command source", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(true);
+    mockIsControlCommandMessage.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          dmPolicy: "open",
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-inline-false-positive",
+        },
+      },
+      message: {
+        message_id: "msg-inline-false-positive",
+        chat_id: "oc-dm",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "hey /status" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    const context = mockCallArg<{
+      ChatType?: string;
+      CommandAuthorized?: boolean;
+      CommandSource?: string;
+      SenderId?: string;
+    }>(mockFinalizeInboundContext, 0, 0);
+    expect(context.ChatType).toBe("direct");
+    expect(context.CommandAuthorized).toBe(true);
+    expect(context.CommandSource).toBeUndefined();
+    expect(context.SenderId).toBe("ou-inline-false-positive");
   });
 
   it("allows group sender when global groupSenderAllowFrom includes sender", async () => {

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1101,10 +1101,12 @@ describe("handleFeishuMessage command authorization", () => {
     const context = mockCallArg<{
       ChatType?: string;
       CommandAuthorized?: boolean;
+      CommandSource?: string;
       SenderId?: string;
     }>(mockFinalizeInboundContext, 0, 0);
     expect(context.ChatType).toBe("group");
     expect(context.CommandAuthorized).toBe(false);
+    expect(context.CommandSource).toBe("text");
     expect(context.SenderId).toBe("ou-attacker");
   });
 
@@ -1183,10 +1185,12 @@ describe("handleFeishuMessage command authorization", () => {
     const context = mockCallArg<{
       ChatType?: string;
       CommandAuthorized?: boolean;
+      CommandSource?: string;
       SenderId?: string;
     }>(mockFinalizeInboundContext, 0, 0);
     expect(context.ChatType).toBe("group");
     expect(context.CommandAuthorized).toBe(true);
+    expect(context.CommandSource).toBe("text");
     expect(context.SenderId).toBe("ou-admin");
   });
 

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1297,6 +1297,7 @@ export async function handleFeishuMessage(params: {
         Timestamp: messageCreateTimeMs,
         WasMentioned: wasMentioned,
         CommandAuthorized: commandAuthorized,
+        ...(shouldComputeCommandAuthorized ? { CommandSource: "text" as const } : {}),
         OriginatingChannel: "feishu" as const,
         OriginatingTo: feishuTo,
         GroupSystemPrompt: isGroup ? normalizeOptionalString(groupConfig?.systemPrompt) : undefined,

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -705,6 +705,10 @@ export async function handleFeishuMessage(params: {
       commandProbeBody,
       cfg,
     );
+    const isExplicitTextCommand = core.channel.commands.isControlCommandMessage(
+      commandProbeBody,
+      cfg,
+    );
     const dmIngress = isDirect
       ? await resolveFeishuDmIngressAccess({
           cfg,
@@ -953,6 +957,10 @@ export async function handleFeishuMessage(params: {
       audioTranscript === undefined
         ? shouldComputeCommandAuthorized
         : core.channel.commands.shouldComputeCommandAuthorized(effectiveCommandProbeBody, cfg);
+    const isEffectiveExplicitTextCommand =
+      audioTranscript === undefined
+        ? isExplicitTextCommand
+        : core.channel.commands.isControlCommandMessage(effectiveCommandProbeBody, cfg);
     const commandAuthorized = shouldComputeEffectiveCommandAuthorized
       ? isDirect && audioTranscript === undefined && dmIngress
         ? dmIngress.commandAccess.authorized
@@ -1297,7 +1305,7 @@ export async function handleFeishuMessage(params: {
         Timestamp: messageCreateTimeMs,
         WasMentioned: wasMentioned,
         CommandAuthorized: commandAuthorized,
-        ...(shouldComputeCommandAuthorized ? { CommandSource: "text" as const } : {}),
+        ...(isEffectiveExplicitTextCommand ? { CommandSource: "text" as const } : {}),
         OriginatingChannel: "feishu" as const,
         OriginatingTo: feishuTo,
         GroupSystemPrompt: isGroup ? normalizeOptionalString(groupConfig?.systemPrompt) : undefined,


### PR DESCRIPTION
## Summary

- Problem: Feishu DM text commands such as `/models` were processed after the upgrade but produced no visible reply.
- Why it matters: command turns silently looked broken in Feishu even when the gateway received and handled them.
- What changed: mark Feishu text-command turns with `CommandSource: "text"` so reply delivery treats them as explicit commands instead of suppressing them under tool-only direct-chat defaults.
- What did NOT change (scope boundary): this does not change Feishu message delivery defaults for ordinary chat turns or any non-Feishu channel behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Feishu DM text commands such as `/models` were received and processed after the upgrade but produced no visible reply because delivery was suppressed under `message_tool_only`.
- Real environment tested: macOS local managed OpenClaw 2026.5.12 gateway with the installed `@openclaw/feishu` plugin, a real Feishu DM, and `messages.visibleReplies` removed from config.
- Exact steps or command run after this patch:
  1. Run `openclaw config unset messages.visibleReplies` so the workaround is removed.
  2. Restart the local gateway.
  3. Send `/models` to the bot in a real Feishu DM.
  4. Inspect the local gateway log for the inbound DM and the outbound Feishu dispatch.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
  - `openclaw config get messages.visibleReplies` now returns `Config path not found: messages.visibleReplies`, confirming the workaround is gone.
  - After-fix live Feishu log:
    - `2026-05-16T21:43:47.410+08:00 feishu[default]: Feishu[default] DM from <redacted-open-id>: /models`
    - `2026-05-16T21:43:58.820+08:00 message processed: channel=feishu ... outcome=completed duration=11389ms`
    - `2026-05-16T21:43:59.376+08:00 feishu[default]: dispatch complete (queuedFinal=true, replies=1)`
  - Local targeted verification after the patch:
    - `node scripts/run-vitest.mjs extensions/feishu/src/bot.test.ts` -> 1 file passed, 63 tests passed
    - `node scripts/run-vitest.mjs src/auto-reply/reply/source-reply-delivery-mode.test.ts src/auto-reply/command-turn-context.test.ts` -> 2 files passed, 27 tests passed
- Observed result after fix: `/models` produced a visible reply in the real Feishu DM, and the gateway logged a completed Feishu dispatch with `replies=1` instead of suppressing the source reply.
- What was not tested: Feishu group chats, inline false-positive text such as `hey /status`, and non-command turns under the same delivery mode.
- Before evidence (optional but encouraged): before the patch, the same real Feishu DM flow logged `Delivery suppressed by sourceReplyDeliveryMode: message_tool_only` immediately after receiving `/models`.

## Root Cause (if applicable)

- Root cause: the Feishu channel passed `CommandAuthorized` for text slash commands but did not set `CommandSource: "text"`, so Codex direct-chat delivery defaults treated those turns like ordinary chat turns and suppressed the automatic source reply under `message_tool_only`.
- Missing detection / guardrail: Feishu command-authorization tests did not assert the command source metadata required by reply delivery.
- Contributing context (if known): newer Codex direct-chat delivery defaults rely on explicit command metadata to bypass tool-only visible-reply suppression.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/feishu/src/bot.test.ts`
- Scenario the test should lock in: Feishu text command turns populate `CommandSource: "text"` alongside the existing authorization metadata for both denied and allowed command paths.
- Why this is the smallest reliable guardrail: the regression sits at the Feishu-to-reply-dispatch seam, and the channel tests already validate the finalized inbound context built for dispatch.
- Existing test that already covers this (if any): existing Feishu command-authorization tests in `extensions/feishu/src/bot.test.ts`
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Feishu DM text commands such as `/models` and `/status` produce visible replies again when they are authorized and handled.

## Diagram (if applicable)

```text
Before:
Feishu DM "/models" -> command handled -> treated like ordinary direct-chat turn -> visible reply suppressed

After:
Feishu DM "/models" -> CommandSource="text" -> explicit command delivery path -> visible reply sent
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local gateway install
- Model/provider: Codex runtime with `openai/gpt-5.4`
- Integration/channel (if any): Feishu DM
- Relevant config (redacted): Feishu enabled with DM allowlist; direct-chat visible replies were using the newer tool-only default path

### Steps

1. Send `/models` to OpenClaw in a Feishu DM.
2. Observe the gateway receive and dispatch the message.
3. Check whether Feishu receives a visible command reply.

### Expected

- Authorized Feishu text commands reply visibly in the DM.

### Actual

- Before the fix, the gateway handled the command but emitted `Delivery suppressed by sourceReplyDeliveryMode: message_tool_only`, so Feishu showed no reply.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: traced a real Feishu DM after the patch with `messages.visibleReplies` removed, confirmed `/models` produced a visible reply, and confirmed the gateway emitted `dispatch complete (queuedFinal=true, replies=1)` instead of the earlier suppression log.
- Edge cases checked: the Feishu command-authorization test coverage that now asserts command metadata in the denied group path, allowed group path, and top-level DM command path; plus targeted reply-delivery and command-turn-context tests.
- What you did **not** verify: Feishu group delivery behavior, inline slash-like false positives, and non-command DM turns in a live environment.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: Feishu could mark non-command turns as command-originated if the guard is too broad.
  - Mitigation: the new field is only attached when the channel already decided the body should go through command-authorization probing.

