### PR TITLE
fix: yield diagnostic event drains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 - Agents/code mode: spell out the `exec` tool's JavaScript/TypeScript, no Node module, and catalog-bridge constraints in model-visible schema text so agents can use enabled tools without trial-and-error. (#84269) Thanks @Kaspre.
 - Codex: give `image_generate` dynamic-tool calls a 120s default watchdog when no per-call or configured image timeout is set, so image generation no longer falls back to the generic 30s bridge timeout. (#84254) Thanks @moritzmmayerhofer.
+- Codex: avoid duplicate dynamic tool terminal diagnostics while large diagnostic backlogs drain without blocking tool responses. (#82937) Thanks @galiniliev.
 - CLI/message: include a stable top-level `messageId` in `openclaw message --json` output when channel sends return one. (#84191) Thanks @100menotu001.
 - Gateway/agents: use an agent's `identity.name` in Gateway agent summaries when `agents.list[].name` is unset, so configured agent labels remain visible in clients. (#84355; refs #57835) Thanks @luoyanglang.
 - Plugins/hooks: apply a default 30-second timeout to `before_compaction` and `after_compaction` hooks so a hung plugin handler no longer blocks compaction completion. (#84153)

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-474c461709084ddd4014112d891c64abf3e062a417dbffae82be1cf54206283b  plugin-sdk-api-baseline.json
-cb7ad8a96c541d1ed7295c4bde6fb6a679e5d3481ed66778610ef897a3152484  plugin-sdk-api-baseline.jsonl
+6468950bae79f48709683957c5b140f634425f02f292bc5981e12c6565044b48  plugin-sdk-api-baseline.json
+2b329a3747a80498d1bc974a64d56a637bde6d2e6f7415f82cdcaeebb8f703af  plugin-sdk-api-baseline.jsonl

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -14,9 +14,11 @@ import {
   type EmbeddedRunAttemptParams,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
 import {
+  emitDiagnosticEvent,
   emitTrustedDiagnosticEvent,
   onInternalDiagnosticEvent,
   resetDiagnosticEventsForTest,
+  waitForDiagnosticEventsDrained,
   type DiagnosticEventPayload,
 } from "openclaw/plugin-sdk/diagnostic-runtime";
 import {
@@ -80,7 +82,19 @@ type RunCodexAppServerAttemptOptions = NonNullable<
 >;
 
 function flushDiagnosticEvents() {
-  return new Promise<void>((resolve) => setImmediate(resolve));
+  return waitForDiagnosticEventsDrained();
+}
+
+function emitAsyncDiagnosticBacklog(count: number): void {
+  for (let index = 0; index < count; index += 1) {
+    emitDiagnosticEvent({
+      type: "model.call.started",
+      runId: `backlog-run-${index}`,
+      callId: `backlog-call-${index}`,
+      provider: "openai",
+      model: "gpt-5.4",
+    });
+  }
 }
 
 function activeDiagnosticToolKeys(events: DiagnosticEventPayload[]): Set<string> {
@@ -2521,6 +2535,7 @@ describe("runCodexAppServerAttempt", () => {
 
     const run = runCodexAppServerAttempt(params);
     await harness.waitForMethod("thread/start");
+    emitAsyncDiagnosticBacklog(150);
 
     const toolResult = (await harness.handleServerRequest({
       id: "request-echo-error-tool",

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -51,6 +51,7 @@ import {
 import { markAuthProfileBlockedUntil, resolveAgentDir } from "openclaw/plugin-sdk/agent-runtime";
 import {
   emitTrustedDiagnosticEvent,
+  hasPendingInternalDiagnosticEvent,
   onInternalDiagnosticEvent,
   type DiagnosticEventPayload,
 } from "openclaw/plugin-sdk/diagnostic-runtime";
@@ -2183,8 +2184,15 @@ export async function runCodexAppServerAttempt(
             },
           });
         }
-        await waitForDiagnosticEventDrain();
-        if (!terminalDiagnosticObserved) {
+        if (
+          !terminalDiagnosticObserved &&
+          !hasPendingDynamicToolTerminalDiagnostic({
+            call,
+            runId: params.runId,
+            sessionId: params.sessionId,
+            sessionKey: params.sessionKey,
+          })
+        ) {
           emitDynamicToolTerminalDiagnostic({
             response,
             call,
@@ -2196,8 +2204,15 @@ export async function runCodexAppServerAttempt(
         }
         return protocolResponse as JsonValue;
       } catch (error) {
-        await waitForDiagnosticEventDrain();
-        if (!terminalDiagnosticObserved) {
+        if (
+          !terminalDiagnosticObserved &&
+          !hasPendingDynamicToolTerminalDiagnostic({
+            call,
+            runId: params.runId,
+            sessionId: params.sessionId,
+            sessionKey: params.sessionKey,
+          })
+        ) {
           emitDynamicToolErrorDiagnostic({
             call,
             runId: params.runId,
@@ -2948,10 +2963,6 @@ function toCodexDynamicToolProtocolResponse(
   };
 }
 
-function waitForDiagnosticEventDrain(): Promise<void> {
-  return new Promise((resolve) => setImmediate(resolve));
-}
-
 type TerminalToolExecutionDiagnostic = Extract<
   DiagnosticEventPayload,
   { type: "tool.execution.blocked" | "tool.execution.completed" | "tool.execution.error" }
@@ -2994,6 +3005,26 @@ function isMatchingDynamicToolTerminalDiagnostic(params: {
     params.event.sessionId === undefined &&
     params.event.sessionKey === undefined
   );
+}
+
+function hasPendingDynamicToolTerminalDiagnostic(params: {
+  call: CodexDynamicToolCallParams;
+  runId?: string;
+  sessionId?: string;
+  sessionKey?: string;
+}): boolean {
+  return hasPendingInternalDiagnosticEvent((event) => {
+    if (!isDynamicToolTerminalDiagnosticEvent(event)) {
+      return false;
+    }
+    return isMatchingDynamicToolTerminalDiagnostic({
+      event,
+      call: params.call,
+      runId: params.runId,
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+    });
+  });
 }
 
 function resolveDynamicToolCallTimeoutMs(params: {

--- a/src/infra/diagnostic-events.test.ts
+++ b/src/infra/diagnostic-events.test.ts
@@ -3,11 +3,14 @@ import {
   emitDiagnosticEvent,
   emitTrustedDiagnosticEvent,
   formatDiagnosticTraceparentForPropagation,
+  hasPendingInternalDiagnosticEvent,
   isDiagnosticsEnabled,
   onInternalDiagnosticEvent,
   onDiagnosticEvent,
   resetDiagnosticEventsForTest,
   setDiagnosticsEnabledForProcess,
+  waitForDiagnosticEventsDrained,
+  type DiagnosticEventPayload,
 } from "./diagnostic-events.js";
 import {
   createDiagnosticTraceContext,
@@ -413,6 +416,224 @@ describe("diagnostic-events", () => {
     expect(events).toStrictEqual([]);
     await new Promise<void>((resolve) => setImmediate(resolve));
     expect(events).toEqual(["tool.execution.started", "model.call.started"]);
+  });
+
+  it("yields between large high-frequency diagnostic event bursts", async () => {
+    const events: string[] = [];
+    onDiagnosticEvent((event) => {
+      events.push(event.type);
+    });
+
+    for (let index = 0; index < 250; index += 1) {
+      emitDiagnosticEvent({
+        type: "model.call.started",
+        runId: `run-${index}`,
+        callId: `call-${index}`,
+        provider: "openai",
+        model: "gpt-5.4",
+      });
+    }
+
+    expect(events).toStrictEqual([]);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(events).toHaveLength(100);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(events).toHaveLength(200);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(events).toHaveLength(250);
+  });
+
+  it("waits for all queued high-frequency diagnostic events to drain", async () => {
+    const events: string[] = [];
+    onDiagnosticEvent((event) => {
+      events.push(event.type);
+    });
+
+    for (let index = 0; index < 250; index += 1) {
+      emitDiagnosticEvent({
+        type: "model.call.started",
+        runId: `run-${index}`,
+        callId: `call-${index}`,
+        provider: "openai",
+        model: "gpt-5.4",
+      });
+    }
+
+    await waitForDiagnosticEventsDrained();
+
+    expect(events).toHaveLength(250);
+  });
+
+  it("reports pending async diagnostic events before they drain", async () => {
+    emitTrustedDiagnosticEvent({
+      type: "tool.execution.error",
+      runId: "run-pending",
+      toolName: "exec",
+      toolCallId: "call-pending",
+      durationMs: 1,
+      errorCategory: "test",
+    });
+
+    expect(
+      hasPendingInternalDiagnosticEvent(
+        (event, metadata) =>
+          metadata.trusted &&
+          event.type === "tool.execution.error" &&
+          event.toolCallId === "call-pending",
+      ),
+    ).toBe(true);
+
+    await waitForDiagnosticEventsDrained();
+
+    expect(
+      hasPendingInternalDiagnosticEvent((event) => event.type === "tool.execution.error"),
+    ).toBe(false);
+  });
+
+  it("passes immutable pending diagnostic copies to queue inspectors", async () => {
+    const events: DiagnosticEventPayload[] = [];
+    onInternalDiagnosticEvent((event) => {
+      events.push(event);
+    });
+
+    emitTrustedDiagnosticEvent({
+      type: "tool.execution.error",
+      runId: "run-immutable",
+      toolName: "exec",
+      toolCallId: "call-immutable",
+      durationMs: 1,
+      errorCategory: "test",
+    });
+
+    let mutationErrors = 0;
+    expect(
+      hasPendingInternalDiagnosticEvent((event, metadata) => {
+        try {
+          (event as { type: string }).type = "model.usage";
+        } catch {
+          mutationErrors += 1;
+        }
+        try {
+          (metadata as { trusted: boolean }).trusted = false;
+        } catch {
+          mutationErrors += 1;
+        }
+        return (
+          metadata.trusted &&
+          event.type === "tool.execution.error" &&
+          event.toolCallId === "call-immutable"
+        );
+      }),
+    ).toBe(true);
+    expect(mutationErrors).toBe(2);
+
+    await waitForDiagnosticEventsDrained();
+
+    expect(events).toMatchObject([
+      {
+        type: "tool.execution.error",
+        toolCallId: "call-immutable",
+      },
+    ]);
+  });
+
+  it("skips uncloneable pending diagnostics during queue inspection", async () => {
+    emitDiagnosticEvent({
+      type: "model.call.started",
+      runId: "run-uncloneable",
+      callId: "call-uncloneable",
+      provider: "openai",
+      model: "gpt-5.4",
+      badValue: () => undefined,
+    } as never);
+    emitTrustedDiagnosticEvent({
+      type: "tool.execution.error",
+      runId: "run-cloneable",
+      toolName: "exec",
+      toolCallId: "call-cloneable",
+      durationMs: 1,
+      errorCategory: "test",
+    });
+
+    expect(
+      hasPendingInternalDiagnosticEvent(
+        (event, metadata) =>
+          metadata.trusted &&
+          event.type === "tool.execution.error" &&
+          event.toolCallId === "call-cloneable",
+      ),
+    ).toBe(true);
+  });
+
+  it("preserves trusted terminal tool diagnostics when the async queue is full", async () => {
+    const events: DiagnosticEventPayload[] = [];
+    onInternalDiagnosticEvent((event) => {
+      events.push(event);
+    });
+
+    emitTrustedDiagnosticEvent({
+      type: "tool.execution.completed",
+      runId: "run-saturation-first",
+      toolName: "exec",
+      toolCallId: "call-saturation-first",
+      durationMs: 1,
+    });
+
+    for (let index = 0; index < 9_999; index += 1) {
+      emitDiagnosticEvent({
+        type: "model.call.started",
+        runId: `saturation-run-${index}`,
+        callId: `saturation-call-${index}`,
+        provider: "openai",
+        model: "gpt-5.4",
+      });
+    }
+
+    emitTrustedDiagnosticEvent({
+      type: "tool.execution.error",
+      runId: "run-saturation-second",
+      toolName: "exec",
+      toolCallId: "call-saturation-second",
+      durationMs: 1,
+      errorCategory: "test",
+    });
+
+    expect(
+      hasPendingInternalDiagnosticEvent(
+        (event, metadata) =>
+          metadata.trusted &&
+          event.type === "tool.execution.error" &&
+          event.toolCallId === "call-saturation-second",
+      ),
+    ).toBe(true);
+
+    await waitForDiagnosticEventsDrained();
+
+    expect(
+      events
+        .filter(
+          (
+            event,
+          ): event is Extract<
+            DiagnosticEventPayload,
+            { type: "tool.execution.completed" | "tool.execution.error" }
+          > => event.type === "tool.execution.completed" || event.type === "tool.execution.error",
+        )
+        .map((event) => ({
+          type: event.type,
+          toolCallId: event.toolCallId,
+        })),
+    ).toEqual([
+      {
+        type: "tool.execution.completed",
+        toolCallId: "call-saturation-first",
+      },
+      {
+        type: "tool.execution.error",
+        toolCallId: "call-saturation-second",
+      },
+    ]);
+    expect(events.filter((event) => event.type === "model.call.started")).toHaveLength(9_998);
   });
 
   it("keeps log records off the public diagnostic event stream", async () => {

--- a/src/infra/diagnostic-events.ts
+++ b/src/infra/diagnostic-events.ts
@@ -649,6 +649,7 @@ type DiagnosticEventsGlobalState = {
 };
 
 const MAX_ASYNC_DIAGNOSTIC_EVENTS = 10_000;
+const MAX_ASYNC_DIAGNOSTIC_EVENTS_PER_TURN = 100;
 const DIAGNOSTIC_EVENTS_STATE_KEY = Symbol.for("openclaw.diagnosticEvents.state.v1");
 const dispatchedTrustedDiagnosticMetadata = new WeakSet<object>();
 const ASYNC_DIAGNOSTIC_EVENT_TYPES = new Set<DiagnosticEventPayload["type"]>([
@@ -670,6 +671,11 @@ const ASYNC_DIAGNOSTIC_EVENT_TYPES = new Set<DiagnosticEventPayload["type"]>([
   "harness.run.error",
   "context.assembled",
   "log.record",
+]);
+const PRIORITY_ASYNC_DIAGNOSTIC_EVENT_TYPES = new Set<DiagnosticEventPayload["type"]>([
+  "tool.execution.completed",
+  "tool.execution.error",
+  "tool.execution.blocked",
 ]);
 
 function createDiagnosticEventsState(): DiagnosticEventsGlobalState {
@@ -780,6 +786,21 @@ function cloneDiagnosticEventForListener(event: DiagnosticEventPayload): Diagnos
   return deepFreezeDiagnosticValue(structuredClone(event)) as DiagnosticEventPayload;
 }
 
+function isPriorityAsyncDiagnosticEvent(entry: QueuedDiagnosticEvent): boolean {
+  return entry.metadata.trusted && PRIORITY_ASYNC_DIAGNOSTIC_EVENT_TYPES.has(entry.event.type);
+}
+
+function makeRoomForPriorityAsyncDiagnosticEvent(state: DiagnosticEventsGlobalState): void {
+  const nonPriorityIndex = state.asyncQueue.findIndex(
+    (entry) => !isPriorityAsyncDiagnosticEvent(entry),
+  );
+  if (nonPriorityIndex >= 0) {
+    state.asyncQueue.splice(nonPriorityIndex, 1);
+    return;
+  }
+  state.asyncQueue.shift();
+}
+
 function deepFreezeDiagnosticValue(value: unknown, seen = new WeakSet<object>()): unknown {
   if (!value || typeof value !== "object") {
     return value;
@@ -807,7 +828,7 @@ function scheduleAsyncDiagnosticDrain(state: DiagnosticEventsGlobalState): void 
   state.asyncDrainScheduled = true;
   setImmediate(() => {
     state.asyncDrainScheduled = false;
-    const batch = state.asyncQueue.splice(0);
+    const batch = state.asyncQueue.splice(0, MAX_ASYNC_DIAGNOSTIC_EVENTS_PER_TURN);
     for (const entry of batch) {
       dispatchDiagnosticEvent(state, entry.event, entry.metadata);
     }
@@ -815,6 +836,13 @@ function scheduleAsyncDiagnosticDrain(state: DiagnosticEventsGlobalState): void 
       scheduleAsyncDiagnosticDrain(state);
     }
   });
+}
+
+export async function waitForDiagnosticEventsDrained(): Promise<void> {
+  const state = getDiagnosticEventsState();
+  while (state.asyncDrainScheduled || state.asyncQueue.length > 0) {
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
 }
 
 function enrichDiagnosticEvent(
@@ -846,7 +874,10 @@ function emitDiagnosticEventWithTrust(event: DiagnosticEventInput, trusted: bool
 
   if (ASYNC_DIAGNOSTIC_EVENT_TYPES.has(enriched.type)) {
     if (state.asyncQueue.length >= MAX_ASYNC_DIAGNOSTIC_EVENTS) {
-      return;
+      if (!trusted || !PRIORITY_ASYNC_DIAGNOSTIC_EVENT_TYPES.has(enriched.type)) {
+        return;
+      }
+      makeRoomForPriorityAsyncDiagnosticEvent(state);
     }
     state.asyncQueue.push({ event: enriched, metadata });
     scheduleAsyncDiagnosticDrain(state);
@@ -877,6 +908,24 @@ export function onInternalDiagnosticEvent(listener: DiagnosticEventListener): ()
   return () => {
     state.listeners.delete(listener);
   };
+}
+
+export function hasPendingInternalDiagnosticEvent(
+  predicate: (event: DiagnosticEventPayload, metadata: DiagnosticEventMetadata) => boolean,
+): boolean {
+  const state = getDiagnosticEventsState();
+  for (const entry of state.asyncQueue) {
+    let event: DiagnosticEventPayload;
+    try {
+      event = cloneDiagnosticEventForListener(entry.event);
+    } catch {
+      continue;
+    }
+    if (predicate(event, Object.freeze({ ...entry.metadata }))) {
+      return true;
+    }
+  }
+  return false;
 }
 
 export function onDiagnosticEvent(listener: (evt: DiagnosticEventPayload) => void): () => void {

--- a/src/plugin-sdk/diagnostic-runtime.ts
+++ b/src/plugin-sdk/diagnostic-runtime.ts
@@ -8,10 +8,12 @@ export type {
 export {
   emitDiagnosticEvent,
   emitTrustedDiagnosticEvent,
+  hasPendingInternalDiagnosticEvent,
   isDiagnosticsEnabled,
   onInternalDiagnosticEvent,
   onDiagnosticEvent,
   resetDiagnosticEventsForTest,
+  waitForDiagnosticEventsDrained,
 } from "../infra/diagnostic-events.js";
 export type { DiagnosticTraceContext } from "../infra/diagnostic-trace-context.js";
 export {


### PR DESCRIPTION
## Summary

- Problem: high-frequency async diagnostic events could drain a large backlog in one `setImmediate` turn, monopolizing the gateway event loop during agent/subagent bursts.
- Why it matters: diagnostic traffic should not create liveness-delay spikes or duplicate/lost dynamic-tool terminal diagnostics.
- What changed: async diagnostic drains now process at most 100 queued events per turn; callers can explicitly wait for a full diagnostic drain; Codex dynamic-tool fallback diagnostics check the pending queue for the matching terminal event instead of waiting on unrelated global backlog; trusted terminal tool diagnostics get queue priority at saturation.
- What did NOT change (scope boundary): diagnostic payload shapes, public diagnostic stream filtering, listener ordering, and the 10k async queue cap remain intact.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #82936
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: Diagnostic event bursts from concurrent gateway agent/subagent activity no longer drain the whole async queue in one event-loop turn, and Codex dynamic-tool terminal diagnostics are not duplicated or dropped behind diagnostic backlog.
- Real environment tested: Local OpenClaw worktree, Node v24.15.0, rebased on `origin/main` `0556ac0291a894836382307eeeeb3b503aa1c0e5`.
- Exact steps or command run after this patch:

```shell
node --import tsx -e "import { emitDiagnosticEvent, onDiagnosticEvent, resetDiagnosticEventsForTest } from './src/infra/diagnostic-events.ts'; resetDiagnosticEventsForTest(); const events=[]; onDiagnosticEvent((event)=>events.push(event)); for (let index=0; index<250; index+=1) emitDiagnosticEvent({type:'model.call.started', runId:'run-'+index, callId:'call-'+index, provider:'openai', model:'gpt-5.4'}); if (events.length !== 0) throw new Error('expected async queue before first turn, got '+events.length); await new Promise((resolve)=>setImmediate(resolve)); if (events.length !== 100) throw new Error('expected 100 after one turn, got '+events.length); await new Promise((resolve)=>setImmediate(resolve)); if (events.length !== 200) throw new Error('expected 200 after two turns, got '+events.length); await new Promise((resolve)=>setImmediate(resolve)); if (events.length !== 250) throw new Error('expected 250 after three turns, got '+events.length); console.log('diagnostic async drain burst probe passed: 250 events over 3 turns');"
node --max-old-space-size=8192 --import tsx scripts/generate-plugin-sdk-api-baseline.ts --check
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
node scripts/run-vitest.mjs src/infra/diagnostic-events.test.ts
node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts -t "does not duplicate terminal diagnostics for wrapped dynamic tool errors"
AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main
```

- Evidence after fix:

```shell
diagnostic async drain burst probe passed: 250 events over 3 turns
OK docs/.generated/plugin-sdk-api-baseline.sha256
core test typecheck completed with exit code 0
Test Files  1 passed (1)
Tests  25 passed (25)
Test Files  1 passed (1)
Tests  1 passed | 183 skipped (184)
autoreview clean: no accepted/actionable findings reported
Test Files  2 passed (2)
Tests  210 passed (210)
```

- Observed result after fix: The scheduler delivered a 250-event burst as 100/200/250 across three event-loop turns; the focused diagnostic tests cover full drain, pending queue inspection, terminal priority under saturation, immutable inspector inputs, and uncloneable pending entries; the Codex regression did not duplicate terminal diagnostics behind a 150-event async backlog.
- What was not tested: I did not rerun the original private multi-subagent gateway workload. Full PR CI was restarted after the refreshed push and is expected to provide broader repository proof.
- Before evidence (optional but encouraged): Redacted log excerpt from the captured bug evidence:

```shell
"liveness warning: reasons=event_loop_delay,event_loop_utilization,cpu interval=30s eventLoopDelayP99Ms=6123.7 eventLoopDelayMaxMs=7709.1 eventLoopUtilization=0.975 cpuCoreRatio=0.983 active=5 waiting=0 queued=1 ..."
"liveness warning: reasons=event_loop_delay,event_loop_utilization interval=329s eventLoopDelayP99Ms=12750.7 eventLoopDelayMaxMs=12750.7 eventLoopUtilization=1 ..."
"liveness warning: reasons=event_loop_delay,cpu interval=30s eventLoopDelayP99Ms=1780.5 eventLoopDelayMaxMs=2128.6 eventLoopUtilization=0.892 cpuCoreRatio=0.951 active=6 ..."
```

## Root Cause (if applicable)

- Root cause: `scheduleAsyncDiagnosticDrain` moved high-frequency diagnostic events out of the emitter path, but processed every queued event in one async drain turn. Under agent/subagent bursts, listener cloning/freezing and stability recording could still monopolize the event loop until the backlog was empty.
- Missing detection / guardrail: Existing coverage only asserted that high-frequency events were asynchronous; it did not assert that large bursts yield between drain turns or that terminal tool diagnostics survive backlog/saturation cases.
- Contributing context (if known): Liveness warnings showed active agent/subagent work and queued work while event-loop delay P99 reached seconds.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/diagnostic-events.test.ts`; `extensions/codex/src/app-server/run-attempt.test.ts`
- Scenario the test should lock in: A burst of 250 async model-call diagnostic events drains as 100/200/250 across three `setImmediate` turns; full-drain callers can await the entire queue; pending diagnostic inspection does not mutate or throw on malformed queued entries; trusted terminal tool diagnostics survive queue saturation; Codex dynamic-tool fallback diagnostics are not duplicated behind backlog.
- Why this is the smallest reliable guardrail: The bug is in the diagnostic event queue scheduler and Codex’s dynamic-tool terminal fallback path, so focused scheduler and app-server tests prove the exact contracts without provider or channel setup.
- Existing test that already covers this (if any): Existing async dispatch coverage only covered a two-event burst.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

The gateway should remain more responsive during diagnostic event bursts from concurrent agent/subagent workloads.

## Diagram (if applicable)

```text
Before:
[diagnostic burst] -> [one drain turn processes entire backlog] -> [event-loop stall risk]

After:
[diagnostic burst] -> [100-event drain turn] -> [yield] -> [next drain turn] -> [continued gateway work]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux local worktree
- Runtime/container: Node v24.15.0
- Model/provider: N/A for focused diagnostic queue probe
- Integration/channel (if any): Gateway diagnostics, Codex app-server dynamic tools
- Relevant config (redacted): Diagnostics event dispatch defaults

### Steps

1. Register a diagnostic event listener.
2. Emit 250 high-frequency `model.call.started` diagnostic events.
3. Await successive `setImmediate` turns and count delivered events.

### Expected

- The async drain yields between chunks instead of delivering all 250 events in one turn.

### Actual

- After patch, delivery progressed as 0 before yield, then 100, 200, and 250 across three event-loop turns.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Focused runtime probe for the diagnostic async queue burst; scheduler Vitest coverage; Codex dynamic-tool duplicate-terminal regression; Plugin SDK API baseline check; core test typecheck matching the CI failure shard; `git diff --check`; autoreview.
- Edge cases checked: Existing two-event async behavior remains compatible because it still drains in the first turn; large backlog continues scheduling while queue entries remain; terminal diagnostics queued behind large async backlog are detected before fallback emission; trusted terminal diagnostics are preserved at queue saturation; pending queue inspection does not expose mutable queued entries or throw on uncloneable queued entries.
- What you did **not** verify: Original private gateway/subagent workload; full CI is running after the refreshed push.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Diagnostic event listeners may observe large async bursts over more event-loop turns instead of one immediate turn.
  - Mitigation: Ordering is preserved and small bursts still drain in a single turn; the queue keeps scheduling until empty.




