### PR TITLE
Fix context overflow fallback to larger models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/auth: honor `OPENCLAW_GATEWAY_TOKEN` as the remote interactive fallback when no remote token is configured, keeping remote TUI setup aligned with documented auth precedence.
 - Providers/xAI: continue polling video generations while xAI reports in-flight jobs as `pending`, so Grok video requests no longer fail before the final `done` response. (#82610) Thanks @Manzojunior.
 - Logs: redact raw Basic auth and named security headers from `logs.tail` output before returning lines to read-scoped clients. Fixes #66832. Thanks @Magicray1217.
+- Agents/model fallback: route exhausted context overflow runs to configured larger-context fallback models when their known effective window can fit the turn. Fixes #9986. Thanks @amknight.
 - CLI/gateway: emit structured JSON for gateway transport close/timeout failures when `--json` is requested by health, gateway health, and devices list commands. Fixes #79108. Thanks @TurboTheTurtle.
 - Telegram: normalize announce group targets via a new `resolveSessionTarget` channel hook so scheduled announcements resolve consistently against the same Telegram session conversation registry as inbound turns. Fixes #81229. Thanks @giodl73-repo.
 - QA/RTT: let `pnpm rtt` lease Convex-backed Telegram credentials while preserving RTT sample counts, sample timeouts, and result stats on the RTT harness path.

--- a/docs/concepts/model-failover.md
+++ b/docs/concepts/model-failover.md
@@ -255,7 +255,7 @@ Defaults:
 
 ## Model fallback
 
-If all profiles for a provider fail, OpenClaw moves to the next model in `agents.defaults.model.fallbacks`. This applies to auth failures, rate limits, and timeouts that exhausted profile rotation (other errors do not advance fallback). Provider errors that do not expose enough detail are still labeled precisely in fallback state: `empty_response` means the provider returned no usable message or status, `no_error_details` means the provider explicitly returned `Unknown error (no error details in response)`, and `unclassified` means OpenClaw preserved the raw preview but no classifier matched it yet.
+If all profiles for a provider fail, OpenClaw moves to the next model in `agents.defaults.model.fallbacks`. This applies to auth failures, rate limits, timeouts that exhausted profile rotation, and context overflow after active-model compaction and oversized-tool-result recovery are exhausted when a later candidate has a known larger effective context window. Other errors do not advance fallback. Provider errors that do not expose enough detail are still labeled precisely in fallback state: `empty_response` means the provider returned no usable message or status, `no_error_details` means the provider explicitly returned `Unknown error (no error details in response)`, and `unclassified` means OpenClaw preserved the raw preview but no classifier matched it yet.
 
 Overloaded and rate-limit errors are handled more aggressively than billing cooldowns. By default, OpenClaw allows one same-provider auth-profile retry, then switches to the next configured model fallback without waiting. Provider-busy signals such as `ModelNotReadyException` land in that overloaded bucket. Tune this with `auth.cooldowns.overloadedProfileRotations`, `auth.cooldowns.overloadedBackoffMs`, and `auth.cooldowns.rateLimitedProfileRotations`.
 
@@ -285,6 +285,7 @@ OpenClaw builds the candidate list from the currently requested `provider/model`
     - rate limits and cooldown exhaustion
     - overloaded/provider-busy errors
     - timeout-shaped failover errors
+    - context overflow after compaction/truncation recovery, only to a later candidate with a known larger effective context window
     - billing disables
     - `LiveSessionModelSwitchError`, which is normalized into a failover path so a stale persisted model does not create an outer retry loop
     - other unrecognized errors when there are still remaining candidates
@@ -292,7 +293,7 @@ OpenClaw builds the candidate list from the currently requested `provider/model`
   </Tab>
   <Tab title="Does not continue on">
     - explicit aborts that are not timeout/failover-shaped
-    - context overflow errors that should stay inside compaction/retry logic (for example `request_too_large`, `INVALID_ARGUMENT: input exceeds the maximum number of tokens`, `input token count exceeds the maximum number of input tokens`, `The input is too long for the model`, or `ollama error: context length exceeded`)
+    - context overflow when no later candidate has a known larger effective context window, or when the observed overflow token count would still exceed that candidate
     - a final unknown error when there are no candidates left
 
   </Tab>

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -88,6 +88,8 @@ export function resolveFailoverStatus(reason: FailoverReason): number | undefine
       return 403;
     case "timeout":
       return 408;
+    case "context_overflow":
+      return 413;
     case "format":
       return 400;
     case "model_not_found":

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import type { ModelDefinitionConfig, ModelProviderConfig } from "../config/types.models.js";
 import { resetLogger, setLoggerOverride } from "../logging/logger.js";
 import { createWarnLogCapture } from "../logging/test-helpers/warn-log-capture.js";
 import {
@@ -160,6 +161,30 @@ vi.mock("./model-fallback-auth.runtime.js", () => authRuntimeMock.runtime);
 const makeCfg = makeModelFallbackCfg;
 let authTempRoot = "";
 let authTempCounter = 0;
+
+function makeContextModel(id: string, contextWindow: number): ModelDefinitionConfig {
+  return {
+    id,
+    name: id,
+    reasoning: false,
+    input: ["text"],
+    cost: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+    },
+    contextWindow,
+    maxTokens: 4096,
+  };
+}
+
+function makeContextProvider(...models: ModelDefinitionConfig[]): ModelProviderConfig {
+  return {
+    baseUrl: "https://example.invalid/v1",
+    models,
+  };
+}
 
 beforeAll(() => {
   setCurrentPluginMetadataSnapshot(loadPluginMetadataSnapshot({ config: {}, env: process.env }), {
@@ -737,6 +762,228 @@ describe("runWithModelFallback", () => {
     expect(run).toHaveBeenCalledTimes(1);
   });
 
+  it("falls back on context overflow when a configured candidate has a larger known context window", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-opus-4-5",
+            fallbacks: ["moonshot/kimi-k2.5"],
+          },
+        },
+      },
+      models: {
+        providers: {
+          anthropic: makeContextProvider(makeContextModel("claude-opus-4-5", 200_000)),
+          moonshot: makeContextProvider(makeContextModel("kimi-k2.5", 256_000)),
+        },
+      },
+    });
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error("INVALID_ARGUMENT: input exceeds the maximum number of tokens"),
+      )
+      .mockResolvedValueOnce("fallback ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "anthropic",
+      model: "claude-opus-4-5",
+      run,
+    });
+
+    expect(result.result).toBe("fallback ok");
+    expect(run.mock.calls).toEqual([
+      ["anthropic", "claude-opus-4-5"],
+      ["moonshot", "kimi-k2.5"],
+    ]);
+    expect(result.attempts[0]).toMatchObject({
+      provider: "anthropic",
+      model: "claude-opus-4-5",
+      reason: "context_overflow",
+      status: 413,
+      code: "context_overflow",
+    });
+  });
+
+  it("skips context overflow fallback candidates that cannot fit the observed token count", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-opus-4-5",
+            fallbacks: ["moonshot/kimi-k2.5", "fallback-large/big-context"],
+          },
+        },
+      },
+      models: {
+        providers: {
+          anthropic: makeContextProvider(makeContextModel("claude-opus-4-5", 200_000)),
+          moonshot: makeContextProvider(makeContextModel("kimi-k2.5", 256_000)),
+          "fallback-large": makeContextProvider(makeContextModel("big-context", 1_048_576)),
+        },
+      },
+    });
+    const run = vi.fn().mockImplementation(async (provider, model) => {
+      if (provider === "anthropic") {
+        throw new Error("prompt is too long: 277403 tokens > 200000 maximum");
+      }
+      if (provider === "fallback-large" && model === "big-context") {
+        return "fallback ok";
+      }
+      throw new Error(`unexpected candidate: ${provider}/${model}`);
+    });
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "anthropic",
+      model: "claude-opus-4-5",
+      run,
+    });
+
+    expect(result.result).toBe("fallback ok");
+    expect(run.mock.calls).toEqual([
+      ["anthropic", "claude-opus-4-5"],
+      ["fallback-large", "big-context"],
+    ]);
+  });
+
+  it("does not fall back on context overflow to smaller known context windows", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-opus-4-5",
+            fallbacks: ["ollama/qwen3.5:27b"],
+          },
+        },
+      },
+      models: {
+        providers: {
+          anthropic: makeContextProvider(makeContextModel("claude-opus-4-5", 200_000)),
+          ollama: makeContextProvider(makeContextModel("qwen3.5:27b", 32_000)),
+        },
+      },
+    });
+    const overflowError = new Error("ollama error: context length exceeded");
+    const run = vi.fn().mockRejectedValueOnce(overflowError);
+
+    await expect(
+      runWithModelFallback({
+        cfg,
+        provider: "anthropic",
+        model: "claude-opus-4-5",
+        run,
+      }),
+    ).rejects.toBe(overflowError);
+    expect(run.mock.calls).toEqual([["anthropic", "claude-opus-4-5"]]);
+  });
+
+  it("uses blocked embedded context overflow results to continue to larger fallbacks", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-opus-4-5",
+            fallbacks: ["moonshot/kimi-k2.5"],
+          },
+        },
+      },
+      models: {
+        providers: {
+          anthropic: makeContextProvider(makeContextModel("claude-opus-4-5", 200_000)),
+          moonshot: makeContextProvider(makeContextModel("kimi-k2.5", 256_000)),
+        },
+      },
+    });
+    const primaryResult: EmbeddedPiRunResult = {
+      payloads: [{ text: "Context overflow: prompt too large for the model.", isError: true }],
+      meta: {
+        durationMs: 1,
+        livenessState: "blocked",
+        error: {
+          kind: "context_overflow",
+          message: "Context overflow: prompt too large for the model.",
+        },
+      },
+    };
+    const fallbackResult: EmbeddedPiRunResult = {
+      payloads: [{ text: "fallback ok" }],
+      meta: { durationMs: 1, finalAssistantVisibleText: "fallback ok" },
+    };
+    const run = vi.fn().mockResolvedValueOnce(primaryResult).mockResolvedValueOnce(fallbackResult);
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "anthropic",
+      model: "claude-opus-4-5",
+      run,
+      classifyResult: ({ provider, model, result }) =>
+        classifyEmbeddedPiRunResultForModelFallback({
+          provider,
+          model,
+          result,
+        }),
+    });
+
+    expect(result.result).toBe(fallbackResult);
+    expect(run.mock.calls).toEqual([
+      ["anthropic", "claude-opus-4-5"],
+      ["moonshot", "kimi-k2.5"],
+    ]);
+    expect(result.attempts[0]?.reason).toBe("context_overflow");
+    expect(result.attempts[0]?.code).toBe("context_overflow");
+  });
+
+  it("keeps embedded context overflow results when no larger context fallback is known", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "anthropic/claude-opus-4-5",
+            fallbacks: ["ollama/qwen3.5:27b"],
+          },
+        },
+      },
+      models: {
+        providers: {
+          anthropic: makeContextProvider(makeContextModel("claude-opus-4-5", 200_000)),
+          ollama: makeContextProvider(makeContextModel("qwen3.5:27b", 32_000)),
+        },
+      },
+    });
+    const primaryResult: EmbeddedPiRunResult = {
+      payloads: [{ text: "Context overflow: prompt too large for the model.", isError: true }],
+      meta: {
+        durationMs: 1,
+        livenessState: "blocked",
+        error: {
+          kind: "context_overflow",
+          message: "Context overflow: prompt too large for the model.",
+        },
+      },
+    };
+    const run = vi.fn().mockResolvedValueOnce(primaryResult);
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "anthropic",
+      model: "claude-opus-4-5",
+      run,
+      classifyResult: ({ provider, model, result }) =>
+        classifyEmbeddedPiRunResultForModelFallback({
+          provider,
+          model,
+          result,
+        }),
+    });
+
+    expect(result.result).toBe(primaryResult);
+    expect(result.attempts).toStrictEqual([]);
+    expect(run.mock.calls).toEqual([["anthropic", "claude-opus-4-5"]]);
+  });
+
   it("does not classify successful results when the optional classifier returns null", async () => {
     const cfg = makeProviderFallbackCfg("openai-codex");
     const run = vi.fn().mockResolvedValueOnce({ payloads: [{ text: "ok" }] });
@@ -811,6 +1058,29 @@ describe("runWithModelFallback", () => {
       classifyEmbeddedPiRunResultForModelFallback({
         provider: "atlassian-ai-gateway-openai",
         model: "gpt-5.5-2026-04-23",
+        result: runResult,
+      }),
+    ).toBeNull();
+  });
+
+  it("keeps context overflow results with outbound delivery evidence out of fallback", () => {
+    const runResult: EmbeddedPiRunResult = {
+      payloads: [{ text: "Context overflow: prompt too large for the model.", isError: true }],
+      messagingToolSentTexts: ["already sent"],
+      meta: {
+        durationMs: 1,
+        livenessState: "blocked",
+        error: {
+          kind: "context_overflow",
+          message: "Context overflow: prompt too large for the model.",
+        },
+      },
+    };
+
+    expect(
+      classifyEmbeddedPiRunResultForModelFallback({
+        provider: "anthropic",
+        model: "claude-opus-4-5",
         result: runResult,
       }),
     ).toBeNull();

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -13,6 +13,7 @@ import { sanitizeForLog } from "../terminal/ansi.js";
 import { externalCliDiscoveryForProviders } from "./auth-profiles/external-cli-discovery.js";
 import { hasAnyAuthProfileStoreSource } from "./auth-profiles/source-check.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
+import { resolveContextTokensForModel } from "./context.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
 import {
   FailoverError,
@@ -20,6 +21,7 @@ import {
   describeFailoverError,
   isFailoverError,
   isTimeoutError,
+  resolveFailoverStatus,
 } from "./failover-error.js";
 import {
   shouldAllowCooldownProbeForReason,
@@ -41,8 +43,12 @@ import {
   resolveConfiguredModelRef,
   resolveModelRefFromString,
 } from "./model-selection-resolve.js";
-import { isLikelyContextOverflowError } from "./pi-embedded-helpers/errors.js";
+import {
+  extractObservedOverflowTokenCount,
+  isLikelyContextOverflowError,
+} from "./pi-embedded-helpers/errors.js";
 import type { FailoverReason } from "./pi-embedded-helpers/types.js";
+import { findNormalizedProviderValue } from "./provider-id.js";
 import { resolveSessionSuspensionReason, suspendSession } from "./session-suspension.js";
 
 const log = createSubsystemLogger("model-fallback");
@@ -184,6 +190,20 @@ type ModelFallbackRunResult<T> = {
   attempts: FallbackAttempt[];
 };
 
+type ContextOverflowFallbackTarget = {
+  candidate: ModelCandidate;
+  index: number;
+  currentContextTokens?: number;
+  nextContextTokens: number;
+  observedTokenCount?: number;
+};
+
+type ContextFallbackProviderConfig = {
+  contextTokens?: number;
+  contextWindow?: number;
+  models?: Array<{ id?: string; contextTokens?: number; contextWindow?: number }>;
+};
+
 type ModelFallbackAuthRuntime = typeof import("./model-fallback-auth.runtime.js");
 
 const modelFallbackAuthRuntimeLoader = createLazyImportLoader<ModelFallbackAuthRuntime>(
@@ -252,7 +272,7 @@ async function runFallbackAttempt<T>(params: {
   attempt: number;
   total: number;
   attribution?: FailoverAttribution;
-}): Promise<{ success: ModelFallbackRunResult<T> } | { error: unknown }> {
+}): Promise<{ success: ModelFallbackRunResult<T> } | { error: unknown; classifiedResult?: T }> {
   const runResult = await runFallbackCandidate({
     run: params.run,
     provider: params.provider,
@@ -274,7 +294,7 @@ async function runFallbackAttempt<T>(params: {
       attribution: params.attribution,
     });
     if (classifiedError) {
-      return { error: classifiedError };
+      return { error: classifiedError, classifiedResult: runResult.result };
     }
     return {
       success: buildFallbackSuccess({
@@ -311,6 +331,125 @@ function resolveResultClassificationError(
     status: classification.status,
     code: classification.code,
     rawError: classification.rawError,
+  });
+}
+
+function normalizePositiveInteger(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
+  }
+  const int = Math.floor(value);
+  return int > 0 ? int : undefined;
+}
+
+function resolveConfiguredCandidateContextTokens(params: {
+  cfg: OpenClawConfig | undefined;
+  candidate: ModelCandidate;
+}): number | undefined {
+  const providers = (
+    params.cfg?.models as
+      | { providers?: Record<string, ContextFallbackProviderConfig | undefined> }
+      | undefined
+  )?.providers;
+  const providerConfig = findNormalizedProviderValue(providers, params.candidate.provider);
+  const modelConfig = Array.isArray(providerConfig?.models)
+    ? providerConfig.models.find((model) => model?.id === params.candidate.model)
+    : undefined;
+  return (
+    normalizePositiveInteger(modelConfig?.contextTokens) ??
+    normalizePositiveInteger(modelConfig?.contextWindow) ??
+    normalizePositiveInteger(providerConfig?.contextTokens) ??
+    normalizePositiveInteger(providerConfig?.contextWindow)
+  );
+}
+
+function resolveEffectiveCandidateContextTokens(params: {
+  cfg: OpenClawConfig | undefined;
+  candidate: ModelCandidate;
+}): number | undefined {
+  const modelTokens =
+    resolveConfiguredCandidateContextTokens(params) ??
+    resolveContextTokensForModel({
+      cfg: params.cfg,
+      provider: params.candidate.provider,
+      model: params.candidate.model,
+      allowAsyncLoad: false,
+    });
+  const normalizedModelTokens = normalizePositiveInteger(modelTokens);
+  if (!normalizedModelTokens) {
+    return undefined;
+  }
+  const agentCap = normalizePositiveInteger(params.cfg?.agents?.defaults?.contextTokens);
+  return agentCap ? Math.min(normalizedModelTokens, agentCap) : normalizedModelTokens;
+}
+
+function resolveContextOverflowFallbackTarget(params: {
+  cfg: OpenClawConfig | undefined;
+  candidates: ModelCandidate[];
+  currentIndex: number;
+  errorMessage: string;
+}): ContextOverflowFallbackTarget | null {
+  const current = params.candidates[params.currentIndex];
+  if (!current) {
+    return null;
+  }
+  const currentContextTokens = resolveEffectiveCandidateContextTokens({
+    cfg: params.cfg,
+    candidate: current,
+  });
+  const observedTokenCount = extractObservedOverflowTokenCount(params.errorMessage);
+
+  for (let index = params.currentIndex + 1; index < params.candidates.length; index += 1) {
+    const candidate = params.candidates[index];
+    if (!candidate) {
+      continue;
+    }
+    const nextContextTokens = resolveEffectiveCandidateContextTokens({
+      cfg: params.cfg,
+      candidate,
+    });
+    if (!nextContextTokens) {
+      continue;
+    }
+    const growsBeyondCurrent =
+      currentContextTokens !== undefined
+        ? nextContextTokens > currentContextTokens
+        : observedTokenCount !== undefined;
+    const fitsObservedOverflow =
+      observedTokenCount === undefined || nextContextTokens > observedTokenCount;
+    if (!growsBeyondCurrent || !fitsObservedOverflow) {
+      continue;
+    }
+    return {
+      candidate,
+      index,
+      nextContextTokens,
+      ...(currentContextTokens !== undefined ? { currentContextTokens } : {}),
+      ...(observedTokenCount !== undefined ? { observedTokenCount } : {}),
+    };
+  }
+  return null;
+}
+
+function createContextOverflowFallbackError(params: {
+  message: string;
+  provider: string;
+  model: string;
+  sessionId?: string;
+  lane?: string;
+  cause: unknown;
+}): FailoverError {
+  return new FailoverError(params.message, {
+    reason: "context_overflow",
+    provider: params.provider,
+    model: params.model,
+    ...(params.sessionId ? { sessionId: params.sessionId } : {}),
+    ...(params.lane ? { lane: params.lane } : {}),
+    status: resolveFailoverStatus("context_overflow"),
+    code:
+      isFailoverError(params.cause) && params.cause.code ? params.cause.code : "context_overflow",
+    rawError: params.message,
+    cause: params.cause instanceof Error ? params.cause : undefined,
   });
 }
 
@@ -1096,13 +1235,59 @@ export async function runWithModelFallback<T>(params: {
           cooldownProbeUsedProviders.add(transientProbeProviderForAttempt);
         }
       }
-      // Context overflow errors should be handled by the inner runner's
-      // compaction/retry logic, not by model fallback.  If one escapes as a
-      // throw, rethrow it immediately rather than trying a different model
-      // that may have a smaller context window and fail worse.
       const errMessage = formatErrorMessage(err);
       if (isLikelyContextOverflowError(errMessage)) {
-        throw err;
+        const target = resolveContextOverflowFallbackTarget({
+          cfg: params.cfg,
+          candidates,
+          currentIndex: i,
+          errorMessage: errMessage,
+        });
+        if (!target) {
+          if ("classifiedResult" in attemptRun) {
+            return buildFallbackSuccess({
+              result: attemptRun.classifiedResult as T,
+              provider: candidate.provider,
+              model: candidate.model,
+              attempts,
+            });
+          }
+          throw err;
+        }
+        const normalized = createContextOverflowFallbackError({
+          message: errMessage,
+          provider: candidate.provider,
+          model: candidate.model,
+          ...(params.sessionId ? { sessionId: params.sessionId } : {}),
+          ...(params.lane ? { lane: params.lane } : {}),
+          cause: err,
+        });
+        lastError = normalized;
+        await observeFailedCandidate({
+          attempts,
+          candidate,
+          error: normalized,
+          runId: params.runId,
+          sessionId: params.sessionId,
+          lane: params.lane,
+          requestedProvider: params.provider,
+          requestedModel: params.model,
+          attempt: i + 1,
+          total: candidates.length,
+          nextCandidate: target.candidate,
+          isPrimary,
+          requestedModelMatched: requestedModel,
+          fallbackConfigured: hasFallbackCandidates,
+        });
+        await params.onError?.({
+          provider: candidate.provider,
+          model: candidate.model,
+          error: normalized,
+          attempt: i + 1,
+          total: candidates.length,
+        });
+        i = target.index - 1;
+        continue;
       }
       const normalized =
         coerceToFailoverError(err, {
@@ -1157,8 +1342,7 @@ export async function runWithModelFallback<T>(params: {
       }
 
       // Even unrecognized errors should not abort the fallback loop when
-      // there are remaining candidates.  Only abort/context-overflow errors
-      // (handled above) are truly non-retryable.
+      // there are remaining candidates. Only abort errors are truly non-retryable.
       const isKnownFailover = isFailoverError(normalized);
       if (!isKnownFailover && i === candidates.length - 1) {
         throw err;

--- a/src/agents/pi-embedded-helpers/types.ts
+++ b/src/agents/pi-embedded-helpers/types.ts
@@ -9,6 +9,7 @@ export type FailoverReason =
   | "billing"
   | "server_error"
   | "timeout"
+  | "context_overflow"
   | "model_not_found"
   | "session_expired"
   | "empty_response"

--- a/src/agents/pi-embedded-runner/result-fallback-classifier.ts
+++ b/src/agents/pi-embedded-runner/result-fallback-classifier.ts
@@ -89,6 +89,20 @@ export function classifyEmbeddedPiRunResultForModelFallback(params: {
     return harnessClassification;
   }
 
+  const errorKind = params.result.meta.error?.kind;
+  if (errorKind === "context_overflow" || errorKind === "compaction_failure") {
+    const message =
+      params.result.meta.error?.message?.trim() ||
+      `${params.provider}/${params.model} exhausted context overflow recovery`;
+    return {
+      message,
+      reason: "context_overflow",
+      status: 413,
+      code: errorKind,
+      rawError: message,
+    };
+  }
+
   const payloads = params.result.payloads ?? [];
   const errorText = payloads
     .filter((payload) => payload?.isError === true)

--- a/src/agents/pi-embedded-runner/run/auth-profile-failure-policy.test.ts
+++ b/src/agents/pi-embedded-runner/run/auth-profile-failure-policy.test.ts
@@ -63,4 +63,12 @@ describe("resolveAuthProfileFailureReason", () => {
       }),
     ).toBeNull();
   });
+
+  it("does not persist context overflow as auth-profile health", () => {
+    expect(
+      resolveAuthProfileFailureReason({
+        failoverReason: "context_overflow",
+      }),
+    ).toBeNull();
+  });
 });

--- a/src/agents/pi-embedded-runner/run/auth-profile-failure-policy.ts
+++ b/src/agents/pi-embedded-runner/run/auth-profile-failure-policy.ts
@@ -20,7 +20,8 @@ export function resolveAuthProfileFailureReason(params: {
     !params.failoverReason ||
     params.failoverReason === "timeout" ||
     params.failoverReason === "server_error" ||
-    params.failoverReason === "format"
+    params.failoverReason === "format" ||
+    params.failoverReason === "context_overflow"
   ) {
     return null;
   }

--- a/src/agents/runtime-plan/types.ts
+++ b/src/agents/runtime-plan/types.ts
@@ -29,6 +29,7 @@ export type AgentRuntimeFailoverReason =
   | "rate_limit"
   | "overloaded"
   | "billing"
+  | "context_overflow"
   | "server_error"
   | "timeout"
   | "model_not_found"

--- a/src/commands/models/list.probe.ts
+++ b/src/commands/models/list.probe.ts
@@ -127,7 +127,7 @@ export function mapFailoverReasonToProbeStatus(reason?: string | null): AuthProb
   if (reason === "timeout") {
     return "timeout";
   }
-  if (reason === "model_not_found") {
+  if (reason === "model_not_found" || reason === "context_overflow") {
     return "format";
   }
   if (reason === "format") {

--- a/src/gateway/openai-compat-errors.ts
+++ b/src/gateway/openai-compat-errors.ts
@@ -14,6 +14,7 @@ const ERROR_TYPE_BY_REASON: Partial<Record<FailoverReason, string>> = {
   auth: "authentication_error",
   auth_permanent: "permission_error",
   billing: "insufficient_quota",
+  context_overflow: "invalid_request_error",
   format: "invalid_request_error",
   model_not_found: "invalid_request_error",
   overloaded: "api_error",

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -69,6 +69,7 @@ const CronFailoverReasonSchema = Type.Union([
   Type.Literal("billing"),
   Type.Literal("server_error"),
   Type.Literal("timeout"),
+  Type.Literal("context_overflow"),
   Type.Literal("model_not_found"),
   Type.Literal("empty_response"),
   Type.Literal("no_error_details"),


### PR DESCRIPTION
## Summary

Fixes #9986 by letting model fallback handle exhausted context overflow when a later configured fallback has a known larger effective context window.

- classifies thrown and embedded context overflow as `context_overflow` failover only after inner compaction/truncation recovery has already failed
- skips fallback candidates whose known context window is not larger, or cannot fit an observed overflow token count
- preserves blocked embedded context-overflow results when no larger fallback is known, and avoids replaying results with outbound delivery evidence
- documents the new fallback behavior and adds the changelog entry

## Reproduction

Pre-fix Blacksmith Testbox on `main` reproduced the bug:

- provider: `blacksmith-testbox`
- Testbox: `tbx_01krsaad8zqdqg0c25hp19r466`
- Actions run: https://github.com/openclaw/openclaw/actions/runs/25973139876
- repro command simulated `anthropic/claude-opus-4-5` raising `INVALID_ARGUMENT: input exceeds the maximum number of tokens`, with `moonshot/kimi-k2.5` configured as a larger fallback
- observed result: `REPRO_FAILURE {"calls":["anthropic/claude-opus-4-5"],"error":"INVALID_ARGUMENT: input exceeds the maximum number of tokens"}`

That showed the overflow was rethrown before the larger fallback was attempted.

## Verification

- `node scripts/run-vitest.mjs src/agents/model-fallback.test.ts src/agents/failover-error.test.ts src/agents/outcome-fallback-runtime-contract.test.ts src/agents/pi-embedded-runner/run/auth-profile-failure-policy.test.ts src/agents/runtime-plan/types.compat.test.ts`
  - passed: 7 files, 213 tests
- Blacksmith Testbox post-fix repro:
  - provider: `blacksmith-testbox`
  - Testbox: `tbx_01krsce172jrcg0h2t8yjpfw7n`
  - Actions run: https://github.com/openclaw/openclaw/actions/runs/25973901488
  - observed result: `POSTFIX_OK`, calls `anthropic/claude-opus-4-5` then `moonshot/kimi-k2.5`, first attempt recorded `reason=context_overflow`, `status=413`, `code=context_overflow`
- Blacksmith Testbox changed gate:
  - provider: `blacksmith-testbox`
  - Testbox: `tbx_01krscg006rkn1nzejmvzng4wt`
  - Actions run: https://github.com/openclaw/openclaw/actions/runs/25973923155
  - command: `pnpm check:changed`
  - passed

## Real behavior proof

Behavior addressed: context overflow that escapes active-model recovery now advances to the next configured larger-context fallback model instead of rethrowing immediately.

Real environment tested: Blacksmith Testbox through Crabbox on the OpenClaw CI check workflow.

Exact steps or command run after this patch: simulated `runWithModelFallback` with primary `anthropic/claude-opus-4-5` configured at 200k context and fallback `moonshot/kimi-k2.5` configured at 256k context, with the primary throwing `INVALID_ARGUMENT: input exceeds the maximum number of tokens`.

Evidence after fix: Testbox `tbx_01krsce172jrcg0h2t8yjpfw7n`, Actions run https://github.com/openclaw/openclaw/actions/runs/25973901488, printed `POSTFIX_OK` with calls `anthropic/claude-opus-4-5` then `moonshot/kimi-k2.5`.

Observed result after fix: the primary attempt was recorded as `context_overflow` with status 413 and the fallback returned `fallback-ok` from `moonshot/kimi-k2.5`.

What was not tested: live provider credentials were not used; the end-to-end proof uses the model fallback runtime with deterministic provider simulation inside Testbox.