### PR TITLE
fix(message): describe channel provider schema

### DIFF
--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -798,6 +798,28 @@ describe("message tool schema scoping", () => {
     },
   );
 
+  it("describes channel as a provider enum instead of a provider-specific target id", () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        { pluginId: "telegram", source: "test", plugin: telegramPlugin },
+        { pluginId: "discord", source: "test", plugin: discordPlugin },
+      ]),
+    );
+
+    const tool = createMessageTool({
+      config: {} as never,
+    });
+    const channel = getToolProperties(tool).channel as
+      | { type?: string; description?: string; enum?: string[] }
+      | undefined;
+
+    expect(channel?.type).toBe("string");
+    expect(channel?.description).toContain("provider id");
+    expect(channel?.description).toContain("put channel/user/chat ids in target or targets");
+    expect(channel?.enum).toEqual(expect.arrayContaining(["discord", "telegram"]));
+    expect(channel?.enum).not.toContain("C07ABC1234X");
+  });
+
   it("includes poll in the action enum when the current channel supports poll actions", () => {
     setActivePluginRegistry(
       createTestRegistry([{ pluginId: "telegram", source: "test", plugin: telegramPlugin }]),

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -118,9 +118,20 @@ function sanitizePresentationTextFields(value: unknown): unknown {
   return presentation;
 }
 
+const MESSAGE_TOOL_CHANNEL_DESCRIPTION =
+  "Optional destination channel provider id, such as telegram, slack, discord, or webchat. Use this only to choose the provider; put channel/user/chat ids in target or targets.";
+
+function listMessageChannelSchemaValues(): string[] {
+  return Array.from(new Set(listChannelPlugins().map((plugin) => plugin.id))).sort();
+}
+
 function buildRoutingSchema() {
   return {
-    channel: Type.Optional(Type.String()),
+    channel: Type.Optional(
+      stringEnum(listMessageChannelSchemaValues(), {
+        description: MESSAGE_TOOL_CHANNEL_DESCRIPTION,
+      }),
+    ),
     target: Type.Optional(channelTargetSchema()),
     targets: Type.Optional(channelTargetsSchema()),
     accountId: Type.Optional(Type.String()),


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary

- Adds provider-oriented guidance to the `message` tool `channel` schema.
- Exposes configured channel provider ids as the schema enum so agents pick values like `telegram`, `slack`, or `discord` instead of provider-specific target ids.
- Adds regression coverage for the channel schema description and enum.

Fixes #10354

## Test Plan

- `node proof-source-probe.mjs` (source-level terminal probe against the patched files)
- Added focused regression coverage in `src/agents/tools/message-tool.test.ts` for the schema shape that would fail on current `main`.
- Not run: full `vitest` / `check:changed`, because this session could not create a full local OpenClaw checkout.

## Real behavior proof

Behavior or issue addressed: the `message` tool previously exposed `channel` as an unconstrained string, which let agents pass Slack/Discord channel IDs where a provider id is expected.

Real environment tested: API-only OpenClaw source patch in `/tmp/openclaw-api-10354` using current upstream files plus the patched `src/agents/tools/message-tool.ts` and `src/agents/tools/message-tool.test.ts`.

Exact steps or command run after this patch: `node proof-source-probe.mjs`

Evidence after fix: terminal output from `node proof-source-probe.mjs`:

```text
PASS channel description constant exists
PASS channel schema uses stringEnum
PASS channel enum derives from registered plugins
PASS channel enum is stable sorted
PASS description explains provider id
PASS description sends target ids to target or targets
PASS regression asserts discord and telegram enum values
PASS regression rejects Slack-style channel id as channel enum
```

Observed result after fix: the patched schema builds `channel` from `stringEnum(listMessageChannelSchemaValues(), ...)`, derives enum values from registered channel plugin ids, includes provider-id guidance, and the regression test asserts provider ids are present while a Slack-style target id is absent.

What was not tested: live message-tool execution and the full OpenClaw test suite were not run because a full local checkout was blocked in this session.

## Risk / Notes

- Narrow schema-only change; runtime routing behavior is unchanged.
- Opened as draft because full local test execution was blocked.
