### PR TITLE
fix(cli): lower extra gateway advisory severity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ Docs: https://docs.openclaw.ai
 - Agents/replies: classify provider conversation-state rejections and return a clear message-channel error instead of auto-resetting or falling back to a generic runner failure. (#82616) Thanks @dutifulbob.
 - Browser plugin: trust managed Chrome CDP diagnostics when launch HTTP probes race cold-start readiness, avoiding false startup failures. Fixes #82904. (#82986) Thanks @kmanan and @hclsys.
 - Android: prompt before replacing a changed Gateway TLS thumbprint, showing the old and new SHA-256 fingerprints so users can accept expected certificate rotations instead of hard failing on pin mismatch. (#83077) Thanks @sliekens.
+- CLI/status: render extra gateway-like service diagnostics as warning/info output instead of error output. Fixes #46930. (#82922) thanks @giodl73-repo.
 
 ## 2026.5.17
 

--- a/src/cli/daemon-cli/status.print.test.ts
+++ b/src/cli/daemon-cli/status.print.test.ts
@@ -437,4 +437,35 @@ describe("printDaemonStatus", () => {
     expectMockLineContains(runtime.error, "Config warnings:");
     expectMockLineContains(runtime.error, "without channelConfigs metadata");
   });
+
+  it("prints extra gateway-like services as warnings instead of errors", () => {
+    printDaemonStatus(
+      {
+        service: {
+          label: "LaunchAgent",
+          loaded: true,
+          loadedText: "loaded",
+          notLoadedText: "not loaded",
+          runtime: { status: "running", pid: 8000 },
+        },
+        rpc: {
+          ok: true,
+          url: "ws://127.0.0.1:18789",
+          server: { version: "2026.5.12" },
+        },
+        port: {
+          port: 18789,
+          status: "busy",
+          listeners: [],
+          hints: [],
+        },
+        extraServices: [{ label: "ai.openclaw.gateway.rescue", scope: "user", detail: "loaded" }],
+      },
+      { json: false },
+    );
+
+    expectMockLineContains(runtime.log, "Other gateway-like services detected");
+    expectMockLineContains(runtime.log, "ai.openclaw.gateway.rescue");
+    expect(runtime.error).not.toHaveBeenCalled();
+  });
 });

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -441,24 +441,24 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean })
   }
 
   if (extraServices.length > 0) {
-    defaultRuntime.error(errorText("Other gateway-like services detected (best effort):"));
+    defaultRuntime.log(warnText("Other gateway-like services detected (best effort):"));
     for (const svc of extraServices) {
-      defaultRuntime.error(`- ${errorText(svc.label)} (${svc.scope}, ${svc.detail})`);
+      defaultRuntime.log(`- ${warnText(svc.label)} (${svc.scope}, ${svc.detail})`);
     }
     for (const hint of renderGatewayServiceCleanupHints()) {
-      defaultRuntime.error(`${errorText("Cleanup hint:")} ${hint}`);
+      defaultRuntime.log(`${infoText("Cleanup hint:")} ${hint}`);
     }
     spacer();
   }
 
   if (extraServices.length > 0) {
-    defaultRuntime.error(
-      errorText(
+    defaultRuntime.log(
+      infoText(
         "Recommendation: run a single gateway per machine for most setups. One gateway supports multiple agents (see docs: /gateway#multiple-gateways-same-host).",
       ),
     );
-    defaultRuntime.error(
-      errorText(
+    defaultRuntime.log(
+      infoText(
         "If you need multiple gateways (e.g., a rescue bot on the same host), isolate ports + config/state (see docs: /gateway#multiple-gateways-same-host).",
       ),
     );


### PR DESCRIPTION
Fixes #46930.

## Summary
- print extra gateway-like service diagnostics through the normal status output stream with warning styling instead of `defaultRuntime.error(errorText(...))`
- keep cleanup hints/recommendations visible as warning/info text without treating this advisory condition as an error
- add focused status-rendering coverage that fails if the extra-gateway advisory path writes to `runtime.error`

## Tests
- `CI=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.cli.config.ts src/cli/daemon-cli/status.print.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/cli/daemon-cli/status.print.ts src/cli/daemon-cli/status.print.test.ts`
- `git diff --check`
- `pnpm check:changed`

## Real behavior proof
Behavior or issue addressed: `openclaw status` treated best-effort “Other gateway-like services detected” guidance as error-level output even though multiple gateways can be an intentional/advanced setup and the issue requests warn/info severity instead.

Real environment tested: WSL Ubuntu source checkout running the actual OpenClaw status renderer through `node --import tsx`, with stdout/stderr captured separately from the terminal process.

Exact steps or command run after this patch: a terminal proof script imported `src/cli/daemon-cli/status.print.ts`, rendered a status payload containing one extra gateway-like service, and redirected stdout/stderr separately with `node --import tsx status-proof.mjs >stdout.log 2>stderr.log`.

Evidence after fix:

```text
COMMAND: node --import tsx status-proof.mjs >stdout.log 2>stderr.log
EXIT_STATUS=0
STDOUT:
Service: Systemd user service (loaded)
Gateway version: 2026.5.12
Runtime: running (pid 8000)
Connectivity probe: ok
Listening: 127.0.0.1:18789
Other gateway-like services detected (best effort):
- openclaw-gateway-rescue.service (user, loaded)
Cleanup hint: systemctl --user disable --now openclaw-gateway.service
Cleanup hint: rm ~/.config/systemd/user/openclaw-gateway.service
Recommendation: run a single gateway per machine for most setups. One gateway supports multiple agents (see docs: /gateway#multiple-gateways-same-host).
If you need multiple gateways (e.g., a rescue bot on the same host), isolate ports + config/state (see docs: /gateway#multiple-gateways-same-host).
Troubles: run openclaw status
Troubleshooting: https://docs.openclaw.ai/troubleshooting
STDERR_BYTES=0
STDERR:
```

Observed result after fix: the extra gateway-like service advisory, service label, cleanup hints, and recommendations all appear on stdout, and stderr is empty (`STDERR_BYTES=0`). The focused CLI status test shard passes with `9 tests`, and `pnpm check:changed` passes with typecheck, lint, import-cycle, dependency, patch, and guard checks clean.

What was not tested: live launchd/systemd discovery on a host with multiple installed gateway services; this patch only changes the severity/output stream once `extraServices` has already been gathered.