### PR TITLE
Fix QQBot debug env parsing

### DIFF
--- a/extensions/qqbot/src/engine/utils/log.test.ts
+++ b/extensions/qqbot/src/engine/utils/log.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { debugLog, sanitizeDebugLogValue } from "./log.js";
+import { debugLog, debugWarn, sanitizeDebugLogValue } from "./log.js";
 
 const originalDebug = process.env.QQBOT_DEBUG;
 
@@ -25,4 +25,28 @@ describe("QQBot debug logging", () => {
 
     expect(logSpy).toHaveBeenCalledWith("prefix line one line two");
   });
+
+  it.each(["0", "false", "off", "no", ""])(
+    "keeps debug warnings silent when QQBOT_DEBUG=%j",
+    (value) => {
+      process.env.QQBOT_DEBUG = value;
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      debugWarn("private message text");
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["1", "true", "yes", "on", " TRUE "])(
+    "enables debug warnings when QQBOT_DEBUG=%j",
+    (value) => {
+      process.env.QQBOT_DEBUG = value;
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      debugWarn("private message text");
+
+      expect(warnSpy).toHaveBeenCalledWith("private message text");
+    },
+  );
 });

--- a/extensions/qqbot/src/engine/utils/log.ts
+++ b/extensions/qqbot/src/engine/utils/log.ts
@@ -2,13 +2,18 @@
  * QQBot debug logging utilities.
  * QQBot 调试日志工具。
  *
- * Only outputs when the QQBOT_DEBUG environment variable is set,
+ * Only outputs when the QQBOT_DEBUG environment variable is explicitly enabled,
  * preventing user message content from leaking in production logs.
  *
  * Self-contained within engine/ — no framework SDK dependency.
  */
 
-const isDebug = () => !!process.env.QQBOT_DEBUG;
+const DEBUG_TRUE_VALUES = new Set(["1", "true", "yes", "on"]);
+
+const isDebug = () => {
+  const normalized = process.env.QQBOT_DEBUG?.trim().toLowerCase();
+  return normalized !== undefined && DEBUG_TRUE_VALUES.has(normalized);
+};
 const MAX_LOG_VALUE_CHARS = 4096;
 
 export function sanitizeDebugLogValue(value: unknown): string {


### PR DESCRIPTION
## Summary

- Require `QQBOT_DEBUG` to be one of `1`, `true`, `yes`, or `on` before QQBot debug logging emits console output.
- Keep common disable values (`0`, `false`, `off`, `no`, empty) silent so private message text is not logged unexpectedly.
- Add regression coverage for false-like and explicit truthy values.

## Verification

- `CI=1 node scripts/run-vitest.mjs extensions/qqbot/src/engine/utils/log.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/qqbot/src/engine/utils/log.ts extensions/qqbot/src/engine/utils/log.test.ts`
- `git diff --check`
- `pnpm check:changed`

Behavior addressed: QQBot debug logging no longer treats any non-empty `QQBOT_DEBUG` value as enabled; `QQBOT_DEBUG=0`, `false`, `off`, and `no` stay silent.

Real environment tested: local OpenClaw WSL checkout on branch `fix-qqbot-debug-env-82644` with the QQBot logger test suite and changed-file validation.

Exact steps or command run after this patch: ran the focused QQBot logger Vitest suite, formatting check, whitespace check, and `pnpm check:changed`; also ran a before/after source-level proof by reverting only `extensions/qqbot/src/engine/utils/log.ts` while keeping the new regression tests.

Evidence after fix:

```text
before_status=1
after_status=0
== before failures ==
× keeps debug warnings silent when QQBOT_DEBUG="0"
× keeps debug warnings silent when QQBOT_DEBUG="false"
× keeps debug warnings silent when QQBOT_DEBUG="off"
× keeps debug warnings silent when QQBOT_DEBUG="no"
AssertionError: expected "warn" to not be called at all, but actually been called 1 times
Tests  4 failed | 8 passed (12)
== after summary ==
Test Files  1 passed (1)
Tests  12 passed (12)
```

Observed result after fix: false-like `QQBOT_DEBUG` values do not call `console.warn`, while explicit truthy values still emit sanitized debug warnings.

What was not tested: live QQBot gateway traffic; the fix is limited to the logger guard and is covered with source-level logger calls.

Fixes #82644
