### PR TITLE
fix: resolve installed plugin facade dist surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Docs: https://docs.openclaw.ai
 - Providers/Anthropic-messages: extract `reasoning_content` from `thinking` blocks during assistant replay so proxy providers that route through the Anthropic-messages transport preserve reasoning context across tool-call follow-up turns. Thanks @Sunnyone2three.
 - Agents/GitHub Copilot: normalize replayed Responses tool-call IDs before dispatch so resumed sessions with historical overlong tool IDs continue instead of failing Copilot schema validation. (#82750) Thanks @galiniliev.
 - CLI/web: resolve provider-scoped web search/fetch SecretRefs for `infer web ... --provider ...` while leaving unrelated plugin secrets untouched. Fixes #82621. Thanks @leno23.
+- Providers/Anthropic Vertex: resolve installed provider public surfaces from package-local `dist/`, restoring `anthropic-vertex/*` model calls after plugin externalization. Fixes #82781. Thanks @0L1v3DaD.
 - Mac app: let menu gateway/session error text wrap across a few lines and stop rebuilding dynamic Context/Gateway menu rows while the menu is open, reducing flicker.
 - Mac app: make device pairing approval sheets friendlier, with concise Mac/device copy, shortened identifiers, friendly scope labels, and Approve as the primary action.
 - Providers/Qwen: honor session thinking level for `qwen-chat-template` payloads so `/think off` disables nested llama.cpp chat-template thinking controls. Fixes #82768. Thanks @bfox55.

--- a/src/agents/anthropic-vertex-stream.test.ts
+++ b/src/agents/anthropic-vertex-stream.test.ts
@@ -30,7 +30,8 @@ function writeExternalAnthropicVertexPlugin(rootDir: string): void {
       version: "0.0.0",
       type: "module",
       openclaw: {
-        extensions: ["./index.js", "./api.js"],
+        extensions: ["./index.ts"],
+        runtimeExtensions: ["./dist/index.js"],
       },
     }),
     "utf8",
@@ -44,8 +45,10 @@ function writeExternalAnthropicVertexPlugin(rootDir: string): void {
     }),
     "utf8",
   );
+  const distDir = path.join(rootDir, "dist");
+  fs.mkdirSync(distDir, { recursive: true });
   fs.writeFileSync(
-    path.join(rootDir, "api.js"),
+    path.join(distDir, "api.js"),
     [
       "export function createAnthropicVertexStreamFnForModel(model, env) {",
       "  return async () => ({ marker: 'external-vertex', baseUrl: model.baseUrl, envMarker: env.OPENCLAW_TEST_MARKER });",
@@ -54,7 +57,7 @@ function writeExternalAnthropicVertexPlugin(rootDir: string): void {
     ].join("\n"),
     "utf8",
   );
-  fs.writeFileSync(path.join(rootDir, "index.js"), "export default {};\n", "utf8");
+  fs.writeFileSync(path.join(distDir, "index.js"), "export default {};\n", "utf8");
 }
 
 afterEach(() => {

--- a/src/plugin-sdk/facade-resolution-shared.ts
+++ b/src/plugin-sdk/facade-resolution-shared.ts
@@ -108,9 +108,13 @@ export function resolveRegistryPluginModuleLocationFromRecords(params: {
   for (const matchFn of tiers) {
     for (const record of params.registry.filter(matchFn)) {
       const rootDir = path.resolve(record.rootDir);
-      const builtCandidate = path.join(rootDir, artifactBasename);
-      if (fs.existsSync(builtCandidate)) {
-        return { modulePath: builtCandidate, boundaryRoot: rootDir };
+      for (const builtCandidate of [
+        path.join(rootDir, artifactBasename),
+        path.join(rootDir, "dist", artifactBasename),
+      ]) {
+        if (fs.existsSync(builtCandidate)) {
+          return { modulePath: builtCandidate, boundaryRoot: rootDir };
+        }
       }
       for (const ext of PUBLIC_SURFACE_SOURCE_EXTENSIONS) {
         const sourceCandidate = path.join(rootDir, `${sourceBaseName}${ext}`);

--- a/src/plugin-sdk/facade-runtime.test.ts
+++ b/src/plugin-sdk/facade-runtime.test.ts
@@ -401,6 +401,56 @@ describe("plugin-sdk facade runtime", () => {
     });
   });
 
+  it("resolves a globally-installed plugin public surface from package dist", () => {
+    const lineDir = createTempDirSync("openclaw-facade-global-line-dist-");
+    fs.mkdirSync(path.join(lineDir, "dist"), { recursive: true });
+    fs.writeFileSync(
+      path.join(lineDir, "dist", "runtime-api.js"),
+      'export const marker = "global-line-dist";\n',
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(lineDir, "package.json"),
+      JSON.stringify({
+        name: "@openclaw/line",
+        version: "0.0.0",
+        type: "module",
+        openclaw: {
+          extensions: ["./index.ts"],
+          runtimeExtensions: ["./dist/index.js"],
+          channel: { id: "line" },
+        },
+      }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(lineDir, "openclaw.plugin.json"),
+      JSON.stringify({
+        id: "line",
+        channels: ["line"],
+        configSchema: { type: "object", additionalProperties: false, properties: {} },
+      }),
+      "utf8",
+    );
+
+    expect(
+      __testing.resolveRegistryPluginModuleLocationFromRegistry({
+        registry: [
+          {
+            id: "line",
+            rootDir: lineDir,
+            channels: ["line"],
+          },
+        ],
+        dirName: "line",
+        artifactBasename: "runtime-api.js",
+      }),
+    ).toEqual({
+      modulePath: path.join(lineDir, "dist", "runtime-api.js"),
+      boundaryRoot: lineDir,
+    });
+  });
+
   it("resolves a globally-installed plugin with an encoded scoped rootDir basename", () => {
     const encodedDir = createTempDirSync("openclaw-facade-encoded-line-");
     fs.mkdirSync(encodedDir, { recursive: true });


### PR DESCRIPTION
## Summary

- Problem: installed npm plugins can publish public facade surfaces under package-local `dist/`, but the installed-plugin facade resolver only checked package root surfaces.
- Why it matters: after Anthropic Vertex was externalized, `anthropic-vertex/*` model calls failed with `Unable to resolve bundled plugin public surface anthropic-vertex/api.js` even when `@openclaw/anthropic-vertex-provider` was installed.
- What changed: registry-backed facade resolution now checks `<pluginRoot>/dist/<artifact>` after root built surfaces, and Anthropic Vertex regression coverage models the real published package layout.
- What did NOT change (scope boundary): no provider-specific shim, no activation policy change, no bundled-plugin resolution behavior change.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #82781
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

Behavior addressed: installed Anthropic Vertex provider packages expose `dist/api.js`, and model runtime facade lookup now resolves that package-local built surface instead of failing while looking only for root `api.js`.

Real environment tested: local macOS source checkout plus delegated Blacksmith Testbox changed-check. Published npm package layout verified against `@openclaw/anthropic-vertex-provider@2026.5.12`.

Exact steps or command run after this patch: `npm pack @openclaw/anthropic-vertex-provider@2026.5.12 --dry-run --json`; `node scripts/run-vitest.mjs src/agents/anthropic-vertex-stream.test.ts src/plugin-sdk/facade-runtime.test.ts`; `pnpm check:changed`; `pnpm build`; `/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --mode local`.

Evidence after fix: focused Vitest result: 3 files, 16 tests passed. Remote changed-check: provider `blacksmith-testbox`, id `tbx_01krsrvmqc6map26wxysc2z8em`, GitHub run https://github.com/openclaw/openclaw/actions/runs/25978036090, exit 0. Build completed with `pnpm build`. Codex review reported no accepted/actionable findings.

Observed result after fix: the Anthropic Vertex regression fixture has only `dist/api.js` and no root `api.js`; `createAnthropicVertexStreamFnForModel` resolves and executes the external provider facade successfully.

What was not tested: no live Vertex API call with real Google credentials; this PR validates the failing host-side facade resolution path and published package layout.

Before evidence (optional but encouraged): `npm pack @openclaw/anthropic-vertex-provider@2026.5.12 --dry-run --json` lists `dist/api.js` and no root `api.js`; previous resolver checked root `api.js` and source candidates only.

## Root Cause (if applicable)

- Root cause: externalized plugin packages build top-level public surfaces into package-local `dist/`, while `resolveRegistryPluginModuleLocationFromRecords` only checked root built surfaces and root source files for registry-installed plugins.
- Missing detection / guardrail: the Anthropic Vertex regression fixture wrote root `api.js`, so it did not match the published npm package layout.
- Contributing context (if known): Anthropic Vertex externalization in 2026.5.12 removed the stock bundled `dist/extensions/anthropic-vertex/api.js` path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/anthropic-vertex-stream.test.ts`, `src/plugin-sdk/facade-runtime.test.ts`
- Scenario the test should lock in: installed plugin registry records resolve package-local `dist/<artifact>` public surfaces when bundled plugin surfaces are absent.
- Why this is the smallest reliable guardrail: it exercises the generic resolver plus the Anthropic Vertex model facade without requiring live provider credentials.
- Existing test that already covers this (if any): none; prior fixture used root `api.js` and missed the published-package shape.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`anthropic-vertex/*` model calls can load the installed external provider facade after plugin externalization.

## Diagram (if applicable)

```text
Before:
anthropic-vertex model call -> registry plugin root -> api.js missing -> facade resolution error

After:
anthropic-vertex model call -> registry plugin root -> dist/api.js -> provider facade loads
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local checkout; Blacksmith Testbox for changed-check
- Runtime/container: Node via repo scripts
- Model/provider: Anthropic Vertex facade path, no live model call
- Integration/channel (if any): `@openclaw/anthropic-vertex-provider` npm package layout
- Relevant config (redacted): installed plugin index fixture with `anthropic-vertex` install path

### Steps

1. Create installed plugin fixture with `openclaw.plugin.json`, `package.json`, and only `dist/api.js`.
2. Disable bundled plugins and point `OPENCLAW_STATE_DIR` at the installed plugin index fixture.
3. Import `createAnthropicVertexStreamFnForModel` and call the returned stream function.

### Expected

- The provider facade resolves from the installed plugin package and returns the fixture marker.

### Actual

- After this patch, the fixture resolves from `dist/api.js` and passes.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: package `dist/api.js` resolver fallback; Anthropic Vertex installed-provider facade fixture; changed type/lint/guard lanes; build; Codex review.
- Edge cases checked: root `api.js` remains preferred for existing package layouts; source fallback remains after built candidates.
- What you did **not** verify: live Anthropic Vertex model call with real Google credentials.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: resolver might choose an unintended `dist/<artifact>` in a malformed plugin package.
  - Mitigation: root built surfaces stay preferred, artifact subpaths remain normalized as plugin-local, and module loading still uses the plugin root boundary check.
