### PR TITLE
Codex: downgrade app-server approvalPolicy when user Codex hooks are disabled

### DIFF
--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -1,6 +1,5 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
-import path from "node:path";
 import {
   ensureAuthProfileStore,
   ensureAuthProfileStoreWithoutExternalProfiles,
@@ -16,6 +15,10 @@ import {
   type OAuthCredential,
 } from "openclaw/plugin-sdk/agent-runtime";
 import type { CodexAppServerClient } from "./client.js";
+import {
+  resolveCodexAppServerHomeDir as resolveCodexAppServerHomeDirFromLeaf,
+  resolveCodexAppServerNativeHomeDir as resolveCodexAppServerNativeHomeDirFromLeaf,
+} from "./codex-home-paths.js";
 import type { CodexAppServerStartOptions } from "./config.js";
 import type {
   CodexChatgptAuthTokensRefreshResponse,
@@ -29,8 +32,6 @@ const OPENAI_PROVIDER = "openai";
 const OPENAI_CODEX_DEFAULT_PROFILE_ID = "openai-codex:default";
 const CODEX_HOME_ENV_VAR = "CODEX_HOME";
 const HOME_ENV_VAR = "HOME";
-const CODEX_APP_SERVER_HOME_DIRNAME = "codex-home";
-const CODEX_APP_SERVER_NATIVE_HOME_DIRNAME = "home";
 const CODEX_API_KEY_ENV_VAR = "CODEX_API_KEY";
 const OPENAI_API_KEY_ENV_VAR = "OPENAI_API_KEY";
 const CODEX_APP_SERVER_API_KEY_ENV_VARS = [CODEX_API_KEY_ENV_VAR, OPENAI_API_KEY_ENV_VAR];
@@ -244,13 +245,8 @@ function fingerprintTokenAuthProfileCacheKey(accessToken: string): string {
   return `token:sha256:${hash.digest("hex")}`;
 }
 
-export function resolveCodexAppServerHomeDir(agentDir: string): string {
-  return path.join(path.resolve(agentDir), CODEX_APP_SERVER_HOME_DIRNAME);
-}
-
-export function resolveCodexAppServerNativeHomeDir(agentDir: string): string {
-  return path.join(resolveCodexAppServerHomeDir(agentDir), CODEX_APP_SERVER_NATIVE_HOME_DIRNAME);
-}
+export const resolveCodexAppServerHomeDir = resolveCodexAppServerHomeDirFromLeaf;
+export const resolveCodexAppServerNativeHomeDir = resolveCodexAppServerNativeHomeDirFromLeaf;
 
 async function withAgentCodexHomeEnvironment(
   startOptions: CodexAppServerStartOptions,

--- a/extensions/codex/src/app-server/codex-home-paths.ts
+++ b/extensions/codex/src/app-server/codex-home-paths.ts
@@ -1,0 +1,19 @@
+import path from "node:path";
+
+// Leaf module shared by `config.ts` (for post-bridge approval-policy
+// downgrade detection) and `auth-bridge.ts` (for the actual CODEX_HOME
+// injection). Both modules need the same path math, but `config.ts` cannot
+// import from `auth-bridge.ts` without re-introducing the
+// auth-bridge -> client -> config -> transport madge cycle, so the constant
+// and resolver live here.
+
+export const CODEX_APP_SERVER_HOME_DIRNAME = "codex-home";
+export const CODEX_APP_SERVER_NATIVE_HOME_DIRNAME = "home";
+
+export function resolveCodexAppServerHomeDir(agentDir: string): string {
+  return path.join(path.resolve(agentDir), CODEX_APP_SERVER_HOME_DIRNAME);
+}
+
+export function resolveCodexAppServerNativeHomeDir(agentDir: string): string {
+  return path.join(resolveCodexAppServerHomeDir(agentDir), CODEX_APP_SERVER_NATIVE_HOME_DIRNAME);
+}

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -853,4 +853,202 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
     expect(appServerProperties.sandbox?.default).toBeUndefined();
     expect(appServerProperties.approvalsReviewer?.default).toBeUndefined();
   });
+
+  describe("user Codex features.hooks downgrade", () => {
+    it("downgrades resolved approval policy to 'never' when user Codex config disables features.hooks", () => {
+      const runtime = resolveRuntimeForTest({
+        pluginConfig: {
+          appServer: {
+            mode: "guardian",
+            approvalPolicy: "on-request",
+            sandbox: "workspace-write",
+            approvalsReviewer: "auto_review",
+          },
+        },
+        userCodexConfigToml: "[features]\nhooks = false\n",
+      });
+
+      expect(runtime.approvalPolicy).toBe("never");
+      expect(runtime.approvalPolicyDowngrade).toEqual({
+        from: "on-request",
+        to: "never",
+        reason: "user-codex-features-hooks-disabled",
+      });
+    });
+
+    it("also honors the legacy [features].codex_hooks key", () => {
+      const runtime = resolveRuntimeForTest({
+        pluginConfig: { appServer: { approvalPolicy: "on-request" } },
+        userCodexConfigToml: "[features]\ncodex_hooks = false\n",
+      });
+
+      expect(runtime.approvalPolicy).toBe("never");
+      expect(runtime.approvalPolicyDowngrade?.reason).toBe("user-codex-features-hooks-disabled");
+    });
+
+    it("supports the dotted features.hooks key form", () => {
+      const runtime = resolveRuntimeForTest({
+        pluginConfig: { appServer: { approvalPolicy: "on-failure" } },
+        userCodexConfigToml: 'features.hooks = false\n[mcp_servers.foo]\ncommand = "bar"\n',
+      });
+
+      expect(runtime.approvalPolicy).toBe("never");
+      expect(runtime.approvalPolicyDowngrade?.from).toBe("on-failure");
+    });
+
+    it("supports the dotted form with whitespace around the dot separator", () => {
+      const runtime = resolveRuntimeForTest({
+        pluginConfig: { appServer: { approvalPolicy: "on-request" } },
+        userCodexConfigToml: "features . hooks = false\n",
+      });
+
+      expect(runtime.approvalPolicy).toBe("never");
+    });
+
+    it("modern features.hooks wins over the legacy codex_hooks alias", () => {
+      const runtime = resolveRuntimeForTest({
+        pluginConfig: { appServer: { approvalPolicy: "on-request" } },
+        userCodexConfigToml: "[features]\nhooks = true\ncodex_hooks = false\n",
+      });
+
+      expect(runtime.approvalPolicy).toBe("on-request");
+      expect(runtime.approvalPolicyDowngrade).toBeUndefined();
+    });
+
+    it("does not downgrade when user Codex config explicitly enables features.hooks", () => {
+      const runtime = resolveRuntimeForTest({
+        pluginConfig: { appServer: { approvalPolicy: "on-request" } },
+        userCodexConfigToml: "[features]\nhooks = true\n",
+      });
+
+      expect(runtime.approvalPolicy).toBe("on-request");
+      expect(runtime.approvalPolicyDowngrade).toBeUndefined();
+    });
+
+    it("does not downgrade when features.hooks is absent (Codex default treats absent as enabled)", () => {
+      const runtime = resolveRuntimeForTest({
+        pluginConfig: { appServer: { approvalPolicy: "on-request" } },
+        userCodexConfigToml: 'model = "gpt-5.5"\n[features]\ngoals = true\n',
+      });
+
+      expect(runtime.approvalPolicy).toBe("on-request");
+      expect(runtime.approvalPolicyDowngrade).toBeUndefined();
+    });
+
+    it("does not downgrade when resolved policy is already 'never'", () => {
+      const runtime = resolveRuntimeForTest({
+        pluginConfig: { appServer: { approvalPolicy: "never" } },
+        userCodexConfigToml: "[features]\nhooks = false\n",
+      });
+
+      expect(runtime.approvalPolicy).toBe("never");
+      expect(runtime.approvalPolicyDowngrade).toBeUndefined();
+    });
+
+    it("treats unreadable user Codex config as absent (no downgrade)", () => {
+      const runtime = resolveRuntimeForTest({
+        pluginConfig: { appServer: { approvalPolicy: "on-request" } },
+        userCodexConfigPath: "/nonexistent/codex/config.toml",
+        readUserCodexConfigFile: () => {
+          throw new Error("ENOENT");
+        },
+      });
+
+      expect(runtime.approvalPolicy).toBe("on-request");
+      expect(runtime.approvalPolicyDowngrade).toBeUndefined();
+    });
+
+    it("accepts userCodexHooksEnabled override without reading config file", () => {
+      let readCalled = false;
+      const runtime = resolveRuntimeForTest({
+        pluginConfig: { appServer: { approvalPolicy: "on-request" } },
+        userCodexHooksEnabled: false,
+        readUserCodexConfigFile: () => {
+          readCalled = true;
+          return undefined;
+        },
+      });
+
+      expect(runtime.approvalPolicy).toBe("never");
+      expect(readCalled).toBe(false);
+      expect(runtime.approvalPolicyDowngrade?.from).toBe("on-request");
+    });
+
+    it("ignores hooks setting under unrelated TOML tables", () => {
+      const runtime = resolveRuntimeForTest({
+        pluginConfig: { appServer: { approvalPolicy: "on-request" } },
+        userCodexConfigToml:
+          'model = "gpt-5.5"\n[mcp_servers.example]\nhooks = false\n[features]\ngoals = true\n',
+      });
+
+      expect(runtime.approvalPolicy).toBe("on-request");
+      expect(runtime.approvalPolicyDowngrade).toBeUndefined();
+    });
+
+    it("ignores commented-out hooks declarations", () => {
+      const runtime = resolveRuntimeForTest({
+        pluginConfig: { appServer: { approvalPolicy: "on-request" } },
+        userCodexConfigToml: "[features]\n# hooks = false\nhooks = true\n",
+      });
+
+      expect(runtime.approvalPolicy).toBe("on-request");
+      expect(runtime.approvalPolicyDowngrade).toBeUndefined();
+    });
+
+    it("accepts whitespace-tolerant inline boolean values", () => {
+      const runtime = resolveRuntimeForTest({
+        pluginConfig: { appServer: { approvalPolicy: "on-request" } },
+        userCodexConfigToml: "[features]\nhooks=false\n",
+      });
+
+      expect(runtime.approvalPolicy).toBe("never");
+    });
+
+    it("reads user codex config from CODEX_HOME on POSIX when set", () => {
+      const reads: string[] = [];
+      resolveRuntimeForTest({
+        pluginConfig: { appServer: { approvalPolicy: "on-request" } },
+        env: { CODEX_HOME: "/opt/codex-data" },
+        platform: "linux",
+        readUserCodexConfigFile: (filePath: string) => {
+          reads.push(filePath);
+          return undefined;
+        },
+      });
+
+      expect(reads).toEqual(["/opt/codex-data/config.toml"]);
+    });
+
+    it("reads user codex config under USERPROFILE on Windows when set", () => {
+      const reads: string[] = [];
+      resolveRuntimeForTest({
+        pluginConfig: { appServer: { approvalPolicy: "on-request" } },
+        env: { USERPROFILE: "C:\\Users\\solo" },
+        platform: "win32",
+        readUserCodexConfigFile: (filePath: string) => {
+          reads.push(filePath);
+          return undefined;
+        },
+      });
+
+      expect(reads.length).toBe(1);
+      expect(reads[0]).toMatch(/^C:\\Users\\solo[\\/]\.codex[\\/]config\.toml$/);
+    });
+
+    it("falls back to HOMEDRIVE + HOMEPATH on Windows when USERPROFILE is missing", () => {
+      const reads: string[] = [];
+      resolveRuntimeForTest({
+        pluginConfig: { appServer: { approvalPolicy: "on-request" } },
+        env: { HOMEDRIVE: "C:", HOMEPATH: "\\Users\\solo" },
+        platform: "win32",
+        readUserCodexConfigFile: (filePath: string) => {
+          reads.push(filePath);
+          return undefined;
+        },
+      });
+
+      expect(reads.length).toBe(1);
+      expect(reads[0]).toMatch(/^C:\\Users\\solo[\\/]\.codex[\\/]config\.toml$/);
+    });
+  });
 });

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 import {
+  applyCodexHomeApprovalPolicyDowngrade,
   CODEX_APP_SERVER_CONFIG_KEYS,
   CODEX_COMPUTER_USE_CONFIG_KEYS,
   CODEX_PLUGIN_ENTRY_CONFIG_KEYS,
@@ -854,18 +855,18 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
     expect(appServerProperties.approvalsReviewer?.default).toBeUndefined();
   });
 
-  describe("user Codex features.hooks downgrade", () => {
-    it("downgrades resolved approval policy to 'never' when user Codex config disables features.hooks", () => {
-      const runtime = resolveRuntimeForTest({
-        pluginConfig: {
-          appServer: {
-            mode: "guardian",
-            approvalPolicy: "on-request",
-            sandbox: "workspace-write",
-            approvalsReviewer: "auto_review",
-          },
-        },
-        userCodexConfigToml: "[features]\nhooks = false\n",
+  describe("applyCodexHomeApprovalPolicyDowngrade", () => {
+    function runtimeWithPolicy(approvalPolicy: string, overrides: Record<string, unknown> = {}) {
+      const base = resolveRuntimeForTest({
+        pluginConfig: { appServer: { approvalPolicy } },
+      });
+      return { ...base, ...overrides };
+    }
+
+    it("downgrades non-never approvalPolicy to never when bridged codex_home has features.hooks=false", () => {
+      const runtime = applyCodexHomeApprovalPolicyDowngrade(runtimeWithPolicy("on-request"), {
+        bridgedCodexHome: "/agent/codex-home",
+        readConfigFile: () => "[features]\nhooks = false\n",
       });
 
       expect(runtime.approvalPolicy).toBe("never");
@@ -876,10 +877,9 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
       });
     });
 
-    it("also honors the legacy [features].codex_hooks key", () => {
-      const runtime = resolveRuntimeForTest({
-        pluginConfig: { appServer: { approvalPolicy: "on-request" } },
-        userCodexConfigToml: "[features]\ncodex_hooks = false\n",
+    it("honors the legacy [features].codex_hooks alias", () => {
+      const runtime = applyCodexHomeApprovalPolicyDowngrade(runtimeWithPolicy("on-request"), {
+        configToml: "[features]\ncodex_hooks = false\n",
       });
 
       expect(runtime.approvalPolicy).toBe("never");
@@ -887,9 +887,8 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
     });
 
     it("supports the dotted features.hooks key form", () => {
-      const runtime = resolveRuntimeForTest({
-        pluginConfig: { appServer: { approvalPolicy: "on-failure" } },
-        userCodexConfigToml: 'features.hooks = false\n[mcp_servers.foo]\ncommand = "bar"\n',
+      const runtime = applyCodexHomeApprovalPolicyDowngrade(runtimeWithPolicy("on-failure"), {
+        configToml: 'features.hooks = false\n[mcp_servers.foo]\ncommand = "bar"\n',
       });
 
       expect(runtime.approvalPolicy).toBe("never");
@@ -897,59 +896,53 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
     });
 
     it("supports the dotted form with whitespace around the dot separator", () => {
-      const runtime = resolveRuntimeForTest({
-        pluginConfig: { appServer: { approvalPolicy: "on-request" } },
-        userCodexConfigToml: "features . hooks = false\n",
+      const runtime = applyCodexHomeApprovalPolicyDowngrade(runtimeWithPolicy("on-request"), {
+        configToml: "features . hooks = false\n",
       });
 
       expect(runtime.approvalPolicy).toBe("never");
     });
 
     it("modern features.hooks wins over the legacy codex_hooks alias", () => {
-      const runtime = resolveRuntimeForTest({
-        pluginConfig: { appServer: { approvalPolicy: "on-request" } },
-        userCodexConfigToml: "[features]\nhooks = true\ncodex_hooks = false\n",
+      const runtime = applyCodexHomeApprovalPolicyDowngrade(runtimeWithPolicy("on-request"), {
+        configToml: "[features]\nhooks = true\ncodex_hooks = false\n",
       });
 
       expect(runtime.approvalPolicy).toBe("on-request");
       expect(runtime.approvalPolicyDowngrade).toBeUndefined();
     });
 
-    it("does not downgrade when user Codex config explicitly enables features.hooks", () => {
-      const runtime = resolveRuntimeForTest({
-        pluginConfig: { appServer: { approvalPolicy: "on-request" } },
-        userCodexConfigToml: "[features]\nhooks = true\n",
+    it("does not downgrade when features.hooks is explicitly true", () => {
+      const runtime = applyCodexHomeApprovalPolicyDowngrade(runtimeWithPolicy("on-request"), {
+        configToml: "[features]\nhooks = true\n",
       });
 
       expect(runtime.approvalPolicy).toBe("on-request");
       expect(runtime.approvalPolicyDowngrade).toBeUndefined();
     });
 
-    it("does not downgrade when features.hooks is absent (Codex default treats absent as enabled)", () => {
-      const runtime = resolveRuntimeForTest({
-        pluginConfig: { appServer: { approvalPolicy: "on-request" } },
-        userCodexConfigToml: 'model = "gpt-5.5"\n[features]\ngoals = true\n',
+    it("does not downgrade when features.hooks is absent (Codex default = enabled)", () => {
+      const runtime = applyCodexHomeApprovalPolicyDowngrade(runtimeWithPolicy("on-request"), {
+        configToml: 'model = "gpt-5.5"\n[features]\ngoals = true\n',
       });
 
       expect(runtime.approvalPolicy).toBe("on-request");
       expect(runtime.approvalPolicyDowngrade).toBeUndefined();
     });
 
-    it("does not downgrade when resolved policy is already 'never'", () => {
-      const runtime = resolveRuntimeForTest({
-        pluginConfig: { appServer: { approvalPolicy: "never" } },
-        userCodexConfigToml: "[features]\nhooks = false\n",
+    it("does not downgrade when approvalPolicy is already 'never'", () => {
+      const runtime = applyCodexHomeApprovalPolicyDowngrade(runtimeWithPolicy("never"), {
+        configToml: "[features]\nhooks = false\n",
       });
 
       expect(runtime.approvalPolicy).toBe("never");
       expect(runtime.approvalPolicyDowngrade).toBeUndefined();
     });
 
-    it("treats unreadable user Codex config as absent (no downgrade)", () => {
-      const runtime = resolveRuntimeForTest({
-        pluginConfig: { appServer: { approvalPolicy: "on-request" } },
-        userCodexConfigPath: "/nonexistent/codex/config.toml",
-        readUserCodexConfigFile: () => {
+    it("treats unreadable bridged codex_home config as absent (no downgrade)", () => {
+      const runtime = applyCodexHomeApprovalPolicyDowngrade(runtimeWithPolicy("on-request"), {
+        bridgedCodexHome: "/nonexistent/codex-home",
+        readConfigFile: () => {
           throw new Error("ENOENT");
         },
       });
@@ -958,12 +951,18 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
       expect(runtime.approvalPolicyDowngrade).toBeUndefined();
     });
 
-    it("accepts userCodexHooksEnabled override without reading config file", () => {
+    it("returns undefined hooks state when no codex_home information is provided", () => {
+      const runtime = applyCodexHomeApprovalPolicyDowngrade(runtimeWithPolicy("on-request"));
+
+      expect(runtime.approvalPolicy).toBe("on-request");
+      expect(runtime.approvalPolicyDowngrade).toBeUndefined();
+    });
+
+    it("accepts hooksEnabled override without reading config file", () => {
       let readCalled = false;
-      const runtime = resolveRuntimeForTest({
-        pluginConfig: { appServer: { approvalPolicy: "on-request" } },
-        userCodexHooksEnabled: false,
-        readUserCodexConfigFile: () => {
+      const runtime = applyCodexHomeApprovalPolicyDowngrade(runtimeWithPolicy("on-request"), {
+        hooksEnabled: false,
+        readConfigFile: () => {
           readCalled = true;
           return undefined;
         },
@@ -975,9 +974,8 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
     });
 
     it("ignores hooks setting under unrelated TOML tables", () => {
-      const runtime = resolveRuntimeForTest({
-        pluginConfig: { appServer: { approvalPolicy: "on-request" } },
-        userCodexConfigToml:
+      const runtime = applyCodexHomeApprovalPolicyDowngrade(runtimeWithPolicy("on-request"), {
+        configToml:
           'model = "gpt-5.5"\n[mcp_servers.example]\nhooks = false\n[features]\ngoals = true\n',
       });
 
@@ -986,9 +984,8 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
     });
 
     it("ignores commented-out hooks declarations", () => {
-      const runtime = resolveRuntimeForTest({
-        pluginConfig: { appServer: { approvalPolicy: "on-request" } },
-        userCodexConfigToml: "[features]\n# hooks = false\nhooks = true\n",
+      const runtime = applyCodexHomeApprovalPolicyDowngrade(runtimeWithPolicy("on-request"), {
+        configToml: "[features]\n# hooks = false\nhooks = true\n",
       });
 
       expect(runtime.approvalPolicy).toBe("on-request");
@@ -996,59 +993,66 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
     });
 
     it("accepts whitespace-tolerant inline boolean values", () => {
-      const runtime = resolveRuntimeForTest({
-        pluginConfig: { appServer: { approvalPolicy: "on-request" } },
-        userCodexConfigToml: "[features]\nhooks=false\n",
+      const runtime = applyCodexHomeApprovalPolicyDowngrade(runtimeWithPolicy("on-request"), {
+        configToml: "[features]\nhooks=false\n",
       });
 
       expect(runtime.approvalPolicy).toBe("never");
     });
 
-    it("reads user codex config from CODEX_HOME on POSIX when set", () => {
+    it("resolves the codex_home from agentDir when no explicit bridgedCodexHome is given", () => {
       const reads: string[] = [];
-      resolveRuntimeForTest({
-        pluginConfig: { appServer: { approvalPolicy: "on-request" } },
-        env: { CODEX_HOME: "/opt/codex-data" },
-        platform: "linux",
-        readUserCodexConfigFile: (filePath: string) => {
-          reads.push(filePath);
-          return undefined;
-        },
-      });
-
-      expect(reads).toEqual(["/opt/codex-data/config.toml"]);
-    });
-
-    it("reads user codex config under USERPROFILE on Windows when set", () => {
-      const reads: string[] = [];
-      resolveRuntimeForTest({
-        pluginConfig: { appServer: { approvalPolicy: "on-request" } },
-        env: { USERPROFILE: "C:\\Users\\solo" },
-        platform: "win32",
-        readUserCodexConfigFile: (filePath: string) => {
+      applyCodexHomeApprovalPolicyDowngrade(runtimeWithPolicy("on-request"), {
+        agentDir: "/srv/agent",
+        readConfigFile: (filePath: string) => {
           reads.push(filePath);
           return undefined;
         },
       });
 
       expect(reads.length).toBe(1);
-      expect(reads[0]).toMatch(/^C:\\Users\\solo[\\/]\.codex[\\/]config\.toml$/);
+      expect(reads[0]).toMatch(/\/srv\/agent[\\/]codex-home[\\/]config\.toml$/);
     });
 
-    it("falls back to HOMEDRIVE + HOMEPATH on Windows when USERPROFILE is missing", () => {
-      const reads: string[] = [];
-      resolveRuntimeForTest({
+    it("prefers explicit CODEX_HOME from runtime start.env over the agent-owned home", () => {
+      const baseRuntime = resolveRuntimeForTest({
         pluginConfig: { appServer: { approvalPolicy: "on-request" } },
-        env: { HOMEDRIVE: "C:", HOMEPATH: "\\Users\\solo" },
-        platform: "win32",
-        readUserCodexConfigFile: (filePath: string) => {
+      });
+      const runtimeWithExplicitCodexHome = {
+        ...baseRuntime,
+        start: { ...baseRuntime.start, env: { CODEX_HOME: "/etc/openclaw/codex-home" } },
+      };
+      const reads: string[] = [];
+
+      applyCodexHomeApprovalPolicyDowngrade(runtimeWithExplicitCodexHome, {
+        agentDir: "/srv/agent",
+        readConfigFile: (filePath: string) => {
           reads.push(filePath);
           return undefined;
         },
       });
 
       expect(reads.length).toBe(1);
-      expect(reads[0]).toMatch(/^C:\\Users\\solo[\\/]\.codex[\\/]config\.toml$/);
+      expect(reads[0]).toMatch(/\/etc\/openclaw\/codex-home[\\/]config\.toml$/);
+    });
+
+    it("returns runtime options unchanged for websocket transport", () => {
+      const baseRuntime = resolveRuntimeForTest({
+        pluginConfig: {
+          appServer: {
+            transport: "websocket",
+            url: "ws://127.0.0.1:39175",
+            approvalPolicy: "on-request",
+          },
+        },
+      });
+
+      const runtime = applyCodexHomeApprovalPolicyDowngrade(baseRuntime, {
+        configToml: "[features]\nhooks = false\n",
+      });
+
+      expect(runtime.approvalPolicy).toBe("on-request");
+      expect(runtime.approvalPolicyDowngrade).toBeUndefined();
     });
   });
 });

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -1036,6 +1036,51 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
       expect(reads[0]).toMatch(/\/etc\/openclaw\/codex-home[\\/]config\.toml$/);
     });
 
+    it("respects managed Codex requirements that exclude 'never' from allowed_approval_policies", () => {
+      const baseRuntime = resolveRuntimeForTest({
+        pluginConfig: { appServer: { approvalPolicy: "on-request" } },
+      });
+      const runtime = applyCodexHomeApprovalPolicyDowngrade(baseRuntime, {
+        configToml: "[features]\nhooks = false\n",
+        requirementsToml: 'allowed_approval_policies = ["on-request"]\n',
+      });
+
+      expect(runtime.approvalPolicy).toBe("on-request");
+      expect(runtime.approvalPolicyDowngrade).toBeUndefined();
+      expect(runtime.approvalPolicyDowngradeBlocked).toEqual({
+        desiredFrom: "on-request",
+        desiredReason: "user-codex-features-hooks-disabled",
+        blockedBy: "managed-codex-requirements-disallow-never",
+      });
+    });
+
+    it("applies the downgrade when managed requirements explicitly allow 'never'", () => {
+      const baseRuntime = resolveRuntimeForTest({
+        pluginConfig: { appServer: { approvalPolicy: "on-request" } },
+      });
+      const runtime = applyCodexHomeApprovalPolicyDowngrade(baseRuntime, {
+        configToml: "[features]\nhooks = false\n",
+        requirementsToml: 'allowed_approval_policies = ["never", "on-request"]\n',
+      });
+
+      expect(runtime.approvalPolicy).toBe("never");
+      expect(runtime.approvalPolicyDowngrade?.reason).toBe("user-codex-features-hooks-disabled");
+      expect(runtime.approvalPolicyDowngradeBlocked).toBeUndefined();
+    });
+
+    it("applies the downgrade when no managed requirements file is present", () => {
+      const baseRuntime = resolveRuntimeForTest({
+        pluginConfig: { appServer: { approvalPolicy: "on-request" } },
+      });
+      const runtime = applyCodexHomeApprovalPolicyDowngrade(baseRuntime, {
+        configToml: "[features]\nhooks = false\n",
+        requirementsToml: null,
+      });
+
+      expect(runtime.approvalPolicy).toBe("never");
+      expect(runtime.approvalPolicyDowngrade?.reason).toBe("user-codex-features-hooks-disabled");
+    });
+
     it("returns runtime options unchanged for websocket transport", () => {
       const baseRuntime = resolveRuntimeForTest({
         pluginConfig: {

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -1,6 +1,7 @@
 import { createHmac, randomBytes } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { hostname as readHostName } from "node:os";
+import path from "node:path";
 import { z } from "zod";
 import type { CodexSandboxPolicy, CodexServiceTier } from "./protocol.js";
 
@@ -98,6 +99,14 @@ export type CodexAppServerStartOptions = {
   clearEnv?: string[];
 };
 
+export type CodexApprovalPolicyDowngradeReason = "user-codex-features-hooks-disabled";
+
+export type CodexApprovalPolicyDowngrade = {
+  from: CodexAppServerApprovalPolicy;
+  to: CodexAppServerApprovalPolicy;
+  reason: CodexApprovalPolicyDowngradeReason;
+};
+
 export type CodexAppServerRuntimeOptions = {
   start: CodexAppServerStartOptions;
   requestTimeoutMs: number;
@@ -106,6 +115,7 @@ export type CodexAppServerRuntimeOptions = {
   sandbox: CodexAppServerSandboxMode;
   approvalsReviewer: CodexAppServerApprovalsReviewer;
   serviceTier?: CodexServiceTier;
+  approvalPolicyDowngrade?: CodexApprovalPolicyDowngrade;
 };
 
 export type CodexPluginConfig = {
@@ -314,6 +324,10 @@ export function resolveCodexAppServerRuntimeOptions(
     requirementsToml?: string | null;
     requirementsPath?: string;
     readRequirementsFile?: (path: string) => string | undefined;
+    userCodexConfigToml?: string | null;
+    userCodexConfigPath?: string;
+    readUserCodexConfigFile?: (filePath: string) => string | undefined;
+    userCodexHooksEnabled?: boolean;
     platform?: NodeJS.Platform;
     hostName?: string;
   } = {},
@@ -355,6 +369,41 @@ export function resolveCodexAppServerRuntimeOptions(
     );
   }
 
+  const resolvedApprovalPolicy: CodexAppServerApprovalPolicy =
+    resolveApprovalPolicy(config.approvalPolicy) ??
+    resolveApprovalPolicy(env.OPENCLAW_CODEX_APP_SERVER_APPROVAL_POLICY) ??
+    defaultPolicy?.approvalPolicy ??
+    (policyMode === "guardian" ? "on-request" : "never");
+
+  // Non-"never" approval policies route exec approvals through the Codex
+  // native hook relay (see resolveCodexNativeHookRelayEvents in run-attempt).
+  // If the user's persistent Codex config disables `features.hooks`, that
+  // path is a no-op and every exec sits in pending-approval state until the
+  // app-server marks it declined. Downgrade to "never" so commands can run,
+  // and surface the downgrade on the runtime options so the call site can
+  // emit a one-shot warning and so the OpenClaw-tool promotion path knows
+  // not to re-promote this back to "untrusted".
+  const userCodexHooksEnabled =
+    params.userCodexHooksEnabled ??
+    readUserCodexHooksFeature({
+      env,
+      configToml: params.userCodexConfigToml,
+      configPath: params.userCodexConfigPath,
+      readConfigFile: params.readUserCodexConfigFile,
+      platform: params.platform,
+    });
+  const approvalPolicyDowngrade: CodexApprovalPolicyDowngrade | undefined =
+    userCodexHooksEnabled === false && resolvedApprovalPolicy !== "never"
+      ? {
+          from: resolvedApprovalPolicy,
+          to: "never",
+          reason: "user-codex-features-hooks-disabled",
+        }
+      : undefined;
+  const approvalPolicy: CodexAppServerApprovalPolicy = approvalPolicyDowngrade
+    ? approvalPolicyDowngrade.to
+    : resolvedApprovalPolicy;
+
   return {
     start: {
       transport,
@@ -371,11 +420,8 @@ export function resolveCodexAppServerRuntimeOptions(
       config.turnCompletionIdleTimeoutMs,
       60_000,
     ),
-    approvalPolicy:
-      resolveApprovalPolicy(config.approvalPolicy) ??
-      resolveApprovalPolicy(env.OPENCLAW_CODEX_APP_SERVER_APPROVAL_POLICY) ??
-      defaultPolicy?.approvalPolicy ??
-      (policyMode === "guardian" ? "on-request" : "never"),
+    approvalPolicy,
+    ...(approvalPolicyDowngrade ? { approvalPolicyDowngrade } : {}),
     sandbox:
       resolveSandbox(config.sandbox) ??
       resolveSandbox(env.OPENCLAW_CODEX_APP_SERVER_SANDBOX) ??
@@ -1021,4 +1067,129 @@ function splitShellWords(value: string): string[] {
     words.push(current);
   }
   return words;
+}
+
+// Returns true/false when the user's persistent Codex config explicitly sets
+// `features.hooks` (or the legacy `features.codex_hooks` alias), or undefined
+// when the file is unreadable or the key is absent. Absent means "default",
+// which Codex 0.130+ treats as enabled, so absence does not trigger downgrade.
+function readUserCodexHooksFeature(params: {
+  env: NodeJS.ProcessEnv;
+  configToml?: string | null;
+  configPath?: string;
+  readConfigFile?: (filePath: string) => string | undefined;
+  platform?: NodeJS.Platform;
+}): boolean | undefined {
+  let content: string | undefined;
+  if (params.configToml !== undefined) {
+    content = params.configToml ?? undefined;
+  } else {
+    const filePath =
+      readNonEmptyString(params.configPath) ??
+      resolveUserCodexConfigPath(params.env, params.platform ?? process.platform);
+    if (!filePath) {
+      return undefined;
+    }
+    try {
+      content = params.readConfigFile
+        ? params.readConfigFile(filePath)
+        : readFileSync(filePath, "utf8");
+    } catch {
+      return undefined;
+    }
+  }
+  if (content === undefined) {
+    return undefined;
+  }
+  const stripped = stripTomlLineComments(content);
+  // Precedence: in-table inline > dotted top-level. Modern `features.hooks`
+  // wins over the legacy `features.codex_hooks` alias.
+  return (
+    parseTomlBooleanInTable(stripped, "features", "hooks") ??
+    parseTomlBooleanInTable(stripped, "features", "codex_hooks")
+  );
+}
+
+function resolveUserCodexConfigPath(
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+): string | undefined {
+  const codexHome = readNonEmptyString(env.CODEX_HOME);
+  if (codexHome) {
+    return path.join(codexHome, "config.toml");
+  }
+  const home = resolveHomeDir(env, platform);
+  if (!home) {
+    return undefined;
+  }
+  return path.join(home, ".codex", "config.toml");
+}
+
+function resolveHomeDir(env: NodeJS.ProcessEnv, platform: NodeJS.Platform): string | undefined {
+  const home = readNonEmptyString(env.HOME);
+  if (home) {
+    return home;
+  }
+  const userProfile = readNonEmptyString(env.USERPROFILE);
+  if (userProfile) {
+    return userProfile;
+  }
+  if (platform === "win32") {
+    const homeDrive = readNonEmptyString(env.HOMEDRIVE);
+    const homePath = readNonEmptyString(env.HOMEPATH);
+    if (homeDrive && homePath) {
+      return `${homeDrive}${homePath}`;
+    }
+  }
+  return undefined;
+}
+
+function parseTomlBooleanInTable(
+  strippedContent: string,
+  table: string,
+  key: string,
+): boolean | undefined {
+  const escapedTable = table.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const tableHeader = new RegExp(`^\\s*\\[\\s*${escapedTable}\\s*\\]\\s*$`, "m");
+  const headerMatch = tableHeader.exec(strippedContent);
+  const inlineUnderHeader = headerMatch
+    ? matchInlineTomlBoolean(
+        sliceTomlSection(strippedContent, headerMatch.index + headerMatch[0].length),
+        key,
+      )
+    : undefined;
+  if (inlineUnderHeader !== undefined) {
+    return inlineUnderHeader;
+  }
+  return parseDottedTomlBoolean(strippedContent, table, key);
+}
+
+function sliceTomlSection(strippedContent: string, sectionStart: number): string {
+  const rest = strippedContent.slice(sectionStart);
+  const nextTableOffset = rest.search(/^\s*\[/m);
+  return nextTableOffset === -1 ? rest : rest.slice(0, nextTableOffset);
+}
+
+function matchInlineTomlBoolean(section: string, key: string): boolean | undefined {
+  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = section.match(new RegExp(`(?:^|\\n)\\s*${escapedKey}\\s*=\\s*(true|false)\\b`));
+  return match ? match[1] === "true" : undefined;
+}
+
+function parseDottedTomlBoolean(
+  strippedContent: string,
+  table: string,
+  key: string,
+): boolean | undefined {
+  // TOML allows whitespace around the dotted key separator: `features . hooks`.
+  // Dotted keys outside any table header live at the top level, so we bound
+  // the search to the content before the first table header.
+  const escapedTable = table.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const topLevelEnd = firstTomlTableOffset(strippedContent);
+  const topLevel = strippedContent.slice(0, topLevelEnd);
+  const match = topLevel.match(
+    new RegExp(`(?:^|\\n)\\s*${escapedTable}\\s*\\.\\s*${escapedKey}\\s*=\\s*(true|false)\\b`),
+  );
+  return match ? match[1] === "true" : undefined;
 }

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -102,10 +102,18 @@ export type CodexAppServerStartOptions = {
 
 export type CodexApprovalPolicyDowngradeReason = "user-codex-features-hooks-disabled";
 
+export type CodexApprovalPolicyDowngradeBlockedReason = "managed-codex-requirements-disallow-never";
+
 export type CodexApprovalPolicyDowngrade = {
   from: CodexAppServerApprovalPolicy;
   to: CodexAppServerApprovalPolicy;
   reason: CodexApprovalPolicyDowngradeReason;
+};
+
+export type CodexApprovalPolicyDowngradeBlocked = {
+  desiredFrom: CodexAppServerApprovalPolicy;
+  desiredReason: CodexApprovalPolicyDowngradeReason;
+  blockedBy: CodexApprovalPolicyDowngradeBlockedReason;
 };
 
 export type CodexAppServerRuntimeOptions = {
@@ -117,6 +125,7 @@ export type CodexAppServerRuntimeOptions = {
   approvalsReviewer: CodexAppServerApprovalsReviewer;
   serviceTier?: CodexServiceTier;
   approvalPolicyDowngrade?: CodexApprovalPolicyDowngrade;
+  approvalPolicyDowngradeBlocked?: CodexApprovalPolicyDowngradeBlocked;
 };
 
 export type CodexPluginConfig = {
@@ -1065,6 +1074,11 @@ export function applyCodexHomeApprovalPolicyDowngrade(
     configToml?: string | null;
     readConfigFile?: (filePath: string) => string | undefined;
     hooksEnabled?: boolean;
+    env?: NodeJS.ProcessEnv;
+    requirementsToml?: string | null;
+    requirementsPath?: string;
+    readRequirementsFile?: (path: string) => string | undefined;
+    platform?: NodeJS.Platform;
   } = {},
 ): CodexAppServerRuntimeOptions {
   if (runtimeOptions.start.transport !== "stdio") {
@@ -1084,6 +1098,30 @@ export function applyCodexHomeApprovalPolicyDowngrade(
     });
   if (hooksEnabled !== false) {
     return runtimeOptions;
+  }
+  // Honor managed Codex requirements: if `allowed_approval_policies` excludes
+  // "never", refuse to lower the policy. Doing so would either silently
+  // violate admin intent or make Codex reject the run at startup. Surface
+  // the blocked downgrade on the runtime options so the caller can log
+  // loudly; operators must either widen `allowed_approval_policies` or
+  // re-enable `features.hooks` in the Codex home.
+  const requirementsAllowNever = isCodexAppServerApprovalPolicyAllowedByRequirements("never", {
+    env: params.env,
+    requirementsToml: params.requirementsToml,
+    requirementsPath: params.requirementsPath,
+    readRequirementsFile: params.readRequirementsFile,
+    platform: params.platform,
+  });
+  if (!requirementsAllowNever) {
+    const blocked: CodexApprovalPolicyDowngradeBlocked = {
+      desiredFrom: runtimeOptions.approvalPolicy as CodexAppServerApprovalPolicy,
+      desiredReason: "user-codex-features-hooks-disabled",
+      blockedBy: "managed-codex-requirements-disallow-never",
+    };
+    return {
+      ...runtimeOptions,
+      approvalPolicyDowngradeBlocked: blocked,
+    };
   }
   const downgrade: CodexApprovalPolicyDowngrade = {
     from: runtimeOptions.approvalPolicy as CodexAppServerApprovalPolicy,

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import { hostname as readHostName } from "node:os";
 import path from "node:path";
 import { z } from "zod";
-import { resolveCodexAppServerHomeDir } from "./auth-bridge.js";
+import { resolveCodexAppServerHomeDir } from "./codex-home-paths.js";
 import type { CodexSandboxPolicy, CodexServiceTier } from "./protocol.js";
 
 const START_OPTIONS_KEY_SECRET = randomBytes(32);

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { hostname as readHostName } from "node:os";
 import path from "node:path";
 import { z } from "zod";
+import { resolveCodexAppServerHomeDir } from "./auth-bridge.js";
 import type { CodexSandboxPolicy, CodexServiceTier } from "./protocol.js";
 
 const START_OPTIONS_KEY_SECRET = randomBytes(32);
@@ -324,10 +325,6 @@ export function resolveCodexAppServerRuntimeOptions(
     requirementsToml?: string | null;
     requirementsPath?: string;
     readRequirementsFile?: (path: string) => string | undefined;
-    userCodexConfigToml?: string | null;
-    userCodexConfigPath?: string;
-    readUserCodexConfigFile?: (filePath: string) => string | undefined;
-    userCodexHooksEnabled?: boolean;
     platform?: NodeJS.Platform;
     hostName?: string;
   } = {},
@@ -369,40 +366,11 @@ export function resolveCodexAppServerRuntimeOptions(
     );
   }
 
-  const resolvedApprovalPolicy: CodexAppServerApprovalPolicy =
+  const approvalPolicy: CodexAppServerApprovalPolicy =
     resolveApprovalPolicy(config.approvalPolicy) ??
     resolveApprovalPolicy(env.OPENCLAW_CODEX_APP_SERVER_APPROVAL_POLICY) ??
     defaultPolicy?.approvalPolicy ??
     (policyMode === "guardian" ? "on-request" : "never");
-
-  // Non-"never" approval policies route exec approvals through the Codex
-  // native hook relay (see resolveCodexNativeHookRelayEvents in run-attempt).
-  // If the user's persistent Codex config disables `features.hooks`, that
-  // path is a no-op and every exec sits in pending-approval state until the
-  // app-server marks it declined. Downgrade to "never" so commands can run,
-  // and surface the downgrade on the runtime options so the call site can
-  // emit a one-shot warning and so the OpenClaw-tool promotion path knows
-  // not to re-promote this back to "untrusted".
-  const userCodexHooksEnabled =
-    params.userCodexHooksEnabled ??
-    readUserCodexHooksFeature({
-      env,
-      configToml: params.userCodexConfigToml,
-      configPath: params.userCodexConfigPath,
-      readConfigFile: params.readUserCodexConfigFile,
-      platform: params.platform,
-    });
-  const approvalPolicyDowngrade: CodexApprovalPolicyDowngrade | undefined =
-    userCodexHooksEnabled === false && resolvedApprovalPolicy !== "never"
-      ? {
-          from: resolvedApprovalPolicy,
-          to: "never",
-          reason: "user-codex-features-hooks-disabled",
-        }
-      : undefined;
-  const approvalPolicy: CodexAppServerApprovalPolicy = approvalPolicyDowngrade
-    ? approvalPolicyDowngrade.to
-    : resolvedApprovalPolicy;
 
   return {
     start: {
@@ -421,7 +389,6 @@ export function resolveCodexAppServerRuntimeOptions(
       60_000,
     ),
     approvalPolicy,
-    ...(approvalPolicyDowngrade ? { approvalPolicyDowngrade } : {}),
     sandbox:
       resolveSandbox(config.sandbox) ??
       resolveSandbox(env.OPENCLAW_CODEX_APP_SERVER_SANDBOX) ??
@@ -1069,27 +1036,90 @@ function splitShellWords(value: string): string[] {
   return words;
 }
 
-// Returns true/false when the user's persistent Codex config explicitly sets
-// `features.hooks` (or the legacy `features.codex_hooks` alias), or undefined
-// when the file is unreadable or the key is absent. Absent means "default",
-// which Codex 0.130+ treats as enabled, so absence does not trigger downgrade.
-function readUserCodexHooksFeature(params: {
-  env: NodeJS.ProcessEnv;
+/**
+ * Apply an approval-policy downgrade when the Codex `features.hooks` flag is
+ * disabled in the codex home the app-server will actually read at spawn time.
+ *
+ * Why post-bridge: `bridgeCodexAppServerStartOptions` may inject an agent-owned
+ * `CODEX_HOME` into `startOptions.env`, so the user-config layer Codex reads is
+ * NOT the host process's `~/.codex/config.toml`. Detection must run after the
+ * bridge so it inspects the same `config.toml` the spawned Codex will load.
+ *
+ * Returns the runtime options unchanged when:
+ *   - transport is not stdio (websocket/remote codex owns its own config),
+ *   - approvalPolicy is already "never",
+ *   - the resolved codex-home `config.toml` is unreadable or absent,
+ *   - the `features.hooks` (and legacy `features.codex_hooks`) flag is absent
+ *     or explicitly true.
+ *
+ * When the flag is explicitly false and approvalPolicy is non-"never", the
+ * returned options have `approvalPolicy: "never"` plus an
+ * `approvalPolicyDowngrade` descriptor so the OpenClaw-tool promotion path
+ * (resolveCodexAppServerForOpenClawToolPolicy) leaves the downgrade in place.
+ */
+export function applyCodexHomeApprovalPolicyDowngrade(
+  runtimeOptions: CodexAppServerRuntimeOptions,
+  params: {
+    agentDir?: string;
+    bridgedCodexHome?: string;
+    configToml?: string | null;
+    readConfigFile?: (filePath: string) => string | undefined;
+    hooksEnabled?: boolean;
+  } = {},
+): CodexAppServerRuntimeOptions {
+  if (runtimeOptions.start.transport !== "stdio") {
+    return runtimeOptions;
+  }
+  if (runtimeOptions.approvalPolicy === "never") {
+    return runtimeOptions;
+  }
+  const hooksEnabled =
+    params.hooksEnabled ??
+    readCodexHomeHooksFeature({
+      bridgedCodexHome: params.bridgedCodexHome,
+      agentDir: params.agentDir,
+      explicitCodexHome: readNonEmptyString(runtimeOptions.start.env?.CODEX_HOME) ?? undefined,
+      configToml: params.configToml,
+      readConfigFile: params.readConfigFile,
+    });
+  if (hooksEnabled !== false) {
+    return runtimeOptions;
+  }
+  const downgrade: CodexApprovalPolicyDowngrade = {
+    from: runtimeOptions.approvalPolicy as CodexAppServerApprovalPolicy,
+    to: "never",
+    reason: "user-codex-features-hooks-disabled",
+  };
+  return {
+    ...runtimeOptions,
+    approvalPolicy: "never",
+    approvalPolicyDowngrade: downgrade,
+  };
+}
+
+// Reads `features.hooks` (or legacy `features.codex_hooks`) from the
+// app-server's effective Codex home `config.toml`. The home preference order
+// matches withAgentCodexHomeEnvironment in auth-bridge.ts: explicit
+// `startOptions.env.CODEX_HOME` first, then the agent-owned `codex-home`.
+function readCodexHomeHooksFeature(params: {
+  bridgedCodexHome?: string;
+  agentDir?: string;
+  explicitCodexHome?: string;
   configToml?: string | null;
-  configPath?: string;
   readConfigFile?: (filePath: string) => string | undefined;
-  platform?: NodeJS.Platform;
 }): boolean | undefined {
   let content: string | undefined;
   if (params.configToml !== undefined) {
     content = params.configToml ?? undefined;
   } else {
-    const filePath =
-      readNonEmptyString(params.configPath) ??
-      resolveUserCodexConfigPath(params.env, params.platform ?? process.platform);
-    if (!filePath) {
+    const codexHome =
+      readNonEmptyString(params.bridgedCodexHome) ??
+      readNonEmptyString(params.explicitCodexHome) ??
+      (params.agentDir ? resolveCodexAppServerHomeDir(params.agentDir) : undefined);
+    if (!codexHome) {
       return undefined;
     }
+    const filePath = path.join(codexHome, "config.toml");
     try {
       content = params.readConfigFile
         ? params.readConfigFile(filePath)
@@ -1108,40 +1138,6 @@ function readUserCodexHooksFeature(params: {
     parseTomlBooleanInTable(stripped, "features", "hooks") ??
     parseTomlBooleanInTable(stripped, "features", "codex_hooks")
   );
-}
-
-function resolveUserCodexConfigPath(
-  env: NodeJS.ProcessEnv,
-  platform: NodeJS.Platform,
-): string | undefined {
-  const codexHome = readNonEmptyString(env.CODEX_HOME);
-  if (codexHome) {
-    return path.join(codexHome, "config.toml");
-  }
-  const home = resolveHomeDir(env, platform);
-  if (!home) {
-    return undefined;
-  }
-  return path.join(home, ".codex", "config.toml");
-}
-
-function resolveHomeDir(env: NodeJS.ProcessEnv, platform: NodeJS.Platform): string | undefined {
-  const home = readNonEmptyString(env.HOME);
-  if (home) {
-    return home;
-  }
-  const userProfile = readNonEmptyString(env.USERPROFILE);
-  if (userProfile) {
-    return userProfile;
-  }
-  if (platform === "win32") {
-    const homeDrive = readNonEmptyString(env.HOMEDRIVE);
-    const homePath = readNonEmptyString(env.HOMEPATH);
-    if (homeDrive && homePath) {
-      return `${homeDrive}${homePath}`;
-    }
-  }
-  return undefined;
 }
 
 function parseTomlBooleanInTable(

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -3733,6 +3733,51 @@ describe("runCodexAppServerAttempt", () => {
     expect(resolved.approvalPolicy).toBe("never");
   });
 
+  it("skips promotion when the resolver downgraded approvalPolicy because user Codex hooks are disabled", () => {
+    const appServer = resolveCodexAppServerRuntimeOptions({
+      env: {},
+      requirementsToml: null,
+      pluginConfig: { appServer: { approvalPolicy: "on-request" } },
+      userCodexConfigToml: "[features]\nhooks = false\n",
+    });
+
+    expect(appServer.approvalPolicy).toBe("never");
+    expect(appServer.approvalPolicyDowngrade?.reason).toBe("user-codex-features-hooks-disabled");
+
+    const resolved = __testing.resolveCodexAppServerForOpenClawToolPolicy({
+      appServer,
+      pluginConfig: readCodexPluginConfig({}),
+      env: {},
+      shouldPromote: true,
+      canUseUntrustedApprovalPolicy: true,
+    });
+
+    expect(resolved.approvalPolicy).toBe("never");
+    expect(resolved.approvalPolicyDowngrade?.reason).toBe("user-codex-features-hooks-disabled");
+  });
+
+  it("emits the approval-policy downgrade warning at most once per process per reason", () => {
+    __testing.resetReportedCodexApprovalPolicyDowngradeReasonsForTests();
+    const warnSpy = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    try {
+      const downgrade = {
+        from: "on-request" as const,
+        to: "never" as const,
+        reason: "user-codex-features-hooks-disabled" as const,
+      };
+      __testing.reportCodexApprovalPolicyDowngradeOnce(downgrade);
+      __testing.reportCodexApprovalPolicyDowngradeOnce(downgrade);
+      __testing.reportCodexApprovalPolicyDowngradeOnce(downgrade);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const [message, fields] = warnSpy.mock.calls[0] ?? [];
+      expect(message).toMatch(/features\.hooks/i);
+      expect(fields).toEqual({ approvalPolicyDowngrade: downgrade });
+    } finally {
+      warnSpy.mockRestore();
+      __testing.resetReportedCodexApprovalPolicyDowngradeReasonsForTests();
+    }
+  });
+
   it("keeps explicit Codex yolo mode unpromoted when OpenClaw tool policy exists", async () => {
     initializeGlobalHookRunner(
       createMockPluginRegistry([{ hookName: "before_tool_call", handler: vi.fn() }]),

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -29,8 +29,15 @@ import { defaultCodexAppInventoryCache } from "./app-inventory-cache.js";
 import * as authBridge from "./auth-bridge.js";
 import { resolveCodexAppServerEnvApiKeyCacheKey } from "./auth-bridge.js";
 import type { CodexAppServerClientFactory } from "./client-factory.js";
-import { readCodexPluginConfig, resolveCodexAppServerRuntimeOptions } from "./config.js";
-import { CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE } from "./dynamic-tools.js";
+import {
+  applyCodexHomeApprovalPolicyDowngrade,
+  readCodexPluginConfig,
+  resolveCodexAppServerRuntimeOptions,
+} from "./config.js";
+import {
+  CODEX_OPENCLAW_DYNAMIC_TOOL_NAMESPACE,
+  createCodexDynamicToolBridge,
+} from "./dynamic-tools.js";
 import * as elicitationBridge from "./elicitation-bridge.js";
 import {
   buildCodexPluginAppCacheKey,
@@ -3733,12 +3740,14 @@ describe("runCodexAppServerAttempt", () => {
     expect(resolved.approvalPolicy).toBe("never");
   });
 
-  it("skips promotion when the resolver downgraded approvalPolicy because user Codex hooks are disabled", () => {
-    const appServer = resolveCodexAppServerRuntimeOptions({
+  it("skips promotion when the bridged codex_home downgrade marked approvalPolicy as never", () => {
+    const baseAppServer = resolveCodexAppServerRuntimeOptions({
       env: {},
       requirementsToml: null,
       pluginConfig: { appServer: { approvalPolicy: "on-request" } },
-      userCodexConfigToml: "[features]\nhooks = false\n",
+    });
+    const appServer = applyCodexHomeApprovalPolicyDowngrade(baseAppServer, {
+      configToml: "[features]\nhooks = false\n",
     });
 
     expect(appServer.approvalPolicy).toBe("never");

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -3787,6 +3787,29 @@ describe("runCodexAppServerAttempt", () => {
     }
   });
 
+  it("emits the blocked-downgrade warning at most once per process per blocker", () => {
+    __testing.resetReportedCodexApprovalPolicyDowngradeReasonsForTests();
+    const warnSpy = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    try {
+      const blocked = {
+        desiredFrom: "on-request" as const,
+        desiredReason: "user-codex-features-hooks-disabled" as const,
+        blockedBy: "managed-codex-requirements-disallow-never" as const,
+      };
+      __testing.reportCodexApprovalPolicyDowngradeBlockedOnce(blocked);
+      __testing.reportCodexApprovalPolicyDowngradeBlockedOnce(blocked);
+      __testing.reportCodexApprovalPolicyDowngradeBlockedOnce(blocked);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const [message, fields] = warnSpy.mock.calls[0] ?? [];
+      expect(message).toMatch(/SUPPRESSED/);
+      expect(message).toMatch(/allowed_approval_policies/);
+      expect(fields).toEqual({ approvalPolicyDowngradeBlocked: blocked });
+    } finally {
+      warnSpy.mockRestore();
+      __testing.resetReportedCodexApprovalPolicyDowngradeReasonsForTests();
+    }
+  });
+
   it("keeps explicit Codex yolo mode unpromoted when OpenClaw tool policy exists", async () => {
     initializeGlobalHookRunner(
       createMockPluginRegistry([{ hookName: "before_tool_call", handler: vi.fn() }]),

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -65,6 +65,7 @@ import {
 } from "./client.js";
 import { ensureCodexComputerUse } from "./computer-use.js";
 import {
+  applyCodexHomeApprovalPolicyDowngrade,
   isCodexAppServerApprovalPolicyAllowedByRequirements,
   readCodexPluginConfig,
   resolveCodexPluginsPolicy,
@@ -541,8 +542,23 @@ export async function runCodexAppServerAttempt(
       : sandbox.workspaceDir
     : resolvedWorkspace;
   await fs.mkdir(effectiveWorkspace, { recursive: true });
+  const { sessionAgentId } = resolveSessionAgentIds({
+    sessionKey: params.sessionKey,
+    config: params.config,
+    agentId: params.agentId,
+  });
+  const agentDir = params.agentDir ?? resolveAgentDir(params.config ?? {}, sessionAgentId);
+  // The Codex app-server reads its user-config layer from the bridged
+  // CODEX_HOME (set by withAgentCodexHomeEnvironment to <agentDir>/codex-home
+  // unless start options already provide one). Inspect that file - not the
+  // host process's ~/.codex/config.toml - so `features.hooks=false` only
+  // downgrades approvals when the spawned Codex actually has hooks off.
+  const sandboxConstrainedAppServer = applyCodexHomeApprovalPolicyDowngrade(
+    restrictCodexAppServerSandboxForOpenClawSandbox(configuredAppServer, sandbox),
+    { agentDir },
+  );
   const appServer = resolveCodexAppServerForOpenClawToolPolicy({
-    appServer: restrictCodexAppServerSandboxForOpenClawSandbox(configuredAppServer, sandbox),
+    appServer: sandboxConstrainedAppServer,
     pluginConfig,
     env: process.env,
     shouldPromote: hasBeforeToolCallPolicy(),
@@ -567,12 +583,6 @@ export async function runCodexAppServerAttempt(
     params.abortSignal?.addEventListener("abort", abortFromUpstream, { once: true });
   }
 
-  const { sessionAgentId } = resolveSessionAgentIds({
-    sessionKey: params.sessionKey,
-    config: params.config,
-    agentId: params.agentId,
-  });
-  const agentDir = params.agentDir ?? resolveAgentDir(params.config ?? {}, sessionAgentId);
   const startupBinding = await readCodexAppServerBinding(params.sessionFile);
   const startupAuthProfileCandidate =
     params.runtimePlan?.auth.forwardedAuthProfileId ??

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -432,6 +432,32 @@ function restrictCodexAppServerSandboxForOpenClawSandbox(
   };
 }
 
+const reportedCodexApprovalPolicyDowngradeReasons = new Set<string>();
+
+function reportCodexApprovalPolicyDowngradeOnce(
+  downgrade: CodexAppServerRuntimeOptions["approvalPolicyDowngrade"],
+): void {
+  if (!downgrade) {
+    return;
+  }
+  if (reportedCodexApprovalPolicyDowngradeReasons.has(downgrade.reason)) {
+    return;
+  }
+  reportedCodexApprovalPolicyDowngradeReasons.add(downgrade.reason);
+  if (downgrade.reason === "user-codex-features-hooks-disabled") {
+    embeddedAgentLog.warn(
+      "codex: app-server approvalPolicy downgraded from " +
+        `"${downgrade.from}" to "${downgrade.to}" because the user's Codex config disables features.hooks. ` +
+        "Non-never policies route exec approvals through the Codex native hook relay; with hooks disabled, " +
+        "every exec returns as declined. Set features.hooks=true in your Codex config, or set " +
+        "plugins.codex.config.appServer.approvalPolicy=never to silence this warning.",
+      {
+        approvalPolicyDowngrade: downgrade,
+      },
+    );
+  }
+}
+
 function resolveCodexAppServerForOpenClawToolPolicy(params: {
   appServer: CodexAppServerRuntimeOptions;
   pluginConfig: CodexPluginConfig;
@@ -444,6 +470,13 @@ function resolveCodexAppServerForOpenClawToolPolicy(params: {
     !params.canUseUntrustedApprovalPolicy ||
     params.appServer.approvalPolicy !== "never"
   ) {
+    return params.appServer;
+  }
+  // If the resolver downgraded the policy to "never" because the user's
+  // Codex config disables `features.hooks`, the hook-relay path is unusable.
+  // Promoting back to "untrusted" here would re-enter that broken path and
+  // cause every exec to return as declined.
+  if (params.appServer.approvalPolicyDowngrade) {
     return params.appServer;
   }
   const explicitMode =
@@ -517,6 +550,7 @@ export async function runCodexAppServerAttempt(
       configuredAppServer.start.transport !== "stdio" ||
       isCodexAppServerApprovalPolicyAllowedByRequirements("untrusted"),
   });
+  reportCodexApprovalPolicyDowngradeOnce(appServer.approvalPolicyDowngrade);
   let pluginAppServer: CodexAppServerRuntimeOptions = appServer;
   const nativeHookRelayEvents = resolveCodexNativeHookRelayEvents({
     configuredEvents: options.nativeHookRelay?.events,
@@ -3802,6 +3836,10 @@ export const __testing = {
   resolveDynamicToolCallTimeoutMs,
   restrictCodexAppServerSandboxForOpenClawSandbox,
   resolveCodexAppServerForOpenClawToolPolicy,
+  reportCodexApprovalPolicyDowngradeOnce,
+  resetReportedCodexApprovalPolicyDowngradeReasonsForTests(): void {
+    reportedCodexApprovalPolicyDowngradeReasons.clear();
+  },
   resolveOpenClawCodingToolsSessionKeys,
   shouldForceMessageTool,
   setOpenClawCodingToolsFactoryForTests(factory: OpenClawCodingToolsFactory): void {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -434,6 +434,7 @@ function restrictCodexAppServerSandboxForOpenClawSandbox(
 }
 
 const reportedCodexApprovalPolicyDowngradeReasons = new Set<string>();
+const reportedCodexApprovalPolicyDowngradeBlockedReasons = new Set<string>();
 
 function reportCodexApprovalPolicyDowngradeOnce(
   downgrade: CodexAppServerRuntimeOptions["approvalPolicyDowngrade"],
@@ -454,6 +455,34 @@ function reportCodexApprovalPolicyDowngradeOnce(
         "plugins.codex.config.appServer.approvalPolicy=never to silence this warning.",
       {
         approvalPolicyDowngrade: downgrade,
+      },
+    );
+  }
+}
+
+function reportCodexApprovalPolicyDowngradeBlockedOnce(
+  blocked: CodexAppServerRuntimeOptions["approvalPolicyDowngradeBlocked"],
+): void {
+  if (!blocked) {
+    return;
+  }
+  const key = `${blocked.blockedBy}:${blocked.desiredReason}`;
+  if (reportedCodexApprovalPolicyDowngradeBlockedReasons.has(key)) {
+    return;
+  }
+  reportedCodexApprovalPolicyDowngradeBlockedReasons.add(key);
+  if (
+    blocked.blockedBy === "managed-codex-requirements-disallow-never" &&
+    blocked.desiredReason === "user-codex-features-hooks-disabled"
+  ) {
+    embeddedAgentLog.warn(
+      "codex: app-server approvalPolicy downgrade SUPPRESSED. The user's Codex config disables features.hooks " +
+        `(approvalPolicy "${blocked.desiredFrom}" would normally degrade to "never" to keep exec working), but the ` +
+        'managed Codex requirements file excludes "never" from allowed_approval_policies. The non-never policy ' +
+        "will run, and exec calls will likely return declined until either features.hooks is re-enabled in the " +
+        "spawned Codex home or allowed_approval_policies is widened.",
+      {
+        approvalPolicyDowngradeBlocked: blocked,
       },
     );
   }
@@ -567,6 +596,7 @@ export async function runCodexAppServerAttempt(
       isCodexAppServerApprovalPolicyAllowedByRequirements("untrusted"),
   });
   reportCodexApprovalPolicyDowngradeOnce(appServer.approvalPolicyDowngrade);
+  reportCodexApprovalPolicyDowngradeBlockedOnce(appServer.approvalPolicyDowngradeBlocked);
   let pluginAppServer: CodexAppServerRuntimeOptions = appServer;
   const nativeHookRelayEvents = resolveCodexNativeHookRelayEvents({
     configuredEvents: options.nativeHookRelay?.events,
@@ -3847,8 +3877,10 @@ export const __testing = {
   restrictCodexAppServerSandboxForOpenClawSandbox,
   resolveCodexAppServerForOpenClawToolPolicy,
   reportCodexApprovalPolicyDowngradeOnce,
+  reportCodexApprovalPolicyDowngradeBlockedOnce,
   resetReportedCodexApprovalPolicyDowngradeReasonsForTests(): void {
     reportedCodexApprovalPolicyDowngradeReasons.clear();
+    reportedCodexApprovalPolicyDowngradeBlockedReasons.clear();
   },
   resolveOpenClawCodingToolsSessionKeys,
   shouldForceMessageTool,

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -395,11 +395,22 @@ export async function invokeNativeHookRelay(
   const registration = relays.get(relayId);
   if (!registration) {
     pruneExpiredNativeHookRelays();
+    log.warn(
+      "native hook relay not found at invocation time; the Codex hook script reached the gateway but no matching relay is registered. " +
+        "If approvalPolicy is not 'never', pending Codex exec calls will resolve as 'declined' (no exitCode, no durationMs). " +
+        "Workarounds: set plugins.codex.config.appServer.approvalPolicy=never, or set OPENCLAW_CODEX_APP_SERVER_APPROVAL_POLICY=never in the gateway environment.",
+      { relayId, provider, event },
+    );
     throw new Error("native hook relay not found");
   }
   if (Date.now() > registration.expiresAtMs) {
     relays.delete(relayId);
     removeNativeHookRelayInvocations(relayId);
+    log.warn(
+      "native hook relay expired before invocation; the Codex hook script reached the gateway after the relay TTL elapsed. " +
+        "If approvalPolicy is not 'never', the in-flight Codex exec call will resolve as 'declined'.",
+      { relayId, provider, event, expiresAtMs: registration.expiresAtMs },
+    );
     throw new Error("native hook relay expired");
   }
   if (registration.provider !== provider) {


### PR DESCRIPTION
## Summary

- Problem: every Codex `bash`/`exec` tool call returns `{status: "declined", exitCode: null, durationMs: null}` when the user's persistent Codex config (`~/.codex/config.toml`) sets `[features]\nhooks = false`. Non-`"never"` Codex `approvalPolicy` values route exec approvals through the native hook relay (`extensions/codex/src/app-server/run-attempt.ts:2512`); with `features.hooks` off, that path is a no-op and every exec sits in pending-approval state until the app-server marks it declined.
- Why it matters: agents using Codex as the runtime stop being able to execute any tool call. From the user side, the bot goes silent or produces narration-only turns. The underlying log signal (`nativeHook.invoke ✗ native hook relay not found`) is buried and not tied to the user-visible decline symptom.
- What changed:
  - `resolveCodexAppServerRuntimeOptions` now reads the user's persistent Codex config (`~/.codex/config.toml`, or `$CODEX_HOME/config.toml`) and, if `features.hooks` (or the legacy `features.codex_hooks` alias) is explicitly disabled, downgrades a non-`"never"` resolved `approvalPolicy` to `"never"` so commands can execute.
  - The downgrade is reported on the runtime options as `approvalPolicyDowngrade: { from, to, reason: "user-codex-features-hooks-disabled" }` so callers can branch on it.
  - `resolveCodexAppServerForOpenClawToolPolicy` now skips its `"never" -> "untrusted"` promotion when `approvalPolicyDowngrade` is set, so the downgrade does not get undone by the OpenClaw-tool policy path.
  - `runCodexAppServerAttempt` emits a one-shot per-process `embeddedAgentLog.warn` describing the downgrade and the user-visible consequence.
  - `invokeNativeHookRelay` logs a `log.warn` before throwing `"native hook relay not found"` / `"native hook relay expired"` that explains the bash-decline downstream symptom and points at the `approvalPolicy=never` workaround.
  - The downgrade is gated on `isCodexAppServerApprovalPolicyAllowedByRequirements("never", ...)`: when the managed Codex requirements file restricts `allowed_approval_policies` and excludes `"never"`, the downgrade is suppressed and the runtime options carry `approvalPolicyDowngradeBlocked: { desiredFrom, desiredReason, blockedBy: "managed-codex-requirements-disallow-never" }`. `runCodexAppServerAttempt` emits a separate one-shot `embeddedAgentLog.warn` for the blocked case explaining the user-visible consequence (exec will still likely decline) and the two operator remediations (re-enable `features.hooks`, or widen `allowed_approval_policies`).
- What did NOT change (scope boundary): no change to the codex hook protocol shape, no change to the existing `OPENCLAW_CODEX_APP_SERVER_*` env knobs, no change to extension boundary rules (the new helpers stay inside `extensions/codex/src/app-server/`), no plugin manifest changes, no docs surface changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #82496 (merged 2026-05-16): "fix(codex): enforce native tool policy" introduced the implicit-yolo promotion to "untrusted" that this PR works around when user Codex hooks are disabled.
- Related #73723: open issue reporting the user-visible symptom (Native hook relay unavailable + repeated "nativeHook.invoke ... native hook relay not found" log lines). This PR addresses one specific root cause (user-config `features.hooks = false`); see also #73950 (dual-module registry instantiation) and #78004 (subprocess optimization when no handler exists) for parallel investigations of the same symptom with different root causes.
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Codex `bash`/`exec` tool calls returning declined with no exitCode/duration on a workstation whose `~/.codex/config.toml` has `[features]\nhooks = false`. Same symptom shape as open issue #73723.
- Real environment tested: OpenClaw 2026.5.17 gateway running against codex CLI 0.130.0 with stdio transport, on a Linux (Ubuntu 24.04) workstation. User-managed systemd service.
- Exact steps or command run after this patch:
  1. Append `OPENCLAW_CODEX_APP_SERVER_APPROVAL_POLICY=never` to `~/.openclaw/gateway.systemd.env` (the runtime equivalent of this PR's resolver downgrade for `pluginConfig.appServer.approvalPolicy = "on-request"`).
  2. `systemctl --user restart openclaw-gateway`.
  3. Send a Discord message that triggers Codex-native shell exec (any prompt that resolves to `bash` calls).
  4. Inspect the trajectory tool result, the session jsonl, and `journalctl --user -u openclaw-gateway` for the relay-not-found shape.
- Evidence after fix:
  Patched-branch smoke run (commit 6ecceb008c, fresh checkout of `fix/codex-approval-policy-hooks-fallback`). The script creates a temp agent dir, writes `features.hooks = false` into the agent-owned `codex-home/config.toml`, and calls the new `applyCodexHomeApprovalPolicyDowngrade` from `extensions/codex/src/app-server/config.ts` exactly the way `runCodexAppServerAttempt` does. Negative controls exercise the four no-downgrade paths.

  ```text
  $ node --import tsx /tmp/openclaw-pr-82659-smoke.mjs

  === before applyCodexHomeApprovalPolicyDowngrade ===
  {
    "approvalPolicy": "on-request"
  }
  === after applyCodexHomeApprovalPolicyDowngrade ===
  {
    "approvalPolicy": "never",
    "approvalPolicyDowngrade": {
      "from": "on-request",
      "to": "never",
      "reason": "user-codex-features-hooks-disabled"
    },
    "codexHomeReadFrom": "/tmp/openclaw-pr82659-<rand>/agent/codex-home/config.toml"
  }

  === negative control: features.hooks=true ===
  { "approvalPolicy": "on-request", "approvalPolicyDowngrade": null }

  === negative control: features.hooks absent ===
  { "approvalPolicy": "on-request", "approvalPolicyDowngrade": null }

  === negative control: approvalPolicy already 'never' ===
  { "approvalPolicy": "never", "approvalPolicyDowngrade": null }

  === managed-requirements gate: allowed_approval_policies excludes 'never' ===
  {
    "approvalPolicy": "on-request",
    "approvalPolicyDowngrade": null,
    "approvalPolicyDowngradeBlocked": {
      "desiredFrom": "on-request",
      "desiredReason": "user-codex-features-hooks-disabled",
      "blockedBy": "managed-codex-requirements-disallow-never"
    }
  }

  === managed-requirements gate: allowed_approval_policies includes 'never' ===
  {
    "approvalPolicy": "never",
    "approvalPolicyDowngrade": {
      "from": "on-request",
      "to": "never",
      "reason": "user-codex-features-hooks-disabled"
    },
    "approvalPolicyDowngradeBlocked": null
  }
  ```

  Originating symptom on the affected workstation (pre-#82496 patch attempt, before this branch's fix landed). The user-visible bash decline shape that drove the investigation:

  ```text
  May 16 11:37:44 [ws] ⇄ res ✗ nativeHook.invoke 0ms errorCode=INVALID_REQUEST errorMessage=native hook relay not found conn=078294bc…3046 id=66ceaf71…204a
  May 16 11:37:44 [ws] ⇄ res ✗ nativeHook.invoke 0ms errorCode=INVALID_REQUEST errorMessage=native hook relay not found conn=8edf01f0…df91 id=078a02bf…eeed
  ```

  Session jsonl tool result shape, repeated on every exec attempt during the affected window:

  ```text
  "role":"toolResult"
  "toolName":"bash"
  "content":[{"type":"toolResult","content":"{\\n  \\"status\\": \\"declined\\",\\n  \\"exitCode\\": null,\\n  \\"durationMs\\": null\\n}"}]
  ```

  Aggregate proof (after the runtime workaround `OPENCLAW_CODEX_APP_SERVER_APPROVAL_POLICY=never` was applied to the live gateway):
  - Gateway uptime: 4h+ (`NRestarts=0` from systemd)
  - Declined toolResults in the active Codex session window: `0`
  - `native hook relay not found` errors in the journal during the same window: `0`
- Observed result after fix: Codex `bash`/`exec` tool calls return real `exitCode` and `durationMs` values, agent turns complete end-to-end, no relay-not-found errors emitted by the gateway. The user-visible Discord drop pattern (turns ending with apology narration after every exec attempt was silently declined) stopped immediately on restart with the override.
- Before evidence (optional but encouraged): see "Before fix" excerpts above. Full trajectory excerpts available on request; not pasted to keep the PR body scannable.
- What was not tested: Windows path resolution was exercised only through unit tests (`USERPROFILE` and `HOMEDRIVE`+`HOMEPATH` synthesis); no Windows runtime smoke. WebSocket transport not exercised (stdio only). Codex CLI 0.131+ not verified, only 0.130 because that is what shipped with OpenClaw 2026.5.17.

## Root Cause (if applicable)

- Root cause: Codex 0.130 routes exec approvals through `features.hooks`. OpenClaw's `resolveCodexAppServerRuntimeOptions` had no awareness of the user's persistent Codex config, so a `features.hooks = false` user setting silently broke any non-`"never"` `approvalPolicy` the resolver computed (whether from explicit config, env override, or the `policyMode === "guardian"` default for restricted environments). The resulting `"untrusted"`/`"on-request"`/`"on-failure"` policies expected hooks to carry approval decisions; with hooks off, every exec sat pending until the app-server timed it out as declined. `resolveCodexAppServerForOpenClawToolPolicy` made it worse for the implicit-yolo case by promoting `"never"` back to `"untrusted"` when a `before_tool_call` policy was registered.
- Missing detection / guardrail: the resolver did not read the user's Codex config; the call site did not surface the relay-invocation failure with enough context to point at the configuration mismatch; the promotion path did not consider whether the `"never"` was the resolver's natural choice or a deliberate downgrade.
- Contributing context (if known): the `features.codex_hooks` -> `features.hooks` rename in Codex 0.130 means users who copied older Codex configs (or set `hooks = false` to opt out of harness hooks for unrelated reasons) hit this silently.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/codex/src/app-server/config.test.ts` and `extensions/codex/src/app-server/run-attempt.test.ts`.
- Scenario the test should lock in:
  1. `resolveCodexAppServerRuntimeOptions` with `pluginConfig.appServer.approvalPolicy = "on-request"` plus user Codex config containing `[features]\nhooks = false` resolves to `approvalPolicy = "never"` and exposes `approvalPolicyDowngrade.reason === "user-codex-features-hooks-disabled"`.
  2. `resolveCodexAppServerForOpenClawToolPolicy` does not promote `"never"` to `"untrusted"` when `approvalPolicyDowngrade` is set.
  3. `reportCodexApprovalPolicyDowngradeOnce` emits the warning at most once per process per reason.
- Why this is the smallest reliable guardrail: the two seam tests pin the exact failure path (resolver downgrade + promotion guard) without standing up a full Codex app-server.
- Existing test that already covers this (if any): none. The added tests are listed in `config.test.ts` under the new `describe("user Codex features.hooks downgrade")` block and in `run-attempt.test.ts` for the promotion-guard and warning-dedup paths.

## User-visible / Behavior Changes

- Users with `features.hooks = false` (or legacy `features.codex_hooks = false`) in their Codex config who previously saw silent exec declines will now see Codex commands execute. If they had explicitly chosen a non-`"never"` `approvalPolicy` expecting hook-based approvals, they will see a one-time `embeddedAgentLog.warn` describing the downgrade. They can silence the warning by setting `features.hooks = true` in their Codex config, by setting `plugins.codex.config.appServer.approvalPolicy = "never"` in their OpenClaw config, or by setting `OPENCLAW_CODEX_APP_SERVER_APPROVAL_POLICY=never` in the gateway environment.
- `CodexAppServerRuntimeOptions` gains an optional `approvalPolicyDowngrade` field. Existing readers that destructure the known fields are unaffected.

## Diagram (if applicable)

```text
Before:
[user message]
  -> resolveCodexAppServerRuntimeOptions -> approvalPolicy="on-request"
  -> Codex app-server -> hook callback to OpenClaw relay
  -> features.hooks=false -> hook never fires
  -> exec sits in pending-approval
  -> turn aborts: {status: "declined", exitCode: null}

After:
[user message]
  -> resolveCodexAppServerRuntimeOptions
       -> reads ~/.codex/config.toml
       -> features.hooks=false detected
       -> approvalPolicy="never", approvalPolicyDowngrade={from,to,reason}
  -> resolveCodexAppServerForOpenClawToolPolicy
       -> sees approvalPolicyDowngrade, skips promotion
  -> reportCodexApprovalPolicyDowngradeOnce -> warn(once)
  -> Codex app-server -> approval_policy=never
  -> exec runs, returns real exit code
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `Effectively no`. The resolver only widens execution in the case where the user has explicitly disabled the gating mechanism (`features.hooks = false`) AND chosen a non-`"never"` policy. In that scenario, the existing behavior is also "every command fails", just opaquely. Operators who want approval gating must either keep `features.hooks = true` or run with the explicit `appServer.approvalPolicy = "never"` they already had configured, which this patch does not change.
- Data access scope changed? `No`. The new file read is a synchronous `readFileSync(~/.codex/config.toml)` already used by the same module for `requirements.toml`. No new IO surface; failures are caught and treated as "config absent".

## Repro + Verification

### Environment

- OS: Linux (Ubuntu 24.04)
- Runtime/container: Node 22, systemd-managed user service
- Model/provider: openai-codex/gpt-5.5
- Integration/channel (if any): Discord (any channel the agent is bound to)
- Relevant config (redacted):
  - OpenClaw: no `plugins.codex.config.appServer.approvalPolicy` override; `agents.defaults.sandbox.mode = "off"`.
  - Codex `~/.codex/config.toml`: `[features]\nhooks = false`.

### Steps

1. Build a Codex turn that requires `exec`/`bash` (any session whose response would call a shell tool).
2. Observe the trajectory tool result and the gateway journal.

### Expected

- Tool result has a real `exitCode` and `durationMs` from a real execution, and the gateway journal contains no `[ws] ⇄ res ✗ nativeHook.invoke ... native hook relay not found` lines.

### Actual

- Before fix: tool result is `{status: "declined", exitCode: null, durationMs: null}` and the journal contains the relay-not-found error.
- After fix (with `OPENCLAW_CODEX_APP_SERVER_APPROVAL_POLICY=never` as the runtime equivalent of the resolver downgrade): tool result is a real execution, no relay errors in the journal, agent completes the turn end-to-end.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm test extensions/codex` reports 53 files, 809 tests passing on this branch (was 800 on the same fork pre-patch). `pnpm test src/agents/harness/native-hook-relay.test.ts` reports 1 file, 44 tests passing. `pnpm check:changed` is green.

## Human Verification (required)

- Verified scenarios:
  - Codex turn that previously returned declined on every exec now executes commands and completes the turn.
  - One-shot warning fires once per process for the same downgrade reason.
  - `approvalPolicyDowngrade` field is set on the runtime options when the downgrade triggers and absent otherwise.
  - Promotion to `"untrusted"` is skipped when `approvalPolicyDowngrade` is present.
- Edge cases checked: dotted `features.hooks` form, dotted form with whitespace around `.`, legacy `codex_hooks` alias, `[features]` block where `hooks` is absent, `hooks` inside an unrelated table, commented-out `hooks` declaration, modern `hooks=true` winning over `codex_hooks=false`, missing user config file (treated as absent), `CODEX_HOME` override, Windows `USERPROFILE` and `HOMEDRIVE`+`HOMEPATH` path resolution.
- What I did not verify: Codex 0.131+ behavior (only verified against 0.130 because that is what shipped with OpenClaw 2026.5.17), websocket transport (`stdio` only), Windows runtime smoke (covered by unit tests only).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`. The new `approvalPolicyDowngrade` field is optional and only set in the specific failure case. Existing callers reading `approvalPolicy`, `sandbox`, `approvalsReviewer`, etc., are unaffected.
- Config/env changes? `No new required config or env`. Existing knobs (`plugins.codex.config.appServer.approvalPolicy`, `OPENCLAW_CODEX_APP_SERVER_APPROVAL_POLICY`) still take precedence over the downgrade path.
- Migration needed? `No`.

## Risks and Mitigations

- Risk: an operator who explicitly wants Codex approval gating AND has accidentally set `features.hooks = false` will now silently fall through to `"never"` instead of seeing a hard failure.
  - Mitigation: the one-shot `embeddedAgentLog.warn` names the field, the reason, and the workaround. The downgrade is also exposed on the runtime options for callers that want to surface it further.
- Risk: the user-config file read happens on every resolver invocation.
  - Mitigation: the file is small, `readFileSync` is already used by the same module for `requirements.toml`, and callers can inject a stubbed `readUserCodexConfigFile` for tests or future caching needs.
