### PR TITLE
Fix isolated best-effort cron delivery with active subagents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Docs: https://docs.openclaw.ai
 - Secrets/audit: treat `$VAR` auth-profile values as env SecretRefs and stop reporting env-ref credentials as plaintext, including mixed `keyRef` plus env-ref profile states. Fixes #53998. Thanks @schirloc and @artwalker.
 - Agents/model fallback: suppress fallback notices when the active OpenAI Codex runtime reports the same canonical OpenAI model.
 - Agents/music generation: remove model-controlled request timeouts, default internal provider requests to five minutes, and keep configured timeouts at a 120-second floor.
+- Cron: let isolated best-effort deliveries send the parent result immediately while fire-and-forget subagents keep running, avoiding false run timeouts. Fixes #44428. Thanks @amknight.
 - Agents/media generation: stop logging delivered failure summaries as missing message-tool delivery when no generated media was expected.
 - Agents/sessions: prioritize manual user turns ahead of queued cron and maintenance work in the same session lane, so visible follow-ups no longer wait behind background runs. Fixes #82764. (#82765) Thanks @galiniliev.
 - Agents/edit tool: honor `file_path` and related path aliases when resolving edit-recovery targets, so post-write errors no longer surface false edit failures after the file actually changed. Fixes #81909. Thanks @giodl73-repo.

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -330,6 +330,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
 
     // deliveryAttempted must be true so timer does NOT fire enqueueSystemEvent
     expect(state.deliveryAttempted).toBe(true);
+    expect(waitForDescendantSubagentSummary).toHaveBeenCalledTimes(1);
 
     // Verify timer guard agrees: shouldEnqueueCronMainSummary returns false
     expect(
@@ -344,6 +345,66 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     ).toBe(false);
 
     // No announce should have been attempted (subagents still running)
+    expect(deliverOutboundPayloads).not.toHaveBeenCalled();
+  });
+
+  it("bestEffort delivery skips active subagent wait and sends the cron reply", async () => {
+    vi.mocked(countActiveDescendantRuns).mockReturnValue(2);
+    vi.mocked(waitForDescendantSubagentSummary).mockResolvedValue(undefined);
+    vi.mocked(readDescendantSubagentFallbackReply).mockResolvedValue(undefined);
+
+    const params = makeBaseParams({
+      synthesizedText: "Parent cron summary is ready.",
+      deliveryBestEffort: true,
+    });
+    const state = await dispatchCronDelivery(params);
+
+    expect(waitForDescendantSubagentSummary).not.toHaveBeenCalled();
+    expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+    expectDeliveryCall(0, {
+      channel: "telegram",
+      to: "123456",
+      payloads: [{ text: "Parent cron summary is ready." }],
+      skipQueue: true,
+    });
+    expect(state.deliveryAttempted).toBe(true);
+    expect(state.delivered).toBe(true);
+  });
+
+  it("bestEffort delivery skips expected subagent follow-up waits", async () => {
+    vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
+    vi.mocked(expectsSubagentFollowup).mockReturnValue(true);
+    vi.mocked(waitForDescendantSubagentSummary).mockResolvedValue(undefined);
+
+    const params = makeBaseParams({
+      synthesizedText: "Spawned a subagent and returning the parent summary now.",
+      deliveryBestEffort: true,
+    });
+    const state = await dispatchCronDelivery(params);
+
+    expect(waitForDescendantSubagentSummary).not.toHaveBeenCalled();
+    expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+    expectDeliveryCall(0, {
+      payloads: [{ text: "Spawned a subagent and returning the parent summary now." }],
+    });
+    expect(state.delivered).toBe(true);
+  });
+
+  it("bestEffort delivery still suppresses stale interim text while descendants run", async () => {
+    vi.mocked(countActiveDescendantRuns).mockReturnValue(2);
+    vi.mocked(isLikelyInterimCronMessage).mockReturnValue(true);
+    vi.mocked(readDescendantSubagentFallbackReply).mockResolvedValue(undefined);
+    vi.mocked(waitForDescendantSubagentSummary).mockResolvedValue(undefined);
+
+    const params = makeBaseParams({
+      synthesizedText: "on it, pulling everything together",
+      deliveryBestEffort: true,
+    });
+    const state = await dispatchCronDelivery(params);
+
+    expect(waitForDescendantSubagentSummary).not.toHaveBeenCalled();
+    expect(state.deliveryAttempted).toBe(true);
+    expect(state.delivered).toBe(false);
     expect(deliverOutboundPayloads).not.toHaveBeenCalled();
   });
 

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -1130,7 +1130,7 @@ export async function dispatchCronDelivery(
         })
       : undefined;
     const hadDescendants = activeSubagentRuns > 0 || Boolean(completedDescendantReply);
-    if (activeSubagentRuns > 0 || expectedSubagentFollowup) {
+    if (!params.deliveryBestEffort && (activeSubagentRuns > 0 || expectedSubagentFollowup)) {
       let finalReply = await subagentFollowupRuntime?.waitForDescendantSubagentSummary({
         sessionKey: subagentFollowupSessionKey,
         initialReply: initialSynthesizedText,
@@ -1160,7 +1160,7 @@ export async function dispatchCronDelivery(
       synthesizedText = completedDescendantReply;
       deliveryPayloads = [{ text: completedDescendantReply }];
     }
-    if (activeSubagentRuns > 0) {
+    if (!params.deliveryBestEffort && activeSubagentRuns > 0) {
       // Parent orchestration is still in progress; avoid announcing a partial
       // update to the main requester. Mark deliveryAttempted so the timer does
       // not fire a redundant enqueueSystemEvent fallback (double-announce bug).


### PR DESCRIPTION
Fixes #44428.

## Summary
- Let isolated cron jobs with `delivery.bestEffort: true` send the parent result immediately instead of waiting for active descendant subagents to drain.
- Preserve strict non-best-effort behavior and stale interim suppression.
- Add regression coverage for active subagents, expected follow-up hints, and stale interim best-effort text.
- Add an unreleased changelog entry.

## Verification
- `env OPENCLAW_TEST_FAST=1 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 node scripts/run-vitest.mjs src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts`
- `git diff --check origin/main..HEAD`
- Blacksmith/Testbox repro with guards removed: `tbx_01krsjet1th58f8t9w27ecbb72`, Actions run `25975960122`; expected failure showed `waitForDescendantSubagentSummary` was called for a best-effort active-subagent delivery.
- Blacksmith/Testbox fixed proof: `tbx_01krsmjnrgnvnfycwtj0e9v1yp`, Actions run `25976651394`; focused Vitest, `git diff --check`, `pnpm build`, and real QA-channel gateway E2E passed.
- `codex review --uncommitted` before commit: no actionable correctness findings.

## Real behavior proof
Behavior addressed: isolated cron with `delivery.bestEffort: true` now delivers the parent result promptly while fire-and-forget subagents continue running.

Real environment tested: Blacksmith Testbox `tbx_01krsmjnrgnvnfycwtj0e9v1yp` through Crabbox, running a real OpenClaw QA-channel gateway child against a scripted OpenAI-compatible provider.

Exact steps or command run after this patch: focused Vitest, `git diff --check`, `pnpm build`, then a manual QA-channel E2E that creates a disabled isolated best-effort cron job, forces `cron.run`, has the parent call `sessions_spawn`, and verifies channel delivery plus child subagent activity.

Evidence after fix: E2E proof printed `CRON_BEST_EFFORT_E2E` with `status:"ok"`, `delivered:true`, `deliveryStatus:"delivered"`, `durationMs:2935`, an active child session with `hasActiveSubagentRun:true`, and a child provider request observed after parent delivery.

Observed result after fix: parent cron delivery reached `dm:qa-operator` in roughly 2.2s wall time / 2.935s cron duration, below the 8s cron timeout, while the child subagent remained active and then began its model request.

What was not tested: broad full-suite CI beyond the focused test, build, and Blacksmith/Testbox manual E2E proof above.