### PR TITLE
Fix Discord reply context at LLM boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/sessions: estimate context usage from local/OpenAI-compatible transcripts when provider usage telemetry is missing, so status no longer shows empty usage for real local-model sessions. Fixes #73990. (#82317) Thanks @giodl73-repo.
 - Update/installers: override npm `min-release-age` quarantine for OpenClaw-managed package installs, so `openclaw update`, plugin updates, and hosted installer scripts can install the requested latest release immediately.
 - Agents/sessions: preserve fresh post-compaction token snapshots across stale usage updates, preventing repeated auto-compaction after every message. Fixes #82576. (#82578) Thanks @njuboy11.
+- Agents/replies: preserve active inbound reply context at the LLM boundary so Discord referenced-message turns do not answer from stale session history. Fixes #82608. (#82801) Thanks @joshavant.
 - Agents/OpenAI Responses: log redacted diagnostics for detail-less `response.failed` events while preserving failed response ids, so operators can correlate provider-side failures. Fixes #82558.
 - Agents/OpenRouter: strip non-replayable Anthropic/xAI reasoning provenance tags from follow-up requests, preventing poisoned thinking signatures from breaking second turns. Fixes #82335. (#82380) Thanks @hclsys.
 - Providers/xAI: send configurable reasoning effort only for Grok 4.3, preserving xAI's default low reasoning while omitting unsupported controls for Grok 4.20 reasoning models. (#81227) Thanks @jason-allen-oneal.

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -313,6 +313,11 @@ describe("normalizeMessagesForLlmBoundary", () => {
           'Conversation info (untrusted metadata):\n```json\n{"channel":"telegram"}\n```\n\nPlain historical ask',
         timestamp: 1,
       },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Historical answer" }],
+        timestamp: 2,
+      },
     ];
 
     const output = normalizeMessagesForLlmBoundary(
@@ -320,6 +325,73 @@ describe("normalizeMessagesForLlmBoundary", () => {
     ) as unknown as Array<{ content?: string }>;
 
     expect(output[0]?.content).toBe("Plain historical ask");
+  });
+
+  it("preserves inbound metadata on the current user turn", () => {
+    const historicalEnvelope =
+      'Conversation info (untrusted metadata):\n```json\n{"channel":"discord"}\n```\n\nOld ask';
+    const currentEnvelope =
+      'Conversation info (untrusted metadata):\n```json\n{"channel":"discord","has_reply_context":true}\n```\n\nReply target of current user message (untrusted, for context):\n```json\n{"body":"quoted status body"}\n```\n\nCurrent ask';
+    const input = [
+      {
+        role: "user",
+        content: [{ type: "text", text: historicalEnvelope }],
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Historical answer" }],
+        timestamp: 2,
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: currentEnvelope }],
+        timestamp: 3,
+      },
+    ];
+
+    const output = normalizeMessagesForLlmBoundary(
+      input as Parameters<typeof normalizeMessagesForLlmBoundary>[0],
+    ) as unknown as Array<{ content?: Array<{ text?: string }> }>;
+
+    expect(output[0]?.content?.[0]?.text).toBe("Old ask");
+    expect(output[2]?.content?.[0]?.text).toContain(
+      "Reply target of current user message (untrusted, for context):",
+    );
+    expect(output[2]?.content?.[0]?.text).toContain("quoted status body");
+  });
+
+  it("preserves current user inbound metadata through tool-result continuation", () => {
+    const currentEnvelope =
+      'Conversation info (untrusted metadata):\n```json\n{"channel":"discord","has_reply_context":true}\n```\n\nReply target of current user message (untrusted, for context):\n```json\n{"body":"quoted status body"}\n```\n\nCurrent ask';
+    const input = [
+      {
+        role: "user",
+        content: [{ type: "text", text: currentEnvelope }],
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+        timestamp: 2,
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_1",
+        toolName: "read",
+        content: [{ type: "text", text: "tool output" }],
+        timestamp: 3,
+      },
+    ];
+
+    const output = normalizeMessagesForLlmBoundary(
+      input as Parameters<typeof normalizeMessagesForLlmBoundary>[0],
+    ) as unknown as Array<{ content?: Array<{ text?: string }> }>;
+
+    expect(output[0]?.content?.[0]?.text).toContain(
+      "Reply target of current user message (untrusted, for context):",
+    );
+    expect(output[0]?.content?.[0]?.text).toContain("quoted status body");
   });
 
   it("strips tool result details before provider conversion", () => {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -659,9 +659,10 @@ export function normalizeMessagesForLlmBoundary(messages: AgentMessage[]): Agent
 }
 
 function stripHistoricalInboundMetadataFromUserMessages(messages: AgentMessage[]): AgentMessage[] {
+  const activeUserMessageIndex = findActiveUserMessageIndex(messages);
   let changed = false;
-  const nextMessages = messages.map((message) => {
-    if (message.role !== "user") {
+  const nextMessages = messages.map((message, index) => {
+    if (message.role !== "user" || index === activeUserMessageIndex) {
       return message;
     }
     const content = (message as { content?: unknown }).content;
@@ -699,6 +700,39 @@ function stripHistoricalInboundMetadataFromUserMessages(messages: AgentMessage[]
     return { ...message, content: nextContent } as AgentMessage;
   });
   return changed ? nextMessages : messages;
+}
+
+function findActiveUserMessageIndex(messages: AgentMessage[]): number {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (!message) {
+      continue;
+    }
+    if (message.role === "user") {
+      return index;
+    }
+    if (message.role === "assistant" && !isToolCallAssistantMessage(message)) {
+      return -1;
+    }
+  }
+  return -1;
+}
+
+function isToolCallAssistantMessage(message: AgentMessage): boolean {
+  if (message.role !== "assistant") {
+    return false;
+  }
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return false;
+  }
+  return content.some((block) => {
+    if (!block || typeof block !== "object") {
+      return false;
+    }
+    const type = (block as { type?: unknown }).type;
+    return type === "toolCall" || type === "toolUse" || type === "functionCall";
+  });
 }
 
 function cloneHookMessages(messages: AgentMessage[]): AgentMessage[] {


### PR DESCRIPTION
Summary
- Preserve active user-turn inbound metadata at the embedded runner LLM boundary so current Discord reply/reference context reaches the model.
- Continue stripping inbound metadata from historical user turns, including after a completed assistant response.
- Add regression coverage for active reply context and tool-result continuation.

Fixes #82608

Verification
- node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/attempt.test.ts -- --runInBand
- .agents/skills/codex-review/scripts/codex-review --mode local --parallel-tests "node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/attempt.test.ts -- --runInBand"
- OPENCLAW_82608_EXPECT_FIXED=1 node scripts/crabbox-wrapper.mjs run --idle-timeout 90m --ttl 240m --timing-json --env-from-profile /private/tmp/convex_pool.env --script /private/tmp/openclaw-82608-discord-repro.sh

Behavior addressed: Discord reply/reference turns could lose the current referenced-message context before the provider request, letting stale prior session history dominate the answer.

Real environment tested: AWS Crabbox live Discord QA lane with Convex-leased discord CI credential and mock-openai/gpt-5.5, provider aws, lease cbx_41aa1cfb6ba0, run run_0f8bf2dd64fd.

Exact steps or command run after this patch: Started the gateway from current main plus this patch, sent an unrelated stale Discord prompt, waited for the SUT reply, sent a new Discord reference message, restarted the gateway, then replied to the referenced message with a current marker and inspected the mock provider request.

Evidence after fix: The provider input for the current turn included the current marker, referenced-message marker, and `Reply target of current user message`; the SUT response contained the referenced-message marker instead of the stale prior-task marker.

Observed result after fix: The repro script reported `fixed: true` and `reproduced: false` in run run_0f8bf2dd64fd.

What was not tested: A real paid OpenAI provider response was not needed; the live Discord/gateway/session path was exercised with the QA mock OpenAI provider so the provider payload could be inspected deterministically.

