### PR TITLE
fix(qwen): honor session thinkingLevel for qwen-chat-template payloads (#82768)

### DIFF
--- a/extensions/qwen/stream.test.ts
+++ b/extensions/qwen/stream.test.ts
@@ -60,6 +60,72 @@ describe("createQwenThinkingWrapper", () => {
     expect(capturePayload({ model: { reasoning: false } })).toStrictEqual({});
     expect(capturePayload({ model: { api: "openai-responses" as never } })).toStrictEqual({});
   });
+
+  describe("qwen-chat-template thinking format", () => {
+    const qwenChatTemplateModel: Partial<Model<"openai-completions">> = {
+      compat: { thinkingFormat: "qwen-chat-template" } as Model<"openai-completions">["compat"],
+    };
+
+    it("mirrors disabled session thinking into chat_template_kwargs.enable_thinking", () => {
+      const payload = capturePayload({
+        thinkingLevel: "off",
+        model: qwenChatTemplateModel,
+        // The transport's qwen-chat-template formatter writes
+        // enable_thinking: true when no explicit reasoning is in options.
+        initialPayload: { chat_template_kwargs: { enable_thinking: true } },
+      });
+
+      expect(payload).toEqual({
+        enable_thinking: false,
+        chat_template_kwargs: { enable_thinking: false },
+      });
+    });
+
+    it("mirrors enabled session thinking into chat_template_kwargs.enable_thinking", () => {
+      const payload = capturePayload({
+        thinkingLevel: "medium",
+        model: qwenChatTemplateModel,
+      });
+
+      expect(payload).toEqual({
+        enable_thinking: true,
+        chat_template_kwargs: { enable_thinking: true },
+      });
+    });
+
+    it("preserves unrelated chat_template_kwargs entries", () => {
+      const payload = capturePayload({
+        thinkingLevel: "off",
+        model: qwenChatTemplateModel,
+        initialPayload: {
+          chat_template_kwargs: { enable_thinking: true, custom_kwarg: "keep" },
+        },
+      });
+
+      expect(payload).toEqual({
+        enable_thinking: false,
+        chat_template_kwargs: { enable_thinking: false, custom_kwarg: "keep" },
+      });
+    });
+
+    it("lets explicit request reasoning override the session thinking level", () => {
+      const payload = capturePayload({
+        thinkingLevel: "off",
+        reasoning: "high",
+        model: qwenChatTemplateModel,
+        initialPayload: { chat_template_kwargs: { enable_thinking: true } },
+      });
+
+      expect(payload).toEqual({
+        enable_thinking: true,
+        chat_template_kwargs: { enable_thinking: true },
+      });
+    });
+
+    it("does not touch chat_template_kwargs for non-chat-template Qwen models", () => {
+      expect(capturePayload({ thinkingLevel: "off" })).toEqual({ enable_thinking: false });
+    });
+  });
 });
 
 describe("wrapQwenProviderStream", () => {

--- a/extensions/qwen/stream.ts
+++ b/extensions/qwen/stream.ts
@@ -24,17 +24,44 @@ export function createQwenThinkingWrapper(
 ): StreamFn {
   return createPayloadPatchStreamWrapper(
     baseStreamFn,
-    ({ payload: payloadObj, options }) => {
+    ({ payload: payloadObj, model, options }) => {
       const enableThinking = isOpenAICompatibleThinkingEnabled({ thinkingLevel, options });
       payloadObj.enable_thinking = enableThinking;
       delete payloadObj.reasoning_effort;
       delete payloadObj.reasoningEffort;
       delete payloadObj.reasoning;
+      // Qwen 3.6 served via llama.cpp honors chat_template_kwargs.enable_thinking
+      // and ignores the top-level enable_thinking field. The transport's
+      // qwen-chat-template formatter resolves enable_thinking from request
+      // options only, so when the session thinking level is the source of truth
+      // (e.g. /think off without an explicit reasoning override) the wrong value
+      // is sent. Mirror the top-level decision into chat_template_kwargs so the
+      // session thinking control wins.
+      if (hasQwenChatTemplateThinkingFormat(model)) {
+        setQwenChatTemplateThinkingEnabled(payloadObj, enableThinking);
+      }
     },
     {
       shouldPatch: ({ model }) => model.api === "openai-completions" && model.reasoning,
     },
   );
+}
+
+function hasQwenChatTemplateThinkingFormat(model: Parameters<StreamFn>[0]): boolean {
+  const compat = (model as { compat?: { thinkingFormat?: unknown } }).compat;
+  return compat?.thinkingFormat === "qwen-chat-template";
+}
+
+function setQwenChatTemplateThinkingEnabled(
+  payload: Record<string, unknown>,
+  enabled: boolean,
+): void {
+  const existing = payload.chat_template_kwargs;
+  if (existing && typeof existing === "object" && !Array.isArray(existing)) {
+    (existing as Record<string, unknown>).enable_thinking = enabled;
+    return;
+  }
+  payload.chat_template_kwargs = { enable_thinking: enabled };
 }
 
 export function wrapQwenProviderStream(ctx: ProviderWrapStreamFnContext): StreamFn | undefined {


### PR DESCRIPTION
Fixes #82768.

## Summary

- The Qwen thinking wrapper already resolves `enable_thinking` from the closure-captured session `thinkingLevel` and writes it to the top-level payload field.
- When a model is configured with `compat.thinkingFormat: "qwen-chat-template"`, the openai-completions transport additionally writes `chat_template_kwargs.enable_thinking` using only request `options` (via `resolveOpenAICompletionsReasoningEffort`, which falls back to `"high"` when no explicit reasoning is supplied). The transport has no visibility into session `thinkingLevel`.
- Qwen 3.6 served by llama.cpp honors `chat_template_kwargs.enable_thinking` and ignores the top-level field, so when a user sets `/think off` without an explicit `reasoning` override, the wrong value wins on the wire and the model still emits thinking blocks.

This PR mirrors the wrapper's `enable_thinking` decision into `chat_template_kwargs.enable_thinking` when the model uses `qwen-chat-template` format. The patch runs after the transport's payload build, preserves any other `chat_template_kwargs` entries the transport already set, and keeps explicit request `reasoning`/`reasoningEffort` ahead of the session level so user-supplied overrides still win.

## Why

`#79777` added `qwen-chat-template` support in the openai-completions transport, but the transport path does not have access to the session `thinkingLevel`. The Qwen plugin wrapper (`createQwenThinkingWrapper`) already holds the right value via its closure, so it is the right layer to reconcile both fields without plumbing a new option through `BaseStreamOptions`.

Scope is intentionally narrow:
- Only the Qwen plugin wrapper changes.
- The patch is guarded on `model.compat.thinkingFormat === "qwen-chat-template"`, so non-chat-template Qwen configurations and unrelated providers are unaffected.
- The existing `shouldPatch` guard (`api === "openai-completions" && model.reasoning`) is unchanged.

## Verification

Targeted unit lane:

```
$ pnpm test:extension qwen
[test-extension] Running 7 test files for qwen
 ✓ extensions/qwen/stream.test.ts (10 tests)
 ✓ extensions/qwen/media-understanding-provider.test.ts (1 test)
 ✓ extensions/qwen/provider-catalog.test.ts (3 tests)
 ✓ extensions/qwen/index.test.ts (2 tests)
 ✓ extensions/qwen/plugin-registration.contract.test.ts (3 tests)
 ✓ extensions/qwen/video-generation-provider.test.ts (4 tests)
 ✓ extensions/qwen/provider-discovery.contract.test.ts (1 test)
 Test Files  7 passed (7)
      Tests  24 passed (24)
```

Transport regressions covering `qwen-chat-template` and the shared OpenAI-compatible thinking helper:

```
$ node scripts/run-vitest.mjs src/agents/openai-transport-stream.test.ts src/plugin-sdk/provider-stream-shared.test.ts
 ✓ ../../src/plugin-sdk/provider-stream-shared.test.ts (12 tests)
 ✓ ../../src/agents/openai-transport-stream.test.ts (161 tests)
 ✓ ../../src/agents/openai-transport-stream.test.ts (161 tests)
 Test Files  3 passed (3)
      Tests  334 passed (334)
```

### Real behavior proof

- **Behavior addressed:** For Qwen models using `compat.thinkingFormat: "qwen-chat-template"`, session `/think off` must set the outbound `chat_template_kwargs.enable_thinking` to `false`; otherwise Qwen 3.6 on llama.cpp keeps thinking enabled even though the top-level field is false.

- **Real environment tested:** Local OpenClaw checkout on macOS 26.3, branch `kiran/daily-community-20260517`, commit `4c4642b19951253b9bd0a00c056bbea71b9d538f`, Node `v25.6.1`. The probe exercised the actual `buildOpenAICompletionsParams` path plus the Qwen `createQwenThinkingWrapper` patch path and printed the outbound payload fields.

- **Exact steps or command run after the patch:** Ran a local Node probe that:
  1. builds an OpenAI-completions payload for a model with `compat.thinkingFormat: "qwen-chat-template"`,
  2. feeds the payload through `createQwenThinkingWrapper`, and
  3. prints `enable_thinking` and `chat_template_kwargs` for session-off and explicit-override cases.

- **Evidence after fix:** Copied terminal output from the probe after this patch:

  ```text
  === AFTER FIX (this PR) ===

  [session /think off, no explicit reasoning]
    request options:            <none>
    session thinkingLevel:      off
    enable_thinking (top):      false
    chat_template_kwargs:       {"enable_thinking":false}

  [session /think off, explicit reasoning=high]
    request options:            {"reasoning":"high"}
    session thinkingLevel:      off
    enable_thinking (top):      true
    chat_template_kwargs:       {"enable_thinking":true}

  [session /think medium, no explicit reasoning]
    request options:            <none>
    session thinkingLevel:      medium
    enable_thinking (top):      true
    chat_template_kwargs:       {"enable_thinking":true}
  ```

  For comparison, the same probe on `origin/main` reproduced the bad wire shape for the linked issue:

  ```text
  === BEFORE FIX (origin/main, reproducing #82768) ===

  [session /think off, no explicit reasoning]
    request options:            <none>
    session thinkingLevel:      off
    enable_thinking (top):      false
    chat_template_kwargs:       {"enable_thinking":true}
  ```

- **Observed result after fix:** The qwen-chat-template field now mirrors the wrapper's final thinking decision for the session-off path (`false`/`false`), while an explicit per-request `reasoning=high` still takes precedence (`true`/`true`). Existing `chat_template_kwargs` entries are preserved by the patch.

- **What was not tested:** Live llama.cpp + Qwen 3.6 GGUF round trip. The reporter's curl evidence in #82768 already confirms that Qwen 3.6 on llama.cpp respects `chat_template_kwargs.enable_thinking: false` and ignores the top-level field, which is the wire-level behavior this patch targets.

## Risk

- No behavior change for non-`qwen-chat-template` Qwen configurations: the new branch is gated on `compat.thinkingFormat === "qwen-chat-template"`.
- No behavior change for non-Qwen providers: the existing wrapper only attaches for canonical Qwen-family provider IDs.
- No new dependencies, no workflow changes, no secrets touched.

