### PR TITLE
fix(cli): isolate gateway model run sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 - Agents/music: steer song, jingle, beat, anthem, and instrumental requests toward `music_generate` audio creation instead of lyric-only replies, and reserve `lyrics` for exact sung words.
 - Codex app-server: record native Codex tool calls and results into trajectory artifacts so debug/trajectory exports capture the full Codex-native tool history, not just OpenClaw-bridged turns. Thanks @vyctorbrzezowski.
 - Codex/app-server: keep bound conversation sessions on the owning agent runtime so native Codex control and follow-up turns do not fall back to the default agent client. Fixes #82954. (#82993)
+- CLI/infer: run gateway model probes in fresh explicit sessions so one-shot provider checks do not inherit default agent transcript state. (#82861) Thanks @Kaspre.
 - CLI/sessions: accept `openclaw sessions list` as an alias for `openclaw sessions`, matching other list-style commands. Fixes #81139. (#81163) Thanks @YB0y.
 - Channels/stream previews: widen compact progress draft lines and cut prose at word boundaries while preserving command/path suffixes, with `streaming.progress.maxLineChars` for channel-specific tuning.
 - CLI/plugins: have `openclaw plugins doctor` warn when a configured runtime needs a missing owner plugin, sharing the same install mapping as `openclaw doctor --fix`. Fixes #81326. (#81674) Thanks @Zavianx.

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -925,13 +925,34 @@ describe("capability cli", () => {
     });
 
     const gatewayCall = firstGatewayCall();
-    const sessionId = String(gatewayCall?.params?.sessionId ?? "");
+    const sessionId = gatewayCall?.params?.sessionId;
     expect(gatewayCall?.method).toBe("agent");
+    expect(typeof sessionId).toBe("string");
+    if (typeof sessionId !== "string") {
+      throw new Error("expected gateway model run session id");
+    }
     expect(sessionId).toEqual(expect.stringMatching(/^model-run-[0-9a-f-]{36}$/));
     expect(gatewayCall?.params?.sessionKey).toBe(`agent:main:explicit:${sessionId}`);
     expect(gatewayCall?.params?.cleanupBundleMcpOnRunEnd).toBe(true);
     expect(gatewayCall?.params?.modelRun).toBe(true);
     expect(gatewayCall?.params?.promptMode).toBe("none");
+
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: ["capability", "model", "run", "--prompt", "again", "--gateway", "--json"],
+    });
+
+    const gatewayCalls = mocks.callGateway.mock.calls as unknown as Array<[GatewayCall]>;
+    const nextGatewayCall = gatewayCalls[1]?.[0];
+    const nextSessionId = nextGatewayCall?.params?.sessionId;
+    expect(nextGatewayCall?.method).toBe("agent");
+    expect(typeof nextSessionId).toBe("string");
+    if (typeof nextSessionId !== "string") {
+      throw new Error("expected second gateway model run session id");
+    }
+    expect(nextSessionId).toEqual(expect.stringMatching(/^model-run-[0-9a-f-]{36}$/));
+    expect(nextGatewayCall?.params?.sessionKey).toBe(`agent:main:explicit:${nextSessionId}`);
+    expect(nextSessionId).not.toBe(sessionId);
   });
 
   it("surfaces gateway model fallback attempts in model probe JSON", async () => {

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -925,7 +925,10 @@ describe("capability cli", () => {
     });
 
     const gatewayCall = firstGatewayCall();
+    const sessionId = String(gatewayCall?.params?.sessionId ?? "");
     expect(gatewayCall?.method).toBe("agent");
+    expect(sessionId).toEqual(expect.stringMatching(/^model-run-[0-9a-f-]{36}$/));
+    expect(gatewayCall?.params?.sessionKey).toBe(`agent:main:explicit:${sessionId}`);
     expect(gatewayCall?.params?.cleanupBundleMcpOnRunEnd).toBe(true);
     expect(gatewayCall?.params?.modelRun).toBe(true);
     expect(gatewayCall?.params?.promptMode).toBe("none");

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -918,7 +918,7 @@ describe("capability cli", () => {
     },
   );
 
-  it("runs gateway model probes without chat-agent prompt policy or tools", async () => {
+  it("runs gateway model probes in fresh raw sessions without chat-agent prompt policy or tools", async () => {
     await runRegisteredCli({
       register: registerCapabilityCli as (program: Command) => void,
       argv: ["capability", "model", "run", "--prompt", "hello", "--gateway", "--json"],

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { createWriteStream } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -10,6 +11,7 @@ import {
   loadAuthProfileStoreForRuntime,
 } from "../agents/auth-profiles.js";
 import { updateAuthProfileStoreWithLock } from "../agents/auth-profiles/store.js";
+import { buildExplicitSessionIdSessionKey } from "../agents/command/session.js";
 import { DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { resolveMemorySearchConfig } from "../agents/memory-search.js";
 import { loadModelCatalog } from "../agents/model-catalog.js";
@@ -846,6 +848,8 @@ async function runModelRun(params: {
   // Provider/model overrides require trusted-operator scope. Use the backend
   // shared-secret lane so local gateway smokes do not depend on paired CLI device scopes.
   const hasModelOverride = Boolean(provider || model);
+  const sessionId = `model-run-${randomUUID()}`;
+  const sessionKey = buildExplicitSessionIdSessionKey({ agentId, sessionId });
   const response: {
     result?: {
       payloads?: Array<{ text?: string; mediaUrl?: string | null; mediaUrls?: string[] }>;
@@ -861,6 +865,8 @@ async function runModelRun(params: {
     method: "agent",
     params: {
       agentId,
+      sessionId,
+      sessionKey,
       message: params.prompt,
       attachments:
         imageFiles.length > 0


### PR DESCRIPTION
## Summary

- Give each `openclaw infer model run --gateway` invocation its own explicit `model-run-<uuid>` session id and matching explicit session key.
- Keep the existing raw model-run safeguards (`modelRun: true`, `promptMode: "none"`, bundle-MCP cleanup) unchanged.
- Extend the CLI regression test so gateway model probes must use fresh, distinct session id/key pairs.

Refs #74986.
Related #69030, #73308, #63263, #75022.

## Why

The raw gateway model-run path was already passing flags that suppress chat-agent prompt policy, tools, context-engine assembly, and bundled MCP. It still relied on the Gateway `agent` RPC's default session resolution, though, so session-aware runtimes could attach the one-shot probe to the default agent lane.

That breaks the documented one-shot contract and can make probes fail for reasons unrelated to provider health, for example when a long-lived default session causes Codex app-server compaction to hit `context_length_exceeded`.

The local model-run path already has separate one-shot behavior. This patch gives the gateway path the same isolation boundary by passing an explicit ephemeral session routing key.

## Real behavior proof

Behavior addressed: `infer model run --gateway` should not inherit the default agent session lane when it is being used as a one-shot model probe.

Real environment tested: Live gateway proof was run on PR head `5a6c5e75ec18617ea0a939ed2adab4bc7b842e13` (`OpenClaw 2026.5.17 (5a6c5e7)`) built on a GCP Crabbox VM, then run locally with a temporary PR-built foreground Gateway on loopback port `19061`, scratch config/state/workspace under `/tmp`, channels skipped, and the existing `main` agent auth profile directory for the provider request. The branch was then cleanly rebased onto current `main` as head `61e6895cf00ef076bab53718f5d736ce20a57fda`; the PR diff remains the same two CLI/test files, and hosted PR CI passed on that rebased head. The production Gateway on port `18789` was not restarted or replaced.

Exact steps or command run after this patch:

```text
git diff --check origin/main...HEAD

GCP Crabbox cbx_0622089ffc12
pnpm install --frozen-lockfile --reporter=append-only
pnpm test src/cli/capability-cli.test.ts

GCP Crabbox cbx_97980d9ca2ad, fresh clone of Kaspre/fix/infer-model-run-gateway-session
git diff --name-only origin/main...HEAD
pnpm install --frozen-lockfile --reporter=append-only
pnpm build
pnpm check:changed

Local live proof against PR-built scratch Gateway on port 19061
pnpm openclaw sessions --agent main --active 30 --limit all --json
pnpm openclaw infer model run --gateway --prompt "Reply exactly: gateway-model-run-session-proof" --json
pnpm openclaw sessions --agent main --active 30 --limit all --json
```

Evidence after fix: Copied live output from the PR-built scratch Gateway run:

```json
{
  "ok": true,
  "capability": "model.run",
  "transport": "gateway",
  "provider": "ollama-cloud",
  "model": "glm-5.1",
  "attempts": [],
  "outputs": [
    {
      "text": "gateway-model-run-session-proof",
      "mediaUrl": null
    }
  ]
}
```

Observed result after fix: The before session store was empty. After the live gateway run, the scratch session store contained exactly one active session and it was the explicit model-run lane, not the default `agent:main:main` lane:

```json
{
  "path": "/tmp/openclaw-pr82861-live/state/agents/main/sessions/sessions.json",
  "count": 1,
  "totalCount": 1,
  "sessions": [
    {
      "key": "agent:main:explicit:model-run-d62bab68-17de-4909-aac4-a0f7f772a96a",
      "sessionId": "model-run-d62bab68-17de-4909-aac4-a0f7f772a96a",
      "model": "glm-5.1",
      "modelProvider": "ollama-cloud",
      "agentId": "main",
      "kind": "direct"
    }
  ]
}
```

What was not tested: I did not restart or replace the production Gateway; the live proof used an isolated PR-built Gateway because the already-running production Gateway rejected the PR-built client with protocol mismatch. I did not rerun the live provider call after the clean rebase; hosted CI passed on rebased head `61e6895cf00ef076bab53718f5d736ce20a57fda`, and the rebased diff remains the same two CLI/test files.

## Validation

- `git diff --check origin/main...HEAD`
- GCP Crabbox `cbx_0622089ffc12`: `pnpm test src/cli/capability-cli.test.ts` (71 tests passed)
- GCP Crabbox `cbx_97980d9ca2ad`: fresh clone of pushed branch, `pnpm build`, `pnpm check:changed` (changed lanes `core, coreTests`)
- Local PR-built scratch Gateway: `pnpm openclaw infer model run --gateway --prompt "Reply exactly: gateway-model-run-session-proof" --json` plus before/after session-store proof
- Hosted PR CI on rebased head `61e6895cf00ef076bab53718f5d736ce20a57fda`: passing
- Review gates: `codex review --base origin/main` found no actionable issues; external Claude CLI review found no blocking issues