### PR TITLE
fix(agents): skip malformed transcript state entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -285,6 +285,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/sessions: keep reachable transcript history when imported tree transcripts reference missing or legacy parent rows, preventing session history reads from going empty after a partial import.
 - Trajectory export: report incomplete transcript parent chains and stop cyclic branch walks so malformed imports cannot hang `/export-trajectory`.
 - Session replay: skip malformed user/assistant-shaped transcript rows during silent session resets instead of copying invalid entries into the fresh transcript.
+- Transcript state: skip malformed persisted JSONL entries before compaction/rewrite helpers choose the active leaf.
 - Backup verify: report malformed archive manifests with a stable error instead of leaking raw JSON parser details.
 - Session export: report skipped malformed transcript JSONL rows instead of silently omitting them from exported HTML archives.
 - Providers: reject malformed successful Runway, BytePlus, and Ollama embedding responses with provider-owned errors instead of raw parser/type failures, silent bad vectors, or long bogus polling.

--- a/src/agents/pi-embedded-runner/transcript-file-state.test.ts
+++ b/src/agents/pi-embedded-runner/transcript-file-state.test.ts
@@ -180,7 +180,7 @@ describe("readTranscriptFileState", () => {
                 type: "function_call",
                 call_id: "call-legacy",
                 name: "search",
-                arguments: { query: "docs" },
+                arguments: '{"query":"docs"}',
               },
             ],
           },

--- a/src/agents/pi-embedded-runner/transcript-file-state.test.ts
+++ b/src/agents/pi-embedded-runner/transcript-file-state.test.ts
@@ -838,6 +838,56 @@ describe("readTranscriptFileState", () => {
     expect(state.getBranch().map((entry) => entry.id)).toEqual(["user-1"]);
   });
 
+  it("drops missing parents reached through rejected rows before rewrite replay", async () => {
+    const root = await makeRoot("openclaw-transcript-state-rejected-missing-parent-");
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          version: 3,
+          id: "session-1",
+          timestamp: "2026-05-16T00:00:00.000Z",
+          cwd: root,
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "bad-message",
+          parentId: "missing-parent",
+          timestamp: "2026-05-16T00:00:01.000Z",
+          message: { role: "user" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "user-1",
+          parentId: "bad-message",
+          timestamp: "2026-05-16T00:00:02.000Z",
+          message: { role: "user", content: "kept after missing malformed parent" },
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const state = await readTranscriptFileState(sessionFile);
+
+    expect(state.getEntries().map((entry) => ({ id: entry.id, parentId: entry.parentId }))).toEqual(
+      [{ id: "user-1", parentId: null }],
+    );
+    expect(state.getBranch().map((entry) => entry.id)).toEqual(["user-1"]);
+    expect(() =>
+      rewriteTranscriptEntriesInState({
+        state,
+        replacements: [
+          {
+            entryId: "user-1",
+            message: { role: "user", content: "replacement prompt", timestamp: 1 },
+          },
+        ],
+      }),
+    ).not.toThrow();
+  });
+
   it("drops labels targeting rejected entries before transcript rewrite replay", async () => {
     const root = await makeRoot("openclaw-transcript-state-rejected-label-");
     const sessionFile = path.join(root, "session.jsonl");

--- a/src/agents/pi-embedded-runner/transcript-file-state.test.ts
+++ b/src/agents/pi-embedded-runner/transcript-file-state.test.ts
@@ -146,6 +146,46 @@ describe("readTranscriptFileState", () => {
     ]);
   });
 
+  it("keeps assistant rows with legacy string content", async () => {
+    const root = await makeRoot("openclaw-transcript-state-assistant-string-");
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          version: 3,
+          id: "session-1",
+          timestamp: "2026-05-16T00:00:00.000Z",
+          cwd: root,
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "user-1",
+          parentId: null,
+          timestamp: "2026-05-16T00:00:01.000Z",
+          message: { role: "user", content: "prompt" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "assistant-string",
+          parentId: "user-1",
+          timestamp: "2026-05-16T00:00:02.000Z",
+          message: { role: "assistant", content: "legacy reply" },
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const state = await readTranscriptFileState(sessionFile);
+
+    expect(state.getEntries().map((entry) => entry.id)).toEqual(["user-1", "assistant-string"]);
+    expect(state.buildSessionContext().messages).toMatchObject([
+      { role: "user", content: "prompt" },
+      { role: "assistant", content: "legacy reply" },
+    ]);
+  });
+
   it("preserves repair-supported assistant tool call payload shapes", async () => {
     const root = await makeRoot("openclaw-transcript-state-tool-input-");
     const sessionFile = path.join(root, "session.jsonl");

--- a/src/agents/pi-embedded-runner/transcript-file-state.test.ts
+++ b/src/agents/pi-embedded-runner/transcript-file-state.test.ts
@@ -216,6 +216,7 @@ describe("readTranscriptFileState", () => {
             content: [
               { type: "toolUse", id: "call-input", name: "read", input: { path: "README.md" } },
               { type: "toolCall", id: "call-args", name: "write", arguments: { path: "out" } },
+              { type: "toolUse", id: "call-no-args", name: "list" },
               {
                 type: "function_call",
                 call_id: "call-legacy",
@@ -413,6 +414,45 @@ describe("readTranscriptFileState", () => {
     expect(state.getBranch().map((entry) => entry.id)).toEqual(["user-1"]);
   });
 
+  it("skips JSON-valid non-object rows before legacy migration", async () => {
+    const root = await makeRoot("openclaw-transcript-state-v1-null-row-");
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          version: 1,
+          id: "session-1",
+          timestamp: "2026-05-16T00:00:00.000Z",
+          cwd: root,
+        }),
+        "null",
+        JSON.stringify({
+          type: "message",
+          timestamp: "2026-05-16T00:00:01.000Z",
+          message: { role: "user", content: "legacy prompt" },
+        }),
+        "false",
+        JSON.stringify({
+          type: "message",
+          timestamp: "2026-05-16T00:00:02.000Z",
+          message: { role: "assistant", content: [{ type: "text", text: "legacy reply" }] },
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const state = await readTranscriptFileState(sessionFile);
+
+    expect(state.migrated).toBe(true);
+    expect(state.getEntries()).toHaveLength(2);
+    expect(state.buildSessionContext().messages).toMatchObject([
+      { role: "user", content: "legacy prompt" },
+      { role: "assistant", content: [{ type: "text", text: "legacy reply" }] },
+    ]);
+  });
+
   it("relinks valid current rows past malformed parents", async () => {
     const root = await makeRoot("openclaw-transcript-state-current-suffix-");
     const sessionFile = path.join(root, "session.jsonl");
@@ -557,6 +597,71 @@ describe("readTranscriptFileState", () => {
           timestamp: "2026-05-16T00:00:04.000Z",
           summary: "summary",
           firstKeptEntryId: "bad-message",
+          tokensBefore: 200,
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const state = await readTranscriptFileState(sessionFile);
+    const compaction = state.getEntries().find((entry) => entry.type === "compaction");
+
+    expect(compaction).toMatchObject({ firstKeptEntryId: "user-1" });
+    expect(state.buildSessionContext().messages).toMatchObject([
+      { role: "compactionSummary", summary: "summary" },
+      { role: "user", content: "first valid kept turn" },
+      { role: "assistant", content: [{ type: "text", text: "valid reply" }] },
+    ]);
+  });
+
+  it("remaps compaction keep markers through consecutive malformed rows", async () => {
+    const root = await makeRoot("openclaw-transcript-state-compaction-chain-marker-");
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          version: 3,
+          id: "session-1",
+          timestamp: "2026-05-16T00:00:00.000Z",
+          cwd: root,
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "bad-root",
+          parentId: null,
+          timestamp: "2026-05-16T00:00:01.000Z",
+          message: { role: "user" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "bad-child",
+          parentId: "bad-root",
+          timestamp: "2026-05-16T00:00:02.000Z",
+          message: { role: "assistant" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "user-1",
+          parentId: "bad-child",
+          timestamp: "2026-05-16T00:00:03.000Z",
+          message: { role: "user", content: "first valid kept turn" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "assistant-1",
+          parentId: "user-1",
+          timestamp: "2026-05-16T00:00:04.000Z",
+          message: { role: "assistant", content: [{ type: "text", text: "valid reply" }] },
+        }),
+        JSON.stringify({
+          type: "compaction",
+          id: "compact-1",
+          parentId: "assistant-1",
+          timestamp: "2026-05-16T00:00:05.000Z",
+          summary: "summary",
+          firstKeptEntryId: "bad-root",
           tokensBefore: 200,
         }),
       ].join("\n"),

--- a/src/agents/pi-embedded-runner/transcript-file-state.test.ts
+++ b/src/agents/pi-embedded-runner/transcript-file-state.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { readTranscriptFileState } from "./transcript-file-state.js";
+import { rewriteTranscriptEntriesInState } from "./transcript-rewrite.js";
 
 const roots: string[] = [];
 
@@ -781,6 +782,79 @@ describe("readTranscriptFileState", () => {
       [{ id: "user-1", parentId: null }],
     );
     expect(state.getBranch().map((entry) => entry.id)).toEqual(["user-1"]);
+  });
+
+  it("drops labels targeting rejected entries before transcript rewrite replay", async () => {
+    const root = await makeRoot("openclaw-transcript-state-rejected-label-");
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          version: 3,
+          id: "session-1",
+          timestamp: "2026-05-16T00:00:00.000Z",
+          cwd: root,
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "user-1",
+          parentId: null,
+          timestamp: "2026-05-16T00:00:01.000Z",
+          message: { role: "user", content: "before malformed row" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "bad-message",
+          parentId: "user-1",
+          timestamp: "2026-05-16T00:00:02.000Z",
+          message: { role: "user" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "user-2",
+          parentId: "bad-message",
+          timestamp: "2026-05-16T00:00:03.000Z",
+          message: { role: "user", content: "after malformed row" },
+        }),
+        JSON.stringify({
+          type: "label",
+          id: "label-1",
+          parentId: "user-2",
+          timestamp: "2026-05-16T00:00:04.000Z",
+          targetId: "bad-message",
+          label: "bad",
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "user-3",
+          parentId: "label-1",
+          timestamp: "2026-05-16T00:00:05.000Z",
+          message: { role: "user", content: "after poisoned label" },
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const state = await readTranscriptFileState(sessionFile);
+
+    expect(state.getEntries().map((entry) => ({ id: entry.id, parentId: entry.parentId }))).toEqual(
+      [
+        { id: "user-1", parentId: null },
+        { id: "user-2", parentId: "user-1" },
+        { id: "user-3", parentId: "user-2" },
+      ],
+    );
+    expect(state.getLabel("bad-message")).toBeUndefined();
+    expect(() =>
+      rewriteTranscriptEntriesInState({
+        state,
+        replacements: [
+          { entryId: "user-1", message: { role: "user", content: "replacement prompt" } },
+        ],
+      }),
+    ).not.toThrow();
   });
 
   it("keeps legacy roots that are missing tree metadata", async () => {

--- a/src/agents/pi-embedded-runner/transcript-file-state.test.ts
+++ b/src/agents/pi-embedded-runner/transcript-file-state.test.ts
@@ -454,6 +454,60 @@ describe("readTranscriptFileState", () => {
     ]);
   });
 
+  it("preserves legacy compaction keep indexes across JSON-valid non-object rows", async () => {
+    const root = await makeRoot("openclaw-transcript-state-v1-compaction-null-row-");
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          version: 1,
+          id: "session-1",
+          timestamp: "2026-05-16T00:00:00.000Z",
+          cwd: root,
+        }),
+        JSON.stringify({
+          type: "message",
+          timestamp: "2026-05-16T00:00:01.000Z",
+          message: { role: "user", content: "legacy prelude" },
+        }),
+        "null",
+        JSON.stringify({
+          type: "message",
+          timestamp: "2026-05-16T00:00:02.000Z",
+          message: { role: "user", content: "legacy kept suffix" },
+        }),
+        JSON.stringify({
+          type: "compaction",
+          timestamp: "2026-05-16T00:00:03.000Z",
+          summary: "summary",
+          firstKeptEntryIndex: 3,
+          tokensBefore: 200,
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const state = await readTranscriptFileState(sessionFile);
+    const kept = state
+      .getEntries()
+      .find(
+        (entry) =>
+          entry.type === "message" &&
+          entry.message.role === "user" &&
+          entry.message.content === "legacy kept suffix",
+      );
+    const compaction = state.getEntries().find((entry) => entry.type === "compaction");
+
+    expect(kept).toBeDefined();
+    expect(compaction).toMatchObject({ firstKeptEntryId: kept?.id });
+    expect(state.buildSessionContext().messages).toMatchObject([
+      { role: "compactionSummary", summary: "summary" },
+      { role: "user", content: "legacy kept suffix" },
+    ]);
+  });
+
   it("relinks valid current rows past malformed parents", async () => {
     const root = await makeRoot("openclaw-transcript-state-current-suffix-");
     const sessionFile = path.join(root, "session.jsonl");
@@ -851,7 +905,10 @@ describe("readTranscriptFileState", () => {
       rewriteTranscriptEntriesInState({
         state,
         replacements: [
-          { entryId: "user-1", message: { role: "user", content: "replacement prompt" } },
+          {
+            entryId: "user-1",
+            message: { role: "user", content: "replacement prompt", timestamp: 1 },
+          },
         ],
       }),
     ).not.toThrow();

--- a/src/agents/pi-embedded-runner/transcript-file-state.test.ts
+++ b/src/agents/pi-embedded-runner/transcript-file-state.test.ts
@@ -533,6 +533,71 @@ describe("readTranscriptFileState", () => {
     ]);
   });
 
+  it("remaps malformed compaction markers to descendants on the active branch", async () => {
+    const root = await makeRoot("openclaw-transcript-state-compaction-branch-marker-");
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          version: 3,
+          id: "session-1",
+          timestamp: "2026-05-16T00:00:00.000Z",
+          cwd: root,
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "bad-message",
+          parentId: null,
+          timestamp: "2026-05-16T00:00:01.000Z",
+          message: { role: "user" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "branch-a-user",
+          parentId: "bad-message",
+          timestamp: "2026-05-16T00:00:02.000Z",
+          message: { role: "user", content: "other branch" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "branch-b-user",
+          parentId: "bad-message",
+          timestamp: "2026-05-16T00:00:03.000Z",
+          message: { role: "user", content: "active branch kept turn" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "branch-b-assistant",
+          parentId: "branch-b-user",
+          timestamp: "2026-05-16T00:00:04.000Z",
+          message: { role: "assistant", content: [{ type: "text", text: "active reply" }] },
+        }),
+        JSON.stringify({
+          type: "compaction",
+          id: "compact-1",
+          parentId: "branch-b-assistant",
+          timestamp: "2026-05-16T00:00:05.000Z",
+          summary: "summary",
+          firstKeptEntryId: "bad-message",
+          tokensBefore: 200,
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const state = await readTranscriptFileState(sessionFile);
+    const compaction = state.getEntries().find((entry) => entry.type === "compaction");
+
+    expect(compaction).toMatchObject({ firstKeptEntryId: "branch-b-user" });
+    expect(state.buildSessionContext().messages).toMatchObject([
+      { role: "compactionSummary", summary: "summary" },
+      { role: "user", content: "active branch kept turn" },
+      { role: "assistant", content: [{ type: "text", text: "active reply" }] },
+    ]);
+  });
+
   it("does not hang on rejected parent cycles", async () => {
     const root = await makeRoot("openclaw-transcript-state-rejected-cycle-");
     const sessionFile = path.join(root, "session.jsonl");

--- a/src/agents/pi-embedded-runner/transcript-file-state.test.ts
+++ b/src/agents/pi-embedded-runner/transcript-file-state.test.ts
@@ -146,6 +146,77 @@ describe("readTranscriptFileState", () => {
     ]);
   });
 
+  it("preserves repair-supported assistant tool call payload shapes", async () => {
+    const root = await makeRoot("openclaw-transcript-state-tool-input-");
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          version: 3,
+          id: "session-1",
+          timestamp: "2026-05-16T00:00:00.000Z",
+          cwd: root,
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "user-1",
+          parentId: null,
+          timestamp: "2026-05-16T00:00:01.000Z",
+          message: { role: "user", content: "read a file" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "assistant-tool",
+          parentId: "user-1",
+          timestamp: "2026-05-16T00:00:02.000Z",
+          message: {
+            role: "assistant",
+            content: [
+              { type: "toolUse", id: "call-input", name: "read", input: { path: "README.md" } },
+              { type: "toolCall", id: "call-args", name: "write", arguments: { path: "out" } },
+              {
+                type: "function_call",
+                call_id: "call-legacy",
+                name: "search",
+                arguments: { query: "docs" },
+              },
+            ],
+          },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "tool-result",
+          parentId: "assistant-tool",
+          timestamp: "2026-05-16T00:00:03.000Z",
+          message: {
+            role: "toolResult",
+            toolCallId: "call-input",
+            toolName: "read",
+            content: [{ type: "text", text: "contents" }],
+            isError: false,
+          },
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const state = await readTranscriptFileState(sessionFile);
+
+    expect(state.getEntries().map((entry) => entry.id)).toEqual([
+      "user-1",
+      "assistant-tool",
+      "tool-result",
+    ]);
+    expect(state.getLeafId()).toBe("tool-result");
+    expect(state.buildSessionContext().messages.map((message) => message.role)).toEqual([
+      "user",
+      "assistant",
+      "toolResult",
+    ]);
+  });
+
   it("preserves empty compaction summary entries as the active leaf", async () => {
     const root = await makeRoot("openclaw-transcript-state-empty-compaction-");
     const sessionFile = path.join(root, "session.jsonl");

--- a/src/agents/pi-embedded-runner/transcript-file-state.test.ts
+++ b/src/agents/pi-embedded-runner/transcript-file-state.test.ts
@@ -222,6 +222,7 @@ describe("readTranscriptFileState", () => {
                 name: "search",
                 arguments: '{"query":"docs"}',
               },
+              { type: "toolCall", id: "call-null-args", name: "noop", arguments: null },
             ],
           },
         }),

--- a/src/agents/pi-embedded-runner/transcript-file-state.test.ts
+++ b/src/agents/pi-embedded-runner/transcript-file-state.test.ts
@@ -1,0 +1,511 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { readTranscriptFileState } from "./transcript-file-state.js";
+
+const roots: string[] = [];
+
+async function makeRoot(prefix: string): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+});
+
+describe("readTranscriptFileState", () => {
+  it("skips malformed session entries without moving the active leaf", async () => {
+    const root = await makeRoot("openclaw-transcript-state-malformed-");
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          version: 3,
+          id: "session-1",
+          timestamp: "2026-05-16T00:00:00.000Z",
+          cwd: root,
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "user-1",
+          parentId: null,
+          timestamp: "2026-05-16T00:00:01.000Z",
+          message: { role: "user", content: "hello" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "assistant-1",
+          parentId: "user-1",
+          timestamp: "2026-05-16T00:00:02.000Z",
+          message: { role: "assistant", content: [{ type: "text", text: "hi" }] },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "bash-1",
+          parentId: "assistant-1",
+          timestamp: "2026-05-16T00:00:02.500Z",
+          message: {
+            role: "bashExecution",
+            command: "echo ok",
+            output: "ok\n",
+            exitCode: 0,
+            cancelled: false,
+            truncated: false,
+          },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "bad-message",
+          parentId: "bash-1",
+          timestamp: "2026-05-16T00:00:03.000Z",
+          message: { content: "missing role" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "bad-missing-content",
+          parentId: "assistant-1",
+          timestamp: "2026-05-16T00:00:03.500Z",
+          message: { role: "user" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "bad-unsupported-role",
+          parentId: "assistant-1",
+          timestamp: "2026-05-16T00:00:03.750Z",
+          message: { role: "system", content: "not an agent message" },
+        }),
+        JSON.stringify({
+          type: "label",
+          parentId: "bad-message",
+          timestamp: "2026-05-16T00:00:04.000Z",
+          targetId: "user-1",
+          label: "missing id",
+        }),
+        JSON.stringify({
+          type: "future_poison",
+          id: "unknown-type",
+          parentId: "assistant-1",
+          timestamp: "2026-05-16T00:00:05.000Z",
+        }),
+        JSON.stringify({
+          type: "model_change",
+          id: "orphan-model-change",
+          parentId: "bad-message",
+          timestamp: "2026-05-16T00:00:06.000Z",
+          provider: "openai",
+          modelId: "gpt-5.5",
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "orphan-user-child",
+          parentId: "bad-missing-content",
+          timestamp: "2026-05-16T00:00:06.500Z",
+          message: { role: "user", content: "child of malformed user content" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "legacy-orphan",
+          parentId: "missing-import-parent",
+          timestamp: "2026-05-16T00:00:07.000Z",
+          message: { role: "user", content: "partial import keeps this row" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "legacy-orphan-child",
+          parentId: "legacy-orphan",
+          timestamp: "2026-05-16T00:00:08.000Z",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "still reachable from the orphan root" }],
+          },
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const state = await readTranscriptFileState(sessionFile);
+
+    expect(state.getEntries().map((entry) => entry.id)).toEqual([
+      "user-1",
+      "assistant-1",
+      "bash-1",
+      "orphan-model-change",
+      "orphan-user-child",
+      "legacy-orphan",
+      "legacy-orphan-child",
+    ]);
+    expect(state.getLeafId()).toBe("legacy-orphan-child");
+    expect(state.getBranch().map((entry) => entry.id)).toEqual([
+      "legacy-orphan",
+      "legacy-orphan-child",
+    ]);
+  });
+
+  it("preserves empty compaction summary entries as the active leaf", async () => {
+    const root = await makeRoot("openclaw-transcript-state-empty-compaction-");
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          version: 3,
+          id: "session-1",
+          timestamp: "2026-05-16T00:00:00.000Z",
+          cwd: root,
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "user-1",
+          parentId: null,
+          timestamp: "2026-05-16T00:00:01.000Z",
+          message: { role: "user", content: "fresh question" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "assistant-1",
+          parentId: "user-1",
+          timestamp: "2026-05-16T00:00:02.000Z",
+          message: { role: "assistant", content: [{ type: "text", text: "fresh answer" }] },
+        }),
+        JSON.stringify({
+          type: "compaction",
+          id: "compact-1",
+          parentId: "assistant-1",
+          timestamp: "2026-05-16T00:00:03.000Z",
+          summary: "",
+          firstKeptEntryId: "user-1",
+          tokensBefore: 200,
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const state = await readTranscriptFileState(sessionFile);
+
+    expect(state.getEntries().map((entry) => entry.id)).toEqual([
+      "user-1",
+      "assistant-1",
+      "compact-1",
+    ]);
+    expect(state.getLeafId()).toBe("compact-1");
+  });
+
+  it("skips JSON-valid non-object rows", async () => {
+    const root = await makeRoot("openclaw-transcript-state-null-row-");
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          version: 3,
+          id: "session-1",
+          timestamp: "2026-05-16T00:00:00.000Z",
+          cwd: root,
+        }),
+        "null",
+        "false",
+        JSON.stringify({
+          type: "message",
+          id: "user-1",
+          parentId: null,
+          timestamp: "2026-05-16T00:00:01.000Z",
+          message: { role: "user", content: "still readable" },
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const state = await readTranscriptFileState(sessionFile);
+
+    expect(state.getEntries().map((entry) => entry.id)).toEqual(["user-1"]);
+    expect(state.getLeafId()).toBe("user-1");
+    expect(state.getBranch().map((entry) => entry.id)).toEqual(["user-1"]);
+  });
+
+  it("relinks valid current rows past malformed parents", async () => {
+    const root = await makeRoot("openclaw-transcript-state-current-suffix-");
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          version: 3,
+          id: "session-1",
+          timestamp: "2026-05-16T00:00:00.000Z",
+          cwd: root,
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "user-1",
+          parentId: null,
+          timestamp: "2026-05-16T00:00:01.000Z",
+          message: { role: "user", content: "before malformed row" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "bad-message",
+          parentId: "user-1",
+          timestamp: "2026-05-16T00:00:02.000Z",
+          message: { role: "user" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "user-2",
+          parentId: "bad-message",
+          timestamp: "2026-05-16T00:00:03.000Z",
+          message: { role: "user", content: "after malformed row" },
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const state = await readTranscriptFileState(sessionFile);
+
+    expect(state.getEntries().map((entry) => entry.id)).toEqual(["user-1", "user-2"]);
+    expect(state.getLeafId()).toBe("user-2");
+    expect(state.getBranch().map((entry) => entry.id)).toEqual(["user-1", "user-2"]);
+  });
+
+  it("remaps compaction keep markers past malformed rows", async () => {
+    const root = await makeRoot("openclaw-transcript-state-compaction-marker-");
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          version: 3,
+          id: "session-1",
+          timestamp: "2026-05-16T00:00:00.000Z",
+          cwd: root,
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "user-1",
+          parentId: null,
+          timestamp: "2026-05-16T00:00:01.000Z",
+          message: { role: "user", content: "before malformed row" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "bad-message",
+          parentId: "user-1",
+          timestamp: "2026-05-16T00:00:02.000Z",
+          message: { role: "user" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "assistant-1",
+          parentId: "bad-message",
+          timestamp: "2026-05-16T00:00:03.000Z",
+          message: { role: "assistant", content: [{ type: "text", text: "after malformed row" }] },
+        }),
+        JSON.stringify({
+          type: "compaction",
+          id: "compact-1",
+          parentId: "assistant-1",
+          timestamp: "2026-05-16T00:00:04.000Z",
+          summary: "summary",
+          firstKeptEntryId: "bad-message",
+          tokensBefore: 200,
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const state = await readTranscriptFileState(sessionFile);
+    const compaction = state.getEntries().find((entry) => entry.type === "compaction");
+
+    expect(compaction).toMatchObject({ firstKeptEntryId: "user-1" });
+    expect(state.buildSessionContext().messages).toMatchObject([
+      { role: "compactionSummary", summary: "summary" },
+      { role: "user", content: "before malformed row" },
+      { role: "assistant", content: [{ type: "text", text: "after malformed row" }] },
+    ]);
+  });
+
+  it("keeps valid suffixes when a compaction marker points at a malformed root", async () => {
+    const root = await makeRoot("openclaw-transcript-state-compaction-root-marker-");
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          version: 3,
+          id: "session-1",
+          timestamp: "2026-05-16T00:00:00.000Z",
+          cwd: root,
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "bad-message",
+          parentId: null,
+          timestamp: "2026-05-16T00:00:01.000Z",
+          message: { role: "user" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "user-1",
+          parentId: "bad-message",
+          timestamp: "2026-05-16T00:00:02.000Z",
+          message: { role: "user", content: "first valid kept turn" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "assistant-1",
+          parentId: "user-1",
+          timestamp: "2026-05-16T00:00:03.000Z",
+          message: { role: "assistant", content: [{ type: "text", text: "valid reply" }] },
+        }),
+        JSON.stringify({
+          type: "compaction",
+          id: "compact-1",
+          parentId: "assistant-1",
+          timestamp: "2026-05-16T00:00:04.000Z",
+          summary: "summary",
+          firstKeptEntryId: "bad-message",
+          tokensBefore: 200,
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const state = await readTranscriptFileState(sessionFile);
+    const compaction = state.getEntries().find((entry) => entry.type === "compaction");
+
+    expect(compaction).toMatchObject({ firstKeptEntryId: "user-1" });
+    expect(state.buildSessionContext().messages).toMatchObject([
+      { role: "compactionSummary", summary: "summary" },
+      { role: "user", content: "first valid kept turn" },
+      { role: "assistant", content: [{ type: "text", text: "valid reply" }] },
+    ]);
+  });
+
+  it("does not hang on rejected parent cycles", async () => {
+    const root = await makeRoot("openclaw-transcript-state-rejected-cycle-");
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          version: 3,
+          id: "session-1",
+          timestamp: "2026-05-16T00:00:00.000Z",
+          cwd: root,
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "bad-message",
+          parentId: "bad-message",
+          timestamp: "2026-05-16T00:00:01.000Z",
+          message: { role: "user" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "user-1",
+          parentId: "bad-message",
+          timestamp: "2026-05-16T00:00:02.000Z",
+          message: { role: "user", content: "kept after cycle" },
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const state = await readTranscriptFileState(sessionFile);
+
+    expect(state.getEntries().map((entry) => ({ id: entry.id, parentId: entry.parentId }))).toEqual(
+      [{ id: "user-1", parentId: null }],
+    );
+    expect(state.getBranch().map((entry) => entry.id)).toEqual(["user-1"]);
+  });
+
+  it("keeps legacy roots that are missing tree metadata", async () => {
+    const root = await makeRoot("openclaw-transcript-state-legacy-root-");
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          version: 3,
+          id: "session-1",
+          timestamp: "2026-05-16T00:00:00.000Z",
+          cwd: root,
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "legacy-root",
+          message: { role: "user", content: "legacy prompt" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "tree-child",
+          parentId: "legacy-root",
+          timestamp: "2026-05-16T00:00:01.000Z",
+          message: { role: "assistant", content: [{ type: "text", text: "tree reply" }] },
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const state = await readTranscriptFileState(sessionFile);
+
+    expect(state.getEntries().map((entry) => entry.id)).toEqual(["legacy-root", "tree-child"]);
+    expect(state.getLeafId()).toBe("tree-child");
+    expect(state.getBranch().map((entry) => entry.id)).toEqual(["legacy-root", "tree-child"]);
+  });
+
+  it("relinks migrated legacy suffixes past malformed rows", async () => {
+    const root = await makeRoot("openclaw-transcript-state-legacy-suffix-");
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          version: 1,
+          id: "session-1",
+          timestamp: "2026-05-16T00:00:00.000Z",
+          cwd: root,
+        }),
+        JSON.stringify({
+          type: "message",
+          timestamp: "2026-05-16T00:00:01.000Z",
+          message: { role: "user", content: "before malformed row" },
+        }),
+        JSON.stringify({
+          type: "message",
+          timestamp: "2026-05-16T00:00:02.000Z",
+          message: { content: "missing role" },
+        }),
+        JSON.stringify({
+          type: "message",
+          timestamp: "2026-05-16T00:00:03.000Z",
+          message: { role: "user", content: "after malformed row" },
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const state = await readTranscriptFileState(sessionFile);
+
+    const branchText = state.getBranch().map((entry) => {
+      const message = entry.type === "message" ? entry.message : null;
+      if (!message || message.role !== "user" || typeof message.content !== "string") {
+        throw new Error("expected string message branch");
+      }
+      return message.content;
+    });
+    expect(branchText).toEqual(["before malformed row", "after malformed row"]);
+  });
+});

--- a/src/agents/pi-embedded-runner/transcript-file-state.test.ts
+++ b/src/agents/pi-embedded-runner/transcript-file-state.test.ts
@@ -217,6 +217,78 @@ describe("readTranscriptFileState", () => {
     ]);
   });
 
+  it("preserves OpenClaw-authored non-model content blocks", async () => {
+    const root = await makeRoot("openclaw-transcript-state-openclaw-blocks-");
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "session",
+          version: 3,
+          id: "session-1",
+          timestamp: "2026-05-16T00:00:00.000Z",
+          cwd: root,
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "user-1",
+          parentId: null,
+          timestamp: "2026-05-16T00:00:01.000Z",
+          message: { role: "user", content: "read the injected blocks" },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "assistant-audio",
+          parentId: "user-1",
+          timestamp: "2026-05-16T00:00:02.000Z",
+          message: {
+            role: "assistant",
+            content: [
+              { type: "text", text: "voice reply" },
+              { type: "audio", data: "UklGRg==", mimeType: "audio/wav" },
+            ],
+          },
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "tool-result",
+          parentId: "assistant-audio",
+          timestamp: "2026-05-16T00:00:03.000Z",
+          message: {
+            role: "toolResult",
+            toolCallId: "call-1",
+            toolName: "codex_progress",
+            content: [
+              {
+                type: "toolResult",
+                id: "call-1",
+                toolUseId: "call-1",
+                content: "progress payload",
+                text: "progress payload",
+              },
+            ],
+            isError: false,
+          },
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const state = await readTranscriptFileState(sessionFile);
+    const messages = state.buildSessionContext().messages;
+
+    expect(state.getEntries().map((entry) => entry.id)).toEqual([
+      "user-1",
+      "assistant-audio",
+      "tool-result",
+    ]);
+    expect(state.getLeafId()).toBe("tool-result");
+    expect(messages.map((message) => message.role)).toEqual(["user", "assistant", "toolResult"]);
+    expect(messages[1]).toMatchObject({ content: [{ type: "text" }, { type: "audio" }] });
+    expect(messages[2]).toMatchObject({ content: [{ type: "toolResult" }] });
+  });
+
   it("preserves empty compaction summary entries as the active leaf", async () => {
     const root = await makeRoot("openclaw-transcript-state-empty-compaction-");
     const sessionFile = path.join(root, "session.jsonl");

--- a/src/agents/pi-embedded-runner/transcript-file-state.ts
+++ b/src/agents/pi-embedded-runner/transcript-file-state.ts
@@ -107,7 +107,8 @@ function isToolCallContent(value: unknown): boolean {
     repairableToolCallContentTypes.has(value.type) &&
     hasToolCallId(value) &&
     isString(value.name) &&
-    (isToolCallPayload(value.arguments) || isToolCallPayload(value.input)) &&
+    (value.arguments === undefined || isToolCallPayload(value.arguments)) &&
+    (value.input === undefined || isToolCallPayload(value.input)) &&
     isOptionalString(value.thoughtSignature)
   );
 }
@@ -373,7 +374,7 @@ function readableSessionEntries(fileEntries: FileEntry[]): SessionEntry[] {
       if (isString(id)) {
         rejectedIds.add(id);
         const parentId = rawEntry.parentId;
-        rejectedParentById.set(id, isString(parentId) ? resolveRejectedParent(parentId) : null);
+        rejectedParentById.set(id, isString(parentId) ? parentId : null);
       }
       continue;
     }
@@ -641,7 +642,7 @@ export class TranscriptFileState {
 
 export async function readTranscriptFileState(sessionFile: string): Promise<TranscriptFileState> {
   const raw = await fs.readFile(sessionFile, "utf-8");
-  const fileEntries = parseSessionEntries(raw);
+  const fileEntries = parseSessionEntries(raw).filter(isRecord);
   const headerBeforeMigration =
     fileEntries.find((entry): entry is SessionHeader => entry.type === "session") ?? null;
   const headerVersionBeforeMigration = sessionHeaderVersion(headerBeforeMigration);

--- a/src/agents/pi-embedded-runner/transcript-file-state.ts
+++ b/src/agents/pi-embedded-runner/transcript-file-state.ts
@@ -108,22 +108,38 @@ function isToolCallContent(value: unknown): boolean {
   );
 }
 
+function isPersistedContentBlock(value: unknown): boolean {
+  if (!isRecord(value) || !isString(value.type)) {
+    return false;
+  }
+  switch (value.type) {
+    case "text":
+      return isTextContent(value);
+    case "thinking":
+      return isThinkingContent(value);
+    case "image":
+      return isImageContent(value);
+    default:
+      if (repairableToolCallContentTypes.has(value.type)) {
+        return isToolCallContent(value);
+      }
+      return true;
+  }
+}
+
 function isUserContent(value: unknown): boolean {
   return (
     typeof value === "string" ||
-    (Array.isArray(value) && value.every((item) => isTextContent(item) || isImageContent(item)))
+    (Array.isArray(value) && value.every((item) => isPersistedContentBlock(item)))
   );
 }
 
 function isAssistantContent(value: unknown): boolean {
-  return (
-    Array.isArray(value) &&
-    value.every((item) => isTextContent(item) || isThinkingContent(item) || isToolCallContent(item))
-  );
+  return Array.isArray(value) && value.every((item) => isPersistedContentBlock(item));
 }
 
 function isToolResultContent(value: unknown): boolean {
-  return Array.isArray(value) && value.every((item) => isTextContent(item) || isImageContent(item));
+  return Array.isArray(value) && value.every((item) => isPersistedContentBlock(item));
 }
 
 function isOptionalBoolean(value: unknown): boolean {

--- a/src/agents/pi-embedded-runner/transcript-file-state.ts
+++ b/src/agents/pi-embedded-runner/transcript-file-state.ts
@@ -96,6 +96,10 @@ function hasToolCallId(value: Record<string, unknown>): boolean {
   );
 }
 
+function isToolCallPayload(value: unknown): boolean {
+  return isRecord(value) || typeof value === "string";
+}
+
 function isToolCallContent(value: unknown): boolean {
   return (
     isRecord(value) &&
@@ -103,7 +107,7 @@ function isToolCallContent(value: unknown): boolean {
     repairableToolCallContentTypes.has(value.type) &&
     hasToolCallId(value) &&
     isString(value.name) &&
-    (isRecord(value.arguments) || isRecord(value.input)) &&
+    (isToolCallPayload(value.arguments) || isToolCallPayload(value.input)) &&
     isOptionalString(value.thoughtSignature)
   );
 }

--- a/src/agents/pi-embedded-runner/transcript-file-state.ts
+++ b/src/agents/pi-embedded-runner/transcript-file-state.ts
@@ -139,7 +139,10 @@ function isUserContent(value: unknown): boolean {
 }
 
 function isAssistantContent(value: unknown): boolean {
-  return Array.isArray(value) && value.every((item) => isPersistedContentBlock(item));
+  return (
+    typeof value === "string" ||
+    (Array.isArray(value) && value.every((item) => isPersistedContentBlock(item)))
+  );
 }
 
 function isToolResultContent(value: unknown): boolean {

--- a/src/agents/pi-embedded-runner/transcript-file-state.ts
+++ b/src/agents/pi-embedded-runner/transcript-file-state.ts
@@ -268,9 +268,40 @@ function isSessionEntry(entry: FileEntry): entry is SessionEntry {
 function readableSessionEntries(fileEntries: FileEntry[]): SessionEntry[] {
   const entries: SessionEntry[] = [];
   const acceptedIds = new Set<string>();
+  const acceptedEntryById = new Map<string, SessionEntry>();
   const rejectedIds = new Set<string>();
   const rejectedParentById = new Map<string, string | null>();
   const firstReadableDescendantByRejectedId = new Map<string, string>();
+  const rejectedAncestorsByAcceptedId = new Map<string, string[]>();
+  const acceptedPath = (leafId: string | null | undefined): SessionEntry[] => {
+    const path: SessionEntry[] = [];
+    let id = leafId ?? null;
+    const seen = new Set<string>();
+    while (id !== null) {
+      if (seen.has(id)) {
+        break;
+      }
+      seen.add(id);
+      const entry = acceptedEntryById.get(id);
+      if (!entry) {
+        break;
+      }
+      path.unshift(entry);
+      id = entry.parentId;
+    }
+    return path;
+  };
+  const firstReadableDescendantOnBranch = (
+    rejectedId: string,
+    leafId: string | null | undefined,
+  ): string | undefined => {
+    for (const entry of acceptedPath(leafId)) {
+      if (rejectedAncestorsByAcceptedId.get(entry.id)?.includes(rejectedId)) {
+        return entry.id;
+      }
+    }
+    return undefined;
+  };
   const rejectedParentChain = (parentId: string | null | undefined): string[] => {
     const chain: string[] = [];
     let resolved = parentId ?? null;
@@ -310,6 +341,7 @@ function readableSessionEntries(fileEntries: FileEntry[]): SessionEntry[] {
         (resolvedFirstKeptParent !== null && acceptedIds.has(resolvedFirstKeptParent)
           ? resolvedFirstKeptParent
           : undefined) ??
+        firstReadableDescendantOnBranch(repaired.firstKeptEntryId, parentId) ??
         firstReadableDescendantByRejectedId.get(repaired.firstKeptEntryId) ??
         parentId;
       if (firstKeptEntryId !== null && firstKeptEntryId !== repaired.firstKeptEntryId) {
@@ -321,6 +353,9 @@ function readableSessionEntries(fileEntries: FileEntry[]): SessionEntry[] {
         if (!firstReadableDescendantByRejectedId.has(rejectedId)) {
           firstReadableDescendantByRejectedId.set(rejectedId, repaired.id);
         }
+      }
+      if (rejectedAncestors.length > 0) {
+        rejectedAncestorsByAcceptedId.set(repaired.id, rejectedAncestors);
       }
     }
     return repaired;
@@ -342,8 +377,10 @@ function readableSessionEntries(fileEntries: FileEntry[]): SessionEntry[] {
     if (acceptedIds.has(entry.id)) {
       continue;
     }
-    entries.push(repairEntryLinks(entry));
-    acceptedIds.add(entry.id);
+    const repaired = repairEntryLinks(entry);
+    entries.push(repaired);
+    acceptedIds.add(repaired.id);
+    acceptedEntryById.set(repaired.id, repaired);
   }
   return entries;
 }

--- a/src/agents/pi-embedded-runner/transcript-file-state.ts
+++ b/src/agents/pi-embedded-runner/transcript-file-state.ts
@@ -45,6 +45,8 @@ const repairableToolCallContentTypes = new Set([
   "tool_use",
 ]);
 
+const invalidJsonlSlotType = "__openclaw_invalid_jsonl_slot";
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
@@ -412,6 +414,18 @@ function serializeTranscriptFileEntries(entries: FileEntry[]): string {
   return `${entries.map((entry) => JSON.stringify(entry)).join("\n")}\n`;
 }
 
+function fileEntryOrMigrationSlot(value: unknown, index: number): FileEntry {
+  if (isRecord(value)) {
+    return value as unknown as FileEntry;
+  }
+  return {
+    type: invalidJsonlSlotType,
+    id: `__openclaw_invalid_jsonl_slot_${index}`,
+    parentId: null,
+    timestamp: "1970-01-01T00:00:00.000Z",
+  } as unknown as FileEntry;
+}
+
 export class TranscriptFileState {
   readonly header: SessionHeader | null;
   readonly entries: SessionEntry[];
@@ -647,7 +661,7 @@ export class TranscriptFileState {
 
 export async function readTranscriptFileState(sessionFile: string): Promise<TranscriptFileState> {
   const raw = await fs.readFile(sessionFile, "utf-8");
-  const fileEntries = parseSessionEntries(raw).filter(isRecord);
+  const fileEntries = (parseSessionEntries(raw) as unknown[]).map(fileEntryOrMigrationSlot);
   const headerBeforeMigration =
     fileEntries.find((entry): entry is SessionHeader => entry.type === "session") ?? null;
   const headerVersionBeforeMigration = sessionHeaderVersion(headerBeforeMigration);

--- a/src/agents/pi-embedded-runner/transcript-file-state.ts
+++ b/src/agents/pi-embedded-runner/transcript-file-state.ts
@@ -24,8 +24,287 @@ type SessionInfoEntry = Extract<SessionEntry, { type: "session_info" }>;
 type SessionMessageEntry = Extract<SessionEntry, { type: "message" }>;
 type ThinkingLevelChangeEntry = Extract<SessionEntry, { type: "thinking_level_change" }>;
 
+const sessionEntryTypes = new Set<string>([
+  "branch_summary",
+  "compaction",
+  "custom",
+  "custom_message",
+  "label",
+  "message",
+  "model_change",
+  "session_info",
+  "thinking_level_change",
+] satisfies SessionEntry["type"][]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === "string" && value.trim() !== "";
+}
+
+function isOptionalString(value: unknown): boolean {
+  return value === undefined || typeof value === "string";
+}
+
+function isTextContent(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    value.type === "text" &&
+    typeof value.text === "string" &&
+    isOptionalString(value.textSignature)
+  );
+}
+
+function isThinkingContent(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    value.type === "thinking" &&
+    typeof value.thinking === "string" &&
+    isOptionalString(value.thinkingSignature) &&
+    (value.redacted === undefined || typeof value.redacted === "boolean")
+  );
+}
+
+function isImageContent(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    value.type === "image" &&
+    typeof value.data === "string" &&
+    typeof value.mimeType === "string"
+  );
+}
+
+function isToolCallContent(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    value.type === "toolCall" &&
+    isString(value.id) &&
+    isString(value.name) &&
+    isRecord(value.arguments) &&
+    isOptionalString(value.thoughtSignature)
+  );
+}
+
+function isUserContent(value: unknown): boolean {
+  return (
+    typeof value === "string" ||
+    (Array.isArray(value) && value.every((item) => isTextContent(item) || isImageContent(item)))
+  );
+}
+
+function isAssistantContent(value: unknown): boolean {
+  return (
+    Array.isArray(value) &&
+    value.every((item) => isTextContent(item) || isThinkingContent(item) || isToolCallContent(item))
+  );
+}
+
+function isToolResultContent(value: unknown): boolean {
+  return Array.isArray(value) && value.every((item) => isTextContent(item) || isImageContent(item));
+}
+
+function isOptionalBoolean(value: unknown): boolean {
+  return value === undefined || typeof value === "boolean";
+}
+
+function isBashExecutionMessage(value: Record<string, unknown>): boolean {
+  return (
+    isString(value.command) &&
+    typeof value.output === "string" &&
+    (value.exitCode === undefined || typeof value.exitCode === "number") &&
+    typeof value.cancelled === "boolean" &&
+    typeof value.truncated === "boolean" &&
+    isOptionalString(value.fullOutputPath) &&
+    isOptionalBoolean(value.excludeFromContext)
+  );
+}
+
+function isAgentMessage(value: unknown): boolean {
+  if (!isRecord(value)) {
+    return false;
+  }
+  switch (value.role) {
+    case "assistant":
+      return isAssistantContent(value.content);
+    case "bashExecution":
+      return isBashExecutionMessage(value);
+    case "custom":
+      return isString(value.customType) && isUserContent(value.content);
+    case "toolResult":
+      return (
+        isString(value.toolCallId) &&
+        isString(value.toolName) &&
+        typeof value.isError === "boolean" &&
+        isToolResultContent(value.content)
+      );
+    case "user":
+      return isUserContent(value.content);
+    default:
+      return false;
+  }
+}
+
+function hasSessionEntryBase(entry: FileEntry): boolean {
+  const candidate = entry as {
+    id?: unknown;
+    parentId?: unknown;
+    timestamp?: unknown;
+  };
+  return (
+    isString(candidate.id) &&
+    (candidate.parentId === undefined ||
+      candidate.parentId === null ||
+      isString(candidate.parentId)) &&
+    (candidate.timestamp === undefined || isString(candidate.timestamp))
+  );
+}
+
 function isSessionEntry(entry: FileEntry): entry is SessionEntry {
-  return entry.type !== "session";
+  if (
+    entry.type === "session" ||
+    !sessionEntryTypes.has(entry.type) ||
+    !hasSessionEntryBase(entry)
+  ) {
+    return false;
+  }
+  switch (entry.type) {
+    case "branch_summary": {
+      const candidate = entry as { fromId?: unknown; summary?: unknown };
+      return isString(candidate.fromId) && typeof candidate.summary === "string";
+    }
+    case "compaction": {
+      const candidate = entry as {
+        firstKeptEntryId?: unknown;
+        summary?: unknown;
+        tokensBefore?: unknown;
+      };
+      return (
+        isString(candidate.firstKeptEntryId) &&
+        typeof candidate.summary === "string" &&
+        typeof candidate.tokensBefore === "number"
+      );
+    }
+    case "custom":
+      return isString((entry as { customType?: unknown }).customType);
+    case "custom_message": {
+      const candidate = entry as {
+        content?: unknown;
+        customType?: unknown;
+        display?: unknown;
+      };
+      return (
+        isString(candidate.customType) &&
+        isUserContent(candidate.content) &&
+        typeof candidate.display === "boolean"
+      );
+    }
+    case "label": {
+      const candidate = entry as { label?: unknown; targetId?: unknown };
+      return (
+        isString(candidate.targetId) &&
+        (candidate.label === undefined || typeof candidate.label === "string")
+      );
+    }
+    case "message": {
+      return isAgentMessage((entry as { message?: unknown }).message);
+    }
+    case "model_change": {
+      const candidate = entry as { modelId?: unknown; provider?: unknown };
+      return isString(candidate.provider) && isString(candidate.modelId);
+    }
+    case "session_info": {
+      const candidate = entry as { name?: unknown };
+      return candidate.name === undefined || typeof candidate.name === "string";
+    }
+    case "thinking_level_change":
+      return isString((entry as { thinkingLevel?: unknown }).thinkingLevel);
+  }
+  return false;
+}
+
+function readableSessionEntries(fileEntries: FileEntry[]): SessionEntry[] {
+  const entries: SessionEntry[] = [];
+  const acceptedIds = new Set<string>();
+  const rejectedIds = new Set<string>();
+  const rejectedParentById = new Map<string, string | null>();
+  const firstReadableDescendantByRejectedId = new Map<string, string>();
+  const rejectedParentChain = (parentId: string | null | undefined): string[] => {
+    const chain: string[] = [];
+    let resolved = parentId ?? null;
+    const seen = new Set<string>();
+    while (resolved !== null && rejectedParentById.has(resolved)) {
+      if (seen.has(resolved)) {
+        break;
+      }
+      seen.add(resolved);
+      chain.push(resolved);
+      resolved = rejectedParentById.get(resolved) ?? null;
+    }
+    return chain;
+  };
+  const resolveRejectedParent = (parentId: string | null | undefined): string | null => {
+    let resolved = parentId ?? null;
+    const seen = new Set<string>();
+    while (resolved !== null && rejectedParentById.has(resolved)) {
+      if (seen.has(resolved)) {
+        return null;
+      }
+      seen.add(resolved);
+      resolved = rejectedParentById.get(resolved) ?? null;
+    }
+    return resolved;
+  };
+  const repairEntryLinks = (entry: SessionEntry): SessionEntry => {
+    const rejectedAncestors = rejectedParentChain(entry.parentId);
+    const parentId =
+      rejectedAncestors.length > 0
+        ? resolveRejectedParent(entry.parentId)
+        : (entry.parentId ?? null);
+    let repaired = parentId === entry.parentId ? entry : ({ ...entry, parentId } as SessionEntry);
+    if (repaired.type === "compaction" && rejectedIds.has(repaired.firstKeptEntryId)) {
+      const resolvedFirstKeptParent = resolveRejectedParent(repaired.firstKeptEntryId);
+      const firstKeptEntryId =
+        (resolvedFirstKeptParent !== null && acceptedIds.has(resolvedFirstKeptParent)
+          ? resolvedFirstKeptParent
+          : undefined) ??
+        firstReadableDescendantByRejectedId.get(repaired.firstKeptEntryId) ??
+        parentId;
+      if (firstKeptEntryId !== null && firstKeptEntryId !== repaired.firstKeptEntryId) {
+        repaired = { ...repaired, firstKeptEntryId } as SessionEntry;
+      }
+    }
+    if (repaired.type !== "compaction") {
+      for (const rejectedId of rejectedAncestors) {
+        if (!firstReadableDescendantByRejectedId.has(rejectedId)) {
+          firstReadableDescendantByRejectedId.set(rejectedId, repaired.id);
+        }
+      }
+    }
+    return repaired;
+  };
+  for (const rawEntry of fileEntries) {
+    if (!isRecord(rawEntry)) {
+      continue;
+    }
+    const entry = rawEntry as FileEntry;
+    const id = rawEntry.id;
+    if (!isSessionEntry(entry)) {
+      if (isString(id)) {
+        rejectedIds.add(id);
+        const parentId = rawEntry.parentId;
+        rejectedParentById.set(id, isString(parentId) ? resolveRejectedParent(parentId) : null);
+      }
+      continue;
+    }
+    if (acceptedIds.has(entry.id)) {
+      continue;
+    }
+    entries.push(repairEntryLinks(entry));
+    acceptedIds.add(entry.id);
+  }
+  return entries;
 }
 
 function sessionHeaderVersion(header: SessionHeader | null): number {
@@ -284,11 +563,12 @@ export async function readTranscriptFileState(sessionFile: string): Promise<Tran
   const fileEntries = parseSessionEntries(raw);
   const headerBeforeMigration =
     fileEntries.find((entry): entry is SessionHeader => entry.type === "session") ?? null;
-  const migrated = sessionHeaderVersion(headerBeforeMigration) < CURRENT_SESSION_VERSION;
+  const headerVersionBeforeMigration = sessionHeaderVersion(headerBeforeMigration);
+  const migrated = headerVersionBeforeMigration < CURRENT_SESSION_VERSION;
   migrateSessionEntries(fileEntries);
   const header =
     fileEntries.find((entry): entry is SessionHeader => entry.type === "session") ?? null;
-  const entries = fileEntries.filter(isSessionEntry);
+  const entries = readableSessionEntries(fileEntries);
   return new TranscriptFileState({ header, entries, migrated });
 }
 

--- a/src/agents/pi-embedded-runner/transcript-file-state.ts
+++ b/src/agents/pi-embedded-runner/transcript-file-state.ts
@@ -97,7 +97,7 @@ function hasToolCallId(value: Record<string, unknown>): boolean {
 }
 
 function isToolCallPayload(value: unknown): boolean {
-  return isRecord(value) || typeof value === "string";
+  return value === null || isRecord(value) || typeof value === "string";
 }
 
 function isToolCallContent(value: unknown): boolean {

--- a/src/agents/pi-embedded-runner/transcript-file-state.ts
+++ b/src/agents/pi-embedded-runner/transcript-file-state.ts
@@ -336,9 +336,13 @@ function readableSessionEntries(fileEntries: FileEntry[]): SessionEntry[] {
   };
   const repairEntryLinks = (entry: SessionEntry): SessionEntry => {
     const rejectedAncestors = rejectedParentChain(entry.parentId);
+    const resolvedRejectedParent =
+      rejectedAncestors.length > 0 ? resolveRejectedParent(entry.parentId) : undefined;
     const parentId =
-      rejectedAncestors.length > 0
-        ? resolveRejectedParent(entry.parentId)
+      resolvedRejectedParent !== undefined
+        ? resolvedRejectedParent !== null && acceptedIds.has(resolvedRejectedParent)
+          ? resolvedRejectedParent
+          : null
         : (entry.parentId ?? null);
     let repaired = parentId === entry.parentId ? entry : ({ ...entry, parentId } as SessionEntry);
     if (repaired.type === "compaction" && rejectedIds.has(repaired.firstKeptEntryId)) {

--- a/src/agents/pi-embedded-runner/transcript-file-state.ts
+++ b/src/agents/pi-embedded-runner/transcript-file-state.ts
@@ -378,6 +378,11 @@ function readableSessionEntries(fileEntries: FileEntry[]): SessionEntry[] {
       }
       continue;
     }
+    if (entry.type === "label" && !acceptedIds.has(entry.targetId)) {
+      rejectedIds.add(entry.id);
+      rejectedParentById.set(entry.id, entry.parentId);
+      continue;
+    }
     if (acceptedIds.has(entry.id)) {
       continue;
     }

--- a/src/agents/pi-embedded-runner/transcript-file-state.ts
+++ b/src/agents/pi-embedded-runner/transcript-file-state.ts
@@ -36,6 +36,15 @@ const sessionEntryTypes = new Set<string>([
   "thinking_level_change",
 ] satisfies SessionEntry["type"][]);
 
+const repairableToolCallContentTypes = new Set([
+  "functionCall",
+  "function_call",
+  "toolCall",
+  "toolUse",
+  "tool_call",
+  "tool_use",
+]);
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
@@ -76,13 +85,25 @@ function isImageContent(value: unknown): boolean {
   );
 }
 
+function hasToolCallId(value: Record<string, unknown>): boolean {
+  return (
+    isString(value.id) ||
+    isString(value.call_id) ||
+    isString(value.toolCallId) ||
+    isString(value.toolUseId) ||
+    isString(value.tool_call_id) ||
+    isString(value.tool_use_id)
+  );
+}
+
 function isToolCallContent(value: unknown): boolean {
   return (
     isRecord(value) &&
-    value.type === "toolCall" &&
-    isString(value.id) &&
+    typeof value.type === "string" &&
+    repairableToolCallContentTypes.has(value.type) &&
+    hasToolCallId(value) &&
     isString(value.name) &&
-    isRecord(value.arguments) &&
+    (isRecord(value.arguments) || isRecord(value.input)) &&
     isOptionalString(value.thoughtSignature)
   );
 }


### PR DESCRIPTION
Summary
- Skip malformed persisted Pi transcript JSONL entries before `TranscriptFileState` chooses the active leaf for compaction/rewrite/truncation helpers.
- Keep only known entry types with required base fields and entry-specific payload shape.
- Prune rows whose parent chain goes through a row rejected as malformed, while preserving valid missing-parent rows as recovery roots for partial imports/legacy trees.
- Add focused regression coverage and changelog entry.

Verification
- Testbox-through-Crabbox `tbx_01krs05eysbnzyatw4a50x7m7y`, Actions run `25969350615`: focused `pnpm test src/agents/pi-embedded-runner/transcript-file-state.test.ts` passed.
- Testbox-through-Crabbox `tbx_01krs05eysbnzyatw4a50x7m7y`, Actions run `25969350615`: explicit-path `pnpm check:changed CHANGELOG.md src/agents/pi-embedded-runner/transcript-file-state.ts src/agents/pi-embedded-runner/transcript-file-state.test.ts` passed.
- Local: `git diff --check` passed. A local node-wrapper Vitest rerun was stopped because unrelated local Vitest lanes were starving the process; Testbox covered the focused test and changed gate.

Behavior addressed: malformed persisted transcript JSONL entries can no longer become the active `TranscriptFileState` leaf used by compaction/rewrite helpers, and descendants of rejected malformed rows are pruned without dropping valid orphan rows from partial imports.
Real environment tested: Blacksmith Testbox Linux via Crabbox wrapper on branch `fix/archive-transcript-import-next-20260516-223625`.
Exact steps or command run after this patch: `pnpm test src/agents/pi-embedded-runner/transcript-file-state.test.ts`; `pnpm check:changed CHANGELOG.md src/agents/pi-embedded-runner/transcript-file-state.ts src/agents/pi-embedded-runner/transcript-file-state.test.ts`.
Evidence after fix: `tbx_01krs05eysbnzyatw4a50x7m7y`, GitHub Actions run `25969350615`, exit code 0.
Observed result after fix: valid transcript rows remain available, malformed rows are skipped, descendants of rejected rows cannot replace the leaf, and valid missing-parent rows are preserved as branch roots.
What was not tested: full live compaction/rewrite of a real user transcript; this patch covers the shared transcript-state reader used by those paths.
