### PR TITLE
feat(slack): add assistant thread lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/performance: split startup benchmark HTTP-listen timing from full gateway-ready timing and add post-bind plugin and sidecar diagnostics to restart-readiness traces. (#82603) Thanks @samzong.
 - QA-Lab: add a deterministic local personal-agent scenario pack covering reminders, threaded replies, scoped memory recall, redaction, and safe tool followthrough. (#78219) Thanks @iFiras-Max1.
 - QA-Lab: add a private Codex-vs-Pi runtime parity axis with runtime-pair suite runs, parity reports, and release-check wiring. (#80238) Thanks @100yenadmin.
+- Slack: add Slack assistant thread lifecycle support with assistant view manifest entries, suggested prompts, thread-scoped assistant sessions, and Slack-provided assistant context. Fixes #80787. Thanks @mobybot27.
 
 ### Fixes
 

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -74,6 +74,17 @@ openclaw plugins install @openclaw/slack
       "messages_tab_enabled": true,
       "messages_tab_read_only_enabled": false
     },
+    "assistant_view": {
+      "assistant_description": "OpenClaw connects Slack assistant threads to OpenClaw agents.",
+      "suggested_prompts": [
+        { "title": "What can you do?", "message": "What can you help me with?" },
+        {
+          "title": "Summarize this channel",
+          "message": "Summarize the recent activity in this channel."
+        },
+        { "title": "Draft a reply", "message": "Help me draft a reply." }
+      ]
+    },
     "slash_commands": [
       {
         "command": "/openclaw",
@@ -117,6 +128,8 @@ openclaw plugins install @openclaw/slack
       "bot_events": [
         "app_home_opened",
         "app_mention",
+        "assistant_thread_context_changed",
+        "assistant_thread_started",
         "channel_rename",
         "member_joined_channel",
         "member_left_channel",
@@ -146,6 +159,17 @@ openclaw plugins install @openclaw/slack
       "home_tab_enabled": true,
       "messages_tab_enabled": true,
       "messages_tab_read_only_enabled": false
+    },
+    "assistant_view": {
+      "assistant_description": "OpenClaw connects Slack assistant threads to OpenClaw agents.",
+      "suggested_prompts": [
+        { "title": "What can you do?", "message": "What can you help me with?" },
+        {
+          "title": "Summarize this channel",
+          "message": "Summarize the recent activity in this channel."
+        },
+        { "title": "Draft a reply", "message": "Help me draft a reply." }
+      ]
     },
     "slash_commands": [
       {
@@ -179,6 +203,8 @@ openclaw plugins install @openclaw/slack
       "bot_events": [
         "app_home_opened",
         "app_mention",
+        "assistant_thread_context_changed",
+        "assistant_thread_started",
         "message.channels",
         "message.groups",
         "message.im"
@@ -264,6 +290,17 @@ openclaw gateway
       "messages_tab_enabled": true,
       "messages_tab_read_only_enabled": false
     },
+    "assistant_view": {
+      "assistant_description": "OpenClaw connects Slack assistant threads to OpenClaw agents.",
+      "suggested_prompts": [
+        { "title": "What can you do?", "message": "What can you help me with?" },
+        {
+          "title": "Summarize this channel",
+          "message": "Summarize the recent activity in this channel."
+        },
+        { "title": "Draft a reply", "message": "Help me draft a reply." }
+      ]
+    },
     "slash_commands": [
       {
         "command": "/openclaw",
@@ -308,6 +345,8 @@ openclaw gateway
       "bot_events": [
         "app_home_opened",
         "app_mention",
+        "assistant_thread_context_changed",
+        "assistant_thread_started",
         "channel_rename",
         "member_joined_channel",
         "member_left_channel",
@@ -343,6 +382,17 @@ openclaw gateway
       "messages_tab_enabled": true,
       "messages_tab_read_only_enabled": false
     },
+    "assistant_view": {
+      "assistant_description": "OpenClaw connects Slack assistant threads to OpenClaw agents.",
+      "suggested_prompts": [
+        { "title": "What can you do?", "message": "What can you help me with?" },
+        {
+          "title": "Summarize this channel",
+          "message": "Summarize the recent activity in this channel."
+        },
+        { "title": "Draft a reply", "message": "Help me draft a reply." }
+      ]
+    },
     "slash_commands": [
       {
         "command": "/openclaw",
@@ -376,6 +426,8 @@ openclaw gateway
       "bot_events": [
         "app_home_opened",
         "app_mention",
+        "assistant_thread_context_changed",
+        "assistant_thread_started",
         "message.channels",
         "message.groups",
         "message.im"
@@ -498,6 +550,17 @@ Base manifest (Socket Mode default):
       "messages_tab_enabled": true,
       "messages_tab_read_only_enabled": false
     },
+    "assistant_view": {
+      "assistant_description": "OpenClaw connects Slack assistant threads to OpenClaw agents.",
+      "suggested_prompts": [
+        { "title": "What can you do?", "message": "What can you help me with?" },
+        {
+          "title": "Summarize this channel",
+          "message": "Summarize the recent activity in this channel."
+        },
+        { "title": "Draft a reply", "message": "Help me draft a reply." }
+      ]
+    },
     "slash_commands": [
       {
         "command": "/openclaw",
@@ -541,6 +604,8 @@ Base manifest (Socket Mode default):
       "bot_events": [
         "app_home_opened",
         "app_mention",
+        "assistant_thread_context_changed",
+        "assistant_thread_started",
         "channel_rename",
         "member_joined_channel",
         "member_left_channel",
@@ -578,6 +643,8 @@ For **HTTP Request URLs mode**, replace `settings` with the HTTP variant and add
       "bot_events": [
         "app_home_opened",
         "app_mention",
+        "assistant_thread_context_changed",
+        "assistant_thread_started",
         "channel_rename",
         "member_joined_channel",
         "member_left_channel",
@@ -604,7 +671,7 @@ For **HTTP Request URLs mode**, replace `settings` with the HTTP variant and add
 
 Surface different features that extend the above defaults.
 
-The default manifest enables the Slack App Home **Home** tab and subscribes to `app_home_opened`. When a workspace member opens the Home tab, OpenClaw publishes a safe default Home view with `views.publish`; no conversation payload or private configuration is included. The **Messages** tab remains enabled for Slack DMs.
+The default manifest enables the Slack App Home **Home** tab and subscribes to `app_home_opened`. When a workspace member opens the Home tab, OpenClaw publishes a safe default Home view with `views.publish`; no conversation payload or private configuration is included. The **Messages** tab remains enabled for Slack DMs. The manifest also enables Slack assistant threads with `features.assistant_view`, `assistant:write`, `assistant_thread_started`, and `assistant_thread_context_changed`; assistant threads route to their own OpenClaw thread sessions and keep Slack-provided thread context available to the agent.
 
 <AccordionGroup>
   <Accordion title="Optional native slash commands">

--- a/extensions/slack/src/draft-stream.ts
+++ b/extensions/slack/src/draft-stream.ts
@@ -1,3 +1,4 @@
+import type { MessageMetadata } from "@slack/types";
 import type { Block, KnownBlock } from "@slack/web-api";
 import { createDraftStreamLoop } from "openclaw/plugin-sdk/channel-lifecycle";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
@@ -37,6 +38,7 @@ export function createSlackDraftStream(params: {
   maxChars?: number;
   throttleMs?: number;
   resolveThreadTs?: () => string | undefined;
+  metadata?: MessageMetadata;
   onMessageSent?: () => void;
   log?: (message: string) => void;
   warn?: (message: string) => void;
@@ -95,6 +97,7 @@ export function createSlackDraftStream(params: {
         accountId: params.accountId,
         threadTs: params.resolveThreadTs?.(),
         identity: params.identity,
+        ...(params.metadata ? { metadata: params.metadata } : {}),
         ...(blocks ? { blocks } : {}),
       });
       streamChannelId = sent.channelId || streamChannelId;

--- a/extensions/slack/src/monitor/context.ts
+++ b/extensions/slack/src/monitor/context.ts
@@ -45,6 +45,51 @@ export type SlackAssistantThreadContext = {
   updatedAt: number;
 };
 
+export const SLACK_ASSISTANT_THREAD_CONTEXT_METADATA_EVENT = "assistant_thread_context";
+
+export function buildSlackAssistantThreadMetadata(
+  context: Omit<SlackAssistantThreadContext, "updatedAt">,
+) {
+  const eventPayload: Record<string, string> = {};
+  if (context.channelId) {
+    eventPayload.channel_id = context.channelId;
+  }
+  if (context.teamId) {
+    eventPayload.team_id = context.teamId;
+  }
+  if (context.enterpriseId) {
+    eventPayload.enterprise_id = context.enterpriseId;
+  }
+  return {
+    event_type: SLACK_ASSISTANT_THREAD_CONTEXT_METADATA_EVENT,
+    event_payload: eventPayload,
+  };
+}
+
+export function parseSlackAssistantThreadMetadata(value: unknown) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const metadata = value as Record<string, unknown>;
+  if (metadata.event_type !== SLACK_ASSISTANT_THREAD_CONTEXT_METADATA_EVENT) {
+    return undefined;
+  }
+  const payload = metadata.event_payload;
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return undefined;
+  }
+  const record = payload as Record<string, unknown>;
+  const stringField = (key: string) => {
+    const raw = record[key];
+    return typeof raw === "string" && raw.trim() ? raw.trim() : undefined;
+  };
+  return {
+    channelId: stringField("channel_id"),
+    teamId: stringField("team_id"),
+    enterpriseId: stringField("enterprise_id"),
+  };
+}
+
 export type SlackMonitorContext = {
   cfg: OpenClawConfig;
   accountId: string;

--- a/extensions/slack/src/monitor/context.ts
+++ b/extensions/slack/src/monitor/context.ts
@@ -30,6 +30,21 @@ import { isSlackChannelAllowedByPolicy } from "./policy.js";
 
 export { normalizeSlackChannelType, resolveSlackChatType } from "./channel-type.js";
 
+export type SlackAssistantSuggestedPrompt = {
+  title: string;
+  message: string;
+};
+
+export type SlackAssistantThreadContext = {
+  assistantChannelId: string;
+  threadTs: string;
+  userId?: string;
+  channelId?: string;
+  teamId?: string;
+  enterpriseId?: string | null;
+  updatedAt: number;
+};
+
 export type SlackMonitorContext = {
   cfg: OpenClawConfig;
   accountId: string;
@@ -99,7 +114,23 @@ export type SlackMonitorContext = {
     threadTs?: string;
     status: string;
   }) => Promise<void>;
+  getSlackAssistantThreadContext: (
+    channelId: string | undefined,
+    threadTs: string | undefined,
+  ) => SlackAssistantThreadContext | undefined;
+  saveSlackAssistantThreadContext: (
+    context: Omit<SlackAssistantThreadContext, "updatedAt">,
+  ) => void;
+  setSlackAssistantSuggestedPrompts: (params: {
+    channelId: string;
+    threadTs: string;
+    title?: string;
+    prompts: SlackAssistantSuggestedPrompt[];
+  }) => Promise<boolean>;
 };
+
+const SLACK_ASSISTANT_CONTEXT_TTL_MS = 24 * 60 * 60 * 1000;
+const SLACK_ASSISTANT_CONTEXT_CLEANUP_INTERVAL_MS = 10 * 60 * 1000;
 
 export function createSlackMonitorContext(params: {
   cfg: OpenClawConfig;
@@ -155,6 +186,8 @@ export function createSlackMonitorContext(params: {
   >();
   const userCache = new Map<string, { name?: string }>();
   const seenMessages = createDedupeCache({ ttlMs: 60_000, maxSize: 500 });
+  const assistantThreadContexts = new Map<string, SlackAssistantThreadContext>();
+  let lastAssistantContextCleanupAt = Date.now();
 
   const allowFrom = normalizeAllowList(params.allowFrom);
   const groupDmChannels = normalizeAllowList(params.groupDmChannels);
@@ -175,6 +208,51 @@ export function createSlackMonitorContext(params: {
       return;
     }
     seenMessages.delete(`${channelId}:${ts}`);
+  };
+
+  const assistantContextKey = (channelId: string, threadTs: string) => `${channelId}:${threadTs}`;
+
+  const cleanupAssistantThreadContexts = () => {
+    const now = Date.now();
+    if (now - lastAssistantContextCleanupAt < SLACK_ASSISTANT_CONTEXT_CLEANUP_INTERVAL_MS) {
+      return;
+    }
+    lastAssistantContextCleanupAt = now;
+    const cutoff = now - SLACK_ASSISTANT_CONTEXT_TTL_MS;
+    for (const [key, entry] of assistantThreadContexts) {
+      if (entry.updatedAt < cutoff) {
+        assistantThreadContexts.delete(key);
+      }
+    }
+  };
+
+  const getSlackAssistantThreadContext = (
+    channelId: string | undefined,
+    threadTs: string | undefined,
+  ) => {
+    if (!channelId || !threadTs) {
+      return undefined;
+    }
+    const key = assistantContextKey(channelId, threadTs);
+    const entry = assistantThreadContexts.get(key);
+    if (!entry) {
+      return undefined;
+    }
+    if (Date.now() - entry.updatedAt > SLACK_ASSISTANT_CONTEXT_TTL_MS) {
+      assistantThreadContexts.delete(key);
+      return undefined;
+    }
+    return entry;
+  };
+
+  const saveSlackAssistantThreadContext = (
+    context: Omit<SlackAssistantThreadContext, "updatedAt">,
+  ) => {
+    cleanupAssistantThreadContexts();
+    assistantThreadContexts.set(assistantContextKey(context.assistantChannelId, context.threadTs), {
+      ...context,
+      updatedAt: Date.now(),
+    });
   };
 
   const resolveSlackSystemEventSessionKey = (p: {
@@ -337,6 +415,39 @@ export function createSlackMonitorContext(params: {
     }
   };
 
+  const setSlackAssistantSuggestedPrompts = async (p: {
+    channelId: string;
+    threadTs: string;
+    title?: string;
+    prompts: SlackAssistantSuggestedPrompt[];
+  }) => {
+    const prompts = p.prompts
+      .map((prompt) => ({
+        title: prompt.title.trim(),
+        message: prompt.message.trim(),
+      }))
+      .filter((prompt) => prompt.title && prompt.message)
+      .slice(0, 4);
+    if (prompts.length === 0) {
+      return false;
+    }
+    try {
+      await params.app.client.assistant.threads.setSuggestedPrompts({
+        token: params.botToken,
+        channel_id: p.channelId,
+        thread_ts: p.threadTs,
+        ...(p.title?.trim() ? { title: p.title.trim() } : {}),
+        prompts,
+      });
+      return true;
+    } catch (err) {
+      logVerbose(
+        `slack suggested prompts update failed for channel ${p.channelId}: ${formatSlackError(err)}`,
+      );
+      return false;
+    }
+  };
+
   const isChannelAllowed = (p: {
     channelId?: string;
     channelName?: string;
@@ -486,5 +597,8 @@ export function createSlackMonitorContext(params: {
     resolveChannelName,
     resolveUserName,
     setSlackThreadStatus,
+    getSlackAssistantThreadContext,
+    saveSlackAssistantThreadContext,
+    setSlackAssistantSuggestedPrompts,
   };
 }

--- a/extensions/slack/src/monitor/events.ts
+++ b/extensions/slack/src/monitor/events.ts
@@ -1,5 +1,6 @@
 import type { ResolvedSlackAccount } from "../accounts.js";
 import type { SlackMonitorContext } from "./context.js";
+import { registerSlackAssistantEvents } from "./events/assistant.js";
 import { registerSlackChannelEvents } from "./events/channels.js";
 import { registerSlackHomeEvents } from "./events/home.js";
 import { registerSlackInteractionEvents } from "./events/interactions.js";
@@ -26,4 +27,5 @@ export function registerSlackMonitorEvents(params: {
   registerSlackPinEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
   registerSlackHomeEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
   registerSlackInteractionEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
+  registerSlackAssistantEvents({ ctx: params.ctx, trackEvent: params.trackEvent });
 }

--- a/extensions/slack/src/monitor/events/assistant.test.ts
+++ b/extensions/slack/src/monitor/events/assistant.test.ts
@@ -5,27 +5,45 @@ import { registerSlackAssistantEvents } from "./assistant.js";
 
 type Handler = (args: { event: Record<string, unknown>; body: unknown }) => Promise<void>;
 
-function createHarness(overrides?: { shouldDrop?: boolean }) {
+function createHarness(overrides?: {
+  shouldDrop?: boolean;
+  existingContext?: ReturnType<SlackMonitorContext["getSlackAssistantThreadContext"]>;
+  replies?: ReturnType<typeof vi.fn>;
+  update?: ReturnType<typeof vi.fn>;
+}) {
   const handlers: Record<string, Handler> = {};
+  const getSlackAssistantThreadContext = vi.fn(() => overrides?.existingContext);
   const saveSlackAssistantThreadContext = vi.fn();
   const setSlackAssistantSuggestedPrompts = vi.fn(async () => true);
+  const replies = overrides?.replies ?? vi.fn(async () => ({ messages: [] }));
+  const update = overrides?.update ?? vi.fn(async () => ({}));
   const trackEvent = vi.fn();
   const ctx = {
     app: {
+      client: {
+        conversations: { replies },
+        chat: { update },
+      },
       event: (name: string, handler: Handler) => {
         handlers[name] = handler;
       },
     } as unknown as App,
     runtime: { error: vi.fn() },
+    botToken: "xoxb-test",
+    botUserId: "B1",
     shouldDropMismatchedSlackEvent: () => overrides?.shouldDrop === true,
+    getSlackAssistantThreadContext,
     saveSlackAssistantThreadContext,
     setSlackAssistantSuggestedPrompts,
   } as unknown as SlackMonitorContext;
   registerSlackAssistantEvents({ ctx, trackEvent });
   return {
     handlers,
+    getSlackAssistantThreadContext,
     saveSlackAssistantThreadContext,
     setSlackAssistantSuggestedPrompts,
+    replies,
+    update,
     trackEvent,
   };
 }
@@ -112,6 +130,51 @@ describe("registerSlackAssistantEvents", () => {
     expect(harness.setSlackAssistantSuggestedPrompts).not.toHaveBeenCalled();
   });
 
+  it("persists changed assistant thread context onto the first bot message", async () => {
+    const replies = vi.fn(async () => ({
+      messages: [
+        { user: "U123", ts: "1729999327.200000", text: "user asks" },
+        {
+          user: "B1",
+          ts: "1729999327.300000",
+          text: "assistant reply",
+          blocks: [{ type: "section", text: { type: "mrkdwn", text: "assistant reply" } }],
+        },
+      ],
+    }));
+    const update = vi.fn(async () => ({}));
+    const harness = createHarness({ replies, update });
+
+    await harness.handlers.assistant_thread_context_changed?.({
+      event: makeThreadEvent("assistant_thread_context_changed"),
+      body: {},
+    });
+
+    expect(replies).toHaveBeenCalledWith({
+      token: "xoxb-test",
+      channel: "D123",
+      ts: "1729999327.187299",
+      oldest: "1729999327.187299",
+      include_all_metadata: true,
+      limit: 4,
+    });
+    expect(update).toHaveBeenCalledWith({
+      token: "xoxb-test",
+      channel: "D123",
+      ts: "1729999327.300000",
+      text: "assistant reply",
+      blocks: [{ type: "section", text: { type: "mrkdwn", text: "assistant reply" } }],
+      metadata: {
+        event_type: "assistant_thread_context",
+        event_payload: {
+          channel_id: "C456",
+          team_id: "T789",
+          enterprise_id: "E123",
+        },
+      },
+    });
+  });
+
   it("accepts Slack assistant context when it is sent beside the thread", async () => {
     const harness = createHarness();
 
@@ -127,6 +190,77 @@ describe("registerSlackAssistantEvents", () => {
       channelId: "C456",
       teamId: "T789",
       enterpriseId: "E123",
+    });
+  });
+
+  it("merges partial assistant thread context per field", async () => {
+    const harness = createHarness();
+
+    await harness.handlers.assistant_thread_context_changed?.({
+      event: {
+        type: "assistant_thread_context_changed",
+        assistant_thread: {
+          user_id: "U123",
+          channel_id: "D123",
+          thread_ts: "1729999327.187299",
+          context: {
+            team_id: "T_THREAD",
+          },
+        },
+        context: {
+          channel_id: "C456",
+          team_id: "T_EVENT",
+          enterprise_id: "E123",
+        },
+      },
+      body: {},
+    });
+
+    expect(harness.saveSlackAssistantThreadContext).toHaveBeenCalledWith({
+      assistantChannelId: "D123",
+      threadTs: "1729999327.187299",
+      userId: "U123",
+      channelId: "C456",
+      teamId: "T_THREAD",
+      enterpriseId: "E123",
+    });
+  });
+
+  it("preserves cached assistant thread context when updates omit optional fields", async () => {
+    const harness = createHarness({
+      existingContext: {
+        assistantChannelId: "D123",
+        threadTs: "1729999327.187299",
+        userId: "UOLD",
+        channelId: "COLD",
+        teamId: "TOLD",
+        enterpriseId: "EOLD",
+        updatedAt: 1,
+      },
+    });
+
+    await harness.handlers.assistant_thread_context_changed?.({
+      event: {
+        type: "assistant_thread_context_changed",
+        assistant_thread: {
+          channel_id: "D123",
+          thread_ts: "1729999327.187299",
+        },
+      },
+      body: {},
+    });
+
+    expect(harness.getSlackAssistantThreadContext).toHaveBeenCalledWith(
+      "D123",
+      "1729999327.187299",
+    );
+    expect(harness.saveSlackAssistantThreadContext).toHaveBeenCalledWith({
+      assistantChannelId: "D123",
+      threadTs: "1729999327.187299",
+      userId: "UOLD",
+      channelId: "COLD",
+      teamId: "TOLD",
+      enterpriseId: "EOLD",
     });
   });
 

--- a/extensions/slack/src/monitor/events/assistant.test.ts
+++ b/extensions/slack/src/monitor/events/assistant.test.ts
@@ -1,0 +1,145 @@
+import type { App } from "@slack/bolt";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SlackMonitorContext } from "../context.js";
+import { registerSlackAssistantEvents } from "./assistant.js";
+
+type Handler = (args: { event: Record<string, unknown>; body: unknown }) => Promise<void>;
+
+function createHarness(overrides?: { shouldDrop?: boolean }) {
+  const handlers: Record<string, Handler> = {};
+  const saveSlackAssistantThreadContext = vi.fn();
+  const setSlackAssistantSuggestedPrompts = vi.fn(async () => true);
+  const trackEvent = vi.fn();
+  const ctx = {
+    app: {
+      event: (name: string, handler: Handler) => {
+        handlers[name] = handler;
+      },
+    } as unknown as App,
+    runtime: { error: vi.fn() },
+    shouldDropMismatchedSlackEvent: () => overrides?.shouldDrop === true,
+    saveSlackAssistantThreadContext,
+    setSlackAssistantSuggestedPrompts,
+  } as unknown as SlackMonitorContext;
+  registerSlackAssistantEvents({ ctx, trackEvent });
+  return {
+    handlers,
+    saveSlackAssistantThreadContext,
+    setSlackAssistantSuggestedPrompts,
+    trackEvent,
+  };
+}
+
+function makeThreadEvent(type: string) {
+  return {
+    type,
+    assistant_thread: {
+      user_id: "U123",
+      channel_id: "D123",
+      thread_ts: "1729999327.187299",
+      context: {
+        channel_id: "C456",
+        team_id: "T789",
+        enterprise_id: "E123",
+      },
+    },
+  };
+}
+
+function makeTopLevelContextThreadEvent(type: string) {
+  return {
+    type,
+    assistant_thread: {
+      user_id: "U123",
+      channel_id: "D123",
+      thread_ts: "1729999327.187299",
+    },
+    context: {
+      channel_id: "C456",
+      team_id: "T789",
+      enterprise_id: "E123",
+    },
+  };
+}
+
+describe("registerSlackAssistantEvents", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("stores new assistant thread context and sets default prompts", async () => {
+    const harness = createHarness();
+
+    await harness.handlers.assistant_thread_started?.({
+      event: makeThreadEvent("assistant_thread_started"),
+      body: {},
+    });
+
+    expect(harness.trackEvent).toHaveBeenCalledTimes(1);
+    expect(harness.saveSlackAssistantThreadContext).toHaveBeenCalledWith({
+      assistantChannelId: "D123",
+      threadTs: "1729999327.187299",
+      userId: "U123",
+      channelId: "C456",
+      teamId: "T789",
+      enterpriseId: "E123",
+    });
+    expect(harness.setSlackAssistantSuggestedPrompts).toHaveBeenCalledWith({
+      channelId: "D123",
+      threadTs: "1729999327.187299",
+      title: "Try asking",
+      prompts: [
+        { title: "What can you do?", message: "What can you help me with?" },
+        {
+          title: "Summarize this channel",
+          message: "Summarize the recent activity in this channel.",
+        },
+        { title: "Draft a reply", message: "Help me draft a reply." },
+      ],
+    });
+  });
+
+  it("updates assistant thread context without resetting prompts", async () => {
+    const harness = createHarness();
+
+    await harness.handlers.assistant_thread_context_changed?.({
+      event: makeThreadEvent("assistant_thread_context_changed"),
+      body: {},
+    });
+
+    expect(harness.trackEvent).toHaveBeenCalledTimes(1);
+    expect(harness.saveSlackAssistantThreadContext).toHaveBeenCalledTimes(1);
+    expect(harness.setSlackAssistantSuggestedPrompts).not.toHaveBeenCalled();
+  });
+
+  it("accepts Slack assistant context when it is sent beside the thread", async () => {
+    const harness = createHarness();
+
+    await harness.handlers.assistant_thread_context_changed?.({
+      event: makeTopLevelContextThreadEvent("assistant_thread_context_changed"),
+      body: {},
+    });
+
+    expect(harness.saveSlackAssistantThreadContext).toHaveBeenCalledWith({
+      assistantChannelId: "D123",
+      threadTs: "1729999327.187299",
+      userId: "U123",
+      channelId: "C456",
+      teamId: "T789",
+      enterpriseId: "E123",
+    });
+  });
+
+  it("drops mismatched workspace events before touching assistant state", async () => {
+    const harness = createHarness({ shouldDrop: true });
+
+    await harness.handlers.assistant_thread_started?.({
+      event: makeThreadEvent("assistant_thread_started"),
+      body: {},
+    });
+
+    expect(harness.trackEvent).not.toHaveBeenCalled();
+    expect(harness.saveSlackAssistantThreadContext).not.toHaveBeenCalled();
+    expect(harness.setSlackAssistantSuggestedPrompts).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/slack/src/monitor/events/assistant.ts
+++ b/extensions/slack/src/monitor/events/assistant.ts
@@ -1,6 +1,12 @@
+import type { Block, KnownBlock } from "@slack/web-api";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
-import type { SlackMonitorContext, SlackAssistantSuggestedPrompt } from "../context.js";
+import { buildSlackAssistantThreadMetadata } from "../context.js";
+import type {
+  SlackMonitorContext,
+  SlackAssistantSuggestedPrompt,
+  SlackAssistantThreadContext,
+} from "../context.js";
 
 type SlackAssistantThreadPayload = {
   user_id?: string;
@@ -50,6 +56,7 @@ const DEFAULT_ASSISTANT_PROMPTS: SlackAssistantSuggestedPrompt[] = [
 
 function normalizeAssistantThread(
   event: SlackAssistantThreadStartedEvent | SlackAssistantThreadContextChangedEvent,
+  getPrevious?: (channelId: string, threadTs: string) => SlackAssistantThreadContext | undefined,
 ) {
   const thread = event.assistant_thread;
   if (!thread) {
@@ -60,14 +67,77 @@ function normalizeAssistantThread(
   if (!channelId || !threadTs) {
     return null;
   }
+  const previous = getPrevious?.(channelId, threadTs);
+  const threadContext = thread.context;
+  const eventContext = event.context;
+  const resolveContextString = (
+    key: keyof Pick<SlackAssistantThreadContextPayload, "channel_id" | "team_id">,
+    previousValue: string | undefined,
+  ) => threadContext?.[key]?.trim() || eventContext?.[key]?.trim() || previousValue;
+  const enterpriseId = (() => {
+    if (threadContext && "enterprise_id" in threadContext) {
+      return threadContext.enterprise_id === null
+        ? null
+        : threadContext.enterprise_id?.trim() || previous?.enterpriseId;
+    }
+    if (eventContext && "enterprise_id" in eventContext) {
+      return eventContext.enterprise_id === null
+        ? null
+        : eventContext.enterprise_id?.trim() || previous?.enterpriseId;
+    }
+    return previous?.enterpriseId;
+  })();
   return {
     assistantChannelId: channelId,
     threadTs,
-    userId: thread.user_id?.trim() || undefined,
-    channelId: (thread.context ?? event.context)?.channel_id?.trim() || undefined,
-    teamId: (thread.context ?? event.context)?.team_id?.trim() || undefined,
-    enterpriseId: (thread.context ?? event.context)?.enterprise_id ?? undefined,
+    userId: thread.user_id?.trim() || previous?.userId,
+    channelId: resolveContextString("channel_id", previous?.channelId),
+    teamId: resolveContextString("team_id", previous?.teamId),
+    enterpriseId,
   };
+}
+
+async function persistAssistantThreadMetadata(params: {
+  ctx: SlackMonitorContext;
+  assistantThread: Omit<SlackAssistantThreadContext, "updatedAt">;
+}) {
+  const { ctx, assistantThread } = params;
+  try {
+    const response = (await ctx.app.client.conversations.replies({
+      token: ctx.botToken,
+      channel: assistantThread.assistantChannelId,
+      ts: assistantThread.threadTs,
+      oldest: assistantThread.threadTs,
+      include_all_metadata: true,
+      limit: 4,
+    })) as {
+      messages?: Array<{
+        subtype?: string;
+        user?: string;
+        ts?: string;
+        text?: string;
+        blocks?: (Block | KnownBlock)[];
+      }>;
+    };
+    const initialMessage = (response.messages ?? []).find(
+      (message) => !message.subtype && message.user === ctx.botUserId && message.ts,
+    );
+    if (!initialMessage?.ts) {
+      return;
+    }
+    await ctx.app.client.chat.update({
+      token: ctx.botToken,
+      channel: assistantThread.assistantChannelId,
+      ts: initialMessage.ts,
+      text: initialMessage.text ?? "",
+      blocks: Array.isArray(initialMessage.blocks) ? initialMessage.blocks : [],
+      metadata: buildSlackAssistantThreadMetadata(assistantThread),
+    });
+  } catch (err) {
+    logVerbose(
+      `slack assistant thread metadata persist failed for channel ${assistantThread.assistantChannelId}: ${formatErrorMessage(err)}`,
+    );
+  }
 }
 
 export function registerSlackAssistantEvents(params: {
@@ -84,7 +154,7 @@ export function registerSlackAssistantEvents(params: {
         return;
       }
       trackEvent?.();
-      const assistantThread = normalizeAssistantThread(event);
+      const assistantThread = normalizeAssistantThread(event, ctx.getSlackAssistantThreadContext);
       if (!assistantThread) {
         logVerbose(
           "slack assistant_thread_started dropped: missing assistant thread channel/thread",
@@ -111,7 +181,7 @@ export function registerSlackAssistantEvents(params: {
         return;
       }
       trackEvent?.();
-      const assistantThread = normalizeAssistantThread(event);
+      const assistantThread = normalizeAssistantThread(event, ctx.getSlackAssistantThreadContext);
       if (!assistantThread) {
         logVerbose(
           "slack assistant_thread_context_changed dropped: missing assistant thread channel/thread",
@@ -119,6 +189,7 @@ export function registerSlackAssistantEvents(params: {
         return;
       }
       ctx.saveSlackAssistantThreadContext(assistantThread);
+      await persistAssistantThreadMetadata({ ctx, assistantThread });
     } catch (err) {
       ctx.runtime.error?.(
         danger(`slack assistant_thread_context_changed handler failed: ${formatErrorMessage(err)}`),

--- a/extensions/slack/src/monitor/events/assistant.ts
+++ b/extensions/slack/src/monitor/events/assistant.ts
@@ -1,0 +1,128 @@
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import type { SlackMonitorContext, SlackAssistantSuggestedPrompt } from "../context.js";
+
+type SlackAssistantThreadPayload = {
+  user_id?: string;
+  context?: SlackAssistantThreadContextPayload;
+  channel_id?: string;
+  thread_ts?: string;
+};
+
+type SlackAssistantThreadContextPayload = {
+  channel_id?: string;
+  team_id?: string;
+  enterprise_id?: string | null;
+};
+
+type SlackAssistantThreadStartedEvent = {
+  type: "assistant_thread_started";
+  assistant_thread?: SlackAssistantThreadPayload;
+  context?: SlackAssistantThreadContextPayload;
+  event_ts?: string;
+};
+
+type SlackAssistantThreadContextChangedEvent = {
+  type: "assistant_thread_context_changed";
+  assistant_thread?: SlackAssistantThreadPayload;
+  context?: SlackAssistantThreadContextPayload;
+  event_ts?: string;
+};
+
+type SlackAssistantEventHandler<TEvent> = (args: { event: TEvent; body: unknown }) => Promise<void>;
+
+type SlackAssistantEventRegistrar = {
+  (
+    name: "assistant_thread_started",
+    handler: SlackAssistantEventHandler<SlackAssistantThreadStartedEvent>,
+  ): void;
+  (
+    name: "assistant_thread_context_changed",
+    handler: SlackAssistantEventHandler<SlackAssistantThreadContextChangedEvent>,
+  ): void;
+};
+
+const DEFAULT_ASSISTANT_PROMPTS: SlackAssistantSuggestedPrompt[] = [
+  { title: "What can you do?", message: "What can you help me with?" },
+  { title: "Summarize this channel", message: "Summarize the recent activity in this channel." },
+  { title: "Draft a reply", message: "Help me draft a reply." },
+];
+
+function normalizeAssistantThread(
+  event: SlackAssistantThreadStartedEvent | SlackAssistantThreadContextChangedEvent,
+) {
+  const thread = event.assistant_thread;
+  if (!thread) {
+    return null;
+  }
+  const channelId = thread.channel_id?.trim();
+  const threadTs = thread.thread_ts?.trim();
+  if (!channelId || !threadTs) {
+    return null;
+  }
+  return {
+    assistantChannelId: channelId,
+    threadTs,
+    userId: thread.user_id?.trim() || undefined,
+    channelId: (thread.context ?? event.context)?.channel_id?.trim() || undefined,
+    teamId: (thread.context ?? event.context)?.team_id?.trim() || undefined,
+    enterpriseId: (thread.context ?? event.context)?.enterprise_id ?? undefined,
+  };
+}
+
+export function registerSlackAssistantEvents(params: {
+  ctx: SlackMonitorContext;
+  /** Called on each inbound event to update liveness tracking. */
+  trackEvent?: () => void;
+}) {
+  const { ctx, trackEvent } = params;
+  const slackApp = ctx.app as unknown as { event: SlackAssistantEventRegistrar };
+
+  slackApp.event("assistant_thread_started", async ({ event, body }) => {
+    try {
+      if (ctx.shouldDropMismatchedSlackEvent(body)) {
+        return;
+      }
+      trackEvent?.();
+      const assistantThread = normalizeAssistantThread(event);
+      if (!assistantThread) {
+        logVerbose(
+          "slack assistant_thread_started dropped: missing assistant thread channel/thread",
+        );
+        return;
+      }
+      ctx.saveSlackAssistantThreadContext(assistantThread);
+      await ctx.setSlackAssistantSuggestedPrompts({
+        channelId: assistantThread.assistantChannelId,
+        threadTs: assistantThread.threadTs,
+        title: "Try asking",
+        prompts: DEFAULT_ASSISTANT_PROMPTS,
+      });
+    } catch (err) {
+      ctx.runtime.error?.(
+        danger(`slack assistant_thread_started handler failed: ${formatErrorMessage(err)}`),
+      );
+    }
+  });
+
+  slackApp.event("assistant_thread_context_changed", async ({ event, body }) => {
+    try {
+      if (ctx.shouldDropMismatchedSlackEvent(body)) {
+        return;
+      }
+      trackEvent?.();
+      const assistantThread = normalizeAssistantThread(event);
+      if (!assistantThread) {
+        logVerbose(
+          "slack assistant_thread_context_changed dropped: missing assistant thread channel/thread",
+        );
+        return;
+      }
+      ctx.saveSlackAssistantThreadContext(assistantThread);
+    } catch (err) {
+      ctx.runtime.error?.(
+        danger(`slack assistant_thread_context_changed handler failed: ${formatErrorMessage(err)}`),
+      );
+    }
+  });
+}

--- a/extensions/slack/src/monitor/events/messages.test.ts
+++ b/extensions/slack/src/monitor/events/messages.test.ts
@@ -89,6 +89,14 @@ function makeAssistantChangedEvent(overrides?: { user?: string }) {
       user: "U_BOT",
       text: "assistant wrapped user text",
       metadata: { event_payload: { user } },
+      assistant_thread: {
+        channel_id: "D1",
+        thread_ts: "123.000",
+        context: {
+          channel_id: "C123",
+          team_id: "T123",
+        },
+      },
     },
     previous_message: { ts: "123.456", user: "U_BOT" },
     event_ts: "123.789",
@@ -248,6 +256,7 @@ describe("registerSlackMessageEvents", () => {
             text?: string;
             ts?: string;
             thread_ts?: string;
+            assistant_thread?: Record<string, unknown>;
           },
           { source?: string },
         ]
@@ -259,6 +268,14 @@ describe("registerSlackMessageEvents", () => {
     expect(message?.text).toBe("assistant wrapped user text");
     expect(message?.ts).toBe("123.456");
     expect(message?.thread_ts).toBe("123.000");
+    expect(message?.assistant_thread).toEqual({
+      channel_id: "D1",
+      thread_ts: "123.000",
+      context: {
+        channel_id: "C123",
+        team_id: "T123",
+      },
+    });
     expect(call?.[1]).toEqual({ source: "message" });
     expect(messageQueueMock).not.toHaveBeenCalled();
   });

--- a/extensions/slack/src/monitor/events/messages.ts
+++ b/extensions/slack/src/monitor/events/messages.ts
@@ -18,6 +18,7 @@ type SlackAssistantMessageRecord = {
   thread_ts?: unknown;
   files?: unknown;
   attachments?: unknown;
+  assistant_thread?: unknown;
   metadata?: unknown;
   blocks?: unknown;
 };
@@ -123,6 +124,11 @@ function resolveAssistantMessageChangedInbound(params: {
     ts: asString(message.ts) ?? asString(changed.event_ts),
     thread_ts: asString(message.thread_ts),
     event_ts: changed.event_ts,
+    assistant_thread:
+      asRecord(message.assistant_thread) ??
+      asRecord(
+        (changed as SlackMessageChangedEvent & { assistant_thread?: unknown }).assistant_thread,
+      ),
     files: Array.isArray(message.files) ? (message.files as SlackMessageEvent["files"]) : undefined,
     attachments: Array.isArray(message.attachments)
       ? (message.attachments as SlackMessageEvent["attachments"])

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -397,6 +397,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     replyToMode: prepared.replyToMode,
   });
   const forcedReplyThreadTs = prepared.forcedReplyThreadTs;
+  const slackMessageMetadata = prepared.slackMessageMetadata;
   const statusThreadTs = forcedReplyThreadTs ?? threadTargets.statusThreadTs;
   const isThreadReply = threadTargets.isThreadReply;
   const replyDeliveryMode = forcedReplyThreadTs ? "off" : prepared.replyToMode;
@@ -631,6 +632,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         replyThreadTs: session.threadTs,
         replyToMode: replyDeliveryMode,
         ...(slackIdentity ? { identity: slackIdentity } : {}),
+        ...(slackMessageMetadata ? { metadata: slackMessageMetadata } : {}),
       });
       markSlackStreamFallbackDelivered(session);
       observedReplyDelivery = true;
@@ -676,6 +678,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       replyThreadTs,
       replyToMode: replyDeliveryMode,
       ...(slackIdentity ? { identity: slackIdentity } : {}),
+      ...(slackMessageMetadata ? { metadata: slackMessageMetadata } : {}),
     });
     observedReplyDelivery = true;
     const deliveredThreadTs = resolveDeliveredSlackReplyThreadTs({
@@ -982,6 +985,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         token: ctx.botToken,
         accountId: account.accountId,
         identity: slackIdentity,
+        ...(slackMessageMetadata ? { metadata: slackMessageMetadata } : {}),
         maxChars: Math.min(ctx.textLimit, SLACK_TEXT_LIMIT),
         resolveThreadTs: () => {
           const ts = replyPlan.peekThreadTs();
@@ -1328,7 +1332,10 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   const finalStream = streamSession as SlackStreamSession | null;
   if (finalStream && !finalStream.stopped) {
     try {
-      await stopSlackStream({ session: finalStream });
+      await stopSlackStream({
+        session: finalStream,
+        ...(slackMessageMetadata ? { metadata: slackMessageMetadata } : {}),
+      });
     } catch (err) {
       if (err instanceof SlackStreamNotDeliveredError) {
         streamFallbackDelivered = await deliverPendingStreamFallback(finalStream, err);

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -392,10 +392,14 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     }
   }
 
-  const { statusThreadTs, isThreadReply } = resolveSlackThreadTargets({
+  const threadTargets = resolveSlackThreadTargets({
     message,
     replyToMode: prepared.replyToMode,
   });
+  const forcedReplyThreadTs = prepared.forcedReplyThreadTs;
+  const statusThreadTs = forcedReplyThreadTs ?? threadTargets.statusThreadTs;
+  const isThreadReply = threadTargets.isThreadReply;
+  const replyDeliveryMode = forcedReplyThreadTs ? "off" : prepared.replyToMode;
   const sourceReplyDeliveryMode = resolveChannelMessageSourceReplyDeliveryMode({
     cfg,
     ctx: prepared.ctxPayload,
@@ -462,11 +466,11 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   // mark this to ensure only the first reply is threaded.
   const hasRepliedRef = { value: false };
   const replyPlan = createSlackReplyDeliveryPlan({
-    replyToMode: prepared.replyToMode,
-    incomingThreadTs,
+    replyToMode: replyDeliveryMode,
+    incomingThreadTs: forcedReplyThreadTs ?? incomingThreadTs,
     messageTs,
     hasRepliedRef,
-    isThreadReply,
+    isThreadReply: Boolean(forcedReplyThreadTs) || isThreadReply,
   });
 
   const typingTarget = statusThreadTs ? `${message.channel}/${statusThreadTs}` : message.channel;
@@ -537,12 +541,14 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     streaming: account.config.streaming,
     nativeStreaming: resolveChannelStreamingNativeTransport(account.config),
   });
-  const streamThreadHint = resolveSlackStreamingThreadHint({
-    replyToMode: prepared.replyToMode,
-    incomingThreadTs,
-    messageTs,
-    isThreadReply,
-  });
+  const streamThreadHint =
+    forcedReplyThreadTs ??
+    resolveSlackStreamingThreadHint({
+      replyToMode: replyDeliveryMode,
+      incomingThreadTs,
+      messageTs,
+      isThreadReply,
+    });
   const previewStreamingEnabled =
     !sourceRepliesAreToolOnly &&
     shouldEnableSlackPreviewStreaming({
@@ -623,7 +629,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         runtime,
         textLimit: ctx.textLimit,
         replyThreadTs: session.threadTs,
-        replyToMode: prepared.replyToMode,
+        replyToMode: replyDeliveryMode,
         ...(slackIdentity ? { identity: slackIdentity } : {}),
       });
       markSlackStreamFallbackDelivered(session);
@@ -668,12 +674,12 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       runtime,
       textLimit: ctx.textLimit,
       replyThreadTs,
-      replyToMode: prepared.replyToMode,
+      replyToMode: replyDeliveryMode,
       ...(slackIdentity ? { identity: slackIdentity } : {}),
     });
     observedReplyDelivery = true;
     const deliveredThreadTs = resolveDeliveredSlackReplyThreadTs({
-      replyToMode: prepared.replyToMode,
+      replyToMode: replyDeliveryMode,
       payloadReplyToId: params.payload.replyToId,
       replyThreadTs,
     });

--- a/extensions/slack/src/monitor/message-handler/prepare-routing.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-routing.ts
@@ -156,7 +156,7 @@ export function resolveSlackRoutingContext(params: {
   isRoom: boolean;
   isRoomish: boolean;
   seedTopLevelRoomThread?: boolean;
-  isAssistantThread?: boolean;
+  assistantThreadTs?: string;
 }): SlackRoutingContext {
   const {
     ctx,
@@ -167,7 +167,7 @@ export function resolveSlackRoutingContext(params: {
     isRoom,
     isRoomish,
     seedTopLevelRoomThread,
-    isAssistantThread,
+    assistantThreadTs,
   } = params;
   let route = resolveSlackInitialAgentRoute({
     ctx,
@@ -205,7 +205,7 @@ export function resolveSlackRoutingContext(params: {
       ? seedCandidateThreadId
       : undefined;
   const roomThreadId = isThreadReply && threadTs ? threadTs : undefined;
-  const assistantThreadId = isAssistantThread ? (threadTs ?? threadContext.messageTs) : undefined;
+  const assistantThreadId = assistantThreadTs;
   // DM threads are a UI affordance, not a session boundary. Route all DM
   // messages, including thread replies, to the user's main DM session so
   // the agent sees them as part of the existing conversation. Slack assistant

--- a/extensions/slack/src/monitor/message-handler/prepare-routing.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-routing.ts
@@ -156,6 +156,7 @@ export function resolveSlackRoutingContext(params: {
   isRoom: boolean;
   isRoomish: boolean;
   seedTopLevelRoomThread?: boolean;
+  isAssistantThread?: boolean;
 }): SlackRoutingContext {
   const {
     ctx,
@@ -166,6 +167,7 @@ export function resolveSlackRoutingContext(params: {
     isRoom,
     isRoomish,
     seedTopLevelRoomThread,
+    isAssistantThread,
   } = params;
   let route = resolveSlackInitialAgentRoute({
     ctx,
@@ -203,11 +205,14 @@ export function resolveSlackRoutingContext(params: {
       ? seedCandidateThreadId
       : undefined;
   const roomThreadId = isThreadReply && threadTs ? threadTs : undefined;
+  const assistantThreadId = isAssistantThread ? (threadTs ?? threadContext.messageTs) : undefined;
   // DM threads are a UI affordance, not a session boundary. Route all DM
   // messages, including thread replies, to the user's main DM session so
-  // the agent sees them as part of the existing conversation.
+  // the agent sees them as part of the existing conversation. Slack assistant
+  // threads are the exception: Slack treats each assistant thread as its own
+  // conversation and sends the lifecycle context only on assistant events.
   const canonicalThreadId = isDirectMessage
-    ? undefined
+    ? assistantThreadId
     : isRoomish
       ? roomThreadId
       : isThreadReply

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -208,7 +208,6 @@ describe("slack prepareSlackMessage inbound contract", () => {
       createSlackAccount({ replyToMode: "all" }),
       createSlackMessage({
         ts: "10.100",
-        thread_ts: "10.000",
         parent_user_id: "B1",
         text: "assistant thread message",
         assistant_thread: {
@@ -225,11 +224,207 @@ describe("slack prepareSlackMessage inbound contract", () => {
     assertPrepared(prepared);
     const payload = prepared.ctxPayload as typeof prepared.ctxPayload & Record<string, unknown>;
     expect(prepared.ctxPayload.SessionKey).toBe("agent:main:main:thread:10.000");
+    expect(prepared.ctxPayload.MessageThreadId).toBe("10.000");
     expect(prepared.forcedReplyThreadTs).toBe("10.000");
     expect(payload.SlackAssistantThread).toBe(true);
     expect(payload.SlackAssistantThreadContextChannelId).toBe("C999");
     expect(payload.SlackAssistantThreadContextTeamId).toBe("T1");
     expect(prepared.ctxPayload.TransportThreadId).toBeUndefined();
+  });
+
+  it("prefers Slack assistant message context over stale lifecycle cache", async () => {
+    const ctx = createDefaultSlackCtx();
+    ctx.saveSlackAssistantThreadContext({
+      assistantChannelId: "D123",
+      threadTs: "10.000",
+      userId: "U1",
+      channelId: "C_OLD",
+      teamId: "T_OLD",
+    });
+
+    const prepared = await prepareMessageWith(
+      ctx,
+      createSlackAccount({ replyToMode: "all" }),
+      createSlackMessage({
+        ts: "10.100",
+        thread_ts: "10.000",
+        parent_user_id: "B1",
+        text: "assistant thread after context update",
+        assistant_thread: {
+          channel_id: "D123",
+          thread_ts: "10.000",
+          user_id: "U1",
+          context: {
+            channel_id: "C_NEW",
+            team_id: "T_NEW",
+          },
+        },
+      }),
+    );
+
+    assertPrepared(prepared);
+    const payload = prepared.ctxPayload as typeof prepared.ctxPayload & Record<string, unknown>;
+    expect(payload.SlackAssistantThreadContextChannelId).toBe("C_NEW");
+    expect(payload.SlackAssistantThreadContextTeamId).toBe("T_NEW");
+    expect(ctx.getSlackAssistantThreadContext("D123", "10.000")).toMatchObject({
+      channelId: "C_NEW",
+      teamId: "T_NEW",
+    });
+  });
+
+  it("preserves cached Slack assistant context when the message marker is partial", async () => {
+    const ctx = createDefaultSlackCtx();
+    ctx.saveSlackAssistantThreadContext({
+      assistantChannelId: "D123",
+      threadTs: "10.000",
+      userId: "U1",
+      channelId: "C_CACHED",
+      teamId: "T_CACHED",
+      enterpriseId: "E_CACHED",
+    });
+
+    const prepared = await prepareMessageWith(
+      ctx,
+      createSlackAccount({ replyToMode: "all" }),
+      createSlackMessage({
+        ts: "10.100",
+        thread_ts: "10.000",
+        parent_user_id: "B1",
+        text: "assistant thread marker without context",
+        assistant_thread: {
+          channel_id: "D123",
+          thread_ts: "10.000",
+          user_id: "U1",
+        },
+      }),
+    );
+
+    assertPrepared(prepared);
+    const payload = prepared.ctxPayload as typeof prepared.ctxPayload & Record<string, unknown>;
+    expect(payload.SlackAssistantThreadContextChannelId).toBe("C_CACHED");
+    expect(payload.SlackAssistantThreadContextTeamId).toBe("T_CACHED");
+    expect(payload.SlackAssistantThreadContextEnterpriseId).toBe("E_CACHED");
+    expect(prepared.slackMessageMetadata).toEqual({
+      event_type: "assistant_thread_context",
+      event_payload: {
+        channel_id: "C_CACHED",
+        team_id: "T_CACHED",
+        enterprise_id: "E_CACHED",
+      },
+    });
+  });
+
+  it("restores Slack assistant DM thread context from Slack message metadata", async () => {
+    const replies = vi.fn().mockResolvedValue({
+      messages: [
+        {
+          user: "B1",
+          metadata: {
+            event_type: "assistant_thread_context",
+            event_payload: {
+              channel_id: "C999",
+              team_id: "T1",
+              enterprise_id: "E1",
+            },
+          },
+        },
+      ],
+      response_metadata: { next_cursor: "" },
+    });
+    const ctx = createInboundSlackCtx({
+      cfg: {
+        channels: { slack: { enabled: true } },
+      } as OpenClawConfig,
+      appClient: { conversations: { replies } } as unknown as App["client"],
+    });
+
+    const prepared = await prepareMessageWith(
+      ctx,
+      createSlackAccount({ replyToMode: "all" }),
+      createSlackMessage({
+        ts: "10.100",
+        thread_ts: "10.000",
+        parent_user_id: "B1",
+        text: "assistant thread after restart",
+      }),
+    );
+
+    assertPrepared(prepared);
+    const payload = prepared.ctxPayload as typeof prepared.ctxPayload & Record<string, unknown>;
+    expect(replies).toHaveBeenCalledWith({
+      channel: "D123",
+      ts: "10.000",
+      oldest: "10.000",
+      include_all_metadata: true,
+      limit: 4,
+    });
+    expect(prepared.ctxPayload.SessionKey).toBe("agent:main:main:thread:10.000");
+    expect(prepared.ctxPayload.MessageThreadId).toBe("10.000");
+    expect(prepared.forcedReplyThreadTs).toBe("10.000");
+    expect(prepared.slackMessageMetadata).toEqual({
+      event_type: "assistant_thread_context",
+      event_payload: {
+        channel_id: "C999",
+        team_id: "T1",
+        enterprise_id: "E1",
+      },
+    });
+    expect(payload.SlackAssistantThread).toBe(true);
+    expect(payload.SlackAssistantThreadContextChannelId).toBe("C999");
+    expect(payload.SlackAssistantThreadContextTeamId).toBe("T1");
+    expect(payload.SlackAssistantThreadContextEnterpriseId).toBe("E1");
+    expect(prepared.ctxPayload.TransportThreadId).toBeUndefined();
+  });
+
+  it("restores Slack assistant metadata from the updated anchor message", async () => {
+    const replies = vi.fn().mockResolvedValue({
+      messages: [
+        {
+          user: "B1",
+          metadata: {
+            event_type: "assistant_thread_context",
+            event_payload: { channel_id: "C_NEW", team_id: "T_NEW" },
+          },
+        },
+        {
+          user: "B1",
+          metadata: {
+            event_type: "assistant_thread_context",
+            event_payload: { channel_id: "C_OLD", team_id: "T_OLD" },
+          },
+        },
+      ],
+      response_metadata: { next_cursor: "" },
+    });
+    const ctx = createInboundSlackCtx({
+      cfg: {
+        channels: { slack: { enabled: true } },
+      } as OpenClawConfig,
+      appClient: { conversations: { replies } } as unknown as App["client"],
+    });
+
+    const prepared = await prepareMessageWith(
+      ctx,
+      createSlackAccount({ replyToMode: "all" }),
+      createSlackMessage({
+        ts: "10.200",
+        thread_ts: "10.000",
+        parent_user_id: "B1",
+        text: "assistant thread after another context change",
+      }),
+    );
+
+    assertPrepared(prepared);
+    const payload = prepared.ctxPayload as typeof prepared.ctxPayload & Record<string, unknown>;
+    expect(payload.SlackAssistantThreadContextChannelId).toBe("C_NEW");
+    expect(payload.SlackAssistantThreadContextTeamId).toBe("T_NEW");
+    expect(prepared.slackMessageMetadata).toEqual({
+      event_type: "assistant_thread_context",
+      event_payload: {
+        channel_id: "C_NEW",
+        team_id: "T_NEW",
+      },
+    });
   });
 
   function createThreadSlackCtx(params: { cfg: OpenClawConfig; replies: unknown }) {

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -168,6 +168,70 @@ describe("slack prepareSlackMessage inbound contract", () => {
     });
   });
 
+  it("keeps Slack assistant DM threads in a thread-scoped session with assistant context", async () => {
+    const ctx = createDefaultSlackCtx();
+    ctx.saveSlackAssistantThreadContext({
+      assistantChannelId: "D123",
+      threadTs: "10.000",
+      userId: "U1",
+      channelId: "C999",
+      teamId: "T1",
+      enterpriseId: "E1",
+    });
+
+    const prepared = await prepareMessageWith(
+      ctx,
+      createSlackAccount({ replyToMode: "all" }),
+      createSlackMessage({
+        ts: "10.100",
+        thread_ts: "10.000",
+        parent_user_id: "B1",
+        text: "assistant thread message",
+      }),
+    );
+
+    assertPrepared(prepared);
+    const payload = prepared.ctxPayload as typeof prepared.ctxPayload & Record<string, unknown>;
+    expect(prepared.ctxPayload.SessionKey).toBe("agent:main:main:thread:10.000");
+    expect(prepared.ctxPayload.MessageThreadId).toBe("10.000");
+    expect(prepared.forcedReplyThreadTs).toBe("10.000");
+    expect(payload.SlackAssistantThread).toBe(true);
+    expect(payload.SlackAssistantThreadContextChannelId).toBe("C999");
+    expect(payload.SlackAssistantThreadContextTeamId).toBe("T1");
+    expect(payload.SlackAssistantThreadContextEnterpriseId).toBe("E1");
+    expect(prepared.ctxPayload.TransportThreadId).toBeUndefined();
+  });
+
+  it("routes Slack assistant DM threads from the message marker without lifecycle cache", async () => {
+    const prepared = await prepareMessageWith(
+      createDefaultSlackCtx(),
+      createSlackAccount({ replyToMode: "all" }),
+      createSlackMessage({
+        ts: "10.100",
+        thread_ts: "10.000",
+        parent_user_id: "B1",
+        text: "assistant thread message",
+        assistant_thread: {
+          channel_id: "D123",
+          thread_ts: "10.000",
+          context: {
+            channel_id: "C999",
+            team_id: "T1",
+          },
+        },
+      }),
+    );
+
+    assertPrepared(prepared);
+    const payload = prepared.ctxPayload as typeof prepared.ctxPayload & Record<string, unknown>;
+    expect(prepared.ctxPayload.SessionKey).toBe("agent:main:main:thread:10.000");
+    expect(prepared.forcedReplyThreadTs).toBe("10.000");
+    expect(payload.SlackAssistantThread).toBe(true);
+    expect(payload.SlackAssistantThreadContextChannelId).toBe("C999");
+    expect(payload.SlackAssistantThreadContextTeamId).toBe("T1");
+    expect(prepared.ctxPayload.TransportThreadId).toBeUndefined();
+  });
+
   function createThreadSlackCtx(params: { cfg: OpenClawConfig; replies: unknown }) {
     return createInboundSlackCtx({
       cfg: params.cfg,

--- a/extensions/slack/src/monitor/message-handler/prepare.thread-session-key.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.thread-session-key.test.ts
@@ -559,7 +559,7 @@ describe("thread-level session keys", () => {
       isGroupDm: false,
       isRoom: false,
       isRoomish: false,
-      isAssistantThread: true,
+      assistantThreadTs: "1770408530.000000",
     });
 
     expect(routing.sessionKey).toBe("agent:main:slack:direct:u3:thread:1770408530.000000");

--- a/extensions/slack/src/monitor/message-handler/prepare.thread-session-key.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.thread-session-key.test.ts
@@ -539,6 +539,33 @@ describe("thread-level session keys", () => {
     expect(routing.sessionKey).not.toContain(":thread:");
   });
 
+  it("routes Slack assistant DM threads to a thread-scoped session", () => {
+    const ctx = buildCtx({ replyToMode: "all", dmScope: "per-channel-peer" });
+    const account = buildAccount("all");
+
+    const routing = resolveSlackRoutingContext({
+      ctx,
+      account,
+      message: {
+        channel: "D456",
+        channel_type: "im",
+        user: "U3",
+        text: "assistant reply",
+        ts: "1770408540.000000",
+        thread_ts: "1770408530.000000",
+        parent_user_id: "B1",
+      } as SlackMessageEvent,
+      isDirectMessage: true,
+      isGroupDm: false,
+      isRoom: false,
+      isRoomish: false,
+      isAssistantThread: true,
+    });
+
+    expect(routing.sessionKey).toBe("agent:main:slack:direct:u3:thread:1770408530.000000");
+    expect(routing.threadContext.messageThreadId).toBe("1770408530.000000");
+  });
+
   it("routes DM thread replies through explicit runtime conversation bindings", () => {
     const targetSessionKey = "agent:review:acp:session-slack-dm";
     const binding: SessionBindingRecord = {

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -51,7 +51,9 @@ import {
   resolveStorePath,
 } from "../config.runtime.js";
 import {
+  buildSlackAssistantThreadMetadata,
   normalizeSlackChannelType,
+  parseSlackAssistantThreadMetadata,
   resolveSlackChatType,
   type SlackAssistantThreadContext,
   type SlackMonitorContext,
@@ -91,6 +93,45 @@ function recordString(
   return normalizeOptionalString(record?.[key]);
 }
 
+function recordNullableString(
+  record: Record<string, unknown> | undefined,
+  key: string,
+): string | null | undefined {
+  if (!record || !(key in record)) {
+    return undefined;
+  }
+  if (record[key] === null) {
+    return null;
+  }
+  return normalizeOptionalString(record[key]);
+}
+
+function mergeSlackAssistantThreadContext(
+  primary: Omit<SlackAssistantThreadContext, "updatedAt"> | undefined,
+  fallback: Omit<SlackAssistantThreadContext, "updatedAt"> | undefined,
+): Omit<SlackAssistantThreadContext, "updatedAt"> | undefined {
+  if (!primary) {
+    return fallback;
+  }
+  if (!fallback) {
+    return primary;
+  }
+  return {
+    assistantChannelId: primary.assistantChannelId || fallback.assistantChannelId,
+    threadTs: primary.threadTs || fallback.threadTs,
+    userId: primary.userId ?? fallback.userId,
+    channelId: primary.channelId ?? fallback.channelId,
+    teamId: primary.teamId ?? fallback.teamId,
+    enterpriseId: primary.enterpriseId !== undefined ? primary.enterpriseId : fallback.enterpriseId,
+  };
+}
+
+function hasSlackAssistantThreadMetadata(
+  context: Omit<SlackAssistantThreadContext, "updatedAt"> | undefined,
+): boolean {
+  return Boolean(context?.channelId || context?.teamId || context?.enterpriseId !== undefined);
+}
+
 function resolveSlackMessageAssistantThreadContext(
   message: SlackMessageEvent,
 ): Omit<SlackAssistantThreadContext, "updatedAt"> | undefined {
@@ -110,8 +151,56 @@ function resolveSlackMessageAssistantThreadContext(
     userId: recordString(thread, "user_id") ?? message.user,
     channelId: recordString(context, "channel_id"),
     teamId: recordString(context, "team_id"),
-    enterpriseId: recordString(context, "enterprise_id"),
+    enterpriseId: recordNullableString(context, "enterprise_id"),
   };
+}
+
+async function restoreSlackAssistantThreadContextFromMetadata(params: {
+  ctx: SlackMonitorContext;
+  message: SlackMessageEvent;
+}): Promise<Omit<SlackAssistantThreadContext, "updatedAt"> | undefined> {
+  const threadTs = params.message.thread_ts;
+  const parentUserId = params.message.parent_user_id?.trim();
+  if (
+    !params.message.channel ||
+    !threadTs ||
+    !parentUserId ||
+    (parentUserId !== params.ctx.botUserId && parentUserId !== params.ctx.botId)
+  ) {
+    return undefined;
+  }
+  try {
+    const response = (await params.ctx.app.client.conversations.replies({
+      channel: params.message.channel,
+      ts: threadTs,
+      oldest: threadTs,
+      include_all_metadata: true,
+      limit: 4,
+    })) as {
+      messages?: Array<{
+        metadata?: unknown;
+      }>;
+    };
+    for (const message of response.messages ?? []) {
+      const context = parseSlackAssistantThreadMetadata(message.metadata);
+      if (!context) {
+        continue;
+      }
+      return {
+        assistantChannelId: params.message.channel,
+        threadTs,
+        userId: params.message.user,
+        channelId: context.channelId,
+        teamId: context.teamId,
+        enterpriseId: context.enterpriseId,
+      };
+    }
+  } catch (err) {
+    logVerbose(
+      `slack assistant context restore failed channel=${params.message.channel} ts=${threadTs}: ${formatErrorMessage(err)}`,
+    );
+  }
+  return undefined;
 }
 
 function resolveCachedMentionRegexes(
@@ -574,10 +663,33 @@ export async function prepareSlackMessage(params: {
       ? "group"
       : "channel";
   const messageAssistantThreadContext = resolveSlackMessageAssistantThreadContext(message);
-  const assistantThreadContext = isDirectMessage
-    ? (ctx.getSlackAssistantThreadContext(message.channel, message.thread_ts ?? message.ts) ??
-      messageAssistantThreadContext)
+  const assistantContextLookupChannelId =
+    messageAssistantThreadContext?.assistantChannelId ?? message.channel;
+  const assistantContextLookupThreadTs =
+    messageAssistantThreadContext?.threadTs ?? message.thread_ts ?? message.ts;
+  const cachedAssistantThreadContext = isDirectMessage
+    ? ctx.getSlackAssistantThreadContext(
+        assistantContextLookupChannelId,
+        assistantContextLookupThreadTs,
+      )
     : undefined;
+  const restoredAssistantThreadContext =
+    isDirectMessage &&
+    !cachedAssistantThreadContext &&
+    !hasSlackAssistantThreadMetadata(messageAssistantThreadContext)
+      ? await restoreSlackAssistantThreadContextFromMetadata({ ctx, message })
+      : undefined;
+  const assistantThreadContext = mergeSlackAssistantThreadContext(
+    messageAssistantThreadContext,
+    cachedAssistantThreadContext ?? restoredAssistantThreadContext,
+  );
+  const assistantThreadContextToCache =
+    messageAssistantThreadContext || restoredAssistantThreadContext
+      ? assistantThreadContext
+      : undefined;
+  if (assistantThreadContextToCache) {
+    ctx.saveSlackAssistantThreadContext(assistantThreadContextToCache);
+  }
   const willImplicitlyThreadReply =
     isRoom && !channelRequireMention && resolveSlackReplyToMode(account, channelChatType) !== "off";
   const seedTopLevelRoomThreadBySource =
@@ -594,7 +706,7 @@ export async function prepareSlackMessage(params: {
     isRoom,
     isRoomish,
     seedTopLevelRoomThread: seedTopLevelRoomThreadBySource,
-    isAssistantThread: Boolean(assistantThreadContext),
+    assistantThreadTs: assistantThreadContext?.threadTs,
   });
 
   const resolveWasMentioned = (mentionRegexes: RegExp[]) =>
@@ -632,7 +744,7 @@ export async function prepareSlackMessage(params: {
       isRoom,
       isRoomish,
       seedTopLevelRoomThread: true,
-      isAssistantThread: Boolean(assistantThreadContext),
+      assistantThreadTs: assistantThreadContext?.threadTs,
     });
     mentionRegexes = resolveCachedMentionRegexes(ctx, routing.route.agentId);
     wasMentioned = resolveWasMentioned(mentionRegexes);
@@ -1109,6 +1221,8 @@ export async function prepareSlackMessage(params: {
   const commandBody = textForCommandDetection.trim();
   const supplementalThreadHistoryBody =
     directThreadRoutedToDmSession && !threadHistoryBody ? threadStarterBody : threadHistoryBody;
+  const effectiveMessageThreadId =
+    assistantThreadContext?.threadTs ?? threadContext.messageThreadId;
 
   const ctxPayload = buildChannelTurnContext({
     channel: "slack",
@@ -1128,7 +1242,7 @@ export async function prepareSlackMessage(params: {
       id: message.channel,
       label: envelopeFrom,
       spaceId: ctx.teamId || undefined,
-      threadId: directThreadRoutedToDmSession ? undefined : threadContext.messageThreadId,
+      threadId: directThreadRoutedToDmSession ? undefined : effectiveMessageThreadId,
       nativeChannelId: message.channel,
       routePeer: {
         kind: chatType,
@@ -1145,7 +1259,7 @@ export async function prepareSlackMessage(params: {
       to: slackTo,
       originatingTo: slackTo,
       replyToId: threadContext.replyToId,
-      messageThreadId: directThreadRoutedToDmSession ? undefined : threadContext.messageThreadId,
+      messageThreadId: directThreadRoutedToDmSession ? undefined : effectiveMessageThreadId,
       nativeChannelId: message.channel,
     },
     message: {
@@ -1265,7 +1379,7 @@ export async function prepareSlackMessage(params: {
               channel: "slack",
               to: `user:${message.user}`,
               accountId: route.accountId,
-              threadId: threadContext.messageThreadId,
+              threadId: effectiveMessageThreadId,
               mainDmOwnerPin:
                 pinnedMainDmOwner && message.user
                   ? {
@@ -1310,6 +1424,9 @@ export async function prepareSlackMessage(params: {
     replyToMode,
     ...(assistantThreadContext?.threadTs
       ? { forcedReplyThreadTs: assistantThreadContext.threadTs }
+      : {}),
+    ...(assistantThreadContext
+      ? { slackMessageMetadata: buildSlackAssistantThreadMetadata(assistantThreadContext) }
       : {}),
     requireMention: shouldRequireMention,
     isDirectMessage,

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -53,6 +53,7 @@ import {
 import {
   normalizeSlackChannelType,
   resolveSlackChatType,
+  type SlackAssistantThreadContext,
   type SlackMonitorContext,
 } from "../context.js";
 import { resolveConversationLabel } from "../conversation.runtime.js";
@@ -76,6 +77,42 @@ const SLACK_HISTORY_MEDIA_MAX_ATTACHMENTS = 4;
 const SLACK_HISTORY_MEDIA_MAX_BYTES = 10 * 1024 * 1024;
 const SLACK_HISTORY_MEDIA_IDLE_TIMEOUT_MS = 1_000;
 const SLACK_HISTORY_MEDIA_TOTAL_TIMEOUT_MS = 3_000;
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function recordString(
+  record: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  return normalizeOptionalString(record?.[key]);
+}
+
+function resolveSlackMessageAssistantThreadContext(
+  message: SlackMessageEvent,
+): Omit<SlackAssistantThreadContext, "updatedAt"> | undefined {
+  const thread = asRecord(message.assistant_thread);
+  if (!thread) {
+    return undefined;
+  }
+  const context = asRecord(thread.context);
+  const assistantChannelId = recordString(thread, "channel_id") ?? message.channel;
+  const threadTs = recordString(thread, "thread_ts") ?? message.thread_ts ?? message.ts;
+  if (!assistantChannelId || !threadTs) {
+    return undefined;
+  }
+  return {
+    assistantChannelId,
+    threadTs,
+    userId: recordString(thread, "user_id") ?? message.user,
+    channelId: recordString(context, "channel_id"),
+    teamId: recordString(context, "team_id"),
+    enterpriseId: recordString(context, "enterprise_id"),
+  };
+}
 
 function resolveCachedMentionRegexes(
   ctx: SlackMonitorContext,
@@ -536,6 +573,11 @@ export async function prepareSlackMessage(params: {
     : isGroupDm
       ? "group"
       : "channel";
+  const messageAssistantThreadContext = resolveSlackMessageAssistantThreadContext(message);
+  const assistantThreadContext = isDirectMessage
+    ? (ctx.getSlackAssistantThreadContext(message.channel, message.thread_ts ?? message.ts) ??
+      messageAssistantThreadContext)
+    : undefined;
   const willImplicitlyThreadReply =
     isRoom && !channelRequireMention && resolveSlackReplyToMode(account, channelChatType) !== "off";
   const seedTopLevelRoomThreadBySource =
@@ -552,6 +594,7 @@ export async function prepareSlackMessage(params: {
     isRoom,
     isRoomish,
     seedTopLevelRoomThread: seedTopLevelRoomThreadBySource,
+    isAssistantThread: Boolean(assistantThreadContext),
   });
 
   const resolveWasMentioned = (mentionRegexes: RegExp[]) =>
@@ -589,6 +632,7 @@ export async function prepareSlackMessage(params: {
       isRoom,
       isRoomish,
       seedTopLevelRoomThread: true,
+      isAssistantThread: Boolean(assistantThreadContext),
     });
     mentionRegexes = resolveCachedMentionRegexes(ctx, routing.route.agentId);
     wasMentioned = resolveWasMentioned(mentionRegexes);
@@ -638,6 +682,7 @@ export async function prepareSlackMessage(params: {
     }
   }
   const directThreadRoutedToDmSession =
+    !assistantThreadContext &&
     isDirectMessage &&
     isThreadReply &&
     threadTs &&
@@ -1146,6 +1191,10 @@ export async function prepareSlackMessage(params: {
       GroupSubject: isRoomish ? roomLabel : undefined,
       UntrustedContext: untrustedChannelMetadata ? [untrustedChannelMetadata] : undefined,
       TransportThreadId: directThreadRoutedToDmSession ? threadContext.messageThreadId : undefined,
+      SlackAssistantThread: assistantThreadContext ? true : undefined,
+      SlackAssistantThreadContextChannelId: assistantThreadContext?.channelId,
+      SlackAssistantThreadContextTeamId: assistantThreadContext?.teamId,
+      SlackAssistantThreadContextEnterpriseId: assistantThreadContext?.enterpriseId ?? undefined,
       IsFirstThreadTurn:
         isThreadReply &&
         threadTs &&
@@ -1259,6 +1308,9 @@ export async function prepareSlackMessage(params: {
           : undefined,
     },
     replyToMode,
+    ...(assistantThreadContext?.threadTs
+      ? { forcedReplyThreadTs: assistantThreadContext.threadTs }
+      : {}),
     requireMention: shouldRequireMention,
     isDirectMessage,
     isRoomish,

--- a/extensions/slack/src/monitor/message-handler/types.ts
+++ b/extensions/slack/src/monitor/message-handler/types.ts
@@ -1,3 +1,4 @@
+import type { MessageMetadata } from "@slack/types";
 import type { HistoryEntry } from "openclaw/plugin-sdk/reply-history";
 import type { FinalizedMsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
@@ -26,6 +27,7 @@ export type PreparedSlackMessage = {
   };
   replyToMode: "off" | "first" | "all" | "batched";
   forcedReplyThreadTs?: string;
+  slackMessageMetadata?: MessageMetadata;
   requireMention: boolean;
   isDirectMessage: boolean;
   isRoomish: boolean;

--- a/extensions/slack/src/monitor/message-handler/types.ts
+++ b/extensions/slack/src/monitor/message-handler/types.ts
@@ -25,6 +25,7 @@ export type PreparedSlackMessage = {
     };
   };
   replyToMode: "off" | "first" | "all" | "batched";
+  forcedReplyThreadTs?: string;
   requireMention: boolean;
   isDirectMessage: boolean;
   isRoomish: boolean;

--- a/extensions/slack/src/monitor/replies.ts
+++ b/extensions/slack/src/monitor/replies.ts
@@ -1,3 +1,4 @@
+import type { MessageMetadata } from "@slack/types";
 import type { MarkdownTableMode, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   chunkMarkdownTextWithMode,
@@ -43,6 +44,7 @@ export async function deliverReplies(params: {
   replyThreadTs?: string;
   replyToMode: "off" | "first" | "all" | "batched";
   identity?: SlackSendIdentity;
+  metadata?: MessageMetadata;
 }) {
   for (const payload of params.replies) {
     const threadTs = resolveDeliveredSlackReplyThreadTs({
@@ -71,6 +73,7 @@ export async function deliverReplies(params: {
         accountId: params.accountId,
         ...(slackBlocks?.length ? { blocks: slackBlocks } : {}),
         ...(params.identity ? { identity: params.identity } : {}),
+        ...(params.metadata ? { metadata: params.metadata } : {}),
       });
       params.runtime.log?.(`delivered reply to ${params.target}`);
       continue;
@@ -95,6 +98,7 @@ export async function deliverReplies(params: {
           threadTs,
           accountId: params.accountId,
           ...(params.identity ? { identity: params.identity } : {}),
+          ...(params.metadata ? { metadata: params.metadata } : {}),
         });
       },
       sendMedia: async ({ mediaUrl, caption }) => {
@@ -105,6 +109,7 @@ export async function deliverReplies(params: {
           threadTs,
           accountId: params.accountId,
           ...(params.identity ? { identity: params.identity } : {}),
+          ...(params.metadata ? { metadata: params.metadata } : {}),
         });
       },
     });

--- a/extensions/slack/src/send.ts
+++ b/extensions/slack/src/send.ts
@@ -1,3 +1,4 @@
+import type { MessageMetadata } from "@slack/types";
 import { type Block, type KnownBlock, type WebClient } from "@slack/web-api";
 import {
   createMessageReceiptFromOutboundResults,
@@ -85,6 +86,7 @@ type SlackBasePostMessagePayload = SlackPostThreadPayload & {
   channel: string;
   text: string;
   blocks?: (Block | KnownBlock)[];
+  metadata?: MessageMetadata;
   unfurl_links?: boolean;
   unfurl_media?: boolean;
 };
@@ -107,6 +109,7 @@ type SlackSendOpts = {
   replyBroadcast?: boolean;
   identity?: SlackSendIdentity;
   blocks?: (Block | KnownBlock)[];
+  metadata?: MessageMetadata;
 };
 
 type SlackWebApiErrorData = {
@@ -142,6 +145,7 @@ function buildSlackPostMessagePayload(params: {
   threadTs?: string;
   replyBroadcast?: boolean;
   blocks?: (Block | KnownBlock)[];
+  metadata?: MessageMetadata;
   unfurl?: SlackUnfurlOptions;
 }): SlackBasePostMessagePayload {
   const threadPayload =
@@ -156,6 +160,7 @@ function buildSlackPostMessagePayload(params: {
       channel: params.channelId,
       text: params.text,
       blocks: params.blocks,
+      ...(params.metadata ? { metadata: params.metadata } : {}),
       ...threadPayload,
       ...unfurlPayload,
     };
@@ -163,6 +168,7 @@ function buildSlackPostMessagePayload(params: {
   return {
     channel: params.channelId,
     text: params.text,
+    ...(params.metadata ? { metadata: params.metadata } : {}),
     ...threadPayload,
     ...unfurlPayload,
   };
@@ -313,6 +319,7 @@ async function postSlackMessageBestEffort(params: {
   replyBroadcast?: boolean;
   identity?: SlackSendIdentity;
   blocks?: (Block | KnownBlock)[];
+  metadata?: MessageMetadata;
   unfurl?: SlackUnfurlOptions;
 }) {
   const basePayload = buildSlackPostMessagePayload(params);
@@ -719,6 +726,7 @@ async function sendMessageSlackQueuedInner(params: {
       replyBroadcast: opts.replyBroadcast,
       identity: opts.identity,
       blocks,
+      metadata: opts.metadata,
       unfurl,
     });
     const messageId = response.ts ?? "unknown";
@@ -782,6 +790,7 @@ async function sendMessageSlackQueuedInner(params: {
         threadTs: opts.threadTs,
         replyBroadcast: sentMessageIds.length === 0 ? opts.replyBroadcast : undefined,
         identity: opts.identity,
+        metadata: sentMessageIds.length === 0 ? opts.metadata : undefined,
         unfurl,
       });
       lastMessageId = response.ts ?? lastMessageId;
@@ -798,6 +807,7 @@ async function sendMessageSlackQueuedInner(params: {
         threadTs: opts.threadTs,
         replyBroadcast: sentMessageIds.length === 0 ? opts.replyBroadcast : undefined,
         identity: opts.identity,
+        metadata: sentMessageIds.length === 0 ? opts.metadata : undefined,
         unfurl,
       });
       lastMessageId = response.ts ?? lastMessageId;

--- a/extensions/slack/src/send.unfurl.test.ts
+++ b/extensions/slack/src/send.unfurl.test.ts
@@ -62,6 +62,24 @@ describe("sendMessageSlack unfurl controls", () => {
     expect("unfurl_media" in payload).toBe(false);
   });
 
+  it("passes message metadata to chat.postMessage", async () => {
+    const client = createSlackSendTestClient();
+    const metadata = {
+      event_type: "assistant_thread_context",
+      event_payload: { channel_id: "C123", team_id: "T123" },
+    };
+
+    await sendMessageSlack("channel:C123", "assistant reply", {
+      token: "xoxb-test",
+      cfg: slackConfig({ botToken: "xoxb-test" }),
+      client,
+      metadata,
+    });
+
+    const payload = requirePostMessagePayload(client);
+    expect(payload.metadata).toEqual(metadata);
+  });
+
   it("passes top-level Slack unfurl flags to chat.postMessage", async () => {
     const client = createSlackSendTestClient();
 

--- a/extensions/slack/src/setup-shared.ts
+++ b/extensions/slack/src/setup-shared.ts
@@ -24,6 +24,23 @@ export function buildSlackManifest(botName = "OpenClaw") {
         messages_tab_enabled: true,
         messages_tab_read_only_enabled: false,
       },
+      assistant_view: {
+        assistant_description: `${safeName} connects Slack assistant threads to OpenClaw agents.`,
+        suggested_prompts: [
+          {
+            title: "What can you do?",
+            message: "What can you help me with?",
+          },
+          {
+            title: "Summarize this channel",
+            message: "Summarize the recent activity in this channel.",
+          },
+          {
+            title: "Draft a reply",
+            message: "Help me draft a reply.",
+          },
+        ],
+      },
       slash_commands: [
         {
           command: "/openclaw",
@@ -67,6 +84,8 @@ export function buildSlackManifest(botName = "OpenClaw") {
         bot_events: [
           "app_home_opened",
           "app_mention",
+          "assistant_thread_context_changed",
+          "assistant_thread_started",
           "channel_rename",
           "member_joined_channel",
           "member_left_channel",
@@ -90,8 +109,8 @@ export function buildSlackSetupLines(): string[] {
     "1) Slack API -> Create App -> From scratch or From manifest (with the JSON below)",
     "2) Add Socket Mode + enable it to get the app-level token (xapp-...)",
     "3) Install App to workspace to get the xoxb- bot token",
-    "4) Enable Event Subscriptions (socket) for message and App Home events",
-    "5) App Home -> enable the Home tab and Messages tab for DMs",
+    "4) Enable Event Subscriptions (socket) for message, App Home, and assistant events",
+    "5) App Home -> enable the Home tab, Messages tab for DMs, and AI assistant view",
     "Manifest JSON follows as plain text for copy/paste.",
     "Tip: set SLACK_BOT_TOKEN + SLACK_APP_TOKEN in your env.",
     `Docs: ${formatDocsLink("/slack", "slack")}`,

--- a/extensions/slack/src/setup-surface.test.ts
+++ b/extensions/slack/src/setup-surface.test.ts
@@ -125,6 +125,23 @@ describe("slackSetupWizard.prepare", () => {
           messages_tab_enabled: true,
           messages_tab_read_only_enabled: false,
         },
+        assistant_view: {
+          assistant_description: "OpenClaw connects Slack assistant threads to OpenClaw agents.",
+          suggested_prompts: [
+            {
+              title: "What can you do?",
+              message: "What can you help me with?",
+            },
+            {
+              title: "Summarize this channel",
+              message: "Summarize the recent activity in this channel.",
+            },
+            {
+              title: "Draft a reply",
+              message: "Help me draft a reply.",
+            },
+          ],
+        },
         slash_commands: [
           {
             command: "/openclaw",
@@ -168,6 +185,8 @@ describe("slackSetupWizard.prepare", () => {
           bot_events: [
             "app_home_opened",
             "app_mention",
+            "assistant_thread_context_changed",
+            "assistant_thread_started",
             "channel_rename",
             "member_joined_channel",
             "member_left_channel",

--- a/extensions/slack/src/streaming.test.ts
+++ b/extensions/slack/src/streaming.test.ts
@@ -12,7 +12,7 @@ import {
 } from "./streaming.js";
 
 type AppendImpl = () => Promise<unknown>;
-type StopImpl = () => Promise<void>;
+type StopImpl = (args?: unknown) => Promise<void>;
 
 function makeSession(params: { appendImpl?: AppendImpl; stopImpl?: StopImpl }): SlackStreamSession {
   return {
@@ -92,6 +92,19 @@ describe("stopSlackStream finalize error handling", () => {
 
     expect(session.delivered).toBe(true);
     expect(session.pendingText).toBe("");
+  });
+
+  it("passes message metadata when finalizing the stream", async () => {
+    const stopImpl = vi.fn(async () => {});
+    const session = makeSession({ stopImpl });
+    const metadata = {
+      event_type: "assistant_thread_context",
+      event_payload: { channel_id: "C123", team_id: "T123" },
+    };
+
+    await stopSlackStream({ session, metadata });
+
+    expect(stopImpl).toHaveBeenCalledWith({ metadata });
   });
 
   it("throws SlackStreamNotDeliveredError with buffered text when append flush fails", async () => {

--- a/extensions/slack/src/streaming.ts
+++ b/extensions/slack/src/streaming.ts
@@ -11,6 +11,7 @@
  * @see https://docs.slack.dev/reference/methods/chat.stopStream
  */
 
+import type { MessageMetadata } from "@slack/types";
 import type { WebClient } from "@slack/web-api";
 import type { ChatStreamer } from "@slack/web-api/dist/chat-stream.js";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
@@ -68,6 +69,7 @@ type StopSlackStreamParams = {
   session: SlackStreamSession;
   /** Optional final markdown text to append before stopping. */
   text?: string;
+  metadata?: MessageMetadata;
 };
 
 /**
@@ -210,7 +212,7 @@ export async function appendSlackStream(params: AppendSlackStreamParams): Promis
  * All other errors propagate unchanged.
  */
 export async function stopSlackStream(params: StopSlackStreamParams): Promise<void> {
-  const { session, text } = params;
+  const { session, text, metadata } = params;
 
   if (session.stopped) {
     logVerbose("slack-stream: stream already stopped, ignoring duplicate stop");
@@ -229,7 +231,10 @@ export async function stopSlackStream(params: StopSlackStreamParams): Promise<vo
   );
 
   try {
-    await session.streamer.stop(text ? { markdown_text: text } : undefined);
+    await session.streamer.stop({
+      ...(text ? { markdown_text: text } : {}),
+      ...(metadata ? { metadata } : {}),
+    });
     session.delivered = true;
     session.pendingText = "";
   } catch (err) {

--- a/extensions/slack/src/types.ts
+++ b/extensions/slack/src/types.ts
@@ -44,6 +44,7 @@ export type SlackMessageEvent = {
   blocks?: unknown[];
   files?: SlackFile[];
   attachments?: SlackAttachment[];
+  assistant_thread?: Record<string, unknown>;
   /**
    * Set by the thread_ts resolver when Slack supplied parent_user_id but the
    * parent thread timestamp could not be recovered.


### PR DESCRIPTION
## Summary
- Adds Slack assistant lifecycle handling for `assistant_thread_started` and `assistant_thread_context_changed`, including per-monitor assistant thread context and suggested prompts.
- Routes Slack assistant DM threads to thread-scoped OpenClaw sessions and forces replies, status, draft/native streaming, and message metadata back into the Slack assistant thread.
- Persists/restores Slack assistant context through Slack message metadata so restart, partial marker, and context-change paths keep the agent-facing channel/team/enterprise context.
- Updates Slack manifest setup, docs, tests, and changelog for `assistant_view`, `assistant:write`, and assistant event subscriptions.

## Verification
- `node --import tsx -e 'const { buildSlackManifest } = await import("./extensions/slack/src/setup-shared.ts"); const manifest = JSON.parse(buildSlackManifest("OpenClaw Proof")); console.log(JSON.stringify({assistant_view: manifest.features.assistant_view, assistant_scope: manifest.oauth_config.scopes.bot.includes("assistant:write"), assistant_events: manifest.settings.event_subscriptions.bot_events.filter((event) => event.startsWith("assistant_thread_"))}, null, 2));'`
- `pnpm test extensions/slack/src/send.unfurl.test.ts extensions/slack/src/streaming.test.ts extensions/slack/src/monitor/events/assistant.test.ts extensions/slack/src/monitor/events/messages.test.ts extensions/slack/src/monitor/message-handler/prepare.test.ts extensions/slack/src/monitor/message-handler/prepare.thread-session-key.test.ts extensions/slack/src/monitor/message-handler/dispatch.streaming.test.ts -- --reporter=dot` (160 passed)
- `pnpm test extensions/slack/src/monitor/events/assistant.test.ts extensions/slack/src/monitor/message-handler/prepare.test.ts -- --reporter=verbose -t "assistant"` (13 passed)
- `git diff --check`
- `pnpm check:changed` (Blacksmith Testbox `tbx_01krsaj3h6aabwzdqfct7st2cd`, GitHub Actions `25973224876`)
- `/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --mode branch` (clean after accepted review fixes)

## Real behavior proof
Behavior addressed: Slack Agents and AI Apps assistant threads now register lifecycle events, seed suggested prompts, route as assistant thread sessions, and carry Slack assistant context to the agent and Slack replies.
Real environment tested: OpenClaw Slack setup runtime from this branch, executed through Node with the built Slack setup surface and installed Slack dependency types available.
Exact steps or command run after this patch: `node --import tsx -e 'const { buildSlackManifest } = await import("./extensions/slack/src/setup-shared.ts"); const manifest = JSON.parse(buildSlackManifest("OpenClaw Proof")); console.log(JSON.stringify({assistant_view: manifest.features.assistant_view, assistant_scope: manifest.oauth_config.scopes.bot.includes("assistant:write"), assistant_events: manifest.settings.event_subscriptions.bot_events.filter((event) => event.startsWith("assistant_thread_"))}, null, 2));'`
Evidence after fix: Terminal output from the Slack setup runtime:
```json
{
  "assistant_view": {
    "assistant_description": "OpenClaw Proof connects Slack assistant threads to OpenClaw agents.",
    "suggested_prompts": [
      {
        "title": "What can you do?",
        "message": "What can you help me with?"
      },
      {
        "title": "Summarize this channel",
        "message": "Summarize the recent activity in this channel."
      },
      {
        "title": "Draft a reply",
        "message": "Help me draft a reply."
      }
    ]
  },
  "assistant_scope": true,
  "assistant_events": [
    "assistant_thread_context_changed",
    "assistant_thread_started"
  ]
}
```
Observed result after fix: The generated Slack manifest exposes the assistant view, includes the `assistant:write` scope, and subscribes to both assistant lifecycle events that drive the new runtime path.
What was not tested: live Slack workspace assistant app event delivery.

Fixes #80787
