### PR TITLE
fix(agents): add trajectory flush timeout diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents: include bounded trajectory queued-writer diagnostics in `pi-trajectory-flush` timeout warnings so flush stalls show pending writes, queued bytes, and append state. Fixes #82961. (#82962) Thanks @galiniliev.
 - Agents/subagents: recover stale completion announces by retrying unsupported transcript-wait wakes without transcript waiting and forcing a message-tool handoff when the requester run is already stale. Fixes #83699. (#83700) Thanks @galiniliev.
 - Agents/subagents: skip stale embedded-run wake probes for dormant completion requesters, so late subagent completions go straight to requester-agent/direct handoff instead of producing `reason=no_active_run` queue noise. (#82964) Thanks @galiniliev.
 - CLI: retry config snapshot reads after a transient failure so one rejected read no longer poisons later commands in the same process. (#83931) Thanks @honor2030.

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -4788,6 +4788,7 @@ export async function runEmbeddedAttempt(
         sessionId: params.sessionId,
         step: "pi-trajectory-flush",
         log,
+        getTimeoutDetails: () => trajectoryRecorder?.describeFlushState(),
         cleanup: async () => {
           await trajectoryRecorder?.flush();
         },

--- a/src/agents/queued-file-writer.test.ts
+++ b/src/agents/queued-file-writer.test.ts
@@ -92,4 +92,34 @@ describe("getQueuedFileWriter", () => {
 
     expect(fs.readFileSync(filePath, "utf8")).toBe("12345\n");
   });
+
+  it("reports pending queue diagnostics before flush drains writes", async () => {
+    const tmpDir = makeTempDir();
+    const filePath = path.join(tmpDir, "trace.jsonl");
+    const writer = getQueuedFileWriter(new Map(), filePath, {
+      maxFileBytes: 1024,
+      maxQueuedBytes: 1024,
+      yieldBeforeWrite: true,
+    });
+
+    writer.write("line\n");
+
+    expect(writer.describeQueue?.()).toEqual({
+      pendingWrites: 1,
+      queuedBytes: 5,
+      activeOperation: "idle",
+      activeWriteBytes: undefined,
+      maxFileBytes: 1024,
+      maxQueuedBytes: 1024,
+      yieldBeforeWrite: true,
+    });
+
+    await writer.flush();
+
+    expect(writer.describeQueue?.()).toMatchObject({
+      pendingWrites: 0,
+      queuedBytes: 0,
+      activeOperation: "idle",
+    });
+  });
 });

--- a/src/agents/queued-file-writer.ts
+++ b/src/agents/queued-file-writer.ts
@@ -4,10 +4,21 @@ import { appendRegularFile, resolveRegularFileAppendFlags } from "../infra/fs-sa
 
 export type QueuedFileWriteResult = "queued" | "dropped";
 
+export type QueuedFileWriterDiagnostics = {
+  pendingWrites: number;
+  queuedBytes: number;
+  activeOperation: "idle" | "mkdir" | "yield" | "file-append";
+  activeWriteBytes?: number;
+  maxFileBytes?: number;
+  maxQueuedBytes?: number;
+  yieldBeforeWrite: boolean;
+};
+
 export type QueuedFileWriter = {
   filePath: string;
   write: (line: string) => unknown;
   flush: () => Promise<void>;
+  describeQueue?: () => QueuedFileWriterDiagnostics;
 };
 
 type QueuedFileWriterOptions = {
@@ -50,7 +61,10 @@ export function getQueuedFileWriter(
   const dir = path.dirname(filePath);
   const ready = fs.mkdir(dir, { recursive: true, mode: 0o700 }).catch(() => undefined);
   let queue: Promise<unknown> = Promise.resolve();
+  let pendingWrites = 0;
   let queuedBytes = 0;
+  let activeOperation: QueuedFileWriterDiagnostics["activeOperation"] = "idle";
+  let activeWriteBytes: number | undefined;
 
   const writer: QueuedFileWriter = {
     filePath,
@@ -62,20 +76,45 @@ export function getQueuedFileWriter(
       ) {
         return "dropped";
       }
+      pendingWrites += 1;
       queuedBytes += lineBytes;
       queue = queue
-        .then(() => ready)
-        .then(() => (options.yieldBeforeWrite ? waitForImmediate() : undefined))
-        .then(() => safeAppendFile(filePath, line, options))
+        .then(async () => {
+          activeOperation = "mkdir";
+          await ready;
+        })
+        .then(async () => {
+          if (options.yieldBeforeWrite) {
+            activeOperation = "yield";
+            await waitForImmediate();
+          }
+        })
+        .then(async () => {
+          activeOperation = "file-append";
+          activeWriteBytes = lineBytes;
+          await safeAppendFile(filePath, line, options);
+        })
         .catch(() => undefined)
         .finally(() => {
+          pendingWrites = Math.max(0, pendingWrites - 1);
           queuedBytes = Math.max(0, queuedBytes - lineBytes);
+          activeWriteBytes = undefined;
+          activeOperation = pendingWrites > 0 ? activeOperation : "idle";
         });
       return "queued";
     },
     flush: async () => {
       await queue;
     },
+    describeQueue: () => ({
+      pendingWrites,
+      queuedBytes,
+      activeOperation,
+      activeWriteBytes,
+      maxFileBytes: options.maxFileBytes,
+      maxQueuedBytes: options.maxQueuedBytes,
+      yieldBeforeWrite: options.yieldBeforeWrite === true,
+    }),
   };
 
   writers.set(filePath, writer);

--- a/src/agents/run-cleanup-timeout.test.ts
+++ b/src/agents/run-cleanup-timeout.test.ts
@@ -65,6 +65,50 @@ describe("agent cleanup timeout", () => {
     );
   });
 
+  it("includes cleanup timeout details when the cleanup step exposes them", async () => {
+    const cleanup = vi.fn(async () => new Promise<never>(() => {}));
+
+    const result = runAgentCleanupStep({
+      runId: "run-trajectory",
+      sessionId: "session-trajectory",
+      step: "pi-trajectory-flush",
+      cleanup,
+      log,
+      timeoutMs: 5,
+      getTimeoutDetails: () => "pendingWrites=2 queuedBytes=128 activeOperation=file-append",
+    });
+
+    await vi.advanceTimersByTimeAsync(5);
+    await expect(result).resolves.toBeUndefined();
+
+    expect(log.warn).toHaveBeenCalledWith(
+      "agent cleanup timed out: runId=run-trajectory sessionId=session-trajectory step=pi-trajectory-flush timeoutMs=5 details=pendingWrites=2 queuedBytes=128 activeOperation=file-append",
+    );
+  });
+
+  it("does not fail cleanup when timeout details throw", async () => {
+    const cleanup = vi.fn(async () => new Promise<never>(() => {}));
+
+    const result = runAgentCleanupStep({
+      runId: "run-trajectory",
+      sessionId: "session-trajectory",
+      step: "pi-trajectory-flush",
+      cleanup,
+      log,
+      timeoutMs: 5,
+      getTimeoutDetails: () => {
+        throw new Error("details unavailable");
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(5);
+    await expect(result).resolves.toBeUndefined();
+
+    expect(log.warn).toHaveBeenCalledWith(
+      "agent cleanup timed out: runId=run-trajectory sessionId=session-trajectory step=pi-trajectory-flush timeoutMs=5 detailsError=details unavailable",
+    );
+  });
+
   it("uses the general cleanup timeout environment override for other cleanup steps", async () => {
     const cleanup = vi.fn(async () => new Promise<never>(() => {}));
 

--- a/src/agents/run-cleanup-timeout.ts
+++ b/src/agents/run-cleanup-timeout.ts
@@ -28,6 +28,17 @@ function parseTimeoutEnvValue(value: string | undefined): number | undefined {
   return normalized > 0 ? normalized : undefined;
 }
 
+function resolveCleanupTimeoutDetails(
+  getTimeoutDetails: (() => string | undefined) | undefined,
+): string {
+  try {
+    const timeoutDetails = getTimeoutDetails?.()?.trim();
+    return timeoutDetails ? ` details=${timeoutDetails}` : "";
+  } catch (error) {
+    return ` detailsError=${formatErrorMessage(error)}`;
+  }
+}
+
 export function resolveAgentCleanupStepTimeoutMs(params: {
   step: string;
   timeoutMs?: number;
@@ -54,6 +65,7 @@ export async function runAgentCleanupStep(params: {
   sessionId: string;
   step: string;
   cleanup: () => Promise<void>;
+  getTimeoutDetails?: () => string | undefined;
   log: AgentCleanupLogger;
   env?: NodeJS.ProcessEnv;
   timeoutMs?: number;
@@ -88,8 +100,9 @@ export async function runAgentCleanupStep(params: {
     clearTimeout(timeoutHandle);
   }
   if (result === "timeout") {
+    const details = resolveCleanupTimeoutDetails(params.getTimeoutDetails);
     params.log.warn(
-      `agent cleanup timed out: runId=${params.runId} sessionId=${params.sessionId} step=${params.step} timeoutMs=${timeoutMs}`,
+      `agent cleanup timed out: runId=${params.runId} sessionId=${params.sessionId} step=${params.step} timeoutMs=${timeoutMs}${details}`,
     );
     void cleanupPromise.catch((error) => {
       params.log.warn(

--- a/src/trajectory/runtime.test.ts
+++ b/src/trajectory/runtime.test.ts
@@ -169,6 +169,33 @@ describe("trajectory runtime", () => {
     expect(truncated?.data.droppedEvents).toBeGreaterThan(0);
   });
 
+  it("describes queued writer state for cleanup timeout logs", () => {
+    const recorder = createTrajectoryRuntimeRecorder({
+      sessionId: "session-1",
+      sessionFile: "/tmp/session.jsonl",
+      writer: {
+        filePath: "/tmp/session.trajectory.jsonl",
+        write: () => "queued",
+        flush: async () => undefined,
+        describeQueue: () => ({
+          pendingWrites: 2,
+          queuedBytes: 256,
+          activeOperation: "file-append",
+          activeWriteBytes: 128,
+          maxFileBytes: 1024,
+          maxQueuedBytes: 1024,
+          yieldBeforeWrite: true,
+        }),
+      },
+    });
+
+    const runtimeRecorder = expectTrajectoryRuntimeRecorder(recorder);
+
+    expect(runtimeRecorder.describeFlushState()).toBe(
+      "pendingWrites=2 queuedBytes=256 activeOperation=file-append yieldBeforeWrite=true activeWriteBytes=128 maxQueuedBytes=1024 maxFileBytes=1024",
+    );
+  });
+
   it("writes a session-adjacent pointer when using an override directory", () => {
     const tmpDir = makeTempDir();
     const sessionFile = path.join(tmpDir, "session.jsonl");

--- a/src/trajectory/runtime.ts
+++ b/src/trajectory/runtime.ts
@@ -45,6 +45,7 @@ type TrajectoryRuntimeRecorder = {
   filePath: string;
   recordEvent: (type: string, data?: Record<string, unknown>) => void;
   flush: () => Promise<void>;
+  describeFlushState: () => string | undefined;
 };
 
 const writers = new Map<string, QueuedFileWriter>();
@@ -208,6 +209,29 @@ function sanitizeTrajectoryPayload(data: Record<string, unknown>): Record<string
   >;
 }
 
+function describeTrajectoryWriterFlushState(writer: QueuedFileWriter): string | undefined {
+  const diagnostics = writer.describeQueue?.();
+  if (!diagnostics) {
+    return undefined;
+  }
+  const parts = [
+    `pendingWrites=${diagnostics.pendingWrites}`,
+    `queuedBytes=${diagnostics.queuedBytes}`,
+    `activeOperation=${diagnostics.activeOperation}`,
+    `yieldBeforeWrite=${diagnostics.yieldBeforeWrite}`,
+  ];
+  if (diagnostics.activeWriteBytes !== undefined) {
+    parts.push(`activeWriteBytes=${diagnostics.activeWriteBytes}`);
+  }
+  if (diagnostics.maxQueuedBytes !== undefined) {
+    parts.push(`maxQueuedBytes=${diagnostics.maxQueuedBytes}`);
+  }
+  if (diagnostics.maxFileBytes !== undefined) {
+    parts.push(`maxFileBytes=${diagnostics.maxFileBytes}`);
+  }
+  return parts.join(" ");
+}
+
 export function toTrajectoryToolDefinitions(
   tools: ReadonlyArray<{ name?: string; description?: string; parameters?: unknown }>,
 ): TrajectoryToolDefinition[] {
@@ -361,5 +385,6 @@ export function createTrajectoryRuntimeRecorder(
         writers.delete(filePath);
       }
     },
+    describeFlushState: () => describeTrajectoryWriterFlushState(writer),
   };
 }


### PR DESCRIPTION
## Summary

- Problem: `pi-trajectory-flush` cleanup timeout warnings only showed the timeout envelope, leaving operators unable to tell whether trajectory flush was waiting on queued writer work, event-loop yield, or file append IO.
- Why it matters: the BUG evidence shows repeated cleanup timeout warnings; without bounded writer state, the next investigation cannot distinguish slow file IO from pending queued writes.
- What changed: queued file writers now expose non-path diagnostics, trajectory runtime formats that state, and the embedded runner passes it into the generic cleanup timeout warning for `pi-trajectory-flush`.
- What did NOT change (scope boundary): this does not change timeout duration, trajectory file caps, append semantics, or abort behavior for in-flight filesystem writes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #82961
- Related #81622
- Related #77133
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `pi-trajectory-flush` timeout warnings now include bounded trajectory writer state such as pending write count, queued bytes, active operation, and active write bytes.
- Real environment tested: local OpenClaw checkout on Windows, Node v24.15.0, direct `tsx` runtime import of the patched cleanup helper; no live provider or channel credentials involved.
- Exact steps or command run after this patch: `node --import tsx -e '<invoke runAgentCleanupStep with step=pi-trajectory-flush, timeoutMs=5, and trajectory writer timeout details>'`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
$ node --import tsx -e '<invoke runAgentCleanupStep with trajectory writer timeout details>'
{
  "logs": [
    "agent cleanup timed out: runId=proof-run sessionId=proof-session step=pi-trajectory-flush timeoutMs=5 details=pendingWrites=2 queuedBytes=128 activeOperation=file-append yieldBeforeWrite=true activeWriteBytes=64 maxQueuedBytes=1024 maxFileBytes=2048"
  ]
}
```

- Observed result after fix: the timeout warning includes `details=` with queued writer state and no local file path.
- What was not tested: focused Vitest and remote Testbox/AWS proof could not complete from this host; see verification notes below. Live production gateway soak with a real long-running trajectory flush was not tested.
- Before evidence (optional but encouraged): BUG evidence showed only `agent cleanup timed out: runId=[redacted run id] sessionId=[redacted session id] step=pi-trajectory-flush timeoutMs=10000`, with no queue or file-append state.

## Root Cause (if applicable)

- Root cause: `runAgentCleanupStep` had no way for owner-specific cleanup steps to attach bounded state to the timeout warning, and `QueuedFileWriter.flush()` exposed no pending queue diagnostics.
- Missing detection / guardrail: cleanup timeout tests asserted the warning string but did not cover owner-provided timeout details; trajectory runtime tests did not assert flush-state formatting.
- Contributing context (if known): #81622 made the trajectory flush timeout configurable, but did not add state showing what a timed-out flush is waiting on.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/run-cleanup-timeout.test.ts`, `src/agents/queued-file-writer.test.ts`, `src/trajectory/runtime.test.ts`
- Scenario the test should lock in: cleanup timeout details are included and detail callback failures do not break cleanup; queued writer diagnostics report pending bytes/writes; trajectory runtime formats writer state for timeout logs.
- Why this is the smallest reliable guardrail: the behavior lives at the cleanup helper, queued writer, and trajectory runtime seams, not in a provider or channel path.
- Existing test that already covers this (if any): existing cleanup timeout tests covered generic timeout logging only.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Timed-out `pi-trajectory-flush` cleanup warnings now include bounded writer diagnostics. Defaults and behavior are otherwise unchanged.

## Diagram (if applicable)

```text
Before:
pi-trajectory-flush -> runAgentCleanupStep -> timeout warning without flush state

After:
pi-trajectory-flush -> trajectoryRecorder.describeFlushState() -> runAgentCleanupStep -> timeout warning with bounded queue/file-append state
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A. Diagnostics intentionally omit file paths and payload contents.

## Repro + Verification

### Environment

- OS: Windows local checkout
- Runtime/container: Node v24.15.0; direct `tsx` runtime proof
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): none

### Steps

1. Confirm the BUG evidence only contains the generic `pi-trajectory-flush` timeout warning.
2. Apply this patch.
3. Run the direct `tsx` cleanup helper proof above.
4. Run patch hygiene checks.

### Expected

- The timeout warning includes bounded cleanup details when the cleanup step provides them.
- Detail collection failures do not make cleanup fail after timeout.
- Generic cleanup warnings without details remain unchanged.

### Actual

- Direct runtime proof emitted a timeout warning with `details=pendingWrites=2 queuedBytes=128 activeOperation=file-append ...`.
- `git diff --check` passed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification attempted:

```text
git diff --check
node --import tsx -e '<invoke runAgentCleanupStep with trajectory writer timeout details>'
node scripts/run-vitest.mjs src/agents/run-cleanup-timeout.test.ts src/agents/queued-file-writer.test.ts src/trajectory/runtime.test.ts
node node_modules\vitest\vitest.mjs run src/agents/run-cleanup-timeout.test.ts --reporter=verbose --pool=threads --maxWorkers=1 --no-file-parallelism --configLoader=runner
codex review --uncommitted
```

Results:

```text
git diff --check -> passed
node --import tsx ... -> emitted timeout warning with details=pendingWrites=2 queuedBytes=128 activeOperation=file-append yieldBeforeWrite=true activeWriteBytes=64 maxQueuedBytes=1024 maxFileBytes=2048
node scripts/run-vitest.mjs ... -> blocked locally by Windows spawn EPERM
node node_modules\vitest\vitest.mjs ... -> timed out without test output; lingering child was stopped
codex review --uncommitted -> blocked by OpenAI API 401 Unauthorized
```

Remote proof attempts:

```text
Crabbox/Testbox via blacksmith-testbox -> blocked: blacksmith CLI not found on PATH
Crabbox AWS -> blocked: AWS credentials unavailable on this host
```

## Human Verification (required)

- Verified scenarios: manual source review of the queued writer promise chain, trajectory runtime flush-state formatting, cleanup timeout logging path, and direct runtime proof for the patched timeout message.
- Edge cases checked: timeout details omitted when unavailable; timeout detail callback exceptions are converted into `detailsError=` without rejecting cleanup; writer diagnostics omit file paths.
- What you did **not** verify: Vitest pass, full changed gate, Testbox/AWS proof, and live gateway soak due host/tooling blockers listed above.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No bot review conversations exist on this PR yet.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: timeout logs become longer for trajectory flush timeouts.
  - Mitigation: details are bounded scalar counters/enums only and omit file paths/payloads.
- Risk: diagnostic callback could fail while logging timeout.
  - Mitigation: `runAgentCleanupStep` catches detail callback failures and logs `detailsError=` instead of throwing.
