### PR TITLE
Fix brew-only skill installs in Docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/heartbeat: defer heartbeat runs while the target reply operation is queued or active, preventing heartbeat prompts from interleaving with WebChat responses before the streaming lane starts. Fixes #82722. Thanks @Andy-Xie-1145.
 - CLI/setup: collapse raw gateway config keys in existing-config summaries into friendly `Model` and `Gateway` rows.
 - CLI/config: show concise human config-write output with an indented backup path instead of printing checksum-heavy overwrite audit details by default.
+- Skills/onboarding: hide brew-only dependency installers in Linux containers without Homebrew and show container-specific guidance instead of a broken install path. Fixes #14593. Thanks @amknight.
 - CLI/docs: call the canonical lowercase docs MCP search tool and surface MCP errors instead of returning empty search results. Fixes #82702. (#82704) Thanks @hclsys.
 - QA-Lab: ignore heartbeat-only operational transcripts when capturing runtime parity cells so background checks cannot replace the scenario reply. (#80323) Thanks @100yenadmin.
 - QA-Lab: pin threaded-memory parity runs to `memory-core`, keep bundled plugin resolution enabled for QA commands, and retry transient session-store lock reads. (#72045) Thanks @WuKongAI-CMU.

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -142,6 +142,12 @@ The setup script accepts these optional environment variables:
 | `OTEL_SEMCONV_STABILITY_OPT_IN`            | Opt in to latest experimental GenAI semantic attributes         |
 | `OPENCLAW_OTEL_PRELOADED`                  | Skip starting a second OpenTelemetry SDK when one is preloaded  |
 
+The official Docker image does not ship Homebrew. During onboarding, OpenClaw
+hides brew-only skill dependency installers when it is running in a Linux
+container without `brew`; those dependencies must be provided by a custom image
+or installed manually. For dependencies available from Debian packages, use
+`OPENCLAW_DOCKER_APT_PACKAGES` during image build.
+
 Maintainers can test bundled plugin source against a packaged image by mounting
 one plugin source directory over its packaged source path, for example
 `OPENCLAW_EXTRA_MOUNTS=/path/to/fork/extensions/synology-chat:/app/extensions/synology-chat:ro`.

--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -328,6 +328,10 @@ metadata:
 
   </Accordion>
   <Accordion title="Per-installer details">
+    - **Homebrew installs:** OpenClaw does not auto-install Homebrew or translate
+      brew formulas into system package manager commands. In Linux containers
+      without `brew`, onboarding hides brew-only dependency installers; use a
+      custom image or install the dependency manually before enabling that skill.
     - **Go installs:** if `go` is missing and `brew` is available, the gateway installs Go via Homebrew first and sets `GOBIN` to Homebrew's `bin` when possible.
     - **Download installs:** `url` (required), `archive` (`tar.gz` | `tar.bz2` | `zip`), `extract` (default: auto when archive detected), `stripComponents`, `targetDir` (default: `~/.openclaw/tools/<skillKey>`).
 

--- a/src/agents/skills-install-fallback.test.ts
+++ b/src/agents/skills-install-fallback.test.ts
@@ -109,6 +109,7 @@ describe("skills-install fallback edge cases", () => {
     skillsInstallTesting.setDepsForTest({
       hasBinary: (bin: string) => hasBinaryMock(bin),
       resolveBrewExecutable: () => undefined,
+      isContainerEnvironment: () => false,
     });
   });
 
@@ -181,6 +182,40 @@ describe("skills-install fallback edge cases", () => {
 
     // Verify NO curl command was attempted (no auto-install)
     expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
+  });
+
+  it("returns container-specific guidance when brew is missing in a Linux container", async () => {
+    const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, "platform")!;
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    skillsInstallTesting.setDepsForTest({
+      hasBinary: (bin: string) => hasBinaryMock(bin),
+      resolveBrewExecutable: () => undefined,
+      isContainerEnvironment: () => true,
+    });
+    mockAvailableBinaries([]);
+    try {
+      skillsMocks.loadWorkspaceSkillEntries.mockReturnValueOnce([
+        makeSkillEntry(workspaceDir, "brew-tool-container", {
+          kind: "brew",
+          formula: "openai-whisper",
+        }),
+      ]);
+
+      const result = await installSkill({
+        workspaceDir,
+        skillName: "brew-tool-container",
+        installId: "deps",
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain("Linux container");
+      expect(result.message).toContain("Build a custom image");
+      expect(result.message).toContain("openai-whisper");
+      expect(result.message).not.toContain("https://brew.sh");
+      expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(process, "platform", originalPlatformDescriptor);
+    }
   });
 
   it("does not use HOMEBREW_PREFIX as a brew bin fallback for go installs", async () => {

--- a/src/agents/skills-install.ts
+++ b/src/agents/skills-install.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveBrewExecutable as defaultResolveBrewExecutable } from "../infra/brew.js";
+import { isContainerEnvironment as defaultIsContainerEnvironment } from "../infra/container-environment.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import {
   type InstallSafetyOverrides,
@@ -38,6 +39,7 @@ type SkillsInstallDeps = {
   loadWorkspaceSkillEntries: typeof defaultLoadWorkspaceSkillEntries;
   resolveNodeInstallStateDir: () => string;
   resolveBrewExecutable: () => string | undefined;
+  isContainerEnvironment: () => boolean;
   resolveSkillsInstallPreferences: typeof defaultResolveSkillsInstallPreferences;
 };
 
@@ -46,6 +48,7 @@ const defaultSkillsInstallDeps: SkillsInstallDeps = {
   loadWorkspaceSkillEntries: defaultLoadWorkspaceSkillEntries,
   resolveNodeInstallStateDir: resolveDefaultNodeInstallStateDir,
   resolveBrewExecutable: defaultResolveBrewExecutable,
+  isContainerEnvironment: defaultIsContainerEnvironment,
   resolveSkillsInstallPreferences: defaultResolveSkillsInstallPreferences,
 };
 
@@ -306,6 +309,11 @@ async function runBestEffortCommand(
 
 function resolveBrewMissingFailure(spec: SkillInstallSpec): SkillInstallResult {
   const formula = spec.formula ?? "this package";
+  if (process.platform === "linux" && getSkillsInstallDeps().isContainerEnvironment()) {
+    return createInstallFailure({
+      message: `brew not installed — Homebrew is not installed in this Linux container. Build a custom image with Homebrew or install "${formula}" manually using a supported system package before enabling this skill.`,
+    });
+  }
   const hint =
     process.platform === "linux"
       ? `Homebrew is not installed. Install it from https://brew.sh or install "${formula}" manually using your system package manager (e.g. apt, dnf, pacman).`

--- a/src/commands/onboard-skills.test.ts
+++ b/src/commands/onboard-skills.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
@@ -7,6 +7,8 @@ const mocks = vi.hoisted(() => ({
   buildWorkspaceSkillStatus: vi.fn(),
   installSkill: vi.fn(),
   detectBinary: vi.fn(),
+  isContainerEnvironment: vi.fn(),
+  resolveBrewExecutable: vi.fn(),
   resolveNodeManagerOptions: vi.fn(() => [
     { value: "npm", label: "npm" },
     { value: "pnpm", label: "pnpm" },
@@ -20,6 +22,12 @@ vi.mock("../agents/skills-status.js", () => ({
 }));
 vi.mock("../agents/skills-install.js", () => ({
   installSkill: mocks.installSkill,
+}));
+vi.mock("../infra/container-environment.js", () => ({
+  isContainerEnvironment: mocks.isContainerEnvironment,
+}));
+vi.mock("../infra/brew.js", () => ({
+  resolveBrewExecutable: mocks.resolveBrewExecutable,
 }));
 vi.mock("./onboard-helpers.js", () => ({
   detectBinary: mocks.detectBinary,
@@ -78,6 +86,7 @@ function createBundledSkill(params: {
 
 function mockMissingBrewStatus(skills: Array<ReturnType<typeof createBundledSkill>>): void {
   mocks.detectBinary.mockResolvedValue(false);
+  mocks.resolveBrewExecutable.mockReturnValue(undefined);
   mocks.installSkill.mockResolvedValue({
     ok: true,
     message: "Installed",
@@ -134,6 +143,66 @@ const runtime: RuntimeEnv = {
 };
 
 describe("setupSkills", () => {
+  afterEach(() => {
+    mocks.isContainerEnvironment.mockReset();
+    mocks.resolveBrewExecutable.mockReset();
+  });
+
+  it("hides brew-only installs in Linux containers when brew is missing", async () => {
+    const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, "platform")!;
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    try {
+      mockMissingBrewStatus([
+        createBundledSkill({
+          name: "video-frames",
+          description: "ffmpeg",
+          bins: ["ffmpeg"],
+          installLabel: "Install ffmpeg (brew)",
+        }),
+      ]);
+      mocks.isContainerEnvironment.mockReturnValue(true);
+
+      const { prompter, notes } = createPrompter({});
+      await setupSkills({} as OpenClawConfig, "/tmp/ws", runtime, prompter);
+
+      expect(prompter.multiselect).not.toHaveBeenCalled();
+      expect(mocks.installSkill).not.toHaveBeenCalled();
+      expect(notes.find((n) => n.title === "Container skill installs")).toBeDefined();
+      expect(notes.find((n) => n.title === "Homebrew recommended")).toBeUndefined();
+    } finally {
+      Object.defineProperty(process, "platform", originalPlatformDescriptor);
+    }
+  });
+
+  it("keeps brew-only installs visible when Linuxbrew is resolved off PATH", async () => {
+    const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, "platform")!;
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    try {
+      mockMissingBrewStatus([
+        createBundledSkill({
+          name: "video-frames",
+          description: "ffmpeg",
+          bins: ["ffmpeg"],
+          installLabel: "Install ffmpeg (brew)",
+        }),
+      ]);
+      mocks.isContainerEnvironment.mockReturnValue(true);
+      mocks.resolveBrewExecutable.mockReturnValue("/home/linuxbrew/.linuxbrew/bin/brew");
+
+      const { prompter, notes } = createPrompter({ multiselect: ["video-frames"] });
+      await setupSkills({} as OpenClawConfig, "/tmp/ws", runtime, prompter);
+
+      expect(prompter.multiselect).toHaveBeenCalled();
+      expect(mocks.installSkill).toHaveBeenCalledWith(
+        expect.objectContaining({ skillName: "video-frames", installId: "brew" }),
+      );
+      expect(notes.find((n) => n.title === "Container skill installs")).toBeUndefined();
+      expect(notes.find((n) => n.title === "Homebrew recommended")).toBeUndefined();
+    } finally {
+      Object.defineProperty(process, "platform", originalPlatformDescriptor);
+    }
+  });
+
   it("does not recommend Homebrew when user skips installing brew-backed deps", async () => {
     if (process.platform === "win32") {
       return;

--- a/src/commands/onboard-skills.ts
+++ b/src/commands/onboard-skills.ts
@@ -2,6 +2,8 @@ import { installSkill } from "../agents/skills-install.js";
 import { buildWorkspaceSkillStatus } from "../agents/skills-status.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveBrewExecutable } from "../infra/brew.js";
+import { isContainerEnvironment } from "../infra/container-environment.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { normalizeSecretInput } from "../utils/normalize-secret-input.js";
 import { t } from "../wizard/i18n/index.js";
@@ -29,6 +31,17 @@ function formatSkillHint(skill: {
   }
   const maxLen = 90;
   return combined.length > maxLen ? `${combined.slice(0, maxLen - 1)}…` : combined;
+}
+
+function isBrewOnlyInstallableSkill(skill: {
+  install: Array<{ kind: string }>;
+  missing: { bins: string[] };
+}): boolean {
+  return (
+    skill.install.length > 0 &&
+    skill.missing.bins.length > 0 &&
+    skill.install.every((option) => option.kind === "brew")
+  );
 }
 
 function upsertSkillEntry(
@@ -82,9 +95,26 @@ export async function setupSkills(
     return cfg;
   }
 
-  const installable = missing.filter(
+  const baseInstallable = missing.filter(
     (skill) => skill.install.length > 0 && skill.missing.bins.length > 0,
   );
+  let brewAvailable: boolean | undefined;
+  const detectBrewOnce = async () => {
+    brewAvailable ??= (await detectBinary("brew")) || resolveBrewExecutable() !== undefined;
+    return brewAvailable;
+  };
+  const inLinuxContainer = process.platform === "linux" && isContainerEnvironment();
+  let installable = baseInstallable;
+  if (inLinuxContainer && baseInstallable.length > 0 && !(await detectBrewOnce())) {
+    const hiddenBrewOnly = baseInstallable.filter(isBrewOnlyInstallableSkill);
+    installable = baseInstallable.filter((skill) => !isBrewOnlyInstallableSkill(skill));
+    if (hiddenBrewOnly.length > 0) {
+      await prompter.note(
+        [t("wizard.skills.containerBrewHidden"), t("wizard.skills.containerBrewManual")].join("\n"),
+        t("wizard.skills.containerInstallsTitle"),
+      );
+    }
+  }
   let next: OpenClawConfig = cfg;
   if (installable.length > 0) {
     const toInstall = await prompter.multiselect({
@@ -112,7 +142,7 @@ export async function setupSkills(
     const needsBrewPrompt =
       process.platform !== "win32" &&
       selectedSkills.some((skill) => skill.install.some((option) => option.kind === "brew")) &&
-      !(await detectBinary("brew"));
+      !(await detectBrewOnce());
 
     if (needsBrewPrompt) {
       await prompter.note(

--- a/src/wizard/i18n/locales/en.ts
+++ b/src/wizard/i18n/locales/en.ts
@@ -307,6 +307,11 @@ export const en = {
     },
     skills: {
       configure: "Configure skills now? (recommended)",
+      containerBrewHidden:
+        "Brew-only skill installs are hidden in Linux containers because the official image does not ship Homebrew.",
+      containerBrewManual:
+        "Use a custom image with Homebrew preinstalled or install those dependencies manually.",
+      containerInstallsTitle: "Container skill installs",
       docsLine: "Docs: https://docs.openclaw.ai/skills",
       enterEnv: "Enter {env}",
       homebrewCommand: "Show Homebrew install command?",

--- a/src/wizard/i18n/locales/zh-CN.ts
+++ b/src/wizard/i18n/locales/zh-CN.ts
@@ -300,6 +300,10 @@ export const zh_CN = {
     },
     skills: {
       configure: "现在配置技能？（推荐）",
+      containerBrewHidden:
+        "在 Linux 容器中会隐藏仅支持 brew 的技能安装项，因为官方镜像不包含 Homebrew。",
+      containerBrewManual: "请使用预装 Homebrew 的自定义镜像，或手动安装这些依赖。",
+      containerInstallsTitle: "容器技能安装",
       docsLine: "文档：https://docs.openclaw.ai/skills",
       enterEnv: "输入 {env}",
       homebrewCommand: "显示 Homebrew 安装命令？",
@@ -422,7 +426,8 @@ export const zh_CN = {
       scanDenied: "用户拒绝授权。改为手动输入。",
       scanError: "注册错误：{error}。改为手动输入。",
       scanExpired: "会话已过期。改为手动输入。",
-      scanQr: "请用手机上的 Lark/飞书扫描二维码。如果手机应用没有反应，请重新运行设置并选择手动输入。",
+      scanQr:
+        "请用手机上的 Lark/飞书扫描二维码。如果手机应用没有反应，请重新运行设置并选择手动输入。",
       scanTimedOut: "扫码超时。改为手动输入。",
       scanTitle: "Feishu 扫码创建",
       scanUnavailable: "当前环境不支持扫码创建。改为手动输入。",

--- a/src/wizard/i18n/locales/zh-TW.ts
+++ b/src/wizard/i18n/locales/zh-TW.ts
@@ -300,6 +300,10 @@ export const zh_TW = {
     },
     skills: {
       configure: "現在設定技能？（建議）",
+      containerBrewHidden:
+        "在 Linux 容器中會隱藏僅支援 brew 的技能安裝項，因為官方映像檔不包含 Homebrew。",
+      containerBrewManual: "請使用預先安裝 Homebrew 的自訂映像檔，或手動安裝這些依賴。",
+      containerInstallsTitle: "容器技能安裝",
       docsLine: "文件：https://docs.openclaw.ai/skills",
       enterEnv: "輸入 {env}",
       homebrewCommand: "顯示 Homebrew 安裝命令？",
@@ -422,7 +426,8 @@ export const zh_TW = {
       scanDenied: "使用者拒絕授權。改為手動輸入。",
       scanError: "註冊錯誤：{error}。改為手動輸入。",
       scanExpired: "工作階段已過期。改為手動輸入。",
-      scanQr: "請用手機上的 Lark/飛書掃描 QR code。如果手機應用程式沒有反應，請重新執行設定並選擇手動輸入。",
+      scanQr:
+        "請用手機上的 Lark/飛書掃描 QR code。如果手機應用程式沒有反應，請重新執行設定並選擇手動輸入。",
       scanTimedOut: "掃碼逾時。改為手動輸入。",
       scanTitle: "Feishu 掃碼建立",
       scanUnavailable: "目前環境不支援掃碼建立。改為手動輸入。",


### PR DESCRIPTION
## Summary

- Hide brew-only skill dependency installers during onboarding when OpenClaw is running in a Linux container without Homebrew.
- Keep brew-backed installers visible when Homebrew is resolvable through the shared Linuxbrew/Homebrew resolver, even if `brew` is not on `PATH`.
- Return container-specific guidance for direct brew-only `installSkill` failures, and document the Docker/manual-install path.

Fixes #14593.

## Reproduction

Current `main` was still affected. I reproduced it on Blacksmith Testbox through Crabbox in a Docker container with no `brew` installed:

- Provider/id: `blacksmith-testbox`, `tbx_01krsj2jcddxqesy4n1bh7j0kc`
- Actions run: https://github.com/openclaw/openclaw/actions/runs/25975835089
- Environment proof: Docker `28.0.4`, container reported `brew absent`
- Failing behavior: direct install for the brew-only `openai-whisper` skill returned the generic missing-brew message:
  `brew not installed — Homebrew is not installed. Install it from https://brew.sh or install "openai-whisper" manually using your system package manager (e.g. apt, dnf, pacman).`

That meant Docker onboarding could still offer brew-only installers even though the official container does not include Homebrew, and the direct install path did not tell container users how to proceed.

## Verification

Behavior addressed: Linux Docker/container installs no longer offer unusable brew-only skill dependency installers during onboarding, and direct brew-only installer attempts return container-specific remediation.

Real environment tested: Blacksmith Testbox through Crabbox, provider `blacksmith-testbox`, id `tbx_01krsk9nz6f0gdht97dxctskfw`, Docker `28.0.4`, nested `node:22-bookworm` container running as the non-root `node` user with no `brew` on `PATH`.

Exact steps or command run after this patch: `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --blacksmith-org openclaw --blacksmith-workflow .github/workflows/ci-check-testbox.yml --blacksmith-job check --blacksmith-ref main --idle-timeout 90m --ttl 240m --timing-json -- bash -lc '<Docker node:22-bookworm repro script that calls setupSkills() and installSkill({ skillName: "openai-whisper", installId: "brew" })>'`

Evidence after fix: https://github.com/openclaw/openclaw/actions/runs/25976226467 printed `container-brew-absent`, `ONBOARDING_PROOF {"noteTitles":["Skills status","Container skill installs"],"multiselectCount":12,"hasWhisperOption":false,"hasContainerNote":true,"hasHomebrewNote":false}`, and `INSTALL_PROOF {"ok":false,"message":"brew not installed — Homebrew is not installed in this Linux container. Build a custom image with Homebrew or install \"openai-whisper\" manually using a supported system package before enabling this skill.","code":null}`.

Observed result after fix: Testbox command exited 0; onboarding hid `openai-whisper` from the installable choices in the no-brew container and direct install returned the Linux-container guidance without linking to the generic Homebrew installer.

What was not tested: A full Docker image rebuild was not run; the proof used a nested Docker container on Blacksmith Testbox with the patched checkout mounted in, plus focused local tests after rebasing onto current `origin/main`.

Additional checks:

- `node scripts/run-vitest.mjs src/commands/onboard-skills.test.ts src/agents/skills-install-fallback.test.ts src/wizard/i18n/index.test.ts`
- `pnpm exec oxfmt --check src/commands/onboard-skills.ts src/agents/skills-install.ts src/commands/onboard-skills.test.ts src/agents/skills-install-fallback.test.ts src/wizard/i18n/locales/en.ts src/wizard/i18n/locales/zh-CN.ts src/wizard/i18n/locales/zh-TW.ts`
- `git diff --check origin/main...HEAD`
- Codex review clean after the resolver-alignment finding was fixed.
