### PR TITLE
fix(tailscale): retry status --json after transient startup failures

### DIFF
--- a/scripts/repro/tailscale-status-json-retry-live-proof.mjs
+++ b/scripts/repro/tailscale-status-json-retry-live-proof.mjs
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+/**
+ * Live repro helper for tailscale status --json retry (#42798).
+ * Simulates the startup race: first status call fails, second succeeds.
+ *
+ * Run: pnpm exec tsx scripts/repro/tailscale-status-json-retry-live-proof.mjs
+ */
+import { getTailnetHostname } from "../../src/infra/tailscale.js";
+
+let calls = 0;
+const exec = async (bin, args) => {
+  calls += 1;
+  if (args[0] === "status" && args[1] === "--json" && calls === 1) {
+    throw new Error("Command failed: tailscale status --json");
+  }
+  return {
+    stdout: JSON.stringify({
+      Self: { DNSName: "proof-host.tailnet.ts.net.", TailscaleIPs: ["100.64.0.1"] },
+    }),
+  };
+};
+
+const host = await getTailnetHostname(exec, "tailscale");
+console.log("status calls:", calls);
+console.log("host:", host);

--- a/src/infra/tailscale.test.ts
+++ b/src/infra/tailscale.test.ts
@@ -104,6 +104,69 @@ describe("tailscale helpers", () => {
     vi.useRealTimers();
   });
 
+  it("suppresses transient status failure logs when a retry succeeds", async () => {
+    vi.useFakeTimers();
+    try {
+      const loggedFailures: string[] = [];
+      const exec = vi.fn(
+        async (command: string, args: string[], options?: { suppressFailureLog?: boolean }) => {
+          if (exec.mock.calls.length === 1) {
+            if (!options?.suppressFailureLog) {
+              loggedFailures.push(`Command failed: ${command} ${args.join(" ")}`);
+            }
+            throw new Error("Command failed: tailscale status --json");
+          }
+          return {
+            stdout: JSON.stringify({
+              Self: { DNSName: "host.tailnet.ts.net.", TailscaleIPs: ["100.1.1.1"] },
+            }),
+          };
+        },
+      );
+
+      const hostPromise = getTailnetHostname(exec as never, "tailscale");
+      await vi.advanceTimersByTimeAsync(500);
+      const host = await hostPromise;
+
+      expect(host).toBe("host.tailnet.ts.net");
+      expect(loggedFailures).toEqual([]);
+      expect(exec.mock.calls.map((call) => call[2]?.suppressFailureLog)).toEqual([true, undefined]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("logs the final status failure after retries are exhausted", async () => {
+    vi.useFakeTimers();
+    try {
+      const loggedFailures: string[] = [];
+      const exec = vi.fn(
+        async (command: string, args: string[], options?: { suppressFailureLog?: boolean }) => {
+          if (!options?.suppressFailureLog) {
+            loggedFailures.push(`Command failed: ${command} ${args.join(" ")}`);
+          }
+          throw new Error("Command failed: tailscale status --json");
+        },
+      );
+
+      const hostPromise = getTailnetHostname(exec as never, "tailscale");
+      const expectation = expect(hostPromise).rejects.toThrow(
+        "Command failed: tailscale status --json",
+      );
+      await vi.advanceTimersByTimeAsync(1_000);
+      await expectation;
+
+      expect(loggedFailures).toEqual(["Command failed: tailscale status --json"]);
+      expect(exec.mock.calls.map((call) => call[2]?.suppressFailureLog)).toEqual([
+        true,
+        true,
+        undefined,
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not retry status --json when the tailscale binary is missing", async () => {
     vi.useFakeTimers();
     const enoent = Object.assign(new Error("spawn tailscale ENOENT"), { code: "ENOENT" });

--- a/src/infra/tailscale.test.ts
+++ b/src/infra/tailscale.test.ts
@@ -130,7 +130,7 @@ describe("tailscale helpers", () => {
 
       expect(host).toBe("host.tailnet.ts.net");
       expect(loggedFailures).toEqual([]);
-      expect(exec.mock.calls.map((call) => call[2]?.suppressFailureLog)).toEqual([true, undefined]);
+      expect(exec.mock.calls.map((call) => call[2]?.suppressFailureLog)).toEqual([true, true]);
     } finally {
       vi.useRealTimers();
     }

--- a/src/infra/tailscale.test.ts
+++ b/src/infra/tailscale.test.ts
@@ -86,6 +86,24 @@ describe("tailscale helpers", () => {
     expect(host).toBe("noisy.tailnet.ts.net");
   });
 
+  it("retries tailscale status --json on transient failure", async () => {
+    vi.useFakeTimers();
+    const exec = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Command failed: tailscale status --json"))
+      .mockResolvedValue({
+        stdout: JSON.stringify({
+          Self: { DNSName: "host.tailnet.ts.net.", TailscaleIPs: ["100.1.1.1"] },
+        }),
+      });
+    const hostPromise = getTailnetHostname(exec);
+    await vi.advanceTimersByTimeAsync(500);
+    const host = await hostPromise;
+    expect(host).toBe("host.tailnet.ts.net");
+    expect(exec).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
   it("allows the test binary override in explicit test environments", () => {
     process.env.OPENCLAW_TEST_TAILSCALE_BINARY = "/tmp/test-tailscale";
     process.env.NODE_ENV = "test";

--- a/src/infra/tailscale.test.ts
+++ b/src/infra/tailscale.test.ts
@@ -104,6 +104,18 @@ describe("tailscale helpers", () => {
     vi.useRealTimers();
   });
 
+  it("does not retry status --json when the tailscale binary is missing", async () => {
+    vi.useFakeTimers();
+    const enoent = Object.assign(new Error("spawn tailscale ENOENT"), { code: "ENOENT" });
+    const exec = vi.fn().mockRejectedValue(enoent);
+    const hostPromise = getTailnetHostname(exec, "tailscale");
+    const expectation = expect(hostPromise).rejects.toThrow("spawn tailscale ENOENT");
+    await vi.advanceTimersByTimeAsync(2_000);
+    await expectation;
+    expect(exec).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+
   it("allows the test binary override in explicit test environments", () => {
     process.env.OPENCLAW_TEST_TAILSCALE_BINARY = "/tmp/test-tailscale";
     process.env.NODE_ENV = "test";

--- a/src/infra/tailscale.ts
+++ b/src/infra/tailscale.ts
@@ -11,6 +11,13 @@ import {
 import { colorize, isRich, theme } from "../terminal/theme.js";
 import { ensureBinary } from "./binaries.js";
 
+const TAILSCALE_STATUS_RETRY_ATTEMPTS = 3;
+const TAILSCALE_STATUS_RETRY_DELAY_MS = 500;
+
+function sleepMs(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 function parsePossiblyNoisyJsonObject(stdout: string): Record<string, unknown> {
   const trimmed = stdout.trim();
   const start = trimmed.indexOf("{");
@@ -107,6 +114,28 @@ export async function findTailscaleBinary(): Promise<string | null> {
   return null;
 }
 
+async function readTailscaleStatusJson(
+  exec: typeof runExec,
+  candidate: string,
+): Promise<Record<string, unknown>> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < TAILSCALE_STATUS_RETRY_ATTEMPTS; attempt++) {
+    if (attempt > 0) {
+      await sleepMs(TAILSCALE_STATUS_RETRY_DELAY_MS);
+    }
+    try {
+      const { stdout } = await exec(candidate, ["status", "--json"], {
+        timeoutMs: 5000,
+        maxBuffer: 400_000,
+      });
+      return stdout ? parsePossiblyNoisyJsonObject(stdout) : {};
+    } catch (err) {
+      lastError = err;
+    }
+  }
+  throw lastError ?? new Error("tailscale status --json failed");
+}
+
 export async function getTailnetHostname(exec: typeof runExec = runExec, detectedBinary?: string) {
   // Derive tailnet hostname (or IP fallback) from tailscale status JSON.
   const candidates = detectedBinary
@@ -119,11 +148,7 @@ export async function getTailnetHostname(exec: typeof runExec = runExec, detecte
       continue;
     }
     try {
-      const { stdout } = await exec(candidate, ["status", "--json"], {
-        timeoutMs: 5000,
-        maxBuffer: 400_000,
-      });
-      const parsed = stdout ? parsePossiblyNoisyJsonObject(stdout) : {};
+      const parsed = await readTailscaleStatusJson(exec, candidate);
       const self =
         typeof parsed.Self === "object" && parsed.Self !== null
           ? (parsed.Self as Record<string, unknown>)

--- a/src/infra/tailscale.ts
+++ b/src/infra/tailscale.ts
@@ -140,6 +140,7 @@ async function readTailscaleStatusJson(
       const { stdout } = await exec(candidate, ["status", "--json"], {
         timeoutMs: 5000,
         maxBuffer: 400_000,
+        suppressFailureLog: attempt < TAILSCALE_STATUS_RETRY_ATTEMPTS - 1,
       });
       return stdout ? parsePossiblyNoisyJsonObject(stdout) : {};
     } catch (err) {

--- a/src/infra/tailscale.ts
+++ b/src/infra/tailscale.ts
@@ -10,6 +10,7 @@ import {
 } from "../shared/string-coerce.js";
 import { colorize, isRich, theme } from "../terminal/theme.js";
 import { ensureBinary } from "./binaries.js";
+import { extractErrorCode, formatErrorMessage } from "./errors.js";
 
 const TAILSCALE_STATUS_RETRY_ATTEMPTS = 3;
 const TAILSCALE_STATUS_RETRY_DELAY_MS = 500;
@@ -19,14 +20,11 @@ function sleepMs(ms: number): Promise<void> {
 }
 
 function isNonRetryableTailscaleStatusError(err: unknown): boolean {
-  if (!err || typeof err !== "object") {
-    return false;
-  }
-  const code = (err as NodeJS.ErrnoException).code;
+  const code = extractErrorCode(err);
   if (code === "ENOENT" || code === "ENOTDIR") {
     return true;
   }
-  const message = err instanceof Error ? err.message : String(err);
+  const message = formatErrorMessage(err);
   if (/command not found/i.test(message)) {
     return true;
   }

--- a/src/infra/tailscale.ts
+++ b/src/infra/tailscale.ts
@@ -18,6 +18,21 @@ function sleepMs(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function isNonRetryableTailscaleStatusError(err: unknown): boolean {
+  if (!err || typeof err !== "object") {
+    return false;
+  }
+  const code = (err as NodeJS.ErrnoException).code;
+  if (code === "ENOENT" || code === "ENOTDIR") {
+    return true;
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  if (/command not found/i.test(message)) {
+    return true;
+  }
+  return /ENOENT/i.test(message) && /spawn/i.test(message);
+}
+
 function parsePossiblyNoisyJsonObject(stdout: string): Record<string, unknown> {
   const trimmed = stdout.trim();
   const start = trimmed.indexOf("{");
@@ -131,6 +146,9 @@ async function readTailscaleStatusJson(
       return stdout ? parsePossiblyNoisyJsonObject(stdout) : {};
     } catch (err) {
       lastError = err;
+      if (isNonRetryableTailscaleStatusError(err)) {
+        break;
+      }
     }
   }
   throw lastError ?? new Error("tailscale status --json failed");

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -178,7 +178,14 @@ export function shouldSpawnWithShell(params: {
 export async function runExec(
   command: string,
   args: string[],
-  opts: number | { timeoutMs?: number; maxBuffer?: number; cwd?: string } = 10_000,
+  opts:
+    | number
+    | {
+        timeoutMs?: number;
+        maxBuffer?: number;
+        cwd?: string;
+        suppressFailureLog?: boolean;
+      } = 10_000,
 ): Promise<{ stdout: string; stderr: string }> {
   const options =
     typeof opts === "number"
@@ -225,7 +232,7 @@ export async function runExec(
         });
       }
     }
-    if (shouldLogVerbose()) {
+    if (shouldLogVerbose() && (typeof opts === "number" || !opts.suppressFailureLog)) {
       logError(danger(`Command failed: ${command} ${args.join(" ")}`));
     }
     throw err;


### PR DESCRIPTION
## Summary

Fixes #42798

After `enableTailscaleServe`, `getTailnetHostname` can run `tailscale status --json` while the CLI is still settling and log a scary transient failure. This adds `readTailscaleStatusJson()` with **3 attempts** and **500ms** backoff (same path used by `getTailnetHostname`).

## Test plan

- [x] `node scripts/run-vitest.mjs src/infra/tailscale.test.ts`
- [x] `pnpm exec tsx scripts/repro/tailscale-status-json-retry-live-proof.mjs`

## Real behavior proof

**Behavior or issue addressed:** Transient `Command failed: tailscale status --json` during gateway Tailscale serve startup when status is queried immediately after serve enable.

**Real environment tested:** macOS, Node 22, local checkout at this branch (injected exec simulating first-call failure).

**Exact steps or command run after this patch:**
```bash
pnpm exec tsx scripts/repro/tailscale-status-json-retry-live-proof.mjs
```

**Evidence after fix:**
```
status calls: 2
host: proof-host.tailnet.ts.net
```

**Observed result after fix:** First simulated `status --json` failure is retried; hostname resolves on the second call instead of aborting.

**What was not tested:** Live gateway restart with Homebrew Tailscale daemon under load; funnel mode status paths (unchanged).