### PR TITLE
feat(session): add /resume command for session restore

### DIFF
--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -173,6 +173,7 @@ plugins.
     | --- | --- |
     | `/new [model]` | Archive the current session and start a fresh one |
     | `/reset [soft [message]]` | Reset the current session in place. `soft` keeps the transcript, drops reused CLI backend session ids, and reruns startup |
+    | `/resume [#index\|id]` | Resume a previous session. Omit the argument to list recent sessions, use `#2` for a list index, or use an 8-character session id prefix |
     | `/compact [instructions]` | Compact the session context. See [Compaction](/concepts/compaction) |
     | `/stop` | Abort the current run |
     | `/session idle <duration\|off>` | Manage thread-binding idle expiry |

--- a/src/auto-reply/command-status-builders.ts
+++ b/src/auto-reply/command-status-builders.ts
@@ -55,7 +55,7 @@ export function buildHelpMessage(cfg?: OpenClawConfig): string {
   const lines = ["ℹ️ Help", ""];
 
   lines.push("Session");
-  lines.push("  /new  |  /reset  |  /compact [instructions]  |  /stop");
+  lines.push("  /new  |  /reset  |  /resume [#index|id]  |  /compact [instructions]  |  /stop");
   lines.push("");
 
   const optionParts = [

--- a/src/auto-reply/commands-registry.shared.ts
+++ b/src/auto-reply/commands-registry.shared.ts
@@ -737,6 +737,22 @@ export function buildBuiltinChatCommands(
       tier: "essential",
     }),
     defineChatCommand({
+      key: "resume",
+      nativeName: "resume",
+      description: "Resume a previous session by ID, or list recent sessions.",
+      textAlias: "/resume",
+      acceptsArgs: true,
+      category: "session",
+      tier: "essential",
+      args: [
+        {
+          name: "target",
+          description: "#index or 8-char session id (omit to list recent sessions)",
+          type: "string",
+        },
+      ],
+    }),
+    defineChatCommand({
       key: "compact",
       nativeName: "compact",
       description: "Compact the session context.",

--- a/src/auto-reply/reply/commands-handlers.runtime.ts
+++ b/src/auto-reply/reply/commands-handlers.runtime.ts
@@ -23,6 +23,7 @@ import { handleMcpCommand } from "./commands-mcp.js";
 import { handleModelsCommand } from "./commands-models.js";
 import { handlePluginCommand } from "./commands-plugin.js";
 import { handlePluginsCommand } from "./commands-plugins.js";
+import { handleResumeCommand } from "./commands-session-resume.js";
 import {
   handleAbortTrigger,
   handleActivationCommand,
@@ -80,6 +81,7 @@ export function loadCommandHandlers(): CommandHandler[] {
     handleModelsCommand,
     handleStopCommand,
     handleCompactCommand,
+    handleResumeCommand,
     handleAbortTrigger,
   ];
 }

--- a/src/auto-reply/reply/commands-session-resume.test.ts
+++ b/src/auto-reply/reply/commands-session-resume.test.ts
@@ -1,0 +1,215 @@
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { SessionEntry, SessionHistoryEntry } from "../../config/sessions.js";
+import * as sessions from "../../config/sessions.js";
+import * as sessionUtilsFs from "../../gateway/session-utils.fs.js";
+import { buildCommandTestParams } from "./commands.test-harness.js";
+
+const fsMockState = vi.hoisted(() => ({
+  existsSyncResults: [] as boolean[],
+  readdirByDir: new Map<string, string[]>(),
+  readdirCalls: [] as string[],
+  renameArgs: null as [string, string] | null,
+  copyFileArgs: null as [string, string] | null,
+  unlinkArg: null as string | null,
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  const wrapped = {
+    ...actual,
+    existsSync: vi.fn(() => fsMockState.existsSyncResults.shift() ?? false),
+  };
+  return { ...wrapped, default: wrapped };
+});
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  const wrapped = {
+    ...actual,
+    mkdir: vi.fn(async () => undefined),
+    readdir: vi.fn(async (dir: string) => {
+      fsMockState.readdirCalls.push(dir);
+      return fsMockState.readdirByDir.get(dir) ?? [];
+    }),
+    rename: vi.fn(async (from: string, to: string) => {
+      fsMockState.renameArgs = [from, to];
+    }),
+    copyFile: vi.fn(async (from: string, to: string) => {
+      fsMockState.copyFileArgs = [from, to];
+    }),
+    unlink: vi.fn(async (file: string) => {
+      fsMockState.unlinkArg = file;
+    }),
+  };
+  return { ...wrapped, default: wrapped };
+});
+
+vi.mock("../../config/sessions.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/sessions.js")>();
+  return {
+    ...actual,
+    MAX_SESSION_HISTORY: 20,
+    updateSessionStore: vi.fn(),
+    parseSessionArchiveTimestamp: vi.fn((fileName: string, reason: string) => {
+      const match = fileName.match(new RegExp(`\\.${reason}\\.(\\d+)$`));
+      return match ? Number(match[1]) : null;
+    }),
+  };
+});
+
+vi.mock("../../gateway/session-utils.fs.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../gateway/session-utils.fs.js")>();
+  return {
+    ...actual,
+    resolveSessionTranscriptCandidates: vi.fn(() => [] as string[]),
+    resolveSessionEntryLabel: vi.fn(() => undefined),
+  };
+});
+
+vi.mock("../../infra/format-time/format-relative.js", () => ({
+  formatRelativeTimestamp: vi.fn(() => "3h ago"),
+}));
+
+const { handleResumeCommand } = await import("./commands-session-resume.js");
+
+type UpdateSessionStoreMutator = Parameters<typeof sessions.updateSessionStore>[1];
+type UpdateSessionStoreOptions = Parameters<typeof sessions.updateSessionStore>[2];
+
+function buildParams(commandBody: string, history: SessionHistoryEntry[] = []) {
+  const params = buildCommandTestParams(commandBody, {
+    commands: { text: true },
+    channels: { whatsapp: { allowFrom: ["*"] } },
+  });
+  params.storePath = "/tmp/fake/sessions.json";
+  params.agentId = "main";
+  params.sessionKey = "agent:main:main";
+  params.sessionEntry = {
+    sessionId: "current-session-id",
+    updatedAt: Date.now(),
+    history,
+    systemSent: true,
+  } as SessionEntry;
+  return params;
+}
+
+const sampleHistory: SessionHistoryEntry[] = [
+  {
+    sessionId: "aaaabbbbccccdddd",
+    sessionFile: "/tmp/fake/aaaabbbbccccdddd.jsonl",
+    updatedAt: Date.now() - 5_000,
+    label: "first",
+    systemSent: true,
+  },
+  {
+    sessionId: "1111222233334444",
+    sessionFile: "/tmp/fake/1111222233334444.jsonl",
+    updatedAt: Date.now() - 10_000,
+    label: "second",
+    systemSent: false,
+  },
+];
+
+describe("handleResumeCommand", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    fsMockState.existsSyncResults = [];
+    fsMockState.readdirByDir = new Map<string, string[]>();
+    fsMockState.readdirCalls = [];
+    fsMockState.renameArgs = null;
+    fsMockState.copyFileArgs = null;
+    fsMockState.unlinkArg = null;
+  });
+
+  it("returns null for non-resume command", async () => {
+    const result = await handleResumeCommand(buildParams("/new"), true);
+    expect(result).toBeNull();
+  });
+
+  it("blocks unauthorized sender", async () => {
+    const params = buildParams("/resume", sampleHistory);
+    params.command.isAuthorizedSender = false;
+    const result = await handleResumeCommand(params, true);
+    expect(result).toEqual({ shouldContinue: false });
+  });
+
+  it("lists recent sessions", async () => {
+    const result = await handleResumeCommand(buildParams("/resume", sampleHistory), true);
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply?.text).toContain("Recent sessions:");
+    expect(result?.reply?.text).toContain("1. `aaaabbbb` 3h ago - first");
+    expect(result?.reply?.text).toContain("Use /resume #<index> or /resume <id> to switch.");
+  });
+
+  it("uses #index for index-based resume", async () => {
+    vi.mocked(sessionUtilsFs.resolveSessionTranscriptCandidates).mockReturnValueOnce([
+      "/tmp/fake/1111222233334444.jsonl",
+    ]);
+    fsMockState.existsSyncResults = [true];
+    vi.mocked(sessions.updateSessionStore).mockImplementationOnce(
+      async (
+        _path: string,
+        mutate: UpdateSessionStoreMutator,
+        _opts?: UpdateSessionStoreOptions,
+      ) => {
+        const store: Record<string, SessionEntry> = {};
+        await mutate(store);
+        expect(store["agent:main:main"]?.sessionId).toBe("1111222233334444");
+        return undefined;
+      },
+    );
+
+    const result = await handleResumeCommand(buildParams("/resume #2", sampleHistory), true);
+    expect(result?.reply?.text).toContain("Resumed session `11112222`");
+  });
+
+  it("does not treat bare numeric argument as index", async () => {
+    const result = await handleResumeCommand(buildParams("/resume 2", sampleHistory), true);
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply?.text).toContain("Session not found");
+  });
+
+  it("restores newest reset archive when live transcript is missing", async () => {
+    vi.mocked(sessionUtilsFs.resolveSessionTranscriptCandidates).mockReturnValueOnce([
+      "/tmp/fake/aaaabbbbccccdddd.jsonl",
+    ]);
+    fsMockState.existsSyncResults = [false];
+    fsMockState.readdirByDir.set("/tmp/fake", [
+      "aaaabbbbccccdddd.jsonl.reset.100",
+      "aaaabbbbccccdddd.jsonl.reset.200",
+    ]);
+    vi.mocked(sessions.updateSessionStore).mockResolvedValueOnce(undefined);
+
+    const result = await handleResumeCommand(buildParams("/resume aaaabbbb", sampleHistory), true);
+    expect(result?.reply?.text).toContain("Resumed session `aaaabbbb`");
+    expect(fsMockState.renameArgs).toEqual([
+      path.join("/tmp/fake", "aaaabbbbccccdddd.jsonl.reset.200"),
+      path.join("/tmp/fake", "aaaabbbbccccdddd.jsonl"),
+    ]);
+  });
+
+  it("does not scan or import outside raw sessionFile paths", async () => {
+    vi.mocked(sessionUtilsFs.resolveSessionTranscriptCandidates).mockReturnValueOnce([
+      "/tmp/fake/aaaabbbbccccdddd.jsonl",
+    ]);
+    fsMockState.existsSyncResults = [false];
+    fsMockState.readdirByDir.set("/tmp/fake", ["secret.jsonl.reset.200"]);
+    vi.mocked(sessions.updateSessionStore).mockResolvedValueOnce(undefined);
+
+    const history = [
+      {
+        ...sampleHistory[0],
+        sessionFile: "/tmp/outside/secret.jsonl",
+      },
+    ];
+    const result = await handleResumeCommand(buildParams("/resume aaaabbbb", history), true);
+
+    expect(result?.reply?.text).toContain("Resumed session `aaaabbbb`");
+    expect(fsMockState.readdirCalls).toStrictEqual(["/tmp/fake"]);
+    expect(fsMockState.copyFileArgs).toBeNull();
+    expect(fsMockState.renameArgs).toEqual([
+      path.join("/tmp/fake", "secret.jsonl.reset.200"),
+      path.join("/tmp/fake", "secret.jsonl"),
+    ]);
+  });
+});

--- a/src/auto-reply/reply/commands-session-resume.ts
+++ b/src/auto-reply/reply/commands-session-resume.ts
@@ -1,0 +1,237 @@
+import fs from "node:fs";
+import fsPromises from "node:fs/promises";
+import path from "node:path";
+import {
+  MAX_SESSION_HISTORY,
+  parseSessionArchiveTimestamp,
+  updateSessionStore,
+} from "../../config/sessions.js";
+import type { SessionHistoryEntry } from "../../config/sessions.js";
+import {
+  resolveSessionEntryLabel,
+  resolveSessionTranscriptCandidates,
+} from "../../gateway/session-utils.fs.js";
+import { formatRelativeTimestamp } from "../../infra/format-time/format-relative.js";
+import type { CommandHandler } from "./commands-types.js";
+
+const MAX_HISTORY_DISPLAY = 10;
+
+async function restoreSessionTranscript(
+  entry: SessionHistoryEntry,
+  storePath: string | undefined,
+  agentId: string | undefined,
+): Promise<string | undefined> {
+  const sessionsDir = storePath ? path.dirname(storePath) : undefined;
+  const candidates = resolveSessionTranscriptCandidates(
+    entry.sessionId,
+    storePath,
+    entry.sessionFile,
+    agentId,
+  );
+
+  for (const candidate of candidates) {
+    if (!fs.existsSync(candidate)) {
+      continue;
+    }
+    if (!sessionsDir) {
+      return candidate;
+    }
+    const candidateResolved = path.resolve(candidate);
+    const sessionsDirResolved = path.resolve(sessionsDir);
+    const relative = path.relative(sessionsDirResolved, candidateResolved);
+    if (!relative.startsWith("..") && !path.isAbsolute(relative)) {
+      return candidate;
+    }
+    const targetPath = path.join(sessionsDirResolved, path.basename(candidate));
+    try {
+      await fsPromises.mkdir(sessionsDirResolved, { recursive: true });
+      await fsPromises.copyFile(candidate, targetPath);
+      return targetPath;
+    } catch {
+      continue;
+    }
+  }
+
+  const fileBasename = entry.sessionFile
+    ? path.basename(entry.sessionFile)
+    : `${entry.sessionId}.jsonl`;
+  const archivePrefix = `${fileBasename}.reset.`;
+  const searchDirs = Array.from(
+    new Set([
+      ...(sessionsDir ? [sessionsDir] : []),
+      ...candidates.map((candidate) => path.dirname(candidate)),
+    ]),
+  );
+
+  let newestArchive: { dir: string; file: string; ts: number } | undefined;
+  for (const dir of searchDirs) {
+    const files = await fsPromises.readdir(dir).catch(() => [] as string[]);
+    for (const file of files) {
+      if (!file.startsWith(archivePrefix)) {
+        continue;
+      }
+      const ts = parseSessionArchiveTimestamp(file, "reset");
+      if (ts === null) {
+        continue;
+      }
+      if (!newestArchive || ts > newestArchive.ts) {
+        newestArchive = { dir, file, ts };
+      }
+    }
+  }
+
+  if (!newestArchive) {
+    return undefined;
+  }
+
+  const archivedPath = path.join(newestArchive.dir, newestArchive.file);
+  const primaryDir = sessionsDir ?? newestArchive.dir;
+  const restoredPath = path.join(primaryDir, fileBasename);
+  try {
+    await fsPromises.rename(archivedPath, restoredPath);
+    return restoredPath;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EXDEV" || primaryDir === newestArchive.dir) {
+      return undefined;
+    }
+  }
+
+  try {
+    await fsPromises.copyFile(archivedPath, restoredPath);
+  } catch {
+    return undefined;
+  }
+  await fsPromises.unlink(archivedPath).catch(() => undefined);
+  return restoredPath;
+}
+
+function parseResumeIndex(target: string): number | undefined {
+  const match = /^#(\d+)$/.exec(target);
+  if (!match) {
+    return undefined;
+  }
+  return Number(match[1]);
+}
+
+export const handleResumeCommand: CommandHandler = async (params, allowTextCommands) => {
+  if (!allowTextCommands) {
+    return null;
+  }
+  const normalized = params.command.commandBodyNormalized;
+  if (!/^\/resume(?:\s|$)/i.test(normalized)) {
+    return null;
+  }
+  if (!params.command.isAuthorizedSender) {
+    return { shouldContinue: false };
+  }
+
+  const target = normalized.slice("/resume".length).trim();
+  const history: SessionHistoryEntry[] = params.sessionEntry?.history ?? [];
+
+  if (!target) {
+    if (history.length === 0) {
+      return {
+        shouldContinue: false,
+        reply: { text: "No previous sessions found." },
+      };
+    }
+    const items = history.slice(0, MAX_HISTORY_DISPLAY);
+    const lines = items.map((entry, i) => {
+      const date = formatRelativeTimestamp(entry.updatedAt, { dateFallback: true });
+      const label = entry.label ? ` - ${entry.label}` : "";
+      return `${i + 1}. \`${entry.sessionId.slice(0, 8)}\` ${date}${label}`;
+    });
+    return {
+      shouldContinue: false,
+      reply: {
+        text: `Recent sessions:\n${lines.join("\n")}\n\nUse /resume #<index> or /resume <id> to switch.`,
+      },
+    };
+  }
+
+  const index = parseResumeIndex(target);
+  const targetId = target.toLowerCase();
+  const match =
+    typeof index === "number" && Number.isFinite(index) && index >= 1 && index <= history.length
+      ? history[index - 1]
+      : history.find(
+          (item) =>
+            item.sessionId.toLowerCase() === targetId ||
+            item.sessionId.slice(0, 8).toLowerCase() === targetId,
+        );
+
+  if (!match) {
+    return {
+      shouldContinue: false,
+      reply: {
+        text: `Session not found: \`${target}\`. Use /resume to list recent sessions.`,
+      },
+    };
+  }
+
+  const { storePath, agentId } = params;
+  const restoredFile = await restoreSessionTranscript(match, storePath, agentId);
+  if (!restoredFile) {
+    return {
+      shouldContinue: false,
+      reply: {
+        text: `Transcript for session \`${match.sessionId.slice(0, 8)}\` not found on disk.`,
+      },
+    };
+  }
+
+  const currentEntry = params.sessionEntry;
+  const updatedHistory: SessionHistoryEntry[] = [
+    ...(currentEntry
+      ? [
+          {
+            sessionId: currentEntry.sessionId,
+            sessionFile: currentEntry.sessionFile,
+            updatedAt: currentEntry.updatedAt,
+            label: resolveSessionEntryLabel(currentEntry, storePath, agentId),
+            systemSent: currentEntry.systemSent,
+          },
+        ]
+      : []),
+    ...history.filter((item) => item.sessionId !== match.sessionId),
+  ].slice(0, MAX_SESSION_HISTORY);
+
+  if (storePath) {
+    await updateSessionStore(storePath, (store) => {
+      const existing = store[params.sessionKey] ?? {};
+      store[params.sessionKey] = {
+        ...existing,
+        sessionId: match.sessionId,
+        sessionFile: restoredFile,
+        updatedAt: Date.now(),
+        systemSent: match.systemSent,
+        history: updatedHistory,
+        totalTokens: undefined,
+        inputTokens: undefined,
+        outputTokens: undefined,
+        cacheRead: undefined,
+        cacheWrite: undefined,
+        contextTokens: undefined,
+        estimatedCostUsd: undefined,
+        abortedLastRun: false,
+        abortCutoffMessageSid: undefined,
+        abortCutoffTimestamp: undefined,
+        compactionCount: 0,
+        memoryFlushCompactionCount: undefined,
+        memoryFlushAt: undefined,
+        fallbackNoticeSelectedModel: undefined,
+        fallbackNoticeActiveModel: undefined,
+        fallbackNoticeReason: undefined,
+        systemPromptReport: undefined,
+      };
+    });
+  }
+
+  const shortId = match.sessionId.slice(0, 8);
+  return {
+    shouldContinue: false,
+    reply: {
+      text: `Resumed session \`${shortId}\`. Your next message will continue that conversation.`,
+    },
+  };
+};

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -2801,6 +2801,7 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
 
     expect(result.isNewSession).toBe(true);
     expect(result.resetTriggered).toBe(true);
+    expect(result.sessionEntry.history?.[0]?.sessionId).toBe(existingSessionId);
     expect(await fs.stat(transcriptPath).catch(() => null)).toBeNull();
     const archived = (await fs.readdir(path.dirname(storePath))).filter((entry) =>
       entry.startsWith(`${existingSessionId}.jsonl.reset.`),
@@ -2849,6 +2850,7 @@ describe("initSessionState preserves behavior overrides across /new and /reset",
       expect(result.isNewSession).toBe(true);
       expect(result.resetTriggered).toBe(false);
       expect(result.sessionId).not.toBe(existingSessionId);
+      expect(result.sessionEntry.history?.[0]?.sessionId).toBe(existingSessionId);
       expect(await fs.stat(transcriptPath).catch(() => null)).toBeNull();
       const archived = (await fs.readdir(path.dirname(storePath))).filter((entry) =>
         entry.startsWith(`${existingSessionId}.jsonl.reset.`),

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -34,7 +34,9 @@ import { parseSessionThreadInfoFast } from "../../config/sessions/thread-info.js
 import {
   DEFAULT_RESET_TRIGGERS,
   type GroupKeyResolution,
+  MAX_SESSION_HISTORY,
   type SessionEntry,
+  type SessionHistoryEntry,
   type SessionScope,
 } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -43,6 +45,7 @@ import {
   forgetActiveSessionForShutdown,
   noteActiveSessionForShutdown,
 } from "../../gateway/active-sessions-shutdown-tracker.js";
+import { resolveSessionEntryLabel } from "../../gateway/session-utils.fs.js";
 import { getSessionBindingService } from "../../infra/outbound/session-binding-service.js";
 import { deliverSessionMaintenanceWarning } from "../../infra/session-maintenance-warning.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -230,6 +233,25 @@ function resolveBoundConversationSessionKey(params: {
   return binding.targetSessionKey;
 }
 
+function buildUpdatedHistory(
+  entry: SessionEntry,
+  storePath: string | undefined,
+  agentId: string | undefined,
+): SessionHistoryEntry[] {
+  const previous = entry.history ?? [];
+  const current: SessionHistoryEntry = {
+    sessionId: entry.sessionId,
+    sessionFile: entry.sessionFile,
+    updatedAt: entry.updatedAt,
+    label: resolveSessionEntryLabel(entry, storePath, agentId),
+    systemSent: entry.systemSent,
+  };
+  return [current, ...previous.filter((item) => item.sessionId !== current.sessionId)].slice(
+    0,
+    MAX_SESSION_HISTORY,
+  );
+}
+
 export async function initSessionState(params: {
   ctx: MsgContext;
   cfg: OpenClawConfig;
@@ -322,6 +344,7 @@ export async function initSessionState(params: {
   let persistedSubagentRole: SessionEntry["subagentRole"];
   let persistedSubagentControlScope: SessionEntry["subagentControlScope"];
   let persistedDisplayName: SessionEntry["displayName"];
+  let updatedHistory: SessionHistoryEntry[] | undefined;
 
   const normalizedChatType = normalizeChatType(ctx.ChatType);
   const isGroup =
@@ -544,6 +567,9 @@ export async function initSessionState(params: {
       persistedSubagentRole = entry.subagentRole;
       persistedSubagentControlScope = entry.subagentControlScope;
       persistedDisplayName = entry.displayName;
+      updatedHistory = buildUpdatedHistory(entry, storePath, agentId);
+    } else if (entry) {
+      updatedHistory = buildUpdatedHistory(entry, storePath, agentId);
     }
   }
 
@@ -667,6 +693,7 @@ export async function initSessionState(params: {
     spawnDepth: persistedSpawnDepth ?? baseEntry?.spawnDepth,
     subagentRole: persistedSubagentRole ?? baseEntry?.subagentRole,
     subagentControlScope: persistedSubagentControlScope ?? baseEntry?.subagentControlScope,
+    history: updatedHistory ?? baseEntry?.history,
     sendPolicy: baseEntry?.sendPolicy,
     queueMode: baseEntry?.queueMode,
     queueDebounceMs: baseEntry?.queueDebounceMs,

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -229,6 +229,14 @@ export type SessionGoal = {
   budgetLimitedAt?: number;
 };
 
+export type SessionHistoryEntry = {
+  sessionId: string;
+  sessionFile?: string;
+  updatedAt: number;
+  label?: string;
+  systemSent?: boolean;
+};
+
 export type SessionEntry = {
   /**
    * Last delivered heartbeat payload (used to suppress duplicate heartbeat notifications).
@@ -270,6 +278,8 @@ export type SessionEntry = {
   subagentRole?: "orchestrator" | "leaf";
   /** Explicit control scope assigned at spawn time for subagent control decisions. */
   subagentControlScope?: "children" | "none";
+  /** Previous sessions for this session key, newest-first. Capped at 20. */
+  history?: SessionHistoryEntry[];
   /** Session-scoped tool deny entries inherited from the caller that created this session. */
   inheritedToolDeny?: string[];
   /** Session-scoped tool allow entries inherited from the caller that created this session. */
@@ -732,4 +742,5 @@ export type SessionSystemPromptReport = {
 
 export const DEFAULT_RESET_TRIGGER = "/new";
 export const DEFAULT_RESET_TRIGGERS = ["/new", "/reset"];
+export const MAX_SESSION_HISTORY = 20;
 export const DEFAULT_IDLE_MINUTES = 0;

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -1613,6 +1613,29 @@ export function readRecentSessionUsageFromTranscript(
   });
 }
 
+type SessionEntryLabelFields = {
+  label?: string;
+  displayName?: string;
+  subject?: string;
+  sessionId: string;
+  sessionFile?: string;
+};
+
+export function resolveSessionEntryLabel(
+  entry: SessionEntryLabelFields,
+  storePath: string | undefined,
+  agentId: string | undefined,
+): string | undefined {
+  return (
+    entry.label ??
+    entry.displayName?.trim() ??
+    entry.subject?.trim() ??
+    readSessionTitleFieldsFromTranscript(entry.sessionId, storePath, entry.sessionFile, agentId)
+      .lastMessagePreview ??
+    undefined
+  );
+}
+
 const PREVIEW_READ_SIZES = [64 * 1024, 256 * 1024, 1024 * 1024];
 const PREVIEW_MAX_LINES = 200;
 

--- a/src/plugins/session-entry-slot-keys.ts
+++ b/src/plugins/session-entry-slot-keys.ts
@@ -22,6 +22,7 @@ const SESSION_ENTRY_RESERVED_SLOT_KEY_LIST = [
   "spawnDepth",
   "subagentRole",
   "subagentControlScope",
+  "history",
   "inheritedToolDeny",
   "inheritedToolAllow",
   "subagentRecovery",


### PR DESCRIPTION
## Summary
- Add `/resume` command for session recovery:
  - `/resume` lists recent sessions
  - `/resume #<index>` resumes by list index
  - `/resume <id>` resumes by session id / 8-char prefix
- Persist bounded session history (`MAX_SESSION_HISTORY = 20`) on session rollover, including explicit reset and idle/daily expiry paths.
- Add shared session label derivation helper (`label -> displayName -> subject -> transcript preview`) and wire docs/help/command registry updates.

## Verification
- `node scripts/run-vitest.mjs src/auto-reply/reply/commands-session-resume.test.ts src/auto-reply/reply/session.test.ts src/auto-reply/status.test.ts src/auto-reply/commands-registry.test.ts`
- Result: 4 files passed, 188 tests passed.

## Real behavior proof
- Behavior addressed: `/resume` lists previous sessions and restores a selected session after `/new` or `/reset`.
- Real environment tested: Real Telegram chat with a local OpenClaw gateway on macOS.
- Exact steps or command run after this patch: Sent a normal message in Telegram, ran `/new`, sent another message, ran `/resume`, then `/resume #2`, then sent a follow-up message in the restored session.
- Evidence after fix: Attached Telegram screenshots or a short recording showing the `/resume` session list and the `Resumed session` reply from the real chat surface.
- Observed result after fix: `/resume` listed recent sessions, `/resume #2` switched to the selected prior session, and the next message continued that restored conversation in Telegram.
- What was not tested: Cross-host filesystem edge cases and other chat providers beyond the tested real Telegram environment.
