### PR TITLE
Fix silent success for non-deliverable Bedrock Telegram turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,7 @@ Docs: https://docs.openclaw.ai
 - Providers/xAI: continue polling video generations while xAI reports in-flight jobs as `pending`, so Grok video requests no longer fail before the final `done` response. (#82610) Thanks @Manzojunior.
 - Logs: redact raw Basic auth and named security headers from `logs.tail` output before returning lines to read-scoped clients. Fixes #66832. Thanks @Magicray1217.
 - CLI/gateway: emit structured JSON for gateway transport close/timeout failures when `--json` is requested by health, gateway health, and devices list commands. Fixes #79108. Thanks @TurboTheTurtle.
+- Agents/Telegram: retry Bedrock non-visible terminal turns and mark non-deliverable attempts as trajectory errors instead of silent success. Fixes #82394. (#82905) Thanks @joshavant.
 - Telegram: normalize announce group targets via a new `resolveSessionTarget` channel hook so scheduled announcements resolve consistently against the same Telegram session conversation registry as inbound turns. Fixes #81229. Thanks @giodl73-repo.
 - QA/RTT: let `pnpm rtt` lease Convex-backed Telegram credentials while preserving RTT sample counts, sample timeouts, and result stats on the RTT harness path.
 - Discord: bind delayed gateway `identify` retries to the originating socket generation so retries triggered after a reconnect do not identify against a fresh socket. Fixes #82225. Thanks @giodl73-repo.

--- a/extensions/telegram/src/message-cache.ts
+++ b/extensions/telegram/src/message-cache.ts
@@ -70,6 +70,8 @@ type TelegramCachedMessageObservation = {
   mode: TelegramMessageObservationMode;
 };
 
+type TelegramEmbeddedReplyMessage = NonNullable<Message["reply_to_message"]>;
+
 const DEFAULT_MAX_MESSAGES = 5000;
 const COMPACT_THRESHOLD_RATIO = 2;
 const persistedMessageCacheBuckets = new Map<string, TelegramMessageCacheBucket>();
@@ -344,24 +346,27 @@ function trimMessages(messages: Map<string, TelegramCachedMessageNode>, maxMessa
 function mergeTelegramSourceMessage(existing: Message, incoming: Message): Message {
   const existingReply = resolveEmbeddedReplyMessage(existing);
   const incomingReply = resolveEmbeddedReplyMessage(incoming);
-  const merged = { ...existing, ...incoming };
   if (existingReply?.message_id != null && incomingReply?.message_id === existingReply.message_id) {
-    return {
-      ...merged,
-      reply_to_message: mergeTelegramSourceMessage(existingReply, incomingReply),
-    };
+    return Object.assign({}, existing, incoming, {
+      reply_to_message: mergeTelegramSourceMessage(
+        existingReply,
+        incomingReply,
+      ) as TelegramEmbeddedReplyMessage,
+    }) as Message;
   }
-  return merged;
+  return Object.assign({}, existing, incoming);
 }
 
 function mergeAuthoritativeTelegramSourceMessage(existing: Message, incoming: Message): Message {
   const existingReply = resolveEmbeddedReplyMessage(existing);
   const incomingReply = resolveEmbeddedReplyMessage(incoming);
   if (existingReply?.message_id != null && incomingReply?.message_id === existingReply.message_id) {
-    return {
-      ...incoming,
-      reply_to_message: mergeTelegramSourceMessage(existingReply, incomingReply),
-    };
+    return Object.assign({}, incoming, {
+      reply_to_message: mergeTelegramSourceMessage(
+        existingReply,
+        incomingReply,
+      ) as TelegramEmbeddedReplyMessage,
+    }) as Message;
   }
   return incoming;
 }
@@ -376,9 +381,7 @@ function mergeCachedMessageNode(
     mode === "authoritative"
       ? mergeAuthoritativeTelegramSourceMessage(existing.sourceMessage, incoming.sourceMessage)
       : mergeTelegramSourceMessage(existing.sourceMessage, incoming.sourceMessage);
-  return normalizeRequiredMessageNode(sourceMessage, {
-    ...(Number.isFinite(threadId) ? { threadId } : {}),
-  });
+  return normalizeRequiredMessageNode(sourceMessage, Number.isFinite(threadId) ? { threadId } : {});
 }
 
 function upsertCachedMessageNode(params: {
@@ -559,7 +562,11 @@ export function createTelegramMessageCache(params?: {
       }
       let recordedEntry: TelegramCachedMessageNode | null = null;
       for (const { node, mode } of observations) {
-        const key = telegramMessageCacheKey({ accountId, chatId, messageId: node.messageId });
+        const { messageId } = node;
+        if (!messageId) {
+          continue;
+        }
+        const key = telegramMessageCacheKey({ accountId, chatId, messageId });
         const cachedNode = upsertCachedMessageNode({ messages, key, node, mode });
         if (node.messageId === currentObservation.node.messageId) {
           recordedEntry = cachedNode;

--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -1350,6 +1350,34 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     expect(retryInstruction).toBe(REASONING_ONLY_RETRY_INSTRUCTION);
   });
 
+  it("retries signed reasoning-only Bedrock Converse turns with a visible-answer continuation", () => {
+    const retryInstruction = resolveReasoningOnlyRetryInstruction({
+      provider: "amazon-bedrock",
+      modelId: "openai.gpt-oss-120b-1:0",
+      modelApi: "bedrock-converse-stream",
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "amazon-bedrock",
+          model: "openai.gpt-oss-120b-1:0",
+          content: [
+            {
+              type: "thinking",
+              thinking: "internal reasoning",
+              thinkingSignature: "bedrock-reasoning-signature",
+            },
+          ],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    });
+
+    expect(retryInstruction).toBe(REASONING_ONLY_RETRY_INSTRUCTION);
+  });
+
   it("does not apply planning-only or ack fast paths to Ollama runs", () => {
     const retryInstruction = resolvePlanningOnlyRetryInstruction({
       provider: "ollama",
@@ -1860,6 +1888,30 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
 
     expect(retryInstruction).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
     expect(DEFAULT_EMPTY_RESPONSE_RETRY_LIMIT).toBe(1);
+  });
+
+  it("retries generic empty Bedrock Converse turns without visible text", () => {
+    const retryInstruction = resolveEmptyResponseRetryInstruction({
+      provider: "amazon-bedrock",
+      modelId: "openai.gpt-oss-120b-1:0",
+      modelApi: "bedrock-converse-stream",
+      payloadCount: 0,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "amazon-bedrock",
+          model: "openai.gpt-oss-120b-1:0",
+          content: [{ type: "text", text: "" }],
+          usage: { input: 950, output: 103, totalTokens: 1053 },
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    });
+
+    expect(retryInstruction).toBe(EMPTY_RESPONSE_RETRY_INSTRUCTION);
   });
 
   it("treats clean empty assistant turns as silent only when the caller allows it", () => {

--- a/src/agents/pi-embedded-runner/run/attempt-trajectory-status.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt-trajectory-status.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import {
+  NON_DELIVERABLE_TERMINAL_TURN_REASON,
+  resolveAttemptTrajectoryTerminal,
+  resolveTerminalAssistantTexts,
+  type ResolveAttemptTrajectoryTerminalParams,
+} from "./attempt-trajectory-status.js";
+
+function baseParams(
+  overrides: Partial<ResolveAttemptTrajectoryTerminalParams> = {},
+): ResolveAttemptTrajectoryTerminalParams {
+  return {
+    aborted: false,
+    timedOut: false,
+    assistantTexts: [],
+    toolMetas: [],
+    didSendViaMessagingTool: false,
+    didSendDeterministicApprovalPrompt: false,
+    messagingToolSentTexts: [],
+    messagingToolSentMediaUrls: [],
+    messagingToolSentTargets: [],
+    successfulCronAdds: 0,
+    synthesizedPayloadCount: 0,
+    ...overrides,
+  };
+}
+
+describe("attempt trajectory status", () => {
+  it("marks a terminal turn without visible text, tools, or delivery as an error", () => {
+    expect(resolveAttemptTrajectoryTerminal(baseParams())).toEqual({
+      status: "error",
+      terminalError: NON_DELIVERABLE_TERMINAL_TURN_REASON,
+    });
+  });
+
+  it("keeps visible assistant text as success", () => {
+    expect(
+      resolveAttemptTrajectoryTerminal(baseParams({ assistantTexts: ["Visible answer."] })),
+    ).toEqual({ status: "success" });
+  });
+
+  it("keeps committed messaging tool delivery as success even without assistant text", () => {
+    expect(
+      resolveAttemptTrajectoryTerminal(
+        baseParams({
+          didSendViaMessagingTool: true,
+          messagingToolSentTargets: [{ channel: "telegram" }],
+        }),
+      ),
+    ).toEqual({ status: "success" });
+  });
+
+  it("does not treat an uncommitted messaging tool attempt as delivery", () => {
+    expect(
+      resolveAttemptTrajectoryTerminal(
+        baseParams({
+          didSendViaMessagingTool: true,
+          messagingToolSentTexts: ["   "],
+          messagingToolSentMediaUrls: ["   "],
+        }),
+      ),
+    ).toEqual({
+      status: "error",
+      terminalError: NON_DELIVERABLE_TERMINAL_TURN_REASON,
+    });
+  });
+
+  it("does not treat tool metadata alone as terminal progress", () => {
+    expect(
+      resolveAttemptTrajectoryTerminal(
+        baseParams({
+          toolMetas: [{ toolName: "read" }],
+        }),
+      ),
+    ).toEqual({
+      status: "error",
+      terminalError: NON_DELIVERABLE_TERMINAL_TURN_REASON,
+    });
+  });
+
+  it("keeps synthesized terminal payloads as success", () => {
+    expect(resolveAttemptTrajectoryTerminal(baseParams({ synthesizedPayloadCount: 1 }))).toEqual({
+      status: "success",
+    });
+  });
+
+  it("keeps heartbeat responses as success", () => {
+    expect(
+      resolveAttemptTrajectoryTerminal(
+        baseParams({
+          heartbeatToolResponse: { notify: false, summary: "ok" },
+        }),
+      ),
+    ).toEqual({
+      status: "success",
+    });
+  });
+
+  it("does not treat expected silent turns as non-deliverable failures", () => {
+    expect(resolveAttemptTrajectoryTerminal(baseParams({ silentExpected: true }))).toEqual({
+      status: "success",
+    });
+  });
+
+  it("does not treat eligible empty silent replies as non-deliverable failures", () => {
+    expect(
+      resolveAttemptTrajectoryTerminal(baseParams({ emptyAssistantReplyIsSilent: true })),
+    ).toEqual({
+      status: "success",
+    });
+  });
+
+  it("does not let the raw silent policy hide ineligible empty failures", () => {
+    expect(
+      resolveAttemptTrajectoryTerminal(baseParams({ emptyAssistantReplyIsSilent: false })),
+    ).toEqual({
+      status: "error",
+      terminalError: NON_DELIVERABLE_TERMINAL_TURN_REASON,
+    });
+  });
+
+  it("uses safe last-assistant fallback text for terminal delivery status", () => {
+    expect(
+      resolveTerminalAssistantTexts({
+        assistantTexts: [],
+        lastAssistantStopReason: "stop",
+        lastAssistantVisibleText: "Fallback answer.",
+      }),
+    ).toEqual(["Fallback answer."]);
+    expect(
+      resolveTerminalAssistantTexts({
+        assistantTexts: [],
+        lastAssistantStopReason: "error",
+        lastAssistantVisibleText: "Raw provider error",
+      }),
+    ).toEqual([]);
+  });
+
+  it("marks terminal tool-use attempts as non-deliverable without explicit delivery", () => {
+    expect(
+      resolveAttemptTrajectoryTerminal(
+        baseParams({
+          assistantTexts: ["I will update that file."],
+          toolMetas: [{ toolName: "write" }],
+          lastAssistantStopReason: "toolUse",
+        }),
+      ),
+    ).toEqual({
+      status: "error",
+      terminalError: NON_DELIVERABLE_TERMINAL_TURN_REASON,
+    });
+    expect(
+      resolveAttemptTrajectoryTerminal(
+        baseParams({
+          assistantTexts: ["I sent the reply."],
+          didSendViaMessagingTool: true,
+          messagingToolSentTexts: ["sent"],
+          lastAssistantStopReason: "toolUse",
+        }),
+      ),
+    ).toEqual({ status: "success" });
+  });
+
+  it("preserves prompt errors and interrupts", () => {
+    expect(
+      resolveAttemptTrajectoryTerminal(baseParams({ promptError: new Error("boom") })),
+    ).toEqual({ status: "error" });
+    expect(resolveAttemptTrajectoryTerminal(baseParams({ timedOut: true }))).toEqual({
+      status: "interrupted",
+    });
+  });
+});

--- a/src/agents/pi-embedded-runner/run/attempt-trajectory-status.ts
+++ b/src/agents/pi-embedded-runner/run/attempt-trajectory-status.ts
@@ -1,0 +1,109 @@
+export type AttemptTrajectoryTerminalStatus = "success" | "error" | "interrupted";
+
+export const NON_DELIVERABLE_TERMINAL_TURN_REASON = "non_deliverable_terminal_turn";
+
+export type AttemptTrajectoryTerminal = {
+  status: AttemptTrajectoryTerminalStatus;
+  terminalError?: typeof NON_DELIVERABLE_TERMINAL_TURN_REASON;
+};
+
+export type ResolveAttemptTrajectoryTerminalParams = {
+  promptError?: unknown;
+  aborted: boolean;
+  timedOut: boolean;
+  assistantTexts: string[];
+  toolMetas: Array<{ toolName: string; meta?: string }>;
+  didSendViaMessagingTool: boolean;
+  didSendDeterministicApprovalPrompt: boolean;
+  messagingToolSentTexts: string[];
+  messagingToolSentMediaUrls: string[];
+  messagingToolSentTargets: unknown[];
+  successfulCronAdds: number;
+  synthesizedPayloadCount: number;
+  heartbeatToolResponse?: unknown;
+  clientToolCalls?: Array<unknown>;
+  yieldDetected?: boolean;
+  lastToolError?: unknown;
+  silentExpected?: boolean;
+  emptyAssistantReplyIsSilent?: boolean;
+  lastAssistantStopReason?: string;
+};
+
+export function resolveTerminalAssistantTexts(params: {
+  assistantTexts: string[];
+  lastAssistantStopReason?: string;
+  lastAssistantVisibleText?: string;
+}): string[] {
+  if (hasNonEmptyAssistantText(params.assistantTexts)) {
+    return params.assistantTexts;
+  }
+  if (params.lastAssistantStopReason === "error" || params.lastAssistantStopReason === "aborted") {
+    return params.assistantTexts;
+  }
+  const fallbackText = params.lastAssistantVisibleText?.trim();
+  return fallbackText ? [fallbackText] : params.assistantTexts;
+}
+
+function hasNonEmptyAssistantText(texts: string[]): boolean {
+  return texts.some((text) => text.trim().length > 0);
+}
+
+function hasNonEmptyString(values: string[]): boolean {
+  return values.some((value) => value.trim().length > 0);
+}
+
+function hasCommittedMessagingDeliveryEvidence(
+  params: Pick<
+    ResolveAttemptTrajectoryTerminalParams,
+    "messagingToolSentTexts" | "messagingToolSentMediaUrls" | "messagingToolSentTargets"
+  >,
+): boolean {
+  return (
+    hasNonEmptyString(params.messagingToolSentTexts) ||
+    hasNonEmptyString(params.messagingToolSentMediaUrls) ||
+    params.messagingToolSentTargets.length > 0
+  );
+}
+
+export function resolveAttemptTrajectoryTerminal(
+  params: ResolveAttemptTrajectoryTerminalParams,
+): AttemptTrajectoryTerminal {
+  if (params.promptError) {
+    return { status: "error" };
+  }
+  if (params.aborted || params.timedOut) {
+    return { status: "interrupted" };
+  }
+
+  const hasExplicitTerminalDelivery =
+    params.silentExpected === true ||
+    params.emptyAssistantReplyIsSilent === true ||
+    params.didSendDeterministicApprovalPrompt ||
+    hasCommittedMessagingDeliveryEvidence(params) ||
+    params.synthesizedPayloadCount > 0 ||
+    params.heartbeatToolResponse !== undefined ||
+    (params.clientToolCalls?.length ?? 0) > 0 ||
+    params.yieldDetected === true ||
+    params.lastToolError !== undefined;
+
+  if (params.lastAssistantStopReason === "toolUse" && !hasExplicitTerminalDelivery) {
+    return {
+      status: "error",
+      terminalError: NON_DELIVERABLE_TERMINAL_TURN_REASON,
+    };
+  }
+
+  const hasDeliverableOrProgress =
+    hasExplicitTerminalDelivery ||
+    hasNonEmptyAssistantText(params.assistantTexts) ||
+    params.successfulCronAdds > 0;
+
+  if (hasDeliverableOrProgress) {
+    return { status: "success" };
+  }
+
+  return {
+    status: "error",
+    terminalError: NON_DELIVERABLE_TERMINAL_TURN_REASON,
+  };
+}

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
@@ -105,6 +105,7 @@ export function createSubscriptionMock(): SubscriptionMock {
     getMessagingToolSentTargets: () => [] as MessagingToolSend[],
     getHeartbeatToolResponse: () => undefined,
     getPendingToolMediaReply: () => null,
+    getVisibleBlockReplyCount: () => 0,
     getSuccessfulCronAdds: () => 0,
     getReplayState: () => ({
       replayInvalid: false,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -276,6 +276,10 @@ import {
   shouldCreateBundleLspRuntimeForAttempt,
   shouldCreateBundleMcpRuntimeForAttempt,
 } from "./attempt-tool-construction-plan.js";
+import {
+  resolveAttemptTrajectoryTerminal,
+  resolveTerminalAssistantTexts,
+} from "./attempt-trajectory-status.js";
 export { buildContextEnginePromptCacheInfo } from "./attempt.context-engine-helpers.js";
 import {
   rotateTranscriptAfterCompaction,
@@ -352,12 +356,17 @@ import {
   selectCompactionTimeoutSnapshot,
   shouldFlagCompactionTimeout,
 } from "./compaction-timeout.js";
+import { resolveFinalAssistantVisibleText } from "./helpers.js";
 import {
   installHistoryImagePruneContextTransform,
   pruneProcessedHistoryImages,
 } from "./history-image-prune.js";
 import { detectAndLoadPromptImages } from "./images.js";
-import { buildAttemptReplayMetadata } from "./incomplete-turn.js";
+import {
+  buildAttemptReplayMetadata,
+  resolveSilentToolResultReplyPayload,
+  shouldTreatEmptyAssistantReplyAsSilent,
+} from "./incomplete-turn.js";
 import { resolveLlmIdleTimeoutMs, streamWithIdleTimeout } from "./llm-idle-timeout.js";
 import { resolveMessageMergeStrategy } from "./message-merge-strategy.js";
 import {
@@ -756,6 +765,15 @@ function flushSessionManagerFile(sessionManager: ReturnType<typeof guardSessionM
 
 export function shouldRunLlmOutputHooksForAttempt(params: { promptErrorSource: string | null }) {
   return params.promptErrorSource !== "hook:before_agent_run";
+}
+
+function hasVisiblePendingToolMediaReply(
+  reply: { mediaUrls?: string[]; audioAsVoice?: boolean } | null | undefined,
+): boolean {
+  return Boolean(
+    reply &&
+    ((reply.mediaUrls ?? []).some((url) => url.trim().length > 0) || reply.audioAsVoice === true),
+  );
 }
 
 function isMidTurnPrecheckAssistantError(message: AgentMessage | undefined): boolean {
@@ -2921,6 +2939,7 @@ export async function runEmbeddedAttempt(
         getMessagingToolSentTargets,
         getHeartbeatToolResponse,
         getPendingToolMediaReply,
+        getVisibleBlockReplyCount,
         getSuccessfulCronAdds,
         getReplayState,
         didSendViaMessagingTool,
@@ -4258,6 +4277,91 @@ export async function runEmbeddedAttempt(
       const replayMetadata = replayMetadataFromState(
         observeReplayMetadata(getReplayState(), observedReplayMetadata),
       );
+      const completedClientToolCalls = clientToolCallSlots.flatMap((slot) =>
+        slot.completed && slot.params
+          ? [
+              {
+                name: slot.name,
+                params: slot.params,
+              },
+            ]
+          : [],
+      );
+      const completedClientToolCallsForAttempt =
+        completedClientToolCalls.length > 0 ? completedClientToolCalls : undefined;
+      const didSendDeterministicApprovalPromptNow = didSendDeterministicApprovalPrompt();
+      const lastToolError = getLastToolError?.();
+      const heartbeatToolResponse = getHeartbeatToolResponse();
+      const pendingToolMediaPayloadCount = hasVisiblePendingToolMediaReply(pendingToolMediaReply)
+        ? 1
+        : 0;
+      const visibleBlockReplyCount = getVisibleBlockReplyCount();
+      const silentToolResultReplyPayload = resolveSilentToolResultReplyPayload({
+        isCronTrigger: params.trigger === "cron",
+        payloadCount: pendingToolMediaPayloadCount,
+        aborted,
+        timedOut,
+        attempt: {
+          clientToolCalls: completedClientToolCallsForAttempt,
+          yieldDetected,
+          didSendDeterministicApprovalPrompt: didSendDeterministicApprovalPromptNow,
+          lastToolError,
+          messagesSnapshot,
+          toolMetas: toolMetasNormalized,
+        },
+      });
+      const synthesizedPayloadCount =
+        visibleBlockReplyCount +
+        pendingToolMediaPayloadCount +
+        (silentToolResultReplyPayload ? 1 : 0);
+      const emptyAssistantReplyIsSilent = shouldTreatEmptyAssistantReplyAsSilent({
+        allowEmptyAssistantReplyAsSilent: params.allowEmptyAssistantReplyAsSilent,
+        payloadCount: 0,
+        aborted,
+        timedOut,
+        attempt: {
+          assistantTexts,
+          clientToolCalls: completedClientToolCallsForAttempt,
+          currentAttemptAssistant,
+          yieldDetected,
+          didSendDeterministicApprovalPrompt: didSendDeterministicApprovalPromptNow,
+          didSendViaMessagingTool: didSendViaMessagingTool(),
+          messagingToolSentTexts: getMessagingToolSentTexts(),
+          messagingToolSentMediaUrls: getMessagingToolSentMediaUrls(),
+          messagingToolSentTargets: getMessagingToolSentTargets(),
+          lastToolError,
+          lastAssistant,
+          replayMetadata,
+          promptErrorSource,
+          timedOutDuringCompaction,
+        },
+      });
+      const terminalAssistantTexts = resolveTerminalAssistantTexts({
+        assistantTexts,
+        lastAssistantStopReason: lastAssistant?.stopReason,
+        lastAssistantVisibleText: resolveFinalAssistantVisibleText(lastAssistant),
+      });
+      const attemptTrajectoryTerminal = resolveAttemptTrajectoryTerminal({
+        promptError,
+        aborted,
+        timedOut,
+        assistantTexts: terminalAssistantTexts,
+        toolMetas: toolMetasNormalized,
+        didSendViaMessagingTool: didSendViaMessagingTool(),
+        didSendDeterministicApprovalPrompt: didSendDeterministicApprovalPromptNow,
+        messagingToolSentTexts: getMessagingToolSentTexts(),
+        messagingToolSentMediaUrls: getMessagingToolSentMediaUrls(),
+        messagingToolSentTargets: getMessagingToolSentTargets(),
+        successfulCronAdds: getSuccessfulCronAdds(),
+        synthesizedPayloadCount,
+        heartbeatToolResponse,
+        clientToolCalls: completedClientToolCalls,
+        yieldDetected,
+        lastToolError,
+        silentExpected: params.silentExpected,
+        emptyAssistantReplyIsSilent,
+        lastAssistantStopReason: lastAssistant?.stopReason,
+      });
       trajectoryRecorder?.recordEvent("model.completed", {
         aborted,
         externalAbort,
@@ -4267,6 +4371,7 @@ export async function runEmbeddedAttempt(
         timedOutDuringToolExecution,
         promptError: promptError ? formatErrorMessage(promptError) : undefined,
         promptErrorSource,
+        terminalError: attemptTrajectoryTerminal.terminalError,
         usage: attemptUsage,
         promptCache,
         compactionCount: getCompactionCount(),
@@ -4277,7 +4382,7 @@ export async function runEmbeddedAttempt(
       trajectoryRecorder?.recordEvent(
         "trace.artifacts",
         buildTrajectoryArtifacts({
-          status: promptError ? "error" : aborted || timedOut ? "interrupted" : "success",
+          status: attemptTrajectoryTerminal.status,
           aborted,
           externalAbort,
           timedOut,
@@ -4286,6 +4391,7 @@ export async function runEmbeddedAttempt(
           timedOutDuringToolExecution,
           promptError: promptError ? formatErrorMessage(promptError) : undefined,
           promptErrorSource,
+          terminalError: attemptTrajectoryTerminal.terminalError,
           usage: attemptUsage,
           promptCache,
           compactionCount: getCompactionCount(),
@@ -4298,11 +4404,11 @@ export async function runEmbeddedAttempt(
           messagingToolSentTexts: getMessagingToolSentTexts(),
           messagingToolSentMediaUrls: getMessagingToolSentMediaUrls(),
           messagingToolSentTargets: getMessagingToolSentTargets(),
-          lastToolError: getLastToolError?.(),
+          lastToolError,
         }),
       );
       trajectoryRecorder?.recordEvent("session.ended", {
-        status: promptError ? "error" : aborted || timedOut ? "interrupted" : "success",
+        status: attemptTrajectoryTerminal.status,
         aborted,
         externalAbort,
         timedOut,
@@ -4310,19 +4416,9 @@ export async function runEmbeddedAttempt(
         timedOutDuringCompaction,
         timedOutDuringToolExecution,
         promptError: promptError ? formatErrorMessage(promptError) : undefined,
+        terminalError: attemptTrajectoryTerminal.terminalError,
       });
       trajectoryEndRecorded = true;
-
-      const completedClientToolCalls = clientToolCallSlots.flatMap((slot) =>
-        slot.completed && slot.params
-          ? [
-              {
-                name: slot.name,
-                params: slot.params,
-              },
-            ]
-          : [],
-      );
 
       return {
         replayMetadata,
@@ -4349,13 +4445,13 @@ export async function runEmbeddedAttempt(
         toolMetas: toolMetasNormalized,
         lastAssistant,
         currentAttemptAssistant,
-        lastToolError: getLastToolError?.(),
+        lastToolError,
         didSendViaMessagingTool: didSendViaMessagingTool(),
-        didSendDeterministicApprovalPrompt: didSendDeterministicApprovalPrompt(),
+        didSendDeterministicApprovalPrompt: didSendDeterministicApprovalPromptNow,
         messagingToolSentTexts: getMessagingToolSentTexts(),
         messagingToolSentMediaUrls: getMessagingToolSentMediaUrls(),
         messagingToolSentTargets: getMessagingToolSentTargets(),
-        heartbeatToolResponse: getHeartbeatToolResponse(),
+        heartbeatToolResponse,
         toolMediaUrls: pendingToolMediaReply?.mediaUrls,
         toolAudioAsVoice: pendingToolMediaReply?.audioAsVoice,
         toolTrustedLocalMedia: pendingToolMediaReply?.trustedLocalMedia,

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -621,7 +621,8 @@ function shouldApplyNonVisibleTurnRetryGuard(params: {
   }
   if (
     normalizeLowercaseStringOrEmpty(params.modelApi ?? "") === "openai-completions" ||
-    normalizeLowercaseStringOrEmpty(params.modelApi ?? "") === "anthropic-messages"
+    normalizeLowercaseStringOrEmpty(params.modelApi ?? "") === "anthropic-messages" ||
+    normalizeLowercaseStringOrEmpty(params.modelApi ?? "") === "bedrock-converse-stream"
   ) {
     return true;
   }

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -105,6 +105,7 @@ export type EmbeddedPiSubscribeState = {
   pendingToolMediaUrls: string[];
   pendingToolAudioAsVoice: boolean;
   pendingToolTrustedLocalMedia: boolean;
+  visibleBlockReplyCount: number;
   pendingAssistantReplyDirectives?: Pick<
     BlockReplyPayload,
     "mediaUrls" | "audioAsVoice" | "replyToId" | "replyToTag" | "replyToCurrent"

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
@@ -717,6 +717,39 @@ describe("subscribeEmbeddedPiSession", () => {
     });
   });
 
+  it("counts orphaned tool media emitted through block replies", async () => {
+    const onBlockReply = vi.fn();
+    const { emit, subscription } = createSubscribedSessionHarness({
+      runId: "run",
+      builtinToolNames: new Set(["tts"]),
+      onBlockReply,
+    });
+
+    emit({
+      type: "tool_execution_end",
+      toolName: "tts",
+      toolCallId: "tc-1",
+      isError: false,
+      result: {
+        details: {
+          media: {
+            mediaUrl: "/tmp/reply.opus",
+            audioAsVoice: true,
+          },
+        },
+      },
+    });
+    emit({ type: "agent_end" });
+    await flushBlockReplyCallbacks();
+
+    expect(onBlockReply).toHaveBeenCalledWith({
+      mediaUrls: ["/tmp/reply.opus"],
+      audioAsVoice: true,
+    });
+    expect(subscription.getPendingToolMediaReply()).toBeNull();
+    expect(subscription.getVisibleBlockReplyCount()).toBe(1);
+  });
+
   it.each(THINKING_TAG_CASES)(
     "suppresses <%s> blocks across chunk boundaries",
     async ({ open, close }) => {

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -28,6 +28,7 @@ import { createEmbeddedPiSessionEventHandler } from "./pi-embedded-subscribe.han
 import {
   consumePendingAssistantReplyDirectivesIntoReply,
   consumePendingToolMediaIntoReply,
+  hasAssistantVisibleReply,
   readPendingToolMediaReply,
 } from "./pi-embedded-subscribe.handlers.messages.js";
 import {
@@ -186,6 +187,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     pendingToolMediaUrls: initialPendingToolMediaUrls,
     pendingToolAudioAsVoice: false,
     pendingToolTrustedLocalMedia: false,
+    visibleBlockReplyCount: 0,
     pendingAssistantReplyDirectives: undefined,
     deterministicApprovalPromptPending: false,
     deterministicApprovalPromptSent: false,
@@ -217,9 +219,9 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
   const emitBlockReplySafely = (
     payload: Parameters<NonNullable<SubscribeEmbeddedPiSessionParams["onBlockReply"]>>[0],
     options?: { assistantMessageIndex?: number },
-  ) => {
+  ): boolean => {
     if (!params.onBlockReply) {
-      return;
+      return false;
     }
     try {
       const taggedPayload =
@@ -230,7 +232,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
           : payload;
       const maybeTask = params.onBlockReply(taggedPayload);
       if (!isPromiseLike<void>(maybeTask)) {
-        return;
+        return true;
       }
       const task = Promise.resolve(maybeTask).catch((err) => {
         log.warn(`block reply callback failed: ${String(err)}`);
@@ -239,8 +241,10 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       void task.finally(() => {
         pendingBlockReplyTasks.delete(task);
       });
+      return true;
     } catch (err) {
       log.warn(`block reply callback failed: ${String(err)}`);
+      return false;
     }
   };
   const emitBlockReply = (
@@ -252,7 +256,10 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       options?.consumePendingToolMedia === false
         ? withAssistantDirectives
         : consumePendingToolMediaIntoReply(state, withAssistantDirectives);
-    emitBlockReplySafely(withToolMedia, options);
+    const emitted = emitBlockReplySafely(withToolMedia, options);
+    if (emitted && !withToolMedia.isReasoning && hasAssistantVisibleReply(withToolMedia)) {
+      state.visibleBlockReplyCount += 1;
+    }
   };
 
   const resetAssistantMessageState = (nextAssistantTextBaseline: number) => {
@@ -925,7 +932,8 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
         messagingToolSentMediaUrls,
         messagingToolSentTargets,
       }) ||
-      state.successfulCronAdds > 0;
+      state.successfulCronAdds > 0 ||
+      state.visibleBlockReplyCount > 0;
     assistantTexts.length = 0;
     toolMetas.length = 0;
     toolMetaById.clear();
@@ -941,9 +949,12 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     pendingMessagingTexts.clear();
     pendingMessagingTargets.clear();
     state.successfulCronAdds = 0;
+    state.heartbeatToolResponse = undefined;
     state.pendingMessagingMediaUrls.clear();
     state.pendingToolMediaUrls = [];
     state.pendingToolAudioAsVoice = false;
+    state.pendingToolTrustedLocalMedia = false;
+    state.visibleBlockReplyCount = 0;
     state.pendingAssistantReplyDirectives = undefined;
     state.deterministicApprovalPromptPending = false;
     state.deterministicApprovalPromptSent = false;
@@ -1101,6 +1112,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     getHeartbeatToolResponse: () =>
       state.heartbeatToolResponse ? { ...state.heartbeatToolResponse } : undefined,
     getPendingToolMediaReply: () => readPendingToolMediaReply(state),
+    getVisibleBlockReplyCount: () => state.visibleBlockReplyCount,
     getSuccessfulCronAdds: () => state.successfulCronAdds,
     getReplayState: () => ({ ...state.replayState }),
     // Returns true if any messaging tool successfully sent a message.

--- a/src/trajectory/export.test.ts
+++ b/src/trajectory/export.test.ts
@@ -909,6 +909,7 @@ describe("exportTrajectoryBundle", () => {
         sessionId: "session-1",
         data: {
           finalStatus: "success",
+          terminalError: "non_deliverable_terminal_turn",
           assistantTexts: ["done"],
           finalPromptText: `final prompt from ${path.join(tmpDir, "prompt.txt")}`,
           itemLifecycle: {
@@ -992,6 +993,7 @@ describe("exportTrajectoryBundle", () => {
     const tools = fs.readFileSync(path.join(outputDir, "tools.json"), "utf8");
     expect(prompts).toContain("$WORKSPACE_DIR/AGENTS.md");
     expect(artifacts).toContain("$WORKSPACE_DIR/prompt.txt");
+    expect(artifacts).toContain("non_deliverable_terminal_turn");
     expect(systemPrompt).toContain("$WORKSPACE_DIR/instructions.md");
     expect(tools).toContain("$WORKSPACE_DIR/docs");
     expect(`${prompts}\n${artifacts}\n${systemPrompt}\n${tools}`).not.toContain(tmpDir);

--- a/src/trajectory/export.ts
+++ b/src/trajectory/export.ts
@@ -866,6 +866,10 @@ function buildArtifactsCapture(params: {
     promptError:
       runtimeArtifacts?.promptError ?? runtimeEnd?.promptError ?? runtimeCompletion?.promptError,
     promptErrorSource: runtimeArtifacts?.promptErrorSource ?? runtimeCompletion?.promptErrorSource,
+    terminalError:
+      runtimeArtifacts?.terminalError ??
+      runtimeEnd?.terminalError ??
+      runtimeCompletion?.terminalError,
     usage: runtimeArtifacts?.usage ?? runtimeCompletion?.usage,
     promptCache: runtimeArtifacts?.promptCache ?? runtimeCompletion?.promptCache,
     compactionCount: runtimeArtifacts?.compactionCount ?? runtimeCompletion?.compactionCount,

--- a/src/trajectory/metadata.ts
+++ b/src/trajectory/metadata.ts
@@ -49,6 +49,7 @@ type BuildTrajectoryArtifactsParams = {
   timedOutDuringToolExecution: boolean;
   promptError?: string;
   promptErrorSource?: string | null;
+  terminalError?: string;
   usage?: unknown;
   promptCache?: unknown;
   compactionCount: number;
@@ -307,6 +308,7 @@ export function buildTrajectoryArtifacts(
     timedOutDuringToolExecution: params.timedOutDuringToolExecution,
     promptError: params.promptError,
     promptErrorSource: params.promptErrorSource,
+    terminalError: params.terminalError,
     usage: params.usage,
     promptCache: params.promptCache,
     compactionCount: params.compactionCount,


### PR DESCRIPTION
Summary
- Treat terminal attempts with no deliverable/progress evidence as trajectory errors instead of silent success.
- Extend Bedrock empty/reasoning-only retry eligibility for the reported model path.
- Preserve legitimate non-text delivery evidence, including committed messaging sends, media-only replies, heartbeat responses, cron progress, yields, client tool calls, and tool errors.
- Carry the latest-main Telegram message-cache type/lint repair needed to keep CI green after rebasing over #82863.

Verification
- `.agents/skills/codex-review/scripts/codex-review --mode local` (clean; focused Vitest coverage passed: 7 files, 309 tests)
- `node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/attempt-trajectory-status.test.ts src/agents/pi-embedded-runner/run.incomplete-turn.test.ts src/trajectory/export.test.ts src/trajectory/metadata.test.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts` (passed: 8 files, 312 tests)
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-pr82905.tsbuildinfo`
- `node scripts/run-bundled-extension-oxlint.mjs`
- `node scripts/check-extension-package-tsc-boundary.mjs --mode=compile`
- AWS Crabbox `run_943fee6e6d01` / `cbx_9bbc8d8db38c`: original Telegram + Bedrock repro observed a Telegram reply after the patch
- AWS Crabbox `run_ca257471b04a` / `cbx_1081c2d5346a`: `pnpm check:changed` passed after Node 22/Corepack setup
- GitHub CI on `ba1b76ccd933a6f379e5d64d98fbef5b8f02c28b`: all checks green/skipped except `Real behavior proof`

Real behavior proof
Behavior addressed: A Bedrock reasoning/empty terminal turn for Telegram could complete with no Telegram reply while trajectory artifacts still reported success.
Real environment tested: AWS Crabbox direct provider `cbx_9bbc8d8db38c`, Telegram live bot group via Convex `telegram` credential, Bedrock model `amazon-bedrock/openai.gpt-oss-120b-1:0`.
Exact steps or command run after this patch: Installed dependencies, built the repo, started the QA live Telegram gateway, sent the original prompt from #82394, and waited for the SUT Telegram bot reply.
Evidence after fix: Crabbox run `run_943fee6e6d01`; sent Telegram message `8958`; observed SUT reply message `8959`.
Observed result after fix: `replyObserved: true`, `observedSutMessageCount: 1`, command exit `0`.
What was not tested: Full repository test suite; the changed gate, focused tests, and PR CI were run instead.

Fixes #82394
