### PR TITLE
[AI-assisted] fix(agents): normalize malformed assistant content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Providers/GitHub Copilot: hash Responses replay item ids with sha256 instead of a weak 32-bit hash and build same-provider Copilot tool-call ids distinctly, so concurrent tool-call replays no longer collide and reject follow-up turns.
+- Agents/replay: normalize malformed assistant replay content before transport conversion while preserving empty-stop replay repair, so bad provider history no longer crashes with non-iterable content. Fixes #43795. (#82748) Thanks @IWhatsskill.
 - Providers/Anthropic-messages: extract `reasoning_content` from `thinking` blocks during assistant replay so proxy providers that route through the Anthropic-messages transport preserve reasoning context across tool-call follow-up turns. Thanks @Sunnyone2three.
 - Agents/GitHub Copilot: normalize replayed Responses tool-call IDs before dispatch so resumed sessions with historical overlong tool IDs continue instead of failing Copilot schema validation. (#82750) Thanks @galiniliev.
 - CLI/web: resolve provider-scoped web search/fetch SecretRefs for `infer web ... --provider ...` while leaving unrelated plugin secrets untouched. Fixes #82621. Thanks @leno23.

--- a/src/agents/pi-embedded-runner/replay-history.test.ts
+++ b/src/agents/pi-embedded-runner/replay-history.test.ts
@@ -147,6 +147,21 @@ describe("normalizeAssistantReplayContent", () => {
     expect(wrapped.content).toEqual([{ type: "text", text: "plain string content" }]);
   });
 
+  it("wraps legacy object assistant content as a single block (regression)", () => {
+    const block = { type: "text", text: "plain object content" };
+    const messages = [userMessage("hi"), bedrockAssistant(block, "stop")];
+    const out = normalizeAssistantReplayContent(messages);
+    const wrapped = out[1] as AgentMessage & { content: unknown[] };
+    expect(wrapped.content).toEqual([block]);
+  });
+
+  it("normalizes null assistant content to an empty block array (regression)", () => {
+    const messages = [userMessage("hi"), bedrockAssistant(null, "toolUse")];
+    const out = normalizeAssistantReplayContent(messages);
+    const normalized = out[1] as AgentMessage & { content: unknown[] };
+    expect(normalized.content).toEqual([]);
+  });
+
   it("drops metadata-only legacy string assistant content from replay", () => {
     const messages = [
       userMessage("first"),

--- a/src/agents/pi-embedded-runner/replay-history.test.ts
+++ b/src/agents/pi-embedded-runner/replay-history.test.ts
@@ -126,6 +126,15 @@ describe("normalizeAssistantReplayContent", () => {
     expect(repaired.content).toEqual([{ type: "text", text: FALLBACK_TEXT }]);
   });
 
+  it("converts mid-turn zero-usage null stop turns to a replay sentinel", () => {
+    const falseSuccessStop = bedrockAssistant(null, "stop");
+    const messages = [userMessage("hello"), falseSuccessStop, userMessage("retry")];
+    const out = normalizeAssistantReplayContent(messages);
+    expect(out).not.toBe(messages);
+    const repaired = out[1] as AgentMessage & { content: { type: string; text: string }[] };
+    expect(repaired.content).toEqual([{ type: "text", text: FALLBACK_TEXT }]);
+  });
+
   it("preserves empty content with non-error stopReasons (toolUse, length) untouched", () => {
     // Boundary lock: only `stopReason:"error"` should trip the sentinel
     // substitution. `toolUse` and `length` are reachable in practice when a

--- a/src/agents/pi-embedded-runner/replay-history.ts
+++ b/src/agents/pi-embedded-runner/replay-history.ts
@@ -355,7 +355,8 @@ export function normalizeAssistantReplayContent(messages: AgentMessage[]): Agent
       touched = true;
       continue;
     }
-    const replayContent = (message as { content?: unknown }).content;
+    let assistantMessage = message;
+    let replayContent = (message as { content?: unknown }).content;
     if (typeof replayContent === "string") {
       const normalized = normalizeAssistantReplayTextContent(message, replayContent);
       if (normalized) {
@@ -364,9 +365,15 @@ export function normalizeAssistantReplayContent(messages: AgentMessage[]): Agent
       touched = true;
       continue;
     }
+    if (!Array.isArray(replayContent)) {
+      replayContent =
+        replayContent != null && typeof replayContent === "object" ? [replayContent] : [];
+      assistantMessage = { ...message, content: replayContent } as AgentMessage;
+      touched = true;
+    }
     if (Array.isArray(replayContent)) {
-      const normalized = normalizeAssistantReplayBlockContent(message, replayContent);
-      if (normalized !== message) {
+      const normalized = normalizeAssistantReplayBlockContent(assistantMessage, replayContent);
+      if (normalized !== assistantMessage) {
         if (normalized) {
           out.push(normalized);
         }
@@ -401,7 +408,7 @@ export function normalizeAssistantReplayContent(messages: AgentMessage[]): Agent
         continue;
       }
     }
-    out.push(message);
+    out.push(assistantMessage);
   }
 
   // Drop trailing stream-error / zero-usage-empty-stop placeholder turns. The

--- a/src/agents/pi-embedded-runner/replay-history.ts
+++ b/src/agents/pi-embedded-runner/replay-history.ts
@@ -59,6 +59,7 @@ type ModelSnapshotEntry = {
   modelApi?: string | null;
   modelId?: string;
 };
+type AssistantReplayMessage = Extract<AgentMessage, { role: "assistant" }>;
 
 type ProviderReplayHookParams = {
   config?: OpenClawConfig;
@@ -355,7 +356,7 @@ export function normalizeAssistantReplayContent(messages: AgentMessage[]): Agent
       touched = true;
       continue;
     }
-    let assistantMessage = message;
+    let assistantMessage: AssistantReplayMessage = message;
     let replayContent = (message as { content?: unknown }).content;
     if (typeof replayContent === "string") {
       const normalized = normalizeAssistantReplayTextContent(message, replayContent);
@@ -368,7 +369,7 @@ export function normalizeAssistantReplayContent(messages: AgentMessage[]): Agent
     if (!Array.isArray(replayContent)) {
       replayContent =
         replayContent != null && typeof replayContent === "object" ? [replayContent] : [];
-      assistantMessage = { ...message, content: replayContent } as AgentMessage;
+      assistantMessage = { ...message, content: replayContent } as AssistantReplayMessage;
       touched = true;
     }
     if (Array.isArray(replayContent)) {
@@ -398,10 +399,10 @@ export function normalizeAssistantReplayContent(messages: AgentMessage[]): Agent
       // or completion and no content. Leaving other non-error empty-content
       // turns untouched preserves silent-reply semantics on every other code
       // path.
-      const stopReason = (message as { stopReason?: unknown }).stopReason;
-      if (stopReason === "error" || isZeroUsageEmptyStopAssistantTurn(message)) {
+      const stopReason = (assistantMessage as { stopReason?: unknown }).stopReason;
+      if (stopReason === "error" || isZeroUsageEmptyStopAssistantTurn(assistantMessage)) {
         out.push({
-          ...message,
+          ...assistantMessage,
           content: [{ type: "text", text: STREAM_ERROR_FALLBACK_TEXT }],
         });
         touched = true;

--- a/src/agents/transport-message-transform.test.ts
+++ b/src/agents/transport-message-transform.test.ts
@@ -45,6 +45,40 @@ function assistantToolCall(
 }
 
 describe("transformTransportMessages synthetic tool-result policy", () => {
+  it("normalizes malformed assistant content before transport conversion", () => {
+    const objectContentMessages = [
+      {
+        ...assistantToolCall("call_object"),
+        stopReason: "stop",
+        content: { type: "text", text: "legacy object" },
+      },
+      { role: "user", content: "continue", timestamp: Date.now() },
+    ] as unknown as Context["messages"];
+    const objectResult = transformTransportMessages(
+      objectContentMessages,
+      makeModel("openai-responses", "openai", "gpt-5.4"),
+    );
+    expect(objectResult[0]).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "legacy object" }],
+    });
+
+    const nullContentMessages = [
+      {
+        ...assistantToolCall("call_null"),
+        stopReason: "stop",
+        content: null,
+      },
+      { role: "user", content: "continue", timestamp: Date.now() },
+    ] as unknown as Context["messages"];
+    const nullResult = transformTransportMessages(
+      nullContentMessages,
+      makeModel("openai-responses", "openai", "gpt-5.4"),
+    );
+    expect(nullResult[0]).toMatchObject({ role: "assistant", content: [] });
+    expect(nullResult[1]).toMatchObject({ role: "user" });
+  });
+
   it("synthesizes Codex-style aborted tool results for OpenAI Responses transports", () => {
     const messages: Context["messages"] = [
       assistantToolCall("call_openai_1"),

--- a/src/agents/transport-message-transform.ts
+++ b/src/agents/transport-message-transform.ts
@@ -70,8 +70,13 @@ export function transformTransportMessages(
     }
     const isSameModel =
       msg.provider === model.provider && msg.api === model.api && msg.model === model.id;
+    const sourceContent = Array.isArray(msg.content)
+      ? msg.content
+      : msg.content != null && typeof msg.content === "object"
+        ? ([msg.content] as typeof msg.content)
+        : [];
     const content: typeof msg.content = [];
-    for (const block of msg.content) {
+    for (const block of sourceContent) {
       if (block.type === "thinking") {
         if (block.redacted) {
           if (isSameModel) {


### PR DESCRIPTION
## Summary

- Problem: malformed assistant `content` replayed from provider/session history can be an object or `null`, then reach transport conversion code that expects iterable content and fail with `v.content is not iterable`.
- Why it matters: one bad assistant replay entry can break the run-attempt path instead of being treated as owned malformed provider/history input.
- What changed: replay history now normalizes object-shaped assistant content into a single content block and normalizes `null`/other malformed non-array shapes to `[]`; transport conversion also has a final defensive guard for malformed assistant content.
- What did NOT change: no provider routing, config shape, gateway delivery, channel behavior, network calls, or credential handling.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #43795
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: malformed assistant replay content no longer reaches transport conversion as a non-iterable value.
- Real environment tested: local OpenClaw checkout on Windows using the bundled Codex Node runtime; no external provider credentials were used.
- Exact steps or command run after this patch:

```text
node --import tsx ../../openclaw/proofs/PR-2026-05-17-malformed-assistant-content-runtime-proof.mjs
node scripts/run-vitest.mjs src/agents/pi-embedded-runner/replay-history.test.ts src/agents/transport-message-transform.test.ts
node scripts/run-vitest.mjs src/agents/pi-embedded-runner/sanitize-session-history.tool-result-details.test.ts src/agents/openai-transport-stream.test.ts src/agents/anthropic-transport-stream.test.ts
pnpm check:changed
git diff --check
```

- Evidence after fix:

```text
OpenClaw malformed assistant content runtime proof
Path: normalizeAssistantReplayContent -> transformTransportMessages
Input: assistant content object + assistant content null from a provider-compatible replay shape
{
  "assistantSummaries": [
    {
      "index": 0,
      "contentIsArray": true,
      "contentLength": 1,
      "firstBlockType": "text",
      "textPreserved": "runtime object payload"
    },
    {
      "index": 1,
      "contentIsArray": true,
      "contentLength": 0,
      "firstBlockType": null,
      "textPreserved": null
    }
  ]
}
RESULT: PASS - malformed assistant replay content is normalized before transport conversion

Test Files  2 passed (2)
Tests       33 passed (33)

Test Files  6 passed (6)
Tests       378 passed (378)

pnpm check:changed exited 0
git diff --check exited 0
```

- Observed result after fix: the non-test runtime proof executes the real `normalizeAssistantReplayContent -> transformTransportMessages` path; object-shaped assistant content is preserved as one content block; `null`/other malformed non-array content becomes an empty content array; the transport conversion path completes without the iterable crash.
- What was not tested: a live Feishu/GptGod provider run or any external provider API call.
- Before evidence: the linked issue and source path show the malformed replay shape; I did not run a live failing provider reproduction.

## Root Cause (if applicable)

- Root cause: replay normalization handled strings and arrays, but object/null assistant content could pass through unchanged.
- Missing detection / guardrail: the downstream image-sanitizer only processed assistant content arrays, while transport conversion assumed assistant `content` was already iterable.
- Contributing context (if known): prior fixes covered string content, but did not fully close non-array malformed assistant content.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/agents/pi-embedded-runner/replay-history.test.ts`
  - `src/agents/transport-message-transform.test.ts`
- Scenario the test should lock in: object-shaped assistant content is normalized to an array block; `null` assistant content is normalized to `[]`; transport conversion keeps valid arrays and guards malformed non-arrays.
- Why this is the smallest reliable guardrail: the bug is in local replay/transport message shaping, so focused tests exercise the failing seam without provider credentials.
- Existing test that already covers this (if any): none for object/null assistant content.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

No intended change for valid messages. Malformed assistant replay/provider content is normalized instead of crashing transport conversion.

## Diagram (if applicable)

```text
Before:
assistant content object/null -> replay keeps malformed shape -> transport iterates content -> crash

After:
assistant content object/null -> replay/transport normalize shape -> transport conversion continues
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A.

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: local OpenClaw checkout, bundled Codex Node runtime
- Model/provider: N/A, no live provider call
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run the focused replay and transport regression tests.
2. Run adjacent OpenAI/Anthropic transport and sanitizer tests.
3. Run `pnpm check:changed` and `git diff --check`.

### Expected

- Malformed assistant content is normalized before the iterable transport path.

### Actual

- Tests pass and the changed files pass `check:changed` and `git diff --check`.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What I personally verified:

- Verified scenarios: object-shaped assistant content and `null` assistant content through a non-test runtime proof that imports the real replay and transport functions; valid array content, valid string content, and direct transport conversion through focused regression tests.
- Edge cases checked: object content is not stringified or logged; `null`/other malformed shapes become `[]`; existing string/array behavior remains covered.
- What I did **not** verify: live Feishu/GptGod provider reproduction, live gateway run, or external provider API call.

## Review Conversations

N/A - no review conversations yet.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A.

## Risks and Mitigations

- Risk: the defensive transport guard could make malformed provider/history input less noisy than a hard crash.
  - Mitigation: the normalization is narrow, preserves object-shaped content as a block, turns only malformed non-array/non-string shapes into empty content, adds focused regression coverage, and does not log or stringify untrusted payload content.
