### PR TITLE
Honor OpenAI Codex auth order for explicit PI runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Docs: https://docs.openclaw.ai
 - Cron: keep legacy string schedules and blank system-event jobs available for runtime repair/skip handling instead of dropping them as malformed persisted rows.
 - Task persistence: drop malformed array/scalar requester-origin JSON from task and task-flow SQLite sidecars instead of restoring it as delivery metadata.
 - Agents/timeouts: clarify model idle-timeout errors and docs so provider `timeoutSeconds` is shown as bounded by the whole agent/run timeout ceiling.
+- OpenAI/Codex auth: honor subscription-first `auth.order.openai` entries for explicit PI `openai/*` runs and accept the documented `models auth login --provider openai-codex --device-code` shortcut. Fixes #82521. Thanks @amknight.
 - Agents/OpenAI streams: yield cooperatively while processing bursty Completions and Responses chunks, keeping aborts, channel liveness timers, and startup heartbeats responsive under noisy model output. Refs #82462.
 - Release tooling: align the published launcher Node floor, `npm start`, package script checks, sharded lint locking, Vitest root project coverage, and plugin-SDK declaration build cache metadata so release/package validation does not silently skip or ship stale surfaces.
 - Cron/agents: honor configured subagent model fallbacks for isolated scheduled runs and forward that fallback policy into embedded agent timeout failover. Fixes #74985. Thanks @chrisgwynne.

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -894,6 +894,7 @@ async function agentCommandInternal(
         const acceptedAuthProviders = listOpenAIAuthProfileProvidersForAgentRuntime({
           provider: providerForAuthProfileValidation,
           harnessRuntime: validationHarnessPolicy.runtime,
+          config: cfg,
         }).map((candidateProvider) =>
           resolveProviderIdForAuth(candidateProvider, { config: cfg, workspaceDir }),
         );
@@ -902,6 +903,7 @@ async function agentCommandInternal(
           acceptedAuthProviders.some((candidateProvider) =>
             isStoredCredentialCompatibleWithAuthProvider({
               cfg,
+              workspaceDir,
               provider: candidateProvider,
               credential: profile,
             }),

--- a/src/agents/auth-profile-runtime-contract.test.ts
+++ b/src/agents/auth-profile-runtime-contract.test.ts
@@ -151,7 +151,7 @@ function providerRuntimeConfig(provider: string, runtime: string): OpenClawConfi
     models: {
       providers: {
         [provider]: {
-          baseUrl: "https://api.openclaw.test/v1",
+          baseUrl: "https://api.openai.com/v1",
           agentRuntime: { id: runtime },
           models: [],
         },

--- a/src/agents/auth-profiles.resolve-auth-profile-order.does-not-prioritize-lastgood-round-robin-ordering.test.ts
+++ b/src/agents/auth-profiles.resolve-auth-profile-order.does-not-prioritize-lastgood-round-robin-ordering.test.ts
@@ -331,12 +331,12 @@ describe("resolveAuthProfileOrder", () => {
     });
     expect(order).toEqual(["openai-codex:user@example.com"]);
   });
-  it("keeps explicit OpenAI alias order ahead of native Codex profiles", () => {
+  it("keeps explicit Codex profile ids in OpenAI alias order ahead of API-key fallbacks", () => {
     const order = resolveAuthProfileOrder({
       cfg: {
         auth: {
           order: {
-            openai: ["openai:api-key"],
+            openai: ["openai-codex:user@example.com", "openai:api-key"],
           },
         },
       },
@@ -360,7 +360,7 @@ describe("resolveAuthProfileOrder", () => {
       provider: "openai-codex",
     });
 
-    expect(order).toEqual(["openai:api-key", "openai-codex:user@example.com"]);
+    expect(order).toEqual(["openai-codex:user@example.com", "openai:api-key"]);
   });
   it("does not bypass explicit ids when the configured profile exists but is invalid", () => {
     const order = resolveAuthProfileOrder({

--- a/src/agents/auth-profiles.resolve-auth-profile-order.does-not-prioritize-lastgood-round-robin-ordering.test.ts
+++ b/src/agents/auth-profiles.resolve-auth-profile-order.does-not-prioritize-lastgood-round-robin-ordering.test.ts
@@ -331,6 +331,37 @@ describe("resolveAuthProfileOrder", () => {
     });
     expect(order).toEqual(["openai-codex:user@example.com"]);
   });
+  it("keeps explicit OpenAI alias order ahead of native Codex profiles", () => {
+    const order = resolveAuthProfileOrder({
+      cfg: {
+        auth: {
+          order: {
+            openai: ["openai:api-key"],
+          },
+        },
+      },
+      store: {
+        version: 1,
+        profiles: {
+          "openai:api-key": {
+            type: "api_key",
+            provider: "openai",
+            key: "sk-openai",
+          },
+          "openai-codex:user@example.com": {
+            type: "oauth",
+            provider: "openai-codex",
+            access: "access-token",
+            refresh: "refresh-token",
+            expires: Date.now() + 60_000,
+          },
+        },
+      },
+      provider: "openai-codex",
+    });
+
+    expect(order).toEqual(["openai:api-key", "openai-codex:user@example.com"]);
+  });
   it("does not bypass explicit ids when the configured profile exists but is invalid", () => {
     const order = resolveAuthProfileOrder({
       cfg: {

--- a/src/agents/auth-profiles/order.ts
+++ b/src/agents/auth-profiles/order.ts
@@ -388,7 +388,15 @@ function mergeAliasOrderWithNativeProfiles(params: {
   aliasOrder: string[];
   nativeProfiles: string[];
 }): string[] {
-  return dedupeProfileIds([...params.aliasOrder, ...params.nativeProfiles]);
+  const nativeProfileIds = new Set(params.nativeProfiles);
+  const aliasHasNativeProfile = params.aliasOrder.some((profileId) =>
+    nativeProfileIds.has(profileId),
+  );
+  return dedupeProfileIds(
+    aliasHasNativeProfile
+      ? [...params.aliasOrder, ...params.nativeProfiles]
+      : [...params.nativeProfiles, ...params.aliasOrder],
+  );
 }
 
 function orderProfilesByMode(order: string[], store: AuthProfileStore): string[] {

--- a/src/agents/auth-profiles/order.ts
+++ b/src/agents/auth-profiles/order.ts
@@ -29,6 +29,7 @@ const OPENAI_CODEX_PROVIDER_ID = "openai-codex";
 
 function isOpenAIApiKeyCompatibleWithCodexAuth(params: {
   cfg?: OpenClawConfig;
+  workspaceDir?: string;
   providerAuthKey: string;
   credential?: AuthProfileCredential;
   profileProvider?: string;
@@ -39,6 +40,7 @@ function isOpenAIApiKeyCompatibleWithCodexAuth(params: {
   }
   const providerKey = resolveProviderIdForAuth(params.profileProvider ?? "", {
     config: params.cfg,
+    workspaceDir: params.workspaceDir,
   });
   const mode = params.credential?.type ?? params.profileMode;
   return providerKey === OPENAI_PROVIDER_ID && mode === "api_key";
@@ -46,16 +48,19 @@ function isOpenAIApiKeyCompatibleWithCodexAuth(params: {
 
 function isCredentialProviderCompatibleWithAuthProvider(params: {
   cfg?: OpenClawConfig;
+  workspaceDir?: string;
   providerAuthKey: string;
   credential: AuthProfileCredential;
 }): boolean {
   const credentialProviderKey = resolveProviderIdForAuth(params.credential.provider, {
     config: params.cfg,
+    workspaceDir: params.workspaceDir,
   });
   return (
     credentialProviderKey === params.providerAuthKey ||
     isOpenAIApiKeyCompatibleWithCodexAuth({
       cfg: params.cfg,
+      workspaceDir: params.workspaceDir,
       providerAuthKey: params.providerAuthKey,
       credential: params.credential,
       profileProvider: params.credential.provider,
@@ -65,12 +70,17 @@ function isCredentialProviderCompatibleWithAuthProvider(params: {
 
 export function isStoredCredentialCompatibleWithAuthProvider(params: {
   cfg?: OpenClawConfig;
+  workspaceDir?: string;
   provider: string;
   credential: AuthProfileCredential;
 }): boolean {
   return isCredentialProviderCompatibleWithAuthProvider({
     cfg: params.cfg,
-    providerAuthKey: resolveProviderIdForAuth(params.provider, { config: params.cfg }),
+    workspaceDir: params.workspaceDir,
+    providerAuthKey: resolveProviderIdForAuth(params.provider, {
+      config: params.cfg,
+      workspaceDir: params.workspaceDir,
+    }),
     credential: params.credential,
   });
 }
@@ -378,13 +388,7 @@ function mergeAliasOrderWithNativeProfiles(params: {
   aliasOrder: string[];
   nativeProfiles: string[];
 }): string[] {
-  const nativeIds = new Set(params.nativeProfiles);
-  const aliasHasNativeProfile = params.aliasOrder.some((profileId) => nativeIds.has(profileId));
-  return dedupeProfileIds(
-    aliasHasNativeProfile
-      ? [...params.aliasOrder, ...params.nativeProfiles]
-      : [...params.nativeProfiles, ...params.aliasOrder],
-  );
+  return dedupeProfileIds([...params.aliasOrder, ...params.nativeProfiles]);
 }
 
 function orderProfilesByMode(order: string[], store: AuthProfileStore): string[] {

--- a/src/agents/auth-profiles/session-override.test.ts
+++ b/src/agents/auth-profiles/session-override.test.ts
@@ -6,6 +6,7 @@ import {
   type OpenClawTestState,
   withOpenClawTestState,
 } from "../../test-utils/openclaw-test-state.js";
+import { listOpenAIAuthProfileProvidersForAgentRuntime } from "../openai-codex-routing.js";
 import { resolveSessionAuthProfileOverride } from "./session-override.js";
 import type { AuthProfileStore } from "./types.js";
 
@@ -132,7 +133,7 @@ function createAuthStore(): AuthProfileStore {
 }
 
 function createAuthStoreWithProfiles(params: {
-  profiles: Record<string, { type: "api_key"; provider: string; key: string }>;
+  profiles: AuthProfileStore["profiles"];
   order?: Record<string, string[]>;
 }): AuthProfileStore {
   return {
@@ -370,6 +371,121 @@ describe("resolveSessionAuthProfileOverride", () => {
       expect(resolved).toBe(TEST_SECONDARY_PROFILE_ID);
       expect(sessionEntry.authProfileOverride).toBe(TEST_SECONDARY_PROFILE_ID);
       expect(sessionEntry.authProfileOverrideSource).toBe("user");
+    });
+  });
+
+  it("honors subscription-first OpenAI auth order for explicit PI runtime", async () => {
+    await withAuthState(async (state) => {
+      const agentDir = state.agentDir();
+      await fs.mkdir(agentDir, { recursive: true });
+      authStoreMocks.state.hasSource = true;
+      authStoreMocks.state.store = createAuthStoreWithProfiles({
+        profiles: {
+          "openai-codex:sub@example.test": {
+            type: "oauth",
+            provider: "openai-codex",
+            access: "access-token",
+            refresh: "refresh-token",
+            expires: Date.now() + 60_000,
+          },
+          "openai:api-key-backup": {
+            type: "api_key",
+            provider: "openai",
+            key: "sk-platform",
+          },
+        },
+      });
+      const sessionEntry: SessionEntry = {
+        sessionId: "s1",
+        updatedAt: Date.now(),
+      };
+      const sessionStore = { "agent:main:main": sessionEntry };
+      const cfg = {
+        auth: {
+          order: {
+            openai: ["openai-codex:sub@example.test", "openai:api-key-backup"],
+          },
+        },
+      } as OpenClawConfig;
+
+      const resolved = await resolveSessionAuthProfileOverride({
+        cfg,
+        provider: "openai",
+        acceptedProviderIds: listOpenAIAuthProfileProvidersForAgentRuntime({
+          provider: "openai",
+          harnessRuntime: "pi",
+          config: cfg,
+        }),
+        agentDir,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:main:main",
+        storePath: undefined,
+        isNewSession: false,
+      });
+
+      expect(resolved).toBe("openai-codex:sub@example.test");
+      expect(sessionEntry.authProfileOverride).toBe("openai-codex:sub@example.test");
+      expect(sessionEntry.authProfileOverrideSource).toBe("auto");
+    });
+  });
+
+  it("keeps custom OpenAI endpoints on OpenAI auth for explicit PI runtime", async () => {
+    await withAuthState(async (state) => {
+      const agentDir = state.agentDir();
+      await fs.mkdir(agentDir, { recursive: true });
+      authStoreMocks.state.hasSource = true;
+      authStoreMocks.state.store = createAuthStoreWithProfiles({
+        profiles: {
+          "openai-codex:sub@example.test": {
+            type: "oauth",
+            provider: "openai-codex",
+            access: "access-token",
+            refresh: "refresh-token",
+            expires: Date.now() + 60_000,
+          },
+          "openai:custom-endpoint": {
+            type: "api_key",
+            provider: "openai",
+            key: "sk-custom",
+          },
+        },
+      });
+      const sessionEntry: SessionEntry = {
+        sessionId: "s1",
+        updatedAt: Date.now(),
+      };
+      const sessionStore = { "agent:main:main": sessionEntry };
+      const cfg = {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://custom-openai.example.test/v1",
+              models: [],
+            },
+          },
+        },
+      } as OpenClawConfig;
+
+      const resolved = await resolveSessionAuthProfileOverride({
+        cfg,
+        provider: "openai",
+        acceptedProviderIds: listOpenAIAuthProfileProvidersForAgentRuntime({
+          provider: "openai",
+          harnessRuntime: "pi",
+          config: cfg,
+        }),
+        agentDir,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:main:main",
+        storePath: undefined,
+        isNewSession: false,
+      });
+
+      expect(resolved).toBe("openai:custom-endpoint");
+      expect(sessionEntry.authProfileOverride).toBe("openai:custom-endpoint");
+      expect(sessionEntry.authProfileOverrideSource).toBe("auto");
     });
   });
 

--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -498,6 +498,50 @@ describe("runBtwSideQuestion", () => {
     expect(ensureArgs?.[2]).toEqual({ workspaceDir: "/tmp/workspace" });
   });
 
+  it("routes explicit OpenAI PI BTW calls through the Codex auth provider", async () => {
+    mockDoneAnswer("Final answer.");
+    resolveSessionAuthProfileOverrideMock.mockResolvedValue("openai-codex:work");
+    resolveModelWithRegistryMock.mockImplementation(({ provider }: { provider: string }) => ({
+      provider,
+      id: "gpt-5.5",
+      api: provider === "openai-codex" ? "openai-codex-responses" : "openai-responses",
+    }));
+
+    const result = await runSideQuestion({
+      cfg: {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              agentRuntime: { id: "pi" },
+              models: [],
+            },
+          },
+        },
+      } as never,
+      provider: "openai",
+      model: "gpt-5.5",
+      sessionKey: DEFAULT_SESSION_KEY,
+    });
+
+    expect(result).toEqual({ text: "Final answer." });
+    expect(getApiKeyForModelMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profileId: "openai-codex:work",
+        model: expect.objectContaining({ provider: "openai-codex" }),
+      }),
+    );
+    expect(registerProviderStreamForModelMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: expect.objectContaining({ provider: "openai-codex" }),
+      }),
+    );
+    expect(streamSimpleMock.mock.calls[0]?.[0]).toMatchObject({
+      provider: "openai-codex",
+      id: "gpt-5.5",
+    });
+  });
+
   it("routes Codex-selected BTW questions through the harness side-question hook", async () => {
     const codexSideQuestionMock = vi.fn().mockResolvedValue({ text: "Codex side answer." });
     registerAgentHarness({

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -24,7 +24,10 @@ import {
 } from "./image-sanitization.js";
 import { getApiKeyForModel, requireApiKey } from "./model-auth.js";
 import { ensureOpenClawModelsJson } from "./models-config.js";
-import { listOpenAIAuthProfileProvidersForAgentRuntime } from "./openai-codex-routing.js";
+import {
+  listOpenAIAuthProfileProvidersForAgentRuntime,
+  resolveOpenAIRuntimeProviderForPi,
+} from "./openai-codex-routing.js";
 import { EmbeddedBlockChunker, type BlockReplyChunking } from "./pi-embedded-block-chunker.js";
 import { resolveModelWithRegistry } from "./pi-embedded-runner/model.js";
 import { getActiveEmbeddedRunSnapshot } from "./pi-embedded-runner/runs.js";
@@ -243,19 +246,21 @@ async function resolveRuntimeModel(params: {
   if (!model) {
     throw new Error(`Unknown model: ${params.provider}/${params.model}`);
   }
+  const agentHarnessPolicy = resolveAvailableAgentHarnessPolicy({
+    provider: params.provider,
+    modelId: params.model,
+    config: params.cfg,
+    agentId: params.agentId,
+    sessionKey: params.sessionKey,
+  });
 
   const authProfileId = await resolveSessionAuthProfileOverride({
     cfg: params.cfg,
     provider: params.provider,
     acceptedProviderIds: listOpenAIAuthProfileProvidersForAgentRuntime({
       provider: params.provider,
-      harnessRuntime: resolveAvailableAgentHarnessPolicy({
-        provider: params.provider,
-        modelId: params.model,
-        config: params.cfg,
-        agentId: params.agentId,
-        sessionKey: params.sessionKey,
-      }).runtime,
+      harnessRuntime: agentHarnessPolicy.runtime,
+      config: params.cfg,
     }),
     agentDir: params.agentDir,
     sessionEntry: params.sessionEntry,
@@ -264,8 +269,28 @@ async function resolveRuntimeModel(params: {
     storePath: params.storePath,
     isNewSession: params.isNewSession,
   });
+  const runtimeProvider = resolveOpenAIRuntimeProviderForPi({
+    provider: params.provider,
+    harnessRuntime: agentHarnessPolicy.runtime,
+    authProfileProvider: authProfileId?.split(":", 1)[0],
+    authProfileId,
+    config: params.cfg,
+    workspaceDir: params.workspaceDir,
+  });
+  const runtimeModel =
+    runtimeProvider === params.provider
+      ? model
+      : resolveModelWithRegistry({
+          provider: runtimeProvider,
+          modelId: params.model,
+          modelRegistry,
+          cfg: params.cfg,
+        });
+  if (!runtimeModel) {
+    throw new Error(`Unknown model: ${runtimeProvider}/${params.model}`);
+  }
   return {
-    model,
+    model: runtimeModel,
     authProfileId,
     authProfileIdSource: params.sessionEntry?.authProfileOverrideSource,
   };

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -1179,9 +1179,11 @@ describe("CLI attempt execution", () => {
 
 describe("embedded attempt harness pinning", () => {
   let tmpDir: string;
+  let storePath: string;
 
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-embedded-attempt-"));
+    storePath = path.join(tmpDir, "sessions.json");
     runCliAgentMock.mockReset();
     runEmbeddedPiAgentMock.mockReset();
   });
@@ -1435,6 +1437,152 @@ describe("embedded attempt harness pinning", () => {
     });
   });
 
+  it("auto-resolves explicit OpenAI PI auth order before routing command attempts", async () => {
+    const sessionKey = "agent:main:main";
+    const sessionEntry: SessionEntry = {
+      sessionId: "openai-pi-auth-order-session",
+      updatedAt: Date.now(),
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
+    await fs.writeFile(
+      path.join(tmpDir, "auth-profiles.json"),
+      JSON.stringify({
+        version: 1,
+        profiles: {
+          "openai-codex:work": {
+            type: "oauth",
+            provider: "openai-codex",
+            access: "access-token",
+            refresh: "refresh-token",
+            expires: Date.now() + 60_000,
+          },
+          "openai:backup": {
+            type: "api_key",
+            provider: "openai",
+            key: "sk-test",
+          },
+        },
+      }),
+    );
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      meta: { durationMs: 1 },
+    } satisfies EmbeddedPiRunResult);
+
+    await runAgentAttempt({
+      providerOverride: "openai",
+      originalProvider: "openai",
+      modelOverride: "gpt-5.4",
+      cfg: {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              agentRuntime: { id: "pi" },
+              models: [],
+            },
+          },
+        },
+        auth: {
+          order: {
+            openai: ["openai-codex:work", "openai:backup"],
+          },
+        },
+      } as OpenClawConfig,
+      sessionEntry,
+      sessionId: sessionEntry.sessionId,
+      sessionKey,
+      sessionAgentId: "main",
+      sessionFile: path.join(tmpDir, "session.jsonl"),
+      workspaceDir: tmpDir,
+      body: "continue",
+      isFallbackRetry: false,
+      resolvedThinkLevel: "medium",
+      timeoutMs: 1_000,
+      runId: "run-openai-pi-auth-order",
+      opts: { senderIsOwner: false } as Parameters<typeof runAgentAttempt>[0]["opts"],
+      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
+      spawnedBy: undefined,
+      messageChannel: undefined,
+      skillsSnapshot: undefined,
+      resolvedVerboseLevel: undefined,
+      agentDir: tmpDir,
+      onAgentEvent: vi.fn(),
+      authProfileProvider: "openai",
+      sessionStore,
+      storePath,
+      sessionHasHistory: false,
+    });
+
+    expectMockArgFields(runEmbeddedPiAgentMock, {
+      provider: "openai-codex",
+      model: "gpt-5.4",
+      agentHarnessRuntimeOverride: "pi",
+      authProfileId: "openai-codex:work",
+      authProfileIdSource: "auto",
+    });
+    expect(sessionStore[sessionKey]?.authProfileOverride).toBe("openai-codex:work");
+  });
+
+  it("forwards OpenAI API-key session auth profiles to default Codex harness runs", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "codex-api-key-auth-session",
+      updatedAt: Date.now(),
+      authProfileOverride: "openai:backup",
+      authProfileOverrideSource: "user",
+    };
+    await fs.writeFile(
+      path.join(tmpDir, "auth-profiles.json"),
+      JSON.stringify({
+        version: 1,
+        profiles: {
+          "openai:backup": {
+            type: "api_key",
+            provider: "openai",
+            key: "sk-test",
+          },
+        },
+      }),
+    );
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      meta: { durationMs: 1 },
+    } satisfies EmbeddedPiRunResult);
+
+    await runAgentAttempt({
+      providerOverride: "openai",
+      originalProvider: "openai",
+      modelOverride: "gpt-5.4",
+      cfg: {} as OpenClawConfig,
+      sessionEntry,
+      sessionId: sessionEntry.sessionId,
+      sessionKey: "agent:main:main",
+      sessionAgentId: "main",
+      sessionFile: path.join(tmpDir, "session.jsonl"),
+      workspaceDir: tmpDir,
+      body: "continue",
+      isFallbackRetry: false,
+      resolvedThinkLevel: "medium",
+      timeoutMs: 1_000,
+      runId: "run-codex-api-key-auth-profile",
+      opts: { senderIsOwner: false } as Parameters<typeof runAgentAttempt>[0]["opts"],
+      runContext: {} as Parameters<typeof runAgentAttempt>[0]["runContext"],
+      spawnedBy: undefined,
+      messageChannel: undefined,
+      skillsSnapshot: undefined,
+      resolvedVerboseLevel: undefined,
+      agentDir: tmpDir,
+      onAgentEvent: vi.fn(),
+      authProfileProvider: "openai",
+      sessionHasHistory: true,
+    });
+
+    expectMockArgFields(runEmbeddedPiAgentMock, {
+      agentHarnessId: undefined,
+      authProfileId: "openai:backup",
+      authProfileIdSource: "user",
+    });
+  });
+
   it("pins a fresh OpenAI session to the Codex harness by default", async () => {
     const sessionEntry: SessionEntry = {
       sessionId: "fresh-session",
@@ -1572,6 +1720,7 @@ describe("embedded attempt harness pinning", () => {
       provider: "openai-codex",
       model: "gpt-5.4",
       agentHarnessId: undefined,
+      agentHarnessRuntimeOverride: "pi",
       authProfileId: "openai-codex:work",
       authProfileIdSource: "user",
     });

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -16,6 +16,7 @@ import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js
 import { sanitizeForLog } from "../../terminal/ansi.js";
 import { resolveMessageChannel } from "../../utils/message-channel.js";
 import { resolveAuthProfileOrder } from "../auth-profiles/order.js";
+import { resolveSessionAuthProfileOverride } from "../auth-profiles/session-override.js";
 import { ensureAuthProfileStore } from "../auth-profiles/store.js";
 import { resolveBootstrapWarningSignaturesSeen } from "../bootstrap-budget.js";
 import { runCliAgent } from "../cli-runner.js";
@@ -24,7 +25,10 @@ import { FailoverError } from "../failover-error.js";
 import { resolveAvailableAgentHarnessPolicy } from "../harness/selection.js";
 import { resolveCliRuntimeExecutionProvider } from "../model-runtime-aliases.js";
 import { isCliProvider } from "../model-selection.js";
-import { resolveOpenAIRuntimeProviderForPi } from "../openai-codex-routing.js";
+import {
+  listOpenAIAuthProfileProvidersForAgentRuntime,
+  resolveOpenAIRuntimeProviderForPi,
+} from "../openai-codex-routing.js";
 import { runEmbeddedPiAgent, type EmbeddedPiRunResult } from "../pi-embedded.js";
 import { buildAgentRuntimeAuthPlan } from "../runtime-plan/auth.js";
 import {
@@ -120,7 +124,7 @@ function resolveProfileAuthFromStore(params: { agentDir: string; profileId: stri
   return { provider: credential?.provider, mode: credential?.type };
 }
 
-function resolveHarnessAuthProfileSelection(params: {
+async function resolveHarnessAuthProfileSelection(params: {
   config: OpenClawConfig;
   agentDir: string;
   workspaceDir: string;
@@ -128,22 +132,39 @@ function resolveHarnessAuthProfileSelection(params: {
   authProfileProvider: string;
   sessionAuthProfileId?: string;
   sessionAuthProfileSource?: "auto" | "user";
+  sessionEntry?: SessionEntry;
+  sessionStore?: Record<string, SessionEntry>;
+  sessionKey?: string;
+  storePath?: string;
+  isNewSession: boolean;
   harnessId?: string;
   harnessRuntime?: string;
   allowHarnessAuthProfileForwarding: boolean;
-}): HarnessAuthProfileSelection {
-  const sessionAuthProfileId = params.sessionAuthProfileId?.trim();
-  if (sessionAuthProfileId) {
+}): Promise<HarnessAuthProfileSelection> {
+  const buildSelectionFromProfile = (
+    profileId: string,
+    source: "auto" | "user" | undefined,
+    authProviderFallback: string,
+  ): HarnessAuthProfileSelection => {
     const profileAuth = resolveProfileAuthFromStore({
       agentDir: params.agentDir,
-      profileId: sessionAuthProfileId,
+      profileId,
     });
     return {
-      authProfileId: sessionAuthProfileId,
-      authProfileIdSource: params.sessionAuthProfileSource,
-      authProfileProvider: profileAuth.provider ?? params.authProfileProvider,
+      authProfileId: profileId,
+      authProfileIdSource: source,
+      authProfileProvider: profileAuth.provider ?? authProviderFallback,
       authProfileMode: profileAuth.mode,
     };
+  };
+
+  const sessionAuthProfileId = params.sessionAuthProfileId?.trim();
+  if (sessionAuthProfileId) {
+    return buildSelectionFromProfile(
+      sessionAuthProfileId,
+      params.sessionAuthProfileSource,
+      params.authProfileProvider,
+    );
   }
 
   const runtimeAuthPlan = buildAgentRuntimeAuthPlan({
@@ -156,25 +177,60 @@ function resolveHarnessAuthProfileSelection(params: {
     allowHarnessAuthProfileForwarding: params.allowHarnessAuthProfileForwarding,
   });
   const harnessAuthProvider = runtimeAuthPlan.harnessAuthProvider;
-  if (!harnessAuthProvider) {
+  const acceptedAuthProviders = harnessAuthProvider
+    ? [harnessAuthProvider]
+    : listOpenAIAuthProfileProvidersForAgentRuntime({
+        provider: params.provider,
+        harnessRuntime: params.harnessRuntime,
+        agentHarnessId: params.harnessId,
+        config: params.config,
+      });
+  const shouldAutoResolveAuthProfile =
+    Boolean(harnessAuthProvider) ||
+    acceptedAuthProviders.some((candidateProvider) => candidateProvider !== params.provider);
+  if (!shouldAutoResolveAuthProfile) {
     return { authProfileProvider: params.authProfileProvider };
+  }
+
+  if (params.sessionEntry && params.sessionStore && params.sessionKey) {
+    const resolvedSessionAuthProfileId = await resolveSessionAuthProfileOverride({
+      cfg: params.config,
+      provider: params.provider,
+      acceptedProviderIds: acceptedAuthProviders,
+      agentDir: params.agentDir,
+      sessionEntry: params.sessionEntry,
+      sessionStore: params.sessionStore,
+      sessionKey: params.sessionKey,
+      storePath: params.storePath,
+      isNewSession: params.isNewSession,
+    });
+    if (resolvedSessionAuthProfileId) {
+      return buildSelectionFromProfile(
+        resolvedSessionAuthProfileId,
+        params.sessionEntry.authProfileOverrideSource ?? "auto",
+        acceptedAuthProviders[0] ?? params.authProfileProvider,
+      );
+    }
   }
 
   const store = ensureAuthProfileStore(params.agentDir, {
     allowKeychainPrompt: false,
   });
-  const authProfileId = resolveAuthProfileOrder({
-    cfg: params.config,
-    store,
-    provider: harnessAuthProvider,
-  })[0];
+  const orderedProfiles = [
+    ...new Set(
+      acceptedAuthProviders.flatMap((candidateProvider) =>
+        resolveAuthProfileOrder({
+          cfg: params.config,
+          store,
+          provider: candidateProvider,
+        }),
+      ),
+    ),
+  ];
+  const authProfileId = orderedProfiles[0];
 
   return authProfileId
-    ? {
-        authProfileId,
-        authProfileIdSource: "auto",
-        authProfileProvider: harnessAuthProvider,
-      }
+    ? buildSelectionFromProfile(authProfileId, "auto", acceptedAuthProviders[0] ?? params.provider)
     : { authProfileProvider: params.authProfileProvider };
 }
 
@@ -350,7 +406,7 @@ export async function persistCliTurnTranscript(params: {
   });
 }
 
-export function runAgentAttempt(params: {
+export async function runAgentAttempt(params: {
   providerOverride: string;
   modelOverride: string;
   originalProvider: string;
@@ -422,7 +478,7 @@ export function runAgentAttempt(params: {
         modelId: params.modelOverride,
       }) ?? params.providerOverride);
   const agentHarnessPolicy = isRawModelRun
-    ? ({ runtime: "pi" } as const)
+    ? ({ runtime: "pi", runtimeSource: "model" } as const)
     : resolveAvailableAgentHarnessPolicy({
         provider: params.providerOverride,
         modelId: params.modelOverride,
@@ -430,7 +486,11 @@ export function runAgentAttempt(params: {
         agentId: params.sessionAgentId,
         sessionKey: params.sessionKey ?? params.sessionId,
       });
-  const harnessAuthSelection = resolveHarnessAuthProfileSelection({
+  const agentHarnessRuntimeOverride =
+    agentHarnessPolicy.runtime === "pi" && agentHarnessPolicy.runtimeSource !== "implicit"
+      ? "pi"
+      : undefined;
+  const harnessAuthSelection = await resolveHarnessAuthProfileSelection({
     config: params.cfg,
     agentDir: params.agentDir,
     workspaceDir: params.workspaceDir,
@@ -438,6 +498,11 @@ export function runAgentAttempt(params: {
     authProfileProvider: params.authProfileProvider,
     sessionAuthProfileId: params.sessionEntry?.authProfileOverride,
     sessionAuthProfileSource: params.sessionEntry?.authProfileOverrideSource,
+    sessionEntry: params.sessionEntry,
+    sessionStore: params.sessionStore,
+    sessionKey: params.sessionKey,
+    storePath: params.storePath,
+    isNewSession: params.sessionHasHistory !== true,
     harnessId: requestedAgentHarnessId,
     harnessRuntime: agentHarnessPolicy.runtime,
     allowHarnessAuthProfileForwarding: !isCliProvider(cliExecutionProvider, params.cfg),
@@ -610,6 +675,7 @@ export function runAgentAttempt(params: {
     workspaceDir: params.workspaceDir,
     config: params.cfg,
     agentHarnessId: requestedAgentHarnessId,
+    agentHarnessRuntimeOverride,
     skillsSnapshot: params.skillsSnapshot,
     prompt: effectivePrompt,
     images: params.isFallbackRetry ? undefined : params.opts.images,

--- a/src/agents/openai-codex-routing.test.ts
+++ b/src/agents/openai-codex-routing.test.ts
@@ -32,6 +32,22 @@ describe("OpenAI Codex routing policy", () => {
 
     expect(openAIProviderUsesCodexRuntimeByDefault({ provider: "openai", config })).toBe(false);
     expect(modelSelectionShouldEnsureCodexPlugin({ model: "openai/gpt-5.5", config })).toBe(false);
+    expect(
+      listOpenAIAuthProfileProvidersForAgentRuntime({
+        provider: "openai",
+        harnessRuntime: "pi",
+        config,
+      }),
+    ).toEqual(["openai"]);
+    expect(
+      resolveOpenAIRuntimeProviderForPi({
+        provider: "openai",
+        harnessRuntime: "pi",
+        authProfileProvider: "openai-codex",
+        authProfileId: "openai-codex:work",
+        config,
+      }),
+    ).toBe("openai");
   });
 
   it("maps explicit PI plus Codex auth profile to the legacy PI Codex-auth transport", () => {
@@ -40,7 +56,7 @@ describe("OpenAI Codex routing policy", () => {
         provider: "openai",
         harnessRuntime: "pi",
       }),
-    ).toEqual(["openai", "openai-codex"]);
+    ).toEqual(["openai-codex"]);
     expect(
       resolveOpenAIRuntimeProviderForPi({
         provider: "openai",

--- a/src/agents/openai-codex-routing.ts
+++ b/src/agents/openai-codex-routing.ts
@@ -89,6 +89,7 @@ export function shouldRouteOpenAIPiThroughCodexAuthProvider(params: {
 }): boolean {
   if (
     !isOpenAIProvider(params.provider) ||
+    openAIProviderUsesCustomBaseUrl(params.config) ||
     !hasOpenAICodexAuthProfileOverride(params.authProfileId)
   ) {
     return false;
@@ -112,6 +113,7 @@ export function listOpenAIAuthProfileProvidersForAgentRuntime(params: {
   provider: string;
   harnessRuntime?: string;
   agentHarnessId?: string;
+  config?: OpenClawConfig;
 }): string[] {
   if (!isOpenAIProvider(params.provider)) {
     return [params.provider];
@@ -122,8 +124,9 @@ export function listOpenAIAuthProfileProvidersForAgentRuntime(params: {
   if (runtime === "codex") {
     return [OPENAI_CODEX_PROVIDER_ID];
   }
-  if (runtime === "pi") {
-    return [OPENAI_PROVIDER_ID, OPENAI_CODEX_PROVIDER_ID];
+  if (runtime === "pi" && !openAIProviderUsesCustomBaseUrl(params.config)) {
+    // Codex auth resolution also carries ordered OpenAI API-key backups.
+    return [OPENAI_CODEX_PROVIDER_ID];
   }
   return [params.provider];
 }

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -1338,6 +1338,85 @@ describe("runAgentTurnWithFallback", () => {
     });
   });
 
+  it("preserves explicit OpenAI PI runtime when Codex auth owns transport", async () => {
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("openai", "gpt-5.4"),
+      provider: "openai",
+      model: "gpt-5.4",
+      attempts: [],
+    }));
+    state.runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ok" }],
+      meta: {},
+    });
+
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "openai";
+    followupRun.run.model = "gpt-5.4";
+    followupRun.run.config = {
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            agentRuntime: { id: "pi" },
+            models: [],
+          },
+        },
+      },
+    };
+    followupRun.run.authProfileId = "openai-codex:work";
+    followupRun.run.authProfileIdSource = "user";
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback(createMinimalRunAgentTurnParams({ followupRun }));
+
+    expect(result.kind).toBe("success");
+    expectMockCallArgFields(state.runEmbeddedPiAgentMock, 0, "embedded run params", {
+      provider: "openai-codex",
+      model: "gpt-5.4",
+      agentHarnessRuntimeOverride: "pi",
+      authProfileId: "openai-codex:work",
+      authProfileIdSource: "user",
+    });
+  });
+
+  it("does not force implicit OpenAI Codex runtime as an override", async () => {
+    state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
+      result: await params.run("openai", "gpt-5.4"),
+      provider: "openai",
+      model: "gpt-5.4",
+      attempts: [],
+    }));
+    state.runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ok" }],
+      meta: {},
+    });
+
+    const followupRun = createFollowupRun();
+    followupRun.run.provider = "openai";
+    followupRun.run.model = "gpt-5.4";
+    followupRun.run.config = {
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            models: [],
+          },
+        },
+      },
+    };
+
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const result = await runAgentTurnWithFallback(createMinimalRunAgentTurnParams({ followupRun }));
+
+    expect(result.kind).toBe("success");
+    expectMockCallArgFields(state.runEmbeddedPiAgentMock, 0, "embedded run params", {
+      provider: "openai",
+      model: "gpt-5.4",
+      agentHarnessRuntimeOverride: undefined,
+    });
+  });
+
   it("classifies GPT-5 plan-only terminal results as fallback-eligible", async () => {
     const followupRun = createFollowupRun();
     followupRun.run.provider = "openai-codex";

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1783,6 +1783,11 @@ export async function runAgentTurnWithFallback(params: {
                 agentId: params.followupRun.run.agentId,
                 sessionKey: params.followupRun.run.runtimePolicySessionKey ?? params.sessionKey,
               });
+          const agentHarnessRuntimeOverride =
+            sessionRuntimeOverride ??
+            (agentHarnessPolicy.runtime === "pi" && agentHarnessPolicy.runtimeSource !== "implicit"
+              ? "pi"
+              : undefined);
           const embeddedRunProvider = resolveOpenAIRuntimeProviderForPi({
             provider,
             harnessRuntime: agentHarnessPolicy.runtime,
@@ -1811,7 +1816,7 @@ export async function runAgentTurnWithFallback(params: {
                 ...runBaseParams,
                 provider: embeddedRunProvider,
                 agentHarnessId: sessionRuntimeOverride,
-                agentHarnessRuntimeOverride: sessionRuntimeOverride,
+                agentHarnessRuntimeOverride,
                 sandboxSessionKey: params.runtimePolicySessionKey,
                 prompt: params.commandBody,
                 transcriptPrompt: params.transcriptCommandBody,

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -880,6 +880,7 @@ export async function runPreparedReply(
       ? listOpenAIAuthProfileProvidersForAgentRuntime({
           provider,
           harnessRuntime: agentHarnessPolicy.runtime,
+          config: cfg,
         })
       : [provider];
   const resolveActiveSessionProviderForAuthProfile = (): string => {

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -1,4 +1,5 @@
 import { resolveAgentConfig } from "../../agents/agent-scope.js";
+import { isStoredCredentialCompatibleWithAuthProvider } from "../../agents/auth-profiles/order.js";
 import { clearSessionAuthProfileOverride } from "../../agents/auth-profiles/session-override.js";
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
@@ -328,8 +329,20 @@ export async function createModelSelectionState(params: {
     const acceptedAuthProviders = listOpenAIAuthProfileProvidersForAgentRuntime({
       provider,
       harnessRuntime: harnessPolicy.runtime,
-    }).map(normalizeProviderId);
-    if (!profile || !acceptedAuthProviders.includes(profileProvider ?? "")) {
+      config: cfg,
+    });
+    const profileIsAccepted =
+      profile &&
+      acceptedAuthProviders.some(
+        (candidateProvider) =>
+          normalizeProviderId(candidateProvider) === profileProvider ||
+          isStoredCredentialCompatibleWithAuthProvider({
+            cfg,
+            provider: candidateProvider,
+            credential: profile,
+          }),
+      );
+    if (!profileIsAccepted) {
       await clearSessionAuthProfileOverride({
         sessionEntry,
         sessionStore,

--- a/src/cli/models-cli.test.ts
+++ b/src/cli/models-cli.test.ts
@@ -209,6 +209,22 @@ describe("models cli", () => {
     });
   });
 
+  it("passes --device-code through models auth login", async () => {
+    await runModelsCommand([
+      "models",
+      "auth",
+      "login",
+      "--provider",
+      "openai-codex",
+      "--device-code",
+    ]);
+
+    expectCommandOptions(modelsAuthLoginCommand, {
+      provider: "openai-codex",
+      method: "device-code",
+    });
+  });
+
   it("passes list-specific --agent and --json to models auth list", async () => {
     await runModelsCommand(["models", "auth", "list", "--agent", "poe", "--json"]);
 

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -332,15 +332,22 @@ export function registerModelsCli(program: Command) {
     .description("Run a provider plugin auth flow (OAuth/API key)")
     .option("--provider <id>", "Provider id registered by a plugin")
     .option("--method <id>", "Provider auth method id")
+    .option("--device-code", "Use the provider's device-code auth method", false)
+    .option("--device-auth", "Alias for --device-code", false)
     .option("--set-default", "Apply the provider's default model recommendation", false)
     .action(async (opts, command) => {
       await withModelsRuntime(async ({ defaultRuntime, resolveModelAgentOption }) => {
         const agent = resolveModelAgentOption(command);
         const { modelsAuthLoginCommand } = await import("../commands/models/auth.js");
+        const wantsDeviceCode = Boolean(opts.deviceCode || opts.deviceAuth);
+        const requestedMethod = opts.method as string | undefined;
+        if (wantsDeviceCode && requestedMethod && requestedMethod !== "device-code") {
+          throw new Error("--device-code cannot be combined with a different --method value.");
+        }
         await modelsAuthLoginCommand(
           {
             provider: opts.provider as string | undefined,
-            method: opts.method as string | undefined,
+            method: wantsDeviceCode ? "device-code" : requestedMethod,
             setDefault: Boolean(opts.setDefault),
             agent,
           },

--- a/src/commands/auth-choice.model-check.ts
+++ b/src/commands/auth-choice.model-check.ts
@@ -26,6 +26,7 @@ function resolveAuthProviderCandidates(params: {
       ...listOpenAIAuthProfileProvidersForAgentRuntime({
         provider: params.provider,
         harnessRuntime: harnessPolicy.runtime,
+        config: params.config,
       }),
     ]),
   ];

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -1,5 +1,7 @@
 import type { BootstrapContextMode } from "../../agents/bootstrap-files.js";
+import { resolveAgentHarnessPolicy } from "../../agents/harness/selection.js";
 import { resolveCliRuntimeExecutionProvider } from "../../agents/model-runtime-aliases.js";
+import { resolveOpenAIRuntimeProviderForPi } from "../../agents/openai-codex-routing.js";
 import type { SkillSnapshot } from "../../agents/skills.js";
 import { normalizeToolList } from "../../agents/tool-policy.js";
 import type { ThinkLevel, VerboseLevel } from "../../auto-reply/thinking.js";
@@ -222,6 +224,25 @@ export function createCronPromptExecutor(params: {
           to: params.resolvedDelivery.to,
           threadId: params.resolvedDelivery.threadId,
         });
+        const agentHarnessPolicy = resolveAgentHarnessPolicy({
+          provider: providerOverride,
+          modelId: modelOverride,
+          config: params.cfgWithAgentDefaults,
+          agentId: params.agentId,
+          sessionKey: params.runSessionKey,
+        });
+        const embeddedRunProvider = resolveOpenAIRuntimeProviderForPi({
+          provider: providerOverride,
+          harnessRuntime: agentHarnessPolicy.runtime,
+          authProfileProvider: params.liveSelection.authProfileId?.split(":", 1)[0],
+          authProfileId: params.liveSelection.authProfileId,
+          config: params.cfgWithAgentDefaults,
+          workspaceDir: params.workspaceDir,
+        });
+        const agentHarnessRuntimeOverride =
+          agentHarnessPolicy.runtime === "pi" && agentHarnessPolicy.runtimeSource !== "implicit"
+            ? "pi"
+            : undefined;
         const result = await runEmbeddedPiAgent({
           sessionId: params.cronSession.sessionEntry.sessionId,
           sessionKey: params.runSessionKey,
@@ -246,9 +267,10 @@ export function createCronPromptExecutor(params: {
           skillsSnapshot: params.skillsSnapshot,
           prompt: promptText,
           lane: resolveCronAgentLane(params.lane),
-          provider: providerOverride,
+          provider: embeddedRunProvider,
           model: modelOverride,
           modelFallbacksOverride: cronFallbacksOverride,
+          agentHarnessRuntimeOverride,
           authProfileId: params.liveSelection.authProfileId,
           authProfileIdSource: params.liveSelection.authProfileId
             ? params.liveSelection.authProfileIdSource

--- a/src/cron/isolated-agent/run.cron-model-override-forwarding.test.ts
+++ b/src/cron/isolated-agent/run.cron-model-override-forwarding.test.ts
@@ -13,7 +13,9 @@ import {
   resolveAllowedModelRefMock,
   resolveConfiguredModelRefMock,
   resolveCronSessionMock,
+  resolveSessionAuthProfileOverrideMock,
   resolveSupportedThinkingLevelMock,
+  mockRunCronFallbackPassthrough,
   resetRunCronIsolatedAgentTurnHarness,
   restoreFastTestEnv,
   runEmbeddedPiAgentMock,
@@ -180,6 +182,112 @@ describe("runCronIsolatedAgentTurn — cron model override forwarding (#58065)",
     const embeddedCall = firstMockArg(runEmbeddedPiAgentMock);
     expect(embeddedCall.provider).toBe("google");
     expect(embeddedCall.model).toBe("gemini-2.0-flash");
+  });
+
+  it("routes explicit OpenAI PI cron runs through the Codex auth provider", async () => {
+    resolveConfiguredModelRefMock.mockReturnValue({
+      provider: "openai",
+      model: "gpt-5.4",
+    });
+    resolveAllowedModelRefMock.mockReturnValue({
+      ref: { provider: "openai", model: "gpt-5.4" },
+    });
+    resolveSessionAuthProfileOverrideMock.mockResolvedValue("openai-codex:work");
+    resolveCronSessionMock.mockReturnValue(
+      makeCronSession({
+        sessionEntry: makeCronSessionEntry({
+          authProfileOverrideSource: "auto",
+        }),
+        isNewSession: false,
+      }),
+    );
+    mockRunCronFallbackPassthrough();
+    runEmbeddedPiAgentMock.mockResolvedValue({
+      payloads: [{ text: "summary done" }],
+      meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+    });
+
+    const result = await runCronIsolatedAgentTurn(
+      makeParams({
+        cfg: {
+          models: {
+            providers: {
+              openai: {
+                baseUrl: "https://api.openai.com/v1",
+                agentRuntime: { id: "pi" },
+                models: [],
+              },
+            },
+          },
+          auth: {
+            order: {
+              openai: ["openai-codex:work"],
+            },
+          },
+        },
+        job: makeJob({
+          payload: {
+            kind: "agentTurn",
+            message: "summarize",
+            model: "openai/gpt-5.4",
+          },
+        }),
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(resolveSessionAuthProfileOverrideMock.mock.calls[0]?.[0]).toMatchObject({
+      acceptedProviderIds: ["openai-codex"],
+    });
+    const embeddedCall = firstMockArg(runEmbeddedPiAgentMock);
+    expect(embeddedCall.provider).toBe("openai-codex");
+    expect(embeddedCall.model).toBe("gpt-5.4");
+    expect(embeddedCall.agentHarnessRuntimeOverride).toBe("pi");
+    expect(embeddedCall.authProfileId).toBe("openai-codex:work");
+    expect(embeddedCall.authProfileIdSource).toBe("auto");
+  });
+
+  it("does not force implicit OpenAI Codex runtime as a cron override", async () => {
+    resolveConfiguredModelRefMock.mockReturnValue({
+      provider: "openai",
+      model: "gpt-5.4",
+    });
+    resolveAllowedModelRefMock.mockReturnValue({
+      ref: { provider: "openai", model: "gpt-5.4" },
+    });
+    mockRunCronFallbackPassthrough();
+    runEmbeddedPiAgentMock.mockResolvedValue({
+      payloads: [{ text: "summary done" }],
+      meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+    });
+
+    const result = await runCronIsolatedAgentTurn(
+      makeParams({
+        cfg: {
+          models: {
+            providers: {
+              openai: {
+                baseUrl: "https://api.openai.com/v1",
+                models: [],
+              },
+            },
+          },
+        },
+        job: makeJob({
+          payload: {
+            kind: "agentTurn",
+            message: "summarize",
+            model: "openai/gpt-5.4",
+          },
+        }),
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    const embeddedCall = firstMockArg(runEmbeddedPiAgentMock);
+    expect(embeddedCall.provider).toBe("openai");
+    expect(embeddedCall.model).toBe("gpt-5.4");
+    expect(embeddedCall.agentHarnessRuntimeOverride).toBeUndefined();
   });
 
   it("forwards isolated cron execution phase updates from embedded runs", async () => {

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -794,6 +794,7 @@ async function prepareCronRunContext(params: {
               agentId,
               sessionKey: agentSessionKey,
             }).runtime,
+            config: cfgWithAgentDefaults,
           }),
           agentDir,
           sessionEntry: cronSession.sessionEntry,


### PR DESCRIPTION
## Summary

Fixes #82521.

This makes explicit PI `openai/*` runs honor subscription-first `auth.order.openai` entries that point at `openai-codex:*` credentials, while keeping custom OpenAI-compatible base URLs on the normal `openai` auth path. The routing fix is applied across command attempts, auto-reply embedded runs, cron isolated-agent runs, and `/btw` runtime resolution.

It also accepts the documented `openclaw models auth login --provider openai-codex --device-code` shortcut, with `--device-auth` as an alias.

Root cause: the OpenAI PI auth-provider list and runtime-provider routing only considered the selected provider namespace in some paths, so `auth.order.openai = ["openai-codex:...", "openai:..."]` could still validate/select the OpenAI API-key backup before the Codex OAuth profile. Some embedded run paths also did not persist/forward the resolved session auth profile before choosing the PI transport provider.

## Reproduction

I added failing regression coverage first, then ran it in Blacksmith before the fix:

- Lease: `tbx_01krr4cyxf0bpqfb22n9gt5c9s`
- Actions run: https://github.com/openclaw/openclaw/actions/runs/25959337464
- Command:

```sh
env CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/auth-profiles/session-override.test.ts src/cli/models-cli.test.ts
```

Pre-fix failures matched the issue:

- Explicit PI `openai/gpt-5.5` with `auth.order.openai = ["openai-codex:sub@example.test", "openai:api-key-backup"]` selected `openai:api-key-backup` instead of `openai-codex:sub@example.test`.
- `models auth login --provider openai-codex --device-code` failed as an unknown option.

## Review Follow-Up

During comprehensive review, `codex review --base origin/main` found one accepted P1 regression: API-key-only `auth.order.openai` entries would have displaced existing native `openai-codex:*` OAuth profiles. I fixed that before pushing the PR update by restoring native Codex profile precedence when the alias order does not explicitly list a native Codex profile, while preserving explicit `openai-codex:*` entries in `auth.order.openai` when present.

A second `codex review --base origin/main` on the rebased branch reported no actionable regressions.

## Verification

Behavior addressed: documented cross-namespace OpenAI/Codex auth order now selects Codex OAuth for explicit PI `openai/*` runs; API-key-only alias orders still keep native Codex OAuth profiles first; OpenAI API-key backups still forward correctly for default Codex harness runs; custom OpenAI base URLs stay on `openai`; documented device-code login option is accepted.

Real environment tested: local Codex worktree and Blacksmith Testbox through Crabbox.

Exact steps or command run after this patch: local `node scripts/run-vitest.mjs src/agents/openai-codex-routing.test.ts src/agents/pi-embedded-runner/run.overflow-compaction.test.ts src/agents/auth-profiles.resolve-auth-profile-order.does-not-prioritize-lastgood-round-robin-ordering.test.ts src/agents/auth-profiles/session-override.test.ts src/cli/models-cli.test.ts src/commands/models/auth.test.ts extensions/codex/src/app-server/auth-bridge.test.ts src/auto-reply/reply/model-selection.test.ts src/agents/agent-command.live-model-switch.test.ts src/agents/command/attempt-execution.cli.test.ts src/auto-reply/reply/agent-runner-execution.test.ts src/agents/btw.test.ts src/cron/isolated-agent/run.cron-model-override-forwarding.test.ts src/agents/auth-profile-runtime-contract.test.ts src/agents/auth-profiles/order.test.ts`; local `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.reviewfix-rebased.tsbuildinfo --pretty false`; local `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/test-src.reviewfix-rebased.tsbuildinfo --pretty false`; local `git diff --check`; `codex review --base origin/main`; Blacksmith `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --blacksmith-workflow .github/workflows/ci-check-testbox.yml --blacksmith-job check --blacksmith-ref main --timing-json --shell -- "pnpm check:changed"`.

Evidence after fix: local focused suite passed 23 project files / 565 tests on the rebased branch; local core and test-source `tsgo` probes passed; `git diff --check` passed; Codex review found no actionable regressions after the native-ordering fix; Blacksmith Testbox lease `tbx_01krrj0be5rrjdd4zy970fe4h5` passed `pnpm check:changed` with exit 0, Actions run https://github.com/openclaw/openclaw/actions/runs/25964039929.

Observed result after fix: explicit PI OpenAI runs route through `openai-codex` when the selected auth profile is a Codex OAuth profile, persist the selected `openai-codex:*` session override, preserve `agentHarnessRuntimeOverride: "pi"`, and continue to allow `openai:*` API-key auth profiles where appropriate.

What was not tested: no live OpenAI/Codex account login was exercised; direct AWS Crabbox was not used because Blacksmith Testbox through Crabbox completed the requested remote proof.
