### PR TITLE
fix: dedupe OpenAI strict schema downgrade diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents: filter silent heartbeat response-tool transcript artifacts out of embedded context snapshots so later user turns are not polluted by heartbeat no-op messages. (#83477) Thanks @fuller-stack-dev.
+- Agents/OpenAI: log repeated strict tool-schema downgrade diagnostics once per provider/model/tool signature, reducing duplicate debug noise while preserving `strict=false` fallback behavior. Fixes #82930. (#82933) Thanks @galiniliev.
 - Agents/code mode: spell out the `exec` tool's JavaScript/TypeScript, no Node module, and catalog-bridge constraints in model-visible schema text so agents can use enabled tools without trial-and-error. (#84269) Thanks @Kaspre.
 - Codex: give `image_generate` dynamic-tool calls a 120s default watchdog when no per-call or configured image timeout is set, so image generation no longer falls back to the generic 30s bridge timeout. (#84254) Thanks @moritzmmayerhofer.
 - Codex: avoid duplicate dynamic tool terminal diagnostics while large diagnostic backlogs drain without blocking tool responses. (#82937) Thanks @galiniliev.

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -3015,6 +3015,45 @@ describe("openai transport stream", () => {
     expect(params.tools?.[0]?.strict).toBe(false);
   });
 
+  it("deduplicates repeated OpenAI strict schema downgrade diagnostics", () => {
+    const model = {
+      id: "gpt-5.4",
+      name: "GPT-5.4",
+      api: "openai-responses",
+      provider: "openai",
+      baseUrl: "https://api.openai.com/v1",
+      reasoning: true,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200000,
+      maxTokens: 8192,
+    } satisfies Model<"openai-responses">;
+    const diagnostic = {
+      toolIndex: 0,
+      toolName: "read",
+      violations: ["read.parameters.required.path"],
+    };
+    const diagnostics = [diagnostic];
+    const context = { transport: "responses" as const, model };
+
+    __testing.resetOpenAIStrictToolDowngradeDiagnosticLogCache();
+    expect(__testing.shouldLogOpenAIStrictToolDowngradeDiagnostic(diagnostics, context)).toBe(true);
+    expect(__testing.shouldLogOpenAIStrictToolDowngradeDiagnostic(diagnostics, context)).toBe(
+      false,
+    );
+    expect(
+      __testing.shouldLogOpenAIStrictToolDowngradeDiagnostic(
+        [
+          {
+            ...diagnostic,
+            violations: ["read.parameters.additionalProperties"],
+          },
+        ],
+        context,
+      ),
+    ).toBe(true);
+  });
+
   it("omits responses strict tool shaping for proxy-like OpenAI routes", () => {
     const params = buildOpenAIResponsesParams(
       {

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -3015,41 +3015,80 @@ describe("openai transport stream", () => {
     expect(params.tools?.[0]?.strict).toBe(false);
   });
 
-  it("deduplicates repeated OpenAI strict schema downgrade diagnostics", () => {
-    const model = {
-      id: "gpt-5.4",
-      name: "GPT-5.4",
-      api: "openai-responses",
-      provider: "openai",
-      baseUrl: "https://api.openai.com/v1",
-      reasoning: true,
-      input: ["text"],
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: 200000,
-      maxTokens: 8192,
-    } satisfies Model<"openai-responses">;
-    const diagnostic = {
-      toolIndex: 0,
-      toolName: "read",
-      violations: ["read.parameters.required.path"],
+  it("deduplicates repeated OpenAI strict schema downgrade diagnostics", async () => {
+    const debug = vi.fn();
+    const logger = {
+      subsystem: "openai-transport",
+      isEnabled: vi.fn((level: string, target?: string) => level === "debug" && target === "any"),
+      trace: vi.fn(),
+      debug,
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      fatal: vi.fn(),
+      raw: vi.fn(),
+      child: vi.fn(),
     };
-    const diagnostics = [diagnostic];
-    const context = { transport: "responses" as const, model };
+    logger.child.mockReturnValue(logger);
 
-    testing.resetOpenAIStrictToolDowngradeDiagnosticLogCache();
-    expect(testing.shouldLogOpenAIStrictToolDowngradeDiagnostic(diagnostics, context)).toBe(true);
-    expect(testing.shouldLogOpenAIStrictToolDowngradeDiagnostic(diagnostics, context)).toBe(false);
-    expect(
-      testing.shouldLogOpenAIStrictToolDowngradeDiagnostic(
-        [
+    vi.resetModules();
+    vi.doMock("../logging/subsystem.js", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("../logging/subsystem.js")>()),
+      createSubsystemLogger: vi.fn(() => logger),
+    }));
+
+    try {
+      const { buildOpenAIResponsesParams: isolatedBuildOpenAIResponsesParams } =
+        await import("./openai-transport-stream.js");
+      const model = {
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        api: "openai-responses",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-responses">;
+      const context = {
+        systemPrompt: "system",
+        messages: [],
+        tools: [
           {
-            ...diagnostic,
-            violations: ["read.parameters.additionalProperties"],
+            name: "read",
+            description: "Read file",
+            parameters: {
+              type: "object",
+              additionalProperties: false,
+              properties: { path: { type: "string" } },
+              required: [],
+            },
           },
         ],
-        context,
-      ),
-    ).toBe(true);
+      } as never;
+
+      const first = isolatedBuildOpenAIResponsesParams(model, context, undefined) as {
+        tools?: Array<{ strict?: boolean }>;
+      };
+      const second = isolatedBuildOpenAIResponsesParams(model, context, undefined) as {
+        tools?: Array<{ strict?: boolean }>;
+      };
+
+      expect(first.tools?.[0]?.strict).toBe(false);
+      expect(second.tools?.[0]?.strict).toBe(false);
+      expect(
+        debug.mock.calls.filter(
+          ([message]) =>
+            typeof message === "string" &&
+            message.includes("tool schema strict mode downgraded to strict=false"),
+        ),
+      ).toHaveLength(1);
+    } finally {
+      vi.doUnmock("../logging/subsystem.js");
+      vi.resetModules();
+    }
   });
 
   it("omits responses strict tool shaping for proxy-like OpenAI routes", () => {

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -3036,13 +3036,11 @@ describe("openai transport stream", () => {
     const diagnostics = [diagnostic];
     const context = { transport: "responses" as const, model };
 
-    __testing.resetOpenAIStrictToolDowngradeDiagnosticLogCache();
-    expect(__testing.shouldLogOpenAIStrictToolDowngradeDiagnostic(diagnostics, context)).toBe(true);
-    expect(__testing.shouldLogOpenAIStrictToolDowngradeDiagnostic(diagnostics, context)).toBe(
-      false,
-    );
+    testing.resetOpenAIStrictToolDowngradeDiagnosticLogCache();
+    expect(testing.shouldLogOpenAIStrictToolDowngradeDiagnostic(diagnostics, context)).toBe(true);
+    expect(testing.shouldLogOpenAIStrictToolDowngradeDiagnostic(diagnostics, context)).toBe(false);
     expect(
-      __testing.shouldLogOpenAIStrictToolDowngradeDiagnostic(
+      testing.shouldLogOpenAIStrictToolDowngradeDiagnostic(
         [
           {
             ...diagnostic,

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1039,10 +1039,6 @@ function shouldLogOpenAIStrictToolDowngradeDiagnostic(
   return true;
 }
 
-function resetOpenAIStrictToolDowngradeDiagnosticLogCache(): void {
-  loggedOpenAIStrictToolDowngradeDiagnosticKeys.clear();
-}
-
 function createResponsesFirstEventTimeoutError(model: Model<Api>, timeoutMs: number): Error {
   return new Error(
     `Azure OpenAI Responses stream did not deliver a first event within ${timeoutMs}ms after HTTP streaming headers. ` +
@@ -3227,7 +3223,5 @@ export const testing = {
   summarizeResponsesPayload,
   summarizeResponsesTools,
   withResponsesFirstEventTimeout,
-  resetOpenAIStrictToolDowngradeDiagnosticLogCache,
-  shouldLogOpenAIStrictToolDowngradeDiagnostic,
 };
 export { testing as __testing };

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -78,7 +78,9 @@ const AZURE_RESPONSES_FIRST_EVENT_TIMEOUT_MS = 30_000;
 const MODEL_STREAM_COOPERATIVE_YIELD_INTERVAL_MS = 12;
 const MODEL_STREAM_COOPERATIVE_YIELD_MAX_EVENTS = 64;
 const RESPONSE_FAILED_NO_DETAILS_MESSAGE = "Unknown error (no error details in response)";
+const MAX_OPENAI_STRICT_TOOL_DOWNGRADE_DIAGNOSTIC_KEYS = 256;
 const log = createSubsystemLogger("openai-transport");
+const loggedOpenAIStrictToolDowngradeDiagnosticKeys = new Set<string>();
 
 type ReplayableResponseOutputMessage = Omit<ResponseOutputMessage, "id"> & { id?: string };
 type ReplayableResponseReasoningItem = Omit<ResponseReasoningItem, "id"> & { id?: string };
@@ -976,6 +978,9 @@ function resolveOpenAIStrictToolFlagWithDiagnostics(
   const strict = resolveOpenAIStrictToolFlagForInventory(tools, strictSetting);
   if (strictSetting === true && strict === false && log.isEnabled("debug", "any")) {
     const diagnostics = findOpenAIStrictToolSchemaDiagnostics(tools);
+    if (!shouldLogOpenAIStrictToolDowngradeDiagnostic(diagnostics, context)) {
+      return strict;
+    }
     const sample = diagnostics.slice(0, 5).map((entry) => ({
       tool: entry.toolName ?? `tool[${entry.toolIndex}]`,
       violations: entry.violations.slice(0, 8),
@@ -994,6 +999,48 @@ function resolveOpenAIStrictToolFlagWithDiagnostics(
     );
   }
   return strict;
+}
+
+function buildOpenAIStrictToolDowngradeDiagnosticKey(
+  diagnostics: ReturnType<typeof findOpenAIStrictToolSchemaDiagnostics>,
+  context: { transport: "responses" | "completions"; model: OpenAIModeModel },
+): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify({
+        transport: context.transport,
+        provider: context.model.provider ?? null,
+        model: context.model.id ?? null,
+        diagnostics: diagnostics.map((entry) => ({
+          toolIndex: entry.toolIndex,
+          toolName: entry.toolName ?? null,
+          violations: entry.violations,
+        })),
+      }),
+    )
+    .digest("hex");
+}
+
+function shouldLogOpenAIStrictToolDowngradeDiagnostic(
+  diagnostics: ReturnType<typeof findOpenAIStrictToolSchemaDiagnostics>,
+  context: { transport: "responses" | "completions"; model: OpenAIModeModel },
+): boolean {
+  const key = buildOpenAIStrictToolDowngradeDiagnosticKey(diagnostics, context);
+  if (loggedOpenAIStrictToolDowngradeDiagnosticKeys.has(key)) {
+    return false;
+  }
+  if (
+    loggedOpenAIStrictToolDowngradeDiagnosticKeys.size >=
+    MAX_OPENAI_STRICT_TOOL_DOWNGRADE_DIAGNOSTIC_KEYS
+  ) {
+    loggedOpenAIStrictToolDowngradeDiagnosticKeys.clear();
+  }
+  loggedOpenAIStrictToolDowngradeDiagnosticKeys.add(key);
+  return true;
+}
+
+function resetOpenAIStrictToolDowngradeDiagnosticLogCache(): void {
+  loggedOpenAIStrictToolDowngradeDiagnosticKeys.clear();
 }
 
 function createResponsesFirstEventTimeoutError(model: Model<Api>, timeoutMs: number): Error {
@@ -3180,5 +3227,7 @@ export const testing = {
   summarizeResponsesPayload,
   summarizeResponsesTools,
   withResponsesFirstEventTimeout,
+  resetOpenAIStrictToolDowngradeDiagnosticLogCache,
+  shouldLogOpenAIStrictToolDowngradeDiagnostic,
 };
 export { testing as __testing };


### PR DESCRIPTION
## Summary

- Problem: OpenAI/Azure OpenAI strict tool schema downgrade diagnostics repeated on nearly every request when the visible tool inventory was not strict-compatible.
- Why it matters: repeated debug lines hid new provider diagnostics and made the same known downgrade look like fresh failures.
- What changed: the downgrade diagnostic is now keyed by provider/model/transport/tool-violation signature and logged once per unique signature per process.
- What did NOT change (scope boundary): this does not alter strict-mode selection or repair incompatible schemas; incompatible inventories still send `strict=false`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #82930
- Related #80926
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: repeated `OpenAI responses tool schema strict mode downgraded to strict=false` diagnostics for the same Azure OpenAI Responses provider/model/tool-violation signature.
- Real environment tested: local OpenClaw worktree, Node v24.15.0, focused OpenAI transport test file exercising the request-build diagnostic seam with a mocked OpenAI transport logger.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/openai-transport-stream.test.ts --reporter=verbose`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): copied terminal capture:

```text
RUN  v4.1.6

✓ |agents-core| ../../src/agents/openai-transport-stream.test.ts > openai transport stream > deduplicates repeated OpenAI strict schema downgrade diagnostics 256ms
✓ |agents-support| ../../src/agents/openai-transport-stream.test.ts > openai transport stream > deduplicates repeated OpenAI strict schema downgrade diagnostics 180ms

Test Files  2 passed (2)
Tests  338 passed (338)
Duration  16.04s
```

- Observed result after fix: the new regression imports the transport module in isolation with debug logging enabled, calls `buildOpenAIResponsesParams` twice for the same strict-incompatible provider/model/tool signature, verifies both payloads keep `strict=false`, and verifies the mocked logger receives exactly one downgrade diagnostic.
- What was not tested: no live Azure OpenAI Responses rerun was performed because the evidence came from a private affected gateway log/session; private deployment names, session identifiers, local paths, and job names were redacted and not reused publicly.
- Before evidence (optional but encouraged): redacted local log evidence showed 2,068 lines matching `strict mode downgraded`; lines 227, 238, 247, 259, and 268 repeated `OpenAI responses tool schema strict mode downgraded to strict=false for azure-openai-responses/gpt-5.3-codex because 13 tool schema(s) are not strict-compatible` within seconds.

## Root Cause (if applicable)

- Root cause: `resolveOpenAIStrictToolFlagWithDiagnostics` logged every debug-enabled strict downgrade without remembering that the same provider/model/transport/tool-violation set had already been reported.
- Missing detection / guardrail: there was no regression coverage for repeated downgrade diagnostics.
- Contributing context (if known): OpenAI strict schema compatibility is inventory-wide, so one incompatible visible tool inventory can downgrade every request until schemas are fixed or the tool surface changes.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/openai-transport-stream.test.ts`
- Scenario the test should lock in: building the same native OpenAI Responses request twice with the same strict-incompatible tool signature keeps `strict=false` while emitting one downgrade diagnostic.
- Why this is the smallest reliable guardrail: the failure is in request-build diagnostic emission, before provider generation; an isolated module import with a mocked logger exercises the production `buildOpenAIResponsesParams` path without adding test-only source exports or requiring live provider credentials.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

OpenAI strict schema downgrade debug logs are less noisy for repeated identical tool-schema incompatibilities. Provider payload strictness behavior is unchanged.

## Diagram (if applicable)

```text
Before:
[same incompatible tool inventory] -> [strict=false] -> [debug line on every request]

After:
[same incompatible tool inventory] -> [strict=false] -> [debug line once per unique signature]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: local source checkout; original affected OS not enough info from redacted evidence
- Runtime/container: Node v24.15.0
- Model/provider: `azure-openai-responses/gpt-5.3-codex` in before evidence; local regression uses native OpenAI Responses model metadata
- Integration/channel (if any): OpenAI transport
- Relevant config (redacted): native Azure OpenAI Responses route with strict tool shaping enabled and 13 strict-incompatible schemas in the visible tool inventory

### Steps

1. Enable debug logging for OpenAI transport/tool schema diagnostics.
2. Send repeated requests using the same native OpenAI/Azure OpenAI Responses model and same strict-incompatible tool inventory.
3. Observe repeated downgrade diagnostics before the patch; after the patch, identical signatures are suppressed after the first log.

### Expected

- Identical strict downgrade diagnostics are emitted once per unique provider/model/transport/tool-violation signature.

### Actual

- Before the patch, the same downgrade diagnostic repeated on nearly every request.
- After the patch, the focused regression test proves identical signatures are deduplicated.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: focused OpenAI transport test file passes after adding the behavior-level dedupe regression.
- Edge cases checked: the repeated same-signature request path keeps `strict=false` for both payload builds while suppressing only the duplicate debug diagnostic.
- What you did **not** verify: live Azure OpenAI Responses rerun with the private affected session/provider setup.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a later identical downgrade diagnostic is suppressed even if an operator wanted repeated per-request reminders.
  - Mitigation: changed provider/model/transport/tool-violation signatures still log, and strict false behavior is unchanged.

