### PR TITLE
fix: sanitize Codex image payload replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 - Mac app: make Channels settings open faster by deferring config-schema work, avoiding startup channel probes, caching decoded channel status rows, and showing only compact quick settings instead of the full generated channel schema.
 - Control UI: include the Control UI and Gateway protocol versions in protocol-mismatch errors so stale app/dashboard pairings identify which side needs rebuilding or restarting.
 - Gateway/protocol: restore Gateway WS protocol v4 and keep `message.action` room-event metadata on the existing `inboundTurnKind` wire field while preserving internal inbound-event classification.
+- Codex: sanitize inline image payloads before Codex app-server and OpenAI Responses replay, and clear poisoned Codex thread bindings after invalid image errors. Fixes #82878.
 - Providers/GitHub Copilot: request identity-encoded Copilot API responses across token exchange, catalog, model calls, usage, and embeddings so compressed Business-account error payloads no longer reach JSON parsers as gzip bytes. Fixes #82871. Thanks @tonyfe01.
 - Telegram: preserve replied-to bot messages, captions, and media metadata in group reply chains so follow-up replies understand what the user is reacting to. (#82863)
 - Providers/Together: update PI runtime packages to 0.74.1 and emit Together-style `reasoning.enabled`/`max_tokens` controls for reasoning-capable OpenAI-completions models.

--- a/extensions/codex/src/app-server/dynamic-tools.ts
+++ b/extensions/codex/src/app-server/dynamic-tools.ts
@@ -19,6 +19,7 @@ import {
   wrapToolWithBeforeToolCallHook,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { CodexDynamicToolsLoading } from "./config.js";
+import { invalidInlineImageText, sanitizeInlineImageDataUrl } from "./image-payload-sanitizer.js";
 import {
   type CodexDynamicToolCallOutputContentItem,
   type CodexDynamicToolCallParams,
@@ -375,10 +376,14 @@ function convertToolContent(
   if (content.type === "text") {
     return [{ type: "inputText", text: content.text }];
   }
+  const imageUrl = sanitizeInlineImageDataUrl(`data:${content.mimeType};base64,${content.data}`);
+  if (!imageUrl) {
+    return [{ type: "inputText", text: invalidInlineImageText("codex dynamic tool") }];
+  }
   return [
     {
       type: "inputImage",
-      imageUrl: `data:${content.mimeType};base64,${content.data}`,
+      imageUrl,
     },
   ];
 }

--- a/extensions/codex/src/app-server/image-payload-sanitizer.test.ts
+++ b/extensions/codex/src/app-server/image-payload-sanitizer.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  invalidInlineImageText,
+  sanitizeCodexHistoryImagePayloads,
+  sanitizeInlineImageDataUrl,
+} from "./image-payload-sanitizer.js";
+
+const PNG_1X1 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=";
+
+describe("Codex app-server image payload sanitizer", () => {
+  it("drops malformed data URL image payloads", () => {
+    expect(sanitizeInlineImageDataUrl("data:image/jpeg;base64,not base64!")).toBeUndefined();
+  });
+
+  it("canonicalizes valid data URL images with sniffed MIME type", () => {
+    expect(sanitizeInlineImageDataUrl(`data:image/jpeg;base64,\n${PNG_1X1}`)).toBe(
+      `data:image/png;base64,${PNG_1X1}`,
+    );
+  });
+
+  it("formats the text replacement used for invalid images", () => {
+    expect(invalidInlineImageText("codex user input")).toContain("invalid inline image data");
+  });
+
+  it("scrubs invalid image blocks from mirrored history values", () => {
+    expect(
+      sanitizeCodexHistoryImagePayloads(
+        [
+          {
+            role: "toolResult",
+            content: [{ type: "image", mimeType: "image/jpeg", data: "not base64!" }],
+          },
+        ],
+        "codex mirrored history",
+      ),
+    ).toEqual([
+      {
+        role: "toolResult",
+        content: [
+          {
+            type: "text",
+            text: "[codex mirrored history] omitted image payload: invalid inline image data",
+          },
+        ],
+      },
+    ]);
+  });
+});

--- a/extensions/codex/src/app-server/image-payload-sanitizer.ts
+++ b/extensions/codex/src/app-server/image-payload-sanitizer.ts
@@ -1,0 +1,167 @@
+const DATA_URL_PREFIX = "data:";
+const IMAGE_OMITTED_TEXT = "omitted image payload: invalid inline image data";
+
+function startsWithDataUrl(value: string): boolean {
+  return value.slice(0, DATA_URL_PREFIX.length).toLowerCase() === DATA_URL_PREFIX;
+}
+
+function canonicalizeBase64(base64: string): string | undefined {
+  let cleaned = "";
+  let padding = 0;
+  let sawPadding = false;
+  for (let i = 0; i < base64.length; i += 1) {
+    const code = base64.charCodeAt(i);
+    if (code <= 0x20) {
+      continue;
+    }
+    if (code === 0x3d) {
+      padding += 1;
+      if (padding > 2) {
+        return undefined;
+      }
+      sawPadding = true;
+      cleaned += "=";
+      continue;
+    }
+    const isBase64DataChar =
+      (code >= 0x41 && code <= 0x5a) ||
+      (code >= 0x61 && code <= 0x7a) ||
+      (code >= 0x30 && code <= 0x39) ||
+      code === 0x2b ||
+      code === 0x2f;
+    if (sawPadding || !isBase64DataChar) {
+      return undefined;
+    }
+    cleaned += base64[i];
+  }
+  if (!cleaned || cleaned.length % 4 !== 0) {
+    return undefined;
+  }
+  return cleaned;
+}
+
+function sniffImageMime(buffer: Buffer): string | undefined {
+  if (
+    buffer.length >= 8 &&
+    buffer[0] === 0x89 &&
+    buffer[1] === 0x50 &&
+    buffer[2] === 0x4e &&
+    buffer[3] === 0x47 &&
+    buffer[4] === 0x0d &&
+    buffer[5] === 0x0a &&
+    buffer[6] === 0x1a &&
+    buffer[7] === 0x0a
+  ) {
+    return "image/png";
+  }
+  if (buffer.length >= 3 && buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) {
+    return "image/jpeg";
+  }
+  if (
+    buffer.length >= 12 &&
+    buffer.subarray(0, 4).toString("ascii") === "RIFF" &&
+    buffer.subarray(8, 12).toString("ascii") === "WEBP"
+  ) {
+    return "image/webp";
+  }
+  if (
+    buffer.length >= 6 &&
+    (buffer.subarray(0, 6).toString("ascii") === "GIF87a" ||
+      buffer.subarray(0, 6).toString("ascii") === "GIF89a")
+  ) {
+    return "image/gif";
+  }
+  return undefined;
+}
+
+export function sanitizeInlineImageDataUrl(imageUrl: string): string | undefined {
+  if (!startsWithDataUrl(imageUrl)) {
+    return imageUrl;
+  }
+  const commaIndex = imageUrl.indexOf(",");
+  if (commaIndex < 0) {
+    return undefined;
+  }
+
+  const metadata = imageUrl.slice(DATA_URL_PREFIX.length, commaIndex);
+  const payload = imageUrl.slice(commaIndex + 1);
+  const metadataParts = metadata.split(";").map((part) => part.trim());
+  const declaredMimeType = metadataParts[0]?.toLowerCase();
+  if (!declaredMimeType?.startsWith("image/")) {
+    return undefined;
+  }
+  if (!metadataParts.slice(1).some((part) => part.toLowerCase() === "base64")) {
+    return undefined;
+  }
+
+  const canonicalPayload = canonicalizeBase64(payload);
+  if (!canonicalPayload) {
+    return undefined;
+  }
+  const sniffedMimeType = sniffImageMime(Buffer.from(canonicalPayload, "base64"));
+  if (!sniffedMimeType) {
+    return undefined;
+  }
+  return `data:${sniffedMimeType};base64,${canonicalPayload}`;
+}
+
+export function invalidInlineImageText(label: string): string {
+  return `[${label}] ${IMAGE_OMITTED_TEXT}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function sanitizeImageContentRecord(
+  record: Record<string, unknown>,
+  label: string,
+): Record<string, unknown> | undefined {
+  if (record.type === "image" && typeof record.data === "string") {
+    const mimeType = typeof record.mimeType === "string" ? record.mimeType : "image/png";
+    const imageUrl = sanitizeInlineImageDataUrl(`data:${mimeType};base64,${record.data}`);
+    if (!imageUrl) {
+      return { type: "text", text: invalidInlineImageText(label) };
+    }
+    const commaIndex = imageUrl.indexOf(",");
+    const metadata = imageUrl.slice(DATA_URL_PREFIX.length, commaIndex);
+    const mime = metadata.split(";")[0] ?? mimeType;
+    return { ...record, mimeType: mime, data: imageUrl.slice(commaIndex + 1) };
+  }
+
+  if (record.type === "inputImage" && typeof record.imageUrl === "string") {
+    const imageUrl = sanitizeInlineImageDataUrl(record.imageUrl);
+    return imageUrl
+      ? { ...record, imageUrl }
+      : { type: "inputText", text: invalidInlineImageText(label) };
+  }
+
+  if (record.type === "input_image" && typeof record.image_url === "string") {
+    const imageUrl = sanitizeInlineImageDataUrl(record.image_url);
+    return imageUrl
+      ? { ...record, image_url: imageUrl }
+      : { type: "input_text", text: invalidInlineImageText(label) };
+  }
+
+  return undefined;
+}
+
+export function sanitizeCodexHistoryImagePayloads<T>(value: T, label: string): T {
+  if (Array.isArray(value)) {
+    return value.map((entry) => sanitizeCodexHistoryImagePayloads(entry, label)) as T;
+  }
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  const imageRecord = sanitizeImageContentRecord(value, label);
+  if (imageRecord) {
+    return imageRecord as T;
+  }
+
+  const next: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value)) {
+    next[key] = sanitizeCodexHistoryImagePayloads(child, label);
+  }
+  return next as T;
+}

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -4130,6 +4130,66 @@ describe("runCodexAppServerAttempt", () => {
     expect(nativeHookRelayTesting.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
   });
 
+  it("preserves a healthy binding when invalid image cleanup hits a transient thread", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    await writeExistingBinding(sessionFile, workspaceDir, {
+      dynamicToolsFingerprint: JSON.stringify([{ name: "message" }]),
+    });
+    const harness = createStartedThreadHarness(async (method) => {
+      if (method === "thread/start") {
+        return threadStartResult("thread-transient");
+      }
+      if (method === "turn/start") {
+        throw new Error("invalid image_url base64 payload");
+      }
+      return undefined;
+    });
+
+    await expect(runCodexAppServerAttempt(createParams(sessionFile, workspaceDir))).rejects.toThrow(
+      "invalid image_url base64 payload",
+    );
+
+    expect(harness.requests.map((request) => request.method)).toEqual([
+      "thread/start",
+      "turn/start",
+    ]);
+    const binding = await readCodexAppServerBinding(sessionFile);
+    expect(binding?.threadId).toBe("thread-existing");
+  });
+
+  it("preserves a healthy binding when the server rejects unsupported image input", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    await writeExistingBinding(sessionFile, workspaceDir, { dynamicToolsFingerprint: "[]" });
+    const harness = createAppServerHarness(async (method) => {
+      if (method === "thread/resume") {
+        return threadStartResult("thread-existing");
+      }
+      if (method === "turn/start") {
+        throw new Error("unsupported image input");
+      }
+      return {};
+    });
+
+    await expect(runCodexAppServerAttempt(createParams(sessionFile, workspaceDir))).rejects.toThrow(
+      "unsupported image input",
+    );
+
+    expect(harness.requests.map((request) => request.method)).toEqual([
+      "thread/resume",
+      "turn/start",
+    ]);
+    const binding = await readCodexAppServerBinding(sessionFile);
+    expect(binding?.threadId).toBe("thread-existing");
+  });
+
+  it("recognizes invalid image payload errors without matching unsupported image input", () => {
+    expect(__testing.isInvalidCodexImagePayloadError("invalid_image_url")).toBe(true);
+    expect(__testing.isInvalidCodexImagePayloadError("malformed-base64 image payload")).toBe(true);
+    expect(__testing.isInvalidCodexImagePayloadError("unsupported image input")).toBe(false);
+  });
+
   it("preserves Codex usage-limit reset details when turn/start fails", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
@@ -4809,12 +4869,14 @@ describe("runCodexAppServerAttempt", () => {
       path.join(tempDir, "session.jsonl"),
       path.join(tempDir, "workspace"),
     );
+    const pngBase64 =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=";
     params.model = createCodexTestModel("codex", ["text", "image"]);
     params.images = [
       {
         type: "image",
         mimeType: "image/png",
-        data: "aW1hZ2UtYnl0ZXM=",
+        data: pngBase64,
       },
     ];
 
@@ -4829,7 +4891,7 @@ describe("runCodexAppServerAttempt", () => {
       | undefined;
     expect(turnStartParams?.input).toEqual([
       { type: "text", text: "hello", text_elements: [] },
-      { type: "image", url: "data:image/png;base64,aW1hZ2UtYnl0ZXM=" },
+      { type: "image", url: `data:image/png;base64,${pngBase64}` },
     ]);
   });
 

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -1969,6 +1969,13 @@ export async function runCodexAppServerAttempt(
         signal: runAbortController.signal,
       });
       const turnStartErrorMessage = usageLimitError?.message ?? formatErrorMessage(turnStartError);
+      if (isInvalidCodexImagePayloadError(turnStartErrorMessage)) {
+        await clearCodexBindingAfterInvalidImagePayload(activeSessionFile, {
+          phase: "turn_start",
+          threadId: thread.threadId,
+          error: turnStartErrorMessage,
+        });
+      }
       emitCodexAppServerEvent(params, {
         stream: "codex_app_server.lifecycle",
         data: { phase: "turn_start_failed", error: turnStartErrorMessage },
@@ -2170,6 +2177,14 @@ export async function runCodexAppServerAttempt(
         : finalPromptError
           ? formatErrorMessage(finalPromptError)
           : undefined;
+    if (isInvalidCodexImagePayloadError(finalPromptErrorMessage)) {
+      await clearCodexBindingAfterInvalidImagePayload(activeSessionFile, {
+        phase: "turn_completed",
+        threadId: thread.threadId,
+        turnId: activeTurnId,
+        error: finalPromptErrorMessage,
+      });
+    }
     if (shouldRefreshCodexRateLimitsForUsageLimitMessage(finalPromptErrorMessage)) {
       finalPromptError = await refreshCodexUsageLimitErrorMessage({
         client,
@@ -3181,6 +3196,38 @@ function readCodexErrorPayload(error: unknown): {
   };
 }
 
+function isInvalidCodexImagePayloadError(message: unknown): boolean {
+  if (typeof message !== "string" || !message.trim()) {
+    return false;
+  }
+  const normalizedMessage = message.replace(/[_-]+/gu, " ");
+  return (
+    /\b(?:invalid|malformed)\b[\s\S]{0,120}\b(?:image|image url|base64)\b/iu.test(
+      normalizedMessage,
+    ) ||
+    /\b(?:image|image url|base64)\b[\s\S]{0,120}\b(?:invalid|malformed)\b/iu.test(normalizedMessage)
+  );
+}
+
+async function clearCodexBindingAfterInvalidImagePayload(
+  sessionFile: string,
+  fields: { phase: string; threadId?: string; turnId?: string; error?: string },
+): Promise<void> {
+  const currentBinding = await readCodexAppServerBinding(sessionFile);
+  if (fields.threadId && currentBinding && currentBinding.threadId !== fields.threadId) {
+    embeddedAgentLog.warn(
+      "codex app-server image payload error detected for unbound thread; preserving thread binding",
+      { ...fields, boundThreadId: currentBinding.threadId },
+    );
+    return;
+  }
+  embeddedAgentLog.warn(
+    "codex app-server image payload error detected; clearing thread binding",
+    fields,
+  );
+  await clearCodexAppServerBinding(sessionFile);
+}
+
 function describeNotificationActivity(
   notification: CodexServerNotification,
 ): Record<string, unknown> | undefined {
@@ -3881,6 +3928,7 @@ export const __testing = {
   filterCodexDynamicToolsForAllowlist,
   filterToolsForVisionInputs,
   handleDynamicToolCallWithTimeout,
+  isInvalidCodexImagePayloadError,
   remapCodexContextFilePath,
   resolveDynamicToolCallTimeoutMs,
   restrictCodexAppServerSandboxForOpenClawSandbox,

--- a/extensions/codex/src/app-server/session-history.ts
+++ b/extensions/codex/src/app-server/session-history.ts
@@ -6,6 +6,7 @@ import {
   parseSessionEntries,
 } from "@earendil-works/pi-coding-agent";
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { sanitizeCodexHistoryImagePayloads } from "./image-payload-sanitizer.js";
 
 function isMissingFileError(error: unknown): boolean {
   return Boolean(
@@ -30,7 +31,10 @@ export async function readCodexMirroredSessionHistoryMessages(
     const sessionEntries = entries.filter(
       (entry): entry is SessionEntry => entry.type !== "session",
     );
-    return buildSessionContext(sessionEntries).messages;
+    return sanitizeCodexHistoryImagePayloads(
+      buildSessionContext(sessionEntries).messages,
+      "codex mirrored history",
+    );
   } catch (error) {
     if (isMissingFileError(error)) {
       return [];

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -1,6 +1,7 @@
 import type { EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { describe, expect, it } from "vitest";
 import {
+  buildTurnStartParams,
   buildThreadResumeParams,
   buildThreadStartParams,
   resolveReasoningEffort,
@@ -13,6 +14,7 @@ function createAttemptParams(params: {
   authProfileProviders?: Record<string, string>;
   bootstrapContextMode?: "full" | "lightweight";
   bootstrapContextRunKind?: "default" | "heartbeat" | "cron";
+  images?: EmbeddedRunAttemptParams["images"];
 }): EmbeddedRunAttemptParams {
   const authProfileProviders =
     params.authProfileProviders ??
@@ -22,11 +24,13 @@ function createAttemptParams(params: {
   return {
     provider: params.provider,
     modelId: "gpt-5.4",
+    prompt: "test prompt",
     authProfileId: params.authProfileId,
     ...(params.bootstrapContextMode ? { bootstrapContextMode: params.bootstrapContextMode } : {}),
     ...(params.bootstrapContextRunKind
       ? { bootstrapContextRunKind: params.bootstrapContextRunKind }
       : {}),
+    ...(params.images ? { images: params.images } : {}),
     authProfileStore: {
       version: 1,
       profiles: Object.fromEntries(
@@ -132,6 +136,31 @@ describe("Codex app-server native code mode config", () => {
       "features.code_mode": true,
       "features.code_mode_only": true,
     });
+  });
+});
+
+describe("Codex app-server turn input image sanitizing", () => {
+  it("replaces malformed inline images before turn/start", () => {
+    const request = buildTurnStartParams(
+      createAttemptParams({
+        provider: "openai",
+        images: [{ type: "image", mimeType: "image/jpeg", data: "not base64!" }] as never,
+      }),
+      {
+        threadId: "thread-1",
+        cwd: "/repo",
+        appServer: createAppServerOptions() as never,
+      },
+    );
+
+    expect(request.input).toEqual([
+      { type: "text", text: "test prompt", text_elements: [] },
+      {
+        type: "text",
+        text: "[codex user input] omitted image payload: invalid inline image data",
+        text_elements: [],
+      },
+    ]);
   });
 });
 

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -15,6 +15,7 @@ import {
   resolveCodexContextEngineProjectionMaxChars,
   resolveCodexContextEngineProjectionReserveTokens,
 } from "./context-engine-projection.js";
+import { invalidInlineImageText, sanitizeInlineImageDataUrl } from "./image-payload-sanitizer.js";
 import {
   isCodexPluginThreadBindingStale,
   mergeCodexThreadConfigs,
@@ -803,15 +804,17 @@ function buildUserInput(
   params: EmbeddedRunAttemptParams,
   promptText: string = params.prompt,
 ): CodexUserInput[] {
-  return [
-    { type: "text", text: promptText, text_elements: [] },
-    ...(params.images ?? []).map(
-      (image): CodexUserInput => ({
-        type: "image",
-        url: `data:${image.mimeType};base64,${image.data}`,
-      }),
-    ),
-  ];
+  const imageInputs = (params.images ?? []).map((image): CodexUserInput => {
+    const imageUrl = sanitizeInlineImageDataUrl(`data:${image.mimeType};base64,${image.data}`);
+    return imageUrl
+      ? { type: "image", url: imageUrl }
+      : {
+          type: "text",
+          text: invalidInlineImageText("codex user input"),
+          text_elements: [],
+        };
+  });
+  return [{ type: "text", text: promptText, text_elements: [] }, ...imageInputs];
 }
 
 export function resolveCodexAppServerModelProvider(params: {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -66,6 +66,7 @@ import {
   buildGuardedModelFetch,
   resolveModelRequestTimeoutMs,
 } from "./provider-transport-fetch.js";
+import { sanitizeResponsesImagePayload } from "./responses-image-payload-sanitizer.js";
 import { stripSystemPromptCacheBoundary } from "./system-prompt-cache-boundary.js";
 import { transformTransportMessages } from "./transport-message-transform.js";
 import { mergeTransportMetadata, sanitizeTransportPayloadText } from "./transport-stream-shared.js";
@@ -1450,6 +1451,7 @@ export function createOpenAIResponsesTransportStreamFn(): StreamFn {
           model,
           params as Record<string, unknown>,
         ) as typeof params;
+        params = sanitizeResponsesImagePayload(params as Record<string, unknown>) as typeof params;
         if (
           (options as { openclawCodeModeToolSurface?: unknown } | undefined)
             ?.openclawCodeModeToolSurface === true
@@ -1849,6 +1851,7 @@ export function createAzureOpenAIResponsesTransportStreamFn(): StreamFn {
           model,
           params as Record<string, unknown>,
         ) as typeof params;
+        params = sanitizeResponsesImagePayload(params as Record<string, unknown>) as typeof params;
         if (
           (options as { openclawCodeModeToolSurface?: unknown } | undefined)
             ?.openclawCodeModeToolSurface === true

--- a/src/agents/responses-image-payload-sanitizer.test.ts
+++ b/src/agents/responses-image-payload-sanitizer.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeResponsesImagePayload } from "./responses-image-payload-sanitizer.js";
+
+const PNG_1X1 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=";
+
+describe("Responses image payload sanitizer", () => {
+  it("replaces malformed input_image data URLs before sending Responses payloads", () => {
+    const sanitized = sanitizeResponsesImagePayload({
+      input: [
+        {
+          type: "function_call_output",
+          call_id: "call_1",
+          output: [{ type: "input_image", image_url: "data:image/jpeg;base64,not base64!" }],
+        },
+      ],
+    });
+
+    expect(sanitized.input).toEqual([
+      {
+        type: "function_call_output",
+        call_id: "call_1",
+        output: [
+          {
+            type: "input_text",
+            text: "[omitted image payload: invalid inline image data]",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("canonicalizes valid inline image payloads and keeps URL image references", () => {
+    const sanitized = sanitizeResponsesImagePayload({
+      input: [
+        {
+          type: "message",
+          role: "user",
+          content: [
+            { type: "input_image", image_url: `data:image/jpeg;base64,\n${PNG_1X1}` },
+            { type: "input_image", image_url: "https://example.test/image.png" },
+          ],
+        },
+      ],
+    });
+
+    expect(sanitized.input).toEqual([
+      {
+        type: "message",
+        role: "user",
+        content: [
+          { type: "input_image", image_url: `data:image/png;base64,${PNG_1X1}` },
+          { type: "input_image", image_url: "https://example.test/image.png" },
+        ],
+      },
+    ]);
+  });
+});

--- a/src/agents/responses-image-payload-sanitizer.ts
+++ b/src/agents/responses-image-payload-sanitizer.ts
@@ -1,0 +1,121 @@
+import { canonicalizeBase64 } from "../media/base64.js";
+
+const DATA_URL_PREFIX = "data:";
+const IMAGE_OMITTED_TEXT = "omitted image payload: invalid inline image data";
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function startsWithDataUrl(value: string): boolean {
+  return value.slice(0, DATA_URL_PREFIX.length).toLowerCase() === DATA_URL_PREFIX;
+}
+
+function sniffImageMime(buffer: Buffer): string | undefined {
+  if (
+    buffer.length >= 8 &&
+    buffer[0] === 0x89 &&
+    buffer[1] === 0x50 &&
+    buffer[2] === 0x4e &&
+    buffer[3] === 0x47 &&
+    buffer[4] === 0x0d &&
+    buffer[5] === 0x0a &&
+    buffer[6] === 0x1a &&
+    buffer[7] === 0x0a
+  ) {
+    return "image/png";
+  }
+  if (buffer.length >= 3 && buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) {
+    return "image/jpeg";
+  }
+  if (
+    buffer.length >= 12 &&
+    buffer.subarray(0, 4).toString("ascii") === "RIFF" &&
+    buffer.subarray(8, 12).toString("ascii") === "WEBP"
+  ) {
+    return "image/webp";
+  }
+  if (
+    buffer.length >= 6 &&
+    (buffer.subarray(0, 6).toString("ascii") === "GIF87a" ||
+      buffer.subarray(0, 6).toString("ascii") === "GIF89a")
+  ) {
+    return "image/gif";
+  }
+  return undefined;
+}
+
+function sanitizeImageUrl(imageUrl: string): string | undefined {
+  if (!startsWithDataUrl(imageUrl)) {
+    return imageUrl;
+  }
+  const commaIndex = imageUrl.indexOf(",");
+  if (commaIndex < 0) {
+    return undefined;
+  }
+
+  const metadata = imageUrl.slice(DATA_URL_PREFIX.length, commaIndex);
+  const payload = imageUrl.slice(commaIndex + 1);
+  const metadataParts = metadata.split(";").map((part) => part.trim());
+  const declaredMimeType = metadataParts[0]?.toLowerCase();
+  if (!declaredMimeType?.startsWith("image/")) {
+    return undefined;
+  }
+  if (!metadataParts.slice(1).some((part) => part.toLowerCase() === "base64")) {
+    return undefined;
+  }
+
+  const canonicalPayload = canonicalizeBase64(payload);
+  if (!canonicalPayload) {
+    return undefined;
+  }
+  const sniffedMimeType = sniffImageMime(Buffer.from(canonicalPayload, "base64"));
+  if (!sniffedMimeType) {
+    return undefined;
+  }
+  return `data:${sniffedMimeType};base64,${canonicalPayload}`;
+}
+
+function invalidSnakeImage(): JsonRecord {
+  return { type: "input_text", text: `[${IMAGE_OMITTED_TEXT}]` };
+}
+
+function sanitizeValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sanitizeValue);
+  }
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  if (value.type === "input_image" && typeof value.image_url === "string") {
+    const imageUrl = sanitizeImageUrl(value.image_url);
+    return imageUrl ? { ...value, image_url: imageUrl } : invalidSnakeImage();
+  }
+
+  const next: JsonRecord = {};
+  for (const [key, child] of Object.entries(value)) {
+    next[key] = sanitizeValue(child);
+  }
+  return next;
+}
+
+export function sanitizeResponsesImagePayload<T extends Record<string, unknown>>(params: T): T {
+  if (!Array.isArray(params.input)) {
+    return params;
+  }
+  return {
+    ...params,
+    input: sanitizeValue(params.input),
+  };
+}
+
+export function sanitizeInlineImageDataUrl(imageUrl: string): string | undefined {
+  return sanitizeImageUrl(imageUrl);
+}
+
+export function invalidInlineImageText(label: string): string {
+  return `[${label}] ${IMAGE_OMITTED_TEXT}`;
+}


### PR DESCRIPTION
## Summary
- sanitize inline image data URLs before Codex app-server user input, dynamic tool output, mirrored history, and OpenAI Responses replay
- replace invalid inline images with text placeholders so malformed base64 is not resent as Responses image_url content
- clear Codex thread bindings only for invalid or malformed image payload errors, while preserving healthy bindings for transient or unsupported-image failures

## Verification
- pnpm test src/agents/responses-image-payload-sanitizer.test.ts extensions/codex/src/app-server/image-payload-sanitizer.test.ts extensions/codex/src/app-server/thread-lifecycle.test.ts extensions/codex/src/app-server/run-attempt.test.ts
- node scripts/run-vitest.mjs extensions/codex/src/app-server/image-payload-sanitizer.test.ts src/agents/responses-image-payload-sanitizer.test.ts extensions/codex/src/app-server/thread-lifecycle.test.ts extensions/codex/src/app-server/run-attempt.test.ts
- node --import tsx -e image sanitizer runtime probe
- git diff --check
- git diff --cached --check
- node scripts/check-changelog-attributions.mjs
- codex-review --mode local: clean, no accepted or actionable findings
- pnpm check:changed via Testbox tbx_01krt43hsywet096r8qhx10749: blocked by unrelated Telegram type errors in extensions/telegram/src/message-cache.ts on current main

## Real behavior proof
Behavior addressed: invalid or malformed inline image data is replaced before Codex app-server and OpenAI Responses replay, preventing poisoned image_url payloads from being resent.
Real environment tested: local OpenClaw checkout on the rebased PR branch, using the real TypeScript sanitizer modules through node --import tsx.
Exact steps or command run after this patch: ran a node --import tsx probe that imported the Codex app-server sanitizer and Responses sanitizer, sent one malformed inline JPEG data URL and one valid PNG payload, then printed the sanitized runtime output.
Evidence after fix: terminal output from the runtime probe:

```json
{
  "appInvalid": null,
  "appPlaceholder": "[codex user input] omitted image payload: invalid inline image data",
  "appValidPrefix": "data:image/png;base64,iVBORw0KGg",
  "responsesOutput": {
    "type": "input_text",
    "text": "[omitted image payload: invalid inline image data]"
  }
}
```

Observed result after fix: the malformed image is rejected by the app-server sanitizer, the app-server replacement text is emitted, the valid PNG data URL is canonicalized to image/png, and the OpenAI Responses replay item is converted from input_image to input_text.
What was not tested: live provider replay against OpenAI/Codex app-server; broad changed check remained blocked by unrelated Telegram type errors on current main.

Fixes #82878
