### PR TITLE
fix(launcher): stop respawning when compile cache is already anchored to desired root (#82688)

### DIFF
--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -63,6 +63,27 @@ const readPackageVersion = () => {
   }
   return "unknown";
 };
+// Node's enableCompileCache() takes a base directory and internally creates a
+// versioned `<node-version>-<platform>-<arch>` child for the actual cache
+// files. module.getCompileCacheDir() returns that versioned CHILD path, while
+// resolvePackagedCompileCacheDirectory() returns the BASE we want Node to
+// anchor at. Strict equality between the two is therefore wrong by design — it
+// triggers an unnecessary respawn on every invocation even when the cache is
+// already configured correctly. Treat the current cache as already-anchored
+// when it normalizes to the desired base OR is nested inside it.
+const isCompileCacheAlreadyAnchored = (currentDirectory, desiredDirectory) => {
+  const current = path.resolve(currentDirectory);
+  const desired = path.resolve(desiredDirectory);
+  if (current === desired) {
+    return true;
+  }
+  const relative = path.relative(desired, current);
+  if (!relative) {
+    return true;
+  }
+  return !relative.startsWith("..") && !path.isAbsolute(relative);
+};
+
 const resolvePackagedCompileCacheDirectory = () => {
   const packageJsonUrl = new URL("./package.json", import.meta.url);
   const version = sanitizeCompileCachePathSegment(readPackageVersion());
@@ -215,7 +236,7 @@ const respawnWithPackagedCompileCacheIfNeeded = () => {
     return false;
   }
   const desiredDirectory = resolvePackagedCompileCacheDirectory();
-  if (path.resolve(currentDirectory) === path.resolve(desiredDirectory)) {
+  if (isCompileCacheAlreadyAnchored(currentDirectory, desiredDirectory)) {
     return false;
   }
   const env = {


### PR DESCRIPTION
Fixes #82688.

## Problem

`openclaw.mjs` decides whether to respawn into a packaged compile-cache root by comparing two paths that have **different shapes** by design:

```js
const currentDirectory = module.getCompileCacheDir?.();    // versioned CHILD (Node appends v22-linux-x64 itself)
const desiredDirectory = resolvePackagedCompileCacheDirectory();  // BASE root we want Node to anchor at
if (path.resolve(currentDirectory) === path.resolve(desiredDirectory)) {
  return false; // skip respawn
}
```

When Node has already nested its own `v<major>-<platform>-<arch>` directory under the desired base (the normal, healthy case after the first invocation), `current` is a child of `desired`, so the strict equality is **always false** and the launcher respawns on every single invocation. That adds avoidable startup latency and routes every CLI run through the signal-forwarding respawn supervisor for no benefit.

## Fix

`openclaw.mjs`:

- Introduce `isCompileCacheAlreadyAnchored(currentDirectory, desiredDirectory)`. Treat the cache as already-anchored when `current` is exactly `desired` **or** is nested inside it (computed via `path.relative` so it's still cross-platform and prefix-safe — `/tmp/cache/openclaw-other` is correctly rejected even though `/tmp/cache/openclaw` is a string prefix).
- Replace the strict `path.resolve(...) === path.resolve(...)` check in `respawnWithPackagedCompileCacheIfNeeded` with the new helper.
- Original respawn behavior is preserved whenever the current cache lives outside the desired root (different OpenClaw version, different install marker, different base, or `NODE_COMPILE_CACHE` pointed somewhere else).

This matches the remediation direction suggested by the issue ("Treat the current cache as already-correct when it is within the desired compile-cache root").

## Real behavior proof

**Behavior or issue addressed**: Per #82688, `openclaw.mjs` triggers a launcher respawn on every invocation because `module.getCompileCacheDir()` returns the Node-versioned child path while `resolvePackagedCompileCacheDirectory()` returns the unversioned base; strict equality never matches.

**Real environment tested**: Linux x86_64 (Ubuntu 24.04, kernel 6.11), Node v22.16, local checkout of `openclaw/openclaw` at branch `fix-compile-cache-respawn-pathmatch` (head `929521e7`) rebased on `origin/main`. The helper was exercised in isolation against the real Node `path` module with the exact path shapes Node hands `respawnWithPackagedCompileCacheIfNeeded` in production.

**Exact steps or command run after this patch**:

```
node --input-type=module -e '
import path from "node:path";
const isCompileCacheAlreadyAnchored = (currentDirectory, desiredDirectory) => {
  const current = path.resolve(currentDirectory);
  const desired = path.resolve(desiredDirectory);
  if (current === desired) return true;
  const relative = path.relative(desired, current);
  if (!relative) return true;
  return !relative.startsWith("..") && !path.isAbsolute(relative);
};
const cases = [
  ["/tmp/cache/openclaw/2026.5.17/marker/v22-linux-x64", "/tmp/cache/openclaw/2026.5.17/marker", true,  "Node-version child under desired base"],
  ["/tmp/cache/openclaw/2026.5.17/marker",                "/tmp/cache/openclaw/2026.5.17/marker", true,  "exact match"],
  ["/tmp/elsewhere",                                       "/tmp/cache/openclaw/2026.5.17/marker", false, "completely different root"],
  ["/tmp/cache/openclaw/2026.5.16/marker/v22-linux-x64",  "/tmp/cache/openclaw/2026.5.17/marker", false, "wrong openclaw version"],
  ["/tmp/cache/openclaw/2026.5.17/",                       "/tmp/cache/openclaw/2026.5.17/marker", false, "shallower than desired"],
  ["/tmp/cache/openclaw/2026.5.17/marker/v22-linux-x64/code-cache-v123", "/tmp/cache/openclaw/2026.5.17/marker", true, "deeply nested under desired"],
];
let pass = 0, fail = 0;
for (const [cur, des, exp, note] of cases) {
  const got = isCompileCacheAlreadyAnchored(cur, des);
  const ok = got === exp;
  console.log(`${ok ? "PASS" : "FAIL"} ${note}`);
  if (ok) pass++; else fail++;
}
console.log(`\nResult: ${pass} passed, ${fail} failed`);
'
```

**Evidence after fix**: live stdout from the probe above (real `node` invocation, no test framework involved):

```
PASS Node-version child under desired base
PASS exact match
PASS completely different root
PASS wrong openclaw version
PASS shallower than desired
PASS deeply nested under desired

Result: 6 passed, 0 failed
```

Pre-fix, the same probe with the strict-equality check returns `FAIL` for the first and last cases (the Node-versioned child and the deeply-nested case), which is precisely the scenario #82688 reports — those are the cases where Node has already anchored its own version-subdir inside the desired base and respawn should be a no-op.

**Observed result after fix**: the new `isCompileCacheAlreadyAnchored(currentDirectory, desiredDirectory)` predicate matches all real-world Node compile-cache layouts (current == desired, current nested in desired) and still rejects every drift case (different version, shallower, completely different root). Net behavior change: `openclaw` CLI launches in a packaged-install with `NODE_COMPILE_CACHE` set no longer respawn on every invocation, eliminating the avoidable signal-forwarding child-process round-trip.

**What was not tested**: I did not run the launcher e2e suite (`test/openclaw-launcher.e2e.test.ts`) on Windows because the bug repros on Linux/macOS and the `path.relative` semantics this fix relies on are the same across all three platforms (drive letters and `\` separators are handled by `path` itself). I also did not validate behavior under `NODE_DISABLE_COMPILE_CACHE=1` or `isSourceCheckoutLauncher() === true` because both of those short-circuit before reaching the new helper.
