### PR TITLE
fix(qqbot): treat false-like QQBOT_DEBUG values as disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/edit tool: honor `file_path` and related path aliases when resolving edit-recovery targets, so post-write errors no longer surface false edit failures after the file actually changed. Fixes #81909. Thanks @giodl73-repo.
+- QQBot: treat only explicit truthy `QQBOT_DEBUG` values as enabling debug logs, so false-like values such as `0` no longer expose debug output. Fixes #82644. (#82697) Thanks @leno23.
 - Gateway/diagnostics: add opt-in critical memory pressure stability snapshots with gateway logs, V8 heap, cgroup, active-resource, and redacted large session-file evidence. Fixes #82518.
 - Doctor/Gateway: avoid treating unrelated macOS LaunchAgents as legacy gateways just because their environment values mention old checkout paths.
 - CLI/setup: collapse raw gateway config keys in existing-config summaries into friendly `Model` and `Gateway` rows.

--- a/extensions/qqbot/src/engine/utils/log.test.ts
+++ b/extensions/qqbot/src/engine/utils/log.test.ts
@@ -25,4 +25,16 @@ describe("QQBot debug logging", () => {
 
     expect(logSpy).toHaveBeenCalledWith("prefix line one line two");
   });
+
+  it.each(["0", "false", "off", "no"])(
+    "does not enable debug logging for QQBOT_DEBUG=%s",
+    (value) => {
+      process.env.QQBOT_DEBUG = value;
+      const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      debugLog("private message text");
+
+      expect(logSpy).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/extensions/qqbot/src/engine/utils/log.ts
+++ b/extensions/qqbot/src/engine/utils/log.ts
@@ -8,7 +8,23 @@
  * Self-contained within engine/ — no framework SDK dependency.
  */
 
-const isDebug = () => !!process.env.QQBOT_DEBUG;
+function isQqbotDebugEnabled(): boolean {
+  const value = process.env.QQBOT_DEBUG;
+  if (typeof value !== "string") {
+    return false;
+  }
+  switch (value.trim().toLowerCase()) {
+    case "1":
+    case "on":
+    case "true":
+    case "yes":
+      return true;
+    default:
+      return false;
+  }
+}
+
+const isDebug = () => isQqbotDebugEnabled();
 const MAX_LOG_VALUE_CHARS = 4096;
 
 export function sanitizeDebugLogValue(value: unknown): string {

--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -67,16 +67,6 @@ export function renderGatewayServiceCleanupHints(
 
 type Marker = (typeof EXTRA_MARKERS)[number];
 
-function detectMarker(content: string): Marker | null {
-  const lower = normalizeLowercaseStringOrEmpty(content);
-  for (const marker of EXTRA_MARKERS) {
-    if (lower.includes(marker)) {
-      return marker;
-    }
-  }
-  return null;
-}
-
 function hasGatewaySubcommandArg(args: string[]): boolean {
   return args.some((arg) => {
     const normalized = normalizeLowercaseStringOrEmpty(arg);


### PR DESCRIPTION
## Summary

- QQBot debug logging now only enables for explicit truthy `QQBOT_DEBUG` values (`1`, `true`, `yes`, `on`)
- Common disable values (`0`, `false`, `off`, `no`) no longer emit debug output (#82644)

## Real behavior proof

- **Behavior or issue addressed:** `QQBOT_DEBUG=0` no longer enables debug logs that may include message text.
- **Real environment tested:** macOS, Node v22.18.0, local checkout `fix/qqbot-debug-env-truthy`.
- **Exact steps or command run after this patch:**
  1. `QQBOT_DEBUG=0 node --import tsx -e "process.env.QQBOT_DEBUG='0'; const {debugLog}=await import('./extensions/qqbot/src/engine/utils/log.ts'); debugLog('secret'); console.log('done')"`
- **Evidence after fix:** With `QQBOT_DEBUG=0`, `debugLog` produces no stdout (only `done`).

```text
$ QQBOT_DEBUG=0 pnpm exec tsx -e "import { debugLog } from './extensions/qqbot/src/engine/utils/log.ts'; debugLog('private message'); console.log('stdout-only-marker')"
stdout-only-marker
```

- **Observed result after fix:** No debug line before the marker; `QQBOT_DEBUG=1` still logs sanitized output.
- **What was not tested:** Production QQBot channel runtime with live gateway.

## Test plan

- [x] `node scripts/run-vitest.mjs extensions/qqbot/src/engine/utils/log.test.ts`

Closes #82644