### PR TITLE
[Fix] Queue startup restart signals during gateway startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Docs: https://docs.openclaw.ai
 - Codex app-server: mark native context compaction completion events as successful, preventing false "Compaction incomplete" notices after successful Codex-managed compaction. Fixes #82470. (#81593) Thanks @Kyzcreig.
 - Codex app-server: keep long-running turns alive while current-turn approvals, user input, dynamic tools, and notifications make progress, and carry that progress into the outer run timeout. (#82601) Thanks @100yenadmin.
 - Gateway/channels: hand off traced channel account startup outside the startup diagnostic phase so long-lived channel tasks do not keep liveness warnings pinned to channel startup. Refs #82398.
+- Gateway/restart: queue restart and shutdown signals received while the gateway startup loop is still returning its server handle, so startup-time restarts are not dropped during update churn. (#82660) Thanks @samzong.
 - GitHub Copilot: route device-login requests through the plugin SSRF guard with a GitHub-only policy.
 - Group/channel replies: keep message-tool-preferred final replies private when the agent misses the message tool, and log suppressed payload metadata in the gateway debug log for quieter diagnosis.
 - Gateway/WebChat: route image attachments through a configured vision-capable `imageModel` plan before inlining images, and carry that image-model fallback chain through runtime retries. (#82524) Thanks @frankekn.

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -280,6 +280,17 @@ async function waitForStart(started: Promise<void>) {
   await new Promise<void>((resolve) => setImmediate(resolve));
 }
 
+async function waitForLoopCondition(predicate: () => boolean, message: string) {
+  const deadline = Date.now() + 1_000;
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+  throw new Error(message);
+}
+
 async function createSignaledLoopHarness(exitCallOrder?: string[]) {
   const close = vi.fn(async () => {});
   const { start, started } = createSignaledStart(close);
@@ -592,6 +603,282 @@ describe("runGatewayLoop", () => {
         reason: "gateway stopping",
         restartExpectedMs: null,
       });
+    });
+  });
+
+  it("queues SIGUSR1 received before the run-loop installs its restart waiter", async () => {
+    vi.clearAllMocks();
+    peekGatewaySigusr1RestartReason.mockReturnValue(undefined);
+    respawnGatewayProcessForUpdate.mockReturnValue({
+      mode: "disabled",
+      detail: "OPENCLAW_NO_RESPAWN",
+    });
+
+    await withIsolatedSignals(async ({ captureSignal }) => {
+      const closeFirst = vi.fn(async () => {});
+      const closeSecond = vi.fn(async () => {});
+      const { runtime, exited } = createRuntimeWithExitSignal();
+      let releaseFirstStart!: () => void;
+      const firstStartMayReturn = new Promise<void>((resolve) => {
+        releaseFirstStart = resolve;
+      });
+      let sigusr1: (() => void) | null = null;
+      let resolveSecondStart: (() => void) | null = null;
+      const startedSecond = new Promise<void>((resolve) => {
+        resolveSecondStart = resolve;
+      });
+      const start = vi.fn();
+      start.mockImplementationOnce(async () => {
+        await firstStartMayReturn;
+        sigusr1?.();
+        await waitForLoopCondition(
+          () => markGatewaySigusr1RestartHandled.mock.calls.length > 0,
+          "expected SIGUSR1 handler to consume the restart before startup returned",
+        );
+        return { close: closeFirst };
+      });
+      start.mockImplementationOnce(async () => {
+        resolveSecondStart?.();
+        return { close: closeSecond };
+      });
+
+      const { runGatewayLoop } = await import("./run-loop.js");
+      void runGatewayLoop({
+        start: start as unknown as Parameters<typeof runGatewayLoop>[0]["start"],
+        runtime: runtime as unknown as Parameters<typeof runGatewayLoop>[0]["runtime"],
+      });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      sigusr1 = captureSignal("SIGUSR1");
+      const sigterm = captureSignal("SIGTERM");
+
+      try {
+        releaseFirstStart();
+
+        await waitForLoopCondition(
+          () => start.mock.calls.length >= 2,
+          "expected queued SIGUSR1 to trigger the second gateway start",
+        );
+        await startedSecond;
+        expect(closeFirst).toHaveBeenCalledWith({
+          reason: "gateway restarting",
+          restartExpectedMs: 1500,
+        });
+        expect(markGatewaySigusr1RestartHandled).toHaveBeenCalledTimes(1);
+        expect(markGatewayDraining).toHaveBeenCalledTimes(1);
+        expect(resetAllLanes).toHaveBeenCalledTimes(1);
+        expect(resetGatewayRestartStateForInProcessRestart).toHaveBeenCalledTimes(1);
+        expect(reloadTaskRegistryFromStore).toHaveBeenCalledTimes(1);
+      } finally {
+        sigterm();
+        await expect(exited).resolves.toBe(0);
+      }
+    });
+  });
+
+  it("processes SIGINT immediately before startup returns a server", async () => {
+    vi.clearAllMocks();
+
+    await withIsolatedSignals(async ({ captureSignal }) => {
+      const close = vi.fn(async () => {});
+      const startupNeverReturns = new Promise<void>(() => {});
+      const { runtime, exited } = createRuntimeWithExitSignal();
+      const start = vi.fn(async () => {
+        await startupNeverReturns;
+        return { close };
+      });
+
+      const { runGatewayLoop } = await import("./run-loop.js");
+      void runGatewayLoop({
+        start: start as unknown as Parameters<typeof runGatewayLoop>[0]["start"],
+        runtime: runtime as unknown as Parameters<typeof runGatewayLoop>[0]["runtime"],
+      });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      const sigint = captureSignal("SIGINT");
+
+      sigint();
+
+      await expect(exited).resolves.toBe(0);
+      expect(close).not.toHaveBeenCalled();
+      expect(start).toHaveBeenCalledTimes(1);
+      expect(acquireGatewayLock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("lets SIGINT override a queued startup restart before startup returns a server", async () => {
+    vi.clearAllMocks();
+    peekGatewaySigusr1RestartReason.mockReturnValue(undefined);
+
+    await withIsolatedSignals(async ({ captureSignal }) => {
+      const close = vi.fn(async () => {});
+      const startupNeverReturns = new Promise<void>(() => {});
+      const { runtime, exited } = createRuntimeWithExitSignal();
+      const start = vi.fn(async () => {
+        await startupNeverReturns;
+        return { close };
+      });
+
+      const { runGatewayLoop } = await import("./run-loop.js");
+      void runGatewayLoop({
+        start: start as unknown as Parameters<typeof runGatewayLoop>[0]["start"],
+        runtime: runtime as unknown as Parameters<typeof runGatewayLoop>[0]["runtime"],
+      });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      const sigusr1 = captureSignal("SIGUSR1");
+      const sigint = captureSignal("SIGINT");
+
+      sigusr1();
+      await waitForLoopCondition(
+        () => markGatewaySigusr1RestartHandled.mock.calls.length > 0,
+        "expected startup SIGUSR1 to be queued",
+      );
+
+      sigint();
+
+      await expect(exited).resolves.toBe(0);
+      expect(close).not.toHaveBeenCalled();
+      expect(markGatewayDraining).not.toHaveBeenCalled();
+      expect(start).toHaveBeenCalledTimes(1);
+      expect(acquireGatewayLock).toHaveBeenCalledTimes(1);
+      expect(gatewayLog.info).toHaveBeenCalledWith(
+        "received SIGINT; overriding pending startup restart with shutdown",
+      );
+    });
+  });
+
+  it("processes queued SIGUSR1 when restart startup fails before returning a server", async () => {
+    vi.clearAllMocks();
+    peekGatewaySigusr1RestartReason.mockReturnValue(undefined);
+    respawnGatewayProcessForUpdate.mockReturnValue({
+      mode: "disabled",
+      detail: "OPENCLAW_NO_RESPAWN",
+    });
+
+    await withIsolatedSignals(async ({ captureSignal }) => {
+      const closeFirst = vi.fn(async () => {});
+      const closeThird = vi.fn(async () => {});
+      const { runtime, exited } = createRuntimeWithExitSignal();
+      let sigusr1: (() => void) | null = null;
+      let resolveThirdStart: (() => void) | null = null;
+      const startedThird = new Promise<void>((resolve) => {
+        resolveThirdStart = resolve;
+      });
+      const start = vi.fn();
+      start.mockResolvedValueOnce({ close: closeFirst });
+      start.mockImplementationOnce(async () => {
+        sigusr1?.();
+        await waitForLoopCondition(
+          () => markGatewaySigusr1RestartHandled.mock.calls.length >= 2,
+          "expected SIGUSR1 during failed startup to be accepted before startup throws",
+        );
+        throw new Error("restart startup failed");
+      });
+      start.mockImplementationOnce(async () => {
+        resolveThirdStart?.();
+        return { close: closeThird };
+      });
+
+      const { runGatewayLoop } = await import("./run-loop.js");
+      void runGatewayLoop({
+        start: start as unknown as Parameters<typeof runGatewayLoop>[0]["start"],
+        runtime: runtime as unknown as Parameters<typeof runGatewayLoop>[0]["runtime"],
+      });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      sigusr1 = captureSignal("SIGUSR1");
+      const sigterm = captureSignal("SIGTERM");
+
+      try {
+        sigusr1();
+
+        await waitForLoopCondition(
+          () => start.mock.calls.length >= 3,
+          "expected queued SIGUSR1 to advance past failed restart startup",
+        );
+        await startedThird;
+        expect(closeFirst).toHaveBeenCalledWith({
+          reason: "gateway restarting",
+          restartExpectedMs: 1500,
+        });
+        expect(markGatewaySigusr1RestartHandled).toHaveBeenCalledTimes(2);
+        expect(markGatewayDraining).toHaveBeenCalledTimes(2);
+        expect(resetAllLanes).toHaveBeenCalledTimes(2);
+        expect(resetGatewayRestartStateForInProcessRestart).toHaveBeenCalledTimes(2);
+        expect(reloadTaskRegistryFromStore).toHaveBeenCalledTimes(2);
+        expect(acquireGatewayLock).toHaveBeenCalledTimes(3);
+        expect(gatewayLog.error).toHaveBeenCalledWith(
+          expect.stringContaining("gateway startup failed: restart startup failed."),
+        );
+      } finally {
+        sigterm();
+        await expect(exited).resolves.toBe(0);
+      }
+    });
+  });
+
+  it("processes SIGUSR1 received after restart startup fails before returning a server", async () => {
+    vi.clearAllMocks();
+    peekGatewaySigusr1RestartReason.mockReturnValue(undefined);
+    respawnGatewayProcessForUpdate.mockReturnValue({
+      mode: "disabled",
+      detail: "OPENCLAW_NO_RESPAWN",
+    });
+
+    await withIsolatedSignals(async ({ captureSignal }) => {
+      const closeFirst = vi.fn(async () => {});
+      const closeThird = vi.fn(async () => {});
+      const { runtime, exited } = createRuntimeWithExitSignal();
+      let resolveThirdStart: (() => void) | null = null;
+      const startedThird = new Promise<void>((resolve) => {
+        resolveThirdStart = resolve;
+      });
+      const start = vi.fn();
+      start.mockResolvedValueOnce({ close: closeFirst });
+      start.mockRejectedValueOnce(new Error("restart startup failed"));
+      start.mockImplementationOnce(async () => {
+        resolveThirdStart?.();
+        return { close: closeThird };
+      });
+
+      const { runGatewayLoop } = await import("./run-loop.js");
+      void runGatewayLoop({
+        start: start as unknown as Parameters<typeof runGatewayLoop>[0]["start"],
+        runtime: runtime as unknown as Parameters<typeof runGatewayLoop>[0]["runtime"],
+      });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      const sigusr1 = captureSignal("SIGUSR1");
+      const sigterm = captureSignal("SIGTERM");
+
+      try {
+        sigusr1();
+        await waitForLoopCondition(
+          () =>
+            gatewayLog.error.mock.calls.some(([message]) =>
+              String(message).includes("gateway startup failed: restart startup failed."),
+            ),
+          "expected failed restart startup to be logged",
+        );
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        expect(start).toHaveBeenCalledTimes(2);
+
+        sigusr1();
+        await waitForLoopCondition(
+          () => start.mock.calls.length >= 3,
+          "expected post-failure SIGUSR1 to retry gateway startup",
+        );
+        await startedThird;
+        expect(closeFirst).toHaveBeenCalledWith({
+          reason: "gateway restarting",
+          restartExpectedMs: 1500,
+        });
+        expect(markGatewaySigusr1RestartHandled).toHaveBeenCalledTimes(2);
+        expect(markGatewayDraining).toHaveBeenCalledTimes(2);
+        expect(resetAllLanes).toHaveBeenCalledTimes(2);
+        expect(resetGatewayRestartStateForInProcessRestart).toHaveBeenCalledTimes(2);
+        expect(reloadTaskRegistryFromStore).toHaveBeenCalledTimes(2);
+        expect(acquireGatewayLock).toHaveBeenCalledTimes(3);
+      } finally {
+        sigterm();
+        await expect(exited).resolves.toBe(0);
+      }
     });
   });
 

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -635,6 +635,10 @@ describe("runGatewayLoop", () => {
           () => markGatewaySigusr1RestartHandled.mock.calls.length > 0,
           "expected SIGUSR1 handler to consume the restart before startup returned",
         );
+        await waitForLoopCondition(
+          () => markGatewayDraining.mock.calls.length > 0,
+          "expected queued startup restart to mark gateway draining before startup returned",
+        );
         return { close: closeFirst };
       });
       start.mockImplementationOnce(async () => {
@@ -673,6 +677,51 @@ describe("runGatewayLoop", () => {
         await expect(exited).resolves.toBe(0);
       }
     });
+  });
+
+  it("exits if a queued startup restart never reaches a close handle", async () => {
+    vi.clearAllMocks();
+    peekGatewaySigusr1RestartReason.mockReturnValue(undefined);
+    vi.useFakeTimers();
+
+    try {
+      await withIsolatedSignals(async ({ captureSignal }) => {
+        const close = vi.fn(async () => {});
+        const startupNeverReturns = new Promise<void>(() => {});
+        const { runtime, exited } = createRuntimeWithExitSignal();
+        const start = vi.fn(async () => {
+          await startupNeverReturns;
+          return { close };
+        });
+
+        const { runGatewayLoop } = await import("./run-loop.js");
+        void runGatewayLoop({
+          start: start as unknown as Parameters<typeof runGatewayLoop>[0]["start"],
+          runtime: runtime as unknown as Parameters<typeof runGatewayLoop>[0]["runtime"],
+        });
+        await vi.advanceTimersByTimeAsync(0);
+        const sigusr1 = captureSignal("SIGUSR1");
+
+        sigusr1();
+        await vi.advanceTimersByTimeAsync(0);
+        expect(markGatewaySigusr1RestartHandled).toHaveBeenCalledTimes(1);
+        expect(markGatewayDraining).toHaveBeenCalledTimes(1);
+        expect(runtime.exit).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(24_999);
+        expect(runtime.exit).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(1);
+
+        await expect(exited).resolves.toBe(1);
+        expect(close).not.toHaveBeenCalled();
+        expect(start).toHaveBeenCalledTimes(1);
+        expect(gatewayLog.error).toHaveBeenCalledWith(
+          "startup restart request timed out before gateway returned a close handle; exiting for supervisor recovery",
+        );
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("processes SIGINT immediately before startup returns a server", async () => {
@@ -736,7 +785,7 @@ describe("runGatewayLoop", () => {
 
       await expect(exited).resolves.toBe(0);
       expect(close).not.toHaveBeenCalled();
-      expect(markGatewayDraining).not.toHaveBeenCalled();
+      expect(markGatewayDraining).toHaveBeenCalledTimes(1);
       expect(start).toHaveBeenCalledTimes(1);
       expect(acquireGatewayLock).toHaveBeenCalledTimes(1);
       expect(gatewayLog.info).toHaveBeenCalledWith(

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -28,6 +28,12 @@ type RestartIntentOptions = {
   force?: boolean;
   waitMs?: number;
 };
+type GatewayRunSignalRequest = {
+  action: GatewayRunSignalAction;
+  signal: string;
+  restartReason?: string;
+  restartIntent?: RestartIntentOptions;
+};
 
 type GatewayLifecycleRuntimeModule = typeof import("./lifecycle.runtime.js");
 
@@ -103,6 +109,10 @@ export async function runGatewayLoop(params: {
   let server: Awaited<ReturnType<typeof startGatewayServer>> | null = null;
   let shuttingDown = false;
   let restartResolver: (() => void) | null = null;
+  // The HTTP server can report ready before params.start returns its close handle.
+  // Defer lifecycle signals from that window until the loop can close and advance.
+  let pendingStartupRequest: GatewayRunSignalRequest | null = null;
+  let startupFailedWithoutServerHandle = false;
   const processInstanceId = randomUUID();
   const waitForHealthyChild = params.waitForHealthyChild ?? waitForHealthyGatewayChild;
 
@@ -224,7 +234,7 @@ export async function runGatewayLoop(params: {
           `restart mode: in-process restart (${respawn.detail ?? "OPENCLAW_NO_RESPAWN"})`,
         );
       }
-      if (hadLock && !(await reacquireLockForInProcessRestart())) {
+      if (!(await reacquireLockForInProcessRestart())) {
         return;
       }
       shuttingDown = false;
@@ -282,7 +292,7 @@ export async function runGatewayLoop(params: {
         `restart mode: in-process restart (${respawn.detail ?? "OPENCLAW_NO_RESPAWN"})`,
       );
     }
-    if (hadLock && !(await reacquireLockForInProcessRestart())) {
+    if (!(await reacquireLockForInProcessRestart())) {
       return;
     }
     shuttingDown = false;
@@ -314,28 +324,12 @@ export async function runGatewayLoop(params: {
     }
   };
 
-  const request = (
-    action: GatewayRunSignalAction,
-    signal: string,
-    restartReason?: string,
-    restartIntent?: RestartIntentOptions,
-  ) => {
-    if (shuttingDown) {
-      gatewayLog.info(`received ${signal} during shutdown; ignoring`);
-      return;
-    }
-    shuttingDown = true;
+  const runAcceptedRequest = ({
+    action,
+    restartReason,
+    restartIntent,
+  }: GatewayRunSignalRequest) => {
     const isRestart = action === "restart";
-    gatewayLog.info(`received ${signal}; ${isRestart ? "restarting" : "shutting down"}`);
-    if (isRestart) {
-      startGatewayRestartTrace("restart.signal.received", [
-        ["signal", signal],
-        ["reason", restartReason ?? signal],
-        ["force", restartIntent?.force === true],
-        ["waitMs", restartIntent?.waitMs ?? "default"],
-      ]);
-    }
-
     let forceExitTimer: ReturnType<typeof setTimeout> | null = null;
     const armForceExitTimer = (forceExitMs: number) => {
       if (forceExitTimer) {
@@ -537,6 +531,62 @@ export async function runGatewayLoop(params: {
       }
     })();
   };
+  const flushPendingStartupRequest = (opts: { allowMissingServer?: boolean } = {}) => {
+    if (!pendingStartupRequest || !restartResolver) {
+      return;
+    }
+    if (!server && opts.allowMissingServer !== true) {
+      return;
+    }
+    const request = pendingStartupRequest;
+    pendingStartupRequest = null;
+    startupFailedWithoutServerHandle = false;
+    runAcceptedRequest(request);
+  };
+  const request = (
+    action: GatewayRunSignalAction,
+    signal: string,
+    restartReason?: string,
+    restartIntent?: RestartIntentOptions,
+  ) => {
+    const acceptedRequest = { action, signal, restartReason, restartIntent };
+    if (shuttingDown) {
+      if (action === "stop" && pendingStartupRequest && !server) {
+        gatewayLog.info(`received ${signal}; overriding pending startup restart with shutdown`);
+        pendingStartupRequest = null;
+        startupFailedWithoutServerHandle = false;
+        runAcceptedRequest(acceptedRequest);
+        return;
+      }
+      gatewayLog.info(`received ${signal} during shutdown; ignoring`);
+      return;
+    }
+    shuttingDown = true;
+    const isRestart = action === "restart";
+    gatewayLog.info(`received ${signal}; ${isRestart ? "restarting" : "shutting down"}`);
+    if (isRestart) {
+      startGatewayRestartTrace("restart.signal.received", [
+        ["signal", signal],
+        ["reason", restartReason ?? signal],
+        ["force", restartIntent?.force === true],
+        ["waitMs", restartIntent?.waitMs ?? "default"],
+      ]);
+    }
+    if (action === "stop") {
+      runAcceptedRequest(acceptedRequest);
+      return;
+    }
+    if (!server && restartResolver && startupFailedWithoutServerHandle) {
+      startupFailedWithoutServerHandle = false;
+      runAcceptedRequest(acceptedRequest);
+      return;
+    }
+    if (!server || !restartResolver) {
+      pendingStartupRequest = acceptedRequest;
+      return;
+    }
+    runAcceptedRequest(acceptedRequest);
+  };
 
   const onSigterm = () => {
     gatewayLog.info("signal SIGTERM received");
@@ -618,8 +668,10 @@ export async function runGatewayLoop(params: {
     let isFirstStart = true;
     for (;;) {
       await onIteration();
+      let startupFailedBeforeServerHandle = false;
       try {
         server = await params.start({ startupStartedAt });
+        startupFailedWithoutServerHandle = false;
         isFirstStart = false;
       } catch (err) {
         // On initial startup, let the error propagate so the outer handler
@@ -630,11 +682,15 @@ export async function runGatewayLoop(params: {
           throw err;
         }
         server = null;
-        // Release the gateway lock so that `daemon restart/stop` (which
-        // discovers PIDs via the gateway port) can still manage the process.
-        // Without this, the process holds the lock but is not listening,
-        // forcing manual cleanup. (#35862)
-        await releaseLockIfHeld();
+        startupFailedWithoutServerHandle = true;
+        startupFailedBeforeServerHandle = true;
+        if (!pendingStartupRequest) {
+          // Release the gateway lock so that `daemon restart/stop` (which
+          // discovers PIDs via the gateway port) can still manage the process.
+          // Without this, the process holds the lock but is not listening,
+          // forcing manual cleanup. (#35862)
+          await releaseLockIfHeld();
+        }
         const errMsg = formatErrorMessage(err);
         const errStack = err instanceof Error && err.stack ? `\n${err.stack}` : "";
         await writeStabilityBundle("gateway.restart_startup_failed", err);
@@ -644,7 +700,11 @@ export async function runGatewayLoop(params: {
         );
       }
       await new Promise<void>((resolve) => {
-        restartResolver = resolve;
+        restartResolver = () => {
+          restartResolver = null;
+          resolve();
+        };
+        flushPendingStartupRequest({ allowMissingServer: startupFailedBeforeServerHandle });
       });
     }
   } finally {

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -112,6 +112,8 @@ export async function runGatewayLoop(params: {
   // The HTTP server can report ready before params.start returns its close handle.
   // Defer lifecycle signals from that window until the loop can close and advance.
   let pendingStartupRequest: GatewayRunSignalRequest | null = null;
+  let pendingStartupForceExitTimer: ReturnType<typeof setTimeout> | null = null;
+  let restartDrainingMarkPromise: Promise<void> | null = null;
   let startupFailedWithoutServerHandle = false;
   const processInstanceId = randomUUID();
   const waitForHealthyChild = params.waitForHealthyChild ?? waitForHealthyGatewayChild;
@@ -305,6 +307,32 @@ export async function runGatewayLoop(params: {
 
   const SUPERVISOR_STOP_TIMEOUT_MS = 30_000;
   const SHUTDOWN_TIMEOUT_MS = SUPERVISOR_STOP_TIMEOUT_MS - 5_000;
+  const clearPendingStartupForceExitTimer = () => {
+    if (!pendingStartupForceExitTimer) {
+      return;
+    }
+    clearTimeout(pendingStartupForceExitTimer);
+    pendingStartupForceExitTimer = null;
+  };
+  const armPendingStartupForceExitTimer = () => {
+    if (pendingStartupForceExitTimer) {
+      return;
+    }
+    pendingStartupForceExitTimer = setTimeout(() => {
+      pendingStartupForceExitTimer = null;
+      gatewayLog.error(
+        "startup restart request timed out before gateway returned a close handle; exiting for supervisor recovery",
+      );
+      void (async () => {
+        try {
+          await writeStabilityBundle("gateway.restart_startup_request_timeout");
+        } finally {
+          exitProcess(1);
+        }
+      })();
+    }, SHUTDOWN_TIMEOUT_MS);
+    pendingStartupForceExitTimer.unref?.();
+  };
   const resolveRestartDrainTimeoutMs = async (
     restartIntent?: RestartIntentOptions,
   ): Promise<RestartDrainTimeoutMs> => {
@@ -322,6 +350,18 @@ export async function runGatewayLoop(params: {
     } catch {
       return DEFAULT_RESTART_DRAIN_TIMEOUT_MS;
     }
+  };
+  const markRestartDraining = async () => {
+    if (!restartDrainingMarkPromise) {
+      restartDrainingMarkPromise = (async () => {
+        const { markGatewayDraining } = await loadGatewayLifecycleRuntimeModule();
+        markGatewayDraining();
+      })().catch((err) => {
+        restartDrainingMarkPromise = null;
+        throw err;
+      });
+    }
+    await restartDrainingMarkPromise;
   };
 
   const runAcceptedRequest = ({
@@ -404,7 +444,6 @@ export async function runGatewayLoop(params: {
                 getInspectableActiveTaskRestartBlockers,
                 getActiveEmbeddedRunCount,
                 getActiveTaskCount,
-                markGatewayDraining,
                 waitForActiveEmbeddedRuns,
                 waitForActiveTasks,
               } = await loadGatewayLifecycleRuntimeModule();
@@ -439,7 +478,7 @@ export async function runGatewayLoop(params: {
 
               // Reject new enqueues immediately during the drain window so
               // sessions get an explicit restart error instead of silent task loss.
-              markGatewayDraining();
+              await markRestartDraining();
               const activeTasks = getActiveTaskCount();
               const activeRuns = getActiveEmbeddedRunCount();
               activeTasksAtDrainStart = activeTasks;
@@ -540,6 +579,7 @@ export async function runGatewayLoop(params: {
     }
     const request = pendingStartupRequest;
     pendingStartupRequest = null;
+    clearPendingStartupForceExitTimer();
     startupFailedWithoutServerHandle = false;
     runAcceptedRequest(request);
   };
@@ -554,6 +594,7 @@ export async function runGatewayLoop(params: {
       if (action === "stop" && pendingStartupRequest && !server) {
         gatewayLog.info(`received ${signal}; overriding pending startup restart with shutdown`);
         pendingStartupRequest = null;
+        clearPendingStartupForceExitTimer();
         startupFailedWithoutServerHandle = false;
         runAcceptedRequest(acceptedRequest);
         return;
@@ -583,6 +624,10 @@ export async function runGatewayLoop(params: {
     }
     if (!server || !restartResolver) {
       pendingStartupRequest = acceptedRequest;
+      void markRestartDraining().catch((err) => {
+        gatewayLog.warn(`failed to mark gateway draining for startup restart: ${String(err)}`);
+      });
+      armPendingStartupForceExitTimer();
       return;
     }
     runAcceptedRequest(acceptedRequest);
@@ -668,6 +713,7 @@ export async function runGatewayLoop(params: {
     let isFirstStart = true;
     for (;;) {
       await onIteration();
+      restartDrainingMarkPromise = null;
       let startupFailedBeforeServerHandle = false;
       try {
         server = await params.start({ startupStartedAt });


### PR DESCRIPTION
## Summary

- Problem: gateway restart signals could arrive while startup was in flight, before the run loop had a server close handle or restart waiter ready.
- Why it matters: that race could drop or mis-order restart/shutdown intent, leaving local gateway recovery inconsistent during restart/update churn.
- What changed: the run loop now queues startup-time lifecycle requests, flushes them once state is valid, and lets shutdown override a queued startup restart.
- What did NOT change (scope boundary): no API, protocol, config schema, UI, plugin, or auth behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes: N/A
- Related: N/A
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: local gateway restart remains recoverable and ready after a restart request while using the patched restart loop.
- Real environment tested: macOS local OpenClaw gateway on branch `fix/gateway-readyz-restart-race`, `OPENCLAW_NO_RESPAWN` in-process restart mode, ephemeral port `52206`.
- Exact steps or command run after this patch:
  1. Started the patched gateway locally on port `52206` with in-process restart enabled.
  2. Requested gateway readiness before restart.
  3. Sent a gateway restart request with reason `codex.local-proof`.
  4. Requested gateway readiness again after restart.
  5. Checked the gateway log for the in-process restart path and two listen events.
- Evidence after fix: terminal capture copied from the local gateway run:
  ```text
  port=52206
  ready_before={"ready":true,"failing":[],"uptimeMs":1318,"eventLoop":{"degraded":false,"reasons":[],"intervalMs":1182,"delayP99Ms":417.6,"delayMaxMs":417.6,"utilization":0.587,"cpuCoreRatio":0.769}}
  restart_response={"ok":true,"status":"scheduled","preflight":{"safe":true,"counts":{"queueSize":0,"pendingReplies":0,"embeddedRuns":0,"activeTasks":0,"totalActive":0},"blockers":[],"summary":"safe to restart now"},"restart":{"ok":true,"pid":80449,"signal":"SIGUSR1","delayMs":0,"reason":"codex.local-proof","mode":"emit","coalesced":false,"cooldownMsApplied":0}}
  ready_after={"ready":true,"failing":[],"uptimeMs":449}
  restart_log=2026-05-17T00:18:31.855+08:00 [gateway] restart mode: in-process restart (OPENCLAW_NO_RESPAWN)
  gateway_listen_count=2
  ```
- Observed result after fix: the gateway was ready before and after restart, the restart request was accepted, uptime reset after the restart, and logs confirmed the in-process restart path with two gateway listen events.
- What was not tested: downstream client traffic during the restart window, OS supervisor respawn semantics, and remote Crabbox/Testbox validation.

## Root Cause (if applicable)

- Root cause: the run loop could receive restart or shutdown signals before `params.start()` returned a server handle and before the loop installed the restart waiter.
- Missing detection / guardrail: there was no explicit startup pending-request buffer or flush gate for lifecycle signals received during in-flight startup.
- Contributing context (if known): the bug depends on startup/shutdown signal ordering, so normal steady-state restart tests did not exercise it.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/cli/gateway-cli/run-loop.test.ts`
- Scenario the test should lock in:
  - Startup SIGUSR1 queueing, immediate SIGINT during startup, SIGINT overriding a queued restart, restart retry after startup failure, and post-failure SIGUSR1 retry.
- Why this is the smallest reliable guardrail:
  - The regression is inside CLI gateway run-loop signal orchestration; focused run-loop tests can force the exact timing windows without a flaky OS signal race.
- Existing test that already covers this (if any):
  - N/A
- If no new test is added, why not:
  - N/A

## User-visible / Behavior Changes

Local gateway restart/update recovery is more reliable during startup timing races. No user-facing API, config, or UI changes.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - N/A

## Repro + Verification

### Environment

- OS:
  - macOS
- Runtime/container:
  - Local OpenClaw checkout, Node/Vitest project harness
- Model/provider:
  - N/A
- Integration/channel (if any):
  - CLI gateway loop
- Relevant config (redacted):
  - `OPENCLAW_NO_RESPAWN` for the local gateway restart proof

### Steps

1. `node scripts/run-vitest.mjs src/cli/gateway-cli/run-loop.test.ts`
2. `OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm check:changed`
3. `OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm test:changed`
4. Local gateway ready/restart/ready proof shown in the Real behavior proof section.

### Expected

- Focused run-loop regression tests pass.
- Changed-surface checks pass.
- Local gateway stays ready after a restart request.

### Actual

- `node scripts/run-vitest.mjs src/cli/gateway-cli/run-loop.test.ts`: `Test Files 1 passed (1)`, `Tests 25 passed (25)`.
- `OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm check:changed`: passed.
- `OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm test:changed`: `Test Files 1 passed (1)`, `Tests 25 passed (25)`.
- GitHub checks are green, including latest `Real behavior proof`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Local gateway ready/restart/ready behavior and focused run-loop regression tests.
- Edge cases checked:
  - Restart signal before startup returns a server, SIGINT before startup returns a server, SIGINT overriding queued startup restart, queued retry after restart startup failure, and SIGUSR1 retry after restart startup failure.
- What you did **not** verify:
  - Downstream client traffic during restart, OS supervisor respawn semantics, and remote Crabbox/Testbox validation.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:
  - N/A

## Risks and Mitigations

- Risk:
  - Another rare concurrent signal burst could expose an untested lifecycle ordering edge.
- Mitigation:
  - Startup lifecycle requests are now represented explicitly and covered by targeted run-loop timing tests.

