### PR TITLE
fix(telegram): repair message cache reply types

### DIFF
--- a/extensions/telegram/src/message-cache.ts
+++ b/extensions/telegram/src/message-cache.ts
@@ -14,7 +14,8 @@ import {
 
 export type TelegramReplyChainEntry = NonNullable<MsgContext["ReplyChain"]>[number];
 
-export type TelegramCachedMessageNode = TelegramReplyChainEntry & {
+export type TelegramCachedMessageNode = Omit<TelegramReplyChainEntry, "messageId"> & {
+  messageId: string;
   sourceMessage: Message;
 };
 


### PR DESCRIPTION
## Summary

- Repair the Telegram message cache types introduced by the latest reply-chain context changes on `main`.
- Keep cached nodes' normalized `messageId` required after normalization so cache upserts can use it without widening to `undefined`.
- Narrow the cast needed when the local cache preserves nested reply messages even though the public Telegram API reply type intentionally forbids nested replies.

## Verification

```sh
node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental false
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental false
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json extensions/telegram/src/message-cache.ts
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-telegram-message-cache-types-rebase node scripts/run-vitest.mjs extensions/telegram/src/message-cache.test.ts
git diff --check origin/main..HEAD
```

## Real behavior proof

Behavior addressed: current `main` CI fails in Telegram message-cache type checks after the reply-chain context changes because cached nested reply messages are represented more richly than grammy's public `reply_to_message` type allows, and normalized cache nodes still expose `messageId` as optional.

Real environment tested: macOS local Codex worktree, Node v24.14.1, pnpm v11.1.0, OpenClaw checkout at `b881a070b2`.

Exact steps or command run after this patch:

```sh
node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental false
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental false
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json extensions/telegram/src/message-cache.ts
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-telegram-message-cache-types-rebase node scripts/run-vitest.mjs extensions/telegram/src/message-cache.test.ts
git diff --check origin/main..HEAD
```

Evidence after fix: terminal output captured after running the local OpenClaw checkout:

```text
$ node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental false
(no output; exit 0)

$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --incremental false
(no output; exit 0)

$ node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.json extensions/telegram/src/message-cache.ts
Found 0 warnings and 0 errors.
Finished in 210ms on 1 file with 216 rules using 1 threads.

$ OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/tmp/openclaw-vitest-telegram-message-cache-types-rebase node scripts/run-vitest.mjs extensions/telegram/src/message-cache.test.ts
Test Files  1 passed (1)
Tests  12 passed (12)
Duration  5.97s

$ git diff --check origin/main..HEAD
(no output)
```

Observed result after fix: the Telegram extension production and test type checks now accept the message-cache source, oxlint stays clean, and the message-cache behavior tests continue to pass while preserving nested cached reply-chain reconstruction.

What was not tested: full repository CI was not run locally; this PR is intended to let GitHub CI re-run the failing main shards.