### PR TITLE
fix(feishu): reject numeric wiki space ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Feishu/wiki: reject numeric wiki space IDs before creating Lark clients and keep numeric-looking IDs documented as quoted opaque strings, preventing JavaScript precision loss in knowledge base calls. Fixes #45301. (#82769) Thanks @hyspacex.
 - Channels/stream previews: contain rejected background draft-stream flushes so preview send failures do not surface as fatal unhandled rejections. Fixes #82712. (#82713) Thanks @coygeek.
 - Providers/OpenAI Codex: include base `gpt-5.5` and `gpt-5.4` reasoning metadata in the bundled Codex catalog so `/think xhigh` remains available for those models. Fixes #82744.
 - Providers/MiniMax: declare CN endpoint auth aliases in the plugin manifest so `minimax-cn` and `minimax-portal-cn` reuse the correct base auth profiles instead of falling back to unrelated models after 401s. Fixes #63823. Thanks @kamusis.

--- a/extensions/feishu/skills/feishu-wiki/SKILL.md
+++ b/extensions/feishu/skills/feishu-wiki/SKILL.md
@@ -8,6 +8,8 @@ description: |
 
 Single tool `feishu_wiki` for knowledge base operations.
 
+Wiki `space_id` values are opaque strings. Always keep them quoted in tool calls, even when they contain only digits; passing a long numeric-looking ID as a number can corrupt the suffix due to JavaScript number precision limits.
+
 ## Token Extraction
 
 From URL `https://xxx.feishu.cn/wiki/ABC123def` → `token` = `ABC123def`

--- a/extensions/feishu/src/tool-account-routing.test.ts
+++ b/extensions/feishu/src/tool-account-routing.test.ts
@@ -4,6 +4,14 @@ import { createToolFactoryHarness } from "./tool-factory-test-harness.js";
 
 const createFeishuClientMock = vi.fn((account: { appId?: string } | undefined) => ({
   __appId: account?.appId,
+  wiki: {
+    spaceNode: {
+      list: vi.fn(async () => ({
+        code: 0,
+        data: { items: [] },
+      })),
+    },
+  },
 }));
 
 vi.mock("./client.js", () => ({
@@ -110,6 +118,46 @@ describe("feishu tool account routing", () => {
     await tool.execute("call", { action: "search" });
 
     expect(lastClientAppId()).toBe("app-a");
+  });
+
+  test("wiki tool rejects number-typed space IDs before Lark receives precision-corrupted values", async () => {
+    const { api, resolveTool } = createToolFactoryHarness(
+      createConfig({
+        toolsA: { wiki: true },
+      }),
+    );
+    registerFeishuWikiTools(api);
+
+    const tool = resolveTool("feishu_wiki", { agentAccountId: "a" });
+    const result = await tool.execute("call", {
+      action: "nodes",
+      space_id: 7616123456789015000,
+    });
+
+    expect(createFeishuClientMock).not.toHaveBeenCalled();
+    expect(result.details.error).toContain("space_id must be a string");
+    expect(result.details.error).toContain("precision loss");
+  });
+
+  test("wiki tool forwards quoted numeric-looking space IDs unchanged", async () => {
+    const { api, resolveTool } = createToolFactoryHarness(
+      createConfig({
+        toolsA: { wiki: true },
+      }),
+    );
+    registerFeishuWikiTools(api);
+
+    const tool = resolveTool("feishu_wiki", { agentAccountId: "a" });
+    await tool.execute("call", {
+      action: "nodes",
+      space_id: "7616123456789014828",
+    });
+
+    const client = createFeishuClientMock.mock.results[0]?.value;
+    expect(client.wiki.spaceNode.list).toHaveBeenCalledWith({
+      path: { space_id: "7616123456789014828" },
+      params: { parent_node_token: undefined },
+    });
   });
 
   test("drive tool registers when first account disables it and routes to agentAccountId", async () => {

--- a/extensions/feishu/src/wiki-schema.ts
+++ b/extensions/feishu/src/wiki-schema.ts
@@ -1,12 +1,15 @@
 import { Type, type Static } from "typebox";
 
+const WIKI_SPACE_ID_DESCRIPTION =
+  "Knowledge space ID. Treat as an opaque string and keep it quoted; never pass numeric-looking IDs as numbers.";
+
 export const FeishuWikiSchema = Type.Union([
   Type.Object({
     action: Type.Literal("spaces"),
   }),
   Type.Object({
     action: Type.Literal("nodes"),
-    space_id: Type.String({ description: "Knowledge space ID" }),
+    space_id: Type.String({ description: WIKI_SPACE_ID_DESCRIPTION }),
     parent_node_token: Type.Optional(
       Type.String({ description: "Parent node token (optional, omit for root)" }),
     ),
@@ -18,11 +21,16 @@ export const FeishuWikiSchema = Type.Union([
   Type.Object({
     action: Type.Literal("search"),
     query: Type.String({ description: "Search query" }),
-    space_id: Type.Optional(Type.String({ description: "Limit search to this space (optional)" })),
+    space_id: Type.Optional(
+      Type.String({
+        description:
+          "Limit search to this knowledge space. Treat as an opaque string and keep it quoted; never pass numeric-looking IDs as numbers.",
+      }),
+    ),
   }),
   Type.Object({
     action: Type.Literal("create"),
-    space_id: Type.String({ description: "Knowledge space ID" }),
+    space_id: Type.String({ description: WIKI_SPACE_ID_DESCRIPTION }),
     title: Type.String({ description: "Node title" }),
     obj_type: Type.Optional(
       Type.Union([Type.Literal("docx"), Type.Literal("sheet"), Type.Literal("bitable")], {
@@ -35,10 +43,16 @@ export const FeishuWikiSchema = Type.Union([
   }),
   Type.Object({
     action: Type.Literal("move"),
-    space_id: Type.String({ description: "Source knowledge space ID" }),
+    space_id: Type.String({
+      description:
+        "Source knowledge space ID. Treat as an opaque string and keep it quoted; never pass numeric-looking IDs as numbers.",
+    }),
     node_token: Type.String({ description: "Node token to move" }),
     target_space_id: Type.Optional(
-      Type.String({ description: "Target space ID (optional, same space if omitted)" }),
+      Type.String({
+        description:
+          "Target knowledge space ID (optional, same space if omitted). Treat as an opaque string and keep it quoted; never pass numeric-looking IDs as numbers.",
+      }),
     ),
     target_parent_token: Type.Optional(
       Type.String({ description: "Target parent node token (optional, root if omitted)" }),
@@ -46,7 +60,7 @@ export const FeishuWikiSchema = Type.Union([
   }),
   Type.Object({
     action: Type.Literal("rename"),
-    space_id: Type.String({ description: "Knowledge space ID" }),
+    space_id: Type.String({ description: WIKI_SPACE_ID_DESCRIPTION }),
     node_token: Type.String({ description: "Node token to rename" }),
     title: Type.String({ description: "New title" }),
   }),

--- a/extensions/feishu/src/wiki.ts
+++ b/extensions/feishu/src/wiki.ts
@@ -17,6 +17,49 @@ const WIKI_ACCESS_HINT =
   "To grant wiki access: Open wiki space → Settings → Members → Add the bot. " +
   "See: https://open.feishu.cn/document/server-docs/docs/wiki-v2/wiki-qa#a40ad4ca";
 
+function requireWikiSpaceId(value: unknown, fieldName: string): string {
+  if (typeof value !== "string") {
+    throw new Error(
+      `${fieldName} must be a string. Feishu wiki space IDs are opaque identifiers; pass them quoted to avoid JavaScript number precision loss.`,
+    );
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error(`${fieldName} must not be empty.`);
+  }
+
+  return trimmed;
+}
+
+function optionalWikiSpaceId(value: unknown, fieldName: string): string | undefined {
+  if (value === undefined || value === null || value === "") {
+    return undefined;
+  }
+  return requireWikiSpaceId(value, fieldName);
+}
+
+function validateWikiSpaceIds(params: { action?: unknown } & Record<string, unknown>): {
+  spaceId?: string;
+  targetSpaceId?: string;
+} {
+  switch (params.action) {
+    case "nodes":
+    case "create":
+    case "rename":
+      return { spaceId: requireWikiSpaceId(params.space_id, "space_id") };
+    case "move":
+      return {
+        spaceId: requireWikiSpaceId(params.space_id, "space_id"),
+        targetSpaceId: optionalWikiSpaceId(params.target_space_id, "target_space_id"),
+      };
+    case "search":
+      return { spaceId: optionalWikiSpaceId(params.space_id, "space_id") };
+    default:
+      return {};
+  }
+}
+
 async function listSpaces(client: Lark.Client) {
   const res = await client.wiki.space.list({});
   if (res.code !== 0) {
@@ -180,6 +223,9 @@ export function registerFeishuWikiTools(api: OpenClawPluginApi) {
         async execute(_toolCallId, params) {
           const p = params as FeishuWikiExecuteParams;
           try {
+            const { spaceId, targetSpaceId } = validateWikiSpaceIds(
+              p as { action?: unknown } & Record<string, unknown>,
+            );
             const client = createFeishuToolClient({
               api,
               executeParams: p,
@@ -189,7 +235,7 @@ export function registerFeishuWikiTools(api: OpenClawPluginApi) {
               case "spaces":
                 return jsonToolResult(await listSpaces(client));
               case "nodes":
-                return jsonToolResult(await listNodes(client, p.space_id, p.parent_node_token));
+                return jsonToolResult(await listNodes(client, spaceId!, p.parent_node_token));
               case "get":
                 return jsonToolResult(await getNode(client, p.token));
               case "search":
@@ -199,20 +245,20 @@ export function registerFeishuWikiTools(api: OpenClawPluginApi) {
                 });
               case "create":
                 return jsonToolResult(
-                  await createNode(client, p.space_id, p.title, p.obj_type, p.parent_node_token),
+                  await createNode(client, spaceId!, p.title, p.obj_type, p.parent_node_token),
                 );
               case "move":
                 return jsonToolResult(
                   await moveNode(
                     client,
-                    p.space_id,
+                    spaceId!,
                     p.node_token,
-                    p.target_space_id,
+                    targetSpaceId,
                     p.target_parent_token,
                   ),
                 );
               case "rename":
-                return jsonToolResult(await renameNode(client, p.space_id, p.node_token, p.title));
+                return jsonToolResult(await renameNode(client, spaceId!, p.node_token, p.title));
               default:
                 return unknownToolActionResult((p as { action?: unknown }).action);
             }

--- a/extensions/feishu/src/wiki.ts
+++ b/extensions/feishu/src/wiki.ts
@@ -39,27 +39,6 @@ function optionalWikiSpaceId(value: unknown, fieldName: string): string | undefi
   return requireWikiSpaceId(value, fieldName);
 }
 
-function validateWikiSpaceIds(params: { action?: unknown } & Record<string, unknown>): {
-  spaceId?: string;
-  targetSpaceId?: string;
-} {
-  switch (params.action) {
-    case "nodes":
-    case "create":
-    case "rename":
-      return { spaceId: requireWikiSpaceId(params.space_id, "space_id") };
-    case "move":
-      return {
-        spaceId: requireWikiSpaceId(params.space_id, "space_id"),
-        targetSpaceId: optionalWikiSpaceId(params.target_space_id, "target_space_id"),
-      };
-    case "search":
-      return { spaceId: optionalWikiSpaceId(params.space_id, "space_id") };
-    default:
-      return {};
-  }
-}
-
 async function listSpaces(client: Lark.Client) {
   const res = await client.wiki.space.list({});
   if (res.code !== 0) {
@@ -223,42 +202,60 @@ export function registerFeishuWikiTools(api: OpenClawPluginApi) {
         async execute(_toolCallId, params) {
           const p = params as FeishuWikiExecuteParams;
           try {
-            const { spaceId, targetSpaceId } = validateWikiSpaceIds(
-              p as { action?: unknown } & Record<string, unknown>,
-            );
-            const client = createFeishuToolClient({
-              api,
-              executeParams: p,
-              defaultAccountId,
-            });
+            const createClient = () =>
+              createFeishuToolClient({
+                api,
+                executeParams: p,
+                defaultAccountId,
+              });
             switch (p.action) {
               case "spaces":
-                return jsonToolResult(await listSpaces(client));
-              case "nodes":
-                return jsonToolResult(await listNodes(client, spaceId!, p.parent_node_token));
+                return jsonToolResult(await listSpaces(createClient()));
+              case "nodes": {
+                const spaceId = requireWikiSpaceId(p.space_id, "space_id");
+                return jsonToolResult(
+                  await listNodes(createClient(), spaceId, p.parent_node_token),
+                );
+              }
               case "get":
-                return jsonToolResult(await getNode(client, p.token));
+                return jsonToolResult(await getNode(createClient(), p.token));
               case "search":
+                optionalWikiSpaceId(p.space_id, "space_id");
+                createClient();
                 return jsonToolResult({
                   error:
                     "Search is not available. Use feishu_wiki with action: 'nodes' to browse or action: 'get' to lookup by token.",
                 });
-              case "create":
+              case "create": {
+                const spaceId = requireWikiSpaceId(p.space_id, "space_id");
                 return jsonToolResult(
-                  await createNode(client, spaceId!, p.title, p.obj_type, p.parent_node_token),
+                  await createNode(
+                    createClient(),
+                    spaceId,
+                    p.title,
+                    p.obj_type,
+                    p.parent_node_token,
+                  ),
                 );
-              case "move":
+              }
+              case "move": {
+                const spaceId = requireWikiSpaceId(p.space_id, "space_id");
                 return jsonToolResult(
                   await moveNode(
-                    client,
-                    spaceId!,
+                    createClient(),
+                    spaceId,
                     p.node_token,
-                    targetSpaceId,
+                    optionalWikiSpaceId(p.target_space_id, "target_space_id"),
                     p.target_parent_token,
                   ),
                 );
-              case "rename":
-                return jsonToolResult(await renameNode(client, spaceId!, p.node_token, p.title));
+              }
+              case "rename": {
+                const spaceId = requireWikiSpaceId(p.space_id, "space_id");
+                return jsonToolResult(
+                  await renameNode(createClient(), spaceId, p.node_token, p.title),
+                );
+              }
               default:
                 return unknownToolActionResult((p as { action?: unknown }).action);
             }


### PR DESCRIPTION
## Summary
- reject number-typed Feishu wiki `space_id` and `target_space_id` values before they reach Lark calls
- preserve quoted numeric-looking wiki space IDs unchanged
- strengthen Feishu wiki schema and skill guidance so models keep wiki space IDs as quoted opaque strings

Fixes #45301.

## Real behavior proof
- **Behavior or issue addressed:** Feishu wiki calls no longer forward precision-corrupted numeric `space_id` values. When a numeric-looking wiki space ID is passed as a JavaScript number, the tool rejects it before any Lark client call instead of sending a rounded suffix such as `...5000`.
- **Real environment tested:** Local OpenClaw checkout on macOS, Node v22.22.0, branch `fix/45301-feishu-space-id-strings`, executing the Feishu wiki tool registration and tool `execute` path directly from the patched source.
- **Exact steps or command run after this patch:**
```sh
node --import tsx --input-type=module <<'EOF'
import { registerFeishuWikiTools } from "./extensions/feishu/src/wiki.ts";

const registered = [];
const api = {
  config: {
    channels: {
      feishu: {
        enabled: true,
        accounts: {
          a: {
            appId: "app-a",
            appSecret: "redacted",
            tools: { wiki: true },
          },
        },
      },
    },
  },
  logger: { info() {}, warn() {}, error() {}, debug() {} },
  registerTool(tool, opts) {
    registered.push({ tool, opts });
  },
};

registerFeishuWikiTools(api);
const entry = registered.find((item) => item.opts?.name === "feishu_wiki");
const built = entry.tool({ agentAccountId: "a" });
const tool = Array.isArray(built) ? built.find((candidate) => candidate.name === "feishu_wiki") : built;

const result = await tool.execute("proof", {
  action: "nodes",
  space_id: 7616123456789015000,
});

console.log(JSON.stringify(result.details, null, 2));
EOF
```
- **Evidence after fix:**
```text
{
  "error": "space_id must be a string. Feishu wiki space IDs are opaque identifiers; pass them quoted to avoid JavaScript number precision loss."
}
```
- **Observed result after fix:** The numeric `space_id` is rejected with a clear precision-loss error before the tool creates a Feishu/Lark client or sends a request.
- **What was not tested:** A live Feishu tenant/network call was not tested; this fix targets pre-client validation and schema guidance for unsafe number-typed IDs.

## Testing
- `node scripts/run-vitest.mjs extensions/feishu/src/tool-account-routing.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/feishu/src/wiki.ts extensions/feishu/src/wiki-schema.ts extensions/feishu/src/tool-account-routing.test.ts extensions/feishu/skills/feishu-wiki/SKILL.md`
- `pnpm check:changed`
- `git diff --check`
