### PR TITLE
fix(agents): normalize Copilot replay tool IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Providers/Anthropic-messages: extract `reasoning_content` from `thinking` blocks during assistant replay so proxy providers that route through the Anthropic-messages transport preserve reasoning context across tool-call follow-up turns. Thanks @Sunnyone2three.
+- Agents/GitHub Copilot: normalize replayed Responses tool-call IDs before dispatch so resumed sessions with historical overlong tool IDs continue instead of failing Copilot schema validation. (#82750) Thanks @galiniliev.
 - Mac app: let menu gateway/session error text wrap across a few lines and stop rebuilding dynamic Context/Gateway menu rows while the menu is open, reducing flicker.
 - Mac app: make device pairing approval sheets friendlier, with concise Mac/device copy, shortened identifiers, friendly scope labels, and Approve as the primary action.
 - Feishu/wiki: reject numeric wiki space IDs before creating Lark clients and keep numeric-looking IDs documented as quoted opaque strings, preventing JavaScript precision loss in knowledge base calls. Fixes #45301. (#82769) Thanks @hyspacex.

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -2298,6 +2298,85 @@ describe("openai transport stream", () => {
     });
   });
 
+  it("normalizes overlong Copilot Responses replay tool ids before dispatch", () => {
+    const longToolItemId = "iVec" + "A".repeat(360);
+    const longToolCallId = `call_ug6lFGKwZDjHfzW8H0PDQRwN|${longToolItemId}`;
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "gpt-5.5",
+        name: "GPT-5.5",
+        api: "openai-responses",
+        provider: "github-copilot",
+        baseUrl: "https://api.githubcopilot.com",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-responses">,
+      {
+        systemPrompt: "system",
+        messages: [
+          { role: "user", content: "read the queue", timestamp: 0 },
+          {
+            role: "assistant",
+            api: "openai-responses",
+            provider: "github-copilot",
+            model: "gpt-5.5",
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            stopReason: "toolUse",
+            timestamp: 1,
+            content: [
+              {
+                type: "toolCall",
+                id: longToolCallId,
+                name: "exec",
+                arguments: { command: "gh pr list --limit 1" },
+              },
+            ],
+          },
+          {
+            role: "toolResult",
+            toolCallId: longToolCallId,
+            toolName: "exec",
+            content: [{ type: "text", text: "[]" }],
+            isError: false,
+            timestamp: 2,
+          },
+          { role: "user", content: "continue", timestamp: 3 },
+        ],
+        tools: [],
+      } as never,
+      { sessionId: "session-123" },
+    ) as {
+      input?: Array<{ type?: string; id?: string; call_id?: string }>;
+    };
+
+    const functionCall = params.input?.find((item) => item.type === "function_call");
+    const functionOutput = params.input?.find((item) => item.type === "function_call_output");
+    expect(functionCall).toBeDefined();
+    expect(functionOutput).toBeDefined();
+    expect(functionCall?.id).toMatch(/^fc_/);
+    expect(functionCall?.id?.length).toBeLessThanOrEqual(64);
+    expect(functionCall?.call_id).toBe("call_ug6lFGKwZDjHfzW8H0PDQRwN");
+    expect(functionOutput?.call_id).toBe(functionCall?.call_id);
+    for (const item of params.input ?? []) {
+      if (item.id !== undefined) {
+        expect(item.id.length).toBeLessThanOrEqual(64);
+      }
+      if (item.call_id !== undefined) {
+        expect(item.call_id.length).toBeLessThanOrEqual(64);
+      }
+    }
+  });
+
   it("adds minimal user input for Codex responses when only the system prompt is present", () => {
     const params = buildOpenAIResponsesParams(
       {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -767,6 +767,7 @@ function convertResponsesMessages(
   const messages: ResponseInput = [];
   const shouldReplayReasoningItems = options?.replayReasoningItems ?? true;
   const shouldReplayResponsesItemIds = options?.replayResponsesItemIds ?? true;
+  const shouldNormalizeSameModelToolCallIds = model.provider === "github-copilot";
   const normalizeIdPart = (part: string) => {
     const sanitized = part.replace(/[^a-zA-Z0-9_-]/g, "_");
     const normalized = sanitized.length > 64 ? sanitized.slice(0, 64) : sanitized;
@@ -802,6 +803,7 @@ function convertResponsesMessages(
     context.messages,
     model,
     normalizeToolCallId,
+    { normalizeSameModelToolCallIds: shouldNormalizeSameModelToolCallIds },
   );
   const includeSystemPrompt = options?.includeSystemPrompt ?? true;
   if (includeSystemPrompt && context.systemPrompt) {
@@ -1692,7 +1694,7 @@ export function buildOpenAIResponsesParams(
   const messages = convertResponsesMessages(
     model,
     context,
-    new Set(["openai", "openai-codex", "opencode", "azure-openai-responses"]),
+    new Set(["openai", "openai-codex", "opencode", "azure-openai-responses", "github-copilot"]),
     {
       includeSystemPrompt: !isCodexResponses,
       supportsDeveloperRole,

--- a/src/agents/transport-message-transform.ts
+++ b/src/agents/transport-message-transform.ts
@@ -45,7 +45,10 @@ export function transformTransportMessages(
     targetModel: Model<Api>,
     source: { provider: string; api: Api; model: string },
   ) => string,
-  options?: { preserveCrossModelToolCallThoughtSignature?: boolean },
+  options?: {
+    normalizeSameModelToolCallIds?: boolean;
+    preserveCrossModelToolCallThoughtSignature?: boolean;
+  },
 ): Context["messages"] {
   const allowSyntheticToolResults = defaultAllowSyntheticToolResults(model.api);
   const syntheticToolResultText = CODEX_STYLE_ABORTED_OUTPUT_APIS.has(model.api)
@@ -103,7 +106,10 @@ export function transformTransportMessages(
         normalizedToolCall = { ...normalizedToolCall };
         delete normalizedToolCall.thoughtSignature;
       }
-      if (!isSameModel && normalizeToolCallId) {
+      if (
+        (!isSameModel || options?.normalizeSameModelToolCallIds === true) &&
+        normalizeToolCallId
+      ) {
         const normalizedId = normalizeToolCallId(block.id, model, msg);
         if (normalizedId !== block.id) {
           toolCallIdMap.set(block.id, normalizedId);


### PR DESCRIPTION
## Summary

- Problem: GitHub Copilot rejected resumed Responses transcripts when historical `function_call.id` values exceeded Copilot's 64-character item ID limit.
- Why it matters: the affected cron workflow could not complete after the default model/provider moved to `github-copilot/gpt-5.5`; the request failed before generation and entered consecutive-error backoff.
- What changed: Copilot Responses replay now opts into same-model tool-call ID normalization, and Copilot is treated as a Responses-style tool ID provider so `call_id` and item IDs are provider-valid before dispatch.
- What did NOT change: this does not reset sessions, change cron behavior, or alter native OpenAI/Codex replay semantics beyond the existing provider-specific normalization path.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #82749
- [x] This PR fixes a bug or regression

## Real Behavior Proof

- Behavior addressed: replayed Copilot Responses `function_call.id` and paired `function_call_output.call_id` values are normalized before dispatch, so historical overlong tool item IDs do not produce Copilot schema rejection.
- Real environment tested: local OpenClaw source checkout on Windows, branch `bug-017-copilot-replay-ids`, Node v24.15.0.
- Exact steps or command run after this patch:

```powershell
node node_modules\vitest\vitest.mjs run src/agents/openai-transport-stream.test.ts --reporter=verbose
node node_modules\vitest\vitest.mjs run src/agents/transport-message-transform.test.ts --reporter=verbose
git diff --check
```

- Evidence after fix: Terminal capture from the local OpenClaw checkout:

```text
RUN  v4.1.6 C:/OpenClaw/worktrees/bug-017-copilot-replay-ids

✓ src/agents/openai-transport-stream.test.ts > openai transport stream > normalizes overlong Copilot Responses replay tool ids before dispatch

Test Files  2 passed (2)
Tests  324 passed (324)

RUN  v4.1.6 C:/OpenClaw/worktrees/bug-017-copilot-replay-ids

Test Files  1 passed (1)
Tests  8 passed (8)

git diff --check
no output; passed
```

- Observed result after fix: the regression test builds a `github-copilot/gpt-5.5` Responses payload from a replayed `call_*|<360+ char item id>` transcript and verifies every outbound `id` and `call_id` is at most 64 characters while preserving tool-output pairing.
- What was not tested: a live GitHub Copilot request with the original private session file was not rerun; the fix is proven at the request-builder seam with the observed failing ID shape.
- Before evidence: logs in #82749 show Copilot rejecting the resumed request with `400 Invalid 'input[77].id': string too long. Expected a string with maximum length 64, but got a string with length 385 instead.`

## Root Cause

- Root cause: tool-call ID normalization only ran for cross-model replay. Same-model/same-provider Copilot replay could preserve historical provider item IDs directly into Responses `function_call.id`, even when those IDs exceeded Copilot's schema limit.
- Missing detection / guardrail: there was no regression coverage for replaying overlong historical Responses IDs through the GitHub Copilot request builder.
- Contributing context: the failing resumed session had older Responses-family history and was later resumed through `github-copilot/gpt-5.5`.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/openai-transport-stream.test.ts`
- Scenario the test locks in: building Copilot Responses params from a replayed assistant tool call with an overlong `call_*|<item id>` normalizes outbound `id` and `call_id` fields to Copilot-valid lengths.
- Why this is the smallest reliable guardrail: the observed failure happened before generation at provider request schema validation, so the request-builder seam catches it without live provider credentials.
- Existing coverage: Codex replay item-id tests covered native/custom Codex behavior, but not same-provider Copilot overlong historical IDs.
- If no new test is added, why not: N/A, a new regression test was added.

## User-Visible / Behavior Changes

Resumed GitHub Copilot agent sessions with historical overlong Responses tool IDs should continue instead of failing provider schema validation before generation.

## Diagram

```text
Before:
[old transcript: call_*|very-long-item-id]
  -> [Copilot Responses payload]
  -> [400 input[].id too long]

After:
[old transcript: call_*|very-long-item-id]
  -> [normalize Copilot replay ids]
  -> [Copilot-valid payload]
```

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows local source checkout for tests; original bug logs came from a Linux/WSL-style gateway dev environment.
- Runtime/container: Node v24.15.0; no container.
- Model/provider: `github-copilot/gpt-5.5` for the failing path; regression test uses `provider: github-copilot`, `api: openai-responses`.
- Integration/channel: cron agent workflow.
- Relevant config: resumed affected agent session after model/provider moved to GitHub Copilot; no secrets included.

### Steps

1. Build a Copilot Responses payload from a transcript containing a replayed assistant tool call shaped like `call_ug6lFGKwZDjHfzW8H0PDQRwN|<overlong item id>`.
2. Include the paired `toolResult` with the same historical ID.
3. Inspect outbound `function_call` and `function_call_output` fields.

### Expected

Outbound `id` and `call_id` values are <= 64 characters, and paired tool output still references the normalized call ID.

### Actual

Before this patch, same-model Copilot replay could preserve the overlong `function_call.id`. After this patch, the regression test confirms normalized outbound IDs.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification

- Verified scenarios: focused OpenAI transport tests and transport-message transform tests pass locally; the new regression proves the reported long-ID shape is normalized for Copilot before dispatch.
- Edge cases checked: tool result pairing remains intact after normalization; `git diff --check` found no whitespace errors.
- What was not verified: live GitHub Copilot execution against the original private session file.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: over-normalizing IDs could break replay pairing.
  - Mitigation: the normalization path records the old-to-new tool call mapping, and the regression asserts paired `function_call_output.call_id` matches the normalized `function_call.call_id`.