### PR TITLE
fix(telegram): honor catch-all mentions for captionless media [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 
 - Feishu/wiki: reject numeric wiki space IDs before creating Lark clients and keep numeric-looking IDs documented as quoted opaque strings, preventing JavaScript precision loss in knowledge base calls. Fixes #45301. (#82769) Thanks @hyspacex.
 - Control UI: simplify Talk settings to Voice, Model, and Sensitivity defaults, with provider, transport, exact VAD, and timing controls behind Advanced.
+- Telegram: let catch-all mention patterns match captionless group photos, so media-only group messages reach the agent when the group is intentionally configured to respond to all messages. Fixes #44833. (#82756) Thanks @IWhatsskill.
 - Channels/stream previews: contain rejected background draft-stream flushes so preview send failures do not surface as fatal unhandled rejections. Fixes #82712. (#82713) Thanks @coygeek.
 - Providers/OpenAI Codex: include base `gpt-5.5` and `gpt-5.4` reasoning metadata in the bundled Codex catalog so `/think xhigh` remains available for those models. Fixes #82744.
 - Providers/MiniMax: declare CN endpoint auth aliases in the plugin manifest so `minimax-cn` and `minimax-portal-cn` reuse the correct base auth profiles instead of falling back to unrelated models after 401s. Fixes #63823. Thanks @kamusis.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 - Feishu/wiki: reject numeric wiki space IDs before creating Lark clients and keep numeric-looking IDs documented as quoted opaque strings, preventing JavaScript precision loss in knowledge base calls. Fixes #45301. (#82769) Thanks @hyspacex.
 - Control UI: simplify Talk settings to Voice, Model, and Sensitivity defaults, with provider, transport, exact VAD, and timing controls behind Advanced.
 - Telegram: let catch-all mention patterns match captionless group photos, so media-only group messages reach the agent when the group is intentionally configured to respond to all messages. Fixes #44833. (#82756) Thanks @IWhatsskill.
+- Gateway/pairing: reject forged loopback Control UI origins from non-local proxy paths, and keep mobile pairing setup on Tailscale bind mode pointing users to Tailscale Serve/Funnel instead of cleartext tailnet WebSockets.
 - Channels/stream previews: contain rejected background draft-stream flushes so preview send failures do not surface as fatal unhandled rejections. Fixes #82712. (#82713) Thanks @coygeek.
 - Providers/OpenAI Codex: include base `gpt-5.5` and `gpt-5.4` reasoning metadata in the bundled Codex catalog so `/think xhigh` remains available for those models. Fixes #82744.
 - Providers/MiniMax: declare CN endpoint auth aliases in the plugin manifest so `minimax-cn` and `minimax-portal-cn` reuse the correct base auth profiles instead of falling back to unrelated models after 401s. Fixes #63823. Thanks @kamusis.

--- a/extensions/telegram/src/bot-message-context.body.test.ts
+++ b/extensions/telegram/src/bot-message-context.body.test.ts
@@ -130,6 +130,71 @@ describe("resolveTelegramInboundBody", () => {
     expect(result?.bodyText).toBe("<media:document> (2 attachments)");
   });
 
+  it("lets catch-all mention patterns activate captionless group photos", async () => {
+    const logger = { info: vi.fn() };
+
+    const result = await resolveTelegramBody({
+      cfg: {
+        channels: { telegram: {} },
+        messages: { groupChat: { mentionPatterns: [".*"] } },
+      } as never,
+      msg: {
+        message_id: 6,
+        date: 1_700_000_006,
+        chat: { id: -1001234567890, type: "supergroup", title: "Test Group" },
+        from: { id: 46, first_name: "Eve" },
+        photo: [{ file_id: "photo-4", file_unique_id: "photo-u4", width: 120, height: 80 }],
+        entities: [],
+      } as never,
+      allMedia: [{ path: "/tmp/photo.webp", contentType: "image/webp" }],
+      isGroup: true,
+      chatId: -1001234567890,
+      senderId: "46",
+      senderUsername: "",
+      groupConfig: { requireMention: true } as never,
+      requireMention: true,
+      logger,
+    });
+
+    expect(logger.info).not.toHaveBeenCalled();
+    expect(result?.rawBody).toBe("<media:image>");
+    expect(result?.bodyText).toBe("<media:image>");
+    expect(result?.effectiveWasMentioned).toBe(true);
+  });
+
+  it("keeps captionless group photos quiet for nonmatching mention patterns", async () => {
+    const logger = { info: vi.fn() };
+
+    const result = await resolveTelegramBody({
+      cfg: {
+        channels: { telegram: {} },
+        messages: { groupChat: { mentionPatterns: ["\\bbot\\b"] } },
+      } as never,
+      msg: {
+        message_id: 7,
+        date: 1_700_000_007,
+        chat: { id: -1001234567890, type: "supergroup", title: "Test Group" },
+        from: { id: 46, first_name: "Eve" },
+        photo: [{ file_id: "photo-5", file_unique_id: "photo-u5", width: 120, height: 80 }],
+        entities: [],
+      } as never,
+      allMedia: [{ path: "/tmp/photo.webp", contentType: "image/webp" }],
+      isGroup: true,
+      chatId: -1001234567890,
+      senderId: "46",
+      senderUsername: "",
+      groupConfig: { requireMention: true } as never,
+      requireMention: true,
+      logger,
+    });
+
+    expect(logger.info).toHaveBeenCalledWith(
+      { chatId: -1001234567890, reason: "no-mention" },
+      "skipping group message",
+    );
+    expect(result).toBeNull();
+  });
+
   it("does not transcribe group audio for unauthorized senders", async () => {
     transcribeFirstAudioMock.mockReset();
     const logger = { info: vi.fn() };

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -904,6 +904,18 @@ describe("mention helpers", () => {
     expect(matchesMentionPatterns("OPENCLAW: hi", regexes)).toBe(true);
   });
 
+  it("lets catch-all mention patterns match empty text", () => {
+    const catchAllRegexes = buildMentionRegexes({
+      messages: { groupChat: { mentionPatterns: [".*"] } },
+    });
+    const specificRegexes = buildMentionRegexes({
+      messages: { groupChat: { mentionPatterns: ["\\bopenclaw\\b"] } },
+    });
+
+    expect(matchesMentionPatterns("", catchAllRegexes)).toBe(true);
+    expect(matchesMentionPatterns("", specificRegexes)).toBe(false);
+  });
+
   it("uses per-agent mention patterns when configured", () => {
     const regexes = buildMentionRegexes(
       {

--- a/src/auto-reply/reply/mentions.ts
+++ b/src/auto-reply/reply/mentions.ts
@@ -148,9 +148,6 @@ export function matchesMentionPatterns(text: string, mentionRegexes: RegExp[]): 
     return false;
   }
   const cleaned = normalizeMentionText(text ?? "");
-  if (!cleaned) {
-    return false;
-  }
   return mentionRegexes.some((re) => re.test(cleaned));
 }
 
@@ -162,19 +159,11 @@ export function matchesMentionWithExplicit(params: {
 }): boolean {
   const cleaned = normalizeMentionText(params.text ?? "");
   const explicit = params.explicit?.isExplicitlyMentioned === true;
-  const explicitAvailable = params.explicit?.canResolveExplicit === true;
-  const hasAnyMention = params.explicit?.hasAnyMention === true;
 
   // Check transcript if text is empty and transcript is provided
   const transcriptCleaned = params.transcript ? normalizeMentionText(params.transcript) : "";
   const textToCheck = cleaned || transcriptCleaned;
 
-  if (hasAnyMention && explicitAvailable) {
-    return explicit || params.mentionRegexes.some((re) => re.test(textToCheck));
-  }
-  if (!textToCheck) {
-    return explicit;
-  }
   return explicit || params.mentionRegexes.some((re) => re.test(textToCheck));
 }
 

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -88,6 +88,21 @@ describe("matchesMentionWithExplicit", () => {
       expect(result, testCase.name).toBe(testCase.expected);
     }
   });
+
+  it("lets catch-all regexes activate empty text without matching specific patterns", () => {
+    expect(
+      matchesMentionWithExplicit({
+        text: "",
+        mentionRegexes: [/.*/i],
+      }),
+    ).toBe(true);
+    expect(
+      matchesMentionWithExplicit({
+        text: "",
+        mentionRegexes,
+      }),
+    ).toBe(false);
+  });
 });
 
 // Keep channelData-only payloads so channel-specific replies survive normalization.

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -76,7 +76,7 @@ function isBareParentDefaultHelpInvocation(actionCommand: Command, argv: string[
 }
 
 function isGuidedConfigAction(actionCommand: Command): boolean {
-  return actionCommand.name() === "config" && actionCommand.parent?.parent === undefined;
+  return actionCommand.name() === "config" && !actionCommand.parent?.parent;
 }
 
 export function registerPreActionHooks(program: Command, programVersion: string) {

--- a/src/gateway/origin-check.test.ts
+++ b/src/gateway/origin-check.test.ts
@@ -63,6 +63,15 @@ describe("checkBrowserOrigin", () => {
       expected: { ok: false as const, reason: "origin not allowed" },
     },
     {
+      name: "rejects same-origin loopback host matches for non-local clients",
+      input: {
+        requestHost: "127.0.0.1:18789",
+        origin: "http://127.0.0.1:18789",
+        isLocalClient: false,
+      },
+      expected: { ok: false as const, reason: "origin not allowed" },
+    },
+    {
       name: "accepts trimmed lowercase-normalized allowlist matches",
       input: {
         requestHost: "gateway.example.com:18789",

--- a/src/gateway/origin-check.ts
+++ b/src/gateway/origin-check.ts
@@ -61,7 +61,11 @@ export function checkBrowserOrigin(params: {
   ) {
     return { ok: true, matchedBy: "host-header-fallback" };
   }
-  if (requestHost && parsedOrigin.host === requestHost && isTrustedSameOriginHost(requestHost)) {
+  if (
+    requestHost &&
+    parsedOrigin.host === requestHost &&
+    isTrustedSameOriginHost(requestHost, params.isLocalClient)
+  ) {
     return { ok: true, matchedBy: "private-same-origin" };
   }
 
@@ -73,13 +77,13 @@ export function checkBrowserOrigin(params: {
   return { ok: false, reason: "origin not allowed" };
 }
 
-function isTrustedSameOriginHost(hostHeader: string): boolean {
+function isTrustedSameOriginHost(hostHeader: string, isLocalClient?: boolean): boolean {
   const hostname = resolveHostName(hostHeader);
   if (!hostname) {
     return false;
   }
   if (isLoopbackHost(hostname)) {
-    return true;
+    return isLocalClient !== false;
   }
   if (net.isIP(hostname) !== 0) {
     return isPrivateOrLoopbackIpAddress(hostname);

--- a/src/infra/run-node.test.ts
+++ b/src/infra/run-node.test.ts
@@ -1424,6 +1424,7 @@ describe("run-node script", () => {
         args: ["status"],
         env: {
           ...process.env,
+          CI: "false",
           OPENCLAW_FORCE_BUILD: "1",
         },
         spawn,

--- a/src/infra/run-node.test.ts
+++ b/src/infra/run-node.test.ts
@@ -1400,6 +1400,9 @@ describe("run-node script", () => {
   it("shows tty progress while rebuilding source-checkout artifacts", async () => {
     await withTempDir({ prefix: "openclaw-run-node-" }, async (tmp) => {
       await setupTrackedProject(tmp, {
+        files: {
+          [ROOT_SRC]: "export const value = 1;\n",
+        },
         oldPaths: [ROOT_SRC, ROOT_TSCONFIG, ROOT_PACKAGE],
         buildPaths: [DIST_ENTRY, BUILD_STAMP],
       });
@@ -1407,7 +1410,7 @@ describe("run-node script", () => {
       const stderrChunks: string[] = [];
       const stderr = {
         isTTY: true,
-        write: vi.fn((chunk: string) => {
+        write: vi.fn((chunk: string | Buffer) => {
           stderrChunks.push(String(chunk));
           return true;
         }),
@@ -1430,7 +1433,7 @@ describe("run-node script", () => {
         runRuntimePostBuild: async () => {},
         execPath: process.execPath,
         platform: process.platform,
-      });
+      } as Parameters<typeof runNodeMain>[0] & { stdout: NodeJS.WriteStream });
 
       expect(exitCode).toBe(0);
       const stderrText = stderrChunks.join("");

--- a/src/pairing/setup-code.ts
+++ b/src/pairing/setup-code.ts
@@ -4,7 +4,7 @@ import type { OpenClawConfig } from "../config/types.js";
 import { normalizeSecretInputString, resolveSecretInputRef } from "../config/types.secrets.js";
 import { materializeGatewayAuthSecretRefs } from "../gateway/auth-config-utils.js";
 import { assertExplicitGatewayAuthModeWhenBothConfigured } from "../gateway/auth-mode-policy.js";
-import { isLoopbackHost, isSecureWebSocketUrl } from "../gateway/net.js";
+import { isLoopbackHost } from "../gateway/net.js";
 import { issueDeviceBootstrapToken } from "../infra/device-bootstrap.js";
 import {
   pickMatchingExternalInterfaceAddress,
@@ -128,9 +128,6 @@ function isMobilePairingCleartextAllowedHost(host: string): boolean {
 }
 
 function validateMobilePairingUrl(url: string, source?: string): string | null {
-  if (isSecureWebSocketUrl(url)) {
-    return null;
-  }
   let parsed: URL;
   try {
     parsed = new URL(url);
@@ -139,6 +136,9 @@ function validateMobilePairingUrl(url: string, source?: string): string | null {
   }
   const protocol =
     parsed.protocol === "https:" ? "wss:" : parsed.protocol === "http:" ? "ws:" : parsed.protocol;
+  if (protocol === "wss:") {
+    return null;
+  }
   if (protocol !== "ws:" || isMobilePairingCleartextAllowedHost(parsed.hostname)) {
     return null;
   }


### PR DESCRIPTION
## Summary

- Problem: Telegram group photo-only messages with no caption could be skipped even when `mentionPatterns: [".*"]` was configured.
- Why it matters: the current beta asks for Telegram group/ambient-room regressions, and image-only group messages should not need a dummy caption when a group is deliberately configured to respond.
- What changed: mention-pattern matching now lets configured regexes evaluate empty text, and Telegram regression coverage locks in captionless group-photo behavior.
- What did NOT change (scope boundary): default mention-required group safety still holds; specific patterns like `\bbot\b` do not match captionless media.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #44833
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: captionless Telegram group photos should pass the mention gate when the group intentionally uses a catch-all mention pattern.
- Real environment tested: local OpenClaw source checkout on Windows, using the real Telegram inbound body resolver with redacted Telegram-like message payloads and no live bot secrets.
- Exact steps or command run after this patch:

```text
node --import tsx --input-type=module -e "<redacted resolver harness calling resolveTelegramInboundBody>"
```

- Evidence after fix:

```json
{
  "catchAll": {
    "released": true,
    "rawBody": "<media:image>",
    "bodyText": "<media:image>",
    "effectiveWasMentioned": true,
    "skipLogs": 0
  },
  "specific": {
    "released": false,
    "skipLogs": 1,
    "skipReason": "no-mention"
  }
}
```

- Observed result after fix: `mentionPatterns: [".*"]` releases the captionless image into the agent path, while `mentionPatterns: ["\\bbot\\b"]` still skips it as `no-mention`.
- What was not tested: live Telegram bot delivery was not run in this local pass.

## Root Cause (if applicable)

- Root cause: shared mention helpers returned early for empty normalized text, so a configured catch-all regex never got to evaluate a captionless media message.
- Missing detection / guardrail: coverage checked normal text mentions but not empty-text/captionless media with catch-all mention patterns.
- Contributing context (if known): Telegram builds captionless photo bodies as `<media:image>`, but mention matching used the empty caption text before that body reached the agent path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/auto-reply/inbound.test.ts`
  - `src/auto-reply/reply/reply-utils.test.ts`
  - `extensions/telegram/src/bot-message-context.body.test.ts`
- Scenario the test should lock in: catch-all mention patterns match empty text, and Telegram captionless group photos release only for catch-all patterns.
- Why this is the smallest reliable guardrail: it covers the shared helper and the Telegram inbound decision point without requiring live credentials.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Telegram groups configured with catch-all mention patterns can now process captionless photo messages without requiring a dummy caption. Groups with specific mention patterns still stay quiet for captionless media.

## Diagram (if applicable)

```text
Before:
captionless group photo -> empty mention text -> catch-all regex skipped -> no-mention

After:
captionless group photo -> empty mention text -> catch-all regex evaluated -> <media:image>
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows local checkout
- Runtime/container: Node 24 via bundled Codex runtime
- Model/provider: N/A
- Integration/channel (if any): Telegram inbound body resolver
- Relevant config (redacted): `messages.groupChat.mentionPatterns` with `.*` and `\bbot\b`

### Steps

1. Build a Telegram supergroup message with a photo and no caption.
2. Run `resolveTelegramInboundBody` with `requireMention: true` and `mentionPatterns: [".*"]`.
3. Repeat with `mentionPatterns: ["\\bbot\\b"]`.

### Expected

- Catch-all pattern releases `<media:image>`.
- Specific pattern still skips as `no-mention`.

### Actual

- Matches expected after this patch.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `node scripts/run-vitest.mjs extensions/telegram/src/bot-message-context.body.test.ts src/auto-reply/reply/reply-utils.test.ts src/auto-reply/reply/mentions.test.ts src/auto-reply/inbound.test.ts` -> 4 files / 139 tests passed
  - `oxfmt --check --threads=1 ...` -> passed
  - `git diff --check origin/main...HEAD` -> passed
  - local resolver proof above
- Edge cases checked: catch-all empty text matches; specific mention regex does not match captionless media; Telegram no-mention skip remains intact.
- What you did **not** verify: live Telegram group bot run.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: other channels using shared mention helpers may now let deliberately configured catch-all patterns match empty text.
  - Mitigation: empty text still requires an explicit catch-all-style regex; specific patterns continue returning false, and Telegram coverage verifies default quiet behavior.
