### PR TITLE
test: type daemon gateway auth mock

### DIFF
--- a/src/cli/daemon-cli/install.test.ts
+++ b/src/cli/daemon-cli/install.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ResolvedGatewayAuth } from "../../gateway/auth.js";
 import { captureFullEnv } from "../../test-utils/env.js";
 import { createCliRuntimeCapture } from "../test-runtime-capture.js";
 import type { DaemonActionResponse } from "./response.js";
@@ -21,12 +22,14 @@ const hasConfiguredSecretInputMock = vi.hoisted(() =>
   }),
 );
 const resolveGatewayAuthMock = vi.hoisted(() =>
-  vi.fn(() => ({
-    mode: "token",
-    token: undefined,
-    password: undefined,
-    allowTailscale: false,
-  })),
+  vi.fn(
+    (): ResolvedGatewayAuth => ({
+      mode: "token",
+      token: undefined,
+      password: undefined,
+      allowTailscale: false,
+    }),
+  ),
 );
 const resolveSecretRefValuesMock = vi.hoisted(() => vi.fn());
 const randomTokenMock = vi.hoisted(() => vi.fn(() => "generated-token"));


### PR DESCRIPTION
## Summary

- Type the daemon install test's `resolveGatewayAuth` mock as `ResolvedGatewayAuth` so token-returning overrides stay valid under `check-test-types`.
- Keep the change scoped to test code; runtime behavior is unchanged.

## Verification

- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `node scripts/run-vitest.mjs src/cli/daemon-cli/install.test.ts`
- `git diff --check origin/main...HEAD`
- `pnpm openclaw --version`

## Real behavior proof (required for external PRs)

Behavior addressed: `check-test-types` accepts the daemon install test mock when a case returns a durable token; runtime behavior is unchanged because this is a test-only type fix.
Real environment tested: Local macOS OpenClaw checkout on this branch with dependencies installed via `pnpm install`.
Exact steps or command run after this patch: `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo && node scripts/run-vitest.mjs src/cli/daemon-cli/install.test.ts && git diff --check origin/main...HEAD`, then `pnpm openclaw --version`.
Evidence after fix: The typecheck/test/diff command exited 0. Local terminal output from a real OpenClaw CLI smoke after the patch:

```text
$ pnpm openclaw --version
[openclaw] Building TypeScript (dist is stale: missing_build_stamp - build stamp missing).
[openclaw] Building bundled plugin assets.
runtime-postbuild: plugin SDK root alias completed in 1ms
runtime-postbuild: bundled plugin metadata completed in 187ms
runtime-postbuild: official channel catalog completed in 4ms
runtime-postbuild: bundled plugin runtime overlay completed in 227ms
runtime-postbuild: static extension assets completed in 52ms
runtime-postbuild: stable root runtime imports completed in 157ms
runtime-postbuild: stable root runtime aliases completed in 27ms
runtime-postbuild: legacy root runtime compat aliases completed in 8ms
runtime-postbuild: legacy CLI exit compat chunks completed in 0ms
OpenClaw 2026.5.17 (2202e50)
```

Observed result after fix: The test type project, targeted daemon install test, diff whitespace check, and real CLI version smoke all pass.
What was not tested: Full repository CI beyond this focused local proof; GitHub Actions will run on this PR.
