### PR TITLE
fix: reuse plugin manifest metadata safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/exec approvals: wait for accepted async approval follow-up runs instead of direct-fallback sending duplicate completions when retries use different nonce keys. Fixes #82711. (#82717) Thanks @udaymanish6.
 - Agents/subagents: mark completed subagent handoffs as ready for parent review so requester agents verify results and continue required follow-up work before reporting done. (#82724) Thanks @100menotu001.
 - QA-Lab: validate Capture saved views loaded from browser storage so malformed local state cannot poison Capture inspector filters or layout controls. (#77722) Thanks @AsaZhou923.
+- Agents/performance: reuse prepared plugin manifest metadata across local CLI turns, model catalog normalization, auth lookups, and tool capability checks, restoring fast pre-provider startup for plugin-heavy installs. Thanks @shakkernerd.
 - CLI/config: add `--dry-run` support to `openclaw config unset`, with `--json` output and allow-exec validation parity with `config set`/`config patch` dry-run handling. (#81895) Thanks @giodl73-repo.
 - Memory-core: retry disabled dreaming cron cleanup until cron is available after startup, so persisted managed dreaming jobs are removed after restart. Fixes #82383. (#82389) Thanks @neeravmakwana.
 - Providers/xAI: keep retired Grok 3, Grok 4 Fast, Grok 4.1 Fast, and Grok Code slugs out of model pickers while preserving compatibility resolution for existing configs.

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -20,6 +20,8 @@ import {
 import { formatErrorMessage } from "../infra/errors.js";
 import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { setCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
+import { loadManifestMetadataSnapshot } from "../plugins/manifest-contract-eligibility.js";
 import {
   isSubagentSessionKey,
   normalizeAgentId,
@@ -36,6 +38,7 @@ import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { sanitizeForLog } from "../terminal/ansi.js";
 import { createTrajectoryRuntimeRecorder } from "../trajectory/runtime.js";
+import { resolveUserPath } from "../utils.js";
 import { resolveMessageChannel } from "../utils/message-channel.js";
 import { resolveAgentRuntimeConfig } from "./agent-runtime-config.js";
 import {
@@ -339,27 +342,6 @@ async function prepareAgentCommandExecution(
     }
   }
   const agentCfg = cfg.agents?.defaults;
-  const configuredModel = resolveConfiguredModelRef({
-    cfg,
-    defaultProvider: DEFAULT_PROVIDER,
-    defaultModel: DEFAULT_MODEL,
-  });
-  const configuredThinkingCatalog = buildConfiguredModelCatalog({ cfg });
-  const thinkingLevelsHint = formatThinkingLevels(
-    configuredModel.provider,
-    configuredModel.model,
-    ", ",
-    configuredThinkingCatalog.length > 0 ? configuredThinkingCatalog : undefined,
-  );
-
-  const thinkOverride = normalizeThinkLevel(opts.thinking);
-  const thinkOnce = normalizeThinkLevel(opts.thinkingOnce);
-  if (opts.thinking && !thinkOverride) {
-    throw new Error(`Invalid thinking level. Use one of: ${thinkingLevelsHint}.`);
-  }
-  if (opts.thinkingOnce && !thinkOnce) {
-    throw new Error(`Invalid one-shot thinking level. Use one of: ${thinkingLevelsHint}.`);
-  }
 
   const verboseOverride = normalizeVerboseLevel(opts.verbose);
   if (opts.verbose && !verboseOverride) {
@@ -414,13 +396,49 @@ async function prepareAgentCommandExecution(
   // Internal callers (for example subagent spawns) may pin workspace inheritance.
   const workspaceDirRaw =
     normalizedSpawned.workspaceDir ?? resolveAgentWorkspaceDir(cfg, sessionAgentId);
+  const workspaceDir = resolveUserPath(workspaceDirRaw);
   const agentDir = resolveAgentDir(cfg, sessionAgentId);
-  const workspace = await ensureAgentWorkspace({
+  const manifestMetadataSnapshot = loadManifestMetadataSnapshot({
+    config: cfg,
+    workspaceDir,
+    env: process.env,
+  });
+  setCurrentPluginMetadataSnapshot(manifestMetadataSnapshot, {
+    config: cfg,
+    env: process.env,
+    workspaceDir,
+  });
+  const manifestPlugins = manifestMetadataSnapshot.plugins;
+  const configuredModel = resolveConfiguredModelRef({
+    cfg,
+    defaultProvider: DEFAULT_PROVIDER,
+    defaultModel: DEFAULT_MODEL,
+    manifestPlugins,
+  });
+  const configuredThinkingCatalog = buildConfiguredModelCatalog({
+    cfg,
+    workspaceDir,
+    manifestPlugins,
+  });
+  const thinkingLevelsHint = formatThinkingLevels(
+    configuredModel.provider,
+    configuredModel.model,
+    ", ",
+    configuredThinkingCatalog.length > 0 ? configuredThinkingCatalog : undefined,
+  );
+  const thinkOverride = normalizeThinkLevel(opts.thinking);
+  const thinkOnce = normalizeThinkLevel(opts.thinkingOnce);
+  if (opts.thinking && !thinkOverride) {
+    throw new Error(`Invalid thinking level. Use one of: ${thinkingLevelsHint}.`);
+  }
+  if (opts.thinkingOnce && !thinkOnce) {
+    throw new Error(`Invalid one-shot thinking level. Use one of: ${thinkingLevelsHint}.`);
+  }
+  await ensureAgentWorkspace({
     dir: workspaceDirRaw,
     ensureBootstrapFiles: !agentCfg?.skipBootstrap,
     skipOptionalBootstrapFiles: agentCfg?.skipOptionalBootstrapFiles,
   });
-  const workspaceDir = workspace.dir;
   const runId = opts.runId?.trim() || sessionId;
   const { getAcpSessionManager } = await loadAcpManagerRuntime();
   const acpManager = getAcpSessionManager();
@@ -460,6 +478,7 @@ async function prepareAgentCommandExecution(
     outboundSession,
     workspaceDir,
     agentDir,
+    manifestPlugins,
     runId,
     acpManager,
     acpResolution,
@@ -499,6 +518,7 @@ async function agentCommandInternal(
     runId,
     acpManager,
     acpResolution,
+    manifestPlugins,
   } = prepared;
   let sessionEntry = prepared.sessionEntry;
 
@@ -750,10 +770,12 @@ async function agentCommandInternal(
     const configuredDefaultRef = resolveDefaultModelForAgent({
       cfg,
       agentId: sessionAgentId,
+      manifestPlugins,
     });
     const { provider: defaultProvider, model: defaultModel } = normalizeModelRef(
       configuredDefaultRef.provider,
       configuredDefaultRef.model,
+      { manifestPlugins },
     );
     let provider = defaultProvider;
     let model = defaultModel;
@@ -786,6 +808,7 @@ async function agentCommandInternal(
       catalog: [],
       defaultProvider,
       defaultModel,
+      manifestPlugins,
     });
 
     if (needsModelCatalog) {
@@ -796,6 +819,7 @@ async function agentCommandInternal(
         defaultProvider,
         defaultModel,
         agentId: sessionAgentId,
+        manifestPlugins,
       });
       allowedModelCatalog = visibilityPolicy.allowedCatalog;
     }
@@ -818,7 +842,9 @@ async function agentCommandInternal(
       const overrideProvider = sessionEntry.providerOverride?.trim() || defaultProvider;
       const overrideModel = sessionEntry.modelOverride?.trim();
       if (overrideModel) {
-        const normalizedOverride = normalizeModelRef(overrideProvider, overrideModel);
+        const normalizedOverride = normalizeModelRef(overrideProvider, overrideModel, {
+          manifestPlugins,
+        });
         const key = modelKey(normalizedOverride.provider, normalizedOverride.model);
         if (!visibilityPolicy.allowsKey(key)) {
           const { updated } = applyModelOverrideToSessionEntry({
@@ -841,7 +867,9 @@ async function agentCommandInternal(
     let storedModelOverride = sessionEntry?.modelOverride?.trim();
     if (storedModelOverride) {
       const candidateProvider = storedProviderOverride || defaultProvider;
-      const normalizedStored = normalizeModelRef(candidateProvider, storedModelOverride);
+      const normalizedStored = normalizeModelRef(candidateProvider, storedModelOverride, {
+        manifestPlugins,
+      });
       const key = modelKey(normalizedStored.provider, normalizedStored.model);
       if (visibilityPolicy.allowsKey(key)) {
         provider = normalizedStored.provider;
@@ -867,10 +895,10 @@ async function agentCommandInternal(
     if (hasExplicitRunOverride) {
       const explicitRef = explicitModelOverride
         ? explicitProviderOverride
-          ? normalizeModelRef(explicitProviderOverride, explicitModelOverride)
-          : parseModelRef(explicitModelOverride, provider)
+          ? normalizeModelRef(explicitProviderOverride, explicitModelOverride, { manifestPlugins })
+          : parseModelRef(explicitModelOverride, provider, { manifestPlugins })
         : explicitProviderOverride
-          ? normalizeModelRef(explicitProviderOverride, model)
+          ? normalizeModelRef(explicitProviderOverride, model, { manifestPlugins })
           : null;
       if (!explicitRef) {
         throw new Error("Invalid model override.");
@@ -1085,6 +1113,7 @@ async function agentCommandInternal(
           cfg,
           provider,
           model,
+          manifestPlugins,
           runId,
           agentDir,
           fallbacksOverride: effectiveFallbacksOverride,
@@ -1276,7 +1305,7 @@ async function agentCommandInternal(
               { cause: err },
             );
           }
-          const switchRef = normalizeModelRef(err.provider, err.model);
+          const switchRef = normalizeModelRef(err.provider, err.model, { manifestPlugins });
           const switchKey = modelKey(switchRef.provider, switchRef.model);
           if (!visibilityPolicy.allowsKey(switchKey)) {
             log.info(

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -20,7 +20,6 @@ import {
 import { formatErrorMessage } from "../infra/errors.js";
 import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { setCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import { loadManifestMetadataSnapshot } from "../plugins/manifest-contract-eligibility.js";
 import {
   isSubagentSessionKey,
@@ -402,11 +401,6 @@ async function prepareAgentCommandExecution(
     config: cfg,
     workspaceDir,
     env: process.env,
-  });
-  setCurrentPluginMetadataSnapshot(manifestMetadataSnapshot, {
-    config: cfg,
-    env: process.env,
-    workspaceDir,
   });
   const manifestPlugins = manifestMetadataSnapshot.plugins;
   const configuredModel = resolveConfiguredModelRef({

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -128,6 +128,23 @@ function modelIdNormalizationSnapshot() {
   };
 }
 
+function configuredModel(id: string) {
+  return {
+    id,
+    name: id,
+    reasoning: false,
+    input: ["text"] as Array<"text">,
+    cost: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+    },
+    contextWindow: 128_000,
+    maxTokens: 8192,
+  };
+}
+
 type ModelCatalogEntry = Awaited<
   ReturnType<typeof import("./model-catalog.js").loadModelCatalog>
 >[number];
@@ -551,8 +568,54 @@ describe("loadModelCatalog", () => {
 
     const result = await loadModelCatalog({ config: {} as OpenClawConfig, readOnly: true });
 
-    expect(requireCatalogEntry(result, "custom", "vendor/model-a").name).toBe("vendor/model-a");
-    expect(requireCatalogEntry(result, "custom", "vendor/model-d").name).toBe("vendor/model-d");
+    expect(requireCatalogEntry(result, "custom", "vendor/model-a").id).toBe("vendor/model-a");
+    expect(requireCatalogEntry(result, "custom", "vendor/model-d").id).toBe("vendor/model-d");
+    expect(loadPluginMetadataSnapshotMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("loads manifest model id policies once for configured read-only catalog rows", async () => {
+    currentPluginMetadataSnapshotMock.mockReturnValue(undefined);
+    loadPluginMetadataSnapshotMock.mockReturnValue(modelIdNormalizationSnapshot());
+
+    const result = await loadModelCatalog({
+      readOnly: true,
+      config: {
+        models: {
+          providers: {
+            custom: {
+              api: "openai-completions",
+              baseUrl: "https://custom.example/v1",
+              models: [
+                configuredModel("model-a"),
+                configuredModel("model-b"),
+                configuredModel("model-c"),
+                configuredModel("model-d"),
+              ],
+            },
+          },
+        },
+      } as OpenClawConfig,
+    });
+
+    expect(requireCatalogEntry(result, "custom", "vendor/model-a").id).toBe("vendor/model-a");
+    expect(requireCatalogEntry(result, "custom", "vendor/model-d").id).toBe("vendor/model-d");
+    expect(loadPluginMetadataSnapshotMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("loads manifest model id policies once for discovered catalog rows", async () => {
+    currentPluginMetadataSnapshotMock.mockReturnValue(undefined);
+    loadPluginMetadataSnapshotMock.mockReturnValue(modelIdNormalizationSnapshot());
+    mockPiDiscoveryModels([
+      { provider: "custom", id: "model-a", name: "Model A" },
+      { provider: "custom", id: "model-b", name: "Model B" },
+      { provider: "custom", id: "model-c", name: "Model C" },
+      { provider: "custom", id: "model-d", name: "Model D" },
+    ]);
+
+    const result = await loadModelCatalog({ config: {} as OpenClawConfig, useCache: false });
+
+    expect(requireCatalogEntry(result, "custom", "vendor/model-a").name).toBe("Model A");
+    expect(requireCatalogEntry(result, "custom", "vendor/model-d").name).toBe("Model D");
     expect(loadPluginMetadataSnapshotMock).toHaveBeenCalledTimes(1);
   });
 

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -23,7 +23,10 @@ import {
   normalizeConfiguredProviderCatalogModelId,
   type ProviderModelIdNormalizationOptions,
 } from "./model-ref-shared.js";
-import { buildConfiguredModelCatalog } from "./model-selection-shared.js";
+import {
+  buildConfiguredModelCatalog,
+  hasConfiguredProviderModelRows,
+} from "./model-selection-shared.js";
 import { ensureOpenClawModelsJson } from "./models-config.js";
 import { normalizeProviderId } from "./provider-id.js";
 
@@ -303,7 +306,10 @@ async function loadReadOnlyPersistedModelCatalog(params?: {
   if (models.length === 0) {
     throw new Error("persisted model catalog has no usable model rows");
   }
-  const configuredModels = buildConfiguredModelCatalog({ cfg });
+  const configuredModels = buildConfiguredModelCatalog({
+    cfg,
+    manifestPlugins: hasConfiguredProviderModelRows(cfg) ? getManifestPlugins() : undefined,
+  });
   if (configuredModels.length > 0) {
     appendCatalogEntriesIfAbsent(models, configuredModels);
   }
@@ -372,6 +378,14 @@ export async function loadModelCatalog(params?: {
     const sortModels = sortModelCatalogEntries;
     try {
       const cfg = params?.config ?? getRuntimeConfig();
+      let manifestPlugins: ProviderModelIdNormalizationOptions["manifestPlugins"];
+      const getManifestPlugins = () => {
+        manifestPlugins ??= loadManifestMetadataSnapshot({
+          config: cfg,
+          env: process.env,
+        }).plugins;
+        return manifestPlugins;
+      };
       if (!readOnly) {
         await ensureOpenClawModelsJson(cfg);
         logStage("models-json-ready");
@@ -411,7 +425,9 @@ export async function loadModelCatalog(params?: {
         if (!provider) {
           continue;
         }
-        const id = normalizeConfiguredProviderCatalogModelId(provider, rawId);
+        const id = normalizeConfiguredProviderCatalogModelId(provider, rawId, {
+          manifestPlugins: getManifestPlugins(),
+        });
         if (shouldSuppressBuiltInModel({ provider, id })) {
           continue;
         }
@@ -454,7 +470,9 @@ export async function loadModelCatalog(params?: {
           for (const entry of supplemental) {
             normalizedSupplemental.push({
               ...entry,
-              id: normalizeConfiguredProviderCatalogModelId(entry.provider, entry.id),
+              id: normalizeConfiguredProviderCatalogModelId(entry.provider, entry.id, {
+                manifestPlugins: getManifestPlugins(),
+              }),
             });
           }
           appendCatalogEntriesIfAbsent(models, normalizedSupplemental);
@@ -462,7 +480,10 @@ export async function loadModelCatalog(params?: {
       }
       logStage("plugin-models-merged", `entries=${models.length}`);
 
-      const configuredModels = buildConfiguredModelCatalog({ cfg });
+      const configuredModels = buildConfiguredModelCatalog({
+        cfg,
+        manifestPlugins: hasConfiguredProviderModelRows(cfg) ? getManifestPlugins() : undefined,
+      });
       if (configuredModels.length > 0) {
         appendCatalogEntriesIfAbsent(models, configuredModels);
       }

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -316,6 +316,17 @@ async function loadReadOnlyPersistedModelCatalog(params?: {
   return sortModelCatalogEntries(models);
 }
 
+function hasConfiguredProviderRowsNeedingManifestLookup(cfg: OpenClawConfig): boolean {
+  const providers = cfg.models?.providers;
+  if (!providers || typeof providers !== "object") {
+    return false;
+  }
+  return Object.entries(providers).some(
+    ([providerRaw, provider]) =>
+      Array.isArray(provider?.models) && normalizeProviderId(providerRaw) !== "openai",
+  );
+}
+
 function loadReadOnlyStaticModelCatalog(params?: { config?: OpenClawConfig }): ModelCatalogEntry[] {
   const cfg = params?.config ?? getRuntimeConfig();
   const models: ModelCatalogEntry[] = [];
@@ -335,7 +346,16 @@ function loadReadOnlyStaticModelCatalog(params?: { config?: OpenClawConfig }): M
     }
   }
 
-  const configuredModels = buildConfiguredModelCatalog({ cfg });
+  const configuredManifestPlugins = hasConfiguredProviderRowsNeedingManifestLookup(cfg)
+    ? loadPluginMetadataSnapshot({
+        config: cfg,
+        env: process.env,
+      }).plugins
+    : [];
+  const configuredModels = buildConfiguredModelCatalog({
+    cfg,
+    manifestPlugins: configuredManifestPlugins,
+  });
   if (configuredModels.length > 0) {
     appendCatalogEntriesIfAbsent(models, configuredModels);
   }

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -6,6 +6,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { emitFailoverEvent } from "../infra/diagnostic-events.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import { isCommandLaneTaskTimeoutError } from "../process/command-queue.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
@@ -92,6 +93,10 @@ type ModelFallbackRunFn<T> = (
   model: string,
   options?: ModelFallbackRunOptions,
 ) => Promise<T>;
+
+type ManifestNormalizationContext = {
+  manifestPlugins?: readonly Pick<PluginManifestRecord, "modelIdNormalization">[];
+};
 
 /**
  * Fallback abort check. Only treats explicit AbortError names as user aborts.
@@ -475,18 +480,22 @@ function resolveFallbackSoonestCooldownExpiry(params: {
   return soonest;
 }
 
-function resolveImageFallbackCandidates(params: {
-  cfg: OpenClawConfig | undefined;
-  defaultProvider: string;
-  modelOverride?: string;
-}): ModelCandidate[] {
+function resolveImageFallbackCandidates(
+  params: {
+    cfg: OpenClawConfig | undefined;
+    defaultProvider: string;
+    modelOverride?: string;
+  } & ManifestNormalizationContext,
+): ModelCandidate[] {
   const aliasIndex = buildModelAliasIndex({
     cfg: params.cfg ?? {},
     defaultProvider: params.defaultProvider,
+    manifestPlugins: params.manifestPlugins,
   });
   const allowlist = buildConfiguredAllowlistKeys({
     cfg: params.cfg,
     defaultProvider: params.defaultProvider,
+    manifestPlugins: params.manifestPlugins,
   });
   const { candidates, addExplicitCandidate, addAllowlistedCandidate } =
     createModelCandidateCollector(allowlist);
@@ -496,6 +505,7 @@ function resolveImageFallbackCandidates(params: {
       raw,
       defaultProvider: params.defaultProvider,
       aliasIndex,
+      manifestPlugins: params.manifestPlugins,
     });
     if (!resolved) {
       return;
@@ -553,43 +563,52 @@ export const __testing = {
   resolveSessionSuspensionReason,
 } as const;
 
-function resolveFallbackCandidates(params: {
-  cfg: OpenClawConfig | undefined;
-  provider: string;
-  model: string;
-  /** Optional explicit fallbacks list; when provided (even empty), replaces agents.defaults.model.fallbacks. */
-  fallbacksOverride?: string[];
-}): ModelCandidate[] {
+function resolveFallbackCandidates(
+  params: {
+    cfg: OpenClawConfig | undefined;
+    provider: string;
+    model: string;
+    /** Optional explicit fallbacks list; when provided (even empty), replaces agents.defaults.model.fallbacks. */
+    fallbacksOverride?: string[];
+  } & ManifestNormalizationContext,
+): ModelCandidate[] {
   const primary = params.cfg
     ? resolveConfiguredModelRef({
         cfg: params.cfg,
         defaultProvider: DEFAULT_PROVIDER,
         defaultModel: DEFAULT_MODEL,
+        manifestPlugins: params.manifestPlugins,
       })
     : null;
   const defaultProvider = primary?.provider ?? DEFAULT_PROVIDER;
   const defaultModel = primary?.model ?? DEFAULT_MODEL;
   const providerRaw = normalizeOptionalString(params.provider) || defaultProvider;
   const modelRaw = normalizeOptionalString(params.model) || defaultModel;
-  const normalizedPrimary = normalizeModelRef(providerRaw, modelRaw);
+  const normalizedPrimary = normalizeModelRef(providerRaw, modelRaw, {
+    manifestPlugins: params.manifestPlugins,
+  });
   const aliasIndex = buildModelAliasIndex({
     cfg: params.cfg ?? {},
     defaultProvider,
+    manifestPlugins: params.manifestPlugins,
   });
   const allowlist = buildConfiguredAllowlistKeys({
     cfg: params.cfg,
     defaultProvider,
+    manifestPlugins: params.manifestPlugins,
   });
   const { candidates, addExplicitCandidate } = createModelCandidateCollector(allowlist);
   const resolvedModelAlias = resolveModelRefFromString({
     raw: modelRaw,
     defaultProvider: providerRaw,
     aliasIndex,
+    manifestPlugins: params.manifestPlugins,
   });
   const resolvedProviderModelAlias = resolveModelRefFromString({
     raw: `${providerRaw}/${modelRaw}`,
     defaultProvider,
     aliasIndex,
+    manifestPlugins: params.manifestPlugins,
   });
   const resolvedBareModelAlias =
     resolvedModelAlias?.alias &&
@@ -601,7 +620,9 @@ function resolveFallbackCandidates(params: {
     (resolvedProviderModelAlias?.alias ? resolvedProviderModelAlias.ref : null) ??
     resolvedBareModelAlias ??
     normalizedPrimary;
-  const effectivePrimary = normalizeModelRef(resolvedPrimary.provider, resolvedPrimary.model);
+  const effectivePrimary = normalizeModelRef(resolvedPrimary.provider, resolvedPrimary.model, {
+    manifestPlugins: params.manifestPlugins,
+  });
 
   addExplicitCandidate(effectivePrimary);
 
@@ -615,6 +636,7 @@ function resolveFallbackCandidates(params: {
       raw,
       defaultProvider,
       aliasIndex,
+      manifestPlugins: params.manifestPlugins,
     });
     if (!resolved) {
       continue;
@@ -814,26 +836,29 @@ function resolveCooldownDecision(params: {
   };
 }
 
-export async function runWithModelFallback<T>(params: {
-  cfg: OpenClawConfig | undefined;
-  provider: string;
-  model: string;
-  runId?: string;
-  sessionId?: string;
-  lane?: string;
-  agentDir?: string;
-  /** Optional explicit fallbacks list; when provided (even empty), replaces agents.defaults.model.fallbacks. */
-  fallbacksOverride?: string[];
-  run: ModelFallbackRunFn<T>;
-  onError?: ModelFallbackErrorHandler;
-  onFallbackStep?: ModelFallbackStepHandler;
-  classifyResult?: ModelFallbackResultClassifier<T>;
-}): Promise<ModelFallbackRunResult<T>> {
+export async function runWithModelFallback<T>(
+  params: {
+    cfg: OpenClawConfig | undefined;
+    provider: string;
+    model: string;
+    runId?: string;
+    sessionId?: string;
+    lane?: string;
+    agentDir?: string;
+    /** Optional explicit fallbacks list; when provided (even empty), replaces agents.defaults.model.fallbacks. */
+    fallbacksOverride?: string[];
+    run: ModelFallbackRunFn<T>;
+    onError?: ModelFallbackErrorHandler;
+    onFallbackStep?: ModelFallbackStepHandler;
+    classifyResult?: ModelFallbackResultClassifier<T>;
+  } & ManifestNormalizationContext,
+): Promise<ModelFallbackRunResult<T>> {
   const candidates = resolveFallbackCandidates({
     cfg: params.cfg,
     provider: params.provider,
     model: params.model,
     fallbacksOverride: params.fallbacksOverride,
+    manifestPlugins: params.manifestPlugins,
   });
   const authRuntime =
     params.cfg && hasAnyAuthProfileStoreSource(params.agentDir)

--- a/src/agents/model-selection-manifest-workspace.test.ts
+++ b/src/agents/model-selection-manifest-workspace.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+
+const loadManifestMetadataSnapshotMock = vi.hoisted(() => vi.fn());
+const getCurrentPluginMetadataSnapshotMock = vi.hoisted(() => vi.fn());
+const getActivePluginRegistryWorkspaceDirFromStateMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../plugins/current-plugin-metadata-snapshot.js", () => ({
+  getCurrentPluginMetadataSnapshot: getCurrentPluginMetadataSnapshotMock,
+}));
+
+vi.mock("../plugins/manifest-contract-eligibility.js", () => ({
+  loadManifestMetadataSnapshot: loadManifestMetadataSnapshotMock,
+}));
+
+vi.mock("../plugins/runtime-state.js", () => ({
+  getActivePluginRegistryWorkspaceDirFromState: getActivePluginRegistryWorkspaceDirFromStateMock,
+}));
+
+vi.mock("./provider-model-normalization.runtime.js", () => ({
+  normalizeProviderModelIdWithRuntime: () => undefined,
+}));
+
+describe("configured model manifest workspace scope", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    loadManifestMetadataSnapshotMock.mockReset();
+    getCurrentPluginMetadataSnapshotMock.mockReset();
+    getActivePluginRegistryWorkspaceDirFromStateMock.mockReset();
+    getCurrentPluginMetadataSnapshotMock.mockReturnValue(undefined);
+    loadManifestMetadataSnapshotMock.mockReturnValue({
+      plugins: [
+        {
+          modelIdNormalization: {
+            providers: {
+              custom: {
+                prefixWhenBare: "workspace-custom",
+              },
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  it("does not reuse workspace manifest policies without a workspace context", async () => {
+    const { buildConfiguredModelCatalog } = await import("./model-selection-shared.js");
+    const cfg = {
+      models: {
+        providers: {
+          custom: {
+            models: [{ id: "fast-model" }],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(buildConfiguredModelCatalog({ cfg })).toMatchObject([
+      {
+        provider: "custom",
+        id: "fast-model",
+      },
+    ]);
+    expect(getCurrentPluginMetadataSnapshotMock).toHaveBeenCalledWith({
+      config: cfg,
+      env: process.env,
+    });
+    expect(loadManifestMetadataSnapshotMock).not.toHaveBeenCalled();
+  });
+
+  it("uses manifest policies when the workspace context is explicit", async () => {
+    const { buildConfiguredModelCatalog } = await import("./model-selection-shared.js");
+    const cfg = {
+      models: {
+        providers: {
+          custom: {
+            models: [{ id: "fast-model" }],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(buildConfiguredModelCatalog({ cfg, workspaceDir: "/workspace/a" })).toMatchObject([
+      {
+        provider: "custom",
+        id: "workspace-custom/fast-model",
+      },
+    ]);
+    expect(loadManifestMetadataSnapshotMock).toHaveBeenCalledWith({
+      config: cfg,
+      workspaceDir: "/workspace/a",
+      env: process.env,
+    });
+    expect(getCurrentPluginMetadataSnapshotMock).not.toHaveBeenCalled();
+  });
+
+  it("uses an unscoped current snapshot without falling back to a metadata scan", async () => {
+    getCurrentPluginMetadataSnapshotMock.mockReturnValue({
+      plugins: [
+        {
+          modelIdNormalization: {
+            providers: {
+              custom: {
+                prefixWhenBare: "global-custom",
+              },
+            },
+          },
+        },
+      ],
+    });
+    const { buildConfiguredModelCatalog } = await import("./model-selection-shared.js");
+    const cfg = {
+      models: {
+        providers: {
+          custom: {
+            models: [{ id: "fast-model" }],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(buildConfiguredModelCatalog({ cfg })).toMatchObject([
+      {
+        provider: "custom",
+        id: "global-custom/fast-model",
+      },
+    ]);
+    expect(loadManifestMetadataSnapshotMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/model-selection-resolve.ts
+++ b/src/agents/model-selection-resolve.ts
@@ -1,5 +1,6 @@
 import { resolveAgentModelFallbackValues } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import type { ModelCatalogEntry } from "./model-catalog.types.js";
 import type { ModelRef } from "./model-selection-normalize.js";
 import {
@@ -19,18 +20,24 @@ export {
 } from "./model-selection-shared.js";
 export type { ModelRefStatus } from "./model-selection-shared.js";
 
+type ManifestNormalizationContext = {
+  manifestPlugins?: readonly Pick<PluginManifestRecord, "modelIdNormalization">[];
+};
+
 function resolveDefaultFallbackModels(cfg: OpenClawConfig): string[] {
   return resolveAgentModelFallbackValues(cfg.agents?.defaults?.model);
 }
 
-export function getModelRefStatus(params: {
-  cfg: OpenClawConfig;
-  catalog: ModelCatalogEntry[];
-  ref: ModelRef;
-  defaultProvider: string;
-  defaultModel?: string;
-}): ModelRefStatus {
-  const { cfg, catalog, ref, defaultProvider, defaultModel } = params;
+export function getModelRefStatus(
+  params: {
+    cfg: OpenClawConfig;
+    catalog: ModelCatalogEntry[];
+    ref: ModelRef;
+    defaultProvider: string;
+    defaultModel?: string;
+  } & ManifestNormalizationContext,
+): ModelRefStatus {
+  const { cfg, catalog, ref, defaultProvider, defaultModel, manifestPlugins } = params;
   return getModelRefStatusWithFallbackModels({
     cfg,
     catalog,
@@ -38,16 +45,19 @@ export function getModelRefStatus(params: {
     defaultProvider,
     defaultModel,
     fallbackModels: resolveDefaultFallbackModels(cfg),
+    manifestPlugins,
   });
 }
 
-export function resolveAllowedModelRef(params: {
-  cfg: OpenClawConfig;
-  catalog: ModelCatalogEntry[];
-  raw: string;
-  defaultProvider: string;
-  defaultModel?: string;
-}):
+export function resolveAllowedModelRef(
+  params: {
+    cfg: OpenClawConfig;
+    catalog: ModelCatalogEntry[];
+    raw: string;
+    defaultProvider: string;
+    defaultModel?: string;
+  } & ManifestNormalizationContext,
+):
   | { ref: ModelRef; key: string }
   | {
       error: string;
@@ -55,12 +65,14 @@ export function resolveAllowedModelRef(params: {
   const aliasIndex = buildModelAliasIndex({
     cfg: params.cfg,
     defaultProvider: params.defaultProvider,
+    manifestPlugins: params.manifestPlugins,
   });
   return resolveAllowedModelRefFromAliasIndex({
     cfg: params.cfg,
     raw: params.raw,
     defaultProvider: params.defaultProvider,
     aliasIndex,
+    manifestPlugins: params.manifestPlugins,
     getStatus: (ref) =>
       getModelRefStatus({
         cfg: params.cfg,
@@ -68,6 +80,7 @@ export function resolveAllowedModelRef(params: {
         ref,
         defaultProvider: params.defaultProvider,
         defaultModel: params.defaultModel,
+        manifestPlugins: params.manifestPlugins,
       }),
   });
 }

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -1,7 +1,9 @@
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { loadManifestMetadataSnapshot } from "../plugins/manifest-contract-eligibility.js";
 import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
+import { getActivePluginRegistryWorkspaceDirFromState } from "../plugins/runtime-state.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -76,10 +78,12 @@ function mergeModelCatalogEntries(params: {
   return merged;
 }
 
-export function inferUniqueProviderFromConfiguredModels(params: {
-  cfg: OpenClawConfig;
-  model: string;
-}): string | undefined {
+export function inferUniqueProviderFromConfiguredModels(
+  params: {
+    cfg: OpenClawConfig;
+    model: string;
+  } & ManifestNormalizationContext,
+): string | undefined {
   const model = params.model.trim();
   if (!model) {
     return undefined;
@@ -126,7 +130,9 @@ export function inferUniqueProviderFromConfiguredModels(params: {
         if (!modelId) {
           continue;
         }
-        const normalizedModelId = normalizeConfiguredProviderCatalogModelId(providerId, modelId);
+        const normalizedModelId = normalizeConfiguredProviderCatalogModelId(providerId, modelId, {
+          manifestPlugins: params.manifestPlugins,
+        });
         if (
           normalizedModelId === model ||
           normalizeLowercaseStringOrEmpty(normalizedModelId) === normalized
@@ -174,14 +180,20 @@ export function inferUniqueProviderFromCatalog(params: {
   return providers.size === 1 ? providers.values().next().value : undefined;
 }
 
-export function resolveBareModelDefaultProvider(params: {
-  cfg: OpenClawConfig;
-  catalog: readonly ModelCatalogEntry[];
-  model: string;
-  defaultProvider: string;
-}): string {
+export function resolveBareModelDefaultProvider(
+  params: {
+    cfg: OpenClawConfig;
+    catalog: readonly ModelCatalogEntry[];
+    model: string;
+    defaultProvider: string;
+  } & ManifestNormalizationContext,
+): string {
   return (
-    inferUniqueProviderFromConfiguredModels({ cfg: params.cfg, model: params.model }) ??
+    inferUniqueProviderFromConfiguredModels({
+      cfg: params.cfg,
+      model: params.model,
+      manifestPlugins: params.manifestPlugins,
+    }) ??
     inferUniqueProviderFromCatalog({ catalog: params.catalog, model: params.model }) ??
     params.defaultProvider
   );
@@ -322,19 +334,26 @@ function resolveExactConfiguredProviderRef(
         allowManifestNormalization: params.allowManifestNormalization,
         manifestPlugins: params.manifestPlugins,
       }),
+      {
+        allowManifestNormalization: params.allowManifestNormalization,
+        manifestPlugins: params.manifestPlugins,
+      },
     ),
   };
 }
 
-export function resolveAllowlistModelKey(params: {
-  cfg?: OpenClawConfig;
-  raw: string;
-  defaultProvider: string;
-}): string | null {
+export function resolveAllowlistModelKey(
+  params: {
+    cfg?: OpenClawConfig;
+    raw: string;
+    defaultProvider: string;
+  } & ManifestNormalizationContext,
+): string | null {
   const parsed = parseModelRefWithCompatAlias({
     cfg: params.cfg,
     raw: params.raw,
     defaultProvider: params.defaultProvider,
+    manifestPlugins: params.manifestPlugins,
   });
   if (!parsed) {
     return null;
@@ -342,10 +361,12 @@ export function resolveAllowlistModelKey(params: {
   return modelKey(parsed.provider, parsed.model);
 }
 
-export function buildConfiguredAllowlistKeys(params: {
-  cfg: OpenClawConfig | undefined;
-  defaultProvider: string;
-}): Set<string> | null {
+export function buildConfiguredAllowlistKeys(
+  params: {
+    cfg: OpenClawConfig | undefined;
+    defaultProvider: string;
+  } & ManifestNormalizationContext,
+): Set<string> | null {
   const visibility = parseConfiguredModelVisibilityEntries({ cfg: params.cfg });
   if (visibility.exactModelRefs.length === 0) {
     return null;
@@ -357,6 +378,7 @@ export function buildConfiguredAllowlistKeys(params: {
       cfg: params.cfg,
       raw,
       defaultProvider: params.defaultProvider,
+      manifestPlugins: params.manifestPlugins,
     });
     if (key) {
       keys.add(key);
@@ -414,12 +436,17 @@ type ModelCatalogMetadata = {
   aliasByKey: Map<string, string>;
 };
 
-function buildModelCatalogMetadata(params: {
-  cfg: OpenClawConfig;
-  defaultProvider: string;
-}): ModelCatalogMetadata {
+function buildModelCatalogMetadata(
+  params: {
+    cfg: OpenClawConfig;
+    defaultProvider: string;
+  } & ManifestNormalizationContext,
+): ModelCatalogMetadata {
   const configuredByKey = new Map<string, ModelCatalogEntry>();
-  for (const entry of buildConfiguredModelCatalog({ cfg: params.cfg })) {
+  for (const entry of buildConfiguredModelCatalog({
+    cfg: params.cfg,
+    manifestPlugins: params.manifestPlugins,
+  })) {
     configuredByKey.set(modelKey(entry.provider, entry.id), entry);
   }
 
@@ -430,6 +457,7 @@ function buildModelCatalogMetadata(params: {
       cfg: params.cfg,
       raw: rawKey,
       defaultProvider: params.defaultProvider,
+      manifestPlugins: params.manifestPlugins,
     });
     if (!key) {
       continue;
@@ -532,13 +560,15 @@ export function resolveModelRefFromString(
   return { ref: parsed };
 }
 
-export function resolveConfiguredModelRef(params: {
-  cfg: OpenClawConfig;
-  defaultProvider: string;
-  defaultModel: string;
-  allowManifestNormalization?: boolean;
-  allowPluginNormalization?: boolean;
-}): ModelRef {
+export function resolveConfiguredModelRef(
+  params: {
+    cfg: OpenClawConfig;
+    defaultProvider: string;
+    defaultModel: string;
+    allowManifestNormalization?: boolean;
+    allowPluginNormalization?: boolean;
+  } & ManifestNormalizationContext,
+): ModelRef {
   const rawModel = resolveAgentModelPrimaryValue(params.cfg.agents?.defaults?.model) ?? "";
   if (rawModel) {
     const trimmed = rawModel.trim();
@@ -547,6 +577,7 @@ export function resolveConfiguredModelRef(params: {
       defaultProvider: params.defaultProvider,
       allowManifestNormalization: params.allowManifestNormalization,
       allowPluginNormalization: params.allowPluginNormalization,
+      manifestPlugins: params.manifestPlugins,
     });
     const aliasKey = normalizeLowercaseStringOrEmpty(trimmed);
     const aliasMatch = aliasIndex.byAlias.get(aliasKey);
@@ -561,6 +592,7 @@ export function resolveConfiguredModelRef(params: {
         defaultProvider: params.defaultProvider,
         allowManifestNormalization: params.allowManifestNormalization,
         allowPluginNormalization: params.allowPluginNormalization,
+        manifestPlugins: params.manifestPlugins,
       });
       if (openrouterCompatRef) {
         return openrouterCompatRef;
@@ -569,6 +601,7 @@ export function resolveConfiguredModelRef(params: {
       const inferredProvider = inferUniqueProviderFromConfiguredModels({
         cfg: params.cfg,
         model: trimmed,
+        manifestPlugins: params.manifestPlugins,
       });
       if (inferredProvider) {
         return { provider: inferredProvider, model: trimmed };
@@ -589,6 +622,7 @@ export function resolveConfiguredModelRef(params: {
       aliasIndex,
       allowManifestNormalization: params.allowManifestNormalization,
       allowPluginNormalization: params.allowPluginNormalization,
+      manifestPlugins: params.manifestPlugins,
     });
     if (resolved) {
       return resolved.ref;
@@ -610,13 +644,17 @@ export function resolveConfiguredModelRef(params: {
   return { provider: params.defaultProvider, model: params.defaultModel };
 }
 
-export function buildAllowedModelSetWithFallbacks(params: {
-  cfg: OpenClawConfig;
-  catalog: ModelCatalogEntry[];
-  defaultProvider: string;
-  defaultModel?: string;
-  fallbackModels: readonly string[];
-}): {
+export function buildAllowedModelSetWithFallbacks(
+  params: {
+    cfg: OpenClawConfig;
+    catalog: ModelCatalogEntry[];
+    defaultProvider: string;
+    defaultModel?: string;
+    fallbackModels: readonly string[];
+    allowManifestNormalization?: boolean;
+    allowPluginNormalization?: boolean;
+  } & ManifestNormalizationContext,
+): {
   allowAny: boolean;
   allowedCatalog: ModelCatalogEntry[];
   allowedKeys: Set<string>;
@@ -624,8 +662,12 @@ export function buildAllowedModelSetWithFallbacks(params: {
   const metadata = buildModelCatalogMetadata({
     cfg: params.cfg,
     defaultProvider: params.defaultProvider,
+    manifestPlugins: params.manifestPlugins,
   });
-  const configuredCatalog = buildConfiguredModelCatalog({ cfg: params.cfg });
+  const configuredCatalog = buildConfiguredModelCatalog({
+    cfg: params.cfg,
+    manifestPlugins: params.manifestPlugins,
+  });
   const catalog = mergeModelCatalogEntries({
     primary: params.catalog,
     secondary: configuredCatalog,
@@ -639,6 +681,9 @@ export function buildAllowedModelSetWithFallbacks(params: {
           cfg: params.cfg,
           raw: defaultModel,
           defaultProvider: params.defaultProvider,
+          allowManifestNormalization: params.allowManifestNormalization,
+          allowPluginNormalization: params.allowPluginNormalization,
+          manifestPlugins: params.manifestPlugins,
         })
       : null;
   const defaultKey = defaultRef ? modelKey(defaultRef.provider, defaultRef.model) : undefined;
@@ -689,12 +734,16 @@ export function buildAllowedModelSetWithFallbacks(params: {
           catalog,
           model: trimmed,
           defaultProvider: params.defaultProvider,
+          manifestPlugins: params.manifestPlugins,
         })
       : params.defaultProvider;
     const parsed = parseModelRefWithCompatAlias({
       cfg: params.cfg,
       raw,
       defaultProvider,
+      allowManifestNormalization: params.allowManifestNormalization,
+      allowPluginNormalization: params.allowPluginNormalization,
+      manifestPlugins: params.manifestPlugins,
     });
     if (!parsed) {
       return;
@@ -795,20 +844,23 @@ function getModelRefStatusFromAllowedSet(params: {
   };
 }
 
-export function getModelRefStatusWithFallbackModels(params: {
-  cfg: OpenClawConfig;
-  catalog: ModelCatalogEntry[];
-  ref: ModelRef;
-  defaultProvider: string;
-  defaultModel?: string;
-  fallbackModels: readonly string[];
-}): ModelRefStatus {
+export function getModelRefStatusWithFallbackModels(
+  params: {
+    cfg: OpenClawConfig;
+    catalog: ModelCatalogEntry[];
+    ref: ModelRef;
+    defaultProvider: string;
+    defaultModel?: string;
+    fallbackModels: readonly string[];
+  } & ManifestNormalizationContext,
+): ModelRefStatus {
   const allowed = buildAllowedModelSetWithFallbacks({
     cfg: params.cfg,
     catalog: params.catalog,
     defaultProvider: params.defaultProvider,
     defaultModel: params.defaultModel,
     fallbackModels: params.fallbackModels,
+    manifestPlugins: params.manifestPlugins,
   });
   return getModelRefStatusFromAllowedSet({
     catalog: params.catalog,
@@ -817,21 +869,26 @@ export function getModelRefStatusWithFallbackModels(params: {
   });
 }
 
-export function resolveAllowedModelRefFromAliasIndex(params: {
-  cfg: OpenClawConfig;
-  raw: string;
-  defaultProvider: string;
-  aliasIndex: ModelAliasIndex;
-  getStatus: (ref: ModelRef) => ModelRefStatus;
-}): ResolveAllowedModelRefResult {
+export function resolveAllowedModelRefFromAliasIndex(
+  params: {
+    cfg: OpenClawConfig;
+    raw: string;
+    defaultProvider: string;
+    aliasIndex: ModelAliasIndex;
+    getStatus: (ref: ModelRef) => ModelRefStatus;
+  } & ManifestNormalizationContext,
+): ResolveAllowedModelRefResult {
   const trimmed = params.raw.trim();
   if (!trimmed) {
     return { error: "invalid model: empty" };
   }
 
   const effectiveDefaultProvider = !trimmed.includes("/")
-    ? (inferUniqueProviderFromConfiguredModels({ cfg: params.cfg, model: trimmed }) ??
-      params.defaultProvider)
+    ? (inferUniqueProviderFromConfiguredModels({
+        cfg: params.cfg,
+        model: trimmed,
+        manifestPlugins: params.manifestPlugins,
+      }) ?? params.defaultProvider)
     : params.defaultProvider;
 
   const resolved = resolveModelRefFromString({
@@ -839,6 +896,7 @@ export function resolveAllowedModelRefFromAliasIndex(params: {
     raw: trimmed,
     defaultProvider: effectiveDefaultProvider,
     aliasIndex: params.aliasIndex,
+    manifestPlugins: params.manifestPlugins,
   });
   if (!resolved) {
     return { error: `invalid model: ${trimmed}` };
@@ -852,12 +910,44 @@ export function resolveAllowedModelRefFromAliasIndex(params: {
   return { ref: resolved.ref, key: status.key };
 }
 
-export function buildConfiguredModelCatalog(params: { cfg: OpenClawConfig }): ModelCatalogEntry[] {
+export function hasConfiguredProviderModelRows(cfg: OpenClawConfig): boolean {
+  const providers = cfg.models?.providers;
+  if (!providers || typeof providers !== "object") {
+    return false;
+  }
+  return Object.values(providers).some((provider) => Array.isArray(provider?.models));
+}
+
+function resolveConfiguredModelManifestPlugins(params: {
+  cfg: OpenClawConfig;
+  workspaceDir?: string;
+  manifestPlugins?: readonly Pick<PluginManifestRecord, "modelIdNormalization">[];
+}): readonly Pick<PluginManifestRecord, "modelIdNormalization">[] | undefined {
+  if (params.manifestPlugins) {
+    return params.manifestPlugins;
+  }
+  if (!hasConfiguredProviderModelRows(params.cfg)) {
+    return undefined;
+  }
+  const workspaceDir = params.workspaceDir ?? getActivePluginRegistryWorkspaceDirFromState();
+  return loadManifestMetadataSnapshot({
+    config: params.cfg,
+    ...(workspaceDir ? { workspaceDir } : {}),
+    env: process.env,
+  }).plugins;
+}
+
+export function buildConfiguredModelCatalog(params: {
+  cfg: OpenClawConfig;
+  workspaceDir?: string;
+  manifestPlugins?: readonly Pick<PluginManifestRecord, "modelIdNormalization">[];
+}): ModelCatalogEntry[] {
   const providers = params.cfg.models?.providers;
   if (!providers || typeof providers !== "object") {
     return [];
   }
 
+  const manifestPlugins = resolveConfiguredModelManifestPlugins(params);
   const catalog: ModelCatalogEntry[] = [];
   for (const [providerRaw, provider] of Object.entries(providers)) {
     const providerId = normalizeProviderId(providerRaw);
@@ -866,7 +956,9 @@ export function buildConfiguredModelCatalog(params: { cfg: OpenClawConfig }): Mo
     }
     for (const model of provider.models) {
       const rawId = normalizeOptionalString(model?.id) ?? "";
-      const id = rawId ? normalizeConfiguredProviderCatalogModelId(providerId, rawId) : "";
+      const id = rawId
+        ? normalizeConfiguredProviderCatalogModelId(providerId, rawId, { manifestPlugins })
+        : "";
       if (!id) {
         continue;
       }
@@ -898,10 +990,12 @@ export function buildConfiguredModelCatalog(params: { cfg: OpenClawConfig }): Mo
   return catalog;
 }
 
-export function resolveHooksGmailModel(params: {
-  cfg: OpenClawConfig;
-  defaultProvider: string;
-}): ModelRef | null {
+export function resolveHooksGmailModel(
+  params: {
+    cfg: OpenClawConfig;
+    defaultProvider: string;
+  } & ManifestNormalizationContext,
+): ModelRef | null {
   const hooksModel = params.cfg.hooks?.gmail?.model;
   if (!hooksModel?.trim()) {
     return null;
@@ -910,6 +1004,7 @@ export function resolveHooksGmailModel(params: {
   const aliasIndex = buildModelAliasIndex({
     cfg: params.cfg,
     defaultProvider: params.defaultProvider,
+    manifestPlugins: params.manifestPlugins,
   });
 
   const resolved = resolveModelRefFromString({
@@ -917,6 +1012,7 @@ export function resolveHooksGmailModel(params: {
     raw: hooksModel,
     defaultProvider: params.defaultProvider,
     aliasIndex,
+    manifestPlugins: params.manifestPlugins,
   });
 
   return resolved?.ref ?? null;
@@ -983,14 +1079,18 @@ export function isModelKeyAllowedBySet(allowedKeys: ReadonlySet<string>, key: st
   return allowedKeys.has(providerWildcardModelKey(key.slice(0, separator)));
 }
 
-export function resolveAllowedModelSelection(params: {
-  provider: string;
-  model: string;
-  allowAny: boolean;
-  allowedKeys: ReadonlySet<string>;
-  allowedCatalog: readonly ModelCatalogEntry[];
-}): ModelRef | null {
-  const current = normalizeModelRef(params.provider, params.model);
+export function resolveAllowedModelSelection(
+  params: {
+    provider: string;
+    model: string;
+    allowAny: boolean;
+    allowedKeys: ReadonlySet<string>;
+    allowedCatalog: readonly ModelCatalogEntry[];
+  } & ManifestNormalizationContext,
+): ModelRef | null {
+  const current = normalizeModelRef(params.provider, params.model, {
+    manifestPlugins: params.manifestPlugins,
+  });
   if (
     params.allowAny ||
     isModelKeyAllowedBySet(params.allowedKeys, modelKey(current.provider, current.model))
@@ -1001,7 +1101,9 @@ export function resolveAllowedModelSelection(params: {
   if (!fallback) {
     return null;
   }
-  return normalizeModelRef(fallback.provider, fallback.id);
+  return normalizeModelRef(fallback.provider, fallback.id, {
+    manifestPlugins: params.manifestPlugins,
+  });
 }
 
 export type ModelVisibilityPolicy = {
@@ -1036,13 +1138,15 @@ function dedupeModelCatalogEntries(entries: readonly ModelCatalogEntry[]): Model
   return next;
 }
 
-export function createModelVisibilityPolicyWithFallbacks(params: {
-  cfg: OpenClawConfig;
-  catalog: ModelCatalogEntry[];
-  defaultProvider: string;
-  defaultModel?: string;
-  fallbackModels: readonly string[];
-}): ModelVisibilityPolicy {
+export function createModelVisibilityPolicyWithFallbacks(
+  params: {
+    cfg: OpenClawConfig;
+    catalog: ModelCatalogEntry[];
+    defaultProvider: string;
+    defaultModel?: string;
+    fallbackModels: readonly string[];
+  } & ManifestNormalizationContext,
+): ModelVisibilityPolicy {
   const visibility = parseConfiguredModelVisibilityEntries({ cfg: params.cfg });
   const allowed = buildAllowedModelSetWithFallbacks(params);
   const allowsKey = (key: string): boolean =>
@@ -1053,6 +1157,7 @@ export function createModelVisibilityPolicyWithFallbacks(params: {
       cfg: params.cfg,
       raw,
       defaultProvider: params.defaultProvider,
+      manifestPlugins: params.manifestPlugins,
     });
     if (key) {
       exactConfiguredKeys.add(key);
@@ -1075,6 +1180,7 @@ export function createModelVisibilityPolicyWithFallbacks(params: {
         allowAny: allowed.allowAny,
         allowedKeys: allowed.allowedKeys,
         allowedCatalog: allowed.allowedCatalog,
+        manifestPlugins: params.manifestPlugins,
       }),
     visibleCatalog: ({ catalog, defaultVisibleCatalog, view }) => {
       if (view === "all") {

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -1,6 +1,7 @@
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { getCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import { loadManifestMetadataSnapshot } from "../plugins/manifest-contract-eligibility.js";
 import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import { getActivePluginRegistryWorkspaceDirFromState } from "../plugins/runtime-state.js";
@@ -934,9 +935,17 @@ function resolveConfiguredModelManifestPlugins(params: {
     return undefined;
   }
   const workspaceDir = params.workspaceDir ?? getActivePluginRegistryWorkspaceDirFromState();
+  if (!workspaceDir) {
+    return (
+      getCurrentPluginMetadataSnapshot({
+        config: params.cfg,
+        env: process.env,
+      })?.plugins ?? []
+    );
+  }
   return loadManifestMetadataSnapshot({
     config: params.cfg,
-    ...(workspaceDir ? { workspaceDir } : {}),
+    workspaceDir,
     env: process.env,
   }).plugins;
 }

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -134,6 +134,8 @@ export function inferUniqueProviderFromConfiguredModels(
           manifestPlugins: params.manifestPlugins,
         });
         if (
+          modelId === model ||
+          normalizeLowercaseStringOrEmpty(modelId) === normalized ||
           normalizedModelId === model ||
           normalizeLowercaseStringOrEmpty(normalizedModelId) === normalized
         ) {
@@ -604,7 +606,9 @@ export function resolveConfiguredModelRef(
         manifestPlugins: params.manifestPlugins,
       });
       if (inferredProvider) {
-        return { provider: inferredProvider, model: trimmed };
+        return normalizeModelRef(inferredProvider, trimmed, {
+          manifestPlugins: params.manifestPlugins,
+        });
       }
 
       const safeTrimmed = sanitizeModelWarningValue(trimmed);

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -695,6 +695,25 @@ describe("model-selection", () => {
       ).toBe("qwen-dashscope");
     });
 
+    it("infers provider from raw configured ids when manifest policies add prefixes", () => {
+      const cfg = {
+        models: {
+          providers: {
+            nvidia: {
+              models: [{ id: "llama-fast" }],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+
+      expect(
+        inferUniqueProviderFromConfiguredModels({
+          cfg,
+          model: "llama-fast",
+        }),
+      ).toBe("nvidia");
+    });
+
     it("infers Google provider from canonicalized configured provider catalogs", () => {
       const cfg = {
         models: {
@@ -1653,6 +1672,34 @@ describe("model-selection", () => {
         setLoggerOverride(null);
         resetLogger();
       }
+    });
+
+    it("normalizes bare configured default model strings with manifest policies", () => {
+      const cfg = {
+        agents: {
+          defaults: {
+            model: { primary: "llama-fast" },
+          },
+        },
+        models: {
+          providers: {
+            nvidia: {
+              models: [{ id: "llama-fast" }],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+
+      const result = resolveConfiguredModelRef({
+        cfg,
+        defaultProvider: "openai",
+        defaultModel: "gpt-5.4",
+      });
+
+      expect(result).toEqual({
+        provider: "nvidia",
+        model: "nvidia/llama-fast",
+      });
     });
 
     it("prefers slash-form aliases for configured default models", () => {

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -4,6 +4,7 @@ import {
   toAgentModelListLike,
 } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -53,6 +54,10 @@ import {
 } from "./model-selection-shared.js";
 
 export type { ModelAliasIndex, ModelRef, ModelRefStatus };
+
+type ManifestNormalizationContext = {
+  manifestPlugins?: readonly Pick<PluginManifestRecord, "modelIdNormalization">[];
+};
 
 export type ThinkLevel =
   | "off"
@@ -205,15 +210,18 @@ export function resolveAllowlistModelKey(
   raw: string,
   defaultProvider: string,
   cfg?: OpenClawConfig,
+  manifestPlugins?: readonly Pick<PluginManifestRecord, "modelIdNormalization">[],
 ): string | null {
-  return resolveAllowlistModelKeyFromShared({ cfg, raw, defaultProvider });
+  return resolveAllowlistModelKeyFromShared({ cfg, raw, defaultProvider, manifestPlugins });
 }
 
-export function resolveDefaultModelForAgent(params: {
-  cfg: OpenClawConfig;
-  agentId?: string;
-  allowPluginNormalization?: boolean;
-}): ModelRef {
+export function resolveDefaultModelForAgent(
+  params: {
+    cfg: OpenClawConfig;
+    agentId?: string;
+    allowPluginNormalization?: boolean;
+  } & ManifestNormalizationContext,
+): ModelRef {
   const agentModelOverride = params.agentId
     ? resolveAgentEffectiveModelPrimary(params.cfg, params.agentId)
     : undefined;
@@ -238,6 +246,7 @@ export function resolveDefaultModelForAgent(params: {
     defaultProvider: DEFAULT_PROVIDER,
     defaultModel: DEFAULT_MODEL,
     allowPluginNormalization: params.allowPluginNormalization,
+    manifestPlugins: params.manifestPlugins,
   });
 }
 
@@ -371,13 +380,15 @@ export function resolveSubagentSpawnModelSelection(params: {
   return resolveModelThroughAliases(raw, aliasIndex);
 }
 
-export function buildAllowedModelSet(params: {
-  cfg: OpenClawConfig;
-  catalog: ModelCatalogEntry[];
-  defaultProvider: string;
-  defaultModel?: string;
-  agentId?: string;
-}): {
+export function buildAllowedModelSet(
+  params: {
+    cfg: OpenClawConfig;
+    catalog: ModelCatalogEntry[];
+    defaultProvider: string;
+    defaultModel?: string;
+    agentId?: string;
+  } & ManifestNormalizationContext,
+): {
   allowAny: boolean;
   allowedCatalog: ModelCatalogEntry[];
   allowedKeys: Set<string>;
@@ -391,16 +402,19 @@ export function buildAllowedModelSet(params: {
       cfg: params.cfg,
       agentId: params.agentId,
     }),
+    manifestPlugins: params.manifestPlugins,
   });
 }
 
-export function getModelRefStatus(params: {
-  cfg: OpenClawConfig;
-  catalog: ModelCatalogEntry[];
-  ref: ModelRef;
-  defaultProvider: string;
-  defaultModel?: string;
-}): ModelRefStatus {
+export function getModelRefStatus(
+  params: {
+    cfg: OpenClawConfig;
+    catalog: ModelCatalogEntry[];
+    ref: ModelRef;
+    defaultProvider: string;
+    defaultModel?: string;
+  } & ManifestNormalizationContext,
+): ModelRefStatus {
   return getModelRefStatusWithFallbackModels({
     cfg: params.cfg,
     catalog: params.catalog,
@@ -410,6 +424,7 @@ export function getModelRefStatus(params: {
     fallbackModels: resolveAllowedFallbacks({
       cfg: params.cfg,
     }),
+    manifestPlugins: params.manifestPlugins,
   });
 }
 
@@ -419,7 +434,7 @@ function getModelRefStatusForResolve(
     catalog: ModelCatalogEntry[];
     defaultProvider: string;
     defaultModel?: string;
-  },
+  } & ManifestNormalizationContext,
   ref: ModelRef,
 ): ModelRefStatus {
   return getModelRefStatus({
@@ -428,16 +443,19 @@ function getModelRefStatusForResolve(
     ref,
     defaultProvider: params.defaultProvider,
     defaultModel: params.defaultModel,
+    manifestPlugins: params.manifestPlugins,
   });
 }
 
-export function resolveAllowedModelRef(params: {
-  cfg: OpenClawConfig;
-  catalog: ModelCatalogEntry[];
-  raw: string;
-  defaultProvider: string;
-  defaultModel?: string;
-}):
+export function resolveAllowedModelRef(
+  params: {
+    cfg: OpenClawConfig;
+    catalog: ModelCatalogEntry[];
+    raw: string;
+    defaultProvider: string;
+    defaultModel?: string;
+  } & ManifestNormalizationContext,
+):
   | { ref: ModelRef; key: string }
   | {
       error: string;
@@ -450,12 +468,14 @@ export function resolveAllowedModelRef(params: {
   const aliasIndex = buildModelAliasIndex({
     cfg: params.cfg,
     defaultProvider: params.defaultProvider,
+    manifestPlugins: params.manifestPlugins,
   });
 
   const openrouterCompatRef = resolveConfiguredOpenRouterCompatAlias({
     cfg: params.cfg,
     raw: trimmed,
     defaultProvider: params.defaultProvider,
+    manifestPlugins: params.manifestPlugins,
   });
   if (openrouterCompatRef) {
     const status = getModelRefStatusForResolve(params, openrouterCompatRef);
@@ -470,6 +490,7 @@ export function resolveAllowedModelRef(params: {
     raw: params.raw,
     defaultProvider: params.defaultProvider,
     aliasIndex,
+    manifestPlugins: params.manifestPlugins,
     getStatus: (ref) => getModelRefStatusForResolve(params, ref),
   });
 }

--- a/src/agents/model-visibility-policy.ts
+++ b/src/agents/model-visibility-policy.ts
@@ -1,5 +1,6 @@
 import { resolveAgentModelFallbackValues } from "../config/model-input.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import { resolveAgentModelFallbacksOverride } from "./agent-scope.js";
 import type { ModelCatalogEntry } from "./model-catalog.types.js";
 import {
@@ -23,6 +24,7 @@ export function createModelVisibilityPolicy(params: {
   defaultProvider: string;
   defaultModel?: string;
   agentId?: string;
+  manifestPlugins?: readonly Pick<PluginManifestRecord, "modelIdNormalization">[];
 }): ModelVisibilityPolicy {
   return createModelVisibilityPolicyWithFallbacks({
     cfg: params.cfg,
@@ -33,6 +35,7 @@ export function createModelVisibilityPolicy(params: {
       cfg: params.cfg,
       agentId: params.agentId,
     }),
+    manifestPlugins: params.manifestPlugins,
   });
 }
 

--- a/src/agents/openclaw-tools.media-factory-plan.test.ts
+++ b/src/agents/openclaw-tools.media-factory-plan.test.ts
@@ -204,6 +204,36 @@ describe("optional media tool factory planning", () => {
     });
   });
 
+  it("does not plan media factories from workspace-scoped metadata without workspace context", () => {
+    const config: OpenClawConfig = {};
+    installSnapshot(
+      config,
+      [
+        createPlugin({
+          id: "image-owner",
+          contracts: { imageGenerationProviders: ["image-owner"] },
+          setupProviders: [{ id: "image-owner", envVars: ["IMAGE_OWNER_API_KEY"] }],
+        }),
+      ],
+      undefined,
+      "/workspace/a",
+    );
+
+    expect(
+      resolveOptionalMediaToolFactoryPlan({
+        config,
+        authStore: createAuthStore(["image-owner"]),
+      }).imageGenerate,
+    ).toBe(false);
+    expect(
+      resolveOptionalMediaToolFactoryPlan({
+        config,
+        workspaceDir: "/workspace/a",
+        authStore: createAuthStore(["image-owner"]),
+      }).imageGenerate,
+    ).toBe(true);
+  });
+
   it("keeps explicit model configs on the factory path", () => {
     const config: OpenClawConfig = {
       agents: {

--- a/src/agents/openclaw-tools.media-factory-plan.ts
+++ b/src/agents/openclaw-tools.media-factory-plan.ts
@@ -101,6 +101,7 @@ function mergeBuiltInFactoryAllowlist(...lists: Array<string[] | undefined>): st
 export function resolveImageToolFactoryAvailable(params: {
   config?: OpenClawConfig;
   agentDir?: string;
+  workspaceDir?: string;
   modelHasVision?: boolean;
   authStore?: AuthProfileStore;
 }): boolean {
@@ -112,6 +113,7 @@ export function resolveImageToolFactoryAvailable(params: {
   }
   const snapshot = loadCapabilityMetadataSnapshot({
     config: params.config,
+    ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
   });
   return (
     hasSnapshotCapabilityAvailability({

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -204,6 +204,7 @@ export function createOpenClawTools(
   const imageTool = resolveImageToolFactoryAvailable({
     config: availabilityConfig ?? resolvedConfig,
     agentDir: imageToolAgentDir,
+    workspaceDir,
     modelHasVision: options?.modelHasVision,
     authStore: options?.authProfileStore,
   })

--- a/src/agents/tools/manifest-capability-availability.ts
+++ b/src/agents/tools/manifest-capability-availability.ts
@@ -68,7 +68,9 @@ export function getCurrentCapabilityMetadataSnapshot(params: {
 }): PluginMetadataSnapshot | undefined {
   return getCurrentPluginMetadataSnapshot({
     config: params.config,
-    ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+    ...(params.workspaceDir
+      ? { workspaceDir: params.workspaceDir }
+      : { allowWorkspaceScopedSnapshot: true }),
   });
 }
 
@@ -80,7 +82,9 @@ export function loadCapabilityMetadataSnapshot(params: {
   return (
     getCurrentPluginMetadataSnapshot({
       config: params.config,
-      ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+      ...(params.workspaceDir
+        ? { workspaceDir: params.workspaceDir }
+        : { allowWorkspaceScopedSnapshot: true }),
     }) ??
     loadManifestContractSnapshot({
       config: params.config,

--- a/src/agents/tools/manifest-capability-availability.ts
+++ b/src/agents/tools/manifest-capability-availability.ts
@@ -11,7 +11,9 @@ import {
   manifestPluginSetupProviderEnvVars,
   manifestProviderBaseUrlGuardPasses,
 } from "../../plugins/manifest-tool-availability.js";
+import { loadPluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
+import { getActivePluginRegistryWorkspaceDirFromState } from "../../plugins/runtime-state.js";
 import { listProfilesForProvider } from "../auth-profiles/profile-list.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
 
@@ -66,11 +68,10 @@ export function getCurrentCapabilityMetadataSnapshot(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
 }): PluginMetadataSnapshot | undefined {
+  const workspaceDir = params.workspaceDir ?? getActivePluginRegistryWorkspaceDirFromState();
   return getCurrentPluginMetadataSnapshot({
     config: params.config,
-    ...(params.workspaceDir
-      ? { workspaceDir: params.workspaceDir }
-      : { allowWorkspaceScopedSnapshot: true }),
+    ...(workspaceDir ? { workspaceDir } : {}),
   });
 }
 
@@ -79,19 +80,24 @@ export function loadCapabilityMetadataSnapshot(params: {
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
 }): Pick<PluginMetadataSnapshot, "index" | "plugins"> {
-  return (
-    getCurrentPluginMetadataSnapshot({
-      config: params.config,
-      ...(params.workspaceDir
-        ? { workspaceDir: params.workspaceDir }
-        : { allowWorkspaceScopedSnapshot: true }),
-    }) ??
-    loadManifestContractSnapshot({
-      config: params.config,
-      env: params.env,
-      ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
-    })
-  );
+  const workspaceDir = params.workspaceDir ?? getActivePluginRegistryWorkspaceDirFromState();
+  const current = getCurrentPluginMetadataSnapshot({
+    config: params.config,
+    ...(workspaceDir ? { workspaceDir } : {}),
+  });
+  if (current) {
+    return current;
+  }
+  return workspaceDir
+    ? loadManifestContractSnapshot({
+        config: params.config,
+        env: params.env,
+        workspaceDir,
+      })
+    : loadPluginMetadataSnapshot({
+        config: params.config ?? {},
+        env: params.env ?? process.env,
+      });
 }
 
 export function hasSnapshotCapabilityAvailability(params: {

--- a/src/plugin-sdk/provider-catalog-shared.ts
+++ b/src/plugin-sdk/provider-catalog-shared.ts
@@ -126,7 +126,9 @@ function buildManifestCatalogModel(
   if (model.maxTokens === undefined) {
     throw new Error(`Manifest modelCatalog row ${model.id} is missing maxTokens`);
   }
-  const id = normalizeConfiguredProviderCatalogModelId(providerId, model.id);
+  const id = normalizeConfiguredProviderCatalogModelId(providerId, model.id, {
+    allowManifestNormalization: false,
+  });
   return {
     id,
     name: model.name ?? id,

--- a/src/plugins/manifest-model-id-normalization.test.ts
+++ b/src/plugins/manifest-model-id-normalization.test.ts
@@ -220,6 +220,19 @@ describe("manifest model id normalization", () => {
     expect(normalizeDemoModel()).toBe("bravo/demo-model");
   });
 
+  it("does not reuse workspace-scoped current metadata without a workspace context", () => {
+    setCurrentPluginMetadataSnapshot(
+      createCurrentSnapshot({
+        manifestHash: "alpha",
+        prefix: "alpha",
+        workspaceDir: "/workspace/a",
+      }),
+      { config: {}, env: process.env },
+    );
+
+    expect(normalizeDemoModel()).toBeUndefined();
+  });
+
   it("reflects manifest edits and state-dir changes on the next lookup", () => {
     const stateDirA = makeTempDir();
     const pluginDirA = path.join(stateDirA, "extensions", "normalizer");

--- a/src/plugins/manifest-model-id-normalization.ts
+++ b/src/plugins/manifest-model-id-normalization.ts
@@ -46,7 +46,7 @@ function resolveMetadataSnapshotForPolicies(
   const current = getCurrentPluginMetadataSnapshot({
     config: params.config,
     env,
-    workspaceDir,
+    ...(workspaceDir !== undefined ? { workspaceDir } : { allowWorkspaceScopedSnapshot: true }),
   });
   if (current) {
     return { snapshot: current, cacheable: true };

--- a/src/plugins/manifest-model-id-normalization.ts
+++ b/src/plugins/manifest-model-id-normalization.ts
@@ -46,7 +46,7 @@ function resolveMetadataSnapshotForPolicies(
   const current = getCurrentPluginMetadataSnapshot({
     config: params.config,
     env,
-    ...(workspaceDir !== undefined ? { workspaceDir } : { allowWorkspaceScopedSnapshot: true }),
+    workspaceDir,
   });
   if (current) {
     return { snapshot: current, cacheable: true };

--- a/src/plugins/runtime/load-context.test.ts
+++ b/src/plugins/runtime/load-context.test.ts
@@ -9,6 +9,18 @@ const resolveAgentWorkspaceDirMock = vi.fn<
 const resolveDefaultAgentIdMock = vi.fn<
   typeof import("../../agents/agent-scope.js").resolveDefaultAgentId
 >(() => "default");
+const manifestRegistry = { diagnostics: [], plugins: [] };
+const metadataSnapshot = {
+  configFingerprint: "fingerprint",
+  diagnostics: [],
+  index: { plugins: [], policyHash: "policy" },
+  manifestRegistry,
+  plugins: [],
+  policyHash: "policy",
+  workspaceDir: "/resolved-workspace",
+};
+const loadPluginMetadataSnapshotMock = vi.fn(() => metadataSnapshot);
+const setCurrentPluginMetadataSnapshotMock = vi.fn();
 
 let resolvePluginRuntimeLoadContext: typeof import("./load-context.js").resolvePluginRuntimeLoadContext;
 let buildPluginRuntimeLoadOptions: typeof import("./load-context.js").buildPluginRuntimeLoadOptions;
@@ -29,6 +41,14 @@ vi.mock("../../agents/agent-scope.js", () => ({
   resolveDefaultAgentId: resolveDefaultAgentIdMock,
 }));
 
+vi.mock("../plugin-metadata-snapshot.js", () => ({
+  loadPluginMetadataSnapshot: loadPluginMetadataSnapshotMock,
+}));
+
+vi.mock("../current-plugin-metadata-snapshot.js", () => ({
+  setCurrentPluginMetadataSnapshot: setCurrentPluginMetadataSnapshotMock,
+}));
+
 describe("resolvePluginRuntimeLoadContext", () => {
   beforeEach(async () => {
     vi.resetModules();
@@ -38,6 +58,8 @@ describe("resolvePluginRuntimeLoadContext", () => {
       await import("./load-context.js"));
     loadConfigMock.mockReset();
     applyPluginAutoEnableMock.mockReset();
+    loadPluginMetadataSnapshotMock.mockClear();
+    setCurrentPluginMetadataSnapshotMock.mockClear();
     resolveAgentWorkspaceDirMock.mockClear();
     resolveDefaultAgentIdMock.mockClear();
 
@@ -84,10 +106,23 @@ describe("resolvePluginRuntimeLoadContext", () => {
       workspaceDir: "/resolved-workspace",
       env,
       logger: context.logger,
+      manifestRegistry,
+    });
+    expect(loadPluginMetadataSnapshotMock).toHaveBeenCalledWith({
+      config: rawConfig,
+      env,
+      workspaceDir: "/resolved-workspace",
     });
     expect(applyPluginAutoEnableMock).toHaveBeenCalledWith({
       config: rawConfig,
       env,
+      manifestRegistry,
+    });
+    expect(setCurrentPluginMetadataSnapshotMock).toHaveBeenCalledWith(metadataSnapshot, {
+      config: rawConfig,
+      compatibleConfigs: [resolvedConfig, rawConfig],
+      env,
+      workspaceDir: "/resolved-workspace",
     });
     expect(resolveDefaultAgentIdMock).toHaveBeenCalledWith(resolvedConfig);
     expect(resolveAgentWorkspaceDirMock).toHaveBeenCalledWith(resolvedConfig, "default");
@@ -111,6 +146,7 @@ describe("resolvePluginRuntimeLoadContext", () => {
     expect(applyPluginAutoEnableMock).toHaveBeenCalledWith({
       config: runtimeConfig,
       env: process.env,
+      manifestRegistry,
     });
   });
 
@@ -134,6 +170,7 @@ describe("resolvePluginRuntimeLoadContext", () => {
       workspaceDir: "/explicit-workspace",
       env: context.env,
       logger: context.logger,
+      manifestRegistry,
       cache: false,
       activate: false,
       onlyPluginIds: ["demo"],

--- a/src/plugins/runtime/load-context.ts
+++ b/src/plugins/runtime/load-context.ts
@@ -4,8 +4,10 @@ import { applyPluginAutoEnable } from "../../config/plugin-auto-enable.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createSubsystemLogger } from "../../logging.js";
 import { resolvePluginActivationSourceConfig } from "../activation-source-config.js";
+import { setCurrentPluginMetadataSnapshot } from "../current-plugin-metadata-snapshot.js";
 import type { PluginLoadOptions } from "../loader.js";
 import type { PluginManifestRegistry } from "../manifest-registry.js";
+import { loadPluginMetadataSnapshot } from "../plugin-metadata-snapshot.js";
 import type { PluginLogger } from "../types.js";
 
 const log = createSubsystemLogger("plugins");
@@ -18,11 +20,18 @@ export type PluginRuntimeLoadContext = {
   workspaceDir: string | undefined;
   env: NodeJS.ProcessEnv;
   logger: PluginLogger;
+  manifestRegistry?: PluginManifestRegistry;
 };
 
 export type PluginRuntimeResolvedLoadValues = Pick<
   PluginLoadOptions,
-  "config" | "activationSourceConfig" | "autoEnabledReasons" | "workspaceDir" | "env" | "logger"
+  | "config"
+  | "activationSourceConfig"
+  | "autoEnabledReasons"
+  | "workspaceDir"
+  | "env"
+  | "logger"
+  | "manifestRegistry"
 >;
 
 export type PluginRuntimeLoadContextOptions = {
@@ -48,6 +57,16 @@ export function resolvePluginRuntimeLoadContext(
 ): PluginRuntimeLoadContext {
   const env = options?.env ?? process.env;
   const rawConfig = options?.config ?? getRuntimeConfig();
+  const rawWorkspaceDir =
+    options?.workspaceDir ?? resolveAgentWorkspaceDir(rawConfig, resolveDefaultAgentId(rawConfig));
+  const metadataSnapshot = options?.manifestRegistry
+    ? undefined
+    : loadPluginMetadataSnapshot({
+        config: rawConfig,
+        env,
+        workspaceDir: rawWorkspaceDir,
+      });
+  const manifestRegistry = options?.manifestRegistry ?? metadataSnapshot?.manifestRegistry;
   const activationSourceConfig = resolvePluginActivationSourceConfig({
     config: rawConfig,
     activationSourceConfig: options?.activationSourceConfig,
@@ -55,11 +74,19 @@ export function resolvePluginRuntimeLoadContext(
   const autoEnabled = applyPluginAutoEnable({
     config: rawConfig,
     env,
-    manifestRegistry: options?.manifestRegistry,
+    manifestRegistry,
   });
   const config = autoEnabled.config;
   const workspaceDir =
     options?.workspaceDir ?? resolveAgentWorkspaceDir(config, resolveDefaultAgentId(config));
+  if (metadataSnapshot) {
+    setCurrentPluginMetadataSnapshot(metadataSnapshot, {
+      config: rawConfig,
+      compatibleConfigs: [config, activationSourceConfig],
+      env,
+      workspaceDir,
+    });
+  }
   return {
     rawConfig,
     config,
@@ -68,6 +95,7 @@ export function resolvePluginRuntimeLoadContext(
     workspaceDir,
     env,
     logger: options?.logger ?? createPluginRuntimeLoaderLogger(),
+    ...(manifestRegistry ? { manifestRegistry } : {}),
   };
 }
 
@@ -89,6 +117,7 @@ export function buildPluginRuntimeLoadOptionsFromValues(
     workspaceDir: values.workspaceDir,
     env: values.env,
     logger: values.logger,
+    ...(values.manifestRegistry ? { manifestRegistry: values.manifestRegistry } : {}),
     ...overrides,
   };
 }

--- a/src/plugins/setup-registry.runtime.test.ts
+++ b/src/plugins/setup-registry.runtime.test.ts
@@ -225,6 +225,38 @@ describe("setup-registry runtime fallback", () => {
     expect(loadPluginMetadataSnapshotMock).not.toHaveBeenCalled();
   });
 
+  it("does not reuse workspace-scoped current metadata without a workspace context", async () => {
+    loadPluginMetadataSnapshotMock.mockReturnValue({
+      index: {
+        diagnostics: [],
+        plugins: [],
+      },
+      plugins: [],
+    });
+
+    const { __testing, resolvePluginSetupCliBackendRuntime } =
+      await import("./setup-registry.runtime.js");
+    __testing.resetRuntimeState();
+    __testing.setRuntimeModuleForTest(null);
+
+    setCurrentPluginMetadataSnapshot(
+      createCurrentSnapshot({
+        manifestHash: "alpha",
+        cliBackends: ["Codex-CLI"],
+        workspaceDir: "/workspace/a",
+      }),
+      { config: {}, env: process.env },
+    );
+
+    expect(
+      resolvePluginSetupCliBackendRuntime({ backend: "codex-cli", config: {} }),
+    ).toBeUndefined();
+    expect(loadPluginMetadataSnapshotMock).toHaveBeenCalledWith({
+      config: {},
+      env: process.env,
+    });
+  });
+
   it("preserves fail-closed setup lookup when the runtime module explicitly declines to resolve", async () => {
     loadPluginMetadataSnapshotMock.mockReturnValue({
       index: {

--- a/src/plugins/setup-registry.runtime.ts
+++ b/src/plugins/setup-registry.runtime.ts
@@ -60,7 +60,7 @@ function resolveMetadataSnapshotForSetupCliBackends(
   const current = getCurrentPluginMetadataSnapshot({
     config: params.config,
     env,
-    workspaceDir,
+    ...(workspaceDir !== undefined ? { workspaceDir } : { allowWorkspaceScopedSnapshot: true }),
   });
   if (current) {
     return { snapshot: current, cacheable: true };

--- a/src/plugins/setup-registry.runtime.ts
+++ b/src/plugins/setup-registry.runtime.ts
@@ -60,7 +60,7 @@ function resolveMetadataSnapshotForSetupCliBackends(
   const current = getCurrentPluginMetadataSnapshot({
     config: params.config,
     env,
-    ...(workspaceDir !== undefined ? { workspaceDir } : { allowWorkspaceScopedSnapshot: true }),
+    workspaceDir,
   });
   if (current) {
     return { snapshot: current, cacheable: true };


### PR DESCRIPTION
## Summary

- Reuse prepared plugin manifest metadata through agent startup, plugin runtime loading, model catalog normalization, model selection, fallback resolution, auth lookups, and tool capability checks.
- Avoid repeated plugin metadata scans on hot startup/turn paths while preserving default model, fallback, catalog, and tool availability behavior.
- Scope reusable metadata to the proven runtime context so stale plugin snapshots are not reused by unrelated global/read-only callers.
- Preserve intentional global/read-only catalog behavior, including static read-only catalog paths that avoid metadata scans unless configured provider rows require manifest normalization.
- Thread runtime context into media/image tool availability so agent and gateway turn execution resolve plugin capabilities from the same prepared metadata path.

## Measured impact

From `.artifacts/plugin-metadata-regression-fix-report.md`, comparing the baseline Kova run to the fixed current-base run for `agent-cold-warm-message`:

- Kova went from `FAIL 3/3` to `PASS 3/3`.
- Metadata scans dropped from `394` to `28` per cold+warm sample: `366` fewer scans, about `92.9%` fewer.
- Metadata scan total dropped from about `14,800ms` to `1,142.43ms` median: about `13.66s` saved, about `92.3%` lower.
- Cold turn median dropped from about `10,640ms` to `3,866ms`: about `6.77s` faster, about `63.7%` lower.
- Warm turn median dropped from about `10,556ms` to `3,699ms`: about `6.86s` faster, about `65.0%` lower.
- Cold pre-provider median dropped from about `10,344ms` to `3,754ms`: about `6.59s` faster, about `63.7%` lower.
- Warm pre-provider median dropped from about `10,100ms` to `3,584ms`: about `6.52s` faster, about `64.5%` lower.
- Provider time stayed effectively unchanged: baseline `0-1ms`, fixed `0-2ms`.

Live CLI probes after rebasing onto `origin/main` at `89532d3a92`:

- `openclaw --version`: `47ms`, status `0`
- `openclaw plugins list --json`: `463ms`, status `0`
- `openclaw gateway status`: `468ms`, status `0`
- `openclaw config get gateway.port`: `302ms`, status `1` with expected missing-key result in isolated empty home
- `openclaw sessions --all-agents --active 5 --json`: `570ms`, status `0`

Current branch gateway proof also stayed green: Kova `gateway-session-send-turn` passed `3/3`, with `3` metadata scans per sample, cold turns around `2.29s-2.40s`, warm turns around `1.61s-1.63s`, and max RSS `695.3 MB`.

## Verification

- Rebased cleanly onto `origin/main` at `89532d3a92`.
- `git diff --check origin/main...HEAD`: passed.
- `node scripts/run-vitest.mjs ... --run`: 16 files, 514 tests passed.
- Core and core-test `tsgo`: passed before the final rebase.
- Kova `gateway-session-send-turn`: 3/3 PASS.
  - Report: `.artifacts/kova/reports/plugin-metadata-gateway-session-send-after-workspace-threading-repeat3/kova-2026-05-17T001010Z.md`
  - Covered gateway `sessions.create`, `sessions.send`, and `chat.history`.
- Kova `agent-cold-warm-message`: 3/3 PASS.
  - Report: `.artifacts/kova/reports/plugin-metadata-agent-cold-warm-after-workspace-threading-repeat3/kova-2026-05-17T001213Z.md`
- `pnpm check:changed`: passed locally across core, core tests, extension typechecks, lint, guards, and import cycles before the final rebase.

## Real behavior proof

Behavior addressed: Plugin-heavy installs avoid repeated manifest metadata scans during model/runtime setup without changing default model selection, fallback handling, catalog visibility, or tool capability behavior.

Real environment tested: Local OpenClaw checkout with Kova mock OpenAI provider scenarios, isolated CLI probes, and local changed-surface checks.

Exact steps or command run after this patch: Kova gateway session-send repeat-3, Kova local agent cold/warm repeat-3, focused Vitest suite, core/core-test tsgo, `git diff --check`, live CLI probes, and local `pnpm check:changed`.

Evidence after fix: Gateway session-send and local agent Kova scenarios both passed 3/3, focused tests passed 514/514 after the final rebase, live CLI probes stayed fast with expected status codes, and the artifacted baseline-to-fixed measurements show metadata scan count fell from 394 to 28.

Observed result after fix: Runtime paths reuse prepared metadata, global/read-only paths do not consume stale runtime snapshots, provider latency remains effectively unchanged, and the measured metadata-scan regression did not reappear.
