### PR TITLE
Discord ambient room events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 - QQBot: treat only explicit truthy `QQBOT_DEBUG` values as enabling debug logs, so false-like values such as `0` no longer expose debug output. Fixes #82644. (#82697) Thanks @leno23.
 - Agents/session_status: resolve implicit no-arg status lookups against the live run session, so `/think` changes report the current thinking level instead of stale sandbox state. Fixes #82669. (#82696) Thanks @leno23.
 - Discord: keep progress drafts visible for message-tool-only guild replies under the default coding tool profile. Fixes #82747. Thanks @eliranwong.
+- Discord: keep unmentioned room-event history until a visible Discord send succeeds, so quiet ambient context does not disappear before message-tool delivery. (#82573) Thanks @obviyus.
 - CLI/setup: order the model/auth provider picker as OpenAI, Anthropic, xAI, Google, then the remaining providers alphabetically.
 - Diagnostics/usage/voice-call: treat explicit zero and non-finite limits as empty results and reject invalid voice-call numeric CLI flags. Fixes #82646, #82650, #82651, and #82653. (#82679) Thanks @leno23.
 - CLI/config: avoid redundant startup config/plugin checks for the guided `openclaw config` flow and show progress while source checkout CLI artifacts build or load.

--- a/extensions/discord/src/actions/handle-action.test.ts
+++ b/extensions/discord/src/actions/handle-action.test.ts
@@ -6,6 +6,8 @@ const handleDiscordActionMock = vi
   .spyOn(runtimeModule, "handleDiscordAction")
   .mockResolvedValue({ content: [], details: { ok: true } });
 const { handleDiscordMessageAction } = await import("./handle-action.js");
+const { beginDiscordInboundEventDeliveryCorrelation } =
+  await import("../inbound-event-delivery.js");
 
 function discordConfig(actions?: Record<string, boolean>): OpenClawConfig {
   return {
@@ -199,6 +201,68 @@ describe("handleDiscordMessageAction", () => {
       cfg,
       options: defaultActionOptions(),
     });
+  });
+
+  it("notifies inbound event delivery after message sends", async () => {
+    const markDelivered = vi.fn();
+    const end = beginDiscordInboundEventDeliveryCorrelation(
+      "agent:main:discord:channel:c1",
+      {
+        outboundTo: "channel:c1",
+        outboundAccountId: "default",
+        markInboundEventDelivered: markDelivered,
+      },
+      { inboundEventKind: "room_event" },
+    );
+
+    try {
+      await handleDiscordMessageAction({
+        action: "send",
+        params: {
+          to: "channel:c1",
+          message: "hello",
+        },
+        cfg: discordConfig(),
+        accountId: "default",
+        sessionKey: "agent:main:discord:channel:c1",
+        inboundEventKind: "room_event",
+      });
+    } finally {
+      end();
+    }
+
+    expect(markDelivered).toHaveBeenCalledTimes(1);
+  });
+
+  it("notifies inbound event delivery after visible message actions", async () => {
+    const markDelivered = vi.fn();
+    const end = beginDiscordInboundEventDeliveryCorrelation(
+      "agent:main:discord:channel:c1",
+      {
+        outboundTo: "channel:c1",
+        outboundAccountId: "default",
+        markInboundEventDelivered: markDelivered,
+      },
+      { inboundEventKind: "room_event" },
+    );
+
+    try {
+      await handleDiscordMessageAction({
+        action: "upload-file",
+        params: {
+          to: "channel:c1",
+          filePath: "/tmp/image.png",
+        },
+        cfg: discordConfig(),
+        accountId: "default",
+        sessionKey: "agent:main:discord:channel:c1",
+        inboundEventKind: "room_event",
+      });
+    } finally {
+      end();
+    }
+
+    expect(markDelivered).toHaveBeenCalledTimes(1);
   });
 
   it("maps upload-file to Discord sendMessage with media read context", async () => {

--- a/extensions/discord/src/actions/handle-action.ts
+++ b/extensions/discord/src/actions/handle-action.ts
@@ -13,6 +13,7 @@ import {
 } from "openclaw/plugin-sdk/interactive-runtime";
 import { normalizeOptionalStringifiedId } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { handleDiscordAction } from "../../action-runtime-api.js";
+import { notifyDiscordInboundEventOutboundSuccess } from "../inbound-event-delivery.js";
 import {
   buildDiscordInteractiveComponents,
   buildDiscordPresentationComponents,
@@ -45,6 +46,8 @@ export async function handleDiscordMessageAction(
     | "mediaAccess"
     | "mediaLocalRoots"
     | "mediaReadFile"
+    | "sessionKey"
+    | "inboundEventKind"
   >,
 ): Promise<AgentToolResult<unknown>> {
   const { action, params, cfg } = ctx;
@@ -54,6 +57,13 @@ export async function handleDiscordMessageAction(
     mediaLocalRoots: ctx.mediaLocalRoots,
     mediaReadFile: ctx.mediaReadFile,
   } as const;
+  const notifyVisibleOutbound = (to: string, fallbackSessionKey?: string) =>
+    notifyDiscordInboundEventOutboundSuccess({
+      sessionKey: ctx.sessionKey ?? fallbackSessionKey ?? undefined,
+      to,
+      accountId,
+      inboundEventKind: ctx.inboundEventKind,
+    });
 
   const readTarget = () => {
     const target =
@@ -106,7 +116,7 @@ export async function handleDiscordMessageAction(
     const sessionKey = readStringParam(params, "__sessionKey");
     const agentId = readStringParam(params, "__agentId");
     const threadName = readStringParam(params, "threadName");
-    return await handleDiscordAction(
+    const result = await handleDiscordAction(
       {
         action: "sendMessage",
         accountId: accountId ?? undefined,
@@ -127,6 +137,8 @@ export async function handleDiscordMessageAction(
       cfg,
       actionOptions,
     );
+    notifyVisibleOutbound(to, sessionKey);
+    return result;
   }
 
   if (action === "upload-file") {
@@ -147,7 +159,7 @@ export async function handleDiscordMessageAction(
     const suppressEmbeds = readBooleanParam(params, "suppressEmbeds");
     const sessionKey = readStringParam(params, "__sessionKey");
     const agentId = readStringParam(params, "__agentId");
-    return await handleDiscordAction(
+    const result = await handleDiscordAction(
       {
         action: "sendMessage",
         accountId: accountId ?? undefined,
@@ -164,6 +176,8 @@ export async function handleDiscordMessageAction(
       cfg,
       actionOptions,
     );
+    notifyVisibleOutbound(to, sessionKey);
+    return result;
   }
 
   if (action === "poll") {
@@ -177,7 +191,7 @@ export async function handleDiscordMessageAction(
       integer: true,
       strict: true,
     });
-    return await handleDiscordAction(
+    const result = await handleDiscordAction(
       {
         action: "poll",
         accountId: accountId ?? undefined,
@@ -191,6 +205,8 @@ export async function handleDiscordMessageAction(
       cfg,
       actionOptions,
     );
+    notifyVisibleOutbound(to);
+    return result;
   }
 
   if (action === "react") {
@@ -315,7 +331,7 @@ export async function handleDiscordMessageAction(
       integer: true,
     });
     const appliedTags = readStringArrayParam(params, "appliedTags");
-    return await handleDiscordAction(
+    const result = await handleDiscordAction(
       {
         action: "threadCreate",
         accountId: accountId ?? undefined,
@@ -329,25 +345,30 @@ export async function handleDiscordMessageAction(
       cfg,
       actionOptions,
     );
+    notifyVisibleOutbound(resolveChannelId());
+    return result;
   }
 
   if (action === "sticker") {
+    const to = readStringParam(params, "to", { required: true });
     const stickerIds =
       readStringArrayParam(params, "stickerId", {
         required: true,
         label: "sticker-id",
       }) ?? [];
-    return await handleDiscordAction(
+    const result = await handleDiscordAction(
       {
         action: "sticker",
         accountId: accountId ?? undefined,
-        to: readStringParam(params, "to", { required: true }),
+        to,
         stickerIds,
         content: readStringParam(params, "message"),
       },
       cfg,
       actionOptions,
     );
+    notifyVisibleOutbound(to);
+    return result;
   }
 
   if (action === "set-presence") {
@@ -371,6 +392,9 @@ export async function handleDiscordMessageAction(
     resolveChannelId,
   });
   if (adminResult !== undefined) {
+    if (action === "thread-reply") {
+      notifyVisibleOutbound(readStringParam(params, "threadId") ?? readTarget());
+    }
     return adminResult;
   }
 

--- a/extensions/discord/src/channel-actions.test.ts
+++ b/extensions/discord/src/channel-actions.test.ts
@@ -414,6 +414,33 @@ describe("discordMessageActions", () => {
     });
   });
 
+  it("prepares inbound event delivery metadata for durable core sends", async () => {
+    const prepared = await discordMessageActions.prepareSendPayload?.({
+      ctx: {
+        channel: "discord",
+        action: "send",
+        cfg: {} as OpenClawConfig,
+        params: {},
+        sessionKey: "agent:main:discord:channel:c1",
+        inboundEventKind: "room_event",
+      },
+      to: "channel:123",
+      payload: { text: "hello" },
+    });
+
+    expect(prepared).toEqual({
+      text: "hello",
+      channelData: {
+        discord: {
+          __openclawInboundEventDelivery: {
+            sessionKey: "agent:main:discord:channel:c1",
+            inboundEventKind: "room_event",
+          },
+        },
+      },
+    });
+  });
+
   it("keeps non-serializable Discord component sends on the legacy action path", async () => {
     const prepared = await discordMessageActions.prepareSendPayload?.({
       ctx: {

--- a/extensions/discord/src/channel-actions.ts
+++ b/extensions/discord/src/channel-actions.ts
@@ -10,6 +10,7 @@ import { extractToolSend } from "openclaw/plugin-sdk/tool-send";
 import { inspectDiscordAccount } from "./account-inspect.js";
 import { createDiscordActionGate, listDiscordAccountIds } from "./accounts.js";
 import { readDiscordComponentSpec } from "./components.js";
+import { withDiscordInboundEventDeliveryMetadata } from "./inbound-event-delivery.js";
 
 let discordChannelActionsRuntimePromise:
   | Promise<typeof import("./channel-actions.runtime.js")>
@@ -180,6 +181,10 @@ export const discordMessageActions: ChannelMessageActionAdapter = {
     if (ctx.action !== "send") {
       return null;
     }
+    const payloadWithDeliveryMetadata = withDiscordInboundEventDeliveryMetadata(payload, {
+      sessionKey: ctx.sessionKey,
+      inboundEventKind: ctx.inboundEventKind,
+    });
     const rawComponents = ctx.params.components;
     if (typeof rawComponents === "function") {
       return null;
@@ -195,18 +200,18 @@ export const discordMessageActions: ChannelMessageActionAdapter = {
     }
     const filename = normalizeOptionalString(ctx.params.filename);
     if (!componentSpec && !nativeComponents && !embeds?.length && !filename) {
-      return payload;
+      return payloadWithDeliveryMetadata;
     }
     const discordData =
-      payload.channelData?.discord &&
-      typeof payload.channelData.discord === "object" &&
-      !Array.isArray(payload.channelData.discord)
-        ? (payload.channelData.discord as Record<string, unknown>)
+      payloadWithDeliveryMetadata.channelData?.discord &&
+      typeof payloadWithDeliveryMetadata.channelData.discord === "object" &&
+      !Array.isArray(payloadWithDeliveryMetadata.channelData.discord)
+        ? (payloadWithDeliveryMetadata.channelData.discord as Record<string, unknown>)
         : {};
     return {
-      ...payload,
+      ...payloadWithDeliveryMetadata,
       channelData: {
-        ...payload.channelData,
+        ...payloadWithDeliveryMetadata.channelData,
         discord: {
           ...discordData,
           ...(componentSpec ? { components: componentSpec } : {}),
@@ -227,6 +232,8 @@ export const discordMessageActions: ChannelMessageActionAdapter = {
     mediaAccess,
     mediaLocalRoots,
     mediaReadFile,
+    sessionKey,
+    inboundEventKind,
   }) => {
     return await (
       await loadDiscordChannelActionsRuntime()
@@ -240,6 +247,8 @@ export const discordMessageActions: ChannelMessageActionAdapter = {
       mediaAccess,
       mediaLocalRoots,
       mediaReadFile,
+      ...(sessionKey ? { sessionKey } : {}),
+      ...(inboundEventKind ? { inboundEventKind } : {}),
     });
   },
 };

--- a/extensions/discord/src/inbound-event-delivery.ts
+++ b/extensions/discord/src/inbound-event-delivery.ts
@@ -1,0 +1,135 @@
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-payload";
+
+export type DiscordInboundEventDeliveryEnd = () => void;
+
+type ActiveEvent = {
+  outboundTo: string;
+  outboundAccountId?: string;
+  markInboundEventDelivered: () => void;
+};
+
+const DISCORD_INBOUND_EVENT_DELIVERY_KEY = "__openclawInboundEventDelivery";
+const registry = new Map<string, ActiveEvent>();
+
+function normalizeDiscordDeliveryTarget(value: string): string {
+  return value
+    .trim()
+    .replace(/^discord:/iu, "")
+    .replace(/^channel:/iu, "")
+    .toLowerCase();
+}
+
+function resolveDiscordInboundEventDeliveryCorrelationKey(
+  sessionKey: string | undefined,
+  inboundEventKind?: string,
+): string | undefined {
+  const key = sessionKey?.trim();
+  if (!key) {
+    return undefined;
+  }
+  return inboundEventKind === "room_event" ? `${key}:room_event` : key;
+}
+
+export function beginDiscordInboundEventDeliveryCorrelation(
+  sessionKey: string | undefined,
+  event: ActiveEvent,
+  options?: { inboundEventKind?: string },
+): DiscordInboundEventDeliveryEnd {
+  const key = resolveDiscordInboundEventDeliveryCorrelationKey(
+    sessionKey,
+    options?.inboundEventKind,
+  );
+  if (!key) {
+    return () => {};
+  }
+  registry.set(key, event);
+  return () => {
+    if (registry.get(key) === event) {
+      registry.delete(key);
+    }
+  };
+}
+
+export function notifyDiscordInboundEventOutboundSuccess(params: {
+  sessionKey: string | undefined;
+  to: string;
+  accountId?: string | null;
+  inboundEventKind?: string;
+}): void {
+  const key = resolveDiscordInboundEventDeliveryCorrelationKey(
+    params.sessionKey,
+    params.inboundEventKind,
+  );
+  if (!key) {
+    return;
+  }
+  const event = registry.get(key);
+  if (
+    !event ||
+    normalizeDiscordDeliveryTarget(event.outboundTo) !== normalizeDiscordDeliveryTarget(params.to)
+  ) {
+    return;
+  }
+  if (event.outboundAccountId && params.accountId && params.accountId !== event.outboundAccountId) {
+    return;
+  }
+  registry.delete(key);
+  event.markInboundEventDelivered();
+}
+
+function readRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export function withDiscordInboundEventDeliveryMetadata(
+  payload: ReplyPayload,
+  params: {
+    sessionKey?: string | null;
+    inboundEventKind?: string;
+  },
+): ReplyPayload {
+  const sessionKey = params.sessionKey?.trim();
+  if (!sessionKey || params.inboundEventKind !== "room_event") {
+    return payload;
+  }
+  const channelData = readRecord(payload.channelData) ?? {};
+  const discordData = readRecord(channelData.discord) ?? {};
+  return {
+    ...payload,
+    channelData: {
+      ...channelData,
+      discord: {
+        ...discordData,
+        [DISCORD_INBOUND_EVENT_DELIVERY_KEY]: {
+          sessionKey,
+          inboundEventKind: params.inboundEventKind,
+        },
+      },
+    },
+  };
+}
+
+export function notifyDiscordInboundEventOutboundPayloadSuccess(params: {
+  payload: ReplyPayload;
+  to: string;
+  accountId?: string | null;
+}): void {
+  const channelData = readRecord(params.payload.channelData);
+  const discordData = readRecord(channelData?.discord);
+  const metadata = readRecord(discordData?.[DISCORD_INBOUND_EVENT_DELIVERY_KEY]);
+  if (!metadata) {
+    return;
+  }
+  notifyDiscordInboundEventOutboundSuccess({
+    sessionKey: readString(metadata.sessionKey),
+    inboundEventKind: readString(metadata.inboundEventKind),
+    to: params.to,
+    accountId: params.accountId,
+  });
+}

--- a/extensions/discord/src/monitor/message-handler.context.ts
+++ b/extensions/discord/src/monitor/message-handler.context.ts
@@ -2,6 +2,7 @@ import {
   buildChannelInboundEventContext,
   formatInboundEnvelope,
   resolveEnvelopeFormatOptions,
+  toHistoryMediaEntries,
   toInboundMediaFacts,
 } from "openclaw/plugin-sdk/channel-inbound";
 import { resolveChannelContextVisibilityMode } from "openclaw/plugin-sdk/context-visibility-runtime";
@@ -151,6 +152,7 @@ export async function buildDiscordMessageProcessContext(params: {
     sessionKey: route.sessionKey,
   });
   const channelHistory = createChannelHistoryWindow({ historyMap: guildHistories });
+  const isRoomEvent = ctx.inboundEventKind === "room_event";
   let combinedBody = formatInboundEnvelope({
     channel: "Discord",
     from: fromLabel,
@@ -162,7 +164,8 @@ export async function buildDiscordMessageProcessContext(params: {
     envelope: envelopeOptions,
   });
   const shouldIncludeChannelHistory =
-    !isDirectMessage && !(isGuildMessage && channelConfig?.autoThread && !threadChannel);
+    !isDirectMessage &&
+    (isRoomEvent || !(isGuildMessage && channelConfig?.autoThread && !threadChannel));
   if (shouldIncludeChannelHistory) {
     combinedBody = channelHistory.buildPendingContext({
       historyKey: messageChannelId,
@@ -277,7 +280,7 @@ export async function buildDiscordMessageProcessContext(params: {
     message,
     messageChannelId,
     isGuildMessage,
-    channelConfig,
+    channelConfig: isRoomEvent ? null : channelConfig,
     threadChannel,
     channelType: channelInfo?.type,
     channelName: channelInfo?.name,
@@ -424,6 +427,20 @@ export async function buildDiscordMessageProcessContext(params: {
     },
   });
   const persistedSessionKey = ctxPayload.SessionKey ?? route.sessionKey;
+  if (isRoomEvent && shouldIncludeChannelHistory) {
+    await channelHistory.recordWithMedia({
+      historyKey: messageChannelId,
+      limit: historyLimit,
+      entry: {
+        sender: senderName,
+        body: text,
+        timestamp: resolveTimestampMs(message.timestamp),
+        messageId: message.id,
+      },
+      media: toHistoryMediaEntries(mediaList, { messageId: message.id }),
+      messageId: message.id,
+    });
+  }
 
   if (shouldLogVerbose()) {
     const preview = truncateUtf16Safe(combinedBody, 200).replace(/\n/g, "\\n");

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -141,6 +141,8 @@ type DispatchInboundParams = {
     sourceReplyDeliveryMode?: "automatic" | "message_tool_only";
     disableBlockStreaming?: boolean;
     suppressDefaultToolProgressMessages?: boolean;
+    queuedDeliveryCorrelations?: Array<{ begin: () => () => void }>;
+    suppressTyping?: boolean;
     onCompactionStart?: () => Promise<void> | void;
     onCompactionEnd?: () => Promise<void> | void;
     onPartialReply?: (payload: { text?: string }) => Promise<void> | void;
@@ -189,6 +191,7 @@ let createDiscordDirectMessageContextOverrides: typeof import("./message-handler
 let threadBindingTesting: typeof import("./thread-bindings.js").__testing;
 let createThreadBindingManager: typeof import("./thread-bindings.js").createThreadBindingManager;
 let processDiscordMessage: typeof import("./message-handler.process.js").processDiscordMessage;
+let notifyDiscordInboundEventOutboundSuccess: typeof import("../inbound-event-delivery.js").notifyDiscordInboundEventOutboundSuccess;
 
 vi.mock("openclaw/plugin-sdk/reply-runtime", () => ({
   dispatchInboundMessage: (params: DispatchInboundParams) => dispatchInboundMessage(params),
@@ -342,6 +345,7 @@ beforeAll(async () => {
   ({ __testing: threadBindingTesting, createThreadBindingManager } =
     await import("./thread-bindings.js"));
   ({ processDiscordMessage } = await import("./message-handler.process.js"));
+  ({ notifyDiscordInboundEventOutboundSuccess } = await import("../inbound-event-delivery.js"));
 });
 
 beforeEach(() => {
@@ -1326,6 +1330,115 @@ describe("processDiscordMessage session routing", () => {
     expect(getLastDispatchReplyOptions()?.sourceReplyDeliveryMode).toBe("message_tool_only");
     expect(getReactionEmojis()).toEqual([]);
     expect(sendMocks.removeReactionDiscord).not.toHaveBeenCalled();
+  });
+
+  it("records Discord room events in history while source replies are tool-only", async () => {
+    const guildHistories = new Map();
+    const ctx = await createBaseContext({
+      guildHistories,
+      historyLimit: 10,
+      shouldRequireMention: false,
+      effectiveWasMentioned: false,
+      inboundEventKind: "room_event",
+      baseSessionKey: BASE_CHANNEL_ROUTE.sessionKey,
+      route: BASE_CHANNEL_ROUTE,
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expect(getLastDispatchReplyOptions()?.sourceReplyDeliveryMode).toBe("message_tool_only");
+    expect(getLastDispatchReplyOptions()?.suppressTyping).toBe(true);
+    expect(getLastDispatchReplyOptions()?.queuedDeliveryCorrelations).toHaveLength(1);
+    expect(guildHistories.get("c1")).toMatchObject([
+      {
+        body: "hi",
+        messageId: "m1",
+        sender: "Alice",
+      },
+    ]);
+  });
+
+  it("clears Discord room event history after a visible action send succeeds", async () => {
+    const guildHistories = new Map();
+    dispatchInboundMessage.mockImplementationOnce(async () => {
+      notifyDiscordInboundEventOutboundSuccess({
+        sessionKey: BASE_CHANNEL_ROUTE.sessionKey,
+        inboundEventKind: "room_event",
+        to: "channel:c1",
+        accountId: "default",
+      });
+      return createNoQueuedDispatchResult();
+    });
+    const ctx = await createBaseContext({
+      guildHistories,
+      historyLimit: 10,
+      shouldRequireMention: false,
+      effectiveWasMentioned: false,
+      inboundEventKind: "room_event",
+      baseSessionKey: BASE_CHANNEL_ROUTE.sessionKey,
+      route: BASE_CHANNEL_ROUTE,
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expect(guildHistories.get("c1")).toEqual([]);
+  });
+
+  it("clears Discord group DM room event history after a visible action send succeeds", async () => {
+    const guildHistories = new Map();
+    dispatchInboundMessage.mockImplementationOnce(async () => {
+      notifyDiscordInboundEventOutboundSuccess({
+        sessionKey: BASE_CHANNEL_ROUTE.sessionKey,
+        inboundEventKind: "room_event",
+        to: "channel:c1",
+        accountId: "default",
+      });
+      return createNoQueuedDispatchResult();
+    });
+    const ctx = await createBaseContext({
+      guildHistories,
+      historyLimit: 10,
+      isGuildMessage: false,
+      isGroupDm: true,
+      isDirectMessage: false,
+      shouldRequireMention: false,
+      effectiveWasMentioned: false,
+      inboundEventKind: "room_event",
+      baseSessionKey: BASE_CHANNEL_ROUTE.sessionKey,
+      route: BASE_CHANNEL_ROUTE,
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expect(guildHistories.get("c1")).toEqual([]);
+  });
+
+  it("clears Discord room event history after a queued core send succeeds", async () => {
+    const guildHistories = new Map();
+    const ctx = await createBaseContext({
+      guildHistories,
+      historyLimit: 10,
+      shouldRequireMention: false,
+      effectiveWasMentioned: false,
+      inboundEventKind: "room_event",
+      baseSessionKey: BASE_CHANNEL_ROUTE.sessionKey,
+      route: BASE_CHANNEL_ROUTE,
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    const begin = getLastDispatchReplyOptions()?.queuedDeliveryCorrelations?.[0]?.begin;
+    expect(begin).toBeTypeOf("function");
+    const end = begin?.();
+    notifyDiscordInboundEventOutboundSuccess({
+      sessionKey: BASE_CHANNEL_ROUTE.sessionKey,
+      inboundEventKind: "room_event",
+      to: "channel:c1",
+      accountId: "default",
+    });
+    end?.();
+
+    expect(guildHistories.get("c1")).toEqual([]);
   });
 
   it("uses PluralKit original ids for inbound dedupe while preserving the Discord message id", async () => {

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -32,10 +32,12 @@ import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-run
 import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";
 import { resolveChunkMode } from "openclaw/plugin-sdk/reply-chunking";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-dispatch-runtime";
+import { createChannelHistoryWindow } from "openclaw/plugin-sdk/reply-history";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { danger, logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolveDiscordMaxLinesPerMessage } from "../accounts.js";
 import { createDiscordRestClient } from "../client.js";
+import { beginDiscordInboundEventDeliveryCorrelation } from "../inbound-event-delivery.js";
 import { removeReactionDiscord } from "../send.js";
 import { editMessageDiscord } from "../send.messages.js";
 import { resolveDiscordTargetChannelId } from "../send.shared.js";
@@ -423,6 +425,28 @@ export async function processDiscordMessage(
     accountId,
   });
   const chunkMode = resolveChunkMode(cfg, "discord", accountId);
+  const clearGroupHistory = () => {
+    if (isDirectMessage) {
+      return;
+    }
+    createChannelHistoryWindow({ historyMap: guildHistories }).clear({
+      historyKey: messageChannelId,
+      limit: historyLimit,
+    });
+  };
+  const beginDeliveryCorrelation = () =>
+    isRoomEvent
+      ? beginDiscordInboundEventDeliveryCorrelation(
+          ctxPayload.SessionKey,
+          {
+            outboundTo: messageChannelId,
+            outboundAccountId: route.accountId,
+            markInboundEventDelivered: clearGroupHistory,
+          },
+          { inboundEventKind: ctxPayload.InboundEventKind },
+        )
+      : () => {};
+  const endDiscordInboundEventDeliveryCorrelation = beginDeliveryCorrelation();
 
   const deliverChannelId = deliverTarget.startsWith("channel:")
     ? deliverTarget.slice("channel:".length)
@@ -651,12 +675,14 @@ export async function processDiscordMessage(
       ctxPayload,
       recordInboundSession,
       record: turn.record,
-      history: {
-        isGroup: isGuildMessage,
-        historyKey: messageChannelId,
-        historyMap: guildHistories,
-        limit: historyLimit,
-      },
+      history: isRoomEvent
+        ? undefined
+        : {
+            isGroup: isGuildMessage,
+            historyKey: messageChannelId,
+            historyMap: guildHistories,
+            limit: historyLimit,
+          },
       onPreDispatchFailure: settleDispatchBeforeStart,
       runDispatch: async () =>
         await dispatchInboundMessage({
@@ -668,6 +694,10 @@ export async function processDiscordMessage(
             abortSignal,
             skillFilter: channelConfig?.skills,
             sourceReplyDeliveryMode,
+            queuedDeliveryCorrelations: isRoomEvent
+              ? [{ begin: beginDeliveryCorrelation }]
+              : undefined,
+            suppressTyping: isRoomEvent ? true : undefined,
             allowProgressCallbacksWhenSourceDeliverySuppressed:
               sourceRepliesAreToolOnly && draftPreview.draftStream && draftPreview.isProgressMode
                 ? true
@@ -827,6 +857,7 @@ export async function processDiscordMessage(
     dispatchError = true;
     throw err;
   } finally {
+    endDiscordInboundEventDeliveryCorrelation();
     try {
       await draftPreview.cleanup();
     } finally {

--- a/extensions/discord/src/outbound-adapter.test.ts
+++ b/extensions/discord/src/outbound-adapter.test.ts
@@ -12,6 +12,7 @@ await installDiscordOutboundModuleSpies(hoisted);
 
 let normalizeDiscordOutboundTarget: typeof import("./normalize.js").normalizeDiscordOutboundTarget;
 let discordOutbound: typeof import("./outbound-adapter.js").discordOutbound;
+let beginDiscordInboundEventDeliveryCorrelation: typeof import("./inbound-event-delivery.js").beginDiscordInboundEventDeliveryCorrelation;
 
 type MockCallSource = { mock: { calls: Array<Array<unknown>> } };
 
@@ -39,6 +40,7 @@ function mockObjectArg(
 beforeAll(async () => {
   ({ normalizeDiscordOutboundTarget } = await import("./normalize.js"));
   ({ discordOutbound } = await import("./outbound-adapter.js"));
+  ({ beginDiscordInboundEventDeliveryCorrelation } = await import("./inbound-event-delivery.js"));
 });
 
 describe("normalizeDiscordOutboundTarget", () => {
@@ -457,6 +459,47 @@ describe("discordOutbound", () => {
     });
 
     expect(touchThread).toHaveBeenCalledWith({ threadId: "thread-1" });
+  });
+
+  it("notifies inbound event delivery after shared outbound delivery succeeds", async () => {
+    const markDelivered = vi.fn();
+    const end = beginDiscordInboundEventDeliveryCorrelation(
+      "agent:main:discord:channel:c1",
+      {
+        outboundTo: "thread-1",
+        outboundAccountId: "default",
+        markInboundEventDelivered: markDelivered,
+      },
+      { inboundEventKind: "room_event" },
+    );
+
+    try {
+      await discordOutbound.afterDeliverPayload?.({
+        cfg: {},
+        target: {
+          channel: "discord",
+          to: "channel:parent-1",
+          accountId: "default",
+          threadId: "thread-1",
+        },
+        payload: {
+          text: "delivered",
+          channelData: {
+            discord: {
+              __openclawInboundEventDelivery: {
+                sessionKey: "agent:main:discord:channel:c1",
+                inboundEventKind: "room_event",
+              },
+            },
+          },
+        },
+        results: [{ channel: "discord", messageId: "msg-1" }],
+      });
+    } finally {
+      end();
+    }
+
+    expect(markDelivered).toHaveBeenCalledTimes(1);
   });
 
   it("sends component payload media sequences with the component message first", async () => {

--- a/extensions/discord/src/outbound-adapter.ts
+++ b/extensions/discord/src/outbound-adapter.ts
@@ -11,6 +11,7 @@ import {
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { chunkDiscordTextWithMode } from "./chunk.js";
 import { withDiscordDeliveryRetry } from "./delivery-retry.js";
+import { notifyDiscordInboundEventOutboundPayloadSuccess } from "./inbound-event-delivery.js";
 import { isLikelyDiscordVideoMedia } from "./media-detection.js";
 import type { ThreadBindingRecord } from "./monitor/thread-bindings.js";
 import { normalizeDiscordOutboundTarget } from "./normalize.js";
@@ -287,7 +288,12 @@ export const discordOutbound: ChannelOutboundAdapter = {
           }),
       }),
   }),
-  afterDeliverPayload: async ({ target }) => {
+  afterDeliverPayload: async ({ target, payload }) => {
+    notifyDiscordInboundEventOutboundPayloadSuccess({
+      payload,
+      to: resolveDiscordOutboundTarget({ to: target.to, threadId: target.threadId }),
+      accountId: target.accountId,
+    });
     const threadId = normalizeOptionalStringifiedId(target.threadId);
     if (!threadId) {
       return;

--- a/src/infra/outbound/outbound-send-service.test.ts
+++ b/src/infra/outbound/outbound-send-service.test.ts
@@ -642,12 +642,21 @@ describe("executeSendAction", () => {
         channel: "discord",
         params: { to: "channel:123", message: "hello" },
         dryRun: false,
+        sessionKey: "discord-session",
+        inboundEventKind: "room_event",
       },
       to: "channel:123",
       message: "hello",
     });
 
-    expect(prepareSendPayload).toHaveBeenCalled();
+    expect(prepareSendPayload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctx: expect.objectContaining({
+          sessionKey: "discord-session",
+          inboundEventKind: "room_event",
+        }),
+      }),
+    );
     expect(mocks.dispatchChannelMessageAction).not.toHaveBeenCalled();
     const sendArgs = expectSingleCallFields(mocks.sendMessage, {
       channel: "discord",

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -197,6 +197,7 @@ function createChannelActionContext(params: {
     senderIsOwner: params.ctx.senderIsOwner,
     sessionKey: params.ctx.sessionKey,
     sessionId: params.ctx.sessionId,
+    inboundEventKind: params.ctx.inboundEventKind,
     agentId: params.ctx.agentId,
     gateway: params.ctx.gateway,
     toolContext: params.ctx.toolContext,


### PR DESCRIPTION
## Summary
- keep unmentioned Discord room-event history pending while source replies are message-tool-only
- clear that pending history only after a visible Discord send succeeds, covering local message actions and durable core outbound sends
- pass the inbound event kind through core outbound send preparation so Discord can attach delivery metadata
- add the maintainer changelog entry for the landed behavior

## Verification
- pnpm test src/infra/outbound/outbound-send-service.test.ts extensions/discord/src/channel-actions.test.ts extensions/discord/src/outbound-adapter.test.ts extensions/discord/src/monitor/message-handler.process.test.ts extensions/discord/src/actions/handle-action.test.ts
- pnpm check:test-types
- git diff --check
- /Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --mode branch --output /tmp/pr82573-codex-review-after-rebase.txt

## Real behavior proof
Behavior addressed: Discord room-event context stays available until the agent actually sends a visible Discord reply through the message tool or durable core send path.
Real environment tested: local OpenClaw checkout with Discord/core outbound unit coverage on the rebased PR branch; live Discord delivery was not run, so proof override is applied.
Exact steps or command run after this patch: see Verification above.
Evidence after fix: focused Discord/core tests cover pending room-event history, clearing on local visible sends, clearing on queued core sends, and metadata propagation into the Discord outbound adapter.
Observed result after fix: focused tests, test types, diff check, and Codex review all passed on rebased head 0344f0b6f3.
What was not tested: live Discord bot runtime against the Discord API.
