### PR TITLE
fix(channels): show missing configured plugins in list

### DIFF
--- a/src/commands/channels.list.test.ts
+++ b/src/commands/channels.list.test.ts
@@ -17,6 +17,8 @@ const mocks = vi.hoisted(() => ({
   isCatalogChannelInstalled: vi.fn<(params: { entry: ChannelPluginCatalogEntry }) => boolean>(
     () => true,
   ),
+  listExplicitConfiguredChannelIdsForConfig: vi.fn<() => string[]>(() => []),
+  resolveMissingOfficialExternalChannelPluginRepairHint: vi.fn(),
   callGateway: vi.fn(),
   resolveAgentWorkspaceDir: vi.fn(() => "/tmp/workspace"),
   resolveDefaultAgentId: vi.fn(() => "main"),
@@ -52,6 +54,15 @@ vi.mock("./channel-setup/trusted-catalog.js", () => ({
 
 vi.mock("./channel-setup/discovery.js", () => ({
   isCatalogChannelInstalled: mocks.isCatalogChannelInstalled,
+}));
+
+vi.mock("../plugins/channel-plugin-ids.js", () => ({
+  listExplicitConfiguredChannelIdsForConfig: mocks.listExplicitConfiguredChannelIdsForConfig,
+}));
+
+vi.mock("../plugins/official-external-plugin-repair-hints.js", () => ({
+  resolveMissingOfficialExternalChannelPluginRepairHint:
+    mocks.resolveMissingOfficialExternalChannelPluginRepairHint,
 }));
 
 vi.mock("../agents/agent-scope.js", () => ({
@@ -120,6 +131,10 @@ describe("channels list", () => {
     mocks.listTrustedChannelPluginCatalogEntries.mockReturnValue([]);
     mocks.isCatalogChannelInstalled.mockReset();
     mocks.isCatalogChannelInstalled.mockReturnValue(true);
+    mocks.listExplicitConfiguredChannelIdsForConfig.mockReset();
+    mocks.listExplicitConfiguredChannelIdsForConfig.mockReturnValue([]);
+    mocks.resolveMissingOfficialExternalChannelPluginRepairHint.mockReset();
+    mocks.resolveMissingOfficialExternalChannelPluginRepairHint.mockReturnValue(null);
     mocks.callGateway.mockReset();
     mocks.callGateway.mockRejectedValue(new Error("gateway unavailable"));
   });
@@ -353,6 +368,51 @@ describe("channels list", () => {
     expect(output).not.toContain("QQ Bot");
     // Hint user about --all
     expect(output).toContain("--all");
+  });
+
+  it("shows configured official external channels when their plugin is missing", async () => {
+    const runtime = createTestRuntime();
+    mocks.listReadOnlyChannelPluginsForConfig.mockReturnValue([]);
+    mocks.listExplicitConfiguredChannelIdsForConfig.mockReturnValue(["discord"]);
+    mocks.resolveMissingOfficialExternalChannelPluginRepairHint.mockReturnValue({
+      pluginId: "@openclaw/discord",
+      channelId: "discord",
+      label: "Discord",
+      installSpec: "@openclaw/discord",
+      installCommand: "openclaw plugins install @openclaw/discord",
+      doctorFixCommand: "openclaw doctor --fix",
+      repairHint:
+        "Install the official external plugin with: openclaw plugins install @openclaw/discord, or run: openclaw doctor --fix.",
+    });
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      ...baseConfigSnapshot,
+      config: {
+        channels: {
+          discord: { enabled: true },
+        },
+      },
+    });
+
+    await channelsListCommand({}, runtime);
+
+    const output = stripAnsi(loggedText(runtime));
+    expect(output).toContain("Discord");
+    expect(output).toContain("not installed");
+    expect(output).toContain("configured");
+    expect(output).toContain("openclaw plugins install");
+    expect(output).toContain("openclaw doctor --fix");
+    expect(output).not.toContain("no configured chat channels");
+
+    runtime.log.mockClear();
+    await channelsListCommand({ json: true }, runtime);
+    const payload = JSON.parse(loggedText(runtime)) as {
+      chat: Record<string, { accounts: string[]; installed: boolean; origin: string }>;
+    };
+    expect(payload.chat.discord).toEqual({
+      accounts: [],
+      installed: false,
+      origin: "configured",
+    });
   });
 
   it("--all surfaces uninstalled catalog channels with installed=false / not configured / not enabled", async () => {

--- a/src/commands/channels/list.ts
+++ b/src/commands/channels/list.ts
@@ -11,6 +11,11 @@ import {
   type RuntimeChannelStatusPayload,
 } from "../../channels/status/read-model.js";
 import { callGateway } from "../../gateway/call.js";
+import { listExplicitConfiguredChannelIdsForConfig } from "../../plugins/channel-plugin-ids.js";
+import {
+  type OfficialExternalPluginRepairHint,
+  resolveMissingOfficialExternalChannelPluginRepairHint,
+} from "../../plugins/official-external-plugin-repair-hints.js";
 import { defaultRuntime, type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
 import { formatDocsLink } from "../../terminal/links.js";
 import { theme } from "../../terminal/theme.js";
@@ -135,6 +140,19 @@ function formatCatalogOnlyLine(params: {
   return `- ${channelText}: ${bits.join(", ")}`;
 }
 
+function formatMissingConfiguredExternalChannelLine(
+  hint: OfficialExternalPluginRepairHint,
+): string {
+  const channelText = theme.accent(hint.label);
+  const bits = [
+    formatInstalled(false),
+    formatConfigured(true),
+    formatEnabled(true),
+    theme.warn(`run ${hint.installCommand} or ${hint.doctorFixCommand}`),
+  ];
+  return `- ${channelText}: ${bits.join(", ")}`;
+}
+
 export async function channelsListCommand(
   opts: ChannelsListOptions,
   runtime: RuntimeEnv = defaultRuntime,
@@ -229,6 +247,25 @@ export async function channelsListCommand(
     });
   }
 
+  const missingConfiguredExternalChannelHints: OfficialExternalPluginRepairHint[] = [];
+  for (const channelId of listExplicitConfiguredChannelIdsForConfig(cfg).toSorted((left, right) =>
+    left.localeCompare(right),
+  )) {
+    if (renderedChannelIds.has(channelId)) {
+      continue;
+    }
+    const hint = resolveMissingOfficialExternalChannelPluginRepairHint({
+      config: cfg,
+      channelId,
+      ...(workspaceDir ? { workspaceDir } : {}),
+    });
+    if (!hint?.channelId || renderedChannelIds.has(hint.channelId)) {
+      continue;
+    }
+    missingConfiguredExternalChannelHints.push(hint);
+    renderedChannelIds.add(hint.channelId);
+  }
+
   // --all also surfaces catalog entries that are not already represented
   // by a plugin row above. Two shapes land here:
   //   1. Catalog plugin package is not yet installed on disk — rendered as
@@ -268,6 +305,16 @@ export async function channelsListCommand(
         };
       }
     }
+    for (const hint of missingConfiguredExternalChannelHints) {
+      if (!hint.channelId) {
+        continue;
+      }
+      chat[hint.channelId] = {
+        accounts: [],
+        installed: false,
+        origin: "configured",
+      };
+    }
     if (showAll) {
       for (const entry of catalogOnlyLines) {
         const installed = isInstalled(entry.id);
@@ -284,7 +331,11 @@ export async function channelsListCommand(
 
   const lines: string[] = [];
   lines.push(theme.heading("Chat channels:"));
-  if (accountLines.length === 0 && catalogOnlyLines.length === 0) {
+  if (
+    accountLines.length === 0 &&
+    missingConfiguredExternalChannelHints.length === 0 &&
+    catalogOnlyLines.length === 0
+  ) {
     lines.push(
       theme.muted(
         showAll
@@ -301,6 +352,9 @@ export async function channelsListCommand(
           installed: line.installed,
         }),
       );
+    }
+    for (const hint of missingConfiguredExternalChannelHints) {
+      lines.push(formatMissingConfiguredExternalChannelLine(hint));
     }
     for (const entry of catalogOnlyLines) {
       lines.push(


### PR DESCRIPTION
## Summary

- Detect configured official external channel IDs that did not resolve to a loaded channel plugin.
- Render those channels in `openclaw channels list` as configured but not installed, with `openclaw plugins install ...` / `openclaw doctor --fix` guidance.
- Include the same missing configured channel in JSON output as `origin: "configured"` and `installed: false`.
- Add regression coverage for the configured Discord / missing plugin case.

## Test Plan

- `pnpm install`
- `pnpm --config.verify-deps-before-run=false exec oxfmt --check --threads=1 src/commands/channels/list.ts src/commands/channels.list.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_TEST_PROJECTS_PARALLEL=1 node scripts/run-vitest.mjs src/commands/channels.list.test.ts -- -t "configured official external channels" --pool=forks --poolOptions.forks.singleFork=true --reporter=dot`
- `pnpm --config.verify-deps-before-run=false test src/commands/channels.list.test.ts -- --reporter=dot`
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false npm_config_verify_deps_before_run=false pnpm --config.verify-deps-before-run=false check:changed --staged`

## Real behavior proof

Behavior addressed: Fixes #82813. A configured official external channel whose plugin package is absent should still appear in `openclaw channels list`; it should not be hidden behind `no configured chat channels`.

Real environment tested: Local source checkout on macOS with Node 22.18.0 and pnpm 11.1.0, using an isolated `OPENCLAW_HOME`, `OPENCLAW_STATE_DIR`, and `OPENCLAW_CONFIG_PATH`. `OPENCLAW_DISABLE_BUNDLED_PLUGINS=1` simulates the upgraded install where the official external Discord plugin is not present on disk.

Exact steps or command run after this patch: Created `.tmp/channels-missing-plugin-proof/openclaw.json` with `{ "channels": { "discord": { "enabled": true } } }`, then ran:

```bash
NO_COLOR=1 HOME="$PWD/.tmp/channels-missing-plugin-proof/home" \
  OPENCLAW_HOME="$PWD/.tmp/channels-missing-plugin-proof/home" \
  OPENCLAW_STATE_DIR="$PWD/.tmp/channels-missing-plugin-proof/state" \
  OPENCLAW_CONFIG_PATH="$PWD/.tmp/channels-missing-plugin-proof/openclaw.json" \
  OPENCLAW_DISABLE_BUNDLED_PLUGINS=1 \
  pnpm openclaw channels list

NO_COLOR=1 HOME="$PWD/.tmp/channels-missing-plugin-proof/home" \
  OPENCLAW_HOME="$PWD/.tmp/channels-missing-plugin-proof/home" \
  OPENCLAW_STATE_DIR="$PWD/.tmp/channels-missing-plugin-proof/state" \
  OPENCLAW_CONFIG_PATH="$PWD/.tmp/channels-missing-plugin-proof/openclaw.json" \
  OPENCLAW_DISABLE_BUNDLED_PLUGINS=1 \
  pnpm openclaw channels list --json
```

Evidence after fix: Copied terminal output from the real CLI invocation:

```text
$ node scripts/run-node.mjs channels list
gateway connect failed: GatewayClientRequestError: protocol mismatch
Chat channels:
- Discord: not installed, configured, enabled, run openclaw plugins install @openclaw/discord or openclaw doctor --fix

Model provider usage moved out of `channels list` — see `openclaw status` or `openclaw models list`.
Docs: https://docs.openclaw.ai/gateway/configuration
$ node scripts/run-node.mjs channels list --json
{
  "chat": {
    "discord": {
      "accounts": [],
      "installed": false,
      "origin": "configured"
    }
  }
}
```

Observed result after fix: The real CLI output shows `Discord` under `Chat channels`, marks it `not installed` and `configured`, includes the repair command `openclaw plugins install @openclaw/discord` plus `openclaw doctor --fix`, and JSON returns `chat.discord.installed: false` with `origin: "configured"`.

What was not tested: I did not run a live upgraded Discord gateway with real Discord credentials. This patch is limited to the CLI diagnostic/listing path and uses existing official external plugin repair hint plumbing.

## Risk/Notes

- Low risk: this only affects `channels list` rendering/JSON for configured official external channels whose plugin owner is missing.
- The gateway connection warning in the real proof is from the local dev gateway mismatch and did not prevent command-local channel listing.

Closes #82813.

## AI usage disclosure

This PR was prepared with AI assistance. I inspected the issue, existing OpenClaw channel/status repair code, implemented the focused change, and ran the validation commands listed above.
