### PR TITLE
fix(tools): sanitize LLM sentinel tokens in bash exec and web-fetch URL inputs

### DIFF
--- a/extensions/gemma-memory-intercept/index.test.ts
+++ b/extensions/gemma-memory-intercept/index.test.ts
@@ -1,0 +1,186 @@
+// extensions/gemma-memory-intercept/index.test.ts
+//
+// Pure-function unit tests for the gemma-memory-intercept plugin.
+// Validates the natural-language detector + the forbidden-call detector
+// against the recall.sh pattern set documented in
+// settings/projects/gemma-memory.md (P2.25 D24.1 + D24.2).
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { __test__ } from "./index.ts";
+
+const { looksLikeNaturalMemoRequest, detectForbiddenCall, buildBlockReason } = __test__;
+
+// ---------------------------------------------------------------------------
+// looksLikeNaturalMemoRequest — POSITIVE cases (must return true)
+// ---------------------------------------------------------------------------
+
+const POSITIVE: Array<[string, string]> = [
+  [
+    "지난주에 그 사람 만나기로 한 계획 어떻게 됐어?",
+    "T1: 지난주(time) + 어떻게 됐어(intent) + 한글 명사",
+  ],
+  ["오로라랑 정한 계획 다시 보여줘", "T1 alt: 보여줘(intent) + 한글 명사"],
+  ["방이동 갔던 날 메모 다시 보여줘", "T2: 보여줘 + 명사"],
+  ["오늘 점심 김치찌개 먹었어, 적어둬", "T3: 오늘(time) + 적어둬(intent) + 명사"],
+  ["어제 적은 거 지워줘", "T4: 어제(time) + 지워줘(intent) + 명사"],
+  ["엄마한테 내일 병원 같이 가자고 했어. 기록해둬", "T5: 내일(time) + 기록해둬(intent) + 명사"],
+  [
+    "그때 정해둔 옵션 가격이 얼마였더라",
+    "READ-tense recall: 그때(time) + 얼마였더라(intent) + 명사",
+  ],
+  ["엄마 전화번호 알려줘", "person + 알려줘(intent) + 명사"],
+  ["방이동 어디에 있더라", "place + SEARCH intent"],
+  ["지난주에 만난 사람 누구였지", "지난주(time) + 명사 (intent 약하지만 time + noun으로 통과)"],
+];
+
+for (const [text, label] of POSITIVE) {
+  test(`looksLikeNaturalMemoRequest POSITIVE: ${label}`, () => {
+    assert.equal(
+      looksLikeNaturalMemoRequest(text),
+      true,
+      `expected true for: ${JSON.stringify(text)}`,
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// looksLikeNaturalMemoRequest — NEGATIVE cases (must return false)
+// ---------------------------------------------------------------------------
+
+const NEGATIVE: Array<[string, string]> = [
+  ["", "empty"],
+  ["응", "too short (1 char)"],
+  ["응 알겠어", "no intent or time keywords + short"],
+  ["/export-context", "slash command"],
+  ["/help", "slash command"],
+  ["bash scripts/recall.sh 어제 메모 보여줘", "already routed to recall.sh — let it through"],
+  ["1234567890", "no Hangul"],
+  ["hello world", "no Hangul"],
+  ["The weather is nice today", "English only, no Hangul"],
+  ["고마워", "noun-only, no intent or time"],
+  [
+    "오늘 날씨가 좋네",
+    "오늘 + noun BUT no intent/recall verb… actually 오늘 is TIME so this should be TRUE — see borderline",
+  ],
+  ["123", "too short"],
+];
+
+// Remove the borderline "오늘 날씨가 좋네" — it actually IS positive by design
+// (time + noun). The recall plugin would catch this and try to route to recall.sh.
+// If false-positive becomes a problem we can tighten in next iteration.
+const NEGATIVE_FILTERED = NEGATIVE.filter(([text]) => text !== "오늘 날씨가 좋네");
+
+for (const [text, label] of NEGATIVE_FILTERED) {
+  test(`looksLikeNaturalMemoRequest NEGATIVE: ${label}`, () => {
+    assert.equal(
+      looksLikeNaturalMemoRequest(text),
+      false,
+      `expected false for: ${JSON.stringify(text)}`,
+    );
+  });
+}
+
+// Track this borderline case explicitly:
+test("looksLikeNaturalMemoRequest BORDERLINE: time + noun without intent verb still matches", () => {
+  assert.equal(
+    looksLikeNaturalMemoRequest("오늘 날씨가 좋네"),
+    true,
+    "design: time + noun is enough to trigger; intent verb optional",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// detectForbiddenCall — must return non-null for forbidden patterns
+// ---------------------------------------------------------------------------
+
+const FORBIDDEN: Array<[string, Record<string, unknown>, string]> = [
+  ["read", { path: "/home/lisyoen/projects/openclaw/skills/memory/SKILL.md" }, "SKILL.md path"],
+  ["read", { path: "/some/where/skill-creator/SKILL.md" }, "SKILL.md nested path"],
+  ["read", { path: "MEMORY-SEARCH/skill.md" }, "case-insensitive SKILL.md"],
+  [
+    "read",
+    { path: "/home/lisyoen/.openclaw/agents/gemma/workspace/SOUL.md" },
+    "workspace profile SOUL.md",
+  ],
+  ["read", { path: "MEMORY.md" }, "workspace profile MEMORY.md (already in prompt)"],
+  ["read", { path: "TOOLS.md" }, "workspace profile TOOLS.md"],
+  ["read", { path: "BOOTSTRAP.md" }, "workspace profile BOOTSTRAP.md"],
+  ["read", { file_path: "AGENTS.md" }, "workspace profile via file_path alias"],
+  ["exec", { command: "find ~/workspace -name '*.md'" }, "exec find"],
+  ["exec", { command: "ind ~/workspace" }, "exec ind (find typo)"],
+  ["exec", { command: "grep -r aurora ~/workspace" }, "exec grep -r"],
+  ["exec", { command: "cat ~/workspace/MEMORY.md" }, "exec cat workspace md"],
+  ["exec", { command: "ls -R ~/workspace" }, "exec ls -R"],
+  ["exec", { command: "bash scripts/memory.sh search aurora" }, "direct memory.sh"],
+  ["exec", { command: "bash scripts/person.sh new aurora" }, "direct person.sh"],
+  ["bash", { command: "find . -type f" }, "bash variant: find"],
+];
+
+for (const [tool, params, label] of FORBIDDEN) {
+  test(`detectForbiddenCall FORBIDDEN: ${label}`, () => {
+    const r = detectForbiddenCall(tool, params);
+    assert.notEqual(
+      r,
+      null,
+      `expected non-null for tool=${tool} params=${JSON.stringify(params)}, got null`,
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// detectForbiddenCall — must return null for allowed patterns
+// ---------------------------------------------------------------------------
+
+const ALLOWED: Array<[string, Record<string, unknown>, string]> = [
+  ["exec", { command: 'bash scripts/recall.sh "어제 메모 보여줘"' }, "recall.sh — allow"],
+  [
+    "exec",
+    {
+      command:
+        'bash /home/lisyoen/.openclaw/agents/gemma/workspace/scripts/recall.sh "오로라 계획"',
+    },
+    "recall.sh abs path",
+  ],
+  ["exec", { command: "date +%Y-%m-%d" }, "harmless date call"],
+  ["exec", { command: "echo hello" }, "echo"],
+  ["read", { path: "/home/lisyoen/some/data.json" }, "read non-md non-skill"],
+  ["read", { path: "/etc/hosts" }, "read unrelated file"],
+  ["write", { path: "/tmp/x.md", content: "..." }, "write tool — out of scope"],
+  ["read", { path: "" }, "read with empty path"],
+  ["exec", {} as Record<string, unknown>, "exec with empty params"],
+];
+
+for (const [tool, params, label] of ALLOWED) {
+  test(`detectForbiddenCall ALLOWED: ${label}`, () => {
+    const r = detectForbiddenCall(tool, params);
+    assert.equal(
+      r,
+      null,
+      `expected null for tool=${tool} params=${JSON.stringify(params)}, got: ${r}`,
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// buildBlockReason — sanity
+// ---------------------------------------------------------------------------
+
+test("buildBlockReason includes original call and user text sample", () => {
+  const reason = buildBlockReason(
+    `read({path:"foo/SKILL.md"})`,
+    "지난주에 오로라랑 정한 계획 다시 보여줘",
+  );
+  assert.match(reason, /P2\.25c/, "should mention P2.25c");
+  assert.match(reason, /scripts\/recall\.sh/, "should suggest recall.sh");
+  assert.match(reason, /지난주에 오로라랑 정한 계획/, "should echo user text sample");
+  assert.match(reason, /read\(\{path:"foo\/SKILL\.md"\}\)/, "should name forbidden call");
+});
+
+test("buildBlockReason embeds escaped double quotes from user text", () => {
+  const reason = buildBlockReason("read SKILL.md", '메모에 "방이동" 적어둬');
+  // The inner " in the user text should appear escaped as \\" inside the sample.
+  assert.match(reason, /방이동/);
+  // Escaped form must be present (the sample is wrapped in escaped quotes).
+  assert.ok(reason.includes('\\"방이동\\"'), 'should escape inner quotes as \\"');
+});

--- a/extensions/gemma-memory-intercept/index.ts
+++ b/extensions/gemma-memory-intercept/index.ts
@@ -261,30 +261,24 @@ export default (api: OpenClawPluginApi) => {
   logger.info(`[gemma-memory-intercept] plugin registered; api keys=${Object.keys(api).join(",")}`);
 
   api.on("message_received", (event, ctx) => {
-    // P2.25c route 1 fix: PluginHookMessageContext is { channelId, accountId?, conversationId? }
-    // — NO agentId field. Old `ctx.agentId !== "gemma"` always returned (undefined).
-    // Now filter by accountId="gemma" (OpenClaw telegram account name for @lisyoen_gemma_bot)
-    // + channelId="telegram".
-    const accountId = (ctx as { accountId?: string }).accountId;
-    const channelId = (ctx as { channelId?: string }).channelId;
-    const conversationIdRaw = (ctx as { conversationId?: string }).conversationId;
-    // P2.25c route 1 fix (2026-05-24 20:30): ctx.conversationId from telegram is
-    // "telegram:56682682" or "telegram:group:-1003821022499" (channel-prefixed).
-    // sessionKeyToConversationId() in before_tool_call strips down to just
-    // "56682682" / "-1003821022499". Normalize both sides by stripping the
-    // leading channel prefix here.
-    const conversationId =
-      typeof conversationIdRaw === "string"
-        ? conversationIdRaw.replace(/^[a-z][a-z0-9_-]*:/i, "").replace(/^group:/, "")
-        : undefined;
-    if (accountId !== "gemma" || channelId !== "telegram") return;
+    // P2.25c route 2 fix (2026-05-24 21:10): PluginHookMessageContext now carries
+    // agentId/sessionKey/sessionId/runId (dispatcher populates them via
+    // toPluginMessageContext + deriveInboundMessageHookContext overrides). The
+    // route-1 accountId-based workaround and channel-prefix strip are removed in
+    // favor of ctx.agentId direct check + sessionKey-derived conversationId
+    // (matches before_tool_call's source for cache key alignment).
+    const agentId = ctx.agentId;
+    const sessionKey = ctx.sessionKey;
+    if (agentId !== "gemma") return;
+    const conversationId = sessionKeyToConversationId(sessionKey);
     counters.messagesSeen++;
 
     const text = extractUserText(event);
     const matched = text ? looksLikeNaturalMemoRequest(text) : false;
     logger.info(
-      `[gemma-memory-intercept] message_received account=${accountId} channel=${channelId} ` +
-        `convId=${conversationId ?? ""} textLen=${text?.length ?? 0} matched=${matched} ` +
+      `[gemma-memory-intercept] message_received agent=${agentId} ` +
+        `sessionKey=${sessionKey ?? ""} convId=${conversationId ?? ""} ` +
+        `textLen=${text?.length ?? 0} matched=${matched} ` +
         `sample="${truncate(text || "", 60).replace(/"/g, '\\"')}"`,
     );
     if (!text) return;
@@ -292,9 +286,7 @@ export default (api: OpenClawPluginApi) => {
 
     counters.naturalMemoMatched++;
 
-    // P2.25c route 1 fix: cache key now (agentId, conversationId).
-    // agentId for telegram:gemma account is always "gemma" (see openclaw.json).
-    const key = cacheKey("gemma", conversationId);
+    const key = cacheKey(agentId, conversationId);
     userTextCache.set(key, { text, firstToolCallSeen: false, ts: Date.now() });
     pruneCache();
 

--- a/extensions/gemma-memory-intercept/index.ts
+++ b/extensions/gemma-memory-intercept/index.ts
@@ -1,0 +1,367 @@
+// extensions/gemma-memory-intercept/index.ts
+//
+// gemma-memory P2.25c option F: plugin-level toolCall intercept.
+//
+// When a user sends a natural-language memo / recall / journal request to
+// agentId="gemma" via Telegram (DM or group), the model has a strong prior
+// from its training data to start with `read({path:"*SKILL.md"})` or
+// `exec({command:"find ..."})` even though the workspace TOOLS/AGENTS/BOOTSTRAP
+// docs forbid those paths and require `bash scripts/recall.sh "<원문>"` instead.
+// Prompt-level enforcement (P2.25a/b/c) was insufficient on DM channel.
+//
+// This plugin enforces the rule at the OpenClaw hook level:
+//   1. message_received -> cache user text per (sessionKey,sessionId,runId),
+//      if it matches the natural-language memo signal.
+//   2. before_tool_call -> if the cached message exists and the first toolCall
+//      matches a forbidden pattern, block it with a reason that steers the
+//      model to bash scripts/recall.sh.
+//
+// Scope: agentId === "gemma" ONLY. Other agents (main/Claw, gemma-kevin,
+// luna) are not affected.
+
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
+
+// ---------------------------------------------------------------------------
+// Pattern definitions (kept in sync with workspace/scripts/recall.sh).
+// If you change any of these, change recall.sh too and vice versa.
+// ---------------------------------------------------------------------------
+
+const INTENT_PATTERNS: RegExp[] = [
+  // DELETE
+  /지워줘|지워|삭제해|삭제|잊어버려|잘못\s*적었어|빼줘|없애줘/,
+  // EDIT
+  /고쳐줘|수정해|바꿔줘|바꿔/,
+  // WRITE
+  /적어둬|적어줘|메모해둬|메모해|기록해둬|기록해줘|기록해|저장해|남겨둬|남겨줘/,
+  // SEARCH
+  /찾아줘|어디에\s*있어|어디에\s*있더라|어디\s*갔지/,
+  // READ / RECALL
+  /보여줘|보여줄래|알려줘|다시\s*봐|다시\s*보자|어떻게\s*됐어|얼마였더라|뭐였더라|봐줘|봐\s*줘|보자|기억나|기억해|기억\s*안\s*나|기억이\s*안/,
+  // PERSON-RECALL (2026-05-24 P2.25c route 1 fix): "누구" 류 인물 회상
+  /누구지|누구야|누구더라|누구였더라|누구였지|누구냐|누구였\b/,
+];
+
+const TIME_PATTERNS: RegExp[] = [
+  /오늘|어제|그제|그저께|내일|모레|지난주|저번주|이번주|지난달|저번달|이번달|작년|올해|하루\s*전|이틀\s*전|사흘\s*전|며칠\s*전|그때|그날|그\s*날/,
+];
+
+const HANGUL_TOKEN_RE = /[가-힣]{2,}/;
+
+const FORBIDDEN_EXEC_HEAD_RE = /^\s*(find|ind|fnd|grep|cat|ls\s+-[a-zA-Z]*[Rr][a-zA-Z]*|ls\s+-l)\b/;
+const DIRECT_MEMORY_SH_RE = /\bscripts\/(memory|person)\.sh\b/;
+const RECALL_SH_RE = /\bscripts\/recall\.sh\b/;
+
+// SKILL.md path matcher (case-insensitive, trailing-anchored). Also catches
+// "...SKILL.md", "memory-search/SKILL.md", "skill-creator/SKILL.md", etc.
+const SKILL_MD_PATH_RE = /SKILL\.md\s*$/i;
+
+// MD profile files inside agent workspace that the model often "reads"
+// instead of calling recall.sh. read({path:"SOUL.md"}), MEMORY.md, USER.md,
+// TOOLS.md, AGENTS.md etc. — these are already in systemPrompt; opening them
+// via the read tool is wasted bandwidth and a signal the model is bypassing
+// recall.sh.
+const WORKSPACE_PROFILE_MD_RE =
+  /\/?(?:SOUL|IDENTITY|USER|MEMORY|AGENTS|TOOLS|BOOTSTRAP|HEARTBEAT)\.md\s*$/;
+
+// ---------------------------------------------------------------------------
+// Detection
+// ---------------------------------------------------------------------------
+
+export function looksLikeNaturalMemoRequest(text: string): boolean {
+  if (typeof text !== "string") return false;
+  const t = text.trim();
+  if (t.length < 4) return false;
+  if (t.startsWith("/")) return false; // slash command, not natural language
+  // If the user is already telling the model to call recall.sh, skip.
+  if (RECALL_SH_RE.test(t)) return false;
+
+  const hasIntent = INTENT_PATTERNS.some((p) => p.test(t));
+  const hasTime = TIME_PATTERNS.some((p) => p.test(t));
+  const hasNoun = HANGUL_TOKEN_RE.test(t);
+
+  return (hasIntent || hasTime) && hasNoun;
+}
+
+export function detectForbiddenCall(
+  toolName: string,
+  params: Record<string, unknown> | undefined,
+): string | null {
+  const p = params ?? {};
+  const name = String(toolName ?? "").toLowerCase();
+
+  // read({path:"...SKILL.md"}) or read on workspace profile mds
+  if (name === "read") {
+    const pathStr = String(
+      (p as { path?: unknown }).path ?? (p as { file_path?: unknown }).file_path ?? "",
+    );
+    if (SKILL_MD_PATH_RE.test(pathStr)) {
+      return `read({path:"${truncate(pathStr, 80)}"}) — SKILL.md path`;
+    }
+    if (WORKSPACE_PROFILE_MD_RE.test(pathStr)) {
+      return `read({path:"${truncate(pathStr, 80)}"}) — workspace profile MD (already in system prompt)`;
+    }
+  }
+
+  // exec/bash direct filesystem explorers and memory.sh/person.sh shortcuts
+  if (name === "exec" || name === "bash") {
+    const cmdRaw = String(
+      (p as { command?: unknown }).command ??
+        (p as { cmd?: unknown }).cmd ??
+        (p as { script?: unknown }).script ??
+        "",
+    );
+    if (!cmdRaw) return null;
+
+    // already routed to recall.sh — allow.
+    if (RECALL_SH_RE.test(cmdRaw)) return null;
+
+    if (FORBIDDEN_EXEC_HEAD_RE.test(cmdRaw)) {
+      const head = cmdRaw.replace(/^\s+/, "").split(/\s/, 1)[0];
+      return `${name}({command:"${head} ..."}) — direct fs explorer`;
+    }
+    if (DIRECT_MEMORY_SH_RE.test(cmdRaw)) {
+      return `${name}({command:"... memory.sh|person.sh ..."}) — direct script (must go via recall.sh)`;
+    }
+  }
+
+  return null;
+}
+
+function truncate(s: string, n: number): string {
+  if (s.length <= n) return s;
+  return s.slice(0, n) + "...";
+}
+
+// ---------------------------------------------------------------------------
+// Block reason text — what the model sees and learns from.
+// ---------------------------------------------------------------------------
+
+function buildBlockReason(originalCall: string, userText: string): string {
+  const sample = truncate(userText.replace(/\n/g, " "), 200).replace(/"/g, '\\"');
+  return (
+    `자연어 메모/일지/회상 요청 감지 (P2.25c 옵션 F). ` +
+    `차단된 호출: ${originalCall}. ` +
+    `허용된 단일 호출: exec({command: "bash scripts/recall.sh \\"${sample}\\""}). ` +
+    `find/grep/cat/ls -R/memory.sh/person.sh/SKILL.md/profile MD 직접 호출 모두 차단됨. ` +
+    `recall.sh 가 자연어 1줄을 받아 intent 분류 + 시간/명사/인물 추출 + 도구 시퀀스를 자동 처리.`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Per-session cache of the latest user text + first-call flag
+// ---------------------------------------------------------------------------
+
+type CacheEntry = {
+  text: string;
+  firstToolCallSeen: boolean;
+  ts: number;
+};
+
+const userTextCache = new Map<string, CacheEntry>();
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const CACHE_CAP = 1000;
+
+function cacheKey(agentId: string | undefined, conversationId: string | undefined): string {
+  // P2.25c route 1 fix (2026-05-24): PluginHookMessageContext lacks
+  // sessionKey/sessionId/runId. Use agentId+conversationId for cross-hook
+  // matching. In message_received ctx provides accountId/channelId/conversationId
+  // (channel-scoped); in before_tool_call ctx provides agentId/sessionKey.
+  // We map sessionKey → conversationId via sessionKeyToConversationId().
+  return `${agentId ?? ""}|${conversationId ?? ""}`;
+}
+
+// P2.25c route 1 fix: extract conversation id (telegram chat_id) from sessionKey.
+// sessionKey format observed (nohup.log hook-shape):
+//   "agent:gemma:telegram:direct:56682682"      → "56682682"
+//   "agent:gemma:telegram:group:-1003821022499" → "-1003821022499"
+// Returns undefined if format doesn't match (e.g. non-telegram or unexpected layout).
+function sessionKeyToConversationId(sessionKey: string | undefined): string | undefined {
+  if (typeof sessionKey !== "string" || !sessionKey) return undefined;
+  const m = /^agent:[^:]+:[^:]+:(?:direct|group):(.+)$/.exec(sessionKey);
+  return m ? m[1] : undefined;
+}
+
+function pruneCache(): void {
+  const now = Date.now();
+  for (const [k, v] of userTextCache) {
+    if (now - v.ts > CACHE_TTL_MS) userTextCache.delete(k);
+  }
+  if (userTextCache.size > CACHE_CAP) {
+    const overflow = userTextCache.size - CACHE_CAP;
+    const it = userTextCache.keys();
+    for (let i = 0; i < overflow; i++) {
+      const k = it.next().value;
+      if (typeof k === "string") userTextCache.delete(k);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Counters (exposed via debug logger; not a registered command in this
+// version to minimize OpenClaw surface area).
+// ---------------------------------------------------------------------------
+
+const counters = {
+  messagesSeen: 0,
+  naturalMemoMatched: 0,
+  toolCallsInspected: 0,
+  blocked: 0,
+  skippedNotGemma: 0,
+  skippedNotFirstCall: 0,
+  skippedNoMatch: 0,
+  skippedAllowed: 0,
+};
+
+export function __dumpCounters(): Record<string, number> {
+  return { ...counters, cacheSize: userTextCache.size };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers for extracting user text from message_received events. The shape
+// can vary by channel; this is best-effort.
+// ---------------------------------------------------------------------------
+
+function extractUserText(event: unknown): string {
+  if (!event || typeof event !== "object") return "";
+  const ev = event as Record<string, unknown>;
+
+  // common shapes
+  const m = ev["message"];
+  if (typeof m === "string") return m;
+  if (m && typeof m === "object") {
+    const t = (m as Record<string, unknown>)["text"];
+    if (typeof t === "string") return t;
+    const c = (m as Record<string, unknown>)["content"];
+    if (typeof c === "string") return c;
+    if (Array.isArray(c)) {
+      const joined = c
+        .map((seg) =>
+          seg && typeof seg === "object" && typeof (seg as { text?: unknown }).text === "string"
+            ? (seg as { text: string }).text
+            : "",
+        )
+        .filter(Boolean)
+        .join("\n");
+      if (joined) return joined;
+    }
+  }
+  if (typeof ev["text"] === "string") return ev["text"] as string;
+  if (typeof ev["content"] === "string") return ev["content"] as string;
+  return "";
+}
+
+// ---------------------------------------------------------------------------
+// Plugin entrypoint
+// ---------------------------------------------------------------------------
+
+export default (api: OpenClawPluginApi) => {
+  const { logger } = api;
+
+  // P2.25c hook-debug: confirm plugin registration on every load
+  logger.info(`[gemma-memory-intercept] plugin registered; api keys=${Object.keys(api).join(",")}`);
+
+  api.on("message_received", (event, ctx) => {
+    // P2.25c route 1 fix: PluginHookMessageContext is { channelId, accountId?, conversationId? }
+    // — NO agentId field. Old `ctx.agentId !== "gemma"` always returned (undefined).
+    // Now filter by accountId="gemma" (OpenClaw telegram account name for @lisyoen_gemma_bot)
+    // + channelId="telegram".
+    const accountId = (ctx as { accountId?: string }).accountId;
+    const channelId = (ctx as { channelId?: string }).channelId;
+    const conversationIdRaw = (ctx as { conversationId?: string }).conversationId;
+    // P2.25c route 1 fix (2026-05-24 20:30): ctx.conversationId from telegram is
+    // "telegram:56682682" or "telegram:group:-1003821022499" (channel-prefixed).
+    // sessionKeyToConversationId() in before_tool_call strips down to just
+    // "56682682" / "-1003821022499". Normalize both sides by stripping the
+    // leading channel prefix here.
+    const conversationId =
+      typeof conversationIdRaw === "string"
+        ? conversationIdRaw.replace(/^[a-z][a-z0-9_-]*:/i, "").replace(/^group:/, "")
+        : undefined;
+    if (accountId !== "gemma" || channelId !== "telegram") return;
+    counters.messagesSeen++;
+
+    const text = extractUserText(event);
+    const matched = text ? looksLikeNaturalMemoRequest(text) : false;
+    logger.info(
+      `[gemma-memory-intercept] message_received account=${accountId} channel=${channelId} ` +
+        `convId=${conversationId ?? ""} textLen=${text?.length ?? 0} matched=${matched} ` +
+        `sample="${truncate(text || "", 60).replace(/"/g, '\\"')}"`,
+    );
+    if (!text) return;
+    if (!matched) return;
+
+    counters.naturalMemoMatched++;
+
+    // P2.25c route 1 fix: cache key now (agentId, conversationId).
+    // agentId for telegram:gemma account is always "gemma" (see openclaw.json).
+    const key = cacheKey("gemma", conversationId);
+    userTextCache.set(key, { text, firstToolCallSeen: false, ts: Date.now() });
+    pruneCache();
+
+    logger.info(
+      `[gemma-memory-intercept] natural-memo cached: key=${key} sample="${truncate(text, 80)}"`,
+    );
+  });
+
+  api.on("before_tool_call", (event, ctx) => {
+    const agentId = (ctx as { agentId?: string }).agentId;
+    if (agentId !== "gemma") {
+      counters.skippedNotGemma++;
+      return;
+    }
+    counters.toolCallsInspected++;
+
+    // P2.25c route 1 fix: derive conversationId from sessionKey to match
+    // the key written by message_received handler.
+    const sessionKey = (ctx as { sessionKey?: string }).sessionKey;
+    const conversationId = sessionKeyToConversationId(sessionKey);
+    const key = cacheKey(agentId, conversationId);
+    const entry = userTextCache.get(key);
+    logger.info(
+      `[gemma-memory-intercept] before_tool_call agent=${agentId} ` +
+        `sessionKey=${sessionKey ?? ""} convId=${conversationId ?? ""} key=${key} ` +
+        `tool=${String(event.toolName ?? "")} ` +
+        `hasCache=${entry ? "yes" : "no"} ` +
+        `firstCall=${entry && !entry.firstToolCallSeen ? "yes" : "no"}`,
+    );
+    if (!entry) {
+      counters.skippedNoMatch++;
+      return;
+    }
+
+    // Only intercept the FIRST toolCall after a matched memo signal.
+    if (entry.firstToolCallSeen) {
+      counters.skippedNotFirstCall++;
+      return;
+    }
+    entry.firstToolCallSeen = true;
+
+    const forbidden = detectForbiddenCall(event.toolName, event.params);
+    if (!forbidden) {
+      counters.skippedAllowed++;
+      return; // model already chose recall.sh or something benign
+    }
+
+    counters.blocked++;
+    const blockReason = buildBlockReason(forbidden, entry.text);
+    logger.warn(
+      `[gemma-memory-intercept] BLOCKED toolCall: key=${key} sessionKey=${sessionKey ?? ""} call=${forbidden}`,
+    );
+
+    return { block: true, blockReason };
+  });
+
+  return undefined;
+};
+
+// ---------------------------------------------------------------------------
+// Test surface — pure functions exported for unit tests.
+// ---------------------------------------------------------------------------
+
+export const __test__ = {
+  looksLikeNaturalMemoRequest,
+  detectForbiddenCall,
+  buildBlockReason,
+  cache: userTextCache,
+  counters,
+};

--- a/extensions/gemma-memory-intercept/openclaw.plugin.json
+++ b/extensions/gemma-memory-intercept/openclaw.plugin.json
@@ -1,0 +1,10 @@
+{
+  "id": "gemma-memory-intercept",
+  "name": "Gemma Memory Intercept (P2.25c option F)",
+  "description": "Intercept first toolCall when user sends a natural-language memo request to agentId=gemma. Blocks forbidden patterns (read SKILL.md, find/grep/cat/ls -R, memory.sh/person.sh direct) and steers to bash scripts/recall.sh.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/portable-context/index.ts
+++ b/extensions/portable-context/index.ts
@@ -4,8 +4,9 @@
 // header + the gemma workspace USER.md + MEMORY.md into a single .md file and
 // delivers it as a Telegram document (via the outbound mediaUrl path).
 //
-// Scope (P6-3a / stage A): NO compressed-context section — that arrives in
-// P6-3b. Keep this handler minimal and self-contained.
+// Scope (P6-3b / stage B): adds a 4th block — a recent-conversation
+// compression section generated via a Gemma4 self-call. On ANY failure the
+// 3-block CONTEXT.md still ships normally (the section is silently omitted).
 
 import { readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
@@ -18,6 +19,139 @@ import { resolvePreferredOpenClawTmpDir, type OpenClawPluginApi } from "openclaw
 function looksLikeGroupTarget(value: string | undefined): boolean {
   const v = (value ?? "").trim();
   return v.length > 0 && v.startsWith("-");
+}
+
+// P6-3b: exact system prompt mandated by the spec (do not paraphrase).
+const COMPRESS_SYSTEM_PROMPT =
+  "다음은 사용자와 AI 비서의 최근 대화 기록이다. 이 대화의 내용을 약 4000자 이내로 압축하라.\n" +
+  "\n" +
+  "중요 원칙:\n" +
+  '- 이것은 "요약"이 아니라 "압축"이다. 정보 보존이 매끄러운 문장보다 우선이다.\n' +
+  "- 구체적인 사실, 숫자, 이름, 시간, 결정사항, 진행 중인 일, 약속, 상태 변화는 모두 보존하라.\n" +
+  '- 인삿말이나 군더더기, 단순 확인 응답("응", "OK")만 제거하라.\n' +
+  "- 한국어로 작성하라.\n" +
+  "- 시간 순서를 유지하라.\n" +
+  "- 출력은 압축본 본문만. 헤더나 메타 설명 금지.";
+
+// Read the most recent conversation messages for this sender from gemma's
+// session jsonl (read-only). Accumulates from newest backwards up to a 50KB
+// raw byte cap, then returns chronological order. Any I/O or parse failure
+// degrades to [] (caller omits the compression section).
+async function readRecentMessages(
+  senderId: string,
+): Promise<Array<{ role: string; text: string }>> {
+  const sessionKey = `agent:gemma:telegram:direct:${senderId}`;
+  const sessionsPath = path.join(os.homedir(), ".openclaw/agents/gemma/sessions/sessions.json");
+  let sessions: Record<string, { sessionId?: string } | undefined>;
+  try {
+    sessions = JSON.parse(await readFile(sessionsPath, "utf-8")) as Record<
+      string,
+      { sessionId?: string } | undefined
+    >;
+  } catch {
+    return [];
+  }
+  const sessionId = sessions[sessionKey]?.sessionId;
+  if (!sessionId) return [];
+
+  const jsonlPath = path.join(os.homedir(), `.openclaw/agents/gemma/sessions/${sessionId}.jsonl`);
+  let jsonlRaw: string;
+  try {
+    jsonlRaw = await readFile(jsonlPath, "utf-8");
+  } catch {
+    return [];
+  }
+
+  const lines = jsonlRaw.split("\n");
+  const collected: Array<{ role: string; text: string }> = [];
+  let accumBytes = 0;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i]?.trim();
+    if (!line) continue;
+    let rec: {
+      type?: string;
+      message?: { role?: string; content?: unknown };
+    };
+    try {
+      rec = JSON.parse(line) as typeof rec;
+    } catch {
+      continue;
+    }
+    if (rec.type !== "message" || !rec.message) continue;
+    const role = (rec.message.role ?? "").trim();
+    if (!role) continue;
+
+    const rawContent = rec.message.content;
+    let text: string;
+    if (typeof rawContent === "string") {
+      text = rawContent;
+    } else if (Array.isArray(rawContent)) {
+      text = rawContent
+        .filter((p): p is { type?: string; text?: string } => !!p && typeof p === "object")
+        .filter((p) => p.type === "text" && typeof p.text === "string")
+        .map((p) => p.text as string)
+        .join("");
+    } else {
+      text = "";
+    }
+    if (!text) continue;
+
+    const byteLen = Buffer.byteLength(text, "utf8");
+    if (accumBytes + byteLen > 50000) break;
+    accumBytes += byteLen;
+    collected.push({ role, text });
+  }
+  collected.reverse();
+  return collected;
+}
+
+// Compress the given message sequence via the local Gemma4 vLLM endpoint.
+// Returns the compressed text (utf-8-safe trimmed to 4096 bytes) or null on
+// empty input / fetch error / timeout / empty response.
+async function compressRecentConversation(
+  messages: Array<{ role: string; text: string }>,
+): Promise<string | null> {
+  if (messages.length === 0) return null;
+  try {
+    const serialized = messages.map((m) => `[${m.role}] ${m.text}`).join("\n\n");
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 30000);
+    let data: { choices?: Array<{ message?: { content?: string } }> };
+    try {
+      const res = await fetch("http://localhost:8005/v1/chat/completions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          model: "gemma4-26b-nvfp4",
+          messages: [
+            { role: "system", content: COMPRESS_SYSTEM_PROMPT },
+            { role: "user", content: serialized },
+          ],
+          max_tokens: 2048,
+          temperature: 0.3,
+        }),
+        signal: controller.signal,
+      });
+      data = (await res.json()) as {
+        choices?: Array<{ message?: { content?: string } }>;
+      };
+    } finally {
+      clearTimeout(timer);
+    }
+
+    const out = data?.choices?.[0]?.message?.content;
+    if (!out || typeof out !== "string") return null;
+
+    const buf = Buffer.from(out, "utf8");
+    if (buf.length <= 4096) return out;
+    // Trim to 4096 bytes, dropping a trailing broken multibyte sequence.
+    let end = 4096;
+    while (end > 0 && (buf[end] & 0xc0) === 0x80) end--;
+    return buf.subarray(0, end).toString("utf8");
+  } catch {
+    return null;
+  }
 }
 
 export default function register(api: OpenClawPluginApi): void {
@@ -59,12 +193,31 @@ export default function register(api: OpenClawPluginApi): void {
         }
 
         // 4. Assemble: header + USER.md + MEMORY.md.
-        //    (Compressed-context section is intentionally omitted — P6-3b.)
         const header =
           "# CONTEXT.md - About This Person\n" +
           `- 이 파일을 업로드한 사람의 식별자: ${senderId}\n` +
           "- 아래 내용은 모두 이 사람에 대한 정보임.\n\n";
         const content = `${header}${userMd.trim()}\n\n${memoryMd.trim()}\n`;
+
+        // 4b. Append recent conversation compression (Gemma4 self-call).
+        //     On any failure (no messages / fetch error / timeout / empty),
+        //     silently omit the section. The 3-block CONTEXT.md still ships.
+        let finalContent = content;
+        try {
+          const messages = await readRecentMessages(senderId);
+          if (messages.length > 0) {
+            const compressed = await compressRecentConversation(messages);
+            if (compressed && compressed.trim()) {
+              finalContent =
+                content +
+                "\n# 최근 대화 압축본 (Gemma4 생성, 약 4KB)\n\n" +
+                compressed.trim() +
+                "\n";
+            }
+          }
+        } catch {
+          // silent fallback to 3-block content
+        }
 
         // 5. Write into OpenClaw's preferred tmp dir so the Telegram outbound
         //    pipeline's mediaLocalRoots allowlist accepts the file:// url.
@@ -74,7 +227,7 @@ export default function register(api: OpenClawPluginApi): void {
           resolvePreferredOpenClawTmpDir(),
           `CONTEXT-${safeId}-${Date.now()}.md`,
         );
-        await writeFile(tmpPath, content, "utf-8");
+        await writeFile(tmpPath, finalContent, "utf-8");
 
         // 6. Returning mediaUrl lets the outbound pipeline deliver it as a
         //    document (`.md` is not image/video/audio → api.sendDocument).

--- a/extensions/portable-context/index.ts
+++ b/extensions/portable-context/index.ts
@@ -1,6 +1,6 @@
 // Bundled "portable-context" command plugin.
 //
-// Adds a `/export-context` native command. When invoked from a DM it bundles a short
+// Adds a `/export_context` native command. When invoked from a DM it bundles a short
 // header + the agent workspace USER.md + MEMORY.md into a single .md file and
 // delivers it as a Telegram document (via the outbound mediaUrl path).
 //
@@ -220,7 +220,7 @@ async function compressRecentConversation(
 
 export default function register(api: OpenClawPluginApi): void {
   api.registerCommand({
-    name: "export-context",
+    name: "export_context",
     description: "Export your USER.md + MEMORY.md as a single portable .md document (DM only).",
     acceptsArgs: false,
     handler: async (ctx) => {

--- a/extensions/portable-context/index.ts
+++ b/extensions/portable-context/index.ts
@@ -80,15 +80,18 @@ async function resolveContextPaths(
 
 // P6-3b: exact system prompt mandated by the spec (do not paraphrase).
 const COMPRESS_SYSTEM_PROMPT =
-  "다음은 사용자와 AI 비서의 최근 대화 기록이다. 이 대화의 내용을 약 8000자 정도로 압축하라.\n" +
+  "다음은 시간순으로 정렬된 사용자와 AI 비서의 최근 대화 메시지들이다.\n" +
+  "이 대화를 이어받을 다른 AI가 사용자의 맥락을 완전히 이해할 수 있도록, 충분히 상세한 인수인계 노트로 정리하라.\n" +
   "\n" +
-  "중요 원칙:\n" +
-  '- 이것은 "요약"이 아니라 "압축"이다. 정보 보존이 매끄러운 문장보다 우선이다.\n' +
-  "- 구체적인 사실, 숫자, 이름, 시간, 결정사항, 진행 중인 일, 약속, 상태 변화는 모두 보존하라.\n" +
-  '- 인삿말이나 군더더기, 단순 확인 응답("응", "OK")만 제거하라.\n' +
+  "요구 사항:\n" +
+  "- 출력 목표 분량: 6000자~10000자 (입력 분량의 약 1/3~1/4).\n" +
+  "- 짧은 출력은 인수인계 실패로 간주된다. 정보 손실보다 길이가 길어지는 것을 선호하라.\n" +
+  "- 주제별로 섹션을 나누어 작성하라 (업무, 프로젝트, 일상, 결정사항, 진행 중인 작업, 약속 등).\n" +
+  "- 구체적인 사실, 숫자, 이름, 시간, 결정사항, 진행 중인 일, 약속, 상태 변화, 우려사항을 모두 보존하라.\n" +
+  '- 인삿말이나 단순 확인 응답("응", "OK")만 제거하라.\n' +
   "- 한국어로 작성하라.\n" +
   "- 시간 순서를 유지하라.\n" +
-  "- 출력은 압축본 본문만. 헤더나 메타 설명 금지.";
+  "- 출력은 노트 본문만. 헤더나 메타 설명 금지.";
 
 // Read the most recent conversation messages for this sender from the agent's
 // session jsonl (read-only). Accumulates from newest backwards up to a 50KB
@@ -180,7 +183,7 @@ async function compressRecentConversation(
     const serialized = messages.map((m) => `[${m.role}] ${m.text}`).join("\n\n");
 
     const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 30000);
+    const timer = setTimeout(() => controller.abort(), 60000);
     let data: { choices?: Array<{ message?: { content?: string } }> };
     try {
       const res = await fetch("http://localhost:8005/v1/chat/completions", {

--- a/extensions/portable-context/index.ts
+++ b/extensions/portable-context/index.ts
@@ -80,7 +80,7 @@ async function resolveContextPaths(
 
 // P6-3b: exact system prompt mandated by the spec (do not paraphrase).
 const COMPRESS_SYSTEM_PROMPT =
-  "다음은 사용자와 AI 비서의 최근 대화 기록이다. 이 대화의 내용을 약 4000자 이내로 압축하라.\n" +
+  "다음은 사용자와 AI 비서의 최근 대화 기록이다. 이 대화의 내용을 약 8000자 정도로 압축하라.\n" +
   "\n" +
   "중요 원칙:\n" +
   '- 이것은 "요약"이 아니라 "압축"이다. 정보 보존이 매끄러운 문장보다 우선이다.\n' +
@@ -170,7 +170,7 @@ async function readRecentMessages(
 }
 
 // Compress the given message sequence via the local Gemma4 vLLM endpoint.
-// Returns the compressed text (utf-8-safe trimmed to 4096 bytes) or null on
+// Returns the compressed text (utf-8-safe trimmed to 16384 bytes) or null on
 // empty input / fetch error / timeout / empty response.
 async function compressRecentConversation(
   messages: Array<{ role: string; text: string }>,
@@ -192,7 +192,7 @@ async function compressRecentConversation(
             { role: "system", content: COMPRESS_SYSTEM_PROMPT },
             { role: "user", content: serialized },
           ],
-          max_tokens: 2048,
+          max_tokens: 8192,
           temperature: 0.3,
         }),
         signal: controller.signal,
@@ -208,9 +208,9 @@ async function compressRecentConversation(
     if (!out || typeof out !== "string") return null;
 
     const buf = Buffer.from(out, "utf8");
-    if (buf.length <= 4096) return out;
-    // Trim to 4096 bytes, dropping a trailing broken multibyte sequence.
-    let end = 4096;
+    if (buf.length <= 16384) return out;
+    // Trim to 16384 bytes, dropping a trailing broken multibyte sequence.
+    let end = 16384;
     while (end > 0 && (buf[end] & 0xc0) === 0x80) end--;
     return buf.subarray(0, end).toString("utf8");
   } catch {
@@ -288,7 +288,7 @@ export default function register(api: OpenClawPluginApi): void {
             if (compressed && compressed.trim()) {
               finalContent =
                 content +
-                "\n# 최근 대화 압축본 (Gemma4 생성, 약 4KB)\n\n" +
+                "\n# 최근 대화 압축본 (Gemma4 생성, 최대 16KB)\n\n" +
                 compressed.trim() +
                 "\n";
             }

--- a/extensions/portable-context/index.ts
+++ b/extensions/portable-context/index.ts
@@ -1,0 +1,96 @@
+// Bundled "portable-context" command plugin.
+//
+// Adds a `/export` native command. When invoked from a DM it bundles a short
+// header + the gemma workspace USER.md + MEMORY.md into a single .md file and
+// delivers it as a Telegram document (via the outbound mediaUrl path).
+//
+// Scope (P6-3a / stage A): NO compressed-context section — that arrives in
+// P6-3b. Keep this handler minimal and self-contained.
+
+import { readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { resolvePreferredOpenClawTmpDir, type OpenClawPluginApi } from "openclaw/plugin-sdk/core";
+
+// PluginCommandContext exposes no chat-type field. Telegram group/channel ids
+// are negative; private chats use a positive user id. Treat a negative target
+// (or a forum/topic thread id) as "not a DM".
+function looksLikeGroupTarget(value: string | undefined): boolean {
+  const v = (value ?? "").trim();
+  return v.length > 0 && v.startsWith("-");
+}
+
+export default function register(api: OpenClawPluginApi): void {
+  api.registerCommand({
+    name: "export",
+    description: "Export your USER.md + MEMORY.md as a single portable .md document (DM only).",
+    acceptsArgs: false,
+    handler: async (ctx) => {
+      try {
+        // 1. DM-only gate (heuristic — see looksLikeGroupTarget).
+        const target = ctx.to ?? ctx.from ?? ctx.senderId;
+        if (looksLikeGroupTarget(target) || ctx.messageThreadId != null) {
+          return { text: "DM 에서만 사용 가능합니다.", isError: true };
+        }
+
+        // 2. Sender identity. Only senderId is available on the command
+        //    context (no display name); use it for the header + filename.
+        const senderId = (ctx.senderId ?? "").trim() || "unknown";
+
+        // 3. Read the gemma workspace context (read-only).
+        const wsDir = path.join(os.homedir(), ".openclaw/agents/gemma/workspace");
+        let userMd: string;
+        let memoryMd: string;
+        try {
+          userMd = await readFile(path.join(wsDir, "USER.md"), "utf-8");
+        } catch {
+          return {
+            text: "USER.md 를 찾을 수 없어 내보내기를 중단했어. (gemma workspace 미초기화)",
+            isError: true,
+          };
+        }
+        try {
+          memoryMd = await readFile(path.join(wsDir, "MEMORY.md"), "utf-8");
+        } catch {
+          return {
+            text: "MEMORY.md 를 찾을 수 없어 내보내기를 중단했어. (gemma workspace 미초기화)",
+            isError: true,
+          };
+        }
+
+        // 4. Assemble: header + USER.md + MEMORY.md.
+        //    (Compressed-context section is intentionally omitted — P6-3b.)
+        const header =
+          "# CONTEXT.md - About This Person\n" +
+          `- 이 파일을 업로드한 사람의 식별자: ${senderId}\n` +
+          "- 아래 내용은 모두 이 사람에 대한 정보임.\n\n";
+        const content = `${header}${userMd.trim()}\n\n${memoryMd.trim()}\n`;
+
+        // 5. Write into OpenClaw's preferred tmp dir so the Telegram outbound
+        //    pipeline's mediaLocalRoots allowlist accepts the file:// url.
+        //    The basename becomes the delivered document filename.
+        const safeId = senderId.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "user";
+        const tmpPath = path.join(
+          resolvePreferredOpenClawTmpDir(),
+          `CONTEXT-${safeId}-${Date.now()}.md`,
+        );
+        await writeFile(tmpPath, content, "utf-8");
+
+        // 6. Returning mediaUrl lets the outbound pipeline deliver it as a
+        //    document (`.md` is not image/video/audio → api.sendDocument).
+        //    The temp file is intentionally left for OpenClaw's tmp reaper:
+        //    the send happens asynchronously after this handler returns, so
+        //    unlinking here would race the upload.
+        return {
+          text: "내보냈어. 사용 안내: 젬마 있는 그룹에 이 .md 를 첨부 업로드하면 자동 인식돼.",
+          mediaUrl: `file://${tmpPath}`,
+        };
+      } catch (err) {
+        return {
+          text: `내보내기 중 오류가 발생했어: ${err instanceof Error ? err.message : String(err)}`,
+          isError: true,
+        };
+      }
+    },
+  });
+}

--- a/extensions/portable-context/index.ts
+++ b/extensions/portable-context/index.ts
@@ -80,18 +80,15 @@ async function resolveContextPaths(
 
 // P6-3b: exact system prompt mandated by the spec (do not paraphrase).
 const COMPRESS_SYSTEM_PROMPT =
-  "다음은 시간순으로 정렬된 사용자와 AI 비서의 최근 대화 메시지들이다.\n" +
-  "이 대화를 이어받을 다른 AI가 사용자의 맥락을 완전히 이해할 수 있도록, 충분히 상세한 인수인계 노트로 정리하라.\n" +
+  "다음은 사용자와 AI 비서의 최근 대화 기록이다. 이 대화의 내용을 약 8000자 정도로 압축하라.\n" +
   "\n" +
-  "요구 사항:\n" +
-  "- 출력 목표 분량: 6000자~10000자 (입력 분량의 약 1/3~1/4).\n" +
-  "- 짧은 출력은 인수인계 실패로 간주된다. 정보 손실보다 길이가 길어지는 것을 선호하라.\n" +
-  "- 주제별로 섹션을 나누어 작성하라 (업무, 프로젝트, 일상, 결정사항, 진행 중인 작업, 약속 등).\n" +
-  "- 구체적인 사실, 숫자, 이름, 시간, 결정사항, 진행 중인 일, 약속, 상태 변화, 우려사항을 모두 보존하라.\n" +
-  '- 인삿말이나 단순 확인 응답("응", "OK")만 제거하라.\n' +
+  "중요 원칙:\n" +
+  '- 이것은 "요약"이 아니라 "압축"이다. 정보 보존이 매끄러운 문장보다 우선이다.\n' +
+  "- 구체적인 사실, 숫자, 이름, 시간, 결정사항, 진행 중인 일, 약속, 상태 변화는 모두 보존하라.\n" +
+  '- 인삿말이나 군더더기, 단순 확인 응답("응", "OK")만 제거하라.\n' +
   "- 한국어로 작성하라.\n" +
   "- 시간 순서를 유지하라.\n" +
-  "- 출력은 노트 본문만. 헤더나 메타 설명 금지.";
+  "- 출력은 압축본 본문만. 헤더나 메타 설명 금지.";
 
 // Read the most recent conversation messages for this sender from the agent's
 // session jsonl (read-only). Accumulates from newest backwards up to a 50KB
@@ -183,7 +180,7 @@ async function compressRecentConversation(
     const serialized = messages.map((m) => `[${m.role}] ${m.text}`).join("\n\n");
 
     const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 60000);
+    const timer = setTimeout(() => controller.abort(), 30000);
     let data: { choices?: Array<{ message?: { content?: string } }> };
     try {
       const res = await fetch("http://localhost:8005/v1/chat/completions", {

--- a/extensions/portable-context/index.ts
+++ b/extensions/portable-context/index.ts
@@ -1,6 +1,6 @@
 // Bundled "portable-context" command plugin.
 //
-// Adds a `/export` native command. When invoked from a DM it bundles a short
+// Adds a `/export-context` native command. When invoked from a DM it bundles a short
 // header + the gemma workspace USER.md + MEMORY.md into a single .md file and
 // delivers it as a Telegram document (via the outbound mediaUrl path).
 //
@@ -22,7 +22,7 @@ function looksLikeGroupTarget(value: string | undefined): boolean {
 
 export default function register(api: OpenClawPluginApi): void {
   api.registerCommand({
-    name: "export",
+    name: "export-context",
     description: "Export your USER.md + MEMORY.md as a single portable .md document (DM only).",
     acceptsArgs: false,
     handler: async (ctx) => {

--- a/extensions/portable-context/index.ts
+++ b/extensions/portable-context/index.ts
@@ -1,17 +1,24 @@
 // Bundled "portable-context" command plugin.
 //
 // Adds a `/export-context` native command. When invoked from a DM it bundles a short
-// header + the gemma workspace USER.md + MEMORY.md into a single .md file and
+// header + the agent workspace USER.md + MEMORY.md into a single .md file and
 // delivers it as a Telegram document (via the outbound mediaUrl path).
 //
 // Scope (P6-3b / stage B): adds a 4th block — a recent-conversation
 // compression section generated via a Gemma4 self-call. On ANY failure the
 // 3-block CONTEXT.md still ships normally (the section is silently omitted).
+//
+// Multi-agent (2026-05-18, "luna support"): supports both gemma (single-tenant
+// workspace) and luna (multi-tenant — caller-specific subdir under
+// workspace/users/) by branching on ctx.accountId. The on-disk layout is the
+// only thing that differs; the resulting CONTEXT.md format is identical.
 
-import { readFile, writeFile } from "node:fs/promises";
+import { readFile, readdir, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { resolvePreferredOpenClawTmpDir, type OpenClawPluginApi } from "openclaw/plugin-sdk/core";
+
+type AgentId = "gemma" | "luna";
 
 // PluginCommandContext exposes no chat-type field. Telegram group/channel ids
 // are negative; private chats use a positive user id. Treat a negative target
@@ -19,6 +26,56 @@ import { resolvePreferredOpenClawTmpDir, type OpenClawPluginApi } from "openclaw
 function looksLikeGroupTarget(value: string | undefined): boolean {
   const v = (value ?? "").trim();
   return v.length > 0 && v.startsWith("-");
+}
+
+// Map ctx.accountId (openclaw.json channels.telegram.accounts key) to an
+// agentId. Default to gemma for backward compat — only "luna" branches off.
+function resolveAgentId(accountId: string | undefined): AgentId {
+  return accountId === "luna" ? "luna" : "gemma";
+}
+
+// Resolve on-disk paths to USER.md + MEMORY.md for the caller.
+//
+// - gemma: single-tenant. Always reads workspace root.
+// - luna:  multi-tenant. luna's dump_users_to_md.py lays out per-user dirs as
+//          workspace/users/{prefix?}{chat_id}-{slug}/. prefix is "00-" for the
+//          admin row, empty otherwise. Match by exact-or-bounded chat_id.
+async function resolveContextPaths(
+  agentId: AgentId,
+  senderId: string,
+): Promise<{ userMdPath: string; memoryMdPath: string } | null> {
+  if (agentId === "gemma") {
+    const wsDir = path.join(os.homedir(), ".openclaw/agents/gemma/workspace");
+    return {
+      userMdPath: path.join(wsDir, "USER.md"),
+      memoryMdPath: path.join(wsDir, "MEMORY.md"),
+    };
+  }
+  // luna: glob workspace/users/ for an entry whose chat_id segment matches.
+  const usersRoot = path.join(os.homedir(), ".openclaw/agents/luna/workspace/users");
+  let entries: string[];
+  try {
+    entries = await readdir(usersRoot);
+  } catch {
+    return null;
+  }
+  // Skip archive-prefixed dirs (e.g. "_archive-..."). Real per-user dirs are
+  // either "<chat_id>-<slug>" or "<prefix>-<chat_id>-<slug>" where <prefix>
+  // is a short numeric sort prefix like "00" (admin).
+  // senderId is sanitized to digits only before going into the regex.
+  const safeSender = senderId.replace(/[^0-9]/g, "");
+  if (!safeSender) return null;
+  const re = new RegExp(`(?:^|-)${safeSender}-`);
+  const matches = entries.filter((e) => !e.startsWith("_") && re.test(e));
+  if (matches.length === 0) return null;
+  // Prefer admin-prefixed match if present (the operator), but normally there
+  // will be exactly one match.
+  const chosen = matches.find((m) => m.startsWith("00-")) ?? matches[0];
+  const userDir = path.join(usersRoot, chosen);
+  return {
+    userMdPath: path.join(userDir, "USER.md"),
+    memoryMdPath: path.join(userDir, "MEMORY.md"),
+  };
 }
 
 // P6-3b: exact system prompt mandated by the spec (do not paraphrase).
@@ -33,15 +90,19 @@ const COMPRESS_SYSTEM_PROMPT =
   "- 시간 순서를 유지하라.\n" +
   "- 출력은 압축본 본문만. 헤더나 메타 설명 금지.";
 
-// Read the most recent conversation messages for this sender from gemma's
+// Read the most recent conversation messages for this sender from the agent's
 // session jsonl (read-only). Accumulates from newest backwards up to a 50KB
 // raw byte cap, then returns chronological order. Any I/O or parse failure
 // degrades to [] (caller omits the compression section).
 async function readRecentMessages(
+  agentId: AgentId,
   senderId: string,
 ): Promise<Array<{ role: string; text: string }>> {
-  const sessionKey = `agent:gemma:telegram:direct:${senderId}`;
-  const sessionsPath = path.join(os.homedir(), ".openclaw/agents/gemma/sessions/sessions.json");
+  const sessionKey = `agent:${agentId}:telegram:direct:${senderId}`;
+  const sessionsPath = path.join(
+    os.homedir(),
+    `.openclaw/agents/${agentId}/sessions/sessions.json`,
+  );
   let sessions: Record<string, { sessionId?: string } | undefined>;
   try {
     sessions = JSON.parse(await readFile(sessionsPath, "utf-8")) as Record<
@@ -54,7 +115,10 @@ async function readRecentMessages(
   const sessionId = sessions[sessionKey]?.sessionId;
   if (!sessionId) return [];
 
-  const jsonlPath = path.join(os.homedir(), `.openclaw/agents/gemma/sessions/${sessionId}.jsonl`);
+  const jsonlPath = path.join(
+    os.homedir(),
+    `.openclaw/agents/${agentId}/sessions/${sessionId}.jsonl`,
+  );
   let jsonlRaw: string;
   try {
     jsonlRaw = await readFile(jsonlPath, "utf-8");
@@ -171,40 +235,54 @@ export default function register(api: OpenClawPluginApi): void {
         //    context (no display name); use it for the header + filename.
         const senderId = (ctx.senderId ?? "").trim() || "unknown";
 
-        // 3. Read the gemma workspace context (read-only).
-        const wsDir = path.join(os.homedir(), ".openclaw/agents/gemma/workspace");
-        let userMd: string;
-        let memoryMd: string;
-        try {
-          userMd = await readFile(path.join(wsDir, "USER.md"), "utf-8");
-        } catch {
+        // 3. Decide which agent's workspace + sessions to read.
+        const agentId = resolveAgentId(ctx.accountId);
+
+        // 4. Resolve on-disk USER/MEMORY paths for this agent + sender.
+        const paths = await resolveContextPaths(agentId, senderId);
+        if (!paths) {
           return {
-            text: "USER.md 를 찾을 수 없어 내보내기를 중단했어. (gemma workspace 미초기화)",
-            isError: true,
-          };
-        }
-        try {
-          memoryMd = await readFile(path.join(wsDir, "MEMORY.md"), "utf-8");
-        } catch {
-          return {
-            text: "MEMORY.md 를 찾을 수 없어 내보내기를 중단했어. (gemma workspace 미초기화)",
+            text:
+              agentId === "luna"
+                ? `네 정보를 워크스페이스에서 찾지 못했어 (chat_id ${senderId}). 루나에 한 번이라도 말 걸어본 적이 있어야 dump 가 생성돼.`
+                : "워크스페이스가 초기화되지 않아 내보내기를 중단했어.",
             isError: true,
           };
         }
 
-        // 4. Assemble: header + USER.md + MEMORY.md.
+        // 5. Read the workspace context (read-only).
+        let userMd: string;
+        let memoryMd: string;
+        try {
+          userMd = await readFile(paths.userMdPath, "utf-8");
+        } catch {
+          return {
+            text: `USER.md 를 찾을 수 없어 내보내기를 중단했어. (${agentId} workspace 미초기화)`,
+            isError: true,
+          };
+        }
+        try {
+          memoryMd = await readFile(paths.memoryMdPath, "utf-8");
+        } catch {
+          return {
+            text: `MEMORY.md 를 찾을 수 없어 내보내기를 중단했어. (${agentId} workspace 미초기화)`,
+            isError: true,
+          };
+        }
+
+        // 6. Assemble: header + USER.md + MEMORY.md.
         const header =
           "# CONTEXT.md - About This Person\n" +
           `- 이 파일을 업로드한 사람의 식별자: ${senderId}\n` +
           "- 아래 내용은 모두 이 사람에 대한 정보임.\n\n";
         const content = `${header}${userMd.trim()}\n\n${memoryMd.trim()}\n`;
 
-        // 4b. Append recent conversation compression (Gemma4 self-call).
-        //     On any failure (no messages / fetch error / timeout / empty),
-        //     silently omit the section. The 3-block CONTEXT.md still ships.
+        // 7. Append recent conversation compression (Gemma4 self-call).
+        //    On any failure (no messages / fetch error / timeout / empty),
+        //    silently omit the section. The 3-block CONTEXT.md still ships.
         let finalContent = content;
         try {
-          const messages = await readRecentMessages(senderId);
+          const messages = await readRecentMessages(agentId, senderId);
           if (messages.length > 0) {
             const compressed = await compressRecentConversation(messages);
             if (compressed && compressed.trim()) {
@@ -219,7 +297,7 @@ export default function register(api: OpenClawPluginApi): void {
           // silent fallback to 3-block content
         }
 
-        // 5. Write into OpenClaw's preferred tmp dir so the Telegram outbound
+        // 8. Write into OpenClaw's preferred tmp dir so the Telegram outbound
         //    pipeline's mediaLocalRoots allowlist accepts the file:// url.
         //    The basename becomes the delivered document filename.
         const safeId = senderId.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "user";
@@ -229,13 +307,17 @@ export default function register(api: OpenClawPluginApi): void {
         );
         await writeFile(tmpPath, finalContent, "utf-8");
 
-        // 6. Returning mediaUrl lets the outbound pipeline deliver it as a
+        // 9. Returning mediaUrl lets the outbound pipeline deliver it as a
         //    document (`.md` is not image/video/audio → api.sendDocument).
         //    The temp file is intentionally left for OpenClaw's tmp reaper:
         //    the send happens asynchronously after this handler returns, so
         //    unlinking here would race the upload.
+        const guidance =
+          agentId === "luna"
+            ? "내보냈어. 이 봇이 있는 그룹에 첨부 업로드하면 자동 인식돼. ⚠ 첨부 시 USER.md 본문이 그 그룹 jsonl 에 영구 기록되니 사적 내용 확인 후 올려."
+            : "내보냈어. 사용 안내: 젬마 있는 그룹에 이 .md 를 첨부 업로드하면 자동 인식돼.";
         return {
-          text: "내보냈어. 사용 안내: 젬마 있는 그룹에 이 .md 를 첨부 업로드하면 자동 인식돼.",
+          text: guidance,
           mediaUrl: `file://${tmpPath}`,
         };
       } catch (err) {

--- a/extensions/portable-context/openclaw.plugin.json
+++ b/extensions/portable-context/openclaw.plugin.json
@@ -1,0 +1,10 @@
+{
+  "id": "portable-context",
+  "name": "Portable Context",
+  "description": "Export this person's USER.md + MEMORY.md as a single portable .md document (DM only).",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/openclaw-pm2.sh
+++ b/openclaw-pm2.sh
@@ -22,6 +22,18 @@ export OPENCLAW_HALLUCINATION_GUARD_CHAT_ID=8324629902
 export OPENCLAW_HALLUCINATION_GUARD_API=http://127.0.0.1:9087/api/send
 export OPENCLAW_HALLUCINATION_GUARD_LOG_LEVEL=info
 
+# P2.18 (2026-05-21): tool_call arguments sanitize guard + false-negative
+# retry-promise watcher. 13:45 KST 사고 (gemma assistantText 채널의
+# 마크업 토큰 "<<|...|>" / "</code>" 가 tool_call args 채널까지
+# 전파되어 shell syntax error 박제 실패) 대응.
+export OPENCLAW_TOOL_ARG_SANITIZE_GUARD_ENABLED=1
+export OPENCLAW_TOOL_ARG_SANITIZE_REMOVE_SENTINEL=1
+export OPENCLAW_TOOL_ARG_SANITIZE_REMOVE_HTML_TAGS=1
+export OPENCLAW_TOOL_ARG_SANITIZE_BALANCE_QUOTE=1
+export OPENCLAW_FALSE_NEGATIVE_GUARD_ENABLED=1
+export OPENCLAW_FALSE_NEGATIVE_GUARD_MODE=warn
+export OPENCLAW_FALSE_NEGATIVE_GUARD_WINDOW_MS=10000
+
 # P6-3a 옵션 B (2026-05-18): SIGUSR1 가 in-process restart 로 전환되어
 # plugins.allow 등 plugins.* 변경 시 게이트웨이 PID 유지 (세션 단절 회피).
 # 근거: src/infra/process-respawn.ts:29, src/entry.ts:84

--- a/openclaw-pm2.sh
+++ b/openclaw-pm2.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# luna-memory plugin agent_end hook 이 /internal/dump-user-md 호출 시 쓰는 내부 토큰.
+# luna-memory-service/.env 의 LUNA_INTERNAL_TOKEN 과 동일 값이어야 함.
+export LUNA_INTERNAL_TOKEN=MTgXLfJB05pM030r3GAUOsy7rPtyxAqN
+
+# P2.12 도구 호출 반복 폭주 차단 활성화 (2026-05-19, gemma-memory follow-up).
+# tool-loop-detection.ts 가 기본 enabled:false 라 명시 활성화 필요.
+# WINDOW=4 → 5회 연속 동일 (toolName, args) 시 critical 차단 + synthetic blocked tool_result 주입.
+export OPENCLAW_TOOL_LOOP_GUARD_ENABLED=1
+export OPENCLAW_TOOL_LOOP_GUARD_WINDOW=4
+
+# P2.14 환각 가드 활성화 (2026-05-20, gemma-memory follow-up).
+# 5/20 ClaudeU TDLib 검증 결과 황선아·정유진 케이스 환각 재발 → 코드 가드 도입.
+# 조건 AND 4건 (gemma + 인명 패턴 + tool_use 0 + 거짓 도구 보고 키워드) 만족 시
+# memory.sh by-person 재실행 + 텔레그램 정정 메시지 발송.
+# CHAT_ID 는 @lisyoen_gemma_bot DM (8324629902). 미설정 시 정정 메시지 미발송.
+export OPENCLAW_HALLUCINATION_GUARD_ENABLED=1
+export OPENCLAW_HALLUCINATION_GUARD_AGENTS=gemma
+export OPENCLAW_HALLUCINATION_GUARD_TIMEOUT_MS=15000
+export OPENCLAW_HALLUCINATION_GUARD_MEMORY_SH=/home/lisyoen/.openclaw/agents/gemma/workspace/scripts/memory.sh
+export OPENCLAW_HALLUCINATION_GUARD_CHAT_ID=8324629902
+export OPENCLAW_HALLUCINATION_GUARD_API=http://127.0.0.1:9087/api/send
+export OPENCLAW_HALLUCINATION_GUARD_LOG_LEVEL=info
+
+# P6-3a 옵션 B (2026-05-18): SIGUSR1 가 in-process restart 로 전환되어
+# plugins.allow 등 plugins.* 변경 시 게이트웨이 PID 유지 (세션 단절 회피).
+# 근거: src/infra/process-respawn.ts:29, src/entry.ts:84
+export OPENCLAW_NO_RESPAWN=1
+
+exec /home/lisyoen/.nvm/versions/node/v22.22.0/bin/node \
+  /home/lisyoen/projects/openclaw/openclaw.mjs \
+  gateway --port 9086 --allow-unconfigured

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -7,7 +7,7 @@ import {
   getShellPathFromLoginShell,
   resolveShellEnvFallbackTimeoutMs,
 } from "../infra/shell-env.js";
-import { logInfo } from "../logger.js";
+import { logInfo, logWarn } from "../logger.js";
 import { parseAgentSessionKey, resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import { markBackgrounded } from "./bash-process-registry.js";
 import { processGatewayAllowlist } from "./bash-tools.exec-host-gateway.js";
@@ -44,6 +44,7 @@ import {
   truncateMiddle,
 } from "./bash-tools.shared.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
+import { sanitizeCommandInput } from "./tools/sanitize-command.js";
 
 export type { BashSandboxConfig } from "./bash-tools.shared.js";
 export type {
@@ -224,6 +225,18 @@ export function createExecTool(
 
       if (!params.command) {
         throw new Error("Provide a command to start.");
+      }
+
+      // Strip leaked LLM special tokens (e.g. <|...|>, <|<|") that smaller models
+      // (Gemma 4, etc.) sometimes emit into the command arg, which makes bash fail
+      // with a syntax error and forces the model to hallucinate. No-op for clean
+      // commands. Mirrors sanitize-url.ts (commit 7cbc14d38).
+      const rawCommand = params.command;
+      params.command = sanitizeCommandInput(rawCommand);
+      if (params.command !== rawCommand) {
+        logWarn(
+          `bash.sanitize_special_tokens original_len=${rawCommand.length} sanitized_len=${params.command.length}`,
+        );
       }
 
       const maxOutput = DEFAULT_MAX_OUTPUT;

--- a/src/agents/hallucination-guard.test.ts
+++ b/src/agents/hallucination-guard.test.ts
@@ -1,0 +1,357 @@
+/**
+ * Regression tests for the P2.14 hallucination guard (gemma-memory
+ * follow-up). The decisive verification is the TDLib end-to-end
+ * suite (proposals/gemma-memory.md §12.7); these unit tests cover
+ * the regex / pure-function surface only, so accidental tightening
+ * or loosening of the matchers shows up in CI.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  buildCorrectionText,
+  checkHallucinationGuard,
+  detectFalseToolReport,
+  extractPersonName,
+  getLastUserText,
+  getMessageText,
+  hasToolUse,
+  readEnvConfig,
+  runHallucinationGuardInline,
+  type HallucinationGuardConfig,
+  type MemoryShResult,
+} from "./hallucination-guard.js";
+
+function gemmaConfig(overrides: Partial<HallucinationGuardConfig> = {}): HallucinationGuardConfig {
+  return {
+    enabled: true,
+    agents: new Set(["gemma"]),
+    timeoutMs: 5000,
+    memoryShPath: "/tmp/memory.sh",
+    fallbackChatId: "8324629902",
+    fallbackApi: "http://127.0.0.1:9087/api/send",
+    logLevel: "info",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// U1 — extractPersonName: P1–P5 + blacklist + non-hangul
+// ---------------------------------------------------------------------------
+
+describe("U1 extractPersonName", () => {
+  it("matches P1 — '누구야' form", () => {
+    expect(extractPersonName("황선아가 누구야?")?.name).toBe("황선아");
+  });
+  it("matches P2 — '알지?' form", () => {
+    expect(extractPersonName("황선아라고 알지?")?.name).toBe("황선아");
+  });
+  it("matches P3 — '어떤 사람' form", () => {
+    expect(extractPersonName("황선아 어떤 사람이야?")?.name).toBe("황선아");
+  });
+  it("matches P4 — '에 대해 알려줘' form", () => {
+    expect(extractPersonName("정유진에 대해 알려줘")?.name).toBe("정유진");
+  });
+  it("matches P5 — '은/는 누구' form", () => {
+    expect(extractPersonName("이서현은 누구야")?.name).toBe("이서현");
+  });
+  it("rejects blacklisted '오늘'", () => {
+    // P1 matches '오늘은 누구야' but the captured token '오늘' is in the
+    // blacklist; downstream patterns should also miss → null.
+    expect(extractPersonName("오늘은 누구야?")).toBeNull();
+  });
+  it("rejects English-only names (MVP scope D15 — hangul only)", () => {
+    expect(extractPersonName("Kevin 알아?")).toBeNull();
+  });
+  it("returns null for non-person sentences", () => {
+    expect(extractPersonName("잘 있지?")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// U2 — detectFalseToolReport: F1–F8 + clean text
+// ---------------------------------------------------------------------------
+
+describe("U2 detectFalseToolReport", () => {
+  it.each([
+    ["F1: 메모리를 검색", "메모리를 검색해 봤는데 없었어"],
+    ["F2: 검색해 봤어", "방금 검색해 봤지만 결과가 없어"],
+    ["F3: 기억이 없", "내 기억이 없어"],
+    ["F4: 기록이 없", "관련 기록이 없네"],
+    ["F5: 정보가 없", "정보가 없어"],
+    ["F6: memory_search()", "memory_search 했지만 hit 없음"],
+    ["F7: Snippet 내용을 바탕으로", "Snippet 내용을 바탕으로 정리하면"],
+    ["F8: 파일을 확인해 봤", "파일을 확인해 봤지만 없었어"],
+  ])("matches %s", (_label, text) => {
+    expect(detectFalseToolReport(text)).toBe(true);
+  });
+  it("does not match clean assistant text", () => {
+    expect(detectFalseToolReport("잘 지내고 있어. 오늘도 화이팅!")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// U3 — hasToolUse + getMessageText (content shape helpers)
+// ---------------------------------------------------------------------------
+
+describe("U3 hasToolUse / getMessageText", () => {
+  it("returns true when content has a tool_use block", () => {
+    const message = {
+      role: "assistant",
+      content: [
+        { type: "text", text: "calling tool" },
+        { type: "tool_use", name: "read", input: {} },
+      ],
+    };
+    expect(hasToolUse(message)).toBe(true);
+  });
+  it("returns false for text-only content", () => {
+    const message = {
+      role: "assistant",
+      content: [{ type: "text", text: "메모리를 검색해 봤는데 없어" }],
+    };
+    expect(hasToolUse(message)).toBe(false);
+  });
+  it("getMessageText concatenates all text blocks", () => {
+    const message = {
+      role: "assistant",
+      content: [
+        { type: "text", text: "첫번째" },
+        { type: "text", text: "두번째" },
+      ],
+    };
+    expect(getMessageText(message)).toBe("첫번째\n두번째");
+  });
+  it("getLastUserText finds the latest user message", () => {
+    const messages = [
+      { role: "user", content: [{ type: "text", text: "안녕" }] },
+      { role: "assistant", content: [{ type: "text", text: "응 안녕" }] },
+      { role: "user", content: [{ type: "text", text: "황선아라고 알지?" }] },
+    ];
+    expect(getLastUserText(messages)).toBe("황선아라고 알지?");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// U4 — checkHallucinationGuard: AND-of-4 trigger
+// ---------------------------------------------------------------------------
+
+describe("U4 checkHallucinationGuard", () => {
+  const userMsg = {
+    role: "user",
+    content: [{ type: "text", text: "황선아라고 알지?" }],
+  };
+  const hallucinatedAssistant = {
+    role: "assistant",
+    content: [{ type: "text", text: "메모리를 검색해 봤는데 기억이 없어" }],
+  };
+
+  it("triggers when all four conditions hold", () => {
+    const result = checkHallucinationGuard({
+      agentId: "gemma",
+      messages: [userMsg, hallucinatedAssistant],
+      lastAssistant: hallucinatedAssistant,
+      config: gemmaConfig(),
+    });
+    expect(result.triggered).toBe(true);
+    if (result.triggered) {
+      expect(result.personName).toBe("황선아");
+    }
+  });
+
+  it("does not trigger when guard is disabled", () => {
+    const result = checkHallucinationGuard({
+      agentId: "gemma",
+      messages: [userMsg, hallucinatedAssistant],
+      lastAssistant: hallucinatedAssistant,
+      config: gemmaConfig({ enabled: false }),
+    });
+    expect(result.triggered).toBe(false);
+    if (!result.triggered) {
+      expect(result.reason).toBe("disabled");
+    }
+  });
+
+  it("does not trigger for non-whitelisted agent", () => {
+    const result = checkHallucinationGuard({
+      agentId: "main",
+      messages: [userMsg, hallucinatedAssistant],
+      lastAssistant: hallucinatedAssistant,
+      config: gemmaConfig(),
+    });
+    expect(result.triggered).toBe(false);
+    if (!result.triggered) {
+      expect(result.reason).toBe("agent-not-in-whitelist");
+    }
+  });
+
+  it("does not trigger when user message lacks a person name", () => {
+    const benignUser = {
+      role: "user",
+      content: [{ type: "text", text: "잘 있지?" }],
+    };
+    const result = checkHallucinationGuard({
+      agentId: "gemma",
+      messages: [benignUser, hallucinatedAssistant],
+      lastAssistant: hallucinatedAssistant,
+      config: gemmaConfig(),
+    });
+    expect(result.triggered).toBe(false);
+    if (!result.triggered) {
+      expect(result.reason).toBe("no-person-pattern");
+    }
+  });
+
+  it("does not trigger when assistant invoked a tool", () => {
+    const toolUsingAssistant = {
+      role: "assistant",
+      content: [
+        { type: "text", text: "메모리를 검색해 봤어" },
+        { type: "tool_use", name: "read", input: { path: "people/황선아.md" } },
+      ],
+    };
+    const result = checkHallucinationGuard({
+      agentId: "gemma",
+      messages: [userMsg, toolUsingAssistant],
+      lastAssistant: toolUsingAssistant,
+      config: gemmaConfig(),
+    });
+    expect(result.triggered).toBe(false);
+    if (!result.triggered) {
+      expect(result.reason).toBe("has-tool-use");
+    }
+  });
+
+  it("does not trigger when assistant text contains no false-tool-report keyword", () => {
+    const cleanAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "황선아는 우리 회사 신입사원이야. 친절해." }],
+    };
+    const result = checkHallucinationGuard({
+      agentId: "gemma",
+      messages: [userMsg, cleanAssistant],
+      lastAssistant: cleanAssistant,
+      config: gemmaConfig(),
+    });
+    expect(result.triggered).toBe(false);
+    if (!result.triggered) {
+      expect(result.reason).toBe("no-false-report");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// U5 — runHallucinationGuardInline with mock memory.sh + sender
+// ---------------------------------------------------------------------------
+
+describe("U5 runHallucinationGuardInline", () => {
+  const userMsg = {
+    role: "user",
+    content: [{ type: "text", text: "황선아라고 알지?" }],
+  };
+  const hallucinatedAssistant = {
+    role: "assistant",
+    content: [{ type: "text", text: "메모리를 검색해 봤는데 기억이 없어" }],
+  };
+
+  it("runs memory.sh and posts fallback on trigger", async () => {
+    const memoryCalls: string[] = [];
+    const sendCalls: Array<{ chatId: string; text: string }> = [];
+    const result = await runHallucinationGuardInline({
+      agentId: "gemma",
+      messages: [userMsg, hallucinatedAssistant],
+      lastAssistant: hallucinatedAssistant,
+      config: gemmaConfig(),
+      runMemoryShFn: async (_path, name) => {
+        memoryCalls.push(name);
+        const ok: MemoryShResult = {
+          status: "ok",
+          matches: 2,
+          stdout: "match line\nRESULT: OK | matches: 2",
+        };
+        return ok;
+      },
+      sendFallbackFn: async (_api, chatId, text) => {
+        sendCalls.push({ chatId, text });
+        return { ok: true, status: 200 };
+      },
+    });
+    expect(result.triggered).toBe(true);
+    expect(result.memoryStatus).toBe("ok");
+    expect(result.fallbackSent).toBe(true);
+    expect(memoryCalls).toEqual(["황선아"]);
+    expect(sendCalls).toHaveLength(1);
+    expect(sendCalls[0]?.chatId).toBe("8324629902");
+    expect(sendCalls[0]?.text).toContain("(가드)");
+    expect(sendCalls[0]?.text).toContain("황선아");
+  });
+
+  it("does not call memory.sh or fallback when not triggered", async () => {
+    let memoryCalled = false;
+    let sendCalled = false;
+    const result = await runHallucinationGuardInline({
+      agentId: "kevin",
+      messages: [userMsg, hallucinatedAssistant],
+      lastAssistant: hallucinatedAssistant,
+      config: gemmaConfig(),
+      runMemoryShFn: async () => {
+        memoryCalled = true;
+        return { status: "ok", matches: 0, stdout: "" };
+      },
+      sendFallbackFn: async () => {
+        sendCalled = true;
+        return { ok: true, status: 200 };
+      },
+    });
+    expect(result.triggered).toBe(false);
+    expect(result.reason).toBe("agent-not-in-whitelist");
+    expect(memoryCalled).toBe(false);
+    expect(sendCalled).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildCorrectionText (kept inline — small surface)
+// ---------------------------------------------------------------------------
+
+describe("buildCorrectionText", () => {
+  it("includes the memory.sh stdout on ok status", () => {
+    const text = buildCorrectionText("황선아", {
+      status: "ok",
+      matches: 1,
+      stdout: "people/황선아.md\nRESULT: OK | matches: 1",
+    });
+    expect(text).toContain("(가드)");
+    expect(text).toContain("황선아");
+    expect(text).toContain("memory.sh");
+  });
+  it("emits a not-found fallback on failed status", () => {
+    const text = buildCorrectionText("이존재안함", {
+      status: "failed",
+      reason: "matches=0",
+      stdout: "",
+    });
+    expect(text).toContain("못 찾았어");
+    expect(text).toContain("이존재안함");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readEnvConfig (env parsing surface)
+// ---------------------------------------------------------------------------
+
+describe("readEnvConfig", () => {
+  it("defaults to enabled + gemma-only", () => {
+    const cfg = readEnvConfig({});
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.agents.has("gemma")).toBe(true);
+  });
+  it("honours OPENCLAW_HALLUCINATION_GUARD_ENABLED=0", () => {
+    const cfg = readEnvConfig({ OPENCLAW_HALLUCINATION_GUARD_ENABLED: "0" });
+    expect(cfg.enabled).toBe(false);
+  });
+  it("parses agent whitelist from comma-separated env", () => {
+    const cfg = readEnvConfig({ OPENCLAW_HALLUCINATION_GUARD_AGENTS: "gemma, kevin" });
+    expect(cfg.agents.has("gemma")).toBe(true);
+    expect(cfg.agents.has("kevin")).toBe(true);
+  });
+});

--- a/src/agents/hallucination-guard.ts
+++ b/src/agents/hallucination-guard.ts
@@ -1,0 +1,614 @@
+/**
+ * Hallucination guard for gemma-style local models that fabricate tool
+ * usage in plain text. P2.14 (gemma-memory follow-up).
+ *
+ * Background: 2026-05-20 ClaudeU TDLib verification reproduced two
+ * patterns that earlier fixes (P2.10 TOOLS.md hardening, P2.11
+ * sentinel sanitize, P2.12 tool-loop block) did not address:
+ *
+ *   user "황선아라고 알지?"
+ *   → assistant "메모리를 검색해 봤는데… 기억 속에 구체적인 정보가 없어…"
+ *   → OpenClaw log: 0 tool_use blocks, 0 memory.sh by-person calls
+ *
+ * The text claims a tool was called but the agent never actually issued
+ * a tool_use. P2.10 study concluded that TOOLS.md cheat-sheet text
+ * hardening cannot steer Gemma 4 26B sampling away from this failure —
+ * only a runtime code guard can.
+ *
+ * Trigger (AND, all four must hold):
+ *   1. agent in OPENCLAW_HALLUCINATION_GUARD_AGENTS whitelist
+ *      (default: "gemma")
+ *   2. last user message matches a Korean person-query pattern (P1-P5)
+ *      and the captured name is not in the blacklist
+ *   3. last assistant message is text-only (content has no tool_use
+ *      blocks)
+ *   4. assistant text matches a false-tool-report pattern (F1-F8)
+ *
+ * On trigger, the guard re-runs the workspace memory.sh by-person
+ * script and posts a corrective follow-up message on the same telegram
+ * chat as a fire-and-forget side channel. The original (false) message
+ * has already been delivered — the correction follows. This is an
+ * MVP integration constraint: the plugin agent_end hook fires after
+ * delivery and the message_sending hook ctx lacks agentId
+ * (deliver.ts:415 metadata omission). See proposals/gemma-memory.md
+ * §12 for the full design and §12.5 for the upgrade path.
+ *
+ * The guard is gemma-scoped by default and has no effect on other
+ * agents. It is disabled with OPENCLAW_HALLUCINATION_GUARD_ENABLED=0.
+ */
+
+import { spawn } from "node:child_process";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("agents/hallucination-guard");
+
+// ---------------------------------------------------------------------------
+// Configuration (env knobs follow the P2.12 pattern)
+// ---------------------------------------------------------------------------
+
+const ENV_ENABLED = "OPENCLAW_HALLUCINATION_GUARD_ENABLED";
+const ENV_AGENTS = "OPENCLAW_HALLUCINATION_GUARD_AGENTS";
+const ENV_TIMEOUT_MS = "OPENCLAW_HALLUCINATION_GUARD_TIMEOUT_MS";
+const ENV_MEMORY_SH = "OPENCLAW_HALLUCINATION_GUARD_MEMORY_SH";
+const ENV_FALLBACK_CHAT_ID = "OPENCLAW_HALLUCINATION_GUARD_CHAT_ID";
+const ENV_FALLBACK_API = "OPENCLAW_HALLUCINATION_GUARD_API";
+const ENV_LOG_LEVEL = "OPENCLAW_HALLUCINATION_GUARD_LOG_LEVEL";
+
+const DEFAULT_AGENTS = "gemma";
+const DEFAULT_TIMEOUT_MS = 15000;
+const DEFAULT_MEMORY_SH = "/home/lisyoen/.openclaw/agents/gemma/workspace/scripts/memory.sh";
+const DEFAULT_FALLBACK_API = "http://127.0.0.1:9087/api/send";
+
+export type HallucinationGuardConfig = {
+  enabled: boolean;
+  agents: ReadonlySet<string>;
+  timeoutMs: number;
+  memoryShPath: string;
+  fallbackChatId: string | null;
+  fallbackApi: string;
+  logLevel: "debug" | "info" | "warn";
+};
+
+export function readEnvConfig(env: NodeJS.ProcessEnv = process.env): HallucinationGuardConfig {
+  const enabledRaw = (env[ENV_ENABLED] ?? "1").trim().toLowerCase();
+  const enabled = enabledRaw !== "0" && enabledRaw !== "false" && enabledRaw !== "no";
+  const agentsRaw = (env[ENV_AGENTS] ?? DEFAULT_AGENTS).trim();
+  const agents = new Set(
+    agentsRaw
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0),
+  );
+  const timeoutRaw = Number.parseInt(env[ENV_TIMEOUT_MS] ?? "", 10);
+  const timeoutMs = Number.isFinite(timeoutRaw) && timeoutRaw > 0 ? timeoutRaw : DEFAULT_TIMEOUT_MS;
+  const memoryShPath = (env[ENV_MEMORY_SH] ?? DEFAULT_MEMORY_SH).trim();
+  const fallbackChatIdRaw = (env[ENV_FALLBACK_CHAT_ID] ?? "").trim();
+  const fallbackChatId = fallbackChatIdRaw.length > 0 ? fallbackChatIdRaw : null;
+  const fallbackApi = (env[ENV_FALLBACK_API] ?? DEFAULT_FALLBACK_API).trim();
+  const logLevelRaw = (env[ENV_LOG_LEVEL] ?? "info").trim().toLowerCase();
+  const logLevel = logLevelRaw === "debug" || logLevelRaw === "warn" ? logLevelRaw : "info";
+  return {
+    enabled,
+    agents,
+    timeoutMs,
+    memoryShPath,
+    fallbackChatId,
+    fallbackApi,
+    logLevel,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pure pattern matchers
+// ---------------------------------------------------------------------------
+
+/**
+ * Korean person-query patterns (P1-P5). Match a 2-5 hangul-char name
+ * embedded in question forms. Names captured here are still subject to
+ * the blacklist below.
+ *
+ * MVP scope (D15): hangul only. English / hanja / mixed names are out
+ * of scope for P2.14 — no hallucination cases were observed for those
+ * in the 2026-05-20 reproduction.
+ */
+const PERSON_QUERY_PATTERNS: ReadonlyArray<RegExp> = [
+  // P1: "<이름>(이)? (가|는|을|를)? 누구(야|입니까|예요|니|냐)"
+  /([가-힣]{2,5}?)(?:이)?\s*(?:가|는|은|을|를)?\s*누구(?:야|입니까|예요|니|냐)/,
+  // P2: "<이름>(이라고|라고)? 알(아|지|아요|아\?)"
+  /([가-힣]{2,5}?)(?:이라고|라고)?\s*알(?:아|지|아요)\??/,
+  // P3: "<이름>(이|가)? 어떤 사람"
+  /([가-힣]{2,5}?)(?:이|가)?\s*어떤\s*사람/,
+  // P4: "<이름> (이|에|을|를|에 대해|에 관해) (기억|아는|알려)"
+  /([가-힣]{2,5}?)(?:이|에|을|를|에\s*대해|에\s*관해)\s*(?:기억|아는|알려)/,
+  // P5: "<이름>(은|는) (누구|어떤)"
+  /([가-힣]{2,5}?)(?:은|는)\s*(?:누구|어떤)/,
+];
+
+/**
+ * Hangul tokens that fit the [가-힣]{2,5}? regex but are obviously not
+ * person names. Filtering these here avoids false positives on common
+ * time/pronoun phrases.
+ */
+const PERSON_NAME_BLACKLIST: ReadonlySet<string> = new Set([
+  "오늘",
+  "내일",
+  "어제",
+  "그제",
+  "모레",
+  "이번",
+  "저번",
+  "다음",
+  "지난",
+  "요즘",
+  "나는",
+  "내가",
+  "우리",
+  "우리는",
+  "너는",
+  "네가",
+]);
+
+/**
+ * False-tool-report patterns (F1-F8). Match phrases the model uses to
+ * *claim* a memory or filesystem lookup happened. Any single match
+ * suffices.
+ */
+const FALSE_TOOL_REPORT_PATTERNS: ReadonlyArray<RegExp> = [
+  // F1: 메모리(를|에서)? (검색|찾아|뒤져|훑어|확인)
+  /메모리(?:를|에서)?\s*(?:검색|찾아|뒤져|훑어|확인)/,
+  // F2: (검색|찾아|뒤져|훑어|확인)(해|봤|을)
+  /(?:검색|찾아|뒤져|훑어|확인)(?:해|봤|을)/,
+  // F3: 기억(이|에)? 없
+  /기억(?:이|에)?\s*없/,
+  // F4: 기록(이|에)? 없
+  /기록(?:이|에)?\s*없/,
+  // F5: 정보(가|는|에)? 없
+  /정보(?:가|는|에)?\s*없/,
+  // F6: memory_(search|lookup|get|find)
+  /memory_(?:search|lookup|get|find)/,
+  // F7: 5/17 박제 환각 키워드
+  /Snippet\s*내용을?\s*바탕으로/,
+  // F8: (파일|디렉토리|폴더)(을|를|에서)? (찾|확인|검색)(아|해)? 봤
+  /(?:파일|디렉토리|폴더)(?:을|를|에서)?\s*(?:찾|확인|검색)(?:아|해)?\s*봤/,
+];
+
+export type PersonNameMatch = {
+  name: string;
+  patternIndex: number;
+};
+
+/**
+ * Extract the first plausible person name from a user message.
+ * Returns null when no pattern matches or when the captured token is
+ * in the blacklist.
+ */
+export function extractPersonName(text: string): PersonNameMatch | null {
+  if (typeof text !== "string" || text.length === 0) {
+    return null;
+  }
+  for (let i = 0; i < PERSON_QUERY_PATTERNS.length; i++) {
+    const pattern = PERSON_QUERY_PATTERNS[i];
+    if (!pattern) {
+      continue;
+    }
+    const match = pattern.exec(text);
+    if (!match) {
+      continue;
+    }
+    const captured = match[1];
+    if (typeof captured !== "string" || captured.length === 0) {
+      continue;
+    }
+    if (PERSON_NAME_BLACKLIST.has(captured)) {
+      // Captured token is blacklisted — keep scanning later patterns.
+      // The same text may legitimately contain a different name elsewhere.
+      continue;
+    }
+    return { name: captured, patternIndex: i };
+  }
+  return null;
+}
+
+/**
+ * Returns true when any false-tool-report pattern matches.
+ */
+/**
+ * Broad-negation fallback (F9). The narrow F1-F8 patterns assume the
+ * negation sits directly after the subject; the model frequently pads
+ * with adverbs ("정보가 *전혀* 없어", "복구되지 *않아서*") or splits
+ * the subject and the negation across a longer clause. F9 fires when
+ * the same sentence contains BOTH a tool/system mention AND a negation
+ * keyword — captured by these two complementary regexes.
+ */
+const FALSE_TOOL_REPORT_NEGATION =
+  /없어|없네|없습니다|없죠|모르겠|모릅니다|모른다|되지\s*않|되지\s*못|안\s*돼/;
+const FALSE_TOOL_REPORT_SUBJECT =
+  /메모리|기억|기록|정보|파일|디렉토리|폴더|MD|시스템|기능|데이터베이스|업데이트|학습|기록이|기록은|기록도/;
+
+export function detectFalseToolReport(text: string): boolean {
+  if (typeof text !== "string" || text.length === 0) {
+    return false;
+  }
+  for (const pattern of FALSE_TOOL_REPORT_PATTERNS) {
+    if (pattern.test(text)) {
+      return true;
+    }
+  }
+  // F9: any sentence containing both a tool/system subject keyword
+  // and a negation keyword. Less precise than F1-F8 but catches the
+  // padded-adverb wordings observed on 2026-05-20.
+  if (FALSE_TOOL_REPORT_NEGATION.test(text) && FALSE_TOOL_REPORT_SUBJECT.test(text)) {
+    return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Message extraction (defensive — the upstream payload is `unknown`)
+// ---------------------------------------------------------------------------
+
+type ContentBlock = { type?: unknown; text?: unknown } & Record<string, unknown>;
+type MessageLike = {
+  role?: unknown;
+  content?: unknown;
+} & Record<string, unknown>;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asContentArray(message: unknown): ContentBlock[] {
+  if (!isPlainObject(message)) {
+    return [];
+  }
+  const content = (message as MessageLike).content;
+  if (Array.isArray(content)) {
+    return content.filter((c): c is ContentBlock => isPlainObject(c));
+  }
+  return [];
+}
+
+/**
+ * Returns true when the message has at least one tool_use content
+ * block. A text-only assistant message returns false.
+ */
+export function hasToolUse(message: unknown): boolean {
+  for (const block of asContentArray(message)) {
+    if (block.type === "tool_use") {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Concatenate all text-block bodies on a message. String-content
+ * messages (legacy shape) are returned as-is.
+ */
+export function getMessageText(message: unknown): string {
+  if (!isPlainObject(message)) {
+    return "";
+  }
+  const content = (message as MessageLike).content;
+  if (typeof content === "string") {
+    return content;
+  }
+  const parts: string[] = [];
+  for (const block of asContentArray(message)) {
+    if (block.type === "text" && typeof block.text === "string") {
+      parts.push(block.text);
+    }
+  }
+  return parts.join("\n");
+}
+
+/**
+ * Find the last user message in a transcript snapshot and return its
+ * concatenated text content. Returns empty string when no user
+ * message is present.
+ */
+export function getLastUserText(messages: unknown): string {
+  if (!Array.isArray(messages)) {
+    return "";
+  }
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (isPlainObject(m) && (m as MessageLike).role === "user") {
+      return getMessageText(m);
+    }
+  }
+  return "";
+}
+
+// ---------------------------------------------------------------------------
+// Trigger check
+// ---------------------------------------------------------------------------
+
+export type GuardCheckResult =
+  | { triggered: false; reason: string }
+  | { triggered: true; personName: string; patternIndex: number };
+
+export type CheckGuardInput = {
+  agentId: string | undefined;
+  messages: unknown;
+  lastAssistant: unknown;
+  config: HallucinationGuardConfig;
+};
+
+export function checkHallucinationGuard(input: CheckGuardInput): GuardCheckResult {
+  const { agentId, messages, lastAssistant, config } = input;
+
+  if (!config.enabled) {
+    return { triggered: false, reason: "disabled" };
+  }
+  if (typeof agentId !== "string" || agentId.length === 0) {
+    return { triggered: false, reason: "no-agent-id" };
+  }
+  if (!config.agents.has(agentId)) {
+    return { triggered: false, reason: "agent-not-in-whitelist" };
+  }
+
+  const userText = getLastUserText(messages);
+  if (userText.length === 0) {
+    return { triggered: false, reason: "no-user-message" };
+  }
+  const personMatch = extractPersonName(userText);
+  if (!personMatch) {
+    return { triggered: false, reason: "no-person-pattern" };
+  }
+
+  if (hasToolUse(lastAssistant)) {
+    return { triggered: false, reason: "has-tool-use" };
+  }
+
+  const assistantText = getMessageText(lastAssistant);
+  if (!detectFalseToolReport(assistantText)) {
+    return { triggered: false, reason: "no-false-report" };
+  }
+
+  return {
+    triggered: true,
+    personName: personMatch.name,
+    patternIndex: personMatch.patternIndex,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// memory.sh runner with hard timeout
+// ---------------------------------------------------------------------------
+
+export type MemoryShResult =
+  | { status: "ok"; matches: number; stdout: string }
+  | { status: "failed"; reason: string; stdout: string }
+  | { status: "error"; errorMessage: string };
+
+export type RunMemoryShDeps = {
+  /** Override the spawner for tests. Defaults to node:child_process spawn. */
+  spawnFn?: typeof spawn;
+};
+
+/**
+ * Run `memory.sh by-person <name>` with a hard timeout. Parses the
+ * trailing RESULT line for `matches: <N>` to classify ok vs failed.
+ */
+export async function runMemorySh(
+  scriptPath: string,
+  personName: string,
+  timeoutMs: number,
+  deps: RunMemoryShDeps = {},
+): Promise<MemoryShResult> {
+  const spawner = deps.spawnFn ?? spawn;
+  return new Promise<MemoryShResult>((resolve) => {
+    let settled = false;
+    const child = spawner("bash", [scriptPath, "by-person", personName], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    const settle = (result: MemoryShResult) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // ignore — child already exited
+      }
+      resolve(result);
+    };
+    const timer = setTimeout(() => {
+      settle({ status: "error", errorMessage: `timeout after ${timeoutMs}ms` });
+    }, timeoutMs);
+    child.stdout?.on("data", (chunk: Buffer | string) => {
+      stdout += typeof chunk === "string" ? chunk : chunk.toString("utf-8");
+    });
+    child.stderr?.on("data", (chunk: Buffer | string) => {
+      stderr += typeof chunk === "string" ? chunk : chunk.toString("utf-8");
+    });
+    child.on("error", (err: Error) => {
+      clearTimeout(timer);
+      settle({ status: "error", errorMessage: String(err) });
+    });
+    child.on("close", (code: number | null) => {
+      clearTimeout(timer);
+      if (code !== 0) {
+        settle({
+          status: "error",
+          errorMessage: `exit ${code ?? "null"}: ${stderr.slice(0, 200)}`,
+        });
+        return;
+      }
+      const matchesMatch = /RESULT:\s*OK[^\n]*matches:\s*(\d+)/i.exec(stdout);
+      if (matchesMatch && matchesMatch[1]) {
+        const matches = Number.parseInt(matchesMatch[1], 10);
+        if (matches > 0) {
+          settle({ status: "ok", matches, stdout });
+          return;
+        }
+        settle({ status: "failed", reason: "matches=0", stdout });
+        return;
+      }
+      // No RESULT line — treat as failed but keep stdout for log.
+      settle({ status: "failed", reason: "no-result-line", stdout });
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Telegram fallback delivery (POST /api/send)
+// ---------------------------------------------------------------------------
+
+export type SendFallbackResult =
+  | { ok: true; status: number }
+  | { ok: false; status: number | null; errorMessage: string };
+
+export type SendFallbackDeps = {
+  fetchFn?: typeof fetch;
+};
+
+export async function sendFallbackMessage(
+  apiUrl: string,
+  chatId: string,
+  text: string,
+  timeoutMs: number,
+  deps: SendFallbackDeps = {},
+): Promise<SendFallbackResult> {
+  const fetcher = deps.fetchFn ?? fetch;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetcher(apiUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ chat_id: chatId, text }),
+      signal: controller.signal,
+    });
+    if (res.ok) {
+      return { ok: true, status: res.status };
+    }
+    return {
+      ok: false,
+      status: res.status,
+      errorMessage: `http ${res.status}`,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      status: null,
+      errorMessage: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Inline guard entry point — called from attempt.ts after agent_end hook
+// ---------------------------------------------------------------------------
+
+export type RunGuardInlineInput = {
+  agentId: string | undefined;
+  messages: unknown;
+  lastAssistant: unknown;
+  /** Override env config (tests). */
+  config?: HallucinationGuardConfig;
+  /** Override env source (tests). */
+  env?: NodeJS.ProcessEnv;
+  /** Test seam for memory.sh. */
+  runMemoryShFn?: typeof runMemorySh;
+  /** Test seam for telegram POST. */
+  sendFallbackFn?: typeof sendFallbackMessage;
+};
+
+export type RunGuardInlineResult = {
+  triggered: boolean;
+  reason: string;
+  memoryStatus?: MemoryShResult["status"];
+  fallbackSent?: boolean;
+};
+
+/**
+ * Build the corrective message body sent to the user. Kept as a pure
+ * function so the format is unit-testable.
+ */
+export function buildCorrectionText(personName: string, memoryResult: MemoryShResult): string {
+  if (memoryResult.status === "ok") {
+    const stdout = memoryResult.stdout.trim();
+    // Trim stdout to keep telegram message size reasonable.
+    const trimmed = stdout.length > 3500 ? `${stdout.slice(0, 3500)}\n…(truncated)` : stdout;
+    return `(가드) 직전 답변은 도구 호출 없이 작성됐어. memory.sh 로 ${personName} 다시 확인한 결과:\n\n${trimmed}`;
+  }
+  if (memoryResult.status === "failed") {
+    return `(가드) memory/ 에서 '${personName}' 관련 일지 못 찾았어. people/${personName}.md 인물 카드도 확인할까? (정확한 이름 알려줘)`;
+  }
+  return `(가드) ${personName} 관련 메모리 조회 실패: ${memoryResult.errorMessage}`;
+}
+
+export async function runHallucinationGuardInline(
+  input: RunGuardInlineInput,
+): Promise<RunGuardInlineResult> {
+  const config = input.config ?? readEnvConfig(input.env);
+
+  const check = checkHallucinationGuard({
+    agentId: input.agentId,
+    messages: input.messages,
+    lastAssistant: input.lastAssistant,
+    config,
+  });
+
+  if (!check.triggered) {
+    if (config.logLevel === "debug") {
+      log.debug(`hallucination-guard skipped: ${check.reason}`);
+    }
+    return { triggered: false, reason: check.reason };
+  }
+
+  log.info(
+    `hallucination-guard triggered: agent=${input.agentId ?? "?"} person=${check.personName} pattern=P${check.patternIndex + 1}`,
+  );
+
+  const runner = input.runMemoryShFn ?? runMemorySh;
+  const memoryResult = await runner(config.memoryShPath, check.personName, config.timeoutMs);
+
+  log.info(
+    `hallucination-guard memory.sh result: status=${memoryResult.status}` +
+      (memoryResult.status === "ok" ? ` matches=${memoryResult.matches}` : "") +
+      (memoryResult.status === "failed" ? ` reason=${memoryResult.reason}` : "") +
+      (memoryResult.status === "error" ? ` error=${memoryResult.errorMessage}` : ""),
+  );
+
+  if (!config.fallbackChatId) {
+    log.warn("hallucination-guard fallback skipped: OPENCLAW_HALLUCINATION_GUARD_CHAT_ID not set");
+    return {
+      triggered: true,
+      reason: "triggered",
+      memoryStatus: memoryResult.status,
+      fallbackSent: false,
+    };
+  }
+
+  const text = buildCorrectionText(check.personName, memoryResult);
+  const sender = input.sendFallbackFn ?? sendFallbackMessage;
+  const sendResult = await sender(
+    config.fallbackApi,
+    config.fallbackChatId,
+    text,
+    config.timeoutMs,
+  );
+
+  if (sendResult.ok) {
+    log.info(`hallucination-guard fallback delivered (status=${sendResult.status})`);
+  } else {
+    log.warn(
+      `hallucination-guard fallback failed: status=${sendResult.status ?? "null"} err=${sendResult.errorMessage ?? ""}`,
+    );
+  }
+
+  return {
+    triggered: true,
+    reason: "triggered",
+    memoryStatus: memoryResult.status,
+    fallbackSent: sendResult.ok,
+  };
+}

--- a/src/agents/p2-24.test.ts
+++ b/src/agents/p2-24.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import {
+  applyReadEmptyArgsGuard,
+  extractPathCandidatesFromUserMessage,
+  isReadPathEmpty,
+  setLastUserMessageTextForReadFallback,
+  __resetReadEmptyArgsGuardForTest,
+} from "./pi-tools.read-guards.js";
+import { sanitizeString, sanitizeToolArgs } from "./tool-arg-sanitize-guard.js";
+import type { ToolArgSanitizeConfig } from "./tool-arg-sanitize-guard.js";
+
+const cfg: ToolArgSanitizeConfig = {
+  enabled: true,
+  removeSentinel: true,
+  removeHtmlTags: true,
+  balanceQuote: true,
+  htmlAllowlist: new Set<string>(),
+  maxFieldLen: 65536,
+};
+
+describe("P2.24b — exec/bash sanitize cmd/script fields", () => {
+  it("E1: sentinel-only — <|find . -name 'aurora.md' → strips <| prefix", () => {
+    const input = '<|find . -name "aurora-somin-plan-2026-05-22.md"';
+    const r = sanitizeToolArgs({ command: input }, "exec", cfg);
+    expect(r.changed).toBe(true);
+    expect(r.args.command).toBe('find . -name "aurora-somin-plan-2026-05-22.md"');
+  });
+
+  it("E1b: cmd field also sanitized (P2.24b)", () => {
+    const input = "<|ls -la";
+    const r = sanitizeToolArgs({ cmd: input }, "bash", cfg);
+    expect(r.changed).toBe(true);
+    expect(r.args.cmd).toBe("ls -la");
+  });
+
+  it("E1c: script field also sanitized (P2.24b)", () => {
+    const input = "<|echo hello";
+    const r = sanitizeToolArgs({ script: input }, "exec", cfg);
+    expect(r.changed).toBe(true);
+    expect(r.args.script).toBe("echo hello");
+  });
+
+  it("E2: html-only — <b>text</b> → strips html tags", () => {
+    const r = sanitizeToolArgs({ command: "<b>echo</b> hello" }, "exec", cfg);
+    expect(r.changed).toBe(true);
+    expect((r.args.command as string).includes("<b>")).toBe(false);
+  });
+
+  it("E3: sentinel + odd dquote — balance applied", () => {
+    const input = '<|echo "unbalanced';
+    const r = sanitizeToolArgs({ command: input }, "exec", cfg);
+    expect(r.changed).toBe(true);
+    // sentinel 제거 후 odd dquote 는 balance-quote 룰 적용 (또는 그대로 — 케이스마다)
+    expect((r.args.command as string).includes("<|")).toBe(false);
+  });
+
+  it("E4: nested sentinel — <<|find|ls.|>", () => {
+    const input = "<<|find|>ls -la";
+    const r = sanitizeToolArgs({ command: input }, "exec", cfg);
+    expect(r.changed).toBe(true);
+    expect((r.args.command as string).includes("<<|")).toBe(false);
+  });
+
+  it("E5: no-change passthrough — clean command", () => {
+    const input = "ls -la /home";
+    const r = sanitizeToolArgs({ command: input }, "exec", cfg);
+    expect(r.args.command).toBe(input);
+    // E5 는 mutations 가 0 이어야 함 (변화 없음)
+    expect(r.mutations.length).toBe(0);
+  });
+});
+
+describe("P2.24a — read empty path guard", () => {
+  beforeEach(() => {
+    __resetReadEmptyArgsGuardForTest();
+  });
+
+  it("isReadPathEmpty detects empty/null/undefined/non-string", () => {
+    expect(isReadPathEmpty("")).toBe(true);
+    expect(isReadPathEmpty(null)).toBe(true);
+    expect(isReadPathEmpty(undefined)).toBe(true);
+    expect(isReadPathEmpty("   ")).toBe(true);
+    expect(isReadPathEmpty(123)).toBe(true);
+    expect(isReadPathEmpty("memory/foo.md")).toBe(false);
+  });
+
+  it("extractPathCandidatesFromUserMessage finds .md and memory/* patterns", () => {
+    const text = "aurora-somin-plan-2026-05-22.md 읽어봐";
+    const cands = extractPathCandidatesFromUserMessage(text);
+    expect(cands).toContain("aurora-somin-plan-2026-05-22.md");
+  });
+
+  it("first empty call with single candidate → auto-extract", () => {
+    setLastUserMessageTextForReadFallback("aurora-somin-plan-2026-05-22.md 읽어봐");
+    const res = applyReadEmptyArgsGuard({ path: "" });
+    expect(res).toBe("aurora-somin-plan-2026-05-22.md");
+  });
+
+  it("empty call with no candidates → throws explicit error", () => {
+    setLastUserMessageTextForReadFallback("그냥 인사해");
+    expect(() => applyReadEmptyArgsGuard({ path: "" })).toThrow(/path argument is empty/);
+  });
+
+  it("empty call with multiple candidates → refuses + lists candidates", () => {
+    setLastUserMessageTextForReadFallback("foo.md 와 bar.md 둘 다 보여줘");
+    expect(() => applyReadEmptyArgsGuard({ path: "" })).toThrow(/Multiple candidates/);
+  });
+
+  it("3rd+ empty call within window → CRITICAL message", () => {
+    setLastUserMessageTextForReadFallback("그냥 인사해"); // no candidates
+    try {
+      applyReadEmptyArgsGuard({ path: "" });
+    } catch {}
+    try {
+      applyReadEmptyArgsGuard({ path: "" });
+    } catch {}
+    expect(() => applyReadEmptyArgsGuard({ path: "" })).toThrow(/CRITICAL/);
+  });
+
+  it("non-empty path is passthrough (returns undefined, no throw)", () => {
+    const res = applyReadEmptyArgsGuard({ path: "memory/foo.md" });
+    expect(res).toBeUndefined();
+  });
+
+  it("sanitizeString E1 reproduction at unit level", () => {
+    const r = sanitizeString('<|find . -name "x.md"', "command", cfg);
+    expect(r.value).toBe('find . -name "x.md"');
+    expect(r.mutations.length).toBeGreaterThan(0);
+  });
+});

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1580,6 +1580,10 @@ export async function runEmbeddedPiAgent(
                 : attempt.yieldDetected
                   ? "end_turn"
                   : (lastAssistant?.stopReason as string | undefined),
+              lastAssistantErrorMessage:
+                lastAssistant?.stopReason === "error"
+                  ? lastAssistant.errorMessage?.trim() || undefined
+                  : undefined,
               pendingToolCalls: attempt.clientToolCall
                 ? [
                     {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -90,6 +90,10 @@ import {
 } from "../../skills.js";
 import { buildSystemPromptParams } from "../../system-prompt-params.js";
 import { buildSystemPromptReport } from "../../system-prompt-report.js";
+import {
+  readEnvConfig as readToolArgSanitizeEnvConfig,
+  wrapStreamFnSanitizeToolCallArguments,
+} from "../../tool-arg-sanitize-guard.js";
 import { sanitizeToolCallIdsForCloudCodeAssist } from "../../tool-call-id.js";
 import { resolveEffectiveToolFsWorkspaceOnly } from "../../tool-fs-policy.js";
 import { normalizeToolName } from "../../tool-policy.js";
@@ -2053,6 +2057,19 @@ export async function runEmbeddedAttempt(
         activeSession.agent.streamFn = wrapStreamFnDecodeXaiToolCallArguments(
           activeSession.agent.streamFn,
         );
+      }
+
+      // P2.18: tool-arg sanitize guard (sentinel/html-tag/balance-quote).
+      // Runs on every provider; gated by
+      // OPENCLAW_TOOL_ARG_SANITIZE_GUARD_ENABLED (default on).
+      {
+        const __p218cfg = readToolArgSanitizeEnvConfig();
+        if (__p218cfg.enabled) {
+          activeSession.agent.streamFn = wrapStreamFnSanitizeToolCallArguments(
+            activeSession.agent.streamFn as unknown as (...args: unknown[]) => unknown,
+            __p218cfg,
+          ) as typeof activeSession.agent.streamFn;
+        }
       }
 
       if (anthropicPayloadLogger) {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -50,6 +50,7 @@ import { ensureCustomApiRegistered } from "../../custom-api-registry.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../defaults.js";
 import { resolveOpenClawDocsPath } from "../../docs-path.js";
 import { isTimeoutError } from "../../failover-error.js";
+import { runHallucinationGuardInline } from "../../hallucination-guard.js";
 import { resolveImageSanitizationLimits } from "../../image-sanitization.js";
 import { resolveModelAuthMode } from "../../model-auth.js";
 import { normalizeProviderId, resolveDefaultModelForAgent } from "../../model-selection.js";
@@ -2758,6 +2759,20 @@ export async function runEmbeddedAttempt(
             log.warn(`llm_output hook failed: ${String(err)}`);
           });
       }
+
+      // P2.14: hallucination guard (gemma-memory follow-up).
+      // Fire-and-forget. Re-runs memory.sh by-person and posts a
+      // corrective follow-up on the telegram chat when the model
+      // hallucinated a tool report in text-only output. Gated by
+      // OPENCLAW_HALLUCINATION_GUARD_* env vars; gemma-only by default;
+      // no-op for any non-whitelisted agent.
+      runHallucinationGuardInline({
+        agentId: hookAgentId,
+        messages: messagesSnapshot,
+        lastAssistant,
+      }).catch((err) => {
+        log.warn(`hallucination-guard failed: ${String(err)}`);
+      });
 
       return {
         aborted,

--- a/src/agents/pi-embedded-runner/run/payloads.fallback-on-error.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.fallback-on-error.test.ts
@@ -1,0 +1,69 @@
+import type { AssistantMessage } from "@mariozechner/pi-ai";
+import { describe, expect, it } from "vitest";
+import { makeAssistantMessageFixture } from "../../test-helpers/assistant-message-fixtures.js";
+import { buildPayloads } from "./payloads.test-helpers.js";
+
+// Regression guards for tasks/openclaw/20260520-001 (luna repetition fix):
+// when the previous assistant turn ended with stopReason === "error" (e.g.
+// vLLM 400 context overflow), the runner must not emit the last successful
+// assistant text as a fallback on the next turn. Doing so caused users to
+// receive the same response twice in a row (see work-report 20260520-040).
+
+describe("buildEmbeddedRunPayloads — fallback-on-error guard", () => {
+  const SUCCESSFUL_PRIOR_ANSWER = "previously successful answer text";
+  const VLLM_CONTEXT_OVERFLOW_RAW =
+    "400 This model's maximum context length is 65536 tokens. However, you requested 70000 tokens.";
+
+  const makeErroredAssistantWithPriorText = (): AssistantMessage =>
+    makeAssistantMessageFixture({
+      stopReason: "error",
+      errorMessage: VLLM_CONTEXT_OVERFLOW_RAW,
+      // The content array still carries the previous successful response text;
+      // this is the exact shape that triggered the repetition bug — the
+      // fallback path mined this content even though the turn errored.
+      content: [{ type: "text", text: SUCCESSFUL_PRIOR_ANSWER }],
+    });
+
+  const makeStoppedAssistantWithText = (text: string): AssistantMessage =>
+    makeAssistantMessageFixture({
+      stopReason: "stop",
+      errorMessage: undefined,
+      content: [{ type: "text", text }],
+    });
+
+  it("T1: lastAssistant errored + no current-turn texts → does not re-emit prior assistant text", () => {
+    const payloads = buildPayloads({
+      assistantTexts: [],
+      lastAssistant: makeErroredAssistantWithPriorText(),
+    });
+
+    // No payload should contain the previously successful answer; the only
+    // emitted text should be the formatted error message (isError true).
+    expect(payloads.some((p) => p.text === SUCCESSFUL_PRIOR_ANSWER)).toBe(false);
+    expect(payloads.some((p) => p.text?.includes(SUCCESSFUL_PRIOR_ANSWER))).toBe(false);
+    const errorPayloads = payloads.filter((p) => p.isError);
+    expect(errorPayloads.length).toBeGreaterThan(0);
+  });
+
+  it("T2: lastAssistant did not error + no current-turn texts → existing fallback behavior preserved", () => {
+    const payloads = buildPayloads({
+      assistantTexts: [],
+      lastAssistant: makeStoppedAssistantWithText("Hello from a clean run"),
+    });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.text).toBe("Hello from a clean run");
+    expect(payloads[0]?.isError).toBeFalsy();
+  });
+
+  it("T3: lastAssistant errored + current-turn text present → current-turn text used, fallback bypassed", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["fresh current-turn answer"],
+      lastAssistant: makeErroredAssistantWithPriorText(),
+    });
+
+    // Current-turn text must survive; prior successful text must not be re-emitted.
+    expect(payloads.some((p) => p.text === "fresh current-turn answer")).toBe(true);
+    expect(payloads.some((p) => p.text === SUCCESSFUL_PRIOR_ANSWER)).toBe(false);
+  });
+});

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -198,7 +198,12 @@ export function buildEmbeddedRunPayloads(params: {
     replyItems.push({ text: reasoningText, isReasoning: true });
   }
 
-  const fallbackAnswerText = params.lastAssistant ? extractAssistantText(params.lastAssistant) : "";
+  // Guard: never reuse an errored assistant turn's text as fallback. When the
+  // model errored out (e.g. vLLM 400 context overflow) the last successful
+  // assistant text would otherwise be re-emitted to the user as if it were a
+  // fresh reply, producing duplicate messages. See work-report 20260520-040.
+  const fallbackAnswerText =
+    params.lastAssistant && !lastAssistantErrored ? extractAssistantText(params.lastAssistant) : "";
   const shouldSuppressRawErrorText = (text: string) => {
     if (!lastAssistantErrored) {
       return false;

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -46,6 +46,13 @@ export type EmbeddedPiRunMeta = {
   };
   /** Stop reason for the agent run (e.g., "completed", "tool_calls"). */
   stopReason?: string;
+  /**
+   * Raw error message from the final assistant turn when it ended with
+   * stopReason === "error". Exposed so callers (e.g. the agent runner safety
+   * net) can run context-overflow detection even when `meta.error` is not
+   * populated for this run path.
+   */
+  lastAssistantErrorMessage?: string;
   /** Pending tool calls when stopReason is "tool_calls". */
   pendingToolCalls?: Array<{
     id: string;

--- a/src/agents/pi-extensions/compaction-safeguard.test.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.test.ts
@@ -687,7 +687,10 @@ describe("compaction-safeguard recent-turn preservation", () => {
   });
 
   it("clamps preserve count into a safe range", () => {
-    expect(resolveRecentTurnsPreserve(undefined)).toBe(3);
+    // DEFAULT_RECENT_TURNS_PRESERVE was reduced 3 -> 1 to relieve high-density
+    // language (e.g. Korean) compaction output pressure on vLLM max_model_len.
+    delete process.env.OPENCLAW_RECENT_TURNS_PRESERVE;
+    expect(resolveRecentTurnsPreserve(undefined)).toBe(1);
     expect(resolveRecentTurnsPreserve(-1)).toBe(0);
     expect(resolveRecentTurnsPreserve(99)).toBe(12);
   });
@@ -1582,4 +1585,251 @@ describe("readWorkspaceContextForSummary", () => {
       });
     },
   );
+});
+
+const {
+  estimateTextTokens,
+  resolveMaxPreservedTurnsTokens,
+  resolveMaxSummaryShare,
+  resolveDefaultRecentTurnsPreserve,
+  MAX_PRESERVED_TURNS_TOKENS,
+  MAX_SUMMARY_SHARE,
+  DEFAULT_RECENT_TURNS_PRESERVE,
+} = __testing;
+
+function restoreCompactionGuardEnv() {
+  delete process.env.OPENCLAW_RECENT_TURNS_PRESERVE;
+  delete process.env.OPENCLAW_PRESERVED_TURNS_TOKENS;
+  delete process.env.OPENCLAW_SUMMARY_MAX_SHARE;
+  delete process.env.OPENCLAW_CONTEXT_WINDOW;
+}
+
+describe("compaction-safeguard verbatim token cap + summary budget", () => {
+  // T1: short preserved turns stay verbatim, no token-cap drop notice.
+  it("T1: preserves all turns when total tokens fit under the cap", () => {
+    restoreCompactionGuardEnv();
+    const messages: AgentMessage[] = [
+      { role: "user", content: "Quick question?", timestamp: 1 },
+      castAgentMessage({
+        role: "assistant",
+        content: [{ type: "text", text: "Short reply." }],
+        timestamp: 2,
+      }),
+    ];
+    const section = formatPreservedTurnsSection(messages);
+    expect(section).toContain("## Recent turns preserved verbatim");
+    expect(section).not.toContain("(older turns omitted due to token budget)");
+    expect(section).toContain("- User: Quick question?");
+    expect(section).toContain("- Assistant: Short reply.");
+  });
+
+  // T2: large CJK turns trigger the cumulative token cap; oldest are dropped first.
+  it("T2: drops oldest preserved turns when cumulative tokens exceed the cap", () => {
+    restoreCompactionGuardEnv();
+    // 5 user/assistant pairs (10 messages), each ~360 Korean chars (~200 tokens each).
+    // Default cap = 800 tokens; expect aggressive drops.
+    const koreanFiller = "한글텍스트로채워진보존대상턴내용입니다".repeat(20).slice(0, 360);
+    const messages: AgentMessage[] = [];
+    for (let i = 0; i < 5; i += 1) {
+      messages.push({
+        role: "user",
+        content: `사용자질문${i}: ${koreanFiller}`,
+        timestamp: i * 2 + 1,
+      });
+      messages.push(
+        castAgentMessage({
+          role: "assistant",
+          content: [{ type: "text", text: `답변${i}: ${koreanFiller}` }],
+          timestamp: i * 2 + 2,
+        }),
+      );
+    }
+    const section = formatPreservedTurnsSection(messages);
+    expect(section).toContain("## Recent turns preserved verbatim");
+    expect(section).toContain("(older turns omitted due to token budget)");
+    // The most recent turn (index 4) must survive; the oldest (index 0) must be dropped.
+    expect(section).toContain("답변4");
+    expect(section).not.toContain("사용자질문0");
+  });
+
+  // T3: a single oversized turn still gets the char-cap suffix (regression guard).
+  it("T3: applies legacy char cap to a single oversized turn", () => {
+    restoreCompactionGuardEnv();
+    const huge = "a".repeat(900); // > MAX_RECENT_TURN_TEXT_CHARS (600)
+    const section = formatPreservedTurnsSection([{ role: "user", content: huge, timestamp: 1 }]);
+    expect(section).toContain("- User: ");
+    // Trimmed line ends with "..." after MAX_RECENT_TURN_TEXT_CHARS slice.
+    expect(section).toMatch(/a{600}\.\.\.$/m);
+  });
+
+  // T4: full summary exceeding budget triggers drop_verbatim reduction.
+  it("T4: drops the verbatim section when the final summary exceeds the budget", async () => {
+    restoreCompactionGuardEnv();
+    mockSummarizeInStages.mockReset();
+    // Generate large Korean summary text so estimateTextTokens (~0.55/char) puts it over budget.
+    const heavySummary = [
+      "## Decisions",
+      "한글로채워진결정사항텍스트입니다".repeat(120),
+      "## Open TODOs",
+      "한글요약개방항목내용입니다".repeat(120),
+      "## Constraints/Rules",
+      "제약사항한글내용".repeat(120),
+      "## Pending user asks",
+      "보류된사용자질문한글".repeat(120),
+      "## Exact identifiers",
+      "ABCDEF1234567890",
+    ].join("\n");
+    mockSummarizeInStages.mockResolvedValue(heavySummary);
+
+    const sessionManager = stubSessionManager();
+    // Small context window so budget = 10000 * 0.25 = 2500 tokens. heavySummary alone ≈ 2200+.
+    const model = createAnthropicModelFixture({ contextWindow: 10000 });
+    setCompactionSafeguardRuntime(sessionManager, {
+      model,
+      contextWindowTokens: 10000,
+      recentTurnsPreserve: 1,
+    });
+
+    const compactionHandler = createCompactionHandler();
+    const getApiKeyMock = vi.fn().mockResolvedValue("test-key");
+    const mockContext = createCompactionContext({ sessionManager, getApiKeyMock });
+
+    const recentKorean = "최근사용자질문한글텍스트".repeat(40);
+    const event = {
+      preparation: {
+        messagesToSummarize: [
+          { role: "user", content: "older context", timestamp: 1 },
+          castAgentMessage({
+            role: "assistant",
+            content: [{ type: "text", text: "older reply" }],
+            timestamp: 2,
+          }),
+          { role: "user", content: recentKorean, timestamp: 3 },
+          castAgentMessage({
+            role: "assistant",
+            content: [{ type: "text", text: `최근답변: ${recentKorean}` }],
+            timestamp: 4,
+          }),
+        ],
+        turnPrefixMessages: [],
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 5000,
+        fileOps: { read: [], edited: [], written: [] },
+        settings: { reserveTokens: 1024 },
+        previousSummary: undefined,
+        isSplitTurn: false,
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+
+    const result = (await compactionHandler(event, mockContext)) as {
+      cancel?: boolean;
+      compaction?: {
+        summary?: string;
+        details?: {
+          appliedReductions?: string[];
+          estimatedSummaryTokens?: number;
+          summaryBudget?: number;
+        };
+      };
+    };
+
+    expect(result.cancel).not.toBe(true);
+    const reductions = result.compaction?.details?.appliedReductions ?? [];
+    expect(reductions).toContain("drop_verbatim");
+    // After drop_verbatim, the verbatim header must no longer be present in the final summary.
+    expect(result.compaction?.summary).not.toContain("## Recent turns preserved verbatim");
+    expect(typeof result.compaction?.details?.estimatedSummaryTokens).toBe("number");
+    expect(typeof result.compaction?.details?.summaryBudget).toBe("number");
+  });
+
+  // T5: OPENCLAW_RECENT_TURNS_PRESERVE=0 suppresses the verbatim section entirely.
+  it("T5: env override OPENCLAW_RECENT_TURNS_PRESERVE=0 suppresses verbatim", () => {
+    restoreCompactionGuardEnv();
+    process.env.OPENCLAW_RECENT_TURNS_PRESERVE = "0";
+    try {
+      expect(resolveDefaultRecentTurnsPreserve()).toBe(0);
+      expect(resolveRecentTurnsPreserve(undefined)).toBe(0);
+      const split = splitPreservedRecentTurns({
+        messages: [
+          { role: "user", content: "hi", timestamp: 1 },
+          castAgentMessage({
+            role: "assistant",
+            content: [{ type: "text", text: "yo" }],
+            timestamp: 2,
+          }),
+        ],
+        recentTurnsPreserve: resolveRecentTurnsPreserve(undefined),
+      });
+      expect(split.preservedMessages).toHaveLength(0);
+      expect(formatPreservedTurnsSection(split.preservedMessages)).toBe("");
+    } finally {
+      restoreCompactionGuardEnv();
+    }
+  });
+
+  // T6: smaller env cap causes earlier drops.
+  it("T6: env override OPENCLAW_PRESERVED_TURNS_TOKENS=200 tightens the cap", () => {
+    restoreCompactionGuardEnv();
+    // Build 3 modest English turns; under the default cap (800) all should fit,
+    // but under a 200-token cap the oldest must be dropped.
+    const filler = "x".repeat(400); // ~100 tokens each at 0.25/char
+    const messages: AgentMessage[] = [
+      { role: "user", content: `q0 ${filler}`, timestamp: 1 },
+      castAgentMessage({
+        role: "assistant",
+        content: [{ type: "text", text: `a0 ${filler}` }],
+        timestamp: 2,
+      }),
+      { role: "user", content: `q1 ${filler}`, timestamp: 3 },
+    ];
+    const beforeSection = formatPreservedTurnsSection(messages);
+    expect(beforeSection).not.toContain("(older turns omitted due to token budget)");
+
+    process.env.OPENCLAW_PRESERVED_TURNS_TOKENS = "200";
+    try {
+      expect(resolveMaxPreservedTurnsTokens()).toBe(200);
+      const tightenedSection = formatPreservedTurnsSection(messages);
+      expect(tightenedSection).toContain("(older turns omitted due to token budget)");
+      // The newest line must survive.
+      expect(tightenedSection).toContain("q1 ");
+      // The oldest line must be gone.
+      expect(tightenedSection).not.toContain("q0 ");
+    } finally {
+      restoreCompactionGuardEnv();
+    }
+  });
+
+  // T7: DEFAULT_RECENT_TURNS_PRESERVE is now 1 (was 3 prior to 2026-05-20).
+  it("T7: DEFAULT_RECENT_TURNS_PRESERVE is 1", () => {
+    restoreCompactionGuardEnv();
+    expect(DEFAULT_RECENT_TURNS_PRESERVE).toBe(1);
+    expect(resolveDefaultRecentTurnsPreserve()).toBe(1);
+    expect(resolveRecentTurnsPreserve(undefined)).toBe(1);
+    // Sanity check on companion constants exposed via __testing.
+    expect(MAX_PRESERVED_TURNS_TOKENS).toBe(800);
+    expect(MAX_SUMMARY_SHARE).toBeCloseTo(0.25);
+    expect(estimateTextTokens("")).toBe(0);
+    // CJK heuristic: 100 Korean chars ≈ 55 tokens.
+    expect(estimateTextTokens("가".repeat(100))).toBeGreaterThanOrEqual(50);
+    // ASCII heuristic: 100 ASCII chars ≈ 25 tokens.
+    expect(estimateTextTokens("x".repeat(100))).toBeLessThanOrEqual(30);
+  });
+
+  it("clamps OPENCLAW_SUMMARY_MAX_SHARE to safe range", () => {
+    restoreCompactionGuardEnv();
+    process.env.OPENCLAW_SUMMARY_MAX_SHARE = "0.9";
+    try {
+      expect(resolveMaxSummaryShare()).toBeCloseTo(0.5);
+    } finally {
+      restoreCompactionGuardEnv();
+    }
+    process.env.OPENCLAW_SUMMARY_MAX_SHARE = "0.05";
+    try {
+      expect(resolveMaxSummaryShare()).toBeCloseTo(0.1);
+    } finally {
+      restoreCompactionGuardEnv();
+    }
+  });
 });

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -38,11 +38,24 @@ const TURN_PREFIX_INSTRUCTIONS =
   " early progress, and any details needed to understand the retained suffix.";
 const MAX_TOOL_FAILURES = 8;
 const MAX_TOOL_FAILURE_CHARS = 240;
-const DEFAULT_RECENT_TURNS_PRESERVE = 3;
+// Default reduced 3 -> 1 (2026-05-20): verbatim preservation pressure on high-density
+// languages (e.g. Korean) caused compaction output to exceed vLLM max_model_len.
+// One recent turn is enough for continuity; older turns survive in the structured summary.
+const DEFAULT_RECENT_TURNS_PRESERVE = 1;
 const DEFAULT_QUALITY_GUARD_MAX_RETRIES = 1;
 const MAX_RECENT_TURNS_PRESERVE = 12;
 const MAX_QUALITY_GUARD_MAX_RETRIES = 3;
 const MAX_RECENT_TURN_TEXT_CHARS = 600;
+// Cumulative token cap across all preserved verbatim turns. Once reached, oldest preserved
+// turns are dropped first. Char-only caps were insufficient for CJK text (high token/char).
+const MAX_PRESERVED_TURNS_TOKENS = 800;
+// Hard ceiling on the share of the model context window the final compaction summary
+// may consume. Above this, verbatim/tool-failure sections are dropped in stages.
+const MAX_SUMMARY_SHARE = 0.25;
+// Fallback context window for budget calculation when no model context is available.
+const DEFAULT_CONTEXT_WINDOW_TOKENS_FOR_SUMMARY_BUDGET = 65536;
+const MIN_SUMMARY_SHARE = 0.1;
+const MAX_SUMMARY_SHARE_CLAMP = 0.5;
 const MAX_EXTRACTED_IDENTIFIERS = 12;
 const MAX_UNTRUSTED_INSTRUCTION_CHARS = 4000;
 const MAX_ASK_OVERLAP_TOKENS = 12;
@@ -71,11 +84,71 @@ function clampNonNegativeInt(value: unknown, fallback: number): number {
   return Math.max(0, Math.floor(normalized));
 }
 
+function readPositiveIntFromEnv(key: string): number | undefined {
+  const raw = process.env[key];
+  if (!raw) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return undefined;
+  }
+  return parsed;
+}
+
+function readFloatFromEnv(key: string): number | undefined {
+  const raw = process.env[key];
+  if (!raw) {
+    return undefined;
+  }
+  const parsed = Number.parseFloat(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return undefined;
+  }
+  return parsed;
+}
+
+function resolveDefaultRecentTurnsPreserve(): number {
+  const envValue = readPositiveIntFromEnv("OPENCLAW_RECENT_TURNS_PRESERVE");
+  return envValue ?? DEFAULT_RECENT_TURNS_PRESERVE;
+}
+
+function resolveMaxPreservedTurnsTokens(): number {
+  const envValue = readPositiveIntFromEnv("OPENCLAW_PRESERVED_TURNS_TOKENS");
+  return envValue ?? MAX_PRESERVED_TURNS_TOKENS;
+}
+
+function resolveMaxSummaryShare(): number {
+  const envValue = readFloatFromEnv("OPENCLAW_SUMMARY_MAX_SHARE");
+  const base = envValue ?? MAX_SUMMARY_SHARE;
+  return Math.min(MAX_SUMMARY_SHARE_CLAMP, Math.max(MIN_SUMMARY_SHARE, base));
+}
+
+function resolveFallbackContextWindow(): number {
+  const envValue = readPositiveIntFromEnv("OPENCLAW_CONTEXT_WINDOW");
+  return envValue && envValue > 0 ? envValue : DEFAULT_CONTEXT_WINDOW_TOKENS_FOR_SUMMARY_BUDGET;
+}
+
+// Lightweight token estimator for plain text. Uses CJK ratio to switch between
+// CJK-heavy (≈0.55 tokens/char) and ASCII-heavy (≈0.25 tokens/char) heuristics.
+// Intentionally independent from estimateMessagesTokens (which operates on
+// AgentMessage[] and adds per-message overhead) so we can budget the rendered
+// summary string directly.
+function estimateTextTokens(text: string): number {
+  if (!text) {
+    return 0;
+  }
+  // Hiragana/Katakana (3040-30FF), CJK Unified (3400-9FFF), Hangul (AC00-D7AF).
+  const cjkMatches = text.match(/[぀-ヿ㐀-鿿가-힯]/g);
+  const cjkCount = cjkMatches ? cjkMatches.length : 0;
+  const cjkRatio = text.length > 0 ? cjkCount / text.length : 0;
+  const tokensPerChar = cjkRatio > 0.3 ? 0.55 : 0.25;
+  return Math.ceil(text.length * tokensPerChar);
+}
+
 function resolveRecentTurnsPreserve(value: unknown): number {
-  return Math.min(
-    MAX_RECENT_TURNS_PRESERVE,
-    clampNonNegativeInt(value, DEFAULT_RECENT_TURNS_PRESERVE),
-  );
+  const fallback = resolveDefaultRecentTurnsPreserve();
+  return Math.min(MAX_RECENT_TURNS_PRESERVE, clampNonNegativeInt(value, fallback));
 }
 
 function resolveQualityGuardMaxRetries(value: unknown): number {
@@ -367,44 +440,81 @@ function splitPreservedRecentTurns(params: {
   return { summarizableMessages: repairedSummarizableMessages, preservedMessages };
 }
 
-function formatPreservedTurnsSection(messages: AgentMessage[]): string {
+function formatPreservedTurnsSection(
+  messages: AgentMessage[],
+  options?: { maxTokens?: number },
+): string {
   if (messages.length === 0) {
     return "";
   }
-  const lines = messages
-    .map((message) => {
-      let roleLabel: string;
-      if (message.role === "assistant") {
-        roleLabel = "Assistant";
-      } else if (message.role === "user") {
-        roleLabel = "User";
-      } else if (message.role === "toolResult") {
-        const toolName = (message as { toolName?: unknown }).toolName;
-        const safeToolName = typeof toolName === "string" && toolName.trim() ? toolName : "tool";
-        roleLabel = `Tool result (${safeToolName})`;
-      } else {
-        return null;
-      }
-      const text = extractMessageText(message);
-      const nonTextPlaceholder = formatNonTextPlaceholder(
-        (message as { content?: unknown }).content,
-      );
-      const rendered =
-        text && nonTextPlaceholder ? `${text}\n${nonTextPlaceholder}` : text || nonTextPlaceholder;
-      if (!rendered) {
-        return null;
-      }
-      const trimmed =
-        rendered.length > MAX_RECENT_TURN_TEXT_CHARS
-          ? `${rendered.slice(0, MAX_RECENT_TURN_TEXT_CHARS)}...`
-          : rendered;
-      return `- ${roleLabel}: ${trimmed}`;
-    })
-    .filter((line): line is string => Boolean(line));
-  if (lines.length === 0) {
+  const renderedLines: string[] = [];
+  for (const message of messages) {
+    let roleLabel: string;
+    if (message.role === "assistant") {
+      roleLabel = "Assistant";
+    } else if (message.role === "user") {
+      roleLabel = "User";
+    } else if (message.role === "toolResult") {
+      const toolName = (message as { toolName?: unknown }).toolName;
+      const safeToolName = typeof toolName === "string" && toolName.trim() ? toolName : "tool";
+      roleLabel = `Tool result (${safeToolName})`;
+    } else {
+      continue;
+    }
+    const text = extractMessageText(message);
+    const nonTextPlaceholder = formatNonTextPlaceholder((message as { content?: unknown }).content);
+    const rendered =
+      text && nonTextPlaceholder ? `${text}\n${nonTextPlaceholder}` : text || nonTextPlaceholder;
+    if (!rendered) {
+      continue;
+    }
+    const trimmed =
+      rendered.length > MAX_RECENT_TURN_TEXT_CHARS
+        ? `${rendered.slice(0, MAX_RECENT_TURN_TEXT_CHARS)}...`
+        : rendered;
+    renderedLines.push(`- ${roleLabel}: ${trimmed}`);
+  }
+  if (renderedLines.length === 0) {
     return "";
   }
-  return `\n\n## Recent turns preserved verbatim\n${lines.join("\n")}`;
+
+  const maxTokens = options?.maxTokens ?? resolveMaxPreservedTurnsTokens();
+  let droppedOlder = false;
+  let keptLines = renderedLines;
+  if (Number.isFinite(maxTokens) && maxTokens > 0) {
+    // Walk newest -> oldest so we keep the most recent turns when the budget is tight.
+    const tokensByLine = renderedLines.map((line) => estimateTextTokens(line));
+    const reversed: { line: string; tokens: number }[] = [];
+    for (let i = renderedLines.length - 1; i >= 0; i -= 1) {
+      reversed.push({
+        line: renderedLines[i],
+        tokens: tokensByLine[i],
+      });
+    }
+    const acceptedReversed: string[] = [];
+    let runningTokens = 0;
+    for (const item of reversed) {
+      if (runningTokens + item.tokens > maxTokens && acceptedReversed.length > 0) {
+        droppedOlder = true;
+        break;
+      }
+      acceptedReversed.push(item.line);
+      runningTokens += item.tokens;
+    }
+    if (acceptedReversed.length < renderedLines.length) {
+      droppedOlder = true;
+    }
+    keptLines = acceptedReversed.toReversed();
+  }
+
+  if (keptLines.length === 0) {
+    return "";
+  }
+  const headerLines = ["## Recent turns preserved verbatim"];
+  if (droppedOlder) {
+    headerLines.push("(older turns omitted due to token budget)");
+  }
+  return `\n\n${headerLines.join("\n")}\n${keptLines.join("\n")}`;
 }
 
 function wrapUntrustedInstructionBlock(label: string, text: string): string {
@@ -517,6 +627,21 @@ function appendSummarySection(summary: string, section: string): string {
     return section.trimStart();
   }
   return `${summary}${section}`;
+}
+
+function assembleFinalSummary(parts: {
+  base: string;
+  preservedTurns: string;
+  toolFailures: string;
+  fileOps: string;
+  workspace: string;
+}): string {
+  let result = parts.base;
+  result = appendSummarySection(result, parts.preservedTurns);
+  result = appendSummarySection(result, parts.toolFailures);
+  result = appendSummarySection(result, parts.fileOps);
+  result = appendSummarySection(result, parts.workspace);
+  return result;
 }
 
 function sanitizeExtractedIdentifier(value: string): string {
@@ -866,6 +991,9 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       const effectivePreviousSummary = droppedSummary ?? preparation.previousSummary;
 
       let summary = "";
+      // Tracked alongside `summary` so the post-summarize reduction stage can drop the
+      // verbatim preserved-turns section without re-running the LLM call.
+      let summaryHistoryOnly = "";
       let currentInstructions = structuredInstructions;
       const totalAttempts = qualityGuardEnabled ? qualityGuardMaxRetries + 1 : 1;
       let lastSuccessfulSummary: string | null = null;
@@ -930,6 +1058,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
           throw attemptError;
         }
         lastSuccessfulSummary = summaryWithPreservedTurns;
+        summaryHistoryOnly = summaryWithoutPreservedTurns;
 
         const canRegenerate =
           messagesToSummarize.length > 0 ||
@@ -962,13 +1091,71 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
           : `${structuredInstructions}\n\n${qualityFeedbackInstruction}`;
       }
 
-      summary = appendSummarySection(summary, toolFailureSection);
-      summary = appendSummarySection(summary, fileOpsSummary);
-
       // Append workspace critical context (Session Startup + Red Lines from AGENTS.md)
       const workspaceContext = await readWorkspaceContextForSummary();
-      if (workspaceContext) {
-        summary = appendSummarySection(summary, workspaceContext);
+
+      // Reassemble from segments so the post-summary reduction stage can drop the
+      // verbatim/tool-failure sections without re-running the LLM call. The base
+      // (`summaryHistoryOnly`) is the LLM history summary plus split-turn section,
+      // before `## Recent turns preserved verbatim` was appended.
+      const baseHistorySegment = summaryHistoryOnly || summary;
+      let activePreservedTurnsSection = preservedTurnsSection;
+      let activeToolFailureSection = toolFailureSection;
+      summary = assembleFinalSummary({
+        base: baseHistorySegment,
+        preservedTurns: activePreservedTurnsSection,
+        toolFailures: activeToolFailureSection,
+        fileOps: fileOpsSummary,
+        workspace: workspaceContext,
+      });
+
+      const effectiveContextWindow =
+        contextWindowTokens && contextWindowTokens > 0
+          ? contextWindowTokens
+          : resolveFallbackContextWindow();
+      const summaryShare = resolveMaxSummaryShare();
+      const summaryBudget = Math.max(1, Math.floor(effectiveContextWindow * summaryShare));
+      const appliedReductions: string[] = [];
+      let estimatedSummaryTokens = estimateTextTokens(summary);
+
+      const tryReduce = (action: "drop_verbatim" | "drop_tool_failures", mutate: () => void) => {
+        if (estimatedSummaryTokens <= summaryBudget) {
+          return;
+        }
+        const before = estimatedSummaryTokens;
+        mutate();
+        summary = assembleFinalSummary({
+          base: baseHistorySegment,
+          preservedTurns: activePreservedTurnsSection,
+          toolFailures: activeToolFailureSection,
+          fileOps: fileOpsSummary,
+          workspace: workspaceContext,
+        });
+        estimatedSummaryTokens = estimateTextTokens(summary);
+        appliedReductions.push(action);
+        log.warn(
+          `[compaction-safeguard] action=${action} est_before=${before} est_after=${estimatedSummaryTokens} budget=${summaryBudget}`,
+        );
+      };
+
+      // Step 1: drop verbatim preserved turns when the rendered summary blows the budget.
+      if (activePreservedTurnsSection) {
+        tryReduce("drop_verbatim", () => {
+          activePreservedTurnsSection = "";
+        });
+      }
+      // Step 2: drop the tool-failures section if still over budget.
+      if (estimatedSummaryTokens > summaryBudget && activeToolFailureSection) {
+        tryReduce("drop_tool_failures", () => {
+          activeToolFailureSection = "";
+        });
+      }
+      // Step 3: nothing left to drop without losing core compaction content.
+      if (estimatedSummaryTokens > summaryBudget) {
+        appliedReductions.push("noop_over_budget");
+        log.warn(
+          `[compaction-safeguard] action=noop_over_budget est=${estimatedSummaryTokens} budget=${summaryBudget} — summary still exceeds budget after reductions`,
+        );
       }
 
       return {
@@ -976,7 +1163,13 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
           summary,
           firstKeptEntryId: preparation.firstKeptEntryId,
           tokensBefore: preparation.tokensBefore,
-          details: { readFiles, modifiedFiles },
+          details: {
+            readFiles,
+            modifiedFiles,
+            estimatedSummaryTokens,
+            summaryBudget,
+            appliedReductions,
+          },
         },
       };
     } catch (error) {
@@ -998,8 +1191,14 @@ export const __testing = {
   buildCompactionStructureInstructions,
   buildStructuredFallbackSummary,
   appendSummarySection,
+  assembleFinalSummary,
   resolveRecentTurnsPreserve,
   resolveQualityGuardMaxRetries,
+  resolveMaxPreservedTurnsTokens,
+  resolveMaxSummaryShare,
+  resolveDefaultRecentTurnsPreserve,
+  resolveFallbackContextWindow,
+  estimateTextTokens,
   extractOpaqueIdentifiers,
   auditSummaryQuality,
   computeAdaptiveChunkRatio,
@@ -1008,4 +1207,7 @@ export const __testing = {
   BASE_CHUNK_RATIO,
   MIN_CHUNK_RATIO,
   SAFETY_MARGIN,
+  MAX_PRESERVED_TURNS_TOKENS,
+  MAX_SUMMARY_SHARE,
+  DEFAULT_RECENT_TURNS_PRESERVE,
 } as const;

--- a/src/agents/pi-tools.before-tool-call.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.e2e.test.ts
@@ -6,8 +6,8 @@ import {
 } from "../infra/diagnostic-events.js";
 import { resetDiagnosticSessionStateForTest } from "../logging/diagnostic-session-state.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
-import { wrapToolWithBeforeToolCallHook } from "./pi-tools.before-tool-call.js";
-import { CRITICAL_THRESHOLD, GLOBAL_CIRCUIT_BREAKER_THRESHOLD } from "./tool-loop-detection.js";
+import { type HookContext, wrapToolWithBeforeToolCallHook } from "./pi-tools.before-tool-call.js";
+import { CRITICAL_THRESHOLD } from "./tool-loop-detection.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
 vi.mock("../plugins/hook-runner-global.js");
@@ -46,7 +46,7 @@ describe("before_tool_call loop detection behavior", () => {
   function createWrappedTool(
     name: string,
     execute: ReturnType<typeof vi.fn>,
-    loopDetectionContext = enabledLoopDetectionContext,
+    loopDetectionContext: HookContext = enabledLoopDetectionContext,
   ) {
     return wrapToolWithBeforeToolCallHook(
       { name, execute } as unknown as AnyAgentTool,
@@ -193,30 +193,57 @@ describe("before_tool_call loop detection behavior", () => {
     }
   });
 
-  it("keeps generic repeated calls warn-only below global breaker", async () => {
+  it("blocks generic repeated identical calls at the block threshold (P2.12)", async () => {
+    // P2.12 deliberately overturns the old "generic loops are warn-only"
+    // contract: a model spamming the same (tool, args) call in a row must be
+    // blocked early, not merely warned. Default block threshold is 5.
     const { tool, params } = createGenericReadRepeatFixture();
 
-    for (let i = 0; i < CRITICAL_THRESHOLD + 5; i += 1) {
+    for (let i = 0; i < 4; i += 1) {
       await expect(tool.execute(`read-${i}`, params, undefined, undefined)).resolves.toBeDefined();
     }
+
+    await expect(tool.execute("read-4", params, undefined, undefined)).rejects.toThrow("CRITICAL");
   });
 
-  it("blocks generic repeated no-progress calls at global breaker threshold", async () => {
-    const { tool, params } = createGenericReadRepeatFixture();
+  it("intercepts a generic identical runaway well before the global breaker (P2.12)", async () => {
+    await withToolLoopEvents(
+      async (emitted) => {
+        const { tool, params } = createGenericReadRepeatFixture();
 
-    for (let i = 0; i < GLOBAL_CIRCUIT_BREAKER_THRESHOLD; i += 1) {
-      await expect(tool.execute(`read-${i}`, params, undefined, undefined)).resolves.toBeDefined();
-    }
+        for (let i = 0; i < 4; i += 1) {
+          await tool.execute(`read-${i}`, params, undefined, undefined);
+        }
+        await expect(tool.execute("read-4", params, undefined, undefined)).rejects.toThrow(
+          "CRITICAL",
+        );
 
-    await expect(
-      tool.execute(`read-${GLOBAL_CIRCUIT_BREAKER_THRESHOLD}`, params, undefined, undefined),
-    ).rejects.toThrow("global circuit breaker");
+        const blockEvent = emitted.at(-1);
+        expect(blockEvent?.detector).toBe("generic_repeat");
+        expect(blockEvent?.level).toBe("critical");
+        expect(blockEvent?.action).toBe("block");
+        // Blocked at 5, far below the global-breaker threshold (30).
+        expect(blockEvent?.count).toBe(5);
+      },
+      (evt) => evt.level === "critical",
+    );
   });
 
   it("coalesces repeated generic warning events into threshold buckets", async () => {
     await withToolLoopEvents(
       async (emitted) => {
-        const { tool, params } = createGenericReadRepeatFixture();
+        const execute = vi.fn().mockResolvedValue({
+          content: [{ type: "text", text: "same output" }],
+          details: { ok: true },
+        });
+        // Raise the P2.12 block threshold above the warn buckets so the
+        // warn-coalescing path stays exercised (block path covered above).
+        const tool = createWrappedTool("read", execute, {
+          agentId: "main",
+          sessionKey: "main",
+          loopDetection: { enabled: true, genericRepeatBlockThreshold: 100 },
+        });
+        const params = { path: "/tmp/file" };
 
         for (let i = 0; i < 21; i += 1) {
           await tool.execute(`read-bucket-${i}`, params, undefined, undefined);

--- a/src/agents/pi-tools.params.ts
+++ b/src/agents/pi-tools.params.ts
@@ -1,4 +1,5 @@
 import type { AnyAgentTool } from "./pi-tools.types.js";
+import { sanitizeFileToolParams } from "./tools/sanitize-tool-args.js";
 
 export type RequiredParamGroup = {
   keys: readonly string[];
@@ -111,7 +112,11 @@ export function normalizeToolParams(params: unknown): Record<string, unknown> | 
   normalizeTextLikeParam(normalized, "content");
   normalizeTextLikeParam(normalized, "oldText");
   normalizeTextLikeParam(normalized, "newText");
-  return normalized;
+  // Strip leaked LLM sentinel tokens from path-like args before they reach the
+  // filesystem layer. Single chokepoint for read/write/edit (and the
+  // workspace-root / memory-flush wrappers, which all call normalizeToolParams).
+  // Content args are intentionally left untouched (see sanitizeFileToolParams).
+  return sanitizeFileToolParams(normalized);
 }
 
 export function patchToolSchemaForClaudeCompatibility(tool: AnyAgentTool): AnyAgentTool {

--- a/src/agents/pi-tools.read-guards.ts
+++ b/src/agents/pi-tools.read-guards.ts
@@ -1,0 +1,124 @@
+// P2.24a — read 도구 빈 args 가드 (2026-05-22)
+// 본 사고: jsonl 11:07:46~57 UTC 사이 read({path:""}) 7회 반복 → 루프 가드 → "잠깐만 기다려줘" 끊김.
+// 결함: assertRequiredParams 가 빈 path 를 catch 하지만 모델이 같은 에러를 반복 무시.
+// 가드: (1) 강한 에러 메시지, (2) 60초 슬라이딩 윈도우 카운터, (3) 사용자 메시지 path 자동 추출 best-effort.
+
+const READ_EMPTY_ARGS_WINDOW_MS = 60_000;
+const READ_EMPTY_ARGS_MAX_ATTEMPTS = 2;
+const readEmptyArgsAttempts: { ts: number }[] = [];
+
+let lastUserMessageTextForReadFallback: string | undefined;
+let lastUserMessageTextTs = 0;
+const LAST_USER_MESSAGE_VALID_MS = 5 * 60_000;
+
+export function setLastUserMessageTextForReadFallback(text: string | undefined): void {
+  lastUserMessageTextForReadFallback = text;
+  lastUserMessageTextTs = Date.now();
+}
+
+function getLastUserMessageTextForReadFallback(): string | undefined {
+  if (!lastUserMessageTextForReadFallback) {
+    return undefined;
+  }
+  if (Date.now() - lastUserMessageTextTs > LAST_USER_MESSAGE_VALID_MS) {
+    return undefined;
+  }
+  return lastUserMessageTextForReadFallback;
+}
+
+function trackReadEmptyArgsAttempt(): number {
+  const now = Date.now();
+  while (
+    readEmptyArgsAttempts.length > 0 &&
+    now - readEmptyArgsAttempts[0].ts > READ_EMPTY_ARGS_WINDOW_MS
+  ) {
+    readEmptyArgsAttempts.shift();
+  }
+  readEmptyArgsAttempts.push({ ts: now });
+  return readEmptyArgsAttempts.length;
+}
+
+export function extractPathCandidatesFromUserMessage(text: string | undefined): string[] {
+  if (!text || typeof text !== "string") {
+    return [];
+  }
+  const candidates = new Set<string>();
+  const mdRe = /[A-Za-z0-9_\-./\uac00-\ud7a3]{3,}\.md/g;
+  const memRe = /(?:^|[^A-Za-z0-9_/-])((?:\/)?memory\/[A-Za-z0-9_\-./\uac00-\ud7a3]+)/g;
+  let m: RegExpExecArray | null;
+  m = mdRe.exec(text);
+  while (m !== null) {
+    candidates.add(m[0]);
+    m = mdRe.exec(text);
+  }
+  m = memRe.exec(text);
+  while (m !== null) {
+    candidates.add(m[1].replace(/^\//, ""));
+    m = memRe.exec(text);
+  }
+  return [...candidates];
+}
+
+export function isReadPathEmpty(value: unknown): boolean {
+  if (value == null) {
+    return true;
+  }
+  if (typeof value !== "string") {
+    return true;
+  }
+  return value.trim().length === 0;
+}
+
+// 빈 args 감지 시: 자동 보완 가능하면 path 문자열 반환, 아니면 강한 에러 throw.
+export function applyReadEmptyArgsGuard(
+  record: Record<string, unknown> | undefined,
+): string | undefined {
+  const rawPath = record?.path;
+  if (!isReadPathEmpty(rawPath)) {
+    return undefined;
+  }
+
+  const attemptCount = trackReadEmptyArgsAttempt();
+  const lastText = getLastUserMessageTextForReadFallback();
+  const candidates = extractPathCandidatesFromUserMessage(lastText);
+
+  if (attemptCount === 1 && candidates.length === 1) {
+    const chosen = candidates[0];
+    try {
+      process.stderr.write(
+        `[P2.24a] read empty path auto-extracted from user msg: ${JSON.stringify(chosen)}\n`,
+      );
+    } catch {
+      // ignore
+    }
+    return chosen;
+  }
+
+  let msg: string;
+  if (attemptCount >= READ_EMPTY_ARGS_MAX_ATTEMPTS + 1) {
+    msg =
+      "CRITICAL: read called with empty path argument " +
+      attemptCount +
+      ' times in the last 60s. STOP retrying — reply to the user with ONE Korean sentence: "read 호출이 ' +
+      attemptCount +
+      '번 빈 path 로 실패했어. 파일 경로를 한 번만 더 적어줄래?". Forbidden filler phrases mid-turn: "잠깐", "곧", "다시", "확인할게".';
+  } else if (candidates.length === 0) {
+    msg =
+      'read: path argument is empty. Could not auto-extract a file path from the most recent user message. Please specify the file path explicitly. Example: read({path: "memory/aurora-somin-plan-2026-05-22.md"})';
+  } else {
+    msg =
+      "read: path argument is empty. Multiple candidates found in the user message; auto-extract refused. Candidates: " +
+      candidates.map((c) => JSON.stringify(c)).join(", ") +
+      ". Please call read again with one explicit path.";
+  }
+  const err = new Error(msg) as Error & { code?: string };
+  err.code = "READ_EMPTY_PATH";
+  throw err;
+}
+
+// 테스트 전용 reset
+export function __resetReadEmptyArgsGuardForTest(): void {
+  readEmptyArgsAttempts.length = 0;
+  lastUserMessageTextForReadFallback = undefined;
+  lastUserMessageTextTs = 0;
+}

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -22,6 +22,7 @@ import {
   patchToolSchemaForClaudeCompatibility,
   wrapToolParamNormalization,
 } from "./pi-tools.params.js";
+import { applyReadEmptyArgsGuard } from "./pi-tools.read-guards.js";
 import type { AnyAgentTool } from "./pi-tools.types.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
@@ -648,6 +649,15 @@ export function createOpenClawReadTool(
       const record =
         normalized ??
         (params && typeof params === "object" ? (params as Record<string, unknown>) : undefined);
+      // P2.24a — empty path guard (auto-extract from last user message, or throw strong error)
+      const autoPath = applyReadEmptyArgsGuard(record);
+      if (autoPath !== undefined) {
+        if (normalized) {
+          normalized.path = autoPath;
+        } else if (record) {
+          record.path = autoPath;
+        }
+      }
       assertRequiredParams(record, CLAUDE_PARAM_GROUPS.read, base.name);
       const result = await executeReadWithAdaptivePaging({
         base,

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -56,6 +56,7 @@ import {
   mergeAlsoAllowPolicy,
   resolveToolProfilePolicy,
 } from "./tool-policy.js";
+import { wrapSearchToolArgSanitization } from "./tools/sanitize-tool-args.js";
 import { resolveWorkspaceRoot } from "./workspace-dir.js";
 
 function isOpenAIProvider(provider?: string) {
@@ -403,6 +404,13 @@ export function createOpenClawCodingTools(options?: {
       }
       const wrapped = createHostWorkspaceEditTool(workspaceRoot, { workspaceOnly });
       return [workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped];
+    }
+    // find/grep/ls bypass normalizeToolParams (no Claude-compat alias
+    // remapping) so leaked LLM sentinel tokens in path/pattern/glob reach the
+    // filesystem unstripped (incident 2026-05-19). Wrap them to strip the same
+    // tokens as read/write/edit and bash exec already do.
+    if (tool.name === "find" || tool.name === "grep" || tool.name === "ls") {
+      return [wrapSearchToolArgSanitization(tool)];
     }
     return [tool];
   });

--- a/src/agents/tool-arg-sanitize-guard.test.ts
+++ b/src/agents/tool-arg-sanitize-guard.test.ts
@@ -319,3 +319,95 @@ describe("R1.1 heredoc-variant sentinel (TD18-2 regression)", () => {
     expect(out.includes("끝")).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// P2.18.2 open-sentinel variant: 18:58 KST live regression (clonari URL).
+// Model serialized web_fetch args.url as:
+//   "<<|\"|https://clonari.craftbay.io/s/36eea1ea48c1505b\""
+// Sentinel marker "<<|\"|" lacks closing ">" so neither RE_SENTINEL_DOUBLE
+// (requires "|>") nor RE_SENTINEL_HEREDOC ([^|>\s] bans pipe) catches it.
+// RE_SENTINEL_OPEN_* matches "<<|inner|" / "<|inner|" when NOT followed by ">".
+// ---------------------------------------------------------------------------
+
+describe("R1.2 open-sentinel variant (clonari URL 18:58 live regression)", () => {
+  it('O1 removes <<|"|payload open-double sentinel (TD18.2 live args)', () => {
+    const r = sanitizeString(
+      '<<|"|https://clonari.craftbay.io/s/36eea1ea48c1505b"',
+      "url",
+      baseCfg,
+    );
+    // sentinel stripped; trailing unescaped quote balance-quote will add one
+    // more " to make pair (we only assert sentinel removal + payload preserved).
+    expect(r.value.includes("<<|")).toBe(false);
+    expect(r.value.includes("https://clonari.craftbay.io/s/36eea1ea48c1505b")).toBe(true);
+    expect(r.mutations.some((m) => m.rule === "sentinel")).toBe(true);
+  });
+
+  it("O2 removes <|x|payload open-single sentinel", () => {
+    const r = sanitizeString("<|x|https://example.com/path", "url", baseCfg);
+    expect(r.value).toBe("https://example.com/path");
+    expect(r.mutations.some((m) => m.rule === "sentinel")).toBe(true);
+  });
+
+  it("O3 closed form <<|x|> still flows through RE_SENTINEL_DOUBLE (no regression)", () => {
+    const r = sanitizeString("<<|x|>https://example.com", "url", baseCfg);
+    expect(r.value).toBe("https://example.com");
+    expect(r.mutations.some((m) => m.rule === "sentinel")).toBe(true);
+  });
+
+  it("O4 natural prose '<< foo |' with whitespace is NOT matched", () => {
+    // Inner bans whitespace so '<< foo |' (space after '<<' or in inner) skipped.
+    // We pick a shape that would only match if whitespace-gating were broken.
+    const r = sanitizeString("see <<x | y stuff", "text", baseCfg);
+    // The opening "<<x" has no closing "|" right after the inner, so even
+    // without whitespace gating it would not match; this case is purely a
+    // canary that benign prose containing < and | is untouched.
+    expect(r.value).toBe("see <<x | y stuff");
+    expect(r.mutations.length).toBe(0);
+  });
+
+  it("O5 detects contamination on web_fetch args.url and sanitizes (TD18.2)", () => {
+    const r = sanitizeToolArgs(
+      { url: '<<|"|https://clonari.craftbay.io/s/36eea1ea48c1505b"' },
+      "web_fetch",
+      baseCfg,
+    );
+    expect(r.changed).toBe(true);
+    const out = String(r.args.url);
+    expect(out.includes("<<|")).toBe(false);
+    expect(out.includes("https://clonari.craftbay.io/s/36eea1ea48c1505b")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// P2.18.3 nested-sentinel variant: 19:24 KST live regression.
+// Model serialized write args.content as: "<|<|\"# 오로라 소민..."
+// Outer "<|" opens marker; inner contains another "<" which RE_SENTINEL_
+// OPEN_SINGLE's inner ban [^|<>\s] rejects. NESTED variants relax inner to
+// ban only "|" and whitespace.
+// ---------------------------------------------------------------------------
+
+describe("R1.3 nested-sentinel variant (write content args 19:24 live regression)", () => {
+  it('N1 removes <|<|\\"payload nested-single sentinel (TD-RAW-2 live args)', () => {
+    const r = sanitizeString(
+      '<|<|"# 오로라 소민(이서현) 방문 후기 2026-05-18(월)',
+      "content",
+      baseCfg,
+    );
+    expect(r.value.includes("<|<|")).toBe(false);
+    expect(r.value.includes("오로라 소민(이서현) 방문 후기")).toBe(true);
+    expect(r.mutations.some((m) => m.rule === "sentinel")).toBe(true);
+  });
+
+  it("N2 removes <<|<|payload nested-double sentinel", () => {
+    const r = sanitizeString("<<|<|payload here", "content", baseCfg);
+    expect(r.value.includes("<<|<|")).toBe(false);
+    expect(r.value.includes("payload here")).toBe(true);
+  });
+
+  it("N3 natural prose '<x| y' with space inside is NOT matched (whitespace guard)", () => {
+    const r = sanitizeString("see <x| y stuff", "text", baseCfg);
+    expect(r.value).toBe("see <x| y stuff");
+    expect(r.mutations.length).toBe(0);
+  });
+});

--- a/src/agents/tool-arg-sanitize-guard.test.ts
+++ b/src/agents/tool-arg-sanitize-guard.test.ts
@@ -267,3 +267,55 @@ describe("false negative guard", () => {
     expect(r.detected).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// P2.18.1 heredoc-variant sentinel: TD18-2 (2026-05-21 17:12 KST live
+// regression) reproduced "<<//code>" where the model serialized "</code>"
+// into args with an extra "<" prefix. bash then interpreted "<<" as a
+// here-doc, reading stdin until EOF and corrupting the command.
+// ---------------------------------------------------------------------------
+
+describe("R1.1 heredoc-variant sentinel (TD18-2 regression)", () => {
+  it("H1 removes <<//code> heredoc-shaped leak", () => {
+    const r = sanitizeString("코드예시 <<//code> P218_MARKER_B_HTMLTAG 끝", "command", baseCfg);
+    expect(r.value).toBe("코드예시  P218_MARKER_B_HTMLTAG 끝");
+    expect(r.mutations.some((m) => m.rule === "sentinel")).toBe(true);
+  });
+
+  it("H2 removes <<TOKEN> heredoc-shaped leak (no slash)", () => {
+    const r = sanitizeString("payload <<EOF> body", "command", baseCfg);
+    expect(r.value).toBe("payload  body");
+  });
+
+  it("H3 does not touch legitimate `<<` in HTML-allowlisted regions (no-op when allowlisted token does not match heredoc shape)", () => {
+    // Heredoc shape requires no whitespace inside. "<< X >" has space, no match.
+    const r = sanitizeString("text << foo > rest", "command", baseCfg);
+    expect(r.value).toBe("text << foo > rest");
+  });
+
+  it("H4 detects contamination on non-standard field via heredoc variant", () => {
+    const r = sanitizeToolArgs(
+      { extra: "x <<//code> y" } as Record<string, unknown>,
+      "some_tool",
+      baseCfg,
+    );
+    expect(r.changed).toBe(true);
+    expect(r.args.extra).toBe("x  y");
+  });
+
+  it("H5 reproduces TD18-2 13:45-style mutated leak with complete sanitize", () => {
+    const r = sanitizeToolArgs(
+      {
+        command:
+          "bash scripts/person.sh new P218자가검증B -- 2026-05-21 코드예시 <<//code> P218_MARKER_B_HTMLTAG 끝",
+      },
+      "bash",
+      baseCfg,
+    );
+    expect(r.changed).toBe(true);
+    const out = String(r.args.command);
+    expect(out.includes("<<//code>")).toBe(false);
+    expect(out.includes("P218_MARKER_B_HTMLTAG")).toBe(true);
+    expect(out.includes("끝")).toBe(true);
+  });
+});

--- a/src/agents/tool-arg-sanitize-guard.test.ts
+++ b/src/agents/tool-arg-sanitize-guard.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, it } from "vitest";
+import {
+  type FalseNegativeEvent,
+  type ToolArgSanitizeConfig,
+  detectFalseNegativePromise,
+  looksLikeRetryPromise,
+  readEnvConfig,
+  readFalseNegativeGuardConfig,
+  sanitizeString,
+  sanitizeToolArgs,
+  sanitizeToolCallArgumentsInMessage,
+} from "./tool-arg-sanitize-guard.js";
+
+const baseCfg: ToolArgSanitizeConfig = {
+  enabled: true,
+  removeSentinel: true,
+  removeHtmlTags: true,
+  balanceQuote: true,
+  htmlAllowlist: new Set<string>(),
+  maxFieldLen: 65536,
+};
+
+describe("readEnvConfig", () => {
+  it("defaults to all rules enabled when env is empty", () => {
+    const cfg = readEnvConfig({} as NodeJS.ProcessEnv);
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.removeSentinel).toBe(true);
+    expect(cfg.removeHtmlTags).toBe(true);
+    expect(cfg.balanceQuote).toBe(true);
+    expect(cfg.maxFieldLen).toBe(65536);
+  });
+
+  it("honours OPENCLAW_TOOL_ARG_SANITIZE_GUARD_ENABLED=0", () => {
+    const cfg = readEnvConfig({
+      OPENCLAW_TOOL_ARG_SANITIZE_GUARD_ENABLED: "0",
+    } as NodeJS.ProcessEnv);
+    expect(cfg.enabled).toBe(false);
+  });
+
+  it("parses html allowlist as a case-insensitive set", () => {
+    const cfg = readEnvConfig({
+      OPENCLAW_TOOL_ARG_SANITIZE_HTML_ALLOWLIST: "Br, P , Strong",
+    } as NodeJS.ProcessEnv);
+    expect(cfg.htmlAllowlist.has("br")).toBe(true);
+    expect(cfg.htmlAllowlist.has("p")).toBe(true);
+    expect(cfg.htmlAllowlist.has("strong")).toBe(true);
+    expect(cfg.htmlAllowlist.has("code")).toBe(false);
+  });
+});
+
+describe("sanitizeString", () => {
+  it("S1 removes <<|tool|> sentinel", () => {
+    const r = sanitizeString("hello <<|tool|> world", "command", baseCfg);
+    expect(r.value).toBe("hello  world");
+    expect(r.mutations[0]?.rule).toBe("sentinel");
+  });
+
+  it("S2 removes <|end|> sentinel", () => {
+    const r = sanitizeString("foo <|end|>bar", "text", baseCfg);
+    expect(r.value).toBe("foo bar");
+    expect(r.mutations[0]?.rule).toBe("sentinel");
+  });
+
+  it("S3 removes </code> html tag", () => {
+    const r = sanitizeString("./script.sh add somebody </code>", "command", baseCfg);
+    expect(r.value).toBe("./script.sh add somebody ");
+    expect(r.mutations.some((m) => m.rule === "html-tag")).toBe(true);
+  });
+
+  it("S4 removes self-closing-ish <br> tag", () => {
+    const r = sanitizeString("line1<br>line2", "body", baseCfg);
+    expect(r.value).toBe("line1line2");
+  });
+
+  it("S5 removes tag with attribute", () => {
+    const r = sanitizeString('click <a href="x">here</a>', "body", baseCfg);
+    expect(r.value).toBe("click here");
+  });
+
+  it("S6 preserves allowlisted html tag", () => {
+    const cfg: ToolArgSanitizeConfig = { ...baseCfg, htmlAllowlist: new Set(["code"]) };
+    const r = sanitizeString("see <code>x</code> ok", "body", cfg);
+    expect(r.value).toBe("see <code>x</code> ok");
+  });
+
+  it("S7 balances odd unescaped double quotes", () => {
+    const r = sanitizeString('say "hello', "body", baseCfg);
+    expect(r.value).toBe('say "hello"');
+    expect(r.mutations.some((m) => m.rule === "balance-quote")).toBe(true);
+  });
+
+  it("S8 leaves even-count quotes alone", () => {
+    const r = sanitizeString('say "hello" and "bye"', "body", baseCfg);
+    expect(r.value).toBe('say "hello" and "bye"');
+    expect(r.mutations.length).toBe(0);
+  });
+
+  it('S9 escaped \\" does not count toward unbalanced quotes', () => {
+    const r = sanitizeString('json: \\"hello\\"', "body", baseCfg);
+    expect(r.value).toBe('json: \\"hello\\"');
+    expect(r.mutations.length).toBe(0);
+  });
+
+  it("S10 truncates oversize field", () => {
+    const cfg: ToolArgSanitizeConfig = { ...baseCfg, maxFieldLen: 10 };
+    const r = sanitizeString("0123456789ABCDE", "body", cfg);
+    expect(r.value).toBe("0123456789");
+    expect(r.mutations.some((m) => m.rule === "truncate")).toBe(true);
+  });
+});
+
+describe("sanitizeToolArgs", () => {
+  it("S11 leaves non-string fields untouched", () => {
+    const r = sanitizeToolArgs({ command: "ok", count: 3, flag: true }, "bash", baseCfg);
+    expect(r.args.count).toBe(3);
+    expect(r.args.flag).toBe(true);
+    expect(r.changed).toBe(false);
+  });
+
+  it("S12 sanitizes non-standard string fields when contaminated", () => {
+    const r = sanitizeToolArgs(
+      { custom: "x <<|sentinel|> y" } as Record<string, unknown>,
+      "some_tool",
+      baseCfg,
+    );
+    expect(r.args.custom).toBe("x  y");
+    expect(r.changed).toBe(true);
+  });
+
+  it("S13 leaves clean non-standard string fields untouched", () => {
+    const r = sanitizeToolArgs(
+      { custom: "plain value" } as Record<string, unknown>,
+      "some_tool",
+      baseCfg,
+    );
+    expect(r.args.custom).toBe("plain value");
+    expect(r.changed).toBe(false);
+  });
+
+  it("S14 reproduces 2026-05-21 13:45 incident: command with </code> leak", () => {
+    const args = {
+      command: './person.sh add 이서현 -- "오로라 소민 5/18 방문" </code>',
+    };
+    const r = sanitizeToolArgs(args, "bash", baseCfg);
+    expect(r.changed).toBe(true);
+    expect(String(r.args.command).includes("</code>")).toBe(false);
+    expect(String(r.args.command).includes("이서현")).toBe(true);
+  });
+
+  it("S15 handles sentinel+html-tag combination in one field", () => {
+    const r = sanitizeToolArgs({ command: "x <<|tool|> y </code> z" }, "bash", baseCfg);
+    expect(r.args.command).toBe("x  y  z");
+    expect(r.changed).toBe(true);
+  });
+
+  it("S16 no-op when guard disabled", () => {
+    const cfg: ToolArgSanitizeConfig = { ...baseCfg, enabled: false };
+    const r = sanitizeToolArgs({ command: "x <<|leak|>" }, "bash", cfg);
+    expect(r.args.command).toBe("x <<|leak|>");
+    expect(r.changed).toBe(false);
+  });
+});
+
+describe("sanitizeToolCallArgumentsInMessage", () => {
+  it("rewrites toolCall block arguments in place", () => {
+    const message = {
+      role: "assistant",
+      content: [
+        { type: "text", text: "ok" },
+        {
+          type: "toolCall",
+          name: "bash",
+          arguments: { command: "echo hi </code>" },
+        },
+      ],
+    };
+    const changed = sanitizeToolCallArgumentsInMessage(message, baseCfg);
+    expect(changed).toBe(true);
+    const toolBlock = message.content[1] as { arguments: { command: string } };
+    expect(toolBlock.arguments.command).toBe("echo hi ");
+  });
+
+  it("ignores non-tool-call blocks", () => {
+    const message = {
+      content: [{ type: "text", text: "raw <<|leak|>" }],
+    };
+    const changed = sanitizeToolCallArgumentsInMessage(message, baseCfg);
+    expect(changed).toBe(false);
+  });
+});
+
+describe("false negative guard", () => {
+  it("readFalseNegativeGuardConfig defaults to warn mode + 10s window", () => {
+    const cfg = readFalseNegativeGuardConfig({} as NodeJS.ProcessEnv);
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.mode).toBe("warn");
+    expect(cfg.windowMs).toBe(10000);
+  });
+
+  it("looksLikeRetryPromise matches Korean and English retry phrases", () => {
+    expect(looksLikeRetryPromise("아, 미안! 다시 시도합니다")).toBe(true);
+    expect(looksLikeRetryPromise("재시도 할게요")).toBe(true);
+    expect(looksLikeRetryPromise("Let me retry that")).toBe(true);
+    expect(looksLikeRetryPromise("I'll try again")).toBe(true);
+    expect(looksLikeRetryPromise("just a normal answer")).toBe(false);
+  });
+
+  it("F1 detects retry-promise without follow-up toolCall (warn mode)", () => {
+    const t0 = 1_000_000;
+    const events: FalseNegativeEvent[] = [
+      { kind: "toolFailed", at: t0, toolName: "bash", error: "syntax error" },
+      { kind: "assistantText", at: t0 + 500, text: "아 미안! 다시 시도합니다" },
+    ];
+    const r = detectFalseNegativePromise(events, {
+      enabled: true,
+      mode: "warn",
+      windowMs: 10_000,
+    });
+    expect(r.detected).toBe(true);
+    if (r.detected) {
+      expect(r.failedToolName).toBe("bash");
+      expect(r.action).toBe("warn");
+    }
+  });
+
+  it("F2 does not flag when a real retry follows within the window", () => {
+    const t0 = 1_000_000;
+    const events: FalseNegativeEvent[] = [
+      { kind: "toolFailed", at: t0, toolName: "bash", error: "syntax error" },
+      { kind: "assistantText", at: t0 + 500, text: "다시 시도합니다" },
+      { kind: "toolCall", at: t0 + 1500, toolName: "bash" },
+    ];
+    const r = detectFalseNegativePromise(events, {
+      enabled: true,
+      mode: "warn",
+      windowMs: 10_000,
+    });
+    expect(r.detected).toBe(false);
+  });
+
+  it("F3 honours windowMs - retry after window still flags as false negative", () => {
+    const t0 = 1_000_000;
+    const events: FalseNegativeEvent[] = [
+      { kind: "toolFailed", at: t0, toolName: "bash", error: "syntax error" },
+      { kind: "assistantText", at: t0 + 500, text: "다시 시도합니다" },
+      { kind: "toolCall", at: t0 + 20_000, toolName: "bash" },
+    ];
+    const r = detectFalseNegativePromise(events, {
+      enabled: true,
+      mode: "warn",
+      windowMs: 10_000,
+    });
+    expect(r.detected).toBe(true);
+  });
+
+  it("F4 disabled guard returns not-detected", () => {
+    const t0 = 1_000_000;
+    const events: FalseNegativeEvent[] = [
+      { kind: "toolFailed", at: t0, toolName: "bash", error: "syntax error" },
+      { kind: "assistantText", at: t0 + 500, text: "다시 시도합니다" },
+    ];
+    const r = detectFalseNegativePromise(events, {
+      enabled: false,
+      mode: "warn",
+      windowMs: 10_000,
+    });
+    expect(r.detected).toBe(false);
+  });
+});

--- a/src/agents/tool-arg-sanitize-guard.test.ts
+++ b/src/agents/tool-arg-sanitize-guard.test.ts
@@ -275,6 +275,34 @@ describe("false negative guard", () => {
 // here-doc, reading stdin until EOF and corrupting the command.
 // ---------------------------------------------------------------------------
 
+describe("R1.x cmd-prefix sentinel (P6-2)", () => {
+  const cases = [
+    { id: "CP1", input: "<|find ~/projects -name foo.md", want: "find ~/projects -name foo.md" },
+    {
+      id: "CP2",
+      input: "<|\\find ~/projects -name foo.md",
+      want: "\\find ~/projects -name foo.md",
+    },
+    {
+      id: "CP3",
+      input: "bash <|scripts/memory.sh on 2026-05-22",
+      want: "bash scripts/memory.sh on 2026-05-22",
+    },
+    {
+      id: "CP4",
+      input: "normal command without sentinel",
+      want: "normal command without sentinel",
+    },
+    { id: "CP5", input: "<|find foo && <|ls bar", want: "find foo && ls bar" },
+  ];
+  cases.forEach(({ id, input, want }) => {
+    it(id, () => {
+      const result = sanitizeString(input, "command", baseCfg);
+      expect(result.value).toBe(want);
+    });
+  });
+});
+
 describe("R1.1 heredoc-variant sentinel (TD18-2 regression)", () => {
   it("H1 removes <<//code> heredoc-shaped leak", () => {
     const r = sanitizeString("코드예시 <<//code> P218_MARKER_B_HTMLTAG 끝", "command", baseCfg);
@@ -501,5 +529,84 @@ describe("R4 path-quote-strip (P2.19b file_path quote sanitize)", () => {
     const r = sanitizeString("'\"x\"'", "file_path", baseCfg, { isPath: true });
     expect(r.value).toBe("x");
     expect(r.mutations.some((m) => m.rule === "path-quote-strip")).toBe(true);
+  });
+});
+
+// ===========================================================================
+// P2.24c — sentinel orphan-prefix + control-char strip (2026-05-22)
+// Regression cases for scenario-07-exec-sentinel-guard failure:
+//   raw bytes "3c 7c 0c 69 6e 64" = "<|<\x0c>ind" — sentinel <| followed by
+//   form-feed (0x0c). RE_SENTINEL_CMD_PREFIX's `[^\s|>]` lookahead rejected
+//   form-feed (\s includes \f), so the sentinel survived sanitize and reached
+//   bash unchanged, producing "ind: command not found".
+// ===========================================================================
+describe("tool-arg-sanitize-guard P2.24c — orphan prefix + control char strip", () => {
+  it("C1 scenario-07 exact raw: <|<0x0c>find ~/projects strips to 'find ~/projects'", () => {
+    // Raw input as emitted by Gemma4 (after JSON.parse): "<|" + 0x0c + "find ..."
+    const raw = "<|\u000cfind ~/projects/openclaw/agents/gemma/workspace";
+    const r = sanitizeString(raw, "command", baseCfg);
+    expect(r.value).toBe("find ~/projects/openclaw/agents/gemma/workspace");
+    expect(r.mutations.some((m) => m.rule === "sentinel")).toBe(true);
+  });
+
+  it("C2 double orphan <<|find ... strips to 'find ...'", () => {
+    const r = sanitizeString("<<|find /home -name '*.md'", "command", baseCfg);
+    expect(r.value).toBe("find /home -name '*.md'");
+    expect(r.mutations.some((m) => m.rule === "sentinel")).toBe(true);
+  });
+
+  it("C3 single orphan <|find ... (no control char) strips to 'find ...'", () => {
+    // Already handled by RE_SENTINEL_CMD_PREFIX (lookahead matches 'f'), but
+    // verify R5b also catches it as a last-resort net.
+    const r = sanitizeString("<|find /tmp", "command", baseCfg);
+    expect(r.value).toBe("find /tmp");
+    expect(r.mutations.some((m) => m.rule === "sentinel")).toBe(true);
+  });
+
+  it("C4 clean command is passed through unchanged", () => {
+    const r = sanitizeString("find /home/lisyoen -name '*.md'", "command", baseCfg);
+    expect(r.value).toBe("find /home/lisyoen -name '*.md'");
+    expect(r.mutations.length).toBe(0);
+  });
+
+  it("C5 multi-line script body preserves \\n and \\t", () => {
+    const raw = "set -e\n\tfind /tmp\n\techo done";
+    const r = sanitizeString(raw, "script", baseCfg);
+    expect(r.value).toBe(raw);
+    expect(r.mutations.length).toBe(0);
+  });
+
+  it("C6 non-EXEC field (body) — control char strip + CMD_PREFIX still cleans <|<0x0c>text", () => {
+    const raw = "<|\u000chello world";
+    const r = sanitizeString(raw, "body", baseCfg);
+    // R5c strips 0x0c -> "<|hello world" -> CMD_PREFIX (next char 'h' is
+    // non-space/pipe/gt) matches -> "hello world"
+    expect(r.value).toBe("hello world");
+    expect(r.mutations.some((m) => m.rule === "sentinel")).toBe(true);
+  });
+
+  it("C7 sanitizeToolArgs end-to-end on exec.command field", () => {
+    const raw = "<|\u000cfind ~/projects -name '*.md'";
+    const r = sanitizeToolArgs({ command: raw }, "exec");
+    expect(r.args.command).toBe("find ~/projects -name '*.md'");
+    expect(r.changed).toBe(true);
+  });
+
+  it("C8 vertical-tab \\x0b is also stripped", () => {
+    const raw = "<|\u000bls /tmp";
+    const r = sanitizeString(raw, "command", baseCfg);
+    expect(r.value).toBe("ls /tmp");
+    expect(r.mutations.some((m) => m.rule === "sentinel")).toBe(true);
+  });
+
+  it("C9 EXEC_CMD_SANITIZED_FIELDS strips <| even when surrounded by literal chars (R5b)", () => {
+    // Construct a case the standard sentinel regexes miss: "<|" embedded mid-string
+    // with no closing |>. RE_SENTINEL_CMD_PREFIX needs lookahead to non-space; this
+    // case has "<|" followed by 'x'. R5b is the safety net.
+    const r = sanitizeString("ls && <|x && pwd", "command", baseCfg);
+    // CMD_PREFIX would also catch this (next char 'x' is non-space), so verify
+    // result is clean regardless of which rule applied.
+    expect(r.value).toBe("ls && x && pwd");
+    expect(r.mutations.some((m) => m.rule === "sentinel")).toBe(true);
   });
 });

--- a/src/agents/tool-arg-sanitize-guard.test.ts
+++ b/src/agents/tool-arg-sanitize-guard.test.ts
@@ -411,3 +411,95 @@ describe("R1.3 nested-sentinel variant (write content args 19:24 live regression
     expect(r.mutations.length).toBe(0);
   });
 });
+
+describe("R4 path-quote-strip (P2.19b file_path quote sanitize)", () => {
+  it("P1 strips paired double quotes from file_path", () => {
+    const r = sanitizeString('"notes/foo.md"', "file_path", baseCfg, { isPath: true });
+    expect(r.value).toBe("notes/foo.md");
+    expect(r.mutations.some((m) => m.rule === "path-quote-strip")).toBe(true);
+  });
+
+  it("P2 strips paired single quotes from file_path", () => {
+    const r = sanitizeString("'~/relative.md'", "file_path", baseCfg, { isPath: true });
+    expect(r.value).toBe("~/relative.md");
+    expect(r.mutations.some((m) => m.rule === "path-quote-strip")).toBe(true);
+  });
+
+  it("P3 strips <| sentinel prefix from file_path", () => {
+    const r = sanitizeString("<|/abs/path.md", "file_path", baseCfg, { isPath: true });
+    expect(r.value).toBe("/abs/path.md");
+    expect(r.mutations.some((m) => m.rule === "path-quote-strip")).toBe(true);
+  });
+
+  it("P4 strips <<| sentinel prefix from file_path", () => {
+    const r = sanitizeString("<<|/abs/path.md", "file_path", baseCfg, { isPath: true });
+    expect(r.value).toBe("/abs/path.md");
+    expect(r.mutations.some((m) => m.rule === "path-quote-strip")).toBe(true);
+  });
+
+  it("P5 strips one-side leading dquote (NOT balance-quote appending)", () => {
+    const r = sanitizeString('"notes/foo.md', "file_path", baseCfg, { isPath: true });
+    expect(r.value).toBe("notes/foo.md");
+    expect(r.mutations.some((m) => m.rule === "path-quote-strip")).toBe(true);
+    expect(r.mutations.some((m) => m.rule === "balance-quote")).toBe(false);
+  });
+
+  it("P6 strips one-side trailing dquote (NOT balance-quote)", () => {
+    const r = sanitizeString('notes/foo.md"', "file_path", baseCfg, { isPath: true });
+    expect(r.value).toBe("notes/foo.md");
+    expect(r.mutations.some((m) => m.rule === "path-quote-strip")).toBe(true);
+    expect(r.mutations.some((m) => m.rule === "balance-quote")).toBe(false);
+  });
+
+  it("P7 reproduces jsonl L34 live case (paired dquotes wrapping path)", () => {
+    // Real failure: file_path: "\"notes/p219-retry.md\"" - model self-correction
+    // wrote a literal "notes/p219-retry.md" (with surrounding dquotes) file.
+    const r = sanitizeString('"notes/p219-retry.md"', "file_path", baseCfg, { isPath: true });
+    expect(r.value).toBe("notes/p219-retry.md");
+    expect(r.mutations.some((m) => m.rule === "path-quote-strip")).toBe(true);
+  });
+
+  it("P8 normal path unchanged (no false positive)", () => {
+    const r = sanitizeString("notes/normal.md", "file_path", baseCfg, { isPath: true });
+    expect(r.value).toBe("notes/normal.md");
+    expect(r.mutations.length).toBe(0);
+  });
+
+  it("P9 empty path unchanged", () => {
+    const r = sanitizeString("", "file_path", baseCfg, { isPath: true });
+    expect(r.value).toBe("");
+    expect(r.mutations.length).toBe(0);
+  });
+
+  it("P10 sanitizeToolArgs detects file_path field on write tool", () => {
+    const r = sanitizeToolArgs({ file_path: '"notes/foo.md"', content: "hello" }, "write");
+    expect(r.args.file_path).toBe("notes/foo.md");
+    expect(r.changed).toBe(true);
+  });
+
+  it("P11 sanitizeToolArgs handles 'path' field too (not just file_path)", () => {
+    const r = sanitizeToolArgs({ path: "'~/test.md'" }, "edit");
+    expect(r.args.path).toBe("~/test.md");
+    expect(r.changed).toBe(true);
+  });
+
+  it("P12 balance-quote bypassed on path field with one-side dquote", () => {
+    // Without isPath: balance-quote appends a stray dquote -> corrupted path.
+    // With isPath: path-quote-strip removes the lone dquote instead.
+    const r = sanitizeString('"notes/foo.md', "file_path", baseCfg, { isPath: true });
+    expect(r.value).toBe("notes/foo.md");
+    expect(r.mutations.some((m) => m.rule === "balance-quote")).toBe(false);
+  });
+
+  it("P13 path with spaces but no quotes is unchanged", () => {
+    const r = sanitizeString("notes/my file.md", "file_path", baseCfg, { isPath: true });
+    expect(r.value).toBe("notes/my file.md");
+    expect(r.mutations.length).toBe(0);
+  });
+
+  it("P14 double-wrapped quotes (paired-single around paired-double)", () => {
+    const r = sanitizeString("'\"x\"'", "file_path", baseCfg, { isPath: true });
+    expect(r.value).toBe("x");
+    expect(r.mutations.some((m) => m.rule === "path-quote-strip")).toBe(true);
+  });
+});

--- a/src/agents/tool-arg-sanitize-guard.test.ts
+++ b/src/agents/tool-arg-sanitize-guard.test.ts
@@ -701,3 +701,43 @@ describe("R5d trailing-orphan sentinel (P2.24d, gemma write-content live regress
     expect(r.value).toBe("echo hi\n");
   });
 });
+
+describe("R5e trailing-lt (P2.24e, bare trailing < on path fields)", () => {
+  it("R5e-1 strips trailing < from file_path (live regression: edit args)", () => {
+    // e8d2bd03 jsonl: edit args file_path = "~/projects/openclaw/.../visit_logs.md<"
+    const r = sanitizeString("memory/visit_logs.md<", "file_path", baseCfg, { isPath: true });
+    expect(r.value).toBe("memory/visit_logs.md");
+    expect(r.mutations.some((m) => m.rule === "path-quote-strip")).toBe(true);
+  });
+
+  it("R5e-2 strips multiple trailing < from path", () => {
+    const r = sanitizeString("memory/foo.md<<", "file_path", baseCfg, { isPath: true });
+    expect(r.value).toBe("memory/foo.md");
+  });
+
+  it("R5e-3 does not touch normal path without trailing <", () => {
+    const r = sanitizeString("memory/aurora-somin-plan-2026-05-22.md", "file_path", baseCfg, {
+      isPath: true,
+    });
+    expect(r.value).toBe("memory/aurora-somin-plan-2026-05-22.md");
+    expect(r.mutations.length).toBe(0);
+  });
+
+  it("R5e-4 sanitizeToolArgs catches file_path ending in < (edit tool)", () => {
+    const args = {
+      file_path: "memory/visit_logs.md<",
+      oldText: "some text",
+      newText: "new text",
+    };
+    const result = sanitizeToolArgs(args, "edit");
+    expect(result.args.file_path).toBe("memory/visit_logs.md");
+    expect(result.changed).toBe(true);
+  });
+
+  it("R5e-5 non-path content field trailing < is preserved (legitimate prose)", () => {
+    // In non-path fields, trailing "<" is not stripped (only path fields).
+    // A content field could end in a math inequality "x < y" which is fine.
+    const r = sanitizeString("x < y means smaller", "content", baseCfg);
+    expect(r.value).toBe("x < y means smaller");
+  });
+});

--- a/src/agents/tool-arg-sanitize-guard.test.ts
+++ b/src/agents/tool-arg-sanitize-guard.test.ts
@@ -610,3 +610,94 @@ describe("tool-arg-sanitize-guard P2.24c — orphan prefix + control char strip"
     expect(r.mutations.some((m) => m.rule === "sentinel")).toBe(true);
   });
 });
+
+describe("R5d trailing-orphan sentinel (P2.24d, gemma write-content live regression)", () => {
+  // Live failure case: 2026-05-23 12:44 KST.
+  // Gemma4 NVFP4 write tool args.content ended with "\n<|" because the
+  // sentinel open-token leaked at final emission. R1 sentinel regexes
+  // require paired form or non-empty suffix; R5b orphan strip is gated
+  // to EXEC_CMD fields. Result: a 568-byte markdown template was written
+  // with literal "<|" appended at end-of-file.
+  //
+  // jsonl: agents/gemma/sessions/e8d2bd03-3cee-48d5-b380-4bdc1dc92756.jsonl L98
+  //   toolName: "write"
+  //   arguments.content ends with: "...작성하세요)*\n<|"
+  //   arguments.file_path: clean (R4 caught it)
+  //   toolResult: isError=false (write succeeded; only content was tainted)
+
+  it("R5d-1 strips trailing <| from content field", () => {
+    const r = sanitizeString("# Heading\n\nBody text.\n<|", "content", baseCfg);
+    expect(r.value).toBe("# Heading\n\nBody text.\n");
+    expect(r.mutations.some((m) => m.rule === "sentinel")).toBe(true);
+  });
+
+  it("R5d-2 strips trailing <<| from content field", () => {
+    const r = sanitizeString("text\n<<|", "content", baseCfg);
+    expect(r.value).toBe("text\n");
+  });
+
+  it("R5d-3 strips trailing <| and trailing whitespace, preserves leading whitespace before sentinel", () => {
+    // Whitespace BEFORE the sentinel is preserved (could be legitimate
+    // body indentation). Whitespace AFTER the sentinel is stripped.
+    const r = sanitizeString("text   <|  \n  ", "body", baseCfg);
+    expect(r.value).toBe("text   ");
+  });
+
+  it("R5d-4 strips trailing <| from text/message/prompt fields", () => {
+    expect(sanitizeString("foo<|", "text", baseCfg).value).toBe("foo");
+    expect(sanitizeString("foo<|", "message", baseCfg).value).toBe("foo");
+    expect(sanitizeString("foo<|", "prompt", baseCfg).value).toBe("foo");
+    expect(sanitizeString("foo<|", "query", baseCfg).value).toBe("foo");
+  });
+
+  it("R5d-5 preserves mid-content <| (legitimate prose about tokens)", () => {
+    // Markdown about LLM tokens may legitimately contain "<|".
+    const input = "The token <|im_start|> opens a turn.\n";
+    const r = sanitizeString(input, "content", baseCfg);
+    // R1 paired "<|im_start|>" should be stripped by RE_SENTINEL_OPEN_SINGLE.
+    // The result should NOT have trailing strip activity beyond R1.
+    expect(r.value).toBe("The token  opens a turn.\n");
+  });
+
+  it("R5d-6 does not touch mid-content <| followed by whitespace (when not at end)", () => {
+    // "<|" followed by whitespace escapes R1.x RE_SENTINEL_CMD_PREFIX
+    // (which requires [^\s|>] lookahead). R5b is gated to EXEC_CMD fields
+    // so content escapes that too. R5d targets end-of-string only — when
+    // "<|" is mid-content with a trailing tail after it, R5d must not
+    // touch it. Verifies R5d is anchored to $.
+    const r = sanitizeString("prefix <| midfix suffix", "content", baseCfg);
+    expect(r.value).toBe("prefix <| midfix suffix");
+  });
+
+  it("R5d-7 multiple trailing <| forms collapsed", () => {
+    const r = sanitizeString("text\n<|<|<|", "content", baseCfg);
+    expect(r.value).toBe("text\n");
+  });
+
+  it("R5d-8 trailing <| through sanitizeToolArgs on write tool", () => {
+    const args = {
+      file_path: "memory/notes.md",
+      content: "# Notes\n\nBody.\n<|",
+    };
+    const res = sanitizeToolArgs(args, "write", baseCfg);
+    expect(res.changed).toBe(true);
+    expect((res.args as { content: string }).content).toBe("# Notes\n\nBody.\n");
+    expect((res.args as { file_path: string }).file_path).toBe("memory/notes.md");
+  });
+
+  it("R5d-9 path field skipped (R4 handles path-style sentinel prefix)", () => {
+    // Trailing "<|" on a path field — R5d skips (options.isPath = true),
+    // but R4 path-quote-strip handles it at the start (not end). For end-
+    // of-string trailing case, R5d skip is correct: paths shouldn't have
+    // trailing "<|" patterns from real models.
+    const r = sanitizeString("memory/file.md", "file_path", baseCfg);
+    expect(r.value).toBe("memory/file.md");
+  });
+
+  it("R5d-10 trailing-only does NOT affect command field beyond R5b", () => {
+    // command field already gets R5b global orphan strip. R5d should
+    // be a no-op for command fields where R5b already cleaned up.
+    const r = sanitizeString("echo hi\n<|", "command", baseCfg);
+    expect(r.value).toBe("echo hi\n");
+  });
+});

--- a/src/agents/tool-arg-sanitize-guard.ts
+++ b/src/agents/tool-arg-sanitize-guard.ts
@@ -167,6 +167,26 @@ export function readFalseNegativeGuardConfig(
 // Bounded length 0..32 to avoid runaway regex backtracking on edge inputs.
 const RE_SENTINEL_DOUBLE = /<<\|[^|<>]{0,32}\|>/g;
 const RE_SENTINEL_SINGLE = /<\|[^|<>]{0,32}\|>/g;
+// R1.2 open sentinel variant: P2.18.2 (2026-05-21 18:58) live reproduction.
+// User sent clonari URL to gemma; model serialized web_fetch args.url as
+// "<<|\"|https://clonari.craftbay.io/s/...". The closing ">" of the sentinel
+// is dropped and the inner "|" is followed directly by the payload, so neither
+// RE_SENTINEL_DOUBLE (requires "|>" terminator) nor RE_SENTINEL_HEREDOC
+// ([^|>\s] inner bans pipe) catches it. RE_SENTINEL_OPEN_* matches the open
+// form "<<|inner|" or "<|inner|" only when NOT followed by ">" (lookahead
+// (?!>) keeps DOUBLE/SINGLE behavior orthogonal — closed forms still flow
+// through R1). Inner also bans whitespace so natural "<< foo |" prose is safe.
+const RE_SENTINEL_OPEN_DOUBLE = /<<\|[^|<>\s]{0,32}\|(?!>)/g;
+const RE_SENTINEL_OPEN_SINGLE = /<\|[^|<>\s]{0,32}\|(?!>)/g;
+// R1.3 nested sentinel variant: P2.18.3 (2026-05-21 19:24) live reproduction.
+// Model serialized write args.content as "<|<|\"# ...". The outer "<|"
+// opens a sentinel marker but inner contains "<" (the second "<|" start),
+// so RE_SENTINEL_OPEN_SINGLE inner ban [^|<>\s] rejects "<". Relax inner
+// to ban only "|" and whitespace — preserving the {1,64} length cap. False
+// positives in natural prose are unlikely because "<...|" with no whitespace
+// for up to 64 chars is rare. Length 1+ so empty inner cannot match.
+const RE_SENTINEL_NESTED_DOUBLE = /<<\|[^|\s]{1,64}\|(?!>)/g;
+const RE_SENTINEL_NESTED_SINGLE = /<\|[^|\s]{1,64}\|(?!>)/g;
 // R1.1 heredoc variant: P2.18 TD18-2 (2026-05-21 17:12) reproduced
 // "<<//code>" - model serializing "</code>" into args ended up adding an
 // extra "<" prefix, which bash then interprets as a here-doc delimiter
@@ -208,7 +228,11 @@ export function sanitizeString(
     const before = current;
     const next = current
       .replace(RE_SENTINEL_DOUBLE, "")
+      .replace(RE_SENTINEL_OPEN_DOUBLE, "")
+      .replace(RE_SENTINEL_NESTED_DOUBLE, "")
       .replace(RE_SENTINEL_SINGLE, "")
+      .replace(RE_SENTINEL_OPEN_SINGLE, "")
+      .replace(RE_SENTINEL_NESTED_SINGLE, "")
       .replace(RE_SENTINEL_HEREDOC, "");
     if (next !== before) {
       mutations.push({
@@ -306,12 +330,20 @@ export function sanitizeToolArgs(
       // Also sanitize any string field whose value looks contaminated.
       const looksContaminated =
         RE_SENTINEL_DOUBLE.test(value) ||
+        RE_SENTINEL_OPEN_DOUBLE.test(value) ||
+        RE_SENTINEL_NESTED_DOUBLE.test(value) ||
         RE_SENTINEL_SINGLE.test(value) ||
+        RE_SENTINEL_OPEN_SINGLE.test(value) ||
+        RE_SENTINEL_NESTED_SINGLE.test(value) ||
         RE_SENTINEL_HEREDOC.test(value) ||
         RE_HTML_TAG.test(value);
       // Reset global regex state after .test().
       RE_SENTINEL_DOUBLE.lastIndex = 0;
+      RE_SENTINEL_OPEN_DOUBLE.lastIndex = 0;
+      RE_SENTINEL_NESTED_DOUBLE.lastIndex = 0;
       RE_SENTINEL_SINGLE.lastIndex = 0;
+      RE_SENTINEL_OPEN_SINGLE.lastIndex = 0;
+      RE_SENTINEL_NESTED_SINGLE.lastIndex = 0;
       RE_SENTINEL_HEREDOC.lastIndex = 0;
       RE_HTML_TAG.lastIndex = 0;
       if (!looksContaminated) {

--- a/src/agents/tool-arg-sanitize-guard.ts
+++ b/src/agents/tool-arg-sanitize-guard.ts
@@ -1,0 +1,539 @@
+/**
+ * Tool-argument sanitize guard for gemma-style local models that leak
+ * sentinel tokens or HTML tags into tool_call arguments. P2.18.
+ *
+ * Background: 2026-05-21 13:45 KST incident reproduced a new failure
+ * pattern that earlier fixes did not address:
+ *
+ *   gemma assistantText (jsonl L196, L216):
+ *     "<<|tool|> bash {"command":"./person.sh add 이서현 -- ..."
+ *   gemma toolCall args (jsonl L218):
+ *     {"command":"./person.sh add 이서현 -- ... </code>"}
+ *   gemma toolResult (jsonl L219):
+ *     "syntax error near unexpected token `<'"
+ *   gemma next assistantText (jsonl L220):
+ *     "아, 미안해! ... 다시 시도합니다"
+ *   gemma actual retry within 10s: NONE
+ *
+ * The model's text channel leaks markup tokens (sentinel "<<|...|>"
+ * and HTML "</code>") and the tool channel inherits the same noise
+ * because the sampler does not separate role from token surface form.
+ * Sanitize.ts (P2.11/P2.16) handles the assistantText channel only;
+ * tool_call arguments are a distinct emission path that bypasses it.
+ *
+ * This guard runs on the stream pipeline, identical placement to
+ * P2.14 hallucination-guard and the xAI HTML-entity decoder, and
+ * sanitizes string fields in tool_call arguments in place before the
+ * runtime dispatches the tool.
+ *
+ * Three sanitize rules (each independently env-gated):
+ *   R1. sentinel  : remove "<<|...|>" and "<|...|>" payloads
+ *   R2. html-tag  : remove "</tag>" / "<tag>" / "<tag attr=...>"
+ *   R3. balance-q : if a string contains an odd number of unescaped
+ *                   double quotes, append one "\"" to balance it
+ *
+ * False-negative companion guard: when the assistant says "다시
+ * 시도합니다" / "retry" after a tool failure but never actually
+ * re-emits a tool_call within windowMs, emit a warn log entry. The
+ * 13:45 incident showed the model promising a retry it never made,
+ * which is itself a signal of sampler confusion.
+ *
+ * The guard is gated by OPENCLAW_TOOL_ARG_SANITIZE_GUARD_ENABLED and
+ * applies to all agents (no agent-id whitelist), since the failure is
+ * a tokenizer property not specific to gemma. Set
+ * OPENCLAW_TOOL_ARG_SANITIZE_GUARD_ENABLED=0 to disable.
+ */
+
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("agents/tool-arg-sanitize-guard");
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+const ENV_ENABLED = "OPENCLAW_TOOL_ARG_SANITIZE_GUARD_ENABLED";
+const ENV_REMOVE_SENTINEL = "OPENCLAW_TOOL_ARG_SANITIZE_REMOVE_SENTINEL";
+const ENV_REMOVE_HTML_TAGS = "OPENCLAW_TOOL_ARG_SANITIZE_REMOVE_HTML_TAGS";
+const ENV_BALANCE_QUOTE = "OPENCLAW_TOOL_ARG_SANITIZE_BALANCE_QUOTE";
+const ENV_HTML_ALLOWLIST = "OPENCLAW_TOOL_ARG_SANITIZE_HTML_ALLOWLIST";
+const ENV_MAX_FIELD_LEN = "OPENCLAW_TOOL_ARG_SANITIZE_MAX_FIELD_LEN";
+
+const ENV_FN_GUARD_ENABLED = "OPENCLAW_FALSE_NEGATIVE_GUARD_ENABLED";
+const ENV_FN_GUARD_MODE = "OPENCLAW_FALSE_NEGATIVE_GUARD_MODE";
+const ENV_FN_GUARD_WINDOW_MS = "OPENCLAW_FALSE_NEGATIVE_GUARD_WINDOW_MS";
+
+const DEFAULT_SANITIZED_FIELDS = [
+  "command",
+  "url",
+  "prompt",
+  "text",
+  "body",
+  "content",
+  "message",
+  "query",
+] as const;
+
+const DEFAULT_MAX_FIELD_LEN = 65536;
+const DEFAULT_FN_WINDOW_MS = 10000;
+
+export type ToolArgSanitizeConfig = {
+  enabled: boolean;
+  removeSentinel: boolean;
+  removeHtmlTags: boolean;
+  balanceQuote: boolean;
+  htmlAllowlist: ReadonlySet<string>;
+  maxFieldLen: number;
+};
+
+export type FalseNegativeGuardMode = "warn" | "none";
+
+export type FalseNegativeGuardConfig = {
+  enabled: boolean;
+  mode: FalseNegativeGuardMode;
+  windowMs: number;
+};
+
+function parseBoolEnv(value: string | undefined, defaultValue: boolean): boolean {
+  if (value === undefined || value === null) {
+    return defaultValue;
+  }
+  const v = String(value).trim().toLowerCase();
+  if (v === "") {
+    return defaultValue;
+  }
+  if (v === "0" || v === "false" || v === "no" || v === "off") {
+    return false;
+  }
+  if (v === "1" || v === "true" || v === "yes" || v === "on") {
+    return true;
+  }
+  return defaultValue;
+}
+
+function parseIntEnv(value: string | undefined, defaultValue: number): number {
+  if (value === undefined || value === null) {
+    return defaultValue;
+  }
+  const n = Number.parseInt(String(value).trim(), 10);
+  if (!Number.isFinite(n) || n <= 0) {
+    return defaultValue;
+  }
+  return n;
+}
+
+function parseAllowlistEnv(value: string | undefined): ReadonlySet<string> {
+  if (!value) {
+    return new Set<string>();
+  }
+  return new Set(
+    String(value)
+      .split(",")
+      .map((s) => s.trim().toLowerCase())
+      .filter((s) => s.length > 0),
+  );
+}
+
+export function readEnvConfig(env: NodeJS.ProcessEnv = process.env): ToolArgSanitizeConfig {
+  return {
+    enabled: parseBoolEnv(env[ENV_ENABLED], true),
+    removeSentinel: parseBoolEnv(env[ENV_REMOVE_SENTINEL], true),
+    removeHtmlTags: parseBoolEnv(env[ENV_REMOVE_HTML_TAGS], true),
+    balanceQuote: parseBoolEnv(env[ENV_BALANCE_QUOTE], true),
+    htmlAllowlist: parseAllowlistEnv(env[ENV_HTML_ALLOWLIST]),
+    maxFieldLen: parseIntEnv(env[ENV_MAX_FIELD_LEN], DEFAULT_MAX_FIELD_LEN),
+  };
+}
+
+export function readFalseNegativeGuardConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): FalseNegativeGuardConfig {
+  const rawMode = String(env[ENV_FN_GUARD_MODE] ?? "warn")
+    .trim()
+    .toLowerCase();
+  const mode: FalseNegativeGuardMode = rawMode === "none" ? "none" : "warn";
+  return {
+    enabled: parseBoolEnv(env[ENV_FN_GUARD_ENABLED], true),
+    mode,
+    windowMs: parseIntEnv(env[ENV_FN_GUARD_WINDOW_MS], DEFAULT_FN_WINDOW_MS),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Sanitize primitives (pure, no I/O)
+// ---------------------------------------------------------------------------
+
+// R1 sentinel: "<<|...|>" then "<|...|>". Inner body bans pipe, lt, gt.
+// Bounded length 0..32 to avoid runaway regex backtracking on edge inputs.
+const RE_SENTINEL_DOUBLE = /<<\|[^|<>]{0,32}\|>/g;
+const RE_SENTINEL_SINGLE = /<\|[^|<>]{0,32}\|>/g;
+
+// R2 html-tag: matches "</tag>", "<tag>", "<tag attr=value ...>".
+// Inner attr region bounded to 256 chars and may not contain "<" or ">".
+const RE_HTML_TAG = /<\/?([a-zA-Z][a-zA-Z0-9-]{0,32})(?:\s[^<>]{0,256})?>/g;
+
+// R3 unescaped double quote counter (ignore \" escapes).
+const RE_UNESCAPED_DQUOTE = /(?<!\\)"/g;
+
+export type SanitizeMutation = {
+  field: string;
+  rule: "sentinel" | "html-tag" | "balance-quote" | "truncate";
+  beforeLen: number;
+  afterLen: number;
+  sample?: string;
+};
+
+export type SanitizeStringResult = {
+  value: string;
+  mutations: SanitizeMutation[];
+};
+
+export function sanitizeString(
+  input: string,
+  field: string,
+  cfg: ToolArgSanitizeConfig,
+): SanitizeStringResult {
+  const mutations: SanitizeMutation[] = [];
+  let current = input;
+
+  if (cfg.removeSentinel) {
+    const before = current;
+    const next = current.replace(RE_SENTINEL_DOUBLE, "").replace(RE_SENTINEL_SINGLE, "");
+    if (next !== before) {
+      mutations.push({
+        field,
+        rule: "sentinel",
+        beforeLen: before.length,
+        afterLen: next.length,
+        sample: before.slice(0, 64),
+      });
+      current = next;
+    }
+  }
+
+  if (cfg.removeHtmlTags) {
+    const before = current;
+    const allowlist = cfg.htmlAllowlist;
+    const next = before.replace(RE_HTML_TAG, (match, tagName: string) => {
+      if (allowlist.has(String(tagName).toLowerCase())) {
+        return match;
+      }
+      return "";
+    });
+    if (next !== before) {
+      mutations.push({
+        field,
+        rule: "html-tag",
+        beforeLen: before.length,
+        afterLen: next.length,
+        sample: before.slice(0, 64),
+      });
+      current = next;
+    }
+  }
+
+  if (cfg.balanceQuote) {
+    const before = current;
+    const matches = before.match(RE_UNESCAPED_DQUOTE);
+    const count = matches ? matches.length : 0;
+    if (count % 2 === 1) {
+      const next = `${before}"`;
+      mutations.push({
+        field,
+        rule: "balance-quote",
+        beforeLen: before.length,
+        afterLen: next.length,
+        sample: before.slice(-64),
+      });
+      current = next;
+    }
+  }
+
+  if (current.length > cfg.maxFieldLen) {
+    const before = current;
+    const next = current.slice(0, cfg.maxFieldLen);
+    mutations.push({
+      field,
+      rule: "truncate",
+      beforeLen: before.length,
+      afterLen: next.length,
+    });
+    current = next;
+  }
+
+  return { value: current, mutations };
+}
+
+export type SanitizeArgsResult = {
+  args: Record<string, unknown>;
+  mutations: SanitizeMutation[];
+  changed: boolean;
+};
+
+export function sanitizeToolArgs(
+  args: Record<string, unknown> | null | undefined,
+  toolName: string,
+  cfg: ToolArgSanitizeConfig = readEnvConfig(),
+): SanitizeArgsResult {
+  if (!args || typeof args !== "object" || Array.isArray(args)) {
+    return { args: {}, mutations: [], changed: false };
+  }
+  if (!cfg.enabled) {
+    return { args, mutations: [], changed: false };
+  }
+
+  const mutations: SanitizeMutation[] = [];
+  const result: Record<string, unknown> = {};
+  let changed = false;
+
+  for (const [key, value] of Object.entries(args)) {
+    if (typeof value !== "string") {
+      result[key] = value;
+      continue;
+    }
+    if (!DEFAULT_SANITIZED_FIELDS.includes(key as (typeof DEFAULT_SANITIZED_FIELDS)[number])) {
+      // Also sanitize any string field whose value looks contaminated.
+      const looksContaminated =
+        RE_SENTINEL_DOUBLE.test(value) || RE_SENTINEL_SINGLE.test(value) || RE_HTML_TAG.test(value);
+      // Reset global regex state after .test().
+      RE_SENTINEL_DOUBLE.lastIndex = 0;
+      RE_SENTINEL_SINGLE.lastIndex = 0;
+      RE_HTML_TAG.lastIndex = 0;
+      if (!looksContaminated) {
+        result[key] = value;
+        continue;
+      }
+    }
+    const sanitized = sanitizeString(value, key, cfg);
+    if (sanitized.mutations.length > 0) {
+      changed = true;
+      for (const m of sanitized.mutations) {
+        mutations.push(m);
+      }
+      log.warn(
+        `tool-arg-sanitize tool=${toolName} field=${key} rules=${sanitized.mutations.map((m) => m.rule).join(",")} before=${value.length} after=${sanitized.value.length}`,
+      );
+    }
+    result[key] = sanitized.value;
+  }
+
+  return { args: result, mutations, changed };
+}
+
+// ---------------------------------------------------------------------------
+// Stream wrapper - sanitize tool_call arguments in messages emitted by
+// the model stream, in place. Mirrors decodeXaiToolCallArgumentsInMessage.
+// ---------------------------------------------------------------------------
+
+export function sanitizeToolCallArgumentsInMessage(
+  message: unknown,
+  cfg: ToolArgSanitizeConfig = readEnvConfig(),
+): boolean {
+  if (!cfg.enabled) {
+    return false;
+  }
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return false;
+  }
+  let anyChanged = false;
+  for (const block of content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const typedBlock = block as { type?: unknown; arguments?: unknown; name?: unknown };
+    const t = typedBlock.type;
+    const isToolCall = t === "toolCall" || t === "toolUse" || t === "functionCall";
+    if (!isToolCall) {
+      continue;
+    }
+    const args = typedBlock.arguments;
+    if (!args || typeof args !== "object" || Array.isArray(args)) {
+      continue;
+    }
+    const toolName = typeof typedBlock.name === "string" ? typedBlock.name : "unknown";
+    const res = sanitizeToolArgs(args as Record<string, unknown>, toolName, cfg);
+    if (res.changed) {
+      typedBlock.arguments = res.args;
+      anyChanged = true;
+    }
+  }
+  return anyChanged;
+}
+
+export type StreamLike = {
+  result: () => Promise<unknown>;
+  [Symbol.asyncIterator]: () => AsyncIterator<unknown>;
+};
+
+export function wrapStreamSanitizeToolCallArguments<S extends StreamLike>(
+  stream: S,
+  cfg: ToolArgSanitizeConfig = readEnvConfig(),
+): S {
+  if (!cfg.enabled) {
+    return stream;
+  }
+  const originalResult = stream.result.bind(stream);
+  stream.result = async () => {
+    const message = await originalResult();
+    sanitizeToolCallArgumentsInMessage(message, cfg);
+    return message;
+  };
+  const originalAsyncIterator = (
+    stream as unknown as {
+      [Symbol.asyncIterator]: () => AsyncIterator<unknown>;
+    }
+  )[Symbol.asyncIterator].bind(stream);
+  (stream as unknown as { [Symbol.asyncIterator]: () => AsyncIterator<unknown> })[
+    Symbol.asyncIterator
+  ] = function () {
+    const iterator = originalAsyncIterator();
+    return {
+      async next() {
+        const result = await iterator.next();
+        if (!result.done && result.value && typeof result.value === "object") {
+          const event = result.value as { partial?: unknown; message?: unknown };
+          sanitizeToolCallArgumentsInMessage(event.partial, cfg);
+          sanitizeToolCallArgumentsInMessage(event.message, cfg);
+        }
+        return result;
+      },
+      async return(value?: unknown) {
+        return iterator.return?.(value) ?? { done: true as const, value: undefined };
+      },
+      async throw(error?: unknown) {
+        return iterator.throw?.(error) ?? { done: true as const, value: undefined };
+      },
+    };
+  };
+  return stream;
+}
+
+export type StreamFn = (...args: unknown[]) => unknown;
+
+export function wrapStreamFnSanitizeToolCallArguments(
+  baseFn: StreamFn,
+  cfg: ToolArgSanitizeConfig = readEnvConfig(),
+): StreamFn {
+  if (!cfg.enabled) {
+    return baseFn;
+  }
+  return (...args: unknown[]) => {
+    const maybeStream = baseFn(...args);
+    if (maybeStream && typeof maybeStream === "object" && "then" in maybeStream) {
+      return (maybeStream as Promise<StreamLike>).then((stream) =>
+        wrapStreamSanitizeToolCallArguments(stream, cfg),
+      );
+    }
+    return wrapStreamSanitizeToolCallArguments(maybeStream as StreamLike, cfg);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// False-negative guard: assistant promises "다시 시도" but does not retry
+// ---------------------------------------------------------------------------
+
+const RETRY_PROMISE_PATTERNS: ReadonlyArray<RegExp> = [
+  /다시\s*시도/i,
+  /재\s*시도/i,
+  /\bretry\b/i,
+  /\btry\s+again\b/i,
+  /again\s*\.\.\./i,
+];
+
+export function looksLikeRetryPromise(text: string): boolean {
+  if (!text || typeof text !== "string") {
+    return false;
+  }
+  for (const re of RETRY_PROMISE_PATTERNS) {
+    if (re.test(text)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export type FalseNegativeEvent =
+  | { kind: "toolFailed"; at: number; toolName: string; error: string }
+  | { kind: "assistantText"; at: number; text: string }
+  | { kind: "toolCall"; at: number; toolName: string };
+
+export type FalseNegativeDetection =
+  | { detected: false }
+  | {
+      detected: true;
+      failedToolName: string;
+      promiseAt: number;
+      windowMs: number;
+      action: "warn" | "none";
+    };
+
+export function detectFalseNegativePromise(
+  events: ReadonlyArray<FalseNegativeEvent>,
+  cfg: FalseNegativeGuardConfig = readFalseNegativeGuardConfig(),
+): FalseNegativeDetection {
+  if (!cfg.enabled) {
+    return { detected: false };
+  }
+  if (!events || events.length === 0) {
+    return { detected: false };
+  }
+
+  // Walk forward: find toolFailed → assistantText(retry promise) → toolCall?
+  for (let i = 0; i < events.length; i++) {
+    const ev = events[i];
+    if (ev.kind !== "toolFailed") {
+      continue;
+    }
+    const failedTool = ev.toolName;
+    // Find the next assistantText after this toolFailed event.
+    let promiseAt: number | null = null;
+    for (let j = i + 1; j < events.length; j++) {
+      const next = events[j];
+      if (next.kind === "assistantText") {
+        if (looksLikeRetryPromise(next.text)) {
+          promiseAt = next.at;
+        }
+        break;
+      }
+      if (next.kind === "toolCall") {
+        // A real retry preempts the promise check.
+        break;
+      }
+    }
+    if (promiseAt === null) {
+      continue;
+    }
+    // Check whether a toolCall follows within windowMs.
+    let retried = false;
+    for (let k = i + 1; k < events.length; k++) {
+      const next = events[k];
+      if (next.kind === "toolCall" && next.at - promiseAt <= cfg.windowMs) {
+        retried = true;
+        break;
+      }
+      if (next.at - promiseAt > cfg.windowMs) {
+        break;
+      }
+    }
+    if (!retried) {
+      const action: "warn" | "none" = cfg.mode === "warn" ? "warn" : "none";
+      if (action === "warn") {
+        log.warn(
+          `false-negative-promise detected failedTool=${failedTool} promiseAt=${promiseAt} windowMs=${cfg.windowMs} no retry within window`,
+        );
+      }
+      return {
+        detected: true,
+        failedToolName: failedTool,
+        promiseAt,
+        windowMs: cfg.windowMs,
+        action,
+      };
+    }
+  }
+  return { detected: false };
+}

--- a/src/agents/tool-arg-sanitize-guard.ts
+++ b/src/agents/tool-arg-sanitize-guard.ts
@@ -167,6 +167,14 @@ export function readFalseNegativeGuardConfig(
 // Bounded length 0..32 to avoid runaway regex backtracking on edge inputs.
 const RE_SENTINEL_DOUBLE = /<<\|[^|<>]{0,32}\|>/g;
 const RE_SENTINEL_SINGLE = /<\|[^|<>]{0,32}\|>/g;
+// R1.1 heredoc variant: P2.18 TD18-2 (2026-05-21 17:12) reproduced
+// "<<//code>" - model serializing "</code>" into args ended up adding an
+// extra "<" prefix, which bash then interprets as a here-doc delimiter
+// and reads stdin until EOF (corrupting the command). Catch any
+// "<<TOKEN>" or "<<TOKEN<TOKEN>" shape where the inner content does NOT
+// contain pipe (pipe is reserved for the explicit |...|> sentinel form
+// above to keep the rules orthogonal).
+const RE_SENTINEL_HEREDOC = /<<[^|>\s]{1,64}>/g;
 
 // R2 html-tag: matches "</tag>", "<tag>", "<tag attr=value ...>".
 // Inner attr region bounded to 256 chars and may not contain "<" or ">".
@@ -198,7 +206,10 @@ export function sanitizeString(
 
   if (cfg.removeSentinel) {
     const before = current;
-    const next = current.replace(RE_SENTINEL_DOUBLE, "").replace(RE_SENTINEL_SINGLE, "");
+    const next = current
+      .replace(RE_SENTINEL_DOUBLE, "")
+      .replace(RE_SENTINEL_SINGLE, "")
+      .replace(RE_SENTINEL_HEREDOC, "");
     if (next !== before) {
       mutations.push({
         field,
@@ -294,10 +305,14 @@ export function sanitizeToolArgs(
     if (!DEFAULT_SANITIZED_FIELDS.includes(key as (typeof DEFAULT_SANITIZED_FIELDS)[number])) {
       // Also sanitize any string field whose value looks contaminated.
       const looksContaminated =
-        RE_SENTINEL_DOUBLE.test(value) || RE_SENTINEL_SINGLE.test(value) || RE_HTML_TAG.test(value);
+        RE_SENTINEL_DOUBLE.test(value) ||
+        RE_SENTINEL_SINGLE.test(value) ||
+        RE_SENTINEL_HEREDOC.test(value) ||
+        RE_HTML_TAG.test(value);
       // Reset global regex state after .test().
       RE_SENTINEL_DOUBLE.lastIndex = 0;
       RE_SENTINEL_SINGLE.lastIndex = 0;
+      RE_SENTINEL_HEREDOC.lastIndex = 0;
       RE_HTML_TAG.lastIndex = 0;
       if (!looksContaminated) {
         result[key] = value;

--- a/src/agents/tool-arg-sanitize-guard.ts
+++ b/src/agents/tool-arg-sanitize-guard.ts
@@ -65,6 +65,9 @@ const ENV_FN_GUARD_WINDOW_MS = "OPENCLAW_FALSE_NEGATIVE_GUARD_WINDOW_MS";
 
 const DEFAULT_SANITIZED_FIELDS = [
   "command",
+  // P2.24b (2026-05-22): exec/bash 도구의 표준 변형 필드. command 외에도 cmd, script 누설 가능.
+  "cmd",
+  "script",
   "url",
   "prompt",
   "text",
@@ -85,6 +88,13 @@ const DEFAULT_SANITIZED_FIELDS = [
 // receive an extra "R4 path-quote-strip" rule and bypass R3 balance-quote
 // (which would corrupt a one-side-unbalanced path by appending a stray dquote).
 const PATH_SANITIZED_FIELDS = new Set<string>(["file_path", "path"]);
+
+// EXEC_CMD_SANITIZED_FIELDS (P2.24c, 2026-05-22): fields holding raw shell
+// command strings. They receive an extra R5b orphan-prefix strip pass that
+// is unsafe to apply globally (would touch markdown body / prose text), but
+// is safe and necessary here because shell command syntax never legitimately
+// contains a "<|" / "<<|" token.
+const EXEC_CMD_SANITIZED_FIELDS = new Set<string>(["command", "cmd", "script"]);
 
 const DEFAULT_MAX_FIELD_LEN = 65536;
 const DEFAULT_FN_WINDOW_MS = 10000;
@@ -207,6 +217,34 @@ const RE_SENTINEL_NESTED_SINGLE = /<\|[^|\s]{1,64}\|(?!>)/g;
 // contain pipe (pipe is reserved for the explicit |...|> sentinel form
 // above to keep the rules orthogonal).
 const RE_SENTINEL_HEREDOC = /<<[^|>\s]{1,64}>/g;
+// R1.x command-prefix sentinel (P6-2 2026-05-22): "<|find", "<|\find" etc.
+// "<|" immediately followed by a non-whitespace/non-pipe/non-> char.
+// Models emit this when the JSON serializer leaks a sentinel token before a
+// command word but without the closing "|>" terminator.
+const RE_SENTINEL_CMD_PREFIX = /<\|(?=[^\s|>])/g;
+
+// R1.x' double-variant cmd-prefix sentinel (P2.24c-fix, 2026-05-22): "<<|find",
+// "<<|\find" etc. Without this, RE_SENTINEL_CMD_PREFIX matches from index 1 of
+// "<<|find" (consuming "<|f" → leaving "<find"). The double variant matches the
+// leading "<<|" so the entire orphan prefix is stripped. Applied BEFORE the
+// single variant so it always wins on this pattern.
+const RE_SENTINEL_CMD_PREFIX_DOUBLE = /<<\|(?=[^\s|>])/g;
+
+// R5b (P2.24c, 2026-05-22): unconditional orphan-prefix strip. Catches cases
+// where the next byte after "<|" or "<<|" is a control character (e.g. \f from
+// "\\f" JSON-decoded), which RE_SENTINEL_CMD_PREFIX's `[^\s|>]` lookahead
+// rejects because `\s` includes \f/\v. Position-free, no lookahead.
+// Safe ordering: runs AFTER all paired/open sentinel regexes, so legitimate
+// `<|...|>` pairs are already consumed.
+const RE_SENTINEL_PIPE_ORPHAN_DOUBLE = /<<\|/g;
+const RE_SENTINEL_PIPE_ORPHAN_SINGLE = /<\|/g;
+
+// R5c (P2.24c, 2026-05-22): strip stray ASCII control bytes that Gemma4
+// occasionally leaks alongside sentinel tokens (form-feed \x0c, vertical-tab
+// \x0b, etc.). Preserves \t (\x09), \n (\x0a), \r (\x0d) which are
+// legitimate in multi-line script bodies.
+// eslint-disable-next-line no-control-regex
+const RE_CONTROL_CHARS_SAFE = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g;
 
 // R2 html-tag: matches "</tag>", "<tag>", "<tag attr=value ...>".
 // Inner attr region bounded to 256 chars and may not contain "<" or ">".
@@ -244,7 +282,13 @@ export function sanitizeString(
 
   if (cfg.removeSentinel) {
     const before = current;
-    const next = current
+    // R5c (P2.24c) FIRST: strip stray ASCII control bytes (form-feed \x0c,
+    // vertical-tab \x0b, etc.) BEFORE the sentinel regexes run, so the
+    // lookahead-based RE_SENTINEL_CMD_PREFIX can match patterns like
+    // "<|<form-feed>find ..." (which previously slipped through because \s
+    // includes \f/\v). Preserves \t / \n / \r.
+    let chain = current.replace(RE_CONTROL_CHARS_SAFE, "");
+    chain = chain
       .replace(RE_SENTINEL_DOUBLE, "")
       .replace(RE_SENTINEL_OPEN_DOUBLE, "")
       .replace(RE_SENTINEL_NESTED_DOUBLE, "")
@@ -252,6 +296,24 @@ export function sanitizeString(
       .replace(RE_SENTINEL_OPEN_SINGLE, "")
       .replace(RE_SENTINEL_NESTED_SINGLE, "")
       .replace(RE_SENTINEL_HEREDOC, "");
+    // CMD_PREFIX variants strip orphan "<|" / "<<|" before command words.
+    // Skipped on path fields so R4 path-quote-strip (below) handles them and
+    // attributes the mutation to "path-quote-strip" rule (P2.19b contract).
+    // DOUBLE applied first to ensure "<<|" matches as a unit (otherwise the
+    // SINGLE pattern matches from index 1, leaving a stray "<").
+    if (!options.isPath) {
+      chain = chain.replace(RE_SENTINEL_CMD_PREFIX_DOUBLE, "").replace(RE_SENTINEL_CMD_PREFIX, "");
+    }
+    // R5b (P2.24c): exec/cmd/script fields get an unconditional orphan-prefix
+    // strip pass as a last-resort net for any remaining "<|" / "<<|" tokens.
+    // Safe because shell command syntax never legitimately contains them.
+    // Also skipped on path fields (R4 handles).
+    if (EXEC_CMD_SANITIZED_FIELDS.has(field) && !options.isPath) {
+      chain = chain
+        .replace(RE_SENTINEL_PIPE_ORPHAN_DOUBLE, "")
+        .replace(RE_SENTINEL_PIPE_ORPHAN_SINGLE, "");
+    }
+    const next = chain;
     if (next !== before) {
       mutations.push({
         field,
@@ -403,6 +465,7 @@ export function sanitizeToolArgs(
       // Also sanitize any string field whose value looks contaminated.
       const looksContaminated =
         RE_SENTINEL_DOUBLE.test(value) ||
+        RE_SENTINEL_CMD_PREFIX.test(value) ||
         RE_SENTINEL_OPEN_DOUBLE.test(value) ||
         RE_SENTINEL_NESTED_DOUBLE.test(value) ||
         RE_SENTINEL_SINGLE.test(value) ||

--- a/src/agents/tool-arg-sanitize-guard.ts
+++ b/src/agents/tool-arg-sanitize-guard.ts
@@ -72,7 +72,19 @@ const DEFAULT_SANITIZED_FIELDS = [
   "content",
   "message",
   "query",
+  // P2.19b (2026-05-21 21:00 KST): path/file_path fields. Live failure case
+  // jsonl L34 - model auto-corrected to file_path: "\"notes/p219-retry.md\""
+  // (sentinel prefix stripped, but JSON-encoded quotes left a literal dquote
+  // file under workspace). Path-style fields get a dedicated quote/sentinel-
+  // prefix strip rule via PATH_SANITIZED_FIELDS + sanitizeString isPath opt.
+  "file_path",
+  "path",
 ] as const;
+
+// PATH_SANITIZED_FIELDS: subset of fields treated as filesystem paths. They
+// receive an extra "R4 path-quote-strip" rule and bypass R3 balance-quote
+// (which would corrupt a one-side-unbalanced path by appending a stray dquote).
+const PATH_SANITIZED_FIELDS = new Set<string>(["file_path", "path"]);
 
 const DEFAULT_MAX_FIELD_LEN = 65536;
 const DEFAULT_FN_WINDOW_MS = 10000;
@@ -205,7 +217,7 @@ const RE_UNESCAPED_DQUOTE = /(?<!\\)"/g;
 
 export type SanitizeMutation = {
   field: string;
-  rule: "sentinel" | "html-tag" | "balance-quote" | "truncate";
+  rule: "sentinel" | "html-tag" | "balance-quote" | "path-quote-strip" | "truncate";
   beforeLen: number;
   afterLen: number;
   sample?: string;
@@ -216,10 +228,16 @@ export type SanitizeStringResult = {
   mutations: SanitizeMutation[];
 };
 
+export type SanitizeStringOptions = {
+  /** When true, apply R4 path-quote-strip and bypass R3 balance-quote. */
+  isPath?: boolean;
+};
+
 export function sanitizeString(
   input: string,
   field: string,
   cfg: ToolArgSanitizeConfig,
+  options: SanitizeStringOptions = {},
 ): SanitizeStringResult {
   const mutations: SanitizeMutation[] = [];
   let current = input;
@@ -267,7 +285,62 @@ export function sanitizeString(
     }
   }
 
-  if (cfg.balanceQuote) {
+  // R4 path-quote-strip (P2.19b): for path-style fields only.
+  // Strips residual sentinel prefix variants ("<|", "<<|", leading "\\")
+  // and outer paired or one-side quotes/dquotes left by P2.18.x sanitize.
+  // Runs BEFORE R3 balance-quote so that a one-sided dquote at either end is
+  // removed rather than balanced (which would corrupt the path).
+  if (options.isPath) {
+    const before = current;
+    let next = before.trim();
+    // Sentinel prefix residue strip loop (defensive: P2.18.x normally catches
+    // closed sentinels; this handles open-end variants that escaped that pass).
+    let prefixGuard = 8;
+    while (prefixGuard-- > 0) {
+      if (next.startsWith("<<|")) {
+        next = next.slice(3).trimStart();
+        continue;
+      }
+      if (next.startsWith("<|")) {
+        next = next.slice(2).trimStart();
+        continue;
+      }
+      if (next.startsWith("\\")) {
+        next = next.slice(1).trimStart();
+        continue;
+      }
+      break;
+    }
+    // Paired outer quotes (same kind on both ends): strip in pairs.
+    let pairGuard = 4;
+    while (
+      pairGuard-- > 0 &&
+      next.length >= 2 &&
+      ((next.startsWith('"') && next.endsWith('"')) || (next.startsWith("'") && next.endsWith("'")))
+    ) {
+      next = next.slice(1, -1).trim();
+    }
+    // Unbalanced one-side leading/trailing quote.
+    if (next.startsWith('"') || next.startsWith("'")) {
+      next = next.slice(1).trim();
+    }
+    if (next.endsWith('"') || next.endsWith("'")) {
+      next = next.slice(0, -1).trim();
+    }
+    if (next !== before) {
+      mutations.push({
+        field,
+        rule: "path-quote-strip",
+        beforeLen: before.length,
+        afterLen: next.length,
+        sample: before.slice(0, 64),
+      });
+      current = next;
+    }
+  }
+
+  // R3 balance-quote: bypass when field is a path (R4 already normalized).
+  if (cfg.balanceQuote && !options.isPath) {
     const before = current;
     const matches = before.match(RE_UNESCAPED_DQUOTE);
     const count = matches ? matches.length : 0;
@@ -351,7 +424,8 @@ export function sanitizeToolArgs(
         continue;
       }
     }
-    const sanitized = sanitizeString(value, key, cfg);
+    const isPath = PATH_SANITIZED_FIELDS.has(key);
+    const sanitized = sanitizeString(value, key, cfg, { isPath });
     if (sanitized.mutations.length > 0) {
       changed = true;
       for (const m of sanitized.mutations) {

--- a/src/agents/tool-arg-sanitize-guard.ts
+++ b/src/agents/tool-arg-sanitize-guard.ts
@@ -408,6 +408,14 @@ export function sanitizeString(
     if (next.endsWith('"') || next.endsWith("'")) {
       next = next.slice(0, -1).trim();
     }
+    // R5e trailing-lt (P2.24e, 2026-05-23): strip trailing "<" from path fields.
+    // Live reproduction: edit args file_path ended in "visit_logs.md<" — the
+    // Gemma4 sampler leaked the opening "<" of a sentinel token at end-of-field
+    // without any following "|". R5d targets "<|" form; a bare "<" at end of a
+    // filesystem path is never legitimate (paths don't end in "<").
+    while (next.endsWith("<")) {
+      next = next.slice(0, -1).trimEnd();
+    }
     if (next !== before) {
       mutations.push({
         field,

--- a/src/agents/tool-arg-sanitize-guard.ts
+++ b/src/agents/tool-arg-sanitize-guard.ts
@@ -239,6 +239,18 @@ const RE_SENTINEL_CMD_PREFIX_DOUBLE = /<<\|(?=[^\s|>])/g;
 const RE_SENTINEL_PIPE_ORPHAN_DOUBLE = /<<\|/g;
 const RE_SENTINEL_PIPE_ORPHAN_SINGLE = /<\|/g;
 
+// R5d trailing-orphan (P2.24d, 2026-05-23): strip trailing "<|" / "<<|"
+// sequences (+ surrounding whitespace) at end-of-string. Reproduction case:
+// jsonl L98 — Gemma4 emitted write args.content ending in "\n<|" (sentinel
+// open token leaked at final emission, no closing "|>"). R1 sentinel regexes
+// require either a paired form or a non-empty suffix; trailing standalone
+// "<|" matches none of them. R5b would have caught it but is gated to
+// EXEC_CMD_SANITIZED_FIELDS only. Trailing-only is safer than global orphan
+// strip because legitimate prose mid-content "<|" (rare but possible in
+// markdown about tokens/syntax) is preserved. Applies to all sanitized
+// fields including markdown content.
+const RE_SENTINEL_TRAILING_ORPHAN = /(?:<<?\|+\s*)+$/;
+
 // R5c (P2.24c, 2026-05-22): strip stray ASCII control bytes that Gemma4
 // occasionally leaks alongside sentinel tokens (form-feed \x0c, vertical-tab
 // \x0b, etc.). Preserves \t (\x09), \n (\x0a), \r (\x0d) which are
@@ -312,6 +324,13 @@ export function sanitizeString(
       chain = chain
         .replace(RE_SENTINEL_PIPE_ORPHAN_DOUBLE, "")
         .replace(RE_SENTINEL_PIPE_ORPHAN_SINGLE, "");
+    }
+    // R5d trailing-orphan (P2.24d): unconditional trailing "<|" strip for
+    // all sanitized fields (including content/text/body/message). Safe
+    // because mid-content "<|" is preserved; only end-of-string is touched.
+    // Path fields skip (R4 path-quote-strip handles trailing prefix forms).
+    if (!options.isPath) {
+      chain = chain.replace(RE_SENTINEL_TRAILING_ORPHAN, "");
     }
     const next = chain;
     if (next !== before) {

--- a/src/agents/tool-loop-detection.gemma-interleaved.test.ts
+++ b/src/agents/tool-loop-detection.gemma-interleaved.test.ts
@@ -1,0 +1,250 @@
+// P2.15 follow-up: the 12:25 KST 2026-05-20 gemma session showed a runaway
+// where the same `exec({command: "bash scripts/memory.sh search 정유진"})` was
+// issued 6 times in a single response, but each pair was separated by a
+// variant call (a different exec command or a different tool entirely). The
+// P2.12 trailing-consecutive-run detector reset on every interleaved call and
+// never fired. These tests pin the windowed-occurrence shape so that pattern
+// blocks on the 5th identical call regardless of interleaving.
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ToolLoopDetectionConfig } from "../config/types.tools.js";
+import type { SessionState } from "../logging/diagnostic-session-state.js";
+import {
+  type LoopDetectionResult,
+  detectToolCallLoop,
+  recordToolCall,
+  recordToolCallOutcome,
+} from "./tool-loop-detection.js";
+
+function createState(): SessionState {
+  return {
+    lastActivity: Date.now(),
+    state: "processing",
+    queueDepth: 0,
+  };
+}
+
+const ENABLED: ToolLoopDetectionConfig = { enabled: true };
+
+const GEMMA_RUNAWAY_ARGS = { command: "bash scripts/memory.sh search 정유진" };
+const GEMMA_RUNAWAY_RESULT = {
+  content: [
+    {
+      type: "text",
+      text: "people/민주.md: → **본명: 정유진** — [정유진.md](정유진.md)",
+    },
+  ],
+  details: { status: "completed", exitCode: 0, aggregated: "people/민주.md…" },
+};
+
+// Variant calls observed in the real session between identical runaway calls.
+const VARIANT_CALLS: Array<{ tool: string; args: unknown; result: unknown }> = [
+  {
+    tool: "exec",
+    args: { command: "bash scripts/memory.sh on 2026-05-19" },
+    result: {
+      content: [{ type: "text", text: "RESULT: FAILED" }],
+      details: { exitCode: 1 },
+    },
+  },
+  {
+    tool: "exec",
+    args: { command: 'bash scripts/memory.sh search 정유진 | grep -A 20 "정유진.md' },
+    result: {
+      content: [
+        {
+          type: "text",
+          text: "/bin/bash: -c: line 1: unexpected EOF while looking for matching `\"'",
+        },
+      ],
+      details: { exitCode: 2 },
+    },
+  },
+  {
+    tool: "read",
+    args: { file_path: "<|<|" },
+    result: {
+      content: [
+        {
+          type: "text",
+          text: '{"status":"error","tool":"read","error":"Missing required parameter"}',
+        },
+      ],
+      details: { status: "error" },
+    },
+  },
+  {
+    tool: "exec",
+    args: {
+      command: 'bash scripts/memory.sh search 정유진 | grep "정유진.md" | head -n 1',
+    },
+    result: {
+      content: [
+        {
+          type: "text",
+          text: "people/민주.md: → **본명: 정유진** — [정유진.md](정유진.md)",
+        },
+      ],
+      details: { status: "completed", exitCode: 0 },
+    },
+  },
+];
+
+const GUARD_ENV_KEYS = [
+  "OPENCLAW_TOOL_LOOP_GUARD_DISABLED",
+  "OPENCLAW_TOOL_LOOP_GUARD_ENABLED",
+  "OPENCLAW_TOOL_LOOP_GUARD_WINDOW",
+] as const;
+
+describe("P2.15 generic_repeat block: gemma-style interleaved runaway", () => {
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    savedEnv = {};
+    for (const key of GUARD_ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of GUARD_ENV_KEYS) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedEnv[key];
+      }
+    }
+  });
+
+  it("blocks the 5th identical exec call even with variant calls interleaved between each repeat (real gemma jsonl pattern)", () => {
+    const state = createState();
+    // Sequence: A, X1, A, X2, A, X3, A, X4, A   (5 A's, 4 distinct variants)
+    const sequence: Array<{ tool: string; args: unknown; result?: unknown }> = [];
+    for (let i = 0; i < 4; i += 1) {
+      sequence.push({ tool: "exec", args: GEMMA_RUNAWAY_ARGS, result: GEMMA_RUNAWAY_RESULT });
+      const variant = VARIANT_CALLS[i];
+      if (variant) {
+        sequence.push(variant);
+      }
+    }
+    // The 5th A — detect should block this one BEFORE we record/execute it.
+    sequence.push({ tool: "exec", args: GEMMA_RUNAWAY_ARGS, result: GEMMA_RUNAWAY_RESULT });
+
+    const results: LoopDetectionResult[] = [];
+    sequence.forEach((call, i) => {
+      const detection = detectToolCallLoop(state, call.tool, call.args, ENABLED);
+      results.push(detection);
+      const toolCallId = `${call.tool}-${i}`;
+      recordToolCall(state, call.tool, call.args, toolCallId, ENABLED);
+      if (call.result !== undefined) {
+        recordToolCallOutcome(state, {
+          toolName: call.tool,
+          toolParams: call.args,
+          toolCallId,
+          result: call.result,
+          config: ENABLED,
+        });
+      }
+    });
+
+    // First 8 calls (4 A's + 4 variants) should not block.
+    expect(results.slice(0, 8).every((r) => !r.stuck)).toBe(true);
+    // 9th call (the 5th A) must block under generic_repeat.
+    const fifthA = results.at(-1);
+    expect(fifthA?.stuck).toBe(true);
+    if (fifthA?.stuck) {
+      expect(fifthA.level).toBe("critical");
+      expect(fifthA.detector).toBe("generic_repeat");
+      expect(fifthA.count).toBe(5);
+    }
+  });
+
+  it("blocks every subsequent identical attempt after the block fires (backstop for runaway models)", () => {
+    const state = createState();
+    // Pre-populate: 4 A's + 4 variants
+    for (let i = 0; i < 4; i += 1) {
+      detectToolCallLoop(state, "exec", GEMMA_RUNAWAY_ARGS, ENABLED);
+      recordToolCall(state, "exec", GEMMA_RUNAWAY_ARGS, `a-${i}`, ENABLED);
+      recordToolCallOutcome(state, {
+        toolName: "exec",
+        toolParams: GEMMA_RUNAWAY_ARGS,
+        toolCallId: `a-${i}`,
+        result: GEMMA_RUNAWAY_RESULT,
+        config: ENABLED,
+      });
+      const variant = VARIANT_CALLS[i];
+      if (variant) {
+        detectToolCallLoop(state, variant.tool, variant.args, ENABLED);
+        recordToolCall(state, variant.tool, variant.args, `v-${i}`, ENABLED);
+        recordToolCallOutcome(state, {
+          toolName: variant.tool,
+          toolParams: variant.args,
+          toolCallId: `v-${i}`,
+          result: variant.result,
+          config: ENABLED,
+        });
+      }
+    }
+    // Two more attempts at A — both must block.
+    const fifth = detectToolCallLoop(state, "exec", GEMMA_RUNAWAY_ARGS, ENABLED);
+    expect(fifth.stuck).toBe(true);
+    // Even if the model didn't get to execute it (no record), detection on a
+    // subsequent attempt with no further state change must still block.
+    const sixth = detectToolCallLoop(state, "exec", GEMMA_RUNAWAY_ARGS, ENABLED);
+    expect(sixth.stuck).toBe(true);
+  });
+
+  it("does not block when the same (tool, args) returns *different* results each time (model is making progress)", () => {
+    const state = createState();
+    // 5 identical exec calls but each returns a different resultHash.
+    for (let i = 0; i < 4; i += 1) {
+      const detection = detectToolCallLoop(state, "exec", GEMMA_RUNAWAY_ARGS, ENABLED);
+      expect(detection.stuck).toBe(false);
+      recordToolCall(state, "exec", GEMMA_RUNAWAY_ARGS, `p-${i}`, ENABLED);
+      recordToolCallOutcome(state, {
+        toolName: "exec",
+        toolParams: GEMMA_RUNAWAY_ARGS,
+        toolCallId: `p-${i}`,
+        result: {
+          content: [{ type: "text", text: `progress ${i}` }],
+          details: { status: "completed", exitCode: 0 },
+        },
+        config: ENABLED,
+      });
+    }
+    // The 5th attempt must NOT block — distinct resultHashes prove progress.
+    const fifth = detectToolCallLoop(state, "exec", GEMMA_RUNAWAY_ARGS, ENABLED);
+    expect(fifth.stuck).toBe(false);
+  });
+
+  it("env-only activation (no config) still blocks the gemma interleaved pattern", () => {
+    process.env.OPENCLAW_TOOL_LOOP_GUARD_ENABLED = "1";
+    const state = createState();
+    for (let i = 0; i < 4; i += 1) {
+      detectToolCallLoop(state, "exec", GEMMA_RUNAWAY_ARGS);
+      recordToolCall(state, "exec", GEMMA_RUNAWAY_ARGS, `a-${i}`);
+      recordToolCallOutcome(state, {
+        toolName: "exec",
+        toolParams: GEMMA_RUNAWAY_ARGS,
+        toolCallId: `a-${i}`,
+        result: GEMMA_RUNAWAY_RESULT,
+      });
+      const variant = VARIANT_CALLS[i];
+      if (variant) {
+        detectToolCallLoop(state, variant.tool, variant.args);
+        recordToolCall(state, variant.tool, variant.args, `v-${i}`);
+        recordToolCallOutcome(state, {
+          toolName: variant.tool,
+          toolParams: variant.args,
+          toolCallId: `v-${i}`,
+          result: variant.result,
+        });
+      }
+    }
+    const fifth = detectToolCallLoop(state, "exec", GEMMA_RUNAWAY_ARGS);
+    expect(fifth.stuck).toBe(true);
+    if (fifth.stuck) {
+      expect(fifth.detector).toBe("generic_repeat");
+    }
+  });
+});

--- a/src/agents/tool-loop-detection.loop-guard.test.ts
+++ b/src/agents/tool-loop-detection.loop-guard.test.ts
@@ -1,0 +1,189 @@
+// P2.12 tool-call loop guard (gemma-memory follow-up).
+// Verifies the generic_repeat blocking escalation + env knobs against the
+// real detectToolCallLoop / recordToolCall API, including the exact runaway
+// argument payloads observed in the 2026-05-19 22:38 KST gemma jsonl.
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ToolLoopDetectionConfig } from "../config/types.tools.js";
+import type { SessionState } from "../logging/diagnostic-session-state.js";
+import {
+  type LoopDetectionResult,
+  detectToolCallLoop,
+  recordToolCall,
+} from "./tool-loop-detection.js";
+
+function createState(): SessionState {
+  return {
+    lastActivity: Date.now(),
+    state: "processing",
+    queueDepth: 0,
+  };
+}
+
+const ENABLED: ToolLoopDetectionConfig = { enabled: true };
+
+/**
+ * Mirror the real before-tool-call flow: detect first (current call not yet
+ * recorded), then record the call. Returns each call's detection result.
+ */
+function simulateCalls(
+  state: SessionState,
+  calls: Array<{ tool: string; args: unknown }>,
+  config: ToolLoopDetectionConfig = ENABLED,
+): LoopDetectionResult[] {
+  const results: LoopDetectionResult[] = [];
+  calls.forEach((call, i) => {
+    const result = detectToolCallLoop(state, call.tool, call.args, config);
+    results.push(result);
+    recordToolCall(state, call.tool, call.args, `${call.tool}-${i}`, config);
+  });
+  return results;
+}
+
+function repeat(tool: string, args: unknown, n: number) {
+  return Array.from({ length: n }, () => ({ tool, args }));
+}
+
+// Exact runaway payloads from the gemma session jsonl
+// (e8d2bd03-3cee-48d5-b380-4bdc1dc92756, 2026-05-19).
+const HWANG_EXEC_ARGS = {
+  command: '<|<|"grep -r "황선아" claude-ref/ 2>/dev/null || echo "Not found',
+};
+const JOURNAL_EXEC_ARGS = { command: '<<|"|>ls -ls -l journal/2026-05-18*' };
+const READ_SENTINEL_ARGS = { file_path: '<|"|' };
+
+const GUARD_ENV_KEYS = [
+  "OPENCLAW_TOOL_LOOP_GUARD_DISABLED",
+  "OPENCLAW_TOOL_LOOP_GUARD_ENABLED",
+  "OPENCLAW_TOOL_LOOP_GUARD_WINDOW",
+] as const;
+
+describe("P2.12 tool-call loop guard", () => {
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    savedEnv = {};
+    for (const key of GUARD_ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of GUARD_ENV_KEYS) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedEnv[key];
+      }
+    }
+  });
+
+  it("case 1: distinct args never block", () => {
+    const state = createState();
+    const results = simulateCalls(
+      state,
+      ["a", "b", "c", "d", "e"].map((c) => ({ tool: "exec", args: { command: c } })),
+    );
+    expect(results.every((r) => !r.stuck)).toBe(true);
+  });
+
+  it("case 2: identical args block on the 5th call", () => {
+    const state = createState();
+    const results = simulateCalls(state, repeat("exec", { command: "a" }, 5));
+
+    expect(results.slice(0, 4).every((r) => !r.stuck)).toBe(true);
+    const fifth = results[4];
+    expect(fifth?.stuck).toBe(true);
+    if (fifth?.stuck) {
+      expect(fifth.level).toBe("critical");
+      expect(fifth.detector).toBe("generic_repeat");
+      expect(fifth.count).toBe(5);
+    }
+  });
+
+  it("case 3: 4 identical + 1 different — the different 5th call is not blocked", () => {
+    const state = createState();
+    const calls = [
+      ...repeat("exec", { command: "a" }, 4),
+      { tool: "exec", args: { command: "b" } },
+    ];
+    const results = simulateCalls(state, calls);
+    expect(results.every((r) => !r.stuck)).toBe(true);
+  });
+
+  it("case 4: 황선아 grep runaway args block on the 5th call", () => {
+    const state = createState();
+    const results = simulateCalls(state, repeat("exec", HWANG_EXEC_ARGS, 5));
+    expect(results.slice(0, 4).every((r) => !r.stuck)).toBe(true);
+    expect(results[4]?.stuck).toBe(true);
+    const fifth = results[4];
+    if (fifth?.stuck) {
+      expect(fifth.level).toBe("critical");
+    }
+  });
+
+  it("case 5: journal ls runaway args block on the 5th call", () => {
+    const state = createState();
+    const results = simulateCalls(state, repeat("exec", JOURNAL_EXEC_ARGS, 5));
+    expect(results[4]?.stuck).toBe(true);
+  });
+
+  it("case 6: read sentinel-only args block on the 5th call", () => {
+    const state = createState();
+    const results = simulateCalls(state, repeat("read", READ_SENTINEL_ARGS, 5));
+    expect(results.slice(0, 4).every((r) => !r.stuck)).toBe(true);
+    expect(results[4]?.stuck).toBe(true);
+  });
+
+  it("case 7: different tools with low counts are not blocked", () => {
+    const state = createState();
+    const calls = [
+      ...repeat("exec", { command: "a" }, 3),
+      ...repeat("read", { file_path: "a" }, 3),
+    ];
+    const results = simulateCalls(state, calls);
+    expect(results.every((r) => !r.stuck)).toBe(true);
+  });
+
+  it("case 8: OPENCLAW_TOOL_LOOP_GUARD_WINDOW=2 blocks on the 3rd call", () => {
+    process.env.OPENCLAW_TOOL_LOOP_GUARD_WINDOW = "2";
+    const state = createState();
+    const results = simulateCalls(state, repeat("exec", { command: "a" }, 3));
+    expect(results[0]?.stuck).toBe(false);
+    expect(results[1]?.stuck).toBe(false);
+    const third = results[2];
+    expect(third?.stuck).toBe(true);
+    if (third?.stuck) {
+      expect(third.count).toBe(3);
+    }
+  });
+
+  it("env: OPENCLAW_TOOL_LOOP_GUARD_DISABLED forces the guard off", () => {
+    process.env.OPENCLAW_TOOL_LOOP_GUARD_DISABLED = "true";
+    const state = createState();
+    const results = simulateCalls(state, repeat("exec", { command: "a" }, 10));
+    expect(results.every((r) => !r.stuck)).toBe(true);
+  });
+
+  it("env: OPENCLAW_TOOL_LOOP_GUARD_ENABLED activates without config", () => {
+    process.env.OPENCLAW_TOOL_LOOP_GUARD_ENABLED = "1";
+    const state = createState();
+    // No config passed at all -> default would be disabled; env turns it on.
+    const results: LoopDetectionResult[] = [];
+    repeat("exec", { command: "a" }, 5).forEach((call, i) => {
+      results.push(detectToolCallLoop(state, call.tool, call.args));
+      recordToolCall(state, call.tool, call.args, `exec-${i}`);
+    });
+    expect(results[4]?.stuck).toBe(true);
+  });
+
+  it("disabled config (default) never blocks even on heavy repetition", () => {
+    const state = createState();
+    const results: LoopDetectionResult[] = [];
+    repeat("exec", { command: "a" }, 12).forEach((call, i) => {
+      results.push(detectToolCallLoop(state, call.tool, call.args));
+      recordToolCall(state, call.tool, call.args, `exec-${i}`);
+    });
+    expect(results.every((r) => !r.stuck)).toBe(true);
+  });
+});

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -276,18 +276,20 @@ describe("tool-loop-detection", () => {
       expect(result.stuck).toBe(false);
     });
 
-    it("warns on generic repeated tool+args calls", () => {
+    it("warns on generic repeated tool+args calls below the block threshold", () => {
       const state = createState();
+      // P2.12: generic_repeat now hard-blocks by default. Raise the block
+      // threshold above the warning threshold so the warn tier is still
+      // exercised (the block tier is covered in the loop-guard test suite).
+      const warnOnlyConfig: ToolLoopDetectionConfig = {
+        enabled: true,
+        genericRepeatBlockThreshold: WARNING_THRESHOLD + 5,
+      };
       for (let i = 0; i < WARNING_THRESHOLD; i += 1) {
-        recordToolCall(state, "read", { path: "/same.txt" }, `warn-${i}`);
+        recordToolCall(state, "read", { path: "/same.txt" }, `warn-${i}`, warnOnlyConfig);
       }
 
-      const result = detectToolCallLoop(
-        state,
-        "read",
-        { path: "/same.txt" },
-        enabledLoopDetectionConfig,
-      );
+      const result = detectToolCallLoop(state, "read", { path: "/same.txt" }, warnOnlyConfig);
 
       expect(result.stuck).toBe(true);
       if (result.stuck) {
@@ -299,7 +301,10 @@ describe("tool-loop-detection", () => {
       }
     });
 
-    it("keeps generic loops warn-only below global breaker threshold", () => {
+    it("blocks generic repeated tool+args calls at the default block threshold (P2.12)", () => {
+      // P2.12 deliberately overturns the old "generic loops are warn-only"
+      // contract: a small local model spamming the same (tool, args) call must
+      // be blocked, not merely warned. Default block threshold is 5.
       const fixture = createReadNoProgressFixture();
       const loopResult = detectLoopAfterRepeatedCalls({
         toolName: fixture.toolName,
@@ -309,7 +314,9 @@ describe("tool-loop-detection", () => {
       });
       expect(loopResult.stuck).toBe(true);
       if (loopResult.stuck) {
-        expect(loopResult.level).toBe("warning");
+        expect(loopResult.level).toBe("critical");
+        expect(loopResult.detector).toBe("generic_repeat");
+        expect(loopResult.message).toContain("CRITICAL");
       }
     });
 

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -28,12 +28,31 @@ export const TOOL_CALL_HISTORY_SIZE = 30;
 export const WARNING_THRESHOLD = 10;
 export const CRITICAL_THRESHOLD = 20;
 export const GLOBAL_CIRCUIT_BREAKER_THRESHOLD = 30;
+
+// P2.12 tool-call loop guard (gemma-memory follow-up).
+// Small local models (e.g. gemma) re-issue the *same* (tool, args) call dozens of
+// times after every ENOENT/sanitize failure, burning tokens + latency (observed
+// up to 61 identical `read` calls in a single session). The pre-existing
+// generic_repeat detector only *warns* and never blocks, so add a low-threshold
+// blocking escalation: once the same (toolName, args) repeats this many times
+// (inclusive of the current attempt) the call is blocked with a synthetic
+// tool_result via the before-tool-call hook, letting the model respond with text.
+// "window" = number of prior identical calls tolerated; block fires on
+// (window + 1)-th. Default window 4 -> block on the 5th identical call.
+export const DEFAULT_GENERIC_REPEAT_BLOCK_WINDOW = 4;
+
+// Env knobs so operators can tune/disable without editing config files.
+const ENV_GUARD_DISABLED = "OPENCLAW_TOOL_LOOP_GUARD_DISABLED";
+const ENV_GUARD_ENABLED = "OPENCLAW_TOOL_LOOP_GUARD_ENABLED";
+const ENV_GUARD_WINDOW = "OPENCLAW_TOOL_LOOP_GUARD_WINDOW";
+
 const DEFAULT_LOOP_DETECTION_CONFIG = {
   enabled: false,
   historySize: TOOL_CALL_HISTORY_SIZE,
   warningThreshold: WARNING_THRESHOLD,
   criticalThreshold: CRITICAL_THRESHOLD,
   globalCircuitBreakerThreshold: GLOBAL_CIRCUIT_BREAKER_THRESHOLD,
+  genericRepeatBlockThreshold: DEFAULT_GENERIC_REPEAT_BLOCK_WINDOW + 1,
   detectors: {
     genericRepeat: true,
     knownPollNoProgress: true,
@@ -47,6 +66,11 @@ type ResolvedLoopDetectionConfig = {
   warningThreshold: number;
   criticalThreshold: number;
   globalCircuitBreakerThreshold: number;
+  /**
+   * Total identical (toolName, args) call count — including the current
+   * attempt — at which generic_repeat escalates from warn to a hard block.
+   */
+  genericRepeatBlockThreshold: number;
   detectors: {
     genericRepeat: boolean;
     knownPollNoProgress: boolean;
@@ -59,6 +83,35 @@ function asPositiveInt(value: number | undefined, fallback: number): number {
     return fallback;
   }
   return value;
+}
+
+/** Parse a boolean-ish env var; undefined when unset/unparseable. */
+function envFlag(name: string): boolean | undefined {
+  const raw = process.env[name];
+  if (raw === undefined) {
+    return undefined;
+  }
+  const v = raw.trim().toLowerCase();
+  if (v === "1" || v === "true" || v === "yes" || v === "on") {
+    return true;
+  }
+  if (v === "" || v === "0" || v === "false" || v === "no" || v === "off") {
+    return false;
+  }
+  return undefined;
+}
+
+/** Parse a positive-int env var; undefined when unset/invalid. */
+function envPositiveInt(name: string): number | undefined {
+  const raw = process.env[name];
+  if (raw === undefined) {
+    return undefined;
+  }
+  const n = Number.parseInt(raw.trim(), 10);
+  if (!Number.isInteger(n) || n <= 0) {
+    return undefined;
+  }
+  return n;
 }
 
 function resolveLoopDetectionConfig(config?: ToolLoopDetectionConfig): ResolvedLoopDetectionConfig {
@@ -82,12 +135,40 @@ function resolveLoopDetectionConfig(config?: ToolLoopDetectionConfig): ResolvedL
     globalCircuitBreakerThreshold = criticalThreshold + 1;
   }
 
+  // enabled precedence: DISABLED env kill-switch > ENABLED env > config > default.
+  let enabled = config?.enabled ?? DEFAULT_LOOP_DETECTION_CONFIG.enabled;
+  const envEnabled = envFlag(ENV_GUARD_ENABLED);
+  if (envEnabled !== undefined) {
+    enabled = envEnabled;
+  }
+  if (envFlag(ENV_GUARD_DISABLED) === true) {
+    enabled = false;
+  }
+
+  // genericRepeatBlockThreshold precedence: WINDOW env (+1) > config > default.
+  // Keep the warn->block ordering sane and never above the global breaker.
+  const envWindow = envPositiveInt(ENV_GUARD_WINDOW);
+  let genericRepeatBlockThreshold =
+    envWindow !== undefined
+      ? envWindow + 1
+      : asPositiveInt(
+          config?.genericRepeatBlockThreshold,
+          DEFAULT_LOOP_DETECTION_CONFIG.genericRepeatBlockThreshold,
+        );
+  if (genericRepeatBlockThreshold < 2) {
+    genericRepeatBlockThreshold = 2;
+  }
+  if (genericRepeatBlockThreshold > globalCircuitBreakerThreshold) {
+    genericRepeatBlockThreshold = globalCircuitBreakerThreshold;
+  }
+
   return {
-    enabled: config?.enabled ?? DEFAULT_LOOP_DETECTION_CONFIG.enabled,
+    enabled,
     historySize: asPositiveInt(config?.historySize, DEFAULT_LOOP_DETECTION_CONFIG.historySize),
     warningThreshold,
     criticalThreshold,
     globalCircuitBreakerThreshold,
+    genericRepeatBlockThreshold,
     detectors: {
       genericRepeat:
         config?.detectors?.genericRepeat ?? DEFAULT_LOOP_DETECTION_CONFIG.detectors.genericRepeat,
@@ -366,6 +447,29 @@ function canonicalPairKey(signatureA: string, signatureB: string): string {
 }
 
 /**
+ * Count the trailing run of identical (toolName, argsHash) calls at the end of
+ * history. Any interleaved different toolName/args resets the run, so this is
+ * a true consecutive streak (not a windowed occurrence count). Used by the
+ * P2.12 generic-repeat hard block so that legitimate alternating patterns
+ * (handled by the ping-pong detector) are never preempted.
+ */
+function getConsecutiveIdenticalStreak(
+  history: ReadonlyArray<{ toolName: string; argsHash: string }>,
+  toolName: string,
+  argsHash: string,
+): number {
+  let streak = 0;
+  for (let i = history.length - 1; i >= 0; i -= 1) {
+    const record = history[i];
+    if (!record || record.toolName !== toolName || record.argsHash !== argsHash) {
+      break;
+    }
+    streak += 1;
+  }
+  return streak;
+}
+
+/**
  * Detect if an agent is stuck in a repetitive tool call loop.
  * Checks if the same tool+params combination has been called excessively.
  */
@@ -470,10 +574,40 @@ export function detectToolCallLoop(
     };
   }
 
-  // Generic detector: warn-only for repeated identical calls.
+  // Generic detector for repeated identical (toolName, args) calls.
+  // `recentCount` counts prior identical calls anywhere in the history window;
+  // the current attempt is not yet recorded (recordToolCall runs after detect).
   const recentCount = history.filter(
     (h) => h.toolName === toolName && h.argsHash === currentHash,
   ).length;
+
+  // P2.12: hard-block consecutive runaways. Count the trailing run of identical
+  // calls (any interleaved different tool/args resets it) and, once the same
+  // call has repeated genericRepeatBlockThreshold times in a row (default 5),
+  // block it with a critical result so the before-tool-call hook injects a
+  // synthetic blocked tool_result instead of executing. Every subsequent
+  // identical attempt keeps getting blocked (the model can never re-run it),
+  // which is the catastrophic-loop backstop. Using a consecutive streak (not a
+  // windowed count) keeps legitimate alternating patterns for the ping-pong
+  // detector, which is evaluated earlier.
+  const consecutiveIdentical = getConsecutiveIdenticalStreak(history, toolName, currentHash) + 1;
+  if (
+    !knownPollTool &&
+    resolvedConfig.detectors.genericRepeat &&
+    consecutiveIdentical >= resolvedConfig.genericRepeatBlockThreshold
+  ) {
+    log.error(
+      `Blocking ${toolName}: called ${consecutiveIdentical} times in a row with identical arguments (generic repeat block)`,
+    );
+    return {
+      stuck: true,
+      level: "critical",
+      detector: "generic_repeat",
+      count: consecutiveIdentical,
+      message: `CRITICAL: ${toolName} has been called ${consecutiveIdentical} times in a row with identical arguments and the previous attempts all returned the same result. Session execution blocked to prevent a runaway loop. Do not retry this exact call — try a different approach or report the result honestly to the user.`,
+      warningKey: `generic:${toolName}:${currentHash}`,
+    };
+  }
 
   if (
     !knownPollTool &&

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -29,16 +29,20 @@ export const WARNING_THRESHOLD = 10;
 export const CRITICAL_THRESHOLD = 20;
 export const GLOBAL_CIRCUIT_BREAKER_THRESHOLD = 30;
 
-// P2.12 tool-call loop guard (gemma-memory follow-up).
+// P2.12 / P2.15 tool-call loop guard (gemma-memory follow-up).
 // Small local models (e.g. gemma) re-issue the *same* (tool, args) call dozens of
 // times after every ENOENT/sanitize failure, burning tokens + latency (observed
 // up to 61 identical `read` calls in a single session). The pre-existing
 // generic_repeat detector only *warns* and never blocks, so add a low-threshold
-// blocking escalation: once the same (toolName, args) repeats this many times
-// (inclusive of the current attempt) the call is blocked with a synthetic
-// tool_result via the before-tool-call hook, letting the model respond with text.
-// "window" = number of prior identical calls tolerated; block fires on
-// (window + 1)-th. Default window 4 -> block on the 5th identical call.
+// blocking escalation: once the same (toolName, args) appears this many times
+// in the recent history window (inclusive of the current attempt) the call is
+// blocked with a synthetic tool_result via the before-tool-call hook, letting
+// the model respond with text. "window" = number of prior identical calls
+// tolerated; block fires on (window + 1)-th. Default window 4 -> block on the
+// 5th identical call. P2.15: occurrence count is windowed across the recent
+// history (not a strict trailing run), so interleaved variant calls between
+// the identical attempts (the real gemma runaway pattern) still trigger the
+// block.
 export const DEFAULT_GENERIC_REPEAT_BLOCK_WINDOW = 4;
 
 // Env knobs so operators can tune/disable without editing config files.
@@ -447,29 +451,6 @@ function canonicalPairKey(signatureA: string, signatureB: string): string {
 }
 
 /**
- * Count the trailing run of identical (toolName, argsHash) calls at the end of
- * history. Any interleaved different toolName/args resets the run, so this is
- * a true consecutive streak (not a windowed occurrence count). Used by the
- * P2.12 generic-repeat hard block so that legitimate alternating patterns
- * (handled by the ping-pong detector) are never preempted.
- */
-function getConsecutiveIdenticalStreak(
-  history: ReadonlyArray<{ toolName: string; argsHash: string }>,
-  toolName: string,
-  argsHash: string,
-): number {
-  let streak = 0;
-  for (let i = history.length - 1; i >= 0; i -= 1) {
-    const record = history[i];
-    if (!record || record.toolName !== toolName || record.argsHash !== argsHash) {
-      break;
-    }
-    streak += 1;
-  }
-  return streak;
-}
-
-/**
  * Detect if an agent is stuck in a repetitive tool call loop.
  * Checks if the same tool+params combination has been called excessively.
  */
@@ -580,33 +561,72 @@ export function detectToolCallLoop(
   const recentCount = history.filter(
     (h) => h.toolName === toolName && h.argsHash === currentHash,
   ).length;
+  const totalIdenticalIncludingCurrent = recentCount + 1;
 
-  // P2.12: hard-block consecutive runaways. Count the trailing run of identical
-  // calls (any interleaved different tool/args resets it) and, once the same
-  // call has repeated genericRepeatBlockThreshold times in a row (default 5),
-  // block it with a critical result so the before-tool-call hook injects a
-  // synthetic blocked tool_result instead of executing. Every subsequent
-  // identical attempt keeps getting blocked (the model can never re-run it),
-  // which is the catastrophic-loop backstop. Using a consecutive streak (not a
-  // windowed count) keeps legitimate alternating patterns for the ping-pong
-  // detector, which is evaluated earlier.
-  const consecutiveIdentical = getConsecutiveIdenticalStreak(history, toolName, currentHash) + 1;
+  // P2.15: hard-block runaways using a windowed-occurrence count instead of a
+  // trailing-consecutive-run count. Real local-model runaways (e.g. the 12:25
+  // KST 2026-05-20 gemma session) interleave variant attempts between identical
+  // calls — `read({file_path:"<|<|"})`, `exec({command:"<garbage>"})`, etc. —
+  // which the prior trailing-run detector treated as a reset to 1, never
+  // firing. Counting occurrences across the historySize window (default 30)
+  // catches "same (tool, args) repeated 5+ times in the recent window" even
+  // when variant calls are interleaved.
+  //
+  // Two gates keep us from over-blocking legitimate patterns:
+  //   1. Progress gate: a model re-calling the same (tool, args) and getting
+  //      *different* results each time is exploring, not stuck. Skip the block
+  //      when matching prior calls produced >1 distinct resultHash. Matches
+  //      with no resultHash yet (outcome not recorded) count as "no progress
+  //      evidence" so test fixtures that exercise the detector via
+  //      detect+record without outcomes still trip the guard.
+  //   2. Ping-pong defer gate: if the trailing window that contains the
+  //      matched calls is a strict 2-argsHash alternation (e.g. A,B,A,B,A),
+  //      defer to the dedicated ping-pong detector instead of pre-empting it
+  //      at this lower threshold. The gemma pattern interleaves the matched
+  //      call with *varying* argsHashes, so its trailing window has >2
+  //      distinct hashes and is NOT deferred.
   if (
     !knownPollTool &&
     resolvedConfig.detectors.genericRepeat &&
-    consecutiveIdentical >= resolvedConfig.genericRepeatBlockThreshold
+    totalIdenticalIncludingCurrent >= resolvedConfig.genericRepeatBlockThreshold
   ) {
-    log.error(
-      `Blocking ${toolName}: called ${consecutiveIdentical} times in a row with identical arguments (generic repeat block)`,
-    );
-    return {
-      stuck: true,
-      level: "critical",
-      detector: "generic_repeat",
-      count: consecutiveIdentical,
-      message: `CRITICAL: ${toolName} has been called ${consecutiveIdentical} times in a row with identical arguments and the previous attempts all returned the same result. Session execution blocked to prevent a runaway loop. Do not retry this exact call — try a different approach or report the result honestly to the user.`,
-      warningKey: `generic:${toolName}:${currentHash}`,
-    };
+    const distinctMatchingResultHashes = new Set<string>();
+    for (const record of history) {
+      if (
+        record.toolName === toolName &&
+        record.argsHash === currentHash &&
+        typeof record.resultHash === "string" &&
+        record.resultHash.length > 0
+      ) {
+        distinctMatchingResultHashes.add(record.resultHash);
+      }
+    }
+    // Strict ping-pong window: the smallest tail that could fit `recentCount`
+    // matches in a strict alternation is `2*recentCount - 1` entries.
+    const alternationWindow = Math.max(0, 2 * recentCount - 1);
+    const windowSize = Math.min(history.length, alternationWindow);
+    const trailingArgsHashes = new Set<string>();
+    trailingArgsHashes.add(currentHash);
+    for (let i = history.length - windowSize; i < history.length; i += 1) {
+      const record = history[i];
+      if (record) {
+        trailingArgsHashes.add(record.argsHash);
+      }
+    }
+    const isStrictPingPongShape = trailingArgsHashes.size === 2;
+    if (distinctMatchingResultHashes.size <= 1 && !isStrictPingPongShape) {
+      log.error(
+        `Blocking ${toolName}: called ${totalIdenticalIncludingCurrent} times with identical arguments in recent history (generic repeat block)`,
+      );
+      return {
+        stuck: true,
+        level: "critical",
+        detector: "generic_repeat",
+        count: totalIdenticalIncludingCurrent,
+        message: `CRITICAL: ${toolName} has been called ${totalIdenticalIncludingCurrent} times with identical arguments in the recent tool-call window. Session execution blocked to prevent a runaway loop. Do not retry this exact call — try a different approach or report the result honestly to the user.`,
+        warningKey: `generic:${toolName}:${currentHash}`,
+      };
+    }
   }
 
   if (

--- a/src/agents/tools/sanitize-command.test.ts
+++ b/src/agents/tools/sanitize-command.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeCommandInput } from "./sanitize-command.js";
+
+describe("sanitizeCommandInput", () => {
+  // 정상 명령 — no-op 검증 (5건)
+  it("leaves a clean command untouched", () => {
+    expect(sanitizeCommandInput("cat memory/people/이서현.md")).toBe("cat memory/people/이서현.md");
+  });
+
+  it("preserves bash pipe |", () => {
+    expect(sanitizeCommandInput("ls memory | grep 황선아")).toBe("ls memory | grep 황선아");
+  });
+
+  it("preserves complex shell with redirect", () => {
+    const cmd = `find memory -name "*.md" -exec grep -l "황선아" {} \\; 2>/dev/null | head -5`;
+    expect(sanitizeCommandInput(cmd)).toBe(cmd);
+  });
+
+  it("preserves quoted strings with special chars", () => {
+    expect(sanitizeCommandInput(`echo "hello | world"`)).toBe(`echo "hello | world"`);
+  });
+
+  it("preserves empty input", () => {
+    expect(sanitizeCommandInput("")).toBe("");
+  });
+
+  // 토큰 누설 — 핵심 차단 (6건)
+  it('strips leading <|<|" pattern (observed Gemma4 leak)', () => {
+    expect(sanitizeCommandInput('<|<|"grep -r "황선아" claude-ref/ 2>/dev/null | head -n 20')).toBe(
+      'grep -r "황선아" claude-ref/ 2>/dev/null | head -n 20',
+    );
+  });
+
+  it('strips <|"| prefix (observed Gemma4 leak)', () => {
+    expect(sanitizeCommandInput('<|"|gcal add --title "상반기 비타민 캠프"')).toBe(
+      'gcal add --title "상반기 비타민 캠프"',
+    );
+  });
+
+  it("strips <|im_start|> wrapper", () => {
+    expect(sanitizeCommandInput("<|im_start|>echo hello<|im_end|>")).toBe("echo hello");
+  });
+
+  it("strips <|...|> with arbitrary content", () => {
+    expect(sanitizeCommandInput("<|whatever|>ls -la")).toBe("ls -la");
+  });
+
+  it("strips multiple leaked tokens in mid-command", () => {
+    expect(sanitizeCommandInput("cat <|foo|>memory/people<|bar|>/이서현.md")).toBe(
+      "cat memory/people/이서현.md",
+    );
+  });
+
+  it("strips trailing |> remnant", () => {
+    expect(sanitizeCommandInput("ls memory/people |>")).toBe("ls memory/people");
+  });
+
+  // edge case (3건)
+  it("returns original if sanitize produces empty", () => {
+    expect(sanitizeCommandInput('<|"|')).toBe('<|"|');
+  });
+
+  it("handles non-string gracefully", () => {
+    expect(sanitizeCommandInput(undefined as unknown as string)).toBe(undefined);
+    expect(sanitizeCommandInput(null as unknown as string)).toBe(null);
+  });
+
+  it("preserves Korean text and emoji", () => {
+    expect(sanitizeCommandInput('echo "안녕 🌙 황선아"')).toBe('echo "안녕 🌙 황선아"');
+  });
+});

--- a/src/agents/tools/sanitize-command.test.ts
+++ b/src/agents/tools/sanitize-command.test.ts
@@ -56,8 +56,10 @@ describe("sanitizeCommandInput", () => {
   });
 
   // edge case (3건)
-  it("returns original if sanitize produces empty", () => {
-    expect(sanitizeCommandInput('<|"|')).toBe('<|"|');
+  it('returns "" for sentinel-only residue (rule 5 강화, 2026-05-19)', () => {
+    // 룰5 강화 전엔 추적 위해 원본을 반환했으나, sentinel-only 잔재는
+    // bash syntax error 만 유발하므로 이제 빈 문자열을 반환한다.
+    expect(sanitizeCommandInput('<|"|')).toBe("");
   });
 
   it("handles non-string gracefully", () => {
@@ -100,5 +102,31 @@ describe("sanitizeCommandInput", () => {
 
   it("preserves html-like <x> text (false-positive guard)", () => {
     expect(sanitizeCommandInput("<x>")).toBe("<x>");
+  });
+});
+
+describe("sentinel residue handling (5/19 황선아 환각 회귀)", () => {
+  it('empty for sentinel-only residue: <<|"|>', () => {
+    expect(sanitizeCommandInput('<<|"|>')).toBe("");
+  });
+  it("empty for double-lt residue: <<", () => {
+    expect(sanitizeCommandInput("<<")).toBe("");
+  });
+  it("empty for sentinel-only mix: <|>", () => {
+    expect(sanitizeCommandInput("<|>")).toBe("");
+  });
+  // jsonl 격리본 실측 exec command 값 (cc1646c8…hallucinated, 2026-05-19 17:02).
+  // 이 잔재가 bash 로 흘러가 syntax error → 모델이 황선아 환각 답변 생성.
+  it('empty for observed jsonl exec residue: <|<|"|', () => {
+    expect(sanitizeCommandInput('<|<|"|')).toBe("");
+  });
+  it("preserves single < (could be valid redirect target)", () => {
+    expect(sanitizeCommandInput("<")).toBe("<");
+  });
+  it("preserves bash heredoc with EOF marker", () => {
+    expect(sanitizeCommandInput("cat <<EOF\nhello\nEOF")).toBe("cat <<EOF\nhello\nEOF");
+  });
+  it("preserves bash input redirect", () => {
+    expect(sanitizeCommandInput("cat <file.txt")).toBe("cat <file.txt");
   });
 });

--- a/src/agents/tools/sanitize-command.test.ts
+++ b/src/agents/tools/sanitize-command.test.ts
@@ -68,4 +68,37 @@ describe("sanitizeCommandInput", () => {
   it("preserves Korean text and emoji", () => {
     expect(sanitizeCommandInput('echo "안녕 🌙 황선아"')).toBe('echo "안녕 🌙 황선아"');
   });
+
+  // 더블 less-than 변형 — 2026-05-17 11:13 재발 (8건)
+  it('strips leading <<|"| variant (double less-than, no closing |>)', () => {
+    expect(sanitizeCommandInput('<<|"|x')).toBe("x");
+  });
+
+  it("strips leading <<| with no closing", () => {
+    expect(sanitizeCommandInput("<<|x")).toBe("x");
+  });
+
+  it("strips a leading double less-than run", () => {
+    expect(sanitizeCommandInput("<<x")).toBe("x");
+  });
+
+  it("strips a leading triple less-than run", () => {
+    expect(sanitizeCommandInput("<<<x")).toBe("x");
+  });
+
+  it('strips mid-command <<|"| variant', () => {
+    expect(sanitizeCommandInput('x<<|"|y')).toBe("xy");
+  });
+
+  it("preserves a lone leading unmatched quote (false-positive guard)", () => {
+    expect(sanitizeCommandInput('"unmatched')).toBe('"unmatched');
+  });
+
+  it('strips trailing <<|"| remnant', () => {
+    expect(sanitizeCommandInput('x<<|"|')).toBe("x");
+  });
+
+  it("preserves html-like <x> text (false-positive guard)", () => {
+    expect(sanitizeCommandInput("<x>")).toBe("<x>");
+  });
 });

--- a/src/agents/tools/sanitize-command.test.ts
+++ b/src/agents/tools/sanitize-command.test.ts
@@ -130,3 +130,78 @@ describe("sentinel residue handling (5/19 황선아 환각 회귀)", () => {
     expect(sanitizeCommandInput("cat <file.txt")).toBe("cat <file.txt");
   });
 });
+
+// P2.11 — args-start sentinel variants observed in the 2026-05-19 22:38 KST
+// hallucination-test jsonl (gemma session e8d2bd03). Each name cites the
+// jsonl line + UTC timestamp the leaked argument was emitted. 471fc7133e
+// sanitize left these as broken bash (`ls -|ls -l`, leading-orphan `<ls ...`).
+describe("P2.11 args-start sentinel variants (jsonl e8d2bd03, 2026-05-19)", () => {
+  it('L252 13:38:10 jsonl: <<|"<<|<|"ls -|<|"ls -l journal/ ... → valid bash', () => {
+    expect(
+      sanitizeCommandInput('<<|"<<|<|"ls -|<|"ls -l journal/ 2>/dev/null | grep 2026-05-18'),
+    ).toBe("ls -ls -l journal/ 2>/dev/null | grep 2026-05-18");
+  });
+
+  it('L254 13:38:11 jsonl: <<|"|>ls -ls -l journal/ | grep ... (leading-orphan <)', () => {
+    expect(sanitizeCommandInput('<<|"|>ls -ls -l journal/ | grep 2026-05-18')).toBe(
+      "ls -ls -l journal/ | grep 2026-05-18",
+    );
+  });
+
+  it('L256 13:38:12 jsonl x7: <<|"|>ls -ls -l journal/2026-05-18*', () => {
+    expect(sanitizeCommandInput('<<|"|>ls -ls -l journal/2026-05-18*')).toBe(
+      "ls -ls -l journal/2026-05-18*",
+    );
+  });
+
+  it('L258 13:38:13 jsonl: <<|"|>ls ... grep "2026-05-18 (trailing model quote kept)', () => {
+    expect(sanitizeCommandInput('<<|"|>ls -ls -l journal/ | grep "2026-05-18')).toBe(
+      'ls -ls -l journal/ | grep "2026-05-18',
+    );
+  });
+
+  it('L116 12:18:32 jsonl: <|<|"|>ls -lls -lt journal/ | head -n 5', () => {
+    expect(sanitizeCommandInput('<|<|"|>ls -lls -lt journal/ | head -n 5')).toBe(
+      "ls -lls -lt journal/ | head -n 5",
+    );
+  });
+
+  it('L14 11:22:08 jsonl x43: <|<|"grep ... || echo "Not found (|| OR preserved)', () => {
+    expect(
+      sanitizeCommandInput('<|<|"grep -r "황선아" claude-ref/ 2>/dev/null || echo "Not found'),
+    ).toBe('grep -r "황선아" claude-ref/ 2>/dev/null || echo "Not found');
+  });
+
+  it('L118 12:18:33 jsonl x61: read file_path <|"| → "" (sentinel-only)', () => {
+    expect(sanitizeCommandInput('<|"|')).toBe("");
+  });
+
+  it('L6 11:22:04 jsonl: read file_path <|<| → "" (sentinel-only)', () => {
+    expect(sanitizeCommandInput("<|<|")).toBe("");
+  });
+
+  // 정상 입력 회귀 안전망 — sanitize 강화가 정당한 bash 를 깨면 안 됨.
+  it("guard: heredoc cat <<EOF is untouched", () => {
+    expect(sanitizeCommandInput("cat <<EOF\nhello\nEOF")).toBe("cat <<EOF\nhello\nEOF");
+  });
+
+  it("guard: quoted heredoc cat << 'EOF' is untouched", () => {
+    expect(sanitizeCommandInput("cat << 'EOF'\nfoo\nEOF")).toBe("cat << 'EOF'\nfoo\nEOF");
+  });
+
+  it("guard: pipe ls -la | grep foo is untouched", () => {
+    expect(sanitizeCommandInput("ls -la | grep foo")).toBe("ls -la | grep foo");
+  });
+
+  it("guard: redirect echo hello > /tmp/x is untouched", () => {
+    expect(sanitizeCommandInput("echo hello > /tmp/x")).toBe("echo hello > /tmp/x");
+  });
+
+  it("guard: unmatched quote is not truncated", () => {
+    expect(sanitizeCommandInput('echo "unclosed quote')).toBe('echo "unclosed quote');
+  });
+
+  it("guard: bash OR || is not stripped", () => {
+    expect(sanitizeCommandInput("grep x f || echo none")).toBe("grep x f || echo none");
+  });
+});

--- a/src/agents/tools/sanitize-command.test.ts
+++ b/src/agents/tools/sanitize-command.test.ts
@@ -205,3 +205,31 @@ describe("P2.11 args-start sentinel variants (jsonl e8d2bd03, 2026-05-19)", () =
     expect(sanitizeCommandInput("grep x f || echo none")).toBe("grep x f || echo none");
   });
 });
+
+// P2.16 — 2026-05-20 12:25 KST 라이브 검증(session e8d2bd03)에서 jsonl 에
+// 누설된 새 prefix-only 변형. PM2 로그 + jsonl tool result(L9 `2026-05-19`)
+// 로 P2.11 가 이미 모두 잡고 있음을 확인했으나, 향후 P2.11 정규식이 깨질
+// 경우 즉시 발견되도록 변형별 명시적 회귀 가드를 잠가둔다.
+describe("P2.16 prefix-only sentinel variants (jsonl e8d2bd03, 2026-05-20 12:25 KST)", () => {
+  // jsonl L8 03:25:29 UTC: exec 도구 raw args
+  //   {command: '<|<|"date -d "yesterday" +%Y-%m-%d'}
+  // tool result L9 = "2026-05-19" → sanitize 가 prefix 를 떼어 정상 실행됨.
+  it('L8 03:25:29 UTC: exec <|<|"date -d "yesterday" +%Y-%m-%d → clean date cmd', () => {
+    expect(sanitizeCommandInput('<|<|"date -d "yesterday" +%Y-%m-%d')).toBe(
+      'date -d "yesterday" +%Y-%m-%d',
+    );
+  });
+
+  // 5글자 prefix-only sentinel (`<|<|"` — P2.11 가 다루던 `<|<|` 4글자 변형의
+  // 따옴표 trailing 형태). bash 로 흘러가면 syntax error 만 유발.
+  it('L8 prefix-only variant: <|<|" (5-char, with trailing quote) → ""', () => {
+    expect(sanitizeCommandInput('<|<|"')).toBe("");
+  });
+
+  // 정상 입력 회귀 안전망 — `date -d ...` 가 P2.16 강화에도 무변형 통과.
+  it("guard: date -d 'yesterday' +%Y-%m-%d (valid bash) is untouched", () => {
+    expect(sanitizeCommandInput("date -d 'yesterday' +%Y-%m-%d")).toBe(
+      "date -d 'yesterday' +%Y-%m-%d",
+    );
+  });
+});

--- a/src/agents/tools/sanitize-command.ts
+++ b/src/agents/tools/sanitize-command.ts
@@ -46,8 +46,24 @@ export function sanitizeCommandInput(raw: string): string {
   s = s.replace(/<\|"?\|?/g, ""); // <|" | <|" | <|
   s = s.replace(/\|>/g, ""); // |>
 
-  // 5) 결과가 비었거나 공백만 남으면 원본 반환 (오류 메시지 추적 가능하게)
+  // 5) 결과 검증
   const trimmed = s.trim();
+
+  // (5a) 원본 자체가 sentinel(`<`,`>`,`|`,`"`,공백)만으로 구성된 경우:
+  //      - 길이 1 (단독 `<`, `>`, `|`, `"`) → 정당한 redirect/pipe 단편일 수 있어 보존
+  //      - 길이 2+ (`<<`, `<|>`, `<<|"|>` 등) → 명령으로 의미 없고 bash syntax
+  //        error 만 유발하므로 "" 반환. 빈 문자열이면 bash 가 no-op 으로 처리되어
+  //        모델이 환각 답변을 만들지 않는다 (incident 2026-05-19 황선아 환각).
+  //      raw 기준으로 판정하는 이유: `<<|"|>` 는 룰 1~4 처리 후 `<` 잔재만 남아
+  //      단독 `<` 입력과 sanitize 결과가 같아진다. 둘을 구분하려면 원본을 본다.
+  //      정당한 bash 입력 (`cat <file`, `echo "x"`, `a | b`) 은 영문/숫자가
+  //      있어 이 정규식에 매칭되지 않으므로 영향 없음.
+  const rawTrimmed = raw.trim();
+  if (/^[<>|"\s]+$/.test(rawTrimmed)) {
+    return rawTrimmed.length === 1 ? rawTrimmed : "";
+  }
+
+  // (5b) 실내용이 있는 명령: sanitize 결과 사용. 비었으면 원본 반환(오류 추적용)
   if (trimmed.length === 0) {
     return raw;
   }

--- a/src/agents/tools/sanitize-command.ts
+++ b/src/agents/tools/sanitize-command.ts
@@ -1,0 +1,41 @@
+/**
+ * Sanitize a shell command before execution.
+ *
+ * Strips LLM special tokens (e.g. `<|...|>`, `<|<|"`, `<\|"|`) that some smaller models
+ * (Gemma 4, etc.) occasionally leak into tool call arguments. These tokens cause
+ * bash to fail with syntax errors, which in turn forces the model to hallucinate
+ * answers it could not retrieve.
+ *
+ * No-op for clean commands. Safe to apply unconditionally.
+ *
+ * Mirrors the approach in `sanitize-url.ts` (commit 7cbc14d38).
+ */
+export function sanitizeCommandInput(raw: string): string {
+  if (typeof raw !== "string") {
+    return raw;
+  }
+  if (raw.length === 0) {
+    return raw;
+  }
+
+  let s = raw;
+
+  // 1) `<|...|>` 형태 special token 전체 제거 (greedy 아님 — 가장 짧게 매칭)
+  //    Llama family: <|im_start|>, <|im_end|>, <|eot_id|>, ...
+  //    Gemma 변형: <|...|>, <|<|...|>, ...
+  s = s.replace(/<\|[^|>]*\|>/g, "");
+
+  // 2) 토큰 잔재 / 누설 패턴 제거
+  //    관찰: `<|"|`, `<|<|"`, `<|<|`, `|>`, `<|`
+  //    명령 시작·중간 어디든 가능. 단 `|` 단독은 파이프이므로 절대 건드리지 않음.
+  s = s.replace(/<\|"?\|?/g, ""); // <|" | <|" | <|
+  s = s.replace(/\|>/g, ""); // |>
+
+  // 3) 결과가 비었거나 공백만 남으면 원본 반환 (오류 메시지 추적 가능하게)
+  const trimmed = s.trim();
+  if (trimmed.length === 0) {
+    return raw;
+  }
+
+  return trimmed;
+}

--- a/src/agents/tools/sanitize-command.ts
+++ b/src/agents/tools/sanitize-command.ts
@@ -1,10 +1,11 @@
 /**
  * Sanitize a shell command before execution.
  *
- * Strips LLM special tokens (e.g. `<|...|>`, `<|<|"`, `<\|"|`) that some smaller models
- * (Gemma 4, etc.) occasionally leak into tool call arguments. These tokens cause
- * bash to fail with syntax errors, which in turn forces the model to hallucinate
- * answers it could not retrieve.
+ * Strips LLM special tokens (e.g. `<|...|>`, `<|<|"`, `<\|"|`, and the
+ * double-less-than variants `<<|"|`, `<<|`, `<<`, `<<<`) that some smaller
+ * models (Gemma 4, etc.) occasionally leak into tool call arguments. These
+ * tokens cause bash to fail with syntax errors, which in turn forces the model
+ * to hallucinate answers it could not retrieve.
  *
  * No-op for clean commands. Safe to apply unconditionally.
  *
@@ -25,13 +26,27 @@ export function sanitizeCommandInput(raw: string): string {
   //    Gemma 변형: <|...|>, <|<|...|>, ...
   s = s.replace(/<\|[^|>]*\|>/g, "");
 
-  // 2) 토큰 잔재 / 누설 패턴 제거
+  // 2) 시작부 sentinel run 제거.
+  //    명령 시작에 붙는 `<`, `|`, `"` 연속 run 을 본다.
+  //    token-like 일 때만 제거 (run 길이 >= 2 AND `<` 포함) →
+  //    단독 `<file` 입력 redirect 나 단독 선행 따옴표(`"unmatched`)는 보존하면서
+  //    `<|"|`, `<|<|"`, `<<|"|`, `<<`, `<<<` 등 누설 패턴만 제거.
+  const lead = s.match(/^[<|"]+/);
+  if (lead && lead[0].length >= 2 && lead[0].includes("<")) {
+    s = s.slice(lead[0].length);
+  }
+
+  // 3) 중간 더블 less-than 변형 `<<|...|` (Gemma 2026-05-17 11:13 재발 관찰).
+  //    `<<` 직후 `|` 가 와야 매칭 → heredoc(`cat <<EOF`)은 건드리지 않음.
+  s = s.replace(/<<+\|[^|]*\|?/g, "");
+
+  // 4) 토큰 잔재 / 누설 패턴 제거
   //    관찰: `<|"|`, `<|<|"`, `<|<|`, `|>`, `<|`
   //    명령 시작·중간 어디든 가능. 단 `|` 단독은 파이프이므로 절대 건드리지 않음.
   s = s.replace(/<\|"?\|?/g, ""); // <|" | <|" | <|
   s = s.replace(/\|>/g, ""); // |>
 
-  // 3) 결과가 비었거나 공백만 남으면 원본 반환 (오류 메시지 추적 가능하게)
+  // 5) 결과가 비었거나 공백만 남으면 원본 반환 (오류 메시지 추적 가능하게)
   const trimmed = s.trim();
   if (trimmed.length === 0) {
     return raw;

--- a/src/agents/tools/sanitize-command.ts
+++ b/src/agents/tools/sanitize-command.ts
@@ -1,11 +1,13 @@
 /**
  * Sanitize a shell command before execution.
  *
- * Strips LLM special tokens (e.g. `<|...|>`, `<|<|"`, `<\|"|`, and the
- * double-less-than variants `<<|"|`, `<<|`, `<<`, `<<<`) that some smaller
- * models (Gemma 4, etc.) occasionally leak into tool call arguments. These
- * tokens cause bash to fail with syntax errors, which in turn forces the model
- * to hallucinate answers it could not retrieve.
+ * Strips LLM special tokens (e.g. `<|...|>`, `<|<|"`, `<\|"|`, the
+ * double-less-than variants `<<|"|`, `<<|`, `<<`, `<<<`, and the args-start
+ * variants `<<|"|>cmd`, `<<|"<<|<|"cmd -|<|"cmd ...` observed 2026-05-19
+ * 13:38) that some smaller models (Gemma 4, etc.) occasionally leak into
+ * tool call arguments. These tokens cause bash to fail with syntax errors,
+ * which in turn forces the model to hallucinate answers it could not
+ * retrieve.
  *
  * No-op for clean commands. Safe to apply unconditionally.
  *
@@ -40,11 +42,34 @@ export function sanitizeCommandInput(raw: string): string {
   //    `<<` 직후 `|` 가 와야 매칭 → heredoc(`cat <<EOF`)은 건드리지 않음.
   s = s.replace(/<<+\|[^|]*\|?/g, "");
 
+  // 3b) 중간 sentinel 클러스터 제거 (2026-05-19 13:38 jsonl L252 변형).
+  //    누설이 명령 중간에 끼어 `ls -|<|"ls -l ...` 처럼 진짜 텍스트 조각과
+  //    엉키는 경우, 단계 4a 는 `<|"` 만 떼어내 선행 `|` 가 남아
+  //    `ls -|ls -l`(깨진 파이프)이 된다. `[<>|"]` 가 2자 이상 연속이고
+  //    `|` 와 `<` 를 모두 포함하는 run(=누설 시그니처) 은 통째로 제거한다.
+  //    순수 `||`(bash OR), `<<`(heredoc), `>>`(append), `"|"`(따옴표 안
+  //    파이프 문자) 는 `<` 또는 `|` 조건에 걸리지 않아 보존된다.
+  s = s.replace(/[<>|"]{2,}/g, (m) => (m.includes("|") && m.includes("<") ? "" : m));
+
   // 4) 토큰 잔재 / 누설 패턴 제거
   //    관찰: `<|"|`, `<|<|"`, `<|<|`, `|>`, `<|`
   //    명령 시작·중간 어디든 가능. 단 `|` 단독은 파이프이므로 절대 건드리지 않음.
   s = s.replace(/<\|"?\|?/g, ""); // <|" | <|" | <|
   s = s.replace(/\|>/g, ""); // |>
+
+  // 4d) raw-anchored 선행 잔재 제거 (2026-05-19 13:38 jsonl L254/256/258).
+  //    원본이 2자 이상 sentinel 클러스터(>= `<` 또는 `|` 포함, `>` 도 인식)
+  //    로 시작한 경우, 단계 1 의 `<|...|>` 제거가 클러스터 안쪽만 떼어내
+  //    선행에 고아 `<`/`|` 1자가 남을 수 있다(`<<|"|>` → 단계1 후 `<`).
+  //    단계 2 는 길이 >= 2 조건 때문에 이 1자 고아를 못 잡는다. 원본 기준
+  //    으로 누설 시작이 확정된 경우에만 남은 선행 sentinel run 을 제거 →
+  //    `<ls -ls -l ...`(잘못된 입력 redirect) 를 `ls -ls -l ...` 로 복원.
+  //    단독 선행 `"`(unmatched quote)·`<x>`·단일 `<` 는 raw 선행 run 이
+  //    1자라 발동하지 않으므로 보존된다.
+  const rawLead = raw.match(/^[<>|"]+/);
+  if (rawLead && rawLead[0].length >= 2 && /[<|]/.test(rawLead[0])) {
+    s = s.replace(/^[<>|"]+/, "");
+  }
 
   // 5) 결과 검증
   const trimmed = s.trim();

--- a/src/agents/tools/sanitize-tool-args.test.ts
+++ b/src/agents/tools/sanitize-tool-args.test.ts
@@ -1,0 +1,93 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { logWarn } from "../../logger.js";
+import { normalizeToolParams } from "../pi-tools.params.js";
+import { sanitizeFileToolParams, sanitizeToolArg } from "./sanitize-tool-args.js";
+
+vi.mock("../../logger.js", () => ({
+  logWarn: vi.fn(),
+  logInfo: vi.fn(),
+}));
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const agentsDir = path.resolve(here, "..");
+
+describe("sanitizeToolArg / sanitizeFileToolParams", () => {
+  afterEach(() => {
+    vi.mocked(logWarn).mockClear();
+  });
+
+  // 1) read.file_path 에 sentinel → sanitize
+  it("sanitizes a sentinel-leaked read file_path", () => {
+    const out = sanitizeFileToolParams({ path: '<<|"|/tmp/notes.md' }, "read");
+    expect(out.path).toBe("/tmp/notes.md");
+  });
+
+  // 2) write.file_path 에 sentinel → sanitize (and content is left untouched)
+  it("sanitizes write path but never mutates content", () => {
+    const out = sanitizeFileToolParams(
+      { path: '<<|"|out.txt', content: "literal <<| and <|x|> stay" },
+      "write",
+    );
+    expect(out.path).toBe("out.txt");
+    expect(out.content).toBe("literal <<| and <|x|> stay");
+  });
+
+  // 3) raw file_path key (pre-normalization) is also covered
+  it("sanitizes the file_path key directly", () => {
+    const out = sanitizeFileToolParams({ file_path: '<|<|"docs/readme.md' }, "edit");
+    expect(out.file_path).toBe("docs/readme.md");
+  });
+
+  // 4) clean args → no-op (returns same reference)
+  it("is a no-op for clean params", () => {
+    const input = { path: "memory/people/이서현.md", content: "hello" };
+    const out = sanitizeFileToolParams(input, "read");
+    expect(out).toBe(input);
+  });
+
+  // 5) 비-string args → no-op
+  it("leaves non-string path values unchanged", () => {
+    const input = { path: 123 as unknown as string };
+    expect(sanitizeToolArg(input.path, "read", "path")).toBe(input.path);
+    const out = sanitizeFileToolParams(input, "read");
+    expect(out).toBe(input);
+  });
+
+  // 6) 이벤트 emit 검증
+  it("emits a tool.sanitize_special_tokens warning when it strips a token", () => {
+    sanitizeToolArg('<<|"|/tmp/x', "read", "path");
+    expect(logWarn).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(logWarn).mock.calls[0]?.[0]).toMatch(
+      /^tool\.sanitize_special_tokens tool=read arg=path original_len=\d+ sanitized_len=\d+$/,
+    );
+  });
+
+  it("does not emit a warning for clean input", () => {
+    sanitizeToolArg("/tmp/clean.md", "read", "path");
+    expect(logWarn).not.toHaveBeenCalled();
+  });
+
+  // 7) normalizeToolParams chokepoint pipes the sanitized path through
+  //    (this is the single entry point read/write/edit all call).
+  it("normalizeToolParams renames file_path then strips the sentinel", () => {
+    const normalized = normalizeToolParams({ file_path: '<<|"|/tmp/report.md' });
+    expect(normalized).toEqual({ path: "/tmp/report.md" });
+  });
+
+  // 8) entry-point check: the file tools route through normalizeToolParams,
+  //    and normalizeToolParams routes through sanitizeFileToolParams.
+  it("all core file tools route through the sanitize chokepoint", () => {
+    const paramsSrc = readFileSync(path.join(agentsDir, "pi-tools.params.ts"), "utf-8");
+    expect(paramsSrc).toContain('from "./tools/sanitize-tool-args.js"');
+    expect(paramsSrc).toContain("return sanitizeFileToolParams(normalized);");
+
+    const readSrc = readFileSync(path.join(agentsDir, "pi-tools.read.ts"), "utf-8");
+    // read tool entry point
+    expect(readSrc).toMatch(/createOpenClawReadTool[\s\S]*normalizeToolParams\(params\)/);
+    // write/edit entry point
+    expect(paramsSrc).toMatch(/wrapToolParamNormalization[\s\S]*normalizeToolParams\(params\)/);
+  });
+});

--- a/src/agents/tools/sanitize-tool-args.test.ts
+++ b/src/agents/tools/sanitize-tool-args.test.ts
@@ -4,7 +4,13 @@ import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { logWarn } from "../../logger.js";
 import { normalizeToolParams } from "../pi-tools.params.js";
-import { sanitizeFileToolParams, sanitizeToolArg } from "./sanitize-tool-args.js";
+import type { AnyAgentTool } from "../pi-tools.types.js";
+import {
+  sanitizeFileToolParams,
+  sanitizeSearchToolParams,
+  sanitizeToolArg,
+  wrapSearchToolArgSanitization,
+} from "./sanitize-tool-args.js";
 
 vi.mock("../../logger.js", () => ({
   logWarn: vi.fn(),
@@ -23,6 +29,14 @@ describe("sanitizeToolArg / sanitizeFileToolParams", () => {
   it("sanitizes a sentinel-leaked read file_path", () => {
     const out = sanitizeFileToolParams({ path: '<<|"|/tmp/notes.md' }, "read");
     expect(out.path).toBe("/tmp/notes.md");
+  });
+
+  // 1b) jsonl 격리본 실측 read path 값 (cc1646c8…hallucinated, 2026-05-19).
+  //     path 전체가 sentinel-only → "" 로 비워져 assertRequiredParams 가
+  //     명시적 retry 를 유도 (ENOENT 후 모델 환각보다 안전).
+  it("empties a sentinel-only read path (observed jsonl <|<|)", () => {
+    const out = sanitizeFileToolParams({ path: "<|<|" }, "read");
+    expect(out.path).toBe("");
   });
 
   // 2) write.file_path 에 sentinel → sanitize (and content is left untouched)
@@ -89,5 +103,83 @@ describe("sanitizeToolArg / sanitizeFileToolParams", () => {
     expect(readSrc).toMatch(/createOpenClawReadTool[\s\S]*normalizeToolParams\(params\)/);
     // write/edit entry point
     expect(paramsSrc).toMatch(/wrapToolParamNormalization[\s\S]*normalizeToolParams\(params\)/);
+  });
+});
+
+describe("sanitizeSearchToolParams / wrapSearchToolArgSanitization (find/grep/ls)", () => {
+  afterEach(() => {
+    vi.mocked(logWarn).mockClear();
+  });
+
+  // 1) path / pattern / glob 모두 sentinel strip
+  it("sanitizes path, pattern and glob on a search params record", () => {
+    const out = sanitizeSearchToolParams(
+      { pattern: '<|<|"황선아', path: '<<|"|claude-ref/', glob: '<|"|*.md' },
+      "grep",
+    );
+    expect(out.pattern).toBe("황선아");
+    expect(out.path).toBe("claude-ref/");
+    expect(out.glob).toBe("*.md");
+  });
+
+  // 2) clean args → no-op (same reference, content-style keys untouched)
+  it("is a no-op for clean search params", () => {
+    const input = { pattern: "황선아", path: "memory/", glob: "*.md" };
+    expect(sanitizeSearchToolParams(input, "find")).toBe(input);
+  });
+
+  // 3) 비-string args → no-op
+  it("leaves non-string search args unchanged", () => {
+    const input = { pattern: 42 as unknown as string };
+    expect(sanitizeSearchToolParams(input, "find")).toBe(input);
+  });
+
+  // 4) wrap helper strips leaked tokens before the tool runs
+  it("wrapSearchToolArgSanitization strips leaked tokens before execute", async () => {
+    let received: Record<string, unknown> | undefined;
+    const tool = {
+      name: "grep",
+      description: "",
+      parameters: {},
+      execute: async (_id: string, params: Record<string, unknown>) => {
+        received = params;
+        return { content: [] };
+      },
+    } as unknown as AnyAgentTool;
+    const wrapped = wrapSearchToolArgSanitization(tool);
+    await wrapped.execute(
+      "call-1",
+      { pattern: '<|<|"황선아', path: "claude-ref/" },
+      undefined,
+      undefined,
+    );
+    expect(received).toEqual({ pattern: "황선아", path: "claude-ref/" });
+  });
+
+  // 5) non-object params pass through untouched
+  it("wrapSearchToolArgSanitization passes non-object params untouched", async () => {
+    let received: unknown = "unset";
+    const tool = {
+      name: "ls",
+      description: "",
+      parameters: {},
+      execute: async (_id: string, params: unknown) => {
+        received = params;
+        return { content: [] };
+      },
+    } as unknown as AnyAgentTool;
+    const wrapped = wrapSearchToolArgSanitization(tool);
+    await wrapped.execute("call-2", undefined, undefined, undefined);
+    expect(received).toBe(undefined);
+  });
+
+  // 6) entry-point check: find/grep/ls route through the search sanitize wrapper
+  it("find/grep/ls route through wrapSearchToolArgSanitization", () => {
+    const piToolsSrc = readFileSync(path.join(agentsDir, "pi-tools.ts"), "utf-8");
+    expect(piToolsSrc).toContain('from "./tools/sanitize-tool-args.js"');
+    expect(piToolsSrc).toMatch(
+      /tool\.name === "find" \|\| tool\.name === "grep" \|\| tool\.name === "ls"/,
+    );
+    expect(piToolsSrc).toContain("wrapSearchToolArgSanitization(tool)");
   });
 });

--- a/src/agents/tools/sanitize-tool-args.test.ts
+++ b/src/agents/tools/sanitize-tool-args.test.ts
@@ -222,3 +222,43 @@ describe("P2.11 args-start sentinel variants (jsonl e8d2bd03, 2026-05-19)", () =
     expect(sanitizeSearchToolParams(input, "grep")).toBe(input);
   });
 });
+
+// P2.16 — 2026-05-20 12:25 KST 라이브 검증(session e8d2bd03)에서 jsonl 에
+// 누설된 새 read tool file_path 변형. PM2 로그 timestamp 12:25:28/12:25:36 의
+// `tool.sanitize_special_tokens tool=file arg=path original_len=4 sanitized_len=0`
+// 으로 sanitize 가 이미 동작 중임을 확인했으나, 향후 회귀 시 즉시 발견되도록
+// 변형별 명시적 회귀 가드를 추가한다.
+describe("P2.16 prefix-only sentinel variants (jsonl e8d2bd03, 2026-05-20 12:25 KST)", () => {
+  afterEach(() => {
+    vi.mocked(logWarn).mockClear();
+  });
+
+  // 5글자 prefix-only sentinel (`<|<|"` — P2.11 의 4글자 `<|<|` 변형에 trailing
+  // 따옴표가 붙은 형태). file_path 전체가 sentinel 잔재이므로 빈 string 으로
+  // 정리되어 read tool 의 "Missing required parameter" 정상 거절을 유도해야 함.
+  it('prefix+quote sentinel-only: read {file_path: "<|<|\\""} → ""', () => {
+    const out = sanitizeFileToolParams({ file_path: '<|<|"' }, "read");
+    expect(out.file_path).toBe("");
+  });
+
+  // prefix + 정상 path: prefix 만 떼어내고 path 본문은 보존되어야 함.
+  it('prefix+quote+path: read {file_path: "<|<|\\"/home/..."} → clean path', () => {
+    const out = sanitizeFileToolParams(
+      {
+        file_path: '<|<|"/home/lisyoen/.openclaw/agents/gemma/workspace/memory/2026-05-02.md',
+      },
+      "read",
+    );
+    expect(out.file_path).toBe(
+      "/home/lisyoen/.openclaw/agents/gemma/workspace/memory/2026-05-02.md",
+    );
+  });
+
+  // 정상 입력 회귀 안전망 — 깨끗한 절대 경로는 무변형 + 동일 참조 반환.
+  it("guard: clean absolute path is a no-op (same reference)", () => {
+    const input = {
+      file_path: "/home/lisyoen/.openclaw/agents/gemma/workspace/memory/2026-05-02.md",
+    };
+    expect(sanitizeFileToolParams(input, "read")).toBe(input);
+  });
+});

--- a/src/agents/tools/sanitize-tool-args.test.ts
+++ b/src/agents/tools/sanitize-tool-args.test.ts
@@ -183,3 +183,42 @@ describe("sanitizeSearchToolParams / wrapSearchToolArgSanitization (find/grep/ls
     expect(piToolsSrc).toContain("wrapSearchToolArgSanitization(tool)");
   });
 });
+
+// P2.11 — args-start sentinel variants from the 2026-05-19 22:38 KST
+// hallucination-test jsonl (gemma session e8d2bd03), exercised through the
+// file/search param chokepoints to confirm the strengthened sanitize-command
+// propagates to read/grep/ls args, not just bash exec.
+describe("P2.11 args-start sentinel variants (jsonl e8d2bd03, 2026-05-19)", () => {
+  afterEach(() => {
+    vi.mocked(logWarn).mockClear();
+  });
+
+  it('L118 12:18:33 jsonl x61: read file_path "<|\\"|" → "" (sentinel-only)', () => {
+    const out = sanitizeFileToolParams({ file_path: '<|"|' }, "read");
+    expect(out.file_path).toBe("");
+  });
+
+  it('L6 11:22:04 jsonl: read file_path "<|<|" → "" (sentinel-only)', () => {
+    const out = sanitizeFileToolParams({ file_path: "<|<|" }, "read");
+    expect(out.file_path).toBe("");
+  });
+
+  it('L254 13:38:11 jsonl: grep leading-orphan <<|"|> path/pattern stripped', () => {
+    const out = sanitizeSearchToolParams(
+      { pattern: '<|<|"황선아', path: '<<|"|>claude-ref/' },
+      "grep",
+    );
+    expect(out.pattern).toBe("황선아");
+    expect(out.path).toBe("claude-ref/");
+  });
+
+  it('L256 13:38:12 jsonl: ls path leading-orphan <<|"|>journal/ stripped', () => {
+    const out = sanitizeSearchToolParams({ path: '<<|"|>journal/2026-05-18' }, "ls");
+    expect(out.path).toBe("journal/2026-05-18");
+  });
+
+  it("guard: clean search params with quotes/pipe stay untouched", () => {
+    const input = { pattern: 'a | b "c"', path: "memory/", glob: "*.md" };
+    expect(sanitizeSearchToolParams(input, "grep")).toBe(input);
+  });
+});

--- a/src/agents/tools/sanitize-tool-args.ts
+++ b/src/agents/tools/sanitize-tool-args.ts
@@ -1,0 +1,61 @@
+import { logWarn } from "../../logger.js";
+import { sanitizeCommandInput } from "./sanitize-command.js";
+
+/**
+ * Generic sanitize for file-tool string args (path / file_path).
+ *
+ * Some smaller models (Gemma 4, etc.) leak LLM sentinel tokens such as
+ * `<<|"|https://...` into tool call arguments. For bash exec we already
+ * sanitize the command; for `read`/`write`/`edit` the leaked token landed in
+ * `file_path`, producing an `ENOENT .../workspace/<|<|` error that the model
+ * then hallucinated a success around (incident 2026-05-17 11:13 KST).
+ *
+ * Reuses the same sentinel-stripping library as bash exec. No-op for clean
+ * input. Non-string args are returned unchanged.
+ *
+ * Logged via `logWarn` mirroring the bash exec pattern:
+ *   `tool.sanitize_special_tokens tool=<name> arg=<name> original_len=.. sanitized_len=..`
+ */
+export function sanitizeToolArg(raw: unknown, toolName: string, argName: string): unknown {
+  if (typeof raw !== "string") {
+    return raw;
+  }
+  const cleaned = sanitizeCommandInput(raw);
+  if (cleaned !== raw) {
+    logWarn(
+      `tool.sanitize_special_tokens tool=${toolName} arg=${argName} original_len=${raw.length} sanitized_len=${typeof cleaned === "string" ? cleaned.length : 0}`,
+    );
+  }
+  return cleaned;
+}
+
+// Path-like keys carried by the core file tools (read/write/edit) after
+// Claude-compat normalization. Content-bearing keys (content/oldText/newText)
+// are intentionally excluded: file contents may legitimately contain `<|`,
+// `<<`, quotes, etc. and must not be mutated.
+const PATH_LIKE_KEYS = ["path", "file_path"] as const;
+
+/**
+ * Sanitize path-like string params on a normalized file-tool params record.
+ * Returns a new record only when something changed; otherwise the original.
+ */
+export function sanitizeFileToolParams(
+  record: Record<string, unknown>,
+  toolName = "file",
+): Record<string, unknown> {
+  let result = record;
+  for (const key of PATH_LIKE_KEYS) {
+    if (!(key in result)) {
+      continue;
+    }
+    const current = result[key];
+    const next = sanitizeToolArg(current, toolName, key);
+    if (next !== current) {
+      if (result === record) {
+        result = { ...record };
+      }
+      result[key] = next;
+    }
+  }
+  return result;
+}

--- a/src/agents/tools/sanitize-tool-args.ts
+++ b/src/agents/tools/sanitize-tool-args.ts
@@ -1,4 +1,5 @@
 import { logWarn } from "../../logger.js";
+import type { AnyAgentTool } from "../pi-tools.types.js";
 import { sanitizeCommandInput } from "./sanitize-command.js";
 
 /**
@@ -29,22 +30,19 @@ export function sanitizeToolArg(raw: unknown, toolName: string, argName: string)
   return cleaned;
 }
 
-// Path-like keys carried by the core file tools (read/write/edit) after
-// Claude-compat normalization. Content-bearing keys (content/oldText/newText)
-// are intentionally excluded: file contents may legitimately contain `<|`,
-// `<<`, quotes, etc. and must not be mutated.
-const PATH_LIKE_KEYS = ["path", "file_path"] as const;
-
 /**
- * Sanitize path-like string params on a normalized file-tool params record.
- * Returns a new record only when something changed; otherwise the original.
+ * Sanitize the given string keys on a params record. Returns a new record only
+ * when something changed; otherwise the original. Shared by the path-like
+ * (read/write/edit) and search-like (find/grep/ls) wrappers so the leak-strip
+ * behavior stays identical across every file tool.
  */
-export function sanitizeFileToolParams(
+function sanitizeRecordKeys(
   record: Record<string, unknown>,
-  toolName = "file",
+  keys: readonly string[],
+  toolName: string,
 ): Record<string, unknown> {
   let result = record;
-  for (const key of PATH_LIKE_KEYS) {
+  for (const key of keys) {
     if (!(key in result)) {
       continue;
     }
@@ -58,4 +56,59 @@ export function sanitizeFileToolParams(
     }
   }
   return result;
+}
+
+// Path-like keys carried by the core file tools (read/write/edit) after
+// Claude-compat normalization. Content-bearing keys (content/oldText/newText)
+// are intentionally excluded: file contents may legitimately contain `<|`,
+// `<<`, quotes, etc. and must not be mutated.
+const PATH_LIKE_KEYS = ["path", "file_path"] as const;
+
+// Search/list tool string args (find/grep/ls). These bypass
+// normalizeToolParams (no Claude-compat alias remapping) so they need their
+// own sanitize entry point. `pattern`/`glob` are search inputs: a leaked
+// sentinel prefix (`<|<|"foo`) makes the search silently miss and the model
+// then hallucinates a result — strip the same tokens as for bash/path args.
+// Content-bearing keys stay excluded for the same reason as PATH_LIKE_KEYS.
+const SEARCH_LIKE_KEYS = ["path", "file_path", "pattern", "glob"] as const;
+
+/**
+ * Sanitize path-like string params on a normalized file-tool params record.
+ * Returns a new record only when something changed; otherwise the original.
+ */
+export function sanitizeFileToolParams(
+  record: Record<string, unknown>,
+  toolName = "file",
+): Record<string, unknown> {
+  return sanitizeRecordKeys(record, PATH_LIKE_KEYS, toolName);
+}
+
+/**
+ * Sanitize string params on a find/grep/ls params record.
+ * Returns a new record only when something changed; otherwise the original.
+ */
+export function sanitizeSearchToolParams(
+  record: Record<string, unknown>,
+  toolName = "search",
+): Record<string, unknown> {
+  return sanitizeRecordKeys(record, SEARCH_LIKE_KEYS, toolName);
+}
+
+/**
+ * Wrap a search/list tool (find/grep/ls) so leaked LLM sentinel tokens are
+ * stripped from its path/pattern/glob args before execution. Mirrors the
+ * read/write/edit protection in pi-tools.params.ts for tools that skip
+ * normalizeToolParams. No-op for clean args.
+ */
+export function wrapSearchToolArgSanitization(tool: AnyAgentTool): AnyAgentTool {
+  return {
+    ...tool,
+    execute: async (toolCallId, params, signal, onUpdate) => {
+      const sanitized =
+        params && typeof params === "object"
+          ? sanitizeSearchToolParams(params as Record<string, unknown>, tool.name)
+          : params;
+      return tool.execute(toolCallId, sanitized ?? params, signal, onUpdate);
+    },
+  };
 }

--- a/src/agents/tools/sanitize-url.test.ts
+++ b/src/agents/tools/sanitize-url.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeUrlInput } from "./sanitize-url.js";
+
+describe("sanitizeUrlInput", () => {
+  it("strips special-token prefix with quotes and pipes", () => {
+    expect(sanitizeUrlInput('<<|"|https://example.com/path')).toBe("https://example.com/path");
+  });
+
+  it("strips angle/pipe tag wrapper before scheme", () => {
+    expect(sanitizeUrlInput("<|something|>https://a.b/c")).toBe("https://a.b/c");
+  });
+
+  it("strips a leading quote", () => {
+    expect(sanitizeUrlInput('"https://x.y')).toBe("https://x.y");
+  });
+
+  it("trims leading whitespace before http scheme", () => {
+    expect(sanitizeUrlInput("   http://x")).toBe("http://x");
+  });
+
+  it("leaves a clean URL untouched", () => {
+    expect(sanitizeUrlInput("https://normal.com")).toBe("https://normal.com");
+  });
+
+  it("leaves a non-URL string untouched so existing error paths fire", () => {
+    expect(sanitizeUrlInput("not-a-url")).toBe("not-a-url");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(sanitizeUrlInput("")).toBe("");
+  });
+});

--- a/src/agents/tools/sanitize-url.ts
+++ b/src/agents/tools/sanitize-url.ts
@@ -1,0 +1,18 @@
+export function sanitizeUrlInput(raw: string): string {
+  if (typeof raw !== "string") {
+    return raw;
+  }
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return trimmed;
+  }
+  const lower = trimmed.toLowerCase();
+  const httpsIdx = lower.indexOf("https://");
+  const httpIdx = lower.indexOf("http://");
+  const candidates = [httpsIdx, httpIdx].filter((i) => i >= 0);
+  if (candidates.length === 0) {
+    return trimmed;
+  }
+  const start = Math.min(...candidates);
+  return start === 0 ? trimmed : trimmed.slice(start);
+}

--- a/src/agents/tools/sanitize-url.ts
+++ b/src/agents/tools/sanitize-url.ts
@@ -1,3 +1,14 @@
+/**
+ * Sanitize a URL argument (web-fetch) by stripping LLM sentinel-token leakage.
+ *
+ * Primary strategy: seek the first `http://` / `https://` and slice from there,
+ * which already drops any sentinel prefix (`<|...|>`, `<<|"|`, leading quote).
+ *
+ * Hardening (2026-05-17): when no scheme is present, also strip paired
+ * `<|...|>` tokens and a leading sentinel run so a no-scheme leak does not pass
+ * through verbatim. Clean non-URL strings (e.g. `not-a-url`) are preserved so
+ * existing downstream error paths still fire.
+ */
 export function sanitizeUrlInput(raw: string): string {
   if (typeof raw !== "string") {
     return raw;
@@ -11,7 +22,14 @@ export function sanitizeUrlInput(raw: string): string {
   const httpIdx = lower.indexOf("http://");
   const candidates = [httpsIdx, httpIdx].filter((i) => i >= 0);
   if (candidates.length === 0) {
-    return trimmed;
+    // No scheme: strip paired sentinel tokens + a token-like leading run.
+    let s = trimmed.replace(/<\|[^|>]*\|>/g, "");
+    const lead = s.match(/^[<|"]+/);
+    if (lead && lead[0].length >= 2 && lead[0].includes("<")) {
+      s = s.slice(lead[0].length);
+    }
+    const cleaned = s.trim();
+    return cleaned.length === 0 ? trimmed : cleaned;
   }
   const start = Math.min(...candidates);
   return start === 0 ? trimmed : trimmed.slice(start);

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -9,6 +9,7 @@ import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
 import { stringEnum } from "../schema/typebox.js";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readNumberParam, readStringParam } from "./common.js";
+import { sanitizeUrlInput } from "./sanitize-url.js";
 import {
   extractReadableContent,
   htmlToMarkdown,
@@ -506,6 +507,7 @@ async function maybeFetchFirecrawlWebFetchPayload(
 }
 
 async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string, unknown>> {
+  params.url = sanitizeUrlInput(params.url);
   const cacheKey = normalizeCacheKey(
     `fetch:${params.url}:${params.extractMode}:${params.maxChars}`,
   );

--- a/src/auto-reply/reply/agent-runner-execution.overflow-safety-net.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.overflow-safety-net.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { isContextOverflowError } from "../../agents/pi-embedded-helpers.js";
+import type { EmbeddedPiRunMeta } from "../../agents/pi-embedded-runner/types.js";
+
+// Contract test for tasks/openclaw/20260520-001 — agent-runner-execution.ts
+// broadened the overflow safety net to also consume
+// `meta.lastAssistantErrorMessage` when `meta.error` is not populated. This
+// keeps the duplicate-emission fix from regressing into a silent failure on
+// the rare runs where vLLM surfaces the context-overflow string only via the
+// final assistant turn (work-report 20260520-040, §4 row D).
+
+describe("agent-runner-execution overflow safety net", () => {
+  const VLLM_CONTEXT_OVERFLOW_RAW =
+    "400 This model's maximum context length is 65536 tokens. However, you requested 70000 tokens.";
+
+  // Mirror the production selection from agent-runner-execution.ts so the
+  // test fails if anyone removes the new field or reverses the precedence.
+  const selectOverflowErrorMessage = (meta: EmbeddedPiRunMeta | undefined): string | undefined =>
+    meta?.error?.message ?? meta?.lastAssistantErrorMessage;
+
+  it("T4: meta.error missing + lastAssistantErrorMessage matches → overflow detected", () => {
+    const meta: EmbeddedPiRunMeta = {
+      durationMs: 12,
+      lastAssistantErrorMessage: VLLM_CONTEXT_OVERFLOW_RAW,
+    };
+
+    const selected = selectOverflowErrorMessage(meta);
+    expect(selected).toBe(VLLM_CONTEXT_OVERFLOW_RAW);
+    expect(isContextOverflowError(selected)).toBe(true);
+  });
+
+  it("T4b: meta.error takes precedence over lastAssistantErrorMessage when both present", () => {
+    const meta: EmbeddedPiRunMeta = {
+      durationMs: 8,
+      error: { kind: "context_overflow", message: "explicit overflow from meta.error" },
+      lastAssistantErrorMessage: VLLM_CONTEXT_OVERFLOW_RAW,
+    };
+
+    expect(selectOverflowErrorMessage(meta)).toBe("explicit overflow from meta.error");
+  });
+
+  it("T4c: no error signal anywhere → selector returns undefined, overflow check false", () => {
+    const meta: EmbeddedPiRunMeta = { durationMs: 5 };
+    expect(selectOverflowErrorMessage(meta)).toBeUndefined();
+    expect(isContextOverflowError(selectOverflowErrorMessage(meta))).toBe(false);
+  });
+});

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -636,8 +636,14 @@ export async function runAgentTurnWithFallback(params: {
   // See #26905: Slack DM sessions silently swallowed messages when context
   // overflow errors were returned as embedded error payloads.
   const finalEmbeddedError = runResult?.meta?.error;
+  // Cover the case where `meta.error` was not populated (e.g. the run path
+  // surfaced the failure via the last assistant turn rather than the embedded
+  // error meta) but the assistant still ended with stopReason === "error" and
+  // an errorMessage that matches the context-overflow signature.
+  const lastAssistantErrorMessage = runResult?.meta?.lastAssistantErrorMessage;
+  const errorForOverflowCheck = finalEmbeddedError?.message ?? lastAssistantErrorMessage;
   const hasPayloadText = runResult?.payloads?.some((p) => p.text?.trim());
-  if (finalEmbeddedError && isContextOverflowError(finalEmbeddedError.message) && !hasPayloadText) {
+  if (errorForOverflowCheck && isContextOverflowError(errorForOverflowCheck) && !hasPayloadText) {
     return {
       kind: "final",
       payload: {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -117,6 +117,10 @@ export async function dispatchReplyFromConfig(params: {
   const chatId = ctx.To ?? ctx.From;
   const messageId = ctx.MessageSid ?? ctx.MessageSidFirst ?? ctx.MessageSidLast;
   const sessionKey = ctx.SessionKey;
+  // P2.25c route 2 (2026-05-24): resolve agentId once per dispatch for plugin hook context.
+  const resolvedAgentIdForHook = sessionKey
+    ? resolveSessionAgentId({ sessionKey, config: cfg })
+    : undefined;
   const startTime = diagnosticsEnabled ? Date.now() : 0;
   const canTrackSession = diagnosticsEnabled && Boolean(sessionKey);
 
@@ -181,7 +185,13 @@ export async function dispatchReplyFromConfig(params: {
     typeof ctx.Timestamp === "number" && Number.isFinite(ctx.Timestamp) ? ctx.Timestamp : undefined;
   const messageIdForHook =
     ctx.MessageSidFull ?? ctx.MessageSid ?? ctx.MessageSidFirst ?? ctx.MessageSidLast;
-  const hookContext = deriveInboundMessageHookContext(ctx, { messageId: messageIdForHook });
+  const hookContext = deriveInboundMessageHookContext(ctx, {
+    messageId: messageIdForHook,
+    // P2.25c route 2 (2026-05-24): populate agent/session identifiers for plugin cross-hook correlation.
+    // sessionId/runId are not yet known at message_received time (agent not invoked yet) — left undefined.
+    agentId: resolvedAgentIdForHook,
+    sessionKey: sessionKey || undefined,
+  });
   const { isGroup, groupId } = hookContext;
 
   // Trigger plugin hooks (fire-and-forget)

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -161,6 +161,12 @@ export type ToolLoopDetectionConfig = {
   criticalThreshold?: number;
   /** Global no-progress breaker threshold (default: 30). */
   globalCircuitBreakerThreshold?: number;
+  /**
+   * Total identical (toolName, args) call count — including the current
+   * attempt — at which generic_repeat hard-blocks the call instead of only
+   * warning (default: 5, or OPENCLAW_TOOL_LOOP_GUARD_WINDOW + 1).
+   */
+  genericRepeatBlockThreshold?: number;
   /** Detector toggles. */
   detectors?: ToolLoopDetectionDetectorConfig;
 };

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -462,6 +462,7 @@ const ToolLoopDetectionSchema = z
     warningThreshold: z.number().int().positive().optional(),
     criticalThreshold: z.number().int().positive().optional(),
     globalCircuitBreakerThreshold: z.number().int().positive().optional(),
+    genericRepeatBlockThreshold: z.number().int().positive().optional(),
     detectors: ToolLoopDetectionDetectorSchema,
   })
   .strict()

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -23,6 +23,14 @@ export type CanonicalInboundMessageHookContext = {
   channelId: string;
   accountId?: string;
   conversationId?: string;
+  /** Agent ID — added in P2.25c route 2 (2026-05-24). */
+  agentId?: string;
+  /** Composite session key — added in P2.25c route 2 (2026-05-24). */
+  sessionKey?: string;
+  /** Ephemeral session UUID — added in P2.25c route 2 (2026-05-24). May be undefined at message_received time. */
+  sessionId?: string;
+  /** Stable run identifier — added in P2.25c route 2 (2026-05-24). May be undefined at message_received time. */
+  runId?: string;
   messageId?: string;
   senderId?: string;
   senderName?: string;
@@ -59,6 +67,14 @@ export function deriveInboundMessageHookContext(
   overrides?: {
     content?: string;
     messageId?: string;
+    /** Added in P2.25c route 2 (2026-05-24) for plugin cross-hook correlation. */
+    agentId?: string;
+    /** Added in P2.25c route 2 (2026-05-24). */
+    sessionKey?: string;
+    /** Added in P2.25c route 2 (2026-05-24). */
+    sessionId?: string;
+    /** Added in P2.25c route 2 (2026-05-24). */
+    runId?: string;
   },
 ): CanonicalInboundMessageHookContext {
   const content =
@@ -87,6 +103,10 @@ export function deriveInboundMessageHookContext(
     channelId,
     accountId: ctx.AccountId,
     conversationId,
+    agentId: overrides?.agentId,
+    sessionKey: overrides?.sessionKey,
+    sessionId: overrides?.sessionId,
+    runId: overrides?.runId,
     messageId:
       overrides?.messageId ??
       ctx.MessageSidFull ??
@@ -144,6 +164,13 @@ export function toPluginMessageContext(
     channelId: canonical.channelId,
     accountId: canonical.accountId,
     conversationId: canonical.conversationId,
+    // P2.25c route 2 (2026-05-24): forward agent/session identifiers when present
+    // (CanonicalInboundMessageHookContext only; CanonicalSentMessageHookContext
+    // does not carry these fields, so type narrowing via "in" guard).
+    agentId: "agentId" in canonical ? canonical.agentId : undefined,
+    sessionKey: "sessionKey" in canonical ? canonical.sessionKey : undefined,
+    sessionId: "sessionId" in canonical ? canonical.sessionId : undefined,
+    runId: "runId" in canonical ? canonical.runId : undefined,
   };
 }
 

--- a/src/infra/net/fetch-guard.ts
+++ b/src/infra/net/fetch-guard.ts
@@ -1,4 +1,5 @@
 import { EnvHttpProxyAgent, type Dispatcher } from "undici";
+import { sanitizeUrlInput } from "../../agents/tools/sanitize-url.js";
 import { logWarn } from "../../logger.js";
 import { bindAbortRelay } from "../../utils/fetch-timeout.js";
 import { hasProxyEnvConfigured } from "./proxy-env.js";
@@ -170,7 +171,7 @@ export async function fetchWithSsrFGuard(params: GuardedFetchOptions): Promise<G
   };
 
   const visited = new Set<string>();
-  let currentUrl = params.url;
+  let currentUrl = sanitizeUrlInput(params.url);
   let currentInit = params.init ? { ...params.init } : undefined;
   let redirectCount = 0;
 

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -663,6 +663,14 @@ export type PluginHookMessageContext = {
   channelId: string;
   accountId?: string;
   conversationId?: string;
+  /** Agent ID (e.g. "gemma", "main"). Added in P2.25c route 2 (2026-05-24) for symmetry with PluginHookToolContext, enabling plugin cross-hook correlation. */
+  agentId?: string;
+  /** Composite session key (e.g. "agent:gemma:telegram:direct:56682682"). Added in P2.25c route 2 (2026-05-24). */
+  sessionKey?: string;
+  /** Ephemeral session UUID — regenerated on /new and /reset. Added in P2.25c route 2 (2026-05-24). May be undefined at message_received time (before agent invocation). */
+  sessionId?: string;
+  /** Stable run identifier for this agent invocation. Added in P2.25c route 2 (2026-05-24). May be undefined at message_received time. */
+  runId?: string;
 };
 
 // message_received hook


### PR DESCRIPTION
## Summary

Related patches that defend OpenClaw against LLM sentinel-token leakage in tool-call arguments. Smaller models (Gemma 4 26B in our deployment) occasionally emit `<|...|>`, `<|<|"`, `<<|"|`, and similar special tokens at the head of `bash.exec` `command`, `web-fetch` `url`, or file-tool `path`/`file_path` arguments. Without sanitization these flow into `bash -c '<|<|"grep ...'`, `fetch('<|"https://...')`, or `read({file_path: '<<|"|https://...'})`, producing syntax/parse/`ENOENT` errors and forcing the model to hallucinate an answer.

All patches:
- **No-op for clean input** — zero impact on Claude (Opus/Sonnet), Mistral, Llama, or any model that does not leak tokens.
- **Logged** — when sanitize changes the input, an event (`bash.sanitize_special_tokens` / `webfetch.sanitize_special_tokens` / `tool.sanitize_special_tokens`) is emitted for monitoring.

## Commits

| commit | scope | files |
|--------|-------|-------|
| `7cbc14d38` | web-fetch URL sanitize | sanitize-url.ts/test, web-fetch.ts, fetch-guard.ts |
| `fe897846b` | bash exec command sanitize | sanitize-command.ts/test (14 cases), bash-tools.exec.ts |
| `d1265be6b` | `<<` sentinel variants + file-tool path args | sanitize-command.ts/test (22 cases), sanitize-url.ts, sanitize-tool-args.ts/test (9 cases), pi-tools.params.ts |

The bash patch mirrors the URL patch's structure exactly (same predicate set, same trim semantics, same log shape). The follow-up commit `d1265be6b` reuses the same sentinel-stripping library for file-tool path args via the single `normalizeToolParams` chokepoint (read/write/edit and the workspace-root / memory-flush wrappers all route through it), and content-bearing args (`content`/`oldText`/`newText`) are intentionally left untouched so file writes are never mutated.

## Compatibility

Sanitize functions are pure and side-effect-free outside the log emission. Untouched on clean input; safe to land before any regression test runs against the broader exec/fetch/file pipelines. False-positive guards keep a lone leading `<x>` (HTML-like text), a lone leading `"` quote, and bash heredocs (`cat <<EOF`) intact — only token-like leading runs (`>= 2` chars containing `<`) and the `<<|...|` mid-command form are stripped.

## Co-authored

Drafted with Claude Opus 4.7 assistance.

## Real behavior proof

**Behavior or issue addressed**: Smaller models — specifically Gemma 4 26B NVFP4 in our deployment — leak LLM sentinel tokens (`<|...|>`, `<|<|"`, `<|"`, `<<|"|`, etc.) at the head of `bash.exec` `command` arguments, `web-fetch` `url` arguments, and file-tool `path`/`file_path` arguments. Without sanitization, the shell receives a command like `<|"|grep something` and returns `bash: syntax error near unexpected token '<|'`. The agent then has no useful tool output and proceeds to fabricate an answer — hallucination caused by silent tool-side failure rather than by model-side reasoning error. The identical failure mode appears on the URL side: `fetch('<|"https://example.com/...')` parses as an invalid URL; and on the file-tool side: `read({file_path: '<<|"|https://...'})` resolves to `ENOENT .../workspace/<|<|` and the agent fabricates file content.

**Real environment tested**: spark-home (DGX Spark GB10, ARM64 Ubuntu 24, 128 GB unified memory). OpenClaw runs under PM2 as a long-lived process via a wrapper script (no `pm2 restart`; reload is `pm2 stop` + `pm2 start` of the wrapper to preserve env). The model backend is Gemma 4 26B NVFP4 served by a local vLLM container on `http://127.0.0.1:8005`. Real Telegram-channel user sessions, not unit fixtures, with the agent named `gemma` (`@lisyoen_gemma_bot`).

**Exact steps or command run after this patch**:

1. Built OpenClaw locally on the branch containing `7cbc14d38`, `fe897846b`, and the follow-up `d1265be6b`.
2. Reloaded OpenClaw via the wrapper (`pm2 stop openclaw && pm2 start openclaw`, wrapper as `pm_exec_path`) to load the patched dist. New gateway PID, port 9086 LISTEN, stable uptime confirmed.
3. Issued real user prompts to the Gemma agent over Telegram that previously caused hallucinated answers — the same prompts that earlier produced `<|"|grep ...` as the bash `command` and `<<|"|https://...` as a `read` `file_path`.
4. Tailed live console output from the running openclaw process: `pm2 logs openclaw --lines 200 --nostream | grep -E 'sanitize_special_tokens'`
5. Compared the new agent answers against the on-disk files to verify content match (no fabrication).

**Evidence after fix**: Redacted runtime logs captured from the live `openclaw` PM2 process on spark-home (KST = UTC+9, command bodies redacted to length-only because they contain user data; the trimmed delta is what the patch removes):

```
2026-05-17 08:13:19  bash.sanitize_special_tokens  original_len=6    sanitized_len=1
2026-05-17 08:13:20  bash.sanitize_special_tokens  original_len=61   sanitized_len=56
2026-05-17 08:13:22  bash.sanitize_special_tokens  original_len=61   sanitized_len=56
2026-05-17 08:13:23  bash.sanitize_special_tokens  original_len=42   sanitized_len=37
2026-05-17 08:13:35  bash.sanitize_special_tokens  original_len=42   sanitized_len=37
2026-05-17 08:21:33  bash.sanitize_special_tokens  original_len=121  sanitized_len=116
2026-05-17 08:21:35  bash.sanitize_special_tokens  original_len=73   sanitized_len=68
2026-05-17 08:45:45  bash.sanitize_special_tokens  original_len=73   sanitized_len=68
```

Each line above is a real Gemma 4 26B tool-call. The trimmed delta is consistently around 5 bytes, matching the design (leading `<|...|>` prefix strip with no false positives on the remainder of the command). Forensic artifacts retained on the deployment and available on request (contain user data so not attached here): the quarantined pre-fix session jsonl at `~/.openclaw/agents/gemma/sessions/.quarantine-fresh-20260517-081701/cb03f312-6f71-4a36-a8c2-a16736300294.jsonl` and the pre-fix `sessions.json` backup containing the leaking `agent:gemma:*` mappings.

**Observed result after fix**: The shell no longer receives `<|...|>` prefixed commands. Every `bash.sanitize_special_tokens` event in the runtime log above corresponds to a leak that was successfully trimmed before reaching `bash -c`; the resulting commands execute cleanly. The same Telegram prompts that produced fabricated answers approximately 24 hours before the fix now return the actual on-disk file contents quoted verbatim. Side-by-side comparison confirmed accuracy: every key fact from the pre-fix fabricated answer was invented; every key fact from the post-fix answer matches the on-disk card. Clean commands (no sentinel prefix, the dominant case under Opus/Sonnet sessions) pass through untouched and emit no event, confirming the no-op-for-clean-input design.

**Additional pattern observed 2026-05-17 11:13 KST (follow-up commit `d1265be6b`)**: A smaller-model leak of the form `<<|"|https://...` (double-`<` prefix, no closing `|>`) bypassed the original `<\|[^|>]*\|>` regex, and the leak landed in a `read` tool `file_path` argument — a path not previously sanitized (only `bash.exec` and `web-fetch` URL were). The quarantined session shows `read({file_path: "<<|\"|https://..."})` resolving to `ENOENT, access '.../workspace/<|<|'`, ten consecutive failed toolResults, and the model then emitting a fabricated "success" reply. The follow-up commit extends the regex to strip token-like leading `<`+ runs (`<<|"|`, `<<|`, `<<`, `<<<`) and the mid-command `<<|...|` form, and applies the same sentinel-stripping to file-tool `path`/`file_path` args through the shared `normalizeToolParams` chokepoint (read/write/edit). Unit coverage grew from 14 to 22 sanitize-command cases plus 9 new sanitize-tool-args cases (38 sanitize tests total, all green), including explicit false-positive guards (`<x>` and a lone leading `"` are preserved). After reload, the new `tool.sanitize_special_tokens` event fires for the file-tool path leaks and the `read` call resolves the real path. Forensic jsonl preserved at `~/.openclaw/agents/gemma/sessions/.quarantine-hallucination-20260517-1113/663a8752-71d0-4826-aaed-a9777f741757.jsonl`.

**What was not tested**: Behavior under non-Gemma frontier models that emit similar prefixes — Opus and Sonnet in our deployment did not exhibit this leakage at the moment of testing, so we could not produce a positive sanitize event for them; the patches are no-op for them by design and that no-op behavior is exercised by the included unit tests. Sanitize event rates under heavy concurrent multi-agent load were also not exercised on spark-home where typical concurrency is at most 3. A live Telegram round-trip on the exact 11:13 prompt after the follow-up reload is pending the operator's own Telegram client (the gateway-side path sanitize and unit suite are verified).
