### PR TITLE
fix(codex): show verbose progress for tools found after completion

### DIFF
--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -1514,6 +1514,63 @@ describe("CodexAppServerEventProjector", () => {
     ).toHaveLength(0);
   });
 
+  it("does not backfill terminal progress for snapshot tool items without terminal status", async () => {
+    const onAgentEvent = vi.fn();
+    const trajectoryRecorder = {
+      filePath: "trajectory.jsonl",
+      recordEvent: vi.fn(),
+      flush: vi.fn(async () => undefined),
+    };
+    const projector = await createProjector(
+      { ...(await createParams()), onAgentEvent },
+      { trajectoryRecorder },
+    );
+
+    await projector.handleNotification(
+      forCurrentTurn("turn/completed", {
+        turn: {
+          id: TURN_ID,
+          status: "completed",
+          error: null,
+          items: [
+            {
+              type: "commandExecution",
+              id: "cmd-missing-status",
+              command: "echo ok",
+              cwd: "/workspace",
+              processId: null,
+              source: "agent",
+              status: null,
+              commandActions: [],
+              aggregatedOutput: "ok",
+              exitCode: 0,
+              durationMs: 7,
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(
+      findAgentEvents(onAgentEvent, {
+        stream: "item",
+        itemId: "cmd-missing-status",
+      }),
+    ).toHaveLength(0);
+    expect(
+      findAgentEvents(onAgentEvent, {
+        stream: "tool",
+        itemId: "cmd-missing-status",
+        name: "bash",
+      }),
+    ).toHaveLength(0);
+    expect(
+      trajectoryRecorder.recordEvent.mock.calls.filter(
+        ([type]) => type === "tool.call" || type === "tool.result",
+      ),
+    ).toHaveLength(0);
+  });
+
   it("orders declined native tool diagnostics after their start event", async () => {
     const projector = await createProjector();
     const diagnosticEvents: DiagnosticEventPayload[] = [];

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -1457,6 +1457,63 @@ describe("CodexAppServerEventProjector", () => {
     ).toHaveLength(1);
   });
 
+  it("does not backfill terminal progress for running snapshot tool items", async () => {
+    const onAgentEvent = vi.fn();
+    const trajectoryRecorder = {
+      filePath: "trajectory.jsonl",
+      recordEvent: vi.fn(),
+      flush: vi.fn(async () => undefined),
+    };
+    const projector = await createProjector(
+      { ...(await createParams()), onAgentEvent },
+      { trajectoryRecorder },
+    );
+
+    await projector.handleNotification(
+      forCurrentTurn("turn/completed", {
+        turn: {
+          id: TURN_ID,
+          status: "interrupted",
+          error: null,
+          items: [
+            {
+              type: "commandExecution",
+              id: "cmd-running",
+              command: "sleep 30",
+              cwd: "/workspace",
+              processId: null,
+              source: "agent",
+              status: "inProgress",
+              commandActions: [],
+              aggregatedOutput: null,
+              exitCode: null,
+              durationMs: null,
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(
+      findAgentEvents(onAgentEvent, {
+        stream: "item",
+        itemId: "cmd-running",
+      }),
+    ).toHaveLength(0);
+    expect(
+      findAgentEvents(onAgentEvent, {
+        stream: "tool",
+        itemId: "cmd-running",
+        name: "bash",
+      }),
+    ).toHaveLength(0);
+    expect(
+      trajectoryRecorder.recordEvent.mock.calls.filter(
+        ([type]) => type === "tool.call" || type === "tool.result",
+      ),
+    ).toHaveLength(0);
+  });
+
   it("orders declined native tool diagnostics after their start event", async () => {
     const projector = await createProjector();
     const diagnosticEvents: DiagnosticEventPayload[] = [];
@@ -1777,16 +1834,47 @@ describe("CodexAppServerEventProjector", () => {
     }).data;
     expect(itemStart.kind).toBe("tool");
     expect(itemStart.suppressChannelProgress).toBe(true);
-    const calls = (onAgentEvent as { mock: { calls: unknown[][] } }).mock.calls;
-    const toolStart = calls.some((call) => {
-      const event = requireRecord(call[0], "agent event");
-      if (event.stream !== "tool") {
-        return false;
-      }
-      const data = requireRecord(event.data, "agent event data");
-      return data.phase === "start" && data.name === "message";
-    });
-    expect(toolStart).toBe(false);
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "dynamicToolCall",
+          id: "call-1",
+          namespace: null,
+          tool: "message",
+          arguments: { action: "send" },
+          status: "completed",
+          contentItems: null,
+          success: true,
+          durationMs: 2,
+        },
+      }),
+    );
+
+    const itemEnd = findAgentEvent(onAgentEvent, {
+      stream: "item",
+      phase: "end",
+      itemId: "call-1",
+      name: "message",
+    }).data;
+    expect(itemEnd.kind).toBe("tool");
+    expect(itemEnd.status).toBe("completed");
+    expect(itemEnd.suppressChannelProgress).toBe(true);
+    expect(
+      findAgentEvents(onAgentEvent, {
+        stream: "tool",
+        phase: "start",
+        itemId: "call-1",
+        name: "message",
+      }),
+    ).toHaveLength(0);
+    expect(
+      findAgentEvents(onAgentEvent, {
+        stream: "tool",
+        phase: "result",
+        itemId: "call-1",
+        name: "message",
+      }),
+    ).toHaveLength(0);
   });
 
   it("emits verbose tool summaries through onToolResult", async () => {

--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -191,6 +191,29 @@ function findAgentEvent(
   throw new Error(`Expected agent event ${params.stream}`);
 }
 
+function findAgentEvents(
+  mock: unknown,
+  params: { stream: string; phase?: string; itemId?: string; name?: string },
+) {
+  const calls = (mock as { mock?: { calls?: unknown[][] } }).mock?.calls;
+  if (!Array.isArray(calls)) {
+    throw new Error("Expected onAgentEvent mock calls");
+  }
+  return calls.flatMap((call) => {
+    const event = requireRecord(call[0], "agent event");
+    const data = requireRecord(event.data, "agent event data");
+    if (
+      event.stream === params.stream &&
+      (!params.phase || data.phase === params.phase) &&
+      (!params.itemId || data.itemId === params.itemId) &&
+      (!params.name || data.name === params.name)
+    ) {
+      return [{ event, data }];
+    }
+    return [];
+  });
+}
+
 function findPlanEventWithSteps(mock: unknown, steps: string[]) {
   const calls = (mock as { mock?: { calls?: unknown[][] } }).mock?.calls;
   if (!Array.isArray(calls)) {
@@ -1251,6 +1274,187 @@ describe("CodexAppServerEventProjector", () => {
     expect(toolResultContentItem.toolName).toBe("bash");
     expect(toolResultContentItem.toolCallId).toBe("cmd-1");
     expect(toolResultContentItem.content).toBe("ok");
+  });
+
+  it("backfills Codex-native tool progress from turn completed snapshots", async () => {
+    const onAgentEvent = vi.fn();
+    const trajectoryRecorder = {
+      filePath: "trajectory.jsonl",
+      recordEvent: vi.fn(),
+      flush: vi.fn(async () => undefined),
+    };
+    const projector = await createProjector(
+      { ...(await createParams()), onAgentEvent },
+      { trajectoryRecorder },
+    );
+
+    await projector.handleNotification(
+      forCurrentTurn("turn/completed", {
+        turn: {
+          id: TURN_ID,
+          status: "completed",
+          error: null,
+          items: [
+            {
+              type: "commandExecution",
+              id: "cmd-final",
+              command: "echo ok",
+              cwd: "/workspace",
+              processId: null,
+              source: "agent",
+              status: "completed",
+              commandActions: [],
+              aggregatedOutput: "ok",
+              exitCode: 0,
+              durationMs: 7,
+            },
+          ],
+        },
+      }),
+    );
+
+    const itemStart = findAgentEvent(onAgentEvent, {
+      stream: "item",
+      phase: "start",
+      itemId: "cmd-final",
+    }).data;
+    expect(itemStart.kind).toBe("command");
+    expect(itemStart.name).toBe("bash");
+    expect(itemStart.suppressChannelProgress).toBe(true);
+    const itemEnd = findAgentEvent(onAgentEvent, {
+      stream: "item",
+      phase: "end",
+      itemId: "cmd-final",
+    }).data;
+    expect(itemEnd.status).toBe("completed");
+    const toolStart = findAgentEvent(onAgentEvent, {
+      stream: "tool",
+      phase: "start",
+      itemId: "cmd-final",
+      name: "bash",
+    }).data;
+    expect(toolStart.args).toEqual({ command: "echo ok", cwd: "/workspace" });
+    const toolResult = findAgentEvent(onAgentEvent, {
+      stream: "tool",
+      phase: "result",
+      itemId: "cmd-final",
+      name: "bash",
+    }).data;
+    expect(toolResult.status).toBe("completed");
+    expect(toolResult.isError).toBe(false);
+    expect(requireRecord(toolResult.result, "tool result payload")).toMatchObject({
+      exitCode: 0,
+      durationMs: 7,
+    });
+    expect(trajectoryRecorder.recordEvent).toHaveBeenCalledWith("tool.call", {
+      threadId: THREAD_ID,
+      turnId: TURN_ID,
+      itemId: "cmd-final",
+      toolCallId: "cmd-final",
+      name: "bash",
+      arguments: { command: "echo ok", cwd: "/workspace" },
+    });
+    expect(trajectoryRecorder.recordEvent).toHaveBeenCalledWith("tool.result", {
+      threadId: THREAD_ID,
+      turnId: TURN_ID,
+      itemId: "cmd-final",
+      toolCallId: "cmd-final",
+      name: "bash",
+      status: "completed",
+      isError: false,
+      result: { status: "completed", exitCode: 0, durationMs: 7 },
+      output: "ok",
+    });
+  });
+
+  it("does not duplicate live Codex-native tool progress when final snapshots repeat it", async () => {
+    const onAgentEvent = vi.fn();
+    const trajectoryRecorder = {
+      filePath: "trajectory.jsonl",
+      recordEvent: vi.fn(),
+      flush: vi.fn(async () => undefined),
+    };
+    const projector = await createProjector(
+      { ...(await createParams()), onAgentEvent },
+      { trajectoryRecorder },
+    );
+    const completedCommand = {
+      type: "commandExecution",
+      id: "cmd-repeat",
+      command: "echo ok",
+      cwd: "/workspace",
+      processId: null,
+      source: "agent",
+      status: "completed",
+      commandActions: [],
+      aggregatedOutput: "ok",
+      exitCode: 0,
+      durationMs: 3,
+    };
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: {
+          ...completedCommand,
+          status: "inProgress",
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: null,
+        },
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: completedCommand,
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("turn/completed", {
+        turn: {
+          id: TURN_ID,
+          status: "completed",
+          error: null,
+          items: [completedCommand],
+        },
+      }),
+    );
+
+    expect(
+      findAgentEvents(onAgentEvent, {
+        stream: "item",
+        phase: "start",
+        itemId: "cmd-repeat",
+      }),
+    ).toHaveLength(1);
+    expect(
+      findAgentEvents(onAgentEvent, {
+        stream: "item",
+        phase: "end",
+        itemId: "cmd-repeat",
+      }),
+    ).toHaveLength(1);
+    expect(
+      findAgentEvents(onAgentEvent, {
+        stream: "tool",
+        phase: "start",
+        itemId: "cmd-repeat",
+        name: "bash",
+      }),
+    ).toHaveLength(1);
+    expect(
+      findAgentEvents(onAgentEvent, {
+        stream: "tool",
+        phase: "result",
+        itemId: "cmd-repeat",
+        name: "bash",
+      }),
+    ).toHaveLength(1);
+    expect(
+      trajectoryRecorder.recordEvent.mock.calls.filter(([type]) => type === "tool.call"),
+    ).toHaveLength(1);
+    expect(
+      trajectoryRecorder.recordEvent.mock.calls.filter(([type]) => type === "tool.result"),
+    ).toHaveLength(1);
   });
 
   it("orders declined native tool diagnostics after their start event", async () => {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -543,7 +543,8 @@ export class CodexAppServerEventProjector {
     }
     this.recordToolMeta(item);
     this.emitToolItemStartIfMissing(item);
-    this.emitToolItemResult(item);
+    this.emitStandardItemEvent({ phase: "end", item });
+    this.emitNormalizedToolItemEvent({ phase: "result", item });
     this.recordNativeToolTranscriptCall(item);
     this.recordNativeToolTranscriptResult(item);
     this.emitToolResultSummary(item);
@@ -650,8 +651,10 @@ export class CodexAppServerEventProjector {
         this.emitPlanUpdate({ explanation: undefined, steps: splitPlanText(item.text) });
       }
       this.recordToolMeta(item);
-      this.emitToolItemStartIfMissing(item);
-      this.emitToolItemResult(item);
+      if (isTerminalToolProgressItem(item)) {
+        this.emitToolItemStartIfMissing(item);
+        this.emitToolItemResult(item);
+      }
       this.recordNativeToolTranscriptCall(item);
       this.recordNativeToolTranscriptResult(item);
       this.emitAfterToolCallObservation(item);
@@ -1604,6 +1607,10 @@ function shouldSynthesizeToolProgressForItem(item: CodexThreadItem): boolean {
     default:
       return false;
   }
+}
+
+function isTerminalToolProgressItem(item: CodexThreadItem): boolean {
+  return itemStatus(item) !== "running";
 }
 
 function isNativePostToolUseRelayItem(item: CodexThreadItem): boolean {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -1610,7 +1610,8 @@ function shouldSynthesizeToolProgressForItem(item: CodexThreadItem): boolean {
 }
 
 function isTerminalToolProgressItem(item: CodexThreadItem): boolean {
-  return itemStatus(item) !== "running";
+  const status = readItemString(item, "status");
+  return status === "completed" || status === "failed" || status === "declined";
 }
 
 function isNativePostToolUseRelayItem(item: CodexThreadItem): boolean {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -41,6 +41,7 @@ import {
   sanitizeCodexAgentEventRecord,
   sanitizeCodexToolArguments,
 } from "./tool-progress-normalization.js";
+import type { CodexTrajectoryRecorder } from "./trajectory.js";
 import { attachCodexMirrorIdentity, buildCodexUserPromptMessage } from "./transcript-mirror.js";
 
 export type CodexAppServerToolTelemetry = {
@@ -57,6 +58,7 @@ export type CodexAppServerToolTelemetry = {
 
 export type CodexAppServerEventProjectorOptions = {
   nativePostToolUseRelayEnabled?: boolean;
+  trajectoryRecorder?: CodexTrajectoryRecorder | null;
 };
 
 const ZERO_USAGE: Usage = {
@@ -120,6 +122,10 @@ export class CodexAppServerEventProjector {
   private readonly toolResultSummaryItemIds = new Set<string>();
   private readonly toolResultOutputItemIds = new Set<string>();
   private readonly toolResultOutputStreamedItemIds = new Set<string>();
+  private readonly standardItemStartEventIds = new Set<string>();
+  private readonly standardItemEndEventIds = new Set<string>();
+  private readonly normalizedToolStartEventIds = new Set<string>();
+  private readonly normalizedToolResultEventIds = new Set<string>();
   private readonly toolResultOutputDeltaState = new Map<
     string,
     { chars: number; messages: number; truncated: boolean }
@@ -536,8 +542,8 @@ export class CodexAppServerEventProjector {
       });
     }
     this.recordToolMeta(item);
-    this.emitStandardItemEvent({ phase: "end", item });
-    this.emitNormalizedToolItemEvent({ phase: "result", item });
+    this.emitToolItemStartIfMissing(item);
+    this.emitToolItemResult(item);
     this.recordNativeToolTranscriptCall(item);
     this.recordNativeToolTranscriptResult(item);
     this.emitToolResultSummary(item);
@@ -644,6 +650,8 @@ export class CodexAppServerEventProjector {
         this.emitPlanUpdate({ explanation: undefined, steps: splitPlanText(item.text) });
       }
       this.recordToolMeta(item);
+      this.emitToolItemStartIfMissing(item);
+      this.emitToolItemResult(item);
       this.recordNativeToolTranscriptCall(item);
       this.recordNativeToolTranscriptResult(item);
       this.emitAfterToolCallObservation(item);
@@ -812,10 +820,16 @@ export class CodexAppServerEventProjector {
     if (!item) {
       return;
     }
+    const emittedItemIds =
+      params.phase === "start" ? this.standardItemStartEventIds : this.standardItemEndEventIds;
+    if (emittedItemIds.has(item.id)) {
+      return;
+    }
     const kind = itemKind(item);
     if (!kind) {
       return;
     }
+    emittedItemIds.add(item.id);
     const meta = itemMeta(item, this.toolProgressDetailMode());
     const suppressChannelProgress = shouldSuppressChannelProgressForItem(item);
     this.emitAgentEvent({
@@ -833,6 +847,22 @@ export class CodexAppServerEventProjector {
     });
   }
 
+  private emitToolItemStartIfMissing(item: CodexThreadItem | undefined): void {
+    if (!item || !shouldSynthesizeToolProgressForItem(item)) {
+      return;
+    }
+    this.emitStandardItemEvent({ phase: "start", item });
+    this.emitNormalizedToolItemEvent({ phase: "start", item });
+  }
+
+  private emitToolItemResult(item: CodexThreadItem | undefined): void {
+    if (!item || !shouldSynthesizeToolProgressForItem(item)) {
+      return;
+    }
+    this.emitStandardItemEvent({ phase: "end", item });
+    this.emitNormalizedToolItemEvent({ phase: "result", item });
+  }
+
   private emitNormalizedToolItemEvent(params: {
     phase: "start" | "result";
     item: CodexThreadItem | undefined;
@@ -841,13 +871,22 @@ export class CodexAppServerEventProjector {
     if (!item || !shouldSynthesizeToolProgressForItem(item)) {
       return;
     }
+    const emittedItemIds =
+      params.phase === "start"
+        ? this.normalizedToolStartEventIds
+        : this.normalizedToolResultEventIds;
+    if (emittedItemIds.has(item.id)) {
+      return;
+    }
     const name = itemName(item);
     if (!name) {
       return;
     }
+    emittedItemIds.add(item.id);
     const meta = itemMeta(item, this.toolProgressDetailMode());
     const args = params.phase === "start" ? itemToolArgs(item) : undefined;
     const status = params.phase === "result" ? itemStatus(item) : "running";
+    this.recordToolTrajectoryEvent({ phase: params.phase, item, name, args, status });
     this.emitDiagnosticToolExecutionEvent({ phase: params.phase, item, name, status });
     this.emitAgentEvent({
       stream: "tool",
@@ -870,6 +909,38 @@ export class CodexAppServerEventProjector {
     if (params.phase === "result") {
       this.emitAfterToolCallObservation(item);
     }
+  }
+
+  private recordToolTrajectoryEvent(params: {
+    phase: "start" | "result";
+    item: CodexThreadItem;
+    name: string;
+    args?: Record<string, unknown>;
+    status: ReturnType<typeof itemStatus>;
+  }): void {
+    if (params.phase === "start") {
+      this.options.trajectoryRecorder?.recordEvent("tool.call", {
+        threadId: this.threadId,
+        turnId: this.turnId,
+        itemId: params.item.id,
+        toolCallId: params.item.id,
+        name: params.name,
+        arguments: params.args,
+      });
+      return;
+    }
+    const toolResult = itemToolResult(params.item).result;
+    this.options.trajectoryRecorder?.recordEvent("tool.result", {
+      threadId: this.threadId,
+      turnId: this.turnId,
+      itemId: params.item.id,
+      toolCallId: params.item.id,
+      name: params.name,
+      status: params.status,
+      isError: isNonSuccessItemStatus(params.status),
+      ...(toolResult ? { result: toolResult } : {}),
+      ...(itemOutputText(params.item) ? { output: itemOutputText(params.item) } : {}),
+    });
   }
 
   private emitDiagnosticToolExecutionEvent(params: {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -2015,6 +2015,7 @@ export async function runCodexAppServerAttempt(
   projector = new CodexAppServerEventProjector(params, thread.threadId, activeTurnId, {
     nativePostToolUseRelayEnabled:
       nativeHookRelay?.allowedEvents.includes("post_tool_use") === true,
+    trajectoryRecorder,
   });
   emitLifecycleStart();
   const activeProjector = projector;

--- a/extensions/codex/src/app-server/trajectory.ts
+++ b/extensions/codex/src/app-server/trajectory.ts
@@ -12,7 +12,7 @@ import {
 } from "openclaw/plugin-sdk/security-runtime";
 import { resolveCodexLocalRuntimeAttribution } from "./local-runtime-attribution.js";
 
-type CodexTrajectoryRecorder = {
+export type CodexTrajectoryRecorder = {
   filePath: string;
   recordEvent: (type: string, data?: Record<string, unknown>) => void;
   flush: () => Promise<void>;


### PR DESCRIPTION
## Summary

This fixes a Codex app-server progress gap where native tool items present only in the final `turn/completed` snapshot were recorded into transcript and verbose-result paths, but never emitted as normalized `stream: "item"` / `stream: "tool"` progress events.

That matters for Telegram `/verbose on` because Telegram command/tool bubbles are driven by the normalized progress stream. If Codex only reports a `bash` command in the completed snapshot, Telegram can look like verbose mode failed even though the completed Codex turn contains the command item.

## Root Cause

`CodexAppServerEventProjector` normalized Codex native tool progress from live `item/started` and `item/completed` notifications, but `handleTurnCompleted` only did the transcript/result side of the projection:

- tool metadata
- native tool transcript call/result
- after-tool hooks
- verbose result summary/output

It did not run the same standard item or normalized tool progress emitters. So a command that arrived only in `turn.completed.items[]` could be present in the final snapshot while never reaching channel progress consumers.

## Implementation

- Add per-item dedupe sets for standard item start/end events and normalized tool start/result events.
- Backfill native tool start/result progress from `item/completed` when no prior start was observed.
- Backfill native tool start/result progress from `turn/completed.items[]` only for explicit terminal item statuses: `completed`, `failed`, or `declined`.
- Keep `dynamicToolCall` excluded from native tool synthesis because OpenClaw dynamic tool calls are already emitted at the `item/tool/call` boundary.
- Preserve standard item end events for non-native item lifecycles such as `dynamicToolCall`.
- Pass the app-server trajectory recorder into the projector and record matching `tool.call` / `tool.result` events for native tool progress.
- Export the `CodexTrajectoryRecorder` type so the projector can accept the existing recorder without widening it to `any`.

## Why This Is Narrow

The change stays inside the Codex app-server projection boundary. It does not change:

- Telegram dispatch logic
- command execution policy
- model/provider selection
- the `message` tool suppression rule
- verbose/full output gates
- dynamic OpenClaw tool-call normalization

The only new behavior is that terminal Codex native tool items found at completion time now go through the same normalized progress contract as live native tool notifications.

## Regression Coverage

New coverage in `extensions/codex/src/app-server/event-projector.test.ts` locks in:

1. A completed turn snapshot containing a `commandExecution` item emits item start/end, tool start/result, sanitized `bash` args, exit/duration metadata, and trajectory `tool.call` / `tool.result`.
2. A live `item/started` + `item/completed` sequence followed by a final snapshot for the same command does not duplicate item/tool/trajectory progress.
3. A `turn/completed` snapshot with an `inProgress` native tool from an interrupted turn does not synthesize terminal item/tool/trajectory progress.
4. A `turn/completed` snapshot with a native tool item but no explicit terminal status does not synthesize terminal item/tool/trajectory progress.
5. A non-native `dynamicToolCall` still emits its standard item completion while staying out of native tool progress synthesis.

## Real Behavior Proof

Behavior addressed: Codex-native tool items that arrive only in completed turn snapshots are now projected into normalized item/tool progress and trajectory events, so channel progress consumers can display them.

Real environment tested: Local OpenClaw Codex app-server projector tests and changed/build gates on macOS, Node v24.15.0, pnpm 11.1.0, rebased on `origin/main` `c2e90914b7`.

Exact steps or command run after this patch:

```text
node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.test.ts
pnpm exec oxfmt --check --threads=1 extensions/codex/src/app-server/event-projector.ts extensions/codex/src/app-server/event-projector.test.ts
git diff --check
pnpm check:changed
pnpm test:changed
pnpm build
```

Evidence after fix: `event-projector.test.ts` passes with 47 tests, including snapshot-only native tool backfill, live-plus-final dedupe, running snapshot guard, missing terminal-status guard, and non-native item completion coverage. `pnpm test:changed` passes 3 files / 190 tests.

Observed result after fix: Terminal snapshot-only Codex `commandExecution` items emit exactly one item start, item end, tool start, tool result, trajectory `tool.call`, and trajectory `tool.result`; repeated final snapshots do not duplicate live progress; running or missing-status snapshot tools do not emit terminal-looking tool results.

What was not tested: A live Telegram DM with real Telegram bot credentials and a real OpenAI/Codex model.

## Validation

```text
node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.test.ts
Test Files 1 passed; Tests 47 passed

pnpm exec oxfmt --check --threads=1 \
  extensions/codex/src/app-server/event-projector.ts \
  extensions/codex/src/app-server/event-projector.test.ts
All matched files use the correct format.

git diff --check
passed

pnpm check:changed
typecheck extensions: passed
typecheck extension tests: passed
lint extensions: 0 warnings, 0 errors
runtime sidecar loader guard: OK
runtime import cycles: 0 runtime value cycle(s)

pnpm test:changed
Test Files 3 passed; Tests 190 passed

pnpm build
check-plugin-sdk-exports: OK: All 4 required plugin-sdk exports verified.
```

## Risk

The main risk is duplicate progress if Codex sends both live item events and final snapshot items. The per-item start/result dedupe sets are meant to make final snapshots idempotent, and regression coverage now covers that path.

A second risk is synthesizing terminal-looking progress from incomplete snapshot data. The final snapshot backfill now requires an explicit terminal native status before emitting terminal item/tool/trajectory progress.

Command args still pass through the existing Codex tool-argument sanitizer. Command output is only copied into trajectory `tool.result` when trajectory capture is explicitly enabled, and the same output already existed in transcript/result-output paths.


