### PR TITLE
fix(control-ui): bump client protocol to v5 to match server

### DIFF
--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -212,8 +212,8 @@ export type GatewayConnectClientInfo = {
 };
 
 export type GatewayConnectParams = {
-  minProtocol: 4;
-  maxProtocol: 4;
+  minProtocol: 5;
+  maxProtocol: 5;
   client: GatewayConnectClientInfo;
   role: string;
   scopes: string[];
@@ -574,8 +574,8 @@ export class GatewayBrowserClient {
 
   private buildConnectParams(plan: ConnectPlan): GatewayConnectParams {
     return {
-      minProtocol: 4,
-      maxProtocol: 4,
+      minProtocol: 5,
+      maxProtocol: 5,
       client: plan.client,
       role: plan.role,
       scopes: plan.scopes,


### PR DESCRIPTION
The server side was bumped to protocol v5 in 07f05e972e ("refactor: move
inbound event classification into core"), but ui/src/ui/gateway.ts still
hard-codes v4 in both the type and the runtime payload. So any source-built
main fails its first WS handshake with `code=1002 protocol mismatch` and
the dashboard is stuck on "无法连接". npm releases are fine since they ship
the UI and gateway together; this only bites people building from source.

This just flips those four 4s to 5s. After: `pnpm build && pnpm ui:build`
from main, gateway run, open the dashboard URL → handshake completes,
agents/models/sessions all load.

Probably worth a follow-up to share a single PROTOCOL_VERSION constant
across server and UI so this can't drift again, but kept this PR to the
one-line unblock.