### PR TITLE
fix(tui): preserve draft while chat is busy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- TUI: restore the submitted draft when chat is busy instead of clearing it or queueing another run. Fixes #45326. (#82774) Thanks @hyspacex.
 - Browser plugin: redact attach-details from Chrome MCP diagnostics and keep raw Chrome launch error output around long enough to surface in user reports without leaking sensitive paths.
 - System prompts: clarify MEMORY guidance over generic TTS hints in the embedded speech-core/system-prompt scaffolding so agents prefer memory-store usage over speech defaults. Fixes #81930. Thanks @giodl73-repo.
 - Agents/auth: include the checked credential source in missing API key errors, so users can see which env var, profile, or config path to fix. Fixes #82785. Thanks @loeclos.

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -480,6 +480,22 @@ describe("tui command handlers", () => {
     expect(setActivityStatus).toHaveBeenLastCalledWith("disconnected");
   });
 
+  it("rejects normal sends while a run is active", async () => {
+    const { handleCommand, sendChat, addUser, addSystem, requestRender, state } = createHarness({
+      activeChatRunId: "run-active",
+    });
+
+    await handleCommand("/context detail");
+
+    expect(sendChat).not.toHaveBeenCalled();
+    expect(addUser).not.toHaveBeenCalled();
+    expect(addSystem).toHaveBeenCalledWith(
+      "agent is busy — press Esc to abort before sending a new message",
+    );
+    expect(requestRender).toHaveBeenCalled();
+    expect(state.activeChatRunId).toBe("run-active");
+  });
+
   it("runs /auth through the local auth flow and refreshes session info", async () => {
     const refreshSessionInfo = vi.fn().mockResolvedValue(undefined);
     const runAuthFlow = vi.fn().mockResolvedValue({ exitCode: 0, signal: null });

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -632,6 +632,14 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       return;
     }
     const isBtw = isBtwCommand(text);
+    if (
+      !isBtw &&
+      (state.activeChatRunId || state.pendingChatRunId || state.pendingOptimisticUserMessage)
+    ) {
+      chatLog.addSystem("agent is busy — press Esc to abort before sending a new message");
+      tui.requestRender();
+      return;
+    }
     const runId = randomUUID();
     try {
       if (!isBtw) {

--- a/src/tui/tui-submit-test-helpers.ts
+++ b/src/tui/tui-submit-test-helpers.ts
@@ -11,10 +11,12 @@ type SubmitHarness = {
   handleCommand: MockFn;
   sendMessage: MockFn;
   handleBangLine: MockFn;
+  canSubmitMessage: MockFn;
+  onBlockedMessageSubmit: MockFn;
   onSubmit: (text: string) => void;
 };
 
-export function createSubmitHarness(): SubmitHarness {
+export function createSubmitHarness(params?: { canSubmitMessage?: () => boolean }): SubmitHarness {
   const editor = {
     setText: vi.fn(),
     addToHistory: vi.fn(),
@@ -22,11 +24,23 @@ export function createSubmitHarness(): SubmitHarness {
   const handleCommand = vi.fn();
   const sendMessage = vi.fn();
   const handleBangLine = vi.fn();
+  const canSubmitMessage = vi.fn(params?.canSubmitMessage ?? (() => true));
+  const onBlockedMessageSubmit = vi.fn();
   const onSubmit = createEditorSubmitHandler({
     editor,
     handleCommand,
     sendMessage,
     handleBangLine,
+    canSubmitMessage,
+    onBlockedMessageSubmit,
   });
-  return { editor, handleCommand, sendMessage, handleBangLine, onSubmit };
+  return {
+    editor,
+    handleCommand,
+    sendMessage,
+    handleBangLine,
+    canSubmitMessage,
+    onBlockedMessageSubmit,
+    onSubmit,
+  };
 }

--- a/src/tui/tui-submit.ts
+++ b/src/tui/tui-submit.ts
@@ -40,6 +40,7 @@ export function createEditorSubmitHandler(params: {
     }
 
     if (params.canSubmitMessage && !params.canSubmitMessage()) {
+      params.editor.setText(value);
       params.onBlockedMessageSubmit?.(value);
       return;
     }

--- a/src/tui/tui-submit.ts
+++ b/src/tui/tui-submit.ts
@@ -8,14 +8,16 @@ export function createEditorSubmitHandler(params: {
   handleCommand: (value: string) => Promise<void> | void;
   sendMessage: (value: string) => Promise<void> | void;
   handleBangLine: (value: string) => Promise<void> | void;
+  canSubmitMessage?: () => boolean;
+  onBlockedMessageSubmit?: (value: string) => void;
 }) {
   return (text: string) => {
     const raw = text;
     const value = raw.trim();
-    params.editor.setText("");
 
     // Keep previous behavior: ignore empty/whitespace-only submissions.
     if (!value) {
+      params.editor.setText("");
       return;
     }
 
@@ -23,19 +25,28 @@ export function createEditorSubmitHandler(params: {
     // IMPORTANT: use the raw (untrimmed) text so leading spaces do NOT trigger.
     // Per requirement: a lone '!' should be treated as a normal message.
     if (raw.startsWith("!") && raw !== "!") {
+      params.editor.setText("");
       params.editor.addToHistory(raw);
       void params.handleBangLine(raw);
       return;
     }
 
-    // Enable built-in editor prompt history navigation (up/down).
-    params.editor.addToHistory(value);
-
     if (value.startsWith("/")) {
+      params.editor.setText("");
+      // Enable built-in editor prompt history navigation (up/down).
+      params.editor.addToHistory(value);
       void params.handleCommand(value);
       return;
     }
 
+    if (params.canSubmitMessage && !params.canSubmitMessage()) {
+      params.onBlockedMessageSubmit?.(value);
+      return;
+    }
+
+    params.editor.setText("");
+    // Enable built-in editor prompt history navigation (up/down).
+    params.editor.addToHistory(value);
     void params.sendMessage(value);
   };
 }

--- a/src/tui/tui.submit-handler.test.ts
+++ b/src/tui/tui.submit-handler.test.ts
@@ -1,6 +1,10 @@
+import type { TUI } from "@earendil-works/pi-tui";
 import { describe, expect, it, vi } from "vitest";
+import { CustomEditor } from "./components/custom-editor.js";
+import { editorTheme } from "./theme/theme.js";
 import { createSubmitHarness } from "./tui-submit-test-helpers.js";
 import {
+  createEditorSubmitHandler,
   createSubmitBurstCoalescer,
   shouldEnableWindowsGitBashPasteFallback,
 } from "./tui-submit.js";
@@ -54,11 +58,33 @@ describe("createEditorSubmitHandler", () => {
 
     onSubmit("  wait, use c++ instead  ");
 
-    expect(editor.setText).not.toHaveBeenCalled();
+    expect(editor.setText).toHaveBeenCalledWith("wait, use c++ instead");
     expect(editor.addToHistory).not.toHaveBeenCalled();
     expect(sendMessage).not.toHaveBeenCalled();
     expect(handleCommand).not.toHaveBeenCalled();
     expect(handleBangLine).not.toHaveBeenCalled();
+    expect(onBlockedMessageSubmit).toHaveBeenCalledWith("wait, use c++ instead");
+  });
+
+  it("restores the real editor value after pi-tui clears a busy submit", () => {
+    const tui = { requestRender: vi.fn() } as unknown as TUI;
+    const editor = new CustomEditor(tui, editorTheme);
+    const sendMessage = vi.fn();
+    const onBlockedMessageSubmit = vi.fn();
+    editor.setText("wait, use c++ instead");
+    editor.onSubmit = createEditorSubmitHandler({
+      editor,
+      handleCommand: vi.fn(),
+      sendMessage,
+      handleBangLine: vi.fn(),
+      canSubmitMessage: () => false,
+      onBlockedMessageSubmit,
+    });
+
+    editor.handleInput("\r");
+
+    expect(editor.getText()).toBe("wait, use c++ instead");
+    expect(sendMessage).not.toHaveBeenCalled();
     expect(onBlockedMessageSubmit).toHaveBeenCalledWith("wait, use c++ instead");
   });
 

--- a/src/tui/tui.submit-handler.test.ts
+++ b/src/tui/tui.submit-handler.test.ts
@@ -46,6 +46,36 @@ describe("createEditorSubmitHandler", () => {
     expect(editor.addToHistory).toHaveBeenCalledWith("hello");
   });
 
+  it("preserves normal message drafts when chat is busy", () => {
+    const { editor, sendMessage, handleCommand, handleBangLine, onBlockedMessageSubmit, onSubmit } =
+      createSubmitHarness({
+        canSubmitMessage: () => false,
+      });
+
+    onSubmit("  wait, use c++ instead  ");
+
+    expect(editor.setText).not.toHaveBeenCalled();
+    expect(editor.addToHistory).not.toHaveBeenCalled();
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(handleCommand).not.toHaveBeenCalled();
+    expect(handleBangLine).not.toHaveBeenCalled();
+    expect(onBlockedMessageSubmit).toHaveBeenCalledWith("wait, use c++ instead");
+  });
+
+  it("continues to route slash commands while chat is busy", () => {
+    const { editor, handleCommand, sendMessage, onBlockedMessageSubmit, onSubmit } =
+      createSubmitHarness({
+        canSubmitMessage: () => false,
+      });
+
+    onSubmit("/abort");
+
+    expect(editor.setText).toHaveBeenCalledWith("");
+    expect(handleCommand).toHaveBeenCalledWith("/abort");
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(onBlockedMessageSubmit).not.toHaveBeenCalled();
+  });
+
   it("preserves internal newlines for multiline messages", () => {
     const { editor, handleCommand, sendMessage, handleBangLine, onSubmit } = createSubmitHarness();
 

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -1182,11 +1182,19 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     closeOverlay,
   });
   updateAutocompleteProvider();
+  const canSubmitChatMessage = () =>
+    !state.activeChatRunId && !state.pendingChatRunId && !state.pendingOptimisticUserMessage;
+  const notifyBlockedChatSubmit = () => {
+    chatLog.addSystem("agent is busy — press Esc to abort before sending a new message");
+    tui.requestRender();
+  };
   const submitHandler = createEditorSubmitHandler({
     editor,
     handleCommand,
     sendMessage,
     handleBangLine: runLocalShellLine,
+    canSubmitMessage: canSubmitChatMessage,
+    onBlockedMessageSubmit: notifyBlockedChatSubmit,
   });
   editor.onSubmit = createSubmitBurstCoalescer({
     submit: submitHandler,


### PR DESCRIPTION
## Summary
- preserve normal TUI message drafts when chat is already busy instead of clearing the editor first
- add a second guard in the TUI send path so normal chat sends cannot start another run while one is active or pending
- keep slash commands such as `/abort` routable while busy, so Esc and explicit abort commands remain the interruption path

Fixes #45326.

## Real behavior proof
- **Behavior or issue addressed:** Submitting normal text while the TUI is busy no longer clears the draft or sends a second chat run. The blocked draft is surfaced to the busy handler instead.
- **Real environment tested:** Local OpenClaw checkout on macOS, Node v22.22.0, branch `fix/45326-tui-preserve-busy-draft`, executing the patched TUI submit handler directly from source.
- **Exact steps or command run after this patch:**
```sh
node --import tsx --input-type=module <<'EOF'
import { createEditorSubmitHandler } from "./src/tui/tui-submit.ts";

const calls = [];
const editor = {
  setText: (value) => calls.push(["setText", value]),
  addToHistory: (value) => calls.push(["addToHistory", value]),
};
const onSubmit = createEditorSubmitHandler({
  editor,
  handleCommand: (value) => calls.push(["handleCommand", value]),
  sendMessage: (value) => calls.push(["sendMessage", value]),
  handleBangLine: (value) => calls.push(["handleBangLine", value]),
  canSubmitMessage: () => false,
  onBlockedMessageSubmit: (value) => calls.push(["blocked", value]),
});

onSubmit("  Wait, stop, use C++ instead  ");
console.log(JSON.stringify(calls, null, 2));
EOF
```
- **Evidence after fix:**
```text
[
  [
    "blocked",
    "Wait, stop, use C++ instead"
  ]
]
```
- **Observed result after fix:** The busy normal submit is blocked with the trimmed draft value. There is no `setText("")`, no `addToHistory`, and no `sendMessage` call, so the editor draft is not swallowed and no stale second run is queued.
- **What was not tested:** A fully interactive terminal recording was not captured; this proof exercises the patched TUI submit boundary directly, and the added tests cover command-handler send rejection.

## Testing
- `node scripts/run-vitest.mjs src/tui/tui.submit-handler.test.ts src/tui/tui-command-handlers.test.ts`
- `node scripts/run-vitest.mjs src/tui/tui.submit-handler.test.ts src/tui/tui-input-history.test.ts src/tui/tui-command-handlers.test.ts src/tui/tui-event-handlers.test.ts src/tui/components/custom-editor.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/tui/tui-submit.ts src/tui/tui-submit-test-helpers.ts src/tui/tui.submit-handler.test.ts src/tui/tui-command-handlers.ts src/tui/tui-command-handlers.test.ts src/tui/tui.ts`
- `pnpm check:changed`
- `git diff --check`
