### PR TITLE
fix: handle empty diagnostic phase limits

### DIFF
--- a/src/logging/diagnostic-phase.test.ts
+++ b/src/logging/diagnostic-phase.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  getRecentDiagnosticPhases,
+  recordDiagnosticPhase,
+  resetDiagnosticPhasesForTest,
+} from "./diagnostic-phase.js";
+
+function recordPhase(name: string): void {
+  recordDiagnosticPhase({
+    name,
+    startedAt: 100,
+    endedAt: 110,
+    durationMs: 10,
+  });
+}
+
+beforeEach(() => {
+  resetDiagnosticPhasesForTest();
+});
+
+describe("diagnostic phase snapshots", () => {
+  it("returns an empty list for non-positive and non-finite limits", () => {
+    recordPhase("first");
+    recordPhase("second");
+
+    expect(getRecentDiagnosticPhases(0)).toStrictEqual([]);
+    expect(getRecentDiagnosticPhases(-1)).toStrictEqual([]);
+    expect(getRecentDiagnosticPhases(Number.NaN)).toStrictEqual([]);
+    expect(getRecentDiagnosticPhases(Number.POSITIVE_INFINITY)).toStrictEqual([]);
+  });
+
+  it("returns copies of the most recent phases for positive limits", () => {
+    recordPhase("first");
+    recordPhase("second");
+    recordPhase("third");
+
+    const phases = getRecentDiagnosticPhases(2);
+
+    expect(phases.map((phase) => phase.name)).toStrictEqual(["second", "third"]);
+    phases[0]!.name = "mutated";
+    expect(getRecentDiagnosticPhases(2).map((phase) => phase.name)).toStrictEqual([
+      "second",
+      "third",
+    ]);
+  });
+});

--- a/src/logging/diagnostic-phase.ts
+++ b/src/logging/diagnostic-phase.ts
@@ -39,7 +39,11 @@ export function getCurrentDiagnosticPhase(): string | undefined {
 }
 
 export function getRecentDiagnosticPhases(limit = 8): DiagnosticPhaseSnapshot[] {
-  return recentPhases.slice(-Math.max(0, limit)).map((phase) => Object.assign({}, phase));
+  const normalizedLimit = Math.trunc(limit);
+  if (!Number.isFinite(normalizedLimit) || normalizedLimit <= 0) {
+    return [];
+  }
+  return recentPhases.slice(-normalizedLimit).map((phase) => Object.assign({}, phase));
 }
 
 export function recordDiagnosticPhase(snapshot: DiagnosticPhaseSnapshot): void {


### PR DESCRIPTION
## Summary

- Return an empty recent diagnostic phase list when `limit` is zero, negative, `NaN`, or infinite.
- Preserve existing positive-limit behavior by returning the most recent snapshots as copies.
- Add focused regression coverage for the diagnostic phase helper.

Fixes #82646.

## Verification

- `git diff --check -- src/logging/diagnostic-phase.ts src/logging/diagnostic-phase.test.ts`
- Local Node probe for the limit normalization behavior

I could not run `node scripts/run-vitest.mjs src/logging/diagnostic-phase.test.ts` locally because cloning/checking out the full OpenClaw repository repeatedly stalled over GitHub smart HTTP on this machine, so this PR was prepared through the GitHub API from the upstream `main` tree.
