### PR TITLE
fix(telegram): redact raw update logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,7 @@ Docs: https://docs.openclaw.ai
 - Mac app: make Config settings open from shallow schema lookups and load selected paths on demand instead of fetching and rendering the full generated config schema up front.
 - Codex: sanitize inline image payloads before Codex app-server and OpenAI Responses replay, and clear poisoned Codex thread bindings after invalid image errors. Fixes #82878.
 - Providers/GitHub Copilot: request identity-encoded Copilot API responses across token exchange, catalog, model calls, usage, and embeddings so compressed Business-account error payloads no longer reach JSON parsers as gzip bytes. Fixes #82871. Thanks @tonyfe01.
+- Telegram: redact nested raw-update identifiers and user metadata before verbose raw update logging, preserving useful update/message ids without exposing chat, user, command, or profile details. (#82945) Thanks @galiniliev and @joshavant.
 - Telegram: preserve replied-to bot messages, captions, and media metadata in group reply chains so follow-up replies understand what the user is reacting to. (#82863)
 - Providers/Together: update PI runtime packages to 0.74.1 and emit Together-style `reasoning.enabled`/`max_tokens` controls for reasoning-capable OpenAI-completions models.
 - Agents/diagnostics: split slow embedded-run `attempt-dispatch` startup summaries into workspace, prompt, runtime-plan, and final dispatch subspans so traces identify the delayed setup phase. Fixes #82782. (#82783) Thanks @galiniliev.

--- a/extensions/telegram/src/bot-core.raw-update-log.test.ts
+++ b/extensions/telegram/src/bot-core.raw-update-log.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { stringifyTelegramRawUpdateForLog } from "./raw-update-log.js";
+
+describe("stringifyTelegramRawUpdateForLog", () => {
+  it("redacts private Telegram raw update fields before verbose logging", () => {
+    const update = {
+      update_id: 98765,
+      message: {
+        message_id: 44,
+        from: {
+          id: 123456,
+          is_bot: false,
+          first_name: "Alice",
+          last_name: "Example",
+          username: "alice_private",
+        },
+        chat: {
+          id: -1001234567890,
+          type: "private",
+          title: "Private Chat",
+          username: "private_chat",
+        },
+        text: "please inspect https://private.example/secret",
+        entities: [{ type: "url", offset: 15, length: 30, url: "https://private.example/entity" }],
+        link_preview_options: { url: "https://private.example/preview" },
+      },
+      callback_query: {
+        id: "callback-id",
+        from: { id: 7777, first_name: "Bob", username: "bob_private" },
+        data: "sensitive callback payload",
+      },
+    };
+
+    const rawLog = stringifyTelegramRawUpdateForLog(update);
+
+    expect(rawLog).toContain('"update_id":98765');
+    expect(rawLog).toContain('"message_id":44');
+    expect(rawLog).toContain('"text":"[redacted]"');
+    expect(rawLog).toContain('"url":"[redacted]"');
+    for (const privateValue of [
+      "123456",
+      "-1001234567890",
+      "Alice",
+      "Example",
+      "alice_private",
+      "Private Chat",
+      "private_chat",
+      "please inspect",
+      "https://private.example",
+      "7777",
+      "Bob",
+      "bob_private",
+      "sensitive callback payload",
+    ]) {
+      expect(rawLog).not.toContain(privateValue);
+    }
+  });
+});

--- a/extensions/telegram/src/bot-core.raw-update-log.test.ts
+++ b/extensions/telegram/src/bot-core.raw-update-log.test.ts
@@ -13,6 +13,8 @@ describe("stringifyTelegramRawUpdateForLog", () => {
           first_name: "Alice",
           last_name: "Example",
           username: "alice_private",
+          language_code: "en-US",
+          is_premium: true,
         },
         chat: {
           id: -1001234567890,
@@ -23,6 +25,17 @@ describe("stringifyTelegramRawUpdateForLog", () => {
         text: "please inspect https://private.example/secret",
         entities: [{ type: "url", offset: 15, length: 30, url: "https://private.example/entity" }],
         link_preview_options: { url: "https://private.example/preview" },
+        new_chat_members: [
+          {
+            id: 246810,
+            is_bot: false,
+            first_name: "New",
+            last_name: "Member",
+            username: "new_member_user",
+            language_code: "fr-CA",
+            added_to_attachment_menu: true,
+          },
+        ],
       },
       callback_query: {
         id: "callback-id",
@@ -43,14 +56,118 @@ describe("stringifyTelegramRawUpdateForLog", () => {
       "Alice",
       "Example",
       "alice_private",
+      "en-US",
       "Private Chat",
       "private_chat",
       "please inspect",
       "https://private.example",
+      "246810",
+      "New",
+      "Member",
+      "new_member_user",
+      "fr-CA",
+      "added_to_attachment_menu",
       "7777",
       "Bob",
       "bob_private",
       "sensitive callback payload",
+    ]) {
+      expect(rawLog).not.toContain(privateValue);
+    }
+  });
+
+  it("redacts identifiers from less common Telegram update shapes", () => {
+    const update = {
+      update_id: 45678,
+      business_connection: {
+        id: "business-connection-id",
+        user: {
+          id: 111222,
+          is_bot: false,
+          first_name: "Business",
+          username: "business_user",
+        },
+        user_chat_id: 333444,
+        date: 1712345678,
+        can_reply: true,
+        is_enabled: true,
+      },
+      chat_join_request: {
+        chat: {
+          id: -100555666,
+          type: "supergroup",
+          title: "Join Request Group",
+          username: "join_request_group",
+        },
+        from: {
+          id: 777888,
+          is_bot: false,
+          first_name: "Joiner",
+          username: "join_user",
+        },
+        user_chat_id: 999000,
+        date: 1712345679,
+        bio: "private bio",
+        invite_link: {
+          invite_link: "https://t.me/+private-invite",
+          creator: {
+            id: 222333,
+            is_bot: false,
+            first_name: "Creator",
+            username: "invite_creator",
+          },
+        },
+      },
+      message_reaction: {
+        chat: {
+          id: -100111222,
+          type: "supergroup",
+          title: "Reaction Group",
+        },
+        message_id: 99,
+        actor_chat: {
+          id: -100333444,
+          type: "channel",
+          title: "Actor Channel",
+          username: "actor_channel",
+        },
+        date: 1712345680,
+        old_reaction: [],
+        new_reaction: [],
+      },
+    };
+
+    const rawLog = stringifyTelegramRawUpdateForLog(update);
+
+    expect(rawLog).toContain('"update_id":45678');
+    expect(rawLog).toContain('"message_id":99');
+    expect(rawLog).toContain('"can_reply":true');
+    expect(rawLog).toContain('"is_enabled":true');
+    expect(rawLog).toContain('"user_chat_id":"[redacted]"');
+    expect(rawLog).toContain('"id":"[redacted]"');
+    for (const privateValue of [
+      "business-connection-id",
+      "111222",
+      "Business",
+      "business_user",
+      "333444",
+      "-100555666",
+      "Join Request Group",
+      "join_request_group",
+      "777888",
+      "Joiner",
+      "join_user",
+      "999000",
+      "private bio",
+      "https://t.me/+private-invite",
+      "222333",
+      "Creator",
+      "invite_creator",
+      "-100111222",
+      "Reaction Group",
+      "-100333444",
+      "Actor Channel",
+      "actor_channel",
     ]) {
       expect(rawLog).not.toContain(privateValue);
     }

--- a/extensions/telegram/src/bot-core.ts
+++ b/extensions/telegram/src/bot-core.ts
@@ -41,6 +41,7 @@ import {
   resolveTelegramOutboundClientTimeoutFloorSeconds,
 } from "./client-fetch.js";
 import { resolveTelegramTransport } from "./fetch.js";
+import { stringifyTelegramRawUpdateForLog } from "./raw-update-log.js";
 import { createTelegramSendChatActionHandler } from "./sendchataction-401-backoff.js";
 import { getTelegramSequentialKey } from "./sequential-key.js";
 import { createTelegramThreadBindingManager } from "./thread-bindings.js";
@@ -215,34 +216,11 @@ export function createTelegramBotCore(
 
   const rawUpdateLogger = createSubsystemLogger("gateway/channels/telegram/raw-update");
   const MAX_RAW_UPDATE_CHARS = 8000;
-  const MAX_RAW_UPDATE_STRING = 500;
-  const MAX_RAW_UPDATE_ARRAY = 20;
-  const stringifyUpdate = (update: unknown) => {
-    const seen = new WeakSet();
-    return JSON.stringify(update ?? null, (_key, value) => {
-      if (typeof value === "string" && value.length > MAX_RAW_UPDATE_STRING) {
-        return `${value.slice(0, MAX_RAW_UPDATE_STRING)}...`;
-      }
-      if (Array.isArray(value) && value.length > MAX_RAW_UPDATE_ARRAY) {
-        return [
-          ...value.slice(0, MAX_RAW_UPDATE_ARRAY),
-          `...(${value.length - MAX_RAW_UPDATE_ARRAY} more)`,
-        ];
-      }
-      if (value && typeof value === "object") {
-        if (seen.has(value)) {
-          return "[Circular]";
-        }
-        seen.add(value);
-      }
-      return value;
-    });
-  };
 
   bot.use(async (ctx, next) => {
     if (shouldLogVerbose()) {
       try {
-        const raw = stringifyUpdate(ctx.update);
+        const raw = stringifyTelegramRawUpdateForLog(ctx.update);
         const preview =
           raw.length > MAX_RAW_UPDATE_CHARS ? `${raw.slice(0, MAX_RAW_UPDATE_CHARS)}...` : raw;
         rawUpdateLogger.debug(`telegram update: ${preview}`);

--- a/extensions/telegram/src/raw-update-log.ts
+++ b/extensions/telegram/src/raw-update-log.ts
@@ -2,50 +2,46 @@ const MAX_RAW_UPDATE_STRING = 500;
 const MAX_RAW_UPDATE_ARRAY = 20;
 const REDACTED_TELEGRAM_FIELD = "[redacted]";
 const TELEGRAM_RAW_UPDATE_ALWAYS_REDACT_KEYS = new Set([
+  "added_to_attachment_menu",
   "author_signature",
   "caption",
   "chat_instance",
   "data",
   "email",
+  "bio",
+  "description",
+  "explanation",
   "file_id",
   "file_unique_id",
   "first_name",
   "invite_link",
+  "is_premium",
+  "language_code",
+  "latitude",
   "last_name",
+  "longitude",
+  "name",
   "phone_number",
+  "question",
   "query",
   "text",
   "title",
   "url",
   "username",
+  "vcard",
 ]);
+const TELEGRAM_RAW_UPDATE_ALLOWED_ID_KEYS = new Set(["message_id", "update_id"]);
 const TELEGRAM_RAW_UPDATE_ID_REDACT_KEYS = new Set([
   "chat_id",
   "custom_emoji_id",
+  "inline_message_id",
   "migrate_from_chat_id",
   "migrate_to_chat_id",
+  "option_ids",
+  "poll_id",
   "sender_chat_id",
   "user_id",
-]);
-const TELEGRAM_RAW_UPDATE_ID_REDACT_PARENTS = new Set([
-  "chat",
-  "from",
-  "sender_chat",
-  "sender_user",
-  "user",
-  "via_bot",
-]);
-const TELEGRAM_RAW_UPDATE_USER_OBJECT_KEYS = new Set([
-  "administrator",
-  "bot",
-  "creator",
-  "forward_from",
-  "forward_from_chat",
-  "left_chat_member",
-  "new_chat_member",
-  "new_chat_members",
-  "old_chat_member",
-  "reply_to_message",
+  "user_chat_id",
 ]);
 
 function shouldRedactTelegramRawUpdateValue(key: string, parentKey: string | undefined): boolean {
@@ -55,27 +51,23 @@ function shouldRedactTelegramRawUpdateValue(key: string, parentKey: string | und
   if (TELEGRAM_RAW_UPDATE_ALWAYS_REDACT_KEYS.has(key)) {
     return true;
   }
+  if (TELEGRAM_RAW_UPDATE_ALLOWED_ID_KEYS.has(key)) {
+    return false;
+  }
   if (TELEGRAM_RAW_UPDATE_ID_REDACT_KEYS.has(key)) {
     return true;
   }
-  if (key === "id") {
-    return parentKey !== undefined && TELEGRAM_RAW_UPDATE_ID_REDACT_PARENTS.has(parentKey);
+  if (key === "id" || key.endsWith("_id") || key.endsWith("_ids")) {
+    return parentKey !== undefined;
   }
   return false;
 }
 
-function shouldTreatTelegramRawUpdateObjectAsPrivate(
-  key: string,
-  value: Record<string, unknown>,
-): boolean {
-  if (!TELEGRAM_RAW_UPDATE_USER_OBJECT_KEYS.has(key)) {
-    return false;
-  }
+function isTelegramUserObject(value: Record<string, unknown>): boolean {
   return (
-    typeof value.id === "number" ||
-    typeof value.username === "string" ||
-    typeof value.first_name === "string" ||
-    typeof value.last_name === "string"
+    typeof value.id === "number" &&
+    typeof value.is_bot === "boolean" &&
+    typeof value.first_name === "string"
   );
 }
 
@@ -103,7 +95,7 @@ export function stringifyTelegramRawUpdateForLog(update: unknown): string {
       }
       seen.add(value);
       const record = value as Record<string, unknown>;
-      if (shouldTreatTelegramRawUpdateObjectAsPrivate(key, record)) {
+      if (isTelegramUserObject(record)) {
         return REDACTED_TELEGRAM_FIELD;
       }
       const redacted: Record<string, unknown> = {};

--- a/extensions/telegram/src/raw-update-log.ts
+++ b/extensions/telegram/src/raw-update-log.ts
@@ -1,0 +1,118 @@
+const MAX_RAW_UPDATE_STRING = 500;
+const MAX_RAW_UPDATE_ARRAY = 20;
+const REDACTED_TELEGRAM_FIELD = "[redacted]";
+const TELEGRAM_RAW_UPDATE_ALWAYS_REDACT_KEYS = new Set([
+  "author_signature",
+  "caption",
+  "chat_instance",
+  "data",
+  "email",
+  "file_id",
+  "file_unique_id",
+  "first_name",
+  "invite_link",
+  "last_name",
+  "phone_number",
+  "query",
+  "text",
+  "title",
+  "url",
+  "username",
+]);
+const TELEGRAM_RAW_UPDATE_ID_REDACT_KEYS = new Set([
+  "chat_id",
+  "custom_emoji_id",
+  "migrate_from_chat_id",
+  "migrate_to_chat_id",
+  "sender_chat_id",
+  "user_id",
+]);
+const TELEGRAM_RAW_UPDATE_ID_REDACT_PARENTS = new Set([
+  "chat",
+  "from",
+  "sender_chat",
+  "sender_user",
+  "user",
+  "via_bot",
+]);
+const TELEGRAM_RAW_UPDATE_USER_OBJECT_KEYS = new Set([
+  "administrator",
+  "bot",
+  "creator",
+  "forward_from",
+  "forward_from_chat",
+  "left_chat_member",
+  "new_chat_member",
+  "new_chat_members",
+  "old_chat_member",
+  "reply_to_message",
+]);
+
+function shouldRedactTelegramRawUpdateValue(key: string, parentKey: string | undefined): boolean {
+  if (!key) {
+    return false;
+  }
+  if (TELEGRAM_RAW_UPDATE_ALWAYS_REDACT_KEYS.has(key)) {
+    return true;
+  }
+  if (TELEGRAM_RAW_UPDATE_ID_REDACT_KEYS.has(key)) {
+    return true;
+  }
+  if (key === "id") {
+    return parentKey !== undefined && TELEGRAM_RAW_UPDATE_ID_REDACT_PARENTS.has(parentKey);
+  }
+  return false;
+}
+
+function shouldTreatTelegramRawUpdateObjectAsPrivate(
+  key: string,
+  value: Record<string, unknown>,
+): boolean {
+  if (!TELEGRAM_RAW_UPDATE_USER_OBJECT_KEYS.has(key)) {
+    return false;
+  }
+  return (
+    typeof value.id === "number" ||
+    typeof value.username === "string" ||
+    typeof value.first_name === "string" ||
+    typeof value.last_name === "string"
+  );
+}
+
+export function stringifyTelegramRawUpdateForLog(update: unknown): string {
+  const seen = new WeakSet<object>();
+  const transform = (value: unknown, key = "", parentKey?: string): unknown => {
+    if (shouldRedactTelegramRawUpdateValue(key, parentKey)) {
+      return REDACTED_TELEGRAM_FIELD;
+    }
+    if (typeof value === "string") {
+      return value.length > MAX_RAW_UPDATE_STRING
+        ? `${value.slice(0, MAX_RAW_UPDATE_STRING)}...`
+        : value;
+    }
+    if (Array.isArray(value)) {
+      const items = value.slice(0, MAX_RAW_UPDATE_ARRAY).map((item) => transform(item, key, key));
+      if (value.length > MAX_RAW_UPDATE_ARRAY) {
+        items.push(`...(${value.length - MAX_RAW_UPDATE_ARRAY} more)`);
+      }
+      return items;
+    }
+    if (value && typeof value === "object") {
+      if (seen.has(value)) {
+        return "[Circular]";
+      }
+      seen.add(value);
+      const record = value as Record<string, unknown>;
+      if (shouldTreatTelegramRawUpdateObjectAsPrivate(key, record)) {
+        return REDACTED_TELEGRAM_FIELD;
+      }
+      const redacted: Record<string, unknown> = {};
+      for (const [entryKey, entryValue] of Object.entries(record)) {
+        redacted[entryKey] = transform(entryValue, entryKey, key);
+      }
+      return redacted;
+    }
+    return value;
+  };
+  return JSON.stringify(transform(update ?? null));
+}


### PR DESCRIPTION
## Summary

- Problem: Telegram verbose raw-update logging serialized `ctx.update` directly, which could write private chat payload values to gateway logs.
- Why it matters: verbose/debug logs can be shared during support and should not contain Telegram user/chat identifiers, names, usernames, message text, callback data, or URLs.
- What changed: raw update formatting now redacts sensitive Telegram fields while preserving update shape, bounded strings, bounded arrays, and circular handling.
- What did NOT change (scope boundary): this does not change Telegram update dispatch, polling, access control, or non-raw-update logging.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #82944
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Telegram raw-update verbose/debug logging no longer emits private Telegram user/chat identifiers, names, usernames, message text, callback data, or URLs for the exercised update shape.
- Real environment tested: Local OpenClaw source worktree on Windows, executing the actual `extensions/telegram/src/raw-update-log.ts` module with Node's TypeScript stripping.
- Exact steps or command run after this patch: `node --experimental-strip-types --input-type=module` with a script that imports `stringifyTelegramRawUpdateForLog`, feeds a representative Telegram update containing private IDs, names, usernames, message text, callback data, and URLs, then fails if any private value remains in the formatted log output.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): terminal capture:

```text
{"update_id":98765,"message":{"message_id":44,"from":{"id":"[redacted]","is_bot":false,"first_name":"[redacted]","last_name":"[redacted]","username":"[redacted]"},"chat":{"id":"[redacted]","type":"private","title":"[redacted]","username":"[redacted]"},"text":"[redacted]","entities":[{"type":"url","offset":15,"length":30,"url":"[redacted]"}],"link_preview_options":{"url":"[redacted]"}},"callback_query":{"id":"callback-id","from":{"id":"[redacted]","first_name":"[redacted]","username":"[redacted]"},"data":"[redacted]"}}
raw update redaction proof passed
```

- Observed result after fix: the formatted raw update kept non-private update shape fields such as `update_id` and `message_id`, while the exercised private values were absent and replaced with `[redacted]`.
- What was not tested: I did not run a live Telegram bot session with real Telegram credentials, and local Vitest/oxfmt were blocked by Windows dependency/tool execution errors documented below.
- Before evidence (optional but encouraged): redacted local evidence showed `gateway/channels/telegram/raw-update` log previews containing fields such as `message.from.id`, `message.from.username`, `message.chat.id`, `message.text`, `message.entities`, and `link_preview_options.url`; unredacted lines are intentionally not included because they contain private Telegram payloads.

## Root Cause (if applicable)

- Root cause: the verbose raw-update middleware in `extensions/telegram/src/bot-core.ts` called `JSON.stringify(ctx.update)` and logged the preview without field-level redaction.
- Missing detection / guardrail: there was no focused formatter test asserting that raw Telegram update logging omits private payload values.
- Contributing context (if known): the old formatter only bounded long strings, long arrays, and circular references; it did not classify Telegram payload fields by privacy sensitivity.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/telegram/src/bot-core.raw-update-log.test.ts`
- Scenario the test should lock in: representative Telegram update formatting redacts private IDs, names, usernames, message text, callback data, and URLs while preserving safe shape fields.
- Why this is the smallest reliable guardrail: the leak occurs in raw-update preview formatting before dispatch behavior, so the formatter seam directly covers the bug without requiring live Telegram credentials.
- Existing test that already covers this (if any): None found.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Verbose/debug Telegram raw-update logs now show `[redacted]` for private Telegram payload values instead of raw private content.

## Diagram (if applicable)

```text
Before:
Telegram update -> verbose raw-update formatter -> gateway log with private payload values

After:
Telegram update -> redacting raw-update formatter -> gateway log with safe update shape and [redacted] values
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows local worktree
- Runtime/container: Node v24.15.0 for the direct formatter proof
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): verbose/debug raw-update logging path only; no live Telegram credentials used

### Steps

1. Inspect the old raw-update middleware in `extensions/telegram/src/bot-core.ts`.
2. Run the direct Node formatter proof against `extensions/telegram/src/raw-update-log.ts` after the patch.
3. Run `git diff --check origin/main...HEAD`.

### Expected

- Raw update log previews redact private Telegram payload values.

### Actual

- After the patch, the copied terminal output shows private values replaced with `[redacted]` and the proof script passed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: direct formatter proof for user ID, chat ID, first/last names, usernames, message text, callback data, entity URL, and link preview URL redaction; `git diff --check origin/main...HEAD` passed.
- Edge cases checked: safe update shape fields remain (`update_id`, `message_id`); bounded string/array and circular handling were preserved by moving the formatter behavior into the redacting formatter.
- What you did **not** verify: live Telegram runtime logs with real Telegram credentials; Vitest could not run locally because pnpm/esbuild failed with `spawnSync C:\Program Files\nodejs\node.exe EPERM`, and `node_modules\.bin\oxfmt.CMD` failed with `Access is denied`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: redacting too aggressively can make raw-update debugging less specific.
  - Mitigation: preserve update structure and safe operational fields such as `update_id`, `message_id`, entity type/offset/length, and non-private booleans/types while redacting private values.