### PR TITLE
fix(codex): isolate app-server clients per runtime key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ Docs: https://docs.openclaw.ai
 
 - Security/audit: add `security.audit.suppressions` for intentionally accepted audit findings, keeping suppressed matches out of the active summary while preserving them in JSON output with an active suppression notice. (#76949) Thanks @100menotu001.
 - Agents/subagents: label delegated task and subagent completion handoffs as ready for parent review, and tell requester agents to review/verify results before calling them done. (#78985) Thanks @100menotu001.
-- Maintainer tooling: warn before running JS package commands on raw Crabbox AWS boxes, pointing maintainers to Actions hydration or Blacksmith Testbox for CI-like proof.
 - Control UI: show provider quota usage in the Overview card and Chat header, and recover stale Chat in-progress state after missed terminal events. (#82647)
 - Providers/xAI: add xAI Grok OAuth login for SuperGrok subscribers, letting `xai/*` models and xAI media/tool providers authenticate without `XAI_API_KEY`.
 - CLI/cron: add `openclaw cron run --wait` with timeout and poll interval controls, plus exact `cron.runs --run-id` filtering so automation can block on one queued manual run. (#81929) Thanks @ificator.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 - Security/audit: add `security.audit.suppressions` for intentionally accepted audit findings, keeping suppressed matches out of the active summary while preserving them in JSON output with an active suppression notice. (#76949) Thanks @100menotu001.
 - Agents/subagents: label delegated task and subagent completion handoffs as ready for parent review, and tell requester agents to review/verify results before calling them done. (#78985) Thanks @100menotu001.
+- Maintainer tooling: warn before running JS package commands on raw Crabbox AWS boxes, pointing maintainers to Actions hydration or Blacksmith Testbox for CI-like proof.
 - Control UI: show provider quota usage in the Overview card and Chat header, and recover stale Chat in-progress state after missed terminal events. (#82647)
 - Providers/xAI: add xAI Grok OAuth login for SuperGrok subscribers, letting `xai/*` models and xAI media/tool providers authenticate without `XAI_API_KEY`.
 - CLI/cron: add `openclaw cron run --wait` with timeout and poll interval controls, plus exact `cron.runs --run-id` filtering so automation can block on one queued manual run. (#81929) Thanks @ificator.
@@ -26,6 +27,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Channels/stream previews: contain rejected background draft-stream flushes so preview send failures do not surface as fatal unhandled rejections. Fixes #82712. (#82713) Thanks @coygeek.
+- Codex/app-server: keep shared native app-server clients isolated per agent runtime key so starting one agent no longer closes another agent's active Codex turn. Fixes #82758. Thanks @PashaGanson.
 - Providers/OpenAI Codex: include base `gpt-5.5` and `gpt-5.4` reasoning metadata in the bundled Codex catalog so `/think xhigh` remains available for those models. Fixes #82744.
 - Providers/MiniMax: declare CN endpoint auth aliases in the plugin manifest so `minimax-cn` and `minimax-portal-cn` reuse the correct base auth profiles instead of falling back to unrelated models after 401s. Fixes #63823. Thanks @kamusis.
 - Agents/model fallback: suppress fallback notices when the active OpenAI Codex runtime reports the same canonical OpenAI model.

--- a/extensions/codex/src/app-server/config.test.ts
+++ b/extensions/codex/src/app-server/config.test.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs/promises";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   CODEX_APP_SERVER_CONFIG_KEYS,
   CODEX_COMPUTER_USE_CONFIG_KEYS,
@@ -771,6 +771,26 @@ allowed_sandbox_modes = ["read-only", "workspace-write"]
     ).toEqual(first);
     expect(first).not.toContain("sk-first");
     expect(second).not.toContain("sk-second");
+  });
+
+  it("keeps secret-derived shared-client keys stable across module reloads", async () => {
+    const startOptions = {
+      transport: "websocket" as const,
+      command: "codex",
+      args: [],
+      url: "ws://127.0.0.1:39175",
+      authToken: "tok_reload",
+      headers: {},
+      env: { OPENAI_API_KEY: "sk-reload" },
+    };
+    const first = codexAppServerStartOptionsKey(startOptions);
+
+    vi.resetModules();
+    const reloaded = await import("./config.js");
+
+    expect(reloaded.codexAppServerStartOptionsKey(startOptions)).toEqual(first);
+    expect(first).not.toContain("tok_reload");
+    expect(first).not.toContain("sk-reload");
   });
 
   it("derives distinct shared-client keys for distinct agent dirs", () => {

--- a/extensions/codex/src/app-server/config.ts
+++ b/extensions/codex/src/app-server/config.ts
@@ -4,7 +4,8 @@ import { hostname as readHostName } from "node:os";
 import { z } from "zod";
 import type { CodexSandboxPolicy, CodexServiceTier } from "./protocol.js";
 
-const START_OPTIONS_KEY_SECRET = randomBytes(32);
+const START_OPTIONS_KEY_SECRET_SYMBOL = Symbol.for("openclaw.codexAppServerStartOptionsKeySecret");
+const START_OPTIONS_KEY_SECRET = getStartOptionsKeySecret();
 const UNIX_CODEX_REQUIREMENTS_PATH = "/etc/codex/requirements.toml";
 const WINDOWS_CODEX_REQUIREMENTS_SUFFIX = "\\OpenAI\\Codex\\requirements.toml";
 
@@ -989,6 +990,14 @@ function hashSecretForKey(value: string | undefined, label: string): string | nu
     .update("\0")
     .update(value)
     .digest("hex");
+}
+
+function getStartOptionsKeySecret(): Buffer {
+  const globalState = globalThis as typeof globalThis & {
+    [START_OPTIONS_KEY_SECRET_SYMBOL]?: Buffer;
+  };
+  globalState[START_OPTIONS_KEY_SECRET_SYMBOL] ??= randomBytes(32);
+  return globalState[START_OPTIONS_KEY_SECRET_SYMBOL];
 }
 
 function splitShellWords(value: string): string[] {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -4849,6 +4849,46 @@ describe("runCodexAppServerAttempt", () => {
     expect(result.timedOut).toBe(false);
   });
 
+  it("does not fail when a buffered terminal notification is followed by client close", async () => {
+    let harness: ReturnType<typeof createAppServerHarness>;
+    let resolveBufferedTerminal!: () => void;
+    const bufferedTerminal = new Promise<void>((resolve) => {
+      resolveBufferedTerminal = resolve;
+    });
+    harness = createAppServerHarness(async (method) => {
+      if (method === "thread/start") {
+        return threadStartResult();
+      }
+      if (method === "turn/start") {
+        await harness.notify({
+          method: "item/started",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            item: { id: "tool-1", type: "commandExecution" },
+          },
+        });
+        await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+        resolveBufferedTerminal();
+        return turnStartResult("turn-1", "inProgress");
+      }
+      return {};
+    });
+
+    const run = runCodexAppServerAttempt(
+      createParams(path.join(tempDir, "session.jsonl"), path.join(tempDir, "workspace")),
+      { turnTerminalIdleTimeoutMs: 60_000 },
+    );
+    await bufferedTerminal;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    harness.close();
+
+    const result = await run;
+    expect(result.promptError ?? undefined).toBeUndefined();
+    expect(result.aborted).toBe(false);
+    expect(result.timedOut).toBe(false);
+  });
+
   it("does not time out when turn progress arrives before turn/start returns", async () => {
     let harness: ReturnType<typeof createAppServerHarness>;
     harness = createAppServerHarness(async (method) => {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -5045,7 +5045,7 @@ describe("runCodexAppServerAttempt", () => {
 
     const result = await run;
     expect(result.promptError).toBe("codex app-server client closed before turn completed");
-    expect(result.aborted).toBe(false);
+    expect(result.aborted).toBe(true);
     expect(result.timedOut).toBe(false);
   });
 

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -238,6 +238,7 @@ function createAppServerHarness(
   const requests: Array<{ method: string; params: unknown }> = [];
   let notify: (notification: CodexServerNotification) => Promise<void> = async () => undefined;
   let handleServerRequest: AppServerRequestHandler | undefined;
+  const closeHandlers = new Set<() => void>();
   const request = vi.fn(async (method: string, params?: unknown) => {
     requests.push({ method, params });
     return requestImpl(method, params);
@@ -254,6 +255,10 @@ function createAppServerHarness(
       addRequestHandler: (handler: AppServerRequestHandler) => {
         handleServerRequest = handler;
         return () => undefined;
+      },
+      addCloseHandler: (handler: () => void) => {
+        closeHandlers.add(handler);
+        return () => closeHandlers.delete(handler);
       },
     } as never;
   });
@@ -301,6 +306,11 @@ function createAppServerHarness(
           turn: { id: params.turnId, status: "completed" },
         },
       });
+    },
+    close() {
+      for (const handler of closeHandlers) {
+        handler();
+      }
     },
   };
 }
@@ -5020,6 +5030,23 @@ describe("runCodexAppServerAttempt", () => {
     expect(result.timedOut).toBe(false);
     expect(result.promptError).toBeNull();
     expect(harness.request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
+  });
+
+  it("releases completion when the app-server client closes during an active turn", async () => {
+    const harness = createStartedThreadHarness();
+    const run = runCodexAppServerAttempt(
+      createParams(path.join(tempDir, "session.jsonl"), path.join(tempDir, "workspace")),
+      { turnTerminalIdleTimeoutMs: 60_000 },
+    );
+
+    await harness.waitForMethod("turn/start");
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    harness.close();
+
+    const result = await run;
+    expect(result.promptError).toBe("codex app-server client closed before turn completed");
+    expect(result.aborted).toBe(false);
+    expect(result.timedOut).toBe(false);
   });
 
   it("does not treat a user prompt containing the interrupted marker as terminal", async () => {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -5049,6 +5049,24 @@ describe("runCodexAppServerAttempt", () => {
     expect(result.timedOut).toBe(false);
   });
 
+  it("does not fail a turn when the client closes after terminal completion is queued", async () => {
+    const harness = createStartedThreadHarness();
+    const run = runCodexAppServerAttempt(
+      createParams(path.join(tempDir, "session.jsonl"), path.join(tempDir, "workspace")),
+      { turnTerminalIdleTimeoutMs: 60_000 },
+    );
+
+    await harness.waitForMethod("turn/start");
+    const completed = harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    harness.close();
+    await completed;
+
+    const result = await run;
+    expect(result.promptError ?? undefined).toBeUndefined();
+    expect(result.aborted).toBe(false);
+    expect(result.timedOut).toBe(false);
+  });
+
   it("does not treat a user prompt containing the interrupted marker as terminal", async () => {
     const harness = createStartedThreadHarness();
     const markerPrompt =

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -5085,7 +5085,7 @@ describe("runCodexAppServerAttempt", () => {
 
     const result = await run;
     expect(result.promptError).toBe("codex app-server client closed before turn completed");
-    expect(result.aborted).toBe(true);
+    expect(result.aborted).toBe(false);
     expect(result.timedOut).toBe(false);
   });
 

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1464,6 +1464,19 @@ export async function runCodexAppServerAttempt(
     });
   };
 
+  const isTerminalTurnNotificationForTurn = (
+    notification: CodexServerNotification,
+    notificationTurnId: string,
+  ): boolean => {
+    if (!isTurnNotification(notification.params, thread.threadId, notificationTurnId)) {
+      return false;
+    }
+    return (
+      notification.method === "turn/completed" ||
+      isCodexTurnAbortMarkerNotification(notification, { currentPromptText: promptBuild.prompt })
+    );
+  };
+
   const handleNotification = async (notification: CodexServerNotification) => {
     userInputBridge?.handleNotification(notification);
     if (!projector || !turnId) {
@@ -1562,7 +1575,7 @@ export async function runCodexAppServerAttempt(
     const isTurnAbortMarker =
       isCurrentTurnNotification &&
       isCodexTurnAbortMarkerNotification(notification, { currentPromptText: promptBuild.prompt });
-    const isTurnTerminal = isTurnCompletion || isTurnAbortMarker;
+    const isTurnTerminal = isTerminalTurnNotificationForTurn(notification, turnId);
     if (isTurnTerminal) {
       terminalTurnNotificationQueued = true;
     }
@@ -1596,16 +1609,7 @@ export async function runCodexAppServerAttempt(
       pendingNotifications.push(notification);
       return Promise.resolve();
     }
-    const isCurrentTurnNotification = isTurnNotification(
-      notification.params,
-      thread.threadId,
-      turnId,
-    );
-    if (
-      isCurrentTurnNotification &&
-      (notification.method === "turn/completed" ||
-        isCodexTurnAbortMarkerNotification(notification, { currentPromptText: promptBuild.prompt }))
-    ) {
+    if (isTerminalTurnNotificationForTurn(notification, turnId)) {
       terminalTurnNotificationQueued = true;
     }
     notificationQueue = notificationQueue.then(
@@ -2034,6 +2038,14 @@ export async function runCodexAppServerAttempt(
     nativePostToolUseRelayEnabled:
       nativeHookRelay?.allowedEvents.includes("post_tool_use") === true,
   });
+  if (
+    isTerminalTurnStatus(turn.turn.status) ||
+    pendingNotifications.some((notification) =>
+      isTerminalTurnNotificationForTurn(notification, activeTurnId),
+    )
+  ) {
+    terminalTurnNotificationQueued = true;
+  }
   closeCleanup = (
     client as {
       addCloseHandler?: (handler: (client: CodexAppServerClient) => void) => () => void;

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1035,6 +1035,7 @@ export async function runCodexAppServerAttempt(
   let userInputBridge: ReturnType<typeof createCodexUserInputBridge> | undefined;
   let steeringQueue: ReturnType<typeof createCodexSteeringQueue> | undefined;
   let completed = false;
+  let terminalTurnNotificationQueued = false;
   let timedOut = false;
   let turnCompletionIdleTimedOut = false;
   let turnCompletionIdleTimeoutMessage: string | undefined;
@@ -1562,6 +1563,9 @@ export async function runCodexAppServerAttempt(
       isCurrentTurnNotification &&
       isCodexTurnAbortMarkerNotification(notification, { currentPromptText: promptBuild.prompt });
     const isTurnTerminal = isTurnCompletion || isTurnAbortMarker;
+    if (isTurnTerminal) {
+      terminalTurnNotificationQueued = true;
+    }
     try {
       await waitForCodexNotificationDispatchTurn();
       await projector.handleNotification(notification);
@@ -1591,6 +1595,18 @@ export async function runCodexAppServerAttempt(
       userInputBridge?.handleNotification(notification);
       pendingNotifications.push(notification);
       return Promise.resolve();
+    }
+    const isCurrentTurnNotification = isTurnNotification(
+      notification.params,
+      thread.threadId,
+      turnId,
+    );
+    if (
+      isCurrentTurnNotification &&
+      (notification.method === "turn/completed" ||
+        isCodexTurnAbortMarkerNotification(notification, { currentPromptText: promptBuild.prompt }))
+    ) {
+      terminalTurnNotificationQueued = true;
     }
     notificationQueue = notificationQueue.then(
       () => handleNotification(notification),
@@ -2023,7 +2039,7 @@ export async function runCodexAppServerAttempt(
       addCloseHandler?: (handler: (client: CodexAppServerClient) => void) => () => void;
     }
   ).addCloseHandler?.(() => {
-    if (completed || runAbortController.signal.aborted) {
+    if (completed || terminalTurnNotificationQueued || runAbortController.signal.aborted) {
       return;
     }
     clientClosedPromptError = "codex app-server client closed before turn completed";

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1038,6 +1038,7 @@ export async function runCodexAppServerAttempt(
   let timedOut = false;
   let turnCompletionIdleTimedOut = false;
   let turnCompletionIdleTimeoutMessage: string | undefined;
+  let clientClosedPromptError: string | undefined;
   let lifecycleStarted = false;
   let lifecycleTerminalEmitted = false;
   let resolveCompletion: (() => void) | undefined;
@@ -1758,6 +1759,7 @@ export async function runCodexAppServerAttempt(
       }
     }
   });
+  let closeCleanup: (() => void) | undefined;
 
   const forceContextEngineCompactionForCodexOverflow = async (error: unknown): Promise<boolean> => {
     if (!activeContextEngine?.info.ownsCompaction) {
@@ -2016,6 +2018,30 @@ export async function runCodexAppServerAttempt(
     nativePostToolUseRelayEnabled:
       nativeHookRelay?.allowedEvents.includes("post_tool_use") === true,
   });
+  closeCleanup = (
+    client as {
+      addCloseHandler?: (handler: (client: CodexAppServerClient) => void) => () => void;
+    }
+  ).addCloseHandler?.(() => {
+    if (completed || runAbortController.signal.aborted) {
+      return;
+    }
+    clientClosedPromptError = "codex app-server client closed before turn completed";
+    trajectoryRecorder?.recordEvent("turn.client_closed", {
+      threadId: thread.threadId,
+      turnId: activeTurnId,
+    });
+    embeddedAgentLog.warn("codex app-server client closed before turn completed", {
+      threadId: thread.threadId,
+      turnId: activeTurnId,
+    });
+    completed = true;
+    clearTurnAttemptIdleTimer();
+    clearTurnCompletionIdleTimer();
+    clearTurnAssistantCompletionIdleTimer();
+    clearTurnTerminalIdleTimer();
+    resolveCompletion?.();
+  });
   emitLifecycleStart();
   const activeProjector = projector;
   turnTerminalIdleWatchArmed = true;
@@ -2081,11 +2107,13 @@ export async function runCodexAppServerAttempt(
     await completion;
     const result = activeProjector.buildResult(toolBridge.telemetry, { yieldDetected });
     const finalAborted = result.aborted || runAbortController.signal.aborted;
-    let finalPromptError = turnCompletionIdleTimedOut
-      ? turnCompletionIdleTimeoutMessage
-      : timedOut
-        ? "codex app-server attempt timed out"
-        : result.promptError;
+    let finalPromptError =
+      clientClosedPromptError ??
+      (turnCompletionIdleTimedOut
+        ? turnCompletionIdleTimeoutMessage
+        : timedOut
+          ? "codex app-server attempt timed out"
+          : result.promptError);
     const finalPromptErrorMessage =
       typeof finalPromptError === "string"
         ? finalPromptError
@@ -2104,7 +2132,8 @@ export async function runCodexAppServerAttempt(
         signal: runAbortController.signal,
       });
     }
-    const finalPromptErrorSource = timedOut ? "prompt" : result.promptErrorSource;
+    const finalPromptErrorSource =
+      timedOut || clientClosedPromptError ? "prompt" : result.promptErrorSource;
     recordCodexTrajectoryCompletion(trajectoryRecorder, {
       attempt: params,
       result,
@@ -2247,6 +2276,7 @@ export async function runCodexAppServerAttempt(
     clearTurnTerminalIdleTimer();
     notificationCleanup();
     requestCleanup();
+    closeCleanup?.();
     nativeHookRelay?.unregister();
     runAbortController.signal.removeEventListener("abort", abortListener);
     params.abortSignal?.removeEventListener("abort", abortFromUpstream);

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -2035,6 +2035,7 @@ export async function runCodexAppServerAttempt(
       threadId: thread.threadId,
       turnId: activeTurnId,
     });
+    runAbortController.abort("client_closed");
     completed = true;
     clearTurnAttemptIdleTimer();
     clearTurnCompletionIdleTimer();

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1040,6 +1040,7 @@ export async function runCodexAppServerAttempt(
   let turnCompletionIdleTimedOut = false;
   let turnCompletionIdleTimeoutMessage: string | undefined;
   let clientClosedPromptError: string | undefined;
+  let clientClosedAbort = false;
   let lifecycleStarted = false;
   let lifecycleTerminalEmitted = false;
   let resolveCompletion: (() => void) | undefined;
@@ -2063,6 +2064,7 @@ export async function runCodexAppServerAttempt(
       threadId: thread.threadId,
       turnId: activeTurnId,
     });
+    clientClosedAbort = true;
     runAbortController.abort("client_closed");
     completed = true;
     clearTurnAttemptIdleTimer();
@@ -2135,7 +2137,8 @@ export async function runCodexAppServerAttempt(
   try {
     await completion;
     const result = activeProjector.buildResult(toolBridge.telemetry, { yieldDetected });
-    const finalAborted = result.aborted || runAbortController.signal.aborted;
+    const finalAborted =
+      result.aborted || (runAbortController.signal.aborted && !clientClosedAbort);
     let finalPromptError =
       clientClosedPromptError ??
       (turnCompletionIdleTimedOut
@@ -2279,11 +2282,14 @@ export async function runCodexAppServerAttempt(
     });
     if (trajectoryRecorder && !trajectoryEndRecorded) {
       trajectoryRecorder.recordEvent("session.ended", {
-        status: timedOut || runAbortController.signal.aborted ? "interrupted" : "cleanup",
+        status:
+          timedOut || (runAbortController.signal.aborted && !clientClosedAbort)
+            ? "interrupted"
+            : "cleanup",
         threadId: thread.threadId,
         turnId: activeTurnId,
         timedOut,
-        aborted: runAbortController.signal.aborted,
+        aborted: runAbortController.signal.aborted && !clientClosedAbort,
       });
     }
     await runAgentCleanupStep({

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -39,6 +39,7 @@ vi.mock("openclaw/plugin-sdk/agent-runtime", () => ({
 let listCodexAppServerModels: typeof import("./models.js").listCodexAppServerModels;
 let clearSharedCodexAppServerClient: typeof import("./shared-client.js").clearSharedCodexAppServerClient;
 let clearSharedCodexAppServerClientIfCurrent: typeof import("./shared-client.js").clearSharedCodexAppServerClientIfCurrent;
+let clearSharedCodexAppServerClientIfCurrentAndWait: typeof import("./shared-client.js").clearSharedCodexAppServerClientIfCurrentAndWait;
 let createIsolatedCodexAppServerClient: typeof import("./shared-client.js").createIsolatedCodexAppServerClient;
 let getSharedCodexAppServerClient: typeof import("./shared-client.js").getSharedCodexAppServerClient;
 let resetSharedCodexAppServerClientForTests: typeof import("./shared-client.js").resetSharedCodexAppServerClientForTests;
@@ -111,6 +112,7 @@ describe("shared Codex app-server client", () => {
     ({
       clearSharedCodexAppServerClient,
       clearSharedCodexAppServerClientIfCurrent,
+      clearSharedCodexAppServerClientIfCurrentAndWait,
       createIsolatedCodexAppServerClient,
       getSharedCodexAppServerClient,
       resetSharedCodexAppServerClientForTests,
@@ -474,6 +476,44 @@ describe("shared Codex app-server client", () => {
     expect(second.process.kill).not.toHaveBeenCalled();
     expect(clearSharedCodexAppServerClientIfCurrent(second.client)).toBe(true);
     expect(second.process.stdin.destroyed).toBe(true);
+  });
+
+  it("waits only for the shared client that is still current", async () => {
+    const first = createClientHarness();
+    const second = createClientHarness();
+    vi.spyOn(CodexAppServerClient, "start")
+      .mockReturnValueOnce(first.client)
+      .mockReturnValueOnce(second.client);
+    const firstCloseAndWait = vi.spyOn(first.client, "closeAndWait");
+    const secondCloseAndWait = vi.spyOn(second.client, "closeAndWait");
+
+    const firstList = listCodexAppServerModels({
+      timeoutMs: 1000,
+      agentDir: "/tmp/openclaw-agent-one",
+    });
+    await sendInitializeResult(first, "openclaw/0.125.0 (macOS; test)");
+    await sendEmptyModelList(first);
+    await expect(firstList).resolves.toEqual({ models: [] });
+
+    const secondList = listCodexAppServerModels({
+      timeoutMs: 1000,
+      agentDir: "/tmp/openclaw-agent-two",
+    });
+    await sendInitializeResult(second, "openclaw/0.125.0 (macOS; test)");
+    await sendEmptyModelList(second);
+    await expect(secondList).resolves.toEqual({ models: [] });
+
+    await expect(
+      clearSharedCodexAppServerClientIfCurrentAndWait(first.client, {
+        exitTimeoutMs: 25,
+        forceKillDelayMs: 5,
+      }),
+    ).resolves.toBe(true);
+
+    expect(firstCloseAndWait).toHaveBeenCalledTimes(1);
+    expect(secondCloseAndWait).not.toHaveBeenCalled();
+    expect(first.process.stdin.destroyed).toBe(true);
+    expect(second.process.stdin.destroyed).toBe(false);
   });
 
   it("uses a fresh websocket Authorization header after shared-client token rotation", async () => {

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { WebSocketServer, type RawData } from "ws";
 import { CodexAppServerClient, MIN_CODEX_APP_SERVER_VERSION } from "./client.js";
+import { codexAppServerStartOptionsKey } from "./config.js";
 import { createClientHarness } from "./test-support.js";
 
 const mocks = vi.hoisted(() => ({
@@ -272,6 +273,41 @@ describe("shared Codex app-server client", () => {
     const applyCall = applyAuthProfileCall();
     expect(applyCall?.agentDir).toBe("/tmp/openclaw-agent-nova");
     expect(applyCall?.authProfileId).toBe("openai-codex:work");
+  });
+
+  it("migrates legacy singleton global state into the keyed registry", async () => {
+    const legacy = createClientHarness();
+    const next = createClientHarness();
+    const startOptions = {
+      transport: "websocket" as const,
+      command: "codex",
+      args: [],
+      url: "ws://127.0.0.1:39175",
+      authToken: "tok-legacy",
+      headers: {},
+    };
+    const key = codexAppServerStartOptionsKey(startOptions, {
+      agentDir: "/tmp/openclaw-agent",
+    });
+    const globalState = globalThis as typeof globalThis & {
+      [key: symbol]: unknown;
+    };
+    globalState[Symbol.for("openclaw.codexAppServerClientState")] = {
+      key,
+      client: legacy.client,
+      promise: Promise.resolve(legacy.client),
+    };
+
+    await expect(getSharedCodexAppServerClient({ startOptions })).resolves.toBe(legacy.client);
+
+    legacy.client.close();
+    const startSpy = vi.spyOn(CodexAppServerClient, "start").mockReturnValue(next.client);
+    const list = listCodexAppServerModels({ timeoutMs: 1000, startOptions });
+    await sendInitializeResult(next, "openclaw/0.125.0 (macOS; test)");
+    await sendEmptyModelList(next);
+
+    await expect(list).resolves.toEqual({ models: [] });
+    expect(startSpy).toHaveBeenCalledTimes(1);
   });
 
   it("keeps an active shared client alive when another agent dir uses a different key", async () => {

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -274,6 +274,35 @@ describe("shared Codex app-server client", () => {
     expect(applyCall?.authProfileId).toBe("openai-codex:work");
   });
 
+  it("keeps an active shared client alive when another agent dir uses a different key", async () => {
+    const first = createClientHarness();
+    const second = createClientHarness();
+    const startSpy = vi
+      .spyOn(CodexAppServerClient, "start")
+      .mockReturnValueOnce(first.client)
+      .mockReturnValueOnce(second.client);
+
+    const firstList = listCodexAppServerModels({
+      timeoutMs: 1000,
+      agentDir: "/tmp/openclaw-agent-one",
+    });
+    await sendInitializeResult(first, "openclaw/0.125.0 (macOS; test)");
+    await sendEmptyModelList(first);
+    await expect(firstList).resolves.toEqual({ models: [] });
+
+    const secondList = listCodexAppServerModels({
+      timeoutMs: 1000,
+      agentDir: "/tmp/openclaw-agent-two",
+    });
+    await sendInitializeResult(second, "openclaw/0.125.0 (macOS; test)");
+    await sendEmptyModelList(second);
+    await expect(secondList).resolves.toEqual({ models: [] });
+
+    expect(startSpy).toHaveBeenCalledTimes(2);
+    expect(first.process.stdin.destroyed).toBe(false);
+    expect(second.process.stdin.destroyed).toBe(false);
+  });
+
   it("resolves the managed binary before bridging and spawning the shared client", async () => {
     const harness = createClientHarness();
     const startSpy = vi.spyOn(CodexAppServerClient, "start").mockReturnValue(harness.client);
@@ -299,7 +328,7 @@ describe("shared Codex app-server client", () => {
     expect(startCall?.commandSource).toBe("resolved-managed");
   });
 
-  it("restarts the shared client when the bridged auth token changes", async () => {
+  it("starts an independent shared client when the bridged auth token changes", async () => {
     const first = createClientHarness();
     const second = createClientHarness();
     const startSpy = vi
@@ -338,10 +367,10 @@ describe("shared Codex app-server client", () => {
     await expect(secondList).resolves.toEqual({ models: [] });
 
     expect(startSpy).toHaveBeenCalledTimes(2);
-    expect(first.process.stdin.destroyed).toBe(true);
+    expect(first.process.stdin.destroyed).toBe(false);
   });
 
-  it("does not let a superseded shared-client failure tear down the newer client", async () => {
+  it("does not let one shared-client failure tear down another keyed client", async () => {
     const first = createClientHarness();
     const second = createClientHarness();
     vi.spyOn(CodexAppServerClient, "start")
@@ -375,11 +404,12 @@ describe("shared Codex app-server client", () => {
     });
     await vi.waitFor(() => expect(second.writes.length).toBeGreaterThanOrEqual(1));
 
-    await expect(firstFailure).resolves.toBeInstanceOf(Error);
-
     await sendInitializeResult(second, "openclaw/0.125.0 (macOS; test)");
     await sendEmptyModelList(second);
     await expect(secondList).resolves.toEqual({ models: [] });
+
+    first.client.close();
+    await expect(firstFailure).resolves.toBeInstanceOf(Error);
 
     expect(second.process.kill).not.toHaveBeenCalled();
   });

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -198,6 +198,27 @@ export function clearSharedCodexAppServerClientIfCurrent(
   return false;
 }
 
+export async function clearSharedCodexAppServerClientIfCurrentAndWait(
+  client: CodexAppServerClient | undefined,
+  options?: {
+    exitTimeoutMs?: number;
+    forceKillDelayMs?: number;
+  },
+): Promise<boolean> {
+  if (!client) {
+    return false;
+  }
+  const state = getSharedCodexAppServerClientState();
+  for (const [key, entry] of state.clients) {
+    if (entry.client === client) {
+      state.clients.delete(key);
+      await client.closeAndWait(options);
+      return true;
+    }
+  }
+  return false;
+}
+
 export async function clearSharedCodexAppServerClientAndWait(options?: {
   exitTimeoutMs?: number;
   forceKillDelayMs?: number;

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -22,13 +22,31 @@ type SharedCodexAppServerClientState = {
   clients: Map<string, SharedCodexAppServerClientEntry>;
 };
 
+type LegacySharedCodexAppServerClientState = Partial<SharedCodexAppServerClientEntry> & {
+  key?: string;
+  clients?: unknown;
+};
+
 const SHARED_CODEX_APP_SERVER_CLIENT_STATE = Symbol.for("openclaw.codexAppServerClientState");
 
 function getSharedCodexAppServerClientState(): SharedCodexAppServerClientState {
   const globalState = globalThis as typeof globalThis & {
-    [SHARED_CODEX_APP_SERVER_CLIENT_STATE]?: SharedCodexAppServerClientState;
+    [SHARED_CODEX_APP_SERVER_CLIENT_STATE]?:
+      | SharedCodexAppServerClientState
+      | LegacySharedCodexAppServerClientState;
   };
-  globalState[SHARED_CODEX_APP_SERVER_CLIENT_STATE] ??= { clients: new Map() };
+  const state = globalState[SHARED_CODEX_APP_SERVER_CLIENT_STATE];
+  if (state?.clients instanceof Map) {
+    return state as SharedCodexAppServerClientState;
+  }
+  const clients = new Map<string, SharedCodexAppServerClientEntry>();
+  if (state?.key && (state.client || state.promise)) {
+    clients.set(state.key, { client: state.client, promise: state.promise });
+    state.client?.addCloseHandler((closedClient) =>
+      clearSharedClientEntryIfCurrent(state.key!, closedClient),
+    );
+  }
+  globalState[SHARED_CODEX_APP_SERVER_CLIENT_STATE] = { clients };
   return globalState[SHARED_CODEX_APP_SERVER_CLIENT_STATE];
 }
 

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -13,10 +13,13 @@ import {
 import { resolveManagedCodexAppServerStartOptions } from "./managed-binary.js";
 import { withTimeout } from "./timeout.js";
 
-type SharedCodexAppServerClientState = {
+type SharedCodexAppServerClientEntry = {
   client?: CodexAppServerClient;
   promise?: Promise<CodexAppServerClient>;
-  key?: string;
+};
+
+type SharedCodexAppServerClientState = {
+  clients: Map<string, SharedCodexAppServerClientEntry>;
 };
 
 const SHARED_CODEX_APP_SERVER_CLIENT_STATE = Symbol.for("openclaw.codexAppServerClientState");
@@ -25,7 +28,7 @@ function getSharedCodexAppServerClientState(): SharedCodexAppServerClientState {
   const globalState = globalThis as typeof globalThis & {
     [SHARED_CODEX_APP_SERVER_CLIENT_STATE]?: SharedCodexAppServerClientState;
   };
-  globalState[SHARED_CODEX_APP_SERVER_CLIENT_STATE] ??= {};
+  globalState[SHARED_CODEX_APP_SERVER_CLIENT_STATE] ??= { clients: new Map() };
   return globalState[SHARED_CODEX_APP_SERVER_CLIENT_STATE];
 }
 
@@ -36,7 +39,6 @@ export async function getSharedCodexAppServerClient(options?: {
   agentDir?: string;
   config?: Parameters<typeof resolveCodexAppServerAuthProfileIdForAgent>[0]["config"];
 }): Promise<CodexAppServerClient> {
-  const state = getSharedCodexAppServerClientState();
   const agentDir = options?.agentDir ?? resolveDefaultAgentDir(options?.config ?? {});
   const usesNativeAuth = options?.authProfileId === null;
   const requestedAuthProfileId =
@@ -61,16 +63,14 @@ export async function getSharedCodexAppServerClient(options?: {
     authProfileId,
     agentDir: usesNativeAuth ? undefined : agentDir,
   });
-  if (state.key && state.key !== key) {
-    clearSharedCodexAppServerClient();
-  }
-  state.key = key;
+  const state = getSharedCodexAppServerClientState();
+  const entry = getOrCreateSharedClientEntry(state, key);
   const sharedPromise =
-    state.promise ??
-    (state.promise = (async () => {
+    entry.promise ??
+    (entry.promise = (async () => {
       const client = CodexAppServerClient.start(startOptions);
-      state.client = client;
-      client.addCloseHandler(clearSharedClientIfCurrent);
+      entry.client = client;
+      client.addCloseHandler((closedClient) => clearSharedClientEntryIfCurrent(key, closedClient));
       try {
         await client.initialize();
         await applyCodexAppServerAuthProfile({
@@ -95,8 +95,9 @@ export async function getSharedCodexAppServerClient(options?: {
       "codex app-server initialize timed out",
     );
   } catch (error) {
-    if (state.promise === sharedPromise && state.key === key) {
-      clearSharedCodexAppServerClient();
+    const currentEntry = state.clients.get(key);
+    if (currentEntry?.promise === sharedPromise) {
+      clearSharedClientEntry(key, currentEntry);
     }
     throw error;
   }
@@ -150,18 +151,16 @@ export async function createIsolatedCodexAppServerClient(options?: {
 
 export function resetSharedCodexAppServerClientForTests(): void {
   const state = getSharedCodexAppServerClientState();
-  state.client = undefined;
-  state.promise = undefined;
-  state.key = undefined;
+  state.clients.clear();
 }
 
 export function clearSharedCodexAppServerClient(): void {
   const state = getSharedCodexAppServerClientState();
-  const client = state.client;
-  state.client = undefined;
-  state.promise = undefined;
-  state.key = undefined;
-  client?.close();
+  const clients = collectSharedClients(state);
+  state.clients.clear();
+  for (const client of clients) {
+    client.close();
+  }
 }
 
 export function clearSharedCodexAppServerClientIfCurrent(
@@ -171,14 +170,14 @@ export function clearSharedCodexAppServerClientIfCurrent(
     return false;
   }
   const state = getSharedCodexAppServerClientState();
-  if (state.client !== client) {
-    return false;
+  for (const [key, entry] of state.clients) {
+    if (entry.client === client) {
+      state.clients.delete(key);
+      client.close();
+      return true;
+    }
   }
-  state.client = undefined;
-  state.promise = undefined;
-  state.key = undefined;
-  client.close();
-  return true;
+  return false;
 }
 
 export async function clearSharedCodexAppServerClientAndWait(options?: {
@@ -186,19 +185,46 @@ export async function clearSharedCodexAppServerClientAndWait(options?: {
   forceKillDelayMs?: number;
 }): Promise<void> {
   const state = getSharedCodexAppServerClientState();
-  const client = state.client;
-  state.client = undefined;
-  state.promise = undefined;
-  state.key = undefined;
-  await client?.closeAndWait(options);
+  const clients = collectSharedClients(state);
+  state.clients.clear();
+  await Promise.all(clients.map((client) => client.closeAndWait(options)));
 }
 
-function clearSharedClientIfCurrent(client: CodexAppServerClient): void {
+function getOrCreateSharedClientEntry(
+  state: SharedCodexAppServerClientState,
+  key: string,
+): SharedCodexAppServerClientEntry {
+  let entry = state.clients.get(key);
+  if (!entry) {
+    entry = {};
+    state.clients.set(key, entry);
+  }
+  return entry;
+}
+
+function clearSharedClientEntry(key: string, entry: SharedCodexAppServerClientEntry): void {
   const state = getSharedCodexAppServerClientState();
-  if (state.client !== client) {
+  if (state.clients.get(key) !== entry) {
     return;
   }
-  state.client = undefined;
-  state.promise = undefined;
-  state.key = undefined;
+  state.clients.delete(key);
+  entry.client?.close();
+}
+
+function clearSharedClientEntryIfCurrent(key: string, client: CodexAppServerClient): void {
+  const state = getSharedCodexAppServerClientState();
+  const entry = state.clients.get(key);
+  if (entry?.client === client) {
+    state.clients.delete(key);
+  }
+}
+
+function collectSharedClients(state: SharedCodexAppServerClientState): CodexAppServerClient[] {
+  return [
+    ...new Set(
+      [...state.clients.values()]
+        .map((entry) => entry.client)
+        .filter((client): client is CodexAppServerClient => Boolean(client)),
+    ),
+  ];
 }

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -31,23 +31,43 @@ const SHARED_CODEX_APP_SERVER_CLIENT_STATE = Symbol.for("openclaw.codexAppServer
 
 function getSharedCodexAppServerClientState(): SharedCodexAppServerClientState {
   const globalState = globalThis as typeof globalThis & {
-    [SHARED_CODEX_APP_SERVER_CLIENT_STATE]?:
-      | SharedCodexAppServerClientState
-      | LegacySharedCodexAppServerClientState;
+    [SHARED_CODEX_APP_SERVER_CLIENT_STATE]?: unknown;
   };
   const state = globalState[SHARED_CODEX_APP_SERVER_CLIENT_STATE];
-  if (state?.clients instanceof Map) {
-    return state as SharedCodexAppServerClientState;
+  if (isSharedCodexAppServerClientState(state)) {
+    return state;
   }
+  const legacyState = readLegacySharedCodexAppServerClientState(state);
   const clients = new Map<string, SharedCodexAppServerClientEntry>();
-  if (state?.key && (state.client || state.promise)) {
-    clients.set(state.key, { client: state.client, promise: state.promise });
-    state.client?.addCloseHandler((closedClient) =>
-      clearSharedClientEntryIfCurrent(state.key!, closedClient),
+  if (legacyState?.key && (legacyState.client || legacyState.promise)) {
+    const legacyKey = legacyState.key;
+    clients.set(legacyKey, { client: legacyState.client, promise: legacyState.promise });
+    legacyState.client?.addCloseHandler((closedClient) =>
+      clearSharedClientEntryIfCurrent(legacyKey, closedClient),
     );
   }
-  globalState[SHARED_CODEX_APP_SERVER_CLIENT_STATE] = { clients };
-  return globalState[SHARED_CODEX_APP_SERVER_CLIENT_STATE];
+  const nextState: SharedCodexAppServerClientState = { clients };
+  globalState[SHARED_CODEX_APP_SERVER_CLIENT_STATE] = nextState;
+  return nextState;
+}
+
+function isSharedCodexAppServerClientState(
+  value: unknown,
+): value is SharedCodexAppServerClientState {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    (value as { clients?: unknown }).clients instanceof Map
+  );
+}
+
+function readLegacySharedCodexAppServerClientState(
+  value: unknown,
+): LegacySharedCodexAppServerClientState | undefined {
+  if (value === null || typeof value !== "object") {
+    return undefined;
+  }
+  return value as LegacySharedCodexAppServerClientState;
 }
 
 export async function getSharedCodexAppServerClient(options?: {

--- a/extensions/codex/src/migration/apply.ts
+++ b/extensions/codex/src/migration/apply.ts
@@ -40,7 +40,7 @@ import { buildCodexPluginAppCacheKey } from "../app-server/plugin-app-cache-key.
 import type { v2 } from "../app-server/protocol.js";
 import { requestCodexAppServerJson } from "../app-server/request.js";
 import {
-  clearSharedCodexAppServerClientAndWait,
+  clearSharedCodexAppServerClientIfCurrentAndWait,
   getSharedCodexAppServerClient,
 } from "../app-server/shared-client.js";
 import { buildCodexMigrationPlan } from "./plan.js";
@@ -84,19 +84,22 @@ export function prepareTargetCodexAppServer(
 ): CodexMigrationTargetAppServerPreparation {
   const appServer = resolveTargetCodexAppServer(ctx);
   const targets = resolveCodexMigrationTargets(ctx);
+  let warmedClient: Awaited<ReturnType<typeof getSharedCodexAppServerClient>> | undefined;
   const ready = getSharedCodexAppServerClient({
     startOptions: appServer.start,
     timeoutMs: 60_000,
     agentDir: targets.agentDir,
     config: ctx.config,
   }).then(
-    () => undefined,
+    (client) => {
+      warmedClient = client;
+    },
     () => undefined,
   );
   return {
     async dispose() {
       await ready;
-      await clearSharedCodexAppServerClientAndWait({
+      await clearSharedCodexAppServerClientIfCurrentAndWait(warmedClient, {
         exitTimeoutMs: 2_000,
         forceKillDelayMs: 250,
       });


### PR DESCRIPTION
## Summary
- Replace the single shared Codex app-server singleton with a keyed registry so different agent dirs/auth/envs no longer evict each other.
- Surface mid-turn app-server client closes as prompt errors while still aborting in-flight tool work, and preserve already-terminal queued completions.
- Keep secret-derived client keys stable across module reloads, scope migration cleanup to its warmed client, and add regression coverage.

Fixes #82758

## Verification
- `pnpm test extensions/codex/src/app-server/config.test.ts extensions/codex/src/app-server/shared-client.test.ts extensions/codex/src/app-server/run-attempt.test.ts -- --reporter=verbose` (3 files, 196 tests passed)
- `codex-review --mode commit --commit a9f3a1462553d51d1096cd4bb1634af106dcebff` clean: no accepted/actionable findings reported
- Review subprocess additionally passed `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts -t "client closes"`
- Earlier `pnpm check:changed` passed in Blacksmith Testbox `tbx_01krsfyv1j96kx7cbj0865k8wp` / Actions run `25975141410`; later rerun hit unrelated latest-main `currentTurnContext` type errors on unchanged lines

Behavior addressed: #82758 concurrent Codex app-server clients no longer evict active clients for different agent runtime keys.
Real environment tested: local Vitest plus delegated Blacksmith Testbox changed gate.
Exact steps or command run after this patch: `pnpm test extensions/codex/src/app-server/config.test.ts extensions/codex/src/app-server/shared-client.test.ts extensions/codex/src/app-server/run-attempt.test.ts -- --reporter=verbose`; `codex-review --mode commit --commit a9f3a1462553d51d1096cd4bb1634af106dcebff`; Testbox `pnpm check:changed`.
Evidence after fix: shared-client regressions keep the first client open when another agent key starts; run-attempt regressions surface active-client close failures without marking user aborts and preserve terminal close races; config regression keeps secret-derived keys stable across module reloads.
Observed result after fix: focused tests passed; Codex review clean; earlier Testbox changed gate passed.
What was not tested: live multi-agent native Codex app-server E2E; latest changed-gate rerun is blocked by unrelated `currentTurnContext` type errors on `origin/main`.
