### PR TITLE
fix(openai): restore Codex xhigh thinking metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Channels/stream previews: contain rejected background draft-stream flushes so preview send failures do not surface as fatal unhandled rejections. Fixes #82712. (#82713) Thanks @coygeek.
+- Providers/OpenAI Codex: include base `gpt-5.5` and `gpt-5.4` reasoning metadata in the bundled Codex catalog so `/think xhigh` remains available for those models. Fixes #82744.
 - Agents/edit tool: honor `file_path` and related path aliases when resolving edit-recovery targets, so post-write errors no longer surface false edit failures after the file actually changed. Fixes #81909. Thanks @giodl73-repo.
 - QQBot: treat only explicit truthy `QQBOT_DEBUG` values as enabling debug logs, so false-like values such as `0` no longer expose debug output. Fixes #82644. (#82697) Thanks @leno23.
 - Gateway/diagnostics: add opt-in critical memory pressure stability snapshots with gateway logs, V8 heap, cgroup, active-resource, and redacted large session-file evidence. Fixes #82518.

--- a/extensions/openai/openclaw.plugin.json
+++ b/extensions/openai/openclaw.plugin.json
@@ -631,6 +631,36 @@
         "api": "openai-codex-responses",
         "models": [
           {
+            "id": "gpt-5.5",
+            "name": "gpt-5.5",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 400000,
+            "contextTokens": 272000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 5,
+              "output": 30,
+              "cacheRead": 0.5,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "gpt-5.4",
+            "name": "gpt-5.4",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1050000,
+            "contextTokens": 272000,
+            "maxTokens": 128000,
+            "cost": {
+              "input": 2.5,
+              "output": 15,
+              "cacheRead": 0.25,
+              "cacheWrite": 0
+            }
+          },
+          {
             "id": "gpt-5.4-pro",
             "name": "gpt-5.4-pro",
             "reasoning": true,

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -1544,6 +1544,55 @@ describe("handleDirectiveOnly model persist behavior (fixes #1435)", () => {
     expect(sessionEntry.thinkingLevel).toBe("medium");
   });
 
+  it.each([
+    ["openai", "gpt-5.5"],
+    ["openai-codex", "gpt-5.5"],
+  ])("accepts xhigh for %s/%s when catalog marks reasoning support", async (provider, model) => {
+    setDirectiveTestProviders([
+      {
+        id: provider,
+        label: provider,
+        auth: [],
+        resolveThinkingProfile: ({ modelId }) => ({
+          levels:
+            modelId === "gpt-5.5"
+              ? [
+                  { id: "off" },
+                  { id: "minimal" },
+                  { id: "low" },
+                  { id: "medium" },
+                  { id: "high" },
+                  { id: "xhigh" },
+                ]
+              : [{ id: "off" }],
+        }),
+      },
+    ]);
+    const sessionEntry = createSessionEntry();
+    const sessionStore = { [sessionKey]: sessionEntry };
+    const catalogEntry = {
+      provider,
+      id: model,
+      name: model,
+      reasoning: true,
+    };
+
+    const result = await handleDirectiveOnly(
+      createHandleParams({
+        directives: parseInlineDirectives("/think xhigh"),
+        provider,
+        model,
+        allowedModelCatalog: [catalogEntry],
+        thinkingCatalog: [catalogEntry],
+        sessionEntry,
+        sessionStore,
+      }),
+    );
+
+    expect(result?.text).toContain("Thinking level set to xhigh.");
+    expect(sessionEntry.thinkingLevel).toBe("xhigh");
+  });
+
   it("persists verbose on and off directives", async () => {
     const sessionEntry = createSessionEntry();
     const sessionStore = { [sessionKey]: sessionEntry };


### PR DESCRIPTION
## Summary
- add OpenAI Codex catalog rows for base `gpt-5.5` and `gpt-5.4` with reasoning/context/cost metadata
- cover `/think xhigh` directive acceptance for OpenAI and OpenAI Codex `gpt-5.5`
- update changelog for #82744

## Verification
- `node scripts/run-vitest.mjs src/auto-reply/reply/directive-handling.model.test.ts src/auto-reply/thinking.test.ts extensions/openai/openai-codex-provider.test.ts` -> 3 files / 128 tests passed
- `jq empty extensions/openai/openclaw.plugin.json`
- `git diff --check`
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md extensions/openai/openclaw.plugin.json src/auto-reply/reply/directive-handling.model.test.ts`
- Codex review helper -> no actionable correctness issues

## Real behavior proof
Behavior addressed: `/think xhigh` no longer falls through to off-only for OpenAI Codex base GPT-5 models when the official catalog supplies reasoning metadata.
Real environment tested: local OpenClaw source checkout.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/auto-reply/reply/directive-handling.model.test.ts src/auto-reply/thinking.test.ts extensions/openai/openai-codex-provider.test.ts`
Evidence after fix: terminal output from the local OpenClaw source checkout for the command above showed `Test Files 3 passed (3)` and `Tests 128 passed (128)` after the bundled OpenAI Codex manifest gained `gpt-5.5`/`gpt-5.4` rows with `reasoning: true`.
Observed result after fix: directive-handling regression persisted `xhigh` for `openai/gpt-5.5` and `openai-codex/gpt-5.5`; JSON/format/diff checks passed; Codex review found no actionable correctness issues.
What was not tested: live Telegram/ChatGPT OAuth round trip.

Fixes #82744.
