### PR TITLE
fix(cli): keep image describe URLs remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/diagnostics: split slow embedded-run `attempt-dispatch` startup summaries into workspace, prompt, runtime-plan, and final dispatch subspans so traces identify the delayed setup phase. Fixes #82782. (#82783) Thanks @galiniliev.
+- CLI/media: accept HTTP(S) URLs in `openclaw infer image describe --file`, fetching remote images through the guarded media path instead of treating URLs as local files. Fixes #82837. (#82854) Thanks @neeravmakwana.
 - Agents/subagents: route group/channel subagent completions through message-tool-only handoffs when required and keep active-requester wake failures from dropping completion delivery. Fixes #82803. Thanks @galiniliev, @yozakura-ava, and @moeedahmed.
 - Memory-core: scan persisted memory source sessions on startup, comparing on-disk transcripts against the index and marking only missing/newer/resized files dirty for incremental sync. Fixes #82341. (#82341) Thanks @giodl73-repo.
 - Telegram: keep the top-level default account in the account list when named accounts or bindings are added alongside top-level credentials, preserving default polling while still letting named-only configs resolve to a single account. Fixes #82794. (#82794) Thanks @giodl73-repo.

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -478,6 +478,7 @@ describe("capability cli", () => {
   };
   type ImageDescribeParams = {
     filePath?: string;
+    mediaUrl?: string;
     model?: unknown;
     prompt?: unknown;
     provider?: unknown;
@@ -1147,6 +1148,26 @@ describe("capability cli", () => {
     expect(describeCall?.timeoutMs).toBe(90000);
   });
 
+  it("keeps image describe URL files as remote media references", async () => {
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: [
+        "capability",
+        "image",
+        "describe",
+        "--file",
+        "https://example.com/photo.png",
+        "--json",
+      ],
+    });
+
+    const describeCall = imageDescribeCall();
+    expect(describeCall?.filePath).toBe("https://example.com/photo.png");
+    expect(describeCall?.mediaUrl).toBe("https://example.com/photo.png");
+    const outputs = firstJsonOutput()?.outputs as Array<Record<string, unknown>>;
+    expect(outputs[0]?.path).toBe("https://example.com/photo.png");
+  });
+
   it("uses the explicit media-understanding provider for image describe model overrides", async () => {
     await runRegisteredCli({
       register: registerCapabilityCli as (program: Command) => void,
@@ -1175,6 +1196,29 @@ describe("capability cli", () => {
     expect(mocks.describeImageFile).not.toHaveBeenCalled();
     expect(firstJsonOutput()?.provider).toBe("ollama");
     expect(firstJsonOutput()?.model).toBe("gpt-4.1-mini");
+  });
+
+  it("keeps explicit-model image describe URL files as remote media references", async () => {
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: [
+        "capability",
+        "image",
+        "describe",
+        "--file",
+        "https://example.com/photo.png",
+        "--model",
+        "ollama/qwen2.5vl:7b",
+        "--json",
+      ],
+    });
+
+    const describeCall = firstImageDescribeWithModelCall();
+    expect(describeCall?.filePath).toBe("https://example.com/photo.png");
+    expect(describeCall?.mediaUrl).toBe("https://example.com/photo.png");
+    expect(mocks.describeImageFile).not.toHaveBeenCalled();
+    const outputs = firstJsonOutput()?.outputs as Array<Record<string, unknown>>;
+    expect(outputs[0]?.path).toBe("https://example.com/photo.png");
   });
 
   it("passes describe-many prompts to each image", async () => {

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -1097,10 +1097,12 @@ async function runImageDescribe(params: {
   const prompt = normalizeOptionalString(params.prompt);
   const outputs = await Promise.all(
     params.files.map(async (filePath) => {
-      const resolvedPath = path.resolve(filePath);
+      const isRemoteUrl = /^https?:\/\//i.test(filePath.trim());
+      const resolvedPath = isRemoteUrl ? filePath.trim() : path.resolve(filePath);
       const result = activeModel
         ? await describeImageFileWithModel({
             filePath: resolvedPath,
+            ...(isRemoteUrl ? { mediaUrl: resolvedPath } : {}),
             cfg,
             agentDir,
             provider: activeModel.provider,
@@ -1110,6 +1112,7 @@ async function runImageDescribe(params: {
           })
         : await describeImageFile({
             filePath: resolvedPath,
+            ...(isRemoteUrl ? { mediaUrl: resolvedPath } : {}),
             cfg,
             agentDir,
             prompt,

--- a/src/media-understanding/attachments.cache.ts
+++ b/src/media-understanding/attachments.cache.ts
@@ -15,7 +15,6 @@ import { detectMime } from "../media/mime.js";
 import { buildRandomTempFilePath } from "../plugin-sdk/temp-path.js";
 import { normalizeAttachmentPath } from "./attachments.normalize.js";
 import { MediaUnderstandingSkipError } from "./errors.js";
-import { fetchWithTimeout } from "./shared.js";
 import type { MediaAttachment } from "./types.js";
 
 type MediaBufferResult = {
@@ -66,16 +65,6 @@ export type MediaAttachmentCacheOptions = {
   ssrfPolicy?: SsrFPolicy;
   workspaceDir?: string;
 };
-
-function resolveRequestUrl(input: RequestInfo | URL): string {
-  if (typeof input === "string") {
-    return input;
-  }
-  if (input instanceof URL) {
-    return input.toString();
-  }
-  return input.url;
-}
 
 export class MediaAttachmentCache {
   private readonly entries = new Map<number, AttachmentCacheEntry>();
@@ -171,11 +160,9 @@ export class MediaAttachmentCache {
     }
 
     try {
-      const fetchImpl = (input: RequestInfo | URL, init?: RequestInit) =>
-        fetchWithTimeout(resolveRequestUrl(input), init ?? {}, params.timeoutMs, globalThis.fetch);
       const fetched = await readRemoteMediaBuffer({
         url,
-        fetchImpl,
+        timeoutMs: params.timeoutMs,
         maxBytes: params.maxBytes,
         ssrfPolicy: this.ssrfPolicy,
         retry: REMOTE_MEDIA_FETCH_RETRY,

--- a/src/media-understanding/media-understanding-url-fallback.test.ts
+++ b/src/media-understanding/media-understanding-url-fallback.test.ts
@@ -17,7 +17,7 @@ vi.mock("../media/fetch.js", async () => {
 
 function requireReadRemoteMediaBufferInput(): {
   url?: unknown;
-  fetchImpl?: unknown;
+  timeoutMs?: unknown;
   maxBytes?: unknown;
   ssrfPolicy?: unknown;
   retry?: unknown;
@@ -84,15 +84,13 @@ describe("media understanding attachment URL fallback", () => {
         expect(path.extname(result.path)).toBe(".jpg");
         expect(readRemoteMediaBufferMock).toHaveBeenCalledTimes(1);
         const fetchInput = requireReadRemoteMediaBufferInput();
-        const fetchImpl = fetchInput.fetchImpl;
         expect(fetchInput).toStrictEqual({
           url: fallbackUrl,
-          fetchImpl,
+          timeoutMs: 1000,
           maxBytes: 1024,
           ssrfPolicy: undefined,
           retry: expect.objectContaining({ attempts: 3 }),
         });
-        expect(typeof fetchImpl).toBe("function");
         // Clean up the temp file
         if (result.cleanup) {
           await result.cleanup();
@@ -113,15 +111,13 @@ describe("media understanding attachment URL fallback", () => {
         expect(result.buffer.toString()).toBe("fallback-buffer");
         expect(readRemoteMediaBufferMock).toHaveBeenCalledTimes(1);
         const fetchInput = requireReadRemoteMediaBufferInput();
-        const fetchImpl = fetchInput.fetchImpl;
         expect(fetchInput).toStrictEqual({
           url: fallbackUrl,
-          fetchImpl,
+          timeoutMs: 1000,
           maxBytes: 1024,
           ssrfPolicy: undefined,
           retry: expect.objectContaining({ attempts: 3 }),
         });
-        expect(typeof fetchImpl).toBe("function");
       },
     );
   });

--- a/src/media-understanding/runtime-types.ts
+++ b/src/media-understanding/runtime-types.ts
@@ -11,6 +11,7 @@ import type {
 export type RunMediaUnderstandingFileParams = {
   capability: "image" | "audio" | "video";
   filePath: string;
+  mediaUrl?: string;
   cfg: OpenClawConfig;
   agentDir?: string;
   workspaceDir?: string;
@@ -30,6 +31,7 @@ export type RunMediaUnderstandingFileResult = {
 
 export type DescribeImageFileParams = {
   filePath: string;
+  mediaUrl?: string;
   cfg: OpenClawConfig;
   agentDir?: string;
   workspaceDir?: string;
@@ -41,6 +43,7 @@ export type DescribeImageFileParams = {
 
 export type DescribeImageFileWithModelParams = {
   filePath: string;
+  mediaUrl?: string;
   cfg: OpenClawConfig;
   agentDir?: string;
   workspaceDir?: string;

--- a/src/media-understanding/runtime.test.ts
+++ b/src/media-understanding/runtime.test.ts
@@ -13,9 +13,15 @@ import {
 
 const mocks = vi.hoisted(() => {
   const cleanup = vi.fn(async () => {});
+  const getBuffer = vi.fn(async () => ({
+    buffer: Buffer.from("remote-image"),
+    fileName: "photo.png",
+    mime: "image/png",
+    size: 12,
+  }));
   return {
     buildProviderRegistry: vi.fn(() => new Map()),
-    createMediaAttachmentCache: vi.fn(() => ({ cleanup })),
+    createMediaAttachmentCache: vi.fn(() => ({ cleanup, getBuffer })),
     normalizeMediaAttachments: vi.fn<() => MediaAttachment[]>(() => []),
     normalizeMediaProviderId: vi.fn((provider: string) => provider.trim().toLowerCase()),
     buildMediaUnderstandingRegistry: vi.fn(() => new Map()),
@@ -24,6 +30,7 @@ const mocks = vi.hoisted(() => {
     describeImageWithModel: vi.fn(async () => ({ text: "generic image ok", model: "vision" })),
     runCapability: vi.fn(),
     cleanup,
+    getBuffer,
   };
 });
 
@@ -71,6 +78,13 @@ describe("media-understanding runtime", () => {
     mocks.runCapability.mockReset();
     mocks.cleanup.mockReset();
     mocks.cleanup.mockResolvedValue(undefined);
+    mocks.getBuffer.mockReset();
+    mocks.getBuffer.mockResolvedValue({
+      buffer: Buffer.from("remote-image"),
+      fileName: "photo.png",
+      mime: "image/png",
+      size: 12,
+    });
   });
 
   it("returns disabled state without loading providers", async () => {
@@ -201,6 +215,36 @@ describe("media-understanding runtime", () => {
     });
   });
 
+  it("passes image file URLs as remote media understanding inputs", async () => {
+    const output: MediaUnderstandingOutput = {
+      kind: "image.description",
+      attachmentIndex: 0,
+      provider: "vision-plugin",
+      model: "vision-v1",
+      text: "image ok",
+    };
+    const media = [{ index: 0, url: "https://example.com/photo.png", mime: "image/png" }];
+    mocks.normalizeMediaAttachments.mockReturnValue(media);
+    mocks.runCapability.mockResolvedValue({ outputs: [output] });
+
+    await describeImageFile({
+      filePath: "https://example.com/photo.png",
+      mediaUrl: "https://example.com/photo.png",
+      mime: "image/png",
+      cfg: {} as OpenClawConfig,
+      agentDir: "/tmp/agent",
+    });
+
+    expect(mocks.normalizeMediaAttachments).toHaveBeenCalledWith({
+      MediaUrl: "https://example.com/photo.png",
+      MediaType: "image/png",
+    });
+    expect(requireRunCapabilityRequest()).toMatchObject({
+      ctx: { MediaUrl: "https://example.com/photo.png", MediaType: "image/png" },
+      media,
+    });
+  });
+
   it("passes workspaceDir through audio and video file helpers", async () => {
     mocks.runCapability.mockResolvedValue({
       outputs: [],
@@ -251,7 +295,7 @@ describe("media-understanding runtime", () => {
   it("passes per-request image prompts into media understanding config", async () => {
     const media = [{ index: 0, path: "/tmp/sample.jpg", mime: "image/jpeg" }];
     const providerRegistry = new Map();
-    const cache = { cleanup: mocks.cleanup };
+    const cache = { cleanup: mocks.cleanup, getBuffer: mocks.getBuffer };
     const output: MediaUnderstandingOutput = {
       kind: "image.description",
       attachmentIndex: 0,
@@ -345,6 +389,27 @@ describe("media-understanding runtime", () => {
       cfg: {},
       agentDir: "/tmp/agent",
     });
+  });
+
+  it("preserves fetched metadata for explicit model URL inputs", async () => {
+    await describeImageFileWithModel({
+      filePath: "https://example.com/photo.png",
+      mediaUrl: "https://example.com/photo.png",
+      provider: "zai",
+      model: "glm-4.6v",
+      prompt: "Describe it",
+      cfg: {} as OpenClawConfig,
+      agentDir: "/tmp/agent",
+    });
+
+    expect(mocks.describeImageWithModel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        buffer: Buffer.from("remote-image"),
+        fileName: "photo.png",
+        mime: "image/png",
+      }),
+    );
+    expect(mocks.cleanup).toHaveBeenCalledTimes(1);
   });
 
   it("routes direct image description through a provider-specific image hook", async () => {

--- a/src/media-understanding/runtime.ts
+++ b/src/media-understanding/runtime.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { readLocalFileSafely } from "../infra/fs-safe.js";
+import { DEFAULT_MAX_BYTES } from "./defaults.constants.js";
 import { describeImageWithModel } from "./image-runtime.js";
 import {
   buildMediaUnderstandingRegistry,
@@ -47,9 +48,9 @@ function resolveDecisionFailureReason(
   return normalizeDecisionReason(findDecisionReason(decision, "failed"));
 }
 
-function buildFileContext(params: { filePath: string; mime?: string }) {
+function buildFileContext(params: { filePath: string; mediaUrl?: string; mime?: string }) {
   return {
-    MediaPath: params.filePath,
+    ...(params.mediaUrl ? { MediaUrl: params.mediaUrl } : { MediaPath: params.filePath }),
     MediaType: params.mime,
   };
 }
@@ -165,12 +166,33 @@ export async function describeImageFileWithModel(params: DescribeImageFileWithMo
   const timeoutMs = params.timeoutMs ?? 30_000;
   const providerRegistry = buildProviderRegistry(undefined, params.cfg);
   const provider = providerRegistry.get(normalizeMediaProviderId(params.provider));
-  const buffer = (await readLocalFileSafely({ filePath: params.filePath })).buffer;
+  let buffer: Buffer;
+  let fileName = path.basename(params.filePath);
+  let mime = params.mime;
+  if (params.mediaUrl) {
+    const cache = createMediaAttachmentCache(normalizeMediaAttachments(buildFileContext(params)), {
+      ssrfPolicy: params.cfg.tools?.web?.fetch?.ssrfPolicy,
+    });
+    try {
+      const media = await cache.getBuffer({
+        attachmentIndex: 0,
+        maxBytes: DEFAULT_MAX_BYTES.image,
+        timeoutMs,
+      });
+      buffer = media.buffer;
+      fileName = media.fileName;
+      mime = media.mime;
+    } finally {
+      await cache.cleanup();
+    }
+  } else {
+    buffer = (await readLocalFileSafely({ filePath: params.filePath })).buffer;
+  }
   const describeImage = provider?.describeImage ?? describeImageWithModel;
   return await describeImage({
     buffer,
-    fileName: path.basename(params.filePath),
-    mime: params.mime,
+    fileName,
+    mime,
     provider: params.provider,
     model: params.model,
     prompt: params.prompt,

--- a/src/media/fetch.test.ts
+++ b/src/media/fetch.test.ts
@@ -539,6 +539,24 @@ describe("readRemoteMediaBuffer", () => {
     });
   });
 
+  it("passes request timeout through the guarded fetch path", async () => {
+    const fetchImpl = vi.fn(async () => new Response("ok", { status: 200 }));
+
+    await readRemoteMediaBuffer({
+      url: "https://example.com/file.bin",
+      fetchImpl,
+      lookupFn: makeLookupFn(),
+      maxBytes: 1024,
+      timeoutMs: 1234,
+    });
+
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(1);
+    expect(requireFetchGuardRequest()).toMatchObject({
+      url: "https://example.com/file.bin",
+      timeoutMs: 1234,
+    });
+  });
+
   it("streams successful responses directly into the media store", async () => {
     const fetchImpl = vi.fn(
       async () =>

--- a/src/media/fetch.ts
+++ b/src/media/fetch.ts
@@ -60,6 +60,8 @@ type FetchMediaOptions = {
   filePathHint?: string;
   maxBytes?: number;
   maxRedirects?: number;
+  /** Abort the guarded fetch request if it has not completed by this deadline (ms). */
+  timeoutMs?: number;
   /** Abort if the response body stops yielding data for this long (ms). */
   readIdleTimeoutMs?: number;
   ssrfPolicy?: SsrFPolicy;
@@ -157,6 +159,7 @@ async function fetchGuardedMediaResponse(
     fetchImpl,
     requestInit,
     maxRedirects,
+    timeoutMs,
     ssrfPolicy,
     lookupFn,
     dispatcherPolicy,
@@ -179,6 +182,7 @@ async function fetchGuardedMediaResponse(
         fetchImpl,
         init: requestInit,
         maxRedirects,
+        ...(timeoutMs !== undefined ? { timeoutMs } : {}),
         policy: ssrfPolicy,
         lookupFn: attempt.lookupFn ?? lookupFn,
         dispatcherPolicy: attempt.dispatcherPolicy,


### PR DESCRIPTION
## Summary

Fixes `openclaw infer image describe --file https://...` by preserving HTTP(S) inputs as remote media references instead of resolving them as local filesystem paths.

The CLI now passes URL inputs through `mediaUrl`, explicit-model image description fetches remote media via the shared guarded media cache, and the media cache uses the guarded fetch timeout path directly instead of wrapping global fetch in a way that breaks pinned dispatchers.

## Real behavior proof

Behavior addressed: `openclaw infer image describe --file https://httpbin.org/image/png --model minimax/MiniMax-VL-01 --json` no longer fails at local path resolution for a URL.

Real environment tested: macOS local clean clone, Node 22.18.0 via `mise exec node@22`, MiniMax key pulled from 1Password item `AI API Key - MiniMax - MINIMAX_API_KEY - OpenClaw` without printing the secret.

Exact steps or command run after this patch: `mise exec node@22 -- pnpm tsx --eval '<runtime probe importing describeImageFileWithModel with filePath/mediaUrl https://httpbin.org/image/png and model minimax/MiniMax-VL-01>'`.

Evidence after fix: copied live stderr after the patch:

```text
Error: MiniMax VLM API error (1004): login fail: Please carry the API secret key in the 'Authorization' field of the request header.
    at ... describeImageFileWithModel ...
```

This proves the URL passed remote media fetch and reached MiniMax VLM instead of failing in local file resolution. Focused regression tests also passed: `pnpm test src/media-understanding/media-understanding-url-fallback.test.ts src/media/fetch.test.ts src/cli/capability-cli.test.ts src/media-understanding/runtime.test.ts -- --reporter=verbose`.

Observed result after fix: URL inputs are preserved as remote media references and fetched through the guarded media path; the remaining runtime failure is MiniMax rejecting the stored credential, not `FsSafeError: file not found`.

What was not tested: full successful MiniMax VLM response, because the available 1Password credential was rejected by MiniMax as missing/invalid API secret key. The unsupported MiniMax M2.5/M2.7 chat-model vision claim from the issue remains out of scope; current code/docs route MiniMax image understanding through `MiniMax-VL-01`.
