### PR TITLE
fix(telegram): preserve bot reply-chain context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Providers/GitHub Copilot: request identity-encoded Copilot API responses across token exchange, catalog, model calls, usage, and embeddings so compressed Business-account error payloads no longer reach JSON parsers as gzip bytes. Fixes #82871. Thanks @tonyfe01.
+- Telegram: preserve replied-to bot messages, captions, and media metadata in group reply chains so follow-up replies understand what the user is reacting to. (#82863)
 - Agents/diagnostics: split slow embedded-run `attempt-dispatch` startup summaries into workspace, prompt, runtime-plan, and final dispatch subspans so traces identify the delayed setup phase. Fixes #82782. (#82783) Thanks @galiniliev.
 - CLI/media: accept HTTP(S) URLs in `openclaw infer image describe --file`, fetching remote images through the guarded media path instead of treating URLs as local files. Fixes #82837. (#82854) Thanks @neeravmakwana.
 - Agents/subagents: keep session-backed parent runs active when the child wait call times out before the child session has actually settled, so late subagent completions are reconciled instead of being lost. Fixes #82787. Thanks @ramitrkar-hash.

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -2237,6 +2237,129 @@ describe("createTelegramBot", () => {
     expect(mediaFetch).toHaveBeenCalledTimes(1);
   });
 
+  it("hydrates bot reply targets cached from earlier Telegram replies", async () => {
+    onSpy.mockClear();
+    replySpy.mockClear();
+    getFileSpy.mockClear();
+
+    const mediaFetch = vi.fn(
+      async () =>
+        new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+    );
+    const ssrfMock = mockPinnedHostnameResolution();
+
+    try {
+      createTelegramBot({
+        token: "tok",
+        telegramTransport: {
+          fetch: mediaFetch as typeof fetch,
+          sourceFetch: mediaFetch as typeof fetch,
+          close: async () => {},
+        },
+      });
+      const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+      const baseCtx = {
+        me: { id: 999, username: "openclaw_bot" },
+        getFile: async () => ({ download: async () => new Uint8Array() }),
+      };
+      const chat = { id: 7, type: "group", title: "Ops" };
+
+      await handler({
+        ...baseCtx,
+        message: {
+          chat,
+          message_id: 102,
+          text: "Why is there a 4th person?",
+          date: 1736380750,
+          from: { id: 2, is_bot: false, first_name: "UserB" },
+          reply_to_message: {
+            chat,
+            message_id: 101,
+            text: "Done, here is the image",
+            date: 1736380700,
+            from: { id: 999, is_bot: true, first_name: "OpenClaw" },
+            photo: [{ file_id: "generated-photo-1" }],
+          },
+        },
+      });
+
+      replySpy.mockClear();
+      getFileSpy.mockClear();
+      mediaFetch.mockClear();
+
+      await handler({
+        ...baseCtx,
+        message: {
+          chat,
+          message_id: 103,
+          text: "@openclaw_bot explain what went wrong",
+          date: 1736380800,
+          from: { id: 1, is_bot: false, first_name: "UserA" },
+          reply_to_message: {
+            chat,
+            message_id: 102,
+            text: "Why is there a 4th person?",
+            date: 1736380750,
+            from: { id: 2, is_bot: false, first_name: "UserB" },
+          },
+        },
+      });
+    } finally {
+      ssrfMock.mockRestore();
+    }
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    const payload = mockMsgContextArg(
+      replySpy as unknown as MockCallSource,
+      0,
+      0,
+      "replySpy call",
+    ) as {
+      ReplyChain?: Array<{
+        messageId?: string;
+        sender?: string;
+        body?: string;
+        mediaRef?: string;
+        mediaPath?: string;
+      }>;
+      UntrustedStructuredContext?: unknown[];
+    };
+    expect(payload.ReplyChain?.map((entry) => entry.messageId)).toEqual(["102", "101"]);
+    expect(payload.ReplyChain?.[1]).toMatchObject({
+      sender: "OpenClaw",
+      body: "Done, here is the image",
+      mediaRef: "telegram:file/generated-photo-1",
+    });
+    expect(payload.ReplyChain?.[1]?.mediaPath).toBeTypeOf("string");
+    const [conversationContext] = requireArray(
+      payload.UntrustedStructuredContext,
+      "structured context",
+    );
+    const contextRecord = requireRecord(conversationContext, "conversation context");
+    const contextPayload = requireRecord(contextRecord.payload, "conversation context payload");
+    const messages = requireArray(contextPayload.messages, "conversation context messages").map(
+      (message, index) => requireRecord(message, `conversation context message ${index + 1}`),
+    );
+    const messagesById = new Map(messages.map((message) => [message.message_id, message]));
+    expect(messagesById.get("101")).toMatchObject({
+      sender: "OpenClaw",
+      body: "Done, here is the image",
+      media_ref: "telegram:file/generated-photo-1",
+      is_reply_target: true,
+    });
+    expect(messagesById.get("102")).toMatchObject({
+      sender: "UserB",
+      body: "Why is there a 4th person?",
+      reply_to_id: "101",
+      is_reply_target: true,
+    });
+    expect(getFileSpy).toHaveBeenCalledWith("generated-photo-1");
+    expect(mediaFetch).toHaveBeenCalledTimes(1);
+  });
+
   it("does not fetch reply media for unauthorized DM replies", async () => {
     onSpy.mockClear();
     replySpy.mockClear();

--- a/extensions/telegram/src/message-cache.test.ts
+++ b/extensions/telegram/src/message-cache.test.ts
@@ -221,6 +221,57 @@ describe("telegram message cache", () => {
     }
   });
 
+  it("replaces authoritative edited message fields without stale caption carryover", () => {
+    const cache = createTelegramMessageCache();
+    const chat = { id: 7, type: "group", title: "Ops" } as const;
+    cache.record({
+      accountId: "default",
+      chatId: 7,
+      msg: {
+        chat,
+        message_id: 104,
+        date: 1736380900,
+        caption: "old caption",
+        from: { id: 999, is_bot: true, first_name: "Bot" },
+        photo: [
+          {
+            file_id: "generated-photo-2",
+            file_unique_id: "generated-photo-unique-2",
+            width: 640,
+            height: 480,
+          },
+        ],
+      } as Message,
+    });
+
+    const updated = cache.record({
+      accountId: "default",
+      chatId: 7,
+      msg: {
+        chat,
+        message_id: 104,
+        date: 1736380900,
+        edit_date: 1736380910,
+        from: { id: 999, is_bot: true, first_name: "Bot" },
+        photo: [
+          {
+            file_id: "generated-photo-2",
+            file_unique_id: "generated-photo-unique-2",
+            width: 640,
+            height: 480,
+          },
+        ],
+      } as Message,
+    });
+
+    expect(updated).toMatchObject({
+      messageId: "104",
+      body: "<media:image>",
+      mediaRef: "telegram:file/generated-photo-2",
+    });
+    expect(updated?.body).not.toBe("old caption");
+  });
+
   it("shares one persisted bucket across live cache instances", async () => {
     const storePath = `/tmp/openclaw-telegram-message-cache-shared-${process.pid}-${Date.now()}.json`;
     const persistedPath = resolveTelegramMessageCachePath(storePath);

--- a/extensions/telegram/src/message-cache.test.ts
+++ b/extensions/telegram/src/message-cache.test.ts
@@ -142,6 +142,85 @@ describe("telegram message cache", () => {
     }
   });
 
+  it("records embedded reply targets as normal cached messages", async () => {
+    const storePath = `/tmp/openclaw-telegram-message-cache-reply-target-${process.pid}-${Date.now()}.json`;
+    const persistedPath = resolveTelegramMessageCachePath(storePath);
+    const chat = { id: 7, type: "group", title: "Ops" } as const;
+    await rm(persistedPath, { force: true });
+    try {
+      const firstCache = createTelegramMessageCache({ persistedPath });
+      firstCache.record({
+        accountId: "default",
+        chatId: 7,
+        msg: {
+          chat,
+          message_id: 102,
+          date: 1736380750,
+          text: "Why is there a 4th person?",
+          from: { id: 2, is_bot: false, first_name: "UserB" },
+          reply_to_message: {
+            chat,
+            message_id: 101,
+            date: 1736380700,
+            text: "Done, here is the image",
+            from: { id: 999, is_bot: true, first_name: "Bot" },
+            photo: [
+              {
+                file_id: "generated-photo-1",
+                file_unique_id: "generated-photo-unique-1",
+                width: 640,
+                height: 480,
+              },
+            ],
+          } as Message["reply_to_message"],
+        } as Message,
+      });
+
+      resetTelegramMessageCacheBucketsForTest();
+      const secondCache = createTelegramMessageCache({ persistedPath });
+      const current = {
+        chat,
+        message_id: 103,
+        date: 1736380800,
+        text: "Explain what went wrong",
+        from: { id: 1, is_bot: false, first_name: "UserA" },
+        reply_to_message: {
+          chat,
+          message_id: 102,
+          date: 1736380750,
+          text: "Why is there a 4th person?",
+          from: { id: 2, is_bot: false, first_name: "UserB" },
+        } as Message["reply_to_message"],
+      } as Message;
+      const chain = buildTelegramReplyChain({
+        cache: secondCache,
+        accountId: "default",
+        chatId: 7,
+        msg: current,
+      });
+      const context = buildTelegramConversationContext({
+        cache: secondCache,
+        accountId: "default",
+        chatId: 7,
+        messageId: "103",
+        replyChainNodes: chain,
+        recentLimit: 10,
+        replyTargetWindowSize: 2,
+      });
+
+      expect(chain.map((entry) => entry.messageId)).toEqual(["102", "101"]);
+      expect(chain[1]).toMatchObject({
+        sender: "Bot",
+        body: "Done, here is the image",
+        mediaRef: "telegram:file/generated-photo-1",
+      });
+      expect(context.map((entry) => entry.node.messageId)).toEqual(["101", "102"]);
+      expect(context.find((entry) => entry.node.messageId === "101")?.isReplyTarget).toBe(true);
+    } finally {
+      await rm(persistedPath, { force: true });
+    }
+  });
+
   it("shares one persisted bucket across live cache instances", async () => {
     const storePath = `/tmp/openclaw-telegram-message-cache-shared-${process.pid}-${Date.now()}.json`;
     const persistedPath = resolveTelegramMessageCachePath(storePath);

--- a/extensions/telegram/src/message-cache.ts
+++ b/extensions/telegram/src/message-cache.ts
@@ -63,6 +63,13 @@ type PersistedMessageReadResult = TelegramMessageCacheBucket & {
   needsRewrite: boolean;
 };
 
+type TelegramMessageObservationMode = "authoritative" | "partial";
+
+type TelegramCachedMessageObservation = {
+  node: TelegramCachedMessageNode;
+  mode: TelegramMessageObservationMode;
+};
+
 const DEFAULT_MAX_MESSAGES = 5000;
 const COMPACT_THRESHOLD_RATIO = 2;
 const persistedMessageCacheBuckets = new Map<string, TelegramMessageCacheBucket>();
@@ -164,14 +171,18 @@ function resolveMessageThreadId(msg: Message): number | undefined {
 function normalizeMessageNodes(
   msg: Message,
   params: { threadId?: number },
-): TelegramCachedMessageNode[] {
-  const nodes: TelegramCachedMessageNode[] = [];
+): TelegramCachedMessageObservation[] {
+  const observations: TelegramCachedMessageObservation[] = [];
   const visited = new Set<string>();
   const nodeThreadId = (node: TelegramCachedMessageNode) => {
     const threadId = Number(node.threadId);
     return Number.isFinite(threadId) ? threadId : undefined;
   };
-  const visit = (message: Message, inheritedThreadId?: number) => {
+  const visit = (
+    message: Message,
+    inheritedThreadId: number | undefined,
+    mode: TelegramMessageObservationMode,
+  ) => {
     const node = normalizeMessageNode(message, {
       threadId: resolveMessageThreadId(message) ?? inheritedThreadId,
     });
@@ -181,12 +192,12 @@ function normalizeMessageNodes(
     visited.add(node.messageId);
     const replyMessage = resolveEmbeddedReplyMessage(message);
     if (replyMessage?.message_id != null) {
-      visit(replyMessage, nodeThreadId(node) ?? inheritedThreadId);
+      visit(replyMessage, nodeThreadId(node) ?? inheritedThreadId, "partial");
     }
-    nodes.push(node);
+    observations.push({ node, mode });
   };
-  visit(msg, params.threadId);
-  return nodes;
+  visit(msg, params.threadId, "authoritative");
+  return observations;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -215,6 +226,7 @@ function isTelegramSourceMessage(value: unknown): value is Message {
 function parsePersistedEntry(value: unknown): Array<{
   key: string;
   node: TelegramCachedMessageNode;
+  mode: TelegramMessageObservationMode;
 }> {
   if (!isRecord(value) || !isString(value.key)) {
     return [];
@@ -229,10 +241,15 @@ function parsePersistedEntry(value: unknown): Array<{
   }
   const keyPrefix = value.key.slice(0, separatorIndex + 1);
   const threadId = Number(readOptionalString(value.node, "threadId"));
+  const sourceMessageId = String(value.node.sourceMessage.message_id);
   return normalizeMessageNodes(
     value.node.sourceMessage,
     Number.isFinite(threadId) ? { threadId } : {},
-  ).map((node) => ({ key: `${keyPrefix}${node.messageId}`, node }));
+  ).map(({ node, mode }) => ({
+    key: `${keyPrefix}${node.messageId}`,
+    node,
+    mode: node.messageId === sourceMessageId ? "authoritative" : mode,
+  }));
 }
 
 function findJsonArrayEnd(text: string): number {
@@ -337,26 +354,41 @@ function mergeTelegramSourceMessage(existing: Message, incoming: Message): Messa
   return merged;
 }
 
+function mergeAuthoritativeTelegramSourceMessage(existing: Message, incoming: Message): Message {
+  const existingReply = resolveEmbeddedReplyMessage(existing);
+  const incomingReply = resolveEmbeddedReplyMessage(incoming);
+  if (existingReply?.message_id != null && incomingReply?.message_id === existingReply.message_id) {
+    return {
+      ...incoming,
+      reply_to_message: mergeTelegramSourceMessage(existingReply, incomingReply),
+    };
+  }
+  return incoming;
+}
+
 function mergeCachedMessageNode(
   existing: TelegramCachedMessageNode,
   incoming: TelegramCachedMessageNode,
+  mode: TelegramMessageObservationMode,
 ): TelegramCachedMessageNode {
   const threadId = Number(incoming.threadId ?? existing.threadId);
-  return normalizeRequiredMessageNode(
-    mergeTelegramSourceMessage(existing.sourceMessage, incoming.sourceMessage),
-    {
-      ...(Number.isFinite(threadId) ? { threadId } : {}),
-    },
-  );
+  const sourceMessage =
+    mode === "authoritative"
+      ? mergeAuthoritativeTelegramSourceMessage(existing.sourceMessage, incoming.sourceMessage)
+      : mergeTelegramSourceMessage(existing.sourceMessage, incoming.sourceMessage);
+  return normalizeRequiredMessageNode(sourceMessage, {
+    ...(Number.isFinite(threadId) ? { threadId } : {}),
+  });
 }
 
 function upsertCachedMessageNode(params: {
   messages: Map<string, TelegramCachedMessageNode>;
   key: string;
   node: TelegramCachedMessageNode;
+  mode: TelegramMessageObservationMode;
 }): TelegramCachedMessageNode {
   const existing = params.messages.get(params.key);
-  const node = existing ? mergeCachedMessageNode(existing, params.node) : params.node;
+  const node = existing ? mergeCachedMessageNode(existing, params.node, params.mode) : params.node;
   params.messages.delete(params.key);
   params.messages.set(params.key, node);
   return node;
@@ -375,7 +407,12 @@ function readPersistedMessages(filePath: string, maxMessages: number): Persisted
     for (const value of persisted.values) {
       for (const entry of parsePersistedEntry(value)) {
         persistedEntryCount++;
-        upsertCachedMessageNode({ messages, key: entry.key, node: entry.node });
+        upsertCachedMessageNode({
+          messages,
+          key: entry.key,
+          node: entry.node,
+          mode: entry.mode,
+        });
         trimMessages(messages, maxMessages);
       }
     }
@@ -515,16 +552,16 @@ export function createTelegramMessageCache(params?: {
 
   return {
     record: ({ accountId, chatId, msg, threadId }) => {
-      const entries = normalizeMessageNodes(msg, { threadId });
-      const entry = entries.at(-1);
-      if (!entry) {
+      const observations = normalizeMessageNodes(msg, { threadId });
+      const currentObservation = observations.at(-1);
+      if (!currentObservation) {
         return null;
       }
       let recordedEntry: TelegramCachedMessageNode | null = null;
-      for (const node of entries) {
+      for (const { node, mode } of observations) {
         const key = telegramMessageCacheKey({ accountId, chatId, messageId: node.messageId });
-        const cachedNode = upsertCachedMessageNode({ messages, key, node });
-        if (node.messageId === entry.messageId) {
+        const cachedNode = upsertCachedMessageNode({ messages, key, node, mode });
+        if (node.messageId === currentObservation.node.messageId) {
           recordedEntry = cachedNode;
         }
         trimMessages(messages, maxMessages);
@@ -544,7 +581,7 @@ export function createTelegramMessageCache(params?: {
           logVerbose(`telegram: failed to persist message cache: ${String(error)}`);
         }
       }
-      return recordedEntry ?? entry;
+      return recordedEntry ?? currentObservation.node;
     },
     get,
     recentBefore: ({ accountId, chatId, messageId, threadId, limit }) => {

--- a/extensions/telegram/src/message-cache.ts
+++ b/extensions/telegram/src/message-cache.ts
@@ -92,6 +92,10 @@ function resolveReplyMessage(msg: Message): Message | undefined {
   return msg.reply_to_message ?? externalReply;
 }
 
+function resolveEmbeddedReplyMessage(msg: Message): Message | undefined {
+  return msg.reply_to_message;
+}
+
 function resolveMessageBody(msg: Message): string | undefined {
   const text = getTelegramTextParts(msg).text.trim();
   if (text) {
@@ -139,6 +143,52 @@ function normalizeMessageNode(
   };
 }
 
+function normalizeRequiredMessageNode(
+  msg: Message,
+  params: { threadId?: number },
+): TelegramCachedMessageNode {
+  const node = normalizeMessageNode(msg, params);
+  if (!node) {
+    throw new Error("Telegram message cache node missing message id");
+  }
+  return node;
+}
+
+function resolveMessageThreadId(msg: Message): number | undefined {
+  const threadId = (msg as { message_thread_id?: unknown }).message_thread_id;
+  return typeof threadId === "number" && Number.isFinite(threadId)
+    ? Math.trunc(threadId)
+    : undefined;
+}
+
+function normalizeMessageNodes(
+  msg: Message,
+  params: { threadId?: number },
+): TelegramCachedMessageNode[] {
+  const nodes: TelegramCachedMessageNode[] = [];
+  const visited = new Set<string>();
+  const nodeThreadId = (node: TelegramCachedMessageNode) => {
+    const threadId = Number(node.threadId);
+    return Number.isFinite(threadId) ? threadId : undefined;
+  };
+  const visit = (message: Message, inheritedThreadId?: number) => {
+    const node = normalizeMessageNode(message, {
+      threadId: resolveMessageThreadId(message) ?? inheritedThreadId,
+    });
+    if (!node?.messageId || visited.has(node.messageId)) {
+      return;
+    }
+    visited.add(node.messageId);
+    const replyMessage = resolveEmbeddedReplyMessage(message);
+    if (replyMessage?.message_id != null) {
+      visit(replyMessage, nodeThreadId(node) ?? inheritedThreadId);
+    }
+    nodes.push(node);
+  };
+  visit(msg, params.threadId);
+  return nodes;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -162,23 +212,27 @@ function isTelegramSourceMessage(value: unknown): value is Message {
   );
 }
 
-function parsePersistedNode(value: unknown): TelegramCachedMessageNode | null {
-  if (!isRecord(value) || !isTelegramSourceMessage(value.sourceMessage)) {
-    return null;
-  }
-  const threadId = Number(readOptionalString(value, "threadId"));
-  return normalizeMessageNode(value.sourceMessage, Number.isFinite(threadId) ? { threadId } : {});
-}
-
-function parsePersistedEntry(value: unknown): {
+function parsePersistedEntry(value: unknown): Array<{
   key: string;
   node: TelegramCachedMessageNode;
-} | null {
+}> {
   if (!isRecord(value) || !isString(value.key)) {
-    return null;
+    return [];
   }
-  const node = parsePersistedNode(value.node);
-  return node ? { key: value.key, node } : null;
+  const separatorIndex = value.key.lastIndexOf(":");
+  if (
+    separatorIndex === -1 ||
+    !isRecord(value.node) ||
+    !isTelegramSourceMessage(value.node.sourceMessage)
+  ) {
+    return [];
+  }
+  const keyPrefix = value.key.slice(0, separatorIndex + 1);
+  const threadId = Number(readOptionalString(value.node, "threadId"));
+  return normalizeMessageNodes(
+    value.node.sourceMessage,
+    Number.isFinite(threadId) ? { threadId } : {},
+  ).map((node) => ({ key: `${keyPrefix}${node.messageId}`, node }));
 }
 
 function findJsonArrayEnd(text: string): number {
@@ -270,6 +324,44 @@ function trimMessages(messages: Map<string, TelegramCachedMessageNode>, maxMessa
   }
 }
 
+function mergeTelegramSourceMessage(existing: Message, incoming: Message): Message {
+  const existingReply = resolveEmbeddedReplyMessage(existing);
+  const incomingReply = resolveEmbeddedReplyMessage(incoming);
+  const merged = { ...existing, ...incoming };
+  if (existingReply?.message_id != null && incomingReply?.message_id === existingReply.message_id) {
+    return {
+      ...merged,
+      reply_to_message: mergeTelegramSourceMessage(existingReply, incomingReply),
+    };
+  }
+  return merged;
+}
+
+function mergeCachedMessageNode(
+  existing: TelegramCachedMessageNode,
+  incoming: TelegramCachedMessageNode,
+): TelegramCachedMessageNode {
+  const threadId = Number(incoming.threadId ?? existing.threadId);
+  return normalizeRequiredMessageNode(
+    mergeTelegramSourceMessage(existing.sourceMessage, incoming.sourceMessage),
+    {
+      ...(Number.isFinite(threadId) ? { threadId } : {}),
+    },
+  );
+}
+
+function upsertCachedMessageNode(params: {
+  messages: Map<string, TelegramCachedMessageNode>;
+  key: string;
+  node: TelegramCachedMessageNode;
+}): TelegramCachedMessageNode {
+  const existing = params.messages.get(params.key);
+  const node = existing ? mergeCachedMessageNode(existing, params.node) : params.node;
+  params.messages.delete(params.key);
+  params.messages.set(params.key, node);
+  return node;
+}
+
 function readPersistedMessages(filePath: string, maxMessages: number): PersistedMessageReadResult {
   const messages = new Map<string, TelegramCachedMessageNode>();
   let persistedEntryCount = 0;
@@ -281,14 +373,11 @@ function readPersistedMessages(filePath: string, maxMessages: number): Persisted
     const persisted = readPersistedEntryValues(fs.readFileSync(filePath, "utf-8"));
     needsRewrite = persisted.needsRewrite;
     for (const value of persisted.values) {
-      const entry = parsePersistedEntry(value);
-      if (!entry) {
-        continue;
+      for (const entry of parsePersistedEntry(value)) {
+        persistedEntryCount++;
+        upsertCachedMessageNode({ messages, key: entry.key, node: entry.node });
+        trimMessages(messages, maxMessages);
       }
-      persistedEntryCount++;
-      messages.delete(entry.key);
-      messages.set(entry.key, entry.node);
-      trimMessages(messages, maxMessages);
     }
   } catch (error) {
     logVerbose(`telegram: failed to read message cache: ${String(error)}`);
@@ -426,30 +515,36 @@ export function createTelegramMessageCache(params?: {
 
   return {
     record: ({ accountId, chatId, msg, threadId }) => {
-      const entry = normalizeMessageNode(msg, { threadId });
-      if (!entry?.messageId) {
+      const entries = normalizeMessageNodes(msg, { threadId });
+      const entry = entries.at(-1);
+      if (!entry) {
         return null;
       }
-      const key = telegramMessageCacheKey({ accountId, chatId, messageId: entry.messageId });
-      messages.delete(key);
-      messages.set(key, entry);
-      trimMessages(messages, maxMessages);
-      try {
-        bucket.persistedEntryCount += appendPersistedMessage({
-          key,
-          node: entry,
-          persistedPath: params?.persistedPath,
-        });
-        if (bucket.persistedEntryCount > maxMessages * COMPACT_THRESHOLD_RATIO) {
-          bucket.persistedEntryCount = replacePersistedMessages({
-            messages,
+      let recordedEntry: TelegramCachedMessageNode | null = null;
+      for (const node of entries) {
+        const key = telegramMessageCacheKey({ accountId, chatId, messageId: node.messageId });
+        const cachedNode = upsertCachedMessageNode({ messages, key, node });
+        if (node.messageId === entry.messageId) {
+          recordedEntry = cachedNode;
+        }
+        trimMessages(messages, maxMessages);
+        try {
+          bucket.persistedEntryCount += appendPersistedMessage({
+            key,
+            node: cachedNode,
             persistedPath: params?.persistedPath,
           });
+          if (bucket.persistedEntryCount > maxMessages * COMPACT_THRESHOLD_RATIO) {
+            bucket.persistedEntryCount = replacePersistedMessages({
+              messages,
+              persistedPath: params?.persistedPath,
+            });
+          }
+        } catch (error) {
+          logVerbose(`telegram: failed to persist message cache: ${String(error)}`);
         }
-      } catch (error) {
-        logVerbose(`telegram: failed to persist message cache: ${String(error)}`);
       }
-      return entry;
+      return recordedEntry ?? entry;
     },
     get,
     recentBefore: ({ accountId, chatId, messageId, threadId, limit }) => {


### PR DESCRIPTION
Summary
- Cache embedded Telegram reply targets as normal message nodes.
- Merge repeated Telegram message observations so later partial reply snapshots keep known reply/media context without preserving stale authoritative edits.
- Add regressions for a user replying through a bot image response and for edited media captions being removed.

Verification
- `node scripts/run-vitest.mjs extensions/telegram/src/message-cache.test.ts extensions/telegram/src/bot.test.ts`
- `git diff --check origin/main...HEAD`
- `/srv/apps/developer/openclaw/.agents/skills/codex-review/scripts/codex-review --mode branch --parallel-tests "node scripts/run-vitest.mjs extensions/telegram/src/message-cache.test.ts extensions/telegram/src/bot.test.ts"`

Live Telegram Proof
Behavior addressed: Telegram reply chains now keep the bot message being replied to, including bot text and media metadata, when a later user replies to the complaint.

Real environment tested: PR checkout `codex/telegram-reply-chain-context` at `eb298cc97f1d14d104d4f149c36654b8ae117800`, real Telegram group with driver/SUT bots, mock OpenAI `/v1/responses` request logging.

Exact steps or command run after this patch: started SUT gateway from the PR checkout with a temp Telegram config and mock OpenAI server; sent an SUT bot photo/caption; had the driver bot reply to that media message with “Why is there a fourth person…”; had the driver bot reply to that complaint with “Explain what went wrong…”; inspected the logged final `/v1/responses` payload.

Evidence after fix: final model input contained the reply chain nearest-first: complaint `#11084 reply_to:11083`, then bot media message `#11083` with caption `Done, here is the generated image of exactly three people standing together.`, `<media:image/jpeg>`, and `media_ref:telegram:file/...`.

Observed result after fix: SUT returned the final marker response, and the mock OpenAI log captured the final request with both the complaint and the prior bot image/caption in the LLM input.

What was not tested: real model reasoning; provider was mocked so the proof isolates Telegram context assembly and request payload shape.