### PR TITLE
Fix delayed WebChat TTS ordering

### DIFF
--- a/src/gateway/chat-display-projection.ts
+++ b/src/gateway/chat-display-projection.ts
@@ -464,7 +464,117 @@ export function sanitizeChatHistoryMessages(
     }
     next.push(res.message);
   }
-  return changed ? next : messages;
+  const merged = mergeTtsSupplementMessages(next);
+  return changed || merged !== next ? merged : messages;
+}
+
+function normalizeAssistantVisibleText(message: unknown): string {
+  if (!message || typeof message !== "object") {
+    return "";
+  }
+  const record = message as Record<string, unknown>;
+  if (record.role !== "assistant") {
+    return "";
+  }
+  const content = record.content;
+  if (typeof content === "string") {
+    return stripInlineDirectiveTagsForDisplay(content).text.trim();
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return content
+    .map((block) => {
+      if (!block || typeof block !== "object") {
+        return "";
+      }
+      const text = (block as { text?: unknown }).text;
+      return typeof text === "string" ? stripInlineDirectiveTagsForDisplay(text).text.trim() : "";
+    })
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+}
+
+function resolveTtsSupplementSpokenText(message: unknown): string | undefined {
+  if (!message || typeof message !== "object") {
+    return undefined;
+  }
+  const marker = (message as { openclawTtsSupplement?: unknown }).openclawTtsSupplement;
+  if (!marker || typeof marker !== "object" || Array.isArray(marker)) {
+    return undefined;
+  }
+  const spokenText = (marker as { spokenText?: unknown }).spokenText;
+  return typeof spokenText === "string" && spokenText.trim() ? spokenText.trim() : undefined;
+}
+
+function extractTtsSupplementContent(content: unknown): unknown[] {
+  if (!Array.isArray(content)) {
+    return [];
+  }
+  return content.filter((block) => {
+    if (!block || typeof block !== "object") {
+      return false;
+    }
+    const type = (block as { type?: unknown }).type;
+    return type !== "text";
+  });
+}
+
+function appendContentBlocks(message: unknown, blocks: unknown[]): unknown {
+  if (!message || typeof message !== "object" || Array.isArray(message) || blocks.length === 0) {
+    return message;
+  }
+  const record = message as Record<string, unknown>;
+  const content = Array.isArray(record.content)
+    ? [...record.content, ...blocks]
+    : typeof record.content === "string"
+      ? [{ type: "text", text: record.content }, ...blocks]
+      : blocks;
+  return {
+    ...record,
+    content,
+  };
+}
+
+function mergeTtsSupplementMessages(messages: unknown[]): unknown[] {
+  let changed = false;
+  const out: unknown[] = [];
+  for (const message of messages) {
+    const spokenText = resolveTtsSupplementSpokenText(message);
+    const contentBlocks =
+      spokenText && typeof message === "object" && message
+        ? extractTtsSupplementContent((message as { content?: unknown }).content)
+        : [];
+    if (!spokenText || contentBlocks.length === 0) {
+      out.push(message);
+      continue;
+    }
+    const targetIndex = findTtsSupplementTargetIndex(out, spokenText);
+    if (targetIndex < 0) {
+      out.push(message);
+      continue;
+    }
+    out[targetIndex] = appendContentBlocks(out[targetIndex], contentBlocks);
+    changed = true;
+  }
+  return changed ? out : messages;
+}
+
+function findTtsSupplementTargetIndex(messages: unknown[], spokenText: string): number {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const message = messages[i];
+    if (!message || typeof message !== "object") {
+      continue;
+    }
+    if ((message as { role?: unknown }).role !== "assistant") {
+      continue;
+    }
+    if (normalizeAssistantVisibleText(message) === spokenText) {
+      return i;
+    }
+  }
+  return -1;
 }
 
 function asRoleContentMessage(message: Record<string, unknown>): RoleContentMessage | null {

--- a/src/gateway/server-methods/chat-transcript-inject.ts
+++ b/src/gateway/server-methods/chat-transcript-inject.ts
@@ -50,6 +50,9 @@ export async function appendInjectedAssistantMessageToTranscript(params: {
   /** When set, used as the assistant `content` array (e.g. text + embedded audio blocks). */
   content?: Array<Record<string, unknown>>;
   idempotencyKey?: string;
+  openclawTtsSupplement?: {
+    spokenText: string;
+  };
   abortMeta?: GatewayInjectedAbortMeta;
   now?: number;
   config?: OpenClawConfig;
@@ -91,6 +94,9 @@ export async function appendInjectedAssistantMessageToTranscript(params: {
     provider: "openclaw",
     model: "gateway-injected",
     ...(params.idempotencyKey ? { idempotencyKey: params.idempotencyKey } : {}),
+    ...(params.openclawTtsSupplement
+      ? { openclawTtsSupplement: params.openclawTtsSupplement }
+      : {}),
     ...(params.abortMeta
       ? {
           openclawAbort: {

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -825,6 +825,9 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
       : [];
     expect(message?.role).toBe("assistant");
     expect(message?.idempotencyKey).toBe("idem-agent-tts:assistant-media");
+    expect(message?.openclawTtsSupplement).toEqual({
+      spokenText: "This text is already in the model transcript.",
+    });
     expect(content[0]).toEqual({ type: "text", text: "Audio reply" });
     expect(content[1]).toEqual({
       type: "attachment",
@@ -836,9 +839,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
         isVoiceNote: true,
       },
     });
-    expect(JSON.stringify(assistantUpdates[0]?.message)).not.toContain(
-      "This text is already in the model transcript.",
-    );
+    expect(JSON.stringify(content)).not.toContain("This text is already in the model transcript.");
   });
 
   it("does not mirror agent-run stale media final text from live delivery", async () => {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -171,7 +171,9 @@ function isMediaBearingPayload(payload: ReplyPayload): boolean {
   return false;
 }
 
-function isTtsSupplementPayload(payload: ReplyPayload): boolean {
+function isTtsSupplementPayload(
+  payload: ReplyPayload,
+): payload is ReplyPayload & { spokenText: string } {
   return (
     typeof payload.spokenText === "string" &&
     payload.spokenText.trim().length > 0 &&
@@ -1398,6 +1400,9 @@ async function appendAssistantTranscriptMessage(params: {
   agentId?: string;
   createIfMissing?: boolean;
   idempotencyKey?: string;
+  openclawTtsSupplement?: {
+    spokenText: string;
+  };
   abortMeta?: {
     aborted: true;
     origin: AbortOrigin;
@@ -1441,6 +1446,7 @@ async function appendAssistantTranscriptMessage(params: {
     label: params.label,
     content: params.content,
     idempotencyKey: params.idempotencyKey,
+    openclawTtsSupplement: params.openclawTtsSupplement,
     abortMeta: params.abortMeta,
     config: params.cfg,
   });
@@ -2530,6 +2536,9 @@ export const chatHandlers: GatewayRequestHandlers = {
           agentId,
           createIfMissing: true,
           idempotencyKey: `${clientRunId}:assistant-media`,
+          ...(isTtsSupplementPayload(payload)
+            ? { openclawTtsSupplement: { spokenText: payload.spokenText.trim() } }
+            : {}),
           cfg,
         });
         if (appended.ok) {

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -501,6 +501,68 @@ describe("sanitizeChatHistoryMessages", () => {
 });
 
 describe("projectRecentChatDisplayMessages", () => {
+  it("merges delayed TTS supplements into their original assistant message", () => {
+    const result = projectRecentChatDisplayMessages([
+      {
+        role: "user",
+        content: [{ type: "text", text: "hello" }],
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "The answer is 42." }],
+        timestamp: 2,
+        __openclaw: { seq: 2 },
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "thanks" }],
+        timestamp: 3,
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Audio reply" },
+          {
+            type: "audio",
+            label: "tts.mp3",
+            source: { type: "url", url: "file:///tmp/tts.mp3", media_type: "audio/mpeg" },
+            isVoiceNote: true,
+          },
+        ],
+        openclawTtsSupplement: { spokenText: "The answer is 42." },
+        timestamp: 4,
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "hello" }],
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "The answer is 42." },
+          {
+            type: "audio",
+            label: "tts.mp3",
+            source: { type: "url", url: "file:///tmp/tts.mp3", media_type: "audio/mpeg" },
+            isVoiceNote: true,
+          },
+        ],
+        timestamp: 2,
+        __openclaw: { seq: 2 },
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "thanks" }],
+        timestamp: 3,
+      },
+    ]);
+  });
+
   it("keeps visible assistant progress text from mixed tool-use messages", () => {
     const result = projectRecentChatDisplayMessages([
       {


### PR DESCRIPTION
Fixes #82570

## Summary
- Tags delayed WebChat TTS media supplements with the original spoken assistant text.
- Merges marked TTS supplement media into the matching earlier assistant history message during display projection, instead of leaving a later standalone assistant row.
- Keeps the generated audio block while avoiding duplicate visible transcript text, so replying before TTS finishes no longer reorders the original assistant response.

## Real behavior proof
- **Behavior or issue addressed**: When a user replies before the delayed TTS audio supplement is appended, WebChat history should keep the original assistant text before the user reply and attach the audio to that original assistant message.
- **Real environment tested**: Local OpenClaw checkout at `/Users/miya/Desktop/Projects/openclaw-82570-tts-order` on macOS, running the production `projectRecentChatDisplayMessages` path through `pnpm tsx`.
- **Exact steps or command run after this patch**: Ran a live terminal command against the production display projection with an assistant text message at timestamp 2, a user reply at timestamp 3, and the delayed marked TTS audio supplement at timestamp 4.
- **Evidence after fix**: Terminal capture from the local OpenClaw checkout:
```json
[
  {
    "role": "user",
    "timestamp": 1,
    "text": "question",
    "audioBlocks": 0
  },
  {
    "role": "assistant",
    "timestamp": 2,
    "text": "Answer before TTS.",
    "audioBlocks": 1
  },
  {
    "role": "user",
    "timestamp": 3,
    "text": "reply sent before audio",
    "audioBlocks": 0
  }
]
```
- **Observed result after fix**: The assistant message remains at timestamp 2, the delayed TTS audio is merged into that assistant message as one audio block, and there is no standalone assistant TTS row after the user's timestamp 3 reply.
- **What was not tested**: Full browser UI recording was not captured; this PR includes live projection output plus focused regression coverage for the affected history ordering path.

## Verification
- `pnpm vitest run src/gateway/server-methods/server-methods.test.ts src/gateway/server-methods/chat.directive-tags.test.ts`
- `pnpm exec oxlint src/gateway/chat-display-projection.ts src/gateway/server-methods/chat-transcript-inject.ts src/gateway/server-methods/chat.directive-tags.test.ts src/gateway/server-methods/chat.ts src/gateway/server-methods/server-methods.test.ts`