### PR TITLE
fix(agents): include auth source in requireApiKey error message

### DIFF
--- a/src/agents/model-auth-runtime-shared.ts
+++ b/src/agents/model-auth-runtime-shared.ts
@@ -30,5 +30,7 @@ export function requireApiKey(auth: ResolvedProviderAuth, provider: string): str
   if (key) {
     return key;
   }
-  throw new Error(`No API key resolved for provider "${provider}" (auth mode: ${auth.mode}).`);
+  throw new Error(
+    `No API key resolved for provider "${provider}" (auth mode: ${auth.mode}, checked: ${auth.source}).`,
+  );
 }

--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -376,7 +376,9 @@ describe("requireApiKey", () => {
         },
         "openai",
       ),
-    ).toThrow('No API key resolved for provider "openai"');
+    ).toThrow(
+      'No API key resolved for provider "openai" (auth mode: api-key, checked: env: OPENAI_API_KEY).',
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

`requireApiKey` error message now includes the `auth.source` label — already present on every `ResolvedProviderAuth` — so users see which env var or config key was checked when auth fails.

**Before:** `No API key resolved for provider "anthropic" (auth mode: env).`
**After:** `No API key resolved for provider "anthropic" (auth mode: env, checked: env: ANTHROPIC_API_KEY).`

- Closes #82785
- [x] This PR fixes a bug or regression
- Behavior or issue addressed: `requireApiKey` had access to `auth.source` but discarded it in the thrown error, leaving users with a dead-end message and no indication of which env var to set or which config path was evaluated.
- Smallest reliable test: `requireApiKey` describe block in `src/agents/model-auth.test.ts` — "throws when no API key is present" now asserts the full message including the source label.

## Real behavior proof

- Behavior addressed: `requireApiKey` throws without naming the checked source
- Real environment tested: local upstream clone, Node 22, `node scripts/run-vitest.mjs src/agents/model-auth.test.ts`
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/model-auth.test.ts`
- Evidence after fix: 2 test files, 96 tests passed
- Observed result after fix: error message includes `checked: env: OPENAI_API_KEY` — source label surfaced
- What was not tested: live agent boot path with a missing key against a real provider