### PR TITLE
ci: avoid opengrep installer pipefail

### DIFF
--- a/.github/workflows/opengrep-precise-full.yml
+++ b/.github/workflows/opengrep-precise-full.yml
@@ -31,15 +31,9 @@ jobs:
 
       - name: Install opengrep
         env:
-          # Pin both the install script (by commit SHA) and the binary version.
-          # The script SHA must match the v1.19.0 release tag in opengrep/opengrep
-          # so a compromised or force-pushed `main` cannot RCE in our CI runner.
-          # Bump both together when upgrading.
           OPENGREP_VERSION: v1.19.0
-          OPENGREP_INSTALL_SHA: 9a4c0a68220618441608cd2bad4ff2eddccf8113
         run: |
-          curl -fsSL "https://raw.githubusercontent.com/opengrep/opengrep/${OPENGREP_INSTALL_SHA}/install.sh" \
-            | bash -s -- -v "$OPENGREP_VERSION"
+          scripts/install-opengrep.sh
           echo "$HOME/.opengrep/cli/latest" >> "$GITHUB_PATH"
 
       - name: Verify opengrep

--- a/.github/workflows/opengrep-precise.yml
+++ b/.github/workflows/opengrep-precise.yml
@@ -57,15 +57,9 @@ jobs:
 
       - name: Install opengrep
         env:
-          # Pin both the install script (by commit SHA) and the binary version.
-          # The script SHA must match the v1.19.0 release tag in opengrep/opengrep
-          # so a compromised or force-pushed `main` cannot RCE in our CI runner.
-          # Bump both together when upgrading.
           OPENGREP_VERSION: v1.19.0
-          OPENGREP_INSTALL_SHA: 9a4c0a68220618441608cd2bad4ff2eddccf8113
         run: |
-          curl -fsSL "https://raw.githubusercontent.com/opengrep/opengrep/${OPENGREP_INSTALL_SHA}/install.sh" \
-            | bash -s -- -v "$OPENGREP_VERSION"
+          scripts/install-opengrep.sh
           echo "$HOME/.opengrep/cli/latest" >> "$GITHUB_PATH"
 
       - name: Verify opengrep

--- a/scripts/install-opengrep.sh
+++ b/scripts/install-opengrep.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Install the pinned OpenGrep release asset without executing the upstream
+# installer script. The upstream installer currently validates versions through
+# a grep -q pipeline that can false-fail under pipefail on CI runners.
+
+set -euo pipefail
+
+VERSION="${OPENGREP_VERSION:-v1.19.0}"
+PREFIX="${OPENGREP_PREFIX:-$HOME/.opengrep/cli}"
+INST="${PREFIX}/${VERSION}"
+LATEST="${PREFIX}/latest"
+
+OS="${OS:-$(uname -s)}"
+ARCH="${ARCH:-$(uname -m)}"
+
+DIST=""
+case "$OS:$ARCH" in
+  Linux:x86_64 | Linux:amd64)
+    if ldd /bin/sh 2>&1 | grep -qi musl; then
+      DIST="opengrep_musllinux_x86"
+    else
+      DIST="opengrep_manylinux_x86"
+    fi
+    ;;
+  Linux:aarch64 | Linux:arm64)
+    if ldd /bin/sh 2>&1 | grep -qi musl; then
+      DIST="opengrep_musllinux_aarch64"
+    else
+      DIST="opengrep_manylinux_aarch64"
+    fi
+    ;;
+  Darwin:x86_64 | Darwin:amd64)
+    DIST="opengrep_osx_x86"
+    ;;
+  Darwin:aarch64 | Darwin:arm64)
+    DIST="opengrep_osx_arm64"
+    ;;
+esac
+
+if [[ -z "$DIST" ]]; then
+  echo "error: unsupported platform ${OS}/${ARCH}" >&2
+  exit 1
+fi
+
+mkdir -p "$INST"
+curl --fail --show-error --location --retry 3 --retry-delay 2 \
+  "https://github.com/opengrep/opengrep/releases/download/${VERSION}/${DIST}" \
+  --output "${INST}/opengrep"
+chmod a+x "${INST}/opengrep"
+
+INSTALLED_VERSION="$("${INST}/opengrep" --version | awk '{print $NF}')"
+if [[ "$INSTALLED_VERSION" != "${VERSION#v}" ]]; then
+  echo "error: expected OpenGrep ${VERSION#v}, got ${INSTALLED_VERSION}" >&2
+  exit 1
+fi
+
+rm -f "$LATEST"
+ln -s "$INST" "$LATEST"
+
+echo "Installed OpenGrep ${VERSION} at ${INST}/opengrep"

--- a/scripts/run-opengrep.sh
+++ b/scripts/run-opengrep.sh
@@ -46,7 +46,7 @@ if ! command -v opengrep >/dev/null 2>&1; then
 error: 'opengrep' not found on PATH.
 
 Install with one of:
-  curl -fsSL https://raw.githubusercontent.com/opengrep/opengrep/v1.19.0/install.sh | bash -s -- -v v1.19.0
+  scripts/install-opengrep.sh
   brew install opengrep/tap/opengrep
   pipx install opengrep
 


### PR DESCRIPTION
## Summary

- Add a local OpenGrep installer that downloads the pinned v1.19.0 release asset directly instead of executing the upstream installer.
- Update the PR-diff and full OpenGrep workflows to use the local installer.
- Point the local `scripts/run-opengrep.sh` missing-tool guidance at the repo installer.

## Verification

- `bash -n scripts/install-opengrep.sh`
- `tmp=$(mktemp -d); HOME="$tmp" scripts/install-opengrep.sh; PATH="$tmp/.opengrep/cli/latest:$PATH" opengrep --version; rm -rf "$tmp"`
- `tmp=$(mktemp -d); HOME="$tmp" scripts/install-opengrep.sh; OPENCLAW_OPENGREP_BASE_REF=origin/main...HEAD PATH="$tmp/.opengrep/cli/latest:$PATH" scripts/run-opengrep.sh --changed --error; rm -rf "$tmp"`
- `git diff --check origin/main...HEAD`
- GitHub Actions: OpenGrep — PR Diff / Scan changed paths (precise) passed on this PR: https://github.com/openclaw/openclaw/actions/runs/25961429491/job/76317259766

## Linked Issue/PR

- Related #82434
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: OpenGrep CI can install the pinned v1.19.0 binary without hitting the upstream install script's version-validation pipefail false negative.
- Real environment tested: macOS arm64 local checkout with the same pinned OpenGrep version and the repo changed-path OpenGrep wrapper; GitHub Actions OpenGrep PR-diff workflow on Ubuntu/Blacksmith for this PR.
- Exact steps or command run after this patch: `scripts/install-opengrep.sh`, `opengrep --version`, `scripts/run-opengrep.sh --changed --error`, `git diff --check origin/main...HEAD`, and the GitHub Actions OpenGrep PR-diff job on this PR.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Terminal output and live GitHub Actions output showed install/verify/scan success:

```text
Installed OpenGrep v1.19.0 at /var/folders/.../.opengrep/cli/v1.19.0/opengrep
opengrep --version -> 1.19.0
scripts/run-opengrep.sh --changed --error
Ran 2 rules on 2 files: 0 findings.
GitHub Actions OpenGrep — PR Diff / Scan changed paths (precise): Install opengrep ✓, Verify opengrep ✓, Run opengrep on PR diff ✓
```

- Observed result after fix: The local install and changed-path scan completed successfully, and this PR's OpenGrep PR-diff workflow completed successfully in GitHub Actions.
- What was not tested: The manual repository-wide OpenGrep — Full workflow was not dispatched.
- Before evidence (optional but encouraged): #82434 failed in `Install opengrep` with `Error: Version v1.19.0 not found` before any scan ran.

## Root Cause (if applicable)

- Root cause: The upstream OpenGrep installer validates explicit versions through an `echo "$AVAILABLE_VERSIONS" | grep -q` pipeline under `set -o pipefail`; on the CI runner that can false-fail with a broken pipe even when v1.19.0 is present in the release list.
- Missing detection / guardrail: The OpenGrep workflow depended on the upstream installer script path instead of a repo-owned installer path that can be exercised by the PR workflow itself.
