### PR TITLE
fix: migrate plugin tool contracts in doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 
 - Codex app-server: limit canonical OpenAI Codex app-server attribution rewrites to local transcript and trajectory records, leaving runtime/tool routing on the selected OpenAI model metadata so OpenAI API-key backup profiles keep their billing path.
 - Android/chat: make bare and markdown URLs in chat messages tappable by preserving Compose URL annotations in rendered markdown. Fixes #82187. (#82392) Thanks @neeravmakwana.
+- Plugins/doctor: migrate legacy top-level plugin `tools` declarations into `contracts.tools`, so `openclaw doctor --fix` repairs local plugins for the manifest tool contract. (#81112) Thanks @100yenadmin.
 - Codex app-server: release raw assistant completions when `turn/completed` is missing while keeping commentary/status items as progress, preventing completed Codex runs from hanging until timeout. Fixes #82343. (#82403) Thanks @IWhatsskill.
 - Agents/sessions: remove the transient `*.bak-<pid>-<ts>` backup written by `repairSessionFileIfNeeded` once the atomic replace succeeds, so a stuck session with a persistently malformed JSONL line no longer accumulates one snapshot per repair invocation. Fixes #80960. (#80969) Thanks @100yenadmin. Co-authored by @tynamite.
 - CLI/status: show plain empty-state messages instead of empty Channels and Sessions tables when no channels or sessions exist.

--- a/src/cli/daemon-cli/install.test.ts
+++ b/src/cli/daemon-cli/install.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ResolvedGatewayAuth } from "../../gateway/auth.js";
 import { captureFullEnv } from "../../test-utils/env.js";
 import { createCliRuntimeCapture } from "../test-runtime-capture.js";
 import type { DaemonActionResponse } from "./response.js";
@@ -21,7 +22,7 @@ const hasConfiguredSecretInputMock = vi.hoisted(() =>
   }),
 );
 const resolveGatewayAuthMock = vi.hoisted(() =>
-  vi.fn(() => ({
+  vi.fn<() => ResolvedGatewayAuth>(() => ({
     mode: "token",
     token: undefined,
     password: undefined,

--- a/src/commands/doctor-plugin-manifests.test.ts
+++ b/src/commands/doctor-plugin-manifests.test.ts
@@ -128,6 +128,42 @@ describe("doctor plugin manifest legacy contract repair", () => {
     ]);
   });
 
+  it("collects legacy top-level plugin tool keys for migration", () => {
+    const pluginsRoot = makeTrustedBundledPluginsDir();
+    const root = path.join(pluginsRoot, "cortex");
+    fs.mkdirSync(root, { recursive: true });
+    writePackageJson(root);
+    writeManifest(root, {
+      id: "cortex",
+      tools: ["cortex_search", "cortex_remember"],
+      configSchema: { type: "object" },
+    });
+
+    const migrations = collectLegacyPluginManifestContractMigrations({
+      config: configWithPluginLoadPath(pluginsRoot),
+      env: {
+        ...process.env,
+      },
+      manifestRoots: [pluginsRoot],
+    });
+
+    const manifestPath = path.join(root, "openclaw.plugin.json");
+    expect(migrations).toStrictEqual([
+      {
+        changeLines: [`- ${manifestPath}: moved tools to contracts.tools`],
+        manifestPath,
+        nextRaw: {
+          id: "cortex",
+          contracts: {
+            tools: ["cortex_search", "cortex_remember"],
+          },
+          configSchema: { type: "object" },
+        },
+        pluginId: "cortex",
+      },
+    ]);
+  });
+
   it("rewrites legacy top-level capability keys into contracts", async () => {
     const pluginsRoot = makeTrustedBundledPluginsDir();
     const root = path.join(pluginsRoot, "openai");
@@ -166,6 +202,41 @@ describe("doctor plugin manifest legacy contract repair", () => {
       speechProviders: ["openai"],
       mediaUnderstandingProviders: ["openai"],
       webSearchProviders: ["gemini"],
+    });
+  });
+
+  it("removes duplicate legacy top-level plugin tools while keeping contracts.tools", async () => {
+    const pluginsRoot = makeTrustedBundledPluginsDir();
+    const root = path.join(pluginsRoot, "cortex");
+    fs.mkdirSync(root, { recursive: true });
+    writePackageJson(root);
+    writeManifest(root, {
+      id: "cortex",
+      tools: ["legacy_tool"],
+      contracts: {
+        tools: ["contract_tool"],
+      },
+      configSchema: { type: "object" },
+    });
+
+    await maybeRepairLegacyPluginManifestContracts({
+      config: configWithPluginLoadPath(pluginsRoot),
+      env: {
+        ...process.env,
+      },
+      manifestRoots: [pluginsRoot],
+      runtime: createRuntime(),
+      prompter: createPrompter(),
+      note: vi.fn(),
+    });
+
+    const next = JSON.parse(fs.readFileSync(path.join(root, "openclaw.plugin.json"), "utf-8")) as {
+      tools?: string[];
+      contracts?: Record<string, string[]>;
+    };
+    expect(next.tools).toBeUndefined();
+    expect(next.contracts).toEqual({
+      tools: ["contract_tool"],
     });
   });
 

--- a/src/commands/doctor-plugin-manifests.ts
+++ b/src/commands/doctor-plugin-manifests.ts
@@ -15,6 +15,7 @@ const LEGACY_MANIFEST_CONTRACT_KEYS = [
   "speechProviders",
   "mediaUnderstandingProviders",
   "imageGenerationProviders",
+  "tools",
 ] as const;
 
 type LegacyManifestContractMigration = {


### PR DESCRIPTION
## Summary

- Applies #81112 on top of current main because the contributor fork rejected maintainer push with HTTP 403.
- Migrates legacy top-level plugin `tools` declarations through `openclaw doctor --fix` by reusing the existing manifest contract migration path.
- Adds maintainer changelog credit for @100yenadmin.

## Real behavior proof

Behavior addressed: `openclaw doctor --fix` repairs legacy plugin manifests that declare tools at top level by moving them to `contracts.tools`.

Real environment tested: local checkout on branch `maintainer/land-81112-doctor-plugin-tools` rebased onto `origin/main` at `192caba631`, using isolated `OPENCLAW_CONFIG_PATH`, `OPENCLAW_STATE_DIR`, and `OPENCLAW_AGENT_DIR` under `/tmp/openclaw-doctor-tools-proof.rBLHGY`.

Exact steps or command run after this patch:

```bash
node scripts/run-vitest.mjs src/commands/doctor-plugin-manifests.test.ts

tmp=$(mktemp -d /tmp/openclaw-doctor-tools-proof.XXXXXX)
OPENCLAW_CONFIG_PATH="$tmp/openclaw.json" \
OPENCLAW_STATE_DIR="$tmp/state" \
OPENCLAW_AGENT_DIR="$tmp/agent" \
pnpm openclaw doctor --fix --non-interactive
```

Evidence after fix:

```text
Test Files  1 passed (1)
Tests  5 passed (5)

Legacy plugin manifest capability keys detected.
- /private/tmp/openclaw-doctor-tools-proof.rBLHGY/plugins/cortex/openclaw.plugin.json:
  moved tools to contracts.tools

Doctor changes
- /private/tmp/openclaw-doctor-tools-proof.rBLHGY/plugins/cortex/openclaw.plugin.json:
  moved tools to contracts.tools
```

Observed manifest after fix:

```json
{
  "id": "cortex",
  "configSchema": {
    "type": "object"
  },
  "contracts": {
    "tools": [
      "cortex_search",
      "cortex_remember"
    ]
  }
}
```

Observed result after fix: legacy top-level plugin `tools` are collected, moved to `contracts.tools`, and duplicate top-level `tools` are removed when the contract already exists.

What was not tested: a real third-party plugin directory was not mutated in place; proof used an isolated disposable plugin manifest with the legacy top-level `tools` shape.

## Verification

- `node scripts/run-vitest.mjs src/commands/doctor-plugin-manifests.test.ts`
- `git diff --check`

Fixes #81111.
Supersedes #81112 while preserving its contributor commit.
