### PR TITLE
fix: cap isolated telegram ingress long poll timeout

### DIFF
--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -640,6 +640,46 @@ describe("TelegramPollingSession", () => {
     await runPromise;
   });
 
+  it("logs isolated ingress timeout diagnostics on startup", async () => {
+    const abort = new AbortController();
+    const log = vi.fn();
+    const bot = {
+      api: {
+        deleteWebhook: vi.fn(async () => true),
+        config: { use: vi.fn() },
+      },
+      init: vi.fn(async () => undefined),
+      handleUpdate: vi.fn(async () => undefined),
+      stop: vi.fn(async () => undefined),
+    };
+    createTelegramBotMock.mockReturnValueOnce(bot);
+    const worker = createIdleIngressWorker();
+
+    const session = createPollingSession({
+      abortSignal: abort.signal,
+      log,
+      isolatedIngress: {
+        enabled: true,
+        timeoutSeconds: 90,
+        createWorker: worker.createWorker,
+        drainIntervalMs: 10,
+      },
+    });
+
+    const runPromise = session.runUntilAbort();
+    await vi.waitFor(() =>
+      expect(log).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "configuredTimeoutSeconds=90 pollTimeoutSeconds=30 requestTimeoutMs=45000",
+        ),
+      ),
+    );
+
+    abort.abort();
+    worker.stop();
+    await runPromise;
+  });
+
   it("keeps failed lanes blocked for the rest of the drain pass", async () => {
     await withTempSpool(async (tempDir) => {
       const abort = new AbortController();

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -16,7 +16,10 @@ import { isRecoverableTelegramNetworkError } from "./network-errors.js";
 import { TelegramPollingLivenessTracker } from "./polling-liveness.js";
 import { createTelegramPollingStatusPublisher } from "./polling-status.js";
 import { TelegramPollingTransportState } from "./polling-transport-state.js";
-import { TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS } from "./request-timeouts.js";
+import {
+  TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS,
+  resolveTelegramGetUpdatesLongPollTimeoutSeconds,
+} from "./request-timeouts.js";
 import { getTelegramSequentialKey } from "./sequential-key.js";
 import {
   claimTelegramSpooledUpdate,
@@ -523,6 +526,9 @@ export class TelegramPollingSession {
     }
     const spoolDir =
       ingress.spoolDir ?? resolveTelegramIngressSpoolDir({ accountId: this.opts.accountId });
+    const pollTimeoutSeconds = resolveTelegramGetUpdatesLongPollTimeoutSeconds(
+      ingress.timeoutSeconds,
+    );
     const workerFactory = ingress.createWorker ?? createTelegramIngressWorker;
     const worker = workerFactory({
       token: this.opts.token,
@@ -530,11 +536,13 @@ export class TelegramPollingSession {
       initialUpdateId: this.opts.getLastUpdateId(),
       spoolDir,
       apiRoot: ingress.apiRoot,
-      timeoutSeconds: ingress.timeoutSeconds,
+      timeoutSeconds: pollTimeoutSeconds,
       network: ingress.network,
       proxy: ingress.proxy,
     });
-    this.opts.log(`[telegram][diag] isolated polling ingress started spool=${spoolDir}`);
+    this.opts.log(
+      `[telegram][diag] isolated polling ingress started spool=${spoolDir} configuredTimeoutSeconds=${ingress.timeoutSeconds ?? "default"} pollTimeoutSeconds=${pollTimeoutSeconds} requestTimeoutMs=${TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS}`,
+    );
     const pollState: {
       startedAt: number | null;
       offset: number | null;

--- a/extensions/telegram/src/request-timeouts.test.ts
+++ b/extensions/telegram/src/request-timeouts.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  resolveTelegramGetUpdatesLongPollTimeoutSeconds,
   resolveTelegramRequestTimeoutMs,
   resolveTelegramStartupProbeTimeoutMs,
 } from "./request-timeouts.js";
@@ -54,5 +55,16 @@ describe("resolveTelegramStartupProbeTimeoutMs", () => {
 
   it("honors higher configured timeoutSeconds", () => {
     expect(resolveTelegramStartupProbeTimeoutMs(60)).toBe(60_000);
+  });
+});
+
+describe("resolveTelegramGetUpdatesLongPollTimeoutSeconds", () => {
+  it("matches the regular polling runner default", () => {
+    expect(resolveTelegramGetUpdatesLongPollTimeoutSeconds()).toBe(30);
+  });
+
+  it("does not let configured timeoutSeconds stretch isolated ingress beyond the hard request guard", () => {
+    expect(resolveTelegramGetUpdatesLongPollTimeoutSeconds(90)).toBe(30);
+    expect(resolveTelegramGetUpdatesLongPollTimeoutSeconds(10)).toBe(30);
   });
 });

--- a/extensions/telegram/src/request-timeouts.ts
+++ b/extensions/telegram/src/request-timeouts.ts
@@ -1,5 +1,6 @@
 export const TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS = 45_000;
 const TELEGRAM_OUTBOUND_TEXT_REQUEST_TIMEOUT_MS = 60_000;
+export const TELEGRAM_GET_UPDATES_LONG_POLL_TIMEOUT_SECONDS = 30;
 
 const TELEGRAM_REQUEST_TIMEOUTS_MS = {
   // Bound startup/control-plane calls so the gateway cannot report Telegram as
@@ -33,6 +34,20 @@ function resolveConfiguredTelegramRequestTimeoutMs(timeoutSeconds: unknown): num
     return undefined;
   }
   return Math.max(1, Math.floor(timeoutSeconds)) * 1000;
+}
+
+export function resolveTelegramGetUpdatesLongPollTimeoutSeconds(timeoutSeconds?: unknown): number {
+  const configuredTimeoutMs = resolveConfiguredTelegramRequestTimeoutMs(timeoutSeconds);
+  if (configuredTimeoutMs === undefined) {
+    return TELEGRAM_GET_UPDATES_LONG_POLL_TIMEOUT_SECONDS;
+  }
+  return Math.max(
+    1,
+    Math.min(
+      TELEGRAM_GET_UPDATES_LONG_POLL_TIMEOUT_SECONDS,
+      Math.floor((TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS - 1_000) / 1000),
+    ),
+  );
 }
 
 export function resolveTelegramRequestTimeoutMs(


### PR DESCRIPTION
## Summary
- cap isolated ingress long-poll timeout to the regular 30s polling ceiling
- log configured timeout, effective poll timeout, and request timeout for startup diagnostics
- add tests covering the timeout cap and diagnostic logging

## Why
The isolated Telegram ingress path could be configured with a timeout that exceeded the getUpdates request guard. This keeps long polling aligned with the existing request timeout envelope and makes startup diagnostics explicit.

## Test Plan
- [x] existing local changes committed and pushed on branch
- [x] targeted timeout logic tests added
- [x] targeted startup diagnostic logging test added

## Real behavior proof
Behavior addressed: isolated Telegram ingress now caps long-poll timeout to 30s even when the configured timeout is higher, and logs the configured/effective/request timeout values at startup.
Real environment tested: local OpenClaw gateway user service on WSL (`openclaw-gateway.service`), Telegram channel enabled for account `default`, patched v2026.5.17 candidate runtime.
Exact steps or command run after this patch: restarted the live gateway service, then inspected the live journal with `journalctl --user -u openclaw-gateway.service -n 80 --no-pager`.
Evidence after fix: `2026-05-16T13:33:42.406-04:00 [telegram] [diag] isolated polling ingress started spool=/home/gonzo/.openclaw/telegram/ingress-spool-default configuredTimeoutSeconds=90 pollTimeoutSeconds=30 requestTimeoutMs=45000`
Observed result after fix: the real gateway started isolated Telegram ingress with `configuredTimeoutSeconds=90` but clamped the effective poll timeout to `30`, matching the request guard, and the channel continued handling inbound Telegram traffic afterward.
What was not tested: I did not run a synthetic multi-minute packet-capture trace of `getUpdates`; proof here is from the real service startup diagnostics and subsequent live traffic on the patched runtime.
