### PR TITLE
fix(commands): satisfy gateway readiness lint

### DIFF
--- a/src/commands/gateway-readiness.ts
+++ b/src/commands/gateway-readiness.ts
@@ -51,9 +51,7 @@ async function defaultGatherStatus(params: {
 }): Promise<DaemonStatus> {
   const { gatherDaemonStatus } = await daemonStatusModuleLoader.load();
   return gatherDaemonStatus({
-    rpc: {
-      ...(params.probeUrl ? { url: params.probeUrl } : {}),
-    },
+    rpc: params.probeUrl ? { url: params.probeUrl } : {},
     probe: true,
     requireRpc: params.requireRpc,
     deep: false,
@@ -67,10 +65,10 @@ function activeProbePortStatus(status: DaemonStatus): DaemonStatus["port"] {
         try {
           return Number(new URL(probeUrl).port);
         } catch {
-          return NaN;
+          return Number.NaN;
         }
       })()
-    : NaN;
+    : Number.NaN;
   if (Number.isFinite(probePort) && status.portCli?.port === probePort) {
     return status.portCli;
   }


### PR DESCRIPTION
## Summary
- Remove the redundant object spread in gateway readiness RPC options.
- Replace global `NaN` with `Number.NaN` in gateway readiness probe parsing.

## Verification
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/commands/gateway-readiness.ts`
- `node scripts/run-vitest.mjs src/commands/gateway-readiness.test.ts`
- `pnpm openclaw dashboard --no-open`
- `git diff --check origin/main...HEAD`

## Real behavior proof
Behavior addressed: Current `main` reports gateway readiness oxlint failures for `unicorn/no-useless-spread` and `unicorn/prefer-number-properties` in `src/commands/gateway-readiness.ts`.
Real environment tested: Local macOS OpenClaw checkout based on `origin/main` at `f50c65f12454`; `pnpm openclaw dashboard --no-open` was run against the local gateway configuration.
Exact steps or command run after this patch: Ran `pnpm openclaw dashboard --no-open` after the patch, plus the targeted oxlint wrapper, the gateway readiness Vitest file, and whitespace validation listed above.
Evidence after fix: The dashboard command completed successfully and printed `Dashboard URL: http://127.0.0.1:18789/`, `Token auto-auth included in browser/clipboard URL.`, `Copied to clipboard.`, and `Browser launch disabled (--no-open). Token-authenticated URL copied to clipboard.` Oxlint reported `Found 0 warnings and 0 errors`; `src/commands/gateway-readiness.test.ts` reported 1 file and 8 tests passed.
Observed result after fix: The real dashboard readiness path still resolves and reports the dashboard URL, while the gateway readiness lint violations are gone.
What was not tested: Full CI; the PR workflow covers the broader lint/check matrix.
