### PR TITLE
fix(tools): support provider-specific array item schemas

### DIFF
--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -49,6 +49,11 @@ function supportsStrictMode(model: Model<Api>): boolean | undefined {
   return (model.compat as { supportsStrictMode?: boolean } | undefined)?.supportsStrictMode;
 }
 
+function arrayToolParameterItems(model: Model<Api>): string | undefined {
+  return (model.compat as { arrayToolParameterItems?: string } | undefined)
+    ?.arrayToolParameterItems;
+}
+
 function expectSupportsDeveloperRoleForcedOff(overrides?: Partial<Model<Api>>): void {
   const model = { ...baseModel(), ...overrides };
   delete (model as { compat?: unknown }).compat;
@@ -181,6 +186,20 @@ describe("normalizeModelCompat", () => {
       provider: "qwen",
       baseUrl: "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
     });
+  });
+
+  it("uses string array item compat for Xiaomi token-plan OpenAI-compatible endpoints", () => {
+    const model = {
+      ...baseModel(),
+      id: "mimo-v2.5",
+      provider: "xiaomi-mimo-tp",
+      baseUrl: "https://token-plan-cn.xiaomimimo.com/v1",
+    };
+    delete (model as { compat?: unknown }).compat;
+
+    const normalized = normalizeModelCompat(model);
+
+    expect(arrayToolParameterItems(normalized)).toBe("string");
   });
 
   it("keeps supportsUsageInStreaming on for DashScope-compatible endpoints regardless of provider id", () => {

--- a/src/agents/openai-completions-compat.ts
+++ b/src/agents/openai-completions-compat.ts
@@ -1,4 +1,5 @@
 import type { Model } from "@earendil-works/pi-ai";
+import type { ArrayToolParameterItemsMode } from "../config/types.models.js";
 import type { ProviderEndpointClass, ProviderRequestCapabilities } from "./provider-attribution.js";
 import { resolveProviderRequestCapabilities } from "./provider-attribution.js";
 
@@ -21,6 +22,7 @@ type OpenAICompletionsCompatDefaults = {
   visibleReasoningDetailTypes: string[];
   supportsStrictMode: boolean;
   requiresReasoningContentOnAssistantMessages: boolean;
+  arrayToolParameterItems: ArrayToolParameterItemsMode;
 };
 
 type DetectedOpenAICompletionsCompat = {
@@ -90,7 +92,9 @@ export function resolveOpenAICompletionsCompatDefaults(
     supportsUsageInStreaming:
       supportsOpenAICompletionsStreamingUsageCompat ||
       (!isNonStandard &&
-        (isLocalEndpoint || !usesConfiguredNonOpenAIEndpoint || supportsNativeStreamingUsageCompat)),
+        (isLocalEndpoint ||
+          !usesConfiguredNonOpenAIEndpoint ||
+          supportsNativeStreamingUsageCompat)),
     maxTokensField: usesMaxTokens ? "max_tokens" : "max_completion_tokens",
     thinkingFormat:
       isDeepSeek || isXiaomi
@@ -103,6 +107,7 @@ export function resolveOpenAICompletionsCompatDefaults(
     visibleReasoningDetailTypes: isOpenRouterLike ? ["response.output_text", "response.text"] : [],
     supportsStrictMode: !isZai && !usesConfiguredNonOpenAIEndpoint,
     requiresReasoningContentOnAssistantMessages: isDeepSeek || isXiaomi,
+    arrayToolParameterItems: isXiaomi ? "string" : "permissive",
   };
 }
 

--- a/src/agents/openai-tool-schema.ts
+++ b/src/agents/openai-tool-schema.ts
@@ -5,6 +5,7 @@ export { resolveOpenAIStrictToolSetting } from "./openai-strict-tool-setting.js"
 type ToolSchemaCompatInput = {
   unsupportedToolSchemaKeywords?: unknown;
   omitEmptyArrayItems?: unknown;
+  arrayToolParameterItems?: unknown;
 };
 
 type ToolWithParameters = {
@@ -18,18 +19,26 @@ function resolveToolSchemaModelCompat(
   if (!compat) {
     return undefined;
   }
-  const unsupportedToolSchemaKeywords = Array.isArray(compat.unsupportedToolSchemaKeywords)
-    ? compat.unsupportedToolSchemaKeywords.filter(
-        (keyword): keyword is string => typeof keyword === "string",
-      )
-    : [];
-  if (unsupportedToolSchemaKeywords.length === 0 && compat.omitEmptyArrayItems !== true) {
-    return undefined;
+  const modelCompat: ModelCompatConfig = {};
+  if (Array.isArray(compat.unsupportedToolSchemaKeywords)) {
+    const unsupportedToolSchemaKeywords = compat.unsupportedToolSchemaKeywords.filter(
+      (keyword): keyword is string => typeof keyword === "string",
+    );
+    if (unsupportedToolSchemaKeywords.length > 0) {
+      modelCompat.unsupportedToolSchemaKeywords = unsupportedToolSchemaKeywords;
+    }
   }
-  return {
-    ...(unsupportedToolSchemaKeywords.length > 0 ? { unsupportedToolSchemaKeywords } : {}),
-    ...(compat.omitEmptyArrayItems === true ? { omitEmptyArrayItems: true } : {}),
-  };
+  if (compat.omitEmptyArrayItems === true) {
+    modelCompat.omitEmptyArrayItems = true;
+  }
+  if (
+    compat.arrayToolParameterItems === "permissive" ||
+    compat.arrayToolParameterItems === "string" ||
+    compat.arrayToolParameterItems === "omit"
+  ) {
+    modelCompat.arrayToolParameterItems = compat.arrayToolParameterItems;
+  }
+  return Object.keys(modelCompat).length > 0 ? modelCompat : undefined;
 }
 
 export function normalizeStrictOpenAIJsonSchema(

--- a/src/agents/pi-tools-parameter-schema.ts
+++ b/src/agents/pi-tools-parameter-schema.ts
@@ -1,7 +1,8 @@
 import type { TSchema } from "typebox";
-import type { ModelCompatConfig } from "../config/types.models.js";
+import type { ArrayToolParameterItemsMode, ModelCompatConfig } from "../config/types.models.js";
 import { stripUnsupportedSchemaKeywords } from "../plugin-sdk/provider-tools.js";
 import {
+  resolveArrayToolParameterItems,
   resolveUnsupportedToolSchemaKeywords,
   shouldOmitEmptyArrayItems,
 } from "../plugins/provider-model-compat.js";
@@ -147,7 +148,10 @@ function isTrulyEmptySchema(schemaRecord: Record<string, unknown>): boolean {
   return Object.keys(schemaRecord).length === 0;
 }
 
-function normalizeArraySchemasMissingItems(schema: unknown): unknown {
+function normalizeArraySchemasMissingItems(
+  schema: unknown,
+  mode: ArrayToolParameterItemsMode = "permissive",
+): unknown {
   if (!isSchemaRecord(schema)) {
     return schema;
   }
@@ -155,7 +159,10 @@ function normalizeArraySchemasMissingItems(schema: unknown): unknown {
   let changed = false;
   const nextSchema: Record<string, unknown> = { ...schema };
   if (nextSchema.type === "array" && nextSchema.items === undefined) {
-    nextSchema.items = {};
+    if (mode === "omit") {
+      return schema;
+    }
+    nextSchema.items = mode === "string" ? { type: "string" } : {};
     changed = true;
   }
 
@@ -165,7 +172,7 @@ function normalizeArraySchemasMissingItems(schema: unknown): unknown {
     }
     const value = nextSchema[key];
     if (Array.isArray(value)) {
-      const normalized = value.map(normalizeArraySchemasMissingItems);
+      const normalized = value.map((entry) => normalizeArraySchemasMissingItems(entry, mode));
       if (normalized.some((entry, index) => entry !== value[index])) {
         nextSchema[key] = normalized;
         changed = true;
@@ -173,7 +180,7 @@ function normalizeArraySchemasMissingItems(schema: unknown): unknown {
       return;
     }
 
-    const normalized = normalizeArraySchemasMissingItems(value);
+    const normalized = normalizeArraySchemasMissingItems(value, mode);
     if (normalized !== value) {
       nextSchema[key] = normalized;
       changed = true;
@@ -211,7 +218,7 @@ function normalizeArraySchemasMissingItems(schema: unknown): unknown {
     let entriesChanged = false;
     const normalizedEntries: Array<[string, unknown]> = Object.entries(value).map(
       ([entryKey, entryValue]) => {
-        const normalizedEntryValue = normalizeArraySchemasMissingItems(entryValue);
+        const normalizedEntryValue = normalizeArraySchemasMissingItems(entryValue, mode);
         if (normalizedEntryValue !== entryValue) {
           entriesChanged = true;
         }
@@ -333,9 +340,12 @@ export function normalizeToolParameterSchema(
   const isAnthropicProvider = normalizedProvider.includes("anthropic");
   const unsupportedToolSchemaKeywords = resolveUnsupportedToolSchemaKeywords(options?.modelCompat);
   const omitEmptyArrayItems = shouldOmitEmptyArrayItems(options?.modelCompat);
+  const arrayToolParameterItems =
+    resolveArrayToolParameterItems(options?.modelCompat) ??
+    (omitEmptyArrayItems ? "omit" : "permissive");
 
   function applyProviderCleaning(s: unknown): TSchema {
-    const normalizedSchema = normalizeArraySchemasMissingItems(s);
+    const normalizedSchema = normalizeArraySchemasMissingItems(s, arrayToolParameterItems);
     const arrayItemsCompatibleSchema = omitEmptyArrayItems
       ? stripEmptyArrayItemsFromArraySchemas(normalizedSchema)
       : normalizedSchema;

--- a/src/agents/pi-tools.schema.test.ts
+++ b/src/agents/pi-tools.schema.test.ts
@@ -109,6 +109,63 @@ describe("normalizeToolParameterSchema", () => {
     });
   });
 
+  it("uses string items for providers that reject permissive array item schemas", () => {
+    expect(
+      normalizeToolParameterSchema(
+        {
+          type: "object",
+          properties: {
+            entity_hints: { type: "array", description: "Optional entity hints" },
+            nested: {
+              type: "object",
+              properties: {
+                ids: { type: "array" },
+              },
+            },
+            alternatives: {
+              anyOf: [{ type: "array" }, { type: "string" }],
+            },
+          },
+        },
+        { modelCompat: { arrayToolParameterItems: "string" } },
+      ),
+    ).toEqual({
+      type: "object",
+      properties: {
+        entity_hints: {
+          type: "array",
+          description: "Optional entity hints",
+          items: { type: "string" },
+        },
+        nested: {
+          type: "object",
+          properties: {
+            ids: { type: "array", items: { type: "string" } },
+          },
+        },
+        alternatives: {
+          anyOf: [{ type: "array", items: { type: "string" } }, { type: "string" }],
+        },
+      },
+    });
+  });
+
+  it("can skip synthetic array items for provider-specific tool schema compat", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        entity_hints: { type: "array", description: "Optional entity hints" },
+        explicit: { type: "array", items: { type: "number" } },
+      },
+    };
+
+    expect(
+      normalizeToolParameterSchema(schema, {
+        modelCompat: { arrayToolParameterItems: "omit" },
+      }),
+    ).toEqual(schema);
+  });
+
   it("inlines local $ref before removing unsupported keywords", () => {
     const cleaned = cleanToolSchemaForGemini({
       type: "object",

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -55,6 +55,8 @@ type SupportedThinkingFormat =
   | "deepseek"
   | "openrouter";
 
+export type ArrayToolParameterItemsMode = "permissive" | "string" | "omit";
+
 export type ModelCompatConfig = SupportedOpenAICompatFields &
   SupportedOpenAIResponsesCompatFields &
   SupportedAnthropicMessagesCompatFields & {
@@ -68,6 +70,8 @@ export type ModelCompatConfig = SupportedOpenAICompatFields &
     strictMessageKeys?: boolean;
     toolSchemaProfile?: string;
     unsupportedToolSchemaKeywords?: string[];
+    omitEmptyArrayItems?: boolean;
+    arrayToolParameterItems?: ArrayToolParameterItemsMode;
     nativeWebSearchTool?: boolean;
     toolCallArgumentsEncoding?: string;
     requiresMistralToolIds?: boolean;

--- a/src/model-catalog/normalize.ts
+++ b/src/model-catalog/normalize.ts
@@ -170,6 +170,7 @@ function normalizeModelCatalogCompat(value: unknown): ModelCompatConfig | undefi
     "supportsStrictMode",
     "requiresStringContent",
     "strictMessageKeys",
+    "omitEmptyArrayItems",
     "requiresToolResultName",
     "requiresAssistantAfterToolResult",
     "requiresThinkingAsText",
@@ -183,9 +184,21 @@ function normalizeModelCatalogCompat(value: unknown): ModelCompatConfig | undefi
     }
   }
 
-  const stringFields = ["toolSchemaProfile", "toolCallArgumentsEncoding"] as const;
+  const stringFields = [
+    "toolSchemaProfile",
+    "toolCallArgumentsEncoding",
+    "arrayToolParameterItems",
+  ] as const;
   for (const field of stringFields) {
     const normalized = normalizeOptionalString(value[field]) ?? "";
+    if (
+      field === "arrayToolParameterItems" &&
+      normalized !== "permissive" &&
+      normalized !== "string" &&
+      normalized !== "omit"
+    ) {
+      continue;
+    }
     if (normalized) {
       compat[field] = normalized;
     }

--- a/src/plugin-sdk/provider-model-shared.ts
+++ b/src/plugin-sdk/provider-model-shared.ts
@@ -66,6 +66,7 @@ export {
   hasToolSchemaProfile,
   hasNativeWebSearchTool,
   normalizeModelCompat,
+  resolveArrayToolParameterItems,
   resolveUnsupportedToolSchemaKeywords,
   resolveToolCallArgumentsEncoding,
 } from "../plugins/provider-model-compat.js";

--- a/src/plugins/provider-model-compat.ts
+++ b/src/plugins/provider-model-compat.ts
@@ -53,6 +53,13 @@ export function resolveToolCallArgumentsEncoding(
   return extractModelCompat(modelOrCompat)?.toolCallArgumentsEncoding;
 }
 
+export function resolveArrayToolParameterItems(
+  modelOrCompat: { compat?: unknown } | ModelCompatConfig | undefined,
+): ModelCompatConfig["arrayToolParameterItems"] | undefined {
+  const mode = extractModelCompat(modelOrCompat)?.arrayToolParameterItems;
+  return mode === "permissive" || mode === "string" || mode === "omit" ? mode : undefined;
+}
+
 export function resolveUnsupportedToolSchemaKeywords(
   modelOrCompat: { compat?: unknown } | ModelCompatConfig | undefined,
 ): ReadonlySet<string> {
@@ -68,10 +75,7 @@ export function resolveUnsupportedToolSchemaKeywords(
 export function shouldOmitEmptyArrayItems(
   modelOrCompat: { compat?: unknown } | ModelCompatConfig | undefined,
 ): boolean {
-  const compat = extractModelCompat(modelOrCompat) as
-    | (ModelCompatConfig & { omitEmptyArrayItems?: unknown })
-    | undefined;
-  return compat?.omitEmptyArrayItems === true;
+  return extractModelCompat(modelOrCompat)?.omitEmptyArrayItems === true;
 }
 
 function isOpenAiCompletionsModel(model: Model<Api>): model is Model<"openai-completions"> {
@@ -100,26 +104,34 @@ export function normalizeModelCompat(model: Model<Api>): Model<Api> {
     return model;
   }
 
-  const compat = model.compat ?? undefined;
+  const compat = extractModelCompat(model);
   const detectedCompatDefaults = baseUrl
     ? detectOpenAICompletionsCompat(model).defaults
     : undefined;
+  const shouldForceArrayToolParameterItems = Boolean(
+    detectedCompatDefaults &&
+    detectedCompatDefaults.arrayToolParameterItems !== "permissive" &&
+    compat?.arrayToolParameterItems === undefined,
+  );
   const needsForce = Boolean(
     detectedCompatDefaults &&
     (!detectedCompatDefaults.supportsDeveloperRole ||
       !detectedCompatDefaults.supportsUsageInStreaming ||
-      !detectedCompatDefaults.supportsStrictMode),
+      !detectedCompatDefaults.supportsStrictMode ||
+      shouldForceArrayToolParameterItems),
   );
   if (!needsForce) {
     return model;
   }
   const forcedDeveloperRole = compat?.supportsDeveloperRole === true;
   const hasStreamingUsageOverride = compat?.supportsUsageInStreaming !== undefined;
+  const hasArrayToolParameterItemsOverride = compat?.arrayToolParameterItems !== undefined;
   const targetStrictMode = compat?.supportsStrictMode ?? detectedCompatDefaults?.supportsStrictMode;
   if (
     compat?.supportsDeveloperRole !== undefined &&
     hasStreamingUsageOverride &&
-    compat?.supportsStrictMode !== undefined
+    compat?.supportsStrictMode !== undefined &&
+    (hasArrayToolParameterItemsOverride || !shouldForceArrayToolParameterItems)
   ) {
     return model;
   }
@@ -136,11 +148,17 @@ export function normalizeModelCompat(model: Model<Api>): Model<Api> {
                 supportsUsageInStreaming: detectedCompatDefaults?.supportsUsageInStreaming ?? false,
               }),
           supportsStrictMode: targetStrictMode,
+          ...(shouldForceArrayToolParameterItems
+            ? { arrayToolParameterItems: detectedCompatDefaults?.arrayToolParameterItems }
+            : {}),
         }
       : {
           supportsDeveloperRole: false,
           supportsUsageInStreaming: detectedCompatDefaults?.supportsUsageInStreaming ?? false,
           supportsStrictMode: detectedCompatDefaults?.supportsStrictMode ?? false,
+          ...(shouldForceArrayToolParameterItems
+            ? { arrayToolParameterItems: detectedCompatDefaults?.arrayToolParameterItems }
+            : {}),
         },
   } as typeof model;
 }


### PR DESCRIPTION
## Summary
- add provider/model compat `arrayToolParameterItems` with `permissive`, `string`, and `omit` modes
- default Xiaomi/OpenAI-compatible token-plan endpoints to string array item schemas while keeping other providers permissive
- pass the compat through tool schema normalization, model catalog normalization, and plugin-sdk exports
- keep normalized compat limited to compat fields instead of copying the whole model into `compat`

Closes #82447

## Real behavior proof
- Behavior or issue addressed: Xiaomi token-plan OpenAI-compatible models now normalize tool parameter arrays that omit `items` to string array items before sending tool schemas.
- Real environment tested: Local OpenClaw checkout on macOS, branch `fix/82447-openai-compatible-array-items`, commit `f09a78c2`; ran OpenClaw runtime schema-normalization code via `node --import tsx` against the Xiaomi token-plan base URL and a real tool-parameter schema shape with an array missing `items`.
- Exact steps or command run after this patch: `node --import tsx --input-type=module` importing `normalizeModelCompat` from `src/plugins/provider-model-compat.ts` and `normalizeToolParameterSchema` from `src/agents/pi-tools-parameter-schema.ts`, then normalizing a Xiaomi token-plan `openai-completions` model and a tool schema containing `tags: { type: "array" }`.
- Evidence after fix: terminal output from the local OpenClaw runtime command:

```text
OpenClaw local runtime schema normalization proof
model=xiaomi-mimo-tp/mimo-v2.5
baseUrl=https://token-plan-cn.xiaomimimo.com/v1
detected arrayToolParameterItems=string
normalized tags.items={"type":"string"}
{
  "compat": {
    "supportsDeveloperRole": false,
    "supportsUsageInStreaming": false,
    "supportsStrictMode": false,
    "arrayToolParameterItems": "string"
  },
  "normalizedTags": {
    "type": "array",
    "description": "array without items from tool metadata",
    "items": {
      "type": "string"
    }
  }
}
```

- Observed result after fix: The runtime compat detection reports `arrayToolParameterItems=string`, and the normalized tool schema contains `tags.items={"type":"string"}` for the Xiaomi token-plan endpoint. The normalized `compat` object only contains compat flags and does not copy model identity/base URL fields into `compat`.
- What was not tested: A live request to Xiaomi token-plan was not sent because that would require external account credentials; the real local OpenClaw runtime normalization path that builds the outgoing tool schema was exercised.

## Test Plan
- `node scripts/run-vitest.mjs src/agents/pi-tools.schema.test.ts src/agents/model-compat.test.ts -- -t "array item|Xiaomi token-plan|omits empty array items"`
- `node scripts/run-vitest.mjs src/agents/openai-completions-compat.test.ts src/agents/openai-tool-schema.test.ts src/model-catalog/normalize.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=2 OPENCLAW_TEST_PROJECTS_PARALLEL=2 OPENCLAW_VITEST_SHARD_NAME=agentic-control-plane-runtime OPENCLAW_VITEST_INCLUDE_FILE=/tmp/openclaw-82632-gateway-runtime-include.json pnpm --config.verify-deps-before-run=false exec node scripts/test-projects.mjs test/vitest/vitest.gateway-server.config.ts`
- `pnpm --config.verify-deps-before-run=false check:changed --staged`

Note: the explicit pnpm config only bypasses pnpm's dependency auto-install check in this isolated worktree, where `node_modules` is a symlink to the main checkout. It does not skip any OpenClaw validation lanes.
