### PR TITLE
fix(qwen): honor chat-template session thinking (#82768)

### DIFF
--- a/extensions/qwen/stream.test.ts
+++ b/extensions/qwen/stream.test.ts
@@ -5,6 +5,7 @@ import { createQwenThinkingWrapper, wrapQwenProviderStream } from "./stream.js";
 
 function capturePayload(params: {
   thinkingLevel?: "off" | "low" | "medium" | "high" | "xhigh" | "max";
+  thinkingFormat?: "qwen-chat-template" | "top-level";
   reasoning?: unknown;
   initialPayload?: Record<string, unknown>;
   model?: Partial<Model<"openai-completions">>;
@@ -17,7 +18,11 @@ function capturePayload(params: {
     return {} as ReturnType<StreamFn>;
   };
 
-  const wrapped = createQwenThinkingWrapper(baseStreamFn, params.thinkingLevel ?? "high");
+  const wrapped = createQwenThinkingWrapper(
+    baseStreamFn,
+    params.thinkingLevel ?? "high",
+    params.thinkingFormat,
+  );
   void wrapped(
     {
       api: "openai-completions",
@@ -56,6 +61,31 @@ describe("createQwenThinkingWrapper", () => {
     expect(capturePayload({ thinkingLevel: "high" })).toEqual({ enable_thinking: true });
   });
 
+  it("maps chat-template format to session-aware chat_template_kwargs", () => {
+    expect(capturePayload({ thinkingFormat: "qwen-chat-template", thinkingLevel: "off" })).toEqual({
+      chat_template_kwargs: { enable_thinking: false },
+      preserve_thinking: true,
+    });
+    expect(
+      capturePayload({
+        thinkingFormat: "qwen-chat-template",
+        thinkingLevel: "high",
+        initialPayload: {
+          enable_thinking: false,
+          chat_template_kwargs: {
+            force_nonempty_content: true,
+          },
+        },
+      }),
+    ).toEqual({
+      chat_template_kwargs: {
+        enable_thinking: true,
+        force_nonempty_content: true,
+      },
+      preserve_thinking: true,
+    });
+  });
+
   it("skips non-reasoning and non-completions models", () => {
     expect(capturePayload({ model: { reasoning: false } })).toStrictEqual({});
     expect(capturePayload({ model: { api: "openai-responses" as never } })).toStrictEqual({});
@@ -73,6 +103,7 @@ describe("wrapQwenProviderStream", () => {
           provider: "qwen",
           id: "qwen3.6-plus",
           reasoning: true,
+          compat: { thinkingFormat: "qwen-chat-template" },
         } as Model<"openai-completions">,
         streamFn: undefined,
       } as never),

--- a/extensions/qwen/stream.ts
+++ b/extensions/qwen/stream.ts
@@ -7,6 +7,7 @@ import {
 } from "openclaw/plugin-sdk/provider-stream-shared";
 
 type QwenThinkingLevel = ProviderWrapStreamFnContext["thinkingLevel"];
+type QwenThinkingFormat = "qwen-chat-template" | "top-level";
 
 function isQwenProviderId(providerId: string): boolean {
   const normalized = normalizeProviderId(providerId);
@@ -21,12 +22,26 @@ function isQwenProviderId(providerId: string): boolean {
 export function createQwenThinkingWrapper(
   baseStreamFn: StreamFn | undefined,
   thinkingLevel: QwenThinkingLevel,
+  thinkingFormat: QwenThinkingFormat = "top-level",
 ): StreamFn {
   return createPayloadPatchStreamWrapper(
     baseStreamFn,
     ({ payload: payloadObj, options }) => {
       const enableThinking = isOpenAICompatibleThinkingEnabled({ thinkingLevel, options });
-      payloadObj.enable_thinking = enableThinking;
+      if (thinkingFormat === "qwen-chat-template") {
+        const existing = payloadObj.chat_template_kwargs;
+        payloadObj.chat_template_kwargs =
+          existing && typeof existing === "object" && !Array.isArray(existing)
+            ? {
+                ...(existing as Record<string, unknown>),
+                enable_thinking: enableThinking,
+              }
+            : { enable_thinking: enableThinking };
+        payloadObj.preserve_thinking = true;
+        delete payloadObj.enable_thinking;
+      } else {
+        payloadObj.enable_thinking = enableThinking;
+      }
       delete payloadObj.reasoning_effort;
       delete payloadObj.reasoningEffort;
       delete payloadObj.reasoning;
@@ -41,5 +56,9 @@ export function wrapQwenProviderStream(ctx: ProviderWrapStreamFnContext): Stream
   if (!isQwenProviderId(ctx.provider) || (ctx.model && ctx.model.api !== "openai-completions")) {
     return undefined;
   }
-  return createQwenThinkingWrapper(ctx.streamFn, ctx.thinkingLevel);
+  return createQwenThinkingWrapper(
+    ctx.streamFn,
+    ctx.thinkingLevel,
+    ctx.model?.compat?.thinkingFormat === "qwen-chat-template" ? "qwen-chat-template" : "top-level",
+  );
 }


### PR DESCRIPTION
## Summary
- make the Qwen stream wrapper write session-aware thinking state into `chat_template_kwargs.enable_thinking` when `compat.thinkingFormat` is `qwen-chat-template`
- preserve the existing top-level `enable_thinking` path for non-chat-template Qwen models
- add regression coverage for `/think off` style session fallback with chat-template payloads

Fixes #82768

## Pre-implementation audit
- Existing-helper check: reused `isOpenAICompatibleThinkingEnabled()` from `openclaw/plugin-sdk/provider-stream-shared`; no new thinking predicate introduced.
- Shared-helper caller check: did not mutate shared helper contracts; changed only the Qwen provider wrapper and its direct tests.
- Broader-fix rival scan: no active PR directly fixes #82768 or the Qwen `chat_template_kwargs.enable_thinking` session fallback; broader thinking PRs are adjacent/stale and do not cover this payload path.

## Real behavior proof
Behavior addressed: Local OpenClaw provider-wrapper payload construction for Qwen OpenAI-compatible models now maps session-level `thinkingLevel: "off"` into `chat_template_kwargs.enable_thinking: false` when `compat.thinkingFormat` is `qwen-chat-template`. This is the request-body contract that llama.cpp Qwen 3.6 reads.

Real environment tested: Local OpenClaw checkout at PR head `6aaebf50a116686351a79d9367b0f98c0b3b9202`, Node/Vitest via repository scripts, branch `fix-qwen-chat-template-session-thinking-82768`. No external provider credentials or llama.cpp server were required for this payload-contract proof.

Exact steps or command run after this patch: Built the Qwen wrapper around an OpenAI-completions stream function, used a model with `provider: "qwen"`, `reasoning: true`, and `compat.thinkingFormat: "qwen-chat-template"`, invoked the wrapper with session fallback `thinkingLevel: "off"` and no explicit request `reasoning`, then captured the outgoing payload after `options.onPayload` ran. The exact repository commands run after the patch were:
```text
node scripts/run-vitest.mjs extensions/qwen/stream.test.ts
node scripts/run-vitest.mjs src/agents/openai-transport-stream.test.ts extensions/qwen/stream.test.ts src/plugin-sdk/provider-stream-shared.test.ts src/agents/openai-thinking-contract.test.ts src/config/config-misc.test.ts src/model-catalog/normalize.test.ts
pnpm exec oxfmt --check --threads=1 extensions/qwen/stream.ts extensions/qwen/stream.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json extensions/qwen/stream.ts extensions/qwen/stream.test.ts
git diff --check
```

Evidence after fix: Terminal output from the local OpenClaw checkout:
```text
node scripts/run-vitest.mjs extensions/qwen/stream.test.ts
Test Files  1 passed (1)
Tests  6 passed (6)

node scripts/run-vitest.mjs src/agents/openai-transport-stream.test.ts extensions/qwen/stream.test.ts src/plugin-sdk/provider-stream-shared.test.ts src/agents/openai-thinking-contract.test.ts src/config/config-misc.test.ts src/model-catalog/normalize.test.ts
Test Files  7 passed (7)
Tests  428 passed (428)

pnpm exec oxfmt --check --threads=1 extensions/qwen/stream.ts extensions/qwen/stream.test.ts
All matched files use the correct format.

node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json extensions/qwen/stream.ts extensions/qwen/stream.test.ts
Found 0 warnings and 0 errors.

git diff --check
no output
```

Observed result after fix: The regression test captured this after-fix payload for session `thinkingLevel: "off"` plus `thinkingFormat: "qwen-chat-template"`:
```js
{
  chat_template_kwargs: { enable_thinking: false },
  preserve_thinking: true,
}
```
It also verifies an existing stale top-level `enable_thinking` field is removed/overridden for chat-template mode and that existing `chat_template_kwargs` keys are preserved while `enable_thinking` is updated.

What was not tested: I did not run a live llama.cpp/Qwen 3.6 server or capture an external HTTP request. The proof is local OpenClaw payload construction plus repository thinking/transport regression coverage.

## Verification
- `node scripts/run-vitest.mjs extensions/qwen/stream.test.ts`
- `node scripts/run-vitest.mjs src/agents/openai-transport-stream.test.ts extensions/qwen/stream.test.ts src/plugin-sdk/provider-stream-shared.test.ts src/agents/openai-thinking-contract.test.ts src/config/config-misc.test.ts src/model-catalog/normalize.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/qwen/stream.ts extensions/qwen/stream.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json extensions/qwen/stream.ts extensions/qwen/stream.test.ts`
- `git diff --check`

## Not changed
- No changes to shared OpenAI transport resolution.
- No changes to non-Qwen providers.
- No live llama.cpp server repro was run locally; this PR verifies the request payload contract in the provider wrapper and existing transport tests.