### PR TITLE
fix(install): add pipe guard to prevent stdin stealing in curl | bash

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,9 +3,10 @@
 # incrementally from stdin. Any child process that also reads stdin steals
 # bytes from the script stream, causing truncated function names and hangs
 # (see #73814). Detect piped execution via empty BASH_SOURCE (piped scripts
-# have no source file), buffer the remaining stdin to a temp file, and
-# re-execute so stdin is free for interactive prompts and child processes.
-if [ -z "${BASH_SOURCE[0]:-}" ] && [ -z "${_OPENCLAW_PIPE_BUFFERED:-}" ]; then
+# have no source file) AND non-terminal stdin (excludes "bash -c" command
+# strings), buffer the remaining stdin to a temp file, and re-execute so
+# stdin is free for interactive prompts and child processes.
+if [ -z "${BASH_SOURCE[0]:-}" ] && [ -z "${_OPENCLAW_PIPE_BUFFERED:-}" ] && [ ! -t 0 ]; then
     _pipe_tmp=$(mktemp)
     cat > "$_pipe_tmp"
     _OPENCLAW_PIPE_BUFFERED="$_pipe_tmp" exec bash "$_pipe_tmp" "$@"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,10 +3,11 @@
 # incrementally from stdin. Any child process that also reads stdin steals
 # bytes from the script stream, causing truncated function names and hangs
 # (see #73814). Detect piped execution via empty BASH_SOURCE (piped scripts
-# have no source file) AND non-terminal stdin (excludes "bash -c" command
-# strings), buffer the remaining stdin to a temp file, and re-execute so
-# stdin is free for interactive prompts and child processes.
-if [ -z "${BASH_SOURCE[0]:-}" ] && [ -z "${_OPENCLAW_PIPE_BUFFERED:-}" ] && [ ! -t 0 ]; then
+# have no source file) AND stdin is a pipe (-p /dev/stdin). Using -p instead
+# of "! -t 0" avoids false positives in non-TTY contexts like bash -c
+# command strings, CI runners, cron, and Docker containers where stdin is
+# /dev/null or a regular file rather than a pipe.
+if [ -z "${BASH_SOURCE[0]:-}" ] && [ -z "${_OPENCLAW_PIPE_BUFFERED:-}" ] && [ -p /dev/stdin ]; then
     _pipe_tmp=$(mktemp)
     cat > "$_pipe_tmp"
     _OPENCLAW_PIPE_BUFFERED="$_pipe_tmp" exec bash "$_pipe_tmp" "$@"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,25 @@
 #!/bin/bash
+# Pipe guard: when invoked via "curl ... | bash", bash reads this script
+# incrementally from stdin. Any child process that also reads stdin steals
+# bytes from the script stream, causing truncated function names and hangs
+# (see #73814). Detect piped execution via empty BASH_SOURCE (piped scripts
+# have no source file), buffer the remaining stdin to a temp file, and
+# re-execute so stdin is free for interactive prompts and child processes.
+if [ -z "${BASH_SOURCE[0]:-}" ] && [ -z "${_OPENCLAW_PIPE_BUFFERED:-}" ]; then
+    _pipe_tmp=$(mktemp)
+    cat > "$_pipe_tmp"
+    _OPENCLAW_PIPE_BUFFERED="$_pipe_tmp" exec bash "$_pipe_tmp" "$@"
+fi
+if [ -n "${_OPENCLAW_PIPE_BUFFERED:-}" ]; then
+    # Only clean up the temp file when the marker matches the script we are
+    # executing, confirming this is our pipe guard's buffered copy rather than
+    # a caller-controlled path inherited via the environment.
+    if [ "${_OPENCLAW_PIPE_BUFFERED}" = "${BASH_SOURCE[0]:-}" ]; then
+        rm -f "$_OPENCLAW_PIPE_BUFFERED" 2>/dev/null || true
+    fi
+    unset _OPENCLAW_PIPE_BUFFERED
+fi
+
 set -euo pipefail
 
 # OpenClaw Installer for macOS and Linux

--- a/scripts/test-install-pipe-guard.sh
+++ b/scripts/test-install-pipe-guard.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+# Test harness for the pipe guard (PR #82918).
+# Verifies the guard triggers ONLY for piped execution (curl | bash),
+# not for direct, command-string, or process-substitution invocation.
+
+set -euo pipefail
+
+BOLD='\033[1m'
+NC='\033[0m'
+GREEN='\033[38;2;0;229;204m'
+RED='\033[38;2;230;57;70m'
+
+pass=0
+fail=0
+
+ok() { pass=$((pass+1)); echo -e "  ${GREEN}✓ PASS${NC}  $1"; }
+ko() { fail=$((fail+1)); echo -e "  ${RED}✗ FAIL${NC}  $1"; }
+announce() { echo -e "\n${BOLD}── $1 ──${NC}"; }
+
+# ---------------------------------------------------------------------------
+# Build a minimal test script that just prints diagnostic state and exits
+# ---------------------------------------------------------------------------
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+cat > "$TMPDIR_TEST/stub.sh" << 'STUB'
+#!/bin/bash
+# Minimal pipe-guard stub that mirrors the real guard logic
+if [ -z "${BASH_SOURCE[0]:-}" ] && [ -z "${_OPENCLAW_PIPE_BUFFERED:-}" ] && [ -p /dev/stdin ]; then
+    _pipe_tmp=$(mktemp)
+    cat > "$_pipe_tmp"
+    echo "GUARD_TRIGGERED=true"
+    _OPENCLAW_PIPE_BUFFERED="$_pipe_tmp" exec bash "$_pipe_tmp" "$@"
+fi
+if [ -n "${_OPENCLAW_PIPE_BUFFERED:-}" ]; then
+    echo "BUFFERED_EXEC=true"
+    if [ "${_OPENCLAW_PIPE_BUFFERED}" = "${BASH_SOURCE[0]:-}" ]; then
+        rm -f "$_OPENCLAW_PIPE_BUFFERED" 2>/dev/null || true
+    fi
+    unset _OPENCLAW_PIPE_BUFFERED
+fi
+echo "REACHED_BODY=true"
+echo "BASH_SOURCE=${BASH_SOURCE[0]:-<empty>}"
+echo "STDIN_IS_TTY=$([ -t 0 ] && echo yes || echo no)"
+echo "STDIN_IS_PIPE=$([ -p /dev/stdin ] && echo yes || echo no)"
+STUB
+chmod +x "$TMPDIR_TEST/stub.sh"
+
+# ---------------------------------------------------------------------------
+# Test 1: Direct file execution (bash script.sh)
+# Guard must NOT trigger.
+# ---------------------------------------------------------------------------
+announce "Direct file execution"
+
+direct_out="$(bash "$TMPDIR_TEST/stub.sh" 2>&1)"
+if echo "$direct_out" | grep -q "GUARD_TRIGGERED=true"; then
+    ko "direct → guard triggered (should not)"
+else
+    ok "direct → guard did NOT trigger"
+fi
+if echo "$direct_out" | grep -q "REACHED_BODY=true"; then
+    ok "direct → script body reached"
+else
+    ko "direct → script body NOT reached"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: Command-string execution (bash -c "$(cat script.sh)")
+# Guard must NOT trigger even though BASH_SOURCE is empty.
+# ---------------------------------------------------------------------------
+announce "Command-string execution (bash -c)"
+
+cmdstr_out="$(bash -c "$(cat "$TMPDIR_TEST/stub.sh")" 2>&1)"
+if echo "$cmdstr_out" | grep -q "GUARD_TRIGGERED=true"; then
+    ko "bash -c → guard triggered (should not)"
+else
+    ok "bash -c → guard did NOT trigger"
+fi
+if echo "$cmdstr_out" | grep -q "REACHED_BODY=true"; then
+    ok "bash -c → script body reached"
+else
+    ko "bash -c → script body NOT reached"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: Piped execution (cat script.sh | bash)
+# Guard MUST trigger and re-exec from the buffered temp file.
+# ---------------------------------------------------------------------------
+announce "Piped execution (cat | bash)"
+
+pipe_out="$(cat "$TMPDIR_TEST/stub.sh" | bash 2>&1)"
+if echo "$pipe_out" | grep -q "GUARD_TRIGGERED=true"; then
+    ok "pipe → guard triggered"
+else
+    ko "pipe → guard did NOT trigger (should have)"
+fi
+if echo "$pipe_out" | grep -q "BUFFERED_EXEC=true"; then
+    ok "pipe → buffered re-exec reached"
+else
+    ko "pipe → buffered re-exec NOT reached"
+fi
+if echo "$pipe_out" | grep -q "REACHED_BODY=true"; then
+    ok "pipe → script body reached"
+else
+    ko "pipe → script body NOT reached"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: Process substitution (bash <(cat script.sh))
+# Guard must NOT trigger (BASH_SOURCE is set to /dev/fd/... or /proc/...).
+# ---------------------------------------------------------------------------
+announce "Process substitution (bash <(...))"
+
+procsub_out="$(bash <(cat "$TMPDIR_TEST/stub.sh") 2>&1)"
+if echo "$procsub_out" | grep -q "GUARD_TRIGGERED=true"; then
+    ko "process-sub → guard triggered (should not)"
+else
+    ok "process-sub → guard did NOT trigger"
+fi
+if echo "$procsub_out" | grep -q "REACHED_BODY=true"; then
+    ok "process-sub → script body reached"
+else
+    ko "process-sub → script body NOT reached"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: Stdin from /dev/null (common in CI/Docker)
+# Guard must NOT trigger.
+# ---------------------------------------------------------------------------
+announce "Stdin from /dev/null (CI/Docker)"
+
+devnull_out="$(bash "$TMPDIR_TEST/stub.sh" < /dev/null 2>&1)"
+if echo "$devnull_out" | grep -q "GUARD_TRIGGERED=true"; then
+    ko "/dev/null → guard triggered (should not)"
+else
+    ok "/dev/null → guard did NOT trigger"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo -e "${BOLD}Results: ${GREEN}${pass} passed${NC}, ${RED}${fail} failed${NC}"
+if [[ $fail -eq 0 ]]; then
+    echo -e "${GREEN}All invocation tests passed.${NC}"
+else
+    echo -e "${RED}Some invocation tests failed!${NC}"
+    exit 1
+fi


### PR DESCRIPTION
## Problem

When invoked via `curl -fsSL https://openclaw.ai/install.sh | bash`, bash reads the script incrementally from stdin. Interactive prompts (gum, read) and child processes that also read stdin steal bytes from the script stream, causing:

1. Truncated function names: `warn_shell_path_missing_di` instead of `warn_shell_path_missing_dir`
2. "command not found" errors for the truncated names
3. Indefinite hangs (the script stream is corrupted, bash blocks waiting for more input)

Reported on WSL2 Ubuntu 24.04 with 3/3 reproduction rate.

## Fix

Add a pipe guard at the top of `install.sh` that detects piped execution via empty `BASH_SOURCE[0]` (piped scripts have no source file), buffers the remaining stdin to a temp file using `cat`, and re-executes from the file via `exec`. This frees stdin for interactive prompts and child processes.

The guard:
- **Does not fire** for direct execution (`bash install.sh`) or process substitution (`bash <(curl ...)`) because `BASH_SOURCE` is set
- **Does not fire** for CI/Docker with non-tty stdin when running from a file
- **Cleans up** the temp file immediately after re-execution starts
- Uses `_OPENCLAW_PIPE_BUFFERED` env var to prevent infinite re-execution loops

Fixes #73814

## Real behavior proof
Behavior addressed: the installer now buffers itself to a temp file when piped via curl, preventing child processes from consuming stdin bytes that corrupt the script stream.
Real environment tested: Linux x86_64, OpenClaw 2026.5.12 installed, Node v26.0.0, bash 5.2. Tested both piped execution (`cat install.sh | bash -s -- --install-method npm`) and direct execution (`bash install.sh --install-method npm < /dev/null`).
Exact steps or command run after this patch: (1) verified pipe guard pattern with a minimal test script that includes a deliberate stdin steal (`head -c 50 < /dev/stdin`); (2) ran full installer in piped mode; (3) ran full installer in direct mode with non-tty stdin; (4) confirmed both complete successfully without truncation.
Evidence after fix: terminal output copied below.

Pipe guard pattern verification (minimal test script with deliberate stdin steal):
```
$ cat /tmp/pipe-test-steal.sh | bash
Before stdin steal
After stdin steal
Function executed correctly
Script completed
```
Without the guard, the `head -c 50` would consume 50 bytes of the script stream, truncating the function definition. With the guard, the script runs from a temp file so stdin stealing has no effect.

Full installer in piped mode (script runs from temp file):
```
$ cat scripts/install.sh | bash -s -- --install-method npm 2>&1 | tail -10
✓ OpenClaw installed

[3/3] Finalizing setup
· Running doctor to migrate settings
· Running doctor
✓ Doctor complete

🦞 OpenClaw installed successfully (2026.5.12)!
```
Note: error source shows `/tmp/tmp.uuj4JcpyzQ: line 2988` confirming the guard buffered to temp file.

Full installer in direct mode (BASH_SOURCE is set, guard does not fire):
```
$ bash scripts/install.sh --install-method npm < /dev/null 2>&1 | tail -10
✓ Doctor complete

🦞 OpenClaw installed successfully (2026.5.12)!
```
Note: error source shows `scripts/install.sh: line 3000` confirming guard did not fire.

Observed result after fix: piped execution completes successfully without truncated function names or hangs. Direct execution is unaffected. The pipe guard adds negligible overhead (one mktemp + cat + exec).
What was not tested: macOS bash 3.2 (BASH_SOURCE behavior may differ in very old bash versions). WSL2 Ubuntu 24.04 (the reporter's environment) was not tested directly, but the fix is bash-level and platform-independent.
