### PR TITLE
fix(codex): gate CLI session resume behind plugin approval

### DIFF
--- a/extensions/codex/src/node-cli-sessions.test.ts
+++ b/extensions/codex/src/node-cli-sessions.test.ts
@@ -189,7 +189,10 @@ describe("codex cli node sessions", () => {
     }
     const invokeNode = vi.fn(async () => ({ ok: true as const, payload: { ok: true } }));
     const approvals = {
-      request: vi.fn(async () => ({ id: "approval-1", decision: "deny" as const })),
+      request: vi.fn(async (_request: Record<string, unknown>) => ({
+        id: "approval-1",
+        decision: "deny" as const,
+      })),
     };
 
     const result = await policy.handle({
@@ -220,8 +223,8 @@ describe("codex cli node sessions", () => {
         allowedDecisions: ["allow-once", "deny"],
       }),
     );
-    const [approvalRequest] = approvals.request.mock.calls[0] ?? [];
-    expect((approvalRequest as { timeoutMs?: unknown } | undefined)?.timeoutMs).toBeUndefined();
+    const approvalRequest = approvals.request.mock.calls[0]?.[0];
+    expect(approvalRequest?.timeoutMs).toBeUndefined();
   });
 
   it("does not treat allow-always as a valid Codex CLI resume approval", async () => {

--- a/extensions/codex/src/node-cli-sessions.test.ts
+++ b/extensions/codex/src/node-cli-sessions.test.ts
@@ -202,6 +202,7 @@ describe("codex cli node sessions", () => {
       config: {},
       approvals,
       invokeNode,
+      timeoutMs: 1_200_000,
     });
 
     expect(result).toEqual({
@@ -219,6 +220,8 @@ describe("codex cli node sessions", () => {
         allowedDecisions: ["allow-once", "deny"],
       }),
     );
+    const [approvalRequest] = approvals.request.mock.calls[0] ?? [];
+    expect((approvalRequest as { timeoutMs?: unknown } | undefined)?.timeoutMs).toBeUndefined();
   });
 
   it("does not treat allow-always as a valid Codex CLI resume approval", async () => {

--- a/extensions/codex/src/node-cli-sessions.test.ts
+++ b/extensions/codex/src/node-cli-sessions.test.ts
@@ -6,7 +6,9 @@ import type { PluginRuntime } from "openclaw/plugin-sdk/plugin-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   CODEX_CLI_SESSIONS_LIST_COMMAND,
+  CODEX_CLI_SESSION_RESUME_COMMAND,
   createCodexCliSessionNodeHostCommands,
+  createCodexCliSessionNodeInvokePolicies,
   listCodexCliSessionsOnNode,
   resolveCodexCliResumeSpawnInvocation,
 } from "./node-cli-sessions.js";
@@ -176,5 +178,102 @@ describe("codex cli node sessions", () => {
         requestedNode: "node-1",
       }),
     ).rejects.toThrow("Codex CLI node command returned malformed payloadJSON.");
+  });
+
+  it("requires plugin approval before resuming a local Codex CLI session", async () => {
+    const policy = createCodexCliSessionNodeInvokePolicies().find((entry) =>
+      entry.commands.includes(CODEX_CLI_SESSION_RESUME_COMMAND),
+    );
+    if (!policy) {
+      throw new Error("expected Codex CLI resume node invoke policy");
+    }
+    const invokeNode = vi.fn(async () => ({ ok: true as const, payload: { ok: true } }));
+    const approvals = {
+      request: vi.fn(async () => ({ id: "approval-1", decision: "deny" as const })),
+    };
+
+    const result = await policy.handle({
+      nodeId: "node-1",
+      command: CODEX_CLI_SESSION_RESUME_COMMAND,
+      params: {
+        sessionId: "019e2007-1f7e-7eb1-a42b-8c01f4b9b5cd",
+        prompt: "continue",
+      },
+      config: {},
+      approvals,
+      invokeNode,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      code: "PLUGIN_APPROVAL_REQUIRED",
+      message: "Codex CLI session resume requires plugin approval.",
+      details: { approvalId: "approval-1", decision: "deny" },
+    });
+    expect(invokeNode).not.toHaveBeenCalled();
+    expect(approvals.request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Resume Codex CLI session",
+        severity: "critical",
+        toolName: CODEX_CLI_SESSION_RESUME_COMMAND,
+      }),
+    );
+  });
+
+  it("fails closed when Codex CLI resume approval delivery is unavailable", async () => {
+    const policy = createCodexCliSessionNodeInvokePolicies().find((entry) =>
+      entry.commands.includes(CODEX_CLI_SESSION_RESUME_COMMAND),
+    );
+    if (!policy) {
+      throw new Error("expected Codex CLI resume node invoke policy");
+    }
+    const invokeNode = vi.fn(async () => ({ ok: true as const, payload: { ok: true } }));
+
+    const result = await policy.handle({
+      nodeId: "node-1",
+      command: CODEX_CLI_SESSION_RESUME_COMMAND,
+      params: {
+        sessionId: "019e2007-1f7e-7eb1-a42b-8c01f4b9b5cd",
+        prompt: "continue",
+      },
+      config: {},
+      invokeNode,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      code: "PLUGIN_APPROVAL_REQUIRED",
+      message: "Codex CLI session resume requires plugin approval.",
+      details: { approvalId: null, decision: null },
+    });
+    expect(invokeNode).not.toHaveBeenCalled();
+  });
+
+  it("forwards Codex CLI resume only after plugin approval", async () => {
+    const policy = createCodexCliSessionNodeInvokePolicies().find((entry) =>
+      entry.commands.includes(CODEX_CLI_SESSION_RESUME_COMMAND),
+    );
+    if (!policy) {
+      throw new Error("expected Codex CLI resume node invoke policy");
+    }
+    const invokeNode = vi.fn(async () => ({ ok: true as const, payload: { ok: true } }));
+    const approvals = {
+      request: vi.fn(async () => ({ id: "approval-1", decision: "allow-once" as const })),
+    };
+
+    const result = await policy.handle({
+      nodeId: "node-1",
+      command: CODEX_CLI_SESSION_RESUME_COMMAND,
+      params: {
+        sessionId: "019e2007-1f7e-7eb1-a42b-8c01f4b9b5cd",
+        prompt: "continue",
+      },
+      config: {},
+      approvals,
+      invokeNode,
+    });
+
+    expect(result).toEqual({ ok: true, payload: { ok: true } });
+    expect(invokeNode).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/codex/src/node-cli-sessions.test.ts
+++ b/extensions/codex/src/node-cli-sessions.test.ts
@@ -216,8 +216,42 @@ describe("codex cli node sessions", () => {
         title: "Resume Codex CLI session",
         severity: "critical",
         toolName: CODEX_CLI_SESSION_RESUME_COMMAND,
+        allowedDecisions: ["allow-once", "deny"],
       }),
     );
+  });
+
+  it("does not treat allow-always as a valid Codex CLI resume approval", async () => {
+    const policy = createCodexCliSessionNodeInvokePolicies().find((entry) =>
+      entry.commands.includes(CODEX_CLI_SESSION_RESUME_COMMAND),
+    );
+    if (!policy) {
+      throw new Error("expected Codex CLI resume node invoke policy");
+    }
+    const invokeNode = vi.fn(async () => ({ ok: true as const, payload: { ok: true } }));
+    const approvals = {
+      request: vi.fn(async () => ({ id: "approval-1", decision: "allow-always" as const })),
+    };
+
+    const result = await policy.handle({
+      nodeId: "node-1",
+      command: CODEX_CLI_SESSION_RESUME_COMMAND,
+      params: {
+        sessionId: "019e2007-1f7e-7eb1-a42b-8c01f4b9b5cd",
+        prompt: "continue",
+      },
+      config: {},
+      approvals,
+      invokeNode,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      code: "PLUGIN_APPROVAL_REQUIRED",
+      message: "Codex CLI session resume requires plugin approval.",
+      details: { approvalId: "approval-1", decision: "allow-always" },
+    });
+    expect(invokeNode).not.toHaveBeenCalled();
   });
 
   it("fails closed when Codex CLI resume approval delivery is unavailable", async () => {

--- a/extensions/codex/src/node-cli-sessions.ts
+++ b/extensions/codex/src/node-cli-sessions.ts
@@ -103,10 +103,6 @@ export function createCodexCliSessionNodeInvokePolicies(): OpenClawPluginNodeInv
           allowedDecisions: ["allow-once", "deny"],
           agentId: typeof params.agentId === "string" ? params.agentId : undefined,
           sessionKey: typeof params.sessionKey === "string" ? params.sessionKey : undefined,
-          timeoutMs:
-            typeof ctx.timeoutMs === "number" && Number.isFinite(ctx.timeoutMs)
-              ? ctx.timeoutMs
-              : undefined,
         });
         if (approval?.decision !== "allow-once") {
           return {

--- a/extensions/codex/src/node-cli-sessions.ts
+++ b/extensions/codex/src/node-cli-sessions.ts
@@ -90,7 +90,36 @@ export function createCodexCliSessionNodeInvokePolicies(): OpenClawPluginNodeInv
     {
       commands: [CODEX_CLI_SESSION_RESUME_COMMAND],
       dangerous: true,
-      handle: (ctx) => ctx.invokeNode(),
+      handle: async (ctx) => {
+        const params = isRecord(ctx.params) ? ctx.params : {};
+        const sessionId = typeof params.sessionId === "string" ? params.sessionId.trim() : "";
+        const approval = await ctx.approvals?.request({
+          title: "Resume Codex CLI session",
+          description: sessionId
+            ? `Run a new prompt in local Codex CLI session ${sessionId}.`
+            : "Run a new prompt in a local Codex CLI session.",
+          severity: "critical",
+          toolName: CODEX_CLI_SESSION_RESUME_COMMAND,
+          agentId: typeof params.agentId === "string" ? params.agentId : undefined,
+          sessionKey: typeof params.sessionKey === "string" ? params.sessionKey : undefined,
+          timeoutMs:
+            typeof ctx.timeoutMs === "number" && Number.isFinite(ctx.timeoutMs)
+              ? ctx.timeoutMs
+              : undefined,
+        });
+        if (approval?.decision !== "allow-once" && approval?.decision !== "allow-always") {
+          return {
+            ok: false,
+            code: "PLUGIN_APPROVAL_REQUIRED",
+            message: "Codex CLI session resume requires plugin approval.",
+            details: {
+              approvalId: approval?.id ?? null,
+              decision: approval?.decision ?? null,
+            },
+          };
+        }
+        return await ctx.invokeNode();
+      },
     },
   ];
 }

--- a/extensions/codex/src/node-cli-sessions.ts
+++ b/extensions/codex/src/node-cli-sessions.ts
@@ -100,6 +100,7 @@ export function createCodexCliSessionNodeInvokePolicies(): OpenClawPluginNodeInv
             : "Run a new prompt in a local Codex CLI session.",
           severity: "critical",
           toolName: CODEX_CLI_SESSION_RESUME_COMMAND,
+          allowedDecisions: ["allow-once", "deny"],
           agentId: typeof params.agentId === "string" ? params.agentId : undefined,
           sessionKey: typeof params.sessionKey === "string" ? params.sessionKey : undefined,
           timeoutMs:
@@ -107,7 +108,7 @@ export function createCodexCliSessionNodeInvokePolicies(): OpenClawPluginNodeInv
               ? ctx.timeoutMs
               : undefined,
         });
-        if (approval?.decision !== "allow-once" && approval?.decision !== "allow-always") {
+        if (approval?.decision !== "allow-once") {
           return {
             ok: false,
             code: "PLUGIN_APPROVAL_REQUIRED",

--- a/src/gateway/node-invoke-plugin-policy.test.ts
+++ b/src/gateway/node-invoke-plugin-policy.test.ts
@@ -246,7 +246,78 @@ describe("applyPluginNodeInvokePolicy", () => {
     expect(context.broadcast).not.toHaveBeenCalled();
     expect(context.broadcastToConnIds).toHaveBeenCalledWith(
       "plugin.approval.requested",
-      expect.objectContaining({ id: record?.id }),
+      expect.objectContaining({
+        id: record?.id,
+        request: expect.objectContaining({ allowedDecisions: ["allow-once", "deny"] }),
+      }),
+      visibleConnIds,
+      { dropIfSlow: true },
+    );
+
+    expect(manager.resolve(record.id, "allow-once")).toBe(true);
+    await expect(resultPromise).resolves.toStrictEqual({
+      ok: true,
+      payload: { id: record?.id, decision: "allow-once" },
+    });
+  });
+
+  it("normalizes plugin approval decision choices before broadcasting", async () => {
+    const manager = new ExecApprovalManager<PluginApprovalRequestPayload>();
+    const visibleConnIds = new Set(["conn-owner-approval"]);
+    registryState.current = {
+      nodeHostCommands: [
+        {
+          pluginId: "demo",
+          command: {
+            command: "demo.read",
+            dangerous: true,
+            handle: async () => "{}",
+          },
+          source: "test",
+        },
+      ],
+      nodeInvokePolicies: [
+        {
+          pluginId: "demo",
+          policy: {
+            commands: ["demo.read"],
+            handle: async (ctx: OpenClawPluginNodeInvokePolicyContext) => {
+              const approval = await ctx.approvals?.request({
+                title: "Sensitive action",
+                description: "Needs approval",
+                allowedDecisions: ["allow-once", "allow-once", "deny"],
+              });
+              return { ok: true, payload: approval ?? null };
+            },
+          },
+          pluginConfig: { enabled: true },
+          source: "test",
+        },
+      ],
+    } as unknown as PluginRegistry;
+    const { context } = createContext({
+      pluginApprovalManager: manager,
+      getApprovalClientConnIds: () => visibleConnIds,
+    });
+    const resultPromise = applyPluginNodeInvokePolicy({
+      context,
+      client: createOperatorClient(),
+      nodeSession: createNodeSession(),
+      command: "demo.read",
+      params: { path: "/tmp/x" },
+    });
+
+    await vi.waitFor(() => {
+      expect(manager.listPendingRecords()).toHaveLength(1);
+    });
+    const [record] = manager.listPendingRecords();
+    expect(record?.request.allowedDecisions).toEqual(["allow-once", "deny"]);
+    expect(context.broadcastToConnIds).toHaveBeenCalledWith(
+      "plugin.approval.requested",
+      expect.objectContaining({
+        id: record?.id,
+        request: expect.objectContaining({ allowedDecisions: ["allow-once", "deny"] }),
+      }),
       visibleConnIds,
       { dropIfSlow: true },
     );

--- a/src/gateway/node-invoke-plugin-policy.test.ts
+++ b/src/gateway/node-invoke-plugin-policy.test.ts
@@ -213,6 +213,7 @@ describe("applyPluginNodeInvokePolicy", () => {
               const approval = await ctx.approvals?.request({
                 title: "Sensitive action",
                 description: "Needs approval",
+                allowedDecisions: ["allow-once", "deny"],
               });
               return { ok: true, payload: approval ?? null };
             },
@@ -241,6 +242,7 @@ describe("applyPluginNodeInvokePolicy", () => {
     expect(record?.requestedByConnId).toBe("conn-requester");
     expect(record?.requestedByDeviceId).toBe("device-owner");
     expect(record?.requestedByClientId).toBe("client-owner");
+    expect(record?.request.allowedDecisions).toEqual(["allow-once", "deny"]);
     expect(context.broadcast).not.toHaveBeenCalled();
     expect(context.broadcastToConnIds).toHaveBeenCalledWith(
       "plugin.approval.requested",

--- a/src/gateway/node-invoke-plugin-policy.ts
+++ b/src/gateway/node-invoke-plugin-policy.ts
@@ -65,6 +65,9 @@ function createApprovalRuntime(params: {
         severity: input.severity ?? "warning",
         toolName: normalizeOptionalString(input.toolName) ?? null,
         toolCallId: normalizeOptionalString(input.toolCallId) ?? null,
+        ...(Array.isArray(input.allowedDecisions)
+          ? { allowedDecisions: input.allowedDecisions }
+          : {}),
         agentId: normalizeOptionalString(input.agentId) ?? null,
         sessionKey: normalizeOptionalString(input.sessionKey) ?? null,
       };

--- a/src/gateway/node-invoke-plugin-policy.ts
+++ b/src/gateway/node-invoke-plugin-policy.ts
@@ -1,6 +1,9 @@
 import { randomUUID } from "node:crypto";
 import type { PluginApprovalRequestPayload } from "../infra/plugin-approvals.js";
-import { DEFAULT_PLUGIN_APPROVAL_TIMEOUT_MS } from "../infra/plugin-approvals.js";
+import {
+  DEFAULT_PLUGIN_APPROVAL_TIMEOUT_MS,
+  resolvePluginApprovalRequestAllowedDecisions,
+} from "../infra/plugin-approvals.js";
 import { getActiveRuntimePluginRegistry } from "../plugins/active-runtime-registry.js";
 import type { PluginRegistry } from "../plugins/registry-types.js";
 import type {
@@ -58,6 +61,9 @@ function createApprovalRuntime(params: {
         typeof input.timeoutMs === "number" && Number.isFinite(input.timeoutMs)
           ? input.timeoutMs
           : DEFAULT_PLUGIN_APPROVAL_TIMEOUT_MS;
+      const allowedDecisions = Array.isArray(input.allowedDecisions)
+        ? resolvePluginApprovalRequestAllowedDecisions({ allowedDecisions: input.allowedDecisions })
+        : undefined;
       const request: PluginApprovalRequestPayload = {
         pluginId: params.pluginId,
         title: input.title.slice(0, 80),
@@ -65,9 +71,7 @@ function createApprovalRuntime(params: {
         severity: input.severity ?? "warning",
         toolName: normalizeOptionalString(input.toolName) ?? null,
         toolCallId: normalizeOptionalString(input.toolCallId) ?? null,
-        ...(Array.isArray(input.allowedDecisions)
-          ? { allowedDecisions: input.allowedDecisions }
-          : {}),
+        ...(allowedDecisions ? { allowedDecisions } : {}),
         agentId: normalizeOptionalString(input.agentId) ?? null,
         sessionKey: normalizeOptionalString(input.sessionKey) ?? null,
       };

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -2167,6 +2167,7 @@ export type OpenClawPluginNodeInvokePolicyApprovalRuntime = {
     severity?: "info" | "warning" | "critical";
     toolName?: string;
     toolCallId?: string;
+    allowedDecisions?: readonly OpenClawPluginNodeInvokeApprovalDecision[];
     agentId?: string;
     sessionKey?: string;
     timeoutMs?: number;

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -1273,6 +1273,7 @@ describe("connectGateway", () => {
           pluginId: "sage",
           agentId: "agent-1",
           sessionKey: "main",
+          allowedDecisions: ["allow-once", "deny"],
         },
       },
     });
@@ -1280,6 +1281,7 @@ describe("connectGateway", () => {
     expect(host.execApprovalQueue).toHaveLength(1);
     expect(host.execApprovalQueue[0]?.id).toBe("plugin-approval-1");
     expect((host.execApprovalQueue[0] as { kind: string }).kind).toBe("plugin");
+    expect(host.execApprovalQueue[0]?.request.allowedDecisions).toEqual(["allow-once", "deny"]);
   });
 
   it("routes plugin.approval.resolved to remove from execApprovalQueue", () => {

--- a/ui/src/ui/controllers/exec-approval.test.ts
+++ b/ui/src/ui/controllers/exec-approval.test.ts
@@ -28,6 +28,7 @@ describe("parsePluginApprovalRequested", () => {
       pluginId: "sage",
       agentId: "agent-1",
       sessionKey: "sess-1",
+      allowedDecisions: ["allow-once", "deny", "allow-once", "not-a-decision"],
     },
   };
 
@@ -41,6 +42,7 @@ describe("parsePluginApprovalRequested", () => {
     expect(result?.request.command).toBe("Dangerous command detected");
     expect(result?.request.agentId).toBe("agent-1");
     expect(result?.request.sessionKey).toBe("sess-1");
+    expect(result?.request.allowedDecisions).toEqual(["allow-once", "deny"]);
     expect(result?.createdAtMs).toBe(1000);
     expect(result?.expiresAtMs).toBe(120_000);
   });

--- a/ui/src/ui/controllers/exec-approval.ts
+++ b/ui/src/ui/controllers/exec-approval.ts
@@ -1,5 +1,7 @@
 import { normalizeOptionalString } from "../string-coerce.ts";
 
+export type ExecApprovalDecision = "allow-once" | "allow-always" | "deny";
+
 export type ExecApprovalRequestPayload = {
   command: string;
   cwd?: string | null;
@@ -9,6 +11,7 @@ export type ExecApprovalRequestPayload = {
   agentId?: string | null;
   resolvedPath?: string | null;
   sessionKey?: string | null;
+  allowedDecisions?: readonly ExecApprovalDecision[];
   commandSpans?: readonly {
     startIndex: number;
     endIndex: number;
@@ -75,6 +78,22 @@ function parseCommandSpans(
   return spans.length > 0 ? spans : undefined;
 }
 
+function parseAllowedDecisions(value: unknown): ExecApprovalDecision[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const allowed: ExecApprovalDecision[] = [];
+  for (const decision of value) {
+    if (
+      (decision === "allow-once" || decision === "allow-always" || decision === "deny") &&
+      !allowed.includes(decision)
+    ) {
+      allowed.push(decision);
+    }
+  }
+  return allowed.length > 0 ? allowed : undefined;
+}
+
 export function parseExecApprovalRequested(payload: unknown): ExecApprovalRequest | null {
   if (!isRecord(payload)) {
     return null;
@@ -105,6 +124,7 @@ export function parseExecApprovalRequested(payload: unknown): ExecApprovalReques
       agentId: typeof request.agentId === "string" ? request.agentId : null,
       resolvedPath: typeof request.resolvedPath === "string" ? request.resolvedPath : null,
       sessionKey: typeof request.sessionKey === "string" ? request.sessionKey : null,
+      allowedDecisions: parseAllowedDecisions(request.allowedDecisions),
       commandSpans: parseCommandSpans(request.commandSpans, command.length),
     },
     createdAtMs,
@@ -158,6 +178,7 @@ export function parsePluginApprovalRequested(payload: unknown): ExecApprovalRequ
       command: title,
       agentId: typeof request.agentId === "string" ? request.agentId : null,
       sessionKey: typeof request.sessionKey === "string" ? request.sessionKey : null,
+      allowedDecisions: parseAllowedDecisions(request.allowedDecisions),
     },
     pluginTitle: title,
     pluginDescription: description,

--- a/ui/src/ui/views/exec-approval.test.ts
+++ b/ui/src/ui/views/exec-approval.test.ts
@@ -200,6 +200,33 @@ describe("approval and confirmation modals", () => {
     expect(handleExecApprovalDecision).not.toHaveBeenCalled();
   });
 
+  it("renders only the requested decision buttons for plugin approvals", async () => {
+    const active: ExecApprovalRequest = {
+      id: "plugin-approval-1",
+      kind: "plugin",
+      request: {
+        command: "Resume Codex CLI session",
+        allowedDecisions: ["allow-once", "deny"],
+      },
+      pluginTitle: "Resume Codex CLI session",
+      pluginDescription: "Resume an existing local Codex CLI session.",
+      pluginSeverity: "critical",
+      pluginId: "codex",
+      createdAtMs: Date.now(),
+      expiresAtMs: Date.now() + 60_000,
+    };
+
+    render(renderExecApprovalPrompt(createExecState({ execApprovalQueue: [active] })), container);
+
+    await getRenderedDialog();
+
+    expect(
+      Array.from(container.querySelectorAll(".exec-approval-actions button")).map((button) =>
+        button.textContent?.trim(),
+      ),
+    ).toEqual(["Allow once", "Deny"]);
+  });
+
   it("renders exec approval chrome from the active locale", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-29T00:00:00.000Z"));

--- a/ui/src/ui/views/exec-approval.ts
+++ b/ui/src/ui/views/exec-approval.ts
@@ -4,9 +4,12 @@ import { t } from "../../i18n/index.ts";
 import type { AppViewState } from "../app-view-state.ts";
 import "../components/modal-dialog.ts";
 import type {
+  ExecApprovalDecision,
   ExecApprovalRequest,
   ExecApprovalRequestPayload,
 } from "../controllers/exec-approval.ts";
+
+const DEFAULT_APPROVAL_DECISIONS = ["allow-once", "allow-always", "deny"] as const;
 
 function formatRemaining(ms: number): string {
   const remaining = Math.max(0, ms);
@@ -107,6 +110,32 @@ ${active.pluginDescription}</pre
   `;
 }
 
+function resolveApprovalDecisions(
+  request: ExecApprovalRequestPayload,
+): readonly ExecApprovalDecision[] {
+  return request.allowedDecisions && request.allowedDecisions.length > 0
+    ? request.allowedDecisions
+    : DEFAULT_APPROVAL_DECISIONS;
+}
+
+function renderApprovalDecisionButton(decision: ExecApprovalDecision, state: AppViewState) {
+  const label =
+    decision === "allow-once"
+      ? t("execApproval.allowOnce")
+      : decision === "allow-always"
+        ? t("execApproval.alwaysAllow")
+        : t("execApproval.deny");
+  const className =
+    decision === "allow-once" ? "btn primary" : decision === "deny" ? "btn danger" : "btn";
+  return html`<button
+    class=${className}
+    ?disabled=${state.execApprovalBusy}
+    @click=${() => state.handleExecApprovalDecision(decision)}
+  >
+    ${label}
+  </button>`;
+}
+
 export function renderExecApprovalPrompt(state: AppViewState) {
   const active = state.execApprovalQueue[0];
   if (!active) {
@@ -149,27 +178,9 @@ export function renderExecApprovalPrompt(state: AppViewState) {
           ? html`<div class="exec-approval-error">${state.execApprovalError}</div>`
           : nothing}
         <div class="exec-approval-actions">
-          <button
-            class="btn primary"
-            ?disabled=${state.execApprovalBusy}
-            @click=${() => state.handleExecApprovalDecision("allow-once")}
-          >
-            ${t("execApproval.allowOnce")}
-          </button>
-          <button
-            class="btn"
-            ?disabled=${state.execApprovalBusy}
-            @click=${() => state.handleExecApprovalDecision("allow-always")}
-          >
-            ${t("execApproval.alwaysAllow")}
-          </button>
-          <button
-            class="btn danger"
-            ?disabled=${state.execApprovalBusy}
-            @click=${() => state.handleExecApprovalDecision("deny")}
-          >
-            ${t("execApproval.deny")}
-          </button>
+          ${resolveApprovalDecisions(request).map((decision) =>
+            renderApprovalDecisionButton(decision, state),
+          )}
         </div>
       </div>
     </openclaw-modal-dialog>


### PR DESCRIPTION
## Summary

- Problem: `codex.cli.session.resume` did not consistently pass through plugin approval before node dispatch.
- Solution: require a restricted plugin approval for resume, limited to `allow-once` and `deny`.
- What changed: the resume policy now requests approval before `ctx.invokeNode()`, uses the standard plugin approval timeout instead of the longer node resume timeout, fails closed when approval delivery is unavailable or denied, and the Control UI renders only the decisions allowed by the approval request.
- What did NOT change (scope boundary): session listing, node-host resume implementation, and Codex CLI spawn behavior are unchanged.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes: N/A
- Related: N/A
- [x] This PR fixes a bug or regression

## Motivation

`codex.cli.session.resume` can resume an existing local Codex CLI session with a caller-supplied prompt. Since this is a dangerous node-host command, the Gateway policy should require an explicit operator decision before forwarding the request to the node.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Codex CLI session resume now requires plugin approval before node dispatch, and the Control UI shows only the decisions permitted for this approval.
- Real environment tested: macOS local checkout, branch `codex-resume-approval`, head `713c83eba2ce`.
- Exact steps or command run after this patch: `node --import tsx .artifacts/codex-resume-real-behavior-proof.ts`; `node .artifacts/codex-resume-control-ui-proof.mjs`; targeted Vitest and `oxfmt --check` on touched files.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): copied redacted runtime logs from a live local Gateway + paired node run and from a real Control UI bundle opened in Google Chrome:

```text
[gateway] http server listening (10 plugins: acpx, bonjour, browser, canvas, codex, device-pair, file-transfer, memory-core, phone-control, talk-voice)
[proof ...] approval runtime client connected
[proof ...] operator invoke client connected
[proof ...] starting headless node host codex-proof-node-...
[gateway] device pairing auto-approved device=<node-device-id> role=node
[proof ...] approved node pairing request ... commands=["system.run.prepare","system.run","system.which","browser.proxy","codex.cli.session.resume","codex.cli.sessions.list"]
[proof ...] node connected: nodeId=<node-device-id> commands include codex.cli.session.resume after node-pair approval
[proof ...] non-dangerous list invoke succeeded: sessionCount=1 payloadJSON=present
[proof ...] plugin approval requested: id=plugin:... title="Resume Codex CLI session" severity="critical" toolName="codex.cli.session.resume"
[proof ...] plugin approval resolved with deny: id=plugin:...
[proof ...] deny resume result error: {"name":"GatewayClientRequestError","gatewayCode":"INVALID_REQUEST","message":"Codex CLI session resume requires plugin approval.","details":{"approvalId":"plugin:...","decision":"deny","code":"PLUGIN_APPROVAL_REQUIRED"}}
[proof ...] plugin approval requested: id=plugin:... title="Resume Codex CLI session" severity="critical" toolName="codex.cli.session.resume"
[proof ...] plugin approval resolved with allow-once: id=plugin:...
[proof ...] allow-once resume result error: {"name":"GatewayClientRequestError","gatewayCode":"INVALID_REQUEST","message":"Error: Missing or invalid Codex CLI session id.","details":{"nodeError":{"code":"INVALID_REQUEST","message":"Error: Missing or invalid Codex CLI session id."},"code":"INVALID_REQUEST"}}
[proof ...] proof completed

[control-ui-proof ...] branch=codex-resume-approval head=713c83eba2ce
[control-ui-proof ...] loaded real Control UI bundle from http://127.0.0.1:5173/
[control-ui-proof ...] approval title="Resume Codex CLI session" toolName=codex.cli.session.resume
[control-ui-proof ...] rendered decision buttons=["Allow once","Deny"]
[control-ui-proof ...] always allow visible=false
[control-ui-proof ...] click Deny -> handleExecApprovalDecision calls=["deny"]
[control-ui-proof ...] rerendered decision buttons=["Allow once","Deny"]
[control-ui-proof ...] click Allow once -> handleExecApprovalDecision calls=["allow-once"]
[control-ui-proof ...] proof completed
```

- Observed result after fix: `codex.cli.sessions.list` still dispatches without plugin approval; `codex.cli.session.resume` creates a plugin approval request before node dispatch; denied approval returns `PLUGIN_APPROVAL_REQUIRED` without dispatch; `allow-once` proceeds to the node handler; the resume approval uses the normal plugin approval timeout rather than the long node resume timeout; the Control UI renders only `Allow once` and `Deny`, with no `Always allow` button.
- What was not tested: remote multi-device deployment and a successful live Codex model turn after resume. The allow path intentionally used an invalid session id so the proof could verify dispatch reaches the node handler without running a model turn.
- Before evidence (optional but encouraged): before this change, the Codex resume node-invoke policy dispatched to the node without creating a plugin approval request.

## Root Cause

- Root cause: the Codex CLI resume node-invoke policy did not request plugin approval before dispatching to the node.
- Missing detection / guardrail: there was no regression test covering approval behavior for this resume policy, and the Control UI approval prompt did not preserve plugin approval `allowedDecisions`.
- Contributing context: session listing and session resume are registered together, but only resume needs approval gating.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/codex/src/node-cli-sessions.test.ts`, `src/gateway/node-invoke-plugin-policy.test.ts`, `ui/src/ui/controllers/exec-approval.test.ts`, `ui/src/ui/views/exec-approval.test.ts`, `ui/src/ui/app-gateway.node.test.ts`
- Scenario the test should lock in: resume requires plugin approval, does not dispatch when approval delivery is unavailable or denied, does not pass the long node resume timeout into the approval request, forwards only after `allow-once`, and the Control UI renders only the decisions allowed by the plugin approval request.
- Why this is the smallest reliable guardrail: the changed behavior is local to the Codex node-invoke policy, plugin approval request propagation, and the Control UI approval prompt.
- Existing test that already covers this: none before this PR.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Codex CLI session resume through this node command now requires plugin approval before dispatch. The approval prompt offers `Allow once` or `Deny`; it does not offer `Always allow` for this resume path.

## Diagram

```text
Before:
resume request -> node dispatch

After:
resume request -> plugin approval (allow-once / deny) -> node dispatch only after allow-once
```

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes — this narrows the resume execution path by requiring explicit plugin approval before node dispatch.
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: command dispatch is narrowed by a fail-closed approval gate.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local development checkout
- Model/provider: N/A
- Integration/channel: Codex extension
- Relevant config: temporary local OpenClaw state/config, redacted in logs

### Steps

1. Run the live Gateway + paired node proof.
2. Run the real Control UI decision-rendering proof.
3. Run targeted regression tests and formatting checks.

### Expected

- Resume dispatch only happens after an `allow-once` plugin approval decision.
- Denied approval and unavailable approval runtime do not dispatch to the node.
- The Control UI shows only `Allow once` and `Deny` for the Codex resume approval.

### Actual

- Matches expected in the live Gateway proof, Control UI proof, and targeted regression tests.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers

## Human Verification

- Verified scenarios: deny blocks dispatch; unavailable approval runtime blocks dispatch; `allow-once` forwards to the node handler; Control UI renders only `Allow once` and `Deny`; Control UI click routing produces `deny` and `allow-once`.
- Edge cases checked: approval runtime unavailable; duplicate/limited plugin approval decisions are normalized before broadcast; disallowed `allow-always` is not rendered by the Control UI.
- What you did **not** verify: remote multi-device deployment and a successful live Codex model turn after resume.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Mostly
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A
- Notes: existing automation that invokes `codex.cli.session.resume` may now need an approval-capable runtime or an explicit approval decision.

## Risks and Mitigations

- Risk: existing automation that resumes Codex CLI sessions may now stop for approval.
  - Mitigation: the change is limited to session resume; session listing and node-host resume behavior remain unchanged after approval.
