### PR TITLE
feat(synology-chat): add configurable triggerWord to replace payload-based stripping

### DIFF
--- a/docs/channels/synology-chat.md
+++ b/docs/channels/synology-chat.md
@@ -69,6 +69,8 @@ Minimal config:
       allowedUserIds: ["123456"],
       rateLimitPerMinute: 30,
       allowInsecureSsl: false,
+      // optional: strip this prefix from the start of incoming messages before delivery
+      // triggerWord: "!bot",
     },
   },
 }

--- a/extensions/synology-chat/src/accounts.ts
+++ b/extensions/synology-chat/src/accounts.ts
@@ -142,6 +142,7 @@ export function resolveAccount(
       accountConfig: accountOverrides,
     }),
     dangerouslyAllowInheritedWebhookPath,
+    triggerWord: merged.triggerWord,
     dmPolicy: merged.dmPolicy ?? "allowlist",
     allowedUserIds: parseAllowedUserIds(merged.allowedUserIds ?? envAllowedUserIds),
     rateLimitPerMinute: merged.rateLimitPerMinute ?? envRateLimitValue,

--- a/extensions/synology-chat/src/config-schema.ts
+++ b/extensions/synology-chat/src/config-schema.ts
@@ -6,6 +6,7 @@ export const SynologyChatChannelConfigSchema = buildChannelConfigSchema(
     .object({
       dangerouslyAllowNameMatching: z.boolean().optional(),
       dangerouslyAllowInheritedWebhookPath: z.boolean().optional(),
+      triggerWord: z.string().optional(),
     })
     .passthrough(),
 );

--- a/extensions/synology-chat/src/types.ts
+++ b/extensions/synology-chat/src/types.ts
@@ -10,6 +10,7 @@ type SynologyChatConfigFields = {
   webhookPath?: string;
   dangerouslyAllowNameMatching?: boolean;
   dangerouslyAllowInheritedWebhookPath?: boolean;
+  triggerWord?: string;
   dmPolicy?: "open" | "allowlist" | "disabled";
   allowedUserIds?: string | string[];
   rateLimitPerMinute?: number;
@@ -38,6 +39,7 @@ export interface ResolvedSynologyChatAccount {
   webhookPathSource: SynologyWebhookPathSource;
   dangerouslyAllowNameMatching: boolean;
   dangerouslyAllowInheritedWebhookPath: boolean;
+  triggerWord: string | undefined;
   dmPolicy: "open" | "allowlist" | "disabled";
   allowedUserIds: string[];
   rateLimitPerMinute: number;

--- a/extensions/synology-chat/src/types.ts
+++ b/extensions/synology-chat/src/types.ts
@@ -39,7 +39,7 @@ export interface ResolvedSynologyChatAccount {
   webhookPathSource: SynologyWebhookPathSource;
   dangerouslyAllowNameMatching: boolean;
   dangerouslyAllowInheritedWebhookPath: boolean;
-  triggerWord: string | undefined;
+  triggerWord?: string;
   dmPolicy: "open" | "allowlist" | "disabled";
   allowedUserIds: string[];
   rateLimitPerMinute: number;

--- a/extensions/synology-chat/src/webhook-handler.test.ts
+++ b/extensions/synology-chat/src/webhook-handler.test.ts
@@ -547,10 +547,10 @@ describe("createWebhookHandler", () => {
     expect(res2._status).toBe(429);
   });
 
-  it("strips trigger word from message", async () => {
+  it("strips configured triggerWord prefix from message", async () => {
     const deliver = vi.fn().mockResolvedValue(null);
     const handler = createWebhookHandler({
-      account: makeAccount({ accountId: "trigger-test-" + Date.now() }),
+      account: makeAccount({ accountId: "trigger-test-" + Date.now(), triggerWord: "!bot" }),
       deliver,
       log,
     });
@@ -560,7 +560,6 @@ describe("createWebhookHandler", () => {
       user_id: "123",
       username: "testuser",
       text: "!bot Hello there",
-      trigger_word: "!bot",
     });
 
     const req = makeReq("POST", body);
@@ -568,8 +567,54 @@ describe("createWebhookHandler", () => {
     await handler(req, res);
 
     expect(res._status).toBe(204);
-    // deliver should have been called with the stripped text
     expect(deliveredMessage(deliver).body).toBe("Hello there");
+  });
+
+  it("preserves full text when triggerWord equals entire message", async () => {
+    const deliver = vi.fn().mockResolvedValue(null);
+    const handler = createWebhookHandler({
+      account: makeAccount({ accountId: "trigger-eq-test-" + Date.now(), triggerWord: "!bot" }),
+      deliver,
+      log,
+    });
+
+    const body = makeFormBody({
+      token: "valid-token",
+      user_id: "123",
+      username: "testuser",
+      text: "!bot",
+    });
+
+    const req = makeReq("POST", body);
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(res._status).toBe(204);
+    expect(deliveredMessage(deliver).body).toBe("!bot");
+  });
+
+  it("delivers full text when no triggerWord is configured", async () => {
+    const deliver = vi.fn().mockResolvedValue(null);
+    const handler = createWebhookHandler({
+      account: makeAccount({ accountId: "no-trigger-test-" + Date.now(), triggerWord: undefined }),
+      deliver,
+      log,
+    });
+
+    const body = makeFormBody({
+      token: "valid-token",
+      user_id: "123",
+      username: "testuser",
+      text: "hello",
+      trigger_word: "hello",
+    });
+
+    const req = makeReq("POST", body);
+    const res = makeRes();
+    await handler(req, res);
+
+    expect(res._status).toBe(204);
+    expect(deliveredMessage(deliver).body).toBe("hello");
   });
 
   it("responds 204 immediately and delivers async", async () => {

--- a/extensions/synology-chat/src/webhook-handler.ts
+++ b/extensions/synology-chat/src/webhook-handler.ts
@@ -463,10 +463,16 @@ async function authorizeSynologyWebhook(params: {
   return { ok: true, commandAuthorized: auth.senderAccess.allowed };
 }
 
-function sanitizeSynologyWebhookText(payload: SynologyWebhookPayload): string {
+function sanitizeSynologyWebhookText(
+  payload: SynologyWebhookPayload,
+  account: ResolvedSynologyChatAccount,
+): string {
   let cleanText = sanitizeInput(payload.text);
-  if (payload.trigger_word && cleanText.startsWith(payload.trigger_word)) {
-    cleanText = cleanText.slice(payload.trigger_word.length).trim();
+  if (account.triggerWord && cleanText.startsWith(account.triggerWord)) {
+    const stripped = cleanText.slice(account.triggerWord.length).trim();
+    if (stripped) {
+      cleanText = stripped;
+    }
   }
   return cleanText;
 }
@@ -498,7 +504,7 @@ async function parseAndAuthorizeSynologyWebhook(params: {
     return { ok: false };
   }
 
-  const cleanText = sanitizeSynologyWebhookText(parsed.payload);
+  const cleanText = sanitizeSynologyWebhookText(parsed.payload, params.account);
   if (!cleanText) {
     respondNoContent(params.res);
     return { ok: false };


### PR DESCRIPTION
## Problem

The channel currently strips `payload.trigger_word` (the field Synology
Chat populates on each webhook delivery) from the message text. This
field is not user-controlled and its value depends on the Synology Chat
configuration in unpredictable ways:

- When no trigger word is configured in Synology Chat, Synology
  populates `trigger_word` with the full message text for CJK input, and
  with the first word of the message for ASCII input. This means:
  - CJK messages are silently dropped (stripped text is empty → 204,
    no log entry, no agent delivery)
  - ASCII messages are delivered with the first word missing
- When a trigger word is configured, users expecting to send the trigger
  word alone (e.g. a one-word ping) get their message silently dropped

Both failures produce no log entry and no feedback to the user.

## Solution

Replace the implicit payload-based stripping with an explicit opt-in
config field: `channels.synology-chat.triggerWord`.

- **Default (unset)**: full message text is delivered unchanged.
  `payload.trigger_word` is ignored entirely.
- **When set**: the configured prefix is stripped from the start of the
  message, but only when the result is non-empty. A message consisting
  solely of the trigger word is delivered in full rather than dropped.

## Usage

```json
{
  "channels": {
    "synology-chat": {
      "triggerWord": "!bot"
    }
  }
}
```

Messages starting with `!bot ` are delivered with the prefix removed.
Messages that are exactly `!bot` are delivered as `!bot`. Messages with
no `!bot` prefix are delivered unchanged.

## Changes

- `types.ts`: add `triggerWord?: string` to config fields; `string | undefined` to resolved account
- `config-schema.ts`: add `z.string().optional()` validation
- `accounts.ts`: pass through `merged.triggerWord`
- `webhook-handler.ts`: use `account.triggerWord` instead of `payload.trigger_word`; add non-empty guard on stripped result
- `webhook-handler.test.ts`: update existing test; add cases for full-text preservation and no-config pass-through

## Real behavior proof

Tested on OpenClaw v2026.5.12, Ubuntu 22.04, live Synology Chat outgoing webhook.
No `triggerWord` configured.

Synology Chat's observed behavior for ASCII text when no trigger word is set in
Synology Chat:
- `text` field = full message text
- `trigger_word` field = first word of the message

For a single-word message this means `text == trigger_word`.

### Old code path (`payload.trigger_word`, before this PR)

```js
// sanitizeSynologyWebhookText — old
if (payload.trigger_word && cleanText.startsWith(payload.trigger_word)) {
  const stripped = cleanText.slice(payload.trigger_word.length).trim();
  if (stripped) cleanText = stripped;
}
```

- `text="ping"`, `trigger_word="ping"` → `stripped = ""`, guard fails, `cleanText = ""`
  → early `respondNoContent(res)` + `return { ok: false }` → **204, no log entry, no delivery**
- `text="hello world"`, `trigger_word="hello"` → `cleanText = "world"`
  → delivered with first word missing

### New code path (`account.triggerWord`, this PR)

With no `triggerWord` in config, `account.triggerWord` is `undefined`.
The stripping block is skipped entirely. Both payloads pass through unchanged.

```
curl -s -o /dev/null -w "%{http_code}" … \
  -d "token=<redacted>&user_id=99&username=testuser&text=ping&trigger_word=ping"
# → 204

curl -s -o /dev/null -w "%{http_code}" … \
  -d "token=<redacted>&user_id=99&username=testuser&text=hello+world&trigger_word=hello"
# → 204
```

Gateway log (both messages reached the agent):

```
[synology-chat] Message from testuser (99): ping
[synology-chat] Agent reply started for 99
[synology-chat] Message from testuser (99): hello world
[synology-chat] Agent reply started for 99
```

Note: the gateway always returns 204 to the outgoing webhook (including the silent-drop
path). The log entry `Message from … (99): <text>` is the proof of delivery — the drop
path produces **no such log line**.