### PR TITLE
fix(plugins): block untrusted workspace setup-only channel loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Docs: https://docs.openclaw.ai
 - Logging: exit cleanly on broken stdout/stderr pipes without masking existing failure exit codes. (#80059) Thanks @pavelzak.
 - Gateway/security: escape transcript metadata field names while extracting oversized session line prefixes. (#85934) Thanks @SebTardif.
 - Plugins/security: validate manifest model pattern regexes with the safe-regex compiler so unsafe patterns are ignored before matching. (#86046) Thanks @SebTardif.
+- Plugins/security: block untrusted workspace channel plugins from setup-only scoped loads and isolate setup-entry channel registration failures so one broken trusted plugin no longer aborts sibling plugin loading. (#82579, #85774) Thanks @SebTardif.
 - Discord: route gateway metadata REST lookups through the configured Discord proxy so proxied accounts do not fall back to direct `discord.com` connections before opening the WebSocket. Fixes #80227. Thanks @Clivilwalker.
 - Agents/media: hydrate current-turn image attachments from filename-derived MIME types so active vision can see generated or forwarded images whose source omitted an image content type. (#84812) Thanks @marchpure.
 - Agents/fs: point workspace-only scratch-path guidance at in-workspace temp directories while keeping host-root writes rejected by the tool guard. (#86501) Thanks @tianxiaochannel-oss88.

--- a/src/channels/plugins/catalog.ts
+++ b/src/channels/plugins/catalog.ts
@@ -416,12 +416,15 @@ export function buildChannelUiCatalog(
 }
 
 /**
- * Exported for trusted-catalog helpers that apply their own filtering.
- * Execution-facing callers should use `listTrustedChannelPluginCatalogEntries`.
+ * Raw catalog primitive. This may include untrusted workspace entries and
+ * workspace shadows. Security-sensitive or execution-facing callers should
+ * prefer `listTrustedChannelPluginCatalogEntries`; use this primitive only when
+ * the caller immediately applies trust filtering or explicitly excludes
+ * workspace entries.
  *
  * @internal
  */
-export function listChannelPluginCatalogEntriesUnfiltered(
+export function listRawChannelPluginCatalogEntries(
   options: CatalogOptions = {},
 ): ChannelPluginCatalogEntry[] {
   const manifestEntries = listChannelCatalogEntries({
@@ -490,13 +493,13 @@ export function listChannelPluginCatalogEntriesUnfiltered(
 
 /**
  * @deprecated Use `listTrustedChannelPluginCatalogEntries` for execution-facing
- * paths, or `listChannelPluginCatalogEntriesUnfiltered` for internal plumbing
+ * paths, or `listRawChannelPluginCatalogEntries` for internal plumbing
  * that applies its own trust filtering.
  */
 export function listChannelPluginCatalogEntries(
   options: CatalogOptions = {},
 ): ChannelPluginCatalogEntry[] {
-  return listChannelPluginCatalogEntriesUnfiltered(options);
+  return listRawChannelPluginCatalogEntries(options);
 }
 
 export function getChannelPluginCatalogEntry(
@@ -507,5 +510,5 @@ export function getChannelPluginCatalogEntry(
   if (!trimmed) {
     return undefined;
   }
-  return listChannelPluginCatalogEntriesUnfiltered(options).find((entry) => entry.id === trimmed);
+  return listRawChannelPluginCatalogEntries(options).find((entry) => entry.id === trimmed);
 }

--- a/src/channels/plugins/catalog.ts
+++ b/src/channels/plugins/catalog.ts
@@ -415,7 +415,13 @@ export function buildChannelUiCatalog(
   return { entries, order, labels, detailLabels, systemImages, byId };
 }
 
-export function listChannelPluginCatalogEntries(
+/**
+ * Exported for trusted-catalog helpers that apply their own filtering.
+ * Execution-facing callers should use `listTrustedChannelPluginCatalogEntries`.
+ *
+ * @internal
+ */
+export function listChannelPluginCatalogEntriesUnfiltered(
   options: CatalogOptions = {},
 ): ChannelPluginCatalogEntry[] {
   const manifestEntries = listChannelCatalogEntries({
@@ -482,6 +488,17 @@ export function listChannelPluginCatalogEntries(
     });
 }
 
+/**
+ * @deprecated Use `listTrustedChannelPluginCatalogEntries` for execution-facing
+ * paths, or `listChannelPluginCatalogEntriesUnfiltered` for internal plumbing
+ * that applies its own trust filtering.
+ */
+export function listChannelPluginCatalogEntries(
+  options: CatalogOptions = {},
+): ChannelPluginCatalogEntry[] {
+  return listChannelPluginCatalogEntriesUnfiltered(options);
+}
+
 export function getChannelPluginCatalogEntry(
   id: string,
   options: CatalogOptions = {},
@@ -490,5 +507,5 @@ export function getChannelPluginCatalogEntry(
   if (!trimmed) {
     return undefined;
   }
-  return listChannelPluginCatalogEntries(options).find((entry) => entry.id === trimmed);
+  return listChannelPluginCatalogEntriesUnfiltered(options).find((entry) => entry.id === trimmed);
 }

--- a/src/cli/channel-auth.test.ts
+++ b/src/cli/channel-auth.test.ts
@@ -33,7 +33,7 @@ vi.mock("../agents/agent-scope.js", () => ({
 vi.mock("../channels/plugins/catalog.js", () => ({
   getChannelPluginCatalogEntry: mocks.getChannelPluginCatalogEntry,
   listChannelPluginCatalogEntries: mocks.listChannelPluginCatalogEntries,
-  listChannelPluginCatalogEntriesUnfiltered: mocks.listChannelPluginCatalogEntries,
+  listRawChannelPluginCatalogEntries: mocks.listChannelPluginCatalogEntries,
 }));
 
 vi.mock("../channels/plugins/helpers.js", () => ({

--- a/src/cli/channel-auth.test.ts
+++ b/src/cli/channel-auth.test.ts
@@ -33,6 +33,7 @@ vi.mock("../agents/agent-scope.js", () => ({
 vi.mock("../channels/plugins/catalog.js", () => ({
   getChannelPluginCatalogEntry: mocks.getChannelPluginCatalogEntry,
   listChannelPluginCatalogEntries: mocks.listChannelPluginCatalogEntries,
+  listChannelPluginCatalogEntriesUnfiltered: mocks.listChannelPluginCatalogEntries,
 }));
 
 vi.mock("../channels/plugins/helpers.js", () => ({

--- a/src/commands/channel-setup/channel-plugin-resolution.test.ts
+++ b/src/commands/channel-setup/channel-plugin-resolution.test.ts
@@ -20,6 +20,7 @@ vi.mock("../../agents/agent-scope.js", () => ({
 
 vi.mock("../../channels/plugins/catalog.js", () => ({
   listChannelPluginCatalogEntries: mocks.listChannelPluginCatalogEntries,
+  listChannelPluginCatalogEntriesUnfiltered: mocks.listChannelPluginCatalogEntries,
   getChannelPluginCatalogEntry: mocks.getChannelPluginCatalogEntry,
 }));
 

--- a/src/commands/channel-setup/channel-plugin-resolution.test.ts
+++ b/src/commands/channel-setup/channel-plugin-resolution.test.ts
@@ -20,7 +20,7 @@ vi.mock("../../agents/agent-scope.js", () => ({
 
 vi.mock("../../channels/plugins/catalog.js", () => ({
   listChannelPluginCatalogEntries: mocks.listChannelPluginCatalogEntries,
-  listChannelPluginCatalogEntriesUnfiltered: mocks.listChannelPluginCatalogEntries,
+  listRawChannelPluginCatalogEntries: mocks.listChannelPluginCatalogEntries,
   getChannelPluginCatalogEntry: mocks.getChannelPluginCatalogEntry,
 }));
 

--- a/src/commands/channel-setup/channel-plugin-resolution.ts
+++ b/src/commands/channel-setup/channel-plugin-resolution.ts
@@ -1,6 +1,6 @@
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import {
-  listChannelPluginCatalogEntries,
+  listRawChannelPluginCatalogEntries,
   type ChannelPluginCatalogEntry,
 } from "../../channels/plugins/catalog.js";
 import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
@@ -63,7 +63,7 @@ function resolveCatalogChannelEntry(raw: string, cfg: OpenClawConfig | null) {
         cfg,
         workspaceDir: resolveWorkspaceDir(cfg),
       })
-    : listChannelPluginCatalogEntries({ excludeWorkspace: true });
+    : listRawChannelPluginCatalogEntries({ excludeWorkspace: true });
   return entries.find((entry) => {
     if (normalizeOptionalLowercaseString(entry.id) === trimmed) {
       return true;

--- a/src/commands/channel-setup/discovery.test.ts
+++ b/src/commands/channel-setup/discovery.test.ts
@@ -30,6 +30,7 @@ vi.mock("../../config/plugin-auto-enable.js", () => ({
 
 vi.mock("../../channels/plugins/catalog.js", () => ({
   listChannelPluginCatalogEntries: (_args?: unknown) => listChannelPluginCatalogEntries(),
+  listChannelPluginCatalogEntriesUnfiltered: (_args?: unknown) => listChannelPluginCatalogEntries(),
 }));
 
 vi.mock("../../channels/chat-meta.js", () => ({

--- a/src/commands/channel-setup/discovery.test.ts
+++ b/src/commands/channel-setup/discovery.test.ts
@@ -30,7 +30,7 @@ vi.mock("../../config/plugin-auto-enable.js", () => ({
 
 vi.mock("../../channels/plugins/catalog.js", () => ({
   listChannelPluginCatalogEntries: (_args?: unknown) => listChannelPluginCatalogEntries(),
-  listChannelPluginCatalogEntriesUnfiltered: (_args?: unknown) => listChannelPluginCatalogEntries(),
+  listRawChannelPluginCatalogEntries: (_args?: unknown) => listChannelPluginCatalogEntries(),
 }));
 
 vi.mock("../../channels/chat-meta.js", () => ({

--- a/src/commands/channel-setup/plugin-install.test.ts
+++ b/src/commands/channel-setup/plugin-install.test.ts
@@ -48,6 +48,8 @@ vi.mock("../../channels/plugins/catalog.js", () => {
     getChannelPluginCatalogEntry: (...args: unknown[]) => getChannelPluginCatalogEntry(...args),
     listChannelPluginCatalogEntries: (...args: unknown[]) =>
       listChannelPluginCatalogEntries(...args),
+    listChannelPluginCatalogEntriesUnfiltered: (...args: unknown[]) =>
+      listChannelPluginCatalogEntries(...args),
   };
 });
 

--- a/src/commands/channel-setup/plugin-install.test.ts
+++ b/src/commands/channel-setup/plugin-install.test.ts
@@ -48,7 +48,7 @@ vi.mock("../../channels/plugins/catalog.js", () => {
     getChannelPluginCatalogEntry: (...args: unknown[]) => getChannelPluginCatalogEntry(...args),
     listChannelPluginCatalogEntries: (...args: unknown[]) =>
       listChannelPluginCatalogEntries(...args),
-    listChannelPluginCatalogEntriesUnfiltered: (...args: unknown[]) =>
+    listRawChannelPluginCatalogEntries: (...args: unknown[]) =>
       listChannelPluginCatalogEntries(...args),
   };
 });

--- a/src/commands/channel-setup/trusted-catalog.test.ts
+++ b/src/commands/channel-setup/trusted-catalog.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelPluginCatalogEntry } from "../../channels/plugins/catalog.js";
 
-const listChannelPluginCatalogEntriesUnfiltered = vi.hoisted(() =>
+const listRawChannelPluginCatalogEntries = vi.hoisted(() =>
   vi.fn((_opts?: unknown): ChannelPluginCatalogEntry[] => []),
 );
 const getChannelPluginCatalogEntry = vi.hoisted(() =>
@@ -16,8 +16,7 @@ const applyPluginAutoEnable = vi.hoisted(() =>
 );
 
 vi.mock("../../channels/plugins/catalog.js", () => ({
-  listChannelPluginCatalogEntriesUnfiltered: (opts?: unknown) =>
-    listChannelPluginCatalogEntriesUnfiltered(opts),
+  listRawChannelPluginCatalogEntries: (opts?: unknown) => listRawChannelPluginCatalogEntries(opts),
   getChannelPluginCatalogEntry: (id?: unknown, opts?: unknown) =>
     getChannelPluginCatalogEntry(id, opts),
 }));
@@ -125,7 +124,7 @@ describe("trusted catalog helpers", () => {
       pluginId: "my-cool-plugin",
       origin: "workspace",
     });
-    listChannelPluginCatalogEntriesUnfiltered.mockImplementation((opts?: unknown) =>
+    listRawChannelPluginCatalogEntries.mockImplementation((opts?: unknown) =>
       (opts as { excludeWorkspace?: boolean } | undefined)?.excludeWorkspace
         ? []
         : [workspaceOnlyEntry],
@@ -146,7 +145,7 @@ describe("trusted catalog helpers", () => {
       pluginId: "my-cool-plugin",
       origin: "workspace",
     });
-    listChannelPluginCatalogEntriesUnfiltered.mockImplementation((opts?: unknown) =>
+    listRawChannelPluginCatalogEntries.mockImplementation((opts?: unknown) =>
       (opts as { excludeWorkspace?: boolean } | undefined)?.excludeWorkspace
         ? []
         : [workspaceOnlyEntry],

--- a/src/commands/channel-setup/trusted-catalog.test.ts
+++ b/src/commands/channel-setup/trusted-catalog.test.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChannelPluginCatalogEntry } from "../../channels/plugins/catalog.js";
+
+const listChannelPluginCatalogEntriesUnfiltered = vi.hoisted(() =>
+  vi.fn((_opts?: unknown): ChannelPluginCatalogEntry[] => []),
+);
+const getChannelPluginCatalogEntry = vi.hoisted(() =>
+  vi.fn((_id?: unknown, _opts?: unknown): ChannelPluginCatalogEntry | undefined => undefined),
+);
+const applyPluginAutoEnable = vi.hoisted(() =>
+  vi.fn(({ config }: { config: unknown }) => ({
+    config: config as never,
+    changes: [] as string[],
+    autoEnabledReasons: {},
+  })),
+);
+
+vi.mock("../../channels/plugins/catalog.js", () => ({
+  listChannelPluginCatalogEntriesUnfiltered: (opts?: unknown) =>
+    listChannelPluginCatalogEntriesUnfiltered(opts),
+  getChannelPluginCatalogEntry: (id?: unknown, opts?: unknown) =>
+    getChannelPluginCatalogEntry(id, opts),
+}));
+
+vi.mock("../../config/plugin-auto-enable.js", () => ({
+  applyPluginAutoEnable: (args: unknown) =>
+    applyPluginAutoEnable(args as { config: unknown; env?: NodeJS.ProcessEnv }),
+}));
+
+import {
+  getTrustedChannelPluginCatalogEntry,
+  listSetupDiscoveryChannelPluginCatalogEntries,
+  listTrustedChannelPluginCatalogEntries,
+} from "./trusted-catalog.js";
+
+function createCatalogEntry(params: {
+  id: string;
+  pluginId: string;
+  origin?: "workspace" | "bundled";
+}): ChannelPluginCatalogEntry {
+  return {
+    id: params.id,
+    pluginId: params.pluginId,
+    origin: params.origin,
+    meta: {
+      id: params.id,
+      label: params.id,
+      selectionLabel: params.id,
+      docsPath: `/channels/${params.id}`,
+      blurb: `${params.id} channel`,
+    },
+    install: {
+      npmSpec: params.pluginId,
+    },
+  };
+}
+
+describe("trusted catalog helpers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    applyPluginAutoEnable.mockImplementation(({ config }: { config: unknown }) => ({
+      config: config as never,
+      changes: [] as string[],
+      autoEnabledReasons: {},
+    }));
+  });
+
+  it("falls back to the bundled entry for an untrusted workspace shadow", () => {
+    const workspaceEntry = createCatalogEntry({
+      id: "telegram",
+      pluginId: "evil-telegram-shadow",
+      origin: "workspace",
+    });
+    const bundledEntry = createCatalogEntry({
+      id: "telegram",
+      pluginId: "telegram",
+      origin: "bundled",
+    });
+    getChannelPluginCatalogEntry
+      .mockReturnValueOnce(workspaceEntry)
+      .mockReturnValueOnce(bundledEntry);
+
+    const result = getTrustedChannelPluginCatalogEntry("telegram", {
+      cfg: {} as never,
+      workspaceDir: "/tmp/workspace",
+      env: process.env,
+    });
+
+    expect(result?.pluginId).toBe("telegram");
+    expect(getChannelPluginCatalogEntry).toHaveBeenNthCalledWith(1, "telegram", {
+      workspaceDir: "/tmp/workspace",
+    });
+    expect(getChannelPluginCatalogEntry).toHaveBeenNthCalledWith(2, "telegram", {
+      workspaceDir: "/tmp/workspace",
+      excludeWorkspace: true,
+    });
+  });
+
+  it("keeps trusted workspace overrides eligible", () => {
+    const workspaceEntry = createCatalogEntry({
+      id: "telegram",
+      pluginId: "trusted-telegram-shadow",
+      origin: "workspace",
+    });
+    getChannelPluginCatalogEntry.mockReturnValue(workspaceEntry);
+
+    const result = getTrustedChannelPluginCatalogEntry("telegram", {
+      cfg: {
+        plugins: {
+          enabled: true,
+          allow: ["trusted-telegram-shadow"],
+        },
+      } as never,
+      workspaceDir: "/tmp/workspace",
+      env: process.env,
+    });
+
+    expect(result?.pluginId).toBe("trusted-telegram-shadow");
+    expect(getChannelPluginCatalogEntry).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits untrusted workspace-only entries from the trusted list", () => {
+    const workspaceOnlyEntry = createCatalogEntry({
+      id: "my-cool-plugin",
+      pluginId: "my-cool-plugin",
+      origin: "workspace",
+    });
+    listChannelPluginCatalogEntriesUnfiltered.mockImplementation((opts?: unknown) =>
+      (opts as { excludeWorkspace?: boolean } | undefined)?.excludeWorkspace
+        ? []
+        : [workspaceOnlyEntry],
+    );
+
+    const result = listTrustedChannelPluginCatalogEntries({
+      cfg: {} as never,
+      workspaceDir: "/tmp/workspace",
+      env: process.env,
+    });
+
+    expect(result).toEqual([]);
+  });
+
+  it("keeps workspace-only install candidates visible in discovery", () => {
+    const workspaceOnlyEntry = createCatalogEntry({
+      id: "my-cool-plugin",
+      pluginId: "my-cool-plugin",
+      origin: "workspace",
+    });
+    listChannelPluginCatalogEntriesUnfiltered.mockImplementation((opts?: unknown) =>
+      (opts as { excludeWorkspace?: boolean } | undefined)?.excludeWorkspace
+        ? []
+        : [workspaceOnlyEntry],
+    );
+
+    const result = listSetupDiscoveryChannelPluginCatalogEntries({
+      cfg: {} as never,
+      workspaceDir: "/tmp/workspace",
+      env: process.env,
+    });
+
+    expect(result.map((entry) => entry.pluginId)).toEqual(["my-cool-plugin"]);
+  });
+
+  it("treats auto-enabled workspace plugins as trusted", () => {
+    const workspaceEntry = createCatalogEntry({
+      id: "telegram",
+      pluginId: "trusted-telegram-shadow",
+      origin: "workspace",
+    });
+    getChannelPluginCatalogEntry.mockReturnValue(workspaceEntry);
+    applyPluginAutoEnable.mockImplementation(({ config }: { config: unknown }) => ({
+      config: {
+        ...(config as Record<string, unknown>),
+        plugins: {
+          enabled: true,
+          allow: ["trusted-telegram-shadow"],
+        },
+      } as never,
+      changes: ["trusted-telegram-shadow"] as string[],
+      autoEnabledReasons: {
+        "trusted-telegram-shadow": ["channel configured"],
+      },
+    }));
+
+    const result = getTrustedChannelPluginCatalogEntry("telegram", {
+      cfg: {
+        channels: {
+          telegram: { token: "existing-token" },
+        },
+      } as never,
+      workspaceDir: "/tmp/workspace",
+      env: process.env,
+    });
+
+    expect(result?.pluginId).toBe("trusted-telegram-shadow");
+    expect(getChannelPluginCatalogEntry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/commands/channel-setup/trusted-catalog.ts
+++ b/src/commands/channel-setup/trusted-catalog.ts
@@ -1,6 +1,6 @@
 import {
   getChannelPluginCatalogEntry,
-  listChannelPluginCatalogEntries,
+  listChannelPluginCatalogEntriesUnfiltered,
   type ChannelPluginCatalogEntry,
 } from "../../channels/plugins/catalog.js";
 import { applyPluginAutoEnable } from "../../config/plugin-auto-enable.js";
@@ -61,11 +61,11 @@ function listChannelPluginCatalogEntriesWithTrustedFallback(
   },
   onMissingFallback: (entry: ChannelPluginCatalogEntry) => ChannelPluginCatalogEntry[],
 ): ChannelPluginCatalogEntry[] {
-  const unfiltered = listChannelPluginCatalogEntries({
+  const unfiltered = listChannelPluginCatalogEntriesUnfiltered({
     workspaceDir: params.workspaceDir,
   });
   const fallbackById = new Map(
-    listChannelPluginCatalogEntries({
+    listChannelPluginCatalogEntriesUnfiltered({
       workspaceDir: params.workspaceDir,
       excludeWorkspace: true,
     }).map((entry) => [entry.id, entry]),

--- a/src/commands/channel-setup/trusted-catalog.ts
+++ b/src/commands/channel-setup/trusted-catalog.ts
@@ -1,6 +1,6 @@
 import {
   getChannelPluginCatalogEntry,
-  listChannelPluginCatalogEntriesUnfiltered,
+  listRawChannelPluginCatalogEntries,
   type ChannelPluginCatalogEntry,
 } from "../../channels/plugins/catalog.js";
 import { applyPluginAutoEnable } from "../../config/plugin-auto-enable.js";
@@ -61,11 +61,11 @@ function listChannelPluginCatalogEntriesWithTrustedFallback(
   },
   onMissingFallback: (entry: ChannelPluginCatalogEntry) => ChannelPluginCatalogEntry[],
 ): ChannelPluginCatalogEntry[] {
-  const unfiltered = listChannelPluginCatalogEntriesUnfiltered({
+  const unfiltered = listRawChannelPluginCatalogEntries({
     workspaceDir: params.workspaceDir,
   });
   const fallbackById = new Map(
-    listChannelPluginCatalogEntriesUnfiltered({
+    listRawChannelPluginCatalogEntries({
       workspaceDir: params.workspaceDir,
       excludeWorkspace: true,
     }).map((entry) => [entry.id, entry]),

--- a/src/commands/channel-setup/workspace-shadow-bypass.test.ts
+++ b/src/commands/channel-setup/workspace-shadow-bypass.test.ts
@@ -31,6 +31,8 @@ const getChannelPluginCatalogEntry = vi.hoisted(() => vi.fn());
 
 vi.mock("../../channels/plugins/catalog.js", () => ({
   listChannelPluginCatalogEntries: (opts?: unknown) => listChannelPluginCatalogEntries(opts),
+  listChannelPluginCatalogEntriesUnfiltered: (opts?: unknown) =>
+    listChannelPluginCatalogEntries(opts),
   getChannelPluginCatalogEntry: (...args: unknown[]) =>
     getChannelPluginCatalogEntry(...(args as [string, Record<string, unknown>])),
 }));

--- a/src/commands/channel-setup/workspace-shadow-bypass.test.ts
+++ b/src/commands/channel-setup/workspace-shadow-bypass.test.ts
@@ -31,8 +31,7 @@ const getChannelPluginCatalogEntry = vi.hoisted(() => vi.fn());
 
 vi.mock("../../channels/plugins/catalog.js", () => ({
   listChannelPluginCatalogEntries: (opts?: unknown) => listChannelPluginCatalogEntries(opts),
-  listChannelPluginCatalogEntriesUnfiltered: (opts?: unknown) =>
-    listChannelPluginCatalogEntries(opts),
+  listRawChannelPluginCatalogEntries: (opts?: unknown) => listChannelPluginCatalogEntries(opts),
   getChannelPluginCatalogEntry: (...args: unknown[]) =>
     getChannelPluginCatalogEntry(...(args as [string, Record<string, unknown>])),
 }));

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -65,6 +65,7 @@ const bundledMocks = vi.hoisted(() => ({
 vi.mock("../channels/plugins/catalog.js", () => ({
   getChannelPluginCatalogEntry: catalogMocks.getChannelPluginCatalogEntry,
   listChannelPluginCatalogEntries: catalogMocks.listChannelPluginCatalogEntries,
+  listChannelPluginCatalogEntriesUnfiltered: catalogMocks.listChannelPluginCatalogEntries,
 }));
 
 vi.mock("./channel-setup/discovery.js", () => ({

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -65,7 +65,7 @@ const bundledMocks = vi.hoisted(() => ({
 vi.mock("../channels/plugins/catalog.js", () => ({
   getChannelPluginCatalogEntry: catalogMocks.getChannelPluginCatalogEntry,
   listChannelPluginCatalogEntries: catalogMocks.listChannelPluginCatalogEntries,
-  listChannelPluginCatalogEntriesUnfiltered: catalogMocks.listChannelPluginCatalogEntries,
+  listRawChannelPluginCatalogEntries: catalogMocks.listChannelPluginCatalogEntries,
 }));
 
 vi.mock("./channel-setup/discovery.js", () => ({

--- a/src/commands/channels.remove.test.ts
+++ b/src/commands/channels.remove.test.ts
@@ -35,6 +35,7 @@ vi.mock("../channels/plugins/catalog.js", async () => {
   return {
     ...actual,
     listChannelPluginCatalogEntries: catalogMocks.listChannelPluginCatalogEntries,
+    listChannelPluginCatalogEntriesUnfiltered: catalogMocks.listChannelPluginCatalogEntries,
   };
 });
 

--- a/src/commands/channels.remove.test.ts
+++ b/src/commands/channels.remove.test.ts
@@ -35,7 +35,7 @@ vi.mock("../channels/plugins/catalog.js", async () => {
   return {
     ...actual,
     listChannelPluginCatalogEntries: catalogMocks.listChannelPluginCatalogEntries,
-    listChannelPluginCatalogEntriesUnfiltered: catalogMocks.listChannelPluginCatalogEntries,
+    listRawChannelPluginCatalogEntries: catalogMocks.listChannelPluginCatalogEntries,
   };
 });
 

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -66,8 +66,8 @@ async function resolveCatalogChannelEntry(raw: string, cfg: OpenClawConfig | nul
           }),
       )
     : await import("../../channels/plugins/catalog.js").then(
-        ({ listChannelPluginCatalogEntries }) =>
-          listChannelPluginCatalogEntries({ excludeWorkspace: true }),
+        ({ listRawChannelPluginCatalogEntries }) =>
+          listRawChannelPluginCatalogEntries({ excludeWorkspace: true }),
       );
   return entries.find((entry) => {
     if (normalizeOptionalLowercaseString(entry.id) === trimmed) {

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -98,6 +98,7 @@ function writeLegacyNpmDeclarationStub(params: {
 
 vi.mock("../../../channels/plugins/catalog.js", () => ({
   listChannelPluginCatalogEntries: mocks.listChannelPluginCatalogEntries,
+  listRawChannelPluginCatalogEntries: mocks.listChannelPluginCatalogEntries,
 }));
 
 vi.mock("../../../plugins/installed-plugin-index-records.js", () => ({

--- a/src/commands/doctor/shared/missing-configured-plugin-install.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.ts
@@ -5,7 +5,7 @@ import {
   listExplicitlyDisabledChannelIdsForConfig,
   listPotentialConfiguredChannelIds,
 } from "../../../channels/config-presence.js";
-import { listChannelPluginCatalogEntries } from "../../../channels/plugins/catalog.js";
+import { listRawChannelPluginCatalogEntries } from "../../../channels/plugins/catalog.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../../../config/types.plugins.js";
 import { parseClawHubPluginSpec } from "../../../infra/clawhub-spec.js";
@@ -176,7 +176,7 @@ function collectConfiguredChannelIds(cfg: OpenClawConfig, env?: NodeJS.ProcessEn
     return ids;
   }
   const disabled = new Set(listExplicitlyDisabledChannelIdsForConfig(cfg));
-  const candidateChannelIds = listChannelPluginCatalogEntries({
+  const candidateChannelIds = listRawChannelPluginCatalogEntries({
     env,
     excludeWorkspace: true,
   }).map((entry) => entry.id);
@@ -239,7 +239,7 @@ function collectDownloadableInstallCandidates(params: {
     params.configuredChannelIds ?? collectConfiguredChannelIds(params.cfg, params.env);
   const candidates = new Map<string, DownloadableInstallCandidate>();
 
-  for (const entry of listChannelPluginCatalogEntries({
+  for (const entry of listRawChannelPluginCatalogEntries({
     env: params.env,
     excludeWorkspace: true,
   })) {

--- a/src/flows/channel-setup.status.ts
+++ b/src/flows/channel-setup.status.ts
@@ -1,6 +1,6 @@
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { listChatChannels } from "../channels/chat-meta.js";
-import { listChannelPluginCatalogEntries } from "../channels/plugins/catalog.js";
+import type { ChannelPluginCatalogEntry } from "../channels/plugins/catalog.js";
 import { listChannelSetupPlugins } from "../channels/plugins/setup-registry.js";
 import type { ChannelSetupPlugin } from "../channels/plugins/setup-wizard-types.js";
 import type { ChannelMeta } from "../channels/plugins/types.core.js";
@@ -30,8 +30,8 @@ import type { FlowContribution } from "./types.js";
 
 type ChannelStatusSummary = {
   installedPlugins: ChannelSetupPlugin[];
-  catalogEntries: ReturnType<typeof listChannelPluginCatalogEntries>;
-  installedCatalogEntries: ReturnType<typeof listChannelPluginCatalogEntries>;
+  catalogEntries: ChannelPluginCatalogEntry[];
+  installedCatalogEntries: ChannelPluginCatalogEntry[];
   statusByChannel: Map<ChannelChoice, ChannelSetupStatus>;
   statusLines: string[];
 };

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -5309,6 +5309,139 @@ module.exports = {
     ).toBe("disabled");
   });
 
+  it("blocks untrusted setup-only workspace channel plugins when explicitly scoped", () => {
+    useNoBundledPlugins();
+    const marker = path.join(makeTempDir(), "workspace-setup-only-loaded.txt");
+    const { workspaceDir, workspacePluginDir } = writeWorkspacePlugin({
+      id: "workspace-shadow",
+      body: `require("node:fs").writeFileSync(${JSON.stringify(marker)}, "loaded", "utf-8");
+module.exports = {
+  id: "workspace-shadow",
+  register(api) {
+    api.registerChannel({
+      plugin: {
+        id: "workspace-shadow",
+        meta: {
+          id: "workspace-shadow",
+          label: "Workspace Shadow",
+          selectionLabel: "Workspace Shadow",
+          docsPath: "/channels/workspace-shadow",
+          blurb: "workspace shadow",
+        },
+        capabilities: { chatTypes: ["direct"] },
+        config: {
+          listAccountIds: () => [],
+          resolveAccount: () => undefined,
+        },
+        outbound: { deliveryMode: "direct" },
+      },
+    });
+  },
+};`,
+    });
+    fs.writeFileSync(
+      path.join(workspacePluginDir, "openclaw.plugin.json"),
+      JSON.stringify(
+        {
+          id: "workspace-shadow",
+          configSchema: EMPTY_PLUGIN_SCHEMA,
+          channels: ["workspace-shadow"],
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      workspaceDir,
+      includeSetupOnlyChannelPlugins: true,
+      forceSetupOnlyChannelPlugins: true,
+      onlyPluginIds: ["workspace-shadow"],
+      config: {
+        plugins: {
+          enabled: true,
+        },
+      },
+    });
+
+    expect(fs.existsSync(marker)).toBe(false);
+    expect(registry.channelSetups).toHaveLength(0);
+    expect(registry.channels).toHaveLength(0);
+    expect(registry.plugins.find((entry) => entry.id === "workspace-shadow")?.status).toBe(
+      "disabled",
+    );
+  });
+
+  it("keeps trusted setup-only workspace channel plugins available when explicitly scoped", () => {
+    useNoBundledPlugins();
+    const marker = path.join(makeTempDir(), "trusted-workspace-setup-only-loaded.txt");
+    const { workspaceDir, workspacePluginDir } = writeWorkspacePlugin({
+      id: "trusted-workspace-shadow",
+      body: `require("node:fs").writeFileSync(${JSON.stringify(marker)}, "loaded", "utf-8");
+module.exports = {
+  id: "trusted-workspace-shadow",
+  register(api) {
+    api.registerChannel({
+      plugin: {
+        id: "telegram",
+        meta: {
+          id: "telegram",
+          label: "Trusted Workspace Telegram",
+          selectionLabel: "Trusted Workspace Telegram",
+          docsPath: "/channels/telegram",
+          blurb: "trusted workspace telegram",
+        },
+        capabilities: { chatTypes: ["direct"] },
+        config: {
+          listAccountIds: () => [],
+          resolveAccount: () => ({ accountId: "default" }),
+        },
+        outbound: { deliveryMode: "direct" },
+      },
+    });
+  },
+};`,
+    });
+    fs.writeFileSync(
+      path.join(workspacePluginDir, "openclaw.plugin.json"),
+      JSON.stringify(
+        {
+          id: "trusted-workspace-shadow",
+          configSchema: EMPTY_PLUGIN_SCHEMA,
+          channels: ["telegram"],
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      workspaceDir,
+      includeSetupOnlyChannelPlugins: true,
+      forceSetupOnlyChannelPlugins: true,
+      onlyPluginIds: ["trusted-workspace-shadow"],
+      config: {
+        plugins: {
+          enabled: true,
+          allow: ["trusted-workspace-shadow"],
+        },
+      },
+    });
+
+    expect(fs.existsSync(marker)).toBe(true);
+    expect(registry.channelSetups.map((entry) => entry.plugin.meta.label)).toEqual([
+      "Trusted Workspace Telegram",
+    ]);
+    expect(registry.channels).toHaveLength(0);
+    expect(registry.plugins.find((entry) => entry.id === "trusted-workspace-shadow")?.status).toBe(
+      "loaded",
+    );
+  });
+
   it.each([
     {
       name: "uses package setupEntry for selected setup-only channel loads",

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -6048,6 +6048,131 @@ module.exports = {
     });
   });
 
+  it("records a diagnostic when registerChannel throws in the setup-entry path", () => {
+    useNoBundledPlugins();
+    const brokenDir = makeTempDir();
+
+    fs.writeFileSync(
+      path.join(brokenDir, "package.json"),
+      JSON.stringify(
+        {
+          name: "@openclaw/register-channel-throws-test",
+          openclaw: {
+            extensions: ["./index.cjs"],
+            setupEntry: "./setup-entry.cjs",
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(brokenDir, "openclaw.plugin.json"),
+      JSON.stringify(
+        {
+          id: "register-channel-throws-test",
+          configSchema: EMPTY_PLUGIN_SCHEMA,
+          channels: ["register-channel-throws-test"],
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      path.join(brokenDir, "index.cjs"),
+      `module.exports = { id: "register-channel-throws-test", register() {} };`,
+      "utf-8",
+    );
+    // setup-entry.cjs: loadSetupPlugin succeeds, but the returned plugin
+    // has a nested throwing getter on config.listAccountIds that triggers
+    // inside registerChannel -> normalizeRegisteredChannelPlugin.
+    fs.writeFileSync(
+      path.join(brokenDir, "setup-entry.cjs"),
+      `const configObj = {
+  resolveAccount: () => ({ accountId: "default" }),
+};
+Object.defineProperty(configObj, "listAccountIds", {
+  get() { throw new Error("boom: registerChannel exploded"); },
+  enumerable: true,
+  configurable: true,
+});
+module.exports = {
+  kind: "bundled-channel-setup-entry",
+  loadSetupPlugin: () => ({
+    id: "register-channel-throws-test",
+    meta: {
+      id: "register-channel-throws-test",
+      label: "Throws on register",
+      selectionLabel: "Throws on register",
+      docsPath: "/channels/register-throws",
+      blurb: "test channel that throws during registration",
+    },
+    capabilities: { chatTypes: ["direct"] },
+    config: configObj,
+    outbound: { deliveryMode: "direct" },
+  }),
+};`,
+      "utf-8",
+    );
+
+    const healthy = writePlugin({
+      id: "healthy-after-register-throw",
+      filename: "healthy-after-register-throw.cjs",
+      body: `module.exports = { id: "healthy-after-register-throw", register(api) {
+  api.registerChannel({
+    plugin: {
+      id: "healthy-after-register-throw-chat",
+      meta: {
+        id: "healthy-after-register-throw-chat",
+        label: "Healthy After Register Throw",
+        selectionLabel: "Healthy After Register Throw",
+        docsPath: "/channels/healthy-after-register-throw",
+        blurb: "survives sibling registerChannel throw",
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => [],
+        resolveAccount: () => ({ accountId: "default" }),
+      },
+      outbound: { deliveryMode: "direct" },
+    }
+  });
+} };`,
+    });
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      config: {
+        plugins: {
+          enabled: true,
+          load: { paths: [brokenDir, healthy.file] },
+          allow: ["register-channel-throws-test", "healthy-after-register-throw"],
+        },
+      },
+    });
+
+    // The broken plugin should be recorded as a diagnostic, not crash the loop.
+    expectDiagnosticContaining({
+      registry,
+      level: "error",
+      pluginId: "register-channel-throws-test",
+      message: "failed to register setup channel",
+    });
+    // The healthy plugin loaded AFTER the broken one must still be present.
+    const healthyChannel = registry.channels.find(
+      (entry) => entry.plugin.id === "healthy-after-register-throw-chat",
+    );
+    if (!healthyChannel) {
+      throw new Error("expected healthy channel after register throw");
+    }
+    expect(healthyChannel.plugin.meta.label).toBe("Healthy After Register Throw");
+    expect(
+      registry.plugins.find((entry) => entry.id === "healthy-after-register-throw")?.status,
+    ).toBe("loaded");
+  });
+
   it("prefers setupEntry for configured channel loads during startup when opted in", () => {
     expect(
       testing.shouldLoadChannelPluginInSetupRuntime({

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -2337,7 +2337,23 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
               continue;
             }
           }
-          api.registerChannel(mergedSetupPlugin);
+          try {
+            api.registerChannel(mergedSetupPlugin);
+          } catch (err) {
+            recordPluginError({
+              logger,
+              registry,
+              record,
+              seenIds,
+              pluginId,
+              origin: candidate.origin,
+              phase: "load",
+              error: err,
+              logPrefix: `[plugins] ${record.id} failed to register setup channel from ${record.source}: `,
+              diagnosticMessagePrefix: "failed to register setup channel: ",
+            });
+            continue;
+          }
           registry.plugins.push(record);
           seenIds.set(pluginId, candidate.origin);
           continue;

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1918,6 +1918,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         (!enableState.enabled || forceSetupOnlyChannelPlugins);
       const canLoadScopedSetupOnlyChannelPlugin =
         scopedSetupOnlyChannelPluginRequested &&
+        (candidate.origin !== "workspace" || enableState.enabled) &&
         (!requireSetupEntryForSetupOnlyChannelPlugins || Boolean(manifestRecord.setupSource));
       const registrationPlan = resolvePluginRegistrationPlan({
         canLoadScopedSetupOnlyChannelPlugin,

--- a/src/plugins/registry.channel-guard.test.ts
+++ b/src/plugins/registry.channel-guard.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createPluginRegistry } from "./registry.js";
+import type { PluginRuntime } from "./runtime/types.js";
+import { createPluginRecord } from "./status.test-helpers.js";
+
+function createTestRegistry() {
+  return createPluginRegistry({
+    logger: {
+      info() {},
+      warn() {},
+      error() {},
+      debug() {},
+    },
+    runtime: {} as PluginRuntime,
+    activateGlobalSideEffects: false,
+  });
+}
+
+function createChannelPlugin(id: string, label: string): ChannelPlugin {
+  return {
+    id,
+    meta: {
+      id,
+      label,
+      selectionLabel: label,
+      docsPath: `/channels/${id}`,
+      blurb: `${label} channel`,
+    },
+    capabilities: { chatTypes: ["direct"] },
+    config: {
+      listAccountIds: () => [],
+      resolveAccount: () => undefined,
+    },
+    outbound: { deliveryMode: "direct" },
+  };
+}
+
+describe("plugin registry channel guard", () => {
+  it("rejects channel registration from disabled workspace plugins", () => {
+    const pluginRegistry = createTestRegistry();
+    const config = {} as OpenClawConfig;
+    const record = createPluginRecord({
+      id: "workspace-shadow",
+      source: "/plugins/workspace-shadow/index.ts",
+      origin: "workspace",
+      enabled: false,
+    });
+
+    pluginRegistry.registry.plugins.push(record);
+    pluginRegistry.createApi(record, { config, registrationMode: "setup-only" }).registerChannel({
+      plugin: createChannelPlugin("workspace-shadow", "Workspace Shadow"),
+    });
+
+    expect(pluginRegistry.registry.channelSetups).toHaveLength(0);
+    expect(pluginRegistry.registry.channels).toHaveLength(0);
+    expect(record.channelIds).toEqual([]);
+    expect(
+      pluginRegistry.registry.diagnostics.some(
+        (diag) =>
+          diag.level === "warn" &&
+          diag.pluginId === "workspace-shadow" &&
+          diag.message ===
+            "channel registration rejected for disabled workspace plugin: workspace-shadow",
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps channel registration available for trusted workspace plugins", () => {
+    const pluginRegistry = createTestRegistry();
+    const config = {} as OpenClawConfig;
+    const record = createPluginRecord({
+      id: "trusted-workspace-shadow",
+      source: "/plugins/trusted-workspace-shadow/index.ts",
+      origin: "workspace",
+      enabled: true,
+    });
+
+    pluginRegistry.registry.plugins.push(record);
+    pluginRegistry.createApi(record, { config, registrationMode: "setup-only" }).registerChannel({
+      plugin: createChannelPlugin("telegram", "Trusted Workspace Telegram"),
+    });
+
+    expect(pluginRegistry.registry.channelSetups).toHaveLength(1);
+    expect(pluginRegistry.registry.channelSetups[0]).toMatchObject({
+      pluginId: "trusted-workspace-shadow",
+      enabled: true,
+    });
+    expect(pluginRegistry.registry.channelSetups[0]?.plugin.id).toBe("telegram");
+    expect(pluginRegistry.registry.channels).toHaveLength(0);
+    expect(record.channelIds).toEqual(["telegram"]);
+  });
+});

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -913,6 +913,15 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
       return;
     }
     const id = plugin.id;
+    if (record.origin === "workspace" && !record.enabled) {
+      pushDiagnostic({
+        level: "warn",
+        pluginId: record.id,
+        source: record.source,
+        message: `channel registration rejected for disabled workspace plugin: ${id}`,
+      });
+      return;
+    }
     const existingRuntime = registry.channels.find((entry) => entry.plugin.id === id);
     if (registrationCapabilities.runtimeChannel && existingRuntime) {
       if (existingRuntime.pluginId === record.id) {


### PR DESCRIPTION
## Summary

- Problem: latest `main` already keeps execution-facing channel setup discovery on the trusted catalog path, but lower-level setup-only scoped plugin loads could still import and execute disabled workspace channel plugins when callers passed explicit `onlyPluginIds`.
- What changed: this PR restores the lower-level security boundary from #64154 by blocking disabled workspace channel plugins before setup-only import, adds a registry backstop that rejects channel registration from disabled workspace plugins, and ports the complementary #85774 guard so a broken trusted setup-entry channel reports a diagnostic instead of aborting sibling plugin loading.
- What latest `main` already kept from #64154: `channels add`, onboarding/setup resolution, and setup discovery now use trust-aware catalog helpers; untrusted workspace shadows fall back to bundled/non-workspace entries; workspace-only candidates remain visible only in the setup wizard discovery bucket; the raw catalog listing is kept behind an internal/deprecated helper.
- Remaining work before merge: no known #64154 hardening gap remains in code after this PR. The remaining gates are CI plus any maintainer-requested live external-plugin proof.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Replaces/supersedes #64154
- Includes the valuable complementary setup-entry error-isolation fix from #85774
- [x] This PR fixes a bug or regression

## Current Main vs This PR

The #64154 design had two layers:

1. Catalog callers should resolve channels through trusted helpers so setup/add flows do not select untrusted workspace shadows.
2. The loader/registry should enforce the same trust boundary before any plugin module can execute, so lower-level callers cannot bypass the catalog layer.

Latest `main` still preserves the first layer. `channels add`, setup/onboarding, and channel setup plugin resolution use `listTrustedChannelPluginCatalogEntries` / `getTrustedChannelPluginCatalogEntry`; the setup wizard's installable display can still show workspace-only candidates through the lenient discovery helper without treating them as executable/installed.

This PR fills the second layer. It prevents explicit setup-only scoped loads from importing disabled workspace channel plugins, rejects disabled workspace channel registrations at the registry boundary, and keeps trusted workspace overrides working. It also ports #85774's try/catch around `api.registerChannel(mergedSetupPlugin)`, which addresses a related but distinct resilience gap: trusted setup-entry plugins are allowed to load, but one malformed registration should not stop healthy sibling plugins from loading.

## Diagram

```mermaid
graph TD
  SOURCES["Plugin source directories"] --> MANIFEST["Manifest registry<br/>(pluginId + origin + channels)"]

  MANIFEST -->|"setup / onboard / channels add"| TRUSTED["Trusted catalog helpers<br/>strict execution list<br/>untrusted workspace shadows fall back"]
  MANIFEST -->|"setup wizard display"| DISCOVERY["Setup discovery helper<br/>lenient display list<br/>workspace-only candidates visible"]
  MANIFEST -->|"gateway or explicit scoped setup load"| LOADER["loadOpenClawPlugins()"]

  TRUSTED --> SETUP["setup/add snapshot request"]
  DISCOVERY --> UI["installable UI bucket only<br/>not an execution decision"]
  SETUP --> LOADER

  LOADER --> GATE{"This PR:<br/>workspace channel plugin enabled?"}
  GATE -->|"disabled workspace"| BLOCK["reject before setup-only import<br/>no plugin code executes"]
  GATE -->|"trusted workspace or non-workspace"| IMPORT["import setup/runtime entry"]

  IMPORT --> REGISTER{"This PR + #85774:<br/>registerChannel succeeds?"}
  REGISTER -->|"yes"| REGISTRY["snapshot/runtime registry"]
  REGISTER -->|"throws"| DIAG["record plugin diagnostic<br/>continue loading siblings"]

  REGISTRY --> SNAPUSE["validateInput / applyAccountConfig<br/>write config / lifecycle callbacks"]
  REGISTRY --> RUNTIME["gateway/runtime channel lookup"]

  BLOCK:::fixed
  GATE:::fixed
  DIAG:::fixed
  TRUSTED:::kept
  DISCOVERY:::display
  UI:::display

  classDef fixed fill:#d4edda,stroke:#28a745,stroke-width:2px
  classDef kept fill:#d9edf7,stroke:#31708f,stroke-width:2px
  classDef display fill:#fff3cd,stroke:#ffc107,stroke-width:2px
```

The important boundary is now shared: catalog helpers decide which channel catalog entries are trusted for setup/add flows, and the loader/registry enforce the same rule before runtime code can execute. If a trusted setup-entry channel still fails during registration, the error is isolated to that plugin and sibling plugins continue loading.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: untrusted workspace channel plugins should not execute during setup-only scoped loads; disabled workspace channel registrations should be rejected at registry assembly; trusted setup-entry channel registration failures should not abort sibling plugin loading.
- Real environment tested: local Linux repo checkout on latest `main` after rebasing this PR.
- Exact steps or command run after this patch:
  - `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/plugins/loader.test.ts -- -t "blocks untrusted setup-only workspace channel plugins|keeps trusted setup-only workspace channel plugins available|records a diagnostic when registerChannel throws in the setup-entry path|keeps healthy sibling channel plugins loadable when a setup entry throws" --reporter=verbose`
  - `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/plugins/registry.channel-guard.test.ts src/commands/channel-setup/trusted-catalog.test.ts src/commands/channels.add.test.ts src/commands/channel-setup/channel-plugin-resolution.test.ts src/commands/channel-setup/discovery.test.ts src/commands/channel-setup/workspace-shadow-bypass.test.ts src/commands/channel-setup/plugin-install.test.ts -- --reporter=verbose`
  - `pnpm check:changed`
  - `pnpm build`
  - `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- Evidence after fix: the targeted loader tests pass for untrusted/trusted workspace setup-only scoped loads and setup-entry `registerChannel` error isolation; the registry/catalog/channel setup tests pass across 65 channel setup cases; `check:changed`, `build`, and autoreview are clean.
- Observed result after fix: disabled workspace shadows no longer execute through scoped setup-only loads; trusted workspace overrides remain available; disabled workspace channel registrations are rejected as a registry backstop; malformed trusted setup-entry channel registration records a diagnostic and sibling plugins keep loading.
- What was not tested: live channel setup against a real external workspace plugin outside the loader test harness.
- Before evidence (optional but encouraged): the same minimal setup-only repro failed on latest `origin/main` before this branch because the marker file was created during scoped setup-only load.

## Root Cause (if applicable)

- Root cause: the scoped setup-only loader path treated explicit `onlyPluginIds` as sufficient to load a disabled workspace channel plugin, so workspace trust was bypassed below the trusted-catalog call sites.
- Missing detection / guardrail: registry assembly still accepted channel registration from disabled workspace plugins if a lower-level caller imported one.
- Complementary #85774 root cause: the setup-entry loader loop caught surrounding registration failures, but `api.registerChannel(mergedSetupPlugin)` itself was unguarded, so one throwing trusted channel registration could abort sibling plugin loading.
- Contributing context: latest `main` already absorbed the higher-level `channels add` / trusted-catalog call-site fixes from #64154, but not this lower-level loader/registry backstop or the setup-entry error-isolation guard.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
- [ ] Unit test
- [x] Seam / integration test
- [ ] End-to-end test
- [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/loader.test.ts`, `src/plugins/registry.channel-guard.test.ts`, `src/commands/channel-setup/trusted-catalog.test.ts`, and existing channel setup/add tests.
- Scenario the test should lock in: explicit scoped setup-only loads must reject disabled workspace channel plugins but keep trusted workspace channel plugins available; registry assembly must reject disabled workspace channel registrations; trusted setup-entry registration errors must be recorded without aborting healthy sibling plugins.
- Why this is the smallest reliable guardrail: the bugs live at loader/registry/catalog boundaries and require real plugin import behavior plus registration-mode assertions.
- Existing test that already covers this (if any): `only setup-loads a disabled channel plugin when the caller scopes to the selected plugin` still covers the non-workspace path.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Untrusted workspace channel shadows no longer execute during setup-only scoped loads.
- Trusted workspace channel plugins remain available to setup-time scoped loading.
- A broken trusted setup-entry channel registration now surfaces as a plugin diagnostic instead of stopping sibling plugin loading.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 local repo checkout
- Model/provider: N/A
- Integration/channel (if any): plugin loader / channel plugin registry / channel setup catalog
- Relevant config (redacted): workspace plugins enabled; untrusted plugin omitted from allowlist

### Steps

1. Create a workspace channel plugin fixture with `channels` metadata and a side-effect marker write in `register()`.
2. Load it through `loadOpenClawPlugins({ includeSetupOnlyChannelPlugins: true, forceSetupOnlyChannelPlugins: true, onlyPluginIds: [...] })`.
3. Compare disabled workspace behavior against trusted workspace behavior.
4. Load a setup-entry channel whose channel config getter throws during `registerChannel` alongside a healthy sibling plugin.

### Expected

- Disabled workspace channel plugin stays disabled and does not execute.
- Trusted workspace channel plugin remains available to setup-only loading.
- A throwing trusted setup-entry channel records a diagnostic and does not prevent sibling plugins from loading.

### Actual

- This branch matches the expected behavior.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets in test output
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: untrusted/trusted workspace scoped setup-only regressions, disabled workspace registry guard, trusted-catalog filtering semantics, `channels add` workspace shadow fallback, #85774 setup-entry `registerChannel` error isolation, `pnpm check:changed`, `pnpm build`, autoreview.
- Edge cases checked: trusted workspace override still loads in setup-only mode; non-workspace disabled plugin behavior stays unchanged; setup wizard discovery still keeps workspace-only install candidates visible without treating them as installed/executable.
- What you did **not** verify: a live end-to-end channel setup outside the loader test harness.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a trusted workspace plugin could accidentally get blocked if the trust check were too broad.
- Mitigation: regression coverage explicitly keeps the trusted workspace scoped-load path green.
- Risk: setup discovery could accidentally hide workspace-only install candidates.
- Mitigation: trusted-catalog and discovery tests keep the strict execution list separate from the lenient setup wizard display list.


### Proof 1: Pre-Fix Reproduction on origin/main

- Behavior addressed: Untrusted workspace channel plugin (evi1-channel-probe) executes its register() function via the setup-only scoped load path when includeSetupOnlyChannelPlugins: true is passed to loadOpenClawPlugins, bypassing the trust boundary.
- Real environment tested: Crabbox docker, provider=docker, container=391883b7652bcb464c523f64ddcabb9bcad47f92e434737b7cc5391f7bc0922f, run=cbx_6dadb5d505eb, checkout SHA=ead847f6065ac36031f9e7a95dd1ee90f171f79c (origin/main)
- Exact steps or command run after this patch: (1) `git fetch --depth=1 origin main && git checkout FETCH_HEAD` inside Crabbox container; (2) `pnpm install --frozen-lockfile && pnpm build`; (3) Deploy evi1-channel-probe plugin to /tmp/proof1-workspace/.openclaw/extensions/evi1-channel-probe/; (4) Confirm /tmp/openclaw-marker-evidence absent; (5) Run `node probe-untrusted.mjs` with onlyPluginIds=["evi1-channel-probe"], includeSetupOnlyChannelPlugins=true, activate=false, cache=false; (6) Check /tmp/openclaw-marker-evidence existence.
- Evidence after fix: Marker file /tmp/openclaw-marker-evidence CREATED with content "evi1-probe-executed\n". Plugin status="disabled" with channelSetups=[{id:"evi1-channel-probe"}] — the setup-only path imported and executed the untrusted workspace plugin code.
- Observed result after fix: On origin/main (pre-fix), the untrusted workspace channel plugin code ran despite being disabled. The plugin appeared in channelSetups (not channels), status was "disabled", yet register() executed and created the marker file. This confirms the bypass vulnerability.
- What was not tested: CLI blackbox path, real channels add flow

### Proof 2: Post-Fix Verification on PR Head

- Behavior addressed: The PR fix blocks untrusted workspace channel plugins from executing during setup-only scoped loads; disabled workspace channel registrations are rejected at registry assembly; trusted workspace plugins with plugins.allow still work; broken trusted setup-entry registerChannel records a diagnostic without aborting sibling plugins.
- Real environment tested: Crabbox docker, provider=docker, container=df29879e2faef7ac8794cba519c1988aff410316a3718d90c6f638cd9977ce15, lease=cbx_0f687f5da081, checkout SHA=b05a7b14fe9bd6c119b3b7fe60a1967d0987804c (PR #82579 head)
- Exact steps or command run after this patch: (1) `git fetch origin pull/82579/head:pr-head && git checkout pr-head` inside Crabbox container; (2) `pnpm install --frozen-lockfile && pnpm build`; (3) `grep -r "channel registration rejected for disabled workspace plugin" dist/` — fix code found in dist/loader-DM-dphfh.js; (4) Deploy evi1-channel-probe (untrusted), confirm marker ABSENT after probe; (5) Deploy evi1-trusted-probe (with plugins.allow), confirm marker EXISTS; (6) Deploy evi1-broken-register + evi1-sibling-probe (with plugins.allow), confirm sibling marker EXISTS and diagnostic recorded; (7) Run focused tests: `pnpm test src/plugins/loader.test.ts` (142 pass), `pnpm test src/plugins/registry.channel-guard.test.ts` (2 pass), `pnpm test src/commands/channel-setup/trusted-catalog.test.ts` (5 pass), `pnpm test src/commands/channel-setup/workspace-shadow-bypass.test.ts` (6 pass); (8) `pnpm check:changed` — 0 errors.
- Evidence after fix: Untrusted probe: MARKER_ABSENT, exit code 0 (clean block, not crash). Plugin status="disabled", channelSetups=[]. Trusted probe: MARKER_EXISTS, content "evi1-probe-executed\n". Plugin status="loaded", channels and channelSetups populated. Error isolation: broken-register records diagnostic (level=error, pluginId=evi1-broken-register), process exit code 0. Sibling marker EXISTS, content "evi1-sibling-probe-executed\n".
- Observed result after fix: The fix blocks untrusted workspace channel plugin execution. Untrusted plugin stays disabled with empty channelSetups. Trusted workspace plugin with plugins.allow still loads and registers channels. Broken trusted registerChannel records a diagnostic and sibling plugins continue loading. All focused tests pass.
- What was not tested: CLI blackbox path, real channels add flow, 3 pre-existing test failures in channel-auth.test.ts (2) and channels.remove.test.ts (1) unrelated to this PR

Crabbox cross-reference: Proof 1 provider=docker, container=391883b7652bcb464c523f64ddcabb9bcad47f92e434737b7cc5391f7bc0922f, run=cbx_6dadb5d505eb, SHA=ead847f6065ac36031f9e7a95dd1ee90f171f79c (origin/main). Proof 2 provider=docker, container=df29879e2faef7ac8794cba519c1988aff410316a3718d90c6f638cd9977ce15, lease=cbx_0f687f5da081, SHA=b05a7b14fe9bd6c119b3b7fe60a1967d0987804c (PR #82579 head). Proof 1 SHA (ead847f6) is an ancestor of Proof 2 SHA (b05a7b14fe) via the main branch lineage. Probe infrastructure file SHA-256 hashes are identical between both proofs (VAL-CROSS-01 confirmed).
