### PR TITLE
fix(auth): avoid keychain creation for oauth profile secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Docs: https://docs.openclaw.ai
 - Slack: guide agents to use stable `<@USER_ID>` mention tokens from context instead of plain `@name` text, so user mentions link and notify correctly. Fixes #82090. (#82152) Thanks @neeravmakwana.
 - Auth: serialize provider login writes through the auth-profile lock for OpenAI Codex, Anthropic, Cloudflare AI Gateway, GitHub Copilot, and z.ai, preserving upsert semantics so a live Gateway cannot overwrite freshly refreshed OAuth credentials with an expired in-memory snapshot.
 - Slack: keep DM thread replies on the main direct-message session instead of routing them to invisible thread-scoped sessions. Refs #82390. (#82418) Thanks @kagura-agent.
+- Auth/macOS: avoid creating the OAuth profile master key in Keychain automatically, falling back to the file-backed secret key so headless agents do not trigger a Keychain prompt.
 - Codex app-server: release raw assistant completions when `turn/completed` is missing while keeping commentary/status items as progress, preventing completed Codex runs from hanging until timeout. Fixes #82343. (#82403) Thanks @IWhatsskill.
 - Agents/sessions: remove the transient `*.bak-<pid>-<ts>` backup written by `repairSessionFileIfNeeded` once the atomic replace succeeds, so a stuck session with a persistently malformed JSONL line no longer accumulates one snapshot per repair invocation. Fixes #80960. (#80969) Thanks @100yenadmin. Co-authored by @tynamite.
 - CLI/status: show plain empty-state messages instead of empty Channels and Sessions tables when no channels or sessions exist.

--- a/src/agents/auth-profiles/persisted-boundary.test.ts
+++ b/src/agents/auth-profiles/persisted-boundary.test.ts
@@ -1,8 +1,89 @@
 import { describe, expect, it } from "vitest";
 import { AUTH_STORE_VERSION } from "./constants.js";
-import { coercePersistedAuthProfileStore } from "./persisted.js";
+import { __testing, coercePersistedAuthProfileStore } from "./persisted.js";
 
 describe("persisted auth profile boundary", () => {
+  it("reads an existing macOS oauth profile master key before file fallback", () => {
+    const calls: string[] = [];
+
+    const seed = __testing.resolveOAuthProfileSecretKeySeedWithDeps(
+      { create: true },
+      {
+        env: {},
+        platform: "darwin",
+        readMacKeychain: () => {
+          calls.push("readMacKeychain");
+          return "existing-keychain-key";
+        },
+        readFile: () => {
+          calls.push("readFile");
+          return "file-key";
+        },
+        createFile: () => {
+          calls.push("createFile");
+          return "created-file-key";
+        },
+      },
+    );
+
+    expect(seed).toBe("existing-keychain-key");
+    expect(calls).toEqual(["readMacKeychain"]);
+  });
+
+  it("creates the fallback oauth profile key file when macOS Keychain has no entry", () => {
+    const calls: string[] = [];
+
+    const seed = __testing.resolveOAuthProfileSecretKeySeedWithDeps(
+      { create: true },
+      {
+        env: {},
+        platform: "darwin",
+        readMacKeychain: () => {
+          calls.push("readMacKeychain");
+          return undefined;
+        },
+        readFile: () => {
+          calls.push("readFile");
+          return undefined;
+        },
+        createFile: () => {
+          calls.push("createFile");
+          return "created-file-key";
+        },
+      },
+    );
+
+    expect(seed).toBe("created-file-key");
+    expect(calls).toEqual(["readMacKeychain", "readFile", "createFile"]);
+  });
+
+  it("skips macOS Keychain reads under Vitest and on non-macOS platforms", () => {
+    expect(
+      __testing.shouldReadMacKeychainForOAuthProfileSecrets({
+        env: {},
+        platform: "darwin",
+      }),
+    ).toBe(true);
+    expect(
+      __testing.shouldReadMacKeychainForOAuthProfileSecrets({
+        env: { VITEST: "true" },
+        platform: "darwin",
+      }),
+    ).toBe(false);
+    expect(
+      __testing.shouldReadMacKeychainForOAuthProfileSecrets({
+        env: { VITEST_WORKER_ID: "1" },
+        platform: "darwin",
+      }),
+    ).toBe(false);
+    expect(
+      __testing.shouldReadMacKeychainForOAuthProfileSecrets({
+        env: {},
+        platform: "linux",
+      }),
+    ).toBe(false);
+  });
+
   it("normalizes malformed persisted credentials and state before runtime use", () => {
     const store = coercePersistedAuthProfileStore({
       version: "not-a-version",

--- a/src/agents/auth-profiles/persisted.ts
+++ b/src/agents/auth-profiles/persisted.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import * as childProcess from "node:child_process";
 import { createCipheriv, createDecipheriv, createHash, randomBytes } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
@@ -71,6 +71,16 @@ type OAuthProfileSecretPayload = OAuthProfileSecretMaterial & {
 type LoadPersistedAuthProfileStoreOptions = {
   rewriteInlineOAuthSecrets?: boolean;
   repairOAuthSecretPayloads?: boolean;
+};
+
+type OAuthProfileSecretKeySeedOptions = { create?: boolean };
+
+type OAuthProfileSecretKeySeedDeps = {
+  env: NodeJS.ProcessEnv;
+  platform: NodeJS.Platform;
+  readMacKeychain: () => string | undefined;
+  readFile: () => string | undefined;
+  createFile: () => string | undefined;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -304,7 +314,7 @@ function readMacOAuthProfileSecretKey(): string | undefined {
     return undefined;
   }
   try {
-    return execFileSync(
+    return childProcess.execFileSync(
       "security",
       [
         "find-generic-password",
@@ -317,33 +327,6 @@ function readMacOAuthProfileSecretKey(): string | undefined {
       { encoding: "utf8", timeout: 5000, stdio: ["pipe", "pipe", "pipe"] },
     ).trim();
   } catch {
-    return undefined;
-  }
-}
-
-function createMacOAuthProfileSecretKey(): string | undefined {
-  if (process.platform !== "darwin") {
-    return undefined;
-  }
-  const generated = randomBytes(32).toString("base64url");
-  try {
-    execFileSync(
-      "security",
-      [
-        "add-generic-password",
-        "-U",
-        "-s",
-        OAUTH_PROFILE_SECRET_KEYCHAIN_SERVICE,
-        "-a",
-        OAUTH_PROFILE_SECRET_KEYCHAIN_ACCOUNT,
-        "-w",
-        generated,
-      ],
-      { encoding: "utf8", timeout: 5000, stdio: ["pipe", "pipe", "pipe"] },
-    );
-    return generated;
-  } catch (err) {
-    log.warn("failed to create oauth profile secret keychain entry", { err });
     return undefined;
   }
 }
@@ -459,37 +442,51 @@ function createFallbackOAuthProfileSecretKeyFile(): string | undefined {
   }
 }
 
-function shouldUseMacKeychainForOAuthProfileSecrets(): boolean {
+function shouldReadMacKeychainForOAuthProfileSecrets(params?: {
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+}): boolean {
+  const env = params?.env ?? process.env;
+  const platform = params?.platform ?? process.platform;
   return (
-    process.platform === "darwin" &&
-    process.env.VITEST !== "true" &&
-    process.env.VITEST_WORKER_ID === undefined
+    platform === "darwin" && env.VITEST !== "true" && env.VITEST_WORKER_ID === undefined
   );
 }
 
-function resolveOAuthProfileSecretKeySeed(options?: { create?: boolean }): string | undefined {
-  const externalKey = process.env[OAUTH_PROFILE_SECRET_KEY_ENV]?.trim();
+function resolveOAuthProfileSecretKeySeedWithDeps(
+  options: OAuthProfileSecretKeySeedOptions | undefined,
+  deps: OAuthProfileSecretKeySeedDeps,
+): string | undefined {
+  const externalKey = deps.env[OAUTH_PROFILE_SECRET_KEY_ENV]?.trim();
   if (externalKey) {
     return externalKey;
   }
-  if (process.env.NODE_ENV === "test" && process.env.VITEST === "true") {
+  if (deps.env.NODE_ENV === "test" && deps.env.VITEST === "true") {
     return "openclaw-test-oauth-profile-secret-key";
   }
-  if (shouldUseMacKeychainForOAuthProfileSecrets()) {
-    const keychainKey =
-      readMacOAuthProfileSecretKey() ??
-      (options?.create === true ? createMacOAuthProfileSecretKey() : undefined);
+  if (shouldReadMacKeychainForOAuthProfileSecrets({ env: deps.env, platform: deps.platform })) {
+    const keychainKey = deps.readMacKeychain();
     if (keychainKey) {
       return keychainKey;
     }
   }
-  const fileKey =
-    readFallbackOAuthProfileSecretKeyFile() ??
-    (options?.create === true ? createFallbackOAuthProfileSecretKeyFile() : undefined);
+  const fileKey = deps.readFile() ?? (options?.create === true ? deps.createFile() : undefined);
   if (fileKey) {
     return fileKey;
   }
   return undefined;
+}
+
+function resolveOAuthProfileSecretKeySeed(
+  options?: OAuthProfileSecretKeySeedOptions,
+): string | undefined {
+  return resolveOAuthProfileSecretKeySeedWithDeps(options, {
+    env: process.env,
+    platform: process.platform,
+    readMacKeychain: readMacOAuthProfileSecretKey,
+    readFile: readFallbackOAuthProfileSecretKeyFile,
+    createFile: createFallbackOAuthProfileSecretKeyFile,
+  });
 }
 
 function buildOAuthProfileSecretKey(options?: { create?: boolean }): Buffer | null {
@@ -499,6 +496,11 @@ function buildOAuthProfileSecretKey(options?: { create?: boolean }): Buffer | nu
   }
   return createHash("sha256").update(`openclaw:auth-profile-oauth:${externalKey}`).digest();
 }
+
+export const __testing = {
+  resolveOAuthProfileSecretKeySeedWithDeps,
+  shouldReadMacKeychainForOAuthProfileSecrets,
+};
 
 function encryptOAuthProfileSecretMaterial(params: {
   ref: OAuthCredentialRef;


### PR DESCRIPTION
## Summary

- Stop creating the OAuth profile master key in macOS Keychain automatically.
- Preserve reads for existing `oauth-profile-master-key` Keychain entries, then fall back to the file-backed secret key path when no entry exists.
- Add pure persisted-boundary coverage for the macOS key-source decision order and the Vitest/non-macOS no-Keychain path.

## Root Cause / Provenance

- Regression source: PR #79006, `Redact persisted secret-shaped payloads [AI]`, merged into `main` on 2026-05-11 at 07:22:33Z from `fix/fix-579`.
- Author/merger: @pgondhi987. The PR had no public closing issue references; the body listed `Related: private report`.
- Blame: merge commit `17ceca86d698c104df48149ba85f8dfab3ea622c` introduced `OAUTH_PROFILE_SECRET_KEYCHAIN_SERVICE`, `OAUTH_PROFILE_SECRET_KEYCHAIN_ACCOUNT = "oauth-profile-master-key"`, and `createMacOAuthProfileSecretKey()`.
- Broken behavior: on macOS, persisting/rewrite-repairing an inline OpenAI Codex OAuth profile could call `security add-generic-password ... -a oauth-profile-master-key ...`, which asks the OS to store a new Keychain item. In headless/missing-login-keychain contexts, macOS can surface a native "Keychain Not Found" modal instead of just failing back to the file key.
- Why it was not universal: Linux VPS installs never take the macOS Keychain branch; macOS users with a normal unlocked login keychain likely saw silent creation; users with an existing `oauth-profile-master-key` entry only read it. The bad path is specifically macOS + no existing master key + no usable default Keychain + an OAuth profile secret write/repair.
- Related but separate: `81d1424ad94f9bb4cecaf44ab0515cf541563c05` is update/doctor plugin-convergence remediation for invalid plugin/channel config during package updates. It does not touch this Keychain path.

## Verification

- `node scripts/run-vitest.mjs src/agents/auth-profiles/persisted-boundary.test.ts src/agents/auth-profiles/profiles.test.ts` — 3 files, 36 tests passed
- `node scripts/run-vitest.mjs src/agents/auth-profiles/persisted-boundary.test.ts` — 1 file, 4 tests passed after rebase
- `git diff --check HEAD~1..HEAD`
- Testbox-through-Crabbox `pnpm check:changed`: provider=blacksmith-testbox, id=tbx_01krrsnk3dfa524dhve1f0zvk1, Actions run 25966955456, exit=0

## Real behavior proof

Behavior addressed: macOS/headless agents should not trigger a Keychain write prompt for `oauth-profile-master-key` while persisting OpenAI Codex OAuth profile secrets.
Real environment tested: local macOS source checkout plus Blacksmith Testbox Linux changed gate through Crabbox.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/auth-profiles/persisted-boundary.test.ts src/agents/auth-profiles/profiles.test.ts`; `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --blacksmith-org openclaw --blacksmith-workflow .github/workflows/ci-check-testbox.yml --blacksmith-job check --blacksmith-ref main --idle-timeout 90m --ttl 240m --timing-json -- CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_TEST_PROJECTS_PARALLEL=6 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm check:changed`.
Evidence after fix: `createMacOAuthProfileSecretKey` and its `security add-generic-password` call are removed; tests assert missing macOS Keychain entries fall back to file creation and Vitest/non-macOS paths skip Keychain reads.
Observed result after fix: focused tests and changed gate passed; no code path remains that creates the macOS Keychain master key automatically.
What was not tested: live reproduction of the native macOS Keychain modal, because intentionally invoking the old `security add-generic-password` path can trigger the host modal this patch removes.
