### PR TITLE
fix(matrix): avoid state-after sync opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Matrix/approvals: release in-flight reaction bindings when the channel approval handler stops mid-delivery, preventing stale approval targets after restart. Fixes #82485. (#82482) Thanks @Feelw00.
+- Matrix/E2EE: stop requesting MSC4222 `state_after` sync responses so homeservers with incomplete state-after data do not leave fresh encrypted rooms without outbound room encryptors. Fixes #82515. Thanks @nickdecooman.
 - TUI: update the displayed model in real time when an auto-fallback resolution swaps in a different model mid-turn, so the status line reflects the actual model handling the run. Fixes #82296. Thanks @giodl73-repo.
 - Gateway/sessions: estimate context usage from local/OpenAI-compatible transcripts when provider usage telemetry is missing, so status no longer shows empty usage for real local-model sessions. Fixes #73990. (#82317) Thanks @giodl73-repo.
 - Agents/sessions: preserve fresh post-compaction token snapshots across stale usage updates, preventing repeated auto-compaction after every message. Fixes #82576. (#82578) Thanks @njuboy11.

--- a/extensions/matrix/CHANGELOG.md
+++ b/extensions/matrix/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Version alignment with core OpenClaw release numbers.
 
+### Fixes
+
+- Matrix/E2EE: stop requesting MSC4222 `state_after` sync responses so homeservers with incomplete state-after data do not leave fresh encrypted rooms without outbound room encryptors. Fixes #82515. Thanks @nickdecooman.
+
 ## 2026.5.16
 
 ### Changes

--- a/extensions/matrix/src/matrix/sdk/transport.test.ts
+++ b/extensions/matrix/src/matrix/sdk/transport.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MatrixMediaSizeLimitError } from "../media-errors.js";
-import { performMatrixRequest } from "./transport.js";
+import { createMatrixGuardedFetch, performMatrixRequest } from "./transport.js";
 
 const TEST_UNDICI_RUNTIME_DEPS_KEY = "__OPENCLAW_TEST_UNDICI_RUNTIME_DEPS__";
 
@@ -164,5 +164,66 @@ describe("performMatrixRequest", () => {
     expect((dispatcher as { constructor?: { name?: string } } | undefined)?.constructor?.name).toBe(
       "MockAgent",
     );
+  });
+});
+
+describe("createMatrixGuardedFetch", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    clearTestUndiciRuntimeDepsOverride();
+  });
+
+  afterEach(() => {
+    clearTestUndiciRuntimeDepsOverride();
+  });
+
+  it("strips matrix-js-sdk state_after sync opt-in from /sync requests", async () => {
+    const runtimeFetch = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response("{}", {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+          },
+        }),
+    );
+    stubRuntimeFetch(runtimeFetch);
+
+    const guardedFetch = createMatrixGuardedFetch({
+      ssrfPolicy: { allowPrivateNetwork: true },
+    });
+
+    await guardedFetch(
+      "http://127.0.0.1:8008/_matrix/client/v3/sync?filter=abc&org.matrix.msc4222.use_state_after=true&timeout=30000",
+    );
+
+    expect(runtimeFetch).toHaveBeenCalledTimes(1);
+    expect(runtimeFetch.mock.calls.at(0)?.[0]).toBe(
+      "http://127.0.0.1:8008/_matrix/client/v3/sync?filter=abc&timeout=30000",
+    );
+  });
+
+  it("leaves non-sync Matrix requests unchanged", async () => {
+    const runtimeFetch = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response("{}", {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+          },
+        }),
+    );
+    stubRuntimeFetch(runtimeFetch);
+
+    const guardedFetch = createMatrixGuardedFetch({
+      ssrfPolicy: { allowPrivateNetwork: true },
+    });
+
+    const url =
+      "http://127.0.0.1:8008/_matrix/client/v3/account/whoami?org.matrix.msc4222.use_state_after=true";
+    await guardedFetch(url);
+
+    expect(runtimeFetch).toHaveBeenCalledTimes(1);
+    expect(runtimeFetch.mock.calls.at(0)?.[0]).toBe(url);
   });
 });

--- a/extensions/matrix/src/matrix/sdk/transport.ts
+++ b/extensions/matrix/src/matrix/sdk/transport.ts
@@ -68,6 +68,24 @@ function toFetchUrl(resource: RequestInfo | URL): string {
   return resource.url;
 }
 
+const MATRIX_STATE_AFTER_SYNC_PARAM = "org.matrix.msc4222.use_state_after";
+
+function withoutMatrixStateAfterSyncParam(rawUrl: string): string {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return rawUrl;
+  }
+
+  if (!url.pathname.endsWith("/sync") || !url.searchParams.has(MATRIX_STATE_AFTER_SYNC_PARAM)) {
+    return rawUrl;
+  }
+
+  url.searchParams.delete(MATRIX_STATE_AFTER_SYNC_PARAM);
+  return url.toString();
+}
+
 function buildBufferedResponse(params: {
   source: Response;
   body: ArrayBuffer;
@@ -213,7 +231,7 @@ export function createMatrixGuardedFetch(params: {
   dispatcherPolicy?: PinnedDispatcherPolicy;
 }): typeof fetch {
   return (async (resource: RequestInfo | URL, init?: RequestInit) => {
-    const url = toFetchUrl(resource);
+    const url = withoutMatrixStateAfterSyncParam(toFetchUrl(resource));
     const { signal, ...requestInit } = init ?? {};
     const { response, release } = await fetchWithMatrixGuardedRedirects({
       url,


### PR DESCRIPTION
## Summary
- strip matrix-js-sdk's MSC4222 `org.matrix.msc4222.use_state_after` opt-in from Matrix SDK `/sync` requests in the guarded transport
- add transport regression coverage for `/sync` rewriting and non-sync request preservation
- add Matrix E2EE changelog entries for #82515

## Verification
Behavior addressed: Matrix E2EE startup/sync no longer asks homeservers for MSC4222 `state_after`, avoiding the reported path where incomplete state_after omits `m.room.encryption` and leaves outbound crypto unconfigured.
Real environment tested: local source checkout plus Blacksmith Testbox `tbx_01krrqf5ynfmy98f85jj3d7hc3`.
Exact steps or command run after this patch:
- `pnpm test extensions/matrix/src/matrix/sdk/transport.test.ts extensions/matrix/src/matrix/sdk.test.ts extensions/matrix/src/matrix/client/file-sync-store.test.ts extensions/matrix/src/matrix/send/client.test.ts -- --reporter=verbose`
- `pnpm test extensions/matrix/src/matrix/sdk/transport.test.ts -- --reporter=verbose`
- `git diff --check`
- `pnpm check:changed` (delegated to Blacksmith Testbox `tbx_01krrqf5ynfmy98f85jj3d7hc3`, GitHub Actions run https://github.com/openclaw/openclaw/actions/runs/25966102838)
- `gemini --approval-mode plan --skip-trust -p ...`
- `/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --full-access`
Evidence after fix: transport regression test confirms `/sync?...org.matrix.msc4222.use_state_after=true...` is sent without that query parameter while non-sync Matrix requests are unchanged.
Observed result after fix: focused Matrix tests passed (4 files, 104 tests before rebase; transport-only rerun passed after rebase), changed check passed in Testbox after rebase, Gemini reported no actionable findings, Codex review reported no actionable correctness issues, and GitHub PR CI passed after rerunning an unrelated Signal account timeout.
What was not tested: no live Matrix homeserver repro with a server returning incomplete MSC4222 `state_after`; coverage is source-level request shaping and Matrix SDK/send/sync-store regression proof.

## Real behavior proof
Behavior addressed: Matrix E2EE startup/sync no longer asks homeservers for MSC4222 `state_after`, avoiding the reported path where incomplete state_after omits `m.room.encryption` and leaves outbound crypto unconfigured.
Real environment tested: Maintainer-reviewed source checkout and Blacksmith Testbox `tbx_01krrqf5ynfmy98f85jj3d7hc3`; no live homeserver with the reported broken MSC4222 response was available, so maintainer override is used for this request-shaping fix.
Exact steps or command run after this patch: `pnpm test extensions/matrix/src/matrix/sdk/transport.test.ts -- --reporter=verbose`; `pnpm check:changed` delegated to Blacksmith Testbox `tbx_01krrqf5ynfmy98f85jj3d7hc3`.
Evidence after fix: terminal output from the focused transport test shows the guarded fetch sends `http://127.0.0.1:8008/_matrix/client/v3/sync?filter=abc&timeout=30000` after receiving a matrix-js-sdk URL containing `org.matrix.msc4222.use_state_after=true`; the Testbox run is https://github.com/openclaw/openclaw/actions/runs/25966102838.
Observed result after fix: the `/sync` opt-in parameter is absent from the actual fetch URL while the non-sync Matrix request keeps its query parameters unchanged; focused transport test rerun passed 1 file / 6 tests after rebase, changed check passed in Testbox, and PR CI passed.
What was not tested: a live Matrix homeserver repro with an incomplete MSC4222 `state_after` response.
