### PR TITLE
fix: limit Codex attribution to local transcripts

### DIFF
--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -348,6 +348,53 @@ describe("CodexAppServerEventProjector", () => {
     expect(result.lastAssistant?.model).toBe("gpt-5.5");
   });
 
+  it("preserves OpenAI attribution for Codex app-server OpenAI API-key fallback profiles", async () => {
+    const params = await createParams();
+    const projector = await createProjector({
+      ...params,
+      provider: "openai",
+      authProfileId: "openai:work",
+      modelId: "gpt-5.5",
+      model: {
+        ...createCodexTestModel("openai"),
+        id: "gpt-5.5",
+        name: "gpt-5.5",
+        api: "openai-responses",
+      } as EmbeddedRunAttemptParams["model"],
+      runtimePlan: {
+        auth: {
+          providerForAuth: "openai",
+          authProfileProviderForAuth: "openai",
+          harnessAuthProvider: "openai-codex",
+          forwardedAuthProfileId: "openai:work",
+        },
+        observability: {
+          resolvedRef: "openai/gpt-5.5",
+          provider: "openai",
+          modelId: "gpt-5.5",
+          harnessId: "codex",
+        },
+        prompt: {
+          resolveSystemPromptContribution: () => undefined,
+        },
+        tools: {
+          normalize: (tools: unknown[]) => tools,
+          logDiagnostics: () => undefined,
+        },
+      } as unknown as EmbeddedRunAttemptParams["runtimePlan"],
+    });
+
+    await projector.handleNotification(
+      turnCompleted([{ type: "agentMessage", id: "msg-1", text: "done" }]),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+
+    expect(result.lastAssistant?.provider).toBe("openai");
+    expect(result.lastAssistant?.api).toBe("openai-responses");
+    expect(result.lastAssistant?.model).toBe("gpt-5.5");
+  });
+
   it("preserves inbound sender metadata on the mirrored user prompt", async () => {
     const params = await createParams();
     const projector = await createProjector({

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -307,6 +307,47 @@ describe("CodexAppServerEventProjector", () => {
     expect(result.replayMetadata.replaySafe).toBe(true);
   });
 
+  it("records canonical OpenAI Codex app-server turns with Codex local attribution", async () => {
+    const params = await createParams();
+    const projector = await createProjector({
+      ...params,
+      provider: "openai",
+      modelId: "gpt-5.5",
+      model: {
+        ...createCodexTestModel("openai"),
+        id: "gpt-5.5",
+        name: "gpt-5.5",
+        api: "openai-responses",
+      } as EmbeddedRunAttemptParams["model"],
+      runtimePlan: {
+        auth: {},
+        observability: {
+          resolvedRef: "openai/gpt-5.5",
+          provider: "openai",
+          modelId: "gpt-5.5",
+          harnessId: "codex",
+        },
+        prompt: {
+          resolveSystemPromptContribution: () => undefined,
+        },
+        tools: {
+          normalize: (tools: unknown[]) => tools,
+          logDiagnostics: () => undefined,
+        },
+      } as unknown as EmbeddedRunAttemptParams["runtimePlan"],
+    });
+
+    await projector.handleNotification(
+      turnCompleted([{ type: "agentMessage", id: "msg-1", text: "done" }]),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+
+    expect(result.lastAssistant?.provider).toBe("openai-codex");
+    expect(result.lastAssistant?.api).toBe("openai-codex-responses");
+    expect(result.lastAssistant?.model).toBe("gpt-5.5");
+  });
+
   it("preserves inbound sender metadata on the mirrored user prompt", async () => {
     const params = await createParams();
     const projector = await createProjector({

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -21,6 +21,7 @@ import {
   type ToolProgressDetailMode,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { emitTrustedDiagnosticEvent } from "openclaw/plugin-sdk/diagnostic-runtime";
+import { resolveCodexLocalRuntimeAttribution } from "./local-runtime-attribution.js";
 import { CodexNativeSubagentTaskMirror } from "./native-subagent-task-mirror.js";
 import { readCodexTurn } from "./protocol-validators.js";
 import {
@@ -1187,6 +1188,7 @@ export class CodexAppServerEventProjector {
   }
 
   private createAssistantMessage(text: string): AssistantMessage {
+    const attribution = resolveCodexLocalRuntimeAttribution(this.params);
     const usage: Usage = this.tokenUsage
       ? {
           input: this.tokenUsage.input ?? 0,
@@ -1205,8 +1207,8 @@ export class CodexAppServerEventProjector {
     return {
       role: "assistant",
       content: [{ type: "text", text }],
-      api: this.params.model.api ?? "openai-codex-responses",
-      provider: this.params.provider,
+      api: attribution.api ?? "openai-codex-responses",
+      provider: attribution.provider,
       model: this.params.modelId,
       usage,
       stopReason: this.aborted ? "aborted" : this.promptError ? "error" : "stop",
@@ -1216,11 +1218,12 @@ export class CodexAppServerEventProjector {
   }
 
   private createAssistantMirrorMessage(title: string, text: string): AssistantMessage {
+    const attribution = resolveCodexLocalRuntimeAttribution(this.params);
     return {
       role: "assistant",
       content: [{ type: "text", text: `${title}:\n${text}` }],
-      api: this.params.model.api ?? "openai-codex-responses",
-      provider: this.params.provider,
+      api: attribution.api ?? "openai-codex-responses",
+      provider: attribution.provider,
       model: this.params.modelId,
       usage: ZERO_USAGE,
       stopReason: "stop",
@@ -1230,6 +1233,7 @@ export class CodexAppServerEventProjector {
 
   private createToolCallMessage(params: ToolTranscriptCallInput): AgentMessage {
     const args = normalizeToolTranscriptArguments(params.arguments);
+    const attribution = resolveCodexLocalRuntimeAttribution(this.params);
     return {
       role: "assistant",
       content: [
@@ -1241,8 +1245,8 @@ export class CodexAppServerEventProjector {
           input: args,
         },
       ],
-      api: this.params.model.api ?? "openai-codex-responses",
-      provider: this.params.provider,
+      api: attribution.api ?? "openai-codex-responses",
+      provider: attribution.provider,
       model: this.params.modelId,
       usage: ZERO_USAGE,
       stopReason: "toolUse",

--- a/extensions/codex/src/app-server/local-runtime-attribution.ts
+++ b/extensions/codex/src/app-server/local-runtime-attribution.ts
@@ -17,8 +17,12 @@ function normalizeRuntimeId(value: string | undefined): string {
 export function resolveCodexLocalRuntimeAttribution(
   params: EmbeddedRunAttemptParams,
 ): CodexLocalRuntimeAttribution {
+  const authProfileProvider = normalizeRuntimeId(
+    params.runtimePlan?.auth?.authProfileProviderForAuth,
+  );
   if (
     normalizeRuntimeId(params.runtimePlan?.observability.harnessId) === "codex" &&
+    authProfileProvider !== OPENAI_PROVIDER_ID &&
     normalizeRuntimeId(params.model.provider) === OPENAI_PROVIDER_ID &&
     normalizeRuntimeId(params.model.api) === OPENAI_RESPONSES_API
   ) {

--- a/extensions/codex/src/app-server/local-runtime-attribution.ts
+++ b/extensions/codex/src/app-server/local-runtime-attribution.ts
@@ -1,0 +1,35 @@
+import type { EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
+
+const OPENAI_PROVIDER_ID = "openai";
+const OPENAI_RESPONSES_API = "openai-responses";
+const OPENAI_CODEX_PROVIDER_ID = "openai-codex";
+const OPENAI_CODEX_RESPONSES_API = "openai-codex-responses";
+
+export type CodexLocalRuntimeAttribution = {
+  provider: string;
+  api?: string;
+};
+
+function normalizeRuntimeId(value: string | undefined): string {
+  return value?.trim().toLowerCase() ?? "";
+}
+
+export function resolveCodexLocalRuntimeAttribution(
+  params: EmbeddedRunAttemptParams,
+): CodexLocalRuntimeAttribution {
+  if (
+    normalizeRuntimeId(params.runtimePlan?.observability.harnessId) === "codex" &&
+    normalizeRuntimeId(params.model.provider) === OPENAI_PROVIDER_ID &&
+    normalizeRuntimeId(params.model.api) === OPENAI_RESPONSES_API
+  ) {
+    return {
+      provider: OPENAI_CODEX_PROVIDER_ID,
+      api: OPENAI_CODEX_RESPONSES_API,
+    };
+  }
+
+  return {
+    provider: params.provider,
+    api: params.model.api,
+  };
+}

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -869,6 +869,52 @@ describe("runCodexAppServerAttempt", () => {
     );
   });
 
+  it("keeps canonical OpenAI Codex runs on OpenAI dynamic tool policy", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(sessionFile, workspaceDir);
+    params.disableTools = false;
+    params.provider = "openai";
+    params.modelId = "gpt-5.5";
+    params.model = {
+      ...createCodexTestModel("openai"),
+      id: "gpt-5.5",
+      name: "gpt-5.5",
+      api: "openai-responses",
+    } as EmbeddedRunAttemptParams["model"];
+    params.runtimePlan = {
+      ...createCodexRuntimePlanFixture(),
+      observability: {
+        resolvedRef: "openai/gpt-5.5",
+        provider: "openai",
+        modelId: "gpt-5.5",
+        harnessId: "codex",
+      },
+    };
+
+    const factoryOptions: unknown[] = [];
+    __testing.setOpenClawCodingToolsFactoryForTests((options) => {
+      factoryOptions.push(options);
+      return [];
+    });
+
+    await __testing.buildDynamicTools({
+      params,
+      resolvedWorkspace: workspaceDir,
+      effectiveWorkspace: workspaceDir,
+      sandboxSessionKey: params.sessionKey!,
+      sandbox: null as never,
+      runAbortController: new AbortController(),
+      sessionAgentId: "main",
+      pluginConfig: {},
+      onYieldDetected: () => undefined,
+    });
+
+    expect(factoryOptions).toHaveLength(1);
+    expect((factoryOptions[0] as { modelProvider?: unknown }).modelProvider).toBe("openai");
+    expect((factoryOptions[0] as { modelApi?: unknown }).modelApi).toBe("openai-responses");
+  });
+
   it("normalizes Codex dynamic toolsAllow entries before filtering", () => {
     const tools = ["exec", "apply_patch", "read", "message"].map((name) => ({ name }));
 

--- a/extensions/codex/src/app-server/trajectory.test.ts
+++ b/extensions/codex/src/app-server/trajectory.test.ts
@@ -82,6 +82,43 @@ describe("Codex trajectory recorder", () => {
     expect(fs.existsSync(path.join(tmpDir, "session.trajectory-path.json"))).toBe(true);
   });
 
+  it("records canonical OpenAI Codex app-server turns with Codex local attribution", async () => {
+    const tmpDir = makeTempDir();
+    const sessionFile = path.join(tmpDir, "session.jsonl");
+    const recorder = createCodexTrajectoryRecorder({
+      cwd: tmpDir,
+      attempt: {
+        sessionFile,
+        sessionId: "session-1",
+        sessionKey: "agent:main:session-1",
+        runId: "run-1",
+        provider: "openai",
+        modelId: "gpt-5.5",
+        model: { provider: "openai", api: "openai-responses" },
+        runtimePlan: {
+          observability: {
+            resolvedRef: "openai/gpt-5.5",
+            provider: "openai",
+            modelId: "gpt-5.5",
+            harnessId: "codex",
+          },
+        },
+      } as never,
+      env: {},
+    });
+
+    const trajectoryRecorder = expectTrajectoryRecorder(recorder);
+    trajectoryRecorder.recordEvent("session.started");
+    await trajectoryRecorder.flush();
+
+    const parsed = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, "session.trajectory.jsonl"), "utf8"),
+    );
+    expect(parsed.provider).toBe("openai-codex");
+    expect(parsed.modelApi).toBe("openai-codex-responses");
+    expect(parsed.modelId).toBe("gpt-5.5");
+  });
+
   it("sanitizes session ids when resolving an override directory", async () => {
     const tmpDir = makeTempDir();
     const recorder = createCodexTrajectoryRecorder({

--- a/extensions/codex/src/app-server/trajectory.ts
+++ b/extensions/codex/src/app-server/trajectory.ts
@@ -10,6 +10,7 @@ import {
   appendRegularFile,
   resolveRegularFileAppendFlags,
 } from "openclaw/plugin-sdk/security-runtime";
+import { resolveCodexLocalRuntimeAttribution } from "./local-runtime-attribution.js";
 
 type CodexTrajectoryRecorder = {
   filePath: string;
@@ -163,6 +164,7 @@ export function createCodexTrajectoryRecorder(
   });
   let queue = Promise.resolve();
   let seq = 0;
+  const attribution = resolveCodexLocalRuntimeAttribution(params.attempt);
 
   return {
     filePath,
@@ -180,9 +182,9 @@ export function createCodexTrajectoryRecorder(
         sessionKey: params.attempt.sessionKey,
         runId: params.attempt.runId,
         workspaceDir: params.cwd,
-        provider: params.attempt.provider,
+        provider: attribution.provider,
         modelId: params.attempt.modelId,
-        modelApi: params.attempt.model.api,
+        modelApi: attribution.api,
         data: data ? sanitizeValue(data) : undefined,
       };
       const line = boundedTrajectoryLine(event);

--- a/src/commands/gateway-readiness.ts
+++ b/src/commands/gateway-readiness.ts
@@ -51,9 +51,7 @@ async function defaultGatherStatus(params: {
 }): Promise<DaemonStatus> {
   const { gatherDaemonStatus } = await daemonStatusModuleLoader.load();
   return gatherDaemonStatus({
-    rpc: {
-      ...(params.probeUrl ? { url: params.probeUrl } : {}),
-    },
+    rpc: params.probeUrl ? { url: params.probeUrl } : {},
     probe: true,
     requireRpc: params.requireRpc,
     deep: false,
@@ -67,10 +65,10 @@ function activeProbePortStatus(status: DaemonStatus): DaemonStatus["port"] {
         try {
           return Number(new URL(probeUrl).port);
         } catch {
-          return NaN;
+          return Number.NaN;
         }
       })()
-    : NaN;
+    : Number.NaN;
   if (Number.isFinite(probePort) && status.portCli?.port === probePort) {
     return status.portCli;
   }


### PR DESCRIPTION
## Summary
- normalize canonical OpenAI Codex app-server local transcript and trajectory attribution to `openai-codex` / `openai-codex-responses`
- keep runtime/tool/app-server provider metadata untouched, so `tools.byProvider.openai` still matches canonical OpenAI Codex turns
- add focused regressions for transcript, trajectory, and dynamic-tool policy boundaries

Replaces #81180.
Related: #81114.

## Verification
- `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test extensions/codex/src/app-server/event-projector.test.ts extensions/codex/src/app-server/trajectory.test.ts extensions/codex/src/app-server/run-attempt.test.ts -t "local attribution|OpenAI dynamic tool policy"`
- `pnpm exec oxfmt --check --threads=1 extensions/codex/src/app-server/local-runtime-attribution.ts extensions/codex/src/app-server/event-projector.ts extensions/codex/src/app-server/trajectory.ts extensions/codex/src/app-server/event-projector.test.ts extensions/codex/src/app-server/trajectory.test.ts extensions/codex/src/app-server/run-attempt.test.ts`
- `git diff --check`
- `codex-review --parallel-tests ...`: clean; focused app-server files passed, 176 tests

## Real behavior proof
Behavior addressed: canonical `openai/gpt-5.5` Codex app-server turns now write local transcript and trajectory attribution as Codex-owned while leaving runtime/tool routing on OpenAI metadata.
Real environment tested: local OpenClaw checkout on branch `fix/codex-local-transcript-attribution`; fake Codex app-server/projector/trajectory harnesses.
Exact steps or command run after this patch: `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test extensions/codex/src/app-server/event-projector.test.ts extensions/codex/src/app-server/trajectory.test.ts extensions/codex/src/app-server/run-attempt.test.ts -t "local attribution|OpenAI dynamic tool policy"`; `codex-review --parallel-tests ...`.
Evidence after fix: transcript and trajectory tests assert `openai-codex` / `openai-codex-responses`; dynamic-tool test asserts `modelProvider: openai` and `modelApi: openai-responses` still reach the tool factory.
Observed result after fix: focused local tests passed; review reported no correctness issues.
What was not tested: live OAuth/frontier Codex app-server traffic; full CI before PR creation.
