### PR TITLE
fix: gate dashboard on gateway readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - CLI/status: show plain empty-state messages instead of empty Channels and Sessions tables when no channels or sessions exist.
+- CLI/dashboard: probe Gateway readiness before handing out the dashboard URL, prompting to start or install the managed service when the Gateway is stopped and printing recovery commands instead of opening a dead browser tab.
 - CLI/context engines: bootstrap and finalize non-legacy context engines for CLI turns while preserving transcript snapshots and deferred maintenance ownership. (#81869) Thanks @sahilsatralkar.
 - Telegram: persist polling updates through restart replay so queued same-topic messages resume in order instead of losing context after a gateway restart. (#82256) Thanks @VACInc.
 - Gateway/Gmail: abort in-flight Gmail watcher startup and hot-reload restarts before shutdown so reloads cannot spawn `gog serve` after the Gateway is closing. Thanks @frankekn.

--- a/src/cli/program/register.maintenance.ts
+++ b/src/cli/program/register.maintenance.ts
@@ -49,10 +49,12 @@ export function registerMaintenanceCommands(program: Command) {
         `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/dashboard", "docs.openclaw.ai/cli/dashboard")}\n`,
     )
     .option("--no-open", "Print URL but do not launch a browser")
+    .option("--yes", "Start/install the gateway without prompting when needed", false)
     .action(async (opts) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
         await dashboardCommand(defaultRuntime, {
           noOpen: opts.open === false,
+          yes: Boolean(opts.yes),
         });
       });
     });

--- a/src/cli/qr-dashboard.integration.test.ts
+++ b/src/cli/qr-dashboard.integration.test.ts
@@ -7,6 +7,7 @@ const loadConfigMock = vi.hoisted(() => vi.fn());
 const readConfigFileSnapshotMock = vi.hoisted(() => vi.fn());
 const resolveGatewayPortMock = vi.hoisted(() => vi.fn(() => 18789));
 const copyToClipboardMock = vi.hoisted(() => vi.fn(async () => false));
+const ensureGatewayReadyForOperationMock = vi.hoisted(() => vi.fn());
 const {
   runtimeLogs,
   runtimeErrors,
@@ -28,6 +29,10 @@ vi.mock("../config/config.js", async (importOriginal) => {
 
 vi.mock("../infra/clipboard.js", () => ({
   copyToClipboard: copyToClipboardMock,
+}));
+
+vi.mock("../commands/gateway-readiness.js", () => ({
+  ensureGatewayReadyForOperation: ensureGatewayReadyForOperationMock,
 }));
 
 vi.mock("../infra/device-bootstrap.js", () => ({
@@ -120,6 +125,11 @@ describe("cli integration: qr + dashboard token SecretRef", () => {
   beforeEach(() => {
     resetRuntimeCapture();
     vi.clearAllMocks();
+    ensureGatewayReadyForOperationMock.mockResolvedValue({
+      ready: true,
+      status: {},
+      recovered: false,
+    });
     runtimeExit.mockImplementation(() => {});
     delete process.env.OPENCLAW_GATEWAY_TOKEN;
     delete process.env.OPENCLAW_GATEWAY_PASSWORD;

--- a/src/commands/dashboard.links.test.ts
+++ b/src/commands/dashboard.links.test.ts
@@ -9,6 +9,7 @@ const openUrlMock = vi.hoisted(() => vi.fn());
 const formatControlUiSshHintMock = vi.hoisted(() => vi.fn());
 const copyToClipboardMock = vi.hoisted(() => vi.fn());
 const resolveSecretRefValuesMock = vi.hoisted(() => vi.fn());
+const ensureGatewayReadyForOperationMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../config/config.js", () => ({
   readConfigFileSnapshot: readConfigFileSnapshotMock,
@@ -24,6 +25,10 @@ vi.mock("./onboard-helpers.js", () => ({
 
 vi.mock("../infra/clipboard.js", () => ({
   copyToClipboard: copyToClipboardMock,
+}));
+
+vi.mock("./gateway-readiness.js", () => ({
+  ensureGatewayReadyForOperation: ensureGatewayReadyForOperationMock,
 }));
 
 vi.mock("../secrets/resolve.js", () => ({
@@ -83,6 +88,12 @@ describe("dashboardCommand", () => {
     openUrlMock.mockClear();
     formatControlUiSshHintMock.mockClear();
     copyToClipboardMock.mockClear();
+    ensureGatewayReadyForOperationMock.mockReset();
+    ensureGatewayReadyForOperationMock.mockResolvedValue({
+      ready: true,
+      status: {},
+      recovered: false,
+    });
     delete process.env.OPENCLAW_GATEWAY_TOKEN;
     delete process.env.CUSTOM_GATEWAY_TOKEN;
   });
@@ -95,6 +106,13 @@ describe("dashboardCommand", () => {
 
     await dashboardCommand(runtime);
 
+    expect(ensureGatewayReadyForOperationMock).toHaveBeenCalledWith({
+      runtime,
+      operation: "open the dashboard",
+      yes: undefined,
+      probeUrl: "ws://127.0.0.1:18789",
+      readyWhenReachable: true,
+    });
     expect(resolveControlUiLinksMock).toHaveBeenCalledWith({
       port: 18789,
       bind: "loopback",
@@ -290,5 +308,21 @@ describe("dashboardCommand", () => {
       "Token auto-auth unavailable: gateway.auth.token SecretRef is unresolved (env:default:CUSTOM_GATEWAY_TOKEN).",
     );
     expectNoLogWith("Token auto-auth is disabled for SecretRef-managed");
+  });
+
+  it("does not copy or open when gateway readiness fails", async () => {
+    mockSnapshot("abc");
+    ensureGatewayReadyForOperationMock.mockResolvedValueOnce({
+      ready: false,
+      status: {},
+      reason: "Gateway is not running.",
+      recoverable: true,
+    });
+
+    await dashboardCommand(runtime);
+
+    expect(readConfigFileSnapshotMock).toHaveBeenCalledTimes(1);
+    expect(copyToClipboardMock).not.toHaveBeenCalled();
+    expect(openUrlMock).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/dashboard.test.ts
+++ b/src/commands/dashboard.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   resolveGatewayPort: vi.fn(),
   resolveControlUiLinks: vi.fn(),
   copyToClipboard: vi.fn(),
+  ensureGatewayReadyForOperation: vi.fn(),
 }));
 
 vi.mock("../config/config.js", () => ({
@@ -23,6 +24,10 @@ vi.mock("./onboard-helpers.js", () => ({
 
 vi.mock("../infra/clipboard.js", () => ({
   copyToClipboard: mocks.copyToClipboard,
+}));
+
+vi.mock("./gateway-readiness.js", () => ({
+  ensureGatewayReadyForOperation: mocks.ensureGatewayReadyForOperation,
 }));
 
 const runtime = {
@@ -67,6 +72,12 @@ describe("dashboardCommand bind selection", () => {
     mocks.resolveGatewayPort.mockClear();
     mocks.resolveControlUiLinks.mockClear();
     mocks.copyToClipboard.mockClear();
+    mocks.ensureGatewayReadyForOperation.mockReset();
+    mocks.ensureGatewayReadyForOperation.mockResolvedValue({
+      ready: true,
+      status: {},
+      recovered: false,
+    });
     runtime.log.mockClear();
     runtime.error.mockClear();
     runtime.exit.mockClear();

--- a/src/commands/dashboard.ts
+++ b/src/commands/dashboard.ts
@@ -3,6 +3,7 @@ import { resolveGatewayAuthToken } from "../gateway/auth-token-resolution.js";
 import { copyToClipboard } from "../infra/clipboard.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
+import { ensureGatewayReadyForOperation } from "./gateway-readiness.js";
 import {
   detectBrowserOpenSupport,
   formatControlUiSshHint,
@@ -12,12 +13,10 @@ import {
 
 type DashboardOptions = {
   noOpen?: boolean;
+  yes?: boolean;
 };
 
-export async function dashboardCommand(
-  runtime: RuntimeEnv = defaultRuntime,
-  options: DashboardOptions = {},
-) {
+async function resolveDashboardTarget() {
   const snapshot = await readConfigFileSnapshot();
   const cfg = snapshot.valid ? (snapshot.sourceConfig ?? snapshot.config) : {};
   const port = resolveGatewayPort(cfg);
@@ -46,6 +45,36 @@ export async function dashboardCommand(
   const dashboardUrl = includeTokenInUrl
     ? `${links.httpUrl}#token=${encodeURIComponent(token)}`
     : links.httpUrl;
+
+  return {
+    port,
+    basePath,
+    links,
+    resolvedToken,
+    token,
+    includeTokenInUrl,
+    dashboardUrl,
+  };
+}
+
+export async function dashboardCommand(
+  runtime: RuntimeEnv = defaultRuntime,
+  options: DashboardOptions = {},
+) {
+  const initialTarget = await resolveDashboardTarget();
+  const readiness = await ensureGatewayReadyForOperation({
+    runtime,
+    operation: "open the dashboard",
+    yes: options.yes,
+    probeUrl: initialTarget.links.wsUrl,
+    readyWhenReachable: true,
+  });
+  if (!readiness.ready) {
+    return;
+  }
+
+  const target = readiness.recovered ? await resolveDashboardTarget() : initialTarget;
+  const { port, basePath, links, resolvedToken, token, includeTokenInUrl, dashboardUrl } = target;
 
   runtime.log(`Dashboard URL: ${links.httpUrl}`);
   if (includeTokenInUrl) {

--- a/src/commands/gateway-readiness.test.ts
+++ b/src/commands/gateway-readiness.test.ts
@@ -1,0 +1,285 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DaemonStatus } from "../cli/daemon-cli/status.gather.js";
+import { ensureGatewayReadyForOperation } from "./gateway-readiness.js";
+
+function createStatus(overrides: Partial<DaemonStatus> = {}): DaemonStatus {
+  return {
+    service: {
+      label: "systemd user",
+      loaded: false,
+      loadedText: "enabled",
+      notLoadedText: "disabled",
+      command: null,
+      runtime: { status: "stopped" },
+    },
+    gateway: {
+      bindMode: "loopback",
+      bindHost: "127.0.0.1",
+      port: 18789,
+      portSource: "env/config",
+      probeUrl: "ws://127.0.0.1:18789",
+    },
+    port: {
+      port: 18789,
+      status: "free",
+      listeners: [],
+      hints: [],
+    },
+    rpc: {
+      ok: false,
+      error: "connect ECONNREFUSED 127.0.0.1:18789",
+    },
+    extraServices: [],
+    ...overrides,
+  };
+}
+
+const runtime = {
+  log: vi.fn(),
+  error: vi.fn(),
+  exit: vi.fn(),
+};
+
+describe("ensureGatewayReadyForOperation", () => {
+  beforeEach(() => {
+    runtime.log.mockClear();
+    runtime.error.mockClear();
+    runtime.exit.mockClear();
+  });
+
+  it("returns ready without prompting when the gateway probe succeeds", async () => {
+    const gatherStatus = vi.fn().mockResolvedValue(
+      createStatus({
+        rpc: { ok: true },
+        port: { port: 18789, status: "busy", listeners: [], hints: [] },
+      }),
+    );
+    const confirm = vi.fn();
+
+    const result = await ensureGatewayReadyForOperation({
+      runtime,
+      operation: "run a command",
+      deps: { gatherStatus, confirm },
+    });
+
+    expect(result.ready).toBe(true);
+    expect(confirm).not.toHaveBeenCalled();
+    expect(runtime.log).not.toHaveBeenCalled();
+  });
+
+  it("prints diagnosis and skips recovery when an interactive user declines", async () => {
+    const gatherStatus = vi.fn().mockResolvedValue(createStatus());
+    const confirm = vi.fn().mockResolvedValue(false);
+
+    const result = await ensureGatewayReadyForOperation({
+      runtime,
+      operation: "open the dashboard",
+      interactive: true,
+      deps: { gatherStatus, confirm },
+    });
+
+    expect(result.ready).toBe(false);
+    expect(confirm).toHaveBeenCalledWith(
+      "Gateway is not installed. Install and start it now so OpenClaw can open the dashboard?",
+      true,
+    );
+    expect(runtime.log.mock.calls.map(([line]) => String(line)).join("\n")).toContain(
+      "Gateway is not running.",
+    );
+  });
+
+  it("installs a missing service and waits for the gateway before returning ready", async () => {
+    const stopped = createStatus();
+    const running = createStatus({
+      service: {
+        label: "systemd user",
+        loaded: true,
+        loadedText: "enabled",
+        notLoadedText: "disabled",
+        command: { programArguments: ["openclaw", "gateway", "run"] },
+        runtime: { status: "running" },
+      },
+      port: { port: 18789, status: "busy", listeners: [], hints: [] },
+      rpc: { ok: true },
+    });
+    const gatherStatus = vi.fn().mockResolvedValueOnce(stopped).mockResolvedValueOnce(running);
+    const installGateway = vi.fn().mockResolvedValue(undefined);
+    const startGateway = vi.fn().mockResolvedValue(undefined);
+
+    const result = await ensureGatewayReadyForOperation({
+      runtime,
+      operation: "open the dashboard",
+      yes: true,
+      deps: { gatherStatus, installGateway, startGateway },
+    });
+
+    expect(result).toMatchObject({ ready: true, recovered: true });
+    expect(installGateway).toHaveBeenCalledTimes(1);
+    expect(startGateway).not.toHaveBeenCalled();
+  });
+
+  it("starts an installed stopped service instead of reinstalling it", async () => {
+    const stopped = createStatus({
+      service: {
+        label: "systemd user",
+        loaded: false,
+        loadedText: "enabled",
+        notLoadedText: "disabled",
+        command: { programArguments: ["openclaw", "gateway", "run"] },
+        runtime: { status: "stopped" },
+      },
+    });
+    const running = createStatus({
+      service: {
+        label: "systemd user",
+        loaded: true,
+        loadedText: "enabled",
+        notLoadedText: "disabled",
+        command: { programArguments: ["openclaw", "gateway", "run"] },
+        runtime: { status: "running" },
+      },
+      port: { port: 18789, status: "busy", listeners: [], hints: [] },
+      rpc: { ok: true },
+    });
+    const gatherStatus = vi.fn().mockResolvedValueOnce(stopped).mockResolvedValueOnce(running);
+    const installGateway = vi.fn().mockResolvedValue(undefined);
+    const startGateway = vi.fn().mockResolvedValue(undefined);
+
+    const result = await ensureGatewayReadyForOperation({
+      runtime,
+      operation: "open the dashboard",
+      yes: true,
+      deps: { gatherStatus, installGateway, startGateway },
+    });
+
+    expect(result).toMatchObject({ ready: true, recovered: true });
+    expect(startGateway).toHaveBeenCalledTimes(1);
+    expect(installGateway).not.toHaveBeenCalled();
+  });
+
+  it("does not prompt to start when the gateway is reachable but unhealthy", async () => {
+    const status = createStatus({
+      service: {
+        label: "systemd user",
+        loaded: true,
+        loadedText: "enabled",
+        notLoadedText: "disabled",
+        command: { programArguments: ["openclaw", "gateway", "run"] },
+        runtime: { status: "running" },
+      },
+      port: { port: 18789, status: "busy", listeners: [], hints: [] },
+      rpc: { ok: false, error: "gateway closed (1008): auth failed" },
+    });
+    const confirm = vi.fn();
+
+    const result = await ensureGatewayReadyForOperation({
+      runtime,
+      operation: "open the dashboard",
+      interactive: true,
+      deps: { gatherStatus: vi.fn().mockResolvedValue(status), confirm },
+    });
+
+    expect(result).toMatchObject({ ready: false, recoverable: false });
+    expect(confirm).not.toHaveBeenCalled();
+    expect(runtime.log.mock.calls.map(([line]) => String(line)).join("\n")).toContain(
+      "Gateway probe failed: gateway closed (1008): auth failed",
+    );
+  });
+
+  it("can accept a reachable dashboard listener when authenticated RPC fails", async () => {
+    const status = createStatus({
+      service: {
+        label: "systemd user",
+        loaded: true,
+        loadedText: "enabled",
+        notLoadedText: "disabled",
+        command: { programArguments: ["openclaw", "gateway", "run", "--port", "18789"] },
+        runtime: { status: "running" },
+      },
+      port: { port: 18789, status: "free", listeners: [], hints: [] },
+      portCli: { port: 49876, status: "busy", listeners: [], hints: [] },
+      rpc: {
+        ok: false,
+        error: "gateway closed (1008): auth failed",
+        url: "ws://127.0.0.1:49876",
+      },
+    });
+    const confirm = vi.fn();
+
+    const result = await ensureGatewayReadyForOperation({
+      runtime,
+      operation: "open the dashboard",
+      readyWhenReachable: true,
+      interactive: true,
+      deps: { gatherStatus: vi.fn().mockResolvedValue(status), confirm },
+    });
+
+    expect(result).toMatchObject({ ready: true, recovered: false });
+    expect(confirm).not.toHaveBeenCalled();
+    expect(runtime.log).not.toHaveBeenCalled();
+  });
+
+  it("still treats a timeout on the target port as not ready", async () => {
+    const status = createStatus({
+      service: {
+        label: "systemd user",
+        loaded: true,
+        loadedText: "enabled",
+        notLoadedText: "disabled",
+        command: { programArguments: ["openclaw", "gateway", "run"] },
+        runtime: { status: "running" },
+      },
+      port: { port: 18789, status: "busy", listeners: [], hints: [] },
+      rpc: { ok: false, error: "timeout", url: "ws://127.0.0.1:18789" },
+    });
+    const confirm = vi.fn();
+
+    const result = await ensureGatewayReadyForOperation({
+      runtime,
+      operation: "open the dashboard",
+      readyWhenReachable: true,
+      interactive: true,
+      deps: { gatherStatus: vi.fn().mockResolvedValue(status), confirm },
+    });
+
+    expect(result).toMatchObject({ ready: false, recoverable: false });
+    expect(confirm).not.toHaveBeenCalled();
+    expect(runtime.log.mock.calls.map(([line]) => String(line)).join("\n")).toContain(
+      "Gateway probe failed: timeout",
+    );
+  });
+
+  it("does not accept an unrelated listener on the dashboard port", async () => {
+    const status = createStatus({
+      service: {
+        label: "systemd user",
+        loaded: true,
+        loadedText: "enabled",
+        notLoadedText: "disabled",
+        command: { programArguments: ["openclaw", "gateway", "run"] },
+        runtime: { status: "running" },
+      },
+      port: { port: 18789, status: "busy", listeners: [], hints: [] },
+      rpc: {
+        ok: false,
+        error: "Unexpected server response: 200",
+        url: "ws://127.0.0.1:18789",
+      },
+    });
+    const confirm = vi.fn();
+
+    const result = await ensureGatewayReadyForOperation({
+      runtime,
+      operation: "open the dashboard",
+      readyWhenReachable: true,
+      interactive: true,
+      deps: { gatherStatus: vi.fn().mockResolvedValue(status), confirm },
+    });
+
+    expect(result).toMatchObject({ ready: false, recoverable: false });
+    expect(confirm).not.toHaveBeenCalled();
+    expect(runtime.log.mock.calls.map(([line]) => String(line)).join("\n")).toContain(
+      "Gateway probe failed: Unexpected server response: 200",
+    );
+  });
+});

--- a/src/commands/gateway-readiness.ts
+++ b/src/commands/gateway-readiness.ts
@@ -1,0 +1,269 @@
+import type { DaemonStatus } from "../cli/daemon-cli/status.gather.js";
+import { promptYesNo } from "../cli/prompt.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { createLazyImportLoader } from "../shared/lazy-promise.js";
+
+const daemonStatusModuleLoader = createLazyImportLoader(
+  () => import("../cli/daemon-cli/status.gather.js"),
+);
+const daemonInstallModuleLoader = createLazyImportLoader(
+  () => import("../cli/daemon-cli/install.runtime.js"),
+);
+const daemonLifecycleModuleLoader = createLazyImportLoader(
+  () => import("../cli/daemon-cli/lifecycle.js"),
+);
+
+export type GatewayReadinessResult =
+  | {
+      ready: true;
+      status: DaemonStatus;
+      recovered: boolean;
+    }
+  | {
+      ready: false;
+      status: DaemonStatus;
+      reason: string;
+      recoverable: boolean;
+    };
+
+type GatewayReadinessDeps = {
+  gatherStatus?: () => Promise<DaemonStatus>;
+  confirm?: (message: string, defaultYes?: boolean) => Promise<boolean>;
+  installGateway?: () => Promise<void>;
+  startGateway?: () => Promise<void>;
+};
+
+export type GatewayReadinessOptions = {
+  runtime: RuntimeEnv;
+  operation: string;
+  yes?: boolean;
+  allowInstall?: boolean;
+  requireRpc?: boolean;
+  probeUrl?: string;
+  readyWhenReachable?: boolean;
+  interactive?: boolean;
+  deps?: GatewayReadinessDeps;
+};
+
+async function defaultGatherStatus(params: {
+  requireRpc: boolean;
+  probeUrl?: string;
+}): Promise<DaemonStatus> {
+  const { gatherDaemonStatus } = await daemonStatusModuleLoader.load();
+  return gatherDaemonStatus({
+    rpc: {
+      ...(params.probeUrl ? { url: params.probeUrl } : {}),
+    },
+    probe: true,
+    requireRpc: params.requireRpc,
+    deep: false,
+  });
+}
+
+function activeProbePortStatus(status: DaemonStatus): DaemonStatus["port"] {
+  const probeUrl = status.rpc?.url ?? status.gateway?.probeUrl;
+  const probePort = probeUrl
+    ? (() => {
+        try {
+          return Number(new URL(probeUrl).port);
+        } catch {
+          return NaN;
+        }
+      })()
+    : NaN;
+  if (Number.isFinite(probePort) && status.portCli?.port === probePort) {
+    return status.portCli;
+  }
+  return status.port;
+}
+
+function gatewayIsRunning(status: DaemonStatus): boolean {
+  return status.rpc?.ok === true;
+}
+
+function gatewayProbeSawGateway(status: DaemonStatus): boolean {
+  const rpc = status.rpc;
+  if (!rpc) {
+    return false;
+  }
+  if (rpc.ok) {
+    return true;
+  }
+  if (rpc.auth?.capability && rpc.auth.capability !== "unknown") {
+    return true;
+  }
+  if (rpc.auth?.role || (rpc.auth?.scopes?.length ?? 0) > 0) {
+    return true;
+  }
+  if (rpc.server?.version || rpc.server?.connId) {
+    return true;
+  }
+  return /\bgateway closed \(\d+\):|\bpairing required\b/i.test(rpc.error ?? "");
+}
+
+function gatewayLooksReachable(status: DaemonStatus): boolean {
+  if (gatewayIsRunning(status)) {
+    return true;
+  }
+  const port = activeProbePortStatus(status);
+  if (port?.status !== "busy") {
+    return false;
+  }
+  return gatewayProbeSawGateway(status);
+}
+
+function gatewayIsReady(status: DaemonStatus, options: { readyWhenReachable?: boolean }): boolean {
+  return (
+    gatewayIsRunning(status) ||
+    (options.readyWhenReachable === true && gatewayLooksReachable(status))
+  );
+}
+
+function gatewayLooksStopped(status: DaemonStatus): boolean {
+  if (status.rpc?.ok === true) {
+    return false;
+  }
+  const port = activeProbePortStatus(status);
+  if (port?.status === "free") {
+    return true;
+  }
+  const runtimeStatus = status.service.runtime?.status;
+  if (runtimeStatus === "stopped") {
+    return true;
+  }
+  const error = status.rpc?.error ?? "";
+  return /\bECONNREFUSED\b|couldn't connect|connection refused/i.test(error);
+}
+
+function gatewayServiceIsInstalled(status: DaemonStatus): boolean {
+  return Boolean(status.service.command || status.service.loaded);
+}
+
+function readinessFailureReason(status: DaemonStatus): string {
+  if (gatewayLooksStopped(status)) {
+    return "Gateway is not running.";
+  }
+  return status.rpc?.error
+    ? `Gateway probe failed: ${status.rpc.error}`
+    : "Gateway is not healthy.";
+}
+
+function printGatewayNotReadyHints(runtime: RuntimeEnv, reason: string): void {
+  runtime.log(reason);
+  runtime.log("Run `openclaw gateway status --deep` for details.");
+  runtime.log("Run `openclaw gateway start` to start a managed gateway.");
+  runtime.log("Run `openclaw gateway run` for a foreground gateway.");
+}
+
+async function confirmRecovery(params: {
+  message: string;
+  yes?: boolean;
+  interactive?: boolean;
+  confirm: (message: string, defaultYes?: boolean) => Promise<boolean>;
+}): Promise<boolean> {
+  if (params.yes) {
+    return true;
+  }
+  if (!(params.interactive ?? process.stdin.isTTY)) {
+    return false;
+  }
+  return params.confirm(params.message, true);
+}
+
+async function waitForGatewayReady(params: {
+  gatherStatus: () => Promise<DaemonStatus>;
+  readyWhenReachable?: boolean;
+  attempts?: number;
+  delayMs?: number;
+}): Promise<DaemonStatus> {
+  const attempts = params.attempts ?? 20;
+  const delayMs = params.delayMs ?? 500;
+  let latest = await params.gatherStatus();
+  for (
+    let attempt = 1;
+    attempt < attempts &&
+    !gatewayIsReady(latest, { readyWhenReachable: params.readyWhenReachable });
+    attempt += 1
+  ) {
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    latest = await params.gatherStatus();
+  }
+  return latest;
+}
+
+export async function ensureGatewayReadyForOperation(
+  options: GatewayReadinessOptions,
+): Promise<GatewayReadinessResult> {
+  const requireRpc = options.requireRpc ?? false;
+  const gatherStatus =
+    options.deps?.gatherStatus ??
+    (() => defaultGatherStatus({ requireRpc, probeUrl: options.probeUrl }));
+  const confirm = options.deps?.confirm ?? promptYesNo;
+  const installGateway =
+    options.deps?.installGateway ??
+    (async () => {
+      const { runDaemonInstall } = await daemonInstallModuleLoader.load();
+      await runDaemonInstall({ json: false });
+    });
+  const startGateway =
+    options.deps?.startGateway ??
+    (async () => {
+      const { runDaemonStart } = await daemonLifecycleModuleLoader.load();
+      await runDaemonStart({ json: false });
+    });
+
+  const initialStatus = await gatherStatus();
+  if (gatewayIsReady(initialStatus, { readyWhenReachable: options.readyWhenReachable })) {
+    return { ready: true, status: initialStatus, recovered: false };
+  }
+
+  const reason = readinessFailureReason(initialStatus);
+  if (!gatewayLooksStopped(initialStatus)) {
+    printGatewayNotReadyHints(options.runtime, reason);
+    return { ready: false, status: initialStatus, reason, recoverable: false };
+  }
+
+  const serviceInstalled = gatewayServiceIsInstalled(initialStatus);
+  const shouldInstall = !serviceInstalled;
+  if (shouldInstall && options.allowInstall === false) {
+    printGatewayNotReadyHints(options.runtime, reason);
+    return { ready: false, status: initialStatus, reason, recoverable: false };
+  }
+
+  const prompt = shouldInstall
+    ? `Gateway is not installed. Install and start it now so OpenClaw can ${options.operation}?`
+    : `Gateway is not running. Start it now so OpenClaw can ${options.operation}?`;
+  const approved = await confirmRecovery({
+    message: prompt,
+    yes: options.yes,
+    interactive: options.interactive,
+    confirm,
+  });
+  if (!approved) {
+    printGatewayNotReadyHints(options.runtime, reason);
+    return { ready: false, status: initialStatus, reason, recoverable: true };
+  }
+
+  if (shouldInstall) {
+    await installGateway();
+  } else {
+    await startGateway();
+  }
+
+  const recoveredStatus = await waitForGatewayReady({
+    gatherStatus,
+    readyWhenReachable: options.readyWhenReachable,
+  });
+  if (gatewayIsReady(recoveredStatus, { readyWhenReachable: options.readyWhenReachable })) {
+    return { ready: true, status: recoveredStatus, recovered: true };
+  }
+
+  const recoveredReason = readinessFailureReason(recoveredStatus);
+  printGatewayNotReadyHints(options.runtime, recoveredReason);
+  return {
+    ready: false,
+    status: recoveredStatus,
+    reason: recoveredReason,
+    recoverable: true,
+  };
+}


### PR DESCRIPTION
## Summary

- add a reusable gateway readiness helper that probes the intended target, prompts to install/start recoverable managed gateways, and prints recovery commands when not ready
- gate `openclaw dashboard` on that helper, including `--yes` support and dashboard-safe readiness for authenticated gateway close/pairing states
- add regression coverage for stopped gateways, target-port mismatches, auth-only dashboard readiness, unrelated busy ports, dashboard no-open behavior, and QR/dashboard SecretRef tests

## Verification

- `node scripts/run-vitest.mjs src/commands/gateway-readiness.test.ts src/commands/dashboard.test.ts src/commands/dashboard.links.test.ts src/cli/program/register.maintenance.test.ts src/cli/qr-dashboard.integration.test.ts`
- `pnpm build`
- `tmpdir=$(mktemp -d); OPENCLAW_STATE_DIR="$tmpdir" OPENCLAW_GATEWAY_PORT=49876 node openclaw.mjs dashboard --no-open 2>&1 | sed -n '1,120p'; rm -rf "$tmpdir"`
- `git diff --check HEAD^..HEAD`
- `codex-review --full-access`

## Real behavior proof

Behavior addressed: `openclaw dashboard` no longer prints/copies/opens a dashboard URL before checking that the configured gateway target is usable or recoverable.
Real environment tested: local macOS checkout on Node/OpenClaw build output, with isolated `OPENCLAW_STATE_DIR` and unused gateway port.
Exact steps or command run after this patch: ran the focused Vitest command above, `pnpm build`, isolated `openclaw.mjs dashboard --no-open` smoke, `git diff --check HEAD^..HEAD`, and `codex-review --full-access`.
Evidence after fix: terminal output from the isolated live CLI smoke was copied after this patch: `Gateway is not running.` followed by `Run openclaw gateway status --deep for details.`, `Run openclaw gateway start to start a managed gateway.`, and `Run openclaw gateway run for a foreground gateway.` No `Dashboard URL:` line was printed.
Observed result after fix: dashboard readiness refused the dead configured target in actual CLI output, printed recovery commands, and did not copy/open a dashboard URL; helper tests additionally cover known gateway auth/pairing close states and unrelated busy ports.
What was not tested: live launchd/systemd/scheduled-task start from an interactive prompt was covered by injected helper tests, not by mutating the developer machine service manager.
