### PR TITLE
fix(ui): run /status locally through session_status

### DIFF
--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -1115,6 +1115,41 @@ describe("handleSendChat", () => {
     expect(feedback.content).toBe("Command `/think` failed unexpectedly.");
   });
 
+  it("runs /status immediately while a chat run is active", async () => {
+    executeSlashCommandMock.mockResolvedValue({
+      content: "**Session Status**\nModel: `openai/gpt-5.4-mini`",
+    });
+    const request = vi.fn(async (method: string) => {
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+      chatRunId: "run-main",
+      chatStream: "Working...",
+      chatMessage: "/status",
+      sessionKey: "agent:main:main",
+    });
+
+    await handleSendChat(host);
+
+    expect(executeSlashCommandMock).toHaveBeenCalledWith(
+      host.client,
+      "agent:main:main",
+      "status",
+      "",
+      expect.any(Object),
+    );
+    expect(host.chatQueue).toStrictEqual([]);
+    expect(host.chatRunId).toBe("run-main");
+    expect(host.chatStream).toBe("Working...");
+    expect(host.chatMessage).toBe("");
+    expect(host.chatMessages).toContainEqual({
+      role: "system",
+      content: "**Session Status**\nModel: `openai/gpt-5.4-mini`",
+      timestamp: expect.any(Number),
+    });
+  });
+
   it("sends /btw immediately while a main run is active without queueing it", async () => {
     const request = vi.fn(async (method: string) => {
       if (method === "chat.send") {

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -635,7 +635,7 @@ export async function handleSendChat(
 }
 
 function shouldQueueLocalSlashCommand(name: string): boolean {
-  return !["stop", "focus", "export-session", "steer", "redirect", "new"].includes(name);
+  return !["stop", "status", "focus", "export-session", "steer", "redirect", "new"].includes(name);
 }
 
 // ── Slash Command Dispatch ──

--- a/ui/src/ui/chat/slash-command-executor.node.test.ts
+++ b/ui/src/ui/chat/slash-command-executor.node.test.ts
@@ -35,6 +35,63 @@ function expectNoRequestCall(request: ReturnType<typeof vi.fn>, method: string) 
   expect(request.mock.calls.some(([calledMethod]) => calledMethod === method)).toBe(false);
 }
 
+describe("executeSlashCommand /status", () => {
+  it("uses the canonical session_status tool output", async () => {
+    const request = vi.fn(async (method: string, payload?: unknown) => {
+      if (method === "tools.invoke") {
+        expect(payload).toEqual({
+          name: "session_status",
+          args: {},
+          sessionKey: "agent:main:main",
+        });
+        return {
+          ok: true,
+          toolName: "session_status",
+          output: {
+            content: [{ type: "text", text: "fallback status text" }],
+            details: {
+              statusText: "**Session Status**\nModel: `openai/gpt-5.4-mini`",
+            },
+          },
+        };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "agent:main:main",
+      "status",
+      "",
+    );
+
+    expect(result.content).toBe("**Session Status**\nModel: `openai/gpt-5.4-mini`");
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces session_status tool errors", async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === "tools.invoke") {
+        return {
+          ok: false,
+          toolName: "session_status",
+          error: { code: "not_found", message: "Tool not available: session_status" },
+        };
+      }
+      throw new Error(`unexpected method: ${method}`);
+    });
+
+    const result = await executeSlashCommand(
+      { request } as unknown as GatewayBrowserClient,
+      "agent:main:main",
+      "status",
+      "",
+    );
+
+    expect(result.content).toBe("Failed to get status: Tool not available: session_status");
+  });
+});
+
 describe("executeSlashCommand /kill", () => {
   it("aborts every sub-agent session for /kill all", async () => {
     const request = vi.fn(async (method: string, _payload?: unknown) => {

--- a/ui/src/ui/chat/slash-command-executor.ts
+++ b/ui/src/ui/chat/slash-command-executor.ts
@@ -31,6 +31,7 @@ import type {
   ModelCatalogEntry,
   SessionsListResult,
   SessionsPatchResult,
+  ToolsInvokeResult,
 } from "../types.ts";
 import { generateUUID } from "../uuid.ts";
 import { SLASH_COMMANDS } from "./slash-commands.ts";
@@ -119,6 +120,8 @@ export async function executeSlashCommand(
       return await executeFast(client, sessionKey, args);
     case "verbose":
       return await executeVerbose(client, sessionKey, args);
+    case "status":
+      return await executeStatus(client, sessionKey);
     case "export-session":
       return { content: "Exporting session...", action: "export" };
     case "usage":
@@ -138,6 +141,40 @@ export async function executeSlashCommand(
 
 // ── Command Implementations ──
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readTextBlocks(value: unknown): string | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const text = value
+    .map((entry) => (isRecord(entry) && typeof entry.text === "string" ? entry.text : ""))
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+  return text || null;
+}
+
+function readStatusToolText(output: unknown): string | null {
+  if (typeof output === "string") {
+    return output.trim() || null;
+  }
+  if (!isRecord(output)) {
+    return null;
+  }
+  const details = isRecord(output.details) ? output.details : null;
+  if (typeof details?.statusText === "string" && details.statusText.trim()) {
+    return details.statusText;
+  }
+  const contentText = readTextBlocks(output.content);
+  if (contentText) {
+    return contentText;
+  }
+  return typeof output.text === "string" && output.text.trim() ? output.text : null;
+}
+
 function executeHelp(): SlashCommandResult {
   const lines = ["**Available Commands**\n"];
   let currentCategory = "";
@@ -155,6 +192,30 @@ function executeHelp(): SlashCommandResult {
 
   lines.push("\nType `/` to open the command menu.");
   return { content: lines.join("\n") };
+}
+
+async function executeStatus(
+  client: GatewayBrowserClient,
+  sessionKey: string,
+): Promise<SlashCommandResult> {
+  try {
+    const result = await client.request<ToolsInvokeResult>("tools.invoke", {
+      name: "session_status",
+      args: {},
+      sessionKey,
+    });
+    if (!result.ok) {
+      return {
+        content: `Failed to get status: ${result?.error?.message ?? "session_status failed"}`,
+      };
+    }
+    const statusText = readStatusToolText(result.output);
+    return {
+      content: statusText ?? "Session status returned no displayable output.",
+    };
+  } catch (err) {
+    return { content: `Failed to get status: ${String(err)}` };
+  }
 }
 
 async function executeCompact(

--- a/ui/src/ui/chat/slash-commands.node.test.ts
+++ b/ui/src/ui/chat/slash-commands.node.test.ts
@@ -71,10 +71,10 @@ describe("parseSlashCommand", () => {
     expectParsedSlash("/fast:on", { name: "fast" }, "on");
   });
 
-  it("keeps /status on the agent path", () => {
+  it("executes /status locally so a single Enter submits it", () => {
     const status = SLASH_COMMANDS.find((entry) => entry.name === "status");
-    expect(status?.executeLocal).not.toBe(true);
-    expectParsedSlash("/status", { name: "status" }, "");
+    expect(status?.executeLocal).toBe(true);
+    expectParsedSlash("/status", { name: "status", executeLocal: true }, "");
   });
 
   it("includes shared /tools with shared arg hints", () => {

--- a/ui/src/ui/chat/slash-commands.ts
+++ b/ui/src/ui/chat/slash-commands.ts
@@ -83,6 +83,7 @@ const LOCAL_COMMANDS = new Set([
   "help",
   "new",
   "reset",
+  "status",
   "stop",
   "compact",
   "focus",

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -759,6 +759,8 @@ export type ToolsEffectiveGroup =
   import("../../../src/gateway/protocol/schema/types.js").ToolsEffectiveGroup;
 export type ToolsEffectiveResult =
   import("../../../src/gateway/protocol/schema/types.js").ToolsEffectiveResult;
+export type ToolsInvokeResult =
+  import("../../../src/gateway/protocol/schema/types.js").ToolsInvokeResult;
 
 export type ModelAuthExpiry =
   import("../../../src/gateway/server-methods/models-auth-status.js").ModelAuthExpiry;


### PR DESCRIPTION
## Summary

- Mark `/status` as a local Control UI slash command so selecting it from the slash menu submits with one Enter.
- Execute local `/status` through the existing `session_status` tool via `tools.invoke`, preserving the canonical `buildStatusText` output instead of adding a separate browser-side formatter.
- Let `/status` run immediately while a chat run is active, rather than queueing behind a stuck or long-running run.

## Context

Fixes #45569.

This is a focused alternative to #45602. That PR identified the same local-command routing gap, but it formats status client-side from `sessions.list`. This patch keeps status rendering on the canonical `session_status` path and adds targeted regression coverage for the active-run queue case.

## Real behavior proof

- Behavior or issue addressed: Control UI `/status` should execute locally and immediately, using the canonical `session_status` output instead of being routed into the agent/model chat path where it can require a second Enter or hang behind an active run.
- Real environment tested: macOS local OpenClaw Gateway, installed OpenClaw `2026.5.12 (f066dd2)`, loopback Gateway on `127.0.0.1:18789`, OpenAI OAuth profile redacted below. The installed Control UI was patched with the same local `/status` route before upstreaming this source fix.
- Exact steps or command run after this patch:
  1. Reloaded the local Control UI after applying the equivalent local `/status` route patch.
  2. Sent `/status` from the main chat while the main session was active.
  3. Confirmed the status path uses the canonical Gateway tool output with:

```shell
openclaw gateway call tools.invoke --json --params '{"name":"session_status","args":{},"sessionKey":"agent:main:main"}' --timeout 10000
```

- Evidence after fix (copied live output, private account redacted):

```json
{
  "ok": true,
  "toolName": "session_status",
  "output": {
    "content": [
      {
        "type": "text",
        "text": "OpenClaw 2026.5.12 (f066dd2)\nUptime: gateway 15h 56m · system 1d 15h\nModel: openai/gpt-5.4-mini · oauth (openai-codex:[redacted])\nFallbacks: openrouter/google/gemini-2.5-pro-preview\nTokens: 33k in / 309 out\nContext: 33k/400k (8%)\nSession: agent:main:main • updated 17m ago\nExecution: direct · Runtime: OpenAI Codex · Think: low · Text: low · elevated\nQueue: steer (depth 0)"
      }
    ],
    "details": {
      "ok": true,
      "sessionKey": "agent:main:main",
      "changedModel": false,
      "statusText": "OpenClaw 2026.5.12 (f066dd2)\nModel: openai/gpt-5.4-mini · oauth (openai-codex:[redacted])\nSession: agent:main:main\nQueue: steer (depth 0)"
    }
  },
  "source": "core"
}
```

- Observed result after fix: `/status` produced the status card immediately from `session_status`; the request did not create a model turn, did not wait behind the active chat run, and the Gateway status output showed queue depth `0`.
- What was not tested: I did not run a fresh source-built browser bundle against this Gateway; the live proof used the equivalent installed Control UI patch, and the source branch locks the exact source behavior with the UI regression coverage below.
- Before evidence (optional but encouraged): On current `main`/`v2026.5.16-beta.3`, `LOCAL_COMMANDS` omits `status` and `slash-command-executor.ts` has no `case "status"`, so the Control UI slash selection path cannot execute `/status` locally.

## Test plan

- `node scripts/run-vitest.mjs run ui/src/ui/chat/slash-commands.node.test.ts`
- `node scripts/run-vitest.mjs run ui/src/ui/chat/slash-command-executor.node.test.ts`
- `node scripts/run-vitest.mjs run ui/src/ui/app-chat.test.ts`
- `node scripts/run-vitest.mjs run ui/src/ui/chat/slash-commands.node.test.ts ui/src/ui/chat/slash-command-executor.node.test.ts ui/src/ui/app-chat.test.ts`
- `pnpm tsgo:test:ui`
- `pnpm tsgo:prod`
- `pnpm lint --threads=8`
- `pnpm exec oxfmt --check --threads=1 ui/src/ui/chat/slash-commands.ts ui/src/ui/chat/slash-command-executor.ts ui/src/ui/app-chat.ts ui/src/ui/types.ts ui/src/ui/chat/slash-commands.node.test.ts ui/src/ui/chat/slash-command-executor.node.test.ts ui/src/ui/app-chat.test.ts`
