### PR TITLE
docs(memory): add guidance for action-sensitive memories

### DIFF
--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -55,6 +55,46 @@ If you want your agent to remember something, just ask it: "Remember that I
 prefer TypeScript." It will write it to the appropriate file.
 </Tip>
 
+## Action-sensitive memories
+
+Most memories can be written as ordinary Markdown notes. But some memories affect what the agent should do later. For those, capture when it is safe to act on the note, not just the fact itself.
+
+Capture that action boundary when a note involves:
+
+- approval or permission requirements,
+- temporary constraints,
+- handoffs to another session, thread, or person,
+- expiry conditions,
+- safe-to-act timing,
+- source or owner authority,
+- instructions to avoid a tempting action.
+
+A useful action-sensitive memory makes clear:
+
+- what changes future behavior,
+- when or under what condition it applies,
+- when it expires, or what unlocks action,
+- what the agent should avoid doing,
+- who is the source or owner, if that affects trust or authority.
+
+Memory can preserve approval context, but it does not enforce policy. Use OpenClaw approval settings, sandboxing, and scheduled tasks for hard operational controls.
+
+Example:
+
+```md
+The API migration is being designed in another session. Future turns should not edit the API implementation from this thread; use findings here only as design input until the migration plan lands.
+```
+
+Another example:
+
+```md
+A report from an untrusted source needs review before promotion. Future turns should treat it as evidence only; do not store it as durable memory until a trusted reviewer confirms the contents.
+```
+
+Use [commitments](/concepts/commitments) for inferred, short-lived follow-ups. Use [scheduled tasks](/automation/cron-jobs) for exact reminders, timed checks, and recurring work. Memory can still summarize the durable context around either path.
+
+This is not a required schema for every memory. Simple facts can stay concise. Use action-sensitive boundaries when losing timing, authority, expiry, or safe-to-act context could cause the agent to do the wrong thing later.
+
 ## Inferred commitments
 
 Some future follow-ups are not durable facts. If you mention an interview


### PR DESCRIPTION
## Summary

- Add guidance for action-sensitive memories: notes that should change what an agent does later.
- Explain when to include an action boundary, such as approval requirements, temporary constraints, handoffs, expiry conditions, safe-to-act timing, and source/owner authority.
- Clarify that this is not a mandatory schema for every memory and that exact timed/recurring work should use commitments or scheduled tasks.

## Why

OpenClaw memory is plain Markdown, which keeps durable memory simple and inspectable. Some notes, though, are not just facts; they affect future behavior.

If the note only stores the fact, a later agent may remember it but lose whether it is safe to act, whether approval is required, whether the condition expired, or whether the work belongs in another session.

## Scope

Docs only. No memory schema, backend, config, prompts, or runtime behavior changes.

## Verification

- `npx --yes pnpm@11.1.2 docs:list`
- `npx --yes pnpm@11.1.2 format:docs:check`
- `npx --yes pnpm@11.1.2 docs:check-mdx`
- `git diff --check -- docs/concepts/memory.md`

## Real behavior proof

Behavior addressed: the Memory overview now distinguishes ordinary durable notes from action-sensitive notes where losing timing, authority, expiry, or safe-to-act context could cause the agent to do the wrong thing later.

Real environment tested: local docs checkout at `/tmp/20260516-openclaw-action-sensitive-memory-pr`.

Exact steps or command run after this patch: ran the verification commands listed above.

Evidence after fix: copied live terminal output from the local OpenClaw docs checkout after applying this patch:

```text
PASS
Docs formatting clean (629 files).
Docs MDX check passed (644 files, 2707ms).
$ node scripts/docs-list.js
$ node scripts/format-docs.mjs --check
$ node scripts/check-docs-mdx.mjs docs README.md

Process exited with code 0.
```

Targeted whitespace check output:

```text
$ git diff --check -- docs/concepts/memory.md
Command exited with code 0 and produced no output.
```

Observed result after fix: the new section gives generic examples, states that the guidance is not a required schema, and points exact timed/recurring work toward commitments or scheduled tasks instead of memory-only operational state.

What was not tested: no runtime behavior, memory backend behavior, config behavior, or scheduled-task behavior changed; this is a docs-only patch.
