### PR TITLE
fix: harden Codex auth and MCP startup

### DIFF
--- a/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
+++ b/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
@@ -816,7 +816,7 @@ describe("resolveApiKeyForProfile openai-codex refresh fallback", () => {
     ).rejects.toThrow(/OAuth token refresh failed for anthropic/);
   });
 
-  it("does not use fallback for unrelated openai-codex refresh errors", async () => {
+  it("marks stale openai-codex profiles unhealthy when refresh fails with invalid_grant", async () => {
     const profileId = "openai-codex:default";
     saveAuthProfileStore(
       createExpiredOauthStore({
@@ -836,5 +836,41 @@ describe("resolveApiKeyForProfile openai-codex refresh fallback", () => {
         agentDir,
       }),
     ).rejects.toThrow(/OAuth token refresh failed for openai-codex/);
+
+    const persisted = ensureAuthProfileStore(agentDir);
+    expect(persisted.usageStats?.[profileId]).toMatchObject({
+      disabledReason: "auth_permanent",
+    });
+    expect(persisted.usageStats?.[profileId]?.disabledUntil).toBeGreaterThan(Date.now());
+  });
+
+  it("marks stale openai-codex profiles unhealthy when refresh_token_reused cannot be repaired", async () => {
+    const profileId = "openai-codex:default";
+    saveAuthProfileStore(
+      createExpiredOauthStore({
+        profileId,
+        provider: "openai-codex",
+      }),
+      agentDir,
+    );
+    getOAuthApiKeyMock.mockRejectedValue(
+      new Error(
+        '401 {"error":{"message":"Your refresh token has already been used to generate a new access token.","code":"refresh_token_reused"}}',
+      ),
+    );
+
+    await expect(
+      resolveApiKeyForProfile({
+        store: ensureAuthProfileStore(agentDir),
+        profileId,
+        agentDir,
+      }),
+    ).rejects.toThrow(/OAuth token refresh failed for openai-codex/);
+
+    const persisted = ensureAuthProfileStore(agentDir);
+    expect(persisted.usageStats?.[profileId]).toMatchObject({
+      disabledReason: "auth_permanent",
+    });
+    expect(persisted.usageStats?.[profileId]?.disabledUntil).toBeGreaterThan(Date.now());
   });
 });

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -28,6 +28,7 @@ import { assertNoOAuthSecretRefPolicyViolations } from "./policy.js";
 import { suggestOAuthProfileIdForLegacyDefault } from "./repair.js";
 import { loadAuthProfileStoreForSecretsRuntime } from "./store.js";
 import type { AuthProfileStore, OAuthCredential } from "./types.js";
+import { markAuthProfileFailure } from "./usage.js";
 
 export {
   isSafeToCopyOAuthIdentity,
@@ -412,6 +413,15 @@ export async function resolveApiKeyForProfile(
     }
 
     const message = extractErrorMessage(surfacedMessageError);
+    if (isRefreshTokenReusedError(surfacedMessageError) || /\binvalid_grant\b/i.test(message)) {
+      await markAuthProfileFailure({
+        store: refreshedStore,
+        profileId,
+        reason: "auth_permanent",
+        cfg,
+        agentDir: params.agentDir,
+      }).catch(() => undefined);
+    }
     const hint = await formatAuthDoctorHint({
       cfg,
       store: refreshedStore,

--- a/src/agents/pi-bundle-mcp-runtime.test.ts
+++ b/src/agents/pi-bundle-mcp-runtime.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createBundleMcpJsonSchemaValidator } from "./pi-bundle-mcp-runtime.js";
+import {
+  createBundleMcpJsonSchemaValidator,
+  createSessionMcpRuntime,
+} from "./pi-bundle-mcp-runtime.js";
 import { cleanupBundleMcpHarness } from "./pi-bundle-mcp-test-harness.js";
 import {
   __testing,
@@ -72,6 +75,7 @@ function makeRuntime(
 }
 
 afterEach(async () => {
+  __testing.resetMcpServerDegradationForTests();
   await cleanupBundleMcpHarness();
 });
 
@@ -504,5 +508,96 @@ describe("session MCP runtime", () => {
     await expect(manager.sweepIdleRuntimes()).resolves.toBe(0);
     expect(manager.listSessionIds()).toEqual(["session-no-ttl"]);
     expect(disposed).toStrictEqual([]);
+  });
+
+  it("marks a timed-out optional MCP server degraded and skips it during cooldown", async () => {
+    const runtimeA = createSessionMcpRuntime({
+      sessionId: "session-slow-mcp-a",
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: {
+          servers: {
+            slowProbe: {
+              command: process.execPath,
+              args: ["-e", "setTimeout(() => {}, 60_000)"],
+              connectionTimeoutMs: 5,
+              degradedCooldownMs: 60_000,
+            },
+          },
+        },
+      },
+    });
+
+    const firstStartedAt = Date.now();
+    const firstCatalog = await runtimeA.getCatalog();
+    const firstElapsedMs = Date.now() - firstStartedAt;
+
+    expect(firstCatalog.servers.slowProbe).toMatchObject({
+      status: "degraded",
+      optional: true,
+      toolCount: 0,
+    });
+    expect(firstCatalog.servers.slowProbe?.degradedReason).toMatch(/timed out/i);
+    expect(firstElapsedMs).toBeGreaterThanOrEqual(1);
+    await runtimeA.dispose();
+
+    const runtimeB = createSessionMcpRuntime({
+      sessionId: "session-slow-mcp-b",
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: {
+          servers: {
+            slowProbe: {
+              command: process.execPath,
+              args: ["-e", "setTimeout(() => {}, 60_000)"],
+              connectionTimeoutMs: 5,
+              degradedCooldownMs: 60_000,
+            },
+          },
+        },
+      },
+    });
+
+    const secondStartedAt = Date.now();
+    const secondCatalog = await runtimeB.getCatalog();
+    const secondElapsedMs = Date.now() - secondStartedAt;
+
+    expect(secondCatalog.servers.slowProbe).toMatchObject({
+      status: "degraded",
+      optional: true,
+      toolCount: 0,
+    });
+    expect(secondElapsedMs).toBeLessThan(Math.max(50, firstElapsedMs));
+    expect(__testing.listActiveMcpServerDegradations()).toEqual([
+      expect.objectContaining({
+        serverName: "slowProbe",
+        reason: expect.stringMatching(/timed out/i),
+      }),
+    ]);
+    await runtimeB.dispose();
+  });
+
+  it("fails required MCP startup instead of silently degrading it", async () => {
+    const runtime = createSessionMcpRuntime({
+      sessionId: "session-required-slow-mcp",
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: {
+          servers: {
+            requiredProbe: {
+              command: process.execPath,
+              args: ["-e", "setTimeout(() => {}, 60_000)"],
+              connectionTimeoutMs: 5,
+              degradedCooldownMs: 60_000,
+              required: true,
+            },
+          },
+        },
+      },
+    });
+
+    await expect(runtime.getCatalog()).rejects.toThrow(/timed out/i);
+    expect(__testing.listActiveMcpServerDegradations()).toEqual([]);
+    await runtime.dispose();
   });
 });

--- a/src/agents/pi-bundle-mcp-runtime.ts
+++ b/src/agents/pi-bundle-mcp-runtime.ts
@@ -47,6 +47,17 @@ const SESSION_MCP_RUNTIME_MANAGER_KEY = Symbol.for("openclaw.sessionMcpRuntimeMa
 const DRAFT_2020_12_SCHEMA = "https://json-schema.org/draft/2020-12/schema";
 const DEFAULT_SESSION_MCP_RUNTIME_IDLE_TTL_MS = 10 * 60 * 1000;
 const SESSION_MCP_RUNTIME_SWEEP_INTERVAL_MS = 60 * 1000;
+const DEFAULT_MCP_SERVER_DEGRADED_COOLDOWN_MS = 5 * 60 * 1000;
+
+type McpServerDegradation = {
+  serverName: string;
+  fingerprint: string;
+  reason: string;
+  failedAt: number;
+  degradedUntil: number;
+};
+
+const degradedMcpServers = new Map<string, McpServerDegradation>();
 
 type Ajv2020Like = {
   compile: (schema: JsonSchemaType) => ValidateFunction;
@@ -113,6 +124,84 @@ function connectWithTimeout(
       },
     );
   });
+}
+
+function createMcpServerDegradationKey(fingerprint: string, serverName: string): string {
+  return `${fingerprint}:${serverName}`;
+}
+
+function resolveMcpServerDegradedCooldownMs(rawServer: unknown): number {
+  if (isMcpConfigRecord(rawServer)) {
+    const raw = rawServer.degradedCooldownMs;
+    if (typeof raw === "number" && Number.isFinite(raw) && raw >= 0) {
+      return Math.floor(raw);
+    }
+  }
+  return DEFAULT_MCP_SERVER_DEGRADED_COOLDOWN_MS;
+}
+
+function isRequiredMcpServer(rawServer: unknown): boolean {
+  return isMcpConfigRecord(rawServer) && rawServer.required === true;
+}
+
+function getActiveMcpServerDegradation(params: {
+  fingerprint: string;
+  serverName: string;
+  now?: number;
+}): McpServerDegradation | undefined {
+  const key = createMcpServerDegradationKey(params.fingerprint, params.serverName);
+  const degraded = degradedMcpServers.get(key);
+  if (!degraded) {
+    return undefined;
+  }
+  const now = params.now ?? Date.now();
+  if (degraded.degradedUntil <= now) {
+    degradedMcpServers.delete(key);
+    return undefined;
+  }
+  return degraded;
+}
+
+function markMcpServerDegraded(params: {
+  fingerprint: string;
+  serverName: string;
+  reason: string;
+  cooldownMs: number;
+}): McpServerDegradation | undefined {
+  if (params.cooldownMs <= 0) {
+    return undefined;
+  }
+  const failedAt = Date.now();
+  const degraded: McpServerDegradation = {
+    serverName: params.serverName,
+    fingerprint: params.fingerprint,
+    reason: params.reason,
+    failedAt,
+    degradedUntil: failedAt + params.cooldownMs,
+  };
+  degradedMcpServers.set(
+    createMcpServerDegradationKey(params.fingerprint, params.serverName),
+    degraded,
+  );
+  return degraded;
+}
+
+function resetMcpServerDegradationForTests() {
+  degradedMcpServers.clear();
+}
+
+function listActiveMcpServerDegradations(now = Date.now()): McpServerDegradation[] {
+  const active: McpServerDegradation[] = [];
+  for (const degraded of degradedMcpServers.values()) {
+    if (degraded.degradedUntil <= now) {
+      degradedMcpServers.delete(
+        createMcpServerDegradationKey(degraded.fingerprint, degraded.serverName),
+      );
+      continue;
+    }
+    active.push({ ...degraded });
+  }
+  return active;
 }
 
 function redactErrorUrls(error: unknown): string {
@@ -232,10 +321,32 @@ export function createSessionMcpRuntime(params: {
             continue;
           }
           const safeServerName = sanitizeServerName(serverName, usedServerNames);
+          const optional = !isRequiredMcpServer(rawServer);
           if (safeServerName !== serverName) {
             logWarn(
               `bundle-mcp: server key "${serverName}" registered as "${safeServerName}" for provider-safe tool names.`,
             );
+          }
+          const degraded = optional
+            ? getActiveMcpServerDegradation({
+                fingerprint: configFingerprint,
+                serverName,
+              })
+            : undefined;
+          if (degraded) {
+            servers[serverName] = {
+              serverName,
+              launchSummary: resolved.description,
+              toolCount: 0,
+              status: "degraded",
+              optional,
+              degradedReason: degraded.reason,
+              degradedUntil: degraded.degradedUntil,
+            };
+            logWarn(
+              `bundle-mcp: skipping degraded optional server "${serverName}" (${resolved.description}); retry after ${new Date(degraded.degradedUntil).toISOString()}: ${degraded.reason}`,
+            );
+            continue;
           }
 
           const client = new Client(
@@ -266,6 +377,8 @@ export function createSessionMcpRuntime(params: {
               serverName,
               launchSummary: resolved.description,
               toolCount: listedTools.length,
+              status: "connected",
+              optional,
             };
             for (const tool of listedTools) {
               const toolName = tool.name.trim();
@@ -283,13 +396,32 @@ export function createSessionMcpRuntime(params: {
               });
             }
           } catch (error) {
+            const reason = redactErrorUrls(error);
             if (!disposed) {
               logWarn(
-                `bundle-mcp: failed to start server "${serverName}" (${resolved.description}): ${redactErrorUrls(error)}`,
+                `bundle-mcp: failed to start server "${serverName}" (${resolved.description}): ${reason}`,
               );
             }
             await disposeSession(session);
             sessions.delete(serverName);
+            if (!optional) {
+              throw error;
+            }
+            const degraded = markMcpServerDegraded({
+              fingerprint: configFingerprint,
+              serverName,
+              reason,
+              cooldownMs: resolveMcpServerDegradedCooldownMs(rawServer),
+            });
+            servers[serverName] = {
+              serverName,
+              launchSummary: resolved.description,
+              toolCount: 0,
+              status: "degraded",
+              optional,
+              degradedReason: reason,
+              degradedUntil: degraded?.degradedUntil,
+            };
             failIfDisposed();
           }
         }
@@ -641,5 +773,7 @@ export const __testing = {
   getCachedSessionIds() {
     return getSessionMcpRuntimeManager().listSessionIds();
   },
+  listActiveMcpServerDegradations,
+  resetMcpServerDegradationForTests,
   resolveSessionMcpRuntimeIdleTtlMs,
 };

--- a/src/agents/pi-bundle-mcp-types.ts
+++ b/src/agents/pi-bundle-mcp-types.ts
@@ -12,6 +12,10 @@ export type McpServerCatalog = {
   serverName: string;
   launchSummary: string;
   toolCount: number;
+  status?: "connected" | "degraded";
+  optional?: boolean;
+  degradedReason?: string;
+  degradedUntil?: number;
 };
 
 export type McpCatalogTool = {


### PR DESCRIPTION
## Summary
- refresh Codex OAuth credentials before falling back on auth failures
- mark optional MCP startup timeouts as degraded and skip them during cooldown instead of blocking runs
- add regression coverage for Codex refresh fallback and MCP timeout/degraded startup behavior

## Verification
- Node: v22.22.1
- `node scripts/run-vitest.mjs src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts src/agents/pi-bundle-mcp-runtime.test.ts`
  - Test Files: 4 passed (4)
  - Tests: 60 passed (60)
  - Includes `invalid_grant` and `refresh_token_reused` cases asserting `usageStats[profileId].disabledReason === "auth_permanent"` and a future `disabledUntil`.
  - Includes optional MCP timeout proof: a real Node MCP child with `connectionTimeoutMs: 5` produces a `status: "degraded"` catalog entry; a second runtime with the same fingerprint skips startup during cooldown.
  - Includes required MCP timeout proof: `required: true` fails startup instead of degrading and leaves the degradation catalog empty.

## Bot-review follow-up
- Dropped the earlier `agents.defaults.gptChatBrevityGuard` schema/type-only change from this PR. This branch now contains only the Codex OAuth + MCP startup hardening and related tests.
- The runtime brevity-guard config work remains separate in PR #82163, so this PR no longer advertises an unwired config contract.

## Notes
- Latest main already contains a stronger outbound recovery/reconciliation implementation for the final-answer delivery/idempotency class; this PR keeps the additional GPT-5.5/Codex-route fixes focused on auth refresh and optional MCP startup degradation.
