### PR TITLE
fix(agents): harden final assistant payload assembly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ Docs: https://docs.openclaw.ai
 - QQBot: treat only explicit truthy `QQBOT_DEBUG` values as enabling debug logs, so false-like values such as `0` no longer expose debug output. Fixes #82644. (#82697) Thanks @leno23.
 - Agents/session_status: resolve implicit no-arg status lookups against the live run session, so `/think` changes report the current thinking level instead of stale sandbox state. Fixes #82669. (#82696) Thanks @leno23.
 - Discord: keep progress drafts visible for message-tool-only guild replies under the default coding tool profile. Fixes #82747. Thanks @eliranwong.
+- Agents: prefer current structured assistant final answers when assembling final reply payloads, reducing reliance on streamed preview fragments after channel transcript recovery. (#82850) Thanks @joshavant.
 - Discord: keep unmentioned room-event history until a visible Discord send succeeds, so quiet ambient context does not disappear before message-tool delivery. (#82573) Thanks @obviyus.
 - CLI/setup: order the model/auth provider picker as OpenAI, Anthropic, xAI, Google, then the remaining providers alphabetically.
 - Diagnostics/usage/voice-call: treat explicit zero and non-finite limits as empty results and reject invalid voice-call numeric CLI flags. Fixes #82646, #82650, #82651, and #82653. (#82679) Thanks @leno23.

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -2592,6 +2592,7 @@ export async function runEmbeddedPiAgent(
             assistantTexts: attempt.assistantTexts,
             toolMetas: attempt.toolMetas,
             lastAssistant: attempt.lastAssistant,
+            currentAssistant: currentAttemptAssistant ?? null,
             lastToolError: attempt.lastToolError,
             config: params.config,
             isCronTrigger: params.trigger === "cron",

--- a/src/agents/pi-embedded-runner/run/payloads.test-helpers.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test-helpers.ts
@@ -9,6 +9,10 @@ export function buildPayloads(overrides: Partial<BuildPayloadParams> = {}) {
     assistantTexts: [],
     toolMetas: [],
     lastAssistant: undefined,
+    currentAssistant:
+      overrides.currentAssistant === undefined
+        ? overrides.lastAssistant
+        : overrides.currentAssistant,
     isCronTrigger: false,
     sessionKey: "session:telegram",
     inlineToolResultsAllowed: false,

--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -90,6 +90,56 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     expectSinglePayloadText(payloads, "Fixed.");
   });
 
+  it("uses the final assistant answer when streamed text was an incomplete preview", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["Long answer, part one"],
+      lastAssistant: {
+        role: "assistant",
+        stopReason: "stop",
+        content: [
+          {
+            type: "text",
+            text: "Long answer, part one\nLong answer, part two\nLong answer, part three",
+            textSignature: JSON.stringify({
+              v: 1,
+              id: "item_final",
+              phase: "final_answer",
+            }),
+          },
+        ],
+      } as AssistantMessage,
+    });
+
+    expectSinglePayloadText(
+      payloads,
+      "Long answer, part one\nLong answer, part two\nLong answer, part three",
+    );
+  });
+
+  it("keeps a current one-chunk reply when only a stale transcript assistant is available", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["Current room event reply."],
+      currentAssistant: null,
+      lastAssistant: {
+        role: "assistant",
+        stopReason: "stop",
+        content: [
+          {
+            type: "text",
+            text: "Previous transcript reply.",
+            textSignature: JSON.stringify({
+              v: 1,
+              id: "item_previous",
+              phase: "final_answer",
+            }),
+          },
+        ],
+      } as AssistantMessage,
+    });
+
+    expectSinglePayloadText(payloads, "Current room event reply.");
+  });
+
   it("delivers only the final assistant answer when accumulated text includes pre-tool progress", () => {
     const payloads = buildPayloads({
       assistantTexts: ["I'll inspect that first.", "Done."],

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -182,6 +182,7 @@ export function buildEmbeddedRunPayloads(params: {
   assistantTexts: string[];
   toolMetas: ToolMetaEntry[];
   lastAssistant: AssistantMessage | undefined;
+  currentAssistant?: AssistantMessage | null;
   lastToolError?: ToolErrorSummary;
   config?: OpenClawConfig;
   isCronTrigger?: boolean;
@@ -264,16 +265,20 @@ export function buildEmbeddedRunPayloads(params: {
   const useMarkdown = params.toolResultFormat === "markdown";
   const suppressAssistantArtifacts =
     params.didSendDeterministicApprovalPrompt === true || hasSourceReplyPayload;
-  const lastAssistantStopReason = params.lastAssistant?.stopReason;
+  const nonEmptyAssistantTexts = params.assistantTexts.filter((text) => text.trim().length > 0);
+  const currentAssistant = params.currentAssistant ?? undefined;
+  const assistantForPayload =
+    currentAssistant ?? (nonEmptyAssistantTexts.length === 1 ? undefined : params.lastAssistant);
+  const lastAssistantStopReason = assistantForPayload?.stopReason;
   const lastAssistantErrored = lastAssistantStopReason === "error";
   const lastAssistantAborted = lastAssistantStopReason === "aborted";
   const runAborted = params.runAborted === true || lastAssistantAborted;
   const lastAssistantNeedsErrorSurface = lastAssistantErrored || lastAssistantAborted;
   const errorText =
-    params.lastAssistant && lastAssistantNeedsErrorSurface
+    assistantForPayload && lastAssistantNeedsErrorSurface
       ? suppressAssistantArtifacts
         ? undefined
-        : formatAssistantErrorText(params.lastAssistant, {
+        : formatAssistantErrorText(assistantForPayload, {
             cfg: params.config,
             sessionKey: params.sessionKey,
             provider: params.provider,
@@ -281,7 +286,7 @@ export function buildEmbeddedRunPayloads(params: {
           })
       : undefined;
   const rawErrorMessage = lastAssistantNeedsErrorSurface
-    ? normalizeOptionalString(params.lastAssistant?.errorMessage)
+    ? normalizeOptionalString(assistantForPayload?.errorMessage)
     : undefined;
   const rawErrorFingerprint = rawErrorMessage
     ? getApiErrorPayloadFingerprint(rawErrorMessage)
@@ -333,17 +338,17 @@ export function buildEmbeddedRunPayloads(params: {
   const reasoningText =
     suppressAssistantArtifacts || runAborted
       ? ""
-      : params.lastAssistant && params.reasoningLevel === "on" && params.thinkingLevel !== "off"
-        ? extractAssistantThinking(params.lastAssistant)
+      : assistantForPayload && params.reasoningLevel === "on" && params.thinkingLevel !== "off"
+        ? extractAssistantThinking(assistantForPayload)
         : "";
   if (reasoningText) {
     replyItems.push({ text: reasoningText, isReasoning: true });
   }
 
-  const fallbackAnswerText = params.lastAssistant
-    ? extractAssistantVisibleText(params.lastAssistant)
+  const fallbackAnswerText = assistantForPayload
+    ? extractAssistantVisibleText(assistantForPayload)
     : "";
-  const fallbackRawAnswerText = resolveRawAssistantAnswerText(params.lastAssistant);
+  const fallbackRawAnswerText = resolveRawAssistantAnswerText(assistantForPayload);
   const shouldSuppressRawErrorText = (text: string) => {
     if (!lastAssistantNeedsErrorSurface) {
       return false;
@@ -403,7 +408,6 @@ export function buildEmbeddedRunPayloads(params: {
     const parsed = parseReplyDirectives(text);
     return (parsed.mediaUrls?.length ?? 0) > 0 || parsed.audioAsVoice;
   });
-  const nonEmptyAssistantTexts = params.assistantTexts.filter((text) => text.trim().length > 0);
   const normalizedAssistantTexts = normalizeTextForComparison(nonEmptyAssistantTexts.join("\n\n"));
   const normalizedRawAnswerText = normalizeTextForComparison(rawAnswerDirectiveState?.text ?? "");
   const shouldPreferRawAnswerText =
@@ -418,7 +422,7 @@ export function buildEmbeddedRunPayloads(params: {
     ? normalizeReplyTextForComparison(fallbackAnswerSourceText)
     : "";
   const shouldUseCanonicalFinalAnswer =
-    nonEmptyAssistantTexts.length > 1 &&
+    !lastAssistantNeedsErrorSurface &&
     fallbackAnswerSourceText.length > 0 &&
     normalizedFallbackAnswerSourceText.length > 0;
   const hasAssistantTextPayload = nonEmptyAssistantTexts.length > 0;


### PR DESCRIPTION
Summary
- Follow up #82862 by hardening embedded agent final payload assembly so completed current-turn assistant answers are preferred over streamed preview fragments.
- Pass the current attempt assistant into `buildEmbeddedRunPayloads`, while avoiding stale transcript assistants for current one-chunk replies.
- Keep error/abort surfaces on their existing error path and add focused regressions for incomplete streamed text and stale assistant fallback.

Verification
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/agents/pi-embedded-runner/run.ts src/agents/pi-embedded-runner/run/payloads.ts src/agents/pi-embedded-runner/run/payloads.test.ts src/agents/pi-embedded-runner/run/payloads.test-helpers.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/payloads.test.ts src/agents/pi-embedded-runner/run/payloads.errors.test.ts extensions/discord/src/monitor/message-handler.process.test.ts`
- `pnpm check:changed`

Real behavior proof:
Behavior addressed: Follow-up hardening for #82862: final reply payload assembly now uses the completed current-turn structured assistant final answer when available, reducing reliance on streamed preview fragments before channel-level transcript recovery is needed.
Real environment tested: Local source checkout rebased on current `origin/main`, which includes #82862.
Exact steps or command run after this patch: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/payloads.test.ts src/agents/pi-embedded-runner/run/payloads.errors.test.ts extensions/discord/src/monitor/message-handler.process.test.ts`; `pnpm check:changed`.
Evidence after fix: Payload regressions assert an incomplete streamed preview is replaced by the structured final answer, and a stale transcript assistant does not override a current one-chunk reply; Discord process tests still pass on top of #82862.
Observed result after fix: Focused Vitest passed with 3 files and 137 tests; `pnpm check:changed` passed.
What was not tested: No new live Discord E2E in this follow-up PR; #82862 remains the issue-specific Discord recovery fix for #82807.

Refs #82807
Follow-up to #82862
