### PR TITLE
Revert PR 82472: Fix bundled channel dist-runtime setup roots

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -2036,8 +2036,6 @@ describe("initSessionState reset triggers in WhatsApp groups", () => {
     const storePath = await createStorePath("openclaw-group-activation-backfill-");
     await writeSessionStoreFast(storePath, {
       [sessionKey]: {
-        sessionId: "activation-only",
-        updatedAt: 0,
         groupActivation: "always",
       },
     });

--- a/src/channels/plugins/bundled.shape-guard.test.ts
+++ b/src/channels/plugins/bundled.shape-guard.test.ts
@@ -187,7 +187,6 @@ afterEach(() => {
   vi.doUnmock("../../plugins/manifest-registry.js");
   vi.doUnmock("../../plugins/channel-catalog-registry.js");
   vi.doUnmock("../../infra/boundary-file-read.js");
-  vi.doUnmock("./bundled-root.js");
   vi.doUnmock("jiti");
 });
 
@@ -573,63 +572,6 @@ describe("bundled channel entry shape guards", () => {
       fs.rmSync(rootA, { recursive: true, force: true });
       fs.rmSync(rootB, { recursive: true, force: true });
       delete testGlobal.__bundledRootRuntime;
-    }
-  });
-
-  it("uses dist-runtime as the boundary root for packaged setup entries", async () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-bundled-runtime-root-"));
-    const pluginDir = path.join(root, "dist-runtime", "extensions", "alpha");
-    fs.mkdirSync(pluginDir, { recursive: true });
-    fs.writeFileSync(
-      path.join(pluginDir, "setup-entry.js"),
-      [
-        "export default {",
-        "  kind: 'bundled-channel-setup-entry',",
-        "  loadSetupPlugin() {",
-        "    return {",
-        "      id: 'alpha',",
-        "      meta: { id: 'alpha', label: 'Setup dist-runtime' },",
-        "      capabilities: {},",
-        "      config: {},",
-        "    };",
-        "  },",
-        "};",
-        "",
-      ].join("\n"),
-      "utf8",
-    );
-
-    vi.doMock("./bundled-root.js", () => ({
-      resolveBundledChannelRootScope: () => ({
-        packageRoot: root,
-        cacheKey: `${root}:dist-runtime`,
-      }),
-    }));
-    vi.doMock("../../plugins/bundled-channel-runtime.js", () => ({
-      listBundledChannelPluginMetadata: () => [alphaChannelMetadata({ includeSetup: true })],
-      resolveBundledChannelGeneratedPath: (
-        rootDir: string,
-        entry: BundledEntrySource | undefined,
-        pluginDirName?: string,
-      ) =>
-        path.join(
-          rootDir,
-          "dist-runtime",
-          "extensions",
-          pluginDirName ?? "alpha",
-          (entry?.built ?? entry?.source ?? "./index.js").replace(/^\.\//u, ""),
-        ),
-    }));
-
-    try {
-      const bundled = await importFreshModule<typeof import("./bundled.js")>(
-        import.meta.url,
-        "./bundled.js?scope=bundled-dist-runtime-boundary",
-      );
-
-      expect(bundled.getBundledChannelSetupPlugin("alpha")?.meta.label).toBe("Setup dist-runtime");
-    } finally {
-      fs.rmSync(root, { recursive: true, force: true });
     }
   });
 

--- a/src/channels/plugins/bundled.ts
+++ b/src/channels/plugins/bundled.ts
@@ -1,7 +1,6 @@
 import path from "node:path";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
-import { isPathInside } from "../../infra/path-guards.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type {
   BundledChannelLegacySessionSurface,
@@ -161,25 +160,19 @@ function resolveBundledChannelBoundaryRoot(params: {
   metadata: BundledChannelPluginMetadata;
   modulePath: string;
 }): string {
-  const isModuleUnderRoot = (root: string) => isPathInside(path.resolve(root), params.modulePath);
   const overrideRoot = params.pluginsDir
     ? path.resolve(params.pluginsDir, params.metadata.dirName)
     : null;
-  if (overrideRoot && isModuleUnderRoot(overrideRoot)) {
+  if (
+    overrideRoot &&
+    (params.modulePath === overrideRoot ||
+      params.modulePath.startsWith(`${overrideRoot}${path.sep}`))
+  ) {
     return overrideRoot;
   }
   const distRoot = path.resolve(params.packageRoot, "dist", "extensions", params.metadata.dirName);
-  if (isModuleUnderRoot(distRoot)) {
+  if (params.modulePath === distRoot || params.modulePath.startsWith(`${distRoot}${path.sep}`)) {
     return distRoot;
-  }
-  const distRuntimeRoot = path.resolve(
-    params.packageRoot,
-    "dist-runtime",
-    "extensions",
-    params.metadata.dirName,
-  );
-  if (isModuleUnderRoot(distRuntimeRoot)) {
-    return distRuntimeRoot;
   }
   return path.resolve(params.packageRoot, "extensions", params.metadata.dirName);
 }

--- a/src/commands/doctor-heartbeat-session-target.test.ts
+++ b/src/commands/doctor-heartbeat-session-target.test.ts
@@ -68,7 +68,7 @@ describe("describeHeartbeatSessionTargetIssues", () => {
     const cfg = cfgWithSession("agent:ops:main");
     writeStore(cfg, {
       "agent:ops:work": {
-        sessionId: "agent-ops-work",
+        sessionId: "agent:ops:work",
         updatedAt: Date.now(),
       },
     });

--- a/src/plugins/bundled-plugin-metadata.test.ts
+++ b/src/plugins/bundled-plugin-metadata.test.ts
@@ -631,22 +631,6 @@ describe("bundled plugin metadata", () => {
     expectGeneratedPathResolution(tempRoot, path.join("dist", "extensions", "plugin", "index.js"));
   });
 
-  it("uses dist-runtime generated paths before source fallback when packaged dist is absent", () => {
-    const tempRoot = createGeneratedPluginTempRoot("openclaw-bundled-plugin-runtime-metadata-");
-    const pluginRoot = path.join(tempRoot, "extensions", "plugin");
-    const runtimePluginRoot = path.join(tempRoot, "dist-runtime", "extensions", "plugin");
-
-    fs.mkdirSync(pluginRoot, { recursive: true });
-    fs.mkdirSync(runtimePluginRoot, { recursive: true });
-    fs.writeFileSync(path.join(pluginRoot, "index.ts"), "export {};\n", "utf8");
-    fs.writeFileSync(path.join(runtimePluginRoot, "index.js"), "export {};\n", "utf8");
-
-    expectGeneratedPathResolution(
-      tempRoot,
-      path.join("dist-runtime", "extensions", "plugin", "index.js"),
-    );
-  });
-
   it("resolves plugin-local generated entry paths when the plugin dir is provided", () => {
     const tempRoot = createGeneratedPluginTempRoot("openclaw-bundled-plugin-metadata-local-");
     const pluginRoot = path.join(tempRoot, "extensions", "alpha");

--- a/src/plugins/bundled-plugin-metadata.ts
+++ b/src/plugins/bundled-plugin-metadata.ts
@@ -231,7 +231,6 @@ function listBundledPluginEntryBaseDirs(params: {
   const baseDirs = [
     ...(params.scanDir ? [path.resolve(params.scanDir, params.pluginDirName ?? "")] : []),
     path.resolve(params.rootDir, "dist", "extensions", params.pluginDirName ?? ""),
-    path.resolve(params.rootDir, "dist-runtime", "extensions", params.pluginDirName ?? ""),
     path.resolve(params.rootDir, "extensions", params.pluginDirName ?? ""),
   ];
   return baseDirs.filter((entry, index, all) => all.indexOf(entry) === index);


### PR DESCRIPTION
## Summary
- Reverts #82472 / 1bd10cfee6a4ad608c97e47b4294cc81586406d9.
- Rebases the revert onto latest origin/main at 6a65ea8c3ac18736f437b212b503255434aa9113.
- Preserves newer follow-up fixes already present on main from #82578, including the cron and gateway test expectations that now match current behavior.

## Real behavior proof
Behavior or issue addressed: The revert PR is updated against current remote main and no longer reintroduces the gateway expectation that CI showed is incorrect on the current code path.

Real environment tested: Local OpenClaw checkout at C:\src\openclaw-stack with GitHub CLI authenticated as giodl73-repo, targeting openclaw/openclaw PR #82612.

Exact steps or command run after this patch: After amending the revert, I ran git diff --check origin/main...HEAD, git push fork HEAD:refs/heads/revert-82472-red-main-20260516-0642 --force-with-lease, and gh api repos/openclaw/openclaw/pulls/82612 to verify the remote PR head/base and mergeability.

Evidence after fix: Terminal output captured after the push showed base 6a65ea8c3ac18736f437b212b503255434aa9113, head 0892099cfc07e94948e67d045fd2bd4c7e62424c, mergeable true, mergeable_state unstable, git diff --check origin/main...HEAD produced no output, and git diff --name-only origin/main...HEAD listed: src/auto-reply/reply/session.test.ts; src/channels/plugins/bundled.shape-guard.test.ts; src/channels/plugins/bundled.ts; src/commands/doctor-heartbeat-session-target.test.ts; src/plugins/bundled-plugin-metadata.test.ts; src/plugins/bundled-plugin-metadata.ts.

Observed result after fix: GitHub reports PR #82612 head 0892099cfc07e94948e67d045fd2bd4c7e62424c based on current base 6a65ea8c3ac18736f437b212b503255434aa9113 with mergeable true; the current diff no longer includes src/gateway/server.sessions.create.test.ts, removing the failing assertion from the PR.

What was not tested: Local Vitest execution on Windows did not start because scripts/run-vitest.mjs hit spawn EPERM; CI remains the runtime test source of truth for the branch.

## Validation
- git diff --check origin/main...HEAD
- CI is the source of truth for test validation on this PR. Local pnpm test:changed stalled during dependency download, and targeted Vitest did not start on Windows due spawn EPERM from scripts/run-vitest.mjs.