### PR TITLE
fix(channels): bypass debounce for bare abort triggers

### DIFF
--- a/src/channels/inbound-debounce-policy.test.ts
+++ b/src/channels/inbound-debounce-policy.test.ts
@@ -13,6 +13,15 @@ describe("shouldDebounceTextInbound", () => {
     expect(shouldDebounceTextInbound({ text: "/status", cfg })).toBe(false);
   });
 
+  it("rejects bare abort triggers so they flush before debounce merging", () => {
+    const cfg = {} as Parameters<typeof shouldDebounceTextInbound>[0]["cfg"];
+
+    expect(shouldDebounceTextInbound({ text: "stop", cfg })).toBe(false);
+    expect(shouldDebounceTextInbound({ text: "abort", cfg })).toBe(false);
+    expect(shouldDebounceTextInbound({ text: "wait", cfg })).toBe(false);
+    expect(shouldDebounceTextInbound({ text: "stop!", cfg })).toBe(false);
+  });
+
   it("accepts normal text when debounce is allowed", () => {
     const cfg = {} as Parameters<typeof shouldDebounceTextInbound>[0]["cfg"];
     expect(shouldDebounceTextInbound({ text: "hello there", cfg })).toBe(true);

--- a/src/channels/inbound-debounce-policy.ts
+++ b/src/channels/inbound-debounce-policy.ts
@@ -1,4 +1,4 @@
-import { hasControlCommand } from "../auto-reply/command-detection.js";
+import { isControlCommandMessage } from "../auto-reply/command-detection.js";
 import type { CommandNormalizeOptions } from "../auto-reply/commands-registry.js";
 import {
   createInboundDebouncer,
@@ -25,7 +25,7 @@ export function shouldDebounceTextInbound(params: {
   if (!text) {
     return false;
   }
-  return !hasControlCommand(text, params.cfg, params.commandOptions);
+  return !isControlCommandMessage(text, params.cfg, params.commandOptions);
 }
 
 export function createChannelInboundDebouncer<T>(


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary

- Makes inbound debounce bypass use `isControlCommandMessage()` instead of only `hasControlCommand()`.
- This preserves slash-command behavior and also recognizes bare abort triggers such as `stop`, `abort`, and `wait` before messages can be merged by debounce.
- Adds regression coverage for bare abort trigger bypass in `shouldDebounceTextInbound()`.

Fixes #48684

## Test Plan

- `node proof-source-probe.mjs` (source-level terminal probe against the patched files)
- Added focused regression coverage in `src/channels/inbound-debounce-policy.test.ts`; the new test would fail on current `main` because `hasControlCommand()` does not recognize bare abort triggers.
- Not run: full `vitest` / `check:changed`, because this session could not create a full local OpenClaw checkout.

## Real behavior proof

Behavior or issue addressed: bare abort phrases like `stop`, `abort`, and `wait` could be delayed by inbound debounce, and could be swallowed if another message was merged into the same debounce window.

Real environment tested: API-only OpenClaw source patch in `/tmp/openclaw-api-48684` using current upstream files plus the patched `src/channels/inbound-debounce-policy.ts` and `src/channels/inbound-debounce-policy.test.ts`.

Exact steps or command run after this patch: `node proof-source-probe.mjs`

Evidence after fix: terminal output from `node proof-source-probe.mjs`:

```text
PASS policy imports isControlCommandMessage
PASS policy uses isControlCommandMessage for debounce bypass
PASS old hasControlCommand-only bypass removed
PASS abort primitives define stop trigger
PASS abort primitives define abort trigger
PASS abort primitives define wait trigger
PASS regression asserts stop bypasses debounce
PASS regression asserts abort bypasses debounce
PASS regression asserts wait bypasses debounce
```

Observed result after fix: the patched policy delegates debounce bypass to `isControlCommandMessage()`, the old `hasControlCommand()`-only return path is gone, abort primitives contain `stop`/`abort`/`wait`, and the regression test asserts those trigger strings return `false` for debounce.

What was not tested: live Discord/Slack inbound flows and the full OpenClaw test suite were not run because a full local checkout was blocked in this session.

## Risk / Notes

- Narrow policy change: slash commands still bypass debounce through the same underlying `hasControlCommand()` path.
- Bare abort trigger matching remains exact and uses the existing abort primitive normalization.
- Opened as draft because full local test execution was blocked.
