### PR TITLE
fix(telegram): preserve implicit default account selection [AI-assisted]

### DIFF
--- a/extensions/telegram/src/account-selection.ts
+++ b/extensions/telegram/src/account-selection.ts
@@ -4,6 +4,7 @@ import {
   normalizeOptionalAccountId,
 } from "openclaw/plugin-sdk/account-id";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { hasConfiguredSecretInput } from "openclaw/plugin-sdk/secret-input";
 
 const DEFAULT_AGENT_ID = "main";
 
@@ -34,7 +35,19 @@ function listConfiguredAccountIds(cfg: OpenClawConfig): string[] {
       ids.add(normalizeAccountId(key));
     }
   }
+  if (hasDefaultTelegramCredential(cfg)) {
+    ids.add(DEFAULT_ACCOUNT_ID);
+  }
   return [...ids];
+}
+
+function hasDefaultTelegramCredential(cfg: OpenClawConfig): boolean {
+  const telegram = cfg.channels?.telegram;
+  return (
+    hasConfiguredSecretInput(telegram?.botToken, cfg.secrets?.defaults) ||
+    hasConfiguredSecretInput(telegram?.tokenFile, cfg.secrets?.defaults) ||
+    Boolean(process.env.TELEGRAM_BOT_TOKEN?.trim())
+  );
 }
 
 function resolveBindingAccount(params: {

--- a/extensions/telegram/src/accounts.test.ts
+++ b/extensions/telegram/src/accounts.test.ts
@@ -36,6 +36,7 @@ function resolveAccountWithEnv(
 
 beforeEach(() => {
   vi.restoreAllMocks();
+  vi.stubEnv("TELEGRAM_BOT_TOKEN", "");
   vi.spyOn(runtimeEnvModule, "createSubsystemLogger").mockImplementation(() => {
     const logger = {
       warn: warnMock,
@@ -43,6 +44,10 @@ beforeEach(() => {
     };
     return logger as unknown as ReturnType<typeof runtimeEnvModule.createSubsystemLogger>;
   });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
 });
 
 describe("resolveTelegramAccount", () => {
@@ -125,6 +130,48 @@ describe("resolveTelegramAccount", () => {
     expect(lines).toContain("resolve { accountId: 'work', enabled: true, tokenSource: 'config' }");
   });
 
+  it("keeps the implicit default account when top-level credentials coexist with a named account", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        telegram: {
+          botToken: "tok-default",
+          accounts: { fusion: { enabled: false, botToken: "tok-fusion" } },
+        },
+      },
+      bindings: [{ agentId: "fusion", match: { channel: "telegram", accountId: "fusion" } }],
+    };
+
+    expect(listTelegramAccountIds(cfg)).toEqual(["default", "fusion"]);
+    expect(listEnabledTelegramAccounts(cfg).map((account) => account.accountId)).toEqual([
+      "default",
+    ]);
+  });
+
+  it("keeps the implicit default account for top-level tokenFile credentials", () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          tokenFile: "/tmp/openclaw-telegram-token",
+          accounts: { work: { botToken: "tok-work" } },
+        },
+      },
+    } as OpenClawConfig;
+
+    expect(listTelegramAccountIds(cfg)).toEqual(["default", "work"]);
+  });
+
+  it("keeps the implicit default account when TELEGRAM_BOT_TOKEN supplies the default token", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        telegram: { accounts: { work: { botToken: "tok-work" } } },
+      },
+    };
+
+    withEnv({ TELEGRAM_BOT_TOKEN: "tok-env" }, () => {
+      expect(listTelegramAccountIds(cfg)).toEqual(["default", "work"]);
+    });
+  });
+
   it("does not resolve disabled account tokens when listing enabled accounts", () => {
     const cfg = {
       channels: {
@@ -183,6 +230,20 @@ describe("resolveDefaultTelegramAccountId", () => {
     };
 
     resolveDefaultTelegramAccountId(cfg);
+    expectNoMissingDefaultWarning();
+  });
+
+  it("does not warn when top-level credentials provide the implicit default account", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        telegram: {
+          botToken: "tok-default",
+          accounts: { work: { botToken: "tok-work" } },
+        },
+      },
+    };
+
+    expect(resolveDefaultTelegramAccountId(cfg)).toBe("default");
     expectNoMissingDefaultWarning();
   });
 


### PR DESCRIPTION
## Summary

- Problem: Adding a named Telegram account could make the implicit `default` Telegram account disappear from account enumeration when the default credentials were configured at the top level or through `TELEGRAM_BOT_TOKEN`.
- Why it matters: A gateway restart/status path could stop probing or starting the existing default bot after a multi-account config was added.
- What changed: Telegram account selection now keeps `default` when default credentials exist, even alongside named accounts or bindings.
- What did NOT change: No config shape, migration, doctor behavior, network calls, or Telegram send/poll runtime behavior changed.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration
- [x] Integrations

## Linked Issue/PR

- Closes #82780
- [x] This PR fixes a bug or regression

## Real behavior proof

- Behavior or issue addressed: Mixed Telegram configs with top-level/default credentials plus a named account keep the implicit `default` account visible to channel selection.
- Real environment tested: Disposable Linux OpenClaw checkout on PR head `8dfc57051b`, Node 22.16.0/pnpm 11.1.0. The config used fake/redacted Telegram tokens only.
- Exact steps or command run after this patch:

```text
node scripts/run-vitest.mjs extensions/telegram/src/accounts.test.ts
node scripts/run-vitest.mjs src/gateway/server-channels.test.ts
node scripts/run-vitest.mjs src/commands/channels.list.test.ts src/commands/health.test.ts
git diff --check
node scripts/check-changed.mjs

OPENCLAW_CONFIG_PATH=<redacted>/openclaw.json \
OPENCLAW_STATE_DIR=<redacted>/state \
pnpm openclaw channels list --json

OPENCLAW_CONFIG_PATH=<redacted>/openclaw.json \
OPENCLAW_STATE_DIR=<redacted>/state \
timeout 18s pnpm openclaw gateway run --port 18790 --auth none --bind loopback --verbose
```

- Evidence after fix:

```text
extensions/telegram/src/accounts.test.ts -> 1 file / 36 tests passed
src/gateway/server-channels.test.ts -> 1 file / 33 tests passed
src/commands/channels.list.test.ts + src/commands/health.test.ts -> 2 files / 21 tests passed
git diff --check -> clean
node scripts/check-changed.mjs -> clean

channels list --json:
{
  "chat": {
    "telegram": {
      "accounts": [
        "default",
        "fusion"
      ],
      "installed": true,
      "origin": "configured"
    }
  }
}

gateway run, redacted excerpt:
[gateway] auto-enabled plugins for this runtime without writing config:
- Telegram configured, enabled automatically.
[plugins] loading telegram from <repo>/dist/extensions/telegram/index.js
[gateway] http server listening (... telegram ...)
[gateway] starting channels and sidecars...
[telegram] [default] Telegram bot token unauthorized for account "default" (getMe returned 401 from Telegram; source: config token).
[telegram] [default] channel exited: Telegram bot token unauthorized for account "default" (getMe returned 401 from Telegram; source: config token).
[gateway] ready
[gateway] received SIGTERM; shutting down
```

- Observed result after fix: `listTelegramAccountIds` keeps `["default", "fusion"]` for a top-level default token plus a named account; `listEnabledTelegramAccounts` keeps `default` enabled while a disabled named account remains disabled. The same guard is covered for top-level `tokenFile` and `TELEGRAM_BOT_TOKEN`.
- What was not tested: Successful live Telegram polling with real bot credentials. The gateway proof intentionally used a fake token; the expected Telegram 401 on account `default` confirms the real gateway startup path attempted the implicit default account.
- Before evidence: ClawSweeper source repro on #82780 showed the old path returned only named/bound IDs once a named account or binding existed.

## Root Cause

- Root cause: `combineAccountIds` only added `default` when the collected set was empty. Any named account or binding made the set non-empty, so top-level default credentials were ignored during account enumeration.
- Missing detection / guardrail: There was no regression test for top-level default Telegram credentials coexisting with named accounts or bindings.
- Contributing context: The default account can be configured without an explicit `accounts.default` block.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
- Target test or file: `extensions/telegram/src/accounts.test.ts`, `src/gateway/server-channels.test.ts`, `src/commands/channels.list.test.ts`, `src/commands/health.test.ts`
- Scenario the test should lock in: Top-level Telegram default credentials remain enumerated when named accounts and account bindings exist.
- Why this is the smallest reliable guardrail: The selection helper owns account ID enumeration, while gateway and CLI slices cover the user-facing startup/status readers that depend on it.
- Existing test that already covers this: Existing named-account and missing-default warning tests covered adjacent behavior, but not the mixed default-plus-named case.
- If no new test is added, why not: New focused tests were added.

## User-visible / Behavior Changes

Existing default Telegram bot credentials continue to be seen as the `default` account after adding named Telegram accounts.

## Diagram

```text
Before:
top-level default token + named account -> ["fusion"] -> default bot not selected

After:
top-level default token + named account -> ["default", "fusion"] -> default bot stays selected
```

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows for focused tests; disposable Linux checkout for CLI/gateway proof
- Runtime/container: Local OpenClaw source checkout plus disposable Linux Node 22.16.0/pnpm 11.1.0 checkout
- Model/provider: N/A
- Integration/channel: Telegram
- Relevant config (redacted):

```json
{
  "channels": {
    "telegram": {
      "botToken": "<redacted default token>",
      "accounts": {
        "fusion": {
          "enabled": false,
          "botToken": "<redacted named token>"
        }
      }
    }
  },
  "bindings": [
    {
      "agentId": "fusion",
      "match": {
        "channel": "telegram",
        "accountId": "fusion"
      }
    }
  ]
}
```

### Steps

1. Configure top-level Telegram default credentials.
2. Add a named Telegram account and a matching account binding.
3. Run the focused Telegram account-selection, gateway channel, channel-list, and health command tests.
4. Run `openclaw channels list --json` against the same redacted config.
5. Run a bounded foreground `openclaw gateway run` against the same redacted config.

### Expected

- Telegram account enumeration includes both `default` and the named account.
- Enabled runtime accounts still respect the named account's `enabled: false` setting.
- Gateway startup attempts the implicit `default` Telegram account rather than silently dropping it.

### Actual

- Matches expected after this patch. The gateway run reaches Telegram with the fake default token and receives the expected 401 for account `default`.

## Evidence

- [x] Trace/log snippets

## Human Verification

- Verified scenarios: Top-level `botToken` plus named account/binding; top-level `tokenFile`; `TELEGRAM_BOT_TOKEN`; missing-default warning behavior when no default credentials exist; real `channels list --json`; bounded real `gateway run`.
- Edge cases checked: Disabled named account does not suppress the default account; gateway/channel list/health readers stay green; gateway startup selected `default` and failed only because the proof token was fake.
- What you did **not** verify: Successful live Telegram polling with real credentials.

## Review Conversations

N/A - no review conversations yet.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Environments with `TELEGRAM_BOT_TOKEN` set can now enumerate `default` alongside named Telegram accounts.
  - Mitigation: That matches the existing default credential fallback contract and is covered by a focused regression test.
