### PR TITLE
fix(agents): fall back to PI when Codex harness is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 - CLI/context engines: bootstrap and finalize non-legacy context engines for CLI turns while preserving transcript snapshots and deferred maintenance ownership. (#81869) Thanks @sahilsatralkar.
 - Telegram: persist polling updates through restart replay so queued same-topic messages resume in order instead of losing context after a gateway restart. (#82256) Thanks @VACInc.
 - Gateway/Gmail: abort in-flight Gmail watcher startup and hot-reload restarts before shutdown so reloads cannot spawn `gog serve` after the Gateway is closing. Thanks @frankekn.
+- Agents/Codex: fall back to the embedded PI runner when OpenAI's implicit Codex harness preference cannot find a registered Codex plugin, preventing OpenAI-compatible gateway requests from failing with an unregistered harness error. Fixes #82437.
 - MCP plugin tools: forward host MCP `tools/call` `AbortSignal` through `createPluginToolsMcpHandlers().callTool` into plugin `tool.execute`, so host cancellation actually cancels in-flight plugin tool calls instead of letting them run to completion. Fixes #82424. (#82443) Thanks @joshavant.
 - Plugins: accept `api.on("deactivate")` as a compatibility alias for `gateway_stop`, so external plugin cleanup handlers run on Gateway shutdown instead of being ignored as unknown hooks.
 - Media: ignore image MIME and filename hints when bytes sniff as generic containers, so zip/octet-stream payloads mislabeled as images do not become local image media or keep image file extensions when staged.

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -47,6 +47,7 @@ import {
   resolveAgentSkillsFilter,
   resolveAgentWorkspaceDir,
 } from "./agent-scope.js";
+import { isStoredCredentialCompatibleWithAuthProvider } from "./auth-profiles/order.js";
 import { clearSessionAuthProfileOverride } from "./auth-profiles/session-override.js";
 import { ensureAuthProfileStore } from "./auth-profiles/store.js";
 import {
@@ -61,7 +62,7 @@ import type { AgentCommandIngressOpts, AgentCommandOpts } from "./command/types.
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
 import { resolveFastModeState } from "./fast-mode.js";
 import { ensureSelectedAgentHarnessPlugin } from "./harness/runtime-plugin.js";
-import { resolveAgentHarnessPolicy } from "./harness/selection.js";
+import { resolveAvailableAgentHarnessPolicy } from "./harness/selection.js";
 import { AGENT_LANE_SUBAGENT } from "./lanes.js";
 import { LiveSessionModelSwitchError } from "./live-model-switch.js";
 import { loadManifestModelCatalog } from "./model-catalog.js";
@@ -867,6 +868,15 @@ async function agentCommandInternal(
     model = allowedInitialSelection.model;
     providerForAuthProfileValidation = provider;
 
+    await ensureSelectedAgentHarnessPlugin({
+      config: cfg,
+      provider,
+      modelId: model,
+      agentId: sessionAgentId,
+      sessionKey,
+      workspaceDir,
+    });
+
     let sessionEntryForAttempt = sessionEntry;
     if (sessionEntry) {
       const authProfileId = sessionEntry.authProfileOverride;
@@ -874,10 +884,7 @@ async function agentCommandInternal(
         const entry = sessionEntry;
         const store = ensureAuthProfileStore();
         const profile = store.profiles[authProfileId];
-        const profileAuthProvider = profile
-          ? resolveProviderIdForAuth(profile.provider, { config: cfg, workspaceDir })
-          : undefined;
-        const validationHarnessPolicy = resolveAgentHarnessPolicy({
+        const validationHarnessPolicy = resolveAvailableAgentHarnessPolicy({
           provider: providerForAuthProfileValidation,
           modelId: model,
           config: cfg,
@@ -890,7 +897,16 @@ async function agentCommandInternal(
         }).map((candidateProvider) =>
           resolveProviderIdForAuth(candidateProvider, { config: cfg, workspaceDir }),
         );
-        if (!profile || !acceptedAuthProviders.includes(profileAuthProvider ?? "")) {
+        const profileMatchesRuntime =
+          profile &&
+          acceptedAuthProviders.some((candidateProvider) =>
+            isStoredCredentialCompatibleWithAuthProvider({
+              cfg,
+              provider: candidateProvider,
+              credential: profile,
+            }),
+          );
+        if (!profileMatchesRuntime) {
           if (hasExplicitRunOverride) {
             sessionEntryForAttempt = {
               ...entry,
@@ -966,14 +982,6 @@ async function agentCommandInternal(
         }
       }
     }
-    await ensureSelectedAgentHarnessPlugin({
-      config: cfg,
-      provider,
-      modelId: model,
-      agentId: sessionAgentId,
-      sessionKey,
-      workspaceDir,
-    });
     const { resolveSessionTranscriptFile } = await loadTranscriptResolveRuntime();
     let sessionFile: string | undefined;
     if (sessionStore && sessionKey) {

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -17,7 +17,7 @@ import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { resolveAgentWorkspaceDir, resolveSessionAgentId } from "./agent-scope.js";
 import { resolveSessionAuthProfileOverride } from "./auth-profiles/session-override.js";
 import { readBtwTranscriptMessages, resolveBtwSessionTranscriptPath } from "./btw-transcript.js";
-import { resolveAgentHarnessPolicy, selectAgentHarness } from "./harness/selection.js";
+import { resolveAvailableAgentHarnessPolicy, selectAgentHarness } from "./harness/selection.js";
 import {
   resolveImageSanitizationLimits,
   type ImageSanitizationLimits,
@@ -249,7 +249,7 @@ async function resolveRuntimeModel(params: {
     provider: params.provider,
     acceptedProviderIds: listOpenAIAuthProfileProvidersForAgentRuntime({
       provider: params.provider,
-      harnessRuntime: resolveAgentHarnessPolicy({
+      harnessRuntime: resolveAvailableAgentHarnessPolicy({
         provider: params.provider,
         modelId: params.model,
         config: params.cfg,

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -913,6 +913,88 @@ describe("CLI attempt execution", () => {
     });
   });
 
+  it("forwards user-pinned OpenAI API-key backup profiles to Codex harness runs", async () => {
+    const { clearAgentHarnesses, registerAgentHarness } = await import("../harness/registry.js");
+    const sessionKey = "agent:main:direct:openai-codex-api-key";
+    const sessionEntry: SessionEntry = {
+      sessionId: "openclaw-session-openai-codex-api-key",
+      updatedAt: Date.now(),
+      authProfileOverride: "openai:backup",
+      authProfileOverrideSource: "user",
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
+    await fs.writeFile(
+      path.join(tmpDir, "auth-profiles.json"),
+      JSON.stringify(
+        {
+          version: 1,
+          profiles: {
+            "openai:backup": {
+              type: "api_key",
+              provider: "openai",
+              key: "sk-test",
+            },
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    clearAgentHarnesses();
+    registerAgentHarness({
+      id: "codex",
+      label: "Codex",
+      supports: () => ({ supported: true, priority: 100 }),
+      runAttempt: vi.fn(),
+    });
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      meta: { durationMs: 1 },
+    } satisfies EmbeddedPiRunResult);
+
+    try {
+      await runAgentAttempt({
+        providerOverride: "openai",
+        originalProvider: "openai",
+        modelOverride: "gpt-5.4",
+        cfg: {} as OpenClawConfig,
+        sessionEntry,
+        sessionId: sessionEntry.sessionId,
+        sessionKey,
+        sessionAgentId: "main",
+        sessionFile: path.join(tmpDir, "session.jsonl"),
+        workspaceDir: tmpDir,
+        body: "use backup auth",
+        isFallbackRetry: false,
+        resolvedThinkLevel: "medium",
+        timeoutMs: 1_000,
+        runId: "run-openai-codex-api-key-backup",
+        opts: { senderIsOwner: false } as Parameters<typeof runAgentAttempt>[0]["opts"],
+        runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
+        spawnedBy: undefined,
+        messageChannel: undefined,
+        skillsSnapshot: undefined,
+        resolvedVerboseLevel: undefined,
+        agentDir: tmpDir,
+        onAgentEvent: vi.fn(),
+        authProfileProvider: "openai",
+        sessionStore,
+        storePath,
+        sessionHasHistory: false,
+      });
+    } finally {
+      clearAgentHarnesses();
+    }
+
+    expectMockArgFields(runEmbeddedPiAgentMock, {
+      provider: "openai",
+      model: "gpt-5.4",
+      authProfileId: "openai:backup",
+      authProfileIdSource: "user",
+    });
+  });
+
   it("keeps one-shot model runs on the raw embedded provider path", async () => {
     const sessionKey = "agent:main:direct:model-run-raw";
     const sessionEntry: SessionEntry = {
@@ -1283,6 +1365,7 @@ describe("embedded attempt harness pinning", () => {
   });
 
   it("auto-forwards OpenAI Codex auth profiles to default Codex harness runs", async () => {
+    const { clearAgentHarnesses, registerAgentHarness } = await import("../harness/registry.js");
     const sessionEntry: SessionEntry = {
       sessionId: "codex-auth-session",
       updatedAt: Date.now(),
@@ -1305,34 +1388,45 @@ describe("embedded attempt harness pinning", () => {
     runEmbeddedPiAgentMock.mockResolvedValueOnce({
       meta: { durationMs: 1 },
     } satisfies EmbeddedPiRunResult);
-
-    await runAgentAttempt({
-      providerOverride: "openai",
-      originalProvider: "openai",
-      modelOverride: "gpt-5.4",
-      cfg: {} as OpenClawConfig,
-      sessionEntry,
-      sessionId: sessionEntry.sessionId,
-      sessionKey: "agent:main:main",
-      sessionAgentId: "main",
-      sessionFile: path.join(tmpDir, "session.jsonl"),
-      workspaceDir: tmpDir,
-      body: "continue",
-      isFallbackRetry: false,
-      resolvedThinkLevel: "medium",
-      timeoutMs: 1_000,
-      runId: "run-codex-auto-auth-profile",
-      opts: { senderIsOwner: false } as Parameters<typeof runAgentAttempt>[0]["opts"],
-      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
-      spawnedBy: undefined,
-      messageChannel: undefined,
-      skillsSnapshot: undefined,
-      resolvedVerboseLevel: undefined,
-      agentDir: tmpDir,
-      onAgentEvent: vi.fn(),
-      authProfileProvider: "openai",
-      sessionHasHistory: true,
+    clearAgentHarnesses();
+    registerAgentHarness({
+      id: "codex",
+      label: "Codex",
+      supports: () => ({ supported: true, priority: 100 }),
+      runAttempt: vi.fn(),
     });
+
+    try {
+      await runAgentAttempt({
+        providerOverride: "openai",
+        originalProvider: "openai",
+        modelOverride: "gpt-5.4",
+        cfg: {} as OpenClawConfig,
+        sessionEntry,
+        sessionId: sessionEntry.sessionId,
+        sessionKey: "agent:main:main",
+        sessionAgentId: "main",
+        sessionFile: path.join(tmpDir, "session.jsonl"),
+        workspaceDir: tmpDir,
+        body: "continue",
+        isFallbackRetry: false,
+        resolvedThinkLevel: "medium",
+        timeoutMs: 1_000,
+        runId: "run-codex-auto-auth-profile",
+        opts: { senderIsOwner: false } as Parameters<typeof runAgentAttempt>[0]["opts"],
+        runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
+        spawnedBy: undefined,
+        messageChannel: undefined,
+        skillsSnapshot: undefined,
+        resolvedVerboseLevel: undefined,
+        agentDir: tmpDir,
+        onAgentEvent: vi.fn(),
+        authProfileProvider: "openai",
+        sessionHasHistory: true,
+      });
+    } finally {
+      clearAgentHarnesses();
+    }
 
     expectMockArgFields(runEmbeddedPiAgentMock, {
       agentHarnessId: undefined,

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -21,7 +21,7 @@ import { resolveBootstrapWarningSignaturesSeen } from "../bootstrap-budget.js";
 import { runCliAgent } from "../cli-runner.js";
 import { getCliSessionBinding, setCliSessionBinding } from "../cli-session.js";
 import { FailoverError } from "../failover-error.js";
-import { resolveAgentHarnessPolicy } from "../harness/selection.js";
+import { resolveAvailableAgentHarnessPolicy } from "../harness/selection.js";
 import { resolveCliRuntimeExecutionProvider } from "../model-runtime-aliases.js";
 import { isCliProvider } from "../model-selection.js";
 import { resolveOpenAIRuntimeProviderForPi } from "../openai-codex-routing.js";
@@ -103,19 +103,21 @@ type HarnessAuthProfileSelection = {
   authProfileId?: string;
   authProfileIdSource?: "auto" | "user";
   authProfileProvider: string;
+  authProfileMode?: string;
 };
 
-function resolveProfileProviderFromStore(params: {
-  agentDir: string;
-  profileId: string | undefined;
-}): string | undefined {
+function resolveProfileAuthFromStore(params: { agentDir: string; profileId: string | undefined }): {
+  provider?: string;
+  mode?: string;
+} {
   const profileId = params.profileId?.trim();
   if (!profileId) {
-    return undefined;
+    return {};
   }
-  return ensureAuthProfileStore(params.agentDir, {
+  const credential = ensureAuthProfileStore(params.agentDir, {
     allowKeychainPrompt: false,
-  }).profiles[profileId]?.provider;
+  }).profiles[profileId];
+  return { provider: credential?.provider, mode: credential?.type };
 }
 
 function resolveHarnessAuthProfileSelection(params: {
@@ -132,14 +134,15 @@ function resolveHarnessAuthProfileSelection(params: {
 }): HarnessAuthProfileSelection {
   const sessionAuthProfileId = params.sessionAuthProfileId?.trim();
   if (sessionAuthProfileId) {
+    const profileAuth = resolveProfileAuthFromStore({
+      agentDir: params.agentDir,
+      profileId: sessionAuthProfileId,
+    });
     return {
       authProfileId: sessionAuthProfileId,
       authProfileIdSource: params.sessionAuthProfileSource,
-      authProfileProvider:
-        resolveProfileProviderFromStore({
-          agentDir: params.agentDir,
-          profileId: sessionAuthProfileId,
-        }) ?? params.authProfileProvider,
+      authProfileProvider: profileAuth.provider ?? params.authProfileProvider,
+      authProfileMode: profileAuth.mode,
     };
   }
 
@@ -420,7 +423,7 @@ export function runAgentAttempt(params: {
       }) ?? params.providerOverride);
   const agentHarnessPolicy = isRawModelRun
     ? ({ runtime: "pi" } as const)
-    : resolveAgentHarnessPolicy({
+    : resolveAvailableAgentHarnessPolicy({
         provider: params.providerOverride,
         modelId: params.modelOverride,
         config: params.cfg,
@@ -442,6 +445,7 @@ export function runAgentAttempt(params: {
   const runtimeAuthPlan = buildAgentRuntimeAuthPlan({
     provider: params.providerOverride,
     authProfileProvider: harnessAuthSelection.authProfileProvider,
+    authProfileMode: harnessAuthSelection.authProfileMode,
     sessionAuthProfileId: harnessAuthSelection.authProfileId,
     config: params.cfg,
     workspaceDir: params.workspaceDir,

--- a/src/agents/harness/runtime-plugin.test.ts
+++ b/src/agents/harness/runtime-plugin.test.ts
@@ -45,6 +45,32 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
     );
   });
 
+  it("tries to load Codex for the implicit official OpenAI runtime before selection", async () => {
+    await ensureSelectedAgentHarnessPlugin({
+      provider: "openai",
+      modelId: "gpt-5.5",
+      config: {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              models: [],
+            },
+          },
+        },
+      } as OpenClawConfig,
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(mocks.ensurePluginRegistryLoaded).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: "all",
+        workspaceDir: "/tmp/workspace",
+        onlyPluginIds: ["codex"],
+      }),
+    );
+  });
+
   it("keeps custom OpenAI-compatible providers on Pi when no runtime override is set", async () => {
     await ensureSelectedAgentHarnessPlugin({
       provider: "openai",

--- a/src/agents/harness/runtime-plugin.ts
+++ b/src/agents/harness/runtime-plugin.ts
@@ -1,6 +1,6 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { withActivatedPluginIds } from "../../plugins/activation-context.js";
-import { resolveAgentHarnessPolicy } from "./selection.js";
+import { resolveAgentHarnessPolicy } from "./policy.js";
 
 export async function ensureSelectedAgentHarnessPlugin(params: {
   provider: string;

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -210,6 +210,17 @@ describe("runAgentHarnessAttempt", () => {
     expect(piRunAttempt).not.toHaveBeenCalled();
   });
 
+  it("falls back to PI when the implicit OpenAI Codex harness is unavailable", async () => {
+    const result = await runAgentHarnessAttempt({
+      ...createAttemptParams(),
+      provider: "openai",
+      modelId: "gpt-5.4",
+    });
+
+    expect(result.sessionIdUsed).toBe("pi");
+    expect(piRunAttempt).toHaveBeenCalledTimes(1);
+  });
+
   it("honors explicit PI runtime for OpenAI agent model runs", async () => {
     const result = await runAgentHarnessAttempt({
       ...createAttemptParams(providerRuntimeConfig("openai", "pi")),
@@ -400,6 +411,10 @@ describe("selectAgentHarness", () => {
     expect(selectAgentHarness({ provider: "anthropic", modelId: "sonnet-4.6", config }).id).toBe(
       "pi",
     );
+  });
+
+  it("selects PI when the implicit OpenAI Codex harness is unavailable", () => {
+    expect(selectAgentHarness({ provider: "openai", modelId: "gpt-5.4" }).id).toBe("pi");
   });
 
   it("ignores legacy agentRuntime as a runtime policy source", () => {

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -8,6 +8,8 @@ import type {
 import { clearAgentHarnesses, registerAgentHarness } from "./registry.js";
 import {
   maybeCompactAgentHarnessSession,
+  resolveAvailableAgentHarnessPolicy,
+  resolveAgentHarnessPolicy,
   runAgentHarnessAttempt,
   selectAgentHarness,
 } from "./selection.js";
@@ -201,6 +203,11 @@ describe("runAgentHarnessAttempt", () => {
   it("uses the Codex harness by default for OpenAI agent model runs", async () => {
     registerSuccessfulCodexHarness();
 
+    expect(resolveAgentHarnessPolicy({ provider: "openai", modelId: "gpt-5.4" })).toEqual({
+      runtime: "codex",
+      runtimeSource: "implicit",
+    });
+
     const result = await runAgentHarnessAttempt({
       ...createAttemptParams(),
       provider: "openai",
@@ -211,6 +218,15 @@ describe("runAgentHarnessAttempt", () => {
   });
 
   it("falls back to PI when the implicit OpenAI Codex harness is unavailable", async () => {
+    expect(resolveAgentHarnessPolicy({ provider: "openai", modelId: "gpt-5.4" })).toEqual({
+      runtime: "codex",
+      runtimeSource: "implicit",
+    });
+    expect(resolveAvailableAgentHarnessPolicy({ provider: "openai", modelId: "gpt-5.4" })).toEqual({
+      runtime: "pi",
+      runtimeSource: "implicit",
+    });
+
     const result = await runAgentHarnessAttempt({
       ...createAttemptParams(),
       provider: "openai",

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -8,13 +8,16 @@ import type {
 } from "../pi-embedded-runner/run/types.js";
 import type { EmbeddedPiCompactResult } from "../pi-embedded-runner/types.js";
 import { createPiAgentHarness } from "./builtin-pi.js";
-import { resolveAgentHarnessPolicy, type AgentHarnessPolicy } from "./policy.js";
-import { listRegisteredAgentHarnesses } from "./registry.js";
+import {
+  resolveAgentHarnessPolicy as resolveConfiguredAgentHarnessPolicy,
+  type AgentHarnessPolicy,
+} from "./policy.js";
+import { getRegisteredAgentHarness, listRegisteredAgentHarnesses } from "./registry.js";
 import type { AgentHarness, AgentHarnessSupport } from "./types.js";
 import { adaptAgentHarnessToV2, runAgentHarnessV2LifecycleAttempt } from "./v2.js";
 
 const log = createSubsystemLogger("agents/harness");
-export { resolveAgentHarnessPolicy };
+export { resolveAgentHarnessPolicy } from "./policy.js";
 export type { AgentHarnessPolicy };
 
 type AgentHarnessSelectionCandidate = {
@@ -44,6 +47,31 @@ type AgentHarnessSelectionDecision = {
 
 function listPluginAgentHarnesses(): AgentHarness[] {
   return listRegisteredAgentHarnesses().map((entry) => entry.harness);
+}
+
+export function resolveAvailableAgentHarnessPolicy(params: {
+  provider?: string;
+  modelId?: string;
+  config?: OpenClawConfig;
+  agentId?: string;
+  sessionKey?: string;
+  env?: NodeJS.ProcessEnv;
+}): AgentHarnessPolicy {
+  return applyAgentHarnessAvailabilityPolicy(resolveConfiguredAgentHarnessPolicy(params));
+}
+
+function applyAgentHarnessAvailabilityPolicy(policy: AgentHarnessPolicy): AgentHarnessPolicy {
+  if (
+    policy.runtime === "codex" &&
+    policy.runtimeSource === "implicit" &&
+    !getRegisteredAgentHarness("codex")
+  ) {
+    return {
+      ...policy,
+      runtime: "pi",
+    };
+  }
+  return policy;
 }
 
 function compareHarnessSupport(
@@ -78,7 +106,7 @@ function selectAgentHarnessDecision(params: {
   agentHarnessId?: string;
   agentHarnessRuntimeOverride?: string;
 }): AgentHarnessSelectionDecision {
-  const resolvedPolicy = resolveAgentHarnessPolicy(params);
+  const resolvedPolicy = resolveConfiguredAgentHarnessPolicy(params);
   const runtimeOverride = params.agentHarnessRuntimeOverride?.trim();
   const policy =
     runtimeOverride && runtimeOverride !== "auto" && runtimeOverride !== "default"
@@ -114,7 +142,10 @@ function selectAgentHarnessDecision(params: {
     if (runtime === "codex" && policy.runtimeSource === "implicit") {
       return buildSelectionDecision({
         harness: piHarness,
-        policy,
+        policy: {
+          ...policy,
+          runtime: "pi",
+        },
         selectedReason: "implicit_plugin_unavailable_pi",
         candidates: listHarnessCandidates(pluginHarnesses),
       });

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -33,6 +33,8 @@ type AgentHarnessSelectionDecision = {
   selectedReason:
     | "forced_pi"
     | "forced_plugin"
+    // Implicit Codex preference found no registered Codex harness, so PI handled the run.
+    | "implicit_plugin_unavailable_pi"
     // Auto mode chose a registered plugin harness that supports the provider/model.
     | "auto_plugin"
     // Auto mode found no supporting plugin harness, so PI handled the run.
@@ -106,6 +108,14 @@ function selectAgentHarnessDecision(params: {
         harness: forced,
         policy,
         selectedReason: "forced_plugin",
+        candidates: listHarnessCandidates(pluginHarnesses),
+      });
+    }
+    if (runtime === "codex" && policy.runtimeSource === "implicit") {
+      return buildSelectionDecision({
+        harness: piHarness,
+        policy,
+        selectedReason: "implicit_plugin_unavailable_pi",
         candidates: listHarnessCandidates(pluginHarnesses),
       });
     }

--- a/src/agents/openai-codex-routing.test.ts
+++ b/src/agents/openai-codex-routing.test.ts
@@ -51,7 +51,7 @@ describe("OpenAI Codex routing policy", () => {
     ).toBe("openai-codex");
   });
 
-  it("ignores session PI pins when validating OpenAI auth profiles", () => {
+  it("validates Codex harness auth through the Codex provider contract", () => {
     expect(
       listOpenAIAuthProfileProvidersForAgentRuntime({
         provider: "openai",


### PR DESCRIPTION
Summary
- Fall back to the embedded PI harness when OpenAI's implicit Codex runtime preference cannot find a registered Codex harness.
- Keep raw harness policy resolution independent from plugin registration so Codex plugin discovery can still run before selection.
- Keep auth-profile validation/runtime forwarding aligned for Codex runs, including OpenAI API-key backup profiles.
- Add regression coverage for the fallback, pre-selection Codex plugin load, and Codex auth-profile forwarding.

Fixes #82437

Verification
- `git diff --check`
- `node scripts/run-vitest.mjs src/agents/command/attempt-execution.cli.test.ts src/agents/openai-codex-routing.test.ts src/agents/runtime-plan/build.test.ts src/agents/auth-profiles/session-override.test.ts src/agents/harness/selection.test.ts src/agents/harness/runtime-plugin.test.ts src/agents/auth-profile-runtime-contract.test.ts` - 13 files, 182 tests passed
- `pnpm check:changed` via Testbox `tbx_01krr5kvqe3ww5c76fstke63bf` - passed
- `/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review` - clean, no accepted/actionable findings

Behavior addressed: `/v1/chat/completions` requests using the default OpenAI agent model no longer fail just because the implicit Codex harness preference cannot find the Codex plugin/harness.
Real environment tested: local focused Vitest plus Blacksmith Testbox changed-files gate on the rebased PR branch.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/command/attempt-execution.cli.test.ts src/agents/openai-codex-routing.test.ts src/agents/runtime-plan/build.test.ts src/agents/auth-profiles/session-override.test.ts src/agents/harness/selection.test.ts src/agents/harness/runtime-plugin.test.ts src/agents/auth-profile-runtime-contract.test.ts`; `pnpm check:changed`.
Evidence after fix: selection tests cover OpenAI implicit Codex preference with no registered Codex harness and assert PI is selected/run; runtime-plugin tests cover pre-selection Codex plugin loading; attempt-execution tests cover OpenAI API-key backup auth forwarding for Codex harness runs; Testbox changed gate passed as `tbx_01krr5kvqe3ww5c76fstke63bf`.
Observed result after fix: implicit OpenAI Codex runtime preference falls back to PI when Codex is unavailable, while explicit plugin runtime policy still fails closed when the requested harness is unavailable.
What was not tested: full published Docker image smoke for the reporter's exact digest.
