### PR TITLE
[Fix] acpx: keep startup probe in runtime service

### DIFF
--- a/docs/tools/acp-agents-setup.md
+++ b/docs/tools/acp-agents-setup.md
@@ -164,10 +164,12 @@ Then verify backend health:
 
 ### acpx command and version configuration
 
-By default, the `acpx` plugin probes the embedded ACP backend during Gateway
-startup and waits for that probe before the gateway `ready` signal. Set
-`OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE=0` to skip the startup probe and register
-the backend lazily instead. Run `/acp doctor` for an explicit on-demand probe.
+By default, the `acpx` plugin registers the embedded ACP backend during Gateway
+startup and waits for the embedded runtime startup probe before the gateway
+`ready` signal. Set `OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE=0` or
+`OPENCLAW_SKIP_ACPX_RUNTIME_PROBE=1` only for scripts or environments that
+intentionally keep the startup probe disabled. Run `/acp doctor` for an explicit
+on-demand probe.
 
 Override the command or version in plugin config:
 

--- a/extensions/acpx/register.runtime.test.ts
+++ b/extensions/acpx/register.runtime.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { runtimeRegistry } = vi.hoisted(() => ({
+  runtimeRegistry: new Map<string, { runtime: unknown }>(),
+}));
+
+const { realRuntime, realServiceStartMock, realServiceStopMock, createRealServiceMock } =
+  vi.hoisted(() => {
+    const runtime = { isHealthy: vi.fn(() => true), probeAvailability: vi.fn(async () => {}) };
+    const start = vi.fn(async () => {
+      runtimeRegistry.set("acpx", { runtime });
+    });
+    const stop = vi.fn(async () => {
+      runtimeRegistry.delete("acpx");
+    });
+    return {
+      realRuntime: runtime,
+      realServiceStartMock: start,
+      realServiceStopMock: stop,
+      createRealServiceMock: vi.fn(() => ({ id: "real-acpx-runtime", start, stop })),
+    };
+  });
+
+vi.mock("openclaw/plugin-sdk/acp-runtime-backend", () => ({
+  getAcpRuntimeBackend: (id: string) => runtimeRegistry.get(id),
+  unregisterAcpRuntimeBackend: (id: string) => {
+    runtimeRegistry.delete(id);
+  },
+}));
+
+vi.mock("./src/service.js", () => ({
+  createAcpxRuntimeService: createRealServiceMock,
+}));
+
+import { createAcpxRuntimeService } from "./register.runtime.js";
+
+const previousSkipRuntime = process.env.OPENCLAW_SKIP_ACPX_RUNTIME;
+
+function restoreEnv(): void {
+  if (previousSkipRuntime === undefined) {
+    delete process.env.OPENCLAW_SKIP_ACPX_RUNTIME;
+  } else {
+    process.env.OPENCLAW_SKIP_ACPX_RUNTIME = previousSkipRuntime;
+  }
+}
+
+function createServiceContext() {
+  return {
+    workspaceDir: "/tmp/openclaw-acpx-register-test",
+    stateDir: "/tmp/openclaw-acpx-register-test/state",
+    config: {},
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+  };
+}
+
+describe("acpx register runtime service", () => {
+  afterEach(() => {
+    runtimeRegistry.clear();
+    realServiceStartMock.mockClear();
+    realServiceStopMock.mockClear();
+    createRealServiceMock.mockClear();
+    restoreEnv();
+  });
+
+  it("starts the real service by default while leaving probe policy to the inner service", async () => {
+    delete process.env.OPENCLAW_SKIP_ACPX_RUNTIME;
+    const ctx = createServiceContext();
+    const service = createAcpxRuntimeService({
+      pluginConfig: { timeoutSeconds: 10 },
+    });
+
+    await service.start(ctx as never);
+
+    expect(createRealServiceMock).toHaveBeenCalledWith({
+      pluginConfig: { timeoutSeconds: 10 },
+    });
+    expect(realServiceStartMock).toHaveBeenCalledWith(ctx);
+    expect(runtimeRegistry.get("acpx")?.runtime).toBe(realRuntime);
+
+    await service.stop?.(ctx as never);
+
+    expect(realServiceStopMock).toHaveBeenCalledWith(ctx);
+    expect(runtimeRegistry.get("acpx")).toBeUndefined();
+  });
+
+  it("keeps the explicit runtime skip env as the only outer startup skip", async () => {
+    process.env.OPENCLAW_SKIP_ACPX_RUNTIME = "1";
+    const ctx = createServiceContext();
+    const service = createAcpxRuntimeService();
+
+    await service.start(ctx as never);
+
+    expect(createRealServiceMock).not.toHaveBeenCalled();
+    expect(runtimeRegistry.get("acpx")).toBeUndefined();
+    expect(ctx.logger.info).toHaveBeenCalledWith(
+      "skipping embedded acpx runtime backend (OPENCLAW_SKIP_ACPX_RUNTIME=1)",
+    );
+  });
+});

--- a/extensions/acpx/register.runtime.ts
+++ b/extensions/acpx/register.runtime.ts
@@ -1,39 +1,23 @@
 import {
   getAcpRuntimeBackend,
-  registerAcpRuntimeBackend,
   unregisterAcpRuntimeBackend,
   type AcpRuntime,
-  type AcpRuntimeCapabilities,
-  type AcpRuntimeDoctorReport,
-  type AcpRuntimeEvent,
-  type AcpRuntimeStatus,
 } from "openclaw/plugin-sdk/acp-runtime-backend";
 import type { OpenClawPluginService, OpenClawPluginServiceContext } from "openclaw/plugin-sdk/core";
 
 const ACPX_BACKEND_ID = "acpx";
-const ENABLE_STARTUP_PROBE_ENV = "OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE";
-const SKIP_RUNTIME_PROBE_ENV = "OPENCLAW_SKIP_ACPX_RUNTIME_PROBE";
 
 type RealAcpxServiceModule = typeof import("./src/service.js");
 type CreateAcpxRuntimeServiceParams = NonNullable<
   Parameters<RealAcpxServiceModule["createAcpxRuntimeService"]>[0]
 >;
 
-type AcpxRuntimeLike = AcpRuntime & {
-  probeAvailability(): Promise<void>;
-  doctor?(): Promise<AcpRuntimeDoctorReport>;
-  isHealthy(): boolean;
-};
-type AcpRuntimeTurnInput = Parameters<AcpRuntime["runTurn"]>[0];
-type AcpRuntimeTurn = ReturnType<NonNullable<AcpRuntime["startTurn"]>>;
-type AcpRuntimeTurnResult = Awaited<AcpRuntimeTurn["result"]>;
-
 type DeferredServiceState = {
   ctx: OpenClawPluginServiceContext | null;
   params: CreateAcpxRuntimeServiceParams;
-  realRuntime: AcpxRuntimeLike | null;
+  realRuntime: AcpRuntime | null;
   realService: OpenClawPluginService | null;
-  startPromise: Promise<AcpxRuntimeLike> | null;
+  startPromise: Promise<AcpRuntime> | null;
 };
 
 let serviceModulePromise: Promise<RealAcpxServiceModule> | null = null;
@@ -43,162 +27,7 @@ function loadServiceModule(): Promise<RealAcpxServiceModule> {
   return serviceModulePromise;
 }
 
-function shouldRunStartupProbe(env: NodeJS.ProcessEnv = process.env): boolean {
-  return env[ENABLE_STARTUP_PROBE_ENV] !== "0" && env[SKIP_RUNTIME_PROBE_ENV] !== "1";
-}
-
-function createDeferredResult<T>() {
-  let resolve!: (value: T) => void;
-  let reject!: (error: unknown) => void;
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise;
-    reject = rejectPromise;
-  });
-  return { promise, resolve, reject };
-}
-
-class LegacyRunTurnEventQueue {
-  private readonly items: AcpRuntimeEvent[] = [];
-  private readonly waits: Array<{
-    resolve: (value: AcpRuntimeEvent | null) => void;
-    reject: (error: unknown) => void;
-  }> = [];
-  private closed = false;
-  private error: unknown;
-
-  push(item: AcpRuntimeEvent): void {
-    if (this.closed) {
-      return;
-    }
-    const waiter = this.waits.shift();
-    if (waiter) {
-      waiter.resolve(item);
-      return;
-    }
-    this.items.push(item);
-  }
-
-  clear(): void {
-    this.items.length = 0;
-  }
-
-  close(): void {
-    if (this.closed) {
-      return;
-    }
-    this.closed = true;
-    for (const waiter of this.waits.splice(0)) {
-      waiter.resolve(null);
-    }
-  }
-
-  fail(error: unknown): void {
-    if (this.closed) {
-      return;
-    }
-    this.error = error;
-    this.closed = true;
-    for (const waiter of this.waits.splice(0)) {
-      waiter.reject(error);
-    }
-  }
-
-  private async next(): Promise<AcpRuntimeEvent | null> {
-    const item = this.items.shift();
-    if (item) {
-      return item;
-    }
-    if (this.error) {
-      throw this.error;
-    }
-    if (this.closed) {
-      return null;
-    }
-    return await new Promise<AcpRuntimeEvent | null>((resolve, reject) => {
-      this.waits.push({ resolve, reject });
-    });
-  }
-
-  async *iterate(): AsyncIterable<AcpRuntimeEvent> {
-    for (;;) {
-      const item = await this.next();
-      if (!item) {
-        return;
-      }
-      yield item;
-    }
-  }
-}
-
-function legacyRunTurnAsStartTurn(runtime: AcpRuntime, input: AcpRuntimeTurnInput): AcpRuntimeTurn {
-  const result = createDeferredResult<AcpRuntimeTurnResult>();
-  result.promise.catch(() => {});
-  const queue = new LegacyRunTurnEventQueue();
-  let resultSettled = false;
-  const settleResult = (next: AcpRuntimeTurnResult) => {
-    if (resultSettled) {
-      return;
-    }
-    resultSettled = true;
-    result.resolve(next);
-  };
-  void (async () => {
-    try {
-      for await (const event of runtime.runTurn(input)) {
-        if (event.type === "done") {
-          settleResult({
-            status: "completed",
-            ...(event.stopReason ? { stopReason: event.stopReason } : {}),
-          });
-          continue;
-        }
-        if (event.type === "error") {
-          settleResult({
-            status: "failed",
-            error: {
-              message: event.message,
-              ...(event.code ? { code: event.code } : {}),
-              ...(event.detailCode ? { detailCode: event.detailCode } : {}),
-              ...(event.retryable === undefined ? {} : { retryable: event.retryable }),
-            },
-          });
-          continue;
-        }
-        queue.push(event);
-      }
-      settleResult({
-        status: "failed",
-        error: {
-          code: "ACP_TURN_FAILED",
-          message: "ACP turn ended without a terminal done event.",
-        },
-      });
-    } catch (error) {
-      result.reject(error);
-      queue.fail(error);
-      return;
-    }
-    queue.close();
-  })();
-  return {
-    requestId: input.requestId,
-    events: queue.iterate(),
-    result: result.promise,
-    async cancel(inputArgs) {
-      await runtime.cancel({ handle: input.handle, reason: inputArgs?.reason });
-    },
-    async closeStream() {
-      queue.clear();
-      queue.close();
-    },
-  };
-}
-
-function startRuntimeTurn(runtime: AcpRuntime, input: AcpRuntimeTurnInput): AcpRuntimeTurn {
-  return runtime.startTurn?.(input) ?? legacyRunTurnAsStartTurn(runtime, input);
-}
-
-async function startRealService(state: DeferredServiceState): Promise<AcpxRuntimeLike> {
+async function startRealService(state: DeferredServiceState): Promise<AcpRuntime> {
   if (state.realRuntime) {
     return state.realRuntime;
   }
@@ -214,74 +43,10 @@ async function startRealService(state: DeferredServiceState): Promise<AcpxRuntim
     if (!backend?.runtime) {
       throw new Error("ACPX runtime service did not register an ACP backend");
     }
-    state.realRuntime = backend.runtime as AcpxRuntimeLike;
+    state.realRuntime = backend.runtime;
     return state.realRuntime;
   })();
   return await state.startPromise;
-}
-
-function createDeferredRuntime(state: DeferredServiceState): AcpxRuntimeLike {
-  return {
-    async ensureSession(input) {
-      return await (await startRealService(state)).ensureSession(input);
-    },
-    startTurn(input) {
-      const turnPromise = startRealService(state).then((runtime) =>
-        startRuntimeTurn(runtime, input),
-      );
-      return {
-        requestId: input.requestId,
-        events: {
-          async *[Symbol.asyncIterator]() {
-            yield* (await turnPromise).events;
-          },
-        },
-        result: turnPromise.then((turn) => turn.result),
-        cancel(inputArgs) {
-          return turnPromise.then((turn) => turn.cancel(inputArgs));
-        },
-        closeStream(inputArgs) {
-          return turnPromise.then((turn) => turn.closeStream(inputArgs));
-        },
-      };
-    },
-    async *runTurn(input) {
-      yield* (await startRealService(state)).runTurn(input);
-    },
-    async getCapabilities(input): Promise<AcpRuntimeCapabilities> {
-      const runtime = await startRealService(state);
-      return (await runtime.getCapabilities?.(input)) ?? { controls: [] };
-    },
-    async getStatus(input): Promise<AcpRuntimeStatus> {
-      const runtime = await startRealService(state);
-      return (await runtime.getStatus?.(input)) ?? {};
-    },
-    async setMode(input) {
-      await (await startRealService(state)).setMode?.(input);
-    },
-    async setConfigOption(input) {
-      await (await startRealService(state)).setConfigOption?.(input);
-    },
-    async doctor(): Promise<AcpRuntimeDoctorReport> {
-      const runtime = await startRealService(state);
-      return (await runtime.doctor?.()) ?? { ok: true, message: "ok" };
-    },
-    async prepareFreshSession(input) {
-      await (await startRealService(state)).prepareFreshSession?.(input);
-    },
-    async cancel(input) {
-      await (await startRealService(state)).cancel(input);
-    },
-    async close(input) {
-      await (await startRealService(state)).close(input);
-    },
-    async probeAvailability() {
-      await (await startRealService(state)).probeAvailability();
-    },
-    isHealthy() {
-      return state.realRuntime?.isHealthy() ?? false;
-    },
-  };
 }
 
 export function createAcpxRuntimeService(
@@ -304,16 +69,7 @@ export function createAcpxRuntimeService(
       }
 
       state.ctx = ctx;
-      if (shouldRunStartupProbe()) {
-        await startRealService(state);
-        return;
-      }
-
-      registerAcpRuntimeBackend({
-        id: ACPX_BACKEND_ID,
-        runtime: createDeferredRuntime(state),
-      });
-      ctx.logger.info("embedded acpx runtime backend registered lazily");
+      await startRealService(state);
     },
     async stop(ctx) {
       if (state.realService) {

--- a/extensions/acpx/src/service.test.ts
+++ b/extensions/acpx/src/service.test.ts
@@ -191,8 +191,9 @@ describe("createAcpxRuntimeService", () => {
     expect(getAcpRuntimeBackend("acpx")).toBeUndefined();
   });
 
-  it("skips the startup probe and defers acpx backend health reporting when explicitly opted out", async () => {
+  it("skips the startup probe and does not advertise backend health when explicitly disabled", async () => {
     process.env.OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE = "0";
+    delete process.env.OPENCLAW_SKIP_ACPX_RUNTIME_PROBE;
     const workspaceDir = await makeTempDir();
     const stateDir = path.join(workspaceDir, "custom-state");
     const ctx = createServiceContext(workspaceDir);
@@ -201,7 +202,7 @@ describe("createAcpxRuntimeService", () => {
     });
     const runtime = createMockRuntime({
       doctor: async () => ({ ok: true, message: "ok" }),
-      isHealthy: () => true,
+      isHealthy: () => false,
       probeAvailability,
     });
     const service = createAcpxRuntimeService({
@@ -218,7 +219,8 @@ describe("createAcpxRuntimeService", () => {
     await service.stop?.(ctx);
   });
 
-  it("waits for the embedded runtime startup probe before resolving", async () => {
+  it("waits for the embedded runtime startup probe before resolving by default", async () => {
+    delete process.env.OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE;
     const workspaceDir = await makeTempDir();
     const ctx = createServiceContext(workspaceDir);
     let releaseProbe!: () => void;
@@ -376,8 +378,9 @@ describe("createAcpxRuntimeService", () => {
     await service.stop?.(ctx);
   });
 
-  it("registers the default backend lazily without importing ACPX runtime when startup probing is opted out", async () => {
+  it("registers the backend lazily without importing ACPX runtime when startup probe is disabled", async () => {
     process.env.OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE = "0";
+    delete process.env.OPENCLAW_SKIP_ACPX_RUNTIME_PROBE;
     const workspaceDir = await makeTempDir();
     const ctx = createServiceContext(workspaceDir);
     const service = createAcpxRuntimeService();
@@ -392,6 +395,7 @@ describe("createAcpxRuntimeService", () => {
       ensureSession(input: { agent: string; mode: string; sessionKey: string }): Promise<unknown>;
     };
     expect(typeof backendRuntime.ensureSession).toBe("function");
+    expect(backend.healthy).toBeUndefined();
     expect(acpxRuntimeConstructorMock).not.toHaveBeenCalled();
 
     await backendRuntime.ensureSession({
@@ -401,6 +405,7 @@ describe("createAcpxRuntimeService", () => {
     });
 
     expect(acpxRuntimeConstructorMock).toHaveBeenCalledOnce();
+    expect(backend.healthy).toBeUndefined();
 
     await service.stop?.(ctx);
   });
@@ -513,7 +518,8 @@ describe("createAcpxRuntimeService", () => {
     await service.stop?.(ctx);
   });
 
-  it("runs the embedded runtime probe at startup by default and reports health", async () => {
+  it("runs the embedded runtime probe at startup when explicitly enabled and reports health", async () => {
+    process.env.OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE = "1";
     const workspaceDir = await makeTempDir();
     const ctx = createServiceContext(workspaceDir);
     const probeAvailability = vi.fn(async () => {});
@@ -533,7 +539,8 @@ describe("createAcpxRuntimeService", () => {
     await service.stop?.(ctx);
   });
 
-  it("bounds the embedded runtime startup probe wait with the configured timeout", async () => {
+  it("bounds the opt-in embedded runtime startup probe wait with the configured timeout", async () => {
+    process.env.OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE = "1";
     const workspaceDir = await makeTempDir();
     const ctx = createServiceContext(workspaceDir);
     const probeAvailability = vi.fn(() => new Promise<void>(() => {}));
@@ -662,7 +669,8 @@ describe("createAcpxRuntimeService", () => {
     await service.stop?.(ctx);
   });
 
-  it("can skip the embedded runtime probe via env", async () => {
+  it("lets the skip env override the opt-in embedded runtime startup probe without advertising health", async () => {
+    process.env.OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE = "1";
     process.env.OPENCLAW_SKIP_ACPX_RUNTIME_PROBE = "1";
     const workspaceDir = await makeTempDir();
     const ctx = createServiceContext(workspaceDir);
@@ -686,6 +694,7 @@ describe("createAcpxRuntimeService", () => {
   });
 
   it("formats non-string doctor details without losing object payloads", async () => {
+    process.env.OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE = "1";
     const workspaceDir = await makeTempDir();
     const ctx = createServiceContext(workspaceDir);
     const runtime = createMockRuntime({


### PR DESCRIPTION
## Summary

- Problem: The ACPX wrapper and inner runtime service both carried startup/probe policy, which made it easy for the outer wrapper to drift from the shipped readiness contract.
- Why it matters: #80187 fixed #79596 by making Gateway readiness wait for the ACPX startup probe by default; this PR must preserve that contract while removing the duplicated outer deferred runtime shim.
- What changed: The outer ACPX wrapper now starts the real inner service directly unless `OPENCLAW_SKIP_ACPX_RUNTIME=1`; the inner service remains the single owner of startup probe policy, with probe-before-ready still enabled by default and disabled only via `OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE=0` or `OPENCLAW_SKIP_ACPX_RUNTIME_PROBE=1`.
- What did NOT change (scope boundary): This does not decouple Discord, heartbeat, or cron startup from ACPX; that broader dependency-aware sidecar startup work remains tracked by #79625.
- AI-assisted: Yes. I reviewed the generated diff and ran the verification below before updating this PR.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A - no linked issue.
- Related #79596, #80187, #79625.
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: ACPX still runs the embedded runtime startup probe before Gateway `ready` by default after the wrapper cleanup, and the outer wrapper no longer registers its own lazy ACPX facade.
- Real environment tested: Local macOS OpenClaw source checkout at commit `2b9e359`, Node `24.14.0`, isolated temporary `OPENCLAW_HOME`, `OPENCLAW_STATE_DIR`, and `OPENCLAW_CONFIG_PATH`, real `node dist/index.js gateway run` process on loopback port `54989`, with `OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE`, `OPENCLAW_SKIP_ACPX_RUNTIME_PROBE`, and `OPENCLAW_SKIP_ACPX_RUNTIME` unset.
- Exact steps or command run after this patch:
  - `pnpm build`
  - `node dist/index.js --version`
  - Start a real local Gateway with isolated state/config: `OPENCLAW_HOME=/tmp/openclaw-acpx-contract-proof-rebased2-7FYrEa/home OPENCLAW_STATE_DIR=/tmp/openclaw-acpx-contract-proof-rebased2-7FYrEa/state OPENCLAW_CONFIG_PATH=/tmp/openclaw-acpx-contract-proof-rebased2-7FYrEa/state/openclaw.json OPENCLAW_SKIP_CRON=1 OPENCLAW_SKIP_CHANNELS=1 node dist/index.js gateway run --auth none --bind loopback --port 54989 --verbose --allow-unconfigured`
  - Probe the live Gateway: `node dist/index.js gateway status --json --url ws://127.0.0.1:54989 --require-rpc --timeout 2000 --token proof-token`
  - Inspect the runtime log for ACPX registration, startup-probe timeout, Gateway readiness, and lazy-registration lines.
- Evidence after fix: Copied terminal output from the real local Gateway run:
  ```text
  $ node dist/index.js --version
  OpenClaw 2026.5.17 (2b9e359)

  $ node dist/index.js gateway status --json --url ws://127.0.0.1:54989 --require-rpc --timeout 2000 --token proof-token
  {
    "rpc": {
      "ok": true,
      "kind": "read",
      "capability": "read_only",
      "url": "ws://127.0.0.1:54989"
    },
    "gateway": {
      "bindMode": "loopback",
      "bindHost": "127.0.0.1",
      "probeUrl": "ws://127.0.0.1:54989"
    }
  }

  $ grep -E "loading acpx|embedded acpx runtime backend|gateway.*ready|startup probe" gateway.log
  2026-05-17T16:25:10.501+08:00 [plugins] loading acpx from /Users/x/git/openclaw--acpx-startup-probe-deferred/dist/extensions/acpx/index.js
  2026-05-17T16:25:10.596+08:00 [plugins] embedded acpx runtime backend registered (cwd: /tmp/openclaw-acpx-contract-proof-rebased2-7FYrEa/workspace)
  2026-05-17T16:25:10.624+08:00 [plugins] embedded acpx runtime setup failed: embedded acpx runtime backend startup probe timed out after 0.001s
  2026-05-17T16:25:10.625+08:00 [gateway] ready

  $ grep -c "embedded acpx runtime setup failed: embedded acpx runtime backend startup probe timed out" gateway.log
  1
  $ grep -c "embedded acpx runtime backend registered lazily" gateway.log
  0
  $ grep -c "embedded acpx runtime backend registered (cwd:" gateway.log
  1
  $ grep -c "[gateway] ready" gateway.log
  1
  ```
- Observed result after fix: The real Gateway loaded the rebased ACPX plugin, registered the embedded ACPX runtime backend, ran the default startup probe, logged the bounded startup-probe timeout, reached `[gateway] ready`, and answered a live RPC status probe. The old outer lazy registration path did not run (`embedded acpx runtime backend registered lazily` count was `0`).
- What was not tested: I did not run a live ACP agent session or solve #79625's broader sidecar-startup decoupling. This proof is scoped to the ACPX startup readiness contract and wrapper cleanup.
- Before evidence: The linked regression source is #80187 / #79596: current `main` intentionally defaults `OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE` to probe-before-ready. This PR now preserves that default and only keeps lazy/no-probe behavior behind explicit disable env.

## Root Cause (if applicable)

- Root cause: Startup probe policy existed in two layers: the outer `register.runtime.ts` wrapper and the inner ACPX runtime service. The initial PR revision changed the inner default to opt-in, which would have regressed #80187's readiness contract.
- Missing detection / guardrail: The first revision's tests asserted the wrong default, so the review correctly caught the readiness regression.
- Contributing context (if known): #79625 is a real latency issue, but it is orthogonal to whether ACPX readiness should be probed before Gateway `ready`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/acpx/src/service.test.ts` and `extensions/acpx/register.runtime.test.ts`
- Scenario the test should lock in: Default startup waits for the embedded runtime startup probe; `OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE=0` and `OPENCLAW_SKIP_ACPX_RUNTIME_PROBE=1` are the explicit no-probe paths; the outer wrapper delegates policy to the inner service.
- Why this is the smallest reliable guardrail: These tests exercise the ACPX service boundary that owns startup probe policy, plus the wrapper boundary that previously duplicated it.
- Existing test that already covers this (if any): Existing tests covered parts of startup probing, but this PR adds wrapper coverage and updates the default/no-probe assertions to match the shipped contract.
- If no new test is added, why not: N/A - updated and new tests are included.

## User-visible / Behavior Changes

The default user-visible readiness contract is unchanged from current `main`: ACPX startup still runs the embedded runtime startup probe before Gateway `ready`. Operators can still set `OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE=0` or `OPENCLAW_SKIP_ACPX_RUNTIME_PROBE=1` when they intentionally want startup probe disabled.

## Diagram (if applicable)

```text
Before this PR:
[ACPX outer wrapper] -> [outer probe policy / optional lazy facade]
                    -> [inner ACPX service with its own probe policy]

After this PR:
[ACPX outer wrapper] -> [inner ACPX service owns startup probe policy]
                    -> [Gateway ready waits for default startup probe]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local checkout
- Runtime/container: Node 24.14.0, local source checkout
- Model/provider: N/A
- Integration/channel (if any): ACPX ACP runtime plugin
- Relevant config (redacted): Isolated temporary OpenClaw config with ACPX enabled, `timeoutSeconds=0.001`, `probeAgent=codex`, and a local `node -e 'setInterval(() => {}, 1000)'` ACPX probe command. `OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE` and `OPENCLAW_SKIP_ACPX_RUNTIME_PROBE` were unset.

### Steps

1. Build the local dist.
2. Start a real local Gateway using `node dist/index.js gateway run` with isolated state and config.
3. Probe the live Gateway with `node dist/index.js gateway status --json --require-rpc`.
4. Inspect Gateway logs for ACPX registration, startup-probe timeout, lazy-registration absence, and Gateway ready.
5. Run focused ACPX service/register tests and docs checks.

### Expected

- Default startup runs the ACPX startup probe.
- The startup probe timeout is bounded by ACPX config.
- Gateway reaches ready after ACPX reports degraded/timeout, not through the outer lazy facade.
- Focused ACPX service/register tests pass.
- Docs checks pass.

### Actual

- Gateway log contained one `embedded acpx runtime backend registered` line, one bounded `startup probe timed out after 0.001s` line, zero `embedded acpx runtime backend registered lazily` lines, and then `[gateway] ready`.
- Live status probe returned `rpc.ok: true` for `ws://127.0.0.1:54989`.
- Focused ACPX service/register tests passed: 21 tests.
- `pnpm build`, docs formatting, docs MDX, `git diff --check`, and changed-lane discovery against `upstream/main` passed.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Default probe-before-ready behavior, explicit no-probe env behavior, outer wrapper delegation to the inner service, runtime skip env, docs wording, changed-lane scope.
- Edge cases checked: `OPENCLAW_SKIP_ACPX_RUNTIME=1`, `OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE=0`, `OPENCLAW_SKIP_ACPX_RUNTIME_PROBE=1`, startup probe timeout/degraded behavior, and absence of the old outer lazy facade log line in the live Gateway proof.
- What you did **not** verify: I did not run a live ACP agent session or implement sidecar decoupling for #79625.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

Addressed the P2 review finding by preserving the default ACPX readiness probe contract from #80187 and updating the PR proof/body accordingly.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A. Existing `OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE=0`, `OPENCLAW_SKIP_ACPX_RUNTIME_PROBE=1`, and `OPENCLAW_SKIP_ACPX_RUNTIME=1` behavior remains available.

## Risks and Mitigations

- Risk: This does not solve the broader channel/heartbeat/cron sidecar coupling in #79625.
  - Mitigation: The PR explicitly preserves the readiness contract and leaves dependency-aware sidecar decoupling to the dedicated issue.


