### PR TITLE
fix(agents): mark interrupted sessions before restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Docs: https://docs.openclaw.ai
 - Discord: bind delayed gateway `identify` retries to the originating socket generation so retries triggered after a reconnect do not identify against a fresh socket. Fixes #82225. Thanks @giodl73-repo.
 - ACP/control plane: refresh cached runtime handles when agent config changes so ACP sessions stop using stale runtimes after `agents.defaults` edits. Fixes #82237. Thanks @giodl73-repo.
 - Gateway/sessions: scope session data lookups by agent id so multi-agent gateway state cannot cross-leak session records across configured agents. (#81386) Thanks @pgondhi987.
+- Gateway/restart: mark active main sessions as restart-aborted before forced restarts so startup recovery can resume interrupted turns instead of leaving them stranded as running. Fixes #82433. (#82772) Thanks @joshavant.
 - Agents/media: require generated music/video completion agents to use the message tool for visible delivery and stop merging generated image attachments into message-tool-only source reply mirrors, avoiding direct fallback posts that can duplicate media the model already sent.
 - Agents/media: accept generated media attachments on internal completion events and report delivery-loss failures as errors, so completed background music/video tasks do not disappear after provider success.
 - Matrix/approvals: release in-flight reaction bindings when the channel approval handler stops mid-delivery, preventing stale approval targets after restart. Fixes #82485. (#82482) Thanks @Feelw00.

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -90,7 +90,7 @@ describe("main-session-restart-recovery", () => {
       "agent:main:completed": {
         sessionId: "completed-session",
         updatedAt: Date.now() - 10_000,
-        status: "completed",
+        status: "done",
       },
       "agent:main:subagent:child": {
         sessionId: "child-session",

--- a/src/agents/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-restart-recovery.test.ts
@@ -9,6 +9,7 @@ import {
   INTERNAL_RUNTIME_CONTEXT_END,
 } from "./internal-runtime-context.js";
 import {
+  markRestartAbortedMainSessions,
   markRestartAbortedMainSessionsFromLocks,
   recoverRestartAbortedMainSessions,
 } from "./main-session-restart-recovery.js";
@@ -78,6 +79,161 @@ function firstGatewayParams(): Record<string, unknown> {
 }
 
 describe("main-session-restart-recovery", () => {
+  it("marks only matching running main sessions by active session key", async () => {
+    const sessionsDir = await makeSessionsDir();
+    await writeStore(sessionsDir, {
+      "agent:main:main": {
+        sessionId: "main-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+      },
+      "agent:main:completed": {
+        sessionId: "completed-session",
+        updatedAt: Date.now() - 10_000,
+        status: "completed",
+      },
+      "agent:main:subagent:child": {
+        sessionId: "child-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+        spawnDepth: 1,
+      },
+      "cron:nightly": {
+        sessionId: "cron-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+      },
+      "agent:main:other": {
+        sessionId: "other-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+      },
+    });
+
+    const result = await markRestartAbortedMainSessions({
+      stateDir: tmpDir,
+      sessionKeys: ["agent:main:main", "agent:main:completed", "agent:main:subagent:child"],
+    });
+
+    const store = loadSessionStore(path.join(sessionsDir, "sessions.json"));
+    expect(result).toEqual({ marked: 1, skipped: 1 });
+    expect(store["agent:main:main"]?.abortedLastRun).toBe(true);
+    expect(store["agent:main:completed"]?.abortedLastRun).toBeUndefined();
+    expect(store["agent:main:subagent:child"]?.abortedLastRun).toBeUndefined();
+    expect(store["cron:nightly"]?.abortedLastRun).toBeUndefined();
+    expect(store["agent:main:other"]?.abortedLastRun).toBeUndefined();
+  });
+
+  it("marks active sessions in a configured custom session store", async () => {
+    const storePath = path.join(tmpDir, "custom", "sessions.json");
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          "agent:main:issue-82433": {
+            sessionId: "custom-session",
+            updatedAt: Date.now() - 10_000,
+            status: "running",
+          },
+        } satisfies Record<string, SessionEntry>,
+        null,
+        2,
+      ),
+    );
+    await writeTranscript(path.dirname(storePath), "custom-session", [
+      { role: "user", content: "continue this custom-store turn" },
+      { role: "toolResult", content: "custom result" },
+    ]);
+
+    const result = await markRestartAbortedMainSessions({
+      cfg: { session: { store: storePath } },
+      stateDir: tmpDir,
+      sessionKeys: ["agent:main:issue-82433"],
+    });
+
+    const store = loadSessionStore(storePath);
+    expect(result).toEqual({ marked: 1, skipped: 0 });
+    expect(store["agent:main:issue-82433"]?.abortedLastRun).toBe(true);
+
+    const recovery = await recoverRestartAbortedMainSessions({
+      cfg: { session: { store: storePath } },
+      stateDir: tmpDir,
+    });
+
+    expect(recovery).toEqual({ recovered: 1, failed: 0, skipped: 0 });
+  });
+
+  it("uses active session ids to avoid marking stale duplicate keys in another store", async () => {
+    const defaultSessionsDir = await makeSessionsDir();
+    await writeStore(defaultSessionsDir, {
+      "agent:main:issue-82433": {
+        sessionId: "stale-default-session",
+        updatedAt: Date.now() - 10_000,
+        status: "running",
+      },
+    });
+
+    const storePath = path.join(tmpDir, "custom-duplicate-key", "sessions.json");
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          "agent:main:issue-82433": {
+            sessionId: "active-custom-session",
+            updatedAt: Date.now() - 10_000,
+            status: "running",
+          },
+        } satisfies Record<string, SessionEntry>,
+        null,
+        2,
+      ),
+    );
+
+    const result = await markRestartAbortedMainSessions({
+      cfg: { session: { store: storePath } },
+      stateDir: tmpDir,
+      sessionIds: ["active-custom-session"],
+      sessionKeys: ["agent:main:issue-82433"],
+    });
+
+    const defaultStore = loadSessionStore(path.join(defaultSessionsDir, "sessions.json"));
+    const customStore = loadSessionStore(storePath);
+    expect(result).toEqual({ marked: 1, skipped: 0 });
+    expect(defaultStore["agent:main:issue-82433"]?.abortedLastRun).toBeUndefined();
+    expect(customStore["agent:main:issue-82433"]?.abortedLastRun).toBe(true);
+  });
+
+  it("marks custom-store sessions by session id when no session key is available", async () => {
+    const storePath = path.join(tmpDir, "custom-by-id", "sessions.json");
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          "agent:main:custom-by-id": {
+            sessionId: "custom-session-id-only",
+            updatedAt: Date.now() - 10_000,
+            status: "running",
+          },
+        } satisfies Record<string, SessionEntry>,
+        null,
+        2,
+      ),
+    );
+
+    const result = await markRestartAbortedMainSessions({
+      cfg: { session: { store: storePath } },
+      stateDir: tmpDir,
+      sessionIds: ["custom-session-id-only"],
+    });
+
+    const store = loadSessionStore(storePath);
+    expect(result).toEqual({ marked: 1, skipped: 0 });
+    expect(store["agent:main:custom-by-id"]?.abortedLastRun).toBe(true);
+  });
+
   it("marks only main running sessions whose transcript lock was cleaned", async () => {
     const sessionsDir = await makeSessionsDir();
     await writeStore(sessionsDir, {

--- a/src/agents/main-session-restart-recovery.ts
+++ b/src/agents/main-session-restart-recovery.ts
@@ -10,12 +10,15 @@ import { resolveStateDir } from "../config/paths.js";
 import {
   type SessionEntry,
   loadSessionStore,
+  resolveAllAgentSessionStoreTargetsSync,
   resolveSessionFilePath,
   resolveSessionTranscriptPathInDir,
   updateSessionStore,
 } from "../config/sessions.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { callGateway } from "../gateway/call.js";
 import { readSessionMessagesAsync } from "../gateway/session-utils.fs.js";
+import { resolveGatewaySessionStoreTarget } from "../gateway/session-utils.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { CommandLane } from "../process/lanes.js";
 import { isAcpSessionKey, isCronSessionKey, isSubagentSessionKey } from "../routing/session-key.js";
@@ -38,6 +41,17 @@ function shouldSkipMainRecovery(entry: SessionEntry, sessionKey: string): boolea
   return (
     isSubagentSessionKey(sessionKey) || isCronSessionKey(sessionKey) || isAcpSessionKey(sessionKey)
   );
+}
+
+function normalizeStringSet(values: Iterable<string> | undefined): Set<string> {
+  const normalized = new Set<string>();
+  for (const value of values ?? []) {
+    const trimmed = value.trim();
+    if (trimmed) {
+      normalized.add(trimmed);
+    }
+  }
+  return normalized;
 }
 
 function normalizeTranscriptLockPath(lockPath: string): string | undefined {
@@ -72,6 +86,104 @@ function resolveEntryTranscriptLockPaths(params: {
   );
   push(() => resolveSessionTranscriptPathInDir(params.entry.sessionId, params.sessionsDir));
   return [...paths];
+}
+
+export async function markRestartAbortedMainSessions(params: {
+  cfg?: OpenClawConfig;
+  additionalCfgs?: Iterable<OpenClawConfig | undefined>;
+  stateDir?: string;
+  sessionKeys?: Iterable<string>;
+  sessionIds?: Iterable<string>;
+  reason?: string;
+}): Promise<{ marked: number; skipped: number }> {
+  const sessionKeys = normalizeStringSet(params.sessionKeys);
+  const sessionIds = normalizeStringSet(params.sessionIds);
+  const preferSessionIdMatch = sessionIds.size > 0;
+  const result = { marked: 0, skipped: 0 };
+  if (sessionKeys.size === 0 && sessionIds.size === 0) {
+    return result;
+  }
+
+  const storePaths = new Set<string>();
+  const env =
+    params.stateDir === undefined
+      ? process.env
+      : { ...process.env, OPENCLAW_STATE_DIR: params.stateDir };
+  const stateDir = resolveStateDir(env);
+  const configs = [params.cfg, ...(params.additionalCfgs ?? [])].filter(
+    (cfg): cfg is OpenClawConfig => Boolean(cfg),
+  );
+  for (const cfg of configs) {
+    try {
+      for (const target of resolveAllAgentSessionStoreTargetsSync(cfg, { env })) {
+        storePaths.add(path.resolve(target.storePath));
+      }
+    } catch (err) {
+      log.warn(`failed to resolve configured session stores for restart marker: ${String(err)}`);
+    }
+    for (const sessionKey of sessionKeys) {
+      try {
+        const target = resolveGatewaySessionStoreTarget({
+          cfg,
+          key: sessionKey,
+          scanLegacyKeys: true,
+        });
+        storePaths.add(path.resolve(target.storePath));
+        for (const storeKey of target.storeKeys) {
+          const trimmed = storeKey.trim();
+          if (trimmed) {
+            sessionKeys.add(trimmed);
+          }
+        }
+      } catch (err) {
+        log.warn(
+          `failed to resolve session store for restart marker ${sessionKey}: ${String(err)}`,
+        );
+      }
+    }
+  }
+
+  for (const sessionsDir of await resolveAgentSessionDirs(stateDir)) {
+    storePaths.add(path.join(sessionsDir, "sessions.json"));
+  }
+
+  for (const storePath of storePaths) {
+    await updateSessionStore(
+      storePath,
+      (store) => {
+        for (const [sessionKey, entry] of Object.entries(store)) {
+          if (!entry || entry.status !== "running") {
+            continue;
+          }
+          const matches =
+            typeof entry.sessionId === "string" && sessionIds.has(entry.sessionId)
+              ? true
+              : !preferSessionIdMatch && sessionKeys.has(sessionKey);
+          if (!matches) {
+            continue;
+          }
+          if (shouldSkipMainRecovery(entry, sessionKey)) {
+            result.skipped++;
+            continue;
+          }
+          entry.abortedLastRun = true;
+          entry.updatedAt = Date.now();
+          store[sessionKey] = entry;
+          result.marked++;
+        }
+      },
+      { skipMaintenance: true },
+    );
+  }
+
+  if (result.marked > 0) {
+    log.warn(
+      `marked ${result.marked} interrupted main session(s) for restart recovery${
+        params.reason ? ` (${params.reason})` : ""
+      }`,
+    );
+  }
+  return result;
 }
 
 function getMessageRole(message: unknown): string | undefined {
@@ -345,20 +457,37 @@ async function recoverStore(params: {
   return result;
 }
 
+async function resolveRestartRecoveryStorePaths(params: {
+  cfg?: OpenClawConfig;
+  stateDir?: string;
+}): Promise<string[]> {
+  const storePaths = new Set<string>();
+  const stateDir = params.stateDir ?? resolveStateDir(process.env);
+  for (const sessionsDir of await resolveAgentSessionDirs(stateDir)) {
+    storePaths.add(path.join(sessionsDir, "sessions.json"));
+  }
+  if (params.cfg) {
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    for (const target of resolveAllAgentSessionStoreTargetsSync(params.cfg, { env })) {
+      storePaths.add(path.resolve(target.storePath));
+    }
+  }
+  return [...storePaths].toSorted((a, b) => a.localeCompare(b));
+}
+
 export async function recoverRestartAbortedMainSessions(
   params: {
+    cfg?: OpenClawConfig;
     stateDir?: string;
     resumedSessionKeys?: Set<string>;
   } = {},
 ): Promise<{ recovered: number; failed: number; skipped: number }> {
   const result = { recovered: 0, failed: 0, skipped: 0 };
   const resumedSessionKeys = params.resumedSessionKeys ?? new Set<string>();
-  const stateDir = params.stateDir ?? resolveStateDir(process.env);
-  const sessionDirs = await resolveAgentSessionDirs(stateDir);
 
-  for (const sessionsDir of sessionDirs) {
+  for (const storePath of await resolveRestartRecoveryStorePaths(params)) {
     const storeResult = await recoverStore({
-      storePath: path.join(sessionsDir, "sessions.json"),
+      storePath,
       resumedSessionKeys,
     });
     result.recovered += storeResult.recovered;
@@ -376,6 +505,7 @@ export async function recoverRestartAbortedMainSessions(
 
 export function scheduleRestartAbortedMainSessionRecovery(
   params: {
+    cfg?: OpenClawConfig;
     delayMs?: number;
     maxRetries?: number;
     stateDir?: string;
@@ -388,6 +518,7 @@ export function scheduleRestartAbortedMainSessionRecovery(
   const attemptRecovery = (attempt: number, delay: number) => {
     setTimeout(() => {
       void recoverRestartAbortedMainSessions({
+        cfg: params.cfg,
         stateDir: params.stateDir,
         resumedSessionKeys,
       })

--- a/src/agents/pi-embedded-runner/run-state.ts
+++ b/src/agents/pi-embedded-runner/run-state.ts
@@ -1,6 +1,7 @@
 import type { SourceReplyDeliveryMode } from "../../auto-reply/get-reply-options.types.js";
 import {
   getActiveReplyRunCount,
+  listActiveReplyRunSessionKeys,
   listActiveReplyRunSessionIds,
 } from "../../auto-reply/reply/reply-run-registry.js";
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
@@ -73,4 +74,23 @@ export function getActiveEmbeddedRunCount(): number {
     }
   }
   return Math.max(activeCount, getActiveReplyRunCount());
+}
+
+export function listActiveEmbeddedRunSessionKeys(): string[] {
+  return [
+    ...new Set([
+      ...ACTIVE_EMBEDDED_RUN_SESSION_IDS_BY_KEY.keys(),
+      ...listActiveReplyRunSessionKeys(),
+    ]),
+  ].toSorted((a, b) => a.localeCompare(b));
+}
+
+export function listActiveEmbeddedRunSessionIds(): string[] {
+  return [
+    ...new Set([
+      ...ACTIVE_EMBEDDED_RUNS.keys(),
+      ...ACTIVE_EMBEDDED_RUN_SESSION_IDS_BY_KEY.values(),
+      ...listActiveReplyRunSessionIds(),
+    ]),
+  ].toSorted((a, b) => a.localeCompare(b));
 }

--- a/src/agents/pi-embedded-runner/runs.ts
+++ b/src/agents/pi-embedded-runner/runs.ts
@@ -25,6 +25,8 @@ import {
   EMBEDDED_RUN_MODEL_SWITCH_REQUESTS,
   EMBEDDED_RUN_WAITERS,
   getActiveEmbeddedRunCount,
+  listActiveEmbeddedRunSessionIds,
+  listActiveEmbeddedRunSessionKeys,
   type ActiveEmbeddedRunSnapshot,
   type EmbeddedPiQueueHandle,
   type EmbeddedPiQueueMessageOptions,
@@ -34,6 +36,8 @@ import {
 
 export {
   getActiveEmbeddedRunCount,
+  listActiveEmbeddedRunSessionIds,
+  listActiveEmbeddedRunSessionKeys,
   type ActiveEmbeddedRunSnapshot,
   type EmbeddedPiQueueHandle,
   type EmbeddedPiQueueMessageOptions,

--- a/src/agents/pi-embedded-runner/runs.ts
+++ b/src/agents/pi-embedded-runner/runs.ts
@@ -25,8 +25,6 @@ import {
   EMBEDDED_RUN_MODEL_SWITCH_REQUESTS,
   EMBEDDED_RUN_WAITERS,
   getActiveEmbeddedRunCount,
-  listActiveEmbeddedRunSessionIds,
-  listActiveEmbeddedRunSessionKeys,
   type ActiveEmbeddedRunSnapshot,
   type EmbeddedPiQueueHandle,
   type EmbeddedPiQueueMessageOptions,

--- a/src/auto-reply/reply/reply-run-registry.ts
+++ b/src/auto-reply/reply/reply-run-registry.ts
@@ -555,6 +555,10 @@ export function listActiveReplyRunSessionIds(): string[] {
   return [...replyRunState.activeSessionIdsByKey.values()];
 }
 
+export function listActiveReplyRunSessionKeys(): string[] {
+  return [...replyRunState.activeSessionIdsByKey.keys()];
+}
+
 export const __testing = {
   resetReplyRunRegistry(): void {
     for (const [sessionKey, sessionId] of replyRunState.activeSessionIdsByKey) {

--- a/src/cli/gateway-cli/lifecycle.runtime.ts
+++ b/src/cli/gateway-cli/lifecycle.runtime.ts
@@ -1,8 +1,11 @@
 export {
   abortEmbeddedPiRun,
   getActiveEmbeddedRunCount,
+  listActiveEmbeddedRunSessionIds,
+  listActiveEmbeddedRunSessionKeys,
   waitForActiveEmbeddedRuns,
 } from "../../agents/pi-embedded-runner/runs.js";
+export { markRestartAbortedMainSessions } from "../../agents/main-session-restart-recovery.js";
 export { getRuntimeConfig } from "../../config/config.js";
 export {
   respawnGatewayProcessForUpdate,

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -72,6 +72,12 @@ const abortEmbeddedPiRun = vi.fn(
   (_sessionId?: string, _opts?: { mode?: "all" | "compacting" }) => false,
 );
 const getActiveEmbeddedRunCount = vi.fn(() => 0);
+const listActiveEmbeddedRunSessionIds = vi.fn(() => [] as string[]);
+const listActiveEmbeddedRunSessionKeys = vi.fn(() => [] as string[]);
+const markRestartAbortedMainSessions = vi.fn(async (_params: unknown) => ({
+  marked: 1,
+  skipped: 0,
+}));
 const waitForActiveEmbeddedRuns = vi.fn(async (_timeoutMs?: number) => ({ drained: true }));
 const DRAIN_TIMEOUT_LOG = "drain timeout reached; proceeding with restart";
 const DEFAULT_RESTART_DEFERRAL_TIMEOUT_MS = 300_000;
@@ -147,7 +153,13 @@ vi.mock("../../agents/pi-embedded-runner/runs.js", () => ({
   abortEmbeddedPiRun: (sessionId?: string, opts?: { mode?: "all" | "compacting" }) =>
     abortEmbeddedPiRun(sessionId, opts),
   getActiveEmbeddedRunCount: () => getActiveEmbeddedRunCount(),
+  listActiveEmbeddedRunSessionIds: () => listActiveEmbeddedRunSessionIds(),
+  listActiveEmbeddedRunSessionKeys: () => listActiveEmbeddedRunSessionKeys(),
   waitForActiveEmbeddedRuns: (timeoutMs?: number) => waitForActiveEmbeddedRuns(timeoutMs),
+}));
+
+vi.mock("../../agents/main-session-restart-recovery.js", () => ({
+  markRestartAbortedMainSessions: (params: unknown) => markRestartAbortedMainSessions(params),
 }));
 
 vi.mock("../../config/config.js", () => ({
@@ -423,11 +435,14 @@ describe("runGatewayLoop", () => {
     consumeGatewayRestartIntentPayloadSync.mockReturnValueOnce({});
     getActiveTaskCount.mockReturnValueOnce(1).mockReturnValue(0);
     getActiveEmbeddedRunCount.mockReturnValueOnce(1).mockReturnValue(0);
+    listActiveEmbeddedRunSessionIds.mockReturnValueOnce(["session-embedded-timeout"]);
+    listActiveEmbeddedRunSessionKeys.mockReturnValueOnce(["agent:main:embedded-timeout"]);
     waitForActiveTasks.mockResolvedValueOnce({ drained: false });
     waitForActiveEmbeddedRuns.mockResolvedValueOnce({ drained: false });
+    markRestartAbortedMainSessions.mockRejectedValueOnce(new Error("store read-only"));
 
     await withIsolatedSignals(async ({ captureSignal }) => {
-      const { start, exited } = await createSignaledLoopHarness();
+      const { close, start, exited } = await createSignaledLoopHarness();
       const sigterm = captureSignal("SIGTERM");
       const sigint = captureSignal("SIGINT");
 
@@ -443,6 +458,25 @@ describe("runGatewayLoop", () => {
         "active embedded run drain grace reached; aborting active run(s) before restart",
       );
       expect(gatewayLog.warn).toHaveBeenCalledWith(DRAIN_TIMEOUT_LOG);
+      expect(markRestartAbortedMainSessions).toHaveBeenCalledWith({
+        cfg: {
+          gateway: {
+            reload: {
+              deferralTimeoutMs: 90_000,
+            },
+          },
+        },
+        sessionIds: new Set(["session-embedded-timeout"]),
+        sessionKeys: new Set(["agent:main:embedded-timeout"]),
+        reason: "gateway restart drain timeout",
+      });
+      expect(gatewayLog.warn).toHaveBeenCalledWith(
+        "failed to mark interrupted main sessions for restart recovery: Error: store read-only",
+      );
+      expect(close).toHaveBeenCalledWith({
+        reason: "gateway restarting",
+        restartExpectedMs: 1500,
+      });
       expect(start).toHaveBeenCalledTimes(2);
 
       sigint();
@@ -455,15 +489,21 @@ describe("runGatewayLoop", () => {
     consumeGatewayRestartIntentPayloadSync.mockReturnValueOnce({ force: true });
     getActiveTaskCount.mockReturnValueOnce(1).mockReturnValue(0);
     getActiveEmbeddedRunCount.mockReturnValueOnce(1).mockReturnValue(0);
-    getInspectableActiveTaskRestartBlockers.mockReturnValueOnce([
+    listActiveEmbeddedRunSessionIds.mockReturnValueOnce(["session-forced-task"]);
+    listActiveEmbeddedRunSessionKeys.mockReturnValueOnce(["agent:main:forced-task"]);
+    const forceTaskBlockers = [
       {
         taskId: "task-force",
         runId: "run-force",
-        status: "running",
-        runtime: "cron",
+        status: "running" as const,
+        runtime: "cron" as const,
         label: "forced",
       },
-    ]);
+    ];
+    getInspectableActiveTaskRestartBlockers
+      .mockReturnValueOnce(forceTaskBlockers)
+      .mockReturnValueOnce(forceTaskBlockers)
+      .mockReturnValueOnce(forceTaskBlockers);
 
     await withIsolatedSignals(async ({ captureSignal }) => {
       const { start, exited } = await createSignaledLoopHarness();
@@ -477,6 +517,18 @@ describe("runGatewayLoop", () => {
       expect(waitForActiveTasks).not.toHaveBeenCalled();
       expect(waitForActiveEmbeddedRuns).not.toHaveBeenCalled();
       expect(abortEmbeddedPiRun).toHaveBeenCalledWith(undefined, { mode: "all" });
+      expect(markRestartAbortedMainSessions).toHaveBeenCalledWith({
+        cfg: {
+          gateway: {
+            reload: {
+              deferralTimeoutMs: 90_000,
+            },
+          },
+        },
+        sessionIds: new Set(["session-forced-task"]),
+        sessionKeys: new Set(["agent:main:forced-task"]),
+        reason: "forced gateway restart",
+      });
       expect(gatewayLog.warn).toHaveBeenCalledWith(
         "restart blocked by active background task run(s): taskId=task-force runId=run-force status=running runtime=cron label=forced",
       );
@@ -509,6 +561,8 @@ describe("runGatewayLoop", () => {
     await withIsolatedSignals(async ({ captureSignal }) => {
       getActiveTaskCount.mockReturnValueOnce(2).mockReturnValueOnce(0);
       getActiveEmbeddedRunCount.mockReturnValueOnce(1).mockReturnValueOnce(0);
+      listActiveEmbeddedRunSessionIds.mockReturnValueOnce(["session-issue-82433"]);
+      listActiveEmbeddedRunSessionKeys.mockReturnValueOnce(["agent:main:issue-82433"]);
       waitForActiveTasks.mockResolvedValueOnce({ drained: false });
       waitForActiveEmbeddedRuns.mockResolvedValueOnce({ drained: true });
 
@@ -571,6 +625,18 @@ describe("runGatewayLoop", () => {
       expect(waitForActiveTasks).toHaveBeenCalledWith(1_234);
       expect(waitForActiveEmbeddedRuns).toHaveBeenCalledWith(1_234);
       expect(abortEmbeddedPiRun).toHaveBeenCalledWith(undefined, { mode: "all" });
+      expect(markRestartAbortedMainSessions).toHaveBeenCalledWith({
+        cfg: {
+          gateway: {
+            reload: {
+              deferralTimeoutMs: 1_234,
+            },
+          },
+        },
+        sessionIds: new Set(["session-issue-82433"]),
+        sessionKeys: new Set(["agent:main:issue-82433"]),
+        reason: "gateway restart drain timeout",
+      });
       expect(markGatewayDraining).toHaveBeenCalledTimes(1);
       expect(gatewayLog.warn).toHaveBeenCalledWith(DRAIN_TIMEOUT_LOG);
       expect(closeFirst).toHaveBeenCalledWith({

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -442,12 +442,49 @@ export async function runGatewayLoop(params: {
             async () => {
               const {
                 abortEmbeddedPiRun,
+                getRuntimeConfig,
                 getInspectableActiveTaskRestartBlockers,
                 getActiveEmbeddedRunCount,
                 getActiveTaskCount,
+                listActiveEmbeddedRunSessionIds,
+                listActiveEmbeddedRunSessionKeys,
+                markRestartAbortedMainSessions,
                 waitForActiveEmbeddedRuns,
                 waitForActiveTasks,
               } = await loadGatewayLifecycleRuntimeModule();
+              const collectActiveRestartSessionKeys = () => {
+                return new Set<string>(listActiveEmbeddedRunSessionKeys());
+              };
+              const collectActiveRestartSessionIds = () => {
+                return new Set<string>(listActiveEmbeddedRunSessionIds());
+              };
+              let activeRestartSessionKeysAtDrainStart = new Set<string>();
+              let activeRestartSessionIdsAtDrainStart = new Set<string>();
+              const markActiveMainSessionsForRestart = async (reason: string) => {
+                const sessionKeys = new Set<string>([
+                  ...activeRestartSessionKeysAtDrainStart,
+                  ...collectActiveRestartSessionKeys(),
+                ]);
+                const sessionIds = new Set<string>([
+                  ...activeRestartSessionIdsAtDrainStart,
+                  ...collectActiveRestartSessionIds(),
+                ]);
+                if (sessionKeys.size === 0 && sessionIds.size === 0) {
+                  return;
+                }
+                try {
+                  await markRestartAbortedMainSessions({
+                    cfg: getRuntimeConfig(),
+                    sessionKeys,
+                    sessionIds,
+                    reason,
+                  });
+                } catch (err) {
+                  gatewayLog.warn(
+                    `failed to mark interrupted main sessions for restart recovery: ${String(err)}`,
+                  );
+                }
+              };
               const formatTaskBlockers = () => {
                 const blockers = getInspectableActiveTaskRestartBlockers();
                 if (blockers.length === 0) {
@@ -484,6 +521,8 @@ export async function runGatewayLoop(params: {
               const activeRuns = getActiveEmbeddedRunCount();
               activeTasksAtDrainStart = activeTasks;
               activeRunsAtDrainStart = activeRuns;
+              activeRestartSessionKeysAtDrainStart = collectActiveRestartSessionKeys();
+              activeRestartSessionIdsAtDrainStart = collectActiveRestartSessionIds();
 
               // Best-effort abort for compacting runs so long compaction operations
               // don't hold session write locks across restart boundaries.
@@ -503,6 +542,7 @@ export async function runGatewayLoop(params: {
                 }
                 if (restartIntent?.force) {
                   gatewayLog.warn("forced restart requested; skipping active work drain");
+                  await markActiveMainSessionsForRestart("forced gateway restart");
                   abortEmbeddedPiRun(undefined, { mode: "all" });
                 } else {
                   const activeRunDrainWaitMs = resolveActiveRunDrainWaitMs(activeRuns);
@@ -535,6 +575,7 @@ export async function runGatewayLoop(params: {
                   } else {
                     drainTimedOut = true;
                     gatewayLog.warn("drain timeout reached; proceeding with restart");
+                    await markActiveMainSessionsForRestart("gateway restart drain timeout");
                     // Final best-effort abort to avoid carrying active runs into the
                     // next lifecycle when drain time budget is exhausted.
                     if (!abortedAfterRunGrace) {

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -35,6 +35,11 @@ const hoisted = vi.hoisted(() => ({
     label?: string;
     title?: string;
   }>,
+  activeEmbeddedRunCount: { value: 0 },
+  activeEmbeddedRunSessionIds: [] as string[],
+  activeEmbeddedRunSessionKeys: [] as string[],
+  markRestartAbortedMainSessions: vi.fn(async (_params: unknown) => ({ marked: 1, skipped: 0 })),
+  runtimeConfig: { value: { session: { store: "/tmp/active-sessions.json" } } as OpenClawConfig },
 }));
 
 vi.mock("../hooks/gmail-watcher.js", () => ({
@@ -76,6 +81,20 @@ vi.mock("../tasks/task-registry.maintenance.js", async () => {
   };
 });
 
+vi.mock("../agents/pi-embedded-runner/run-state.js", () => ({
+  getActiveEmbeddedRunCount: () => hoisted.activeEmbeddedRunCount.value,
+  listActiveEmbeddedRunSessionIds: () => hoisted.activeEmbeddedRunSessionIds,
+  listActiveEmbeddedRunSessionKeys: () => hoisted.activeEmbeddedRunSessionKeys,
+}));
+
+vi.mock("../agents/main-session-restart-recovery.js", () => ({
+  markRestartAbortedMainSessions: hoisted.markRestartAbortedMainSessions,
+}));
+
+vi.mock("../config/config.js", () => ({
+  getRuntimeConfig: () => hoisted.runtimeConfig.value,
+}));
+
 function createReloadHandlersForTest(logReload = { info: vi.fn(), warn: vi.fn() }) {
   const cron = { start: vi.fn(async () => {}), stop: vi.fn() };
   const heartbeatRunner = {
@@ -115,6 +134,11 @@ afterEach(() => {
   hoisted.stopGmailWatcher.mockClear();
   hoisted.activeTaskCount.value = 0;
   hoisted.activeTaskBlockers.length = 0;
+  hoisted.activeEmbeddedRunCount.value = 0;
+  hoisted.activeEmbeddedRunSessionIds.length = 0;
+  hoisted.activeEmbeddedRunSessionKeys.length = 0;
+  hoisted.markRestartAbortedMainSessions.mockClear();
+  hoisted.runtimeConfig.value = { session: { store: "/tmp/active-sessions.json" } };
 });
 
 describe("gateway restart deferral preflight", () => {
@@ -124,6 +148,8 @@ describe("gateway restart deferral preflight", () => {
     const logReload = { info: vi.fn(), warn: vi.fn() };
     const { requestGatewayRestart } = createReloadHandlersForTest(logReload);
     hoisted.activeTaskCount.value = 1;
+    hoisted.activeEmbeddedRunSessionIds.push("session-issue-82433");
+    hoisted.activeEmbeddedRunSessionKeys.push("agent:main:issue-82433");
     hoisted.activeTaskBlockers.push({
       taskId: "task-nightly",
       runId: "run-nightly",
@@ -171,6 +197,15 @@ describe("gateway restart deferral preflight", () => {
       await Promise.resolve();
 
       expect(signalSpy).toHaveBeenCalledTimes(1);
+      expect(hoisted.markRestartAbortedMainSessions).toHaveBeenCalledWith({
+        cfg: {
+          gateway: { reload: { deferralTimeoutMs: 1_000 } },
+        },
+        additionalCfgs: [{ session: { store: "/tmp/active-sessions.json" } }],
+        sessionIds: new Set(["session-issue-82433"]),
+        sessionKeys: new Set(["agent:main:issue-82433"]),
+        reason: "config reload forced restart",
+      });
       expect(logReload.warn.mock.calls).toEqual([
         [
           "config change requires gateway restart (gateway.port) — deferring until 1 background task run(s) complete",

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -1,9 +1,14 @@
 import { resetModelCatalogCache } from "../agents/model-catalog.js";
 import { disposeAllSessionMcpRuntimes } from "../agents/pi-bundle-mcp-tools.js";
-import { getActiveEmbeddedRunCount } from "../agents/pi-embedded-runner/run-state.js";
+import {
+  getActiveEmbeddedRunCount,
+  listActiveEmbeddedRunSessionIds,
+  listActiveEmbeddedRunSessionKeys,
+} from "../agents/pi-embedded-runner/run-state.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
 import type { CliDeps } from "../cli/deps.types.js";
 import { isRestartEnabled } from "../config/commands.flags.js";
+import { getRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
@@ -194,6 +199,28 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
     const shown = blockers.slice(0, 8).map(formatTaskBlocker);
     const omitted = blockers.length - shown.length;
     return omitted > 0 ? `${shown.join("; ")}; +${omitted} more` : shown.join("; ");
+  };
+  const collectActiveRestartSessionKeys = () => {
+    return new Set<string>(listActiveEmbeddedRunSessionKeys());
+  };
+  const collectActiveRestartSessionIds = () => {
+    return new Set<string>(listActiveEmbeddedRunSessionIds());
+  };
+  const markActiveMainSessionsForRestart = async (nextConfig: OpenClawConfig, reason: string) => {
+    const sessionKeys = collectActiveRestartSessionKeys();
+    const sessionIds = collectActiveRestartSessionIds();
+    if (sessionKeys.size === 0 && sessionIds.size === 0) {
+      return;
+    }
+    const { markRestartAbortedMainSessions } =
+      await import("../agents/main-session-restart-recovery.js");
+    await markRestartAbortedMainSessions({
+      cfg: nextConfig,
+      additionalCfgs: [getRuntimeConfig()],
+      sessionKeys,
+      sessionIds,
+      reason,
+    });
   };
   const waitForActiveWorkBeforeChannelReload = async (
     channels: Iterable<ChannelKind>,
@@ -450,6 +477,10 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
         maxWaitMs: resolveGatewayRestartDeferralTimeoutMs(
           nextConfig.gateway?.reload?.deferralTimeoutMs,
         ),
+        emitHooks: {
+          beforeEmit: () =>
+            markActiveMainSessionsForRestart(nextConfig, "config reload forced restart"),
+        },
         hooks: {
           onReady: () => {
             restartPending = false;

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -622,7 +622,7 @@ export async function startGatewaySidecars(params: {
     run: async () => {
       const { scheduleRestartAbortedMainSessionRecovery } =
         await import("../agents/main-session-restart-recovery.js");
-      scheduleRestartAbortedMainSessionRecovery();
+      scheduleRestartAbortedMainSessionRecovery({ cfg: params.cfg });
     },
   });
 


### PR DESCRIPTION
## Summary

- Problem: main sessions interrupted by a forced gateway restart could remain `running` without `abortedLastRun`, so startup recovery did not resume or fail the interrupted turn.
- Why it matters: a user-visible agent response can be stranded after a config-triggered restart while model/tool work is still in flight.
- What changed: restart deferral and forced restart paths now mark active main sessions for restart recovery using active embedded/reply run session ids, including configured custom session stores.
- What did NOT change (scope boundary): subagent/cron/ACP recovery behavior remains excluded, and detached background task requester keys are not used as main-session selectors.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #82433
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

Behavior addressed: forced gateway restart while a main agent turn is active leaves the session recoverable instead of stranded without `abortedLastRun`.
Real environment tested: AWS Crabbox, provider `aws`, lease `cbx_12b1656eac41`, run `run_0c7d40c7e54e`, Linux c7a.8xlarge, Node 22.22.2 bootstrapped in the run.
Exact steps or command run after this patch: synced the patched dirty branch to Crabbox, built OpenClaw, started a gateway with isolated state and a local slow OpenAI-compatible model endpoint, began a main `agent` call, changed config to trigger a restart with `gateway.reload.deferralTimeoutMs=1200`, then inspected the persisted session row after the forced restart marker.
Evidence after fix: run `run_0c7d40c7e54e` printed `before_restart status=running abortedLastRun=false hasActiveRun=null`, then `after_restart status=running abortedLastRun=true hasActiveRun=null`, plus `[main-session-restart-recovery] marked 1 interrupted main session(s) for restart recovery (config reload forced restart)`.
Observed result after fix: the harness printed `FIX_CONFIRMED issue=82433 active session marked restart-aborted` and exited 0.
What was not tested: actual provider auth and channel delivery were not exercised; the model endpoint was a local OpenAI-compatible slow-response server to isolate restart/session behavior.
Before evidence: AWS Crabbox main-branch repro `cbx_3da5ccc6840a`, run `run_206ed4b243f8`, showed `after_restart status=running abortedLastRun=false hasActiveRun=null`.

## Root Cause (if applicable)

- Root cause: stale transcript-lock cleanup could only mark interrupted sessions after lock cleanup, but the forced restart path did not mark the active main session before aborting/restarting, so a running session could survive without `abortedLastRun`.
- Missing detection / guardrail: coverage did not exercise forced restart with active embedded/reply run session metadata or custom session stores.
- Contributing context (if known): restart deferral already knew active embedded run counts, but not enough prepared session identity was carried into the pre-restart recovery marker.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/main-session-restart-recovery.test.ts`, `src/gateway/server-reload-handlers.test.ts`, `src/cli/gateway-cli/run-loop.test.ts`
- Scenario the test should lock in: active main sessions are marked by session id/key during forced restart, custom stores are scanned and recovered, duplicate keys across stores do not mark stale sessions, and marker failures do not block server close.
- Why this is the smallest reliable guardrail: the behavior crosses gateway restart orchestration and persisted session recovery; focused seam tests cover each boundary without requiring live provider auth.
- Existing test that already covers this (if any): stale lock recovery tests covered only lock-cleanup marking, not pre-restart active run marking.

## User-visible / Behavior Changes

Interrupted main agent sessions are now marked for restart recovery when a forced gateway restart cuts off active model/tool work.

## Diagram (if applicable)

```text
Before:
[active main turn] -> [forced gateway restart] -> [session remains running, abortedLastRun=false]

After:
[active main turn] -> [forced gateway restart] -> [session marked abortedLastRun=true] -> [startup recovery can resume/fail it]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local focused tests; AWS Crabbox Linux for live repro/fix proof
- Runtime/container: Node 22.22.2 in AWS proof
- Model/provider: local OpenAI-compatible slow-response test server
- Integration/channel (if any): gateway agent RPC with channels skipped
- Relevant config (redacted): isolated `OPENCLAW_STATE_DIR`, custom `session.store`, `gateway.reload.mode=restart`, `gateway.reload.deferralTimeoutMs=1200`

### Steps

1. Start gateway with isolated state and a slow local model endpoint.
2. Start a main `agent` request and wait for the session row to become `running`.
3. Change config to trigger a gateway restart while the run is active.
4. Wait for forced restart marker and inspect the session row.

### Expected

- Active interrupted main session has `abortedLastRun=true` after the forced restart marker.

### Actual

- After fix: `status=running abortedLastRun=true`; harness exited 0.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: focused local regression tests, `$codex-review`, and AWS Crabbox before/after repro path for #82433.
- Edge cases checked: custom session stores, duplicate session keys across stores, session-id-only marking, skipped subagent/cron sessions, marker failure still allowing server close, old/current config store resolution during config reload.
- What you did **not** verify: live external model provider auth and post-restart final delivery through a real channel.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: over-marking sessions in unrelated stores that reuse a session key.
  - Mitigation: restart callers pass active session ids and the marker prefers session-id matching when available; regression test covers duplicate keys across stores.
- Risk: marker failure could interrupt restart cleanup.
  - Mitigation: run-loop marker failures are caught and logged before server close proceeds.
