### PR TITLE
fix(agents): log detail-less responses failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 - Codex app-server: mark native context compaction completion events as successful, preventing false "Compaction incomplete" notices after successful Codex-managed compaction. Fixes #82470. (#81593) Thanks @Kyzcreig.
 - Gateway/channels: hand off traced channel account startup outside the startup diagnostic phase so long-lived channel tasks do not keep liveness warnings pinned to channel startup. Refs #82398.
 - GitHub Copilot: route device-login requests through the plugin SSRF guard with a GitHub-only policy.
+- Agents/OpenAI Responses: log redacted `response.failed` previews when providers omit error details, preserving response ids and hashed request/provider ids for operator diagnosis. Fixes #82558.
 - Gateway/WebChat: route image attachments through a configured vision-capable `imageModel` plan before inlining images, and carry that image-model fallback chain through runtime retries. (#82524) Thanks @frankekn.
 - WebChat: show progress while manual `/compact` is running by streaming a session operation event to subscribed Control UI clients. Fixes #82407. Thanks @Conan-Scott.
 - Codex app-server: limit canonical OpenAI Codex app-server attribution rewrites to local transcript and trajectory records, leaving runtime/tool routing on the selected OpenAI model metadata so OpenAI API-key backup profiles keep their billing path.

--- a/extensions/github-copilot/index.test.ts
+++ b/extensions/github-copilot/index.test.ts
@@ -18,8 +18,22 @@ import { _setGitHubCopilotDeviceFlowFetchGuardForTesting } from "./login.js";
 
 const mocks = vi.hoisted(() => ({
   githubCopilotLoginCommand: vi.fn(),
+  fetchWithSsrFGuard: vi.fn(async (params: { url: string; init?: RequestInit }) => ({
+    response: await fetch(params.url, params.init),
+    release: vi.fn(async () => {}),
+  })),
   resolveCopilotApiToken: vi.fn(),
 }));
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/ssrf-runtime")>(
+    "openclaw/plugin-sdk/ssrf-runtime",
+  );
+  return {
+    ...actual,
+    fetchWithSsrFGuard: mocks.fetchWithSsrFGuard,
+  };
+});
 
 vi.mock("./register.runtime.js", () => ({
   DEFAULT_COPILOT_API_BASE_URL: "https://api.githubcopilot.test",

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -210,6 +210,33 @@ describe("openai transport stream", () => {
     expect(output.responseId).toBe("resp_failed_runtime");
   });
 
+  it("treats empty Responses error objects as detail-less failures", async () => {
+    const model = createAzureResponsesModel();
+    const output = createResponsesAssistantOutput(model);
+
+    await expect(
+      __testing.processResponsesStream(
+        streamChunks([
+          {
+            type: "response.failed",
+            response: {
+              id: "resp_failed_empty_error",
+              status: "failed",
+              model: "gpt-5.4-pro",
+              error: { code: null, message: null },
+              provider_request_id: "provider_req_empty_error",
+            },
+          },
+        ]),
+        output,
+        { push: vi.fn() },
+        model,
+      ),
+    ).rejects.toThrow("Unknown error (no error details in response)");
+
+    expect(output.responseId).toBe("resp_failed_empty_error");
+  });
+
   it("clamps Responses cached prompt usage at zero", async () => {
     const model = createAzureResponsesModel();
     const output = createResponsesAssistantOutput(model);

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -158,6 +158,9 @@ describe("openai transport stream", () => {
         },
         provider_error: {
           request_id: "provider_error_req_nested_012",
+          headers: {
+            "x-request-id": ["header_req_plaintext_345", "header_req_plaintext_678"],
+          },
         },
       },
     };
@@ -169,7 +172,7 @@ describe("openai transport stream", () => {
     expect(observation.responseId).toBe("resp_failed_123");
     expect(observation.responseStatus).toBe("failed");
     expect(observation.responseModel).toBe("gpt-5.4-pro");
-    expect(observation.requestIdHashes).toHaveLength(4);
+    expect(observation.requestIdHashes).toHaveLength(6);
     expect(observation.requestIdHashes.join(",")).toContain("sha256:");
     expect(summary).toContain("responseId=resp_failed_123");
     expect(summary).toContain("requestIds=");
@@ -177,6 +180,8 @@ describe("openai transport stream", () => {
     expect(JSON.stringify(observation)).not.toContain("provider_req_plaintext_456");
     expect(JSON.stringify(observation)).not.toContain("provider_req_nested_789");
     expect(JSON.stringify(observation)).not.toContain("provider_error_req_nested_012");
+    expect(JSON.stringify(observation)).not.toContain("header_req_plaintext_345");
+    expect(JSON.stringify(observation)).not.toContain("header_req_plaintext_678");
     expect(JSON.stringify(observation)).not.toContain("sk-observation-secret");
   });
 

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -140,6 +140,71 @@ describe("openai transport stream", () => {
     ).rejects.toThrow(/did not deliver a first event within 1ms after HTTP streaming headers/);
   });
 
+  it("observes detail-less Responses failures without leaking request ids", async () => {
+    const model = createAzureResponsesModel();
+    const event = {
+      type: "response.failed",
+      response: {
+        id: "resp_failed_123",
+        status: "failed",
+        model: "gpt-5.4-pro",
+        metadata: {
+          litellm_request_id: "litellm_req_plaintext_123",
+          api_key: "sk-observation-secret",
+        },
+        provider_request_id: "provider_req_plaintext_456",
+        status_details: {
+          provider_request_id: "provider_req_nested_789",
+        },
+        provider_error: {
+          request_id: "provider_error_req_nested_012",
+        },
+      },
+    };
+
+    const observation = __testing.buildResponsesFailedNoDetailsObservation(event, model);
+    const summary = __testing.summarizeResponsesFailedNoDetailsObservation(observation);
+
+    expect(observation.providerRuntimeFailureKind).toBe("no_error_details");
+    expect(observation.responseId).toBe("resp_failed_123");
+    expect(observation.responseStatus).toBe("failed");
+    expect(observation.responseModel).toBe("gpt-5.4-pro");
+    expect(observation.requestIdHashes).toHaveLength(4);
+    expect(observation.requestIdHashes.join(",")).toContain("sha256:");
+    expect(summary).toContain("responseId=resp_failed_123");
+    expect(summary).toContain("requestIds=");
+    expect(JSON.stringify(observation)).not.toContain("litellm_req_plaintext_123");
+    expect(JSON.stringify(observation)).not.toContain("provider_req_plaintext_456");
+    expect(JSON.stringify(observation)).not.toContain("provider_req_nested_789");
+    expect(JSON.stringify(observation)).not.toContain("provider_error_req_nested_012");
+    expect(JSON.stringify(observation)).not.toContain("sk-observation-secret");
+  });
+
+  it("preserves the failed response id before throwing detail-less Responses failures", async () => {
+    const model = createAzureResponsesModel();
+    const output = createResponsesAssistantOutput(model);
+
+    await expect(
+      __testing.processResponsesStream(
+        streamChunks([
+          {
+            type: "response.failed",
+            response: {
+              id: "resp_failed_runtime",
+              status: "failed",
+              model: "gpt-5.4-pro",
+            },
+          },
+        ]),
+        output,
+        { push: vi.fn() },
+        model,
+      ),
+    ).rejects.toThrow("Unknown error (no error details in response)");
+
+    expect(output.responseId).toBe("resp_failed_runtime");
+  });
+
   it("clamps Responses cached prompt usage at zero", async () => {
     const model = createAzureResponsesModel();
     const output = createResponsesAssistantOutput(model);

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -565,6 +565,17 @@ function summarizeResponsesFailedNoDetailsObservation(
   );
 }
 
+function responseFailedErrorMessage(
+  error: { code?: unknown; message?: unknown } | null | undefined,
+): string | undefined {
+  const code = stringifyUnknown(error?.code).trim();
+  const message = stringifyUnknown(error?.message).trim();
+  if (!code && !message) {
+    return undefined;
+  }
+  return `${code || "unknown"}: ${message || "no message"}`;
+}
+
 function summarizeResponsesPayload(params: unknown): string {
   if (!params || typeof params !== "object") {
     return "payload=non-object";
@@ -1157,15 +1168,16 @@ async function processResponsesStream(
       const response = event.response as
         | {
             id?: string;
-            error?: { code?: string; message?: string };
+            error?: { code?: unknown; message?: unknown } | null;
             incomplete_details?: { reason?: string };
           }
         | undefined;
       if (typeof response?.id === "string") {
         output.responseId = response.id;
       }
-      const msg = response?.error
-        ? `${response.error.code || "unknown"}: ${response.error.message || "no message"}`
+      const detailedErrorMessage = responseFailedErrorMessage(response?.error);
+      const msg = detailedErrorMessage
+        ? detailedErrorMessage
         : response?.incomplete_details?.reason
           ? `incomplete: ${response.incomplete_details.reason}`
           : RESPONSE_FAILED_NO_DETAILS_MESSAGE;

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -24,6 +24,7 @@ import type {
   ResponseReasoningItem,
 } from "openai/resources/responses/responses.js";
 import type { ModelCompatConfig } from "../config/types.models.js";
+import { redactIdentifier } from "../logging/redact-identifier.js";
 import { redactSensitiveText } from "../logging/redact.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
@@ -75,6 +76,7 @@ const GEMINI_THOUGHT_SIGNATURE_VALIDATOR_SKIP = "skip_thought_signature_validato
 const AZURE_RESPONSES_FIRST_EVENT_TIMEOUT_MS = 30_000;
 const MODEL_STREAM_COOPERATIVE_YIELD_INTERVAL_MS = 12;
 const MODEL_STREAM_COOPERATIVE_YIELD_MAX_EVENTS = 64;
+const RESPONSE_FAILED_NO_DETAILS_MESSAGE = "Unknown error (no error details in response)";
 const log = createSubsystemLogger("openai-transport");
 
 type ReplayableResponseOutputMessage = Omit<ResponseOutputMessage, "id"> & { id?: string };
@@ -370,6 +372,186 @@ function stringifyRedactedPayload(value: unknown): string {
 function stringifyRedactedEvent(value: unknown): string {
   const redacted = stringifyRedactedPayload(value);
   return redacted.length > 2000 ? `${redacted.slice(0, 2000)}…<truncated>` : redacted;
+}
+
+function readRecordString(record: Record<string, unknown> | undefined, key: string): string {
+  return stringifyUnknown(record?.[key]);
+}
+
+function isResponseFailedIdentifierKey(key: string): boolean {
+  const normalized = key.replace(/[-_\s]/g, "").toLowerCase();
+  return (
+    normalized === "requestid" ||
+    normalized === "xrequestid" ||
+    normalized === "providerrequestid" ||
+    normalized === "providerresponseid" ||
+    normalized === "litellmrequestid" ||
+    (normalized.includes("request") && normalized.endsWith("id")) ||
+    (normalized.includes("provider") && normalized.endsWith("id"))
+  );
+}
+
+function collectResponseFailedIdentifierHashes(
+  value: unknown,
+  opts: {
+    path?: string;
+    depth?: number;
+    out?: string[];
+    seen?: WeakSet<object>;
+  } = {},
+): string[] {
+  const path = opts.path ?? "";
+  const depth = opts.depth ?? 0;
+  const out = opts.out ?? [];
+  const seen = opts.seen ?? new WeakSet<object>();
+  if (out.length >= 12 || depth > 4 || !value || typeof value !== "object") {
+    return out;
+  }
+  if (seen.has(value)) {
+    return out;
+  }
+  seen.add(value);
+  if (Array.isArray(value)) {
+    for (const [index, item] of value.entries()) {
+      if (index >= 8 || out.length >= 12) {
+        break;
+      }
+      collectResponseFailedIdentifierHashes(item, {
+        path: `${path}[${index}]`,
+        depth: depth + 1,
+        out,
+        seen,
+      });
+    }
+    return out;
+  }
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    if (out.length >= 12) {
+      break;
+    }
+    const childPath = path ? `${path}.${key}` : key;
+    const childString =
+      typeof child === "string" || typeof child === "number" ? String(child).trim() : "";
+    if (isResponseFailedIdentifierKey(key) && childString) {
+      out.push(`${childPath}=${redactIdentifier(childString, { len: 12 })}`);
+      continue;
+    }
+    collectResponseFailedIdentifierHashes(child, {
+      path: childPath,
+      depth: depth + 1,
+      out,
+      seen,
+    });
+  }
+  return out;
+}
+
+function redactResponseFailedIdentifierFields(
+  value: unknown,
+  opts: {
+    key?: string;
+    depth?: number;
+    seen?: WeakSet<object>;
+  } = {},
+): unknown {
+  const key = opts.key ?? "";
+  const depth = opts.depth ?? 0;
+  if (typeof value === "string" || typeof value === "number") {
+    return key && isResponseFailedIdentifierKey(key)
+      ? redactIdentifier(String(value), { len: 12 })
+      : value;
+  }
+  if (depth > 6 || !value || typeof value !== "object") {
+    return value;
+  }
+  const seen = opts.seen ?? new WeakSet<object>();
+  if (seen.has(value)) {
+    return "<circular>";
+  }
+  seen.add(value);
+  if (Array.isArray(value)) {
+    return value.slice(0, 16).map((item) =>
+      redactResponseFailedIdentifierFields(item, {
+        depth: depth + 1,
+        seen,
+      }),
+    );
+  }
+  const out: Record<string, unknown> = {};
+  for (const [childKey, child] of Object.entries(value as Record<string, unknown>)) {
+    out[childKey] = redactResponseFailedIdentifierFields(child, {
+      key: childKey,
+      depth: depth + 1,
+      seen,
+    });
+  }
+  return out;
+}
+
+function buildResponsesFailedFailureFields(response: Record<string, unknown> | undefined) {
+  if (!response) {
+    return {};
+  }
+  const fields: Record<string, unknown> = {};
+  for (const key of [
+    "error",
+    "incomplete_details",
+    "status_details",
+    "failure_reason",
+    "last_error",
+    "provider_error",
+    "error_details",
+  ]) {
+    if (response[key] !== undefined && response[key] !== null) {
+      fields[key] = response[key];
+    }
+  }
+  return fields;
+}
+
+function buildResponsesFailedNoDetailsObservation(
+  event: Record<string, unknown>,
+  model: Model<Api>,
+) {
+  const response = isRecord(event.response) ? event.response : undefined;
+  const failureFields = redactResponseFailedIdentifierFields(
+    buildResponsesFailedFailureFields(response),
+  ) as Record<string, unknown>;
+  const responsePreview = {
+    id: readRecordString(response, "id"),
+    status: readRecordString(response, "status"),
+    model: readRecordString(response, "model"),
+    object: readRecordString(response, "object"),
+    failureFields,
+    metadataKeys: isRecord(response?.metadata)
+      ? Object.keys(response.metadata).toSorted().join(",")
+      : "",
+  };
+  return {
+    event: "openai_responses_response_failed_without_details",
+    provider: model.provider,
+    api: model.api,
+    transportModel: model.id,
+    providerRuntimeFailureKind: "no_error_details",
+    responseId: responsePreview.id,
+    responseStatus: responsePreview.status,
+    responseModel: responsePreview.model,
+    requestIdHashes: collectResponseFailedIdentifierHashes(event),
+    failureFieldsPreview: stringifyRedactedEvent(failureFields),
+    responsePreview: stringifyRedactedEvent(responsePreview),
+  };
+}
+
+function summarizeResponsesFailedNoDetailsObservation(
+  observation: ReturnType<typeof buildResponsesFailedNoDetailsObservation>,
+): string {
+  const requestIds = observation.requestIdHashes.join(",");
+  return (
+    `responseId=${safeDebugValue(observation.responseId || undefined)} ` +
+    `responseStatus=${safeDebugValue(observation.responseStatus || undefined)} ` +
+    `responseModel=${safeDebugValue(observation.responseModel || undefined)} ` +
+    `requestIds=${requestIds || "none"} response=${observation.responsePreview}`
+  );
 }
 
 function summarizeResponsesPayload(params: unknown): string {
@@ -963,15 +1145,27 @@ async function processResponsesStream(
     } else if (type === "response.failed") {
       const response = event.response as
         | {
+            id?: string;
             error?: { code?: string; message?: string };
             incomplete_details?: { reason?: string };
           }
         | undefined;
+      if (typeof response?.id === "string") {
+        output.responseId = response.id;
+      }
       const msg = response?.error
         ? `${response.error.code || "unknown"}: ${response.error.message || "no message"}`
         : response?.incomplete_details?.reason
           ? `incomplete: ${response.incomplete_details.reason}`
-          : "Unknown error (no error details in response)";
+          : RESPONSE_FAILED_NO_DETAILS_MESSAGE;
+      if (msg === RESPONSE_FAILED_NO_DETAILS_MESSAGE) {
+        const observation = buildResponsesFailedNoDetailsObservation(event, model);
+        log.warn(
+          `[responses] response.failed missing error details provider=${model.provider} api=${model.api} model=${model.id} ` +
+            summarizeResponsesFailedNoDetailsObservation(observation),
+          observation,
+        );
+      }
       throw new Error(msg);
     }
     await cooperativeScheduler.afterEvent();
@@ -2795,6 +2989,8 @@ export const __testing = {
   processOpenAICompletionsStream,
   processResponsesStream,
   formatModelTransportDebugBaseUrl,
+  buildResponsesFailedNoDetailsObservation,
+  summarizeResponsesFailedNoDetailsObservation,
   summarizeResponsesPayload,
   summarizeResponsesTools,
   withResponsesFirstEventTimeout,

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -396,12 +396,14 @@ function collectResponseFailedIdentifierHashes(
   opts: {
     path?: string;
     depth?: number;
+    identifierKey?: string;
     out?: string[];
     seen?: WeakSet<object>;
   } = {},
 ): string[] {
   const path = opts.path ?? "";
   const depth = opts.depth ?? 0;
+  const identifierKey = opts.identifierKey ?? "";
   const out = opts.out ?? [];
   const seen = opts.seen ?? new WeakSet<object>();
   if (out.length >= 12 || depth > 4 || !value || typeof value !== "object") {
@@ -416,9 +418,16 @@ function collectResponseFailedIdentifierHashes(
       if (index >= 8 || out.length >= 12) {
         break;
       }
+      const itemString =
+        typeof item === "string" || typeof item === "number" ? String(item).trim() : "";
+      if (identifierKey && isResponseFailedIdentifierKey(identifierKey) && itemString) {
+        out.push(`${path}[${index}]=${redactIdentifier(itemString, { len: 12 })}`);
+        continue;
+      }
       collectResponseFailedIdentifierHashes(item, {
         path: `${path}[${index}]`,
         depth: depth + 1,
+        identifierKey,
         out,
         seen,
       });
@@ -439,6 +448,7 @@ function collectResponseFailedIdentifierHashes(
     collectResponseFailedIdentifierHashes(child, {
       path: childPath,
       depth: depth + 1,
+      identifierKey: isResponseFailedIdentifierKey(key) ? key : undefined,
       out,
       seen,
     });
@@ -472,6 +482,7 @@ function redactResponseFailedIdentifierFields(
   if (Array.isArray(value)) {
     return value.slice(0, 16).map((item) =>
       redactResponseFailedIdentifierFields(item, {
+        key,
         depth: depth + 1,
         seen,
       }),

--- a/src/cron/service.skips-main-jobs-empty-systemevent-text.test.ts
+++ b/src/cron/service.skips-main-jobs-empty-systemevent-text.test.ts
@@ -114,7 +114,9 @@ describe("CronService", () => {
 
       const job = await waitForFirstJob(cron, (current) => current?.state.lastStatus === "skipped");
       expect(job?.enabled).toBe(false);
+      expect(job?.state.lastStatus).toBe("skipped");
       expect(job?.state.lastError).toMatch(/non-empty/i);
+      expect(job?.state.nextRunAtMs).toBeUndefined();
     });
   });
 

--- a/src/cron/service/store.test.ts
+++ b/src/cron/service/store.test.ts
@@ -309,7 +309,7 @@ describe("cron service store seam coverage", () => {
         updatedAtMs: STORE_TEST_NOW,
         state: { nextRunAtMs: staleNextRunAtMs },
       }),
-      schedule: "0 17 * * *",
+      schedule: { kind: "cron", expr: "" },
     });
 
     await expect(ensureLoaded(state, { forceReload: true, skipRecompute: true })).resolves.toBe(

--- a/src/cron/service/store.test.ts
+++ b/src/cron/service/store.test.ts
@@ -309,7 +309,7 @@ describe("cron service store seam coverage", () => {
         updatedAtMs: STORE_TEST_NOW,
         state: { nextRunAtMs: staleNextRunAtMs },
       }),
-      schedule: { kind: "cron", expr: "" },
+      schedule: "0 17 * * *",
     });
 
     await expect(ensureLoaded(state, { forceReload: true, skipRecompute: true })).resolves.toBe(


### PR DESCRIPTION
Summary
- Log a redacted structured observation when OpenAI Responses emits `response.failed` without `error` or `incomplete_details`.
- Preserve the failed response id on the assistant output before throwing the existing `no_error_details`-classified fallback error.
- Add regression coverage for response id preservation and hashing nested request/provider ids before previews are logged.

Verification
Behavior addressed: detail-less `response.failed` events now emit operator diagnostics with response id/status/model, hashed request/provider ids, and redacted failure fields instead of only collapsing to the generic fallback string.
Real environment tested: local macOS checkout plus Blacksmith Testbox changed gate.
Exact steps or command run after this patch: `pnpm test src/agents/openai-transport-stream.test.ts -- --reporter=verbose`; `/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review`; `pnpm check:changed` via Testbox `tbx_01krre8k74ppsnv5d4fbj6z1sh`.
Evidence after fix: focused Vitest passed 154 tests; Codex review clean with no accepted/actionable findings after accepting the nested-id redaction finding; Testbox changed gate exited 0.
Observed result after fix: observation previews contain hashed request/provider ids and do not contain plaintext nested request ids or API keys.
What was not tested: live LiteLLM/OpenAI production failure; regression uses synthetic Responses stream events matching the SDK event shape.

Fixes #82558.
