### PR TITLE
feat: show user-installed channel plugins in openclaw configure

### DIFF
--- a/src/channels/chat-meta.ts
+++ b/src/channels/chat-meta.ts
@@ -1,5 +1,7 @@
 import { buildChatChannelMetaById, type ChatChannelMeta } from "./chat-meta-shared.js";
 import { CHAT_CHANNEL_ORDER, type ChatChannelId } from "./ids.js";
+import { listChannelCatalogEntries } from "../plugins/channel-catalog-registry.js";
+import { buildManifestChannelMeta } from "./plugins/channel-meta.js";
 
 const CHAT_CHANNEL_META = buildChatChannelMetaById();
 
@@ -7,6 +9,38 @@ export type { ChatChannelMeta };
 
 export function listChatChannels(): ChatChannelMeta[] {
   return CHAT_CHANNEL_ORDER.map((id) => CHAT_CHANNEL_META[id]);
+}
+
+export function listAllChatChannels(): ChatChannelMeta[] {
+  const bundled = listChatChannels();
+  const seen = new Set(bundled.map((m) => m.id));
+  const extra: ChatChannelMeta[] = [];
+
+  for (const entry of listChannelCatalogEntries()) {
+    const id = entry.channel?.id?.toLowerCase();
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+
+    const label = entry.channel?.label?.trim();
+    if (!label) continue;
+
+    const meta = buildManifestChannelMeta({
+      id,
+      channel: entry.channel!,
+      label,
+      selectionLabel: entry.channel?.selectionLabel?.trim() || label,
+      docsPath: entry.channel?.docsPath?.trim() || `/channels/${id}`,
+      docsLabel: entry.channel?.docsLabel,
+      blurb: entry.channel?.blurb?.trim() || "",
+      detailLabel: entry.channel?.detailLabel?.trim(),
+      systemImage: entry.channel?.systemImage,
+      arrayFieldMode: "defined",
+      selectionDocsPrefixMode: "truthy",
+    });
+    extra.push(meta);
+  }
+
+  return [...bundled, ...extra];
 }
 
 export function getChatChannelMeta(id: ChatChannelId): ChatChannelMeta {

--- a/src/commands/channel-setup/discovery.ts
+++ b/src/commands/channel-setup/discovery.ts
@@ -1,5 +1,5 @@
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
-import { listChatChannels } from "../../channels/chat-meta.js";
+import { listAllChatChannels } from "../../channels/chat-meta.js";
 import { type ChannelPluginCatalogEntry } from "../../channels/plugins/catalog.js";
 import { isChannelVisibleInSetup } from "../../channels/plugins/exposure.js";
 import { normalizeChannelMeta } from "../../channels/plugins/meta-normalization.js";
@@ -118,7 +118,7 @@ export function resolveChannelSetupEntries(params: {
     );
 
   const metaById = new Map<string, ChannelMeta>();
-  for (const meta of listChatChannels()) {
+  for (const meta of listAllChatChannels()) {
     metaById.set(
       meta.id,
       normalizeChannelMeta({

--- a/src/commands/configure.channels.ts
+++ b/src/commands/configure.channels.ts
@@ -1,4 +1,4 @@
-import { listChatChannels } from "../channels/chat-meta.js";
+import { listAllChatChannels } from "../channels/chat-meta.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { CONFIG_PATH } from "../config/config.js";
 import { isBlockedObjectKey } from "../config/prototype-keys.js";
@@ -36,7 +36,7 @@ function listConfiguredChannelRemovalChoices(
     return [];
   }
   const labelsById = new Map(
-    listChatChannels().map((meta) => [meta.id, formatChannelRemovalLabel(meta.label, meta.id)]),
+    listAllChatChannels().map((meta) => [meta.id, formatChannelRemovalLabel(meta.label, meta.id)]),
   );
   return Object.keys(channels)
     .filter((id) => !RESERVED_CHANNEL_CONFIG_KEYS.has(id))


### PR DESCRIPTION
## Summary

When a user installs a channel plugin (third-party, origin "global"), `openclaw configure` does not show it — it only displays channels from the bundled `channel-catalog.json` (17 built-in channels).

This PR adds `listAllChatChannels()` which includes channel plugins from **all origins** (bundled + global + workspace), not only bundled.

## Changes

### `src/channels/chat-meta.ts`
- Added `listAllChatChannels()` that starts from the bundled list and extends it with channel plugins discovered from all origins via `listChannelCatalogEntries()`
- Each non-bundled channel builds its `ChannelMeta` from the plugin manifest metadata

### `src/commands/configure.channels.ts`
- Channel removal wizard now uses `listAllChatChannels()` so user-installed channel plugins get proper labels instead of raw IDs

### `src/commands/channel-setup/discovery.ts`
- `resolveChannelSetupEntries()` uses `listAllChatChannels()` as baseline metadata source instead of only bundled channels, so the setup picker shows metadata for user-installed plugins

## Motivation

Our team developed a Max.ru (max-messenger) channel plugin. The plugin works perfectly — it loads, processes messages, handles webhooks — but it is invisible in `openclaw configure`. The removal wizard showed just "max" without a label, and the setup picker could not discover its metadata.

This fix makes `configure` work correctly with any channel plugin regardless of origin.

## Testing

- [ ] The existing test suite mocks `listChatChannels()` — the new `listAllChatChannels()` is separate and backward-compatible
- [ ] Manual: user-installed channel plugin now appears with proper label in `configure` removal menu
