### PR TITLE
fix(sessions): include agent identity names in a2a contexts

### DIFF
--- a/src/agents/tools/sessions-send-helpers.test.ts
+++ b/src/agents/tools/sessions-send-helpers.test.ts
@@ -1,7 +1,13 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createSessionConversationTestRegistry } from "../../test-utils/session-conversation-registry.js";
-import { resolveAnnounceTargetFromKey, resolvePingPongTurns } from "./sessions-send-helpers.js";
+import {
+  buildAgentToAgentAnnounceContext,
+  buildAgentToAgentMessageContext,
+  buildAgentToAgentReplyContext,
+  resolveAnnounceTargetFromKey,
+  resolvePingPongTurns,
+} from "./sessions-send-helpers.js";
 
 describe("resolveAnnounceTargetFromKey", () => {
   beforeEach(() => {
@@ -61,6 +67,59 @@ describe("resolveAnnounceTargetFromKey", () => {
       to: "oc_group_chat:topic:om_topic_root:sender:ou_topic_user",
       threadId: undefined,
     });
+  });
+});
+
+describe("agent-to-agent context identity", () => {
+  const cfg = {
+    agents: {
+      list: [
+        { id: "habit", identity: { name: "Stevo" } },
+        { id: "story", identity: { name: "Story Bot" } },
+      ],
+    },
+  } as never;
+
+  it("includes configured requester identity name in the initial message context", () => {
+    const context = buildAgentToAgentMessageContext({
+      cfg,
+      requesterSessionKey: "agent:habit:telegram:direct:6344794319",
+      requesterChannel: "telegram",
+      targetSessionKey: "agent:story:main",
+    });
+
+    expect(context).toContain("Agent 1 (requester) name: Stevo.");
+    expect(context.indexOf("Agent 1 (requester) name: Stevo.")).toBeLessThan(
+      context.indexOf("Agent 1 (requester) session:"),
+    );
+  });
+
+  it("includes configured requester and target identity names in reply and announce contexts", () => {
+    const shared = {
+      cfg,
+      requesterSessionKey: "agent:habit:telegram:direct:6344794319",
+      requesterChannel: "telegram",
+      targetSessionKey: "agent:story:main",
+      targetChannel: "internal",
+    };
+
+    const replyContext = buildAgentToAgentReplyContext({
+      ...shared,
+      currentRole: "target",
+      turn: 1,
+      maxTurns: 2,
+    });
+    expect(replyContext).toContain("Agent 1 (requester) name: Stevo.");
+    expect(replyContext).toContain("Agent 2 (target) name: Story Bot.");
+
+    const announceContext = buildAgentToAgentAnnounceContext({
+      ...shared,
+      originalMessage: "check the metrics",
+      roundOneReply: "done",
+      latestReply: "done",
+    });
+    expect(announceContext).toContain("Agent 1 (requester) name: Stevo.");
+    expect(announceContext).toContain("Agent 2 (target) name: Story Bot.");
   });
 });
 

--- a/src/agents/tools/sessions-send-helpers.ts
+++ b/src/agents/tools/sessions-send-helpers.ts
@@ -5,6 +5,8 @@ import {
 import { resolveSessionConversationRef } from "../../channels/plugins/session-conversation.js";
 import { normalizeChannelId as normalizeChatChannelId } from "../../channels/registry.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { resolveAgentIdentity } from "../identity.js";
 import { ANNOUNCE_SKIP_TOKEN, REPLY_SKIP_TOKEN } from "./sessions-send-tokens.js";
 export {
   isAnnounceSkip,
@@ -45,25 +47,49 @@ export function resolveAnnounceTargetFromKey(sessionKey: string): AnnounceTarget
   };
 }
 
+function resolveAgentIdentityName(params: {
+  cfg?: OpenClawConfig;
+  sessionKey?: string;
+}): string | undefined {
+  if (!params.cfg || !params.sessionKey) {
+    return undefined;
+  }
+  const agentId = resolveAgentIdFromSessionKey(params.sessionKey);
+  const name = resolveAgentIdentity(params.cfg, agentId)?.name?.trim();
+  return name || undefined;
+}
+
 function buildAgentSessionLines(params: {
+  cfg?: OpenClawConfig;
   requesterSessionKey?: string;
   requesterChannel?: string;
   targetSessionKey: string;
   targetChannel?: string;
 }): string[] {
+  const requesterName = resolveAgentIdentityName({
+    cfg: params.cfg,
+    sessionKey: params.requesterSessionKey,
+  });
+  const targetName = resolveAgentIdentityName({
+    cfg: params.cfg,
+    sessionKey: params.targetSessionKey,
+  });
   return [
+    requesterName ? `Agent 1 (requester) name: ${requesterName}.` : undefined,
     params.requesterSessionKey
       ? `Agent 1 (requester) session: ${params.requesterSessionKey}.`
       : undefined,
     params.requesterChannel
       ? `Agent 1 (requester) channel: ${params.requesterChannel}.`
       : undefined,
+    targetName ? `Agent 2 (target) name: ${targetName}.` : undefined,
     `Agent 2 (target) session: ${params.targetSessionKey}.`,
     params.targetChannel ? `Agent 2 (target) channel: ${params.targetChannel}.` : undefined,
   ].filter((line): line is string => Boolean(line));
 }
 
 export function buildAgentToAgentMessageContext(params: {
+  cfg?: OpenClawConfig;
   requesterSessionKey?: string;
   requesterChannel?: string;
   targetSessionKey: string;
@@ -75,6 +101,7 @@ export function buildAgentToAgentMessageContext(params: {
 }
 
 export function buildAgentToAgentReplyContext(params: {
+  cfg?: OpenClawConfig;
   requesterSessionKey?: string;
   requesterChannel?: string;
   targetSessionKey: string;
@@ -96,6 +123,7 @@ export function buildAgentToAgentReplyContext(params: {
 }
 
 export function buildAgentToAgentAnnounceContext(params: {
+  cfg?: OpenClawConfig;
   requesterSessionKey?: string;
   requesterChannel?: string;
   targetSessionKey: string;

--- a/src/agents/tools/sessions-send-tool.a2a.test.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.test.ts
@@ -207,6 +207,31 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
     expect(gatewayCalls.find((call) => call.method === "send")).toBeUndefined();
   });
 
+  it("includes configured agent identity names in announce prompts", async () => {
+    await runSessionsSendA2AFlow({
+      cfg: {
+        agents: {
+          list: [
+            { id: "habit", identity: { name: "Stevo" } },
+            { id: "story", identity: { name: "Story Bot" } },
+          ],
+        },
+      } as never,
+      targetSessionKey: "agent:story:main",
+      displayKey: "agent:story:main",
+      message: "Test message",
+      announceTimeoutMs: 10_000,
+      maxPingPongTurns: 0,
+      requesterSessionKey: "agent:habit:telegram:direct:6344794319",
+      requesterChannel: "telegram",
+      roundOneReply: "Worker completed successfully",
+    });
+
+    const stepInput = firstMockArg(vi.mocked(runAgentStep), "agent step");
+    expect(stepInput.extraSystemPrompt).toContain("Agent 1 (requester) name: Stevo.");
+    expect(stepInput.extraSystemPrompt).toContain("Agent 2 (target) name: Story Bot.");
+  });
+
   it.each(["NO_REPLY", "HEARTBEAT_OK"])(
     "suppresses exact announce control reply %s before channel delivery",
     async (announceReply) => {

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { CallGatewayOptions } from "../../gateway/call.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
@@ -35,6 +36,7 @@ let sessionsSendA2ADeps: {
 } = defaultSessionsSendA2ADeps;
 
 export async function runSessionsSendA2AFlow(params: {
+  cfg?: OpenClawConfig;
   targetSessionKey: string;
   displayKey: string;
   message: string;
@@ -95,6 +97,7 @@ export async function runSessionsSendA2AFlow(params: {
         const currentRole =
           currentSessionKey === params.requesterSessionKey ? "requester" : "target";
         const replyPrompt = buildAgentToAgentReplyContext({
+          cfg: params.cfg,
           requesterSessionKey: params.requesterSessionKey,
           requesterChannel: params.requesterChannel,
           targetSessionKey: params.displayKey,
@@ -126,6 +129,7 @@ export async function runSessionsSendA2AFlow(params: {
     }
 
     const announcePrompt = buildAgentToAgentAnnounceContext({
+      cfg: params.cfg,
       requesterSessionKey: params.requesterSessionKey,
       requesterChannel: params.requesterChannel,
       targetSessionKey: params.displayKey,

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -412,6 +412,7 @@ export function createSessionsSendTool(opts?: {
             });
 
       const agentMessageContext = buildAgentToAgentMessageContext({
+        cfg,
         requesterSessionKey: opts?.agentSessionKey,
         requesterChannel: opts?.agentChannel,
         targetSessionKey: displayKey,
@@ -478,6 +479,7 @@ export function createSessionsSendTool(opts?: {
           return;
         }
         void runSessionsSendA2AFlow({
+          cfg,
           targetSessionKey: resolvedKey,
           displayKey,
           message,


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->
## Summary
- Add configured agent identity names to the shared `sessions_send` agent-to-agent context lines.
- Thread runtime config into the initial message context, ping-pong reply context, and announce context so receiving agents see the actual requester name instead of inferring it from a session key.
- Add regressions covering direct context builders and the announce prompt path.

## Test Plan
- Added regression coverage in `src/agents/tools/sessions-send-helpers.test.ts` for requester/target identity names.
- Added regression coverage in `src/agents/tools/sessions-send-tool.a2a.test.ts` for announce prompts receiving configured identity names.
- Ran source-level proof below against the API-downloaded patched files.
- Full local vitest/check: not run locally because this session is continuing API-only without a full OpenClaw checkout/node_modules.

## Real behavior proof
Behavior or issue addressed: `sessions_send` inter-agent prompts omitted the configured `identity.name`, so receivers could misattribute the sender to the default/main agent.

Real environment tested: API-downloaded OpenClaw source files for issue #38570 in `/tmp/openclaw-api-38570`, patched locally without cloning the repository.

Exact steps or command run after this patch:

```bash
cd /tmp/openclaw-api-38570 && node proof-source-probe.mjs | tee proof-source-probe.out
```

Evidence after fix:

```text
PASS helper regression expects requester identity name
PASS helper regression expects target identity name
PASS A2A regression expects identity names in announce prompt
PASS helper emits requester identity name line
PASS helper emits target identity name line
PASS helper resolves configured identity names from session agent ids
PASS initial sessions_send context passes runtime cfg to helper
PASS A2A flow accepts cfg and passes it into reply/announce helpers
```

Observed result after fix: the patched source now emits requester and target identity-name lines, the initial `sessions_send` context passes runtime config to the helper, and the A2A reply/announce flow passes config into its context builders.

What was not tested: a full local OpenClaw vitest/typecheck run was not executed because the workflow is API-only; GitHub Actions should run the repo checks on the draft PR.

## Risk/Notes
- The new name lines are only emitted when an agent identity name is configured and resolvable from the session key.
- Existing session/channel lines remain unchanged, preserving current context format for configurations without identity names.

Fixes #38570
