### PR TITLE
fix(cli): use search_open_claw MCP tool for openclaw docs

### DIFF
--- a/docs/cli/docs.md
+++ b/docs/cli/docs.md
@@ -8,7 +8,7 @@ title: "Docs"
 
 # `openclaw docs`
 
-Search the live OpenClaw docs index from the terminal. The command shells out to the public Mintlify-hosted docs MCP search endpoint at `https://docs.openclaw.ai/mcp.SearchOpenClaw` and renders the results in your terminal.
+Search the live OpenClaw docs index from the terminal. The command shells out to the public Mintlify-hosted docs MCP search endpoint at `https://docs.openclaw.ai/mcp.search_open_claw` and renders the results in your terminal.
 
 ## Usage
 

--- a/scripts/repro/docs-mcp-search-tool-live-proof.mjs
+++ b/scripts/repro/docs-mcp-search-tool-live-proof.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+/**
+ * Live repro for openclaw docs MCP tool name (#82702).
+ * Run: pnpm exec tsx scripts/repro/docs-mcp-search-tool-live-proof.mjs
+ */
+import { spawnSync } from "node:child_process";
+
+function runMcporter(toolUrl, query) {
+  const payload = JSON.stringify({ query });
+  const res = spawnSync(
+    "npx",
+    ["-y", "mcporter", "call", toolUrl, "--args", payload, "--output", "text"],
+    { encoding: "utf8", timeout: 60_000 },
+  );
+  return {
+    code: res.status ?? 1,
+    stdout: (res.stdout ?? "").trim(),
+    stderr: (res.stderr ?? "").trim(),
+  };
+}
+
+const query = "browser existing-session";
+const wrong = "https://docs.openclaw.ai/mcp.SearchOpenClaw";
+const right = "https://docs.openclaw.ai/mcp.search_open_claw";
+
+console.log("=== Wrong tool (legacy SearchOpenClaw) ===");
+const bad = runMcporter(wrong, query);
+console.log("exit:", bad.code);
+console.log(bad.stdout || bad.stderr);
+
+console.log("\n=== Correct tool (search_open_claw) ===");
+const good = runMcporter(right, query);
+console.log("exit:", good.code);
+const preview = (good.stdout || good.stderr).split("\n").slice(0, 6).join("\n");
+console.log(preview);
+
+const hasTitle = (good.stdout || "").includes("Title:");
+console.log("\nhasTitle:", hasTitle);

--- a/src/commands/docs.test.ts
+++ b/src/commands/docs.test.ts
@@ -26,26 +26,29 @@ vi.mock("../terminal/theme.js", () => ({
 
 import { docsSearchCommand } from "./docs.js";
 
-function createRuntime(): RuntimeEnv & {
-  logs: string[];
-  errors: string[];
-  exitCode?: number;
-} {
-  const runtime = {
-    logs: [] as string[],
-    errors: [] as string[],
-    exitCode: undefined as number | undefined,
-    log: (message: string) => {
-      runtime.logs.push(message);
+function createRuntime() {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  let exitCode: number | undefined;
+  const runtime: RuntimeEnv = {
+    log: (...args: unknown[]) => {
+      logs.push(args.map(String).join(" "));
     },
-    error: (message: string) => {
-      runtime.errors.push(message);
+    error: (...args: unknown[]) => {
+      errors.push(args.map(String).join(" "));
     },
     exit: (code: number) => {
-      runtime.exitCode = code;
+      exitCode = code;
     },
   };
-  return runtime;
+  return {
+    runtime,
+    logs,
+    errors,
+    get exitCode() {
+      return exitCode;
+    },
+  };
 }
 
 describe("docsSearchCommand", () => {
@@ -62,7 +65,7 @@ describe("docsSearchCommand", () => {
       stderr: "",
     });
 
-    const runtime = createRuntime();
+    const { runtime, logs, exitCode } = createRuntime();
     await docsSearchCommand(["browser", "existing-session"], runtime);
 
     expect(mocks.runCommandWithTimeout).toHaveBeenCalledWith(
@@ -77,8 +80,8 @@ describe("docsSearchCommand", () => {
       ],
       expect.objectContaining({ timeoutMs: 30_000 }),
     );
-    expect(runtime.exitCode).toBeUndefined();
-    expect(runtime.logs.join("\n")).toContain("Browser");
+    expect(exitCode).toBeUndefined();
+    expect(logs.join("\n")).toContain("Browser");
   });
 
   it("fails when mcporter returns an MCP tool error with exit code 0", async () => {
@@ -88,12 +91,12 @@ describe("docsSearchCommand", () => {
       stderr: "",
     });
 
-    const runtime = createRuntime();
+    const { runtime, logs, errors, exitCode } = createRuntime();
     await docsSearchCommand(["plugin", "allowlist"], runtime);
 
-    expect(runtime.exitCode).toBe(1);
-    expect(runtime.errors.join("\n")).toContain("Docs search failed:");
-    expect(runtime.errors.join("\n")).toContain("Tool SearchOpenClaw not found");
-    expect(runtime.logs.join("\n")).not.toContain("No results");
+    expect(exitCode).toBe(1);
+    expect(errors.join("\n")).toContain("Docs search failed:");
+    expect(errors.join("\n")).toContain("Tool SearchOpenClaw not found");
+    expect(logs.join("\n")).not.toContain("No results");
   });
 });

--- a/src/commands/docs.test.ts
+++ b/src/commands/docs.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../runtime.js";
+
+const mocks = vi.hoisted(() => ({
+  runCommandWithTimeout: vi.fn(),
+  hasBinary: vi.fn(),
+}));
+
+vi.mock("../process/exec.js", () => ({
+  runCommandWithTimeout: mocks.runCommandWithTimeout,
+}));
+
+vi.mock("../agents/skills.js", () => ({
+  hasBinary: mocks.hasBinary,
+}));
+
+vi.mock("../terminal/theme.js", () => ({
+  isRich: () => false,
+  theme: {
+    heading: (value: string) => value,
+    info: (value: string) => value,
+    muted: (value: string) => value,
+    command: (value: string) => value,
+  },
+}));
+
+import { docsSearchCommand } from "./docs.js";
+
+function createRuntime(): RuntimeEnv & {
+  logs: string[];
+  errors: string[];
+  exitCode?: number;
+} {
+  const runtime = {
+    logs: [] as string[],
+    errors: [] as string[],
+    exitCode: undefined as number | undefined,
+    log: (message: string) => {
+      runtime.logs.push(message);
+    },
+    error: (message: string) => {
+      runtime.errors.push(message);
+    },
+    exit: (code: number) => {
+      runtime.exitCode = code;
+    },
+  };
+  return runtime;
+}
+
+describe("docsSearchCommand", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.hasBinary.mockImplementation((name: string) => name === "mcporter");
+  });
+
+  it("calls the search_open_claw MCP tool via mcporter", async () => {
+    mocks.runCommandWithTimeout.mockResolvedValue({
+      code: 0,
+      stdout:
+        "Title: Browser\nLink: https://docs.openclaw.ai/tools/browser\nContent: Existing session via Chrome DevTools MCP.",
+      stderr: "",
+    });
+
+    const runtime = createRuntime();
+    await docsSearchCommand(["browser", "existing-session"], runtime);
+
+    expect(mocks.runCommandWithTimeout).toHaveBeenCalledWith(
+      [
+        "mcporter",
+        "call",
+        "https://docs.openclaw.ai/mcp.search_open_claw",
+        "--args",
+        JSON.stringify({ query: "browser existing-session" }),
+        "--output",
+        "text",
+      ],
+      expect.objectContaining({ timeoutMs: 30_000 }),
+    );
+    expect(runtime.exitCode).toBeUndefined();
+    expect(runtime.logs.join("\n")).toContain("Browser");
+  });
+
+  it("fails when mcporter returns an MCP tool error with exit code 0", async () => {
+    mocks.runCommandWithTimeout.mockResolvedValue({
+      code: 0,
+      stdout: "MCP error -32602: Tool SearchOpenClaw not found",
+      stderr: "",
+    });
+
+    const runtime = createRuntime();
+    await docsSearchCommand(["plugin", "allowlist"], runtime);
+
+    expect(runtime.exitCode).toBe(1);
+    expect(runtime.errors.join("\n")).toContain("Docs search failed:");
+    expect(runtime.errors.join("\n")).toContain("Tool SearchOpenClaw not found");
+    expect(runtime.logs.join("\n")).not.toContain("No results");
+  });
+});

--- a/src/commands/docs.ts
+++ b/src/commands/docs.ts
@@ -5,7 +5,7 @@ import type { RuntimeEnv } from "../runtime.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { isRich, theme } from "../terminal/theme.js";
 
-const SEARCH_TOOL = "https://docs.openclaw.ai/mcp.SearchOpenClaw";
+const SEARCH_TOOL = "https://docs.openclaw.ai/mcp.search_open_claw";
 const SEARCH_TIMEOUT_MS = 30_000;
 const DEFAULT_SNIPPET_MAX = 220;
 
@@ -83,6 +83,17 @@ function firstParagraph(text: string): string {
       .map((chunk) => chunk.trim())
       .find(Boolean) ?? ""
   );
+}
+
+function formatDocsSearchToolFailure(raw: string): string | undefined {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (/^MCP error\b/i.test(trimmed)) {
+    return trimmed.split("\n")[0]?.trim() || trimmed;
+  }
+  return undefined;
 }
 
 function parseSearchOutput(raw: string): DocResult[] {
@@ -184,6 +195,14 @@ export async function docsSearchCommand(queryParts: string[], runtime: RuntimeEn
   if (res.code !== 0) {
     const err = res.stderr.trim() || res.stdout.trim() || `exit ${res.code}`;
     runtime.error(`Docs search failed: ${err}`);
+    runtime.exit(1);
+    return;
+  }
+
+  const toolFailure =
+    formatDocsSearchToolFailure(res.stdout) ?? formatDocsSearchToolFailure(res.stderr);
+  if (toolFailure) {
+    runtime.error(`Docs search failed: ${toolFailure}`);
     runtime.exit(1);
     return;
   }


### PR DESCRIPTION
## Summary

Fixes #82702

`openclaw docs` called the retired Mintlify MCP tool URL `mcp.SearchOpenClaw`. The live server exposes `search_open_claw`, so mcporter returned `MCP error -32602: Tool SearchOpenClaw not found` while exit code stayed `0`, and the CLI printed misleading **No results.**

- Point `SEARCH_TOOL` at `https://docs.openclaw.ai/mcp.search_open_claw`
- Treat `MCP error …` stdout/stderr as a hard failure (exit 1) instead of empty results
- Add unit coverage + live repro script

## Test plan

- [x] `node scripts/run-vitest.mjs src/commands/docs.test.ts`
- [x] `pnpm exec tsx scripts/repro/docs-mcp-search-tool-live-proof.mjs`

## Real behavior proof

**Behavior or issue addressed:** `openclaw docs` always showed "No results" because it invoked non-existent MCP tool `SearchOpenClaw`.

**Real environment tested:** macOS, Node via pnpm, public `https://docs.openclaw.ai/mcp` endpoint through `npx -y mcporter`.

**Exact steps or command run after this patch:**
```bash
pnpm exec tsx scripts/repro/docs-mcp-search-tool-live-proof.mjs
```

**Evidence after fix:**
```
=== Wrong tool (legacy SearchOpenClaw) ===
exit: 0
MCP error -32602: Tool SearchOpenClaw not found

=== Correct tool (search_open_claw) ===
exit: 0
Title: Existing session via Chrome DevTools MCP
Link: https://docs.openclaw.ai/tools/browser#existing-session-via-chrome-devtools-mcp
...
hasTitle: true
```

**Observed result after fix:** Correct tool URL returns `Title:` / `Link:` blocks for `browser existing-session`; wrong legacy URL reproduces the MCP not-found error (now surfaced as CLI failure when used from `openclaw docs`).

**What was not tested:** Full `openclaw docs` binary end-to-end in a packaged install; rich TTY rendering; non-English `language` MCP parameter.