### PR TITLE
fix: preserve generated media completion attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/media: accept generated media attachments on internal completion events and report delivery-loss failures as errors, so completed background music/video tasks do not disappear after provider success.
 - Matrix/approvals: release in-flight reaction bindings when the channel approval handler stops mid-delivery, preventing stale approval targets after restart. Fixes #82485. (#82482) Thanks @Feelw00.
 - Matrix/E2EE: stop requesting MSC4222 `state_after` sync responses so homeservers with incomplete state-after data do not leave fresh encrypted rooms without outbound room encryptors. Fixes #82515. Thanks @nickdecooman.
 - TUI: update the displayed model in real time when an auto-fallback resolution swaps in a different model mid-turn, so the status line reflects the actual model handling the run. Fixes #82296. Thanks @giodl73-repo.

--- a/src/agents/tools/media-generate-background-shared.ts
+++ b/src/agents/tools/media-generate-background-shared.ts
@@ -323,7 +323,7 @@ async function wakeMediaGenerationTaskCompletion(params: {
     directIdempotencyKey: announceId,
   });
   if (!delivery.delivered && delivery.error) {
-    log.warn("Media generation completion wake failed", {
+    log.error("Media generation completion wake failed; generated media may not be delivered", {
       taskId: params.handle.taskId,
       runId: params.handle.runId,
       toolName: params.toolName,

--- a/src/gateway/protocol/schema/agent.test.ts
+++ b/src/gateway/protocol/schema/agent.test.ts
@@ -1,0 +1,61 @@
+import { Value } from "typebox/value";
+import { describe, expect, it } from "vitest";
+import type { AgentInternalEvent } from "../../../agents/internal-events.js";
+import { AgentParamsSchema } from "./agent.js";
+
+function makeAgentParamsWithInternalEvent(event: AgentInternalEvent) {
+  return {
+    message: "A music generation task finished. Process the completion update now.",
+    sessionKey: "agent:main:discord:channel:1456744319972282449",
+    internalEvents: [event],
+    idempotencyKey: "music_generate:task-123:ok",
+  };
+}
+
+const musicCompletionEvent: AgentInternalEvent = {
+  type: "task_completion",
+  source: "music_generation",
+  childSessionKey: "music_generate:task-123",
+  childSessionId: "task-123",
+  announceType: "music generation task",
+  taskLabel: "OpenClaw release anthem",
+  status: "ok",
+  statusLabel: "completed successfully",
+  result: "Generated 1 track.",
+  attachments: [
+    {
+      type: "audio",
+      path: "/tmp/openclaw/generated-release-anthem.mp3",
+      mimeType: "audio/mpeg",
+      name: "generated-release-anthem.mp3",
+    },
+  ],
+  mediaUrls: ["/tmp/openclaw/generated-release-anthem.mp3"],
+  replyInstruction: "Deliver the generated music.",
+};
+
+describe("AgentParamsSchema", () => {
+  it("accepts generated music attachments on internal completion events", () => {
+    const params = makeAgentParamsWithInternalEvent(musicCompletionEvent);
+
+    expect(Value.Check(AgentParamsSchema, params)).toBe(true);
+  });
+
+  it("keeps task completion internal events strict", () => {
+    const params = makeAgentParamsWithInternalEvent({
+      ...musicCompletionEvent,
+      unexpected: true,
+    } as AgentInternalEvent);
+
+    expect(Value.Check(AgentParamsSchema, params)).toBe(false);
+  });
+
+  it("rejects malformed generated attachment entries on internal events", () => {
+    const params = makeAgentParamsWithInternalEvent({
+      ...musicCompletionEvent,
+      attachments: [null],
+    } as unknown as AgentInternalEvent);
+
+    expect(Value.Check(AgentParamsSchema, params)).toBe(false);
+  });
+});

--- a/src/gateway/protocol/schema/agent.ts
+++ b/src/gateway/protocol/schema/agent.ts
@@ -6,6 +6,19 @@ import {
 } from "../../../agents/internal-event-contract.js";
 import { InputProvenanceSchema, NonEmptyString, SessionLabelString } from "./primitives.js";
 
+export const AgentGeneratedAttachmentSchema = Type.Object(
+  {
+    type: Type.Optional(Type.String({ enum: ["image", "audio", "video", "file"] })),
+    path: Type.Optional(Type.String()),
+    url: Type.Optional(Type.String()),
+    mediaUrl: Type.Optional(Type.String()),
+    filePath: Type.Optional(Type.String()),
+    mimeType: Type.Optional(Type.String()),
+    name: Type.Optional(Type.String()),
+  },
+  { additionalProperties: false },
+);
+
 export const AgentInternalEventSchema = Type.Object(
   {
     type: Type.Literal(AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION),
@@ -17,6 +30,7 @@ export const AgentInternalEventSchema = Type.Object(
     status: Type.String({ enum: [...AGENT_INTERNAL_EVENT_STATUSES] }),
     statusLabel: Type.String(),
     result: Type.String(),
+    attachments: Type.Optional(Type.Array(AgentGeneratedAttachmentSchema)),
     mediaUrls: Type.Optional(Type.Array(Type.String())),
     statsLine: Type.Optional(Type.String()),
     replyInstruction: Type.String(),


### PR DESCRIPTION
## Summary

- Accept generated media attachments on internal task-completion events so background music/video completion handoffs pass gateway validation.
- Add a regression test for generated music completion attachments and malformed attachment entries.
- Escalate failed media completion handoffs to an error log so delivery-loss cases are easier to spot.

## Verification

- `pnpm test src/gateway/protocol/schema/agent.test.ts src/agents/tools/music-generate-background.test.ts`
- `pnpm format:check src/gateway/protocol/schema/agent.ts src/gateway/protocol/schema/agent.test.ts src/agents/tools/media-generate-background-shared.ts`
- `git diff --check HEAD^ HEAD`
- `codex review --commit HEAD`

## Real behavior proof

Behavior addressed: generated music/video completion events with structured attachments are accepted by the gateway instead of being rejected as invalid agent params.
Real environment tested: local OpenClaw checkout on macOS with the real gateway protocol schema loaded through Node/tsx.
Exact steps or command run after this patch: ran a Node command against `AgentParamsSchema` using a generated music completion payload containing `internalEvents[0].attachments`.
Evidence after fix: terminal output from the local OpenClaw checkout:

```text
{"validCompletionAccepted":true,"malformedAttachmentRejected":true}
```

Observed result after fix: the generated music completion payload is accepted, and the malformed attachment variant is rejected.
What was not tested: no live MiniMax generation was run from this branch.
