### PR TITLE
fix(signal): preserve group IDs in session keys

### DIFF
--- a/src/channels/session.ts
+++ b/src/channels/session.ts
@@ -1,5 +1,6 @@
 import type { MsgContext } from "../auto-reply/templating.js";
 import type { GroupKeyResolution } from "../config/sessions/types.js";
+import { normalizeSessionKeyPreservingOpaqueIds } from "../sessions/session-key-utils.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import type { InboundLastRouteUpdate } from "./session.types.js";
 export type { InboundLastRouteUpdate, RecordInboundSession } from "./session.types.js";
@@ -39,7 +40,7 @@ export async function recordInboundSession(params: {
   trackSessionMetaTask?: (task: Promise<unknown>) => void;
 }): Promise<void> {
   const { storePath, sessionKey, ctx, groupResolution, createIfMissing } = params;
-  const canonicalSessionKey = normalizeLowercaseStringOrEmpty(sessionKey);
+  const canonicalSessionKey = normalizeSessionKeyPreservingOpaqueIds(sessionKey);
   const runtime = await loadInboundSessionRuntime();
   const metaTask = runtime
     .recordSessionMetaFromInbound({
@@ -60,7 +61,7 @@ export async function recordInboundSession(params: {
   if (shouldSkipPinnedMainDmRouteUpdate(update.mainDmOwnerPin)) {
     return;
   }
-  const targetSessionKey = normalizeLowercaseStringOrEmpty(update.sessionKey);
+  const targetSessionKey = normalizeSessionKeyPreservingOpaqueIds(update.sessionKey);
   await runtime.updateLastRoute({
     storePath,
     sessionKey: targetSessionKey,

--- a/src/config/sessions/explicit-session-key-normalization.test.ts
+++ b/src/config/sessions/explicit-session-key-normalization.test.ts
@@ -45,7 +45,7 @@ describe("normalizeExplicitSessionKey", () => {
     ).toBe("agent:fina:discord:direct:123456");
   });
 
-  it("lowercases and passes through unknown providers unchanged", () => {
+  it("lowercases unknown providers while preserving opaque Signal group IDs", () => {
     expect(
       normalizeExplicitSessionKey(
         "Agent:Fina:Slack:DM:ABC",
@@ -55,5 +55,12 @@ describe("normalizeExplicitSessionKey", () => {
         }),
       ),
     ).toBe("agent:fina:slack:dm:abc");
+    const groupId = "VWATOdKF2hc8zdOS76q9tb0+5BI522e03QLDAq/9yPg=";
+    expect(
+      normalizeExplicitSessionKey(
+        `Agent:Main:Signal:Group:${groupId}`,
+        makeCtx({ Surface: "signal", ChatType: "group", From: `group:${groupId}` }),
+      ),
+    ).toBe(`agent:main:signal:group:${groupId}`);
   });
 });

--- a/src/config/sessions/explicit-session-key-normalization.ts
+++ b/src/config/sessions/explicit-session-key-normalization.ts
@@ -1,5 +1,6 @@
 import type { MsgContext } from "../../auto-reply/templating.js";
 import { getLoadedChannelPlugin, listChannelPlugins } from "../../channels/plugins/index.js";
+import { normalizeSessionKeyPreservingOpaqueIds } from "../../sessions/session-key-utils.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
@@ -36,12 +37,12 @@ function resolveExplicitSessionKeyNormalizerCandidates(
 }
 
 export function normalizeExplicitSessionKey(sessionKey: string, ctx: MsgContext): string {
-  const normalized = normalizeLowercaseStringOrEmpty(sessionKey);
+  const normalized = normalizeSessionKeyPreservingOpaqueIds(sessionKey);
   for (const channelId of resolveExplicitSessionKeyNormalizerCandidates(normalized, ctx)) {
     const normalize = getLoadedChannelPlugin(channelId)?.messaging?.normalizeExplicitSessionKey;
     const next = normalize?.({ sessionKey: normalized, ctx });
     if (typeof next === "string" && next.trim()) {
-      return normalizeLowercaseStringOrEmpty(next);
+      return normalizeSessionKeyPreservingOpaqueIds(next);
     }
   }
   return normalized;

--- a/src/config/sessions/store-entry.ts
+++ b/src/config/sessions/store-entry.ts
@@ -1,8 +1,8 @@
-import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
+import { normalizeSessionKeyPreservingOpaqueIds } from "../../sessions/session-key-utils.js";
 import type { SessionEntry } from "./types.js";
 
 export function normalizeStoreSessionKey(sessionKey: string): string {
-  return normalizeLowercaseStringOrEmpty(sessionKey);
+  return normalizeSessionKeyPreservingOpaqueIds(sessionKey);
 }
 
 export function resolveSessionStoreEntry(params: {

--- a/src/config/sessions/store.session-key-normalization.test.ts
+++ b/src/config/sessions/store.session-key-normalization.test.ts
@@ -62,6 +62,22 @@ describe("session store key normalization", () => {
     expect(store[CANONICAL_KEY]?.origin?.provider).toBe("webchat");
   });
 
+  it("preserves opaque Signal group IDs when recording inbound metadata", async () => {
+    const groupId = "VWATOdKF2hc8zdOS76q9tb0+5BI522e03QLDAq/9yPg=";
+    const canonicalKey = `agent:main:signal:group:${groupId}`;
+    await recordSessionMetaFromInbound({
+      storePath,
+      sessionKey: `Agent:Main:Signal:Group:${groupId}`,
+      ctx: {
+        To: `group:${groupId}`,
+      },
+    });
+
+    const store = loadSessionStore(storePath, { skipCache: true });
+    expect(Object.keys(store)).toEqual([canonicalKey]);
+    expect(store[canonicalKey]?.origin?.to).toBe(`group:${groupId}`);
+  });
+
   it("does not create a duplicate mixed-case key when last route is updated", async () => {
     await recordSessionMetaFromInbound({
       storePath,

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -422,6 +422,16 @@ describe("resolveAgentRoute", () => {
     expect(route.sessionKey).toBe("agent:main:discord:channel:1468834856187203680");
   });
 
+  test("preserves mixed-case Signal group IDs in route session keys", () => {
+    const groupId = "VWATOdKF2hc8zdOS76q9tb0+5BI522e03QLDAq/9yPg=";
+    const route = resolveAgentRoute({
+      cfg: {},
+      channel: "Signal",
+      peer: { kind: "group", id: groupId },
+    });
+    expect(route.sessionKey).toBe(`agent:main:signal:group:${groupId}`);
+  });
+
   test.each([
     {
       name: "peer+guild binding does not act as guild-wide fallback when peer mismatches (#14752)",

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -661,16 +661,14 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   ) => {
     const resolvedAgentId = pickFirstExistingAgentId(input.cfg, agentId);
     const effectiveDmScope = sessionOverride?.dmScope ?? dmScope;
-    const sessionKey = normalizeLowercaseStringOrEmpty(
-      buildAgentSessionKey({
-        agentId: resolvedAgentId,
-        channel,
-        accountId,
-        peer,
-        dmScope: effectiveDmScope,
-        identityLinks,
-      }),
-    );
+    const sessionKey = buildAgentSessionKey({
+      agentId: resolvedAgentId,
+      channel,
+      accountId,
+      peer,
+      dmScope: effectiveDmScope,
+      identityLinks,
+    });
     const mainSessionKey = normalizeLowercaseStringOrEmpty(
       buildAgentMainSessionKey({
         agentId: resolvedAgentId,

--- a/src/routing/session-key.test.ts
+++ b/src/routing/session-key.test.ts
@@ -7,6 +7,8 @@ import {
   resolveThreadParentSessionKey,
 } from "../sessions/session-key-utils.js";
 import {
+  buildAgentPeerSessionKey,
+  buildGroupHistoryKey,
   classifySessionKeyShape,
   isValidAgentId,
   parseAgentSessionKey,
@@ -158,6 +160,24 @@ describe("session key canonicalization", () => {
     },
   ] as const)("$name", ({ run }) => {
     expectSessionKeyCanonicalizationCase({ run });
+  });
+});
+
+describe("Signal group session key casing", () => {
+  const groupId = "VWATOdKF2hc8zdOS76q9tb0+5BI522e03QLDAq/9yPg=";
+
+  it("preserves opaque Signal group IDs in peer and history keys", () => {
+    expect(
+      buildAgentPeerSessionKey({
+        agentId: "Main",
+        channel: "Signal",
+        peerKind: "group",
+        peerId: groupId,
+      }),
+    ).toBe(`agent:main:signal:group:${groupId}`);
+    expect(buildGroupHistoryKey({ channel: "Signal", peerKind: "group", peerId: groupId })).toBe(
+      `signal:default:group:${groupId}`,
+    );
   });
 });
 

--- a/src/routing/session-key.test.ts
+++ b/src/routing/session-key.test.ts
@@ -7,7 +7,6 @@ import {
   resolveThreadParentSessionKey,
 } from "../sessions/session-key-utils.js";
 import {
-  buildAgentPeerSessionKey,
   buildGroupHistoryKey,
   classifySessionKeyShape,
   isValidAgentId,
@@ -166,15 +165,7 @@ describe("session key canonicalization", () => {
 describe("Signal group session key casing", () => {
   const groupId = "VWATOdKF2hc8zdOS76q9tb0+5BI522e03QLDAq/9yPg=";
 
-  it("preserves opaque Signal group IDs in peer and history keys", () => {
-    expect(
-      buildAgentPeerSessionKey({
-        agentId: "Main",
-        channel: "Signal",
-        peerKind: "group",
-        peerId: groupId,
-      }),
-    ).toBe(`agent:main:signal:group:${groupId}`);
+  it("preserves opaque Signal group IDs in history keys", () => {
     expect(buildGroupHistoryKey({ channel: "Signal", peerKind: "group", peerId: groupId })).toBe(
       `signal:default:group:${groupId}`,
     );

--- a/src/routing/session-key.ts
+++ b/src/routing/session-key.ts
@@ -1,5 +1,9 @@
 import type { ChatType } from "../channels/chat-type.js";
-import { isCronRunSessionKey, parseAgentSessionKey } from "../sessions/session-key-utils.js";
+import {
+  isCronRunSessionKey,
+  normalizeSessionPeerId,
+  parseAgentSessionKey,
+} from "../sessions/session-key-utils.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { normalizeAccountId } from "./account-id.js";
 
@@ -208,7 +212,7 @@ export function buildAgentPeerSessionKey(params: {
     });
   }
   const channel = normalizeLowercaseStringOrEmpty(params.channel) || "unknown";
-  const peerId = normalizeLowercaseStringOrEmpty(params.peerId) || "unknown";
+  const peerId = normalizeSessionPeerId({ channel, peerKind, peerId: params.peerId }) || "unknown";
   return `agent:${normalizeAgentId(params.agentId)}:${channel}:${peerKind}:${peerId}`;
 }
 
@@ -266,7 +270,9 @@ export function buildGroupHistoryKey(params: {
 }): string {
   const channel = normalizeToken(params.channel) || "unknown";
   const accountId = normalizeAccountId(params.accountId);
-  const peerId = normalizeLowercaseStringOrEmpty(params.peerId) || "unknown";
+  const peerId =
+    normalizeSessionPeerId({ channel, peerKind: params.peerKind, peerId: params.peerId }) ||
+    "unknown";
   return `${channel}:${accountId}:${params.peerKind}:${peerId}`;
 }
 

--- a/src/sessions/session-key-utils.ts
+++ b/src/sessions/session-key-utils.ts
@@ -21,6 +21,35 @@ export type RawSessionConversationRef = {
   prefix: string;
 };
 
+export function normalizeSessionPeerId(params: {
+  channel: string;
+  peerKind?: string | null;
+  peerId?: string | null;
+}): string {
+  const peerId = (params.peerId ?? "").trim();
+  return normalizeLowercaseStringOrEmpty(params.channel) === "signal" &&
+    normalizeLowercaseStringOrEmpty(params.peerKind) === "group"
+    ? peerId
+    : normalizeLowercaseStringOrEmpty(peerId);
+}
+
+export function normalizeSessionKeyPreservingOpaqueIds(sessionKey: string): string {
+  const trimmed = sessionKey.trim();
+  if (!trimmed) {
+    return "";
+  }
+  const parts = trimmed.split(":");
+  return parts
+    .map((part, index) => {
+      const prev = normalizeLowercaseStringOrEmpty(parts[index - 1]);
+      const prevPrev = normalizeLowercaseStringOrEmpty(parts[index - 2]);
+      return prevPrev === "signal" && prev === "group"
+        ? part.trim()
+        : normalizeLowercaseStringOrEmpty(part);
+    })
+    .join(":");
+}
+
 /**
  * Parse agent-scoped session keys in a canonical, case-insensitive way.
  * Returned values are normalized to lowercase for stable comparisons/routing.


### PR DESCRIPTION
## Summary
- Preserve mixed-case Signal group IDs when building and storing route/session keys.
- Keep existing lowercase canonicalization for structural session tokens and non-Signal group peers.
- Add focused regression coverage for route resolution, explicit session keys, session persistence, and group history keys.

## Root cause
Signal group IDs are opaque, Base64-like identifiers, but shared session-key paths lowercased the full session key or peer ID. That corrupted `signal:group:<id>` keys even though Signal delivery targets already preserve `group:<id>` casing.

Fixes #82827.

## Why This Is Safe
The new normalization keeps provider/channel/agent/key tokens lowercase and only preserves the peer-id segment immediately after `signal:group:`. Other providers and non-group Signal targets continue through the existing lowercase canonicalization behavior.

## Security And Runtime Controls
No prompt-based policy, auth, allowlist, sandbox, or delivery permission controls are changed. This only changes runtime string canonicalization for Signal group identifiers in session keys.

## Real Behavior Proof
Behavior addressed: Signal group auto-reply/session routing no longer corrupts mixed-case group IDs in route keys, explicit session keys, persisted session keys, or group history keys.

Real environment tested: local source checkout with focused unit/regression tests for the affected runtime paths.

Exact steps or command run after this patch:
- `git diff --check origin/main...HEAD`
- `node scripts/run-vitest.mjs src/routing/session-key.test.ts src/routing/resolve-route.test.ts src/config/sessions/explicit-session-key-normalization.test.ts src/config/sessions/store.session-key-normalization.test.ts extensions/signal/src/normalize.test.ts`
- `pnpm check:changed`

Evidence after fix: the new tests assert mixed-case `VWATOdKF2hc8zdOS76q9tb0+5BI522e03QLDAq/9yPg=` remains mixed-case in route/session/history/persisted keys.

Observed result after fix: all focused tests passed and `pnpm check:changed` passed.

What was not tested: live signal-cli daemon delivery in a real Signal group.

## Out Of Scope
- Broader provider-specific opaque-ID policy beyond the Signal group session-key regression.
- Migration or repair of already-corrupted historical session entries.
- Changes to Signal daemon setup, manual send behavior, or delivery authorization.

AI-assisted: yes. I reviewed the final diff and understand the runtime normalization change.

Made with [Cursor](https://cursor.com)