### PR TITLE
fix: Subagent completion direct announce often fails with no visible reply

### DIFF
--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -137,6 +137,7 @@ async function deliverSlackThreadAnnouncement(params: {
 }) {
   __testing.setDepsForTest({
     callGateway: params.callGateway,
+    ...(params.sendMessage ? { sendMessage: params.sendMessage } : {}),
     getRequesterSessionActivity: () => ({
       sessionId: params.sessionId,
       isActive: params.isActive,
@@ -178,6 +179,7 @@ async function deliverDiscordDirectMessageCompletion(params: {
   };
   __testing.setDepsForTest({
     callGateway: params.callGateway,
+    ...(params.sendMessage ? { sendMessage: params.sendMessage } : {}),
     getRequesterSessionActivity: () => ({
       sessionId: "requester-session-dm",
       isActive: false,
@@ -217,6 +219,7 @@ async function deliverTelegramDirectMessageCompletion(params: {
   };
   __testing.setDepsForTest({
     callGateway: params.callGateway,
+    ...(params.sendMessage ? { sendMessage: params.sendMessage } : {}),
     getRequesterSessionActivity: () => ({
       sessionId: "requester-session-telegram",
       isActive: params.isActive === true,
@@ -276,6 +279,7 @@ async function deliverSlackChannelAnnouncement(params: {
 
   __testing.setDepsForTest({
     callGateway: params.callGateway,
+    ...(params.sendMessage ? { sendMessage: params.sendMessage } : {}),
     getRequesterSessionActivity: () => ({
       sessionId: params.sessionId,
       isActive: params.isActive,
@@ -1150,7 +1154,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
-  it("reports failure when announce-agent returns no visible output", async () => {
+  it("falls back for thread completions when announce-agent returns no visible output", async () => {
     const callGateway = createGatewayMock({
       result: {
         payloads: [],
@@ -1181,12 +1185,19 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     });
 
     expectRecordFields(result, {
-      delivered: false,
+      delivered: true,
       path: "direct",
-      error: "completion agent did not produce a visible reply",
     });
     expect(callGateway).toHaveBeenCalledTimes(1);
-    expect(sendMessage).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expectRecordFields(mockCallArg(sendMessage), {
+      channel: "slack",
+      to: "channel:C123",
+      accountId: "acct-1",
+      threadId: "171.222",
+      content: "Background task completed: thread completion smoke\n\nchild completion output",
+      idempotencyKey: "announce-thread-fallback-empty:completion-fallback",
+    });
   });
 
   it("reports failure for completion DMs when announce-agent returns no visible output", async () => {
@@ -1807,7 +1818,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
-  it("reports channel completion failure when announce-agent returns no visible output", async () => {
+  it("falls back to a visible completion message when announce-agent returns no visible output", async () => {
     const callGateway = createGatewayMock({
       result: {
         payloads: [],
@@ -1838,12 +1849,19 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     });
 
     expectRecordFields(result, {
-      delivered: false,
+      delivered: true,
       path: "direct",
-      error: "completion agent did not produce a visible reply",
     });
     expect(callGateway).toHaveBeenCalledTimes(1);
-    expect(sendMessage).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expectRecordFields(mockCallArg(sendMessage), {
+      channel: "slack",
+      to: "channel:C123",
+      accountId: "acct-1",
+      threadId: undefined,
+      content: "Background task completed: channel completion smoke\n\nchild completion output",
+      idempotencyKey: "announce-channel-fallback-empty:completion-fallback",
+    });
   });
 
   it("falls back to the external requester route when completion origin is internal", async () => {

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -76,6 +76,29 @@ function createQueueOutcomeMock(
   );
 }
 
+function createQueueOutcomeSequenceMock(
+  queuedOutcomes: boolean[],
+): ReturnType<typeof vi.fn<QueueEmbeddedPiMessageWithOutcome>> {
+  let index = 0;
+  return vi.fn((sessionId: string) => {
+    const queued = queuedOutcomes[Math.min(index, queuedOutcomes.length - 1)] ?? false;
+    index += 1;
+    return queued
+      ? {
+          queued: true,
+          sessionId,
+          target: "embedded_run",
+          gatewayHealth: "live",
+        }
+      : {
+          queued: false,
+          sessionId,
+          reason: "not_streaming",
+          gatewayHealth: "live",
+        };
+  });
+}
+
 const longChildCompletionOutput = [
   "34/34 tests pass, clean build. Now docker repro:",
   "Root cause: the requester's announce delivery accepted a prefix-only assistant payload as delivered.",
@@ -135,9 +158,9 @@ async function deliverSlackThreadAnnouncement(params: {
   internalEvents?: AgentInternalEvent[];
   sourceTool?: string;
 }) {
+  void params.sendMessage;
   __testing.setDepsForTest({
     callGateway: params.callGateway,
-    ...(params.sendMessage ? { sendMessage: params.sendMessage } : {}),
     getRequesterSessionActivity: () => ({
       sessionId: params.sessionId,
       isActive: params.isActive,
@@ -172,6 +195,7 @@ async function deliverDiscordDirectMessageCompletion(params: {
   internalEvents?: AgentInternalEvent[];
   sourceTool?: string;
 }) {
+  void params.sendMessage;
   const origin = {
     channel: "discord",
     to: "dm:U123",
@@ -179,7 +203,6 @@ async function deliverDiscordDirectMessageCompletion(params: {
   };
   __testing.setDepsForTest({
     callGateway: params.callGateway,
-    ...(params.sendMessage ? { sendMessage: params.sendMessage } : {}),
     getRequesterSessionActivity: () => ({
       sessionId: "requester-session-dm",
       isActive: false,
@@ -212,6 +235,7 @@ async function deliverTelegramDirectMessageCompletion(params: {
   isActive?: boolean;
   queueEmbeddedPiMessageWithOutcome?: QueueEmbeddedPiMessageWithOutcome;
 }) {
+  void params.sendMessage;
   const origin = {
     channel: "telegram",
     to: "123456789",
@@ -219,7 +243,6 @@ async function deliverTelegramDirectMessageCompletion(params: {
   };
   __testing.setDepsForTest({
     callGateway: params.callGateway,
-    ...(params.sendMessage ? { sendMessage: params.sendMessage } : {}),
     getRequesterSessionActivity: () => ({
       sessionId: "requester-session-telegram",
       isActive: params.isActive === true,
@@ -271,6 +294,7 @@ async function deliverSlackChannelAnnouncement(params: {
   internalEvents?: AgentInternalEvent[];
   sourceTool?: string;
 }) {
+  void params.sendMessage;
   const origin = {
     channel: "slack",
     to: "channel:C123",
@@ -279,7 +303,6 @@ async function deliverSlackChannelAnnouncement(params: {
 
   __testing.setDepsForTest({
     callGateway: params.callGateway,
-    ...(params.sendMessage ? { sendMessage: params.sendMessage } : {}),
     getRequesterSessionActivity: () => ({
       sessionId: params.sessionId,
       isActive: params.isActive,
@@ -1154,16 +1177,18 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
-  it("falls back for thread completions when announce-agent returns no visible output", async () => {
+  it("steers thread completions when announce-agent returns no visible output", async () => {
     const callGateway = createGatewayMock({
       result: {
         payloads: [],
       },
     });
     const sendMessage = createSendMessageMock();
+    const queueEmbeddedPiMessageWithOutcome = createQueueOutcomeSequenceMock([false, true]);
     const result = await deliverSlackThreadAnnouncement({
       callGateway,
       sendMessage,
+      queueEmbeddedPiMessageWithOutcome,
       sessionId: "requester-session-4",
       isActive: false,
       expectsCompletionMessage: true,
@@ -1186,18 +1211,43 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
 
     expectRecordFields(result, {
       delivered: true,
-      path: "direct",
+      path: "steered",
+      phases: [
+        {
+          phase: "direct-primary",
+          delivered: false,
+          path: "direct",
+          error: "completion agent did not produce a visible reply",
+        },
+        {
+          phase: "steer-fallback",
+          delivered: true,
+          path: "steered",
+          error: undefined,
+        },
+      ],
     });
     expect(callGateway).toHaveBeenCalledTimes(1);
-    expect(sendMessage).toHaveBeenCalledTimes(1);
-    expectRecordFields(mockCallArg(sendMessage), {
-      channel: "slack",
-      to: "channel:C123",
-      accountId: "acct-1",
-      threadId: "171.222",
-      content: "Background task completed: thread completion smoke\n\nchild completion output",
-      idempotencyKey: "announce-thread-fallback-empty:completion-fallback",
-    });
+    expect(queueEmbeddedPiMessageWithOutcome).toHaveBeenCalledTimes(2);
+    expect(queueEmbeddedPiMessageWithOutcome).toHaveBeenNthCalledWith(
+      1,
+      "requester-session-4",
+      "child done",
+      {
+        steeringMode: "all",
+        debounceMs: 500,
+      },
+    );
+    expect(queueEmbeddedPiMessageWithOutcome).toHaveBeenNthCalledWith(
+      2,
+      "requester-session-4",
+      "child done",
+      {
+        steeringMode: "all",
+        debounceMs: 500,
+      },
+    );
+    expect(sendMessage).not.toHaveBeenCalled();
   });
 
   it("reports failure for completion DMs when announce-agent returns no visible output", async () => {
@@ -1818,16 +1868,18 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
-  it("falls back to a visible completion message when announce-agent returns no visible output", async () => {
+  it("steers channel completions when announce-agent returns no visible output", async () => {
     const callGateway = createGatewayMock({
       result: {
         payloads: [],
       },
     });
     const sendMessage = createSendMessageMock();
+    const queueEmbeddedPiMessageWithOutcome = createQueueOutcomeSequenceMock([false, true]);
     const result = await deliverSlackChannelAnnouncement({
       callGateway,
       sendMessage,
+      queueEmbeddedPiMessageWithOutcome,
       sessionId: "requester-session-channel",
       isActive: false,
       expectsCompletionMessage: true,
@@ -1850,18 +1902,43 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
 
     expectRecordFields(result, {
       delivered: true,
-      path: "direct",
+      path: "steered",
+      phases: [
+        {
+          phase: "direct-primary",
+          delivered: false,
+          path: "direct",
+          error: "completion agent did not produce a visible reply",
+        },
+        {
+          phase: "steer-fallback",
+          delivered: true,
+          path: "steered",
+          error: undefined,
+        },
+      ],
     });
     expect(callGateway).toHaveBeenCalledTimes(1);
-    expect(sendMessage).toHaveBeenCalledTimes(1);
-    expectRecordFields(mockCallArg(sendMessage), {
-      channel: "slack",
-      to: "channel:C123",
-      accountId: "acct-1",
-      threadId: undefined,
-      content: "Background task completed: channel completion smoke\n\nchild completion output",
-      idempotencyKey: "announce-channel-fallback-empty:completion-fallback",
-    });
+    expect(queueEmbeddedPiMessageWithOutcome).toHaveBeenCalledTimes(2);
+    expect(queueEmbeddedPiMessageWithOutcome).toHaveBeenNthCalledWith(
+      1,
+      "requester-session-channel",
+      "child done",
+      {
+        steeringMode: "all",
+        debounceMs: 500,
+      },
+    );
+    expect(queueEmbeddedPiMessageWithOutcome).toHaveBeenNthCalledWith(
+      2,
+      "requester-session-channel",
+      "child done",
+      {
+        steeringMode: "all",
+        debounceMs: 500,
+      },
+    );
+    expect(sendMessage).not.toHaveBeenCalled();
   });
 
   it("falls back to the external requester route when completion origin is internal", async () => {

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -5,6 +5,7 @@ import {
 } from "../infra/outbound/session-binding-service.js";
 import type { AgentInternalEvent } from "./internal-events.js";
 import type {
+  EmbeddedPiQueueFailureReason,
   EmbeddedPiQueueMessageOptions,
   EmbeddedPiQueueMessageOutcome,
 } from "./pi-embedded-runner/runs.js";
@@ -34,6 +35,17 @@ const slackThreadOrigin = {
 
 function createGatewayMock(response: Record<string, unknown> = {}) {
   return vi.fn(async () => response) as unknown as typeof runtimeCallGateway;
+}
+
+function createGatewaySequenceMock(
+  responses: Record<string, unknown>[],
+): ReturnType<typeof vi.fn> & typeof runtimeCallGateway {
+  let index = 0;
+  return vi.fn(async () => {
+    const response = responses[Math.min(index, responses.length - 1)] ?? {};
+    index += 1;
+    return response;
+  }) as unknown as ReturnType<typeof vi.fn> & typeof runtimeCallGateway;
 }
 
 function createInProcessGatewayMock(response: Record<string, unknown> = {}) {
@@ -77,13 +89,13 @@ function createQueueOutcomeMock(
 }
 
 function createQueueOutcomeSequenceMock(
-  queuedOutcomes: boolean[],
+  queuedOutcomes: (boolean | EmbeddedPiQueueFailureReason)[],
 ): ReturnType<typeof vi.fn<QueueEmbeddedPiMessageWithOutcome>> {
   let index = 0;
   return vi.fn((sessionId: string) => {
-    const queued = queuedOutcomes[Math.min(index, queuedOutcomes.length - 1)] ?? false;
+    const outcome = queuedOutcomes[Math.min(index, queuedOutcomes.length - 1)] ?? false;
     index += 1;
-    return queued
+    return outcome === true
       ? {
           queued: true,
           sessionId,
@@ -93,7 +105,7 @@ function createQueueOutcomeSequenceMock(
       : {
           queued: false,
           sessionId,
-          reason: "not_streaming",
+          reason: typeof outcome === "string" ? outcome : "not_streaming",
           gatewayHealth: "live",
         };
   });
@@ -962,7 +974,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expectRecordFields(result, {
       delivered: false,
       path: "direct",
-      error: "completion agent did not produce a visible reply",
+      error: "completion agent did not deliver through the message tool",
     });
     expect(sendMessage).not.toHaveBeenCalled();
   });
@@ -1177,14 +1189,31 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
-  it("steers thread completions when announce-agent returns no visible output", async () => {
-    const callGateway = createGatewayMock({
-      result: {
-        payloads: [],
+  it("forces message-tool thread completions after a stale requester run", async () => {
+    const callGateway = createGatewaySequenceMock([
+      {
+        result: {
+          payloads: [],
+        },
       },
-    });
+      {
+        result: {
+          payloads: [],
+          messagingToolSentTargets: [
+            {
+              tool: "message",
+              provider: "slack",
+              accountId: "acct-1",
+              to: "channel:C123",
+              threadId: "171.222",
+              text: "The background task completed.",
+            },
+          ],
+        },
+      },
+    ]);
     const sendMessage = createSendMessageMock();
-    const queueEmbeddedPiMessageWithOutcome = createQueueOutcomeSequenceMock([false, true]);
+    const queueEmbeddedPiMessageWithOutcome = createQueueOutcomeSequenceMock(["no_active_run"]);
     const result = await deliverSlackThreadAnnouncement({
       callGateway,
       sendMessage,
@@ -1211,35 +1240,35 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
 
     expectRecordFields(result, {
       delivered: true,
-      path: "steered",
+      path: "direct",
       phases: [
         {
           phase: "direct-primary",
-          delivered: false,
-          path: "direct",
-          error: "completion agent did not produce a visible reply",
-        },
-        {
-          phase: "steer-fallback",
           delivered: true,
-          path: "steered",
+          path: "direct",
           error: undefined,
         },
       ],
     });
-    expect(callGateway).toHaveBeenCalledTimes(1);
-    expect(queueEmbeddedPiMessageWithOutcome).toHaveBeenCalledTimes(2);
-    expect(queueEmbeddedPiMessageWithOutcome).toHaveBeenNthCalledWith(
-      1,
-      "requester-session-4",
-      "child done",
-      {
-        steeringMode: "all",
-        debounceMs: 500,
-      },
-    );
-    expect(queueEmbeddedPiMessageWithOutcome).toHaveBeenNthCalledWith(
-      2,
+    expect(callGateway).toHaveBeenCalledTimes(2);
+    expectGatewayAgentParams(callGateway, {
+      deliver: true,
+      channel: "slack",
+      accountId: "acct-1",
+      to: "channel:C123",
+      threadId: "171.222",
+    });
+    expectRecordFields(mockCallArg(callGateway, 1).params, {
+      deliver: false,
+      channel: "slack",
+      accountId: "acct-1",
+      to: "channel:C123",
+      threadId: "171.222",
+      sourceReplyDeliveryMode: "message_tool_only",
+      idempotencyKey: "announce-thread-fallback-empty:message-tool",
+    });
+    expect(queueEmbeddedPiMessageWithOutcome).toHaveBeenCalledTimes(1);
+    expect(queueEmbeddedPiMessageWithOutcome).toHaveBeenCalledWith(
       "requester-session-4",
       "child done",
       {
@@ -1868,14 +1897,23 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
-  it("steers channel completions when announce-agent returns no visible output", async () => {
-    const callGateway = createGatewayMock({
-      result: {
-        payloads: [],
+  it("forces message-tool channel completions after a stale requester run", async () => {
+    const callGateway = createGatewaySequenceMock([
+      {
+        result: {
+          payloads: [],
+        },
       },
-    });
+      {
+        result: {
+          payloads: [],
+          didSendViaMessagingTool: true,
+          messagingToolSentTexts: ["The background task completed."],
+        },
+      },
+    ]);
     const sendMessage = createSendMessageMock();
-    const queueEmbeddedPiMessageWithOutcome = createQueueOutcomeSequenceMock([false, true]);
+    const queueEmbeddedPiMessageWithOutcome = createQueueOutcomeSequenceMock(["no_active_run"]);
     const result = await deliverSlackChannelAnnouncement({
       callGateway,
       sendMessage,
@@ -1902,35 +1940,35 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
 
     expectRecordFields(result, {
       delivered: true,
-      path: "steered",
+      path: "direct",
       phases: [
         {
           phase: "direct-primary",
-          delivered: false,
-          path: "direct",
-          error: "completion agent did not produce a visible reply",
-        },
-        {
-          phase: "steer-fallback",
           delivered: true,
-          path: "steered",
+          path: "direct",
           error: undefined,
         },
       ],
     });
-    expect(callGateway).toHaveBeenCalledTimes(1);
-    expect(queueEmbeddedPiMessageWithOutcome).toHaveBeenCalledTimes(2);
-    expect(queueEmbeddedPiMessageWithOutcome).toHaveBeenNthCalledWith(
-      1,
-      "requester-session-channel",
-      "child done",
-      {
-        steeringMode: "all",
-        debounceMs: 500,
-      },
-    );
-    expect(queueEmbeddedPiMessageWithOutcome).toHaveBeenNthCalledWith(
-      2,
+    expect(callGateway).toHaveBeenCalledTimes(2);
+    expectGatewayAgentParams(callGateway, {
+      deliver: true,
+      channel: "slack",
+      accountId: "acct-1",
+      to: "channel:C123",
+      threadId: undefined,
+    });
+    expectRecordFields(mockCallArg(callGateway, 1).params, {
+      deliver: false,
+      channel: "slack",
+      accountId: "acct-1",
+      to: "channel:C123",
+      threadId: undefined,
+      sourceReplyDeliveryMode: "message_tool_only",
+      idempotencyKey: "announce-channel-fallback-empty:message-tool",
+    });
+    expect(queueEmbeddedPiMessageWithOutcome).toHaveBeenCalledTimes(1);
+    expect(queueEmbeddedPiMessageWithOutcome).toHaveBeenCalledWith(
       "requester-session-channel",
       "child done",
       {

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -44,6 +44,7 @@ import {
   resolveConversationIdFromTargets,
   resolveExternalBestEffortDeliveryTarget,
   resolveQueueSettings,
+  sendMessage,
   resolveStorePath,
 } from "./subagent-announce-delivery.runtime.js";
 import {
@@ -75,6 +76,7 @@ type SubagentAnnounceDeliveryDeps = {
     text: string,
     options?: EmbeddedPiQueueMessageOptions,
   ) => EmbeddedPiQueueMessageOutcome | Promise<EmbeddedPiQueueMessageOutcome>;
+  sendMessage: typeof sendMessage;
 };
 
 const defaultSubagentAnnounceDeliveryDeps: SubagentAnnounceDeliveryDeps = {
@@ -90,6 +92,7 @@ const defaultSubagentAnnounceDeliveryDeps: SubagentAnnounceDeliveryDeps = {
     };
   },
   queueEmbeddedPiMessageWithOutcome: queueEmbeddedPiMessageWithOutcomeAsync,
+  sendMessage,
 };
 
 let subagentAnnounceDeliveryDeps: SubagentAnnounceDeliveryDeps =
@@ -535,6 +538,24 @@ function hasGatewayAgentDeliveredExpectedMedia(
   return Boolean(result && hasDeliveredExpectedMedia(result, expectedMediaUrls));
 }
 
+function buildFallbackCompletionMessage(
+  events: AgentInternalEvent[] | undefined,
+): string | undefined {
+  if (events?.length !== 1) {
+    return undefined;
+  }
+  const completion = events?.find((event) => event.type === "task_completion");
+  const result = completion?.result.trim();
+  if (!completion || !result || result === "(no output)") {
+    return undefined;
+  }
+  const taskLabel = completion.taskLabel.trim();
+  const heading = taskLabel
+    ? `Background task completed: ${taskLabel}`
+    : "Background task completed";
+  return `${heading}\n\n${result}`;
+}
+
 function getGatewayAgentCommandDeliveryFailure(response: unknown): string | undefined {
   const result = getGatewayAgentResult(response);
   return result ? getAgentCommandDeliveryFailure(result) : undefined;
@@ -793,6 +814,25 @@ async function sendSubagentAnnounceDirectly(params: {
       shouldDeliverAgentFinal &&
       !hasVisibleGatewayAgentPayload(directAnnounceResponse)
     ) {
+      const fallbackCompletionMessage = buildFallbackCompletionMessage(params.internalEvents);
+      if (fallbackCompletionMessage) {
+        await subagentAnnounceDeliveryDeps.sendMessage({
+          channel: deliveryTarget.channel,
+          to: deliveryTarget.to ?? "",
+          accountId: deliveryTarget.accountId,
+          threadId: deliveryTarget.threadId,
+          content: fallbackCompletionMessage,
+          cfg,
+          bestEffort: params.bestEffortDeliver,
+          requesterSessionKey: canonicalRequesterSessionKey,
+          agentId: resolveAgentIdFromSessionKey(canonicalRequesterSessionKey),
+          idempotencyKey: `${params.directIdempotencyKey}:completion-fallback`,
+        });
+        return {
+          delivered: true,
+          path: "direct",
+        };
+      }
       return {
         delivered: false,
         path: "direct",

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -44,7 +44,6 @@ import {
   resolveConversationIdFromTargets,
   resolveExternalBestEffortDeliveryTarget,
   resolveQueueSettings,
-  sendMessage,
   resolveStorePath,
 } from "./subagent-announce-delivery.runtime.js";
 import {
@@ -76,7 +75,6 @@ type SubagentAnnounceDeliveryDeps = {
     text: string,
     options?: EmbeddedPiQueueMessageOptions,
   ) => EmbeddedPiQueueMessageOutcome | Promise<EmbeddedPiQueueMessageOutcome>;
-  sendMessage: typeof sendMessage;
 };
 
 const defaultSubagentAnnounceDeliveryDeps: SubagentAnnounceDeliveryDeps = {
@@ -92,7 +90,6 @@ const defaultSubagentAnnounceDeliveryDeps: SubagentAnnounceDeliveryDeps = {
     };
   },
   queueEmbeddedPiMessageWithOutcome: queueEmbeddedPiMessageWithOutcomeAsync,
-  sendMessage,
 };
 
 let subagentAnnounceDeliveryDeps: SubagentAnnounceDeliveryDeps =
@@ -538,24 +535,6 @@ function hasGatewayAgentDeliveredExpectedMedia(
   return Boolean(result && hasDeliveredExpectedMedia(result, expectedMediaUrls));
 }
 
-function buildFallbackCompletionMessage(
-  events: AgentInternalEvent[] | undefined,
-): string | undefined {
-  if (events?.length !== 1) {
-    return undefined;
-  }
-  const completion = events?.find((event) => event.type === "task_completion");
-  const result = completion?.result.trim();
-  if (!completion || !result || result === "(no output)") {
-    return undefined;
-  }
-  const taskLabel = completion.taskLabel.trim();
-  const heading = taskLabel
-    ? `Background task completed: ${taskLabel}`
-    : "Background task completed";
-  return `${heading}\n\n${result}`;
-}
-
 function getGatewayAgentCommandDeliveryFailure(response: unknown): string | undefined {
   const result = getGatewayAgentResult(response);
   return result ? getAgentCommandDeliveryFailure(result) : undefined;
@@ -814,25 +793,6 @@ async function sendSubagentAnnounceDirectly(params: {
       shouldDeliverAgentFinal &&
       !hasVisibleGatewayAgentPayload(directAnnounceResponse)
     ) {
-      const fallbackCompletionMessage = buildFallbackCompletionMessage(params.internalEvents);
-      if (fallbackCompletionMessage) {
-        await subagentAnnounceDeliveryDeps.sendMessage({
-          channel: deliveryTarget.channel,
-          to: deliveryTarget.to ?? "",
-          accountId: deliveryTarget.accountId,
-          threadId: deliveryTarget.threadId,
-          content: fallbackCompletionMessage,
-          cfg,
-          bestEffort: params.bestEffortDeliver,
-          requesterSessionKey: canonicalRequesterSessionKey,
-          agentId: resolveAgentIdFromSessionKey(canonicalRequesterSessionKey),
-          idempotencyKey: `${params.directIdempotencyKey}:completion-fallback`,
-        });
-        return {
-          delivered: true,
-          path: "direct",
-        };
-      }
       return {
         delivered: false,
         path: "direct",

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -28,7 +28,10 @@ import {
   hasVisibleAgentPayload,
 } from "./pi-embedded-runner/delivery-evidence.js";
 import type { EmbeddedPiQueueMessageOptions } from "./pi-embedded-runner/run-state.js";
-import type { EmbeddedPiQueueMessageOutcome } from "./pi-embedded-runner/runs.js";
+import type {
+  EmbeddedPiQueueFailureReason,
+  EmbeddedPiQueueMessageOutcome,
+} from "./pi-embedded-runner/runs.js";
 import {
   callGateway,
   createBoundDeliveryRouter,
@@ -638,7 +641,7 @@ async function sendSubagentAnnounceDirectly(params: {
     const completionSourceReplyDeliveryMode = requiresMessageToolDelivery
       ? "message_tool_only"
       : undefined;
-    const shouldDeliverAgentFinal = deliveryTarget.deliver && !requiresMessageToolDelivery;
+    let completionWakeFailureReason: EmbeddedPiQueueFailureReason | undefined;
     const requesterActivity = resolveRequesterSessionActivity(canonicalRequesterSessionKey);
     const requesterQueueSettings = resolveQueueSettings({
       cfg,
@@ -670,6 +673,7 @@ async function sendSubagentAnnounceDirectly(params: {
           path: "steered",
         };
       }
+      completionWakeFailureReason = wakeOutcome.reason;
       const shouldFallbackToForcedAgentHandoff =
         requiresMessageToolDelivery && wakeOutcome.reason === "source_reply_delivery_mode_mismatch";
       if (requesterActivity.isActive && !shouldFallbackToForcedAgentHandoff) {
@@ -686,6 +690,7 @@ async function sendSubagentAnnounceDirectly(params: {
         };
       }
     }
+    const shouldDeliverAgentFinal = deliveryTarget.deliver && !requiresMessageToolDelivery;
     if (params.signal?.aborted) {
       return {
         delivered: false,
@@ -758,7 +763,7 @@ async function sendSubagentAnnounceDirectly(params: {
     }
 
     if (
-      requiresMessageToolDelivery &&
+      completionSourceReplyDeliveryMode &&
       !hasGatewayAgentMessagingToolDelivery(directAnnounceResponse)
     ) {
       return {
@@ -793,6 +798,40 @@ async function sendSubagentAnnounceDirectly(params: {
       shouldDeliverAgentFinal &&
       !hasVisibleGatewayAgentPayload(directAnnounceResponse)
     ) {
+      if (completionWakeFailureReason === "no_active_run") {
+        const forcedMessageToolResponse = await runAnnounceDeliveryWithRetry({
+          operation: "completion message-tool announce agent call",
+          signal: params.signal,
+          run: async () =>
+            await runAnnounceAgentCall({
+              agentParams: {
+                ...directAgentParams,
+                deliver: false,
+                sourceReplyDeliveryMode: "message_tool_only",
+                idempotencyKey: `${params.directIdempotencyKey}:message-tool`,
+              },
+              expectFinal: true,
+              timeoutMs: announceTimeoutMs,
+            }),
+        });
+        if (isGatewayAgentRunPending(forcedMessageToolResponse)) {
+          return {
+            delivered: true,
+            path: "direct",
+          };
+        }
+        if (hasGatewayAgentMessagingToolDelivery(forcedMessageToolResponse)) {
+          return {
+            delivered: true,
+            path: "direct",
+          };
+        }
+        return {
+          delivered: false,
+          path: "direct",
+          error: "completion agent did not deliver through the message tool",
+        };
+      }
       return {
         delivered: false,
         path: "direct",


### PR DESCRIPTION
## Summary

- Problem: completed subagent announcements could fail with `completion agent did not produce a visible reply` after the requester wake path hit a stale session id (`queue_message_failed reason=no_active_run`).
- Why it matters: the child run may have completed with usable output, but the requester can still see no visible completion update if both wake routing and the automatic direct handoff dead-end.
- What changed: when the initial requester wake fails with `no_active_run` and the automatic completion-agent handoff returns no visible payload, OpenClaw retries the requester-agent handoff once with `sourceReplyDeliveryMode: "message_tool_only"` and `deliver: false`.
- What did NOT change (scope boundary): no raw child completion output is sent to external chat; the requester agent still mediates the final visible update, grouped child-result guardrails remain mediated, and generated-media message-tool enforcement keeps its existing contract.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #82803
- Related #44925
- Related #79059
- Related #80223
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

Behavior addressed: Completed subagent direct announces no longer dead-end at the reported `no_active_run` plus no-visible-payload path. After the stale requester wake fails and the automatic direct handoff has no visible output, the runtime now retries a mediated requester-agent handoff that requires message-tool delivery instead of raw-sending child output.

Real environment tested: Windows local Codex worktree based on `origin/main` c2e90914b7, Node v24.15.0. Dependencies were partially installed after `pnpm install` hit an `esbuild` postinstall spawn EPERM; the direct Vitest entry was available and used for the focused delivery seam.

Exact steps or command run after this patch: `$env:OPENCLAW_VITEST_MAX_WORKERS='1'; node node_modules\vitest\vitest.mjs run src/agents/subagent-announce-delivery.test.ts --reporter=dot`

Evidence after fix: Copied terminal capture from the post-review focused delivery run:

```text
RUN  v4.1.6 C:/OpenClaw/worktrees/bug-001-subagent-completion-direct-announce

Test Files  2 passed (2)
Tests  86 passed (86)
Start at  18:50:08
Duration  27.03s (transform 12.67s, setup 967ms, import 15.41s, tests 10.11s, environment 0ms)
```

The updated assertions simulate `queueEmbeddedPiMessageWithOutcome` returning `reason: "no_active_run"`, then an automatic direct completion handoff with empty `payloads`. The runtime performs a second requester-agent handoff with `deliver: false`, `sourceReplyDeliveryMode: "message_tool_only"`, and a `:message-tool` idempotency key; the test only marks delivery successful when the second handoff reports committed message-tool evidence. The fallback `sendMessage` mock is not called.

Observed result after fix: single completed subagent thread/channel cases with stale requester runs now complete through a mediated message-tool-only retry when the first direct handoff is empty. If the retry still lacks message-tool evidence, delivery remains failed and queued for the existing retry/give-up machinery instead of raw-sending child output.

What was not tested: no live gateway/provider/channel rerun was performed. The after-fix proof is local delivery-seam execution, not a private live session replay.

Before evidence: raw runtime log excerpt from the affected gateway trace that this patch addresses:

```text
Trace/proof:
- gateway-dev.log:27070
  "Subagent completion direct announce failed for run c73d9446-0a7f-422d-a904-4f0a5e92b556: completion agent did not produce a visible reply"
  traceId=be3befc660e5cba4364d3d60bdbcc9a9 spanId=c0e47fb6cf0e786b
- Neighboring same trace:
  gateway-dev.log:27069 "queue message failed: sessionId=4d1ec534-2295-41cf-b55a-9300cc14f1f1 reason=no_active_run"
```

## Root Cause (if applicable)

- Root cause: `sendSubagentAnnounceDirectly` detected the empty automatic completion-agent handoff but did not distinguish the reported stale requester wake (`no_active_run`) from ordinary no-visible output, so the path could fail without trying the stricter message-tool-only mediated handoff.
- Missing detection / guardrail: coverage previously proved only the already-existing direct-then-steer branch. It did not cover `no_active_run` followed by an empty automatic direct handoff.
- Contributing context (if known): prior fallback scaffolding that raw-sent child output was removed by 92284bc460 / #78700; this patch keeps the repair within the requester-agent delivery contract documented for no-output handoffs.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/subagent-announce-delivery.test.ts`
- Scenario the test should lock in: a stale requester wake returns `no_active_run`, the automatic requester-agent completion handoff returns empty payloads, and the runtime retries the same mediated handoff with `sourceReplyDeliveryMode: "message_tool_only"` without raw-sending child completion text.
- Why this is the smallest reliable guardrail: it exercises the delivery decision seam directly without requiring a live provider to intentionally produce an empty final response.
- Existing test that already covers this (if any): existing no-visible-output tests covered the failure and the direct-then-steer fallback; this PR adds the stale-run message-tool retry behavior.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Completed subagent announcements that previously dead-ended after a stale requester wake and empty automatic handoff can now be retried through a message-tool-only requester-agent handoff, producing a visible update when the requester agent sends through the message tool.

## Diagram (if applicable)

```text
Before:
[subagent completed] -> [wake requester: no_active_run] -> [automatic direct handoff: empty payload] -> [delivery failure]

After:
[subagent completed] -> [wake requester: no_active_run] -> [automatic direct handoff: empty payload] -> [message-tool-only requester handoff] -> [visible requester update]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows local worktree for the regression test; original gateway log OS not grounded.
- Runtime/container: Node v24.15.0 for local Vitest; OpenClaw current `main` c2e90914b7 before fix.
- Model/provider: NOT_ENOUGH_INFO from the original log evidence.
- Integration/channel (if any): regression covers Slack-style thread/channel delivery helpers; original log channel not grounded.
- Relevant config (redacted): NOT_ENOUGH_INFO

### Steps

1. Run the focused delivery regression file.
2. In the single-completion cases, mock the requester wake queue attempt as `reason: "no_active_run"`.
3. Mock the automatic requester-agent direct handoff as `{ result: { payloads: [] } }`.
4. Verify the runtime makes a second requester-agent handoff with `deliver: false` and `sourceReplyDeliveryMode: "message_tool_only"`.
5. Verify delivery succeeds only when that second handoff reports committed message-tool evidence, and verify the raw `sendMessage` fallback mock is not called.

### Expected

- Stale requester wake plus empty automatic direct handoff retries through a mediated message-tool-only requester-agent handoff.
- Raw child output is not sent directly to external chat.
- Grouped and media completion guardrails remain enforced.

### Actual

- Matches expected after this patch.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: focused delivery regression file passed locally with 86 tests across both configured Vitest projects.
- Edge cases checked: stale-run no-visible single thread/channel completions retry through message-tool-only handoff; grouped child-result fallback remains mediated and does not raw-send; generated-media message-tool enforcement remains covered by existing tests in the same file.
- What you did **not** verify: live provider/channel behavior requiring private sessions or credentials.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: the message-tool-only retry can still fail if the requester agent does not send through the message tool.
  - Mitigation: that failure remains explicit and feeds the existing retry/give-up machinery instead of bypassing the requester-agent contract with raw child output.
