### PR TITLE
fix(compaction): increase token estimation safety margin to 50%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/compaction: increase token estimation safety margin from 20% to 50% to reduce context overflow from CJK text, code tokens, and special tokens that the chars/4 heuristic underestimates. Thanks @SebTardif.
 - Agents/skills: apply the full effective tool policy pipeline to inline `command-dispatch: tool` skill dispatch before owner-only filtering, preserving configured allow, deny, sandbox, sender, group, and subagent restrictions. (#78525)
 - Codex/Telegram: synthesize native Codex tool progress from final turn snapshots so Telegram `/verbose` stays visible when command events arrive only at completion.
 - Mac app: make Channels settings open faster by deferring config-schema work, avoiding startup channel probes, caching decoded channel status rows, and showing only compact quick settings instead of the full generated channel schema.

--- a/src/agents/compaction.test.ts
+++ b/src/agents/compaction.test.ts
@@ -4,14 +4,21 @@ import { beforeAll, describe, expect, it, vi } from "vitest";
 import { makeAgentAssistantMessage } from "./test-helpers/agent-message-fixtures.js";
 import "./test-helpers/pi-coding-agent-token-mock.js";
 
+let SAFETY_MARGIN: typeof import("./compaction.js").SAFETY_MARGIN;
+let chunkMessagesByMaxTokens: typeof import("./compaction.js").chunkMessagesByMaxTokens;
 let estimateMessagesTokens: typeof import("./compaction.js").estimateMessagesTokens;
 let pruneHistoryForContextShare: typeof import("./compaction.js").pruneHistoryForContextShare;
 let splitMessagesByTokenShare: typeof import("./compaction.js").splitMessagesByTokenShare;
 
 beforeAll(async () => {
   vi.resetModules();
-  ({ estimateMessagesTokens, pruneHistoryForContextShare, splitMessagesByTokenShare } =
-    await import("./compaction.js"));
+  ({
+    SAFETY_MARGIN,
+    chunkMessagesByMaxTokens,
+    estimateMessagesTokens,
+    pruneHistoryForContextShare,
+    splitMessagesByTokenShare,
+  } = await import("./compaction.js"));
 });
 
 function makeMessage(id: number, size: number): AgentMessage {
@@ -367,5 +374,41 @@ describe("pruneHistoryForContextShare", () => {
     const keptToolResults = pruned.messages.filter((m) => m.role === "toolResult");
     expect(keptToolResults).toHaveLength(0);
     expect(pruned.droppedMessages).toBe(pruned.droppedMessagesList.length);
+  });
+});
+
+describe("SAFETY_MARGIN regression (#82956)", () => {
+  it("equals 1.5 to account for CJK and code token underestimation", () => {
+    expect(SAFETY_MARGIN).toBe(1.5);
+  });
+
+  it("chunkMessagesByMaxTokens splits within the tighter 1.5 margin", () => {
+    // Two messages whose combined estimated tokens exceed floor(maxTokens/1.5)
+    // but stay under floor(maxTokens/1.2), proving the wider margin is active.
+    const maxTokens = 3000;
+    // floor(3000 / 1.5) = 2000 (new effective max)
+    // floor(3000 / 1.2) = 2500 (old effective max)
+    // Each message: 4400 chars -> ceil(4400/4) = 1100 est. tokens
+    // Combined: 2200 tokens -- exceeds 2000 but not 2500
+    const content = "x".repeat(4400);
+    const messages: AgentMessage[] = [
+      { role: "user", content, timestamp: 1 },
+      { role: "user", content, timestamp: 2 },
+    ];
+
+    const combined = estimateMessagesTokens(messages);
+    expect(combined).toBeGreaterThan(Math.floor(maxTokens / 1.5));
+    expect(combined).toBeLessThan(Math.floor(maxTokens / 1.2));
+
+    const chunks = chunkMessagesByMaxTokens(messages, maxTokens);
+    expect(chunks.length).toBe(2);
+  });
+
+  it("effective chunk budget is 66% of raw limit with 1.5 margin", () => {
+    const maxTokens = 3000;
+    const effectiveMax = Math.floor(maxTokens / SAFETY_MARGIN);
+    expect(effectiveMax).toBe(2000);
+    // The old 1.2 margin would allow 2500 -- 25% more headroom consumed
+    expect(effectiveMax).toBeLessThan(Math.floor(maxTokens / 1.2));
   });
 });

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -19,7 +19,7 @@ const log = createSubsystemLogger("compaction");
 
 export const BASE_CHUNK_RATIO = 0.4;
 export const MIN_CHUNK_RATIO = 0.15;
-export const SAFETY_MARGIN = 1.2; // 20% buffer for estimateTokens() inaccuracy
+export const SAFETY_MARGIN = 1.5; // 50% buffer for estimateTokens() inaccuracy (chars/4 heuristic underestimates CJK, code tokens, and special tokens)
 const DEFAULT_SUMMARY_FALLBACK = "No prior history.";
 const DEFAULT_PARTS = 2;
 const MERGE_SUMMARIES_INSTRUCTIONS = [


### PR DESCRIPTION
## Problem

The `SAFETY_MARGIN` constant in `src/agents/compaction.ts` is set to 1.2 (20% buffer) to compensate for `estimateTokens()` inaccuracy. The code comments at line 247 explicitly acknowledge the limitation: *"chars/4 heuristic misses multi-byte chars, special tokens, code tokens, etc."*

A 20% buffer is insufficient for:
- **CJK text**: characters average ~1 token each vs ~4 chars/token for ASCII, so the heuristic underestimates by ~4x
- **Code with operators/braces**: each symbol consumes a full token
- **Base64/encoded content**: dense bytes inflate token count disproportionately

This causes the compaction chunking and threshold calculations to underestimate token usage, leading to context overflow.

## Fix

Increase `SAFETY_MARGIN` from 1.2 to 1.5 (50% buffer). This is the simplest conservative fix that helps for all content types without requiring a CJK-detection heuristic. The `estimateTokens()` function is imported from `@earendil-works/pi-coding-agent` and not controlled in this repo, so the margin is the downstream mitigation.

## Real behavior proof

- Behavior or issue addressed: `SAFETY_MARGIN` of 1.2 (20%) was insufficient for CJK text, code tokens, and special tokens where `chars/4` underestimates real token count.
- Real environment tested: macOS 15, Node 24.15.0, vitest 4.1.6.
- How the proof works: Regression tests import the real `SAFETY_MARGIN` constant and `chunkMessagesByMaxTokens` function from `compaction.ts`. Tests verify the constant value and demonstrate that the wider margin forces chunk splits where the old value would not.
- Tests added and passing (40 total across 2 shards, 3 new):
  ```
  ok equals 1.5 to account for CJK and code token underestimation
  ok chunkMessagesByMaxTokens splits within the tighter 1.5 margin
  ok effective chunk budget is 66% of raw limit with 1.5 margin
  ```
- Key test: Creates two messages with 2200 combined estimated tokens. This exceeds floor(3000/1.5) = 2000 (new effective max) but stays under floor(3000/1.2) = 2500 (old effective max), proving the wider margin forces a split where 1.2 would not.
- Full test run: `node scripts/run-vitest.mjs src/agents/compaction.test.ts` -- 40 passed, 0 failed.
- **Exact steps or command run after this patch**:
  ```bash
  node scripts/run-vitest.mjs src/agents/compaction.test.ts -t "SAFETY_MARGIN"
  ```
- **Evidence after fix**:
Terminal output from `node scripts/run-vitest.mjs src/agents/compaction.test.ts`:
  ```
  ✓ equals 1.5 to account for CJK and code token underestimation
  ✓ chunkMessagesByMaxTokens splits within the tighter 1.5 margin
  ✓ effective chunk budget is 66% of raw limit with 1.5 margin
  Test Files  1 passed (1)
       Tests  40 passed (40)
  ```
- **Observed result after fix**: After running `node scripts/run-vitest.mjs`, `SAFETY_MARGIN` reads 1.5 and `chunkMessagesByMaxTokens` splits 2200 estimated tokens against a 3000 limit (effective max `floor(3000/1.5)=2000`), producing 2 chunks. With the old 1.2 margin the effective max was 2500, so no split would have occurred for the same input.
- What was not tested: Real CJK text tokenization against a live model tokenizer.

