### PR TITLE
fix(github-copilot): guard device flow fetches

### DIFF
--- a/extensions/github-copilot/login.ts
+++ b/extensions/github-copilot/login.ts
@@ -7,11 +7,13 @@ import {
   upsertAuthProfileWithLock,
 } from "openclaw/plugin-sdk/provider-auth";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime";
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 
 const CLIENT_ID = "Iv1.b507a08c87ecfe98";
 const DEVICE_CODE_URL = "https://github.com/login/device/code";
 const ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token";
 const GITHUB_DEVICE_VERIFICATION_URL = "https://github.com/login/device";
+const GITHUB_DEVICE_FLOW_SSRF_POLICY = { allowedHostnames: ["github.com"] };
 
 type DeviceCodeResponse = {
   device_code: string;
@@ -71,26 +73,46 @@ function parseJsonResponse(value: unknown): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
+async function postGitHubDeviceFlowJson<T>(
+  url: string,
+  body: URLSearchParams,
+  failurePrefix: string,
+): Promise<T> {
+  const { response, release } = await fetchWithSsrFGuard({
+    url,
+    policy: GITHUB_DEVICE_FLOW_SSRF_POLICY,
+    auditContext: "github-copilot-device-flow",
+    init: {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body,
+    },
+  });
+
+  try {
+    if (!response.ok) {
+      throw new Error(`${failurePrefix}: HTTP ${response.status}`);
+    }
+    return parseJsonResponse(await response.json()) as T;
+  } finally {
+    await release();
+  }
+}
+
 async function requestDeviceCode(params: { scope: string }): Promise<DeviceCodeResponse> {
   const body = new URLSearchParams({
     client_id: CLIENT_ID,
     scope: params.scope,
   });
 
-  const res = await fetch(DEVICE_CODE_URL, {
-    method: "POST",
-    headers: {
-      Accept: "application/json",
-      "Content-Type": "application/x-www-form-urlencoded",
-    },
+  const json = await postGitHubDeviceFlowJson<DeviceCodeResponse>(
+    DEVICE_CODE_URL,
     body,
-  });
-
-  if (!res.ok) {
-    throw new Error(`GitHub device code failed: HTTP ${res.status}`);
-  }
-
-  const json = parseJsonResponse(await res.json()) as DeviceCodeResponse;
+    "GitHub device code failed",
+  );
   if (!json.device_code || !json.user_code || !json.verification_uri) {
     throw new Error("GitHub device code response missing fields");
   }
@@ -109,20 +131,11 @@ async function pollForAccessToken(params: {
   });
 
   while (Date.now() < params.expiresAt) {
-    const res = await fetch(ACCESS_TOKEN_URL, {
-      method: "POST",
-      headers: {
-        Accept: "application/json",
-        "Content-Type": "application/x-www-form-urlencoded",
-      },
-      body: bodyBase,
-    });
-
-    if (!res.ok) {
-      throw new Error(`GitHub device token failed: HTTP ${res.status}`);
-    }
-
-    const json = parseJsonResponse(await res.json()) as DeviceTokenResponse;
+    const json = await postGitHubDeviceFlowJson<DeviceTokenResponse>(
+      ACCESS_TOKEN_URL,
+      bodyBase,
+      "GitHub device token failed",
+    );
     if ("access_token" in json && typeof json.access_token === "string") {
       return json.access_token;
     }


### PR DESCRIPTION
## Summary

- Route the GitHub Copilot device-code and token polling requests through `fetchWithSsrFGuard()`.
- Scope the guarded request policy to `github.com` and release guarded fetch resources after each response body is consumed.
- Fix the current `lint:tmp:no-raw-channel-fetch` failure without expanding the temporary raw-fetch allowlist.

## Verification

- `pnpm run lint:tmp:no-raw-channel-fetch`
- `node scripts/run-vitest.mjs extensions/github-copilot/index.test.ts -t "can refresh an existing token profile during interactive onboarding" --testTimeout 120000 --reporter verbose`
- `pnpm exec oxfmt --check extensions/github-copilot/login.ts --threads=1`
- `git diff --check`

## Real behavior proof

Behavior addressed: GitHub Copilot plugin login used raw `fetch()` calls for GitHub device-flow HTTP requests, causing the channel/plugin raw-fetch boundary check to fail on current main.
Real environment tested: Local macOS OpenClaw worktree using the real boundary script and the GitHub Copilot onboarding test path.
Exact steps or command run after this patch: `pnpm run lint:tmp:no-raw-channel-fetch` and `node scripts/run-vitest.mjs extensions/github-copilot/index.test.ts -t "can refresh an existing token profile during interactive onboarding" --testTimeout 120000 --reporter verbose`
Evidence after fix: Terminal output from the boundary check and focused onboarding run:

```text
$ pnpm run lint:tmp:no-raw-channel-fetch
$ node scripts/check-no-raw-channel-fetch.mjs
exit status: 0; no raw fetch violations reported

$ node scripts/run-vitest.mjs extensions/github-copilot/index.test.ts -t "can refresh an existing token profile during interactive onboarding" --testTimeout 120000 --reporter verbose
✓ github-copilot plugin > can refresh an existing token profile during interactive onboarding 348ms
Test Files  1 passed (1)
Tests  1 passed | 11 skipped (12)
Duration  7.73s (transform 5.13s, setup 221ms, import 7.05s, tests 351ms)
```

Observed result after fix: The raw-fetch boundary command returned exit status 0 with no `extensions/github-copilot/login.ts` violations, and the Copilot interactive refresh path still stored the refreshed token in the focused local run.
What was not tested: Live GitHub browser device-code authorization was not completed; the HTTP exchange remains covered by the existing mocked interactive onboarding path.
