### PR TITLE
fix(matrix): deliver explicit reasoning replies

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -1767,6 +1767,22 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           ...prefixOptions,
           humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, _route.agentId),
           deliver: async (payload: ReplyPayload, info: { kind: string }) => {
+            if (payload.isReasoning === true) {
+              await deliverMatrixReplies({
+                cfg,
+                replies: [payload],
+                roomId,
+                client,
+                runtime,
+                textLimit,
+                replyToMode,
+                threadId: threadTarget,
+                accountId: _route.accountId,
+                mediaLocalRoots,
+                tableMode,
+              });
+              return;
+            }
             if (draftStream && info.kind !== "tool" && !payload.isCompactionNotice) {
               const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
 
@@ -2123,6 +2139,7 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
                       dispatcher,
                       replyOptions: {
                         ...replyOptions,
+                        deliverReasoningReplies: true,
                         skillFilter: roomConfig?.skills,
                         // Keep block streaming enabled when explicitly requested, even
                         // with draft previews on. The draft remains the live preview

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -2158,7 +2158,10 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
                           : undefined,
                         onBlockReplyQueued: draftStream
                           ? (payload, context) => {
-                              if (payload.isCompactionNotice === true) {
+                              if (
+                                payload.isCompactionNotice === true ||
+                                payload.isReasoning === true
+                              ) {
                                 return;
                               }
                               queueDraftBlockBoundary(payload, context);

--- a/extensions/matrix/src/matrix/monitor/replies.test.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.test.ts
@@ -196,6 +196,26 @@ describe("deliverMatrixReplies", () => {
     expect(sendOptions(0).cfg).toBe(cfg);
   });
 
+  it("delivers explicit reasoning payloads before Matrix sends", async () => {
+    await deliverMatrixReplies({
+      cfg,
+      replies: [
+        { text: "Reasoning:\nvisible because this payload is explicit", isReasoning: true },
+        { text: "<think>still hidden</think>" },
+        { text: "Visible answer" },
+      ],
+      roomId: "room:5",
+      client: {} as MatrixClient,
+      runtime: runtimeEnv,
+      textLimit: 4000,
+      replyToMode: "off",
+    });
+
+    expect(sendMessageMatrixMock).toHaveBeenCalledTimes(2);
+    expect(sendCall(0)[1]).toBe("Reasoning:\nvisible because this payload is explicit");
+    expect(sendCall(1)[1]).toBe("Visible answer");
+  });
+
   it("uses supplied cfg for chunking and send delivery without reloading runtime config", async () => {
     const explicitCfg = {
       channels: {

--- a/extensions/matrix/src/matrix/monitor/replies.ts
+++ b/extensions/matrix/src/matrix/monitor/replies.ts
@@ -58,7 +58,7 @@ export async function deliverMatrixReplies(params: {
   let hasReplied = false;
   let deliveredAny = false;
   for (const reply of params.replies) {
-    if (reply.isReasoning === true || shouldSuppressReasoningReplyText(reply.text)) {
+    if (reply.isReasoning !== true && shouldSuppressReasoningReplyText(reply.text)) {
       logVerbose("matrix reply suppressed as reasoning-only");
       continue;
     }

--- a/src/auto-reply/get-reply-options.types.ts
+++ b/src/auto-reply/get-reply-options.types.ts
@@ -90,6 +90,8 @@ export type GetReplyOptions = {
   onReasoningStream?: (payload: ReplyPayload) => Promise<void> | void;
   /** Called when a thinking/reasoning block ends. */
   onReasoningEnd?: () => Promise<void> | void;
+  /** If true, generic dispatch may deliver explicit isReasoning payloads. */
+  deliverReasoningReplies?: boolean;
   /** Called when a new assistant message starts (e.g., after tool call or thinking block). */
   onAssistantMessageStart?: () => Promise<void> | void;
   /** Called synchronously when a block reply is logically emitted, before async

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -4021,6 +4021,31 @@ describe("dispatchReplyFromConfig", () => {
     expect((finalCalls[0]?.[0] as ReplyPayload | undefined)?.text).toBe("The answer is 42");
   });
 
+  it("delivers isReasoning final replies when the channel opts in", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "matrix", Surface: "matrix" });
+    const replyResolver = async () =>
+      [
+        { text: "Reasoning:\nthinking...", isReasoning: true },
+        { text: "The answer is 42" },
+      ] satisfies ReplyPayload[];
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyOptions: { deliverReasoningReplies: true },
+      replyResolver,
+    });
+
+    const finalCalls = (dispatcher.sendFinalReply as ReturnType<typeof vi.fn>).mock.calls;
+    expect(finalCalls.map((call) => (call[0] as ReplyPayload).text)).toEqual([
+      "Reasoning:\nthinking...",
+      "The answer is 42",
+    ]);
+  });
+
   it("suppresses isReasoning payloads from block replies (generic dispatch path)", async () => {
     setNoAbort();
     const dispatcher = createDispatcher();
@@ -4047,6 +4072,39 @@ describe("dispatchReplyFromConfig", () => {
     await dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher, replyResolver });
     expect(blockReplySentTexts).not.toContain("thinking...");
     expect(blockReplySentTexts).toContain("The answer is 42");
+  });
+
+  it("delivers isReasoning block replies when the channel opts in", async () => {
+    setNoAbort();
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({ Provider: "matrix", Surface: "matrix" });
+    const blockReplySentTexts: string[] = [];
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+    ): Promise<ReplyPayload> => {
+      await opts?.onBlockReply?.({ text: "Reasoning:\nthinking...", isReasoning: true });
+      await opts?.onBlockReply?.({ text: "The answer is 42" });
+      return { text: "The answer is 42" };
+    };
+    (dispatcher.sendBlockReply as ReturnType<typeof vi.fn>).mockImplementation(
+      (payload: ReplyPayload) => {
+        if (payload.text) {
+          blockReplySentTexts.push(payload.text);
+        }
+        return true;
+      },
+    );
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyOptions: { deliverReasoningReplies: true },
+      replyResolver,
+    });
+
+    expect(blockReplySentTexts).toEqual(["Reasoning:\nthinking...", "The answer is 42"]);
   });
 
   it("strips split TTS directives from streamed block text before delivery", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -436,6 +436,7 @@ export async function dispatchReplyFromConfig(
       config: cfg,
       attributes: traceAttributes,
     });
+  const shouldDeliverReasoningReplies = params.replyOptions?.deliverReasoningReplies === true;
 
   const recordProcessed = (
     outcome: "completed" | "skipped" | "error",
@@ -1503,10 +1504,9 @@ export async function dispatchReplyFromConfig(
               if (suppressDelivery) {
                 return;
               }
-              // Suppress reasoning payloads — channels using this generic dispatch
-              // path (WhatsApp, web, etc.) do not have a dedicated reasoning lane.
+              // Suppress reasoning payloads unless a channel explicitly opts in.
               // Telegram has its own dispatch path that handles reasoning splitting.
-              if (payload.isReasoning === true) {
+              if (payload.isReasoning === true && !shouldDeliverReasoningReplies) {
                 return;
               }
               // Accumulate block text for TTS generation after streaming.
@@ -1632,9 +1632,9 @@ export async function dispatchReplyFromConfig(
       !sendPolicyDenied &&
       getReplyPayloadMetadata(reply)?.deliverDespiteSourceReplySuppression === true;
     for (const reply of replies) {
-      // Suppress reasoning payloads from channel delivery — channels using this
-      // generic dispatch path do not have a dedicated reasoning lane.
-      if (reply.isReasoning === true) {
+      // Suppress reasoning payloads from channel delivery unless a channel
+      // explicitly opts in with a dedicated reasoning lane.
+      if (reply.isReasoning === true && !shouldDeliverReasoningReplies) {
         continue;
       }
       if (suppressDelivery && !shouldDeliverDespiteSourceReplySuppression(reply)) {


### PR DESCRIPTION
Fixes #81892.

## Summary
- add an explicit dispatch opt-in for channels that can deliver reasoning replies
- opt Matrix into explicit `isReasoning` delivery and bypass draft preview handling for those payloads
- keep suppressing raw reasoning-looking text unless it is an explicit reasoning payload

## Tests
- Not run locally; full OpenClaw clone/install was unavailable due repeated GitHub connection timeouts. Added focused dispatch and Matrix reply tests for the new behavior.