### PR TITLE
[AI-assisted] fix(media): resolve externalized LCM image refs

### DIFF
--- a/src/agents/pi-embedded-runner/run/images.test.ts
+++ b/src/agents/pi-embedded-runner/run/images.test.ts
@@ -314,6 +314,43 @@ what is this?`);
     expectNoImageReferences("See file://attacker/share/evil.png");
   });
 
+  it("detects LCM externalized image refs without treating them as workspace paths", () => {
+    const prompt = `
+      [file_ref:file_0123456789abcdef]
+      [externalized file_fedcba9876543210]
+      [LCM File: file_aaaaaaaaaaaaaaaa | photo.webp | image/webp | 123 bytes]
+      /tmp/file_0123456789abcdef.png
+    `;
+
+    expect(detectImageReferences(prompt)).toStrictEqual([
+      {
+        raw: "file_0123456789abcdef",
+        type: "lcm-file-ref",
+        resolved: "file_0123456789abcdef",
+      },
+      {
+        raw: "file_fedcba9876543210",
+        type: "lcm-file-ref",
+        resolved: "file_fedcba9876543210",
+      },
+      {
+        raw: "file_aaaaaaaaaaaaaaaa",
+        type: "lcm-file-ref",
+        resolved: "file_aaaaaaaaaaaaaaaa",
+      },
+      {
+        raw: "/tmp/file_0123456789abcdef.png",
+        type: "path",
+        resolved: "/tmp/file_0123456789abcdef.png",
+      },
+    ]);
+  });
+
+  it("ignores short or path-shaped LCM-like refs", () => {
+    expectNoImageReferences("[file_ref:file_abc]");
+    expectNoImageReferences("/tmp/file_0123456789abcdef");
+  });
+
   it("ignores Windows network paths from attachment-style references", () => {
     const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("win32");
 
@@ -517,6 +554,39 @@ describe("detectAndLoadPromptImages", () => {
       });
 
       expect(result.detectedRefs).toHaveLength(1);
+      expect(result.loadedCount).toBe(1);
+      expect(result.skippedCount).toBe(0);
+      expect(result.images).toHaveLength(1);
+    } finally {
+      vi.unstubAllEnvs();
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("loads managed LCM image refs when workspaceOnly is enabled", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-native-image-lcm-"));
+    const workspaceDir = path.join(stateDir, "workspace-agent");
+    const lcmDir = path.join(stateDir, "lcm-files", "conversation-a");
+    const fileRef = "file_0123456789abcdef";
+    const imagePath = path.join(lcmDir, `${fileRef}.webp`);
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.mkdir(lcmDir, { recursive: true });
+    const pngB64 =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
+    await fs.writeFile(imagePath, Buffer.from(pngB64, "base64"));
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+
+    try {
+      const result = await detectAndLoadPromptImages({
+        prompt: `Inspect [file_ref:${fileRef}]`,
+        workspaceDir,
+        model: { input: ["text", "image"] },
+        workspaceOnly: true,
+      });
+
+      expect(result.detectedRefs).toStrictEqual([
+        { raw: fileRef, type: "lcm-file-ref", resolved: fileRef },
+      ]);
       expect(result.loadedCount).toBe(1);
       expect(result.skippedCount).toBe(0);
       expect(result.images).toHaveLength(1);

--- a/src/agents/pi-embedded-runner/run/images.ts
+++ b/src/agents/pi-embedded-runner/run/images.ts
@@ -2,6 +2,10 @@ import path from "node:path";
 import type { ImageContent } from "@earendil-works/pi-ai";
 import { formatErrorMessage } from "../../../infra/errors.js";
 import { assertNoWindowsNetworkPath, safeFileURLToPath } from "../../../infra/local-file-access.js";
+import {
+  LCM_FILE_REF_SCAN_PATTERN,
+  resolveLcmImageFileReference,
+} from "../../../media/lcm-file-reference.js";
 import type { PromptImageOrderEntry } from "../../../media/prompt-image-order.js";
 import { loadWebMedia } from "../../../media/web-media.js";
 import { normalizeLowercaseStringOrEmpty } from "../../../shared/string-coerce.js";
@@ -84,7 +88,7 @@ export interface DetectedImageRef {
   /** The raw matched string from the prompt */
   raw: string;
   /** The type of reference */
-  type: "path" | "media-uri";
+  type: "path" | "media-uri" | "lcm-file-ref";
   /** The resolved/normalized path, or the raw media URI for media-uri type */
   resolved: string;
 }
@@ -231,6 +235,7 @@ async function sanitizeImagesWithLog(
  * - file:// URLs: file:///path/to/image.png
  * - Message attachments: [Image: source: /path/to/image.jpg]
  * - Gateway claim-check URIs: [media attached: media://inbound/<id>]
+ * - LCM externalized image references: [file_ref:file_<16hex>]
  *
  * @param prompt The user prompt text to scan
  * @returns Array of detected image references
@@ -270,6 +275,7 @@ export function detectImageReferences(prompt: string): DetectedImageRef[] {
   FILE_URL_PATTERN.lastIndex = 0;
   WINDOWS_DRIVE_PATH_PATTERN.lastIndex = 0;
   PATH_PATTERN.lastIndex = 0;
+  LCM_FILE_REF_SCAN_PATTERN.lastIndex = 0;
   let match: RegExpExecArray | null;
   while ((match = MEDIA_ATTACHED_PATTERN.exec(prompt)) !== null) {
     const content = match[1];
@@ -312,6 +318,22 @@ export function detectImageReferences(prompt: string): DetectedImageRef[] {
   }
 
   // Remote HTTP(S) URLs are intentionally ignored. Native image injection is local-only.
+
+  // LCM/lossless can externalize images into ~/.openclaw/lcm-files and leave only
+  // an opaque file_<16hex> reference in the rewritten prompt. Keep these refs out
+  // of normal workspace-relative path resolution.
+  while ((match = LCM_FILE_REF_SCAN_PATTERN.exec(prompt)) !== null) {
+    const raw = match[1]?.trim().toLowerCase();
+    if (!raw) {
+      continue;
+    }
+    const dedupeKey = normalizeRefForDedupe(raw);
+    if (seen.has(dedupeKey)) {
+      continue;
+    }
+    seen.add(dedupeKey);
+    refs.push({ raw, type: "lcm-file-ref", resolved: raw });
+  }
 
   // Pattern for file:// URLs - treat as paths since loadWebMedia handles them
   while ((match = FILE_URL_PATTERN.exec(prompt)) !== null) {
@@ -372,9 +394,20 @@ export async function loadImageFromRef(
 ): Promise<ImageContent | null> {
   try {
     let targetPath = ref.resolved;
+    let lcmRoot: string | undefined;
+
+    if (ref.type === "lcm-file-ref") {
+      const resolved = await resolveLcmImageFileReference(ref.resolved);
+      if (!resolved) {
+        log.debug(`Native image: managed LCM image not found: ${ref.resolved}`);
+        return null;
+      }
+      targetPath = resolved.path;
+      lcmRoot = resolved.root;
+    }
 
     // Resolve paths relative to sandbox or workspace as needed
-    if (options?.sandbox) {
+    if (options?.sandbox && ref.type !== "lcm-file-ref") {
       try {
         const resolved = await resolveSandboxedBridgeMediaPath({
           sandbox: {
@@ -396,7 +429,7 @@ export async function loadImageFromRef(
     }
 
     // loadWebMedia handles local file paths (including file:// URLs)
-    const media = options?.sandbox
+    const media = options?.sandbox && ref.type !== "lcm-file-ref"
       ? await loadWebMedia(targetPath, {
           maxBytes: options.maxBytes,
           sandboxValidated: true,
@@ -404,9 +437,11 @@ export async function loadImageFromRef(
         })
       : await loadWebMedia(
           targetPath,
-          options?.workspaceOnly
-            ? { maxBytes: options.maxBytes, localRoots: [workspaceDir] }
-            : options?.maxBytes,
+          lcmRoot
+            ? { maxBytes: options?.maxBytes, localRoots: [lcmRoot] }
+            : options?.workspaceOnly
+              ? { maxBytes: options.maxBytes, localRoots: [workspaceDir] }
+              : options?.maxBytes,
         );
 
     if (media.kind !== "image") {

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -1781,6 +1781,23 @@ describe("image tool managed inbound media", () => {
     }
   }
 
+  async function withManagedLcmPng(
+    run: (params: { stateDir: string; fileRef: string; mediaPath: string }) => Promise<void>,
+  ) {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-image-managed-lcm-"));
+    const lcmDir = path.join(stateDir, "lcm-files", "conversation-a");
+    const fileRef = "file_0123456789abcdef";
+    const mediaPath = path.join(lcmDir, `${fileRef}.webp`);
+    await fs.mkdir(lcmDir, { recursive: true });
+    await fs.writeFile(mediaPath, Buffer.from(ONE_PIXEL_PNG_B64, "base64"));
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    try {
+      await run({ stateDir, fileRef, mediaPath });
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  }
+
   it("resolves media://inbound refs", async () => {
     await withManagedInboundPng(async ({ mediaId }) => {
       installImageUnderstandingProviderStubs();
@@ -1810,6 +1827,24 @@ describe("image tool managed inbound media", () => {
         });
 
         await expectImageToolExecOk(tool, mediaPath);
+        expect(fetch).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  it("resolves managed LCM file refs before workspace-relative path fallback", async () => {
+    await withManagedLcmPng(async ({ fileRef }) => {
+      installImageUnderstandingProviderStubs();
+      const fetch = stubMinimaxOkFetch();
+      await withTempAgentDir(async (agentDir) => {
+        const tool = createRequiredImageTool({
+          config: createMinimaxImageConfig(),
+          agentDir,
+          workspaceDir: path.join(os.tmpdir(), "empty-workspace"),
+          fsPolicy: { workspaceOnly: true },
+        });
+
+        await expectImageToolExecOk(tool, `[file_ref:${fileRef}]`);
         expect(fetch).toHaveBeenCalledTimes(1);
       });
     });

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -16,6 +16,10 @@ import {
   classifyMediaReferenceSource,
   normalizeMediaReferenceSource,
 } from "../../media/media-reference.js";
+import {
+  extractLcmImageFileReference,
+  resolveLcmImageFileReference,
+} from "../../media/lcm-file-reference.js";
 import { loadWebMedia } from "../../media/web-media.js";
 import {
   describeImageWithModel,
@@ -531,6 +535,29 @@ export function createImageTool(options?: {
         }
 
         const normalizedRef = normalizeMediaReferenceSource(imageRaw);
+
+        const lcmFileRef = extractLcmImageFileReference(normalizedRef);
+        if (lcmFileRef) {
+          const resolved = await resolveLcmImageFileReference(normalizedRef);
+          if (!resolved) {
+            throw new Error(`Managed LCM image file not found: ${lcmFileRef}`);
+          }
+          const media = await loadWebMedia(resolved.path, {
+            maxBytes,
+            localRoots: [resolved.root],
+            ssrfPolicy: remoteMediaSsrfPolicy,
+          });
+          if (media.kind !== "image") {
+            throw new Error(`Unsupported media type: ${media.kind}`);
+          }
+          loadedImages.push({
+            buffer: media.buffer,
+            mimeType: media.contentType ?? "image/png",
+            resolvedImage: resolved.path,
+            rewrittenFrom: normalizedRef,
+          });
+          continue;
+        }
 
         // The tool accepts file paths, file/data URLs, or http(s) URLs. In some
         // agent/model contexts, images can be referenced as pseudo-URIs like

--- a/src/media/lcm-file-reference.test.ts
+++ b/src/media/lcm-file-reference.test.ts
@@ -1,0 +1,79 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  extractLcmImageFileReference,
+  resolveLcmFilesRoot,
+  resolveLcmImageFileReference,
+} from "./lcm-file-reference.js";
+
+describe("LCM file references", () => {
+  it("extracts only strict file_<16hex> image refs", () => {
+    expect(extractLcmImageFileReference("[file_ref:file_0123456789abcdef]")).toBe(
+      "file_0123456789abcdef",
+    );
+    expect(extractLcmImageFileReference("[externalized file_fedcba9876543210]")).toBe(
+      "file_fedcba9876543210",
+    );
+    expect(extractLcmImageFileReference("file_abc")).toBeNull();
+    expect(extractLcmImageFileReference("/tmp/file_0123456789abcdef.webp")).toBeNull();
+  });
+
+  it("resolves one-level LCM image files under the managed state root", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lcm-ref-"));
+    const lcmRoot = resolveLcmFilesRoot(stateDir);
+    const conversationDir = path.join(lcmRoot, "conversation-a");
+    const fileRef = "file_0123456789abcdef";
+    const imagePath = path.join(conversationDir, `${fileRef}.webp`);
+    await fs.mkdir(conversationDir, { recursive: true });
+    await fs.writeFile(imagePath, Buffer.from("image"));
+
+    try {
+      await expect(resolveLcmImageFileReference(`[file_ref:${fileRef}]`, { stateDir })).resolves
+        .toStrictEqual({
+          fileRef,
+          path: await fs.realpath(imagePath),
+          root: await fs.realpath(lcmRoot),
+        });
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not resolve non-image extensions or missing roots", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lcm-ref-miss-"));
+    const lcmRoot = resolveLcmFilesRoot(stateDir);
+    const conversationDir = path.join(lcmRoot, "conversation-a");
+    const fileRef = "file_0123456789abcdef";
+    await fs.mkdir(conversationDir, { recursive: true });
+    await fs.writeFile(path.join(conversationDir, `${fileRef}.txt`), "not an image");
+
+    try {
+      await expect(resolveLcmImageFileReference(fileRef, { stateDir })).resolves.toBeNull();
+      await expect(
+        resolveLcmImageFileReference(fileRef, {
+          stateDir: path.join(stateDir, "missing"),
+        }),
+      ).resolves.toBeNull();
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not guess when an LCM image file reference is ambiguous", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lcm-ref-ambiguous-"));
+    const lcmRoot = resolveLcmFilesRoot(stateDir);
+    const fileRef = "file_0123456789abcdef";
+    await fs.mkdir(path.join(lcmRoot, "conversation-a"), { recursive: true });
+    await fs.mkdir(path.join(lcmRoot, "conversation-b"), { recursive: true });
+    await fs.writeFile(path.join(lcmRoot, "conversation-a", `${fileRef}.webp`), Buffer.from("a"));
+    await fs.writeFile(path.join(lcmRoot, "conversation-b", `${fileRef}.webp`), Buffer.from("b"));
+
+    try {
+      await expect(resolveLcmImageFileReference(fileRef, { stateDir })).resolves.toBeNull();
+    } finally {
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/media/lcm-file-reference.ts
+++ b/src/media/lcm-file-reference.ts
@@ -1,0 +1,81 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
+import { isPathInside } from "../infra/path-guards.js";
+
+const LCM_FILE_REF_TOKEN_SOURCE =
+  "(?:^|[^A-Za-z0-9_./\\\\-])(?:file_ref:|externalized\\s+)?(file_[a-f0-9]{16})(?![A-Za-z0-9_.-])";
+const LCM_IMAGE_EXTENSIONS = [".webp", ".png", ".jpg", ".jpeg", ".gif", ".svg"] as const;
+
+const lcmFileRefExtractPattern = new RegExp(LCM_FILE_REF_TOKEN_SOURCE, "i");
+
+export const LCM_FILE_REF_SCAN_PATTERN = new RegExp(LCM_FILE_REF_TOKEN_SOURCE, "gi");
+
+export type LcmImageFileReference = {
+  fileRef: string;
+  path: string;
+  root: string;
+};
+
+export function extractLcmImageFileReference(input: string): string | null {
+  const match = input.match(lcmFileRefExtractPattern);
+  return match?.[1]?.toLowerCase() ?? null;
+}
+
+export function resolveLcmFilesRoot(stateDir = resolveStateDir()): string {
+  return path.join(stateDir, "lcm-files");
+}
+
+export async function resolveLcmImageFileReference(
+  input: string,
+  options?: { stateDir?: string },
+): Promise<LcmImageFileReference | null> {
+  const fileRef = extractLcmImageFileReference(input);
+  if (!fileRef) {
+    return null;
+  }
+
+  const root = resolveLcmFilesRoot(options?.stateDir);
+  let rootRealPath: string;
+  try {
+    rootRealPath = await fs.realpath(root);
+  } catch {
+    return null;
+  }
+
+  let entries: Array<{ name: string; isDirectory: () => boolean }>;
+  try {
+    entries = await fs.readdir(rootRealPath, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+
+  let resolved: LcmImageFileReference | null = null;
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const conversationDir = path.join(rootRealPath, entry.name);
+    for (const ext of LCM_IMAGE_EXTENSIONS) {
+      const candidate = path.join(conversationDir, `${fileRef}${ext}`);
+      try {
+        const stat = await fs.lstat(candidate);
+        if (!stat.isFile()) {
+          continue;
+        }
+        const candidateRealPath = await fs.realpath(candidate);
+        if (!isPathInside(rootRealPath, candidateRealPath)) {
+          continue;
+        }
+        if (resolved) {
+          return null;
+        }
+        resolved = { fileRef, path: candidateRealPath, root: rootRealPath };
+      } catch {
+        // Try the next allowed image extension/conversation directory.
+      }
+    }
+  }
+
+  return resolved;
+}


### PR DESCRIPTION
## Summary

- Problem: Lossless/LCM can externalize an image into `lcm-files/<conversation>/file_<16hex>.<image-ext>`, leaving only the opaque `file_<16hex>` reference in the prompt or image-tool input.
- Why it matters: OpenClaw currently treats that remaining ref as a workspace-relative file, so real uploaded images can reach storage but still fail with `Local media file not found` before the model sees them.
- What changed: The prompt image loader and agent `image` tool now resolve strict LCM image refs from the managed `lcm-files` root before workspace fallback.
- Scope boundary: This does not add arbitrary LCM file reads, text/document reads, network calls, config changes, or plugin API changes.

## Change Type

- [x] Bug fix

## Scope

- [x] Skills / tool execution
- [x] Memory / storage

## Linked Issue/PR

- Related: none found. This fixes a real-world LCM image-ref failure found from a JSOS/Rokid OpenClaw setup; duplicate search found adjacent `media://inbound` work but no exact `file_<16hex>` LCM image-ref PR.
- [x] This PR fixes a bug or regression

## Real behavior proof

- Behavior or issue addressed: LCM image refs are resolved as managed images instead of falling through to workspace path lookup.
- Real environment tested: local OpenClaw checkout using the normal prompt image loader, temporary `OPENCLAW_STATE_DIR`, and a managed `lcm-files` image. No API key or live model call.
- Exact steps or command run after this patch:

```text
node --import tsx --input-type=module -e "<temporary proof script>"
```

- Evidence after fix:

```json
{
  "detectedRefs": [
    {
      "type": "lcm-file-ref",
      "resolved": "file_0123456789abcdef"
    }
  ],
  "loadedCount": 1,
  "skippedCount": 0,
  "imagesCount": 1,
  "firstMime": "image/png"
}
```

- Observed result after fix: the normal prompt image loader detected the LCM ref and loaded one image while `workspaceOnly` was enabled.
- What was not tested: no live model/API request, no live gateway/channel run, no full repo test suite.
- Before evidence: production symptom was `Local media file not found` after a `file_<16hex>` image ref was treated as a workspace file.

## Root Cause

- Root cause: prompt/tool inputs could contain an LCM `file_<16hex>` image ref after Lossless externalization, but OpenClaw only knew how to resolve file paths, `file://`, and `media://inbound` image refs.
- Missing detection / guardrail: no strict parser existed for managed LCM image refs, so they fell through to workspace-relative local path handling.
- Contributing context: the image payload was already under OpenClaw state in `lcm-files`, but the remaining ref no longer carried a normal image extension or `media://` URI.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
- Target test or file:
  - `src/media/lcm-file-reference.test.ts`
  - `src/agents/pi-embedded-runner/run/images.test.ts`
  - `src/agents/tools/image-tool.test.ts`
- Scenario the test should lock in: strict `file_<16hex>` LCM image refs resolve only from managed `lcm-files` image files and do not fall through to workspace-relative path lookup.
- Why this is the smallest reliable guardrail: it covers the resolver, prompt image injection path, and image tool path without a live provider call.
- Existing test that already covers this: none.

## User-visible / Behavior Changes

OpenClaw can now load images referenced by strict LCM `file_<16hex>` refs when the backing image exists in the managed `lcm-files` store.

## Diagram

```text
Before:
LCM file_<16hex> ref -> workspace path fallback -> Local media file not found

After:
LCM file_<16hex> ref -> lcm-files image resolver -> prompt/image tool receives image
```

## Security Impact

- New permissions/capabilities? No.
- Secrets/tokens handling changed? No.
- New/changed network calls? No.
- Command/tool execution surface changed? No.
- Data access scope changed? Yes.
- Risk + mitigation: the loader can now read matching image files from the managed `lcm-files` root. It only accepts strict `file_<16hex>` refs, only checks one directory level below the root, only permits image extensions, rejects symlinks/non-files, verifies realpath containment, and rejects ambiguous duplicate refs.

## Repro + Verification

### Environment

- OS: Windows local checkout
- Runtime/container: Node with pnpm-installed OpenClaw workspace dependencies
- Model/provider: no live provider call
- Integration/channel: LCM/Lossless-style image ref shape
- Relevant config: temporary `OPENCLAW_STATE_DIR`

### Steps

1. Create a temporary `lcm-files/42/file_0123456789abcdef.webp` image under `OPENCLAW_STATE_DIR`.
2. Run the normal prompt image loader with prompt text containing `[LCM File: file_0123456789abcdef | rokid.webp | image/webp | 68 bytes]`.
3. Keep `workspaceOnly` enabled so normal workspace fallback would not be enough.

### Expected

- The image ref is detected as `lcm-file-ref`.
- One image is loaded.
- No workspace-relative lookup is needed.

### Actual

- `loadedCount=1`, `skippedCount=0`, `imagesCount=1`.

## Evidence

- Copied after-fix terminal output from the local proof above.
- Focused test output below.

Focused local checks:

```text
node scripts/test-projects.mjs src/media/lcm-file-reference.test.ts src/agents/pi-embedded-runner/run/images.test.ts src/agents/tools/image-tool.test.ts
```

Result:

```text
3 files via 2 Vitest shards
103 tests passed
```

Additional checks:

```text
node scripts/check-changed.mjs
git diff --check
```

Both passed.

## Human Verification

- Verified scenarios: strict LCM ref extraction, prompt image loading under `workspaceOnly`, image tool LCM ref loading before workspace fallback.
- Edge cases checked: short refs rejected, path-shaped refs rejected, non-image extensions rejected, missing roots rejected, ambiguous duplicate refs rejected.
- What I did not verify: live model/API call, live gateway/channel run, full repo test suite.

## Review Conversations

N/A. No review conversations yet.

## Compatibility / Migration

- Backward compatible? Yes.
- Config/env changes? No.
- Migration needed? No.
- Exact upgrade steps: None.

## Risks and Mitigations

- Risk: Core gains a narrow Lossless/LCM-aware image resolver.
  - Mitigation: the resolver is limited to strict opaque image refs under the managed `lcm-files` root and does not broaden plugin/config/API behavior.
- Risk: future Lossless file-ref formats may not match this parser.
  - Mitigation: unmatched refs keep existing behavior; this PR only fixes the current strict `file_<16hex>` shape.
