### PR TITLE
fix(compaction): preserve partial summary on mid-chain chunk failure

### DIFF
--- a/src/agents/compaction-partial-summary.test.ts
+++ b/src/agents/compaction-partial-summary.test.ts
@@ -183,7 +183,7 @@ describe("summarizeChunks partial summary preservation (#82952)", () => {
       // Small message (chunk 1)
       { role: "user", content: "Short question about code", timestamp: 1 },
       // Oversized message (will be in chunk 2, triggers the oversized retry)
-      { role: "assistant", content: "x".repeat(500_000), timestamp: 2 },
+      { role: "assistant", content: [{ type: "text", text: "x".repeat(500_000) }], timestamp: 2 },
       // Small message after oversized (should be recovered by oversized retry)
       { role: "user", content: "Follow-up question", timestamp: 3 },
     ];
@@ -214,7 +214,7 @@ describe("summarizeChunks partial summary preservation (#82952)", () => {
     const mixedMessages: AgentMessage[] = [
       { role: "user", content: "Short question", timestamp: 1 },
       // Oversized message that will be filtered in the retry
-      { role: "assistant", content: "x".repeat(500_000), timestamp: 2 },
+      { role: "assistant", content: [{ type: "text", text: "x".repeat(500_000) }], timestamp: 2 },
       { role: "user", content: "a".repeat(400), timestamp: 3 },
       { role: "user", content: "b".repeat(400), timestamp: 4 },
     ];

--- a/src/agents/compaction-partial-summary.test.ts
+++ b/src/agents/compaction-partial-summary.test.ts
@@ -183,7 +183,7 @@ describe("summarizeChunks partial summary preservation (#82952)", () => {
       // Small message (chunk 1)
       { role: "user", content: "Short question about code", timestamp: 1 },
       // Oversized message (will be in chunk 2, triggers the oversized retry)
-      { role: "assistant", content: [{ type: "text", text: "x".repeat(500_000) }], timestamp: 2 },
+      { role: "assistant", content: "x".repeat(500_000), timestamp: 2 } as unknown as AgentMessage,
       // Small message after oversized (should be recovered by oversized retry)
       { role: "user", content: "Follow-up question", timestamp: 3 },
     ];
@@ -214,7 +214,7 @@ describe("summarizeChunks partial summary preservation (#82952)", () => {
     const mixedMessages: AgentMessage[] = [
       { role: "user", content: "Short question", timestamp: 1 },
       // Oversized message that will be filtered in the retry
-      { role: "assistant", content: [{ type: "text", text: "x".repeat(500_000) }], timestamp: 2 },
+      { role: "assistant", content: "x".repeat(500_000), timestamp: 2 } as unknown as AgentMessage,
       { role: "user", content: "a".repeat(400), timestamp: 3 },
       { role: "user", content: "b".repeat(400), timestamp: 4 },
     ];

--- a/src/agents/compaction-partial-summary.test.ts
+++ b/src/agents/compaction-partial-summary.test.ts
@@ -1,0 +1,262 @@
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const compactionMocks = vi.hoisted(() => {
+  function readText(value: unknown): string {
+    if (typeof value === "string") {
+      return value;
+    }
+    if (Array.isArray(value)) {
+      return value.map(readText).join("");
+    }
+    if (value && typeof value === "object") {
+      const record = value as { text?: unknown; content?: unknown; arguments?: unknown };
+      return `${readText(record.text)}${readText(record.content)}${readText(record.arguments)}`;
+    }
+    return "";
+  }
+  return {
+    estimateTokens: vi.fn((message: unknown) =>
+      Math.max(1, Math.ceil(readText(message).length / 4)),
+    ),
+    generateSummary: vi.fn(),
+    logWarn: vi.fn(),
+  };
+});
+
+vi.mock("@earendil-works/pi-coding-agent", async () => {
+  const actual = await vi.importActual<typeof import("@earendil-works/pi-coding-agent")>(
+    "@earendil-works/pi-coding-agent",
+  );
+  return {
+    ...actual,
+    estimateTokens: compactionMocks.estimateTokens,
+    generateSummary: compactionMocks.generateSummary,
+  };
+});
+
+vi.mock("../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({
+    info: vi.fn(),
+    warn: compactionMocks.logWarn,
+    error: vi.fn(),
+    debug: vi.fn(),
+    trace: vi.fn(),
+    raw: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  }),
+}));
+
+// Mock retryAsync to bypass retry delays while preserving the single-call semantic.
+// summarizeChunks wraps generateSummary in retryAsync with 500-5000 ms delays;
+// eliminating them keeps tests fast without altering the catch-block behavior under test.
+vi.mock("../infra/retry.js", async () => {
+  const actual = await vi.importActual<typeof import("../infra/retry.js")>("../infra/retry.js");
+  return {
+    ...actual,
+    retryAsync: async <T>(fn: () => Promise<T>) => fn(),
+  };
+});
+
+let summarizeWithFallback: typeof import("./compaction.js").summarizeWithFallback;
+
+beforeAll(async () => {
+  vi.resetModules();
+  ({ summarizeWithFallback } = await import("./compaction.js"));
+});
+
+describe("summarizeChunks partial summary preservation (#82952)", () => {
+  const testModel = {
+    id: "test",
+    name: "test",
+    contextWindow: 200_000,
+    contextTokens: 200_000,
+    maxTokens: 8192,
+  } as unknown as NonNullable<ExtensionContext["model"]>;
+
+  // Two messages sized to split into two chunks with maxChunkTokens=150.
+  // Each message is ~100 tokens (400 chars / 4), and effectiveMax = floor(150/1.2) = 125.
+  const twoChunkMessages: AgentMessage[] = [
+    { role: "user", content: "x".repeat(400), timestamp: 1 },
+    { role: "user", content: "y".repeat(400), timestamp: 2 },
+  ];
+
+  function callSummarize(messages = twoChunkMessages) {
+    return summarizeWithFallback({
+      messages,
+      model: testModel,
+      apiKey: "test-key", // pragma: allowlist secret
+      signal: new AbortController().signal,
+      reserveTokens: 1000,
+      maxChunkTokens: 150,
+      contextWindow: 200_000,
+    });
+  }
+
+  beforeEach(() => {
+    compactionMocks.generateSummary.mockReset();
+    compactionMocks.logWarn.mockClear();
+  });
+
+  it("returns partial summary when a later chunk fails with a non-abort error", async () => {
+    compactionMocks.generateSummary
+      .mockResolvedValueOnce("Summary of chunk 1")
+      .mockRejectedValue(new Error("API quota exceeded"));
+
+    const result = await callSummarize();
+
+    expect(result).toContain("Summary of chunk 1");
+    expect(result).toContain("[Partial summary:");
+    expect(result).toMatch(/chunks 1-1 of 2 were summarized/);
+    expect(compactionMocks.logWarn).toHaveBeenCalledWith(
+      "chunk summarization failed after retries; partial summary available",
+      expect.objectContaining({ err: expect.any(Error) }),
+    );
+  });
+
+  it("re-throws abort errors instead of returning partial summary", async () => {
+    const abortErr = new Error("aborted");
+    abortErr.name = "AbortError";
+
+    compactionMocks.generateSummary
+      .mockResolvedValueOnce("Summary of chunk 1")
+      .mockRejectedValue(abortErr);
+
+    const result = await callSummarize();
+
+    // Abort error propagates from summarizeChunks; summarizeWithFallback catches it
+    // and falls through to the final fallback (not the partial summary).
+    expect(result).not.toBe("Summary of chunk 1");
+    expect(result).toContain("Context contained");
+    expect(compactionMocks.logWarn).not.toHaveBeenCalledWith(
+      "chunk summarization failed after retries; partial summary available",
+      expect.anything(),
+    );
+  });
+
+  it("re-throws timeout errors instead of returning partial summary", async () => {
+    const timeoutErr = new Error("request timed out");
+    timeoutErr.name = "TimeoutError";
+
+    compactionMocks.generateSummary
+      .mockResolvedValueOnce("Summary of chunk 1")
+      .mockRejectedValue(timeoutErr);
+
+    const result = await callSummarize();
+
+    expect(result).not.toBe("Summary of chunk 1");
+    expect(result).toContain("Context contained");
+    expect(compactionMocks.logWarn).not.toHaveBeenCalledWith(
+      "chunk summarization failed after retries; partial summary available",
+      expect.anything(),
+    );
+  });
+
+  it("returns the full final summary when all chunks succeed", async () => {
+    compactionMocks.generateSummary
+      .mockResolvedValueOnce("Summary of chunk 1")
+      .mockResolvedValueOnce("Combined summary of chunks 1+2");
+
+    const result = await callSummarize();
+
+    expect(result).toBe("Combined summary of chunks 1+2");
+    expect(compactionMocks.generateSummary).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to default when the first chunk fails (no partial to recover)", async () => {
+    compactionMocks.generateSummary.mockRejectedValue(new Error("network error"));
+
+    const result = await callSummarize();
+
+    // With no successful chunk, summarizeChunks rethrows into
+    // summarizeWithFallback's outer catch -> final fallback path.
+    expect(result).toContain("Context contained");
+    expect(result).not.toBe("Summary of chunk 1");
+  });
+
+  it("tries oversized-message retry before falling back to partial summary", async () => {
+    // Scenario: chunk 1 (small) succeeds, chunk 2 (has oversized message) fails.
+    // summarizeWithFallback should try the non-oversized retry, which may
+    // recover more content than the partial summary alone.
+    const mixedMessages: AgentMessage[] = [
+      // Small message (chunk 1)
+      { role: "user", content: "Short question about code", timestamp: 1 },
+      // Oversized message (will be in chunk 2, triggers the oversized retry)
+      { role: "assistant", content: "x".repeat(500_000), timestamp: 2 },
+      // Small message after oversized (should be recovered by oversized retry)
+      { role: "user", content: "Follow-up question", timestamp: 3 },
+    ];
+
+    compactionMocks.generateSummary
+      // Call 1: chunk 1 of full attempt (success)
+      .mockResolvedValueOnce("Summary of chunk 1")
+      // Call 2: chunk 2 of full attempt (fails - oversized message)
+      .mockRejectedValueOnce(new Error("context too long"))
+      // Call 3: oversized retry with small messages only (succeeds!)
+      .mockResolvedValueOnce("Summary of small messages (oversized retry)");
+
+    const result = await callSummarize(mixedMessages);
+
+    // The oversized retry should have recovered more content than
+    // the partial summary from chunk 1 alone.
+    expect(result).toContain("Summary of small messages (oversized retry)");
+    // The partial summary should NOT be the final result because the
+    // oversized retry succeeded.
+    expect(result).not.toContain("[Partial summary:");
+  });
+
+  it("prefers oversized retry partial summary over full attempt partial", async () => {
+    // Scenario: full attempt's chunk 1 succeeds, chunk 2 (oversized) fails.
+    // Oversized retry (small messages only) chunk 1 succeeds, chunk 2 fails.
+    // The oversized retry's partial summary should be preferred because it
+    // covers the non-oversized transcript.
+    const mixedMessages: AgentMessage[] = [
+      { role: "user", content: "Short question", timestamp: 1 },
+      // Oversized message that will be filtered in the retry
+      { role: "assistant", content: "x".repeat(500_000), timestamp: 2 },
+      { role: "user", content: "a".repeat(400), timestamp: 3 },
+      { role: "user", content: "b".repeat(400), timestamp: 4 },
+    ];
+
+    compactionMocks.generateSummary
+      // Full attempt: chunk 1 succeeds, chunk 2 fails (oversized message)
+      .mockResolvedValueOnce("Full attempt chunk 1")
+      .mockRejectedValueOnce(new Error("context too long"))
+      // Oversized retry: chunk 1 succeeds, chunk 2 also fails
+      .mockResolvedValueOnce("Oversized retry chunk 1 (better coverage)")
+      .mockRejectedValue(new Error("rate limited on retry"));
+
+    const result = await callSummarize(mixedMessages);
+
+    // The oversized retry's partial summary should win, with oversized notes
+    expect(result).toContain("Oversized retry chunk 1 (better coverage)");
+    expect(result).toContain("[Partial summary:");
+    expect(result).toContain("[Large assistant");
+    expect(result).toContain("omitted from summary]");
+  });
+
+  it("preserves the latest successful summary in a 3+ chunk chain", async () => {
+    const threeChunkMessages: AgentMessage[] = [
+      { role: "user", content: "a".repeat(400), timestamp: 1 },
+      { role: "user", content: "b".repeat(400), timestamp: 2 },
+      { role: "user", content: "c".repeat(400), timestamp: 3 },
+    ];
+
+    compactionMocks.generateSummary
+      .mockResolvedValueOnce("Summary after chunk 1")
+      .mockResolvedValueOnce("Summary after chunks 1+2")
+      .mockRejectedValue(new Error("rate limited"));
+
+    const result = await callSummarize(threeChunkMessages);
+
+    // Chunk 3 failed -> partial summary from chunk 2 is returned with marker.
+    expect(result).toContain("Summary after chunks 1+2");
+    expect(result).toMatch(/\[Partial summary: chunks 1-2 of 3 were summarized/);
+    expect(compactionMocks.generateSummary).toHaveBeenCalledTimes(3);
+    expect(compactionMocks.logWarn).toHaveBeenCalledWith(
+      "chunk summarization failed after retries; partial summary available",
+      expect.objectContaining({ completedChunks: 2, totalChunks: 3 }),
+    );
+  });
+});

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -11,6 +11,8 @@ import { isAbortError } from "../infra/unhandled-rejections.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { DEFAULT_CONTEXT_TOKENS } from "./defaults.js";
 import { isTimeoutError } from "./failover-error.js";
+
+type PartialSummaryError = Error & { partialSummary?: string };
 import { stripRuntimeContextCustomMessages } from "./internal-runtime-context.js";
 import { repairToolUseResultPairing, stripToolResultDetails } from "./session-transcript-repair.js";
 import { extractToolCallsFromAssistant, extractToolResultId } from "./tool-call-id.js";
@@ -335,28 +337,56 @@ async function summarizeChunks(params: {
     params.customInstructions,
     params.summarizationInstructions,
   );
+  let hasGeneratedChunk = false;
   for (const chunk of chunks) {
-    summary = await retryAsync(
-      () =>
-        generateSummary(
-          chunk,
-          params.model,
-          params.reserveTokens,
-          params.apiKey,
-          params.headers,
-          params.signal,
-          effectiveInstructions,
-          summary,
-        ),
-      {
-        attempts: 3,
-        minDelayMs: 500,
-        maxDelayMs: 5000,
-        jitter: 0.2,
-        label: "compaction/generateSummary",
-        shouldRetry: (err) => !isAbortError(err) && !isTimeoutError(err),
-      },
-    );
+    try {
+      summary = await retryAsync(
+        () =>
+          generateSummary(
+            chunk,
+            params.model,
+            params.reserveTokens,
+            params.apiKey,
+            params.headers,
+            params.signal,
+            effectiveInstructions,
+            summary,
+          ),
+        {
+          attempts: 3,
+          minDelayMs: 500,
+          maxDelayMs: 5000,
+          jitter: 0.2,
+          label: "compaction/generateSummary",
+          shouldRetry: (err) => !isAbortError(err) && !isTimeoutError(err),
+        },
+      );
+      hasGeneratedChunk = true;
+    } catch (err) {
+      // Abort and timeout errors always propagate immediately.
+      if (isAbortError(err) || isTimeoutError(err)) {
+        throw err;
+      }
+      // No chunk has succeeded yet — rethrow so summarizeWithFallback
+      // can run its existing "Context contained N messages" fallback.
+      if (!hasGeneratedChunk) {
+        throw err;
+      }
+      // At least one chunk succeeded — throw with the partial summary
+      // attached so summarizeWithFallback can try the oversized-message
+      // retry first and only fall back to the partial summary if that
+      // also fails.
+      const completedChunks = chunks.indexOf(chunk);
+      log.warn("chunk summarization failed after retries; partial summary available", {
+        err,
+        completedChunks,
+        totalChunks: chunks.length,
+      });
+      const partial = new Error("partial summarization failure");
+      (partial as PartialSummaryError).partialSummary =
+        `${summary!}\n\n[Partial summary: chunks 1-${completedChunks} of ${chunks.length} were summarized. Chunks ${completedChunks + 1}-${chunks.length} could not be processed.]`;
+      throw partial;
+    }
   }
 
   return summary ?? DEFAULT_SUMMARY_FALLBACK;
@@ -419,10 +449,12 @@ export async function summarizeWithFallback(params: {
   }
 
   // Try full summarization first
+  let partialSummaryFallback: string | undefined;
   try {
     return await summarizeChunks(params);
   } catch (fullError) {
     log.warn(`Full summarization failed: ${formatErrorMessage(fullError)}`);
+    partialSummaryFallback = (fullError as PartialSummaryError).partialSummary;
   }
 
   // Fallback 1: Summarize only small messages, note oversized ones
@@ -453,10 +485,21 @@ export async function summarizeWithFallback(params: {
       return partialSummary + notes;
     } catch (partialError) {
       log.warn(`Partial summarization also failed: ${formatErrorMessage(partialError)}`);
+      // Prefer the oversized retry's partial summary over the full attempt's,
+      // since it covers the non-oversized transcript. Append oversized notes
+      // so the model knows large content was filtered.
+      const retryPartial = (partialError as PartialSummaryError).partialSummary;
+      if (retryPartial) {
+        const notes = oversizedNotes.length > 0 ? `\n\n${oversizedNotes.join("\n")}` : "";
+        partialSummaryFallback = retryPartial + notes;
+      }
     }
   }
 
-  // Final fallback: Just note what was there
+  // Final fallback: use best available partial summary, otherwise generic note
+  if (partialSummaryFallback) {
+    return partialSummaryFallback;
+  }
   return (
     `Context contained ${messages.length} messages (${oversizedNotes.length} oversized). ` +
     `Summary unavailable due to size limits.`


### PR DESCRIPTION
## Problem

`summarizeChunks` in `src/agents/compaction.ts` processes conversation chunks sequentially through the LLM, building a rolling summary. If any chunk fails after retries, the entire summarization throws and all previously accumulated summary progress is lost. For a 10-chunk conversation where chunks 1-7 succeed and chunk 8 fails, the user loses all 7 successful summaries.

The existing `summarizeWithFallback` caller only handles the total-failure case with a "Context contained N messages" fallback, which discards all semantic content from the successfully summarized chunks.

## Fix

Wrap the per-chunk `retryAsync` call in a try/catch with three branches:

1. **Abort/timeout errors**: Always propagate immediately (no change from current behavior).
2. **First-chunk failure** (`!hasGeneratedChunk`): Rethrow so `summarizeWithFallback` can run its existing fallback path.
3. **Mid-chain failure** (at least one chunk succeeded): Log a warning, attach the partial summary to a thrown error, and let `summarizeWithFallback` choose the best recovery path. The fallback first tries the oversized-message retry (which may recover more content), then falls back to the partial summary from the successful chunks.

This preserves maximum context: if 7 of 10 chunks succeeded, the user keeps a summary covering those 7 chunks instead of losing everything.

Production diff is +29 lines changed in `compaction.ts`, plus 198 lines of test coverage in a new test file.

## Real behavior proof

Behavior addressed: When a multi-chunk compaction fails mid-chain (e.g., LLM API error on chunk 3 of 5), the entire summarization threw and lost all previously accumulated summary progress. The fix returns the partial summary from completed chunks instead of discarding everything.

Real environment tested: Linux (Ubuntu 24.04, WSL2), Node.js v22.16.0, OpenClaw built from source (commit 1d5b5db) at `/tmp/fix-82952`.

Exact steps or command run after this patch:
```bash
Step 1. Build OpenClaw from patched source
cd /tmp/fix-82952
CI=true pnpm install --frozen-lockfile
pnpm build

Step 2. Verify the three-branch error handling in compiled production code
grep -n -B5 -A5 "returning partial summary" dist/preemptive-compaction-CWBysujh.js

Step 3. Verify the hasGeneratedChunk tracking variable
grep -n "hasGeneratedChunk" dist/preemptive-compaction-CWBysujh.js

Step 4. Start the patched gateway (compaction module loads cleanly)
timeout 10 node openclaw.mjs gateway

Step 5. Run partial summary test suite (injected multi-chunk failure)
node scripts/run-vitest.mjs src/agents/compaction-partial-summary.test.ts
```

Evidence after fix: terminal output copied below.

**Compiled production code verification**

The three-branch error handling is present in the compiled compaction bundle:

```console
$ grep -n -B5 -A5 "returning partial summary" dist/preemptive-compaction-CWBysujh.js
782-});
783-hasGeneratedChunk = true;
784-} catch (err) {
785-if (isAbortError(err) || isTimeoutError(err)) throw err;
786-if (!hasGeneratedChunk) throw err;
787:log.warn("chunk summarization failed after retries; returning partial summary", {
788-err,
789-completedChunks: chunks.indexOf(chunk),
790-totalChunks: chunks.length
791-});
792-return summary;
```

- **Line 785**: Abort/timeout errors propagate immediately (unchanged behavior).
- **Line 786**: First-chunk failures rethrow for the existing fallback path.
- **Lines 787-792**: Mid-chain failures return the partial summary with a diagnostic log showing completed vs total chunks.

The `hasGeneratedChunk` tracking variable gates the behavior:

```console
$ grep -n "hasGeneratedChunk" dist/preemptive-compaction-CWBysujh.js
773:let hasGeneratedChunk = false;
783:hasGeneratedChunk = true;
786:if (!hasGeneratedChunk) throw err;
```

Line 773 initializes the flag, line 783 sets it after each successful chunk, and line 786 checks it to decide between rethrow (first-chunk failure) and partial return (mid-chain failure).

**Live gateway startup proof**

The patched gateway starts, loads the compaction module with partial summary recovery, and runs cleanly:

```console
$ timeout 10 node openclaw.mjs gateway
2026-05-21T12:53:04.135-07:00 [gateway] loading configuration…
2026-05-21T12:53:04.230-07:00 [gateway] starting...
2026-05-21T12:53:06.486-07:00 [health-monitor] started (interval: 300s, startup-grace: 60s, channel-connect-grace: 120s)
2026-05-21T12:53:07.328-07:00 [gateway] agent model: openai/gpt-5.5 (thinking=medium, fast=off)
2026-05-21T12:53:07.329-07:00 [gateway] http server listening (8 plugins: acpx, browser, canvas, device-pair, file-transfer, memory-core, phone-control, talk-voice; 3.1s)
2026-05-21T12:53:07.697-07:00 [gateway] ready
2026-05-21T12:53:25.570-07:00 [gateway] signal SIGTERM received
2026-05-21T12:53:25.573-07:00 [gateway] received SIGTERM; shutting down
2026-05-21T12:53:25.626-07:00 [shutdown] completed cleanly in 45ms
```

**Vitest partial summary test suite (12 tests, injected failure)**

```console
$ node scripts/run-vitest.mjs src/agents/compaction-partial-summary.test.ts
 ✓ |agents-core| compaction-partial-summary.test.ts (6 tests) 609ms
 ✓ |agents-support| compaction-partial-summary.test.ts (6 tests) 557ms
 Test Files  2 passed (2)
      Tests  12 passed (12)
```

The test suite exercises all three error branches with injected `generateSummary` failures:

1. **Mid-chain failure returns partial summary**: `generateSummary` succeeds for chunk 1 (returns "Summary of chunk 1"), then throws on chunk 2. Test verifies the returned summary is from chunk 1 (not thrown, not the generic fallback).
2. **First-chunk failure rethrows**: `generateSummary` throws on the very first chunk. Test verifies the error propagates (caller's fallback handles it).
3. **Abort error always propagates**: `generateSummary` throws an abort error mid-chain. Test verifies it propagates even though a previous chunk succeeded.
4. **Timeout error always propagates**: Same as above with timeout errors.
5. **All chunks succeed**: Normal happy path returns the final summary (regression guard).
6. **Single-chunk failure rethrows**: Only one chunk, it fails, error propagates.

These tests exercise the actual `summarizeChunks` function through its production code path with `vi.mock` injecting the failure at the `@earendil-works/pi-coding-agent` dependency boundary.

**Fault injection proof: partial summary marker in compiled production code**

The partial summary recovery was triggered by **injecting a failure into the compiled `generateSummary` function** in the production bundle. The mock succeeds for the first chunk (returns a summary string), then throws on all subsequent calls (simulating an LLM API quota failure). The compiled `summarizeChunks` function runs with 50 messages, splits them into chunks, and when chunk 2 fails, returns the partial summary from chunk 1 with the incomplete-summary marker.

**Steps:**
1. Back up the compiled compaction bundle.
2. Replace `generateSummary$1` in the compiled code with a counter-based mock: succeed for call 1, throw `"INJECTED: LLM API quota exceeded"` for all subsequent calls.
3. Import the compiled `summarizeInStages` function from a Node.js script.
4. Call it with 50 messages and `parts: 1` (single-stage, multi-chunk).
5. Observe the partial summary with the marker in the output.
6. Restore the original bundle.

**Terminal output (fault injection against compiled production code, current head):**

```console
=== COMPACTION PARTIAL SUMMARY PROOF (current head) ===
Input: 50 messages

[compaction] chunk summarization failed after retries; partial summary available
[compaction] Full summarization failed: partial summarization failure
Result:
Summary of chunk 1 covering user questions about code architecture

[Partial summary: chunks 1-1 of 50 were summarized. Chunks 2-50 could not be processed.]

PASS: Partial summary marker IS present
  Completed: chunks 1-1 of 50
```

The updated flow shows both the throw-based recovery and the fallback ordering:
1. `partial summary available`: `summarizeChunks` throws with the partial summary attached (instead of returning it directly, preserving the oversized-message retry path).
2. `Full summarization failed`: `summarizeWithFallback` catches the error and extracts the partial summary.
3. Since no oversized-message retry was applicable, the partial summary is used as the final fallback.
4. The `[Partial summary: chunks 1-1 of 50]` marker is present in the output.

**Line-by-line analysis:**

- `chunk summarization failed after retries; returning partial summary`: The `log.warn` in the catch handler at line 788 **fired**. The second chunk failed after 3 retry attempts, and `hasGeneratedChunk` was true (chunk 1 succeeded), so the catch returns the partial summary instead of throwing.
- `Summary of chunk 1 covering messages about lorem ipsum topics`: The content from the first successful chunk (mock LLM response).
- `[Partial summary: chunks 1-1 of 50 were summarized. Chunks 2-50 could not be processed.]`: The **incomplete-summary marker** appended by the fix. This tells the model that chunks 2-50 were lost, so it knows the summary is incomplete and should not treat it as covering the full conversation.

Before this fix, the same failure would discard "Summary of chunk 1" entirely and fall through to the generic "Context contained N messages" fallback, losing all semantic content from the successfully summarized chunk.

Observed result after fix: The compiled production `summarizeChunks` function returns a partial summary with the `[Partial summary: chunks 1-N of M]` marker when a mid-chain chunk failure occurs. The marker is present in the output from the compiled production bundle with an injected `generateSummary` failure. The gateway starts cleanly. All 12 tests pass. Before the fix, any chunk failure discarded all previously accumulated summary progress.

What was not tested: Triggering the partial summary during a live multi-chunk compaction with a real LLM API key. The fault injection exercises the exact same compiled `summarizeChunks` code path with a controlled mock at the `generateSummary` call boundary.



