### PR TITLE
fix(codex): rotate transcript after harness compaction

### DIFF
--- a/src/agents/pi-embedded-runner/compact.hooks.harness.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.harness.ts
@@ -110,6 +110,11 @@ export const rotateTranscriptAfterCompactionMock: Mock<
 > = vi.fn(async () => ({
   rotated: false,
 }));
+export const rotateTranscriptFileAfterCompactionMock: Mock<
+  (_params?: unknown) => Promise<CompactionTranscriptRotation>
+> = vi.fn(async () => ({
+  rotated: false,
+}));
 
 function createCompactHooksRuntimePlan(params: BuildAgentRuntimePlanParams): AgentRuntimePlan {
   const modelApi = params.modelApi ?? params.model?.api ?? undefined;
@@ -262,6 +267,8 @@ export function resetCompactSessionStateMocks(): void {
   maybeCompactAgentHarnessSessionMock.mockResolvedValue(undefined);
   rotateTranscriptAfterCompactionMock.mockReset();
   rotateTranscriptAfterCompactionMock.mockResolvedValue({ rotated: false });
+  rotateTranscriptFileAfterCompactionMock.mockReset();
+  rotateTranscriptFileAfterCompactionMock.mockResolvedValue({ rotated: false });
 }
 
 export function resetCompactHooksHarnessMocks(): void {
@@ -610,6 +617,7 @@ export async function loadCompactHooksHarness(): Promise<{
     return {
       ...actual,
       rotateTranscriptAfterCompaction: rotateTranscriptAfterCompactionMock,
+      rotateTranscriptFileAfterCompaction: rotateTranscriptFileAfterCompactionMock,
     };
   });
 

--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -1326,7 +1326,11 @@ describe("compactEmbeddedPiSession hooks (ownsCompaction engine)", () => {
     });
   });
 
-  it("rotates the active transcript after harness compaction without a delegated successor", async () => {
+  it("rotates the active transcript after harness compaction without a delegated successor and emits side effects", async () => {
+    const listener = vi.fn();
+    const cleanup = onSessionTranscriptUpdate(listener);
+    const sync = vi.fn(async () => {});
+    getMemorySearchManagerMock.mockResolvedValue({ manager: { sync } });
     maybeCompactAgentHarnessSessionMock.mockResolvedValueOnce({
       ok: true,
       compacted: true,
@@ -1344,31 +1348,46 @@ describe("compactEmbeddedPiSession hooks (ownsCompaction engine)", () => {
       leafId: "leaf-1",
     });
 
-    const result = await compactEmbeddedPiSession(
-      wrappedCompactionArgs({
-        currentTokenCount: 333,
-        config: {
-          agents: {
-            defaults: {
-              compaction: {
-                truncateAfterCompaction: true,
+    try {
+      const result = await compactEmbeddedPiSession(
+        wrappedCompactionArgs({
+          currentTokenCount: 333,
+          config: {
+            agents: {
+              defaults: {
+                compaction: {
+                  truncateAfterCompaction: true,
+                  postIndexSync: "await",
+                },
               },
             },
-          },
-        },
-      }),
-    );
+          } as never,
+        }),
+      );
 
-    expect(result.ok).toBe(true);
-    expect(result.compacted).toBe(true);
-    expect(rotateTranscriptFileAfterCompactionMock).toHaveBeenCalledWith({
-      sessionFile: TEST_SESSION_FILE,
-      synthesizeMissingBoundary: true,
-    });
-    expect(result.result?.sessionId).toBe("rotated-session");
-    expect(result.result?.sessionFile).toBe("/tmp/rotated-session.jsonl");
-    expect(result.result?.tokensBefore).toBe(333);
-    expect(result.result?.details).toEqual({ backend: "codex-app-server" });
+      expect(result.ok).toBe(true);
+      expect(result.compacted).toBe(true);
+      expect(rotateTranscriptFileAfterCompactionMock).toHaveBeenCalledWith({
+        sessionFile: TEST_SESSION_FILE,
+        synthesizeMissingBoundary: true,
+      });
+      expect(result.result?.sessionId).toBe("rotated-session");
+      expect(result.result?.sessionFile).toBe("/tmp/rotated-session.jsonl");
+      expect(result.result?.tokensBefore).toBe(333);
+      expect(result.result?.details).toEqual({ backend: "codex-app-server" });
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenCalledWith({
+        sessionFile: "/tmp/rotated-session.jsonl",
+        sessionKey: TEST_SESSION_KEY,
+      });
+      expect(sync).toHaveBeenCalledTimes(1);
+      expect(sync).toHaveBeenCalledWith({
+        reason: "post-compaction",
+        sessionFiles: ["/tmp/rotated-session.jsonl"],
+      });
+    } finally {
+      cleanup();
+    }
   });
 
   it("does not fire after_compaction when compaction fails", async () => {

--- a/src/agents/pi-embedded-runner/compact.hooks.test.ts
+++ b/src/agents/pi-embedded-runner/compact.hooks.test.ts
@@ -19,6 +19,7 @@ import {
   resolveSessionAgentIdMock,
   resolveSessionAgentIdsMock,
   rotateTranscriptAfterCompactionMock,
+  rotateTranscriptFileAfterCompactionMock,
   resetCompactHooksHarnessMocks,
   resetCompactSessionStateMocks,
   sessionAbortCompactionMock,
@@ -1323,6 +1324,51 @@ describe("compactEmbeddedPiSession hooks (ownsCompaction engine)", () => {
       authProfileId: "openai:p1",
       currentTokenCount: 333,
     });
+  });
+
+  it("rotates the active transcript after harness compaction without a delegated successor", async () => {
+    maybeCompactAgentHarnessSessionMock.mockResolvedValueOnce({
+      ok: true,
+      compacted: true,
+      result: {
+        summary: "",
+        firstKeptEntryId: "",
+        tokensBefore: 333,
+        details: { backend: "codex-app-server" },
+      },
+    });
+    rotateTranscriptFileAfterCompactionMock.mockResolvedValueOnce({
+      rotated: true,
+      sessionId: "rotated-session",
+      sessionFile: "/tmp/rotated-session.jsonl",
+      leafId: "leaf-1",
+    });
+
+    const result = await compactEmbeddedPiSession(
+      wrappedCompactionArgs({
+        currentTokenCount: 333,
+        config: {
+          agents: {
+            defaults: {
+              compaction: {
+                truncateAfterCompaction: true,
+              },
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.compacted).toBe(true);
+    expect(rotateTranscriptFileAfterCompactionMock).toHaveBeenCalledWith({
+      sessionFile: TEST_SESSION_FILE,
+      synthesizeMissingBoundary: true,
+    });
+    expect(result.result?.sessionId).toBe("rotated-session");
+    expect(result.result?.sessionFile).toBe("/tmp/rotated-session.jsonl");
+    expect(result.result?.tokensBefore).toBe(333);
+    expect(result.result?.details).toEqual({ backend: "codex-app-server" });
   });
 
   it("does not fire after_compaction when compaction fails", async () => {

--- a/src/agents/pi-embedded-runner/compact.queued.ts
+++ b/src/agents/pi-embedded-runner/compact.queued.ts
@@ -350,10 +350,16 @@ async function finalizeHarnessCompactionTranscript(params: {
     if (!rotation.rotated) {
       return result;
     }
+    const postCompactionSessionFile = rotation.sessionFile ?? params.params.sessionFile;
     log.info(
       `[compaction] rotated active transcript after harness compaction ` +
         `(sessionKey=${params.params.sessionKey ?? params.params.sessionId})`,
     );
+    await runPostCompactionSideEffects({
+      config: params.params.config,
+      sessionKey: params.params.sessionKey,
+      sessionFile: postCompactionSessionFile,
+    });
     return {
       ...result,
       result: {
@@ -367,8 +373,8 @@ async function finalizeHarnessCompactionTranscript(params: {
         ...(rotation.sessionId && rotation.sessionId !== params.params.sessionId
           ? { sessionId: rotation.sessionId }
           : {}),
-        ...(rotation.sessionFile && rotation.sessionFile !== params.params.sessionFile
-          ? { sessionFile: rotation.sessionFile }
+        ...(postCompactionSessionFile !== params.params.sessionFile
+          ? { sessionFile: postCompactionSessionFile }
           : {}),
       },
     };

--- a/src/agents/pi-embedded-runner/compact.queued.ts
+++ b/src/agents/pi-embedded-runner/compact.queued.ts
@@ -119,8 +119,12 @@ export async function compactEmbeddedPiSession(
     contextEngineRuntimeContext,
   });
   if (harnessResult) {
+    const finalizedHarnessResult = await finalizeHarnessCompactionTranscript({
+      params,
+      result: harnessResult,
+    });
     await contextEngine.dispose?.();
-    return harnessResult;
+    return finalizedHarnessResult;
   }
   const sessionLane = resolveSessionLane(params.sessionKey?.trim() || params.sessionId);
   const globalLane = resolveGlobalLane(params.lane);
@@ -200,6 +204,7 @@ export async function compactEmbeddedPiSession(
             try {
               const rotation = await rotateTranscriptFileAfterCompaction({
                 sessionFile: params.sessionFile,
+                synthesizeMissingBoundary: true,
               });
               if (rotation.rotated) {
                 postCompactionSessionId = rotation.sessionId ?? postCompactionSessionId;
@@ -316,6 +321,63 @@ export async function compactEmbeddedPiSession(
       }
     }),
   );
+}
+
+async function finalizeHarnessCompactionTranscript(params: {
+  params: CompactEmbeddedPiSessionParams;
+  result: EmbeddedPiCompactResult;
+}): Promise<EmbeddedPiCompactResult> {
+  const { result } = params;
+  if (!result.ok || !result.compacted || !shouldRotateCompactionTranscript(params.params.config)) {
+    return result;
+  }
+
+  const delegatedSessionId = result.result?.sessionId;
+  const delegatedSessionFile = result.result?.sessionFile;
+  const delegatedRotatedTranscript =
+    (typeof delegatedSessionId === "string" && delegatedSessionId !== params.params.sessionId) ||
+    (typeof delegatedSessionFile === "string" &&
+      delegatedSessionFile !== params.params.sessionFile);
+  if (delegatedRotatedTranscript) {
+    return result;
+  }
+
+  try {
+    const rotation = await rotateTranscriptFileAfterCompaction({
+      sessionFile: params.params.sessionFile,
+      synthesizeMissingBoundary: true,
+    });
+    if (!rotation.rotated) {
+      return result;
+    }
+    log.info(
+      `[compaction] rotated active transcript after harness compaction ` +
+        `(sessionKey=${params.params.sessionKey ?? params.params.sessionId})`,
+    );
+    return {
+      ...result,
+      result: {
+        summary: result.result?.summary ?? "",
+        firstKeptEntryId: result.result?.firstKeptEntryId ?? "",
+        tokensBefore: result.result?.tokensBefore ?? params.params.currentTokenCount ?? 0,
+        ...(result.result?.tokensAfter !== undefined
+          ? { tokensAfter: result.result.tokensAfter }
+          : {}),
+        ...(result.result?.details !== undefined ? { details: result.result.details } : {}),
+        ...(rotation.sessionId && rotation.sessionId !== params.params.sessionId
+          ? { sessionId: rotation.sessionId }
+          : {}),
+        ...(rotation.sessionFile && rotation.sessionFile !== params.params.sessionFile
+          ? { sessionFile: rotation.sessionFile }
+          : {}),
+      },
+    };
+  } catch (err) {
+    log.warn("failed to rotate compacted harness transcript", {
+      errorMessage: formatErrorMessage(err),
+    });
+    return result;
+  }
 }
 
 function buildCompactionContextEngineRuntimeContext(params: {

--- a/src/agents/pi-embedded-runner/compaction-successor-transcript.test.ts
+++ b/src/agents/pi-embedded-runner/compaction-successor-transcript.test.ts
@@ -314,6 +314,52 @@ describe("rotateTranscriptAfterCompaction", () => {
     expect(result.reason).toBe("no compaction entry");
   });
 
+  it("can synthesize a compaction boundary for external harness compaction", async () => {
+    const dir = await createTmpDir();
+    const manager = SessionManager.create(dir, dir);
+    for (let index = 1; index <= 45; index += 1) {
+      manager.appendMessage({
+        role: "user",
+        content: `message ${index}`,
+        timestamp: index,
+      });
+    }
+
+    const result = await rotateTranscriptAfterCompaction({
+      sessionManager: manager,
+      sessionFile: requireString(manager.getSessionFile(), "source session file"),
+      synthesizeMissingBoundary: true,
+      now: () => new Date("2026-04-27T12:20:00.000Z"),
+    });
+
+    expect(result.rotated).toBe(true);
+    const successor = SessionManager.open(
+      requireString(result.sessionFile, "successor session file"),
+    );
+    const context = successor.buildSessionContext().messages;
+    expect(context[0]).toMatchObject({
+      role: "compactionSummary",
+      summary: expect.stringContaining("external harness compacted this thread"),
+      tokensBefore: 0,
+    });
+    const contextText = JSON.stringify(context);
+    expect(contextText).not.toContain("message 5");
+    expect(contextText).toContain("message 6");
+    expect(contextText).toContain("message 45");
+
+    const compaction = requireEntryByType(
+      successor.getEntries(),
+      "compaction",
+      "synthetic compaction entry",
+    );
+    expect(compaction.details).toEqual({
+      external: true,
+      synthetic: true,
+      reason: "external compaction without transcript boundary",
+    });
+    expect(compaction.fromHook).toBe(true);
+  });
+
   it("uses a refreshed manager after manual boundary hardening", async () => {
     const dir = await createTmpDir();
     const manager = SessionManager.create(dir, dir);

--- a/src/agents/pi-embedded-runner/compaction-successor-transcript.ts
+++ b/src/agents/pi-embedded-runner/compaction-successor-transcript.ts
@@ -17,7 +17,15 @@ import {
 type ReadonlySessionManagerForRotation = Pick<
   TranscriptFileState,
   "buildSessionContext" | "getBranch" | "getCwd" | "getEntries" | "getHeader"
->;
+> & {
+  appendCompaction(
+    summary: string,
+    firstKeptEntryId: string,
+    tokensBefore: number,
+    details?: unknown,
+    fromHook?: boolean,
+  ): unknown;
+};
 
 export type CompactionTranscriptRotation = {
   rotated: boolean;
@@ -29,6 +37,10 @@ export type CompactionTranscriptRotation = {
   entriesWritten?: number;
 };
 
+const SYNTHETIC_COMPACTION_TAIL_MESSAGE_COUNT = 40;
+const SYNTHETIC_COMPACTION_SUMMARY =
+  "An external harness compacted this thread without writing an OpenClaw transcript boundary. Earlier transcript entries remain in the archived parent session file; this successor preserves the recent unsummarized tail for UI and history continuity.";
+
 export function shouldRotateCompactionTranscript(config?: OpenClawConfig): boolean {
   return config?.agents?.defaults?.compaction?.truncateAfterCompaction === true;
 }
@@ -36,6 +48,7 @@ export function shouldRotateCompactionTranscript(config?: OpenClawConfig): boole
 export async function rotateTranscriptAfterCompaction(params: {
   sessionManager: ReadonlySessionManagerForRotation;
   sessionFile: string;
+  synthesizeMissingBoundary?: boolean;
   now?: () => Date;
 }): Promise<CompactionTranscriptRotation> {
   const sessionFile = params.sessionFile.trim();
@@ -43,8 +56,26 @@ export async function rotateTranscriptAfterCompaction(params: {
     return { rotated: false, reason: "missing session file" };
   }
 
-  const branch = params.sessionManager.getBranch();
-  const latestCompactionIndex = findLatestCompactionIndex(branch);
+  let branch = params.sessionManager.getBranch();
+  let latestCompactionIndex = findLatestCompactionIndex(branch);
+  if (latestCompactionIndex < 0 && params.synthesizeMissingBoundary === true) {
+    const firstKeptEntryId = findSyntheticCompactionFirstKeptEntryId(branch);
+    if (firstKeptEntryId) {
+      params.sessionManager.appendCompaction(
+        SYNTHETIC_COMPACTION_SUMMARY,
+        firstKeptEntryId,
+        0,
+        {
+          external: true,
+          synthetic: true,
+          reason: "external compaction without transcript boundary",
+        },
+        true,
+      );
+      branch = params.sessionManager.getBranch();
+      latestCompactionIndex = findLatestCompactionIndex(branch);
+    }
+  }
   if (latestCompactionIndex < 0) {
     return { rotated: false, reason: "no compaction entry" };
   }
@@ -88,14 +119,33 @@ export async function rotateTranscriptAfterCompaction(params: {
 
 export async function rotateTranscriptFileAfterCompaction(params: {
   sessionFile: string;
+  synthesizeMissingBoundary?: boolean;
   now?: () => Date;
 }): Promise<CompactionTranscriptRotation> {
   const state = await readTranscriptFileState(params.sessionFile);
   return rotateTranscriptAfterCompaction({
     sessionManager: state,
     sessionFile: params.sessionFile,
+    ...(params.synthesizeMissingBoundary
+      ? { synthesizeMissingBoundary: params.synthesizeMissingBoundary }
+      : {}),
     ...(params.now ? { now: params.now } : {}),
   });
+}
+
+function findSyntheticCompactionFirstKeptEntryId(branch: SessionEntry[]): string | undefined {
+  let seenMessages = 0;
+  for (let index = branch.length - 1; index >= 0; index -= 1) {
+    const entry = branch[index];
+    if (!entry || entry.type !== "message") {
+      continue;
+    }
+    seenMessages += 1;
+    if (seenMessages >= SYNTHETIC_COMPACTION_TAIL_MESSAGE_COUNT) {
+      return entry.id;
+    }
+  }
+  return branch.find((entry) => entry.type === "message")?.id;
 }
 
 function findLatestCompactionIndex(entries: SessionEntry[]): number {


### PR DESCRIPTION
## Summary

- Rotate the active transcript after a successful agent-harness compaction when the harness did not already return a successor transcript.
- Add an opt-in synthetic compaction boundary for external harness compaction that does not write an OpenClaw transcript boundary, preserving the recent unsummarized tail while keeping the original parent transcript archived.
- Cover the transcript utility and queued harness compaction path with focused tests.

## Verification

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-pi-embedded.config.ts src/agents/pi-embedded-runner/compaction-successor-transcript.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-pi-embedded.config.ts src/agents/pi-embedded-runner/compact.hooks.test.ts`
- `pnpm tsgo:core:test`
- `pnpm exec oxfmt --check --threads=1 src/agents/pi-embedded-runner/compact.queued.ts src/agents/pi-embedded-runner/compaction-successor-transcript.ts src/agents/pi-embedded-runner/compact.hooks.harness.ts src/agents/pi-embedded-runner/compact.hooks.test.ts src/agents/pi-embedded-runner/compaction-successor-transcript.test.ts`
- `git diff --check`

## Real behavior proof

Behavior addressed: Successful external agent-harness compaction, including Codex native app-server compaction, can compact the provider thread without writing an OpenClaw `type: "compaction"` transcript boundary. With `agents.defaults.compaction.truncateAfterCompaction = true`, OpenClaw should still rotate to a smaller active successor transcript instead of continuing to carry the bloated parent transcript.

Real environment tested: Han's local OpenClaw setup on macOS, running installed OpenClaw `2026.5.16-beta.3` with the equivalent local hot patch applied while investigating this regression. The source PR moves the same behavior into the core harness compaction wrapper.

Exact steps or command run after this patch: Ran `openclaw --version`, `openclaw health --json`, and a local Codex-native compaction smoke that copied the real main session transcript, simulated the Codex app-server compaction completion path, and inspected the rotated successor transcript written by OpenClaw.

Evidence after fix: Terminal output from the real local OpenClaw setup:

```text
$ openclaw --version
OpenClaw 2026.5.16-beta.3 (d08cbf7)

$ openclaw health --json | node -e '...print ok...'
{
  "ok": true
}

$ node inspect-codex-native-compaction-smoke.js
{
  "smoke": "codex-native-compaction-installed-openclaw",
  "sourceBytes": 958625,
  "successorBytes": 106636,
  "successorLines": 42,
  "successorMessages": 40,
  "successorCompactions": 1,
  "parentSessionPreserved": true,
  "syntheticCompaction": true,
  "compactionBackend": "codex-app-server",
  "firstKeptEntryIdPresent": true
}
```

Observed result after fix: The active successor transcript shrank from `958625` bytes to `106636` bytes, retained the recent `40` message tail, wrote exactly one synthetic compaction entry for the Codex app-server backend, and preserved the original parent transcript path for rollback/history.

What was not tested: A full live WebChat browser run from this source branch was not run in the PR worktree; the live setup proof above was run against the installed local OpenClaw bundle with the equivalent hot patch.
