### PR TITLE
feat(cli): config unset --dry-run with runConfigOperations architecture

### DIFF
--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -37,6 +37,7 @@ openclaw config set channels.discord.token --ref-provider default --ref-source e
 openclaw config set secrets.providers.vaultfile --provider-source file --provider-path /etc/openclaw/secrets.json --provider-mode json
 openclaw config patch --file ./openclaw.patch.json5 --dry-run
 openclaw config unset plugins.entries.brave.config.webSearch.apiKey
+openclaw config unset secrets.providers.env-provider --dry-run
 openclaw config set channels.discord.token --ref-provider default --ref-source env --ref-id DISCORD_BOT_TOKEN --dry-run
 openclaw config validate
 openclaw config validate --json
@@ -237,6 +238,80 @@ openclaw config set secrets.providers.vaultfile \
   '{"source":"file","path":"/etc/openclaw/secrets.json","mode":"json"}' \
   --strict-json
 ```
+
+## `config unset`
+
+Remove a config value by dot path. Use `--dry-run` to validate the removal before committing.
+
+```bash
+openclaw config unset plugins.entries.brave.config.webSearch.apiKey
+openclaw config unset secrets.providers.env-provider --dry-run
+openclaw config unset secrets.providers.exec-provider --dry-run --allow-exec
+```
+
+### Dry-run options
+
+<Tabs>
+  <Tab title="--dry-run">
+    Validate removal without writing `openclaw.json`. Checks that the path exists, validates the post-change config against the schema, and verifies SecretRef fallout for `secrets.providers`/`secrets.defaults` removals.
+
+    ```bash
+    openclaw config unset tools.alsoAllow --dry-run
+    ```
+  </Tab>
+  <Tab title="--dry-run --json">
+    Output structured JSON for scripting. Requires `--dry-run`.
+
+    ```bash
+    openclaw config unset tools.alsoAllow --dry-run --json
+    ```
+
+    Returns:
+    ```json
+    {
+      "ok": true,
+      "operations": 1,
+      "inputModes": ["unset"],
+      "checks": { "schema": true, "resolvability": true, "resolvabilityComplete": true },
+      "refsChecked": 0,
+      "skippedExecRefs": 0
+    }
+    ```
+  </Tab>
+  <Tab title="--allow-exec">
+    Allow exec SecretRef resolvability checks during dry-run. Exec providers are skipped by default to avoid command side effects. Requires `--dry-run`.
+
+    ```bash
+    openclaw config unset secrets.providers.vault --dry-run --allow-exec
+    ```
+  </Tab>
+</Tabs>
+
+<AccordionGroup>
+  <Accordion title="SecretRef fallout detection">
+    When unsetting `secrets.providers.<alias>` or `secrets.defaults`, `config unset --dry-run` checks whether any remaining SecretRefs would become unresolvable. If refs would break, dry-run fails with resolution errors:
+
+    ```bash
+    $ openclaw config unset secrets.providers.env-provider --dry-run
+
+    Dry run failed: 1 SecretRef assignment(s) could not be resolved.
+    - env:env-provider:TEST_API_KEY -> SecretProviderResolutionError: Secret provider "env-provider" is not configured.
+    ```
+  </Accordion>
+  <Accordion title="Exec SecretRef handling">
+    By default, exec-backed SecretRefs are skipped during dry-run to avoid executing arbitrary commands. Use `--allow-exec` to opt in:
+
+    ```bash
+    # Without --allow-exec: exec refs skipped
+    $ openclaw config unset secrets.providers.exec-provider --dry-run
+
+    Dry run note: skipped 1 exec SecretRef resolvability check(s). Re-run with --allow-exec to execute exec providers during dry-run.
+
+    # With --allow-exec: exec providers are executed
+    $ openclaw config unset secrets.providers.exec-provider --dry-run --allow-exec
+    ```
+  </Accordion>
+</AccordionGroup>
 
 ## Provider builder flags
 

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -2694,6 +2694,83 @@ describe("config cli", () => {
         unsetPaths: [["channels", "discord", "guilds", "123"]],
       });
     });
+
+    it("dry-runs an unset without writing the config file", async () => {
+      const resolved: OpenClawConfig = {
+        agents: { list: [{ id: "main" }] },
+        gateway: { port: 18789 },
+        tools: {
+          profile: "coding",
+          alsoAllow: ["agents_list"],
+        },
+      };
+      setSnapshot(resolved, resolved);
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand(["config", "unset", "tools.alsoAllow", "--dry-run"]);
+
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expectLogIncludes("Dry run successful: 1 update(s) validated against /tmp/openclaw.json.");
+      expect(mockReadConfigFileSnapshot).toHaveBeenCalledTimes(2);
+    });
+
+    it("prints JSON for config unset dry-run", async () => {
+      const resolved: OpenClawConfig = {
+        agents: { list: [{ id: "main" }] },
+        gateway: { port: 18789 },
+        tools: {
+          profile: "coding",
+          alsoAllow: ["agents_list"],
+        },
+      };
+      setSnapshot(resolved, resolved);
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand(["config", "unset", "tools.alsoAllow", "--dry-run", "--json"]);
+
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expect(parseLastLogPayload()).toMatchObject({
+        ok: true,
+        operations: 1,
+        inputModes: ["unset"],
+        checks: {
+          schema: true,
+          resolvability: true,
+          resolvabilityComplete: true,
+        },
+      });
+    });
+
+    it("returns JSON error for missing path in dry-run", async () => {
+      const resolved: OpenClawConfig = { gateway: { port: 18789 } };
+      setSnapshot(resolved, resolved);
+
+      await expect(
+        runConfigCommand(["config", "unset", "tools.nonexistent", "--dry-run", "--json"]),
+      ).rejects.toThrow("__exit__:1");
+
+      const payload = parseLastLogPayload() as { ok: boolean; errors: unknown[] };
+      expect(payload.ok).toBe(false);
+      expect(payload.errors.length).toBeGreaterThan(0);
+    });
+
+    it("rejects config unset --json without --dry-run", async () => {
+      await expect(
+        runConfigCommand(["config", "unset", "tools.alsoAllow", "--json"]),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expectErrorIncludes("--json can only be used with --dry-run.");
+    });
+
+    it("rejects config unset --allow-exec without --dry-run", async () => {
+      await expect(
+        runConfigCommand(["config", "unset", "tools.alsoAllow", "--allow-exec"]),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(mockWriteConfigFile).not.toHaveBeenCalled();
+      expectErrorIncludes("--allow-exec can only be used with --dry-run.");
+    });
   });
 
   describe("config file", () => {

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -79,6 +79,7 @@ type ConfigSetOperation = {
   schemaValidated?: boolean;
   touchedSecretTargetPath?: string;
   touchedProviderAlias?: string;
+  affectsAllSecretRefs?: boolean;
   assignedRef?: SecretRef;
 };
 type ConfigPatchOptions = {
@@ -88,6 +89,11 @@ type ConfigPatchOptions = {
   allowExec?: boolean | undefined;
   json?: boolean | undefined;
   replacePath?: string[] | undefined;
+};
+type ConfigUnsetOptions = {
+  dryRun?: boolean | undefined;
+  allowExec?: boolean | undefined;
+  json?: boolean | undefined;
 };
 type ConfigMutationOptions = {
   dryRun?: boolean | undefined;
@@ -1153,6 +1159,35 @@ function buildDeleteOperation(path: PathSegment[]): ConfigSetOperation {
   };
 }
 
+function buildUnsetOperation(path: PathSegment[]): ConfigSetOperation {
+  const resolved = resolveConfigSecretTargetByPath(path);
+  const providerAlias = parseProviderAliasFromTargetPath(path);
+  const isProviderPath =
+    path[0] === SECRET_PROVIDER_PATH_PREFIX[0] &&
+    path[1] === SECRET_PROVIDER_PATH_PREFIX[1];
+  const isDefaultsPath =
+    path.length >= 2 &&
+    path[0] === "secrets" &&
+    path[1] === "defaults";
+  const isTopLevelSecrets = path.length === 1 && path[0] === "secrets";
+  // Broad secret unsets (secrets, secrets.providers, secrets.defaults, secrets.defaults.*)
+  // affect all SecretRef resolvability — mark so collectDryRunRefs collects all refs.
+  const affectsAllSecretRefs =
+    (isProviderPath && path.length === 2) || // secrets.providers (entire map)
+    isDefaultsPath || // secrets.defaults or secrets.defaults.*
+    isTopLevelSecrets; // secrets
+  return {
+    inputMode: "unset",
+    requestedPath: path,
+    setPath: path,
+    value: undefined,
+    mutation: "delete",
+    ...(resolved ? { touchedSecretTargetPath: toDotPath(resolved.pathSegments) } : {}),
+    ...(providerAlias ? { touchedProviderAlias: providerAlias } : {}),
+    ...(affectsAllSecretRefs ? { affectsAllSecretRefs: true } : {}),
+  };
+}
+
 function buildApplyValueOperation(params: {
   path: PathSegment[];
   value: unknown;
@@ -1357,6 +1392,7 @@ function collectDryRunRefs(params: {
   const refsByKey = new Map<string, SecretRef>();
   const targetPaths = new Set<string>();
   const providerAliases = new Set<string>();
+  const affectsAll = params.operations.some((operation) => operation.affectsAllSecretRefs);
 
   for (const operation of params.operations) {
     if (operation.assignedRef) {
@@ -1371,6 +1407,22 @@ function collectDryRunRefs(params: {
     if (operation.touchedProviderAlias) {
       providerAliases.add(operation.touchedProviderAlias);
     }
+  }
+
+  if (affectsAll) {
+    // Broad secret unsets affect all refs — collect everything.
+    const defaults = params.config.secrets?.defaults;
+    for (const target of discoverConfigSecretTargets(params.config)) {
+      const { ref } = resolveSecretInputRef({
+        value: target.value,
+        refValue: target.refValue,
+        defaults,
+      });
+      if (ref) {
+        refsByKey.set(secretRefKey(ref), ref);
+      }
+    }
+    return [...refsByKey.values()];
   }
 
   if (targetPaths.size === 0 && providerAliases.size === 0) {
@@ -1716,11 +1768,14 @@ async function runConfigOperations(params: {
   if (options.dryRun) {
     const hasJsonMode = operations.some((operation) => operation.inputMode === "json");
     const hasBuilderMode = operations.some((operation) => operation.inputMode === "builder");
+    const hasUnsetMode = operations.some((operation) => operation.inputMode === "unset");
     const requiresFullSchemaValidation = operations.some(
-      (operation) => operation.inputMode === "json" && operation.schemaValidated !== true,
+      (operation) =>
+        operation.inputMode === "unset" ||
+        (operation.inputMode === "json" && operation.schemaValidated !== true),
     );
     const refs =
-      hasJsonMode || hasBuilderMode
+      hasJsonMode || hasBuilderMode || hasUnsetMode
         ? collectDryRunRefs({
             config: nextConfig,
             operations,
@@ -1746,7 +1801,7 @@ async function runConfigOperations(params: {
         }),
       );
     }
-    if (hasJsonMode || hasBuilderMode) {
+    if (hasJsonMode || hasBuilderMode || hasUnsetMode) {
       errors.push(
         ...collectDryRunStaticErrorsForSkippedExecRefs({
           refs: selectedDryRunRefs.skippedExecRefs,
@@ -1768,9 +1823,10 @@ async function runConfigOperations(params: {
       inputModes: [...new Set(operations.map((operation) => operation.inputMode))],
       checks: {
         schema: requiresFullSchemaValidation || policyIssueLines.length > 0,
-        resolvability: hasJsonMode || hasBuilderMode,
+        resolvability: hasJsonMode || hasBuilderMode || hasUnsetMode,
         resolvabilityComplete:
-          (hasJsonMode || hasBuilderMode) && selectedDryRunRefs.skippedExecRefs.length === 0,
+          (hasJsonMode || hasBuilderMode || hasUnsetMode) &&
+          selectedDryRunRefs.skippedExecRefs.length === 0,
       },
       refsChecked: selectedDryRunRefs.refsToResolve.length,
       skippedExecRefs: selectedDryRunRefs.skippedExecRefs.length,
@@ -1986,9 +2042,20 @@ export async function runConfigGet(opts: { path: string; json?: boolean; runtime
   }
 }
 
-export async function runConfigUnset(opts: { path: string; runtime?: RuntimeEnv }) {
+export async function runConfigUnset(opts: {
+  path: string;
+  cliOptions?: ConfigUnsetOptions;
+  runtime?: RuntimeEnv;
+}) {
   const runtime = opts.runtime ?? defaultRuntime;
+  const cliOptions = opts.cliOptions ?? {};
   try {
+    if (cliOptions.allowExec && !cliOptions.dryRun) {
+      throw new Error("--allow-exec can only be used with --dry-run.");
+    }
+    if (cliOptions.json && !cliOptions.dryRun) {
+      throw new Error("--json can only be used with --dry-run.");
+    }
     const parsedPath = parseRequiredPath(opts.path);
     const autoManagedUnsetTargets = findAutoManagedMetaUnsetTargets(parsedPath);
     if (autoManagedUnsetTargets.length > 0) {
@@ -2001,12 +2068,32 @@ export async function runConfigUnset(opts: { path: string; runtime?: RuntimeEnv 
     const next = structuredClone(snapshot.resolved) as Record<string, unknown>;
     const unsetResult = unsetAtPath(next, parsedPath);
     if (!unsetResult.removed) {
-      runtime.error(
-        danger(
-          `Config path not found: ${opts.path}. Nothing was changed. Run ${formatCliCommand("openclaw config get <path>")} first if you are unsure of the path.`,
-        ),
-      );
+      if (cliOptions.json) {
+        writeRuntimeJson(runtime, {
+          ok: false,
+          operations: 0,
+          configPath: shortenHomePath(snapshot.path),
+          inputModes: ["unset"],
+          checks: { schema: false, resolvability: false, resolvabilityComplete: false },
+          errors: [{ kind: "schema", message: "Config path not found" }],
+        });
+      } else {
+        runtime.error(
+          danger(
+            `Config path not found: ${opts.path}. Nothing was changed. Run ${formatCliCommand("openclaw config get <path>")} first if you are unsure of the path.`,
+          ),
+        );
+      }
       runtime.exit(1);
+      return;
+    }
+    if (cliOptions.dryRun) {
+      await runConfigOperations({
+        runtime,
+        operations: [buildUnsetOperation(parsedPath)],
+        options: cliOptions,
+        successMode: "set",
+      });
       return;
     }
     await replaceConfigFile({
@@ -2018,8 +2105,7 @@ export async function runConfigUnset(opts: { path: string; runtime?: RuntimeEnv 
     });
     runtime.log(info(`Removed ${opts.path}. Restart the gateway to apply.`));
   } catch (err) {
-    runtime.error(danger(String(err)));
-    runtime.exit(1);
+    handleConfigMutationError({ err, runtime, options: cliOptions });
   }
 }
 
@@ -2258,8 +2344,11 @@ export function registerConfigCli(program: Command) {
     .command("unset")
     .description("Remove a config value by dot path")
     .argument("<path>", "Config path (dot or bracket notation)")
-    .action(async (path: string) => {
-      await runConfigUnset({ path });
+    .option("--dry-run", "validate the removal without writing the config file")
+    .option("--allow-exec", "allow exec SecretRef providers during --dry-run")
+    .option("--json", "print dry-run result as JSON")
+    .action(async (path: string, options: ConfigUnsetOptions) => {
+      await runConfigUnset({ path, cliOptions: options });
     });
 
   cmd


### PR DESCRIPTION
PR #80773 passed all 8 rounds of ClawSweeper review and was acknowledged as
"more complete" by @giodl73-repo before he closed his own draft #81497.

However, #80773 was then closed by ClawSweeper Bot as superseded by #81895,
which:
- Was submitted later
- Still has 2 unresolved P2 defects (confidence 0.87, 0.82)
- Lacks documentation

This PR adopts the runConfigOperations architecture preference while providing
a complete implementation:
- Fixes both P2 defects from #81895
- Includes documentation in docs/cli/config.md
- SecretRef fallout detection for secrets.providers/secrets.defaults

If architecture preference was the concern, I would have appreciated the
opportunity to adjust my PR rather than having it closed without communication.

## Real behavior proof

- **Behavior or issue addressed**: Add --dry-run, --json, --allow-exec to config unset with SecretRef fallout detection
- **Real environment tested**: Windows 10, Node.js v22.12.0, OpenClaw 2026.5.17 (commit 5759364)
- **Exact steps or command run after this patch**:

### 0. Help output

```
$ openclaw config unset --help

Usage: openclaw config unset [options] <path>

Remove a config value by dot path

Arguments:
  path          Config path (dot or bracket notation)

Options:
  --allow-exec  allow exec SecretRef providers during --dry-run
  --dry-run     validate the removal without writing the config file
  -h, --help    Display help for command
  --json        print dry-run result as JSON
```

### 1. Basic dry-run

```
$ openclaw config unset tools.alsoAllow --dry-run

Dry run successful: 1 update(s) validated against ~\.openclaw\openclaw.json.
```

### 2. dry-run --json output

```json
$ openclaw config unset tools.alsoAllow --dry-run --json

{
  "ok": true,
  "operations": 1,
  "configPath": "~\.openclaw\openclaw.json",
  "inputModes": ["unset"],
  "checks": {
    "schema": true,
    "resolvability": true,
    "resolvabilityComplete": true
  },
  "refsChecked": 0,
  "skippedExecRefs": 0
}
```

### 3. Path not found (JSON error)

```json
$ openclaw config unset nonexistent.path --dry-run --json

{
  "ok": false,
  "operations": 0,
  "configPath": "~\.openclaw\openclaw.json",
  "inputModes": ["unset"],
  "checks": {
    "schema": false,
    "resolvability": false,
    "resolvabilityComplete": false
  },
  "errors": [
    {
      "kind": "schema",
      "message": "Config path not found"
    }
  ]
}
```

### 4. --json without --dry-run error

```
$ openclaw config unset tools.alsoAllow --json

Error: --json can only be used with --dry-run.
```

### 5. --allow-exec without --dry-run error

```
$ openclaw config unset tools.alsoAllow --allow-exec

Error: --allow-exec can only be used with --dry-run.
```

### 6. SecretRef fallout detection (env provider)

Config with env-provider referenced by SecretRef:
```json
{
  "secrets": {"providers": {"env-provider": {"source": "env"}}},
  "models": {"providers": {"test-provider": {
    "apiKey": {"source": "env", "provider": "env-provider", "id": "TEST_API_KEY"}
  }}}
}
```

```
$ openclaw config unset secrets.providers.env-provider --dry-run

Error: Dry run failed: 1 SecretRef assignment(s) could not be resolved.
- env:env-provider:TEST_API_KEY -> SecretProviderResolutionError: Secret provider "env-provider" is not configured.
```

JSON output:
```json
{
  "ok": false,
  "operations": 1,
  "inputModes": ["unset"],
  "checks": {"schema": true, "resolvability": true, "resolvabilityComplete": true},
  "refsChecked": 1,
  "skippedExecRefs": 0,
  "errors": [{"kind": "resolvability", "message": "SecretProviderResolutionError: Secret provider \"env-provider\" is not configured.", "ref": "env:env-provider:TEST_API_KEY"}]
}
```

### 7. Exec SecretRef handling (--allow-exec)

Config with exec-provider:
```json
{
  "secrets": {"providers": {"exec-provider": {
    "source": "exec",
    "command": "C:/Windows/System32/cmd.exe",
    "args": ["/c", "echo test-secret-value"]
  }}},
  "models": {"providers": {"test-provider": {
    "apiKey": {"source": "exec", "provider": "exec-provider", "id": "api-key"}
  }}}
}
```

Without --allow-exec (exec skipped):
```json
{
  "ok": false,
  "checks": {"resolvabilityComplete": false},
  "refsChecked": 0,
  "skippedExecRefs": 1
}
```

With --allow-exec (exec executed):
```json
{
  "ok": false,
  "checks": {"resolvabilityComplete": true},
  "refsChecked": 1,
  "skippedExecRefs": 0
}
```

- **Observed result after fix**: All features work correctly. SecretRef fallout detection prevents unsafe provider removals. Exec providers are skipped by default, executed only with --allow-exec.
- **What was not tested**: None

Closes #80721