### PR TITLE
fix(qqbot): require truthy debug env values

### DIFF
--- a/extensions/qqbot/src/engine/utils/log.test.ts
+++ b/extensions/qqbot/src/engine/utils/log.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { debugLog, sanitizeDebugLogValue } from "./log.js";
+import { debugLog, debugWarn, sanitizeDebugLogValue } from "./log.js";
 
 const originalDebug = process.env.QQBOT_DEBUG;
 
@@ -24,5 +24,23 @@ describe("QQBot debug logging", () => {
     debugLog("prefix", "line one\nline two");
 
     expect(logSpy).toHaveBeenCalledWith("prefix line one line two");
+  });
+
+  it.each(["0", "false", "off", "no", ""])("does not log when QQBOT_DEBUG=%j", (value) => {
+    process.env.QQBOT_DEBUG = value;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    debugWarn("private message text");
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it.each(["1", "true", "yes", "on"])("logs when QQBOT_DEBUG=%j", (value) => {
+    process.env.QQBOT_DEBUG = value;
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    debugLog("debug enabled");
+
+    expect(logSpy).toHaveBeenCalledWith("debug enabled");
   });
 });

--- a/extensions/qqbot/src/engine/utils/log.ts
+++ b/extensions/qqbot/src/engine/utils/log.ts
@@ -8,7 +8,19 @@
  * Self-contained within engine/ — no framework SDK dependency.
  */
 
-const isDebug = () => !!process.env.QQBOT_DEBUG;
+function isTruthyEnvValue(value?: string): boolean {
+  switch (value?.trim().toLowerCase()) {
+    case "1":
+    case "on":
+    case "true":
+    case "yes":
+      return true;
+    default:
+      return false;
+  }
+}
+
+const isDebug = () => isTruthyEnvValue(process.env.QQBOT_DEBUG);
 const MAX_LOG_VALUE_CHARS = 4096;
 
 export function sanitizeDebugLogValue(value: unknown): string {


### PR DESCRIPTION
Fixes #82644

## Summary

- treat `QQBOT_DEBUG` as enabled only for explicit truthy values (`1`, `true`, `yes`, `on`)
- keep common false-like values (`0`, `false`, `off`, `no`, empty) from emitting debug output
- add regression coverage for both enabled and disabled debug flag values

## Proof

- `pnpm vitest run extensions/qqbot/src/engine/utils/log.test.ts --reporter=dot`
