### PR TITLE
fix(usage): respect zero session log limits

### DIFF
--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -1692,6 +1692,39 @@ example
     expect(logs?.[0]?.content).toBe("hello there");
   });
 
+  it("returns no session usage logs for zero or invalid limits", async () => {
+    const root = await makeSessionCostRoot("logs-zero-limit");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionFile = path.join(sessionsDir, "sess-zero-limit.jsonl");
+
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "message",
+          timestamp: "2026-02-21T17:47:00.000Z",
+          message: { role: "user", content: "first" },
+        }),
+        JSON.stringify({
+          type: "message",
+          timestamp: "2026-02-21T17:48:00.000Z",
+          message: { role: "user", content: "second" },
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    await withStateDir(root, async () => {
+      await expect(loadSessionLogs({ sessionFile, limit: 0 })).resolves.toEqual([]);
+      await expect(loadSessionLogs({ sessionFile, limit: -1 })).resolves.toEqual([]);
+      await expect(loadSessionLogs({ sessionFile, limit: Number.NaN })).resolves.toEqual([]);
+      await expect(loadSessionLogs({ sessionFile, limit: 1 })).resolves.toMatchObject([
+        { content: "second" },
+      ]);
+    });
+  });
+
   it("buckets hourly message counts into UTC quarter-hour slots", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cost-quarter-"));
     const sessionFile = path.join(root, "session.jsonl");

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -1944,6 +1944,16 @@ export async function loadSessionUsageTimeSeries(params: {
   return { sessionId: params.sessionId, points: sortedPoints };
 }
 
+function normalizeSessionResultLimit(limit: number | undefined, fallback: number): number {
+  if (limit === undefined) {
+    return fallback;
+  }
+  if (!Number.isFinite(limit)) {
+    return 0;
+  }
+  return Math.max(0, Math.floor(limit));
+}
+
 export async function loadSessionLogs(params: {
   sessionId?: string;
   sessionEntry?: SessionEntry;
@@ -1958,7 +1968,10 @@ export async function loadSessionLogs(params: {
   }
 
   const logs: SessionLogEntry[] = [];
-  const limit = params.limit ?? 50;
+  const limit = normalizeSessionResultLimit(params.limit, 50);
+  if (limit === 0) {
+    return [];
+  }
 
   for await (const parsed of readJsonlRecords(sessionFile)) {
     try {


### PR DESCRIPTION
Fixes #82650

## Summary

- normalize explicit `loadSessionLogs` limits before applying the recent-log slice
- return `[]` for zero, negative, and non-finite limits instead of accidentally exposing all or the wrong subset of logs
- add regression coverage for zero, negative, `NaN`, and positive limit behavior

## Proof

- `pnpm vitest run src/infra/session-cost-usage.test.ts -t "returns no session usage logs for zero or invalid limits" --reporter=dot`
