### PR TITLE
fix(auto-reply): add env opt-out for GPT-5 chat brevity guard [AI-assisted]

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.brevity-guard-opt-out.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.brevity-guard-opt-out.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ReplyPayload } from "../types.js";
+import { applyOpenAIGptChatReplyGuard } from "./agent-runner-execution.js";
+
+const ENV_KEY = "OPENCLAW_DISABLE_GPT_CHAT_BREVITY_GUARD";
+
+function buildChattyText(): string {
+  const para = (label: string) =>
+    `${label} sentence one. ${label} sentence two. ${label} sentence three. ${label} sentence four. ${label} sentence five.`;
+  // 3 paragraphs, 15 sentences total, ~ > 1500 chars after padding, includes summary phrase.
+  const filler = "x".repeat(1_200);
+  return [
+    para("First"),
+    para("Second"),
+    `${para("Third")} In summary, here is what changed. ${filler}`,
+  ].join("\n\n");
+}
+
+function makePayload(text: string): ReplyPayload {
+  return { text };
+}
+
+describe("applyOpenAIGptChatReplyGuard opt-out", () => {
+  let previousEnv: string | undefined;
+
+  beforeEach(() => {
+    previousEnv = process.env[ENV_KEY];
+    delete process.env[ENV_KEY];
+  });
+
+  afterEach(() => {
+    if (previousEnv === undefined) {
+      delete process.env[ENV_KEY];
+    } else {
+      process.env[ENV_KEY] = previousEnv;
+    }
+  });
+
+  it("shortens chatty replies for openai gpt-5 by default (baseline)", () => {
+    const text = buildChattyText();
+    const payload = makePayload(text);
+    applyOpenAIGptChatReplyGuard({
+      provider: "openai",
+      model: "gpt-5",
+      commandBody: "hello there",
+      isHeartbeat: false,
+      payloads: [payload],
+    });
+    expect(payload.text).not.toBe(text);
+    expect(payload.text!.endsWith("...")).toBe(true);
+    expect(payload.text!.length).toBeLessThan(text.length);
+  });
+
+  it("leaves replies untouched when the env opt-out is enabled", () => {
+    process.env[ENV_KEY] = "1";
+    const text = buildChattyText();
+    const payload = makePayload(text);
+    applyOpenAIGptChatReplyGuard({
+      provider: "openai",
+      model: "gpt-5",
+      commandBody: "hello there",
+      isHeartbeat: false,
+      payloads: [payload],
+    });
+    expect(payload.text).toBe(text);
+  });
+
+  it("accepts case-insensitive 'true' as the opt-out value", () => {
+    process.env[ENV_KEY] = "TRUE";
+    const text = buildChattyText();
+    const payload = makePayload(text);
+    applyOpenAIGptChatReplyGuard({
+      provider: "openai",
+      model: "gpt-5",
+      commandBody: "hello there",
+      isHeartbeat: false,
+      payloads: [payload],
+    });
+    expect(payload.text).toBe(text);
+  });
+});

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -838,6 +838,15 @@ export function buildContextOverflowRecoveryText(params: {
   );
 }
 
+function isOpenAIGptChatBrevityGuardDisabledByEnv(): boolean {
+  const raw = process.env.OPENCLAW_DISABLE_GPT_CHAT_BREVITY_GUARD;
+  if (typeof raw !== "string") {
+    return false;
+  }
+  const normalized = raw.trim().toLowerCase();
+  return normalized === "1" || normalized === "true";
+}
+
 function shouldApplyOpenAIGptChatGuard(params: { provider?: string; model?: string }): boolean {
   if (params.provider !== "openai" && params.provider !== "openai-codex") {
     return false;
@@ -910,13 +919,16 @@ function shortenChattyFinalReplyText(
   return shortened.replace(/[.,;:!?-]*$/u, "").trimEnd() + "...";
 }
 
-function applyOpenAIGptChatReplyGuard(params: {
+export function applyOpenAIGptChatReplyGuard(params: {
   provider?: string;
   model?: string;
   commandBody: string;
   isHeartbeat: boolean;
   payloads?: ReplyPayload[];
 }): void {
+  if (isOpenAIGptChatBrevityGuardDisabledByEnv()) {
+    return;
+  }
   if (
     params.isHeartbeat ||
     !shouldApplyOpenAIGptChatGuard({


### PR DESCRIPTION
> 🤖 AI-assisted (built with Codex via Hermes orchestration). Test level: lightly tested. Prompt summary available on request.

## Summary
- Problem: `applyOpenAIGptChatReplyGuard` in `src/auto-reply/reply/agent-runner-execution.ts` unconditionally shortens assistant replies for `openai`/`openai-codex` providers on `gpt-5*` models, truncating to N sentences and appending a literal `"..."`. There is no configuration knob to disable it, so users must hand-patch the shipped `dist/` to opt out (workaround is wiped on every reinstall and the dist filename hash changes per release).
- Why it matters: silently corrupts user-facing replies (e.g. a 3-item numbered list is cut at "3...") with no log line emitted. Indistinguishable to a casual reader from the model itself trailing off.
- What changed: added env var `OPENCLAW_DISABLE_GPT_CHAT_BREVITY_GUARD` (accepts `1` or `true`, case-insensitive, trimmed). When set, `applyOpenAIGptChatReplyGuard` short-circuits and replies pass through untouched.
- What did NOT change (scope boundary): default behavior is identical — the guard still fires for all existing flows unless the env var is explicitly set. No new config-file key, no per-agent override, no provider/model matrix change, no changes to the shortening logic itself.

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [x] Other (auto-reply / agent runner reply post-processing)

## Linked Issue/PR
- Closes #82910
- [x] This PR fixes a bug or regression

## Root Cause
- Root cause: `applyOpenAIGptChatReplyGuard` was introduced with hardcoded ack/soft-cap thresholds and no opt-out path. Any user hitting its preconditions (gpt-5* on openai/openai-codex, short prompt without detail/depth/explain/compare/why/how) gets their reply truncated with a literal `"..."`, with no documented way to turn it off.
- Missing detection / guardrail: the brevity guard shipped without a config or env opt-out and without an emitted log line, so end users cannot identify or disable the source of the truncation.
- Contributing context (if known): the issue reporter had to short-circuit the function by `sed`-patching the hashed `dist/` bundle after every install.

## Regression Test Plan
- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/auto-reply/reply/agent-runner-execution.brevity-guard-opt-out.test.ts` (new)
- Scenario the test should lock in:
  1. Baseline — a chatty reply on `openai`/`gpt-5` is still shortened when the env var is unset (regression protection for default behavior).
  2. Opt-out — same input with `OPENCLAW_DISABLE_GPT_CHAT_BREVITY_GUARD=1` is left untouched.
  3. Case-insensitive — `TRUE` also opts out.
- Why this is the smallest reliable guardrail: directly exercises the new short-circuit branch and pins the default path so a future refactor can't silently re-break either side. Env is saved/restored per-test via beforeEach/afterEach.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes
- New opt-in env var: `OPENCLAW_DISABLE_GPT_CHAT_BREVITY_GUARD=1` (or `true`) disables the GPT-5 chat reply brevity guard for the process. Unset → existing behavior, fully unchanged.

## Security Impact (required)
- New permissions/capabilities? No
- This is a process-local env-var opt-out for a post-processing text shortener. No new I/O, no new network/file/auth surface, no change to default behavior, no change to provider/model handling. The guarded code path is purely reply-text mutation; disabling it cannot leak data or escalate privilege.
