### PR TITLE
fix(telegram): keep streamed text when tts arrives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Docs: https://docs.openclaw.ai
 - Agents/auth: redact OAuth refresh failure causes against in-memory, attempted, and reloaded credentials before generic token masking while ensuring failed ACP dispatch cleanup closes initialized runtimes.
 - Google/Gemini CLI OAuth: add provider-owned refresh support for `google-gemini-cli` so expired Gemini CLI tokens refresh in OpenClaw instead of falling through to the generic unknown-provider path. Fixes #42541. Thanks @jason-allen-oneal.
 - Telegram: cache successful startup bot identity by account and token fingerprint for up to 24 hours, so restarts can skip redundant `getMe` probes during Telegram API slow periods without permanently pinning renamed bots. Refs #82525.
+- Telegram: keep streamed text replies in place when delayed TTS audio arrives, sending the audio as a follow-up instead of deleting the preview. Fixes #82570. (#82820) Thanks @joshavant.
 - Gateway/sessions: discard stale metadata when recreating dead main session rows, so replacement sessions do not inherit old labels or transcript paths.
 - Codex app-server: mark native context compaction completion events as successful, preventing false "Compaction incomplete" notices after successful Codex-managed compaction. Fixes #82470. (#81593) Thanks @Kyzcreig.
 - Codex app-server: keep long-running turns alive while current-turn approvals, user input, dynamic tools, and notifications make progress, and carry that progress into the outer run timeout. (#82601) Thanks @100yenadmin.

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1350,21 +1350,52 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(editMessageTelegram).not.toHaveBeenCalled();
   });
 
-  it("falls back to normal send for media and clears the pending stream", async () => {
+  it("keeps streamed final text in place when late media arrives", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
-    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
-      await dispatcherOptions.deliver(
-        { text: "Photo", mediaUrl: "https://example.com/a.png" },
-        { kind: "final" },
-      );
-      return { queuedFinal: true };
-    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Photo" });
+        await dispatcherOptions.deliver(
+          { text: "Photo", mediaUrl: "https://example.com/a.png" },
+          { kind: "final" },
+        );
+        return { queuedFinal: true };
+      },
+    );
 
     await dispatchWithContext({ context: createContext() });
 
-    expect(answerDraftStream.clear).toHaveBeenCalled();
-    expect(answerDraftStream.update).not.toHaveBeenCalledWith("Photo");
-    expectDeliveredReply(0, { text: "Photo", mediaUrl: "https://example.com/a.png" });
+    expect(answerDraftStream.clear).not.toHaveBeenCalled();
+    expect(answerDraftStream.update).toHaveBeenCalledWith("Photo");
+    expectDeliveredReply(0, { text: undefined, mediaUrl: "https://example.com/a.png" });
+  });
+
+  it("attaches interactive buttons to streamed text when late media arrives", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Photo" });
+        await dispatcherOptions.deliver(
+          {
+            text: "Photo",
+            mediaUrl: "https://example.com/a.png",
+            interactive: {
+              blocks: [{ type: "buttons", buttons: [{ label: "OK", value: "ok" }] }],
+            },
+          },
+          { kind: "final" },
+        );
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({ context: createContext() });
+
+    expect(answerDraftStream.update).toHaveBeenCalledWith("Photo");
+    expectRecordFields(mockCallArg(editMessageTelegram, 0, 3), {
+      buttons: [[{ text: "OK", callback_data: "ok" }]],
+    });
+    expectDeliveredReply(0, { text: undefined, mediaUrl: "https://example.com/a.png" });
   });
 
   it("shows Telegram progress drafts immediately for explicit tool starts", async () => {
@@ -1482,6 +1513,30 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(mockCallArg(editMessageTelegram, 0, 1)).toBe(2001);
     expect(mockCallArg(editMessageTelegram, 0, 2)).toBe("Choose");
     expectRecordFields(mockCallArg(editMessageTelegram, 0, 3), { buttons });
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
+  it("streams interactive buttons into the same message", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver(
+        {
+          text: "Choose",
+          interactive: {
+            blocks: [{ type: "buttons", buttons: [{ label: "OK", value: "ok" }] }],
+          },
+        },
+        { kind: "final" },
+      );
+      return { queuedFinal: true };
+    });
+
+    await dispatchWithContext({ context: createContext() });
+
+    expect(answerDraftStream.update).toHaveBeenCalledWith("Choose");
+    expectRecordFields(mockCallArg(editMessageTelegram, 0, 3), {
+      buttons: [[{ text: "OK", callback_data: "ok" }]],
+    });
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -36,6 +36,10 @@ import type {
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { runInboundReplyTurn } from "openclaw/plugin-sdk/inbound-reply-dispatch";
 import {
+  normalizeMessagePresentation,
+  presentationToInteractiveReply,
+} from "openclaw/plugin-sdk/interactive-runtime";
+import {
   createOutboundPayloadPlan,
   projectOutboundPayloadPlanForDelivery,
 } from "openclaw/plugin-sdk/outbound-runtime";
@@ -82,7 +86,7 @@ import {
   type TelegramNativeQuoteCandidateByMessageId,
 } from "./bot/native-quote.js";
 import type { TelegramStreamMode } from "./bot/types.js";
-import type { TelegramInlineButtons } from "./button-types.js";
+import { resolveTelegramInlineButtons, type TelegramInlineButtons } from "./button-types.js";
 import { createTelegramDraftStream } from "./draft-stream.js";
 import {
   buildTelegramErrorScopeKey,
@@ -133,6 +137,22 @@ function resolveDraftPartialText(
     return undefined;
   }
   return nextText;
+}
+
+function resolvePayloadTelegramInlineButtons(
+  payload: ReplyPayload,
+): TelegramInlineButtons | undefined {
+  const telegramData = payload.channelData?.telegram as
+    | { buttons?: TelegramInlineButtons }
+    | undefined;
+  const presentation = normalizeMessagePresentation(payload.presentation);
+  const interactive =
+    payload.interactive ??
+    (presentation ? presentationToInteractiveReply(presentation) : undefined);
+  return resolveTelegramInlineButtons({
+    buttons: telegramData?.buttons,
+    interactive,
+  });
 }
 
 async function resolveStickerVisionSupport(cfg: OpenClawConfig, agentId: string) {
@@ -1375,11 +1395,7 @@ export const dispatchTelegramMessage = async ({
                       queuedFinal = true;
                       return;
                     }
-                    const telegramButtons = (
-                      effectivePayload.channelData?.telegram as
-                        | { buttons?: TelegramInlineButtons }
-                        | undefined
-                    )?.buttons;
+                    const telegramButtons = resolvePayloadTelegramInlineButtons(effectivePayload);
                     const split = splitTextIntoLaneSegments(
                       { text: effectivePayload.text },
                       payload.isReasoning,
@@ -1412,11 +1428,7 @@ export const dispatchTelegramMessage = async ({
                       if (!buffered) {
                         return;
                       }
-                      const bufferedButtons = (
-                        buffered.payload.channelData?.telegram as
-                          | { buttons?: TelegramInlineButtons }
-                          | undefined
-                      )?.buttons;
+                      const bufferedButtons = resolvePayloadTelegramInlineButtons(buffered.payload);
                       await deliverFinalAnswerText(
                         buffered.payload,
                         buffered.text,

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -268,6 +268,16 @@ function isCaptionTooLong(err: unknown): boolean {
   return CAPTION_TOO_LONG_RE.test(formatErrorMessage(err));
 }
 
+function resolveVoiceFallbackText(reply: ReplyPayload): string | undefined {
+  if (reply.text?.trim()) {
+    return reply.text;
+  }
+  if (reply.spokenText?.trim()) {
+    return reply.spokenText;
+  }
+  return undefined;
+}
+
 async function sendTelegramVoiceFallbackText(opts: {
   bot: Bot;
   chatId: string;
@@ -337,8 +347,9 @@ async function deliverMediaReply(params: {
   replyToId?: number;
   replyToMode: ReplyToMode;
   progress: DeliveryProgress;
-}): Promise<number | undefined> {
+}): Promise<{ firstDeliveredMessageId?: number; visibleFallbackText?: string }> {
   let firstDeliveredMessageId: number | undefined;
+  let visibleFallbackText: string | undefined;
   let first = true;
   let pendingFollowUpText: string | undefined;
   for (const mediaUrl of params.mediaList) {
@@ -456,7 +467,7 @@ async function deliverMediaReply(params: {
           await sendVoiceMedia(mediaParams, (err) => !isVoiceMessagesForbidden(err));
         } catch (voiceErr) {
           if (isVoiceMessagesForbidden(voiceErr)) {
-            const fallbackText = params.reply.text;
+            const fallbackText = resolveVoiceFallbackText(params.reply);
             if (!fallbackText || !fallbackText.trim()) {
               throw voiceErr;
             }
@@ -487,6 +498,7 @@ async function deliverMediaReply(params: {
             if (firstDeliveredMessageId == null) {
               firstDeliveredMessageId = fallbackMessageId;
             }
+            visibleFallbackText = fallbackText;
             markReplyApplied(params.progress, voiceFallbackReplyTo);
             markDelivered(params.progress);
             continue;
@@ -499,7 +511,7 @@ async function deliverMediaReply(params: {
             delete noCaptionParams.caption;
             delete noCaptionParams.parse_mode;
             await sendVoiceMedia(noCaptionParams);
-            const fallbackText = params.reply.text;
+            const fallbackText = resolveVoiceFallbackText(params.reply);
             if (fallbackText?.trim()) {
               await sendTelegramVoiceFallbackText({
                 bot: params.bot,
@@ -513,6 +525,7 @@ async function deliverMediaReply(params: {
                 silent: params.silent,
                 replyMarkup: params.replyMarkup,
               });
+              visibleFallbackText = fallbackText;
             }
             markReplyApplied(params.progress, replyToMessageId);
             continue;
@@ -566,7 +579,7 @@ async function deliverMediaReply(params: {
       pendingFollowUpText = undefined;
     }
   }
-  return firstDeliveredMessageId;
+  return { firstDeliveredMessageId, visibleFallbackText };
 }
 
 async function maybePinFirstDeliveredMessage(params: {
@@ -784,6 +797,11 @@ export async function deliverReplies(params: {
     }
 
     const rawContent = resolvedReplyText;
+    const spokenHookContent =
+      !rawContent && reply.audioAsVoice === true && reply.spokenText?.trim()
+        ? reply.spokenText
+        : undefined;
+    const hookContent = spokenHookContent ?? rawContent;
     const replyToId =
       params.replyToMode === "off" ? undefined : resolveTelegramReplyId(reply.replyToId);
     const replyQuote = resolveReplyQuoteForSend({
@@ -798,7 +816,7 @@ export async function deliverReplies(params: {
       const hookResult = await hookRunner?.runMessageSending(
         {
           to: params.chatId,
-          content: rawContent,
+          content: hookContent,
           replyToId,
           threadId: params.thread?.id,
           metadata: {
@@ -816,12 +834,15 @@ export async function deliverReplies(params: {
       if (hookResult?.cancel) {
         continue;
       }
-      if (typeof hookResult?.content === "string" && hookResult.content !== rawContent) {
-        reply = { ...reply, text: hookResult.content };
+      if (typeof hookResult?.content === "string" && hookResult.content !== hookContent) {
+        reply = spokenHookContent
+          ? { ...reply, spokenText: hookResult.content }
+          : { ...reply, text: hookResult.content };
       }
     }
 
-    const contentForSentHook = reply.text || "";
+    let contentForSentHook =
+      reply.text || (reply.audioAsVoice === true ? resolveVoiceFallbackText(reply) : "") || "";
 
     try {
       const deliveredCountBeforeReply = progress.deliveredCount;
@@ -853,7 +874,7 @@ export async function deliverReplies(params: {
           progress,
         });
       } else {
-        firstDeliveredMessageId = await deliverMediaReply({
+        const mediaDelivery = await deliverMediaReply({
           reply,
           mediaList,
           bot: params.bot,
@@ -876,6 +897,10 @@ export async function deliverReplies(params: {
           replyToMode: params.replyToMode,
           progress,
         });
+        firstDeliveredMessageId = mediaDelivery.firstDeliveredMessageId;
+        if (mediaDelivery.visibleFallbackText) {
+          contentForSentHook = mediaDelivery.visibleFallbackText;
+        }
       }
       await maybePinFirstDeliveredMessage({
         pin: reply.delivery?.pin,

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -1168,6 +1168,96 @@ describe("deliverReplies", () => {
     }
   });
 
+  it("uses spokenText only after voice rejection", async () => {
+    const { runtime, sendVoice, sendMessage, bot } = createVoiceFailureHarness({
+      voiceError: createVoiceMessagesForbiddenError(),
+      sendMessageResult: {
+        message_id: 5,
+        chat: { id: "123" },
+      },
+    });
+    const transcriptMirror = vi.fn();
+
+    mockMediaLoad("note.ogg", "audio/ogg", "voice");
+
+    await deliverWith({
+      replies: [
+        {
+          mediaUrl: "https://example.com/note.ogg",
+          audioAsVoice: true,
+          spokenText: "Hidden voice fallback",
+        },
+      ],
+      runtime,
+      bot,
+      transcriptMirror,
+    });
+
+    expect(sendVoice).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(firstMockCallArg(sendMessage, 1)).toContain("Hidden voice fallback");
+    expect(transcriptMirror).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "Hidden voice fallback" }),
+    );
+  });
+
+  it("runs message_sending hooks over spokenText voice fallback content", async () => {
+    messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sending");
+    messageHookRunner.runMessageSending.mockResolvedValue({ content: "Rewritten voice fallback" });
+    const { runtime, sendVoice, sendMessage, bot } = createVoiceFailureHarness({
+      voiceError: createVoiceMessagesForbiddenError(),
+      sendMessageResult: {
+        message_id: 5,
+        chat: { id: "123" },
+      },
+    });
+
+    mockMediaLoad("note.ogg", "audio/ogg", "voice");
+
+    await deliverWith({
+      replies: [
+        {
+          mediaUrl: "https://example.com/note.ogg",
+          audioAsVoice: true,
+          spokenText: "Hidden voice fallback",
+        },
+      ],
+      runtime,
+      bot,
+    });
+
+    expectRecordFields(mockCallArg(messageHookRunner.runMessageSending, 0, 0), {
+      content: "Hidden voice fallback",
+    });
+    expect(sendVoice).toHaveBeenCalledTimes(1);
+    expect((firstMockCallArg(sendVoice, 2) as { caption?: unknown }).caption).toBeUndefined();
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(firstMockCallArg(sendMessage, 1)).toContain("Rewritten voice fallback");
+  });
+
+  it("does not render spokenText as a successful voice caption", async () => {
+    const runtime = createRuntime(false);
+    const sendVoice = vi.fn().mockResolvedValue({ message_id: 8, chat: { id: "123" } });
+    const bot = createBot({ sendVoice });
+
+    mockMediaLoad("note.ogg", "audio/ogg", "voice");
+
+    await deliverWith({
+      replies: [
+        {
+          mediaUrl: "https://example.com/note.ogg",
+          audioAsVoice: true,
+          spokenText: "Hidden voice fallback",
+        },
+      ],
+      runtime,
+      bot,
+    });
+
+    expect(sendVoice).toHaveBeenCalledTimes(1);
+    expect((firstMockCallArg(sendVoice, 2) as { caption?: unknown }).caption).toBeUndefined();
+  });
+
   it("keeps disable_notification on voice fallback text when silent is true", async () => {
     const runtime = createRuntime();
     const sendVoice = vi.fn().mockRejectedValue(createVoiceMessagesForbiddenError());

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -19,6 +19,7 @@ export type DraftLaneState = {
 type LanePreviewFinalizedDelivery = {
   content: string;
   messageId: number;
+  buttonsAttached?: boolean;
   receipt: MessageReceipt;
 };
 
@@ -154,6 +155,116 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     params.applyTextToFollowUpPayload
       ? params.applyTextToFollowUpPayload(payload, text)
       : params.applyTextToPayload(payload, text);
+  const textOnlyPayload = (payload: ReplyPayload): ReplyPayload => {
+    const {
+      mediaUrl: _mediaUrl,
+      mediaUrls: _mediaUrls,
+      audioAsVoice: _audioAsVoice,
+      spokenText: _spokenText,
+      ...rest
+    } = payload;
+    return rest;
+  };
+  const mediaChannelData = (
+    channelData: ReplyPayload["channelData"],
+    options?: { stripButtons?: boolean },
+  ): ReplyPayload["channelData"] => {
+    if (!options?.stripButtons) {
+      return channelData;
+    }
+    const telegramData = channelData?.telegram;
+    if (!telegramData || typeof telegramData !== "object" || Array.isArray(telegramData)) {
+      return channelData;
+    }
+    const { buttons: _buttons, ...telegramRest } = telegramData as Record<string, unknown>;
+    if (_buttons === undefined) {
+      return channelData;
+    }
+    const next: Record<string, unknown> = { ...channelData };
+    if (Object.keys(telegramRest).length > 0) {
+      next.telegram = telegramRest;
+    } else {
+      delete next.telegram;
+    }
+    return Object.keys(next).length > 0 ? next : undefined;
+  };
+  const withMediaChannelData = (
+    payload: ReplyPayload,
+    options?: { stripButtons?: boolean },
+  ): ReplyPayload => {
+    const channelData = mediaChannelData(payload.channelData, options);
+    if (channelData === payload.channelData) {
+      return payload;
+    }
+    if (channelData) {
+      return { ...payload, channelData };
+    }
+    const { channelData: _channelData, ...rest } = payload;
+    return rest;
+  };
+  const withFallbackTelegramButtons = (
+    payload: ReplyPayload,
+    buttons?: TelegramInlineButtons,
+  ): ReplyPayload => {
+    if (!buttons) {
+      return payload;
+    }
+    const channelData = payload.channelData ?? {};
+    const telegramData = channelData.telegram;
+    if (
+      telegramData &&
+      typeof telegramData === "object" &&
+      !Array.isArray(telegramData) &&
+      "buttons" in telegramData
+    ) {
+      return payload;
+    }
+    const telegramRest =
+      telegramData && typeof telegramData === "object" && !Array.isArray(telegramData)
+        ? (telegramData as Record<string, unknown>)
+        : {};
+    return {
+      ...payload,
+      channelData: {
+        ...channelData,
+        telegram: {
+          ...telegramRest,
+          buttons,
+        },
+      },
+    };
+  };
+  const mediaOnlyPayload = (
+    payload: ReplyPayload,
+    text: string,
+    options?: { stripButtons?: boolean; fallbackButtons?: TelegramInlineButtons },
+  ): ReplyPayload => {
+    if (payload.audioAsVoice === true) {
+      const {
+        text: _text,
+        presentation: _presentation,
+        interactive: _interactive,
+        btw: _btw,
+        spokenText: _spokenText,
+        ...voicePayload
+      } = params.applyTextToPayload(payload, text);
+      return withFallbackTelegramButtons(
+        withMediaChannelData({ ...voicePayload, spokenText: text }, options),
+        options?.fallbackButtons,
+      );
+    }
+    const {
+      text: _text,
+      presentation: _presentation,
+      interactive: _interactive,
+      btw: _btw,
+      ...rest
+    } = payload;
+    return withFallbackTelegramButtons(
+      withMediaChannelData(rest, options),
+      options?.fallbackButtons,
+    );
+  };
 
   const clearUnfinalizedStream = async (lane: DraftLaneState) => {
     if (!lane.stream || lane.finalized) {
@@ -215,9 +326,11 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       if (deliveredStreamText !== undefined && deliveredStreamText !== previewText) {
         return undefined;
       }
+      let buttonsAttached = false;
       if (buttons) {
         try {
           await params.editStreamMessage({ laneName, messageId, text: previewText, buttons });
+          buttonsAttached = true;
         } catch (err) {
           params.log(`telegram: ${laneName} stream button edit failed: ${String(err)}`);
         }
@@ -230,7 +343,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       }
       lane.finalized = true;
       params.markDelivered();
-      return result("preview-finalized", { content: previewText, messageId });
+      return result("preview-finalized", { content: previewText, messageId, buttonsAttached });
     }
 
     lane.lastPartialText = firstChunk;
@@ -263,9 +376,11 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     }
 
     params.markDelivered();
+    let buttonsAttached = false;
     if (buttons) {
       try {
         await params.editStreamMessage({ laneName, messageId, text: firstChunk, buttons });
+        buttonsAttached = true;
       } catch (err) {
         params.log(`telegram: ${laneName} stream button edit failed: ${String(err)}`);
       }
@@ -279,7 +394,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
         }
         await params.sendPayload(followUpPayload(payload, chunk));
       }
-      return result("preview-finalized", { content: text, messageId });
+      return result("preview-finalized", { content: text, messageId, buttonsAttached });
     }
 
     return result("preview-updated");
@@ -300,6 +415,41 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
       : undefined;
     if (streamed) {
       return streamed;
+    }
+
+    if (
+      isFinal &&
+      reply.hasMedia &&
+      lane.stream &&
+      lane.hasStreamedMessage &&
+      !lane.finalized &&
+      text.trim().length > 0
+    ) {
+      const finalizedPreview = await streamText(
+        laneName,
+        lane,
+        text,
+        textOnlyPayload(payload),
+        true,
+        buttons,
+      );
+      if (finalizedPreview) {
+        const stripButtons =
+          finalizedPreview.kind === "preview-finalized" &&
+          finalizedPreview.delivery.buttonsAttached === true;
+        const mediaText =
+          finalizedPreview.kind === "preview-finalized" ? finalizedPreview.delivery.content : text;
+        await params.sendPayload(
+          mediaOnlyPayload(payload, mediaText, {
+            stripButtons,
+            fallbackButtons: stripButtons ? undefined : buttons,
+          }),
+          {
+            durable: true,
+          },
+        );
+        return finalizedPreview;
+      }
     }
 
     if (isFinal) {

--- a/extensions/telegram/src/lane-delivery.test.ts
+++ b/extensions/telegram/src/lane-delivery.test.ts
@@ -390,7 +390,33 @@ describe("createLaneTextDeliverer", () => {
     expect(harness.lanes.answer.finalized).toBe(true);
   });
 
-  it("clears unfinalized stream state before non-stream final delivery", async () => {
+  it("keeps streamed final text in place when late media arrives", async () => {
+    const harness = createHarness({ answerMessageId: 999 });
+    harness.lanes.answer.hasStreamedMessage = true;
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "photo",
+      payload: { text: "photo", mediaUrl: "https://example.com/a.png" },
+      infoKind: "final",
+    });
+
+    const delivery = expectPreviewFinalized(result);
+    expect(delivery.content).toBe("photo");
+    expect(delivery.messageId).toBe(999);
+    expect(harness.clearDraftLane).not.toHaveBeenCalled();
+    expect(harness.answer?.clear).not.toHaveBeenCalled();
+    expect(harness.answer?.update).toHaveBeenCalledWith("photo");
+    expect(harness.stopDraftLane).toHaveBeenCalledTimes(1);
+    expect(harness.sendPayload).toHaveBeenCalledWith(
+      {
+        mediaUrl: "https://example.com/a.png",
+      },
+      { durable: true },
+    );
+  });
+
+  it("uses normal media final delivery when no preview has streamed", async () => {
     const harness = createHarness({ answerMessageId: 999 });
 
     const result = await harness.deliverLaneText({
@@ -402,11 +428,217 @@ describe("createLaneTextDeliverer", () => {
 
     expect(result.kind).toBe("sent");
     expect(harness.clearDraftLane).toHaveBeenCalledTimes(1);
-    expect(harness.answer?.clear).toHaveBeenCalledTimes(1);
     expect(harness.sendPayload).toHaveBeenCalledWith(
       {
         text: "photo",
         mediaUrl: "https://example.com/a.png",
+      },
+      { durable: true },
+    );
+  });
+
+  it("uses normal media final delivery when no stream exists", async () => {
+    const harness = createHarness({ answerStream: null });
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "photo",
+      payload: { text: "photo", mediaUrl: "https://example.com/a.png" },
+      infoKind: "final",
+    });
+
+    expect(result.kind).toBe("sent");
+    expect(harness.clearDraftLane).not.toHaveBeenCalled();
+    expect(harness.sendPayload).toHaveBeenCalledWith(
+      {
+        text: "photo",
+        mediaUrl: "https://example.com/a.png",
+      },
+      { durable: true },
+    );
+  });
+
+  it("strips rich fallback content from late media follow-up", async () => {
+    const harness = createHarness({ answerMessageId: 999 });
+    harness.lanes.answer.hasStreamedMessage = true;
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "photo",
+      payload: {
+        text: "photo",
+        mediaUrl: "https://example.com/a.png",
+        presentation: {
+          title: "Photo",
+          blocks: [{ type: "text", text: "Visible fallback" }],
+        },
+        interactive: {
+          blocks: [{ type: "buttons", buttons: [{ label: "OK", value: "ok" }] }],
+        },
+        btw: { question: "side question" },
+      },
+      infoKind: "final",
+    });
+
+    expectPreviewFinalized(result);
+    expect(harness.sendPayload).toHaveBeenCalledWith(
+      {
+        mediaUrl: "https://example.com/a.png",
+      },
+      { durable: true },
+    );
+  });
+
+  it("keeps text on late voice media so blocked voice sends can fall back", async () => {
+    const harness = createHarness({ answerMessageId: 999 });
+    harness.lanes.answer.hasStreamedMessage = true;
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "resolved voice fallback",
+      payload: {
+        text: "stale voice fallback",
+        mediaUrl: "https://example.com/note.ogg",
+        audioAsVoice: true,
+      },
+      infoKind: "final",
+    });
+
+    expectPreviewFinalized(result);
+    expect(harness.sendPayload).toHaveBeenCalledWith(
+      {
+        mediaUrl: "https://example.com/note.ogg",
+        audioAsVoice: true,
+        spokenText: "resolved voice fallback",
+      },
+      { durable: true },
+    );
+  });
+
+  it("uses retained final preview text for late voice media fallback", async () => {
+    const fullAnswer =
+      "A longer transcript-backed answer that has enough continuation text to avoid falling back to the truncated snapshot.";
+    const truncatedFinal = "A longer transcript-backed answer that has enough...";
+    const answer = createTestDraftStream({ messageId: 999 });
+    answer.lastDeliveredText.mockReturnValue(fullAnswer);
+    const harness = createHarness({
+      answerStream: answer,
+      resolveFinalTextCandidate: () => fullAnswer,
+    });
+    harness.lanes.answer.hasStreamedMessage = true;
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: truncatedFinal,
+      payload: {
+        text: truncatedFinal,
+        mediaUrl: "https://example.com/note.ogg",
+        audioAsVoice: true,
+      },
+      infoKind: "final",
+    });
+
+    const delivery = expectPreviewFinalized(result);
+    expect(delivery.content).toBe(fullAnswer);
+    expect(harness.sendPayload).toHaveBeenCalledWith(
+      {
+        mediaUrl: "https://example.com/note.ogg",
+        audioAsVoice: true,
+        spokenText: fullAnswer,
+      },
+      { durable: true },
+    );
+  });
+
+  it("keeps inline buttons on the streamed text instead of late media", async () => {
+    const harness = createHarness({ answerMessageId: 999 });
+    harness.lanes.answer.hasStreamedMessage = true;
+    const buttons = [[{ text: "OK", callback_data: "ok" }]];
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "photo",
+      payload: {
+        text: "photo",
+        mediaUrl: "https://example.com/a.png",
+        channelData: { telegram: { buttons, effect: "spark" }, other: true },
+      },
+      infoKind: "final",
+      buttons,
+    });
+
+    expectPreviewFinalized(result);
+    expect(harness.editStreamMessage).toHaveBeenCalledWith({
+      laneName: "answer",
+      messageId: 999,
+      text: "photo",
+      buttons,
+    });
+    expect(harness.sendPayload).toHaveBeenCalledWith(
+      {
+        mediaUrl: "https://example.com/a.png",
+        channelData: { telegram: { effect: "spark" }, other: true },
+      },
+      { durable: true },
+    );
+  });
+
+  it("keeps inline buttons on late media when the stream button edit fails", async () => {
+    const harness = createHarness({ answerMessageId: 999 });
+    harness.lanes.answer.hasStreamedMessage = true;
+    harness.editStreamMessage.mockRejectedValueOnce(new Error("400: button rejected"));
+    const buttons = [[{ text: "OK", callback_data: "ok" }]];
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "photo",
+      payload: {
+        text: "photo",
+        mediaUrl: "https://example.com/a.png",
+        channelData: { telegram: { buttons, effect: "spark" }, other: true },
+      },
+      infoKind: "final",
+      buttons,
+    });
+
+    expectPreviewFinalized(result);
+    expect(harness.log).toHaveBeenCalledWith(
+      "telegram: answer stream button edit failed: Error: 400: button rejected",
+    );
+    expect(harness.sendPayload).toHaveBeenCalledWith(
+      {
+        mediaUrl: "https://example.com/a.png",
+        channelData: { telegram: { buttons, effect: "spark" }, other: true },
+      },
+      { durable: true },
+    );
+  });
+
+  it("preserves derived inline buttons on late media when the stream button edit fails", async () => {
+    const harness = createHarness({ answerMessageId: 999 });
+    harness.lanes.answer.hasStreamedMessage = true;
+    harness.editStreamMessage.mockRejectedValueOnce(new Error("400: button rejected"));
+    const buttons = [[{ text: "OK", callback_data: "ok" }]];
+
+    const result = await harness.deliverLaneText({
+      laneName: "answer",
+      text: "photo",
+      payload: {
+        text: "photo",
+        mediaUrl: "https://example.com/a.png",
+        interactive: {
+          blocks: [{ type: "buttons", buttons: [{ label: "OK", value: "ok" }] }],
+        },
+      },
+      infoKind: "final",
+      buttons,
+    });
+
+    expectPreviewFinalized(result);
+    expect(harness.sendPayload).toHaveBeenCalledWith(
+      {
+        mediaUrl: "https://example.com/a.png",
+        channelData: { telegram: { buttons } },
       },
       { durable: true },
     );


### PR DESCRIPTION
Summary
- Keep Telegram streamed final text in place when delayed TTS/media arrives.
- Send late media as a durable media-only follow-up, while preserving voice fallback text and inline button behavior.
- Add regression coverage for late media, voice fallback, and derived Telegram buttons.

Verification
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/telegram/src/lane-delivery.test.ts extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/bot/delivery.test.ts extensions/telegram/src/outbound-adapter.test.ts`
- `git diff --check`
- `.agents/skills/codex-review/scripts/codex-review --mode local`

Behavior addressed: Telegram no longer deletes the streamed text reply when delayed TTS/audio is delivered after the final answer.

Real environment tested: AWS Crabbox with a real Telegram group and human-loop Telegram user, provider `aws`, lease `cbx_2bf916433186`, run `run_d396eb3687e1`.

Exact steps or command run after this patch: `pnpm crabbox:run -- --provider aws --idle-timeout 90m --ttl 120m --timing-json --env-from-profile /private/tmp/openclaw-82570-telegram-human-loop.env --allow-env OPENCLAW_QA_TELEGRAM_SUT_BOT_TOKEN --allow-env OPENCLAW_QA_TELEGRAM_GROUP_ID --allow-env OPENCLAW_QA_TELEGRAM_APPROVER_USER_ID --allow-env OPENCLAW_QA_TELEGRAM_CHAT_TITLE --script .artifacts/qa-e2e/issue-82570/repro-telegram-human-loop.sh`

Evidence after fix: Harness run id `82570-1778979761` observed `sendMessage` message `210`, `editMessageText` on message `210`, delayed TTS request, then `sendAudio` message `212`, with `sawDeleteMessage: false`.

Observed result after fix: The streamed Telegram text stayed in place and the delayed audio arrived as a separate follow-up message.

What was not tested: The reporter's exact original chat transcript was not available; the repro used a deterministic live Telegram human-loop scenario matching the reported text-plus-TTS timing behavior.

Fixes #82570
