### PR TITLE
fix(agents): harden auth refresh redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 - Update/installers: override npm `min-release-age` quarantine for OpenClaw-managed package installs, so `openclaw update`, plugin updates, and hosted installer scripts can install the requested latest release immediately.
 - Agents/sessions: preserve fresh post-compaction token snapshots across stale usage updates, preventing repeated auto-compaction after every message. Fixes #82576. (#82578) Thanks @njuboy11.
 - Agents/OpenAI Responses: log redacted diagnostics for detail-less `response.failed` events while preserving failed response ids, so operators can correlate provider-side failures. Fixes #82558.
+- Agents/auth: redact OAuth refresh failure causes against in-memory, attempted, and reloaded credentials before generic token masking while ensuring failed ACP dispatch cleanup closes initialized runtimes.
 - Telegram: cache successful startup bot identity by account and token fingerprint for up to 24 hours, so restarts can skip redundant `getMe` probes during Telegram API slow periods without permanently pinning renamed bots. Refs #82525.
 - Gateway/sessions: discard stale metadata when recreating dead main session rows, so replacement sessions do not inherit old labels or transcript paths.
 - Codex app-server: mark native context compaction completion events as successful, preventing false "Compaction incomplete" notices after successful Codex-managed compaction. Fixes #82470. (#81593) Thanks @Kyzcreig.

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -2735,6 +2735,15 @@ describe("spawnAcpDirect", () => {
     expect(expectFailedSpawn(result, "error").error).toContain("agent dispatch failed");
     expect(relayHandle.dispose).toHaveBeenCalledTimes(1);
     expect(relayHandle.notifyStarted).not.toHaveBeenCalled();
+    expect(hoisted.cleanupFailedAcpSpawnMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeCloseHandle: expect.objectContaining({
+          handle: expect.objectContaining({
+            backend: "acpx",
+          }),
+        }),
+      }),
+    );
   });
 
   it('rejects streamTo="parent" without requester session context', async () => {

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -1440,6 +1440,7 @@ export async function spawnAcpDirect(
       sessionKey,
       shouldDeleteSession: true,
       deleteTranscript: true,
+      runtimeCloseHandle: initializedRuntime,
     });
     return createAcpSpawnFailure({
       status: "error",

--- a/src/agents/apply-patch.test.ts
+++ b/src/agents/apply-patch.test.ts
@@ -409,6 +409,38 @@ describe("applyPatch", () => {
     });
   });
 
+  it("rejects move targets whose parent path is a symlink outside cwd", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    await withTempDir(async (dir) => {
+      const outsideDir = await fs.mkdtemp(path.join(path.dirname(dir), "openclaw-patch-outside-"));
+      try {
+        const sourcePath = path.join(dir, "source.txt");
+        const outsideTarget = path.join(outsideDir, "moved.txt");
+        const linkDir = path.join(dir, "link");
+        await fs.writeFile(sourcePath, "before\n", "utf8");
+        await fs.symlink(outsideDir, linkDir);
+
+        const patch = `*** Begin Patch
+*** Update File: source.txt
+*** Move to: link/moved.txt
+@@
+-before
++after
+*** End Patch`;
+
+        await expect(applyPatch(patch, { cwd: dir })).rejects.toThrow(
+          /path alias under sandbox root|symlink escapes sandbox root/i,
+        );
+        await expect(fs.readFile(sourcePath, "utf8")).resolves.toBe("before\n");
+        await expectMissingPath(fs.readFile(outsideTarget, "utf8"));
+      } finally {
+        await fs.rm(outsideDir, { recursive: true, force: true });
+      }
+    });
+  });
+
   it.runIf(process.platform !== "win32")(
     "does not delete out-of-root files when a checked directory is rebound before remove",
     async () => {

--- a/src/agents/auth-profiles/oauth-manager.test.ts
+++ b/src/agents/auth-profiles/oauth-manager.test.ts
@@ -153,6 +153,40 @@ describe("OAuthManagerRefreshError", () => {
     expect(serialized).not.toContain("store-access");
     expect(serialized).not.toContain("store-refresh");
   });
+
+  it("redacts credential secrets from the refresh error message", () => {
+    const refreshedStore: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "openai-codex:default": createCredential({
+          access: "store-access",
+          refresh: "store-refresh",
+          idToken: "store-id-token",
+        }),
+      },
+    };
+    const error = new OAuthManagerRefreshError({
+      credential: createCredential({
+        access: "error-access",
+        refresh: "error-refresh",
+        idToken: "error-id-token",
+      }),
+      profileId: "openai-codex:default",
+      refreshedStore,
+      cause: new Error(
+        "refresh rejected error-access error-refresh error-id-token store-access store-refresh store-id-token",
+      ),
+    });
+
+    expect(error.message).toContain("refresh rejected");
+    expect(error.message).not.toContain("error-access");
+    expect(error.message).not.toContain("error-refresh");
+    expect(error.message).not.toContain("error-id-token");
+    expect(error.message).not.toContain("store-access");
+    expect(error.message).not.toContain("store-refresh");
+    expect(error.message).not.toContain("store-id-token");
+    expect(error.message.match(/\[redacted\]/g)?.length).toBe(6);
+  });
 });
 
 describe("createOAuthManager", () => {

--- a/src/agents/auth-profiles/oauth-manager.test.ts
+++ b/src/agents/auth-profiles/oauth-manager.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { formatErrorMessage } from "../../infra/errors.js";
 import { captureEnv } from "../../test-utils/env.js";
 import { __testing as externalAuthTesting } from "./external-auth.js";
 import {
@@ -186,6 +187,72 @@ describe("OAuthManagerRefreshError", () => {
     expect(error.message).not.toContain("store-refresh");
     expect(error.message).not.toContain("store-id-token");
     expect(error.message.match(/\[redacted\]/g)?.length).toBe(6);
+    const surfacedCauseMessage = formatErrorMessage(error.cause);
+    expect(surfacedCauseMessage).not.toContain("error-access");
+    expect(surfacedCauseMessage).not.toContain("error-refresh");
+    expect(surfacedCauseMessage).not.toContain("error-id-token");
+    expect(surfacedCauseMessage).not.toContain("store-access");
+    expect(surfacedCauseMessage).not.toContain("store-refresh");
+    expect(surfacedCauseMessage).not.toContain("store-id-token");
+    expect(surfacedCauseMessage.match(/\[redacted\]/g)?.length).toBe(6);
+  });
+
+  it("redacts token-shaped credential secrets before generic masking", () => {
+    const access = "sk-oauthreviewredaction1234567890zzzz";
+    const refresh = "ya29.oauthreviewredaction1234567890yyyy";
+    const error = new OAuthManagerRefreshError({
+      credential: createCredential({ access, refresh }),
+      profileId: "openai-codex:default",
+      refreshedStore: { version: 1, profiles: {} },
+      cause: new Error(`refresh rejected ${access} ${refresh}`, {
+        cause: new Error(`nested failure ${access}`),
+      }),
+    });
+
+    const surfacedCauseMessage = formatErrorMessage(error.cause);
+    for (const message of [error.message, surfacedCauseMessage]) {
+      expect(message).not.toContain(access);
+      expect(message).not.toContain(refresh);
+      expect(message).not.toContain("sk-oau");
+      expect(message).not.toContain("zzzz");
+      expect(message).not.toContain("ya29.o");
+      expect(message).not.toContain("yyyy");
+      expect(message.match(/\[redacted\]/g)?.length).toBe(3);
+    }
+  });
+
+  it.each([undefined, Symbol("refresh-failed"), () => "refresh-failed"])(
+    "formats non-json refresh failure values without throwing",
+    (cause) => {
+      const error = new OAuthManagerRefreshError({
+        credential: createCredential({
+          access: "sk-nonjsonredaction1234567890zzzz",
+        }),
+        profileId: "openai-codex:default",
+        refreshedStore: { version: 1, profiles: {} },
+        cause,
+      });
+
+      expect(error.message).toContain("OAuth token refresh failed");
+    },
+  );
+
+  it("redacts overlapping credential secrets longest first", () => {
+    const error = new OAuthManagerRefreshError({
+      credential: createCredential({
+        access: "abc123",
+        refresh: "abc123456",
+      }),
+      profileId: "openai-codex:default",
+      refreshedStore: { version: 1, profiles: {} },
+      cause: new Error("refresh rejected abc123 abc123456"),
+    });
+
+    expect(error.message).toContain("refresh rejected");
+    expect(error.message).not.toContain("abc123");
+    expect(error.message).not.toContain("abc123456");
+    expect(error.message).not.toContain("[redacted]456");
+    expect(error.message.match(/\[redacted\]/g)?.length).toBe(2);
   });
 });
 
@@ -379,5 +446,71 @@ describe("createOAuthManager", () => {
     expect(result.credential.provider).toBe("minimax-portal");
     expect(result.credential.access).toBe("rotated-access");
     expect(result.credential.refresh).toBe("rotated-refresh");
+  });
+
+  it("redacts the external oauth credential attempted during refresh failures", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "oauth-manager-refresh-redact-"));
+    tempDirs.push(tempRoot);
+    process.env.OPENCLAW_STATE_DIR = tempRoot;
+    const agentDir = path.join(tempRoot, "agents", "sub", "agent");
+    await fs.mkdir(agentDir, { recursive: true });
+    const profileId = "minimax-portal:default";
+    const localCredential = createCredential({
+      provider: "minimax-portal",
+      access: "fresh-local-access",
+      refresh: "fresh-local-refresh",
+      expires: Date.now() + 60_000,
+    });
+    const externalCredential = createCredential({
+      provider: "minimax-portal",
+      access: "external-attempt-access",
+      refresh: "external-attempt-refresh",
+      idToken: "external-attempt-id-token",
+      expires: Date.now() - 30_000,
+    });
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          [profileId]: localCredential,
+        },
+      },
+      agentDir,
+      { filterExternalAuthProfiles: false },
+    );
+
+    const manager = createOAuthManager({
+      buildApiKey: async (_provider, credential) => credential.access,
+      refreshCredential: vi.fn(async () => {
+        throw new Error(
+          "refresh rejected external-attempt-access external-attempt-refresh external-attempt-id-token",
+        );
+      }),
+      readBootstrapCredential: () => externalCredential,
+      isRefreshTokenReusedError: () => false,
+    });
+
+    try {
+      await manager.resolveOAuthAccess({
+        store: ensureAuthProfileStore(agentDir),
+        profileId,
+        credential: localCredential,
+        agentDir,
+        forceRefresh: true,
+      });
+      throw new Error("Expected refresh failure");
+    } catch (caught) {
+      if (!(caught instanceof OAuthManagerRefreshError)) {
+        throw caught;
+      }
+      expect(caught.message).toContain("refresh rejected");
+      expect(caught.message).not.toContain("external-attempt-access");
+      expect(caught.message).not.toContain("external-attempt-refresh");
+      expect(caught.message).not.toContain("external-attempt-id-token");
+      const surfacedCauseMessage = formatErrorMessage(caught.cause);
+      expect(surfacedCauseMessage).not.toContain("external-attempt-access");
+      expect(surfacedCauseMessage).not.toContain("external-attempt-refresh");
+      expect(surfacedCauseMessage).not.toContain("external-attempt-id-token");
+    }
   });
 });

--- a/src/agents/auth-profiles/oauth-manager.ts
+++ b/src/agents/auth-profiles/oauth-manager.ts
@@ -80,10 +80,17 @@ export class OAuthManagerRefreshError extends Error {
       structuredCause?.code === "refresh_contention" && structuredCause.cause
         ? structuredCause.cause
         : params.cause;
-    super(
-      `OAuth token refresh failed for ${params.credential.provider}: ${formatErrorMessage(params.cause)}`,
-      { cause: delegatedCause },
+    const storedCredential = params.refreshedStore.profiles[params.profileId];
+    const causeMessage = redactOAuthCredentialSecrets(
+      formatErrorMessage(params.cause),
+      collectOAuthCredentialSecrets(
+        params.credential,
+        storedCredential?.type === "oauth" ? storedCredential : undefined,
+      ),
     );
+    super(`OAuth token refresh failed for ${params.credential.provider}: ${causeMessage}`, {
+      cause: delegatedCause,
+    });
     this.name = "OAuthManagerRefreshError";
     this.#credential = params.credential;
     this.profileId = params.profileId;
@@ -152,6 +159,28 @@ function canReuseOAuthCredentialAfterRefreshFailure(params: {
   candidate: OAuthCredential;
 }): boolean {
   return !params.forceRefresh || hasOAuthCredentialChanged(params.attempted, params.candidate);
+}
+
+function collectOAuthCredentialSecrets(
+  ...credentials: Array<OAuthCredential | undefined>
+): string[] {
+  const secrets = new Set<string>();
+  for (const credential of credentials) {
+    for (const secret of [credential?.access, credential?.refresh, credential?.idToken]) {
+      if (secret) {
+        secrets.add(secret);
+      }
+    }
+  }
+  return Array.from(secrets);
+}
+
+function redactOAuthCredentialSecrets(message: string, secrets: string[]): string {
+  let redacted = message;
+  for (const secret of secrets) {
+    redacted = redacted.split(secret).join("[redacted]");
+  }
+  return redacted;
 }
 
 async function loadFreshStoredOAuthCredential(params: {

--- a/src/agents/auth-profiles/oauth-manager.ts
+++ b/src/agents/auth-profiles/oauth-manager.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { withFileLock } from "../../infra/file-lock.js";
+import { redactSensitiveText } from "../../logging/redact.js";
 import {
   AUTH_STORE_LOCK_OPTIONS,
   OAUTH_REFRESH_CALL_TIMEOUT_MS,
@@ -68,6 +69,7 @@ export class OAuthManagerRefreshError extends Error {
 
   constructor(params: {
     credential: OAuthCredential;
+    attemptedCredentials?: OAuthCredential[];
     profileId: string;
     refreshedStore: AuthProfileStore;
     cause: unknown;
@@ -81,15 +83,14 @@ export class OAuthManagerRefreshError extends Error {
         ? structuredCause.cause
         : params.cause;
     const storedCredential = params.refreshedStore.profiles[params.profileId];
-    const causeMessage = redactOAuthCredentialSecrets(
-      formatErrorMessage(params.cause),
-      collectOAuthCredentialSecrets(
-        params.credential,
-        storedCredential?.type === "oauth" ? storedCredential : undefined,
-      ),
+    const secrets = collectOAuthCredentialSecrets(
+      params.credential,
+      ...(params.attemptedCredentials ?? []),
+      storedCredential?.type === "oauth" ? storedCredential : undefined,
     );
+    const causeMessage = formatRedactedOAuthRefreshError(params.cause, secrets);
     super(`OAuth token refresh failed for ${params.credential.provider}: ${causeMessage}`, {
-      cause: delegatedCause,
+      cause: createRedactedOAuthRefreshCause(delegatedCause, secrets),
     });
     this.name = "OAuthManagerRefreshError";
     this.#credential = params.credential;
@@ -172,7 +173,7 @@ function collectOAuthCredentialSecrets(
       }
     }
   }
-  return Array.from(secrets);
+  return Array.from(secrets).toSorted((a, b) => b.length - a.length);
 }
 
 function redactOAuthCredentialSecrets(message: string, secrets: string[]): string {
@@ -181,6 +182,55 @@ function redactOAuthCredentialSecrets(message: string, secrets: string[]): strin
     redacted = redacted.split(secret).join("[redacted]");
   }
   return redacted;
+}
+
+function formatRawErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    let formatted = error.message || error.name || "Error";
+    let cause: unknown = error.cause;
+    const seen = new Set<unknown>([error]);
+    while (cause && !seen.has(cause)) {
+      seen.add(cause);
+      if (cause instanceof Error) {
+        if (cause.message) {
+          formatted += ` | ${cause.message}`;
+        }
+        cause = cause.cause;
+      } else if (typeof cause === "string") {
+        formatted += ` | ${cause}`;
+        break;
+      } else {
+        break;
+      }
+    }
+    return formatted;
+  }
+  if (
+    typeof error === "string" ||
+    typeof error === "number" ||
+    typeof error === "boolean" ||
+    typeof error === "bigint"
+  ) {
+    return String(error);
+  }
+  try {
+    return JSON.stringify(error) ?? String(error);
+  } catch {
+    return Object.prototype.toString.call(error);
+  }
+}
+
+function formatRedactedOAuthRefreshError(error: unknown, secrets: string[]): string {
+  return redactSensitiveText(redactOAuthCredentialSecrets(formatRawErrorMessage(error), secrets));
+}
+
+function createRedactedOAuthRefreshCause(cause: unknown, secrets: string[]): Error {
+  const redacted = formatRedactedOAuthRefreshError(cause, secrets);
+  const sanitized = new Error(redacted);
+  if (cause instanceof Error && cause.name) {
+    sanitized.name = cause.name;
+  }
+  return sanitized;
 }
 
 async function loadFreshStoredOAuthCredential(params: {
@@ -367,6 +417,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     agentDir?: string;
     cfg?: OpenClawConfig;
     forceRefresh?: boolean;
+    attemptedCredentials?: OAuthCredential[];
   }): Promise<ResolvedOAuthAccess | null> {
     const ownerAgentDir = resolvePersistedAuthProfileOwnerAgentDir(params);
     const authPath = resolveAuthStorePath(ownerAgentDir);
@@ -479,6 +530,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
             `refreshOAuthCredential(${cred.provider})`,
             OAUTH_REFRESH_CALL_TIMEOUT_MS,
             async () => {
+              params.attemptedCredentials?.push(credentialToRefresh);
               const refreshed = await adapter.refreshCredential(credentialToRefresh);
               return refreshed
                 ? ({
@@ -530,6 +582,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     agentDir?: string;
     cfg?: OpenClawConfig;
     forceRefresh?: boolean;
+    attemptedCredentials?: OAuthCredential[];
   }): Promise<ResolvedOAuthAccess | null> {
     const key = refreshQueueKey(params.provider, params.profileId);
     const prev = refreshQueues.get(key) ?? Promise.resolve();
@@ -569,6 +622,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
       credential: adoptedCredential,
       readBootstrapCredential: adapter.readBootstrapCredential,
     });
+    const attemptedCredentials: OAuthCredential[] = [];
 
     if (!params.forceRefresh && hasUsableOAuthCredential(effectiveCredential)) {
       return {
@@ -587,6 +641,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
         agentDir: params.agentDir,
         cfg: params.cfg,
         forceRefresh: params.forceRefresh,
+        attemptedCredentials,
       });
       return refreshed;
     } catch (error) {
@@ -638,6 +693,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
             agentDir: params.agentDir,
             cfg: params.cfg,
             forceRefresh: params.forceRefresh,
+            attemptedCredentials,
           });
           if (retried) {
             return retried;
@@ -712,6 +768,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
       }
       throw new OAuthManagerRefreshError({
         credential: params.credential,
+        attemptedCredentials: [effectiveCredential, ...attemptedCredentials],
         profileId: params.profileId,
         refreshedStore,
         cause: error,


### PR DESCRIPTION
## Summary

- Close initialized ACP runtimes when a spawn dispatch fails after runtime setup.
- Add apply-patch coverage for move targets whose parent path is a symlink outside the workspace.
- Redact OAuth refresh failure messages and surfaced causes against in-memory, attempted bootstrap, reloaded, token-shaped, and non-JSON refresh-failure values.
- Add a changelog entry for the agent/auth hardening.

Refs https://github.com/openclaw/openclaw/issues/42541, but does not close it. The provider-owned Gemini refresh fix remains owned by https://github.com/openclaw/openclaw/pull/78030.

## Related follow-up lanes

- Gemini provider-owned refresh behavior stays with https://github.com/openclaw/openclaw/pull/78030.
- Broader OAuth cooldown/logging policy from https://github.com/openclaw/openclaw/issues/42541 is a separate lane.
- Semantic-map leftovers outside this carveout: anthropic-transport-stream, agent-command, auth order/API-key rotation, and broader provider auth surfaces.

## Verification

Behavior addressed: failed ACP dispatch cleanup no longer leaves the initialized runtime handle open; OAuth refresh failures no longer surface credential material from current, attempted bootstrap, token-shaped, non-JSON, or reloaded credentials; apply-patch move-target symlink escapes stay rejected.

Real environment tested: local Codex worktree for focused Vitest proof, plus Blacksmith Testbox through Crabbox for `pnpm check:changed`.

Exact steps or command run after this patch:

```sh
node scripts/run-vitest.mjs src/agents/auth-profiles/oauth-manager.test.ts
node scripts/run-vitest.mjs src/agents/apply-patch.test.ts src/agents/apply-patch-paths.test.ts src/agents/acp-spawn.test.ts src/agents/auth-profiles/oauth-manager.test.ts
node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --blacksmith-org openclaw --blacksmith-workflow .github/workflows/ci-check-testbox.yml --blacksmith-job check --blacksmith-ref main --idle-timeout 90m --ttl 240m --timing-json -- CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_TEST_PROJECTS_PARALLEL=6 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm check:changed
.agents/skills/codex-review/scripts/codex-review --mode branch
git diff --check origin/main..HEAD
```

Evidence after fix: final auth-focused Vitest passed 2 files / 34 tests; the touched-surface suite passed 8 files / 214 tests earlier in the same review-fix loop; final Codex review helper reran a targeted set at 6 files / 180 tests and reported `codex-review clean: no accepted/actionable findings reported`; final Testbox-through-Crabbox passed with provider `blacksmith-testbox`, id `tbx_01krrx5hzp5h6bd3gne14354wj`, GitHub Actions run https://github.com/openclaw/openclaw/actions/runs/25968292153, exit 0.

Observed result after fix: cleanup receives the initialized ACP runtime close handle on dispatch failure, OAuth refresh wrapper/cause text redacts all credential variants under test before generic token masking, non-JSON refresh failure values do not replace the refresh error with a TypeError, and the changed gate reports 0 lint errors plus 0 runtime import cycles.

What was not tested: no live Gemini OAuth refresh was run here; https://github.com/openclaw/openclaw/pull/78030 owns that provider behavior and the closing path for #42541.
