### PR TITLE
fix(tasks): recover childless Codex native subagent tasks

### DIFF
--- a/extensions/codex/src/app-server/native-subagent-task-mirror.ts
+++ b/extensions/codex/src/app-server/native-subagent-task-mirror.ts
@@ -1,4 +1,7 @@
 import {
+  CODEX_NATIVE_SUBAGENT_RUN_ID_PREFIX,
+  CODEX_NATIVE_SUBAGENT_RUNTIME,
+  CODEX_NATIVE_SUBAGENT_TASK_KIND,
   createRunningTaskRun,
   finalizeTaskRunByRunId,
   recordTaskRunProgressByRunId,
@@ -15,9 +18,6 @@ import type {
   JsonValue,
 } from "./protocol.js";
 import { isJsonObject } from "./protocol.js";
-
-const CODEX_NATIVE_SUBAGENT_RUNTIME = "subagent";
-const CODEX_NATIVE_SUBAGENT_TASK_KIND = "codex-native";
 
 export type TaskLifecycleRuntime = {
   createRunningTaskRun: typeof createRunningTaskRun;
@@ -291,7 +291,7 @@ export class CodexNativeSubagentTaskMirror {
 }
 
 export function codexNativeSubagentRunId(threadId: string): string {
-  return `codex-thread:${threadId.trim()}`;
+  return `${CODEX_NATIVE_SUBAGENT_RUN_ID_PREFIX}${threadId.trim()}`;
 }
 
 export function readSubagentThreadSpawnSource(

--- a/src/plugin-sdk/codex-native-task-runtime.ts
+++ b/src/plugin-sdk/codex-native-task-runtime.ts
@@ -4,6 +4,13 @@
 // plugin SDK.
 
 export {
+  CODEX_NATIVE_SUBAGENT_RUN_ID_PREFIX,
+  CODEX_NATIVE_SUBAGENT_RUNTIME,
+  CODEX_NATIVE_SUBAGENT_STALE_ERROR,
+  CODEX_NATIVE_SUBAGENT_TASK_KIND,
+} from "../tasks/codex-native-subagent-task.js";
+
+export {
   createRunningTaskRun,
   finalizeTaskRunByRunId,
   recordTaskRunProgressByRunId,

--- a/src/tasks/codex-native-subagent-task.ts
+++ b/src/tasks/codex-native-subagent-task.ts
@@ -1,11 +1,15 @@
 import type { TaskRecord } from "./task-registry.types.js";
 
+export const CODEX_NATIVE_SUBAGENT_RUNTIME = "subagent";
 export const CODEX_NATIVE_SUBAGENT_TASK_KIND = "codex-native";
 export const CODEX_NATIVE_SUBAGENT_RUN_ID_PREFIX = "codex-thread:";
 export const CODEX_NATIVE_SUBAGENT_STALE_ERROR = "Codex native subagent stopped reporting progress";
 
 export function isChildlessCodexNativeSubagentTask(task: TaskRecord): boolean {
-  if (task.runtime !== "subagent" || task.taskKind !== CODEX_NATIVE_SUBAGENT_TASK_KIND) {
+  if (
+    task.runtime !== CODEX_NATIVE_SUBAGENT_RUNTIME ||
+    task.taskKind !== CODEX_NATIVE_SUBAGENT_TASK_KIND
+  ) {
     return false;
   }
   if (task.childSessionKey?.trim()) {

--- a/src/tasks/codex-native-subagent-task.ts
+++ b/src/tasks/codex-native-subagent-task.ts
@@ -1,0 +1,17 @@
+import type { TaskRecord } from "./task-registry.types.js";
+
+export const CODEX_NATIVE_SUBAGENT_TASK_KIND = "codex-native";
+export const CODEX_NATIVE_SUBAGENT_RUN_ID_PREFIX = "codex-thread:";
+export const CODEX_NATIVE_SUBAGENT_STALE_ERROR = "Codex native subagent stopped reporting progress";
+
+export function isChildlessCodexNativeSubagentTask(task: TaskRecord): boolean {
+  if (task.runtime !== "subagent" || task.taskKind !== CODEX_NATIVE_SUBAGENT_TASK_KIND) {
+    return false;
+  }
+  if (task.childSessionKey?.trim()) {
+    return false;
+  }
+  return [task.sourceId, task.runId].some((candidate) =>
+    candidate?.trim().startsWith(CODEX_NATIVE_SUBAGENT_RUN_ID_PREFIX),
+  );
+}

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -33,6 +33,10 @@ import {
   normalizeOptionalString,
 } from "../shared/string-coerce.js";
 import {
+  CODEX_NATIVE_SUBAGENT_STALE_ERROR,
+  isChildlessCodexNativeSubagentTask,
+} from "./codex-native-subagent-task.js";
+import {
   getDetachedTaskLifecycleRuntime,
   tryRecoverTaskBeforeMarkLost,
 } from "./detached-task-runtime.js";
@@ -59,6 +63,7 @@ import type { TaskRecord, TaskRegistrySummary, TaskStatus } from "./task-registr
 
 const log = createSubsystemLogger("tasks/task-registry-maintenance");
 const TASK_RECONCILE_GRACE_MS = 5 * 60_000;
+const CHILDLESS_CODEX_NATIVE_RECONCILE_GRACE_MS = 30 * 60_000;
 const TASK_RETENTION_MS = 7 * 24 * 60 * 60_000;
 const TASK_SWEEP_INTERVAL_MS = 60_000;
 
@@ -290,7 +295,10 @@ function isTerminalTask(task: TaskRecord): boolean {
 
 function hasLostGraceExpired(task: TaskRecord, now: number): boolean {
   const referenceAt = task.lastEventAt ?? task.startedAt ?? task.createdAt;
-  return now - referenceAt >= TASK_RECONCILE_GRACE_MS;
+  const graceMs = isChildlessCodexNativeSubagentTask(task)
+    ? CHILDLESS_CODEX_NATIVE_RECONCILE_GRACE_MS
+    : TASK_RECONCILE_GRACE_MS;
+  return now - referenceAt >= graceMs;
 }
 
 function parseCronExecutionId(task: TaskRecord): CronExecutionId | undefined {
@@ -462,7 +470,7 @@ function hasBackingSession(task: TaskRecord, context?: BackingSessionLookupConte
 
   const childSessionKey = task.childSessionKey?.trim();
   if (!childSessionKey) {
-    return true;
+    return !isChildlessCodexNativeSubagentTask(task);
   }
   if (task.runtime === "acp") {
     const acpEntry = taskRegistryMaintenanceRuntime.readAcpSessionEntry({
@@ -491,6 +499,9 @@ function hasBackingSession(task: TaskRecord, context?: BackingSessionLookupConte
 }
 
 function resolveTaskLostError(task: TaskRecord, context?: BackingSessionLookupContext): string {
+  if (isChildlessCodexNativeSubagentTask(task)) {
+    return CODEX_NATIVE_SUBAGENT_STALE_ERROR;
+  }
   if (task.runtime === "subagent") {
     const entry = findTaskSessionEntry(task, context);
     if (entry && isSubagentRecoveryWedgedEntry(entry)) {

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -1957,6 +1957,42 @@ describe("task-registry", () => {
     });
   });
 
+  it("does not mark unrelated childless subagent tasks lost", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+      const now = Date.now();
+
+      const task = createTaskRecord({
+        runtime: "subagent",
+        taskKind: "codex-native",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        sourceId: "other-runtime:child-thread",
+        runId: "other-runtime:child-thread",
+        task: "Non-Codex childless row",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        notifyPolicy: "silent",
+      });
+      setTaskTimingById({
+        taskId: task.taskId,
+        lastEventAt: now - 31 * 60_000,
+      });
+
+      expect(await runTaskRegistryMaintenance()).toEqual({
+        reconciled: 0,
+        recovered: 0,
+        cleanupStamped: 0,
+        pruned: 0,
+      });
+      expectRecordFields(requireTaskById(task.taskId), {
+        status: "running",
+        lastEventAt: now - 31 * 60_000,
+      });
+    });
+  });
+
   it("closes terminal parent-owned one-shot ACP sessions during maintenance", async () => {
     await withTaskRegistryTempDir(async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;
@@ -3236,6 +3272,38 @@ describe("task-registry", () => {
         lastEventAt: expect.any(Number),
         cleanupAfter: expect.any(Number),
         error: "Cancelled by operator.",
+      });
+      expect(hoisted.killSubagentRunAdminMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("does not cancel unrelated childless subagent tasks", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+      const task = createTaskRecord({
+        runtime: "subagent",
+        taskKind: "codex-native",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        sourceId: "other-runtime:child-thread",
+        runId: "other-runtime:child-thread",
+        task: "Non-Codex childless row",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        notifyPolicy: "silent",
+      });
+
+      const result = await cancelTaskById({
+        cfg: {} as never,
+        taskId: task.taskId,
+      });
+
+      expect(result).toEqual({
+        found: true,
+        cancelled: false,
+        reason: "Task has no cancellable child session.",
+        task,
       });
       expect(hoisted.killSubagentRunAdminMock).not.toHaveBeenCalled();
     });

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -1885,7 +1885,7 @@ describe("task-registry", () => {
     });
   });
 
-  it("does not mark codex-native subagent tasks lost when they have no OpenClaw child session", async () => {
+  it("keeps fresh childless codex-native subagent tasks live", async () => {
     await withTaskRegistryTempDir(async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;
       resetTaskRegistryForTests();
@@ -1914,10 +1914,45 @@ describe("task-registry", () => {
         cleanupStamped: 0,
         pruned: 0,
       });
-      expect(getTaskById(task.taskId)).toEqual({
-        ...task,
-        createdAt: now - 10 * 60_000,
+      expectRecordFields(requireTaskById(task.taskId), {
+        status: "running",
         lastEventAt: now - 10 * 60_000,
+      });
+    });
+  });
+
+  it("marks stale childless codex-native subagent tasks lost", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+      const now = Date.now();
+
+      const task = createTaskRecord({
+        runtime: "subagent",
+        taskKind: "codex-native",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        sourceId: "codex-thread:child-thread",
+        runId: "codex-thread:child-thread",
+        task: "Codex native child",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        notifyPolicy: "silent",
+      });
+      setTaskTimingById({
+        taskId: task.taskId,
+        lastEventAt: now - 31 * 60_000,
+      });
+
+      expect(await runTaskRegistryMaintenance()).toEqual({
+        reconciled: 1,
+        recovered: 0,
+        cleanupStamped: 0,
+        pruned: 0,
+      });
+      expectRecordFields(requireTaskById(task.taskId), {
+        status: "lost",
+        error: "Codex native subagent stopped reporting progress",
       });
     });
   });
@@ -3168,7 +3203,7 @@ describe("task-registry", () => {
     });
   });
 
-  it("does not route codex-native task cancellation through OpenClaw subagent sessions", async () => {
+  it("cancels childless codex-native tasks without routing through OpenClaw subagent sessions", async () => {
     await withTaskRegistryTempDir(async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;
       resetTaskRegistryForTests();
@@ -3190,11 +3225,17 @@ describe("task-registry", () => {
         taskId: task.taskId,
       });
 
-      expect(result).toEqual({
+      expectRecordFields(result, {
         found: true,
-        cancelled: false,
-        reason: "Task has no cancellable child session.",
-        task,
+        cancelled: true,
+      });
+      expectRecordFields(result.task, {
+        taskId: task.taskId,
+        status: "cancelled",
+        endedAt: expect.any(Number),
+        lastEventAt: expect.any(Number),
+        cleanupAfter: expect.any(Number),
+        error: "Cancelled by operator.",
       });
       expect(hoisted.killSubagentRunAdminMock).not.toHaveBeenCalled();
     });

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -11,6 +11,7 @@ import { parseAgentSessionKey } from "../routing/session-key.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.shared.js";
 import { isDeliverableMessageChannel } from "../utils/message-channel.js";
+import { isChildlessCodexNativeSubagentTask } from "./codex-native-subagent-task.js";
 import {
   formatTaskBlockedFollowupMessage,
   formatTaskStateChangeMessage,
@@ -1898,14 +1899,20 @@ export async function cancelTaskById(params: {
   try {
     if (task.runtime !== "cli") {
       if (!childSessionKey) {
-        return {
-          found: true,
-          cancelled: false,
-          reason: "Task has no cancellable child session.",
-          task: cloneTaskRecord(task),
-        };
+        if (!isChildlessCodexNativeSubagentTask(task)) {
+          return {
+            found: true,
+            cancelled: false,
+            reason: "Task has no cancellable child session.",
+            task: cloneTaskRecord(task),
+          };
+        }
       }
-      if (task.runtime === "acp") {
+      if (!childSessionKey) {
+        // Codex native subagents are mirrored from the Codex app server and do
+        // not have OpenClaw child sessions to terminate. Cancellation clears
+        // the stale task-registry record only.
+      } else if (task.runtime === "acp") {
         const { getAcpSessionManager } = await loadTaskRegistryControlRuntime();
         await getAcpSessionManager().cancelSession({
           cfg: params.cfg,


### PR DESCRIPTION
## Summary

- Treat childless Codex-native subagent task mirrors as recoverable registry-only records.
- Keep fresh childless `codex-native` task mirrors alive for a longer 30 minute grace period, then mark stale records `lost`.
- Allow operator cancellation of childless Codex-native task mirrors by clearing those registry-only mirrors without trying to kill a missing OpenClaw child session.

## Root Cause

PR #79512 intentionally mirrors Codex app-server native subagents into the Task Registry with `runtime=subagent`, `taskKind=codex-native`, and `runId` / `sourceId` set to `codex-thread:<threadId>`, while deliberately leaving `childSessionKey` unset because these are not OpenClaw-managed child sessions.

The existing task maintenance and cancellation code treated childless non-CLI tasks as still-backed forever and not cancellable. If the Codex app-server never emitted a terminal lifecycle event, the mirrored task could remain `running` indefinitely and `openclaw tasks cancel` returned `Task has no cancellable child session.`

## Change

- Adds a small shared helper for detecting childless Codex-native subagent task mirrors.
- Makes maintenance consider those mirrors missing-backed after 30 minutes without progress and mark them `lost` with a specific error.
- Keeps ordinary task reconciliation behavior unchanged for ACP, normal subagent, CLI, and cron paths.
- Makes `tasks cancel` mark childless Codex-native mirrors `cancelled` in the registry without routing through OpenClaw subagent teardown.

## Real behavior proof

Behavior addressed: a childless Codex-native subagent task mirror could remain `running` with no OpenClaw child session to cancel. After this patch, the live gateway kept a fresh mirror alive during the grace period, then reconciled it to `lost` after the 30 minute threshold.

Real environment tested: live local OpenClaw gateway, rebuilt from this PR patch and restarted. Private paths, chat/user ids, session keys, task prompt text, and full Codex thread ids are redacted below.

Exact steps or commands run after this patch:

1. Rebuilt the patched checkout and restarted the live gateway.
2. Ran task maintenance and audit against the live task registry.
3. Rechecked the same childless Codex-native mirror before and after the 30 minute grace period.
4. Checked gateway connectivity after reconciliation.

Evidence after fix, redacted from live `openclaw tasks audit --json` / `openclaw tasks list --runtime subagent --json` output:

```json
{
  "fresh_grace_check": {
    "taskId": "b5ed...99",
    "runtime": "subagent",
    "taskKind": "codex-native",
    "sourceId": "codex-thread:019e3374-...-136d",
    "runId": "codex-thread:019e3374-...-136d",
    "childSessionKey": null,
    "status": "running",
    "ageAtCheck": "about 22 minutes",
    "result": "kept running because it was still inside the 30 minute grace period"
  },
  "after_grace_check": {
    "taskId": "b5ed...99",
    "runtime": "subagent",
    "taskKind": "codex-native",
    "sourceId": "codex-thread:019e3374-...-136d",
    "runId": "codex-thread:019e3374-...-136d",
    "childSessionKey": null,
    "createdAt": "2026-05-17 10:02:25 JST",
    "endedAt": "2026-05-17 10:33:22 JST",
    "status": "lost",
    "error": "Codex native subagent stopped reporting progress",
    "progressSummary": "Codex native subagent is initializing."
  },
  "audit_after_reconciliation": {
    "byCode": {
      "stale_running": 0,
      "lost": 5,
      "delivery_failed": 0
    }
  },
  "gateway_after_reconciliation": {
    "runtime": "running",
    "connectivityProbe": "ok",
    "capability": "admin-capable"
  }
}
```

Observed result after fix: the childless Codex-native mirror no longer remained `running` indefinitely. It stayed live while fresh, then changed to terminal `lost` with the expected Codex-native stale error after the grace period. The task audit had `stale_running: 0` afterward and the gateway remained healthy.

What was not tested live: the operator `tasks cancel` path against a fresh live childless Codex-native mirror. That path is covered by the focused regression test below.

## Validation

- `node scripts/run-vitest.mjs src/tasks/task-registry.test.ts src/tasks/task-registry.maintenance.issue-60299.test.ts`
  - 2 files passed, 83 tests passed
- `./node_modules/.bin/oxfmt --check --threads=1 src/tasks/codex-native-subagent-task.ts src/tasks/task-registry.maintenance.ts src/tasks/task-registry.ts src/tasks/task-registry.test.ts`
- `git diff --check`

## Notes

`node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json ...` could not complete in the temporary worktree because it reused an older local `node_modules` from another checkout and failed before linting these files on unrelated `@openclaw/proxyline` type mismatches.