### PR TITLE
fix(voice-call): validate numeric cli options

### DIFF
--- a/extensions/voice-call/src/cli.test.ts
+++ b/extensions/voice-call/src/cli.test.ts
@@ -10,3 +10,23 @@ describe("voice-call CLI gateway fallback", () => {
     ).toBe(true);
   });
 });
+
+describe("voice-call CLI numeric options", () => {
+  it("parses bounded integer options", () => {
+    expect(__testing.parseBoundedIntegerOption(undefined, 25, { name: "--since", min: 0 })).toBe(
+      25,
+    );
+    expect(__testing.parseBoundedIntegerOption("12.9", 25, { name: "--since", min: 0 })).toBe(12);
+    expect(__testing.parseBoundedIntegerOption("-10", 25, { name: "--since", min: 0 })).toBe(0);
+    expect(__testing.parseBoundedIntegerOption("0", 200, { name: "--last", min: 1 })).toBe(1);
+  });
+
+  it("rejects invalid numeric option values", () => {
+    expect(() =>
+      __testing.parseBoundedIntegerOption("later", 25, { name: "--since", min: 0 }),
+    ).toThrow("--since must be a finite number");
+    expect(() =>
+      __testing.parseBoundedIntegerOption(Number.NaN, 250, { name: "--poll", min: 50 }),
+    ).toThrow("--poll must be a finite number");
+  });
+});

--- a/extensions/voice-call/src/cli.ts
+++ b/extensions/voice-call/src/cli.ts
@@ -61,6 +61,7 @@ export const __testing = {
     voiceCallCliDeps.callGatewayFromCli = next ?? callGatewayFromCli;
   },
   isGatewayUnavailableForLocalFallback,
+  parseBoundedIntegerOption,
 };
 
 function writeStdoutLine(...values: unknown[]): void {
@@ -221,6 +222,24 @@ function resolveDefaultStorePath(config: VoiceCallConfig): string {
     }) ?? resolvedPreferred;
   const base = config.store?.trim() ? resolveUserPath(config.store) : existing;
   return path.join(base, "calls.jsonl");
+}
+
+function parseBoundedIntegerOption(
+  value: unknown,
+  fallback: number,
+  opts: { name: string; min: number },
+): number {
+  const raw = value ?? fallback;
+  const parsed =
+    typeof raw === "number"
+      ? raw
+      : typeof raw === "string" && raw.trim()
+        ? Number(raw)
+        : Number.NaN;
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`${opts.name} must be a finite number`);
+  }
+  return Math.max(opts.min, Math.floor(parsed));
 }
 
 function percentile(values: number[], p: number): number {
@@ -708,8 +727,11 @@ export function registerVoiceCallCli(params: {
     .option("--poll <ms>", "Poll interval in ms", "250")
     .action(async (options: { file: string; since?: string; poll?: string }) => {
       const file = options.file;
-      const since = Math.max(0, Number(options.since ?? 0));
-      const pollMs = Math.max(50, Number(options.poll ?? 250));
+      const since = parseBoundedIntegerOption(options.since, 0, { name: "--since", min: 0 });
+      const pollMs = parseBoundedIntegerOption(options.poll, 250, {
+        name: "--poll",
+        min: 50,
+      });
 
       if (!fs.existsSync(file)) {
         logger.error(`No log file at ${file}`);
@@ -758,7 +780,7 @@ export function registerVoiceCallCli(params: {
     .option("--last <n>", "Analyze last N records", "200")
     .action(async (options: { file: string; last?: string }) => {
       const file = options.file;
-      const last = Math.max(1, Number(options.last ?? 200));
+      const last = parseBoundedIntegerOption(options.last, 200, { name: "--last", min: 1 });
 
       if (!fs.existsSync(file)) {
         throw new Error("No log file at " + file);
@@ -805,7 +827,10 @@ export function registerVoiceCallCli(params: {
     .action(
       async (options: { mode?: string; port?: string; path?: string; servePath?: string }) => {
         const mode = resolveMode(options.mode ?? "funnel");
-        const servePort = Number(options.port ?? config.serve.port ?? 3334);
+        const servePort = parseBoundedIntegerOption(options.port ?? config.serve.port, 3334, {
+          name: "--port",
+          min: 1,
+        });
         const servePath = options.servePath ?? config.serve.path ?? "/voice/webhook";
         const tsPath = options.path ?? config.tailscale?.path ?? servePath;
 


### PR DESCRIPTION
Fixes #82653

## Summary

- add a bounded integer parser for voice-call CLI numeric options
- reject non-finite numeric input instead of letting `NaN` flow into slices, sleeps, and webhook URLs
- clamp valid numeric inputs to each command's existing minimum bounds
- add regression coverage for valid, clamped, and invalid option values

## Proof

- `pnpm vitest run extensions/voice-call/src/cli.test.ts --reporter=dot`
