### PR TITLE
Trust local plugin approval waits

### DIFF
--- a/src/agents/tools/gateway.test.ts
+++ b/src/agents/tools/gateway.test.ts
@@ -17,6 +17,9 @@ vi.mock("../../config/config.js", () => ({
 vi.mock("../../gateway/call.js", () => ({
   callGateway: (...args: unknown[]) => mocks.callGateway(...args),
 }));
+vi.mock("../../gateway/operator-approval-runtime-token.js", () => ({
+  getOperatorApprovalRuntimeToken: () => "test-approval-runtime-token",
+}));
 
 function capturedGatewayCall(): CallGatewayScopedOptions {
   expect(mocks.callGateway).toHaveBeenCalledTimes(1);
@@ -167,6 +170,32 @@ describe("gateway tool defaults", () => {
     expect(call.method).toBe("cron.add");
     expect(call.params).toEqual({ id: "job-1" });
     expect(call.scopes).toEqual(["operator.admin"]);
+  });
+
+  it("marks default plugin approval calls as approval-runtime calls", async () => {
+    mocks.callGateway.mockResolvedValueOnce({ id: "plugin:approval-1" });
+
+    await callGatewayTool("plugin.approval.waitDecision", {}, { id: "plugin:approval-1" });
+
+    const call = capturedGatewayCall();
+    expect(call.method).toBe("plugin.approval.waitDecision");
+    expect(call.scopes).toEqual(["operator.approvals"]);
+    expect(call.approvalRuntimeToken).toBe("test-approval-runtime-token");
+  });
+
+  it("does not send the approval-runtime token to explicit gateway overrides", async () => {
+    mocks.callGateway.mockResolvedValueOnce({ id: "plugin:approval-1" });
+
+    await callGatewayTool(
+      "plugin.approval.waitDecision",
+      { gatewayUrl: "ws://127.0.0.1:18789", gatewayToken: "t" },
+      { id: "plugin:approval-1" },
+    );
+
+    const call = capturedGatewayCall();
+    expect(call.method).toBe("plugin.approval.waitDecision");
+    expect(call.scopes).toEqual(["operator.approvals"]);
+    expect(call.approvalRuntimeToken).toBeUndefined();
   });
 
   it("derives plugin session action scopes from call params", async () => {

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -49,6 +49,7 @@ type CallGatewayBaseOptions = {
   url?: string;
   token?: string;
   password?: string;
+  approvalRuntimeToken?: string;
   tlsFingerprint?: string;
   config?: OpenClawConfig;
   method: string;
@@ -691,6 +692,7 @@ async function executeGatewayRequestWithScopes<T>(params: {
       url,
       token,
       password,
+      approvalRuntimeToken: opts.approvalRuntimeToken,
       tlsFingerprint,
       preauthHandshakeTimeoutMs,
       instanceId: opts.instanceId ?? randomUUID(),


### PR DESCRIPTION
## Summary

- pass the existing operator approval runtime token through `callGateway` into `GatewayClient`
- mark default local `plugin.approval.*` agent gateway calls as approval-runtime calls when they use `operator.approvals`
- keep explicit `gatewayUrl` overrides unchanged so remote/manual gateway calls do not receive the local runtime token

## Verification

- `node scripts/run-vitest.mjs src/agents/tools/gateway.test.ts`
- `pnpm build`
- `git diff --check`

## Real behavior proof

Behavior addressed: external plugin before-tool-call approval flows create a plugin approval over one short-lived local backend gateway connection, then wait for a decision over another. Without the local approval runtime token, the wait connection can be unable to see the record created by the request connection.

Real environment tested: local OpenClaw checkout with the same gateway-token patch applied in the linked AgentKit host-API checkout, plus the external `openclaw-agentkit` plugin installed from its built `dist/index.js` into a temporary OpenClaw home.

Exact steps or command run after this patch: started a real OpenClaw gateway with the external AgentKit plugin installed, invoked `runBeforeToolCallHook` for a protected tool, listed the pending `plugin.approval.*` request, resolved it through the gateway, and awaited `plugin.approval.waitDecision` over a separate local backend gateway connection.

Evidence after fix: copied live output from the local external-plugin gateway proof:

```text
[plugins] plugins.allow is empty; discovered non-bundled plugins may auto-load: agentkit (.../openclaw-agentkit/dist/index.js).
http server listening (10 plugins: acpx, agentkit, ...)
[ws] ⇄ res ✓ plugin.approval.waitDecision 231ms conn=ed76edd7...a972 id=4efb8a53...49b5
{
  "ok": true,
  "pluginLoaded": true,
  "approvalId": "plugin:ea69c9f1-5527-4450-8ad1-6c90d3947df3",
  "actionCommands": [
    "/agentkit approve plugin:ea69c9f1-5527-4450-8ad1-6c90d3947df3 allow-once",
    "/agentkit approve plugin:ea69c9f1-5527-4450-8ad1-6c90d3947df3 allow-always",
    "/approve plugin:ea69c9f1-5527-4450-8ad1-6c90d3947df3 deny"
  ],
  "hookResult": {
    "blocked": true,
    "kind": "failure",
    "deniedReason": "plugin-approval",
    "reason": "Denied by user",
    "params": {
      "cmd": "echo agentkit"
    }
  }
}
```

Observed result after fix: the external AgentKit plugin loaded as an installed plugin, the core plugin approval request stayed visible across the request/wait gateway connections, `plugin.approval.waitDecision` returned after the gateway resolution, and the hook produced the expected denied result instead of `Plugin approval required (gateway unavailable)` / `approval expired or not found`.

What was not tested: a full external AgentKit plugin build against this branch alone, because that plugin also depends on the separately open SDK/API PRs for verified plugin approval resolution, approval action metadata, and chat injection metadata.
