### PR TITLE
fix(media-understanding): include prompt text in user message for image requests

### DIFF
--- a/src/media-understanding/image.test.ts
+++ b/src/media-understanding/image.test.ts
@@ -209,6 +209,7 @@ describe("describeImageWithModel", () => {
           expect.objectContaining({
             role: "user",
             content: [
+              expect.objectContaining({ type: "text", text: "Describe the image." }),
               expect.objectContaining({
                 type: "image",
                 mimeType: "image/png",
@@ -220,7 +221,7 @@ describe("describeImageWithModel", () => {
       expect.any(Object),
     );
     const [, context] = completeMock.mock.calls[0] ?? [];
-    expect(context?.messages?.[0]?.content).toHaveLength(1);
+    expect(context?.messages?.[0]?.content).toHaveLength(2);
   });
 
   it("normalizes deprecated google flash ids before lookup and keeps profile auth selection", async () => {

--- a/src/media-understanding/image.ts
+++ b/src/media-understanding/image.ts
@@ -72,16 +72,22 @@ function buildImageContext(
   prompt: string,
   images: Array<{ buffer: Buffer; mime?: string }>,
 ): Context {
+  // Build image content blocks and prepend the prompt as a text block.
+  // Some providers (e.g. MiniMax chat completion) require at least one text
+  // content block in the user message and will reject image-only payloads
+  // with "chat content is empty".  Placing the prompt here also matches
+  // the typical vision-model convention of interleaved text + images.
+  const imageBlocks = images.map((image) => ({
+    type: "image" as const,
+    data: image.buffer.toString("base64"),
+    mimeType: image.mime ?? "image/jpeg",
+  }));
   return {
     systemPrompt: prompt,
     messages: [
       {
         role: "user",
-        content: images.map((image) => ({
-          type: "image" as const,
-          data: image.buffer.toString("base64"),
-          mimeType: image.mime ?? "image/jpeg",
-        })),
+        content: [{ type: "text" as const, text: prompt }, ...imageBlocks],
         timestamp: Date.now(),
       },
     ],


### PR DESCRIPTION
## Summary

Fixes #82837

When using non-VLM models (e.g. `MiniMax-M2.5` via `minimax-cn` provider) for image understanding, the `buildImageContext` function created a user message with **only image content blocks** and no text. 

MiniMax's chat completion API requires at least one text content block in the user message and rejects image-only payloads with:

```
chat content is empty (2013)
```

The prompt was already set as `systemPrompt`, but some providers need it in the user message content alongside images.

## Changes

- **`src/media-understanding/image.ts`**: Modified `buildImageContext()` to prepend the prompt as a `{ type: "text", text: prompt }` content block before the image blocks in the user message. This matches the standard vision-model convention of interleaved text + images.
- **`src/media-understanding/image.test.ts`**: Updated the codex image test assertion to expect the new text content block and adjusted the content length check from 1 to 2.

## Root Cause

```
buildImageContext() 
  → user message: [{ type: "image", ... }]     ← no text!
  → MiniMax chat completion: "chat content is empty"
```

## Fix

```
buildImageContext() 
  → user message: [{ type: "text", text: prompt }, { type: "image", ... }]  ← text + image
  → MiniMax chat completion: ✅ works
```

## Scope

- The VLM path (`MiniMax-VL-01` via `minimax-portal`) is **unaffected** — it uses a dedicated API endpoint (`describeImagesWithMinimax`).
- All other providers (OpenAI, Anthropic, Google, etc.) already handle text+image mixed content correctly.
- This is a **regression fix** with minimal blast radius — only `buildImageContext` is changed.

## Testing

- Updated existing unit test for the `buildImageContext` output format.
- CI will validate the full test suite.
