### PR TITLE
xai(video): treat 'pending' poll status as 'processing'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 - Providers/OAuth: let browser-hosted identity provider pages read successful localhost callback responses, preventing xAI Grok OAuth from showing a false connection failure after OpenClaw completes login.
 - Gateway/diagnostics: redact credential-bearing gateway target URLs and client diagnostics while preserving raw connection URLs for programmatic use, so connect-failure logs no longer surface embedded tokens.
 - Gateway/auth: honor `OPENCLAW_GATEWAY_TOKEN` as the remote interactive fallback when no remote token is configured, keeping remote TUI setup aligned with documented auth precedence.
+- Providers/xAI: continue polling video generations while xAI reports in-flight jobs as `pending`, so Grok video requests no longer fail before the final `done` response. (#82610) Thanks @Manzojunior.
 - Logs: redact raw Basic auth and named security headers from `logs.tail` output before returning lines to read-scoped clients. Fixes #66832. Thanks @Magicray1217.
 - CLI/gateway: emit structured JSON for gateway transport close/timeout failures when `--json` is requested by health, gateway health, and devices list commands. Fixes #79108. Thanks @TurboTheTurtle.
 - Telegram: normalize announce group targets via a new `resolveSessionTarget` channel hook so scheduled announcements resolve consistently against the same Telegram session conversation registry as inbound turns. Fixes #81229. Thanks @giodl73-repo.

--- a/extensions/xai/video-generation-provider.test.ts
+++ b/extensions/xai/video-generation-provider.test.ts
@@ -195,6 +195,56 @@ describe("xai video generation provider", () => {
     ).rejects.toThrow("xAI video generation response malformed");
   });
 
+  it("normalizes the xAI 'pending' poll status to 'processing' and keeps polling until done", async () => {
+    postJsonRequestMock.mockResolvedValue({
+      response: {
+        json: async () => ({
+          request_id: "req_pending",
+        }),
+      },
+      release: vi.fn(async () => {}),
+    });
+    fetchWithTimeoutMock
+      // First poll: in-progress payload mirroring xAI's real shape
+      .mockResolvedValueOnce({
+        json: async () => ({
+          request_id: "req_pending",
+          status: "pending",
+          progress: 42,
+        }),
+      })
+      // Second poll: complete
+      .mockResolvedValueOnce({
+        json: async () => ({
+          request_id: "req_pending",
+          status: "done",
+          video: { url: "https://cdn.x.ai/video-pending.mp4" },
+          progress: 100,
+        }),
+      })
+      // Download
+      .mockResolvedValueOnce({
+        headers: new Headers({ "content-type": "video/mp4" }),
+        arrayBuffer: async () => Buffer.from("mp4-bytes"),
+      });
+
+    const provider = buildXaiVideoGenerationProvider();
+    const result = await provider.generateVideo({
+      provider: "xai",
+      model: "grok-imagine-video",
+      prompt: "Pending then done",
+      cfg: {},
+      durationSeconds: 6,
+      aspectRatio: "9:16",
+      resolution: "720P",
+    });
+
+    // Two poll calls (one pending, one done) — not throwing on "pending"
+    expect((fetchWithTimeoutMock.mock.calls as unknown[]).length).toBeGreaterThanOrEqual(2);
+    expect(result.videos[0]?.mimeType).toBe("video/mp4");
+    expect(result.metadata?.requestId).toBe("req_pending");
+  });
+
   it("sends a single unroled image as xAI first-frame image-to-video", async () => {
     postJsonRequestMock.mockResolvedValue({
       response: {

--- a/extensions/xai/video-generation-provider.ts
+++ b/extensions/xai/video-generation-provider.ts
@@ -91,7 +91,12 @@ function readXaiCreateResponse(payload: Record<string, unknown>): XaiVideoCreate
 }
 
 function readXaiStatusResponse(payload: Record<string, unknown>): XaiVideoStatusResponse {
-  const status = normalizeOptionalString(payload.status);
+  const rawStatus = normalizeOptionalString(payload.status);
+  // xAI's /v1/videos/{id} endpoint currently returns "pending" (with a progress
+  // integer) for in-flight jobs. Treat it as "processing" so polling continues
+  // instead of failing with XAI_VIDEO_MALFORMED_RESPONSE.
+  const status =
+    rawStatus === "pending" || rawStatus === "in_progress" ? "processing" : rawStatus;
   if (!status || !["queued", "processing", "done", "failed", "expired"].includes(status)) {
     throw new Error(XAI_VIDEO_MALFORMED_RESPONSE);
   }


### PR DESCRIPTION
## Problem

After authenticating xAI via `openclaw models auth login --provider xai`, every
call to `openclaw capability video generate --model xai/grok-imagine-video …`
fails with:

```
Error: xAI video generation response malformed
```

The submit (`POST /v1/videos/generations`) and the first poll
(`GET /v1/videos/{id}`) both succeed against `api.x.ai`. The crash is in
`readXaiStatusResponse` — xAI's poll endpoint currently returns

```json
{ "status": "pending", "progress": 24 }
{ "status": "pending", "progress": 81 }
{ "status": "done", "video": { "url": "https://vidgen.x.ai/…" }, "progress": 100, … }
```

…but the whitelist is `queued | processing | done | failed | expired`. `"pending"`
trips the malformed-response throw, so polling never gets a chance to see the
final `"done"`.

Verified on the live API today (2026-05-16) with a real SuperGrok OAuth token.

## Fix

Normalize the incoming status: treat `"pending"` (and `"in_progress"` for
forward-compat) as `"processing"` before the whitelist check. The downstream
polling loop already handles `"processing"` correctly, so no further changes
are needed.

```diff
 function readXaiStatusResponse(payload: Record<string, unknown>): XaiVideoStatusResponse {
-  const status = normalizeOptionalString(payload.status);
+  const rawStatus = normalizeOptionalString(payload.status);
+  const status =
+    rawStatus === "pending" || rawStatus === "in_progress" ? "processing" : rawStatus;
   if (!status || !["queued", "processing", "done", "failed", "expired"].includes(status)) {
     throw new Error(XAI_VIDEO_MALFORMED_RESPONSE);
   }
```

## Test

Added a focused unit test that mocks the real-shape sequence
(`pending` → `done`) and asserts the polling loop survives the first response
and completes with the video URL from the second response. Follows the existing
fixture style in `video-generation-provider.test.ts`.

## End-to-end verification

After applying this patch to my local `dist/` build:

```bash
openclaw capability video generate \
  --model xai/grok-imagine-video \
  --prompt "peaceful Korean countryside village at sunrise, light fog drifting" \
  --aspect-ratio 9:16 --resolution 720P --duration 6 \
  --output /tmp/grok.mp4 --timeout-ms 360000
# → /tmp/grok.mp4 (≈7 MB, 9:16 720P 6s mp4)
```

`models status` continues to show xAI as `configured=true`, default chat model
untouched.

## Notes (separate from this PR)

I ran into two adjacent rough edges during validation; happy to file them as
issues or follow-up PRs if useful:

1. The `xai` plugin isn't in the default `plugins.allow` list, so
   `openclaw plugins enable xai` returns
   `Plugin "xai" could not be enabled (blocked by allowlist).` until the user
   manually edits `openclaw.json`. Given the plugin ships in
   `dist/extensions/xai/` with `enabledByDefault: true`, adding `xai` to the
   default allowlist would match the apparent intent.
2. `dist/undici-runtime-*.js` requires `undici` unconditionally, but it isn't
   in OpenClaw's own `package.json`. A fresh `npm i -g openclaw` then a video
   call throws `Cannot find module 'undici'` until the user installs it
   manually.

## Maintainer real behavior proof

Behavior addressed: xAI video polling now accepts the live `pending` status and continues until the final `done` response instead of throwing `xAI video generation response malformed`.

Real environment tested: Contributor verified against the live xAI API on 2026-05-16 with a real SuperGrok OAuth token; maintainer verified the patch shape against current source and pushed the rebased PR branch.

Exact steps or command run after this patch: `openclaw capability video generate --model xai/grok-imagine-video --prompt "peaceful Korean countryside village at sunrise, light fog drifting" --aspect-ratio 9:16 --resolution 720P --duration 6 --output /tmp/grok.mp4 --timeout-ms 360000`

Evidence after fix: Contributor reported `/tmp/grok.mp4` was produced as an approximately 7 MB 9:16 720P 6s mp4 after applying the patch.

Observed result after fix: The first poll response with `status: "pending"` no longer aborts the request; polling reaches `done` and downloads the generated video.

What was not tested: Maintainer local Vitest for `extensions/xai/video-generation-provider.test.ts` stalled in the local extension-provider harness before assertions; GitHub CI is the authoritative unit/check lane for the rebased PR SHA.


## Real behavior proof

Behavior addressed: xAI video polling now accepts the live `pending` status and continues until the final `done` response instead of throwing `xAI video generation response malformed`.

Real environment tested: Contributor verified against the live xAI API on 2026-05-16 with a real SuperGrok OAuth token.

Exact steps or command run after this patch: `openclaw capability video generate --model xai/grok-imagine-video --prompt "peaceful Korean countryside village at sunrise, light fog drifting" --aspect-ratio 9:16 --resolution 720P --duration 6 --output /tmp/grok.mp4 --timeout-ms 360000`

Evidence after fix: Live output: `/tmp/grok.mp4` was produced as an approximately 7 MB 9:16 720P 6s mp4 after applying the patch.

Observed result after fix: The first poll response with `status: "pending"` no longer aborts the request; polling reaches `done` and downloads the generated video.

What was not tested: Maintainer local Vitest for `extensions/xai/video-generation-provider.test.ts` stalled in the local extension-provider harness before assertions; GitHub CI is the authoritative unit/check lane for the rebased PR SHA.
