### PR TITLE
docs(messages): clarify session key queue lanes

### DIFF
--- a/docs/concepts/messages.md
+++ b/docs/concepts/messages.md
@@ -69,12 +69,22 @@ Sessions are owned by the gateway, not by clients.
 - Groups/channels get their own session keys.
 - The session store and transcripts live on the gateway host.
 
+The resolved `sessionKey` also controls queueing. Runs with the same session
+key share one session lane, then contend for the configured global lane. Runs
+with different session keys can run in parallel up to the global concurrency
+cap.
+
+Changing `session.dmScope` changes which direct messages collapse into the same
+session key. That changes both context sharing and queue contention.
+
 Multiple devices/channels can map to the same session, but history is not fully
 synced back to every client. Recommendation: use one primary device for long
 conversations to avoid divergent context. The Control UI and TUI always show the
 gateway-backed session transcript, so they are the source of truth.
 
-Details: [Session management](/concepts/session).
+A `sessionKey` selects context; it is not a user authorization boundary. Details:
+[Session management](/concepts/session), [Command queue](/concepts/queue), and
+[Gateway security](/gateway/security).
 
 ## Tool result metadata
 


### PR DESCRIPTION
## Summary

- Problem: #72633 was closed because it introduced a broad standalone architecture page without current maintainer ownership.
- Why it matters: the existing Messages page names the routing -> session key -> queue flow, but does not connect session-key routing to queue lanes and the security boundary.
- What changed: add one short clarification under `docs/concepts/messages.md` explaining that `sessionKey` controls the per-session lane, global lane contention, and `session.dmScope` context/queue sharing.
- What did NOT change (scope boundary): no new docs page, no docs nav entry, no glossary/i18n changes, no new terminology surface.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #72633
- [ ] This PR fixes a bug or regression

## Concrete docs gap

The docs already cover these pieces separately:

- Messages: inbound flow uses `routing/bindings -> session key -> queue -> agent run`.
- Command Queue: embedded runs are serialized by `session:<key>` and then contend for a global lane.
- Session Management: `session.dmScope` changes how direct messages share or isolate session keys.
- Gateway Security: `sessionKey` is routing/context selection, not per-user authorization.

This PR connects those facts in the maintained Messages concept page instead of adding a new architecture guide.

## Real behavior proof (required for external PRs)

- Behavior addressed: docs-only clarification of current session-key queue behavior.
- Real environment tested: local OpenClaw source checkout on Windows with Node 24.13.0 and GitHub CLI 2.92.0.
- Exact steps or command run after this patch:
  - `node scripts/docs-list.js`
  - `git diff --check`
  - `node scripts/check-docs-mdx.mjs docs/concepts/messages.md`
  - `node scripts/docs-link-audit.mjs docs/concepts/messages.md`
- Evidence after fix: copied terminal output from the local docs checks:

```text
$ node scripts/check-docs-mdx.mjs docs/concepts/messages.md
Docs MDX check passed (1 files, 37ms).

$ node scripts/docs-link-audit.mjs docs/concepts/messages.md
checked_internal_links=4374
broken_links=0

$ git diff --check
(no output)
```
- Observed result after fix: `docs/concepts/messages.md` now connects session-key routing, per-session/global queue lanes, DM scope, and the security boundary in one existing concept page.
- What was not tested: full Mintlify publish build; no runtime behavior changed.

## Root Cause (if applicable)

N/A

## Regression Test Plan (if applicable)

N/A

## User-visible / Behavior Changes

Docs only. No runtime behavior change.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: Node 24.13.0, local source checkout
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Read `docs/concepts/messages.md`, `docs/concepts/queue.md`, `docs/concepts/session.md`, and `docs/gateway/security/index.md`.
2. Confirm the current source path resolves routing to `sessionKey`, session lanes, and global lanes.
3. Add the clarification to the existing Messages page only.
4. Run the docs checks listed above.

### Expected

- The Messages page briefly connects session keys to queue lanes and links to the canonical detailed pages.

### Actual

- The Messages page now includes that clarification without adding a new page or nav entry.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Docs-only before state: the page did not explain queue lane implications of `sessionKey`. After patch: local docs checks passed.

## Human Verification (required)

What I personally verified (not just CI), and how:

- Verified scenarios: checked current docs and source ownership for routing, queue lanes, DM scope, and session-key security wording.
- Edge cases checked: no nav/i18n/new-page surface added; links remain root-relative and valid.
- What I did **not** verify: full hosted docs build.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No bot review conversation is being addressed directly; this is a narrow resubmission after maintainer close guidance in #72633.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.


