### PR TITLE
feat(messages): add toolMessageLogging override

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1762,6 +1762,7 @@ See [Multi-Agent Sandbox & Tools](/tools/multi-agent-sandbox-tools) for preceden
     responsePrefix: "🦞", // or "auto"
     ackReaction: "👀",
     ackReactionScope: "group-mentions", // group-mentions | group-all | direct | all
+    toolMessageLogging: true,
     removeAckAfterReply: false,
     queue: {
       mode: "collect", // steer | followup | collect | steer-backlog | steer+backlog | queue | interrupt
@@ -1808,6 +1809,7 @@ Variables are case-insensitive. `{think}` is an alias for `{thinkingLevel}`.
 - Per-channel overrides: `channels.<channel>.ackReaction`, `channels.<channel>.accounts.<id>.ackReaction`.
 - Resolution order: account → channel → `messages.ackReaction` → identity fallback.
 - Scope: `group-mentions` (default), `group-all`, `direct`, `all`.
+- `toolMessageLogging`: when `false`, suppresses intermediate tool-result/status messages and only sends the final reply. Default behavior is automatic: enabled for DMs and forum-style threads, suppressed for regular group chats.
 - `removeAckAfterReply`: removes ack after reply on Slack, Discord, and Telegram.
 - `messages.statusReactions.enabled`: enables lifecycle status reactions on Slack, Discord, and Telegram.
   On Slack and Discord, unset keeps status reactions enabled when ack reactions are active.

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1056,6 +1056,61 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
   });
 
+  it("suppresses DM tool summaries when messages.toolMessageLogging=false", async () => {
+    setNoAbort();
+    const cfg = {
+      ...emptyConfig,
+      messages: { toolMessageLogging: false },
+    } satisfies OpenClawConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      ChatType: "direct",
+    });
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      await opts?.onToolResult?.({ text: "🔧 exec: ls" });
+      return { text: "done" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+  });
+
+  it("delivers regular group tool summaries when messages.toolMessageLogging=true", async () => {
+    setNoAbort();
+    const cfg = {
+      ...emptyConfig,
+      messages: { toolMessageLogging: true },
+    } satisfies OpenClawConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      ChatType: "group",
+    });
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => {
+      await opts?.onToolResult?.({ text: "🔧 exec: ls" });
+      return { text: "done" } satisfies ReplyPayload;
+    };
+
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+    expect(dispatcher.sendToolResult).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "🔧 exec: ls" }),
+    );
+    expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(1);
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
+  });
+
   it("delivers deterministic exec approval tool payloads in groups", async () => {
     setNoAbort();
     const cfg = emptyConfig;

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -558,8 +558,10 @@ export async function dispatchReplyFromConfig(params: {
       chatType: sessionStoreEntry.entry?.chatType,
     });
 
-    const shouldSendToolSummaries = ctx.ChatType !== "group" || ctx.IsForum === true;
-    const shouldSendToolStartStatuses = ctx.ChatType !== "group" || ctx.IsForum === true;
+    const defaultToolMessageLogging = ctx.ChatType !== "group" || ctx.IsForum === true;
+    const shouldSendToolSummaries = cfg.messages?.toolMessageLogging ?? defaultToolMessageLogging;
+    const shouldSendToolStartStatuses =
+      cfg.messages?.toolMessageLogging ?? defaultToolMessageLogging;
     const sendFinalPayload = async (
       payload: ReplyPayload,
     ): Promise<{ queuedFinal: boolean; routedFinalCount: number }> => {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1495,6 +1495,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Map provider -> channel id -> model override (values are provider/model or aliases).",
   "messages.suppressToolErrors":
     "When true, suppress ⚠️ tool-error warnings from being shown to the user. The agent already sees errors in context and can retry. Default: false.",
+  "messages.toolMessageLogging":
+    "When false, suppress intermediate tool-result/status messages and only send the final reply. Default behavior is automatic: enabled for DMs/forums, suppressed for regular group chats.",
   "messages.ackReaction": "Emoji reaction used to acknowledge inbound messages (empty disables).",
   "messages.ackReactionScope":
     'When to send ack reactions ("group-mentions", "group-all", "direct", "all", "off", "none"). "off"/"none" disables ack reactions entirely.',

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -730,6 +730,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "messages.queue.drop": "Queue Drop Strategy",
   "messages.inbound": "Inbound Debounce",
   "messages.suppressToolErrors": "Suppress Tool Error Warnings",
+  "messages.toolMessageLogging": "Tool Message Logging",
   "messages.ackReaction": "Ack Reaction Emoji",
   "messages.ackReactionScope": "Ack Reaction Scope",
   "messages.removeAckAfterReply": "Remove Ack Reaction After Reply",

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -118,6 +118,8 @@ export type MessagesConfig = {
   removeAckAfterReply?: boolean;
   /** Lifecycle status reactions configuration. */
   statusReactions?: StatusReactionsConfig;
+  /** When false, suppress intermediate tool-result/status messages and only send the final reply. Default: auto (on for DMs/forums, off for regular groups). */
+  toolMessageLogging?: boolean;
   /** When true, suppress ⚠️ tool-error warnings from being shown to the user. Default: false. */
   suppressToolErrors?: boolean;
   /** Text-to-speech settings for outbound replies. */

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -186,6 +186,7 @@ export const MessagesSchema = z
       })
       .strict()
       .optional(),
+    toolMessageLogging: z.boolean().optional(),
     suppressToolErrors: z.boolean().optional(),
     tts: TtsConfigSchema,
   })


### PR DESCRIPTION
## Summary
- add a `messages.toolMessageLogging` configuration override to control tool-message logging behavior
- wire the setting through schema labels/help/types and session zod schema
- cover config dispatch behavior with auto-reply tests

## Test
- `pnpm exec vitest run src/auto-reply/reply/dispatch-from-config.test.ts --config vitest.config.ts`
