### PR TITLE
fix(agents): retry primary after auto model fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/model fallback: clear auto-persisted fallback session overrides before the next turn so recovered primaries are retried instead of leaving sessions pinned to fallback models indefinitely. Fixes #82544.
 - TUI: update the displayed model in real time when an auto-fallback resolution swaps in a different model mid-turn, so the status line reflects the actual model handling the run. Fixes #82296. Thanks @giodl73-repo.
 - Agents/sessions: preserve fresh post-compaction token snapshots across stale usage updates, preventing repeated auto-compaction after every message. Fixes #82576. (#82578) Thanks @njuboy11.
 - Agents/OpenAI Responses: log redacted diagnostics for detail-less `response.failed` events while preserving failed response ids, so operators can correlate provider-side failures. Fixes #82558.

--- a/docs/concepts/model-failover.md
+++ b/docs/concepts/model-failover.md
@@ -21,7 +21,7 @@ For a normal text run, OpenClaw evaluates candidates in this order:
 
 <Steps>
   <Step title="Resolve session state">
-    Resolve the active session model and auth-profile preference.
+    Resolve the active session model and auth-profile preference. A direct auto fallback override from an earlier turn is cleared first so the configured primary is retried; user-selected overrides stay sticky.
   </Step>
   <Step title="Build candidate chain">
     Build the model candidate chain from the current model selection and the fallback policy for that selection source. Configured defaults, cron job primaries, and auto-selected fallback models can use configured fallbacks; explicit user session selections are strict.
@@ -60,7 +60,7 @@ OpenClaw separates the selected provider/model from why it was selected. That so
 
 - **Configured default**: `agents.defaults.model.primary` uses `agents.defaults.model.fallbacks`.
 - **Agent primary**: `agents.list[].model` is strict unless that agent model object includes its own `fallbacks`. Use `fallbacks: []` to make the strict behavior explicit, or provide a non-empty list to opt that agent into model fallback.
-- **Auto fallback override**: a runtime fallback writes `providerOverride`, `modelOverride`, `modelOverrideSource: "auto"`, and the selected origin model before retrying. That auto override can keep walking the configured fallback chain and is cleared by `/new`, `/reset`, and `sessions.reset`. Heartbeat runs without an explicit `heartbeat.model` also clear a direct auto override when its origin no longer matches the current configured default.
+- **Auto fallback override**: a runtime fallback writes `providerOverride`, `modelOverride`, `modelOverrideSource: "auto"`, and the selected origin model before retrying. That auto override is cleared before the next turn starts so the configured primary is retried; if the primary is still unhealthy, fallback writes a fresh auto override for that turn. `/new`, `/reset`, and `sessions.reset` also clear auto-sourced overrides.
 - **User session override**: `/model`, the model picker, `session_status(model=...)`, and `sessions.patch` write `modelOverrideSource: "user"`. That is an exact session selection. If the selected provider/model fails before producing a reply, OpenClaw reports the failure instead of answering from an unrelated configured fallback.
 - **Legacy session override**: older session entries may have `modelOverride` without `modelOverrideSource`. OpenClaw treats those as user overrides so an explicit old selection is not silently converted into fallback behavior.
 - **Cron payload model**: a cron job `payload.model` / `--model` is a job primary, not a user session override. It uses configured fallbacks unless the job provides `payload.fallbacks`; `payload.fallbacks: []` makes the cron run strict.
@@ -305,7 +305,7 @@ That means fallback retries have to coordinate with live model switching:
 - System-driven model changes such as fallback rotation, heartbeat overrides, or compaction never mark a pending live switch on their own.
 - User-driven model overrides are treated as exact selections for fallback policy, so an unreachable selected provider surfaces as a failure instead of being masked by `agents.defaults.model.fallbacks`.
 - Before a fallback retry starts, the reply runner persists the selected fallback override fields to the session entry.
-- Auto fallback overrides remain selected on subsequent turns so OpenClaw does not probe a known-bad primary on every message. `/new`, `/reset`, and `sessions.reset` clear auto-sourced overrides and return the session to the configured default.
+- Auto fallback overrides are one-turn recovery state. The next run clears direct auto-sourced overrides before model selection, retries the configured primary immediately, and lets fallback record a fresh auto override only if the primary still fails.
 - `/status` shows the selected model and, when fallback state differs, the active fallback model and reason.
 - Live-session reconciliation prefers persisted session overrides over stale runtime model fields.
 - If a live-switch error points at a later candidate in the active fallback chain, OpenClaw jumps directly to that selected model instead of walking unrelated candidates first.

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -34,6 +34,7 @@ const state = vi.hoisted(() => ({
   trajectoryRecordEventMock: vi.fn(),
   trajectoryFlushMock: vi.fn(async () => undefined),
   clearSessionAuthProfileOverrideMock: vi.fn(),
+  applyModelOverrideToSessionEntryMock: vi.fn(),
   isThinkingLevelSupportedMock: vi.fn((_args: unknown) => true),
   resolveThinkingDefaultMock: vi.fn((_args: unknown) => "low"),
   loadManifestModelCatalogMock: vi.fn(() => []),
@@ -46,6 +47,7 @@ const state = vi.hoisted(() => ({
   authProfileStoreMock: { profiles: {} } as { profiles: Record<string, unknown> },
   sessionEntryMock: undefined as unknown,
   sessionStoreMock: undefined as unknown,
+  hasSessionAutoModelFallbackProvenanceMock: vi.fn((_entry: unknown) => false),
 }));
 
 vi.mock("./model-fallback.js", () => ({
@@ -240,7 +242,11 @@ vi.mock("../sessions/level-overrides.js", () => ({
 }));
 
 vi.mock("../sessions/model-overrides.js", () => ({
-  applyModelOverrideToSessionEntry: () => ({ updated: false }),
+  applyModelOverrideToSessionEntry: (params: {
+    entry: Record<string, unknown>;
+    selection: { provider: string; model: string; isDefault?: boolean };
+    preserveAuthProfileOverride?: boolean;
+  }) => state.applyModelOverrideToSessionEntryMock(params),
   repairProviderWrappedModelOverride: () => ({ updated: false }),
 }));
 
@@ -266,7 +272,8 @@ vi.mock("../utils/message-channel.js", () => ({
 }));
 
 vi.mock("./agent-scope.js", () => ({
-  hasSessionAutoModelFallbackProvenance: () => false,
+  hasSessionAutoModelFallbackProvenance: (entry: unknown) =>
+    state.hasSessionAutoModelFallbackProvenanceMock(entry),
   listAgentEntries: () => [],
   listAgentIds: () => ["default"],
   resolveAgentConfig: () => undefined,
@@ -744,6 +751,32 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     state.deliverAgentCommandResultMock.mockResolvedValue(undefined);
     state.updateSessionStoreAfterAgentRunMock.mockResolvedValue(undefined);
     state.trajectoryFlushMock.mockResolvedValue(undefined);
+    state.applyModelOverrideToSessionEntryMock.mockImplementation(
+      (params: {
+        entry: Record<string, unknown>;
+        selection: { provider: string; model: string; isDefault?: boolean };
+        preserveAuthProfileOverride?: boolean;
+      }) => {
+        const before = JSON.stringify(params.entry);
+        if (params.selection.isDefault) {
+          delete params.entry.providerOverride;
+          delete params.entry.modelOverride;
+          delete params.entry.modelOverrideSource;
+          delete params.entry.modelOverrideFallbackOriginProvider;
+          delete params.entry.modelOverrideFallbackOriginModel;
+        } else {
+          params.entry.providerOverride = params.selection.provider;
+          params.entry.modelOverride = params.selection.model;
+        }
+        if (!params.preserveAuthProfileOverride) {
+          delete params.entry.authProfileOverride;
+          delete params.entry.authProfileOverrideSource;
+          delete params.entry.authProfileOverrideCompactionCount;
+        }
+        return { updated: JSON.stringify(params.entry) !== before };
+      },
+    );
+    state.hasSessionAutoModelFallbackProvenanceMock.mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -1031,6 +1064,45 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
 
     expect(capturedAuthProfileProvider).toBe("openai");
     expect(state.runWithModelFallbackMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears direct auto-fallback session overrides before direct agent runs", async () => {
+    const sessionEntry = {
+      sessionId: "session-1",
+      updatedAt: Date.now(),
+      providerOverride: "openai",
+      modelOverride: "gpt-5.4",
+      modelOverrideSource: "auto",
+      modelOverrideFallbackOriginProvider: "anthropic",
+      modelOverrideFallbackOriginModel: "claude",
+      skillsSnapshot: { prompt: "", skills: [], version: 0 },
+    };
+    state.sessionEntryMock = sessionEntry;
+    state.runWithModelFallbackMock.mockImplementation(async (params: FallbackRunnerParams) => {
+      const result = await params.run(params.provider, params.model);
+      return {
+        result,
+        provider: params.provider,
+        model: params.model,
+        attempts: [],
+      };
+    });
+    state.runAgentAttemptMock.mockResolvedValue(makeSuccessResult("anthropic", "claude"));
+
+    await runBasicAgentCommand();
+
+    expect(state.runWithModelFallbackMock).toHaveBeenCalledTimes(1);
+    const fallbackCall = mockCallArg(state.runWithModelFallbackMock) as FallbackRunnerParams;
+    expect(fallbackCall.provider).toBe("anthropic");
+    expect(fallbackCall.model).toBe("claude");
+    expect(state.resolveEffectiveModelFallbacksMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hasSessionModelOverride: false,
+        modelOverrideSource: undefined,
+        hasAutoFallbackProvenance: false,
+      }),
+    );
+    expect(state.applyModelOverrideToSessionEntryMock).not.toHaveBeenCalled();
   });
 
   it("keeps aliased session auth profiles for codex-cli runs", async () => {

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -226,6 +226,9 @@ type PersistSessionEntryParams = {
 type OverrideFieldClearedByDelete =
   | "providerOverride"
   | "modelOverride"
+  | "modelOverrideSource"
+  | "modelOverrideFallbackOriginProvider"
+  | "modelOverrideFallbackOriginModel"
   | "authProfileOverride"
   | "authProfileOverrideSource"
   | "authProfileOverrideCompactionCount"
@@ -237,6 +240,9 @@ type OverrideFieldClearedByDelete =
 const OVERRIDE_FIELDS_CLEARED_BY_DELETE: OverrideFieldClearedByDelete[] = [
   "providerOverride",
   "modelOverride",
+  "modelOverrideSource",
+  "modelOverrideFallbackOriginProvider",
+  "modelOverrideFallbackOriginModel",
   "authProfileOverride",
   "authProfileOverrideSource",
   "authProfileOverrideCompactionCount",
@@ -750,7 +756,7 @@ async function agentCommandInternal(
     let storedModelOverrideSource = hasStoredOverride
       ? sessionEntry?.modelOverrideSource
       : undefined;
-    const hasStoredAutoFallbackProvenance =
+    let hasStoredAutoFallbackProvenance =
       hasStoredOverride && hasSessionAutoModelFallbackProvenance(sessionEntry);
     const explicitProviderOverride =
       typeof opts.provider === "string"
@@ -786,7 +792,47 @@ async function agentCommandInternal(
       allowedModelCatalog = visibilityPolicy.allowedCatalog;
     }
 
-    if (sessionEntry && sessionStore && sessionKey && hasStoredOverride) {
+    const shouldClearDirectAutoFallbackOverride = Boolean(
+      sessionEntry &&
+      hasStoredOverride &&
+      !hasExplicitRunOverride &&
+      (sessionEntry.modelOverrideSource === "auto" ||
+        (sessionEntry.modelOverrideSource === undefined && hasStoredAutoFallbackProvenance)),
+    );
+
+    if (
+      sessionEntry &&
+      sessionStore &&
+      sessionKey &&
+      hasStoredOverride &&
+      shouldClearDirectAutoFallbackOverride
+    ) {
+      const { updated } = applyModelOverrideToSessionEntry({
+        entry: sessionEntry,
+        selection: { provider: defaultProvider, model: defaultModel, isDefault: true },
+        preserveAuthProfileOverride: sessionEntry.authProfileOverrideSource === "user",
+      });
+      if (updated) {
+        await persistSessionEntry({
+          sessionStore,
+          sessionKey,
+          storePath,
+          entry: sessionEntry,
+        });
+      }
+    }
+    if (shouldClearDirectAutoFallbackOverride) {
+      storedModelOverrideSource = undefined;
+      hasStoredAutoFallbackProvenance = false;
+    }
+
+    if (
+      sessionEntry &&
+      sessionStore &&
+      sessionKey &&
+      hasStoredOverride &&
+      !shouldClearDirectAutoFallbackOverride
+    ) {
       const entry = sessionEntry;
       const repaired = repairProviderWrappedModelOverride({
         entry,
@@ -823,8 +869,12 @@ async function agentCommandInternal(
       }
     }
 
-    const storedProviderOverride = sessionEntry?.providerOverride?.trim();
-    let storedModelOverride = sessionEntry?.modelOverride?.trim();
+    const storedProviderOverride = shouldClearDirectAutoFallbackOverride
+      ? undefined
+      : sessionEntry?.providerOverride?.trim();
+    let storedModelOverride = shouldClearDirectAutoFallbackOverride
+      ? undefined
+      : sessionEntry?.modelOverride?.trim();
     if (storedModelOverride) {
       const candidateProvider = storedProviderOverride || defaultProvider;
       const normalizedStored = normalizeModelRef(candidateProvider, storedModelOverride);

--- a/src/auto-reply/reply/get-reply-directives.target-session.test.ts
+++ b/src/auto-reply/reply/get-reply-directives.target-session.test.ts
@@ -34,6 +34,33 @@ function makeTypingController() {
 
 function parseInlineDirectivesForTest(body: string) {
   const normalized = body.trim();
+  if (normalized === "status hello") {
+    return {
+      cleaned: "hello",
+      hasThinkDirective: false,
+      hasVerboseDirective: false,
+      hasTraceDirective: false,
+      traceLevel: undefined,
+      rawTraceLevel: undefined,
+      hasFastDirective: false,
+      hasReasoningDirective: false,
+      reasoningLevel: undefined,
+      rawReasoningLevel: undefined,
+      hasElevatedDirective: false,
+      hasExecDirective: false,
+      hasModelDirective: false,
+      hasQueueDirective: false,
+      hasStatusDirective: true,
+      queueReset: false,
+      thinkLevel: undefined,
+      verboseLevel: undefined,
+      fastMode: undefined,
+      elevatedLevel: undefined,
+      rawElevatedLevel: undefined,
+      rawModelDirective: undefined,
+      execSecurity: undefined,
+    };
+  }
   if (normalized === "/reasoning stream") {
     return {
       cleaned: "",
@@ -487,6 +514,24 @@ describe("resolveReplyDirectives", () => {
       resolvedReasoningLevel: "on",
     });
     expect(resolveDefaultReasoningLevel).toHaveBeenCalledOnce();
+  });
+
+  it("marks deferred status turns to refresh model reasoning defaults after auto-fallback clear", async () => {
+    const { result } = await resolveHelloWithModelDefaults({
+      body: "status hello",
+      commandAuthorized: true,
+      defaultThinking: "off",
+      defaultReasoning: "on",
+    });
+
+    expectContinueResult(result, {
+      deferredAutoFallbackClear: true,
+      refreshModelDefaultReasoningLevel: true,
+      resolvedReasoningLevel: "on",
+    });
+    expect(mockCallInput(mocks.createModelSelectionState).clearDirectAutoFallbackOverride).toBe(
+      false,
+    );
   });
 
   it("does not re-enable model reasoning when thinking was explicitly disabled", async () => {

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -133,6 +133,9 @@ export type ReplyDirectiveContinuation = {
   modelState: Awaited<ReturnType<typeof createModelSelectionState>>;
   contextTokens: number;
   inlineStatusRequested: boolean;
+  deferredAutoFallbackClear: boolean;
+  refreshModelDefaultThinkingLevel: boolean;
+  refreshModelDefaultReasoningLevel: boolean;
   directiveAck?: ReplyPayload;
   perMessageQueueMode?: InlineDirectives["queueMode"];
   perMessageQueueOptions?: {
@@ -514,6 +517,11 @@ export async function resolveReplyDirectives(params: {
         aliasIndex: params.aliasIndex,
       }));
 
+  const deferredAutoFallbackClear =
+    hasInlineStatus ||
+    (allowTextCommands &&
+      command.isAuthorizedSender &&
+      command.commandBodyNormalized.startsWith("/"));
   const modelState = useFastModelSelection
     ? createFastTestModelSelectionState({
         agentCfg,
@@ -540,6 +548,7 @@ export async function resolveReplyDirectives(params: {
         hasOneTurnModelOverride,
         hasResolvedHeartbeatModelOverride,
         isHeartbeat: opts?.isHeartbeat === true,
+        clearDirectAutoFallbackOverride: !deferredAutoFallbackClear,
       });
   provider = modelState.provider;
   model = modelState.model;
@@ -673,6 +682,10 @@ export async function resolveReplyDirectives(params: {
       modelState,
       contextTokens,
       inlineStatusRequested,
+      deferredAutoFallbackClear,
+      refreshModelDefaultThinkingLevel:
+        resolvedThinkLevel === undefined && agentCfg?.thinkingDefault === undefined,
+      refreshModelDefaultReasoningLevel: !reasoningExplicitlySet && !thinkingExplicitlySet,
       directiveAck,
       perMessageQueueMode,
       perMessageQueueOptions,

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -44,7 +44,11 @@ import { runPreparedReply } from "./get-reply-run.js";
 import { finalizeInboundContext } from "./inbound-context.js";
 import { hasInboundMedia } from "./inbound-media.js";
 import { emitPreAgentMessageHooks } from "./message-preprocess-hooks.js";
-import { createFastTestModelSelectionState } from "./model-selection.js";
+import {
+  createFastTestModelSelectionState,
+  createModelSelectionState,
+  resolveContextTokens,
+} from "./model-selection.js";
 import { sanitizePendingFinalDeliveryText } from "./pending-final-delivery.js";
 import { initSessionState } from "./session.js";
 import {
@@ -730,6 +734,9 @@ export async function getReplyFromConfig(
     modelState,
     contextTokens,
     inlineStatusRequested,
+    deferredAutoFallbackClear,
+    refreshModelDefaultThinkingLevel,
+    refreshModelDefaultReasoningLevel,
     directiveAck,
     perMessageQueueMode,
     perMessageQueueOptions,
@@ -809,6 +816,52 @@ export async function getReplyFromConfig(
   directives = inlineActionResult.directives;
   cleanedBody = inlineActionResult.cleanedBody;
   abortedLastRun = inlineActionResult.abortedLastRun ?? abortedLastRun;
+  if (deferredAutoFallbackClear) {
+    const refreshedSessionEntry = sessionStore[sessionKey] ?? sessionEntry;
+    modelState = await createModelSelectionState({
+      cfg,
+      agentId,
+      agentCfg,
+      sessionEntry: refreshedSessionEntry,
+      sessionStore,
+      sessionKey,
+      parentSessionKey:
+        refreshedSessionEntry.parentSessionKey ??
+        sessionCtx.ModelParentSessionKey ??
+        sessionCtx.ParentSessionKey,
+      storePath,
+      defaultProvider,
+      defaultModel,
+      primaryProvider,
+      primaryModel,
+      provider,
+      model,
+      hasModelDirective: directives.hasModelDirective,
+      hasOneTurnModelOverride: hasAppliedImageModelOverride,
+      hasResolvedHeartbeatModelOverride,
+      isHeartbeat: resolvedOpts?.isHeartbeat === true,
+      clearDirectAutoFallbackOverride: true,
+    });
+    provider = modelState.provider;
+    model = modelState.model;
+    if (refreshModelDefaultThinkingLevel) {
+      resolvedThinkLevel =
+        (await modelState.resolveDefaultThinkingLevel()) ??
+        (agentCfg?.thinkingDefault as typeof resolvedThinkLevel);
+    }
+    if (refreshModelDefaultReasoningLevel) {
+      resolvedReasoningLevel =
+        resolvedThinkLevel && resolvedThinkLevel !== "off"
+          ? "off"
+          : await modelState.resolveDefaultReasoningLevel();
+    }
+    contextTokens = resolveContextTokens({
+      cfg,
+      agentCfg,
+      provider,
+      model,
+    });
+  }
 
   // Allow plugins to intercept and return a synthetic reply before the LLM runs.
   if (!useFastTestBootstrap) {

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -901,6 +901,7 @@ describe("createModelSelectionState auto-failover overrides", () => {
     primaryProvider?: string;
     primaryModel?: string;
     isHeartbeat?: boolean;
+    clearDirectAutoFallbackOverride?: boolean;
   }) {
     const cfg = {} as OpenClawConfig;
     const sessionEntry = makeEntry({
@@ -928,15 +929,62 @@ describe("createModelSelectionState auto-failover overrides", () => {
       model: params.model ?? defaultModel,
       hasModelDirective: false,
       isHeartbeat: params.isHeartbeat,
+      clearDirectAutoFallbackOverride: params.clearDirectAutoFallbackOverride ?? true,
     });
     return { state, sessionEntry, sessionStore };
   }
 
-  it("preserves auto-failover overrides across turns until reset", async () => {
+  it("clears auto-failover override and retries the configured primary", async () => {
     const { state, sessionStore } = await resolveStateWithOverride({
       providerOverride: "openrouter",
       modelOverride: "minimax/minimax-m2.7",
       modelOverrideSource: "auto",
+    });
+
+    expect(state.provider).toBe(defaultProvider);
+    expect(state.model).toBe(defaultModel);
+    expect(sessionStore[sessionKey]?.providerOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverrideSource).toBeUndefined();
+    expect(state.resetModelOverride).toBe(false);
+  });
+
+  it("clears auto-failover override without replacing explicit heartbeat model", async () => {
+    const cfg = {} as OpenClawConfig;
+    const sessionEntry = makeEntry({
+      providerOverride: "openrouter",
+      modelOverride: "minimax/minimax-m2.7",
+      modelOverrideSource: "auto",
+    });
+    const sessionStore = { [sessionKey]: sessionEntry };
+
+    const state = await createModelSelectionState({
+      cfg,
+      agentCfg: cfg.agents?.defaults,
+      sessionEntry,
+      sessionStore,
+      sessionKey,
+      defaultProvider,
+      defaultModel,
+      provider: "openai",
+      model: "gpt-4o-mini",
+      hasModelDirective: false,
+      hasResolvedHeartbeatModelOverride: true,
+      clearDirectAutoFallbackOverride: true,
+    });
+
+    expect(state.provider).toBe("openai");
+    expect(state.model).toBe("gpt-4o-mini");
+    expect(sessionStore[sessionKey]?.providerOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverride).toBeUndefined();
+  });
+
+  it("keeps direct auto-failover override while only resolving directives", async () => {
+    const { state, sessionStore } = await resolveStateWithOverride({
+      providerOverride: "openrouter",
+      modelOverride: "minimax/minimax-m2.7",
+      modelOverrideSource: "auto",
+      clearDirectAutoFallbackOverride: false,
     });
 
     expect(state.provider).toBe("openrouter");
@@ -944,10 +992,49 @@ describe("createModelSelectionState auto-failover overrides", () => {
     expect(sessionStore[sessionKey]?.providerOverride).toBe("openrouter");
     expect(sessionStore[sessionKey]?.modelOverride).toBe("minimax/minimax-m2.7");
     expect(sessionStore[sessionKey]?.modelOverrideSource).toBe("auto");
-    expect(state.resetModelOverride).toBe(false);
   });
 
-  it("still clears disallowed auto-failover overrides through allowlist validation", async () => {
+  it("applies a parent override after clearing a child auto-failover override", async () => {
+    const cfg = {} as OpenClawConfig;
+    const parentSessionKey = "agent:main:telegram:direct";
+    const childEntry = makeEntry({
+      providerOverride: "openrouter",
+      modelOverride: "minimax/minimax-m2.7",
+      modelOverrideSource: "auto",
+    });
+    const parentEntry = makeEntry({
+      providerOverride: "anthropic",
+      modelOverride: "claude-sonnet-4-6",
+      modelOverrideSource: "user",
+    });
+    const sessionStore = {
+      [sessionKey]: childEntry,
+      [parentSessionKey]: parentEntry,
+    };
+
+    const state = await createModelSelectionState({
+      cfg,
+      agentCfg: cfg.agents?.defaults,
+      sessionEntry: childEntry,
+      sessionStore,
+      sessionKey,
+      parentSessionKey,
+      defaultProvider,
+      defaultModel,
+      provider: defaultProvider,
+      model: defaultModel,
+      hasModelDirective: false,
+      clearDirectAutoFallbackOverride: true,
+    });
+
+    expect(state.provider).toBe("anthropic");
+    expect(state.model).toBe("claude-sonnet-4-6");
+    expect(sessionStore[sessionKey]?.providerOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverride).toBeUndefined();
+    expect(sessionStore[parentSessionKey]?.providerOverride).toBe("anthropic");
+  });
+
+  it("clears auto-failover overrides before allowlist validation", async () => {
     const cfg = {
       agents: {
         defaults: {
@@ -976,15 +1063,18 @@ describe("createModelSelectionState auto-failover overrides", () => {
       provider: "openrouter",
       model: "minimax/minimax-m2.7",
       hasModelDirective: false,
+      clearDirectAutoFallbackOverride: true,
     });
 
-    expect(state.resetModelOverride).toBe(true);
+    expect(state.provider).toBe(defaultProvider);
+    expect(state.model).toBe(defaultModel);
+    expect(state.resetModelOverride).toBe(false);
     expect(sessionStore[sessionKey]?.providerOverride).toBeUndefined();
     expect(sessionStore[sessionKey]?.modelOverride).toBeUndefined();
     expect(sessionStore[sessionKey]?.modelOverrideSource).toBeUndefined();
   });
 
-  it("keeps pre-loaded fallback provider/model for an auto-failover override", async () => {
+  it("resets pre-loaded fallback provider/model for an auto-failover override", async () => {
     const cfg = {} as OpenClawConfig;
     const sessionEntry = makeEntry({
       providerOverride: "openrouter",
@@ -1003,11 +1093,14 @@ describe("createModelSelectionState auto-failover overrides", () => {
       provider: "openrouter",
       model: "minimax/minimax-m2.7",
       hasModelDirective: false,
+      clearDirectAutoFallbackOverride: true,
     });
 
-    expect(state.provider).toBe("openrouter");
-    expect(state.model).toBe("minimax/minimax-m2.7");
-    expect(sessionStore[sessionKey]?.modelOverrideSource).toBe("auto");
+    expect(state.provider).toBe(defaultProvider);
+    expect(state.model).toBe(defaultModel);
+    expect(sessionStore[sessionKey]?.providerOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverrideSource).toBeUndefined();
     expect(state.resetModelOverride).toBe(false);
   });
 
@@ -1025,8 +1118,8 @@ describe("createModelSelectionState auto-failover overrides", () => {
 
     expect(state.provider).toBe(defaultProvider);
     expect(state.model).toBe(defaultModel);
-    expect(state.resetModelOverride).toBe(true);
-    expect(state.resetModelOverrideRef).toBe("openrouter/minimax/minimax-m2.7");
+    expect(state.resetModelOverride).toBe(false);
+    expect(state.resetModelOverrideRef).toBeUndefined();
     expect(sessionStore[sessionKey]?.providerOverride).toBeUndefined();
     expect(sessionStore[sessionKey]?.modelOverride).toBeUndefined();
     expect(sessionStore[sessionKey]?.modelOverrideSource).toBeUndefined();
@@ -1060,14 +1153,14 @@ describe("createModelSelectionState auto-failover overrides", () => {
 
     expect(state.provider).toBe(defaultProvider);
     expect(state.model).toBe(defaultModel);
-    expect(state.resetModelOverride).toBe(true);
+    expect(state.resetModelOverride).toBe(false);
     expect(sessionStore[sessionKey]?.providerOverride).toBeUndefined();
     expect(sessionStore[sessionKey]?.modelOverride).toBeUndefined();
     expect(sessionStore[sessionKey]?.authProfileOverride).toBe("mac-studio:local");
     expect(sessionStore[sessionKey]?.authProfileOverrideSource).toBe("user");
   });
 
-  it("keeps heartbeat auto-failover override when the fallback origin still matches default", async () => {
+  it("clears heartbeat auto-failover override when the fallback origin still matches default", async () => {
     const { state, sessionStore } = await resolveStateWithOverride({
       providerOverride: "openrouter",
       modelOverride: "minimax/minimax-m2.7",
@@ -1079,14 +1172,15 @@ describe("createModelSelectionState auto-failover overrides", () => {
       isHeartbeat: true,
     });
 
-    expect(state.provider).toBe("openrouter");
-    expect(state.model).toBe("minimax/minimax-m2.7");
+    expect(state.provider).toBe(defaultProvider);
+    expect(state.model).toBe(defaultModel);
     expect(state.resetModelOverride).toBe(false);
-    expect(sessionStore[sessionKey]?.providerOverride).toBe("openrouter");
-    expect(sessionStore[sessionKey]?.modelOverride).toBe("minimax/minimax-m2.7");
+    expect(sessionStore[sessionKey]?.providerOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverrideSource).toBeUndefined();
   });
 
-  it("keeps heartbeat auto-failover override when the origin matches the channel primary", async () => {
+  it("clears heartbeat auto-failover override when the origin matches the channel primary", async () => {
     const { state, sessionStore } = await resolveStateWithOverride({
       providerOverride: "openrouter",
       modelOverride: "minimax/minimax-m2.7",
@@ -1100,14 +1194,15 @@ describe("createModelSelectionState auto-failover overrides", () => {
       isHeartbeat: true,
     });
 
-    expect(state.provider).toBe("openrouter");
-    expect(state.model).toBe("minimax/minimax-m2.7");
+    expect(state.provider).toBe("openai");
+    expect(state.model).toBe("gpt-4o");
     expect(state.resetModelOverride).toBe(false);
-    expect(sessionStore[sessionKey]?.providerOverride).toBe("openrouter");
-    expect(sessionStore[sessionKey]?.modelOverride).toBe("minimax/minimax-m2.7");
+    expect(sessionStore[sessionKey]?.providerOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverrideSource).toBeUndefined();
   });
 
-  it("keeps recovered heartbeat auto-failover override without modelOverrideSource", async () => {
+  it("clears recovered heartbeat auto-failover override without modelOverrideSource", async () => {
     const { state, sessionStore } = await resolveStateWithOverride({
       providerOverride: "openrouter",
       modelOverride: "minimax/minimax-m2.7",
@@ -1121,11 +1216,11 @@ describe("createModelSelectionState auto-failover overrides", () => {
       isHeartbeat: true,
     });
 
-    expect(state.provider).toBe("openrouter");
-    expect(state.model).toBe("minimax/minimax-m2.7");
+    expect(state.provider).toBe("openai");
+    expect(state.model).toBe("gpt-4o");
     expect(state.resetModelOverride).toBe(false);
-    expect(sessionStore[sessionKey]?.providerOverride).toBe("openrouter");
-    expect(sessionStore[sessionKey]?.modelOverride).toBe("minimax/minimax-m2.7");
+    expect(sessionStore[sessionKey]?.providerOverride).toBeUndefined();
+    expect(sessionStore[sessionKey]?.modelOverride).toBeUndefined();
     expect(sessionStore[sessionKey]?.modelOverrideSource).toBeUndefined();
   });
 
@@ -1141,13 +1236,13 @@ describe("createModelSelectionState auto-failover overrides", () => {
 
     expect(state.provider).toBe(defaultProvider);
     expect(state.model).toBe(defaultModel);
-    expect(state.resetModelOverride).toBe(true);
+    expect(state.resetModelOverride).toBe(false);
     expect(sessionStore[sessionKey]?.providerOverride).toBeUndefined();
     expect(sessionStore[sessionKey]?.modelOverride).toBeUndefined();
     expect(sessionStore[sessionKey]?.modelOverrideSource).toBeUndefined();
   });
 
-  it("uses fallback notice metadata for legacy heartbeat auto-failover overrides", async () => {
+  it("clears fallback-notice heartbeat auto-failover overrides", async () => {
     const { state, sessionStore } = await resolveStateWithOverride({
       providerOverride: "openrouter",
       modelOverride: "minimax/minimax-m2.7",
@@ -1158,10 +1253,10 @@ describe("createModelSelectionState auto-failover overrides", () => {
       isHeartbeat: true,
     });
 
-    expect(state.provider).toBe("openrouter");
-    expect(state.model).toBe("minimax/minimax-m2.7");
+    expect(state.provider).toBe(defaultProvider);
+    expect(state.model).toBe(defaultModel);
     expect(state.resetModelOverride).toBe(false);
-    expect(sessionStore[sessionKey]?.modelOverrideSource).toBe("auto");
+    expect(sessionStore[sessionKey]?.modelOverrideSource).toBeUndefined();
   });
 
   it("preserves a user-selected override across turns", async () => {

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -1,4 +1,7 @@
-import { resolveAgentConfig } from "../../agents/agent-scope.js";
+import {
+  hasSessionAutoModelFallbackProvenance,
+  resolveAgentConfig,
+} from "../../agents/agent-scope.js";
 import { clearSessionAuthProfileOverride } from "../../agents/auth-profiles/session-override.js";
 import { resolveContextTokensForModel } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
@@ -108,6 +111,7 @@ export async function createModelSelectionState(params: {
    *  In that case, skip session-stored overrides so the heartbeat selection wins. */
   hasResolvedHeartbeatModelOverride?: boolean;
   isHeartbeat?: boolean;
+  clearDirectAutoFallbackOverride?: boolean;
 }): Promise<ModelSelectionState> {
   const timingEnabled = shouldLogModelSelectionTiming();
   const startMs = timingEnabled ? Date.now() : 0;
@@ -171,6 +175,17 @@ export async function createModelSelectionState(params: {
   const directStoredModelOverride = directStoredOverride
     ? { ...directStoredOverride, source: "session" as const }
     : null;
+  const hasDirectAutoFallbackOverride = Boolean(
+    directStoredOverride &&
+    sessionEntry &&
+    (sessionEntry.modelOverrideSource === "auto" ||
+      (sessionEntry.modelOverrideSource === undefined &&
+        hasSessionAutoModelFallbackProvenance(sessionEntry))),
+  );
+  const shouldClearDirectAutoFallbackOverride =
+    hasDirectAutoFallbackOverride &&
+    params.clearDirectAutoFallbackOverride === true &&
+    !hasOneTurnModelOverride;
   const staleHeartbeatAutoFallbackOverride = isStaleHeartbeatAutoFallbackOverride({
     isHeartbeat: params.isHeartbeat,
     hasResolvedHeartbeatModelOverride: params.hasResolvedHeartbeatModelOverride,
@@ -216,11 +231,45 @@ export async function createModelSelectionState(params: {
     logStage("configured-catalog-ready", `entries=${configuredModelCatalog.length}`);
   }
 
+  if (shouldClearDirectAutoFallbackOverride && sessionEntry && sessionStore && sessionKey) {
+    const clearedSelectionProvider =
+      params.hasResolvedHeartbeatModelOverride === true ? provider : primaryProvider;
+    const clearedSelectionModel =
+      params.hasResolvedHeartbeatModelOverride === true ? model : primaryModel;
+    const { updated } = applyModelOverrideToSessionEntry({
+      entry: sessionEntry,
+      selection: {
+        provider: clearedSelectionProvider,
+        model: clearedSelectionModel,
+        isDefault: true,
+      },
+      preserveAuthProfileOverride: sessionEntry.authProfileOverrideSource === "user",
+    });
+    if (updated) {
+      sessionStore[sessionKey] = sessionEntry;
+      if (storePath) {
+        await (
+          await loadSessionStoreRuntime()
+        ).updateSessionStore(storePath, (store) => {
+          store[sessionKey] = sessionEntry;
+        });
+      }
+      provider = clearedSelectionProvider;
+      model = clearedSelectionModel;
+    }
+  } else if (shouldClearDirectAutoFallbackOverride) {
+    if (params.hasResolvedHeartbeatModelOverride !== true) {
+      provider = primaryProvider;
+      model = primaryModel;
+    }
+  }
+
   if (
     sessionEntry &&
     sessionStore &&
     sessionKey &&
     directStoredOverride &&
+    !hasDirectAutoFallbackOverride &&
     !hasOneTurnModelOverride
   ) {
     const normalizedOverride = normalizeModelRef(
@@ -250,7 +299,7 @@ export async function createModelSelectionState(params: {
       }
     }
   }
-  if (staleHeartbeatAutoFallbackOverride) {
+  if (staleHeartbeatAutoFallbackOverride && !hasDirectAutoFallbackOverride) {
     const normalizedCurrentSelection = normalizeModelRef(provider, model);
     const currentSelectionKey = modelKey(
       normalizedCurrentSelection.provider,
@@ -282,7 +331,10 @@ export async function createModelSelectionState(params: {
   const skipStoredOverride =
     hasOneTurnModelOverride ||
     params.hasResolvedHeartbeatModelOverride === true ||
-    (staleHeartbeatAutoFallbackOverride && storedOverride?.source === "session");
+    (shouldClearDirectAutoFallbackOverride && storedOverride?.source === "session") ||
+    (staleHeartbeatAutoFallbackOverride &&
+      !hasDirectAutoFallbackOverride &&
+      storedOverride?.source === "session");
 
   if (storedOverride?.model && !skipStoredOverride) {
     const normalizedStoredOverride = normalizeModelRef(


### PR DESCRIPTION
## Summary
- Clear direct auto-persisted fallback model session overrides before subsequent model runs so recovered primaries are retried.
- Preserve user/legacy session model overrides, directive/status views, explicit heartbeat model runs, parent inherited overrides, and user auth-profile pins.
- Update model failover docs and changelog. Fixes #82544.

## Verification
Behavior addressed: Sessions that auto-fallback no longer stay pinned to the fallback indefinitely; the next model run retries the configured primary and writes a fresh auto override only if fallback is still needed.
Real environment tested: local OpenClaw source checkout, focused model-selection, direct-agent, directive, and reply-run unit coverage for auto-fallback session override clearing, allowlist, heartbeat, recovered provenance, user override, parent override, deferred inline-status continuation, and media-only run behavior.
Exact steps or command run after this patch:
- `pnpm docs:list`
- `node scripts/run-vitest.mjs src/auto-reply/reply/get-reply-directives.target-session.test.ts src/auto-reply/reply/model-selection.test.ts src/agents/agent-command.live-model-switch.test.ts src/auto-reply/reply/get-reply-run.media-only.test.ts`
- `pnpm tsgo:core`
- `git diff --check`
- `/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review`
Evidence after fix: focused tests passed 162 tests; `tsgo:core` passed; Codex review reported no accepted/actionable findings.
Observed result after fix: direct auto fallback overrides clear before model-run selection, normal turns retry primary, explicit heartbeat model remains selected, user and legacy overrides remain sticky, directive/status paths can still show current fallback state, and parent inherited overrides are applied after child auto fallback clears.
What was not tested: live Slack/provider outage roundtrip; full suite.
