### PR TITLE
fix(usage): guard invalid timeseries max points

### DIFF
--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -1962,4 +1962,49 @@ example
     expect(lastPoint?.cumulativeTokens).toBe(165);
     expect(lastPoint?.cumulativeCost).toBeCloseTo(0.055, 8);
   });
+
+  it("returns no timeseries points for non-positive and non-finite maxPoints", async () => {
+    const root = await makeSessionCostRoot("timeseries-invalid-max-points");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionFile = path.join(sessionsDir, "sess-invalid-max-points.jsonl");
+
+    const entries = [1, 2].map((idx) => ({
+      type: "message",
+      timestamp: new Date(Date.UTC(2026, 1, 12, 10, idx, 0)).toISOString(),
+      message: {
+        role: "assistant",
+        provider: "openai",
+        model: "gpt-5.4",
+        usage: {
+          input: idx,
+          output: idx,
+          totalTokens: idx * 2,
+          cost: { total: idx * 0.001 },
+        },
+      },
+    }));
+
+    await fs.writeFile(
+      sessionFile,
+      entries.map((entry) => JSON.stringify(entry)).join("\n"),
+      "utf-8",
+    );
+
+    for (const maxPoints of [
+      0,
+      -1,
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+    ]) {
+      const timeseries = await loadSessionUsageTimeSeries({
+        sessionFile,
+        maxPoints,
+      });
+
+      const series = requireValue(timeseries, "session usage timeseries missing");
+      expect(series.points).toEqual([]);
+    }
+  });
 });

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -1896,6 +1896,9 @@ export async function loadSessionUsageTimeSeries(params: {
 
   // Optionally downsample if too many points
   const maxPoints = params.maxPoints ?? 100;
+  if (!Number.isFinite(maxPoints) || maxPoints <= 0) {
+    return { sessionId: params.sessionId, points: [] };
+  }
   if (sortedPoints.length > maxPoints) {
     const step = Math.ceil(sortedPoints.length / maxPoints);
     const downsampled: SessionUsageTimePoint[] = [];


### PR DESCRIPTION
## Summary
- Guard `loadSessionUsageTimeSeries` against non-positive and non-finite `maxPoints` before downsampling math.
- Add regression coverage for `0`, negative, `NaN`, and infinities while keeping positive downsampling coverage intact.

Fixes #82651

## Verification
- `node scripts/run-vitest.mjs src/infra/session-cost-usage.test.ts`
- `corepack pnpm exec oxfmt --check --threads=1 src/infra/session-cost-usage.ts src/infra/session-cost-usage.test.ts`
- `git diff --check`

## Real behavior proof
Behavior addressed: `loadSessionUsageTimeSeries({ maxPoints: 0 })` no longer returns one aggregated point; invalid limits return an empty `points` array.
Real environment tested: Windows local OpenClaw checkout, importing the real `src/infra/session-cost-usage.ts` loader with `tsx` against a temporary session JSONL transcript.
Exact steps or command run after this patch: Created a temporary transcript with two assistant usage entries, then ran `corepack pnpm exec tsx $env:TEMP\openclaw-timeseries-proof.mts`; the script imported `loadSessionUsageTimeSeries` from the checkout and called it with `0`, `-1`, `NaN`, `Infinity`, `-Infinity`, and a positive `maxPoints: 1` control.
Evidence after fix: Terminal output from that runtime probe:

```json
{
  "invalidPointCounts": {
    "0": 0,
    "-1": 0,
    "NaN": 0,
    "Infinity": 0,
    "-Infinity": 0
  },
  "positiveMaxPointsOne": {
    "points": 1,
    "totalTokens": 12,
    "cumulativeTokens": 12
  }
}
```

Observed result after fix: Invalid `maxPoints` values returned zero points, while the positive downsampling control still returned one aggregated point preserving the transcript's 12 cumulative tokens.
What was not tested: Full local suite; remote CI covers the broader gates for this narrow loader/test change.