### PR TITLE
test: mock channel catalog in command account tests

### DIFF
--- a/src/commands/channels.adds-non-default-telegram-account.test.ts
+++ b/src/commands/channels.adds-non-default-telegram-account.test.ts
@@ -14,7 +14,16 @@ import { baseConfigSnapshot, createTestRuntime } from "./test-runtime-config-hel
 
 const runtime = createTestRuntime();
 let minimalChannelsCommandRegistry: ReturnType<typeof createTestRegistry>;
+const catalogMocks = vi.hoisted(() => ({
+  getChannelPluginCatalogEntry: vi.fn(() => undefined),
+  listChannelPluginCatalogEntries: vi.fn(() => []),
+}));
 const createClackPrompterMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../channels/plugins/catalog.js", () => ({
+  getChannelPluginCatalogEntry: catalogMocks.getChannelPluginCatalogEntry,
+  listChannelPluginCatalogEntries: catalogMocks.listChannelPluginCatalogEntries,
+}));
 
 vi.mock("../wizard/clack-prompter.js", () => ({
   createClackPrompter: createClackPrompterMock,
@@ -325,6 +334,8 @@ describe("channels command", () => {
   });
 
   beforeEach(() => {
+    catalogMocks.getChannelPluginCatalogEntry.mockClear();
+    catalogMocks.listChannelPluginCatalogEntries.mockClear();
     configMocks.readConfigFileSnapshot.mockClear();
     configMocks.writeConfigFile.mockClear();
     secretMocks.resolveCommandConfigWithSecrets.mockClear();


### PR DESCRIPTION
## Summary

- Mock the channel plugin catalog in the channel account command tests.
- Keep these tests on their in-memory channel plugin registry instead of doing real catalog discovery.
- Cuts the affected signal account repro from ~78s of test time to milliseconds and the full file to ~1.5s.

## Verification

- `node scripts/run-vitest.mjs src/commands/channels.adds-non-default-telegram-account.test.ts -t "adds a second signal account with a distinct name" --testTimeout 120000 --reporter verbose`
- `node scripts/run-vitest.mjs src/commands/channels.adds-non-default-telegram-account.test.ts --testTimeout 120000 --reporter verbose`
- `git diff --check`

## Real behavior proof

Behavior addressed: CI timeout in `checks-node-agentic-commands-agent-channel` while running the channel account command tests.
Real environment tested: Local macOS OpenClaw worktree using the repo Vitest wrapper.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/commands/channels.adds-non-default-telegram-account.test.ts --testTimeout 120000 --reporter verbose`
Evidence after fix: Terminal output from the focused before/after repro and full-file run:

```text
Before this patch, focused repro on the same test:
✓ adds a second signal account with a distinct name 77829ms
Duration 78.98s (transform 545ms, setup 92ms, import 965ms, tests 77.83s)

After this patch, focused repro:
✓ adds a second signal account with a distinct name 21ms
Duration 2.53s (transform 1.74s, setup 236ms, import 2.17s, tests 22ms)

After this patch, full affected file:
Test Files  1 passed (1)
Tests  20 passed (20)
Duration  1.50s (transform 715ms, setup 102ms, import 1.11s, tests 187ms)
```

Observed result after fix: The command-account test file no longer performs real channel catalog discovery and completes the full affected file in 1.50s locally.
What was not tested: Full GitHub CI has not completed yet.
