### PR TITLE
fix(diagnostics): recover stale idle embedded-run lanes

### DIFF
--- a/src/logging/diagnostic-session-recovery-coordinator.ts
+++ b/src/logging/diagnostic-session-recovery-coordinator.ts
@@ -11,6 +11,7 @@ import {
 import {
   getDiagnosticSessionState,
   isDiagnosticSessionStateCurrent,
+  peekDiagnosticSessionState,
 } from "./diagnostic-session-state.js";
 
 export type RecoverStuckSession = (
@@ -27,7 +28,7 @@ function emitSessionRecoveryRequested(params: {
     type: "session.recovery.requested",
     sessionId: params.request.sessionId,
     sessionKey: params.request.sessionKey,
-    state: "processing",
+    state: params.request.expectedState ?? "processing",
     stateGeneration: params.request.stateGeneration,
     ageMs: params.request.ageMs,
     queueDepth: params.request.queueDepth,
@@ -46,7 +47,7 @@ function emitSessionRecoveryCompleted(params: {
     type: "session.recovery.completed",
     sessionId: params.request.sessionId,
     sessionKey: params.request.sessionKey,
-    state: "processing",
+    state: params.request.expectedState ?? "processing",
     stateGeneration: params.request.stateGeneration,
     ageMs: params.request.ageMs,
     queueDepth: params.request.queueDepth,
@@ -75,6 +76,10 @@ function isRecoveryPromiseLike(
   );
 }
 
+function recoveryOutcomeHasQueuedLaneWork(outcome: StuckSessionRecoveryOutcome): boolean {
+  return outcome.status === "aborted" && (outcome.queuedCount ?? 0) > 0;
+}
+
 function applyRecoveryOutcomeToDiagnosticState(params: {
   request: StuckSessionRecoveryRequest;
   outcome: StuckSessionRecoveryOutcome | undefined;
@@ -86,14 +91,25 @@ function applyRecoveryOutcomeToDiagnosticState(params: {
     emitSessionRecoveryCompleted({ request: params.request, outcome: params.outcome });
     return;
   }
-  if (
-    !isDiagnosticSessionStateCurrent({
-      sessionId: params.request.sessionId,
-      sessionKey: params.request.sessionKey,
-      generation: params.request.stateGeneration,
-      state: "processing",
-    })
-  ) {
+  const expectedState = params.request.expectedState ?? "processing";
+  const currentState = peekDiagnosticSessionState(params.request);
+  const currentGeneration = currentState?.generation ?? 0;
+  const requestGeneration = params.request.stateGeneration ?? 0;
+  const stateIsCurrent =
+    expectedState === "idle" &&
+    params.request.stateGeneration !== undefined &&
+    params.outcome.action === "abort_embedded_run"
+      ? // abortAndDrainEmbeddedPiRun can synchronously clear the stale run and
+        // log one idle transition before this recovery outcome is applied.
+        currentState?.state === "idle" &&
+        (currentGeneration === requestGeneration || currentGeneration === requestGeneration + 1)
+      : isDiagnosticSessionStateCurrent({
+          sessionId: params.request.sessionId,
+          sessionKey: params.request.sessionKey,
+          generation: params.request.stateGeneration,
+          state: expectedState,
+        });
+  if (!stateIsCurrent) {
     emitSessionRecoveryCompleted({
       request: params.request,
       outcome: params.outcome,
@@ -108,9 +124,13 @@ function applyRecoveryOutcomeToDiagnosticState(params: {
   state.generation = (state.generation ?? 0) + 1;
   state.lastStuckWarnAgeMs = undefined;
   state.lastLongRunningWarnAgeMs = undefined;
+  const preserveQueuedIdleWork =
+    params.request.expectedState === "idle" && recoveryOutcomeHasQueuedLaneWork(params.outcome);
   state.queueDepth = recoveryOutcomeClearsQueuedSessionState(params.outcome)
     ? 0
-    : Math.max(0, state.queueDepth - 1);
+    : preserveQueuedIdleWork
+      ? Math.max(state.queueDepth, params.request.queueDepth ?? 0)
+      : Math.max(0, state.queueDepth - 1);
   emitDiagnosticEvent({
     type: "session.state",
     sessionId: state.sessionId,

--- a/src/logging/diagnostic-session-recovery.ts
+++ b/src/logging/diagnostic-session-recovery.ts
@@ -1,4 +1,7 @@
-import type { DiagnosticSessionActiveWorkKind } from "../infra/diagnostic-events.js";
+import type {
+  DiagnosticSessionActiveWorkKind,
+  DiagnosticSessionState,
+} from "../infra/diagnostic-events.js";
 
 export type DiagnosticSessionRecoveryStatus =
   | "aborted"
@@ -23,6 +26,7 @@ export type StuckSessionRecoveryRequest = {
   ageMs: number;
   queueDepth?: number;
   allowActiveAbort?: boolean;
+  expectedState?: DiagnosticSessionState;
   stateGeneration?: number;
 };
 
@@ -42,6 +46,7 @@ export type StuckSessionRecoveryOutcome =
       drained: boolean;
       forceCleared: boolean;
       released: number;
+      queuedCount?: number;
     })
   | (DiagnosticSessionRecoveryBaseOutcome & {
       status: "released";
@@ -85,6 +90,7 @@ export function recoveryOutcomeClearsQueuedSessionState(
 ): boolean {
   return (
     outcome.status === "released" ||
+    (outcome.status === "aborted" && outcome.released > 0 && (outcome.queuedCount ?? 0) === 0) ||
     (outcome.status === "noop" && outcome.reason === "no_active_work")
   );
 }

--- a/src/logging/diagnostic-stuck-session-recovery.integration.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.integration.test.ts
@@ -1,29 +1,72 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveEmbeddedSessionLane } from "../agents/pi-embedded-runner/lanes.js";
+import {
+  __testing as embeddedRunTesting,
+  clearActiveEmbeddedRun,
+  isEmbeddedPiRunActive,
+  queueEmbeddedPiMessageWithOutcomeAsync,
+  setActiveEmbeddedRun,
+  type EmbeddedPiQueueHandle,
+} from "../agents/pi-embedded-runner/runs.js";
 import {
   __testing as replyRunTesting,
   createReplyOperation,
 } from "../auto-reply/reply/reply-run-registry.js";
+import {
+  onDiagnosticEvent,
+  resetDiagnosticEventsForTest,
+  type DiagnosticEventPayload,
+} from "../infra/diagnostic-events.js";
 import {
   enqueueCommandInLane,
   getQueueSize,
   resetCommandLane,
   resetCommandQueueStateForTest,
 } from "../process/command-queue.js";
+import { markDiagnosticRunProgressForTest } from "./diagnostic-run-activity.js";
+import {
+  getDiagnosticSessionState,
+  resetDiagnosticSessionStateForTest,
+} from "./diagnostic-session-state.js";
 import {
   __testing as recoveryTesting,
   recoverStuckDiagnosticSession,
 } from "./diagnostic-stuck-session-recovery.runtime.js";
+import {
+  logSessionStateChange,
+  resetDiagnosticStateForTest,
+  startDiagnosticHeartbeat,
+} from "./diagnostic.js";
 
 function delay(ms: number): Promise<"blocked"> {
   return new Promise((resolve) => setTimeout(() => resolve("blocked"), ms));
 }
 
+function requireMatchingEvent(
+  events: readonly DiagnosticEventPayload[],
+  fields: Record<string, unknown>,
+  label: string,
+): DiagnosticEventPayload {
+  const found = events.find((event) => {
+    const record = event as unknown as Record<string, unknown>;
+    return Object.entries(fields).every(([key, value]) => Object.is(record[key], value));
+  });
+  if (!found) {
+    throw new Error(`missing ${label}`);
+  }
+  return found;
+}
+
 describe("stuck session recovery integration", () => {
   afterEach(() => {
+    embeddedRunTesting.resetActiveEmbeddedRuns();
     recoveryTesting.resetRecoveriesInFlight();
     replyRunTesting.resetReplyRunRegistry();
+    resetDiagnosticEventsForTest();
+    resetDiagnosticStateForTest();
+    resetDiagnosticSessionStateForTest();
     resetCommandQueueStateForTest();
+    vi.useRealTimers();
   });
 
   it("does not reset a blocked lane while a reply operation is still active", async () => {
@@ -86,5 +129,281 @@ describe("stuck session recovery integration", () => {
 
     expect(resetCommandLane(lane)).toBe(1);
     await expect(queued).resolves.toBe("drained");
+  });
+
+  it("aborts a stale idle embedded run from heartbeat without dropping queued follow-up work", async () => {
+    vi.useFakeTimers();
+
+    const sessionKey = "agent:main:idle-embedded-runtime-proof";
+    const sessionId = "idle-embedded-runtime-proof-session";
+    const lane = resolveEmbeddedSessionLane(sessionKey);
+    const events: DiagnosticEventPayload[] = [];
+    const queuedMessages: string[] = [];
+    let aborts = 0;
+    let releaseActiveLane: (() => void) | undefined;
+
+    const activeLaneTask = enqueueCommandInLane(
+      lane,
+      () =>
+        new Promise<void>((resolve) => {
+          releaseActiveLane = resolve;
+        }),
+      { warnAfterMs: Number.MAX_SAFE_INTEGER },
+    );
+    const queuedLaneTask = enqueueCommandInLane(
+      lane,
+      async () => {
+        logSessionStateChange({
+          sessionId,
+          sessionKey,
+          state: "processing",
+          reason: "queued_followup_started",
+        });
+        logSessionStateChange({
+          sessionId,
+          sessionKey,
+          state: "idle",
+          reason: "queued_followup_completed",
+        });
+        return "follow-up-drained";
+      },
+      { warnAfterMs: Number.MAX_SAFE_INTEGER },
+    );
+    activeLaneTask.catch(() => {});
+    queuedLaneTask.catch(() => {});
+
+    const handle: EmbeddedPiQueueHandle = {
+      queueMessage: async (text) => {
+        queuedMessages.push(text);
+      },
+      isStreaming: () => true,
+      isCompacting: () => false,
+      abort: () => {
+        aborts += 1;
+        clearActiveEmbeddedRun(sessionId, handle, sessionKey);
+      },
+    };
+
+    const unsubscribe = onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+
+    try {
+      startDiagnosticHeartbeat(
+        {
+          diagnostics: {
+            enabled: true,
+            stuckSessionWarnMs: 30_000,
+            stuckSessionAbortMs: 60_000,
+          },
+        },
+        {
+          emitMemorySample: () => ({
+            rssBytes: 1,
+            heapTotalBytes: 1,
+            heapUsedBytes: 1,
+            externalBytes: 0,
+            arrayBuffersBytes: 0,
+          }),
+          sampleLiveness: () => null,
+        },
+      );
+      setActiveEmbeddedRun(sessionId, handle, sessionKey);
+      markDiagnosticRunProgressForTest({
+        sessionId,
+        sessionKey,
+        reason: "codex_app_server:notification:item/completed",
+      });
+      logSessionStateChange({
+        sessionId,
+        sessionKey,
+        state: "idle",
+        reason: "run_completed_without_clear",
+      });
+
+      await vi.advanceTimersByTimeAsync(59_000);
+      const queueOutcome = await queueEmbeddedPiMessageWithOutcomeAsync(
+        sessionId,
+        "queued follow-up",
+        { steeringMode: "all" },
+      );
+      expect(queueOutcome).toMatchObject({
+        queued: true,
+        sessionId,
+        target: "embedded_run",
+      });
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await Promise.resolve();
+      await Promise.resolve();
+    } finally {
+      unsubscribe();
+    }
+
+    expect(queuedMessages).toStrictEqual(["queued follow-up"]);
+    expect(aborts).toBe(1);
+    expect(isEmbeddedPiRunActive(sessionId)).toBe(false);
+    expect(getDiagnosticSessionState({ sessionId, sessionKey }).queueDepth).toBe(1);
+    expect(getQueueSize(lane)).toBe(2);
+
+    requireMatchingEvent(
+      events,
+      {
+        type: "session.stalled",
+        sessionId,
+        sessionKey,
+        state: "idle",
+        classification: "stalled_agent_run",
+        reason: "active_work_without_progress",
+        activeWorkKind: "embedded_run",
+        queueDepth: 1,
+      },
+      "idle embedded-run stalled event",
+    );
+    requireMatchingEvent(
+      events,
+      {
+        type: "session.recovery.requested",
+        sessionId,
+        sessionKey,
+        state: "idle",
+        activeWorkKind: "embedded_run",
+        allowActiveAbort: true,
+        queueDepth: 1,
+      },
+      "idle embedded-run recovery request",
+    );
+    requireMatchingEvent(
+      events,
+      {
+        type: "session.recovery.completed",
+        sessionId,
+        sessionKey,
+        state: "idle",
+        status: "aborted",
+        action: "abort_embedded_run",
+        activeWorkKind: "embedded_run",
+        queueDepth: 1,
+      },
+      "idle embedded-run recovery completion",
+    );
+
+    releaseActiveLane?.();
+    await expect(activeLaneTask).resolves.toBeUndefined();
+    await expect(queuedLaneTask).resolves.toBe("follow-up-drained");
+    expect(getQueueSize(lane)).toBe(0);
+    expect(getDiagnosticSessionState({ sessionId, sessionKey }).queueDepth).toBe(0);
+  });
+
+  it("does not leave phantom diagnostic queueDepth for handle-only queued steering", async () => {
+    vi.useFakeTimers();
+
+    const sessionKey = "agent:main:idle-embedded-handle-only";
+    const sessionId = "idle-embedded-handle-only-session";
+    const lane = resolveEmbeddedSessionLane(sessionKey);
+    const events: DiagnosticEventPayload[] = [];
+    const queuedMessages: string[] = [];
+    let aborts = 0;
+
+    const handle: EmbeddedPiQueueHandle = {
+      queueMessage: async (text) => {
+        queuedMessages.push(text);
+      },
+      isStreaming: () => true,
+      isCompacting: () => false,
+      abort: () => {
+        aborts += 1;
+        clearActiveEmbeddedRun(sessionId, handle, sessionKey);
+      },
+    };
+
+    const unsubscribe = onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+
+    try {
+      startDiagnosticHeartbeat(
+        {
+          diagnostics: {
+            enabled: true,
+            stuckSessionWarnMs: 30_000,
+            stuckSessionAbortMs: 60_000,
+          },
+        },
+        {
+          emitMemorySample: () => ({
+            rssBytes: 1,
+            heapTotalBytes: 1,
+            heapUsedBytes: 1,
+            externalBytes: 0,
+            arrayBuffersBytes: 0,
+          }),
+          sampleLiveness: () => null,
+        },
+      );
+      setActiveEmbeddedRun(sessionId, handle, sessionKey);
+      markDiagnosticRunProgressForTest({
+        sessionId,
+        sessionKey,
+        reason: "codex_app_server:notification:item/completed",
+      });
+      logSessionStateChange({
+        sessionId,
+        sessionKey,
+        state: "idle",
+        reason: "run_completed_without_clear",
+      });
+
+      await vi.advanceTimersByTimeAsync(59_000);
+      const queueOutcome = await queueEmbeddedPiMessageWithOutcomeAsync(
+        sessionId,
+        "handle-only follow-up",
+        { steeringMode: "all" },
+      );
+      expect(queueOutcome).toMatchObject({
+        queued: true,
+        sessionId,
+        target: "embedded_run",
+      });
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await Promise.resolve();
+      await Promise.resolve();
+    } finally {
+      unsubscribe();
+    }
+
+    expect(queuedMessages).toStrictEqual(["handle-only follow-up"]);
+    expect(aborts).toBe(1);
+    expect(isEmbeddedPiRunActive(sessionId)).toBe(false);
+    expect(getQueueSize(lane)).toBe(0);
+    expect(getDiagnosticSessionState({ sessionId, sessionKey }).queueDepth).toBe(0);
+
+    requireMatchingEvent(
+      events,
+      {
+        type: "session.recovery.completed",
+        sessionId,
+        sessionKey,
+        state: "idle",
+        status: "aborted",
+        action: "abort_embedded_run",
+        activeWorkKind: "embedded_run",
+        queueDepth: 1,
+      },
+      "handle-only idle embedded-run recovery completion",
+    );
+    requireMatchingEvent(
+      events,
+      {
+        type: "session.state",
+        sessionId,
+        sessionKey,
+        state: "idle",
+        reason: "stuck_recovery:aborted",
+        queueDepth: 0,
+      },
+      "handle-only idle embedded-run state clear",
+    );
   });
 });

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   abortEmbeddedPiRun: vi.fn(),
@@ -61,6 +61,10 @@ vi.mock("./diagnostic-runtime.js", () => ({
 }));
 
 import {
+  getDiagnosticSessionState,
+  resetDiagnosticSessionStateForTest,
+} from "./diagnostic-session-state.js";
+import {
   __testing,
   recoverStuckDiagnosticSession,
 } from "./diagnostic-stuck-session-recovery.runtime.js";
@@ -99,6 +103,11 @@ function warnLogMessages(): string[] {
 describe("stuck session recovery", () => {
   beforeEach(() => {
     resetMocks();
+    resetDiagnosticSessionStateForTest();
+  });
+
+  afterEach(() => {
+    resetDiagnosticSessionStateForTest();
   });
 
   it("does not abort an active embedded run by default", async () => {
@@ -211,7 +220,7 @@ describe("stuck session recovery", () => {
 
     expect(warnLogMessages()).toEqual([
       'stuck session recovery: sessionId=run-456 sessionKey=agent:clawblocker:cron:job-123:run:run-456 age=629s action=abort_embedded_run aborted=true drained=true released=0 stopped="Twitter Mention Moderation Agent" cronJobId=job-123 cronRunId=run-456 lastAssistant="There are 40 cached mentions."',
-      "stuck session recovery outcome: status=aborted action=abort_embedded_run sessionId=run-456 sessionKey=agent:clawblocker:cron:job-123:run:run-456 activeSessionId=run-456 activeWorkKind=embedded_run lane=session:agent:clawblocker:cron:job-123:run:run-456 aborted=true drained=true forceCleared=false released=0",
+      "stuck session recovery outcome: status=aborted action=abort_embedded_run sessionId=run-456 sessionKey=agent:clawblocker:cron:job-123:run:run-456 activeSessionId=run-456 activeWorkKind=embedded_run lane=session:agent:clawblocker:cron:job-123:run:run-456 aborted=true drained=true forceCleared=false released=0 laneQueued=1",
     ]);
   });
 
@@ -219,6 +228,7 @@ describe("stuck session recovery", () => {
     mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue("session-1");
     mocks.abortEmbeddedPiRun.mockReturnValue(true);
     mocks.waitForEmbeddedPiRunEnd.mockResolvedValue(false);
+    mocks.forceClearEmbeddedPiRun.mockReturnValue(true);
     mocks.resetCommandLane.mockReturnValue(1);
 
     await recoverStuckDiagnosticSession({
@@ -314,8 +324,106 @@ describe("stuck session recovery", () => {
     expect(mocks.resetCommandLane).not.toHaveBeenCalled();
     expect(warnLogMessages()).toEqual([
       "stuck session recovery: sessionId=queued-reply-session sessionKey=agent:main:main age=720s action=abort_embedded_run aborted=true drained=true released=0",
-      "stuck session recovery outcome: status=aborted action=abort_embedded_run sessionId=queued-reply-session sessionKey=agent:main:main activeSessionId=queued-reply-session activeWorkKind=embedded_run lane=session:agent:main:main aborted=true drained=true forceCleared=false released=0",
+      "stuck session recovery outcome: status=aborted action=abort_embedded_run sessionId=queued-reply-session sessionKey=agent:main:main activeSessionId=queued-reply-session activeWorkKind=embedded_run lane=session:agent:main:main aborted=true drained=true forceCleared=false released=0 laneQueued=1",
     ]);
+  });
+
+  it("accepts idle diagnostic state when idle recovery carries the expected generation", async () => {
+    const state = getDiagnosticSessionState({
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+    });
+    state.state = "idle";
+    state.generation = 7;
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue("session-1");
+    mocks.abortEmbeddedPiRun.mockReturnValue(true);
+    mocks.waitForEmbeddedPiRunEnd.mockResolvedValue(true);
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      ageMs: 360_000,
+      queueDepth: 1,
+      allowActiveAbort: true,
+      expectedState: "idle",
+      stateGeneration: 7,
+    });
+
+    expect(outcome).toMatchObject({
+      status: "aborted",
+      action: "abort_embedded_run",
+      activeSessionId: "session-1",
+      activeWorkKind: "embedded_run",
+      queuedCount: 1,
+    });
+    expect(mocks.abortEmbeddedPiRun).toHaveBeenCalledWith("session-1");
+  });
+
+  it("records queued lane work when abort recovery has to reset the lane", async () => {
+    const state = getDiagnosticSessionState({
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+    });
+    state.state = "idle";
+    state.generation = 7;
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue("session-1");
+    mocks.abortEmbeddedPiRun.mockReturnValue(true);
+    mocks.waitForEmbeddedPiRunEnd.mockResolvedValue(false);
+    mocks.forceClearEmbeddedPiRun.mockReturnValue(true);
+    mocks.resetCommandLane.mockReturnValue(1);
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      ageMs: 360_000,
+      queueDepth: 1,
+      allowActiveAbort: true,
+      expectedState: "idle",
+      stateGeneration: 7,
+    });
+
+    expect(outcome).toMatchObject({
+      status: "aborted",
+      action: "abort_embedded_run",
+      activeSessionId: "session-1",
+      activeWorkKind: "embedded_run",
+      released: 1,
+      queuedCount: 1,
+    });
+    expect(mocks.resetCommandLane).toHaveBeenCalledWith("session:agent:main:main");
+  });
+
+  it("records queued lane work when processing recovery abort resets the lane", async () => {
+    const state = getDiagnosticSessionState({
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+    });
+    state.state = "processing";
+    state.generation = 7;
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue("session-1");
+    mocks.abortEmbeddedPiRun.mockReturnValue(true);
+    mocks.waitForEmbeddedPiRunEnd.mockResolvedValue(false);
+    mocks.forceClearEmbeddedPiRun.mockReturnValue(true);
+    mocks.resetCommandLane.mockReturnValue(1);
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId: "session-1",
+      sessionKey: "agent:main:main",
+      ageMs: 360_000,
+      queueDepth: 2,
+      allowActiveAbort: true,
+      stateGeneration: 7,
+    });
+
+    expect(outcome).toMatchObject({
+      status: "aborted",
+      action: "abort_embedded_run",
+      activeSessionId: "session-1",
+      activeWorkKind: "embedded_run",
+      released: 1,
+      queuedCount: 1,
+    });
+    expect(mocks.resetCommandLane).toHaveBeenCalledWith("session:agent:main:main");
   });
 
   it("does not release the session lane while unregistered lane work is active", async () => {

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.ts
@@ -74,7 +74,7 @@ export async function recoverStuckDiagnosticSession(
         sessionId: params.sessionId,
         sessionKey: params.sessionKey,
         generation: params.stateGeneration,
-        state: "processing",
+        state: params.expectedState ?? "processing",
       })
     ) {
       return {
@@ -176,6 +176,7 @@ export async function recoverStuckDiagnosticSession(
       }
     }
 
+    const queuedCount = sessionLane ? getCommandLaneSnapshot(sessionLane).queuedCount : 0;
     const released =
       sessionLane && (!activeSessionId || !aborted || !drained) ? resetCommandLane(sessionLane) : 0;
 
@@ -207,6 +208,7 @@ export async function recoverStuckDiagnosticSession(
               forceCleared,
               released,
               lane: sessionLane ?? undefined,
+              ...(queuedCount > 0 ? { queuedCount } : {}),
             }
           : {
               status: "released",

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -679,6 +679,333 @@ describe("stuck session diagnostics threshold", () => {
     );
   });
 
+  it("does not preserve handle-only idle recovery queueDepth after abort", async () => {
+    const events: DiagnosticEventPayload[] = [];
+    const recoverStuckSession = vi.fn().mockImplementation(async () => {
+      logSessionStateChange({
+        sessionId: "s1",
+        sessionKey: "main",
+        state: "idle",
+        reason: "run_completed",
+      });
+      return {
+        status: "aborted",
+        action: "abort_embedded_run",
+        sessionId: "s1",
+        sessionKey: "main",
+        activeSessionId: "s1",
+        activeWorkKind: "embedded_run",
+        aborted: true,
+        drained: true,
+        forceCleared: false,
+        released: 0,
+      };
+    });
+    const unsubscribe = onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+    try {
+      startDiagnosticHeartbeat(
+        {
+          diagnostics: {
+            enabled: true,
+            stuckSessionWarnMs: 30_000,
+            stuckSessionAbortMs: 60_000,
+          },
+        },
+        { recoverStuckSession },
+      );
+      logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test" });
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+      markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+      markDiagnosticRunProgressForTest({
+        sessionId: "s1",
+        sessionKey: "main",
+        reason: "codex_app_server:notification:item/completed",
+      });
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "idle" });
+
+      vi.advanceTimersByTime(59_000);
+      logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test-followup" });
+      vi.advanceTimersByTime(1_000);
+      await Promise.resolve();
+      await Promise.resolve();
+    } finally {
+      unsubscribe();
+    }
+
+    expectRecordFields(
+      requireRecord(
+        events.findLast((event) => event.type === "session.stalled"),
+        "stalled event",
+      ),
+      {
+        state: "idle",
+        classification: "stalled_agent_run",
+        reason: "active_work_without_progress",
+        activeWorkKind: "embedded_run",
+        queueDepth: 1,
+        lastProgressReason: "codex_app_server:notification:item/completed",
+      },
+    );
+    expectRecoveryCall(
+      recoverStuckSession,
+      {
+        sessionId: "s1",
+        sessionKey: "main",
+        queueDepth: 1,
+        allowActiveAbort: true,
+        expectedState: "idle",
+      },
+      ["ageMs", "stateGeneration"],
+    );
+    requireMatchingRecord(
+      events,
+      {
+        type: "session.recovery.completed",
+        state: "idle",
+        status: "aborted",
+        action: "abort_embedded_run",
+      },
+      "idle abort recovery event",
+    );
+    requireMatchingRecord(
+      events,
+      {
+        type: "session.state",
+        state: "idle",
+        reason: "stuck_recovery:aborted",
+        queueDepth: 0,
+      },
+      "idle abort state clear event",
+    );
+    expect(getDiagnosticSessionState({ sessionId: "s1", sessionKey: "main" }).queueDepth).toBe(0);
+  });
+
+  it("preserves queued idle recovery after abort reset releases active lane work", async () => {
+    const events: DiagnosticEventPayload[] = [];
+    const recoverStuckSession = vi.fn().mockResolvedValue({
+      status: "aborted",
+      action: "abort_embedded_run",
+      sessionId: "s1",
+      sessionKey: "main",
+      activeSessionId: "s1",
+      activeWorkKind: "embedded_run",
+      aborted: true,
+      drained: false,
+      forceCleared: true,
+      released: 1,
+      queuedCount: 1,
+    });
+    const unsubscribe = onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+    try {
+      startDiagnosticHeartbeat(
+        {
+          diagnostics: {
+            enabled: true,
+            stuckSessionWarnMs: 30_000,
+            stuckSessionAbortMs: 60_000,
+          },
+        },
+        { recoverStuckSession },
+      );
+      logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test" });
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+      markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+      markDiagnosticRunProgressForTest({
+        sessionId: "s1",
+        sessionKey: "main",
+        reason: "codex_app_server:notification:item/completed",
+      });
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "idle" });
+
+      vi.advanceTimersByTime(59_000);
+      logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test-followup" });
+      vi.advanceTimersByTime(1_000);
+      await Promise.resolve();
+      await Promise.resolve();
+    } finally {
+      unsubscribe();
+    }
+
+    requireMatchingRecord(
+      events,
+      {
+        type: "session.recovery.completed",
+        state: "idle",
+        status: "aborted",
+        action: "abort_embedded_run",
+      },
+      "idle abort recovery event with queued lane work",
+    );
+    requireMatchingRecord(
+      events,
+      { type: "session.state", state: "idle", reason: "stuck_recovery:aborted", queueDepth: 1 },
+      "idle abort state preserves queued work",
+    );
+    expect(getDiagnosticSessionState({ sessionId: "s1", sessionKey: "main" }).queueDepth).toBe(1);
+  });
+
+  it("preserves queued processing recovery after abort reset releases active lane work", async () => {
+    const events: DiagnosticEventPayload[] = [];
+    const recoverStuckSession = vi.fn().mockResolvedValue({
+      status: "aborted",
+      action: "abort_embedded_run",
+      sessionId: "s1",
+      sessionKey: "main",
+      activeSessionId: "s1",
+      activeWorkKind: "embedded_run",
+      aborted: true,
+      drained: false,
+      forceCleared: true,
+      released: 1,
+      queuedCount: 1,
+    });
+    const unsubscribe = onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+    try {
+      startDiagnosticHeartbeat(
+        {
+          diagnostics: {
+            enabled: true,
+            stuckSessionWarnMs: 30_000,
+            stuckSessionAbortMs: 60_000,
+          },
+        },
+        { recoverStuckSession },
+      );
+      logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test" });
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+      markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+      markDiagnosticRunProgressForTest({
+        sessionId: "s1",
+        sessionKey: "main",
+        reason: "codex_app_server:notification:item/completed",
+      });
+      logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test-followup" });
+
+      vi.advanceTimersByTime(61_000);
+      await Promise.resolve();
+      await Promise.resolve();
+    } finally {
+      unsubscribe();
+    }
+
+    expectRecoveryCall(
+      recoverStuckSession,
+      {
+        sessionId: "s1",
+        sessionKey: "main",
+        queueDepth: 2,
+        allowActiveAbort: true,
+        expectedState: "processing",
+      },
+      ["ageMs", "stateGeneration"],
+    );
+    requireMatchingRecord(
+      events,
+      {
+        type: "session.recovery.completed",
+        state: "processing",
+        status: "aborted",
+        action: "abort_embedded_run",
+        queueDepth: 2,
+      },
+      "processing abort recovery event with queued lane work",
+    );
+    requireMatchingRecord(
+      events,
+      { type: "session.state", state: "idle", reason: "stuck_recovery:aborted", queueDepth: 1 },
+      "processing abort state preserves queued work",
+    );
+    expect(getDiagnosticSessionState({ sessionId: "s1", sessionKey: "main" }).queueDepth).toBe(1);
+  });
+
+  it("does not preserve queued idle recovery after later work completes", async () => {
+    const events: DiagnosticEventPayload[] = [];
+    const recoverStuckSession = vi.fn().mockImplementation(async () => {
+      logSessionStateChange({
+        sessionId: "s1",
+        sessionKey: "main",
+        state: "idle",
+        reason: "run_completed",
+      });
+      logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "new-turn" });
+      logSessionStateChange({
+        sessionId: "s1",
+        sessionKey: "main",
+        state: "processing",
+        reason: "new_turn_started",
+      });
+      logSessionStateChange({
+        sessionId: "s1",
+        sessionKey: "main",
+        state: "idle",
+        reason: "new_turn_completed",
+      });
+      return {
+        status: "aborted",
+        action: "abort_embedded_run",
+        sessionId: "s1",
+        sessionKey: "main",
+        activeSessionId: "s1",
+        activeWorkKind: "embedded_run",
+        aborted: true,
+        drained: true,
+        forceCleared: false,
+        released: 0,
+      };
+    });
+    const unsubscribe = onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+    try {
+      startDiagnosticHeartbeat(
+        {
+          diagnostics: {
+            enabled: true,
+            stuckSessionWarnMs: 30_000,
+            stuckSessionAbortMs: 60_000,
+          },
+        },
+        { recoverStuckSession },
+      );
+      logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test" });
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+      markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+      markDiagnosticRunProgressForTest({
+        sessionId: "s1",
+        sessionKey: "main",
+        reason: "codex_app_server:notification:item/completed",
+      });
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "idle" });
+
+      vi.advanceTimersByTime(59_000);
+      logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test-followup" });
+      vi.advanceTimersByTime(1_000);
+      await Promise.resolve();
+      await Promise.resolve();
+    } finally {
+      unsubscribe();
+    }
+
+    requireMatchingRecord(
+      events,
+      {
+        type: "session.recovery.completed",
+        state: "idle",
+        status: "aborted",
+        action: "abort_embedded_run",
+        stale: true,
+      },
+      "stale idle abort recovery event",
+    );
+    expect(getDiagnosticSessionState({ sessionId: "s1", sessionKey: "main" }).queueDepth).toBe(0);
+  });
+
   it("marks diagnostic session state idle only after a mutating recovery outcome", async () => {
     const events: DiagnosticEventPayload[] = [];
     const recoverStuckSession = vi.fn().mockResolvedValue({

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -493,6 +493,22 @@ function isActiveAbortRecoveryEligible(params: {
   return isStalledEmbeddedRunRecoveryEligible(params) || isBlockedToolCallRecoveryEligible(params);
 }
 
+function isIdleQueuedEmbeddedRunStall(params: {
+  state: {
+    state: SessionStateValue;
+    queueDepth: number;
+  };
+  activity: DiagnosticSessionActivitySnapshot;
+  staleMs: number;
+}): boolean {
+  return (
+    params.state.state === "idle" &&
+    params.state.queueDepth > 0 &&
+    params.activity.activeWorkKind === "embedded_run" &&
+    (params.activity.lastProgressAgeMs ?? 0) > params.staleMs
+  );
+}
+
 export function logWebhookReceived(params: {
   channel: string;
   updateType?: string;
@@ -1034,16 +1050,27 @@ export function startDiagnosticHeartbeat(
 
     for (const [, state] of diagnosticSessionStates) {
       const ageMs = now - state.lastActivity;
-      if (state.state === "processing" && ageMs > stuckSessionWarnMs) {
-        const activity = getDiagnosticSessionActivitySnapshot(
-          { sessionId: state.sessionId, sessionKey: state.sessionKey },
-          now,
-        );
+      const activity = getDiagnosticSessionActivitySnapshot(
+        { sessionId: state.sessionId, sessionKey: state.sessionKey },
+        now,
+      );
+      const idleQueuedEmbeddedRunStall = isIdleQueuedEmbeddedRunStall({
+        state,
+        activity,
+        staleMs: stuckSessionWarnMs,
+      });
+      if (
+        (state.state === "processing" && ageMs > stuckSessionWarnMs) ||
+        idleQueuedEmbeddedRunStall
+      ) {
+        const attentionAgeMs = idleQueuedEmbeddedRunStall
+          ? (activity.lastProgressAgeMs ?? ageMs)
+          : ageMs;
         const classification = logSessionAttention({
           sessionId: state.sessionId,
           sessionKey: state.sessionKey,
           state: state.state,
-          ageMs,
+          ageMs: attentionAgeMs,
           thresholdMs: stuckSessionWarnMs,
           abortThresholdMs: stuckSessionAbortMs,
         });
@@ -1054,8 +1081,9 @@ export function startDiagnosticHeartbeat(
             request: {
               sessionId: state.sessionId,
               sessionKey: state.sessionKey,
-              ageMs,
+              ageMs: attentionAgeMs,
               queueDepth: state.queueDepth,
+              expectedState: state.state,
               stateGeneration: state.generation,
             },
           });
@@ -1064,7 +1092,7 @@ export function startDiagnosticHeartbeat(
           isActiveAbortRecoveryEligible({
             classification,
             activity,
-            ageMs,
+            ageMs: attentionAgeMs,
             stuckSessionAbortMs,
           })
         ) {
@@ -1074,9 +1102,10 @@ export function startDiagnosticHeartbeat(
             request: {
               sessionId: state.sessionId,
               sessionKey: state.sessionKey,
-              ageMs,
+              ageMs: attentionAgeMs,
               queueDepth: state.queueDepth,
               allowActiveAbort: true,
+              expectedState: state.state,
               stateGeneration: state.generation,
             },
           });


### PR DESCRIPTION
## Summary

- Fixes stale idle embedded-run lanes: a session can look idle while a stale embedded-run handle remains active and follow-up work queues behind it.
- Diagnostic heartbeat now treats idle + queued + stale embedded-run progress as recoverable, then requests recovery with expectedState=idle.
- Recovery aborts the stale embedded handle, preserves real queued command-lane work, and clears handle-only phantom queue depth.
- Out of scope: compaction/auth routing, blocked_tool_call recovery, terminal idle timeout recovery, model/provider behavior.

## Change Type / Scope

- [x] Bug fix
- [x] Refactor required for the fix
- Scope: gateway/orchestration diagnostics only.

## Linked Issue/PR

- Closes N/A
- Related #71127, #76038
- [x] This PR fixes a bug or regression

## Real Behavior Proof

- Behavior or issue addressed: stale embedded-run state can remain attached after the visible lane state returns to idle, leaving a queued follow-up stuck behind activeWorkKind=embedded_run with no recovery request.
- Real environment tested: local OpenClaw checkout on macOS, using the real diagnostic heartbeat/recovery path, embedded-run registry, and command-lane machinery with synthetic embedded handles.
- Exact steps or command run after this patch: reproduced the live failure shape in the runtime seam by creating an idle diagnostic session with queueDepth=1, stale embedded-run progress, and queued follow-up work; then ticked the diagnostic heartbeat and reran the focused logging suite.
- Evidence after fix: copied terminal/event output from the local run showed the intended recovery path:

```text
session.stalled state=idle classification=stalled_agent_run activeWorkKind=embedded_run queueDepth=1
session.recovery.requested state=idle allowActiveAbort=true activeWorkKind=embedded_run queueDepth=1
session.recovery.completed state=idle status=aborted action=abort_embedded_run activeWorkKind=embedded_run queueDepth=1
session.state state=idle reason=stuck_recovery:aborted queueDepth=0
queued follow-up drained: follow-up-drained

Test Files  3 passed (3)
Tests       60 passed (60)
```

- Observed result after fix: the stale embedded handle is cleared, real queued command-lane work is preserved and drains, and handle-only queued steering clears queueDepth instead of leaving phantom queued state.
- What was not tested: a live installed gateway built from this branch, public-channel delivery, compaction behavior, model/provider auth routing, or blocked terminal/tool-call stalls.

## Root Cause

Stuck-session recovery only considered stale processing sessions. It did not treat idle sessions with queued work plus stale active embedded-run activity as recoverable.

The fix carries the expected session state into recovery and tolerates the embedded-run abort path recording an idle transition before the recovery outcome is applied.

## Regression Test Plan

New coverage:
- src/logging/diagnostic.test.ts
- src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
- src/logging/diagnostic-stuck-session-recovery.integration.test.ts

Locked scenario: idle session + stale embedded-run activity + queued follow-up triggers recovery without dropping real queued command-lane work.

Why this is the smallest reliable guardrail: it drives the actual heartbeat/recovery coordinator and embedded-run/command-lane seams without relying on a flaky live model/tool call.

## User-visible / Behavior Changes

Stale idle embedded-run lanes with queued follow-up work can now self-recover instead of waiting for unrelated timeout/retry paths. No config or UI changes.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

Steps covered by the focused tests:
1. Create a diagnostic session that transitions to idle while an embedded-run handle remains active.
2. Queue a follow-up message so diagnostic queue depth is greater than zero.
3. Let stale embedded-run progress exceed the abort threshold.
4. Tick the diagnostic heartbeat.

Expected and actual: diagnostics classify the idle lane as a stale embedded-run stall, request recovery with expectedState=idle, abort the stale embedded handle, preserve real queued command-lane work, and clear handle-only phantom queue depth.

Verification command:

node scripts/run-vitest.mjs run --config test/vitest/vitest.logging.config.ts src/logging/diagnostic.test.ts src/logging/diagnostic-stuck-session-recovery.runtime.test.ts src/logging/diagnostic-stuck-session-recovery.integration.test.ts

## Human Verification

Verified locally:
- idle+queued stale embedded-run stall requests recovery from heartbeat
- stale embedded handle is aborted
- real queued command-lane follow-up work is preserved and drains
- handle-only queued steering clears queue depth
- stale-generation recovery outcome does not mutate newer state
- active reply/unregistered lane work still prevents unsafe command-lane reset

Not verified: live installed gateway from this branch, blocked terminal/tool-call recovery, compaction/auth-profile behavior.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: aborting stale embedded-run handles from idle state could drop legitimate queued work.
  - Mitigation: recovery is gated on stale progress and preserves real command-lane queued work.
- Risk: a recovery result could arrive after newer session work starts.
  - Mitigation: recovery carries expectedState and state generation; tests cover stale outcome handling.
- Risk: reviewers may expect blocked tool-call recovery here.
  - Mitigation: blocked_tool_call and terminal idle timeout recovery are explicitly out of scope.


