### PR TITLE
fix(usage): handle zero timeseries max points

### DIFF
--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -1966,4 +1966,53 @@ example
     expect(lastPoint?.cumulativeTokens).toBe(165);
     expect(lastPoint?.cumulativeCost).toBeCloseTo(0.055, 8);
   });
+
+  it("returns no timeseries points when maxPoints is zero or invalid", async () => {
+    const root = await makeSessionCostRoot("timeseries-zero-maxpoints");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionFile = path.join(sessionsDir, "sess-zero-maxpoints.jsonl");
+
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({
+          type: "message",
+          timestamp: "2026-02-12T10:01:00.000Z",
+          message: {
+            role: "assistant",
+            provider: "openai",
+            model: "gpt-5.4",
+            usage: { input: 1, output: 2, totalTokens: 3, cost: { total: 0.001 } },
+          },
+        }),
+        JSON.stringify({
+          type: "message",
+          timestamp: "2026-02-12T10:02:00.000Z",
+          message: {
+            role: "assistant",
+            provider: "openai",
+            model: "gpt-5.4",
+            usage: { input: 2, output: 3, totalTokens: 5, cost: { total: 0.002 } },
+          },
+        }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    await expect(loadSessionUsageTimeSeries({ sessionFile, maxPoints: 0 })).resolves.toEqual({
+      sessionId: undefined,
+      points: [],
+    });
+    await expect(loadSessionUsageTimeSeries({ sessionFile, maxPoints: -1 })).resolves.toEqual({
+      sessionId: undefined,
+      points: [],
+    });
+    await expect(
+      loadSessionUsageTimeSeries({ sessionFile, maxPoints: Number.NaN }),
+    ).resolves.toEqual({
+      sessionId: undefined,
+      points: [],
+    });
+  });
 });

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -1895,7 +1895,15 @@ export async function loadSessionUsageTimeSeries(params: {
   const sortedPoints = points.toSorted((a, b) => a.timestamp - b.timestamp);
 
   // Optionally downsample if too many points
-  const maxPoints = params.maxPoints ?? 100;
+  const maxPoints =
+    params.maxPoints === undefined
+      ? 100
+      : Number.isFinite(params.maxPoints)
+        ? Math.max(0, Math.floor(params.maxPoints))
+        : 0;
+  if (maxPoints === 0) {
+    return { sessionId: params.sessionId, points: [] };
+  }
   if (sortedPoints.length > maxPoints) {
     const step = Math.ceil(sortedPoints.length / maxPoints);
     const downsampled: SessionUsageTimePoint[] = [];


### PR DESCRIPTION
Fixes #82651

## Summary

- normalize explicit `maxPoints` values for session usage time-series loading
- return an empty `points` array for zero, negative, and non-finite values instead of downsampling through an infinite step
- add regression coverage for `0`, negative, and `NaN` `maxPoints`

## Proof

- `pnpm vitest run src/infra/session-cost-usage.test.ts -t "returns no timeseries points when maxPoints is zero or invalid" --reporter=dot`
