### PR TITLE
fix(process): clarify lane wait diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 - Agents/tools: keep the `message` tool available in embedded runs when it is explicitly allowed through `tools.alsoAllow` or runtime tool allowlists, so channel plugins with custom reply delivery can still use configured message sends. Fixes #82833. Thanks @cn1313113.
 - WhatsApp: honor forced document delivery for outbound image, GIF, and video media so `forceDocument`/`asDocument` sends preserve original media bytes instead of using compressed media payloads. (#79272) Thanks @itsuzef.
 - WhatsApp: name outbound document attachments from their MIME type when no filename is provided, so PDF and CSV sends arrive as `file.pdf` and `file.csv` instead of an extensionless `file`. Thanks @mcaxtr.
+- Process/diagnostics: report active lane blockers in lane wait warnings so `queueAhead=0` no longer hides commands waiting behind active work. Fixes #82791. (#82792) Thanks @galiniliev.
 
 ## 2026.5.17
 

--- a/src/process/command-queue.test.ts
+++ b/src/process/command-queue.test.ts
@@ -219,6 +219,55 @@ describe("command queue", () => {
     expect(calls).toEqual(["first", "second"]);
   });
 
+  it("reports queueAhead after priority insertion", async () => {
+    vi.useFakeTimers();
+    try {
+      const { task: blocker, release } = enqueueBlockedMainTask(async () => "blocker");
+      const calls: string[] = [];
+      let queuedAhead: number | null = null;
+
+      const background = enqueueCommandInLane(
+        CommandLane.Main,
+        async () => {
+          calls.push("background");
+          return "background";
+        },
+        { priority: "background" },
+      );
+      const foreground = enqueueCommandInLane(
+        CommandLane.Main,
+        async () => {
+          calls.push("foreground");
+          return "foreground";
+        },
+        {
+          priority: "foreground",
+          warnAfterMs: 5,
+          onWait: (_ms, ahead) => {
+            queuedAhead = ahead;
+          },
+        },
+      );
+
+      await vi.advanceTimersByTimeAsync(6);
+      release();
+      await expect(blocker).resolves.toBe("blocker");
+      await expect(foreground).resolves.toBe("foreground");
+      await expect(background).resolves.toBe("background");
+
+      expect(calls).toEqual(["foreground", "background"]);
+      expect(queuedAhead).toBe(0);
+      const waitWarning = diagnosticMocks.diag.warn.mock.calls.find(
+        ([message]) =>
+          typeof message === "string" && message.includes("lane wait exceeded: lane=main"),
+      );
+      expect(waitWarning?.[0]).toContain("queueAhead=0 activeAhead=1");
+      expect(waitWarning?.[0]).toContain("queueBehind=1");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("logs enqueue depth after push", async () => {
     const task = enqueueCommand(async () => {});
 
@@ -254,6 +303,11 @@ describe("command queue", () => {
       expect(typeof waited).toBe("number");
       expect(waited).toBeGreaterThanOrEqual(5);
       expect(queuedAhead).toBe(0);
+      const waitWarning = diagnosticMocks.diag.warn.mock.calls.find(
+        ([message]) =>
+          typeof message === "string" && message.includes("lane wait exceeded: lane=main"),
+      );
+      expect(waitWarning?.[0]).toContain("queueAhead=0 activeAhead=1");
     } finally {
       vi.useRealTimers();
     }
@@ -720,6 +774,64 @@ describe("command queue", () => {
       await expect(waitForActiveTasks(0)).resolves.toEqual({ drained: true });
     } finally {
       // Restore original state so subsequent tests are not affected.
+      if (original !== undefined) {
+        globalStore[key] = original;
+      } else {
+        delete globalStore[key];
+      }
+      resetCommandQueueStateForTest();
+    }
+  });
+
+  it("migrates legacy queued entries missing priority and wait diagnostics", async () => {
+    const key = Symbol.for("openclaw.commandQueueState");
+    const globalStore = globalThis as Record<PropertyKey, unknown>;
+    const original = globalStore[key];
+    let queuedAhead: number | null = null;
+    const legacyTask = new Promise<string>((resolve, reject) => {
+      globalStore[key] = {
+        gatewayDraining: false,
+        lanes: new Map([
+          [
+            CommandLane.Main,
+            {
+              lane: CommandLane.Main,
+              queue: [
+                {
+                  task: async () => "done",
+                  resolve,
+                  reject,
+                  enqueuedAt: Date.now() - 10,
+                  warnAfterMs: 0,
+                  onWait: (_ms: number, ahead: number) => {
+                    queuedAhead = ahead;
+                  },
+                },
+              ],
+              activeTaskIds: new Set(),
+              maxConcurrent: 1,
+              draining: false,
+              generation: 0,
+            },
+          ],
+        ]),
+        activeTaskWaiters: new Set(),
+        nextTaskId: 1,
+        nextQueueSequence: 1,
+      };
+    });
+
+    try {
+      resetAllLanes();
+
+      await expect(legacyTask).resolves.toBe("done");
+      expect(queuedAhead).toBe(0);
+      const waitWarning = diagnosticMocks.diag.warn.mock.calls.find(
+        ([message]) =>
+          typeof message === "string" && message.includes("lane wait exceeded: lane=main"),
+      );
+      expect(waitWarning?.[0]).toContain("queueAhead=0 activeAhead=0");
+    } finally {
       if (original !== undefined) {
         globalStore[key] = original;
       } else {

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -64,6 +64,8 @@ type QueueEntry = {
   sequence: number;
   priority: number;
   warnAfterMs: number;
+  queuedAheadAtEnqueue: number;
+  activeAheadAtEnqueue: number;
   taskTimeoutMs?: number;
   taskTimeoutProgressAtMs?: () => number | undefined;
   onWait?: (waitMs: number, queuedAhead: number) => void;
@@ -125,9 +127,16 @@ function getQueueState() {
   }
   let maxQueueSequence = state.nextQueueSequence - 1;
   for (const lane of state.lanes.values()) {
-    for (const entry of lane.queue as Array<
-      QueueEntry & { priority?: number; sequence?: number }
-    >) {
+    for (const [index, entry] of (
+      lane.queue as Array<
+        QueueEntry & {
+          activeAheadAtEnqueue?: number;
+          priority?: number;
+          queuedAheadAtEnqueue?: number;
+          sequence?: number;
+        }
+      >
+    ).entries()) {
       if (typeof entry.priority !== "number") {
         entry.priority = 0;
       }
@@ -135,6 +144,12 @@ function getQueueState() {
         entry.sequence = state.nextQueueSequence++;
       } else {
         maxQueueSequence = Math.max(maxQueueSequence, entry.sequence);
+      }
+      if (typeof entry.queuedAheadAtEnqueue !== "number") {
+        entry.queuedAheadAtEnqueue = index;
+      }
+      if (typeof entry.activeAheadAtEnqueue !== "number") {
+        entry.activeAheadAtEnqueue = lane.activeTaskIds.size;
       }
     }
   }
@@ -245,6 +260,8 @@ function enqueueLaneEntry(state: LaneState, entry: QueueEntry): void {
       queued.priority < entry.priority ||
       (queued.priority === entry.priority && queued.sequence > entry.sequence),
   );
+  entry.queuedAheadAtEnqueue = insertAt < 0 ? state.queue.length : insertAt;
+  entry.activeAheadAtEnqueue = state.activeTaskIds.size;
   if (insertAt < 0) {
     state.queue.push(entry);
     return;
@@ -325,12 +342,13 @@ function drainLane(lane: string) {
         const waitedMs = Date.now() - entry.enqueuedAt;
         if (waitedMs >= entry.warnAfterMs) {
           try {
-            entry.onWait?.(waitedMs, state.queue.length);
+            entry.onWait?.(waitedMs, entry.queuedAheadAtEnqueue);
           } catch (err) {
             diag.error(`lane onWait callback failed: lane=${lane} error="${String(err)}"`);
           }
           diag.warn(
-            `lane wait exceeded: lane=${lane} waitedMs=${waitedMs} queueAhead=${state.queue.length}`,
+            `lane wait exceeded: lane=${lane} waitedMs=${waitedMs} queueAhead=${entry.queuedAheadAtEnqueue} ` +
+              `activeAhead=${entry.activeAheadAtEnqueue} activeNow=${state.activeTaskIds.size} queueBehind=${state.queue.length}`,
           );
         }
         logLaneDequeue(lane, waitedMs, state.queue.length);
@@ -418,6 +436,8 @@ export function enqueueCommandInLane<T>(
       sequence: queueState.nextQueueSequence++,
       priority: resolveQueuePriority(opts?.priority),
       warnAfterMs,
+      queuedAheadAtEnqueue: 0,
+      activeAheadAtEnqueue: 0,
       taskTimeoutMs: normalizeTaskTimeoutMs(opts?.taskTimeoutMs),
       taskTimeoutProgressAtMs: opts?.taskTimeoutProgressAtMs,
       onWait: opts?.onWait,


### PR DESCRIPTION
## Summary

- Problem: `lane wait exceeded` warnings could show `queueAhead=0` even when the command waited behind an active lane task.
- Why it matters: operators debugging lane waits could read the diagnostic as a stale queue/scheduler mismatch instead of an active-run blocker.
- What changed: queue entries now capture queued and active work present at enqueue time, and wait warnings include `activeAhead`, `activeNow`, and `queueBehind` alongside `queueAhead`.
- What did NOT change (scope boundary): lane scheduling, concurrency, task timeout, and lane release behavior are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #82791
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

Behavior addressed: Lane wait diagnostics now identify active lane work when a queued command waited past `warnAfterMs` with no queued entries ahead, and `queueAhead` is captured after priority insertion order is known.
Real environment tested: Windows source worktree rebased on current `origin/main`, using the actual OpenClaw command queue runtime module and diagnostic logger via `node --import tsx`; focused Vitest coverage used the repo's installed Vitest dependency.
Exact steps or command run after this patch: `NO_COLOR=1 node --import tsx -e <runtime queue repro>`; `OPENCLAW_VITEST_MAX_WORKERS=1 node node_modules\vitest\vitest.mjs run src/process/command-queue.test.ts --reporter=dot --pool=threads --maxWorkers=1`; `node node_modules\oxlint\bin\oxlint src/process/command-queue.ts src/process/command-queue.test.ts`; `git diff --check HEAD~1 HEAD`.
Evidence after fix: Real runtime console output from the actual command queue module and diagnostic logger after this patch:

```shell
[diagnostic] lane wait exceeded: lane=proof-lane waitedMs=28 queueAhead=0 activeAhead=1 activeNow=0 queueBehind=1
```

Supplemental focused test output also passed:

```shell
Test Files  1 passed (1)
Tests  30 passed (30)
```

The regression coverage checks priority insertion too: a foreground task inserted ahead of a previously queued background task reports `queueAhead=0 activeAhead=1 queueBehind=1`.
Observed result after fix: The diagnostic still preserves `queueAhead=0`, but now also reports the active blocker state and remaining queued work that explain the wait: `activeAhead=1 activeNow=0 queueBehind=1`.
What was not tested: A live gateway run using the private affected scheduled/session setup was not rerun; the after-fix proof uses the real OpenClaw runtime queue/logger path with a synthetic `proof-lane` lane. Earlier `pnpm install` and `node scripts/run-vitest.mjs ...` attempts hit Windows nested-spawn/tooling issues, so the direct Vitest entrypoint was used for focused test coverage.
Before evidence (optional but encouraged): Redacted raw gateway log excerpts from the affected run:

```shell
Trace/proof:
- gateway-dev.log:5053
  "lane wait exceeded: lane=session:agent:[redacted agent]:main waitedMs=15751 queueAhead=0"
  traceId=f5026bc428cbcfcab8fdb01452f63d92 spanId=9d2cbe5c803d863c
- gateway-dev.log:30324
  "lane wait exceeded: lane=session:agent:[redacted agent]:main waitedMs=18133 queueAhead=0"
  traceId=3e2a2a2beb86136cae9c3395b422e5ef spanId=46cecc81c8f7f864
```

## Root Cause (if applicable)

- Root cause: `src/process/command-queue.ts` emitted `queueAhead` from `state.queue.length` after shifting the warned entry out of the queue, and it did not record active tasks present when the entry was enqueued.
- Missing detection / guardrail: The command queue test asserted the wait callback fired but did not assert that the warning exposed active lane blockers.
- Contributing context (if known): A lane can legitimately have no queued entries ahead while still waiting behind an already active task.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/process/command-queue.test.ts`
- Scenario the test should lock in: a second command waits past the warning threshold behind an active main-lane task and the warning includes `queueAhead=0 activeAhead=1`.
- Why this is the smallest reliable guardrail: the bug is in command queue diagnostic construction, so the command queue unit test directly exercises the seam without a live provider or channel.
- Existing test that already covers this (if any): `invokes onWait callback when a task waits past the threshold`, now extended with the warning assertion.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Lane wait warning text now includes `activeAhead`, `activeNow`, and `queueBehind` fields. Scheduling behavior is unchanged.

## Diagram (if applicable)

```text
Before:
[active lane task] -> [queued task waits] -> warning: queueAhead=0

After:
[active lane task] -> [queued task waits] -> warning: queueAhead=0 activeAhead=1
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: Node v24.15.0 local source worktree
- Model/provider: N/A
- Integration/channel (if any): command queue diagnostics
- Relevant config (redacted): N/A

### Steps

1. Start a main-lane command that remains active.
2. Enqueue a second command in the same lane with a low `warnAfterMs`.
3. Advance past the warning threshold, release the active command, and inspect the warning.

### Expected

- The warning identifies that the waited command had no queued entries ahead but did have active work ahead.

### Actual

- Before this patch, the warning only reported `queueAhead=0`; after this patch, it reports `queueAhead=0 activeAhead=1` for that scenario.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: real runtime queue/logger warning output, focused command queue regression test, targeted oxlint, and diff whitespace hygiene.
- Edge cases checked: priority insertion diagnostic counts, legacy queued-entry diagnostic defaults, and existing command queue tests for lane reset, task timeout, draining, and shared lane state still pass in the same file.
- What you did **not** verify: live gateway reproduction with the private affected session; broader `pnpm check:changed` was not run in this Codex worktree.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Consumers parsing the exact diagnostic warning string may see extra fields.
  - Mitigation: Existing field names remain present; the change only appends diagnostic context and does not alter scheduling behavior.