### PR TITLE
fix(codex): guard post-tool raw assistant terminal gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@ Docs: https://docs.openclaw.ai
 - Slack: keep DM thread replies on the main direct-message session instead of routing them to invisible thread-scoped sessions. Refs #82390. (#82418) Thanks @kagura-agent.
 - Auth/macOS: avoid creating the OAuth profile master key in Keychain automatically, falling back to the file-backed secret key so headless agents do not trigger a Keychain prompt.
 - Codex app-server: release raw assistant completions when `turn/completed` is missing while keeping commentary/status items as progress, preventing completed Codex runs from hanging until timeout. Fixes #82343. (#82403) Thanks @IWhatsskill.
+- Codex app-server: keep a bounded terminal guard after post-tool raw assistant completions so missing `turn/completed` events fail fast instead of leaving embedded runs stuck. Fixes #82775. (#82816) Thanks @joshavant.
 - Agents/sessions: remove the transient `*.bak-<pid>-<ts>` backup written by `repairSessionFileIfNeeded` once the atomic replace succeeds, so a stuck session with a persistently malformed JSONL line no longer accumulates one snapshot per repair invocation. Fixes #80960. (#80969) Thanks @100yenadmin. Co-authored by @tynamite.
 - CLI/status: show plain empty-state messages instead of empty Channels and Sessions tables when no channels or sessions exist.
 - CLI/dashboard: probe Gateway readiness before handing out the dashboard URL, prompting to start or install the managed service when the Gateway is stopped and printing recovery commands instead of opening a dead browser tab.

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -2254,7 +2254,7 @@ describe("runCodexAppServerAttempt", () => {
     expect(request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
   });
 
-  it("does not release post-tool raw assistant progress after the assistant idle timeout", async () => {
+  it("times out post-tool raw assistant progress after the assistant idle timeout", async () => {
     let notify: (notification: CodexServerNotification) => Promise<void> = async () => undefined;
     let handleRequest:
       | ((request: { id: string; method: string; params?: unknown }) => Promise<unknown>)
@@ -2327,26 +2327,28 @@ describe("runCodexAppServerAttempt", () => {
         },
       },
     });
-    await new Promise((resolve) => setTimeout(resolve, 30));
-    expect(request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
-
-    await notify({
-      method: "turn/completed",
-      params: {
-        threadId: "thread-1",
-        turnId: "turn-1",
-        turn: { id: "turn-1", status: "completed" },
-      },
-    });
 
     const result = await run;
-    expect(result.aborted).toBe(false);
-    expect(result.timedOut).toBe(false);
-    expect(result.promptError).toBeNull();
-    expect(request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
+    expect(result.aborted).toBe(true);
+    expect(result.timedOut).toBe(true);
+    expect(result.promptError).toBe(
+      "codex app-server turn idle timed out waiting for turn/completed",
+    );
+    await vi.waitFor(
+      () =>
+        expect(request).toHaveBeenCalledWith(
+          "turn/interrupt",
+          {
+            threadId: "thread-1",
+            turnId: "turn-1",
+          },
+          { timeoutMs: 5_000 },
+        ),
+      { interval: 1 },
+    );
   });
 
-  it("does not release post-native-tool raw assistant progress after the assistant idle timeout", async () => {
+  it("times out post-native-tool raw assistant progress after the assistant idle timeout", async () => {
     let notify: (notification: CodexServerNotification) => Promise<void> = async () => undefined;
     const request = vi.fn(async (method: string) => {
       if (method === "thread/start") {
@@ -2413,23 +2415,25 @@ describe("runCodexAppServerAttempt", () => {
         },
       },
     });
-    await new Promise((resolve) => setTimeout(resolve, 30));
-    expect(request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
-
-    await notify({
-      method: "turn/completed",
-      params: {
-        threadId: "thread-1",
-        turnId: "turn-1",
-        turn: { id: "turn-1", status: "completed" },
-      },
-    });
 
     const result = await run;
-    expect(result.aborted).toBe(false);
-    expect(result.timedOut).toBe(false);
-    expect(result.promptError).toBeNull();
-    expect(request.mock.calls.some(([method]) => method === "turn/interrupt")).toBe(false);
+    expect(result.aborted).toBe(true);
+    expect(result.timedOut).toBe(true);
+    expect(result.promptError).toBe(
+      "codex app-server turn idle timed out waiting for turn/completed",
+    );
+    await vi.waitFor(
+      () =>
+        expect(request).toHaveBeenCalledWith(
+          "turn/interrupt",
+          {
+            threadId: "thread-1",
+            turnId: "turn-1",
+          },
+          { timeoutMs: 5_000 },
+        ),
+      { interval: 1 },
+    );
   });
 
   it("logs raw assistant item context when the terminal watchdog fires", async () => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1060,6 +1060,7 @@ export async function runCodexAppServerAttempt(
   let turnCompletionIdleTimer: ReturnType<typeof setTimeout> | undefined;
   let turnCompletionIdleWatchArmed = false;
   let turnCompletionIdleWatchPinnedByTerminalError = false;
+  let turnCompletionIdleTimeoutOverrideMs: number | undefined;
   let turnAssistantCompletionIdleTimer: ReturnType<typeof setTimeout> | undefined;
   let turnAssistantCompletionIdleWatchArmed = false;
   let turnAssistantCompletionLastActivityAt = Date.now();
@@ -1195,8 +1196,9 @@ export async function runCodexAppServerAttempt(
     ) {
       return;
     }
+    const timeoutMs = turnCompletionIdleTimeoutOverrideMs ?? turnCompletionIdleTimeoutMs;
     const idleMs = Math.max(0, Date.now() - turnCompletionLastActivityAt);
-    if (idleMs < turnCompletionIdleTimeoutMs) {
+    if (idleMs < timeoutMs) {
       scheduleTurnCompletionIdleWatch();
       return;
     }
@@ -1209,7 +1211,7 @@ export async function runCodexAppServerAttempt(
       threadId: thread.threadId,
       turnId,
       idleMs,
-      timeoutMs: turnCompletionIdleTimeoutMs,
+      timeoutMs,
       lastActivityReason: turnCompletionLastActivityReason,
       ...turnCompletionLastActivityDetails,
     });
@@ -1217,7 +1219,7 @@ export async function runCodexAppServerAttempt(
       threadId: thread.threadId,
       turnId,
       idleMs,
-      timeoutMs: turnCompletionIdleTimeoutMs,
+      timeoutMs,
       lastActivityReason: turnCompletionLastActivityReason,
       ...turnCompletionLastActivityDetails,
     });
@@ -1273,7 +1275,8 @@ export async function runCodexAppServerAttempt(
       return;
     }
     const elapsedMs = Math.max(0, Date.now() - turnCompletionLastActivityAt);
-    const delayMs = Math.max(1, turnCompletionIdleTimeoutMs - elapsedMs);
+    const timeoutMs = turnCompletionIdleTimeoutOverrideMs ?? turnCompletionIdleTimeoutMs;
+    const delayMs = Math.max(1, timeoutMs - elapsedMs);
     turnCompletionIdleTimer = setTimeout(fireTurnCompletionIdleTimeout, delayMs);
     turnCompletionIdleTimer.unref?.();
   }
@@ -1351,6 +1354,7 @@ export async function runCodexAppServerAttempt(
     turnCompletionLastActivityAt = Date.now();
     turnCompletionLastActivityReason = reason;
     turnCompletionLastActivityDetails = options?.details;
+    turnCompletionIdleTimeoutOverrideMs = undefined;
     if (options?.attemptProgress) {
       turnAttemptLastProgressAt = turnCompletionLastActivityAt;
       turnAttemptLastProgressReason = reason;
@@ -1380,6 +1384,7 @@ export async function runCodexAppServerAttempt(
   const disarmTurnCompletionIdleWatch = () => {
     turnCompletionIdleWatchArmed = false;
     turnCompletionIdleWatchPinnedByTerminalError = false;
+    turnCompletionIdleTimeoutOverrideMs = undefined;
     clearTurnCompletionIdleTimer();
   };
 
@@ -1396,9 +1401,14 @@ export async function runCodexAppServerAttempt(
     scheduleTurnAssistantCompletionIdleWatch();
   };
 
-  const armTurnCompletionIdleWatch = (options?: { pinnedByTerminalError?: boolean }) => {
+  const armTurnCompletionIdleWatch = (options?: {
+    pinnedByTerminalError?: boolean;
+    timeoutMs?: number;
+  }) => {
     turnCompletionIdleWatchArmed = true;
     turnCompletionIdleWatchPinnedByTerminalError = options?.pinnedByTerminalError === true;
+    turnCompletionIdleTimeoutOverrideMs =
+      options?.timeoutMs !== undefined ? Math.max(1, Math.floor(options.timeoutMs)) : undefined;
     scheduleTurnCompletionIdleWatch();
   };
 
@@ -1520,6 +1530,11 @@ export async function runCodexAppServerAttempt(
       notification,
       turnCrossedToolHandoff,
     );
+    const postToolRawAssistantCompletionNeedsTerminalGuard =
+      isCurrentTurnNotification &&
+      turnCrossedToolHandoff &&
+      isRawAssistantCompletionNotification(notification) &&
+      activeTurnItemIds.size === 0;
     const shouldRearmCompletionIdleWatchAfterLastCurrentTurnItem =
       isCurrentTurnNotification &&
       notification.method === "item/completed" &&
@@ -1537,6 +1552,8 @@ export async function runCodexAppServerAttempt(
       disarmTurnAssistantCompletionIdleWatch();
     } else if (isCurrentTurnNotification && assistantCompletionCanRelease) {
       armTurnAssistantCompletionIdleWatch(describeNotificationActivity(notification));
+    } else if (postToolRawAssistantCompletionNeedsTerminalGuard) {
+      armTurnCompletionIdleWatch({ timeoutMs: turnAssistantCompletionIdleTimeoutMs });
     } else if (unblockedAssistantCompletionRelease) {
       armTurnAssistantCompletionIdleWatch(describeNotificationActivity(notification));
     } else if (shouldRearmCompletionIdleWatchAfterLastCurrentTurnItem) {
@@ -1561,6 +1578,7 @@ export async function runCodexAppServerAttempt(
       isCurrentTurnNotification &&
       !trackedDynamicToolCompletion &&
       !rawToolOutputCompletion &&
+      !postToolRawAssistantCompletionNeedsTerminalGuard &&
       !shouldRearmCompletionIdleWatchAfterLastCurrentTurnItem
     ) {
       // The short completion-idle watchdog guards blind gaps after Codex


### PR DESCRIPTION
## Summary

- Keep the Codex app-server completion watchdog armed after post-tool raw assistant completion items when no `turn/completed` arrives.
- Reuse the existing assistant-completion idle budget for this terminal guard so missing terminal events fail fast instead of waiting for the broader terminal/supervisor timeout.
- Update regression coverage for dynamic-tool and native-tool post-handoff raw assistant completion paths.

Fixes #82775.

## Verification

- `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts` - 140 passed after rebasing onto latest `origin/main`.
- `git diff --check origin/main...HEAD`
- `codex review --uncommitted` - no actionable correctness issues before commit.
- AWS Crabbox current-main repro: provider `aws`, run `run_fb847b6c2af4`, lease `cbx_62f08c578fde`; reproduced missing-terminal post-tool raw assistant completion falling through to a broader timeout.
- AWS Crabbox post-review fix proof: provider `aws`, run `run_65591d962b0c`, lease `cbx_ae89adc669d6`; focused repro tests passed on synced dirty patch.
- AWS Crabbox changed gate: provider `aws`, run `run_cc5d2fe811cb`, lease `cbx_b3ad15dd02ed`; `pnpm check:changed` passed on synced dirty patch.

## Real behavior proof

Behavior addressed: Codex app-server turns that cross a tool handoff and then emit a raw assistant completion without `turn/completed` no longer remain stuck until the broad terminal/supervisor timeout.

Real environment tested: Direct AWS Crabbox Linux runs from the OpenClaw checkout, including a current-main protocol-level repro and patched synced-checkout proof.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts -t 'times out post-tool raw assistant progress after the assistant idle timeout|times out post-native-tool raw assistant progress after the assistant idle timeout|keeps waiting when Codex emits a raw assistant item after a dynamic tool response'` on AWS Crabbox run `run_65591d962b0c`, plus `pnpm check:changed` on AWS Crabbox run `run_cc5d2fe811cb`.

Evidence after fix: The patched AWS repro tests returned `3 passed`, and the changed gate returned exit `0` for lanes `extensions` and `extensionTests`.

Observed result after fix: The bridge now times out through the completion watchdog with `codex app-server turn idle timed out waiting for turn/completed` instead of disarming the short guard after the raw assistant item.

What was not tested: I did not get real Codex 0.130.0 to organically produce the exact upstream `op.dispatch.shutdown` missing-terminal sequence; a credential-backed `thread/archive` shutdown probe ended terminally enough and did not reproduce that upstream trigger.
