### PR TITLE
fix(install): align install-cli.sh Node default to 24.15.0

### DIFF
--- a/docs/install/installer.md
+++ b/docs/install/installer.md
@@ -245,7 +245,7 @@ by default, plus git-checkout installs under the same prefix flow.
 | `--git`, `--github`         | Shortcut for git method                                                         |
 | `--git-dir <path>`          | Git checkout directory (default: `~/openclaw`). Alias: `--dir`                  |
 | `--version <ver>`           | OpenClaw version or dist-tag (default: `latest`)                                |
-| `--node-version <ver>`      | Node version (default: `22.22.0`)                                               |
+| `--node-version <ver>`      | Node version (default: `24.15.0`)                                               |
 | `--json`                    | Emit NDJSON events                                                              |
 | `--onboard`                 | Run `openclaw onboard` after install                                            |
 | `--no-onboard`              | Skip onboarding (default)                                                       |

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -31,7 +31,7 @@ ensure_home_env
 
 PREFIX="${OPENCLAW_PREFIX:-${HOME}/.openclaw}"
 OPENCLAW_VERSION="${OPENCLAW_VERSION:-latest}"
-NODE_VERSION="${OPENCLAW_NODE_VERSION:-22.22.0}"
+NODE_VERSION="${OPENCLAW_NODE_VERSION:-24.15.0}"
 SHARP_IGNORE_GLOBAL_LIBVIPS="${SHARP_IGNORE_GLOBAL_LIBVIPS:-1}"
 NPM_LOGLEVEL="${OPENCLAW_NPM_LOGLEVEL:-error}"
 INSTALL_METHOD="${OPENCLAW_INSTALL_METHOD:-npm}"
@@ -52,7 +52,7 @@ Usage: install-cli.sh [options]
   --git, --github                     Shortcut for --install-method git
   --git-dir, --dir <path>             Checkout directory (default: ~/openclaw)
   --version <ver>                     OpenClaw version (default: latest)
-  --node-version <ver>                Node version (default: 22.22.0)
+  --node-version <ver>                Node version (default: 24.15.0)
   --onboard                           Run "openclaw onboard" after install
   --no-onboard                        Skip onboarding (default)
   --set-npm-prefix                    Force npm prefix to ~/.npm-global if current prefix is not writable (Linux)


### PR DESCRIPTION
## Problem

`install.sh` defaults to Node 24 (`NODE_DEFAULT_MAJOR=24`) and docs recommend Node 24, but `install-cli.sh` defaults to Node 22.22.0 (`OPENCLAW_NODE_VERSION:-22.22.0`). This mismatch means:

- Users following the main installer get Node 24
- Users using local-prefix install get Node 22
- Native modules rebuilt with the shell Node (24) produce ABI errors when loaded by the managed Node (22):
  ```
  NODE_MODULE_VERSION 137
  This version of Node.js requires NODE_MODULE_VERSION 127
  ```

## Fix

Update `install-cli.sh` default from `22.22.0` to `24.15.0` (current Node 24 LTS), matching `install.sh` and the docs recommendation. Users can still pin a specific version via `--node-version` or `OPENCLAW_NODE_VERSION`.

Fixes #79558

## Real behavior proof
Behavior addressed: install-cli.sh now defaults to Node 24.15.0, matching install.sh and eliminating the Node 22 vs 24 mismatch that caused native module ABI errors.
Real environment tested: Linux (Ubuntu 24.04, WSL2), Node.js v22.16.0, patched source checkout at `/tmp/fix-82932` (commit ac1399).

Exact steps or command run after this patch:
Step 1 -- verify the default value in the patched install-cli.sh. Step 2 -- run the installer help to show the new default. Step 3 -- cross-reference with install.sh to confirm alignment.

Evidence after fix: terminal output copied below.

**Patched install-cli.sh default:**
```console
$ grep "NODE_VERSION=" scripts/install-cli.sh | head -1
NODE_VERSION="${OPENCLAW_NODE_VERSION:-24.15.0}"
```

**Help output confirms new default:**
```console
$ bash scripts/install-cli.sh --help 2>&1 | grep "node-version"
  --node-version <ver>                Node version (default: 24.15.0)
```

**Cross-reference with install.sh (already uses Node 24):**
```console
$ grep NODE_DEFAULT_MAJOR scripts/install.sh | head -1
NODE_DEFAULT_MAJOR=24
```

**Docs match:**
```console
$ grep "node-version" docs/install/installer.md
| `--node-version <ver>`      | Node version (default: `24.15.0`)                                               |
```

**Syntax validation:**
```console
$ bash -n scripts/install-cli.sh && echo "syntax valid"
syntax valid
```

Observed result after fix: Both installer paths (`install.sh` and `install-cli.sh`) now default to Node 24. The help text, source default, and documentation all show `24.15.0`. Before the fix, `install-cli.sh` defaulted to `22.22.0` while `install.sh` used `NODE_DEFAULT_MAJOR=24`, causing version mismatch and potential native module ABI errors.

What was not tested: Actual local-prefix install with the new default (would require removing the existing Node installation). The fix is a default value change only; the Node download and installation logic is unchanged.


