### PR TITLE
fix(tui): show 0/ctx instead of ?/ctx when usage counters are missing

### DIFF
--- a/scripts/repro/tui-footer-token-total-live-proof.mjs
+++ b/scripts/repro/tui-footer-token-total-live-proof.mjs
@@ -17,7 +17,7 @@ const cases = [
     session: { totalTokens: 42_000, contextTokens },
   },
   {
-    label: "input + output fallback",
+    label: "stale cumulative counters without total (show 0, not sum)",
     session: { inputTokens: 10_000, outputTokens: 5_000, contextTokens },
   },
 ];

--- a/scripts/repro/tui-footer-token-total-live-proof.mjs
+++ b/scripts/repro/tui-footer-token-total-live-proof.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+/**
+ * Live repro for TUI footer token total when usage counters are missing (#43009).
+ * Run: pnpm exec tsx scripts/repro/tui-footer-token-total-live-proof.mjs
+ */
+import { formatTokens, resolveSessionFooterTokenTotal } from "../../src/tui/tui-formatters.ts";
+
+const contextTokens = 200_000;
+
+const cases = [
+  {
+    label: "context only (was ?/200k in footer)",
+    session: { contextTokens },
+  },
+  {
+    label: "explicit total",
+    session: { totalTokens: 42_000, contextTokens },
+  },
+  {
+    label: "input + output fallback",
+    session: { inputTokens: 10_000, outputTokens: 5_000, contextTokens },
+  },
+];
+
+for (const { label, session } of cases) {
+  const total = resolveSessionFooterTokenTotal(session);
+  console.log(`${label}: ${formatTokens(total, contextTokens)}`);
+}

--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -4,7 +4,9 @@ import {
   extractContentFromMessage,
   extractTextFromMessage,
   extractThinkingFromMessage,
+  formatTokens,
   isCommandMessage,
+  resolveSessionFooterTokenTotal,
   sanitizeRenderableText,
 } from "./tui-formatters.js";
 
@@ -359,21 +361,21 @@ describe("sanitizeRenderableText", () => {
   });
 
   it("wraps rtl lines with directional isolation marks", () => {
-    const input = "مرحبا بالعالم";
+    const input = "????? ???????";
     const sanitized = sanitizeRenderableText(input);
 
-    expect(sanitized).toBe("\u2067مرحبا بالعالم\u2069");
+    expect(sanitized).toBe("\u2067????? ???????\u2069");
   });
 
   it("only wraps lines that contain rtl script", () => {
-    const input = "hello\nمرحبا";
+    const input = "hello\n?????";
     const sanitized = sanitizeRenderableText(input);
 
-    expect(sanitized).toBe("hello\n\u2067مرحبا\u2069");
+    expect(sanitized).toBe("hello\n\u2067?????\u2069");
   });
 
   it("does not double-wrap lines that already include bidi controls", () => {
-    const input = "\u2067مرحبا\u2069";
+    const input = "\u2067?????\u2069";
     const sanitized = sanitizeRenderableText(input);
 
     expect(sanitized).toBe(input);
@@ -471,7 +473,7 @@ describe("sanitizeRenderableText", () => {
   });
 
   it("does not chunk box-drawing horizontal rules used in tables", () => {
-    const input = "─".repeat(60);
+    const input = "?".repeat(60);
     const sanitized = sanitizeRenderableText(input);
 
     expect(sanitized).toBe(input);
@@ -506,5 +508,38 @@ describe("sanitizeRenderableText", () => {
     const sanitized = sanitizeRenderableText(input);
 
     expect(sanitized).toContain("[binary data omitted]");
+  });
+});
+
+describe("resolveSessionFooterTokenTotal", () => {
+  it("prefers explicit totalTokens", () => {
+    expect(
+      resolveSessionFooterTokenTotal({
+        totalTokens: 42,
+        inputTokens: 10,
+        outputTokens: 5,
+        contextTokens: 200_000,
+      }),
+    ).toBe(42);
+  });
+
+  it("derives total from input and output when totalTokens is missing", () => {
+    expect(
+      resolveSessionFooterTokenTotal({
+        inputTokens: 1200,
+        outputTokens: 300,
+        contextTokens: 200_000,
+      }),
+    ).toBe(1500);
+  });
+
+  it("defaults to zero usage when only context window is known", () => {
+    expect(resolveSessionFooterTokenTotal({ contextTokens: 200_000 })).toBe(0);
+  });
+});
+
+describe("formatTokens", () => {
+  it("shows zero usage against a known context window", () => {
+    expect(formatTokens(0, 200_000)).toBe("tokens 0/200k (0%)");
   });
 });

--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -524,14 +524,14 @@ describe("resolveSessionFooterTokenTotal", () => {
     ).toBe(42);
   });
 
-  it("derives total from input and output when totalTokens is missing", () => {
+  it("defaults to zero when context is known but total is stale or missing", () => {
     expect(
       resolveSessionFooterTokenTotal({
         inputTokens: 1200,
         outputTokens: 300,
         contextTokens: 200_000,
       }),
-    ).toBe(1500);
+    ).toBe(0);
   });
 
   it("defaults to zero usage when only context window is known", () => {

--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -361,21 +361,21 @@ describe("sanitizeRenderableText", () => {
   });
 
   it("wraps rtl lines with directional isolation marks", () => {
-    const input = "????? ???????";
+    const input = "مرحبا بالعالم";
     const sanitized = sanitizeRenderableText(input);
 
-    expect(sanitized).toBe("\u2067????? ???????\u2069");
+    expect(sanitized).toBe("\u2067مرحبا بالعالم\u2069");
   });
 
   it("only wraps lines that contain rtl script", () => {
-    const input = "hello\n?????";
+    const input = "hello\nمرحبا";
     const sanitized = sanitizeRenderableText(input);
 
-    expect(sanitized).toBe("hello\n\u2067?????\u2069");
+    expect(sanitized).toBe("hello\n\u2067مرحبا\u2069");
   });
 
   it("does not double-wrap lines that already include bidi controls", () => {
-    const input = "\u2067?????\u2069";
+    const input = "\u2067مرحبا\u2069";
     const sanitized = sanitizeRenderableText(input);
 
     expect(sanitized).toBe(input);
@@ -473,7 +473,7 @@ describe("sanitizeRenderableText", () => {
   });
 
   it("does not chunk box-drawing horizontal rules used in tables", () => {
-    const input = "?".repeat(60);
+    const input = "─".repeat(60);
     const sanitized = sanitizeRenderableText(input);
 
     expect(sanitized).toBe(input);
@@ -504,7 +504,8 @@ describe("sanitizeRenderableText", () => {
   });
 
   it("redacts heavily corrupted lines even inside fenced code blocks", () => {
-    const input = `Header\n\`\`\`\n${"�".repeat(40)}\n\`\`\`\nFooter`;
+    const input = `Header\n\`\`\`\n${"\uFFFD".repeat(40)}\n\`\`\`\nFooter`;
+
     const sanitized = sanitizeRenderableText(input);
 
     expect(sanitized).toContain("[binary data omitted]");

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -428,15 +428,10 @@ export function isCommandMessage(message: unknown): boolean {
 
 export function resolveSessionFooterTokenTotal(session: {
   totalTokens?: number | null;
-  inputTokens?: number | null;
-  outputTokens?: number | null;
   contextTokens?: number | null;
 }): number | null {
   if (typeof session.totalTokens === "number") {
     return session.totalTokens;
-  }
-  if (session.inputTokens != null || session.outputTokens != null) {
-    return (session.inputTokens ?? 0) + (session.outputTokens ?? 0);
   }
   if (typeof session.contextTokens === "number") {
     return 0;

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -429,6 +429,8 @@ export function isCommandMessage(message: unknown): boolean {
 export function resolveSessionFooterTokenTotal(session: {
   totalTokens?: number | null;
   contextTokens?: number | null;
+  inputTokens?: number | null;
+  outputTokens?: number | null;
 }): number | null {
   if (typeof session.totalTokens === "number") {
     return session.totalTokens;

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -426,6 +426,24 @@ export function isCommandMessage(message: unknown): boolean {
   return (message as Record<string, unknown>).command === true;
 }
 
+export function resolveSessionFooterTokenTotal(session: {
+  totalTokens?: number | null;
+  inputTokens?: number | null;
+  outputTokens?: number | null;
+  contextTokens?: number | null;
+}): number | null {
+  if (typeof session.totalTokens === "number") {
+    return session.totalTokens;
+  }
+  if (session.inputTokens != null || session.outputTokens != null) {
+    return (session.inputTokens ?? 0) + (session.outputTokens ?? 0);
+  }
+  if (typeof session.contextTokens === "number") {
+    return 0;
+  }
+  return null;
+}
+
 export function formatTokens(total?: number | null, context?: number | null) {
   if (total == null && context == null) {
     return "tokens ?";

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -33,7 +33,7 @@ import { editorTheme, theme } from "./theme/theme.js";
 import type { TuiBackend } from "./tui-backend.js";
 import { createCommandHandlers } from "./tui-command-handlers.js";
 import { createEventHandlers } from "./tui-event-handlers.js";
-import { formatTokens } from "./tui-formatters.js";
+import { formatTokens, resolveSessionFooterTokenTotal } from "./tui-formatters.js";
 import {
   buildTuiLastSessionScopeKey,
   readTuiLastSessionKey,
@@ -1018,7 +1018,10 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
         ? `${sessionInfo.modelProvider}/${sessionInfo.model}`
         : sessionInfo.model
       : "unknown";
-    const tokens = formatTokens(sessionInfo.totalTokens ?? null, sessionInfo.contextTokens ?? null);
+    const tokens = formatTokens(
+      resolveSessionFooterTokenTotal(sessionInfo),
+      sessionInfo.contextTokens ?? null,
+    );
     const think = sessionInfo.thinkingLevel ?? "off";
     const fast = sessionInfo.fastMode === true;
     const verbose = sessionInfo.verboseLevel ?? "off";


### PR DESCRIPTION
## Summary

Fixes #43009 — TUI footer showed `tokens ?/200k` when `contextTokens` was known but `totalTokens` was absent.

- Add `resolveSessionFooterTokenTotal()` to use explicit `totalTokens`, else `0/ctx` when the context window is known.
- Do **not** sum stale `inputTokens`/`outputTokens` (can remain when `totalTokensFresh=false`).
- Wire footer in `tui.ts` through the helper; tests + live repro script.

## Test plan

- [x] `node scripts/run-vitest.mjs src/tui/tui-formatters.test.ts`
- [x] `npm run check:test-types`
- [x] `pnpm exec tsx scripts/repro/tui-footer-token-total-live-proof.mjs`

## Real behavior proof

**Behavior or issue addressed:** Footer token display showed `?/ctx` when only the context window was known; should show `0/ctx` to match `session_status`.

**Real environment tested:** macOS, Node 22, local checkout on branch `fix/tui-footer-token-total`.

**Exact steps or command run after this patch:**
```bash
pnpm exec tsx scripts/repro/tui-footer-token-total-live-proof.mjs
```

**Evidence after fix:**
```
context only (was ?/200k in footer): tokens 0/200k (0%)
explicit total: tokens 42k/200k (21%)
stale cumulative counters without total (show 0, not sum): tokens 0/200k (0%)
```

**Observed result after fix:** Context-only and stale-counter sessions format as `tokens 0/200k` instead of unknown `?/200k` or a misleading sum.

**What was not tested:** Full interactive TUI session against a live gateway in this proof run.