### PR TITLE
fix(plugins): cache metadata snapshots across bootstrap keys

### DIFF
--- a/src/plugins/plugin-metadata-snapshot.memo.test.ts
+++ b/src/plugins/plugin-metadata-snapshot.memo.test.ts
@@ -275,6 +275,50 @@ describe("loadPluginMetadataSnapshot process memo", () => {
     expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledOnce();
   });
 
+  it("memoizes source-stale derived snapshots after persisted registry freshness checks", () => {
+    const stateDir = tempStateDir();
+    touchPersistedIndex(stateDir);
+    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
+      source: "derived",
+      snapshot: makeIndex(),
+      diagnostics: [
+        {
+          level: "warn",
+          code: "persisted-registry-stale-source",
+          message: "source changed",
+        },
+      ],
+    });
+
+    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir });
+    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir });
+
+    expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledOnce();
+  });
+
+  it("keeps separate memo entries for workspace-scoped and unscoped callers", () => {
+    const stateDir = tempStateDir();
+    touchPersistedIndex(stateDir);
+    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
+      source: "derived",
+      snapshot: makeIndex(),
+      diagnostics: [
+        {
+          level: "warn",
+          code: "persisted-registry-stale-policy",
+          message: "policy changed",
+        },
+      ],
+    });
+
+    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir, workspaceDir: "/workspace" });
+    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir });
+    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir, workspaceDir: "/workspace" });
+    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir });
+
+    expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledTimes(2);
+  });
+
   it("refreshes policy-stale derived snapshots when derived plugin files change", () => {
     const stateDir = tempStateDir();
     touchPersistedIndex(stateDir);
@@ -304,7 +348,6 @@ describe("loadPluginMetadataSnapshot process memo", () => {
 
   it.each([
     ["persisted-registry-missing", undefined],
-    ["persisted-registry-stale-source", undefined],
     ["persisted-registry-disabled", undefined],
     [undefined, { preferPersisted: false }],
   ])("does not memoize derived snapshots for %s diagnostics", (code, options) => {

--- a/src/plugins/plugin-metadata-snapshot.memo.test.ts
+++ b/src/plugins/plugin-metadata-snapshot.memo.test.ts
@@ -423,6 +423,64 @@ describe("loadPluginMetadataSnapshot process memo", () => {
     expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledTimes(2);
   });
 
+  it("invalidates source-stale memo entries when existing discovery children gain plugin files", () => {
+    const stateDir = tempStateDir();
+    const loadPath = path.join(stateDir, "configured-plugins");
+    const pluginDir = path.join(loadPath, "new-plugin");
+    fs.mkdirSync(pluginDir, { recursive: true });
+    touchPersistedIndex(stateDir);
+    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
+      source: "derived",
+      snapshot: makeIndex("stable"),
+      diagnostics: [
+        {
+          level: "warn",
+          code: "persisted-registry-stale-source",
+          message: "source changed",
+        },
+      ],
+    });
+    const config = { plugins: { load: { paths: [loadPath] } } };
+
+    loadPluginMetadataSnapshot({ config, env: {}, stateDir });
+    writeJson(path.join(pluginDir, "package.json"), {
+      name: "new-plugin",
+      openclaw: { extensions: ["index.js"] },
+    });
+    loadPluginMetadataSnapshot({ config, env: {}, stateDir });
+
+    expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidates source-stale memo entries when discovery child marker files change", () => {
+    const stateDir = tempStateDir();
+    const loadPath = path.join(stateDir, "configured-plugins");
+    const pluginDir = path.join(loadPath, "new-plugin");
+    writeJson(path.join(pluginDir, "package.json"), { name: "new-plugin" });
+    touchPersistedIndex(stateDir);
+    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
+      source: "derived",
+      snapshot: makeIndex("stable"),
+      diagnostics: [
+        {
+          level: "warn",
+          code: "persisted-registry-stale-source",
+          message: "source changed",
+        },
+      ],
+    });
+    const config = { plugins: { load: { paths: [loadPath] } } };
+
+    loadPluginMetadataSnapshot({ config, env: {}, stateDir });
+    writeJson(path.join(pluginDir, "package.json"), {
+      name: "new-plugin",
+      openclaw: { extensions: ["index.js"] },
+    });
+    loadPluginMetadataSnapshot({ config, env: {}, stateDir });
+
+    expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledTimes(2);
+  });
+
   it("evicts the least recently used snapshot memo entry after the cap", () => {
     const stateDir = tempStateDir();
     touchPersistedIndex(stateDir);

--- a/src/plugins/plugin-metadata-snapshot.memo.test.ts
+++ b/src/plugins/plugin-metadata-snapshot.memo.test.ts
@@ -335,6 +335,42 @@ describe("loadPluginMetadataSnapshot process memo", () => {
     expect(unscopedAgain.index.plugins[0]?.pluginId).toBe("unscoped");
   });
 
+  it("does not let one workspace's discovery watches invalidate another workspace slot", () => {
+    const stateDir = tempStateDir();
+    const firstWorkspaceDir = path.join(stateDir, "workspace-a");
+    const secondWorkspaceDir = path.join(stateDir, "workspace-b");
+    touchPersistedIndex(stateDir);
+    loadPluginRegistrySnapshotWithMetadata.mockImplementation(
+      (params: { workspaceDir?: string }) => ({
+        source: "derived",
+        snapshot: makeIndex(params.workspaceDir === firstWorkspaceDir ? "first" : "second"),
+        diagnostics: [
+          {
+            level: "warn",
+            code: "persisted-registry-stale-source",
+            message: "source changed",
+          },
+        ],
+      }),
+    );
+
+    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir, workspaceDir: firstWorkspaceDir });
+    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir, workspaceDir: secondWorkspaceDir });
+    writeJson(
+      path.join(firstWorkspaceDir, ".openclaw", "extensions", "new-plugin", "package.json"),
+      { name: "new-plugin" },
+    );
+    const secondAgain = loadPluginMetadataSnapshot({
+      config: {},
+      env: {},
+      stateDir,
+      workspaceDir: secondWorkspaceDir,
+    });
+
+    expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledTimes(2);
+    expect(secondAgain.index.plugins[0]?.pluginId).toBe("second");
+  });
+
   it("keeps separate source-stale memo entries reachable across registry contexts", () => {
     const firstStateDir = tempStateDir();
     const secondStateDir = tempStateDir();
@@ -399,6 +435,46 @@ describe("loadPluginMetadataSnapshot process memo", () => {
     expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledTimes(2);
   });
 
+  it("invalidates source-stale memo entries when orphaned diagnostic sources appear", () => {
+    const stateDir = tempStateDir();
+    const orphanedDiagnosticSource = path.join(stateDir, "extensions", "orphaned", "index.js");
+    writeJson(path.join(stateDir, "plugins", "installs.json"), {
+      version: 1,
+      hostContractVersion: "test",
+      compatRegistryVersion: "test",
+      migrationVersion: 1,
+      policyHash: "test",
+      generatedAtMs: 1,
+      installRecords: {},
+      plugins: [],
+      diagnostics: [
+        {
+          level: "warn",
+          pluginId: "orphaned",
+          source: orphanedDiagnosticSource,
+          message: "missing diagnostic source",
+        },
+      ],
+    });
+    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
+      source: "derived",
+      snapshot: makeIndex("stable"),
+      diagnostics: [
+        {
+          level: "warn",
+          code: "persisted-registry-stale-source",
+          message: "source changed",
+        },
+      ],
+    });
+
+    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir });
+    writeJson(orphanedDiagnosticSource, "restored");
+    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir });
+
+    expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledTimes(2);
+  });
+
   it("invalidates source-stale memo entries when discovery roots gain plugins", () => {
     const stateDir = tempStateDir();
     const loadPath = path.join(stateDir, "configured-plugins");
@@ -411,6 +487,30 @@ describe("loadPluginMetadataSnapshot process memo", () => {
           level: "warn",
           code: "persisted-registry-stale-source",
           message: "source changed",
+        },
+      ],
+    });
+    const config = { plugins: { load: { paths: [loadPath] } } };
+
+    loadPluginMetadataSnapshot({ config, env: {}, stateDir });
+    writeJson(path.join(loadPath, "new-plugin", "openclaw.plugin.json"), { id: "new-plugin" });
+    loadPluginMetadataSnapshot({ config, env: {}, stateDir });
+
+    expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidates policy-stale memo entries when discovery roots gain plugins", () => {
+    const stateDir = tempStateDir();
+    const loadPath = path.join(stateDir, "configured-plugins");
+    touchPersistedIndex(stateDir);
+    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
+      source: "derived",
+      snapshot: makeIndex("stable"),
+      diagnostics: [
+        {
+          level: "warn",
+          code: "persisted-registry-stale-policy",
+          message: "policy changed",
         },
       ],
     });
@@ -477,6 +577,149 @@ describe("loadPluginMetadataSnapshot process memo", () => {
       openclaw: { extensions: ["index.js"] },
     });
     loadPluginMetadataSnapshot({ config, env: {}, stateDir });
+
+    expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidates source-stale memo entries when nested bundle default markers appear", () => {
+    const stateDir = tempStateDir();
+    const loadPath = path.join(stateDir, "configured-plugins");
+    const pluginDir = path.join(loadPath, "cursor-bundle");
+    writeJson(path.join(pluginDir, ".cursor-plugin", "plugin.json"), { name: "cursor-bundle" });
+    fs.mkdirSync(path.join(pluginDir, ".cursor"), { recursive: true });
+    touchPersistedIndex(stateDir);
+    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
+      source: "derived",
+      snapshot: makeIndex("stable"),
+      diagnostics: [
+        {
+          level: "warn",
+          code: "persisted-registry-stale-source",
+          message: "source changed",
+        },
+      ],
+    });
+    const config = { plugins: { load: { paths: [loadPath] } } };
+
+    loadPluginMetadataSnapshot({ config, env: {}, stateDir });
+    fs.mkdirSync(path.join(pluginDir, ".cursor", "commands"), { recursive: true });
+    loadPluginMetadataSnapshot({ config, env: {}, stateDir });
+
+    expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidates source-stale memo entries when package-declared nested entry files appear", () => {
+    const stateDir = tempStateDir();
+    const loadPath = path.join(stateDir, "configured-plugins");
+    const pluginDir = path.join(loadPath, "nested-plugin");
+    fs.mkdirSync(path.join(pluginDir, "src"), { recursive: true });
+    writeJson(path.join(pluginDir, "package.json"), {
+      name: "nested-plugin",
+      openclaw: { extensions: ["src/index.ts"] },
+    });
+    touchPersistedIndex(stateDir);
+    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
+      source: "derived",
+      snapshot: makeIndex("stable"),
+      diagnostics: [
+        {
+          level: "warn",
+          code: "persisted-registry-stale-source",
+          message: "source changed",
+        },
+      ],
+    });
+    const config = { plugins: { load: { paths: [loadPath] } } };
+
+    loadPluginMetadataSnapshot({ config, env: {}, stateDir });
+    fs.writeFileSync(path.join(pluginDir, "src", "index.js"), "export {};\n");
+    loadPluginMetadataSnapshot({ config, env: {}, stateDir });
+
+    expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores malformed package manifests while caching source-stale discovery watches", () => {
+    const stateDir = tempStateDir();
+    const loadPath = path.join(stateDir, "configured-plugins");
+    const pluginDir = path.join(loadPath, "malformed-plugin");
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.writeFileSync(path.join(pluginDir, "package.json"), "{", "utf8");
+    touchPersistedIndex(stateDir);
+    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
+      source: "derived",
+      snapshot: makeIndex("stable"),
+      diagnostics: [
+        {
+          level: "warn",
+          code: "persisted-registry-stale-source",
+          message: "source changed",
+        },
+      ],
+    });
+    const config = { plugins: { load: { paths: [loadPath] } } };
+
+    loadPluginMetadataSnapshot({ config, env: {}, stateDir });
+    loadPluginMetadataSnapshot({ config, env: {}, stateDir });
+
+    expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not read package-declared entry watches from package manifests outside the plugin root", () => {
+    const stateDir = tempStateDir();
+    const loadPath = path.join(stateDir, "configured-plugins");
+    const pluginDir = path.join(loadPath, "symlinked-package");
+    const sourceDir = path.join(pluginDir, "src");
+    const outsidePackageJson = path.join(stateDir, "outside", "package.json");
+    fs.mkdirSync(sourceDir, { recursive: true });
+    writeJson(outsidePackageJson, {
+      name: "outside-package",
+      openclaw: { extensions: ["src/index.ts"] },
+    });
+    fs.symlinkSync(outsidePackageJson, path.join(pluginDir, "package.json"));
+    touchPersistedIndex(stateDir);
+    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
+      source: "derived",
+      snapshot: makeIndex("stable"),
+      diagnostics: [
+        {
+          level: "warn",
+          code: "persisted-registry-stale-source",
+          message: "source changed",
+        },
+      ],
+    });
+    const config = { plugins: { load: { paths: [loadPath] } } };
+
+    loadPluginMetadataSnapshot({ config, env: {}, stateDir });
+    fs.writeFileSync(path.join(sourceDir, "index.js"), "export {};\n");
+    loadPluginMetadataSnapshot({ config, env: {}, stateDir });
+
+    expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledTimes(1);
+  });
+
+  it("invalidates source-stale memo entries when bundled source checkout roots gain plugins", () => {
+    const stateDir = tempStateDir();
+    const packageRoot = path.join(stateDir, "openclaw-package");
+    const stockRoot = path.join(packageRoot, "dist", "extensions");
+    const sourceRoot = path.join(packageRoot, "extensions");
+    fs.mkdirSync(stockRoot, { recursive: true });
+    touchPersistedIndex(stateDir);
+    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
+      source: "derived",
+      snapshot: makeIndex("stable"),
+      diagnostics: [
+        {
+          level: "warn",
+          code: "persisted-registry-stale-source",
+          message: "source changed",
+        },
+      ],
+    });
+    const env = { OPENCLAW_BUNDLED_PLUGINS_DIR: stockRoot };
+
+    loadPluginMetadataSnapshot({ config: {}, env, stateDir });
+    writeJson(path.join(sourceRoot, "new-plugin", "openclaw.plugin.json"), { id: "new-plugin" });
+    loadPluginMetadataSnapshot({ config: {}, env, stateDir });
 
     expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledTimes(2);
   });

--- a/src/plugins/plugin-metadata-snapshot.memo.test.ts
+++ b/src/plugins/plugin-metadata-snapshot.memo.test.ts
@@ -319,6 +319,79 @@ describe("loadPluginMetadataSnapshot process memo", () => {
     expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledTimes(2);
   });
 
+  it("keeps separate source-stale memo entries reachable across registry contexts", () => {
+    const firstStateDir = tempStateDir();
+    const secondStateDir = tempStateDir();
+    touchPersistedIndex(firstStateDir);
+    touchPersistedIndex(secondStateDir);
+    loadPluginRegistrySnapshotWithMetadata.mockImplementation((params: { stateDir?: string }) => ({
+      source: "derived",
+      snapshot: makeIndex(params.stateDir === firstStateDir ? "first" : "second"),
+      diagnostics: [
+        {
+          level: "warn",
+          code: "persisted-registry-stale-source",
+          message: "source changed",
+        },
+      ],
+    }));
+
+    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir: firstStateDir });
+    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir: secondStateDir });
+    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir: firstStateDir });
+    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir: secondStateDir });
+
+    expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidates source-stale memo entries when stale persisted plugin files appear", () => {
+    const stateDir = tempStateDir();
+    const staleSourcePath = path.join(stateDir, "extensions", "stale", "index.js");
+    writePersistedIndex({ pluginId: "stale", source: staleSourcePath, stateDir });
+    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
+      source: "derived",
+      snapshot: makeIndex("stable"),
+      diagnostics: [
+        {
+          level: "warn",
+          code: "persisted-registry-stale-source",
+          message: "source changed",
+        },
+      ],
+    });
+
+    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir });
+    writeJson(staleSourcePath, "restored");
+    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir });
+
+    expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledTimes(2);
+  });
+
+  it("evicts the least recently used snapshot memo entry after the cap", () => {
+    const stateDir = tempStateDir();
+    touchPersistedIndex(stateDir);
+    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
+      source: "persisted",
+      snapshot: makeIndex(),
+      diagnostics: [],
+    });
+
+    for (let index = 0; index < 8; index += 1) {
+      loadPluginMetadataSnapshot({
+        config: {},
+        env: {},
+        stateDir,
+        workspaceDir: `/workspace-${index}`,
+      });
+    }
+    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir, workspaceDir: "/workspace-0" });
+    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir, workspaceDir: "/workspace-8" });
+    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir, workspaceDir: "/workspace-0" });
+    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir, workspaceDir: "/workspace-1" });
+
+    expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledTimes(10);
+  });
+
   it("refreshes policy-stale derived snapshots when derived plugin files change", () => {
     const stateDir = tempStateDir();
     touchPersistedIndex(stateDir);

--- a/src/plugins/plugin-metadata-snapshot.memo.test.ts
+++ b/src/plugins/plugin-metadata-snapshot.memo.test.ts
@@ -299,24 +299,40 @@ describe("loadPluginMetadataSnapshot process memo", () => {
   it("keeps separate memo entries for workspace-scoped and unscoped callers", () => {
     const stateDir = tempStateDir();
     touchPersistedIndex(stateDir);
-    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
-      source: "derived",
-      snapshot: makeIndex(),
-      diagnostics: [
-        {
-          level: "warn",
-          code: "persisted-registry-stale-policy",
-          message: "policy changed",
-        },
-      ],
-    });
+    loadPluginRegistrySnapshotWithMetadata.mockImplementation(
+      (params: { workspaceDir?: string }) => ({
+        source: "derived",
+        snapshot: makeIndex(params.workspaceDir ? "workspace" : "unscoped"),
+        diagnostics: [
+          {
+            level: "warn",
+            code: "persisted-registry-stale-policy",
+            message: "policy changed",
+          },
+        ],
+      }),
+    );
 
-    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir, workspaceDir: "/workspace" });
-    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir });
-    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir, workspaceDir: "/workspace" });
-    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir });
+    const workspaceInitial = loadPluginMetadataSnapshot({
+      config: {},
+      env: {},
+      stateDir,
+      workspaceDir: "/workspace",
+    });
+    const unscopedInitial = loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir });
+    const workspaceAgain = loadPluginMetadataSnapshot({
+      config: {},
+      env: {},
+      stateDir,
+      workspaceDir: "/workspace",
+    });
+    const unscopedAgain = loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir });
 
     expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledTimes(2);
+    expect(workspaceInitial.index.plugins[0]?.pluginId).toBe("workspace");
+    expect(unscopedInitial.index.plugins[0]?.pluginId).toBe("unscoped");
+    expect(workspaceAgain.index.plugins[0]?.pluginId).toBe("workspace");
+    expect(unscopedAgain.index.plugins[0]?.pluginId).toBe("unscoped");
   });
 
   it("keeps separate source-stale memo entries reachable across registry contexts", () => {
@@ -336,12 +352,28 @@ describe("loadPluginMetadataSnapshot process memo", () => {
       ],
     }));
 
-    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir: firstStateDir });
-    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir: secondStateDir });
-    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir: firstStateDir });
-    loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir: secondStateDir });
+    const firstInitial = loadPluginMetadataSnapshot({
+      config: {},
+      env: {},
+      stateDir: firstStateDir,
+    });
+    const secondInitial = loadPluginMetadataSnapshot({
+      config: {},
+      env: {},
+      stateDir: secondStateDir,
+    });
+    const firstAgain = loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir: firstStateDir });
+    const secondAgain = loadPluginMetadataSnapshot({
+      config: {},
+      env: {},
+      stateDir: secondStateDir,
+    });
 
     expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledTimes(2);
+    expect(firstInitial.index.plugins[0]?.pluginId).toBe("first");
+    expect(secondInitial.index.plugins[0]?.pluginId).toBe("second");
+    expect(firstAgain.index.plugins[0]?.pluginId).toBe("first");
+    expect(secondAgain.index.plugins[0]?.pluginId).toBe("second");
   });
 
   it("invalidates source-stale memo entries when stale persisted plugin files appear", () => {
@@ -363,6 +395,30 @@ describe("loadPluginMetadataSnapshot process memo", () => {
     loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir });
     writeJson(staleSourcePath, "restored");
     loadPluginMetadataSnapshot({ config: {}, env: {}, stateDir });
+
+    expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidates source-stale memo entries when discovery roots gain plugins", () => {
+    const stateDir = tempStateDir();
+    const loadPath = path.join(stateDir, "configured-plugins");
+    touchPersistedIndex(stateDir);
+    loadPluginRegistrySnapshotWithMetadata.mockReturnValue({
+      source: "derived",
+      snapshot: makeIndex("stable"),
+      diagnostics: [
+        {
+          level: "warn",
+          code: "persisted-registry-stale-source",
+          message: "source changed",
+        },
+      ],
+    });
+    const config = { plugins: { load: { paths: [loadPath] } } };
+
+    loadPluginMetadataSnapshot({ config, env: {}, stateDir });
+    writeJson(path.join(loadPath, "new-plugin", "openclaw.plugin.json"), { id: "new-plugin" });
+    loadPluginMetadataSnapshot({ config, env: {}, stateDir });
 
     expect(loadPluginRegistrySnapshotWithMetadata).toHaveBeenCalledTimes(2);
   });

--- a/src/plugins/plugin-metadata-snapshot.ts
+++ b/src/plugins/plugin-metadata-snapshot.ts
@@ -13,6 +13,8 @@ import {
   CODEX_BUNDLE_MANIFEST_RELATIVE_PATH,
   CURSOR_BUNDLE_MANIFEST_RELATIVE_PATH,
 } from "./bundle-manifest.js";
+import { buildLegacyBundledRootPath } from "./bundled-load-path-aliases.js";
+import { listBundledSourceOverlayDirs } from "./bundled-source-overlays.js";
 import { resolveDefaultPluginNpmDir } from "./install-paths.js";
 import { hashJson } from "./installed-plugin-index-hash.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
@@ -24,7 +26,14 @@ import {
   resolveInstalledManifestRegistryIndexFingerprint,
 } from "./manifest-registry-installed.js";
 import { loadPluginManifestRegistry, type PluginManifestRecord } from "./manifest-registry.js";
-import { DEFAULT_PLUGIN_ENTRY_CANDIDATES, PLUGIN_MANIFEST_FILENAME } from "./manifest.js";
+import {
+  DEFAULT_PLUGIN_ENTRY_CANDIDATES,
+  getPackageManifestMetadata,
+  PLUGIN_MANIFEST_FILENAME,
+  resolvePackageExtensionEntries,
+  type PackageManifest,
+} from "./manifest.js";
+import { listBuiltRuntimeEntryCandidates } from "./package-entrypoints.js";
 import {
   resolvePluginControlPlaneFingerprint,
   resolvePluginDiscoveryContext,
@@ -49,9 +58,15 @@ type PersistedRegistryMemoState = {
   contextHash: string;
   fastHash: string;
   fingerprint: unknown;
+  scopeHash?: string;
   watchedFilesHash: string;
   watchedFiles: readonly string[];
 };
+
+type PersistedRegistryMemoLookupIdentity = Pick<
+  PersistedRegistryMemoState,
+  "contextHash" | "fastHash" | "scopeHash"
+>;
 
 const PLUGIN_METADATA_SNAPSHOT_MEMO_MAX_ENTRIES = 8;
 const pluginMetadataSnapshotMemo = new Map<string, PluginMetadataSnapshotMemo>();
@@ -64,11 +79,18 @@ const PLUGIN_DISCOVERY_CANDIDATE_MARKER_PATHS = [
   CURSOR_BUNDLE_MANIFEST_RELATIVE_PATH,
   CLAUDE_BUNDLE_MANIFEST_RELATIVE_PATH,
   "skills",
+  "hooks",
+  ".app.json",
   "commands",
   "agents",
   path.join("hooks", "hooks.json"),
+  path.join(".cursor", "commands"),
+  path.join(".cursor", "agents"),
+  path.join(".cursor", "hooks.json"),
+  path.join(".cursor", "rules"),
   ".mcp.json",
   ".lsp.json",
+  "output-styles",
   "settings.json",
 ] as const;
 
@@ -222,6 +244,23 @@ function watchedFileFingerprint(filePath: string | undefined, watchedFiles: Set<
   }
   watchedFiles.add(filePath);
   return fileFingerprint(filePath);
+}
+
+function persistedDiagnosticSourceFingerprint(params: {
+  pluginRootDir: string | undefined;
+  source: string | undefined;
+  watchedFiles: Set<string>;
+}): unknown {
+  if (params.pluginRootDir) {
+    return persistedPluginFileFingerprint(params.pluginRootDir, params.source, {
+      watchedFiles: params.watchedFiles,
+    });
+  }
+  return params.source && path.isAbsolute(params.source)
+    ? watchedFileFingerprint(params.source, params.watchedFiles)
+    : persistedPluginFileFingerprint(params.pluginRootDir, params.source, {
+        watchedFiles: params.watchedFiles,
+      });
 }
 
 function resolveInstallRecordPath(value: unknown, env: NodeJS.ProcessEnv): string | undefined {
@@ -410,6 +449,20 @@ function resolvePersistedRegistryMemoContextHash(params: {
   });
 }
 
+function resolvePersistedRegistryMemoLookupIdentity(params: {
+  env: NodeJS.ProcessEnv;
+  preferPersisted?: boolean;
+  stateDir?: string;
+}): PersistedRegistryMemoLookupIdentity {
+  const fastFingerprint = resolvePersistedRegistryFastMemoFingerprint(params);
+  const fastHash = hashJson(fastFingerprint);
+  const contextHash = resolvePersistedRegistryMemoContextHash({
+    ...params,
+    fastFingerprint,
+  });
+  return { contextHash, fastHash };
+}
+
 function hashWatchedFiles(watchedFiles: readonly string[]): string {
   return hashJson(watchedFiles.map((filePath) => fileFingerprint(filePath)));
 }
@@ -419,6 +472,7 @@ function setCappedMemoEntry<Key, Value>(params: {
   key: Key;
   value: Value;
 }): void {
+  // Map iteration is insertion-ordered; re-inserting on hits makes this an LRU cap.
   params.memo.delete(params.key);
   params.memo.set(params.key, params.value);
   if (params.memo.size > PLUGIN_METADATA_SNAPSHOT_MEMO_MAX_ENTRIES) {
@@ -431,10 +485,12 @@ function setCappedMemoEntry<Key, Value>(params: {
 
 function computePersistedRegistryMemoStateMemoKey(
   state: Pick<PersistedRegistryMemoState, "contextHash" | "fastHash">,
+  scopeHash: string,
 ): string {
   return hashJson({
     contextHash: state.contextHash,
     fastHash: state.fastHash,
+    scopeHash,
   });
 }
 
@@ -448,11 +504,23 @@ function mergePersistedRegistryMemoStates(params: {
   );
   return {
     ...merged,
+    scopeHash: params.lookup.scopeHash,
     fingerprint: {
       derived: params.derived.fingerprint,
-      lookup: params.lookup.fingerprint,
+      lookup: unwrapMergedPersistedRegistryLookupFingerprint(params.lookup.fingerprint),
     },
   };
+}
+
+function unwrapMergedPersistedRegistryLookupFingerprint(fingerprint: unknown): unknown {
+  if (
+    isRecord(fingerprint) &&
+    Object.prototype.hasOwnProperty.call(fingerprint, "derived") &&
+    Object.prototype.hasOwnProperty.call(fingerprint, "lookup")
+  ) {
+    return fingerprint.lookup;
+  }
+  return fingerprint;
 }
 
 function mergePersistedRegistryMemoStateWatchedFiles(
@@ -548,10 +616,13 @@ function resolvePersistedRegistryMemoState(params: {
     }
     const pluginId = normalizeString(rawDiagnostic.pluginId);
     const source = normalizeString(rawDiagnostic.source);
+    const pluginRootDir = pluginId ? pluginRootById.get(pluginId) : undefined;
     return [
       pluginId,
       source,
-      persistedPluginFileFingerprint(pluginId ? pluginRootById.get(pluginId) : undefined, source, {
+      persistedDiagnosticSourceFingerprint({
+        pluginRootDir,
+        source,
         watchedFiles,
       }),
     ];
@@ -582,22 +653,21 @@ function resolvePersistedRegistryMemoState(params: {
 }
 
 function resolvePersistedRegistryMemoStateForLookup(params: {
+  config: OpenClawConfig;
   env: NodeJS.ProcessEnv;
   preferPersisted?: boolean;
   stateDir?: string;
+  workspaceDir?: string;
 }): PersistedRegistryMemoState {
-  const fastFingerprint = resolvePersistedRegistryFastMemoFingerprint(params);
-  const fastHash = hashJson(fastFingerprint);
-  const contextHash = resolvePersistedRegistryMemoContextHash({
-    ...params,
-    fastFingerprint,
-  });
-  const memoKey = computePersistedRegistryMemoStateMemoKey({ contextHash, fastHash });
+  const { contextHash, fastHash } = resolvePersistedRegistryMemoLookupIdentity(params);
+  const scopeHash = resolvePersistedRegistryMemoStateScopeHash(params);
+  const memoKey = computePersistedRegistryMemoStateMemoKey({ contextHash, fastHash }, scopeHash);
   const registryState = pluginMetadataSnapshotRegistryStateMemo.get(memoKey);
   if (
     registryState &&
     registryState.contextHash === contextHash &&
     registryState.fastHash === fastHash &&
+    registryState.scopeHash === scopeHash &&
     hashWatchedFiles(registryState.watchedFiles) === registryState.watchedFilesHash
   ) {
     setCappedMemoEntry({
@@ -607,27 +677,35 @@ function resolvePersistedRegistryMemoStateForLookup(params: {
     });
     return registryState;
   }
-  return resolvePersistedRegistryMemoState(params);
+  return {
+    ...resolvePersistedRegistryMemoState(params),
+    scopeHash,
+  };
 }
 
 function isPersistedRegistryMemoStateFreshForLookup(
-  params: {
-    env: NodeJS.ProcessEnv;
-    preferPersisted?: boolean;
-    stateDir?: string;
-  },
+  identity: PersistedRegistryMemoLookupIdentity,
   registryState: PersistedRegistryMemoState,
 ): boolean {
-  const fastFingerprint = resolvePersistedRegistryFastMemoFingerprint(params);
-  const fastHash = hashJson(fastFingerprint);
-  const contextHash = resolvePersistedRegistryMemoContextHash({
-    ...params,
-    fastFingerprint,
-  });
   return (
-    registryState.contextHash === contextHash &&
-    registryState.fastHash === fastHash &&
+    registryState.contextHash === identity.contextHash &&
+    registryState.fastHash === identity.fastHash &&
+    registryState.scopeHash === identity.scopeHash &&
     hashWatchedFiles(registryState.watchedFiles) === registryState.watchedFilesHash
+  );
+}
+
+function resolvePersistedRegistryMemoStateScopeHash(params: {
+  config: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  workspaceDir?: string;
+}): string {
+  return hashJson(
+    resolvePluginDiscoveryContext({
+      config: params.config,
+      env: params.env,
+      workspaceDir: params.workspaceDir,
+    }),
   );
 }
 
@@ -815,7 +893,9 @@ export function loadPluginMetadataSnapshot(
   const activeTimelineSpan = getActiveDiagnosticsTimelineSpan();
   const env = params.env ?? process.env;
   const registryStateLookupParams = {
+    config: params.config,
     env,
+    ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
     ...(params.stateDir ? { stateDir: resolveUserPath(params.stateDir, env) } : {}),
     ...(params.preferPersisted !== undefined ? { preferPersisted: params.preferPersisted } : {}),
   };
@@ -823,7 +903,6 @@ export function loadPluginMetadataSnapshot(
   const memoLookup = resolvePluginMetadataSnapshotMemoLookup({
     params,
     registryState,
-    registryStateLookupParams,
   });
   if (memoLookup) {
     setCappedMemoEntry({
@@ -867,13 +946,18 @@ export function loadPluginMetadataSnapshot(
       registryState,
       result,
     });
+    // Derived entries keep lookup-side context/fast hashes; the derived index
+    // only changes the richer fingerprint used by the snapshot memo key.
     const cachedMemoKey = computePluginMetadataSnapshotMemoKey({
       params,
       registryState: cachedRegistryState,
     });
     setCappedMemoEntry({
       memo: pluginMetadataSnapshotRegistryStateMemo,
-      key: computePersistedRegistryMemoStateMemoKey(cachedRegistryState),
+      key: computePersistedRegistryMemoStateMemoKey(
+        cachedRegistryState,
+        resolvePersistedRegistryMemoStateScopeHash(registryStateLookupParams),
+      ),
       value: cachedRegistryState,
     });
     setCappedMemoEntry({
@@ -891,11 +975,6 @@ export function loadPluginMetadataSnapshot(
 function resolvePluginMetadataSnapshotMemoLookup(params: {
   params: LoadPluginMetadataSnapshotParams;
   registryState: PersistedRegistryMemoState;
-  registryStateLookupParams: {
-    env: NodeJS.ProcessEnv;
-    preferPersisted?: boolean;
-    stateDir?: string;
-  };
 }): { memoKey: string; memo: PluginMetadataSnapshotMemo } | undefined {
   const memoKey = computePluginMetadataSnapshotMemoKey({
     params: params.params,
@@ -905,18 +984,20 @@ function resolvePluginMetadataSnapshotMemoLookup(params: {
   if (memo) {
     return { memoKey, memo };
   }
+  const lookupIdentity = {
+    contextHash: params.registryState.contextHash,
+    fastHash: params.registryState.fastHash,
+    scopeHash: params.registryState.scopeHash,
+  };
   for (const [candidateKey, candidate] of pluginMetadataSnapshotMemo) {
     if (!candidate.registryState) {
       continue;
     }
-    if (
-      !isPersistedRegistryMemoStateFreshForLookup(
-        params.registryStateLookupParams,
-        candidate.registryState,
-      )
-    ) {
+    if (!isPersistedRegistryMemoStateFreshForLookup(lookupIdentity, candidate.registryState)) {
       continue;
     }
+    // The registry-state memo can evict independently; probe each snapshot with
+    // its own state so still-fresh snapshot slots remain reachable.
     const candidateMemoKey = computePluginMetadataSnapshotMemoKey({
       params: params.params,
       registryState: candidate.registryState,
@@ -932,15 +1013,6 @@ const CACHEABLE_DERIVED_REGISTRY_DIAGNOSTIC_CODES = new Set([
   "persisted-registry-stale-policy",
   "persisted-registry-stale-source",
 ]);
-
-function hasRegistryDiagnosticCode(
-  result: {
-    snapshot: PluginMetadataSnapshot;
-  },
-  code: string,
-): boolean {
-  return result.snapshot.registryDiagnostics.some((diagnostic) => diagnostic.code === code);
-}
 
 function resolveCachedRegistryStateForResult(params: {
   env: NodeJS.ProcessEnv;
@@ -964,18 +1036,16 @@ function resolveCachedRegistryStateForResult(params: {
       ? { preferPersisted: params.params.preferPersisted }
       : {}),
   });
-  return hasRegistryDiagnosticCode(params.result, "persisted-registry-stale-source")
-    ? mergePersistedRegistryMemoStates({
-        derived: mergePersistedRegistryMemoStateWatchedFiles(
-          derivedRegistryState,
-          resolvePluginDiscoveryWatchPaths({
-            env: params.env,
-            params: params.params,
-          }),
-        ),
-        lookup: params.registryState,
-      })
-    : derivedRegistryState;
+  return mergePersistedRegistryMemoStates({
+    derived: mergePersistedRegistryMemoStateWatchedFiles(
+      derivedRegistryState,
+      resolvePluginDiscoveryWatchPaths({
+        env: params.env,
+        params: params.params,
+      }),
+    ),
+    lookup: params.registryState,
+  });
 }
 
 function resolvePluginDiscoveryWatchPaths(params: {
@@ -988,11 +1058,19 @@ function resolvePluginDiscoveryWatchPaths(params: {
     workspaceDir: params.params.workspaceDir,
   });
   const watchedFiles = new Set<string>();
+  const bundledSourceRoot = discovery.roots.stock
+    ? buildLegacyBundledRootPath(discovery.roots.stock)
+    : null;
   for (const filePath of [
     discovery.roots.stock,
+    bundledSourceRoot,
     discovery.roots.global,
     discovery.roots.workspace,
     ...discovery.loadPaths,
+    ...listBundledSourceOverlayDirs({
+      bundledRoot: discovery.roots.stock,
+      env: params.env,
+    }),
   ]) {
     addPluginDiscoveryWatchPath(watchedFiles, filePath);
   }
@@ -1001,7 +1079,7 @@ function resolvePluginDiscoveryWatchPaths(params: {
 
 function addPluginDiscoveryWatchPath(
   watchedFiles: Set<string>,
-  filePath: string | undefined,
+  filePath: string | null | undefined,
 ): void {
   if (!filePath) {
     return;
@@ -1011,6 +1089,9 @@ function addPluginDiscoveryWatchPath(
   if (!stat?.isDirectory()) {
     return;
   }
+  // Stale derived scans can discover plugins outside the persisted index, so
+  // keep the cache tied to the same first-level markers discovery uses. Directory
+  // fingerprints catch missing marker creation; existing markers catch content changes.
   addPluginDiscoveryCandidateMarkerWatchPaths(watchedFiles, filePath);
   let entries: fs.Dirent[] = [];
   try {
@@ -1032,7 +1113,106 @@ function addPluginDiscoveryCandidateMarkerWatchPaths(
   candidateRoot: string,
 ): void {
   for (const markerPath of PLUGIN_DISCOVERY_CANDIDATE_MARKER_PATHS) {
-    watchedFiles.add(path.join(candidateRoot, markerPath));
+    const resolvedMarkerPath = path.join(candidateRoot, markerPath);
+    addExistingWatchPath(watchedFiles, resolvedMarkerPath);
+    if (path.dirname(markerPath) !== ".") {
+      addNearestExistingParentDirectory(watchedFiles, candidateRoot, resolvedMarkerPath);
+    }
+  }
+  addPackageDeclaredEntryWatchPaths(watchedFiles, candidateRoot);
+}
+
+function addExistingWatchPath(watchedFiles: Set<string>, filePath: string): void {
+  if (safeStat(filePath)) {
+    watchedFiles.add(filePath);
+  }
+}
+
+function addPackageDeclaredEntryWatchPaths(watchedFiles: Set<string>, candidateRoot: string): void {
+  const packageJson = readPluginRootPackageJson(candidateRoot);
+  if (!packageJson) {
+    return;
+  }
+  const packageManifest = getPackageManifestMetadata(packageJson);
+  const extensionResolution = resolvePackageExtensionEntries(packageJson);
+  if (extensionResolution.status === "ok") {
+    for (const entryPath of extensionResolution.entries) {
+      addPackageEntryWatchPath(watchedFiles, candidateRoot, entryPath);
+    }
+  }
+  for (const entryPath of [
+    ...normalizeStringList(packageManifest?.runtimeExtensions),
+    packageManifest?.setupEntry,
+    packageManifest?.runtimeSetupEntry,
+  ]) {
+    addPackageEntryWatchPath(watchedFiles, candidateRoot, entryPath);
+  }
+}
+
+function readPluginRootPackageJson(candidateRoot: string): PackageManifest | undefined {
+  const resolved = resolvePluginFilePath(candidateRoot, "package.json");
+  if (resolved.status !== "ok") {
+    return undefined;
+  }
+  return readJsonObject(resolved.path) as PackageManifest | undefined;
+}
+
+function normalizeStringList(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter(
+    (entry): entry is string => typeof entry === "string" && entry.trim().length > 0,
+  );
+}
+
+function addPackageEntryWatchPath(
+  watchedFiles: Set<string>,
+  candidateRoot: string,
+  entryPath: string | undefined,
+): void {
+  if (!entryPath) {
+    return;
+  }
+  const rootDir = path.resolve(candidateRoot);
+  const resolved = path.resolve(rootDir, entryPath);
+  if (!isPathInsideOrEqual(resolved, rootDir)) {
+    return;
+  }
+  addPackageEntryTargetWatchPath(watchedFiles, rootDir, resolved);
+  for (const candidate of listBuiltRuntimeEntryCandidates(entryPath)) {
+    const built = path.resolve(rootDir, candidate);
+    if (isPathInsideOrEqual(built, rootDir)) {
+      addPackageEntryTargetWatchPath(watchedFiles, rootDir, built);
+    }
+  }
+}
+
+function addPackageEntryTargetWatchPath(
+  watchedFiles: Set<string>,
+  rootDir: string,
+  targetPath: string,
+): void {
+  addExistingWatchPath(watchedFiles, targetPath);
+  addNearestExistingParentDirectory(watchedFiles, rootDir, targetPath);
+}
+
+function addNearestExistingParentDirectory(
+  watchedFiles: Set<string>,
+  rootDir: string,
+  targetPath: string,
+): void {
+  let current = path.dirname(targetPath);
+  while (isPathInsideOrEqual(current, rootDir)) {
+    if (safeStat(current)?.isDirectory()) {
+      watchedFiles.add(current);
+      return;
+    }
+    const next = path.dirname(current);
+    if (next === current) {
+      return;
+    }
+    current = next;
   }
 }
 

--- a/src/plugins/plugin-metadata-snapshot.ts
+++ b/src/plugins/plugin-metadata-snapshot.ts
@@ -32,7 +32,6 @@ import {
 } from "./plugin-registry.js";
 
 type PluginMetadataSnapshotMemo = {
-  key: string;
   registryState?: PersistedRegistryMemoState;
   snapshot: PluginMetadataSnapshot;
 };
@@ -45,10 +44,15 @@ type PersistedRegistryMemoState = {
   watchedFiles: readonly string[];
 };
 
-let pluginMetadataSnapshotMemo: PluginMetadataSnapshotMemo | undefined;
+const PLUGIN_METADATA_SNAPSHOT_MEMO_MAX_ENTRIES = 8;
+const pluginMetadataSnapshotMemo = new Map<string, PluginMetadataSnapshotMemo>();
+let pluginMetadataSnapshotRegistryStateMemo:
+  | Pick<PluginMetadataSnapshotMemo, "registryState">
+  | undefined;
 
 export function clearLoadPluginMetadataSnapshotMemo(): void {
-  pluginMetadataSnapshotMemo = undefined;
+  pluginMetadataSnapshotMemo.clear();
+  pluginMetadataSnapshotRegistryStateMemo = undefined;
 }
 
 const MEMO_RELEVANT_ENV_KEYS = [
@@ -500,7 +504,7 @@ function resolvePersistedRegistryMemoStateForLookup(
     preferPersisted?: boolean;
     stateDir?: string;
   },
-  memo: PluginMetadataSnapshotMemo | undefined,
+  memo: Pick<PluginMetadataSnapshotMemo, "registryState"> | undefined,
 ): PersistedRegistryMemoState {
   const fastFingerprint = resolvePersistedRegistryFastMemoFingerprint(params);
   const fastHash = hashJson(fastFingerprint);
@@ -702,7 +706,6 @@ export function loadPluginMetadataSnapshot(
   params: LoadPluginMetadataSnapshotParams,
 ): PluginMetadataSnapshot {
   const activeTimelineSpan = getActiveDiagnosticsTimelineSpan();
-  const memo = pluginMetadataSnapshotMemo;
   const env = params.env ?? process.env;
   const registryState = resolvePersistedRegistryMemoStateForLookup(
     {
@@ -710,10 +713,13 @@ export function loadPluginMetadataSnapshot(
       ...(params.stateDir ? { stateDir: resolveUserPath(params.stateDir, env) } : {}),
       ...(params.preferPersisted !== undefined ? { preferPersisted: params.preferPersisted } : {}),
     },
-    memo,
+    pluginMetadataSnapshotRegistryStateMemo,
   );
   const memoKey = computePluginMetadataSnapshotMemoKey({ params, registryState });
-  if (memo?.key === memoKey) {
+  const memo = pluginMetadataSnapshotMemo.get(memoKey);
+  if (memo) {
+    pluginMetadataSnapshotMemo.delete(memoKey);
+    pluginMetadataSnapshotMemo.set(memoKey, memo);
     return measureDiagnosticsTimelineSpanSync(
       "plugins.metadata.scan",
       () => clonePluginMetadataSnapshot(memo.snapshot),
@@ -755,14 +761,29 @@ export function loadPluginMetadataSnapshot(
               : {}),
           })
         : registryState;
-    pluginMetadataSnapshotMemo = {
-      key: computePluginMetadataSnapshotMemoKey({ params, registryState: cachedRegistryState }),
+    const cachedMemoKey = computePluginMetadataSnapshotMemoKey({
+      params,
+      registryState: cachedRegistryState,
+    });
+    pluginMetadataSnapshotRegistryStateMemo = { registryState: cachedRegistryState };
+    pluginMetadataSnapshotMemo.set(cachedMemoKey, {
       registryState: cachedRegistryState,
       snapshot: clonePluginMetadataSnapshot(result.snapshot),
-    };
+    });
+    if (pluginMetadataSnapshotMemo.size > PLUGIN_METADATA_SNAPSHOT_MEMO_MAX_ENTRIES) {
+      const oldestKey = pluginMetadataSnapshotMemo.keys().next().value;
+      if (oldestKey !== undefined) {
+        pluginMetadataSnapshotMemo.delete(oldestKey);
+      }
+    }
   }
   return result.snapshot;
 }
+
+const CACHEABLE_DERIVED_REGISTRY_DIAGNOSTIC_CODES = new Set([
+  "persisted-registry-stale-policy",
+  "persisted-registry-stale-source",
+]);
 
 function canMemoizePluginMetadataSnapshotResult(result: {
   registrySource: PluginRegistrySnapshotSource;
@@ -776,8 +797,8 @@ function canMemoizePluginMetadataSnapshotResult(result: {
   }
   return (
     result.snapshot.registryDiagnostics.length > 0 &&
-    result.snapshot.registryDiagnostics.every(
-      (diagnostic) => diagnostic.code === "persisted-registry-stale-policy",
+    result.snapshot.registryDiagnostics.every((diagnostic) =>
+      CACHEABLE_DERIVED_REGISTRY_DIAGNOSTIC_CODES.has(diagnostic.code),
     )
   );
 }

--- a/src/plugins/plugin-metadata-snapshot.ts
+++ b/src/plugins/plugin-metadata-snapshot.ts
@@ -8,6 +8,11 @@ import {
 } from "../infra/diagnostics-timeline.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveCompatibilityHostVersion } from "../version.js";
+import {
+  CLAUDE_BUNDLE_MANIFEST_RELATIVE_PATH,
+  CODEX_BUNDLE_MANIFEST_RELATIVE_PATH,
+  CURSOR_BUNDLE_MANIFEST_RELATIVE_PATH,
+} from "./bundle-manifest.js";
 import { resolveDefaultPluginNpmDir } from "./install-paths.js";
 import { hashJson } from "./installed-plugin-index-hash.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
@@ -19,6 +24,7 @@ import {
   resolveInstalledManifestRegistryIndexFingerprint,
 } from "./manifest-registry-installed.js";
 import { loadPluginManifestRegistry, type PluginManifestRecord } from "./manifest-registry.js";
+import { DEFAULT_PLUGIN_ENTRY_CANDIDATES, PLUGIN_MANIFEST_FILENAME } from "./manifest.js";
 import {
   resolvePluginControlPlaneFingerprint,
   resolvePluginDiscoveryContext,
@@ -50,6 +56,21 @@ type PersistedRegistryMemoState = {
 const PLUGIN_METADATA_SNAPSHOT_MEMO_MAX_ENTRIES = 8;
 const pluginMetadataSnapshotMemo = new Map<string, PluginMetadataSnapshotMemo>();
 const pluginMetadataSnapshotRegistryStateMemo = new Map<string, PersistedRegistryMemoState>();
+const PLUGIN_DISCOVERY_CANDIDATE_MARKER_PATHS = [
+  "package.json",
+  PLUGIN_MANIFEST_FILENAME,
+  ...DEFAULT_PLUGIN_ENTRY_CANDIDATES,
+  CODEX_BUNDLE_MANIFEST_RELATIVE_PATH,
+  CURSOR_BUNDLE_MANIFEST_RELATIVE_PATH,
+  CLAUDE_BUNDLE_MANIFEST_RELATIVE_PATH,
+  "skills",
+  "commands",
+  "agents",
+  path.join("hooks", "hooks.json"),
+  ".mcp.json",
+  ".lsp.json",
+  "settings.json",
+] as const;
 
 export function clearLoadPluginMetadataSnapshotMemo(): void {
   pluginMetadataSnapshotMemo.clear();
@@ -88,6 +109,14 @@ function fileFingerprint(filePath: string): unknown {
     return [filePath, kind, stat.size.toString(), stat.mtimeNs.toString(), stat.ctimeNs.toString()];
   } catch {
     return [filePath, "missing"];
+  }
+}
+
+function safeStat(filePath: string): fs.Stats | null {
+  try {
+    return fs.statSync(filePath);
+  } catch {
+    return null;
   }
 }
 
@@ -958,12 +987,53 @@ function resolvePluginDiscoveryWatchPaths(params: {
     env: params.env,
     workspaceDir: params.params.workspaceDir,
   });
-  return [
+  const watchedFiles = new Set<string>();
+  for (const filePath of [
     discovery.roots.stock,
     discovery.roots.global,
     discovery.roots.workspace,
     ...discovery.loadPaths,
-  ].filter((filePath): filePath is string => typeof filePath === "string" && filePath.length > 0);
+  ]) {
+    addPluginDiscoveryWatchPath(watchedFiles, filePath);
+  }
+  return [...watchedFiles].toSorted();
+}
+
+function addPluginDiscoveryWatchPath(
+  watchedFiles: Set<string>,
+  filePath: string | undefined,
+): void {
+  if (!filePath) {
+    return;
+  }
+  watchedFiles.add(filePath);
+  const stat = safeStat(filePath);
+  if (!stat?.isDirectory()) {
+    return;
+  }
+  addPluginDiscoveryCandidateMarkerWatchPaths(watchedFiles, filePath);
+  let entries: fs.Dirent[] = [];
+  try {
+    entries = fs.readdirSync(filePath, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const childPath = path.join(filePath, entry.name);
+    if (entry.isDirectory() || (entry.isSymbolicLink() && safeStat(childPath)?.isDirectory())) {
+      watchedFiles.add(childPath);
+      addPluginDiscoveryCandidateMarkerWatchPaths(watchedFiles, childPath);
+    }
+  }
+}
+
+function addPluginDiscoveryCandidateMarkerWatchPaths(
+  watchedFiles: Set<string>,
+  candidateRoot: string,
+): void {
+  for (const markerPath of PLUGIN_DISCOVERY_CANDIDATE_MARKER_PATHS) {
+    watchedFiles.add(path.join(candidateRoot, markerPath));
+  }
 }
 
 function canMemoizePluginMetadataSnapshotResult(result: {

--- a/src/plugins/plugin-metadata-snapshot.ts
+++ b/src/plugins/plugin-metadata-snapshot.ts
@@ -46,13 +46,11 @@ type PersistedRegistryMemoState = {
 
 const PLUGIN_METADATA_SNAPSHOT_MEMO_MAX_ENTRIES = 8;
 const pluginMetadataSnapshotMemo = new Map<string, PluginMetadataSnapshotMemo>();
-let pluginMetadataSnapshotRegistryStateMemo:
-  | Pick<PluginMetadataSnapshotMemo, "registryState">
-  | undefined;
+const pluginMetadataSnapshotRegistryStateMemo = new Map<string, PersistedRegistryMemoState>();
 
 export function clearLoadPluginMetadataSnapshotMemo(): void {
   pluginMetadataSnapshotMemo.clear();
-  pluginMetadataSnapshotRegistryStateMemo = undefined;
+  pluginMetadataSnapshotRegistryStateMemo.clear();
 }
 
 const MEMO_RELEVANT_ENV_KEYS = [
@@ -384,6 +382,49 @@ function hashWatchedFiles(watchedFiles: readonly string[]): string {
   return hashJson(watchedFiles.map((filePath) => fileFingerprint(filePath)));
 }
 
+function setCappedMemoEntry<Key, Value>(params: {
+  memo: Map<Key, Value>;
+  key: Key;
+  value: Value;
+}): void {
+  params.memo.delete(params.key);
+  params.memo.set(params.key, params.value);
+  if (params.memo.size > PLUGIN_METADATA_SNAPSHOT_MEMO_MAX_ENTRIES) {
+    const oldestKey = params.memo.keys().next().value;
+    if (oldestKey !== undefined) {
+      params.memo.delete(oldestKey);
+    }
+  }
+}
+
+function computePersistedRegistryMemoStateMemoKey(
+  state: Pick<PersistedRegistryMemoState, "contextHash" | "fastHash">,
+): string {
+  return hashJson({
+    contextHash: state.contextHash,
+    fastHash: state.fastHash,
+  });
+}
+
+function mergePersistedRegistryMemoStates(params: {
+  derived: PersistedRegistryMemoState;
+  lookup: PersistedRegistryMemoState;
+}): PersistedRegistryMemoState {
+  const watchedFiles = [
+    ...new Set([...params.lookup.watchedFiles, ...params.derived.watchedFiles]),
+  ].toSorted();
+  return {
+    contextHash: params.derived.contextHash,
+    fastHash: params.derived.fastHash,
+    fingerprint: {
+      derived: params.derived.fingerprint,
+      lookup: params.lookup.fingerprint,
+    },
+    watchedFiles,
+    watchedFilesHash: hashWatchedFiles(watchedFiles),
+  };
+}
+
 function resolvePersistedRegistryMemoState(params: {
   env: NodeJS.ProcessEnv;
   index?: InstalledPluginIndex;
@@ -498,27 +539,30 @@ function resolvePersistedRegistryMemoState(params: {
   };
 }
 
-function resolvePersistedRegistryMemoStateForLookup(
-  params: {
-    env: NodeJS.ProcessEnv;
-    preferPersisted?: boolean;
-    stateDir?: string;
-  },
-  memo: Pick<PluginMetadataSnapshotMemo, "registryState"> | undefined,
-): PersistedRegistryMemoState {
+function resolvePersistedRegistryMemoStateForLookup(params: {
+  env: NodeJS.ProcessEnv;
+  preferPersisted?: boolean;
+  stateDir?: string;
+}): PersistedRegistryMemoState {
   const fastFingerprint = resolvePersistedRegistryFastMemoFingerprint(params);
   const fastHash = hashJson(fastFingerprint);
   const contextHash = resolvePersistedRegistryMemoContextHash({
     ...params,
     fastFingerprint,
   });
-  const registryState = memo?.registryState;
+  const memoKey = computePersistedRegistryMemoStateMemoKey({ contextHash, fastHash });
+  const registryState = pluginMetadataSnapshotRegistryStateMemo.get(memoKey);
   if (
     registryState &&
     registryState.contextHash === contextHash &&
     registryState.fastHash === fastHash &&
     hashWatchedFiles(registryState.watchedFiles) === registryState.watchedFilesHash
   ) {
+    setCappedMemoEntry({
+      memo: pluginMetadataSnapshotRegistryStateMemo,
+      key: memoKey,
+      value: registryState,
+    });
     return registryState;
   }
   return resolvePersistedRegistryMemoState(params);
@@ -707,19 +751,15 @@ export function loadPluginMetadataSnapshot(
 ): PluginMetadataSnapshot {
   const activeTimelineSpan = getActiveDiagnosticsTimelineSpan();
   const env = params.env ?? process.env;
-  const registryState = resolvePersistedRegistryMemoStateForLookup(
-    {
-      env,
-      ...(params.stateDir ? { stateDir: resolveUserPath(params.stateDir, env) } : {}),
-      ...(params.preferPersisted !== undefined ? { preferPersisted: params.preferPersisted } : {}),
-    },
-    pluginMetadataSnapshotRegistryStateMemo,
-  );
+  const registryState = resolvePersistedRegistryMemoStateForLookup({
+    env,
+    ...(params.stateDir ? { stateDir: resolveUserPath(params.stateDir, env) } : {}),
+    ...(params.preferPersisted !== undefined ? { preferPersisted: params.preferPersisted } : {}),
+  });
   const memoKey = computePluginMetadataSnapshotMemoKey({ params, registryState });
   const memo = pluginMetadataSnapshotMemo.get(memoKey);
   if (memo) {
-    pluginMetadataSnapshotMemo.delete(memoKey);
-    pluginMetadataSnapshotMemo.set(memoKey, memo);
+    setCappedMemoEntry({ memo: pluginMetadataSnapshotMemo, key: memoKey, value: memo });
     return measureDiagnosticsTimelineSpanSync(
       "plugins.metadata.scan",
       () => clonePluginMetadataSnapshot(memo.snapshot),
@@ -750,32 +790,29 @@ export function loadPluginMetadataSnapshot(
     },
   );
   if (canMemoizePluginMetadataSnapshotResult(result)) {
-    const cachedRegistryState =
-      result.registrySource === "derived"
-        ? resolvePersistedRegistryMemoState({
-            env,
-            index: result.snapshot.index,
-            ...(params.stateDir ? { stateDir: resolveUserPath(params.stateDir, env) } : {}),
-            ...(params.preferPersisted !== undefined
-              ? { preferPersisted: params.preferPersisted }
-              : {}),
-          })
-        : registryState;
+    const cachedRegistryState = resolveCachedRegistryStateForResult({
+      env,
+      params,
+      registryState,
+      result,
+    });
     const cachedMemoKey = computePluginMetadataSnapshotMemoKey({
       params,
       registryState: cachedRegistryState,
     });
-    pluginMetadataSnapshotRegistryStateMemo = { registryState: cachedRegistryState };
-    pluginMetadataSnapshotMemo.set(cachedMemoKey, {
-      registryState: cachedRegistryState,
-      snapshot: clonePluginMetadataSnapshot(result.snapshot),
+    setCappedMemoEntry({
+      memo: pluginMetadataSnapshotRegistryStateMemo,
+      key: computePersistedRegistryMemoStateMemoKey(cachedRegistryState),
+      value: cachedRegistryState,
     });
-    if (pluginMetadataSnapshotMemo.size > PLUGIN_METADATA_SNAPSHOT_MEMO_MAX_ENTRIES) {
-      const oldestKey = pluginMetadataSnapshotMemo.keys().next().value;
-      if (oldestKey !== undefined) {
-        pluginMetadataSnapshotMemo.delete(oldestKey);
-      }
-    }
+    setCappedMemoEntry({
+      memo: pluginMetadataSnapshotMemo,
+      key: cachedMemoKey,
+      value: {
+        registryState: cachedRegistryState,
+        snapshot: clonePluginMetadataSnapshot(result.snapshot),
+      },
+    });
   }
   return result.snapshot;
 }
@@ -784,6 +821,45 @@ const CACHEABLE_DERIVED_REGISTRY_DIAGNOSTIC_CODES = new Set([
   "persisted-registry-stale-policy",
   "persisted-registry-stale-source",
 ]);
+
+function hasRegistryDiagnosticCode(
+  result: {
+    snapshot: PluginMetadataSnapshot;
+  },
+  code: string,
+): boolean {
+  return result.snapshot.registryDiagnostics.some((diagnostic) => diagnostic.code === code);
+}
+
+function resolveCachedRegistryStateForResult(params: {
+  env: NodeJS.ProcessEnv;
+  params: LoadPluginMetadataSnapshotParams;
+  registryState: PersistedRegistryMemoState;
+  result: {
+    registrySource: PluginRegistrySnapshotSource;
+    snapshot: PluginMetadataSnapshot;
+  };
+}): PersistedRegistryMemoState {
+  if (params.result.registrySource !== "derived") {
+    return params.registryState;
+  }
+  const derivedRegistryState = resolvePersistedRegistryMemoState({
+    env: params.env,
+    index: params.result.snapshot.index,
+    ...(params.params.stateDir
+      ? { stateDir: resolveUserPath(params.params.stateDir, params.env) }
+      : {}),
+    ...(params.params.preferPersisted !== undefined
+      ? { preferPersisted: params.params.preferPersisted }
+      : {}),
+  });
+  return hasRegistryDiagnosticCode(params.result, "persisted-registry-stale-source")
+    ? mergePersistedRegistryMemoStates({
+        derived: derivedRegistryState,
+        lookup: params.registryState,
+      })
+    : derivedRegistryState;
+}
 
 function canMemoizePluginMetadataSnapshotResult(result: {
   registrySource: PluginRegistrySnapshotSource;

--- a/src/plugins/plugin-metadata-snapshot.ts
+++ b/src/plugins/plugin-metadata-snapshot.ts
@@ -19,7 +19,10 @@ import {
   resolveInstalledManifestRegistryIndexFingerprint,
 } from "./manifest-registry-installed.js";
 import { loadPluginManifestRegistry, type PluginManifestRecord } from "./manifest-registry.js";
-import { resolvePluginControlPlaneFingerprint } from "./plugin-control-plane-context.js";
+import {
+  resolvePluginControlPlaneFingerprint,
+  resolvePluginDiscoveryContext,
+} from "./plugin-control-plane-context.js";
 import type {
   LoadPluginMetadataSnapshotParams,
   PluginMetadataSnapshot,
@@ -410,16 +413,26 @@ function mergePersistedRegistryMemoStates(params: {
   derived: PersistedRegistryMemoState;
   lookup: PersistedRegistryMemoState;
 }): PersistedRegistryMemoState {
-  const watchedFiles = [
-    ...new Set([...params.lookup.watchedFiles, ...params.derived.watchedFiles]),
-  ].toSorted();
+  const merged = mergePersistedRegistryMemoStateWatchedFiles(
+    params.derived,
+    params.lookup.watchedFiles,
+  );
   return {
-    contextHash: params.derived.contextHash,
-    fastHash: params.derived.fastHash,
+    ...merged,
     fingerprint: {
       derived: params.derived.fingerprint,
       lookup: params.lookup.fingerprint,
     },
+  };
+}
+
+function mergePersistedRegistryMemoStateWatchedFiles(
+  state: PersistedRegistryMemoState,
+  watchedFilesToAdd: readonly string[],
+): PersistedRegistryMemoState {
+  const watchedFiles = [...new Set([...state.watchedFiles, ...watchedFilesToAdd])].toSorted();
+  return {
+    ...state,
     watchedFiles,
     watchedFilesHash: hashWatchedFiles(watchedFiles),
   };
@@ -566,6 +579,27 @@ function resolvePersistedRegistryMemoStateForLookup(params: {
     return registryState;
   }
   return resolvePersistedRegistryMemoState(params);
+}
+
+function isPersistedRegistryMemoStateFreshForLookup(
+  params: {
+    env: NodeJS.ProcessEnv;
+    preferPersisted?: boolean;
+    stateDir?: string;
+  },
+  registryState: PersistedRegistryMemoState,
+): boolean {
+  const fastFingerprint = resolvePersistedRegistryFastMemoFingerprint(params);
+  const fastHash = hashJson(fastFingerprint);
+  const contextHash = resolvePersistedRegistryMemoContextHash({
+    ...params,
+    fastFingerprint,
+  });
+  return (
+    registryState.contextHash === contextHash &&
+    registryState.fastHash === fastHash &&
+    hashWatchedFiles(registryState.watchedFiles) === registryState.watchedFilesHash
+  );
 }
 
 function computePluginMetadataSnapshotMemoKey(params: {
@@ -751,18 +785,26 @@ export function loadPluginMetadataSnapshot(
 ): PluginMetadataSnapshot {
   const activeTimelineSpan = getActiveDiagnosticsTimelineSpan();
   const env = params.env ?? process.env;
-  const registryState = resolvePersistedRegistryMemoStateForLookup({
+  const registryStateLookupParams = {
     env,
     ...(params.stateDir ? { stateDir: resolveUserPath(params.stateDir, env) } : {}),
     ...(params.preferPersisted !== undefined ? { preferPersisted: params.preferPersisted } : {}),
+  };
+  const registryState = resolvePersistedRegistryMemoStateForLookup(registryStateLookupParams);
+  const memoLookup = resolvePluginMetadataSnapshotMemoLookup({
+    params,
+    registryState,
+    registryStateLookupParams,
   });
-  const memoKey = computePluginMetadataSnapshotMemoKey({ params, registryState });
-  const memo = pluginMetadataSnapshotMemo.get(memoKey);
-  if (memo) {
-    setCappedMemoEntry({ memo: pluginMetadataSnapshotMemo, key: memoKey, value: memo });
+  if (memoLookup) {
+    setCappedMemoEntry({
+      memo: pluginMetadataSnapshotMemo,
+      key: memoLookup.memoKey,
+      value: memoLookup.memo,
+    });
     return measureDiagnosticsTimelineSpanSync(
       "plugins.metadata.scan",
-      () => clonePluginMetadataSnapshot(memo.snapshot),
+      () => clonePluginMetadataSnapshot(memoLookup.memo.snapshot),
       {
         phase: activeTimelineSpan?.phase ?? "startup",
         config: params.config,
@@ -817,6 +859,46 @@ export function loadPluginMetadataSnapshot(
   return result.snapshot;
 }
 
+function resolvePluginMetadataSnapshotMemoLookup(params: {
+  params: LoadPluginMetadataSnapshotParams;
+  registryState: PersistedRegistryMemoState;
+  registryStateLookupParams: {
+    env: NodeJS.ProcessEnv;
+    preferPersisted?: boolean;
+    stateDir?: string;
+  };
+}): { memoKey: string; memo: PluginMetadataSnapshotMemo } | undefined {
+  const memoKey = computePluginMetadataSnapshotMemoKey({
+    params: params.params,
+    registryState: params.registryState,
+  });
+  const memo = pluginMetadataSnapshotMemo.get(memoKey);
+  if (memo) {
+    return { memoKey, memo };
+  }
+  for (const [candidateKey, candidate] of pluginMetadataSnapshotMemo) {
+    if (!candidate.registryState) {
+      continue;
+    }
+    if (
+      !isPersistedRegistryMemoStateFreshForLookup(
+        params.registryStateLookupParams,
+        candidate.registryState,
+      )
+    ) {
+      continue;
+    }
+    const candidateMemoKey = computePluginMetadataSnapshotMemoKey({
+      params: params.params,
+      registryState: candidate.registryState,
+    });
+    if (candidateMemoKey === candidateKey) {
+      return { memoKey: candidateKey, memo: candidate };
+    }
+  }
+  return undefined;
+}
+
 const CACHEABLE_DERIVED_REGISTRY_DIAGNOSTIC_CODES = new Set([
   "persisted-registry-stale-policy",
   "persisted-registry-stale-source",
@@ -855,10 +937,33 @@ function resolveCachedRegistryStateForResult(params: {
   });
   return hasRegistryDiagnosticCode(params.result, "persisted-registry-stale-source")
     ? mergePersistedRegistryMemoStates({
-        derived: derivedRegistryState,
+        derived: mergePersistedRegistryMemoStateWatchedFiles(
+          derivedRegistryState,
+          resolvePluginDiscoveryWatchPaths({
+            env: params.env,
+            params: params.params,
+          }),
+        ),
         lookup: params.registryState,
       })
     : derivedRegistryState;
+}
+
+function resolvePluginDiscoveryWatchPaths(params: {
+  env: NodeJS.ProcessEnv;
+  params: LoadPluginMetadataSnapshotParams;
+}): readonly string[] {
+  const discovery = resolvePluginDiscoveryContext({
+    config: params.params.config,
+    env: params.env,
+    workspaceDir: params.params.workspaceDir,
+  });
+  return [
+    discovery.roots.stock,
+    discovery.roots.global,
+    discovery.roots.workspace,
+    ...discovery.loadPaths,
+  ].filter((filePath): filePath is string => typeof filePath === "string" && filePath.length > 0);
 }
 
 function canMemoizePluginMetadataSnapshotResult(result: {


### PR DESCRIPTION
## Problem

OpenClaw 2026.5.16-beta.2 can get stuck in CLI bootstrap for commands that load plugin metadata. In the observed beta2 install, `plugins list`, `config get`, `gateway status`, and `sessions` all timed out under a 25s cap while repeatedly rebuilding the plugin metadata snapshot.

The immediate trigger is that multiple bootstrap callers use different snapshot keys: one passes a workspace directory and another is unscoped. The existing process memo has only one slot, so those callers evict each other. On installs where the persisted registry falls back to a derived snapshot, the cache gate also needs to treat stable stale-source diagnostics as cacheable; otherwise there is no memo entry for the multi-slot cache to reuse.

## Change and value

This PR changes the process-local plugin metadata snapshot memo from one slot to a bounded 8-entry LRU map keyed by the existing memo key. It keeps persisted-registry freshness hints in a bounded map, probes cached entries with their own registry state, and allows derived snapshots with `persisted-registry-stale-source` diagnostics to be memoized alongside the existing stale-policy case.

The intended result is that bootstrap callers with different legitimate keys warm separate entries once, then reuse them instead of rebuilding the same plugin registry over and over.

## Who is affected, and who is not

Affected:

- Operators on beta2 or later builds whose CLI commands bootstrap plugin metadata repeatedly.
- Installs with stale persisted plugin registry diagnostics that fall back to derived registry snapshots.
- Agent and scheduler flows that depend on `openclaw agent --local`, `sessions`, `gateway status`, or other plugin-aware CLI commands completing.

Not changed:

- No persistent on-disk cache is added.
- The existing memo key still controls cache separation.
- Empty derived snapshots, missing registry diagnostics, disabled persisted registry reads, and explicit non-persisted caller paths remain non-cacheable.

## Why now

This blocks beta3: beta2 can leave normal CLI and agent-dispatch paths timing out even though the gateway itself is alive. The local mitigation restored the affected commands enough to keep the production install operational, and the source fix should ship before the next beta cut.

## Implementation

- Store plugin metadata snapshots in a capped `Map<string, PluginMetadataSnapshotMemo>` instead of a single module variable.
- LRU-touch memo hits and evict the oldest entry after 8 cached snapshots.
- Preserve the existing clone-on-hit behavior so callers cannot mutate cached snapshots.
- Probe cached entries with their own registry state so scoped and unscoped derived snapshots with different indexes stay reachable.
- Keep a capped persisted-registry freshness hint map so source-stale memo slots remain reachable across different registry contexts.
- For source-stale derived snapshots, include both the stale persisted registry fingerprint and the derived registry fingerprint in the cached state so restored persisted plugin paths and orphaned diagnostic sources invalidate the cache.
- Watch discovery roots, bundled source roots, configured load paths, existing plugin markers, nested marker parents, and package-declared entry parents for stale derived snapshots so newly added or changed plugins invalidate the cache.
- Resolve package-declared entry watches through the plugin-root boundary check, so unsafe symlinked package manifests are skipped like real discovery.
- Treat `persisted-registry-stale-source` as a cacheable derived snapshot diagnostic, matching the existing stale-policy behavior.

## Verification

- `pnpm exec oxfmt --check --threads=1 src/plugins/plugin-metadata-snapshot.ts src/plugins/plugin-metadata-snapshot.memo.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/plugins/plugin-metadata-snapshot.memo.test.ts` (36 tests passed)
- `pnpm tsgo:core`

## Real behavior proof

Behavior or issue addressed: Plugin-aware CLI commands repeatedly rebuild plugin metadata snapshots during bootstrap and can time out instead of returning.

Real environment tested: OpenClaw 2026.5.16-beta.2 production install with the equivalent compiled dist patch applied, plus this PR head's focused source regression tests.

Exact steps or command run after this patch: Ran `timeout 25s openclaw plugins list --json`, `timeout 25s openclaw config get gateway.port`, `timeout 25s openclaw gateway status`, `timeout 25s openclaw sessions --all-agents --active 5 --json`, `timeout 25s openclaw agent --help`, and a diagnostics timeline run with `OPENCLAW_DIAGNOSTICS=1` and a temporary timeline output path.

Evidence after fix: Terminal transcript from the patched beta2 install:

```text
$ timeout 25s openclaw plugins list --json
exit=0 wall=0:07.52 output_bytes=188669

$ timeout 25s openclaw config get gateway.port
exit=0 wall=0:13.80 stdout=18789

$ timeout 25s openclaw gateway status
exit=0 wall=0:15.02
note=sandbox/systemd inspection warnings remained, but command returned before timeout

$ timeout 25s openclaw sessions --all-agents --active 5 --json
exit=0 wall=0:10.54 output_bytes=2437

$ timeout 25s openclaw agent --help
exit=0 wall=0:05.97

$ OPENCLAW_DIAGNOSTICS=1 openclaw plugins list --json
metadata_scan_starts=182 cache_hit_starts=179 cache_miss_starts=3
```

Observed result after fix: The affected CLI commands no longer hit the 25s timeout, and metadata scan calls become hot cache hits after the distinct bootstrap keys warm.

What was not tested: I did not install a packaged artifact built from this exact PR head into the production OpenClaw install; the live timing proof used an equivalent compiled beta2 dist patch. Broad CI-shaped validation is running on the latest pushed head.