### PR TITLE
refactor: unify async media generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 - Agents/skills: cache hydrated `resolvedSkills` across warm gateway turns while keying reuse by the redacted effective config, reducing redundant skill snapshot rebuilds without crossing config-gated skill boundaries. (#81451) Thanks @solodmd.
 - Telegram/group chat: add opt-in `messages.groupChat.ambientTurns: "room_event"` handling so always-on ambient chatter can run as quiet room context and speak visibly only via the message tool. (#81317) Thanks @obviyus.
 - Codex/context engines: bind thread-bootstrap projection epochs to Codex app-server threads, carry redacted tool-result context into fresh threads, and rotate backend threads when projection state changes. (#82351) Thanks @jalehman.
+- Agents/media: run `image_generate` through the shared async media-generation task lifecycle in session-backed chats, with task status, duplicate guarding, and message-tool completion delivery matching music/video.
 - Gateway: add opt-in restart trace logs for restart signal, active-work drain, close, next-start, ready, and memory spans. (#82396) Thanks @samzong.
 - Gateway/performance: split startup benchmark HTTP-listen timing from full gateway-ready timing and add post-bind plugin and sidecar diagnostics to restart-readiness traces. (#82603) Thanks @samzong.
 - QA-Lab: add a deterministic local personal-agent scenario pack covering reminders, threaded replies, scoped memory recall, redaction, and safe tool followthrough. (#78219) Thanks @iFiras-Max1.

--- a/docs/automation/tasks.md
+++ b/docs/automation/tasks.md
@@ -90,23 +90,23 @@ Not every agent run creates a task. Heartbeat turns and normal interactive chat 
 
 ## What creates a task
 
-| Source                 | Runtime type | When a task record is created                          | Default notify policy |
-| ---------------------- | ------------ | ------------------------------------------------------ | --------------------- |
-| ACP background runs    | `acp`        | Spawning a child ACP session                           | `done_only`           |
-| Subagent orchestration | `subagent`   | Spawning a subagent via `sessions_spawn`               | `done_only`           |
-| Cron jobs (all types)  | `cron`       | Every cron execution (main-session and isolated)       | `silent`              |
-| CLI operations         | `cli`        | `openclaw agent` commands that run through the gateway | `silent`              |
-| Agent media jobs       | `cli`        | Session-backed `music_generate`/`video_generate` runs  | `silent`              |
+| Source                 | Runtime type | When a task record is created                                          | Default notify policy |
+| ---------------------- | ------------ | ---------------------------------------------------------------------- | --------------------- |
+| ACP background runs    | `acp`        | Spawning a child ACP session                                           | `done_only`           |
+| Subagent orchestration | `subagent`   | Spawning a subagent via `sessions_spawn`                               | `done_only`           |
+| Cron jobs (all types)  | `cron`       | Every cron execution (main-session and isolated)                       | `silent`              |
+| CLI operations         | `cli`        | `openclaw agent` commands that run through the gateway                 | `silent`              |
+| Agent media jobs       | `cli`        | Session-backed `image_generate`/`music_generate`/`video_generate` runs | `silent`              |
 
 <AccordionGroup>
   <Accordion title="Notify defaults for cron and media">
     Main-session cron tasks use `silent` notify policy by default - they create records for tracking but do not generate notifications. Isolated cron tasks also default to `silent` but are more visible because they run in their own session.
 
-    Session-backed `music_generate` and `video_generate` runs also use `silent` notify policy. They still create task records, but completion is handed back to the original agent session as an internal wake so the agent can write the follow-up message and attach the finished media itself. Group/channel completions follow the normal visible-reply policy, so the agent uses the message tool when source delivery requires it. If the completion agent fails to produce message-tool delivery evidence in a tool-only route, OpenClaw sends the completion fallback directly to the original channel instead of leaving the media private.
+    Session-backed `image_generate`, `music_generate`, and `video_generate` runs also use `silent` notify policy. They still create task records, but completion is handed back to the original agent session as an internal wake so the agent can write the follow-up message and attach the finished media itself. Group/channel completions follow the normal visible-reply policy, so the agent uses the message tool when source delivery requires it. If the completion agent fails to produce message-tool delivery evidence in a tool-only route, OpenClaw sends the completion fallback directly to the original channel instead of leaving the media private.
 
   </Accordion>
-  <Accordion title="Concurrent video_generate guardrail">
-    While a session-backed `video_generate` task is still active, the tool also acts as a guardrail: repeated `video_generate` calls in that same session return the active task status instead of starting a second concurrent generation. Use `action: "status"` when you want an explicit progress/status lookup from the agent side.
+  <Accordion title="Concurrent media-generation guardrail">
+    While a session-backed media-generation task is still active, the tool also acts as a guardrail: repeated `image_generate`, `music_generate`, or `video_generate` calls in that same session return the active task status instead of starting a second concurrent generation. Use `action: "status"` when you want an explicit progress/status lookup from the agent side.
   </Accordion>
   <Accordion title="What does not create tasks">
     - Heartbeat turns - main-session; see [Heartbeat](/gateway/heartbeat)

--- a/docs/tools/image-generation.md
+++ b/docs/tools/image-generation.md
@@ -9,10 +9,11 @@ sidebarTitle: "Image generation"
 ---
 
 The `image_generate` tool lets the agent create and edit images using your
-configured providers. Generated images are returned as structured media
-attachments. On routes that require the `message` tool for visible replies,
-the agent must send the generated images through `message`; OpenClaw does not
-auto-post a private final reply as a fallback.
+configured providers. In chat sessions, image generation runs asynchronously:
+OpenClaw records a background task, returns the task id immediately, and wakes
+the agent when the provider finishes. The completion agent must send generated
+images through the `message` tool; OpenClaw does not auto-post a private final
+reply as a fallback.
 
 <Note>
 The tool only appears when at least one image-generation provider is
@@ -54,9 +55,9 @@ or sign in with OpenAI Codex OAuth.
     _"Generate an image of a friendly robot mascot."_
 
     The agent calls `image_generate` automatically. No tool allow-listing
-    needed - it is enabled by default when a provider is available. In
-    message-tool-only channels, the agent then sends the generated attachment
-    through the `message` tool.
+    needed - it is enabled by default when a provider is available. The tool
+    returns a background task id, then the completion agent sends the generated
+    attachment through the `message` tool when it is ready.
 
   </Step>
 </Steps>
@@ -109,6 +110,13 @@ Use `action: "list"` to inspect available providers and models at runtime:
 /tool image_generate action=list
 ```
 
+Use `action: "status"` to inspect the active image-generation task for the
+current session:
+
+```text
+/tool image_generate action=status
+```
+
 ## Provider capabilities
 
 | Capability            | ComfyUI            | DeepInfra | fal                       | Google         | MiniMax               | OpenAI         | Vydra | xAI            |
@@ -124,8 +132,9 @@ Use `action: "list"` to inspect available providers and models at runtime:
 <ParamField path="prompt" type="string" required>
   Image generation prompt. Required for `action: "generate"`.
 </ParamField>
-<ParamField path="action" type='"generate" | "list"' default="generate">
-  Use `"list"` to inspect available providers and models at runtime.
+<ParamField path="action" type='"generate" | "status" | "list"' default="generate">
+  Use `"status"` to inspect the active session task or `"list"` to inspect
+  available providers and models at runtime.
 </ParamField>
 <ParamField path="model" type="string">
   Provider/model override (e.g. `openai/gpt-image-2`). Use

--- a/docs/tools/media-overview.md
+++ b/docs/tools/media-overview.md
@@ -25,16 +25,16 @@ telephony, meetings, browser realtime, and native push-to-talk clients.
 <CardGroup cols={2}>
   <Card title="Image generation" href="/tools/image-generation" icon="image">
     Create and edit images from text prompts or reference images via
-    `image_generate`. Synchronous — returns structured media attachments for
-    the agent to deliver with the reply contract.
+    `image_generate`. Async in chat sessions — runs in the background and
+    posts the result when ready.
   </Card>
   <Card title="Video generation" href="/tools/video-generation" icon="video">
     Text-to-video, image-to-video, and video-to-video via `video_generate`.
     Async — runs in the background and posts the result when ready.
   </Card>
   <Card title="Music generation" href="/tools/music-generation" icon="music">
-    Generate music or audio tracks via `music_generate`. Async on shared
-    providers; ComfyUI workflow path runs synchronously.
+    Generate music or audio tracks via `music_generate`. Async in chat
+    sessions on the shared media-generation task lifecycle.
   </Card>
   <Card title="Text-to-speech" href="/tools/tts" icon="microphone">
     Convert outbound replies to spoken audio via the `tts` tool plus
@@ -87,13 +87,12 @@ reply model.
 
 ## Async vs synchronous
 
-| Capability      | Mode         | Why                                                                                                  |
-| --------------- | ------------ | ---------------------------------------------------------------------------------------------------- |
-| Image           | Synchronous  | Provider responses return in seconds; tool-result media follows the current reply contract.          |
-| Text-to-speech  | Synchronous  | Provider responses return in seconds; attached to the reply audio.                                   |
-| Video           | Asynchronous | Provider processing takes 30 s to several minutes; slow queues can run up to the configured timeout. |
-| Music (shared)  | Asynchronous | Same provider-processing characteristic as video.                                                    |
-| Music (ComfyUI) | Synchronous  | Local workflow runs inline against the configured ComfyUI server.                                    |
+| Capability     | Mode         | Why                                                                                                  |
+| -------------- | ------------ | ---------------------------------------------------------------------------------------------------- |
+| Image          | Asynchronous | Provider processing can outlive a chat turn; generated attachments use the shared completion path.   |
+| Text-to-speech | Synchronous  | Provider responses return in seconds; attached to the reply audio.                                   |
+| Video          | Asynchronous | Provider processing takes 30 s to several minutes; slow queues can run up to the configured timeout. |
+| Music          | Asynchronous | Same provider-processing characteristic as video.                                                    |
 
 For async tools, OpenClaw submits the request to the provider, returns a task
 id immediately, and tracks the job in the task ledger. The agent continues

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -13,6 +13,7 @@ import type { ContextEngine } from "../../context-engine/types.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { __testing as cliBackendsTesting } from "../cli-backends.js";
 import { hashCliSessionText } from "../cli-session.js";
+import { buildActiveImageGenerationTaskPromptContextForSession } from "../image-generation-task-status.js";
 import { buildActiveMusicGenerationTaskPromptContextForSession } from "../music-generation-task-status.js";
 import { buildActiveVideoGenerationTaskPromptContextForSession } from "../video-generation-task-status.js";
 import {
@@ -50,6 +51,16 @@ vi.mock("../video-generation-task-status.js", () => ({
   isActiveVideoGenerationTask: vi.fn(() => false),
 }));
 
+vi.mock("../image-generation-task-status.js", () => ({
+  IMAGE_GENERATION_TASK_KIND: "image_generation",
+  buildActiveImageGenerationTaskPromptContextForSession: vi.fn(() => undefined),
+  buildImageGenerationTaskStatusDetails: vi.fn(() => ({})),
+  buildImageGenerationTaskStatusText: vi.fn(() => ""),
+  findActiveImageGenerationTaskForSession: vi.fn(() => undefined),
+  getImageGenerationTaskProviderId: vi.fn(() => undefined),
+  isActiveImageGenerationTask: vi.fn(() => false),
+}));
+
 vi.mock("../music-generation-task-status.js", () => ({
   MUSIC_GENERATION_TASK_KIND: "music_generation",
   buildActiveMusicGenerationTaskPromptContextForSession: vi.fn(() => undefined),
@@ -61,6 +72,9 @@ vi.mock("../music-generation-task-status.js", () => ({
 const mockGetGlobalHookRunner = vi.mocked(getGlobalHookRunner);
 const mockBuildActiveVideoGenerationTaskPromptContextForSession = vi.mocked(
   buildActiveVideoGenerationTaskPromptContextForSession,
+);
+const mockBuildActiveImageGenerationTaskPromptContextForSession = vi.mocked(
+  buildActiveImageGenerationTaskPromptContextForSession,
 );
 const mockBuildActiveMusicGenerationTaskPromptContextForSession = vi.mocked(
   buildActiveMusicGenerationTaskPromptContextForSession,
@@ -187,6 +201,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
     });
     mockGetGlobalHookRunner.mockReturnValue(null);
     getRuntimeConfigMock.mockReturnValue({});
+    mockBuildActiveImageGenerationTaskPromptContextForSession.mockReturnValue(undefined);
     mockBuildActiveVideoGenerationTaskPromptContextForSession.mockReturnValue(undefined);
     mockBuildActiveMusicGenerationTaskPromptContextForSession.mockReturnValue(undefined);
   });
@@ -195,6 +210,7 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
     cliBackendsTesting.resetDepsForTest();
     getRuntimeConfigMock.mockReset();
     mockGetGlobalHookRunner.mockReset();
+    mockBuildActiveImageGenerationTaskPromptContextForSession.mockReset();
     mockBuildActiveVideoGenerationTaskPromptContextForSession.mockReset();
     mockBuildActiveMusicGenerationTaskPromptContextForSession.mockReset();
     vi.unstubAllEnvs();
@@ -887,6 +903,9 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
   it("applies direct-run prepend system context helpers on the CLI path", async () => {
     const { dir, sessionFile } = createSessionFile();
     try {
+      mockBuildActiveImageGenerationTaskPromptContextForSession.mockReturnValue(
+        "active image task",
+      );
       mockBuildActiveVideoGenerationTaskPromptContextForSession.mockReturnValue(
         "active video task",
       );
@@ -915,7 +934,10 @@ describe("shouldSkipLocalCliCredentialEpoch", () => {
       });
 
       expect(context.systemPrompt).toBe(
-        "active video task\n\nhook prepend system\n\nhook system\n\nCurrent model identity: test-cli/test-model. If asked what model you are, answer with this value for the current run.",
+        "active image task\n\nactive video task\n\nhook prepend system\n\nhook system\n\nCurrent model identity: test-cli/test-model. If asked what model you are, answer with this value for the current run.",
+      );
+      expect(mockBuildActiveImageGenerationTaskPromptContextForSession).toHaveBeenCalledWith(
+        "agent:main:test",
       );
       expect(mockBuildActiveVideoGenerationTaskPromptContextForSession).toHaveBeenCalledWith(
         "agent:main:test",

--- a/src/agents/image-generation-task-status.test.ts
+++ b/src/agents/image-generation-task-status.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildActiveImageGenerationTaskPromptContextForSession,
+  buildImageGenerationTaskStatusDetails,
+  buildImageGenerationTaskStatusText,
+  findActiveImageGenerationTaskForSession,
+  getImageGenerationTaskProviderId,
+  isActiveImageGenerationTask,
+  IMAGE_GENERATION_TASK_KIND,
+} from "./image-generation-task-status.js";
+
+const taskRuntimeInternalMocks = vi.hoisted(() => ({
+  listTasksForOwnerKey: vi.fn(),
+}));
+
+vi.mock("../tasks/runtime-internal.js", () => taskRuntimeInternalMocks);
+
+function expectActiveImageGenerationTask(
+  task: ReturnType<typeof findActiveImageGenerationTaskForSession>,
+): NonNullable<ReturnType<typeof findActiveImageGenerationTaskForSession>> {
+  if (task == null) {
+    throw new Error("Expected active image generation task");
+  }
+  return task;
+}
+
+describe("image generation task status", () => {
+  beforeEach(() => {
+    taskRuntimeInternalMocks.listTasksForOwnerKey.mockReset();
+    taskRuntimeInternalMocks.listTasksForOwnerKey.mockReturnValue([]);
+  });
+
+  it("recognizes active session-backed image generation tasks", () => {
+    expect(
+      isActiveImageGenerationTask({
+        taskId: "task-1",
+        runtime: "cli",
+        taskKind: IMAGE_GENERATION_TASK_KIND,
+        sourceId: "image_generate:openai",
+        requesterSessionKey: "agent:main",
+        ownerKey: "agent:main",
+        scopeKind: "session",
+        task: "make watercolor robot",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        notifyPolicy: "silent",
+        createdAt: Date.now(),
+      }),
+    ).toBe(true);
+    expect(
+      isActiveImageGenerationTask({
+        taskId: "task-2",
+        runtime: "cron",
+        taskKind: IMAGE_GENERATION_TASK_KIND,
+        sourceId: "image_generate:openai",
+        requesterSessionKey: "agent:main",
+        ownerKey: "agent:main",
+        scopeKind: "session",
+        task: "make watercolor robot",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        notifyPolicy: "silent",
+        createdAt: Date.now(),
+      }),
+    ).toBe(false);
+  });
+
+  it("prefers a running task over queued session siblings", () => {
+    taskRuntimeInternalMocks.listTasksForOwnerKey.mockReturnValue([
+      {
+        taskId: "task-queued",
+        runtime: "cli",
+        taskKind: IMAGE_GENERATION_TASK_KIND,
+        sourceId: "image_generate:google",
+        requesterSessionKey: "agent:main",
+        ownerKey: "agent:main",
+        scopeKind: "session",
+        task: "queued task",
+        status: "queued",
+        deliveryStatus: "not_applicable",
+        notifyPolicy: "silent",
+        createdAt: Date.now(),
+      },
+      {
+        taskId: "task-running",
+        runtime: "cli",
+        taskKind: IMAGE_GENERATION_TASK_KIND,
+        sourceId: "image_generate:openai",
+        requesterSessionKey: "agent:main",
+        ownerKey: "agent:main",
+        scopeKind: "session",
+        task: "running task",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        notifyPolicy: "silent",
+        createdAt: Date.now(),
+        progressSummary: "Generating image",
+      },
+    ]);
+
+    const task = findActiveImageGenerationTaskForSession("agent:main");
+
+    expect(task?.taskId).toBe("task-running");
+    const activeTask = expectActiveImageGenerationTask(task);
+    expect(getImageGenerationTaskProviderId(activeTask)).toBe("openai");
+    expect(buildImageGenerationTaskStatusText(activeTask, { duplicateGuard: true })).toContain(
+      "Do not call image_generate again for this request.",
+    );
+    const details = buildImageGenerationTaskStatusDetails(activeTask);
+    expect(details.active).toBe(true);
+    expect(details.existingTask).toBe(true);
+    expect(details.status).toBe("running");
+    expect(details.taskKind).toBe(IMAGE_GENERATION_TASK_KIND);
+    expect(details.provider).toBe("openai");
+    expect(details.progressSummary).toBe("Generating image");
+  });
+
+  it("builds prompt context for active session work", () => {
+    taskRuntimeInternalMocks.listTasksForOwnerKey.mockReturnValue([
+      {
+        taskId: "task-running",
+        runtime: "cli",
+        taskKind: IMAGE_GENERATION_TASK_KIND,
+        sourceId: "image_generate:openai",
+        requesterSessionKey: "agent:main",
+        ownerKey: "agent:main",
+        scopeKind: "session",
+        task: "running task",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        notifyPolicy: "silent",
+        createdAt: Date.now(),
+        progressSummary: "Generating image",
+      },
+    ]);
+
+    const context = buildActiveImageGenerationTaskPromptContextForSession("agent:main");
+
+    expect(context).toContain("An active image generation background task already exists");
+    expect(context).toContain("Task task-running is currently running via openai.");
+    expect(context).toContain('call `image_generate` with `action:"status"`');
+  });
+});

--- a/src/agents/image-generation-task-status.ts
+++ b/src/agents/image-generation-task-status.ts
@@ -1,0 +1,67 @@
+import type { TaskRecord } from "../tasks/task-registry.types.js";
+import {
+  buildActiveMediaGenerationTaskPromptContextForSession,
+  buildMediaGenerationTaskStatusDetails,
+  buildMediaGenerationTaskStatusText,
+  findActiveMediaGenerationTaskForSession,
+  getMediaGenerationTaskProviderId,
+  isActiveMediaGenerationTask,
+} from "./media-generation-task-status-shared.js";
+
+export const IMAGE_GENERATION_TASK_KIND = "image_generation";
+const IMAGE_GENERATION_SOURCE_PREFIX = "image_generate";
+
+export function isActiveImageGenerationTask(task: TaskRecord): boolean {
+  return isActiveMediaGenerationTask({
+    task,
+    taskKind: IMAGE_GENERATION_TASK_KIND,
+  });
+}
+
+export function getImageGenerationTaskProviderId(task: TaskRecord): string | undefined {
+  return getMediaGenerationTaskProviderId(task, IMAGE_GENERATION_SOURCE_PREFIX);
+}
+
+export function findActiveImageGenerationTaskForSession(
+  sessionKey?: string,
+): TaskRecord | undefined {
+  return findActiveMediaGenerationTaskForSession({
+    sessionKey,
+    taskKind: IMAGE_GENERATION_TASK_KIND,
+    sourcePrefix: IMAGE_GENERATION_SOURCE_PREFIX,
+  });
+}
+
+export function buildImageGenerationTaskStatusDetails(task: TaskRecord): Record<string, unknown> {
+  return buildMediaGenerationTaskStatusDetails({
+    task,
+    sourcePrefix: IMAGE_GENERATION_SOURCE_PREFIX,
+  });
+}
+
+export function buildImageGenerationTaskStatusText(
+  task: TaskRecord,
+  params?: { duplicateGuard?: boolean },
+): string {
+  return buildMediaGenerationTaskStatusText({
+    task,
+    sourcePrefix: IMAGE_GENERATION_SOURCE_PREFIX,
+    nounLabel: "Image generation",
+    toolName: "image_generate",
+    completionLabel: "image",
+    duplicateGuard: params?.duplicateGuard,
+  });
+}
+
+export function buildActiveImageGenerationTaskPromptContextForSession(
+  sessionKey?: string,
+): string | undefined {
+  return buildActiveMediaGenerationTaskPromptContextForSession({
+    sessionKey,
+    taskKind: IMAGE_GENERATION_TASK_KIND,
+    sourcePrefix: IMAGE_GENERATION_SOURCE_PREFIX,
+    nounLabel: "Image generation",
+    toolName: "image_generate",
+    completionLabel: "images",
+  });
+}

--- a/src/agents/internal-event-contract.ts
+++ b/src/agents/internal-event-contract.ts
@@ -3,6 +3,7 @@ export const AGENT_INTERNAL_EVENT_TYPE_TASK_COMPLETION = "task_completion" as co
 export const AGENT_INTERNAL_EVENT_SOURCES = [
   "subagent",
   "cron",
+  "image_generation",
   "video_generation",
   "music_generation",
 ] as const;

--- a/src/agents/media-generation-task-status-shared.ts
+++ b/src/agents/media-generation-task-status-shared.ts
@@ -66,8 +66,8 @@ export function buildMediaGenerationTaskStatusText(params: {
     `${params.nounLabel} task ${params.task.taskId} is already ${params.task.status}${provider ? ` with ${provider}` : ""}.`,
     params.task.progressSummary ? `Progress: ${params.task.progressSummary}.` : null,
     params.duplicateGuard
-      ? `Do not call ${params.toolName} again for this request. Wait for the completion event; I will post the finished ${params.completionLabel} here.`
-      : `Wait for the completion event; I will post the finished ${params.completionLabel} here when it's ready.`,
+      ? `Do not call ${params.toolName} again for this request. Wait for the completion event; the completion agent will send the finished ${params.completionLabel} here.`
+      : `Wait for the completion event; the completion agent will send the finished ${params.completionLabel} here when it's ready.`,
   ].filter((entry): entry is string => Boolean(entry));
   return lines.join("\n");
 }

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -224,6 +224,8 @@ export function createOpenClawTools(
         config: options?.config,
         agentDir: options?.agentDir,
         authProfileStore: options?.authProfileStore,
+        agentSessionKey: options?.agentSessionKey,
+        requesterOrigin: deliveryContext ?? undefined,
         workspaceDir,
         sandbox,
         fsPolicy: options?.fsPolicy,

--- a/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.test.ts
@@ -8,6 +8,16 @@ const musicGenerationTaskStatusMocks = vi.hoisted(() => ({
   MUSIC_GENERATION_TASK_KIND: "music_generation",
 }));
 
+const imageGenerationTaskStatusMocks = vi.hoisted(() => ({
+  buildActiveImageGenerationTaskPromptContextForSession: vi.fn(),
+  buildImageGenerationTaskStatusDetails: vi.fn(() => ({})),
+  buildImageGenerationTaskStatusText: vi.fn(() => "Image generation task status"),
+  findActiveImageGenerationTaskForSession: vi.fn(),
+  getImageGenerationTaskProviderId: vi.fn(),
+  isActiveImageGenerationTask: vi.fn(() => false),
+  IMAGE_GENERATION_TASK_KIND: "image_generation",
+}));
+
 const videoGenerationTaskStatusMocks = vi.hoisted(() => ({
   buildActiveVideoGenerationTaskPromptContextForSession: vi.fn(),
   buildVideoGenerationTaskStatusDetails: vi.fn(() => ({})),
@@ -22,6 +32,7 @@ const hostHookStateMocks = vi.hoisted(() => ({
   drainPluginNextTurnInjectionContext: vi.fn(),
 }));
 
+vi.mock("../../image-generation-task-status.js", () => imageGenerationTaskStatusMocks);
 vi.mock("../../music-generation-task-status.js", () => musicGenerationTaskStatusMocks);
 vi.mock("../../video-generation-task-status.js", () => videoGenerationTaskStatusMocks);
 vi.mock("../../../plugins/host-hook-state.js", () => hostHookStateMocks);
@@ -35,6 +46,9 @@ import {
 
 describe("resolveAttemptPrependSystemContext", () => {
   it("prepends active video task guidance ahead of hook system context", () => {
+    imageGenerationTaskStatusMocks.buildActiveImageGenerationTaskPromptContextForSession.mockReturnValue(
+      "Image task hint",
+    );
     videoGenerationTaskStatusMocks.buildActiveVideoGenerationTaskPromptContextForSession.mockReturnValue(
       "Active task hint",
     );
@@ -49,15 +63,24 @@ describe("resolveAttemptPrependSystemContext", () => {
     });
 
     expect(
+      imageGenerationTaskStatusMocks.buildActiveImageGenerationTaskPromptContextForSession,
+    ).toHaveBeenCalledWith("agent:main:discord:direct:123");
+    expect(
       videoGenerationTaskStatusMocks.buildActiveVideoGenerationTaskPromptContextForSession,
     ).toHaveBeenCalledWith("agent:main:discord:direct:123");
     expect(
       musicGenerationTaskStatusMocks.buildActiveMusicGenerationTaskPromptContextForSession,
     ).toHaveBeenCalledWith("agent:main:discord:direct:123");
-    expect(result).toBe("Active task hint\n\nMusic task hint\n\nHook system context");
+    expect(result).toBe(
+      "Image task hint\n\nActive task hint\n\nMusic task hint\n\nHook system context",
+    );
   });
 
   it("skips active video task guidance for non-user triggers", () => {
+    imageGenerationTaskStatusMocks.buildActiveImageGenerationTaskPromptContextForSession.mockReset();
+    imageGenerationTaskStatusMocks.buildActiveImageGenerationTaskPromptContextForSession.mockReturnValue(
+      "Should not be used",
+    );
     videoGenerationTaskStatusMocks.buildActiveVideoGenerationTaskPromptContextForSession.mockReset();
     videoGenerationTaskStatusMocks.buildActiveVideoGenerationTaskPromptContextForSession.mockReturnValue(
       "Should not be used",
@@ -73,6 +96,9 @@ describe("resolveAttemptPrependSystemContext", () => {
       hookPrependSystemContext: "Hook system context",
     });
 
+    expect(
+      imageGenerationTaskStatusMocks.buildActiveImageGenerationTaskPromptContextForSession,
+    ).not.toHaveBeenCalled();
     expect(
       videoGenerationTaskStatusMocks.buildActiveVideoGenerationTaskPromptContextForSession,
     ).not.toHaveBeenCalled();

--- a/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts
@@ -16,6 +16,7 @@ import { isCronSessionKey, isSubagentSessionKey } from "../../../routing/session
 import { joinPresentTextSegments } from "../../../shared/text/join-segments.js";
 import { listActiveProcessSessionReferences } from "../../bash-process-references.js";
 import { resolveHeartbeatPromptForSystemPrompt } from "../../heartbeat-system-prompt.js";
+import { buildActiveImageGenerationTaskPromptContextForSession } from "../../image-generation-task-status.js";
 import { buildActiveMusicGenerationTaskPromptContextForSession } from "../../music-generation-task-status.js";
 import { resolveProcessToolScopeKey } from "../../pi-tools.js";
 import { prependSystemPromptAdditionAfterCacheBoundary } from "../../system-prompt-cache-boundary.js";
@@ -479,6 +480,7 @@ export function resolveAttemptPrependSystemContext(params: {
   const activeMediaTaskPromptContexts =
     params.trigger === "user" || params.trigger === "manual"
       ? [
+          buildActiveImageGenerationTaskPromptContextForSession(params.sessionKey),
           buildActiveVideoGenerationTaskPromptContextForSession(params.sessionKey),
           buildActiveMusicGenerationTaskPromptContextForSession(params.sessionKey),
         ]

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -1333,6 +1333,60 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
+  it("requires generated image completion DMs to use the message tool", async () => {
+    const callGateway = createGatewayMock({
+      result: {
+        payloads: [],
+        messagingToolSentTargets: [
+          {
+            tool: "message",
+            provider: "discord",
+            accountId: "acct-1",
+            to: "dm:U123",
+            text: "The image is ready.",
+            mediaUrls: ["/tmp/generated-robot.png"],
+          },
+        ],
+      },
+    });
+    const sendMessage = createSendMessageMock();
+    const result = await deliverDiscordDirectMessageCompletion({
+      callGateway,
+      sendMessage,
+      sourceTool: "image_generate",
+      internalEvents: [
+        {
+          type: "task_completion",
+          source: "image_generation",
+          childSessionKey: "image_generate:task-123",
+          childSessionId: "task-123",
+          announceType: "image generation task",
+          taskLabel: "small watercolor robot",
+          status: "ok",
+          statusLabel: "completed successfully",
+          result: "Generated 1 image.\nMEDIA:/tmp/generated-robot.png",
+          mediaUrls: ["/tmp/generated-robot.png"],
+          replyInstruction:
+            "Tell the user the image is ready and send it through the message tool.",
+        },
+      ],
+    });
+
+    expectRecordFields(result, {
+      delivered: true,
+      path: "direct",
+    });
+    expectGatewayAgentParams(callGateway, {
+      deliver: false,
+      channel: "discord",
+      accountId: "acct-1",
+      to: "dm:U123",
+      threadId: undefined,
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
   it("accepts failed generated media completion notices through the message tool", async () => {
     const callGateway = createGatewayMock({
       result: {

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -57,7 +57,11 @@ import type { SpawnSubagentMode } from "./subagent-spawn.types.js";
 
 const DEFAULT_SUBAGENT_ANNOUNCE_TIMEOUT_MS = 120_000;
 const MAX_TIMER_SAFE_TIMEOUT_MS = 2_147_000_000;
-const AGENT_MEDIATED_COMPLETION_TOOLS = new Set(["music_generate", "video_generate"]);
+const AGENT_MEDIATED_COMPLETION_TOOLS = new Set([
+  "image_generate",
+  "music_generate",
+  "video_generate",
+]);
 
 type SubagentAnnounceDeliveryDeps = {
   dispatchGatewayMethodInProcess: typeof dispatchGatewayMethodInProcess;

--- a/src/agents/tools/image-generate-background.test.ts
+++ b/src/agents/tools/image-generate-background.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { IMAGE_GENERATION_TASK_KIND } from "../image-generation-task-status.js";
+import {
+  announceDeliveryMocks,
+  createMediaCompletionFixture,
+  expectFallbackMediaAnnouncement,
+  expectQueuedTaskRun,
+  expectRecordedTaskProgress,
+  resetMediaBackgroundMocks,
+  taskDeliveryRuntimeMocks,
+  taskExecutorMocks,
+} from "./media-generate-background.test-support.js";
+
+vi.mock("../../tasks/detached-task-runtime.js", () => taskExecutorMocks);
+vi.mock("../../tasks/task-registry-delivery-runtime.js", () => taskDeliveryRuntimeMocks);
+vi.mock("../subagent-announce-delivery.js", () => announceDeliveryMocks);
+
+const {
+  createImageGenerationTaskRun,
+  recordImageGenerationTaskProgress,
+  wakeImageGenerationTaskCompletion,
+} = await import("./image-generate-background.js");
+
+function getDeliveredInternalEvents(): Array<Record<string, unknown>> {
+  const params = announceDeliveryMocks.deliverSubagentAnnouncement.mock.calls.at(0)?.[0] as
+    | { internalEvents?: unknown }
+    | undefined;
+  if (!Array.isArray(params?.internalEvents)) {
+    throw new Error("Expected delivered internal events");
+  }
+  return params.internalEvents as Array<Record<string, unknown>>;
+}
+
+function expectReplyInstructionContains(text: string) {
+  const event = getDeliveredInternalEvents().find(
+    (item) => typeof item.replyInstruction === "string" && item.replyInstruction.includes(text),
+  );
+  if (!event) {
+    throw new Error(`Expected reply instruction containing ${text}`);
+  }
+}
+
+describe("image generate background helpers", () => {
+  beforeEach(() => {
+    resetMediaBackgroundMocks({
+      taskExecutorMocks,
+      taskDeliveryRuntimeMocks,
+      announceDeliveryMocks,
+    });
+  });
+
+  it("creates a running task with queued progress text", () => {
+    taskExecutorMocks.createRunningTaskRun.mockReturnValue({
+      taskId: "task-123",
+    });
+
+    const handle = createImageGenerationTaskRun({
+      sessionKey: "agent:main:discord:direct:123",
+      requesterOrigin: {
+        channel: "discord",
+        to: "channel:1",
+      },
+      prompt: "small watercolor robot",
+      providerId: "openai",
+    });
+
+    if (!handle) {
+      throw new Error("Expected image generation task handle");
+    }
+    expect(handle.taskId).toBe("task-123");
+    expect(handle.requesterSessionKey).toBe("agent:main:discord:direct:123");
+    expect(handle.taskLabel).toBe("small watercolor robot");
+    expectQueuedTaskRun({
+      taskExecutorMocks,
+      taskKind: IMAGE_GENERATION_TASK_KIND,
+      sourceId: "image_generate:openai",
+      progressSummary: "Queued image generation",
+    });
+  });
+
+  it("records task progress updates", () => {
+    recordImageGenerationTaskProgress({
+      handle: {
+        taskId: "task-123",
+        runId: "tool:image_generate:abc",
+        requesterSessionKey: "agent:main:discord:direct:123",
+        taskLabel: "small watercolor robot",
+      },
+      progressSummary: "Saving generated image",
+    });
+
+    expectRecordedTaskProgress({
+      taskExecutorMocks,
+      runId: "tool:image_generate:abc",
+      progressSummary: "Saving generated image",
+    });
+  });
+
+  it("queues a completion event through the shared generated-media wake path", async () => {
+    announceDeliveryMocks.deliverSubagentAnnouncement.mockResolvedValue({
+      delivered: true,
+      path: "direct",
+    });
+
+    await wakeImageGenerationTaskCompletion({
+      ...createMediaCompletionFixture({
+        runId: "tool:image_generate:abc",
+        taskLabel: "small watercolor robot",
+        result: "Generated 1 image.\nMEDIA:/tmp/generated-robot.png",
+        mediaUrls: ["/tmp/generated-robot.png"],
+      }),
+    });
+
+    expect(taskDeliveryRuntimeMocks.sendMessage).not.toHaveBeenCalled();
+    expectFallbackMediaAnnouncement({
+      deliverAnnouncementMock: announceDeliveryMocks.deliverSubagentAnnouncement,
+      requesterSessionKey: "agent:main:discord:direct:123",
+      channel: "discord",
+      to: "channel:1",
+      source: "image_generation",
+      announceType: "image generation task",
+      resultMediaPath: "MEDIA:/tmp/generated-robot.png",
+      mediaUrls: ["/tmp/generated-robot.png"],
+    });
+  });
+
+  it("routes failure completion notices through the message tool", async () => {
+    announceDeliveryMocks.deliverSubagentAnnouncement.mockResolvedValue({
+      delivered: true,
+      path: "direct",
+    });
+    const completion = createMediaCompletionFixture({
+      runId: "tool:image_generate:abc",
+      taskLabel: "small watercolor robot",
+      result: "provider failed",
+    });
+
+    await wakeImageGenerationTaskCompletion({
+      ...completion,
+      status: "error",
+      statusLabel: "failed",
+    });
+
+    expectReplyInstructionContains("failure summary");
+    expectReplyInstructionContains("the user will NOT see your normal assistant final reply");
+    expectReplyInstructionContains('message tool with action="send"');
+  });
+});

--- a/src/agents/tools/image-generate-background.ts
+++ b/src/agents/tools/image-generate-background.ts
@@ -1,0 +1,50 @@
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { AgentGeneratedAttachment } from "../generated-attachments.js";
+import { IMAGE_GENERATION_TASK_KIND } from "../image-generation-task-status.js";
+import {
+  createMediaGenerationTaskLifecycle,
+  type MediaGenerationTaskHandle,
+} from "./media-generate-background-shared.js";
+
+export type ImageGenerationTaskHandle = MediaGenerationTaskHandle;
+
+export const imageGenerationTaskLifecycle = createMediaGenerationTaskLifecycle({
+  toolName: "image_generate",
+  taskKind: IMAGE_GENERATION_TASK_KIND,
+  label: "Image generation",
+  queuedProgressSummary: "Queued image generation",
+  generatedLabel: "image",
+  failureProgressSummary: "Image generation failed",
+  eventSource: "image_generation",
+  announceType: "image generation task",
+  completionLabel: "image",
+});
+
+export const createImageGenerationTaskRun = (
+  ...params: Parameters<typeof imageGenerationTaskLifecycle.createTaskRun>
+) => imageGenerationTaskLifecycle.createTaskRun(...params);
+
+export const recordImageGenerationTaskProgress = (
+  ...params: Parameters<typeof imageGenerationTaskLifecycle.recordTaskProgress>
+) => imageGenerationTaskLifecycle.recordTaskProgress(...params);
+
+export const completeImageGenerationTaskRun = (
+  ...params: Parameters<typeof imageGenerationTaskLifecycle.completeTaskRun>
+) => imageGenerationTaskLifecycle.completeTaskRun(...params);
+
+export const failImageGenerationTaskRun = (
+  ...params: Parameters<typeof imageGenerationTaskLifecycle.failTaskRun>
+) => imageGenerationTaskLifecycle.failTaskRun(...params);
+
+export async function wakeImageGenerationTaskCompletion(params: {
+  config?: OpenClawConfig;
+  handle: ImageGenerationTaskHandle | null;
+  status: "ok" | "error";
+  statusLabel: string;
+  result: string;
+  attachments?: AgentGeneratedAttachment[];
+  mediaUrls?: string[];
+  statsLine?: string;
+}) {
+  await imageGenerationTaskLifecycle.wakeTaskCompletion(params);
+}

--- a/src/agents/tools/image-generate-tool.actions.ts
+++ b/src/agents/tools/image-generate-tool.actions.ts
@@ -1,0 +1,97 @@
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { listRuntimeImageGenerationProviders } from "../../image-generation/runtime.js";
+import type { ImageGenerationProvider } from "../../image-generation/types.js";
+import type { AuthProfileStore } from "../auth-profiles/types.js";
+import {
+  buildImageGenerationTaskStatusDetails,
+  buildImageGenerationTaskStatusText,
+  findActiveImageGenerationTaskForSession,
+} from "../image-generation-task-status.js";
+import {
+  createMediaGenerateProviderListActionResult,
+  createMediaGenerateTaskStatusActions,
+  type MediaGenerateActionResult,
+} from "./media-generate-tool-actions-shared.js";
+
+export type ImageGenerateActionResult = MediaGenerateActionResult;
+
+export function formatImageGenerationAuthHint(provider: {
+  id: string;
+  authEnvVars: readonly string[];
+}): string | undefined {
+  if (provider.id === "openai") {
+    return "set OPENAI_API_KEY or configure OpenAI Codex OAuth for openai/gpt-image-2";
+  }
+  if (provider.authEnvVars.length === 0) {
+    return undefined;
+  }
+  return `set ${provider.authEnvVars.join(" / ")} to use ${provider.id}/*`;
+}
+
+export function listSupportedImageGenerationModes(provider: ImageGenerationProvider): string[] {
+  return ["generate", ...(provider.capabilities.edit.enabled ? ["edit"] : [])];
+}
+
+export function summarizeImageGenerationCapabilities(provider: ImageGenerationProvider): string {
+  const caps: string[] = [];
+  if (provider.capabilities.edit.enabled) {
+    const maxRefs = provider.capabilities.edit.maxInputImages;
+    caps.push(
+      `editing${typeof maxRefs === "number" ? ` up to ${maxRefs} ref${maxRefs === 1 ? "" : "s"}` : ""}`,
+    );
+  }
+  if ((provider.capabilities.geometry?.resolutions?.length ?? 0) > 0) {
+    caps.push(`resolutions ${provider.capabilities.geometry?.resolutions?.join("/")}`);
+  }
+  if ((provider.capabilities.geometry?.sizes?.length ?? 0) > 0) {
+    caps.push(`sizes ${provider.capabilities.geometry?.sizes?.join(", ")}`);
+  }
+  if ((provider.capabilities.geometry?.aspectRatios?.length ?? 0) > 0) {
+    caps.push(`aspect ratios ${provider.capabilities.geometry?.aspectRatios?.join(", ")}`);
+  }
+  if ((provider.capabilities.output?.formats?.length ?? 0) > 0) {
+    caps.push(`formats ${provider.capabilities.output?.formats?.join("/")}`);
+  }
+  if ((provider.capabilities.output?.backgrounds?.length ?? 0) > 0) {
+    caps.push(`backgrounds ${provider.capabilities.output?.backgrounds?.join("/")}`);
+  }
+  return caps.join("; ");
+}
+
+export function createImageGenerateListActionResult(params: {
+  cfg?: OpenClawConfig;
+  agentDir?: string;
+  authStore?: AuthProfileStore;
+}): ImageGenerateActionResult {
+  const providers = listRuntimeImageGenerationProviders({ config: params.cfg });
+  return createMediaGenerateProviderListActionResult({
+    kind: "image_generation",
+    providers,
+    emptyText: "No image-generation providers are registered.",
+    cfg: params.cfg,
+    agentDir: params.agentDir,
+    authStore: params.authStore,
+    listModes: listSupportedImageGenerationModes,
+    summarizeCapabilities: summarizeImageGenerationCapabilities,
+    formatAuthHint: formatImageGenerationAuthHint,
+  });
+}
+
+const imageGenerateTaskStatusActions = createMediaGenerateTaskStatusActions({
+  inactiveText: "No active image generation task is currently running for this session.",
+  findActiveTask: (sessionKey) => findActiveImageGenerationTaskForSession(sessionKey) ?? undefined,
+  buildStatusText: buildImageGenerationTaskStatusText,
+  buildStatusDetails: buildImageGenerationTaskStatusDetails,
+});
+
+export function createImageGenerateStatusActionResult(
+  sessionKey?: string,
+): ImageGenerateActionResult {
+  return imageGenerateTaskStatusActions.createStatusActionResult(sessionKey);
+}
+
+export function createImageGenerateDuplicateGuardResult(
+  sessionKey?: string,
+): ImageGenerateActionResult | undefined {
+  return imageGenerateTaskStatusActions.createDuplicateGuardResult(sessionKey);
+}

--- a/src/agents/tools/image-generate-tool.test.ts
+++ b/src/agents/tools/image-generate-tool.test.ts
@@ -1,5 +1,14 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
+const taskRuntimeMocks = vi.hoisted(() => ({
+  createRunningTaskRun: vi.fn(),
+  recordTaskRunProgressByRunId: vi.fn(),
+  completeTaskRunByRunId: vi.fn(),
+  failTaskRunByRunId: vi.fn(),
+}));
+
+vi.mock("../../tasks/detached-task-runtime.js", () => taskRuntimeMocks);
+
 let imageGenerationRuntime: typeof import("../../image-generation/runtime.js");
 let imageOps: typeof import("../../media/image-ops.js");
 let splitMediaFromOutput: typeof import("../../media/parse.js").splitMediaFromOutput;
@@ -291,6 +300,10 @@ describe("createImageGenerateTool", () => {
     for (const envVar of GENERATION_PROVIDER_ENV_VARS) {
       vi.stubEnv(envVar, "");
     }
+    taskRuntimeMocks.createRunningTaskRun.mockReset();
+    taskRuntimeMocks.recordTaskRunProgressByRunId.mockReset();
+    taskRuntimeMocks.completeTaskRunByRunId.mockReset();
+    taskRuntimeMocks.failTaskRunByRunId.mockReset();
   });
 
   afterEach(() => {
@@ -656,6 +669,71 @@ describe("createImageGenerateTool", () => {
     expect(text).toContain('path="/tmp/generated-1.png"');
     expect(text).toContain('path="/tmp/generated-2.png"');
     expect(text).not.toMatch(/^MEDIA:/m);
+  });
+
+  it("starts image generation asynchronously when a session delivery context is available", async () => {
+    stubImageGenerationProviders();
+    vi.stubEnv("OPENAI_API_KEY", "openai-test");
+    const generateImage = vi.spyOn(imageGenerationRuntime, "generateImage").mockResolvedValue({
+      provider: "openai",
+      model: "gpt-image-1",
+      attempts: [],
+      ignoredOverrides: [],
+      images: [
+        {
+          buffer: Buffer.from("png-out"),
+          mimeType: "image/png",
+          fileName: "cat.png",
+        },
+      ],
+    });
+    taskRuntimeMocks.createRunningTaskRun.mockReturnValue({
+      taskId: "task-image-123",
+    });
+    const scheduled: Array<() => Promise<void>> = [];
+    const tool = requireImageGenerateTool(
+      createImageGenerateTool({
+        config: {
+          agents: {
+            defaults: {
+              imageGenerationModel: {
+                primary: "openai/gpt-image-1",
+              },
+            },
+          },
+        },
+        agentDir: "/tmp/agent",
+        agentSessionKey: "agent:main:discord:direct:123",
+        requesterOrigin: {
+          channel: "discord",
+          to: "dm:123",
+        },
+        scheduleBackgroundWork: (work) => {
+          scheduled.push(work);
+        },
+      }),
+    );
+
+    const result = await tool.execute("call-async", {
+      prompt: "A cat wearing sunglasses",
+      model: "openai/gpt-image-1",
+    });
+
+    expect(generateImage).not.toHaveBeenCalled();
+    expect(scheduled).toHaveLength(1);
+    expect(resultText(result)).toContain("Background task started for image generation");
+    const details = resultDetails(result);
+    expect(details.async).toBe(true);
+    expect(details.status).toBe("started");
+    expect(details.taskId).toBe("task-image-123");
+    expect(taskRuntimeMocks.createRunningTaskRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskKind: "image_generation",
+        sourceId: "image_generate:openai",
+        requesterSessionKey: "agent:main:discord:direct:123",
+        progressSummary: "Queued image generation",
+      }),
+    );
   });
 
   it("uses configured timeoutMs for image generation and lets calls override it", async () => {

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -20,6 +20,7 @@ import type {
   ImageGenerationSourceImage,
 } from "../../image-generation/types.js";
 import type { SsrFPolicy } from "../../infra/net/ssrf.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import {
   resolveConfiguredMediaMaxBytes,
   resolveGeneratedMediaMaxBytes,
@@ -32,18 +33,38 @@ import {
 import { saveMediaBuffer } from "../../media/store.js";
 import { loadWebMedia } from "../../media/web-media.js";
 import { resolveUserPath } from "../../utils.js";
+import type { DeliveryContext } from "../../utils/delivery-context.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
-import { formatGeneratedAttachmentLines } from "../generated-attachments.js";
+import {
+  formatGeneratedAttachmentLines,
+  type AgentGeneratedAttachment,
+} from "../generated-attachments.js";
 import { optionalStringEnum } from "../schema/string-enum.js";
 import { ToolInputError, readNumberParam, readStringParam } from "./common.js";
+import {
+  completeImageGenerationTaskRun,
+  createImageGenerationTaskRun,
+  failImageGenerationTaskRun,
+  imageGenerationTaskLifecycle,
+  recordImageGenerationTaskProgress,
+  type ImageGenerationTaskHandle,
+} from "./image-generate-background.js";
+import {
+  createImageGenerateDuplicateGuardResult,
+  createImageGenerateListActionResult,
+  createImageGenerateStatusActionResult,
+} from "./image-generate-tool.actions.js";
 import { decodeDataUrl } from "./image-tool.helpers.js";
 import {
-  createMediaGenerateProviderListActionResult,
-  type MediaGenerateActionResult,
-} from "./media-generate-tool-actions-shared.js";
+  buildMediaGenerationStartedToolResult,
+  createDefaultMediaGenerateBackgroundScheduler,
+  scheduleMediaGenerationTaskCompletion,
+  type MediaGenerateBackgroundScheduler,
+} from "./media-generate-background-shared.js";
 import {
   applyImageGenerationModelConfigDefaults,
   buildMediaReferenceDetails,
+  buildTaskRunDetails,
   hasGenerationToolAvailability,
   normalizeMediaReferenceInputs,
   readGenerationTimeoutMs,
@@ -87,11 +108,13 @@ const SUPPORTED_ASPECT_RATIOS = new Set([
   "21:9",
 ]);
 
+const log = createSubsystemLogger("agents/tools/image-generate");
+
 const ImageGenerateToolSchema = Type.Object({
   action: Type.Optional(
     Type.String({
       description:
-        'Optional action: "generate" (default) or "list" to inspect available providers/models.',
+        'Optional action: "generate" (default), "status" to inspect the active session task, or "list" to inspect available providers/models.',
     }),
   ),
   prompt: Type.Optional(Type.String({ description: "Image generation prompt." })),
@@ -183,68 +206,6 @@ const ImageGenerateToolSchema = Type.Object({
   ),
 });
 
-function formatImageGenerationAuthHint(provider: {
-  id: string;
-  authEnvVars: readonly string[];
-}): string | undefined {
-  if (provider.id === "openai") {
-    return "set OPENAI_API_KEY or configure OpenAI Codex OAuth for openai/gpt-image-2";
-  }
-  if (provider.authEnvVars.length === 0) {
-    return undefined;
-  }
-  return `set ${provider.authEnvVars.join(" / ")} to use ${provider.id}/*`;
-}
-
-function listSupportedImageGenerationModes(provider: ImageGenerationProvider): string[] {
-  return ["generate", ...(provider.capabilities.edit.enabled ? ["edit"] : [])];
-}
-
-function summarizeImageGenerationCapabilities(provider: ImageGenerationProvider): string {
-  const caps: string[] = [];
-  if (provider.capabilities.edit.enabled) {
-    const maxRefs = provider.capabilities.edit.maxInputImages;
-    caps.push(
-      `editing${typeof maxRefs === "number" ? ` up to ${maxRefs} ref${maxRefs === 1 ? "" : "s"}` : ""}`,
-    );
-  }
-  if ((provider.capabilities.geometry?.resolutions?.length ?? 0) > 0) {
-    caps.push(`resolutions ${provider.capabilities.geometry?.resolutions?.join("/")}`);
-  }
-  if ((provider.capabilities.geometry?.sizes?.length ?? 0) > 0) {
-    caps.push(`sizes ${provider.capabilities.geometry?.sizes?.join(", ")}`);
-  }
-  if ((provider.capabilities.geometry?.aspectRatios?.length ?? 0) > 0) {
-    caps.push(`aspect ratios ${provider.capabilities.geometry?.aspectRatios?.join(", ")}`);
-  }
-  if ((provider.capabilities.output?.formats?.length ?? 0) > 0) {
-    caps.push(`formats ${provider.capabilities.output?.formats?.join("/")}`);
-  }
-  if ((provider.capabilities.output?.backgrounds?.length ?? 0) > 0) {
-    caps.push(`backgrounds ${provider.capabilities.output?.backgrounds?.join("/")}`);
-  }
-  return caps.join("; ");
-}
-
-function createImageGenerateListActionResult(params: {
-  cfg?: OpenClawConfig;
-  agentDir?: string;
-  authStore?: AuthProfileStore;
-}): MediaGenerateActionResult {
-  const providers = listRuntimeImageGenerationProviders({ config: params.cfg });
-  return createMediaGenerateProviderListActionResult({
-    kind: "image_generation",
-    providers,
-    emptyText: "No image-generation providers are registered.",
-    cfg: params.cfg,
-    agentDir: params.agentDir,
-    authStore: params.authStore,
-    listModes: listSupportedImageGenerationModes,
-    summarizeCapabilities: summarizeImageGenerationCapabilities,
-    formatAuthHint: formatImageGenerationAuthHint,
-  });
-}
-
 export function resolveImageGenerationModelConfigForTool(params: {
   cfg?: OpenClawConfig;
   agentDir?: string;
@@ -263,10 +224,10 @@ function hasExplicitImageGenerationModelConfig(cfg?: OpenClawConfig): boolean {
   return hasToolModelConfig(coerceToolModelConfig(cfg?.agents?.defaults?.imageGenerationModel));
 }
 
-function resolveAction(args: Record<string, unknown>): "generate" | "list" {
+function resolveAction(args: Record<string, unknown>): "generate" | "list" | "status" {
   return resolveGenerateAction({
     args,
-    allowed: ["generate", "list"],
+    allowed: ["generate", "status", "list"],
     defaultAction: "generate",
   });
 }
@@ -619,13 +580,194 @@ async function inferResolutionFromInputImages(
   return DEFAULT_RESOLUTION;
 }
 
+type LoadedReferenceImage = Awaited<ReturnType<typeof loadReferenceImages>>[number];
+
+type ExecutedImageGeneration = {
+  provider: string;
+  model: string;
+  savedPaths: string[];
+  count: number;
+  paths: string[];
+  attachments: AgentGeneratedAttachment[];
+  contentText: string;
+  details: Record<string, unknown>;
+  wakeResult: string;
+};
+
+const defaultScheduleImageGenerateBackgroundWork = createDefaultMediaGenerateBackgroundScheduler({
+  toolName: "image_generate",
+  onCrash: (message, meta) => log.error(message, meta),
+});
+
+async function executeImageGenerationJob(params: {
+  effectiveCfg: OpenClawConfig;
+  prompt: string;
+  agentDir?: string;
+  model?: string;
+  size?: string;
+  aspectRatio?: string;
+  resolution?: ImageGenerationResolution;
+  quality?: ImageGenerationQuality;
+  outputFormat?: ImageGenerationOutputFormat;
+  background?: ImageGenerationBackground;
+  count: number;
+  inputImages: ImageGenerationSourceImage[];
+  timeoutMs?: number;
+  providerOptions?: ImageGenerationProviderOptions;
+  ssrfPolicy?: SsrFPolicy;
+  filename?: string;
+  loadedReferenceImages: LoadedReferenceImage[];
+  taskHandle?: ImageGenerationTaskHandle | null;
+  autoProviderFallback?: boolean;
+}) {
+  if (params.taskHandle) {
+    recordImageGenerationTaskProgress({
+      handle: params.taskHandle,
+      progressSummary: "Generating image",
+    });
+  }
+  const result = await generateImage({
+    cfg: params.effectiveCfg,
+    prompt: params.prompt,
+    agentDir: params.agentDir,
+    modelOverride: params.model,
+    autoProviderFallback: params.autoProviderFallback,
+    size: params.size,
+    aspectRatio: params.aspectRatio,
+    resolution: params.resolution,
+    quality: params.quality,
+    outputFormat: params.outputFormat,
+    background: params.background,
+    count: params.count,
+    inputImages: params.inputImages,
+    timeoutMs: params.timeoutMs,
+    providerOptions: params.providerOptions,
+    ssrfPolicy: params.ssrfPolicy,
+  });
+  if (params.taskHandle) {
+    recordImageGenerationTaskProgress({
+      handle: params.taskHandle,
+      progressSummary: "Saving generated image",
+    });
+  }
+  const ignoredOverrides = result.ignoredOverrides ?? [];
+  const displayProvider = sanitizeInlineDirectiveText(result.provider);
+  const displayModel = sanitizeInlineDirectiveText(result.model);
+  const warning =
+    ignoredOverrides.length > 0
+      ? `Ignored unsupported overrides for ${displayProvider}/${displayModel}: ${ignoredOverrides.map(formatIgnoredImageGenerationOverride).join(", ")}.`
+      : undefined;
+  const normalizedSize =
+    result.normalization?.size?.applied ??
+    (typeof result.metadata?.normalizedSize === "string" && result.metadata.normalizedSize.trim()
+      ? result.metadata.normalizedSize
+      : undefined);
+  const normalizedAspectRatio =
+    result.normalization?.aspectRatio?.applied ??
+    (typeof result.metadata?.normalizedAspectRatio === "string" &&
+    result.metadata.normalizedAspectRatio.trim()
+      ? result.metadata.normalizedAspectRatio
+      : undefined);
+  const normalizedResolution =
+    result.normalization?.resolution?.applied ??
+    (typeof result.metadata?.normalizedResolution === "string" &&
+    result.metadata.normalizedResolution.trim()
+      ? result.metadata.normalizedResolution
+      : undefined);
+  const sizeTranslatedToAspectRatio =
+    result.normalization?.aspectRatio?.derivedFrom === "size" ||
+    (!normalizedSize &&
+      typeof result.metadata?.requestedSize === "string" &&
+      result.metadata.requestedSize === params.size &&
+      Boolean(normalizedAspectRatio));
+
+  const mediaMaxBytes = resolveGeneratedMediaMaxBytes(params.effectiveCfg, "image");
+  const savedImages = await Promise.all(
+    result.images.map((image) =>
+      saveMediaBuffer(
+        image.buffer,
+        image.mimeType,
+        "tool-image-generation",
+        mediaMaxBytes,
+        params.filename || image.fileName,
+      ),
+    ),
+  );
+
+  const revisedPrompts = result.images
+    .map((image) => image.revisedPrompt?.trim())
+    .filter((entry): entry is string => Boolean(entry));
+  const attachments = savedImages.map((image) => ({
+    type: "image" as const,
+    path: image.path,
+    mimeType: image.contentType,
+    name: image.id,
+  }));
+  const lines = [
+    `Generated ${savedImages.length} image${savedImages.length === 1 ? "" : "s"} with ${displayProvider}/${displayModel}.`,
+    ...(warning ? [`Warning: ${warning}`] : []),
+    ...formatGeneratedAttachmentLines(attachments),
+  ];
+  return {
+    provider: result.provider,
+    model: result.model,
+    savedPaths: savedImages.map((image) => image.path),
+    count: savedImages.length,
+    paths: savedImages.map((image) => image.path),
+    attachments,
+    contentText: lines.join("\n"),
+    wakeResult: lines.join("\n"),
+    details: {
+      provider: result.provider,
+      model: result.model,
+      count: savedImages.length,
+      media: {
+        mediaUrls: savedImages.map((image) => image.path),
+        attachments,
+      },
+      attachments,
+      paths: savedImages.map((image) => image.path),
+      ...buildTaskRunDetails(params.taskHandle),
+      ...buildMediaReferenceDetails({
+        entries: params.loadedReferenceImages,
+        singleKey: "image",
+        pluralKey: "images",
+        getResolvedInput: (entry) => entry.resolvedImage,
+      }),
+      ...(normalizedResolution || params.resolution
+        ? { resolution: normalizedResolution ?? params.resolution }
+        : {}),
+      ...(normalizedSize || (params.size && !sizeTranslatedToAspectRatio)
+        ? { size: normalizedSize ?? params.size }
+        : {}),
+      ...(normalizedAspectRatio || params.aspectRatio
+        ? { aspectRatio: normalizedAspectRatio ?? params.aspectRatio }
+        : {}),
+      ...(params.quality ? { quality: params.quality } : {}),
+      ...(params.outputFormat ? { outputFormat: params.outputFormat } : {}),
+      ...(params.background ? { background: params.background } : {}),
+      ...(params.filename ? { filename: params.filename } : {}),
+      ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
+      attempts: result.attempts,
+      ...(result.normalization ? { normalization: result.normalization } : {}),
+      metadata: result.metadata,
+      ...(warning ? { warning } : {}),
+      ...(ignoredOverrides.length > 0 ? { ignoredOverrides } : {}),
+      ...(revisedPrompts.length > 0 ? { revisedPrompts } : {}),
+    },
+  } satisfies ExecutedImageGeneration;
+}
+
 export function createImageGenerateTool(options?: {
   config?: OpenClawConfig;
   agentDir?: string;
   authProfileStore?: AuthProfileStore;
+  agentSessionKey?: string;
+  requesterOrigin?: DeliveryContext;
   workspaceDir?: string;
   sandbox?: ImageGenerateSandboxConfig;
   fsPolicy?: ToolFsPolicy;
+  scheduleBackgroundWork?: MediaGenerateBackgroundScheduler;
 }): AnyAgentTool | null {
   const cfg = options?.config ?? getRuntimeConfig();
   if (
@@ -648,12 +790,14 @@ export function createImageGenerateTool(options?: {
           workspaceOnly: options.fsPolicy?.workspaceOnly === true,
         }
       : null;
+  const scheduleBackgroundWork =
+    options?.scheduleBackgroundWork ?? defaultScheduleImageGenerateBackgroundWork;
 
   return {
     label: "Image Generation",
     name: "image_generate",
     description:
-      'Generate new images or edit reference images with the configured or inferred image-generation model. For transparent backgrounds, use outputFormat="png" or "webp" and background="transparent"; OpenAI also accepts openai.background and OpenClaw routes the default OpenAI image model to gpt-image-1.5 for that mode. Set agents.defaults.imageGenerationModel.primary to pick a provider/model. Providers declare their own auth/readiness; use action="list" to inspect registered providers, models, readiness, and auth hints. Generated images are returned as structured tool-result attachments; in message-tool-only routes, send visible image results through the message tool.',
+      'Generate new images or edit reference images with the configured or inferred image-generation model. In session-backed chats, generation runs as a background task; do not call image_generate again for the same request, wait for the completion event, then send the generated attachments through the message tool. For transparent backgrounds, use outputFormat="png" or "webp" and background="transparent"; OpenAI also accepts openai.background and OpenClaw routes the default OpenAI image model to gpt-image-1.5 for that mode. Set agents.defaults.imageGenerationModel.primary to pick a provider/model. Providers declare their own auth/readiness; use action="list" to inspect registered providers, models, readiness, and auth hints; use action="status" to inspect the active task.',
     parameters: ImageGenerateToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
@@ -664,6 +808,9 @@ export function createImageGenerateTool(options?: {
           agentDir: options?.agentDir,
           authStore: options?.authProfileStore,
         });
+      }
+      if (action === "status") {
+        return createImageGenerateStatusActionResult(options?.agentSessionKey);
       }
 
       const imageGenerationModelConfig = resolveImageGenerationModelConfigForTool({
@@ -678,6 +825,14 @@ export function createImageGenerateTool(options?: {
       const effectiveCfg =
         applyImageGenerationModelConfigDefaults(cfg, imageGenerationModelConfig) ?? cfg;
       const remoteMediaSsrfPolicy = resolveRemoteMediaSsrfPolicy(effectiveCfg);
+
+      const duplicateGuardResult = createImageGenerateDuplicateGuardResult(
+        options?.agentSessionKey,
+      );
+      if (duplicateGuardResult) {
+        return duplicateGuardResult;
+      }
+
       const prompt = readStringParam(params, "prompt", { required: true });
       const imageInputs = normalizeReferenceImages(params);
       const model = readStringParam(params, "model");
@@ -697,7 +852,6 @@ export function createImageGenerateTool(options?: {
       });
       const count = resolveRequestedCount(params);
       const configuredMediaMaxBytes = resolveConfiguredMediaMaxBytes(effectiveCfg);
-      const mediaMaxBytes = resolveGeneratedMediaMaxBytes(effectiveCfg, "image");
       const loadedReferenceImages = await loadReferenceImages({
         imageInputs,
         maxBytes: configuredMediaMaxBytes,
@@ -726,124 +880,112 @@ export function createImageGenerateTool(options?: {
         resolution,
         explicitResolution: Boolean(explicitResolution),
       });
-
-      const result = await generateImage({
-        cfg: effectiveCfg,
+      const taskHandle = createImageGenerationTaskRun({
+        sessionKey: options?.agentSessionKey,
+        requesterOrigin: options?.requesterOrigin,
         prompt,
-        agentDir: options?.agentDir,
-        modelOverride: model,
-        autoProviderFallback: explicitModelConfig ? false : undefined,
-        size,
-        aspectRatio,
-        resolution,
-        quality,
-        outputFormat,
-        background,
-        count,
-        inputImages,
-        timeoutMs,
-        providerOptions,
-        ssrfPolicy: remoteMediaSsrfPolicy,
+        providerId: selectedProvider?.id,
       });
-      const ignoredOverrides = result.ignoredOverrides ?? [];
-      const displayProvider = sanitizeInlineDirectiveText(result.provider);
-      const displayModel = sanitizeInlineDirectiveText(result.model);
-      const warning =
-        ignoredOverrides.length > 0
-          ? `Ignored unsupported overrides for ${displayProvider}/${displayModel}: ${ignoredOverrides.map(formatIgnoredImageGenerationOverride).join(", ")}.`
-          : undefined;
-      const normalizedSize =
-        result.normalization?.size?.applied ??
-        (typeof result.metadata?.normalizedSize === "string" &&
-        result.metadata.normalizedSize.trim()
-          ? result.metadata.normalizedSize
-          : undefined);
-      const normalizedAspectRatio =
-        result.normalization?.aspectRatio?.applied ??
-        (typeof result.metadata?.normalizedAspectRatio === "string" &&
-        result.metadata.normalizedAspectRatio.trim()
-          ? result.metadata.normalizedAspectRatio
-          : undefined);
-      const normalizedResolution =
-        result.normalization?.resolution?.applied ??
-        (typeof result.metadata?.normalizedResolution === "string" &&
-        result.metadata.normalizedResolution.trim()
-          ? result.metadata.normalizedResolution
-          : undefined);
-      const sizeTranslatedToAspectRatio =
-        result.normalization?.aspectRatio?.derivedFrom === "size" ||
-        (!normalizedSize &&
-          typeof result.metadata?.requestedSize === "string" &&
-          result.metadata.requestedSize === size &&
-          Boolean(normalizedAspectRatio));
+      const shouldDetach = Boolean(taskHandle && options?.agentSessionKey?.trim());
 
-      const savedImages = await Promise.all(
-        result.images.map((image) =>
-          saveMediaBuffer(
-            image.buffer,
-            image.mimeType,
-            "tool-image-generation",
-            mediaMaxBytes,
-            filename || image.fileName,
-          ),
-        ),
-      );
+      if (shouldDetach) {
+        scheduleMediaGenerationTaskCompletion({
+          lifecycle: imageGenerationTaskLifecycle,
+          handle: taskHandle,
+          scheduleBackgroundWork,
+          progressSummary: "Generating image",
+          config: effectiveCfg,
+          toolName: "Image generation",
+          onWakeFailure: (message, meta) => log.warn(message, meta),
+          run: () =>
+            executeImageGenerationJob({
+              effectiveCfg,
+              prompt,
+              agentDir: options?.agentDir,
+              model,
+              size,
+              aspectRatio,
+              resolution,
+              quality,
+              outputFormat,
+              background,
+              count,
+              inputImages,
+              timeoutMs,
+              providerOptions,
+              ssrfPolicy: remoteMediaSsrfPolicy,
+              filename,
+              loadedReferenceImages,
+              taskHandle,
+              autoProviderFallback: explicitModelConfig ? false : undefined,
+            }),
+        });
 
-      const revisedPrompts = result.images
-        .map((image) => image.revisedPrompt?.trim())
-        .filter((entry): entry is string => Boolean(entry));
-      const attachments = savedImages.map((image) => ({
-        type: "image" as const,
-        path: image.path,
-        mimeType: image.contentType,
-        name: image.id,
-      }));
-      const lines = [
-        `Generated ${savedImages.length} image${savedImages.length === 1 ? "" : "s"} with ${displayProvider}/${displayModel}.`,
-        ...(warning ? [`Warning: ${warning}`] : []),
-        ...formatGeneratedAttachmentLines(attachments),
-      ];
-
-      return {
-        content: [{ type: "text", text: lines.join("\n") }],
-        details: {
-          provider: result.provider,
-          model: result.model,
-          count: savedImages.length,
-          media: {
-            mediaUrls: savedImages.map((image) => image.path),
-            attachments,
+        return buildMediaGenerationStartedToolResult({
+          toolName: "image_generate",
+          generationLabel: "image",
+          completionLabel: "image",
+          taskHandle,
+          detailExtras: {
+            ...buildMediaReferenceDetails({
+              entries: loadedReferenceImages,
+              singleKey: "image",
+              pluralKey: "images",
+              getResolvedInput: (entry) => entry.resolvedImage,
+            }),
+            ...(model ? { model } : {}),
+            ...(resolution ? { resolution } : {}),
+            ...(size ? { size } : {}),
+            ...(aspectRatio ? { aspectRatio } : {}),
+            ...(quality ? { quality } : {}),
+            ...(outputFormat ? { outputFormat } : {}),
+            ...(background ? { background } : {}),
+            ...(filename ? { filename } : {}),
+            ...(timeoutMs !== undefined ? { timeoutMs } : {}),
           },
-          attachments,
-          paths: savedImages.map((image) => image.path),
-          ...buildMediaReferenceDetails({
-            entries: loadedReferenceImages,
-            singleKey: "image",
-            pluralKey: "images",
-            getResolvedInput: (entry) => entry.resolvedImage,
-          }),
-          ...(normalizedResolution || resolution
-            ? { resolution: normalizedResolution ?? resolution }
-            : {}),
-          ...(normalizedSize || (size && !sizeTranslatedToAspectRatio)
-            ? { size: normalizedSize ?? size }
-            : {}),
-          ...(normalizedAspectRatio || aspectRatio
-            ? { aspectRatio: normalizedAspectRatio ?? aspectRatio }
-            : {}),
-          ...(quality ? { quality } : {}),
-          ...(outputFormat ? { outputFormat } : {}),
-          ...(background ? { background } : {}),
-          ...(filename ? { filename } : {}),
-          ...(timeoutMs !== undefined ? { timeoutMs } : {}),
-          attempts: result.attempts,
-          ...(result.normalization ? { normalization: result.normalization } : {}),
-          metadata: result.metadata,
-          ...(warning ? { warning } : {}),
-          ...(ignoredOverrides.length > 0 ? { ignoredOverrides } : {}),
-          ...(revisedPrompts.length > 0 ? { revisedPrompts } : {}),
-        },
-      };
+        });
+      }
+
+      try {
+        const executed = await executeImageGenerationJob({
+          effectiveCfg,
+          prompt,
+          agentDir: options?.agentDir,
+          model,
+          size,
+          aspectRatio,
+          resolution,
+          quality,
+          outputFormat,
+          background,
+          count,
+          inputImages,
+          timeoutMs,
+          providerOptions,
+          ssrfPolicy: remoteMediaSsrfPolicy,
+          filename,
+          loadedReferenceImages,
+          taskHandle,
+          autoProviderFallback: explicitModelConfig ? false : undefined,
+        });
+        completeImageGenerationTaskRun({
+          handle: taskHandle,
+          provider: executed.provider,
+          model: executed.model,
+          count: executed.count,
+          paths: executed.paths,
+        });
+        return {
+          content: [{ type: "text", text: executed.contentText }],
+          details: executed.details,
+        };
+      } catch (error) {
+        failImageGenerationTaskRun({
+          handle: taskHandle,
+          error,
+        });
+        throw error;
+      }
     },
   };
 }

--- a/src/agents/tools/media-generate-background-shared.ts
+++ b/src/agents/tools/media-generate-background-shared.ts
@@ -30,6 +30,18 @@ export type MediaGenerationTaskHandle = {
   taskLabel: string;
 };
 
+export type MediaGenerateBackgroundScheduler = (work: () => Promise<void>) => void;
+
+export type MediaGenerationExecutionResult = {
+  provider: string;
+  model: string;
+  count: number;
+  paths: string[];
+  wakeResult: string;
+  attachments?: AgentGeneratedAttachment[];
+  mediaUrls?: string[];
+};
+
 type CreateMediaGenerationTaskRunParams = {
   sessionKey?: string;
   requesterOrigin?: DeliveryContext;
@@ -65,6 +77,14 @@ type WakeMediaGenerationTaskCompletionParams = {
   attachments?: AgentGeneratedAttachment[];
   mediaUrls?: string[];
   statsLine?: string;
+};
+
+type MediaGenerationTaskLifecycle = {
+  createTaskRun: (params: CreateMediaGenerationTaskRunParams) => MediaGenerationTaskHandle | null;
+  recordTaskProgress: (params: RecordMediaGenerationTaskProgressParams) => void;
+  completeTaskRun: (params: CompleteMediaGenerationTaskRunParams) => void;
+  failTaskRun: (params: FailMediaGenerationTaskRunParams) => void;
+  wakeTaskCompletion: (params: WakeMediaGenerationTaskCompletionParams) => Promise<void>;
 };
 
 function touchMediaGenerationTaskRunContext(handle: MediaGenerationTaskHandle) {
@@ -247,6 +267,119 @@ function buildMediaGenerationReplyInstruction(params: {
   ].join(" ");
 }
 
+export function createDefaultMediaGenerateBackgroundScheduler(params: {
+  toolName: string;
+  onCrash: (message: string, meta?: Record<string, unknown>) => void;
+}): MediaGenerateBackgroundScheduler {
+  return (work) => {
+    queueMicrotask(() => {
+      void work().catch((error) => {
+        params.onCrash(`Detached ${params.toolName} job crashed`, { error });
+      });
+    });
+  };
+}
+
+export function buildMediaGenerationStartedToolResult(params: {
+  toolName: string;
+  generationLabel: string;
+  completionLabel: string;
+  taskHandle: MediaGenerationTaskHandle | null;
+  detailExtras?: Record<string, unknown>;
+  messages?: Array<string | undefined>;
+}) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: [
+          `Background task started for ${params.generationLabel} generation (${params.taskHandle?.taskId ?? "unknown"}). Do not call ${params.toolName} again for this request. Wait for the completion event; the completion agent will send the finished ${params.completionLabel} here when it's ready.`,
+          ...(params.messages ?? []),
+        ]
+          .filter((entry): entry is string => Boolean(entry))
+          .join("\n"),
+      },
+    ],
+    details: {
+      async: true,
+      status: "started",
+      ...(params.taskHandle
+        ? {
+            taskId: params.taskHandle.taskId,
+            runId: params.taskHandle.runId,
+            task: {
+              taskId: params.taskHandle.taskId,
+              runId: params.taskHandle.runId,
+            },
+          }
+        : {}),
+      ...params.detailExtras,
+    },
+  };
+}
+
+export function scheduleMediaGenerationTaskCompletion<
+  T extends MediaGenerationExecutionResult,
+>(params: {
+  lifecycle: MediaGenerationTaskLifecycle;
+  handle: MediaGenerationTaskHandle | null;
+  scheduleBackgroundWork: MediaGenerateBackgroundScheduler;
+  progressSummary: string;
+  config?: OpenClawConfig;
+  toolName: string;
+  run: () => Promise<T>;
+  onWakeFailure: (message: string, meta?: Record<string, unknown>) => void;
+}) {
+  params.scheduleBackgroundWork(async () => {
+    try {
+      const executed = await withMediaGenerationTaskKeepalive({
+        handle: params.handle,
+        progressSummary: params.progressSummary,
+        run: params.run,
+      });
+      params.lifecycle.completeTaskRun({
+        handle: params.handle,
+        provider: executed.provider,
+        model: executed.model,
+        count: executed.count,
+        paths: executed.paths,
+      });
+      try {
+        await params.lifecycle.wakeTaskCompletion({
+          config: params.config,
+          handle: params.handle,
+          status: "ok",
+          statusLabel: "completed successfully",
+          result: executed.wakeResult,
+          attachments: executed.attachments,
+          mediaUrls: executed.mediaUrls,
+        });
+      } catch (error) {
+        params.onWakeFailure(
+          `${params.toolName} completion wake failed after successful generation`,
+          {
+            taskId: params.handle?.taskId,
+            runId: params.handle?.runId,
+            error,
+          },
+        );
+      }
+    } catch (error) {
+      params.lifecycle.failTaskRun({
+        handle: params.handle,
+        error,
+      });
+      await params.lifecycle.wakeTaskCompletion({
+        config: params.config,
+        handle: params.handle,
+        status: "error",
+        statusLabel: "failed",
+        result: formatErrorMessage(error),
+      });
+    }
+  });
+}
+
 async function wakeMediaGenerationTaskCompletion(params: {
   config?: OpenClawConfig;
   handle: MediaGenerationTaskHandle | null;
@@ -315,7 +448,7 @@ async function wakeMediaGenerationTaskCompletion(params: {
     directIdempotencyKey: announceId,
   });
   if (!delivery.delivered && delivery.error) {
-    log.error("Media generation completion wake failed; generated media may not be delivered", {
+    log.error("Media generation completion wake failed; requester session was not woken", {
       taskId: params.handle.taskId,
       runId: params.handle.runId,
       toolName: params.toolName,
@@ -334,7 +467,7 @@ export function createMediaGenerationTaskLifecycle(params: {
   eventSource: AgentInternalEvent["source"];
   announceType: string;
   completionLabel: string;
-}) {
+}): MediaGenerationTaskLifecycle {
   return {
     createTaskRun(runParams: CreateMediaGenerationTaskRunParams): MediaGenerationTaskHandle | null {
       return createMediaGenerationTaskRun({

--- a/src/agents/tools/music-generate-background.ts
+++ b/src/agents/tools/music-generate-background.ts
@@ -8,7 +8,7 @@ import {
 
 export type MusicGenerationTaskHandle = MediaGenerationTaskHandle;
 
-const musicGenerationTaskLifecycle = createMediaGenerationTaskLifecycle({
+export const musicGenerationTaskLifecycle = createMediaGenerationTaskLifecycle({
   toolName: "music_generate",
   taskKind: MUSIC_GENERATION_TASK_KIND,
   label: "Music generation",

--- a/src/agents/tools/music-generate-tool.status.test.ts
+++ b/src/agents/tools/music-generate-tool.status.test.ts
@@ -52,7 +52,7 @@ describe("createMusicGenerateTool status actions", () => {
     expect(result?.content).toStrictEqual([
       {
         type: "text",
-        text: "Music generation task task-active is already running with google.\nProgress: Generating music.\nDo not call music_generate again for this request. Wait for the completion event; I will post the finished music here.",
+        text: "Music generation task task-active is already running with google.\nProgress: Generating music.\nDo not call music_generate again for this request. Wait for the completion event; the completion agent will send the finished music here.",
       },
     ]);
     const text = content?.text ?? "";

--- a/src/agents/tools/music-generate-tool.test.ts
+++ b/src/agents/tools/music-generate-tool.test.ts
@@ -32,6 +32,23 @@ const musicGenerationRuntimeMocks = vi.hoisted(() => ({
 }));
 
 const musicGenerateBackgroundMocks = vi.hoisted(() => ({
+  musicGenerationTaskLifecycle: {
+    createTaskRun: (
+      params: Parameters<typeof musicGenerateBackground.createMusicGenerationTaskRun>[0],
+    ) => musicGenerateBackgroundMocks.createMusicGenerationTaskRun(params),
+    recordTaskProgress: (
+      params: Parameters<typeof musicGenerateBackground.recordMusicGenerationTaskProgress>[0],
+    ) => musicGenerateBackgroundMocks.recordMusicGenerationTaskProgress(params),
+    completeTaskRun: (
+      params: Parameters<typeof musicGenerateBackground.completeMusicGenerationTaskRun>[0],
+    ) => musicGenerateBackgroundMocks.completeMusicGenerationTaskRun(params),
+    failTaskRun: (
+      params: Parameters<typeof musicGenerateBackground.failMusicGenerationTaskRun>[0],
+    ) => musicGenerateBackgroundMocks.failMusicGenerationTaskRun(params),
+    wakeTaskCompletion: (
+      params: Parameters<typeof musicGenerateBackground.wakeMusicGenerationTaskCompletion>[0],
+    ) => musicGenerateBackgroundMocks.wakeMusicGenerationTaskCompletion(params),
+  },
   completeMusicGenerationTaskRun: vi.fn((params) => {
     if (!params.handle) {
       return;

--- a/src/agents/tools/music-generate-tool.ts
+++ b/src/agents/tools/music-generate-tool.ts
@@ -1,7 +1,6 @@
 import { Type } from "typebox";
 import { getRuntimeConfig } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { formatErrorMessage } from "../../infra/errors.js";
 import type { SsrFPolicy } from "../../infra/net/ssrf.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveGeneratedMediaMaxBytes } from "../../media/configured-max-bytes.js";
@@ -33,7 +32,12 @@ import {
 } from "../generated-attachments.js";
 import { ToolInputError, readNumberParam, readStringParam } from "./common.js";
 import { decodeDataUrl } from "./image-tool.helpers.js";
-import { withMediaGenerationTaskKeepalive } from "./media-generate-background-shared.js";
+import {
+  buildMediaGenerationStartedToolResult,
+  createDefaultMediaGenerateBackgroundScheduler,
+  scheduleMediaGenerationTaskCompletion,
+  type MediaGenerateBackgroundScheduler,
+} from "./media-generate-background-shared.js";
 import {
   applyMusicGenerationModelConfigDefaults,
   buildMediaReferenceDetails,
@@ -57,9 +61,9 @@ import {
   completeMusicGenerationTaskRun,
   createMusicGenerationTaskRun,
   failMusicGenerationTaskRun,
+  musicGenerationTaskLifecycle,
   recordMusicGenerationTaskProgress,
   type MusicGenerationTaskHandle,
-  wakeMusicGenerationTaskCompletion,
 } from "./music-generate-background.js";
 import {
   createMusicGenerateDuplicateGuardResult,
@@ -243,8 +247,6 @@ type MusicGenerateSandboxConfig = {
   bridge: SandboxFsBridge;
 };
 
-type MusicGenerateBackgroundScheduler = (work: () => Promise<void>) => void;
-
 type MusicGenerationTimeoutNormalization = {
   requested: number;
   applied: number;
@@ -281,15 +283,10 @@ function normalizeMusicGenerationTimeoutMs(timeoutMs: number | undefined): {
   };
 }
 
-function defaultScheduleMusicGenerateBackgroundWork(work: () => Promise<void>) {
-  queueMicrotask(() => {
-    void work().catch((error) => {
-      log.error("Detached music generation job crashed", {
-        error,
-      });
-    });
-  });
-}
+const defaultScheduleMusicGenerateBackgroundWork = createDefaultMediaGenerateBackgroundScheduler({
+  toolName: "music_generate",
+  onCrash: (message, meta) => log.error(message, meta),
+});
 
 async function loadReferenceImages(params: {
   inputs: string[];
@@ -405,6 +402,8 @@ type ExecutedMusicGeneration = {
   provider: string;
   model: string;
   savedPaths: string[];
+  count: number;
+  paths: string[];
   attachments: AgentGeneratedAttachment[];
   contentText: string;
   details: Record<string, unknown>;
@@ -513,6 +512,8 @@ async function executeMusicGenerationJob(params: {
     provider: result.provider,
     model: result.model,
     savedPaths: savedTracks.map((track) => track.path),
+    count: savedTracks.length,
+    paths: savedTracks.map((track) => track.path),
     attachments,
     contentText: lines.join("\n"),
     wakeResult: lines.join("\n"),
@@ -575,7 +576,7 @@ export function createMusicGenerateTool(options?: {
   workspaceDir?: string;
   sandbox?: MusicGenerateSandboxConfig;
   fsPolicy?: ToolFsPolicy;
-  scheduleBackgroundWork?: MusicGenerateBackgroundScheduler;
+  scheduleBackgroundWork?: MediaGenerateBackgroundScheduler;
 }): AnyAgentTool | null {
   const cfg: OpenClawConfig = options?.config ?? getRuntimeConfig();
   if (
@@ -606,7 +607,7 @@ export function createMusicGenerateTool(options?: {
     name: "music_generate",
     displaySummary: "Generate music",
     description:
-      "Generate music using configured providers. Generated tracks are saved under OpenClaw-managed media storage and delivered automatically as attachments.",
+      'Generate music using configured providers. In session-backed chats, generation runs as a background task; do not call music_generate again for the same request, wait for the completion event, then send the generated attachments through the message tool. Use action="status" to inspect the active task.',
     parameters: MusicGenerateToolSchema,
     execute: async (_toolCallId, rawArgs) => {
       const args = rawArgs as Record<string, unknown>;
@@ -696,84 +697,40 @@ export function createMusicGenerateTool(options?: {
       const shouldDetach = Boolean(taskHandle && options?.agentSessionKey?.trim());
 
       if (shouldDetach) {
-        scheduleBackgroundWork(async () => {
-          try {
-            const executed = await withMediaGenerationTaskKeepalive({
-              handle: taskHandle,
-              progressSummary: "Generating music",
-              run: () =>
-                executeMusicGenerationJob({
-                  effectiveCfg,
-                  prompt,
-                  agentDir: options?.agentDir,
-                  model,
-                  lyrics,
-                  instrumental,
-                  durationSeconds,
-                  format,
-                  filename,
-                  loadedReferenceImages,
-                  taskHandle,
-                  autoProviderFallback: explicitModelConfig ? false : undefined,
-                  timeoutMs,
-                  timeoutNormalization: timeout.normalization,
-                }),
-            });
-            completeMusicGenerationTaskRun({
-              handle: taskHandle,
-              provider: executed.provider,
-              model: executed.model,
-              count: executed.savedPaths.length,
-              paths: executed.savedPaths,
-            });
-            try {
-              await wakeMusicGenerationTaskCompletion({
-                config: effectiveCfg,
-                handle: taskHandle,
-                status: "ok",
-                statusLabel: "completed successfully",
-                result: executed.wakeResult,
-                attachments: executed.attachments,
-              });
-            } catch (error) {
-              log.warn("Music generation completion wake failed after successful generation", {
-                taskId: taskHandle?.taskId,
-                runId: taskHandle?.runId,
-                error,
-              });
-            }
-          } catch (error) {
-            failMusicGenerationTaskRun({
-              handle: taskHandle,
-              error,
-            });
-            await wakeMusicGenerationTaskCompletion({
-              config: effectiveCfg,
-              handle: taskHandle,
-              status: "error",
-              statusLabel: "failed",
-              result: formatErrorMessage(error),
-            });
-            return;
-          }
+        scheduleMediaGenerationTaskCompletion({
+          lifecycle: musicGenerationTaskLifecycle,
+          handle: taskHandle,
+          scheduleBackgroundWork,
+          progressSummary: "Generating music",
+          config: effectiveCfg,
+          toolName: "Music generation",
+          onWakeFailure: (message, meta) => log.warn(message, meta),
+          run: () =>
+            executeMusicGenerationJob({
+              effectiveCfg,
+              prompt,
+              agentDir: options?.agentDir,
+              model,
+              lyrics,
+              instrumental,
+              durationSeconds,
+              format,
+              filename,
+              loadedReferenceImages,
+              taskHandle,
+              autoProviderFallback: explicitModelConfig ? false : undefined,
+              timeoutMs,
+              timeoutNormalization: timeout.normalization,
+            }),
         });
 
-        return {
-          content: [
-            {
-              type: "text",
-              text: [
-                `Background task started for music generation (${taskHandle?.taskId ?? "unknown"}). Do not call music_generate again for this request. Wait for the completion event; I'll post the finished music here when it's ready.`,
-                timeout.message,
-              ]
-                .filter((entry): entry is string => Boolean(entry))
-                .join("\n"),
-            },
-          ],
-          details: {
-            async: true,
-            status: "started",
-            ...buildTaskRunDetails(taskHandle),
+        return buildMediaGenerationStartedToolResult({
+          toolName: "music_generate",
+          generationLabel: "music",
+          completionLabel: "music",
+          taskHandle,
+          messages: [timeout.message],
+          detailExtras: {
             ...buildMediaReferenceDetails({
               entries: loadedReferenceImages,
               singleKey: "image",
@@ -795,7 +752,7 @@ export function createMusicGenerateTool(options?: {
                 }
               : {}),
           },
-        };
+        });
       }
 
       try {

--- a/src/agents/tools/video-generate-background.ts
+++ b/src/agents/tools/video-generate-background.ts
@@ -8,7 +8,7 @@ import {
 
 export type VideoGenerationTaskHandle = MediaGenerationTaskHandle;
 
-const videoGenerationTaskLifecycle = createMediaGenerationTaskLifecycle({
+export const videoGenerationTaskLifecycle = createMediaGenerationTaskLifecycle({
   toolName: "video_generate",
   taskKind: VIDEO_GENERATION_TASK_KIND,
   label: "Video generation",

--- a/src/agents/tools/video-generate-tool.status.test.ts
+++ b/src/agents/tools/video-generate-tool.status.test.ts
@@ -52,7 +52,7 @@ describe("createVideoGenerateTool status actions", () => {
     expect(result?.content).toStrictEqual([
       {
         type: "text",
-        text: "Video generation task task-active is already running with openai.\nProgress: Generating video.\nDo not call video_generate again for this request. Wait for the completion event; I will post the finished video here.",
+        text: "Video generation task task-active is already running with openai.\nProgress: Generating video.\nDo not call video_generate again for this request. Wait for the completion event; the completion agent will send the finished video here.",
       },
     ]);
     const text = content?.text ?? "";

--- a/src/agents/tools/video-generate-tool.test.ts
+++ b/src/agents/tools/video-generate-tool.test.ts
@@ -578,7 +578,7 @@ describe("createVideoGenerateTool", () => {
       createdAt: Date.now(),
     });
     const wakeSpy = vi
-      .spyOn(videoGenerateBackground, "wakeVideoGenerationTaskCompletion")
+      .spyOn(videoGenerateBackground.videoGenerationTaskLifecycle, "wakeTaskCompletion")
       .mockResolvedValue(undefined);
     const saveSpy = vi.spyOn(mediaStore, "saveMediaBuffer");
     vi.spyOn(videoGenerationRuntime, "generateVideo").mockResolvedValue({

--- a/src/agents/tools/video-generate-tool.ts
+++ b/src/agents/tools/video-generate-tool.ts
@@ -1,7 +1,6 @@
 import { Type } from "typebox";
 import { getRuntimeConfig } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { formatErrorMessage } from "../../infra/errors.js";
 import type { SsrFPolicy } from "../../infra/net/ssrf.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveGeneratedMediaMaxBytes } from "../../media/configured-max-bytes.js";
@@ -36,7 +35,12 @@ import {
 } from "../generated-attachments.js";
 import { ToolInputError, readNumberParam, readStringParam } from "./common.js";
 import { decodeDataUrl } from "./image-tool.helpers.js";
-import { withMediaGenerationTaskKeepalive } from "./media-generate-background-shared.js";
+import {
+  buildMediaGenerationStartedToolResult,
+  createDefaultMediaGenerateBackgroundScheduler,
+  scheduleMediaGenerationTaskCompletion,
+  type MediaGenerateBackgroundScheduler,
+} from "./media-generate-background-shared.js";
 import {
   applyVideoGenerationModelConfigDefaults,
   buildMediaReferenceDetails,
@@ -68,8 +72,8 @@ import {
   createVideoGenerationTaskRun,
   failVideoGenerationTaskRun,
   recordVideoGenerationTaskProgress,
+  videoGenerationTaskLifecycle,
   type VideoGenerationTaskHandle,
-  wakeVideoGenerationTaskCompletion,
 } from "./video-generate-background.js";
 import {
   createVideoGenerateDuplicateGuardResult,
@@ -404,17 +408,10 @@ type VideoGenerateSandboxConfig = {
   bridge: SandboxFsBridge;
 };
 
-type VideoGenerateBackgroundScheduler = (work: () => Promise<void>) => void;
-
-function defaultScheduleVideoGenerateBackgroundWork(work: () => Promise<void>) {
-  queueMicrotask(() => {
-    void work().catch((error) => {
-      log.error("Detached video generation job crashed", {
-        error,
-      });
-    });
-  });
-}
+const defaultScheduleVideoGenerateBackgroundWork = createDefaultMediaGenerateBackgroundScheduler({
+  toolName: "video_generate",
+  onCrash: (message, meta) => log.error(message, meta),
+});
 
 async function loadReferenceAssets(params: {
   inputs: string[];
@@ -544,6 +541,8 @@ type ExecutedVideoGeneration = {
   urlOnlyUrls: string[];
   /** Total generated video count, including url-only assets. */
   count: number;
+  paths: string[];
+  mediaUrls: string[];
   attachments: AgentGeneratedAttachment[];
   contentText: string;
   details: Record<string, unknown>;
@@ -733,6 +732,8 @@ async function executeVideoGenerationJob(params: {
     savedPaths: savedVideos.map((video) => video.path),
     urlOnlyUrls: urlOnlyVideos.map((video) => video.url),
     count: totalCount,
+    paths: savedVideos.map((video) => video.path),
+    mediaUrls: allMediaUrls,
     attachments,
     contentText: lines.join("\n"),
     wakeResult: lines.join("\n"),
@@ -807,7 +808,7 @@ export function createVideoGenerateTool(options?: {
   workspaceDir?: string;
   sandbox?: VideoGenerateSandboxConfig;
   fsPolicy?: ToolFsPolicy;
-  scheduleBackgroundWork?: VideoGenerateBackgroundScheduler;
+  scheduleBackgroundWork?: MediaGenerateBackgroundScheduler;
 }): AnyAgentTool | null {
   const cfg: OpenClawConfig = options?.config ?? getRuntimeConfig();
   if (
@@ -838,7 +839,7 @@ export function createVideoGenerateTool(options?: {
     name: "video_generate",
     displaySummary: "Generate videos",
     description:
-      "Generate videos using configured providers. Generated videos are saved under OpenClaw-managed media storage and delivered automatically as attachments. Duration requests may be rounded to the nearest provider-supported value.",
+      'Generate videos using configured providers. In session-backed chats, generation runs as a background task; do not call video_generate again for the same request, wait for the completion event, then send the generated attachments through the message tool. Use action="status" to inspect the active task. Duration requests may be rounded to the nearest provider-supported value.',
     parameters: VideoGenerateToolSchema,
     execute: async (_toolCallId, rawArgs) => {
       const args = rawArgs as Record<string, unknown>;
@@ -1007,83 +1008,43 @@ export function createVideoGenerateTool(options?: {
       const shouldDetach = Boolean(taskHandle && options?.agentSessionKey?.trim());
 
       if (shouldDetach) {
-        scheduleBackgroundWork(async () => {
-          try {
-            const executed = await withMediaGenerationTaskKeepalive({
-              handle: taskHandle,
-              progressSummary: "Generating video",
-              run: () =>
-                executeVideoGenerationJob({
-                  effectiveCfg,
-                  prompt,
-                  agentDir: options?.agentDir,
-                  model,
-                  size,
-                  aspectRatio,
-                  resolution,
-                  durationSeconds,
-                  audio,
-                  watermark,
-                  filename,
-                  loadedReferenceImages,
-                  loadedReferenceVideos,
-                  loadedReferenceAudios,
-                  taskHandle,
-                  providerOptions,
-                  autoProviderFallback: explicitModelConfig ? false : undefined,
-                  timeoutMs,
-                }),
-            });
-            completeVideoGenerationTaskRun({
-              handle: taskHandle,
-              provider: executed.provider,
-              model: executed.model,
-              count: executed.count,
-              paths: executed.savedPaths,
-            });
-            try {
-              await wakeVideoGenerationTaskCompletion({
-                config: effectiveCfg,
-                handle: taskHandle,
-                status: "ok",
-                statusLabel: "completed successfully",
-                result: executed.wakeResult,
-                attachments: executed.attachments,
-              });
-            } catch (error) {
-              log.warn("Video generation completion wake failed after successful generation", {
-                taskId: taskHandle?.taskId,
-                runId: taskHandle?.runId,
-                error,
-              });
-            }
-          } catch (error) {
-            failVideoGenerationTaskRun({
-              handle: taskHandle,
-              error,
-            });
-            await wakeVideoGenerationTaskCompletion({
-              config: effectiveCfg,
-              handle: taskHandle,
-              status: "error",
-              statusLabel: "failed",
-              result: formatErrorMessage(error),
-            });
-            return;
-          }
+        scheduleMediaGenerationTaskCompletion({
+          lifecycle: videoGenerationTaskLifecycle,
+          handle: taskHandle,
+          scheduleBackgroundWork,
+          progressSummary: "Generating video",
+          config: effectiveCfg,
+          toolName: "Video generation",
+          onWakeFailure: (message, meta) => log.warn(message, meta),
+          run: () =>
+            executeVideoGenerationJob({
+              effectiveCfg,
+              prompt,
+              agentDir: options?.agentDir,
+              model,
+              size,
+              aspectRatio,
+              resolution,
+              durationSeconds,
+              audio,
+              watermark,
+              filename,
+              loadedReferenceImages,
+              loadedReferenceVideos,
+              loadedReferenceAudios,
+              taskHandle,
+              providerOptions,
+              autoProviderFallback: explicitModelConfig ? false : undefined,
+              timeoutMs,
+            }),
         });
 
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Background task started for video generation (${taskHandle?.taskId ?? "unknown"}). Do not call video_generate again for this request. Wait for the completion event; I'll post the finished video here when it's ready.`,
-            },
-          ],
-          details: {
-            async: true,
-            status: "started",
-            ...buildTaskRunDetails(taskHandle),
+        return buildMediaGenerationStartedToolResult({
+          toolName: "video_generate",
+          generationLabel: "video",
+          completionLabel: "video",
+          taskHandle,
+          detailExtras: {
             ...buildMediaReferenceDetails({
               entries: loadedReferenceImages,
               singleKey: "image",
@@ -1107,7 +1068,7 @@ export function createVideoGenerateTool(options?: {
             ...(filename ? { filename } : {}),
             ...(timeoutMs !== undefined ? { timeoutMs } : {}),
           },
-        };
+        });
       }
 
       try {

--- a/src/auto-reply/reply/commands-tasks.test.ts
+++ b/src/auto-reply/reply/commands-tasks.test.ts
@@ -107,6 +107,29 @@ describe("buildTasksReply", () => {
     expect(reply.text).toContain("Queued video generation");
   });
 
+  it("lists session-backed image generation tasks for the current session", async () => {
+    createRunningTaskRun({
+      runtime: "cli",
+      taskKind: "image_generation",
+      sourceId: "image_generate:openai",
+      requesterSessionKey: "agent:main:main",
+      childSessionKey: "agent:main:main",
+      runId: "tool:image_generate:tasks-visible",
+      label: "Image generation",
+      task: "blue square icon",
+      progressSummary: "Queued image generation",
+      deliveryStatus: "not_applicable",
+      notifyPolicy: "silent",
+    });
+
+    const reply = await buildTasksReplyForTest();
+
+    expect(reply.text).toContain("Current session: 1 active · 1 total");
+    expect(reply.text).toContain("🟢 Image generation");
+    expect(reply.text).toContain("CLI · running");
+    expect(reply.text).toContain("Queued image generation");
+  });
+
   it("sanitizes leaked internal runtime context from visible task details", async () => {
     createRunningTaskRun({
       runtime: "acp",


### PR DESCRIPTION
## Summary

- Refactors image/music/video generation onto the shared async media-generation scheduler and task lifecycle.
- Makes session-backed image generation async with status, duplicate guarding, active-task prompt context, and message-tool completion delivery.
- Updates docs/changelog for image generation async behavior and shared media completion semantics.

## Verification

- pnpm docs:list
- node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental false
- pnpm test src/agents/tools/image-generate-tool.test.ts src/agents/tools/image-generate-background.test.ts src/agents/tools/music-generate-tool.test.ts src/agents/tools/video-generate-tool.test.ts src/agents/tools/music-generate-background.test.ts src/agents/tools/video-generate-background.test.ts src/agents/tools/music-generate-tool.status.test.ts src/agents/tools/video-generate-tool.status.test.ts src/agents/image-generation-task-status.test.ts src/agents/subagent-announce-delivery.test.ts src/agents/pi-embedded-runner/run/attempt.prompt-helpers.test.ts src/agents/cli-runner/prepare.test.ts -- --reporter=dot
- git diff --check
- codex-review --full-access
- Crabbox aws check:changed run run_fbd1b62c7472 passed on hydrated lease cbx_475a45ba77cb.
- Crabbox aws live openclaw infer run run_c17929e0e224 passed with OpenAI gpt-image-2.

## Real behavior proof

- Behavior addressed: image generation now follows the same async completion contract as music/video in session-backed chats; completions are handed back to the requester agent and require message-tool delivery, avoiding automatic raw posting.
- Real environment tested: Crabbox aws hydrated lease cbx_475a45ba77cb; live OpenAI image generation used the 1Password item AI API Key - OpenAI - OPENAI_API_KEY - Personal, field OPENAI_API_KEY, without printing the secret.
- Exact steps or command run after this patch: node scripts/crabbox-wrapper.mjs run --id cbx_475a45ba77cb --allow-env OPENAI_API_KEY --allow-env OPENCLAW_LIVE_TEST --shell -- "pnpm openclaw infer image providers --json; pnpm openclaw infer image generate --model openai/gpt-image-2 --prompt 'small blue square icon on white background' --count 1 --json; assert generated JSON provider/model/output bytes"
- Evidence after fix: live output from Crabbox run run_c17929e0e224 on aws printed LIVE_INFER_OK provider=openai model=gpt-image-2 bytes=761560 after the generated image JSON assertion passed.
- Observed result after fix: openclaw infer resolved the OpenAI image provider, generated one gpt-image-2 image in the real OpenClaw runtime, and returned 761560 bytes. Separately, the session-backed image tool now returns async started details with task/run ids, exposes status, blocks duplicate active image tasks, and completion delivery is validated through the same message-tool mediated path used by music/video.
- What was not tested: no live music/video provider generation was run for this PR; their refactor is covered by focused unit tests and Crabbox changed checks. Earlier raw Crabbox attempts without hydration failed before project code because pnpm was unavailable, then the lease was hydrated and rerun successfully.
