### PR TITLE
fix: accept WhatsApp group-prefixed targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,6 +219,7 @@ Docs: https://docs.openclaw.ai
 - Memory search: stop using chokidar write-stability polling for memory and QMD watchers so large Markdown extraPath trees no longer build up regular file descriptors; changed files now settle through the existing debounced sync queue. Fixes #77327 and #78224. (#81802) Thanks @frankekn, @loyur, and @JanPlessow.
 - Message tool: rename the Discord channel-create schema field exposed to models from `type` to `channelType`, avoiding NVIDIA NIM JSON Schema parser failures while still accepting legacy `type` tool calls. (#78920) Thanks @YashSaliya.
 - Feishu: send CardKit streaming cards as delivered deltas and retry failed updates, preventing duplicated or dropped streamed text. Fixes #82417. (#82419) Thanks @hclsys.
+- WhatsApp: accept `group:`-prefixed group JIDs for outbound targets so `whatsapp:group:<jid>@g.us` resolves to the canonical group JID. Thanks @mcaxtr.
 - Gateway/Gmail: stop queued post-ready Gmail sidecars before hot reload and abort stale Tailscale setup, so cancelled watcher restarts cannot rewrite an old public hook target or report abort-killed commands as success. (#82395) Thanks @samzong.
 
 ## 2026.5.14

--- a/extensions/whatsapp/src/normalize-target.ts
+++ b/extensions/whatsapp/src/normalize-target.ts
@@ -18,17 +18,23 @@ function stripWhatsAppTargetPrefixes(value: string): string {
   }
 }
 
-export function isWhatsAppGroupJid(value: string): boolean {
-  const candidate = stripWhatsAppTargetPrefixes(value);
+function normalizeWhatsAppGroupJid(value: string): string | null {
+  const candidate = stripWhatsAppTargetPrefixes(value)
+    .replace(/^group:/i, "")
+    .trim();
   const lower = normalizeLowercaseStringOrEmpty(candidate);
   if (!lower.endsWith("@g.us")) {
-    return false;
+    return null;
   }
   const localPart = candidate.slice(0, candidate.length - "@g.us".length);
   if (!localPart || localPart.includes("@")) {
-    return false;
+    return null;
   }
-  return /^[0-9]+(-[0-9]+)*$/.test(localPart);
+  return /^[0-9]+(-[0-9]+)*$/.test(localPart) ? `${localPart}@g.us` : null;
+}
+
+export function isWhatsAppGroupJid(value: string): boolean {
+  return normalizeWhatsAppGroupJid(value) !== null;
 }
 
 export function isWhatsAppNewsletterJid(value: string): boolean {
@@ -66,9 +72,9 @@ export function normalizeWhatsAppTarget(value: string): string | null {
   if (!candidate) {
     return null;
   }
-  if (isWhatsAppGroupJid(candidate)) {
-    const localPart = candidate.slice(0, candidate.length - "@g.us".length);
-    return `${localPart}@g.us`;
+  const groupJid = normalizeWhatsAppGroupJid(candidate);
+  if (groupJid) {
+    return groupJid;
   }
   if (isWhatsAppNewsletterJid(candidate)) {
     const match = candidate.match(WHATSAPP_NEWSLETTER_JID_RE);

--- a/extensions/whatsapp/src/resolve-target.test.ts
+++ b/extensions/whatsapp/src/resolve-target.test.ts
@@ -7,6 +7,7 @@ import {
   normalizeWhatsAppMessagingTarget,
   normalizeWhatsAppTarget,
 } from "./normalize-target.js";
+import { resolveWhatsAppOutboundTarget } from "./resolve-outbound-target.js";
 
 describe("normalizeWhatsAppTarget", () => {
   it("preserves group JIDs", () => {
@@ -14,6 +15,15 @@ describe("normalizeWhatsAppTarget", () => {
     expect(normalizeWhatsAppTarget("123456789-987654321@g.us")).toBe("123456789-987654321@g.us");
     expect(normalizeWhatsAppTarget("whatsapp:120363401234567890@g.us")).toBe(
       "120363401234567890@g.us",
+    );
+    expect(normalizeWhatsAppTarget("group:120363401234567890@g.us")).toBe(
+      "120363401234567890@g.us",
+    );
+    expect(normalizeWhatsAppTarget("whatsapp:group:120363401234567890@g.us")).toBe(
+      "120363401234567890@g.us",
+    );
+    expect(normalizeWhatsAppTarget(" WhatsApp:Group:123456789-987654321@G.US ")).toBe(
+      "123456789-987654321@g.us",
     );
   });
 
@@ -46,9 +56,9 @@ describe("normalizeWhatsAppTarget", () => {
     expect(normalizeWhatsAppTarget("whatsapp:")).toBeNull();
     expect(normalizeWhatsAppTarget("@g.us")).toBeNull();
     expect(normalizeWhatsAppTarget("whatsapp:group:@g.us")).toBeNull();
-    expect(normalizeWhatsAppTarget("whatsapp:group:120363401234567890@g.us")).toBeNull();
-    expect(normalizeWhatsAppTarget("group:123456789-987654321@g.us")).toBeNull();
-    expect(normalizeWhatsAppTarget(" WhatsApp:Group:123456789-987654321@G.US ")).toBeNull();
+    expect(normalizeWhatsAppTarget("group:+15551234567")).toBeNull();
+    expect(normalizeWhatsAppTarget("group:abc@g.us")).toBeNull();
+    expect(normalizeWhatsAppTarget("group:120363401234567890@newsletter")).toBeNull();
     expect(normalizeWhatsAppTarget("abc@s.whatsapp.net")).toBeNull();
     expect(normalizeWhatsAppTarget("abc@newsletter")).toBeNull();
   });
@@ -95,7 +105,7 @@ describe("isWhatsAppGroupJid", () => {
     expect(isWhatsAppGroupJid("120363401234567890@g.us")).toBe(true);
     expect(isWhatsAppGroupJid("123456789-987654321@g.us")).toBe(true);
     expect(isWhatsAppGroupJid("whatsapp:120363401234567890@g.us")).toBe(true);
-    expect(isWhatsAppGroupJid("whatsapp:group:120363401234567890@g.us")).toBe(false);
+    expect(isWhatsAppGroupJid("whatsapp:group:120363401234567890@g.us")).toBe(true);
     expect(isWhatsAppGroupJid("x@g.us")).toBe(false);
     expect(isWhatsAppGroupJid("@g.us")).toBe(false);
     expect(isWhatsAppGroupJid("120@g.usx")).toBe(false);
@@ -114,7 +124,20 @@ describe("looksLikeWhatsAppTargetId", () => {
     expect(looksLikeWhatsAppTargetId("whatsapp:+15555550123")).toBe(true);
     expect(looksLikeWhatsAppTargetId("15555550123@c.us")).toBe(true);
     expect(looksLikeWhatsAppTargetId("120363401234567890@newsletter")).toBe(true);
+    expect(looksLikeWhatsAppTargetId("whatsapp:group:120363401234567890@g.us")).toBe(true);
     expect(looksLikeWhatsAppTargetId("+15555550123")).toBe(true);
     expect(looksLikeWhatsAppTargetId("")).toBe(false);
+  });
+});
+
+describe("resolveWhatsAppOutboundTarget", () => {
+  it("accepts group-prefixed WhatsApp group JIDs", () => {
+    expect(
+      resolveWhatsAppOutboundTarget({
+        to: "whatsapp:group:120363401234567890@g.us",
+        allowFrom: undefined,
+        mode: "explicit",
+      }),
+    ).toEqual({ ok: true, to: "120363401234567890@g.us" });
   });
 });


### PR DESCRIPTION
## Summary

- Accept WhatsApp group targets with a `group:` kind prefix after an optional `whatsapp:` provider prefix.
- Canonicalize those targets to bare `<jid>@g.us` before outbound resolution while preserving invalid target rejection.

## Verification

- `node scripts/test-projects.mjs extensions/whatsapp/src/resolve-target.test.ts extensions/whatsapp/src/resolve-outbound-target.test.ts -- --reporter=verbose`
- `git diff --check origin/main...HEAD`
- `codex review --base origin/main`

Behavior addressed: WhatsApp outbound target normalization now accepts valid group JIDs supplied as `group:<jid>@g.us` or `whatsapp:group:<jid>@g.us` and resolves them to canonical `<jid>@g.us`.

Real environment tested: Local OpenClaw WhatsApp extension Vitest shard in the `fix/whatsapp-group-target-prefix` worktree.

Exact steps or command run after this patch: `node scripts/test-projects.mjs extensions/whatsapp/src/resolve-target.test.ts extensions/whatsapp/src/resolve-outbound-target.test.ts -- --reporter=verbose`

Evidence after fix: The new resolver test covers `normalizeWhatsAppTarget` and `resolveWhatsAppOutboundTarget` for `whatsapp:group:120363401234567890@g.us` returning `120363401234567890@g.us`.

Observed result after fix: 2 test files passed, 37 tests passed.

What was not tested: Live WhatsApp delivery to a real group; this patch only changes target normalization and outbound resolution before the existing send handoff.
