### PR TITLE
fix(gateway): harden token comparison paths

### DIFF
--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -1,4 +1,4 @@
-import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import { createHmac, randomBytes } from "node:crypto";
 import fs from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import path from "node:path";
@@ -18,6 +18,7 @@ import { assertLocalMediaAllowed, getDefaultLocalRoots } from "../media/local-me
 import { getAgentScopedMediaLocalRoots } from "../media/local-roots.js";
 import { resolveMediaReferenceLocalPath } from "../media/media-reference.js";
 import { detectMime } from "../media/mime.js";
+import { safeEqualSecret } from "../security/secret-equal.js";
 import { AVATAR_MAX_BYTES } from "../shared/avatar-policy.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveRuntimeServiceVersion } from "../version.js";
@@ -422,9 +423,7 @@ function verifyAssistantMediaTicket(ticket: string | null, source: string, nowMs
     return false;
   }
   const expectedSig = signAssistantMediaTicketPayload(encodedPayload);
-  const sigBuffer = Buffer.from(sig, "base64url");
-  const expectedBuffer = Buffer.from(expectedSig, "base64url");
-  if (sigBuffer.length !== expectedBuffer.length || !timingSafeEqual(sigBuffer, expectedBuffer)) {
+  if (!safeEqualSecret(sig, expectedSig)) {
     return false;
   }
   try {

--- a/src/gateway/operator-approval-runtime-token.test.ts
+++ b/src/gateway/operator-approval-runtime-token.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import {
+  getOperatorApprovalRuntimeToken,
+  isOperatorApprovalRuntimeToken,
+} from "./operator-approval-runtime-token.js";
+
+describe("operator approval runtime token", () => {
+  it("accepts the exact runtime token", () => {
+    const token = getOperatorApprovalRuntimeToken();
+
+    expect(isOperatorApprovalRuntimeToken(token)).toBe(true);
+    expect(isOperatorApprovalRuntimeToken(` ${token} `)).toBe(true);
+  });
+
+  it("rejects missing, truncated, and extended runtime tokens", () => {
+    const token = getOperatorApprovalRuntimeToken();
+
+    expect(isOperatorApprovalRuntimeToken(undefined)).toBe(false);
+    expect(isOperatorApprovalRuntimeToken(null)).toBe(false);
+    expect(isOperatorApprovalRuntimeToken("")).toBe(false);
+    expect(isOperatorApprovalRuntimeToken(token.slice(0, -1))).toBe(false);
+    expect(isOperatorApprovalRuntimeToken(`${token}x`)).toBe(false);
+  });
+});

--- a/src/gateway/operator-approval-runtime-token.ts
+++ b/src/gateway/operator-approval-runtime-token.ts
@@ -1,4 +1,5 @@
-import { randomBytes, timingSafeEqual } from "node:crypto";
+import { randomBytes } from "node:crypto";
+import { safeEqualSecret } from "../security/secret-equal.js";
 
 let approvalRuntimeToken: string | null = null;
 
@@ -13,7 +14,5 @@ export function isOperatorApprovalRuntimeToken(value: string | null | undefined)
     return false;
   }
   const expected = getOperatorApprovalRuntimeToken();
-  const tokenBytes = Buffer.from(token);
-  const expectedBytes = Buffer.from(expected);
-  return tokenBytes.length === expectedBytes.length && timingSafeEqual(tokenBytes, expectedBytes);
+  return safeEqualSecret(token, expected);
 }


### PR DESCRIPTION
## Summary

- Problem: gateway runtime token and assistant media ticket comparisons used manual length checks before `timingSafeEqual`.
- Why it matters: these are secret-bearing validation paths, so keeping them on one shared constant-time helper avoids drift and repeated comparison logic.
- What changed: runtime token validation and assistant media ticket validation now use `safeEqualSecret`; runtime token behavior has direct unit coverage.
- What did NOT change (scope boundary): token generation, ticket format, auth scopes, and assistant media access policy are unchanged.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: runtime operator approval token validation still accepts only the exact runtime token while moving the comparison to the shared secret-safe helper.
- Real environment tested: local Linux workspace, Node 22 toolchain, dependencies installed from `pnpm-lock.yaml`.
- Exact steps or command run after this patch: `node --import tsx -e 'const mod=await import("./src/gateway/operator-approval-runtime-token.ts"); const token=mod.getOperatorApprovalRuntimeToken(); const rows={ exact: mod.isOperatorApprovalRuntimeToken(token), trimmed: mod.isOperatorApprovalRuntimeToken(` ${token} `), truncated: mod.isOperatorApprovalRuntimeToken(token.slice(0,-1)), extended: mod.isOperatorApprovalRuntimeToken(`${token}x`), empty: mod.isOperatorApprovalRuntimeToken("") }; console.log(JSON.stringify(rows, null, 2));'`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): copied terminal output from the command above:

```json
{
  "exact": true,
  "trimmed": true,
  "truncated": false,
  "extended": false,
  "empty": false
}
```

- Observed result after fix: the exact runtime token is accepted, whitespace-trimmed token input matches existing behavior, and truncated/extended/empty token values are rejected.
- What was not tested: a full browser-driven assistant media flow was not run locally; the existing targeted gateway HTTP test covers assistant media ticket rejection/acceptance behavior.
- Before evidence (optional but encouraged): before the patch, these paths used local buffer length checks before `timingSafeEqual` instead of the existing shared helper.

## Root Cause (if applicable)

- Root cause: duplicate secret comparison logic existed in gateway-specific code instead of using the shared `safeEqualSecret` helper.
- Missing detection / guardrail: runtime token comparison did not have a focused unit test.
- Contributing context (if known): `safeEqualSecret` is already used by other gateway auth paths.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/operator-approval-runtime-token.test.ts`
- Scenario the test should lock in: exact runtime token accepts; missing, truncated, and extended values reject.
- Why this is the smallest reliable guardrail: it directly exercises the comparison function without gateway setup noise.
- Existing test that already covers this (if any): assistant media ticket HTTP behavior remains covered by `src/gateway/control-ui.http.test.ts`.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A

## Verification

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/operator-approval-runtime-token.test.ts src/gateway/control-ui.http.test.ts` passed: 2 files, 49 tests.
- `pnpm exec oxlint src/gateway/operator-approval-runtime-token.ts src/gateway/operator-approval-runtime-token.test.ts src/gateway/control-ui.ts src/gateway/control-ui.http.test.ts` passed with 0 warnings and 0 errors.
- `pnpm exec oxfmt --check src/gateway/operator-approval-runtime-token.ts src/gateway/operator-approval-runtime-token.test.ts src/gateway/control-ui.ts src/gateway/control-ui.http.test.ts` passed.
- `node scripts/check-no-conflict-markers.mjs` passed.

## Local full-suite note

`OPENCLAW_VITEST_MAX_WORKERS=2 pnpm test:unit:fast` was attempted locally before this patch and hit an unrelated host/platform issue importing `sharp` in `src/agents/tool-images.test.ts`: the installed prebuilt binary requires a newer x64 CPU baseline than this machine exposes. The targeted gateway checks above pass.
