### PR TITLE
fix(tasks): fail closed stale cli owner main sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Tasks/maintenance: stop stale persistent `openclaw agent` owner-session CLI tasks from staying `running` forever once their live run context is gone, even if the `agent:...:main` session row still exists on disk.
 - CLI/config: add `--dry-run` support to `openclaw config unset`, with `--json` output and allow-exec validation parity with `config set`/`config patch` dry-run handling. (#81895) Thanks @giodl73-repo.
 - Memory-core: retry disabled dreaming cron cleanup until cron is available after startup, so persisted managed dreaming jobs are removed after restart. Fixes #82383. (#82389) Thanks @neeravmakwana.
 - Providers/xAI: keep retired Grok 3, Grok 4 Fast, Grok 4.1 Fast, and Grok Code slugs out of model pickers while preserving compatibility resolution for existing configs.

--- a/docs/automation/tasks.md
+++ b/docs/automation/tasks.md
@@ -250,7 +250,7 @@ openclaw tasks notify <lookup> state_changes
     - ACP/subagent tasks check their backing child session.
     - Subagent tasks whose child session has a restart-recovery tombstone are marked lost instead of being treated as recoverable backing sessions.
     - Cron tasks check whether the cron runtime still owns the job, then recover terminal status from persisted cron run logs/job state before falling back to `lost`. Only the Gateway process is authoritative for the in-memory cron active-job set; offline CLI audit uses durable history but does not mark a cron task lost solely because that local Set is empty.
-    - CLI tasks with run identity check the owning live run context, not just child-session or chat-session rows.
+    - CLI tasks with run identity check the owning live run context, not just child-session or chat-session rows, and stale persistent owner-session CLI lanes do not stay alive solely because their `agent:...:main` session row still exists.
 
     Completion cleanup is also runtime-aware:
 

--- a/src/tasks/task-registry.maintenance.issue-60299.test.ts
+++ b/src/tasks/task-registry.maintenance.issue-60299.test.ts
@@ -470,6 +470,47 @@ describe("task-registry maintenance issue #60299", () => {
     expectTaskStatus(currentTasks, task.taskId, "lost");
   });
 
+  it("marks stale persistent cli owner sessions lost after the owning run context disappears", async () => {
+    const sessionKey = "agent:main:explicit:main";
+    const task = makeStaleTask({
+      runtime: "cli",
+      sourceId: "run-persistent-cli-stale",
+      runId: "run-persistent-cli-stale",
+      ownerKey: sessionKey,
+      requesterSessionKey: sessionKey,
+      childSessionKey: sessionKey,
+    });
+
+    const { currentTasks } = createTaskRegistryMaintenanceHarness({
+      tasks: [task],
+      sessionStore: { [sessionKey]: { sessionId: sessionKey, updatedAt: Date.now() } },
+    });
+
+    expectMaintenanceCounts(await runTaskRegistryMaintenance(), { reconciled: 1 });
+    expectTaskStatus(currentTasks, task.taskId, "lost");
+  });
+
+  it("keeps persistent cli owner sessions live while the owning run context is still active", async () => {
+    const sessionKey = "agent:main:main";
+    const task = makeStaleTask({
+      runtime: "cli",
+      sourceId: "run-persistent-cli-live",
+      runId: "run-persistent-cli-live",
+      ownerKey: sessionKey,
+      requesterSessionKey: sessionKey,
+      childSessionKey: sessionKey,
+    });
+
+    const { currentTasks } = createTaskRegistryMaintenanceHarness({
+      tasks: [task],
+      sessionStore: { [sessionKey]: { sessionId: sessionKey, updatedAt: Date.now() } },
+      activeRunIds: ["run-persistent-cli-live"],
+    });
+
+    expectMaintenanceCounts(await runTaskRegistryMaintenance(), { reconciled: 0 });
+    expectTaskStatus(currentTasks, task.taskId, "running");
+  });
+
   it("does not keep stale CLI run-context tasks alive through stale subagent session rows", async () => {
     const childSessionKey = "agent:main:subagent:stale-cli";
     const task = makeStaleTask({

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -440,6 +440,22 @@ function hasActiveCliRun(task: TaskRecord): boolean {
   return false;
 }
 
+function isPersistentCliOwnerMainSession(task: TaskRecord, childSessionKey: string): boolean {
+  const normalizedChild = normalizeLowercaseStringOrEmpty(childSessionKey);
+  if (!normalizedChild) {
+    return false;
+  }
+  if (normalizedChild !== normalizeLowercaseStringOrEmpty(task.ownerKey)) {
+    return false;
+  }
+  if (normalizedChild !== normalizeLowercaseStringOrEmpty(task.requesterSessionKey)) {
+    return false;
+  }
+  const parsed = taskRegistryMaintenanceRuntime.parseAgentSessionKey(childSessionKey);
+  const normalizedRest = normalizeLowercaseStringOrEmpty(parsed?.rest);
+  return normalizedRest === "main" || normalizedRest.endsWith(":main");
+}
+
 function hasCliRunIdentity(task: TaskRecord): boolean {
   return [task.sourceId, task.runId].some((candidate) => Boolean(candidate?.trim()));
 }
@@ -477,6 +493,9 @@ function hasBackingSession(task: TaskRecord, context?: BackingSessionLookupConte
     if (task.runtime === "cli") {
       const chatType = resolveSessionChatType(childSessionKey, context);
       if (chatType === "channel" || chatType === "group" || chatType === "direct") {
+        return false;
+      }
+      if (isPersistentCliOwnerMainSession(task, childSessionKey)) {
         return false;
       }
     }


### PR DESCRIPTION
## Summary
- fail closed persistent CLI owner-session lanes when only the `agent:...:main` session row remains but no live run context exists
- add two regression tests covering stale vs live persistent owner-session CLI tasks
- document the runtime-aware maintenance behavior and record it in the changelog

## Root cause
`hasBackingSession()` could keep stale CLI tasks alive solely because a persistent `childSessionKey` like `agent:...:main` still existed on disk, even after the owning run context had disappeared.

## Verification
- `corepack pnpm exec oxfmt --check CHANGELOG.md docs/automation/tasks.md src/tasks/task-registry.maintenance.ts src/tasks/task-registry.maintenance.issue-60299.test.ts`
- `node scripts/test-projects.mjs src/tasks/task-registry.maintenance.issue-60299.test.ts`

## Notes
- repo-wide `pnpm format:check` is not currently green on this fresh upstream checkout because of unrelated pre-existing formatting drift outside this slice
- a broader `tasks` shard run in this Windows environment also hit unrelated pre-existing task-suite failures outside this change