### PR TITLE
Fix Windows image model event loop stalls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,7 @@ Docs: https://docs.openclaw.ai
 - Task persistence: drop malformed array/scalar requester-origin JSON from task and task-flow SQLite sidecars instead of restoring it as delivery metadata.
 - Agents/timeouts: clarify model idle-timeout errors and docs so provider `timeoutSeconds` is shown as bounded by the whole agent/run timeout ceiling.
 - Agents/OpenAI streams: yield cooperatively while processing bursty Completions and Responses chunks, keeping aborts, channel liveness timers, and startup heartbeats responsive under noisy model output. Refs #82462.
+- Media/images: avoid broad model/plugin discovery while preparing image requests, preventing Windows event-loop stalls that could block Telegram polling. Fixes #82338. (#82799) Thanks @joshavant.
 - Release tooling: align the published launcher Node floor, `npm start`, package script checks, sharded lint locking, Vitest root project coverage, and plugin-SDK declaration build cache metadata so release/package validation does not silently skip or ship stale surfaces.
 - Cron/agents: honor configured subagent model fallbacks for isolated scheduled runs and forward that fallback policy into embedded agent timeout failover. Fixes #74985. Thanks @chrisgwynne.
 - Codex app-server/MCP: scope user MCP servers to specific OpenClaw agent ids through an optional `mcp.servers.<name>.codex.agents` list and accept `codex.defaultToolsApprovalMode` (`auto`/`prompt`/`approve`) for native Codex approval defaults; OpenClaw strips the `codex` block before handing `mcp_servers` config to Codex. (#82180) Thanks @sercada.

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -516,6 +516,57 @@ describe("resolveModel", () => {
     expect(discoverModels).not.toHaveBeenCalled();
   });
 
+  it("applies provider overrides to bundled static catalog rows while skipping PI discovery", async () => {
+    resolveBundledStaticCatalogModelMock.mockReturnValueOnce({
+      provider: "mistral",
+      id: "mistral-medium-3-5",
+      name: "Mistral Medium 3.5",
+      api: "openai-completions",
+      baseUrl: "https://api.mistral.ai/v1",
+      input: ["text", "image"],
+      contextWindow: 262144,
+      maxTokens: 8192,
+    });
+    const cfg = {
+      models: {
+        providers: {
+          mistral: {
+            baseUrl: "https://mistral-proxy.example.com/v1",
+            api: "openai-completions",
+            headers: { "X-Proxy": "static-fast-path" },
+            request: { proxy: { mode: "explicit-proxy", url: "http://127.0.0.1:18080" } },
+            localService: {
+              command: "/opt/mistral/start",
+              args: ["--port", "18080"],
+              healthUrl: "http://127.0.0.1:18080/health",
+            },
+            models: [],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = await resolveModelAsync("mistral", "mistral-medium-3-5", "/tmp/agent", cfg, {
+      allowBundledStaticCatalogFallback: true,
+      runtimeHooks: createRuntimeHooks(),
+      skipPiDiscovery: true,
+    });
+    const model = expectResolvedModel(result);
+
+    expect(model.baseUrl).toBe("https://mistral-proxy.example.com/v1");
+    expect(model.headers).toEqual({ "X-Proxy": "static-fast-path" });
+    expect(getModelProviderRequestTransport(model)).toEqual({
+      proxy: { mode: "explicit-proxy", url: "http://127.0.0.1:18080" },
+    });
+    expect(getModelProviderLocalService(model)).toEqual({
+      command: "/opt/mistral/start",
+      args: ["--port", "18080"],
+      healthUrl: "http://127.0.0.1:18080/health",
+    });
+    expect(discoverAuthStorage).not.toHaveBeenCalled();
+    expect(discoverModels).not.toHaveBeenCalled();
+  });
+
   it("does not use bundled static catalog rows unless the caller opts in", async () => {
     const result = await resolveModelAsync(
       "mistral",

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -1212,12 +1212,22 @@ export async function resolveModelAsync(
       workspaceDir,
     });
     if (staticCatalogModel) {
+      const overriddenStaticCatalogModel = applyConfiguredProviderOverrides({
+        provider: normalizedRef.provider,
+        discoveredModel: staticCatalogModel,
+        providerConfig,
+        modelId: normalizedRef.model,
+        cfg,
+        runtimeHooks,
+        workspaceDir,
+        preferDiscoveredModelMetadata: true,
+      });
       model = normalizeResolvedModel({
         provider: normalizedRef.provider,
         cfg,
         agentDir: resolvedAgentDir,
         workspaceDir,
-        model: staticCatalogModel,
+        model: overriddenStaticCatalogModel,
         runtimeHooks,
       });
     }

--- a/src/agents/provider-stream.ts
+++ b/src/agents/provider-stream.ts
@@ -11,6 +11,7 @@ export function registerProviderStreamForModel<TApi extends Api>(params: {
   agentDir?: string;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  allowRuntimePluginLoad?: boolean;
 }): StreamFn | undefined {
   const streamFn =
     resolveProviderStreamFn({
@@ -18,6 +19,7 @@ export function registerProviderStreamForModel<TApi extends Api>(params: {
       config: params.cfg,
       workspaceDir: params.workspaceDir,
       env: params.env,
+      allowRuntimePluginLoad: params.allowRuntimePluginLoad,
       context: {
         config: params.cfg,
         agentDir: params.agentDir,

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -283,6 +283,7 @@ async function runImagePrompt(params: {
   modelOverride?: string;
   prompt: string;
   images: Array<{ buffer: Buffer; mimeType: string }>;
+  workspaceDir?: string;
 }): Promise<{
   text: string;
   provider: string;
@@ -326,6 +327,7 @@ async function runImagePrompt(params: {
           timeoutMs,
           cfg: providerCfg,
           agentDir: params.agentDir,
+          ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
         });
         return { text: described.text, provider, model: described.model ?? modelId };
       }
@@ -344,6 +346,7 @@ async function runImagePrompt(params: {
           timeoutMs,
           cfg: providerCfg,
           agentDir: params.agentDir,
+          ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
         });
         return { text: described.text, provider, model: described.model ?? modelId };
       }
@@ -361,6 +364,7 @@ async function runImagePrompt(params: {
           timeoutMs,
           cfg: providerCfg,
           agentDir: params.agentDir,
+          ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
         });
         parts.push(`Image ${index + 1}:\n${described.text.trim()}`);
       }
@@ -658,6 +662,7 @@ export function createImageTool(options?: {
         modelOverride,
         prompt: promptRaw,
         images: loadedImages.map((img) => ({ buffer: img.buffer, mimeType: img.mimeType })),
+        workspaceDir: options?.workspaceDir,
       });
 
       const imageDetails =

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -6,7 +6,7 @@ import {
   isSessionIdentityPending,
   resolveSessionIdentityFromMeta,
 } from "../../acp/runtime/session-identity.js";
-import { resolveAgentDir } from "../../agents/agent-scope.js";
+import { resolveAgentDir, resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
 import { logVerbose } from "../../globals.js";
@@ -463,6 +463,7 @@ export async function tryDispatchAcpReply(params: {
           ctx: params.ctx,
           cfg: params.cfg,
           agentDir: resolveAgentDir(params.cfg, acpAgentId),
+          workspaceDir: resolveAgentWorkspaceDir(params.cfg, acpAgentId),
         });
       } catch (err) {
         logVerbose(

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -163,6 +163,7 @@ async function applyMediaUnderstandingIfNeeded(params: {
   ctx: MsgContext;
   cfg: OpenClawConfig;
   agentDir?: string;
+  workspaceDir?: string;
   activeModel: { provider: string; model: string };
 }): Promise<boolean> {
   if (!hasInboundMedia(params.ctx)) {
@@ -355,6 +356,7 @@ export async function getReplyFromConfig(
         ctx: finalized,
         cfg,
         agentDir,
+        workspaceDir,
         activeModel: { provider, model },
       }),
     );

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -991,6 +991,56 @@ describe("applyMediaUnderstanding", () => {
     expect(ctx.Body).toBe("[Image]\nDescription:\nshared description");
   });
 
+  it("uses media workspace for staged files and agent workspace for provider resolution", async () => {
+    const mediaWorkspaceDir = await createTempMediaDir();
+    const relativeImagePath = path.join("media", "inbound", "workspace.jpg");
+    const imagePath = path.join(mediaWorkspaceDir, relativeImagePath);
+    await fs.mkdir(path.dirname(imagePath), { recursive: true });
+    await fs.writeFile(imagePath, "image-bytes");
+    const describeImage = vi.fn(async () => ({ text: "workspace image" }));
+    const ctx: MsgContext = {
+      Body: "<media:image>",
+      MediaPath: relativeImagePath,
+      MediaType: "image/jpeg",
+      MediaWorkspaceDir: mediaWorkspaceDir,
+    };
+    const cfg: OpenClawConfig = {
+      tools: {
+        media: {
+          image: {
+            enabled: true,
+            models: [{ provider: "openai", model: "gpt-5.4" }],
+          },
+        },
+      },
+    };
+
+    const result = await applyMediaUnderstanding({
+      ctx,
+      cfg,
+      agentDir: "/tmp/openclaw-agent",
+      workspaceDir: "/tmp/openclaw-workspace",
+      providers: {
+        openai: {
+          id: "openai",
+          capabilities: ["image"],
+          describeImage,
+        },
+      },
+    });
+
+    expect(result.appliedImage).toBe(true);
+    expect(describeImage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentDir: "/tmp/openclaw-agent",
+        workspaceDir: "/tmp/openclaw-workspace",
+        fileName: "workspace.jpg",
+        provider: "openai",
+        model: "gpt-5.4",
+      }),
+    );
+  });
+
   it("uses active model when enabled and models are missing", async () => {
     const audioPath = await createTempMediaFile({
       fileName: "fallback.ogg",

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -523,10 +523,12 @@ export async function applyMediaUnderstanding(params: {
   ctx: MsgContext;
   cfg: OpenClawConfig;
   agentDir?: string;
+  workspaceDir?: string;
   providers?: Record<string, MediaUnderstandingProvider>;
   activeModel?: ActiveMediaModel;
 }): Promise<ApplyMediaUnderstandingResult> {
   const { ctx, cfg } = params;
+  const mediaWorkspaceDir = ctx.MediaWorkspaceDir ?? params.workspaceDir;
   const commandCandidates = [ctx.CommandBody, ctx.RawBody, ctx.Body];
   const originalUserText =
     commandCandidates
@@ -536,9 +538,13 @@ export async function applyMediaUnderstanding(params: {
   const attachments = normalizeMediaAttachments(ctx);
   const providerRegistry = buildProviderRegistry(params.providers, cfg);
   const cache = createMediaAttachmentCache(attachments, {
-    localPathRoots: resolveMediaAttachmentLocalRoots({ cfg, ctx }),
+    localPathRoots: resolveMediaAttachmentLocalRoots({
+      cfg,
+      ctx,
+      workspaceDir: params.workspaceDir,
+    }),
     ssrfPolicy: cfg.tools?.web?.fetch?.ssrfPolicy,
-    workspaceDir: ctx.MediaWorkspaceDir,
+    workspaceDir: mediaWorkspaceDir,
   });
 
   try {
@@ -551,6 +557,7 @@ export async function applyMediaUnderstanding(params: {
         attachments: cache,
         media: attachments,
         agentDir: params.agentDir,
+        workspaceDir: params.workspaceDir,
         providerRegistry,
         config,
         activeModel: params.activeModel,

--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -218,7 +218,7 @@ describe("describeImageWithModel", () => {
       text: "portal ok",
       model: "MiniMax-VL-01",
     });
-    expect(ensureOpenClawModelsJsonMock).toHaveBeenCalled();
+    expect(ensureOpenClawModelsJsonMock).not.toHaveBeenCalled();
     const authRequest = getApiKeyForModelCall();
     expect(authRequest?.store).toBe(authStore);
     expect(requireApiKeyMock).toHaveBeenCalled();
@@ -297,10 +297,237 @@ describe("describeImageWithModel", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("passes workspaceDir through MiniMax VLM fallback auth", async () => {
+    const authStorage = {
+      setRuntimeApiKey: setRuntimeApiKeyMock,
+    };
+    resolveModelAsyncMock.mockResolvedValue({
+      authStorage,
+      modelRegistry: { find: vi.fn(() => null) },
+      error: "Unknown model: minimax-portal/MiniMax-VL-01",
+    });
+
+    await expect(
+      describeImageWithModel({
+        cfg: {},
+        agentDir: "/tmp/openclaw-agent",
+        workspaceDir: "/tmp/openclaw-workspace",
+        provider: "minimax-portal",
+        model: "MiniMax-VL-01",
+        buffer: Buffer.from("png-bytes"),
+        fileName: "image.png",
+        mime: "image/png",
+        prompt: "Describe the image.",
+        timeoutMs: 1000,
+      }),
+    ).resolves.toEqual({
+      text: "portal ok",
+      model: "MiniMax-VL-01",
+    });
+
+    expect(resolveApiKeyForProviderMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "minimax-portal",
+        agentDir: "/tmp/openclaw-agent",
+        workspaceDir: "/tmp/openclaw-workspace",
+      }),
+    );
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("carries workspaceDir through image model and stream resolution", async () => {
+    discoverModelsMock.mockReturnValue({
+      find: vi.fn(() => ({
+        provider: "google",
+        id: "gemini-2.5-flash",
+        api: "google-generative-ai",
+        input: ["text", "image"],
+      })),
+    });
+    completeMock.mockResolvedValue({
+      role: "assistant",
+      api: "google-generative-ai",
+      provider: "google",
+      model: "gemini-2.5-flash",
+      stopReason: "stop",
+      timestamp: Date.now(),
+      content: [{ type: "text", text: "workspace ok" }],
+    });
+
+    const result = await describeImageWithModel({
+      cfg: {},
+      agentDir: "/tmp/openclaw-agent",
+      workspaceDir: "/tmp/openclaw-workspace",
+      provider: "google",
+      model: "gemini-2.5-flash",
+      buffer: Buffer.from("png-bytes"),
+      fileName: "image.png",
+      mime: "image/png",
+      prompt: "Describe the image.",
+      timeoutMs: 1000,
+    });
+
+    expect(result.text).toBe("workspace ok");
+    expect(ensureOpenClawModelsJsonMock).not.toHaveBeenCalled();
+    expect(resolveModelAsyncMock).toHaveBeenCalledWith(
+      "google",
+      "gemini-2.5-flash",
+      "/tmp/openclaw-agent",
+      {},
+      {
+        allowBundledStaticCatalogFallback: true,
+        skipPiDiscovery: true,
+        skipProviderRuntimeHooks: true,
+        workspaceDir: "/tmp/openclaw-workspace",
+      },
+    );
+    expect(registerProviderStreamForModelMock).toHaveBeenCalledWith({
+      model: {
+        provider: "google",
+        id: "gemini-2.5-flash",
+        api: "google-generative-ai",
+        input: ["text", "image"],
+      },
+      cfg: {},
+      agentDir: "/tmp/openclaw-agent",
+      workspaceDir: "/tmp/openclaw-workspace",
+    });
+  });
+
+  it("applies provider normalization before using a fast image model match", async () => {
+    const authStorage = {
+      setRuntimeApiKey: setRuntimeApiKeyMock,
+    };
+    resolveModelAsyncMock
+      .mockResolvedValueOnce({
+        authStorage,
+        model: {
+          provider: "openai",
+          id: "gpt-5.4",
+          api: "openai-completions",
+          input: ["text", "image"],
+        },
+      })
+      .mockResolvedValueOnce({
+        authStorage,
+        model: {
+          provider: "openai",
+          id: "gpt-5.4",
+          api: "openai-responses",
+          input: ["text", "image"],
+        },
+      });
+    completeMock.mockResolvedValue({
+      role: "assistant",
+      api: "openai-responses",
+      provider: "openai",
+      model: "gpt-5.4",
+      stopReason: "stop",
+      timestamp: Date.now(),
+      content: [{ type: "text", text: "normalized ok" }],
+    });
+
+    const result = await describeImageWithModel({
+      cfg: {},
+      agentDir: "/tmp/openclaw-agent",
+      provider: "openai",
+      model: "gpt-5.4",
+      buffer: Buffer.from("png-bytes"),
+      fileName: "image.png",
+      mime: "image/png",
+      prompt: "Describe the image.",
+      timeoutMs: 1000,
+    });
+
+    expect(result).toEqual({
+      text: "normalized ok",
+      model: "gpt-5.4",
+    });
+    expect(ensureOpenClawModelsJsonMock).not.toHaveBeenCalled();
+    expect(resolveModelAsyncMock).toHaveBeenNthCalledWith(
+      1,
+      "openai",
+      "gpt-5.4",
+      "/tmp/openclaw-agent",
+      {},
+      {
+        allowBundledStaticCatalogFallback: true,
+        skipPiDiscovery: true,
+        skipProviderRuntimeHooks: true,
+      },
+    );
+    expect(resolveModelAsyncMock).toHaveBeenNthCalledWith(
+      2,
+      "openai",
+      "gpt-5.4",
+      "/tmp/openclaw-agent",
+      {},
+      {
+        allowBundledStaticCatalogFallback: true,
+        skipPiDiscovery: true,
+      },
+    );
+    const [completeModel] = requireFirstMockCall(completeMock, "complete");
+    expect(requireRecord(completeModel, "complete model").api).toBe("openai-responses");
+  });
+
+  it("uses plugin stream hooks when available for image models", async () => {
+    discoverModelsMock.mockReturnValue({
+      find: vi.fn(() => ({
+        provider: "ollama",
+        id: "llava:latest",
+        api: "ollama",
+        input: ["text", "image"],
+      })),
+    });
+    const streamResult = {
+      result: vi.fn(async () => ({
+        role: "assistant",
+        api: "ollama",
+        provider: "ollama",
+        model: "llava:latest",
+        stopReason: "stop",
+        timestamp: Date.now(),
+        content: [{ type: "text", text: "plugin vision ok" }],
+      })),
+    };
+    const streamFn = vi.fn(() => streamResult);
+    registerProviderStreamForModelMock.mockReturnValueOnce(streamFn);
+
+    const result = await describeImageWithModel({
+      cfg: {},
+      agentDir: "/tmp/openclaw-agent",
+      provider: "ollama",
+      model: "llava:latest",
+      buffer: Buffer.from("png-bytes"),
+      fileName: "image.png",
+      mime: "image/png",
+      prompt: "Describe the image.",
+      timeoutMs: 1000,
+    });
+
+    expect(result).toEqual({
+      text: "plugin vision ok",
+      model: "llava:latest",
+    });
+    expect(registerProviderStreamForModelMock).toHaveBeenCalledWith({
+      model: {
+        provider: "ollama",
+        id: "llava:latest",
+        api: "ollama",
+        input: ["text", "image"],
+      },
+      cfg: {},
+      agentDir: "/tmp/openclaw-agent",
+    });
+    expect(streamFn).toHaveBeenCalledOnce();
+    expect(completeMock).not.toHaveBeenCalled();
+  });
+
   it("resolves configured image models when discovery has not registered the provider", async () => {
     const registryFind = vi.fn(() => null);
     discoverModelsMock.mockReturnValue({ find: registryFind });
-    resolveModelWithRegistryMock.mockImplementationOnce(
+    resolveModelWithRegistryMock.mockImplementation(
       ({ provider, modelId }: ResolveModelWithRegistryTestParams) => ({
         provider,
         id: modelId,
@@ -684,7 +911,7 @@ describe("describeImageWithModel", () => {
 
   it("rejects when image runtime setup exceeds the request timeout", async () => {
     vi.useFakeTimers();
-    ensureOpenClawModelsJsonMock.mockImplementationOnce(() => new Promise(() => {}));
+    resolveModelAsyncMock.mockImplementationOnce(() => new Promise(() => {}));
 
     const result = describeImageWithModel({
       cfg: {},
@@ -743,7 +970,7 @@ describe("describeImageWithModel", () => {
       text: "flash ok",
       model: "gemini-3-flash-preview",
     });
-    expect(findMock).toHaveBeenCalledOnce();
+    expect(findMock).toHaveBeenCalled();
     const authRequest = getApiKeyForModelCall();
     expect(authRequest?.profileId).toBe("google:default");
     expect(setRuntimeApiKeyMock).toHaveBeenCalledWith("google", "oauth-test");
@@ -788,7 +1015,7 @@ describe("describeImageWithModel", () => {
       text: "flash lite ok",
       model: "gemini-3.1-flash-lite-preview",
     });
-    expect(findMock).toHaveBeenCalledOnce();
+    expect(findMock).toHaveBeenCalled();
     const authRequest = getApiKeyForModelCall();
     expect(authRequest?.profileId).toBe("google:default");
     expect(setRuntimeApiKeyMock).toHaveBeenCalledWith("google", "oauth-test");

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -142,9 +142,44 @@ async function resolveImageRuntime(params: {
   profile?: string;
   preferredProfile?: string;
   authStore?: ImageDescriptionRequest["authStore"];
+  workspaceDir?: string;
 }): Promise<{ apiKey: string; model: Model<Api> }> {
-  await ensureOpenClawModelsJson(params.cfg, params.agentDir);
   const resolvedRef = normalizeModelRef(params.provider, params.model);
+  const fastResolved = await resolveModelAsync(
+    resolvedRef.provider,
+    resolvedRef.model,
+    params.agentDir,
+    params.cfg,
+    {
+      allowBundledStaticCatalogFallback: true,
+      skipPiDiscovery: true,
+      skipProviderRuntimeHooks: true,
+      ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+    },
+  );
+  if (fastResolved.model?.input?.includes("image")) {
+    const normalizedResolved = await resolveModelAsync(
+      resolvedRef.provider,
+      resolvedRef.model,
+      params.agentDir,
+      params.cfg,
+      {
+        allowBundledStaticCatalogFallback: true,
+        skipPiDiscovery: true,
+        ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+      },
+    );
+    if (normalizedResolved.model?.input?.includes("image")) {
+      return await prepareResolvedImageRuntime(
+        params,
+        normalizedResolved.model,
+        normalizedResolved.authStorage,
+      );
+    }
+  }
+
+  const modelsOptions = params.workspaceDir ? { workspaceDir: params.workspaceDir } : undefined;
+  await ensureOpenClawModelsJson(params.cfg, params.agentDir, modelsOptions);
   const resolved = await resolveModelAsync(
     resolvedRef.provider,
     resolvedRef.model,
@@ -152,6 +187,7 @@ async function resolveImageRuntime(params: {
     params.cfg,
     {
       allowBundledStaticCatalogFallback: true,
+      ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
     },
   );
   const { authStorage } = resolved;
@@ -172,10 +208,29 @@ async function resolveImageRuntime(params: {
         `(resolved ${model.provider}/${model.id} input: ${formatModelInputCapabilities(model.input)})`,
     );
   }
+  return await prepareResolvedImageRuntime(params, model, authStorage);
+}
+
+async function prepareResolvedImageRuntime(
+  params: {
+    cfg: ImageDescriptionRequest["cfg"];
+    agentDir: string;
+    provider: string;
+    model: string;
+    profile?: string;
+    preferredProfile?: string;
+    authStore?: ImageDescriptionRequest["authStore"];
+    workspaceDir?: string;
+  },
+  resolvedModel: Model<Api>,
+  authStorage: Awaited<ReturnType<typeof resolveModelAsync>>["authStorage"],
+): Promise<{ apiKey: string; model: Model<Api> }> {
+  let model = resolvedModel;
   const apiKeyInfo = await getApiKeyForModel({
     model,
     cfg: params.cfg,
     agentDir: params.agentDir,
+    ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
     profileId: params.profile,
     preferredProfile: params.preferredProfile,
     store: params.authStore,
@@ -305,6 +360,7 @@ function resolveConfiguredProviderBaseUrl(
 async function resolveMinimaxVlmFallbackRuntime(params: {
   cfg: ImageDescriptionRequest["cfg"];
   agentDir: string;
+  workspaceDir?: string;
   provider: string;
   profile?: string;
   preferredProfile?: string;
@@ -315,6 +371,7 @@ async function resolveMinimaxVlmFallbackRuntime(params: {
     profileId: params.profile,
     preferredProfile: params.preferredProfile,
     agentDir: params.agentDir,
+    ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
   });
   return {
     apiKey: requireApiKey(auth, params.provider),
@@ -403,6 +460,7 @@ async function describeImagesWithModelInternal(
     model,
     cfg: params.cfg,
     agentDir: params.agentDir,
+    ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
   });
 
   const context = buildImageContext(prompt, params.images, {
@@ -488,6 +546,7 @@ export async function describeImageWithModel(
     preferredProfile: params.preferredProfile,
     authStore: params.authStore,
     agentDir: params.agentDir,
+    ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
     cfg: params.cfg,
   });
 }
@@ -514,6 +573,7 @@ export async function describeImageWithModelPayloadTransform(
       preferredProfile: params.preferredProfile,
       authStore: params.authStore,
       agentDir: params.agentDir,
+      ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
       cfg: params.cfg,
     },
     onPayload,

--- a/src/media-understanding/runner.auto-audio.test.ts
+++ b/src/media-understanding/runner.auto-audio.test.ts
@@ -105,6 +105,47 @@ describe("runCapability auto audio entries", () => {
     expect(result.decision.outcome).toBe("success");
   });
 
+  it("passes workspaceDir to auto-selected audio provider execution auth", async () => {
+    const modelAuth = await import("../agents/model-auth.js");
+    const resolveApiKeyForProvider = vi.mocked(modelAuth.resolveApiKeyForProvider);
+    resolveApiKeyForProvider.mockClear();
+
+    await withAudioFixture("openclaw-auto-audio-workspace-auth", async ({ ctx, media, cache }) => {
+      const result = await runCapability({
+        capability: "audio",
+        cfg: {
+          models: {
+            providers: {
+              openai: {
+                models: [],
+              },
+            },
+          },
+        } as unknown as OpenClawConfig,
+        ctx,
+        attachments: cache,
+        media,
+        providerRegistry: createOpenAiAudioProvider(async (req) => ({
+          text: `workspace ${req.apiKey}`,
+          model: req.model ?? "unknown",
+        })),
+        agentDir: "/tmp/openclaw-agent",
+        workspaceDir: "/tmp/openclaw-workspace",
+      });
+
+      expect(result.decision.outcome).toBe("success");
+      expect(requireCapabilityOutput(result, 0).text).toBe("workspace test-key");
+    });
+
+    expect(resolveApiKeyForProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openai",
+        agentDir: "/tmp/openclaw-agent",
+        workspaceDir: "/tmp/openclaw-workspace",
+      }),
+    );
+  });
+
   it("uses the provider audio default instead of the active Codex chat model", async () => {
     let runResult: Awaited<ReturnType<typeof runCapability>> | undefined;
     let seenModel: string | undefined;

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -422,6 +422,7 @@ async function resolveProviderExecutionAuth(params: {
   cfg: OpenClawConfig;
   entry: MediaUnderstandingModelConfig;
   agentDir?: string;
+  workspaceDir?: string;
 }) {
   const literalApiKey = resolveLiteralProviderApiKey({
     cfg: params.cfg,
@@ -443,6 +444,7 @@ async function resolveProviderExecutionAuth(params: {
     profileId: params.entry.profile,
     preferredProfile: params.entry.preferredProfile,
     agentDir: params.agentDir,
+    workspaceDir: params.workspaceDir,
   });
   return {
     apiKeys: collectProviderApiKeysForExecution({
@@ -459,12 +461,14 @@ async function resolveProviderExecutionContext(params: {
   entry: MediaUnderstandingModelConfig;
   config?: MediaUnderstandingConfig;
   agentDir?: string;
+  workspaceDir?: string;
 }) {
   const { apiKeys, providerConfig } = await resolveProviderExecutionAuth({
     providerId: params.providerId,
     cfg: params.cfg,
     entry: params.entry,
     agentDir: params.agentDir,
+    workspaceDir: params.workspaceDir,
   });
   const baseUrl = params.entry.baseUrl ?? params.config?.baseUrl ?? providerConfig?.baseUrl;
   const mergedHeaders = {
@@ -552,6 +556,7 @@ export async function runProviderEntry(params: {
   attachmentIndex: number;
   cache: MediaAttachmentCache;
   agentDir?: string;
+  workspaceDir?: string;
   providerRegistry: ProviderRegistry;
   config?: MediaUnderstandingConfig;
 }): Promise<MediaUnderstandingOutput | null> {
@@ -594,6 +599,7 @@ export async function runProviderEntry(params: {
       profile: entry.profile,
       preferredProfile: entry.preferredProfile,
       agentDir: params.agentDir,
+      workspaceDir: params.workspaceDir,
       cfg: params.cfg,
     };
     const describeImage = provider?.describeImage ?? describeImageWithModel;
@@ -634,6 +640,7 @@ export async function runProviderEntry(params: {
       entry,
       config: params.config,
       agentDir: params.agentDir,
+      workspaceDir: params.workspaceDir,
     });
     const providerQuery = resolveProviderQuery({
       providerId,
@@ -646,6 +653,7 @@ export async function runProviderEntry(params: {
         cfg,
         providerId,
         capability: "audio",
+        workspaceDir: params.workspaceDir,
       }) ||
       entry.model;
     const result = await executeWithApiKeyRotation({
@@ -705,6 +713,7 @@ export async function runProviderEntry(params: {
     entry,
     config: params.config,
     agentDir: params.agentDir,
+    workspaceDir: params.workspaceDir,
   });
   const result = await executeWithApiKeyRotation({
     provider: providerId,

--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -81,6 +81,7 @@ async function hasProviderAuthAvailable(params: {
   provider: string;
   cfg?: OpenClawConfig;
   agentDir?: string;
+  workspaceDir?: string;
 }): Promise<boolean> {
   if (resolveLiteralProviderApiKey(params.cfg, params.provider)) {
     return true;
@@ -217,6 +218,7 @@ async function resolveAutoImageModelId(params: {
   providerId: string;
   providerRegistry: ProviderRegistry;
   explicitModel?: string;
+  workspaceDir?: string;
 }): Promise<string | undefined> {
   const explicit = normalizeOptionalString(params.explicitModel);
   if (explicit) {
@@ -246,6 +248,7 @@ async function resolveAutoImageModelId(params: {
     cfg: params.cfg,
     providerId: params.providerId,
     capability: "image",
+    workspaceDir: params.workspaceDir,
   });
   if (bundledDefaultModel) {
     return bundledDefaultModel;
@@ -269,13 +272,14 @@ export function buildProviderRegistry(
 export function resolveMediaAttachmentLocalRoots(params: {
   cfg: OpenClawConfig;
   ctx: MsgContext;
+  workspaceDir?: string;
 }): readonly string[] {
   // ctx.MediaWorkspaceDir is set by chat.send's prestageNonImageOffloads when
   // inbound attachments were staged into a sandbox workspace. The paths in
   // ctx.MediaPaths are kept sandbox-relative (so the agent inside the
   // container can read them), and the workspace dir is carried separately so
   // host-side media-understanding can still resolve them via this root list.
-  const workspaceDir = params.ctx.MediaWorkspaceDir;
+  const workspaceDir = params.ctx.MediaWorkspaceDir ?? params.workspaceDir;
   return mergeInboundPathRoots(
     getDefaultMediaLocalRoots(),
     workspaceDir ? [path.resolve(workspaceDir)] : undefined,
@@ -522,11 +526,12 @@ async function resolveGeminiCliEntry(
 async function resolveKeyEntry(params: {
   cfg: OpenClawConfig;
   agentDir?: string;
+  workspaceDir?: string;
   providerRegistry: ProviderRegistry;
   capability: MediaUnderstandingCapability;
   activeModel?: ActiveMediaModel;
 }): Promise<MediaUnderstandingModelConfig | null> {
-  const { cfg, agentDir, providerRegistry, capability } = params;
+  const { cfg, agentDir, workspaceDir, providerRegistry, capability } = params;
   const checkProvider = async (
     providerId: string,
     model?: string,
@@ -549,6 +554,7 @@ async function resolveKeyEntry(params: {
         provider: providerId,
         cfg,
         agentDir,
+        workspaceDir,
       }))
     ) {
       return null;
@@ -560,6 +566,7 @@ async function resolveKeyEntry(params: {
             providerId,
             providerRegistry,
             explicitModel: model,
+            workspaceDir,
           })
         : model;
     if (capability === "image" && !resolvedModel) {
@@ -634,6 +641,7 @@ function hasExplicitImageUnderstandingConfig(params: {
 async function resolveAutoEntries(params: {
   cfg: OpenClawConfig;
   agentDir?: string;
+  workspaceDir?: string;
   providerRegistry: ProviderRegistry;
   capability: MediaUnderstandingCapability;
   activeModel?: ActiveMediaModel;
@@ -672,6 +680,7 @@ async function resolveAutoEntries(params: {
 export async function resolveAutoImageModel(params: {
   cfg: OpenClawConfig;
   agentDir?: string;
+  workspaceDir?: string;
   activeModel?: ActiveMediaModel;
 }): Promise<ActiveMediaModel | null> {
   const providerRegistry = buildProviderRegistry(undefined, params.cfg);
@@ -695,6 +704,7 @@ export async function resolveAutoImageModel(params: {
   const activeEntry = await resolveActiveModelEntry({
     cfg: params.cfg,
     agentDir: params.agentDir,
+    workspaceDir: params.workspaceDir,
     providerRegistry,
     capability: "image",
     activeModel: params.activeModel,
@@ -706,6 +716,7 @@ export async function resolveAutoImageModel(params: {
   const keyEntry = await resolveKeyEntry({
     cfg: params.cfg,
     agentDir: params.agentDir,
+    workspaceDir: params.workspaceDir,
     providerRegistry,
     capability: "image",
     activeModel: params.activeModel,
@@ -716,6 +727,7 @@ export async function resolveAutoImageModel(params: {
 async function resolveActiveModelEntry(params: {
   cfg: OpenClawConfig;
   agentDir?: string;
+  workspaceDir?: string;
   providerRegistry: ProviderRegistry;
   capability: MediaUnderstandingCapability;
   activeModel?: ActiveMediaModel;
@@ -745,6 +757,7 @@ async function resolveActiveModelEntry(params: {
     provider: providerId,
     cfg: params.cfg,
     agentDir: params.agentDir,
+    workspaceDir: params.workspaceDir,
   });
   if (!hasAuth) {
     return null;
@@ -756,6 +769,7 @@ async function resolveActiveModelEntry(params: {
       providerId,
       providerRegistry: params.providerRegistry,
       explicitModel: params.activeModel?.model,
+      workspaceDir: params.workspaceDir,
     });
   } else if (params.capability === "audio") {
     model = resolveDefaultMediaModelFromRegistry({
@@ -782,6 +796,7 @@ async function runAttachmentEntries(params: {
   ctx: MsgContext;
   attachmentIndex: number;
   agentDir?: string;
+  workspaceDir?: string;
   providerRegistry: ProviderRegistry;
   cache: MediaAttachmentCache;
   entries: MediaUnderstandingModelConfig[];
@@ -814,6 +829,7 @@ async function runAttachmentEntries(params: {
               attachmentIndex: params.attachmentIndex,
               cache: params.cache,
               agentDir: params.agentDir,
+              workspaceDir: params.workspaceDir,
               providerRegistry: params.providerRegistry,
               config: params.config,
             });
@@ -876,6 +892,7 @@ export async function runCapability(params: {
   attachments: MediaAttachmentCache;
   media: MediaAttachment[];
   agentDir?: string;
+  workspaceDir?: string;
   providerRegistry: ProviderRegistry;
   config?: MediaUnderstandingConfig;
   activeModel?: ActiveMediaModel;
@@ -970,6 +987,7 @@ export async function runCapability(params: {
     resolvedEntries = await resolveAutoEntries({
       cfg,
       agentDir: params.agentDir,
+      workspaceDir: params.workspaceDir,
       providerRegistry: params.providerRegistry,
       capability,
       activeModel: params.activeModel,
@@ -995,6 +1013,7 @@ export async function runCapability(params: {
       ctx,
       attachmentIndex: attachment.index,
       agentDir: params.agentDir,
+      workspaceDir: params.workspaceDir,
       providerRegistry: params.providerRegistry,
       cache: params.attachments,
       entries: resolvedEntries,

--- a/src/media-understanding/runner.vision-skip.test.ts
+++ b/src/media-understanding/runner.vision-skip.test.ts
@@ -421,7 +421,7 @@ describe("runCapability image skip", () => {
         },
       );
     } finally {
-      hasAvailableAuthForProvider.mockImplementation(() => true);
+      hasAvailableAuthForProvider.mockImplementation(async () => true);
     }
   });
 

--- a/src/media-understanding/runner.vision-skip.test.ts
+++ b/src/media-understanding/runner.vision-skip.test.ts
@@ -364,6 +364,67 @@ describe("runCapability image skip", () => {
     }
   });
 
+  it("passes workspaceDir to auto image provider auth checks", async () => {
+    const modelAuth = await import("../agents/model-auth.js");
+    const hasAvailableAuthForProvider = vi.mocked(modelAuth.hasAvailableAuthForProvider);
+    hasAvailableAuthForProvider.mockClear();
+    hasAvailableAuthForProvider.mockImplementation(
+      async (params) => params.workspaceDir === "/tmp/openclaw-workspace",
+    );
+
+    try {
+      await withMediaFixture(
+        {
+          filePrefix: "openclaw-image-workspace-auth",
+          extension: "png",
+          mediaType: "image/png",
+          fileContents: Buffer.from("image"),
+        },
+        async ({ ctx, media, cache }) => {
+          const result = await runCapability({
+            capability: "image",
+            cfg: {} as OpenClawConfig,
+            ctx,
+            attachments: cache,
+            media,
+            agentDir: "/tmp/openclaw-agent",
+            workspaceDir: "/tmp/openclaw-workspace",
+            providerRegistry: new Map([
+              [
+                "workspace-vision",
+                {
+                  id: "workspace-vision",
+                  capabilities: ["image"],
+                  describeImage: async (req) => ({
+                    text: "workspace auth ok",
+                    model: req.model,
+                  }),
+                },
+              ],
+            ]),
+            activeModel: { provider: "workspace-vision", model: "vision-v1" },
+          });
+
+          expect(result.decision.outcome).toBe("success");
+          expect(requireCapabilityOutput(result, 0)).toMatchObject({
+            provider: "workspace-vision",
+            model: "vision-v1",
+            text: "workspace auth ok",
+          });
+          expect(hasAvailableAuthForProvider).toHaveBeenCalledWith(
+            expect.objectContaining({
+              provider: "workspace-vision",
+              agentDir: "/tmp/openclaw-agent",
+              workspaceDir: "/tmp/openclaw-workspace",
+            }),
+          );
+        },
+      );
+    } finally {
+      hasAvailableAuthForProvider.mockImplementation(() => true);
+    }
+  });
+
   it("auto-selects configured OpenRouter image providers with a resolved model", async () => {
     let seenModel: string | undefined;
     await withMediaFixture(

--- a/src/media-understanding/runtime-types.ts
+++ b/src/media-understanding/runtime-types.ts
@@ -13,6 +13,7 @@ export type RunMediaUnderstandingFileParams = {
   filePath: string;
   cfg: OpenClawConfig;
   agentDir?: string;
+  workspaceDir?: string;
   mime?: string;
   activeModel?: ActiveMediaModel;
   prompt?: string;
@@ -31,6 +32,7 @@ export type DescribeImageFileParams = {
   filePath: string;
   cfg: OpenClawConfig;
   agentDir?: string;
+  workspaceDir?: string;
   mime?: string;
   activeModel?: ActiveMediaModel;
   prompt?: string;
@@ -41,6 +43,7 @@ export type DescribeImageFileWithModelParams = {
   filePath: string;
   cfg: OpenClawConfig;
   agentDir?: string;
+  workspaceDir?: string;
   mime?: string;
   provider: string;
   model: string;
@@ -78,6 +81,7 @@ export type DescribeVideoFileParams = {
   filePath: string;
   cfg: OpenClawConfig;
   agentDir?: string;
+  workspaceDir?: string;
   mime?: string;
   activeModel?: ActiveMediaModel;
 };
@@ -86,6 +90,7 @@ export type TranscribeAudioFileParams = {
   filePath: string;
   cfg: OpenClawConfig;
   agentDir?: string;
+  workspaceDir?: string;
   mime?: string;
   activeModel?: ActiveMediaModel;
   language?: string;

--- a/src/media-understanding/runtime.test.ts
+++ b/src/media-understanding/runtime.test.ts
@@ -3,10 +3,12 @@ import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
 import type { OpenClawConfig } from "../config/types.js";
 import type { MediaAttachment, MediaUnderstandingOutput } from "../media-understanding/types.js";
 import {
+  describeVideoFile,
   describeImageFile,
   describeImageFileWithModel,
   extractStructuredWithModel,
   runMediaUnderstandingFile,
+  transcribeAudioFile,
 } from "./runtime.js";
 
 const mocks = vi.hoisted(() => {
@@ -168,6 +170,82 @@ describe("media-understanding runtime", () => {
 
     expect(mocks.runCapability).toHaveBeenCalledTimes(1);
     expect(mocks.cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes workspaceDir through file media understanding requests", async () => {
+    const output: MediaUnderstandingOutput = {
+      kind: "image.description",
+      attachmentIndex: 0,
+      provider: "vision-plugin",
+      model: "vision-v1",
+      text: "image ok",
+    };
+    mocks.normalizeMediaAttachments.mockReturnValue([
+      { index: 0, path: "/tmp/sample.jpg", mime: "image/jpeg" },
+    ]);
+    mocks.runCapability.mockResolvedValue({
+      outputs: [output],
+    });
+
+    await describeImageFile({
+      filePath: "/tmp/sample.jpg",
+      mime: "image/jpeg",
+      cfg: {} as OpenClawConfig,
+      agentDir: "/tmp/agent",
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(requireRunCapabilityRequest()).toMatchObject({
+      agentDir: "/tmp/agent",
+      workspaceDir: "/tmp/workspace",
+    });
+  });
+
+  it("passes workspaceDir through audio and video file helpers", async () => {
+    mocks.runCapability.mockResolvedValue({
+      outputs: [],
+      decision: { capability: "video", outcome: "skipped", attachments: [] },
+    });
+    mocks.normalizeMediaAttachments.mockReturnValue([
+      { index: 0, path: "/tmp/sample.mp4", mime: "video/mp4" },
+    ]);
+
+    await describeVideoFile({
+      filePath: "/tmp/sample.mp4",
+      mime: "video/mp4",
+      cfg: {} as OpenClawConfig,
+      agentDir: "/tmp/agent",
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(requireRunCapabilityRequest()).toMatchObject({
+      capability: "video",
+      agentDir: "/tmp/agent",
+      workspaceDir: "/tmp/workspace",
+    });
+
+    mocks.runCapability.mockReset();
+    mocks.runCapability.mockResolvedValue({
+      outputs: [],
+      decision: { capability: "audio", outcome: "skipped", attachments: [] },
+    });
+    mocks.normalizeMediaAttachments.mockReturnValue([
+      { index: 0, path: "/tmp/sample.ogg", mime: "audio/ogg" },
+    ]);
+
+    await transcribeAudioFile({
+      filePath: "/tmp/sample.ogg",
+      mime: "audio/ogg",
+      cfg: {} as OpenClawConfig,
+      agentDir: "/tmp/agent",
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(requireRunCapabilityRequest()).toMatchObject({
+      capability: "audio",
+      agentDir: "/tmp/agent",
+      workspaceDir: "/tmp/workspace",
+    });
   });
 
   it("passes per-request image prompts into media understanding config", async () => {

--- a/src/media-understanding/runtime.ts
+++ b/src/media-understanding/runtime.ts
@@ -125,6 +125,7 @@ export async function runMediaUnderstandingFile(
       attachments: cache,
       media: attachments,
       agentDir: params.agentDir,
+      ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
       providerRegistry,
       config,
       activeModel: params.activeModel,
@@ -177,6 +178,7 @@ export async function describeImageFileWithModel(params: DescribeImageFileWithMo
     timeoutMs,
     cfg: params.cfg,
     agentDir: params.agentDir ?? "",
+    ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
   });
 }
 

--- a/src/media-understanding/types.ts
+++ b/src/media-understanding/types.ts
@@ -134,6 +134,7 @@ export type ImageDescriptionRequest = {
   preferredProfile?: string;
   authStore?: AuthProfileStore;
   agentDir: string;
+  workspaceDir?: string;
   cfg: OpenClawConfig;
   model: string;
   provider: string;
@@ -156,6 +157,7 @@ export type ImagesDescriptionRequest = {
   preferredProfile?: string;
   authStore?: AuthProfileStore;
   agentDir: string;
+  workspaceDir?: string;
   cfg: OpenClawConfig;
 };
 

--- a/src/plugins/provider-hook-runtime.ts
+++ b/src/plugins/provider-hook-runtime.ts
@@ -214,6 +214,19 @@ export function resolveProviderRuntimePlugin(
   return plugin ?? undefined;
 }
 
+export function resolveLoadedProviderRuntimePlugin(
+  params: ProviderRuntimePluginLookupParams,
+): ProviderPlugin | undefined {
+  const apiOwnerHint = resolveProviderConfigApiOwnerHint({
+    provider: params.provider,
+    config: params.config,
+  });
+  return findProviderRuntimePluginInLoadedRegistries({
+    lookup: params,
+    apiOwnerHint,
+  });
+}
+
 export function resolveProviderHookPlugin(params: {
   provider: string;
   config?: OpenClawConfig;

--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -485,6 +485,45 @@ describe("provider-runtime", () => {
     expect(resolvePluginProvidersMock).not.toHaveBeenCalled();
   });
 
+  it("uses loaded stream hooks without loading runtime plugins when requested", () => {
+    const createStreamFn = vi.fn(() => vi.fn());
+    const provider: ProviderPlugin = {
+      id: DEMO_PROVIDER_ID,
+      label: "Demo",
+      auth: [],
+      createStreamFn,
+    };
+    const registry = createEmptyPluginRegistry();
+    registry.providers.push({
+      pluginId: DEMO_PROVIDER_ID,
+      provider,
+      source: "test",
+    });
+    setActivePluginRegistry(registry, "startup-registry", "gateway-bindable", "/tmp/workspace");
+
+    expect(
+      resolveProviderStreamFn({
+        provider: DEMO_PROVIDER_ID,
+        workspaceDir: "/tmp/workspace",
+        allowRuntimePluginLoad: false,
+        context: createDemoResolvedModelContext({}),
+      }),
+    ).toBeTypeOf("function");
+    expect(createStreamFn).toHaveBeenCalledOnce();
+    expect(resolvePluginProvidersMock).not.toHaveBeenCalled();
+  });
+
+  it("does not load runtime plugins for stream hooks when loading is disabled", () => {
+    expect(
+      resolveProviderStreamFn({
+        provider: DEMO_PROVIDER_ID,
+        allowRuntimePluginLoad: false,
+        context: createDemoResolvedModelContext({}),
+      }),
+    ).toBeUndefined();
+    expect(resolvePluginProvidersMock).not.toHaveBeenCalled();
+  });
+
   it("uses current provider-ref owner plugin config for provider hooks", () => {
     const provider: ProviderPlugin = {
       id: DEMO_PROVIDER_ID,

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -19,6 +19,7 @@ import {
   resolveProviderExtraParamsForTransport,
   resolveProviderFollowupFallbackRoute,
   ensureProviderRuntimePluginHandle,
+  resolveLoadedProviderRuntimePlugin,
   resolveProviderHookPlugin,
   resolveProviderPluginsForHooks,
   resolveProviderRuntimePlugin,
@@ -598,9 +599,14 @@ export function resolveProviderStreamFn(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
+  allowRuntimePluginLoad?: boolean;
   context: ProviderCreateStreamFnContext;
 }) {
-  return resolveProviderRuntimePlugin(params)?.createStreamFn?.(params.context) ?? undefined;
+  const plugin =
+    params.allowRuntimePluginLoad === false
+      ? resolveLoadedProviderRuntimePlugin(params)
+      : resolveProviderRuntimePlugin(params);
+  return plugin?.createStreamFn?.(params.context) ?? undefined;
 }
 
 export function resolveProviderTransportTurnStateWithPlugin(params: {


### PR DESCRIPTION
Summary:
- Avoid broad PI/plugin discovery on the image-model resolution hot path when a configured/static image model can be resolved directly.
- Preserve provider normalization, stream hooks, provider overrides, and workspace-scoped auth while using the faster image path.
- Thread workspaceDir through media-understanding image/audio/video helper paths so sandboxed media and provider auth resolve from the intended roots.

Verification:
- node scripts/run-vitest.mjs src/media-understanding/image.test.ts src/media-understanding/runtime.test.ts src/media-understanding/runner.auto-audio.test.ts src/agents/pi-embedded-runner/model.test.ts src/plugins/provider-runtime.test.ts src/media-understanding/apply.test.ts src/auto-reply/reply/dispatch-acp.test.ts src/agents/tools/image-tool.test.ts src/media-understanding/runner.vision-skip.test.ts
- .agents/skills/codex-review/scripts/codex-review --mode local
- pnpm build
- git diff --check

Behavior addressed: Windows image-model resolution no longer blocks the event loop long enough to stall Telegram polling while preparing a Gemini image request.
Real environment tested: Parallels Windows 11 VM, Windows NT 10.0.26200.0, Node v24.15.0, npm 11.12.1, package installed from a freshly packed openclaw-2026.5.17.tgz built from this branch.
Exact steps or command run after this patch: Installed the packed tarball globally in the Windows VM and ran the image payload-readiness probe from /private/tmp/openclaw-82338-repro/windows-patched-payload-probe.mjs with a dummy Gemini API key.
Evidence after fix: The probe reached the provider payload transform and intentionally threw PAYLOAD_READY before any network call, with prePayloadMs=9551.7, totalMs=9552.1, eventLoopMaxMs=31.1, and intervalMaxMs=31.3.
Observed result after fix: Payload construction completed without the multi-second or tens-of-seconds event-loop starvation reproduced on current main.
What was not tested: A full live Telegram bot/image round trip on the patched branch was not rerun because the fix proof isolates the previously blocking image payload preparation path without requiring live Telegram or provider credentials.

Refs #82338
