### PR TITLE
fix: add WhatsApp document fallback extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - WhatsApp: honor forced document delivery for outbound image, GIF, and video media so `forceDocument`/`asDocument` sends preserve original media bytes instead of using compressed media payloads. (#79272) Thanks @itsuzef.
+- WhatsApp: name outbound document attachments from their MIME type when no filename is provided, so PDF and CSV sends arrive as `file.pdf` and `file.csv` instead of an extensionless `file`. Thanks @mcaxtr.
 
 ## 2026.5.17
 

--- a/extensions/whatsapp/src/document-filename.ts
+++ b/extensions/whatsapp/src/document-filename.ts
@@ -1,0 +1,17 @@
+import { extensionForMime } from "openclaw/plugin-sdk/media-mime";
+
+const WHATSAPP_DEFAULT_DOCUMENT_FILE_NAME = "file";
+
+export function resolveWhatsAppDefaultDocumentFileName(mimetype?: string): string {
+  const extension = extensionForMime(mimetype);
+  return extension
+    ? `${WHATSAPP_DEFAULT_DOCUMENT_FILE_NAME}${extension}`
+    : WHATSAPP_DEFAULT_DOCUMENT_FILE_NAME;
+}
+
+export function resolveWhatsAppDocumentFileName(params: {
+  fileName?: string;
+  mimetype?: string;
+}): string {
+  return params.fileName?.trim() || resolveWhatsAppDefaultDocumentFileName(params.mimetype);
+}

--- a/extensions/whatsapp/src/inbound/send-api.test.ts
+++ b/extensions/whatsapp/src/inbound/send-api.test.ts
@@ -111,15 +111,39 @@ describe("createWebSendApi", () => {
     });
   });
 
-  it("falls back to default document filename when fileName is absent", async () => {
+  it("falls back to a MIME-aware document filename when fileName is absent", async () => {
     const payload = Buffer.from("pdf");
     await api.sendMessage("+1555", "doc", payload, "application/pdf");
     expectFirstSendJid("1555@s.whatsapp.net");
     expectSendContentFields(0, {
       document: payload,
-      fileName: "file",
+      fileName: "file.pdf",
       caption: "doc",
       mimetype: "application/pdf",
+    });
+  });
+
+  it("uses MIME mappings for text document filename fallbacks", async () => {
+    const payload = Buffer.from("a,b\n1,2\n");
+    await api.sendMessage("+1555", "doc", payload, "text/csv");
+
+    expectSendContentFields(0, {
+      document: payload,
+      fileName: "file.csv",
+      caption: "doc",
+      mimetype: "text/csv",
+    });
+  });
+
+  it("keeps the plain default document filename when MIME has no extension mapping", async () => {
+    const payload = Buffer.from("unknown");
+    await api.sendMessage("+1555", "doc", payload, "application/x-custom");
+
+    expectSendContentFields(0, {
+      document: payload,
+      fileName: "file",
+      caption: "doc",
+      mimetype: "application/x-custom",
     });
   });
 
@@ -134,6 +158,23 @@ describe("createWebSendApi", () => {
       expect.objectContaining({
         document: payload,
         fileName: "promo.png",
+        caption: "promo",
+        mimetype: "image/png",
+      }),
+    );
+  });
+
+  it("uses MIME-aware filename fallback for forced visual documents", async () => {
+    const payload = Buffer.from("img");
+    await api.sendMessage("+1555", "promo", payload, "image/png", {
+      asDocument: true,
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      "1555@s.whatsapp.net",
+      expect.objectContaining({
+        document: payload,
+        fileName: "file.png",
         caption: "promo",
         mimetype: "image/png",
       }),

--- a/extensions/whatsapp/src/inbound/send-api.ts
+++ b/extensions/whatsapp/src/inbound/send-api.ts
@@ -5,6 +5,7 @@ import type {
   WAPresence,
 } from "baileys";
 import { recordChannelActivity } from "openclaw/plugin-sdk/channel-activity-runtime";
+import { resolveWhatsAppDocumentFileName } from "../document-filename.js";
 import { isWhatsAppNewsletterJid } from "../normalize.js";
 import { buildQuotedMessageOptions } from "../quoted-message.js";
 import { toWhatsappJid, toWhatsappJidWithLid } from "../text-runtime.js";
@@ -84,7 +85,10 @@ export function createWebSendApi(params: {
         : await resolveMentions(jid, text);
       if (mediaBuffer && mediaType) {
         if (sendOptions?.asDocument === true && supportsForcedDocumentMediaType(mediaType)) {
-          const fileName = sendOptions?.fileName?.trim() || "file";
+          const fileName = resolveWhatsAppDocumentFileName({
+            fileName: sendOptions?.fileName,
+            mimetype: mediaType,
+          });
           payload = {
             document: mediaBuffer,
             fileName,
@@ -108,7 +112,10 @@ export function createWebSendApi(params: {
             ...(gifPlayback ? { gifPlayback: true } : {}),
           };
         } else {
-          const fileName = sendOptions?.fileName?.trim() || "file";
+          const fileName = resolveWhatsAppDocumentFileName({
+            fileName: sendOptions?.fileName,
+            mimetype: mediaType,
+          });
           payload = {
             document: mediaBuffer,
             fileName,

--- a/extensions/whatsapp/src/outbound-media-contract.ts
+++ b/extensions/whatsapp/src/outbound-media-contract.ts
@@ -3,6 +3,7 @@ import { MEDIA_FFMPEG_MAX_AUDIO_DURATION_SECS, runFfmpeg } from "openclaw/plugin
 import { sanitizeForPlainText } from "openclaw/plugin-sdk/outbound-runtime";
 import { writeExternalFileWithinRoot } from "openclaw/plugin-sdk/security-runtime";
 import { resolvePreferredOpenClawTmpDir, withTempWorkspace } from "openclaw/plugin-sdk/temp-path";
+import { resolveWhatsAppDocumentFileName } from "./document-filename.js";
 import { formatError } from "./session-errors.js";
 import {
   sanitizeAssistantVisibleText,
@@ -123,7 +124,10 @@ function normalizeWhatsAppLoadedMedia(
       : (media.contentType ?? "application/octet-stream");
   const fileName =
     kind === "document"
-      ? (media.fileName ?? deriveWhatsAppDocumentFileName(mediaUrl) ?? "file")
+      ? resolveWhatsAppDocumentFileName({
+          fileName: media.fileName ?? deriveWhatsAppDocumentFileName(mediaUrl),
+          mimetype,
+        })
       : media.fileName;
   return {
     buffer: media.buffer,

--- a/extensions/whatsapp/src/send.test.ts
+++ b/extensions/whatsapp/src/send.test.ts
@@ -452,6 +452,23 @@ describe("web outbound", () => {
     });
   });
 
+  it("maps documents without fileName to MIME-aware default filename", async () => {
+    const buf = Buffer.from("pdf");
+    loadWebMediaMock.mockResolvedValueOnce({
+      buffer: buf,
+      contentType: "application/pdf",
+      kind: "document",
+    });
+    await sendMessageWhatsApp("+1555", "doc", {
+      verbose: false,
+      cfg: WHATSAPP_TEST_CFG,
+      mediaUrl: "media://generated",
+    });
+    expect(sendMessage).toHaveBeenLastCalledWith("+1555", "doc", buf, "application/pdf", {
+      fileName: "file.pdf",
+    });
+  });
+
   it("forces document branch when forceDocument is true with image media", async () => {
     const buf = Buffer.from("img");
     loadWebMediaMock.mockResolvedValueOnce({
@@ -511,7 +528,7 @@ describe("web outbound", () => {
     });
     expect(sendMessage).toHaveBeenLastCalledWith("+1555", "promo", buf, "image/png", {
       asDocument: true,
-      fileName: "file",
+      fileName: "file.png",
     });
   });
 

--- a/extensions/whatsapp/src/send.ts
+++ b/extensions/whatsapp/src/send.ts
@@ -15,6 +15,7 @@ import {
   resolveWhatsAppMediaMaxBytes,
 } from "./accounts.js";
 import { getRegisteredWhatsAppConnectionController } from "./connection-controller-registry.js";
+import { resolveWhatsAppDocumentFileName } from "./document-filename.js";
 import type { ActiveWebListener, ActiveWebSendOptions } from "./inbound/types.js";
 import { isWhatsAppNewsletterJid } from "./normalize.js";
 import {
@@ -151,7 +152,10 @@ export async function sendMessageWhatsApp(
         text = caption ?? "";
       }
       if (forceDocumentDelivery) {
-        documentFileName ??= media.fileName ?? "file";
+        documentFileName ??= resolveWhatsAppDocumentFileName({
+          fileName: media.fileName,
+          mimetype: media.mimetype,
+        });
       }
     }
     outboundLog.info(`Sending message -> ${redactedJid}${primaryMediaUrl ? " (media)" : ""}`);


### PR DESCRIPTION
## Summary

- Add a shared WhatsApp document filename helper that preserves explicit filenames and falls back to MIME-aware defaults.
- Use the helper for normal document sends and forced image/video-as-document sends.
- Add regressions for PDF, CSV, unknown MIME, and forced visual document fallbacks.

## Verification

- `node scripts/test-projects.mjs extensions/whatsapp/src/inbound/send-api.test.ts extensions/whatsapp/src/send.test.ts -- --reporter=verbose`
- `git diff --check`
- `.agents/skills/codex-review/scripts/codex-review`

## Real behavior proof

Behavior addressed: WhatsApp document sends without explicit filenames now use MIME-aware fallback names such as `file.pdf`, `file.csv`, and `file.png` instead of extensionless `file`.

Real environment tested: Local OpenClaw WhatsApp plugin send-path tests in a linked worktree.

Exact steps or command run after this patch: `node scripts/test-projects.mjs extensions/whatsapp/src/inbound/send-api.test.ts extensions/whatsapp/src/send.test.ts -- --reporter=verbose`

Evidence after fix: The focused WhatsApp tests passed 59 tests across 2 files, including new assertions for `application/pdf` -> `file.pdf`, `text/csv` -> `file.csv`, unknown MIME -> `file`, and forced `image/png` document delivery -> `file.png`.

Observed result after fix: OpenClaw builds WhatsApp document payloads with extension-bearing fallback filenames whenever the MIME map has a known extension, while preserving explicit filenames.

What was not tested: I did not live-send to a real WhatsApp recipient; the proof covers the payload metadata passed to the WhatsApp provider boundary.
