### PR TITLE
fix(agents): skip dormant completion wake probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/subagents: skip stale embedded-run wake probes for dormant completion requesters, so late subagent completions go straight to requester-agent/direct handoff instead of producing `reason=no_active_run` queue noise. (#82964) Thanks @galiniliev.
 - WhatsApp: drain pending outbound deliveries on a 30s periodic timer in addition to the reconnect handler, so messages enqueued while the provider is already connected no longer wait for the next reconnect to send. (#79083) Thanks @Oviemudiaga.
 
 ## 2026.5.19

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -849,12 +849,14 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
 
   it("keeps direct external delivery for dormant completion requesters", async () => {
     const callGateway = createGatewayMock();
+    const queueEmbeddedPiMessageWithOutcome = createQueueOutcomeMock(false);
     await deliverSlackThreadAnnouncement({
       callGateway,
       sessionId: "requester-session-2",
       isActive: false,
       expectsCompletionMessage: true,
       directIdempotencyKey: "announce-1b",
+      queueEmbeddedPiMessageWithOutcome,
     });
 
     expectGatewayAgentParams(callGateway, {
@@ -865,6 +867,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       threadId: "171.222",
       bestEffortDeliver: true,
     });
+    expect(queueEmbeddedPiMessageWithOutcome).not.toHaveBeenCalled();
   });
 
   it("uses in-process agent dispatch for dormant completion requesters", async () => {
@@ -1389,7 +1392,7 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     const result = await deliverSlackChannelAnnouncement({
       callGateway,
       sessionId: "requester-session-channel",
-      isActive: false,
+      isActive: true,
       expectsCompletionMessage: true,
       directIdempotencyKey: "announce-channel-empty-direct-steer-fallback",
       queueEmbeddedPiMessageWithOutcome,

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -457,8 +457,8 @@ async function maybeSteerSubagentAnnounce(params: {
   }
   const { cfg, entry } = loadRequesterSessionEntry(params.requesterSessionKey);
   const canonicalKey = resolveRequesterStoreKey(cfg, params.requesterSessionKey);
-  const { sessionId } = resolveRequesterSessionActivity(canonicalKey);
-  if (!sessionId) {
+  const { sessionId, isActive } = resolveRequesterSessionActivity(canonicalKey);
+  if (!sessionId || !isActive) {
     return { status: "none" };
   }
 
@@ -691,7 +691,11 @@ async function sendSubagentAnnounceDirectly(params: {
         directOrigin?.channel,
       sessionEntry: requesterEntry,
     });
-    if (params.expectsCompletionMessage && requesterActivity.sessionId) {
+    if (
+      params.expectsCompletionMessage &&
+      requesterActivity.sessionId &&
+      requesterActivity.isActive
+    ) {
       const wakeOutcome = await resolveQueueEmbeddedPiMessageOutcome(
         requesterActivity.sessionId,
         params.triggerMessage,
@@ -715,14 +719,12 @@ async function sendSubagentAnnounceDirectly(params: {
           path: "steered",
         };
       }
-      if (requesterActivity.isActive) {
-        defaultRuntime.log(
-          `[warn] Active requester session could not be woken for subagent completion; falling back to requester-agent handoff: ${formatQueueWakeFailureError(
-            "active requester session could not be woken",
-            wakeOutcome,
-          )}`,
-        );
-      }
+      defaultRuntime.log(
+        `[warn] Active requester session could not be woken for subagent completion; falling back to requester-agent handoff: ${formatQueueWakeFailureError(
+          "active requester session could not be woken",
+          wakeOutcome,
+        )}`,
+      );
     }
     if (params.signal?.aborted) {
       return {


### PR DESCRIPTION
## Summary

- Problem: dormant requester sessions could still be probed through `queueEmbeddedPiMessageWithOutcome`, producing `reason=no_active_run` when a stored session id no longer had an active embedded or reply-run handle.
- Why it matters: late subagent completion announcements should take the requester-agent/direct handoff path instead of adding stale-run queue failures before visible delivery.
- What changed: subagent announce delivery now only attempts requester wake/steer when requester activity is active; dormant completion delivery skips the wake probe and proceeds directly to the persisted handoff.
- What did NOT change (scope boundary): active requester steering, active wake failure fallback, delivery routing, and embedded-run queue semantics are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #82963
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count. Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

- Behavior addressed: dormant subagent completion delivery no longer probes a stale stored requester session id before using requester-agent/direct delivery.
- Real environment tested: local Windows checkout/worktree, Node v24.15.0, direct Vitest invocation after the worktree dependency install populated dependencies but failed the `esbuild` postinstall validation.
- Exact steps or command run after this patch: `node node_modules\vitest\vitest.mjs run src/agents/subagent-announce-delivery.test.ts --reporter=verbose -t "dormant completion requesters|steer fallback"`; `node node_modules\vitest\vitest.mjs run src/agents/subagent-announce-delivery.test.ts --reporter=dot`; `git diff --check`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): terminal capture:

```text
RUN  v4.1.6 [redacted worktree]

✓ |agents-core| ../../src/agents/subagent-announce-delivery.test.ts > deliverSubagentAnnouncement completion delivery > keeps direct external delivery for dormant completion requesters 159ms
✓ |agents-core| ../../src/agents/subagent-announce-delivery.test.ts > deliverSubagentAnnouncement completion delivery > uses in-process agent dispatch for dormant completion requesters 123ms
✓ |agents-core| ../../src/agents/subagent-announce-delivery.test.ts > deliverSubagentAnnouncement completion delivery > uses steer fallback when a completion handoff has no visible output 124ms
✓ |agents-support| ../../src/agents/subagent-announce-delivery.test.ts > deliverSubagentAnnouncement completion delivery > keeps direct external delivery for dormant completion requesters 161ms
✓ |agents-support| ../../src/agents/subagent-announce-delivery.test.ts > deliverSubagentAnnouncement completion delivery > uses in-process agent dispatch for dormant completion requesters 127ms
✓ |agents-support| ../../src/agents/subagent-announce-delivery.test.ts > deliverSubagentAnnouncement completion delivery > uses steer fallback when a completion handoff has no visible output 126ms

Test Files  2 passed (2)
Tests  6 passed | 86 skipped (92)
Duration  25.79s

RUN  v4.1.6 [redacted worktree]

Test Files  2 passed (2)
Tests  92 passed (92)
Duration  28.49s

git diff --check: passed with no output
```

- Observed result after fix: the dormant completion requester test asserts the direct external handoff params and `expect(queueEmbeddedPiMessageWithOutcome).not.toHaveBeenCalled()`, while the active fallback test still proves steering fallback remains available for active requester sessions.
- What was not tested: no live gateway/provider rerun against the original private session, because the evidence folder only included redacted local logs and no reusable credentials/session state.
- Before evidence (optional but encouraged): redacted gateway log excerpt from the bug evidence:

```text
Observed count: 192 lines matching "reason=no_active_run".
gateway-dev.log line 26944: "queue message failed: sessionId=[redacted session id] reason=no_active_run"
gateway-dev.log line 30248: "queue message failed: sessionId=[redacted session id] reason=no_active_run"
```

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: subagent completion delivery treated the presence of a stored requester `sessionId` as enough to attempt a wake/steer, even when requester activity reported that the embedded/reply run was no longer active.
- Missing detection / guardrail: dormant completion coverage verified direct handoff routing but did not assert that stale run wake was skipped.
- Contributing context (if known): `queueEmbeddedPiMessageWithOutcome` correctly returns `no_active_run` when no active embedded or reply-run handle exists; the caller was using it for dormant completions that should not require an active streaming handle.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/subagent-announce-delivery.test.ts`
- Scenario the test should lock in: dormant completion requesters with stored session ids use direct handoff without calling `queueEmbeddedPiMessageWithOutcome`; active completion fallback can still steer.
- Why this is the smallest reliable guardrail: it covers the delivery seam that decides between stale-run wake and requester-agent handoff without needing private gateway sessions.
- Existing test that already covers this (if any): existing dormant delivery tests covered handoff params, but not the missing negative assertion on stale queue wake.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Dormant late completion delivery no longer attempts stale embedded-run queue wake before using requester-agent/direct delivery, reducing `reason=no_active_run` churn for completed requester runs.

## Diagram (if applicable)

```text
Before:
[dormant completion + stored session id] -> [wake stale run] -> [no_active_run] -> [direct handoff]

After:
[dormant completion + stored session id] -> [direct handoff]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: local Node v24.15.0 worktree; direct Vitest fallback because `pnpm install` repeatedly failed during `esbuild` postinstall validation after populating dependencies.
- Model/provider: NOT_ENOUGH_INFO
- Integration/channel (if any): subagent completion delivery seam; original logs did not include a public reusable channel setup.
- Relevant config (redacted): NOT_ENOUGH_INFO

### Steps

1. Run the focused completion delivery tests for dormant requesters and active steer fallback.
2. Run the full touched test file.
3. Run patch whitespace validation.

### Expected

- Dormant completion requesters use direct handoff and do not call embedded-run queue wake.
- Active requester completion fallback can still steer.

### Actual

- Focused completion delivery tests passed in both project shards.
- Full `src/agents/subagent-announce-delivery.test.ts` passed in both project shards.
- `git diff --check` passed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: dormant completion handoff does not queue stale embedded-run wake; active completion fallback still steers; touched test file passes.
- Edge cases checked: active wake rejection still logs and falls back to requester-agent handoff because the warning remains inside the active-only branch.
- What you did **not** verify: live replay of the original private gateway session and provider credentials.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: an active requester might be misclassified as inactive and skip steering.
  - Mitigation: the active check already uses `isEmbeddedPiRunActive`, which includes embedded and reply-run activity; existing active steering coverage still passes.