### PR TITLE
feat(qa-lab): add scenario pack selector

### DIFF
--- a/docs/concepts/personal-agent-benchmark-pack.md
+++ b/docs/concepts/personal-agent-benchmark-pack.md
@@ -25,19 +25,19 @@ The first pack is intentionally narrow:
 ## Scenarios
 
 The machine-readable pack metadata lives in
-`extensions/qa-lab/src/scenario-packs.ts`. The initial pack does not add a CLI
-pack selector, so run the scenarios explicitly:
+`extensions/qa-lab/src/scenario-packs.ts`. Run the pack with
+`--pack personal-agent`:
 
 ```bash
 OPENCLAW_ENABLE_PRIVATE_QA_CLI=1 pnpm openclaw qa suite \
   --provider-mode mock-openai \
-  --scenario personal-reminder-roundtrip \
-  --scenario personal-channel-thread-reply \
-  --scenario personal-memory-preference-recall \
-  --scenario personal-redaction-no-secret-leak \
-  --scenario personal-tool-safety-followthrough \
+  --pack personal-agent \
   --concurrency 1
 ```
+
+`--pack` is additive with repeated `--scenario` flags. Explicit scenarios run
+first, then the pack scenarios run in `QA_PERSONAL_AGENT_SCENARIO_IDS` order with
+duplicates removed.
 
 The pack is designed for `qa-channel` with `mock-openai` or another local QA
 provider lane. It should not be pointed at live chat services or real personal

--- a/docs/concepts/qa-e2e-automation.md
+++ b/docs/concepts/qa-e2e-automation.md
@@ -231,6 +231,9 @@ Host and Multipass suite runs execute multiple selected scenarios in parallel
 with isolated gateway workers by default. `qa-channel` defaults to concurrency
 4, capped by the selected scenario count. Use `--concurrency <count>` to tune
 the worker count, or `--concurrency 1` for serial execution.
+Use `--pack personal-agent` to run the personal assistant benchmark pack. The
+pack selector is additive with repeated `--scenario` flags: explicit scenarios
+run first, then pack scenarios run in pack order with duplicates removed.
 The command exits non-zero when any scenario fails. Use `--allow-failures` when
 you want artifacts without a failing exit code.
 Live runs forward the supported QA auth inputs that are practical for the

--- a/extensions/qa-lab/src/cli.runtime.test.ts
+++ b/extensions/qa-lab/src/cli.runtime.test.ts
@@ -761,6 +761,35 @@ describe("qa cli runtime", () => {
     });
   });
 
+  it("expands the personal-agent pack onto the suite scenario list", async () => {
+    await runQaSuiteCommand({
+      repoRoot: "/tmp/openclaw-repo",
+      pack: "personal-agent",
+      scenarioIds: ["channel-chat-baseline"],
+    });
+
+    expectFields(mockFirstObjectArg(runQaSuiteFromRuntime), {
+      repoRoot: path.resolve("/tmp/openclaw-repo"),
+      scenarioIds: [
+        "channel-chat-baseline",
+        "personal-reminder-roundtrip",
+        "personal-channel-thread-reply",
+        "personal-memory-preference-recall",
+        "personal-redaction-no-secret-leak",
+        "personal-tool-safety-followthrough",
+      ],
+    });
+  });
+
+  it("rejects unknown suite packs", async () => {
+    await expect(
+      runQaSuiteCommand({
+        repoRoot: "/tmp/openclaw-repo",
+        pack: "personal-admin",
+      }),
+    ).rejects.toThrow('--pack must be one of personal-agent, got "personal-admin"');
+  });
+
   it("rejects unknown suite CLI auth modes", async () => {
     await expect(
       runQaSuiteCommand({

--- a/extensions/qa-lab/src/cli.runtime.ts
+++ b/extensions/qa-lab/src/cli.runtime.ts
@@ -43,6 +43,7 @@ import {
 } from "./run-config.js";
 import type { RuntimeId } from "./runtime-parity.js";
 import { readQaScenarioPack } from "./scenario-catalog.js";
+import { resolveQaScenarioPackScenarioIds } from "./scenario-packs.js";
 import { runQaSuiteFromRuntime } from "./suite-launch.runtime.js";
 import { readQaSuiteFailedScenarioCountFromSummary } from "./suite-summary.js";
 
@@ -496,6 +497,7 @@ export async function runQaSuiteCommand(opts: {
   thinking?: string;
   cliAuthMode?: string;
   parityPack?: string;
+  pack?: string;
   scenarioIds?: string[];
   concurrency?: number;
   allowFailures?: boolean;
@@ -510,9 +512,12 @@ export async function runQaSuiteCommand(opts: {
   const repoRoot = path.resolve(opts.repoRoot ?? process.cwd());
   const transportId = normalizeQaTransportId(opts.transportId);
   const runner = (opts.runner ?? "host").trim().toLowerCase();
-  const scenarioIds = resolveQaParityPackScenarioIds({
-    parityPack: opts.parityPack,
-    scenarioIds: opts.scenarioIds,
+  const scenarioIds = resolveQaScenarioPackScenarioIds({
+    pack: opts.pack,
+    scenarioIds: resolveQaParityPackScenarioIds({
+      parityPack: opts.parityPack,
+      scenarioIds: opts.scenarioIds,
+    }),
   });
   const allowFailures = opts.allowFailures === true;
   if (runner !== "host" && runner !== "multipass") {

--- a/extensions/qa-lab/src/cli.test.ts
+++ b/extensions/qa-lab/src/cli.test.ts
@@ -537,6 +537,13 @@ describe("qa cli registration", () => {
     expect(options.allowFailures).toBe(true);
   });
 
+  it("forwards --pack for suite runs", async () => {
+    await program.parseAsync(["node", "openclaw", "qa", "suite", "--pack", "personal-agent"]);
+
+    const options = requireQaSuiteOptions();
+    expect(options.pack).toBe("personal-agent");
+  });
+
   it("routes credential add flags into the qa runtime command", async () => {
     await program.parseAsync([
       "node",

--- a/extensions/qa-lab/src/cli.ts
+++ b/extensions/qa-lab/src/cli.ts
@@ -253,6 +253,7 @@ export function registerQaLabCli(program: Command) {
       "CLI backend auth mode for live Claude CLI runs: auto, api-key, or subscription",
     )
     .option("--parity-pack <name>", 'Preset scenario pack; currently only "agentic" is supported')
+    .option("--pack <id>", 'Scenario pack id; currently only "personal-agent" is supported')
     .option("--scenario <id>", "Run only the named QA scenario (repeatable)", collectString, [])
     .option(
       "--enable-plugin <id>",
@@ -290,6 +291,7 @@ export function registerQaLabCli(program: Command) {
         altModel?: string;
         cliAuthMode?: string;
         parityPack?: string;
+        pack?: string;
         scenario?: string[];
         enablePlugin?: string[];
         concurrency?: number;
@@ -315,6 +317,7 @@ export function registerQaLabCli(program: Command) {
           thinking: opts.thinking,
           cliAuthMode: opts.cliAuthMode,
           parityPack: opts.parityPack,
+          pack: opts.pack,
           scenarioIds: opts.scenario,
           enabledPluginIds: opts.enablePlugin,
           concurrency: opts.concurrency,

--- a/extensions/qa-lab/src/cli.ts
+++ b/extensions/qa-lab/src/cli.ts
@@ -41,6 +41,7 @@ async function runQaSuite(opts: {
   enabledPluginIds?: string[];
   cliAuthMode?: string;
   parityPack?: string;
+  pack?: string;
   scenarioIds?: string[];
   concurrency?: number;
   runner?: string;

--- a/extensions/qa-lab/src/scenario-catalog.ts
+++ b/extensions/qa-lab/src/scenario-catalog.ts
@@ -227,6 +227,7 @@ export type QaBootstrapScenarioCatalog = {
 export {
   QA_PERSONAL_AGENT_SCENARIO_IDS,
   QA_SCENARIO_PACKS,
+  resolveQaScenarioPackScenarioIds,
   type QaScenarioPackDefinition,
 } from "./scenario-packs.js";
 

--- a/extensions/qa-lab/src/scenario-packs.test.ts
+++ b/extensions/qa-lab/src/scenario-packs.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { QA_SCENARIO_PACKS, readQaScenarioById } from "./scenario-catalog.js";
+import {
+  QA_PERSONAL_AGENT_SCENARIO_IDS,
+  QA_SCENARIO_PACKS,
+  readQaScenarioById,
+  resolveQaScenarioPackScenarioIds,
+} from "./scenario-catalog.js";
 
 describe("qa scenario packs", () => {
   it("points every pack scenario id at a loadable markdown scenario", () => {
@@ -39,6 +44,27 @@ describe("qa scenario packs", () => {
       expect(scenario.sourcePath).toMatch(/^qa\/scenarios\/personal\//);
       expect(scenario.coverage?.primary.some((id) => id.startsWith("personal."))).toBe(true);
     }
+  });
+
+  it("expands the personal-agent pack in pack order", () => {
+    expect(resolveQaScenarioPackScenarioIds({ pack: "personal-agent" })).toEqual([
+      ...QA_PERSONAL_AGENT_SCENARIO_IDS,
+    ]);
+  });
+
+  it("combines explicit scenarios with pack scenarios", () => {
+    expect(
+      resolveQaScenarioPackScenarioIds({
+        pack: "personal-agent",
+        scenarioIds: ["channel-chat-baseline", "personal-reminder-roundtrip"],
+      }),
+    ).toEqual(["channel-chat-baseline", ...QA_PERSONAL_AGENT_SCENARIO_IDS]);
+  });
+
+  it("rejects unknown scenario packs", () => {
+    expect(() => resolveQaScenarioPackScenarioIds({ pack: "personal-admin" })).toThrow(
+      '--pack must be one of personal-agent, got "personal-admin"',
+    );
   });
 
   it("keeps personal pack mock debug assertions scoped to each reviewed scenario", () => {

--- a/extensions/qa-lab/src/scenario-packs.ts
+++ b/extensions/qa-lab/src/scenario-packs.ts
@@ -22,3 +22,21 @@ export const QA_SCENARIO_PACKS = [
     scenarioIds: QA_PERSONAL_AGENT_SCENARIO_IDS,
   },
 ] as const satisfies readonly QaScenarioPackDefinition[];
+
+export function resolveQaScenarioPackScenarioIds(params: {
+  pack?: string;
+  scenarioIds?: string[];
+}): string[] {
+  const normalizedPack = params.pack?.trim().toLowerCase();
+  const explicitScenarioIds = [...new Set(params.scenarioIds ?? [])];
+  if (!normalizedPack) {
+    return explicitScenarioIds;
+  }
+  const pack = QA_SCENARIO_PACKS.find((candidate) => candidate.id === normalizedPack);
+  if (!pack) {
+    throw new Error(
+      `--pack must be one of ${QA_SCENARIO_PACKS.map((candidate) => candidate.id).join(", ")}, got "${params.pack}"`,
+    );
+  }
+  return [...new Set([...explicitScenarioIds, ...pack.scenarioIds])];
+}

--- a/extensions/qa-lab/src/suite-planning.test.ts
+++ b/extensions/qa-lab/src/suite-planning.test.ts
@@ -189,6 +189,23 @@ describe("qa suite planning helpers", () => {
     ).toEqual(["anthropic-only"]);
   });
 
+  it("keeps explicitly requested scenarios in request order", () => {
+    const scenarios = [
+      makeQaSuiteTestScenario("first"),
+      makeQaSuiteTestScenario("second"),
+      makeQaSuiteTestScenario("third"),
+    ];
+
+    expect(
+      selectQaSuiteScenarios({
+        scenarios,
+        scenarioIds: ["third", "first"],
+        providerMode: "live-frontier",
+        primaryModel: "openai/gpt-5.5",
+      }).map((scenario) => scenario.id),
+    ).toEqual(["third", "first"]);
+  });
+
   it("collects unique scenario-declared bundled plugins in encounter order", () => {
     const scenarios = [
       makeQaSuiteTestScenario("generic", { plugins: ["active-memory", "memory-wiki"] }),

--- a/extensions/qa-lab/src/suite-planning.ts
+++ b/extensions/qa-lab/src/suite-planning.ts
@@ -66,20 +66,17 @@ function selectQaSuiteScenarios(params: {
 }) {
   const requestedScenarioIds =
     params.scenarioIds && params.scenarioIds.length > 0 ? new Set(params.scenarioIds) : null;
-  const requestedScenarios = requestedScenarioIds
-    ? params.scenarios.filter((scenario) => requestedScenarioIds.has(scenario.id))
-    : params.scenarios;
   if (requestedScenarioIds) {
-    const foundScenarioIds = new Set(requestedScenarios.map((scenario) => scenario.id));
+    const scenarioById = new Map(params.scenarios.map((scenario) => [scenario.id, scenario]));
     const missingScenarioIds = [...requestedScenarioIds].filter(
-      (scenarioId) => !foundScenarioIds.has(scenarioId),
+      (scenarioId) => !scenarioById.has(scenarioId),
     );
     if (missingScenarioIds.length > 0) {
       throw new Error(`unknown QA scenario id(s): ${missingScenarioIds.join(", ")}`);
     }
-    return requestedScenarios;
+    return [...requestedScenarioIds].map((scenarioId) => scenarioById.get(scenarioId)!);
   }
-  return requestedScenarios.filter((scenario) =>
+  return params.scenarios.filter((scenario) =>
     scenarioMatchesLiveLane({
       scenario,
       providerMode: params.providerMode,


### PR DESCRIPTION
## Summary

Adds `--pack personal-agent` to `openclaw qa suite`.

This is a focused follow-up to the Personal Agent Benchmark Pack that landed in:
- PR: https://github.com/openclaw/openclaw/pull/78219
- commit: https://github.com/openclaw/openclaw/commit/440333125c4c8a896d18c08d8d09bb5a8e015b29

That pack already has repo-backed metadata in `QA_SCENARIO_PACKS`. This PR only wires that metadata into the suite CLI, so the accepted pack can be run without spelling out each scenario id.

```bash
OPENCLAW_ENABLE_PRIVATE_QA_CLI=1 pnpm openclaw qa suite \
  --provider-mode mock-openai \
  --pack personal-agent \
  --concurrency 1
```

## What changed

- adds `--pack <id>` for `qa suite`
- expands `personal-agent` through the existing `QA_SCENARIO_PACKS` metadata
- preserves the pack scenario order from `QA_PERSONAL_AGENT_SCENARIO_IDS`
- keeps repeated `--scenario` additive with `--pack`
- rejects unknown pack ids with a clear error
- updates the personal-agent docs to use the selector

No new scenarios, runner, dependency, live transport, or model judge in this PR.

## Why

The first pack intentionally kept execution explicit. Now that the pack has landed, the selector makes it easier for maintainers to run the accepted personal-agent coverage as one unit while keeping the implementation small.

It also gives future packs the same CLI path without adding a separate runner.

## Real behavior proof

**Behavior addressed:** The accepted `personal-agent` scenario pack can now be selected with `--pack personal-agent` instead of listing each scenario id manually.

**Real environment tested:** Local OpenClaw checkout on this branch, running the repo QA suite CLI against the local `qa-channel` lane with the `mock-openai` provider mode.

**Exact steps or command run after the patch:**

```bash
OPENCLAW_ENABLE_PRIVATE_QA_CLI=1 pnpm openclaw qa suite \
  --provider-mode mock-openai \
  --pack personal-agent \
  --concurrency 1
```

**Evidence after fix:** Terminal output from the local run:

```text
$ node scripts/run-node.mjs qa suite --provider-mode mock-openai --pack personal-agent --concurrency 1
QA suite report: .artifacts/qa-e2e/suite-mp8w7w74/qa-suite-report.md
QA suite summary: .artifacts/qa-e2e/suite-mp8w7w74/qa-suite-summary.json
```

The generated summary recorded this selected scenario list:

```text
personal-reminder-roundtrip
personal-channel-thread-reply
personal-memory-preference-recall
personal-redaction-no-secret-leak
personal-tool-safety-followthrough
```

**Observed result after fix:** The suite ran through the new pack selector and all five selected scenarios completed with `pass`: reminder roundtrip, channel/thread reply, memory preference recall, redaction no-secret-leak, and tool safety followthrough.

**What was not tested:** Live chat transports, new scenarios, and release-lane wiring. This PR only adds the suite pack selector for the existing repo-backed pack.

## Verification

```bash
node scripts/run-vitest.mjs \
  extensions/qa-lab/src/scenario-packs.test.ts \
  extensions/qa-lab/src/cli.test.ts \
  extensions/qa-lab/src/cli.runtime.test.ts \
  extensions/qa-lab/src/suite-planning.test.ts
```

Result: 4 files passed, 94 tests passed.

```bash
pnpm tsgo:prod
pnpm check:test-types
pnpm run test:extensions:package-boundary:compile
pnpm run test:extensions:package-boundary:canary
```

Result: all passed.

```bash
git diff --check
```

Result: clean.