### PR TITLE
fix(web-fetch): recover body when readability returns title only

### DIFF
--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -267,6 +267,27 @@ function normalizeContentType(value: string | null | undefined): string | undefi
   return trimmed || undefined;
 }
 
+function normalizeExtractedTextForComparison(value: string | undefined): string {
+  return normalizeLowercaseStringOrEmpty(value).replace(/\s+/g, " ").trim();
+}
+
+function shouldPreferBasicHtmlOverReadable(params: {
+  readableText: string;
+  readableTitle?: string;
+  basicText?: string;
+}): boolean {
+  const readable = normalizeExtractedTextForComparison(params.readableText);
+  const title = normalizeExtractedTextForComparison(params.readableTitle);
+  const basic = normalizeExtractedTextForComparison(params.basicText);
+  if (!readable || !basic || basic.length <= readable.length) {
+    return false;
+  }
+  // Some Readability extractors can return only the document title/head metadata
+  // for small static pages. Prefer the raw HTML body cleanup in that case so the
+  // page body is not silently dropped.
+  return Boolean(title && readable === title);
+}
+
 type WebFetchRuntimeParams = {
   url: string;
   extractMode: ExtractMode;
@@ -524,6 +545,22 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
           text = readable.text;
           title = readable.title;
           extractor = readable.extractor;
+          const basic = await extractBasicHtmlContent({
+            html: body,
+            extractMode: params.extractMode,
+          });
+          if (
+            shouldPreferBasicHtmlOverReadable({
+              readableText: readable.text,
+              readableTitle: readable.title,
+              basicText: basic?.text,
+            }) &&
+            basic?.text
+          ) {
+            text = basic.text;
+            title = basic.title ?? title;
+            extractor = "raw-html";
+          }
         } else {
           let payload: Record<string, unknown> | null = null;
           try {

--- a/src/agents/tools/web-tools.fetch.test.ts
+++ b/src/agents/tools/web-tools.fetch.test.ts
@@ -460,6 +460,31 @@ describe("web_fetch extraction fallbacks", () => {
     ).rejects.toThrow("Readability, Test Fetch, and basic HTML cleanup returned no content");
   });
 
+  it("uses basic HTML cleanup when readability only returns title metadata", async () => {
+    installMockFetch(
+      (input: RequestInfo | URL) =>
+        Promise.resolve(
+          htmlResponse(
+            "<!doctype html><html><head><title>Example Title</title></head><body><main><h1>Example Title</h1><p>Body section that should be visible to the model.</p></main></body></html>",
+            resolveRequestUrl(input),
+          ),
+        ) as Promise<Response>,
+    );
+    extractReadableContentMock.mockResolvedValue({
+      text: "Example Title",
+      title: "Example Title",
+      extractor: "readability",
+    });
+
+    const tool = createFetchTool({ firecrawl: { enabled: false } });
+    const result = await executeFetch(tool, { url: "https://example.com/title-only" });
+    const details = result?.details as { extractor?: string; text?: string; title?: string };
+
+    expect(details.extractor).toBe("raw-html");
+    expect(details.text).toContain("Body section that should be visible to the model.");
+    expect(details.title).toContain("Example Title");
+  });
+
   it("falls back to basic HTML cleanup after readability and before giving up", async () => {
     installMockFetch(
       (input: RequestInfo | URL) =>


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->
## Summary
- Fall back to basic HTML cleanup when Readability returns only the page title/head metadata while the raw HTML body contains more content.
- Add a regression covering a simple static HTML page whose body text would otherwise be dropped.

Closes #82685

## Test Plan
- `pnpm --config.verify-deps-before-run=false exec oxfmt --check --threads=1 src/agents/tools/web-fetch.ts src/agents/tools/web-tools.fetch.test.ts`
- `pnpm --config.verify-deps-before-run=false test src/agents/tools/web-tools.fetch.test.ts -- -t "title metadata|basic HTML cleanup" --reporter=dot`
  - 2 passed, 17 skipped
- `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false npm_config_verify_deps_before_run=false pnpm --config.verify-deps-before-run=false check:changed --staged`
  - passed early guard lanes through package patch guard, then timed out locally during core/core-test tsgo in this symlinked worktree before completion

## Real behavior proof

Behavior or issue addressed: `web_fetch` could accept a non-empty Readability result even when that result contained only the page title/head metadata. For simple static HTML pages, that meant the actual `<body>` content could be omitted instead of falling back to the raw HTML cleanup path.

Real environment tested: API-downloaded PR head files from `leno23/openclaw:fix/web-fetch-body-fallback-82685`, inspected and exercised with Node.js against the patched `src/agents/tools/web-fetch.ts` and `src/agents/tools/web-tools.fetch.test.ts`.

Exact steps or command run after this patch: `cd /tmp/openclaw-maintain-82890 && node proof-source-probe.mjs`. A focused Vitest regression was also run separately: `pnpm --config.verify-deps-before-run=false test src/agents/tools/web-tools.fetch.test.ts -- -t "title metadata|basic HTML cleanup" --reporter=dot`.

Evidence after fix: Terminal output from the patched PR head files shows the fallback guard, raw-html assignment, regression fixture, and sample title-only behavior all present and consistent:

```text
source probe: PR #82890 web_fetch title-only readability fallback
PASS web-fetch.ts defines a conservative readable-vs-basic fallback guard
PASS web-fetch.ts invokes basic HTML cleanup even after non-empty Readability output
PASS web-fetch.ts checks whether Readability only returned title metadata
PASS web-fetch.ts marks the fallback result as raw-html
PASS regression test documents title-only Readability behavior
PASS regression fixture includes body text that must survive extraction
PASS regression asserts the raw-html fallback path is used
PASS regression asserts body text is returned to the model
PASS sample title-only Readability result prefers richer basic HTML body text
PASS non-title-only Readability result is not replaced
source probe result: PASS
```

Focused regression output from the same patch:

```text
Test Files  1 passed (1)
Tests  2 passed | 17 skipped (19)
Duration  79.83s
[test] passed 1 Vitest shard in 107.71s
```

The regression feeds this HTML and has Readability return only `Example Title`:

```html
<!doctype html><html><head><title>Example Title</title></head><body><main><h1>Example Title</h1><p>Body section that should be visible to the model.</p></main></body></html>
```

Observed result after fix: The title-only Readability result is replaced by the richer basic HTML cleanup output. The returned extractor is `raw-html`, and the body text `Body section that should be visible to the model.` remains available to the model.

What was not tested: Original reporter live URL validation was unavailable because the issue did not include a concrete URL or HTML sample. Full `check:changed --staged` reached the core/core-test tsgo lane and then exceeded the local timeout in the symlinked worktree; focused formatter, source proof, and targeted regression evidence above were captured.

## Risk/Notes
- The fallback is conservative: it only prefers basic HTML when Readability text normalizes exactly to the page title and basic HTML has more content.
- Existing non-empty Readability results that include body content should remain unchanged.
