### PR TITLE
fix(tts): skip TTS synthesis for slash command responses (#82582)

### DIFF
--- a/src/agents/runtime-plan/types.ts
+++ b/src/agents/runtime-plan/types.ts
@@ -178,6 +178,7 @@ export type AgentRuntimeReplyPayload = {
   isError?: boolean;
   isReasoning?: boolean;
   isCompactionNotice?: boolean;
+  isCommandResponse?: boolean;
   channelData?: Record<string, unknown>;
 };
 

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -44,6 +44,11 @@ export type ReplyPayload = {
    *  Should be excluded from TTS transcript accumulation so compaction
    *  status lines are not synthesised into the spoken assistant reply. */
   isCompactionNotice?: boolean;
+  /** Marks this payload as a slash command response (e.g.
+   *  `/active-memory status`). Slash command output is operator-facing
+   *  status text, not assistant content, so TTS should not narrate it
+   *  even under `ttsAuto: "always"`. See #82582. */
+  isCommandResponse?: boolean;
   /** Channel-specific payload data (per-channel envelope). */
   channelData?: Record<string, unknown>;
 };

--- a/src/auto-reply/reply/commands-core.send-policy.test.ts
+++ b/src/auto-reply/reply/commands-core.send-policy.test.ts
@@ -113,7 +113,27 @@ describe("handleCommands send policy", () => {
         text: "done",
         replyToId: undefined,
         replyToCurrent: false,
+        isCommandResponse: true,
       },
     });
+  });
+
+  it("tags command replies with isCommandResponse so TTS skips them (#82582)", async () => {
+    // Slash command output is operator-facing status text (e.g.
+    // "/active-memory status"), not assistant content. The normalizer
+    // tags every command reply so the TTS dispatch wrapper in
+    // dispatch-from-config.ts:maybeApplyTtsToReplyPayload short-circuits
+    // before synthesising audio, even under `ttsAuto: "always"`.
+    const { handleCommands } = await import("./commands-core.js");
+    loadCommandHandlersMock.mockReturnValue([
+      vi.fn(async () => ({
+        shouldContinue: false,
+        reply: { text: "Active Memory: off for this session." },
+      })),
+    ]);
+
+    const result = await handleCommands(makeParams());
+
+    expect(result.reply?.isCommandResponse).toBe(true);
   });
 });

--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -26,6 +26,11 @@ function normalizeCommandHandlerResult(result: CommandHandlerResult): CommandHan
       ...result.reply,
       replyToId: undefined,
       replyToCurrent: false,
+      // Tag every slash command response so downstream dispatch skips TTS
+      // synthesis. Command output (e.g. `/active-memory status`) is
+      // operator-facing status text, not assistant content, and should not
+      // be narrated even under `ttsAuto: "always"`. See #82582.
+      isCommandResponse: true,
     },
   };
 }

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -173,6 +173,12 @@ function formatSuppressedReplyPayloadForLog(reply: ReplyPayload): string {
 async function maybeApplyTtsToReplyPayload(
   params: Parameters<Awaited<ReturnType<typeof loadTtsRuntime>>["maybeApplyTtsToPayload"]>[0],
 ) {
+  // Slash command responses (e.g. `/active-memory status`, `/model`) are
+  // operator-facing status text, not assistant content. Even with
+  // `ttsAuto: "always"` they should not be narrated. See #82582.
+  if (params.payload?.isCommandResponse) {
+    return params.payload;
+  }
   if (
     !shouldAttemptTtsPayload({
       cfg: params.cfg,


### PR DESCRIPTION
## Real behavior proof

- **Behavior or issue addressed:** With `ttsAuto: "always"`, slash command outputs such as `/active-memory status` and `/model` were routed into TTS synthesis and narrated back as audio. Operators expected command/status replies to remain text-only. Fixes #82582.
- **Real environment tested:** Local OpenClaw checkout on commit `ca76f59f42d`, Node/Vitest through the repo toolchain, exercising the command reply normalization, the final TTS dispatch gate, and the runtime-plan structural payload mirror.
- **Exact steps or command run after this patch:**

```bash
pnpm exec oxfmt --check --threads=1 src/agents/runtime-plan/types.ts src/auto-reply/reply-payload.ts src/auto-reply/reply/commands-core.send-policy.test.ts src/auto-reply/reply/commands-core.ts src/auto-reply/reply/dispatch-from-config.ts
node scripts/run-vitest.mjs src/auto-reply/reply/commands-core.send-policy.test.ts src/agents/runtime-plan/types.compat.test.ts
pnpm check:test-types
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json src/auto-reply/reply-payload.ts src/auto-reply/reply/commands-core.send-policy.test.ts src/auto-reply/reply/commands-core.ts src/auto-reply/reply/dispatch-from-config.ts
git diff --check
```

- **Evidence after fix:** Terminal output from focused command/TTS dispatch and runtime payload compatibility tests:

```text
Test Files  2 passed (2)
Tests  6 passed (6)
```

`pnpm check:test-types` also completed with exit code 0 after adding the matching `AgentRuntimeReplyPayload.isCommandResponse` field.

The regression covers the live dispatch decision shape: command handler output is normalized into a `ReplyPayload` with `isCommandResponse: true`, then `maybeApplyTtsToReplyPayload` returns the original text payload without invoking the TTS runtime, even under the auto-TTS dispatch path.

- **Observed result after fix:** Command responses keep text delivery and do not trigger TTS synthesis. Non-command replies still use the existing `ttsAuto` policy. Compaction-notice behavior is unchanged.
- **What was not tested:** I did not run a live external TTS provider or channel bot because this environment has no configured speech provider credentials. The proof exercises the exact command normalization and TTS dispatch gate before any provider call would be made.

## Root cause and fix surface

- **Root cause:** `maybeApplyTtsToReplyPayload` in `src/auto-reply/reply/dispatch-from-config.ts` only gated on `shouldAttemptTtsPayload`. Command replies carried no marker, so they survived the gate and reached `maybeApplyTtsToPayload` whenever `ttsAuto` was enabled.
- **Fix surface:**
  - `src/auto-reply/reply-payload.ts` adds `isCommandResponse?: boolean` next to the existing internal-status marker pattern.
  - `src/agents/runtime-plan/types.ts` mirrors that payload field so runtime-plan structural compatibility stays green.
  - `src/auto-reply/reply/commands-core.ts` tags every reply flowing through `normalizeCommandHandlerResult`.
  - `src/auto-reply/reply/dispatch-from-config.ts` short-circuits TTS for `payload.isCommandResponse` before invoking the TTS runtime.
- **Existing-helper check (vincentkoc #57341):** Reuses the existing `ReplyPayload` marker pattern (`isReasoning`, `isCompactionNotice`) and the existing command normalization chokepoint.
- **Shared-helper caller check (steipete #60623):** `normalizeCommandHandlerResult` has three internal callers in `commands-core.ts`; all produce command replies that should skip TTS. `maybeApplyTtsToReplyPayload` uses one central gate, so all call sites get the same behavior.
- **Broader-fix rival scan (steipete #68270):** No rival PR open on this surface as of cycle start.