### PR TITLE
fix(compaction): preserve fresh usage after compaction

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.compaction.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.test.ts
@@ -14,6 +14,18 @@ import {
   reconcileSessionStoreCompactionCountAfterSuccess,
 } from "./pi-embedded-subscribe.handlers.compaction.js";
 import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
+import { makeZeroUsageSnapshot } from "./usage.js";
+
+function makeUsage(input: number, output: number, totalTokens: number) {
+  return {
+    input,
+    output,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  };
+}
 
 function createCompactionContext(params: {
   storePath: string;
@@ -21,12 +33,13 @@ function createCompactionContext(params: {
   agentId?: string;
   initialCount: number;
   info?: (message: string, meta?: Record<string, unknown>) => void;
+  messages?: unknown[];
 }): EmbeddedPiSubscribeContext {
   let compactionCount = params.initialCount;
   return {
     params: {
       runId: "run-test",
-      session: { messages: [] } as never,
+      session: { messages: params.messages ?? [] } as never,
       config: { session: { store: params.storePath } } as never,
       sessionKey: params.sessionKey,
       sessionId: "session-1",
@@ -305,5 +318,60 @@ describe("handleCompactionEnd", () => {
 
     expect(await readCompactionCount(storePath, sessionKey)).toBe(2);
     expect(ctx.noteCompactionTokensAfter).toHaveBeenCalledWith(undefined);
+  });
+
+  it("keeps fresh assistant usage after the latest compaction summary", async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-compaction-usage-"));
+    const storePath = path.join(tmp, "sessions.json");
+    const sessionKey = "main";
+    await seedSessionStore({
+      storePath,
+      sessionKey,
+      compactionCount: 0,
+    });
+    const staleUsage = makeUsage(120_000, 3_000, 123_000);
+    const freshUsage = makeUsage(1_000, 250, 1_250);
+    const messages: Array<Record<string, unknown> & { usage?: unknown }> = [
+      {
+        role: "assistant",
+        content: "pre-compaction answer",
+        timestamp: "2026-03-20T00:00:00.000Z",
+        usage: staleUsage,
+      },
+      {
+        role: "compactionSummary",
+        summary: "compressed",
+        timestamp: "2026-03-20T00:00:10.000Z",
+      },
+      {
+        role: "user",
+        content: "new question",
+        timestamp: "2026-03-20T00:00:20.000Z",
+      },
+      {
+        role: "assistant",
+        content: "fresh answer",
+        timestamp: "2026-03-20T00:00:30.000Z",
+        usage: freshUsage,
+      },
+    ];
+
+    const ctx = createCompactionContext({
+      storePath,
+      sessionKey,
+      initialCount: 0,
+      messages,
+    });
+
+    handleCompactionEnd(ctx, {
+      type: "compaction_end",
+      reason: "threshold",
+      result: { kept: 12 },
+      willRetry: false,
+      aborted: false,
+    });
+
+    expect(messages[0]?.usage).toEqual(makeZeroUsageSnapshot());
+    expect(messages[3]?.usage).toEqual(freshUsage);
   });
 });

--- a/src/agents/pi-embedded-subscribe.handlers.compaction.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.ts
@@ -183,16 +183,61 @@ function clearStaleAssistantUsageOnSessionMessages(ctx: EmbeddedPiSubscribeConte
   if (!Array.isArray(messages)) {
     return;
   }
-  for (const message of messages) {
+
+  let latestCompactionSummaryIndex = -1;
+  let latestCompactionTimestamp: number | null = null;
+  for (let i = 0; i < messages.length; i += 1) {
+    const entry = messages[i];
+    if (!entry || typeof entry !== "object") {
+      continue;
+    }
+    const candidate = entry as { role?: unknown; timestamp?: unknown };
+    if (candidate.role !== "compactionSummary") {
+      continue;
+    }
+    latestCompactionSummaryIndex = i;
+    latestCompactionTimestamp = parseMessageTimestamp(candidate.timestamp);
+  }
+
+  for (let i = 0; i < messages.length; i += 1) {
+    const message = messages[i];
     if (!message || typeof message !== "object") {
       continue;
     }
-    const candidate = message as { role?: unknown; usage?: unknown };
+    const candidate = message as {
+      role?: unknown;
+      timestamp?: unknown;
+      usage?: unknown;
+    };
     if (candidate.role !== "assistant") {
+      continue;
+    }
+    const staleByLegacyNoSummary = latestCompactionSummaryIndex === -1;
+    const messageTimestamp = parseMessageTimestamp(candidate.timestamp);
+    const staleByTimestamp =
+      latestCompactionTimestamp !== null &&
+      messageTimestamp !== null &&
+      messageTimestamp <= latestCompactionTimestamp;
+    const staleByLegacyOrdering =
+      latestCompactionSummaryIndex !== -1 && i < latestCompactionSummaryIndex;
+    if (!staleByLegacyNoSummary && !staleByTimestamp && !staleByLegacyOrdering) {
       continue;
     }
     // pi-coding-agent expects assistant usage to exist when computing context usage.
     // Reset stale snapshots to zeros instead of deleting the field.
     candidate.usage = makeZeroUsageSnapshot();
   }
+}
+
+function parseMessageTimestamp(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return null;
 }


### PR DESCRIPTION
## Summary
- Make the live embedded subscribe compaction handler find the latest `compactionSummary` boundary before clearing assistant usage snapshots.
- Zero only stale assistant usage before that boundary, so fresh post-compaction usage from the next assistant response remains available for the TUI context counter.
- Preserve the legacy no-summary behavior by zeroing all assistant usage when no compaction summary exists.
- Add focused handler coverage for stale-before/fresh-after compaction usage.

## Test Plan
- `node run-real-handler-proof.mjs` in the API-only PR workspace: transpiles and executes the PR-head `src/agents/pi-embedded-subscribe.handlers.compaction.ts` module, sends a `compaction_end` event through the real exported `handleCompactionEnd`, and confirms stale assistant usage is zeroed while fresh post-compaction usage stays nonzero.
- `node` standalone reproduction of the patched stale/fresh usage decision logic.
- TypeScript parser check for `src/agents/pi-embedded-subscribe.handlers.compaction.ts` and `src/agents/pi-embedded-subscribe.handlers.compaction.test.ts` using `typescript.createSourceFile`.
- GitHub Actions on this PR: `check`, `check-lint`, `check-test-types`, `checks-node-*`, security shards, and changed-path gates have been running on the pushed branch; no code failure was observed in the latest poll, with only the real-behavior proof review gate awaiting stronger evidence.
- Not run locally: full repository Vitest/check:changed suites, because a local clone/checkout was denied in this environment; GitHub CI is expected to provide the full project validation.

## Real behavior proof
Behavior or issue addressed: after a successful compaction, `clearStaleAssistantUsageOnSessionMessages` previously zeroed every assistant `usage` snapshot, including fresh assistant messages after the latest `compactionSummary`. That left the TUI context counter at `0/1.0m (0%)` even when the latest assistant response had nonzero usage.

Real environment tested: macOS with Node v22.18.0, PR-head branch `leno23:fix/50795-preserve-compaction-usage` at commit `06c47e7f96836500fae5dc5601ea33bf373087c4`, API-only OpenClaw source workspace `/tmp/openclaw-api-50795`. The command executed the PR-head production `src/agents/pi-embedded-subscribe.handlers.compaction.ts` module through its exported `handleCompactionEnd` compaction-event path and captured the same gateway log message that the live embedded run emits on successful auto-compaction.

Exact steps or command run after this patch:
```bash
cd /tmp/openclaw-api-50795
node run-real-handler-proof.mjs
```

Evidence after fix:
```text
{
  "sourceFile": "src/agents/pi-embedded-subscribe.handlers.compaction.ts",
  "sourceSha256Prefix": "5f6e1452c976416a",
  "commandPath": "real-handler-proof/out/src/agents/pi-embedded-subscribe.handlers.compaction.js",
  "event": "compaction_end willRetry=false result.tokensAfter=1250",
  "gatewayLog": "embedded run auto-compaction complete: runId=real-proof-run reason=threshold compactionCount=1 willRetry=false",
  "emittedCompactionEvent": {
    "phase": "end",
    "willRetry": false,
    "completed": true
  },
  "beforeFreshContext": "1250/1000000 (0.1%)",
  "staleAssistantTotalTokensAfterHandler": 0,
  "freshAssistantTotalTokensAfterHandler": 1250,
  "afterFreshContext": "1250/1000000 (0.1%)",
  "freshUsagePreserved": true,
  "staleUsageZeroed": true,
  "livenessState": "working"
}
```

Observed result after fix: the compaction-end handler emitted `embedded run auto-compaction complete`, moved the live session state back to `working`, reset only the stale assistant message before the latest compaction summary to a zero usage snapshot, and preserved the fresh assistant message after that summary with `totalTokens: 1250`; the post-compaction context readout therefore remained `1250/1000000 (0.1%)` instead of dropping to zero.

What was not tested: a full interactive TUI/gateway session with a live model provider was not run locally because cloning/checking out the repository was denied in this environment; the proof above exercises the actual PR-head compaction-end handler source and GitHub CI covers the repository-level gates.

## Risk/Notes
- Low risk: the change stays inside the existing live compaction-end helper and mirrors the replay sanitizer's compaction boundary pattern.
- The legacy path with no recorded `compactionSummary` keeps the previous zero-all behavior, so existing no-summary hook tests should continue to pass.

Fixes #50795
