### PR TITLE
Fix iMessage slash command acknowledgements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Docs: https://docs.openclaw.ai
 
+## Unreleased
+
+### Changes
+
+### Fixes
+- iMessage: mark authorized slash-command turns as text-sourced commands so `/status`, `/new`, and `/restart` acknowledgements return to the source conversation. (#82642) thanks @homer-byte.
+
+
 ## 2026.5.24
 
 ### Changes
@@ -337,7 +345,6 @@ Docs: https://docs.openclaw.ai
 - Agents/embedded runner: classify HTML auth provider responses as `auth_html` and return a re-authentication hint instead of the CDN-blocked copy that `upstream_html` returns. Cloudflare Access login pages, nginx basic-auth challenges, and gateway login walls all produce HTML auth bodies that were previously misdiagnosed as transient CDN blocks. (#79900) Thanks @martingarramon.
 - TUI/streaming watchdog: dismiss the `This response is taking longer than expected` notice as soon as a chat event for the same run arrives, so the message no longer sits next to the recovered response when the run was only briefly silent. Refs #67052, #69081 (closed), prior attempt #69026. Thanks @jpruit20 and @romneyda.
 - Agents/Pi: tolerate OpenClaw-owned transcript writes while embedded prompts are released for model I/O, keeping long-running Feishu, Slack, Telegram, and cron turns from failing with false session-takeover errors. Fixes #84059. (#84250) Thanks @tianxiaochannel-oss88.
-- iMessage: mark authorized slash-command turns as text-sourced commands so `/status`, `/new`, and `/restart` acknowledgements return to the source conversation. (#82642) thanks @homer-byte.
 
 ## 2026.5.20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -337,6 +337,7 @@ Docs: https://docs.openclaw.ai
 - Agents/embedded runner: classify HTML auth provider responses as `auth_html` and return a re-authentication hint instead of the CDN-blocked copy that `upstream_html` returns. Cloudflare Access login pages, nginx basic-auth challenges, and gateway login walls all produce HTML auth bodies that were previously misdiagnosed as transient CDN blocks. (#79900) Thanks @martingarramon.
 - TUI/streaming watchdog: dismiss the `This response is taking longer than expected` notice as soon as a chat event for the same run arrives, so the message no longer sits next to the recovered response when the run was only briefly silent. Refs #67052, #69081 (closed), prior attempt #69026. Thanks @jpruit20 and @romneyda.
 - Agents/Pi: tolerate OpenClaw-owned transcript writes while embedded prompts are released for model I/O, keeping long-running Feishu, Slack, Telegram, and cron turns from failing with false session-takeover errors. Fixes #84059. (#84250) Thanks @tianxiaochannel-oss88.
+- iMessage: mark authorized slash-command turns as text-sourced commands so `/status`, `/new`, and `/restart` acknowledgements return to the source conversation. (#82642) thanks @homer-byte.
 
 ## 2026.5.20
 

--- a/extensions/imessage/src/monitor/inbound-processing.systemPrompt.test.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.systemPrompt.test.ts
@@ -213,6 +213,7 @@ describe("buildIMessageInboundContext forwards GroupSystemPrompt", () => {
         replyContext: null,
         effectiveWasMentioned: false,
         commandAuthorized: false,
+        hasControlCommand: false,
         effectiveDmAllowFrom: [],
         effectiveGroupAllowFrom: [],
         groupSystemPrompt: decision.groupSystemPrompt,

--- a/extensions/imessage/src/monitor/inbound-processing.test.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.test.ts
@@ -803,6 +803,7 @@ describe("resolveIMessageInboundDecision command auth", () => {
     storeAllowFrom: string[];
     dmPolicy?: "open" | "pairing" | "allowlist" | "disabled";
     allowFrom?: string[];
+    text?: string;
   }) =>
     resolveIMessageInboundDecision({
       cfg,
@@ -810,13 +811,13 @@ describe("resolveIMessageInboundDecision command auth", () => {
       message: {
         id: params.messageId,
         sender: "+15555550123",
-        text: "/status",
+        text: params.text ?? "/status",
         is_from_me: false,
         is_group: false,
       },
       opts: undefined,
-      messageText: "/status",
-      bodyText: "/status",
+      messageText: params.text ?? "/status",
+      bodyText: params.text ?? "/status",
       allowFrom: params.allowFrom ?? [],
       groupAllowFrom: [],
       groupPolicy: "open",
@@ -849,6 +850,44 @@ describe("resolveIMessageInboundDecision command auth", () => {
       return;
     }
     expect(decision.commandAuthorized).toBe(true);
+  });
+
+  it("marks authorized iMessage control commands as text command turns", async () => {
+    const decision = await resolveDmCommandDecision({
+      messageId: 102,
+      dmPolicy: "pairing",
+      storeAllowFrom: ["+15555550123"],
+      text: "/new",
+    });
+
+    expect(decision.kind).toBe("dispatch");
+    if (decision.kind !== "dispatch") {
+      return;
+    }
+
+    const { ctxPayload } = buildIMessageInboundContext({
+      cfg,
+      decision,
+      message: {
+        id: 102,
+        guid: "p:0/GUID-command",
+        sender: "+15555550123",
+        text: "/new",
+        is_from_me: false,
+        is_group: false,
+      },
+      historyLimit: 0,
+      groupHistories: new Map(),
+    });
+
+    expect(ctxPayload.CommandAuthorized).toBe(true);
+    expect(ctxPayload.CommandSource).toBe("text");
+    expect(ctxPayload.CommandTurn).toMatchObject({
+      kind: "text-slash",
+      source: "text",
+      authorized: true,
+      commandName: "new",
+    });
   });
 });
 

--- a/extensions/imessage/src/monitor/inbound-processing.test.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.test.ts
@@ -850,6 +850,7 @@ describe("resolveIMessageInboundDecision command auth", () => {
       return;
     }
     expect(decision.commandAuthorized).toBe(true);
+    expect(decision.hasControlCommand).toBe(true);
   });
 
   it("marks authorized iMessage control commands as text command turns", async () => {
@@ -887,6 +888,45 @@ describe("resolveIMessageInboundDecision command auth", () => {
       source: "text",
       authorized: true,
       commandName: "new",
+    });
+  });
+
+  it("does not mark authorized non-command iMessage DMs as text command turns", async () => {
+    const decision = await resolveDmCommandDecision({
+      messageId: 103,
+      dmPolicy: "pairing",
+      storeAllowFrom: ["+15555550123"],
+      text: "hello there",
+    });
+
+    expect(decision.kind).toBe("dispatch");
+    if (decision.kind !== "dispatch") {
+      return;
+    }
+    expect(decision.commandAuthorized).toBe(true);
+    expect(decision.hasControlCommand).toBe(false);
+
+    const { ctxPayload } = buildIMessageInboundContext({
+      cfg,
+      decision,
+      message: {
+        id: 103,
+        guid: "p:0/GUID-non-command",
+        sender: "+15555550123",
+        text: "hello there",
+        is_from_me: false,
+        is_group: false,
+      },
+      historyLimit: 0,
+      groupHistories: new Map(),
+    });
+
+    expect(ctxPayload.CommandAuthorized).toBe(true);
+    expect(ctxPayload.CommandSource).toBeUndefined();
+    expect(ctxPayload.CommandTurn).toMatchObject({
+      kind: "normal",
+      source: "message",
+      commandName: undefined,
     });
   });
 });
@@ -931,6 +971,7 @@ describe("buildIMessageInboundContext MessageSid handling (rowid-leak regression
       replyContext: undefined,
       isCommand: false,
       commandAuthorized: false,
+      hasControlCommand: false,
     };
     return {
       cfg: {} as OpenClawConfig,

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -1031,6 +1031,7 @@ export function buildIMessageInboundContext(params: {
     MediaRemoteHost: params.remoteHost,
     WasMentioned: decision.effectiveWasMentioned,
     CommandAuthorized: decision.commandAuthorized,
+    CommandSource: decision.commandAuthorized ? ("text" as const) : undefined,
     OriginatingChannel: "imessage" as const,
     OriginatingTo: imessageTo,
   });

--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -395,6 +395,7 @@ type IMessageInboundDispatchDecision = {
   replyContext: IMessageReplyContext | null;
   effectiveWasMentioned: boolean;
   commandAuthorized: boolean;
+  hasControlCommand: boolean;
   // Forwarded as ctxPayload.GroupSystemPrompt for group messages. Resolved
   // from `channels.imessage.groups.<chat_id>.systemPrompt` (or the `"*"`
   // wildcard) at gate time. Always undefined for DMs.
@@ -884,6 +885,7 @@ export async function resolveIMessageInboundDecision(params: {
     replyContext: filteredReplyContext,
     effectiveWasMentioned,
     commandAuthorized,
+    hasControlCommand: hasControlCommandInMessage,
     groupSystemPrompt,
   };
 }
@@ -1031,7 +1033,8 @@ export function buildIMessageInboundContext(params: {
     MediaRemoteHost: params.remoteHost,
     WasMentioned: decision.effectiveWasMentioned,
     CommandAuthorized: decision.commandAuthorized,
-    CommandSource: decision.commandAuthorized ? ("text" as const) : undefined,
+    CommandSource:
+      decision.commandAuthorized && decision.hasControlCommand ? ("text" as const) : undefined,
     OriginatingChannel: "imessage" as const,
     OriginatingTo: imessageTo,
   });


### PR DESCRIPTION
## Summary

Fix iMessage slash command acknowledgement delivery by marking authorized iMessage text commands with `CommandSource="text"` only when the inbound message is actually a control command.

## Root cause

The `/new` reset handler still returns its acknowledgement, but iMessage inbound turns only set `CommandAuthorized=true`. They did not set the matching text command source signal used by reply delivery policy. That left authorized slash commands eligible for direct-chat source reply suppression, so the reset completed while the acknowledgement was dropped.

The first version of this PR set `CommandSource` from `commandAuthorized` alone. That was too broad because authorization can be true for ordinary allowed iMessage messages. The updated patch carries the real control-command detection result into the dispatch decision and sets `CommandSource="text"` only when the sender is authorized and the inbound body is an actual text slash command.

## Real behavior proof

Behavior addressed: Authorized iMessage text slash commands such as `/status`, `/new`, and `/restart` identify themselves as explicit text-sourced slash command turns, allowing command acknowledgements to follow the explicit command reply path.

Real environment tested: Packaged OpenClaw 2026.5.18 Gateway using direct iMessage DM commands from an authorized owner sender, with live iMessage ingestion and outbound native reply delivery confirmed healthy.

Exact steps or command run after the patch: In a local dist patch matching this PR's final behavior, send direct iMessage DM commands `/status`, `/new`, and `/restart` after gating source marking on messages that are both authorized and actual control commands.

Evidence after fix: @flo246874 provided copied live packaged-Gateway output in https://github.com/openclaw/openclaw/pull/82642#issuecomment-4490164392. The relevant observed output was:

```text
After patch:
- /status replied immediately.
- /new acknowledged successfully.
- /restart restarted the Gateway and returned healthy with iMessage OK.
```

Observed result after fix: Direct authorized iMessage slash commands delivered native acknowledgements/replies again, while the implementation now avoids marking ordinary authorized non-command iMessage messages as text-sourced command turns.

What was not tested: The PR author did not run a second live packaged-Gateway test from this checkout after the final commit. Local validation on the PR head remains the focused iMessage inbound-processing regression suite, formatter check, and whitespace check; the real packaged-Gateway proof is from @flo246874's live setup above.

## Validation

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-imessage.config.ts extensions/imessage/src/monitor/inbound-processing.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/imessage/src/monitor/inbound-processing.ts extensions/imessage/src/monitor/inbound-processing.test.ts`
- `git diff --check`