### PR TITLE
fix(macos): prevent duplicate menu bar icons

### DIFF
--- a/apps/macos/Sources/OpenClaw/ControlChannel.swift
+++ b/apps/macos/Sources/OpenClaw/ControlChannel.swift
@@ -39,6 +39,48 @@ enum ControlChannelError: Error, LocalizedError {
     }
 }
 
+struct ControlChannelStateDebouncer {
+    private let interval: TimeInterval
+    private var lastAppliedAt: Date
+
+    init(interval: TimeInterval = 0.5, lastAppliedAt: Date = .distantPast) {
+        self.interval = interval
+        self.lastAppliedAt = lastAppliedAt
+    }
+
+    mutating func delayBeforeApplying(
+        currentState: ControlChannel.ConnectionState,
+        newState: ControlChannel.ConnectionState,
+        now: Date) -> TimeInterval?
+    {
+        if Self.isTerminal(currentState) || Self.isTerminal(newState) {
+            self.lastAppliedAt = now
+            return nil
+        }
+
+        let elapsed = now.timeIntervalSince(self.lastAppliedAt)
+        guard elapsed < self.interval else {
+            self.lastAppliedAt = now
+            return nil
+        }
+
+        return self.interval - max(0, elapsed)
+    }
+
+    mutating func recordDeferredApply(at date: Date) {
+        self.lastAppliedAt = date
+    }
+
+    private static func isTerminal(_ state: ControlChannel.ConnectionState) -> Bool {
+        switch state {
+        case .connected, .disconnected:
+            true
+        case .connecting, .degraded:
+            false
+        }
+    }
+}
+
 @MainActor
 @Observable
 final class ControlChannel {
@@ -85,6 +127,46 @@ final class ControlChannel {
     private var recoveryTask: Task<Void, Never>?
     private var lastRecoveryAt: Date?
 
+    // Coalesce rapid connecting/degraded oscillations so SwiftUI does not churn
+    // MenuBarExtra status items while the gateway connection is unstable.
+    private var pendingStateTask: Task<Void, Never>?
+    private var stateDebouncer = ControlChannelStateDebouncer()
+
+    private func setStateThrottled(_ newState: ConnectionState) {
+        let now = Date()
+        if let delay = self.stateDebouncer.delayBeforeApplying(
+            currentState: self.state,
+            newState: newState,
+            now: now)
+        {
+            self.pendingStateTask?.cancel()
+            self.pendingStateTask = Task { [weak self] in
+                try? await Task.sleep(nanoseconds: Self.nanoseconds(for: delay))
+                guard let self, !Task.isCancelled else { return }
+                self.pendingStateTask = nil
+                self.stateDebouncer.recordDeferredApply(at: Date())
+                self.applyState(newState)
+            }
+            return
+        }
+
+        self.cancelPendingStateTask()
+        self.applyState(newState)
+    }
+
+    private func cancelPendingStateTask() {
+        self.pendingStateTask?.cancel()
+        self.pendingStateTask = nil
+    }
+
+    private func applyState(_ newState: ConnectionState) {
+        self.state = newState
+    }
+
+    private static func nanoseconds(for interval: TimeInterval) -> UInt64 {
+        UInt64(max(0, interval) * 1_000_000_000)
+    }
+
     private init() {
         self.startEventStream()
     }
@@ -105,11 +187,11 @@ final class ControlChannel {
                 self.logger.info(
                     "control channel configure mode=remote " +
                         "target=\(target, privacy: .public) identitySet=\(idSet, privacy: .public)")
-                self.state = .connecting
+                self.setStateThrottled(.connecting)
                 _ = try await GatewayEndpointStore.shared.ensureRemoteControlTunnel()
                 await self.refreshEndpoint(reason: "configure")
             } catch {
-                self.state = .degraded(error.localizedDescription)
+                self.setStateThrottled(.degraded(error.localizedDescription))
                 throw error
             }
         }
@@ -117,20 +199,20 @@ final class ControlChannel {
 
     func refreshEndpoint(reason: String) async {
         self.logger.info("control channel refresh endpoint reason=\(reason, privacy: .public)")
-        self.state = .connecting
+        self.setStateThrottled(.connecting)
         do {
             try await self.establishGatewayConnection()
-            self.state = .connected
+            self.setStateThrottled(.connected)
             PresenceReporter.shared.sendImmediate(reason: "connect")
         } catch {
             let message = self.friendlyGatewayMessage(error)
-            self.state = .degraded(message)
+            self.setStateThrottled(.degraded(message))
         }
     }
 
     func disconnect() async {
         await GatewayConnection.shared.shutdown()
-        self.state = .disconnected
+        self.setStateThrottled(.disconnected)
         self.lastPingMs = nil
         self.authSourceLabel = nil
     }
@@ -146,11 +228,11 @@ final class ControlChannel {
             let payload = try await self.request(method: "health", params: params, timeoutMs: timeoutMs)
             let ms = Date().timeIntervalSince(start) * 1000
             self.lastPingMs = ms
-            self.state = .connected
+            self.setStateThrottled(.connected)
             return payload
         } catch {
             let message = self.friendlyGatewayMessage(error)
-            self.state = .degraded(message)
+            self.setStateThrottled(.degraded(message))
             throw ControlChannelError.badResponse(message)
         }
     }
@@ -173,11 +255,11 @@ final class ControlChannel {
                 method: method,
                 params: rawParams,
                 timeoutMs: timeoutMs)
-            self.state = .connected
+            self.setStateThrottled(.connected)
             return data
         } catch {
             let message = self.friendlyGatewayMessage(error)
-            self.state = .degraded(message)
+            self.setStateThrottled(.degraded(message))
             throw ControlChannelError.badResponse(message)
         }
     }
@@ -386,9 +468,9 @@ final class ControlChannel {
                 NotificationCenter.default.post(name: .controlHeartbeat, object: data)
             }
         case let .event(evt) where evt.event == "shutdown":
-            self.state = .degraded("gateway shutdown")
+            self.setStateThrottled(.degraded("gateway shutdown"))
         case .snapshot:
-            self.state = .connected
+            self.setStateThrottled(.connected)
         default:
             break
         }

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -55,6 +55,13 @@ struct OpenClawApp: App {
                 .background(SettingsWindowOpenRegistrar())
         }
         .menuBarExtraAccess(isPresented: self.$isMenuPresented) { item in
+            // SwiftUI can vend a replacement status item during connection churn.
+            // Keep ownership to one item so stale menu bar icons are removed.
+            if let currentStatusItem = self.statusItem {
+                guard currentStatusItem !== item else { return }
+                Self.logger.warning("Replacing stale menu bar status item")
+                NSStatusBar.system.removeStatusItem(currentStatusItem)
+            }
             self.statusItem = item
             MenuSessionsInjector.shared.install(into: item)
             self.applyStatusItemAppearance(paused: self.state.isPaused, sleeping: self.isGatewaySleeping)

--- a/apps/macos/Tests/OpenClawIPCTests/ControlChannelStateDebouncerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ControlChannelStateDebouncerTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+@testable import OpenClaw
+
+struct ControlChannelStateDebouncerTests {
+    @Test func `terminal states apply immediately`() {
+        let start = Date(timeIntervalSince1970: 1_000)
+        var debouncer = ControlChannelStateDebouncer(interval: 0.5, lastAppliedAt: start)
+
+        let degradedDelay = debouncer.delayBeforeApplying(
+            currentState: .connecting,
+            newState: .degraded("gateway unavailable"),
+            now: start.addingTimeInterval(0.1))
+        #expect(degradedDelay != nil)
+
+        let connectedDelay = debouncer.delayBeforeApplying(
+            currentState: .connecting,
+            newState: .connected,
+            now: start.addingTimeInterval(0.2))
+        #expect(connectedDelay == nil)
+
+        let afterTerminalDelay = debouncer.delayBeforeApplying(
+            currentState: .connected,
+            newState: .connecting,
+            now: start.addingTimeInterval(0.3))
+        #expect(afterTerminalDelay == nil)
+    }
+
+    @Test func `nonterminal states are debounced within interval`() {
+        let start = Date(timeIntervalSince1970: 1_000)
+        var debouncer = ControlChannelStateDebouncer(interval: 0.5, lastAppliedAt: start)
+
+        let soonDelay = debouncer.delayBeforeApplying(
+            currentState: .connecting,
+            newState: .degraded("gateway unavailable"),
+            now: start.addingTimeInterval(0.1))
+        #expect(soonDelay != nil)
+        #expect(abs((soonDelay ?? 0) - 0.4) < 0.001)
+
+        let afterWindowDelay = debouncer.delayBeforeApplying(
+            currentState: .connecting,
+            newState: .degraded("gateway unavailable"),
+            now: start.addingTimeInterval(0.6))
+        #expect(afterWindowDelay == nil)
+    }
+
+    @Test func `deferred apply resets debounce window`() {
+        let start = Date(timeIntervalSince1970: 1_000)
+        var debouncer = ControlChannelStateDebouncer(interval: 0.5, lastAppliedAt: start)
+
+        debouncer.recordDeferredApply(at: start.addingTimeInterval(0.5))
+
+        let delayAfterDeferredUpdate = debouncer.delayBeforeApplying(
+            currentState: .degraded("gateway unavailable"),
+            newState: .connecting,
+            now: start.addingTimeInterval(0.7))
+        #expect(delayAfterDeferredUpdate != nil)
+        #expect(abs((delayAfterDeferredUpdate ?? 0) - 0.3) < 0.001)
+    }
+}


### PR DESCRIPTION
## Summary

This is a fresh current-main version of the macOS menu bar icon storm fix. The bug still reproduces in the official 2026.5.12 release, where rapid gateway connection state changes can make SwiftUI/MenuBarExtra create duplicate menu bar icons.

The previous stale PR, #30856, is useful evidence that the issue has existed for a while. This PR intentionally does not reuse the stale branch history; it reapplies the fix on top of current `main` and incorporates the Codex/Greptile review feedback from that PR.

## Changes

- Keep ownership of a single `NSStatusItem` from `menuBarExtraAccess`; if SwiftUI vends a replacement item, remove the stale item before adopting the new one.
- Add a small `ControlChannelStateDebouncer` for rapid `.connecting` / `.degraded` oscillations so UI-observed state does not churn during gateway instability.
- Keep terminal states (`.connected` and `.disconnected`) immediate, and make them cancel any pending delayed intermediate state update.
- Route all `ControlChannel` state changes through the throttled setter so a stale delayed `.degraded` update cannot overwrite a newer terminal state.
- Add focused Swift tests for the debounce policy.

## Real behavior proof

Behavior addressed: macOS menu bar icon storm / duplicate OpenClaw status items caused by rapid control-channel state churn in the SwiftUI `MenuBarExtra` host.

Real environment tested: macOS on this Mac. Before-fix reference used the installed official OpenClaw 2026.5.12 app (`CFBundleVersion` 2026051290). After-fix proof used a locally signed debug `OpenClaw.app` built from this PR at `fbe0c306cd`.

Exact steps or command run after this patch: Built the current branch with `swift build --package-path apps/macos -c debug --product OpenClaw --build-path apps/macos/.build/arm64 --arch arm64 -Xlinker -rpath -Xlinker @executable_path/../Frameworks`; packaged the app with `SKIP_PNPM_INSTALL=1 SKIP_TSC=1 SKIP_UI_BUILD=1 BUILD_ARCHS=arm64 scripts/package-mac-app.sh`; signed a temporary app copy with `scripts/codesign-mac-app.sh`; launched that signed app; sampled the exact app process plus Accessibility menu-bar counts six times; terminated the app and verified no exact app process remained.

Evidence after fix: Copied live terminal output from the patched app on the real macOS menu bar setup:

```text
fixed exact sample 1 17:33:24
exact fixed app pid 88017
fixed exact sample 2 17:33:28
exact fixed app pid 88017
menu bar 1: 6
menu bar 2: 1
fixed exact sample 3 17:33:29
exact fixed app pid 88017
menu bar 1: 6
menu bar 2: 1
fixed exact sample 4 17:33:30
exact fixed app pid 88017
menu bar 1: 6
menu bar 2: 1
fixed exact sample 5 17:33:32
exact fixed app pid 88017
menu bar 1: 6
menu bar 2: 1
fixed exact sample 6 17:33:33
exact fixed app pid 88017
menu bar 1: 6
menu bar 2: 1
terminating exact fixed app pids: 88017
remaining exact fixed app pids: none
```

Before evidence: The installed official release was also launched on the same Mac first. Its bundle metadata was:

```text
CFBundleExecutable => OpenClaw
CFBundleIdentifier => ai.openclaw.mac
CFBundleShortVersionString => 2026.5.12
CFBundleVersion => 2026051290
```

The same run reproduced the rapid state churn that triggers the menu bar icon storm; redacted control log excerpt from 2026-05-16 17:29:24-17:29:25 local time:

```text
OpenClaw: [ai.openclaw:control] control channel refresh endpoint reason=endpoint changed
OpenClaw: [ai.openclaw:control] control channel state -> connecting
OpenClaw: [ai.openclaw:control] control channel state -> degraded: Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again.
OpenClaw: [ai.openclaw:control] control channel recovery starting mode=remote reason=Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again.
OpenClaw: [ai.openclaw:control] control channel recovery ensured SSH tunnel port=18789
OpenClaw: [ai.openclaw:control] control channel refresh endpoint reason=recovery:Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again.
OpenClaw: [ai.openclaw:control] control channel state -> connecting
OpenClaw: [ai.openclaw:control] control channel state -> degraded: Pairing required. In an already-paired OpenClaw client, run /pair approve, then check the connection again.
```

Observed result after fix: The patched app stayed on one exact app process during the sampled run, and Accessibility reported exactly one OpenClaw status item (`menu bar 2: 1`) on every completed sample. After termination, the exact temporary app process check returned `none`.

What was not tested: Release notarization and full-release packaging were not retested in this proof; this was a local signed debug app proof for the macOS menu bar behavior, plus the focused Swift tests below.

## Verification

- `swift test --package-path apps/macos --filter ControlChannelStateDebouncerTests`
- `swift build --package-path apps/macos -c debug --product OpenClaw --build-path apps/macos/.build/arm64 --arch arm64 -Xlinker -rpath -Xlinker @executable_path/../Frameworks`
- Built a local `OpenClaw.app` bundle, signed a temporary verification copy, launched it on this Mac, and confirmed via Accessibility that OpenClaw exposed exactly one status item (`menu bar 2: 1`).
- During that final launch, control logs showed the relevant state path was exercised: `connecting` -> `degraded` with recovery attempted, while the status item count stayed at one.
