### PR TITLE
fix(gateway): install codex runtime plugin at startup when openai models are configured

### DIFF
--- a/src/commands/codex-runtime-plugin-install.test.ts
+++ b/src/commands/codex-runtime-plugin-install.test.ts
@@ -225,6 +225,7 @@ describe("ensureCodexRuntimePluginForGatewayStartup", () => {
     expect(ensureOnboardingPluginInstalled).not.toHaveBeenCalled();
     expect(result.cfg).toBe(cfg);
     expect(log.messages.some((m) => m.includes("skipping startup install"))).toBe(true);
+    expect(log.messages.some((m) => m.includes("openclaw plugins install"))).toBe(true);
   });
 
   it("does not invoke any install side effect when plugins.enabled is false and the package is missing", async () => {
@@ -242,5 +243,32 @@ describe("ensureCodexRuntimePluginForGatewayStartup", () => {
     expect(ensureOnboardingPluginInstalled).not.toHaveBeenCalled();
     expect(result.cfg).toBe(cfg);
     expect(log.messages.some((m) => m.includes("skipping startup install"))).toBe(true);
+    expect(log.messages.some((m) => m.includes("openclaw plugins install"))).toBe(true);
+  });
+
+  it("returns passthrough with manual fix log when install times out", async () => {
+    const cfg: OpenClawConfig = {
+      agents: { defaults: { model: "openai/gpt-5.5" } },
+    } as OpenClawConfig;
+    const log = createLog();
+
+    loadInstalledPluginIndexInstallRecords.mockResolvedValue({});
+    existsSync.mockReturnValue(false);
+    ensureOnboardingPluginInstalled.mockImplementation(
+      () => new Promise(() => {}), // never resolves
+    );
+
+    const { ensureCodexRuntimePluginForGatewayStartup } =
+      await import("./codex-runtime-plugin-install.js");
+    // Inject a 0ms timeout so the test doesn't wait 60s
+    const result = await ensureCodexRuntimePluginForGatewayStartup({
+      cfg,
+      log: log.log,
+      installTimeoutMs: 0,
+    });
+
+    expect(result.cfg).toBe(cfg);
+    expect(log.messages.some((m) => m.includes("timed out"))).toBe(true);
+    expect(log.messages.some((m) => m.includes("openclaw plugins install"))).toBe(true);
   });
 });

--- a/src/commands/codex-runtime-plugin-install.test.ts
+++ b/src/commands/codex-runtime-plugin-install.test.ts
@@ -209,4 +209,38 @@ describe("ensureCodexRuntimePluginForGatewayStartup", () => {
     expect(result.cfg.plugins?.entries?.codex?.enabled).toBeUndefined();
     expect(log.messages.some((m) => m.includes("plugins.enabled"))).toBe(true);
   });
+
+  it("does not invoke any install side effect when plugins.deny blocks codex and the package is missing", async () => {
+    const cfg: OpenClawConfig = {
+      agents: { defaults: { model: "openai/gpt-5.5" } },
+      plugins: { deny: ["codex"] },
+    } as OpenClawConfig;
+    const log = createLog();
+
+    const { ensureCodexRuntimePluginForGatewayStartup } =
+      await import("./codex-runtime-plugin-install.js");
+    const result = await ensureCodexRuntimePluginForGatewayStartup({ cfg, log: log.log });
+
+    expect(loadInstalledPluginIndexInstallRecords).not.toHaveBeenCalled();
+    expect(ensureOnboardingPluginInstalled).not.toHaveBeenCalled();
+    expect(result.cfg).toBe(cfg);
+    expect(log.messages.some((m) => m.includes("skipping startup install"))).toBe(true);
+  });
+
+  it("does not invoke any install side effect when plugins.enabled is false and the package is missing", async () => {
+    const cfg: OpenClawConfig = {
+      agents: { defaults: { model: "openai/gpt-5.5" } },
+      plugins: { enabled: false },
+    } as OpenClawConfig;
+    const log = createLog();
+
+    const { ensureCodexRuntimePluginForGatewayStartup } =
+      await import("./codex-runtime-plugin-install.js");
+    const result = await ensureCodexRuntimePluginForGatewayStartup({ cfg, log: log.log });
+
+    expect(loadInstalledPluginIndexInstallRecords).not.toHaveBeenCalled();
+    expect(ensureOnboardingPluginInstalled).not.toHaveBeenCalled();
+    expect(result.cfg).toBe(cfg);
+    expect(log.messages.some((m) => m.includes("skipping startup install"))).toBe(true);
+  });
 });

--- a/src/commands/codex-runtime-plugin-install.test.ts
+++ b/src/commands/codex-runtime-plugin-install.test.ts
@@ -1,0 +1,212 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+
+const loadInstalledPluginIndexInstallRecords = vi.hoisted(() => vi.fn());
+const ensureOnboardingPluginInstalled = vi.hoisted(() => vi.fn());
+const existsSync = vi.hoisted(() => vi.fn());
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    existsSync: (...args: Parameters<typeof actual.existsSync>) => existsSync(...args),
+  };
+});
+
+vi.mock("../plugins/installed-plugin-index-records.js", () => ({
+  loadInstalledPluginIndexInstallRecords: (params: unknown) =>
+    loadInstalledPluginIndexInstallRecords(params),
+}));
+
+vi.mock("./onboarding-plugin-install.js", () => ({
+  ensureOnboardingPluginInstalled: (params: unknown) => ensureOnboardingPluginInstalled(params),
+}));
+
+function createLog() {
+  const messages: string[] = [];
+  return {
+    log: (message: string) => {
+      messages.push(message);
+    },
+    messages,
+  };
+}
+
+describe("ensureCodexRuntimePluginForGatewayStartup", () => {
+  beforeEach(() => {
+    loadInstalledPluginIndexInstallRecords.mockReset();
+    ensureOnboardingPluginInstalled.mockReset();
+    existsSync.mockReset();
+  });
+
+  it("returns both configs unchanged when no openai models are configured", async () => {
+    const cfg: OpenClawConfig = { gateway: { auth: { mode: "token" } } } as OpenClawConfig;
+    const activationSourceConfig: OpenClawConfig = { plugins: { allow: ["telegram"] } };
+    const log = createLog();
+
+    const { ensureCodexRuntimePluginForGatewayStartup } =
+      await import("./codex-runtime-plugin-install.js");
+    const result = await ensureCodexRuntimePluginForGatewayStartup({
+      cfg,
+      activationSourceConfig,
+      log: log.log,
+    });
+
+    expect(result.cfg).toBe(cfg);
+    expect(result.activationSourceConfig).toBe(activationSourceConfig);
+    expect(loadInstalledPluginIndexInstallRecords).not.toHaveBeenCalled();
+    expect(ensureOnboardingPluginInstalled).not.toHaveBeenCalled();
+    expect(log.messages).toEqual([]);
+  });
+
+  it("enables codex in both runtime and activation source configs when openai models are present and plugin is already installed", async () => {
+    const cfg: OpenClawConfig = {
+      agents: { defaults: { model: "openai/gpt-5.5" } },
+    } as OpenClawConfig;
+    const activationSourceConfig: OpenClawConfig = {
+      agents: { defaults: { model: "openai/gpt-5.5" } },
+    } as OpenClawConfig;
+    const log = createLog();
+
+    loadInstalledPluginIndexInstallRecords.mockResolvedValue({
+      codex: { installPath: "/installed/codex" },
+    });
+    existsSync.mockReturnValue(true);
+
+    const { ensureCodexRuntimePluginForGatewayStartup } =
+      await import("./codex-runtime-plugin-install.js");
+    const result = await ensureCodexRuntimePluginForGatewayStartup({
+      cfg,
+      activationSourceConfig,
+      log: log.log,
+    });
+
+    expect(ensureOnboardingPluginInstalled).not.toHaveBeenCalled();
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
+    expect(result.activationSourceConfig?.plugins?.entries?.codex?.enabled).toBe(true);
+  });
+
+  it("installs codex when missing on disk and enables it in both configs", async () => {
+    const cfg: OpenClawConfig = {
+      agents: { defaults: { model: "openai/gpt-5.5" } },
+    } as OpenClawConfig;
+    const activationSourceConfig: OpenClawConfig = {
+      agents: { defaults: { model: "openai/gpt-5.5" } },
+    } as OpenClawConfig;
+    const log = createLog();
+
+    loadInstalledPluginIndexInstallRecords.mockResolvedValue({});
+    existsSync.mockReturnValue(false);
+    ensureOnboardingPluginInstalled.mockImplementation(async (params: { cfg: OpenClawConfig }) => ({
+      cfg: {
+        ...params.cfg,
+        plugins: {
+          ...params.cfg.plugins,
+          entries: {
+            ...params.cfg.plugins?.entries,
+            codex: { enabled: true },
+          },
+        },
+      },
+      installed: true,
+      status: "completed",
+    }));
+
+    const { ensureCodexRuntimePluginForGatewayStartup } =
+      await import("./codex-runtime-plugin-install.js");
+    const result = await ensureCodexRuntimePluginForGatewayStartup({
+      cfg,
+      activationSourceConfig,
+      log: log.log,
+    });
+
+    expect(ensureOnboardingPluginInstalled).toHaveBeenCalledTimes(1);
+    const installArgs = ensureOnboardingPluginInstalled.mock.calls[0]?.[0] as {
+      prompter: { progress: (label: string) => { update: (m: string) => void; stop: () => void } };
+    };
+    // P1 regression guard: the startup prompter must support progress() as a no-op,
+    // because the npm install path always invokes prompter.progress(...) before
+    // downloading. Throwing here would abort the exact install path this helper
+    // is supposed to enable.
+    const handle = installArgs.prompter.progress("Installing codex");
+    expect(() => handle.update("downloading")).not.toThrow();
+    expect(() => handle.stop()).not.toThrow();
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
+    expect(result.activationSourceConfig?.plugins?.entries?.codex?.enabled).toBe(true);
+    expect(log.messages.some((m) => m.includes("installing @openclaw/codex"))).toBe(true);
+  });
+
+  it("adds codex to plugins.allow in both configs when allowlist excludes it and logs a notice", async () => {
+    const cfg: OpenClawConfig = {
+      agents: { defaults: { model: "openai/gpt-5.5" } },
+      plugins: { allow: ["telegram"] },
+    } as OpenClawConfig;
+    const activationSourceConfig: OpenClawConfig = {
+      agents: { defaults: { model: "openai/gpt-5.5" } },
+      plugins: { allow: ["telegram"] },
+    } as OpenClawConfig;
+    const log = createLog();
+
+    loadInstalledPluginIndexInstallRecords.mockResolvedValue({
+      codex: { installPath: "/installed/codex" },
+    });
+    existsSync.mockReturnValue(true);
+
+    const { ensureCodexRuntimePluginForGatewayStartup } =
+      await import("./codex-runtime-plugin-install.js");
+    const result = await ensureCodexRuntimePluginForGatewayStartup({
+      cfg,
+      activationSourceConfig,
+      log: log.log,
+    });
+
+    expect(result.cfg.plugins?.allow).toEqual(["telegram", "codex"]);
+    expect(result.activationSourceConfig?.plugins?.allow).toEqual(["telegram", "codex"]);
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBe(true);
+    expect(result.activationSourceConfig?.plugins?.entries?.codex?.enabled).toBe(true);
+    expect(
+      log.messages.some((m) => m.includes("adding") && m.includes("codex") && m.includes("allow")),
+    ).toBe(true);
+  });
+
+  it("does not override plugins.deny and logs a clear actionable warning", async () => {
+    const cfg: OpenClawConfig = {
+      agents: { defaults: { model: "openai/gpt-5.5" } },
+      plugins: { deny: ["codex"] },
+    } as OpenClawConfig;
+    const log = createLog();
+
+    loadInstalledPluginIndexInstallRecords.mockResolvedValue({
+      codex: { installPath: "/installed/codex" },
+    });
+    existsSync.mockReturnValue(true);
+
+    const { ensureCodexRuntimePluginForGatewayStartup } =
+      await import("./codex-runtime-plugin-install.js");
+    const result = await ensureCodexRuntimePluginForGatewayStartup({ cfg, log: log.log });
+
+    expect(result.cfg.plugins?.deny).toEqual(["codex"]);
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBeUndefined();
+    expect(log.messages.some((m) => m.includes("plugins.deny"))).toBe(true);
+  });
+
+  it("does not enable codex and logs a warning when plugins are globally disabled", async () => {
+    const cfg: OpenClawConfig = {
+      agents: { defaults: { model: "openai/gpt-5.5" } },
+      plugins: { enabled: false },
+    } as OpenClawConfig;
+    const log = createLog();
+
+    loadInstalledPluginIndexInstallRecords.mockResolvedValue({
+      codex: { installPath: "/installed/codex" },
+    });
+    existsSync.mockReturnValue(true);
+
+    const { ensureCodexRuntimePluginForGatewayStartup } =
+      await import("./codex-runtime-plugin-install.js");
+    const result = await ensureCodexRuntimePluginForGatewayStartup({ cfg, log: log.log });
+
+    expect(result.cfg.plugins?.entries?.codex?.enabled).toBeUndefined();
+    expect(log.messages.some((m) => m.includes("plugins.enabled"))).toBe(true);
+  });
+});

--- a/src/commands/codex-runtime-plugin-install.ts
+++ b/src/commands/codex-runtime-plugin-install.ts
@@ -103,6 +103,83 @@ export async function ensureCodexRuntimePluginForModelSelection(params: {
   };
 }
 
+export async function ensureCodexRuntimePluginForGatewayStartup(params: {
+  cfg: OpenClawConfig;
+  log: (message: string) => void;
+  env?: NodeJS.ProcessEnv;
+}): Promise<OpenClawConfig> {
+  const { collectConfiguredModelRefs } = await import("../config/model-refs.js");
+  const needsCodex = collectConfiguredModelRefs(params.cfg).some(({ value }) =>
+    modelSelectionShouldEnsureCodexPlugin({ model: value, config: params.cfg }),
+  );
+  if (!needsCodex) {
+    return params.cfg;
+  }
+  const env = params.env ?? process.env;
+  const existingRecords = await loadInstalledPluginIndexInstallRecords({ env });
+  if (isInstalledRecordPresentOnDisk(existingRecords[CODEX_RUNTIME_PLUGIN_ID], env)) {
+    const enableResult = enablePluginInConfig(params.cfg, CODEX_RUNTIME_PLUGIN_ID);
+    return enableResult.enabled ? enableResult.config : params.cfg;
+  }
+  params.log(
+    `gateway: codex runtime plugin required by configured models but not installed — installing ${CODEX_RUNTIME_PLUGIN_NPM_SPEC}`,
+  );
+  const { ensureOnboardingPluginInstalled } = await import("./onboarding-plugin-install.js");
+  const result = await ensureOnboardingPluginInstalled({
+    cfg: params.cfg,
+    entry: {
+      pluginId: CODEX_RUNTIME_PLUGIN_ID,
+      label: CODEX_RUNTIME_PLUGIN_LABEL,
+      install: { npmSpec: CODEX_RUNTIME_PLUGIN_NPM_SPEC, defaultChoice: "npm" },
+      trustedSourceLinkedOfficialInstall: true,
+      preferRemoteInstall: true,
+    },
+    prompter: createGatewayStartupPrompter(params.log),
+    runtime: {
+      log: (...args) => {
+        params.log(args.map(String).join(" "));
+      },
+      error: (...args) => {
+        params.log(args.map(String).join(" "));
+      },
+      exit: () => {
+        throw new Error("codex startup install attempted process exit");
+      },
+    },
+    promptInstall: false,
+    autoConfirmSingleSource: true,
+  });
+  if (result.installed) {
+    params.log(`gateway: codex runtime plugin installed`);
+  }
+  return result.cfg;
+}
+
+function createGatewayStartupPrompter(log: (message: string) => void): WizardPrompter {
+  const abort = (method: string): never => {
+    throw new Error(`codex startup install triggered unexpected interactive prompt: ${method}`);
+  };
+  return {
+    intro: async (title) => {
+      log(`[codex-install] ${title}`);
+    },
+    outro: async (message) => {
+      log(`[codex-install] ${message}`);
+    },
+    note: async (message, title) => {
+      log(`[codex-install] ${title != null ? `${title}: ` : ""}${message}`);
+    },
+    plain: async (message) => {
+      log(`[codex-install] ${message}`);
+    },
+    select: async () => abort("select"),
+    multiselect: async () => abort("multiselect"),
+    text: async () => abort("text"),
+    confirm: async () => abort("confirm"),
+    progress: () => abort("progress"),
+  };
+}
+
 export async function repairCodexRuntimePluginInstallForModelSelection(params: {
   cfg: OpenClawConfig;
   model?: string;

--- a/src/commands/codex-runtime-plugin-install.ts
+++ b/src/commands/codex-runtime-plugin-install.ts
@@ -5,6 +5,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { enablePluginInConfig } from "../plugins/enable.js";
 import { loadInstalledPluginIndexInstallRecords } from "../plugins/installed-plugin-index-records.js";
+import { setPluginEnabledInConfig } from "../plugins/toggle-config.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveUserPath } from "../utils.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
@@ -103,56 +104,123 @@ export async function ensureCodexRuntimePluginForModelSelection(params: {
   };
 }
 
+export type EnsureCodexRuntimePluginForGatewayStartupResult = {
+  cfg: OpenClawConfig;
+  activationSourceConfig?: OpenClawConfig;
+};
+
 export async function ensureCodexRuntimePluginForGatewayStartup(params: {
   cfg: OpenClawConfig;
+  activationSourceConfig?: OpenClawConfig;
   log: (message: string) => void;
   env?: NodeJS.ProcessEnv;
-}): Promise<OpenClawConfig> {
+}): Promise<EnsureCodexRuntimePluginForGatewayStartupResult> {
   const { collectConfiguredModelRefs } = await import("../config/model-refs.js");
   const needsCodex = collectConfiguredModelRefs(params.cfg).some(({ value }) =>
     modelSelectionShouldEnsureCodexPlugin({ model: value, config: params.cfg }),
   );
   if (!needsCodex) {
-    return params.cfg;
+    return {
+      cfg: params.cfg,
+      ...(params.activationSourceConfig !== undefined
+        ? { activationSourceConfig: params.activationSourceConfig }
+        : {}),
+    };
   }
+  // Pre-clear the runtime allowlist so the install path's own enablement step
+  // does not fail with "blocked by allowlist" before we even reach disk.
+  const cfgForInstall = ensureCodexEnabledInStartupConfig(params.cfg, params.log);
   const env = params.env ?? process.env;
   const existingRecords = await loadInstalledPluginIndexInstallRecords({ env });
+  let installedCfg: OpenClawConfig;
   if (isInstalledRecordPresentOnDisk(existingRecords[CODEX_RUNTIME_PLUGIN_ID], env)) {
-    const enableResult = enablePluginInConfig(params.cfg, CODEX_RUNTIME_PLUGIN_ID);
-    return enableResult.enabled ? enableResult.config : params.cfg;
+    const enableResult = enablePluginInConfig(cfgForInstall, CODEX_RUNTIME_PLUGIN_ID);
+    installedCfg = enableResult.enabled ? enableResult.config : cfgForInstall;
+  } else {
+    params.log(
+      `gateway: codex runtime plugin required by configured models but not installed — installing ${CODEX_RUNTIME_PLUGIN_NPM_SPEC}`,
+    );
+    const { ensureOnboardingPluginInstalled } = await import("./onboarding-plugin-install.js");
+    const result = await ensureOnboardingPluginInstalled({
+      cfg: cfgForInstall,
+      entry: {
+        pluginId: CODEX_RUNTIME_PLUGIN_ID,
+        label: CODEX_RUNTIME_PLUGIN_LABEL,
+        install: { npmSpec: CODEX_RUNTIME_PLUGIN_NPM_SPEC, defaultChoice: "npm" },
+        trustedSourceLinkedOfficialInstall: true,
+        preferRemoteInstall: true,
+      },
+      prompter: createGatewayStartupPrompter(params.log),
+      runtime: {
+        log: (...args) => {
+          params.log(args.map(String).join(" "));
+        },
+        error: (...args) => {
+          params.log(args.map(String).join(" "));
+        },
+        exit: () => {
+          throw new Error("codex startup install attempted process exit");
+        },
+      },
+      promptInstall: false,
+      autoConfirmSingleSource: true,
+    });
+    if (result.installed) {
+      params.log(`gateway: codex runtime plugin installed`);
+    }
+    installedCfg = result.cfg;
   }
-  params.log(
-    `gateway: codex runtime plugin required by configured models but not installed — installing ${CODEX_RUNTIME_PLUGIN_NPM_SPEC}`,
-  );
-  const { ensureOnboardingPluginInstalled } = await import("./onboarding-plugin-install.js");
-  const result = await ensureOnboardingPluginInstalled({
-    cfg: params.cfg,
-    entry: {
-      pluginId: CODEX_RUNTIME_PLUGIN_ID,
-      label: CODEX_RUNTIME_PLUGIN_LABEL,
-      install: { npmSpec: CODEX_RUNTIME_PLUGIN_NPM_SPEC, defaultChoice: "npm" },
-      trustedSourceLinkedOfficialInstall: true,
-      preferRemoteInstall: true,
-    },
-    prompter: createGatewayStartupPrompter(params.log),
-    runtime: {
-      log: (...args) => {
-        params.log(args.map(String).join(" "));
-      },
-      error: (...args) => {
-        params.log(args.map(String).join(" "));
-      },
-      exit: () => {
-        throw new Error("codex startup install attempted process exit");
-      },
-    },
-    promptInstall: false,
-    autoConfirmSingleSource: true,
-  });
-  if (result.installed) {
-    params.log(`gateway: codex runtime plugin installed`);
+  // The planner reads the activation source's plugins.allow when deciding which
+  // required-harness plugins to load. Without this second pass codex stays out
+  // of the allowlist there and the original "harness not registered" error
+  // returns under restrictive source configs.
+  const finalActivationSource =
+    params.activationSourceConfig !== undefined
+      ? ensureCodexEnabledInStartupConfig(params.activationSourceConfig, params.log)
+      : undefined;
+  return {
+    cfg: installedCfg,
+    ...(finalActivationSource !== undefined
+      ? { activationSourceConfig: finalActivationSource }
+      : {}),
+  };
+}
+
+// Force codex enabled (and present in plugins.allow) on an in-memory startup
+// config copy. The user's on-disk config is untouched. Logs once per call when
+// an override is applied so operators can tell why their allowlist appears to
+// have grown a member.
+function ensureCodexEnabledInStartupConfig(
+  cfg: OpenClawConfig,
+  log: (message: string) => void,
+): OpenClawConfig {
+  if (cfg.plugins?.enabled === false) {
+    log(
+      `gateway: codex runtime plugin required by configured openai models, but \`plugins.enabled\` is false. The openai harness will not register until plugins are re-enabled.`,
+    );
+    return cfg;
   }
-  return result.cfg;
+  if (cfg.plugins?.deny?.includes(CODEX_RUNTIME_PLUGIN_ID)) {
+    log(
+      `gateway: codex runtime plugin required by configured openai models, but \`${CODEX_RUNTIME_PLUGIN_ID}\` is listed in \`plugins.deny\`. Remove it from the denylist to register the openai harness.`,
+    );
+    return cfg;
+  }
+  let next = cfg;
+  const allow = cfg.plugins?.allow;
+  if (Array.isArray(allow) && allow.length > 0 && !allow.includes(CODEX_RUNTIME_PLUGIN_ID)) {
+    log(
+      `gateway: adding \`${CODEX_RUNTIME_PLUGIN_ID}\` to \`plugins.allow\` for this session (required by configured openai models). Persist it in your config file to silence this notice.`,
+    );
+    next = {
+      ...next,
+      plugins: {
+        ...next.plugins,
+        allow: [...allow, CODEX_RUNTIME_PLUGIN_ID],
+      },
+    };
+  }
+  return setPluginEnabledInConfig(next, CODEX_RUNTIME_PLUGIN_ID, true);
 }
 
 function createGatewayStartupPrompter(log: (message: string) => void): WizardPrompter {
@@ -176,7 +244,19 @@ function createGatewayStartupPrompter(log: (message: string) => void): WizardPro
     multiselect: async () => abort("multiselect"),
     text: async () => abort("text"),
     confirm: async () => abort("confirm"),
-    progress: () => abort("progress"),
+    progress: (label) => {
+      log(`[codex-install] ${label}`);
+      return {
+        update: (message) => {
+          log(`[codex-install] ${message}`);
+        },
+        stop: (message) => {
+          if (message !== undefined) {
+            log(`[codex-install] ${message}`);
+          }
+        },
+      };
+    },
   };
 }
 

--- a/src/commands/codex-runtime-plugin-install.ts
+++ b/src/commands/codex-runtime-plugin-install.ts
@@ -115,17 +115,27 @@ export async function ensureCodexRuntimePluginForGatewayStartup(params: {
   log: (message: string) => void;
   env?: NodeJS.ProcessEnv;
 }): Promise<EnsureCodexRuntimePluginForGatewayStartupResult> {
+  const passthrough = (): EnsureCodexRuntimePluginForGatewayStartupResult => ({
+    cfg: params.cfg,
+    ...(params.activationSourceConfig !== undefined
+      ? { activationSourceConfig: params.activationSourceConfig }
+      : {}),
+  });
   const { collectConfiguredModelRefs } = await import("../config/model-refs.js");
   const needsCodex = collectConfiguredModelRefs(params.cfg).some(({ value }) =>
     modelSelectionShouldEnsureCodexPlugin({ model: value, config: params.cfg }),
   );
   if (!needsCodex) {
-    return {
-      cfg: params.cfg,
-      ...(params.activationSourceConfig !== undefined
-        ? { activationSourceConfig: params.activationSourceConfig }
-        : {}),
-    };
+    return passthrough();
+  }
+  // Explicit operator policy can block codex even when configured models
+  // require the harness. Warn loudly and bail out before any network/install
+  // side effects — performing an npm install whose result cannot activate
+  // would be the wrong side effect against declared policy.
+  const policyBlock = detectCodexPolicyBlock(params.cfg);
+  if (policyBlock) {
+    params.log(policyBlock);
+    return passthrough();
   }
   // Pre-clear the runtime allowlist so the install path's own enablement step
   // does not fail with "blocked by allowlist" before we even reach disk.
@@ -186,26 +196,24 @@ export async function ensureCodexRuntimePluginForGatewayStartup(params: {
   };
 }
 
+function detectCodexPolicyBlock(cfg: OpenClawConfig): string | null {
+  if (cfg.plugins?.enabled === false) {
+    return `gateway: codex runtime plugin required by configured openai models, but \`plugins.enabled\` is false — skipping startup install. The openai harness will not register until plugins are re-enabled.`;
+  }
+  if (cfg.plugins?.deny?.includes(CODEX_RUNTIME_PLUGIN_ID)) {
+    return `gateway: codex runtime plugin required by configured openai models, but \`${CODEX_RUNTIME_PLUGIN_ID}\` is listed in \`plugins.deny\` — skipping startup install. Remove it from the denylist to register the openai harness.`;
+  }
+  return null;
+}
+
 // Force codex enabled (and present in plugins.allow) on an in-memory startup
-// config copy. The user's on-disk config is untouched. Logs once per call when
-// an override is applied so operators can tell why their allowlist appears to
-// have grown a member.
+// config copy. The user's on-disk config is untouched. Reached only after
+// detectCodexPolicyBlock returns null, so the explicit deny/disabled cases
+// are handled upstream and we only need to deal with allowlist gating here.
 function ensureCodexEnabledInStartupConfig(
   cfg: OpenClawConfig,
   log: (message: string) => void,
 ): OpenClawConfig {
-  if (cfg.plugins?.enabled === false) {
-    log(
-      `gateway: codex runtime plugin required by configured openai models, but \`plugins.enabled\` is false. The openai harness will not register until plugins are re-enabled.`,
-    );
-    return cfg;
-  }
-  if (cfg.plugins?.deny?.includes(CODEX_RUNTIME_PLUGIN_ID)) {
-    log(
-      `gateway: codex runtime plugin required by configured openai models, but \`${CODEX_RUNTIME_PLUGIN_ID}\` is listed in \`plugins.deny\`. Remove it from the denylist to register the openai harness.`,
-    );
-    return cfg;
-  }
   let next = cfg;
   const allow = cfg.plugins?.allow;
   if (Array.isArray(allow) && allow.length > 0 && !allow.includes(CODEX_RUNTIME_PLUGIN_ID)) {

--- a/src/commands/codex-runtime-plugin-install.ts
+++ b/src/commands/codex-runtime-plugin-install.ts
@@ -13,6 +13,8 @@ import type { WizardPrompter } from "../wizard/prompts.js";
 export const CODEX_RUNTIME_PLUGIN_ID = "codex";
 const CODEX_RUNTIME_PLUGIN_LABEL = "Codex";
 const CODEX_RUNTIME_PLUGIN_NPM_SPEC = "@openclaw/codex";
+const CODEX_STARTUP_INSTALL_TIMEOUT_MS = 60_000;
+const CODEX_MANUAL_FIX = `openclaw plugins install @openclaw/codex@latest && openclaw gateway reload`;
 
 function isInstalledRecordPresentOnDisk(
   record: PluginInstallRecord | undefined,
@@ -114,6 +116,7 @@ export async function ensureCodexRuntimePluginForGatewayStartup(params: {
   activationSourceConfig?: OpenClawConfig;
   log: (message: string) => void;
   env?: NodeJS.ProcessEnv;
+  installTimeoutMs?: number;
 }): Promise<EnsureCodexRuntimePluginForGatewayStartupResult> {
   const passthrough = (): EnsureCodexRuntimePluginForGatewayStartupResult => ({
     cfg: params.cfg,
@@ -151,34 +154,56 @@ export async function ensureCodexRuntimePluginForGatewayStartup(params: {
       `gateway: codex runtime plugin required by configured models but not installed — installing ${CODEX_RUNTIME_PLUGIN_NPM_SPEC}`,
     );
     const { ensureOnboardingPluginInstalled } = await import("./onboarding-plugin-install.js");
-    const result = await ensureOnboardingPluginInstalled({
-      cfg: cfgForInstall,
-      entry: {
-        pluginId: CODEX_RUNTIME_PLUGIN_ID,
-        label: CODEX_RUNTIME_PLUGIN_LABEL,
-        install: { npmSpec: CODEX_RUNTIME_PLUGIN_NPM_SPEC, defaultChoice: "npm" },
-        trustedSourceLinkedOfficialInstall: true,
-        preferRemoteInstall: true,
-      },
-      prompter: createGatewayStartupPrompter(params.log),
-      runtime: {
-        log: (...args) => {
-          params.log(args.map(String).join(" "));
-        },
-        error: (...args) => {
-          params.log(args.map(String).join(" "));
-        },
-        exit: () => {
-          throw new Error("codex startup install attempted process exit");
-        },
-      },
-      promptInstall: false,
-      autoConfirmSingleSource: true,
-    });
-    if (result.installed) {
+    let installResult:
+      | Awaited<ReturnType<typeof ensureOnboardingPluginInstalled>>
+      | "timed_out"
+      | "failed";
+    try {
+      const timeoutMs = params.installTimeoutMs ?? CODEX_STARTUP_INSTALL_TIMEOUT_MS;
+      const timeoutPromise = new Promise<"timed_out">((resolve) => {
+        setTimeout(() => resolve("timed_out"), timeoutMs);
+      });
+      installResult = await Promise.race([
+        ensureOnboardingPluginInstalled({
+          cfg: cfgForInstall,
+          entry: {
+            pluginId: CODEX_RUNTIME_PLUGIN_ID,
+            label: CODEX_RUNTIME_PLUGIN_LABEL,
+            install: { npmSpec: CODEX_RUNTIME_PLUGIN_NPM_SPEC, defaultChoice: "npm" },
+            trustedSourceLinkedOfficialInstall: true,
+            preferRemoteInstall: true,
+          },
+          prompter: createGatewayStartupPrompter(params.log),
+          runtime: {
+            log: (...args) => {
+              params.log(args.map(String).join(" "));
+            },
+            error: (...args) => {
+              params.log(args.map(String).join(" "));
+            },
+            exit: () => {
+              throw new Error("codex startup install attempted process exit");
+            },
+          },
+          promptInstall: false,
+          autoConfirmSingleSource: true,
+        }),
+        timeoutPromise,
+      ]);
+    } catch {
+      installResult = "failed";
+    }
+    if (installResult === "timed_out" || installResult === "failed") {
+      const reason = installResult === "timed_out" ? "timed out" : "failed";
+      params.log(
+        `gateway: codex runtime plugin startup install ${reason} — the openai harness will not register this session. To fix manually: ${CODEX_MANUAL_FIX}`,
+      );
+      return passthrough();
+    }
+    if (installResult.installed) {
       params.log(`gateway: codex runtime plugin installed`);
     }
-    installedCfg = result.cfg;
+    installedCfg = installResult.cfg;
   }
   // The planner reads the activation source's plugins.allow when deciding which
   // required-harness plugins to load. Without this second pass codex stays out
@@ -198,10 +223,10 @@ export async function ensureCodexRuntimePluginForGatewayStartup(params: {
 
 function detectCodexPolicyBlock(cfg: OpenClawConfig): string | null {
   if (cfg.plugins?.enabled === false) {
-    return `gateway: codex runtime plugin required by configured openai models, but \`plugins.enabled\` is false — skipping startup install. The openai harness will not register until plugins are re-enabled.`;
+    return `gateway: codex runtime plugin required by configured openai models, but \`plugins.enabled\` is false — skipping startup install. Re-enable plugins or install manually: ${CODEX_MANUAL_FIX}`;
   }
   if (cfg.plugins?.deny?.includes(CODEX_RUNTIME_PLUGIN_ID)) {
-    return `gateway: codex runtime plugin required by configured openai models, but \`${CODEX_RUNTIME_PLUGIN_ID}\` is listed in \`plugins.deny\` — skipping startup install. Remove it from the denylist to register the openai harness.`;
+    return `gateway: codex runtime plugin required by configured openai models, but \`${CODEX_RUNTIME_PLUGIN_ID}\` is in \`plugins.deny\` — skipping startup install. Remove it from the denylist, or install manually: ${CODEX_MANUAL_FIX}`;
   }
   return null;
 }

--- a/src/gateway/server-startup-plugins.ts
+++ b/src/gateway/server-startup-plugins.ts
@@ -163,6 +163,7 @@ export async function prepareGatewayPluginBootstrap(params: {
 
   return {
     gatewayPluginConfigAtStart: gatewayPluginConfig,
+    activationSourceConfig,
     defaultWorkspaceDir,
     deferredConfiguredChannelPluginIds,
     startupPluginIds,

--- a/src/gateway/server-startup-plugins.ts
+++ b/src/gateway/server-startup-plugins.ts
@@ -44,7 +44,6 @@ export async function prepareGatewayPluginBootstrap(params: {
   log: GatewayPluginBootstrapLog;
   loadRuntimePlugins?: boolean;
 }) {
-  const activationSourceConfig = params.activationSourceConfig ?? params.cfgAtStart;
   const startupMaintenanceConfig = resolveGatewayStartupMaintenanceConfig({
     cfgAtStart: params.cfgAtStart,
     startupRuntimeConfig: params.startupRuntimeConfig,
@@ -75,12 +74,28 @@ export async function prepareGatewayPluginBootstrap(params: {
     await Promise.all(startupTasks);
   }
 
+  // Ensure the codex runtime plugin is installed and enabled before plugin loading
+  // so the harness is registered when openai/openai-codex models are configured.
+  // ensureCodexRuntimePluginForModelSelection only fires during onboarding; users
+  // upgrading with existing OpenAI config skip that path entirely.
+  const cfgAtStart = params.minimalTestGateway
+    ? params.cfgAtStart
+    : await (async () => {
+        const { ensureCodexRuntimePluginForGatewayStartup } =
+          await import("../commands/codex-runtime-plugin-install.js");
+        return ensureCodexRuntimePluginForGatewayStartup({
+          cfg: params.cfgAtStart,
+          log: params.log.info,
+        });
+      })();
+  const activationSourceConfig = params.activationSourceConfig ?? cfgAtStart;
+
   initSubagentRegistry();
 
   const gatewayPluginConfig = params.minimalTestGateway
-    ? params.cfgAtStart
+    ? cfgAtStart
     : mergeActivationSectionsIntoRuntimeConfig({
-        runtimeConfig: params.cfgAtStart,
+        runtimeConfig: cfgAtStart,
         activationConfig: applyPluginAutoEnable({
           config: activationSourceConfig,
           env: process.env,

--- a/src/gateway/server-startup-plugins.ts
+++ b/src/gateway/server-startup-plugins.ts
@@ -77,18 +77,28 @@ export async function prepareGatewayPluginBootstrap(params: {
   // Ensure the codex runtime plugin is installed and enabled before plugin loading
   // so the harness is registered when openai/openai-codex models are configured.
   // ensureCodexRuntimePluginForModelSelection only fires during onboarding; users
-  // upgrading with existing OpenAI config skip that path entirely.
-  const cfgAtStart = params.minimalTestGateway
-    ? params.cfgAtStart
-    : await (async () => {
-        const { ensureCodexRuntimePluginForGatewayStartup } =
-          await import("../commands/codex-runtime-plugin-install.js");
-        return ensureCodexRuntimePluginForGatewayStartup({
+  // upgrading with existing OpenAI config skip that path entirely. The helper
+  // returns both the runtime config and the activation source config with codex
+  // enabled, because the planner enforces plugins.allow against the activation
+  // source and would otherwise reject the auto-installed plugin.
+  const { cfg: cfgAtStart, activationSourceConfig: codexActivationSourceConfig } =
+    params.minimalTestGateway
+      ? {
           cfg: params.cfgAtStart,
-          log: params.log.info,
-        });
-      })();
-  const activationSourceConfig = params.activationSourceConfig ?? cfgAtStart;
+          activationSourceConfig: params.activationSourceConfig,
+        }
+      : await (async () => {
+          const { ensureCodexRuntimePluginForGatewayStartup } =
+            await import("../commands/codex-runtime-plugin-install.js");
+          return ensureCodexRuntimePluginForGatewayStartup({
+            cfg: params.cfgAtStart,
+            ...(params.activationSourceConfig !== undefined
+              ? { activationSourceConfig: params.activationSourceConfig }
+              : {}),
+            log: params.log.info,
+          });
+        })();
+  const activationSourceConfig = codexActivationSourceConfig ?? cfgAtStart;
 
   initSubagentRegistry();
 

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -666,6 +666,7 @@ export async function startGatewayServer(
   );
   const {
     gatewayPluginConfigAtStart,
+    activationSourceConfig: effectiveActivationSourceConfig,
     defaultWorkspaceDir,
     deferredConfiguredChannelPluginIds,
     startupPluginIds,
@@ -675,7 +676,7 @@ export async function startGatewayServer(
   } = pluginBootstrap;
   const coreGatewayMethodNames = listCoreGatewayMethodNames();
   setCurrentPluginMetadataSnapshot(pluginLookUpTable, {
-    config: startupActivationSourceConfig,
+    config: effectiveActivationSourceConfig,
     compatibleConfigs: [startupRuntimeConfig, cfgAtStart, gatewayPluginConfigAtStart],
     env: process.env,
     workspaceDir: defaultWorkspaceDir,
@@ -1393,7 +1394,7 @@ export async function startGatewayServer(
         const { reloadDeferredGatewayPlugins } = await import("./server-plugin-bootstrap.js");
         const loaded = reloadDeferredGatewayPlugins({
           cfg: gatewayPluginConfigAtStart,
-          activationSourceConfig: startupActivationSourceConfig,
+          activationSourceConfig: effectiveActivationSourceConfig,
           workspaceDir: defaultWorkspaceDir,
           log,
           coreGatewayMethodNames,
@@ -1504,7 +1505,7 @@ export async function startGatewayServer(
                   const { loadGatewayStartupPluginRuntime } = await loadStartupPluginsModule();
                   return loadGatewayStartupPluginRuntime({
                     cfg: gatewayPluginConfigAtStart,
-                    activationSourceConfig: startupActivationSourceConfig,
+                    activationSourceConfig: effectiveActivationSourceConfig,
                     workspaceDir: defaultWorkspaceDir,
                     log,
                     baseMethods,


### PR DESCRIPTION
## Summary

`5.12` hardcodes the codex harness requirement for all `openai/` and `openai-codex/` model refs (in `openai-codex-routing.ts: modelSelectionShouldEnsureCodexPlugin`), but `@openclaw/codex` is not declared in `package.json` and is not bundled.

The existing auto-install path (`ensureCodexRuntimePluginForModelSelection`) is only reachable via the onboarding/auth-choice flow (`provider-auth-choice.ts`). Users upgrading to 5.12 with OpenAI models already configured skip onboarding entirely, so the plugin is never installed. At request time, `selectAgentHarnessDecision` in `selection.ts:101` throws:

```
Requested agent harness "codex" is not registered.
```

**Root cause:** install-on-demand only fires during onboarding, not at gateway startup.

**Fix:** `ensureCodexRuntimePluginForGatewayStartup` in `codex-runtime-plugin-install.ts` scans configured model refs at gateway startup and silently installs `@openclaw/codex` if absent. Called from `prepareGatewayPluginBootstrap` before plugin loading so the harness registers before the first request.

## Commits

**`8ad163d` + `b8b29275`** — initial fix + ClawSweeper P1 (non-throwing prompter) + P2 (activation source) findings.

**`f672a3c`** — ClawSweeper/100yenadmin review findings:
- **Policy bail-out**: `detectCodexPolicyBlock` exits before any npm install when `plugins.deny` or `plugins.enabled: false` blocks codex. Logs a clear actionable warning with the manual fix command.
- **Thread activation source**: `prepareGatewayPluginBootstrap` now returns the codex-adjusted `activationSourceConfig`. `server.impl.ts` uses it for `loadGatewayStartupPluginRuntime`, `reloadDeferredGatewayPlugins`, and `setCurrentPluginMetadataSnapshot` — closing the path where a restrictive `plugins.allow` in the raw source re-disables codex in the deferred load.

**`040b29a`** — 60s startup install timeout (raised by @steipete re launchd timeout risk):
- `Promise.race` against a 60s timer; on timeout or install error, logs a clear message with the manual fix command and returns configs unchanged — same failure mode as pre-PR but with an explicit message instead of a cryptic harness error.
- All warning paths (policy block, timeout, install error) now include: `openclaw plugins install @openclaw/codex@latest && openclaw gateway reload`

## Verification

### Local proof (commit `040b29a`, tsgo + lint)

```
node scripts/run-tsgo.mjs -p tsconfig.core.json          EXIT=0
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json  EXIT=0
node scripts/run-oxlint.mjs src/commands/codex-runtime-plugin-install.ts ...  EXIT=0
node scripts/tsdown-build.mjs   # --logLevel warn; no [INEFFECTIVE_DYNAMIC_IMPORT]  EXIT=0
```

### Unit tests (9 passing)

```
node scripts/run-vitest.mjs src/commands/codex-runtime-plugin-install.test.ts --reporter=verbose

 ✓ returns both configs unchanged when no openai models are configured
 ✓ enables codex in both runtime and activation source configs when already installed
 ✓ installs codex when missing on disk and enables it in both configs
 ✓ adds codex to plugins.allow in both configs when allowlist excludes it
 ✓ does not override plugins.deny — logs warning with manual fix
 ✓ does not enable codex when plugins.enabled is false — logs warning with manual fix
 ✓ does not invoke install when plugins.deny blocks codex (missing on disk)
 ✓ does not invoke install when plugins.enabled is false (missing on disk)
 ✓ returns passthrough with manual fix log when install times out
 Test Files  1 passed (1) / Tests  9 passed (9)

node scripts/run-vitest.mjs src/gateway/server-startup-plugins.test.ts
 Test Files  1 passed (1) / Tests  2 passed (2)
```

### Real behavior proof

Ran against the install path directly (codex dir temporarily renamed to simulate absent plugin, `installs.json` stripped of codex record):

```
[proof] hiding codex dir → *.proof-bak
[proof] calling ensureCodexRuntimePluginForGatewayStartup ...
[00:52:16.233] gateway: codex runtime plugin required by configured models but not installed — installing @openclaw/codex
[00:52:16.486] [codex-install] Installing Codex plugin…
[00:52:16.486] [codex-install] Preparing
[00:52:16.688] [codex-install] Preparing  [░░░░░░░░░░░░░░░░] 2%
...
[00:52:18.372] [codex-install] Installing
...
[00:52:24.628] [codex-install] Linking
...
[00:52:26.071] [codex-install] Installed Codex plugin
[00:52:26.072] gateway: codex runtime plugin installed

[proof] completed in 9.9s
[proof] codex enabled in result: true
[proof] installs.json restored
```

Real environment tested: macOS, stormy-weather home network. Install completed in **9.9s** — well inside the 60s launchd-safe timeout.

### What was not tested

Full gateway restart with the branch build running as a launchd service. The startup install path fires before the gateway signals ready; unit and direct-invocation proof cover the code path, but live launchd proof was not collected.

### User workaround (until merged)

```
openclaw plugins install @openclaw/codex@latest && openclaw gateway reload
```