### PR TITLE
fix(gateway): redact credential-bearing diagnostics

### DIFF
--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -695,6 +695,21 @@ describe("buildGatewayConnectionDetails", () => {
     expect(details.message).toContain("Source: cli --url");
   });
 
+  it("redacts credential-bearing target URLs from connection messages", () => {
+    setLocalLoopbackGatewayConfig(18800);
+
+    const details = buildGatewayConnectionDetails({
+      url: "wss://user:pass@example.com/ws?token=secret-token&keep=visible",
+    });
+
+    expect(details.url).toBe("wss://user:pass@example.com/ws?token=secret-token&keep=visible");
+    expect(details.message).toContain(
+      "Gateway target: wss://***:***@example.com/ws?token=***&keep=visible",
+    );
+    expect(details.message).not.toContain("user:pass");
+    expect(details.message).not.toContain("secret-token");
+  });
+
   it("emits a remote fallback note when remote url is missing", () => {
     getRuntimeConfig.mockReturnValue({
       gateway: { mode: "remote", bind: "loopback", remote: {} },
@@ -822,6 +837,28 @@ describe("buildGatewayConnectionDetails", () => {
     expect((thrown as Error).message).toContain("wss://");
     expect((thrown as Error).message).toContain("Tailscale Serve/Funnel");
     expect((thrown as Error).message).toContain("openclaw doctor --fix");
+  });
+
+  it("redacts credential-bearing target URLs from insecure ws:// errors", () => {
+    getRuntimeConfig.mockReturnValue({
+      gateway: {
+        mode: "remote",
+        bind: "loopback",
+        remote: { url: "ws://user:pass@remote.example.com:18789/ws?token=secret-token" },
+      },
+    });
+    resolveGatewayPort.mockReturnValue(18789);
+
+    expect(() => buildGatewayConnectionDetails()).toThrow(
+      'Gateway URL "ws://***:***@remote.example.com:18789/ws?token=***" uses plaintext',
+    );
+    try {
+      buildGatewayConnectionDetails();
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).not.toContain("user:pass");
+      expect((error as Error).message).not.toContain("secret-token");
+    }
   });
 
   it("allows ws:// private remote URLs only when OPENCLAW_ALLOW_INSECURE_PRIVATE_WS=1", () => {

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -4,6 +4,11 @@ import type { DeviceIdentity } from "../infra/device-identity.js";
 import { captureEnv } from "../test-utils/env.js";
 import { MIN_CLIENT_PROTOCOL_VERSION, PROTOCOL_VERSION } from "./protocol/index.js";
 
+type MockLoggingConfig = {
+  redactPatterns?: string[];
+  redactSensitive?: "off" | "tools";
+};
+
 const wsInstances = vi.hoisted((): MockWebSocket[] => []);
 const wsConstructorObservers = vi.hoisted((): Array<(url: string, options: unknown) => void> => []);
 const clearDeviceAuthTokenMock = vi.hoisted(() => vi.fn());
@@ -11,6 +16,9 @@ const loadDeviceAuthTokenMock = vi.hoisted(() => vi.fn());
 const storeDeviceAuthTokenMock = vi.hoisted(() => vi.fn());
 const logDebugMock = vi.hoisted(() => vi.fn());
 const logErrorMock = vi.hoisted(() => vi.fn());
+const readLoggingConfigMock = vi.hoisted(() =>
+  vi.fn<() => MockLoggingConfig | undefined>(() => undefined),
+);
 const {
   installGlobalProxyMock,
   proxylineRegisterBypassMock,
@@ -164,6 +172,15 @@ vi.mock("../logger.js", async () => {
     ...actual,
     logDebug: (...args: unknown[]) => logDebugMock(...args),
     logError: (...args: unknown[]) => logErrorMock(...args),
+  };
+});
+
+vi.mock("../logging/config.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../logging/config.js")>("../logging/config.js");
+  return {
+    ...actual,
+    readLoggingConfig: () => readLoggingConfigMock(),
   };
 });
 
@@ -820,6 +837,8 @@ describe("GatewayClient connect auth payload", () => {
     clearDeviceAuthTokenMock.mockReset();
     loadDeviceAuthTokenMock.mockReset();
     storeDeviceAuthTokenMock.mockReset();
+    readLoggingConfigMock.mockReset();
+    readLoggingConfigMock.mockReturnValue(undefined);
     logDebugMock.mockClear();
     logErrorMock.mockClear();
   });
@@ -1065,6 +1084,82 @@ describe("GatewayClient connect auth payload", () => {
       "gateway connect failed: Error: gateway client stopped",
     );
     expect(ws.closeCalls).toBe(1);
+  });
+
+  it("redacts secret-bearing connect failure logs", async () => {
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      token: "shared-token",
+      deviceIdentity: null,
+    });
+
+    const { ws, connect } = startClientAndConnect({ client });
+    emitConnectFailure(
+      ws,
+      connect.id,
+      { code: "AUTH_UNAUTHORIZED" },
+      "Authorization: Bearer sk-testsecret1234567890abcd wss://user:pass@gateway.example/ws?token=secret-token", // pragma: allowlist secret
+    );
+
+    await vi.waitFor(() => {
+      expect(logErrorMock).toHaveBeenCalledWith(expect.stringContaining("gateway connect failed:"));
+    });
+    const logged = String(logErrorMock.mock.calls.at(-1)?.[0] ?? "");
+    expect(logged).toContain("Authorization: Bearer");
+    expect(logged).not.toContain("sk-testsecret1234567890abcd");
+    expect(logged).not.toContain("user:pass");
+    expect(logged).not.toContain("secret-token");
+    client.stop();
+  });
+
+  it("preserves trailing diagnostics after redacted connect failure URL query params", async () => {
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      token: "shared-token",
+      deviceIdentity: null,
+    });
+
+    const { ws, connect } = startClientAndConnect({ client });
+    emitConnectFailure(
+      ws,
+      connect.id,
+      { code: "AUTH_UNAUTHORIZED" },
+      "wss://gateway.example/ws?token=secret-token failed with 401 from remote gateway", // pragma: allowlist secret
+    );
+
+    await vi.waitFor(() => {
+      expect(logErrorMock).toHaveBeenCalledWith(expect.stringContaining("gateway connect failed:"));
+    });
+    const logged = String(logErrorMock.mock.calls.at(-1)?.[0] ?? "");
+    expect(logged).toContain("wss://gateway.example/ws?token=*** failed with 401");
+    expect(logged).toContain("from remote gateway");
+    expect(logged).not.toContain("secret-token");
+    client.stop();
+  });
+
+  it("forces secret redaction for connect failure logs when general log redaction is off", async () => {
+    readLoggingConfigMock.mockReturnValue({ redactSensitive: "off" });
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      token: "shared-token",
+      deviceIdentity: null,
+    });
+
+    const { ws, connect } = startClientAndConnect({ client });
+    emitConnectFailure(
+      ws,
+      connect.id,
+      { code: "AUTH_UNAUTHORIZED" },
+      "Authorization: Bearer sk-disabledredaction1234567890abcd", // pragma: allowlist secret
+    );
+
+    await vi.waitFor(() => {
+      expect(logErrorMock).toHaveBeenCalledWith(expect.stringContaining("gateway connect failed:"));
+    });
+    const logged = String(logErrorMock.mock.calls.at(-1)?.[0] ?? "");
+    expect(logged).toContain("Authorization: Bearer");
+    expect(logged).not.toContain("sk-disabledredaction1234567890abcd");
+    client.stop();
   });
 
   it("uses explicit shared password and does not inject stored device token", () => {

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -18,6 +18,8 @@ import {
 import { normalizeFingerprint } from "../infra/tls/fingerprint.js";
 import { rawDataToString } from "../infra/ws.js";
 import { logDebug, logError } from "../logger.js";
+import { redactToolPayloadText } from "../logging/redact.js";
+import { isSensitiveUrlQueryParamName } from "../shared/net/redact-sensitive-url.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -188,6 +190,15 @@ function readConnectChallengeTimeoutOverride(
 function isGatewayClientStoppedError(err: unknown): boolean {
   const message = err instanceof Error ? err.message : String(err);
   return message === "gateway client stopped" || message === "Error: gateway client stopped";
+}
+
+function formatGatewayClientErrorForLog(err: unknown): string {
+  const redactedUrlLikeString = String(err)
+    .replace(/\/\/([^@/?#\s]+)@/g, "//***:***@")
+    .replace(/([?&])([^=&\s]+)=([^&#\s"'<>)]*)/g, (match, prefix: string, key: string) =>
+      isSensitiveUrlQueryParamName(key) ? `${prefix}${key}=***` : match,
+    );
+  return redactToolPayloadText(redactedUrlLikeString);
 }
 
 export function resolveGatewayClientConnectChallengeTimeoutMs(
@@ -398,7 +409,7 @@ export class GatewayClient {
       this.opts.onClose?.(code, reasonText);
     });
     ws.on("error", (err) => {
-      logDebug(`gateway client error: ${String(err)}`);
+      logDebug(`gateway client error: ${formatGatewayClientErrorForLog(err)}`);
       if (!this.connectSent) {
         this.opts.onConnectError?.(err instanceof Error ? err : new Error(String(err)));
       }
@@ -655,7 +666,7 @@ export class GatewayClient {
         const startupRetryAfterMs = resolveGatewayStartupRetryAfterMs(err);
         if (startupRetryAfterMs !== null) {
           this.pendingStartupReconnectDelayMs = startupRetryAfterMs;
-          logDebug(`gateway connect failed: ${String(err)}`);
+          logDebug(`gateway connect failed: ${formatGatewayClientErrorForLog(err)}`);
           this.ws?.close(1013, "gateway starting");
           return;
         }
@@ -673,7 +684,7 @@ export class GatewayClient {
           return;
         }
         this.opts.onConnectError?.(err instanceof Error ? err : new Error(String(err)));
-        const msg = `gateway connect failed: ${String(err)}`;
+        const msg = `gateway connect failed: ${formatGatewayClientErrorForLog(err)}`;
         if (this.opts.mode === GATEWAY_CLIENT_MODES.PROBE || isGatewayClientStoppedError(err)) {
           logDebug(msg);
         } else {
@@ -941,7 +952,7 @@ export class GatewayClient {
         }
       }
     } catch (err) {
-      logDebug(`gateway client parse error: ${String(err)}`);
+      logDebug(`gateway client parse error: ${formatGatewayClientErrorForLog(err)}`);
     }
   }
 

--- a/src/gateway/connection-details.ts
+++ b/src/gateway/connection-details.ts
@@ -1,5 +1,6 @@
 import { resolveConfigPath, resolveGatewayPort } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.js";
+import { redactSensitiveUrlLikeString } from "../shared/net/redact-sensitive-url.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { isSecureWebSocketUrl } from "./net.js";
 
@@ -51,6 +52,7 @@ export function buildGatewayConnectionDetailsWithResolvers(
   const urlSourceHint =
     options.urlSource ?? (cliUrlOverride ? "cli" : envUrlOverride ? "env" : undefined);
   const url = urlOverride || remoteUrl || localUrl;
+  const displayUrl = redactSensitiveUrlLikeString(url);
   const urlSource = urlOverride
     ? urlSourceHint === "env"
       ? "env OPENCLAW_GATEWAY_URL"
@@ -69,7 +71,7 @@ export function buildGatewayConnectionDetailsWithResolvers(
   if (!isSecureWebSocketUrl(url, { allowPrivateWs })) {
     throw new Error(
       [
-        `SECURITY ERROR: Gateway URL "${url}" uses plaintext ws:// to a non-loopback address.`,
+        `SECURITY ERROR: Gateway URL "${displayUrl}" uses plaintext ws:// to a non-loopback address.`,
         "Both credentials and chat data would be exposed to network interception.",
         `Source: ${urlSource}`,
         `Config: ${configPath}`,
@@ -87,7 +89,7 @@ export function buildGatewayConnectionDetailsWithResolvers(
   }
 
   const message = [
-    `Gateway target: ${url}`,
+    `Gateway target: ${displayUrl}`,
     `Source: ${urlSource}`,
     `Config: ${configPath}`,
     bindDetail,


### PR DESCRIPTION
## Summary

- Redacts credential-bearing gateway target URLs before they are shown in connection detail messages or plaintext-URL safety errors.
- Redacts Gateway client connect/error/parse diagnostics before they hit debug/error logs, including when `logging.redactSensitive` is `off`.
- Preserves non-secret diagnostic suffixes after redacted URL query params, so errors like `?token=... failed with 401` keep the `failed with 401` context.

## Related

- Related, not closed: https://github.com/openclaw/openclaw/issues/66832 (`logs.tail` shared redaction formats; separate surface)
- Related, not closed: https://github.com/openclaw/openclaw/pull/67041 (candidate fix for #66832)
- Related, not closed: https://github.com/openclaw/openclaw/pull/79233 (gateway transport failure output; adjacent but separate)

No closing refs: this patch is a gateway diagnostic redaction reliability pass, not the `logs.tail` issue fix.

## Verification

- `node scripts/run-vitest.mjs src/gateway/client.test.ts -- --reporter=verbose -t "connect failure logs"`
  - passed: `2 passed`, `90 passed`
- `node scripts/run-vitest.mjs src/gateway/call.test.ts src/gateway/client.test.ts -- --reporter=dot`
  - passed: `5 passed`, `333 passed`
- `git diff --check`
  - passed
- `node scripts/crabbox-wrapper.mjs run -provider blacksmith-testbox -blacksmith-org openclaw -blacksmith-workflow .github/workflows/ci-check-testbox.yml -blacksmith-job check -blacksmith-ref main -idle-timeout 90m -ttl 240m -timing-json -shell -- "CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_TEST_PROJECTS_PARALLEL=6 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm check:changed"`
  - passed: `tbx_01krrwjvepsj3458ybk6bk1k6j`, https://github.com/openclaw/openclaw/actions/runs/25968066889

## Real behavior proof

Behavior addressed: Gateway diagnostic strings no longer expose credential-bearing target URLs, Authorization bearer values, URL userinfo, or sensitive query params in connection/error logs, while preserving non-secret trailing diagnostic text.

Real environment tested: local Codex worktree for focused Vitest proof, plus Blacksmith Testbox for `pnpm check:changed`.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/gateway/call.test.ts src/gateway/client.test.ts -- --reporter=dot`; `OPENCLAW_TESTBOX=1 ... pnpm check:changed` through `node scripts/crabbox-wrapper.mjs run -provider blacksmith-testbox ...`.

Evidence after fix: focused tests assert raw `details.url` still preserves connection behavior, display/error strings redact `user:pass` and `token=...`, connect failure logs redact bearer tokens and URL credentials even with `logging.redactSensitive: off`, and the regression case preserves `failed with 401` after `?token=***`.

Observed result after fix: focused gateway tests passed and Testbox `check:changed` exited 0.

What was not tested: live remote gateway connection against a real credential-bearing URL; the fix is covered at the formatter/connection-details boundary with fake credentials.
