### PR TITLE
Fix infer SecretRef resolution for provider-backed commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Docs: https://docs.openclaw.ai
 - Agents/subagents: mark completed subagent handoffs as ready for parent review so requester agents verify results and continue required follow-up work before reporting done. (#82724) Thanks @100menotu001.
 - QA-Lab: validate Capture saved views loaded from browser storage so malformed local state cannot poison Capture inspector filters or layout controls. (#77722) Thanks @AsaZhou923.
 - CLI/config: add `--dry-run` support to `openclaw config unset`, with `--json` output and allow-exec validation parity with `config set`/`config patch` dry-run handling. (#81895) Thanks @giodl73-repo.
+- CLI/infer: resolve command SecretRefs before local provider-backed capability runs, so web search/fetch and other local infer commands can use plugin-scoped credential refs. Fixes #82621. (#82798) Thanks @joshavant.
 - Memory-core: retry disabled dreaming cron cleanup until cron is available after startup, so persisted managed dreaming jobs are removed after restart. Fixes #82383. (#82389) Thanks @neeravmakwana.
 - Providers/xAI: keep retired Grok 3, Grok 4 Fast, Grok 4.1 Fast, and Grok Code slugs out of model pickers while preserving compatibility resolution for existing configs.
 - Providers/xAI: replace the retired `grok-imagine-image-pro` image model with `grok-imagine-image-quality` in the bundled image-generation provider and docs. (#81399) Thanks @KateWilkins.

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -20,6 +20,8 @@ const mocks = vi.hoisted(() => ({
     writeStdout: vi.fn(),
   },
   loadConfig: vi.fn(() => ({})),
+  getRuntimeConfigSourceSnapshot: vi.fn(() => null),
+  setRuntimeConfigSnapshot: vi.fn(),
   loadAuthProfileStoreForRuntime: vi.fn(() => ({ profiles: {}, order: {} })),
   listProfilesForProvider: vi.fn(() => []),
   updateAuthProfileStoreWithLock: vi.fn(
@@ -133,6 +135,23 @@ const mocks = vi.hoisted(() => ({
   convertHeicToJpeg: vi.fn(async () => Buffer.from("jpeg-normalized")),
   isWebSearchProviderConfigured: vi.fn(() => false),
   isWebFetchProviderConfigured: vi.fn(() => false),
+  resolveCommandConfigWithSecrets: vi.fn(async ({ config }: { config: unknown }) => ({
+    resolvedConfig: config,
+    effectiveConfig: config,
+    diagnostics: [],
+  })),
+  getAgentRuntimeCommandSecretTargetIds: vi.fn(() => new Set(["agent-runtime-target"])),
+  getMemoryEmbeddingCommandSecretTargetIds: vi.fn(() => new Set(["memory-target"])),
+  getModelsCommandSecretTargetIds: vi.fn(() => new Set(["model-target"])),
+  getTtsCommandSecretTargetIds: vi.fn(() => new Set(["tts-target"])),
+  getWebFetchCommandSecretTargets: vi.fn(() => ({
+    targetIds: new Set(["web-fetch-target"]),
+    allowedPaths: new Set(["plugins.entries.firecrawl.config.webFetch.apiKey"]),
+  })),
+  getWebSearchCommandSecretTargets: vi.fn(() => ({
+    targetIds: new Set(["web-search-target"]),
+    allowedPaths: new Set(["plugins.entries.tavily.config.webSearch.apiKey"]),
+  })),
   modelsStatusCommand: vi.fn(
     async (_opts: unknown, runtime: { log: (...args: unknown[]) => void }) => {
       runtime.log(JSON.stringify({ ok: true, providers: [{ id: "openai" }] }));
@@ -147,8 +166,12 @@ vi.mock("../runtime.js", () => ({
 }));
 
 vi.mock("../config/config.js", () => ({
+  getRuntimeConfigSourceSnapshot:
+    mocks.getRuntimeConfigSourceSnapshot as typeof import("../config/config.js").getRuntimeConfigSourceSnapshot,
   getRuntimeConfig: mocks.loadConfig as typeof import("../config/config.js").getRuntimeConfig,
   loadConfig: mocks.loadConfig as typeof import("../config/config.js").loadConfig,
+  setRuntimeConfigSnapshot:
+    mocks.setRuntimeConfigSnapshot as typeof import("../config/config.js").setRuntimeConfigSnapshot,
 }));
 
 vi.mock("../agents/agent-scope.js", () => ({
@@ -292,6 +315,26 @@ vi.mock("../web-fetch/runtime.js", () => ({
   resolveWebFetchDefinition: vi.fn(),
 }));
 
+vi.mock("./command-config-resolution.js", () => ({
+  resolveCommandConfigWithSecrets:
+    mocks.resolveCommandConfigWithSecrets as typeof import("./command-config-resolution.js").resolveCommandConfigWithSecrets,
+}));
+
+vi.mock("./command-secret-targets.js", () => ({
+  getAgentRuntimeCommandSecretTargetIds:
+    mocks.getAgentRuntimeCommandSecretTargetIds as typeof import("./command-secret-targets.js").getAgentRuntimeCommandSecretTargetIds,
+  getMemoryEmbeddingCommandSecretTargetIds:
+    mocks.getMemoryEmbeddingCommandSecretTargetIds as typeof import("./command-secret-targets.js").getMemoryEmbeddingCommandSecretTargetIds,
+  getModelsCommandSecretTargetIds:
+    mocks.getModelsCommandSecretTargetIds as typeof import("./command-secret-targets.js").getModelsCommandSecretTargetIds,
+  getTtsCommandSecretTargetIds:
+    mocks.getTtsCommandSecretTargetIds as typeof import("./command-secret-targets.js").getTtsCommandSecretTargetIds,
+  getWebFetchCommandSecretTargets:
+    mocks.getWebFetchCommandSecretTargets as typeof import("./command-secret-targets.js").getWebFetchCommandSecretTargets,
+  getWebSearchCommandSecretTargets:
+    mocks.getWebSearchCommandSecretTargets as typeof import("./command-secret-targets.js").getWebSearchCommandSecretTargets,
+}));
+
 describe("capability cli", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -302,6 +345,8 @@ describe("capability cli", () => {
     mocks.runtime.log.mockClear();
     mocks.runtime.error.mockClear();
     mocks.runtime.writeJson.mockClear();
+    mocks.getRuntimeConfigSourceSnapshot.mockReset().mockReturnValue(null);
+    mocks.setRuntimeConfigSnapshot.mockClear();
     mocks.loadModelCatalog
       .mockReset()
       .mockResolvedValue([{ id: "gpt-5.4", provider: "openai", name: "GPT-5.4" }] as never);
@@ -352,6 +397,29 @@ describe("capability cli", () => {
     mocks.registerBuiltInMemoryEmbeddingProviders.mockClear();
     mocks.isWebSearchProviderConfigured.mockReset().mockReturnValue(false);
     mocks.isWebFetchProviderConfigured.mockReset().mockReturnValue(false);
+    mocks.resolveCommandConfigWithSecrets
+      .mockReset()
+      .mockImplementation(async ({ config }: { config: unknown }) => ({
+        resolvedConfig: config,
+        effectiveConfig: config,
+        diagnostics: [],
+      }));
+    mocks.getAgentRuntimeCommandSecretTargetIds
+      .mockReset()
+      .mockReturnValue(new Set(["agent-runtime-target"]));
+    mocks.getMemoryEmbeddingCommandSecretTargetIds
+      .mockReset()
+      .mockReturnValue(new Set(["memory-target"]));
+    mocks.getModelsCommandSecretTargetIds.mockReset().mockReturnValue(new Set(["model-target"]));
+    mocks.getTtsCommandSecretTargetIds.mockReset().mockReturnValue(new Set(["tts-target"]));
+    mocks.getWebFetchCommandSecretTargets.mockReset().mockReturnValue({
+      targetIds: new Set(["web-fetch-target"]),
+      allowedPaths: new Set(["plugins.entries.firecrawl.config.webFetch.apiKey"]),
+    });
+    mocks.getWebSearchCommandSecretTargets.mockReset().mockReturnValue({
+      targetIds: new Set(["web-search-target"]),
+      allowedPaths: new Set(["plugins.entries.tavily.config.webSearch.apiKey"]),
+    });
     mocks.modelsStatusCommand.mockClear();
     mocks.callGateway.mockImplementation((async ({ method }: { method: string }) => {
       if (method === "tts.status") {
@@ -483,6 +551,13 @@ describe("capability cli", () => {
 
   function firstEmbeddingProviderCall() {
     const calls = mocks.createEmbeddingProvider.mock.calls as unknown as Array<
+      [Record<string, unknown>]
+    >;
+    return calls[0]?.[0];
+  }
+
+  function firstCommandConfigResolutionCall() {
+    const calls = mocks.resolveCommandConfigWithSecrets.mock.calls as unknown as Array<
       [Record<string, unknown>]
     >;
     return calls[0]?.[0];
@@ -1814,6 +1889,35 @@ describe("capability cli", () => {
     expect(firstJsonOutput()?.model).toBe("text-embedding-3-small");
   });
 
+  it("resolves command SecretRefs before local model capability execution", async () => {
+    const rawConfig = { agents: { defaults: { model: "openai/gpt-5.4" } } };
+    const resolvedConfig = { agents: { defaults: { model: "openai/gpt-5.4" } }, resolved: true };
+    const targetIds = new Set(["models.providers.*.apiKey"]);
+    mocks.loadConfig.mockReturnValue(rawConfig);
+    mocks.getModelsCommandSecretTargetIds.mockReturnValue(targetIds);
+    mocks.resolveCommandConfigWithSecrets.mockResolvedValueOnce({
+      resolvedConfig,
+      effectiveConfig: resolvedConfig,
+      diagnostics: [],
+    } as never);
+
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: ["capability", "model", "run", "--prompt", "hello", "--json"],
+    });
+
+    expect(firstCommandConfigResolutionCall()).toEqual(
+      expect.objectContaining({
+        config: rawConfig,
+        commandName: "infer model run",
+        targetIds,
+        runtime: mocks.runtime,
+      }),
+    );
+    expect(firstPreparedModelParams()?.cfg).toBe(resolvedConfig);
+    expect(mocks.setRuntimeConfigSnapshot).toHaveBeenCalledWith(resolvedConfig);
+  });
+
   it("derives the embedding provider from a provider/model override", async () => {
     await runRegisteredCli({
       register: registerCapabilityCli as (program: Command) => void,
@@ -2095,6 +2199,159 @@ describe("capability cli", () => {
           envVars: ["FIRECRAWL_API_KEY"],
         },
       ],
+    });
+  });
+
+  it("resolves command SecretRefs before local web search execution", async () => {
+    const rawConfig = {
+      tools: { web: { search: { provider: "brave" } } },
+      plugins: {
+        entries: {
+          tavily: {
+            config: {
+              webSearch: {
+                apiKey: { source: "env", provider: "default", id: "TAVILY_API_KEY" },
+              },
+            },
+          },
+        },
+      },
+    };
+    const resolvedConfig = {
+      ...rawConfig,
+      tools: { web: { search: { provider: "tavily" } } },
+      plugins: {
+        entries: {
+          tavily: { config: { webSearch: { apiKey: "resolved-tavily-key" } } },
+        },
+      },
+    };
+    const targetIds = new Set(["plugins.entries.tavily.config.webSearch.apiKey"]);
+    const allowedPaths = new Set(["plugins.entries.tavily.config.webSearch.apiKey"]);
+    mocks.loadConfig.mockReturnValue(rawConfig);
+    mocks.getWebSearchCommandSecretTargets.mockReturnValue({
+      targetIds,
+      allowedPaths,
+    });
+    mocks.resolveCommandConfigWithSecrets.mockResolvedValueOnce({
+      resolvedConfig,
+      effectiveConfig: resolvedConfig,
+      diagnostics: [],
+    } as never);
+    const webSearchRuntime = await import("../web-search/runtime.js");
+    vi.mocked(webSearchRuntime.runWebSearch).mockResolvedValueOnce({
+      provider: "tavily",
+      result: { results: [] },
+    } as never);
+
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: ["capability", "web", "search", "--provider", "tavily", "--query", "ping", "--json"],
+    });
+
+    expect(firstCommandConfigResolutionCall()).toEqual(
+      expect.objectContaining({
+        commandName: "infer web search",
+        targetIds,
+        allowedPaths,
+        runtime: mocks.runtime,
+      }),
+    );
+    expect(firstCommandConfigResolutionCall()?.config).toEqual(
+      expect.objectContaining({
+        tools: { web: { search: { provider: "tavily" } } },
+      }),
+    );
+    expect(rawConfig.tools.web.search.provider).toBe("brave");
+    expect(vi.mocked(webSearchRuntime.runWebSearch).mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        config: resolvedConfig,
+        preferInputConfig: true,
+        providerId: "tavily",
+      }),
+    );
+  });
+
+  it("resolves command SecretRefs before local web fetch execution", async () => {
+    const rawConfig = {
+      tools: { web: { fetch: { provider: "browser" } } },
+      plugins: {
+        entries: {
+          firecrawl: {
+            config: {
+              webFetch: {
+                apiKey: { source: "env", provider: "default", id: "FIRECRAWL_API_KEY" },
+              },
+            },
+          },
+        },
+      },
+    };
+    const resolvedConfig = {
+      ...rawConfig,
+      tools: { web: { fetch: { provider: "firecrawl" } } },
+      plugins: {
+        entries: {
+          firecrawl: { config: { webFetch: { apiKey: "resolved-firecrawl-key" } } },
+        },
+      },
+    };
+    const targetIds = new Set(["plugins.entries.firecrawl.config.webFetch.apiKey"]);
+    const allowedPaths = new Set(["plugins.entries.firecrawl.config.webFetch.apiKey"]);
+    mocks.loadConfig.mockReturnValue(rawConfig);
+    mocks.getWebFetchCommandSecretTargets.mockReturnValue({
+      targetIds,
+      allowedPaths,
+    });
+    mocks.resolveCommandConfigWithSecrets.mockResolvedValueOnce({
+      resolvedConfig,
+      effectiveConfig: resolvedConfig,
+      diagnostics: [],
+    } as never);
+    const webFetchRuntime = await import("../web-fetch/runtime.js");
+    const execute = vi.fn(async () => ({ text: "ok" }));
+    vi.mocked(webFetchRuntime.resolveWebFetchDefinition).mockReturnValueOnce({
+      provider: { id: "firecrawl" },
+      definition: { execute },
+    } as never);
+
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: [
+        "capability",
+        "web",
+        "fetch",
+        "--provider",
+        "firecrawl",
+        "--url",
+        "https://example.com",
+        "--json",
+      ],
+    });
+
+    expect(firstCommandConfigResolutionCall()).toEqual(
+      expect.objectContaining({
+        commandName: "infer web fetch",
+        targetIds,
+        allowedPaths,
+        runtime: mocks.runtime,
+      }),
+    );
+    expect(firstCommandConfigResolutionCall()?.config).toEqual(
+      expect.objectContaining({
+        tools: { web: { fetch: { provider: "firecrawl" } } },
+      }),
+    );
+    expect(rawConfig.tools.web.fetch.provider).toBe("browser");
+    expect(vi.mocked(webFetchRuntime.resolveWebFetchDefinition).mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        config: resolvedConfig,
+        providerId: "firecrawl",
+      }),
+    );
+    expect(execute).toHaveBeenCalledWith({
+      url: "https://example.com",
+      format: undefined,
     });
   });
 

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -19,7 +19,11 @@ import {
   prepareSimpleCompletionModelForAgent,
 } from "../agents/simple-completion-runtime.js";
 import { normalizeThinkLevel, type ThinkLevel } from "../auto-reply/thinking.js";
-import { getRuntimeConfig } from "../config/config.js";
+import {
+  getRuntimeConfig,
+  getRuntimeConfigSourceSnapshot,
+  setRuntimeConfigSnapshot,
+} from "../config/config.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { callGateway, randomIdempotencyKey } from "../gateway/call.js";
@@ -87,6 +91,14 @@ import {
   runWebSearch,
 } from "../web-search/runtime.js";
 import { runCommandWithRuntime } from "./cli-utils.js";
+import { resolveCommandConfigWithSecrets } from "./command-config-resolution.js";
+import {
+  getMemoryEmbeddingCommandSecretTargetIds,
+  getModelsCommandSecretTargetIds,
+  getTtsCommandSecretTargetIds,
+  getWebFetchCommandSecretTargets,
+  getWebSearchCommandSecretTargets,
+} from "./command-secret-targets.js";
 import { removeCommandByName } from "./program/command-tree.js";
 import { collectOption } from "./program/helpers.js";
 
@@ -667,6 +679,52 @@ function normalizeModelRunThinking(value: unknown): ThinkLevel | undefined {
   return normalized;
 }
 
+async function resolveLocalCapabilityRuntimeConfig(params: {
+  commandName: string;
+  targetIds: Set<string>;
+  allowedPaths?: Set<string>;
+  config?: OpenClawConfig;
+}): Promise<OpenClawConfig> {
+  const cfg = params.config ?? getRuntimeConfig();
+  const sourceConfig = getRuntimeConfigSourceSnapshot();
+  const { resolvedConfig } = await resolveCommandConfigWithSecrets({
+    config: cfg,
+    commandName: params.commandName,
+    targetIds: params.targetIds,
+    ...(params.allowedPaths ? { allowedPaths: params.allowedPaths } : {}),
+    runtime: defaultRuntime,
+  });
+  if (sourceConfig) {
+    setRuntimeConfigSnapshot(resolvedConfig, sourceConfig);
+  } else {
+    setRuntimeConfigSnapshot(resolvedConfig);
+  }
+  return resolvedConfig;
+}
+
+function withWebProviderOverride(
+  config: OpenClawConfig,
+  kind: "search" | "fetch",
+  provider?: string,
+): OpenClawConfig {
+  const normalizedProvider = normalizeOptionalString(provider);
+  if (!normalizedProvider) {
+    return config;
+  }
+  const next = structuredClone(config);
+  const tools = (next.tools ??= {});
+  const web = (tools.web ??= {});
+  const existing = web[kind];
+  web[kind] =
+    existing && typeof existing === "object"
+      ? {
+          ...existing,
+          provider: normalizedProvider,
+        }
+      : { provider: normalizedProvider };
+  return next;
+}
+
 async function runModelRun(params: {
   prompt: string;
   files?: string[];
@@ -674,7 +732,13 @@ async function runModelRun(params: {
   thinking?: ThinkLevel;
   transport: CapabilityTransport;
 }) {
-  const cfg = getRuntimeConfig();
+  const cfg =
+    params.transport === "local"
+      ? await resolveLocalCapabilityRuntimeConfig({
+          commandName: "infer model run",
+          targetIds: getModelsCommandSecretTargetIds(),
+        })
+      : getRuntimeConfig();
   const agentId = resolveDefaultAgentId(cfg);
   const modelRef = await canonicalizeModelRunRef({
     raw: params.model,
@@ -950,7 +1014,10 @@ async function runImageGenerate(params: {
   output?: string;
   timeoutMs?: number;
 }) {
-  const cfg = getRuntimeConfig();
+  const cfg = await resolveLocalCapabilityRuntimeConfig({
+    commandName: `infer ${params.capability}`,
+    targetIds: getModelsCommandSecretTargetIds(),
+  });
   const agentDir = resolveAgentDir(cfg, resolveDefaultAgentId(cfg));
   const inputImages =
     params.file && params.file.length > 0
@@ -1019,7 +1086,10 @@ async function runImageDescribe(params: {
   prompt?: string;
   timeoutMs?: number;
 }) {
-  const cfg = getRuntimeConfig();
+  const cfg = await resolveLocalCapabilityRuntimeConfig({
+    commandName: `infer ${params.capability}`,
+    targetIds: getModelsCommandSecretTargetIds(),
+  });
   const agentDir = resolveAgentDir(cfg, resolveDefaultAgentId(cfg));
   const activeModel = requireProviderModelOverride(params.model);
   const prompt = normalizeOptionalString(params.prompt);
@@ -1086,7 +1156,10 @@ async function runAudioTranscribe(params: {
   model?: string;
   prompt?: string;
 }) {
-  const cfg = getRuntimeConfig();
+  const cfg = await resolveLocalCapabilityRuntimeConfig({
+    commandName: "infer audio transcribe",
+    targetIds: getModelsCommandSecretTargetIds(),
+  });
   const activeModel = requireProviderModelOverride(params.model);
   const result = await transcribeAudioFile({
     filePath: path.resolve(params.file),
@@ -1181,7 +1254,10 @@ async function runVideoGenerate(params: {
   watermark?: boolean;
   timeoutMs?: number;
 }) {
-  const cfg = getRuntimeConfig();
+  const cfg = await resolveLocalCapabilityRuntimeConfig({
+    commandName: "infer video generate",
+    targetIds: getModelsCommandSecretTargetIds(),
+  });
   const agentDir = resolveAgentDir(cfg, resolveDefaultAgentId(cfg));
   const result = await generateVideo({
     cfg,
@@ -1256,7 +1332,10 @@ async function runVideoGenerate(params: {
 }
 
 async function runVideoDescribe(params: { file: string; model?: string }) {
-  const cfg = getRuntimeConfig();
+  const cfg = await resolveLocalCapabilityRuntimeConfig({
+    commandName: "infer video describe",
+    targetIds: getModelsCommandSecretTargetIds(),
+  });
   const activeModel = requireProviderModelOverride(params.model);
   const result = await describeVideoFile({
     filePath: path.resolve(params.file),
@@ -1335,7 +1414,10 @@ async function runTtsConvert(params: {
     } satisfies CapabilityEnvelope;
   }
 
-  const cfg = getRuntimeConfig();
+  const cfg = await resolveLocalCapabilityRuntimeConfig({
+    commandName: "infer tts convert",
+    targetIds: getTtsCommandSecretTargetIds(),
+  });
   const overrides = resolveExplicitTtsOverrides({
     cfg,
     provider: params.provider,
@@ -1451,7 +1533,10 @@ async function runTtsPersonas(transport: CapabilityTransport) {
 }
 
 async function runTtsVoices(providerRaw?: string) {
-  const cfg = getRuntimeConfig();
+  const cfg = await resolveLocalCapabilityRuntimeConfig({
+    commandName: "infer tts voices",
+    targetIds: getTtsCommandSecretTargetIds(),
+  });
   const config = resolveTtsConfig(cfg);
   const prefsPath = resolveTtsPrefsPath(config);
   const provider = normalizeOptionalString(providerRaw) || getTtsProvider(config, prefsPath);
@@ -1527,9 +1612,21 @@ async function runTtsStateMutation(params: {
 }
 
 async function runWebSearchCommand(params: { query: string; provider?: string; limit?: number }) {
-  const cfg = getRuntimeConfig();
+  const rawConfig = getRuntimeConfig();
+  const config = withWebProviderOverride(rawConfig, "search", params.provider);
+  const secretTargets = getWebSearchCommandSecretTargets({
+    config,
+    provider: params.provider,
+  });
+  const cfg = await resolveLocalCapabilityRuntimeConfig({
+    commandName: "infer web search",
+    targetIds: secretTargets.targetIds,
+    ...(secretTargets.allowedPaths ? { allowedPaths: secretTargets.allowedPaths } : {}),
+    config,
+  });
   const result = await runWebSearch({
     config: cfg,
+    preferInputConfig: true,
     providerId: params.provider,
     args: {
       query: params.query,
@@ -1548,7 +1645,18 @@ async function runWebSearchCommand(params: { query: string; provider?: string; l
 }
 
 async function runWebFetchCommand(params: { url: string; provider?: string; format?: string }) {
-  const cfg = getRuntimeConfig();
+  const rawConfig = getRuntimeConfig();
+  const config = withWebProviderOverride(rawConfig, "fetch", params.provider);
+  const secretTargets = getWebFetchCommandSecretTargets({
+    config,
+    provider: params.provider,
+  });
+  const cfg = await resolveLocalCapabilityRuntimeConfig({
+    commandName: "infer web fetch",
+    targetIds: secretTargets.targetIds,
+    ...(secretTargets.allowedPaths ? { allowedPaths: secretTargets.allowedPaths } : {}),
+    config,
+  });
   const resolved = resolveWebFetchDefinition({
     config: cfg,
     providerId: params.provider,
@@ -1576,7 +1684,10 @@ async function runMemoryEmbeddingCreate(params: {
   model?: string;
 }) {
   ensureMemoryEmbeddingProvidersRegistered();
-  const cfg = getRuntimeConfig();
+  const cfg = await resolveLocalCapabilityRuntimeConfig({
+    commandName: "infer embedding create",
+    targetIds: getMemoryEmbeddingCommandSecretTargetIds(),
+  });
   const modelRef = resolveModelRefOverride(params.model);
   const requestedProvider = normalizeOptionalString(params.provider) || modelRef.provider || "auto";
   const result = await createEmbeddingProvider({

--- a/src/cli/command-secret-resolution.coverage.test.ts
+++ b/src/cli/command-secret-resolution.coverage.test.ts
@@ -4,6 +4,7 @@ import { readCommandSource } from "./command-source.test-helpers.js";
 
 const SECRET_TARGET_CALLSITES = [
   bundledPluginFile("memory-core", "src/cli.runtime.ts"),
+  "src/cli/capability-cli.ts",
   "src/cli/qr-cli.ts",
   "src/agents/agent-runtime-config.ts",
   "src/commands/agent.ts",

--- a/src/cli/command-secret-targets.test.ts
+++ b/src/cli/command-secret-targets.test.ts
@@ -11,10 +11,15 @@ const REGISTRY_IDS = [
   "gateway.auth.password",
   "gateway.remote.token",
   "gateway.remote.password",
+  "models.providers.google.apiKey",
   "models.providers.openai.apiKey",
   "messages.tts.providers.openai.apiKey",
   "plugins.entries.firecrawl.config.webFetch.apiKey",
+  "plugins.entries.firecrawl.config.webSearch.apiKey",
   "plugins.entries.exa.config.webSearch.apiKey",
+  "plugins.entries.google.config.webSearch.apiKey",
+  "plugins.entries.readerlab.config.webFetch.apiKey",
+  "plugins.entries.searchlab.config.webSearch.apiKey",
   "skills.entries.demo.apiKey",
   "tools.web.search.apiKey",
 ] as const;
@@ -28,8 +33,12 @@ vi.mock("../secrets/target-registry.js", () => ({
   discoverConfigSecretTargetsByIds: vi.fn((config: unknown, targetIds?: Iterable<string>) => {
     const allowed = targetIds ? new Set(targetIds) : null;
     const out: Array<{ path: string; pathSegments: string[] }> = [];
+    const isAllowed = (path: string) =>
+      !allowed ||
+      allowed.has(path) ||
+      (allowed.has("models.providers.*.apiKey") && /^models\.providers\.[^.]+\.apiKey$/.test(path));
     const record = (path: string) => {
-      if (allowed && !allowed.has(path)) {
+      if (!isAllowed(path)) {
         return;
       }
       out.push({ path, pathSegments: path.split(".") });
@@ -48,16 +57,59 @@ vi.mock("../secrets/target-registry.js", () => ({
         record(`channels.discord.accounts.${accountId}.token`);
       }
     }
+    const models = (config as { models?: { providers?: Record<string, { apiKey?: unknown }> } })
+      ?.models;
+    for (const [providerId, provider] of Object.entries(models?.providers ?? {})) {
+      if (provider?.apiKey !== undefined) {
+        record(`models.providers.${providerId}.apiKey`);
+      }
+    }
+    const plugins = (
+      config as {
+        plugins?: {
+          entries?: Record<
+            string,
+            { config?: { webSearch?: { apiKey?: unknown }; webFetch?: { apiKey?: unknown } } }
+          >;
+        };
+      }
+    )?.plugins;
+    for (const [pluginId, entry] of Object.entries(plugins?.entries ?? {})) {
+      if (entry?.config?.webSearch?.apiKey !== undefined) {
+        record(`plugins.entries.${pluginId}.config.webSearch.apiKey`);
+      }
+      if (entry?.config?.webFetch?.apiKey !== undefined) {
+        record(`plugins.entries.${pluginId}.config.webFetch.apiKey`);
+      }
+    }
     return out;
   }),
 }));
 
+vi.mock("../plugins/plugin-registry.js", () => ({
+  resolveManifestContractOwnerPluginId: vi.fn(
+    ({ value }: { value?: string }) =>
+      ({
+        firecrawl: "firecrawl",
+        gemini: "google",
+        pagefetch: "readerlab",
+        serpapi: "searchlab",
+      })[value ?? ""],
+  ),
+}));
+
 import {
   getAgentRuntimeCommandSecretTargetIds,
+  getMemoryEmbeddingCommandSecretTargetIds,
   getModelsCommandSecretTargetIds,
   getQrRemoteCommandSecretTargetIds,
   getScopedChannelsCommandSecretTargets,
   getSecurityAuditCommandSecretTargetIds,
+  getTtsCommandSecretTargetIds,
+  getWebFetchCommandSecretTargets,
+  getWebFetchCommandSecretTargetIds,
+  getWebSearchCommandSecretTargets,
+  getWebSearchCommandSecretTargetIds,
 } from "./command-secret-targets.js";
 
 describe("command secret target ids", () => {
@@ -80,6 +132,201 @@ describe("command secret target ids", () => {
     expect(ids.has("plugins.entries.firecrawl.config.webFetch.apiKey")).toBe(true);
     expect(ids.has("plugins.entries.exa.config.webSearch.apiKey")).toBe(true);
     expect(ids.has("channels.discord.token")).toBe(false);
+  });
+
+  it("scopes capability target ids to the provider family", () => {
+    const webSearch = getWebSearchCommandSecretTargetIds();
+    expect(webSearch).toEqual(
+      new Set([
+        "plugins.entries.exa.config.webSearch.apiKey",
+        "plugins.entries.firecrawl.config.webSearch.apiKey",
+        "plugins.entries.google.config.webSearch.apiKey",
+        "plugins.entries.searchlab.config.webSearch.apiKey",
+        "tools.web.search.apiKey",
+      ]),
+    );
+    expect(webSearch.has("plugins.entries.firecrawl.config.webFetch.apiKey")).toBe(false);
+    expect(webSearch.has("models.providers.*.apiKey")).toBe(false);
+
+    const webFetch = getWebFetchCommandSecretTargetIds();
+    expect(webFetch).toEqual(
+      new Set([
+        "plugins.entries.firecrawl.config.webFetch.apiKey",
+        "plugins.entries.readerlab.config.webFetch.apiKey",
+      ]),
+    );
+    expect(webFetch.has("plugins.entries.exa.config.webSearch.apiKey")).toBe(false);
+
+    const tts = getTtsCommandSecretTargetIds();
+    expect(tts.has("models.providers.*.apiKey")).toBe(true);
+    expect(tts.has("messages.tts.providers.*.apiKey")).toBe(true);
+    expect(tts.has("plugins.entries.exa.config.webSearch.apiKey")).toBe(false);
+
+    const memory = getMemoryEmbeddingCommandSecretTargetIds();
+    expect(memory.has("models.providers.*.apiKey")).toBe(true);
+    expect(memory.has("agents.defaults.memorySearch.remote.apiKey")).toBe(true);
+    expect(memory.has("messages.tts.providers.*.apiKey")).toBe(false);
+  });
+
+  it("selects model-provider fallback credentials for selected web search providers", () => {
+    const selected = getWebSearchCommandSecretTargets({
+      config: {
+        tools: { web: { search: { provider: "gemini" } } },
+        models: {
+          providers: {
+            google: { apiKey: { source: "env", id: "GEMINI_API_KEY" } },
+            openai: { apiKey: { source: "env", id: "OPENAI_API_KEY" } },
+          },
+        },
+        plugins: {
+          entries: {
+            firecrawl: { config: { webSearch: { apiKey: { source: "env", id: "FC" } } } },
+          },
+        },
+      } as never,
+      provider: "gemini",
+    });
+
+    expect(selected.targetIds.has("models.providers.*.apiKey")).toBe(true);
+    expect(selected.allowedPaths).toEqual(new Set(["models.providers.google.apiKey"]));
+
+    const pluginCredential = getWebSearchCommandSecretTargets({
+      config: {
+        tools: { web: { search: { provider: "gemini" } } },
+        models: {
+          providers: {
+            google: { apiKey: { source: "env", id: "GEMINI_API_KEY" } },
+          },
+        },
+        plugins: {
+          entries: {
+            google: { config: { webSearch: { apiKey: { source: "env", id: "GOOGLE" } } } },
+          },
+        },
+      } as never,
+      provider: "gemini",
+    });
+    expect(pluginCredential.targetIds.has("models.providers.*.apiKey")).toBe(false);
+    expect(pluginCredential.allowedPaths).toEqual(
+      new Set(["plugins.entries.google.config.webSearch.apiKey"]),
+    );
+
+    const unselected = getWebSearchCommandSecretTargets({
+      config: {
+        models: {
+          providers: {
+            google: { apiKey: { source: "env", id: "GEMINI_API_KEY" } },
+          },
+        },
+      } as never,
+      provider: "tavily",
+    });
+    expect(unselected.targetIds.has("models.providers.*.apiKey")).toBe(false);
+    expect(unselected.allowedPaths).toEqual(new Set());
+
+    const configuredOnly = getWebSearchCommandSecretTargets({
+      config: {
+        tools: { web: { search: { provider: "gemini" } } },
+        models: {
+          providers: {
+            google: { apiKey: { source: "env", id: "GEMINI_API_KEY" } },
+          },
+        },
+      } as never,
+    });
+    expect(configuredOnly.targetIds.has("models.providers.*.apiKey")).toBe(true);
+    expect(configuredOnly.allowedPaths).toEqual(new Set(["models.providers.google.apiKey"]));
+
+    const externalOwner = getWebSearchCommandSecretTargets({
+      config: {
+        plugins: {
+          entries: {
+            serpapi: { config: { webSearch: { apiKey: { source: "env", id: "WRONG" } } } },
+            searchlab: { config: { webSearch: { apiKey: { source: "env", id: "SERP" } } } },
+          },
+        },
+      } as never,
+      provider: "serpapi",
+    });
+    expect(externalOwner.allowedPaths).toEqual(
+      new Set(["plugins.entries.searchlab.config.webSearch.apiKey"]),
+    );
+  });
+
+  it("selects same-plugin web search fallback credentials for web fetch providers", () => {
+    const selected = getWebFetchCommandSecretTargets({
+      config: {
+        tools: { web: { fetch: { provider: "firecrawl" } } },
+        plugins: {
+          entries: {
+            exa: { config: { webSearch: { apiKey: { source: "env", id: "EXA" } } } },
+            firecrawl: { config: { webSearch: { apiKey: { source: "env", id: "FC" } } } },
+          },
+        },
+      } as never,
+      provider: "firecrawl",
+    });
+
+    expect(selected.targetIds.has("plugins.entries.firecrawl.config.webFetch.apiKey")).toBe(true);
+    expect(selected.targetIds.has("plugins.entries.firecrawl.config.webSearch.apiKey")).toBe(true);
+    expect(selected.allowedPaths).toEqual(
+      new Set(["plugins.entries.firecrawl.config.webSearch.apiKey"]),
+    );
+
+    const configuredOnly = getWebFetchCommandSecretTargets({
+      config: {
+        tools: { web: { fetch: { provider: "firecrawl" } } },
+        plugins: {
+          entries: {
+            firecrawl: { config: { webSearch: { apiKey: { source: "env", id: "FC" } } } },
+          },
+        },
+      } as never,
+    });
+    expect(configuredOnly.targetIds.has("plugins.entries.firecrawl.config.webSearch.apiKey")).toBe(
+      true,
+    );
+    expect(configuredOnly.allowedPaths).toEqual(
+      new Set(["plugins.entries.firecrawl.config.webSearch.apiKey"]),
+    );
+
+    const fetchCredential = getWebFetchCommandSecretTargets({
+      config: {
+        tools: { web: { fetch: { provider: "firecrawl" } } },
+        plugins: {
+          entries: {
+            firecrawl: {
+              config: {
+                webFetch: { apiKey: { source: "env", id: "FC_FETCH" } },
+                webSearch: { apiKey: { source: "env", id: "FC_SEARCH" } },
+              },
+            },
+          },
+        },
+      } as never,
+      provider: "firecrawl",
+    });
+    expect(fetchCredential.targetIds.has("plugins.entries.firecrawl.config.webSearch.apiKey")).toBe(
+      false,
+    );
+    expect(fetchCredential.allowedPaths).toEqual(
+      new Set(["plugins.entries.firecrawl.config.webFetch.apiKey"]),
+    );
+
+    const externalOwner = getWebFetchCommandSecretTargets({
+      config: {
+        plugins: {
+          entries: {
+            pagefetch: { config: { webFetch: { apiKey: { source: "env", id: "WRONG" } } } },
+            readerlab: { config: { webFetch: { apiKey: { source: "env", id: "PAGE" } } } },
+          },
+        },
+      } as never,
+      provider: "pagefetch",
+    });
+    expect(externalOwner.allowedPaths).toEqual(
+      new Set(["plugins.entries.readerlab.config.webFetch.apiKey"]),
+    );
   });
 
   it("includes channel targets for agent runtime when delivery needs them", () => {

--- a/src/cli/command-secret-targets.ts
+++ b/src/cli/command-secret-targets.ts
@@ -1,12 +1,16 @@
 import { listReadOnlyChannelPluginsForConfig } from "../channels/plugins/read-only.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveManifestContractOwnerPluginId } from "../plugins/plugin-registry.js";
 import { normalizeOptionalAccountId } from "../routing/session-key.js";
 import { loadChannelSecretContractApi } from "../secrets/channel-contract-api.js";
 import {
   discoverConfigSecretTargetsByIds,
   listSecretTargetRegistryEntries,
 } from "../secrets/target-registry.js";
-import { normalizeOptionalString } from "../shared/string-coerce.js";
+import {
+  normalizeOptionalLowercaseString,
+  normalizeOptionalString,
+} from "../shared/string-coerce.js";
 
 const STATIC_QR_REMOTE_TARGET_IDS = ["gateway.remote.token", "gateway.remote.password"] as const;
 const STATIC_MODEL_TARGET_IDS = [
@@ -33,6 +37,17 @@ const STATIC_AGENT_RUNTIME_BASE_TARGET_IDS = [
   "skills.entries.*.apiKey",
   "tools.web.search.apiKey",
 ] as const;
+const STATIC_MEMORY_EMBEDDING_TARGET_IDS = [
+  ...STATIC_MODEL_TARGET_IDS,
+  "agents.defaults.memorySearch.remote.apiKey",
+  "agents.list[].memorySearch.remote.apiKey",
+] as const;
+const STATIC_TTS_TARGET_IDS = [
+  ...STATIC_MODEL_TARGET_IDS,
+  "agents.list[].tts.providers.*.apiKey",
+  "messages.tts.providers.*.apiKey",
+] as const;
+const STATIC_WEB_SEARCH_TARGET_IDS = ["tools.web.search.apiKey"] as const;
 const STATIC_STATUS_TARGET_IDS = [
   "agents.defaults.memorySearch.remote.apiKey",
   "agents.list[].memorySearch.remote.apiKey",
@@ -58,6 +73,11 @@ type CommandSecretTargets = {
   securityAudit: string[];
 };
 
+type CommandSecretTargetSelection = {
+  targetIds: Set<string>;
+  allowedPaths?: Set<string>;
+};
+
 let cachedCommandSecretTargets: CommandSecretTargets | undefined;
 let cachedAgentRuntimeBaseTargetIds: string[] | undefined;
 let cachedChannelSecretTargetIds: string[] | undefined;
@@ -67,13 +87,34 @@ function getChannelSecretTargetIds(): string[] {
   return cachedChannelSecretTargetIds;
 }
 
-function isPluginWebCredentialTargetId(id: string): boolean {
+function isPluginWebCredentialTargetId(id: string, configPathFilter?: string): boolean {
   const segments = id.split(".");
   if (segments[0] !== "plugins" || segments[1] !== "entries" || segments[3] !== "config") {
     return false;
   }
   const configPath = segments.slice(4).join(".");
+  if (configPathFilter) {
+    return configPath === configPathFilter;
+  }
   return configPath === "webSearch.apiKey" || configPath === "webFetch.apiKey";
+}
+
+function getPluginWebCredentialTargetIds(configPath: "webSearch.apiKey" | "webFetch.apiKey") {
+  return listSecretTargetRegistryEntries()
+    .map((entry) => entry.id)
+    .filter((id) => isPluginWebCredentialTargetId(id, configPath))
+    .toSorted();
+}
+
+function pluginIdFromWebCredentialPath(
+  path: string,
+  configPath: "webSearch.apiKey" | "webFetch.apiKey",
+): string | undefined {
+  const match = /^plugins\.entries\.([^.]+)\.config\.(webSearch|webFetch)\.apiKey$/.exec(path);
+  if (!match) {
+    return undefined;
+  }
+  return match[2] === configPath.split(".")[0] ? match[1] : undefined;
 }
 
 function getAgentRuntimeBaseTargetIds(): string[] {
@@ -81,7 +122,7 @@ function getAgentRuntimeBaseTargetIds(): string[] {
     ...STATIC_AGENT_RUNTIME_BASE_TARGET_IDS,
     ...listSecretTargetRegistryEntries()
       .map((entry) => entry.id)
-      .filter(isPluginWebCredentialTargetId)
+      .filter((id) => isPluginWebCredentialTargetId(id))
       .toSorted(),
   ];
   return cachedAgentRuntimeBaseTargetIds;
@@ -162,6 +203,16 @@ function toTargetIdSet(values: readonly string[]): Set<string> {
   return new Set(values);
 }
 
+function mergeTargetIdSets(...sets: ReadonlyArray<ReadonlySet<string>>): Set<string> {
+  const merged = new Set<string>();
+  for (const set of sets) {
+    for (const value of set) {
+      merged.add(value);
+    }
+  }
+  return merged;
+}
+
 function selectChannelTargetIds(channel?: string): Set<string> {
   const commandSecretTargets = getCommandSecretTargets();
   if (!channel) {
@@ -234,6 +285,195 @@ export function getConfiguredChannelsCommandSecretTargetIds(
 
 export function getModelsCommandSecretTargetIds(): Set<string> {
   return toTargetIdSet(STATIC_MODEL_TARGET_IDS);
+}
+
+export function getMemoryEmbeddingCommandSecretTargetIds(): Set<string> {
+  return toTargetIdSet(STATIC_MEMORY_EMBEDDING_TARGET_IDS);
+}
+
+export function getTtsCommandSecretTargetIds(): Set<string> {
+  return toTargetIdSet(STATIC_TTS_TARGET_IDS);
+}
+
+export function getWebSearchCommandSecretTargetIds(): Set<string> {
+  return toTargetIdSet([
+    ...STATIC_WEB_SEARCH_TARGET_IDS,
+    ...getPluginWebCredentialTargetIds("webSearch.apiKey"),
+  ]);
+}
+
+export function getWebFetchCommandSecretTargetIds(): Set<string> {
+  return toTargetIdSet(getPluginWebCredentialTargetIds("webFetch.apiKey"));
+}
+
+function getConfiguredWebProviderId(
+  config: OpenClawConfig,
+  kind: "search" | "fetch",
+): string | undefined {
+  const webConfig = config.tools?.web?.[kind];
+  return normalizeOptionalLowercaseString(
+    webConfig && typeof webConfig === "object" ? webConfig.provider : undefined,
+  );
+}
+
+function configuredTargetPaths(config: OpenClawConfig, targetIds: Set<string>): Set<string> {
+  return new Set(discoverConfigSecretTargetsByIds(config, targetIds).map((target) => target.path));
+}
+
+function modelProviderCredentialFallbackPathForWebSearchProvider(
+  providerId: string | undefined,
+): string | undefined {
+  switch (providerId) {
+    case "gemini":
+      return "models.providers.google.apiKey";
+    case "ollama":
+      return "models.providers.ollama.apiKey";
+    default:
+      return undefined;
+  }
+}
+
+function resolveSelectedWebProviderPluginId(params: {
+  config: OpenClawConfig;
+  providerId: string | undefined;
+  contract: "webSearchProviders" | "webFetchProviders";
+}): string | undefined {
+  if (!params.providerId) {
+    return undefined;
+  }
+  return (
+    resolveManifestContractOwnerPluginId({
+      config: params.config,
+      contract: params.contract,
+      value: params.providerId,
+    }) ?? params.providerId
+  );
+}
+
+function pathForPluginCredential(
+  paths: ReadonlySet<string>,
+  pluginId: string | undefined,
+  configPath: "webSearch.apiKey" | "webFetch.apiKey",
+): string | undefined {
+  if (!pluginId) {
+    return undefined;
+  }
+  for (const path of paths) {
+    if (pluginIdFromWebCredentialPath(path, configPath) === pluginId) {
+      return path;
+    }
+  }
+  return undefined;
+}
+
+export function getWebSearchCommandSecretTargets(params: {
+  config: OpenClawConfig;
+  provider?: string | null;
+}): CommandSecretTargetSelection {
+  const webSearchTargetIds = getWebSearchCommandSecretTargetIds();
+  const targetIds = new Set(webSearchTargetIds);
+  const providerId =
+    normalizeOptionalLowercaseString(params.provider) ??
+    getConfiguredWebProviderId(params.config, "search");
+  const webSearchPaths = configuredTargetPaths(params.config, webSearchTargetIds);
+  if (!providerId) {
+    return { targetIds, allowedPaths: webSearchPaths };
+  }
+
+  const allowedPaths = new Set<string>();
+  const selectedPluginId = resolveSelectedWebProviderPluginId({
+    config: params.config,
+    providerId,
+    contract: "webSearchProviders",
+  });
+  const pluginCredentialPath = pathForPluginCredential(
+    webSearchPaths,
+    selectedPluginId,
+    "webSearch.apiKey",
+  );
+  if (pluginCredentialPath) {
+    allowedPaths.add(pluginCredentialPath);
+    return { targetIds, allowedPaths };
+  }
+
+  const fallbackPath = modelProviderCredentialFallbackPathForWebSearchProvider(providerId);
+  if (fallbackPath) {
+    const modelPaths = configuredTargetPaths(params.config, getModelsCommandSecretTargetIds());
+    if (modelPaths.has(fallbackPath)) {
+      targetIds.add("models.providers.*.apiKey");
+      allowedPaths.add(fallbackPath);
+      return { targetIds, allowedPaths };
+    }
+  }
+
+  if (webSearchPaths.has("tools.web.search.apiKey")) {
+    allowedPaths.add("tools.web.search.apiKey");
+  }
+  return { targetIds, allowedPaths };
+}
+
+export function getWebFetchCommandSecretTargets(params: {
+  config: OpenClawConfig;
+  provider?: string | null;
+}): CommandSecretTargetSelection {
+  const webFetchTargetIds = getWebFetchCommandSecretTargetIds();
+  const webSearchTargetIds = getWebSearchCommandSecretTargetIds();
+  const webFetchPaths = configuredTargetPaths(params.config, webFetchTargetIds);
+  const webSearchPaths = configuredTargetPaths(params.config, webSearchTargetIds);
+  const providerId =
+    normalizeOptionalLowercaseString(params.provider) ??
+    getConfiguredWebProviderId(params.config, "fetch");
+  const selectedPluginId = resolveSelectedWebProviderPluginId({
+    config: params.config,
+    providerId,
+    contract: "webFetchProviders",
+  });
+  const webFetchPluginIds = new Set(
+    [...getPluginWebCredentialTargetIds("webFetch.apiKey")]
+      .map((id) => pluginIdFromWebCredentialPath(id, "webFetch.apiKey"))
+      .filter((id): id is string => Boolean(id)),
+  );
+  const candidatePluginIds = new Set<string>();
+  if (selectedPluginId) {
+    candidatePluginIds.add(selectedPluginId);
+  }
+  for (const path of webFetchPaths) {
+    const pluginId = pluginIdFromWebCredentialPath(path, "webFetch.apiKey");
+    if (!selectedPluginId && pluginId) {
+      candidatePluginIds.add(pluginId);
+    }
+  }
+  for (const path of webSearchPaths) {
+    const pluginId = pluginIdFromWebCredentialPath(path, "webSearch.apiKey");
+    if (!selectedPluginId && pluginId && webFetchPluginIds.has(pluginId)) {
+      candidatePluginIds.add(pluginId);
+    }
+  }
+
+  const allowedPaths = new Set<string>();
+  const pluginsWithFetchCredential = new Set<string>();
+  let hasWebSearchFallbackPath = false;
+  for (const path of webFetchPaths) {
+    const pluginId = pluginIdFromWebCredentialPath(path, "webFetch.apiKey");
+    if (!selectedPluginId || (pluginId && candidatePluginIds.has(pluginId))) {
+      allowedPaths.add(path);
+      if (pluginId) {
+        pluginsWithFetchCredential.add(pluginId);
+      }
+    }
+  }
+  for (const path of webSearchPaths) {
+    const pluginId = pluginIdFromWebCredentialPath(path, "webSearch.apiKey");
+    if (pluginId && candidatePluginIds.has(pluginId) && !pluginsWithFetchCredential.has(pluginId)) {
+      allowedPaths.add(path);
+      hasWebSearchFallbackPath = true;
+    }
+  }
+
+  const targetIds = hasWebSearchFallbackPath
+    ? mergeTargetIdSets(webFetchTargetIds, webSearchTargetIds)
+    : new Set(webFetchTargetIds);
+  return { targetIds, allowedPaths };
 }
 
 export function getAgentRuntimeCommandSecretTargetIds(params?: {

--- a/src/web-search/runtime-types.ts
+++ b/src/web-search/runtime-types.ts
@@ -17,6 +17,7 @@ export type ResolveWebSearchDefinitionParams = {
   runtimeWebSearch?: RuntimeWebSearchMetadata;
   providerId?: string;
   preferRuntimeProviders?: boolean;
+  preferInputConfig?: boolean;
 };
 
 export type RunWebSearchParams = ResolveWebSearchDefinitionParams & {

--- a/src/web-search/runtime.test.ts
+++ b/src/web-search/runtime.test.ts
@@ -138,11 +138,13 @@ describe("web search runtime", () => {
   let runWebSearch: typeof import("./runtime.js").runWebSearch;
   let activateSecretsRuntimeSnapshot: typeof import("../secrets/runtime.js").activateSecretsRuntimeSnapshot;
   let clearSecretsRuntimeSnapshot: typeof import("../secrets/runtime.js").clearSecretsRuntimeSnapshot;
+  let setRuntimeConfigSnapshot: typeof import("../config/config.js").setRuntimeConfigSnapshot;
 
   beforeAll(async () => {
     ({ runWebSearch } = await import("./runtime.js"));
     ({ activateSecretsRuntimeSnapshot, clearSecretsRuntimeSnapshot } =
       await import("../secrets/runtime.js"));
+    ({ setRuntimeConfigSnapshot } = await import("../config/config.js"));
   });
 
   beforeEach(() => {
@@ -323,6 +325,45 @@ describe("web search runtime", () => {
       provider: "custom",
       result: {
         query: "runtime-source",
+        apiKey: "resolved-custom-key",
+      },
+    });
+  });
+
+  it("can prefer an explicitly resolved input config over a pinned config snapshot", async () => {
+    const provider = createCustomSearchProvider({
+      createTool: ({ config }) => ({
+        description: "custom",
+        parameters: {},
+        execute: async (args) => ({
+          ...args,
+          apiKey: getCustomSearchApiKey(config),
+        }),
+      }),
+    });
+    resolveRuntimeWebSearchProvidersMock.mockReturnValue([provider]);
+    resolvePluginWebSearchProvidersMock.mockReturnValue([provider]);
+
+    setRuntimeConfigSnapshot(
+      createCustomSearchConfig({
+        source: "env",
+        provider: "default",
+        id: "CUSTOM_SEARCH_API_KEY",
+      }),
+    );
+
+    await expect(
+      runWebSearch({
+        config: createCustomSearchConfig("resolved-custom-key"),
+        preferInputConfig: true,
+        providerId: "custom",
+        preferRuntimeProviders: false,
+        args: { query: "resolved-input" },
+      }),
+    ).resolves.toEqual({
+      provider: "custom",
+      result: {
+        query: "resolved-input",
         apiKey: "resolved-custom-key",
       },
     });

--- a/src/web-search/runtime.ts
+++ b/src/web-search/runtime.ts
@@ -49,9 +49,15 @@ function resolveSearchConfig(cfg?: OpenClawConfig): WebSearchConfig {
   return resolveWebProviderConfig(cfg, "search") as NonNullable<WebSearchConfig> | undefined;
 }
 
-function resolveWebSearchRuntimeConfig(config?: OpenClawConfig): OpenClawConfig | undefined {
+function resolveWebSearchRuntimeConfig(params?: {
+  config?: OpenClawConfig;
+  preferInputConfig?: boolean;
+}): OpenClawConfig | undefined {
+  if (params?.preferInputConfig && params.config) {
+    return params.config;
+  }
   return selectApplicableRuntimeConfig({
-    inputConfig: config,
+    inputConfig: params?.config,
     runtimeConfig: getRuntimeConfigSnapshot(),
     runtimeSourceConfig: getRuntimeConfigSourceSnapshot(),
   });
@@ -111,14 +117,14 @@ export function isWebSearchProviderConfigured(params: {
   >;
   config?: OpenClawConfig;
 }): boolean {
-  const config = resolveWebSearchRuntimeConfig(params.config);
+  const config = resolveWebSearchRuntimeConfig({ config: params.config });
   return hasEntryCredential(params.provider, config, resolveSearchConfig(config));
 }
 
 export function listWebSearchProviders(params?: {
   config?: OpenClawConfig;
 }): PluginWebSearchProviderEntry[] {
-  const config = resolveWebSearchRuntimeConfig(params?.config);
+  const config = resolveWebSearchRuntimeConfig({ config: params?.config });
   return resolveRuntimeWebSearchProviders({
     config,
     bundledAllowlistCompat: true,
@@ -128,7 +134,7 @@ export function listWebSearchProviders(params?: {
 export function listConfiguredWebSearchProviders(params?: {
   config?: OpenClawConfig;
 }): PluginWebSearchProviderEntry[] {
-  const config = resolveWebSearchRuntimeConfig(params?.config);
+  const config = resolveWebSearchRuntimeConfig({ config: params?.config });
   return resolvePluginWebSearchProviders({
     config,
     bundledAllowlistCompat: true,
@@ -140,7 +146,7 @@ export function resolveWebSearchProviderId(params: {
   config?: OpenClawConfig;
   providers?: PluginWebSearchProviderEntry[];
 }): string {
-  const config = resolveWebSearchRuntimeConfig(params.config);
+  const config = resolveWebSearchRuntimeConfig({ config: params.config });
   const search = params.search ?? resolveSearchConfig(config);
   const providers = sortWebSearchProvidersForAutoDetect(
     params.providers ??
@@ -248,7 +254,10 @@ function resolveWebSearchProviderLoadScope(params: {
 export function resolveWebSearchDefinition(
   options?: ResolveWebSearchDefinitionParams,
 ): { provider: PluginWebSearchProviderEntry; definition: WebSearchProviderToolDefinition } | null {
-  const config = resolveWebSearchRuntimeConfig(options?.config);
+  const config = resolveWebSearchRuntimeConfig({
+    config: options?.config,
+    preferInputConfig: options?.preferInputConfig,
+  });
   const search = resolveSearchConfig(config);
   const runtimeWebSearch = options?.runtimeWebSearch ?? getActiveRuntimeWebToolsMetadata()?.search;
   const loadScope = resolveWebSearchProviderLoadScope({
@@ -307,7 +316,10 @@ export function resolveWebSearchDefinition(
 function resolveWebSearchCandidates(
   options?: ResolveWebSearchDefinitionParams,
 ): PluginWebSearchProviderEntry[] {
-  const config = resolveWebSearchRuntimeConfig(options?.config);
+  const config = resolveWebSearchRuntimeConfig({
+    config: options?.config,
+    preferInputConfig: options?.preferInputConfig,
+  });
   const search = resolveSearchConfig(config);
   const runtimeWebSearch = options?.runtimeWebSearch ?? getActiveRuntimeWebToolsMetadata()?.search;
   if (!resolveWebSearchEnabled({ search, sandboxed: options?.sandboxed })) {
@@ -402,7 +414,10 @@ function isStructuredAvailabilityError(result: unknown): result is { error: stri
 }
 
 export async function runWebSearch(params: RunWebSearchParams): Promise<RunWebSearchResult> {
-  const config = resolveWebSearchRuntimeConfig(params.config);
+  const config = resolveWebSearchRuntimeConfig({
+    config: params.config,
+    preferInputConfig: params.preferInputConfig,
+  });
   const search = resolveSearchConfig(config);
   const runtimeWebSearch = params.runtimeWebSearch ?? getActiveRuntimeWebToolsMetadata()?.search;
   const candidates = resolveWebSearchCandidates({


### PR DESCRIPTION
## Summary

- Problem: local `infer` provider-backed commands could instantiate providers against raw config before command SecretRefs were resolved.
- Why it matters: plugin-scoped web search/fetch credential refs could pass `secrets audit` but fail at runtime with unresolved SecretRef errors.
- What changed: resolve command SecretRefs before local provider execution, scope web credential targets to the selected provider/fallback, and let web search use the explicitly resolved CLI config.
- What did NOT change: no legacy config migration and no successful live Tavily query is claimed without a real key.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #82621
- [x] This PR fixes a bug or regression

## Real behavior proof

Behavior addressed: CLI web search resolves plugin-scoped `webSearch.apiKey` SecretRefs before invoking the local provider.

Real environment tested: AWS Crabbox Linux, provider `aws`, lease `cbx_b66e354b1546`, run `run_71a9ceeecc03`, isolated OpenClaw config and gateway.

Exact steps or command run after this patch: configured Tavily plugin `plugins.entries.tavily.config.webSearch.apiKey` as an env SecretRef, started a local gateway, then ran `infer web search --provider tavily --query ping --limit 1 --json` using a dummy `TAVILY_API_KEY`.

Evidence after fix: AWS proof output showed `ASSERT_UNRESOLVED_SECRETREF=absent` and `GATEWAY_SECRETS_RESOLVE_SEEN=1`; the command reached Tavily and returned `401 Unauthorized: missing or invalid API key`, which is expected for the dummy key.

Observed result after fix: the command crossed the SecretRef resolution boundary and failed only at provider auth with the intentionally fake key.

What was not tested: a successful live Tavily result with a real Tavily API key.

Before evidence: current-main AWS repro on `bea4f0d2f4b48ddd62db45970e513441e9af8f98` failed with `unresolved SecretRef "env:default:TAVILY_API_KEY"` while `secrets audit` reported `unresolved=0`.

## Root Cause

- Root cause: local provider-backed `infer` paths read raw `getRuntimeConfig()` and constructed providers directly, bypassing the command SecretRef resolver used by other command surfaces.
- Missing detection / guardrail: command-secret resolution coverage did not include `src/cli/capability-cli.ts`, and web search runtime could prefer a stale runtime snapshot over the resolved CLI config.
- Contributing context: web search/fetch need provider-specific credential target scoping so unrelated configured refs do not block a selected provider.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [x] End-to-end test
- Target test or file: `src/cli/capability-cli.test.ts`, `src/cli/command-secret-targets.test.ts`, `src/web-search/runtime.test.ts`, `src/cli/command-secret-resolution.coverage.test.ts`.
- Scenario the test should lock in: local `infer` commands resolve command SecretRefs before provider construction and web search/fetch target only selected-provider credential paths.
- Why this is the smallest reliable guardrail: it exercises the CLI boundary, command target selection, and web-search runtime snapshot behavior without requiring a live provider key.
- Existing test that already covers this (if any): none covered this exact local `infer` SecretRef bypass.

## User-visible / Behavior Changes

Local `infer` provider-backed commands can now use command SecretRefs before provider execution. Web search/fetch plugin-scoped credentials work through the selected provider path.

## Diagram

```text
Before:
infer web search -> raw config -> provider reads unresolved SecretRef -> failure

After:
infer web search -> command SecretRef resolver -> resolved config -> provider auth/network
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? Yes
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: command-scoped SecretRefs are resolved earlier for local provider execution using the existing command resolver and selected-provider `allowedPaths`, limiting resolution to the relevant credential paths.

## Repro + Verification

### Environment

- OS: macOS local targeted tests; Linux AWS Crabbox and Blacksmith Testbox remote proof
- Runtime/container: Node 22, pnpm 11.1.0
- Model/provider: Tavily web search with dummy key for auth-boundary proof
- Integration/channel (if any): Web search
- Relevant config (redacted): Tavily plugin `webSearch.apiKey` as env SecretRef `TAVILY_API_KEY`

### Steps

1. Configure plugin-scoped Tavily `webSearch.apiKey` as an env SecretRef.
2. Start the gateway from that config.
3. Run `infer web search --provider tavily --query ping --limit 1 --json`.

### Expected

- No unresolved SecretRef error; with a dummy key, provider auth should fail after resolution.

### Actual

- AWS proof returned Tavily 401 for the dummy key, with unresolved SecretRef absent and `secrets.resolve` observed in gateway logs.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: focused local tests, Testbox `pnpm check:changed`, AWS E2E reproduction of the CLI/gateway/provider path.
- Edge cases checked: selected provider credential scoping, Gemini model-provider fallback, Firecrawl webFetch/webSearch fallback, external provider owner mapping, stale web-search runtime snapshot handling.
- What you did **not** verify: successful Tavily live search with a real key.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: resolving too many unrelated credential refs for web commands could block selected-provider usage.
  - Mitigation: web search/fetch target selection now scopes `allowedPaths` to selected provider credentials and known same-provider fallbacks.
