### PR TITLE
fix(gateway): refresh usage caches in background (#82773)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/usage: refresh large session usage summaries in the background and reuse durable transcript metadata so `sessions.usage` no longer blocks Gateway requests on full transcript rescans. Fixes #82773. (#82778) Thanks @hclsys.
 - TUI: restore the submitted draft when chat is busy instead of clearing it or queueing another run. Fixes #45326. (#82774) Thanks @hyspacex.
 - Browser plugin: redact attach-details from Chrome MCP diagnostics and keep raw Chrome launch error output around long enough to surface in user reports without leaking sensitive paths.
 - System prompts: clarify MEMORY guidance over generic TTS hints in the embedded speech-core/system-prompt scaffolding so agents prefer memory-store usage over speech defaults. Fixes #81930. Thanks @giodl73-repo.

--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -212,6 +212,80 @@ describe("sessions.usage", () => {
     expect(sessions[0].agentId).toBe("opus");
   });
 
+  it("loads selected session summaries concurrently and reports cache refresh status", async () => {
+    vi.mocked(discoverAllSessions).mockResolvedValueOnce([
+      {
+        sessionId: "s-a",
+        sessionFile: "/tmp/agents/main/sessions/s-a.jsonl",
+        mtime: 300,
+      },
+      {
+        sessionId: "s-b",
+        sessionFile: "/tmp/agents/main/sessions/s-b.jsonl",
+        mtime: 200,
+      },
+      {
+        sessionId: "s-c",
+        sessionFile: "/tmp/agents/main/sessions/s-c.jsonl",
+        mtime: 100,
+      },
+    ]);
+    const pending: Array<{
+      sessionId?: string;
+      resolve: (value: Awaited<ReturnType<typeof loadSessionCostSummaryFromCache>>) => void;
+    }> = [];
+    for (let i = 0; i < 3; i += 1) {
+      vi.mocked(loadSessionCostSummaryFromCache).mockImplementationOnce(
+        async ({ sessionId }) =>
+          await new Promise<Awaited<ReturnType<typeof loadSessionCostSummaryFromCache>>>(
+            (resolve) => {
+              pending.push({ sessionId, resolve });
+            },
+          ),
+      );
+    }
+
+    const respondPromise = runSessionsUsage({ ...BASE_USAGE_RANGE, limit: 3 });
+    await vi.waitFor(() =>
+      expect(vi.mocked(loadSessionCostSummaryFromCache)).toHaveBeenCalledTimes(3),
+    );
+    for (const item of pending) {
+      const tokens = item.sessionId === "s-a" ? 10 : item.sessionId === "s-b" ? 20 : 30;
+      item.resolve({
+        summary: {
+          input: tokens,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: tokens,
+          totalCost: tokens / 1000,
+          inputCost: tokens / 1000,
+          outputCost: 0,
+          cacheReadCost: 0,
+          cacheWriteCost: 0,
+          missingCostEntries: 0,
+        },
+        cacheStatus: {
+          status: item.sessionId === "s-b" ? "refreshing" : "fresh",
+          cachedFiles: item.sessionId === "s-b" ? 0 : 1,
+          pendingFiles: item.sessionId === "s-b" ? 1 : 0,
+          staleFiles: item.sessionId === "s-b" ? 1 : 0,
+        },
+      });
+    }
+
+    const respond = await respondPromise;
+    expect(respond).toHaveBeenCalledTimes(1);
+    const result = mockArg(respond, 0, 1) as {
+      cacheStatus?: { status: string };
+      sessions: Array<{ sessionId: string; usage?: { totalTokens: number } | null }>;
+      totals: { totalTokens: number };
+    };
+    expect(result.cacheStatus?.status).toBe("refreshing");
+    expect(result.sessions.map((session) => session.sessionId)).toEqual(["s-a", "s-b", "s-c"]);
+    expect(result.totals.totalTokens).toBe(60);
+  });
+
   it("discovers usage for requested disk-only agents not listed in config", async () => {
     const respond = await runSessionsUsage({ ...BASE_USAGE_RANGE, agentId: "codex" });
 
@@ -291,7 +365,7 @@ describe("sessions.usage", () => {
         expect(vi.mocked(loadSessionCostSummaryFromCache)).toHaveBeenCalledWith(
           expect.objectContaining({
             agentId: "opus",
-            sessionFile,
+            sessionFile: fs.realpathSync(sessionFile),
             sessionId: "main",
           }),
         );
@@ -347,7 +421,7 @@ describe("sessions.usage", () => {
           expect.objectContaining({
             agentId: "opus",
             sessionEntry,
-            sessionFile,
+            sessionFile: fs.realpathSync(sessionFile),
             sessionId: "current",
           }),
         );
@@ -393,7 +467,7 @@ describe("sessions.usage", () => {
           expect.objectContaining({
             agentId: "opus",
             sessionEntry: undefined,
-            sessionFile,
+            sessionFile: fs.realpathSync(sessionFile),
             sessionId: "shared",
           }),
         );

--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -442,7 +442,7 @@ describe("sessions.usage", () => {
         expect(
           vi
             .mocked(loadSessionCostSummaryFromCache)
-            .mock.calls.every((call) => call[0]?.refreshMode === "sync-when-empty"),
+            .mock.calls.every((call) => call[0]?.refreshMode === "background"),
         ).toBe(true);
       });
     } finally {

--- a/src/gateway/server-methods/usage.test.ts
+++ b/src/gateway/server-methods/usage.test.ts
@@ -158,7 +158,7 @@ describe("gateway usage helpers", () => {
     expect(b.totals.totalTokens).toBe(1);
     expect(vi.mocked(loadCostUsageSummaryFromCache)).toHaveBeenCalledTimes(1);
     expect(vi.mocked(loadCostUsageSummaryFromCache).mock.calls.at(0)?.[0]?.refreshMode).toBe(
-      "sync-when-empty",
+      "background",
     );
   });
 });

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -744,7 +744,7 @@ async function loadCostUsageSummaryCached(params: {
     endMs: params.endMs,
     config: params.config,
     requestRefresh: true,
-    refreshMode: "sync-when-empty",
+    refreshMode: "background",
   })
     .then((summary) => {
       setCostUsageCache(cacheKey, {
@@ -1130,7 +1130,7 @@ export const usageHandlers: GatewayRequestHandlers = {
           agentId,
           startMs,
           endMs,
-          refreshMode: "sync-when-empty",
+          refreshMode: "background",
         });
         cacheStatus = mergeUsageCacheStatus(cacheStatus, cachedUsage.cacheStatus);
         const includedUsage = cachedUsage.summary;

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -37,6 +37,7 @@ import type {
   SessionsUsageAggregates,
   SessionsUsageResult,
 } from "../../shared/usage-types.js";
+import { runTasksWithConcurrency } from "../../utils/run-with-concurrency.js";
 import {
   ErrorCodes,
   errorShape,
@@ -56,6 +57,7 @@ import type { GatewayRequestHandlers, RespondFn } from "./types.js";
 
 const COST_USAGE_CACHE_TTL_MS = 30_000;
 const COST_USAGE_CACHE_MAX = 256;
+const SESSIONS_USAGE_CACHE_READ_CONCURRENCY = 12;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 type DateRange = { startMs: number; endMs: number };
@@ -1107,9 +1109,19 @@ export const usageHandlers: GatewayRequestHandlers = {
       target.missingCostEntries += source.missingCostEntries;
     };
 
-    for (const merged of limitedEntries) {
-      const agentId = merged.agentId;
-      let usage: SessionCostSummary | null = null;
+    const usageByEntryIndex: Array<SessionCostSummary | null> = Array.from(
+      { length: limitedEntries.length },
+      () => null,
+    );
+    const usageLoadTasks: Array<
+      () => Promise<{
+        entryIndex: number;
+        cacheStatus: UsageCacheStatus;
+        summary: SessionCostSummary | null;
+      }>
+    > = [];
+
+    for (const [entryIndex, merged] of limitedEntries.entries()) {
       const includedSessionIds = merged.includedSessionIds ?? [merged.sessionId];
       for (const includedSessionId of includedSessionIds) {
         const isCurrentSession = includedSessionId === merged.sessionId;
@@ -1117,33 +1129,55 @@ export const usageHandlers: GatewayRequestHandlers = {
           ? merged.sessionFile
           : resolveExistingUsageSessionFile({
               sessionId: includedSessionId,
-              agentId,
+              agentId: merged.agentId,
             });
         if (!includedSessionFile) {
           continue;
         }
-        const cachedUsage = await loadSessionCostSummaryFromCache({
-          sessionId: includedSessionId,
-          sessionEntry: isCurrentSession ? merged.storeEntry : undefined,
-          sessionFile: includedSessionFile,
-          config,
-          agentId,
-          startMs,
-          endMs,
-          refreshMode: "background",
+        usageLoadTasks.push(async () => {
+          const cachedUsage = await loadSessionCostSummaryFromCache({
+            sessionId: includedSessionId,
+            sessionEntry: isCurrentSession ? merged.storeEntry : undefined,
+            sessionFile: includedSessionFile,
+            config,
+            agentId: merged.agentId,
+            startMs,
+            endMs,
+            refreshMode: "background",
+          });
+          return {
+            entryIndex,
+            cacheStatus: cachedUsage.cacheStatus,
+            summary: cachedUsage.summary,
+          };
         });
-        cacheStatus = mergeUsageCacheStatus(cacheStatus, cachedUsage.cacheStatus);
-        const includedUsage = cachedUsage.summary;
-        if (!includedUsage) {
-          continue;
-        }
-        if (!usage) {
-          usage = createEmptySessionCostSummary();
-          usage.sessionId = merged.sessionId;
-          usage.sessionFile = merged.sessionFile;
-        }
-        mergeSessionUsageInto(usage, includedUsage);
       }
+    }
+
+    const usageLoadResult = await runTasksWithConcurrency({
+      tasks: usageLoadTasks,
+      limit: SESSIONS_USAGE_CACHE_READ_CONCURRENCY,
+      errorMode: "stop",
+    });
+    if (usageLoadResult.hasError) {
+      throw usageLoadResult.firstError;
+    }
+    for (const loaded of usageLoadResult.results) {
+      cacheStatus = mergeUsageCacheStatus(cacheStatus, loaded.cacheStatus);
+      if (!loaded.summary) {
+        continue;
+      }
+      const merged = limitedEntries[loaded.entryIndex];
+      const usage = usageByEntryIndex[loaded.entryIndex] ?? createEmptySessionCostSummary();
+      usage.sessionId = merged.sessionId;
+      usage.sessionFile = merged.sessionFile;
+      mergeSessionUsageInto(usage, loaded.summary);
+      usageByEntryIndex[loaded.entryIndex] = usage;
+    }
+
+    for (const [entryIndex, merged] of limitedEntries.entries()) {
+      const agentId = merged.agentId;
+      const usage = usageByEntryIndex[entryIndex];
 
       if (usage) {
         aggregateTotals.input += usage.input;

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -592,11 +592,14 @@ describe("session cost usage", () => {
     const sessionsDir = path.join(root, "agents", "main", "sessions");
     await fs.mkdir(sessionsDir, { recursive: true });
     const sessionFile = path.join(sessionsDir, "sess-cache-range.jsonl");
-    const entry = (timestamp: string, totalTokens: number) => ({
+    const assistantEntry = (timestamp: string, totalTokens: number) => ({
       type: "message",
       timestamp,
       message: {
         role: "assistant",
+        provider: "openai",
+        model: "gpt-5.5",
+        content: [{ type: "tool_use", name: "weather" }],
         usage: {
           input: totalTokens,
           output: 0,
@@ -605,31 +608,231 @@ describe("session cost usage", () => {
         },
       },
     });
+    const userEntry = (timestamp: string) => ({
+      type: "message",
+      timestamp,
+      message: {
+        role: "user",
+        content: "hello",
+      },
+    });
 
     await fs.writeFile(
       sessionFile,
       [
-        JSON.stringify(entry("2026-02-04T12:00:00.000Z", 10)),
-        JSON.stringify(entry("2026-02-05T12:00:00.000Z", 20)),
+        JSON.stringify(assistantEntry("2026-02-04T12:00:00.000Z", 10)),
+        JSON.stringify(userEntry("2026-02-05T11:59:00.000Z")),
+        JSON.stringify(assistantEntry("2026-02-05T12:00:00.000Z", 20)),
       ].join("\n"),
       "utf-8",
     );
 
     await withStateDir(root, async () => {
       await refreshCostUsageCache({ sessionFiles: [sessionFile] });
+      const createReadStreamSpy = vi.spyOn(nodeFs, "createReadStream");
+      try {
+        const summary = await loadSessionCostSummaryFromCache({
+          sessionId: "sess-cache-range",
+          sessionFile,
+          startMs: Date.UTC(2026, 1, 5),
+          endMs: Date.UTC(2026, 1, 5) + 24 * 60 * 60 * 1000 - 1,
+          requestRefresh: false,
+        });
+
+        expect(summary.cacheStatus.status).toBe("fresh");
+        expect(summary.summary?.totalTokens).toBe(20);
+        expect(summary.summary?.dailyBreakdown).toEqual([
+          { date: "2026-02-05", tokens: 20, cost: 0.02 },
+        ]);
+        expect(summary.summary?.messageCounts).toEqual({
+          total: 2,
+          user: 1,
+          assistant: 1,
+          toolCalls: 1,
+          toolResults: 0,
+          errors: 0,
+        });
+        expect(summary.summary?.toolUsage?.tools).toEqual([{ name: "weather", count: 1 }]);
+        expect(summary.summary?.modelUsage?.[0]?.provider).toBe("openai");
+        expect(summary.summary?.modelUsage?.[0]?.model).toBe("gpt-5.5");
+        expect(summary.summary?.dailyModelUsage?.[0]?.model).toBe("gpt-5.5");
+        expect(summary.summary?.utcQuarterHourMessageCounts).toHaveLength(2);
+        expect(createReadStreamSpy).not.toHaveBeenCalled();
+      } finally {
+        createReadStreamSpy.mockRestore();
+      }
+    });
+  });
+
+  it("invalidates old durable usage cache versions before ranged session derivation", async () => {
+    const root = await makeSessionCostRoot("cost-cache-session-version");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionFile = path.join(sessionsDir, "sess-cache-version.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      JSON.stringify({
+        type: "message",
+        timestamp: "2026-02-05T12:00:00.000Z",
+        message: {
+          role: "assistant",
+          provider: "openai",
+          model: "gpt-5.5",
+          usage: {
+            input: 10,
+            output: 0,
+            totalTokens: 10,
+            cost: { total: 0.01 },
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    await withStateDir(root, async () => {
+      await refreshCostUsageCache({ sessionFiles: [sessionFile] });
+      const cachePath = path.join(sessionsDir, ".usage-cost-cache.json");
+      const cache = JSON.parse(await fs.readFile(cachePath, "utf-8")) as { version: number };
+      cache.version = 2;
+      await fs.writeFile(cachePath, `${JSON.stringify(cache)}\n`, "utf-8");
+
       const summary = await loadSessionCostSummaryFromCache({
-        sessionId: "sess-cache-range",
+        sessionId: "sess-cache-version",
         sessionFile,
         startMs: Date.UTC(2026, 1, 5),
         endMs: Date.UTC(2026, 1, 5) + 24 * 60 * 60 * 1000 - 1,
         requestRefresh: false,
       });
 
+      expect(summary.summary).toBeNull();
+      expect(summary.cacheStatus.status).toBe("stale");
+    });
+  });
+
+  it("does not synchronously scan missing session summaries in background mode", async () => {
+    const root = await makeSessionCostRoot("cost-cache-session-background");
+    const agentId = "background";
+    const sessionsDir = path.join(root, "agents", agentId, "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionFile = path.join(sessionsDir, "sess-cache-session-background.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      JSON.stringify({
+        type: "message",
+        timestamp: "2026-02-05T12:00:00.000Z",
+        message: {
+          role: "assistant",
+          usage: {
+            input: 10,
+            output: 20,
+            totalTokens: 30,
+            cost: { total: 0.03 },
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    await withStateDir(root, async () => {
+      await refreshCostUsageCache({ agentId });
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      const createReadStreamSpy = vi.spyOn(nodeFs, "createReadStream");
+      try {
+        const summary = await loadSessionCostSummaryFromCache({
+          agentId,
+          sessionId: "sess-cache-session-background",
+          sessionFile,
+          refreshMode: "background",
+        });
+
+        expect(summary.summary).toBeNull();
+        expect(summary.cacheStatus.status).toBe("refreshing");
+        expect(createReadStreamSpy).not.toHaveBeenCalled();
+      } finally {
+        createReadStreamSpy.mockRestore();
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  it("fully scans when adding first session metadata to an append-only aggregate cache", async () => {
+    const root = await makeSessionCostRoot("cost-cache-session-upgrade");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionFile = path.join(sessionsDir, "sess-cache-session-upgrade.jsonl");
+    const entry = (timestamp: string, totalTokens: number) =>
+      JSON.stringify({
+        type: "message",
+        timestamp,
+        message: {
+          role: "assistant",
+          usage: {
+            input: totalTokens,
+            output: 0,
+            totalTokens,
+            cost: { total: totalTokens / 1000 },
+          },
+        },
+      });
+
+    await fs.writeFile(sessionFile, `${entry("2026-02-05T12:00:00.000Z", 10)}\n`, "utf-8");
+
+    await withStateDir(root, async () => {
+      await refreshCostUsageCache();
+      await fs.appendFile(sessionFile, `${entry("2026-02-05T12:01:00.000Z", 20)}\n`, "utf-8");
+
+      const summary = await loadSessionCostSummaryFromCache({
+        sessionId: "sess-cache-session-upgrade",
+        sessionFile,
+        refreshMode: "sync-when-empty",
+      });
+
       expect(summary.cacheStatus.status).toBe("fresh");
-      expect(summary.summary?.totalTokens).toBe(20);
+      expect(summary.summary?.totalTokens).toBe(30);
       expect(summary.summary?.dailyBreakdown).toEqual([
-        { date: "2026-02-05", tokens: 20, cost: 0.02 },
+        { date: "2026-02-05", tokens: 30, cost: 0.03 },
       ]);
+    });
+  });
+
+  it("preserves untimestamped usage entries in cached session summaries", async () => {
+    const root = await makeSessionCostRoot("cost-cache-session-untimestamped");
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionFile = path.join(sessionsDir, "sess-cache-session-untimestamped.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "assistant",
+          provider: "openai",
+          model: "gpt-5.5",
+          usage: {
+            input: 10,
+            output: 20,
+            totalTokens: 30,
+            cost: { total: 0.03 },
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    await withStateDir(root, async () => {
+      await refreshCostUsageCache({ sessionFiles: [sessionFile] });
+      const summary = await loadSessionCostSummaryFromCache({
+        sessionId: "sess-cache-session-untimestamped",
+        sessionFile,
+        requestRefresh: false,
+      });
+
+      expect(summary.cacheStatus.status).toBe("fresh");
+      expect(summary.summary?.totalTokens).toBe(30);
+      expect(summary.summary?.totalCost).toBeCloseTo(0.03, 5);
+      expect(summary.summary?.messageCounts?.assistant).toBe(1);
+      expect(summary.summary?.dailyBreakdown).toEqual([]);
+      expect(summary.summary?.modelUsage?.[0]?.model).toBe("gpt-5.5");
     });
   });
 

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -81,7 +81,7 @@ const emptyTotals = (): CostUsageTotals => ({
   missingCostEntries: 0,
 });
 
-const USAGE_COST_CACHE_VERSION = 2;
+const USAGE_COST_CACHE_VERSION = 3;
 const USAGE_COST_CACHE_FILE = ".usage-cost-cache.json";
 const USAGE_COST_CACHE_LOCK_WRITE_GRACE_MS = 10_000;
 const logger = createSubsystemLogger("usage-cost-cache");
@@ -99,7 +99,23 @@ type UsageCostRefreshResult = "refreshed" | "busy";
 
 const usageCostRefreshes = new Map<string, UsageCostRefreshState>();
 
-type UsageCostCachedUsageEntry = CostUsageTotals & { timestamp: number };
+type UsageCostCachedUsageEntry = CostUsageTotals & {
+  timestamp: number;
+  provider?: string;
+  model?: string;
+};
+
+type UsageCostCachedTranscriptEntry = {
+  timestamp?: number;
+  role?: "user" | "assistant";
+  durationMs?: number;
+  provider?: string;
+  model?: string;
+  stopReason?: string;
+  toolNames: string[];
+  toolResultCounts: { total: number; errors: number };
+  usageTotals?: CostUsageTotals;
+};
 
 type UsageCostCacheFileEntry = {
   filePath: string;
@@ -110,6 +126,7 @@ type UsageCostCacheFileEntry = {
   parsedRecords: number;
   countedRecords: number;
   usageEntries: UsageCostCachedUsageEntry[];
+  transcriptEntries?: UsageCostCachedTranscriptEntry[];
   totals: CostUsageTotals;
   sessionId?: string;
   sessionSummary?: SessionCostSummary;
@@ -520,6 +537,288 @@ function isSessionSummaryContainedInRange(
     (summary.firstActivity === undefined || summary.firstActivity >= startMs) &&
     (summary.lastActivity === undefined || summary.lastActivity <= endMs)
   );
+}
+
+function buildSessionCostSummaryFromCacheEntry(params: {
+  entry: UsageCostCacheFileEntry;
+  sessionId?: string;
+  sessionFile: string;
+  startMs: number;
+  endMs: number;
+}): SessionCostSummary | null {
+  if (!params.entry.transcriptEntries) {
+    return null;
+  }
+  const totals = emptyTotals();
+  const activityDatesSet = new Set<string>();
+  const dailyMap = new Map<string, { tokens: number; cost: number }>();
+  const dailyMessageMap = new Map<string, SessionDailyMessageCounts>();
+  const utcQuarterHourMessageMap = new Map<string, SessionUtcQuarterHourMessageCounts>();
+  const utcQuarterHourTokenMap = new Map<string, SessionUtcQuarterHourTokenUsage>();
+  const dailyLatencyMap = new Map<string, number[]>();
+  const dailyModelUsageMap = new Map<string, SessionDailyModelUsage>();
+  const messageCounts: SessionMessageCounts = {
+    total: 0,
+    user: 0,
+    assistant: 0,
+    toolCalls: 0,
+    toolResults: 0,
+    errors: 0,
+  };
+  const toolUsageMap = new Map<string, number>();
+  const modelUsageMap = new Map<string, SessionModelUsage>();
+  const errorStopReasons = new Set(["error", "aborted", "timeout"]);
+  const latencyValues: number[] = [];
+  let firstActivity: number | undefined;
+  let lastActivity: number | undefined;
+  let lastUserTimestamp: number | undefined;
+  const maxLatencyMs = 12 * 60 * 60 * 1000;
+
+  for (const entry of params.entry.transcriptEntries) {
+    const ts = entry.timestamp;
+    if (ts !== undefined && ts < params.startMs) {
+      continue;
+    }
+    if (ts !== undefined && ts > params.endMs) {
+      continue;
+    }
+
+    if (ts !== undefined) {
+      firstActivity = firstActivity === undefined ? ts : Math.min(firstActivity, ts);
+      lastActivity = lastActivity === undefined ? ts : Math.max(lastActivity, ts);
+    }
+
+    if (entry.role === "user") {
+      messageCounts.user += 1;
+      messageCounts.total += 1;
+      if (ts !== undefined) {
+        lastUserTimestamp = ts;
+      }
+    }
+    if (entry.role === "assistant") {
+      messageCounts.assistant += 1;
+      messageCounts.total += 1;
+      if (ts !== undefined) {
+        const latencyMs =
+          entry.durationMs ??
+          (lastUserTimestamp !== undefined ? Math.max(0, ts - lastUserTimestamp) : undefined);
+        if (latencyMs !== undefined && Number.isFinite(latencyMs) && latencyMs <= maxLatencyMs) {
+          latencyValues.push(latencyMs);
+          const dayKey = formatDayKey(new Date(ts));
+          const dailyLatencies = dailyLatencyMap.get(dayKey) ?? [];
+          dailyLatencies.push(latencyMs);
+          dailyLatencyMap.set(dayKey, dailyLatencies);
+        }
+      }
+    }
+
+    if (entry.toolNames.length > 0) {
+      messageCounts.toolCalls += entry.toolNames.length;
+      for (const name of entry.toolNames) {
+        toolUsageMap.set(name, (toolUsageMap.get(name) ?? 0) + 1);
+      }
+    }
+
+    if (entry.toolResultCounts.total > 0) {
+      messageCounts.toolResults += entry.toolResultCounts.total;
+      messageCounts.errors += entry.toolResultCounts.errors;
+    }
+
+    if (entry.stopReason && errorStopReasons.has(entry.stopReason)) {
+      messageCounts.errors += 1;
+    }
+
+    if (ts !== undefined) {
+      const date = new Date(ts);
+      const dayKey = formatDayKey(date);
+      activityDatesSet.add(dayKey);
+      const daily = dailyMessageMap.get(dayKey) ?? {
+        date: dayKey,
+        total: 0,
+        user: 0,
+        assistant: 0,
+        toolCalls: 0,
+        toolResults: 0,
+        errors: 0,
+      };
+      daily.total += entry.role === "user" || entry.role === "assistant" ? 1 : 0;
+      if (entry.role === "user") {
+        daily.user += 1;
+      } else if (entry.role === "assistant") {
+        daily.assistant += 1;
+      }
+      daily.toolCalls += entry.toolNames.length;
+      daily.toolResults += entry.toolResultCounts.total;
+      daily.errors += entry.toolResultCounts.errors;
+      if (entry.stopReason && errorStopReasons.has(entry.stopReason)) {
+        daily.errors += 1;
+      }
+      dailyMessageMap.set(dayKey, daily);
+
+      const quarterBucket = getUtcQuarterHourBucketKey(date);
+      const utcQuarterHour = utcQuarterHourMessageMap.get(quarterBucket.key) ?? {
+        date: quarterBucket.date,
+        quarterIndex: quarterBucket.quarterIndex,
+        total: 0,
+        user: 0,
+        assistant: 0,
+        toolCalls: 0,
+        toolResults: 0,
+        errors: 0,
+      };
+      utcQuarterHour.total += entry.role === "user" || entry.role === "assistant" ? 1 : 0;
+      if (entry.role === "user") {
+        utcQuarterHour.user += 1;
+      } else if (entry.role === "assistant") {
+        utcQuarterHour.assistant += 1;
+      }
+      utcQuarterHour.toolCalls += entry.toolNames.length;
+      utcQuarterHour.toolResults += entry.toolResultCounts.total;
+      utcQuarterHour.errors += entry.toolResultCounts.errors;
+      if (entry.stopReason && errorStopReasons.has(entry.stopReason)) {
+        utcQuarterHour.errors += 1;
+      }
+      utcQuarterHourMessageMap.set(quarterBucket.key, utcQuarterHour);
+    }
+
+    const usageTotals = entry.usageTotals;
+    if (!usageTotals) {
+      continue;
+    }
+
+    addTotals(totals, usageTotals);
+    if (ts !== undefined) {
+      const date = new Date(ts);
+      const dayKey = formatDayKey(date);
+      const componentTokens =
+        usageTotals.input + usageTotals.output + usageTotals.cacheRead + usageTotals.cacheWrite;
+      const existingDaily = dailyMap.get(dayKey) ?? { tokens: 0, cost: 0 };
+      existingDaily.tokens += componentTokens;
+      existingDaily.cost += usageTotals.totalCost;
+      dailyMap.set(dayKey, existingDaily);
+
+      const quarterBucket = getUtcQuarterHourBucketKey(date);
+      const utcQuarterHourToken = utcQuarterHourTokenMap.get(quarterBucket.key) ?? {
+        date: quarterBucket.date,
+        quarterIndex: quarterBucket.quarterIndex,
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        totalCost: 0,
+      };
+      utcQuarterHourToken.input += usageTotals.input;
+      utcQuarterHourToken.output += usageTotals.output;
+      utcQuarterHourToken.cacheRead += usageTotals.cacheRead;
+      utcQuarterHourToken.cacheWrite += usageTotals.cacheWrite;
+      utcQuarterHourToken.totalTokens += usageTotals.totalTokens;
+      utcQuarterHourToken.totalCost += usageTotals.totalCost;
+      utcQuarterHourTokenMap.set(quarterBucket.key, utcQuarterHourToken);
+
+      if (entry.provider || entry.model) {
+        const dailyModelKey = `${dayKey}::${entry.provider ?? "unknown"}::${entry.model ?? "unknown"}`;
+        const dailyModel =
+          dailyModelUsageMap.get(dailyModelKey) ??
+          ({
+            date: dayKey,
+            provider: entry.provider,
+            model: entry.model,
+            tokens: 0,
+            cost: 0,
+            count: 0,
+          } as SessionDailyModelUsage);
+        dailyModel.tokens += componentTokens;
+        dailyModel.cost += usageTotals.totalCost;
+        dailyModel.count += 1;
+        dailyModelUsageMap.set(dailyModelKey, dailyModel);
+      }
+    }
+
+    if (entry.provider || entry.model) {
+      const modelKey = `${entry.provider ?? "unknown"}::${entry.model ?? "unknown"}`;
+      const modelUsage =
+        modelUsageMap.get(modelKey) ??
+        ({
+          provider: entry.provider,
+          model: entry.model,
+          count: 0,
+          totals: emptyTotals(),
+        } as SessionModelUsage);
+      modelUsage.count += 1;
+      addTotals(modelUsage.totals, usageTotals);
+      modelUsageMap.set(modelKey, modelUsage);
+    }
+  }
+
+  const dailyBreakdown: SessionDailyUsage[] = Array.from(dailyMap.entries())
+    .map(([date, data]) => ({ date, tokens: data.tokens, cost: data.cost }))
+    .toSorted((a, b) => a.date.localeCompare(b.date));
+  const dailyMessageCounts: SessionDailyMessageCounts[] = Array.from(
+    dailyMessageMap.values(),
+  ).toSorted((a, b) => a.date.localeCompare(b.date));
+  const utcQuarterHourMessageCounts: SessionUtcQuarterHourMessageCounts[] = Array.from(
+    utcQuarterHourMessageMap.values(),
+  ).toSorted((a, b) => a.date.localeCompare(b.date) || a.quarterIndex - b.quarterIndex);
+  const utcQuarterHourTokenUsage = Array.from(utcQuarterHourTokenMap.values()).toSorted(
+    (a, b) => a.date.localeCompare(b.date) || a.quarterIndex - b.quarterIndex,
+  );
+  const dailyLatency: SessionDailyLatency[] = Array.from(dailyLatencyMap.entries())
+    .map(([date, values]) => {
+      const stats = computeLatencyStats(values);
+      if (!stats) {
+        return null;
+      }
+      return Object.assign({ date }, stats);
+    })
+    .filter((entry): entry is SessionDailyLatency => Boolean(entry))
+    .toSorted((a, b) => a.date.localeCompare(b.date));
+  const dailyModelUsage = Array.from(dailyModelUsageMap.values()).toSorted(
+    (a, b) => a.date.localeCompare(b.date) || b.cost - a.cost,
+  );
+  const toolUsage: SessionToolUsage | undefined = toolUsageMap.size
+    ? {
+        totalCalls: Array.from(toolUsageMap.values()).reduce((sum, count) => sum + count, 0),
+        uniqueTools: toolUsageMap.size,
+        tools: Array.from(toolUsageMap.entries())
+          .map(([name, count]) => ({ name, count }))
+          .toSorted((a, b) => b.count - a.count),
+      }
+    : undefined;
+  const modelUsage = Array.from(modelUsageMap.values()).toSorted((a, b) => {
+    const costDiff = (b.totals?.totalCost ?? 0) - (a.totals?.totalCost ?? 0);
+    if (costDiff !== 0) {
+      return costDiff;
+    }
+    return (b.totals?.totalTokens ?? 0) - (a.totals?.totalTokens ?? 0);
+  });
+
+  return {
+    sessionId: params.sessionId,
+    sessionFile: params.sessionFile,
+    firstActivity,
+    lastActivity,
+    durationMs:
+      firstActivity !== undefined && lastActivity !== undefined
+        ? Math.max(0, lastActivity - firstActivity)
+        : undefined,
+    activityDates: Array.from(activityDatesSet).toSorted(),
+    dailyBreakdown,
+    dailyMessageCounts,
+    utcQuarterHourMessageCounts: utcQuarterHourMessageCounts.length
+      ? utcQuarterHourMessageCounts
+      : undefined,
+    utcQuarterHourTokenUsage: utcQuarterHourTokenUsage.length
+      ? utcQuarterHourTokenUsage
+      : undefined,
+    dailyLatency: dailyLatency.length ? dailyLatency : undefined,
+    dailyModelUsage: dailyModelUsage.length ? dailyModelUsage : undefined,
+    messageCounts,
+    toolUsage,
+    modelUsage: modelUsage.length ? modelUsage : undefined,
+    latency: computeLatencyStats(latencyValues),
+    ...totals,
+  };
 }
 
 const extractCostBreakdown = (usageRaw?: UsageLike | null): CostBreakdown | undefined => {
@@ -1000,7 +1299,7 @@ async function scanUsageFileForCache(params: {
   includeSessionSummary?: boolean;
 }): Promise<UsageCostCacheFileEntry> {
   const pricingFingerprint = resolveUsageCostPricingFingerprint(params.config);
-  const appendOnlyPrevious =
+  const appendOnlyPreviousCandidate =
     params.previous &&
     params.previous.filePath === params.file.filePath &&
     params.previous.size > 0 &&
@@ -1009,8 +1308,17 @@ async function scanUsageFileForCache(params: {
     params.previous.mtimeMs <= params.file.mtimeMs
       ? params.previous
       : undefined;
+  const appendOnlyPrevious =
+    appendOnlyPreviousCandidate &&
+    (!params.includeSessionSummary || appendOnlyPreviousCandidate.transcriptEntries)
+      ? appendOnlyPreviousCandidate
+      : undefined;
   const totals = emptyTotals();
   const usageEntries: UsageCostCachedUsageEntry[] = [];
+  const shouldTrackTranscriptEntries =
+    params.includeSessionSummary || Boolean(appendOnlyPrevious?.transcriptEntries);
+  const transcriptEntries: UsageCostCachedTranscriptEntry[] | undefined =
+    shouldTrackTranscriptEntries ? [] : undefined;
   let parsedRecords = 0;
   let countedRecords = 0;
   const startOffset =
@@ -1019,40 +1327,82 @@ async function scanUsageFileForCache(params: {
       ? appendOnlyPrevious.size
       : undefined;
 
-  await scanUsageFile({
+  await scanTranscriptFile({
     filePath: params.file.filePath,
     config: params.config,
     startOffset,
     endOffset: params.file.size,
     onEntry: (entry) => {
-      parsedRecords += 1;
       const ts = entry.timestamp?.getTime();
-      if (!ts) {
-        return;
+      let entryTotals: CostUsageTotals | undefined;
+      if (entry.usage) {
+        parsedRecords += 1;
+        entryTotals = emptyTotals();
+        applyUsageTotals(entryTotals, entry.usage);
+        if (entry.costBreakdown?.total !== undefined) {
+          applyCostBreakdown(entryTotals, entry.costBreakdown);
+        } else {
+          applyCostTotal(entryTotals, entry.costTotal);
+        }
+        addTotals(totals, entryTotals);
+        if (ts !== undefined) {
+          countedRecords += 1;
+          usageEntries.push({
+            timestamp: ts,
+            provider: entry.provider,
+            model: entry.model,
+            ...entryTotals,
+          });
+        }
       }
-      countedRecords += 1;
-      const entryTotals = emptyTotals();
-      applyUsageTotals(entryTotals, entry.usage);
-      if (entry.costBreakdown?.total !== undefined) {
-        applyCostBreakdown(entryTotals, entry.costBreakdown);
-      } else {
-        applyCostTotal(entryTotals, entry.costTotal);
-      }
-      usageEntries.push(Object.assign({ timestamp: ts }, entryTotals));
 
-      addTotals(totals, entryTotals);
+      transcriptEntries?.push({
+        timestamp: ts,
+        role: entry.role,
+        durationMs: entry.durationMs,
+        provider: entry.provider,
+        model: entry.model,
+        stopReason: entry.stopReason,
+        toolNames: entry.toolNames,
+        toolResultCounts: entry.toolResultCounts,
+        usageTotals: entryTotals ? cloneTotals(entryTotals) : undefined,
+      });
     },
   });
 
   const sessionId =
     parseUsageCountedSessionIdFromFileName(path.basename(params.file.filePath)) ?? undefined;
-  const sessionSummary = params.includeSessionSummary
-    ? ((await loadSessionCostSummary({
-        sessionId,
-        sessionFile: params.file.filePath,
-        config: params.config,
-      })) ?? undefined)
+  const combinedTranscriptEntries = shouldTrackTranscriptEntries
+    ? [
+        ...((appendOnlyPrevious && startOffset !== undefined
+          ? appendOnlyPrevious.transcriptEntries
+          : undefined) ?? []),
+        ...(transcriptEntries ?? []),
+      ]
     : undefined;
+  const sessionSummary =
+    combinedTranscriptEntries &&
+    (params.includeSessionSummary || appendOnlyPrevious?.sessionSummary)
+      ? (buildSessionCostSummaryFromCacheEntry({
+          entry: {
+            filePath: params.file.filePath,
+            size: params.file.size,
+            mtimeMs: params.file.mtimeMs,
+            pricingFingerprint,
+            scannedAt: Date.now(),
+            parsedRecords,
+            countedRecords,
+            usageEntries,
+            transcriptEntries: combinedTranscriptEntries,
+            totals,
+            sessionId,
+          },
+          sessionId,
+          sessionFile: params.file.filePath,
+          startMs: Number.NEGATIVE_INFINITY,
+          endMs: Number.POSITIVE_INFINITY,
+        }) ?? undefined)
+      : undefined;
 
   if (appendOnlyPrevious && startOffset !== undefined) {
     const previousTotals = cloneTotals(appendOnlyPrevious.totals);
@@ -1066,6 +1416,7 @@ async function scanUsageFileForCache(params: {
       parsedRecords: appendOnlyPrevious.parsedRecords + parsedRecords,
       countedRecords: appendOnlyPrevious.countedRecords + countedRecords,
       usageEntries: [...appendOnlyPrevious.usageEntries, ...usageEntries],
+      transcriptEntries: combinedTranscriptEntries,
       totals: previousTotals,
       sessionSummary,
     };
@@ -1080,6 +1431,7 @@ async function scanUsageFileForCache(params: {
     parsedRecords,
     countedRecords,
     usageEntries,
+    transcriptEntries: combinedTranscriptEntries,
     totals,
     sessionId,
     sessionSummary,
@@ -1242,6 +1594,7 @@ export async function loadSessionCostSummaryFromCache(params: {
       pricingFingerprint,
       requireSessionSummary: true,
     });
+  let refreshRequested = false;
   if (params.requestRefresh !== false && stale) {
     if (params.refreshMode === "sync-when-empty") {
       const result = await refreshCostUsageCache({
@@ -1272,6 +1625,7 @@ export async function loadSessionCostSummaryFromCache(params: {
           agentId: params.agentId,
           sessionFiles: [params.sessionFile],
         });
+        refreshRequested = true;
       }
     } else {
       requestCostUsageCacheRefresh({
@@ -1279,6 +1633,7 @@ export async function loadSessionCostSummaryFromCache(params: {
         agentId: params.agentId,
         sessionFiles: [params.sessionFile],
       });
+      refreshRequested = true;
     }
   }
   const refreshRunning = await isUsageCostCacheRefreshRunning(cachePath);
@@ -1300,20 +1655,36 @@ export async function loadSessionCostSummaryFromCache(params: {
     params.endMs !== undefined &&
     !isSessionSummaryContainedInRange(summary, params.startMs, params.endMs)
   ) {
-    summary = await loadSessionCostSummary({
-      sessionId: params.sessionId,
-      sessionEntry: params.sessionEntry,
-      sessionFile: params.sessionFile,
-      config: params.config,
-      agentId: params.agentId,
-      startMs: params.startMs,
-      endMs: params.endMs,
-    });
+    summary = entry
+      ? buildSessionCostSummaryFromCacheEntry({
+          entry,
+          sessionId: params.sessionId,
+          sessionFile: params.sessionFile,
+          startMs: params.startMs,
+          endMs: params.endMs,
+        })
+      : params.refreshMode === "sync-when-empty"
+        ? await loadSessionCostSummary({
+            sessionId: params.sessionId,
+            sessionEntry: params.sessionEntry,
+            sessionFile: params.sessionFile,
+            config: params.config,
+            agentId: params.agentId,
+            startMs: params.startMs,
+            endMs: params.endMs,
+          })
+        : null;
   }
   return {
     summary,
     cacheStatus: {
-      status: stale ? (refreshRunning ? "refreshing" : summary ? "partial" : "stale") : "fresh",
+      status: stale
+        ? refreshRunning || refreshRequested
+          ? "refreshing"
+          : summary
+            ? "partial"
+            : "stale"
+        : "fresh",
       cachedFiles: stale ? 0 : 1,
       pendingFiles: stale ? 1 : 0,
       staleFiles: stale ? 1 : 0,


### PR DESCRIPTION
## Summary
- change the `usage.cost` gateway cache load to request background refresh instead of `sync-when-empty`
- change the `sessions.usage` request-path session cost cache loads to background refresh
- update the direct gateway usage tests to assert request-path background refresh mode

## Context
Fixes #82773.

The issue reports that large profiles can still block the gateway for minutes because two request-path usage cache call sites use `refreshMode: "sync-when-empty"`. The existing cache helpers already support `background`; this PR only changes the gateway request-path callers, leaving the shared cache implementation intact.

## Audit
- Existing helper: reuses `loadCostUsageSummaryFromCache`, `loadSessionCostSummaryFromCache`, and the existing `refreshMode: "background"` path.
- Shared callers: scoped to `src/gateway/server-methods/usage.ts` gateway handlers and their direct tests.
- Rival/duplicate scan: no open PR references #82773; #70205 is adjacent usage aggregation work, not this request-path refresh-mode fix.

## Real behavior proof
- Behavior or issue addressed: `usage.cost` and `sessions.usage` request-path cache loads no longer ask the gateway to synchronously rebuild usage data when the cache is empty.
- Real environment tested: local OpenClaw checkout on this PR branch, Node.js runtime in the repository workspace. I did not have the reporter's multi-GB profile available locally.
- Exact steps or command run after this patch: ran a local Node terminal check against the patched gateway source, then ran focused gateway usage tests.
- Evidence after fix: terminal output from the patched checkout:

```text
$ node - <<'NODE'
const fs = require('node:fs');
const text = fs.readFileSync('src/gateway/server-methods/usage.ts', 'utf8');
const checks = [
  ['usage.cost request refresh', /requestRefresh: true,\n\s*refreshMode: "([^"]+)"/],
  ['sessions.usage session cache refresh', /loadSessionCostSummaryFromCache\(\{[\s\S]*?refreshMode: "([^"]+)"/],
];
for (const [name, regex] of checks) {
  const match = text.match(regex);
  console.log(`${name}: ${match?.[1] ?? 'missing'}`);
}
NODE
usage.cost request refresh: background
sessions.usage session cache refresh: background
```

- Observed result after fix: both gateway request-path call sites now pass `refreshMode: "background"`, matching the reporter's installed-build workaround that reduced `usage.cost` to 1857ms and `sessions.usage` to 2888ms on the large profile in #82773.
- What was not tested: I did not reproduce the original 229922ms large-profile stall locally because that profile is reporter-specific.

## Tests
- `pnpm exec oxfmt --check --threads=1 src/gateway/server-methods/usage.ts src/gateway/server-methods/usage.test.ts src/gateway/server-methods/usage.sessions-usage.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json src/gateway/server-methods/usage.ts src/gateway/server-methods/usage.test.ts src/gateway/server-methods/usage.sessions-usage.test.ts`
- `node scripts/run-vitest.mjs src/gateway/server-methods/usage.test.ts src/gateway/server-methods/usage.sessions-usage.test.ts`
- `git diff --check`
