### PR TITLE
fix(agents): ignore duplicate embedded run clears

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,6 +235,7 @@ Docs: https://docs.openclaw.ai
 - Agents/OpenAI: preserve deterministic tool payload ordering for prompt-cache reuse across OpenAI Responses and chat completions calls. (#82940) Thanks @galiniliev.
 - ACP/Codex: honor terminal ACP turn results so failed Codex/acpx runs are not recorded as successful after only progress text. Fixes #79522. Thanks @dudaefj.
 - Telegram: warn when a media group drops photos that fail to download, including albums where every photo is skipped. Fixes #55216. (#82987) Thanks @eldar702.
+- Agents/diagnostics: treat repeated same-handle embedded-run cleanup as idempotent while preserving true replacement-handle mismatch diagnostics. Fixes #82959. (#82960) Thanks @galiniliev.
 - Agents/skills: apply the full effective tool policy pipeline to inline `command-dispatch: tool` skill dispatch before owner-only filtering, preserving configured allow, deny, sandbox, sender, group, and subagent restrictions. (#78525)
 - Codex: avoid spawning native hook relay subprocesses for post-tool/finalize events with no registered hook handlers while preserving pre-tool safety and approval relays. Fixes #76552. (#78004) Thanks @evgyur.
 - Channel accounts: keep top-level default channel accounts visible when named accounts are added alongside default credential material, so mixed legacy/new account configs keep resolving `default` instead of silently dropping it.

--- a/src/agents/pi-embedded-runner/runs.test.ts
+++ b/src/agents/pi-embedded-runner/runs.test.ts
@@ -1,5 +1,6 @@
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { diagnosticLogger } from "../../logging/diagnostic.js";
 import {
   testing as replyRunTesting,
   createReplyOperation,
@@ -354,6 +355,39 @@ describe("pi-embedded runner run registry", () => {
 
     expect(isEmbeddedPiRunHandleActive("session-a")).toBe(false);
     expect(resolveActiveEmbeddedRunHandleSessionId("agent:main:main")).toBeUndefined();
+  });
+
+  it("treats repeated clears for a completed run handle as idempotent", () => {
+    const debugSpy = vi.spyOn(diagnosticLogger, "debug").mockImplementation(() => undefined);
+    const handle = createRunHandle();
+
+    setActiveEmbeddedRun("session-repeat-clear", handle, "agent:main:main");
+    clearActiveEmbeddedRun("session-repeat-clear", handle, "agent:main:main");
+    clearActiveEmbeddedRun("session-repeat-clear", handle, "agent:main:main");
+
+    expect(isEmbeddedPiRunHandleActive("session-repeat-clear")).toBe(false);
+    expect(resolveActiveEmbeddedRunHandleSessionId("agent:main:main")).toBeUndefined();
+    expect(
+      debugSpy.mock.calls.some(([message]) =>
+        String(message).includes("reason=handle_mismatch"),
+      ),
+    ).toBe(false);
+  });
+
+  it("still logs handle mismatches when another run owns the session", () => {
+    const debugSpy = vi.spyOn(diagnosticLogger, "debug").mockImplementation(() => undefined);
+    const staleHandle = createRunHandle();
+    const activeHandle = createRunHandle();
+
+    setActiveEmbeddedRun("session-handle-replaced", activeHandle);
+    clearActiveEmbeddedRun("session-handle-replaced", staleHandle);
+
+    expect(isEmbeddedPiRunHandleActive("session-handle-replaced")).toBe(true);
+    expect(
+      debugSpy.mock.calls.some(([message]) =>
+        String(message).includes("reason=handle_mismatch"),
+      ),
+    ).toBe(true);
   });
 
   it("tracks and clears per-session transcript snapshots for active runs", () => {

--- a/src/agents/pi-embedded-runner/runs.test.ts
+++ b/src/agents/pi-embedded-runner/runs.test.ts
@@ -368,9 +368,7 @@ describe("pi-embedded runner run registry", () => {
     expect(isEmbeddedPiRunHandleActive("session-repeat-clear")).toBe(false);
     expect(resolveActiveEmbeddedRunHandleSessionId("agent:main:main")).toBeUndefined();
     expect(
-      debugSpy.mock.calls.some(([message]) =>
-        String(message).includes("reason=handle_mismatch"),
-      ),
+      debugSpy.mock.calls.some(([message]) => message.includes("reason=handle_mismatch")),
     ).toBe(false);
   });
 
@@ -384,9 +382,7 @@ describe("pi-embedded runner run registry", () => {
 
     expect(isEmbeddedPiRunHandleActive("session-handle-replaced")).toBe(true);
     expect(
-      debugSpy.mock.calls.some(([message]) =>
-        String(message).includes("reason=handle_mismatch"),
-      ),
+      debugSpy.mock.calls.some(([message]) => message.includes("reason=handle_mismatch")),
     ).toBe(true);
   });
 

--- a/src/agents/pi-embedded-runner/runs.ts
+++ b/src/agents/pi-embedded-runner/runs.ts
@@ -565,7 +565,11 @@ export function clearActiveEmbeddedRun(
   handle: EmbeddedPiQueueHandle,
   sessionKey?: string,
 ) {
-  if (ACTIVE_EMBEDDED_RUNS.get(sessionId) === handle) {
+  const activeHandle = ACTIVE_EMBEDDED_RUNS.get(sessionId);
+  if (activeHandle === undefined) {
+    return;
+  }
+  if (activeHandle === handle) {
     ACTIVE_EMBEDDED_RUNS.delete(sessionId);
     ACTIVE_EMBEDDED_RUN_SNAPSHOTS.delete(sessionId);
     EMBEDDED_RUN_MODEL_SWITCH_REQUESTS.delete(sessionId);


### PR DESCRIPTION
## Summary

- Problem: duplicate embedded-run cleanup can report a same-handle terminal/finally clear as `reason=handle_mismatch`.
- Why it matters: the diagnostic noise makes real lifecycle races harder to spot in gateway logs.
- What changed: `clearActiveEmbeddedRun` now treats an already-cleared session as idempotent while preserving mismatch diagnostics when another handle is active.
- What did NOT change (scope boundary): embedded-run queueing, terminal lifecycle ordering, and real stale-handle replacement diagnostics are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #82959
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: Duplicate same-handle embedded-run clears no longer emit `reason=handle_mismatch`; stale clears against a different active handle still emit the mismatch diagnostic.
- Real environment tested: Local Windows worktree at commit `6ebbf43f45f3228d0a60c492d5c15d6a0cffaf3a`, Node `v24.15.0`, dependencies partially installed by `pnpm install`.
- Exact steps or command run after this patch: Ran a direct seam probe with `node --import tsx/esm --input-type=module` importing `src/agents/pi-embedded-runner/runs.ts`, clearing the same handle twice, then clearing a stale handle while another handle owned the session.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```shell
> node --import tsx/esm --input-type=module
seam probe passed: duplicate clear is idempotent; replacement mismatch still logs
```

- Observed result after fix: The probe asserted that the duplicate same-handle clear left no `reason=handle_mismatch` message and that a stale handle against an active replacement still logged `reason=handle_mismatch`.
- What was not tested: Full Vitest execution and Crabbox/Testbox proof were not completed from this Windows environment. `node scripts/run-vitest.mjs src/agents/pi-embedded-runner/runs.test.ts` first failed because `vitest/package.json` was missing, then after `pnpm install` failed with local Windows `spawn EPERM`; the allowed direct Vitest entrypoint timed out before producing output. Crabbox/Testbox tools were unavailable on PATH.
- Before evidence (optional but encouraged):

```shell
Trace/proof:
- gateway-dev.log:280
  "run clear skipped: sessionId=[redacted session id] reason=handle_mismatch"
- gateway-dev.log:30372
  "run clear skipped: sessionId=[redacted session id] reason=handle_mismatch"
  traceId=[redacted trace id] spanId=[redacted span id]
```

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: Terminal lifecycle cleanup clears the active embedded-run handle before the attempt `finally` block performs its best-effort cleanup. After the first clear removes the map entry, the second same-handle clear saw `undefined !== handle` and logged `reason=handle_mismatch`.
- Missing detection / guardrail: `clearActiveEmbeddedRun` had no regression coverage for duplicate same-handle clears after completion.
- Contributing context (if known): The same function must still report true races where a different active handle owns the session, so the idempotent behavior has to be limited to the no-active-run case.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-embedded-runner/runs.test.ts`
- Scenario the test should lock in: clearing the same completed handle twice does not log `handle_mismatch`, while clearing a stale handle when another run owns the session still logs `handle_mismatch`.
- Why this is the smallest reliable guardrail: the bug is in the run registry clear semantics, independent of provider or channel behavior.
- Existing test that already covers this (if any): None before this PR.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Embedded-run diagnostics no longer report duplicate same-handle cleanup as a handle mismatch.

## Diagram (if applicable)

```text
Before:
[terminal lifecycle clear] -> [active run removed] -> [finally clear] -> [handle_mismatch log]

After:
[terminal lifecycle clear] -> [active run removed] -> [finally clear] -> [idempotent return]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: Node `v24.15.0`
- Model/provider: NOT_ENOUGH_INFO
- Integration/channel (if any): Embedded PI agent runner
- Relevant config (redacted): N/A

### Steps

1. Clear an active embedded-run handle.
2. Clear the same handle again after the active run map entry is gone.
3. Clear a stale handle while a different handle still owns the session.

### Expected

- The second same-handle clear is idempotent and quiet.
- The stale-handle clear still logs `reason=handle_mismatch`.

### Actual

- After this patch, the direct seam probe observed the expected behavior.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: direct seam probe for duplicate same-handle clear and stale-handle mismatch; `git diff --check`.
- Edge cases checked: active replacement handle still emits `reason=handle_mismatch`.
- What you did **not** verify: full Vitest and remote Crabbox/Testbox proof due local tooling blockers described above.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: treating all missing active handles as idempotent could hide a useful diagnostic for unrelated stale cleanup.
  - Mitigation: the mismatch diagnostic is preserved when the session still has a different active handle, which is the actionable ownership race this log should report.
