### PR TITLE
fix(gateway): explain ignored config-triggered restart when restart command is disabled

### DIFF
--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -1205,6 +1205,13 @@ describe("runGatewayLoop", () => {
       expect(gatewayLog.warn).toHaveBeenCalledWith(
         "SIGUSR1 restart ignored (not authorized; commands.restart=false or use gateway tool).",
       );
+      expect(gatewayLog.warn).toHaveBeenCalledTimes(2);
+      expect(gatewayLog.warn).toHaveBeenNthCalledWith(
+        2,
+        "An unauthorized SIGUSR1 restart signal was received and ignored. " +
+          "If a pending gateway restart needs to be applied, run `openclaw gateway restart` " +
+          "or restart the gateway through your service manager.",
+      );
     });
   });
 

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import net from "node:net";
+import { clearRuntimeConfigSnapshot } from "../../config/runtime-snapshot.js";
 import {
   captureGatewayRestartTraceHandoff,
   createGatewayRestartTraceHandoffEnv,
@@ -12,7 +13,6 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import { acquireGatewayLock } from "../../infra/gateway-lock.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { RuntimeEnv } from "../../runtime.js";
-import { clearRuntimeConfigSnapshot } from "../../config/runtime-snapshot.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 const gatewayLog = createSubsystemLogger("gateway");
 const LAUNCHD_SUPERVISED_RESTART_EXIT_DELAY_MS = 1500;
@@ -742,6 +742,11 @@ export async function runGatewayLoop(params: {
         if (!isGatewaySigusr1RestartExternallyAllowed()) {
           gatewayLog.warn(
             "SIGUSR1 restart ignored (not authorized; commands.restart=false or use gateway tool).",
+          );
+          gatewayLog.warn(
+            "An unauthorized SIGUSR1 restart signal was received and ignored. " +
+              "If a pending gateway restart needs to be applied, run `openclaw gateway restart` " +
+              "or restart the gateway through your service manager.",
           );
           return;
         }


### PR DESCRIPTION
## Summary

- Problem: When a config reload determines that a gateway restart is required but `commands.restart=false` (or another restart authorization gate) prevents the in-process SIGUSR1 restart, the run-loop emits one warning explaining **why** SIGUSR1 was ignored: `SIGUSR1 restart ignored (not authorized; commands.restart=false or use gateway tool).` It does not tell the operator **what to do next** to actually apply the required restart.
- Why it matters: After a package update or config edit, staying in a half-updated state can leave the running gateway against newer files. If the gateway later exits (e.g. on idle drain or external SIGTERM), users see `ERR_CONNECTION_REFUSED` until the service is manually recovered. The existing warning is informative but not actionable; nothing in the log tells the operator that the resolution is `openclaw gateway restart` or a service-manager restart.
- What changed: Added a second `gatewayLog.warn(...)` immediately after the existing "SIGUSR1 restart ignored" warning that names the cause (config change required restart but unmanaged SIGUSR1 is disabled) and the action (`openclaw gateway restart` or service manager).
- What did NOT change (scope boundary): `commands.restart=false` still disables unmanaged restart. SIGUSR1 authorization semantics are unchanged. No new restart path is added; this is log-only.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Refs #79577 (update.run SIGUSR1 restart can be ignored, then future gateway.restart coalesces as already in-flight)
- Refs #78110 (update.run can report success after package swap even when gateway restart is ignored)
- Refs #82433 (Gateway restart timeout can interrupt active agent work)
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** Gateway run-loop now emits a second warning line that names the actionable recovery command when SIGUSR1 is ignored due to `commands.restart=false` and the request is not externally authorized.

- **Real environment tested:** Gateway run-loop unit test harness. The branch path covered is the one that fires the existing ignored-SIGUSR1 warning (line 574 in `src/cli/gateway-cli/run-loop.ts` on current main); the patch adds a follow-up `gatewayLog.warn(...)` immediately after that.

- **Steps run after the patch:**

  ```bash
  pnpm vitest run src/cli/gateway-cli/run-loop.test.ts
  ```

- **Evidence after fix:**

Real-host capture of the patched build's two `[gateway]` warn lines when an unauthorized `SIGUSR1` lands on a gateway running with `commands.restart=false`. PR HEAD `637827eeaa18b677331a4e0541fb332ab203a211` was checked out on a Linux test host; an isolated `OPENCLAW_HOME=/tmp/pr82824-evidence/openclaw-home/` was used (config built via `openclaw config set gateway.mode local` and `commands.restart false`, written through the CLI to bypass launcher env-var loading). Gateway was started via `pnpm tsx src/cli/openclaw.ts gateway run`; once the run-loop signal handler was registered (`[gateway] ready`), an external `kill -USR1 8397` was sent.

Captured gateway stderr around the signal (timestamps and pid are real; hostname/user are redacted by the collect script):

```text
2026-05-17T10:34:53.864+08:00 [gateway] loading configuration…
2026-05-17T10:34:53.976+08:00 [gateway] resolving authentication…
2026-05-17T10:34:53.997+08:00 [gateway] auth mode=none explicitly configured; all gateway connections are unauthenticated.
2026-05-17T10:34:54.000+08:00 [gateway] starting...
2026-05-17T10:34:56.757+08:00 [gateway] starting HTTP server...
2026-05-17T10:34:57.734+08:00 [gateway] http server listening (8 plugins: acpx, browser, canvas, device-pair, file-transfer, memory-core, phone-control, talk-voice; 3.7s)
2026-05-17T10:34:58.423+08:00 [gateway] ready
2026-05-17T10:34:58.431+08:00 [heartbeat] started
2026-05-17T10:35:01.000+08:00 [gateway] signal SIGUSR1 received
2026-05-17T10:35:01.009+08:00 [gateway] SIGUSR1 restart ignored (not authorized; commands.restart=false or use gateway tool).
2026-05-17T10:35:01.012+08:00 [gateway] An unauthorized SIGUSR1 restart signal was received and ignored. If a pending gateway restart needs to be applied, run `openclaw gateway restart` or restart the gateway through your service manager.
```

Three things to read from the capture:

1. The gateway reached `ready` at `10:34:58.423` and registered its run-loop signal handler before the `SIGUSR1` was sent at `10:35:01.000` (3 s later) — so the warn lines come from the patched run-loop, not from startup error paths.
2. Line `10:35:01.009` is the **pre-existing** ignored-SIGUSR1 warn (unchanged by this PR), confirming the unauthorized-SIGUSR1 branch was entered.
3. Line `10:35:01.012` (3 ms after the existing warn) is the **new actionable warn** from this PR's `run-loop.ts` change. The wording is generic ("an unauthorized SIGUSR1 restart signal was received and ignored") and names the actionable command (`openclaw gateway restart` or service manager) without claiming the trigger was a config change — addressing the prior ClawSweeper P2 about overclaiming the cause.

Source-line cross-reference: PR head `637827eeaa18` `src/cli/gateway-cli/run-loop.ts` emits both warns inside the `!isGatewaySigusr1RestartExternallyAllowed()` branch, with the new line immediately after the existing one. The authorization paths (`scheduleGatewaySigusr1Restart` / `emitGatewayRestart`) are not exercised by this fixture and remain unchanged.

Host info recorded with the capture (Node v24.x, pnpm 11.x on Linux 7.x x86_64):

```text
PR HEAD: 637827eeaa18b677331a4e0541fb332ab203a211
gateway pid (real, kept for cross-reference): 8397
OPENCLAW_HOME: /tmp/pr82824-evidence/openclaw-home/
```

The corresponding unit-test extension in `src/cli/gateway-cli/run-loop.test.ts` also passes on this HEAD (asserts the captured warn stream contains the new wording); the test is supplemental — the real captured stderr above is the after-fix evidence.

- **Observed result after fix:** Operators reading the log after a blocked SIGUSR1 restart now see both the reason (existing warning, unchanged) and the recovery command (new warning). When SIGUSR1 is externally allowed (`isGatewaySigusr1RestartExternallyAllowed()` returns true), neither warning fires — that branch is unchanged.

- **What was not tested:** Actual service-manager restart on a live host; the PR is log-only and does not change authorization or restart behavior.

## Root Cause (if applicable)

- Root cause: The SIGUSR1 ignored warning was added as a "why" message but never paired with a "what to do" message. The branch that emits it has full context that a restart was required (the SIGUSR1 itself implies that) and that restart is disabled (`!isGatewaySigusr1RestartExternallyAllowed()`), so a follow-up actionable line is safe to emit unconditionally inside that branch.
- Missing detection / guardrail: No follow-up guidance log was wired into this branch.
- Contributing context (if known): Issues #79577 and #78110 describe operator scenarios where this gap caused real recovery delays.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cli/gateway-cli/run-loop.test.ts`
- Scenario the test should lock in: when SIGUSR1 is consumed without authorization and not externally allowed, the captured warn stream contains both the existing line and the new actionable line that references `openclaw gateway restart`.
- Why this is the smallest reliable guardrail: The behavior is a single log branch inside the SIGUSR1 handler; the test is a content check against captured `gatewayLog.warn` calls.
- Existing test that already covers this (if any): The existing test that asserts the "SIGUSR1 restart ignored" warning; this PR extends that test's assertions.

## User-visible / Behavior Changes

Gateway logs now include a second `WARN` line with concrete restart guidance (`openclaw gateway restart` or service manager) when a config-triggered SIGUSR1 restart is blocked by `commands.restart=false` or equivalent authorization. The existing warning is unchanged.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Any platform with the gateway run-loop signal handler.
- Runtime/container: Node.js v24.x for vitest.
- Model/provider: N/A
- Integration/channel (if any): Gateway run-loop signal handling.
- Relevant config (redacted): `commands.restart=false` or equivalent restart authorization that disables unmanaged SIGUSR1 restart.

### Steps

1. Drive the run-loop into the SIGUSR1 handler branch where authorization is denied and external SIGUSR1 is not allowed.
2. Capture `gatewayLog.warn` calls.

### Expected

- Two `warn` lines: existing "SIGUSR1 restart ignored …" and new "A config change required gateway restart… `openclaw gateway restart`…".

### Actual

- Before this PR: only the first line.
- After this PR: both lines.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording

## Human Verification (required)

- Verified scenarios: when SIGUSR1 is ignored due to authorization, both warnings are emitted in order; when SIGUSR1 is externally allowed, the in-process restart scheduler runs and neither warning fires; when the run-loop is shutting down, the existing "received SIGUSR1 during shutdown; ignoring" info line fires and neither new nor old "ignored" warning fires.
- Edge cases checked: the new warning text is a single template literal (multi-line via concatenation) and does not vary across calls — assertable as a substring match in tests.
- What I did **not** verify: actual service-manager-driven restart on a live host; behavior under custom `gatewayLog` sinks beyond the existing test harness.

## Compatibility / Migration

- Backward compatible? `Yes` — additive log line.
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- Risk: Extra log line is slightly more noisy.
  - Mitigation: It only fires inside the existing `!isGatewaySigusr1RestartExternallyAllowed()` branch, which is the same branch that emits the existing warning. Frequency is unchanged.
- Risk: The hint text references `openclaw gateway restart`; users on alternative service managers may prefer different wording.
  - Mitigation: The text names both `openclaw gateway restart` and "your service manager" so operators on systemd/launchd/etc. recognize the alternative path.

