### PR TITLE
[AI-assisted] fix(cron): respect best-effort subagent delivery

### DIFF
--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -347,6 +347,56 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(deliverOutboundPayloads).not.toHaveBeenCalled();
   });
 
+  it("best-effort delivery skips active descendant waits and sends the cron result", async () => {
+    vi.mocked(countActiveDescendantRuns).mockReturnValue(2);
+    vi.mocked(waitForDescendantSubagentSummary).mockResolvedValue(undefined);
+    vi.mocked(readDescendantSubagentFallbackReply).mockResolvedValue(undefined);
+
+    const params = makeBaseParams({
+      synthesizedText: "Parent cron summary is ready.",
+      deliveryBestEffort: true,
+    });
+    const state = await dispatchCronDelivery(params);
+
+    expect(waitForDescendantSubagentSummary).not.toHaveBeenCalled();
+    expect(state.deliveryAttempted).toBe(true);
+    expect(state.delivered).toBe(true);
+    expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+    expectDeliveryCall(0, {
+      channel: "telegram",
+      to: "123456",
+      payloads: [{ text: "Parent cron summary is ready." }],
+      skipQueue: true,
+    });
+  });
+
+  it("best-effort delivery still suppresses stale interim text from active descendants", async () => {
+    vi.mocked(countActiveDescendantRuns).mockReturnValue(2);
+    vi.mocked(waitForDescendantSubagentSummary).mockResolvedValue(undefined);
+    vi.mocked(readDescendantSubagentFallbackReply).mockResolvedValue(undefined);
+    vi.mocked(isLikelyInterimCronMessage).mockReturnValue(true);
+
+    const params = makeBaseParams({
+      synthesizedText: "on it, pulling everything together",
+      deliveryBestEffort: true,
+    });
+    const state = await dispatchCronDelivery(params);
+
+    expect(waitForDescendantSubagentSummary).not.toHaveBeenCalled();
+    expect(state.deliveryAttempted).toBe(true);
+    expect(deliverOutboundPayloads).not.toHaveBeenCalled();
+    expect(
+      shouldEnqueueCronMainSummary({
+        summaryText: "on it, pulling everything together",
+        deliveryRequested: true,
+        delivered: state.delivered,
+        deliveryAttempted: state.deliveryAttempted,
+        suppressMainSummary: false,
+        isCronSystemEvent: () => true,
+      }),
+    ).toBe(false);
+  });
+
   it("early return (stale interim suppression) sets deliveryAttempted=true so timer skips enqueueSystemEvent", async () => {
     // First countActiveDescendantRuns call returns >0 (had descendants), second returns 0
     vi.mocked(countActiveDescendantRuns)

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -1113,8 +1113,10 @@ export async function dispatchCronDelivery(
     );
     const shouldCheckCompletedDescendants =
       activeSubagentRuns === 0 && isLikelyInterimCronMessage(initialSynthesizedText);
+    const shouldWaitForDescendantSummary =
+      !params.deliveryBestEffort && (activeSubagentRuns > 0 || expectedSubagentFollowup);
     const needsSubagentFollowupRuntime =
-      shouldCheckCompletedDescendants || activeSubagentRuns > 0 || expectedSubagentFollowup;
+      shouldCheckCompletedDescendants || shouldWaitForDescendantSummary;
     const subagentFollowupRuntime = needsSubagentFollowupRuntime
       ? await loadSubagentFollowupRuntime()
       : undefined;
@@ -1130,7 +1132,7 @@ export async function dispatchCronDelivery(
         })
       : undefined;
     const hadDescendants = activeSubagentRuns > 0 || Boolean(completedDescendantReply);
-    if (activeSubagentRuns > 0 || expectedSubagentFollowup) {
+    if (shouldWaitForDescendantSummary) {
       let finalReply = await subagentFollowupRuntime?.waitForDescendantSubagentSummary({
         sessionKey: subagentFollowupSessionKey,
         initialReply: initialSynthesizedText,
@@ -1160,7 +1162,7 @@ export async function dispatchCronDelivery(
       synthesizedText = completedDescendantReply;
       deliveryPayloads = [{ text: completedDescendantReply }];
     }
-    if (activeSubagentRuns > 0) {
+    if (!params.deliveryBestEffort && activeSubagentRuns > 0) {
       // Parent orchestration is still in progress; avoid announcing a partial
       // update to the main requester. Mark deliveryAttempted so the timer does
       // not fire a redundant enqueueSystemEvent fallback (double-announce bug).


### PR DESCRIPTION
## Summary

- Problem: isolated cron jobs with `delivery.bestEffort: true` could still wait on active fire-and-forget subagents and suppress their own delivery.
- Why it matters: best-effort cron delivery should return the parent cron result without spending the full timeout budget on descendant follow-up that is not required for delivery.
- What changed: descendant waiting and active-descendant delivery suppression now apply only to required delivery, while completed-descendant/stale-interim checks remain in place.
- What did NOT change (scope boundary): required cron delivery still waits for descendant summaries, and stale interim text is still suppressed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #44428
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: best-effort isolated cron delivery should not block on active fire-and-forget subagents before sending the parent cron result.
- Real environment tested: disposable Ubuntu testserver checkout of this PR branch, using the real cron delivery dispatch path, real in-process subagent registry state, and a local proof outbound adapter with no external credentials.
- Exact steps or command run after this patch:

```text
node --import tsx proof-cron-besteffort.mjs
```

- Evidence after fix:

```json
{
  "proof": "cron-best-effort-active-descendant",
  "activeBefore": 1,
  "timeoutMs": 5000,
  "durationMs": 989,
  "delivered": true,
  "deliveryAttempted": true,
  "sentCount": 1,
  "sent": [
    {
      "channel": "proof-channel",
      "to": "redacted-target",
      "text": "Parent cron summary is ready.",
      "kind": "text"
    }
  ],
  "resultStatus": null,
  "usedExternalCredentials": false,
  "usedRealNetworkChannel": false
}
```

- Observed result after fix: when `deliveryBestEffort` is true and active descendants exist, the runtime dispatch completes well under the timeout and the parent cron payload is delivered; the focused regression test also verifies the descendant wait helper is not called.
- What was not tested: live cron daemon run with a real external channel credential; the proof used a local outbound adapter to avoid secrets and network delivery.
- Before evidence (optional but encouraged): current main enters the descendant wait path without a `deliveryBestEffort` guard, as documented in #44428 and the linked ClawSweeper source review.

## Root Cause (if applicable)

- Root cause: cron delivery treated active descendant runs as a required wait/suppression condition even when the job requested best-effort delivery.
- Missing detection / guardrail: existing tests covered active-descendant suppression and best-effort delivery separately, but not the combined `deliveryBestEffort: true` plus active descendants case.
- Contributing context (if known): descendant follow-up can consume the cron timeout budget, which made fire-and-forget subagents look like a blocking delivery dependency.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts`
- Scenario the test should lock in: best-effort cron delivery skips active descendant waits and still delivers the parent result; stale interim text remains suppressed.
- Why this is the smallest reliable guardrail: it covers the owner-local dispatch decision without requiring live channel credentials or a full cron daemon run.
- Existing test that already covers this (if any): none covered best-effort delivery with active descendant runs.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Best-effort isolated cron runs with fire-and-forget subagents can deliver the parent cron result without waiting for descendant follow-up to drain.

## Diagram (if applicable)

```text
Before:
best-effort cron result + active subagent -> descendant wait -> timeout/suppressed delivery

After:
best-effort cron result + active subagent -> skip descendant wait -> deliver parent cron result

Required delivery:
active subagent -> descendant wait/suppression remains unchanged
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows local checkout plus disposable Ubuntu testserver proof
- Runtime/container: Node 24 via bundled Codex runtime
- Model/provider: N/A
- Integration/channel (if any): cron delivery dispatch path with local proof outbound adapter
- Relevant config (redacted): `deliveryBestEffort: true`, active descendant count > 0

### Steps

1. Set up a cron delivery dispatch state with `deliveryBestEffort: true`.
2. Make `countActiveDescendantRuns()` report active descendants.
3. Dispatch a parent cron payload.

### Expected

- Best-effort delivery skips descendant waiting and sends the parent cron payload.
- Stale interim text is still suppressed instead of being delivered as a placeholder.

### Actual

- Matches expected after this patch.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `node scripts/run-vitest.mjs run src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts` -> 1 file / 64 tests passed
  - `oxfmt --check --threads=1 src/cron/isolated-agent/delivery-dispatch.ts src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts` -> passed
  - `git diff --check` -> passed
  - `node scripts/check-changed.mjs` -> passed
  - disposable testserver runtime proof: active descendant count 1, `durationMs: 989` under a 5000ms timeout, `sentCount: 1`, no external credentials
- Edge cases checked: required delivery still uses descendant wait/suppression; best-effort stale interim text is still suppressed.
- What you did **not** verify: live cron daemon delivery with a real external channel credential.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: best-effort cron delivery could surface a stale parent placeholder while descendants are active.
  - Mitigation: completed-descendant/stale-interim detection remains active for best-effort, and a regression test locks that behavior in.
