### PR TITLE
Fix Kimi Coding tool-call replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ Docs: https://docs.openclaw.ai
 - Providers/polling: reject array, null, or scalar successful operation status responses with provider-owned malformed JSON errors instead of waiting until timeout.
 - ACPX/Codex: reap plugin-local Codex ACP adapter orphans on startup after wrapper crashes while keeping direct adapter commands out of launch-lease injection. Fixes #82364. (#82459) Thanks @joshavant.
 - Telegram: send presentation-only payloads by rendering fallback text and inline buttons instead of treating them as empty. Fixes #82404. (#82449) Thanks @joshavant.
+- Providers/Kimi: preserve Kimi Coding `reasoning_content` replay and backfill assistant tool-call placeholders when thinking is enabled, so `kimi-for-coding` follow-up tool turns no longer fail after prior tool use. Fixes #82161. Thanks @amknight.
 - Providers/search tools: reject malformed successful xAI, Gemini, and Kimi web/code search responses with provider-owned errors instead of silent `No response` payloads or ungrounded fallback state.
 - Trajectory export: skip and report malformed session/runtime JSONL rows in `manifest.json` instead of letting wrong-shaped session rows crash support bundle export.
 - Voice calls: persist rejected inbound-call replay keys so duplicate carrier webhook retries stay ignored after a Gateway restart.

--- a/extensions/kimi-coding/stream.test.ts
+++ b/extensions/kimi-coding/stream.test.ts
@@ -307,6 +307,126 @@ describe("kimi tool-call markup wrapper", () => {
     });
   });
 
+  it("backfills Kimi OpenAI-compatible tool-call reasoning_content when thinking is enabled", () => {
+    const { streamFn: baseStreamFn, getCapturedPayload } = createPayloadCapturingStream({
+      messages: [
+        { role: "user", content: "run pwd" },
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: { name: "exec", arguments: "{\"command\":\"pwd\"}" },
+            },
+          ],
+        },
+        {
+          role: "assistant",
+          content: "kept",
+          reasoning_content: "native reasoning",
+          tool_calls: [
+            {
+              id: "call_2",
+              type: "function",
+              function: { name: "read", arguments: "{}" },
+            },
+          ],
+        },
+      ],
+    });
+
+    const wrapped = createKimiThinkingWrapper(baseStreamFn, "enabled");
+    void wrapped(
+      {
+        api: "openai-completions",
+        provider: "kimi",
+        id: "kimi-for-coding",
+      } as Model<"openai-completions">,
+      { messages: [] } as Context,
+      {},
+    );
+
+    expect(getCapturedPayload()).toEqual({
+      messages: [
+        { role: "user", content: "run pwd" },
+        {
+          role: "assistant",
+          content: null,
+          reasoning_content: "",
+          tool_calls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: { name: "exec", arguments: "{\"command\":\"pwd\"}" },
+            },
+          ],
+        },
+        {
+          role: "assistant",
+          content: "kept",
+          reasoning_content: "native reasoning",
+          tool_calls: [
+            {
+              id: "call_2",
+              type: "function",
+              function: { name: "read", arguments: "{}" },
+            },
+          ],
+        },
+      ],
+      thinking: { type: "enabled" },
+    });
+  });
+
+  it("strips Kimi OpenAI-compatible replay reasoning_content when thinking is disabled", () => {
+    const { streamFn: baseStreamFn, getCapturedPayload } = createPayloadCapturingStream({
+      messages: [
+        {
+          role: "assistant",
+          content: null,
+          reasoning_content: "old reasoning",
+          tool_calls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: { name: "exec", arguments: "{\"command\":\"pwd\"}" },
+            },
+          ],
+        },
+      ],
+    });
+
+    const wrapped = createKimiThinkingWrapper(baseStreamFn, "disabled");
+    void wrapped(
+      {
+        api: "openai-completions",
+        provider: "kimi",
+        id: "kimi-for-coding",
+      } as Model<"openai-completions">,
+      { messages: [] } as Context,
+      {},
+    );
+
+    expect(getCapturedPayload()).toEqual({
+      messages: [
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: { name: "exec", arguments: "{\"command\":\"pwd\"}" },
+            },
+          ],
+        },
+      ],
+      thinking: { type: "disabled" },
+    });
+  });
+
   it("enables Kimi Anthropic thinking with a high budget and enough output room", () => {
     const { streamFn: baseStreamFn, getCapturedPayload } = createPayloadCapturingStream();
 

--- a/extensions/kimi-coding/stream.ts
+++ b/extensions/kimi-coding/stream.ts
@@ -75,6 +75,39 @@ function ensureKimiAnthropicMaxTokens(
   payloadObj.max_tokens = current === undefined ? required : Math.max(current, required);
 }
 
+function messageHasOpenAIToolCalls(message: Record<string, unknown>): boolean {
+  return Array.isArray(message.tool_calls) && message.tool_calls.length > 0;
+}
+
+function ensureKimiOpenAIReasoningContent(payloadObj: Record<string, unknown>): void {
+  if (!Array.isArray(payloadObj.messages)) {
+    return;
+  }
+  for (const message of payloadObj.messages) {
+    if (!message || typeof message !== "object") {
+      continue;
+    }
+    const record = message as Record<string, unknown>;
+    if (record.role !== "assistant" || !messageHasOpenAIToolCalls(record)) {
+      continue;
+    }
+    if (!("reasoning_content" in record)) {
+      record.reasoning_content = "";
+    }
+  }
+}
+
+function stripKimiOpenAIReasoningContent(payloadObj: Record<string, unknown>): void {
+  if (!Array.isArray(payloadObj.messages)) {
+    return;
+  }
+  for (const message of payloadObj.messages) {
+    if (message && typeof message === "object") {
+      delete (message as Record<string, unknown>).reasoning_content;
+    }
+  }
+}
+
 function normalizeKimiThinkingType(value: unknown): KimiThinkingType | undefined {
   if (typeof value === "boolean") {
     return value ? "enabled" : "disabled";
@@ -331,6 +364,10 @@ export function createKimiThinkingWrapper(
         model.api === "anthropic-messages" ? { ...normalized } : { type: normalized.type };
       if (model.api === "anthropic-messages") {
         ensureKimiAnthropicMaxTokens(payloadObj, normalized);
+      } else if (normalized.type === "enabled") {
+        ensureKimiOpenAIReasoningContent(payloadObj);
+      } else {
+        stripKimiOpenAIReasoningContent(payloadObj);
       }
       delete payloadObj.reasoning;
       delete payloadObj.reasoning_effort;

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -5725,6 +5725,14 @@ describe("buildOpenAICompletionsParams sanitizes reasoning replay fields", () =>
     maxTokens: 32_000,
   } satisfies Model<"openai-completions">;
 
+  const kimiCodingProxyModel = {
+    ...customKimiProxyModel,
+    id: "kimi-for-coding",
+    name: "Kimi for Coding",
+    provider: "kimi",
+    baseUrl: "https://api.kimi.com/coding/v1",
+  } satisfies Model<"openai-completions">;
+
   function getAssistantMessage(params: { messages: unknown }) {
     expect(Array.isArray(params.messages)).toBe(true);
     const list = params.messages as Array<Record<string, unknown>>;
@@ -5916,12 +5924,37 @@ describe("buildOpenAICompletionsParams sanitizes reasoning replay fields", () =>
     expect(assistant).not.toHaveProperty("reasoning_text");
   });
 
+  it("preserves reasoning_content replay for Kimi Coding OpenAI-compatible routes", () => {
+    const assistant = getAssistantMessage(
+      buildReplayParams(kimiCodingProxyModel, "reasoning_content"),
+    );
+
+    expect(assistant.reasoning_content).toBe("Need to answer politely.");
+    expect(assistant).not.toHaveProperty("reasoning_details");
+    expect(assistant).not.toHaveProperty("reasoning");
+    expect(assistant).not.toHaveProperty("reasoning_text");
+  });
+
   it("preserves reasoning_content replay for suffixed reasoning model ids", () => {
     const assistant = getAssistantMessage(
       buildReplayParams(
         {
           ...customMiMoProxyModel,
           id: "xiaomi/mimo-v2.5-pro:cloud",
+        },
+        "reasoning_content",
+      ),
+    );
+
+    expect(assistant.reasoning_content).toBe("Need to answer politely.");
+  });
+
+  it("preserves reasoning_content replay for prefixed reasoning model ids", () => {
+    const assistant = getAssistantMessage(
+      buildReplayParams(
+        {
+          ...customKimiProxyModel,
+          id: "hf:moonshotai/kimi-k2-thinking",
         },
         "reasoning_content",
       ),

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -2552,6 +2552,7 @@ function sanitizeReasoningContentReplayFields(record: Record<string, unknown>): 
 const REASONING_CONTENT_REPLAY_MODEL_IDS = new Set([
   "deepseek-v4-flash",
   "deepseek-v4-pro",
+  "kimi-for-coding",
   "kimi-k2.5",
   "kimi-k2.6",
   "kimi-k2-thinking",
@@ -2563,16 +2564,22 @@ const REASONING_CONTENT_REPLAY_MODEL_IDS = new Set([
   "mimo-v2.6-pro",
 ]);
 
-function normalizeReasoningContentReplayModelId(modelId: unknown): string | undefined {
+function getReasoningContentReplayModelIdCandidates(modelId: unknown): string[] {
   if (typeof modelId !== "string") {
-    return undefined;
+    return [];
   }
-  const normalized = modelId.trim().toLowerCase().split(":", 1)[0];
+  const normalized = modelId.trim().toLowerCase();
   if (!normalized) {
-    return undefined;
+    return [];
   }
   const parts = normalized.split("/").filter(Boolean);
-  return parts[parts.length - 1] ?? normalized;
+  const finalPart = parts[parts.length - 1] ?? normalized;
+  const candidates = [finalPart];
+  const colonParts = finalPart.split(":").filter(Boolean);
+  if (colonParts.length > 1) {
+    candidates.push(colonParts[0] ?? "", colonParts[colonParts.length - 1] ?? "");
+  }
+  return [...new Set(candidates.filter(Boolean))];
 }
 
 function shouldPreserveReasoningContentReplay(
@@ -2586,9 +2593,8 @@ function shouldPreserveReasoningContentReplay(
   ) {
     return true;
   }
-  const normalizedModelId = normalizeReasoningContentReplayModelId(model.id);
-  return (
-    normalizedModelId !== undefined && REASONING_CONTENT_REPLAY_MODEL_IDS.has(normalizedModelId)
+  return getReasoningContentReplayModelIdCandidates(model.id).some((modelId) =>
+    REASONING_CONTENT_REPLAY_MODEL_IDS.has(modelId),
   );
 }
 

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -362,7 +362,14 @@ describe("resolveTranscriptPolicy", () => {
     expect(responsesPolicy.dropReasoningFromHistory).toBe(false);
   });
 
-  it.each(["moonshotai/kimi-k2.6", "kimi-k2-thinking", "xiaomi/mimo-v2.6-pro"])(
+  it.each([
+    "kimi-for-coding",
+    "moonshotai/kimi-k2.6",
+    "kimi-k2-thinking",
+    "hf:moonshotai/kimi-k2-thinking",
+    "xiaomi/mimo-v2.6-pro",
+    "xiaomi/mimo-v2.6-pro:cloud",
+  ])(
     "preserves historical reasoning for %s replay-required OpenAI-compatible models",
     (modelId) => {
       const policy = resolveTranscriptPolicy({

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -158,6 +158,7 @@ function buildUnownedProviderTransportReplayFallback(params: {
 }
 
 const REASONING_CONTENT_REPLAY_MODEL_IDS = new Set([
+  "kimi-for-coding",
   "kimi-k2.5",
   "kimi-k2.6",
   "kimi-k2-thinking",
@@ -170,13 +171,18 @@ const REASONING_CONTENT_REPLAY_MODEL_IDS = new Set([
 ]);
 
 function requiresReasoningContentReplay(modelId: string | null | undefined): boolean {
-  const normalized = normalizeLowercaseStringOrEmpty(modelId).split(":", 1)[0];
+  const normalized = normalizeLowercaseStringOrEmpty(modelId);
   if (!normalized) {
     return false;
   }
   const parts = normalized.split("/").filter(Boolean);
   const finalPart = parts[parts.length - 1] ?? normalized;
-  return REASONING_CONTENT_REPLAY_MODEL_IDS.has(finalPart);
+  const candidates = [finalPart];
+  const colonParts = finalPart.split(":").filter(Boolean);
+  if (colonParts.length > 1) {
+    candidates.push(colonParts[0] ?? "", colonParts[colonParts.length - 1] ?? "");
+  }
+  return candidates.some((candidate) => REASONING_CONTENT_REPLAY_MODEL_IDS.has(candidate));
 }
 
 function mergeTranscriptPolicy(


### PR DESCRIPTION
## Summary

Fixes #82161 by preserving Kimi Coding reasoning replay on OpenAI-compatible follow-up turns and by backfilling the blank `reasoning_content` placeholder Kimi expects on assistant tool-call replay messages when thinking is enabled.

## Reproduction

I reproduced the issue against current `main` with a source-level probe for `{ provider: "kimi", api: "openai-completions", id: "kimi-for-coding" }`. The failing behavior was that `buildOpenAICompletionsParams` serialized the assistant tool-call replay without `reasoning_content`, even though the Kimi/Moonshot-compatible K2.6 route preserved it.

I also ran the same reproduction path in Blacksmith Testbox before the fix. That Blacksmith source probe showed `assistantHasReasoningContent: false` for `kimi-for-coding`. The Blacksmith environment did not expose a live Kimi/Moonshot key, so live provider auth was blocked; the manual E2E proof below uses a local Kimi-compatible endpoint that rejects the same missing-field condition.

## Root Cause

`kimi-for-coding` was not in the OpenAI-compatible reasoning replay allowlist used by the Chat Completions payload sanitizer, so the replay sanitizer stripped provider-owned `reasoning_content` before the next request. The Kimi provider wrapper also did not add the blank `reasoning_content` placeholder for assistant tool-call replay messages when OpenAI-compatible Kimi thinking was enabled.

## Fix

- Adds `kimi-for-coding` to the replay-required model ids in the OpenAI Chat Completions sanitizer and transcript policy.
- Expands model-id matching to handle prefixed/suffixed aliases such as `hf:moonshotai/kimi-k2-thinking` and `xiaomi/mimo-v2.6-pro:cloud`.
- Updates the Kimi Coding stream wrapper to backfill `reasoning_content: ""` on assistant tool-call replay messages when thinking is enabled, and to strip replay reasoning fields when thinking is disabled.
- Adds focused regression coverage for transport serialization, transcript policy, and the Kimi wrapper.
- Adds a changelog entry.

## Verification

- `node scripts/run-vitest.mjs src/agents/openai-transport-stream.test.ts src/agents/transcript-policy.test.ts extensions/kimi-coding/stream.test.ts` locally after rebasing onto `origin/main` (`400 passed`).
- `git diff --check origin/main...HEAD`.
- `codex review --uncommitted` before publishing: no actionable correctness findings.

## Real behavior proof

Behavior addressed: Kimi Coding OpenAI-compatible follow-up turns after tool use must include provider-owned assistant replay `reasoning_content` so Kimi does not reject the next request.

Real environment tested: Blacksmith Testbox `tbx_01krr7g58dy8f2qcxd7vqxh01q`, GitHub Actions run https://github.com/openclaw/openclaw/actions/runs/25960370706.

Exact steps or command run after this patch: `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --blacksmith-workflow .github/workflows/ci-check-testbox.yml --blacksmith-job check --blacksmith-ref main --timing-json --shell -- "... node scripts/run-vitest.mjs src/agents/openai-transport-stream.test.ts src/agents/transcript-policy.test.ts extensions/kimi-coding/stream.test.ts; ... manual Kimi-compatible loopback E2E ..."`.

Evidence after fix: Blacksmith focused tests passed (`5 passed`, `396 passed` at that pre-rebase base), then the manual E2E fake provider captured `/v1/chat/completions` with `thinking: { "type": "enabled" }` and assistant replay `reasoning_content: ""`.

Observed result after fix: the fake Kimi-compatible endpoint returned `KIMI_REPLAY_OK`; the same harness rejects the request if assistant tool-call replay is missing `reasoning_content`.

What was not tested: a live Kimi API request, because the Blacksmith environment did not provide `KIMI_API_KEY`, `KIMICODE_API_KEY`, or `MOONSHOT_API_KEY`.