### PR TITLE
fix: reconcile subagent wait timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 - Agents/diagnostics: split slow embedded-run `attempt-dispatch` startup summaries into workspace, prompt, runtime-plan, and final dispatch subspans so traces identify the delayed setup phase. Fixes #82782. (#82783) Thanks @galiniliev.
 - CLI/media: accept HTTP(S) URLs in `openclaw infer image describe --file`, fetching remote images through the guarded media path instead of treating URLs as local files. Fixes #82837. (#82854) Thanks @neeravmakwana.
+- Agents/subagents: keep session-backed parent runs active when the child wait call times out before the child session has actually settled, so late subagent completions are reconciled instead of being lost. Fixes #82787. Thanks @ramitrkar-hash.
 - Agents/subagents: route group/channel subagent completions through message-tool-only handoffs when required and keep active-requester wake failures from dropping completion delivery. Fixes #82803. Thanks @galiniliev, @yozakura-ava, and @moeedahmed.
 - Memory-core: scan persisted memory source sessions on startup, comparing on-disk transcripts against the index and marking only missing/newer/resized files dirty for incremental sync. Fixes #82341. (#82341) Thanks @giodl73-repo.
 - Telegram: keep the top-level default account in the account list when named accounts or bindings are added alongside top-level credentials, preserving default polling while still letting named-only configs resolve to a single account. Fixes #82794. (#82794) Thanks @giodl73-repo.

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts
@@ -481,11 +481,12 @@ describe("openclaw-tools: subagents (sessions_spawn lifecycle)", () => {
     expect(deletedKey?.startsWith("agent:main:subagent:")).toBe(true);
   });
 
-  it("sessions_spawn records timeout when agent.wait returns timeout", async () => {
+  it("sessions_spawn records timeout when agent.wait returns timeout and child session is terminal", async () => {
     const ctx = setupSessionsSpawnGatewayMock({
       includeChatHistory: true,
       chatHistoryText: "still working",
       agentWaitResult: { status: "timeout", startedAt: 6000, endedAt: 7000 },
+      subagentSessionEntryPatch: { status: "timeout", endedAt: 7000 },
     });
 
     const tool = await getDiscordGroupSpawnTool();

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.test-harness.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.test-harness.ts
@@ -16,6 +16,13 @@ type SubagentSpawnTesting = (typeof import("./subagent-spawn.js"))["__testing"];
 type CreateOpenClawToolsOpts = Parameters<CreateSessionsSpawnTool>[0];
 type GatewayRequest = { method?: string; params?: unknown; timeoutMs?: number };
 type AgentWaitCall = { runId?: string; timeoutMs?: number };
+type TestSessionEntry = {
+  sessionId: string;
+  updatedAt: number;
+  startedAt?: number;
+  endedAt?: number;
+  status?: "running" | "done" | "failed" | "killed" | "timeout";
+};
 type SessionsSpawnGatewayMockOptions = {
   includeSessionsList?: boolean;
   includeChatHistory?: boolean;
@@ -24,6 +31,7 @@ type SessionsSpawnGatewayMockOptions = {
   onSessionsPatch?: (params: unknown) => void;
   onSessionsDelete?: (params: unknown) => void;
   agentWaitResult?: { status: "ok" | "timeout"; startedAt: number; endedAt: number };
+  subagentSessionEntryPatch?: Partial<TestSessionEntry>;
 };
 type EventWaiter = {
   label: string;
@@ -35,7 +43,7 @@ type EventWaiter = {
 
 const hoisted = vi.hoisted(() => {
   const callGatewayMock = vi.fn();
-  const sessionStore: Record<string, { sessionId: string; updatedAt: number }> = {};
+  const sessionStore: Record<string, TestSessionEntry> = {};
   let nextRunId = 0;
   const defaultConfigOverride = {
     session: {
@@ -269,6 +277,7 @@ export function setupSessionsSpawnGatewayMock(setupOpts: SessionsSpawnGatewayMoc
           hoisted.sessionStore[childSessionKey] = {
             sessionId: `sess-${childSessionKey}`,
             updatedAt: Date.now(),
+            ...setupOpts.subagentSessionEntryPatch,
           };
         }
         setupOpts.onAgentSubagentSpawn?.(params);
@@ -347,6 +356,8 @@ vi.mock("../config/sessions.js", () => ({
     ...existing,
     ...patch,
   }),
+  resolveAgentIdFromSessionKey: (sessionKey: string) =>
+    sessionKey.match(/^agent:([^:]+)/)?.[1] ?? "main",
   resolveAgentMainSessionKey: (params: {
     cfg?: { session?: { mainKey?: string } };
     agentId: string;

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -28,6 +28,7 @@ import {
   safeRemoveAttachmentsDir,
 } from "./subagent-registry-helpers.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
+import type { SubagentSessionCompletion } from "./subagent-session-reconciliation.js";
 
 const log = createSubsystemLogger("agents/subagent-registry");
 const RECOVERABLE_WAIT_RETRY_DELAY_MS = process.env.OPENCLAW_TEST_FAST === "1" ? 25 : 5_000;
@@ -123,6 +124,11 @@ export function createSubagentRunManager(params: {
   clearPendingLifecycleError(runId: string): void;
   resolveSubagentWaitTimeoutMs(cfg: OpenClawConfig, runTimeoutSeconds?: number): number;
   scheduleOrphanRecovery(args?: { delayMs?: number; maxRetries?: number }): void;
+  resolveSubagentSessionCompletion(args: {
+    childSessionKey: string;
+    fallbackEndedAt: number;
+    notBeforeMs?: number;
+  }): SubagentSessionCompletion | null;
   notifyContextEngineSubagentEnded(args: {
     childSessionKey: string;
     reason: "completed" | "deleted" | "released";
@@ -151,6 +157,22 @@ export function createSubagentRunManager(params: {
     expectedEntry?: SubagentRunRecord,
   ) => {
     let completionForRetry: Parameters<typeof params.completeSubagentRun>[0] | undefined;
+    const scheduleWaitRetry = (entry: SubagentRunRecord, reason: string, error?: string) => {
+      params.scheduleOrphanRecovery({ delayMs: 1_000 });
+      const scheduledEntry = entry;
+      setTimeout(() => {
+        const current = params.runs.get(runId);
+        if (!current || current !== scheduledEntry || typeof current.endedAt === "number") {
+          return;
+        }
+        void waitForSubagentCompletion(runId, waitTimeoutMs, scheduledEntry);
+      }, RECOVERABLE_WAIT_RETRY_DELAY_MS).unref?.();
+      log.info(reason, {
+        runId,
+        childSessionKey: entry.childSessionKey,
+        ...(error ? { error } : {}),
+      });
+    };
     try {
       const wait = await waitForAgentRun({
         runId,
@@ -177,23 +199,49 @@ export function createSubagentRunManager(params: {
         return;
       }
       if (wait.status === "error" && isRecoverableAgentWaitError(wait.error)) {
-        log.info("subagent wait interrupted; scheduling recovery", {
-          runId,
-          childSessionKey: expectedEntry?.childSessionKey ?? entry?.childSessionKey,
-          error: wait.error,
+        scheduleWaitRetry(entry, "subagent wait interrupted; scheduling recovery", wait.error);
+        return;
+      }
+      if (wait.status === "timeout") {
+        const isTerminalWaitTimeout =
+          typeof wait.endedAt === "number" ||
+          typeof wait.stopReason === "string" ||
+          typeof wait.livenessState === "string";
+        const completion = params.resolveSubagentSessionCompletion({
+          childSessionKey: entry.childSessionKey,
+          fallbackEndedAt: typeof wait.endedAt === "number" ? wait.endedAt : Date.now(),
+          notBeforeMs: entry.startedAt ?? entry.createdAt,
         });
-        params.scheduleOrphanRecovery({ delayMs: 1_000 });
-        const scheduledEntry = entry;
-        setTimeout(() => {
-          if (!scheduledEntry) {
-            return;
-          }
-          const current = params.runs.get(runId);
-          if (!current || current !== scheduledEntry || typeof current.endedAt === "number") {
-            return;
-          }
-          void waitForSubagentCompletion(runId, waitTimeoutMs, scheduledEntry);
-        }, RECOVERABLE_WAIT_RETRY_DELAY_MS).unref?.();
+        if (completion) {
+          completionForRetry = {
+            runId,
+            endedAt: completion.endedAt,
+            outcome: completion.outcome,
+            reason: completion.reason,
+            sendFarewell: true,
+            accountId: entry.requesterOrigin?.accountId,
+            triggerCleanup: true,
+          };
+          await params.completeSubagentRun(completionForRetry);
+          return;
+        }
+        if (isTerminalWaitTimeout) {
+          completionForRetry = {
+            runId,
+            endedAt: wait.endedAt,
+            outcome: { status: "timeout" },
+            reason: SUBAGENT_ENDED_REASON_COMPLETE,
+            sendFarewell: true,
+            accountId: entry.requesterOrigin?.accountId,
+            triggerCleanup: true,
+          };
+          await params.completeSubagentRun(completionForRetry);
+          return;
+        }
+        scheduleWaitRetry(
+          entry,
+          "subagent wait timed out; deferring terminal state until session reconciliation",
+        );
         return;
       }
       let mutated = false;
@@ -214,11 +262,7 @@ export function createSubagentRunManager(params: {
       }
       const waitError = typeof wait.error === "string" ? wait.error : undefined;
       const baseOutcome: SubagentRunOutcome =
-        wait.status === "error"
-          ? { status: "error", error: waitError }
-          : wait.status === "timeout"
-            ? { status: "timeout" }
-            : { status: "ok" };
+        wait.status === "error" ? { status: "error", error: waitError } : { status: "ok" };
       const outcome = withSubagentOutcomeTiming(baseOutcome, {
         startedAt: entry.startedAt,
         endedAt: entry.endedAt,

--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -329,6 +329,177 @@ describe("subagent registry seam flow", () => {
     expect(run?.outcome).toBeUndefined();
   });
 
+  it("keeps parent run active when agent.wait times out before child session settles", async () => {
+    let waitAttempts = 0;
+    let resolveSecondWait: (value: {
+      status: "ok";
+      startedAt: number;
+      endedAt: number;
+    }) => void = () => {};
+    const secondWait = new Promise<{ status: "ok"; startedAt: number; endedAt: number }>(
+      (resolve) => {
+        resolveSecondWait = resolve;
+      },
+    );
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        waitAttempts += 1;
+        if (waitAttempts === 1) {
+          return { status: "timeout" };
+        }
+        return secondWait;
+      }
+      return {};
+    });
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        updatedAt: 1,
+        status: "running",
+      },
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-waiter-timeout",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "eventually complete",
+      cleanup: "keep",
+    });
+
+    await waitForFast(() => {
+      expect(waitAttempts).toBeGreaterThanOrEqual(1);
+    });
+    await waitForFast(() => {
+      expect(waitAttempts).toBeGreaterThanOrEqual(2);
+    });
+    const activeRun = mod
+      .listSubagentRunsForRequester("agent:main:main")
+      .find((entry) => entry.runId === "run-waiter-timeout");
+    expect(activeRun?.endedAt).toBeUndefined();
+    expect(activeRun?.outcome).toBeUndefined();
+
+    resolveSecondWait({
+      status: "ok",
+      startedAt: 111,
+      endedAt: 222,
+    });
+    await waitForFast(() => {
+      const completedRun = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-waiter-timeout");
+      expect(waitAttempts).toBeGreaterThanOrEqual(2);
+      expect(completedRun?.endedAt).toBe(222);
+      expectRecordFields(completedRun?.outcome, { status: "ok" }, "completed run outcome");
+    });
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it("records terminal agent.wait timeouts even before session store timing is persisted", async () => {
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        return {
+          status: "timeout",
+          startedAt: 111,
+          endedAt: 222,
+          stopReason: "rpc",
+        };
+      }
+      return {};
+    });
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        updatedAt: 1,
+        status: "running",
+      },
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-terminal-timeout",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "time out terminally",
+      cleanup: "keep",
+    });
+
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-terminal-timeout");
+      expect(run?.endedAt).toBe(222);
+      expectRecordFields(run?.outcome, { status: "timeout" }, "terminal timeout outcome");
+    });
+    expect(mocks.runSubagentAnnounceFlow).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores stale terminal session-store rows from older child runs", async () => {
+    let waitAttempts = 0;
+    let resolveSecondWait: (value: {
+      status: "ok";
+      startedAt: number;
+      endedAt: number;
+    }) => void = () => {};
+    const secondWait = new Promise<{ status: "ok"; startedAt: number; endedAt: number }>(
+      (resolve) => {
+        resolveSecondWait = resolve;
+      },
+    );
+    mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
+      if (request.method === "agent.wait") {
+        waitAttempts += 1;
+        if (waitAttempts === 1) {
+          return { status: "timeout" };
+        }
+        return secondWait;
+      }
+      return {};
+    });
+    const staleEndedAt = Date.parse("2026-03-24T11:59:00Z");
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:main:subagent:child": {
+        sessionId: "sess-child",
+        updatedAt: staleEndedAt,
+        status: "done",
+        startedAt: staleEndedAt - 100,
+        endedAt: staleEndedAt,
+      },
+    });
+
+    mod.registerSubagentRun({
+      runId: "run-reactivated-timeout",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "new run after stale terminal row",
+      cleanup: "keep",
+    });
+
+    await waitForFast(() => {
+      expect(waitAttempts).toBeGreaterThanOrEqual(2);
+    });
+    const activeRun = mod
+      .listSubagentRunsForRequester("agent:main:main")
+      .find((entry) => entry.runId === "run-reactivated-timeout");
+    expect(activeRun?.endedAt).toBeUndefined();
+    expect(activeRun?.outcome).toBeUndefined();
+    expect(mocks.runSubagentAnnounceFlow).not.toHaveBeenCalled();
+
+    resolveSecondWait({
+      status: "ok",
+      startedAt: Date.parse("2026-03-24T12:00:01Z"),
+      endedAt: Date.parse("2026-03-24T12:00:02Z"),
+    });
+    await waitForFast(() => {
+      const completedRun = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-reactivated-timeout");
+      expectRecordFields(completedRun?.outcome, { status: "ok" }, "reactivated run outcome");
+    });
+  });
+
   it("keeps sessions_yield-ended subagent runs paused instead of announcing no output", async () => {
     mocks.callGateway.mockImplementation(async (request: { method?: string }) => {
       if (request.method === "agent.wait") {
@@ -397,6 +568,7 @@ describe("subagent registry seam flow", () => {
       },
     });
 
+    vi.setSystemTime(persistedStartedAt - 1);
     mod.registerSubagentRun({
       runId: "run-stale-terminal",
       childSessionKey: "agent:main:subagent:child",

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -1,11 +1,5 @@
 import type { cleanupBrowserSessionsForLifecycleEnd } from "../browser-lifecycle-cleanup.js";
 import { getRuntimeConfig } from "../config/config.js";
-import {
-  loadSessionStore,
-  resolveAgentIdFromSessionKey,
-  resolveStorePath,
-  type SessionEntry,
-} from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ResolveContextEngineOptions } from "../context-engine/registry.js";
 import type { ContextEngine, SubagentEndReason } from "../context-engine/types.js";
@@ -17,7 +11,6 @@ import { importRuntimeModule } from "../shared/runtime-import.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.shared.js";
 import type { DeliveryContext } from "../utils/delivery-context.types.js";
 import type { ensureRuntimePluginsLoaded as ensureRuntimePluginsLoadedFn } from "./runtime-plugins.js";
-import type { SubagentRunOutcome } from "./subagent-announce-output.js";
 import {
   SUBAGENT_ENDED_REASON_COMPLETE,
   SUBAGENT_ENDED_REASON_ERROR,
@@ -64,6 +57,12 @@ import {
 } from "./subagent-registry-state.js";
 import { configureSubagentRegistrySteerRuntime } from "./subagent-registry-steer-runtime.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
+import {
+  loadSubagentSessionEntry,
+  resolveCompletionFromSessionEntry,
+  resolveSubagentSessionCompletion,
+  type SubagentSessionStoreCache,
+} from "./subagent-session-reconciliation.js";
 import { resolveAgentTimeoutMs } from "./timeout.js";
 
 export type { SubagentRunRecord } from "./subagent-registry.types.js";
@@ -199,90 +198,6 @@ const SESSION_RUN_TTL_MS = 5 * 60_000; // 5 minutes
 const PENDING_LIFECYCLE_TERMINAL_TTL_MS = 5 * 60_000; // 5 minutes
 /** Grace period before treating a "running" subagent without a live run context as stale. */
 const STALE_ACTIVE_SUBAGENT_GRACE_MS = process.env.OPENCLAW_TEST_FAST === "1" ? 1_000 : 60_000;
-
-function findSessionEntryByKey(store: Record<string, SessionEntry>, sessionKey: string) {
-  const direct = store[sessionKey];
-  if (direct) {
-    return direct;
-  }
-  const normalized = sessionKey.trim().toLowerCase();
-  for (const [key, entry] of Object.entries(store)) {
-    if (key.trim().toLowerCase() === normalized) {
-      return entry;
-    }
-  }
-  return undefined;
-}
-
-function loadSubagentSessionEntry(
-  childSessionKey: string,
-  storeCache: Map<string, Record<string, SessionEntry>>,
-): SessionEntry | undefined {
-  const key = childSessionKey.trim();
-  if (!key) {
-    return undefined;
-  }
-  const agentId = resolveAgentIdFromSessionKey(key);
-  const storePath = resolveStorePath(getRuntimeConfig().session?.store, { agentId });
-  let store = storeCache.get(storePath);
-  if (!store) {
-    store = loadSessionStore(storePath);
-    storeCache.set(storePath, store);
-  }
-  return findSessionEntryByKey(store, key);
-}
-
-function resolveCompletionFromSessionEntry(
-  sessionEntry: SessionEntry | undefined,
-  fallbackEndedAt: number,
-): {
-  endedAt: number;
-  outcome: SubagentRunOutcome;
-  reason: SubagentLifecycleEndedReason;
-} | null {
-  const status = sessionEntry?.status;
-  const endedAt =
-    typeof sessionEntry?.endedAt === "number" && Number.isFinite(sessionEntry.endedAt)
-      ? sessionEntry.endedAt
-      : fallbackEndedAt;
-
-  if (status === "done") {
-    return {
-      endedAt,
-      outcome: { status: "ok" },
-      reason: SUBAGENT_ENDED_REASON_COMPLETE,
-    };
-  }
-  if (status === "timeout") {
-    return {
-      endedAt,
-      outcome: { status: "timeout" },
-      reason: SUBAGENT_ENDED_REASON_COMPLETE,
-    };
-  }
-  if (status === "failed") {
-    return {
-      endedAt,
-      outcome: { status: "error", error: "session completed before registry settled" },
-      reason: SUBAGENT_ENDED_REASON_ERROR,
-    };
-  }
-  if (status === "killed") {
-    return {
-      endedAt,
-      outcome: { status: "error", error: "subagent run terminated" },
-      reason: SUBAGENT_ENDED_REASON_KILLED,
-    };
-  }
-  if (status !== "running" && typeof sessionEntry?.endedAt === "number") {
-    return {
-      endedAt,
-      outcome: { status: "ok" },
-      reason: SUBAGENT_ENDED_REASON_COMPLETE,
-    };
-  }
-  return null;
-}
 
 function loadContextEngineInitModule(): Promise<ContextEngineInitModule> {
   return contextEngineInitLoader.load();
@@ -747,7 +662,7 @@ async function sweepSubagentRuns() {
   sweepInProgress = true;
   try {
     const now = Date.now();
-    const storeCache = new Map<string, Record<string, SessionEntry>>();
+    const storeCache: SubagentSessionStoreCache = new Map();
     let mutated = false;
     for (const [runId, entry] of subagentRuns.entries()) {
       if (typeof entry.endedAt !== "number") {
@@ -774,8 +689,13 @@ async function sweepSubagentRuns() {
             continue;
           }
 
-          const sessionEntry = loadSubagentSessionEntry(entry.childSessionKey, storeCache);
-          const completion = resolveCompletionFromSessionEntry(sessionEntry, now);
+          const sessionEntry = loadSubagentSessionEntry({
+            childSessionKey: entry.childSessionKey,
+            storeCache,
+          });
+          const completion = resolveCompletionFromSessionEntry(sessionEntry, now, {
+            notBeforeMs: entry.startedAt ?? entry.createdAt,
+          });
           if (completion) {
             await completeSubagentRun({
               runId,
@@ -986,6 +906,7 @@ const subagentRunManager = createSubagentRunManager({
   clearPendingLifecycleError,
   resolveSubagentWaitTimeoutMs,
   scheduleOrphanRecovery: (args) => scheduleSubagentOrphanRecovery(args),
+  resolveSubagentSessionCompletion,
   notifyContextEngineSubagentEnded,
   completeCleanupBookkeeping,
   completeSubagentRun,

--- a/src/agents/subagent-session-reconciliation.ts
+++ b/src/agents/subagent-session-reconciliation.ts
@@ -1,0 +1,158 @@
+import { getRuntimeConfig } from "../config/config.js";
+import {
+  loadSessionStore,
+  resolveAgentIdFromSessionKey,
+  resolveStorePath,
+  type SessionEntry,
+} from "../config/sessions.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { SubagentRunOutcome } from "./subagent-announce-output.js";
+import {
+  SUBAGENT_ENDED_REASON_COMPLETE,
+  SUBAGENT_ENDED_REASON_ERROR,
+  SUBAGENT_ENDED_REASON_KILLED,
+  type SubagentLifecycleEndedReason,
+} from "./subagent-lifecycle-events.js";
+
+export type SubagentSessionStoreCache = Map<string, Record<string, SessionEntry>>;
+
+export type SubagentSessionCompletion = {
+  endedAt: number;
+  outcome: SubagentRunOutcome;
+  reason: SubagentLifecycleEndedReason;
+};
+
+function finiteTimestamp(value: number | undefined): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function terminalSessionTimestamp(sessionEntry: SessionEntry | undefined): number | undefined {
+  return finiteTimestamp(sessionEntry?.endedAt) ?? finiteTimestamp(sessionEntry?.updatedAt);
+}
+
+function isFreshForRun(
+  sessionEntry: SessionEntry | undefined,
+  notBeforeMs: number | undefined,
+): boolean {
+  if (notBeforeMs === undefined) {
+    return true;
+  }
+  const terminalAt = terminalSessionTimestamp(sessionEntry);
+  return terminalAt !== undefined && terminalAt >= notBeforeMs;
+}
+
+function findSessionEntryByKey(store: Record<string, SessionEntry>, sessionKey: string) {
+  const direct = store[sessionKey];
+  if (direct) {
+    return direct;
+  }
+  const normalized = sessionKey.trim().toLowerCase();
+  for (const [key, entry] of Object.entries(store)) {
+    if (key.trim().toLowerCase() === normalized) {
+      return entry;
+    }
+  }
+  return undefined;
+}
+
+export function loadSubagentSessionEntry(params: {
+  childSessionKey: string;
+  storeCache?: SubagentSessionStoreCache;
+  cfg?: OpenClawConfig;
+}): SessionEntry | undefined {
+  const key = params.childSessionKey.trim();
+  if (!key) {
+    return undefined;
+  }
+  const agentId = resolveAgentIdFromSessionKey(key);
+  const cfg = params.cfg ?? getRuntimeConfig();
+  const storePath = resolveStorePath(cfg.session?.store, { agentId });
+  let store = params.storeCache?.get(storePath);
+  if (!store) {
+    store = loadSessionStore(storePath);
+    params.storeCache?.set(storePath, store);
+  }
+  return findSessionEntryByKey(store, key);
+}
+
+export function resolveCompletionFromSessionEntry(
+  sessionEntry: SessionEntry | undefined,
+  fallbackEndedAt: number,
+  opts?: { notBeforeMs?: number },
+): SubagentSessionCompletion | null {
+  const status = sessionEntry?.status;
+  const endedAt =
+    finiteTimestamp(sessionEntry?.endedAt) ??
+    finiteTimestamp(sessionEntry?.updatedAt) ??
+    fallbackEndedAt;
+
+  if (status === "done") {
+    if (!isFreshForRun(sessionEntry, opts?.notBeforeMs)) {
+      return null;
+    }
+    return {
+      endedAt,
+      outcome: { status: "ok" },
+      reason: SUBAGENT_ENDED_REASON_COMPLETE,
+    };
+  }
+  if (status === "timeout") {
+    if (!isFreshForRun(sessionEntry, opts?.notBeforeMs)) {
+      return null;
+    }
+    return {
+      endedAt,
+      outcome: { status: "timeout" },
+      reason: SUBAGENT_ENDED_REASON_COMPLETE,
+    };
+  }
+  if (status === "failed") {
+    if (!isFreshForRun(sessionEntry, opts?.notBeforeMs)) {
+      return null;
+    }
+    return {
+      endedAt,
+      outcome: { status: "error", error: "session completed before registry settled" },
+      reason: SUBAGENT_ENDED_REASON_ERROR,
+    };
+  }
+  if (status === "killed") {
+    if (!isFreshForRun(sessionEntry, opts?.notBeforeMs)) {
+      return null;
+    }
+    return {
+      endedAt,
+      outcome: { status: "error", error: "subagent run terminated" },
+      reason: SUBAGENT_ENDED_REASON_KILLED,
+    };
+  }
+  if (status !== "running" && typeof sessionEntry?.endedAt === "number") {
+    if (!isFreshForRun(sessionEntry, opts?.notBeforeMs)) {
+      return null;
+    }
+    return {
+      endedAt,
+      outcome: { status: "ok" },
+      reason: SUBAGENT_ENDED_REASON_COMPLETE,
+    };
+  }
+  return null;
+}
+
+export function resolveSubagentSessionCompletion(params: {
+  childSessionKey: string;
+  fallbackEndedAt: number;
+  notBeforeMs?: number;
+  storeCache?: SubagentSessionStoreCache;
+  cfg?: OpenClawConfig;
+}): SubagentSessionCompletion | null {
+  return resolveCompletionFromSessionEntry(
+    loadSubagentSessionEntry({
+      childSessionKey: params.childSessionKey,
+      storeCache: params.storeCache,
+      cfg: params.cfg,
+    }),
+    params.fallbackEndedAt,
+    { notBeforeMs: params.notBeforeMs },
+  );
+}


### PR DESCRIPTION
Summary
- Refactors subagent session-store terminal reconciliation into a shared helper used by both live wait handling and registry sweeps.
- Keeps parent subagent runs active when agent.wait returns a plain poll timeout before the child session settles, then retries/reconciles the later completion.
- Guards session-store reconciliation with run freshness so stale terminal rows from reused/reactivated child sessions cannot complete a newer run.

Fixes #82787.

Verification
- CodexReview: clean, no accepted/actionable findings reported.
- pnpm test src/agents/subagent-registry.test.ts src/agents/subagent-registry.lifecycle-retry-grace.e2e.test.ts src/agents/openclaw-tools.subagents.sessions-spawn.lifecycle.test.ts -- --reporter=dot
- git diff --check
- pnpm check:changed
- Testbox: provider=blacksmith-testbox id=tbx_01krt1rxpkb7vj53mkaqwfserq exit=0

## Real behavior proof

Behavior addressed: parent subagent waiters no longer record a terminal timeout when agent.wait only hit its poll timeout and the child session is still running.
Real environment tested: local OpenClaw checkout plus Blacksmith Testbox changed-check environment for the touched runtime surface.
Exact steps or command run after this patch: focused subagent registry/session-spawn Vitest command, CodexReview, git diff --check, and pnpm check:changed in Testbox tbx_01krt1rxpkb7vj53mkaqwfserq.
Evidence after fix: terminal output from the rebased focused run and remote Testbox run:

```text
[test] passed 2 Vitest shards in 10.42s
blacksmith run summary sync=delegated command=1m52.657s total=1m55.545s exit=0
provider=blacksmith-testbox leaseId=tbx_01krt1rxpkb7vj53mkaqwfserq
Import cycle check: 0 runtime value cycle(s).
Found 0 warnings and 0 errors.
```

Observed result after fix: the unsettled child-session timeout, terminal wait timeout, stale terminal row rejection, and terminal session-store reconciliation regressions pass; changed-check completed with exit 0 in Testbox.
What was not tested: live Discord/Telegram provider roundtrip with a real delayed subagent; covered with registry/session-spawn e2e simulation and Testbox checks instead.
