### PR TITLE
Improve macOS pairing approval prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Mac app: make device pairing approval sheets friendlier, with concise Mac/device copy, shortened identifiers, friendly scope labels, and Approve as the primary action.
 - Feishu/wiki: reject numeric wiki space IDs before creating Lark clients and keep numeric-looking IDs documented as quoted opaque strings, preventing JavaScript precision loss in knowledge base calls. Fixes #45301. (#82769) Thanks @hyspacex.
 - Control UI: simplify Talk settings to Voice, Model, and Sensitivity defaults, with provider, transport, exact VAD, and timing controls behind Advanced.
 - Channels/stream previews: contain rejected background draft-stream flushes so preview send failures do not surface as fatal unhandled rejections. Fixes #82712. (#82713) Thanks @coygeek.

--- a/apps/macos/Sources/OpenClaw/DevicePairingApprovalPrompter.swift
+++ b/apps/macos/Sources/OpenClaw/DevicePairingApprovalPrompter.swift
@@ -33,7 +33,7 @@ final class DevicePairingApprovalPrompter {
         let remoteIp: String?
     }
 
-    private struct PendingRequest: Codable, Equatable, Identifiable {
+    struct PendingRequest: Codable, Equatable, Identifiable {
         let requestId: String
         let deviceId: String
         let publicKey: String
@@ -115,14 +115,16 @@ final class DevicePairingApprovalPrompter {
         PairingAlertSupport.presentPairingAlert(
             request: req,
             requestId: req.requestId,
-            messageText: "Allow device to connect?",
-            informativeText: Self.describe(req),
+            messageText: Self.alertTitle(for: req),
+            informativeText: Self.alertSummary(for: req),
+            buttonTitles: PairingAlertSupport.ButtonTitles(approve: Self.approveButtonTitle(for: req)),
+            accessoryView: Self.buildAccessoryView(for: req),
             state: self.alertState,
             onResponse: self.handleAlertResponse)
     }
 
     private func handleAlertResponse(_ response: NSApplication.ModalResponse, request: PendingRequest) async {
-        var shouldRemove = response != .alertFirstButtonReturn
+        var shouldRemove = response != .alertSecondButtonReturn
         defer {
             if shouldRemove {
                 if self.queue.first == request {
@@ -144,14 +146,14 @@ final class DevicePairingApprovalPrompter {
 
         switch response {
         case .alertFirstButtonReturn:
+            _ = await self.approve(requestId: request.requestId)
+        case .alertSecondButtonReturn:
             shouldRemove = false
             if let idx = self.queue.firstIndex(of: request) {
                 self.queue.remove(at: idx)
             }
             self.queue.append(request)
             return
-        case .alertSecondButtonReturn:
-            _ = await self.approve(requestId: request.requestId)
         case .alertThirdButtonReturn:
             await self.reject(requestId: request.requestId)
         default:
@@ -233,24 +235,166 @@ final class DevicePairingApprovalPrompter {
         self.updatePendingCounts()
     }
 
-    private static func describe(_ req: PendingRequest) -> String {
-        var lines: [String] = []
-        lines.append("Device: \(req.displayName ?? req.deviceId)")
-        if let platform = req.platform {
-            lines.append("Platform: \(platform)")
+    static func alertTitle(for req: PendingRequest) -> String {
+        self.isMac(req.platform) ? "New Mac wants to connect" : "New device wants to connect"
+    }
+
+    static func alertSummary(for req: PendingRequest) -> String {
+        let subject = self.isMac(req.platform) ? "this Mac app" : "this device"
+        return "Approve \(subject) to control OpenClaw. Only approve if this is yours; you can remove it later in Settings."
+    }
+
+    static func approveButtonTitle(for req: PendingRequest) -> String {
+        self.isMac(req.platform) ? "Approve Mac" : "Approve Device"
+    }
+
+    static func buildAccessoryView(for req: PendingRequest) -> NSView {
+        let stack = NSStackView()
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 8
+        stack.edgeInsets = NSEdgeInsets(top: 2, left: 0, bottom: 0, right: 0)
+
+        stack.addArrangedSubview(self.makeValueRow(label: "Device", value: self.deviceName(for: req)))
+        if let platform = self.prettyPlatform(req.platform) {
+            stack.addArrangedSubview(self.makeValueRow(label: "Platform", value: platform))
         }
-        if let role = req.role {
-            lines.append("Role: \(role)")
+        if let role = self.prettyRole(req.role) {
+            stack.addArrangedSubview(self.makeValueRow(label: "Role", value: role))
         }
-        if let scopes = req.scopes, !scopes.isEmpty {
-            lines.append("Scopes: \(scopes.joined(separator: ", "))")
+        let accessItems = self.friendlyScopeNames(req.scopes)
+        if !accessItems.isEmpty {
+            stack.addArrangedSubview(self.makeSectionLabel("Access requested"))
+            for item in accessItems {
+                stack.addArrangedSubview(self.makeBullet(item))
+            }
         }
-        if let remoteIp = req.remoteIp {
-            lines.append("IP: \(remoteIp)")
+        stack.addArrangedSubview(self.makeDetailLine(req))
+
+        let fitting = stack.fittingSize
+        stack.frame = NSRect(x: 0, y: 0, width: 420, height: fitting.height)
+        return stack
+    }
+
+    static func deviceName(for req: PendingRequest) -> String {
+        let trimmedName = req.displayName?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let trimmedName, !trimmedName.isEmpty, trimmedName != req.deviceId {
+            return trimmedName
+        }
+        return self.isMac(req.platform) ? "OpenClaw Mac app" : "New device"
+    }
+
+    static func prettyPlatform(_ raw: String?) -> String? {
+        let platform = raw?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let platform, !platform.isEmpty else { return nil }
+        switch platform.lowercased() {
+        case "macintel", "x86_64-apple-darwin":
+            return "Mac (Intel)"
+        case "macarm", "macarm64", "arm64-apple-darwin", "aarch64-apple-darwin":
+            return "Mac (Apple silicon)"
+        case "darwin":
+            return "Mac"
+        default:
+            if platform.lowercased().contains("mac") {
+                return "Mac"
+            }
+            return platform
+        }
+    }
+
+    static func prettyRole(_ raw: String?) -> String? {
+        let role = raw?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let role, !role.isEmpty else { return nil }
+        return role == "operator" ? "Operator" : role
+    }
+
+    static func friendlyScopeNames(_ scopes: [String]?) -> [String] {
+        guard let scopes else { return [] }
+        var seen = Set<String>()
+        return scopes.compactMap { scope in
+            let normalized = scope.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !normalized.isEmpty, seen.insert(normalized).inserted else { return nil }
+            switch normalized {
+            case "operator.admin":
+                return "Admin access"
+            case "operator.read":
+                return "Read OpenClaw data"
+            case "operator.write":
+                return "Send messages and make changes"
+            case "operator.approvals":
+                return "Manage approvals"
+            case "operator.pairing":
+                return "Pair and repair devices"
+            case "operator.talk.secrets":
+                return "Use Talk credentials"
+            default:
+                return normalized
+            }
+        }
+    }
+
+    static func shortIdentifier(_ id: String) -> String {
+        let trimmed = id.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count > 20 else { return trimmed }
+        return "\(trimmed.prefix(8))...\(trimmed.suffix(7))"
+    }
+
+    private static func isMac(_ platform: String?) -> Bool {
+        guard let platform else { return false }
+        let lower = platform.lowercased()
+        return lower.contains("mac") || lower.contains("darwin")
+    }
+
+    private static func makeValueRow(label: String, value: String) -> NSView {
+        let row = NSStackView()
+        row.orientation = .horizontal
+        row.alignment = .firstBaseline
+        row.spacing = 8
+
+        let labelField = self.makeLabel("\(label):", font: .systemFont(ofSize: 12, weight: .semibold))
+        labelField.textColor = .secondaryLabelColor
+        labelField.setContentHuggingPriority(.required, for: .horizontal)
+        let valueField = self.makeLabel(value, font: .systemFont(ofSize: 12, weight: .regular))
+        valueField.maximumNumberOfLines = 2
+
+        row.addArrangedSubview(labelField)
+        row.addArrangedSubview(valueField)
+        return row
+    }
+
+    private static func makeSectionLabel(_ text: String) -> NSTextField {
+        let label = self.makeLabel(text, font: .systemFont(ofSize: 12, weight: .semibold))
+        label.textColor = .secondaryLabelColor
+        return label
+    }
+
+    private static func makeBullet(_ text: String) -> NSTextField {
+        let label = self.makeLabel("• \(text)", font: .systemFont(ofSize: 12, weight: .regular))
+        label.maximumNumberOfLines = 2
+        return label
+    }
+
+    private static func makeDetailLine(_ req: PendingRequest) -> NSTextField {
+        var parts = ["ID \(self.shortIdentifier(req.deviceId))"]
+        if let remoteIp = req.remoteIp?.trimmingCharacters(in: .whitespacesAndNewlines), !remoteIp.isEmpty {
+            parts.append("IP \(remoteIp.replacingOccurrences(of: "::ffff:", with: ""))")
         }
         if req.isRepair == true {
-            lines.append("Repair: yes")
+            parts.append("repair request")
         }
-        return lines.joined(separator: "\n")
+        let label = self.makeLabel(
+            parts.joined(separator: " · "),
+            font: .monospacedSystemFont(ofSize: 11, weight: .regular))
+        label.textColor = .tertiaryLabelColor
+        label.maximumNumberOfLines = 2
+        return label
+    }
+
+    private static func makeLabel(_ text: String, font: NSFont) -> NSTextField {
+        let label = NSTextField(labelWithString: text)
+        label.font = font
+        label.lineBreakMode = .byWordWrapping
+        label.textColor = .labelColor
+        return label
     }
 }

--- a/apps/macos/Sources/OpenClaw/NodePairingApprovalPrompter.swift
+++ b/apps/macos/Sources/OpenClaw/NodePairingApprovalPrompter.swift
@@ -280,6 +280,7 @@ final class NodePairingApprovalPrompter {
             requestId: req.requestId,
             messageText: "Allow node to connect?",
             informativeText: Self.describe(req),
+            buttonTitles: PairingAlertSupport.ButtonTitles(approve: "Approve Node"),
             state: self.alertState,
             onResponse: self.handleAlertResponse)
     }
@@ -307,11 +308,11 @@ final class NodePairingApprovalPrompter {
 
         switch response {
         case .alertFirstButtonReturn:
-            // Later: leave as pending (CLI can approve/reject). Request will expire on the gateway TTL.
-            return
-        case .alertSecondButtonReturn:
             _ = await self.approve(requestId: request.requestId)
             await self.notify(resolution: .approved, request: request, via: "local")
+        case .alertSecondButtonReturn:
+            // Later: leave as pending (CLI can approve/reject). Request will expire on the gateway TTL.
+            return
         case .alertThirdButtonReturn:
             await self.reject(requestId: request.requestId)
             await self.notify(resolution: .rejected, request: request, via: "local")

--- a/apps/macos/Sources/OpenClaw/PairingAlertSupport.swift
+++ b/apps/macos/Sources/OpenClaw/PairingAlertSupport.swift
@@ -26,6 +26,18 @@ enum PairingAlertSupport {
         case rejected
     }
 
+    struct ButtonTitles {
+        var approve: String = "Approve"
+        var postpone: String = "Not Now"
+        var reject: String = "Reject"
+
+        init(approve: String = "Approve", postpone: String = "Not Now", reject: String = "Reject") {
+            self.approve = approve
+            self.postpone = postpone
+            self.reject = reject
+        }
+    }
+
     struct PairingResolvedEvent: Codable {
         let requestId: String
         let decision: String
@@ -71,14 +83,17 @@ enum PairingAlertSupport {
     static func configureDefaultPairingAlert(
         _ alert: NSAlert,
         messageText: String,
-        informativeText: String)
+        informativeText: String,
+        buttonTitles: ButtonTitles = ButtonTitles(),
+        accessoryView: NSView? = nil)
     {
-        alert.alertStyle = .warning
+        alert.alertStyle = .informational
         alert.messageText = messageText
         alert.informativeText = informativeText
-        alert.addButton(withTitle: "Later")
-        alert.addButton(withTitle: "Approve")
-        alert.addButton(withTitle: "Reject")
+        alert.accessoryView = accessoryView
+        alert.addButton(withTitle: buttonTitles.approve)
+        alert.addButton(withTitle: buttonTitles.postpone)
+        alert.addButton(withTitle: buttonTitles.reject)
         if #available(macOS 11.0, *), alert.buttons.indices.contains(2) {
             alert.buttons[2].hasDestructiveAction = true
         }
@@ -133,13 +148,20 @@ enum PairingAlertSupport {
     static func beginPairingAlert(
         messageText: String,
         informativeText: String,
+        buttonTitles: ButtonTitles = ButtonTitles(),
+        accessoryView: NSView? = nil,
         alertHostWindow: inout NSWindow?,
         completion: @escaping (NSApplication.ModalResponse, NSWindow) -> Void) -> NSAlert
     {
         NSApp.activate(ignoringOtherApps: true)
 
         let alert = NSAlert()
-        self.configureDefaultPairingAlert(alert, messageText: messageText, informativeText: informativeText)
+        self.configureDefaultPairingAlert(
+            alert,
+            messageText: messageText,
+            informativeText: informativeText,
+            buttonTitles: buttonTitles,
+            accessoryView: accessoryView)
 
         let hostWindow = self.requireAlertHostWindow(alertHostWindow: &alertHostWindow)
         self.beginCenteredSheet(alert: alert, hostWindow: hostWindow) { response in
@@ -152,6 +174,8 @@ enum PairingAlertSupport {
         requestId: String,
         messageText: String,
         informativeText: String,
+        buttonTitles: ButtonTitles = ButtonTitles(),
+        accessoryView: NSView? = nil,
         activeAlert: inout NSAlert?,
         activeRequestId: inout String?,
         alertHostWindow: inout NSWindow?,
@@ -161,6 +185,8 @@ enum PairingAlertSupport {
         activeAlert = self.beginPairingAlert(
             messageText: messageText,
             informativeText: informativeText,
+            buttonTitles: buttonTitles,
+            accessoryView: accessoryView,
             alertHostWindow: &alertHostWindow,
             completion: completion)
     }
@@ -170,6 +196,8 @@ enum PairingAlertSupport {
         requestId: String,
         messageText: String,
         informativeText: String,
+        buttonTitles: ButtonTitles = ButtonTitles(),
+        accessoryView: NSView? = nil,
         state: PairingAlertState,
         onResponse: @escaping @MainActor (NSApplication.ModalResponse, Request) async -> Void)
     {
@@ -177,6 +205,8 @@ enum PairingAlertSupport {
             requestId: requestId,
             messageText: messageText,
             informativeText: informativeText,
+            buttonTitles: buttonTitles,
+            accessoryView: accessoryView,
             activeAlert: &state.activeAlert,
             activeRequestId: &state.activeRequestId,
             alertHostWindow: &state.alertHostWindow,

--- a/apps/macos/Tests/OpenClawIPCTests/NodePairingApprovalPrompterTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/NodePairingApprovalPrompterTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import AppKit
 @testable import OpenClaw
 
 @Suite(.serialized)
@@ -6,5 +7,61 @@ import Testing
 struct NodePairingApprovalPrompterTests {
     @Test func `node pairing approval prompter exercises`() async {
         await NodePairingApprovalPrompter.exerciseForTesting()
+    }
+
+    @Test func `pairing alert makes approve the primary action`() {
+        let alert = NSAlert()
+        PairingAlertSupport.configureDefaultPairingAlert(
+            alert,
+            messageText: "New Mac wants to connect",
+            informativeText: "Approve this Mac app to control OpenClaw.",
+            buttonTitles: PairingAlertSupport.ButtonTitles(approve: "Approve Mac"))
+
+        #expect(alert.alertStyle == .informational)
+        #expect(alert.buttons.map(\.title) == ["Approve Mac", "Not Now", "Reject"])
+        if #available(macOS 11.0, *) {
+            #expect(alert.buttons[2].hasDestructiveAction)
+        }
+    }
+
+    @Test func `device pairing copy summarizes Mac requests`() {
+        let request = DevicePairingApprovalPrompter.PendingRequest(
+            requestId: "req-1",
+            deviceId: "4a865684dbfa7b7937bd333813476ca88b672c2d02ad08fc52b80d88af4e82bd",
+            publicKey: "pub",
+            displayName: nil,
+            platform: "MacIntel",
+            clientId: nil,
+            clientMode: nil,
+            role: "operator",
+            scopes: [
+                "operator.admin",
+                "operator.read",
+                "operator.write",
+                "operator.approvals",
+                "operator.pairing",
+            ],
+            remoteIp: "192.0.2.10",
+            silent: nil,
+            isRepair: nil,
+            ts: 1)
+
+        #expect(DevicePairingApprovalPrompter.alertTitle(for: request) == "New Mac wants to connect")
+        #expect(DevicePairingApprovalPrompter.approveButtonTitle(for: request) == "Approve Mac")
+        #expect(DevicePairingApprovalPrompter.deviceName(for: request) == "OpenClaw Mac app")
+        #expect(DevicePairingApprovalPrompter.prettyPlatform(request.platform) == "Mac (Intel)")
+        #expect(DevicePairingApprovalPrompter.shortIdentifier(request.deviceId) == "4a865684...f4e82bd")
+        #expect(DevicePairingApprovalPrompter.friendlyScopeNames(request.scopes) == [
+            "Admin access",
+            "Read OpenClaw data",
+            "Send messages and make changes",
+            "Manage approvals",
+            "Pair and repair devices",
+        ])
+        #expect(!DevicePairingApprovalPrompter.alertSummary(for: request).contains(request.deviceId))
+
+        let accessory = DevicePairingApprovalPrompter.buildAccessoryView(for: request)
+        #expect(accessory.frame.width >= 380)
+        #expect(accessory.frame.height > 80)
     }
 }


### PR DESCRIPTION
## Summary
- Make the macOS device pairing sheet use friendly Mac/device copy instead of raw IDs and scope dumps.
- Put Approve first as the primary action, rename postpone to Not Now, and keep Reject destructive.
- Add focused Swift coverage for button ordering and Mac pairing copy/accessory layout.

## Verification
- `swiftformat --lint --config config/swiftformat apps/macos/Sources/OpenClaw/DevicePairingApprovalPrompter.swift apps/macos/Sources/OpenClaw/NodePairingApprovalPrompter.swift apps/macos/Sources/OpenClaw/PairingAlertSupport.swift`
- `git diff --check`
- `cd apps/macos && swift test --filter NodePairingApprovalPrompterTests`
- `env CLANG_MODULE_CACHE_PATH=$PWD/.clang-module-cache SWIFTPM_CACHE_PATH=$PWD/.swiftpm-cache swift test --disable-sandbox --package-path apps/macos --filter NodePairingApprovalPrompterTests`
- `/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --mode local`

## Real behavior proof
Behavior addressed: Mac app device pairing approval prompts were hard to read because they showed a full opaque device id and raw scopes, with Later as the default primary action.

Real environment tested: Local macOS Swift package test target for the macOS app on this checkout. Maintainer override applies because this is native AppKit alert configuration/copy wiring; no live pairing screenshot was captured.

Exact steps or command run after this patch: `swift test --filter NodePairingApprovalPrompterTests` from `apps/macos`, plus SwiftFormat lint and Codex review from the repo checkout.

Evidence after fix: Terminal output from the local macOS Swift package run showed all focused pairing alert tests passing after the copy/button changes:

```text
Test Suite 'Selected tests' passed.
Executed 3 tests, with 0 failures in NodePairingApprovalPrompterTests.
```

Observed result after fix: The focused test asserts `Approve Mac` is the first/default alert button, `Not Now` is secondary, `Reject` remains destructive, `MacIntel` renders as `Mac (Intel)`, the long device id is shortened, and operator scopes render as friendly labels. Codex review reported no accepted/actionable findings.

What was not tested: A live gateway pairing request shown through the running macOS app UI was not manually clicked; the native alert configuration and copy path are covered by focused Swift tests.
