### PR TITLE
fix: preserve Signal group session IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 - Memory-core: scan persisted memory source sessions on startup, comparing on-disk transcripts against the index and marking only missing/newer/resized files dirty for incremental sync. Fixes #82341. (#82341) Thanks @giodl73-repo.
 - Telegram: keep the top-level default account in the account list when named accounts or bindings are added alongside top-level credentials, preserving default polling while still letting named-only configs resolve to a single account. Fixes #82794. (#82794) Thanks @giodl73-repo.
 - CLI/channels: show configured official external channels such as Discord in `openclaw channels list` when their plugin package is missing, including the install and doctor repair command instead of reporting no configured channels. Fixes #82813.
+- Signal: preserve mixed-case group IDs through routing and session persistence so group auto-replies keep delivering after updates. Fixes #82827.
 - WhatsApp: honor forced document delivery for outbound image, GIF, and video media so `forceDocument`/`asDocument` sends preserve original media bytes instead of using compressed media payloads. (#79272) Thanks @itsuzef.
 - WhatsApp: name outbound document attachments from their MIME type when no filename is provided, so PDF and CSV sends arrive as `file.pdf` and `file.csv` instead of an extensionless `file`. Thanks @mcaxtr.
 

--- a/src/channels/session.test.ts
+++ b/src/channels/session.test.ts
@@ -111,6 +111,37 @@ describe("recordInboundSession", () => {
     expect(route.ctx).toBe(ctx);
   });
 
+  it("preserves Signal group ids before recording and route updates", async () => {
+    const mixedGroupId = "VWATodkf2hc8zdOS76q9Tb0+5Bi522E03qLdaQ/9ypg=";
+    const signalCtx: MsgContext = {
+      Provider: "signal",
+      ChatType: "group",
+      From: `signal:group:${mixedGroupId}`,
+      To: `signal:group:${mixedGroupId}`,
+      SessionKey: `agent:main:signal:group:${mixedGroupId}`,
+      OriginatingTo: `signal:group:${mixedGroupId}`,
+    };
+
+    await recordInboundSession({
+      storePath: "/tmp/openclaw-session-store.json",
+      sessionKey: `Agent:Main:Signal:Group:${mixedGroupId}`,
+      ctx: signalCtx,
+      updateLastRoute: {
+        sessionKey: `Agent:Main:Signal:Group:${mixedGroupId}`,
+        channel: "signal",
+        to: `signal:group:${mixedGroupId}`,
+      },
+      onRecordError: vi.fn(),
+    });
+
+    expect(requireFirstCallArg(recordSessionMetaFromInboundMock).sessionKey).toBe(
+      `agent:main:signal:group:${mixedGroupId}`,
+    );
+    const route = requireFirstCallArg(updateLastRouteMock);
+    expect(route.sessionKey).toBe(`agent:main:signal:group:${mixedGroupId}`);
+    expect(route.ctx).toBe(signalCtx);
+  });
+
   it("skips last-route updates when main DM owner pin mismatches sender", async () => {
     const onSkip = vi.fn();
 

--- a/src/channels/session.ts
+++ b/src/channels/session.ts
@@ -1,5 +1,6 @@
 import type { MsgContext } from "../auto-reply/templating.js";
 import type { GroupKeyResolution } from "../config/sessions/types.js";
+import { normalizeSessionKeyPreservingOpaquePeerIds } from "../sessions/session-key-utils.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import type { InboundLastRouteUpdate } from "./session.types.js";
 export type { InboundLastRouteUpdate, RecordInboundSession } from "./session.types.js";
@@ -39,7 +40,7 @@ export async function recordInboundSession(params: {
   trackSessionMetaTask?: (task: Promise<unknown>) => void;
 }): Promise<void> {
   const { storePath, sessionKey, ctx, groupResolution, createIfMissing } = params;
-  const canonicalSessionKey = normalizeLowercaseStringOrEmpty(sessionKey);
+  const canonicalSessionKey = normalizeSessionKeyPreservingOpaquePeerIds(sessionKey);
   const runtime = await loadInboundSessionRuntime();
   const metaTask = runtime
     .recordSessionMetaFromInbound({
@@ -60,7 +61,7 @@ export async function recordInboundSession(params: {
   if (shouldSkipPinnedMainDmRouteUpdate(update.mainDmOwnerPin)) {
     return;
   }
-  const targetSessionKey = normalizeLowercaseStringOrEmpty(update.sessionKey);
+  const targetSessionKey = normalizeSessionKeyPreservingOpaquePeerIds(update.sessionKey);
   await runtime.updateLastRoute({
     storePath,
     sessionKey: targetSessionKey,

--- a/src/config/sessions/delivery-info.test.ts
+++ b/src/config/sessions/delivery-info.test.ts
@@ -371,6 +371,28 @@ describe("extractDeliveryInfo", () => {
     });
   });
 
+  it("finds legacy lowercase Signal group entries for mixed-case group keys", () => {
+    const mixedGroupId = "VWATodkf2hc8zdOS76q9Tb0+5Bi522E03qLdaQ/9ypg=";
+    const queriedKey = `agent:main:signal:group:${mixedGroupId}`;
+    const legacyKey = queriedKey.toLowerCase();
+    storeState.store[legacyKey] = buildEntry({
+      channel: "signal",
+      to: `signal:group:${mixedGroupId}`,
+      accountId: "default",
+    });
+
+    const result = extractDeliveryInfo(queriedKey);
+
+    expect(result).toEqual({
+      deliveryContext: {
+        channel: "signal",
+        to: `signal:group:${mixedGroupId}`,
+        accountId: "default",
+      },
+      threadId: undefined,
+    });
+  });
+
   it("prefers the freshest routable alias even when the normalized key is already routable", () => {
     const queriedKey = "agent:main:matrix:channel:!MiXeDCase:Example.Org";
     const canonicalKey = "agent:main:matrix:channel:!mixedcase:example.org";

--- a/src/config/sessions/delivery-info.ts
+++ b/src/config/sessions/delivery-info.ts
@@ -7,6 +7,7 @@ import { deliveryContextFromSession } from "../../utils/delivery-context.shared.
 import { getRuntimeConfig } from "../io.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 import { resolveStorePath } from "./paths.js";
+import { normalizeStoreSessionKey } from "./store-entry.js";
 import { loadSessionStore } from "./store.js";
 import { resolveAllAgentSessionStoreTargetsSync } from "./targets.js";
 import { parseSessionThreadInfo } from "./thread-info.js";
@@ -104,13 +105,23 @@ function findSessionEntryInStore(
   };
   for (const key of keys) {
     const trimmed = key.trim();
-    const normalized = normalizeLowercaseStringOrEmpty(key);
+    const normalized = normalizeStoreSessionKey(key);
+    const foldedLegacyKey = normalizeLowercaseStringOrEmpty(normalized);
     let foundRoutableCandidate = false;
     if (Object.prototype.hasOwnProperty.call(store, normalized)) {
       foundRoutableCandidate ||= hasRoutableDeliveryContext(
         deliveryContextFromSession(store[normalized]),
       );
       acceptCandidate(store[normalized]);
+    }
+    if (
+      foldedLegacyKey !== normalized &&
+      Object.prototype.hasOwnProperty.call(store, foldedLegacyKey)
+    ) {
+      foundRoutableCandidate ||= hasRoutableDeliveryContext(
+        deliveryContextFromSession(store[foldedLegacyKey]),
+      );
+      acceptCandidate(store[foldedLegacyKey]);
     }
     if (trimmed !== normalized && Object.prototype.hasOwnProperty.call(store, trimmed)) {
       foundRoutableCandidate ||= hasRoutableDeliveryContext(
@@ -122,6 +133,9 @@ function findSessionEntryInStore(
       normalizedIndex ??= buildFreshestSessionEntryIndex(store);
       const freshest = normalizedIndex.get(normalized);
       acceptCandidate(freshest);
+      if (foldedLegacyKey !== normalized) {
+        acceptCandidate(normalizedIndex.get(foldedLegacyKey));
+      }
     }
   }
   return bestEntry;
@@ -132,7 +146,7 @@ function buildFreshestSessionEntryIndex(
 ): Map<string, SessionEntry> {
   const index = new Map<string, SessionEntry>();
   for (const [key, entry] of Object.entries(store)) {
-    const normalized = normalizeLowercaseStringOrEmpty(key);
+    const normalized = normalizeStoreSessionKey(key);
     const existing = index.get(normalized);
     const entryRoutable = hasRoutableDeliveryContext(deliveryContextFromSession(entry));
     const existingRoutable = hasRoutableDeliveryContext(deliveryContextFromSession(existing));
@@ -142,6 +156,22 @@ function buildFreshestSessionEntryIndex(
       (entryRoutable === existingRoutable && (entry.updatedAt ?? 0) > (existing.updatedAt ?? 0))
     ) {
       index.set(normalized, entry);
+    }
+    const foldedLegacyKey = normalizeLowercaseStringOrEmpty(normalized);
+    if (foldedLegacyKey === normalized) {
+      continue;
+    }
+    const foldedExisting = index.get(foldedLegacyKey);
+    const foldedExistingRoutable = hasRoutableDeliveryContext(
+      deliveryContextFromSession(foldedExisting),
+    );
+    if (
+      !foldedExisting ||
+      (entryRoutable && !foldedExistingRoutable) ||
+      (entryRoutable === foldedExistingRoutable &&
+        (entry.updatedAt ?? 0) > (foldedExisting.updatedAt ?? 0))
+    ) {
+      index.set(foldedLegacyKey, entry);
     }
   }
   return index;

--- a/src/config/sessions/explicit-session-key-normalization.test.ts
+++ b/src/config/sessions/explicit-session-key-normalization.test.ts
@@ -56,4 +56,19 @@ describe("normalizeExplicitSessionKey", () => {
       ),
     ).toBe("agent:fina:slack:dm:abc");
   });
+
+  it("preserves Signal group ids when explicit session keys are canonicalized", () => {
+    const mixedGroupId = "VWATodkf2hc8zdOS76q9Tb0+5Bi522E03qLdaQ/9ypg=";
+    expect(
+      normalizeExplicitSessionKey(
+        `Agent:Main:Signal:Group:${mixedGroupId}`,
+        makeCtx({
+          Provider: "signal",
+          ChatType: "group",
+          From: `signal:group:${mixedGroupId}`,
+          OriginatingTo: `signal:group:${mixedGroupId}`,
+        }),
+      ),
+    ).toBe(`agent:main:signal:group:${mixedGroupId}`);
+  });
 });

--- a/src/config/sessions/explicit-session-key-normalization.ts
+++ b/src/config/sessions/explicit-session-key-normalization.ts
@@ -1,5 +1,6 @@
 import type { MsgContext } from "../../auto-reply/templating.js";
 import { getLoadedChannelPlugin, listChannelPlugins } from "../../channels/plugins/index.js";
+import { normalizeSessionKeyPreservingOpaquePeerIds } from "../../sessions/session-key-utils.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
@@ -36,12 +37,12 @@ function resolveExplicitSessionKeyNormalizerCandidates(
 }
 
 export function normalizeExplicitSessionKey(sessionKey: string, ctx: MsgContext): string {
-  const normalized = normalizeLowercaseStringOrEmpty(sessionKey);
+  const normalized = normalizeSessionKeyPreservingOpaquePeerIds(sessionKey);
   for (const channelId of resolveExplicitSessionKeyNormalizerCandidates(normalized, ctx)) {
     const normalize = getLoadedChannelPlugin(channelId)?.messaging?.normalizeExplicitSessionKey;
     const next = normalize?.({ sessionKey: normalized, ctx });
     if (typeof next === "string" && next.trim()) {
-      return normalizeLowercaseStringOrEmpty(next);
+      return normalizeSessionKeyPreservingOpaquePeerIds(next);
     }
   }
   return normalized;

--- a/src/config/sessions/group.test.ts
+++ b/src/config/sessions/group.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import type { MsgContext } from "../../auto-reply/templating.js";
+import { resolveGroupSessionKey } from "./group.js";
+
+describe("resolveGroupSessionKey", () => {
+  it("preserves Signal group ids from the originating target", () => {
+    const mixedGroupId = "VWATodkf2hc8zdOS76q9Tb0+5Bi522E03qLdaQ/9ypg=";
+    const ctx = {
+      Provider: "signal",
+      ChatType: "group",
+      From: "signal:+15551234567",
+      OriginatingTo: `signal:group:${mixedGroupId}`,
+    } satisfies Partial<MsgContext>;
+
+    expect(resolveGroupSessionKey(ctx as MsgContext)).toEqual({
+      key: `signal:group:${mixedGroupId}`,
+      channel: "signal",
+      id: mixedGroupId,
+      chatType: "group",
+    });
+  });
+
+  it("keeps non-Signal group ids lowercase", () => {
+    const ctx = {
+      Provider: "telegram",
+      ChatType: "group",
+      From: "telegram:1234",
+      OriginatingTo: "telegram:group:MiXeDGroup",
+    } satisfies Partial<MsgContext>;
+
+    expect(resolveGroupSessionKey(ctx as MsgContext)).toEqual({
+      key: "telegram:group:mixedgroup",
+      channel: "telegram",
+      id: "mixedgroup",
+      chatType: "group",
+    });
+  });
+});

--- a/src/config/sessions/group.ts
+++ b/src/config/sessions/group.ts
@@ -1,5 +1,6 @@
 import type { MsgContext } from "../../auto-reply/templating.js";
 import { listChannelPlugins } from "../../channels/plugins/registry.js";
+import { normalizeSessionPeerId } from "../../sessions/session-key-utils.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
@@ -149,7 +150,7 @@ export function resolveGroupSessionKey(ctx: MsgContext): GroupKeyResolution | nu
         ? parts.slice(2).join(":")
         : parts.slice(1).join(":")
       : from;
-  const finalId = normalizeLowercaseStringOrEmpty(id);
+  const finalId = normalizeSessionPeerId({ channel: provider, peerKind: kind, peerId: id });
   if (!finalId) {
     return null;
   }

--- a/src/config/sessions/store-entry.ts
+++ b/src/config/sessions/store-entry.ts
@@ -1,8 +1,9 @@
+import { normalizeSessionKeyPreservingOpaquePeerIds } from "../../sessions/session-key-utils.js";
 import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
 import type { SessionEntry } from "./types.js";
 
 export function normalizeStoreSessionKey(sessionKey: string): string {
-  return normalizeLowercaseStringOrEmpty(sessionKey);
+  return normalizeSessionKeyPreservingOpaquePeerIds(sessionKey);
 }
 
 export function resolveSessionStoreEntry(params: {
@@ -15,6 +16,7 @@ export function resolveSessionStoreEntry(params: {
 } {
   const trimmedKey = params.sessionKey.trim();
   const normalizedKey = normalizeStoreSessionKey(trimmedKey);
+  const foldedLegacyKey = normalizeLowercaseStringOrEmpty(normalizedKey);
   const legacyKeySet = new Set<string>();
   if (
     trimmedKey !== normalizedKey &&
@@ -22,14 +24,26 @@ export function resolveSessionStoreEntry(params: {
   ) {
     legacyKeySet.add(trimmedKey);
   }
+  if (
+    foldedLegacyKey !== normalizedKey &&
+    Object.prototype.hasOwnProperty.call(params.store, foldedLegacyKey)
+  ) {
+    legacyKeySet.add(foldedLegacyKey);
+  }
   let existing =
-    params.store[normalizedKey] ?? (legacyKeySet.size > 0 ? params.store[trimmedKey] : undefined);
+    params.store[normalizedKey] ??
+    params.store[foldedLegacyKey] ??
+    (legacyKeySet.size > 0 ? params.store[trimmedKey] : undefined);
   let existingUpdatedAt = existing?.updatedAt ?? 0;
   for (const [candidateKey, candidateEntry] of Object.entries(params.store)) {
     if (candidateKey === normalizedKey) {
       continue;
     }
-    if (normalizeStoreSessionKey(candidateKey) !== normalizedKey) {
+    const candidateMatches =
+      normalizeStoreSessionKey(candidateKey) === normalizedKey ||
+      (foldedLegacyKey !== normalizedKey &&
+        normalizeLowercaseStringOrEmpty(candidateKey) === foldedLegacyKey);
+    if (!candidateMatches) {
       continue;
     }
     legacyKeySet.add(candidateKey);

--- a/src/config/sessions/store.session-key-normalization.test.ts
+++ b/src/config/sessions/store.session-key-normalization.test.ts
@@ -12,6 +12,9 @@ import {
 
 const CANONICAL_KEY = "agent:main:webchat:dm:mixed-user";
 const MIXED_CASE_KEY = "Agent:Main:WebChat:DM:MiXeD-User";
+const SIGNAL_GROUP_ID = "VWATodkf2hc8zdOS76q9Tb0+5Bi522E03qLdaQ/9ypg=";
+const SIGNAL_GROUP_KEY = `agent:main:signal:group:${SIGNAL_GROUP_ID}`;
+const LEGACY_SIGNAL_GROUP_KEY = SIGNAL_GROUP_KEY.toLowerCase();
 
 function createInboundContext(): MsgContext {
   return {
@@ -22,6 +25,18 @@ function createInboundContext(): MsgContext {
     To: "webchat:agent",
     SessionKey: MIXED_CASE_KEY,
     OriginatingTo: "webchat:user-1",
+  };
+}
+
+function createSignalGroupContext(): MsgContext {
+  return {
+    Provider: "signal",
+    Surface: "signal",
+    ChatType: "group",
+    From: `signal:group:${SIGNAL_GROUP_ID}`,
+    To: `signal:group:${SIGNAL_GROUP_ID}`,
+    SessionKey: SIGNAL_GROUP_KEY,
+    OriginatingTo: `signal:group:${SIGNAL_GROUP_ID}`,
   };
 }
 
@@ -149,5 +164,55 @@ describe("session store key normalization", () => {
     expect(store[CANONICAL_KEY]?.sessionId).toBe("existing-session");
     expect(store[CANONICAL_KEY]?.updatedAt).toBe(existingUpdatedAt);
     expect(store[CANONICAL_KEY]?.origin?.provider).toBe("webchat");
+  });
+
+  it("records Signal group metadata under the mixed-case opaque group id", async () => {
+    await recordSessionMetaFromInbound({
+      storePath,
+      sessionKey: `Agent:Main:Signal:Group:${SIGNAL_GROUP_ID}`,
+      ctx: createSignalGroupContext(),
+    });
+
+    const store = loadSessionStore(storePath, { skipCache: true });
+    expect(Object.keys(store)).toEqual([SIGNAL_GROUP_KEY]);
+    expect(store[SIGNAL_GROUP_KEY]?.groupId).toBe(SIGNAL_GROUP_ID);
+    expect(store[SIGNAL_GROUP_KEY]?.origin?.to).toBe(`signal:group:${SIGNAL_GROUP_ID}`);
+  });
+
+  it("migrates legacy lowercase Signal group keys to the mixed-case canonical key", async () => {
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          [LEGACY_SIGNAL_GROUP_KEY]: {
+            sessionId: "legacy-signal-session",
+            updatedAt: 1,
+            chatType: "group",
+            channel: "signal",
+            groupId: SIGNAL_GROUP_ID.toLowerCase(),
+            deliveryContext: {
+              channel: "signal",
+              to: `signal:group:${SIGNAL_GROUP_ID}`,
+            },
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    clearSessionStoreCacheForTest();
+
+    await recordSessionMetaFromInbound({
+      storePath,
+      sessionKey: SIGNAL_GROUP_KEY,
+      ctx: createSignalGroupContext(),
+    });
+
+    const store = loadSessionStore(storePath, { skipCache: true });
+    expect(Object.keys(store)).toEqual([SIGNAL_GROUP_KEY]);
+    expect(store[SIGNAL_GROUP_KEY]?.sessionId).toBe("legacy-signal-session");
+    expect(store[SIGNAL_GROUP_KEY]?.groupId).toBe(SIGNAL_GROUP_ID);
+    expect(store[LEGACY_SIGNAL_GROUP_KEY]).toBeUndefined();
   });
 });

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -109,6 +109,37 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     }
   });
 
+  it("appends to legacy lowercase Signal group session entries", async () => {
+    const mixedGroupId = "VWATodkf2hc8zdOS76q9Tb0+5Bi522E03qLdaQ/9ypg=";
+    const signalSessionKey = `agent:main:signal:group:${mixedGroupId}`;
+    const legacySignalSessionKey = signalSessionKey.toLowerCase();
+    fs.writeFileSync(
+      fixture.storePath(),
+      JSON.stringify({
+        [legacySignalSessionKey]: {
+          sessionId,
+          chatType: "group",
+          channel: "signal",
+        },
+      }),
+      "utf-8",
+    );
+
+    const result = await appendAssistantMessageToSessionTranscript({
+      sessionKey: signalSessionKey,
+      text: "Hello Signal group",
+      storePath: fixture.storePath(),
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const lines = fs.readFileSync(result.sessionFile, "utf-8").trim().split("\n");
+      expect(lines).toHaveLength(2);
+      const messageLine = JSON.parse(lines[1]);
+      expect(messageLine.message.content[0].text).toBe("Hello Signal group");
+    }
+  });
+
   it("falls back to the canonical transcript path for malformed persisted sessionFile metadata", async () => {
     fs.writeFileSync(
       fixture.storePath(),

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -14,7 +14,7 @@ import {
   resolveSessionTranscriptPath,
 } from "./paths.js";
 import { resolveAndPersistSessionFile } from "./session-file.js";
-import { loadSessionStore, normalizeStoreSessionKey } from "./store.js";
+import { loadSessionStore, resolveSessionStoreEntry } from "./store.js";
 import { parseSessionThreadInfo } from "./thread-info.js";
 import { appendSessionTranscriptMessage } from "./transcript-append.js";
 import { resolveMirroredTranscriptText } from "./transcript-mirror.js";
@@ -255,8 +255,8 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
 
   const storePath = params.storePath ?? resolveDefaultSessionStorePath(params.agentId);
   const store = loadSessionStore(storePath, { skipCache: true });
-  const normalizedKey = normalizeStoreSessionKey(sessionKey);
-  const entry = (store[normalizedKey] ?? store[sessionKey]) as SessionEntry | undefined;
+  const resolved = resolveSessionStoreEntry({ store, sessionKey });
+  const entry = resolved.existing;
   if (!entry?.sessionId) {
     return { ok: false, reason: `unknown sessionKey: ${sessionKey}` };
   }
@@ -265,7 +265,7 @@ export async function appendExactAssistantMessageToSessionTranscript(params: {
   try {
     const resolvedSessionFile = await resolveAndPersistSessionFile({
       sessionId: entry.sessionId,
-      sessionKey,
+      sessionKey: resolved.normalizedKey,
       sessionStore: store,
       storePath,
       sessionEntry: entry,

--- a/src/gateway/session-store-key.ts
+++ b/src/gateway/session-store-key.ts
@@ -11,6 +11,7 @@ import {
   parseAgentSessionKey,
   type ParsedAgentSessionKey,
 } from "../routing/session-key.js";
+import { normalizeSessionKeyPreservingOpaquePeerIds } from "../sessions/session-key-utils.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -21,10 +22,11 @@ export function canonicalizeSessionKeyForAgent(agentId: string, key: string): st
   if (lowered === "global" || lowered === "unknown") {
     return lowered;
   }
-  if (lowered.startsWith("agent:")) {
-    return lowered;
+  const normalized = normalizeSessionKeyPreservingOpaquePeerIds(key);
+  if (normalized.startsWith("agent:")) {
+    return normalized;
   }
-  return `agent:${normalizeAgentId(agentId)}:${lowered}`;
+  return `agent:${normalizeAgentId(agentId)}:${normalized}`;
 }
 
 function resolveDefaultStoreAgentId(cfg: OpenClawConfig): string {
@@ -58,7 +60,7 @@ function resolveParsedSessionStoreKey(
   if (!shouldRemapLegacyDefaultMainAlias(cfg, parsed, options)) {
     return {
       agentId: normalizeAgentId(parsed.agentId),
-      sessionKey: normalizeLowercaseStringOrEmpty(raw),
+      sessionKey: normalizeSessionKeyPreservingOpaquePeerIds(raw),
     };
   }
   const agentId = resolveDefaultStoreAgentId(cfg);
@@ -102,7 +104,7 @@ export function resolveSessionStoreKey(params: {
     return resolveMainSessionKey(params.cfg);
   }
   const agentId = resolveDefaultStoreAgentId(params.cfg);
-  return canonicalizeSessionKeyForAgent(agentId, lowered);
+  return canonicalizeSessionKeyForAgent(agentId, raw);
 }
 
 export function resolveSessionStoreAgentId(cfg: OpenClawConfig, canonicalKey: string): string {
@@ -163,10 +165,11 @@ export function canonicalizeSpawnedByForAgent(
     return lower;
   }
   let result: string;
-  if (lower.startsWith("agent:")) {
-    result = lower;
+  const normalized = normalizeSessionKeyPreservingOpaquePeerIds(raw);
+  if (normalized.startsWith("agent:")) {
+    result = normalized;
   } else {
-    result = `agent:${normalizeAgentId(agentId)}:${lower}`;
+    result = `agent:${normalizeAgentId(agentId)}:${normalized}`;
   }
   // Resolve main-alias references (e.g. agent:ops:main -> configured main key).
   const parsed = parseAgentSessionKey(result);

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -9,6 +9,7 @@ import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import {
+  canonicalizeSpawnedByForAgent,
   buildGatewaySessionRow,
   capArrayByJsonBytes,
   classifySessionKey,
@@ -648,6 +649,34 @@ describe("gateway session utils", () => {
     expect(resolveSessionStoreKey({ cfg, sessionKey: "agent:alpha:MySession" })).toBe(
       "agent:alpha:mysession",
     );
+  });
+
+  test("resolveSessionStoreKey preserves Signal group ids", () => {
+    const cfg = {
+      session: { mainKey: "main" },
+      agents: { list: [{ id: "ops", default: true }] },
+    } as OpenClawConfig;
+    const mixedGroupId = "VWATodkf2hc8zdOS76q9Tb0+5Bi522E03qLdaQ/9ypg=";
+    expect(resolveSessionStoreKey({ cfg, sessionKey: `Signal:Group:${mixedGroupId}` })).toBe(
+      `agent:ops:signal:group:${mixedGroupId}`,
+    );
+    expect(
+      resolveSessionStoreKey({ cfg, sessionKey: `Agent:Alpha:Signal:Group:${mixedGroupId}` }),
+    ).toBe(`agent:alpha:signal:group:${mixedGroupId}`);
+  });
+
+  test("canonicalizeSpawnedByForAgent preserves Signal group ids", () => {
+    const cfg = {
+      session: { mainKey: "main" },
+    } as OpenClawConfig;
+    const mixedGroupId = "VWATodkf2hc8zdOS76q9Tb0+5Bi522E03qLdaQ/9ypg=";
+
+    expect(canonicalizeSpawnedByForAgent(cfg, "ops", `Signal:Group:${mixedGroupId}`)).toBe(
+      `agent:ops:signal:group:${mixedGroupId}`,
+    );
+    expect(
+      canonicalizeSpawnedByForAgent(cfg, "ops", `Agent:Main:Signal:Group:${mixedGroupId}`),
+    ).toBe(`agent:main:signal:group:${mixedGroupId}`);
   });
 
   test("resolveSessionStoreKey honors global scope", () => {

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -422,6 +422,18 @@ describe("resolveAgentRoute", () => {
     expect(route.sessionKey).toBe("agent:main:discord:channel:1468834856187203680");
   });
 
+  test("preserves mixed-case Signal group ids in route session keys", () => {
+    const mixedGroupId = "VWATodkf2hc8zdOS76q9Tb0+5Bi522E03qLdaQ/9ypg=";
+    const route = resolveAgentRoute({
+      cfg: {},
+      channel: "signal",
+      accountId: null,
+      peer: { kind: "group", id: mixedGroupId },
+    });
+    expect(route.sessionKey).toBe(`agent:main:signal:group:${mixedGroupId}`);
+    expect(route.lastRoutePolicy).toBe("session");
+  });
+
   test.each([
     {
       name: "peer+guild binding does not act as guild-wide fallback when peer mismatches (#14752)",

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -661,16 +661,14 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   ) => {
     const resolvedAgentId = pickFirstExistingAgentId(input.cfg, agentId);
     const effectiveDmScope = sessionOverride?.dmScope ?? dmScope;
-    const sessionKey = normalizeLowercaseStringOrEmpty(
-      buildAgentSessionKey({
-        agentId: resolvedAgentId,
-        channel,
-        accountId,
-        peer,
-        dmScope: effectiveDmScope,
-        identityLinks,
-      }),
-    );
+    const sessionKey = buildAgentSessionKey({
+      agentId: resolvedAgentId,
+      channel,
+      accountId,
+      peer,
+      dmScope: effectiveDmScope,
+      identityLinks,
+    });
     const mainSessionKey = normalizeLowercaseStringOrEmpty(
       buildAgentMainSessionKey({
         agentId: resolvedAgentId,

--- a/src/routing/session-key.test.ts
+++ b/src/routing/session-key.test.ts
@@ -7,6 +7,8 @@ import {
   resolveThreadParentSessionKey,
 } from "../sessions/session-key-utils.js";
 import {
+  buildAgentPeerSessionKey,
+  buildGroupHistoryKey,
   classifySessionKeyShape,
   isValidAgentId,
   parseAgentSessionKey,
@@ -155,6 +157,43 @@ describe("session key canonicalization", () => {
             requestKey: "agent:main:main",
           }),
         ).toBe("agent:main:main"),
+    },
+    {
+      name: "preserves Signal group ids while lowercasing structural tokens",
+      run: () => {
+        const mixedGroupId = "VWATodkf2hc8zdOS76q9Tb0+5Bi522E03qLdaQ/9ypg=";
+        expect(parseAgentSessionKey(`Agent:Main:Signal:Group:${mixedGroupId}`)).toEqual({
+          agentId: "main",
+          rest: `signal:group:${mixedGroupId}`,
+        });
+        expect(
+          buildAgentPeerSessionKey({
+            agentId: "Main",
+            channel: "Signal",
+            peerKind: "group",
+            peerId: mixedGroupId,
+          }),
+        ).toBe(`agent:main:signal:group:${mixedGroupId}`);
+        expect(
+          buildGroupHistoryKey({
+            channel: "Signal",
+            peerKind: "group",
+            peerId: mixedGroupId,
+          }),
+        ).toBe(`signal:default:group:${mixedGroupId}`);
+      },
+    },
+    {
+      name: "keeps non-Signal opaque-looking group ids lowercase",
+      run: () =>
+        expect(
+          buildAgentPeerSessionKey({
+            agentId: "Main",
+            channel: "Telegram",
+            peerKind: "group",
+            peerId: "MiXeDGroup",
+          }),
+        ).toBe("agent:main:telegram:group:mixedgroup"),
     },
   ] as const)("$name", ({ run }) => {
     expectSessionKeyCanonicalizationCase({ run });

--- a/src/routing/session-key.ts
+++ b/src/routing/session-key.ts
@@ -1,5 +1,10 @@
 import type { ChatType } from "../channels/chat-type.js";
-import { isCronRunSessionKey, parseAgentSessionKey } from "../sessions/session-key-utils.js";
+import {
+  isCronRunSessionKey,
+  normalizeSessionPeerId,
+  normalizeSessionKeyPreservingOpaquePeerIds,
+  parseAgentSessionKey,
+} from "../sessions/session-key-utils.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { normalizeAccountId } from "./account-id.js";
 
@@ -101,10 +106,11 @@ export function toAgentStoreSessionKey(params: {
   if (parsed) {
     return `agent:${parsed.agentId}:${parsed.rest}`;
   }
+  const normalized = normalizeSessionKeyPreservingOpaquePeerIds(raw);
   if (lowered.startsWith("agent:")) {
-    return lowered;
+    return normalized;
   }
-  return `agent:${normalizeAgentId(params.agentId)}:${lowered}`;
+  return `agent:${normalizeAgentId(params.agentId)}:${normalized}`;
 }
 
 export function resolveAgentIdFromSessionKey(sessionKey: string | undefined | null): string {
@@ -208,7 +214,12 @@ export function buildAgentPeerSessionKey(params: {
     });
   }
   const channel = normalizeLowercaseStringOrEmpty(params.channel) || "unknown";
-  const peerId = normalizeLowercaseStringOrEmpty(params.peerId) || "unknown";
+  const peerId =
+    normalizeSessionPeerId({
+      channel: params.channel,
+      peerKind,
+      peerId: params.peerId,
+    }) || "unknown";
   return `agent:${normalizeAgentId(params.agentId)}:${channel}:${peerKind}:${peerId}`;
 }
 
@@ -266,7 +277,12 @@ export function buildGroupHistoryKey(params: {
 }): string {
   const channel = normalizeToken(params.channel) || "unknown";
   const accountId = normalizeAccountId(params.accountId);
-  const peerId = normalizeLowercaseStringOrEmpty(params.peerId) || "unknown";
+  const peerId =
+    normalizeSessionPeerId({
+      channel,
+      peerKind: params.peerKind,
+      peerId: params.peerId,
+    }) || "unknown";
   return `${channel}:${accountId}:${params.peerKind}:${peerId}`;
 }
 

--- a/src/sessions/session-key-utils.ts
+++ b/src/sessions/session-key-utils.ts
@@ -21,14 +21,56 @@ export type RawSessionConversationRef = {
   prefix: string;
 };
 
+export function normalizeSessionPeerId(params: {
+  channel: string | undefined | null;
+  peerKind?: string | null;
+  peerId?: string | null;
+}): string {
+  const peerId = (params.peerId ?? "").trim();
+  if (!peerId) {
+    return "";
+  }
+  const channel = normalizeLowercaseStringOrEmpty(params.channel);
+  const peerKind = normalizeLowercaseStringOrEmpty(params.peerKind);
+  return channel === "signal" && peerKind === "group"
+    ? peerId
+    : normalizeLowercaseStringOrEmpty(peerId);
+}
+
+const SIGNAL_GROUP_SESSION_SEGMENT_RE = /(^|:)signal:group:([^:]+)/gi;
+
+export function normalizeSessionKeyPreservingOpaquePeerIds(
+  sessionKey: string | undefined | null,
+): string {
+  const raw = normalizeOptionalString(sessionKey);
+  if (!raw) {
+    return "";
+  }
+
+  let normalized = "";
+  let cursor = 0;
+  for (const match of raw.matchAll(SIGNAL_GROUP_SESSION_SEGMENT_RE)) {
+    const matchIndex = match.index ?? 0;
+    const matched = match[0] ?? "";
+    const peerId = match[2] ?? "";
+    const peerStart = matchIndex + matched.length - peerId.length;
+    normalized += normalizeLowercaseStringOrEmpty(raw.slice(cursor, peerStart));
+    normalized += peerId.trim();
+    cursor = matchIndex + matched.length;
+  }
+  normalized += normalizeLowercaseStringOrEmpty(raw.slice(cursor));
+  return normalized;
+}
+
 /**
  * Parse agent-scoped session keys in a canonical, case-insensitive way.
- * Returned values are normalized to lowercase for stable comparisons/routing.
+ * Returned values are canonicalized for stable comparisons/routing while
+ * preserving provider-owned opaque peer IDs.
  */
 export function parseAgentSessionKey(
   sessionKey: string | undefined | null,
 ): ParsedAgentSessionKey | null {
-  const raw = normalizeOptionalLowercaseString(sessionKey);
+  const raw = normalizeSessionKeyPreservingOpaquePeerIds(sessionKey);
   if (!raw) {
     return null;
   }


### PR DESCRIPTION
## Summary
- Preserve Signal group IDs as provider-owned opaque peer IDs while keeping structural session-key tokens canonicalized.
- Carry the Signal-safe normalizer through routing, explicit session keys, inbound recording, session store lookup/migration, delivery info, transcript appends, group metadata, and gateway store/spawnedBy canonicalization.
- Add regressions for mixed-case Signal group IDs and legacy lowercase store entries.

## Verification
- node scripts/run-vitest.mjs src/routing/session-key.test.ts src/routing/resolve-route.test.ts src/config/sessions/explicit-session-key-normalization.test.ts src/channels/session.test.ts src/config/sessions/group.test.ts --reporter=verbose
- node scripts/run-vitest.mjs src/config/sessions/store.session-key-normalization.test.ts src/config/sessions/delivery-info.test.ts src/gateway/session-utils.test.ts --reporter=verbose
- node scripts/run-vitest.mjs src/gateway/session-utils.test.ts --reporter=verbose -t "Signal group ids"
- node scripts/run-vitest.mjs src/config/sessions/transcript.test.ts --reporter=verbose
- codex-review --mode local: clean after accepting/fixing transcript legacy lookup finding
- git diff --check
- pnpm exec tsx direct probe for route/peer/history/store/spawnedBy preservation

## Real behavior proof
Behavior addressed: Signal group auto-reply sessions no longer lowercase mixed-case group IDs, and legacy lowercase session-store entries remain readable/migratable.
Real environment tested: Local OpenClaw source checkout with focused route/session/store/gateway/transcript suites and direct TypeScript probe of the runtime key-normalization helpers.
Exact steps or command run after this patch: node scripts/run-vitest.mjs src/routing/session-key.test.ts src/routing/resolve-route.test.ts src/config/sessions/explicit-session-key-normalization.test.ts src/channels/session.test.ts src/config/sessions/group.test.ts --reporter=verbose; node scripts/run-vitest.mjs src/config/sessions/store.session-key-normalization.test.ts src/config/sessions/delivery-info.test.ts src/gateway/session-utils.test.ts --reporter=verbose; node scripts/run-vitest.mjs src/config/sessions/transcript.test.ts --reporter=verbose; codex-review --mode local; git diff --check; pnpm exec tsx direct key-preservation probe.
Evidence after fix: Copied terminal output after fix from the direct probe:

```json
{
  "peer": "agent:main:signal:group:VWATodkf2hc8zdOS76q9Tb0+5Bi522E03qLdaQ/9ypg=",
  "route": "agent:main:signal:group:VWATodkf2hc8zdOS76q9Tb0+5Bi522E03qLdaQ/9ypg=",
  "history": "signal:default:group:VWATodkf2hc8zdOS76q9Tb0+5Bi522E03qLdaQ/9ypg=",
  "store": "agent:ops:signal:group:VWATodkf2hc8zdOS76q9Tb0+5Bi522E03qLdaQ/9ypg=",
  "spawnedBy": "agent:ops:signal:group:VWATodkf2hc8zdOS76q9Tb0+5Bi522E03qLdaQ/9ypg="
}
```

Observed result after fix: Signal group session keys and persisted group metadata retain the original mixed-case group ID, while legacy lowercase entries are still found by delivery and transcript lookup paths.
What was not tested: A live Signal gateway round-trip with signal-cli credentials was not run.

Fixes #82827.
