### PR TITLE
fix(agents): split embedded attempt dispatch timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/diagnostics: split slow embedded-run `attempt-dispatch` startup summaries into workspace, prompt, runtime-plan, and final dispatch subspans so traces identify the delayed setup phase. Fixes #82782. (#82783) Thanks @galiniliev.
 - Agents/subagents: route group/channel subagent completions through message-tool-only handoffs when required and keep active-requester wake failures from dropping completion delivery. Fixes #82803. Thanks @galiniliev, @yozakura-ava, and @moeedahmed.
 - Memory-core: scan persisted memory source sessions on startup, comparing on-disk transcripts against the index and marking only missing/newer/resized files dirty for incremental sync. Fixes #82341. (#82341) Thanks @giodl73-repo.
 - Telegram: keep the top-level default account in the account list when named accounts or bindings are added alongside top-level credentials, preserving default polling while still letting named-only configs resolve to a single account. Fixes #82794. (#82794) Thanks @giodl73-repo.

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -114,6 +114,7 @@ import { createEmbeddedRunReplayState, observeReplayMetadata } from "./replay-st
 import { handleAssistantFailover } from "./run/assistant-failover.js";
 import {
   createEmbeddedRunStageTracker,
+  EMBEDDED_RUN_ATTEMPT_DISPATCH_STAGE,
   formatEmbeddedRunStageSummary,
   shouldWarnEmbeddedRunStageSummary,
 } from "./run/attempt-stage-timing.js";
@@ -193,6 +194,16 @@ const MID_TURN_PRECHECK_CONTINUATION_PROMPT =
 const COMPACTION_CONTINUATION_RETRY_INSTRUCTION =
   "The previous attempt compacted the conversation context before producing a final user-visible answer. Continue from the compacted transcript and produce the final answer now. Do not restart from scratch, do not repeat completed work, and do not rerun tools unless the transcript clearly lacks required evidence.";
 type EmbeddedRunAttemptForRunner = Awaited<ReturnType<typeof runEmbeddedAttemptWithBackend>>;
+
+function resolveAttemptDispatchApiKey(params: {
+  apiKeyInfo: ApiKeyInfo | null;
+  runtimeAuthState: RuntimeAuthState | null;
+}): string | undefined {
+  if (params.runtimeAuthState) {
+    return undefined;
+  }
+  return params.apiKeyInfo?.apiKey;
+}
 
 function resolveEmbeddedRunLaneTimeoutMs(timeoutMs: number): number | undefined {
   if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
@@ -1271,6 +1282,9 @@ export async function runEmbeddedPiAgent(
           authRetryPending = false;
           attemptedThinking.add(thinkLevel);
           await fs.mkdir(resolvedWorkspace, { recursive: true });
+          if (!startupStagesEmitted) {
+            startupStages.mark(EMBEDDED_RUN_ATTEMPT_DISPATCH_STAGE.workspace);
+          }
 
           const basePrompt =
             nextAttemptPromptOverride ??
@@ -1289,9 +1303,12 @@ export async function runEmbeddedPiAgent(
             promptAdditions.length > 0
               ? `${basePrompt}\n\n${promptAdditions.join("\n\n")}`
               : basePrompt;
-          let resolvedStreamApiKey: string | undefined;
-          if (!runtimeAuthState && apiKeyInfo) {
-            resolvedStreamApiKey = (apiKeyInfo as ApiKeyInfo).apiKey;
+          const resolvedStreamApiKey = resolveAttemptDispatchApiKey({
+            apiKeyInfo,
+            runtimeAuthState,
+          });
+          if (!startupStagesEmitted) {
+            startupStages.mark(EMBEDDED_RUN_ATTEMPT_DISPATCH_STAGE.prompt);
           }
           const runtimePlan = buildAgentRuntimePlan({
             provider,
@@ -1323,9 +1340,10 @@ export async function runEmbeddedPiAgent(
             },
           });
           if (!startupStagesEmitted) {
-            startupStages.mark("attempt-dispatch");
+            startupStages.mark(EMBEDDED_RUN_ATTEMPT_DISPATCH_STAGE.runtimePlan);
+            startupStages.mark(EMBEDDED_RUN_ATTEMPT_DISPATCH_STAGE.dispatch);
             notifyExecutionPhase("attempt_dispatch", { provider, model: modelId });
-            emitStartupStageSummary("attempt-dispatch");
+            emitStartupStageSummary(EMBEDDED_RUN_ATTEMPT_DISPATCH_STAGE.dispatch);
             startupStagesEmitted = true;
           }
 

--- a/src/agents/pi-embedded-runner/run/attempt-stage-timing.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt-stage-timing.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   createEmbeddedRunStageTracker,
+  EMBEDDED_RUN_ATTEMPT_DISPATCH_STAGE,
   formatEmbeddedRunStageSummary,
   shouldWarnEmbeddedRunStageSummary,
 } from "./attempt-stage-timing.js";
@@ -64,6 +65,24 @@ describe("embedded run stage timing", () => {
       }),
     ).toBe(
       "embedded run startup stages: runId=r1 totalMs=80 stages=workspace:25ms@25ms,tools:55ms@80ms",
+    );
+  });
+
+  it("names first-attempt dispatch subspans for slow startup summaries", () => {
+    let clock = 0;
+    const tracker = createEmbeddedRunStageTracker({ now: () => clock });
+
+    clock = 10;
+    tracker.mark(EMBEDDED_RUN_ATTEMPT_DISPATCH_STAGE.workspace);
+    clock = 40;
+    tracker.mark(EMBEDDED_RUN_ATTEMPT_DISPATCH_STAGE.prompt);
+    clock = 90;
+    tracker.mark(EMBEDDED_RUN_ATTEMPT_DISPATCH_STAGE.runtimePlan);
+    clock = 91;
+    tracker.mark(EMBEDDED_RUN_ATTEMPT_DISPATCH_STAGE.dispatch);
+
+    expect(formatEmbeddedRunStageSummary("startup", tracker.snapshot())).toBe(
+      "startup totalMs=91 stages=attempt-workspace:10ms@10ms,attempt-prompt:30ms@40ms,attempt-runtime-plan:50ms@90ms,attempt-dispatch:1ms@91ms",
     );
   });
 });

--- a/src/agents/pi-embedded-runner/run/attempt-stage-timing.ts
+++ b/src/agents/pi-embedded-runner/run/attempt-stage-timing.ts
@@ -14,6 +14,13 @@ export type EmbeddedRunStageTracker = {
   snapshot: () => EmbeddedRunStageSummary;
 };
 
+export const EMBEDDED_RUN_ATTEMPT_DISPATCH_STAGE = {
+  workspace: "attempt-workspace",
+  prompt: "attempt-prompt",
+  runtimePlan: "attempt-runtime-plan",
+  dispatch: "attempt-dispatch",
+} as const;
+
 const EMBEDDED_RUN_STAGE_WARN_TOTAL_MS = 10_000;
 const EMBEDDED_RUN_STAGE_WARN_STAGE_MS = 5_000;
 


### PR DESCRIPTION
## Summary

- Problem: slow embedded runner startup summaries can collapse all first-attempt setup latency into `phase=attempt-dispatch` without identifying the slow subphase.
- Why it matters: the local BUG-014 trace evidence includes 7 `attempt-dispatch` matches and a representative `attempt-dispatch:11632ms`, but that log shape is not enough to tell whether the delay came from workspace setup, prompt assembly, runtime-plan setup, or final dispatch.
- What changed: added named first-attempt dispatch timing stages for `attempt-workspace`, `attempt-prompt`, `attempt-runtime-plan`, and `attempt-dispatch`, and added focused formatter coverage for those labels.
- What did NOT change (scope boundary): no runtime policy, provider selection, auth, prompt content, or attempt execution behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #82782
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: slow embedded-run startup summaries for `phase=attempt-dispatch` now include first-attempt dispatch subspans.
- Real environment tested: Azure Crabbox `brisk-krill` / `cbx_0c3538867945`, Linux `Standard_D32ads_v6`, synced PR head `fb02b69c10543efbb92fbcb63e057f724ab56148` under `/work/crabbox/cbx_0c3538867945/pr-82783-prepare`.
- Exact steps or command run after this patch:

```text
/home/galini/.codex/skills/crabbox-oc-evidence/scripts/collect-openclaw-evidence.sh \
  --id brisk-krill \
  --name pr-82783-after-fix \
  --test src/agents/pi-embedded-runner/run/attempt-stage-timing.test.ts \
  --command 'node --import tsx --input-type=module -e <after-fix summary assertion>'
```

- Evidence after fix:

```text
CRABBOX_PHASE:context
/work/crabbox/cbx_0c3538867945/pr-82783-prepare
fb02b69c10543efbb92fbcb63e057f724ab56148
CRABBOX_PHASE:tests
[test] passed 1 Vitest shard in 4.02s
Test Files  1 passed (1)
Tests       5 passed (5)
CRABBOX_PHASE:evidence_1
AFTER_FIX_ATTEMPT_DISPATCH_SUMMARY=embedded run startup stages: runId=crabbox-after-fix totalMs=91 stages=attempt-workspace:10ms@10ms,attempt-prompt:30ms@40ms,attempt-runtime-plan:50ms@90ms,attempt-dispatch:1ms@91ms
AFTER_FIX_ATTEMPT_DISPATCH_LABELS_PRESENT=attempt-workspace,attempt-prompt,attempt-runtime-plan,attempt-dispatch
CRABBOX_PHASE:done
run summary sync=28.962s command=4m11.353s total=4m40.378s sync_skipped=false exit=0
```

- Observed result after fix: the remote PR-head proof prints the startup summary with all four first-attempt dispatch subspans: `attempt-workspace`, `attempt-prompt`, `attempt-runtime-plan`, and `attempt-dispatch`; the focused regression test passes 5/5.
- What was not tested: a live provider-backed embedded agent turn with real model credentials was not run; the proof is a remote PR-head timing/formatter behavior proof plus focused Vitest regression coverage for the changed observability seam.
- Before evidence (optional but encouraged): local BUG-014 evidence recorded 7 `attempt-dispatch` trace matches and a representative `[trace:embedded-run] ... attempt-dispatch:11632ms` line.

## Root Cause (if applicable)

- Root cause: the outer embedded-run startup tracker marked only a single `attempt-dispatch` stage after prompt setup and runtime-plan construction, so the emitted slow-startup summary did not expose which pre-attempt dispatch setup step consumed time.
- Missing detection / guardrail: existing stage timing tests covered generic formatting but did not lock in the dispatch subspan names needed for this trace path.
- Contributing context (if known): the lower-level attempt path already has separate prep/core-plugin-tool stage summaries, but the outer first-attempt dispatch region did not have comparable detail.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-runner/run/attempt-stage-timing.test.ts`
- Scenario the test should lock in: first-attempt dispatch subspan names are formatted into startup summaries.
- Why this is the smallest reliable guardrail: the bug is an observability label/summary gap, and the formatter helper is the narrowest seam for the emitted stage list.
- Existing test that already covers this (if any): generic stage timing and summary formatting existed, but not the dispatch subspan labels.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Embedded-run trace/warn logs for slow startup can include more detailed stage names inside the existing startup summary. No config or default behavior changed.

## Diagram (if applicable)

```text
Before:
startup setup -> attempt-dispatch -> one coarse stage in slow summary

After:
startup setup -> attempt-workspace -> attempt-prompt -> attempt-runtime-plan -> attempt-dispatch -> detailed stages in the same summary
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows local worktree for patch hygiene; original BUG-014 runtime environment is `NOT_ENOUGH_INFO`.
- Runtime/container: Node v24.15.0 locally; repo requires Node 22+, and local test execution was blocked before meaningful runtime proof.
- Model/provider: NOT_ENOUGH_INFO
- Integration/channel (if any): embedded runner trace path
- Relevant config (redacted): NOT_ENOUGH_INFO

### Steps

1. Enable embedded-run trace or collect slow startup summaries.
2. Run an embedded agent turn that reaches first-attempt dispatch.
3. Inspect the `phase=attempt-dispatch` startup summary.

### Expected

- The startup summary includes the first-attempt dispatch setup subspans.

### Actual

- BUG-014 evidence showed a coarse `attempt-dispatch:11632ms` trace line without enough subphase detail.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Azure Crabbox `brisk-krill` / `cbx_0c3538867945` ran the focused timing test and after-fix summary assertion on PR head `fb02b69c10543efbb92fbcb63e057f724ab56148`; local `git diff --check origin/main...HEAD` also passed before the Crabbox run.
- Edge cases checked: retry attempts do not add duplicate startup stages because all new marks are gated by `!startupStagesEmitted`.
- What you did **not** verify: live provider-backed embedded-run logs with real model credentials.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: trace summaries gain extra stage labels, which may affect tooling that string-matches the exact `stages=` payload.
  - Mitigation: the existing summary prefix and `phase=attempt-dispatch` are preserved; only the stage list becomes more specific.
