### PR TITLE
fix(github-copilot): request identity-encoded API responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Providers/GitHub Copilot: request identity-encoded Copilot API responses across token exchange, catalog, model calls, usage, and embeddings so compressed Business-account error payloads no longer reach JSON parsers as gzip bytes. Fixes #82871. Thanks @tonyfe01.
 - Agents/diagnostics: split slow embedded-run `attempt-dispatch` startup summaries into workspace, prompt, runtime-plan, and final dispatch subspans so traces identify the delayed setup phase. Fixes #82782. (#82783) Thanks @galiniliev.
 - Agents/subagents: route group/channel subagent completions through message-tool-only handoffs when required and keep active-requester wake failures from dropping completion delivery. Fixes #82803. Thanks @galiniliev, @yozakura-ava, and @moeedahmed.
 - Memory-core: scan persisted memory source sessions on startup, comparing on-disk transcripts against the index and marking only missing/newer/resized files dirty for incremental sync. Fixes #82341. (#82341) Thanks @giodl73-repo.

--- a/extensions/github-copilot/embeddings.test.ts
+++ b/extensions/github-copilot/embeddings.test.ts
@@ -244,6 +244,7 @@ describe("githubCopilotMemoryEmbeddingProviderAdapter", () => {
 
     const discoveryCall = firstDiscoveryRequest();
     expect(discoveryCall.url).toBe("https://proxy.example/v1/models");
+    expect(discoveryCall.init.headers["Accept-Encoding"]).toBe("identity");
     expect(discoveryCall.init.headers["X-Proxy-Token"]).toBe("proxy");
   });
 

--- a/extensions/github-copilot/models.test.ts
+++ b/extensions/github-copilot/models.test.ts
@@ -412,6 +412,10 @@ describe("github-copilot token", () => {
 
     expect(res.token).toBe("fresh;proxy-ep=https://proxy.contoso.test;");
     expect(res.baseUrl).toBe("https://api.contoso.test");
+    const [, calledInit] = fetchImpl.mock.calls[0] ?? [];
+    expect(((calledInit as RequestInit).headers as Record<string, string>)["Accept-Encoding"]).toBe(
+      "identity",
+    );
     expect(jsonStoreMocks.saveJsonFile).toHaveBeenCalledTimes(1);
   });
 });
@@ -536,6 +540,9 @@ describe("fetchCopilotModelCatalog", () => {
     expect((calledInit as RequestInit).method).toBe("GET");
     expect(((calledInit as RequestInit).headers as Record<string, string>).Authorization).toBe(
       "Bearer tid=test",
+    );
+    expect(((calledInit as RequestInit).headers as Record<string, string>)["Accept-Encoding"]).toBe(
+      "identity",
     );
 
     expect(out.map((m) => m.id)).toEqual([

--- a/extensions/github-copilot/stream.test.ts
+++ b/extensions/github-copilot/stream.test.ts
@@ -64,6 +64,7 @@ describe("wrapCopilotAnthropicStream", () => {
       messages,
       hasImages: true,
     });
+    expect(expectedCopilotHeaders["Accept-Encoding"]).toBe("identity");
 
     void wrapped(
       {

--- a/src/plugin-sdk/provider-auth.ts
+++ b/src/plugin-sdk/provider-auth.ts
@@ -122,6 +122,7 @@ export function buildCopilotIdeHeaders(
   } = {},
 ): Record<string, string> {
   return {
+    "Accept-Encoding": "identity",
     "Editor-Version": COPILOT_EDITOR_VERSION,
     "Editor-Plugin-Version": COPILOT_EDITOR_PLUGIN_VERSION,
     "User-Agent": COPILOT_USER_AGENT,


### PR DESCRIPTION
## Summary

- request `Accept-Encoding: identity` from the shared GitHub Copilot IDE header helper
- cover Copilot token exchange, catalog discovery, stream headers, and embedding discovery with focused assertions
- add changelog entry for #82871

## Verification

- `node --import tsx -e 'import { buildCopilotIdeHeaders } from "./src/plugin-sdk/provider-auth.ts"; console.log(JSON.stringify(buildCopilotIdeHeaders({ includeApiVersion: true }), null, 2));'`
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-copilot-82871 node scripts/run-vitest.mjs extensions/github-copilot/models.test.ts extensions/github-copilot/stream.test.ts extensions/github-copilot/embeddings.test.ts`
- `pnpm check:changed` via Blacksmith Testbox `tbx_01krt22vggzn326qregmb2nd89`, GitHub Actions run https://github.com/openclaw/openclaw/actions/runs/25981012511
- `/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --mode local`

## Real behavior proof

Behavior addressed: github-copilot requests now opt out of compressed Copilot API responses before token exchange, catalog discovery, model-call headers, usage, image understanding, and embedding discovery parse JSON.
Real environment tested: local OpenClaw runtime module import on macOS, plus delegated Blacksmith Testbox changed gate.
Exact steps or command run after this patch: `node --import tsx -e 'import { buildCopilotIdeHeaders } from "./src/plugin-sdk/provider-auth.ts"; console.log(JSON.stringify(buildCopilotIdeHeaders({ includeApiVersion: true }), null, 2));'`
Evidence after fix: console output from the local OpenClaw runtime import after this patch:
```json
{
  "Accept-Encoding": "identity",
  "Editor-Version": "vscode/1.107.0",
  "Editor-Plugin-Version": "copilot-chat/0.35.0",
  "User-Agent": "GitHubCopilotChat/0.35.0",
  "X-Github-Api-Version": "2025-04-01"
}
```
Observed result after fix: the shared Copilot header set now includes `Accept-Encoding: identity`, so every caller spreading `buildCopilotIdeHeaders()` sends the identity-encoding policy. Focused Copilot tests also passed 3 files / 51 tests, and the Testbox changed gate exited 0.
What was not tested: live GitHub Copilot Business account call; no credential was available in this run.

## Links

Fixes #82871.
