### PR TITLE
fix(subagents): make completion handoff review-first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Docs: https://docs.openclaw.ai
 - CLI/docs: call the canonical lowercase docs MCP search tool and surface MCP errors instead of returning empty search results. Fixes #82702. (#82704) Thanks @hclsys.
 - QA-Lab: ignore heartbeat-only operational transcripts when capturing runtime parity cells so background checks cannot replace the scenario reply. (#80323) Thanks @100yenadmin.
 - Gateway/exec approvals: wait for accepted async approval follow-up runs instead of direct-fallback sending duplicate completions when retries use different nonce keys. Fixes #82711. (#82717) Thanks @udaymanish6.
-- Agents/subagents: mark completed subagent handoffs as ready for parent review so requester agents verify results and continue required follow-up work before reporting done.
+- Agents/subagents: mark completed subagent handoffs as ready for parent review so requester agents verify results and continue required follow-up work before reporting done. (#82724) Thanks @100menotu001.
 - CLI/config: add `--dry-run` support to `openclaw config unset`, with `--json` output and allow-exec validation parity with `config set`/`config patch` dry-run handling. (#81895) Thanks @giodl73-repo.
 - Memory-core: retry disabled dreaming cron cleanup until cron is available after startup, so persisted managed dreaming jobs are removed after restart. Fixes #82383. (#82389) Thanks @neeravmakwana.
 - Providers/xAI: keep retired Grok 3, Grok 4 Fast, Grok 4.1 Fast, and Grok Code slugs out of model pickers while preserving compatibility resolution for existing configs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 - CLI/docs: call the canonical lowercase docs MCP search tool and surface MCP errors instead of returning empty search results. Fixes #82702. (#82704) Thanks @hclsys.
 - QA-Lab: ignore heartbeat-only operational transcripts when capturing runtime parity cells so background checks cannot replace the scenario reply. (#80323) Thanks @100yenadmin.
 - Gateway/exec approvals: wait for accepted async approval follow-up runs instead of direct-fallback sending duplicate completions when retries use different nonce keys. Fixes #82711. (#82717) Thanks @udaymanish6.
+- Agents/subagents: mark completed subagent handoffs as ready for parent review so requester agents verify results and continue required follow-up work before reporting done.
 - CLI/config: add `--dry-run` support to `openclaw config unset`, with `--json` output and allow-exec validation parity with `config set`/`config patch` dry-run handling. (#81895) Thanks @giodl73-repo.
 - Memory-core: retry disabled dreaming cron cleanup until cron is available after startup, so persisted managed dreaming jobs are removed after restart. Fixes #82383. (#82389) Thanks @neeravmakwana.
 - Providers/xAI: keep retired Grok 3, Grok 4 Fast, Grok 4.1 Fast, and Grok Code slugs out of model pickers while preserving compatibility resolution for existing configs.

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -99,7 +99,9 @@ requester chat when the run finishes.
     - `Result` — latest visible `assistant` reply text, otherwise sanitized latest tool/toolResult text. Terminal failed runs do not reuse captured reply text.
     - `Status` — `completed successfully` / `failed` / `timed out` / `unknown`.
     - Compact runtime/token stats.
-    - A delivery instruction telling the requester agent to rewrite in normal assistant voice (not forward raw internal metadata).
+    - A review instruction telling the requester agent to verify the result before deciding whether the original task is done.
+    - Follow-up guidance telling the requester agent to continue the task or record a follow-up when the child result leaves more action.
+    - A final-update instruction for the no-more-action path, written in normal assistant voice without forwarding raw internal metadata.
 
   </Accordion>
   <Accordion title="Modes and ACP runtime">

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -511,8 +511,13 @@ describe("subagent announce formatting", () => {
     expect(msg).toContain("</prompt-data>");
     expect(msg).toContain("raw subagent reply");
     expect(msg).toContain("Stats:");
-    expect(msg).toContain("A completed subagent task is ready for user delivery.");
-    expect(msg).toContain("Convert the result above into your normal assistant voice");
+    expect(msg).toContain("A completed subagent task is ready for parent review.");
+    expect(msg).toContain(
+      "Review/verify the result above before deciding whether the original task is done.",
+    );
+    expect(msg).toContain(
+      "If additional action is required, continue the task or record a follow-up; otherwise send a truthful user-facing update.",
+    );
     expect(msg).toContain("Keep this internal context private");
     expect(call?.params?.internalEvents?.[0]?.type).toBe("task_completion");
     expect(call?.params?.internalEvents?.[0]?.taskLabel).toBe("do thing");
@@ -697,7 +702,10 @@ describe("subagent announce formatting", () => {
     expect(msg).toContain("tokens 1.0k (in 12 / out 1.0k)");
     expect(msg).toContain("prompt/cache 197.0k");
     expect(msg).toContain("session_id: child-session-usage");
-    expect(msg).toContain("A completed subagent task is ready for user delivery.");
+    expect(msg).toContain("A completed subagent task is ready for parent review.");
+    expect(msg).toContain(
+      "If additional action is required, continue the task or record a follow-up; otherwise send a truthful user-facing update.",
+    );
     expect(msg).toContain(
       `Reply ONLY: ${SILENT_REPLY_TOKEN} if this exact result was already delivered to the user in this same turn.`,
     );

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -88,9 +88,9 @@ function buildAnnounceReplyInstruction(params: {
     return `Convert this completion into a concise internal orchestration update for your parent agent in your own words. Keep this internal context private (don't mention system/log/stats/session details or announce type). If this result is duplicate or no update is needed, reply ONLY: ${SILENT_REPLY_TOKEN}.`;
   }
   if (params.expectsCompletionMessage) {
-    return `A completed ${params.announceType} is ready for user delivery. Convert the result above into your normal assistant voice and send that user-facing update now. Keep this internal context private (don't mention system/log/stats/session details or announce type).`;
+    return `A completed ${params.announceType} is ready for parent review. Review/verify the result above before deciding whether the original task is done. If additional action is required, continue the task or record a follow-up; otherwise send a truthful user-facing update. Keep this internal context private (don't mention system/log/stats/session details or announce type).`;
   }
-  return `A completed ${params.announceType} is ready for user delivery. Convert the result above into your normal assistant voice and send that user-facing update now. Keep this internal context private (don't mention system/log/stats/session details or announce type), and do not copy the internal event text verbatim. Reply ONLY: ${SILENT_REPLY_TOKEN} if this exact result was already delivered to the user in this same turn.`;
+  return `A completed ${params.announceType} is ready for parent review. Review/verify the result above before deciding whether the original task is done. If additional action is required, continue the task or record a follow-up; otherwise send a truthful user-facing update. Keep this internal context private (don't mention system/log/stats/session details or announce type), and do not copy the internal event text verbatim. Reply ONLY: ${SILENT_REPLY_TOKEN} if this exact result was already delivered to the user in this same turn.`;
 }
 
 function buildAnnounceSteerMessage(events: AgentInternalEvent[]): string {


### PR DESCRIPTION
## Summary

- Problem: completed subagent announce handoffs tell the requester agent the result is "ready for user delivery", which frames the handoff as a final-response rewrite instead of a parent review point.
- Why it matters: when the child result identifies remaining work, the requester agent should verify the result and continue or record follow-up work before reporting done.
- What changed: successful subagent announce instructions now say the handoff is ready for parent review, require review/verification before deciding the original task is done, and explicitly tell the requester to continue or record follow-up when more action is required.
- What did NOT change (scope boundary): no delivery routing, registry state, child execution, task registry, ACP lifecycle, config, or channel behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #82726
- Related #78985
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: completed subagent announce handoffs now instruct the requester/parent to review and verify child results before deciding whether the original task is done, and to continue or record follow-up work when additional action remains.
- Real environment tested: local OpenClaw source checkout from current `openclaw/openclaw@main` on macOS, branch `codex/subagent-review-handoff`, running the actual `runSubagentAnnounceFlow` formatter coverage used by the runtime announce path.
- Exact steps or command run after this patch:
  - `git show upstream/main:src/agents/subagent-announce.ts | rg -n "ready for user delivery|ready for parent review"`
  - `rg -n "ready for user delivery|ready for parent review|Review/verify|additional action" src/agents/subagent-announce.ts src/agents/subagent-announce.format.e2e.test.ts CHANGELOG.md | sed -n '1,80p'`
  - `pnpm exec vitest run --config test/vitest/vitest.e2e.config.ts src/agents/subagent-announce.format.e2e.test.ts`
  - `pnpm exec oxfmt --check --threads=1 src/agents/subagent-announce.ts src/agents/subagent-announce.format.e2e.test.ts CHANGELOG.md`
  - `pnpm check:changed`
  - `git diff --check`
  - Synthetic redacted requester handoff capture using `runSubagentAnnounceFlow` with a temp config/session store and captured `agent` handoff params.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
$ git show upstream/main:src/agents/subagent-announce.ts | rg -n "ready for user delivery|ready for parent review"
91:    return `A completed ${params.announceType} is ready for user delivery. Convert the result above into your normal assistant voice and send that user-facing update now. Keep this internal context private (don't mention system/log/stats/session details or announce type).`;
93:  return `A completed ${params.announceType} is ready for user delivery. Convert the result above into your normal assistant voice and send that user-facing update now. Keep this internal context private (don't mention system/log/stats/session details or announce type), and do not copy the internal event text verbatim. Reply ONLY: ${SILENT_REPLY_TOKEN} if this exact result was already delivered to the user in this same turn.`;

$ rg -n "ready for user delivery|ready for parent review|Review/verify|additional action" src/agents/subagent-announce.ts src/agents/subagent-announce.format.e2e.test.ts CHANGELOG.md | sed -n '1,80p'
src/agents/subagent-announce.ts:91:    return `A completed ${params.announceType} is ready for parent review. Review/verify the result above before deciding whether the original task is done. If additional action is required, continue the task or record a follow-up; otherwise send a truthful user-facing update. Keep this internal context private (don't mention system/log/stats/session details or announce type).`;
src/agents/subagent-announce.ts:93:  return `A completed ${params.announceType} is ready for parent review. Review/verify the result above before deciding whether the original task is done. If additional action is required, continue the task or record a follow-up; otherwise send a truthful user-facing update. Keep this internal context private (don't mention system/log/stats/session details or announce type), and do not copy the internal event text verbatim. Reply ONLY: ${SILENT_REPLY_TOKEN} if this exact result was already delivered to the user in this same turn.`;
src/agents/subagent-announce.format.e2e.test.ts:514:    expect(msg).toContain("A completed subagent task is ready for parent review.");
src/agents/subagent-announce.format.e2e.test.ts:516:      "Review/verify the result above before deciding whether the original task is done.",
src/agents/subagent-announce.format.e2e.test.ts:519:      "If additional action is required, continue the task or record a follow-up; otherwise send a truthful user-facing update.",
src/agents/subagent-announce.format.e2e.test.ts:705:    expect(msg).toContain("A completed subagent task is ready for parent review.");
src/agents/subagent-announce.format.e2e.test.ts:707:      "If additional action is required, continue the task or record a follow-up; otherwise send a truthful user-facing update.",
CHANGELOG.md:24:- Agents/subagents: mark completed subagent handoffs as ready for parent review so requester agents verify results and continue required follow-up work before reporting done.

$ pnpm exec vitest run --config test/vitest/vitest.e2e.config.ts src/agents/subagent-announce.format.e2e.test.ts
Test Files  1 passed (1)
Tests  79 passed (79)

$ pnpm exec oxfmt --check --threads=1 src/agents/subagent-announce.ts src/agents/subagent-announce.format.e2e.test.ts CHANGELOG.md
All matched files use the correct format.

$ pnpm check:changed
Import cycle check: 0 runtime value cycle(s).
[check:changed] completed successfully

$ git diff --check
(no output)

$ OPENCLAW_CONFIG_PATH=<temp>/openclaw.json OPENCLAW_STATE_DIR=<temp> OPENCLAW_PROOF_STORE=<temp>/sessions.json pnpm exec tsx --eval '<capture runSubagentAnnounceFlow handoff>'
captured_method=agent
captured_session=agent:main:main
captured_deliver=false
captured_message_excerpt:
child found a stale override and recommends a follow-up fix
A completed subagent task is ready for parent review. Review/verify the result above before deciding whether the original task is done. If additional action is required, continue the task or record a follow-up; otherwise send a truthful user-facing update. Keep this internal context private (don't mention system/log/stats/session details or announce type), and do not copy the internal event text verbatim. Reply ONLY: NO_REPLY if this exact result was already delivered to the user in this same turn.
```

- Observed result after fix: the subagent announce prompt generated by the runtime formatter now says the completion is ready for parent review, asks the requester agent to verify before deciding the original task is done, and tells it to continue or record follow-up when more action remains. A synthetic redacted runtime handoff capture also showed `runSubagentAnnounceFlow` delivering those instructions through the requester `agent` handoff params.
- What was not tested: no live provider-backed Telegram/Discord/Slack turn was run for this PR; the change is limited to runtime prompt wording and covered through the existing subagent announce formatter e2e path.
- Before evidence (optional but encouraged): `upstream/main` output above shows both non-subagent requester handoff branches used `ready for user delivery` wording before this patch.

## Root Cause (if applicable)

- Root cause: the non-subagent requester handoff text treated a completed child run as a user-delivery event, not as parent-owned evidence that may require review, verification, or more work.
- Missing detection / guardrail: formatter coverage asserted the old delivery wording but did not require review-first closeout language.
- Contributing context (if known): subagent completion announces are internal handoff data; requester agents own synthesis and final task state.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/subagent-announce.format.e2e.test.ts`
- Scenario the test should lock in: generated subagent announce prompts for requester sessions contain parent-review wording, verification guidance, and continue/follow-up guidance instead of delivery-only wording.
- Why this is the smallest reliable guardrail: it exercises the runtime announce formatter path without requiring external channels or providers for a prompt-text-only change.
- Existing test that already covers this (if any): existing formatter e2e cases covered the same prompt branches but expected the old wording.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Subagent completion handoffs now guide the requester/parent agent to verify child results and continue required follow-up work before reporting done. No config or channel behavior changes.

## Diagram (if applicable)

```text
Before:
subagent completes -> requester sees "ready for user delivery" -> likely final-answer rewrite

After:
subagent completes -> requester sees "ready for parent review" -> verify -> continue/follow-up or truthful final update
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local OpenClaw source checkout
- Model/provider: N/A; prompt formatter change only
- Integration/channel (if any): subagent announce formatter/runtime path
- Relevant config (redacted): N/A

### Steps

1. Inspect `upstream/main` subagent announce instruction text.
2. Apply this patch.
3. Inspect the patched instruction text and run the formatter e2e test shard.
4. Run formatting, changed-file gate, and whitespace checks.

### Expected

- Subagent announce requester prompts say `ready for parent review` and instruct review/verification before done.
- Prompt text tells the requester to continue or record follow-up if additional action is required.
- Formatter e2e tests pass.

### Actual

- Expected behavior observed.
- Focused e2e, formatting, docs formatting, synthetic handoff capture, `check:changed`, and `git diff --check` passed.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: both non-subagent requester handoff branches now use parent-review wording; existing formatter e2e branch assertions were updated and passed; a synthetic redacted handoff run captured the actual requester `agent` handoff message containing the parent-review/follow-up instruction.
- Edge cases checked: duplicate-delivery `SILENT_REPLY_TOKEN` guidance remains intact on the default branch; requester-is-subagent internal orchestration wording remains unchanged.
- What you did **not** verify: live model-backed channel turn; no runtime routing or delivery code was changed.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a requester agent may spend more effort reviewing a child result before replying.
  - Mitigation: the new wording only applies when a child completion is handed back to the requester and keeps the final-update path explicit when no more action is needed.



