### PR TITLE
fix(backup): hide manifest parser internals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/sessions: keep reachable transcript history when imported tree transcripts reference missing or legacy parent rows, preventing session history reads from going empty after a partial import.
 - Trajectory export: report incomplete transcript parent chains and stop cyclic branch walks so malformed imports cannot hang `/export-trajectory`.
 - Session replay: skip malformed user/assistant-shaped transcript rows during silent session resets instead of copying invalid entries into the fresh transcript.
+- Backup verify: report malformed archive manifests with a stable error instead of leaking raw JSON parser details.
 - Providers: reject malformed successful Runway, BytePlus, and Ollama embedding responses with provider-owned errors instead of raw parser/type failures, silent bad vectors, or long bogus polling.
 - Providers/images: reject malformed successful OpenAI-compatible, OpenAI, Google, fal, and OpenRouter image responses with provider-owned errors instead of raw shape failures, silent invalid base64 skips, or empty image results.
 - Providers/videos: reject malformed successful xAI, OpenRouter, and fal video create, poll, and result responses with provider-owned errors instead of raw parser failures or long bogus polling.

--- a/src/commands/backup-verify.test.ts
+++ b/src/commands/backup-verify.test.ts
@@ -32,6 +32,47 @@ function createBackupManifest(assetArchivePath: string, archiveRoot = TEST_ARCHI
   };
 }
 
+async function createArchiveWithManifestContent(
+  options: {
+    tempPrefix: string;
+    manifestContent: string;
+    payloadArchivePath?: string;
+  },
+  run: (archivePath: string) => Promise<void>,
+) {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), options.tempPrefix));
+  const archivePath = path.join(tempDir, "broken.tar.gz");
+  const manifestPath = path.join(tempDir, "manifest.json");
+  const payloadPath = path.join(tempDir, "payload.txt");
+  const payloadArchivePath =
+    options.payloadArchivePath ?? `${TEST_ARCHIVE_ROOT}/payload/posix/tmp/.openclaw/payload.txt`;
+  try {
+    await fs.writeFile(manifestPath, options.manifestContent, "utf8");
+    await fs.writeFile(payloadPath, "payload\n", "utf8");
+    await tar.c(
+      {
+        file: archivePath,
+        gzip: true,
+        portable: true,
+        preservePaths: true,
+        onWriteEntry: (entry) => {
+          if (entry.path === manifestPath) {
+            entry.path = `${TEST_ARCHIVE_ROOT}/manifest.json`;
+            return;
+          }
+          if (entry.path === payloadPath) {
+            entry.path = payloadArchivePath;
+          }
+        },
+      },
+      [manifestPath, payloadPath],
+    );
+    await run(archivePath);
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+}
+
 async function withBrokenArchiveFixture(
   options: {
     tempPrefix: string;
@@ -194,6 +235,24 @@ describe("backupVerifyCommand", () => {
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
     }
+  });
+
+  it("reports malformed manifest JSON without leaking parser internals", async () => {
+    await createArchiveWithManifestContent(
+      {
+        tempPrefix: "openclaw-backup-bad-manifest-json-",
+        manifestContent: '{"schemaVersion":1,',
+      },
+      async (archivePath) => {
+        const runtime = createBackupVerifyRuntime();
+        await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.toThrow(
+          /^Backup manifest is not valid JSON\.$/u,
+        );
+        await expect(backupVerifyCommand(runtime, { archive: archivePath })).rejects.not.toThrow(
+          /position|Unexpected|Expected|SyntaxError/u,
+        );
+      },
+    );
   });
 
   it("rejects unsafe archive paths", async () => {

--- a/src/commands/backup-verify.ts
+++ b/src/commands/backup-verify.ts
@@ -96,7 +96,7 @@ function parseManifest(raw: string): BackupManifest {
   try {
     parsed = JSON.parse(raw);
   } catch (err) {
-    throw new Error(`Backup manifest is not valid JSON: ${String(err)}`, { cause: err });
+    throw new Error("Backup manifest is not valid JSON.", { cause: err });
   }
 
   if (!isRecord(parsed)) {


### PR DESCRIPTION
Summary
- Hide raw JSON.parse parser details when `openclaw backup verify` reads a malformed archive manifest.
- Add a malformed manifest archive fixture covering truncated `manifest.json`.
- Add changelog entry.

Verification
- Crabbox run_166ead4070f0 / cbx_8dae81643324: `pnpm test src/commands/backup-verify.test.ts` passed.
- Crabbox run_81ea14deb7be / cbx_3a5d36d3de2b: fresh-clone `pnpm check:changed` passed.

Behavior addressed: `openclaw backup verify` now reports malformed archive manifests with the stable error `Backup manifest is not valid JSON.` instead of leaking raw JSON parser internals.
Real environment tested: Crabbox AWS Linux fresh checkout.
Exact steps or command run after this patch: `pnpm test src/commands/backup-verify.test.ts`; fresh-clone `pnpm check:changed`.
Evidence after fix: run_166ead4070f0 / cbx_8dae81643324 passed 7 backup verify tests; run_81ea14deb7be / cbx_3a5d36d3de2b passed changed gate.
Observed result after fix: malformed archive manifest verification fails cleanly with the stable manifest JSON error and no parser-position/SyntaxError text.
What was not tested: full backup create/restore E2E beyond the focused verifier tests and changed gate.
