### PR TITLE
fix: bypass npm freshness filters during updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 - Matrix/E2EE: stop requesting MSC4222 `state_after` sync responses so homeservers with incomplete state-after data do not leave fresh encrypted rooms without outbound room encryptors. Fixes #82515. Thanks @nickdecooman.
 - TUI: update the displayed model in real time when an auto-fallback resolution swaps in a different model mid-turn, so the status line reflects the actual model handling the run. Fixes #82296. Thanks @giodl73-repo.
 - Gateway/sessions: estimate context usage from local/OpenAI-compatible transcripts when provider usage telemetry is missing, so status no longer shows empty usage for real local-model sessions. Fixes #73990. (#82317) Thanks @giodl73-repo.
+- Update/installers: override npm `min-release-age` quarantine for OpenClaw-managed package installs, so `openclaw update`, plugin updates, and hosted installer scripts can install the requested latest release immediately.
 - Agents/sessions: preserve fresh post-compaction token snapshots across stale usage updates, preventing repeated auto-compaction after every message. Fixes #82576. (#82578) Thanks @njuboy11.
 - Agents/OpenAI Responses: log redacted diagnostics for detail-less `response.failed` events while preserving failed response ids, so operators can correlate provider-side failures. Fixes #82558.
 - Telegram: cache successful startup bot identity by account and token fingerprint for up to 24 hours, so restarts can skip redundant `getMe` probes during Telegram API slow periods without permanently pinning renamed bots. Refs #82525.

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -75,6 +75,13 @@ If you already manage Node yourself:
     npm install -g openclaw@latest
     openclaw onboard --install-daemon
     ```
+
+    <Note>
+    The hosted installer clears npm freshness filters such as `min-release-age`
+    for the OpenClaw package install. If you install manually with npm, your own
+    npm policy still applies.
+    </Note>
+
   </Tab>
   <Tab title="pnpm">
     ```bash

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -111,6 +111,12 @@ OpenClaw retries once with `--omit=optional`. That retry helps hosts where nativ
 optional dependencies cannot compile, while keeping the original failure visible
 if the fallback also fails.
 
+OpenClaw-managed npm update and plugin-update commands also clear npm
+`min-release-age` quarantine for the child npm process. npm may report that
+policy as a derived `before` cutoff; both are useful for general supply-chain
+quarantine policies, but an explicit OpenClaw update means "install the selected
+OpenClaw release now."
+
 ```bash
 pnpm add -g openclaw@latest
 ```

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -624,10 +624,21 @@ fix_npm_prefix_if_needed() {
 
 install_openclaw() {
   local requested="${OPENCLAW_VERSION:-latest}"
+  local freshness_flag="--min-release-age=0"
+  local min_release_age=""
+  min_release_age="$(env -u NPM_CONFIG_BEFORE -u npm_config_before "$(npm_bin)" config get min-release-age 2>/dev/null || true)"
+  if [[ -z "$min_release_age" || "$min_release_age" == "null" || "$min_release_age" == "undefined" ]]; then
+    local before_value=""
+    before_value="$(env -u NPM_CONFIG_MIN_RELEASE_AGE -u npm_config_min_release_age -u npm_config_min-release-age "$(npm_bin)" config get before 2>/dev/null || true)"
+    if [[ -n "$before_value" && "$before_value" != "null" && "$before_value" != "undefined" ]]; then
+      freshness_flag="--before=$(date -u '+%Y-%m-%dT%H:%M:%S.000Z')"
+    fi
+  fi
   local npm_args=(
     --loglevel "$NPM_LOGLEVEL"
     --no-fund
     --no-audit
+    "$freshness_flag"
   )
   emit_json "{\"event\":\"step\",\"name\":\"openclaw\",\"status\":\"start\",\"version\":\"${requested}\"}"
   log "Installing OpenClaw (${requested})..."
@@ -636,14 +647,14 @@ install_openclaw() {
   fi
 
   if [[ "${requested}" == "latest" ]]; then
-    if ! SHARP_IGNORE_GLOBAL_LIBVIPS="$SHARP_IGNORE_GLOBAL_LIBVIPS" "$(npm_bin)" install -g --prefix "$(node_dir)" "${npm_args[@]}" "openclaw@latest"; then
+    if ! env -u NPM_CONFIG_BEFORE -u npm_config_before -u NPM_CONFIG_MIN_RELEASE_AGE -u npm_config_min_release_age -u npm_config_min-release-age "SHARP_IGNORE_GLOBAL_LIBVIPS=$SHARP_IGNORE_GLOBAL_LIBVIPS" "$(npm_bin)" install -g --prefix "$(node_dir)" "${npm_args[@]}" "openclaw@latest"; then
       log "npm install openclaw@latest failed; retrying openclaw@next"
       emit_json "{\"event\":\"step\",\"name\":\"openclaw\",\"status\":\"retry\",\"version\":\"next\"}"
-      SHARP_IGNORE_GLOBAL_LIBVIPS="$SHARP_IGNORE_GLOBAL_LIBVIPS" "$(npm_bin)" install -g --prefix "$(node_dir)" "${npm_args[@]}" "openclaw@next"
+      env -u NPM_CONFIG_BEFORE -u npm_config_before -u NPM_CONFIG_MIN_RELEASE_AGE -u npm_config_min_release_age -u npm_config_min-release-age "SHARP_IGNORE_GLOBAL_LIBVIPS=$SHARP_IGNORE_GLOBAL_LIBVIPS" "$(npm_bin)" install -g --prefix "$(node_dir)" "${npm_args[@]}" "openclaw@next"
       requested="next"
     fi
   else
-    SHARP_IGNORE_GLOBAL_LIBVIPS="$SHARP_IGNORE_GLOBAL_LIBVIPS" "$(npm_bin)" install -g --prefix "$(node_dir)" "${npm_args[@]}" "openclaw@${requested}"
+    env -u NPM_CONFIG_BEFORE -u npm_config_before -u NPM_CONFIG_MIN_RELEASE_AGE -u npm_config_min_release_age -u npm_config_min-release-age "SHARP_IGNORE_GLOBAL_LIBVIPS=$SHARP_IGNORE_GLOBAL_LIBVIPS" "$(npm_bin)" install -g --prefix "$(node_dir)" "${npm_args[@]}" "openclaw@${requested}"
   fi
 
   mkdir -p "${PREFIX}/bin"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -510,20 +510,32 @@ function Install-OpenClaw {
     }
     $installSpec = Resolve-NpmOpenClawInstallSpec -PackageName $packageName -RequestedTag $Tag
     Write-Host "[*] Installing OpenClaw ($installSpec)..." -ForegroundColor Yellow
+    $freshnessArgs = @("--min-release-age=0")
+    $minReleaseAge = (& (Get-NpmCommandPath) config get min-release-age 2>$null)
+    if ($LASTEXITCODE -ne 0 -or -not $minReleaseAge -or $minReleaseAge.Trim() -eq "null" -or $minReleaseAge.Trim() -eq "undefined") {
+        $beforeValue = (& (Get-NpmCommandPath) config get before 2>$null)
+        if ($LASTEXITCODE -eq 0 -and $beforeValue -and $beforeValue.Trim() -ne "null" -and $beforeValue.Trim() -ne "undefined") {
+            $freshnessArgs = @("--before=$((Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ"))")
+        }
+    }
     $prevLogLevel = $env:NPM_CONFIG_LOGLEVEL
     $prevUpdateNotifier = $env:NPM_CONFIG_UPDATE_NOTIFIER
     $prevFund = $env:NPM_CONFIG_FUND
     $prevAudit = $env:NPM_CONFIG_AUDIT
     $prevScriptShell = $env:NPM_CONFIG_SCRIPT_SHELL
     $prevNodeLlamaSkipDownload = $env:NODE_LLAMA_CPP_SKIP_DOWNLOAD
+    $prevBefore = $env:NPM_CONFIG_BEFORE
+    $prevMinReleaseAge = $env:NPM_CONFIG_MIN_RELEASE_AGE
     $env:NPM_CONFIG_LOGLEVEL = "error"
     $env:NPM_CONFIG_UPDATE_NOTIFIER = "false"
     $env:NPM_CONFIG_FUND = "false"
     $env:NPM_CONFIG_AUDIT = "false"
     $env:NPM_CONFIG_SCRIPT_SHELL = "cmd.exe"
     $env:NODE_LLAMA_CPP_SKIP_DOWNLOAD = "1"
+    Remove-Item Env:NPM_CONFIG_BEFORE -ErrorAction SilentlyContinue
+    Remove-Item Env:NPM_CONFIG_MIN_RELEASE_AGE -ErrorAction SilentlyContinue
     try {
-        $npmOutput = & (Get-NpmCommandPath) install -g "$installSpec" 2>&1
+        $npmOutput = & (Get-NpmCommandPath) install -g @freshnessArgs "$installSpec" 2>&1
         if ($LASTEXITCODE -ne 0) {
             Write-Host "[!] npm install failed" -ForegroundColor Red
             if ($npmOutput -match "spawn git" -or $npmOutput -match "ENOENT.*git") {
@@ -544,6 +556,8 @@ function Install-OpenClaw {
         $env:NPM_CONFIG_AUDIT = $prevAudit
         $env:NPM_CONFIG_SCRIPT_SHELL = $prevScriptShell
         $env:NODE_LLAMA_CPP_SKIP_DOWNLOAD = $prevNodeLlamaSkipDownload
+        $env:NPM_CONFIG_BEFORE = $prevBefore
+        $env:NPM_CONFIG_MIN_RELEASE_AGE = $prevMinReleaseAge
     }
     Write-Host "[OK] OpenClaw installed" -ForegroundColor Green
     return $true

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -713,12 +713,23 @@ run_npm_global_install() {
     local spec="$1"
     local log="$2"
 
+    local freshness_flag="--min-release-age=0"
+    local min_release_age=""
+    min_release_age="$(env -u NPM_CONFIG_BEFORE -u npm_config_before npm config get min-release-age 2>/dev/null || true)"
+    if [[ -z "$min_release_age" || "$min_release_age" == "null" || "$min_release_age" == "undefined" ]]; then
+        local before_value=""
+        before_value="$(env -u NPM_CONFIG_MIN_RELEASE_AGE -u npm_config_min_release_age -u npm_config_min-release-age npm config get before 2>/dev/null || true)"
+        if [[ -n "$before_value" && "$before_value" != "null" && "$before_value" != "undefined" ]]; then
+            freshness_flag="--before=$(date -u '+%Y-%m-%dT%H:%M:%S.000Z')"
+        fi
+    fi
+
     local -a cmd
-    cmd=(env "SHARP_IGNORE_GLOBAL_LIBVIPS=$SHARP_IGNORE_GLOBAL_LIBVIPS" npm --loglevel "$NPM_LOGLEVEL")
+    cmd=(env -u NPM_CONFIG_BEFORE -u npm_config_before -u NPM_CONFIG_MIN_RELEASE_AGE -u npm_config_min_release_age -u npm_config_min-release-age "SHARP_IGNORE_GLOBAL_LIBVIPS=$SHARP_IGNORE_GLOBAL_LIBVIPS" npm --loglevel "$NPM_LOGLEVEL")
     if [[ -n "$NPM_SILENT_FLAG" ]]; then
         cmd+=("$NPM_SILENT_FLAG")
     fi
-    cmd+=(--no-fund --no-audit install -g "$spec")
+    cmd+=(--no-fund --no-audit "$freshness_flag" install -g "$spec")
     local cmd_display=""
     printf -v cmd_display '%q ' "${cmd[@]}"
     LAST_NPM_INSTALL_CMD="${cmd_display% }"

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -483,6 +483,7 @@ describe("update-cli", () => {
       "--no-fund",
       "--no-audit",
       "--loglevel=error",
+      "--min-release-age=0",
     ]);
     if (call?.[1] === undefined) {
       throw new Error("Expected package install command options");
@@ -2577,7 +2578,16 @@ describe("update-cli", () => {
       .map(([argv]) => argv)
       .filter((argv) => argv[0] === "npm" && argv[1] === "i" && argv[2] === "-g");
     expect(installArgvs).toEqual([
-      ["npm", "i", "-g", "openclaw@latest", "--no-fund", "--no-audit", "--loglevel=error"],
+      [
+        "npm",
+        "i",
+        "-g",
+        "openclaw@latest",
+        "--no-fund",
+        "--no-audit",
+        "--loglevel=error",
+        "--min-release-age=0",
+      ],
       [
         "npm",
         "i",
@@ -2587,6 +2597,7 @@ describe("update-cli", () => {
         "--no-fund",
         "--no-audit",
         "--loglevel=error",
+        "--min-release-age=0",
       ],
     ]);
     expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);

--- a/src/infra/install-source-utils.test.ts
+++ b/src/infra/install-source-utils.test.ts
@@ -210,7 +210,13 @@ describe("packNpmSpecToArchive", () => {
         timeoutMs: 300_000,
         env: {
           COREPACK_ENABLE_DOWNLOAD_PROMPT: "0",
+          NPM_CONFIG_BEFORE: "",
           NPM_CONFIG_IGNORE_SCRIPTS: "true",
+          NPM_CONFIG_MIN_RELEASE_AGE: "",
+          "NPM_CONFIG_MIN-RELEASE-AGE": "",
+          npm_config_before: "",
+          "npm_config_min-release-age": "0",
+          npm_config_min_release_age: "",
         },
       },
     );

--- a/src/infra/install-source-utils.ts
+++ b/src/infra/install-source-utils.ts
@@ -5,6 +5,7 @@ import { runCommandWithTimeout } from "../process/exec.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveArchiveKind } from "./archive.js";
 import { pathExists } from "./fs-safe.js";
+import { applyNpmFreshnessBypassEnv } from "./npm-install-env.js";
 import { withTempWorkspace } from "./private-temp-workspace.js";
 
 export type NpmSpecResolution = {
@@ -34,6 +35,15 @@ export function buildNpmResolutionFields(resolution?: NpmSpecResolution): NpmRes
     shasum: resolution?.shasum,
     resolvedAt: resolution?.resolvedAt,
   };
+}
+
+export function createNpmMetadataEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {
+    COREPACK_ENABLE_DOWNLOAD_PROMPT: "0",
+    NPM_CONFIG_IGNORE_SCRIPTS: "true",
+  };
+  applyNpmFreshnessBypassEnv(env);
+  return env;
 }
 
 function normalizeNpmViewMetadata(value: unknown): NpmSpecResolution | null {
@@ -69,10 +79,7 @@ export async function resolveNpmSpecMetadata(params: { spec: string; timeoutMs?:
     ["npm", "view", params.spec, "name", "version", "dist.integrity", "dist.shasum", "--json"],
     {
       timeoutMs: Math.max(params.timeoutMs ?? 60_000, 60_000),
-      env: {
-        COREPACK_ENABLE_DOWNLOAD_PROMPT: "0",
-        NPM_CONFIG_IGNORE_SCRIPTS: "true",
-      },
+      env: createNpmMetadataEnv(),
     },
   );
   if (res.code !== 0) {
@@ -279,10 +286,7 @@ export async function packNpmSpecToArchive(params: {
     {
       timeoutMs: Math.max(params.timeoutMs, 300_000),
       cwd: params.cwd,
-      env: {
-        COREPACK_ENABLE_DOWNLOAD_PROMPT: "0",
-        NPM_CONFIG_IGNORE_SCRIPTS: "true",
-      },
+      env: createNpmMetadataEnv(),
     },
   );
   if (res.code !== 0) {
@@ -346,10 +350,7 @@ export async function resolveNpmPackArchiveMetadata(params: {
     ["npm", "pack", archivePath, "--ignore-scripts", "--dry-run", "--json"],
     {
       timeoutMs: Math.max(params.timeoutMs ?? 60_000, 60_000),
-      env: {
-        COREPACK_ENABLE_DOWNLOAD_PROMPT: "0",
-        NPM_CONFIG_IGNORE_SCRIPTS: "true",
-      },
+      env: createNpmMetadataEnv(),
     },
   );
   if (res.code !== 0) {

--- a/src/infra/npm-install-env.test.ts
+++ b/src/infra/npm-install-env.test.ts
@@ -1,6 +1,17 @@
 import fsSync from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { createNpmProjectInstallEnv } from "./npm-install-env.js";
+
+const EXPECTED_MIN_FRESHNESS_ENV = {
+  NPM_CONFIG_BEFORE: "",
+  NPM_CONFIG_MIN_RELEASE_AGE: "",
+  "NPM_CONFIG_MIN-RELEASE-AGE": "",
+  npm_config_before: "",
+  "npm_config_min-release-age": "0",
+  npm_config_min_release_age: "",
+};
 
 describe("npm project install env", () => {
   it("uses an absolute POSIX script shell for npm lifecycle scripts", () => {
@@ -14,6 +25,7 @@ describe("npm project install env", () => {
           PATH: "/tmp/openclaw-npm-global/bin",
         }),
       ).toEqual({
+        ...EXPECTED_MIN_FRESHNESS_ENV,
         NPM_CONFIG_SCRIPT_SHELL: "/bin/sh",
         PATH: "/tmp/openclaw-npm-global/bin",
         npm_config_dry_run: "false",
@@ -40,6 +52,7 @@ describe("npm project install env", () => {
           NPM_CONFIG_SCRIPT_SHELL: "/custom/sh",
         }),
       ).toEqual({
+        ...EXPECTED_MIN_FRESHNESS_ENV,
         NPM_CONFIG_SCRIPT_SHELL: "/custom/sh",
         npm_config_dry_run: "false",
         npm_config_fetch_retries: "5",
@@ -56,6 +69,7 @@ describe("npm project install env", () => {
           npm_config_script_shell: "/custom/lower-sh",
         }),
       ).toEqual({
+        ...EXPECTED_MIN_FRESHNESS_ENV,
         npm_config_dry_run: "false",
         npm_config_fetch_retries: "5",
         npm_config_fetch_retry_maxtimeout: "120000",
@@ -69,6 +83,57 @@ describe("npm project install env", () => {
       });
     } finally {
       platformSpy.mockRestore();
+    }
+  });
+
+  it("bypasses npm release-age filters for OpenClaw-managed installs", () => {
+    const env = createNpmProjectInstallEnv({
+      NPM_CONFIG_BEFORE: "2026-01-01T00:00:00.000Z",
+      NPM_CONFIG_MIN_RELEASE_AGE: "7",
+      "npm_config_min-release-age": "7",
+      npm_config_before: "2026-01-01T00:00:00.000Z",
+      npm_config_min_release_age: "7",
+    });
+
+    expect(env.NPM_CONFIG_BEFORE).toBe("");
+    expect(env.npm_config_before).toBe("");
+    expect(env.NPM_CONFIG_MIN_RELEASE_AGE).toBe("");
+    expect(env["npm_config_min-release-age"]).toBe("0");
+    expect(env.npm_config_min_release_age).toBe("");
+  });
+
+  it("does not leak parent npm freshness env into explicit child envs", () => {
+    const previousBefore = process.env.NPM_CONFIG_BEFORE;
+    process.env.NPM_CONFIG_BEFORE = "2026-01-01T00:00:00.000Z";
+    try {
+      const env = createNpmProjectInstallEnv({});
+
+      expect(env.NPM_CONFIG_BEFORE).toBe("");
+      expect(env.npm_config_before).toBe("");
+      expect(env["npm_config_min-release-age"]).toBe("0");
+    } finally {
+      if (previousBefore == null) {
+        delete process.env.NPM_CONFIG_BEFORE;
+      } else {
+        process.env.NPM_CONFIG_BEFORE = previousBefore;
+      }
+    }
+  });
+
+  it("uses a current before override for explicit npm before policy", () => {
+    const dir = fsSync.mkdtempSync(path.join(os.tmpdir(), "openclaw-npmrc-"));
+    try {
+      const npmrc = path.join(dir, "npmrc");
+      fsSync.writeFileSync(npmrc, "before=2026-01-01T00:00:00.000Z\n", "utf-8");
+      const env = createNpmProjectInstallEnv({
+        NPM_CONFIG_USERCONFIG: npmrc,
+      });
+
+      expect(env["npm_config_min-release-age"]).toBe("");
+      expect(env.npm_config_before).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      expect(env.npm_config_before).not.toBe("2026-01-01T00:00:00.000Z");
+    } finally {
+      fsSync.rmSync(dir, { recursive: true, force: true });
     }
   });
 });

--- a/src/infra/npm-install-env.ts
+++ b/src/infra/npm-install-env.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import fsSync from "node:fs";
 import path from "node:path";
 
@@ -8,6 +9,7 @@ export type NpmProjectInstallEnvOptions = {
 const NPM_CONFIG_SCRIPT_SHELL_KEYS = ["NPM_CONFIG_SCRIPT_SHELL", "npm_config_script_shell"];
 
 const NPM_CONFIG_KEYS_TO_RESET = new Set([
+  "npm_config_before",
   "npm_config_cache",
   "npm_config_dry_run",
   "npm_config_global",
@@ -19,7 +21,77 @@ const NPM_CONFIG_KEYS_TO_RESET = new Set([
   "npm_config_strict_peer_deps",
   "npm_config_workspace",
   "npm_config_workspaces",
+  "npm_config_min_release_age",
+  "npm_config_min-release-age",
 ]);
+
+const NPM_FRESHNESS_BYPASS_KEYS = [
+  "NPM_CONFIG_BEFORE",
+  "npm_config_before",
+  "NPM_CONFIG_MIN_RELEASE_AGE",
+  "npm_config_min_release_age",
+  "NPM_CONFIG_MIN-RELEASE-AGE",
+  "npm_config_min-release-age",
+] as const;
+
+const NPM_CONFIG_PROBE_PARENT_ENV_KEYS = ["PATH", "Path", "PATHEXT", "SystemRoot", "ComSpec"];
+
+function createNpmConfigProbeEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const probeEnv = { ...env };
+  for (const key of NPM_CONFIG_PROBE_PARENT_ENV_KEYS) {
+    if (probeEnv[key] == null && process.env[key] != null) {
+      probeEnv[key] = process.env[key];
+    }
+  }
+  return probeEnv;
+}
+
+function readNpmConfigValue(key: string, env: NodeJS.ProcessEnv): string | null {
+  try {
+    return execFileSync("npm", ["config", "get", key], {
+      encoding: "utf-8",
+      env: createNpmConfigProbeEnv(env),
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 2_000,
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function isNullNpmConfigValue(value: string | null): boolean {
+  return !value || value === "null" || value === "undefined";
+}
+
+function hasExplicitNpmBeforeConfig(env: NodeJS.ProcessEnv): boolean {
+  const minReleaseAge = readNpmConfigValue("min-release-age", env);
+  if (!isNullNpmConfigValue(minReleaseAge)) {
+    return false;
+  }
+  return !isNullNpmConfigValue(readNpmConfigValue("before", env));
+}
+
+export function createNpmFreshnessBypassArgs(
+  env: NodeJS.ProcessEnv = process.env,
+  now = new Date(),
+): string[] {
+  if (hasExplicitNpmBeforeConfig(env)) {
+    return [`--before=${now.toISOString()}`];
+  }
+  return ["--min-release-age=0"];
+}
+
+export function applyNpmFreshnessBypassEnv(env: NodeJS.ProcessEnv): void {
+  for (const key of NPM_FRESHNESS_BYPASS_KEYS) {
+    env[key] = "";
+  }
+  const [arg] = createNpmFreshnessBypassArgs(env);
+  if (arg?.startsWith("--before=")) {
+    env.npm_config_before = arg.slice("--before=".length);
+    return;
+  }
+  env["npm_config_min-release-age"] = "0";
+}
 
 export function createNpmProjectInstallEnv(
   env: NodeJS.ProcessEnv,
@@ -44,6 +116,7 @@ export function createNpmProjectInstallEnv(
     npm_config_save: "false",
     ...(options.cacheDir ? { npm_config_cache: options.cacheDir } : {}),
   };
+  applyNpmFreshnessBypassEnv(installEnv);
   applyPosixNpmScriptShellEnv(installEnv);
   return installEnv;
 }

--- a/src/infra/safe-package-install.test.ts
+++ b/src/infra/safe-package-install.test.ts
@@ -51,9 +51,11 @@ describe("safe npm install helpers", () => {
     );
 
     expect(env.PATH).toBe("/usr/bin:/bin");
+    expect(env.NPM_CONFIG_BEFORE).toBe("");
     expect(env.COREPACK_ENABLE_DOWNLOAD_PROMPT).toBe("0");
     expect(env.NPM_CONFIG_IGNORE_SCRIPTS).toBe("true");
     expect(env.npm_config_audit).toBe("false");
+    expect(env.npm_config_before).toBe("");
     expect(env.npm_config_cache).toBe("/tmp/openclaw-npm-cache");
     expect(env.npm_config_dry_run).toBe("false");
     expect(env.npm_config_fetch_retries).toBe("5");
@@ -74,6 +76,8 @@ describe("safe npm install helpers", () => {
     expect(env.npm_config_yes).toBe("true");
     expect(env.npm_config_include_workspace_root).toBeUndefined();
     expect(env.npm_config_workspace).toBeUndefined();
+    expect(env["npm_config_min-release-age"]).toBe("0");
+    expect(env.npm_config_min_release_age).toBe("");
   });
 
   it("does not inherit host legacy peer dependency mode by default", () => {

--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -141,6 +141,9 @@ describe("update global helpers", () => {
   it("defaults corepack download prompts off for global install env", async () => {
     const defaultEnv = await createGlobalInstallEnv({});
     expect(defaultEnv?.COREPACK_ENABLE_DOWNLOAD_PROMPT).toBe("0");
+    expect(defaultEnv?.NPM_CONFIG_BEFORE).toBe("");
+    expect(defaultEnv?.npm_config_before).toBe("");
+    expect(defaultEnv?.["npm_config_min-release-age"]).toBe("0");
 
     const explicitEnv = await createGlobalInstallEnv({
       COREPACK_ENABLE_DOWNLOAD_PROMPT: "1",
@@ -327,6 +330,7 @@ describe("update global helpers", () => {
           "--no-fund",
           "--no-audit",
           "--loglevel=error",
+          "--min-release-age=0",
         ]);
         expect(globalInstallFallbackArgs("npm", "openclaw@latest", pkgRoot)).toEqual([
           brewNpm,
@@ -337,6 +341,7 @@ describe("update global helpers", () => {
           "--no-fund",
           "--no-audit",
           "--loglevel=error",
+          "--min-release-age=0",
         ]);
       });
     } finally {
@@ -364,6 +369,7 @@ describe("update global helpers", () => {
         "--no-fund",
         "--no-audit",
         "--loglevel=error",
+        "--min-release-age=0",
       ]);
     });
   });
@@ -398,6 +404,7 @@ describe("update global helpers", () => {
           "--no-fund",
           "--no-audit",
           "--loglevel=error",
+          "--min-release-age=0",
         ]);
       });
     } finally {
@@ -563,6 +570,7 @@ describe("update global helpers", () => {
       "--no-fund",
       "--no-audit",
       "--loglevel=error",
+      "--min-release-age=0",
     ]);
     expect(globalInstallArgs("pnpm", "openclaw@latest")).toEqual([
       "pnpm",
@@ -602,6 +610,7 @@ describe("update global helpers", () => {
       "--no-fund",
       "--no-audit",
       "--loglevel=error",
+      "--min-release-age=0",
     ]);
     expect(globalInstallFallbackArgs("pnpm", "openclaw@latest")).toBeNull();
     expect(
@@ -644,6 +653,7 @@ describe("update global helpers", () => {
       "--no-fund",
       "--no-audit",
       "--loglevel=error",
+      "--min-release-age=0",
     ]);
     expect(globalInstallFallbackArgs("npm", "openclaw@latest", null, "/tmp/stage")).toEqual([
       "npm",
@@ -656,6 +666,7 @@ describe("update global helpers", () => {
       "--no-fund",
       "--no-audit",
       "--loglevel=error",
+      "--min-release-age=0",
     ]);
   });
 

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -6,9 +6,9 @@ import { BUNDLED_RUNTIME_SIDECAR_PATHS } from "../plugins/runtime-sidecar-paths.
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { pathExists } from "../utils.js";
 import {
+  applyNpmFreshnessBypassEnv,
   applyPosixNpmScriptShellEnv,
-  hasNpmScriptShellSetting,
-  resolvePosixNpmScriptShell,
+  createNpmFreshnessBypassArgs,
 } from "./npm-install-env.js";
 import {
   collectPackageDistInventory,
@@ -42,10 +42,6 @@ const GLOBAL_RENAME_PREFIX = ".";
 export const OPENCLAW_MAIN_PACKAGE_SPEC = "github:openclaw/openclaw#main";
 const COREPACK_ENABLE_DOWNLOAD_PROMPT_DEFAULT = "0";
 const NPM_GLOBAL_INSTALL_QUIET_FLAGS = ["--no-fund", "--no-audit", "--loglevel=error"] as const;
-const NPM_GLOBAL_INSTALL_OMIT_OPTIONAL_FLAGS = [
-  "--omit=optional",
-  ...NPM_GLOBAL_INSTALL_QUIET_FLAGS,
-] as const;
 const PNPM_OPENCLAW_BUILD_ALLOWLIST_FLAG = `--allow-build=${PRIMARY_PACKAGE_NAME}`;
 const FIRST_PACKAGED_DIST_INVENTORY_VERSION = { major: 2026, minor: 4, patch: 15 };
 const OMITTED_PRIVATE_QA_BUNDLED_PLUGIN_ROOTS = new Set([
@@ -372,19 +368,6 @@ export async function createGlobalInstallEnv(
 ): Promise<NodeJS.ProcessEnv | undefined> {
   const pathPrepend = await resolvePortableGitPathPrepend();
   const sourceEnv = env ?? process.env;
-  const hasCorepackDownloadPromptSetting = Boolean(
-    sourceEnv.COREPACK_ENABLE_DOWNLOAD_PROMPT?.trim(),
-  );
-  const missingPosixScriptShell =
-    Boolean(resolvePosixNpmScriptShell(sourceEnv)) && !hasNpmScriptShellSetting(sourceEnv);
-  const requiresMergedEnv =
-    pathPrepend.length > 0 ||
-    process.platform === "win32" ||
-    !hasCorepackDownloadPromptSetting ||
-    missingPosixScriptShell;
-  if (!requiresMergedEnv) {
-    return env;
-  }
   const merged = Object.fromEntries(
     Object.entries(sourceEnv)
       .filter(([, value]) => value != null)
@@ -393,6 +376,7 @@ export async function createGlobalInstallEnv(
   applyPathPrepend(merged, pathPrepend);
   applyWindowsPackageInstallEnv(merged);
   applyCorepackDownloadPromptEnv(merged);
+  applyNpmFreshnessBypassEnv(merged);
   applyPosixNpmScriptShellEnv(merged);
   return merged;
 }
@@ -745,6 +729,7 @@ export function globalInstallArgs(
     ...(installPrefix ? ["--prefix", installPrefix] : []),
     spec,
     ...NPM_GLOBAL_INSTALL_QUIET_FLAGS,
+    ...createNpmFreshnessBypassArgs(),
   ];
 }
 
@@ -764,7 +749,9 @@ export function globalInstallFallbackArgs(
     "-g",
     ...(installPrefix ? ["--prefix", installPrefix] : []),
     spec,
-    ...NPM_GLOBAL_INSTALL_OMIT_OPTIONAL_FLAGS,
+    "--omit=optional",
+    ...NPM_GLOBAL_INSTALL_QUIET_FLAGS,
+    ...createNpmFreshnessBypassArgs(),
   ];
 }
 

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -280,15 +280,27 @@ describe("runGatewayUpdate", () => {
     return { nodeModules, pkgRoot };
   }
 
+  const npmGlobalInstallCommand = (spec: string, extraArgs: string[] = []) =>
+    [
+      "npm",
+      "i",
+      "-g",
+      spec,
+      ...extraArgs,
+      "--no-fund",
+      "--no-audit",
+      "--loglevel=error",
+      "--min-release-age=0",
+    ].join(" ");
+
   function createGlobalNpmUpdateRunner(params: {
     pkgRoot: string;
     nodeModules: string;
     onBaseInstall?: () => Promise<CommandResult>;
     onOmitOptionalInstall?: () => Promise<CommandResult>;
   }) {
-    const baseInstallKey = "npm i -g openclaw@latest --no-fund --no-audit --loglevel=error";
-    const omitOptionalInstallKey =
-      "npm i -g openclaw@latest --omit=optional --no-fund --no-audit --loglevel=error";
+    const baseInstallKey = npmGlobalInstallCommand("openclaw@latest");
+    const omitOptionalInstallKey = npmGlobalInstallCommand("openclaw@latest", ["--omit=optional"]);
 
     return async (argv: string[]): Promise<CommandResult> => {
       const key = argv.join(" ");
@@ -1668,16 +1680,16 @@ describe("runGatewayUpdate", () => {
   it.each([
     {
       title: "updates global npm installs when detected",
-      expectedInstallCommand: "npm i -g openclaw@latest --no-fund --no-audit --loglevel=error",
+      expectedInstallCommand: npmGlobalInstallCommand("openclaw@latest"),
     },
     {
       title: "uses update channel for global npm installs when tag is omitted",
-      expectedInstallCommand: "npm i -g openclaw@beta --no-fund --no-audit --loglevel=error",
+      expectedInstallCommand: npmGlobalInstallCommand("openclaw@beta"),
       channel: "beta" as const,
     },
     {
       title: "updates global npm installs with tag override",
-      expectedInstallCommand: "npm i -g openclaw@beta --no-fund --no-audit --loglevel=error",
+      expectedInstallCommand: npmGlobalInstallCommand("openclaw@beta"),
       tag: "beta",
     },
   ])("$title", async ({ expectedInstallCommand, channel, tag }) => {
@@ -1696,16 +1708,13 @@ describe("runGatewayUpdate", () => {
 
   it("updates global npm installs from the GitHub main package spec", async () => {
     const { calls, result } = await runNpmGlobalUpdateCase({
-      expectedInstallCommand:
-        "npm i -g github:openclaw/openclaw#main --no-fund --no-audit --loglevel=error",
+      expectedInstallCommand: npmGlobalInstallCommand("github:openclaw/openclaw#main"),
       tag: "main",
     });
 
     expect(result.status).toBe("ok");
     expect(result.mode).toBe("npm");
-    expect(calls).toContain(
-      "npm i -g github:openclaw/openclaw#main --no-fund --no-audit --loglevel=error",
-    );
+    expect(calls).toContain(npmGlobalInstallCommand("github:openclaw/openclaw#main"));
   });
 
   it("runs doctor after global npm updates before reporting success", async () => {
@@ -1717,7 +1726,7 @@ describe("runGatewayUpdate", () => {
     const { calls, runCommand } = createGlobalInstallHarness({
       pkgRoot,
       npmRootOutput: nodeModules,
-      installCommand: "npm i -g openclaw@latest --no-fund --no-audit --loglevel=error",
+      installCommand: npmGlobalInstallCommand("openclaw@latest"),
       onInstall: async () => {
         await writeGlobalPackageVersion(pkgRoot);
         await writeGatewayEntrypoint(pkgRoot);
@@ -1756,7 +1765,7 @@ describe("runGatewayUpdate", () => {
     const { calls, runCommand } = createGlobalInstallHarness({
       pkgRoot,
       npmRootOutput: nodeModules,
-      installCommand: "npm i -g openclaw@latest --no-fund --no-audit --loglevel=error",
+      installCommand: npmGlobalInstallCommand("openclaw@latest"),
       onInstall: async () => {
         await writeGlobalPackageVersion(pkgRoot);
         await writeGatewayEntrypoint(pkgRoot);
@@ -1793,7 +1802,7 @@ describe("runGatewayUpdate", () => {
     const { calls, runCommand } = createGlobalInstallHarness({
       pkgRoot,
       npmRootOutput: nodeModules,
-      installCommand: "npm i -g openclaw@latest --no-fund --no-audit --loglevel=error",
+      installCommand: npmGlobalInstallCommand("openclaw@latest"),
       gitRootMode: "missing",
       onInstall: async () => writeGlobalPackageVersion(pkgRoot),
     });
@@ -1802,7 +1811,7 @@ describe("runGatewayUpdate", () => {
 
     expect(result.status).toBe("ok");
     expect(result.mode).toBe("npm");
-    expect(calls).toContain("npm i -g openclaw@latest --no-fund --no-audit --loglevel=error");
+    expect(calls).toContain(npmGlobalInstallCommand("openclaw@latest"));
   });
 
   it("cleans stale npm rename dirs before global update", async () => {
@@ -1861,7 +1870,7 @@ describe("runGatewayUpdate", () => {
 
   it("fails global npm update when the installed version misses the requested correction", async () => {
     const { calls, result } = await runNpmGlobalUpdateCase({
-      expectedInstallCommand: "npm i -g openclaw@2026.3.23-2 --no-fund --no-audit --loglevel=error",
+      expectedInstallCommand: npmGlobalInstallCommand("openclaw@2026.3.23-2"),
       tag: "2026.3.23-2",
     });
 
@@ -1871,12 +1880,12 @@ describe("runGatewayUpdate", () => {
     expect(result.steps.at(-1)?.stderrTail).toContain(
       "expected installed version 2026.3.23-2, found 2.0.0",
     );
-    expect(calls).toContain("npm i -g openclaw@2026.3.23-2 --no-fund --no-audit --loglevel=error");
+    expect(calls).toContain(npmGlobalInstallCommand("openclaw@2026.3.23-2"));
   });
 
   it("fails global npm update when bundled runtime sidecars are missing after install", async () => {
     const { nodeModules, pkgRoot } = await createGlobalPackageFixture(tempDir);
-    const expectedInstallCommand = "npm i -g openclaw@latest --no-fund --no-audit --loglevel=error";
+    const expectedInstallCommand = npmGlobalInstallCommand("openclaw@latest");
     const { runCommand } = createGlobalInstallHarness({
       pkgRoot,
       npmRootOutput: nodeModules,
@@ -1932,7 +1941,7 @@ describe("runGatewayUpdate", () => {
     const { runCommand } = createGlobalInstallHarness({
       pkgRoot,
       npmRootOutput: nodeModules,
-      installCommand: "npm i -g openclaw@latest --no-fund --no-audit --loglevel=error",
+      installCommand: npmGlobalInstallCommand("openclaw@latest"),
       onInstall: async (options) => {
         installEnv = options?.env;
         await writeGlobalPackageVersion(options?.packageRoot ?? pkgRoot);
@@ -1967,7 +1976,7 @@ describe("runGatewayUpdate", () => {
     const { runCommand } = createGlobalInstallHarness({
       pkgRoot,
       npmRootOutput: nodeModules,
-      installCommand: "npm i -g openclaw@latest --no-fund --no-audit --loglevel=error",
+      installCommand: npmGlobalInstallCommand("openclaw@latest"),
       onInstall: async (options) => {
         await writeGlobalPackageVersion(options?.packageRoot ?? pkgRoot);
         if (options?.installPrefix) {
@@ -2005,7 +2014,7 @@ describe("runGatewayUpdate", () => {
     const { calls, runCommand } = createGlobalInstallHarness({
       pkgRoot,
       pnpmRootOutput: nodeModules,
-      installCommand: "npm i -g openclaw@latest --no-fund --no-audit --loglevel=error",
+      installCommand: npmGlobalInstallCommand("openclaw@latest"),
       onInstall: async (options) => {
         await writeGlobalPackageVersion(options?.packageRoot ?? pkgRoot);
       },
@@ -2028,8 +2037,9 @@ describe("runGatewayUpdate", () => {
 
   it("uses OPENCLAW_UPDATE_PACKAGE_SPEC for global package updates", async () => {
     const { nodeModules, pkgRoot } = await createGlobalPackageFixture(tempDir);
-    const expectedInstallCommand =
-      "npm i -g http://10.211.55.2:8138/openclaw-next.tgz --no-fund --no-audit --loglevel=error";
+    const expectedInstallCommand = npmGlobalInstallCommand(
+      "http://10.211.55.2:8138/openclaw-next.tgz",
+    );
     const { calls, runCommand } = createGlobalInstallHarness({
       pkgRoot,
       npmRootOutput: nodeModules,

--- a/src/plugins/install.ts
+++ b/src/plugins/install.ts
@@ -6,6 +6,7 @@ import { packageNameMatchesId } from "../infra/install-safe-path.js";
 import {
   resolveNpmPackArchiveMetadata,
   resolveNpmSpecMetadata,
+  createNpmMetadataEnv,
   type NpmIntegrityDrift,
   type NpmSpecResolution,
 } from "../infra/install-source-utils.js";
@@ -218,10 +219,7 @@ async function resolveTrustedOfficialPrereleaseResolution(params: {
     ["npm", "view", params.spec.name, "versions", "--json"],
     {
       timeoutMs: Math.max(params.timeoutMs, 60_000),
-      env: {
-        COREPACK_ENABLE_DOWNLOAD_PROMPT: "0",
-        NPM_CONFIG_IGNORE_SCRIPTS: "true",
-      },
+      env: createNpmMetadataEnv(),
     },
   );
   if (versions.code !== 0) {

--- a/test/scripts/install-cli.test.ts
+++ b/test/scripts/install-cli.test.ts
@@ -90,4 +90,10 @@ describe("install-cli.sh", () => {
     expect(script).toContain('"$corepack_cmd" prepare "pnpm@${version}" --activate');
     expect(script).toContain('activate_repo_pnpm_version "$repo_dir"');
   });
+
+  it("clears npm freshness filters for package installs", () => {
+    expect(script).toContain('freshness_flag="--min-release-age=0"');
+    expect(script).toContain('freshness_flag="--before=$(date -u');
+    expect(script).toContain("env -u NPM_CONFIG_BEFORE -u npm_config_before");
+  });
 });

--- a/test/scripts/install-ps1.test.ts
+++ b/test/scripts/install-ps1.test.ts
@@ -90,8 +90,15 @@ describe("install.ps1 failure handling", () => {
     expect(npmInstallBody).toContain('$env:NPM_CONFIG_FUND = "false"');
     expect(npmInstallBody).toContain('$env:NPM_CONFIG_AUDIT = "false"');
     expect(npmInstallBody).toContain('$env:NPM_CONFIG_SCRIPT_SHELL = "cmd.exe"');
+    expect(npmInstallBody).toContain('$freshnessArgs = @("--min-release-age=0")');
+    expect(npmInstallBody).toContain("Remove-Item Env:NPM_CONFIG_BEFORE");
+    expect(npmInstallBody).toContain("Remove-Item Env:NPM_CONFIG_MIN_RELEASE_AGE");
     expect(npmInstallBody).toContain('$env:NODE_LLAMA_CPP_SKIP_DOWNLOAD = "1"');
+    expect(npmInstallBody).toContain(
+      '$npmOutput = & (Get-NpmCommandPath) install -g @freshnessArgs "$installSpec"',
+    );
     expect(npmInstallBody).toContain("$env:NPM_CONFIG_LOGLEVEL = $prevLogLevel");
+    expect(npmInstallBody).toContain("$env:NPM_CONFIG_BEFORE = $prevBefore");
     expect(npmInstallBody).toContain(
       "$env:NODE_LLAMA_CPP_SKIP_DOWNLOAD = $prevNodeLlamaSkipDownload",
     );

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -34,6 +34,13 @@ describe("install.sh", () => {
     expect(rawAptInstalls).toStrictEqual([]);
   });
 
+  it("clears npm freshness filters for package installs", () => {
+    expect(script).toContain("env -u NPM_CONFIG_BEFORE -u npm_config_before");
+    expect(script).toContain('freshness_flag="--min-release-age=0"');
+    expect(script).toContain('freshness_flag="--before=$(date -u');
+    expect(script).toContain('cmd+=(--no-fund --no-audit "$freshness_flag" install -g "$spec")');
+  });
+
   it("exports noninteractive apt env during Linux startup", () => {
     expect(script).toMatch(
       /detect_os_or_die\s+if \[\[ "\$OS" == "linux" \]\]; then\s+export DEBIAN_FRONTEND="\$\{DEBIAN_FRONTEND:-noninteractive\}"\s+export NEEDRESTART_MODE="\$\{NEEDRESTART_MODE:-a\}"\s+fi/m,


### PR DESCRIPTION
Fixes #82630.

Summary:
- Bypass npm freshness quarantine for OpenClaw-managed npm operations: global update/install, plugin metadata resolution, npm pack flows, and safe managed plugin installs.
- Harden hosted installer sources (`install.sh`, `install-cli.sh`, `install.ps1`) so they blank inherited npm freshness env vars and pass a current `--before=...` when npm exposes a freshness cutoff; otherwise they pass `--min-release-age=0`.
- Document the behavior and add a changelog entry; `openclaw.ai` installers are covered by the existing website sync workflow that copies these canonical scripts into `openclaw.ai/public/` after merge.

Verification:
- `bash -n scripts/install.sh scripts/install-cli.sh`
- `pnpm test src/infra/npm-install-env.test.ts src/infra/safe-package-install.test.ts src/infra/update-global.test.ts src/infra/install-source-utils.test.ts test/scripts/install-cli.test.ts test/scripts/install-sh.test.ts test/scripts/install-ps1.test.ts -- --reporter=verbose`
- `pnpm test src/cli/update-cli.test.ts -- --reporter=verbose`
- `pnpm test src/infra/update-runner.test.ts -- --reporter=verbose`
- `node scripts/run-vitest.mjs src/infra/npm-install-env.test.ts src/infra/update-global.test.ts src/infra/install-source-utils.test.ts src/infra/safe-package-install.test.ts test/scripts/install-cli.test.ts test/scripts/install-sh.test.ts test/scripts/install-ps1.test.ts` (via codex-review)
- `git diff --check`
- `codex-review --mode local`

## Real behavior proof

Behavior addressed: `openclaw update`, OpenClaw-managed plugin npm metadata/pack/install paths, and hosted installer scripts no longer fail just because npm is configured with release-age quarantine.
Real environment tested: macOS local checkout with npm 11.12.1 and temporary npmrc files for `min-release-age=7` and explicit `before=...`.
Exact steps or command run after this patch: created temporary npmrc files and ran npm config probes with current `--before=...` and `--min-release-age=0`; ran focused Vitest/script syntax/review commands listed above.
Evidence after fix: file-backed `min-release-age=7` exposes a computed `before` cutoff and is bypassed with a current `--before=<now>`; explicit `before=2020-01-01T00:00:00.000Z` resolves to the current timestamp when overridden with `--before=<now>`; inherited npm freshness env vars are blanked so `runCommandWithTimeout` cannot merge them back from `process.env`; focused tests pass 49 infra tests, 30 tooling tests plus 4 skipped, 4 unit-fast tests, 98 CLI update tests, and 42 update-runner tests.
Observed result after fix: OpenClaw-owned npm child processes apply the correct npm override for the configured policy shape instead of inheriting quarantine.
What was not tested: PowerShell parse/runtime execution, because `pwsh` is not installed on this machine.
