### PR TITLE
fix(logging): reject zero/negative/non-finite limits in getRecentDiagnosticPhases (#82646)

### DIFF
--- a/src/logging/diagnostic-phase.test.ts
+++ b/src/logging/diagnostic-phase.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  endDiagnosticPhase,
+  getRecentDiagnosticPhases,
+  startDiagnosticPhase,
+} from "./diagnostic-phase.js";
+
+function flushPhases(): void {
+  // Drain any in-flight phases left by other tests; getRecentDiagnosticPhases
+  // pulls from a module-level buffer that we cannot directly reset.
+  for (let i = 0; i < 256; i += 1) {
+    endDiagnosticPhase();
+  }
+}
+
+function seedPhases(count: number): void {
+  for (let i = 0; i < count; i += 1) {
+    startDiagnosticPhase(`phase-${i}`);
+    endDiagnosticPhase();
+  }
+}
+
+describe("getRecentDiagnosticPhases limit guard (#82646)", () => {
+  afterEach(() => {
+    flushPhases();
+  });
+
+  it("returns an empty array for an explicit zero limit", () => {
+    seedPhases(3);
+    expect(getRecentDiagnosticPhases(0)).toEqual([]);
+  });
+
+  it("returns an empty array for a negative limit", () => {
+    seedPhases(3);
+    expect(getRecentDiagnosticPhases(-2)).toEqual([]);
+  });
+
+  it("returns an empty array for a non-finite limit", () => {
+    seedPhases(3);
+    expect(getRecentDiagnosticPhases(Number.NaN)).toEqual([]);
+    expect(getRecentDiagnosticPhases(Number.POSITIVE_INFINITY)).toEqual([]);
+  });
+
+  it("returns the requested suffix when the limit is positive", () => {
+    seedPhases(3);
+    const last = getRecentDiagnosticPhases(2);
+    expect(last).toHaveLength(2);
+  });
+});

--- a/src/logging/diagnostic-phase.ts
+++ b/src/logging/diagnostic-phase.ts
@@ -39,7 +39,14 @@ export function getCurrentDiagnosticPhase(): string | undefined {
 }
 
 export function getRecentDiagnosticPhases(limit = 8): DiagnosticPhaseSnapshot[] {
-  return recentPhases.slice(-Math.max(0, limit)).map((phase) => Object.assign({}, phase));
+  // `slice(-0)` is identical to `slice(0)`, which returns the entire buffer
+  // — the exact opposite of what a zero limit should mean. Reject zero,
+  // negative, and non-finite limits explicitly. See #82646.
+  if (!Number.isFinite(limit) || limit <= 0) {
+    return [];
+  }
+  const clamped = Math.floor(limit);
+  return recentPhases.slice(-clamped).map((phase) => Object.assign({}, phase));
 }
 
 export function recordDiagnosticPhase(snapshot: DiagnosticPhaseSnapshot): void {


### PR DESCRIPTION
## Real behavior proof

- **Behavior or issue addressed:** `getRecentDiagnosticPhases(0)` returns the entire recent-phase buffer instead of an empty list. `slice(-0)` is treated the same as `slice(0)` in JS, so a zero `limit` accidentally surfaces every phase. Fixes #82646.
- **Root cause:** `src/logging/diagnostic-phase.ts:42` uses `recentPhases.slice(-Math.max(0, limit))`. The `Math.max(0, limit)` guard prevents negative slices but doesn't catch the `-0` collapse for `limit === 0`, and it doesn't reject non-finite limits (`NaN`, `Infinity`).
- **Fix surface:** Single function in `diagnostic-phase.ts` — reject `!Number.isFinite(limit) || limit <= 0` early with `[]`, then `Math.floor` positive values before slicing. The default-arg path (`limit = 8`) and existing positive callers (e.g. `src/logging/diagnostic.ts:360` passes `6`) are unchanged.
- **Existing-helper check (vincentkoc #57341):** Reuses `Number.isFinite` and `Math.floor` directly. No new helper introduced. The existing module-level `recentPhases` buffer and `DiagnosticPhaseSnapshot` shape are unchanged.
- **Shared-helper caller check (steipete #60623):** `getRecentDiagnosticPhases` has one production caller in `src/logging/diagnostic.ts:360` (passes `6` — unchanged) plus the new test. All positive integer callers keep behaviour. Zero / negative / non-finite callers now match the documented intent (an empty result).
- **Broader-fix rival scan (steipete #68270):** No rival PR open. The reporter (`jbetala7`) filed five small numeric-guard bugs in a single sweep (#82646, #82644, #82650, #82651, #82653); this PR addresses the first one in isolation so each fix can land independently.
- **Live verification:** Added `src/logging/diagnostic-phase.test.ts` with four regression cases:
  - `limit = 0` → `[]`
  - `limit = -2` → `[]`
  - `limit = NaN` / `Infinity` → `[]`
  - `limit = 2` after seeding three phases → array of length 2
- **Backward compatibility:** The default-arg path keeps `8`. Existing call sites pass positive integers. The semantic change only affects the three invalid input classes the reporter explicitly flagged.