### PR TITLE
fix(gateway): land linked diagnostics fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gateway/diagnostics: redact credential-bearing gateway target URLs and client diagnostics while preserving raw connection URLs for programmatic use, so connect-failure logs no longer surface embedded tokens.
+- Logs: redact raw Basic auth and named security headers from `logs.tail` output before returning lines to read-scoped clients. Fixes #66832. Thanks @Magicray1217.
 - Telegram: normalize announce group targets via a new `resolveSessionTarget` channel hook so scheduled announcements resolve consistently against the same Telegram session conversation registry as inbound turns. Fixes #81229. Thanks @giodl73-repo.
 - Discord: bind delayed gateway `identify` retries to the originating socket generation so retries triggered after a reconnect do not identify against a fresh socket. Fixes #82225. Thanks @giodl73-repo.
 - ACP/control plane: refresh cached runtime handles when agent config changes so ACP sessions stop using stale runtimes after `agents.defaults` edits. Fixes #82237. Thanks @giodl73-repo.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 - Gateway/diagnostics: redact credential-bearing gateway target URLs and client diagnostics while preserving raw connection URLs for programmatic use, so connect-failure logs no longer surface embedded tokens.
 - Logs: redact raw Basic auth and named security headers from `logs.tail` output before returning lines to read-scoped clients. Fixes #66832. Thanks @Magicray1217.
+- CLI/gateway: emit structured JSON for gateway transport close/timeout failures when `--json` is requested by health, gateway health, and devices list commands. Fixes #79108. Thanks @TurboTheTurtle.
 - Telegram: normalize announce group targets via a new `resolveSessionTarget` channel hook so scheduled announcements resolve consistently against the same Telegram session conversation registry as inbound turns. Fixes #81229. Thanks @giodl73-repo.
 - Discord: bind delayed gateway `identify` retries to the originating socket generation so retries triggered after a reconnect do not identify against a fresh socket. Fixes #82225. Thanks @giodl73-repo.
 - ACP/control plane: refresh cached runtime handles when agent config changes so ACP sessions stop using stale runtimes after `agents.defaults` edits. Fixes #82237. Thanks @giodl73-repo.

--- a/src/cli/devices-cli.runtime.ts
+++ b/src/cli/devices-cli.runtime.ts
@@ -1,4 +1,8 @@
-import { buildGatewayConnectionDetails, callGateway } from "../gateway/call.js";
+import {
+  buildGatewayConnectionDetails,
+  callGateway,
+  formatGatewayTransportErrorJson,
+} from "../gateway/call.js";
 import { ADMIN_SCOPE, PAIRING_SCOPE, type OperatorScope } from "../gateway/method-scopes.js";
 import { isLoopbackHost } from "../gateway/net.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../gateway/protocol/client-info.js";
@@ -504,7 +508,20 @@ function resolveRequiredDeviceRole(
 }
 
 export async function runDevicesListCommand(opts: DevicesRpcOpts): Promise<void> {
-  const list = await listPairingWithFallback(opts);
+  let list: DevicePairingList;
+  try {
+    list = await listPairingWithFallback(opts);
+  } catch (error) {
+    if (opts.json) {
+      const payload = formatGatewayTransportErrorJson(error);
+      if (payload) {
+        defaultRuntime.writeJson(payload);
+        defaultRuntime.exit(1);
+        return;
+      }
+    }
+    throw error;
+  }
   const pairedByDeviceId = indexPairedDevices(list.paired);
   if (opts.json) {
     defaultRuntime.writeJson(list);

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { stripAnsi } from "../terminal/ansi.js";
 import { registerDevicesCli } from "./devices-cli.js";
 
 const mocks = vi.hoisted(() => ({
@@ -10,6 +11,7 @@ const mocks = vi.hoisted(() => ({
     writeJson: vi.fn(),
   },
   callGateway: vi.fn(),
+  formatGatewayTransportErrorJson: vi.fn(),
   buildGatewayConnectionDetails: vi.fn(() => ({
     url: "ws://127.0.0.1:18789",
     urlSource: "local loopback",
@@ -24,6 +26,7 @@ const mocks = vi.hoisted(() => ({
 const {
   runtime,
   callGateway,
+  formatGatewayTransportErrorJson,
   buildGatewayConnectionDetails,
   listDevicePairing,
   approveDevicePairing,
@@ -32,6 +35,7 @@ const {
 
 vi.mock("../gateway/call.js", () => ({
   callGateway: mocks.callGateway,
+  formatGatewayTransportErrorJson: mocks.formatGatewayTransportErrorJson,
   buildGatewayConnectionDetails: mocks.buildGatewayConnectionDetails,
 }));
 
@@ -676,18 +680,43 @@ describe("devices cli list", () => {
 
     await runDevicesCommand(["list"]);
 
-    const output = readRuntimeOutput();
+    const output = stripAnsi(readRuntimeOutput());
     expect(output).not.toContain("\u001b");
     expect(output).not.toContain("\r");
     expect(output).toContain("BadName");
     expect(output).toContain("spoof");
     expect(output).toContain("Paired");
   });
+
+  it("emits JSON when the gateway transport fails in JSON mode", async () => {
+    const error = new Error("gateway closed (1006)");
+    const payload = {
+      ok: false,
+      error: {
+        type: "gateway_transport_error",
+        kind: "closed",
+        message: "gateway closed (1006)",
+      },
+      gateway: {
+        url: "ws://127.0.0.1:18789",
+        urlSource: "local loopback",
+      },
+    };
+    callGateway.mockRejectedValueOnce(error);
+    formatGatewayTransportErrorJson.mockReturnValueOnce(payload);
+
+    await runDevicesCommand(["list", "--json"]);
+
+    expect(formatGatewayTransportErrorJson).toHaveBeenCalledWith(error);
+    expect(runtime.writeJson).toHaveBeenCalledWith(payload);
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
 });
 
 beforeEach(() => {
   vi.clearAllMocks();
   runtime.exit.mockImplementation(() => {});
+  formatGatewayTransportErrorJson.mockReturnValue(null);
 });
 
 afterEach(() => {

--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -12,6 +12,7 @@ type DiscoveredBeacon = Awaited<
 >[number];
 
 const callGateway = vi.fn<(opts: unknown) => Promise<{ ok: true }>>(async () => ({ ok: true }));
+const formatGatewayTransportErrorJson = vi.fn();
 const startGatewayServer = vi.fn<
   (port: number, opts?: unknown) => Promise<{ close: () => Promise<void> }>
 >(async () => ({
@@ -44,6 +45,7 @@ vi.mock(
   new URL("../../gateway/call.ts", new URL("./gateway-cli/call.ts", import.meta.url)).href,
   () => ({
     callGateway: (opts: unknown) => callGateway(opts),
+    formatGatewayTransportErrorJson: (error: unknown) => formatGatewayTransportErrorJson(error),
     randomIdempotencyKey: () => "rk_test",
   }),
 );
@@ -143,6 +145,8 @@ describe("gateway-cli coverage", () => {
     startGatewayServer.mockClear();
     inspectPortUsage.mockClear();
     formatPortDiagnostics.mockClear();
+    formatGatewayTransportErrorJson.mockReset();
+    formatGatewayTransportErrorJson.mockReturnValue(null);
   });
 
   it("registers call/health commands and routes to callGateway", async () => {
@@ -182,6 +186,30 @@ describe("gateway-cli coverage", () => {
       limit: 5,
       type: "payload.large",
     });
+  });
+
+  it("writes JSON for gateway health transport failures in JSON mode", async () => {
+    const error = new Error("gateway closed (1006)");
+    const payload = {
+      ok: false,
+      error: {
+        type: "gateway_transport_error",
+        kind: "closed",
+        message: "gateway closed (1006)",
+      },
+      gateway: {
+        url: "ws://127.0.0.1:18789",
+        urlSource: "local loopback",
+      },
+    };
+    callGateway.mockRejectedValueOnce(error);
+    formatGatewayTransportErrorJson.mockReturnValueOnce(payload);
+
+    await expectGatewayExit(["gateway", "health", "--json"]);
+
+    expect(formatGatewayTransportErrorJson).toHaveBeenCalledWith(error);
+    expect(defaultRuntime.writeJson).toHaveBeenCalledWith(payload);
+    expect(runtimeErrors.join("\n")).not.toContain("gateway closed");
   });
 
   it("prints the latest stability bundle without calling Gateway", async () => {

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -1,5 +1,6 @@
 import type { Command } from "commander";
 import type { HealthSummary } from "../../commands/health.js";
+import { formatGatewayTransportErrorJson } from "../../gateway/call.js";
 import type { CostUsageSummary } from "../../infra/session-cost-usage.js";
 import type {
   DiagnosticStabilityBundle,
@@ -97,8 +98,16 @@ function loadDaemonStatusGatherModule() {
   return daemonStatusGatherModuleLoader.load();
 }
 
-function runGatewayCommand(action: () => Promise<void>, label?: string) {
+function runGatewayCommand(action: () => Promise<void>, label?: string, opts?: { json?: boolean }) {
   return runCommandWithRuntime(defaultRuntime, action, (err) => {
+    if (opts?.json) {
+      const payload = formatGatewayTransportErrorJson(err);
+      if (payload) {
+        defaultRuntime.writeJson(payload);
+        defaultRuntime.exit(1);
+        return;
+      }
+    }
     const message = String(err);
     defaultRuntime.error(label ? `${label}: ${message}` : message);
     defaultRuntime.exit(1);
@@ -459,30 +468,34 @@ export function registerGatewayCli(program: Command) {
       .command("health")
       .description("Fetch Gateway health")
       .action(async (opts, command) => {
-        await runGatewayCommand(async () => {
-          const rpcOpts = resolveGatewayRpcOptions(opts, command);
-          const [{ formatHealthChannelLines }, { styleHealthChannelLine }] = await Promise.all([
-            loadGatewayHealthModule(),
-            loadHealthStyleModule(),
-          ]);
-          const result = await callGatewayCli("health", rpcOpts);
-          if (rpcOpts.json) {
-            defaultRuntime.writeJson(result);
-            return;
-          }
-          const rich = isRich();
-          const obj: Record<string, unknown> = result && typeof result === "object" ? result : {};
-          const durationMs = typeof obj.durationMs === "number" ? obj.durationMs : null;
-          defaultRuntime.log(colorize(rich, theme.heading, "Gateway Health"));
-          defaultRuntime.log(
-            `${colorize(rich, theme.success, "OK")}${durationMs != null ? ` (${durationMs}ms)` : ""}`,
-          );
-          if (obj.channels && typeof obj.channels === "object") {
-            for (const line of formatHealthChannelLines(obj as HealthSummary)) {
-              defaultRuntime.log(styleHealthChannelLine(line, rich));
+        await runGatewayCommand(
+          async () => {
+            const rpcOpts = resolveGatewayRpcOptions(opts, command);
+            const [{ formatHealthChannelLines }, { styleHealthChannelLine }] = await Promise.all([
+              loadGatewayHealthModule(),
+              loadHealthStyleModule(),
+            ]);
+            const result = await callGatewayCli("health", rpcOpts);
+            if (rpcOpts.json) {
+              defaultRuntime.writeJson(result);
+              return;
             }
-          }
-        });
+            const rich = isRich();
+            const obj: Record<string, unknown> = result && typeof result === "object" ? result : {};
+            const durationMs = typeof obj.durationMs === "number" ? obj.durationMs : null;
+            defaultRuntime.log(colorize(rich, theme.heading, "Gateway Health"));
+            defaultRuntime.log(
+              `${colorize(rich, theme.success, "OK")}${durationMs != null ? ` (${durationMs}ms)` : ""}`,
+            );
+            if (obj.channels && typeof obj.channels === "object") {
+              for (const line of formatHealthChannelLines(obj as HealthSummary)) {
+                defaultRuntime.log(styleHealthChannelLine(line, rich));
+              }
+            }
+          },
+          undefined,
+          { json: Boolean(opts.json) },
+        );
       }),
   );
 

--- a/src/commands/health.test.ts
+++ b/src/commands/health.test.ts
@@ -52,8 +52,11 @@ const createHealthSummary = (params: {
 };
 
 const callGatewayMock = vi.fn();
+const formatGatewayTransportErrorJsonMock = vi.fn();
 vi.mock("../gateway/call.js", () => ({
   callGateway: (...args: unknown[]) => callGatewayMock(...args),
+  formatGatewayTransportErrorJson: (...args: unknown[]) =>
+    formatGatewayTransportErrorJsonMock(...args),
 }));
 
 function requireFirstRuntimeLog(): string {
@@ -83,6 +86,7 @@ function requireFirstGatewayRequest(): Record<string, unknown> {
 describe("healthCommand", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    formatGatewayTransportErrorJsonMock.mockReturnValue(null);
   });
 
   it("outputs JSON from gateway", async () => {
@@ -144,6 +148,33 @@ describe("healthCommand", () => {
     expect(gatewayRequest.method).toBe("health");
     expect(gatewayRequest.token).toBe("setup-token");
     expect(gatewayRequest.password).toBe("setup-password");
+  });
+
+  it("outputs JSON for gateway transport failures in JSON mode", async () => {
+    const error = new Error("gateway closed (1006)");
+    const payload = {
+      ok: false,
+      error: {
+        type: "gateway_transport_error",
+        kind: "closed",
+        message: "gateway closed (1006)",
+        code: 1006,
+        reason: "no close reason",
+      },
+      gateway: {
+        url: "ws://127.0.0.1:18789",
+        urlSource: "local loopback",
+        bindDetail: "Bind: loopback",
+      },
+    };
+    callGatewayMock.mockRejectedValueOnce(error);
+    formatGatewayTransportErrorJsonMock.mockReturnValueOnce(payload);
+
+    await healthCommand({ json: true, timeoutMs: 5000, config: {} }, runtime as never);
+
+    expect(formatGatewayTransportErrorJsonMock).toHaveBeenCalledWith(error);
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(JSON.parse(requireFirstRuntimeLog())).toEqual(payload);
   });
 
   it("prints degraded model-pricing health without failing the command", async () => {

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -13,7 +13,11 @@ import { withProgress } from "../cli/progress.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { buildGatewayConnectionDetails, callGateway } from "../gateway/call.js";
+import {
+  buildGatewayConnectionDetails,
+  callGateway,
+  formatGatewayTransportErrorJson,
+} from "../gateway/call.js";
 import {
   DEFAULT_CHANNEL_CONNECT_GRACE_MS,
   DEFAULT_CHANNEL_STALE_EVENT_THRESHOLD_MS,
@@ -603,22 +607,35 @@ export async function healthCommand(
 ) {
   const cfg = opts.config ?? (await readBestEffortHealthConfig());
   // Always query the running gateway; do not open a direct Baileys socket here.
-  const summary = await withProgress(
-    {
-      label: "Checking gateway health…",
-      indeterminate: true,
-      enabled: opts.json !== true,
-    },
-    async () =>
-      await callGateway<HealthSummary>({
-        method: "health",
-        params: opts.verbose ? { probe: true } : undefined,
-        timeoutMs: opts.timeoutMs,
-        config: cfg,
-        token: opts.token,
-        password: opts.password,
-      }),
-  );
+  let summary: HealthSummary;
+  try {
+    summary = await withProgress(
+      {
+        label: "Checking gateway health…",
+        indeterminate: true,
+        enabled: opts.json !== true,
+      },
+      async () =>
+        await callGateway<HealthSummary>({
+          method: "health",
+          params: opts.verbose ? { probe: true } : undefined,
+          timeoutMs: opts.timeoutMs,
+          config: cfg,
+          token: opts.token,
+          password: opts.password,
+        }),
+    );
+  } catch (error) {
+    if (opts.json) {
+      const payload = formatGatewayTransportErrorJson(error);
+      if (payload) {
+        writeRuntimeJson(runtime, payload);
+        runtime.exit(1);
+        return;
+      }
+    }
+    throw error;
+  }
   // Gateway reachability defines success; channel issues are reported but not fatal here.
   const fatal = false;
 

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -139,6 +139,7 @@ const {
   callGateway,
   callGatewayCli,
   callGatewayScoped,
+  formatGatewayTransportErrorJson,
   isGatewayTransportError,
 } = await import("./call.js");
 
@@ -989,6 +990,34 @@ describe("callGateway error details", () => {
     expect(transportError.name).toBe("GatewayTransportError");
     expect(transportError.kind).toBe("timeout");
     expect(transportError.timeoutMs).toBe(5);
+  });
+
+  it("formats typed transport errors for CLI JSON output", async () => {
+    startMode = "close";
+    closeCode = 1006;
+    closeReason = "";
+    setLocalLoopbackGatewayConfig();
+
+    let err: unknown;
+    await callGateway({ method: "health" }).catch((caught) => {
+      err = caught;
+    });
+
+    expect(formatGatewayTransportErrorJson(err)).toEqual({
+      ok: false,
+      error: {
+        type: "gateway_transport_error",
+        kind: "closed",
+        message: "gateway closed (1006 abnormal closure (no close frame)): no close reason",
+        code: 1006,
+        reason: "no close reason",
+      },
+      gateway: {
+        url: "ws://127.0.0.1:18789",
+        urlSource: "local loopback",
+        bindDetail: "Bind: loopback",
+      },
+    });
   });
 
   it("charges event-loop readiness against the wrapper timeout", async () => {

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -9,6 +9,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { loadOrCreateDeviceIdentity, type DeviceIdentity } from "../infra/device-identity.js";
 import { loadGatewayTlsRuntime } from "../infra/tls/gateway.js";
 import { isLoopbackIpAddress } from "../shared/net/ip.js";
+import { redactSensitiveUrlLikeString } from "../shared/net/redact-sensitive-url.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import {
   GATEWAY_CLIENT_MODES,
@@ -114,6 +115,55 @@ export class GatewayTransportError extends Error {
       this.timeoutMs = params.timeoutMs;
     }
   }
+}
+
+export type GatewayTransportErrorJson = {
+  ok: false;
+  error: {
+    type: "gateway_transport_error";
+    kind: GatewayTransportErrorKind;
+    message: string;
+    code?: number;
+    reason?: string;
+    timeoutMs?: number;
+  };
+  gateway: {
+    url: string;
+    urlSource: string;
+    bindDetail?: string;
+    remoteFallbackNote?: string;
+  };
+};
+
+function firstGatewayErrorLine(message: string): string {
+  return message.split("\n", 1)[0]?.trim() || message;
+}
+
+export function formatGatewayTransportErrorJson(value: unknown): GatewayTransportErrorJson | null {
+  if (!isGatewayTransportError(value)) {
+    return null;
+  }
+  return {
+    ok: false,
+    error: {
+      type: "gateway_transport_error",
+      kind: value.kind,
+      message: firstGatewayErrorLine(value.message),
+      ...(value.code !== undefined ? { code: value.code } : {}),
+      ...(value.reason !== undefined ? { reason: value.reason } : {}),
+      ...(value.timeoutMs !== undefined ? { timeoutMs: value.timeoutMs } : {}),
+    },
+    gateway: {
+      url: redactSensitiveUrlLikeString(value.connectionDetails.url),
+      urlSource: value.connectionDetails.urlSource,
+      ...(value.connectionDetails.bindDetail
+        ? { bindDetail: value.connectionDetails.bindDetail }
+        : {}),
+      ...(value.connectionDetails.remoteFallbackNote
+        ? { remoteFallbackNote: value.connectionDetails.remoteFallbackNote }
+        : {}),
+    },
+  };
 }
 
 export function isGatewayTransportError(value: unknown): value is GatewayTransportError {

--- a/src/logging/log-tail-redaction.test.ts
+++ b/src/logging/log-tail-redaction.test.ts
@@ -1,0 +1,67 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resetLogger, setLoggerOverride } from "../logging.js";
+import { readConfiguredLogTail } from "./log-tail.js";
+
+const originalConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+let tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-log-tail-redaction-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  if (originalConfigPath === undefined) {
+    delete process.env.OPENCLAW_CONFIG_PATH;
+  } else {
+    process.env.OPENCLAW_CONFIG_PATH = originalConfigPath;
+  }
+  setLoggerOverride(null);
+  resetLogger();
+  await Promise.all(tempDirs.map((dir) => fs.rm(dir, { force: true, recursive: true })));
+  tempDirs = [];
+});
+
+describe("readConfiguredLogTail redaction", () => {
+  it("redacts raw auth headers before returning log lines", async () => {
+    const dir = await makeTempDir();
+    const logFile = path.join(dir, "openclaw.log");
+    const configFile = path.join(dir, "openclaw.json");
+    const basicSecret = "c2VjcmV0OnBhc3M=";
+    const openClawToken = "supersecretgatewaytoken1234567890";
+    const pomeriumJwt = "eyJheaderabcd.eyJpayloadabcd.signatureabcd123456";
+
+    await fs.writeFile(
+      configFile,
+      JSON.stringify({ logging: { redactSensitive: "tools" } }),
+      "utf8",
+    );
+    await fs.writeFile(
+      logFile,
+      [
+        `Authorization: Basic ${basicSecret}`,
+        `X-OpenClaw-Token: ${openClawToken}`,
+        `x-pomerium-jwt-assertion: ${pomeriumJwt}`,
+        "normal diagnostic line",
+      ].join("\n"),
+      "utf8",
+    );
+    process.env.OPENCLAW_CONFIG_PATH = configFile;
+    setLoggerOverride({ file: logFile });
+
+    const payload = await readConfiguredLogTail({ limit: 10 });
+    const text = payload.lines.join("\n");
+
+    expect(text).toContain("Authorization: Basic ***");
+    expect(text).toContain("X-OpenClaw-Token: supers…7890");
+    expect(text).toContain("x-pomerium-jwt-assertion: eyJhea…3456");
+    expect(text).toContain("normal diagnostic line");
+    expect(text).not.toContain(basicSecret);
+    expect(text).not.toContain(openClawToken);
+    expect(text).not.toContain(pomeriumJwt);
+  });
+});

--- a/src/logging/redact.test.ts
+++ b/src/logging/redact.test.ts
@@ -208,6 +208,39 @@ describe("redactSensitiveText", () => {
     expect(output).toBe("Authorization: Bearer abcdef…ghij");
   });
 
+  it("masks Basic authorization header tokens", () => {
+    const secret = "c2VjcmV0OnBhc3M=";
+    const output = redactSensitiveText(`Authorization: Basic ${secret}`, {
+      mode: "tools",
+      patterns: defaults,
+    });
+
+    expect(output).toBe("Authorization: Basic ***");
+    expect(output).not.toContain(secret);
+  });
+
+  it("masks named Gateway security headers", () => {
+    const openClawToken = "supersecretgatewaytoken1234567890";
+    const pomeriumJwt = "eyJheaderabcd.eyJpayloadabcd.signatureabcd123456";
+    const apiKey = "shortsecret";
+    const input = [
+      `X-OpenClaw-Token: ${openClawToken}`,
+      `x-pomerium-jwt-assertion: ${pomeriumJwt}`,
+      `X-Api-Key=${apiKey}`,
+    ].join("\n");
+    const output = redactSensitiveText(input, {
+      mode: "tools",
+      patterns: defaults,
+    });
+
+    expect(output).toContain("X-OpenClaw-Token: supers…7890");
+    expect(output).toContain("x-pomerium-jwt-assertion: eyJhea…3456");
+    expect(output).toContain("X-Api-Key=***");
+    expect(output).not.toContain(openClawToken);
+    expect(output).not.toContain(pomeriumJwt);
+    expect(output).not.toContain(apiKey);
+  });
+
   it("masks token prefixes embedded after adjacent text", () => {
     const token = `ghp_${"a".repeat(5_000)}`;
     const output = redactSensitiveText(`prefix-${token} suffix`, {

--- a/src/logging/redact.ts
+++ b/src/logging/redact.ts
@@ -56,6 +56,8 @@ const DEFAULT_REDACT_PATTERNS: string[] = [
   String.raw`--(?:api[-_]?key|hook[-_]?token|token|secret|password|passwd|${PAYMENT_CREDENTIAL_QUERY_KEYS})\s+(["']?)([^\s"']+)\1`,
   // Authorization headers.
   String.raw`Authorization\s*[:=]\s*Bearer\s+([A-Za-z0-9._\-+=]+)`,
+  String.raw`Authorization\s*[:=]\s*Basic\s+([A-Za-z0-9+/=]+)`,
+  String.raw`(?:X-OpenClaw-Token|x-pomerium-jwt-assertion|X-Api-Key|X-Auth-Token)\s*[:=]\s*([^\s"',;]+)`,
   String.raw`\bBearer\s+([A-Za-z0-9._\-+=]{18,})\b`,
   // Standalone token assignments in CLI or HTTP diagnostics. URL query params
   // are handled above so non-secret params survive and long values stay hinted.


### PR DESCRIPTION
## Summary

- Repair the #67041 logs.tail redaction fix by covering raw Basic auth plus named gateway/security headers without changing auth semantics.
- Repair the #79233 CLI JSON transport-error fix by formatting existing typed GatewayTransportError failures for JSON-mode health, gateway health, and devices list commands.
- Add focused regression coverage and changelog entries with contributor credit.

Fixes #66832.
Fixes #79108.
Supersedes #67041.
Supersedes #79233.

## Verification

- `git diff --check`
- `node scripts/run-vitest.mjs src/logging/redact.test.ts src/logging/log-tail-redaction.test.ts src/gateway/call.test.ts src/commands/health.test.ts src/cli/gateway-cli.coverage.test.ts src/cli/devices-cli.test.ts -- --reporter=dot`
- `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --blacksmith-org openclaw --blacksmith-workflow .github/workflows/ci-check-testbox.yml --blacksmith-job check --blacksmith-ref main --idle-timeout 90m --ttl 240m --timing-json -- CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_TEST_PROJECTS_PARALLEL=6 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm check:changed`

## Real behavior proof

Behavior addressed: logs.tail no longer returns raw Basic auth or named gateway/security header credentials; JSON-mode health/gateway health/devices list commands emit structured gateway_transport_error payloads for typed Gateway close/timeout failures instead of plain text errors.
Real environment tested: focused local Vitest through `scripts/run-vitest.mjs`; Blacksmith Testbox through Crabbox provider `blacksmith-testbox`.
Exact steps or command run after this patch: the Verification commands above, after rebasing onto `origin/main`.
Evidence after fix: focused tests passed 8 files / 348 tests; Testbox `tbx_01krryzqc6djxxnbrpea1n3n0t`, Actions run https://github.com/openclaw/openclaw/actions/runs/25968977106, exited 0.
Observed result after fix: redaction assertions remove raw fixture credentials from log-tail output, and CLI JSON assertions receive `ok:false` gateway_transport_error payloads without stderr fallback.
What was not tested: live gateway network failure against a real daemon; the code paths are covered with typed transport-error unit/CLI tests plus changed-gate lint/type/import-cycle checks.
