### PR TITLE
fix: prevent persistSessionUsageUpdate from corrupting totalTokens (fixes #82576)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/sessions: preserve fresh post-compaction token snapshots across stale usage updates, preventing repeated auto-compaction after every message. Fixes #82576. (#82578) Thanks @njuboy11.
 - Gateway/WebChat: route image attachments through a configured vision-capable `imageModel` plan before inlining images, and carry that image-model fallback chain through runtime retries. (#82524) Thanks @frankekn.
 - WebChat: show progress while manual `/compact` is running by streaming a session operation event to subscribed Control UI clients. Fixes #82407. Thanks @Conan-Scott.
 - Codex app-server: limit canonical OpenAI Codex app-server attribution rewrites to local transcript and trajectory records, leaving runtime/tool routing on the selected OpenAI model metadata so OpenAI API-key backup profiles keep their billing path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/sessions: preserve fresh post-compaction token snapshots across stale usage updates, preventing repeated auto-compaction after every message. Fixes #82576. (#82578) Thanks @njuboy11.
+- Gateway/sessions: discard stale metadata when recreating dead main session rows, so replacement sessions do not inherit old labels or transcript paths.
 - Gateway/WebChat: route image attachments through a configured vision-capable `imageModel` plan before inlining images, and carry that image-model fallback chain through runtime retries. (#82524) Thanks @frankekn.
 - WebChat: show progress while manual `/compact` is running by streaming a session operation event to subscribed Control UI clients. Fixes #82407. Thanks @Conan-Scott.
 - Codex app-server: limit canonical OpenAI Codex app-server attribution rewrites to local transcript and trajectory records, leaving runtime/tool routing on the selected OpenAI model metadata so OpenAI API-key backup profiles keep their billing path.

--- a/extensions/github-copilot/index.test.ts
+++ b/extensions/github-copilot/index.test.ts
@@ -14,6 +14,7 @@ import type {
 } from "openclaw/plugin-sdk/plugin-entry";
 import { createTestPluginApi } from "openclaw/plugin-sdk/plugin-test-api";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { _setGitHubCopilotDeviceFlowFetchGuardForTesting } from "./login.js";
 
 const mocks = vi.hoisted(() => ({
   githubCopilotLoginCommand: vi.fn(),
@@ -49,6 +50,7 @@ type GithubCopilotTestModelCatalogProvider = {
 afterEach(async () => {
   vi.clearAllMocks();
   vi.unstubAllGlobals();
+  _setGitHubCopilotDeviceFlowFetchGuardForTesting(null);
   clearRuntimeAuthProfileStoreSnapshots();
   await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
 });
@@ -313,7 +315,7 @@ describe("github-copilot plugin", () => {
         },
       }),
     );
-    const fetchMock = vi.fn(async (input: unknown) => {
+    const fetchMock = vi.fn(async (input: unknown, _init?: RequestInit) => {
       const target =
         typeof input === "string"
           ? input
@@ -343,6 +345,11 @@ describe("github-copilot plugin", () => {
       throw new Error(`unexpected fetch in github-copilot refresh test: ${target}`);
     });
     vi.stubGlobal("fetch", fetchMock);
+    _setGitHubCopilotDeviceFlowFetchGuardForTesting(async (params) => ({
+      response: await fetchMock(params.url, params.init),
+      finalUrl: params.url,
+      release: async () => {},
+    }));
     const prompter = {
       confirm: vi.fn(async () => true),
       note: vi.fn(),

--- a/extensions/github-copilot/login.ts
+++ b/extensions/github-copilot/login.ts
@@ -7,6 +7,7 @@ import {
   upsertAuthProfileWithLock,
 } from "openclaw/plugin-sdk/provider-auth";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime";
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 
 const CLIENT_ID = "Iv1.b507a08c87ecfe98";
 const DEVICE_CODE_URL = "https://github.com/login/device/code";
@@ -47,6 +48,14 @@ class GitHubDeviceFlowError extends Error {
   }
 }
 
+let githubDeviceFlowFetchGuard = fetchWithSsrFGuard;
+
+export function _setGitHubCopilotDeviceFlowFetchGuardForTesting(
+  impl: typeof fetchWithSsrFGuard | null,
+): void {
+  githubDeviceFlowFetchGuard = impl ?? fetchWithSsrFGuard;
+}
+
 async function upsertAuthProfileWithLockOrThrow(params: UpsertAuthProfileParams): Promise<void> {
   const updated = await upsertAuthProfileWithLock(params);
   if (!updated) {
@@ -71,26 +80,45 @@ function parseJsonResponse(value: unknown): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
+async function postGitHubDeviceFlowForm(params: {
+  url: string;
+  body: URLSearchParams;
+  failureLabel: string;
+}): Promise<Record<string, unknown>> {
+  const { response, release } = await githubDeviceFlowFetchGuard({
+    url: params.url,
+    init: {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: params.body,
+    },
+    requireHttps: true,
+    auditContext: "github-copilot-device-flow",
+  });
+  try {
+    if (!response.ok) {
+      throw new Error(`${params.failureLabel}: HTTP ${response.status}`);
+    }
+    return parseJsonResponse(await response.json());
+  } finally {
+    await release();
+  }
+}
+
 async function requestDeviceCode(params: { scope: string }): Promise<DeviceCodeResponse> {
   const body = new URLSearchParams({
     client_id: CLIENT_ID,
     scope: params.scope,
   });
 
-  const res = await fetch(DEVICE_CODE_URL, {
-    method: "POST",
-    headers: {
-      Accept: "application/json",
-      "Content-Type": "application/x-www-form-urlencoded",
-    },
+  const json = (await postGitHubDeviceFlowForm({
+    url: DEVICE_CODE_URL,
     body,
-  });
-
-  if (!res.ok) {
-    throw new Error(`GitHub device code failed: HTTP ${res.status}`);
-  }
-
-  const json = parseJsonResponse(await res.json()) as DeviceCodeResponse;
+    failureLabel: "GitHub device code failed",
+  })) as DeviceCodeResponse;
   if (!json.device_code || !json.user_code || !json.verification_uri) {
     throw new Error("GitHub device code response missing fields");
   }
@@ -109,20 +137,11 @@ async function pollForAccessToken(params: {
   });
 
   while (Date.now() < params.expiresAt) {
-    const res = await fetch(ACCESS_TOKEN_URL, {
-      method: "POST",
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/x-www-form-urlencoded",
-      },
+    const json = (await postGitHubDeviceFlowForm({
+      url: ACCESS_TOKEN_URL,
       body: bodyBase,
-    });
-
-    if (!res.ok) {
-      throw new Error(`GitHub device token failed: HTTP ${res.status}`);
-    }
-
-    const json = parseJsonResponse(await res.json()) as DeviceTokenResponse;
+      failureLabel: "GitHub device token failed",
+    })) as DeviceTokenResponse;
     if ("access_token" in json && typeof json.access_token === "string") {
       return json.access_token;
     }

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1614,6 +1614,7 @@ export async function runReplyAgent(params: {
       systemPromptReport: runResult.meta?.systemPromptReport,
       cliSessionId,
       cliSessionBinding,
+      preserveFreshTotalTokensOnStaleUsage: preflightCompactionApplied,
     });
 
     const returnSilentFallbackFailureIfNeeded = async (): Promise<ReplyPayload | undefined> => {

--- a/src/auto-reply/reply/reply-state.test.ts
+++ b/src/auto-reply/reply/reply-state.test.ts
@@ -606,7 +606,7 @@ describe("incrementCompactionCount", () => {
     const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
     expect(stored[sessionKey].compactionCount).toBe(1);
     expect(stored[sessionKey].totalTokens).toBe(180_000);
-    expect(stored[sessionKey].totalTokensFresh).toBe(true);
+    expect(stored[sessionKey].totalTokensFresh).toBe(false);
   });
 
   it("updates sessionId and sessionFile when compaction rotated transcripts", async () => {
@@ -732,12 +732,13 @@ describe("incrementCompactionCount", () => {
     expect(stored[sessionKey].compactionCount).toBe(1);
   });
 
-  it("does not update totalTokens when tokensAfter is not provided", async () => {
+  it("marks totalTokens stale when tokensAfter is not provided", async () => {
     const entry = {
       sessionId: "s1",
       updatedAt: Date.now(),
       compactionCount: 0,
       totalTokens: 180_000,
+      totalTokensFresh: true,
     } as SessionEntry;
     const { storePath, sessionKey, sessionStore } = await createCompactionSessionFixture(entry);
 
@@ -752,5 +753,6 @@ describe("incrementCompactionCount", () => {
     expect(stored[sessionKey].compactionCount).toBe(1);
     // totalTokens unchanged
     expect(stored[sessionKey].totalTokens).toBe(180_000);
+    expect(stored[sessionKey].totalTokensFresh).toBe(false);
   });
 });

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -420,6 +420,8 @@ export async function incrementCompactionCount(params: {
     updates.outputTokens = undefined;
     updates.cacheRead = undefined;
     updates.cacheWrite = undefined;
+  } else if (incrementBy > 0) {
+    updates.totalTokensFresh = false;
   }
   sessionStore[sessionKey] = {
     ...entry,

--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -154,10 +154,15 @@ export async function persistSessionUsageUpdate(params: {
           if (runEstimatedCostUsd !== undefined) {
             patch.estimatedCostUsd = runEstimatedCostUsd;
           }
-          // Missing a last-call snapshot (and promptTokens fallback) means
-          // context utilization is stale/unknown.
-          patch.totalTokens = totalTokens;
-          patch.totalTokensFresh = typeof totalTokens === "number";
+          // Only update totalTokens when we have a fresh context snapshot
+          // (lastCallUsage or promptTokens or usageIsContextSnapshot).
+          // Without a snapshot the session keeps its existing totalTokens so
+          // that preflight compaction guards set by incrementCompactionCount
+          // are not corrupted by a stale usage update.
+          if (hasFreshContextSnapshot) {
+            patch.totalTokens = totalTokens;
+            patch.totalTokensFresh = true;
+          }
           return applyCliSessionIdToSessionPatch(params, entry, patch);
         },
       });

--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -88,6 +88,7 @@ export async function persistSessionUsageUpdate(params: {
   systemPromptReport?: SessionSystemPromptReport;
   cliSessionId?: string;
   cliSessionBinding?: import("../../config/sessions.js").CliSessionBinding;
+  preserveFreshTotalTokensOnStaleUsage?: boolean;
   logLabel?: string;
 }): Promise<void> {
   const { storePath, sessionKey } = params;
@@ -154,15 +155,13 @@ export async function persistSessionUsageUpdate(params: {
           if (runEstimatedCostUsd !== undefined) {
             patch.estimatedCostUsd = runEstimatedCostUsd;
           }
-          // Only update totalTokens value when we have a fresh context snapshot
-          // (lastCallUsage or promptTokens or usageIsContextSnapshot).
-          // When the snapshot is stale we keep the existing totalTokens so that
-          // preflight compaction guards set by incrementCompactionCount are not
-          // corrupted by a stale usage update, but mark it as stale.
           if (hasFreshContextSnapshot) {
             patch.totalTokens = totalTokens;
             patch.totalTokensFresh = true;
-          } else {
+          } else if (
+            params.preserveFreshTotalTokensOnStaleUsage !== true ||
+            entry.totalTokensFresh !== true
+          ) {
             patch.totalTokensFresh = false;
           }
           return applyCliSessionIdToSessionPatch(params, entry, patch);

--- a/src/auto-reply/reply/session-usage.ts
+++ b/src/auto-reply/reply/session-usage.ts
@@ -154,14 +154,16 @@ export async function persistSessionUsageUpdate(params: {
           if (runEstimatedCostUsd !== undefined) {
             patch.estimatedCostUsd = runEstimatedCostUsd;
           }
-          // Only update totalTokens when we have a fresh context snapshot
+          // Only update totalTokens value when we have a fresh context snapshot
           // (lastCallUsage or promptTokens or usageIsContextSnapshot).
-          // Without a snapshot the session keeps its existing totalTokens so
-          // that preflight compaction guards set by incrementCompactionCount
-          // are not corrupted by a stale usage update.
+          // When the snapshot is stale we keep the existing totalTokens so that
+          // preflight compaction guards set by incrementCompactionCount are not
+          // corrupted by a stale usage update, but mark it as stale.
           if (hasFreshContextSnapshot) {
             patch.totalTokens = totalTokens;
             patch.totalTokensFresh = true;
+          } else {
+            patch.totalTokensFresh = false;
           }
           return applyCliSessionIdToSessionPatch(params, entry, patch);
         },

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -3056,6 +3056,59 @@ describe("persistSessionUsageUpdate", () => {
     expect(stored[sessionKey].totalTokensFresh).toBe(false);
   });
 
+  it("preserves fresh post-compaction totalTokens across stale usage updates", async () => {
+    const storePath = await createStorePath("openclaw-usage-");
+    const sessionKey = "main";
+    await seedSessionStore({
+      storePath,
+      sessionKey,
+      entry: {
+        sessionId: "s1",
+        updatedAt: Date.now(),
+        totalTokens: 42_000,
+        totalTokensFresh: true,
+      },
+    });
+
+    await persistSessionUsageUpdate({
+      storePath,
+      sessionKey,
+      usage: { input: 50_000, output: 5_000, total: 55_000 },
+      contextTokensUsed: 200_000,
+      preserveFreshTotalTokensOnStaleUsage: true,
+    });
+
+    const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
+    expect(stored[sessionKey].totalTokens).toBe(42_000);
+    expect(stored[sessionKey].totalTokensFresh).toBe(true);
+  });
+
+  it("marks older fresh totalTokens stale when no compaction preservation is requested", async () => {
+    const storePath = await createStorePath("openclaw-usage-");
+    const sessionKey = "main";
+    await seedSessionStore({
+      storePath,
+      sessionKey,
+      entry: {
+        sessionId: "s1",
+        updatedAt: Date.now(),
+        totalTokens: 42_000,
+        totalTokensFresh: true,
+      },
+    });
+
+    await persistSessionUsageUpdate({
+      storePath,
+      sessionKey,
+      usage: { input: 50_000, output: 5_000, total: 55_000 },
+      contextTokensUsed: 200_000,
+    });
+
+    const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
+    expect(stored[sessionKey].totalTokens).toBe(42_000);
+    expect(stored[sessionKey].totalTokensFresh).toBe(false);
+  });
+
   it("uses promptTokens when available without lastCallUsage", async () => {
     const storePath = await createStorePath("openclaw-usage-");
     const sessionKey = "main";

--- a/src/cron/service.skips-main-jobs-empty-systemevent-text.test.ts
+++ b/src/cron/service.skips-main-jobs-empty-systemevent-text.test.ts
@@ -94,7 +94,7 @@ describe("CronService", () => {
     expect(requestHeartbeat).not.toHaveBeenCalled();
   });
 
-  it("drops persisted main jobs with empty systemEvent text before they run", async () => {
+  it("disables persisted main jobs with empty systemEvent text after skipping them", async () => {
     await withCronService(true, async ({ cron, enqueueSystemEvent, requestHeartbeat }) => {
       const atMs = Date.parse("2025-12-13T00:00:01.000Z");
       await cron.add({
@@ -112,8 +112,9 @@ describe("CronService", () => {
       expect(enqueueSystemEvent).not.toHaveBeenCalled();
       expect(requestHeartbeat).not.toHaveBeenCalled();
 
-      const job = await waitForFirstJob(cron, (current) => current === undefined);
-      expect(job).toBeUndefined();
+      const job = await waitForFirstJob(cron, (current) => current?.state.lastStatus === "skipped");
+      expect(job?.enabled).toBe(false);
+      expect(job?.state.lastError).toMatch(/non-empty/i);
     });
   });
 

--- a/src/cron/service/store.test.ts
+++ b/src/cron/service/store.test.ts
@@ -291,7 +291,7 @@ describe("cron service store seam coverage", () => {
     expect(findJobOrThrow(state, "reload-cron-expr-job").state.nextRunAtMs).toBe(dueNextRunAtMs);
   });
 
-  it("skips a force-reloaded job when the persisted schedule is malformed", async () => {
+  it("keeps a force-reloaded legacy string schedule for runtime repair handling", async () => {
     const { storePath } = await makeStorePath();
     const staleNextRunAtMs = STORE_TEST_NOW + 3_600_000;
 
@@ -316,12 +316,9 @@ describe("cron service store seam coverage", () => {
       undefined,
     );
 
-    expect(state.store?.jobs.find((job) => job.id === "reload-cron-expr-job")).toBeUndefined();
-    expectWarnedJob({
-      storePath,
-      jobId: "reload-cron-expr-job",
-      message: "skipped invalid persisted job",
-    });
+    const job = findJobOrThrow(state, "reload-cron-expr-job");
+    expect(job.schedule).toBe("0 17 * * *");
+    expect(job.state.nextRunAtMs).toBeUndefined();
   });
 
   it("preserves nextRunAtMs after force reload when scheduling inputs are unchanged", async () => {

--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -173,6 +173,37 @@ describe("gateway sessions patch", () => {
     expect(entry.fastMode).toBe(true);
   });
 
+  test("recreates partial rows without dropping session settings", async () => {
+    const store: Record<string, SessionEntry> = {
+      [MAIN_SESSION_KEY]: {
+        updatedAt: 1,
+        sessionFile: "stale.jsonl",
+        label: "Stale Session",
+        sendPolicy: "deny",
+        modelOverride: "gpt-5.4",
+        responseUsage: "tokens",
+        parentSessionKey: "agent:main:main",
+      } as SessionEntry,
+    };
+    const entry = expectPatchOk(
+      await runPatch({
+        store,
+        patch: { key: MAIN_SESSION_KEY, fastMode: true },
+      }),
+    );
+
+    expect(entry.sessionId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+    expect(entry.sessionFile).toBeUndefined();
+    expect(entry.label).toBeUndefined();
+    expect(entry.sendPolicy).toBe("deny");
+    expect(entry.modelOverride).toBe("gpt-5.4");
+    expect(entry.responseUsage).toBe("tokens");
+    expect(entry.parentSessionKey).toBe("agent:main:main");
+    expect(entry.fastMode).toBe(true);
+  });
+
   test("clears fastMode when patch sets null", async () => {
     const store: Record<string, SessionEntry> = {
       [MAIN_SESSION_KEY]: { fastMode: true } as SessionEntry,

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -130,6 +130,10 @@ export async function applySessionsPatchToStore(params: {
         sessionFile: undefined,
         updatedAt: Math.max(existing?.updatedAt ?? 0, now),
       };
+  if (existing && !existing.sessionId) {
+    delete next.label;
+    delete next.displayName;
+  }
 
   if ("spawnedBy" in patch) {
     const raw = patch.spawnedBy;


### PR DESCRIPTION
## Summary

Fixes #82576 — `persistSessionUsageUpdate` unconditionally overwrote `totalTokens=undefined` when there was no fresh context snapshot, corrupting the value set by `incrementCompactionCount` after compaction.

## Problem

After every model call, `persistSessionUsageUpdate` updates the session store. When `hasFreshContextSnapshot` is false (no `lastCallUsage`, no `promptTokens`, no `usageIsContextSnapshot`), it wrote `totalTokens=undefined` and `totalTokensFresh=false`, overwriting compaction state. This caused `runPreflightCompactionIfNeeded` to skip its early-return guard and fall through to full transcript re-estimation, triggering repeated compactions on every message for smaller-context models.

## Real behavior proof

**Behavior or issue addressed**: Repeated auto-compaction on every feishu/webchat message dispatch for models with smaller context windows (~204K tokens). Every message triggered a new compaction because `persistSessionUsageUpdate` corrupted `totalTokens` to `undefined`, forcing `runPreflightCompactionIfNeeded` to re-estimate from scratch and always exceed the threshold.

**Real environment tested**: OpenClaw v2026.5.16-beta.1 on Linux VM100, MiniMax M2.7-highspeed model (contextWindow: 204800), long-running feishu DM conversation with image analysis.

**Exact steps or command run after this patch**: The fix is a one-line logic change in `src/auto-reply/reply/session-usage.ts`. Cannot deploy patched binary directly, but verified by:
1. Traced source code to confirm `patch.totalTokens = undefined` is unconditionally applied
2. Verified session store state: `sessions.json` showed `totalTokens: None, totalTokensFresh: False, compactionCount: 6`
3. Verified log evidence: 5 compaction rotations on 5 consecutive feishu messages within 6 minutes
4. Unit test `checks-node-auto-reply-reply-session` passes (see CI)

**Evidence after fix**: 
- Session store snapshots before fix: `totalTokens: None` (corrupted), `totalTokensFresh: False`
- Compaction rotation logs before fix (one per feishu message):
```
19:30:07 [compaction] rotated active transcript after compaction (sessionKey=agent:main:main)
19:32:31 [compaction] rotated active transcript after compaction (sessionKey=agent:main:main)
19:34:02 [compaction] rotated active transcript after compaction (sessionKey=agent:main:main)
19:35:07 [compaction] rotated active transcript after compaction (sessionKey=agent:main:main)
19:35:56 [compaction] rotated active transcript after compaction (sessionKey=agent:main:main)
```
- After-fix behavior: `totalTokens` from compaction is preserved (not set to undefined); `totalTokensFresh=false` still marks snapshot as stale for preflight re-checks.
- Unit test `marks totalTokens as unknown when no fresh context snapshot is available` updated to cover the new behavior.

**Observed result after fix**: When snapshot is stale, `totalTokens` value from the most recent `incrementCompactionCount` call is preserved instead of corrupted. This prevents the preflight compaction guard from falling through to full transcript re-estimation, stopping the repeated-compaction cycle. The session test passes the updated assertion.

**Not tested**: Models with very large context windows (behavior unchanged since threshold is never exceeded); CLI-provider compaction path (separate code path via `incrementRunCompactionCount`).

## Change

```diff
- patch.totalTokens = totalTokens;
- patch.totalTokensFresh = typeof totalTokens === "number";
+ if (hasFreshContextSnapshot) {
+   patch.totalTokens = totalTokens;
+   patch.totalTokensFresh = true;
+ } else {
+   patch.totalTokensFresh = false;
+ }
```

When snapshot is stale: preserves existing totalTokens (from compaction), marks as stale with totalTokensFresh=false.
