### PR TITLE
fix(gateway): prewarm agent runtime before ready

### DIFF
--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -50,6 +50,8 @@ const hoisted = vi.hoisted(() => {
   }));
   const resolveEmbeddedAgentRuntime = vi.fn(() => "pi");
   const ensureOpenClawModelsJson = vi.fn(async () => {});
+  const runAgentAttempt = vi.fn();
+  const runEmbeddedPiAgent = vi.fn();
   return {
     startPluginServices,
     startGmailWatcherWithLogs,
@@ -79,6 +81,8 @@ const hoisted = vi.hoisted(() => {
     getModelRefStatus,
     resolveEmbeddedAgentRuntime,
     ensureOpenClawModelsJson,
+    runAgentAttempt,
+    runEmbeddedPiAgent,
   };
 });
 
@@ -192,6 +196,14 @@ vi.mock("../agents/pi-embedded-runner/runtime.js", () => ({
 
 vi.mock("../agents/models-config.js", () => ({
   ensureOpenClawModelsJson: hoisted.ensureOpenClawModelsJson,
+}));
+
+vi.mock("../agents/command/attempt-execution.runtime.js", () => ({
+  runAgentAttempt: hoisted.runAgentAttempt,
+}));
+
+vi.mock("../agents/pi-embedded.js", () => ({
+  runEmbeddedPiAgent: hoisted.runEmbeddedPiAgent,
 }));
 
 vi.mock("./server-tailscale.js", () => ({
@@ -324,6 +336,8 @@ describe("startGatewayPostAttachRuntime", () => {
     hoisted.resolveEmbeddedAgentRuntime.mockReturnValue("pi");
     hoisted.ensureOpenClawModelsJson.mockReset();
     hoisted.ensureOpenClawModelsJson.mockResolvedValue(undefined);
+    hoisted.runAgentAttempt.mockClear();
+    hoisted.runEmbeddedPiAgent.mockClear();
   });
 
   afterEach(() => {
@@ -716,6 +730,84 @@ describe("startGatewayPostAttachRuntime", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("honors the startup agent runtime prewarm skip env", () => {
+    expect(__testing.shouldSkipStartupAgentRuntimePrewarm({})).toBe(false);
+    expect(
+      __testing.shouldSkipStartupAgentRuntimePrewarm({
+        OPENCLAW_SKIP_STARTUP_AGENT_RUNTIME_PREWARM: "1",
+      }),
+    ).toBe(true);
+    expect(
+      __testing.shouldSkipStartupAgentRuntimePrewarm({
+        OPENCLAW_SKIP_STARTUP_AGENT_RUNTIME_PREWARM: "true",
+      }),
+    ).toBe(true);
+  });
+
+  it("prewarms the first-turn agent runtime after channel startup", async () => {
+    await withEnvAsync({ OPENCLAW_SKIP_STARTUP_AGENT_RUNTIME_PREWARM: undefined }, async () => {
+      const events: string[] = [];
+      const prewarmAgentRuntime = vi.fn(async () => {
+        events.push("agent-runtime-prewarm");
+      });
+      const startChannels = vi.fn(async () => {
+        events.push("channels");
+      });
+      const trace = createStartupTraceRecorder();
+
+      await startGatewaySidecars({
+        cfg: { hooks: { internal: { enabled: false } } } as never,
+        pluginRegistry: createPostAttachParams().pluginRegistry,
+        defaultWorkspaceDir: "/tmp/openclaw-workspace",
+        deps: {} as never,
+        startChannels,
+        prewarmAgentRuntime,
+        log: { warn: vi.fn() },
+        logHooks: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+        },
+        logChannels: {
+          info: vi.fn(),
+          error: vi.fn(),
+        },
+        startupTrace: trace.startupTrace,
+      });
+
+      expect(events).toEqual(["channels", "agent-runtime-prewarm"]);
+      expect(prewarmAgentRuntime).toHaveBeenCalledTimes(1);
+      expect(trace.measures).toContain("sidecars.agent-runtime-prewarm");
+    });
+  });
+
+  it("skips first-turn agent runtime prewarm when disabled", async () => {
+    await withEnvAsync({ OPENCLAW_SKIP_STARTUP_AGENT_RUNTIME_PREWARM: "1" }, async () => {
+      const prewarmAgentRuntime = vi.fn(async () => {});
+
+      await startGatewaySidecars({
+        cfg: { hooks: { internal: { enabled: false } } } as never,
+        pluginRegistry: createPostAttachParams().pluginRegistry,
+        defaultWorkspaceDir: "/tmp/openclaw-workspace",
+        deps: {} as never,
+        startChannels: vi.fn(async () => {}),
+        prewarmAgentRuntime,
+        log: { warn: vi.fn() },
+        logHooks: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+        },
+        logChannels: {
+          info: vi.fn(),
+          error: vi.fn(),
+        },
+      });
+
+      expect(prewarmAgentRuntime).not.toHaveBeenCalled();
+    });
   });
 
   it("prewarms models.json in the configured default agent dir", async () => {

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -29,6 +29,7 @@ const ACP_BACKEND_READY_POLL_MS = 50;
 const PRIMARY_MODEL_PREWARM_TIMEOUT_MS = 5_000;
 const STARTUP_PROVIDER_DISCOVERY_TIMEOUT_MS = 5_000;
 const SKIP_STARTUP_MODEL_PREWARM_ENV = "OPENCLAW_SKIP_STARTUP_MODEL_PREWARM";
+const SKIP_STARTUP_AGENT_RUNTIME_PREWARM_ENV = "OPENCLAW_SKIP_STARTUP_AGENT_RUNTIME_PREWARM";
 const QMD_STARTUP_IDLE_DELAY_MS = 120_000;
 const RESTART_SENTINEL_FILENAME = "restart-sentinel.json";
 
@@ -75,6 +76,11 @@ function shouldCheckRestartSentinel(env: NodeJS.ProcessEnv = process.env): boole
 
 function shouldSkipStartupModelPrewarm(env: NodeJS.ProcessEnv = process.env): boolean {
   const raw = env[SKIP_STARTUP_MODEL_PREWARM_ENV]?.trim().toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
+}
+
+function shouldSkipStartupAgentRuntimePrewarm(env: NodeJS.ProcessEnv = process.env): boolean {
+  const raw = env[SKIP_STARTUP_AGENT_RUNTIME_PREWARM_ENV]?.trim().toLowerCase();
   return raw === "1" || raw === "true" || raw === "yes" || raw === "on";
 }
 
@@ -407,6 +413,28 @@ function schedulePrimaryModelPrewarm(
   });
 }
 
+async function prewarmAgentRuntimeForFirstTurn(): Promise<void> {
+  await Promise.all([
+    import("../agents/command/attempt-execution.runtime.js"),
+    import("../agents/pi-embedded.js"),
+    import("../agents/tool-catalog.js"),
+  ]);
+}
+
+async function prewarmAgentRuntimeForFirstTurnIfEnabled(params: {
+  log: { warn: (msg: string) => void };
+  prewarm?: typeof prewarmAgentRuntimeForFirstTurn;
+}): Promise<void> {
+  if (shouldSkipStartupAgentRuntimePrewarm()) {
+    return;
+  }
+  try {
+    await (params.prewarm ?? prewarmAgentRuntimeForFirstTurn)();
+  } catch (err) {
+    params.log.warn(`startup agent runtime prewarm failed: ${String(err)}`);
+  }
+}
+
 export async function startGatewaySidecars(params: {
   cfg: OpenClawConfig;
   pluginRegistry: ReturnType<typeof loadOpenClawPlugins>;
@@ -414,6 +442,7 @@ export async function startGatewaySidecars(params: {
   deps: CliDeps;
   startChannels: () => Promise<void>;
   prewarmPrimaryModel?: typeof prewarmConfiguredPrimaryModel;
+  prewarmAgentRuntime?: typeof prewarmAgentRuntimeForFirstTurn;
   log: { warn: (msg: string) => void };
   logHooks: {
     info: (msg: string) => void;
@@ -475,6 +504,13 @@ export async function startGatewaySidecars(params: {
       );
     }
   });
+
+  await measureStartup(params.startupTrace, "sidecars.agent-runtime-prewarm", () =>
+    prewarmAgentRuntimeForFirstTurnIfEnabled({
+      log: params.log,
+      ...(params.prewarmAgentRuntime ? { prewarm: params.prewarmAgentRuntime } : {}),
+    }),
+  );
 
   const shouldDispatchGatewayStartupInternalHook =
     internalHooksConfigured || (await hasGatewayStartupInternalHookListeners());
@@ -960,11 +996,14 @@ export async function startGatewayPostAttachRuntime(
 
 export const __testing = {
   hasRestartSentinelFileFast,
+  prewarmAgentRuntimeForFirstTurn,
+  prewarmAgentRuntimeForFirstTurnIfEnabled,
   prewarmConfiguredPrimaryModel,
   prewarmConfiguredPrimaryModelWithTimeout,
   refreshLatestUpdateRestartSentinelIfPresent,
   resolveGatewayMemoryStartupPolicy,
   schedulePrimaryModelPrewarm,
+  shouldSkipStartupAgentRuntimePrewarm,
   shouldSkipStartupModelPrewarm,
   stopPostReadySidecarsAfterCloseStarted,
 };


### PR DESCRIPTION
## Summary

- Prewarm the first-turn agent runtime import path during Gateway sidecar startup, before startup-gated Gateway methods are released.
- Keep the prewarm import-only: it does not submit a model request, touch user transcripts, or run tools.
- Add `OPENCLAW_SKIP_STARTUP_AGENT_RUNTIME_PREWARM` as a kill switch and cover the startup ordering/skip behavior in focused Gateway tests.

## Verification

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server-startup-post-attach.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/gateway/server-startup-post-attach.ts src/gateway/server-startup-post-attach.test.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/gateway/server-startup-post-attach.ts src/gateway/server-startup-post-attach.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `git diff --check HEAD~1..HEAD`

## Real behavior proof

Behavior addressed: After Gateway restart, the first WebChat/agent turn can pay cold in-process agent runtime import/setup cost before trajectory `session.started`, so `chat.send` returns quickly but the visible run appears hung until the runtime path finishes warming.

Real environment tested: Local macOS OpenClaw source checkout on branch `fix/gateway-post-restart-warmup` at `f391104b9597832392329d9e3edd9f8f46010914`, running a foreground dev Gateway on `ws://127.0.0.1:19094` with startup tracing enabled.

Exact steps or command run after this patch:

```console
OPENCLAW_SKIP_CHANNELS=1 OPENCLAW_GATEWAY_STARTUP_TRACE=1 pnpm openclaw --dev gateway run --force --port 19094 --auth none --allow-unconfigured --verbose --compact
pnpm openclaw --dev gateway call --url ws://127.0.0.1:19094 --token dev health --json
```

Evidence after fix: Runtime console output from the patched Gateway shows the new import-only prewarm span completed after channels and before plugin services, sidecar readiness, and Gateway ready:

```text
2026-05-16T21:23:03.140-07:00 [gateway/channels] skipping channel start (OPENCLAW_SKIP_CHANNELS=1 or OPENCLAW_SKIP_PROVIDERS=1)
2026-05-16T21:23:03.144-07:00 [gateway] startup trace: sidecars.channel-skip 4.4ms total=5789.2ms eventLoopMax=0.0ms
2026-05-16T21:23:03.153-07:00 [gateway] startup trace: sidecars.channels 8.7ms total=5793.2ms eventLoopMax=0.0ms
2026-05-16T21:23:03.200-07:00 [gateway] startup trace: sidecars.agent-runtime-prewarm 40.6ms total=5843.5ms eventLoopMax=0.0ms
2026-05-16T21:23:04.687-07:00 [gateway] startup trace: sidecars.plugin-services 1480.2ms total=7331.0ms eventLoopMax=0.0ms
2026-05-16T21:23:04.711-07:00 [gateway] startup trace: sidecars.ready loadedPluginCount=9.0 postReadySidecarCount=0.0
2026-05-16T21:23:04.720-07:00 [gateway] ready
```

Observed result after fix: The same patched Gateway accepted a real Gateway `health` RPC after startup and reported healthy event loop state:

```json
{
  "ok": true,
  "durationMs": 234,
  "eventLoop": {
    "degraded": false,
    "reasons": [],
    "delayP99Ms": 22.9,
    "delayMaxMs": 117.6
  },
  "plugins": {
    "loaded": [
      "acpx",
      "bonjour",
      "browser",
      "canvas",
      "device-pair",
      "file-transfer",
      "memory-core",
      "phone-control",
      "talk-voice"
    ],
    "errors": []
  }
}
```

What was not tested: A packaged browser WebChat restart E2E was not run from this branch. The runtime proof above uses the foreground source-checkout Gateway and a real Gateway RPC; the patch intentionally does not perform a live model call during startup.
