### PR TITLE
Fix Telegram polling routing and CLI sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 - Control UI: simplify Talk settings to Voice, Model, and Sensitivity defaults, with provider, transport, exact VAD, and timing controls behind Advanced.
 - Telegram: let catch-all mention patterns match captionless group photos, so media-only group messages reach the agent when the group is intentionally configured to respond to all messages. Fixes #44833. (#82756) Thanks @IWhatsskill.
 - Gateway/pairing: reject forged loopback Control UI origins from non-local proxy paths, and keep mobile pairing setup on Tailscale bind mode pointing users to Tailscale Serve/Funnel instead of cleartext tailnet WebSockets.
+- Telegram/Gateway: persist isolated polling offsets only after main-thread dispatch and preserve gateway caller scopes for Telegram message actions, fixing consumed-but-unrouted polling updates and recursive CLI send scope approvals. Fixes #82277. (#82705) Thanks @udaymanish6.
 - Channels/stream previews: contain rejected background draft-stream flushes so preview send failures do not surface as fatal unhandled rejections. Fixes #82712. (#82713) Thanks @coygeek.
 - Providers/OpenAI Codex: include base `gpt-5.5` and `gpt-5.4` reasoning metadata in the bundled Codex catalog so `/think xhigh` remains available for those models. Fixes #82744.
 - Providers/MiniMax: declare CN endpoint auth aliases in the plugin manifest so `minimax-cn` and `minimax-portal-cn` reuse the correct base auth profiles instead of falling back to unrelated models after 401s. Fixes #63823. Thanks @kamusis.

--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -668,6 +668,39 @@ describe("handleTelegramAction", () => {
     ]);
   });
 
+  it("forwards gateway client scopes into Telegram send target resolution", async () => {
+    await handleTelegramAction(
+      {
+        action: "sendMessage",
+        to: "@testchannel",
+        content: "Hello from CLI",
+      },
+      telegramConfig(),
+      { gatewayClientScopes: ["operator.write"] },
+    );
+    const call = mockCall(sendMessageTelegram, 0, "gateway-scoped send");
+    expect(requireRecord(call[2], "gateway-scoped send options").gatewayClientScopes).toEqual([
+      "operator.write",
+    ]);
+  });
+
+  it("forwards gateway client scopes into Telegram poll target resolution", async () => {
+    await handleTelegramAction(
+      {
+        action: "poll",
+        to: "@testchannel",
+        question: "Ready?",
+        answers: ["Yes", "No"],
+      },
+      telegramConfig(),
+      { gatewayClientScopes: ["operator.write"] },
+    );
+    const call = mockCall(sendPollTelegram, 0, "gateway-scoped poll");
+    expect(requireRecord(call[2], "gateway-scoped poll options").gatewayClientScopes).toEqual([
+      "operator.write",
+    ]);
+  });
+
   it.each([
     {
       name: "react",

--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -367,6 +367,7 @@ describe("handleTelegramAction", () => {
         content: "Hello, Telegram!",
       },
       telegramConfig(),
+      { gatewayClientScopes: ["operator.write"] },
     );
     const call = mockCall(sendMessageTelegram, 0, "text message");
     expect(call[0]).toBe("@testchannel");
@@ -550,6 +551,7 @@ describe("handleTelegramAction", () => {
         media: "https://example.com/image.jpg",
       },
       telegramConfig(),
+      { gatewayClientScopes: ["operator.write"] },
     );
     const call = mockCall(sendMessageTelegram, 0, "send alias");
     expect(call[0]).toBe("@testchannel");
@@ -771,22 +773,28 @@ describe("handleTelegramAction", () => {
         readCallOpts: (calls: unknown[][], argIndex: number) => Record<string, unknown>,
       ) => readCallOpts(editForumTopicTelegram.mock.calls as unknown[][], 2),
     },
-  ])("forwards resolved cfg for $name action", async ({ params, cfg, assertCall }) => {
-    const readCallOpts = (calls: unknown[][], argIndex: number): Record<string, unknown> => {
-      const args = calls[0];
-      if (!Array.isArray(args)) {
-        throw new Error("Expected Telegram action call args");
-      }
-      const opts = args[argIndex];
-      if (!opts || typeof opts !== "object") {
-        throw new Error("Expected Telegram action options object");
-      }
-      return opts as Record<string, unknown>;
-    };
-    await handleTelegramAction(params as Record<string, unknown>, cfg);
-    const opts = assertCall(readCallOpts);
-    expect(opts.cfg).toBe(cfg);
-  });
+  ])(
+    "forwards resolved cfg and gateway scopes for $name action",
+    async ({ params, cfg, assertCall }) => {
+      const readCallOpts = (calls: unknown[][], argIndex: number): Record<string, unknown> => {
+        const args = calls[0];
+        if (!Array.isArray(args)) {
+          throw new Error("Expected Telegram action call args");
+        }
+        const opts = args[argIndex];
+        if (!opts || typeof opts !== "object") {
+          throw new Error("Expected Telegram action options object");
+        }
+        return opts as Record<string, unknown>;
+      };
+      await handleTelegramAction(params as Record<string, unknown>, cfg, {
+        gatewayClientScopes: ["operator.write"],
+      });
+      const opts = assertCall(readCallOpts);
+      expect(opts.cfg).toBe(cfg);
+      expect(opts.gatewayClientScopes).toEqual(["operator.write"]);
+    },
+  );
 
   it.each([
     {
@@ -908,6 +916,7 @@ describe("handleTelegramAction", () => {
         delivery: { pin: { enabled: true } },
       },
       telegramConfig(),
+      { gatewayClientScopes: ["operator.write"] },
     );
 
     const call = mockCall(pinMessageTelegram, 0, "delivery pin");
@@ -916,6 +925,7 @@ describe("handleTelegramAction", () => {
     const options = requireRecord(call[2], "delivery pin options");
     expect(options.accountId).toBeUndefined();
     expect(options.verbose).toBe(false);
+    expect(options.gatewayClientScopes).toEqual(["operator.write"]);
   });
 
   it("passes delivery pin notify requests for action sends", async () => {

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -241,6 +241,7 @@ export async function handleTelegramAction(
     mediaReadFile?: (filePath: string) => Promise<Buffer>;
     sessionKey?: string | null;
     inboundEventKind?: string;
+    gatewayClientScopes?: readonly string[];
   },
 ): Promise<AgentToolResult<unknown>> {
   const { action, accountId } = {
@@ -404,6 +405,7 @@ export async function handleTelegramAction(
       mediaUrl: mediaUrl || undefined,
       mediaLocalRoots: options?.mediaLocalRoots,
       mediaReadFile: options?.mediaReadFile,
+      gatewayClientScopes: options?.gatewayClientScopes,
       buttons,
       replyToMessageId: replyToMessageId ?? undefined,
       messageThreadId: messageThreadId ?? undefined,
@@ -491,6 +493,7 @@ export async function handleTelegramAction(
         messageThreadId: messageThreadId ?? undefined,
         isAnonymous: isAnonymous ?? undefined,
         silent: silent ?? undefined,
+        gatewayClientScopes: options?.gatewayClientScopes,
       },
     );
     notifyVisibleOutboundSuccess(to, messageThreadId);

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -208,6 +208,7 @@ async function maybePinTelegramActionSend(params: {
   accountId?: string;
   to: string;
   messageId?: string;
+  gatewayClientScopes?: readonly string[];
 }) {
   const pin = normalizeTelegramDeliveryPin(params.args);
   if (!pin) {
@@ -225,6 +226,7 @@ async function maybePinTelegramActionSend(params: {
       accountId: params.accountId,
       notify: pin.notify,
       verbose: false,
+      gatewayClientScopes: params.gatewayClientScopes,
     });
   } catch (err) {
     if (pin.required) {
@@ -316,6 +318,7 @@ export async function handleTelegramAction(
           token,
           remove,
           accountId: accountId ?? undefined,
+          gatewayClientScopes: options?.gatewayClientScopes,
         },
       );
     } catch (err) {
@@ -424,6 +427,7 @@ export async function handleTelegramAction(
       accountId: accountId ?? undefined,
       to,
       messageId: result.messageId,
+      gatewayClientScopes: options?.gatewayClientScopes,
     });
     return jsonResult({
       ok: true,
@@ -524,6 +528,7 @@ export async function handleTelegramAction(
       cfg,
       token,
       accountId: accountId ?? undefined,
+      gatewayClientScopes: options?.gatewayClientScopes,
     });
     if (!result.ok) {
       return jsonResult({ ok: false, deleted: false, warning: result.warning });
@@ -570,6 +575,7 @@ export async function handleTelegramAction(
         token,
         accountId: accountId ?? undefined,
         buttons,
+        gatewayClientScopes: options?.gatewayClientScopes,
       },
     );
     return jsonResult({
@@ -606,6 +612,7 @@ export async function handleTelegramAction(
       accountId: accountId ?? undefined,
       replyToMessageId: replyToMessageId ?? undefined,
       messageThreadId: messageThreadId ?? undefined,
+      gatewayClientScopes: options?.gatewayClientScopes,
     });
     notifyVisibleOutboundSuccess(to, messageThreadId);
     return jsonResult({
@@ -661,6 +668,7 @@ export async function handleTelegramAction(
       accountId: accountId ?? undefined,
       iconColor,
       iconCustomEmojiId: iconCustomEmojiId ?? undefined,
+      gatewayClientScopes: options?.gatewayClientScopes,
     });
     return jsonResult({
       ok: true,
@@ -696,6 +704,7 @@ export async function handleTelegramAction(
         accountId: accountId ?? undefined,
         name: name ?? undefined,
         iconCustomEmojiId: iconCustomEmojiId ?? undefined,
+        gatewayClientScopes: options?.gatewayClientScopes,
       },
     );
     return jsonResult(result);

--- a/extensions/telegram/src/bot-core.ts
+++ b/extensions/telegram/src/bot-core.ts
@@ -154,6 +154,10 @@ export function createTelegramBotCore(
   };
   const updateTracker = createTelegramUpdateTracker({
     initialUpdateId,
+    persistenceFloorUpdateId:
+      typeof opts.updateOffset?.persistenceFloorUpdateId === "number"
+        ? opts.updateOffset.persistenceFloorUpdateId
+        : initialUpdateId,
     ackPolicy: "after_agent_dispatch",
     ...(typeof opts.updateOffset?.onUpdateId === "function"
       ? { onAcceptedUpdateId: opts.updateOffset.onUpdateId }

--- a/extensions/telegram/src/bot-update-tracker.test.ts
+++ b/extensions/telegram/src/bot-update-tracker.test.ts
@@ -165,6 +165,38 @@ describe("createTelegramUpdateTracker", () => {
     } satisfies Partial<TelegramUpdateTrackerState>);
   });
 
+  it("keeps below-floor spool replays dispatchable after newer updates advance", () => {
+    const tracker = createTelegramUpdateTracker({
+      initialUpdateId: null,
+      persistenceFloorUpdateId: 42,
+      ackPolicy: "after_agent_dispatch",
+    });
+
+    const newer = tracker.beginUpdate(updateCtx(43));
+    if (!newer.accepted) {
+      throw new Error("expected newer update to be accepted");
+    }
+    tracker.finishUpdate(newer.update, { completed: true });
+
+    const oldReplay = tracker.beginUpdate(updateCtx(42));
+    if (!oldReplay.accepted) {
+      throw new Error("expected below-floor replay to remain accepted");
+    }
+    tracker.finishUpdate(oldReplay.update, { completed: true });
+
+    expect(tracker.beginUpdate(updateCtx(42))).toEqual({
+      accepted: false,
+      reason: "accepted-watermark",
+    });
+    expectTrackerState(tracker.getState(), {
+      highestAcceptedUpdateId: 43,
+      highestCompletedUpdateId: 43,
+      safeCompletedUpdateId: 43,
+      pendingUpdateIds: [],
+      failedUpdateIds: [],
+    } satisfies Partial<TelegramUpdateTrackerState>);
+  });
+
   it("serializes and coalesces accepted offset persistence", async () => {
     const firstWrite = deferred();
     const secondWrite = deferred();

--- a/extensions/telegram/src/bot-update-tracker.test.ts
+++ b/extensions/telegram/src/bot-update-tracker.test.ts
@@ -133,6 +133,38 @@ describe("createTelegramUpdateTracker", () => {
     });
   });
 
+  it("can keep a persistence floor while replaying older spooled updates", async () => {
+    const onAcceptedUpdateId = vi.fn();
+    const tracker = createTelegramUpdateTracker({
+      initialUpdateId: null,
+      persistenceFloorUpdateId: 42,
+      ackPolicy: "after_agent_dispatch",
+      onAcceptedUpdateId,
+    });
+
+    const oldPending = tracker.beginUpdate(updateCtx(42));
+    if (!oldPending.accepted) {
+      throw new Error("expected old spooled update to be accepted");
+    }
+    tracker.finishUpdate(oldPending.update, { completed: false });
+
+    const newer = tracker.beginUpdate(updateCtx(43));
+    if (!newer.accepted) {
+      throw new Error("expected newer update to be accepted");
+    }
+    tracker.finishUpdate(newer.update, { completed: true });
+    await flushTrackerMicrotasks();
+
+    expect(onAcceptedUpdateId).toHaveBeenCalledWith(43);
+    expectTrackerState(tracker.getState(), {
+      highestAcceptedUpdateId: 43,
+      highestPersistedAcceptedUpdateId: 43,
+      highestCompletedUpdateId: 43,
+      safeCompletedUpdateId: 43,
+      failedUpdateIds: [42],
+    } satisfies Partial<TelegramUpdateTrackerState>);
+  });
+
   it("serializes and coalesces accepted offset persistence", async () => {
     const firstWrite = deferred();
     const secondWrite = deferred();

--- a/extensions/telegram/src/bot-update-tracker.ts
+++ b/extensions/telegram/src/bot-update-tracker.ts
@@ -67,6 +67,7 @@ export function createTelegramUpdateTracker(options: TelegramUpdateTrackerOption
   const activeHandledUpdateKeys = new Map<string, boolean>();
   const pendingUpdateIds = new Set<number>();
   const failedUpdateIds = new Set<number>();
+  const completedFloorReplayUpdateIds = new Set<number>();
   let highestAcceptedUpdateId: number | null = initialUpdateId;
   let highestPersistedAcceptedUpdateId: number | null = persistenceFloorUpdateId;
   let highestPersistenceRequestedUpdateId: number | null = persistenceFloorUpdateId;
@@ -129,6 +130,11 @@ export function createTelegramUpdateTracker(options: TelegramUpdateTrackerOption
     highestAcceptedUpdateId = updateId;
   };
 
+  const isFloorReplayUpdateId = (updateId: number) =>
+    initialUpdateId === null &&
+    persistenceFloorUpdateId !== null &&
+    updateId <= persistenceFloorUpdateId;
+
   function resolveSafeCompletedUpdateId() {
     if (highestCompletedUpdateId === null) {
       return null;
@@ -178,7 +184,12 @@ export function createTelegramUpdateTracker(options: TelegramUpdateTrackerOption
     const updateKey = buildTelegramUpdateKey(ctx);
     if (typeof updateId === "number") {
       if (highestAcceptedUpdateId !== null && updateId <= highestAcceptedUpdateId) {
-        if (!failedUpdateIds.has(updateId)) {
+        const floorReplay = isFloorReplayUpdateId(updateId);
+        if (!floorReplay && !failedUpdateIds.has(updateId)) {
+          skip(`update:${updateId}`);
+          return { accepted: false, reason: "accepted-watermark" };
+        }
+        if (floorReplay && completedFloorReplayUpdateIds.has(updateId)) {
           skip(`update:${updateId}`);
           return { accepted: false, reason: "accepted-watermark" };
         }
@@ -229,6 +240,9 @@ export function createTelegramUpdateTracker(options: TelegramUpdateTrackerOption
       pendingUpdateIds.delete(update.updateId);
       if (finish.completed) {
         failedUpdateIds.delete(update.updateId);
+        if (isFloorReplayUpdateId(update.updateId)) {
+          completedFloorReplayUpdateIds.add(update.updateId);
+        }
         if (highestCompletedUpdateId === null || update.updateId > highestCompletedUpdateId) {
           highestCompletedUpdateId = update.updateId;
         }

--- a/extensions/telegram/src/bot-update-tracker.ts
+++ b/extensions/telegram/src/bot-update-tracker.ts
@@ -14,6 +14,7 @@ type PersistUpdateId = (updateId: number) => void | Promise<void>;
 
 type TelegramUpdateTrackerOptions = {
   initialUpdateId?: number | null;
+  persistenceFloorUpdateId?: number | null;
   ackPolicy?: MessageAckPolicy;
   onAcceptedUpdateId?: PersistUpdateId;
   onPersistError?: (error: unknown) => void;
@@ -56,6 +57,10 @@ function sortedIds(ids: Set<number>): number[] {
 export function createTelegramUpdateTracker(options: TelegramUpdateTrackerOptions = {}) {
   const initialUpdateId =
     typeof options.initialUpdateId === "number" ? options.initialUpdateId : null;
+  const persistenceFloorUpdateId =
+    typeof options.persistenceFloorUpdateId === "number"
+      ? options.persistenceFloorUpdateId
+      : initialUpdateId;
   const ackPolicy = options.ackPolicy ?? "after_receive_record";
   const recentUpdates = createTelegramUpdateDedupe();
   const pendingUpdateKeys = new Set<string>();
@@ -63,9 +68,9 @@ export function createTelegramUpdateTracker(options: TelegramUpdateTrackerOption
   const pendingUpdateIds = new Set<number>();
   const failedUpdateIds = new Set<number>();
   let highestAcceptedUpdateId: number | null = initialUpdateId;
-  let highestPersistedAcceptedUpdateId: number | null = initialUpdateId;
-  let highestPersistenceRequestedUpdateId: number | null = initialUpdateId;
-  let highestCompletedUpdateId: number | null = initialUpdateId;
+  let highestPersistedAcceptedUpdateId: number | null = persistenceFloorUpdateId;
+  let highestPersistenceRequestedUpdateId: number | null = persistenceFloorUpdateId;
+  let highestCompletedUpdateId: number | null = persistenceFloorUpdateId;
   let persistInFlight = false;
   let persistTargetUpdateId: number | null = null;
 
@@ -130,11 +135,17 @@ export function createTelegramUpdateTracker(options: TelegramUpdateTrackerOption
     }
     let safeCompletedUpdateId = highestCompletedUpdateId;
     for (const updateId of pendingUpdateIds) {
+      if (persistenceFloorUpdateId !== null && updateId <= persistenceFloorUpdateId) {
+        continue;
+      }
       if (updateId <= safeCompletedUpdateId) {
         safeCompletedUpdateId = updateId - 1;
       }
     }
     for (const updateId of failedUpdateIds) {
+      if (persistenceFloorUpdateId !== null && updateId <= persistenceFloorUpdateId) {
+        continue;
+      }
       if (updateId <= safeCompletedUpdateId) {
         safeCompletedUpdateId = updateId - 1;
       }

--- a/extensions/telegram/src/bot.types.ts
+++ b/extensions/telegram/src/bot.types.ts
@@ -23,6 +23,7 @@ export type TelegramBotOptions = {
   minimumClientTimeoutSeconds?: number;
   updateOffset?: {
     lastUpdateId?: number | null;
+    persistenceFloorUpdateId?: number | null;
     onUpdateId?: (updateId: number) => void | Promise<void>;
   };
   testTimings?: {

--- a/extensions/telegram/src/channel-actions.test.ts
+++ b/extensions/telegram/src/channel-actions.test.ts
@@ -63,7 +63,9 @@ describe("telegramMessageActions", () => {
       {},
       {
         mediaLocalRoots: [],
+        mediaReadFile: undefined,
         sessionKey: "telegram-session",
+        gatewayClientScopes: undefined,
       },
     );
   });

--- a/extensions/telegram/src/channel-actions.ts
+++ b/extensions/telegram/src/channel-actions.ts
@@ -183,9 +183,11 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
     cfg,
     accountId,
     mediaLocalRoots,
+    mediaReadFile,
     sessionKey,
     inboundEventKind,
     toolContext,
+    gatewayClientScopes,
   }) => {
     const telegramAction = resolveTelegramMessageActionName(action);
     if (!telegramAction) {
@@ -203,7 +205,7 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
           : {}),
       },
       cfg,
-      { mediaLocalRoots, sessionKey, inboundEventKind },
+      { mediaLocalRoots, mediaReadFile, sessionKey, inboundEventKind, gatewayClientScopes },
     );
   },
 };

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -585,9 +585,10 @@ describe("TelegramPollingSession", () => {
           token: "tok",
         }),
       );
-      expect(
-        mockObjectArg(createTelegramBotMock, "createTelegramBot").updateOffset,
-      ).toBeUndefined();
+      expect(mockObjectArg(createTelegramBotMock, "createTelegramBot").updateOffset).toEqual({
+        lastUpdateId: null,
+        onUpdateId: expect.any(Function),
+      });
       expect(init).toHaveBeenCalledBefore(handleUpdate);
       expect(handleUpdate).toHaveBeenCalledWith({ update_id: 42, message: { text: "hello" } });
     } finally {

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -242,6 +242,7 @@ function createPollingSession(params: {
   log?: (message: string) => void;
   telegramTransport?: ReturnType<typeof makeTelegramTransport>;
   createTelegramTransport?: () => ReturnType<typeof makeTelegramTransport>;
+  getLastUpdateId?: () => number | null;
   stallThresholdMs?: number;
   setStatus?: (patch: Omit<ChannelAccountSnapshot, "accountId">) => void;
   isolatedIngress?: ConstructorParameters<typeof TelegramPollingSession>[0]["isolatedIngress"];
@@ -254,7 +255,7 @@ function createPollingSession(params: {
     proxyFetch: undefined,
     abortSignal: params.abortSignal,
     runnerOptions: {},
-    getLastUpdateId: () => null,
+    getLastUpdateId: params.getLastUpdateId ?? (() => null),
     persistUpdateId: async () => undefined,
     log: params.log ?? (() => undefined),
     telegramTransport: params.telegramTransport,
@@ -587,10 +588,75 @@ describe("TelegramPollingSession", () => {
       );
       expect(mockObjectArg(createTelegramBotMock, "createTelegramBot").updateOffset).toEqual({
         lastUpdateId: null,
+        persistenceFloorUpdateId: null,
         onUpdateId: expect.any(Function),
       });
       expect(init).toHaveBeenCalledBefore(handleUpdate);
       expect(handleUpdate).toHaveBeenCalledWith({ update_id: 42, message: { text: "hello" } });
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("drains existing isolated ingress spool entries below the persisted offset", async () => {
+    const abort = new AbortController();
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));
+    const handleUpdate = vi.fn(async () => undefined);
+    createTelegramBotMock.mockReturnValueOnce({
+      api: {
+        deleteWebhook: vi.fn(async () => true),
+        config: { use: vi.fn() },
+      },
+      init: vi.fn(async () => undefined),
+      handleUpdate,
+      stop: vi.fn(async () => undefined),
+    });
+    await writeTelegramSpooledUpdate({
+      spoolDir: tempDir,
+      update: { update_id: 42, message: { text: "pre-upgrade pending" } },
+    });
+    let stopWorker: (() => void) | undefined;
+    const workerDone = new Promise<void>((resolve) => {
+      stopWorker = resolve;
+    });
+    const createWorker = vi.fn(() => ({
+      onMessage: vi.fn(() => () => undefined),
+      stop: vi.fn(async () => {
+        stopWorker?.();
+      }),
+      task: vi.fn(async () => {
+        await workerDone;
+      }),
+    }));
+
+    try {
+      const session = createPollingSession({
+        abortSignal: abort.signal,
+        getLastUpdateId: () => 42,
+        isolatedIngress: {
+          enabled: true,
+          spoolDir: tempDir,
+          createWorker,
+          drainIntervalMs: 10,
+        },
+      });
+
+      const runPromise = session.runUntilAbort();
+      await vi.waitFor(() => expect(handleUpdate).toHaveBeenCalledTimes(1));
+      await vi.waitFor(async () => expect(await fs.readdir(tempDir)).toEqual([]));
+      abort.abort();
+      await runPromise;
+
+      expect(createWorker).toHaveBeenCalledWith(expect.objectContaining({ initialUpdateId: 42 }));
+      expect(mockObjectArg(createTelegramBotMock, "createTelegramBot").updateOffset).toEqual({
+        lastUpdateId: null,
+        persistenceFloorUpdateId: 42,
+        onUpdateId: expect.any(Function),
+      });
+      expect(handleUpdate).toHaveBeenCalledWith({
+        update_id: 42,
+        message: { text: "pre-upgrade pending" },
+      });
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
     }

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -279,12 +279,10 @@ export class TelegramPollingSession {
     const fetchAbortController = new AbortController();
     this.#activeFetchAbort = fetchAbortController;
     const telegramTransport = this.#transportState.acquireForNextCycle();
-    const updateOffset = this.opts.isolatedIngress?.enabled
-      ? undefined
-      : {
-          lastUpdateId: this.opts.getLastUpdateId(),
-          onUpdateId: this.opts.persistUpdateId,
-        };
+    const updateOffset = {
+      lastUpdateId: this.opts.getLastUpdateId(),
+      onUpdateId: this.opts.persistUpdateId,
+    };
     try {
       return createTelegramBot({
         token: this.opts.token,

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -279,8 +279,11 @@ export class TelegramPollingSession {
     const fetchAbortController = new AbortController();
     this.#activeFetchAbort = fetchAbortController;
     const telegramTransport = this.#transportState.acquireForNextCycle();
+    const persistedLastUpdateId = this.opts.getLastUpdateId();
+    const lastUpdateId = this.opts.isolatedIngress?.enabled ? null : persistedLastUpdateId;
     const updateOffset = {
-      lastUpdateId: this.opts.getLastUpdateId(),
+      lastUpdateId,
+      persistenceFloorUpdateId: persistedLastUpdateId,
       onUpdateId: this.opts.persistUpdateId,
     };
     try {

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -123,6 +123,7 @@ type TelegramReactionOpts = {
   remove?: boolean;
   verbose?: boolean;
   retry?: RetryConfig;
+  gatewayClientScopes?: readonly string[];
 };
 
 type TelegramTypingOpts = {
@@ -1040,6 +1041,7 @@ export async function reactMessageTelegram(
     lookupTarget: rawTarget,
     persistTarget: rawTarget,
     verbose: opts.verbose,
+    gatewayClientScopes: opts.gatewayClientScopes,
   });
   const messageId = normalizeMessageId(messageIdInput);
   const requestWithDiag = createTelegramRequestWithDiag({
@@ -1080,6 +1082,7 @@ type TelegramDeleteOpts = {
   verbose?: boolean;
   api?: TelegramApiOverride;
   retry?: RetryConfig;
+  gatewayClientScopes?: readonly string[];
 };
 
 export async function deleteMessageTelegram(
@@ -1095,6 +1098,7 @@ export async function deleteMessageTelegram(
     lookupTarget: rawTarget,
     persistTarget: rawTarget,
     verbose: opts.verbose,
+    gatewayClientScopes: opts.gatewayClientScopes,
   });
   const messageId = normalizeMessageId(messageIdInput);
   const requestWithDiag = createTelegramRequestWithDiag({
@@ -1136,6 +1140,7 @@ export async function pinMessageTelegram(
     lookupTarget: rawTarget,
     persistTarget: rawTarget,
     verbose: opts.verbose,
+    gatewayClientScopes: opts.gatewayClientScopes,
   });
   const messageId = normalizeMessageId(messageIdInput);
   const requestWithDiag = createTelegramRequestWithDiag({
@@ -1168,6 +1173,7 @@ export async function unpinMessageTelegram(
     lookupTarget: rawTarget,
     persistTarget: rawTarget,
     verbose: opts.verbose,
+    gatewayClientScopes: opts.gatewayClientScopes,
   });
   const messageId = messageIdInput === undefined ? undefined : normalizeMessageId(messageIdInput);
   const requestWithDiag = createTelegramRequestWithDiag({
@@ -1229,6 +1235,7 @@ export async function editForumTopicTelegram(
     lookupTarget: target.chatId,
     persistTarget: rawTarget,
     verbose: opts.verbose,
+    gatewayClientScopes: opts.gatewayClientScopes,
   });
   const messageThreadId = normalizeMessageId(messageThreadIdInput);
   const requestWithDiag = createTelegramRequestWithDiag({
@@ -1279,6 +1286,7 @@ type TelegramEditOpts = {
   verbose?: boolean;
   api?: TelegramApiOverride;
   retry?: RetryConfig;
+  gatewayClientScopes?: readonly string[];
   textMode?: "markdown" | "html";
   /** Controls whether link previews are shown in the edited message. */
   linkPreview?: boolean;
@@ -1294,6 +1302,7 @@ type TelegramEditReplyMarkupOpts = {
   verbose?: boolean;
   api?: TelegramApiOverride;
   retry?: RetryConfig;
+  gatewayClientScopes?: readonly string[];
   /** Inline keyboard buttons (reply markup). Pass empty array to remove buttons. */
   buttons?: TelegramInlineButtons;
   /** Resolved runtime config from the command or gateway boundary. */
@@ -1317,6 +1326,7 @@ export async function editMessageReplyMarkupTelegram(
     lookupTarget: rawTarget,
     persistTarget: rawTarget,
     verbose: opts.verbose,
+    gatewayClientScopes: opts.gatewayClientScopes,
   });
   const messageId = normalizeMessageId(messageIdInput);
   const requestWithDiag = createTelegramRequestWithDiag({
@@ -1360,6 +1370,7 @@ export async function editMessageTelegram(
     lookupTarget: rawTarget,
     persistTarget: rawTarget,
     verbose: opts.verbose,
+    gatewayClientScopes: opts.gatewayClientScopes,
   });
   const messageId = normalizeMessageId(messageIdInput);
   const requestWithDiag = createTelegramRequestWithDiag({
@@ -1463,6 +1474,7 @@ type TelegramStickerOpts = {
   verbose?: boolean;
   api?: TelegramApiOverride;
   retry?: RetryConfig;
+  gatewayClientScopes?: readonly string[];
   /** Message ID to reply to (for threading) */
   replyToMessageId?: number;
   /** Forum topic thread ID (for forum supergroups) */
@@ -1492,6 +1504,7 @@ export async function sendStickerTelegram(
     lookupTarget: target.chatId,
     persistTarget: to,
     verbose: opts.verbose,
+    gatewayClientScopes: opts.gatewayClientScopes,
   });
 
   const threadParams = buildTelegramThreadReplyParams({
@@ -1664,6 +1677,7 @@ type TelegramCreateForumTopicOpts = {
   api?: TelegramApiOverride;
   verbose?: boolean;
   retry?: RetryConfig;
+  gatewayClientScopes?: readonly string[];
   /** Icon color for the topic (must be one of 0x6FB9F0, 0xFFD67E, 0xCB86DB, 0x8EEE98, 0xFF93B2, 0xFB6F5F). */
   iconColor?: TelegramCreateForumTopicParams["icon_color"];
   /** Custom emoji ID for the topic icon. */
@@ -1707,6 +1721,7 @@ export async function createForumTopicTelegram(
     lookupTarget: target.chatId,
     persistTarget: chatId,
     verbose: opts.verbose,
+    gatewayClientScopes: opts.gatewayClientScopes,
   });
 
   const requestWithDiag = createTelegramNonIdempotentRequestWithDiag({

--- a/extensions/telegram/src/telegram-ingress-worker.runtime.ts
+++ b/extensions/telegram/src/telegram-ingress-worker.runtime.ts
@@ -10,7 +10,6 @@ import type {
   TelegramIngressWorkerMessage,
   TelegramIngressWorkerOptions,
 } from "./telegram-ingress-worker.js";
-import { writeTelegramUpdateOffset } from "./update-offset-store.js";
 
 const options = workerData as TelegramIngressWorkerOptions;
 const pollLimit = 100;
@@ -131,11 +130,6 @@ async function main(): Promise<void> {
           });
           if (lastUpdateId === null || updateId > lastUpdateId) {
             lastUpdateId = updateId;
-            await writeTelegramUpdateOffset({
-              accountId: options.accountId,
-              botToken: options.token,
-              updateId,
-            });
           }
           post({ type: "spooled", updateId, queued: result.length });
         }

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -695,6 +695,7 @@ export type ChannelMessageActionContext = {
   };
   toolContext?: ChannelThreadingToolContext;
   dryRun?: boolean;
+  gatewayClientScopes?: readonly string[];
 };
 
 export type ChannelToolSend = {

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -1325,17 +1325,21 @@ describe("gateway send mirroring", () => {
       "send-test-message-action-media-roots",
     );
 
-    const { respond } = await runMessageActionRequest({
-      channel: "telegram",
-      action: "sendAttachment",
-      params: { chatId: "123", mediaUrl: `${TEST_AGENT_WORKSPACE}/render.png` },
-      agentId: "work",
-      idempotencyKey: "idem-message-action-media-roots",
-    });
+    const { respond } = await runMessageActionRequest(
+      {
+        channel: "telegram",
+        action: "sendAttachment",
+        params: { chatId: "123", mediaUrl: `${TEST_AGENT_WORKSPACE}/render.png` },
+        agentId: "work",
+        idempotencyKey: "idem-message-action-media-roots",
+      },
+      { connect: { scopes: ["operator.write"] } },
+    );
 
     expect(firstRespondCall(respond)[0]).toBe(true);
     const actionCall = lastDispatchChannelMessageActionCall();
     expect(actionCall?.mediaLocalRoots).toContain(TEST_AGENT_WORKSPACE);
+    expect(actionCall?.gatewayClientScopes).toEqual(["operator.write"]);
   });
 
   it("forces senderIsOwner=false for narrowly-scoped callers but honors it for full operators", async () => {

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -373,6 +373,7 @@ export const sendHandlers: GatewayRequestHandlers = {
           ),
           toolContext: request.toolContext,
           dryRun: false,
+          gatewayClientScopes: client?.connect?.scopes ?? [],
         });
         if (!handled) {
           const error = errorShape(


### PR DESCRIPTION
Fixes #82277

## Summary
- Move isolated Telegram polling offset persistence back to the main update-dispatch path, so fetched updates are not treated as complete until the bot handler has processed them.
- Preserve gateway client scopes when Telegram message actions are invoked through the gateway, which prevents CLI sends from re-entering the scope-upgrade approval loop.
- Add focused coverage for the polling handoff, gateway-scoped Telegram sends, floor replay handling, and related Telegram action scope propagation.

## Verification
- `node scripts/run-vitest.mjs extensions/telegram/src/action-runtime.test.ts extensions/telegram/src/send.test.ts extensions/telegram/src/bot-update-tracker.test.ts extensions/telegram/src/polling-session.test.ts src/gateway/server-methods/send.test.ts`
- `pnpm changed:lanes --json && pnpm check:changed` on Blacksmith Testbox `tbx_01krsmsw1af5sc0tc7v0aa1g65`: https://github.com/openclaw/openclaw/actions/runs/25976724105
- `/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --mode branch`: no accepted/actionable findings after the Telegram routing fixes.

## Real behavior proof (required for external PRs)
- Behavior addressed: Telegram isolated polling now persists offsets only after main-thread dispatch, so inbound updates are not consumed before routing. Telegram gateway message actions now preserve CLI/operator caller scopes, so CLI sends do not recurse into admin-only target writeback approval.
- Real environment tested: Local OpenClaw checkout on the PR branch, Blacksmith Testbox changed gate, and attempted Telegram real-user Crabbox proof with the repo Telegram QA runner.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/telegram/src/action-runtime.test.ts extensions/telegram/src/send.test.ts extensions/telegram/src/bot-update-tracker.test.ts extensions/telegram/src/polling-session.test.ts src/gateway/server-methods/send.test.ts`; `pnpm changed:lanes --json && pnpm check:changed`; `pnpm qa:telegram-user:crabbox -- start --tdlib-url http://artifacts.openclaw.ai/tdlib-v1.8.0-linux-x64.tgz --output-dir .artifacts/qa-e2e/telegram-user-crabbox/pr-82705`.
- Evidence after fix: Focused tests passed 288 assertions across 6 files. Blacksmith Testbox changed gate passed: https://github.com/openclaw/openclaw/actions/runs/25976724105. Real Telegram proof runner reached the shared credential broker and failed before launch with live output `POOL_EXHAUSTED No available credential for kind "telegram-user"`.
- Observed result after fix: Unit and integration coverage verifies dispatch-before-offset persistence, below-floor replay handling, and gateway caller scope preservation across Telegram send/action paths. Testbox reported exit 0 for the changed gate. The real Telegram user run was blocked by QA credential pool availability, not by the patched code path.
- What was not tested: A full real Telegram Desktop send/receive recording was not completed because the shared `telegram-user` credential pool was exhausted. No personal Telegram account or production account was used.
