### PR TITLE
fix(cli): resolve web command SecretRefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 
 - Providers/Anthropic-messages: extract `reasoning_content` from `thinking` blocks during assistant replay so proxy providers that route through the Anthropic-messages transport preserve reasoning context across tool-call follow-up turns. Thanks @Sunnyone2three.
 - Agents/GitHub Copilot: normalize replayed Responses tool-call IDs before dispatch so resumed sessions with historical overlong tool IDs continue instead of failing Copilot schema validation. (#82750) Thanks @galiniliev.
+- CLI/web: resolve provider-scoped web search/fetch SecretRefs for `infer web ... --provider ...` while leaving unrelated plugin secrets untouched. Fixes #82621. Thanks @leno23.
 - Mac app: let menu gateway/session error text wrap across a few lines and stop rebuilding dynamic Context/Gateway menu rows while the menu is open, reducing flicker.
 - Mac app: make device pairing approval sheets friendlier, with concise Mac/device copy, shortened identifiers, friendly scope labels, and Approve as the primary action.
 - Providers/Qwen: honor session thinking level for `qwen-chat-template` payloads so `/think off` disables nested llama.cpp chat-template thinking controls. Fixes #82768. Thanks @bfox55.

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1501,18 +1501,22 @@ public struct SecretsReloadParams: Codable, Sendable {}
 public struct SecretsResolveParams: Codable, Sendable {
     public let commandname: String
     public let targetids: [String]
+    public let provideroverrides: [String: AnyCodable]?
 
     public init(
         commandname: String,
-        targetids: [String])
+        targetids: [String],
+        provideroverrides: [String: AnyCodable]?)
     {
         self.commandname = commandname
         self.targetids = targetids
+        self.provideroverrides = provideroverrides
     }
 
     private enum CodingKeys: String, CodingKey {
         case commandname = "commandName"
         case targetids = "targetIds"
+        case provideroverrides = "providerOverrides"
     }
 }
 

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -4,9 +4,9 @@ import os from "node:os";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { setTimeout as scheduleNativeTimeout } from "node:timers";
+import { withMockedWindowsPlatform } from "openclaw/plugin-sdk/test-node-mocks";
 import type { Mock } from "vitest";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { withMockedWindowsPlatform } from "../../../../src/test-utils/vitest-spies.js";
 
 const { logWarnMock, logDebugMock, logInfoMock } = vi.hoisted(() => ({
   logWarnMock: vi.fn(),

--- a/extensions/whatsapp/src/media.test.ts
+++ b/extensions/whatsapp/src/media.test.ts
@@ -5,13 +5,10 @@ import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { captureEnv } from "openclaw/plugin-sdk/test-env";
 import { mockPinnedHostnameResolution } from "openclaw/plugin-sdk/test-env";
+import { withMockedWindowsPlatform, withRestoredMocks } from "openclaw/plugin-sdk/test-node-mocks";
 import { optimizeImageToPng } from "openclaw/plugin-sdk/web-media";
 import sharp from "sharp";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
-import {
-  withMockedWindowsPlatform,
-  withRestoredMocks,
-} from "../../../src/test-utils/vitest-spies.js";
 import {
   LocalMediaAccessError,
   loadWebMedia,

--- a/scripts/repro/cli-web-search-secret-refs-live-proof.mjs
+++ b/scripts/repro/cli-web-search-secret-refs-live-proof.mjs
@@ -4,7 +4,7 @@
  * Run: TAVILY_API_KEY=resolved-live-proof pnpm exec tsx scripts/repro/cli-web-search-secret-refs-live-proof.mjs
  */
 import { resolveCommandConfigWithSecrets } from "../../src/cli/command-config-resolution.js";
-import { getAgentRuntimeCommandSecretTargetIds } from "../../src/cli/command-secret-targets.js";
+import { getCapabilityWebCommandSecretTargetIds } from "../../src/cli/command-secret-targets.js";
 
 const unresolvedConfig = {
   tools: { web: { search: { provider: "tavily", enabled: true } } },
@@ -26,7 +26,7 @@ process.env.TAVILY_API_KEY = process.env.TAVILY_API_KEY ?? "resolved-live-proof"
 const { effectiveConfig, diagnostics } = await resolveCommandConfigWithSecrets({
   config: unresolvedConfig,
   commandName: "infer web search",
-  targetIds: getAgentRuntimeCommandSecretTargetIds(),
+  targetIds: getCapabilityWebCommandSecretTargetIds(),
   autoEnable: true,
 });
 

--- a/scripts/repro/cli-web-search-secret-refs-live-proof.mjs
+++ b/scripts/repro/cli-web-search-secret-refs-live-proof.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+/**
+ * Live repro for CLI infer web search SecretRef resolution (PR #82699).
+ * Run: TAVILY_API_KEY=resolved-live-proof pnpm exec tsx scripts/repro/cli-web-search-secret-refs-live-proof.mjs
+ */
+import { resolveCommandConfigWithSecrets } from "../../src/cli/command-config-resolution.js";
+import { getAgentRuntimeCommandSecretTargetIds } from "../../src/cli/command-secret-targets.js";
+
+const unresolvedConfig = {
+  tools: { web: { search: { provider: "tavily", enabled: true } } },
+  plugins: {
+    entries: {
+      tavily: {
+        config: {
+          webSearch: {
+            apiKey: { source: "env", provider: "default", id: "TAVILY_API_KEY" },
+          },
+        },
+      },
+    },
+  },
+};
+
+process.env.TAVILY_API_KEY = process.env.TAVILY_API_KEY ?? "resolved-live-proof";
+
+const { effectiveConfig, diagnostics } = await resolveCommandConfigWithSecrets({
+  config: unresolvedConfig,
+  commandName: "infer web search",
+  targetIds: getAgentRuntimeCommandSecretTargetIds(),
+  autoEnable: true,
+});
+
+const apiKey = effectiveConfig.plugins?.entries?.tavily?.config?.webSearch?.apiKey;
+const unresolved = unresolvedConfig.plugins.entries.tavily.config.webSearch.apiKey;
+
+console.log("unresolved apiKey is SecretRef object =", typeof unresolved === "object");
+console.log(
+  "resolveCommandConfigWithSecrets apiKey is string =",
+  typeof apiKey === "string" && apiKey.length > 0,
+);
+console.log(
+  "resolved apiKey prefix =",
+  typeof apiKey === "string" ? `${apiKey.slice(0, 8)}…` : apiKey,
+);
+console.log("diagnostics count =", diagnostics.length);

--- a/scripts/repro/cli-web-search-secret-refs-live-proof.mjs
+++ b/scripts/repro/cli-web-search-secret-refs-live-proof.mjs
@@ -4,7 +4,7 @@
  * Run: TAVILY_API_KEY=resolved-live-proof pnpm exec tsx scripts/repro/cli-web-search-secret-refs-live-proof.mjs
  */
 import { resolveCommandConfigWithSecrets } from "../../src/cli/command-config-resolution.js";
-import { getCapabilityWebCommandSecretTargetIds } from "../../src/cli/command-secret-targets.js";
+import { getWebSearchCommandSecretTargetIds } from "../../src/cli/command-secret-targets.js";
 
 const unresolvedConfig = {
   tools: { web: { search: { provider: "tavily", enabled: true } } },
@@ -26,7 +26,7 @@ process.env.TAVILY_API_KEY = process.env.TAVILY_API_KEY ?? "resolved-live-proof"
 const { effectiveConfig, diagnostics } = await resolveCommandConfigWithSecrets({
   config: unresolvedConfig,
   commandName: "infer web search",
-  targetIds: getCapabilityWebCommandSecretTargetIds(),
+  targetIds: getWebSearchCommandSecretTargetIds(),
   autoEnable: true,
 });
 
@@ -38,8 +38,5 @@ console.log(
   "resolveCommandConfigWithSecrets apiKey is string =",
   typeof apiKey === "string" && apiKey.length > 0,
 );
-console.log(
-  "resolved apiKey prefix =",
-  typeof apiKey === "string" ? `${apiKey.slice(0, 8)}…` : apiKey,
-);
+console.log("resolved apiKey remains redacted =", typeof apiKey === "string");
 console.log("diagnostics count =", diagnostics.length);

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -2254,6 +2254,7 @@ describe("capability cli", () => {
         commandName: "infer web search",
         targetIds,
         allowedPaths,
+        providerOverrides: { webSearch: "tavily" },
         runtime: mocks.runtime,
       }),
     );
@@ -2334,6 +2335,7 @@ describe("capability cli", () => {
         commandName: "infer web fetch",
         targetIds,
         allowedPaths,
+        providerOverrides: { webFetch: "firecrawl" },
         runtime: mocks.runtime,
       }),
     );

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -683,6 +683,7 @@ async function resolveLocalCapabilityRuntimeConfig(params: {
   commandName: string;
   targetIds: Set<string>;
   allowedPaths?: Set<string>;
+  providerOverrides?: { webSearch?: string; webFetch?: string };
   config?: OpenClawConfig;
 }): Promise<OpenClawConfig> {
   const cfg = params.config ?? getRuntimeConfig();
@@ -692,6 +693,7 @@ async function resolveLocalCapabilityRuntimeConfig(params: {
     commandName: params.commandName,
     targetIds: params.targetIds,
     ...(params.allowedPaths ? { allowedPaths: params.allowedPaths } : {}),
+    ...(params.providerOverrides ? { providerOverrides: params.providerOverrides } : {}),
     runtime: defaultRuntime,
   });
   if (sourceConfig) {
@@ -1614,14 +1616,16 @@ async function runTtsStateMutation(params: {
 async function runWebSearchCommand(params: { query: string; provider?: string; limit?: number }) {
   const rawConfig = getRuntimeConfig();
   const config = withWebProviderOverride(rawConfig, "search", params.provider);
+  const provider = normalizeOptionalString(params.provider);
   const secretTargets = getWebSearchCommandSecretTargets({
     config,
-    provider: params.provider,
+    provider,
   });
   const cfg = await resolveLocalCapabilityRuntimeConfig({
     commandName: "infer web search",
     targetIds: secretTargets.targetIds,
     ...(secretTargets.allowedPaths ? { allowedPaths: secretTargets.allowedPaths } : {}),
+    ...(provider ? { providerOverrides: { webSearch: provider } } : {}),
     config,
   });
   const result = await runWebSearch({
@@ -1647,14 +1651,16 @@ async function runWebSearchCommand(params: { query: string; provider?: string; l
 async function runWebFetchCommand(params: { url: string; provider?: string; format?: string }) {
   const rawConfig = getRuntimeConfig();
   const config = withWebProviderOverride(rawConfig, "fetch", params.provider);
+  const provider = normalizeOptionalString(params.provider);
   const secretTargets = getWebFetchCommandSecretTargets({
     config,
-    provider: params.provider,
+    provider,
   });
   const cfg = await resolveLocalCapabilityRuntimeConfig({
     commandName: "infer web fetch",
     targetIds: secretTargets.targetIds,
     ...(secretTargets.allowedPaths ? { allowedPaths: secretTargets.allowedPaths } : {}),
+    ...(provider ? { providerOverrides: { webFetch: provider } } : {}),
     config,
   });
   const resolved = resolveWebFetchDefinition({

--- a/src/cli/command-config-resolution.test.ts
+++ b/src/cli/command-config-resolution.test.ts
@@ -79,4 +79,25 @@ describe("resolveCommandConfigWithSecrets", () => {
     });
     expect(result.effectiveConfig).toBe(effectiveConfig);
   });
+
+  it("passes provider overrides to command secret resolution", async () => {
+    const config = { tools: { web: { search: { provider: "tavily" } } } };
+    mocks.resolveCommandSecretRefsViaGateway.mockResolvedValue({
+      resolvedConfig: config,
+      diagnostics: [],
+    });
+
+    await resolveCommandConfigWithSecrets({
+      config,
+      commandName: "infer web search",
+      targetIds: new Set(["plugins.entries.*.config.webSearch.apiKey"]),
+      providerOverrides: { webSearch: "tavily" },
+    });
+
+    expect(mocks.resolveCommandSecretRefsViaGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerOverrides: { webSearch: "tavily" },
+      }),
+    );
+  });
 });

--- a/src/cli/command-config-resolution.ts
+++ b/src/cli/command-config-resolution.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../config/types.js";
 import type { RuntimeEnv } from "../runtime.js";
 import {
   type CommandSecretResolutionMode,
+  type CommandSecretsProviderOverrides,
   resolveCommandSecretRefsViaGateway,
 } from "./command-secret-gateway.js";
 
@@ -12,6 +13,7 @@ export async function resolveCommandConfigWithSecrets<TConfig extends OpenClawCo
   targetIds: Set<string>;
   mode?: CommandSecretResolutionMode;
   allowedPaths?: Set<string>;
+  providerOverrides?: CommandSecretsProviderOverrides;
   runtime?: RuntimeEnv;
   autoEnable?: boolean;
   env?: NodeJS.ProcessEnv;
@@ -26,6 +28,7 @@ export async function resolveCommandConfigWithSecrets<TConfig extends OpenClawCo
     targetIds: params.targetIds,
     ...(params.mode ? { mode: params.mode } : {}),
     ...(params.allowedPaths ? { allowedPaths: params.allowedPaths } : {}),
+    ...(params.providerOverrides ? { providerOverrides: params.providerOverrides } : {}),
   });
   if (params.runtime) {
     for (const entry of diagnostics) {

--- a/src/cli/command-secret-gateway.test.ts
+++ b/src/cli/command-secret-gateway.test.ts
@@ -543,9 +543,10 @@ describe("resolveCommandSecretRefsViaGateway", () => {
         targetIds: new Set(["tools.web.fetch.firecrawl.apiKey"]),
       });
 
-      expect(result.resolvedConfig.tools?.web?.fetch?.firecrawl?.apiKey).toBe(
-        "legacy-firecrawl-local-fallback-key",
-      );
+      const resolvedFetch = result.resolvedConfig.tools?.web?.fetch as
+        | { firecrawl?: { apiKey?: unknown } }
+        | undefined;
+      expect(resolvedFetch?.firecrawl?.apiKey).toBe("legacy-firecrawl-local-fallback-key");
       expect(result.targetStatesByPath["tools.web.fetch.firecrawl.apiKey"]).toBe("resolved_local");
       expectGatewayUnavailableLocalFallbackDiagnostics(result);
     });

--- a/src/cli/command-secret-gateway.test.ts
+++ b/src/cli/command-secret-gateway.test.ts
@@ -172,6 +172,103 @@ describe("resolveCommandSecretRefsViaGateway", () => {
     expect(readTalkProviderApiKey(result.resolvedConfig)).toBe("sk-live");
   });
 
+  it("passes command provider overrides to gateway secret resolution", async () => {
+    callGateway.mockResolvedValueOnce({
+      assignments: [
+        {
+          path: TALK_TEST_PROVIDER_API_KEY_PATH,
+          pathSegments: [...TALK_TEST_PROVIDER_API_KEY_PATH_SEGMENTS],
+          value: "sk-live",
+        },
+      ],
+      diagnostics: [],
+    });
+    const config = buildTalkTestProviderConfig({
+      source: "env",
+      provider: "default",
+      id: "TALK_API_KEY",
+    });
+
+    await resolveCommandSecretRefsViaGateway({
+      config,
+      commandName: "infer web search",
+      targetIds: new Set(["talk.providers.*.apiKey"]),
+      providerOverrides: { webSearch: "tavily" },
+    });
+
+    expect(callGateway.mock.calls[0]?.[0]?.params).toEqual({
+      commandName: "infer web search",
+      targetIds: ["talk.providers.*.apiKey"],
+      providerOverrides: { webSearch: "tavily" },
+    });
+  });
+
+  it("applies provider overrides during unavailable-gateway local fallback", async () => {
+    const restoreDeps = commandSecretGatewayTesting.setDepsForTest({
+      collectConfigAssignments: ({ context }) => {
+        context.assignments.push({
+          path: "plugins.entries.google.config.webSearch.apiKey",
+        } as never);
+      },
+      resolveManifestContractOwnerPluginId: (params) =>
+        params.contract === "webSearchProviders" && params.value === "gemini"
+          ? "google"
+          : undefined,
+    });
+    const envKey = "WEB_SEARCH_GEMINI_OVERRIDE_LOCAL_FALLBACK";
+    await withEnvValue(envKey, "gemini-override-local-fallback-key", async () => {
+      try {
+        callGateway.mockRejectedValueOnce(new Error("gateway closed"));
+        const result = await resolveCommandSecretRefsViaGateway({
+          config: {
+            tools: {
+              web: {
+                search: {
+                  provider: "brave",
+                  apiKey: {
+                    source: "env",
+                    provider: "default",
+                    id: "WEB_SEARCH_BRAVE_MISSING_LOCAL_FALLBACK",
+                  },
+                },
+              },
+            },
+            plugins: {
+              entries: {
+                google: {
+                  config: {
+                    webSearch: {
+                      apiKey: { source: "env", provider: "default", id: envKey },
+                    },
+                  },
+                },
+              },
+            },
+          } as unknown as OpenClawConfig,
+          commandName: "infer web search",
+          targetIds: new Set([
+            "tools.web.search.apiKey",
+            "plugins.entries.google.config.webSearch.apiKey",
+          ]),
+          providerOverrides: { webSearch: "gemini" },
+        });
+
+        const googleWebSearchConfig = result.resolvedConfig.plugins?.entries?.google?.config as
+          | { webSearch?: { apiKey?: unknown } }
+          | undefined;
+        expect(result.resolvedConfig.tools?.web?.search?.provider).toBe("gemini");
+        expect(googleWebSearchConfig?.webSearch?.apiKey).toBe("gemini-override-local-fallback-key");
+        expect(result.targetStatesByPath["plugins.entries.google.config.webSearch.apiKey"]).toBe(
+          "resolved_local",
+        );
+        expect(result.targetStatesByPath["tools.web.search.apiKey"]).toBe("inactive_surface");
+        expectGatewayUnavailableLocalFallbackDiagnostics(result);
+      } finally {
+        restoreDeps();
+      }
+    });
+  });
+
   it("enforces unresolved checks only for allowed paths when provided", async () => {
     const restoreDeps = commandSecretGatewayTesting.setDepsForTest({
       analyzeCommandSecretAssignmentsFromSnapshot: () =>
@@ -425,6 +522,35 @@ describe("resolveCommandSecretRefsViaGateway", () => {
     });
   });
 
+  it("falls back to local resolution for legacy web fetch SecretRefs when gateway is unavailable", async () => {
+    const envKey = "WEB_FETCH_FIRECRAWL_LEGACY_LOCAL_FALLBACK";
+    await withEnvValue(envKey, "legacy-firecrawl-local-fallback-key", async () => {
+      callGateway.mockRejectedValueOnce(new Error("gateway closed"));
+      const result = await resolveCommandSecretRefsViaGateway({
+        config: {
+          tools: {
+            web: {
+              fetch: {
+                provider: "firecrawl",
+                firecrawl: {
+                  apiKey: { source: "env", provider: "default", id: envKey },
+                },
+              },
+            },
+          },
+        } as unknown as OpenClawConfig,
+        commandName: "infer web fetch",
+        targetIds: new Set(["tools.web.fetch.firecrawl.apiKey"]),
+      });
+
+      expect(result.resolvedConfig.tools?.web?.fetch?.firecrawl?.apiKey).toBe(
+        "legacy-firecrawl-local-fallback-key",
+      );
+      expect(result.targetStatesByPath["tools.web.fetch.firecrawl.apiKey"]).toBe("resolved_local");
+      expectGatewayUnavailableLocalFallbackDiagnostics(result);
+    });
+  });
+
   it("marks web SecretRefs inactive when the web surface is disabled during local fallback", async () => {
     const restoreDeps = commandSecretGatewayTesting.setDepsForTest({
       collectConfigAssignments: ({ context }) => {
@@ -467,6 +593,7 @@ describe("resolveCommandSecretRefsViaGateway", () => {
         } as OpenClawConfig,
         commandName: "agent",
         targetIds: new Set(["plugins.entries.google.config.webSearch.apiKey"]),
+        providerOverrides: { webSearch: "gemini" },
       });
 
       expect(result.hadUnresolvedTargets).toBe(false);

--- a/src/cli/command-secret-gateway.ts
+++ b/src/cli/command-secret-gateway.ts
@@ -5,6 +5,7 @@ import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../gateway/protocol/
 import { validateSecretsResolveResult } from "../gateway/protocol/index.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { resolveManifestContractOwnerPluginId } from "../plugins/plugin-registry.js";
+import { resolveBundledExplicitWebSearchProvidersFromPublicArtifacts } from "../plugins/web-provider-public-artifacts.explicit.js";
 import {
   analyzeCommandSecretAssignmentsFromSnapshot,
   type UnresolvedCommandSecretAssignment,
@@ -19,7 +20,10 @@ import {
   discoverConfigSecretTargetsByIds,
   type DiscoveredConfigSecretTarget,
 } from "../secrets/target-registry.js";
-import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalString,
+} from "../shared/string-coerce.js";
 
 type ResolveCommandSecretsResult = {
   resolvedConfig: OpenClawConfig;
@@ -56,8 +60,16 @@ type GatewaySecretsResolveResult = {
   inactiveRefPaths?: string[];
 };
 
-const WEB_RUNTIME_SECRET_TARGET_ID_PREFIXES = ["tools.web.search", "plugins.entries."] as const;
-const WEB_RUNTIME_SECRET_PATH_PREFIXES = ["tools.web.search.", "plugins.entries."] as const;
+const WEB_RUNTIME_SECRET_TARGET_ID_PREFIXES = [
+  "tools.web.search",
+  "tools.web.fetch",
+  "plugins.entries.",
+] as const;
+const WEB_RUNTIME_SECRET_PATH_PREFIXES = [
+  "tools.web.search.",
+  "tools.web.fetch.",
+  "plugins.entries.",
+] as const;
 
 type CommandSecretGatewayDeps = {
   analyzeCommandSecretAssignmentsFromSnapshot: typeof analyzeCommandSecretAssignmentsFromSnapshot;
@@ -65,6 +77,11 @@ type CommandSecretGatewayDeps = {
   discoverConfigSecretTargetsByIds: typeof discoverConfigSecretTargetsByIds;
   resolveManifestContractOwnerPluginId: typeof resolveManifestContractOwnerPluginId;
   resolveRuntimeWebTools: typeof resolveRuntimeWebTools;
+};
+
+export type CommandSecretsProviderOverrides = {
+  webSearch?: string;
+  webFetch?: string;
 };
 
 const commandSecretGatewayDeps: CommandSecretGatewayDeps = {
@@ -97,6 +114,115 @@ export const __testing = {
 function pluginIdFromRuntimeWebPath(path: string): string | undefined {
   const match = /^plugins\.entries\.([^.]+)\.config\.(webSearch|webFetch)\.apiKey$/.exec(path);
   return match?.[1];
+}
+
+function applyProviderOverridesToConfig(
+  config: OpenClawConfig,
+  overrides: CommandSecretsProviderOverrides | undefined,
+): OpenClawConfig {
+  if (
+    !normalizeOptionalString(overrides?.webSearch) &&
+    !normalizeOptionalString(overrides?.webFetch)
+  ) {
+    return config;
+  }
+  const next = structuredClone(config);
+  const tools = (next.tools ??= {}) as Record<string, unknown>;
+  const web = (tools.web ??= {}) as Record<string, unknown>;
+  const webSearch = normalizeOptionalString(overrides?.webSearch);
+  if (webSearch) {
+    const search = (web.search ??= {}) as Record<string, unknown>;
+    search.provider = webSearch;
+  }
+  const webFetch = normalizeOptionalString(overrides?.webFetch);
+  if (webFetch) {
+    const fetch = (web.fetch ??= {}) as Record<string, unknown>;
+    fetch.provider = webFetch;
+  }
+  return next;
+}
+
+function webSearchProviderUsesSharedSearchCredential(params: {
+  config: OpenClawConfig;
+  provider: string;
+}): boolean {
+  const sentinel = "__openclaw_shared_web_search_probe__";
+  const pluginId = commandSecretGatewayDeps.resolveManifestContractOwnerPluginId({
+    contract: "webSearchProviders",
+    value: params.provider,
+    origin: "bundled",
+    config: params.config,
+  });
+  if (!pluginId) {
+    return false;
+  }
+  const providers = resolveBundledExplicitWebSearchProvidersFromPublicArtifacts({
+    onlyPluginIds: [pluginId],
+  });
+  const provider = providers?.find((entry) => entry.id === params.provider);
+  return (
+    provider?.credentialPath === "tools.web.search.apiKey" ||
+    provider?.getCredentialValue({ apiKey: sentinel }) === sentinel ||
+    provider?.getConfiguredCredentialFallback?.(params.config)?.path === "tools.web.search.apiKey"
+  );
+}
+
+function isProviderOverridePath(params: {
+  config: OpenClawConfig;
+  path: string;
+  providerOverrides: CommandSecretsProviderOverrides | undefined;
+}): boolean {
+  const webSearch = normalizeOptionalString(params.providerOverrides?.webSearch);
+  if (webSearch) {
+    if (params.config.tools?.web?.search?.enabled === false) {
+      return false;
+    }
+    if (params.path === "tools.web.search.apiKey") {
+      return webSearchProviderUsesSharedSearchCredential({
+        config: params.config,
+        provider: webSearch,
+      });
+    }
+    const directSearchProvider = /^tools\.web\.search\.([^.]+)\.apiKey$/.exec(params.path)?.[1];
+    if (directSearchProvider) {
+      return directSearchProvider === webSearch;
+    }
+    const pluginId = pluginIdFromRuntimeWebPath(params.path);
+    if (pluginId && params.path.endsWith(".config.webSearch.apiKey")) {
+      return (
+        commandSecretGatewayDeps.resolveManifestContractOwnerPluginId({
+          contract: "webSearchProviders",
+          value: webSearch,
+          origin: "bundled",
+          config: params.config,
+        }) === pluginId
+      );
+    }
+  }
+
+  const webFetch = normalizeOptionalString(params.providerOverrides?.webFetch);
+  if (webFetch) {
+    if (params.config.tools?.web?.fetch?.enabled === false) {
+      return false;
+    }
+    const directFetchProvider = /^tools\.web\.fetch\.([^.]+)\.apiKey$/.exec(params.path)?.[1];
+    if (directFetchProvider) {
+      return directFetchProvider === webFetch;
+    }
+    const pluginId = pluginIdFromRuntimeWebPath(params.path);
+    if (pluginId && params.path.endsWith(".config.webFetch.apiKey")) {
+      return (
+        commandSecretGatewayDeps.resolveManifestContractOwnerPluginId({
+          contract: "webFetchProviders",
+          value: webFetch,
+          origin: "bundled",
+          config: params.config,
+        }) === pluginId
+      );
+    }
+  }
+
+  return false;
 }
 
 function normalizeCommandSecretResolutionMode(
@@ -136,7 +262,22 @@ function targetsRuntimeWebPath(path: string): boolean {
 function classifyRuntimeWebTargetPathState(params: {
   config: OpenClawConfig;
   path: string;
+  providerOverrides?: CommandSecretsProviderOverrides;
 }): "active" | "inactive" | "unknown" {
+  if (
+    (normalizeOptionalString(params.providerOverrides?.webSearch) ||
+      normalizeOptionalString(params.providerOverrides?.webFetch)) &&
+    isDirectRuntimeWebTargetPath(params.path)
+  ) {
+    return isProviderOverridePath({
+      config: params.config,
+      path: params.path,
+      providerOverrides: params.providerOverrides,
+    })
+      ? "active"
+      : "inactive";
+  }
+
   if (params.path === "tools.web.search.apiKey") {
     return params.config.tools?.web?.search?.enabled !== false ? "active" : "inactive";
   }
@@ -179,28 +320,74 @@ function classifyRuntimeWebTargetPathState(params: {
       : "inactive";
   }
 
-  const match = /^tools\.web\.search\.([^.]+)\.apiKey$/.exec(params.path);
-  if (!match) {
+  const directSearchMatch = /^tools\.web\.search\.([^.]+)\.apiKey$/.exec(params.path);
+  if (directSearchMatch) {
+    const search = params.config.tools?.web?.search;
+    if (search?.enabled === false) {
+      return "inactive";
+    }
+
+    const configuredProvider = normalizeLowercaseStringOrEmpty(search?.provider);
+    if (!configuredProvider) {
+      return "active";
+    }
+
+    return configuredProvider === directSearchMatch[1] ? "active" : "inactive";
+  }
+
+  const directFetchMatch = /^tools\.web\.fetch\.([^.]+)\.apiKey$/.exec(params.path);
+  if (!directFetchMatch) {
     return "unknown";
   }
 
-  const search = params.config.tools?.web?.search;
-  if (search?.enabled === false) {
+  const fetch = params.config.tools?.web?.fetch;
+  if (fetch?.enabled === false) {
     return "inactive";
   }
 
-  const configuredProvider = normalizeLowercaseStringOrEmpty(search?.provider);
+  const configuredProvider = normalizeLowercaseStringOrEmpty(fetch?.provider);
   if (!configuredProvider) {
     return "active";
   }
 
-  return configuredProvider === match[1] ? "active" : "inactive";
+  return configuredProvider === directFetchMatch[1] ? "active" : "inactive";
 }
 
 function describeInactiveRuntimeWebTargetPath(params: {
   config: OpenClawConfig;
   path: string;
+  providerOverrides?: CommandSecretsProviderOverrides;
 }): string | undefined {
+  if (
+    params.config.tools?.web?.search?.enabled === false &&
+    (params.path === "tools.web.search.apiKey" ||
+      params.path.startsWith("tools.web.search.") ||
+      params.path.includes(".webSearch."))
+  ) {
+    return "tools.web.search is disabled.";
+  }
+  if (
+    params.config.tools?.web?.fetch?.enabled === false &&
+    (params.path.startsWith("tools.web.fetch.") || params.path.includes(".webFetch."))
+  ) {
+    return "tools.web.fetch is disabled.";
+  }
+
+  const webSearchOverride = normalizeOptionalString(params.providerOverrides?.webSearch);
+  if (webSearchOverride && params.path.includes(".webSearch.")) {
+    return `tools.web.search.provider is "${webSearchOverride}".`;
+  }
+  if (webSearchOverride && params.path.startsWith("tools.web.search.")) {
+    return `tools.web.search.provider is "${webSearchOverride}".`;
+  }
+  const webFetchOverride = normalizeOptionalString(params.providerOverrides?.webFetch);
+  if (webFetchOverride && params.path.includes(".webFetch.")) {
+    return `tools.web.fetch.provider is "${webFetchOverride}".`;
+  }
+  if (webFetchOverride && params.path.startsWith("tools.web.fetch.")) {
+    return `tools.web.fetch.provider is "${webFetchOverride}".`;
+  }
+
   if (params.path === "tools.web.search.apiKey") {
     return params.config.tools?.web?.search?.enabled === false
       ? "tools.web.search is disabled."
@@ -239,19 +426,34 @@ function describeInactiveRuntimeWebTargetPath(params: {
     return undefined;
   }
 
-  const match = /^tools\.web\.search\.([^.]+)\.apiKey$/.exec(params.path);
-  if (!match) {
+  const directSearchMatch = /^tools\.web\.search\.([^.]+)\.apiKey$/.exec(params.path);
+  if (directSearchMatch) {
+    const search = params.config.tools?.web?.search;
+    if (search?.enabled === false) {
+      return "tools.web.search is disabled.";
+    }
+
+    const configuredProvider = normalizeLowercaseStringOrEmpty(search?.provider);
+    if (configuredProvider && configuredProvider !== directSearchMatch[1]) {
+      return `tools.web.search.provider is "${configuredProvider}".`;
+    }
+
     return undefined;
   }
 
-  const search = params.config.tools?.web?.search;
-  if (search?.enabled === false) {
-    return "tools.web.search is disabled.";
+  const directFetchMatch = /^tools\.web\.fetch\.([^.]+)\.apiKey$/.exec(params.path);
+  if (!directFetchMatch) {
+    return undefined;
   }
 
-  const configuredProvider = normalizeLowercaseStringOrEmpty(search?.provider);
-  if (configuredProvider && configuredProvider !== match[1]) {
-    return `tools.web.search.provider is "${configuredProvider}".`;
+  const fetch = params.config.tools?.web?.fetch;
+  if (fetch?.enabled === false) {
+    return "tools.web.fetch is disabled.";
+  }
+
+  const configuredProvider = normalizeLowercaseStringOrEmpty(fetch?.provider);
+  if (configuredProvider && configuredProvider !== directFetchMatch[1]) {
+    return `tools.web.fetch.provider is "${configuredProvider}".`;
   }
 
   return undefined;
@@ -407,8 +609,9 @@ function isUnsupportedSecretsResolveError(err: unknown): boolean {
 
 function isDirectRuntimeWebTargetPath(path: string): boolean {
   return (
+    path === "tools.web.search.apiKey" ||
     /^plugins\.entries\.[^.]+\.config\.(webSearch|webFetch)\.apiKey$/.test(path) ||
-    /^tools\.web\.search\.[^.]+\.apiKey$/.test(path)
+    /^tools\.web\.(search|fetch)\.[^.]+\.apiKey$/.test(path)
   );
 }
 
@@ -419,9 +622,10 @@ async function resolveCommandSecretRefsLocally(params: {
   preflightDiagnostics: string[];
   mode: CommandSecretResolutionMode;
   allowedPaths?: ReadonlySet<string>;
+  providerOverrides?: CommandSecretsProviderOverrides;
 }): Promise<ResolveCommandSecretsResult> {
-  const sourceConfig = params.config;
-  const resolvedConfig = structuredClone(params.config);
+  const sourceConfig = applyProviderOverridesToConfig(params.config, params.providerOverrides);
+  const resolvedConfig = structuredClone(sourceConfig);
   const context = createResolverContext({
     sourceConfig,
     env: process.env,
@@ -434,7 +638,7 @@ async function resolveCommandSecretRefsLocally(params: {
     targetsRuntimeWebPath(target.path),
   );
   commandSecretGatewayDeps.collectConfigAssignments({
-    config: structuredClone(params.config),
+    config: structuredClone(sourceConfig),
     context,
   });
   if (
@@ -471,12 +675,14 @@ async function resolveCommandSecretRefsLocally(params: {
     const runtimeState = classifyRuntimeWebTargetPathState({
       config: sourceConfig,
       path: target.path,
+      providerOverrides: params.providerOverrides,
     });
     if (runtimeState === "inactive") {
       inactiveRefPaths.add(target.path);
       const inactiveDetail = describeInactiveRuntimeWebTargetPath({
         config: sourceConfig,
         path: target.path,
+        providerOverrides: params.providerOverrides,
       });
       if (inactiveDetail) {
         runtimeWebInactiveDiagnostics.push(`${target.path}: ${inactiveDetail}`);
@@ -657,28 +863,30 @@ export async function resolveCommandSecretRefsViaGateway(params: {
   targetIds: Set<string>;
   mode?: CommandSecretResolutionModeInput;
   allowedPaths?: ReadonlySet<string>;
+  providerOverrides?: CommandSecretsProviderOverrides;
 }): Promise<ResolveCommandSecretsResult> {
   const mode = normalizeCommandSecretResolutionMode(params.mode);
+  const commandConfig = applyProviderOverridesToConfig(params.config, params.providerOverrides);
   const configuredTargetRefPaths = collectConfiguredTargetRefPaths({
-    config: params.config,
+    config: commandConfig,
     targetIds: params.targetIds,
     allowedPaths: params.allowedPaths,
   });
   if (configuredTargetRefPaths.size === 0) {
     return {
-      resolvedConfig: params.config,
+      resolvedConfig: commandConfig,
       diagnostics: [],
       targetStatesByPath: {},
       hadUnresolvedTargets: false,
     };
   }
   const preflight = classifyConfiguredTargetRefs({
-    config: params.config,
+    config: commandConfig,
     configuredTargetRefPaths,
   });
   if (!preflight.hasActiveConfiguredRef && !preflight.hasUnknownConfiguredRef) {
     return {
-      resolvedConfig: params.config,
+      resolvedConfig: commandConfig,
       diagnostics: preflight.diagnostics,
       targetStatesByPath: {},
       hadUnresolvedTargets: false,
@@ -694,6 +902,7 @@ export async function resolveCommandSecretRefsViaGateway(params: {
       params: {
         commandName: params.commandName,
         targetIds: [...params.targetIds],
+        ...(params.providerOverrides ? { providerOverrides: params.providerOverrides } : {}),
       },
       timeoutMs: 30_000,
       clientName: GATEWAY_CLIENT_NAMES.CLI,
@@ -708,6 +917,7 @@ export async function resolveCommandSecretRefsViaGateway(params: {
         preflightDiagnostics: preflight.diagnostics,
         mode,
         allowedPaths: params.allowedPaths,
+        providerOverrides: params.providerOverrides,
       });
       const recoveredLocally = Object.values(fallback.targetStatesByPath).some(
         (state) => state === "resolved_local",
@@ -741,7 +951,7 @@ export async function resolveCommandSecretRefsViaGateway(params: {
   }
 
   const parsed = parseGatewaySecretsResolveResult(payload);
-  const resolvedConfig = structuredClone(params.config);
+  const resolvedConfig = structuredClone(commandConfig);
   for (const assignment of parsed.assignments) {
     const pathSegments = assignment.pathSegments.filter((segment) => segment.length > 0);
     if (pathSegments.length === 0) {
@@ -762,7 +972,7 @@ export async function resolveCommandSecretRefsViaGateway(params: {
       ? new Set(parsed.inactiveRefPaths)
       : collectInactiveSurfacePathsFromDiagnostics(parsed.diagnostics);
   const analyzed = commandSecretGatewayDeps.analyzeCommandSecretAssignmentsFromSnapshot({
-    sourceConfig: params.config,
+    sourceConfig: commandConfig,
     resolvedConfig,
     targetIds: params.targetIds,
     inactiveRefPaths,
@@ -782,6 +992,7 @@ export async function resolveCommandSecretRefsViaGateway(params: {
         preflightDiagnostics: [],
         mode,
         allowedPaths: new Set(analyzed.unresolved.map((entry) => entry.path)),
+        providerOverrides: params.providerOverrides,
       });
       for (const unresolved of analyzed.unresolved) {
         if (localFallback.targetStatesByPath[unresolved.path] !== "resolved_local") {

--- a/src/cli/command-secret-targets.test.ts
+++ b/src/cli/command-secret-targets.test.ts
@@ -136,6 +136,7 @@ describe("command secret target ids", () => {
     expect(ids.has("agents.list[].memorySearch.remote.apiKey")).toBe(true);
     expect(ids.has("plugins.entries.firecrawl.config.webFetch.apiKey")).toBe(true);
     expect(ids.has("plugins.entries.exa.config.webSearch.apiKey")).toBe(true);
+    expect(ids.has("tools.web.fetch.firecrawl.apiKey")).toBe(true);
     expect(ids.has("channels.discord.token")).toBe(false);
   });
 

--- a/src/cli/command-secret-targets.test.ts
+++ b/src/cli/command-secret-targets.test.ts
@@ -153,6 +153,7 @@ describe("command secret target ids", () => {
       new Set([
         "plugins.entries.firecrawl.config.webFetch.apiKey",
         "plugins.entries.readerlab.config.webFetch.apiKey",
+        "tools.web.fetch.firecrawl.apiKey",
       ]),
     );
     expect(webFetch.has("plugins.entries.exa.config.webSearch.apiKey")).toBe(false);
@@ -327,6 +328,25 @@ describe("command secret target ids", () => {
     expect(externalOwner.allowedPaths).toEqual(
       new Set(["plugins.entries.readerlab.config.webFetch.apiKey"]),
     );
+  });
+
+  it("keeps legacy Firecrawl web fetch targets available for selected fetch commands", () => {
+    const selected = getWebFetchCommandSecretTargets({
+      config: {
+        tools: {
+          web: {
+            fetch: {
+              provider: "firecrawl",
+              firecrawl: { apiKey: { source: "env", id: "FIRECRAWL_API_KEY" } },
+            },
+          },
+        },
+      } as never,
+      provider: "firecrawl",
+    });
+
+    expect(selected.targetIds.has("tools.web.fetch.firecrawl.apiKey")).toBe(true);
+    expect(selected.allowedPaths).toEqual(new Set(["tools.web.fetch.firecrawl.apiKey"]));
   });
 
   it("includes channel targets for agent runtime when delivery needs them", () => {

--- a/src/cli/command-secret-targets.test.ts
+++ b/src/cli/command-secret-targets.test.ts
@@ -82,6 +82,11 @@ vi.mock("../secrets/target-registry.js", () => ({
         record(`plugins.entries.${pluginId}.config.webFetch.apiKey`);
       }
     }
+    const tools = (config as { tools?: { web?: { fetch?: { firecrawl?: { apiKey?: unknown } } } } })
+      ?.tools;
+    if (tools?.web?.fetch?.firecrawl?.apiKey !== undefined) {
+      record("tools.web.fetch.firecrawl.apiKey");
+    }
     return out;
   }),
 }));

--- a/src/cli/command-secret-targets.ts
+++ b/src/cli/command-secret-targets.ts
@@ -36,6 +36,7 @@ const STATIC_AGENT_RUNTIME_BASE_TARGET_IDS = [
   "messages.tts.providers.*.apiKey",
   "skills.entries.*.apiKey",
   "tools.web.search.apiKey",
+  "tools.web.fetch.firecrawl.apiKey",
 ] as const;
 const STATIC_MEMORY_EMBEDDING_TARGET_IDS = [
   ...STATIC_MODEL_TARGET_IDS,

--- a/src/cli/command-secret-targets.ts
+++ b/src/cli/command-secret-targets.ts
@@ -48,6 +48,7 @@ const STATIC_TTS_TARGET_IDS = [
   "messages.tts.providers.*.apiKey",
 ] as const;
 const STATIC_WEB_SEARCH_TARGET_IDS = ["tools.web.search.apiKey"] as const;
+const STATIC_WEB_FETCH_TARGET_IDS = ["tools.web.fetch.firecrawl.apiKey"] as const;
 const STATIC_STATUS_TARGET_IDS = [
   "agents.defaults.memorySearch.remote.apiKey",
   "agents.list[].memorySearch.remote.apiKey",
@@ -303,7 +304,10 @@ export function getWebSearchCommandSecretTargetIds(): Set<string> {
 }
 
 export function getWebFetchCommandSecretTargetIds(): Set<string> {
-  return toTargetIdSet(getPluginWebCredentialTargetIds("webFetch.apiKey"));
+  return toTargetIdSet([
+    ...STATIC_WEB_FETCH_TARGET_IDS,
+    ...getPluginWebCredentialTargetIds("webFetch.apiKey"),
+  ]);
 }
 
 function getConfiguredWebProviderId(
@@ -461,6 +465,12 @@ export function getWebFetchCommandSecretTargets(params: {
         pluginsWithFetchCredential.add(pluginId);
       }
     }
+  }
+  if (
+    webFetchPaths.has("tools.web.fetch.firecrawl.apiKey") &&
+    (!selectedPluginId || selectedPluginId === "firecrawl" || providerId === "firecrawl")
+  ) {
+    allowedPaths.add("tools.web.fetch.firecrawl.apiKey");
   }
   for (const path of webSearchPaths) {
     const pluginId = pluginIdFromWebCredentialPath(path, "webSearch.apiKey");

--- a/src/gateway/protocol/schema/secrets.ts
+++ b/src/gateway/protocol/schema/secrets.ts
@@ -7,6 +7,15 @@ export const SecretsResolveParamsSchema = Type.Object(
   {
     commandName: NonEmptyString,
     targetIds: Type.Array(NonEmptyString),
+    providerOverrides: Type.Optional(
+      Type.Object(
+        {
+          webSearch: Type.Optional(NonEmptyString),
+          webFetch: Type.Optional(NonEmptyString),
+        },
+        { additionalProperties: false },
+      ),
+    ),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-aux-handlers.ts
+++ b/src/gateway/server-aux-handlers.ts
@@ -223,11 +223,12 @@ export function createGatewayAuxHandlers(params: {
               }
             }),
           log: params.log,
-          resolveSecrets: async ({ commandName, targetIds }) => {
+          resolveSecrets: async ({ commandName, targetIds, providerOverrides }) => {
             const { assignments, diagnostics, inactiveRefPaths } =
-              resolveCommandSecretsFromActiveRuntimeSnapshot({
+              await resolveCommandSecretsFromActiveRuntimeSnapshot({
                 commandName,
                 targetIds: new Set(targetIds),
+                ...(providerOverrides ? { providerOverrides } : {}),
               });
             if (assignments.length === 0) {
               return {

--- a/src/gateway/server-methods/secrets.test.ts
+++ b/src/gateway/server-methods/secrets.test.ts
@@ -26,12 +26,14 @@ async function invokeSecretsResolve(params: {
   respond: ReturnType<typeof vi.fn>;
   commandName: unknown;
   targetIds: unknown;
+  providerOverrides?: unknown;
 }) {
   await params.handlers["secrets.resolve"]({
     req: { type: "req", id: "1", method: "secrets.resolve" },
     params: {
       commandName: params.commandName,
       targetIds: params.targetIds,
+      ...(params.providerOverrides ? { providerOverrides: params.providerOverrides } : {}),
     },
     client: null,
     isWebchatConnect: () => false,
@@ -70,7 +72,11 @@ function expectWarnMessageWith(warn: ReturnType<typeof vi.fn>, text: string): vo
 describe("secrets handlers", () => {
   function createHandlers(overrides?: {
     reloadSecrets?: () => Promise<{ warningCount: number }>;
-    resolveSecrets?: (params: { commandName: string; targetIds: string[] }) => Promise<{
+    resolveSecrets?: (params: {
+      commandName: string;
+      targetIds: string[];
+      providerOverrides?: { webSearch?: string; webFetch?: string };
+    }) => Promise<{
       assignments: Array<{ path: string; pathSegments: string[]; value: unknown }>;
       diagnostics: string[];
       inactiveRefPaths: string[];
@@ -152,6 +158,36 @@ describe("secrets handlers", () => {
       diagnostics: ["note"],
       inactiveRefPaths: [TALK_TEST_PROVIDER_API_KEY_PATH],
     });
+  });
+
+  it("passes trimmed provider overrides to secrets.resolve", async () => {
+    const resolveSecrets = vi.fn().mockResolvedValue({
+      assignments: [],
+      diagnostics: [],
+      inactiveRefPaths: [],
+    });
+    const handlers = createHandlers({ resolveSecrets });
+    const respond = vi.fn();
+
+    await invokeSecretsResolve({
+      handlers,
+      respond,
+      commandName: "infer web search",
+      targetIds: ["talk.providers.*.apiKey"],
+      providerOverrides: { webSearch: " tavily ", webFetch: " " },
+    });
+
+    expect(resolveSecrets).toHaveBeenCalledWith({
+      commandName: "infer web search",
+      targetIds: ["talk.providers.*.apiKey"],
+      providerOverrides: { webSearch: "tavily" },
+    });
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        ok: true,
+      }),
+    );
   });
 
   it("rejects invalid secrets.resolve params", async () => {

--- a/src/gateway/server-methods/secrets.ts
+++ b/src/gateway/server-methods/secrets.ts
@@ -8,13 +8,18 @@ import {
 } from "../protocol/index.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
+type SecretsResolveProviderOverrides = {
+  webSearch?: string;
+  webFetch?: string;
+};
+
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
 function invalidSecretsResolveField(
   errors: ErrorObject[] | null | undefined,
-): "commandName" | "targetIds" {
+): "commandName" | "targetIds" | "providerOverrides" {
   for (const issue of errors ?? []) {
     if (
       issue.instancePath === "/commandName" ||
@@ -23,13 +28,34 @@ function invalidSecretsResolveField(
     ) {
       return "commandName";
     }
+    if (issue.instancePath.startsWith("/providerOverrides")) {
+      return "providerOverrides";
+    }
   }
   return "targetIds";
 }
 
+function normalizeSecretsResolveProviderOverrides(
+  overrides: { webSearch?: string; webFetch?: string } | undefined,
+): SecretsResolveProviderOverrides | undefined {
+  const webSearch = overrides?.webSearch?.trim();
+  const webFetch = overrides?.webFetch?.trim();
+  if (!webSearch && !webFetch) {
+    return undefined;
+  }
+  return {
+    ...(webSearch ? { webSearch } : {}),
+    ...(webFetch ? { webFetch } : {}),
+  };
+}
+
 export function createSecretsHandlers(params: {
   reloadSecrets: () => Promise<{ warningCount: number }>;
-  resolveSecrets: (params: { commandName: string; targetIds: string[] }) => Promise<{
+  resolveSecrets: (params: {
+    commandName: string;
+    targetIds: string[];
+    providerOverrides?: SecretsResolveProviderOverrides;
+  }) => Promise<{
     assignments: Array<{
       path: string;
       pathSegments: string[];
@@ -74,6 +100,9 @@ export function createSecretsHandlers(params: {
       const targetIds = requestParams.targetIds
         .map((entry) => entry.trim())
         .filter((entry) => entry.length > 0);
+      const providerOverrides = normalizeSecretsResolveProviderOverrides(
+        requestParams.providerOverrides,
+      );
 
       for (const targetId of targetIds) {
         if (!isKnownSecretTargetId(targetId)) {
@@ -93,6 +122,7 @@ export function createSecretsHandlers(params: {
         const result = await params.resolveSecrets({
           commandName,
           targetIds,
+          ...(providerOverrides ? { providerOverrides } : {}),
         });
         const payload = {
           ok: true,

--- a/src/plugin-sdk/test-node-mocks.ts
+++ b/src/plugin-sdk/test-node-mocks.ts
@@ -5,3 +5,8 @@ export {
   mockNodeChildProcessExecFile,
   mockNodeChildProcessSpawnSync,
 } from "./test-helpers/node-builtin-mocks.js";
+export {
+  withMockedPlatform,
+  withMockedWindowsPlatform,
+  withRestoredMocks,
+} from "../test-utils/vitest-spies.js";

--- a/src/secrets/credential-matrix.ts
+++ b/src/secrets/credential-matrix.ts
@@ -22,26 +22,40 @@ export type SecretRefCredentialMatrixDocument = {
 };
 
 export function buildSecretRefCredentialMatrix(): SecretRefCredentialMatrixDocument {
-  const entries: CredentialMatrixEntry[] = getSourceSecretTargetRegistry()
-    .map((entry) => {
-      const isCanonicalFirecrawlWebFetchEntry =
-        entry.id === "plugins.entries.firecrawl.config.webFetch.apiKey";
-      const canonicalId = isCanonicalFirecrawlWebFetchEntry
-        ? "tools.web.fetch.firecrawl.apiKey"
-        : entry.id;
-      const canonicalPath = isCanonicalFirecrawlWebFetchEntry
-        ? "tools.web.fetch.firecrawl.apiKey"
-        : entry.pathPattern;
+  const entriesByKey = new Map<string, CredentialMatrixEntry>();
+  for (const entry of getSourceSecretTargetRegistry()) {
+    const isCanonicalFirecrawlWebFetchEntry =
+      entry.id === "plugins.entries.firecrawl.config.webFetch.apiKey";
+    const canonicalId = isCanonicalFirecrawlWebFetchEntry
+      ? "tools.web.fetch.firecrawl.apiKey"
+      : entry.id;
+    const canonicalPath = isCanonicalFirecrawlWebFetchEntry
+      ? "tools.web.fetch.firecrawl.apiKey"
+      : entry.pathPattern;
+    const matrixEntry = Object.assign(
+      { id: canonicalId, configFile: entry.configFile, path: canonicalPath },
+      entry.refPathPattern ? { refPath: entry.refPathPattern } : {},
+      entry.authProfileType ? { when: { type: entry.authProfileType } } : {},
+      { secretShape: entry.secretShape, optIn: true as const },
+      entry.secretShape === `sibling_ref` && entry.refPathPattern
+        ? { notes: `Compatibility exception: sibling ref field remains canonical.` }
+        : {},
+    );
+    entriesByKey.set(
+      [
+        matrixEntry.configFile,
+        matrixEntry.id,
+        matrixEntry.path,
+        matrixEntry.refPath ?? "",
+        matrixEntry.when?.type ?? "",
+      ].join("\0"),
+      matrixEntry,
+    );
+  }
 
-      return Object.assign(
-        { id: canonicalId, configFile: entry.configFile, path: canonicalPath },
-        entry.refPathPattern ? { refPath: entry.refPathPattern } : {},
-        entry.authProfileType ? { when: { type: entry.authProfileType } } : {},
-        { secretShape: entry.secretShape, optIn: true as const },
-        entry.secretShape === `sibling_ref` && entry.refPathPattern
-          ? { notes: `Compatibility exception: sibling ref field remains canonical.` }
-          : {},
-      );
+  const entries: CredentialMatrixEntry[] = [...entriesByKey.values()]
+    .map((entry) => {
+      return entry;
     })
     .toSorted((a, b) => a.id.localeCompare(b.id));
 

--- a/src/secrets/runtime-command-secrets.test.ts
+++ b/src/secrets/runtime-command-secrets.test.ts
@@ -43,8 +43,14 @@ describe("resolveCommandSecretsFromActiveRuntimeSnapshot", () => {
       env,
       includeAuthStoreRefs: false,
     });
-    expect(snapshot.config.plugins?.entries?.google?.config?.webSearch?.apiKey).toBe("gemini-live");
-    expect(snapshot.config.plugins?.entries?.brave?.config?.webSearch?.apiKey).toEqual({
+    const googleConfig = snapshot.config.plugins?.entries?.google?.config as
+      | { webSearch?: { apiKey?: unknown } }
+      | undefined;
+    const braveConfig = snapshot.config.plugins?.entries?.brave?.config as
+      | { webSearch?: { apiKey?: unknown } }
+      | undefined;
+    expect(googleConfig?.webSearch?.apiKey).toBe("gemini-live");
+    expect(braveConfig?.webSearch?.apiKey).toEqual({
       source: "env",
       provider: "default",
       id: "BRAVE_API_KEY",
@@ -93,7 +99,10 @@ describe("resolveCommandSecretsFromActiveRuntimeSnapshot", () => {
       env,
       includeAuthStoreRefs: false,
     });
-    expect(snapshot.config.tools?.web?.fetch?.firecrawl?.apiKey).toEqual({
+    const fetchConfig = snapshot.config.tools?.web?.fetch as
+      | { firecrawl?: { apiKey?: unknown } }
+      | undefined;
+    expect(fetchConfig?.firecrawl?.apiKey).toEqual({
       source: "env",
       provider: "default",
       id: "FIRECRAWL_API_KEY",

--- a/src/secrets/runtime-command-secrets.test.ts
+++ b/src/secrets/runtime-command-secrets.test.ts
@@ -1,0 +1,409 @@
+import { describe, expect, it } from "vitest";
+import { resolveCommandSecretsFromActiveRuntimeSnapshot } from "./runtime-command-secrets.js";
+import { activateSecretsRuntimeSnapshot } from "./runtime.js";
+import { asConfig, setupSecretsRuntimeSnapshotTestHooks } from "./runtime.test-support.ts";
+
+const { prepareSecretsRuntimeSnapshot } = setupSecretsRuntimeSnapshotTestHooks();
+
+describe("resolveCommandSecretsFromActiveRuntimeSnapshot", () => {
+  it("reruns web secret resolution for provider overrides", async () => {
+    const googlePath = "plugins.entries.google.config.webSearch.apiKey";
+    const bravePath = "plugins.entries.brave.config.webSearch.apiKey";
+    const config = asConfig({
+      tools: { web: { search: { provider: "gemini", enabled: true } } },
+      plugins: {
+        entries: {
+          google: {
+            config: {
+              webSearch: {
+                apiKey: { source: "env", provider: "default", id: "GEMINI_API_KEY" },
+              },
+            },
+          },
+          brave: {
+            config: {
+              webSearch: {
+                apiKey: { source: "env", provider: "default", id: "BRAVE_API_KEY" },
+              },
+            },
+          },
+        },
+      },
+    });
+    const env = {
+      ...process.env,
+      OPENCLAW_BUNDLED_PLUGINS_DIR: "extensions",
+      OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+      GEMINI_API_KEY: "gemini-live",
+      BRAVE_API_KEY: "brave-live",
+    };
+
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config,
+      env,
+      includeAuthStoreRefs: false,
+    });
+    expect(snapshot.config.plugins?.entries?.google?.config?.webSearch?.apiKey).toBe("gemini-live");
+    expect(snapshot.config.plugins?.entries?.brave?.config?.webSearch?.apiKey).toEqual({
+      source: "env",
+      provider: "default",
+      id: "BRAVE_API_KEY",
+    });
+
+    activateSecretsRuntimeSnapshot(snapshot);
+    const result = await resolveCommandSecretsFromActiveRuntimeSnapshot({
+      commandName: "infer web search",
+      targetIds: new Set([googlePath, bravePath]),
+      providerOverrides: { webSearch: "brave" },
+    });
+
+    expect(result.assignments).toEqual([
+      {
+        path: bravePath,
+        pathSegments: bravePath.split("."),
+        value: "brave-live",
+      },
+    ]);
+    expect(result.inactiveRefPaths).toContain(googlePath);
+  });
+
+  it("returns legacy web fetch assignments for provider overrides", async () => {
+    const legacyPath = "tools.web.fetch.firecrawl.apiKey";
+    const config = asConfig({
+      tools: {
+        web: {
+          fetch: {
+            provider: "browser",
+            firecrawl: {
+              apiKey: { source: "env", provider: "default", id: "FIRECRAWL_API_KEY" },
+            },
+          },
+        },
+      },
+    });
+    const env = {
+      ...process.env,
+      OPENCLAW_BUNDLED_PLUGINS_DIR: "extensions",
+      OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+      FIRECRAWL_API_KEY: "firecrawl-live",
+    };
+
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config,
+      env,
+      includeAuthStoreRefs: false,
+    });
+    expect(snapshot.config.tools?.web?.fetch?.firecrawl?.apiKey).toEqual({
+      source: "env",
+      provider: "default",
+      id: "FIRECRAWL_API_KEY",
+    });
+
+    activateSecretsRuntimeSnapshot(snapshot);
+    const result = await resolveCommandSecretsFromActiveRuntimeSnapshot({
+      commandName: "infer web fetch",
+      targetIds: new Set([legacyPath]),
+      providerOverrides: { webFetch: "firecrawl" },
+    });
+
+    expect(result.assignments).toEqual([
+      {
+        path: legacyPath,
+        pathSegments: legacyPath.split("."),
+        value: "firecrawl-live",
+      },
+    ]);
+  });
+
+  it("returns legacy web fetch assignments for the configured provider", async () => {
+    const legacyPath = "tools.web.fetch.firecrawl.apiKey";
+    const config = asConfig({
+      tools: {
+        web: {
+          fetch: {
+            provider: "firecrawl",
+            firecrawl: {
+              apiKey: { source: "env", provider: "default", id: "FIRECRAWL_API_KEY" },
+            },
+          },
+        },
+      },
+    });
+    const env = {
+      ...process.env,
+      OPENCLAW_BUNDLED_PLUGINS_DIR: "extensions",
+      OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+      FIRECRAWL_API_KEY: "firecrawl-live",
+    };
+
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config,
+      env,
+      includeAuthStoreRefs: false,
+    });
+
+    activateSecretsRuntimeSnapshot(snapshot);
+    const result = await resolveCommandSecretsFromActiveRuntimeSnapshot({
+      commandName: "infer web fetch",
+      targetIds: new Set([legacyPath]),
+    });
+
+    expect(result.assignments).toEqual([
+      {
+        path: legacyPath,
+        pathSegments: legacyPath.split("."),
+        value: "firecrawl-live",
+      },
+    ]);
+  });
+
+  it("keeps legacy shared web search refs inactive for plugin-scoped provider overrides", async () => {
+    const sharedPath = "tools.web.search.apiKey";
+    const googlePath = "plugins.entries.google.config.webSearch.apiKey";
+    const config = asConfig({
+      tools: {
+        web: {
+          search: {
+            provider: "brave",
+            apiKey: { source: "env", provider: "default", id: "BRAVE_API_KEY" },
+          },
+        },
+      },
+      plugins: {
+        entries: {
+          google: {
+            config: {
+              webSearch: {
+                apiKey: { source: "env", provider: "default", id: "GEMINI_API_KEY" },
+              },
+            },
+          },
+        },
+      },
+    });
+    const env = {
+      ...process.env,
+      OPENCLAW_BUNDLED_PLUGINS_DIR: "extensions",
+      OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+      BRAVE_API_KEY: "brave-live",
+      GEMINI_API_KEY: "gemini-live",
+    };
+
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config,
+      env,
+      includeAuthStoreRefs: false,
+    });
+    const resolvedSearchConfig = snapshot.config.tools?.web?.search as { apiKey?: unknown };
+    resolvedSearchConfig.apiKey = "brave-live";
+
+    activateSecretsRuntimeSnapshot(snapshot);
+    const result = await resolveCommandSecretsFromActiveRuntimeSnapshot({
+      commandName: "infer web search",
+      targetIds: new Set([sharedPath, googlePath]),
+      providerOverrides: { webSearch: "gemini" },
+    });
+
+    expect(result.assignments).toEqual([
+      {
+        path: googlePath,
+        pathSegments: googlePath.split("."),
+        value: "gemini-live",
+      },
+    ]);
+    expect(result.inactiveRefPaths).toContain(sharedPath);
+  });
+
+  it("keeps provider override refs inactive when the web search surface is disabled", async () => {
+    const googlePath = "plugins.entries.google.config.webSearch.apiKey";
+    const config = asConfig({
+      tools: { web: { search: { enabled: false, provider: "brave" } } },
+      plugins: {
+        entries: {
+          google: {
+            config: {
+              webSearch: {
+                apiKey: { source: "env", provider: "default", id: "GEMINI_API_KEY" },
+              },
+            },
+          },
+        },
+      },
+    });
+    const env = {
+      ...process.env,
+      OPENCLAW_BUNDLED_PLUGINS_DIR: "extensions",
+      OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+      GEMINI_API_KEY: "gemini-live",
+    };
+
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config,
+      env,
+      includeAuthStoreRefs: false,
+    });
+
+    activateSecretsRuntimeSnapshot(snapshot);
+    const result = await resolveCommandSecretsFromActiveRuntimeSnapshot({
+      commandName: "infer web search",
+      targetIds: new Set([googlePath]),
+      providerOverrides: { webSearch: "gemini" },
+    });
+
+    expect(result.assignments).toEqual([]);
+    expect(result.inactiveRefPaths).toContain(googlePath);
+  });
+
+  it("returns legacy shared web search assignments for providers that read the shared key", async () => {
+    const sharedPath = "tools.web.search.apiKey";
+    const config = asConfig({
+      tools: {
+        web: {
+          search: {
+            provider: "gemini",
+            apiKey: { source: "env", provider: "default", id: "BRAVE_API_KEY" },
+          },
+        },
+      },
+      plugins: {
+        entries: {
+          google: {
+            config: {
+              webSearch: {
+                apiKey: { source: "env", provider: "default", id: "GEMINI_API_KEY" },
+              },
+            },
+          },
+        },
+      },
+    });
+    const env = {
+      ...process.env,
+      OPENCLAW_BUNDLED_PLUGINS_DIR: "extensions",
+      OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+      BRAVE_API_KEY: "brave-live",
+      GEMINI_API_KEY: "gemini-live",
+    };
+
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config,
+      env,
+      includeAuthStoreRefs: false,
+    });
+
+    activateSecretsRuntimeSnapshot(snapshot);
+    const result = await resolveCommandSecretsFromActiveRuntimeSnapshot({
+      commandName: "infer web search",
+      targetIds: new Set([sharedPath]),
+      providerOverrides: { webSearch: "brave" },
+    });
+
+    expect(result.assignments).toEqual([
+      {
+        path: sharedPath,
+        pathSegments: sharedPath.split("."),
+        value: "brave-live",
+      },
+    ]);
+  });
+
+  it("returns shared web search assignments for selected top-level credential providers", async () => {
+    const sharedPath = "tools.web.search.apiKey";
+    const config = asConfig({
+      tools: {
+        web: {
+          search: {
+            provider: "gemini",
+            apiKey: { source: "env", provider: "default", id: "MINIMAX_API_KEY" },
+          },
+        },
+      },
+    });
+    const env = {
+      ...process.env,
+      OPENCLAW_BUNDLED_PLUGINS_DIR: "extensions",
+      OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+      MINIMAX_API_KEY: "minimax-live",
+    };
+
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config,
+      env,
+      includeAuthStoreRefs: false,
+    });
+
+    activateSecretsRuntimeSnapshot(snapshot);
+    const result = await resolveCommandSecretsFromActiveRuntimeSnapshot({
+      commandName: "infer web search",
+      targetIds: new Set([sharedPath]),
+      providerOverrides: { webSearch: "minimax" },
+    });
+
+    expect(result.assignments).toEqual([
+      {
+        path: sharedPath,
+        pathSegments: sharedPath.split("."),
+        value: "minimax-live",
+      },
+    ]);
+  });
+
+  it("preserves non-web snapshot assignments when provider overrides are present", async () => {
+    const talkPath = "talk.providers.default.apiKey";
+    const googlePath = "plugins.entries.google.config.webSearch.apiKey";
+    const config = asConfig({
+      talk: {
+        providers: {
+          default: {
+            apiKey: { source: "env", provider: "default", id: "TALK_API_KEY" },
+          },
+        },
+      },
+      plugins: {
+        entries: {
+          google: {
+            config: {
+              webSearch: {
+                apiKey: { source: "env", provider: "default", id: "GEMINI_API_KEY" },
+              },
+            },
+          },
+        },
+      },
+    });
+    const env = {
+      ...process.env,
+      OPENCLAW_BUNDLED_PLUGINS_DIR: "extensions",
+      OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR: "1",
+      TALK_API_KEY: "talk-live",
+      GEMINI_API_KEY: "gemini-live",
+    };
+
+    const snapshot = await prepareSecretsRuntimeSnapshot({
+      config,
+      env,
+      includeAuthStoreRefs: false,
+    });
+    expect(snapshot.config.talk?.providers?.default?.apiKey).toBe("talk-live");
+
+    activateSecretsRuntimeSnapshot(snapshot);
+    const result = await resolveCommandSecretsFromActiveRuntimeSnapshot({
+      commandName: "infer web search",
+      targetIds: new Set(["talk.providers.*.apiKey", googlePath]),
+      providerOverrides: { webSearch: "gemini" },
+    });
+
+    expect(result.assignments).toEqual([
+      {
+        path: talkPath,
+        pathSegments: talkPath.split("."),
+        value: "talk-live",
+      },
+      {
+        path: googlePath,
+        pathSegments: googlePath.split("."),
+        value: "gemini-live",
+      },
+    ]);
+  });
+});

--- a/src/secrets/runtime-command-secrets.ts
+++ b/src/secrets/runtime-command-secrets.ts
@@ -1,32 +1,451 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveSecretInputRef } from "../config/types.secrets.js";
+import { resolveManifestContractOwnerPluginId } from "../plugins/plugin-registry.js";
+import { resolveBundledExplicitWebSearchProvidersFromPublicArtifacts } from "../plugins/web-provider-public-artifacts.explicit.js";
+import { normalizeOptionalString } from "../shared/string-coerce.js";
 import {
+  analyzeCommandSecretAssignmentsFromSnapshot,
   collectCommandSecretAssignmentsFromSnapshot,
   type CommandSecretAssignment,
 } from "./command-config.js";
-import { getActiveSecretsRuntimeSnapshot } from "./runtime.js";
+import { getPath, setPathExistingStrict } from "./path-utils.js";
+import { createResolverContext } from "./runtime-shared.js";
+import { resolveRuntimeWebTools } from "./runtime-web-tools.js";
+import { getActiveSecretsRuntimeEnv, getActiveSecretsRuntimeSnapshot } from "./runtime.js";
+import { discoverConfigSecretTargetsByIds } from "./target-registry.js";
 
 export type { CommandSecretAssignment } from "./command-config.js";
+
+export type CommandSecretProviderOverrides = {
+  webSearch?: string;
+  webFetch?: string;
+};
+
+function hasProviderOverrides(overrides: CommandSecretProviderOverrides | undefined): boolean {
+  return (
+    normalizeOptionalString(overrides?.webSearch) !== undefined ||
+    normalizeOptionalString(overrides?.webFetch) !== undefined
+  );
+}
+
+function applyProviderOverridesToConfig(
+  config: OpenClawConfig,
+  overrides: CommandSecretProviderOverrides | undefined,
+): OpenClawConfig {
+  if (!hasProviderOverrides(overrides)) {
+    return config;
+  }
+  const next = structuredClone(config);
+  const tools = (next.tools ??= {}) as Record<string, unknown>;
+  const web = (tools.web ??= {}) as Record<string, unknown>;
+  const webSearch = normalizeOptionalString(overrides?.webSearch);
+  if (webSearch) {
+    const search = (web.search ??= {}) as Record<string, unknown>;
+    search.provider = webSearch;
+  }
+  const webFetch = normalizeOptionalString(overrides?.webFetch);
+  if (webFetch) {
+    const fetch = (web.fetch ??= {}) as Record<string, unknown>;
+    fetch.provider = webFetch;
+  }
+  return next;
+}
+
+function pluginIdFromRuntimeWebPath(path: string): string | undefined {
+  return /^plugins\.entries\.([^.]+)\.config\.(webSearch|webFetch)\.apiKey$/.exec(path)?.[1];
+}
+
+function searchProviderFromDirectWebPath(path: string): string | undefined {
+  return /^tools\.web\.search\.([^.]+)\.apiKey$/.exec(path)?.[1];
+}
+
+function fetchProviderFromDirectWebPath(path: string): string | undefined {
+  return /^tools\.web\.fetch\.([^.]+)\.apiKey$/.exec(path)?.[1];
+}
+
+function isWebCommandSecretPath(path: string): boolean {
+  return (
+    path === "tools.web.search.apiKey" ||
+    /^tools\.web\.(search|fetch)\.[^.]+\.apiKey$/.test(path) ||
+    /^plugins\.entries\.[^.]+\.config\.(webSearch|webFetch)\.apiKey$/.test(path)
+  );
+}
+
+function webSearchProviderUsesSharedSearchCredential(params: {
+  config: OpenClawConfig;
+  provider: string;
+}): boolean {
+  const sentinel = "__openclaw_shared_web_search_probe__";
+  const pluginId = resolveManifestContractOwnerPluginId({
+    contract: "webSearchProviders",
+    value: params.provider,
+    origin: "bundled",
+    config: params.config,
+  });
+  if (!pluginId) {
+    return false;
+  }
+  const providers = resolveBundledExplicitWebSearchProvidersFromPublicArtifacts({
+    onlyPluginIds: [pluginId],
+  });
+  const provider = providers?.find((entry) => entry.id === params.provider);
+  return (
+    provider?.credentialPath === "tools.web.search.apiKey" ||
+    provider?.getCredentialValue({ apiKey: sentinel }) === sentinel ||
+    provider?.getConfiguredCredentialFallback?.(params.config)?.path === "tools.web.search.apiKey"
+  );
+}
+
+function isProviderOverridePath(params: {
+  config: OpenClawConfig;
+  path: string;
+  providerOverrides: CommandSecretProviderOverrides | undefined;
+}): boolean {
+  const webSearch = normalizeOptionalString(params.providerOverrides?.webSearch);
+  if (webSearch) {
+    if (params.config.tools?.web?.search?.enabled === false) {
+      return false;
+    }
+    if (params.path === "tools.web.search.apiKey") {
+      return webSearchProviderUsesSharedSearchCredential({
+        config: params.config,
+        provider: webSearch,
+      });
+    }
+    const directProvider = searchProviderFromDirectWebPath(params.path);
+    if (directProvider) {
+      return directProvider === webSearch;
+    }
+    const pluginId = pluginIdFromRuntimeWebPath(params.path);
+    if (pluginId && params.path.endsWith(".config.webSearch.apiKey")) {
+      return (
+        resolveManifestContractOwnerPluginId({
+          contract: "webSearchProviders",
+          value: webSearch,
+          origin: "bundled",
+          config: params.config,
+        }) === pluginId
+      );
+    }
+  }
+
+  const webFetch = normalizeOptionalString(params.providerOverrides?.webFetch);
+  if (webFetch) {
+    if (params.config.tools?.web?.fetch?.enabled === false) {
+      return false;
+    }
+    const directProvider = fetchProviderFromDirectWebPath(params.path);
+    if (directProvider) {
+      return directProvider === webFetch;
+    }
+    const pluginId = pluginIdFromRuntimeWebPath(params.path);
+    if (pluginId && params.path.endsWith(".config.webFetch.apiKey")) {
+      return (
+        resolveManifestContractOwnerPluginId({
+          contract: "webFetchProviders",
+          value: webFetch,
+          origin: "bundled",
+          config: params.config,
+        }) === pluginId
+      );
+    }
+  }
+
+  return false;
+}
+
+function restoreInactiveWebCommandSecretTargets(params: {
+  sourceConfig: OpenClawConfig;
+  resolvedConfig: OpenClawConfig;
+  targetIds: ReadonlySet<string>;
+  inactiveRefPaths: string[];
+  providerOverrides: CommandSecretProviderOverrides | undefined;
+}): string[] {
+  if (!hasProviderOverrides(params.providerOverrides)) {
+    return params.inactiveRefPaths;
+  }
+  const inactive = new Set(params.inactiveRefPaths);
+  const defaults = params.sourceConfig.secrets?.defaults;
+  for (const target of discoverConfigSecretTargetsByIds(params.sourceConfig, params.targetIds)) {
+    if (!isWebCommandSecretPath(target.path)) {
+      continue;
+    }
+    const { ref } = resolveSecretInputRef({
+      value: target.value,
+      refValue: target.refValue,
+      defaults,
+    });
+    if (!ref) {
+      continue;
+    }
+    if (
+      isProviderOverridePath({
+        config: params.sourceConfig,
+        path: target.path,
+        providerOverrides: params.providerOverrides,
+      })
+    ) {
+      continue;
+    }
+    inactive.add(target.path);
+    setPathExistingStrict(
+      params.resolvedConfig as Record<string, unknown>,
+      target.pathSegments,
+      target.value,
+    );
+  }
+  return [...inactive];
+}
+
+function filterInactiveRefPathsForProviderOverrides(params: {
+  config: OpenClawConfig;
+  inactiveRefPaths: readonly string[];
+  providerOverrides: CommandSecretProviderOverrides | undefined;
+}): string[] {
+  if (!hasProviderOverrides(params.providerOverrides)) {
+    return [...params.inactiveRefPaths];
+  }
+  return params.inactiveRefPaths.filter(
+    (path) =>
+      !isProviderOverridePath({
+        config: params.config,
+        path,
+        providerOverrides: params.providerOverrides,
+      }),
+  );
+}
+
+function mirrorResolvedProviderCredentialToDirectPath(params: {
+  config: OpenClawConfig;
+  resolvedConfig: OpenClawConfig;
+  contract: "webSearchProviders" | "webFetchProviders";
+  provider: string | undefined;
+  directPathPrefix: string;
+  pluginConfigKey: "webSearch" | "webFetch";
+}): void {
+  const provider = normalizeOptionalString(params.provider);
+  if (!provider) {
+    return;
+  }
+  const pluginId = resolveManifestContractOwnerPluginId({
+    contract: params.contract,
+    value: provider,
+    origin: "bundled",
+    config: params.config,
+  });
+  if (!pluginId) {
+    return;
+  }
+  const directSegments = [...params.directPathPrefix.split("."), provider, "apiKey"];
+  const directValue = getPath(params.config, directSegments);
+  if (directValue === undefined) {
+    return;
+  }
+  const resolvedValue = getPath(params.resolvedConfig, [
+    "plugins",
+    "entries",
+    pluginId,
+    "config",
+    params.pluginConfigKey,
+    "apiKey",
+  ]);
+  if (typeof resolvedValue !== "string" || resolvedValue.length === 0) {
+    return;
+  }
+  setPathExistingStrict(
+    params.resolvedConfig as Record<string, unknown>,
+    directSegments,
+    resolvedValue,
+  );
+}
+
+function mirrorResolvedProviderCredentialToDirectPaths(params: {
+  config: OpenClawConfig;
+  resolvedConfig: OpenClawConfig;
+  providerOverrides: CommandSecretProviderOverrides | undefined;
+}): void {
+  const configuredSearchProvider =
+    normalizeOptionalString(params.providerOverrides?.webSearch) ??
+    normalizeOptionalString(params.config.tools?.web?.search?.provider);
+  const configuredFetchProvider =
+    normalizeOptionalString(params.providerOverrides?.webFetch) ??
+    normalizeOptionalString(params.config.tools?.web?.fetch?.provider);
+  mirrorResolvedProviderCredentialToDirectPath({
+    config: params.config,
+    resolvedConfig: params.resolvedConfig,
+    contract: "webSearchProviders",
+    provider: configuredSearchProvider,
+    directPathPrefix: "tools.web.search",
+    pluginConfigKey: "webSearch",
+  });
+  mirrorResolvedProviderCredentialToDirectPath({
+    config: params.config,
+    resolvedConfig: params.resolvedConfig,
+    contract: "webFetchProviders",
+    provider: configuredFetchProvider,
+    directPathPrefix: "tools.web.fetch",
+    pluginConfigKey: "webFetch",
+  });
+  const webSearch = configuredSearchProvider;
+  if (
+    webSearch &&
+    webSearchProviderUsesSharedSearchCredential({
+      config: params.config,
+      provider: webSearch,
+    }) &&
+    getPath(params.config, ["tools", "web", "search", "apiKey"]) !== undefined
+  ) {
+    const pluginId = resolveManifestContractOwnerPluginId({
+      contract: "webSearchProviders",
+      value: webSearch,
+      origin: "bundled",
+      config: params.config,
+    });
+    const resolvedValue = pluginId
+      ? getPath(params.resolvedConfig, [
+          "plugins",
+          "entries",
+          pluginId,
+          "config",
+          "webSearch",
+          "apiKey",
+        ])
+      : undefined;
+    if (typeof resolvedValue === "string" && resolvedValue.length > 0) {
+      setPathExistingStrict(
+        params.resolvedConfig as Record<string, unknown>,
+        ["tools", "web", "search", "apiKey"],
+        resolvedValue,
+      );
+    }
+  }
+}
 
 export function resolveCommandSecretsFromActiveRuntimeSnapshot(params: {
   commandName: string;
   targetIds: ReadonlySet<string>;
-}): { assignments: CommandSecretAssignment[]; diagnostics: string[]; inactiveRefPaths: string[] } {
+  providerOverrides?: CommandSecretProviderOverrides;
+}): Promise<{
+  assignments: CommandSecretAssignment[];
+  diagnostics: string[];
+  inactiveRefPaths: string[];
+}> {
   const activeSnapshot = getActiveSecretsRuntimeSnapshot();
   if (!activeSnapshot) {
     throw new Error("Secrets runtime snapshot is not active.");
   }
   if (params.targetIds.size === 0) {
-    return { assignments: [], diagnostics: [], inactiveRefPaths: [] };
+    return Promise.resolve({ assignments: [], diagnostics: [], inactiveRefPaths: [] });
   }
-  const inactiveRefPaths = [
-    ...new Set(
-      activeSnapshot.warnings
-        .filter((warning) => warning.code === "SECRETS_REF_IGNORED_INACTIVE_SURFACE")
-        .map((warning) => warning.path),
-    ),
-  ];
+  return resolveCommandSecretsFromSnapshot({
+    activeSnapshot,
+    commandName: params.commandName,
+    targetIds: params.targetIds,
+    providerOverrides: params.providerOverrides,
+  });
+}
+
+async function resolveCommandSecretsFromSnapshot(params: {
+  activeSnapshot: NonNullable<ReturnType<typeof getActiveSecretsRuntimeSnapshot>>;
+  commandName: string;
+  targetIds: ReadonlySet<string>;
+  providerOverrides?: CommandSecretProviderOverrides;
+}): Promise<{
+  assignments: CommandSecretAssignment[];
+  diagnostics: string[];
+  inactiveRefPaths: string[];
+}> {
+  const hasOverrides = hasProviderOverrides(params.providerOverrides);
+  const sourceConfig = applyProviderOverridesToConfig(
+    params.activeSnapshot.sourceConfig,
+    params.providerOverrides,
+  );
+  const resolvedConfig = applyProviderOverridesToConfig(
+    params.activeSnapshot.config,
+    params.providerOverrides,
+  );
+  const context = hasOverrides
+    ? createResolverContext({
+        sourceConfig,
+        env: getActiveSecretsRuntimeEnv(),
+      })
+    : undefined;
+  if (context) {
+    await resolveRuntimeWebTools({
+      sourceConfig,
+      resolvedConfig,
+      context,
+    });
+  }
+  mirrorResolvedProviderCredentialToDirectPaths({
+    config: sourceConfig,
+    resolvedConfig,
+    providerOverrides: params.providerOverrides,
+  });
+  const warningSource = context?.warnings ?? params.activeSnapshot.warnings;
+  let inactiveRefPaths = filterInactiveRefPathsForProviderOverrides({
+    config: sourceConfig,
+    providerOverrides: params.providerOverrides,
+    inactiveRefPaths: [
+      ...new Set(
+        warningSource
+          .filter((warning) => warning.code === "SECRETS_REF_IGNORED_INACTIVE_SURFACE")
+          .map((warning) => warning.path),
+      ),
+    ],
+  });
+  inactiveRefPaths = restoreInactiveWebCommandSecretTargets({
+    sourceConfig,
+    resolvedConfig,
+    targetIds: params.targetIds,
+    inactiveRefPaths,
+    providerOverrides: params.providerOverrides,
+  });
+  let analyzed = analyzeCommandSecretAssignmentsFromSnapshot({
+    sourceConfig,
+    resolvedConfig,
+    targetIds: params.targetIds,
+    inactiveRefPaths: new Set(inactiveRefPaths),
+  });
+  if (hasOverrides) {
+    const impliedInactivePaths = analyzed.unresolved
+      .filter((entry) => isWebCommandSecretPath(entry.path))
+      .filter(
+        (entry) =>
+          !isProviderOverridePath({
+            config: sourceConfig,
+            path: entry.path,
+            providerOverrides: params.providerOverrides,
+          }),
+      )
+      .map((entry) => entry.path);
+    if (impliedInactivePaths.length > 0) {
+      inactiveRefPaths = [...new Set([...inactiveRefPaths, ...impliedInactivePaths])];
+      analyzed = analyzeCommandSecretAssignmentsFromSnapshot({
+        sourceConfig,
+        resolvedConfig,
+        targetIds: params.targetIds,
+        inactiveRefPaths: new Set(inactiveRefPaths),
+      });
+    }
+  }
+  const selectedProviderUnresolved = analyzed.unresolved.filter((entry) =>
+    isProviderOverridePath({
+      config: sourceConfig,
+      path: entry.path,
+      providerOverrides: params.providerOverrides,
+    }),
+  );
+  if (selectedProviderUnresolved.length > 0) {
+    return {
+      assignments: analyzed.assignments,
+      diagnostics: analyzed.diagnostics,
+      inactiveRefPaths,
+    };
+  }
   const resolved = collectCommandSecretAssignmentsFromSnapshot({
-    sourceConfig: activeSnapshot.sourceConfig,
-    resolvedConfig: activeSnapshot.config,
+    sourceConfig,
+    resolvedConfig,
     commandName: params.commandName,
     targetIds: params.targetIds,
     inactiveRefPaths: new Set(inactiveRefPaths),

--- a/src/secrets/runtime-web-tools.ts
+++ b/src/secrets/runtime-web-tools.ts
@@ -479,7 +479,10 @@ function readConfiguredProviderCredential(params: {
   config: OpenClawConfig;
   search: Record<string, unknown> | undefined;
 }): unknown {
-  return params.provider.getConfiguredCredentialValue?.(params.config);
+  return (
+    params.provider.getConfiguredCredentialValue?.(params.config) ??
+    params.provider.getCredentialValue(params.search)
+  );
 }
 
 function readConfiguredProviderCredentialFallback(params: {

--- a/src/secrets/runtime.ts
+++ b/src/secrets/runtime.ts
@@ -499,6 +499,12 @@ export function getActiveSecretsRuntimeSnapshot(): PreparedSecretsRuntimeSnapsho
   return snapshot;
 }
 
+export function getActiveSecretsRuntimeEnv(): NodeJS.ProcessEnv {
+  return {
+    ...(activeRefreshContext?.env ?? process.env),
+  } as NodeJS.ProcessEnv;
+}
+
 export function getActiveRuntimeWebToolsMetadata(): RuntimeWebToolsMetadata | null {
   return getActiveRuntimeWebToolsMetadataFromState();
 }

--- a/src/secrets/target-registry-data.ts
+++ b/src/secrets/target-registry-data.ts
@@ -438,6 +438,17 @@ const CORE_SECRET_TARGET_REGISTRY: SecretTargetRegistryEntry[] = [
     includeInConfigure: true,
     includeInAudit: true,
   },
+  {
+    id: "tools.web.fetch.firecrawl.apiKey",
+    targetType: "tools.web.fetch.firecrawl.apiKey",
+    configFile: "openclaw.json",
+    pathPattern: "tools.web.fetch.firecrawl.apiKey",
+    secretShape: SECRET_INPUT_SHAPE,
+    expectedResolvedValue: "string",
+    includeInPlan: true,
+    includeInConfigure: true,
+    includeInAudit: true,
+  },
 ];
 
 let cachedSecretTargetRegistry: SecretTargetRegistryEntry[] | null = null;


### PR DESCRIPTION
Summary
- Resolve web search and web fetch SecretRefs against the provider selected by infer web commands, including CLI provider overrides.
- Add gateway protocol support for web provider overrides and keep unrelated plugin secrets inactive.
- Preserve legacy Firecrawl fetch and shared web search credential compatibility while using plugin-owned config paths.
- Add regression coverage and changelog credit for #82699 / #82621.

Verification
- codex-review: clean, no actionable findings.
- node scripts/run-vitest.mjs src/secrets/runtime-command-secrets.test.ts src/cli/command-secret-gateway.test.ts src/cli/command-secret-targets.test.ts src/gateway/server-methods/secrets.test.ts src/cli/capability-cli.test.ts src/cli/command-config-resolution.test.ts
- TAVILY_API_KEY=resolved-live-proof pnpm exec tsx scripts/repro/cli-web-search-secret-refs-live-proof.mjs
- pnpm tsgo:core
- git diff --check
- Crabbox AWS cbx_aebcfe04e4bc, hydrated by Actions run 25977253055, E2E run run_e442983bbd8d.

## Real behavior proof
Behavior addressed: infer web search and infer web fetch now resolve only the selected web provider SecretRefs, including --provider overrides, and leave unrelated plugin secrets inactive.
Real environment tested: local source checkout plus AWS Crabbox cbx_aebcfe04e4bc with live provider keys injected through an allowlisted env profile.
Exact steps or command run after this patch: node scripts/run-vitest.mjs src/secrets/runtime-command-secrets.test.ts src/cli/command-secret-gateway.test.ts src/cli/command-secret-targets.test.ts src/gateway/server-methods/secrets.test.ts src/cli/capability-cli.test.ts src/cli/command-config-resolution.test.ts; TAVILY_API_KEY=resolved-live-proof pnpm exec tsx scripts/repro/cli-web-search-secret-refs-live-proof.mjs; pnpm tsgo:core; git diff --check; pnpm crabbox:run -- --provider aws --id cbx_aebcfe04e4bc --no-sync --env-from-profile /tmp/openclaw-82699-live-web.env --allow-env FIRECRAWL_API_KEY,GEMINI_API_KEY,XAI_API_KEY --script /tmp/openclaw-82699-crabbox-live.sh.
Evidence after fix: local focused suite passed 7 files and 137 tests; live repro converted a Tavily env SecretRef to a string; Crabbox installed and inspected the Firecrawl plugin, DuckDuckGo config and CLI override searches returned results, and Grok, Gemini, and Firecrawl config and CLI override cases reached the expected live provider auth responses with redacted key presence.
Observed result after fix: selected web provider credentials are resolved for command execution, unrelated voice-call/Twilio SecretRefs remain inactive, and legacy Firecrawl fetch refs remain covered.
What was not tested: valid paid-provider success for Grok, Gemini, or Firecrawl because the available live keys currently return provider auth errors; those errors still prove the selected SecretRefs were resolved and used.

Fixes #82621.
Supersedes #82699.
