### PR TITLE
Bound tool transcript payloads

### DIFF
--- a/src/agents/pi-embedded-subscribe.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.tools.test.ts
@@ -6,6 +6,8 @@ import {
   sanitizeToolResult,
 } from "./pi-embedded-subscribe.tools.js";
 
+const TRUNCATION_MARKER = "\n…(truncated)…";
+
 afterEach(() => {
   vi.restoreAllMocks();
 });
@@ -192,6 +194,29 @@ describe("sanitizeToolResult", () => {
     expect(sanitized).toContain("OPENROUTER_API_KEY=");
   });
 
+  it("bounds oversized exec-style nested result strings without dropping context", () => {
+    const long = "x".repeat(50000);
+    const sanitized = sanitizeToolResult({
+      details: {
+        status: "completed",
+        aggregated: long,
+        nested: { output: long },
+      },
+      content: [{ type: "text", text: long }],
+    }) as {
+      details: { status: string; aggregated: string; nested: { output: string } };
+      content: Array<{ text: string }>;
+    };
+
+    expect(sanitized.details.status).toBe("completed");
+    expect(sanitized.details.aggregated.length).toBeLessThan(long.length);
+    expect(sanitized.details.aggregated.endsWith(TRUNCATION_MARKER)).toBe(true);
+    expect(sanitized.details.aggregated.startsWith("x")).toBe(true);
+    expect(sanitized.details.nested.output.endsWith(TRUNCATION_MARKER)).toBe(true);
+    expect(sanitized.content[0]?.text.endsWith(TRUNCATION_MARKER)).toBe(true);
+    expect(sanitized.content[0]?.text.startsWith("x")).toBe(true);
+  });
+
   it("preserves top-level arrays while redacting nested strings", () => {
     const sanitized = sanitizeToolResult([
       { output: "Authorization: Bearer abcdef0123456789QWERTY=" },
@@ -249,5 +274,25 @@ describe("sanitizeToolArgs", () => {
       count: 3,
       file_path: "/tmp/x.txt",
     });
+  });
+
+  it("bounds oversized apply-patch-style args while keeping the leading context visible", () => {
+    const long = "x".repeat(50000);
+    const sanitized = sanitizeToolArgs({
+      input: long,
+      nested: { diff: long },
+      flags: ["--explain", long],
+    }) as {
+      input: string;
+      nested: { diff: string };
+      flags: string[];
+    };
+
+    expect(sanitized.input.length).toBeLessThan(long.length);
+    expect(sanitized.input.endsWith(TRUNCATION_MARKER)).toBe(true);
+    expect(sanitized.input.startsWith("x")).toBe(true);
+    expect(sanitized.nested.diff.endsWith(TRUNCATION_MARKER)).toBe(true);
+    expect(sanitized.flags[0]).toBe("--explain");
+    expect(sanitized.flags[1]?.endsWith(TRUNCATION_MARKER)).toBe(true);
   });
 });

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -14,14 +14,24 @@ import { isMessageToolSendActionName } from "./pi-embedded-messaging.js";
 import type { MessagingToolSend } from "./pi-embedded-messaging.types.js";
 import { normalizeToolName } from "./tool-policy.js";
 
+const TOOL_ARGS_MAX_CHARS = 4000;
 const TOOL_RESULT_MAX_CHARS = 8000;
 const TOOL_ERROR_MAX_CHARS = 400;
+const TOOL_TRUNCATION_MARKER = "\n…(truncated)…";
 
-function truncateToolText(text: string): string {
-  if (text.length <= TOOL_RESULT_MAX_CHARS) {
+function truncateToolString(text: string, maxChars: number): string {
+  if (text.length <= maxChars) {
     return text;
   }
-  return `${truncateUtf16Safe(text, TOOL_RESULT_MAX_CHARS)}\n…(truncated)…`;
+  return `${truncateUtf16Safe(text, maxChars)}${TOOL_TRUNCATION_MARKER}`;
+}
+
+function truncateToolArgsText(text: string): string {
+  return truncateToolString(text, TOOL_ARGS_MAX_CHARS);
+}
+
+function truncateToolText(text: string): string {
+  return truncateToolString(text, TOOL_RESULT_MAX_CHARS);
 }
 
 function normalizeToolErrorText(text: string): string | undefined {
@@ -116,16 +126,20 @@ function isHostDenialToolText(text: string): boolean {
   return normalized.toLowerCase().includes("approval cannot safely bind");
 }
 
-function redactStringsDeep(value: unknown, seen = new WeakSet<object>()): unknown {
+function redactStringsDeep(
+  value: unknown,
+  seen = new WeakSet<object>(),
+  maxChars = TOOL_RESULT_MAX_CHARS,
+): unknown {
   if (typeof value === "string") {
-    return redactToolPayloadText(value);
+    return truncateToolString(redactToolPayloadText(value), maxChars);
   }
   if (Array.isArray(value)) {
     if (seen.has(value)) {
       return "[Circular]";
     }
     seen.add(value);
-    return value.map((item) => redactStringsDeep(item, seen));
+    return value.map((item) => redactStringsDeep(item, seen, maxChars));
   }
   if (value && typeof value === "object") {
     if (seen.has(value)) {
@@ -136,8 +150,8 @@ function redactStringsDeep(value: unknown, seen = new WeakSet<object>()): unknow
     for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
       out[key] =
         typeof child === "string"
-          ? redactSensitiveFieldValue(key, child)
-          : redactStringsDeep(child, seen);
+          ? truncateToolString(redactSensitiveFieldValue(key, child), maxChars)
+          : redactStringsDeep(child, seen, maxChars);
     }
     return out;
   }
@@ -145,15 +159,18 @@ function redactStringsDeep(value: unknown, seen = new WeakSet<object>()): unknow
 }
 
 export function sanitizeToolArgs(args: unknown): unknown {
-  return redactStringsDeep(args);
+  if (typeof args === "string") {
+    return truncateToolArgsText(redactToolPayloadText(args));
+  }
+  return redactStringsDeep(args, new WeakSet<object>(), TOOL_ARGS_MAX_CHARS);
 }
 
 export function sanitizeToolResult(result: unknown): unknown {
   if (typeof result === "string") {
-    return redactToolPayloadText(result);
+    return truncateToolText(redactToolPayloadText(result));
   }
   if (Array.isArray(result)) {
-    return redactStringsDeep(result);
+    return redactStringsDeep(result, new WeakSet<object>(), TOOL_RESULT_MAX_CHARS);
   }
   if (!result || typeof result !== "object") {
     return result;
@@ -181,7 +198,11 @@ export function sanitizeToolResult(result: unknown): unknown {
   }
   // Deep-redact the entire result so any top-level or nested string is
   // protected, not just `details` and text content blocks.
-  const baseline = redactStringsDeep(preCleaned) as Record<string, unknown>;
+  const baseline = redactStringsDeep(
+    preCleaned,
+    new WeakSet<object>(),
+    TOOL_RESULT_MAX_CHARS,
+  ) as Record<string, unknown>;
   const out: Record<string, unknown> = { ...baseline };
   const content = Array.isArray(baseline.content) ? baseline.content : null;
   if (content) {


### PR DESCRIPTION
## Summary
- bound oversized tool argument strings before they enter transcript events
- apply the same bounded truncation to deeply nested tool result strings while preserving visible leading context and metadata
- add focused tests for apply-patch-style args and exec-style aggregated output

## Validation
- npm test src/agents/pi-embedded-subscribe.tools.test.ts
