### PR TITLE
fix(agents): log warnings instead of swallowing subagent errors

### DIFF
--- a/src/agents/model-fallback.probe.test.ts
+++ b/src/agents/model-fallback.probe.test.ts
@@ -28,8 +28,42 @@ vi.mock("./provider-model-normalization.runtime.js", () => ({
 }));
 
 const emptyPluginMetadataSnapshot = vi.hoisted(() => ({
+  policyHash: "model-fallback-probe-test-empty-plugin-policy",
   configFingerprint: "model-fallback-probe-test-empty-plugin-metadata",
+  index: {
+    hostContractVersion: "test",
+    compatRegistryVersion: "test",
+    migrationVersion: 1,
+    policyHash: "model-fallback-probe-test-empty-plugin-policy",
+    generatedAtMs: 0,
+    installRecords: {},
+    plugins: [],
+    diagnostics: [],
+  },
+  registryDiagnostics: [],
+  manifestRegistry: { plugins: [], diagnostics: [] },
   plugins: [],
+  diagnostics: [],
+  byPluginId: new Map(),
+  normalizePluginId: (pluginId: string) => pluginId,
+  owners: {
+    channels: new Map(),
+    channelConfigs: new Map(),
+    providers: new Map(),
+    modelCatalogProviders: new Map(),
+    cliBackends: new Map(),
+    setupProviders: new Map(),
+    commandAliases: new Map(),
+    contracts: new Map(),
+  },
+  metrics: {
+    registrySnapshotMs: 0,
+    manifestRegistryMs: 0,
+    ownerMapsMs: 0,
+    totalMs: 0,
+    indexPluginCount: 0,
+    manifestPluginCount: 0,
+  },
 }));
 
 vi.mock("../plugins/current-plugin-metadata-snapshot.js", () => ({

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { testing as extraParamsTesting } from "./pi-embedded-runner/extra-params.js";
 
 vi.mock("../plugins/provider-hook-runtime.js", () => ({
+  clearProviderRuntimePluginCacheForTest: vi.fn(),
   testing: {
     buildHookProviderCacheKey: () => "test-provider-hook-cache-key",
   },

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test-harness.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test-harness.ts
@@ -88,6 +88,7 @@ export function createSanitizeSessionHistoryProviderHookRuntimeMock(
   extra: Record<string, unknown> = {},
 ) {
   return {
+    clearProviderRuntimePluginCacheForTest: vi.fn(),
     resolveProviderRuntimePlugin: vi.fn(() => undefined),
     resolveProviderHookPlugin: vi.fn(() => undefined),
     resolveProviderPluginsForHooks: vi.fn(() => []),

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -29,6 +29,7 @@ vi.mock("./pi-embedded-helpers.js", async () => ({
 }));
 
 vi.mock("../plugins/provider-hook-runtime.js", async () => ({
+  clearProviderRuntimePluginCacheForTest: vi.fn(),
   testing: {},
   prepareProviderExtraParams: vi.fn(() => undefined),
   resolveProviderHookPlugin: vi.fn(() => undefined),

--- a/src/agents/subagent-registry-completion.ts
+++ b/src/agents/subagent-registry-completion.ts
@@ -1,3 +1,4 @@
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { SubagentRunOutcome } from "./subagent-announce-output.js";
 import {
@@ -9,6 +10,8 @@ import {
   type SubagentLifecycleEndedReason,
 } from "./subagent-lifecycle-events.js";
 import type { SubagentRunRecord } from "./subagent-registry.types.js";
+
+const log = createSubsystemLogger("agents/subagent-registry-completion");
 
 export function runOutcomesEqual(
   a: SubagentRunOutcome | undefined,
@@ -113,7 +116,10 @@ export async function emitSubagentEndedHookOnce(params: {
     params.entry.endedHookEmittedAt = Date.now();
     params.persist();
     return true;
-  } catch {
+  } catch (err) {
+    log.warn(
+      `failed to emit subagent_ended hook for run ${runId}: ${err instanceof Error ? err.message : String(err)}`,
+    );
     return false;
   } finally {
     params.inFlightRunIds.delete(runId);

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -646,8 +646,10 @@ function restoreSubagentRunsOnce() {
     // Cold-start restore path: queue the same recovery pass that restart
     // startup also uses so resumed children are handled through one seam.
     scheduleSubagentOrphanRecovery();
-  } catch {
-    // ignore restore failures
+  } catch (err) {
+    log.warn(
+      `failed to restore subagent runs from disk: ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
 }
 


### PR DESCRIPTION
## Problem

Two catch blocks in the subagent registry silently discard errors, leaving no diagnostic trail when hook emission or disk restore fails:

1. **`emitSubagentEndedHookOnce`** (`subagent-registry-completion.ts:116`): `catch { return false; }` discards hook-runner errors when emitting the `subagent_ended` lifecycle hook.
2. **`restoreSubagentRunsOnce`** (`subagent-registry.ts:645`): `catch { // ignore restore failures }` discards errors when restoring subagent runs from disk on cold start.

When either path fails (hook runner unavailable, corrupt disk state, reconciliation error), the system continues silently. Operators have no indication that subagent lifecycle hooks were skipped or that restored runs were lost.

## Fix

Wire `log.warn()` into both catch blocks so errors are logged before the existing fallback behavior continues:

1. **Hook emission path**: `catch (err) { log.warn("failed to emit subagent_ended hook for run ${runId}: ..."); return false; }`
2. **Restore path**: `catch (err) { log.warn("failed to restore subagent runs from disk: ..."); }`

Both paths still return/continue as before (no behavior change beyond logging). The completion file gets its own `createSubsystemLogger("agents/subagent-registry-completion")` to match the existing `createSubsystemLogger("agents/subagent-registry")` in the registry file.

Production diff is +8 lines changed across 2 files.

## Real behavior proof

Behavior addressed: Two silent `catch` blocks in the subagent registry discard errors during hook emission and disk restore. The fix adds `log.warn()` to both paths so failures leave a diagnostic trail instead of being silently swallowed.

Real environment tested: Linux (Ubuntu 24.04, WSL2), Node.js v22.16.0, OpenClaw built from source (commit 1d5b5db) at `/tmp/fix-82943`.

Exact steps or command run after this patch:
```bash
Step 1. Build OpenClaw from patched source
cd /tmp/fix-82943
CI=true pnpm install --frozen-lockfile
pnpm build

Step 2. Verify both log.warn calls are in compiled production code
grep -n "failed to emit subagent_ended hook" dist/subagent-registry-DLVHJynj.js
grep -n "failed to restore subagent runs" dist/subagent-registry-DLVHJynj.js

Step 3. Start the patched gateway
timeout 10 node openclaw.mjs gateway

Step 4. Run test suites for both changed files
node scripts/run-vitest.mjs src/agents/subagent-registry-completion.test.ts
node scripts/run-vitest.mjs src/agents/subagent-registry.test.ts
```

Evidence after fix: terminal output copied below.

**Compiled production code verification**

Both `log.warn` calls are present in the compiled subagent-registry bundle:

```console
$ grep -n "failed to emit subagent_ended hook" dist/subagent-registry-DLVHJynj.js
94:log$2.warn(`failed to emit subagent_ended hook for run ${runId}: ${err instanceof Error ? err.message : String(err)}`);

$ grep -n "failed to restore subagent runs" dist/subagent-registry-DLVHJynj.js
1911:log.warn(`failed to restore subagent runs from disk: ${err instanceof Error ? err.message : String(err)}`);
```

Line 94 is `emitSubagentEndedHookOnce` (the hook emission path). Line 1911 is `restoreSubagentRunsOnce` (the disk restore path). Before this fix, both were `catch { }` (empty) and `catch { // ignore restore failures }` respectively.

The `log$2` prefix on line 94 is the compiled form of the new `createSubsystemLogger("agents/subagent-registry-completion")`, while `log` on line 1911 is the existing `createSubsystemLogger("agents/subagent-registry")`.

**Live gateway startup proof**

The patched gateway starts, loads the subagent registry with both warning-enabled catch blocks, and runs cleanly:

```console
$ timeout 10 node openclaw.mjs gateway
2026-05-21T12:39:28.862-07:00 [gateway] loading configuration…
2026-05-21T12:39:28.917-07:00 [gateway] starting...
2026-05-21T12:39:33.527-07:00 [health-monitor] started (interval: 300s, startup-grace: 60s, channel-connect-grace: 120s)
2026-05-21T12:39:34.421-07:00 [gateway] agent model: openai/gpt-5.5 (thinking=medium, fast=off)
2026-05-21T12:39:34.422-07:00 [gateway] http server listening (8 plugins: acpx, browser, canvas, device-pair, file-transfer, memory-core, phone-control, talk-voice; 5.5s)
2026-05-21T12:39:34.913-07:00 [gateway] ready
2026-05-21T12:39:52.803-07:00 [gateway] signal SIGTERM received
2026-05-21T12:39:52.807-07:00 [gateway] received SIGTERM; shutting down
2026-05-21T12:39:52.856-07:00 [shutdown] completed cleanly in 38ms
```

No `[agents/subagent-registry-completion]` or `[agents/subagent-registry]` warnings appear in the startup log, confirming the catch blocks are not triggered during normal operation (they are defensive logging for error paths only).

**Vitest test suites (supplemental)**

```console
$ node scripts/run-vitest.mjs src/agents/subagent-registry-completion.test.ts
 ✓ |agents-core| subagent-registry-completion.test.ts (8 tests) 86ms
 ✓ |agents-support| subagent-registry-completion.test.ts (8 tests) 73ms
 Test Files  2 passed (2)
      Tests  16 passed (16)

$ node scripts/run-vitest.mjs src/agents/subagent-registry.test.ts
 ✓ |agents-core| subagent-registry.test.ts (29 tests) 2679ms
 ✓ |agents-support| subagent-registry.test.ts (29 tests) 2264ms
 Test Files  2 passed (2)
      Tests  58 passed (58)
```

**Fault injection proof: restore catch path fires in real gateway**

The `restoreSubagentRunsOnce` catch handler was triggered in a **live running gateway** by injecting `throw new Error("INJECTED: corrupt registry state")` at the top of the try block in the compiled `dist/subagent-registry-DLVHJynj.js`. This forces the catch path to fire during gateway startup.

**Steps:**
1. Back up the compiled subagent-registry bundle.
2. Inject `throw new Error(...)` inside the try block of `restoreSubagentRunsOnce` (after `restoreAttempted = true`, before `restoreSubagentRunsFromDisk`).
3. Start the gateway.
4. Observe the `log.warn` message in the gateway output.
5. Confirm the gateway continues to start normally (the catch swallows the error).
6. Restore the original bundle.

**Terminal output (fault injection):**

```console
2026-05-21T16:15:54.095-07:00 [gateway] starting...
2026-05-21T16:15:54.710-07:00 [agents/subagent-registry] failed to restore subagent runs from disk: INJECTED: corrupt registry state
2026-05-21T16:15:54.832-07:00 [gateway] starting HTTP server...
2026-05-21T16:15:56.662-07:00 [gateway] agent model: openai/gpt-5.5 (thinking=medium, fast=off)
2026-05-21T16:15:56.665-07:00 [gateway] http server listening (8 plugins; 2.6s)
2026-05-21T16:15:57.476-07:00 [gateway] ready
```

**Line-by-line analysis:**

- `[gateway] starting...`: Gateway startup begins.
- `[agents/subagent-registry] failed to restore subagent runs from disk: INJECTED: corrupt registry state`: The **`log.warn` in the catch handler fired**. The error message includes the full error text. Before this fix, this catch block was `catch { // ignore restore failures }` with no logging at all.
- `[gateway] ready`: The gateway **continued to start normally** despite the restore failure. The catch handler swallowed the error and let startup proceed.

Without this fix, the same error would be silently ignored (empty catch block with only a comment), leaving no diagnostic trail.

**Fault injection proof: hook emission catch path fires in real gateway**

The `emitSubagentEndedHookOnce` catch handler was also triggered in a **live running gateway**. A conditional `throw` was injected inside the try block of `emitSubagentEndedHookOnce` in `dist/subagent-registry-DLVHJynj.js` (line 73), and a timed trigger called the function after the gateway was ready.

**Terminal output (hook emission catch):**

```console
2026-05-21T21:35:44.608-07:00 [gateway] ready
2026-05-21T21:35:58.683-07:00 [agents/subagent-registry-completion] failed to emit subagent_ended hook for run INJECTED-PROOF-RUN: INJECTED: hook runner unavailable
2026-05-21T21:35:58.686-07:00 [gateway] signal SIGTERM received
2026-05-21T21:35:58.734-07:00 [gmail-watcher] gmail watcher stopped
2026-05-21T21:35:58.736-07:00 [shutdown] completed cleanly in 38ms
```

**Analysis:**
- `[agents/subagent-registry-completion]` subsystem prefix confirms the **new** `createSubsystemLogger("agents/subagent-registry-completion")` is active (this logger was added by this PR).
- `failed to emit subagent_ended hook for run INJECTED-PROOF-RUN: INJECTED: hook runner unavailable` is the exact `log.warn` message from the catch block at compiled line 94.
- The gateway continued running after the hook emission failure (the catch returns `false`, not rethrow).
- Before this fix, this catch block was `catch { return false; }` with no logging at all.

**Both catch blocks are now proven in live gateway runs:**
1. **Restore catch** (`restoreSubagentRunsOnce`): `[agents/subagent-registry] failed to restore subagent runs from disk: INJECTED: corrupt registry state`
2. **Hook emission catch** (`emitSubagentEndedHookOnce`): `[agents/subagent-registry-completion] failed to emit subagent_ended hook for run INJECTED-PROOF-RUN: INJECTED: hook runner unavailable`

Observed result after fix: Both new `log.warn` calls fire correctly in production compiled code. The restore catch logs under `[agents/subagent-registry]` and the hook emission catch logs under `[agents/subagent-registry-completion]`. Both allow the gateway to continue running. All 74 tests pass across both test files.

What was not tested: The hook emission was triggered via injected timer call rather than a real subagent completion event. The injection proves the catch handler mechanism (log.warn + return false + gateway continues) works identically to the restore path proof.



