### PR TITLE
fix(daemon): preserve container service env across regen

### DIFF
--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -1493,12 +1493,12 @@ describe("gatewayInstallErrorHint", () => {
 describe("collectPreservedExistingServiceEnvVars — operator opt-in allowlist", () => {
   const managedKeys = new Set<string>();
 
-  it("preserves OPENCLAW_ALLOW_ROOT operator opt-in", () => {
+  it("continues to drop stale OPENCLAW_ALLOW_ROOT", () => {
     const result = collectPreservedExistingServiceEnvVars(
       { OPENCLAW_ALLOW_ROOT: "1" },
       managedKeys,
     );
-    expect(result.OPENCLAW_ALLOW_ROOT).toBe("1");
+    expect(result.OPENCLAW_ALLOW_ROOT).toBeUndefined();
   });
 
   it("preserves OPENCLAW_CLI_CONTAINER_BYPASS and OPENCLAW_CONTAINER_HINT", () => {
@@ -1518,12 +1518,17 @@ describe("collectPreservedExistingServiceEnvVars — operator opt-in allowlist",
     expect(result.OPENCLAW_FOO).toBeUndefined();
   });
 
-  it("preserves the opt-in while dropping unrelated OPENCLAW_* keys", () => {
+  it("preserves container opt-ins while dropping unrelated OPENCLAW_* keys", () => {
     const result = collectPreservedExistingServiceEnvVars(
-      { OPENCLAW_ALLOW_ROOT: "1", OPENCLAW_BAZ: "qux" },
+      {
+        OPENCLAW_CLI_CONTAINER_BYPASS: "1",
+        OPENCLAW_CONTAINER_HINT: "ci",
+        OPENCLAW_BAZ: "qux",
+      },
       managedKeys,
     );
-    expect(result.OPENCLAW_ALLOW_ROOT).toBe("1");
+    expect(result.OPENCLAW_CLI_CONTAINER_BYPASS).toBe("1");
+    expect(result.OPENCLAW_CONTAINER_HINT).toBe("ci");
     expect(result.OPENCLAW_BAZ).toBeUndefined();
   });
 });

--- a/src/commands/daemon-install-helpers.test.ts
+++ b/src/commands/daemon-install-helpers.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { writeStateDirDotEnv } from "../config/test-helpers.js";
+import { collectPreservedExistingServiceEnvVars } from "./daemon-install-helpers.js";
 
 const mocks = vi.hoisted(() => ({
   hasAnyAuthProfileStoreSource: vi.fn(() => true),
@@ -1486,5 +1487,43 @@ describe("gatewayInstallErrorHint", () => {
     expect(gatewayInstallErrorHint("linux")).toMatch(
       /(?:openclaw|openclaw)( --profile isolated)? gateway install/,
     );
+  });
+});
+
+describe("collectPreservedExistingServiceEnvVars — operator opt-in allowlist", () => {
+  const managedKeys = new Set<string>();
+
+  it("preserves OPENCLAW_ALLOW_ROOT operator opt-in", () => {
+    const result = collectPreservedExistingServiceEnvVars(
+      { OPENCLAW_ALLOW_ROOT: "1" },
+      managedKeys,
+    );
+    expect(result.OPENCLAW_ALLOW_ROOT).toBe("1");
+  });
+
+  it("preserves OPENCLAW_CLI_CONTAINER_BYPASS and OPENCLAW_CONTAINER_HINT", () => {
+    const result = collectPreservedExistingServiceEnvVars(
+      {
+        OPENCLAW_CLI_CONTAINER_BYPASS: "1",
+        OPENCLAW_CONTAINER_HINT: "ci",
+      },
+      managedKeys,
+    );
+    expect(result.OPENCLAW_CLI_CONTAINER_BYPASS).toBe("1");
+    expect(result.OPENCLAW_CONTAINER_HINT).toBe("ci");
+  });
+
+  it("still drops arbitrary OPENCLAW_FOO", () => {
+    const result = collectPreservedExistingServiceEnvVars({ OPENCLAW_FOO: "bar" }, managedKeys);
+    expect(result.OPENCLAW_FOO).toBeUndefined();
+  });
+
+  it("preserves the opt-in while dropping unrelated OPENCLAW_* keys", () => {
+    const result = collectPreservedExistingServiceEnvVars(
+      { OPENCLAW_ALLOW_ROOT: "1", OPENCLAW_BAZ: "qux" },
+      managedKeys,
+    );
+    expect(result.OPENCLAW_ALLOW_ROOT).toBe("1");
+    expect(result.OPENCLAW_BAZ).toBeUndefined();
   });
 });

--- a/src/commands/daemon-install-helpers.ts
+++ b/src/commands/daemon-install-helpers.ts
@@ -437,7 +437,6 @@ function mergeServicePath(
 // environments. These represent intentional, user-placed configuration on the
 // service definition that the install/repair flow should not silently revert.
 const PRESERVED_OPENCLAW_OPERATOR_OPT_IN_ENV_KEYS = new Set([
-  "OPENCLAW_ALLOW_ROOT",
   "OPENCLAW_CLI_CONTAINER_BYPASS",
   "OPENCLAW_CONTAINER_HINT",
 ]);

--- a/src/commands/daemon-install-helpers.ts
+++ b/src/commands/daemon-install-helpers.ts
@@ -432,7 +432,17 @@ function mergeServicePath(
   return segments.length > 0 ? segments.join(path.delimiter) : undefined;
 }
 
-function collectPreservedExistingServiceEnvVars(
+// Operator opt-in env vars that should survive service regeneration even though
+// they share the OPENCLAW_ prefix that is otherwise stripped from preserved
+// environments. These represent intentional, user-placed configuration on the
+// service definition that the install/repair flow should not silently revert.
+const PRESERVED_OPENCLAW_OPERATOR_OPT_IN_ENV_KEYS = new Set([
+  "OPENCLAW_ALLOW_ROOT",
+  "OPENCLAW_CLI_CONTAINER_BYPASS",
+  "OPENCLAW_CONTAINER_HINT",
+]);
+
+export function collectPreservedExistingServiceEnvVars(
   existingEnvironment: Record<string, string | undefined> | undefined,
   managedServiceEnvKeys: Set<string>,
 ): Record<string, string | undefined> {
@@ -450,7 +460,7 @@ function collectPreservedExistingServiceEnvVars(
       upper === "HOME" ||
       upper === "PATH" ||
       upper === "TMPDIR" ||
-      upper.startsWith("OPENCLAW_")
+      (upper.startsWith("OPENCLAW_") && !PRESERVED_OPENCLAW_OPERATOR_OPT_IN_ENV_KEYS.has(upper))
     ) {
       continue;
     }


### PR DESCRIPTION
## Summary

- Problem: gateway service regeneration preserved selected host env vars but dropped every existing `OPENCLAW_*` key, which also removed current container-targeting service hints.
- What changed: preserve only the current container opt-in pair, `OPENCLAW_CLI_CONTAINER_BYPASS` and `OPENCLAW_CONTAINER_HINT`, while continuing to strip stale or arbitrary `OPENCLAW_*` keys such as `OPENCLAW_ALLOW_ROOT` and `OPENCLAW_FOO`.
- Scope boundary: this PR does not add root execution behavior, does not reintroduce the reverted root guard contract, and does not preserve arbitrary OpenClaw-managed service env.

## Change Type

- [x] Bug fix
- [x] Security hardening

## Scope

- [x] Gateway / orchestration
- [x] CI/CD / infra

## Linked Issue/PR

- Refs #81370 (reverted the beta-only global root refusal / `OPENCLAW_ALLOW_ROOT` runtime contract)
- Refs #67509 (prior root guard PR)
- Refs #67499 (earlier root guard attempt)

## Real behavior proof

- Behavior addressed: `collectPreservedExistingServiceEnvVars()` now preserves the current container service env pair and still drops stale or arbitrary `OPENCLAW_*` keys.
- Real environment tested: local OpenClaw checkout on PR branch after maintainer fixup commit `2e4b7f7fccbc46541c9c0ac271b1c97f1a6aa071`.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/commands/daemon-install-helpers.test.ts -t "operator opt-in allowlist"`
- Evidence after fix:

```text
Test Files  1 passed (1)
Tests       4 passed | 38 skipped (42)
```

- Observed result after fix: `OPENCLAW_CLI_CONTAINER_BYPASS` and `OPENCLAW_CONTAINER_HINT` are preserved; `OPENCLAW_ALLOW_ROOT`, `OPENCLAW_FOO`, and unrelated arbitrary `OPENCLAW_*` keys are stripped.
- What was not tested: live systemd activation or daemon restart; this patch is limited to the pure helper that feeds service regeneration.

## Regression Test Plan

- Coverage level: unit test.
- Target test: `src/commands/daemon-install-helpers.test.ts`.
- Scenario locked in: current container opt-ins are preserved, stale root opt-in and arbitrary `OPENCLAW_*` keys are not preserved.

## User-visible / Behavior Changes

Operators who intentionally keep container-targeting hints on a managed gateway service keep those hints after `openclaw gateway install --force` or doctor/repair regeneration. `OPENCLAW_ALLOW_ROOT` is not preserved because current runtime no longer consumes it as a root-guard override.

## Security Impact

- New permissions/capabilities? `No`.
- Secrets/tokens handling changed? `No`.
- New/changed network calls? `No`.
- Command/tool execution surface changed? `No`.
- Data access scope changed? `Yes` — service regeneration reads and re-emits two existing operator-placed container routing env keys from the previous service definition.
- Risk mitigation: the allowlist is intentionally narrow and excludes `OPENCLAW_ALLOW_ROOT` plus arbitrary `OPENCLAW_*` keys, so stale authorization-like state is not made durable.

## Verification

- `git diff --check`
- `node scripts/run-vitest.mjs src/commands/daemon-install-helpers.test.ts -t "operator opt-in allowlist"`
- `.agents/skills/autoreview/scripts/autoreview --mode local --prompt "Review the local fixup for PR #82828. Context: previous PR preserved OPENCLAW_ALLOW_ROOT plus container env keys; this fix intentionally removes OPENCLAW_ALLOW_ROOT because the runtime root guard was reverted, while preserving the current container env contracts."`


