### PR TITLE
fix(signal): preserve group id casing in session keys

### DIFF
--- a/src/config/sessions/explicit-session-key-normalization.test.ts
+++ b/src/config/sessions/explicit-session-key-normalization.test.ts
@@ -56,4 +56,15 @@ describe("normalizeExplicitSessionKey", () => {
       ),
     ).toBe("agent:fina:slack:dm:abc");
   });
+
+  it("preserves case-sensitive Signal group IDs in explicit session keys", () => {
+    const groupId = "VWATOdKF2hc8zdOS76q9tb0+5BI522e03QLDAq/9yPg=";
+
+    expect(
+      normalizeExplicitSessionKey(
+        `Agent:Main:Signal:Group:${groupId}`,
+        makeCtx({ Provider: "signal", Surface: "signal" }),
+      ),
+    ).toBe(`agent:main:signal:group:${groupId}`);
+  });
 });

--- a/src/config/sessions/explicit-session-key-normalization.ts
+++ b/src/config/sessions/explicit-session-key-normalization.ts
@@ -1,5 +1,6 @@
 import type { MsgContext } from "../../auto-reply/templating.js";
 import { getLoadedChannelPlugin, listChannelPlugins } from "../../channels/plugins/index.js";
+import { normalizeSessionKeyPreservingOpaquePeerIds } from "../../sessions/session-key-utils.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
@@ -36,12 +37,12 @@ function resolveExplicitSessionKeyNormalizerCandidates(
 }
 
 export function normalizeExplicitSessionKey(sessionKey: string, ctx: MsgContext): string {
-  const normalized = normalizeLowercaseStringOrEmpty(sessionKey);
+  const normalized = normalizeSessionKeyPreservingOpaquePeerIds(sessionKey);
   for (const channelId of resolveExplicitSessionKeyNormalizerCandidates(normalized, ctx)) {
     const normalize = getLoadedChannelPlugin(channelId)?.messaging?.normalizeExplicitSessionKey;
     const next = normalize?.({ sessionKey: normalized, ctx });
     if (typeof next === "string" && next.trim()) {
-      return normalizeLowercaseStringOrEmpty(next);
+      return normalizeSessionKeyPreservingOpaquePeerIds(next);
     }
   }
   return normalized;

--- a/src/config/sessions/store-entry.ts
+++ b/src/config/sessions/store-entry.ts
@@ -1,8 +1,8 @@
-import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
+import { normalizeSessionKeyPreservingOpaquePeerIds } from "../../sessions/session-key-utils.js";
 import type { SessionEntry } from "./types.js";
 
 export function normalizeStoreSessionKey(sessionKey: string): string {
-  return normalizeLowercaseStringOrEmpty(sessionKey);
+  return normalizeSessionKeyPreservingOpaquePeerIds(sessionKey);
 }
 
 export function resolveSessionStoreEntry(params: {

--- a/src/config/sessions/store.session-key-normalization.test.ts
+++ b/src/config/sessions/store.session-key-normalization.test.ts
@@ -12,6 +12,8 @@ import {
 
 const CANONICAL_KEY = "agent:main:webchat:dm:mixed-user";
 const MIXED_CASE_KEY = "Agent:Main:WebChat:DM:MiXeD-User";
+const SIGNAL_GROUP_ID = "VWATOdKF2hc8zdOS76q9tb0+5BI522e03QLDAq/9yPg=";
+const SIGNAL_GROUP_KEY = `agent:main:signal:group:${SIGNAL_GROUP_ID}`;
 
 function createInboundContext(): MsgContext {
   return {
@@ -60,6 +62,27 @@ describe("session store key normalization", () => {
     const store = loadSessionStore(storePath, { skipCache: true });
     expect(Object.keys(store)).toEqual([CANONICAL_KEY]);
     expect(store[CANONICAL_KEY]?.origin?.provider).toBe("webchat");
+  });
+
+  it("preserves Signal group ID case while canonicalizing store keys", async () => {
+    await recordSessionMetaFromInbound({
+      storePath,
+      sessionKey: `Agent:Main:Signal:Group:${SIGNAL_GROUP_ID}`,
+      ctx: {
+        ...createInboundContext(),
+        Provider: "signal",
+        Surface: "signal",
+        ChatType: "group",
+        From: `group:${SIGNAL_GROUP_ID}`,
+        To: `group:${SIGNAL_GROUP_ID}`,
+        SessionKey: `Agent:Main:Signal:Group:${SIGNAL_GROUP_ID}`,
+        OriginatingTo: `group:${SIGNAL_GROUP_ID}`,
+      },
+    });
+
+    const store = loadSessionStore(storePath, { skipCache: true });
+    expect(Object.keys(store)).toEqual([SIGNAL_GROUP_KEY]);
+    expect(store[SIGNAL_GROUP_KEY]?.origin?.to).toBe(`group:${SIGNAL_GROUP_ID}`);
   });
 
   it("does not create a duplicate mixed-case key when last route is updated", async () => {

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -115,6 +115,24 @@ describe("resolveAgentRoute", () => {
     });
   });
 
+  test("preserves case-sensitive Signal group IDs in route session keys", () => {
+    const groupId = "VWATOdKF2hc8zdOS76q9tb0+5BI522e03QLDAq/9yPg=";
+    const route = resolveAgentRoute({
+      cfg: {},
+      channel: "signal",
+      accountId: null,
+      peer: { kind: "group", id: groupId },
+    });
+
+    expectResolvedRoute(route, {
+      agentId: "main",
+      accountId: "default",
+      sessionKey: `agent:main:signal:group:${groupId}`,
+      lastRoutePolicy: "session",
+      matchedBy: "default",
+    });
+  });
+
   test.each([
     { dmScope: "per-peer" as const, expected: "agent:main:direct:+15551234567" },
     {

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -661,22 +661,18 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   ) => {
     const resolvedAgentId = pickFirstExistingAgentId(input.cfg, agentId);
     const effectiveDmScope = sessionOverride?.dmScope ?? dmScope;
-    const sessionKey = normalizeLowercaseStringOrEmpty(
-      buildAgentSessionKey({
-        agentId: resolvedAgentId,
-        channel,
-        accountId,
-        peer,
-        dmScope: effectiveDmScope,
-        identityLinks,
-      }),
-    );
-    const mainSessionKey = normalizeLowercaseStringOrEmpty(
-      buildAgentMainSessionKey({
-        agentId: resolvedAgentId,
-        mainKey: DEFAULT_MAIN_KEY,
-      }),
-    );
+    const sessionKey = buildAgentSessionKey({
+      agentId: resolvedAgentId,
+      channel,
+      accountId,
+      peer,
+      dmScope: effectiveDmScope,
+      identityLinks,
+    });
+    const mainSessionKey = buildAgentMainSessionKey({
+      agentId: resolvedAgentId,
+      mainKey: DEFAULT_MAIN_KEY,
+    });
     const route = {
       agentId: resolvedAgentId,
       channel,

--- a/src/routing/session-key.continuity.test.ts
+++ b/src/routing/session-key.continuity.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { buildAgentSessionKey } from "./resolve-route.js";
+import { buildGroupHistoryKey } from "./session-key.js";
 
 describe("Channel Session Key Continuity", () => {
   const agentId = "main";
@@ -63,5 +64,18 @@ describe("Channel Session Key Continuity", () => {
 
   it.each(["", "   "] as const)("handles invalid channel id %j without collision", (channelId) => {
     expectUnknownChannelKeyCase(channelId);
+  });
+
+  it("preserves case-sensitive Signal group IDs in history keys", () => {
+    const groupId = "AbCdEF123+/Z=";
+
+    expect(
+      buildGroupHistoryKey({
+        channel: "signal",
+        accountId: "default",
+        peerKind: "group",
+        peerId: groupId,
+      }),
+    ).toBe(`signal:default:group:${groupId}`);
   });
 });

--- a/src/routing/session-key.ts
+++ b/src/routing/session-key.ts
@@ -32,6 +32,27 @@ function normalizeToken(value: string | undefined | null): string {
   return normalizeLowercaseStringOrEmpty(value);
 }
 
+function shouldPreserveOpaquePeerIdCase(params: {
+  channel: string | undefined | null;
+  peerKind: ChatType;
+}): boolean {
+  return normalizeToken(params.channel) === "signal" && params.peerKind === "group";
+}
+
+function normalizePeerIdForSessionKey(params: {
+  channel: string | undefined | null;
+  peerKind: ChatType;
+  peerId: string | undefined | null;
+}): string {
+  const trimmed = (params.peerId ?? "").trim();
+  if (!trimmed) {
+    return "";
+  }
+  return shouldPreserveOpaquePeerIdCase(params)
+    ? trimmed
+    : normalizeLowercaseStringOrEmpty(trimmed);
+}
+
 export function scopedHeartbeatWakeOptions<T extends object>(
   sessionKey: string,
   wakeOptions: T,
@@ -208,7 +229,8 @@ export function buildAgentPeerSessionKey(params: {
     });
   }
   const channel = normalizeLowercaseStringOrEmpty(params.channel) || "unknown";
-  const peerId = normalizeLowercaseStringOrEmpty(params.peerId) || "unknown";
+  const peerId =
+    normalizePeerIdForSessionKey({ channel, peerKind, peerId: params.peerId }) || "unknown";
   return `agent:${normalizeAgentId(params.agentId)}:${channel}:${peerKind}:${peerId}`;
 }
 
@@ -266,7 +288,12 @@ export function buildGroupHistoryKey(params: {
 }): string {
   const channel = normalizeToken(params.channel) || "unknown";
   const accountId = normalizeAccountId(params.accountId);
-  const peerId = normalizeLowercaseStringOrEmpty(params.peerId) || "unknown";
+  const peerId =
+    normalizePeerIdForSessionKey({
+      channel,
+      peerKind: params.peerKind,
+      peerId: params.peerId,
+    }) || "unknown";
   return `${channel}:${accountId}:${params.peerKind}:${peerId}`;
 }
 

--- a/src/sessions/session-key-utils.ts
+++ b/src/sessions/session-key-utils.ts
@@ -21,14 +21,38 @@ export type RawSessionConversationRef = {
   prefix: string;
 };
 
+const SIGNAL_GROUP_SESSION_SEGMENT_RE = /(^|:)signal:group:([^:]+)/gi;
+
+export function normalizeSessionKeyPreservingOpaquePeerIds(
+  sessionKey: string | undefined | null,
+): string {
+  const raw = normalizeOptionalString(sessionKey);
+  if (!raw) {
+    return "";
+  }
+  let normalized = "";
+  let cursor = 0;
+  for (const match of raw.matchAll(SIGNAL_GROUP_SESSION_SEGMENT_RE)) {
+    const matchIndex = match.index ?? 0;
+    const matched = match[0] ?? "";
+    const groupId = match[2] ?? "";
+    const groupStart = matchIndex + matched.length - groupId.length;
+    normalized += normalizeLowercaseStringOrEmpty(raw.slice(cursor, groupStart));
+    normalized += groupId.trim();
+    cursor = matchIndex + matched.length;
+  }
+  normalized += normalizeLowercaseStringOrEmpty(raw.slice(cursor));
+  return normalized;
+}
+
 /**
  * Parse agent-scoped session keys in a canonical, case-insensitive way.
- * Returned values are normalized to lowercase for stable comparisons/routing.
+ * Returned values are canonicalized for stable comparisons/routing while preserving opaque IDs.
  */
 export function parseAgentSessionKey(
   sessionKey: string | undefined | null,
 ): ParsedAgentSessionKey | null {
-  const raw = normalizeOptionalLowercaseString(sessionKey);
+  const raw = normalizeSessionKeyPreservingOpaquePeerIds(sessionKey);
   if (!raw) {
     return null;
   }


### PR DESCRIPTION
## Summary

Fixes #82827 by preserving Signal group IDs as opaque, case-sensitive values in routing and session key normalization.

Signal group IDs are Base64-like identifiers. The existing generic session-key canonicalization lowercased peer IDs and whole session keys, which corrupted `signal:group:<id>` targets and could make generated auto-replies visible in OpenClaw but undeliverable back to Signal.

## Changes

- Preserve `channel === "signal" && peerKind === "group"` IDs when building agent session keys.
- Preserve Signal group IDs when canonicalizing session-store and explicit session keys.
- Stop re-lowercasing the fully built route key after `buildAgentSessionKey()` has already canonicalized safe segments.
- Add regressions for route keys, group history keys, session-store writes, and explicit session key normalization.

## Real behavior proof

- **Behavior or issue addressed:** Signal group auto-replies can fail when OpenClaw lowercases opaque, case-sensitive Signal group IDs before reply delivery.
- **Real environment tested:** OpenClaw checkout in WSL Ubuntu-24.04 on `fix-signal-group-id-case-82827`; before/after artifact generated locally with the established Python/Pillow proof script pattern and published to `proof-artifacts/pr-82840-fresh`.
- **Exact steps or command run after this patch:** Ran the focused after-fix route/session/store checks and source before/after probe against a mixed-case Signal group ID shaped like the issue report: `VWATOdKF2hc8zdOS76q9tb0+5BI522e03QLDAq/9yPg=`.
- **Evidence after fix:** ![Before/after proof](https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-82840-fresh/pr-82840/pr-82840-signal-group-id-case-before-after-proof.png)

  Scripted proof summary: https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-82840-fresh/pr-82840/summary.txt

  ```text
  before_peer_lowercase_status=0
  before_route_lowercase_status=0
  before_store_lowercase_status=0
  after_helper_status=0
  after_peer_preserve_status=0
  after_route_preserve_status=0
  after_store_preserve_status=0
  ```
- **Observed result after fix:** The generated route/session key and store-key normalization preserve `agent:main:signal:group:VWATOdKF2hc8zdOS76q9tb0+5BI522e03QLDAq/9yPg=` exactly instead of corrupting the group ID to lowercase.
- **What was not tested:** No live Signal daemon send was run because this environment does not have the user's Signal account/group credentials; the proof exercises the real OpenClaw routing/session/store code path that corrupted the target before delivery.

## Validation

```text
pnpm exec vitest run src/routing/resolve-route.test.ts src/routing/session-key.continuity.test.ts src/config/sessions/store.session-key-normalization.test.ts src/config/sessions/explicit-session-key-normalization.test.ts extensions/signal/src/normalize.test.ts --reporter=dot
Test Files  5 passed (5)
Tests  76 passed (76)

pnpm exec oxfmt --check src/sessions/session-key-utils.ts src/config/sessions/store-entry.ts src/config/sessions/explicit-session-key-normalization.ts src/routing/session-key.ts src/routing/resolve-route.ts src/routing/resolve-route.test.ts src/routing/session-key.continuity.test.ts src/config/sessions/store.session-key-normalization.test.ts src/config/sessions/explicit-session-key-normalization.test.ts
All matched files use the correct format.

git diff --check
(no output)

pnpm check:changed
exit code 0
```
