### PR TITLE
Strip inbound metadata from replayed user turns

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -279,6 +279,49 @@ describe("buildToolSearchRunPlan", () => {
 });
 
 describe("normalizeMessagesForLlmBoundary", () => {
+  it("strips inbound metadata from historical user turns before model replay", () => {
+    const historicalEnvelope =
+      'Conversation info (untrusted metadata):\n```json\n{"channel":"telegram","chatType":"dm"}\n```\n\nSender (untrusted metadata):\n```json\n{"id":"user-1"}\n```\n\nActual historical ask';
+    const input = [
+      {
+        role: "user",
+        content: [{ type: "text", text: historicalEnvelope }],
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Historical answer" }],
+        timestamp: 2,
+      },
+    ];
+
+    const output = normalizeMessagesForLlmBoundary(
+      input as Parameters<typeof normalizeMessagesForLlmBoundary>[0],
+    ) as unknown as Array<{ content?: Array<{ text?: string }> }>;
+
+    expect(output[0]?.content?.[0]?.text).toBe("Actual historical ask");
+    expect(JSON.stringify(output)).not.toContain("Conversation info");
+    expect(JSON.stringify(output)).not.toContain("Sender (untrusted metadata)");
+    expect(JSON.stringify(input)).toContain("Conversation info");
+  });
+
+  it("strips inbound metadata from string historical user turns", () => {
+    const input = [
+      {
+        role: "user",
+        content:
+          'Conversation info (untrusted metadata):\n```json\n{"channel":"telegram"}\n```\n\nPlain historical ask',
+        timestamp: 1,
+      },
+    ];
+
+    const output = normalizeMessagesForLlmBoundary(
+      input as Parameters<typeof normalizeMessagesForLlmBoundary>[0],
+    ) as unknown as Array<{ content?: string }>;
+
+    expect(output[0]?.content).toBe("Plain historical ask");
+  });
+
   it("strips tool result details before provider conversion", () => {
     const input = [
       {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -6,6 +6,7 @@ import { createAgentSession, SessionManager } from "@earendil-works/pi-coding-ag
 import { isAcpRuntimeSpawnAvailable } from "../../../acp/runtime/availability.js";
 import { buildHierarchyReinforcementMessage } from "../../../auto-reply/handoff-summarizer.js";
 import { filterHeartbeatPairs } from "../../../auto-reply/heartbeat-filter.js";
+import { stripInboundMetadata } from "../../../auto-reply/reply/strip-inbound-meta.js";
 import { getRuntimeConfig } from "../../../config/config.js";
 import { resolveStorePath } from "../../../config/sessions/paths.js";
 import {
@@ -652,7 +653,52 @@ function summarizeSessionContext(messages: AgentMessage[]): {
 
 export function normalizeMessagesForLlmBoundary(messages: AgentMessage[]): AgentMessage[] {
   const normalized = stripToolResultDetails(normalizeAssistantReplayContent(messages));
-  return stripHistoricalRuntimeContextCustomMessages(normalized);
+  const withoutHistoricalInboundMetadata =
+    stripHistoricalInboundMetadataFromUserMessages(normalized);
+  return stripHistoricalRuntimeContextCustomMessages(withoutHistoricalInboundMetadata);
+}
+
+function stripHistoricalInboundMetadataFromUserMessages(messages: AgentMessage[]): AgentMessage[] {
+  let changed = false;
+  const nextMessages = messages.map((message) => {
+    if (message.role !== "user") {
+      return message;
+    }
+    const content = (message as { content?: unknown }).content;
+    if (typeof content === "string") {
+      const stripped = stripInboundMetadata(content);
+      if (stripped === content) {
+        return message;
+      }
+      changed = true;
+      return { ...message, content: stripped } as AgentMessage;
+    }
+    if (!Array.isArray(content)) {
+      return message;
+    }
+    let contentChanged = false;
+    const nextContent = content.map((block) => {
+      if (!block || typeof block !== "object") {
+        return block;
+      }
+      const textBlock = block as { type?: unknown; text?: unknown };
+      if (textBlock.type !== "text" || typeof textBlock.text !== "string") {
+        return block;
+      }
+      const stripped = stripInboundMetadata(textBlock.text);
+      if (stripped === textBlock.text) {
+        return block;
+      }
+      contentChanged = true;
+      return Object.assign({}, block, { text: stripped });
+    });
+    if (!contentChanged) {
+      return message;
+    }
+    changed = true;
+    return { ...message, content: nextContent } as AgentMessage;
+  });
+  return changed ? nextMessages : messages;
 }
 
 function cloneHookMessages(messages: AgentMessage[]): AgentMessage[] {

--- a/src/auto-reply/reply/strip-inbound-meta.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.ts
@@ -1,12 +1,14 @@
 /**
  * Strips OpenClaw-injected inbound metadata blocks from a user-role message
- * text before it is displayed in any UI surface (TUI, webchat, macOS app).
+ * text before it is displayed in any UI surface (TUI, webchat, macOS app) or
+ * replayed as historical context to the model.
  *
  * Background: `buildInboundUserContextPrefix` in `inbound-meta.ts` prepends
  * structured metadata blocks (Conversation info, Sender info, reply context,
  * etc.) directly to the stored user message content so the LLM can access
- * them. These blocks are AI-facing only and must never surface in user-visible
- * chat history.
+ * them. These blocks are current-turn AI-facing context only and must never
+ * surface in user-visible chat history or accumulate in historical prompt
+ * replay.
  *
  * Also strips the timestamp prefix injected by `injectTimestamp` so UI surfaces
  * do not show AI-facing envelope metadata as user text.


### PR DESCRIPTION
## Summary
- strip OpenClaw inbound metadata envelopes from historical user turns at the LLM replay boundary
- preserve current-turn inbound context because it is still built separately for the active prompt
- cover both string user content and structured text-block user content

Fixes #82337

## Tests
- `CI=1 node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/attempt.test.ts src/auto-reply/reply/strip-inbound-meta.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/agents/pi-embedded-runner/run/attempt.ts src/agents/pi-embedded-runner/run/attempt.test.ts src/auto-reply/reply/strip-inbound-meta.ts`
- `/usr/bin/git diff --check`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/pi-embedded-runner/run/attempt.ts src/agents/pi-embedded-runner/run/attempt.test.ts src/auto-reply/reply/strip-inbound-meta.ts`
- `pnpm check:changed`

## Real behavior proof
- **Behavior or issue addressed:** Historical user turns that were persisted with OpenClaw inbound metadata envelopes (`Conversation info`, `Sender`, etc.) are stripped before model-bound replay, while the current turn still receives its active metadata through the normal current-turn context path.
- **Real environment tested:** WSL `Ubuntu-24.04`, source checkout at `/root/src/openclaw-branches/base`, branch `fix-strip-inbound-replay-82337`, commit `0273c3b37fdbceebf8d97dfbac26d90a87684fb3`.
- **Exact steps or command run after this patch:** In the source checkout, I generated a production-only reverse patch for `attempt.ts`/`strip-inbound-meta.ts`, ran the historical replay command before and after restoring the production fix, then reran the focused after-fix command:

```bash
cd /root/src/openclaw-branches/base
CI=1 node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/attempt.test.ts -t 'historical user'
```

- **Evidence after fix:** Copied terminal output from the WSL source checkout:

```text
before_status=1
after_status=0
BEFORE_EXCERPT
Failed Tests 4
FAIL agents-core ../../src/agents/pi-embedded-runner/run/attempt.test.ts > normalizeMessagesForLlmBoundary > strips inbound metadata from historical user turns before model replay
AssertionError: expected 'Conversation info (untrusted metadata…' to be 'Actual historical ask'
FAIL agents-core ../../src/agents/pi-embedded-runner/run/attempt.test.ts > normalizeMessagesForLlmBoundary > strips inbound metadata from string historical user turns
AssertionError: expected 'Conversation info (untrusted metadata…' to be 'Plain historical ask'
AFTER_EXCERPT
Test Files 2 passed (2)
Tests 4 passed | 280 skipped (284)
```

- **Observed result after fix:** The same historical replay normalization path now outputs `Actual historical ask` and `Plain historical ask` instead of replaying the inbound `Conversation info` envelope. The branch keeps current-turn metadata untouched because this sanitizer only runs on the historical `activeSession.messages` replay boundary.
- **What was not tested:** No additional gaps.