### PR TITLE
fix(sessions): prune malformed missing transcript rows [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/sessions: let `openclaw sessions cleanup --fix-missing` prune malformed rows with unresolvable transcript metadata instead of throwing. Fixes #80970. (#82745) Thanks @IWhatsskill.
 - Gateway/usage: refresh large session usage summaries in the background and reuse durable transcript metadata so `sessions.usage` no longer blocks Gateway requests on full transcript rescans. Fixes #82773. (#82778) Thanks @hclsys.
 - TUI: restore the submitted draft when chat is busy instead of clearing it or queueing another run. Fixes #45326. (#82774) Thanks @hyspacex.
 - Browser plugin: redact attach-details from Chrome MCP diagnostics and keep raw Chrome launch error output around long enough to surface in user reports without leaking sensitive paths.

--- a/src/config/sessions/cleanup-service.ts
+++ b/src/config/sessions/cleanup-service.ts
@@ -205,13 +205,20 @@ function pruneMissingTranscriptEntries(params: {
   });
   let removed = 0;
   for (const [key, entry] of Object.entries(params.store)) {
-    let transcriptPath: string | undefined;
-    if (entry?.sessionId) {
-      try {
-        transcriptPath = resolveSessionFilePath(entry.sessionId, entry, sessionPathOpts);
-      } catch {
-        // Malformed legacy rows cannot resolve a transcript path; --fix-missing prunes them.
+    if (!entry?.sessionId) {
+      if (parseAgentSessionKey(key)) {
+        continue;
       }
+      delete params.store[key];
+      removed += 1;
+      params.onPruned?.(key);
+      continue;
+    }
+    let transcriptPath: string | undefined;
+    try {
+      transcriptPath = resolveSessionFilePath(entry.sessionId, entry, sessionPathOpts);
+    } catch {
+      // Malformed legacy rows cannot resolve a transcript path; --fix-missing prunes them.
     }
     if (!transcriptPath || !fs.existsSync(transcriptPath)) {
       delete params.store[key];

--- a/src/config/sessions/cleanup-service.ts
+++ b/src/config/sessions/cleanup-service.ts
@@ -205,11 +205,15 @@ function pruneMissingTranscriptEntries(params: {
   });
   let removed = 0;
   for (const [key, entry] of Object.entries(params.store)) {
-    if (!entry?.sessionId) {
-      continue;
+    let transcriptPath: string | undefined;
+    if (entry?.sessionId) {
+      try {
+        transcriptPath = resolveSessionFilePath(entry.sessionId, entry, sessionPathOpts);
+      } catch {
+        // Malformed legacy rows cannot resolve a transcript path; --fix-missing prunes them.
+      }
     }
-    const transcriptPath = resolveSessionFilePath(entry.sessionId, entry, sessionPathOpts);
-    if (!fs.existsSync(transcriptPath)) {
+    if (!transcriptPath || !fs.existsSync(transcriptPath)) {
       delete params.store[key];
       removed += 1;
       params.onPruned?.(key);

--- a/src/config/sessions/store.pruning.integration.test.ts
+++ b/src/config/sessions/store.pruning.integration.test.ts
@@ -315,6 +315,66 @@ describe("Integration: saveSessionStore with pruning", () => {
     await expectPathExists(freshOrphanTranscript);
   });
 
+  it("sessions cleanup fix-missing prunes malformed stored session rows", async () => {
+    applyEnforcedMaintenanceConfig(mockLoadConfig);
+
+    const now = Date.now();
+    const validTranscript = path.join(testDir, "valid-present.jsonl");
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          "invalid-no-file": { sessionId: "agent:main:main", updatedAt: now },
+          "invalid-bad-file": {
+            sessionId: "agent:main:main",
+            sessionFile: "../outside.jsonl",
+            updatedAt: now,
+          },
+          "invalid-missing-relative-file": {
+            sessionId: "agent:main:main",
+            sessionFile: "missing.jsonl",
+            updatedAt: now,
+          },
+          "valid-present": { sessionId: "valid-present", updatedAt: now },
+        } satisfies Record<string, SessionEntry>,
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    await fs.writeFile(validTranscript, "valid", "utf-8");
+
+    const dryRun = await runSessionsCleanup({
+      cfg: {},
+      opts: { store: storePath, dryRun: true, enforce: true, fixMissing: true },
+      targets: [{ agentId: "main", storePath }],
+    });
+    const preview = dryRun.previewResults[0];
+    expect(preview?.summary.missing).toBe(3);
+    expect(preview?.summary.beforeCount).toBe(4);
+    expect(preview?.summary.afterCount).toBe(1);
+    expect(preview?.missingKeys.has("invalid-no-file")).toBe(true);
+    expect(preview?.missingKeys.has("invalid-bad-file")).toBe(true);
+    expect(preview?.missingKeys.has("invalid-missing-relative-file")).toBe(true);
+    const rawAfterDryRun = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+      string,
+      unknown
+    >;
+    expect(rawAfterDryRun).toHaveProperty("invalid-no-file");
+
+    const applied = await runSessionsCleanup({
+      cfg: {},
+      opts: { store: storePath, enforce: true, fixMissing: true },
+      targets: [{ agentId: "main", storePath }],
+    });
+
+    expect(applied.appliedSummaries[0]?.missing).toBe(3);
+    expect(applied.appliedSummaries[0]?.afterCount).toBe(1);
+    const persisted = loadSessionStore(storePath, { skipCache: true });
+    expect(Object.keys(persisted)).toEqual(["valid-present"]);
+    await expectPathExists(validTranscript);
+  });
+
   it("sessions cleanup previews stale direct DM rows after dmScope returns to main", async () => {
     applyEnforcedMaintenanceConfig(mockLoadConfig);
 

--- a/src/config/sessions/store.pruning.integration.test.ts
+++ b/src/config/sessions/store.pruning.integration.test.ts
@@ -320,6 +320,7 @@ describe("Integration: saveSessionStore with pruning", () => {
 
     const now = Date.now();
     const validTranscript = path.join(testDir, "valid-present.jsonl");
+    const legacyPresentTranscript = path.join(testDir, "legacy-present.jsonl");
     await fs.writeFile(
       storePath,
       JSON.stringify(
@@ -340,6 +341,11 @@ describe("Integration: saveSessionStore with pruning", () => {
             updatedAt: now,
             groupActivation: "always",
           },
+          "legacy-present-invalid-id": {
+            sessionId: "agent:main:main",
+            sessionFile: "legacy-present.jsonl",
+            updatedAt: now,
+          },
           "valid-present": { sessionId: "valid-present", updatedAt: now },
         } satisfies Record<string, SessionEntry>,
         null,
@@ -348,6 +354,7 @@ describe("Integration: saveSessionStore with pruning", () => {
       "utf-8",
     );
     await fs.writeFile(validTranscript, "valid", "utf-8");
+    await fs.writeFile(legacyPresentTranscript, "legacy", "utf-8");
 
     const dryRun = await runSessionsCleanup({
       cfg: {},
@@ -356,12 +363,13 @@ describe("Integration: saveSessionStore with pruning", () => {
     });
     const preview = dryRun.previewResults[0];
     expect(preview?.summary.missing).toBe(3);
-    expect(preview?.summary.beforeCount).toBe(5);
-    expect(preview?.summary.afterCount).toBe(2);
+    expect(preview?.summary.beforeCount).toBe(6);
+    expect(preview?.summary.afterCount).toBe(3);
     expect(preview?.missingKeys.has("invalid-no-file")).toBe(true);
     expect(preview?.missingKeys.has("invalid-bad-file")).toBe(true);
     expect(preview?.missingKeys.has("invalid-missing-relative-file")).toBe(true);
     expect(preview?.missingKeys.has("agent:main:metadata")).toBe(false);
+    expect(preview?.missingKeys.has("legacy-present-invalid-id")).toBe(false);
     const rawAfterDryRun = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
       string,
       unknown
@@ -375,12 +383,18 @@ describe("Integration: saveSessionStore with pruning", () => {
     });
 
     expect(applied.appliedSummaries[0]?.missing).toBe(3);
-    expect(applied.appliedSummaries[0]?.afterCount).toBe(2);
+    expect(applied.appliedSummaries[0]?.afterCount).toBe(3);
     const persisted = loadSessionStore(storePath, { skipCache: true });
-    expect(Object.keys(persisted)).toEqual(["agent:main:metadata", "valid-present"]);
+    expect(Object.keys(persisted)).toEqual([
+      "agent:main:metadata",
+      "legacy-present-invalid-id",
+      "valid-present",
+    ]);
     expect(persisted["agent:main:metadata"]).toMatchObject({ groupActivation: "always" });
     expect(persisted["agent:main:metadata"]?.sessionId).toBeUndefined();
+    expect(persisted["legacy-present-invalid-id"]?.sessionId).toBe("agent:main:main");
     await expectPathExists(validTranscript);
+    await expectPathExists(legacyPresentTranscript);
   });
 
   it("sessions cleanup previews stale direct DM rows after dmScope returns to main", async () => {

--- a/src/config/sessions/store.pruning.integration.test.ts
+++ b/src/config/sessions/store.pruning.integration.test.ts
@@ -335,6 +335,11 @@ describe("Integration: saveSessionStore with pruning", () => {
             sessionFile: "missing.jsonl",
             updatedAt: now,
           },
+          "agent:main:metadata": {
+            sessionId: "agent:main:metadata",
+            updatedAt: now,
+            groupActivation: "always",
+          },
           "valid-present": { sessionId: "valid-present", updatedAt: now },
         } satisfies Record<string, SessionEntry>,
         null,
@@ -351,11 +356,12 @@ describe("Integration: saveSessionStore with pruning", () => {
     });
     const preview = dryRun.previewResults[0];
     expect(preview?.summary.missing).toBe(3);
-    expect(preview?.summary.beforeCount).toBe(4);
-    expect(preview?.summary.afterCount).toBe(1);
+    expect(preview?.summary.beforeCount).toBe(5);
+    expect(preview?.summary.afterCount).toBe(2);
     expect(preview?.missingKeys.has("invalid-no-file")).toBe(true);
     expect(preview?.missingKeys.has("invalid-bad-file")).toBe(true);
     expect(preview?.missingKeys.has("invalid-missing-relative-file")).toBe(true);
+    expect(preview?.missingKeys.has("agent:main:metadata")).toBe(false);
     const rawAfterDryRun = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
       string,
       unknown
@@ -369,9 +375,11 @@ describe("Integration: saveSessionStore with pruning", () => {
     });
 
     expect(applied.appliedSummaries[0]?.missing).toBe(3);
-    expect(applied.appliedSummaries[0]?.afterCount).toBe(1);
+    expect(applied.appliedSummaries[0]?.afterCount).toBe(2);
     const persisted = loadSessionStore(storePath, { skipCache: true });
-    expect(Object.keys(persisted)).toEqual(["valid-present"]);
+    expect(Object.keys(persisted)).toEqual(["agent:main:metadata", "valid-present"]);
+    expect(persisted["agent:main:metadata"]).toMatchObject({ groupActivation: "always" });
+    expect(persisted["agent:main:metadata"]?.sessionId).toBeUndefined();
     await expectPathExists(validTranscript);
   });
 


### PR DESCRIPTION
## Summary

- Problem: `openclaw sessions cleanup --fix-missing` could still crash on persisted session rows whose `sessionId` was a session-store key like `agent:main:main`.
- Why it matters: the repair command could fail before pruning corrupt or missing-transcript rows.
- What changed: cleanup now treats rows with missing or unresolvable transcript metadata as missing/corrupt entries and prunes them under `--fix-missing`.
- What did NOT change (scope boundary): `validateSessionId` and normal transcript session-id validation are unchanged.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #80970
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: malformed stored session rows no longer crash or survive `sessions cleanup --fix-missing`.
- Real environment tested: disposable OpenClaw checkout on Linux with Node v22.16.0, using a temporary local session store and no real secrets.
- Exact steps or command run after this patch:
  - `node --import tsx src/entry.ts sessions cleanup --store <proof-dir>/sessions.json --dry-run --enforce --fix-missing --json`
  - `node --import tsx src/entry.ts sessions cleanup --store <proof-dir>/sessions.json --enforce --fix-missing --json`
- Evidence after fix:

```text
CLI_DRY_RUN
{
  "storePath": "<proof-dir>/sessions.json",
  "mode": "enforce",
  "dryRun": true,
  "beforeCount": 3,
  "afterCount": 1,
  "missing": 2,
  "wouldMutate": true
}
KEYS_AFTER_DRY=invalid-no-file,invalid-bad-file,valid-present

CLI_APPLY
{
  "storePath": "<proof-dir>/sessions.json",
  "mode": "enforce",
  "dryRun": false,
  "missing": 2,
  "appliedCount": 1
}
KEYS_AFTER_APPLY=valid-present
```

- Observed result after fix: dry-run reports the malformed rows as missing, and apply removes them while keeping the valid transcript row.
- What was not tested: a long-running gateway service; this change is limited to the explicit CLI/store cleanup repair path.
- Before evidence: current-main reproduction threw `Invalid session ID: agent:main:main` for an invalid stored `sessionId` with an invalid `sessionFile`.

## Root Cause (if applicable)

- Root cause: `pruneMissingTranscriptEntries` assumed every loaded row still had a transcript-safe `sessionId`, then let `resolveSessionFilePath` fall back into `validateSessionId` after corrupt `sessionFile` metadata failed to resolve.
- Missing detection / guardrail: cleanup had no guard for malformed persisted rows that could not resolve any transcript path.
- Contributing context (if known): store normalization can preserve an invalid session-key-like `sessionId` when a `sessionFile` is present for legacy path recovery.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/config/sessions/store.pruning.integration.test.ts`
- Scenario the test should lock in: `--fix-missing` prunes malformed rows with invalid key-shaped session ids, invalid stored session files, and missing relative transcript files while keeping a valid transcript row.
- Why this is the smallest reliable guardrail: it exercises `runSessionsCleanup` against a real temporary store and transcript files without starting unrelated services.
- Existing test that already covers this (if any): none for malformed key-shaped session ids in cleanup.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`openclaw sessions cleanup --fix-missing` can now repair malformed/unresolvable session-store rows instead of crashing or leaving them behind.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows local checkout and disposable Linux checkout
- Runtime/container: Node v24 locally for tests; Node v22.16.0 on Linux proof
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): temporary session store only

### Steps

1. Create a temporary `sessions.json` with two malformed rows using `sessionId: "agent:main:main"` and one valid row with a matching transcript file.
2. Run `openclaw sessions cleanup --store <proof-dir>/sessions.json --dry-run --enforce --fix-missing --json`.
3. Run `openclaw sessions cleanup --store <proof-dir>/sessions.json --enforce --fix-missing --json`.

### Expected

- Dry-run reports the malformed rows as missing without mutating the store.
- Apply removes the malformed rows and keeps the valid row.

### Actual

- Dry-run reported `beforeCount: 3`, `afterCount: 1`, `missing: 2`.
- Apply left only `valid-present`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - current-main reproduction for invalid key-shaped `sessionId` with invalid `sessionFile`
  - local focused regression test
  - local neighboring sessions-cleanup tests
  - disposable Linux CLI dry-run/apply proof
- Edge cases checked:
  - row with no usable `sessionId`
  - row with invalid `sessionFile`
  - row with missing relative transcript file
  - valid row with existing transcript remains
- What you did **not** verify: persistent gateway service behavior, because this patch only changes explicit sessions cleanup repair.

## Review Conversations

- [x] No bot review conversations exist yet for this PR.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: `--fix-missing` now removes malformed rows that cannot resolve a transcript path.
  - Mitigation: this only runs for explicit `--fix-missing`; valid transcript rows are preserved by the regression test and real CLI proof.
