### PR TITLE
fix(update): repair configured plugins during legacy upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,7 @@ Docs: https://docs.openclaw.ai
 - Telegram: send the transcript-backed full final answer after progress-mode tool drafts when the dispatcher final payload is an ellipsis-truncated snapshot. Fixes #82409. Thanks @PashaGanson.
 - Providers/Ollama: omit truthy native `think` payloads for models marked non-reasoning while preserving supported thinking models and explicit `think: false`. (#82445) Thanks @leno23.
 - Update/channels: preserve pre-update channel config through package-swap doctor and post-core plugin repair so externalized channel upgrades do not drop configured chat channels. Fixes #82533. Thanks @imbaig.
+- Update/doctor: repair configured externalized plugin installs during legacy 2026.4.x upgrades so configured Discord channels remain available after 2026.5.x package updates. Fixes #82813. (#82859) Thanks @joshavant.
 - CLI/context engines: bootstrap and finalize non-legacy context engines for CLI turns while preserving transcript snapshots and deferred maintenance ownership. (#81869) Thanks @sahilsatralkar.
 - Telegram: persist polling updates through restart replay so queued same-topic messages resume in order instead of losing context after a gateway restart. (#82256) Thanks @VACInc.
 - Gateway/Gmail: abort in-flight Gmail watcher startup and hot-reload restarts before shutdown so reloads cannot spawn `gog serve` after the Gateway is closing. Thanks @frankekn.

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -4535,6 +4535,7 @@ describe("update-cli", () => {
     await withEnvAsync(
       {
         OPENCLAW_UPDATE_IN_PROGRESS: undefined,
+        OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR: undefined,
         OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE: undefined,
       },
       async () => {
@@ -4547,8 +4548,10 @@ describe("update-cli", () => {
         await updateFinalizeCommand({ json: true, yes: true, timeout: "9", restart: false });
 
         expect(doctorEnv?.OPENCLAW_UPDATE_IN_PROGRESS).toBe("1");
+        expect(doctorEnv?.OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR).toBe("1");
         expect(doctorEnv?.OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE).toBe("1");
         expect(process.env.OPENCLAW_UPDATE_IN_PROGRESS).toBeUndefined();
+        expect(process.env.OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR).toBeUndefined();
         expect(process.env.OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE).toBeUndefined();
         expect(doctorCommand).toHaveBeenCalledWith(defaultRuntime, {
           nonInteractive: true,

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -9,6 +9,7 @@ import {
   ensureCompletionCacheExists,
 } from "../../commands/doctor-completion.js";
 import { doctorCommand } from "../../commands/doctor.js";
+import { UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV } from "../../commands/doctor/shared/update-phase.js";
 import { createPreUpdateConfigSnapshot } from "../../config/backup-rotation.js";
 import {
   assertConfigWriteAllowedInCurrentMode,
@@ -1264,6 +1265,7 @@ async function runPackageInstallUpdate(params: {
               invocationCwd: params.invocationCwd,
             }),
             OPENCLAW_UPDATE_IN_PROGRESS: "1",
+            [UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV]: "1",
             [UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV]: "1",
           },
           timeoutMs: params.timeoutMs,
@@ -1336,6 +1338,7 @@ async function runGitUpdate(params: {
     channel: params.channel,
     tag: params.tag,
     devTargetRef: params.devTargetRef,
+    deferConfiguredPluginInstallRepair: true,
   });
   const steps = [...(cloneStep ? [cloneStep] : []), ...updateResult.steps];
 
@@ -2018,15 +2021,24 @@ type UpdateFinalizeResult = {
 
 function withUpdateFinalizationEnv<T>(run: () => Promise<T>): Promise<T> {
   const previousUpdateInProgress = process.env.OPENCLAW_UPDATE_IN_PROGRESS;
+  const previousDeferConfiguredPluginInstallRepair =
+    process.env[UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV];
   const previousParentSupportsDoctorConfigWrite =
     process.env[UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV];
   process.env.OPENCLAW_UPDATE_IN_PROGRESS = "1";
+  process.env[UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV] = "1";
   process.env[UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV] = "1";
   return run().finally(() => {
     if (previousUpdateInProgress === undefined) {
       delete process.env.OPENCLAW_UPDATE_IN_PROGRESS;
     } else {
       process.env.OPENCLAW_UPDATE_IN_PROGRESS = previousUpdateInProgress;
+    }
+    if (previousDeferConfiguredPluginInstallRepair === undefined) {
+      delete process.env[UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV];
+    } else {
+      process.env[UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV] =
+        previousDeferConfiguredPluginInstallRepair;
     }
     if (previousParentSupportsDoctorConfigWrite === undefined) {
       delete process.env[UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV];

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -1192,7 +1192,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     const result = await repairMissingConfiguredPluginInstalls({
       cfg: {
         channels: {
-          whatsapp: { enabled: true, authDir: "/tmp/wa" },
+          whatsapp: { enabled: true, allowFrom: ["+15555550123"] },
         },
       },
       env: {

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -962,6 +962,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       },
       env: {
         OPENCLAW_UPDATE_IN_PROGRESS: "1",
+        OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR: "1",
       },
     });
 
@@ -1061,6 +1062,7 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       },
       env: {
         OPENCLAW_UPDATE_IN_PROGRESS: "1",
+        OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR: "1",
       },
     });
 
@@ -1077,7 +1079,53 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     });
   });
 
-  it("does not install channel-selected external plugins during the package update doctor pass", async () => {
+  it("does not install channel-selected external plugins during an opted-in package update doctor pass", async () => {
+    mocks.listChannelPluginCatalogEntries.mockReturnValue([
+      {
+        id: "discord",
+        pluginId: "discord",
+        meta: { label: "Discord" },
+        install: {
+          npmSpec: "@openclaw/discord",
+        },
+      },
+    ]);
+
+    const { repairMissingConfiguredPluginInstalls } =
+      await import("./missing-configured-plugin-install.js");
+    const result = await repairMissingConfiguredPluginInstalls({
+      cfg: {
+        channels: {
+          discord: { enabled: true, token: "secret" },
+        },
+      },
+      env: {
+        OPENCLAW_UPDATE_IN_PROGRESS: "1",
+        OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR: "1",
+      },
+    });
+
+    expect(mocks.updateNpmInstalledPlugins).not.toHaveBeenCalled();
+    expect(mocks.installPluginFromClawHub).not.toHaveBeenCalled();
+    expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
+    expect(mocks.writePersistedInstalledPluginIndexInstallRecords).not.toHaveBeenCalled();
+    expect(result).toEqual({ changes: [], warnings: [], records: {} });
+  });
+
+  it("installs channel-selected external plugins during a legacy package update doctor pass", async () => {
+    mocks.installPluginFromNpmSpec.mockResolvedValueOnce({
+      ok: true,
+      pluginId: "discord",
+      targetDir: "/tmp/openclaw-plugins/discord",
+      version: "2026.5.17",
+      npmResolution: {
+        name: "@openclaw/discord",
+        version: "2026.5.17",
+        resolvedSpec: "@openclaw/discord@2026.5.17",
+        integrity: "sha512-discord",
+        resolvedAt: "2026-05-17T00:00:00.000Z",
+      },
+    });
     mocks.listChannelPluginCatalogEntries.mockReturnValue([
       {
         id: "discord",
@@ -1102,11 +1150,104 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       },
     });
 
-    expect(mocks.updateNpmInstalledPlugins).not.toHaveBeenCalled();
+    expect(mocks.installPluginFromNpmSpec).toHaveBeenCalledTimes(1);
+    expect(result.changes).toEqual([
+      'Installed missing configured plugin "discord" from @openclaw/discord.',
+    ]);
+    expectRecordFields(result.records.discord, {
+      source: "npm",
+      installPath: "/tmp/openclaw-plugins/discord",
+    });
+  });
+
+  it("prefers npm over ClawHub during a legacy package update doctor pass", async () => {
+    mocks.installPluginFromNpmSpec.mockResolvedValueOnce({
+      ok: true,
+      pluginId: "whatsapp",
+      targetDir: "/tmp/openclaw-plugins/whatsapp",
+      version: "2026.5.17",
+      npmResolution: {
+        name: "@openclaw/whatsapp",
+        version: "2026.5.17",
+        resolvedSpec: "@openclaw/whatsapp@2026.5.17",
+        integrity: "sha512-whatsapp",
+        resolvedAt: "2026-05-17T00:00:00.000Z",
+      },
+    });
+    mocks.listChannelPluginCatalogEntries.mockReturnValue([
+      {
+        id: "whatsapp",
+        pluginId: "whatsapp",
+        meta: { label: "WhatsApp" },
+        install: {
+          clawhubSpec: "clawhub:@openclaw/whatsapp",
+          npmSpec: "@openclaw/whatsapp",
+          defaultChoice: "clawhub",
+        },
+      },
+    ]);
+
+    const { repairMissingConfiguredPluginInstalls } =
+      await import("./missing-configured-plugin-install.js");
+    const result = await repairMissingConfiguredPluginInstalls({
+      cfg: {
+        channels: {
+          whatsapp: { enabled: true, authDir: "/tmp/wa" },
+        },
+      },
+      env: {
+        OPENCLAW_UPDATE_IN_PROGRESS: "1",
+      },
+    });
+
     expect(mocks.installPluginFromClawHub).not.toHaveBeenCalled();
+    expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
+      spec: "@openclaw/whatsapp",
+      expectedPluginId: "whatsapp",
+    });
+    expect(result.changes).toEqual([
+      'Installed missing configured plugin "whatsapp" from @openclaw/whatsapp.',
+    ]);
+    expectRecordFields(result.records.whatsapp, {
+      source: "npm",
+      installPath: "/tmp/openclaw-plugins/whatsapp",
+    });
+  });
+
+  it("keeps ClawHub-only candidates available during a legacy package update doctor pass", async () => {
+    mocks.listChannelPluginCatalogEntries.mockReturnValue([
+      {
+        id: "matrix",
+        pluginId: "matrix",
+        meta: { label: "Matrix" },
+        install: {
+          clawhubSpec: "clawhub:@openclaw/plugin-matrix@stable",
+          defaultChoice: "clawhub",
+        },
+      },
+    ]);
+
+    const { repairMissingConfiguredPluginInstalls } =
+      await import("./missing-configured-plugin-install.js");
+    const result = await repairMissingConfiguredPluginInstalls({
+      cfg: {
+        channels: {
+          matrix: { enabled: true, homeserver: "https://matrix.example.org" },
+        },
+      },
+      env: {
+        OPENCLAW_UPDATE_IN_PROGRESS: "1",
+      },
+    });
+
+    expectRecordFields(mockCallArg(mocks.installPluginFromClawHub), {
+      spec: "clawhub:@openclaw/plugin-matrix@stable",
+      expectedPluginId: "matrix",
+    });
     expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
-    expect(mocks.writePersistedInstalledPluginIndexInstallRecords).not.toHaveBeenCalled();
-    expect(result).toEqual({ changes: [], warnings: [], records: {} });
+    expect(result.changes).toEqual([
+      'Installed missing configured plugin "matrix" from clawhub:@openclaw/plugin-matrix@stable.',
+    ]);
   });
 
   it("does not install configured plugins when plugins are globally disabled", async () => {

--- a/src/commands/doctor/shared/missing-configured-plugin-install.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.ts
@@ -50,7 +50,10 @@ import { normalizeOptionalLowercaseString } from "../../../shared/string-coerce.
 import { resolveUserPath } from "../../../utils.js";
 import { VERSION } from "../../../version.js";
 import { asObjectRecord } from "./object.js";
-import { isUpdatePackageSwapInProgress } from "./update-phase.js";
+import {
+  isLegacyPackageUpdateDoctorPass,
+  shouldDeferConfiguredPluginInstallRepair,
+} from "./update-phase.js";
 
 type DownloadableInstallCandidate = {
   pluginId: string;
@@ -763,6 +766,7 @@ async function installCandidate(params: {
   records: Record<string, PluginInstallRecord>;
   updateChannel?: UpdateChannel;
   mode?: "install" | "update";
+  preferNpm?: boolean;
 }): Promise<{
   records: Record<string, PluginInstallRecord>;
   changes: string[];
@@ -786,7 +790,11 @@ async function installCandidate(params: {
     : null;
   const clawhubInstallSpec = clawhubSpecs?.installSpec ?? candidate.clawhubSpec;
   const npmInstallSpec = npmSpecs?.installSpec ?? candidate.npmSpec;
-  if (clawhubInstallSpec && candidate.defaultChoice !== "npm") {
+  const shouldTryClawHub =
+    clawhubInstallSpec &&
+    !(params.preferNpm && npmInstallSpec) &&
+    candidate.defaultChoice !== "npm";
+  if (shouldTryClawHub) {
     const clawhubResult = await installPluginFromClawHub({
       spec: clawhubInstallSpec,
       extensionsDir,
@@ -1012,6 +1020,7 @@ async function repairMissingPluginInstalls(params: {
     configChannel: normalizeUpdateChannel(params.cfg.update?.channel),
     currentVersion: VERSION,
   });
+  const preferNpmInstalls = isLegacyPackageUpdateDoctorPass(env);
   let nextRecords = records;
 
   for (const [pluginId, record] of Object.entries(records)) {
@@ -1026,7 +1035,7 @@ async function repairMissingPluginInstalls(params: {
     changes.push(`Removed stale managed install record for bundled plugin "${pluginId}".`);
   }
 
-  if (isUpdatePackageSwapInProgress(env)) {
+  if (shouldDeferConfiguredPluginInstallRepair(env)) {
     const updateDeferredPluginIds = collectUpdateDeferredPluginIds({
       cfg: params.cfg,
       env,
@@ -1171,6 +1180,7 @@ async function repairMissingPluginInstalls(params: {
       records: nextRecords,
       updateChannel,
       mode: shouldReplaceBrokenOfficialInstall ? "update" : "install",
+      preferNpm: preferNpmInstalls,
     });
     if (shouldReplaceBrokenOfficialInstall) {
       const installedRecord = installed.records[candidate.pluginId];

--- a/src/commands/doctor/shared/release-configured-plugin-installs.test.ts
+++ b/src/commands/doctor/shared/release-configured-plugin-installs.test.ts
@@ -352,12 +352,18 @@ describe("configured plugin install release step", () => {
       },
       currentVersion: "2026.5.2-beta.1",
       touchedVersion: "2026.5.1",
-      env: { OPENCLAW_UPDATE_IN_PROGRESS: "1" },
+      env: {
+        OPENCLAW_UPDATE_IN_PROGRESS: "1",
+        OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR: "1",
+      },
     });
 
     const repairCall = readOnlyMissingPluginInstallRepairCall();
     expect(repairCall.pluginIds).toEqual(["codex"]);
-    expect(repairCall.env).toEqual({ OPENCLAW_UPDATE_IN_PROGRESS: "1" });
+    expect(repairCall.env).toEqual({
+      OPENCLAW_UPDATE_IN_PROGRESS: "1",
+      OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR: "1",
+    });
     expect(result).toEqual({
       changes: [
         'Skipped package-manager repair for configured plugin "codex" during package update; rerun "openclaw doctor --fix" after the update completes.',

--- a/src/commands/doctor/shared/release-configured-plugin-installs.ts
+++ b/src/commands/doctor/shared/release-configured-plugin-installs.ts
@@ -12,7 +12,7 @@ import { resolveWebSearchInstallCatalogEntry } from "../../../plugins/web-search
 import { VERSION } from "../../../version.js";
 import { repairMissingPluginInstallsForIds } from "./missing-configured-plugin-install.js";
 import { asObjectRecord } from "./object.js";
-import { isUpdatePackageSwapInProgress } from "./update-phase.js";
+import { shouldDeferConfiguredPluginInstallRepair } from "./update-phase.js";
 
 export const CONFIGURED_PLUGIN_INSTALL_RELEASE_VERSION = "2026.5.2-beta.1";
 
@@ -326,7 +326,7 @@ export async function maybeRunConfiguredPluginInstallReleaseStep(params: {
   touchedConfig: boolean;
 }> {
   const env = params.env ?? process.env;
-  const updateInProgress = isUpdatePackageSwapInProgress(env);
+  const updateInProgress = shouldDeferConfiguredPluginInstallRepair(env);
   const configured = collectReleaseConfiguredPluginIds({ cfg: params.cfg, env });
   const shouldRunReleaseStep = shouldRunConfiguredPluginInstallReleaseStep({
     currentVersion: params.currentVersion,

--- a/src/commands/doctor/shared/update-phase.test.ts
+++ b/src/commands/doctor/shared/update-phase.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest";
 import {
+  UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV,
   UPDATE_IN_PROGRESS_ENV,
   UPDATE_POST_CORE_CONVERGENCE_ENV,
+  isLegacyPackageUpdateDoctorPass,
   isPostCoreConvergencePass,
   isUpdatePackageSwapInProgress,
+  shouldDeferConfiguredPluginInstallRepair,
 } from "./update-phase.js";
 
 describe("update-phase env helpers", () => {
@@ -29,5 +32,46 @@ describe("update-phase env helpers", () => {
     };
     expect(isUpdatePackageSwapInProgress(env)).toBe(false);
     expect(isPostCoreConvergencePass(env)).toBe(true);
+  });
+
+  it("defers configured plugin repair only when the updater explicitly opts in", () => {
+    expect(
+      shouldDeferConfiguredPluginInstallRepair({
+        [UPDATE_IN_PROGRESS_ENV]: "1",
+      }),
+    ).toBe(false);
+    expect(
+      shouldDeferConfiguredPluginInstallRepair({
+        [UPDATE_IN_PROGRESS_ENV]: "1",
+        [UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV]: "1",
+      }),
+    ).toBe(true);
+    expect(
+      shouldDeferConfiguredPluginInstallRepair({
+        [UPDATE_IN_PROGRESS_ENV]: "1",
+        [UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV]: "1",
+        [UPDATE_POST_CORE_CONVERGENCE_ENV]: "1",
+      }),
+    ).toBe(false);
+  });
+
+  it("identifies legacy package update doctor passes", () => {
+    expect(
+      isLegacyPackageUpdateDoctorPass({
+        [UPDATE_IN_PROGRESS_ENV]: "1",
+      }),
+    ).toBe(true);
+    expect(
+      isLegacyPackageUpdateDoctorPass({
+        [UPDATE_IN_PROGRESS_ENV]: "1",
+        [UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV]: "1",
+      }),
+    ).toBe(false);
+    expect(
+      isLegacyPackageUpdateDoctorPass({
+        [UPDATE_IN_PROGRESS_ENV]: "1",
+        [UPDATE_POST_CORE_CONVERGENCE_ENV]: "1",
+      }),
+    ).toBe(false);
   });
 });

--- a/src/commands/doctor/shared/update-phase.ts
+++ b/src/commands/doctor/shared/update-phase.ts
@@ -2,6 +2,8 @@ import { isTruthyEnvValue } from "../../../infra/env.js";
 
 export const UPDATE_IN_PROGRESS_ENV = "OPENCLAW_UPDATE_IN_PROGRESS";
 export const UPDATE_POST_CORE_CONVERGENCE_ENV = "OPENCLAW_UPDATE_POST_CORE_CONVERGENCE";
+export const UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV =
+  "OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR";
 
 /**
  * True iff the caller is the doctor pass that runs WHILE the core package
@@ -31,6 +33,29 @@ export function isUpdatePackageSwapInProgress(env: NodeJS.ProcessEnv): boolean {
     return false;
   }
   return isTruthyEnvValue(env[UPDATE_IN_PROGRESS_ENV]);
+}
+
+/**
+ * True iff configured plugin install repair should be deferred because the
+ * updater guarantees a later post-core convergence pass. Older updaters only
+ * set `OPENCLAW_UPDATE_IN_PROGRESS`; when they run a newer doctor from the
+ * swapped package, repair must proceed there or externalized plugins stay
+ * missing until the operator manually runs doctor.
+ */
+export function shouldDeferConfiguredPluginInstallRepair(env: NodeJS.ProcessEnv): boolean {
+  return (
+    isUpdatePackageSwapInProgress(env) &&
+    isTruthyEnvValue(env[UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV])
+  );
+}
+
+/**
+ * True iff this newer doctor is running under an older updater. Legacy
+ * updaters set only `OPENCLAW_UPDATE_IN_PROGRESS`; they do not opt into the
+ * post-core convergence pass, so configured plugin repair must happen now.
+ */
+export function isLegacyPackageUpdateDoctorPass(env: NodeJS.ProcessEnv): boolean {
+  return isUpdatePackageSwapInProgress(env) && !shouldDeferConfiguredPluginInstallRepair(env);
 }
 
 /**

--- a/src/infra/update-runner.test.ts
+++ b/src/infra/update-runner.test.ts
@@ -212,6 +212,7 @@ describe("runGatewayUpdate", () => {
       tag?: string;
       cwd?: string;
       devTargetRef?: string;
+      deferConfiguredPluginInstallRepair?: boolean;
     },
   ) {
     return runGatewayUpdate({
@@ -221,6 +222,9 @@ describe("runGatewayUpdate", () => {
       ...(options?.channel ? { channel: options.channel } : {}),
       ...(options?.tag ? { tag: options.tag } : {}),
       ...(options?.devTargetRef ? { devTargetRef: options.devTargetRef } : {}),
+      ...(options?.deferConfiguredPluginInstallRepair
+        ? { deferConfiguredPluginInstallRepair: true }
+        : {}),
     });
   }
 
@@ -231,6 +235,7 @@ describe("runGatewayUpdate", () => {
       tag?: string;
       cwd?: string;
       devTargetRef?: string;
+      deferConfiguredPluginInstallRepair?: boolean;
     },
   ) {
     return runWithCommand(runner, options);
@@ -427,6 +432,38 @@ describe("runGatewayUpdate", () => {
       npm_config_resolution_mode: "highest",
       pnpm_config_resolution_mode: "highest",
     });
+  });
+
+  it("marks git update doctor passes for configured-plugin repair deferral when requested", async () => {
+    await setupGitCheckout({ packageManager: "pnpm@8.0.0" });
+    await setupUiIndex();
+    const stableTag = "v1.0.1-1";
+    let doctorEnv: NodeJS.ProcessEnv | undefined;
+    const doctorNodePath = await resolveStableNodePath(process.execPath);
+    const doctorCommand = `${doctorNodePath} ${path.join(tempDir, "openclaw.mjs")} doctor --non-interactive --fix`;
+    const { runCommand } = createGitInstallRunner({
+      stableTag,
+      installCommand: "pnpm install",
+      buildCommand: "pnpm build",
+      uiBuildCommand: "pnpm ui:build",
+      doctorCommand,
+      onCommand: (key, options) => {
+        if (key === doctorCommand) {
+          doctorEnv = options?.env;
+        }
+        return undefined;
+      },
+    });
+
+    const result = await runWithCommand(runCommand, {
+      channel: "stable",
+      deferConfiguredPluginInstallRepair: true,
+    });
+
+    expect(result.status).toBe("ok");
+    expect(doctorEnv?.OPENCLAW_UPDATE_IN_PROGRESS).toBe("1");
+    expect(doctorEnv?.OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR).toBe("1");
+    expect(doctorEnv?.OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE).toBe("1");
   });
 
   it("uses pnpm highest resolution mode for dev preflight installs", async () => {

--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -126,6 +126,7 @@ type UpdateRunnerOptions = {
   tag?: string;
   channel?: UpdateChannel;
   devTargetRef?: string;
+  deferConfiguredPluginInstallRepair?: boolean;
   timeoutMs?: number;
   runCommand?: CommandRunner;
   progress?: UpdateStepProgress;
@@ -168,6 +169,8 @@ const MAX_LOG_CHARS = 8000;
 const PREFLIGHT_MAX_COMMITS = 10;
 const DEFAULT_PACKAGE_NAME = "openclaw";
 const CORE_PACKAGE_NAMES = new Set([DEFAULT_PACKAGE_NAME]);
+const UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV =
+  "OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR";
 const UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV =
   "OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE";
 const PREFLIGHT_TEMP_PREFIX =
@@ -1318,6 +1321,9 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
       const doctorStep = await runStep(
         step("openclaw doctor", doctorArgv, gitRoot, {
           OPENCLAW_UPDATE_IN_PROGRESS: "1",
+          ...(opts.deferConfiguredPluginInstallRepair
+            ? { [UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV]: "1" }
+            : {}),
           [UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV]: "1",
         }),
       );


### PR DESCRIPTION
## Summary

- Problem: upgrading from 2026.4.x to 2026.5.x could leave configured externalized channel plugins, including Discord, without installed plugin payloads.
- Why it matters: the existing channel config survived but the channel appeared disabled/missing until the operator manually installed the plugin.
- What changed: current update doctor passes now opt into configured-plugin repair deferral, while legacy update handoffs repair missing configured plugin installs immediately and prefer npm only in that legacy handoff when both npm and ClawHub specs exist.
- What did NOT change (scope boundary): this does not change normal doctor behavior outside update handoffs, and it does not change channel list diagnostics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #82813
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

Behavior addressed: configured Discord/Telegram/WhatsApp channel plugin installs survive a 2026.4.27 -> current package upgrade without requiring manual `openclaw plugins install discord`.

Real environment tested: AWS Crabbox direct-provider Linux host, provider `aws`, lease `cbx_df0f5805c899`, Docker published-upgrade-survivor lane.

Exact steps or command run after this patch:

```sh
OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE=1 \
OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC=openclaw@2026.4.27 \
OPENCLAW_UPGRADE_SURVIVOR_SCENARIO=base \
OPENCLAW_UPGRADE_SURVIVOR_DOCKER_RUN_TIMEOUT=1800s \
OPENCLAW_SKIP_CHANNELS=1 \
pnpm test:docker:published-upgrade-survivor
```

Evidence after fix: Crabbox run `run_40c5ff416aa2`, provider `aws`, lease `cbx_df0f5805c899`, printed `Upgrade survivor Docker E2E passed baseline=openclaw@2026.4.27 scenario=base candidate=2026.5.17`.

Observed result after fix: baseline `openclaw@2026.4.27` upgraded to the patched current tarball, doctor and post-upgrade survival assertions passed, gateway started, and health/status probes passed.

What was not tested: live Discord API traffic was not exercised; channel runtime startup used the upgrade-survivor lane's channel-skipping setup to focus on install/upgrade survival.

Before evidence (optional but encouraged): pre-fix AWS repro showed `openclaw update` post-update plugin sync made no changes and standalone doctor later reported missing configured plugin installs, including Discord.

## Root Cause (if applicable)

- Root cause: missing configured plugin install repair was gated on `OPENCLAW_UPDATE_IN_PROGRESS`, but legacy 2026.4.x updaters set only that env while running newer doctor code and do not have the newer post-core convergence phase.
- Missing detection / guardrail: update-phase helpers did not distinguish current update handoffs that should defer repair from legacy handoffs that must repair immediately.
- Contributing context: some externalized plugins publish both npm and ClawHub install specs, but ClawHub payloads can require a newer plugin API than the old runtime executing the legacy update handoff.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [x] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/commands/doctor/shared/missing-configured-plugin-install.test.ts`, `src/commands/doctor/shared/update-phase.test.ts`, `src/commands/doctor/shared/release-configured-plugin-installs.test.ts`, `src/infra/update-runner.test.ts`, `src/cli/update-cli.test.ts`.
- Scenario the test should lock in: legacy update doctor repairs configured plugin installs, current update/finalize/git doctors defer to post-core convergence, and ClawHub-only candidates still work.
- Why this is the smallest reliable guardrail: these tests lock the phase/env contract and installer-source selection without requiring Docker for every edit loop.
- Existing test that already covers this (if any): published upgrade-survivor Docker E2E covers the reported upgrade path.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Users upgrading from older 2026.4.x installs should keep configured externalized channel plugins installed automatically instead of needing manual plugin installation after update.

## Diagram (if applicable)

```text
Before:
2026.4.x updater -> newer doctor sees OPENCLAW_UPDATE_IN_PROGRESS -> defers repair -> plugin missing

After:
legacy updater -> newer doctor sees no explicit defer marker -> repairs configured plugin install
current updater -> newer doctor sets explicit defer marker -> post-core convergence repairs and smoke-checks
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: AWS Crabbox Linux
- Runtime/container: Node 22, pnpm 11.1.0, Docker published-upgrade-survivor E2E
- Model/provider: N/A
- Integration/channel (if any): Discord/Telegram/WhatsApp configured channel plugin install survival
- Relevant config (redacted): upgrade-survivor baseline recipe with configured `channels.discord`, `channels.telegram`, and `channels.whatsapp`

### Steps

1. Install published baseline `openclaw@2026.4.27` in the upgrade-survivor container.
2. Seed configured channel/plugin state from the baseline recipe.
3. Upgrade to the patched current tarball.
4. Run doctor, survival assertions, gateway start, and status probes.

### Expected

- Missing configured plugin installs are repaired during the legacy handoff/update path, and gateway startup/status probes pass.

### Actual

- AWS Crabbox `run_40c5ff416aa2` passed the full published upgrade-survivor lane.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: local focused tests; post-review AWS Crabbox 2026.4.27 -> patched current upgrade-survivor Docker E2E.
- Edge cases checked: current package/finalize/git doctor deferral, legacy update repair, npm-over-ClawHub only when npm exists, ClawHub-only candidates still install.
- What you did **not** verify: real Discord bot message delivery.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? Yes
- Migration needed? No
- If yes, exact upgrade steps: no user action; current update paths set an internal defer marker, while legacy handoffs are inferred by its absence.

## Risks and Mitigations

- Risk: installing too early during current update flows could bypass post-core convergence.
  - Mitigation: current package/finalize/git update doctor paths explicitly set the defer marker and have regression tests.
- Risk: preferring npm in legacy handoff could break ClawHub-only installs.
  - Mitigation: npm is preferred only when an npm spec exists; ClawHub-only behavior has regression coverage.
