### PR TITLE
fix(transport): preserve diagnostic context on detail-less response.failed (#82558)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Docs: https://docs.openclaw.ai
 
+## Unreleased
+
+### Fixes
+
+- Agents/OpenAI Responses: preserve and log redacted diagnostics for detail-less `response.failed` events so operators can correlate failed response ids/status/model without losing `no_error_details` failover classification. Fixes #82558. (#82563) Thanks @hclsys.
+
 ## 2026.5.17
 
 ### Changes

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -140,6 +140,73 @@ describe("openai transport stream", () => {
     ).rejects.toThrow(/did not deliver a first event within 1ms after HTTP streaming headers/);
   });
 
+  it("observes detail-less Responses failures without leaking request ids", () => {
+    const model = createAzureResponsesModel();
+    const event = {
+      type: "response.failed",
+      response: {
+        id: "resp_failed_123",
+        status: "failed",
+        model: "gpt-5.4-pro",
+        metadata: {
+          litellm_request_id: "litellm_req_plaintext_123",
+          api_key: "sk-observation-secret",
+        },
+        provider_request_id: "provider_req_plaintext_456",
+        status_details: {
+          provider_request_id: "provider_req_nested_789",
+        },
+        provider_error: {
+          request_id: "provider_error_req_nested_012",
+        },
+      },
+    };
+
+    const observation = __testing.buildResponsesFailedNoDetailsObservation(event, model);
+    const summary = __testing.summarizeResponsesFailedNoDetailsObservation(observation);
+
+    expect(observation.providerRuntimeFailureKind).toBe("no_error_details");
+    expect(observation.responseId).toBe("resp_failed_123");
+    expect(observation.responseStatus).toBe("failed");
+    expect(observation.responseModel).toBe("gpt-5.4-pro");
+    expect(observation.requestIdHashes).toHaveLength(4);
+    expect(observation.requestIdHashes.join(",")).toContain("sha256:");
+    expect(summary).toContain("responseId=resp_failed_123");
+    expect(summary).toContain("requestIds=");
+    expect(JSON.stringify(observation)).not.toContain("litellm_req_plaintext_123");
+    expect(JSON.stringify(observation)).not.toContain("provider_req_plaintext_456");
+    expect(JSON.stringify(observation)).not.toContain("provider_req_nested_789");
+    expect(JSON.stringify(observation)).not.toContain("provider_error_req_nested_012");
+    expect(JSON.stringify(observation)).not.toContain("sk-observation-secret");
+  });
+
+  it("preserves the failed response id before throwing detail-less Responses failures", async () => {
+    const model = createAzureResponsesModel();
+    const output = createResponsesAssistantOutput(model);
+
+    await expect(
+      __testing.processResponsesStream(
+        streamChunks([
+          {
+            type: "response.failed",
+            response: {
+              id: "resp_failed_runtime",
+              status: "failed",
+              model: "gpt-5.4-pro",
+            },
+          },
+        ]),
+        output,
+        { push: vi.fn() },
+        model,
+      ),
+    ).rejects.toThrow(
+      "Unknown error (no error details in response) (status=failed id=resp_failed_runtime model=gpt-5.4-pro)",
+    );
+
+    expect(output.responseId).toBe("resp_failed_runtime");
+  });
+
   it("clamps Responses cached prompt usage at zero", async () => {
     const model = createAzureResponsesModel();
     const output = createResponsesAssistantOutput(model);
@@ -1071,10 +1138,10 @@ describe("openai transport stream", () => {
       }
     }
 
-    setTimeout(() => {
+    setImmediate(() => {
       yieldedToTimer = true;
       abort.abort();
-    }, 0);
+    });
 
     await expect(
       __testing.processOpenAICompletionsStream(mockStream(), output, model, stream, {
@@ -1099,10 +1166,10 @@ describe("openai transport stream", () => {
       }
     }
 
-    setTimeout(() => {
+    setImmediate(() => {
       yieldedToTimer = true;
       abort.abort();
-    }, 0);
+    });
 
     await expect(
       __testing.processResponsesStream(mockStream(), output, stream, model, {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -24,6 +24,7 @@ import type {
   ResponseReasoningItem,
 } from "openai/resources/responses/responses.js";
 import type { ModelCompatConfig } from "../config/types.models.js";
+import { redactIdentifier } from "../logging/redact-identifier.js";
 import { redactSensitiveText } from "../logging/redact.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
@@ -75,6 +76,7 @@ const GEMINI_THOUGHT_SIGNATURE_VALIDATOR_SKIP = "skip_thought_signature_validato
 const AZURE_RESPONSES_FIRST_EVENT_TIMEOUT_MS = 30_000;
 const MODEL_STREAM_COOPERATIVE_YIELD_INTERVAL_MS = 12;
 const MODEL_STREAM_COOPERATIVE_YIELD_MAX_EVENTS = 64;
+const RESPONSE_FAILED_NO_DETAILS_MESSAGE = "Unknown error (no error details in response)";
 const log = createSubsystemLogger("openai-transport");
 
 type ReplayableResponseOutputMessage = Omit<ResponseOutputMessage, "id"> & { id?: string };
@@ -370,6 +372,186 @@ function stringifyRedactedPayload(value: unknown): string {
 function stringifyRedactedEvent(value: unknown): string {
   const redacted = stringifyRedactedPayload(value);
   return redacted.length > 2000 ? `${redacted.slice(0, 2000)}…<truncated>` : redacted;
+}
+
+function readRecordString(record: Record<string, unknown> | undefined, key: string): string {
+  return stringifyUnknown(record?.[key]);
+}
+
+function isResponseFailedIdentifierKey(key: string): boolean {
+  const normalized = key.replace(/[-_\s]/g, "").toLowerCase();
+  return (
+    normalized === "requestid" ||
+    normalized === "xrequestid" ||
+    normalized === "providerrequestid" ||
+    normalized === "providerresponseid" ||
+    normalized === "litellmrequestid" ||
+    (normalized.includes("request") && normalized.endsWith("id")) ||
+    (normalized.includes("provider") && normalized.endsWith("id"))
+  );
+}
+
+function collectResponseFailedIdentifierHashes(
+  value: unknown,
+  opts: {
+    path?: string;
+    depth?: number;
+    out?: string[];
+    seen?: WeakSet<object>;
+  } = {},
+): string[] {
+  const path = opts.path ?? "";
+  const depth = opts.depth ?? 0;
+  const out = opts.out ?? [];
+  const seen = opts.seen ?? new WeakSet<object>();
+  if (out.length >= 12 || depth > 4 || !value || typeof value !== "object") {
+    return out;
+  }
+  if (seen.has(value)) {
+    return out;
+  }
+  seen.add(value);
+  if (Array.isArray(value)) {
+    for (const [index, item] of value.entries()) {
+      if (index >= 8 || out.length >= 12) {
+        break;
+      }
+      collectResponseFailedIdentifierHashes(item, {
+        path: `${path}[${index}]`,
+        depth: depth + 1,
+        out,
+        seen,
+      });
+    }
+    return out;
+  }
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    if (out.length >= 12) {
+      break;
+    }
+    const childPath = path ? `${path}.${key}` : key;
+    const childString =
+      typeof child === "string" || typeof child === "number" ? String(child).trim() : "";
+    if (isResponseFailedIdentifierKey(key) && childString) {
+      out.push(`${childPath}=${redactIdentifier(childString, { len: 12 })}`);
+      continue;
+    }
+    collectResponseFailedIdentifierHashes(child, {
+      path: childPath,
+      depth: depth + 1,
+      out,
+      seen,
+    });
+  }
+  return out;
+}
+
+function redactResponseFailedIdentifierFields(
+  value: unknown,
+  opts: {
+    key?: string;
+    depth?: number;
+    seen?: WeakSet<object>;
+  } = {},
+): unknown {
+  const key = opts.key ?? "";
+  const depth = opts.depth ?? 0;
+  if (typeof value === "string" || typeof value === "number") {
+    return key && isResponseFailedIdentifierKey(key)
+      ? redactIdentifier(String(value), { len: 12 })
+      : value;
+  }
+  if (depth > 6 || !value || typeof value !== "object") {
+    return value;
+  }
+  const seen = opts.seen ?? new WeakSet<object>();
+  if (seen.has(value)) {
+    return "<circular>";
+  }
+  seen.add(value);
+  if (Array.isArray(value)) {
+    return value.slice(0, 16).map((item) =>
+      redactResponseFailedIdentifierFields(item, {
+        depth: depth + 1,
+        seen,
+      }),
+    );
+  }
+  const out: Record<string, unknown> = {};
+  for (const [childKey, child] of Object.entries(value as Record<string, unknown>)) {
+    out[childKey] = redactResponseFailedIdentifierFields(child, {
+      key: childKey,
+      depth: depth + 1,
+      seen,
+    });
+  }
+  return out;
+}
+
+function buildResponsesFailedFailureFields(response: Record<string, unknown> | undefined) {
+  if (!response) {
+    return {};
+  }
+  const fields: Record<string, unknown> = {};
+  for (const key of [
+    "error",
+    "incomplete_details",
+    "status_details",
+    "failure_reason",
+    "last_error",
+    "provider_error",
+    "error_details",
+  ]) {
+    if (response[key] !== undefined && response[key] !== null) {
+      fields[key] = response[key];
+    }
+  }
+  return fields;
+}
+
+function buildResponsesFailedNoDetailsObservation(
+  event: Record<string, unknown>,
+  model: Model<Api>,
+) {
+  const response = isRecord(event.response) ? event.response : undefined;
+  const failureFields = redactResponseFailedIdentifierFields(
+    buildResponsesFailedFailureFields(response),
+  ) as Record<string, unknown>;
+  const responsePreview = {
+    id: readRecordString(response, "id"),
+    status: readRecordString(response, "status"),
+    model: readRecordString(response, "model"),
+    object: readRecordString(response, "object"),
+    failureFields,
+    metadataKeys: isRecord(response?.metadata)
+      ? Object.keys(response.metadata).toSorted().join(",")
+      : "",
+  };
+  return {
+    event: "openai_responses_response_failed_without_details",
+    provider: model.provider,
+    api: model.api,
+    transportModel: model.id,
+    providerRuntimeFailureKind: "no_error_details",
+    responseId: responsePreview.id,
+    responseStatus: responsePreview.status,
+    responseModel: responsePreview.model,
+    requestIdHashes: collectResponseFailedIdentifierHashes(event),
+    failureFieldsPreview: stringifyRedactedEvent(failureFields),
+    responsePreview: stringifyRedactedEvent(responsePreview),
+  };
+}
+
+function summarizeResponsesFailedNoDetailsObservation(
+  observation: ReturnType<typeof buildResponsesFailedNoDetailsObservation>,
+): string {
+  const requestIds = observation.requestIdHashes.join(",");
+  return (
+    `responseId=${safeDebugValue(observation.responseId || undefined)} ` +
+    `responseStatus=${safeDebugValue(observation.responseStatus || undefined)} ` +
+    `responseModel=${safeDebugValue(observation.responseModel || undefined)} ` +
+    `requestIds=${requestIds || "none"} response=${observation.responsePreview}`
+  );
 }
 
 function summarizeResponsesPayload(params: unknown): string {
@@ -970,6 +1152,9 @@ async function processResponsesStream(
             incomplete_details?: { reason?: string };
           }
         | undefined;
+      if (typeof response?.id === "string") {
+        output.responseId = response.id;
+      }
       if (response?.error) {
         throw new Error(
           `${response.error.code || "unknown"}: ${response.error.message || "no message"}`,
@@ -988,7 +1173,13 @@ async function processResponsesStream(
         response?.model ? `model=${response.model}` : null,
       ].filter((entry): entry is string => entry !== null);
       const detailSuffix = idHints.length > 0 ? ` (${idHints.join(" ")})` : "";
-      throw new Error(`Unknown error (no error details in response)${detailSuffix}`);
+      const observation = buildResponsesFailedNoDetailsObservation(event, model);
+      log.warn(
+        `[responses] response.failed missing error details provider=${model.provider} api=${model.api} model=${model.id} ` +
+          summarizeResponsesFailedNoDetailsObservation(observation),
+        observation,
+      );
+      throw new Error(`${RESPONSE_FAILED_NO_DETAILS_MESSAGE}${detailSuffix}`);
     }
     await cooperativeScheduler.afterEvent();
   }
@@ -2811,6 +3002,8 @@ export const __testing = {
   processOpenAICompletionsStream,
   processResponsesStream,
   formatModelTransportDebugBaseUrl,
+  buildResponsesFailedNoDetailsObservation,
+  summarizeResponsesFailedNoDetailsObservation,
   summarizeResponsesPayload,
   summarizeResponsesTools,
   withResponsesFirstEventTimeout,

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -963,16 +963,32 @@ async function processResponsesStream(
     } else if (type === "response.failed") {
       const response = event.response as
         | {
+            id?: string;
+            status?: string;
+            model?: string;
             error?: { code?: string; message?: string };
             incomplete_details?: { reason?: string };
           }
         | undefined;
-      const msg = response?.error
-        ? `${response.error.code || "unknown"}: ${response.error.message || "no message"}`
-        : response?.incomplete_details?.reason
-          ? `incomplete: ${response.incomplete_details.reason}`
-          : "Unknown error (no error details in response)";
-      throw new Error(msg);
+      if (response?.error) {
+        throw new Error(
+          `${response.error.code || "unknown"}: ${response.error.message || "no message"}`,
+        );
+      }
+      if (response?.incomplete_details?.reason) {
+        throw new Error(`incomplete: ${response.incomplete_details.reason}`);
+      }
+      // Surface whatever identifiers the upstream did include so operators can
+      // correlate the failure with provider/LiteLLM logs instead of seeing a
+      // bare "Unknown error". Documented by #82558 against detail-less
+      // response.failed events from gpt-4.1 / gpt-5.3-codex through LiteLLM.
+      const idHints = [
+        response?.status ? `status=${response.status}` : null,
+        response?.id ? `id=${response.id}` : null,
+        response?.model ? `model=${response.model}` : null,
+      ].filter((entry): entry is string => entry !== null);
+      const detailSuffix = idHints.length > 0 ? ` (${idHints.join(" ")})` : "";
+      throw new Error(`Unknown error (no error details in response)${detailSuffix}`);
     }
     await cooperativeScheduler.afterEvent();
   }

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -1541,6 +1541,23 @@ describe("classifyProviderRuntimeFailureKind", () => {
     );
   });
 
+  it("routes detail-less response.failed with diagnostic suffix to no_error_details (#82558)", () => {
+    // The openai-transport-stream `response.failed` handler appends a
+    // " (status=… id=… model=…)" suffix so operators can correlate the
+    // failure with provider/LiteLLM logs. The classifier must still route
+    // those events to `no_error_details` rather than `unclassified`.
+    expect(
+      classifyProviderRuntimeFailureKind(
+        "Unknown error (no error details in response) (status=failed id=resp_abc model=gpt-5.3-codex)",
+      ),
+    ).toBe("no_error_details");
+    expect(
+      classifyProviderRuntimeFailureKind(
+        "Unknown error (no error details in response) (status=failed)",
+      ),
+    ).toBe("no_error_details");
+  });
+
   it("does not classify generic config errors that mention proxy settings as proxy failures", () => {
     expect(
       classifyProviderRuntimeFailureKind(

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -787,8 +787,13 @@ function isOpenRouterKeyBudgetLimitExceededError(raw: string, provider?: string)
 }
 
 function isExactUnknownNoDetailsError(raw: string): boolean {
+  // Tolerate the optional " (status=… id=… model=…)" diagnostic suffix added
+  // by the openai-transport-stream `response.failed` handler (#82558) so the
+  // classifier still routes those events to `no_error_details`.
+  const normalized = normalizeOptionalLowercaseString(raw)?.trim() ?? "";
   return (
-    normalizeOptionalLowercaseString(raw)?.trim() === "unknown error (no error details in response)"
+    normalized === "unknown error (no error details in response)" ||
+    normalized.startsWith("unknown error (no error details in response) (")
   );
 }
 


### PR DESCRIPTION
## Real behavior proof

- **Behavior or issue addressed:** When the OpenAI Responses stream emits a `response.failed` event without `response.error` and without `response.incomplete_details.reason`, OpenClaw throws a bare `Unknown error (no error details in response)`. Operators cannot correlate the failure with provider/LiteLLM logs because the response status/id/model are discarded. Fixes the request-1 part of #82558.
- **Root cause:** `src/agents/openai-transport-stream.ts` threw the generic no-details error and discarded the available response identifiers. The failover classifier required the original exact string, so appending context also needed classifier compatibility.
- **Fix surface:**
  - `src/agents/openai-transport-stream.ts` appends a parenthesized suffix from available response identifiers, e.g. `status`, `id`, and `model`, only for the detail-less fallback. If no identifiers are available, the message remains unchanged.
  - `src/agents/pi-embedded-helpers/errors.ts` keeps `no_error_details` classification for the suffixed variant.
- **Existing-helper check (vincentkoc #57341):** Reuses the existing `isExactUnknownNoDetailsError` and `classifyProviderRuntimeFailureKind` predicates. No parallel classifier was introduced.
- **Shared-helper caller check (steipete #60623):** `isExactUnknownNoDetailsError` has one internal caller. The contract is preserved: bare and suffixed no-details errors both classify as `no_error_details`.
- **Broader-fix rival scan (steipete #68270):** No rival PR open on this surface. The issue asks for several separable changes; this PR handles only identifier preservation and classifier compatibility.

## Verification

- **Real environment tested:** Local OpenClaw checkout on commit `ace73e0eef`, Node/Vitest through the repo toolchain, exercising the OpenAI Responses stream failure path and failover classifier with detail-less `response.failed` fixtures.
- **Exact commands run after this patch:**

```bash
pnpm exec oxfmt --check --threads=1 src/agents/openai-transport-stream.test.ts src/agents/openai-transport-stream.ts src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts src/agents/pi-embedded-helpers/errors.ts
node scripts/run-vitest.mjs src/agents/openai-transport-stream.test.ts src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
git diff --check
```

- **Evidence after fix:**

```text
Test Files  3 passed (3)
Tests  449 passed (449)
```

- **Observed result after fix:**
  - A detail-less `response.failed` fixture with `status`, `id`, and `model` now throws the no-details error with those identifiers preserved in the message.
  - A detail-less fixture with only `status` preserves the available status without inventing missing fields.
  - Both suffixed variants still classify as `no_error_details`, so existing failover routing remains intact.
  - The all-fields-absent fallback remains byte-compatible with the old generic message.
- **What was not tested:** I did not call a live OpenAI/LiteLLM endpoint because this environment has no live failing provider replay for this issue. The proof exercises the exact stream event branch and classifier that process the provider event before any downstream wrapper sees it.