### PR TITLE
test(matrix): add state-after E2EE QA coverage

### DIFF
--- a/extensions/qa-matrix/src/runners/contract/scenario-catalog.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-catalog.ts
@@ -74,6 +74,7 @@ type MatrixQaScenarioId =
   | "matrix-inbound-edit-ignored"
   | "matrix-inbound-edit-no-duplicate-trigger"
   | "matrix-e2ee-basic-reply"
+  | "matrix-e2ee-state-after-missing-encryption"
   | "matrix-e2ee-thread-follow-up"
   | "matrix-e2ee-bootstrap-success"
   | "matrix-e2ee-recovery-key-lifecycle"
@@ -834,6 +835,16 @@ export const MATRIX_QA_SCENARIOS: MatrixQaScenarioDefinition[] = [
     topology: buildMatrixQaE2eeScenarioTopology({
       scenarioId: "matrix-e2ee-basic-reply",
       name: "Matrix QA E2EE Basic Reply Room",
+    }),
+    configOverrides: MATRIX_QA_E2EE_CONFIG,
+  },
+  {
+    id: "matrix-e2ee-state-after-missing-encryption",
+    timeoutMs: MATRIX_QA_E2EE_REPLY_TIMEOUT_MS,
+    title: "Matrix E2EE sync state_after opt-in stays disabled for encrypted rooms",
+    topology: buildMatrixQaE2eeScenarioTopology({
+      scenarioId: "matrix-e2ee-state-after-missing-encryption",
+      name: "Matrix QA E2EE State After Missing Encryption Room",
     }),
     configOverrides: MATRIX_QA_E2EE_CONFIG,
   },

--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime-e2ee.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime-e2ee.ts
@@ -59,6 +59,10 @@ const MATRIX_QA_ROOM_KEY_BACKUP_VERSION_ENDPOINT = "/_matrix/client/v3/room_keys
 const MATRIX_QA_ROOM_KEY_BACKUP_FAULT_RULE_ID = "room-key-backup-version-unavailable";
 const MATRIX_QA_OWNER_SIGNATURE_UPLOAD_BLOCKED_RULE_ID = "owner-signature-upload-blocked";
 const MATRIX_QA_KEYS_SIGNATURES_UPLOAD_ENDPOINT = "/_matrix/client/v3/keys/signatures/upload";
+const MATRIX_QA_SYNC_ENDPOINT = "/_matrix/client/v3/sync";
+const MATRIX_QA_SYNC_STATE_AFTER_FAULT_RULE_ID = "sync-state-after-missing-encryption";
+const MATRIX_QA_SYNC_STATE_AFTER_KEY = "org.matrix.msc4222.state_after";
+const MATRIX_QA_SYNC_STATE_AFTER_PARAM = "org.matrix.msc4222.use_state_after";
 
 type MatrixQaE2eeBootstrapResult = Awaited<ReturnType<typeof runMatrixQaE2eeBootstrap>>;
 type MatrixQaCliVerificationStatus = {
@@ -951,6 +955,58 @@ function buildOwnerSignatureUploadBlockedFaultRule(accessToken: string): MatrixQ
   };
 }
 
+function removeMatrixQaSyncStateAfterEncryptionEvents(payload: unknown) {
+  if (!isMatrixQaPlainRecord(payload)) {
+    return 0;
+  }
+  const rooms = isMatrixQaPlainRecord(payload.rooms) ? payload.rooms : {};
+  const join = isMatrixQaPlainRecord(rooms.join) ? rooms.join : {};
+  let removed = 0;
+  for (const room of Object.values(join)) {
+    if (!isMatrixQaPlainRecord(room)) {
+      continue;
+    }
+    const stateAfter = room[MATRIX_QA_SYNC_STATE_AFTER_KEY];
+    if (!isMatrixQaPlainRecord(stateAfter) || !Array.isArray(stateAfter.events)) {
+      continue;
+    }
+    const filtered = stateAfter.events.filter((event) => {
+      if (isMatrixQaPlainRecord(event) && event.type === "m.room.encryption") {
+        removed += 1;
+        return false;
+      }
+      return true;
+    });
+    stateAfter.events = filtered;
+  }
+  return removed;
+}
+
+function buildSyncStateAfterMissingEncryptionFaultRule(
+  accessToken: string,
+): MatrixQaFaultProxyRule {
+  return {
+    id: MATRIX_QA_SYNC_STATE_AFTER_FAULT_RULE_ID,
+    match: (request) =>
+      request.method === "GET" &&
+      request.path === MATRIX_QA_SYNC_ENDPOINT &&
+      request.bearerToken === accessToken &&
+      new URLSearchParams(request.search).get(MATRIX_QA_SYNC_STATE_AFTER_PARAM) === "true",
+    mutateResponse: ({ response }) => {
+      const contentType = response.headers.get("content-type") ?? "";
+      if (!contentType.includes("json")) {
+        return response;
+      }
+      const payload = JSON.parse(response.body.toString("utf8")) as unknown;
+      removeMatrixQaSyncStateAfterEncryptionEvents(payload);
+      return {
+        ...response,
+        body: Buffer.from(JSON.stringify(payload)),
+      };
+    },
+  };
+}
+
 async function runMatrixQaFaultedE2eeBootstrap(context: MatrixQaScenarioContext): Promise<{
   faultHits: MatrixQaFaultProxyHit[];
   result: MatrixQaE2eeBootstrapResult;
@@ -1310,6 +1366,97 @@ export async function runMatrixQaE2eeBasicReplyScenario(
       ...buildMatrixReplyDetails("E2EE reply", result.reply),
     ].join("\n"),
   };
+}
+
+export async function runMatrixQaE2eeStateAfterMissingEncryptionScenario(
+  context: MatrixQaScenarioContext,
+): Promise<MatrixQaScenarioExecution> {
+  if (!context.restartGatewayAfterStateMutation) {
+    throw new Error("Matrix E2EE state_after QA scenario requires hard gateway restart support");
+  }
+  const accountId = context.sutAccountId ?? "sut";
+  const configPath = requireMatrixQaGatewayConfigPath(context);
+  const originalAccountConfig = await readMatrixQaGatewayMatrixAccount({
+    accountId,
+    configPath,
+  });
+  const proxy = await startMatrixQaFaultProxy({
+    targetBaseUrl: context.baseUrl,
+    rules: [buildSyncStateAfterMissingEncryptionFaultRule(context.sutAccessToken)],
+  });
+  let gatewayPatched = false;
+  try {
+    await context.restartGatewayAfterStateMutation(
+      async () => {
+        await patchMatrixQaGatewayMatrixAccount({
+          accountId,
+          accountPatch: {
+            homeserver: proxy.baseUrl,
+            network: {
+              dangerouslyAllowPrivateNetwork: true,
+            },
+          },
+          configPath,
+        });
+        gatewayPatched = true;
+      },
+      {
+        timeoutMs: context.timeoutMs,
+        waitAccountId: accountId,
+      },
+    );
+    const result = await runMatrixQaE2eeTopLevelScenario(context, {
+      scenarioId: "matrix-e2ee-state-after-missing-encryption",
+      tokenPrefix: "MATRIX_QA_E2EE_STATE_AFTER",
+    });
+    const stateAfterHits = proxy
+      .hits()
+      .filter((hit) => hit.ruleId === MATRIX_QA_SYNC_STATE_AFTER_FAULT_RULE_ID);
+    if (stateAfterHits.length > 0) {
+      throw new Error(
+        `Matrix E2EE gateway still sent ${MATRIX_QA_SYNC_STATE_AFTER_PARAM}=true on /sync`,
+      );
+    }
+    return {
+      artifacts: {
+        driverEventId: result.driverEventId,
+        faultProxyBaseUrl: proxy.baseUrl,
+        reply: result.reply,
+        roomKey: result.roomKey,
+        roomId: result.roomId,
+        stateAfterFaultHitCount: stateAfterHits.length,
+        stateAfterFaultRuleId: MATRIX_QA_SYNC_STATE_AFTER_FAULT_RULE_ID,
+        strippedSyncStateAfterParam: true,
+      },
+      details: [
+        `encrypted room key: ${result.roomKey}`,
+        `encrypted room id: ${result.roomId}`,
+        `driver event: ${result.driverEventId}`,
+        `fault proxy: ${proxy.baseUrl}`,
+        `state_after sync opt-in hits: ${stateAfterHits.length}`,
+        ...buildMatrixReplyDetails("E2EE state_after reply", result.reply),
+      ].join("\n"),
+    };
+  } finally {
+    if (gatewayPatched) {
+      await context
+        .restartGatewayAfterStateMutation(
+          async () => {
+            await replaceMatrixQaGatewayMatrixAccount({
+              accountConfig: originalAccountConfig,
+              accountId,
+              configPath,
+            });
+          },
+          {
+            timeoutMs: context.timeoutMs,
+            waitAccountId: accountId,
+          },
+        )
+        .catch(() => undefined);
+    }
+    await proxy.stop().catch(() => undefined);
+  }
 }
 
 export async function runMatrixQaE2eeThreadFollowUpScenario(

--- a/extensions/qa-matrix/src/runners/contract/scenario-runtime.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-runtime.ts
@@ -61,6 +61,7 @@ import {
   runMatrixQaE2eeRecoveryKeyLifecycleScenario,
   runMatrixQaE2eeRecoveryOwnerVerificationRequiredScenario,
   runMatrixQaE2eeRestartResumeScenario,
+  runMatrixQaE2eeStateAfterMissingEncryptionScenario,
   runMatrixQaE2eeStaleDeviceHygieneScenario,
   runMatrixQaE2eeThreadFollowUpScenario,
   runMatrixQaE2eeVerificationNoticeNoTriggerScenario,
@@ -387,6 +388,8 @@ export async function runMatrixQaScenario(
       return await runInboundEditNoDuplicateTriggerScenario(context);
     case "matrix-e2ee-basic-reply":
       return await runMatrixQaE2eeBasicReplyScenario(context);
+    case "matrix-e2ee-state-after-missing-encryption":
+      return await runMatrixQaE2eeStateAfterMissingEncryptionScenario(context);
     case "matrix-e2ee-thread-follow-up":
       return await runMatrixQaE2eeThreadFollowUpScenario(context);
     case "matrix-e2ee-bootstrap-success":

--- a/extensions/qa-matrix/src/runners/contract/scenario-types.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenario-types.ts
@@ -128,6 +128,7 @@ export type MatrixQaScenarioArtifacts = {
   deletedBackupVersion?: string | null;
   faultedEndpoint?: string;
   faultHitCount?: number;
+  faultProxyBaseUrl?: string;
   faultRuleId?: string;
   historyEventId?: string;
   observerRecoveryDeviceId?: string;
@@ -165,6 +166,9 @@ export type MatrixQaScenarioArtifacts = {
   gatewayUserId?: string;
   secondEncryptionChanged?: boolean;
   setupSuccess?: boolean;
+  stateAfterFaultHitCount?: number;
+  stateAfterFaultRuleId?: string;
+  strippedSyncStateAfterParam?: boolean;
   verificationBootstrapAttempted?: boolean;
   verificationBootstrapSuccess?: boolean;
   gatewayReply?: MatrixQaReplyArtifact;

--- a/extensions/qa-matrix/src/runners/contract/scenarios.test.ts
+++ b/extensions/qa-matrix/src/runners/contract/scenarios.test.ts
@@ -351,6 +351,7 @@ describe("matrix live qa scenarios", () => {
       "matrix-inbound-edit-ignored",
       "matrix-inbound-edit-no-duplicate-trigger",
       "matrix-e2ee-basic-reply",
+      "matrix-e2ee-state-after-missing-encryption",
       "matrix-e2ee-thread-follow-up",
       "matrix-e2ee-bootstrap-success",
       "matrix-e2ee-recovery-key-lifecycle",
@@ -1032,6 +1033,226 @@ describe("matrix live qa scenarios", () => {
         requireMention: true,
       },
     ]);
+  });
+
+  it("runs the Matrix E2EE state_after regression scenario through the gateway fault proxy", async () => {
+    const outputDir = await mkdtemp(path.join(os.tmpdir(), "matrix-e2ee-state-after-"));
+    const gatewayConfigPath = path.join(outputDir, "gateway-config.json");
+    try {
+      await writeTestJsonFile(gatewayConfigPath, {
+        channels: {
+          matrix: {
+            defaultAccount: "sut",
+            accounts: {
+              sut: {
+                accessToken: "sut-token",
+                enabled: true,
+                homeserver: "http://127.0.0.1:28008/",
+                network: {
+                  existing: true,
+                },
+                userId: "@sut:matrix-qa.test",
+              },
+            },
+          },
+        },
+      });
+      const proxyStop = vi.fn().mockResolvedValue(undefined);
+      const proxyHits = vi.fn().mockReturnValue([]);
+      startMatrixQaFaultProxy.mockResolvedValue({
+        baseUrl: "http://127.0.0.1:39879",
+        hits: proxyHits,
+        stop: proxyStop,
+      });
+      let replyToken = "";
+      const driverStop = vi.fn().mockResolvedValue(undefined);
+      const driverClient = {
+        prime: vi.fn().mockResolvedValue("s1"),
+        sendTextMessage: vi.fn(async ({ body }) => {
+          replyToken = String(body).match(/MATRIX_QA_E2EE_STATE_AFTER_[A-Z0-9]+/)?.[0] ?? "";
+          return "$state-after-trigger";
+        }),
+        stop: driverStop,
+        waitForRoomEvent: vi.fn(async ({ predicate }) => {
+          const event = {
+            body: replyToken,
+            eventId: "$state-after-reply",
+            kind: "message",
+            roomId: "!state-after:matrix-qa.test",
+            sender: "@sut:matrix-qa.test",
+            type: "m.room.message",
+          };
+          expect(predicate(event)).toBe(true);
+          return { event, since: "s2" };
+        }),
+      };
+      createMatrixQaE2eeScenarioClient.mockResolvedValueOnce(driverClient);
+      const restartGatewayAfterStateMutation = vi.fn(async (mutateState) => {
+        await mutateState({ stateDir: path.join(outputDir, "state") });
+      });
+
+      const scenario = requireMatrixQaScenario("matrix-e2ee-state-after-missing-encryption");
+
+      const result = await runMatrixQaScenario(scenario, {
+        ...matrixQaScenarioContext(),
+        driverDeviceId: "DRIVERDEVICE",
+        gatewayRuntimeEnv: {
+          OPENCLAW_CONFIG_PATH: gatewayConfigPath,
+          PATH: process.env.PATH,
+        },
+        outputDir,
+        restartGatewayAfterStateMutation,
+        sutAccountId: "sut",
+        topology: {
+          defaultRoomId: "!main:matrix-qa.test",
+          defaultRoomKey: "main",
+          rooms: [
+            {
+              encrypted: true,
+              key: matrixQaE2eeRoomKey("matrix-e2ee-state-after-missing-encryption"),
+              kind: "group",
+              memberRoles: ["driver", "observer", "sut"],
+              memberUserIds: [
+                "@driver:matrix-qa.test",
+                "@observer:matrix-qa.test",
+                "@sut:matrix-qa.test",
+              ],
+              name: "E2EE",
+              requireMention: true,
+              roomId: "!state-after:matrix-qa.test",
+            },
+          ],
+        },
+      });
+      const artifacts = result.artifacts as {
+        reply?: { eventId?: unknown; tokenMatched?: unknown };
+        roomId?: unknown;
+        stateAfterFaultHitCount?: unknown;
+        stateAfterFaultRuleId?: unknown;
+        strippedSyncStateAfterParam?: unknown;
+      };
+      expect(artifacts.reply?.eventId).toBe("$state-after-reply");
+      expect(artifacts.reply?.tokenMatched).toBe(true);
+      expect(artifacts.roomId).toBe("!state-after:matrix-qa.test");
+      expect(artifacts.stateAfterFaultHitCount).toBe(0);
+      expect(artifacts.stateAfterFaultRuleId).toBe("sync-state-after-missing-encryption");
+      expect(artifacts.strippedSyncStateAfterParam).toBe(true);
+
+      const restoredConfig = JSON.parse(await readFile(gatewayConfigPath, "utf8")) as {
+        channels: {
+          matrix: {
+            accounts: {
+              sut: {
+                homeserver?: string;
+                network?: Record<string, unknown>;
+              };
+            };
+          };
+        };
+      };
+      expect(restoredConfig.channels.matrix.accounts.sut.homeserver).toBe(
+        "http://127.0.0.1:28008/",
+      );
+      expect(restoredConfig.channels.matrix.accounts.sut.network).toEqual({ existing: true });
+      expect(restartGatewayAfterStateMutation).toHaveBeenCalledTimes(2);
+      expect(proxyStop).toHaveBeenCalledTimes(1);
+
+      const proxyArgs = mockObjectArg(startMatrixQaFaultProxy, "startMatrixQaFaultProxy") as {
+        rules: Array<{
+          match: (params: {
+            bearerToken?: string;
+            headers: Record<string, string>;
+            method: string;
+            path: string;
+            search: string;
+          }) => boolean;
+          mutateResponse: (params: {
+            request: unknown;
+            response: {
+              body: Buffer;
+              headers: Headers;
+              status: number;
+            };
+          }) =>
+            | {
+                body: Buffer;
+                headers: Headers;
+                status: number;
+              }
+            | Promise<{
+                body: Buffer;
+                headers: Headers;
+                status: number;
+              }>;
+        }>;
+        targetBaseUrl?: unknown;
+      };
+      const [faultRule] = proxyArgs.rules;
+      if (!faultRule) {
+        throw new Error("expected Matrix QA fault proxy rule");
+      }
+      expect(proxyArgs.targetBaseUrl).toBe("http://127.0.0.1:28008/");
+      expect(
+        faultRule.match({
+          bearerToken: "sut-token",
+          headers: {},
+          method: "GET",
+          path: "/_matrix/client/v3/sync",
+          search: "?timeout=30000&org.matrix.msc4222.use_state_after=true",
+        }),
+      ).toBe(true);
+      expect(
+        faultRule.match({
+          bearerToken: "sut-token",
+          headers: {},
+          method: "GET",
+          path: "/_matrix/client/v3/sync",
+          search: "?timeout=30000",
+        }),
+      ).toBe(false);
+      const mutated = await faultRule.mutateResponse({
+        request: {},
+        response: {
+          body: Buffer.from(
+            JSON.stringify({
+              rooms: {
+                join: {
+                  "!state-after:matrix-qa.test": {
+                    "org.matrix.msc4222.state_after": {
+                      events: [{ type: "m.room.encryption" }, { type: "m.room.name" }],
+                    },
+                  },
+                },
+              },
+            }),
+          ),
+          headers: new Headers({ "content-type": "application/json" }),
+          status: 200,
+        },
+      });
+      expect(JSON.parse(mutated.body.toString("utf8"))).toEqual({
+        rooms: {
+          join: {
+            "!state-after:matrix-qa.test": {
+              "org.matrix.msc4222.state_after": {
+                events: [{ type: "m.room.name" }],
+              },
+            },
+          },
+        },
+      });
+
+      const e2eeClientOptions = mockObjectArg(
+        createMatrixQaE2eeScenarioClient,
+        "createMatrixQaE2eeScenarioClient",
+      );
+      expect(e2eeClientOptions.baseUrl).toBe("http://127.0.0.1:28008/");
+      expect(mockObjectArg(driverClient.sendTextMessage, "sendTextMessage").roomId).toBe(
+        "!state-after:matrix-qa.test",
+      );
+    } finally {
+      await rm(outputDir, { force: true, recursive: true });
+    }
   });
 
   it("resolves scenario room ids from provisioned topology keys", () => {

--- a/extensions/qa-matrix/src/substrate/fault-proxy.test.ts
+++ b/extensions/qa-matrix/src/substrate/fault-proxy.test.ts
@@ -124,4 +124,49 @@ describe("Matrix QA fault proxy", () => {
       },
     ]);
   });
+
+  it("mutates matching forwarded Matrix responses", async () => {
+    const target = await startTargetServer();
+    proxy = await startMatrixQaFaultProxy({
+      targetBaseUrl: target.baseUrl,
+      rules: [
+        {
+          id: "sync-state-after",
+          match: (request) =>
+            request.method === "GET" &&
+            request.path === "/_matrix/client/v3/sync" &&
+            request.search.includes("org.matrix.msc4222.use_state_after=true"),
+          mutateResponse: ({ response }) => ({
+            ...response,
+            body: Buffer.from(JSON.stringify({ forwarded: true, mutated: true })),
+          }),
+        },
+      ],
+    });
+
+    const mutated = await fetch(
+      `${proxy.baseUrl}/_matrix/client/v3/sync?timeout=0&org.matrix.msc4222.use_state_after=true`,
+      {
+        headers: { authorization: "Bearer driver-token" },
+      },
+    );
+
+    expect(mutated.status).toBe(200);
+    await expect(mutated.json()).resolves.toEqual({ forwarded: true, mutated: true });
+    expect(proxy.hits()).toEqual([
+      {
+        method: "GET",
+        path: "/_matrix/client/v3/sync",
+        ruleId: "sync-state-after",
+      },
+    ]);
+    expect(target.requests).toEqual([
+      {
+        authorization: "Bearer driver-token",
+        body: "",
+        method: "GET",
+        url: "/_matrix/client/v3/sync?timeout=0&org.matrix.msc4222.use_state_after=true",
+      },
+    ]);
+  });
 });

--- a/extensions/qa-matrix/src/substrate/fault-proxy.ts
+++ b/extensions/qa-matrix/src/substrate/fault-proxy.ts
@@ -32,10 +32,20 @@ type MatrixQaFaultProxyResponse = {
   status: number;
 };
 
+type MatrixQaFaultProxyForwardedResponse = {
+  body: Buffer;
+  headers: Headers;
+  status: number;
+};
+
 export type MatrixQaFaultProxyRule = {
   id: string;
   match(request: MatrixQaFaultProxyRequest): boolean;
-  response(request: MatrixQaFaultProxyRequest): MatrixQaFaultProxyResponse;
+  mutateResponse?(params: {
+    request: MatrixQaFaultProxyRequest;
+    response: MatrixQaFaultProxyForwardedResponse;
+  }): MatrixQaFaultProxyForwardedResponse | Promise<MatrixQaFaultProxyForwardedResponse>;
+  response?(request: MatrixQaFaultProxyRequest): MatrixQaFaultProxyResponse;
 };
 
 export type MatrixQaFaultProxyHit = {
@@ -105,7 +115,7 @@ async function forwardMatrixQaFaultProxyRequest(params: {
   body: Buffer;
   req: IncomingMessage;
   targetUrl: URL;
-}) {
+}): Promise<MatrixQaFaultProxyForwardedResponse> {
   const method = params.req.method ?? "GET";
   const init: RequestInit = {
     headers: buildFetchHeaders(params.req.headers),
@@ -134,7 +144,7 @@ async function forwardMatrixQaFaultProxyRequest(params: {
 
 function writeForwardedResponse(
   res: ServerResponse,
-  response: Awaited<ReturnType<typeof forwardMatrixQaFaultProxyRequest>>,
+  response: MatrixQaFaultProxyForwardedResponse,
 ) {
   const headers: Record<string, string> = {};
   for (const [key, value] of response.headers) {
@@ -172,17 +182,24 @@ export async function startMatrixQaFaultProxy(params: {
           path: request.path,
           ruleId: rule.id,
         });
-        writeJsonResponse(res, rule.response(request));
-        return;
+        if (rule.response) {
+          writeJsonResponse(res, rule.response(request));
+          return;
+        }
       }
-      writeForwardedResponse(
-        res,
-        await forwardMatrixQaFaultProxyRequest({
-          body,
-          req,
-          targetUrl: requestUrl,
-        }),
-      );
+      const forwarded = await forwardMatrixQaFaultProxyRequest({
+        body,
+        req,
+        targetUrl: requestUrl,
+      });
+      const response =
+        rule?.mutateResponse !== undefined
+          ? await rule.mutateResponse({
+              request,
+              response: forwarded,
+            })
+          : forwarded;
+      writeForwardedResponse(res, response);
     } catch (error) {
       writeJsonResponse(res, {
         body: {


### PR DESCRIPTION
## Summary

Follow-up to #82631 for #82515. The transport fix is already merged; this PR adds the Matrix QA regression scenario that proves the gateway no longer opts into MSC4222 `state_after` sync for encrypted rooms.

The best E2E course is the existing Matrix QA harness: start a disposable Matrix homeserver, drive the OpenClaw Matrix plugin through a real gateway, and insert a local fault proxy between the SUT and the homeserver. I did not make ClickCluck Matrix-compatible for this proof. That would mean building or bridging enough of the Matrix client-server API, sync semantics, devices, keys, and encrypted-room behavior to be believable, which is a separate product-sized project and less faithful than testing against a real Matrix homeserver.

## Changes

- Extends the Matrix QA fault proxy so it can mutate forwarded Matrix responses, not only return synthetic responses.
- Adds `matrix-e2ee-state-after-missing-encryption`, an encrypted-room scenario that patches the SUT Matrix homeserver URL through the fault proxy, hard-restarts the gateway, sends a real E2EE mention, and asserts the gateway never sends `org.matrix.msc4222.use_state_after=true` on `/sync`.
- Adds unit coverage for the new proxy response-mutation path and scenario wiring.

## Verification

Local focused regression tests:

```sh
node scripts/run-vitest.mjs extensions/qa-matrix/src/substrate/fault-proxy.test.ts extensions/qa-matrix/src/runners/contract/scenarios.test.ts
```

Result:

```text
PASS 2 files, 73 tests
```

Remote setup notes:

- Initial Blacksmith Testbox attempt could not run because `.github/workflows/crabbox-hydrate.yml` has no explicit Testbox job.
- Raw AWS Crabbox initially had no `pnpm`, then needed Node 22/corepack and Docker Compose v2 installed.
- Final proof ran on the warmed AWS Crabbox lease below after setup completed.

Crabbox E2E Matrix QA:

```text
provider: aws
lease: cbx_e41cefe741f9
slug: golden-barnacle
run: run_e18982901eaa
actions: https://github.com/openclaw/openclaw/actions/runs/25966810530
```

Command:

```sh
node scripts/crabbox-wrapper.mjs run --id cbx_e41cefe741f9 --no-sync --idle-timeout 90m --ttl 240m --timing-json --shell -- "set -euo pipefail; echo CRABBOX_PHASE:setup; if ! docker compose version >/dev/null 2>&1; then sudo apt-get update; sudo apt-get install -y docker-compose-v2; fi; sudo systemctl start docker || sudo service docker start; sudo chmod 666 /var/run/docker.sock; docker compose version; echo CRABBOX_PHASE:qa; env CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_QA_MATRIX_NO_REPLY_WINDOW_MS=3000 pnpm openclaw qa matrix --profile all --scenario matrix-e2ee-state-after-missing-encryption --provider-mode mock-openai --fail-fast"
```

Observed result:

```text
Matrix harness ready: baseUrl=http://127.0.0.1:28008/
topology ready: rooms=2
gateway boot done
canary pass
scenario pass matrix-e2ee-state-after-missing-encryption 33.8s
suite pass 4/4 total=81.2s
```

Artifacts reported by the QA run:

```text
/home/crabbox/actions-runner/_work/openclaw/openclaw/.artifacts/qa-e2e/matrix-mp8k6pvm/matrix-qa-report.md
/home/crabbox/actions-runner/_work/openclaw/openclaw/.artifacts/qa-e2e/matrix-mp8k6pvm/matrix-qa-summary.json
/home/crabbox/actions-runner/_work/openclaw/openclaw/.artifacts/qa-e2e/matrix-mp8k6pvm/matrix-qa-observed-events.json
```

Crabbox changed gate:

```text
provider: aws
lease: cbx_e41cefe741f9
slug: golden-barnacle
run: run_380d8195f9b9
actions: https://github.com/openclaw/openclaw/actions/runs/25966810530
```

Command:

```sh
node scripts/crabbox-wrapper.mjs run --id cbx_e41cefe741f9 --idle-timeout 90m --ttl 240m --timing-json --shell -- "env CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_TEST_PROJECTS_PARALLEL=6 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 pnpm check:changed"
```

Result:

```text
PASS, exitCode=0, totalMs=65162
```

Codex review:

```sh
/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --full-access
```

Result:

```text
No actionable correctness issues found in the reviewed dirty changes.
codex-review complete after 9m12s
```

## Real behavior proof

Behavior addressed: Matrix E2EE rooms must keep the Matrix SDK `state_after` sync opt-in disabled so Synapse-style responses do not hide `m.room.encryption` from the gateway room state path.

Real environment tested: AWS Crabbox `cbx_e41cefe741f9` (`golden-barnacle`) running the Matrix QA harness with a disposable Matrix homeserver, gateway SUT, real encrypted room topology, mock OpenAI provider, and a local fault proxy between the SUT and homeserver.

Exact steps or command run after this patch: `pnpm openclaw qa matrix --profile all --scenario matrix-e2ee-state-after-missing-encryption --provider-mode mock-openai --fail-fast` through `scripts/crabbox-wrapper.mjs` on AWS Crabbox, plus `pnpm check:changed` on the same lease.

Evidence after fix: Copied live console output from AWS Crabbox `run_e18982901eaa`:

```text
Matrix harness ready: baseUrl=http://127.0.0.1:28008/
topology ready: rooms=2
gateway boot done
canary pass
scenario pass matrix-e2ee-state-after-missing-encryption 33.8s
suite pass 4/4 total=81.2s
```

The new scenario hard-restarted the gateway with the SUT Matrix account pointed at the fault proxy, sent a real E2EE mention/reply flow, and recorded zero proxy hits for `/sync?org.matrix.msc4222.use_state_after=true` from the SUT token.

Observed result after fix: The E2E scenario passed in 33.8s and the Matrix QA suite reported `suite pass 4/4 total=81.2s`.

What was not tested: I did not build Matrix compatibility into ClickCluck. I also did not run against an external public Matrix homeserver, because the disposable QA homeserver plus fault proxy gives deterministic coverage for this regression.
