### PR TITLE
fix(webchat): trust local TTS media on accumulated block streaming tail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ Docs: https://docs.openclaw.ai
 - Telegram/Gateway: route targeted Telegram `/stop@bot` messages onto the control lane without cached bot metadata and match gateway stop requests across raw/canonical session aliases. (#82298) Thanks @VACInc.
 - MS Teams/media: sniff inline `data:image/*` attachment bytes before staging them, skipping payloads that are not actually images.
 - WebChat/media: require trusted local-media provenance before preserving local audio reply paths for display, so untrusted audio-looking paths go through normal staging and read-policy checks.
+- WebChat: trust local Auto-TTS audio on block-streamed replies, including ACP-dispatched tails, so synthesized browser audio renders instead of being silently dropped. Fixes #82628. (#82701) Thanks @leno23.
 - Agents/tool media: preserve trusted local-media provenance when merging generated tool attachments into final reply payloads, so trusted audio/media survives outbound display normalization.
 - Anthropic/Claude CLI: write model-scoped `claude-cli` runtime policy when reusing local Claude CLI auth, so upgraded Telegram and Dashboard gateway turns keep using the CLI backend instead of falling through to Anthropic API billing. Fixes #82344. Thanks @amknight.
 - Update: let package-swap `doctor --fix` persist core config repairs while plugin schemas are still converging, preventing update failures on externalized channel configs.

--- a/extensions/speech-core/src/tts.test.ts
+++ b/extensions/speech-core/src/tts.test.ts
@@ -186,6 +186,7 @@ async function expectTtsPayloadResult(params: {
   audioAsVoice: true | undefined;
   providerResult?: MockSpeechSynthesisResult;
   mediaExtension?: string;
+  kind?: "tool" | "block" | "final";
 }) {
   if (params.providerResult) {
     synthesizeMock.mockResolvedValueOnce(params.providerResult);
@@ -197,7 +198,7 @@ async function expectTtsPayloadResult(params: {
       payload: { text: params.text },
       cfg,
       channel: params.channel,
-      kind: "final",
+      kind: params.kind ?? "final",
     });
 
     expect(synthesizeMock).toHaveBeenCalled();
@@ -209,6 +210,7 @@ async function expectTtsPayloadResult(params: {
     expect(result.audioAsVoice).toBe(params.audioAsVoice);
     expect(result.mediaUrl).toMatch(new RegExp(`voice-\\d+\\.${params.mediaExtension ?? "ogg"}$`));
     expect(result.spokenText).toBe(params.text);
+    expect(result.trustedLocalMedia).toBe(true);
 
     mediaDir = result.mediaUrl ? path.dirname(result.mediaUrl) : undefined;
   } finally {
@@ -438,6 +440,32 @@ describe("speech-core native voice-note routing", () => {
         rmSync(mediaDir, { recursive: true, force: true });
       }
     }
+  });
+
+  it("applies TTS for block delivery kind in final mode (#82628)", async () => {
+    await expectTtsPayloadResult({
+      channel: "webchat",
+      prefsName: "openclaw-speech-core-block-kind-tts-test",
+      text: "WebChat block replies should synthesize audio for auto TTS.",
+      target: "audio-file",
+      audioAsVoice: undefined,
+      kind: "block",
+    });
+  });
+
+  it("skips tool delivery kind in final mode", async () => {
+    synthesizeMock.mockClear();
+    const cfg = createTtsConfig("openclaw-speech-core-tool-kind-tts-test");
+    const result = await maybeApplyTtsToPayload({
+      payload: { text: "Intermediate tool output should not be spoken." },
+      cfg,
+      channel: "webchat",
+      kind: "tool",
+    });
+
+    expect(synthesizeMock).not.toHaveBeenCalled();
+    expect(result.trustedLocalMedia).toBeUndefined();
+    expect(result.text).toBe("Intermediate tool output should not be spoken.");
   });
 
   it("keeps skipping untagged short TTS text", async () => {

--- a/extensions/speech-core/src/tts.test.ts
+++ b/extensions/speech-core/src/tts.test.ts
@@ -210,7 +210,7 @@ async function expectTtsPayloadResult(params: {
     expect(result.audioAsVoice).toBe(params.audioAsVoice);
     expect(result.mediaUrl).toMatch(new RegExp(`voice-\\d+\\.${params.mediaExtension ?? "ogg"}$`));
     expect(result.spokenText).toBe(params.text);
-    expect(result.trustedLocalMedia).toBe(true);
+    expect((result as { trustedLocalMedia?: boolean }).trustedLocalMedia).toBe(true);
 
     mediaDir = result.mediaUrl ? path.dirname(result.mediaUrl) : undefined;
   } finally {
@@ -453,7 +453,7 @@ describe("speech-core native voice-note routing", () => {
     });
 
     expect(synthesizeMock).not.toHaveBeenCalled();
-    expect(result.trustedLocalMedia).toBeUndefined();
+    expect((result as { trustedLocalMedia?: boolean }).trustedLocalMedia).toBeUndefined();
     expect(result.text).toBe("WebChat block stream chunks defer TTS to the final tail.");
   });
 
@@ -468,7 +468,7 @@ describe("speech-core native voice-note routing", () => {
     });
 
     expect(synthesizeMock).not.toHaveBeenCalled();
-    expect(result.trustedLocalMedia).toBeUndefined();
+    expect((result as { trustedLocalMedia?: boolean }).trustedLocalMedia).toBeUndefined();
     expect(result.text).toBe("Intermediate tool output should not be spoken.");
   });
 

--- a/extensions/speech-core/src/tts.test.ts
+++ b/extensions/speech-core/src/tts.test.ts
@@ -442,15 +442,19 @@ describe("speech-core native voice-note routing", () => {
     }
   });
 
-  it("applies TTS for block delivery kind in final mode (#82628)", async () => {
-    await expectTtsPayloadResult({
+  it("skips block delivery kind in final mode (accumulated final tail synthesizes instead)", async () => {
+    synthesizeMock.mockClear();
+    const cfg = createTtsConfig("openclaw-speech-core-block-kind-tts-test");
+    const result = await maybeApplyTtsToPayload({
+      payload: { text: "WebChat block stream chunks defer TTS to the final tail." },
+      cfg,
       channel: "webchat",
-      prefsName: "openclaw-speech-core-block-kind-tts-test",
-      text: "WebChat block replies should synthesize audio for auto TTS.",
-      target: "audio-file",
-      audioAsVoice: undefined,
       kind: "block",
     });
+
+    expect(synthesizeMock).not.toHaveBeenCalled();
+    expect(result.trustedLocalMedia).toBeUndefined();
+    expect(result.text).toBe("WebChat block stream chunks defer TTS to the final tail.");
   });
 
   it("skips tool delivery kind in final mode", async () => {

--- a/extensions/speech-core/src/tts.ts
+++ b/extensions/speech-core/src/tts.ts
@@ -1850,7 +1850,7 @@ export async function maybeApplyTtsToPayload(params: {
       audioAsVoice: result.audioAsVoice || params.payload.audioAsVoice,
       spokenText: textForAudio,
       trustedLocalMedia: true,
-    };
+    } as ReplyPayload;
   }
 
   lastTtsAttempt = {

--- a/extensions/speech-core/src/tts.ts
+++ b/extensions/speech-core/src/tts.ts
@@ -1759,7 +1759,7 @@ export async function maybeApplyTtsToPayload(params: {
   }
 
   const mode = config.mode ?? "final";
-  if (mode === "final" && params.kind && params.kind !== "final") {
+  if (mode === "final" && params.kind && params.kind !== "final" && params.kind !== "block") {
     return nextPayload;
   }
 
@@ -1849,6 +1849,7 @@ export async function maybeApplyTtsToPayload(params: {
       mediaUrl: result.audioPath,
       audioAsVoice: result.audioAsVoice || params.payload.audioAsVoice,
       spokenText: textForAudio,
+      trustedLocalMedia: true,
     };
   }
 

--- a/extensions/speech-core/src/tts.ts
+++ b/extensions/speech-core/src/tts.ts
@@ -1759,7 +1759,7 @@ export async function maybeApplyTtsToPayload(params: {
   }
 
   const mode = config.mode ?? "final";
-  if (mode === "final" && params.kind && params.kind !== "final" && params.kind !== "block") {
+  if (mode === "final" && params.kind && params.kind !== "final") {
     return nextPayload;
   }
 

--- a/scripts/repro/webchat-auto-tts-live-proof.mjs
+++ b/scripts/repro/webchat-auto-tts-live-proof.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+/**
+ * Live repro for WebChat auto-TTS fix (PR #82701).
+ * Run: pnpm exec tsx scripts/repro/webchat-auto-tts-live-proof.mjs
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { maybeApplyTtsToPayload } from "../../extensions/speech-core/src/tts.ts";
+import { buildWebchatAudioContentBlocksFromReplyPayloads } from "../../src/gateway/server-methods/chat-webchat-media.ts";
+import { createPluginRecord } from "../../src/plugins/loader-records.ts";
+import { createPluginRegistry } from "../../src/plugins/registry.ts";
+import {
+  resetPluginRuntimeStateForTest,
+  setActivePluginRegistry,
+} from "../../src/plugins/runtime.ts";
+
+const noopLogger = {
+  info() {},
+  warn() {},
+  error() {},
+  debug() {},
+};
+
+async function main() {
+  resetPluginRuntimeStateForTest();
+  const pluginRegistry = createPluginRegistry({
+    logger: noopLogger,
+    runtime: {},
+    activateGlobalSideEffects: false,
+  });
+  const record = createPluginRecord({
+    id: "repro-mock-tts",
+    name: "Repro Mock TTS",
+    source: "scripts/repro/webchat-auto-tts-live-proof.mjs",
+    origin: "global",
+    enabled: true,
+    configSchema: false,
+  });
+  pluginRegistry.registerSpeechProvider(record, {
+    id: "mock",
+    label: "Mock",
+    autoSelectOrder: 1,
+    isConfigured: () => true,
+    synthesize: async (request) => ({
+      audioBuffer: Buffer.from("voice"),
+      fileExtension: ".ogg",
+      outputFormat: "ogg",
+      voiceCompatible: request.target === "voice-note",
+    }),
+  });
+  setActivePluginRegistry(pluginRegistry.registry);
+
+  const prefsPath = path.join(os.tmpdir(), `openclaw-webchat-tts-proof-${process.pid}.json`);
+  const cfg = {
+    messages: {
+      tts: {
+        enabled: true,
+        provider: "mock",
+        prefsPath,
+      },
+    },
+  };
+
+  const blockText = "WebChat block replies should synthesize audio for auto TTS.";
+  const blockResult = await maybeApplyTtsToPayload({
+    payload: { text: blockText },
+    cfg,
+    channel: "webchat",
+    kind: "block",
+  });
+  console.log("maybeApplyTtsToPayload(kind=block).mediaUrl =", blockResult.mediaUrl ?? "(none)");
+  console.log(
+    "maybeApplyTtsToPayload(kind=block).trustedLocalMedia =",
+    blockResult.trustedLocalMedia ?? false,
+  );
+
+  const toolResult = await maybeApplyTtsToPayload({
+    payload: { text: "Intermediate tool output should not be spoken." },
+    cfg,
+    channel: "webchat",
+    kind: "tool",
+  });
+  console.log("maybeApplyTtsToPayload(kind=tool).mediaUrl =", toolResult.mediaUrl ?? "(none)");
+
+  const mediaPath = blockResult.mediaUrl;
+  if (!mediaPath || !fs.existsSync(mediaPath)) {
+    throw new Error("expected block TTS to write a local media file");
+  }
+  const localRoots = [path.dirname(mediaPath)];
+  const trustedBlocks = await buildWebchatAudioContentBlocksFromReplyPayloads(
+    [{ mediaUrl: mediaPath, trustedLocalMedia: true }],
+    { localRoots },
+  );
+  const untrustedBlocks = await buildWebchatAudioContentBlocksFromReplyPayloads(
+    [{ mediaUrl: mediaPath }],
+    { localRoots },
+  );
+  console.log(
+    "buildWebchatAudioContentBlocksFromReplyPayloads(trustedLocalMedia=true).length =",
+    trustedBlocks.length,
+  );
+  console.log(
+    "buildWebchatAudioContentBlocksFromReplyPayloads(trustedLocalMedia missing).length =",
+    untrustedBlocks.length,
+  );
+
+  if (blockResult.mediaUrl) {
+    fs.rmSync(path.dirname(blockResult.mediaUrl), { recursive: true, force: true });
+  }
+  try {
+    fs.unlinkSync(prefsPath);
+  } catch {
+    // optional prefs file
+  }
+}
+
+await main();

--- a/scripts/repro/webchat-auto-tts-live-proof.mjs
+++ b/scripts/repro/webchat-auto-tts-live-proof.mjs
@@ -89,16 +89,14 @@ async function main() {
     throw new Error("expected final-mode tail TTS to write a local media file");
   }
 
+  // Same shape as dispatch-from-config accumulated block TTS-only final payload.
   const ttsOnlyPayload = {
     mediaUrl: tailResult.mediaUrl,
     audioAsVoice: tailResult.audioAsVoice,
     spokenText: accumulatedBlockText,
-    trustedLocalMedia: tailResult.trustedLocalMedia,
+    trustedLocalMedia: true,
   };
-  console.log(
-    "dispatch ttsOnlyPayload.trustedLocalMedia =",
-    ttsOnlyPayload.trustedLocalMedia ?? false,
-  );
+  console.log("dispatch ttsOnlyPayload.trustedLocalMedia =", ttsOnlyPayload.trustedLocalMedia);
 
   const localRoots = [path.dirname(mediaPath)];
   const trustedBlocks = await buildWebchatAudioContentBlocksFromReplyPayloads([ttsOnlyPayload], {

--- a/scripts/repro/webchat-auto-tts-live-proof.mjs
+++ b/scripts/repro/webchat-auto-tts-live-proof.mjs
@@ -62,52 +62,62 @@ async function main() {
     },
   };
 
-  const blockText = "WebChat block replies should synthesize audio for auto TTS.";
+  const accumulatedBlockText =
+    "WebChat streams block text; dispatch synthesizes one TTS tail with kind final.";
   const blockResult = await maybeApplyTtsToPayload({
-    payload: { text: blockText },
+    payload: { text: accumulatedBlockText },
     cfg,
     channel: "webchat",
     kind: "block",
   });
   console.log("maybeApplyTtsToPayload(kind=block).mediaUrl =", blockResult.mediaUrl ?? "(none)");
-  console.log(
-    "maybeApplyTtsToPayload(kind=block).trustedLocalMedia =",
-    blockResult.trustedLocalMedia ?? false,
-  );
 
-  const toolResult = await maybeApplyTtsToPayload({
-    payload: { text: "Intermediate tool output should not be spoken." },
+  const tailResult = await maybeApplyTtsToPayload({
+    payload: { text: accumulatedBlockText },
     cfg,
     channel: "webchat",
-    kind: "tool",
+    kind: "final",
   });
-  console.log("maybeApplyTtsToPayload(kind=tool).mediaUrl =", toolResult.mediaUrl ?? "(none)");
-
-  const mediaPath = blockResult.mediaUrl;
-  if (!mediaPath || !fs.existsSync(mediaPath)) {
-    throw new Error("expected block TTS to write a local media file");
-  }
-  const localRoots = [path.dirname(mediaPath)];
-  const trustedBlocks = await buildWebchatAudioContentBlocksFromReplyPayloads(
-    [{ mediaUrl: mediaPath, trustedLocalMedia: true }],
-    { localRoots },
+  console.log("maybeApplyTtsToPayload(kind=final).mediaUrl =", tailResult.mediaUrl ?? "(none)");
+  console.log(
+    "maybeApplyTtsToPayload(kind=final).trustedLocalMedia =",
+    tailResult.trustedLocalMedia ?? false,
   );
+
+  const mediaPath = tailResult.mediaUrl;
+  if (!mediaPath || !fs.existsSync(mediaPath)) {
+    throw new Error("expected final-mode tail TTS to write a local media file");
+  }
+
+  const ttsOnlyPayload = {
+    mediaUrl: tailResult.mediaUrl,
+    audioAsVoice: tailResult.audioAsVoice,
+    spokenText: accumulatedBlockText,
+    trustedLocalMedia: tailResult.trustedLocalMedia,
+  };
+  console.log(
+    "dispatch ttsOnlyPayload.trustedLocalMedia =",
+    ttsOnlyPayload.trustedLocalMedia ?? false,
+  );
+
+  const localRoots = [path.dirname(mediaPath)];
+  const trustedBlocks = await buildWebchatAudioContentBlocksFromReplyPayloads([ttsOnlyPayload], {
+    localRoots,
+  });
   const untrustedBlocks = await buildWebchatAudioContentBlocksFromReplyPayloads(
     [{ mediaUrl: mediaPath }],
     { localRoots },
   );
   console.log(
-    "buildWebchatAudioContentBlocksFromReplyPayloads(trustedLocalMedia=true).length =",
+    "buildWebchatAudioContentBlocksFromReplyPayloads(ttsOnlyPayload).length =",
     trustedBlocks.length,
   );
   console.log(
-    "buildWebchatAudioContentBlocksFromReplyPayloads(trustedLocalMedia missing).length =",
+    "buildWebchatAudioContentBlocksFromReplyPayloads(untrusted).length =",
     untrustedBlocks.length,
   );
 
-  if (blockResult.mediaUrl) {
-    fs.rmSync(path.dirname(blockResult.mediaUrl), { recursive: true, force: true });
-  }
+  fs.rmSync(path.dirname(mediaPath), { recursive: true, force: true });
   try {
     fs.unlinkSync(prefsPath);
   } catch {

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -1852,6 +1852,44 @@ describe("tryDispatchAcpReply", () => {
     expect(dispatcherCall(dispatcher.sendFinalReply).text).toBe("CODEX_OK");
   });
 
+  it("marks accumulated ACP block TTS finals as trusted local media for WebChat", async () => {
+    setReadyAcpResolution();
+    ttsMocks.resolveTtsConfig.mockReturnValue({ mode: "final" });
+    queueTtsReplies({
+      mediaUrl: "/tmp/openclaw-media/acp-tts.ogg",
+      audioAsVoice: true,
+    } as MockTtsReply);
+    mockVisibleTextTurn("WebChat ACP block reply.");
+    const cfg = createAcpTestConfig({
+      acp: {
+        enabled: true,
+        stream: {
+          deliveryMode: "live",
+          coalesceIdleMs: 0,
+          maxChunkChars: 64,
+        },
+      },
+    });
+
+    const { dispatcher } = createDispatcher();
+    const result = await runDispatch({
+      bodyForAgent: "reply",
+      cfg,
+      dispatcher,
+      ctxOverrides: {
+        Provider: "webchat",
+        Surface: "webchat",
+      },
+    });
+
+    const finalPayload = dispatcherCall(dispatcher.sendFinalReply);
+    expect(finalPayload.mediaUrl).toBe("/tmp/openclaw-media/acp-tts.ogg");
+    expect(finalPayload.audioAsVoice).toBe(true);
+    expect(finalPayload.spokenText).toBe("WebChat ACP block reply.");
+    expect(finalPayload.trustedLocalMedia).toBe(true);
+    expect(result?.queuedFinal).toBe(true);
+  });
+
   it("falls back to final text when a later telegram ACP block delivery fails", async () => {
     setReadyAcpResolution();
     ttsMocks.resolveTtsConfig.mockReturnValue({ mode: "final" });

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -254,6 +254,7 @@ async function finalizeAcpTurnOutput(params: {
           mediaUrl: ttsSyntheticReply.mediaUrl,
           audioAsVoice: ttsSyntheticReply.audioAsVoice,
           spokenText: accumulatedBlockTtsText,
+          trustedLocalMedia: true,
         });
         queuedFinal = queuedFinal || delivered;
         finalMediaDelivered = delivered;

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -153,6 +153,7 @@ const ttsMocks = vi.hoisted(() => {
           ...params.payload,
           mediaUrl: "https://example.com/tts-synth.opus",
           audioAsVoice: true,
+          trustedLocalMedia: true,
         };
       }
       return params.payload;
@@ -2722,6 +2723,7 @@ describe("dispatchReplyFromConfig", () => {
     expect(finalPayload?.mediaUrls).toStrictEqual(["/tmp/openclaw-media/normalized-tts.ogg"]);
     expect(finalPayload?.audioAsVoice).toBe(true);
     expect(finalPayload?.spokenText).toBe("Hello from block streaming.");
+    expect(finalPayload?.trustedLocalMedia).toBe(true);
   });
 
   it("closes oneshot ACP sessions after the turn completes", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1700,6 +1700,7 @@ export async function dispatchReplyFromConfig(
               mediaUrl: ttsSyntheticReply.mediaUrl,
               audioAsVoice: ttsSyntheticReply.audioAsVoice,
               spokenText: accumulatedBlockTtsText,
+              trustedLocalMedia: ttsSyntheticReply.trustedLocalMedia,
             };
             const normalizedTtsOnlyPayload = await normalizeReplyMediaPayload(ttsOnlyPayload);
             const result = await routeReplyToOriginating(normalizedTtsOnlyPayload);

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1700,7 +1700,7 @@ export async function dispatchReplyFromConfig(
               mediaUrl: ttsSyntheticReply.mediaUrl,
               audioAsVoice: ttsSyntheticReply.audioAsVoice,
               spokenText: accumulatedBlockTtsText,
-              trustedLocalMedia: ttsSyntheticReply.trustedLocalMedia,
+              trustedLocalMedia: true,
             };
             const normalizedTtsOnlyPayload = await normalizeReplyMediaPayload(ttsOnlyPayload);
             const result = await routeReplyToOriginating(normalizedTtsOnlyPayload);

--- a/src/plugin-sdk/reply-payload.ts
+++ b/src/plugin-sdk/reply-payload.ts
@@ -6,7 +6,7 @@ import { normalizeLowercaseStringOrEmpty, readStringValue } from "../shared/stri
 
 export type { MediaPayload, MediaPayloadInput } from "../channels/plugins/media-payload.js";
 export { buildMediaPayload } from "../channels/plugins/media-payload.js";
-export type ReplyPayload = Omit<InternalReplyPayload, "trustedLocalMedia">;
+export type ReplyPayload = InternalReplyPayload;
 
 export type OutboundReplyPayload = {
   text?: string;

--- a/src/plugin-sdk/reply-payload.ts
+++ b/src/plugin-sdk/reply-payload.ts
@@ -6,7 +6,7 @@ import { normalizeLowercaseStringOrEmpty, readStringValue } from "../shared/stri
 
 export type { MediaPayload, MediaPayloadInput } from "../channels/plugins/media-payload.js";
 export { buildMediaPayload } from "../channels/plugins/media-payload.js";
-export type ReplyPayload = InternalReplyPayload;
+export type ReplyPayload = Omit<InternalReplyPayload, "trustedLocalMedia">;
 
 export type OutboundReplyPayload = {
   text?: string;


### PR DESCRIPTION
## Summary

Fixes #82628 — WebChat Auto-TTS synthesized audio locally but the browser never played it.

**Root cause:** Block streaming defers synthesis to the existing `dispatch-from-config` tail (`kind: "final"` on accumulated block text). The gaps were:

1. **`trustedLocalMedia` missing** on successful TTS output and on the **TTS-only final payload** forwarded after block streaming.
2. **Public SDK boundary** — `trustedLocalMedia` must stay internal; we do **not** widen public `ReplyPayload` (still `Omit<..., "trustedLocalMedia">`). Speech-core sets the flag at runtime (`as ReplyPayload`); dispatch sets `trustedLocalMedia: true` on the internal TTS-only final.

We **do not** enable per-block `kind: "block"` synthesis in final mode (avoids duplicate tail synthesis).

## Test plan

- [x] `pnpm exec tsx scripts/repro/webchat-auto-tts-live-proof.mjs`
- [x] `node scripts/run-vitest.mjs extensions/speech-core/src/tts.test.ts src/plugin-sdk/reply-payload.test.ts`
- [x] `node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts -t "accumulated block TTS"`

## Real behavior proof

- **Behavior or issue addressed:** After block streaming, WebChat must receive one TTS-only `final` payload with `trustedLocalMedia: true` so `buildWebchatAudioContentBlocksFromReplyPayloads` embeds local audio (no duplicate per-block synthesis).
- **Real environment tested:** macOS, Node v22.x, local checkout `fix/webchat-auto-tts` with mock speech provider; repro mirrors `dispatch-from-config` TTS-only final payload shape.
- **Exact steps or command run after this patch:**
  1. `pnpm exec tsx scripts/repro/webchat-auto-tts-live-proof.mjs`
- **Evidence after fix:** Copied live terminal output:

```text
$ pnpm exec tsx scripts/repro/webchat-auto-tts-live-proof.mjs
maybeApplyTtsToPayload(kind=block).mediaUrl = (none)
maybeApplyTtsToPayload(kind=final).mediaUrl = /private/tmp/openclaw/tts-.../voice-....ogg
maybeApplyTtsToPayload(kind=final).trustedLocalMedia = true
dispatch ttsOnlyPayload.trustedLocalMedia = true
buildWebchatAudioContentBlocksFromReplyPayloads(ttsOnlyPayload).length = 1
buildWebchatAudioContentBlocksFromReplyPayloads(untrusted).length = 0
```

- **Observed result after fix:** Block chunks skip synthesis; accumulated final tail synthesizes once; dispatch-shaped TTS-only payload embeds in WebChat only with `trustedLocalMedia: true`.
- **What was not tested:** Live browser WebChat UI with MiniMax provider and full `chat.send` gateway stream.

## Root Cause

- Root cause: TTS tail omitted `trustedLocalMedia` on the payload WebChat reads.
- Missing detection / guardrail: No test asserting accumulated block TTS-only finals carry `trustedLocalMedia`.
- Contributing context: Per-block `maybeApplyTtsToPayload(..., kind: "block")` is intentionally skipped in final mode; tail `kind: "final"` is the supported synthesis path.

## Regression Test Plan

- `extensions/speech-core/src/tts.test.ts` — `trustedLocalMedia` on final synthesis; block kind still skipped
- `src/auto-reply/reply/dispatch-from-config.test.ts` — accumulated block TTS-only final includes `trustedLocalMedia`
- `src/plugin-sdk/reply-payload.test.ts` — deliverer still strips flag for external channels