### PR TITLE
fix(agents): honor Codex auth order for OpenAI Pi

### DIFF
--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -191,12 +191,15 @@ specific configured agent store. The parent `--agent` flag is honored by
 For OpenAI models, `--provider openai` defaults to ChatGPT/Codex account login.
 Use `--method api-key` only when you want to add an OpenAI API-key profile,
 usually as a backup for Codex subscription limits. The legacy
-`--provider openai-codex` spelling still works for existing scripts.
+`--provider openai-codex` spelling still works for existing scripts. Use
+`--device-code` when you need the ChatGPT/Codex browser device-code flow instead
+of the localhost OAuth callback.
 
 Examples:
 
 ```bash
 openclaw models auth login --provider openai --set-default
+openclaw models auth login --provider openai-codex --device-code
 openclaw models auth login --provider openai --method api-key
 openclaw models auth list --provider openai
 ```

--- a/src/agents/auth-profile-runtime-contract.test.ts
+++ b/src/agents/auth-profile-runtime-contract.test.ts
@@ -489,6 +489,48 @@ describe("Auth profile runtime contract - Pi and CLI adapter", () => {
     expect(params.authProfileId).toBeUndefined();
   });
 
+  it("does not bypass an explicit OpenAI-only auth order with a stored Codex OAuth profile", async () => {
+    const authStore: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        [AUTH_PROFILE_RUNTIME_CONTRACT.openAiProfileId]: {
+          type: "api_key",
+          provider: AUTH_PROFILE_RUNTIME_CONTRACT.openAiProvider,
+          key: "sk-openai",
+        },
+        [AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProfileId]: {
+          type: "oauth",
+          provider: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider,
+          access: "codex-access",
+          refresh: "codex-refresh",
+          expires: Date.now() + 60_000,
+        },
+      },
+    };
+    saveAuthProfileStore(authStore, tmpDir);
+
+    await runAuthContractAttempt({
+      tmpDir,
+      storePath,
+      providerOverride: AUTH_PROFILE_RUNTIME_CONTRACT.openAiProvider,
+      authProfileProvider: AUTH_PROFILE_RUNTIME_CONTRACT.openAiProvider,
+      cfg: {
+        ...providerRuntimeConfig(AUTH_PROFILE_RUNTIME_CONTRACT.openAiProvider, "pi"),
+        auth: {
+          order: {
+            [AUTH_PROFILE_RUNTIME_CONTRACT.openAiProvider]: [
+              AUTH_PROFILE_RUNTIME_CONTRACT.openAiProfileId,
+            ],
+          },
+        },
+      } as OpenClawConfig,
+    });
+
+    const params = capturedEmbeddedRunParams();
+    expect(params.provider).toBe(AUTH_PROFILE_RUNTIME_CONTRACT.openAiProvider);
+    expect(params.authProfileId).toBeUndefined();
+  });
+
   it("forwards an OpenAI Codex auth profile through the default OpenAI Codex harness path", async () => {
     await runAuthContractAttempt({
       tmpDir,

--- a/src/agents/auth-profile-runtime-contract.test.ts
+++ b/src/agents/auth-profile-runtime-contract.test.ts
@@ -10,6 +10,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type * as ManifestRegistryModule from "../plugins/manifest-registry.js";
+import { saveAuthProfileStore } from "./auth-profiles/store.js";
+import type { AuthProfileStore } from "./auth-profiles/types.js";
 import { runAgentAttempt } from "./command/attempt-execution.js";
 import type { RunEmbeddedPiAgentParams } from "./pi-embedded-runner/run/params.js";
 import type { EmbeddedPiRunResult } from "./pi-embedded.js";
@@ -165,7 +167,7 @@ async function runAuthContractAttempt(params: {
   storePath: string;
   providerOverride: string;
   authProfileProvider: string;
-  authProfileOverride: string;
+  authProfileOverride?: string;
   cfg?: OpenClawConfig;
   sessionHasHistory?: boolean;
 }) {
@@ -173,8 +175,12 @@ async function runAuthContractAttempt(params: {
   const sessionEntry: SessionEntry = {
     sessionId: AUTH_PROFILE_RUNTIME_CONTRACT.sessionId,
     updatedAt: Date.now(),
-    authProfileOverride: params.authProfileOverride,
-    authProfileOverrideSource: "user",
+    ...(params.authProfileOverride
+      ? {
+          authProfileOverride: params.authProfileOverride,
+          authProfileOverrideSource: "user" as const,
+        }
+      : {}),
   };
   const sessionStore: Record<string, SessionEntry> = {
     [AUTH_PROFILE_RUNTIME_CONTRACT.sessionKey]: sessionEntry,
@@ -394,6 +400,93 @@ describe("Auth profile runtime contract - Pi and CLI adapter", () => {
     const params = capturedEmbeddedRunParams();
     expect(params.provider).toBe(AUTH_PROFILE_RUNTIME_CONTRACT.openAiProvider);
     expect(params.authProfileId).toBe(AUTH_PROFILE_RUNTIME_CONTRACT.openAiProfileId);
+  });
+
+  it("auto-selects configured OpenAI Codex auth order for embedded OpenAI PI runs", async () => {
+    const authStore: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        [AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProfileId]: {
+          type: "oauth",
+          provider: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider,
+          access: "codex-access",
+          refresh: "codex-refresh",
+          expires: Date.now() + 60_000,
+        },
+        [AUTH_PROFILE_RUNTIME_CONTRACT.openAiProfileId]: {
+          type: "api_key",
+          provider: AUTH_PROFILE_RUNTIME_CONTRACT.openAiProvider,
+          key: "sk-openai",
+        },
+      },
+    };
+    saveAuthProfileStore(authStore, tmpDir);
+
+    await runAuthContractAttempt({
+      tmpDir,
+      storePath,
+      providerOverride: AUTH_PROFILE_RUNTIME_CONTRACT.openAiProvider,
+      authProfileProvider: AUTH_PROFILE_RUNTIME_CONTRACT.openAiProvider,
+      cfg: {
+        ...providerRuntimeConfig(AUTH_PROFILE_RUNTIME_CONTRACT.openAiProvider, "pi"),
+        auth: {
+          order: {
+            [AUTH_PROFILE_RUNTIME_CONTRACT.openAiProvider]: [
+              AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProfileId,
+              AUTH_PROFILE_RUNTIME_CONTRACT.openAiProfileId,
+            ],
+          },
+        },
+      } as OpenClawConfig,
+    });
+
+    const params = capturedEmbeddedRunParams();
+    expect(params.provider).toBe(AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider);
+    expect(params.authProfileId).toBe(AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProfileId);
+    expect(params.authProfileIdSource).toBe("auto");
+  });
+
+  it("preserves OpenAI auth order when an OpenAI API-key profile comes before Codex OAuth", async () => {
+    const authStore: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        [AUTH_PROFILE_RUNTIME_CONTRACT.openAiProfileId]: {
+          type: "api_key",
+          provider: AUTH_PROFILE_RUNTIME_CONTRACT.openAiProvider,
+          key: "sk-openai",
+        },
+        [AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProfileId]: {
+          type: "oauth",
+          provider: AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProvider,
+          access: "codex-access",
+          refresh: "codex-refresh",
+          expires: Date.now() + 60_000,
+        },
+      },
+    };
+    saveAuthProfileStore(authStore, tmpDir);
+
+    await runAuthContractAttempt({
+      tmpDir,
+      storePath,
+      providerOverride: AUTH_PROFILE_RUNTIME_CONTRACT.openAiProvider,
+      authProfileProvider: AUTH_PROFILE_RUNTIME_CONTRACT.openAiProvider,
+      cfg: {
+        ...providerRuntimeConfig(AUTH_PROFILE_RUNTIME_CONTRACT.openAiProvider, "pi"),
+        auth: {
+          order: {
+            [AUTH_PROFILE_RUNTIME_CONTRACT.openAiProvider]: [
+              AUTH_PROFILE_RUNTIME_CONTRACT.openAiProfileId,
+              AUTH_PROFILE_RUNTIME_CONTRACT.openAiCodexProfileId,
+            ],
+          },
+        },
+      } as OpenClawConfig,
+    });
+
+    const params = capturedEmbeddedRunParams();
+    expect(params.provider).toBe(AUTH_PROFILE_RUNTIME_CONTRACT.openAiProvider);
+    expect(params.authProfileId).toBeUndefined();
   });
 
   it("forwards an OpenAI Codex auth profile through the default OpenAI Codex harness path", async () => {

--- a/src/agents/auth-profiles.external-cli-scope.test.ts
+++ b/src/agents/auth-profiles.external-cli-scope.test.ts
@@ -87,6 +87,20 @@ describe("external CLI auth scope", () => {
     expect(scope?.profileIds).toContain("openai-codex:default");
   });
 
+  it("scopes Codex CLI discovery from OpenAI auth order profile ids", () => {
+    const scope = resolveExternalCliAuthScopeFromConfig({
+      auth: {
+        order: {
+          openai: ["openai-codex:work"],
+        },
+      },
+    });
+
+    expect(scope?.providerIds).toContain("openai");
+    expect(scope?.providerIds).toContain("openai-codex");
+    expect(scope?.profileIds).toEqual(["openai-codex:work"]);
+  });
+
   it("includes a CLI provider only when it is the active runtime", () => {
     const scope = resolveExternalCliAuthScopeFromConfig({
       agents: {

--- a/src/agents/auth-profiles/external-cli-scope.ts
+++ b/src/agents/auth-profiles/external-cli-scope.ts
@@ -35,6 +35,18 @@ function addProviderScopeFromModelRef(out: Set<string>, value: string | undefine
   addProviderScopeId(out, raw.slice(0, slash));
 }
 
+function addProviderScopeFromProfileId(out: Set<string>, value: string | undefined): void {
+  const raw = value?.trim();
+  if (!raw) {
+    return;
+  }
+  const colon = raw.indexOf(":");
+  if (colon <= 0) {
+    return;
+  }
+  addProviderScopeId(out, raw.slice(0, colon));
+}
+
 function addProviderScopeFromModelConfig(out: Set<string>, model: AgentModelConfig | undefined) {
   addProviderScopeFromModelRef(out, resolveAgentModelPrimaryValue(model));
   for (const fallback of resolveAgentModelFallbackValues(model)) {
@@ -80,6 +92,7 @@ export function resolveExternalCliAuthScopeFromConfig(
     const normalizedProfileId = profileId.trim();
     if (normalizedProfileId) {
       profileIds.add(normalizedProfileId);
+      addProviderScopeFromProfileId(providerIds, normalizedProfileId);
     }
     addProviderScopeId(providerIds, profile?.provider);
   }
@@ -89,6 +102,7 @@ export function resolveExternalCliAuthScopeFromConfig(
       const normalizedProfileId = profileId.trim();
       if (normalizedProfileId) {
         profileIds.add(normalizedProfileId);
+        addProviderScopeFromProfileId(providerIds, normalizedProfileId);
       }
     }
   }

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -39,6 +39,11 @@ import {
   resolveFallbackRetryPrompt,
 } from "./attempt-execution.helpers.js";
 import { persistSessionEntry } from "./attempt-execution.shared.js";
+import {
+  profileIdProvider,
+  resolveOrderedOpenAIPiAuthProfileSelection,
+  type HarnessAuthProfileSelection,
+} from "./auth-profile-selection.js";
 import { resolveAgentRunContext } from "./run-context.js";
 import { clearCliSessionInStore } from "./session-store.js";
 import type { AgentCommandOpts } from "./types.js";
@@ -99,13 +104,6 @@ type PersistTextTurnTranscriptParams = {
   };
 };
 
-type HarnessAuthProfileSelection = {
-  authProfileId?: string;
-  authProfileIdSource?: "auto" | "user";
-  authProfileProvider: string;
-  authProfileMode?: string;
-};
-
 function resolveProfileAuthFromStore(params: { agentDir: string; profileId: string | undefined }): {
   provider?: string;
   mode?: string;
@@ -141,7 +139,7 @@ function resolveHarnessAuthProfileSelection(params: {
     return {
       authProfileId: sessionAuthProfileId,
       authProfileIdSource: params.sessionAuthProfileSource,
-      authProfileProvider: profileAuth.provider ?? params.authProfileProvider,
+      authProfileProvider: profileAuth.provider ?? profileIdProvider(sessionAuthProfileId),
       authProfileMode: profileAuth.mode,
     };
   }
@@ -157,6 +155,10 @@ function resolveHarnessAuthProfileSelection(params: {
   });
   const harnessAuthProvider = runtimeAuthPlan.harnessAuthProvider;
   if (!harnessAuthProvider) {
+    const openAIPiSelection = resolveOrderedOpenAIPiAuthProfileSelection(params);
+    if (openAIPiSelection) {
+      return openAIPiSelection;
+    }
     return { authProfileProvider: params.authProfileProvider };
   }
 

--- a/src/agents/command/auth-profile-selection.test.ts
+++ b/src/agents/command/auth-profile-selection.test.ts
@@ -97,6 +97,44 @@ describe("resolveOrderedOpenAIPiAuthProfileSelection", () => {
     ).toBeUndefined();
   });
 
+  it("does not use a stored Codex profile when OpenAI auth order names only OpenAI", () => {
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "openai:default": {
+          type: "api_key",
+          provider: "openai",
+          key: "sk-openai",
+        },
+        "openai-codex:work": {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "codex-access",
+          refresh: "codex-refresh",
+          expires: Date.now() + 60_000,
+        },
+      },
+    };
+    saveAuthProfileStore(store, tmpDir);
+
+    expect(
+      resolveOrderedOpenAIPiAuthProfileSelection({
+        config: {
+          auth: {
+            order: {
+              openai: ["openai:default"],
+            },
+          },
+        },
+        agentDir: tmpDir,
+        workspaceDir: tmpDir,
+        provider: "openai",
+        harnessRuntime: "pi",
+        allowHarnessAuthProfileForwarding: true,
+      }),
+    ).toBeUndefined();
+  });
+
   it("does not select Codex OAuth profiles for non-Pi OpenAI runs", () => {
     const store: AuthProfileStore = {
       version: 1,

--- a/src/agents/command/auth-profile-selection.test.ts
+++ b/src/agents/command/auth-profile-selection.test.ts
@@ -1,0 +1,132 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { saveAuthProfileStore } from "../auth-profiles/store.js";
+import type { AuthProfileStore } from "../auth-profiles/types.js";
+import { resolveOrderedOpenAIPiAuthProfileSelection } from "./auth-profile-selection.js";
+
+describe("resolveOrderedOpenAIPiAuthProfileSelection", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-openai-pi-auth-selection-"));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("selects a Codex OAuth profile from OpenAI auth order for OpenAI Pi runs", () => {
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "openai-codex:work": {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "codex-access",
+          refresh: "codex-refresh",
+          expires: Date.now() + 60_000,
+        },
+        "openai:default": {
+          type: "api_key",
+          provider: "openai",
+          key: "sk-openai",
+        },
+      },
+    };
+    saveAuthProfileStore(store, tmpDir);
+
+    const selection = resolveOrderedOpenAIPiAuthProfileSelection({
+      config: {
+        auth: {
+          order: {
+            openai: ["openai-codex:work", "openai:default"],
+          },
+        },
+      },
+      agentDir: tmpDir,
+      workspaceDir: tmpDir,
+      provider: "openai",
+      harnessRuntime: "pi",
+      allowHarnessAuthProfileForwarding: true,
+    });
+
+    expect(selection).toEqual({
+      authProfileId: "openai-codex:work",
+      authProfileIdSource: "auto",
+      authProfileProvider: "openai-codex",
+    });
+  });
+
+  it("does not skip an earlier OpenAI API-key profile to select a later Codex OAuth profile", () => {
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "openai:default": {
+          type: "api_key",
+          provider: "openai",
+          key: "sk-openai",
+        },
+        "openai-codex:work": {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "codex-access",
+          refresh: "codex-refresh",
+          expires: Date.now() + 60_000,
+        },
+      },
+    };
+    saveAuthProfileStore(store, tmpDir);
+
+    expect(
+      resolveOrderedOpenAIPiAuthProfileSelection({
+        config: {
+          auth: {
+            order: {
+              openai: ["openai:default", "openai-codex:work"],
+            },
+          },
+        },
+        agentDir: tmpDir,
+        workspaceDir: tmpDir,
+        provider: "openai",
+        harnessRuntime: "pi",
+        allowHarnessAuthProfileForwarding: true,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("does not select Codex OAuth profiles for non-Pi OpenAI runs", () => {
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "openai-codex:work": {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "codex-access",
+          refresh: "codex-refresh",
+          expires: Date.now() + 60_000,
+        },
+      },
+    };
+    saveAuthProfileStore(store, tmpDir);
+
+    expect(
+      resolveOrderedOpenAIPiAuthProfileSelection({
+        config: {
+          auth: {
+            order: {
+              openai: ["openai-codex:work"],
+            },
+          },
+        },
+        agentDir: tmpDir,
+        workspaceDir: tmpDir,
+        provider: "openai",
+        harnessRuntime: "default",
+        allowHarnessAuthProfileForwarding: true,
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/src/agents/command/auth-profile-selection.ts
+++ b/src/agents/command/auth-profile-selection.ts
@@ -1,0 +1,73 @@
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveAuthProfileOrder } from "../auth-profiles/order.js";
+import { ensureAuthProfileStore } from "../auth-profiles/store.js";
+import {
+  OPENAI_CODEX_PROVIDER_ID,
+  listOpenAIAuthProfileProvidersForAgentRuntime,
+} from "../openai-codex-routing.js";
+import { buildAgentRuntimeAuthPlan } from "../runtime-plan/auth.js";
+
+export type HarnessAuthProfileSelection = {
+  authProfileId?: string;
+  authProfileIdSource?: "auto" | "user";
+  authProfileProvider: string;
+  authProfileMode?: string;
+};
+
+export function profileIdProvider(profileId: string): string {
+  return profileId.split(":", 1)[0] ?? "";
+}
+
+export function resolveOrderedOpenAIPiAuthProfileSelection(params: {
+  config: OpenClawConfig;
+  agentDir: string;
+  workspaceDir: string;
+  provider: string;
+  harnessId?: string;
+  harnessRuntime?: string;
+  allowHarnessAuthProfileForwarding: boolean;
+}): HarnessAuthProfileSelection | undefined {
+  const runtimeAuthProviders = listOpenAIAuthProfileProvidersForAgentRuntime({
+    provider: params.provider,
+    harnessRuntime: params.harnessRuntime,
+    agentHarnessId: params.harnessId,
+  });
+  if (!runtimeAuthProviders.includes(OPENAI_CODEX_PROVIDER_ID)) {
+    return undefined;
+  }
+
+  const store = ensureAuthProfileStore(params.agentDir, {
+    allowKeychainPrompt: false,
+  });
+  const orderedCompatibleProfiles = resolveAuthProfileOrder({
+    cfg: params.config,
+    store,
+    provider: OPENAI_CODEX_PROVIDER_ID,
+  });
+
+  const profileId = orderedCompatibleProfiles[0];
+  if (!profileId || profileIdProvider(profileId) !== OPENAI_CODEX_PROVIDER_ID) {
+    return undefined;
+  }
+  const credential = store.profiles[profileId];
+  const candidateAuthPlan = buildAgentRuntimeAuthPlan({
+    provider: params.provider,
+    authProfileProvider: credential?.provider ?? profileIdProvider(profileId),
+    authProfileMode: credential?.type,
+    sessionAuthProfileId: profileId,
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+    harnessId: params.harnessId,
+    harnessRuntime: params.harnessRuntime,
+    allowHarnessAuthProfileForwarding: params.allowHarnessAuthProfileForwarding,
+  });
+  if (candidateAuthPlan.forwardedAuthProfileId === profileId) {
+    return {
+      authProfileId: profileId,
+      authProfileIdSource: "auto",
+      authProfileProvider: credential?.provider ?? profileIdProvider(profileId),
+    };
+  }
+
+  return undefined;
+}

--- a/src/agents/command/auth-profile-selection.ts
+++ b/src/agents/command/auth-profile-selection.ts
@@ -3,8 +3,10 @@ import { resolveAuthProfileOrder } from "../auth-profiles/order.js";
 import { ensureAuthProfileStore } from "../auth-profiles/store.js";
 import {
   OPENAI_CODEX_PROVIDER_ID,
+  OPENAI_PROVIDER_ID,
   listOpenAIAuthProfileProvidersForAgentRuntime,
 } from "../openai-codex-routing.js";
+import { findNormalizedProviderValue } from "../provider-id.js";
 import { buildAgentRuntimeAuthPlan } from "../runtime-plan/auth.js";
 
 export type HarnessAuthProfileSelection = {
@@ -16,6 +18,20 @@ export type HarnessAuthProfileSelection = {
 
 export function profileIdProvider(profileId: string): string {
   return profileId.split(":", 1)[0] ?? "";
+}
+
+function resolveExplicitOpenAIAuthOrder(params: {
+  config: OpenClawConfig;
+  storeOrder?: Record<string, string[]>;
+}): string[] | undefined {
+  return (
+    findNormalizedProviderValue(params.storeOrder, OPENAI_PROVIDER_ID) ??
+    findNormalizedProviderValue(params.config.auth?.order, OPENAI_PROVIDER_ID)
+  );
+}
+
+function resolveFirstExistingProfile(profileIds: string[], storeProfiles: Record<string, unknown>) {
+  return profileIds.find((profileId) => storeProfiles[profileId]);
 }
 
 export function resolveOrderedOpenAIPiAuthProfileSelection(params: {
@@ -39,6 +55,37 @@ export function resolveOrderedOpenAIPiAuthProfileSelection(params: {
   const store = ensureAuthProfileStore(params.agentDir, {
     allowKeychainPrompt: false,
   });
+  const explicitOpenAIOrder = resolveExplicitOpenAIAuthOrder({
+    config: params.config,
+    storeOrder: store.order,
+  });
+  if (explicitOpenAIOrder) {
+    const firstProfileId = resolveFirstExistingProfile(explicitOpenAIOrder, store.profiles);
+    if (!firstProfileId || profileIdProvider(firstProfileId) !== OPENAI_CODEX_PROVIDER_ID) {
+      return undefined;
+    }
+    const credential = store.profiles[firstProfileId];
+    const candidateAuthPlan = buildAgentRuntimeAuthPlan({
+      provider: params.provider,
+      authProfileProvider: credential?.provider ?? profileIdProvider(firstProfileId),
+      authProfileMode: credential?.type,
+      sessionAuthProfileId: firstProfileId,
+      config: params.config,
+      workspaceDir: params.workspaceDir,
+      harnessId: params.harnessId,
+      harnessRuntime: params.harnessRuntime,
+      allowHarnessAuthProfileForwarding: params.allowHarnessAuthProfileForwarding,
+    });
+    if (candidateAuthPlan.forwardedAuthProfileId === firstProfileId) {
+      return {
+        authProfileId: firstProfileId,
+        authProfileIdSource: "auto",
+        authProfileProvider: credential?.provider ?? profileIdProvider(firstProfileId),
+      };
+    }
+    return undefined;
+  }
+
   const orderedCompatibleProfiles = resolveAuthProfileOrder({
     cfg: params.config,
     store,

--- a/src/cli/models-cli.test.ts
+++ b/src/cli/models-cli.test.ts
@@ -209,6 +209,40 @@ describe("models cli", () => {
     });
   });
 
+  it("maps --device-code to the provider device-code auth method", async () => {
+    await runModelsCommand([
+      "models",
+      "auth",
+      "login",
+      "--provider",
+      "openai-codex",
+      "--device-code",
+    ]);
+
+    expectCommandOptions(modelsAuthLoginCommand, {
+      provider: "openai-codex",
+      method: "device-code",
+    });
+  });
+
+  it("rejects conflicting --device-code and --method values", async () => {
+    await expect(
+      runModelsCommand([
+        "models",
+        "auth",
+        "login",
+        "--provider",
+        "openai-codex",
+        "--device-code",
+        "--method",
+        "oauth",
+      ]),
+    ).rejects.toThrow(
+      "--device-code cannot be combined with --method unless --method is device-code",
+    );
+    expect(modelsAuthLoginCommand).not.toHaveBeenCalled();
+  });
+
   it("passes list-specific --agent and --json to models auth list", async () => {
     await runModelsCommand(["models", "auth", "list", "--agent", "poe", "--json"]);
 

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -332,15 +332,22 @@ export function registerModelsCli(program: Command) {
     .description("Run a provider plugin auth flow (OAuth/API key)")
     .option("--provider <id>", "Provider id registered by a plugin")
     .option("--method <id>", "Provider auth method id")
+    .option("--device-code", "Use the provider's device-code auth method", false)
     .option("--set-default", "Apply the provider's default model recommendation", false)
     .action(async (opts, command) => {
+      if (opts.deviceCode && opts.method && opts.method !== "device-code") {
+        throw new Error(
+          "--device-code cannot be combined with --method unless --method is device-code",
+        );
+      }
       await withModelsRuntime(async ({ defaultRuntime, resolveModelAgentOption }) => {
         const agent = resolveModelAgentOption(command);
         const { modelsAuthLoginCommand } = await import("../commands/models/auth.js");
         await modelsAuthLoginCommand(
           {
             provider: opts.provider as string | undefined,
-            method: opts.method as string | undefined,
+            method:
+              (opts.method as string | undefined) ?? (opts.deviceCode ? "device-code" : undefined),
             setDefault: Boolean(opts.setDefault),
             agent,
           },


### PR DESCRIPTION
## Summary

- Problem: OpenAI Pi runs could ignore an agent auth.order where an OpenAI-compatible Codex OAuth profile was first, so they fell back to the normal OpenAI auth path instead of the existing Codex auth transport.
- Why it matters: agents configured to use Codex OAuth for OpenAI-compatible Pi runs could route with the wrong auth profile.
- What changed: added a small selection helper that preserves auth.order semantics for OpenAI Pi runs, forwards compatible Codex OAuth profiles through the Codex transport, and leaves first-choice OpenAI profiles on the normal OpenAI path.
- What did NOT change (scope boundary): no changes to token formats, persisted profile schema, non-OpenAI providers, or live OAuth refresh behavior.

## Change Type (select all)

- [x] Bug fix
- [x] Refactor required for the fix
- [x] Docs

## Scope (select all touched areas)

- [x] Skills / tool execution
- [x] Auth / tokens
- [x] UI / DX

## Linked Issue/PR

- Closes #82521
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: OpenAI-compatible Pi runs respect Codex OAuth entries in the OpenAI auth order, and the models auth CLI exposes device-code login for the Codex provider.
- Real environment tested: local OpenClaw source checkout on Node v24.15.0 and pnpm 11.1.0.
- Exact steps or command run after this patch:
  1. node --import tsx src/entry.ts models auth login --help
  2. node --import tsx src/entry.ts models auth login --provider openai-codex --device-code --help
  3. node --import tsx src/entry.ts models auth login --provider openai-codex --device-code --method oauth
- Evidence after fix: copied terminal output from the local OpenClaw source checkout:

```text
$ node --import tsx src/entry.ts models auth login --help
OpenClaw 2026.5.17 (fa386d0) -- All your chats, one OpenClaw.

Usage: openclaw models auth login [options]

Run a provider plugin auth flow (OAuth/API key)

Options:
  --device-code    Use the provider's device-code auth method (default: false)
  -h, --help       Display help for command
  --method <id>    Provider auth method id
  --provider <id>  Provider id registered by a plugin
  --set-default    Apply the provider's default model recommendation (default:
                   false)

$ node --import tsx src/entry.ts models auth login --provider openai-codex --device-code --method oauth
[openclaw] Could not start the CLI.
[openclaw] Reason: --device-code cannot be combined with --method unless --method is device-code
[openclaw] Debug: set OPENCLAW_DEBUG=1 to include the stack trace.
[openclaw] Try: openclaw doctor
[openclaw] Help: openclaw --help
```

  - Focused tests below prove OpenAI Pi auth selection now follows the configured auth order without requiring private live credentials.
- Observed result after fix: CLI option is available, invalid option combinations are rejected, and tests pass for Codex-first, OpenAI-first, and missing-profile auth-order cases.
- What was not tested: live OpenAI/Codex OAuth against a private account.
- Before evidence (optional but encouraged): not captured; regression coverage encodes the previous missing selection behavior.

## Root Cause (if applicable)

- Root cause: the OpenAI Pi route only looked at explicit/session auth overrides and did not resolve compatible Codex OAuth profiles from the configured OpenAI auth order.
- Missing detection / guardrail: there was no focused test for OpenAI Pi auth order containing openai-codex profile ids.
- Contributing context (if known): Codex OAuth is OpenAI-compatible for this route, but it needs the existing Codex transport.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: src/agents/command/auth-profile-selection.test.ts and src/agents/auth-profile-runtime-contract.test.ts
- Scenario the test should lock in: OpenAI Pi runs select the first compatible openai-codex profile from auth.order, preserve OpenAI-first order, and ignore missing incompatible profiles.
- Why this is the smallest reliable guardrail: it exercises the selection boundary without live provider credentials.
- Existing test that already covers this (if any): none before this patch.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

OpenAI Pi runs can now use a first-choice openai-codex OAuth profile from auth.order. The models auth login CLI also accepts --device-code as shorthand for the provider device-code auth method.

## Diagram (if applicable)

```text
Before:
auth.order openai -> openai-codex:work -> OpenAI Pi run -> normal OpenAI auth path

After:
auth.order openai -> openai-codex:work -> OpenAI Pi run -> Codex auth transport
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes
- Data access scope changed? No
- If any Yes, explain risk + mitigation: OpenAI Pi runs may forward an already-configured Codex OAuth profile when auth.order selects it. The helper only selects stored compatible profiles and keeps OpenAI-first order on the existing OpenAI path.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node v24.15.0, pnpm 11.1.0, local source checkout
- Model/provider: OpenAI Pi / openai-codex auth profile routing
- Integration/channel (if any): CLI agent command path
- Relevant config (redacted): tests create temporary auth-profiles.json and auth.order fixtures

### Steps

1. Configure an OpenAI auth order with openai-codex:work before openai:default.
2. Start an OpenAI Pi agent run without an explicit auth override.
3. Inspect the runtime auth plan / CLI runner args.

### Expected

- The run forwards openai-codex:work through the Codex auth transport.

### Actual

- Before this patch, the route could fall back to the normal OpenAI auth path. After this patch, focused tests show the Codex profile is selected only when it is first and compatible.

## Evidence

- [x] Failing test/log before + passing after

Focused validation run:

```bash
node scripts/test-projects.mjs src/agents/command/auth-profile-selection.test.ts src/agents/auth-profile-runtime-contract.test.ts src/agents/auth-profiles.external-cli-scope.test.ts src/cli/models-cli.test.ts
```

Result: passed, 3 Vitest shards, 43 tests.

Additional checks:

```bash
git diff --check
node --import tsx src/entry.ts models auth login --help
node --import tsx src/entry.ts models auth login --provider openai-codex --device-code --help
node --import tsx src/entry.ts models auth login --provider openai-codex --device-code --method oauth
```

The invalid CLI combination exits with the expected option conflict error.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Codex-first auth order, OpenAI-first auth order, missing profile handling, device-code CLI help, invalid device-code/method combination.
- Edge cases checked: missing auth profiles are ignored; OpenAI-first order remains on the normal OpenAI path; explicit OpenAI-only order is not bypassed by a stored Codex profile; --device-code with --method oauth is rejected.
- What you did not verify: live OAuth against a private OpenAI/Codex account.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: selecting a Codex OAuth profile for an OpenAI Pi run could override an intended OpenAI token profile.
  - Mitigation: the helper preserves auth.order, so OpenAI-first order remains on the existing OpenAI path.

