### PR TITLE
fix(skill-creator): accept mixed-case resources

### DIFF
--- a/skills/skill-creator/scripts/init_skill.py
+++ b/skills/skill-creator/scripts/init_skill.py
@@ -208,8 +208,18 @@ def title_case_skill_name(skill_name):
 def parse_resources(raw_resources):
     if not raw_resources:
         return []
-    resources = [item.strip() for item in raw_resources.split(",") if item.strip()]
-    invalid = sorted({item for item in resources if item not in ALLOWED_RESOURCES})
+    resources = []
+    invalid = []
+    for item in raw_resources.split(","):
+        original = item.strip()
+        if not original:
+            continue
+        resource = original.lower()
+        if resource not in ALLOWED_RESOURCES:
+            invalid.append(original)
+        else:
+            resources.append(resource)
+    invalid = sorted(set(invalid))
     if invalid:
         allowed = ", ".join(sorted(ALLOWED_RESOURCES))
         print(f"[ERROR] Unknown resource type(s): {', '.join(invalid)}")

--- a/skills/skill-creator/scripts/test_init_skill.py
+++ b/skills/skill-creator/scripts/test_init_skill.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""
+Regression tests for skill initializer parsing behavior.
+"""
+
+import io
+import sys
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest import TestCase, main
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+from init_skill import parse_resources
+
+
+class TestParseResources(TestCase):
+    def test_accepts_mixed_case_resources_with_order_preserving_deduplication(self):
+        resources = parse_resources("Scripts, references,ASSETS,scripts,REFERENCES")
+
+        self.assertEqual(resources, ["scripts", "references", "assets"])
+
+    def test_ignores_empty_tokens_after_case_normalization(self):
+        resources = parse_resources(" scripts, ,REFERENCES,,assets ")
+
+        self.assertEqual(resources, ["scripts", "references", "assets"])
+
+    def test_reports_invalid_resource_with_original_spelling(self):
+        output = io.StringIO()
+
+        with redirect_stdout(output), self.assertRaises(SystemExit) as raised:
+            parse_resources("Scripts, BadResource")
+
+        self.assertEqual(raised.exception.code, 1)
+        self.assertIn("Unknown resource type(s): BadResource", output.getvalue())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Normalize `init_skill.py --resources` tokens case-insensitively before validation and deduplication.
- Preserve canonical lowercase resource names and original spelling in invalid-resource errors.
- Add focused regression coverage for mixed-case resources, empty tokens, deduplication, and invalid-resource reporting.

## Test Plan
- RED: `PYTHONDONTWRITEBYTECODE=1 python3 -B skills/skill-creator/scripts/test_init_skill.py` failed before the implementation with `SystemExit` for mixed-case valid resources.
- GREEN: `PYTHONDONTWRITEBYTECODE=1 python3 -B skills/skill-creator/scripts/test_init_skill.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -B skills/skill-creator/scripts/test_package_skill.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -B skills/skill-creator/scripts/test_quick_validate.py`
- `git diff --check`

## Real behavior proof
Behavior addressed: `init_skill.py --resources` now accepts semantically valid mixed-case resource names like `Scripts,References,ASSETS`, dedupes them case-insensitively, and still rejects unknown resource names.

Real environment tested: local checkout on the branch for this PR using `python3 -B` with `PYTHONDONTWRITEBYTECODE=1`.

Exact steps or command run after this patch:
```bash
PYTHONDONTWRITEBYTECODE=1 python3 -B - <<'PY'
import io
import sys
from contextlib import redirect_stdout
sys.path.insert(0, 'skills/skill-creator/scripts')
from init_skill import parse_resources
print(parse_resources('Scripts,References,ASSETS,scripts'))
buf = io.StringIO()
try:
    with redirect_stdout(buf):
        parse_resources('Scripts,BadResource')
except SystemExit as exc:
    print(f'invalid_exit={exc.code}')
    print(buf.getvalue().splitlines()[0])
PY
```

Evidence after fix:
```text
['scripts', 'references', 'assets']
invalid_exit=1
[ERROR] Unknown resource type(s): BadResource
```

Observed result after fix: mixed-case valid resources return the canonical lowercase resource list, duplicate `scripts` is removed, and invalid input exits with the original invalid token spelling.

What was not tested: full OpenClaw CI/full suite; this patch is limited to the Python skill-creator parser and adjacent skill-creator script tests.

## Risk/Notes
- Scope is limited to `skills/skill-creator/scripts/init_skill.py` and focused parser tests.
- Existing lowercase `--resources` input keeps the same canonical output.

Closes #38076
