### PR TITLE
[codex] Add Control UI sidebar session shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Control UI: move settings-only destinations into the Settings workspace and add sidebar recent-session shortcuts plus a one-click new-session action.
+- Control UI: simplify the Cron Jobs workspace with modal job creation, collapsed filters, and an empty state aimed at first-time setup.
 - Security/audit: add `security.audit.suppressions` for intentionally accepted audit findings, keeping suppressed matches out of the active summary while preserving them in JSON output with an active suppression notice. (#76949) Thanks @100menotu001.
 - Agents/subagents: label delegated task and subagent completion handoffs as ready for parent review, and tell requester agents to review/verify results before calling them done. (#78985) Thanks @100menotu001.
 - Providers/media: add fal and OpenRouter music-generation providers for the shared `music_generate` tool, including fal MiniMax/ACE/Stable Audio endpoints and OpenRouter Lyria audio output.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Control UI: move settings-only destinations into the Settings workspace and add sidebar recent-session shortcuts plus a one-click new-session action.
+- Control UI: speed up scoped settings pages by loading required config before schema refreshes, caching burst schema responses, and opening Communications on lighter message settings first.
 - Control UI: simplify the Cron Jobs workspace with modal job creation, collapsed filters, and an empty state aimed at first-time setup.
 - Security/audit: add `security.audit.suppressions` for intentionally accepted audit findings, keeping suppressed matches out of the active summary while preserving them in JSON output with an active suppression notice. (#76949) Thanks @100menotu001.
 - Agents/subagents: label delegated task and subagent completion handoffs as ready for parent review, and tell requester agents to review/verify results before calling them done. (#78985) Thanks @100menotu001.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Control UI: move settings-only destinations into the Settings workspace and add sidebar recent-session shortcuts plus a one-click new-session action.
 - Security/audit: add `security.audit.suppressions` for intentionally accepted audit findings, keeping suppressed matches out of the active summary while preserving them in JSON output with an active suppression notice. (#76949) Thanks @100menotu001.
 - Agents/subagents: label delegated task and subagent completion handoffs as ready for parent review, and tell requester agents to review/verify results before calling them done. (#78985) Thanks @100menotu001.
 - Providers/media: add fal and OpenRouter music-generation providers for the shared `music_generate` tool, including fal MiniMax/ACE/Stable Audio endpoints and OpenRouter Lyria audio output.

--- a/src/gateway/server-methods/config.test.ts
+++ b/src/gateway/server-methods/config.test.ts
@@ -1,8 +1,20 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { configHandlers, resolveConfigOpenCommand } from "./config.js";
+import {
+  clearConfigSchemaResponseCacheForTests,
+  configHandlers,
+  loadConfigSchemaResponseForTests,
+  resolveConfigOpenCommand,
+} from "./config.js";
 import { createConfigHandlerHarness } from "./config.test-helpers.js";
 
-const execFileMock = vi.hoisted(() => vi.fn());
+const { execFileMock, loadGatewayRuntimeConfigSchemaMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+  loadGatewayRuntimeConfigSchemaMock: vi.fn(() => ({
+    schema: { type: "object" },
+    uiHints: undefined,
+    version: "test-schema",
+  })),
+}));
 
 vi.mock("node:child_process", async () => {
   const { mockNodeBuiltinModule } = await import("openclaw/plugin-sdk/test-node-mocks");
@@ -16,6 +28,10 @@ vi.mock("node:child_process", async () => {
   );
 });
 
+vi.mock("../../config/runtime-schema.js", () => ({
+  loadGatewayRuntimeConfigSchema: loadGatewayRuntimeConfigSchemaMock,
+}));
+
 function invokeExecFileCallback(args: unknown[], error: Error | null) {
   const callback = args.at(-1);
   if (typeof callback !== "function") {
@@ -23,6 +39,11 @@ function invokeExecFileCallback(args: unknown[], error: Error | null) {
   }
   callback(error);
 }
+
+afterEach(() => {
+  clearConfigSchemaResponseCacheForTests();
+  vi.clearAllMocks();
+});
 
 describe("resolveConfigOpenCommand", () => {
   it("uses open on macOS", () => {
@@ -55,7 +76,6 @@ describe("resolveConfigOpenCommand", () => {
 describe("config.openFile", () => {
   afterEach(() => {
     delete process.env.OPENCLAW_CONFIG_PATH;
-    vi.clearAllMocks();
   });
 
   it("opens the configured file without shell interpolation", async () => {
@@ -107,5 +127,22 @@ describe("config.openFile", () => {
     expect(logGateway.warn).toHaveBeenCalledWith(
       "config.openFile failed path=/tmp/config.json: spawn xdg-open ENOENT",
     );
+  });
+});
+
+describe("config schema response cache", () => {
+  it("reuses a recent schema build across burst config requests", () => {
+    loadConfigSchemaResponseForTests();
+    loadConfigSchemaResponseForTests();
+
+    expect(loadGatewayRuntimeConfigSchemaMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("can be cleared when config writes change schema inputs", () => {
+    loadConfigSchemaResponseForTests();
+    clearConfigSchemaResponseCacheForTests();
+    loadConfigSchemaResponseForTests();
+
+    expect(loadGatewayRuntimeConfigSchemaMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -52,6 +52,12 @@ import type { GatewayRequestHandlers, RespondFn } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
 const MAX_CONFIG_ISSUES_IN_ERROR_MESSAGE = 3;
+const CONFIG_SCHEMA_RESPONSE_CACHE_TTL_MS = 5_000;
+
+let configSchemaResponseCache: {
+  expiresAtMs: number;
+  response: ConfigSchemaResponse;
+} | null = null;
 
 type ConfigOpenCommand = {
   command: string;
@@ -258,12 +264,30 @@ async function ensureResolvableSecretRefsOrRespond(params: {
   }
 }
 
+export function clearConfigSchemaResponseCacheForTests() {
+  configSchemaResponseCache = null;
+}
+
+export function loadConfigSchemaResponseForTests(): ConfigSchemaResponse {
+  return loadSchemaWithPlugins();
+}
+
+function clearConfigSchemaResponseCache() {
+  configSchemaResponseCache = null;
+}
+
 function loadSchemaWithPlugins(): ConfigSchemaResponse {
-  // Note: We can't easily cache this, as there are no callback that can invalidate
-  // our cache. However, getRuntimeConfig() and loadOpenClawPlugins() (called inside
-  // loadGatewayRuntimeConfigSchema) already cache their results, and buildConfigSchema()
-  // is just a cheap transformation.
-  return loadGatewayRuntimeConfigSchema();
+  const now = Date.now();
+  if (configSchemaResponseCache && configSchemaResponseCache.expiresAtMs > now) {
+    return configSchemaResponseCache.response;
+  }
+
+  const response = loadGatewayRuntimeConfigSchema();
+  configSchemaResponseCache = {
+    expiresAtMs: Date.now() + CONFIG_SCHEMA_RESPONSE_CACHE_TTL_MS,
+    response,
+  };
+  return response;
 }
 
 export const configHandlers: GatewayRequestHandlers = {
@@ -335,6 +359,7 @@ export const configHandlers: GatewayRequestHandlers = {
       nextConfig: parsed.config,
       context,
     });
+    clearConfigSchemaResponseCache();
     respond(
       true,
       {
@@ -467,6 +492,7 @@ export const configHandlers: GatewayRequestHandlers = {
       context,
       disconnectSharedAuthClients,
     });
+    clearConfigSchemaResponseCache();
 
     const { payload, sentinelPath, restart } = await resolveGatewayConfigRestartWriteResult({
       requestParams: params,
@@ -533,6 +559,7 @@ export const configHandlers: GatewayRequestHandlers = {
       context,
       disconnectSharedAuthClients,
     });
+    clearConfigSchemaResponseCache();
 
     const { payload, sentinelPath, restart } = await resolveGatewayConfigRestartWriteResult({
       requestParams: params,

--- a/ui/src/i18n/.i18n/ar.meta.json
+++ b/ui/src/i18n/.i18n/ar.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-15T06:55:20.574Z",
+  "generatedAt": "2026-05-17T04:23:07.350Z",
   "locale": "ar",
-  "model": "claude-opus-4-6",
-  "provider": "anthropic",
-  "sourceHash": "aa10028509a638096a0e2c1d178279d31c1b53df551d0b9aa44d185577311fd2",
-  "totalKeys": 1113,
-  "translatedKeys": 1113,
+  "model": "gpt-5.5",
+  "provider": "openai",
+  "sourceHash": "79544002c00e9adfebe5cc0ad3a6ff6393313f6fd7b546e68f0d53110df29914",
+  "totalKeys": 1117,
+  "translatedKeys": 1117,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/de.meta.json
+++ b/ui/src/i18n/.i18n/de.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-15T06:53:55.667Z",
+  "generatedAt": "2026-05-17T04:22:55.626Z",
   "locale": "de",
-  "model": "claude-opus-4-6",
-  "provider": "anthropic",
-  "sourceHash": "aa10028509a638096a0e2c1d178279d31c1b53df551d0b9aa44d185577311fd2",
-  "totalKeys": 1113,
-  "translatedKeys": 1113,
+  "model": "gpt-5.5",
+  "provider": "openai",
+  "sourceHash": "79544002c00e9adfebe5cc0ad3a6ff6393313f6fd7b546e68f0d53110df29914",
+  "totalKeys": 1117,
+  "translatedKeys": 1117,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/es.meta.json
+++ b/ui/src/i18n/.i18n/es.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-15T06:54:28.519Z",
+  "generatedAt": "2026-05-17T04:22:57.470Z",
   "locale": "es",
-  "model": "claude-opus-4-6",
-  "provider": "anthropic",
-  "sourceHash": "aa10028509a638096a0e2c1d178279d31c1b53df551d0b9aa44d185577311fd2",
-  "totalKeys": 1113,
-  "translatedKeys": 1113,
+  "model": "gpt-5.5",
+  "provider": "openai",
+  "sourceHash": "79544002c00e9adfebe5cc0ad3a6ff6393313f6fd7b546e68f0d53110df29914",
+  "totalKeys": 1117,
+  "translatedKeys": 1117,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fa.meta.json
+++ b/ui/src/i18n/.i18n/fa.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-15T06:56:25.567Z",
+  "generatedAt": "2026-05-17T04:23:23.796Z",
   "locale": "fa",
-  "model": "claude-opus-4-6",
-  "provider": "anthropic",
-  "sourceHash": "aa10028509a638096a0e2c1d178279d31c1b53df551d0b9aa44d185577311fd2",
-  "totalKeys": 1113,
-  "translatedKeys": 1113,
+  "model": "gpt-5.5",
+  "provider": "openai",
+  "sourceHash": "79544002c00e9adfebe5cc0ad3a6ff6393313f6fd7b546e68f0d53110df29914",
+  "totalKeys": 1117,
+  "translatedKeys": 1117,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/fr.meta.json
+++ b/ui/src/i18n/.i18n/fr.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-15T06:54:44.184Z",
+  "generatedAt": "2026-05-17T04:23:05.794Z",
   "locale": "fr",
-  "model": "claude-opus-4-6",
-  "provider": "anthropic",
-  "sourceHash": "aa10028509a638096a0e2c1d178279d31c1b53df551d0b9aa44d185577311fd2",
-  "totalKeys": 1113,
-  "translatedKeys": 1113,
+  "model": "gpt-5.5",
+  "provider": "openai",
+  "sourceHash": "79544002c00e9adfebe5cc0ad3a6ff6393313f6fd7b546e68f0d53110df29914",
+  "totalKeys": 1117,
+  "translatedKeys": 1117,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/id.meta.json
+++ b/ui/src/i18n/.i18n/id.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-15T06:55:42.684Z",
+  "generatedAt": "2026-05-17T04:23:13.312Z",
   "locale": "id",
-  "model": "claude-opus-4-6",
-  "provider": "anthropic",
-  "sourceHash": "aa10028509a638096a0e2c1d178279d31c1b53df551d0b9aa44d185577311fd2",
-  "totalKeys": 1113,
-  "translatedKeys": 1113,
+  "model": "gpt-5.5",
+  "provider": "openai",
+  "sourceHash": "79544002c00e9adfebe5cc0ad3a6ff6393313f6fd7b546e68f0d53110df29914",
+  "totalKeys": 1117,
+  "translatedKeys": 1117,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/it.meta.json
+++ b/ui/src/i18n/.i18n/it.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-15T06:54:58.587Z",
+  "generatedAt": "2026-05-17T04:23:08.778Z",
   "locale": "it",
-  "model": "claude-opus-4-6",
-  "provider": "anthropic",
-  "sourceHash": "aa10028509a638096a0e2c1d178279d31c1b53df551d0b9aa44d185577311fd2",
-  "totalKeys": 1113,
-  "translatedKeys": 1113,
+  "model": "gpt-5.5",
+  "provider": "openai",
+  "sourceHash": "79544002c00e9adfebe5cc0ad3a6ff6393313f6fd7b546e68f0d53110df29914",
+  "totalKeys": 1117,
+  "translatedKeys": 1117,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ja-JP.meta.json
+++ b/ui/src/i18n/.i18n/ja-JP.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-15T06:54:27.126Z",
+  "generatedAt": "2026-05-17T04:22:59.289Z",
   "locale": "ja-JP",
-  "model": "claude-opus-4-6",
-  "provider": "anthropic",
-  "sourceHash": "aa10028509a638096a0e2c1d178279d31c1b53df551d0b9aa44d185577311fd2",
-  "totalKeys": 1113,
-  "translatedKeys": 1113,
+  "model": "gpt-5.5",
+  "provider": "openai",
+  "sourceHash": "79544002c00e9adfebe5cc0ad3a6ff6393313f6fd7b546e68f0d53110df29914",
+  "totalKeys": 1117,
+  "translatedKeys": 1117,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/ko.meta.json
+++ b/ui/src/i18n/.i18n/ko.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-15T06:54:29.226Z",
+  "generatedAt": "2026-05-17T04:23:02.977Z",
   "locale": "ko",
-  "model": "claude-opus-4-6",
-  "provider": "anthropic",
-  "sourceHash": "aa10028509a638096a0e2c1d178279d31c1b53df551d0b9aa44d185577311fd2",
-  "totalKeys": 1113,
-  "translatedKeys": 1113,
+  "model": "gpt-5.5",
+  "provider": "openai",
+  "sourceHash": "79544002c00e9adfebe5cc0ad3a6ff6393313f6fd7b546e68f0d53110df29914",
+  "totalKeys": 1117,
+  "translatedKeys": 1117,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/nl.meta.json
+++ b/ui/src/i18n/.i18n/nl.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-15T06:56:17.712Z",
+  "generatedAt": "2026-05-17T04:23:22.004Z",
   "locale": "nl",
-  "model": "claude-opus-4-6",
-  "provider": "anthropic",
-  "sourceHash": "aa10028509a638096a0e2c1d178279d31c1b53df551d0b9aa44d185577311fd2",
-  "totalKeys": 1113,
-  "translatedKeys": 1113,
+  "model": "gpt-5.5",
+  "provider": "openai",
+  "sourceHash": "79544002c00e9adfebe5cc0ad3a6ff6393313f6fd7b546e68f0d53110df29914",
+  "totalKeys": 1117,
+  "translatedKeys": 1117,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pl.meta.json
+++ b/ui/src/i18n/.i18n/pl.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-15T06:55:47.167Z",
+  "generatedAt": "2026-05-17T04:23:15.396Z",
   "locale": "pl",
-  "model": "claude-opus-4-6",
-  "provider": "anthropic",
-  "sourceHash": "aa10028509a638096a0e2c1d178279d31c1b53df551d0b9aa44d185577311fd2",
-  "totalKeys": 1113,
-  "translatedKeys": 1113,
+  "model": "gpt-5.5",
+  "provider": "openai",
+  "sourceHash": "79544002c00e9adfebe5cc0ad3a6ff6393313f6fd7b546e68f0d53110df29914",
+  "totalKeys": 1117,
+  "translatedKeys": 1117,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/pt-BR.meta.json
+++ b/ui/src/i18n/.i18n/pt-BR.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-15T06:53:45.485Z",
+  "generatedAt": "2026-05-17T04:22:53.877Z",
   "locale": "pt-BR",
-  "model": "claude-opus-4-6",
-  "provider": "anthropic",
-  "sourceHash": "aa10028509a638096a0e2c1d178279d31c1b53df551d0b9aa44d185577311fd2",
-  "totalKeys": 1113,
-  "translatedKeys": 1113,
+  "model": "gpt-5.5",
+  "provider": "openai",
+  "sourceHash": "79544002c00e9adfebe5cc0ad3a6ff6393313f6fd7b546e68f0d53110df29914",
+  "totalKeys": 1117,
+  "translatedKeys": 1117,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/raw-copy-baseline.json
+++ b/ui/src/i18n/.i18n/raw-copy-baseline.json
@@ -3345,13 +3345,6 @@
       "kind": "html-text",
       "name": "text",
       "path": "ui/src/ui/views/cron.ts",
-      "text": "+ New"
-    },
-    {
-      "count": 1,
-      "kind": "html-text",
-      "name": "text",
-      "path": "ui/src/ui/views/cron.ts",
       "text": "Announce (via channel)"
     },
     {

--- a/ui/src/i18n/.i18n/raw-copy-baseline.json
+++ b/ui/src/i18n/.i18n/raw-copy-baseline.json
@@ -1427,7 +1427,7 @@
       "kind": "html-attribute",
       "name": "placeholder",
       "path": "ui/src/ui/views/chat.ts",
-      "text": "gpt-realtime-2"
+      "text": "Auto"
     },
     {
       "count": 1,
@@ -1472,6 +1472,13 @@
       "text": "&times;"
     },
     {
+      "count": 1,
+      "kind": "html-text",
+      "name": "text",
+      "path": "ui/src/ui/views/chat.ts",
+      "text": "Advanced"
+    },
+    {
       "count": 2,
       "kind": "html-text",
       "name": "text",
@@ -1486,7 +1493,14 @@
       "text": "close"
     },
     {
-      "count": 2,
+      "count": 1,
+      "kind": "html-text",
+      "name": "text",
+      "path": "ui/src/ui/views/chat.ts",
+      "text": "Custom"
+    },
+    {
+      "count": 3,
       "kind": "html-text",
       "name": "text",
       "path": "ui/src/ui/views/chat.ts",
@@ -1505,6 +1519,13 @@
       "name": "text",
       "path": "ui/src/ui/views/chat.ts",
       "text": "Esc"
+    },
+    {
+      "count": 1,
+      "kind": "html-text",
+      "name": "text",
+      "path": "ui/src/ui/views/chat.ts",
+      "text": "Exact VAD"
     },
     {
       "count": 2,
@@ -1528,7 +1549,7 @@
       "text": "Google"
     },
     {
-      "count": 1,
+      "count": 2,
       "kind": "html-text",
       "name": "text",
       "path": "ui/src/ui/views/chat.ts",
@@ -1546,10 +1567,17 @@
       "kind": "html-text",
       "name": "text",
       "path": "ui/src/ui/views/chat.ts",
+      "text": "Lead-in"
+    },
+    {
+      "count": 2,
+      "kind": "html-text",
+      "name": "text",
+      "path": "ui/src/ui/views/chat.ts",
       "text": "Low"
     },
     {
-      "count": 1,
+      "count": 2,
       "kind": "html-text",
       "name": "text",
       "path": "ui/src/ui/views/chat.ts",
@@ -1595,7 +1623,7 @@
       "kind": "html-text",
       "name": "text",
       "path": "ui/src/ui/views/chat.ts",
-      "text": "Prefix ms"
+      "text": "Pause before send"
     },
     {
       "count": 1,
@@ -1637,7 +1665,7 @@
       "kind": "html-text",
       "name": "text",
       "path": "ui/src/ui/views/chat.ts",
-      "text": "Silence ms"
+      "text": "Sensitivity"
     },
     {
       "count": 2,
@@ -1652,13 +1680,6 @@
       "name": "text",
       "path": "ui/src/ui/views/chat.ts",
       "text": "Transport"
-    },
-    {
-      "count": 1,
-      "kind": "html-text",
-      "name": "text",
-      "path": "ui/src/ui/views/chat.ts",
-      "text": "VAD"
     },
     {
       "count": 1,

--- a/ui/src/i18n/.i18n/th.meta.json
+++ b/ui/src/i18n/.i18n/th.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-15T06:55:59.783Z",
+  "generatedAt": "2026-05-17T04:23:16.938Z",
   "locale": "th",
-  "model": "claude-opus-4-6",
-  "provider": "anthropic",
-  "sourceHash": "aa10028509a638096a0e2c1d178279d31c1b53df551d0b9aa44d185577311fd2",
-  "totalKeys": 1113,
-  "translatedKeys": 1113,
+  "model": "gpt-5.5",
+  "provider": "openai",
+  "sourceHash": "79544002c00e9adfebe5cc0ad3a6ff6393313f6fd7b546e68f0d53110df29914",
+  "totalKeys": 1117,
+  "translatedKeys": 1117,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/tr.meta.json
+++ b/ui/src/i18n/.i18n/tr.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-15T06:55:08.515Z",
+  "generatedAt": "2026-05-17T04:23:10.211Z",
   "locale": "tr",
-  "model": "claude-opus-4-6",
-  "provider": "anthropic",
-  "sourceHash": "aa10028509a638096a0e2c1d178279d31c1b53df551d0b9aa44d185577311fd2",
-  "totalKeys": 1113,
-  "translatedKeys": 1113,
+  "model": "gpt-5.5",
+  "provider": "openai",
+  "sourceHash": "79544002c00e9adfebe5cc0ad3a6ff6393313f6fd7b546e68f0d53110df29914",
+  "totalKeys": 1117,
+  "translatedKeys": 1117,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/uk.meta.json
+++ b/ui/src/i18n/.i18n/uk.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-15T06:55:14.114Z",
+  "generatedAt": "2026-05-17T04:23:11.418Z",
   "locale": "uk",
-  "model": "claude-opus-4-6",
-  "provider": "anthropic",
-  "sourceHash": "aa10028509a638096a0e2c1d178279d31c1b53df551d0b9aa44d185577311fd2",
-  "totalKeys": 1113,
-  "translatedKeys": 1113,
+  "model": "gpt-5.5",
+  "provider": "openai",
+  "sourceHash": "79544002c00e9adfebe5cc0ad3a6ff6393313f6fd7b546e68f0d53110df29914",
+  "totalKeys": 1117,
+  "translatedKeys": 1117,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/vi.meta.json
+++ b/ui/src/i18n/.i18n/vi.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-15T06:55:50.269Z",
+  "generatedAt": "2026-05-17T04:23:18.710Z",
   "locale": "vi",
-  "model": "claude-opus-4-6",
-  "provider": "anthropic",
-  "sourceHash": "aa10028509a638096a0e2c1d178279d31c1b53df551d0b9aa44d185577311fd2",
-  "totalKeys": 1113,
-  "translatedKeys": 1113,
+  "model": "gpt-5.5",
+  "provider": "openai",
+  "sourceHash": "79544002c00e9adfebe5cc0ad3a6ff6393313f6fd7b546e68f0d53110df29914",
+  "totalKeys": 1117,
+  "translatedKeys": 1117,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-CN.meta.json
+++ b/ui/src/i18n/.i18n/zh-CN.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-15T06:53:51.570Z",
+  "generatedAt": "2026-05-17T04:22:50.063Z",
   "locale": "zh-CN",
-  "model": "claude-opus-4-6",
-  "provider": "anthropic",
-  "sourceHash": "aa10028509a638096a0e2c1d178279d31c1b53df551d0b9aa44d185577311fd2",
-  "totalKeys": 1113,
-  "translatedKeys": 1113,
+  "model": "gpt-5.5",
+  "provider": "openai",
+  "sourceHash": "79544002c00e9adfebe5cc0ad3a6ff6393313f6fd7b546e68f0d53110df29914",
+  "totalKeys": 1117,
+  "translatedKeys": 1117,
   "workflow": 1
 }

--- a/ui/src/i18n/.i18n/zh-TW.meta.json
+++ b/ui/src/i18n/.i18n/zh-TW.meta.json
@@ -1,11 +1,11 @@
 {
   "fallbackKeys": [],
-  "generatedAt": "2026-05-15T06:53:50.373Z",
+  "generatedAt": "2026-05-17T04:22:52.169Z",
   "locale": "zh-TW",
-  "model": "claude-opus-4-6",
-  "provider": "anthropic",
-  "sourceHash": "aa10028509a638096a0e2c1d178279d31c1b53df551d0b9aa44d185577311fd2",
-  "totalKeys": 1113,
-  "translatedKeys": 1113,
+  "model": "gpt-5.5",
+  "provider": "openai",
+  "sourceHash": "79544002c00e9adfebe5cc0ad3a6ff6393313f6fd7b546e68f0d53110df29914",
+  "totalKeys": 1117,
+  "translatedKeys": 1117,
   "workflow": 1
 }

--- a/ui/src/i18n/locales/ar.ts
+++ b/ui/src/i18n/locales/ar.ts
@@ -1192,6 +1192,9 @@ export const ar: TranslationMap = {
       ascending: "تصاعدي",
       descending: "تنازلي",
       reset: "إعادة تعيين",
+      emptyTitle: "No scheduled jobs yet.",
+      emptyHint: "Create one from a plain-language prompt; advanced fields can wait.",
+      emptyFilteredHint: "Clear or change filters to see scheduled jobs.",
       noMatching: "لا توجد مهام مطابقة.",
       loading: "جارٍ التحميل...",
       loadMore: "تحميل المزيد من المهام",
@@ -1227,6 +1230,7 @@ export const ar: TranslationMap = {
     form: {
       editJob: "تعديل المهمة",
       newJob: "مهمة جديدة",
+      advancedJob: "Advanced job",
       updateSubtitle: "حدّث المهمة المجدولة المحددة.",
       createSubtitle: "أنشئ تنبيهًا مجدولًا أو تشغيل وكيل.",
       required: "مطلوب",

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -1218,6 +1218,9 @@ export const de: TranslationMap = {
       ascending: "Aufsteigend",
       descending: "Absteigend",
       reset: "Zurücksetzen",
+      emptyTitle: "No scheduled jobs yet.",
+      emptyHint: "Create one from a plain-language prompt; advanced fields can wait.",
+      emptyFilteredHint: "Clear or change filters to see scheduled jobs.",
       noMatching: "Keine passenden Jobs.",
       loading: "Wird geladen...",
       loadMore: "Weitere Jobs laden",
@@ -1253,6 +1256,7 @@ export const de: TranslationMap = {
     form: {
       editJob: "Job bearbeiten",
       newJob: "Neuer Job",
+      advancedJob: "Advanced job",
       updateSubtitle: "Aktualisiere den ausgewählten geplanten Job.",
       createSubtitle: "Erstelle ein geplantes Aufwachen oder einen Agentenlauf.",
       required: "Erforderlich",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -1169,7 +1169,7 @@ export const en: TranslationMap = {
       whenHint: "Pick a schedule. You can fine-tune it later.",
       howHeading: "How should it work?",
       howHint: "Choose how results are delivered.",
-      title: "New Automation",
+      title: "New Cron Job",
     },
     summary: {
       enabled: "Enabled",
@@ -1198,6 +1198,9 @@ export const en: TranslationMap = {
       ascending: "Ascending",
       descending: "Descending",
       reset: "Reset",
+      emptyTitle: "No scheduled jobs yet.",
+      emptyHint: "Create one from a plain-language prompt; advanced fields can wait.",
+      emptyFilteredHint: "Clear or change filters to see scheduled jobs.",
       noMatching: "No matching jobs.",
       loading: "Loading...",
       loadMore: "Load more jobs",
@@ -1233,6 +1236,7 @@ export const en: TranslationMap = {
     form: {
       editJob: "Edit Job",
       newJob: "New Job",
+      advancedJob: "Advanced job",
       updateSubtitle: "Update the selected scheduled job.",
       createSubtitle: "Create a scheduled wakeup or agent run.",
       required: "Required",

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -1214,6 +1214,9 @@ export const es: TranslationMap = {
       ascending: "Ascendente",
       descending: "Descendente",
       reset: "Restablecer",
+      emptyTitle: "No scheduled jobs yet.",
+      emptyHint: "Create one from a plain-language prompt; advanced fields can wait.",
+      emptyFilteredHint: "Clear or change filters to see scheduled jobs.",
       noMatching: "No hay tareas coincidentes.",
       loading: "Cargando...",
       loadMore: "Cargar más tareas",
@@ -1249,6 +1252,7 @@ export const es: TranslationMap = {
     form: {
       editJob: "Editar tarea",
       newJob: "Nueva tarea",
+      advancedJob: "Advanced job",
       updateSubtitle: "Actualiza la tarea programada seleccionada.",
       createSubtitle: "Crea una activación programada o ejecución de agente.",
       required: "Requerido",

--- a/ui/src/i18n/locales/fa.ts
+++ b/ui/src/i18n/locales/fa.ts
@@ -1209,6 +1209,9 @@ export const fa: TranslationMap = {
       ascending: "صعودی",
       descending: "نزولی",
       reset: "بازنشانی",
+      emptyTitle: "No scheduled jobs yet.",
+      emptyHint: "Create one from a plain-language prompt; advanced fields can wait.",
+      emptyFilteredHint: "Clear or change filters to see scheduled jobs.",
       noMatching: "کار منطبقی وجود ندارد.",
       loading: "در حال بارگیری...",
       loadMore: "بارگیری کارهای بیشتر",
@@ -1244,6 +1247,7 @@ export const fa: TranslationMap = {
     form: {
       editJob: "ویرایش کار",
       newJob: "کار جدید",
+      advancedJob: "Advanced job",
       updateSubtitle: "کار زمان‌بندی‌شده انتخاب‌شده را به‌روزرسانی کنید.",
       createSubtitle: "یک بیدارباش زمان‌بندی‌شده یا اجرای عامل ایجاد کنید.",
       required: "ضروری",

--- a/ui/src/i18n/locales/fr.ts
+++ b/ui/src/i18n/locales/fr.ts
@@ -1222,6 +1222,9 @@ export const fr: TranslationMap = {
       ascending: "Croissant",
       descending: "Décroissant",
       reset: "Réinitialiser",
+      emptyTitle: "No scheduled jobs yet.",
+      emptyHint: "Create one from a plain-language prompt; advanced fields can wait.",
+      emptyFilteredHint: "Clear or change filters to see scheduled jobs.",
       noMatching: "Aucune tâche correspondante.",
       loading: "Chargement...",
       loadMore: "Charger plus de tâches",
@@ -1257,6 +1260,7 @@ export const fr: TranslationMap = {
     form: {
       editJob: "Modifier la tâche",
       newJob: "Nouvelle tâche",
+      advancedJob: "Advanced job",
       updateSubtitle: "Mettez à jour la tâche planifiée sélectionnée.",
       createSubtitle: "Créez un réveil planifié ou une exécution d’agent.",
       required: "Obligatoire",

--- a/ui/src/i18n/locales/id.ts
+++ b/ui/src/i18n/locales/id.ts
@@ -1207,6 +1207,9 @@ export const id: TranslationMap = {
       ascending: "Naik",
       descending: "Turun",
       reset: "Atur Ulang",
+      emptyTitle: "No scheduled jobs yet.",
+      emptyHint: "Create one from a plain-language prompt; advanced fields can wait.",
+      emptyFilteredHint: "Clear or change filters to see scheduled jobs.",
       noMatching: "Tidak ada tugas yang cocok.",
       loading: "Memuat...",
       loadMore: "Muat lebih banyak tugas",
@@ -1242,6 +1245,7 @@ export const id: TranslationMap = {
     form: {
       editJob: "Edit Tugas",
       newJob: "Tugas Baru",
+      advancedJob: "Advanced job",
       updateSubtitle: "Perbarui tugas terjadwal yang dipilih.",
       createSubtitle: "Buat bangun terjadwal atau proses agen.",
       required: "Wajib",

--- a/ui/src/i18n/locales/it.ts
+++ b/ui/src/i18n/locales/it.ts
@@ -1216,6 +1216,9 @@ export const it: TranslationMap = {
       ascending: "Crescente",
       descending: "Decrescente",
       reset: "Reimposta",
+      emptyTitle: "No scheduled jobs yet.",
+      emptyHint: "Create one from a plain-language prompt; advanced fields can wait.",
+      emptyFilteredHint: "Clear or change filters to see scheduled jobs.",
       noMatching: "Nessun processo corrispondente.",
       loading: "Caricamento...",
       loadMore: "Carica altri processi",
@@ -1251,6 +1254,7 @@ export const it: TranslationMap = {
     form: {
       editJob: "Modifica processo",
       newJob: "Nuovo processo",
+      advancedJob: "Advanced job",
       updateSubtitle: "Aggiorna il processo pianificato selezionato.",
       createSubtitle: "Crea un risveglio pianificato o un'esecuzione dell'agente.",
       required: "Obbligatorio",

--- a/ui/src/i18n/locales/ja-JP.ts
+++ b/ui/src/i18n/locales/ja-JP.ts
@@ -1212,6 +1212,9 @@ export const ja_JP: TranslationMap = {
       ascending: "昇順",
       descending: "降順",
       reset: "リセット",
+      emptyTitle: "No scheduled jobs yet.",
+      emptyHint: "Create one from a plain-language prompt; advanced fields can wait.",
+      emptyFilteredHint: "Clear or change filters to see scheduled jobs.",
       noMatching: "一致するジョブはありません。",
       loading: "読み込み中...",
       loadMore: "さらにジョブを読み込む",
@@ -1247,6 +1250,7 @@ export const ja_JP: TranslationMap = {
     form: {
       editJob: "ジョブを編集",
       newJob: "新しいジョブ",
+      advancedJob: "Advanced job",
       updateSubtitle: "選択したスケジュール済みジョブを更新します。",
       createSubtitle: "スケジュールされたウェイクアップまたはエージェント実行を作成します。",
       required: "必須",

--- a/ui/src/i18n/locales/ko.ts
+++ b/ui/src/i18n/locales/ko.ts
@@ -1200,6 +1200,9 @@ export const ko: TranslationMap = {
       ascending: "오름차순",
       descending: "내림차순",
       reset: "재설정",
+      emptyTitle: "No scheduled jobs yet.",
+      emptyHint: "Create one from a plain-language prompt; advanced fields can wait.",
+      emptyFilteredHint: "Clear or change filters to see scheduled jobs.",
       noMatching: "일치하는 작업이 없습니다.",
       loading: "로딩 중...",
       loadMore: "작업 더 불러오기",
@@ -1235,6 +1238,7 @@ export const ko: TranslationMap = {
     form: {
       editJob: "작업 편집",
       newJob: "새 작업",
+      advancedJob: "Advanced job",
       updateSubtitle: "선택한 예약 작업을 업데이트합니다.",
       createSubtitle: "예약된 웨이크업 또는 에이전트 실행을 생성합니다.",
       required: "필수",

--- a/ui/src/i18n/locales/nl.ts
+++ b/ui/src/i18n/locales/nl.ts
@@ -1212,6 +1212,9 @@ export const nl: TranslationMap = {
       ascending: "Oplopend",
       descending: "Aflopend",
       reset: "Resetten",
+      emptyTitle: "No scheduled jobs yet.",
+      emptyHint: "Create one from a plain-language prompt; advanced fields can wait.",
+      emptyFilteredHint: "Clear or change filters to see scheduled jobs.",
       noMatching: "Geen overeenkomende taken.",
       loading: "Laden...",
       loadMore: "Meer taken laden",
@@ -1247,6 +1250,7 @@ export const nl: TranslationMap = {
     form: {
       editJob: "Taak bewerken",
       newJob: "Nieuwe taak",
+      advancedJob: "Advanced job",
       updateSubtitle: "Werk de geselecteerde geplande taak bij.",
       createSubtitle: "Maak een geplande wakeup of agent-run.",
       required: "Vereist",

--- a/ui/src/i18n/locales/pl.ts
+++ b/ui/src/i18n/locales/pl.ts
@@ -1213,6 +1213,9 @@ export const pl: TranslationMap = {
       ascending: "Rosnąco",
       descending: "Malejąco",
       reset: "Resetuj",
+      emptyTitle: "No scheduled jobs yet.",
+      emptyHint: "Create one from a plain-language prompt; advanced fields can wait.",
+      emptyFilteredHint: "Clear or change filters to see scheduled jobs.",
       noMatching: "Brak pasujących zadań.",
       loading: "Ładowanie...",
       loadMore: "Wczytaj więcej zadań",
@@ -1248,6 +1251,7 @@ export const pl: TranslationMap = {
     form: {
       editJob: "Edytuj zadanie",
       newJob: "Nowe zadanie",
+      advancedJob: "Advanced job",
       updateSubtitle: "Zaktualizuj wybrane zaplanowane zadanie.",
       createSubtitle: "Utwórz zaplanowane wybudzenie lub uruchomienie agenta.",
       required: "Wymagane",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -1210,6 +1210,9 @@ export const pt_BR: TranslationMap = {
       ascending: "Crescente",
       descending: "Decrescente",
       reset: "Redefinir",
+      emptyTitle: "No scheduled jobs yet.",
+      emptyHint: "Create one from a plain-language prompt; advanced fields can wait.",
+      emptyFilteredHint: "Clear or change filters to see scheduled jobs.",
       noMatching: "Nenhuma tarefa correspondente.",
       loading: "Carregando...",
       loadMore: "Carregar mais tarefas",
@@ -1245,6 +1248,7 @@ export const pt_BR: TranslationMap = {
     form: {
       editJob: "Editar tarefa",
       newJob: "Nova tarefa",
+      advancedJob: "Advanced job",
       updateSubtitle: "Atualize a tarefa agendada selecionada.",
       createSubtitle: "Crie um despertar agendado ou uma execução de agente.",
       required: "Obrigatório",

--- a/ui/src/i18n/locales/th.ts
+++ b/ui/src/i18n/locales/th.ts
@@ -1177,6 +1177,9 @@ export const th: TranslationMap = {
       ascending: "น้อยไปมาก",
       descending: "มากไปน้อย",
       reset: "รีเซ็ต",
+      emptyTitle: "No scheduled jobs yet.",
+      emptyHint: "Create one from a plain-language prompt; advanced fields can wait.",
+      emptyFilteredHint: "Clear or change filters to see scheduled jobs.",
       noMatching: "ไม่พบงานที่ตรงกัน",
       loading: "กำลังโหลด...",
       loadMore: "โหลดงานเพิ่มเติม",
@@ -1212,6 +1215,7 @@ export const th: TranslationMap = {
     form: {
       editJob: "แก้ไขงาน",
       newJob: "งานใหม่",
+      advancedJob: "Advanced job",
       updateSubtitle: "อัปเดตงานตามกำหนดเวลาที่เลือก",
       createSubtitle: "สร้างการปลุกหรืองานรันของเอเจนต์ตามกำหนดเวลา",
       required: "จำเป็น",

--- a/ui/src/i18n/locales/tr.ts
+++ b/ui/src/i18n/locales/tr.ts
@@ -1213,6 +1213,9 @@ export const tr: TranslationMap = {
       ascending: "Artan",
       descending: "Azalan",
       reset: "Sıfırla",
+      emptyTitle: "No scheduled jobs yet.",
+      emptyHint: "Create one from a plain-language prompt; advanced fields can wait.",
+      emptyFilteredHint: "Clear or change filters to see scheduled jobs.",
       noMatching: "Eşleşen iş yok.",
       loading: "Yükleniyor...",
       loadMore: "Daha fazla iş yükle",
@@ -1248,6 +1251,7 @@ export const tr: TranslationMap = {
     form: {
       editJob: "İşi Düzenle",
       newJob: "Yeni İş",
+      advancedJob: "Advanced job",
       updateSubtitle: "Seçili zamanlanmış işi güncelleyin.",
       createSubtitle: "Zamanlanmış bir uyandırma veya aracı çalıştırması oluşturun.",
       required: "Gerekli",

--- a/ui/src/i18n/locales/uk.ts
+++ b/ui/src/i18n/locales/uk.ts
@@ -1210,6 +1210,9 @@ export const uk: TranslationMap = {
       ascending: "За зростанням",
       descending: "За спаданням",
       reset: "Скинути",
+      emptyTitle: "No scheduled jobs yet.",
+      emptyHint: "Create one from a plain-language prompt; advanced fields can wait.",
+      emptyFilteredHint: "Clear or change filters to see scheduled jobs.",
       noMatching: "Немає відповідних завдань.",
       loading: "Завантаження...",
       loadMore: "Завантажити більше завдань",
@@ -1245,6 +1248,7 @@ export const uk: TranslationMap = {
     form: {
       editJob: "Редагувати завдання",
       newJob: "Нове завдання",
+      advancedJob: "Advanced job",
       updateSubtitle: "Оновіть вибране заплановане завдання.",
       createSubtitle: "Створіть заплановане пробудження або запуск агента.",
       required: "Обов’язково",

--- a/ui/src/i18n/locales/vi.ts
+++ b/ui/src/i18n/locales/vi.ts
@@ -1200,6 +1200,9 @@ export const vi: TranslationMap = {
       ascending: "Tăng dần",
       descending: "Giảm dần",
       reset: "Đặt lại",
+      emptyTitle: "No scheduled jobs yet.",
+      emptyHint: "Create one from a plain-language prompt; advanced fields can wait.",
+      emptyFilteredHint: "Clear or change filters to see scheduled jobs.",
       noMatching: "Không có tác vụ khớp.",
       loading: "Đang tải...",
       loadMore: "Tải thêm tác vụ",
@@ -1235,6 +1238,7 @@ export const vi: TranslationMap = {
     form: {
       editJob: "Chỉnh sửa tác vụ",
       newJob: "Tác vụ mới",
+      advancedJob: "Advanced job",
       updateSubtitle: "Cập nhật tác vụ đã lên lịch được chọn.",
       createSubtitle: "Tạo một lần đánh thức hoặc chạy agent theo lịch.",
       required: "Bắt buộc",

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -1173,6 +1173,9 @@ export const zh_CN: TranslationMap = {
       ascending: "升序",
       descending: "降序",
       reset: "重置",
+      emptyTitle: "No scheduled jobs yet.",
+      emptyHint: "Create one from a plain-language prompt; advanced fields can wait.",
+      emptyFilteredHint: "Clear or change filters to see scheduled jobs.",
       noMatching: "没有匹配的任务。",
       loading: "加载中...",
       loadMore: "加载更多任务",
@@ -1208,6 +1211,7 @@ export const zh_CN: TranslationMap = {
     form: {
       editJob: "编辑任务",
       newJob: "新建任务",
+      advancedJob: "Advanced job",
       updateSubtitle: "更新所选定时任务。",
       createSubtitle: "创建定时唤醒或代理运行。",
       required: "必填",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -1175,6 +1175,9 @@ export const zh_TW: TranslationMap = {
       ascending: "升序",
       descending: "降序",
       reset: "重設",
+      emptyTitle: "No scheduled jobs yet.",
+      emptyHint: "Create one from a plain-language prompt; advanced fields can wait.",
+      emptyFilteredHint: "Clear or change filters to see scheduled jobs.",
       noMatching: "沒有符合的工作。",
       loading: "載入中...",
       loadMore: "載入更多工作",
@@ -1210,6 +1213,7 @@ export const zh_TW: TranslationMap = {
     form: {
       editJob: "編輯工作",
       newJob: "新增工作",
+      advancedJob: "Advanced job",
       updateSubtitle: "更新所選的排程工作。",
       createSubtitle: "建立排程喚醒或 Agent 執行。",
       required: "必填",

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1581,6 +1581,19 @@
   animation: fade-in 0.3s var(--ease-out);
 }
 
+.chat-loading-skeleton .chat-msg {
+  width: min(560px, 82%);
+}
+
+.chat-loading-skeleton .chat-line.user .chat-msg {
+  width: min(360px, 70%);
+}
+
+.chat-loading-skeleton .chat-bubble {
+  width: 100%;
+  box-sizing: border-box;
+}
+
 /* Welcome state (new session) */
 .agent-chat__welcome {
   display: flex;

--- a/ui/src/styles/chat/layout.test.ts
+++ b/ui/src/styles/chat/layout.test.ts
@@ -67,4 +67,15 @@ describe("chat layout styles", () => {
     expect(css).toContain("@media (max-width: 860px)");
     expect(css).toContain("width: 44px;");
   });
+
+  it("keeps the initial chat loading skeleton wide enough to read as message bubbles", () => {
+    const css = readLayoutCss();
+
+    expect(css).toContain(".chat-loading-skeleton .chat-msg");
+    expect(css).toContain("width: min(560px, 82%);");
+    expect(css).toContain(".chat-loading-skeleton .chat-line.user .chat-msg");
+    expect(css).toContain("width: min(360px, 70%);");
+    expect(css).toContain(".chat-loading-skeleton .chat-bubble");
+    expect(css).toContain("width: 100%;");
+  });
 });

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1059,10 +1059,7 @@
 
 .cron-workspace {
   margin-top: 16px;
-  display: grid;
-  grid-template-columns: minmax(0, 1.2fr) minmax(340px, 0.8fr);
-  gap: 16px;
-  align-items: start;
+  display: block;
 }
 
 .cron-workspace--form-collapsed {
@@ -1076,10 +1073,25 @@
 }
 
 .cron-workspace-form {
-  position: sticky;
-  top: 74px;
-  max-height: calc(100vh - 74px - 32px);
+  max-height: calc(100vh - 80px);
   overflow-y: auto;
+}
+
+.cron-form-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: grid;
+  place-items: center;
+  padding: 32px;
+  background: color-mix(in srgb, #000 58%, transparent);
+  backdrop-filter: blur(8px);
+}
+
+.cron-form-modal {
+  width: min(760px, calc(100vw - 48px));
+  max-height: min(860px, calc(100vh - 64px));
+  box-shadow: var(--shadow-xl);
 }
 
 .cron-workspace-form--collapsed {
@@ -1323,6 +1335,70 @@
 
 .cron-workspace .filters .field {
   min-width: 160px;
+}
+
+.cron-filter-panel {
+  margin-top: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--bg-elevated) 72%, transparent);
+}
+
+.cron-filter-panel__summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+  list-style: none;
+}
+
+.cron-filter-panel__summary::-webkit-details-marker {
+  display: none;
+}
+
+.cron-filter-panel__summary::after {
+  content: "v";
+  color: var(--muted);
+  font-size: 14px;
+  transition: transform var(--duration-fast) var(--ease-out);
+}
+
+.cron-filter-panel[open] .cron-filter-panel__summary::after {
+  transform: rotate(180deg);
+}
+
+.cron-filter-panel__body,
+.cron-filter-panel .cron-run-filters {
+  padding: 0 12px 12px;
+}
+
+.cron-empty-state {
+  margin-top: 12px;
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-md);
+  padding: 22px;
+  display: grid;
+  justify-items: start;
+  gap: 8px;
+  background: color-mix(in srgb, var(--bg-elevated) 58%, transparent);
+}
+
+.cron-empty-state__title {
+  color: var(--text-strong);
+  font-size: 14px;
+  font-weight: 650;
+}
+
+.cron-empty-state__copy {
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.45;
+  max-width: 520px;
 }
 
 .cron-run-filters {

--- a/ui/src/styles/config-quick.css
+++ b/ui/src/styles/config-quick.css
@@ -15,7 +15,7 @@
   width: 100%;
   max-width: 1520px;
   margin: 0 auto;
-  padding: 24px 16px 0;
+  padding: 24px 16px 16px;
 }
 
 .settings-section-nav__item {
@@ -1230,7 +1230,7 @@
 
 @media (max-width: 480px) {
   .settings-section-nav {
-    padding: 16px 0 0;
+    padding: 16px 0 12px;
   }
 
   .settings-section-nav__item {

--- a/ui/src/styles/config-quick.css
+++ b/ui/src/styles/config-quick.css
@@ -65,6 +65,16 @@
 .settings-section-nav__icon svg {
   width: 14px;
   height: 14px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.7px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.settings-section-nav__icon svg * {
+  stroke: currentColor;
+  fill: none;
 }
 
 .settings-section-nav__label {

--- a/ui/src/styles/config-quick.css
+++ b/ui/src/styles/config-quick.css
@@ -1,5 +1,76 @@
 /* ── Quick Settings ── */
 
+.settings-workspace {
+  width: 100%;
+}
+
+.settings-workspace__body {
+  width: 100%;
+}
+
+.settings-section-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  width: 100%;
+  max-width: 1520px;
+  margin: 0 auto;
+  padding: 24px 16px 0;
+}
+
+.settings-section-nav__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 34px;
+  padding: 6px 10px;
+  border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--card) 82%, transparent);
+  color: var(--muted);
+  font-size: 0.8125rem;
+  font-weight: 550;
+  text-decoration: none;
+  transition:
+    background var(--duration-fast) var(--ease-out),
+    border-color var(--duration-fast) var(--ease-out),
+    color var(--duration-fast) var(--ease-out);
+}
+
+.settings-section-nav__item:hover {
+  background: var(--bg-hover);
+  border-color: var(--border-strong);
+  color: var(--text);
+}
+
+.settings-section-nav__item:focus-visible {
+  outline: none;
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--border) 45%);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 20%, transparent);
+}
+
+.settings-section-nav__item--active {
+  background: color-mix(in srgb, var(--accent) 14%, var(--card) 86%);
+  border-color: color-mix(in srgb, var(--accent) 44%, var(--border) 56%);
+  color: var(--text-strong);
+}
+
+.settings-section-nav__icon {
+  display: inline-flex;
+  width: 14px;
+  height: 14px;
+  color: currentColor;
+}
+
+.settings-section-nav__icon svg {
+  width: 14px;
+  height: 14px;
+}
+
+.settings-section-nav__label {
+  overflow-wrap: anywhere;
+}
+
 .qs-container {
   width: 100%;
   max-width: 1520px;
@@ -1158,6 +1229,15 @@
 }
 
 @media (max-width: 480px) {
+  .settings-section-nav {
+    padding: 16px 0 0;
+  }
+
+  .settings-section-nav__item {
+    flex: 1 1 calc(50% - 4px);
+    justify-content: center;
+  }
+
   .qs-container {
     padding: 20px 0 40px;
   }

--- a/ui/src/styles/config-quick.test.ts
+++ b/ui/src/styles/config-quick.test.ts
@@ -53,6 +53,15 @@ describe("config-quick styles", () => {
     expect(css).toContain("padding: 16px 0 12px;");
   });
 
+  it("keeps settings section icons on the current text color", () => {
+    expect(css).toMatch(
+      /\.settings-section-nav__icon svg \{[\s\S]*stroke: currentColor;[\s\S]*fill: none;/,
+    );
+    expect(css).toMatch(
+      /\.settings-section-nav__icon svg \* \{[\s\S]*stroke: currentColor;[\s\S]*fill: none;/,
+    );
+  });
+
   it("avoids transition-all in the quick settings surface", () => {
     expect(css).not.toContain("transition: all");
   });

--- a/ui/src/styles/config-quick.test.ts
+++ b/ui/src/styles/config-quick.test.ts
@@ -48,6 +48,11 @@ describe("config-quick styles", () => {
     expect(css).toContain(".qs-profile-panel__actions-row");
   });
 
+  it("keeps settings section tabs padded away from scoped page content", () => {
+    expect(css).toContain("padding: 24px 16px 16px;");
+    expect(css).toContain("padding: 16px 0 12px;");
+  });
+
   it("avoids transition-all in the quick settings surface", () => {
     expect(css).not.toContain("transition: all");
   });

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -8,7 +8,7 @@
   grid-template-columns: minmax(0, 1fr);
   gap: 0;
   height: calc(100vh - 160px);
-  margin: 0 -16px -32px;
+  margin: 12px 0 0;
   border-radius: var(--radius-xl);
   border: 1px solid var(--border);
   background: var(--panel);
@@ -28,18 +28,15 @@
   }
 }
 
-/* Mobile: adjust margins to match mobile .content padding (4px 4px 16px) */
 @media (max-width: 600px) {
   .config-layout {
-    margin: 0;
-    /* safest: no negative margin cancellation on mobile */
+    margin: 8px 0 0;
   }
 }
 
-/* Small mobile: even smaller padding */
 @media (max-width: 400px) {
   .config-layout {
-    margin: 0;
+    margin: 8px 0 0;
   }
 }
 
@@ -187,8 +184,8 @@
   align-items: flex-start;
   justify-content: space-between;
   flex-wrap: wrap;
-  gap: 10px 16px;
-  padding: 10px 20px;
+  gap: 12px 18px;
+  padding: 14px 24px;
   background: var(--bg-accent);
   border-bottom: 1px solid var(--border);
   flex-shrink: 0;
@@ -293,8 +290,8 @@
 .config-top-tabs {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 10px 20px;
+  gap: 12px;
+  padding: 14px 24px 12px;
   background: var(--bg-accent);
   border-bottom: 1px solid var(--border);
   flex-shrink: 0;
@@ -315,7 +312,7 @@
 .config-top-tabs__scroller {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
   min-width: 0;
   flex: 1 1 auto;
   flex-wrap: nowrap;
@@ -331,7 +328,8 @@
   flex: 0 0 auto;
   border: 1px solid var(--border);
   border-radius: var(--radius-full);
-  padding: 5px 12px;
+  min-height: 36px;
+  padding: 8px 14px;
   background: var(--bg-elevated);
   color: var(--muted);
   font-size: 11.5px;
@@ -1957,7 +1955,7 @@
   .config-layout {
     height: calc(100vh - 100px);
     height: calc(100dvh - 100px);
-    margin: 0 -8px -16px;
+    margin: 8px 0 0;
     border-radius: var(--radius-md);
   }
 
@@ -2059,7 +2057,7 @@
 
 @media (max-width: 900px) {
   .config-actions {
-    padding: 10px 14px;
+    padding: 12px 16px;
   }
 
   .config-actions__left,

--- a/ui/src/styles/config.test.ts
+++ b/ui/src/styles/config.test.ts
@@ -13,4 +13,15 @@ describe("config styles", () => {
       /@media \(hover: none\) and \(pointer: coarse\) \{[\s\S]*\.config-search__input,[\s\S]*\.settings-theme-import__input,[\s\S]*\.config-raw-field textarea,[\s\S]*\.cfg-input,[\s\S]*\.cfg-input--sm,[\s\S]*\.cfg-textarea,[\s\S]*\.cfg-textarea--sm,[\s\S]*\.cfg-number__input,[\s\S]*\.cfg-select \{[\s\S]*font-size: 16px;/,
     );
   });
+
+  it("keeps the config chrome padded away from the page edge", () => {
+    const css = readConfigCss();
+
+    expect(css).toMatch(/\.config-layout \{[\s\S]*margin: 12px 0 0;/);
+    expect(css).toMatch(/\.config-actions \{[\s\S]*padding: 14px 24px;/);
+    expect(css).toMatch(/\.config-top-tabs \{[\s\S]*padding: 14px 24px 12px;/);
+    expect(css).toMatch(/\.config-top-tabs__tab \{[\s\S]*min-height: 36px;/);
+    expect(css).not.toContain("margin: 0 -16px -32px");
+    expect(css).not.toContain("margin: 0 -8px -16px");
+  });
 });

--- a/ui/src/styles/cron-quick-create.css
+++ b/ui/src/styles/cron-quick-create.css
@@ -1,9 +1,25 @@
 /* ── Cron Quick Create Wizard ── */
 
 .cqc-container {
-  max-width: 600px;
-  margin: 0 auto;
-  padding: 32px 20px 56px;
+  width: min(680px, calc(100vw - 40px));
+  max-height: min(760px, calc(100vh - 56px));
+  overflow-y: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--card);
+  box-shadow: var(--shadow-xl);
+  padding: 28px;
+}
+
+.cqc-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: grid;
+  place-items: center;
+  padding: 28px;
+  background: color-mix(in srgb, #000 58%, transparent);
+  backdrop-filter: blur(8px);
 }
 
 .cqc-header {
@@ -28,6 +44,11 @@
   width: 20px;
   height: 20px;
   color: var(--accent);
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.7;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .cqc-header__close {
@@ -56,6 +77,11 @@
 .cqc-header__close svg {
   width: 14px;
   height: 14px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 /* ── Step Indicator ── */
@@ -364,7 +390,13 @@
 
 @media (max-width: 480px) {
   .cqc-container {
-    padding: 20px 14px 40px;
+    width: calc(100vw - 20px);
+    max-height: calc(100vh - 20px);
+    padding: 20px 14px 28px;
+  }
+
+  .cqc-backdrop {
+    padding: 10px;
   }
 
   .cqc-preset-grid {

--- a/ui/src/styles/cron-quick-create.css
+++ b/ui/src/styles/cron-quick-create.css
@@ -369,10 +369,23 @@
 
 .cqc-actions {
   display: flex;
-  justify-content: flex-end;
+  align-items: center;
+  justify-content: space-between;
   gap: 8px;
+  flex-wrap: wrap;
   padding-top: 20px;
   border-top: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
+}
+
+.cqc-actions__secondary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.cqc-advanced-button {
+  color: var(--muted);
 }
 
 .cqc-actions .btn.primary {
@@ -406,5 +419,13 @@
   .cqc-step__line {
     width: 32px;
     margin: 0 6px;
+  }
+
+  .cqc-actions {
+    align-items: stretch;
+  }
+
+  .cqc-actions__secondary {
+    flex: 1 1 100%;
   }
 }

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -508,6 +508,7 @@
   display: grid;
   gap: 10px;
   flex-shrink: 0;
+  padding: 0 8px;
   margin-bottom: 16px;
 }
 
@@ -517,16 +518,18 @@
   justify-content: center;
   gap: 8px;
   width: 100%;
-  min-height: 40px;
-  padding: 0 12px;
-  border: 1px solid color-mix(in srgb, var(--accent) 36%, var(--border) 64%);
+  min-height: 38px;
+  box-sizing: border-box;
+  padding: 0 10px;
+  border: 1px solid color-mix(in srgb, var(--accent) 30%, var(--border) 70%);
   border-radius: var(--radius-md);
-  background: color-mix(in srgb, var(--accent) 16%, var(--bg-elevated) 84%);
+  background: color-mix(in srgb, var(--accent) 11%, var(--bg-elevated) 89%);
   color: var(--text-strong);
   cursor: pointer;
   font: inherit;
   font-size: 13px;
   font-weight: 700;
+  line-height: 1.2;
   transition:
     background var(--duration-fast) ease,
     border-color var(--duration-fast) ease,
@@ -535,8 +538,8 @@
 }
 
 .sidebar-new-session:hover:not(:disabled) {
-  background: color-mix(in srgb, var(--accent) 22%, var(--bg-hover) 78%);
-  border-color: color-mix(in srgb, var(--accent) 54%, var(--border) 46%);
+  background: color-mix(in srgb, var(--accent) 18%, var(--bg-hover) 82%);
+  border-color: color-mix(in srgb, var(--accent) 44%, var(--border) 56%);
   transform: translateY(-1px);
 }
 
@@ -547,14 +550,23 @@
 
 .sidebar-new-session__icon,
 .sidebar-new-session__icon svg {
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
 }
 
 .sidebar-new-session__icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  color: currentColor;
+}
+
+.sidebar-new-session__icon svg {
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.8px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .sidebar-recent-sessions {
@@ -866,6 +878,7 @@
 
 .sidebar--collapsed .sidebar-sessions {
   justify-items: center;
+  padding: 0;
   margin-bottom: 14px;
 }
 

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -446,6 +446,7 @@
   min-height: 0;
   flex: 1;
   display: flex;
+  flex-direction: column;
 }
 
 .sidebar-shell__footer {
@@ -501,6 +502,152 @@
   overflow-x: hidden;
   padding: 0;
   scrollbar-width: none;
+}
+
+.sidebar-sessions {
+  display: grid;
+  gap: 10px;
+  flex-shrink: 0;
+  margin-bottom: 16px;
+}
+
+.sidebar-new-session {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  min-height: 40px;
+  padding: 0 12px;
+  border: 1px solid color-mix(in srgb, var(--accent) 36%, var(--border) 64%);
+  border-radius: var(--radius-md);
+  background: color-mix(in srgb, var(--accent) 16%, var(--bg-elevated) 84%);
+  color: var(--text-strong);
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 700;
+  transition:
+    background var(--duration-fast) ease,
+    border-color var(--duration-fast) ease,
+    color var(--duration-fast) ease,
+    transform var(--duration-fast) ease;
+}
+
+.sidebar-new-session:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent) 22%, var(--bg-hover) 78%);
+  border-color: color-mix(in srgb, var(--accent) 54%, var(--border) 46%);
+  transform: translateY(-1px);
+}
+
+.sidebar-new-session:disabled {
+  cursor: not-allowed;
+  opacity: 0.52;
+}
+
+.sidebar-new-session__icon,
+.sidebar-new-session__icon svg {
+  width: 16px;
+  height: 16px;
+}
+
+.sidebar-new-session__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.sidebar-recent-sessions {
+  display: grid;
+  gap: 6px;
+}
+
+.sidebar-recent-sessions__label {
+  padding: 0 10px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--muted) 78%, var(--text) 22%);
+}
+
+.sidebar-recent-sessions__list {
+  display: grid;
+  gap: 4px;
+}
+
+.sidebar-recent-session {
+  display: grid;
+  grid-template-columns: 8px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  min-height: 40px;
+  padding: 7px 9px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  color: var(--muted);
+  text-decoration: none;
+  transition:
+    background var(--duration-fast) ease,
+    border-color var(--duration-fast) ease,
+    color var(--duration-fast) ease;
+}
+
+.sidebar-recent-session:hover {
+  background: color-mix(in srgb, var(--bg-hover) 78%, transparent);
+  border-color: color-mix(in srgb, var(--border) 70%, transparent);
+  color: var(--text);
+  text-decoration: none;
+}
+
+.sidebar-recent-session--active {
+  background: color-mix(in srgb, var(--accent-subtle) 68%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 18%, transparent);
+  color: var(--text-strong);
+}
+
+.sidebar-recent-session__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--muted) 46%, transparent);
+}
+
+.sidebar-recent-session--active .sidebar-recent-session__dot {
+  background: var(--accent);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
+.sidebar-recent-session__body {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.sidebar-recent-session__name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  font-weight: 650;
+}
+
+.sidebar-recent-session__meta {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.sidebar-recent-session__live {
+  width: 7px;
+  height: 7px;
+  border-radius: var(--radius-full);
+  background: var(--ok);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--ok) 12%, transparent);
 }
 
 .sidebar-nav::-webkit-scrollbar {
@@ -715,6 +862,18 @@
 
 .sidebar--collapsed .sidebar-nav {
   padding: 0;
+}
+
+.sidebar--collapsed .sidebar-sessions {
+  justify-items: center;
+  margin-bottom: 14px;
+}
+
+.sidebar--collapsed .sidebar-new-session {
+  width: 44px;
+  min-height: 44px;
+  padding: 0;
+  border-radius: var(--radius-lg);
 }
 
 .sidebar--collapsed .nav-section {

--- a/ui/src/styles/layout.mobile.test.ts
+++ b/ui/src/styles/layout.mobile.test.ts
@@ -55,6 +55,18 @@ describe("sidebar menu trigger styles", () => {
     expect(css).toContain(".topbar-nav-toggle {");
     expect(css).toContain("display: none;");
   });
+
+  it("keeps the sidebar new-session button inset and its icon visible", () => {
+    const css = readLayoutCss();
+
+    expect(css).toMatch(/\.sidebar-sessions \{[\s\S]*padding: 0 8px;/);
+    expect(css).toMatch(/\.sidebar-new-session \{[\s\S]*min-height: 38px;/);
+    expect(css).toMatch(/\.sidebar-new-session \{[\s\S]*box-sizing: border-box;/);
+    expect(css).toMatch(
+      /\.sidebar-new-session__icon svg \{[\s\S]*stroke: currentColor;[\s\S]*fill: none;/,
+    );
+    expect(css).toMatch(/\.sidebar--collapsed \.sidebar-sessions \{[\s\S]*padding: 0;/);
+  });
 });
 
 describe("grouped chat width styles", () => {

--- a/ui/src/ui/app-render.helpers.browser.test.ts
+++ b/ui/src/ui/app-render.helpers.browser.test.ts
@@ -1,7 +1,7 @@
 import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
 import { t } from "../i18n/index.ts";
-import { renderChatControls, renderChatMobileToggle } from "./app-render.helpers.ts";
+import { renderChatControls, renderChatMobileToggle, renderTab } from "./app-render.helpers.ts";
 import type { AppViewState } from "./app-view-state.ts";
 import type { SessionsListResult } from "./types.ts";
 
@@ -19,6 +19,8 @@ function createState(overrides: Partial<AppViewState> = {}) {
     chatSending: false,
     chatStream: null,
     onboarding: false,
+    basePath: "",
+    tab: "chat",
     sessionKey: "main",
     sessionsHideCron: true,
     sessionsResult: {
@@ -91,6 +93,22 @@ function requireElement<T extends Element>(element: T | null | undefined, label:
 }
 
 describe("chat header controls (browser)", () => {
+  it("keeps the sidebar settings entry active for nested settings tabs", async () => {
+    const state = createState({ tab: "appearance" });
+    const container = document.createElement("div");
+    render(renderTab(state, "config"), container);
+    await Promise.resolve();
+
+    const link = requireElement(
+      container.querySelector<HTMLAnchorElement>(".nav-item"),
+      "nav item",
+    );
+    expect(link.classList.contains("nav-item--active")).toBe(true);
+    expect(link.getAttribute("href")).toBe("/config");
+    expect(link.getAttribute("title")).toBe("Settings");
+    expect(link.textContent?.trim()).toBe("Settings");
+  });
+
   it("renders explicit hover tooltip metadata for the top-right action buttons", async () => {
     const container = document.createElement("div");
     render(renderChatControls(createState()), container);

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -18,7 +18,7 @@ import { resolveControlUiAuthToken } from "./control-ui-auth.ts";
 import { ChatState, loadChatHistory } from "./controllers/chat.ts";
 import { createSessionAndRefresh, loadSessions } from "./controllers/sessions.ts";
 import { icons } from "./icons.ts";
-import { iconForTab, pathForTab, titleForTab, type Tab } from "./navigation.ts";
+import { iconForTab, isSettingsTab, pathForTab, titleForTab, type Tab } from "./navigation.ts";
 import { isCronSessionKey, parseSessionKey, resolveSessionDisplayName } from "./session-display.ts";
 import {
   normalizeAgentId,
@@ -181,7 +181,7 @@ const NEW_CHAT_CREATE_FAILED_MESSAGE =
 
 export function renderTab(state: AppViewState, tab: Tab, opts?: { collapsed?: boolean }) {
   const href = pathForTab(tab, state.basePath);
-  const isActive = state.tab === tab;
+  const isActive = tab === "config" ? isSettingsTab(state.tab) : state.tab === tab;
   const collapsed = opts?.collapsed ?? state.settings.navCollapsed;
   return html`
     <a
@@ -672,17 +672,17 @@ export function dismissChatError(state: AppViewState) {
   }
 }
 
-export async function createChatSession(state: AppViewState) {
+export async function createChatSession(state: AppViewState): Promise<boolean> {
   if (!state.client || !state.connected) {
-    return;
+    return false;
   }
   if (!canSwitchToNewChatSession(state)) {
     state.lastError = NEW_CHAT_ACTIVE_RUN_MESSAGE;
-    return;
+    return false;
   }
   if (state.sessionsLoading) {
     state.lastError = NEW_CHAT_SESSIONS_LOADING_MESSAGE;
-    return;
+    return false;
   }
 
   state.lastError = null;
@@ -720,7 +720,7 @@ export async function createChatSession(state: AppViewState) {
           ? NEW_CHAT_SESSIONS_LOADING_MESSAGE
           : NEW_CHAT_CREATE_FAILED_MESSAGE);
     }
-    return;
+    return false;
   }
 
   const preservedDraft = state.chatMessage;
@@ -728,6 +728,7 @@ export async function createChatSession(state: AppViewState) {
   switchChatSession(state, nextSessionKey);
   state.chatMessage = preservedDraft;
   state.chatAttachments = preservedAttachments;
+  return true;
 }
 
 async function refreshSessionOptions(state: AppViewState) {

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -148,9 +148,10 @@ import {
 } from "./navigation.ts";
 import { isPluginEnabledInConfigSnapshot } from "./plugin-activation.ts";
 import "./components/dashboard-header.ts";
-import { resolveSessionDisplayName } from "./session-display.ts";
+import { isCronSessionKey, resolveSessionDisplayName } from "./session-display.ts";
 import {
   buildAgentMainSessionKey,
+  isSubagentSessionKey,
   parseAgentSessionKey,
   resolveAgentIdFromSessionKey,
 } from "./session-key.ts";
@@ -248,7 +249,16 @@ function isSidebarSessionBusy(state: AppViewState) {
 
 function resolveSidebarRecentSessions(state: AppViewState): GatewaySessionRow[] {
   return (state.sessionsResult?.sessions ?? [])
-    .filter((row) => !row.archived)
+    .filter(
+      (row) =>
+        !row.archived &&
+        row.kind !== "global" &&
+        row.kind !== "unknown" &&
+        row.kind !== "cron" &&
+        !isCronSessionKey(row.key) &&
+        !isSubagentSessionKey(row.key) &&
+        !row.spawnedBy,
+    )
     .toSorted((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0))
     .slice(0, 5);
 }

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -824,8 +824,8 @@ function renderCronQuickCreateForTab(
       state.cronForm = { ...DEFAULT_CRON_FORM, ...formPatch } as typeof state.cronForm;
       requestHostUpdate?.();
       void (async () => {
-        await addCronJob(state);
-        if (state.cronError || hasCronFormErrors(state.cronFieldErrors)) {
+        const saved = await addCronJob(state);
+        if (!saved) {
           requestHostUpdate?.();
           return;
         }
@@ -2105,7 +2105,15 @@ export function renderApp(state: AppViewState) {
                   state.cronFieldErrors = validateCronForm(state.cronForm);
                 },
                 onRefresh: () => state.loadCron(),
-                onAdd: () => addCronJob(state),
+                onAdd: () => {
+                  void (async () => {
+                    const saved = await addCronJob(state);
+                    if (saved) {
+                      state.cronFormCollapsed = true;
+                    }
+                    requestHostUpdate?.();
+                  })();
+                },
                 onEdit: (job) => {
                   state.cronFormCollapsed = false;
                   startCronEdit(state, job);
@@ -2114,9 +2122,14 @@ export function renderApp(state: AppViewState) {
                   state.cronFormCollapsed = false;
                   startCronClone(state, job);
                 },
-                onCancelEdit: () => cancelCronEdit(state),
+                onCancelEdit: () => {
+                  cancelCronEdit(state);
+                  state.cronFormCollapsed = true;
+                  requestHostUpdate?.();
+                },
                 onToggleFormCollapsed: (collapsed) => {
                   state.cronFormCollapsed = collapsed;
+                  requestHostUpdate?.();
                 },
                 onToggle: (job, enabled) => toggleCronJob(state, job, enabled),
                 onRun: (job, mode) => runCronJob(state, job, mode ?? "force"),

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -131,10 +131,16 @@ import {
 } from "./controllers/skills.ts";
 import { getCronJobPayload } from "./cron-payload.ts";
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "./external-link.ts";
+import { formatRelativeTimestamp } from "./format.ts";
 import { icons } from "./icons.ts";
 import { createLazyView, renderLazyView } from "./lazy-view.ts";
 import {
+  iconForTab,
+  isTabInGroup,
+  isSettingsTab,
   normalizeBasePath,
+  pathForTab,
+  SETTINGS_TABS,
   TAB_GROUPS,
   subtitleForTab,
   titleForTab,
@@ -142,6 +148,7 @@ import {
 } from "./navigation.ts";
 import { isPluginEnabledInConfigSnapshot } from "./plugin-activation.ts";
 import "./components/dashboard-header.ts";
+import { resolveSessionDisplayName } from "./session-display.ts";
 import {
   buildAgentMainSessionKey,
   parseAgentSessionKey,
@@ -149,6 +156,7 @@ import {
 } from "./session-key.ts";
 import { loadLocalAssistantIdentity } from "./storage.ts";
 import { normalizeOptionalString } from "./string-coerce.ts";
+import type { GatewaySessionRow } from "./types.ts";
 import { isRenderableControlUiAvatarUrl } from "./views/agents-utils.ts";
 import { agentLogoUrl } from "./views/agents-utils.ts";
 import {
@@ -178,6 +186,157 @@ import { renderOverview } from "./views/overview.ts";
 let _pendingUpdate: (() => void) | undefined;
 
 const notifyLazyViewChanged = () => _pendingUpdate?.();
+
+function renderSettingsSectionNav(state: AppViewState) {
+  if (!isSettingsTab(state.tab)) {
+    return nothing;
+  }
+  return html`
+    <nav class="settings-section-nav" aria-label="Settings sections">
+      ${SETTINGS_TABS.map((tab) => {
+        const active = state.tab === tab;
+        const href = pathForTab(tab, state.basePath);
+        return html`
+          <a
+            href=${href}
+            class="settings-section-nav__item ${active ? "settings-section-nav__item--active" : ""}"
+            @click=${(event: MouseEvent) => {
+              if (
+                event.defaultPrevented ||
+                event.button !== 0 ||
+                event.metaKey ||
+                event.ctrlKey ||
+                event.shiftKey ||
+                event.altKey
+              ) {
+                return;
+              }
+              event.preventDefault();
+              state.setTab(tab);
+            }}
+            title=${titleForTab(tab)}
+          >
+            <span class="settings-section-nav__icon" aria-hidden="true"
+              >${icons[iconForTab(tab)]}</span
+            >
+            <span class="settings-section-nav__label">${titleForTab(tab)}</span>
+          </a>
+        `;
+      })}
+    </nav>
+  `;
+}
+
+function renderSettingsWorkspace(state: AppViewState, body: unknown) {
+  return html`
+    <section class="settings-workspace">
+      ${renderSettingsSectionNav(state)}
+      <div class="settings-workspace__body">${body}</div>
+    </section>
+  `;
+}
+
+function isSidebarSessionBusy(state: AppViewState) {
+  return (
+    state.chatLoading ||
+    state.chatSending ||
+    Boolean(state.chatRunId) ||
+    state.chatStream !== null ||
+    state.chatQueue.length > 0
+  );
+}
+
+function resolveSidebarRecentSessions(state: AppViewState): GatewaySessionRow[] {
+  return (state.sessionsResult?.sessions ?? [])
+    .filter((row) => !row.archived)
+    .toSorted((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0))
+    .slice(0, 5);
+}
+
+function renderSidebarSessions(state: AppViewState) {
+  const collapsed = state.settings.navCollapsed;
+  const busy = isSidebarSessionBusy(state);
+  const recent = collapsed ? [] : resolveSidebarRecentSessions(state);
+  const newSessionDisabled = !state.connected || state.sessionsLoading || busy || !state.client;
+  const newSessionTitle = !state.connected
+    ? "Connect to create a new session"
+    : busy
+      ? "Finish the active run before creating a new session"
+      : "New session";
+
+  return html`
+    <section class="sidebar-sessions ${collapsed ? "sidebar-sessions--collapsed" : ""}">
+      <button
+        type="button"
+        class="sidebar-new-session"
+        title=${newSessionTitle}
+        aria-label="New session"
+        ?disabled=${newSessionDisabled}
+        @click=${async () => {
+          if (newSessionDisabled) {
+            return;
+          }
+          if (await createChatSession(state)) {
+            state.setTab("chat" as import("./navigation.ts").Tab);
+          }
+        }}
+      >
+        <span class="sidebar-new-session__icon" aria-hidden="true">${icons.plus}</span>
+        ${collapsed ? nothing : html`<span class="sidebar-new-session__label">New session</span>`}
+      </button>
+      ${collapsed || recent.length === 0
+        ? nothing
+        : html`
+            <div class="sidebar-recent-sessions" aria-label="Recent sessions">
+              <div class="sidebar-recent-sessions__label">Recent</div>
+              <div class="sidebar-recent-sessions__list">
+                ${recent.map((row) => renderSidebarRecentSession(state, row))}
+              </div>
+            </div>
+          `}
+    </section>
+  `;
+}
+
+function renderSidebarRecentSession(state: AppViewState, row: GatewaySessionRow) {
+  const active = row.key === state.sessionKey;
+  const label = resolveSessionDisplayName(row.key, row);
+  const meta = row.updatedAt ? formatRelativeTimestamp(row.updatedAt) : "n/a";
+  const href = `${pathForTab("chat", state.basePath)}?session=${encodeURIComponent(row.key)}`;
+  return html`
+    <a
+      href=${href}
+      class="sidebar-recent-session ${active ? "sidebar-recent-session--active" : ""}"
+      title=${`${label} · ${row.key}`}
+      @click=${(event: MouseEvent) => {
+        if (
+          event.defaultPrevented ||
+          event.button !== 0 ||
+          event.metaKey ||
+          event.ctrlKey ||
+          event.shiftKey ||
+          event.altKey
+        ) {
+          return;
+        }
+        event.preventDefault();
+        if (row.key !== state.sessionKey) {
+          switchChatSession(state, row.key);
+        }
+        state.setTab("chat" as import("./navigation.ts").Tab);
+      }}
+    >
+      <span class="sidebar-recent-session__dot" aria-hidden="true"></span>
+      <span class="sidebar-recent-session__body">
+        <span class="sidebar-recent-session__name">${label}</span>
+        <span class="sidebar-recent-session__meta">${meta}</span>
+      </span>
+      ${row.hasActiveRun
+        ? html`<span class="sidebar-recent-session__live" aria-label="Active run"></span>`
+        : nothing}
+    </a>
+  `;
+}
 
 // Lazy-loaded view modules are deferred so the initial bundle stays small.
 // The shared loader renders visible fallback states instead of leaving a tab blank.
@@ -1088,9 +1247,8 @@ export function renderApp(state: AppViewState) {
             fastMode,
             onModelChange: () => {
               state.configSettingsMode = "advanced";
-              state.tab = "aiAgents" as import("./navigation.ts").Tab;
               state.aiAgentsActiveSection = "models";
-              requestHostUpdate?.();
+              state.setTab("aiAgents");
             },
             onThinkingChange: (level) => {
               void patchSession(state, state.sessionKey, { thinkingLevel: level }).then(() =>
@@ -1104,9 +1262,7 @@ export function renderApp(state: AppViewState) {
             },
             channels: extractQuickSettingsChannels(state),
             onChannelConfigure: () => {
-              state.tab = "communications" as import("./navigation.ts").Tab;
-              state.communicationsActiveSection = "channels";
-              requestHostUpdate?.();
+              state.setTab("channels");
             },
             automation: {
               cronJobCount: state.cronJobs?.length ?? 0,
@@ -1114,17 +1270,14 @@ export function renderApp(state: AppViewState) {
               mcpServerCount: extractMcpServerCount(state),
             },
             onManageCron: () => {
-              state.tab = "cron" as import("./navigation.ts").Tab;
-              requestHostUpdate?.();
+              state.setTab("cron");
             },
             onBrowseSkills: () => {
-              state.tab = "skills" as import("./navigation.ts").Tab;
-              requestHostUpdate?.();
+              state.setTab("skills");
             },
             onConfigureMcp: () => {
-              state.tab = "infrastructure" as import("./navigation.ts").Tab;
               state.infrastructureActiveSection = "mcp";
-              requestHostUpdate?.();
+              state.setTab("infrastructure");
             },
             security: extractQuickSettingsSecurity(state),
             onSecurityConfigure: () => {
@@ -1246,6 +1399,43 @@ export function renderApp(state: AppViewState) {
           ],
         });
       }
+      case "channels":
+        return renderLazyView(lazyChannels, (m) =>
+          m.renderChannels({
+            connected: state.connected,
+            loading: state.channelsLoading,
+            snapshot: state.channelsSnapshot,
+            lastError: state.channelsError,
+            lastSuccessAt: state.channelsLastSuccess,
+            whatsappMessage: state.whatsappLoginMessage,
+            whatsappQrDataUrl: state.whatsappLoginQrDataUrl,
+            whatsappConnected: state.whatsappLoginConnected,
+            whatsappBusy: state.whatsappBusy,
+            configSchema: state.configSchema,
+            configSchemaLoading: state.configSchemaLoading,
+            configForm: state.configForm,
+            configUiHints: state.configUiHints,
+            configSaving: state.configSaving,
+            configFormDirty: state.configFormDirty,
+            nostrProfileFormState: state.nostrProfileFormState,
+            nostrProfileAccountId: state.nostrProfileAccountId,
+            onRefresh: (probe) => loadChannels(state, probe),
+            onWhatsAppStart: (force) => state.handleWhatsAppStart(force),
+            onWhatsAppWait: () => state.handleWhatsAppWait(),
+            onWhatsAppLogout: () => state.handleWhatsAppLogout(),
+            onConfigPatch: (path, value) => updateConfigFormValue(state, path, value),
+            onConfigSave: () => state.handleChannelConfigSave(),
+            onConfigReload: () => state.handleChannelConfigReload(),
+            onNostrProfileEdit: (accountId, profile) =>
+              state.handleNostrProfileEdit(accountId, profile),
+            onNostrProfileCancel: () => state.handleNostrProfileCancel(),
+            onNostrProfileFieldChange: (field, value) =>
+              state.handleNostrProfileFieldChange(field, value),
+            onNostrProfileSave: () => state.handleNostrProfileSave(),
+            onNostrProfileImport: () => state.handleNostrProfileImport(),
+            onNostrProfileToggleAdvanced: () => state.handleNostrProfileToggleAdvanced(),
+          }),
+        );
       case "communications":
         return renderConfigTab({
           formMode: state.communicationsFormMode,
@@ -1511,10 +1701,11 @@ export function renderApp(state: AppViewState) {
               </button>
             </div>
             <div class="sidebar-shell__body">
+              ${renderSidebarSessions(state)}
               <nav class="sidebar-nav">
                 ${TAB_GROUPS.map((group) => {
                   const isGroupCollapsed = state.settings.navGroupsCollapsed[group.label] ?? false;
-                  const hasActiveTab = group.tabs.some((tab) => tab === state.tab);
+                  const hasActiveTab = isTabInGroup(group, state.tab);
                   const showItems = navCollapsed || hasActiveTab || !isGroupCollapsed;
 
                   return html`
@@ -1712,44 +1903,6 @@ export function renderApp(state: AppViewState) {
               onNavigate: (tab) => state.setTab(tab as import("./navigation.ts").Tab),
               onRefreshLogs: () => state.loadOverview({ refresh: true }),
             })
-          : nothing}
-        ${state.tab === "channels"
-          ? renderLazyView(lazyChannels, (m) =>
-              m.renderChannels({
-                connected: state.connected,
-                loading: state.channelsLoading,
-                snapshot: state.channelsSnapshot,
-                lastError: state.channelsError,
-                lastSuccessAt: state.channelsLastSuccess,
-                whatsappMessage: state.whatsappLoginMessage,
-                whatsappQrDataUrl: state.whatsappLoginQrDataUrl,
-                whatsappConnected: state.whatsappLoginConnected,
-                whatsappBusy: state.whatsappBusy,
-                configSchema: state.configSchema,
-                configSchemaLoading: state.configSchemaLoading,
-                configForm: state.configForm,
-                configUiHints: state.configUiHints,
-                configSaving: state.configSaving,
-                configFormDirty: state.configFormDirty,
-                nostrProfileFormState: state.nostrProfileFormState,
-                nostrProfileAccountId: state.nostrProfileAccountId,
-                onRefresh: (probe) => loadChannels(state, probe),
-                onWhatsAppStart: (force) => state.handleWhatsAppStart(force),
-                onWhatsAppWait: () => state.handleWhatsAppWait(),
-                onWhatsAppLogout: () => state.handleWhatsAppLogout(),
-                onConfigPatch: (path, value) => updateConfigFormValue(state, path, value),
-                onConfigSave: () => state.handleChannelConfigSave(),
-                onConfigReload: () => state.handleChannelConfigReload(),
-                onNostrProfileEdit: (accountId, profile) =>
-                  state.handleNostrProfileEdit(accountId, profile),
-                onNostrProfileCancel: () => state.handleNostrProfileCancel(),
-                onNostrProfileFieldChange: (field, value) =>
-                  state.handleNostrProfileFieldChange(field, value),
-                onNostrProfileSave: () => state.handleNostrProfileSave(),
-                onNostrProfileImport: () => state.handleNostrProfileImport(),
-                onNostrProfileToggleAdvanced: () => state.handleNostrProfileToggleAdvanced(),
-              }),
-            )
           : nothing}
         ${state.tab === "instances"
           ? renderLazyView(lazyInstances, (m) =>
@@ -2609,48 +2762,56 @@ export function renderApp(state: AppViewState) {
                 }),
             )
           : nothing}
-        ${renderConfigTabForActiveTab()}
+        ${isSettingsTab(state.tab) && state.tab !== "debug" && state.tab !== "logs"
+          ? renderSettingsWorkspace(state, renderConfigTabForActiveTab())
+          : renderConfigTabForActiveTab()}
         ${state.tab === "debug"
-          ? renderLazyView(lazyDebug, (m) =>
-              m.renderDebug({
-                loading: state.debugLoading,
-                status: state.debugStatus,
-                health: state.debugHealth,
-                models: state.debugModels,
-                heartbeat: state.debugHeartbeat,
-                eventLog: state.eventLog,
-                methods: (state.hello?.features?.methods ?? []).toSorted(),
-                callMethod: state.debugCallMethod,
-                callParams: state.debugCallParams,
-                callResult: state.debugCallResult,
-                callError: state.debugCallError,
-                onCallMethodChange: (next) => (state.debugCallMethod = next),
-                onCallParamsChange: (next) => (state.debugCallParams = next),
-                onRefresh: () => loadDebug(state),
-                onCall: () => callDebugMethod(state),
-              }),
+          ? renderSettingsWorkspace(
+              state,
+              renderLazyView(lazyDebug, (m) =>
+                m.renderDebug({
+                  loading: state.debugLoading,
+                  status: state.debugStatus,
+                  health: state.debugHealth,
+                  models: state.debugModels,
+                  heartbeat: state.debugHeartbeat,
+                  eventLog: state.eventLog,
+                  methods: (state.hello?.features?.methods ?? []).toSorted(),
+                  callMethod: state.debugCallMethod,
+                  callParams: state.debugCallParams,
+                  callResult: state.debugCallResult,
+                  callError: state.debugCallError,
+                  onCallMethodChange: (next) => (state.debugCallMethod = next),
+                  onCallParamsChange: (next) => (state.debugCallParams = next),
+                  onRefresh: () => loadDebug(state),
+                  onCall: () => callDebugMethod(state),
+                }),
+              ),
             )
           : nothing}
         ${state.tab === "logs"
-          ? renderLazyView(lazyLogs, (m) =>
-              m.renderLogs({
-                loading: state.logsLoading,
-                error: state.logsError,
-                file: state.logsFile,
-                entries: state.logsEntries,
-                filterText: state.logsFilterText,
-                levelFilters: state.logsLevelFilters,
-                autoFollow: state.logsAutoFollow,
-                truncated: state.logsTruncated,
-                onFilterTextChange: (next) => (state.logsFilterText = next),
-                onLevelToggle: (level, enabled) => {
-                  state.logsLevelFilters = { ...state.logsLevelFilters, [level]: enabled };
-                },
-                onToggleAutoFollow: (next) => (state.logsAutoFollow = next),
-                onRefresh: () => loadLogs(state, { reset: true }),
-                onExport: (lines, label) => state.exportLogs(lines, label),
-                onScroll: (event) => state.handleLogsScroll(event),
-              }),
+          ? renderSettingsWorkspace(
+              state,
+              renderLazyView(lazyLogs, (m) =>
+                m.renderLogs({
+                  loading: state.logsLoading,
+                  error: state.logsError,
+                  file: state.logsFile,
+                  entries: state.logsEntries,
+                  filterText: state.logsFilterText,
+                  levelFilters: state.logsLevelFilters,
+                  autoFollow: state.logsAutoFollow,
+                  truncated: state.logsTruncated,
+                  onFilterTextChange: (next) => (state.logsFilterText = next),
+                  onLevelToggle: (level, enabled) => {
+                    state.logsLevelFilters = { ...state.logsLevelFilters, [level]: enabled };
+                  },
+                  onToggleAutoFollow: (next) => (state.logsAutoFollow = next),
+                  onRefresh: () => loadLogs(state, { reset: true }),
+                  onExport: (lines, label) => state.exportLogs(lines, label),
+                  onScroll: (event) => state.handleLogsScroll(event),
+                }),
+              ),
             )
           : nothing}
         ${state.tab === "dreams"

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -488,12 +488,12 @@ function dismissUpdateBanner(updateAvailable: unknown) {
 }
 
 const COMMUNICATION_SECTION_KEYS = [
-  "channels",
   "messages",
   "broadcast",
   "__notifications__",
   "talk",
   "audio",
+  "channels",
 ] as const;
 const APPEARANCE_SECTION_KEYS = ["__appearance__", "ui", "wizard"] as const;
 const AUTOMATION_SECTION_KEYS = [
@@ -544,6 +544,7 @@ type ConfigTabOverrides = Pick<
       ConfigProps,
       | "showModeToggle"
       | "navRootLabel"
+      | "showRootTab"
       | "includeSections"
       | "excludeSections"
       | "includeVirtualSections"
@@ -585,14 +586,29 @@ function normalizeScopedConfigSelection(
   return { activeSection, activeSubsection };
 }
 
-function countTopLevelSchemaProperties(schema: unknown): number {
+function countScopedTopLevelSchemaProperties(
+  schema: unknown,
+  includeSections?: readonly string[],
+  excludeSections?: readonly string[],
+): number {
   if (!schema || typeof schema !== "object" || Array.isArray(schema)) {
     return 0;
   }
   const properties = (schema as { properties?: unknown }).properties;
-  return properties && typeof properties === "object" && !Array.isArray(properties)
-    ? Object.keys(properties).length
-    : 0;
+  if (!properties || typeof properties !== "object" || Array.isArray(properties)) {
+    return 0;
+  }
+  const include = includeSections?.length ? new Set(includeSections) : null;
+  const exclude = excludeSections?.length ? new Set(excludeSections) : null;
+  return Object.keys(properties).filter((key) => {
+    if (include && !include.has(key)) {
+      return false;
+    }
+    if (exclude?.has(key)) {
+      return false;
+    }
+    return true;
+  }).length;
 }
 
 function renderMeasured<T>(
@@ -1191,16 +1207,23 @@ export function renderApp(state: AppViewState) {
     | "excludeSections"
     | "includeVirtualSections"
   >;
-  const renderConfigTab = (overrides: ConfigTabOverrides) =>
-    renderMeasured(
+  const renderConfigTab = (overrides: ConfigTabOverrides) => {
+    const scopedDefaultSection = overrides.includeSections?.[0] ?? null;
+    const activeSection = overrides.activeSection ?? scopedDefaultSection;
+    const showRootTab = overrides.showRootTab ?? !overrides.includeSections?.length;
+    return renderMeasured(
       state,
       "config",
       {
         tab: state.tab,
         formMode: overrides.formMode,
-        activeSection: overrides.activeSection,
+        activeSection,
         activeSubsection: overrides.activeSubsection,
-        schemaSectionCount: countTopLevelSchemaProperties(commonConfigProps.schema),
+        schemaSectionCount: countScopedTopLevelSchemaProperties(
+          commonConfigProps.schema,
+          overrides.includeSections,
+          overrides.excludeSections,
+        ),
         hasSearch: Boolean(overrides.searchQuery?.trim()),
       },
       () =>
@@ -1208,8 +1231,11 @@ export function renderApp(state: AppViewState) {
           ...commonConfigProps,
           includeVirtualSections: false,
           ...overrides,
+          activeSection,
+          showRootTab,
         }),
     );
+  };
   const configSelection = normalizeMainConfigSelection(
     state.configActiveSection,
     state.configActiveSubsection,

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -193,7 +193,7 @@ function renderSettingsSectionNav(state: AppViewState) {
     return nothing;
   }
   return html`
-    <nav class="settings-section-nav" aria-label="Settings sections">
+    <nav class="settings-section-nav" aria-label=${t("common.settingsSections")}>
       ${SETTINGS_TABS.map((tab) => {
         const active = state.tab === tab;
         const href = pathForTab(tab, state.basePath);
@@ -280,7 +280,7 @@ function renderSidebarSessions(state: AppViewState) {
         type="button"
         class="sidebar-new-session"
         title=${newSessionTitle}
-        aria-label="New session"
+        aria-label=${t("chat.runControls.newSession")}
         ?disabled=${newSessionDisabled}
         @click=${async () => {
           if (newSessionDisabled) {
@@ -292,13 +292,17 @@ function renderSidebarSessions(state: AppViewState) {
         }}
       >
         <span class="sidebar-new-session__icon" aria-hidden="true">${icons.plus}</span>
-        ${collapsed ? nothing : html`<span class="sidebar-new-session__label">New session</span>`}
+        ${collapsed
+          ? nothing
+          : html`<span class="sidebar-new-session__label"
+              >${t("chat.runControls.newSession")}</span
+            >`}
       </button>
       ${collapsed || recent.length === 0
         ? nothing
         : html`
-            <div class="sidebar-recent-sessions" aria-label="Recent sessions">
-              <div class="sidebar-recent-sessions__label">Recent</div>
+            <div class="sidebar-recent-sessions" aria-label=${t("overview.cards.recentSessions")}>
+              <div class="sidebar-recent-sessions__label">${t("usage.sessions.recentShort")}</div>
               <div class="sidebar-recent-sessions__list">
                 ${recent.map((row) => renderSidebarRecentSession(state, row))}
               </div>
@@ -342,7 +346,10 @@ function renderSidebarRecentSession(state: AppViewState, row: GatewaySessionRow)
         <span class="sidebar-recent-session__meta">${meta}</span>
       </span>
       ${row.hasActiveRun
-        ? html`<span class="sidebar-recent-session__live" aria-label="Active run"></span>`
+        ? html`<span
+            class="sidebar-recent-session__live"
+            aria-label=${t("sessions.sessionDetails.activeRun")}
+          ></span>`
         : nothing}
     </a>
   `;

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -835,6 +835,21 @@ function renderCronQuickCreateForTab(
         requestHostUpdate?.();
       })();
     },
+    onAdvancedCreate: () => {
+      const draft = state.cronQuickCreateDraft ?? createDefaultDraft();
+      const formPatch = draftToCronFormPatch(draft);
+      state.cronEditingJobId = null;
+      state.cronForm = normalizeCronFormState({
+        ...DEFAULT_CRON_FORM,
+        ...formPatch,
+      } as typeof state.cronForm);
+      state.cronFieldErrors = validateCronForm(state.cronForm);
+      state.cronQuickCreateOpen = false;
+      state.cronQuickCreateStep = "what";
+      state.cronQuickCreateDraft = null;
+      state.cronFormCollapsed = false;
+      requestHostUpdate?.();
+    },
     onCancel: () => {
       state.cronQuickCreateOpen = false;
       state.cronQuickCreateStep = "what";

--- a/ui/src/ui/app-settings.refresh-active-tab.node.test.ts
+++ b/ui/src/ui/app-settings.refresh-active-tab.node.test.ts
@@ -5,13 +5,15 @@ type CronRunsLoadStatus = "ok" | "error" | "skipped";
 
 function createDeferred<T = void>() {
   let resolve: ((value: T | PromiseLike<T>) => void) | undefined;
-  const promise = new Promise<T>((res) => {
+  let reject: ((reason?: unknown) => void) | undefined;
+  const promise = new Promise<T>((res, rej) => {
     resolve = res;
+    reject = rej;
   });
-  if (!resolve) {
+  if (!resolve || !reject) {
     throw new Error("Expected deferred resolver to be initialized");
   }
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 async function raceWithNextMacrotask(promise: Promise<unknown>): Promise<"resolved" | "pending"> {
@@ -346,6 +348,39 @@ describe("refreshActiveTab", () => {
     await vi.waitFor(() => {
       expect(host.requestUpdate).toHaveBeenCalledOnce();
     });
+  });
+
+  it("loads scoped settings snapshots before starting the schema refresh", async () => {
+    const host = createHost();
+    host.tab = "communications";
+    const config = createDeferred();
+    mocks.loadConfigMock.mockReturnValueOnce(config.promise);
+
+    const refresh = refreshActiveTab(host as never);
+    await Promise.resolve();
+
+    expect(mocks.loadConfigMock).toHaveBeenCalledOnce();
+    expect(mocks.loadConfigSchemaMock).not.toHaveBeenCalled();
+    await expect(raceWithNextMacrotask(refresh)).resolves.toBe("pending");
+
+    config.resolve();
+    await refresh;
+
+    await vi.waitFor(() => {
+      expect(mocks.loadConfigSchemaMock).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("does not start the deferred schema refresh when scoped settings fail to load", async () => {
+    const host = createHost();
+    host.tab = "communications";
+    const error = new Error("config unavailable");
+    mocks.loadConfigMock.mockRejectedValueOnce(error);
+
+    await expect(refreshActiveTab(host as never)).rejects.toBe(error);
+    await Promise.resolve();
+
+    expect(mocks.loadConfigSchemaMock).not.toHaveBeenCalled();
   });
 
   it("renders channels from the cheap snapshot without waiting for config schema", async () => {

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -390,6 +390,19 @@ async function refreshAgentsTab(host: SettingsHost, app: SettingsAppHost) {
   }
 }
 
+function loadConfigSchemaAfterPrimary(
+  host: SettingsHost,
+  app: SettingsAppHost,
+  primaryRefresh: Promise<unknown>,
+) {
+  void primaryRefresh.then(
+    () => {
+      void loadConfigSchema(app).finally(() => host.requestUpdate?.());
+    },
+    () => undefined,
+  );
+}
+
 export async function refreshActiveTab(host: SettingsHost) {
   const app = host as unknown as SettingsAppHost;
   const refreshRun = beginControlUiRefresh(host, host.tab);
@@ -401,8 +414,11 @@ export async function refreshActiveTab(host: SettingsHost) {
       case "automation":
       case "infrastructure":
       case "aiAgents":
-        void loadConfigSchema(app).finally(() => host.requestUpdate?.());
-        await loadConfig(app);
+        {
+          const primaryRefresh = loadConfig(app);
+          loadConfigSchemaAfterPrimary(host, app, primaryRefresh);
+          await primaryRefresh;
+        }
         break;
       case "overview":
         await loadOverview(host);
@@ -906,8 +922,9 @@ function buildAttentionItems(host: SettingsAppHost) {
 
 export async function loadChannelsTab(host: SettingsHost) {
   const app = host as unknown as SettingsAppHost;
-  void loadConfigSchema(app).finally(() => host.requestUpdate?.());
-  await Promise.all([loadChannels(app, false), loadConfig(app)]);
+  const primaryRefresh = Promise.all([loadChannels(app, false), loadConfig(app)]);
+  loadConfigSchemaAfterPrimary(host, app, primaryRefresh);
+  await primaryRefresh;
 }
 
 export async function loadCron(host: SettingsHost) {

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -499,7 +499,7 @@ export class OpenClawApp extends LitElement {
   @state() cronStatus: CronStatus | null = null;
   @state() cronError: string | null = null;
   @state() cronForm: CronFormState = { ...DEFAULT_CRON_FORM };
-  @state() cronFormCollapsed = false;
+  @state() cronFormCollapsed = true;
   @state() cronFieldErrors: import("./controllers/cron.js").CronFieldErrors = {};
   @state() cronEditingJobId: string | null = null;
   @state() cronRunsJobId: string | null = null;

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -150,7 +150,7 @@ function renderChatQuotaPill(state: AppViewState) {
         state.setTab("usage");
       }}
     >
-      <span class="chat-controls__quota-label">Usage</span>
+      <span class="chat-controls__quota-label">${t("tabs.usage")}</span>
       <span class="chat-controls__quota-value">${primary.remaining}%</span>
     </a>
   `;

--- a/ui/src/ui/controllers/cron.test.ts
+++ b/ui/src/ui/controllers/cron.test.ts
@@ -176,9 +176,10 @@ describe("cron controller", () => {
       },
     });
 
-    await addCronJob(state);
+    const saved = await addCronJob(state);
 
     const addCall = findRequestCall(request.mock.calls, "cron.add");
+    expect(saved).toBe(true);
     const payload = requestPayload(addCall);
     expectRecordFields(payload, {
       name: "webhook job",
@@ -1138,7 +1139,8 @@ describe("cron controller", () => {
         payloadText: "",
       },
     });
-    await addCronJob(state);
+    const saved = await addCronJob(state);
+    expect(saved).toBe(false);
     expect(request).not.toHaveBeenCalled();
     expectRecordFields(state.cronFieldErrors, {
       name: "cron.errors.nameRequired",

--- a/ui/src/ui/controllers/cron.ts
+++ b/ui/src/ui/controllers/cron.ts
@@ -644,7 +644,8 @@ function buildFailureAlert(form: CronFormState, existingChannel?: string) {
   return patch;
 }
 
-export async function addCronJob(state: CronState) {
+export async function addCronJob(state: CronState): Promise<boolean> {
+  let saved = false;
   await withCronBusy(state, async (client) => {
     const form = normalizeCronFormState(state.cronForm);
     if (form !== state.cronForm) {
@@ -730,7 +731,9 @@ export async function addCronJob(state: CronState) {
     }
     await loadCronJobsPage(state);
     await loadCronStatus(state);
+    saved = true;
   });
+  return saved;
 }
 
 export async function toggleCronJob(state: CronState, job: CronJob, enabled: boolean) {

--- a/ui/src/ui/navigation-groups.test.ts
+++ b/ui/src/ui/navigation-groups.test.ts
@@ -1,19 +1,35 @@
 import { describe, expect, it } from "vitest";
-import { TAB_GROUPS, tabFromPath } from "./navigation.ts";
+import {
+  SETTINGS_TABS,
+  TAB_GROUPS,
+  isSettingsTab,
+  isTabInGroup,
+  tabFromPath,
+} from "./navigation.ts";
 
 describe("TAB_GROUPS", () => {
-  it("does not expose unfinished settings slices in the sidebar", () => {
+  it("collapses detailed settings slices into one sidebar entry", () => {
     const settings = TAB_GROUPS.find((group) => group.label === "settings");
-    expect(settings?.tabs).toEqual([
-      "config",
-      "communications",
-      "appearance",
-      "automation",
-      "infrastructure",
-      "aiAgents",
-      "debug",
-      "logs",
-    ]);
+    expect(settings?.tabs).toEqual(["config"]);
+    expect(SETTINGS_TABS.every((tab) => isSettingsTab(tab))).toBe(true);
+  });
+
+  it("keeps channel management out of the primary control sidebar", () => {
+    const control = TAB_GROUPS.find((group) => group.label === "control");
+    expect(control?.tabs).toEqual(["overview", "instances", "sessions", "usage", "cron"]);
+    expect(SETTINGS_TABS).toContain("channels");
+  });
+
+  it("keeps the settings group active for nested settings routes", () => {
+    const settings = TAB_GROUPS.find((group) => group.label === "settings");
+    if (!settings) {
+      throw new Error("Expected settings group");
+    }
+
+    expect(isTabInGroup(settings, "appearance")).toBe(true);
+    expect(isTabInGroup(settings, "channels")).toBe(true);
+    expect(isTabInGroup(settings, "debug")).toBe(true);
+    expect(isTabInGroup(settings, "chat")).toBe(false);
   });
 
   it("routes every published settings slice", () => {
@@ -23,5 +39,6 @@ describe("TAB_GROUPS", () => {
     expect(tabFromPath("/infrastructure")).toBe("infrastructure");
     expect(tabFromPath("/ai-agents")).toBe("aiAgents");
     expect(tabFromPath("/config")).toBe("config");
+    expect(tabFromPath("/channels")).toBe("channels");
   });
 });

--- a/ui/src/ui/navigation.browser.test.ts
+++ b/ui/src/ui/navigation.browser.test.ts
@@ -37,6 +37,20 @@ function expectButtonWithText(app: ReturnType<typeof mountApp>, text: string): H
   return button;
 }
 
+function createSessionsResult(sessions: Array<Record<string, unknown>>) {
+  return {
+    ts: 0,
+    path: "",
+    count: sessions.length,
+    defaults: { modelProvider: "openai", model: "gpt-5.5", contextTokens: null },
+    sessions: sessions.map((session) => ({
+      kind: "direct",
+      updatedAt: Date.now(),
+      ...session,
+    })),
+  };
+}
+
 async function confirmPendingGatewayChange(app: ReturnType<typeof mountApp>) {
   const confirmButton = expectButtonWithText(app, "Confirm");
   confirmButton.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
@@ -406,11 +420,11 @@ describe("control UI routing", () => {
     expect([...nav.classList]).toEqual(["shell-nav"]);
     expect(toggle.getAttribute("aria-expanded")).toBe("true");
 
-    const link = expectElement(app, 'a.nav-item[href="/channels"]', HTMLAnchorElement);
+    const link = expectElement(app, 'a.nav-item[href="/config"]', HTMLAnchorElement);
     link.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, button: 0 }));
 
     await app.updateComplete;
-    expect(app.tab).toBe("channels");
+    expect(app.tab).toBe("config");
     expect([...shell.classList]).toEqual(["shell"]);
 
     app.applySettings({ ...app.settings, navCollapsed: true });
@@ -431,6 +445,67 @@ describe("control UI routing", () => {
     expect(item.querySelector(".nav-item__text")).toBeNull();
     expect(app.querySelector(".sidebar-brand__copy")).toBeNull();
     expectElement(header, ".nav-collapse-toggle", HTMLElement);
+  });
+
+  it("shows recent sessions in the sidebar and switches through them", async () => {
+    const app = mountApp("/overview");
+    app.sessionKey = "agent:main:second";
+    app.sessionsResult = createSessionsResult([
+      { key: "agent:main:first", label: "First workspace", updatedAt: Date.now() - 5 * 60_000 },
+      { key: "agent:main:second", label: "Second workspace", updatedAt: Date.now() - 30_000 },
+    ]) as typeof app.sessionsResult;
+    await app.updateComplete;
+
+    const recent = Array.from(app.querySelectorAll<HTMLAnchorElement>(".sidebar-recent-session"));
+    expect(recent.map((entry) => entry.textContent?.replace(/\s+/g, " ").trim())).toEqual([
+      "Second workspace just now",
+      "First workspace 5m ago",
+    ]);
+
+    recent[1]?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    await app.updateComplete;
+
+    expect(app.tab).toBe("chat");
+    expect(app.sessionKey).toBe("agent:main:first");
+    expect(window.location.pathname).toBe("/chat");
+    expect(window.location.search).toBe("?session=agent%3Amain%3Afirst");
+  });
+
+  it("creates a new chat session from the sidebar", async () => {
+    const app = mountApp("/overview");
+    app.sessionKey = "agent:main:main";
+    app.sessionsResult = createSessionsResult([
+      { key: "agent:main:main", label: "Main Session" },
+    ]) as typeof app.sessionsResult;
+    app.client = {
+      stop: vi.fn(),
+      request: vi.fn(async (method: string) => {
+        if (method === "sessions.create") {
+          return { key: "agent:main:fresh" };
+        }
+        if (method === "sessions.list") {
+          return createSessionsResult([
+            { key: "agent:main:fresh", label: "Fresh session" },
+            { key: "agent:main:main", label: "Main Session" },
+          ]);
+        }
+        return null;
+      }),
+    } as unknown as typeof app.client;
+    await app.updateComplete;
+
+    expectButtonWithText(app, "New session").click();
+
+    await vi.waitFor(() => {
+      expect(app.sessionKey).toBe("agent:main:fresh");
+    });
+    expect(app.tab).toBe("chat");
+    expect(window.location.pathname).toBe("/chat");
+    expect(app.client?.request).toHaveBeenCalledWith("sessions.create", {
+      agentId: "main",
+      parentSessionKey: "agent:main:main",
+      emitCommandHooks: true,
+    });
   });
 
   it("closes mobile chat controls on Escape, outside pointerdown, and tab changes", async () => {
@@ -510,10 +585,7 @@ describe("control UI routing", () => {
     await app.updateComplete;
     expect([...shell.classList]).toEqual(["shell", "shell--chat", "shell--chat-focus"]);
 
-    const channelsLink = expectElement(app, 'a.nav-item[href="/channels"]', HTMLAnchorElement);
-    channelsLink.dispatchEvent(
-      new MouseEvent("click", { bubbles: true, cancelable: true, button: 0 }),
-    );
+    app.setTab("channels");
 
     await app.updateComplete;
     expect(app.tab).toBe("channels");

--- a/ui/src/ui/navigation.browser.test.ts
+++ b/ui/src/ui/navigation.browser.test.ts
@@ -451,6 +451,15 @@ describe("control UI routing", () => {
     const app = mountApp("/overview");
     app.sessionKey = "agent:main:second";
     app.sessionsResult = createSessionsResult([
+      { key: "global", kind: "global", label: "Global", updatedAt: Date.now() },
+      { key: "unknown", kind: "unknown", label: "Unknown", updatedAt: Date.now() - 10_000 },
+      { key: "cron:daily", kind: "cron", label: "Daily cron", updatedAt: Date.now() - 20_000 },
+      {
+        key: "agent:main:subagent:task",
+        label: "Subagent",
+        spawnedBy: "agent:main:second",
+        updatedAt: Date.now() - 25_000,
+      },
       { key: "agent:main:first", label: "First workspace", updatedAt: Date.now() - 5 * 60_000 },
       { key: "agent:main:second", label: "Second workspace", updatedAt: Date.now() - 30_000 },
     ]) as typeof app.sessionsResult;

--- a/ui/src/ui/navigation.test.ts
+++ b/ui/src/ui/navigation.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   TAB_GROUPS,
+  SETTINGS_TABS,
   iconForTab,
   inferBasePathFromPathname,
+  isSettingsTab,
   normalizeBasePath,
   normalizePath,
   pathForTab,
@@ -12,8 +14,10 @@ import {
   type Tab,
 } from "./navigation.ts";
 
-/** All valid tab identifiers derived from TAB_GROUPS */
-const ALL_TABS: Tab[] = TAB_GROUPS.flatMap((group) => group.tabs) as Tab[];
+/** All valid tab identifiers derived from visible groups plus routed settings slices. */
+const ALL_TABS: Tab[] = Array.from(
+  new Set<Tab>([...(TAB_GROUPS.flatMap((group) => group.tabs) as Tab[]), ...SETTINGS_TABS]),
+);
 
 const leadingSlashNormalizerCases = [
   { name: "normalizeBasePath", normalize: normalizeBasePath, input: "ui", expected: "/ui" },
@@ -66,7 +70,7 @@ describe("titleForTab", () => {
       skills: "Skills",
       nodes: "Nodes",
       dreams: "Dreaming",
-      config: "Config",
+      config: "Settings",
       communications: "Communications",
       appearance: "Appearance",
       automation: "Automation",
@@ -214,5 +218,22 @@ describe("TAB_GROUPS", () => {
     const allTabs = TAB_GROUPS.flatMap((g) => g.tabs);
     const uniqueTabs = new Set(allTabs);
     expect(uniqueTabs.size).toBe(allTabs.length);
+  });
+
+  it("keeps detailed settings slices routed but out of the root sidebar", () => {
+    const settings = TAB_GROUPS.find((group) => group.label === "settings");
+    expect(settings?.tabs).toEqual(["config"]);
+    expect(SETTINGS_TABS).toEqual([
+      "config",
+      "channels",
+      "communications",
+      "appearance",
+      "automation",
+      "infrastructure",
+      "aiAgents",
+      "debug",
+      "logs",
+    ]);
+    expect(SETTINGS_TABS.every((tab) => isSettingsTab(tab))).toBe(true);
   });
 });

--- a/ui/src/ui/navigation.ts
+++ b/ui/src/ui/navigation.ts
@@ -6,21 +6,12 @@ export const TAB_GROUPS = [
   { label: "chat", tabs: ["chat"] },
   {
     label: "control",
-    tabs: ["overview", "channels", "instances", "sessions", "usage", "cron"],
+    tabs: ["overview", "instances", "sessions", "usage", "cron"],
   },
   { label: "agent", tabs: ["agents", "skills", "nodes", "dreams"] },
   {
     label: "settings",
-    tabs: [
-      "config",
-      "communications",
-      "appearance",
-      "automation",
-      "infrastructure",
-      "aiAgents",
-      "debug",
-      "logs",
-    ],
+    tabs: ["config"],
   },
 ] as const;
 
@@ -44,6 +35,18 @@ export type Tab =
   | "debug"
   | "logs"
   | "dreams";
+
+export const SETTINGS_TABS = [
+  "config",
+  "channels",
+  "communications",
+  "appearance",
+  "automation",
+  "infrastructure",
+  "aiAgents",
+  "debug",
+  "logs",
+] as const satisfies readonly Tab[];
 
 const TAB_PATHS: Record<Tab, string> = {
   agents: "/agents",
@@ -111,6 +114,17 @@ export function pathForTab(tab: Tab, basePath = ""): string {
   const base = normalizeBasePath(basePath);
   const path = TAB_PATHS[tab];
   return base ? `${base}${path}` : path;
+}
+
+export function isSettingsTab(tab: Tab): boolean {
+  return (SETTINGS_TABS as readonly Tab[]).includes(tab);
+}
+
+export function isTabInGroup(group: (typeof TAB_GROUPS)[number], tab: Tab): boolean {
+  if (group.label === "settings") {
+    return isSettingsTab(tab);
+  }
+  return (group.tabs as readonly Tab[]).includes(tab);
 }
 
 export function tabFromPath(pathname: string, basePath = ""): Tab | null {
@@ -201,6 +215,9 @@ export function iconForTab(tab: Tab): IconName {
 }
 
 export function titleForTab(tab: Tab) {
+  if (tab === "config") {
+    return t("nav.settings");
+  }
   return t(`tabs.${tab}`);
 }
 

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -489,6 +489,14 @@ describe("chat loading skeleton", () => {
     expect(container.querySelector(".agent-chat__welcome")).toBeNull();
   });
 
+  it("shows the reading indicator instead of the skeleton while an active run has no stream yet", () => {
+    const container = renderChatView({ canAbort: true, loading: true });
+
+    expect(container.querySelector(".chat-loading-skeleton")).toBeNull();
+    expect(container.querySelectorAll(".chat-reading-indicator")).toHaveLength(1);
+    expect(container.querySelector(".agent-chat__welcome")).toBeNull();
+  });
+
   it("keeps existing messages visible without the skeleton during a background reload", () => {
     const container = renderChatView({
       loading: true,

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1003,6 +1003,7 @@ export function renderChat(props: ChatProps) {
   const requestUpdate = props.onRequestUpdate ?? (() => {});
   const splitRatio = props.splitRatio ?? 0.6;
   const sidebarOpen = Boolean(props.sidebarOpen && props.onCloseSidebar);
+  const displayStream = props.stream ?? (canAbort ? "" : null);
 
   const handleCodeBlockCopy = (e: Event) => {
     const btn = (e.target as HTMLElement).closest(".code-block-copy");
@@ -1024,7 +1025,7 @@ export function renderChat(props: ChatProps) {
     messages: props.messages,
     toolMessages: props.toolMessages,
     streamSegments: props.streamSegments,
-    stream: props.stream,
+    stream: displayStream,
     streamStartedAt: props.streamStartedAt,
     showToolCalls: props.showToolCalls,
     searchOpen: vs.searchOpen,

--- a/ui/src/ui/views/config-quick.ts
+++ b/ui/src/ui/views/config-quick.ts
@@ -1078,7 +1078,7 @@ export function renderQuickSettings(props: QuickSettingsProps) {
   return html`
     <div class="qs-container">
       <div class="qs-header">
-        <h2 class="qs-header__title">${icons.settings} Settings</h2>
+        <h2 class="qs-header__title">${icons.settings} Quick Settings</h2>
         <button class="btn btn--sm" @click=${props.onAdvancedSettings}>
           Advanced ${icons.chevronRight}
         </button>

--- a/ui/src/ui/views/config.browser.test.ts
+++ b/ui/src/ui/views/config.browser.test.ts
@@ -401,6 +401,27 @@ describe("config view", () => {
     expect(content.scrollLeft).toBe(0);
   });
 
+  it("can hide the root tab for scoped settings surfaces", () => {
+    const { container } = renderConfigView({
+      activeSection: "channels",
+      navRootLabel: "Communication",
+      showRootTab: false,
+      includeSections: ["channels", "messages"],
+      schema: {
+        type: "object",
+        properties: {
+          channels: { type: "object", properties: {} },
+          messages: { type: "object", properties: {} },
+        },
+      },
+    });
+
+    const tabs = Array.from(container.querySelectorAll(".config-top-tabs__tab")).map((tab) =>
+      tab.textContent?.trim(),
+    );
+    expect(tabs).toEqual(["Channels", "Messages"]);
+  });
+
   it("does not normalize off-scope schema sections for scoped config tabs", () => {
     const offScopeSchema = { type: "object" } as Record<string, unknown>;
     Object.defineProperty(offScopeSchema, "properties", {

--- a/ui/src/ui/views/config.ts
+++ b/ui/src/ui/views/config.ts
@@ -104,6 +104,7 @@ export type ConfigProps = {
   assistantName: string;
   configPath?: string | null;
   navRootLabel?: string;
+  showRootTab?: boolean;
   includeSections?: string[];
   excludeSections?: string[];
   includeVirtualSections?: boolean;
@@ -1191,6 +1192,7 @@ export function resetConfigViewStateForTests() {
 
 export function renderConfig(props: ConfigProps) {
   const showModeToggle = props.showModeToggle ?? false;
+  const showRootTab = props.showRootTab ?? true;
   const validity = props.valid == null ? "unknown" : props.valid ? "valid" : "invalid";
   const includeVirtualSections = props.includeVirtualSections ?? true;
   const include = props.includeSections?.length ? new Set(props.includeSections) : null;
@@ -1250,7 +1252,9 @@ export function renderConfig(props: ConfigProps) {
   const effectiveSubsection = null;
 
   const topTabs = [
-    { key: null as string | null, label: props.navRootLabel ?? "Settings" },
+    ...(showRootTab
+      ? [{ key: null as string | null, label: props.navRootLabel ?? "Settings" }]
+      : []),
     ...[...visibleCategories, ...(otherCategory ? [otherCategory] : [])].flatMap((cat) =>
       cat.sections.map((s) => ({ key: s.key, label: s.label })),
     ),

--- a/ui/src/ui/views/cron-quick-create.ts
+++ b/ui/src/ui/views/cron-quick-create.ts
@@ -21,6 +21,7 @@ export type CronQuickCreateProps = {
   onStepChange: (step: CronQuickCreateStep) => void;
   onCreate: () => void;
   onCancel: () => void;
+  onAdvancedCreate?: () => void;
 };
 
 export type CronQuickCreateStep = "what" | "when" | "how";
@@ -233,6 +234,17 @@ function renderStepIndicator(current: CronQuickCreateStep) {
 
 // ── Step renderers ──
 
+function renderAdvancedButton(props: CronQuickCreateProps) {
+  if (!props.onAdvancedCreate) {
+    return nothing;
+  }
+  return html`
+    <button class="btn cqc-advanced-button" @click=${props.onAdvancedCreate}>
+      ${t("cron.form.advanced")}
+    </button>
+  `;
+}
+
 function renderWhatStep(props: CronQuickCreateProps) {
   return html`
     <div class="cqc-body">
@@ -259,7 +271,10 @@ function renderWhatStep(props: CronQuickCreateProps) {
       </div>
     </div>
     <div class="cqc-actions">
-      <button class="btn" @click=${props.onCancel}>${t("common.cancel")}</button>
+      <div class="cqc-actions__secondary">
+        <button class="btn" @click=${props.onCancel}>${t("common.cancel")}</button>
+        ${renderAdvancedButton(props)}
+      </div>
       <button
         class="btn primary"
         ?disabled=${!props.draft.prompt.trim()}
@@ -294,7 +309,10 @@ function renderWhenStep(props: CronQuickCreateProps) {
       </div>
     </div>
     <div class="cqc-actions">
-      <button class="btn" @click=${() => props.onStepChange("what")}>${t("common.back")}</button>
+      <div class="cqc-actions__secondary">
+        <button class="btn" @click=${() => props.onStepChange("what")}>${t("common.back")}</button>
+        ${renderAdvancedButton(props)}
+      </div>
       <button class="btn primary" @click=${() => props.onStepChange("how")}>
         ${t("common.next")} ${icons.chevronRight}
       </button>
@@ -329,7 +347,10 @@ function renderHowStep(props: CronQuickCreateProps) {
       </div>
     </div>
     <div class="cqc-actions">
-      <button class="btn" @click=${() => props.onStepChange("when")}>${t("common.back")}</button>
+      <div class="cqc-actions__secondary">
+        <button class="btn" @click=${() => props.onStepChange("when")}>${t("common.back")}</button>
+        ${renderAdvancedButton(props)}
+      </div>
       <button class="btn primary" @click=${props.onCreate}>
         ${t("common.create")} ${icons.check}
       </button>

--- a/ui/src/ui/views/cron-quick-create.ts
+++ b/ui/src/ui/views/cron-quick-create.ts
@@ -345,18 +345,35 @@ export function renderCronQuickCreate(props: CronQuickCreateProps) {
   }
 
   return html`
-    <div class="cqc-container">
-      <div class="cqc-header">
-        <h2 class="cqc-header__title">${icons.zap} ${t("cron.quickCreate.title")}</h2>
-        <button class="cqc-header__close" @click=${props.onCancel}>${icons.x}</button>
-      </div>
+    <div class="cqc-backdrop" @click=${props.onCancel}>
+      <section
+        class="cqc-container"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="cron-quick-create-title"
+        @click=${(event: Event) => event.stopPropagation()}
+      >
+        <div class="cqc-header">
+          <h2 id="cron-quick-create-title" class="cqc-header__title">
+            ${icons.zap} ${t("cron.quickCreate.title")}
+          </h2>
+          <button
+            type="button"
+            class="cqc-header__close"
+            aria-label=${t("common.dismiss")}
+            @click=${props.onCancel}
+          >
+            ${icons.x}
+          </button>
+        </div>
 
-      ${renderStepIndicator(props.step)}
-      ${props.step === "what"
-        ? renderWhatStep(props)
-        : props.step === "when"
-          ? renderWhenStep(props)
-          : renderHowStep(props)}
+        ${renderStepIndicator(props.step)}
+        ${props.step === "what"
+          ? renderWhatStep(props)
+          : props.step === "when"
+            ? renderWhenStep(props)
+            : renderHowStep(props)}
+      </section>
     </div>
   `;
 }

--- a/ui/src/ui/views/cron.test.ts
+++ b/ui/src/ui/views/cron.test.ts
@@ -2,6 +2,7 @@ import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
 import { DEFAULT_CRON_FORM } from "../app-defaults.ts";
 import type { CronJob } from "../types.ts";
+import { createDefaultDraft, renderCronQuickCreate } from "./cron-quick-create.ts";
 import { renderCron, type CronProps } from "./cron.ts";
 
 function createJob(id: string): CronJob {
@@ -353,18 +354,42 @@ describe("cron view", () => {
     expect(container.querySelector('input[placeholder="https://example.com/cron"]')).toBeNull();
   });
 
-  it("keeps the advanced job form hidden until explicitly opened", () => {
+  it("keeps the full job form behind the New Job dialog advanced action", () => {
     const container = document.createElement("div");
+    const onQuickCreate = vi.fn();
     const onToggleFormCollapsed = vi.fn();
 
-    render(renderCron(createProps({ onToggleFormCollapsed })), container);
+    render(renderCron(createProps({ onQuickCreate, onToggleFormCollapsed })), container);
 
     expect(container.querySelector(".cron-form-modal")).toBeNull();
     expect(container.querySelector(".cron-form")).toBeNull();
+    expect(
+      Array.from(container.querySelectorAll("button")).map((button) => button.textContent?.trim()),
+    ).not.toContain("Advanced job");
 
-    const advancedButton = getButtonByText(container, "Advanced job");
-    advancedButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    expect(onToggleFormCollapsed).toHaveBeenCalledWith(false);
+    const newJobButton = getButtonByText(container, "New Job");
+    newJobButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(onQuickCreate).toHaveBeenCalledTimes(1);
+    expect(onToggleFormCollapsed).not.toHaveBeenCalled();
+
+    const onAdvancedCreate = vi.fn();
+    render(
+      renderCronQuickCreate({
+        open: true,
+        step: "what",
+        draft: createDefaultDraft(),
+        onDraftChange: () => undefined,
+        onStepChange: () => undefined,
+        onCreate: () => undefined,
+        onCancel: () => undefined,
+        onAdvancedCreate,
+      }),
+      container,
+    );
+    getButtonByText(container, "Advanced").dispatchEvent(
+      new MouseEvent("click", { bubbles: true }),
+    );
+    expect(onAdvancedCreate).toHaveBeenCalledTimes(1);
 
     const onCancelEdit = vi.fn();
     render(renderCron(createProps({ cronFormCollapsed: false, onCancelEdit })), container);

--- a/ui/src/ui/views/cron.test.ts
+++ b/ui/src/ui/views/cron.test.ts
@@ -306,6 +306,7 @@ describe("cron view", () => {
     render(
       renderCron(
         createProps({
+          cronFormCollapsed: false,
           form: { ...DEFAULT_CRON_FORM, payloadKind: "agentTurn" },
         }),
       ),
@@ -327,6 +328,7 @@ describe("cron view", () => {
     render(
       renderCron(
         createProps({
+          cronFormCollapsed: false,
           form: {
             ...DEFAULT_CRON_FORM,
             sessionTarget: "main",
@@ -351,50 +353,32 @@ describe("cron view", () => {
     expect(container.querySelector('input[placeholder="https://example.com/cron"]')).toBeNull();
   });
 
-  it("collapses the new job sidebar without rendering the full form", () => {
+  it("keeps the advanced job form hidden until explicitly opened", () => {
     const container = document.createElement("div");
     const onToggleFormCollapsed = vi.fn();
-    const expandedProps = createProps() as CronProps & {
-      cronFormCollapsed: boolean;
-      onToggleFormCollapsed: (collapsed: boolean) => void;
-    };
-    expandedProps.cronFormCollapsed = false;
-    expandedProps.onToggleFormCollapsed = onToggleFormCollapsed;
 
-    render(renderCron(expandedProps), container);
+    render(renderCron(createProps({ onToggleFormCollapsed })), container);
 
-    const collapseButton = getElement(
+    expect(container.querySelector(".cron-form-modal")).toBeNull();
+    expect(container.querySelector(".cron-form")).toBeNull();
+
+    const advancedButton = getButtonByText(container, "Advanced job");
+    advancedButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(onToggleFormCollapsed).toHaveBeenCalledWith(false);
+
+    const onCancelEdit = vi.fn();
+    render(renderCron(createProps({ cronFormCollapsed: false, onCancelEdit })), container);
+
+    const closeButton = getElement(
       container,
-      '[data-test-id="cron-form-collapse-toggle"]',
+      '[data-test-id="cron-form-close"]',
       HTMLButtonElement,
     );
-    expect(collapseButton.getAttribute("aria-expanded")).toBe("true");
-    collapseButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    expect(onToggleFormCollapsed).toHaveBeenCalledWith(true);
-    getElement(container, ".cron-form", HTMLElement);
+    expect(container.querySelectorAll(".cron-form-modal")).toHaveLength(1);
+    expect(container.querySelectorAll(".cron-form")).toHaveLength(1);
 
-    const collapsedProps = createProps() as CronProps & {
-      cronFormCollapsed: boolean;
-      onToggleFormCollapsed: (collapsed: boolean) => void;
-    };
-    collapsedProps.cronFormCollapsed = true;
-    collapsedProps.onToggleFormCollapsed = onToggleFormCollapsed;
-
-    render(renderCron(collapsedProps), container);
-
-    const collapsedButton = getElement(
-      container,
-      '[data-test-id="cron-form-collapse-toggle"]',
-      HTMLButtonElement,
-    );
-    expect(container.querySelectorAll(".cron-workspace--form-collapsed")).toHaveLength(1);
-    expect(container.querySelectorAll(".cron-workspace-form--collapsed")).toHaveLength(1);
-    expect(collapsedButton.getAttribute("aria-expanded")).toBe("false");
-    expect(container.querySelector(".cron-form")?.hasAttribute("hidden")).toBe(true);
-    expect(container.querySelector(".cron-form-actions")?.hasAttribute("hidden")).toBe(true);
-
-    collapsedButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    expect(onToggleFormCollapsed).toHaveBeenLastCalledWith(false);
+    closeButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(onCancelEdit).toHaveBeenCalledTimes(1);
   });
 
   it("shows webhook delivery details for jobs", () => {
@@ -583,6 +567,7 @@ describe("cron view", () => {
     render(
       renderCron(
         createProps({
+          cronFormCollapsed: false,
           form: {
             ...DEFAULT_CRON_FORM,
             scheduleKind: "cron",
@@ -655,6 +640,7 @@ describe("cron view", () => {
     render(
       renderCron(
         createProps({
+          cronFormCollapsed: false,
           form: {
             ...DEFAULT_CRON_FORM,
             clearAgent: true,
@@ -671,6 +657,7 @@ describe("cron view", () => {
     render(
       renderCron(
         createProps({
+          cronFormCollapsed: false,
           form: {
             ...DEFAULT_CRON_FORM,
             scheduleKind: "every",
@@ -697,6 +684,7 @@ describe("cron view", () => {
     render(
       renderCron(
         createProps({
+          cronFormCollapsed: false,
           form: {
             ...DEFAULT_CRON_FORM,
             name: "",
@@ -751,6 +739,7 @@ describe("cron view", () => {
     render(
       renderCron(
         createProps({
+          cronFormCollapsed: false,
           form: {
             ...DEFAULT_CRON_FORM,
             scheduleKind: "every",
@@ -843,6 +832,7 @@ describe("cron view", () => {
     render(
       renderCron(
         createProps({
+          cronFormCollapsed: false,
           form: { ...DEFAULT_CRON_FORM, scheduleKind: "cron", payloadKind: "agentTurn" },
           agentSuggestions: ["main"],
           modelSuggestions: ["openai/gpt-5.2"],

--- a/ui/src/ui/views/cron.ts
+++ b/ui/src/ui/views/cron.ts
@@ -390,6 +390,11 @@ export function renderCron(props: CronProps) {
   const formTitle = isEditing ? t("cron.form.editJob") : t("cron.form.newJob");
   const blockingFields = collectBlockingFields(props.fieldErrors, props.form, selectedDeliveryMode);
   const blockedByValidation = !props.busy && blockingFields.length > 0;
+  const openNewJob = props.onQuickCreate
+    ? props.onQuickCreate
+    : props.onToggleFormCollapsed
+      ? () => props.onToggleFormCollapsed?.(false)
+      : null;
   const hasActiveJobsFilters =
     props.jobsQuery.trim().length > 0 ||
     props.jobsEnabledFilter !== "all" ||
@@ -434,17 +439,10 @@ export function renderCron(props: CronProps) {
         </div>
       </div>
       <div class="cron-summary-strip__actions">
-        ${props.onQuickCreate
+        ${openNewJob
           ? html`
-              <button class="btn btn--primary" @click=${props.onQuickCreate}>
+              <button class="btn btn--primary" @click=${openNewJob}>
                 ${t("cron.form.newJob")}
-              </button>
-            `
-          : nothing}
-        ${props.onToggleFormCollapsed
-          ? html`
-              <button class="btn" @click=${() => props.onToggleFormCollapsed?.(false)}>
-                ${t("cron.form.advancedJob")}
               </button>
             `
           : nothing}
@@ -596,9 +594,9 @@ export function renderCron(props: CronProps) {
                       ? t("cron.jobs.emptyFilteredHint")
                       : t("cron.jobs.emptyHint")}
                   </div>
-                  ${props.onQuickCreate && !hasActiveJobsFilters
+                  ${openNewJob && !hasActiveJobsFilters
                     ? html`
-                        <button class="btn btn--primary" @click=${props.onQuickCreate}>
+                        <button class="btn btn--primary" @click=${openNewJob}>
                           ${t("cron.form.newJob")}
                         </button>
                       `

--- a/ui/src/ui/views/cron.ts
+++ b/ui/src/ui/views/cron.ts
@@ -385,9 +385,9 @@ export function renderCron(props: CronProps) {
     props.form.sessionTarget !== "main" && props.form.payloadKind === "agentTurn";
   const selectedDeliveryMode =
     props.form.deliveryMode === "announce" && !supportsAnnounce ? "none" : props.form.deliveryMode;
-  const formCollapsed = props.cronFormCollapsed === true;
+  const formOpen = props.cronFormCollapsed === false || isEditing;
+  const formCollapsed = !formOpen;
   const formTitle = isEditing ? t("cron.form.editJob") : t("cron.form.newJob");
-  const toggleFormCollapsed = props.onToggleFormCollapsed;
   const blockingFields = collectBlockingFields(props.fieldErrors, props.form, selectedDeliveryMode);
   const blockedByValidation = !props.busy && blockingFields.length > 0;
   const hasActiveJobsFilters =
@@ -397,6 +397,12 @@ export function renderCron(props: CronProps) {
     props.jobsLastStatusFilter !== "all" ||
     props.jobsSortBy !== "nextRunAtMs" ||
     props.jobsSortDir !== "asc";
+  const hasActiveRunsFilters =
+    props.runsScope !== "all" ||
+    props.runsQuery.trim().length > 0 ||
+    props.runsStatuses.length > 0 ||
+    props.runsDeliveryStatuses.length > 0 ||
+    props.runsSortDir !== "desc";
   const submitDisabledReason =
     blockedByValidation && !props.canSubmit
       ? blockingFields.length === 1
@@ -429,7 +435,18 @@ export function renderCron(props: CronProps) {
       </div>
       <div class="cron-summary-strip__actions">
         ${props.onQuickCreate
-          ? html` <button class="btn btn--primary" @click=${props.onQuickCreate}>+ New</button> `
+          ? html`
+              <button class="btn btn--primary" @click=${props.onQuickCreate}>
+                ${t("cron.form.newJob")}
+              </button>
+            `
+          : nothing}
+        ${props.onToggleFormCollapsed
+          ? html`
+              <button class="btn" @click=${() => props.onToggleFormCollapsed?.(false)}>
+                ${t("cron.form.advancedJob")}
+              </button>
+            `
           : nothing}
         <button
           class=${props.loading ? "btn cron-refresh-btn--loading" : "btn"}
@@ -460,108 +477,134 @@ export function renderCron(props: CronProps) {
               })}
             </div>
           </div>
-          <div class="filters" style="margin-top: 12px;">
-            <label class="field cron-filter-search">
-              <span>${t("cron.jobs.searchJobs")}</span>
-              <input
-                .value=${props.jobsQuery}
-                placeholder=${t("cron.jobs.searchPlaceholder")}
-                @input=${(e: Event) =>
-                  props.onJobsFiltersChange({
-                    cronJobsQuery: (e.target as HTMLInputElement).value,
-                  })}
-              />
-            </label>
-            <label class="field">
-              <span>${t("cron.jobs.enabled")}</span>
-              <select
-                .value=${props.jobsEnabledFilter}
-                @change=${(e: Event) =>
-                  props.onJobsFiltersChange({
-                    cronJobsEnabledFilter: (e.target as HTMLSelectElement)
-                      .value as CronJobsEnabledFilter,
-                  })}
-              >
-                <option value="all">${t("cron.jobs.all")}</option>
-                <option value="enabled">${t("common.enabled")}</option>
-                <option value="disabled">${t("common.disabled")}</option>
-              </select>
-            </label>
-            <label class="field">
-              <span>${t("cron.jobs.schedule")}</span>
-              <select
-                data-test-id="cron-jobs-schedule-filter"
-                .value=${props.jobsScheduleKindFilter}
-                @change=${(e: Event) =>
-                  props.onJobsFiltersChange({
-                    cronJobsScheduleKindFilter: (e.target as HTMLSelectElement)
-                      .value as CronJobsScheduleKindFilter,
-                  })}
-              >
-                <option value="all">${t("cron.jobs.all")}</option>
-                <option value="at">${t("cron.form.at")}</option>
-                <option value="every">${t("cron.form.every")}</option>
-                <option value="cron">${t("cron.form.cronOption")}</option>
-              </select>
-            </label>
-            <label class="field">
-              <span>${t("cron.jobs.lastRun")}</span>
-              <select
-                data-test-id="cron-jobs-last-status-filter"
-                .value=${props.jobsLastStatusFilter}
-                @change=${(e: Event) =>
-                  props.onJobsFiltersChange({
-                    cronJobsLastStatusFilter: (e.target as HTMLSelectElement)
-                      .value as CronJobsLastStatusFilter,
-                  })}
-              >
-                <option value="all">${t("cron.jobs.all")}</option>
-                <option value="ok">${t("cron.runs.runStatusOk")}</option>
-                <option value="error">${t("cron.runs.runStatusError")}</option>
-                <option value="skipped">${t("cron.runs.runStatusSkipped")}</option>
-              </select>
-            </label>
-            <label class="field">
-              <span>${t("cron.jobs.sort")}</span>
-              <select
-                .value=${props.jobsSortBy}
-                @change=${(e: Event) =>
-                  props.onJobsFiltersChange({
-                    cronJobsSortBy: (e.target as HTMLSelectElement).value as CronJobsSortBy,
-                  })}
-              >
-                <option value="nextRunAtMs">${t("cron.jobs.nextRun")}</option>
-                <option value="updatedAtMs">${t("cron.jobs.recentlyUpdated")}</option>
-                <option value="name">${t("cron.jobs.name")}</option>
-              </select>
-            </label>
-            <label class="field">
-              <span>${t("cron.jobs.direction")}</span>
-              <select
-                .value=${props.jobsSortDir}
-                @change=${(e: Event) =>
-                  props.onJobsFiltersChange({
-                    cronJobsSortDir: (e.target as HTMLSelectElement).value as CronSortDir,
-                  })}
-              >
-                <option value="asc">${t("cron.jobs.ascending")}</option>
-                <option value="desc">${t("cron.jobs.descending")}</option>
-              </select>
-            </label>
-            <label class="field">
-              <span>${t("cron.jobs.reset")}</span>
-              <button
-                class="btn"
-                data-test-id="cron-jobs-filters-reset"
-                ?disabled=${!hasActiveJobsFilters}
-                @click=${props.onJobsFiltersReset}
-              >
-                ${t("cron.jobs.reset")}
-              </button>
-            </label>
-          </div>
+          <details class="cron-filter-panel" ?open=${hasActiveJobsFilters}>
+            <summary class="cron-filter-panel__summary">
+              <span>${t("sessionsView.filters")}</span>
+              ${hasActiveJobsFilters
+                ? html`<span class="chip">${t("common.active")}</span>`
+                : nothing}
+            </summary>
+            <div class="filters cron-filter-panel__body">
+              <label class="field cron-filter-search">
+                <span>${t("cron.jobs.searchJobs")}</span>
+                <input
+                  .value=${props.jobsQuery}
+                  placeholder=${t("cron.jobs.searchPlaceholder")}
+                  @input=${(e: Event) =>
+                    props.onJobsFiltersChange({
+                      cronJobsQuery: (e.target as HTMLInputElement).value,
+                    })}
+                />
+              </label>
+              <label class="field">
+                <span>${t("cron.jobs.enabled")}</span>
+                <select
+                  .value=${props.jobsEnabledFilter}
+                  @change=${(e: Event) =>
+                    props.onJobsFiltersChange({
+                      cronJobsEnabledFilter: (e.target as HTMLSelectElement)
+                        .value as CronJobsEnabledFilter,
+                    })}
+                >
+                  <option value="all">${t("cron.jobs.all")}</option>
+                  <option value="enabled">${t("common.enabled")}</option>
+                  <option value="disabled">${t("common.disabled")}</option>
+                </select>
+              </label>
+              <label class="field">
+                <span>${t("cron.jobs.schedule")}</span>
+                <select
+                  data-test-id="cron-jobs-schedule-filter"
+                  .value=${props.jobsScheduleKindFilter}
+                  @change=${(e: Event) =>
+                    props.onJobsFiltersChange({
+                      cronJobsScheduleKindFilter: (e.target as HTMLSelectElement)
+                        .value as CronJobsScheduleKindFilter,
+                    })}
+                >
+                  <option value="all">${t("cron.jobs.all")}</option>
+                  <option value="at">${t("cron.form.at")}</option>
+                  <option value="every">${t("cron.form.every")}</option>
+                  <option value="cron">${t("cron.form.cronOption")}</option>
+                </select>
+              </label>
+              <label class="field">
+                <span>${t("cron.jobs.lastRun")}</span>
+                <select
+                  data-test-id="cron-jobs-last-status-filter"
+                  .value=${props.jobsLastStatusFilter}
+                  @change=${(e: Event) =>
+                    props.onJobsFiltersChange({
+                      cronJobsLastStatusFilter: (e.target as HTMLSelectElement)
+                        .value as CronJobsLastStatusFilter,
+                    })}
+                >
+                  <option value="all">${t("cron.jobs.all")}</option>
+                  <option value="ok">${t("cron.runs.runStatusOk")}</option>
+                  <option value="error">${t("cron.runs.runStatusError")}</option>
+                  <option value="skipped">${t("cron.runs.runStatusSkipped")}</option>
+                </select>
+              </label>
+              <label class="field">
+                <span>${t("cron.jobs.sort")}</span>
+                <select
+                  .value=${props.jobsSortBy}
+                  @change=${(e: Event) =>
+                    props.onJobsFiltersChange({
+                      cronJobsSortBy: (e.target as HTMLSelectElement).value as CronJobsSortBy,
+                    })}
+                >
+                  <option value="nextRunAtMs">${t("cron.jobs.nextRun")}</option>
+                  <option value="updatedAtMs">${t("cron.jobs.recentlyUpdated")}</option>
+                  <option value="name">${t("cron.jobs.name")}</option>
+                </select>
+              </label>
+              <label class="field">
+                <span>${t("cron.jobs.direction")}</span>
+                <select
+                  .value=${props.jobsSortDir}
+                  @change=${(e: Event) =>
+                    props.onJobsFiltersChange({
+                      cronJobsSortDir: (e.target as HTMLSelectElement).value as CronSortDir,
+                    })}
+                >
+                  <option value="asc">${t("cron.jobs.ascending")}</option>
+                  <option value="desc">${t("cron.jobs.descending")}</option>
+                </select>
+              </label>
+              <label class="field">
+                <span>${t("cron.jobs.reset")}</span>
+                <button
+                  class="btn"
+                  data-test-id="cron-jobs-filters-reset"
+                  ?disabled=${!hasActiveJobsFilters}
+                  @click=${props.onJobsFiltersReset}
+                >
+                  ${t("cron.jobs.reset")}
+                </button>
+              </label>
+            </div>
+          </details>
           ${props.jobs.length === 0
-            ? html` <div class="muted" style="margin-top: 12px">${t("cron.jobs.noMatching")}</div> `
+            ? html`
+                <div class="cron-empty-state">
+                  <div class="cron-empty-state__title">
+                    ${hasActiveJobsFilters ? t("cron.jobs.noMatching") : t("cron.jobs.emptyTitle")}
+                  </div>
+                  <div class="cron-empty-state__copy">
+                    ${hasActiveJobsFilters
+                      ? t("cron.jobs.emptyFilteredHint")
+                      : t("cron.jobs.emptyHint")}
+                  </div>
+                  ${props.onQuickCreate && !hasActiveJobsFilters
+                    ? html`
+                        <button class="btn btn--primary" @click=${props.onQuickCreate}>
+                          ${t("cron.form.newJob")}
+                        </button>
+                      `
+                    : nothing}
+                </div>
+              `
             : html`
                 <div class="list" style="margin-top: 12px;">
                   ${props.jobs.map((job) => renderJob(job, props))}
@@ -602,87 +645,95 @@ export function renderCron(props: CronProps) {
               })}
             </div>
           </div>
-          <div class="cron-run-filters">
-            <div class="cron-run-filters__row cron-run-filters__row--primary">
-              <label class="field">
-                <span>${t("cron.runs.scope")}</span>
-                <select
-                  .value=${props.runsScope}
-                  @change=${(e: Event) =>
-                    props.onRunsFiltersChange({
-                      cronRunsScope: (e.target as HTMLSelectElement).value as CronRunScope,
-                    })}
-                >
-                  <option value="all">${t("cron.runs.allJobs")}</option>
-                  <option value="job" ?disabled=${props.runsJobId == null}>
-                    ${t("cron.runs.selectedJob")}
-                  </option>
-                </select>
-              </label>
-              <label class="field cron-run-filter-search">
-                <span>${t("cron.runs.searchRuns")}</span>
-                <input
-                  .value=${props.runsQuery}
-                  placeholder=${t("cron.runs.searchPlaceholder")}
-                  @input=${(e: Event) =>
-                    props.onRunsFiltersChange({
-                      cronRunsQuery: (e.target as HTMLInputElement).value,
-                    })}
-                />
-              </label>
-              <label class="field">
-                <span>${t("cron.jobs.sort")}</span>
-                <select
-                  .value=${props.runsSortDir}
-                  @change=${(e: Event) =>
-                    props.onRunsFiltersChange({
-                      cronRunsSortDir: (e.target as HTMLSelectElement).value as CronSortDir,
-                    })}
-                >
-                  <option value="desc">${t("cron.runs.newestFirst")}</option>
-                  <option value="asc">${t("cron.runs.oldestFirst")}</option>
-                </select>
-              </label>
+          <details class="cron-filter-panel" ?open=${hasActiveRunsFilters}>
+            <summary class="cron-filter-panel__summary">
+              <span>${t("sessionsView.filters")}</span>
+              ${hasActiveRunsFilters
+                ? html`<span class="chip">${t("common.active")}</span>`
+                : nothing}
+            </summary>
+            <div class="cron-run-filters">
+              <div class="cron-run-filters__row cron-run-filters__row--primary">
+                <label class="field">
+                  <span>${t("cron.runs.scope")}</span>
+                  <select
+                    .value=${props.runsScope}
+                    @change=${(e: Event) =>
+                      props.onRunsFiltersChange({
+                        cronRunsScope: (e.target as HTMLSelectElement).value as CronRunScope,
+                      })}
+                  >
+                    <option value="all">${t("cron.runs.allJobs")}</option>
+                    <option value="job" ?disabled=${props.runsJobId == null}>
+                      ${t("cron.runs.selectedJob")}
+                    </option>
+                  </select>
+                </label>
+                <label class="field cron-run-filter-search">
+                  <span>${t("cron.runs.searchRuns")}</span>
+                  <input
+                    .value=${props.runsQuery}
+                    placeholder=${t("cron.runs.searchPlaceholder")}
+                    @input=${(e: Event) =>
+                      props.onRunsFiltersChange({
+                        cronRunsQuery: (e.target as HTMLInputElement).value,
+                      })}
+                  />
+                </label>
+                <label class="field">
+                  <span>${t("cron.jobs.sort")}</span>
+                  <select
+                    .value=${props.runsSortDir}
+                    @change=${(e: Event) =>
+                      props.onRunsFiltersChange({
+                        cronRunsSortDir: (e.target as HTMLSelectElement).value as CronSortDir,
+                      })}
+                  >
+                    <option value="desc">${t("cron.runs.newestFirst")}</option>
+                    <option value="asc">${t("cron.runs.oldestFirst")}</option>
+                  </select>
+                </label>
+              </div>
+              <div class="cron-run-filters__row cron-run-filters__row--secondary">
+                ${renderRunFilterDropdown({
+                  id: "status",
+                  title: t("cron.runs.status"),
+                  summary: statusSummary,
+                  options: runStatusOptions,
+                  selected: props.runsStatuses,
+                  onToggle: (value, checked) => {
+                    const next = toggleSelection(
+                      props.runsStatuses,
+                      value as CronRunsStatusValue,
+                      checked,
+                    );
+                    void props.onRunsFiltersChange({ cronRunsStatuses: next });
+                  },
+                  onClear: () => {
+                    void props.onRunsFiltersChange({ cronRunsStatuses: [] });
+                  },
+                })}
+                ${renderRunFilterDropdown({
+                  id: "delivery",
+                  title: t("cron.runs.delivery"),
+                  summary: deliverySummary,
+                  options: runDeliveryOptions,
+                  selected: props.runsDeliveryStatuses,
+                  onToggle: (value, checked) => {
+                    const next = toggleSelection(
+                      props.runsDeliveryStatuses,
+                      value as CronDeliveryStatus,
+                      checked,
+                    );
+                    void props.onRunsFiltersChange({ cronRunsDeliveryStatuses: next });
+                  },
+                  onClear: () => {
+                    void props.onRunsFiltersChange({ cronRunsDeliveryStatuses: [] });
+                  },
+                })}
+              </div>
             </div>
-            <div class="cron-run-filters__row cron-run-filters__row--secondary">
-              ${renderRunFilterDropdown({
-                id: "status",
-                title: t("cron.runs.status"),
-                summary: statusSummary,
-                options: runStatusOptions,
-                selected: props.runsStatuses,
-                onToggle: (value, checked) => {
-                  const next = toggleSelection(
-                    props.runsStatuses,
-                    value as CronRunsStatusValue,
-                    checked,
-                  );
-                  void props.onRunsFiltersChange({ cronRunsStatuses: next });
-                },
-                onClear: () => {
-                  void props.onRunsFiltersChange({ cronRunsStatuses: [] });
-                },
-              })}
-              ${renderRunFilterDropdown({
-                id: "delivery",
-                title: t("cron.runs.delivery"),
-                summary: deliverySummary,
-                options: runDeliveryOptions,
-                selected: props.runsDeliveryStatuses,
-                onToggle: (value, checked) => {
-                  const next = toggleSelection(
-                    props.runsDeliveryStatuses,
-                    value as CronDeliveryStatus,
-                    checked,
-                  );
-                  void props.onRunsFiltersChange({ cronRunsDeliveryStatuses: next });
-                },
-                onClear: () => {
-                  void props.onRunsFiltersChange({ cronRunsDeliveryStatuses: [] });
-                },
-              })}
-            </div>
-          </div>
+          </details>
           ${props.runsScope === "job" && props.runsJobId == null
             ? html`
                 <div class="muted" style="margin-top: 12px">${t("cron.runs.selectJobHint")}</div>
@@ -711,696 +762,719 @@ export function renderCron(props: CronProps) {
             : nothing}
         </section>
       </div>
+    </section>
 
-      <section
-        class=${`card cron-workspace-form ${formCollapsed ? "cron-workspace-form--collapsed" : ""}`}
-      >
-        <div class="cron-form-header">
-          <div class="cron-form-header__copy">
-            <div class="card-title">${formTitle}</div>
-            ${formCollapsed
-              ? nothing
-              : html`
-                  <div class="card-sub">
-                    ${isEditing ? t("cron.form.updateSubtitle") : t("cron.form.createSubtitle")}
-                  </div>
-                `}
-          </div>
-          ${toggleFormCollapsed
-            ? html`
+    ${formOpen
+      ? html`
+          <div class="cron-form-modal-backdrop" @click=${props.onCancelEdit}>
+            <section
+              class="card cron-workspace-form cron-form-modal"
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="cron-form-title"
+              @click=${(event: Event) => event.stopPropagation()}
+            >
+              <div class="cron-form-header">
+                <div class="cron-form-header__copy">
+                  <div id="cron-form-title" class="card-title">${formTitle}</div>
+                  ${formCollapsed
+                    ? nothing
+                    : html`
+                        <div class="card-sub">
+                          ${isEditing
+                            ? t("cron.form.updateSubtitle")
+                            : t("cron.form.createSubtitle")}
+                        </div>
+                      `}
+                </div>
                 <button
                   type="button"
                   class="btn cron-form-collapse-toggle"
-                  data-test-id="cron-form-collapse-toggle"
-                  title=${formCollapsed ? t("nav.expand") : t("nav.collapse")}
-                  aria-label=${formCollapsed ? t("nav.expand") : t("nav.collapse")}
-                  aria-expanded=${formCollapsed ? "false" : "true"}
-                  @click=${() => toggleFormCollapsed(!formCollapsed)}
+                  data-test-id="cron-form-close"
+                  title=${t("common.dismiss")}
+                  aria-label=${t("common.dismiss")}
+                  @click=${props.onCancelEdit}
                 >
-                  <span aria-hidden="true">${formCollapsed ? "<" : ">"}</span>
+                  <span aria-hidden="true">×</span>
                 </button>
-              `
-            : nothing}
-        </div>
-        <div class="cron-form" ?hidden=${formCollapsed}>
-          <div class="cron-required-legend">
-            <span class="cron-required-marker" aria-hidden="true">*</span> ${t(
-              "cron.form.required",
-            )}
-          </div>
-          <section class="cron-form-section">
-            <div class="cron-form-section__title">${t("cron.form.basics")}</div>
-            <div class="cron-form-section__sub">${t("cron.form.basicsSub")}</div>
-            <div class="form-grid cron-form-grid">
-              <label class="field">
-                ${renderFieldLabel(t("cron.form.fieldName"), true)}
-                <input
-                  id="cron-name"
-                  .value=${props.form.name}
-                  placeholder=${t("cron.form.namePlaceholder")}
-                  aria-invalid=${props.fieldErrors.name ? "true" : "false"}
-                  aria-describedby=${ifDefined(
-                    props.fieldErrors.name ? errorIdForField("name") : undefined,
+              </div>
+              <div class="cron-form" ?hidden=${formCollapsed}>
+                <div class="cron-required-legend">
+                  <span class="cron-required-marker" aria-hidden="true">*</span> ${t(
+                    "cron.form.required",
                   )}
-                  @input=${(e: Event) =>
-                    props.onFormChange({ name: (e.target as HTMLInputElement).value })}
-                />
-                ${renderFieldError(props.fieldErrors.name, errorIdForField("name"))}
-              </label>
-              <label class="field">
-                <span>${t("cron.form.description")}</span>
-                <input
-                  .value=${props.form.description}
-                  placeholder=${t("cron.form.descriptionPlaceholder")}
-                  @input=${(e: Event) =>
-                    props.onFormChange({ description: (e.target as HTMLInputElement).value })}
-                />
-              </label>
-              <label class="field">
-                ${renderFieldLabel(t("cron.form.agentId"))}
-                <input
-                  id="cron-agent-id"
-                  .value=${props.form.agentId}
-                  list="cron-agent-suggestions"
-                  ?disabled=${props.form.clearAgent}
-                  @input=${(e: Event) =>
-                    props.onFormChange({ agentId: (e.target as HTMLInputElement).value })}
-                  placeholder=${t("cron.form.agentPlaceholder")}
-                />
-                <div class="cron-help">${t("cron.form.agentHelp")}</div>
-              </label>
-              <label class="field checkbox cron-checkbox cron-checkbox-inline">
-                <input
-                  type="checkbox"
-                  .checked=${props.form.enabled}
-                  @change=${(e: Event) =>
-                    props.onFormChange({ enabled: (e.target as HTMLInputElement).checked })}
-                />
-                <span class="field-checkbox__label">${t("cron.summary.enabled")}</span>
-              </label>
-            </div>
-          </section>
-
-          <section class="cron-form-section">
-            <div class="cron-form-section__title">${t("cron.form.schedule")}</div>
-            <div class="cron-form-section__sub">${t("cron.form.scheduleSub")}</div>
-            <div class="form-grid cron-form-grid">
-              <label class="field cron-span-2">
-                ${renderFieldLabel(t("cron.form.schedule"))}
-                <select
-                  id="cron-schedule-kind"
-                  .value=${props.form.scheduleKind}
-                  @change=${(e: Event) =>
-                    props.onFormChange({
-                      scheduleKind: (e.target as HTMLSelectElement)
-                        .value as CronFormState["scheduleKind"],
-                    })}
-                >
-                  <option value="every">${t("cron.form.every")}</option>
-                  <option value="at">${t("cron.form.at")}</option>
-                  <option value="cron">${t("cron.form.cronOption")}</option>
-                </select>
-              </label>
-            </div>
-            ${renderScheduleFields(props)}
-          </section>
-
-          <section class="cron-form-section">
-            <div class="cron-form-section__title">${t("cron.form.execution")}</div>
-            <div class="cron-form-section__sub">${t("cron.form.executionSub")}</div>
-            <div class="form-grid cron-form-grid">
-              <label class="field">
-                ${renderFieldLabel(t("cron.form.session"))}
-                <select
-                  id="cron-session-target"
-                  .value=${props.form.sessionTarget}
-                  @change=${(e: Event) =>
-                    props.onFormChange({
-                      sessionTarget: (e.target as HTMLSelectElement)
-                        .value as CronFormState["sessionTarget"],
-                    })}
-                >
-                  <option value="main">${t("cron.form.main")}</option>
-                  <option value="isolated">${t("cron.form.isolated")}</option>
-                </select>
-                <div class="cron-help">${t("cron.form.sessionHelp")}</div>
-              </label>
-              <label class="field">
-                ${renderFieldLabel(t("cron.form.wakeMode"))}
-                <select
-                  id="cron-wake-mode"
-                  .value=${props.form.wakeMode}
-                  @change=${(e: Event) =>
-                    props.onFormChange({
-                      wakeMode: (e.target as HTMLSelectElement).value as CronFormState["wakeMode"],
-                    })}
-                >
-                  <option value="now">${t("cron.form.now")}</option>
-                  <option value="next-heartbeat">${t("cron.form.nextHeartbeat")}</option>
-                </select>
-                <div class="cron-help">${t("cron.form.wakeModeHelp")}</div>
-              </label>
-              <label class="field ${isAgentTurn ? "" : "cron-span-2"}">
-                ${renderFieldLabel(t("cron.form.payloadKind"))}
-                <select
-                  id="cron-payload-kind"
-                  .value=${props.form.payloadKind}
-                  @change=${(e: Event) =>
-                    props.onFormChange({
-                      payloadKind: (e.target as HTMLSelectElement)
-                        .value as CronFormState["payloadKind"],
-                    })}
-                >
-                  <option value="systemEvent">${t("cron.form.systemEvent")}</option>
-                  <option value="agentTurn">${t("cron.form.agentTurn")}</option>
-                </select>
-                <div class="cron-help">
-                  ${props.form.payloadKind === "systemEvent"
-                    ? t("cron.form.systemEventHelp")
-                    : t("cron.form.agentTurnHelp")}
                 </div>
-              </label>
-              ${isAgentTurn
-                ? html`
+                <section class="cron-form-section">
+                  <div class="cron-form-section__title">${t("cron.form.basics")}</div>
+                  <div class="cron-form-section__sub">${t("cron.form.basicsSub")}</div>
+                  <div class="form-grid cron-form-grid">
                     <label class="field">
-                      ${renderFieldLabel(t("cron.form.timeoutSeconds"))}
+                      ${renderFieldLabel(t("cron.form.fieldName"), true)}
                       <input
-                        id="cron-timeout-seconds"
-                        .value=${props.form.timeoutSeconds}
-                        placeholder=${t("cron.form.timeoutPlaceholder")}
-                        aria-invalid=${props.fieldErrors.timeoutSeconds ? "true" : "false"}
+                        id="cron-name"
+                        .value=${props.form.name}
+                        placeholder=${t("cron.form.namePlaceholder")}
+                        aria-invalid=${props.fieldErrors.name ? "true" : "false"}
                         aria-describedby=${ifDefined(
-                          props.fieldErrors.timeoutSeconds
-                            ? errorIdForField("timeoutSeconds")
-                            : undefined,
+                          props.fieldErrors.name ? errorIdForField("name") : undefined,
                         )}
                         @input=${(e: Event) =>
-                          props.onFormChange({
-                            timeoutSeconds: (e.target as HTMLInputElement).value,
-                          })}
+                          props.onFormChange({ name: (e.target as HTMLInputElement).value })}
                       />
-                      <div class="cron-help">${t("cron.form.timeoutHelp")}</div>
-                      ${renderFieldError(
-                        props.fieldErrors.timeoutSeconds,
-                        errorIdForField("timeoutSeconds"),
-                      )}
-                    </label>
-                  `
-                : nothing}
-            </div>
-            <label class="field cron-span-2">
-              ${renderFieldLabel(
-                props.form.payloadKind === "systemEvent"
-                  ? t("cron.form.mainTimelineMessage")
-                  : t("cron.form.assistantTaskPrompt"),
-                true,
-              )}
-              <textarea
-                id="cron-payload-text"
-                .value=${props.form.payloadText}
-                aria-invalid=${props.fieldErrors.payloadText ? "true" : "false"}
-                aria-describedby=${ifDefined(
-                  props.fieldErrors.payloadText ? errorIdForField("payloadText") : undefined,
-                )}
-                @input=${(e: Event) =>
-                  props.onFormChange({
-                    payloadText: (e.target as HTMLTextAreaElement).value,
-                  })}
-                rows="4"
-              ></textarea>
-              ${renderFieldError(props.fieldErrors.payloadText, errorIdForField("payloadText"))}
-            </label>
-          </section>
-
-          <section class="cron-form-section">
-            <div class="cron-form-section__title">${t("cron.form.deliverySection")}</div>
-            <div class="cron-form-section__sub">${t("cron.form.deliverySub")}</div>
-            <div class="form-grid cron-form-grid">
-              <label class="field ${selectedDeliveryMode === "none" ? "cron-span-2" : ""}">
-                ${renderFieldLabel(t("cron.form.resultDelivery"))}
-                <select
-                  id="cron-delivery-mode"
-                  .value=${selectedDeliveryMode}
-                  @change=${(e: Event) =>
-                    props.onFormChange({
-                      deliveryMode: (e.target as HTMLSelectElement)
-                        .value as CronFormState["deliveryMode"],
-                    })}
-                >
-                  ${supportsAnnounce
-                    ? html` <option value="announce">${t("cron.form.announceDefault")}</option> `
-                    : nothing}
-                  <option value="webhook">${t("cron.form.webhookPost")}</option>
-                  <option value="none">${t("cron.form.noneInternal")}</option>
-                </select>
-                <div class="cron-help">${t("cron.form.deliveryHelp")}</div>
-              </label>
-              ${selectedDeliveryMode !== "none"
-                ? html`
-                    <label class="field ${selectedDeliveryMode === "webhook" ? "cron-span-2" : ""}">
-                      ${renderFieldLabel(
-                        selectedDeliveryMode === "webhook"
-                          ? t("cron.form.webhookUrl")
-                          : t("cron.form.channel"),
-                        selectedDeliveryMode === "webhook",
-                      )}
-                      ${selectedDeliveryMode === "webhook"
-                        ? html`
-                            <input
-                              id="cron-delivery-to"
-                              .value=${props.form.deliveryTo}
-                              list="cron-delivery-to-suggestions"
-                              aria-invalid=${props.fieldErrors.deliveryTo ? "true" : "false"}
-                              aria-describedby=${ifDefined(
-                                props.fieldErrors.deliveryTo
-                                  ? errorIdForField("deliveryTo")
-                                  : undefined,
-                              )}
-                              @input=${(e: Event) =>
-                                props.onFormChange({
-                                  deliveryTo: (e.target as HTMLInputElement).value,
-                                })}
-                              placeholder=${t("cron.form.webhookPlaceholder")}
-                            />
-                          `
-                        : html`
-                            <select
-                              id="cron-delivery-channel"
-                              .value=${props.form.deliveryChannel || "last"}
-                              @change=${(e: Event) =>
-                                props.onFormChange({
-                                  deliveryChannel: (e.target as HTMLSelectElement).value,
-                                })}
-                            >
-                              ${channelOptions.map(
-                                (channel) =>
-                                  html`<option value=${channel}>
-                                    ${resolveChannelLabel(props, channel)}
-                                  </option>`,
-                              )}
-                            </select>
-                          `}
-                      ${selectedDeliveryMode === "announce"
-                        ? html` <div class="cron-help">${t("cron.form.channelHelp")}</div> `
-                        : html` <div class="cron-help">${t("cron.form.webhookHelp")}</div> `}
-                    </label>
-                    ${selectedDeliveryMode === "announce"
-                      ? html`
-                          <label class="field cron-span-2">
-                            ${renderFieldLabel(t("cron.form.to"))}
-                            <input
-                              id="cron-delivery-to"
-                              .value=${props.form.deliveryTo}
-                              list="cron-delivery-to-suggestions"
-                              @input=${(e: Event) =>
-                                props.onFormChange({
-                                  deliveryTo: (e.target as HTMLInputElement).value,
-                                })}
-                              placeholder=${t("cron.form.toPlaceholder")}
-                            />
-                            <div class="cron-help">${t("cron.form.toHelp")}</div>
-                          </label>
-                        `
-                      : nothing}
-                    ${selectedDeliveryMode === "webhook"
-                      ? renderFieldError(
-                          props.fieldErrors.deliveryTo,
-                          errorIdForField("deliveryTo"),
-                        )
-                      : nothing}
-                  `
-                : nothing}
-            </div>
-          </section>
-
-          <details class="cron-advanced">
-            <summary class="cron-advanced__summary">${t("cron.form.advanced")}</summary>
-            <div class="cron-help">${t("cron.form.advancedHelp")}</div>
-            <div class="form-grid cron-form-grid">
-              <label class="field checkbox cron-checkbox">
-                <input
-                  type="checkbox"
-                  .checked=${props.form.deleteAfterRun}
-                  @change=${(e: Event) =>
-                    props.onFormChange({
-                      deleteAfterRun: (e.target as HTMLInputElement).checked,
-                    })}
-                />
-                <span class="field-checkbox__label">${t("cron.form.deleteAfterRun")}</span>
-                <div class="cron-help">${t("cron.form.deleteAfterRunHelp")}</div>
-              </label>
-              <label class="field checkbox cron-checkbox">
-                <input
-                  type="checkbox"
-                  .checked=${props.form.clearAgent}
-                  @change=${(e: Event) =>
-                    props.onFormChange({
-                      clearAgent: (e.target as HTMLInputElement).checked,
-                    })}
-                />
-                <span class="field-checkbox__label">${t("cron.form.clearAgentOverride")}</span>
-                <div class="cron-help">${t("cron.form.clearAgentHelp")}</div>
-              </label>
-              <label class="field cron-span-2">
-                ${renderFieldLabel("Session key")}
-                <input
-                  id="cron-session-key"
-                  .value=${props.form.sessionKey}
-                  @input=${(e: Event) =>
-                    props.onFormChange({
-                      sessionKey: (e.target as HTMLInputElement).value,
-                    })}
-                  placeholder="agent:main:main"
-                />
-                <div class="cron-help">Optional routing key for job delivery and wake routing.</div>
-              </label>
-              ${isCronSchedule
-                ? html`
-                    <label class="field checkbox cron-checkbox cron-span-2">
-                      <input
-                        type="checkbox"
-                        .checked=${props.form.scheduleExact}
-                        @change=${(e: Event) =>
-                          props.onFormChange({
-                            scheduleExact: (e.target as HTMLInputElement).checked,
-                          })}
-                      />
-                      <span class="field-checkbox__label">${t("cron.form.exactTiming")}</span>
-                      <div class="cron-help">${t("cron.form.exactTimingHelp")}</div>
-                    </label>
-                    <div class="cron-stagger-group cron-span-2">
-                      <label class="field">
-                        ${renderFieldLabel(t("cron.form.staggerWindow"))}
-                        <input
-                          id="cron-stagger-amount"
-                          .value=${props.form.staggerAmount}
-                          ?disabled=${props.form.scheduleExact}
-                          aria-invalid=${props.fieldErrors.staggerAmount ? "true" : "false"}
-                          aria-describedby=${ifDefined(
-                            props.fieldErrors.staggerAmount
-                              ? errorIdForField("staggerAmount")
-                              : undefined,
-                          )}
-                          @input=${(e: Event) =>
-                            props.onFormChange({
-                              staggerAmount: (e.target as HTMLInputElement).value,
-                            })}
-                          placeholder=${t("cron.form.staggerPlaceholder")}
-                        />
-                        ${renderFieldError(
-                          props.fieldErrors.staggerAmount,
-                          errorIdForField("staggerAmount"),
-                        )}
-                      </label>
-                      <label class="field">
-                        <span>${t("cron.form.staggerUnit")}</span>
-                        <select
-                          .value=${props.form.staggerUnit}
-                          ?disabled=${props.form.scheduleExact}
-                          @change=${(e: Event) =>
-                            props.onFormChange({
-                              staggerUnit: (e.target as HTMLSelectElement)
-                                .value as CronFormState["staggerUnit"],
-                            })}
-                        >
-                          <option value="seconds">${t("cron.form.seconds")}</option>
-                          <option value="minutes">${t("cron.form.minutes")}</option>
-                        </select>
-                      </label>
-                    </div>
-                  `
-                : nothing}
-              ${isAgentTurn
-                ? html`
-                    <label class="field cron-span-2">
-                      ${renderFieldLabel("Account ID")}
-                      <input
-                        id="cron-delivery-account-id"
-                        .value=${props.form.deliveryAccountId}
-                        list="cron-delivery-account-suggestions"
-                        ?disabled=${selectedDeliveryMode !== "announce"}
-                        @input=${(e: Event) =>
-                          props.onFormChange({
-                            deliveryAccountId: (e.target as HTMLInputElement).value,
-                          })}
-                        placeholder="default"
-                      />
-                      <div class="cron-help">
-                        Optional channel account ID for multi-account setups.
-                      </div>
-                    </label>
-                    <label class="field checkbox cron-checkbox cron-span-2">
-                      <input
-                        type="checkbox"
-                        .checked=${props.form.payloadLightContext}
-                        @change=${(e: Event) =>
-                          props.onFormChange({
-                            payloadLightContext: (e.target as HTMLInputElement).checked,
-                          })}
-                      />
-                      <span class="field-checkbox__label">Light context</span>
-                      <div class="cron-help">
-                        Use lightweight bootstrap context for this agent job.
-                      </div>
+                      ${renderFieldError(props.fieldErrors.name, errorIdForField("name"))}
                     </label>
                     <label class="field">
-                      ${renderFieldLabel(t("cron.form.model"))}
+                      <span>${t("cron.form.description")}</span>
                       <input
-                        id="cron-payload-model"
-                        .value=${props.form.payloadModel}
-                        list="cron-model-suggestions"
+                        .value=${props.form.description}
+                        placeholder=${t("cron.form.descriptionPlaceholder")}
                         @input=${(e: Event) =>
-                          props.onFormChange({
-                            payloadModel: (e.target as HTMLInputElement).value,
-                          })}
-                        placeholder=${t("cron.form.modelPlaceholder")}
+                          props.onFormChange({ description: (e.target as HTMLInputElement).value })}
                       />
-                      <div class="cron-help">${t("cron.form.modelHelp")}</div>
                     </label>
                     <label class="field">
-                      ${renderFieldLabel(t("cron.form.thinking"))}
+                      ${renderFieldLabel(t("cron.form.agentId"))}
                       <input
-                        id="cron-payload-thinking"
-                        .value=${props.form.payloadThinking}
-                        list="cron-thinking-suggestions"
+                        id="cron-agent-id"
+                        .value=${props.form.agentId}
+                        list="cron-agent-suggestions"
+                        ?disabled=${props.form.clearAgent}
                         @input=${(e: Event) =>
-                          props.onFormChange({
-                            payloadThinking: (e.target as HTMLInputElement).value,
-                          })}
-                        placeholder=${t("cron.form.thinkingPlaceholder")}
+                          props.onFormChange({ agentId: (e.target as HTMLInputElement).value })}
+                        placeholder=${t("cron.form.agentPlaceholder")}
                       />
-                      <div class="cron-help">${t("cron.form.thinkingHelp")}</div>
+                      <div class="cron-help">${t("cron.form.agentHelp")}</div>
                     </label>
-                  `
-                : nothing}
-              ${isAgentTurn
-                ? html`
+                    <label class="field checkbox cron-checkbox cron-checkbox-inline">
+                      <input
+                        type="checkbox"
+                        .checked=${props.form.enabled}
+                        @change=${(e: Event) =>
+                          props.onFormChange({ enabled: (e.target as HTMLInputElement).checked })}
+                      />
+                      <span class="field-checkbox__label">${t("cron.summary.enabled")}</span>
+                    </label>
+                  </div>
+                </section>
+
+                <section class="cron-form-section">
+                  <div class="cron-form-section__title">${t("cron.form.schedule")}</div>
+                  <div class="cron-form-section__sub">${t("cron.form.scheduleSub")}</div>
+                  <div class="form-grid cron-form-grid">
                     <label class="field cron-span-2">
-                      ${renderFieldLabel("Failure alerts")}
+                      ${renderFieldLabel(t("cron.form.schedule"))}
                       <select
-                        .value=${props.form.failureAlertMode}
+                        id="cron-schedule-kind"
+                        .value=${props.form.scheduleKind}
                         @change=${(e: Event) =>
                           props.onFormChange({
-                            failureAlertMode: (e.target as HTMLSelectElement)
-                              .value as CronFormState["failureAlertMode"],
+                            scheduleKind: (e.target as HTMLSelectElement)
+                              .value as CronFormState["scheduleKind"],
                           })}
                       >
-                        <option value="inherit">Inherit global setting</option>
-                        <option value="disabled">Disable for this job</option>
-                        <option value="custom">Custom per-job settings</option>
+                        <option value="every">${t("cron.form.every")}</option>
+                        <option value="at">${t("cron.form.at")}</option>
+                        <option value="cron">${t("cron.form.cronOption")}</option>
+                      </select>
+                    </label>
+                  </div>
+                  ${renderScheduleFields(props)}
+                </section>
+
+                <section class="cron-form-section">
+                  <div class="cron-form-section__title">${t("cron.form.execution")}</div>
+                  <div class="cron-form-section__sub">${t("cron.form.executionSub")}</div>
+                  <div class="form-grid cron-form-grid">
+                    <label class="field">
+                      ${renderFieldLabel(t("cron.form.session"))}
+                      <select
+                        id="cron-session-target"
+                        .value=${props.form.sessionTarget}
+                        @change=${(e: Event) =>
+                          props.onFormChange({
+                            sessionTarget: (e.target as HTMLSelectElement)
+                              .value as CronFormState["sessionTarget"],
+                          })}
+                      >
+                        <option value="main">${t("cron.form.main")}</option>
+                        <option value="isolated">${t("cron.form.isolated")}</option>
+                      </select>
+                      <div class="cron-help">${t("cron.form.sessionHelp")}</div>
+                    </label>
+                    <label class="field">
+                      ${renderFieldLabel(t("cron.form.wakeMode"))}
+                      <select
+                        id="cron-wake-mode"
+                        .value=${props.form.wakeMode}
+                        @change=${(e: Event) =>
+                          props.onFormChange({
+                            wakeMode: (e.target as HTMLSelectElement)
+                              .value as CronFormState["wakeMode"],
+                          })}
+                      >
+                        <option value="now">${t("cron.form.now")}</option>
+                        <option value="next-heartbeat">${t("cron.form.nextHeartbeat")}</option>
+                      </select>
+                      <div class="cron-help">${t("cron.form.wakeModeHelp")}</div>
+                    </label>
+                    <label class="field ${isAgentTurn ? "" : "cron-span-2"}">
+                      ${renderFieldLabel(t("cron.form.payloadKind"))}
+                      <select
+                        id="cron-payload-kind"
+                        .value=${props.form.payloadKind}
+                        @change=${(e: Event) =>
+                          props.onFormChange({
+                            payloadKind: (e.target as HTMLSelectElement)
+                              .value as CronFormState["payloadKind"],
+                          })}
+                      >
+                        <option value="systemEvent">${t("cron.form.systemEvent")}</option>
+                        <option value="agentTurn">${t("cron.form.agentTurn")}</option>
                       </select>
                       <div class="cron-help">
-                        Control when this job sends repeated-failure alerts.
+                        ${props.form.payloadKind === "systemEvent"
+                          ? t("cron.form.systemEventHelp")
+                          : t("cron.form.agentTurnHelp")}
                       </div>
                     </label>
-                    ${props.form.failureAlertMode === "custom"
+                    ${isAgentTurn
                       ? html`
                           <label class="field">
-                            ${renderFieldLabel("Alert after")}
+                            ${renderFieldLabel(t("cron.form.timeoutSeconds"))}
                             <input
-                              id="cron-failure-alert-after"
-                              .value=${props.form.failureAlertAfter}
-                              aria-invalid=${props.fieldErrors.failureAlertAfter ? "true" : "false"}
+                              id="cron-timeout-seconds"
+                              .value=${props.form.timeoutSeconds}
+                              placeholder=${t("cron.form.timeoutPlaceholder")}
+                              aria-invalid=${props.fieldErrors.timeoutSeconds ? "true" : "false"}
                               aria-describedby=${ifDefined(
-                                props.fieldErrors.failureAlertAfter
-                                  ? errorIdForField("failureAlertAfter")
+                                props.fieldErrors.timeoutSeconds
+                                  ? errorIdForField("timeoutSeconds")
                                   : undefined,
                               )}
                               @input=${(e: Event) =>
                                 props.onFormChange({
-                                  failureAlertAfter: (e.target as HTMLInputElement).value,
+                                  timeoutSeconds: (e.target as HTMLInputElement).value,
                                 })}
-                              placeholder="2"
                             />
-                            <div class="cron-help">Consecutive errors before alerting.</div>
+                            <div class="cron-help">${t("cron.form.timeoutHelp")}</div>
                             ${renderFieldError(
-                              props.fieldErrors.failureAlertAfter,
-                              errorIdForField("failureAlertAfter"),
+                              props.fieldErrors.timeoutSeconds,
+                              errorIdForField("timeoutSeconds"),
                             )}
-                          </label>
-                          <label class="field">
-                            ${renderFieldLabel("Cooldown (seconds)")}
-                            <input
-                              id="cron-failure-alert-cooldown-seconds"
-                              .value=${props.form.failureAlertCooldownSeconds}
-                              aria-invalid=${props.fieldErrors.failureAlertCooldownSeconds
-                                ? "true"
-                                : "false"}
-                              aria-describedby=${ifDefined(
-                                props.fieldErrors.failureAlertCooldownSeconds
-                                  ? errorIdForField("failureAlertCooldownSeconds")
-                                  : undefined,
-                              )}
-                              @input=${(e: Event) =>
-                                props.onFormChange({
-                                  failureAlertCooldownSeconds: (e.target as HTMLInputElement).value,
-                                })}
-                              placeholder="3600"
-                            />
-                            <div class="cron-help">Minimum seconds between alerts.</div>
-                            ${renderFieldError(
-                              props.fieldErrors.failureAlertCooldownSeconds,
-                              errorIdForField("failureAlertCooldownSeconds"),
-                            )}
-                          </label>
-                          <label class="field">
-                            ${renderFieldLabel("Alert channel")}
-                            <select
-                              .value=${props.form.failureAlertChannel || "last"}
-                              @change=${(e: Event) =>
-                                props.onFormChange({
-                                  failureAlertChannel: (e.target as HTMLSelectElement).value,
-                                })}
-                            >
-                              ${channelOptions.map(
-                                (channel) =>
-                                  html`<option value=${channel}>
-                                    ${resolveChannelLabel(props, channel)}
-                                  </option>`,
-                              )}
-                            </select>
-                          </label>
-                          <label class="field">
-                            ${renderFieldLabel("Alert to")}
-                            <input
-                              .value=${props.form.failureAlertTo}
-                              list="cron-delivery-to-suggestions"
-                              @input=${(e: Event) =>
-                                props.onFormChange({
-                                  failureAlertTo: (e.target as HTMLInputElement).value,
-                                })}
-                              placeholder="+1555... or chat id"
-                            />
-                            <div class="cron-help">
-                              Optional recipient override for failure alerts.
-                            </div>
-                          </label>
-                          <label class="field">
-                            ${renderFieldLabel("Alert mode")}
-                            <select
-                              .value=${props.form.failureAlertDeliveryMode || "announce"}
-                              @change=${(e: Event) =>
-                                props.onFormChange({
-                                  failureAlertDeliveryMode: (e.target as HTMLSelectElement)
-                                    .value as CronFormState["failureAlertDeliveryMode"],
-                                })}
-                            >
-                              <option value="announce">Announce (via channel)</option>
-                              <option value="webhook">Webhook (HTTP POST)</option>
-                            </select>
-                          </label>
-                          <label class="field">
-                            ${renderFieldLabel("Alert account ID")}
-                            <input
-                              .value=${props.form.failureAlertAccountId}
-                              @input=${(e: Event) =>
-                                props.onFormChange({
-                                  failureAlertAccountId: (e.target as HTMLInputElement).value,
-                                })}
-                              placeholder="Account ID for multi-account setups"
-                            />
                           </label>
                         `
                       : nothing}
-                  `
-                : nothing}
-              ${selectedDeliveryMode !== "none"
-                ? html`
-                    <label class="field checkbox cron-checkbox cron-span-2">
-                      <input
-                        type="checkbox"
-                        .checked=${props.form.deliveryBestEffort}
+                  </div>
+                  <label class="field cron-span-2">
+                    ${renderFieldLabel(
+                      props.form.payloadKind === "systemEvent"
+                        ? t("cron.form.mainTimelineMessage")
+                        : t("cron.form.assistantTaskPrompt"),
+                      true,
+                    )}
+                    <textarea
+                      id="cron-payload-text"
+                      .value=${props.form.payloadText}
+                      aria-invalid=${props.fieldErrors.payloadText ? "true" : "false"}
+                      aria-describedby=${ifDefined(
+                        props.fieldErrors.payloadText ? errorIdForField("payloadText") : undefined,
+                      )}
+                      @input=${(e: Event) =>
+                        props.onFormChange({
+                          payloadText: (e.target as HTMLTextAreaElement).value,
+                        })}
+                      rows="4"
+                    ></textarea>
+                    ${renderFieldError(
+                      props.fieldErrors.payloadText,
+                      errorIdForField("payloadText"),
+                    )}
+                  </label>
+                </section>
+
+                <section class="cron-form-section">
+                  <div class="cron-form-section__title">${t("cron.form.deliverySection")}</div>
+                  <div class="cron-form-section__sub">${t("cron.form.deliverySub")}</div>
+                  <div class="form-grid cron-form-grid">
+                    <label class="field ${selectedDeliveryMode === "none" ? "cron-span-2" : ""}">
+                      ${renderFieldLabel(t("cron.form.resultDelivery"))}
+                      <select
+                        id="cron-delivery-mode"
+                        .value=${selectedDeliveryMode}
                         @change=${(e: Event) =>
                           props.onFormChange({
-                            deliveryBestEffort: (e.target as HTMLInputElement).checked,
+                            deliveryMode: (e.target as HTMLSelectElement)
+                              .value as CronFormState["deliveryMode"],
+                          })}
+                      >
+                        ${supportsAnnounce
+                          ? html`
+                              <option value="announce">${t("cron.form.announceDefault")}</option>
+                            `
+                          : nothing}
+                        <option value="webhook">${t("cron.form.webhookPost")}</option>
+                        <option value="none">${t("cron.form.noneInternal")}</option>
+                      </select>
+                      <div class="cron-help">${t("cron.form.deliveryHelp")}</div>
+                    </label>
+                    ${selectedDeliveryMode !== "none"
+                      ? html`
+                          <label
+                            class="field ${selectedDeliveryMode === "webhook" ? "cron-span-2" : ""}"
+                          >
+                            ${renderFieldLabel(
+                              selectedDeliveryMode === "webhook"
+                                ? t("cron.form.webhookUrl")
+                                : t("cron.form.channel"),
+                              selectedDeliveryMode === "webhook",
+                            )}
+                            ${selectedDeliveryMode === "webhook"
+                              ? html`
+                                  <input
+                                    id="cron-delivery-to"
+                                    .value=${props.form.deliveryTo}
+                                    list="cron-delivery-to-suggestions"
+                                    aria-invalid=${props.fieldErrors.deliveryTo ? "true" : "false"}
+                                    aria-describedby=${ifDefined(
+                                      props.fieldErrors.deliveryTo
+                                        ? errorIdForField("deliveryTo")
+                                        : undefined,
+                                    )}
+                                    @input=${(e: Event) =>
+                                      props.onFormChange({
+                                        deliveryTo: (e.target as HTMLInputElement).value,
+                                      })}
+                                    placeholder=${t("cron.form.webhookPlaceholder")}
+                                  />
+                                `
+                              : html`
+                                  <select
+                                    id="cron-delivery-channel"
+                                    .value=${props.form.deliveryChannel || "last"}
+                                    @change=${(e: Event) =>
+                                      props.onFormChange({
+                                        deliveryChannel: (e.target as HTMLSelectElement).value,
+                                      })}
+                                  >
+                                    ${channelOptions.map(
+                                      (channel) =>
+                                        html`<option value=${channel}>
+                                          ${resolveChannelLabel(props, channel)}
+                                        </option>`,
+                                    )}
+                                  </select>
+                                `}
+                            ${selectedDeliveryMode === "announce"
+                              ? html` <div class="cron-help">${t("cron.form.channelHelp")}</div> `
+                              : html` <div class="cron-help">${t("cron.form.webhookHelp")}</div> `}
+                          </label>
+                          ${selectedDeliveryMode === "announce"
+                            ? html`
+                                <label class="field cron-span-2">
+                                  ${renderFieldLabel(t("cron.form.to"))}
+                                  <input
+                                    id="cron-delivery-to"
+                                    .value=${props.form.deliveryTo}
+                                    list="cron-delivery-to-suggestions"
+                                    @input=${(e: Event) =>
+                                      props.onFormChange({
+                                        deliveryTo: (e.target as HTMLInputElement).value,
+                                      })}
+                                    placeholder=${t("cron.form.toPlaceholder")}
+                                  />
+                                  <div class="cron-help">${t("cron.form.toHelp")}</div>
+                                </label>
+                              `
+                            : nothing}
+                          ${selectedDeliveryMode === "webhook"
+                            ? renderFieldError(
+                                props.fieldErrors.deliveryTo,
+                                errorIdForField("deliveryTo"),
+                              )
+                            : nothing}
+                        `
+                      : nothing}
+                  </div>
+                </section>
+
+                <details class="cron-advanced">
+                  <summary class="cron-advanced__summary">${t("cron.form.advanced")}</summary>
+                  <div class="cron-help">${t("cron.form.advancedHelp")}</div>
+                  <div class="form-grid cron-form-grid">
+                    <label class="field checkbox cron-checkbox">
+                      <input
+                        type="checkbox"
+                        .checked=${props.form.deleteAfterRun}
+                        @change=${(e: Event) =>
+                          props.onFormChange({
+                            deleteAfterRun: (e.target as HTMLInputElement).checked,
+                          })}
+                      />
+                      <span class="field-checkbox__label">${t("cron.form.deleteAfterRun")}</span>
+                      <div class="cron-help">${t("cron.form.deleteAfterRunHelp")}</div>
+                    </label>
+                    <label class="field checkbox cron-checkbox">
+                      <input
+                        type="checkbox"
+                        .checked=${props.form.clearAgent}
+                        @change=${(e: Event) =>
+                          props.onFormChange({
+                            clearAgent: (e.target as HTMLInputElement).checked,
                           })}
                       />
                       <span class="field-checkbox__label"
-                        >${t("cron.form.bestEffortDelivery")}</span
+                        >${t("cron.form.clearAgentOverride")}</span
                       >
-                      <div class="cron-help">${t("cron.form.bestEffortHelp")}</div>
+                      <div class="cron-help">${t("cron.form.clearAgentHelp")}</div>
                     </label>
+                    <label class="field cron-span-2">
+                      ${renderFieldLabel("Session key")}
+                      <input
+                        id="cron-session-key"
+                        .value=${props.form.sessionKey}
+                        @input=${(e: Event) =>
+                          props.onFormChange({
+                            sessionKey: (e.target as HTMLInputElement).value,
+                          })}
+                        placeholder="agent:main:main"
+                      />
+                      <div class="cron-help">
+                        Optional routing key for job delivery and wake routing.
+                      </div>
+                    </label>
+                    ${isCronSchedule
+                      ? html`
+                          <label class="field checkbox cron-checkbox cron-span-2">
+                            <input
+                              type="checkbox"
+                              .checked=${props.form.scheduleExact}
+                              @change=${(e: Event) =>
+                                props.onFormChange({
+                                  scheduleExact: (e.target as HTMLInputElement).checked,
+                                })}
+                            />
+                            <span class="field-checkbox__label">${t("cron.form.exactTiming")}</span>
+                            <div class="cron-help">${t("cron.form.exactTimingHelp")}</div>
+                          </label>
+                          <div class="cron-stagger-group cron-span-2">
+                            <label class="field">
+                              ${renderFieldLabel(t("cron.form.staggerWindow"))}
+                              <input
+                                id="cron-stagger-amount"
+                                .value=${props.form.staggerAmount}
+                                ?disabled=${props.form.scheduleExact}
+                                aria-invalid=${props.fieldErrors.staggerAmount ? "true" : "false"}
+                                aria-describedby=${ifDefined(
+                                  props.fieldErrors.staggerAmount
+                                    ? errorIdForField("staggerAmount")
+                                    : undefined,
+                                )}
+                                @input=${(e: Event) =>
+                                  props.onFormChange({
+                                    staggerAmount: (e.target as HTMLInputElement).value,
+                                  })}
+                                placeholder=${t("cron.form.staggerPlaceholder")}
+                              />
+                              ${renderFieldError(
+                                props.fieldErrors.staggerAmount,
+                                errorIdForField("staggerAmount"),
+                              )}
+                            </label>
+                            <label class="field">
+                              <span>${t("cron.form.staggerUnit")}</span>
+                              <select
+                                .value=${props.form.staggerUnit}
+                                ?disabled=${props.form.scheduleExact}
+                                @change=${(e: Event) =>
+                                  props.onFormChange({
+                                    staggerUnit: (e.target as HTMLSelectElement)
+                                      .value as CronFormState["staggerUnit"],
+                                  })}
+                              >
+                                <option value="seconds">${t("cron.form.seconds")}</option>
+                                <option value="minutes">${t("cron.form.minutes")}</option>
+                              </select>
+                            </label>
+                          </div>
+                        `
+                      : nothing}
+                    ${isAgentTurn
+                      ? html`
+                          <label class="field cron-span-2">
+                            ${renderFieldLabel("Account ID")}
+                            <input
+                              id="cron-delivery-account-id"
+                              .value=${props.form.deliveryAccountId}
+                              list="cron-delivery-account-suggestions"
+                              ?disabled=${selectedDeliveryMode !== "announce"}
+                              @input=${(e: Event) =>
+                                props.onFormChange({
+                                  deliveryAccountId: (e.target as HTMLInputElement).value,
+                                })}
+                              placeholder="default"
+                            />
+                            <div class="cron-help">
+                              Optional channel account ID for multi-account setups.
+                            </div>
+                          </label>
+                          <label class="field checkbox cron-checkbox cron-span-2">
+                            <input
+                              type="checkbox"
+                              .checked=${props.form.payloadLightContext}
+                              @change=${(e: Event) =>
+                                props.onFormChange({
+                                  payloadLightContext: (e.target as HTMLInputElement).checked,
+                                })}
+                            />
+                            <span class="field-checkbox__label">Light context</span>
+                            <div class="cron-help">
+                              Use lightweight bootstrap context for this agent job.
+                            </div>
+                          </label>
+                          <label class="field">
+                            ${renderFieldLabel(t("cron.form.model"))}
+                            <input
+                              id="cron-payload-model"
+                              .value=${props.form.payloadModel}
+                              list="cron-model-suggestions"
+                              @input=${(e: Event) =>
+                                props.onFormChange({
+                                  payloadModel: (e.target as HTMLInputElement).value,
+                                })}
+                              placeholder=${t("cron.form.modelPlaceholder")}
+                            />
+                            <div class="cron-help">${t("cron.form.modelHelp")}</div>
+                          </label>
+                          <label class="field">
+                            ${renderFieldLabel(t("cron.form.thinking"))}
+                            <input
+                              id="cron-payload-thinking"
+                              .value=${props.form.payloadThinking}
+                              list="cron-thinking-suggestions"
+                              @input=${(e: Event) =>
+                                props.onFormChange({
+                                  payloadThinking: (e.target as HTMLInputElement).value,
+                                })}
+                              placeholder=${t("cron.form.thinkingPlaceholder")}
+                            />
+                            <div class="cron-help">${t("cron.form.thinkingHelp")}</div>
+                          </label>
+                        `
+                      : nothing}
+                    ${isAgentTurn
+                      ? html`
+                          <label class="field cron-span-2">
+                            ${renderFieldLabel("Failure alerts")}
+                            <select
+                              .value=${props.form.failureAlertMode}
+                              @change=${(e: Event) =>
+                                props.onFormChange({
+                                  failureAlertMode: (e.target as HTMLSelectElement)
+                                    .value as CronFormState["failureAlertMode"],
+                                })}
+                            >
+                              <option value="inherit">Inherit global setting</option>
+                              <option value="disabled">Disable for this job</option>
+                              <option value="custom">Custom per-job settings</option>
+                            </select>
+                            <div class="cron-help">
+                              Control when this job sends repeated-failure alerts.
+                            </div>
+                          </label>
+                          ${props.form.failureAlertMode === "custom"
+                            ? html`
+                                <label class="field">
+                                  ${renderFieldLabel("Alert after")}
+                                  <input
+                                    id="cron-failure-alert-after"
+                                    .value=${props.form.failureAlertAfter}
+                                    aria-invalid=${props.fieldErrors.failureAlertAfter
+                                      ? "true"
+                                      : "false"}
+                                    aria-describedby=${ifDefined(
+                                      props.fieldErrors.failureAlertAfter
+                                        ? errorIdForField("failureAlertAfter")
+                                        : undefined,
+                                    )}
+                                    @input=${(e: Event) =>
+                                      props.onFormChange({
+                                        failureAlertAfter: (e.target as HTMLInputElement).value,
+                                      })}
+                                    placeholder="2"
+                                  />
+                                  <div class="cron-help">Consecutive errors before alerting.</div>
+                                  ${renderFieldError(
+                                    props.fieldErrors.failureAlertAfter,
+                                    errorIdForField("failureAlertAfter"),
+                                  )}
+                                </label>
+                                <label class="field">
+                                  ${renderFieldLabel("Cooldown (seconds)")}
+                                  <input
+                                    id="cron-failure-alert-cooldown-seconds"
+                                    .value=${props.form.failureAlertCooldownSeconds}
+                                    aria-invalid=${props.fieldErrors.failureAlertCooldownSeconds
+                                      ? "true"
+                                      : "false"}
+                                    aria-describedby=${ifDefined(
+                                      props.fieldErrors.failureAlertCooldownSeconds
+                                        ? errorIdForField("failureAlertCooldownSeconds")
+                                        : undefined,
+                                    )}
+                                    @input=${(e: Event) =>
+                                      props.onFormChange({
+                                        failureAlertCooldownSeconds: (e.target as HTMLInputElement)
+                                          .value,
+                                      })}
+                                    placeholder="3600"
+                                  />
+                                  <div class="cron-help">Minimum seconds between alerts.</div>
+                                  ${renderFieldError(
+                                    props.fieldErrors.failureAlertCooldownSeconds,
+                                    errorIdForField("failureAlertCooldownSeconds"),
+                                  )}
+                                </label>
+                                <label class="field">
+                                  ${renderFieldLabel("Alert channel")}
+                                  <select
+                                    .value=${props.form.failureAlertChannel || "last"}
+                                    @change=${(e: Event) =>
+                                      props.onFormChange({
+                                        failureAlertChannel: (e.target as HTMLSelectElement).value,
+                                      })}
+                                  >
+                                    ${channelOptions.map(
+                                      (channel) =>
+                                        html`<option value=${channel}>
+                                          ${resolveChannelLabel(props, channel)}
+                                        </option>`,
+                                    )}
+                                  </select>
+                                </label>
+                                <label class="field">
+                                  ${renderFieldLabel("Alert to")}
+                                  <input
+                                    .value=${props.form.failureAlertTo}
+                                    list="cron-delivery-to-suggestions"
+                                    @input=${(e: Event) =>
+                                      props.onFormChange({
+                                        failureAlertTo: (e.target as HTMLInputElement).value,
+                                      })}
+                                    placeholder="+1555... or chat id"
+                                  />
+                                  <div class="cron-help">
+                                    Optional recipient override for failure alerts.
+                                  </div>
+                                </label>
+                                <label class="field">
+                                  ${renderFieldLabel("Alert mode")}
+                                  <select
+                                    .value=${props.form.failureAlertDeliveryMode || "announce"}
+                                    @change=${(e: Event) =>
+                                      props.onFormChange({
+                                        failureAlertDeliveryMode: (e.target as HTMLSelectElement)
+                                          .value as CronFormState["failureAlertDeliveryMode"],
+                                      })}
+                                  >
+                                    <option value="announce">Announce (via channel)</option>
+                                    <option value="webhook">Webhook (HTTP POST)</option>
+                                  </select>
+                                </label>
+                                <label class="field">
+                                  ${renderFieldLabel("Alert account ID")}
+                                  <input
+                                    .value=${props.form.failureAlertAccountId}
+                                    @input=${(e: Event) =>
+                                      props.onFormChange({
+                                        failureAlertAccountId: (e.target as HTMLInputElement).value,
+                                      })}
+                                    placeholder="Account ID for multi-account setups"
+                                  />
+                                </label>
+                              `
+                            : nothing}
+                        `
+                      : nothing}
+                    ${selectedDeliveryMode !== "none"
+                      ? html`
+                          <label class="field checkbox cron-checkbox cron-span-2">
+                            <input
+                              type="checkbox"
+                              .checked=${props.form.deliveryBestEffort}
+                              @change=${(e: Event) =>
+                                props.onFormChange({
+                                  deliveryBestEffort: (e.target as HTMLInputElement).checked,
+                                })}
+                            />
+                            <span class="field-checkbox__label"
+                              >${t("cron.form.bestEffortDelivery")}</span
+                            >
+                            <div class="cron-help">${t("cron.form.bestEffortHelp")}</div>
+                          </label>
+                        `
+                      : nothing}
+                  </div>
+                </details>
+              </div>
+              ${blockedByValidation
+                ? html`
+                    <div
+                      class="cron-form-status"
+                      role="status"
+                      aria-live="polite"
+                      ?hidden=${formCollapsed}
+                    >
+                      <div class="cron-form-status__title">${t("cron.form.cantAddYet")}</div>
+                      <div class="cron-help">${t("cron.form.fillRequired")}</div>
+                      <ul class="cron-form-status__list">
+                        ${blockingFields.map(
+                          (field) => html`
+                            <li>
+                              <button
+                                type="button"
+                                class="cron-form-status__link"
+                                @click=${() => focusFormField(field.inputId)}
+                              >
+                                ${field.label}: ${t(field.message)}
+                              </button>
+                            </li>
+                          `,
+                        )}
+                      </ul>
+                    </div>
                   `
                 : nothing}
-            </div>
-          </details>
-        </div>
-        ${blockedByValidation
-          ? html`
-              <div
-                class="cron-form-status"
-                role="status"
-                aria-live="polite"
-                ?hidden=${formCollapsed}
-              >
-                <div class="cron-form-status__title">${t("cron.form.cantAddYet")}</div>
-                <div class="cron-help">${t("cron.form.fillRequired")}</div>
-                <ul class="cron-form-status__list">
-                  ${blockingFields.map(
-                    (field) => html`
-                      <li>
-                        <button
-                          type="button"
-                          class="cron-form-status__link"
-                          @click=${() => focusFormField(field.inputId)}
-                        >
-                          ${field.label}: ${t(field.message)}
-                        </button>
-                      </li>
-                    `,
-                  )}
-                </ul>
-              </div>
-            `
-          : nothing}
-        <div class="row cron-form-actions" ?hidden=${formCollapsed}>
-          <button
-            class="btn primary"
-            ?disabled=${props.busy || !props.canSubmit}
-            @click=${props.onAdd}
-          >
-            ${props.busy
-              ? t("cron.form.saving")
-              : isEditing
-                ? t("cron.form.saveChanges")
-                : t("cron.form.addJob")}
-          </button>
-          ${submitDisabledReason
-            ? html`
-                <div class="cron-submit-reason" aria-live="polite">${submitDisabledReason}</div>
-              `
-            : nothing}
-          ${isEditing
-            ? html`
-                <button class="btn" ?disabled=${props.busy} @click=${props.onCancelEdit}>
-                  ${t("cron.form.cancel")}
+              <div class="row cron-form-actions" ?hidden=${formCollapsed}>
+                <button
+                  class="btn primary"
+                  ?disabled=${props.busy || !props.canSubmit}
+                  @click=${props.onAdd}
+                >
+                  ${props.busy
+                    ? t("cron.form.saving")
+                    : isEditing
+                      ? t("cron.form.saveChanges")
+                      : t("cron.form.addJob")}
                 </button>
-              `
-            : nothing}
-        </div>
-      </section>
-    </section>
-
+                ${submitDisabledReason
+                  ? html`
+                      <div class="cron-submit-reason" aria-live="polite">
+                        ${submitDisabledReason}
+                      </div>
+                    `
+                  : nothing}
+                ${isEditing
+                  ? html`
+                      <button class="btn" ?disabled=${props.busy} @click=${props.onCancelEdit}>
+                        ${t("cron.form.cancel")}
+                      </button>
+                    `
+                  : nothing}
+              </div>
+            </section>
+          </div>
+        `
+      : nothing}
     ${renderSuggestionList("cron-agent-suggestions", props.agentSuggestions)}
     ${renderSuggestionList("cron-model-suggestions", props.modelSuggestions)}
     ${renderSuggestionList("cron-thinking-suggestions", props.thinkingSuggestions)}


### PR DESCRIPTION
## Summary

- Move settings-only destinations into the Settings workspace and keep Channels out of the main Control sidebar.
- Add recent session shortcuts and a one-click New session action to the sidebar.
- Simplify Cron Jobs with collapsed filters, an empty state, and modal job creation while keeping Advanced job available.
- Speed up scoped settings pages by letting `/communications` render from the config snapshot before the schema refresh and by caching burst schema responses.

## Real behavior proof

Behavior addressed: Control UI sidebar/navigation cleanup, beginner-friendly Cron Jobs creation, and slow `/communications` settings load.
Real environment tested: local dev Control UI at http://127.0.0.1:3002 connected to the local OpenClaw gateway.
Exact steps or command run after this patch: Opened http://127.0.0.1:3002/communications in the browser against the running local gateway and inspected the Control UI performance events after reload.
Evidence after fix: Console output from the real dev browser showed `control-ui.refresh` duration ~902ms and `control-ui.render` duration 134ms for `/communications` with `activeSection:"messages"`; before the patch the same page rendered the heavier Channels settings first and render timing was about 2937ms.
Observed result after fix: `/communications` became usable in about a second in the real dev UI, while Channels remained available as a tab and as the dedicated `/channels` page.
What was not tested: a live authenticated gateway cron add through the real browser session, because the headless browser lacks the local gateway token and hit the login/protocol gate.

## Verification

Exact steps or command run after this patch: OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/gateway/server-methods/config.test.ts ui/src/ui/app-settings.refresh-active-tab.node.test.ts ui/src/ui/views/config.browser.test.ts -- --reporter=verbose --testTimeout=15000
Observed result after fix: gateway config cache tests and UI settings/config tests passed, including the deferred schema rejection regression.
Exact steps or command run after this patch: OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test ui/src/i18n/test/translate.test.ts -- --reporter=verbose --testTimeout=15000
Observed result after fix: UI shard passed, including shipped-locale structural parity for the new cron strings.
Exact steps or command run after this patch: pnpm check:changed in Testbox run tbx_01krszrfxwxwga3q37y67vse26
Observed result after fix: changed gate passed in Testbox.
Exact steps or command run after this patch: git diff --check && node scripts/check-changelog-attributions.mjs
Observed result after fix: whitespace and changelog attribution checks passed.
Exact steps or command run after this patch: /Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --mode branch
Observed result after fix: codex-review clean; no accepted/actionable findings.

<!-- proof refreshed 2026-05-17T04:20Z -->
