### PR TITLE
fix(node-host): exit on PAIRING_REQUIRED for systemd restart

### DIFF
--- a/src/node-host/runner.credentials.test.ts
+++ b/src/node-host/runner.credentials.test.ts
@@ -177,27 +177,32 @@ describe("handleNodeHostReconnectPaused", () => {
     ]);
   });
 
-  it("keeps pairing pauses visible without exiting foreground approval flow", () => {
+  it("exits on pairing required so systemd can restart after approval", () => {
     const lines: string[] = [];
     const exit = vi.fn((code: number) => {
       throw new Error(`exit ${code}`);
     }) as (code: number) => never;
 
-    handleNodeHostReconnectPaused(
-      {
-        code: 1008,
-        reason: "connect failed",
-        detailCode: ConnectErrorDetailCodes.PAIRING_REQUIRED,
-      },
-      { writeLine: (line) => lines.push(line), exit },
+    // Node should exit on PAIRING_REQUIRED so systemd can restart it.
+    // After the operator approves the device, the restarted node will connect.
+    expect(shouldExitNodeHostOnReconnectPaused(ConnectErrorDetailCodes.PAIRING_REQUIRED)).toBe(
+      true,
     );
 
-    expect(shouldExitNodeHostOnReconnectPaused(ConnectErrorDetailCodes.PAIRING_REQUIRED)).toBe(
-      false,
-    );
-    expect(exit).not.toHaveBeenCalled();
+    expect(() =>
+      handleNodeHostReconnectPaused(
+        {
+          code: 1008,
+          reason: "connect failed",
+          detailCode: ConnectErrorDetailCodes.PAIRING_REQUIRED,
+        },
+        { writeLine: (line) => lines.push(line), exit },
+      ),
+    ).toThrow("exit 1");
+
+    expect(exit).toHaveBeenCalledWith(1);
     expect(lines).toEqual([
-      "node host gateway reconnect paused after close (1008): connect failed detail=PAIRING_REQUIRED; waiting for operator action",
+      "node host gateway reconnect paused after close (1008): connect failed detail=PAIRING_REQUIRED; exiting for supervisor restart",
     ]);
   });
 });

--- a/src/node-host/runner.ts
+++ b/src/node-host/runner.ts
@@ -72,6 +72,10 @@ const NODE_HOST_EXIT_ON_RECONNECT_PAUSE_CODES: ReadonlySet<string> = new Set([
   ConnectErrorDetailCodes.AUTH_BOOTSTRAP_TOKEN_INVALID,
   ConnectErrorDetailCodes.AUTH_PASSWORD_MISSING,
   ConnectErrorDetailCodes.AUTH_PASSWORD_MISMATCH,
+  // Exit on pairing required so systemd can restart the node. After approval,
+  // the restarted node will connect successfully. Without this, the node would
+  // pause reconnection and never retry after the operator approves it.
+  ConnectErrorDetailCodes.PAIRING_REQUIRED,
 ]);
 
 type NodeHostReconnectPausedDeps = {


### PR DESCRIPTION
## Problem

When a node receives `PAIRING_REQUIRED`, it was previously pausing reconnection indefinitely and waiting for 'operator action'. This caused nodes to hang after being approved:

1. Node connects → gets `PAIRING_REQUIRED` → pauses reconnection
2. Operator approves the device
3. Node never retries connecting because it's waiting
4. Even restarting via systemd didn't help because the new process would also get `PAIRING_REQUIRED` and pause

## Solution

Add `PAIRING_REQUIRED` to `NODE_HOST_EXIT_ON_RECONNECT_PAUSE_CODES`. Now the node exits with code 1 on `PAIRING_REQUIRED`, allowing systemd to restart it. After approval, the restarted node will connect successfully because the device is now in the paired list with a token.

## Testing

This was discovered while debugging integration tests for exec-over-node. The approval happened but the node never reconnected. With this fix, the node exits, systemd restarts it, and the second attempt succeeds because the device is now approved.