### PR TITLE
fix(slack): show assistant status on interactive reply clicks in threads

### DIFF
--- a/extensions/slack/src/monitor/events/interactions.block-actions.ts
+++ b/extensions/slack/src/monitor/events/interactions.block-actions.ts
@@ -90,7 +90,7 @@ type SlackBlockActionBody = {
   response_url?: string;
   channel?: { id?: string };
   container?: { channel_id?: string; message_ts?: string; thread_ts?: string };
-  message?: { ts?: string; text?: string; blocks?: unknown[] };
+  message?: { ts?: string; thread_ts?: string; text?: string; blocks?: unknown[] };
 };
 
 type SlackBlockActionRespond = NonNullable<SlackActionMiddlewareArgs["respond"]>;
@@ -431,7 +431,7 @@ function parseSlackBlockAction(params: {
     userId: typedBody.user?.id ?? "unknown",
     channelId: typedBody.channel?.id ?? typedBody.container?.channel_id,
     messageTs: typedBody.message?.ts ?? typedBody.container?.message_ts,
-    threadTs: typedBody.container?.thread_ts,
+    threadTs: typedBody.container?.thread_ts ?? typedBody.message?.thread_ts,
     actionSummary: summarizeAction(typedAction),
   };
 }

--- a/extensions/slack/src/monitor/events/interactions.test.ts
+++ b/extensions/slack/src/monitor/events/interactions.test.ts
@@ -134,7 +134,7 @@ type RegisteredHandler = (args: {
     response_url?: string;
     channel?: { id?: string };
     container?: { channel_id?: string; message_ts?: string; thread_ts?: string };
-    message?: { ts?: string; text?: string; blocks?: unknown[] };
+    message?: { ts?: string; thread_ts?: string; text?: string; blocks?: unknown[] };
   };
   action: Record<string, unknown>;
   respond?: (payload: { text: string; response_type: string }) => Promise<void>;
@@ -461,6 +461,53 @@ describe("registerSlackInteractionEvents", () => {
     });
     expect(trackEvent).toHaveBeenCalledTimes(1);
     expect(app.client.chat.update).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to message.thread_ts when container.thread_ts is absent", async () => {
+    const { ctx, getHandler, resolveSessionKey } = createContext();
+    registerSlackInteractionEvents({ ctx: ctx as never });
+
+    const handler = getHandler();
+    const ack = vi.fn().mockResolvedValue(undefined);
+    await handler({
+      ack,
+      body: {
+        user: { id: "U123" },
+        channel: { id: "C1" },
+        // container has no thread_ts; thread_ts is on message instead
+        container: { channel_id: "C1", message_ts: "200.300" },
+        message: {
+          ts: "200.300",
+          thread_ts: "200.100",
+          text: "fallback",
+          blocks: [
+            {
+              type: "actions",
+              block_id: "fallback_block",
+              elements: [{ type: "button", action_id: "openclaw:verify" }],
+            },
+          ],
+        },
+      },
+      action: {
+        type: "button",
+        action_id: "openclaw:verify",
+        block_id: "fallback_block",
+        value: "ok",
+      },
+    });
+
+    expect(ack).toHaveBeenCalled();
+    expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+    const payload = slackInteractionPayload();
+    expectRecordFields(payload, {
+      threadTs: "200.100",
+      channelId: "C1",
+      messageTs: "200.300",
+    });
+    expect(resolveSessionKey).toHaveBeenCalledWith(
+      expect.objectContaining({ threadTs: "200.100" }),
+    );
   });
 
   it("registers a matcher that accepts plugin action ids beyond the OpenClaw prefix", () => {


### PR DESCRIPTION
## Summary

- Block action handler only read `thread_ts` from `container`, missing cases where Slack delivers it on `message.thread_ts` instead
- This caused `assistant.threads.setStatus` to silently skip, so no typing/status indicator appeared after button/select clicks in threads
- Fix: fall back to `message.thread_ts` when `container.thread_ts` is absent; also add `thread_ts` to the `message` type in `SlackBlockActionBody`

## Verification

Added test: block action with `thread_ts` on `message` only — asserts correct `threadTs` forwarded to session key and event payload. `pnpm test extensions/slack/src/monitor/events/interactions.test.ts` — 44/44 passed.

## Real behavior proof

Behavior addressed: Slack native assistant status/typing indicator missing after interactive reply button/select clicks in threads
Real environment tested: macOS Darwin 25.5.0 arm64, Slack socket mode, @openclaw/slack 2026.5.12
Exact steps or command run after this patch: pnpm test extensions/slack/src/monitor/events/interactions.test.ts
Evidence after fix: 44 tests passed including new fallback case for message.thread_ts
Observed result after fix: threadTs correctly resolved from message.thread_ts when container.thread_ts is absent; assistant.threads.setStatus proceeds instead of bailing early
What was not tested: live Slack workspace end-to-end button click

Fixes #82886