### PR TITLE
Fix Claude CLI runtime migration for gateway turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 - MS Teams/media: sniff inline `data:image/*` attachment bytes before staging them, skipping payloads that are not actually images.
 - WebChat/media: require trusted local-media provenance before preserving local audio reply paths for display, so untrusted audio-looking paths go through normal staging and read-policy checks.
 - Agents/tool media: preserve trusted local-media provenance when merging generated tool attachments into final reply payloads, so trusted audio/media survives outbound display normalization.
+- Anthropic/Claude CLI: write model-scoped `claude-cli` runtime policy when reusing local Claude CLI auth, so upgraded Telegram and Dashboard gateway turns keep using the CLI backend instead of falling through to Anthropic API billing. Fixes #82344. Thanks @amknight.
 - Update: let package-swap `doctor --fix` persist core config repairs while plugin schemas are still converging, preventing update failures on externalized channel configs.
 - Update: carry plugin-validation bypasses into config mutation pre-write reads, so package update doctor repairs can finish while externalized plugin schemas are converging.
 - Update/doctor: keep plugin-validation bypasses on the top-level `$include` config write path, so package repair can update included plugin config files without flattening them into the root config.

--- a/extensions/anthropic/cli-migration.test.ts
+++ b/extensions/anthropic/cli-migration.test.ts
@@ -133,12 +133,18 @@ describe("anthropic cli migration", () => {
           },
           agentRuntime: { id: "claude-cli" },
           models: {
-            "anthropic/claude-opus-4-7": { alias: "Opus" },
-            "anthropic/claude-sonnet-4-6": {},
-            "anthropic/claude-opus-4-6": { alias: "Opus" },
-            "anthropic/claude-opus-4-5": {},
-            "anthropic/claude-sonnet-4-5": {},
-            "anthropic/claude-haiku-4-5": {},
+            "anthropic/claude-opus-4-7": {
+              alias: "Opus",
+              agentRuntime: { id: "claude-cli" },
+            },
+            "anthropic/claude-sonnet-4-6": { agentRuntime: { id: "claude-cli" } },
+            "anthropic/claude-opus-4-6": {
+              alias: "Opus",
+              agentRuntime: { id: "claude-cli" },
+            },
+            "anthropic/claude-opus-4-5": { agentRuntime: { id: "claude-cli" } },
+            "anthropic/claude-sonnet-4-5": { agentRuntime: { id: "claude-cli" } },
+            "anthropic/claude-haiku-4-5": { agentRuntime: { id: "claude-cli" } },
             "openai/gpt-5.2": {},
           },
         },
@@ -165,12 +171,12 @@ describe("anthropic cli migration", () => {
           agentRuntime: { id: "claude-cli" },
           models: {
             "openai/gpt-5.2": {},
-            "anthropic/claude-opus-4-7": {},
-            "anthropic/claude-sonnet-4-6": {},
-            "anthropic/claude-opus-4-6": {},
-            "anthropic/claude-opus-4-5": {},
-            "anthropic/claude-sonnet-4-5": {},
-            "anthropic/claude-haiku-4-5": {},
+            "anthropic/claude-opus-4-7": { agentRuntime: { id: "claude-cli" } },
+            "anthropic/claude-sonnet-4-6": { agentRuntime: { id: "claude-cli" } },
+            "anthropic/claude-opus-4-6": { agentRuntime: { id: "claude-cli" } },
+            "anthropic/claude-opus-4-5": { agentRuntime: { id: "claude-cli" } },
+            "anthropic/claude-sonnet-4-5": { agentRuntime: { id: "claude-cli" } },
+            "anthropic/claude-haiku-4-5": { agentRuntime: { id: "claude-cli" } },
           },
         },
       },
@@ -195,15 +201,52 @@ describe("anthropic cli migration", () => {
           model: { primary: "anthropic/claude-opus-4-7" },
           agentRuntime: { id: "claude-cli" },
           models: {
-            "anthropic/claude-opus-4-7": {},
-            "anthropic/claude-sonnet-4-6": {},
-            "anthropic/claude-opus-4-6": {},
-            "anthropic/claude-opus-4-5": {},
-            "anthropic/claude-sonnet-4-5": {},
-            "anthropic/claude-haiku-4-5": {},
+            "anthropic/claude-opus-4-7": { agentRuntime: { id: "claude-cli" } },
+            "anthropic/claude-sonnet-4-6": { agentRuntime: { id: "claude-cli" } },
+            "anthropic/claude-opus-4-6": { agentRuntime: { id: "claude-cli" } },
+            "anthropic/claude-opus-4-5": { agentRuntime: { id: "claude-cli" } },
+            "anthropic/claude-sonnet-4-5": { agentRuntime: { id: "claude-cli" } },
+            "anthropic/claude-haiku-4-5": { agentRuntime: { id: "claude-cli" } },
           },
         },
       },
+    });
+  });
+
+  it("preserves explicit model runtime policy while filling missing Claude CLI policies", () => {
+    const result = buildAnthropicCliMigrationResult({
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-opus-4-7",
+            fallbacks: ["anthropic/claude-sonnet-4-6"],
+          },
+          models: {
+            "anthropic/claude-opus-4-7": {
+              alias: "Opus",
+              agentRuntime: { id: "pi" },
+            },
+            "anthropic/claude-sonnet-4-6": {
+              alias: "Sonnet",
+              agentRuntime: { id: "auto" },
+            },
+          },
+        },
+      },
+    });
+
+    const defaults = result.configPatch?.agents?.defaults;
+    if (!defaults) {
+      throw new Error("Expected Claude CLI migration to return default agent config");
+    }
+
+    expect(defaults.models?.["anthropic/claude-opus-4-7"]).toEqual({
+      alias: "Opus",
+      agentRuntime: { id: "pi" },
+    });
+    expect(defaults.models?.["anthropic/claude-sonnet-4-6"]).toEqual({
+      alias: "Sonnet",
+      agentRuntime: { id: "claude-cli" },
     });
   });
 
@@ -340,9 +383,11 @@ describe("anthropic cli migration", () => {
     expect(defaults?.agentRuntime?.id).toBe("claude-cli");
     expect(defaults?.models?.["anthropic/claude-opus-4-7"]).toEqual({
       alias: "Opus",
+      agentRuntime: { id: "claude-cli" },
     });
     expect(defaults?.models?.["anthropic/claude-opus-4-6"]).toEqual({
       alias: "Opus",
+      agentRuntime: { id: "claude-cli" },
     });
     expect(defaults?.models?.["openai/gpt-5.2"]).toEqual({});
   });

--- a/extensions/anthropic/cli-migration.ts
+++ b/extensions/anthropic/cli-migration.ts
@@ -35,23 +35,29 @@ function toAnthropicModelRef(raw: string): string | null {
   return `anthropic/${modelId}`;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
 function rewriteModelSelection(model: AgentDefaultsModel): {
   value: AgentDefaultsModel;
   primary?: string;
+  runtimeRefs: string[];
   changed: boolean;
 } {
   if (typeof model === "string") {
     const converted = toAnthropicModelRef(model);
     return converted
-      ? { value: converted, primary: converted, changed: true }
-      : { value: model, changed: false };
+      ? { value: converted, primary: converted, runtimeRefs: [converted], changed: true }
+      : { value: model, runtimeRefs: [], changed: false };
   }
   if (!model || typeof model !== "object" || Array.isArray(model)) {
-    return { value: model, changed: false };
+    return { value: model, runtimeRefs: [], changed: false };
   }
 
   const current = model as Record<string, unknown>;
   const next: Record<string, unknown> = { ...current };
+  const runtimeRefs: string[] = [];
   let changed = false;
   let primary: string | undefined;
 
@@ -60,15 +66,23 @@ function rewriteModelSelection(model: AgentDefaultsModel): {
     if (converted) {
       next.primary = converted;
       primary = converted;
+      runtimeRefs.push(converted);
       changed = true;
     }
   }
 
   const currentFallbacks = current.fallbacks;
   if (Array.isArray(currentFallbacks)) {
-    const nextFallbacks = currentFallbacks.map((entry) =>
-      typeof entry === "string" ? (toAnthropicModelRef(entry) ?? entry) : entry,
-    );
+    const nextFallbacks = currentFallbacks.map((entry) => {
+      if (typeof entry !== "string") {
+        return entry;
+      }
+      const converted = toAnthropicModelRef(entry);
+      if (converted) {
+        runtimeRefs.push(converted);
+      }
+      return converted ?? entry;
+    });
     if (nextFallbacks.some((entry, index) => entry !== currentFallbacks[index])) {
       next.fallbacks = nextFallbacks;
       changed = true;
@@ -78,6 +92,7 @@ function rewriteModelSelection(model: AgentDefaultsModel): {
   return {
     value: changed ? next : model,
     ...(primary ? { primary } : {}),
+    runtimeRefs,
     changed,
   };
 }
@@ -116,11 +131,19 @@ function rewriteModelEntryMap(models: Record<string, unknown> | undefined): {
 
 function seedClaudeCliAllowlist(
   models: NonNullable<AgentDefaultsModels>,
+  selectedRefs: readonly string[] = [],
 ): NonNullable<AgentDefaultsModels> {
   const next = { ...models };
+  const runtimeRefs = new Set<string>();
   for (const ref of CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS) {
     const canonicalRef = toAnthropicModelRef(ref) ?? ref;
-    next[canonicalRef] = next[canonicalRef] ?? {};
+    runtimeRefs.add(canonicalRef);
+  }
+  for (const ref of selectedRefs) {
+    runtimeRefs.add(ref);
+  }
+  for (const ref of runtimeRefs) {
+    next[ref] = modelEntryWithClaudeCliRuntime(next[ref]);
   }
   return next;
 }
@@ -134,6 +157,21 @@ function selectClaudeCliRuntime(agentRuntime: AgentDefaultsRuntimePolicy | undef
     ...agentRuntime,
     id: CLAUDE_CLI_BACKEND_ID,
   };
+}
+
+function modelEntryWithClaudeCliRuntime(entry: unknown): Record<string, unknown> {
+  const base = isRecord(entry) ? { ...entry } : {};
+  const currentRuntimeId = isRecord(base.agentRuntime) ? base.agentRuntime.id : undefined;
+  const currentRuntime =
+    typeof currentRuntimeId === "string" ? normalizeLowercaseStringOrEmpty(currentRuntimeId) : "";
+  if (currentRuntime && currentRuntime !== "auto") {
+    return base;
+  }
+  base.agentRuntime = {
+    ...(isRecord(base.agentRuntime) ? base.agentRuntime : {}),
+    id: CLAUDE_CLI_BACKEND_ID,
+  };
+  return base;
 }
 
 export function hasClaudeCliAuth(options?: { allowKeychainPrompt?: boolean }): boolean {
@@ -187,7 +225,10 @@ export function buildAnthropicCliMigrationResult(
   const existingModels = (rewrittenModels.value ??
     defaults?.models ??
     {}) as NonNullable<AgentDefaultsModels>;
-  const nextModels = seedClaudeCliAllowlist(existingModels);
+  const nextModels = seedClaudeCliAllowlist(existingModels, [
+    ...rewrittenModel.runtimeRefs,
+    ...rewrittenModels.migrated,
+  ]);
   const defaultModel = rewrittenModel.primary ?? "anthropic/claude-opus-4-7";
 
   return {

--- a/extensions/anthropic/config-defaults.ts
+++ b/extensions/anthropic/config-defaults.ts
@@ -16,6 +16,10 @@ function normalizeProviderId(provider: string): string {
   return normalized;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
 function resolveAnthropicDefaultAuthMode(
   config: OpenClawConfig,
   env: NodeJS.ProcessEnv,
@@ -154,9 +158,16 @@ function usesClaudeCliModelSelection(config: OpenClawConfig): boolean {
   if (parsedPrimary?.provider === CLAUDE_CLI_BACKEND_ID) {
     return true;
   }
-  return Object.keys(config.agents?.defaults?.models ?? {}).some((key) => {
+  return Object.entries(config.agents?.defaults?.models ?? {}).some(([key, entry]) => {
     const parsed = parseProviderModelRef(key, "anthropic");
-    return parsed?.provider === CLAUDE_CLI_BACKEND_ID;
+    if (parsed?.provider === CLAUDE_CLI_BACKEND_ID) {
+      return true;
+    }
+    const runtimeId = isRecord(entry?.agentRuntime) ? entry.agentRuntime.id : undefined;
+    return (
+      parsed?.provider === "anthropic" &&
+      normalizeLowercaseStringOrEmpty(runtimeId) === CLAUDE_CLI_BACKEND_ID
+    );
   });
 }
 
@@ -164,6 +175,63 @@ function toCanonicalAnthropicModelRef(ref: string): string {
   return ref.startsWith(`${CLAUDE_CLI_BACKEND_ID}/`)
     ? `anthropic/${ref.slice(CLAUDE_CLI_BACKEND_ID.length + 1)}`
     : ref;
+}
+
+function toClaudeCliRuntimeModelRef(raw: string): string | null {
+  const ref = resolveAnthropicPrimaryModelRef(raw);
+  if (!ref) {
+    return null;
+  }
+  const parsed = parseProviderModelRef(ref, "anthropic");
+  if (!parsed) {
+    return null;
+  }
+  if (parsed.provider !== "anthropic" && parsed.provider !== CLAUDE_CLI_BACKEND_ID) {
+    return null;
+  }
+  if (!normalizeLowercaseStringOrEmpty(parsed.model).startsWith("claude-")) {
+    return null;
+  }
+  return `anthropic/${parsed.model}`;
+}
+
+function modelEntryWithClaudeCliRuntime(entry: unknown): Record<string, unknown> {
+  const base = isRecord(entry) ? { ...entry } : {};
+  const currentRuntimeId = isRecord(base.agentRuntime) ? base.agentRuntime.id : undefined;
+  const currentRuntime = normalizeLowercaseStringOrEmpty(currentRuntimeId);
+  if (currentRuntime && currentRuntime !== "auto") {
+    return base;
+  }
+  base.agentRuntime = {
+    ...(isRecord(base.agentRuntime) ? base.agentRuntime : {}),
+    id: CLAUDE_CLI_BACKEND_ID,
+  };
+  return base;
+}
+
+function collectClaudeCliRuntimeRefs(
+  model: string | { primary?: string; fallbacks?: string[] } | undefined,
+): string[] {
+  const refs = new Set<string>();
+  if (typeof model === "string") {
+    const ref = toClaudeCliRuntimeModelRef(model);
+    if (ref) {
+      refs.add(ref);
+    }
+    return [...refs];
+  }
+  const primary =
+    typeof model?.primary === "string" ? toClaudeCliRuntimeModelRef(model.primary) : null;
+  if (primary) {
+    refs.add(primary);
+  }
+  for (const fallback of model?.fallbacks ?? []) {
+    const ref = toClaudeCliRuntimeModelRef(fallback);
+    if (ref) {
+      refs.add(ref);
+    }
+  }
+  return [...refs];
 }
 
 function normalizeAnthropicProviderConfig<T extends { api?: string; models?: unknown[] }>(
@@ -290,12 +358,17 @@ export function applyAnthropicConfigDefaults(params: {
   if (authMode === "oauth" && usesClaudeCliModelSelection(params.config)) {
     const nextModels = defaults.models ? { ...defaults.models } : {};
     let modelsMutated = false;
+    const runtimeRefs = new Set<string>(collectClaudeCliRuntimeRefs(defaults.model));
     for (const rawRef of CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS) {
-      const ref = toCanonicalAnthropicModelRef(rawRef);
-      if (ref in nextModels) {
+      runtimeRefs.add(toCanonicalAnthropicModelRef(rawRef));
+    }
+    for (const ref of runtimeRefs) {
+      const current = nextModels[ref];
+      const updated = modelEntryWithClaudeCliRuntime(current);
+      if (JSON.stringify(updated) === JSON.stringify(current ?? {})) {
         continue;
       }
-      nextModels[ref] = {};
+      nextModels[ref] = updated;
       modelsMutated = true;
     }
     if (modelsMutated) {

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -264,7 +264,7 @@ describe("anthropic provider replay hooks", () => {
       "anthropic/claude-sonnet-4-5",
       "anthropic/claude-haiku-4-5",
     ]) {
-      expect(models[modelId]).toEqual({});
+      expect(models[modelId]).toEqual({ agentRuntime: { id: "claude-cli" } });
     }
   });
 

--- a/src/gateway/gateway-cli-backend.live.test.ts
+++ b/src/gateway/gateway-cli-backend.live.test.ts
@@ -370,8 +370,10 @@ describeLive("gateway live (cli backend)", () => {
             ...(bootstrapWorkspace ? { workspace: bootstrapWorkspace.workspaceRootDir } : {}),
             model: { primary: configModelKey },
             models: {
-              [configModelKey]: {},
-              ...(modelSwitchTarget ? { [modelSwitchTarget]: {} } : {}),
+              [configModelKey]: { agentRuntime: modelSelection.agentRuntime },
+              ...(modelSwitchTarget
+                ? { [modelSwitchTarget]: { agentRuntime: modelSelection.agentRuntime } }
+                : {}),
             },
             agentRuntime: modelSelection.agentRuntime,
             cliBackends: {


### PR DESCRIPTION
## Summary

Fixes #82344 by moving the Claude CLI auth migration onto the runtime-selection contract the gateway actually uses.

The regression was that the Anthropic Claude CLI migration wrote `agents.defaults.agentRuntime.id = "claude-cli"`, but current runtime selection intentionally ignores that legacy whole-agent field. Gateway-mediated turns from Telegram and Dashboard could therefore resolve an Anthropic model without a model/provider-scoped runtime policy and fall through to Anthropic API billing, while direct Claude CLI use still worked.

This PR:
- writes `agentRuntime: { id: "claude-cli" }` onto migrated canonical Anthropic model entries during Claude CLI auth migration;
- backfills the same model-scoped policy through Anthropic config defaults for already-upgraded configs;
- preserves explicit non-`auto` model runtime policies;
- updates the gateway CLI backend live smoke config to exercise model-scoped runtime selection;
- adds regression coverage and a changelog entry.

## Reproduction

I reproduced the issue on Blacksmith before the fix with a source-level migration/resolver harness. The migrated config had the legacy default runtime, but the canonical model entry lacked `agentRuntime`, so `resolveModelRuntimePolicy({ provider: "anthropic", modelId: "claude-opus-4-7" })` returned no runtime.

Pre-fix Testbox: `tbx_01krr54ntaqd1hxqsad1ygmw82`

Observed pre-fix output shape:

```json
{
  "migratedEntry": { "alias": "Opus" },
  "defaultRuntime": { "id": "claude-cli" }
}
```

The assertion expected `claude-cli` but failed because the gateway resolver ignored the legacy whole-agent runtime.

## Verification

Behavior addressed: upgraded Claude CLI auth configs keep Telegram and Dashboard gateway turns on the local Claude CLI runtime instead of falling through to Anthropic API billing.

Real environment tested: Blacksmith Testbox Linux, post-rebase branch content, `tbx_01krr7e0pqfbw4az114zcwyg0s`, GitHub Actions run `https://github.com/openclaw/openclaw/actions/runs/25960349269`.

Exact steps or command run after this patch: Blacksmith command ran a migration/resolver assertion, then `pnpm check:changed`, then `pnpm test extensions/anthropic/cli-migration.test.ts extensions/anthropic/index.test.ts src/agents/command/attempt-execution.cli.test.ts src/commands/models/auth.test.ts`.

Evidence after fix:

```json
{
  "migratedEntry": {
    "alias": "Opus",
    "agentRuntime": { "id": "claude-cli" }
  },
  "defaultRuntime": { "id": "claude-cli" },
  "resolved": "claude-cli",
  "source": "model"
}
```

Observed result after fix: `pnpm check:changed` passed, focused tests passed across 3 Vitest shards, and the Blacksmith run exited 0.

What was not tested: live Claude account billing/auth was not exercised; the proof validates the config migration/defaulting path and the gateway runtime resolver contract that selects the CLI backend before any provider billing path.

I also attempted the default AWS Crabbox route during investigation. The raw AWS lease lacked Node, and Actions hydration was blocked by GitHub runner-registration permissions (`403`); a manually prepared AWS lease reproduced the resolver result but later lost SSH on the configured port, so final proof uses Blacksmith Testbox as requested.