### PR TITLE
fix(voice-call): validate numeric CLI flags instead of silently producing NaN (#82653)

### DIFF
--- a/extensions/voice-call/index.test.ts
+++ b/extensions/voice-call/index.test.ts
@@ -685,6 +685,22 @@ describe("voice-call plugin", () => {
     }
   });
 
+  it("CLI latency rejects non-numeric --last instead of running with NaN (#82653)", async () => {
+    const program = new Command();
+    const tmpFile = path.join(os.tmpdir(), `voicecall-nan-${Date.now()}.jsonl`);
+    fs.writeFileSync(tmpFile, JSON.stringify({ metadata: {} }) + "\n", "utf8");
+    try {
+      await registerVoiceCallCli(program);
+      await expect(
+        program.parseAsync(["voicecall", "latency", "--file", tmpFile, "--last", "nope"], {
+          from: "user",
+        }),
+      ).rejects.toThrow(/Invalid value for --last/);
+    } finally {
+      fs.unlinkSync(tmpFile);
+    }
+  });
+
   it("CLI start prints JSON", async () => {
     const program = new Command();
     const stdout = captureStdout();

--- a/extensions/voice-call/src/cli.ts
+++ b/extensions/voice-call/src/cli.ts
@@ -23,6 +23,33 @@ type Logger = {
   error: (message: string) => void;
 };
 
+/**
+ * Parse a finite non-negative integer CLI flag. Returns the clamped integer
+ * on success, or throws with a clear error message naming the offending flag
+ * and value. Replaces ad-hoc `Math.max(min, Number(value))` patterns that
+ * silently propagate `NaN` into timers / URLs / slices. See #82653.
+ */
+function parseFiniteIntCliOption(params: {
+  flag: string;
+  rawValue: string | undefined;
+  defaultValue: number;
+  min: number;
+}): number {
+  const raw = params.rawValue ?? String(params.defaultValue);
+  const trimmed = typeof raw === "string" ? raw.trim() : raw;
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(
+      `Invalid value for ${params.flag}: ${JSON.stringify(raw)} is not a finite number.`,
+    );
+  }
+  const integral = Math.trunc(parsed);
+  if (integral < params.min) {
+    return params.min;
+  }
+  return integral;
+}
+
 type SetupCheck = {
   id: string;
   ok: boolean;
@@ -708,8 +735,18 @@ export function registerVoiceCallCli(params: {
     .option("--poll <ms>", "Poll interval in ms", "250")
     .action(async (options: { file: string; since?: string; poll?: string }) => {
       const file = options.file;
-      const since = Math.max(0, Number(options.since ?? 0));
-      const pollMs = Math.max(50, Number(options.poll ?? 250));
+      const since = parseFiniteIntCliOption({
+        flag: "--since",
+        rawValue: options.since,
+        defaultValue: 25,
+        min: 0,
+      });
+      const pollMs = parseFiniteIntCliOption({
+        flag: "--poll",
+        rawValue: options.poll,
+        defaultValue: 250,
+        min: 50,
+      });
 
       if (!fs.existsSync(file)) {
         logger.error(`No log file at ${file}`);
@@ -758,7 +795,12 @@ export function registerVoiceCallCli(params: {
     .option("--last <n>", "Analyze last N records", "200")
     .action(async (options: { file: string; last?: string }) => {
       const file = options.file;
-      const last = Math.max(1, Number(options.last ?? 200));
+      const last = parseFiniteIntCliOption({
+        flag: "--last",
+        rawValue: options.last,
+        defaultValue: 200,
+        min: 1,
+      });
 
       if (!fs.existsSync(file)) {
         throw new Error("No log file at " + file);
@@ -805,7 +847,12 @@ export function registerVoiceCallCli(params: {
     .action(
       async (options: { mode?: string; port?: string; path?: string; servePath?: string }) => {
         const mode = resolveMode(options.mode ?? "funnel");
-        const servePort = Number(options.port ?? config.serve.port ?? 3334);
+        const servePort = parseFiniteIntCliOption({
+          flag: "--port",
+          rawValue: options.port ?? String(config.serve.port ?? 3334),
+          defaultValue: 3334,
+          min: 1,
+        });
         const servePath = options.servePath ?? config.serve.path ?? "/voice/webhook";
         const tsPath = options.path ?? config.tailscale?.path ?? servePath;
 


### PR DESCRIPTION
## Real behavior proof

- **Behavior or issue addressed:** Four voicecall CLI commands (`tail --since`, `tail --poll`, `latency --last`, `expose --port`) accept invalid numeric flag values and propagate `NaN` into `sleep()`, `slice()`, and constructed URLs like `http://127.0.0.1:NaN`. Fixes #82653.
- **Root cause:** Each flag is parsed with `Math.max(min, Number(options.flag ?? default))`. `Number("nope")` is `NaN`, and `Math.max(0, NaN)` is `NaN` (per IEEE-754 / ECMA-262 semantics). The bad value then leaks through the entire command.
- **Fix surface:** Single file (`extensions/voice-call/src/cli.ts`) — introduce `parseFiniteIntCliOption({ flag, rawValue, defaultValue, min })` that rejects `NaN` / `Infinity` with a clear error naming the flag and value, then truncates and clamps. Wire it through the four affected call sites.
- **Existing-helper check (vincentkoc #57341):** The repo has no existing CLI-flag numeric validator (`grep -rn 'parseFinite\|parseInt.*flag'` came back empty). The new helper is private to this file. Pattern mirrors the codebase's existing `Number.isFinite` guards (e.g. `extensions/voice-call/src/cli.ts:780` uses `typeof latency === "number" && Number.isFinite(latency)` for log parsing).
- **Shared-helper caller check (steipete #60623):** `parseFiniteIntCliOption` is private to `cli.ts` with four call sites — all four are updated in this PR. No external callers; semantics are documented in the JSDoc.
- **Broader-fix rival scan (steipete #68270):** No rival PR open. Reporter `jbetala7` filed five small numeric-validation bugs in a single sweep (#82644, #82646, #82650, #82651, #82653); the other four are addressed in PR #82654, PR #82656, and PR #82672. This PR handles #82653 in isolation since it lives in a different package.
- **Live verification:** Added `extensions/voice-call/index.test.ts` regression "CLI latency rejects non-numeric --last instead of running with NaN" that drives `voicecall latency --file ... --last nope` through the CLI parser and asserts the thrown error matches `/Invalid value for --last/`. Existing latency test (line 657) keeps passing because it passes `--last 10` (valid).
- **Backward compatibility:** Valid numeric inputs (positive integers, decimals that truncate cleanly, the documented defaults) keep working with the same clamp semantics. Only invalid (non-numeric, `Infinity`, `NaN`) values change behaviour — from silent failure to fail-fast with a clear error.