### PR TITLE
Fix Telegram truncated progress finals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 - CLI/gateway: recover the Linux user systemd bus environment when `openclaw dashboard` starts the Gateway from stripped desktop shells such as VNC terminals.
 - Gateway/WebSocket: log expected startup `1013 gateway starting` retry closes at debug instead of warn while preserving WARN for unexpected pre-connect failures. Fixes #76361. (#82457) Thanks @IWhatsskill.
 - Providers/Xiaomi: strip synthetic empty array `items` from MiMo tool schemas while preserving typed array items, avoiding strict OpenAI-compatible schema rejection.
+- Telegram: send the transcript-backed full final answer after progress-mode tool drafts when the dispatcher final payload is an ellipsis-truncated snapshot. Fixes #82409. Thanks @PashaGanson.
 - CLI/context engines: bootstrap and finalize non-legacy context engines for CLI turns while preserving transcript snapshots and deferred maintenance ownership. (#81869) Thanks @sahilsatralkar.
 - Telegram: persist polling updates through restart replay so queued same-topic messages resume in order instead of losing context after a gateway restart. (#82256) Thanks @VACInc.
 - Gateway/Gmail: abort in-flight Gmail watcher startup and hot-reload restarts before shutdown so reloads cannot spawn `gog serve` after the Gateway is closing. Thanks @frankekn.

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1296,6 +1296,38 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(editMessageTelegram).not.toHaveBeenCalled();
   });
 
+  it("uses the transcript final when progress-mode final text is truncated", async () => {
+    setupDraftStreams({ answerMessageId: 2001 });
+    const fullAnswer =
+      "Ja. Hier nochmal sauber Schritt fuer Schritt. Einen API Key kopiert man aus der Google Cloud Console. Danach pruefst du die Projekt- und API-Einstellungen.";
+    const truncatedFinal =
+      "Ja. Hier nochmal sauber Schritt fuer Schritt. Einen API Key kopiert man...";
+    const context = createContext();
+    context.ctxPayload.SessionKey = "agent:default:telegram:direct:123";
+    loadSessionStore.mockReturnValue({
+      "agent:default:telegram:direct:123": { sessionId: "s1" },
+    });
+    readLatestAssistantTextFromSessionTranscript.mockResolvedValue({
+      text: fullAnswer,
+      timestamp: Date.now() + 1_000,
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+        await dispatcherOptions.deliver({ text: truncatedFinal }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({
+      context,
+      streamMode: "progress",
+      telegramCfg: { streaming: { mode: "progress" } },
+    });
+
+    expectDeliveredReply(0, { text: fullAnswer });
+  });
+
   it("streams the first long final chunk and sends follow-up chunks", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     const longText = "one ".repeat(80);

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -96,6 +96,8 @@ import { beginTelegramInboundTurnDeliveryCorrelation } from "./inbound-turn-deli
 import {
   createLaneDeliveryStateTracker,
   createLaneTextDeliverer,
+  isPotentialTruncatedFinal,
+  selectLongerFinalText,
   type DraftLaneState,
   type LaneDeliveryResult,
   type LaneName,
@@ -1260,6 +1262,13 @@ export const dispatchTelegramMessage = async ({
       answerLane.finalized = true;
       return delivered ? { kind: "sent" } : { kind: "skipped" };
     };
+    const resolveTranscriptBackedFinalText = async (text: string): Promise<string> =>
+      isPotentialTruncatedFinal(text)
+        ? (selectLongerFinalText({
+            finalText: text,
+            candidateTexts: [await resolveCurrentTurnTranscriptFinalText()],
+          }) ?? text)
+        : text;
 
     if (isDmTopic) {
       try {
@@ -1383,13 +1392,14 @@ export const dispatchTelegramMessage = async ({
                       text: string,
                       buttons?: TelegramInlineButtons,
                     ) => {
+                      const finalText = await resolveTranscriptBackedFinalText(text);
                       if (streamMode === "progress") {
-                        return deliverProgressModeFinalAnswer(answerPayload, text);
+                        return deliverProgressModeFinalAnswer(answerPayload, finalText);
                       }
                       await rotateAnswerLaneAfterToolProgress();
                       return deliverLaneText({
                         laneName: "answer",
-                        text,
+                        text: finalText,
                         payload: answerPayload,
                         infoKind: "final",
                         buttons,

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -112,7 +112,7 @@ function stripTrailingEllipsis(text: string): string {
 const MIN_TRUNCATED_FINAL_PREFIX_CHARS = 48;
 const MIN_TRUNCATED_FINAL_CONTINUATION_CHARS = 24;
 
-function isPotentialTruncatedFinal(finalText: string): boolean {
+export function isPotentialTruncatedFinal(finalText: string): boolean {
   const trimmedFinal = finalText.trimEnd();
   const untruncatedFinal = stripTrailingEllipsis(trimmedFinal);
   return (
@@ -120,18 +120,15 @@ function isPotentialTruncatedFinal(finalText: string): boolean {
   );
 }
 
-function selectLongerPreviewForFinal(params: {
+export function selectLongerFinalText(params: {
   finalText: string;
   candidateTexts: readonly (string | undefined)[];
 }): string | undefined {
   const finalText = params.finalText.trimEnd();
-  const untruncatedFinal = stripTrailingEllipsis(finalText);
-  if (
-    untruncatedFinal.length < MIN_TRUNCATED_FINAL_PREFIX_CHARS ||
-    untruncatedFinal === finalText
-  ) {
+  if (!isPotentialTruncatedFinal(finalText)) {
     return undefined;
   }
+  const untruncatedFinal = stripTrailingEllipsis(finalText);
   for (const candidate of params.candidateTexts) {
     const candidateText = candidate?.trimEnd();
     if (
@@ -191,7 +188,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
 
     const retainedPreview =
       isFinal && remainingChunks.length === 0 && isPotentialTruncatedFinal(text)
-        ? selectLongerPreviewForFinal({
+        ? selectLongerFinalText({
             finalText: text,
             candidateTexts: [
               await params.resolveFinalTextCandidate?.({ finalText: text, laneName }),

--- a/extensions/telegram/src/lane-delivery.ts
+++ b/extensions/telegram/src/lane-delivery.ts
@@ -1,5 +1,7 @@
 export {
   createLaneTextDeliverer,
+  isPotentialTruncatedFinal,
+  selectLongerFinalText,
   type DraftLaneState,
   type LaneDeliveryResult,
   type LaneName,


### PR DESCRIPTION
Summary
- Use transcript-backed final text before choosing Telegram final delivery path.
- Share the longer-final selection helper between retained draft finals and progress-mode final sends.
- Add a regression for progress-mode tool drafts where the dispatcher final is ellipsis-truncated.

Verification
- `node scripts/run-vitest.mjs extensions/telegram/src/lane-delivery.test.ts extensions/telegram/src/bot-message-dispatch.test.ts --reporter=verbose`
- `git diff --check origin/main..HEAD`
- `node scripts/check-changelog-attributions.mjs`

Behavior addressed: Telegram progress-mode final replies can display an ellipsis-truncated dispatcher final even when the session transcript stores the complete Codex final.
Real environment tested: Mantis Telegram Desktop Proof ran with Convex CI credentials, but did not generate GIFs because the current desktop proof runner cannot honestly synthesize the required progress-draft plus truncated-dispatcher/full-transcript state.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/telegram/src/bot-message-dispatch.test.ts --reporter=verbose -t 'uses the transcript final when progress-mode final text is truncated'`
Evidence after fix: the targeted regression passes on this PR.
Observed result after fix: delivered Telegram reply text equals the full transcript final instead of the truncated dispatcher final.
What was not tested: native Telegram before/after GIF; Mantis recorded this as unsupported by the current proof runner.

Main repro: the same targeted regression, applied test-only to `origin/main`, fails with the delivered reply ending in `...` instead of the complete final sentence.

Fixes #82409.