### PR TITLE
fix(auth): serialize auth login writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 - Android/chat: make bare and markdown URLs in chat messages tappable by preserving Compose URL annotations in rendered markdown. Fixes #82187. (#82392) Thanks @neeravmakwana.
 - Plugins/doctor: migrate legacy top-level plugin `tools` declarations into `contracts.tools`, so `openclaw doctor --fix` repairs local plugins for the manifest tool contract. (#81112) Thanks @100yenadmin.
 - Slack: guide agents to use stable `<@USER_ID>` mention tokens from context instead of plain `@name` text, so user mentions link and notify correctly. Fixes #82090. (#82152) Thanks @neeravmakwana.
+- Auth/OpenAI Codex: serialize provider login writes through the auth-profile lock so a live Gateway cannot overwrite freshly refreshed OAuth credentials with an expired in-memory snapshot.
 - Codex app-server: release raw assistant completions when `turn/completed` is missing while keeping commentary/status items as progress, preventing completed Codex runs from hanging until timeout. Fixes #82343. (#82403) Thanks @IWhatsskill.
 - Agents/sessions: remove the transient `*.bak-<pid>-<ts>` backup written by `repairSessionFileIfNeeded` once the atomic replace succeeds, so a stuck session with a persistently malformed JSONL line no longer accumulates one snapshot per repair invocation. Fixes #80960. (#80969) Thanks @100yenadmin. Co-authored by @tynamite.
 - CLI/status: show plain empty-state messages instead of empty Channels and Sessions tables when no channels or sessions exist.

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -16,7 +16,7 @@ import {
   type OpenClawConfig as ProviderAuthConfig,
   type ProviderAuthResult,
   suggestOAuthProfileIdForLegacyDefault,
-  upsertAuthProfile,
+  upsertAuthProfileWithLock,
   validateAnthropicSetupToken,
 } from "openclaw/plugin-sdk/provider-auth";
 import {
@@ -44,6 +44,7 @@ import { buildAnthropicReplayPolicy } from "./replay-policy.js";
 import { wrapAnthropicProviderStream } from "./stream-wrappers.js";
 
 const PROVIDER_ID = "anthropic";
+type UpsertAuthProfileParams = Parameters<typeof upsertAuthProfileWithLock>[0];
 const DEFAULT_ANTHROPIC_MODEL = "anthropic/claude-opus-4-7";
 const ANTHROPIC_OPUS_47_MODEL_ID = "claude-opus-4-7";
 const ANTHROPIC_OPUS_47_DOT_MODEL_ID = "claude-opus-4.7";
@@ -80,6 +81,15 @@ const CLAUDE_CLI_CANONICAL_ALLOWLIST_REFS = CLAUDE_CLI_DEFAULT_ALLOWLIST_REFS.ma
     ? `anthropic/${ref.slice(CLAUDE_CLI_BACKEND_ID.length + 1)}`
     : ref,
 );
+
+async function upsertAuthProfileWithLockOrThrow(params: UpsertAuthProfileParams): Promise<void> {
+  const updated = await upsertAuthProfileWithLock(params);
+  if (!updated) {
+    throw new Error(
+      "Failed to update auth profile store; the auth store lock may be busy. Wait a moment and retry.",
+    );
+  }
+}
 const CLAUDE_CLI_CANONICAL_DEFAULT_MODEL_REF = CLAUDE_CLI_DEFAULT_MODEL_REF.startsWith(
   `${CLAUDE_CLI_BACKEND_ID}/`,
 )
@@ -166,7 +176,7 @@ async function runAnthropicSetupTokenNonInteractive(
 
   const profileId = resolveAnthropicSetupTokenProfileId(ctx.opts.tokenProfileId);
   const expires = resolveAnthropicSetupTokenExpiry(ctx.opts.tokenExpiresIn);
-  upsertAuthProfile({
+  await upsertAuthProfileWithLockOrThrow({
     profileId,
     credential: {
       type: "token",

--- a/extensions/cloudflare-ai-gateway/index.ts
+++ b/extensions/cloudflare-ai-gateway/index.ts
@@ -7,7 +7,7 @@ import {
   listProfilesForProvider,
   normalizeApiKeyInput,
   normalizeOptionalSecretInput,
-  upsertAuthProfile,
+  upsertAuthProfileWithLock,
   validateApiKeyInput,
 } from "openclaw/plugin-sdk/provider-auth";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -19,6 +19,16 @@ import { wrapCloudflareAiGatewayProviderStream } from "./stream-wrappers.js";
 const PROVIDER_ID = "cloudflare-ai-gateway";
 const PROVIDER_ENV_VAR = "CLOUDFLARE_AI_GATEWAY_API_KEY";
 const PROFILE_ID = "cloudflare-ai-gateway:default";
+type UpsertAuthProfileParams = Parameters<typeof upsertAuthProfileWithLock>[0];
+
+async function upsertAuthProfileWithLockOrThrow(params: UpsertAuthProfileParams): Promise<void> {
+  const updated = await upsertAuthProfileWithLock(params);
+  if (!updated) {
+    throw new Error(
+      "Failed to update auth profile store; the auth store lock may be busy. Wait a moment and retry.",
+    );
+  }
+}
 
 function readRequiredTextInput(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
@@ -176,7 +186,7 @@ export default definePluginEntry({
               if (!credential) {
                 return null;
               }
-              upsertAuthProfile({
+              await upsertAuthProfileWithLockOrThrow({
                 profileId: PROFILE_ID,
                 credential,
                 agentDir: ctx.agentDir,

--- a/extensions/github-copilot/login.ts
+++ b/extensions/github-copilot/login.ts
@@ -4,7 +4,7 @@ import { logConfigUpdated, updateConfig } from "openclaw/plugin-sdk/config-mutat
 import {
   applyAuthProfileConfig,
   ensureAuthProfileStore,
-  upsertAuthProfile,
+  upsertAuthProfileWithLock,
 } from "openclaw/plugin-sdk/provider-auth";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime";
 
@@ -36,12 +36,23 @@ type DeviceTokenResponse =
 const GITHUB_DEVICE_ACCESS_DENIED = Symbol("github-device-access-denied");
 const GITHUB_DEVICE_EXPIRED = Symbol("github-device-expired");
 
+type UpsertAuthProfileParams = Parameters<typeof upsertAuthProfileWithLock>[0];
+
 class GitHubDeviceFlowError extends Error {
   readonly kind: symbol;
   constructor(kind: symbol, message: string) {
     super(message);
     this.kind = kind;
     this.name = "GitHubDeviceFlowError";
+  }
+}
+
+async function upsertAuthProfileWithLockOrThrow(params: UpsertAuthProfileParams): Promise<void> {
+  const updated = await upsertAuthProfileWithLock(params);
+  if (!updated) {
+    throw new Error(
+      "Failed to update auth profile store; the auth store lock may be busy. Wait a moment and retry.",
+    );
   }
 }
 
@@ -266,7 +277,7 @@ export async function githubCopilotLoginCommand(
   });
   polling.stop("GitHub access token acquired");
 
-  upsertAuthProfile({
+  await upsertAuthProfileWithLockOrThrow({
     profileId,
     credential: {
       type: "token",

--- a/extensions/zai/index.ts
+++ b/extensions/zai/index.ts
@@ -14,7 +14,7 @@ import {
   normalizeApiKeyInput,
   normalizeOptionalSecretInput,
   type SecretInput,
-  upsertAuthProfile,
+  upsertAuthProfileWithLock,
   validateApiKeyInput,
 } from "openclaw/plugin-sdk/provider-auth-api-key";
 import {
@@ -36,6 +36,16 @@ import { applyZaiConfig, applyZaiProviderConfig, ZAI_DEFAULT_MODEL_REF } from ".
 const PROVIDER_ID = "zai";
 const GLM5_TEMPLATE_MODEL_ID = "glm-4.7";
 const PROFILE_ID = "zai:default";
+type UpsertAuthProfileParams = Parameters<typeof upsertAuthProfileWithLock>[0];
+
+async function upsertAuthProfileWithLockOrThrow(params: UpsertAuthProfileParams): Promise<void> {
+  const updated = await upsertAuthProfileWithLock(params);
+  if (!updated) {
+    throw new Error(
+      "Failed to update auth profile store; the auth store lock may be busy. Wait a moment and retry.",
+    );
+  }
+}
 
 function resolveGlm5ForwardCompatModel(
   ctx: ProviderResolveDynamicModelContext,
@@ -229,7 +239,7 @@ async function runZaiApiKeyAuthNonInteractive(
     if (!credential) {
       return null;
     }
-    upsertAuthProfile({
+    await upsertAuthProfileWithLockOrThrow({
       profileId: PROFILE_ID,
       credential,
       agentDir: ctx.agentDir,

--- a/src/agents/auth-profiles/persisted.ts
+++ b/src/agents/auth-profiles/persisted.ts
@@ -460,7 +460,11 @@ function createFallbackOAuthProfileSecretKeyFile(): string | undefined {
 }
 
 function shouldUseMacKeychainForOAuthProfileSecrets(): boolean {
-  return process.platform === "darwin" && process.env.VITEST !== "true";
+  return (
+    process.platform === "darwin" &&
+    process.env.VITEST !== "true" &&
+    process.env.VITEST_WORKER_ID === undefined
+  );
 }
 
 function resolveOAuthProfileSecretKeySeed(options?: { create?: boolean }): string | undefined {

--- a/src/agents/auth-profiles/profiles.test.ts
+++ b/src/agents/auth-profiles/profiles.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import { resolveOAuthDir } from "../../config/paths.js";
 import { AUTH_STORE_VERSION } from "./constants.js";
 import { resolveAuthStorePath } from "./paths.js";
-import { promoteAuthProfileInOrder } from "./profiles.js";
+import { promoteAuthProfileInOrder, upsertAuthProfileWithLock } from "./profiles.js";
 import {
   clearRuntimeAuthProfileStoreSnapshots,
   findPersistedAuthProfileCredential,
@@ -138,6 +138,54 @@ function expectOpenClawCredentialsOAuthRef(
 }
 
 describe("promoteAuthProfileInOrder", () => {
+  it("normalizes copied secrets when using the locked upsert path", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-profile-upsert-"));
+    const agentDir = path.join(stateDir, "agents", "main", "agent");
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    try {
+      fs.mkdirSync(agentDir, { recursive: true });
+
+      await upsertAuthProfileWithLock({
+        profileId: "openai:manual",
+        credential: {
+          type: "token",
+          provider: "openai",
+          token: "  bearer\r\n-token\u2502  ",
+        },
+        agentDir,
+      });
+      await upsertAuthProfileWithLock({
+        profileId: "anthropic:key",
+        credential: {
+          type: "api_key",
+          provider: "anthropic",
+          key: "  sk-\r\nant\u2502  ",
+        },
+        agentDir,
+      });
+
+      const profiles = loadAuthProfileStoreWithoutExternalProfiles(agentDir).profiles;
+      expect(profiles["openai:manual"]).toMatchObject({
+        type: "token",
+        provider: "openai",
+        token: "bearer-token",
+      });
+      expect(profiles["anthropic:key"]).toMatchObject({
+        type: "api_key",
+        provider: "anthropic",
+        key: "sk-ant",
+      });
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
   it("omits inline openai-codex oauth secrets from persisted auth profile files", () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-profile-metadata-"));
     const agentDir = path.join(stateDir, "agents", "main", "agent");
@@ -610,10 +658,18 @@ describe("promoteAuthProfileInOrder", () => {
         { filterExternalAuthProfiles: false },
       );
 
+      const expectedKeyPath =
+        process.platform === "darwin"
+          ? path.join(
+              homeDir,
+              "Library",
+              "Application Support",
+              "OpenClaw",
+              "auth-profile-secret-key",
+            )
+          : path.join(homeDir, ".openclaw-auth-profile-secrets", "auth-profile-secret-key");
       const keyPaths = findFilesNamed(rootDir, "auth-profile-secret-key");
-      expect(keyPaths).toEqual([
-        path.join(homeDir, ".openclaw-auth-profile-secrets", "auth-profile-secret-key"),
-      ]);
+      expect(keyPaths).toEqual([expectedKeyPath]);
       expect(keyPaths.every((keyPath) => !isPathInsideOrEqual(stateDir, keyPath))).toBe(true);
       const keyValues = keyPaths.map((keyPath) => fs.readFileSync(keyPath, "utf8").trim());
       const persistedStateTree = readPersistedTree(stateDir);

--- a/src/agents/auth-profiles/profiles.ts
+++ b/src/agents/auth-profiles/profiles.ts
@@ -106,22 +106,35 @@ export async function promoteAuthProfileInOrder(params: {
   });
 }
 
+function normalizeAuthProfileCredential(credential: AuthProfileCredential): AuthProfileCredential {
+  if (credential.type === "api_key") {
+    if (typeof credential.key !== "string") {
+      return credential;
+    }
+    const { key: _key, ...rest } = credential;
+    const key = normalizeSecretInput(credential.key);
+    return {
+      ...rest,
+      ...(key ? { key } : {}),
+    };
+  }
+  if (credential.type === "token") {
+    if (typeof credential.token !== "string") {
+      return credential;
+    }
+    const { token: _token, ...rest } = credential;
+    const token = normalizeSecretInput(credential.token);
+    return { ...rest, ...(token ? { token } : {}) };
+  }
+  return credential;
+}
+
 export function upsertAuthProfile(params: {
   profileId: string;
   credential: AuthProfileCredential;
   agentDir?: string;
 }): void {
-  const credential =
-    params.credential.type === "api_key"
-      ? {
-          ...params.credential,
-          ...(typeof params.credential.key === "string"
-            ? { key: normalizeSecretInput(params.credential.key) }
-            : {}),
-        }
-      : params.credential.type === "token"
-        ? { ...params.credential, token: normalizeSecretInput(params.credential.token) }
-        : params.credential;
+  const credential = normalizeAuthProfileCredential(params.credential);
   const store = ensureAuthProfileStoreForLocalUpdate(params.agentDir);
   store.profiles[params.profileId] = credential;
   saveAuthProfileStore(store, params.agentDir, {
@@ -135,10 +148,15 @@ export async function upsertAuthProfileWithLock(params: {
   credential: AuthProfileCredential;
   agentDir?: string;
 }): Promise<AuthProfileStore | null> {
+  const credential = normalizeAuthProfileCredential(params.credential);
   return await updateAuthProfileStoreWithLock({
     agentDir: params.agentDir,
+    saveOptions: {
+      filterExternalAuthProfiles: false,
+      syncExternalCli: false,
+    },
     updater: (store) => {
-      store.profiles[params.profileId] = params.credential;
+      store.profiles[params.profileId] = credential;
       return true;
     },
   });

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -456,6 +456,7 @@ function buildLocalAuthProfileStoreForSave(params: {
 
 export async function updateAuthProfileStoreWithLock(params: {
   agentDir?: string;
+  saveOptions?: SaveAuthProfileStoreOptions;
   updater: (store: AuthProfileStore) => boolean;
 }): Promise<AuthProfileStore | null> {
   const authPath = resolveAuthStorePath(params.agentDir);
@@ -469,7 +470,7 @@ export async function updateAuthProfileStoreWithLock(params: {
       const store = loadAuthProfileStoreForAgent(params.agentDir, { syncExternalCli: false });
       const shouldSave = params.updater(store);
       if (shouldSave) {
-        saveAuthProfileStore(store, params.agentDir);
+        saveAuthProfileStore(store, params.agentDir, params.saveOptions);
       }
       return store;
     });

--- a/src/agents/auth-profiles/upsert-with-lock.ts
+++ b/src/agents/auth-profiles/upsert-with-lock.ts
@@ -1,6 +1,30 @@
+import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
 import { ensureAuthStoreFile, resolveAuthStorePath } from "./paths.js";
 import { updateAuthProfileStoreWithLock } from "./store.js";
 import type { AuthProfileCredential, AuthProfileStore } from "./types.js";
+
+function normalizeAuthProfileCredential(credential: AuthProfileCredential): AuthProfileCredential {
+  if (credential.type === "api_key") {
+    if (typeof credential.key !== "string") {
+      return credential;
+    }
+    const { key: _key, ...rest } = credential;
+    const key = normalizeSecretInput(credential.key);
+    return {
+      ...rest,
+      ...(key ? { key } : {}),
+    };
+  }
+  if (credential.type === "token") {
+    if (typeof credential.token !== "string") {
+      return credential;
+    }
+    const { token: _token, ...rest } = credential;
+    const token = normalizeSecretInput(credential.token);
+    return { ...rest, ...(token ? { token } : {}) };
+  }
+  return credential;
+}
 
 export async function upsertAuthProfileWithLock(params: {
   profileId: string;
@@ -11,10 +35,15 @@ export async function upsertAuthProfileWithLock(params: {
   ensureAuthStoreFile(authPath);
 
   try {
+    const credential = normalizeAuthProfileCredential(params.credential);
     return await updateAuthProfileStoreWithLock({
       agentDir: params.agentDir,
+      saveOptions: {
+        filterExternalAuthProfiles: false,
+        syncExternalCli: false,
+      },
       updater: (store) => {
-        store.profiles[params.profileId] = params.credential;
+        store.profiles[params.profileId] = credential;
         return true;
       },
     });

--- a/src/commands/models/auth.test.ts
+++ b/src/commands/models/auth.test.ts
@@ -46,6 +46,7 @@ const mocks = vi.hoisted(() => ({
   resolveAgentWorkspaceDir: vi.fn(),
   resolveDefaultAgentWorkspaceDir: vi.fn(),
   upsertAuthProfile: vi.fn(),
+  upsertAuthProfileWithLock: vi.fn(),
   resolvePluginProviders: vi.fn(),
   createClackPrompter: vi.fn(),
   loadValidConfigOrThrow: vi.fn(),
@@ -65,6 +66,7 @@ vi.mock("../../agents/auth-profiles/profiles.js", () => ({
   listProfilesForProvider: mocks.listProfilesForProvider,
   promoteAuthProfileInOrder: mocks.promoteAuthProfileInOrder,
   upsertAuthProfile: mocks.upsertAuthProfile,
+  upsertAuthProfileWithLock: mocks.upsertAuthProfileWithLock,
 }));
 
 vi.mock("../../agents/auth-profiles/store.js", () => ({
@@ -322,7 +324,8 @@ describe("modelsAuthLoginCommand", () => {
     );
     mocks.clackSelect.mockReset();
     mocks.clackText.mockReset();
-    mocks.upsertAuthProfile.mockReset();
+    mocks.upsertAuthProfileWithLock.mockReset();
+    mocks.upsertAuthProfileWithLock.mockResolvedValue({ version: 1, profiles: {} });
     mocks.promoteAuthProfileInOrder.mockReset();
 
     mocks.resolveDefaultAgentId.mockReturnValue("main");
@@ -437,7 +440,7 @@ describe("modelsAuthLoginCommand", () => {
       runProviderAuth.mock.invocationCallOrder[0],
     );
     expect(runProviderAuth).toHaveBeenCalledOnce();
-    const upsertCall = readMockCallArg(mocks.upsertAuthProfile) as UpsertAuthProfileCall;
+    const upsertCall = readMockCallArg(mocks.upsertAuthProfileWithLock) as UpsertAuthProfileCall;
     expect(upsertCall.profileId).toBe("openai-codex:user@example.com");
     expect(upsertCall.credential?.type).toBe("oauth");
     expect(upsertCall.credential?.provider).toBe("openai-codex");
@@ -735,9 +738,9 @@ describe("modelsAuthLoginCommand", () => {
     const authRunCall = readMockCallArg(runProviderAuth) as AuthRunCall;
     expect(authRunCall.agentDir).toBe("/tmp/openclaw/agents/coder");
     expect(authRunCall.workspaceDir).toBe("/tmp/openclaw/workspaces/coder");
-    expect((readMockCallArg(mocks.upsertAuthProfile) as UpsertAuthProfileCall).agentDir).toBe(
-      "/tmp/openclaw/agents/coder",
-    );
+    expect(
+      (readMockCallArg(mocks.upsertAuthProfileWithLock) as UpsertAuthProfileCall).agentDir,
+    ).toBe("/tmp/openclaw/agents/coder");
   });
 
   it("loads the owning plugin for an explicit provider even in a clean config", async () => {
@@ -791,7 +794,7 @@ describe("modelsAuthLoginCommand", () => {
     expect(providerResolutionCall.providerRefs).toEqual(["anthropic"]);
     expect(providerResolutionCall.activate).toBe(true);
     expect(runClaudeCliMigration).toHaveBeenCalledOnce();
-    expect(mocks.upsertAuthProfile).not.toHaveBeenCalled();
+    expect(mocks.upsertAuthProfileWithLock).not.toHaveBeenCalled();
     expect(lastUpdatedConfig?.agents?.defaults?.model).toEqual({
       primary: "claude-cli/claude-sonnet-4-6",
     });
@@ -928,7 +931,7 @@ describe("modelsAuthLoginCommand", () => {
         (order) => order < runClaudeCliMigration.mock.invocationCallOrder[0],
       ),
     ).toBe(true);
-    expect(mocks.upsertAuthProfile).not.toHaveBeenCalled();
+    expect(mocks.upsertAuthProfileWithLock).not.toHaveBeenCalled();
     expect(lastUpdatedConfig?.agents?.defaults?.model).toEqual({
       primary: "claude-cli/claude-sonnet-4-6",
       fallbacks: ["claude-cli/claude-opus-4-6", "openai/gpt-5.2"],
@@ -1125,7 +1128,7 @@ describe("modelsAuthLoginCommand", () => {
         "exit:0",
       );
 
-      expect(mocks.upsertAuthProfile).not.toHaveBeenCalled();
+      expect(mocks.upsertAuthProfileWithLock).not.toHaveBeenCalled();
       expect(mocks.updateConfig).not.toHaveBeenCalled();
       expect(mocks.logConfigUpdated).not.toHaveBeenCalled();
     } finally {
@@ -1139,7 +1142,7 @@ describe("modelsAuthLoginCommand", () => {
 
     await modelsAuthPasteTokenCommand({ provider: "anthropic" }, runtime);
 
-    expect(mocks.upsertAuthProfile).toHaveBeenCalledWith({
+    expect(mocks.upsertAuthProfileWithLock).toHaveBeenCalledWith({
       profileId: "anthropic:manual",
       credential: {
         type: "token",
@@ -1167,7 +1170,7 @@ describe("modelsAuthLoginCommand", () => {
     await modelsAuthPasteTokenCommand({ provider: "openai", agent: "coder" }, runtime);
 
     expect(mocks.resolveDefaultAgentId).not.toHaveBeenCalled();
-    expect(mocks.upsertAuthProfile).toHaveBeenCalledWith({
+    expect(mocks.upsertAuthProfileWithLock).toHaveBeenCalledWith({
       profileId: "openai:manual",
       credential: {
         type: "token",
@@ -1189,7 +1192,7 @@ describe("modelsAuthLoginCommand", () => {
     );
 
     expect(mocks.clackText).not.toHaveBeenCalled();
-    expect(mocks.upsertAuthProfile).not.toHaveBeenCalled();
+    expect(mocks.upsertAuthProfileWithLock).not.toHaveBeenCalled();
     expect(mocks.updateConfig).not.toHaveBeenCalled();
   });
 
@@ -1225,7 +1228,7 @@ describe("modelsAuthLoginCommand", () => {
     await modelsAuthSetupTokenCommand({ provider: "moonshot", yes: true }, runtime);
 
     expect(runTokenAuth).toHaveBeenCalledOnce();
-    expect(mocks.upsertAuthProfile).toHaveBeenCalledWith({
+    expect(mocks.upsertAuthProfileWithLock).toHaveBeenCalledWith({
       profileId: "moonshot:token",
       credential: {
         type: "token",
@@ -1272,9 +1275,9 @@ describe("modelsAuthLoginCommand", () => {
     const tokenAuthCall = readMockCallArg(runTokenAuth) as AuthRunCall;
     expect(tokenAuthCall.agentDir).toBe("/tmp/openclaw/agents/coder");
     expect(tokenAuthCall.workspaceDir).toBe("/tmp/openclaw/workspaces/coder");
-    expect((readMockCallArg(mocks.upsertAuthProfile) as UpsertAuthProfileCall).agentDir).toBe(
-      "/tmp/openclaw/agents/coder",
-    );
+    expect(
+      (readMockCallArg(mocks.upsertAuthProfileWithLock) as UpsertAuthProfileCall).agentDir,
+    ).toBe("/tmp/openclaw/agents/coder");
   });
 
   it("uses the requested agent store for interactive token auth add", async () => {
@@ -1314,9 +1317,9 @@ describe("modelsAuthLoginCommand", () => {
     const tokenAuthCall = readMockCallArg(runTokenAuth) as AuthRunCall;
     expect(tokenAuthCall.agentDir).toBe("/tmp/openclaw/agents/coder");
     expect(tokenAuthCall.workspaceDir).toBe("/tmp/openclaw/workspaces/coder");
-    expect((readMockCallArg(mocks.upsertAuthProfile) as UpsertAuthProfileCall).agentDir).toBe(
-      "/tmp/openclaw/agents/coder",
-    );
+    expect(
+      (readMockCallArg(mocks.upsertAuthProfileWithLock) as UpsertAuthProfileCall).agentDir,
+    ).toBe("/tmp/openclaw/agents/coder");
   });
 
   it("keeps the requested agent store when interactive auth add falls back to paste-token", async () => {
@@ -1333,7 +1336,7 @@ describe("modelsAuthLoginCommand", () => {
     await modelsAuthAddCommand({ agent: "coder" }, runtime);
 
     expect(mocks.resolveDefaultAgentId).not.toHaveBeenCalled();
-    expect(mocks.upsertAuthProfile).toHaveBeenCalledWith({
+    expect(mocks.upsertAuthProfileWithLock).toHaveBeenCalledWith({
       profileId: "openai:manual",
       credential: {
         type: "token",

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -14,7 +14,7 @@ import { externalCliDiscoveryForProviderAuth } from "../../agents/auth-profiles.
 import {
   listProfilesForProvider,
   promoteAuthProfileInOrder,
-  upsertAuthProfile,
+  upsertAuthProfileWithLock,
 } from "../../agents/auth-profiles/profiles.js";
 import { loadAuthProfileStoreForRuntime } from "../../agents/auth-profiles/store.js";
 import type { AuthProfileCredential } from "../../agents/auth-profiles/types.js";
@@ -56,6 +56,8 @@ import { validateAnthropicSetupToken } from "../auth-token.js";
 import { repairCodexRuntimePluginInstallForModelSelection } from "../codex-runtime-plugin-install.js";
 import { isRemoteEnvironment } from "../oauth-env.js";
 import { loadValidConfigOrThrow, resolveKnownAgentId, updateConfig } from "./shared.js";
+
+type UpsertAuthProfileParams = Parameters<typeof upsertAuthProfileWithLock>[0];
 
 function guardCancel<T>(value: T | symbol): T {
   if (typeof value === "symbol" || isCancel(value)) {
@@ -311,7 +313,7 @@ async function persistProviderAuthResult(params: {
     ? normalizeAgentModelRefForConfig(params.result.defaultModel)
     : undefined;
   for (const profile of params.result.profiles) {
-    upsertAuthProfile({
+    await upsertAuthProfileWithLockOrThrow({
       profileId: profile.profileId,
       credential: profile.credential,
       agentDir: params.agentDir,
@@ -525,7 +527,7 @@ export async function modelsAuthPasteTokenCommand(
       })
     : undefined;
 
-  upsertAuthProfile({
+  await upsertAuthProfileWithLockOrThrow({
     profileId,
     credential: {
       type: "token",
@@ -544,6 +546,15 @@ export async function modelsAuthPasteTokenCommand(
     runtime.log("Anthropic setup-token auth is supported in OpenClaw.");
     runtime.log("OpenClaw prefers Claude CLI reuse when it is available on the host.");
     runtime.log("Anthropic staff told us this OpenClaw path is allowed again.");
+  }
+}
+
+async function upsertAuthProfileWithLockOrThrow(params: UpsertAuthProfileParams): Promise<void> {
+  const updated = await upsertAuthProfileWithLock(params);
+  if (!updated) {
+    throw new Error(
+      "Failed to update auth profile store; the auth store lock may be busy. Wait a moment and retry.",
+    );
   }
 }
 

--- a/src/commands/onboard-auth.test.ts
+++ b/src/commands/onboard-auth.test.ts
@@ -33,36 +33,45 @@ vi.mock("../config/paths.js", () => ({
 vi.mock("../agents/auth-profiles/profiles.js", async () => {
   const fs = await import("node:fs");
   const path = await import("node:path");
-  return {
-    upsertAuthProfile: (params: { profileId: string; credential: unknown; agentDir?: string }) => {
-      const stateDir = process.env.OPENCLAW_STATE_DIR ?? "/tmp/openclaw-state";
-      const agentDir = params.agentDir ?? path.join(stateDir, "agents", "main", "agent");
-      const file = path.join(agentDir, "auth-profiles.json");
-      fs.mkdirSync(agentDir, { recursive: true });
-      const existing = (() => {
-        try {
-          return JSON.parse(fs.readFileSync(file, "utf8")) as {
-            version?: number;
-            profiles?: Record<string, unknown>;
-          };
-        } catch {
-          return { version: 1, profiles: {} };
-        }
-      })();
-      fs.writeFileSync(
-        file,
-        `${JSON.stringify(
-          {
-            version: existing.version ?? 1,
-            profiles: {
-              ...existing.profiles,
-              [params.profileId]: params.credential,
-            },
+  const upsert = (params: { profileId: string; credential: unknown; agentDir?: string }) => {
+    const stateDir = process.env.OPENCLAW_STATE_DIR ?? "/tmp/openclaw-state";
+    const agentDir = params.agentDir ?? path.join(stateDir, "agents", "main", "agent");
+    const file = path.join(agentDir, "auth-profiles.json");
+    fs.mkdirSync(agentDir, { recursive: true });
+    const existing = (() => {
+      try {
+        return JSON.parse(fs.readFileSync(file, "utf8")) as {
+          version?: number;
+          profiles?: Record<string, unknown>;
+        };
+      } catch {
+        return { version: 1, profiles: {} };
+      }
+    })();
+    fs.writeFileSync(
+      file,
+      `${JSON.stringify(
+        {
+          version: existing.version ?? 1,
+          profiles: {
+            ...existing.profiles,
+            [params.profileId]: params.credential,
           },
-          null,
-          2,
-        )}\n`,
-      );
+        },
+        null,
+        2,
+      )}\n`,
+    );
+  };
+  return {
+    upsertAuthProfile: upsert,
+    upsertAuthProfileWithLock: async (params: {
+      profileId: string;
+      credential: unknown;
+      agentDir?: string;
+    }) => {
+      upsert(params);
+      return { version: 1, profiles: {} };
     },
   };
 });

--- a/src/plugin-sdk/provider-auth-api-key.ts
+++ b/src/plugin-sdk/provider-auth-api-key.ts
@@ -3,7 +3,7 @@
 export type { OpenClawConfig } from "../config/config.js";
 export type { SecretInput } from "../config/types.secrets.js";
 
-export { upsertAuthProfile } from "../agents/auth-profiles/profiles.js";
+export { upsertAuthProfile, upsertAuthProfileWithLock } from "../agents/auth-profiles/profiles.js";
 export {
   formatApiKeyPreview,
   normalizeApiKeyInput,

--- a/src/plugins/provider-api-key-auth.ts
+++ b/src/plugins/provider-api-key-auth.ts
@@ -1,4 +1,4 @@
-import { upsertAuthProfile } from "../agents/auth-profiles/profiles.js";
+import { upsertAuthProfileWithLock } from "../agents/auth-profiles/profiles.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { SecretInput } from "../config/types.secrets.js";
 import { createLazyRuntimeSurface } from "../shared/lazy-runtime.js";
@@ -32,6 +32,8 @@ type ProviderApiKeyAuthMethodOptions = {
   applyConfig?: (cfg: OpenClawConfig) => OpenClawConfig;
 };
 
+type UpsertAuthProfileParams = Parameters<typeof upsertAuthProfileWithLock>[0];
+
 const loadProviderApiKeyAuthRuntime = createLazyRuntimeSurface(
   () => import("./provider-api-key-auth.runtime.js"),
   ({ providerApiKeyAuthRuntime }) => providerApiKeyAuthRuntime,
@@ -55,6 +57,15 @@ function resolveProfileIds(params: {
     return explicit;
   }
   return [resolveProfileId(params)];
+}
+
+async function upsertAuthProfileWithLockOrThrow(params: UpsertAuthProfileParams): Promise<void> {
+  const updated = await upsertAuthProfileWithLock(params);
+  if (!updated) {
+    throw new Error(
+      "Failed to update auth profile store; the auth store lock may be busy. Wait a moment and retry.",
+    );
+  }
 }
 
 async function applyApiKeyConfig(params: {
@@ -177,7 +188,7 @@ export function createProviderApiKeyAuthMethod(
           if (!credential) {
             return null;
           }
-          upsertAuthProfile({
+          await upsertAuthProfileWithLockOrThrow({
             profileId,
             credential,
             agentDir: ctx.agentDir,

--- a/src/plugins/provider-auth-choice.ts
+++ b/src/plugins/provider-auth-choice.ts
@@ -3,7 +3,7 @@ import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
 } from "../agents/agent-scope.js";
-import { upsertAuthProfile } from "../agents/auth-profiles.js";
+import { upsertAuthProfileWithLock } from "../agents/auth-profiles.js";
 import { formatLiteralProviderPrefixedModelRef } from "../agents/model-ref-shared.js";
 import { resolveDefaultAgentWorkspaceDir } from "../agents/workspace.js";
 import { normalizeAgentModelRefForConfig } from "../config/model-input.js";
@@ -28,6 +28,8 @@ import { resolveProviderInstallCatalogEntry } from "./provider-install-catalog.j
 import { createVpsAwareOAuthHandlers } from "./provider-oauth-flow.js";
 import { isRemoteEnvironment, openUrl } from "./setup-browser.js";
 import type { ProviderAuthMethod, ProviderAuthOptionBag, ProviderPlugin } from "./types.js";
+
+type UpsertAuthProfileParams = Parameters<typeof upsertAuthProfileWithLock>[0];
 
 export type ApplyProviderAuthChoiceParams = {
   authChoice: string;
@@ -289,7 +291,7 @@ export async function runProviderPluginAuthMethod(params: {
   }
 
   for (const profile of result.profiles) {
-    upsertAuthProfile({
+    await upsertAuthProfileWithLockOrThrow({
       profileId: profile.profileId,
       credential: profile.credential,
       agentDir,
@@ -587,4 +589,13 @@ export async function applyAuthChoicePluginProvider(
   }
 
   return { config: nextConfig };
+}
+
+async function upsertAuthProfileWithLockOrThrow(params: UpsertAuthProfileParams): Promise<void> {
+  const updated = await upsertAuthProfileWithLock(params);
+  if (!updated) {
+    throw new Error(
+      "Failed to update auth profile store; the auth store lock may be busy. Wait a moment and retry.",
+    );
+  }
 }

--- a/src/plugins/provider-auth-helpers.ts
+++ b/src/plugins/provider-auth-helpers.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import type { OAuthCredentials } from "@earendil-works/pi-ai";
 import { resolveDefaultAgentDir } from "../agents/agent-scope-config.js";
 import { buildAuthProfileId } from "../agents/auth-profiles/identity.js";
-import { upsertAuthProfile } from "../agents/auth-profiles/profiles.js";
+import { upsertAuthProfile, upsertAuthProfileWithLock } from "../agents/auth-profiles/profiles.js";
 import { resolveProviderIdForAuth } from "../agents/provider-auth-aliases.js";
 import { resolveStateDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -18,6 +18,7 @@ import { normalizeSecretInput } from "../utils/normalize-secret-input.js";
 import type { SecretInputMode } from "./provider-auth-types.js";
 
 const ENV_REF_PATTERN = /^\$\{([A-Z][A-Z0-9_]*)\}$/;
+type UpsertAuthProfileParams = Parameters<typeof upsertAuthProfileWithLock>[0];
 
 const resolveAuthAgentDir = (agentDir?: string, config?: OpenClawConfig) =>
   agentDir ?? resolveDefaultAgentDir(config ?? {});
@@ -131,6 +132,15 @@ export function upsertApiKeyProfile(params: {
     agentDir: resolveAuthAgentDir(params.agentDir, params.options?.config),
   });
   return profileId;
+}
+
+async function upsertAuthProfileWithLockOrThrow(params: UpsertAuthProfileParams): Promise<void> {
+  const updated = await upsertAuthProfileWithLock(params);
+  if (!updated) {
+    throw new Error(
+      "Failed to update auth profile store; the auth store lock may be busy. Wait a moment and retry.",
+    );
+  }
 }
 
 export function applyAuthProfileConfig(
@@ -291,7 +301,7 @@ export async function writeOAuthCredentials(
     ...(options?.displayName ? { displayName: options.displayName } : {}),
   };
 
-  upsertAuthProfile({
+  await upsertAuthProfileWithLockOrThrow({
     profileId,
     credential,
     agentDir: resolvedAgentDir,
@@ -305,7 +315,7 @@ export async function writeOAuthCredentials(
         continue;
       }
       try {
-        upsertAuthProfile({
+        await upsertAuthProfileWithLock({
           profileId,
           credential,
           agentDir: targetAgentDir,


### PR DESCRIPTION
## Summary

- Serialize CLI/configure/onboarding provider auth writes through the auth-profile file lock, matching the live gateway writer contract.
- Preserve old upsert semantics while doing that: token/API-key copy-paste normalization, local save options, SecretRef cleanup, and explicit failure when the lock/write fails.
- Widen the fix beyond the OpenAI Codex OAuth symptom to adjacent API-key/token setup writers that can run while a gateway is live.

## RCA

Live incident evidence, redacted:

- On OpenClaw 2026.5.16-beta.2, `openclaw models auth login --provider openai-codex` completed successfully and updated config metadata.
- The config file mtime changed during login, but the agent auth-profile store and credential secret file stayed at their old mtimes.
- The persisted agent profile still had an expired OpenAI Codex OAuth credential (`expires: 0`) after login.
- Gateway logs kept reporting `refresh_token_reused`, and Telegram `/status` still reported the model login as expired.

What broke:

- PR #53211, merged 2026-03-23 by @vincentkoc as merge commit `03231c0633874527ece3fda449643edfb3775fd3`, fixed the live gateway side of the stale-auth race by reloading under the auth-profile lock before runtime writes.
- CLI/configure/onboarding auth writers still used non-locking upsert paths. A running gateway could therefore keep writing from a stale in-memory auth snapshot while the CLI reported re-login success.
- Recent OpenAI/Codex routing changes made this old missing-lock path hit default users:
  - PR #78899, merged 2026-05-07 by @pashpashpash as merge commit `1c33990108155febc8edc572437f91e619517b27`, routed OpenAI agents through Codex by default.
  - PR #80790, merged 2026-05-11 by @pashpashpash as merge commit `3b44dfc367afc51eb3fb851dc773a354831c7192`, made OpenAI auth login use ChatGPT/Codex by default.
  - `626e07886383992a2b8edcde96306a53671a9972`, authored 2026-05-04 by Val Alexander, repaired Codex auth profile routing/order but did not serialize the profile write itself.

Who/how/when:

- This was an older missing lock, not a single beta-only bad line.
- @steipete authored the original non-locking CLI persist helper in `src/commands/models/auth.ts` on 2026-03-15 (`a33caab280f3`) and the OAuth helper write path in `src/plugins/provider-auth-helpers.ts` on 2026-03-16 (`6d6825ea182a`).
- @BunsDev touched the Codex relogin/order path on 2026-05-04 (`626e07886383992a2b8edcde96306a53671a9972`).
- @pashpashpash's May 7 and May 11 OpenAI/Codex default-routing PRs made the old missing-lock path hot for default OpenAI users.
- @vincentkoc's March 23 PR #53211 was related remediation, but incomplete for this incident: it protected live gateway writers, not CLI/configure/onboarding login writers.

## Fix

- `src/commands/models/auth.ts`: CLI provider login and paste-token now use locked upsert and fail loudly if persistence fails.
- `src/plugins/provider-auth-choice.ts`: configure/onboard provider auth now uses locked upsert.
- `src/plugins/provider-auth-helpers.ts`: OAuth credential writes and sibling-agent sync now use locked upsert.
- `src/plugins/provider-api-key-auth.ts`: generic non-interactive API-key setup now uses locked upsert.
- `extensions/github-copilot/login.ts`, `extensions/anthropic/register.runtime.ts`, `extensions/cloudflare-ai-gateway/index.ts`, `extensions/zai/index.ts`: bundled provider setup writes now use locked upsert where they write auth profiles directly.
- `src/agents/auth-profiles/profiles.ts` and `src/agents/auth-profiles/upsert-with-lock.ts`: locked upsert now normalizes token/API-key credentials like the old path and omits empty inline secrets when a SecretRef is used.
- `src/agents/auth-profiles/store.ts`: locked updates can pass save options through to persistence.
- `src/agents/auth-profiles/persisted.ts`: Vitest workers no longer trigger macOS Keychain prompts for OAuth profile master-key fallback.
- `src/plugin-sdk/provider-auth-api-key.ts`: exports the locked upsert for API-key provider plugin setup.
- `CHANGELOG.md`: adds the user-visible auth fix note.

## Verification

- `node scripts/run-vitest.mjs src/agents/auth-profiles/profiles.test.ts src/commands/models/auth.test.ts src/commands/onboard-auth.test.ts src/plugins/provider-auth-choice.test.ts extensions/github-copilot/index.test.ts extensions/cloudflare-ai-gateway/index.test.ts extensions/anthropic/index.test.ts extensions/zai/index.test.ts` passed: 9 files, 105 tests.
- `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --blacksmith-org openclaw --blacksmith-workflow .github/workflows/ci-check-testbox.yml --blacksmith-job check --blacksmith-ref main --idle-timeout 90m --ttl 240m --timing-json -- CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_TEST_PROJECTS_PARALLEL=6 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm check:changed` passed on Testbox-through-Crabbox `tbx_01krrcy2gx3bk4smmdjjx6gcsv` (`provider=blacksmith-testbox`, `sync=delegated`, exit 0).
- `git diff --check origin/main...HEAD` passed.
- `codex review --base origin/main` found valid issues in earlier patch revisions; accepted findings are fixed here. The final review runner was stopped because it recursively spawned nested review commands after the accepted fixes; final closeout used manual diff review plus the targeted and Testbox proof above.

## Real behavior proof

Behavior addressed: OpenAI Codex OAuth re-login can no longer report CLI success while a live gateway races the auth-profile store and keeps an expired/reused refresh-token snapshot.

Real environment tested: Live managed gateway on a remote Linux VPS reproduced the pre-fix failure with secrets and identity redacted. The post-fix code was validated with focused local tests and a Testbox-through-Crabbox changed gate that included core, extension, and plugin-SDK contract lanes.

Exact steps or command run after this patch: focused Vitest command and Testbox `pnpm check:changed` command listed in Verification.

Evidence after fix: CLI/configure/onboard OAuth/API-key/token auth writers now use locked auth-profile updates, preserve secret normalization, and throw on failed persistence instead of updating config/logging success.

Observed result after fix: Focused tests passed; Testbox-through-Crabbox changed gate passed with `lanes=core, coreTests, extensions, extensionTests, docs`.

What was not tested: I have not re-run live OpenAI Codex OAuth on the production VPS with real user credentials after this code change.
