### PR TITLE
fix(synology-chat): preserve message when trigger word equals full text

### DIFF
--- a/extensions/synology-chat/src/webhook-handler.test.ts
+++ b/extensions/synology-chat/src/webhook-handler.test.ts
@@ -572,6 +572,31 @@ describe("createWebhookHandler", () => {
     expect(deliveredMessage(deliver).body).toBe("Hello there");
   });
 
+  it("preserves full text when trigger word equals entire message", async () => {
+    const deliver = vi.fn().mockResolvedValue(null);
+    const handler = createWebhookHandler({
+      account: makeAccount({ accountId: "trigger-eq-text-" + Date.now() }),
+      deliver,
+      log,
+    });
+
+    const body = makeFormBody({
+      token: "valid-token",
+      user_id: "123",
+      username: "testuser",
+      text: "!bot",
+      trigger_word: "!bot",
+    });
+
+    const req = makeReq("POST", body);
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(res._status).toBe(204);
+    // when the entire message is the trigger word, deliver the full text rather than dropping it
+    expect(deliveredMessage(deliver).body).toBe("!bot");
+  });
+
   it("responds 204 immediately and delivers async", async () => {
     const { deliver, res } = await runValidReply({ accountIdSuffix: "async-test" });
     expect(res._body).toBe("");

--- a/extensions/synology-chat/src/webhook-handler.ts
+++ b/extensions/synology-chat/src/webhook-handler.ts
@@ -467,7 +467,9 @@ function sanitizeSynologyWebhookText(payload: SynologyWebhookPayload): string {
   let cleanText = sanitizeInput(payload.text);
   if (payload.trigger_word && cleanText.startsWith(payload.trigger_word)) {
     const stripped = cleanText.slice(payload.trigger_word.length).trim();
-    if (stripped) cleanText = stripped;
+    if (stripped) {
+      cleanText = stripped;
+    }
   }
   return cleanText;
 }

--- a/extensions/synology-chat/src/webhook-handler.ts
+++ b/extensions/synology-chat/src/webhook-handler.ts
@@ -466,7 +466,8 @@ async function authorizeSynologyWebhook(params: {
 function sanitizeSynologyWebhookText(payload: SynologyWebhookPayload): string {
   let cleanText = sanitizeInput(payload.text);
   if (payload.trigger_word && cleanText.startsWith(payload.trigger_word)) {
-    cleanText = cleanText.slice(payload.trigger_word.length).trim();
+    const stripped = cleanText.slice(payload.trigger_word.length).trim();
+    if (stripped) cleanText = stripped;
   }
   return cleanText;
 }


### PR DESCRIPTION
## Problem

\`sanitizeSynologyWebhookText\` strips the \`trigger_word\` prefix from the message text. When the stripped result is empty, the handler calls \`respondNoContent\` and returns \`{ ok: false }\`, silently dropping the message with a 204 — no log entry, no agent delivery.

This silent failure occurs in two real-world configurations:

**Case 1 — trigger word equals full message text**
User sends exactly the trigger word with no additional content (e.g. trigger word = \`!bot\`, message = \`!bot\`). After stripping, \`cleanText\` is empty and the message is dropped.

**Case 2 — no trigger word configured in Synology Chat**
When the Synology Chat outgoing webhook has no trigger word set, Synology Chat populates \`trigger_word\` with the full message text on every delivery. Since \`text.startsWith(trigger_word)\` is always true when they are equal, the entire text is stripped, \`cleanText\` becomes empty, and every message is silently dropped. This makes the no-trigger-word configuration completely non-functional.

Both cases are hard to diagnose: the gateway returns 204 with no log entry and no feedback to the user.

## Fix

Only replace \`cleanText\` with the stripped remainder when the stripped result is non-empty. If stripping the trigger word would produce an empty string, pass the full original text to the agent instead.

\`\`\`typescript
// before
if (payload.trigger_word && cleanText.startsWith(payload.trigger_word)) {
  cleanText = cleanText.slice(payload.trigger_word.length).trim();
}

// after
if (payload.trigger_word && cleanText.startsWith(payload.trigger_word)) {
  const stripped = cleanText.slice(payload.trigger_word.length).trim();
  if (stripped) cleanText = stripped;
}
\`\`\`

## Tests

Adds a regression test: \`"preserves full text when trigger word equals entire message"\` covering both the \`text == trigger_word\` edge case and the no-trigger-word Synology configuration.

## Behaviour summary

| \`text\` | \`trigger_word\` | Configuration | before | after |
|--------|---------------|---------------|--------|-------|
| \`"!bot Hello"\` | \`"!bot"\` | normal prefix trigger | \`"Hello"\` ✅ | \`"Hello"\` ✅ |
| \`"!bot"\` | \`"!bot"\` | single-word trigger | _(dropped, 204)_ ❌ | \`"!bot"\` ✅ |
| \`"hello"\` | \`"hello"\` | no trigger word set (Synology fills full text) | _(dropped, 204)_ ❌ | \`"hello"\` ✅ |

## Real behavior proof

Tested on OpenClaw v2026.5.12 with `@openclaw/synology-chat` plugin, Ubuntu 26.04, Synology Chat 2.4.5-22148.

**Before patch — message silently dropped (trigger word = full message text)**

```
$ curl -s -w "HTTP:%{http_code}" -X POST "http://127.0.0.1:18789/webhook/synology" \
  -H "Content-Type: application/x-www-form-urlencoded" \
  --data-urlencode "token=<redacted>" \
  --data-urlencode "channel_id=4" --data-urlencode "channel_type=1" \
  --data-urlencode "user_id=4" --data-urlencode "username=testuser" \
  --data-urlencode "text=hello" --data-urlencode "trigger_word=hello"

HTTP:204
```

Gateway log: **no entry written** — zero bytes added to log file after the request.

**After patch — message delivered to agent**

Same request, same parameters:

```
HTTP:204
```

Gateway log:

```
2026-05-16T11:56:01 Message from testuser (4): hello
2026-05-16T11:56:10 Agent reply started for 4
```

**No-trigger-word Synology Chat configuration**

When the Synology Chat outgoing webhook has no trigger word configured, Synology Chat 2.4.5-22148 populates `trigger_word` with the full message text on every delivery — confirmed from a live webhook capture:

```
token=<redacted>&channel_id=4&channel_type=1&channel_name=OpenClaw
&user_id=4&username=testuser&text=hello&trigger_word=hello
```

Before patch: every message dropped. After patch: delivered normally.