### PR TITLE
fix(gateway): watch config include files for reload

### DIFF
--- a/src/config/includes-scan.ts
+++ b/src/config/includes-scan.ts
@@ -45,6 +45,13 @@ function resolveIncludePath(baseConfigPath: string, includePath: string): string
   );
 }
 
+export function collectDirectIncludePaths(params: {
+  configPath: string;
+  parsed: unknown;
+}): string[] {
+  return listDirectIncludes(params.parsed).map((raw) => resolveIncludePath(params.configPath, raw));
+}
+
 export async function collectIncludePathsRecursive(params: {
   configPath: string;
   parsed: unknown;

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -505,7 +505,7 @@ describe("resolveGatewayReloadSettings", () => {
   });
 });
 
-type WatcherHandler = () => void;
+type WatcherHandler = (eventPath?: string) => void;
 type WatcherEvent = "add" | "change" | "unlink" | "error";
 
 function createWatcherMock() {
@@ -517,11 +517,13 @@ function createWatcherMock() {
       handlers.set(event, existing);
       return this;
     },
-    emit(event: WatcherEvent) {
+    emit(event: WatcherEvent, eventPath?: string) {
       for (const handler of handlers.get(event) ?? []) {
-        handler();
+        handler(eventPath);
       }
     },
+    add: vi.fn(() => {}),
+    unwatch: vi.fn(() => {}),
     close: vi.fn(async () => {}),
   };
 }
@@ -591,6 +593,7 @@ function createReloaderHarness(
     promoteSnapshot?: (snapshot: ConfigFileSnapshot, reason: string) => Promise<boolean>;
     initialPluginInstallRecords?: Record<string, PluginInstallRecord>;
     readPluginInstallRecords?: () => Promise<Record<string, PluginInstallRecord>>;
+    initialSnapshot?: ConfigFileSnapshot;
   } = {},
 ) {
   const watcher = createWatcherMock();
@@ -615,6 +618,7 @@ function createReloaderHarness(
     initialConfig: { gateway: { reload: { debounceMs: 0 } } },
     initialCompareConfig: options.initialCompareConfig,
     initialInternalWriteHash: options.initialInternalWriteHash,
+    initialSnapshot: options.initialSnapshot,
     readSnapshot,
     promoteSnapshot: options.promoteSnapshot,
     initialPluginInstallRecords: options.initialPluginInstallRecords ?? {},
@@ -676,6 +680,135 @@ describe("startGatewayConfigReloader", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
+  });
+
+  it("watches $include files from the startup snapshot", async () => {
+    const startupSnapshot = makeSnapshot({
+      path: "/tmp/openclaw.json",
+      parsed: { $include: "includes/models.json" },
+    });
+    const readSnapshot = vi.fn<() => Promise<ConfigFileSnapshot>>();
+    const { watcher, reloader } = createReloaderHarness(readSnapshot, {
+      initialSnapshot: startupSnapshot,
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(readSnapshot).not.toHaveBeenCalled();
+    expect(watcher.add).toHaveBeenCalledWith(["/tmp/includes/models.json"]);
+
+    await reloader.stop();
+  });
+
+  it("refreshes watched $include files after an accepted config snapshot", async () => {
+    const startupSnapshot = makeSnapshot({
+      path: "/tmp/openclaw.json",
+      parsed: { $include: "includes/old.json" },
+    });
+    const nextSnapshot = makeSnapshot({
+      path: "/tmp/openclaw.json",
+      parsed: { $include: "includes/next.json" },
+      config: {
+        gateway: { reload: { debounceMs: 0 } },
+        hooks: { enabled: true },
+      },
+      hash: "next-root-hash",
+    });
+    const readSnapshot = vi
+      .fn<() => Promise<ConfigFileSnapshot>>()
+      .mockResolvedValueOnce(nextSnapshot);
+    const { watcher, reloader } = createReloaderHarness(readSnapshot, {
+      initialSnapshot: startupSnapshot,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    watcher.add.mockClear();
+    watcher.unwatch.mockClear();
+
+    watcher.emit("change", "/tmp/openclaw.json");
+    await vi.runAllTimersAsync();
+
+    expect(watcher.add).toHaveBeenCalledWith(["/tmp/includes/next.json"]);
+    expect(watcher.unwatch).toHaveBeenCalledWith(["/tmp/includes/old.json"]);
+
+    await reloader.stop();
+  });
+
+  it("refreshes watched $include files after an accepted in-process write", async () => {
+    const startupSnapshot = makeSnapshot({
+      path: "/tmp/openclaw.json",
+      parsed: { $include: "includes/old.json" },
+    });
+    const nextConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      hooks: { enabled: true },
+    } satisfies OpenClawConfig;
+    const acceptedSnapshot = makeSnapshot({
+      path: "/tmp/openclaw.json",
+      parsed: { $include: "includes/next.json" },
+      sourceConfig: nextConfig,
+      runtimeConfig: nextConfig,
+      config: nextConfig,
+      hash: "internal-include-hash",
+    });
+    const readSnapshot = vi
+      .fn<() => Promise<ConfigFileSnapshot>>()
+      .mockResolvedValueOnce(acceptedSnapshot);
+    const { watcher, reloader, emitWrite } = createReloaderHarness(readSnapshot, {
+      initialSnapshot: startupSnapshot,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    watcher.add.mockClear();
+    watcher.unwatch.mockClear();
+
+    emitWrite({
+      ...makeZeroDebounceHookWrite("internal-include-hash"),
+      sourceConfig: nextConfig,
+      runtimeConfig: nextConfig,
+    });
+    await vi.runAllTimersAsync();
+
+    expect(readSnapshot).toHaveBeenCalledTimes(1);
+    expect(watcher.add).toHaveBeenCalledWith(["/tmp/includes/next.json"]);
+    expect(watcher.unwatch).toHaveBeenCalledWith(["/tmp/includes/old.json"]);
+
+    await reloader.stop();
+  });
+
+  it("reloads include-only changes even when the root config hash matches a recent write", async () => {
+    const startupSnapshot = makeSnapshot({
+      path: "/tmp/openclaw.json",
+      parsed: { $include: "includes/runtime.json" },
+    });
+    const includeConfig = {
+      gateway: { reload: { debounceMs: 0 }, channelHealthCheckMinutes: 5 },
+    } satisfies OpenClawConfig;
+    const includeChangedSnapshot = makeSnapshot({
+      path: "/tmp/openclaw.json",
+      parsed: { $include: "includes/runtime.json" },
+      sourceConfig: includeConfig,
+      runtimeConfig: includeConfig,
+      config: includeConfig,
+      hash: "root-hash",
+    });
+    const readSnapshot = vi
+      .fn<() => Promise<ConfigFileSnapshot>>()
+      .mockResolvedValueOnce(includeChangedSnapshot);
+    const { watcher, reloader } = createReloaderHarness(readSnapshot, {
+      initialInternalWriteHash: "root-hash",
+      initialSnapshot: startupSnapshot,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    watcher.emit("change", "/tmp/includes/runtime.json");
+    await vi.runAllTimersAsync();
+
+    expect(readSnapshot).toHaveBeenCalledTimes(1);
+
+    await reloader.stop();
   });
 
   it("retries missing snapshots and reloads once config file reappears", async () => {

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -1,5 +1,10 @@
+import path from "node:path";
 import chokidar from "chokidar";
 import { bumpSkillsSnapshotVersion } from "../agents/skills/refresh-state.js";
+import {
+  collectDirectIncludePaths,
+  collectIncludePathsRecursive,
+} from "../config/includes-scan.js";
 import type { ConfigWriteNotification } from "../config/io.js";
 import { formatConfigIssueLines } from "../config/issue-format.js";
 import { resolveConfigWriteFollowUp } from "../config/runtime-snapshot.js";
@@ -85,6 +90,7 @@ export function startGatewayConfigReloader(opts: {
   initialConfig: OpenClawConfig;
   initialCompareConfig?: OpenClawConfig;
   initialInternalWriteHash?: string | null;
+  initialSnapshot?: ConfigFileSnapshot;
   readSnapshot: () => Promise<ConfigFileSnapshot>;
   onHotReload: (plan: GatewayReloadPlan, nextConfig: OpenClawConfig) => Promise<void>;
   onRestart: (plan: GatewayReloadPlan, nextConfig: OpenClawConfig) => void | Promise<void>;
@@ -115,10 +121,102 @@ export function startGatewayConfigReloader(opts: {
     afterWrite?: ConfigWriteNotification["afterWrite"];
   } | null = null;
   let lastAppliedWriteHash = opts.initialInternalWriteHash ?? null;
+  let pendingIncludeWatchEvent = false;
+  const rootWatchPath = path.normalize(opts.watchPath);
+  const normalizeWatchPath = (watchPath: string) => path.normalize(watchPath);
+  let watchedIncludePaths = new Set<string>();
+  const suppressIncludeAddEvents = new Set<string>();
+  let syncingIncludeWatchPaths = false;
+  const watcher = chokidar.watch(opts.watchPath, {
+    ignoreInitial: true,
+    awaitWriteFinish: { stabilityThreshold: 200, pollInterval: 50 },
+    usePolling: Boolean(process.env.VITEST),
+  });
   let currentPluginInstallRecords =
     opts.initialPluginInstallRecords ?? loadInstalledPluginIndexInstallRecordsSync();
   const readPluginInstallRecords =
     opts.readPluginInstallRecords ?? loadInstalledPluginIndexInstallRecords;
+
+  const normalizeIncludeWatchPaths = (includePaths: string[]): string[] =>
+    Array.from(
+      new Set(
+        includePaths.map(normalizeWatchPath).filter((includePath) => includePath !== rootWatchPath),
+      ),
+    ).sort();
+
+  const collectDirectIncludeWatchPaths = (snapshot: ConfigFileSnapshot): string[] => {
+    if (!snapshot.exists || !snapshot.valid) {
+      return [];
+    }
+    return normalizeIncludeWatchPaths(
+      collectDirectIncludePaths({
+        configPath: snapshot.path,
+        parsed: snapshot.parsed,
+      }),
+    );
+  };
+
+  const collectIncludeWatchPaths = async (snapshot: ConfigFileSnapshot): Promise<string[]> => {
+    if (!snapshot.exists || !snapshot.valid) {
+      return [];
+    }
+    const includePaths = await collectIncludePathsRecursive({
+      configPath: snapshot.path,
+      parsed: snapshot.parsed,
+    });
+    return normalizeIncludeWatchPaths(includePaths);
+  };
+
+  const applyIncludeWatchPaths = (nextIncludePaths: string[], reason: string) => {
+    if (stopped) {
+      return;
+    }
+    const nextIncludePathSet = new Set(nextIncludePaths);
+    const toAdd = nextIncludePaths.filter((includePath) => !watchedIncludePaths.has(includePath));
+    const toRemove = Array.from(watchedIncludePaths)
+      .filter((includePath) => !nextIncludePathSet.has(includePath))
+      .toSorted();
+    if (toAdd.length === 0 && toRemove.length === 0) {
+      return;
+    }
+    syncingIncludeWatchPaths = true;
+    try {
+      if (toAdd.length > 0) {
+        for (const includePath of toAdd) {
+          suppressIncludeAddEvents.add(includePath);
+        }
+        watcher.add(toAdd);
+      }
+      if (toRemove.length > 0) {
+        watcher.unwatch(toRemove);
+      }
+      watchedIncludePaths = nextIncludePathSet;
+    } catch (err) {
+      opts.log.warn(`config reload include watch sync failed (${reason}): ${String(err)}`);
+    } finally {
+      syncingIncludeWatchPaths = false;
+    }
+  };
+
+  const syncIncludeWatchPaths = async (snapshot: ConfigFileSnapshot, reason: string) => {
+    if (stopped) {
+      return;
+    }
+    try {
+      applyIncludeWatchPaths(collectDirectIncludeWatchPaths(snapshot), `${reason}-direct`);
+    } catch (err) {
+      opts.log.warn(`config reload include watch sync failed (${reason}): ${String(err)}`);
+      return;
+    }
+    let nextIncludePaths: string[];
+    try {
+      nextIncludePaths = await collectIncludeWatchPaths(snapshot);
+    } catch (err) {
+      opts.log.warn(`config reload include watch sync failed (${reason}): ${String(err)}`);
+      return;
+    }
+    applyIncludeWatchPaths(nextIncludePaths, reason);
+  };
 
   const scheduleAfter = (wait: number) => {
     if (stopped) {
@@ -298,17 +396,17 @@ export function startGatewayConfigReloader(opts: {
   };
 
   const promoteAcceptedInProcessWrite = async (persistedHash: string) => {
-    if (!opts.promoteSnapshot) {
-      return;
-    }
     try {
       const snapshot = await opts.readSnapshot();
       if (snapshot.hash !== persistedHash || !snapshot.valid) {
         return;
       }
-      await promoteAcceptedSnapshot(snapshot, "in-process-write");
+      await syncIncludeWatchPaths(snapshot, "in-process-write");
+      if (opts.promoteSnapshot) {
+        await promoteAcceptedSnapshot(snapshot, "in-process-write");
+      }
     } catch (err) {
-      opts.log.warn(`config reload in-process last-known-good promotion failed: ${String(err)}`);
+      opts.log.warn(`config reload in-process snapshot handling failed: ${String(err)}`);
     }
   };
 
@@ -321,6 +419,8 @@ export function startGatewayConfigReloader(opts: {
       return;
     }
     running = true;
+    const includeTriggeredReload = pendingIncludeWatchEvent;
+    pendingIncludeWatchEvent = false;
     if (debounceTimer) {
       clearTimeout(debounceTimer);
       debounceTimer = null;
@@ -340,7 +440,7 @@ export function startGatewayConfigReloader(opts: {
       }
       let snapshot = await opts.readSnapshot();
       if (lastAppliedWriteHash && typeof snapshot.hash === "string") {
-        if (snapshot.hash === lastAppliedWriteHash) {
+        if (snapshot.hash === lastAppliedWriteHash && !includeTriggeredReload) {
           return;
         }
         lastAppliedWriteHash = null;
@@ -352,6 +452,7 @@ export function startGatewayConfigReloader(opts: {
         handleInvalidSnapshot(snapshot);
         return;
       }
+      await syncIncludeWatchPaths(snapshot, "valid-config");
       await applySnapshot(snapshot.config, snapshot.sourceConfig);
       await promoteAcceptedSnapshot(snapshot, "valid-config");
     } catch (err) {
@@ -365,13 +466,22 @@ export function startGatewayConfigReloader(opts: {
     }
   };
 
-  const watcher = chokidar.watch(opts.watchPath, {
-    ignoreInitial: true,
-    awaitWriteFinish: { stabilityThreshold: 200, pollInterval: 50 },
-    usePolling: Boolean(process.env.VITEST),
-  });
-
-  const scheduleFromWatcher = () => {
+  const scheduleFromWatcher = (eventKind: "add" | "change" | "unlink") => (eventPath?: string) => {
+    if (syncingIncludeWatchPaths) {
+      return;
+    }
+    const normalizedEventPath =
+      typeof eventPath === "string" ? normalizeWatchPath(eventPath) : null;
+    if (
+      eventKind === "add" &&
+      normalizedEventPath &&
+      suppressIncludeAddEvents.delete(normalizedEventPath)
+    ) {
+      return;
+    }
+    if (normalizedEventPath && watchedIncludePaths.has(normalizedEventPath)) {
+      pendingIncludeWatchEvent = true;
+    }
     schedule();
   };
 
@@ -390,9 +500,13 @@ export function startGatewayConfigReloader(opts: {
       scheduleAfter(0);
     }) ?? (() => {});
 
-  watcher.on("add", scheduleFromWatcher);
-  watcher.on("change", scheduleFromWatcher);
-  watcher.on("unlink", scheduleFromWatcher);
+  watcher.on("add", scheduleFromWatcher("add"));
+  watcher.on("change", scheduleFromWatcher("change"));
+  watcher.on("unlink", scheduleFromWatcher("unlink"));
+  if (opts.initialSnapshot) {
+    applyIncludeWatchPaths(collectDirectIncludeWatchPaths(opts.initialSnapshot), "startup");
+    void syncIncludeWatchPaths(opts.initialSnapshot, "startup");
+  }
   let watcherClosed = false;
   watcher.on("error", (err) => {
     if (watcherClosed) {

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -9,7 +9,7 @@ import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.
 import type { CliDeps } from "../cli/deps.types.js";
 import { isRestartEnabled } from "../config/commands.flags.js";
 import { getRuntimeConfig } from "../config/config.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.openclaw.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
 import { resetDirectoryCache } from "../infra/outbound/target-resolver.js";
@@ -136,6 +136,7 @@ type ManagedGatewayConfigReloaderParams = Omit<
   initialConfig: OpenClawConfig;
   initialCompareConfig?: OpenClawConfig;
   initialInternalWriteHash: string | null;
+  initialSnapshot?: ConfigFileSnapshot;
   watchPath: string;
   readSnapshot: typeof import("../config/config.js").readConfigFileSnapshot;
   promoteSnapshot: typeof import("../config/config.js").promoteConfigSnapshotToLastKnownGood;
@@ -579,6 +580,7 @@ export function startManagedGatewayConfigReloader(params: ManagedGatewayConfigRe
     initialConfig: params.initialConfig,
     initialCompareConfig: params.initialCompareConfig,
     initialInternalWriteHash: params.initialInternalWriteHash,
+    initialSnapshot: params.initialSnapshot,
     readSnapshot: params.readSnapshot,
     promoteSnapshot: async (snapshot, _reason) => await params.promoteSnapshot(snapshot),
     subscribeToWrites: params.subscribeToWrites,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1559,6 +1559,7 @@ export async function startGatewayServer(
       initialConfig: cfgAtStart,
       initialCompareConfig: startupLastGoodSnapshot.sourceConfig,
       initialInternalWriteHash: startupInternalWriteHash,
+      initialSnapshot: startupLastGoodSnapshot,
       watchPath: configSnapshot.path,
       readSnapshot: readConfigFileSnapshot,
       promoteSnapshot: promoteConfigSnapshotToLastKnownGood,


### PR DESCRIPTION
Fixes #59616
Relates to #41587
Supersedes the closed/conflicted #59632 approach on current `main`.

## Summary
- Pass the startup `ConfigFileSnapshot` into the gateway config reloader so `$include` dependencies can be watched immediately at startup.
- Track `$include` files alongside the root config file, adding/removing chokidar paths after valid snapshots and accepted in-process writes.
- Suppress synthetic `add` events from dynamic watcher registration, and let include-triggered changes bypass the root-hash internal-write dedupe guard.
- Add regression coverage for startup include watching, include watch refresh, in-process writes, and include-only changes with an unchanged root hash.

## Real behavior proof
- **Behavior or issue addressed:** Config hot-reload now observes files referenced by `$include`; editing an included file no longer requires a manual gateway restart.
- **Real environment tested:** Local macOS development checkout using the real OpenClaw `startGatewayConfigReloader`, real chokidar filesystem watcher, and temporary real config files under `/tmp`. The watcher itself was not mocked.
- **Exact steps or command run after this patch:** Ran a Node/tsx proof script that created a temporary root `openclaw.json` containing `{ "$include": "includes/runtime.json" }`, started `startGatewayConfigReloader` with the startup `ConfigFileSnapshot` and an `initialInternalWriteHash` equal to the root hash, then changed only `includes/runtime.json` from `gateway.channelHealthCheckMinutes: 1` to `7`.
- **Evidence after fix:** Terminal output from the after-fix proof script:

  ```json
  {
    "proof": "include-only filesystem change triggered gateway hot reload",
    "rootHashUnchanged": true,
    "readSnapshotCalls": 1,
    "changedPaths": [
      "gateway.channelHealthCheckMinutes"
    ],
    "nextChannelHealthCheckMinutes": 7
  }
  ```

- **Observed result after fix:** The root config hash stayed unchanged, but the include-only file edit caused the real reloader to read a snapshot once and invoke the hot reload path for `gateway.channelHealthCheckMinutes` with the new value `7`.
- **What was not tested:** No additional gaps.

## Tests
- `node scripts/run-vitest.mjs src/gateway/config-reload.test.ts -- -t "in-process write|\\$include files|include-only changes"`
- `node scripts/run-vitest.mjs src/gateway/config-reload.test.ts`
- `pnpm --config.verify-deps-before-run=false check:changed --staged`
