### PR TITLE
fix: hide decorative emoji on unsupported terminals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 - Codex app-server: release raw assistant completions when `turn/completed` is missing while keeping commentary/status items as progress, preventing completed Codex runs from hanging until timeout. Fixes #82343. (#82403) Thanks @IWhatsskill.
 - CLI/status: show plain empty-state messages instead of empty Channels and Sessions tables when no channels or sessions exist.
 - CLI/dashboard: probe Gateway readiness before handing out the dashboard URL, prompting to start or install the managed service when the Gateway is stopped and printing recovery commands instead of opening a dead browser tab.
+- CLI: hide decorative startup and status emoji on terminals that are unlikely to render them correctly, keeping semantic message and identity emoji intact.
 - CLI/context engines: bootstrap and finalize non-legacy context engines for CLI turns while preserving transcript snapshots and deferred maintenance ownership. (#81869) Thanks @sahilsatralkar.
 - Telegram: persist polling updates through restart replay so queued same-topic messages resume in order instead of losing context after a gateway restart. (#82256) Thanks @VACInc.
 - Gateway/Gmail: abort in-flight Gmail watcher startup and hot-reload restarts before shutdown so reloads cannot spawn `gog serve` after the Gateway is closing. Thanks @frankekn.

--- a/src/cli/banner.test.ts
+++ b/src/cli/banner.test.ts
@@ -20,6 +20,9 @@ describe("formatCliBannerLine", () => {
 
     const line = formatCliBannerLine("2026.3.7", {
       commit: "abc1234",
+      env: { LANG: "en_US.UTF-8" },
+      isTty: true,
+      platform: "darwin",
       richTty: false,
     });
 
@@ -31,6 +34,9 @@ describe("formatCliBannerLine", () => {
 
     const line = formatCliBannerLine("2026.3.7", {
       commit: "abc1234",
+      env: { LANG: "en_US.UTF-8" },
+      isTty: true,
+      platform: "darwin",
       richTty: false,
     });
 
@@ -42,10 +48,27 @@ describe("formatCliBannerLine", () => {
 
     const line = formatCliBannerLine("2026.3.7", {
       commit: "abc1234",
+      env: { LANG: "en_US.UTF-8" },
+      isTty: true,
+      platform: "darwin",
       richTty: false,
       mode: "default",
     });
 
     expect(line).toBe("🦞 OpenClaw 2026.3.7 (abc1234) — All your chats, one OpenClaw.");
+  });
+
+  it("drops decorative emoji for generic Linux terminals", () => {
+    readCliBannerTaglineModeMock.mockReturnValue("off");
+
+    const line = formatCliBannerLine("2026.3.7", {
+      commit: "abc1234",
+      env: { TERM: "xterm-256color", LANG: "en_US.UTF-8" },
+      isTty: true,
+      platform: "linux",
+      richTty: false,
+    });
+
+    expect(line).toBe("OpenClaw 2026.3.7 (abc1234)");
   });
 });

--- a/src/cli/banner.ts
+++ b/src/cli/banner.ts
@@ -1,5 +1,12 @@
 import { resolveCommitHash } from "../infra/git-commit.js";
 import { visibleWidth } from "../terminal/ansi.js";
+import {
+  decorativeEmoji,
+  decorativePrefix,
+  stripDecorativeEmojiForTerminal,
+  supportsDecorativeEmoji,
+  type DecorativeEmojiOptions,
+} from "../terminal/decorative-emoji.js";
 import { isRich, theme } from "../terminal/theme.js";
 import { hasRootVersionAlias } from "./argv.js";
 import { parseTaglineMode, readCliBannerTaglineMode } from "./banner-config-lite.js";
@@ -9,6 +16,8 @@ type BannerOptions = TaglineOptions & {
   argv?: string[];
   commit?: string | null;
   columns?: number;
+  isTty?: boolean;
+  platform?: NodeJS.Platform;
   richTty?: boolean;
 };
 
@@ -44,14 +53,27 @@ function resolveTaglineMode(options: BannerOptions): TaglineMode | undefined {
   return readCliBannerTaglineMode(options.env);
 }
 
+function resolveEmojiOptions(options: BannerOptions): DecorativeEmojiOptions {
+  return {
+    ...(options.env ? { env: options.env } : {}),
+    ...(options.isTty === undefined ? {} : { isTty: options.isTty }),
+    ...(options.platform ? { platform: options.platform } : {}),
+  };
+}
+
 export function formatCliBannerLine(version: string, options: BannerOptions = {}): string {
   const commit =
     options.commit ?? resolveCommitHash({ env: options.env, moduleUrl: import.meta.url });
   const commitLabel = commit ?? "unknown";
-  const tagline = pickTagline({ ...options, mode: resolveTaglineMode(options) });
+  const emojiOptions = resolveEmojiOptions(options);
+  const tagline = stripDecorativeEmojiForTerminal(
+    pickTagline({ ...options, mode: resolveTaglineMode(options) }),
+    emojiOptions,
+  );
   const rich = options.richTty ?? isRich();
-  const title = "🦞 OpenClaw";
-  const prefix = "🦞 ";
+  const title = decorativePrefix("🦞", "OpenClaw", emojiOptions);
+  const prefix = decorativeEmoji("🦞", emojiOptions);
+  const indent = prefix ? `${prefix} ` : "";
   const columns = options.columns ?? process.stdout.columns ?? 120;
   const plainBaseLine = `${title} ${version} (${commitLabel})`;
   const plainFullLine = tagline ? `${plainBaseLine} — ${tagline}` : plainBaseLine;
@@ -71,7 +93,7 @@ export function formatCliBannerLine(version: string, options: BannerOptions = {}
     if (!tagline) {
       return line1;
     }
-    const line2 = `${" ".repeat(prefix.length)}${theme.accentDim(tagline)}`;
+    const line2 = `${" ".repeat(indent.length)}${theme.accentDim(tagline)}`;
     return `${line1}\n${line2}`;
   }
   if (fitsOnOneLine) {
@@ -81,24 +103,37 @@ export function formatCliBannerLine(version: string, options: BannerOptions = {}
   if (!tagline) {
     return line1;
   }
-  const line2 = `${" ".repeat(prefix.length)}${tagline}`;
+  const line2 = `${" ".repeat(indent.length)}${tagline}`;
   return `${line1}\n${line2}`;
 }
 
-const LOBSTER_ASCII = [
+const LOBSTER_ASCII_BODY = [
   "▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄",
   "██░▄▄▄░██░▄▄░██░▄▄▄██░▀██░██░▄▄▀██░████░▄▄▀██░███░██",
   "██░███░██░▀▀░██░▄▄▄██░█░█░██░█████░████░▀▀░██░█░█░██",
   "██░▀▀▀░██░█████░▀▀▀██░██▄░██░▀▀▄██░▀▀░█░██░██▄▀▄▀▄██",
   "▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀",
-  "                  🦞 OPENCLAW 🦞                    ",
-  " ",
 ];
+
+function centerText(text: string, width: number): string {
+  const pad = Math.max(0, width - visibleWidth(text));
+  const left = Math.floor(pad / 2);
+  const right = pad - left;
+  return `${" ".repeat(left)}${text}${" ".repeat(right)}`;
+}
+
+function formatCliBannerArtLines(options: BannerOptions): string[] {
+  const width = visibleWidth(LOBSTER_ASCII_BODY[0] ?? "");
+  const emojiOptions = resolveEmojiOptions(options);
+  const title = supportsDecorativeEmoji(emojiOptions) ? "🦞 OPENCLAW 🦞" : "OPENCLAW";
+  return [...LOBSTER_ASCII_BODY, centerText(title, width), " "];
+}
 
 export function formatCliBannerArt(options: BannerOptions = {}): string {
   const rich = options.richTty ?? isRich();
+  const lines = formatCliBannerArtLines(options);
   if (!rich) {
-    return LOBSTER_ASCII.join("\n");
+    return lines.join("\n");
   }
 
   const colorChar = (ch: string) => {
@@ -114,13 +149,18 @@ export function formatCliBannerArt(options: BannerOptions = {}): string {
     return theme.muted(ch);
   };
 
-  const colored = LOBSTER_ASCII.map((line) => {
+  const emojiOptions = resolveEmojiOptions(options);
+  const icon = decorativeEmoji("🦞", emojiOptions);
+  const colored = lines.map((line) => {
     if (line.includes("OPENCLAW")) {
+      if (!icon) {
+        return theme.info(centerText("OPENCLAW", visibleWidth(line)));
+      }
       return (
         theme.muted("              ") +
-        theme.accent("🦞") +
+        theme.accent(icon) +
         theme.info(" OPENCLAW ") +
-        theme.accent("🦞")
+        theme.accent(icon)
       );
     }
     return splitGraphemes(line).map(colorChar).join("");

--- a/src/cli/hooks-cli.ts
+++ b/src/cli/hooks-cli.ts
@@ -13,6 +13,7 @@ import { loadWorkspaceHookEntries } from "../hooks/workspace.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { buildPluginDiagnosticsReport } from "../plugins/status.js";
 import { defaultRuntime } from "../runtime.js";
+import { decorativeEmoji, decorativePrefix } from "../terminal/decorative-emoji.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { getTerminalTableWidth, renderTable } from "../terminal/table.js";
 import { theme } from "../terminal/theme.js";
@@ -103,14 +104,15 @@ function formatHookStatus(hook: HookStatusEntry): string {
     return theme.success("✓ ready");
   }
   if (!hook.enabledByConfig) {
-    return theme.warn("⏸ disabled");
+    return theme.warn(decorativePrefix("⏸", "disabled"));
   }
   return theme.error("✗ missing");
 }
 
 function formatHookName(hook: HookStatusEntry): string {
-  const emoji = hook.emoji ?? "🔗";
-  return `${emoji} ${theme.command(hook.name)}`;
+  const emoji = hook.emoji ?? decorativeEmoji("🔗");
+  const name = theme.command(hook.name);
+  return emoji ? `${emoji} ${name}` : name;
 }
 
 function formatHookSource(hook: HookStatusEntry): string {
@@ -266,14 +268,14 @@ export function formatHookInfo(
   }
 
   const lines: string[] = [];
-  const emoji = hook.emoji ?? "🔗";
+  const emoji = hook.emoji ?? decorativeEmoji("🔗");
   const status = hook.loadable
     ? theme.success("✓ Ready")
     : !hook.enabledByConfig
-      ? theme.warn("⏸ Disabled")
+      ? theme.warn(decorativePrefix("⏸", "Disabled"))
       : theme.error("✗ Missing requirements");
 
-  lines.push(`${emoji} ${theme.heading(hook.name)} ${status}`);
+  lines.push(`${emoji ? `${emoji} ` : ""}${theme.heading(hook.name)} ${status}`);
   lines.push("");
   lines.push(hook.description);
   lines.push("");
@@ -409,7 +411,8 @@ export function formatHooksCheck(report: HookStatusReport, opts: HooksCheckOptio
       if (hook.missing.os.length > 0) {
         reasons.push(`os: ${hook.missing.os.join(", ")}`);
       }
-      lines.push(`  ${hook.emoji ?? "🔗"} ${hook.name} - ${reasons.join("; ")}`);
+      const emoji = hook.emoji ?? decorativeEmoji("🔗");
+      lines.push(`  ${emoji ? `${emoji} ` : ""}${hook.name} - ${reasons.join("; ")}`);
     }
   }
 
@@ -432,7 +435,7 @@ export async function enableHook(hookName: string): Promise<void> {
     ...(snapshot.hash !== undefined ? { baseHash: snapshot.hash } : {}),
   });
   defaultRuntime.log(
-    `${theme.success("✓")} Enabled hook: ${hook.emoji ?? "🔗"} ${theme.command(hookName)}`,
+    `${theme.success("✓")} Enabled hook: ${hook.emoji ? `${hook.emoji} ${theme.command(hookName)}` : decorativePrefix("🔗", theme.command(hookName))}`,
   );
 }
 
@@ -447,7 +450,7 @@ export async function disableHook(hookName: string): Promise<void> {
     ...(snapshot.hash !== undefined ? { baseHash: snapshot.hash } : {}),
   });
   defaultRuntime.log(
-    `${theme.warn("⏸")} Disabled hook: ${hook.emoji ?? "🔗"} ${theme.command(hookName)}`,
+    `${theme.warn(decorativePrefix("⏸", "Disabled hook:"))} ${hook.emoji ? `${hook.emoji} ${theme.command(hookName)}` : decorativePrefix("🔗", theme.command(hookName))}`,
   );
 }
 

--- a/src/cli/skills-cli.format.ts
+++ b/src/cli/skills-cli.format.ts
@@ -1,5 +1,6 @@
 import type { SkillStatusEntry, SkillStatusReport } from "../agents/skills-status.js";
 import { sanitizeForLog, stripAnsi } from "../terminal/ansi.js";
+import { decorativeEmoji, decorativePrefix } from "../terminal/decorative-emoji.js";
 import { getTerminalTableWidth, renderTable } from "../terminal/table.js";
 import { theme } from "../terminal/theme.js";
 import { shortenHomePath } from "../utils.js";
@@ -29,13 +30,13 @@ function appendClawHubHint(output: string, json?: boolean): string {
 
 function formatSkillStatus(skill: SkillStatusEntry): string {
   if (skill.disabled) {
-    return theme.warn("⏸ disabled");
+    return theme.warn(decorativePrefix("⏸", "disabled"));
   }
   if (skill.blockedByAllowlist) {
-    return theme.warn("🚫 blocked");
+    return theme.warn(decorativePrefix("🚫", "blocked"));
   }
   if (skill.blockedByAgentFilter) {
-    return theme.warn("🚫 excluded");
+    return theme.warn(decorativePrefix("🚫", "excluded"));
   }
   if (skill.eligible) {
     return theme.success("✓ ready");
@@ -44,7 +45,10 @@ function formatSkillStatus(skill: SkillStatusEntry): string {
 }
 
 function normalizeSkillEmoji(emoji?: string): string {
-  return (emoji ?? "📦").replaceAll("\uFE0E", "\uFE0F");
+  if (emoji) {
+    return emoji.replaceAll("\uFE0E", "\uFE0F");
+  }
+  return decorativeEmoji("📦");
 }
 
 const REMAINING_ESC_SEQUENCE_REGEX = new RegExp(
@@ -75,7 +79,8 @@ function sanitizeJsonValue(value: unknown): unknown {
 }
 function formatSkillName(skill: SkillStatusEntry): string {
   const emoji = normalizeSkillEmoji(skill.emoji);
-  return `${emoji} ${theme.command(sanitizeForLog(skill.name))}`;
+  const name = theme.command(sanitizeForLog(skill.name));
+  return emoji ? `${emoji} ${name}` : name;
 }
 
 function formatSkillMissingSummary(skill: SkillStatusEntry): string {
@@ -197,11 +202,11 @@ export function formatSkillInfo(
   const lines: string[] = [];
   const emoji = normalizeSkillEmoji(skill.emoji);
   const status = skill.disabled
-    ? theme.warn("⏸ Disabled")
+    ? theme.warn(decorativePrefix("⏸", "Disabled"))
     : skill.blockedByAllowlist
-      ? theme.warn("🚫 Blocked by allowlist")
+      ? theme.warn(decorativePrefix("🚫", "Blocked by allowlist"))
       : skill.blockedByAgentFilter
-        ? theme.warn("🚫 Excluded by agent allowlist")
+        ? theme.warn(decorativePrefix("🚫", "Excluded by agent allowlist"))
         : skill.eligible
           ? theme.success("✓ Ready")
           : theme.warn("△ Needs setup");
@@ -210,7 +215,7 @@ export function formatSkillInfo(
   const safeHomepage = skill.homepage ? sanitizeForLog(skill.homepage) : undefined;
   const safeSkillKey = sanitizeForLog(skill.skillKey);
 
-  lines.push(`${emoji} ${theme.heading(safeName)} ${status}`);
+  lines.push(`${emoji ? `${emoji} ` : ""}${theme.heading(safeName)} ${status}`);
   lines.push("");
   lines.push(sanitizeForLog(skill.description));
   lines.push("");
@@ -376,11 +381,15 @@ export function formatSkillsCheck(report: SkillStatusReport, opts: SkillsCheckOp
   lines.push(
     `${theme.success("✓")} ${theme.muted("Available as command:")} ${commandVisible.length}`,
   );
-  lines.push(`${theme.warn("⏸")} ${theme.muted("Disabled:")} ${disabled.length}`);
-  lines.push(`${theme.warn("🚫")} ${theme.muted("Blocked by allowlist:")} ${blocked.length}`);
+  lines.push(
+    `${theme.warn(decorativePrefix("⏸", "Disabled:"))} ${theme.muted(String(disabled.length))}`,
+  );
+  lines.push(
+    `${theme.warn(decorativePrefix("🚫", "Blocked by allowlist:"))} ${theme.muted(String(blocked.length))}`,
+  );
   if (agentId || agentFiltered.length > 0) {
     lines.push(
-      `${theme.warn("🚫")} ${theme.muted("Excluded by agent allowlist:")} ${agentFiltered.length}`,
+      `${theme.warn(decorativePrefix("🚫", "Excluded by agent allowlist:"))} ${theme.muted(String(agentFiltered.length))}`,
     );
   }
   if (promptHidden.length > 0) {
@@ -418,7 +427,7 @@ export function formatSkillsCheck(report: SkillStatusReport, opts: SkillsCheckOp
     lines.push(theme.heading("Ready and visible to model:"));
     for (const skill of modelVisible) {
       const emoji = normalizeSkillEmoji(skill.emoji);
-      lines.push(`  ${emoji} ${sanitizeForLog(skill.name)}`);
+      lines.push(`  ${emoji ? `${emoji} ` : ""}${sanitizeForLog(skill.name)}`);
     }
   }
 
@@ -430,7 +439,9 @@ export function formatSkillsCheck(report: SkillStatusReport, opts: SkillsCheckOp
       const reason = skill.commandVisible
         ? "skill hides its instructions from the model; commands/cron may still use it"
         : "skill hides its instructions from the model and is not exposed as a command";
-      lines.push(`  ${emoji} ${sanitizeForLog(skill.name)} ${theme.muted(`(${reason})`)}`);
+      lines.push(
+        `  ${emoji ? `${emoji} ` : ""}${sanitizeForLog(skill.name)} ${theme.muted(`(${reason})`)}`,
+      );
     }
   }
 
@@ -440,7 +451,7 @@ export function formatSkillsCheck(report: SkillStatusReport, opts: SkillsCheckOp
     for (const skill of agentFiltered) {
       const emoji = normalizeSkillEmoji(skill.emoji);
       lines.push(
-        `  ${emoji} ${sanitizeForLog(skill.name)} ${theme.muted("(loaded, but this agent is not allowed to see/use it)")}`,
+        `  ${emoji ? `${emoji} ` : ""}${sanitizeForLog(skill.name)} ${theme.muted("(loaded, but this agent is not allowed to see/use it)")}`,
       );
     }
   }
@@ -451,7 +462,9 @@ export function formatSkillsCheck(report: SkillStatusReport, opts: SkillsCheckOp
     for (const skill of missingReqs) {
       const emoji = normalizeSkillEmoji(skill.emoji);
       const missing = formatSkillMissingSummary(skill);
-      lines.push(`  ${emoji} ${sanitizeForLog(skill.name)} ${theme.muted(`(${missing})`)}`);
+      lines.push(
+        `  ${emoji ? `${emoji} ` : ""}${sanitizeForLog(skill.name)} ${theme.muted(`(${missing})`)}`,
+      );
     }
   }
 

--- a/src/commands/gateway-readiness.ts
+++ b/src/commands/gateway-readiness.ts
@@ -51,9 +51,7 @@ async function defaultGatherStatus(params: {
 }): Promise<DaemonStatus> {
   const { gatherDaemonStatus } = await daemonStatusModuleLoader.load();
   return gatherDaemonStatus({
-    rpc: {
-      ...(params.probeUrl ? { url: params.probeUrl } : {}),
-    },
+    rpc: params.probeUrl ? { url: params.probeUrl } : {},
     probe: true,
     requireRpc: params.requireRpc,
     deep: false,
@@ -67,10 +65,10 @@ function activeProbePortStatus(status: DaemonStatus): DaemonStatus["port"] {
         try {
           return Number(new URL(probeUrl).port);
         } catch {
-          return NaN;
+          return Number.NaN;
         }
       })()
-    : NaN;
+    : Number.NaN;
   if (Number.isFinite(probePort) && status.portCli?.port === probePort) {
     return status.portCli;
   }

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -20,6 +20,8 @@ import { detectBinary } from "../infra/detect-binary.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
+import { visibleWidth } from "../terminal/ansi.js";
+import { decorativeEmoji, supportsDecorativeEmoji } from "../terminal/decorative-emoji.js";
 import { stylePromptTitle } from "../terminal/prompt-style.js";
 import { resolveConfigDir, shortenHomeInString, shortenHomePath, sleep } from "../utils.js";
 import { VERSION } from "../version.js";
@@ -97,13 +99,18 @@ export function validateGatewayPasswordInput(value: unknown): string | undefined
 }
 
 export function printWizardHeader(runtime: RuntimeEnv) {
+  const bannerWidth = 54;
+  const icon = decorativeEmoji("🦞");
+  const title = supportsDecorativeEmoji() && icon ? `${icon} OPENCLAW ${icon}` : "OPENCLAW";
+  const pad = Math.max(0, bannerWidth - visibleWidth(title));
+  const titleLine = `${" ".repeat(Math.floor(pad / 2))}${title}${" ".repeat(Math.ceil(pad / 2))}`;
   const header = [
     "▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄",
     "██░▄▄▄░██░▄▄░██░▄▄▄██░▀██░██░▄▄▀██░████░▄▄▀██░███░██",
     "██░███░██░▀▀░██░▄▄▄██░█░█░██░█████░████░▀▀░██░█░█░██",
     "██░▀▀▀░██░█████░▀▀▀██░██▄░██░▀▀▄██░▀▀░█░██░██▄▀▄▀▄██",
     "▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀",
-    "                  🦞 OPENCLAW 🦞                    ",
+    titleLine,
     " ",
   ].join("\n");
   runtime.log(header);

--- a/src/terminal/decorative-emoji.test.ts
+++ b/src/terminal/decorative-emoji.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+  decorativeEmoji,
+  decorativePrefix,
+  stripDecorativeEmojiForTerminal,
+  supportsDecorativeEmoji,
+} from "./decorative-emoji.js";
+
+describe("decorative emoji terminal helpers", () => {
+  it("disables decorative emoji without a TTY", () => {
+    expect(supportsDecorativeEmoji({ env: { TERM: "xterm-256color" }, isTty: false })).toBe(false);
+  });
+
+  it("disables decorative emoji for dumb or non-UTF-8 terminals", () => {
+    expect(
+      supportsDecorativeEmoji({ env: { TERM: "dumb", LANG: "en_US.UTF-8" }, isTty: true }),
+    ).toBe(false);
+    expect(
+      supportsDecorativeEmoji({
+        env: { TERM: "xterm-256color", LANG: "C" },
+        isTty: true,
+        platform: "darwin",
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps emoji for known-good terminal programs", () => {
+    expect(
+      supportsDecorativeEmoji({
+        env: { TERM_PROGRAM: "WezTerm", LANG: "en_US.UTF-8" },
+        isTty: true,
+        platform: "linux",
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps emoji on macOS and drops it on generic Linux terminals", () => {
+    expect(
+      supportsDecorativeEmoji({
+        env: { TERM: "xterm-256color", LANG: "en_US.UTF-8" },
+        isTty: true,
+        platform: "darwin",
+      }),
+    ).toBe(true);
+    expect(
+      supportsDecorativeEmoji({
+        env: { TERM: "xterm-256color", LANG: "en_US.UTF-8" },
+        isTty: true,
+        platform: "linux",
+      }),
+    ).toBe(false);
+  });
+
+  it("formats decorative emoji prefixes conservatively", () => {
+    const badTerminal = {
+      env: { TERM: "xterm-256color", LANG: "en_US.UTF-8" },
+      isTty: true,
+      platform: "linux" as const,
+    };
+    const goodTerminal = {
+      env: { TERM_PROGRAM: "ghostty", LANG: "en_US.UTF-8" },
+      isTty: true,
+    };
+
+    expect(decorativeEmoji("🦞", badTerminal)).toBe("");
+    expect(decorativePrefix("🦞", "OpenClaw", badTerminal)).toBe("OpenClaw");
+    expect(decorativePrefix("🦞", "OpenClaw", goodTerminal)).toBe("🦞 OpenClaw");
+  });
+
+  it("strips decorative emoji from curated terminal text only when unsupported", () => {
+    const badTerminal = {
+      env: { TERM: "xterm-256color", LANG: "en_US.UTF-8" },
+      isTty: true,
+      platform: "linux" as const,
+    };
+    const goodTerminal = {
+      env: { TERM_PROGRAM: "iTerm.app", LANG: "en_US.UTF-8" },
+      isTty: true,
+    };
+
+    expect(stripDecorativeEmojiForTerminal("The lobster in your shell. 🦞", badTerminal)).toBe(
+      "The lobster in your shell.",
+    );
+    expect(stripDecorativeEmojiForTerminal("The lobster in your shell. 🦞", goodTerminal)).toBe(
+      "The lobster in your shell. 🦞",
+    );
+  });
+});

--- a/src/terminal/decorative-emoji.ts
+++ b/src/terminal/decorative-emoji.ts
@@ -1,0 +1,85 @@
+import { splitGraphemes } from "./ansi.js";
+
+export type DecorativeEmojiOptions = {
+  env?: NodeJS.ProcessEnv;
+  isTty?: boolean;
+  platform?: NodeJS.Platform;
+  stream?: { isTTY?: boolean };
+};
+
+const EMOJI_GRAPHEME_PATTERN = /[\p{Extended_Pictographic}\p{Regional_Indicator}\u20e3]/u;
+
+function isKnownEmojiTerminal(env: NodeJS.ProcessEnv): boolean {
+  const termProgram = (env.TERM_PROGRAM ?? "").toLowerCase();
+  const term = (env.TERM ?? "").toLowerCase();
+  return (
+    termProgram.includes("iterm") ||
+    termProgram.includes("apple_terminal") ||
+    termProgram.includes("ghostty") ||
+    termProgram.includes("wezterm") ||
+    termProgram.includes("vscode") ||
+    term.includes("ghostty") ||
+    term.includes("wezterm") ||
+    Boolean(env.WT_SESSION)
+  );
+}
+
+function hasUtf8Locale(env: NodeJS.ProcessEnv): boolean {
+  const locale = [env.LC_ALL, env.LC_CTYPE, env.LANG].find(
+    (value) => typeof value === "string" && value.trim().length > 0,
+  );
+  if (!locale) {
+    return true;
+  }
+  return /utf-?8/i.test(locale);
+}
+
+export function supportsDecorativeEmoji(options: DecorativeEmojiOptions = {}): boolean {
+  const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const isTty = options.isTty ?? options.stream?.isTTY ?? process.stdout.isTTY;
+
+  if (!isTty) {
+    return false;
+  }
+  if ((env.TERM ?? "").toLowerCase() === "dumb") {
+    return false;
+  }
+  if (!hasUtf8Locale(env)) {
+    return false;
+  }
+  if (isKnownEmojiTerminal(env)) {
+    return true;
+  }
+  if (platform === "darwin") {
+    return true;
+  }
+  return false;
+}
+
+export function decorativeEmoji(emoji: string, options: DecorativeEmojiOptions = {}): string {
+  return supportsDecorativeEmoji(options) ? emoji : "";
+}
+
+export function decorativePrefix(
+  emoji: string,
+  text: string,
+  options: DecorativeEmojiOptions = {},
+): string {
+  const prefix = decorativeEmoji(emoji, options);
+  return prefix ? `${prefix} ${text}` : text;
+}
+
+export function stripDecorativeEmojiForTerminal(
+  text: string,
+  options: DecorativeEmojiOptions = {},
+): string {
+  if (supportsDecorativeEmoji(options)) {
+    return text;
+  }
+  return splitGraphemes(text)
+    .filter((grapheme) => !EMOJI_GRAPHEME_PATTERN.test(grapheme))
+    .join("")
+    .replace(/\s{2,}/g, " ")
+    .trim();
+}


### PR DESCRIPTION
Summary
- Add a centralized decorative terminal emoji helper that uses conservative TTY/locale/terminal heuristics.
- Gate startup/onboarding banner emoji plus decorative skills/hooks status and fallback icons while preserving semantic skill/hook metadata emoji and JSON output.
- Fix a current-main gateway-readiness lint blocker found by the changed gate.

Verification
- node scripts/run-vitest.mjs src/terminal/decorative-emoji.test.ts src/cli/banner.test.ts src/cli/skills-cli.test.ts
- node scripts/run-vitest.mjs src/cli/hooks-cli.test.ts
- node scripts/run-vitest.mjs src/commands/gateway-readiness.test.ts
- /Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --mode branch --parallel-tests "pnpm check:changed"
- Testbox tbx_01krr8q6r1pf08508mkwjhgera: pnpm check:changed

Behavior addressed: Decorative terminal emoji no longer print on generic Linux TTYs such as Crabbox xfce4-terminal where they render as broken glyphs.
Real environment tested: Local macOS checkout plus Blacksmith Testbox changed gate.
Exact steps or command run after this patch: node scripts/run-vitest.mjs src/terminal/decorative-emoji.test.ts src/cli/banner.test.ts src/cli/skills-cli.test.ts; node scripts/run-vitest.mjs src/cli/hooks-cli.test.ts; node scripts/run-vitest.mjs src/commands/gateway-readiness.test.ts; pnpm check:changed via Testbox tbx_01krr8q6r1pf08508mkwjhgera.
Evidence after fix: Generic Linux banner test returns "OpenClaw ..." without lobster; helper tests drop decorative prefixes/sanitized tagline emoji on unsupported terminals; Testbox changed gate exited 0.
Observed result after fix: Startup/onboarding/status fallback decorations are omitted when emoji support is unlikely, while macOS/known-good terminals and semantic metadata emoji still render normally.
What was not tested: A live Crabbox desktop screenshot after installing this branch.
