### PR TITLE
fix(agents): classify ACP subagent stalls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/ACP: forward ACP turn, status, and tool progress into subagent stream diagnostics so stalled Codex ACP runs report runtime handoff/network-style silence instead of a generic interactive-input wait. Fixes #44810.
 - Agents/skills: apply the full effective tool policy pipeline to inline `command-dispatch: tool` skill dispatch before owner-only filtering, preserving configured allow, deny, sandbox, sender, group, and subagent restrictions. (#78525)
 - Channel accounts: keep top-level default channel accounts visible when named accounts are added alongside default credential material, so mixed legacy/new account configs keep resolving `default` instead of silently dropping it.
 - Codex/Telegram: synthesize native Codex tool progress from final turn snapshots so Telegram `/verbose` stays visible when command events arrive only at completion.

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -1858,7 +1858,14 @@ describe("AcpSessionManager", () => {
       code: "ACP_TURN_FAILED",
     });
 
-    expect(events).toEqual([expect.objectContaining({ type: "text_delta", text: "partial" })]);
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: "turn_started",
+        mode: "prompt",
+        requestId: "r-output",
+      }),
+      expect.objectContaining({ type: "text_delta", text: "partial" }),
+    ]);
     expect(harness.fallbackRuntime.runTurn).not.toHaveBeenCalled();
   });
 

--- a/src/acp/control-plane/manager.turn-stream.ts
+++ b/src/acp/control-plane/manager.turn-stream.ts
@@ -25,6 +25,14 @@ export async function consumeAcpTurnStream(params: {
   let sawOutput = false;
   let sawTerminalEvent = false;
 
+  if (params.eventGate.open) {
+    await params.onEvent?.({
+      type: "turn_started",
+      mode: params.turn.mode,
+      requestId: params.turn.requestId,
+    });
+  }
+
   for await (const event of params.runtime.runTurn(params.turn)) {
     if (!params.eventGate.open) {
       continue;

--- a/src/acp/runtime/agent-event-bridge.ts
+++ b/src/acp/runtime/agent-event-bridge.ts
@@ -1,0 +1,76 @@
+import { emitAgentEvent } from "../../infra/agent-events.js";
+import { normalizeOptionalString } from "../../shared/string-coerce.js";
+import type { AcpRuntimeEvent } from "./types.js";
+
+export function emitAcpRuntimeAgentEvent(params: {
+  runId: string | undefined;
+  sessionKey?: string;
+  event: AcpRuntimeEvent;
+  includeAssistantOutput?: boolean;
+}) {
+  const runId = normalizeOptionalString(params.runId);
+  if (!runId) {
+    return;
+  }
+  const sessionKey = normalizeOptionalString(params.sessionKey);
+  const base = {
+    runId,
+    ...(sessionKey ? { sessionKey } : {}),
+  };
+  switch (params.event.type) {
+    case "turn_started":
+      emitAgentEvent({
+        ...base,
+        stream: "lifecycle",
+        data: {
+          phase: "turn_started",
+          ...(params.event.mode ? { mode: params.event.mode } : {}),
+          ...(params.event.requestId ? { requestId: params.event.requestId } : {}),
+        },
+      });
+      return;
+    case "status":
+      emitAgentEvent({
+        ...base,
+        stream: "status",
+        data: {
+          text: params.event.text,
+          ...(params.event.tag ? { tag: params.event.tag } : {}),
+          ...(params.event.used != null ? { used: params.event.used } : {}),
+          ...(params.event.size != null ? { size: params.event.size } : {}),
+        },
+      });
+      return;
+    case "tool_call":
+      emitAgentEvent({
+        ...base,
+        stream: "tool",
+        data: {
+          text: params.event.text,
+          ...(params.event.tag ? { tag: params.event.tag } : {}),
+          ...(params.event.toolCallId ? { toolCallId: params.event.toolCallId } : {}),
+          ...(params.event.status ? { status: params.event.status } : {}),
+          ...(params.event.title ? { title: params.event.title } : {}),
+        },
+      });
+      return;
+    case "text_delta":
+      if (!params.event.text || params.event.stream === "thought") {
+        return;
+      }
+      if (params.includeAssistantOutput !== true) {
+        return;
+      }
+      emitAgentEvent({
+        ...base,
+        stream: "assistant",
+        data: {
+          delta: params.event.text,
+        },
+      });
+      return;
+    case "done":
+    case "error":
+      return;
+  }
+}

--- a/src/acp/runtime/types.ts
+++ b/src/acp/runtime/types.ts
@@ -88,6 +88,11 @@ export type AcpRuntimeDoctorReport = {
 
 export type AcpRuntimeEvent =
   | {
+      type: "turn_started";
+      mode?: AcpRuntimePromptMode;
+      requestId?: string;
+    }
+  | {
       type: "text_delta";
       text: string;
       stream?: "output" | "thought";

--- a/src/agents/acp-spawn-parent-stream.test.ts
+++ b/src/agents/acp-spawn-parent-stream.test.ts
@@ -259,7 +259,7 @@ describe("startAcpSpawnParentStreamRelay", () => {
     });
 
     vi.advanceTimersByTime(1_500);
-    expectTextWithFragment(collectedTexts(), "has produced no output for 1s");
+    expectTextWithFragment(collectedTexts(), "has not started an ACP turn after 1s");
 
     emitAgentEvent({
       runId: "run-2",
@@ -283,6 +283,65 @@ describe("startAcpSpawnParentStreamRelay", () => {
       },
     });
     expectTextWithFragment(collectedTexts(), "run failed: boom");
+    relay.dispose();
+  });
+
+  it("classifies stalls after ACP turn handoff without blaming interactive input", () => {
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-turn-started",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:child-turn",
+      agentId: "codex",
+      streamFlushMs: 1,
+      noOutputNoticeMs: 1_000,
+      noOutputPollMs: 250,
+    });
+
+    emitAgentEvent({
+      runId: "run-turn-started",
+      stream: "lifecycle",
+      data: {
+        phase: "turn_started",
+      },
+    });
+    vi.advanceTimersByTime(1_500);
+
+    const texts = collectedTexts();
+    expectTextWithFragment(texts, "started an ACP turn but has produced no runtime activity");
+    expectNoTextWithFragment(texts, "interactive input");
+    relay.dispose();
+  });
+
+  it("classifies runtime activity without assistant output", () => {
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-runtime-activity",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:child-activity",
+      agentId: "codex",
+      streamFlushMs: 1,
+      noOutputNoticeMs: 1_000,
+      noOutputPollMs: 250,
+    });
+
+    emitAgentEvent({
+      runId: "run-runtime-activity",
+      stream: "lifecycle",
+      data: {
+        phase: "turn_started",
+      },
+    });
+    emitAgentEvent({
+      runId: "run-runtime-activity",
+      stream: "status",
+      data: {
+        text: "warming up",
+      },
+    });
+    vi.advanceTimersByTime(1_500);
+
+    const texts = collectedTexts();
+    expectTextWithFragment(texts, "reported ACP runtime activity but no assistant output");
+    expectNoTextWithFragment(texts, "interactive input");
     relay.dispose();
   });
 

--- a/src/agents/acp-spawn-parent-stream.ts
+++ b/src/agents/acp-spawn-parent-stream.ts
@@ -190,6 +190,7 @@ export function startAcpSpawnParentStreamRelay(params: {
     });
   };
   const shouldSurfaceUpdates = params.surfaceUpdates !== false;
+  const startedAt = Date.now();
   const wake = () => {
     if (!shouldSurfaceUpdates) {
       return;
@@ -241,7 +242,11 @@ export function startAcpSpawnParentStreamRelay(params: {
 
   let disposed = false;
   let pendingText = "";
-  let lastProgressAt = Date.now();
+  let lastAssistantOutputAt = startedAt;
+  let lastTurnStartedAt = startedAt;
+  let sawTurnStarted = false;
+  let sawRuntimeActivity = false;
+  let sawAssistantOutput = false;
   let stallNotified = false;
   let flushTimer: NodeJS.Timeout | undefined;
   let relayLifetimeTimer: NodeJS.Timeout | undefined;
@@ -284,6 +289,32 @@ export function startAcpSpawnParentStreamRelay(params: {
     flushTimer.unref?.();
   };
 
+  const resolveNoOutputSummary = () => {
+    const seconds = Math.round(noOutputNoticeMs / 1000);
+    if (!sawTurnStarted) {
+      return {
+        task: `No ACP turn handoff for ${seconds}s. Runtime setup may be stalled.`,
+        text: `${relayLabel} has not started an ACP turn after ${seconds}s. Runtime setup may be stalled.`,
+      };
+    }
+    if (!sawRuntimeActivity && !sawAssistantOutput) {
+      return {
+        task: `ACP turn started but no runtime activity or assistant output for ${seconds}s.`,
+        text: `${relayLabel} started an ACP turn but has produced no runtime activity or assistant output for ${seconds}s. Upstream auth, proxy, or network access may be stalled.`,
+      };
+    }
+    if (!sawAssistantOutput) {
+      return {
+        task: `ACP runtime activity observed, but no assistant output for ${seconds}s.`,
+        text: `${relayLabel} reported ACP runtime activity but no assistant output for ${seconds}s. The upstream agent may still be working or blocked before a final answer.`,
+      };
+    }
+    return {
+      task: `No assistant output for ${seconds}s after previous output.`,
+      text: `${relayLabel} has produced no additional assistant output for ${seconds}s.`,
+    };
+  };
+
   const noOutputWatcherTimer = setInterval(() => {
     if (disposed || noOutputNoticeMs <= 0) {
       return;
@@ -291,21 +322,24 @@ export function startAcpSpawnParentStreamRelay(params: {
     if (stallNotified) {
       return;
     }
-    if (Date.now() - lastProgressAt < noOutputNoticeMs) {
+    const outputReferenceAt = sawAssistantOutput
+      ? lastAssistantOutputAt
+      : sawTurnStarted
+        ? lastTurnStartedAt
+        : startedAt;
+    if (Date.now() - outputReferenceAt < noOutputNoticeMs) {
       return;
     }
     stallNotified = true;
+    const summary = resolveNoOutputSummary();
     recordTaskRunProgressByRunId({
       runId,
       runtime: "acp",
       sessionKey: params.childSessionKey,
       lastEventAt: Date.now(),
-      eventSummary: `No output for ${Math.round(noOutputNoticeMs / 1000)}s. It may be waiting for input.`,
+      eventSummary: summary.task,
     });
-    emit(
-      `${relayLabel} has produced no output for ${Math.round(noOutputNoticeMs / 1000)}s. It may be waiting for interactive input.`,
-      `${contextPrefix}:stall`,
-    );
+    emit(summary.text, `${contextPrefix}:stall`);
   }, noOutputPollMs);
   noOutputWatcherTimer.unref?.();
 
@@ -342,13 +376,13 @@ export function startAcpSpawnParentStreamRelay(params: {
       if (!delta || !delta.trim()) {
         return;
       }
+      sawRuntimeActivity = true;
       logEvent("assistant_delta", {
         delta,
         ...(assistantPhase ? { phase: assistantPhase } : {}),
       });
 
       if (assistantPhase === "commentary") {
-        lastProgressAt = Date.now();
         return;
       }
 
@@ -364,7 +398,8 @@ export function startAcpSpawnParentStreamRelay(params: {
         emit(`${relayLabel} resumed output.`, `${contextPrefix}:resumed`);
       }
 
-      lastProgressAt = Date.now();
+      sawAssistantOutput = true;
+      lastAssistantOutputAt = Date.now();
       pendingText += delta;
       if (pendingText.length > STREAM_BUFFER_MAX_CHARS) {
         pendingText = pendingText.slice(-STREAM_BUFFER_MAX_CHARS);
@@ -377,12 +412,49 @@ export function startAcpSpawnParentStreamRelay(params: {
       return;
     }
 
+    if (event.stream === "status" || event.stream === "tool") {
+      sawRuntimeActivity = true;
+      const text = normalizeOptionalString(
+        (event.data as { text?: unknown; title?: unknown } | undefined)?.text ??
+          (event.data as { title?: unknown } | undefined)?.title,
+      );
+      logEvent(event.stream, {
+        ...(text ? { text } : {}),
+        data: event.data,
+      });
+      if (text) {
+        recordTaskRunProgressByRunId({
+          runId,
+          runtime: "acp",
+          sessionKey: params.childSessionKey,
+          lastEventAt: Date.now(),
+          eventSummary: truncate(compactWhitespace(text), STREAM_SNIPPET_MAX_CHARS),
+        });
+      }
+      return;
+    }
+
     if (event.stream !== "lifecycle") {
       return;
     }
 
     const phase = normalizeOptionalString((event.data as { phase?: unknown } | undefined)?.phase);
     logEvent("lifecycle", { phase: phase ?? "unknown", data: event.data });
+    if (phase === "turn_started") {
+      sawTurnStarted = true;
+      lastTurnStartedAt = Date.now();
+      if (stallNotified && !sawAssistantOutput) {
+        stallNotified = false;
+      }
+      recordTaskRunProgressByRunId({
+        runId,
+        runtime: "acp",
+        sessionKey: params.childSessionKey,
+        lastEventAt: Date.now(),
+        eventSummary: "ACP turn started.",
+      });
+      return;
+    }
     if (phase === "end") {
       flushPending();
       const startedAt = toFiniteNumber(

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -1,3 +1,4 @@
+import { emitAcpRuntimeAgentEvent } from "../acp/runtime/agent-event-bridge.js";
 import { sanitizePendingFinalDeliveryText } from "../auto-reply/reply/pending-final-delivery.js";
 import {
   formatThinkingLevels,
@@ -576,6 +577,12 @@ async function agentCommandInternal(
           requestId: runId,
           signal: opts.abortSignal,
           onEvent: (event) => {
+            emitAcpRuntimeAgentEvent({
+              runId,
+              sessionKey,
+              event,
+              includeAssistantOutput: false,
+            });
             if (event.type === "done") {
               stopReason = event.stopReason;
               return;

--- a/src/auto-reply/reply/acp-projector.ts
+++ b/src/auto-reply/reply/acp-projector.ts
@@ -174,6 +174,7 @@ export function createAcpReplyProjector(params: {
     meta?: AcpProjectedDeliveryMeta,
   ) => Promise<boolean>;
   onProgress?: () => void;
+  onVisibleText?: (text: string) => void;
   provider?: string;
   accountId?: string;
 }): AcpReplyProjector {
@@ -444,6 +445,7 @@ export function createAcpReplyProjector(params: {
       const remaining = settings.maxOutputChars - emittedOutputChars;
       const accepted = remaining < text.length ? text.slice(0, remaining) : text;
       if (accepted.length > 0) {
+        params.onVisibleText?.(accepted);
         emittedOutputChars += accepted.length;
         lastVisibleOutputTail = accepted.slice(-1);
         if (settings.deliveryMode === "live") {

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -1,4 +1,5 @@
 import { resolveAcpAgentPolicyError, resolveAcpDispatchPolicyError } from "../../acp/policy.js";
+import { emitAcpRuntimeAgentEvent } from "../../acp/runtime/agent-event-bridge.js";
 import { formatAcpRuntimeErrorText } from "../../acp/runtime/error-text.js";
 import { toAcpRuntimeError } from "../../acp/runtime/errors.js";
 import { resolveAcpThreadSessionDetailLines } from "../../acp/runtime/session-identifiers.js";
@@ -421,6 +422,20 @@ export async function tryDispatchAcpReply(params: {
     shouldSendToolSummaries: params.shouldSendToolSummaries,
     deliver: delivery.deliver,
     onProgress: markAcpProgress,
+    onVisibleText: (delta) => {
+      const runId = normalizeOptionalString(params.runId);
+      if (!runId) {
+        return;
+      }
+      emitAgentEvent({
+        runId,
+        sessionKey,
+        stream: "assistant",
+        data: {
+          delta,
+        },
+      });
+    },
     provider: params.ctx.Surface ?? params.ctx.Provider,
     accountId: effectiveDispatchAccountId,
   });
@@ -519,7 +534,15 @@ export async function tryDispatchAcpReply(params: {
       mode: "prompt",
       requestId: resolveAcpRequestId(params.ctx),
       ...(params.abortSignal ? { signal: params.abortSignal } : {}),
-      onEvent: async (event) => await projector.onEvent(event),
+      onEvent: async (event) => {
+        emitAcpRuntimeAgentEvent({
+          runId: params.runId,
+          sessionKey,
+          event,
+          includeAssistantOutput: false,
+        });
+        await projector.onEvent(event);
+      },
     });
 
     await projector.flush(true);

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -690,6 +690,11 @@ function createMockAcpSessionManager() {
           mode: (entry?.acp?.mode || "persistent") as AcpRuntimeEnsureInput["mode"],
           agent: entry?.acp?.agent || "codex",
         });
+        await params.onEvent({
+          type: "turn_started",
+          mode: params.mode,
+          requestId: params.requestId,
+        });
         const stream = runtimeBackend.runtime.runTurn({
           handle,
           text: params.text ?? "",
@@ -2171,7 +2176,18 @@ describe("dispatchReplyFromConfig", () => {
 
   it("emits lifecycle end for ACP turns using the current run id", async () => {
     setNoAbort();
-    const runtime = createAcpRuntime([{ type: "text_delta", text: "done" }, { type: "done" }]);
+    const runtime = createAcpRuntime([
+      { type: "status", tag: "usage_update", text: "warming up" },
+      {
+        type: "tool_call",
+        text: "reading",
+        title: "Read file",
+        status: "running",
+      },
+      { type: "text_delta", text: "hidden plan", tag: "plan" },
+      { type: "text_delta", text: "done" },
+      { type: "done" },
+    ]);
     acpMocks.readAcpSessionEntry.mockReturnValue({
       sessionKey: "agent:codex-acp:session-1",
       storeSessionKey: "agent:codex-acp:session-1",
@@ -2215,7 +2231,7 @@ describe("dispatchReplyFromConfig", () => {
       },
     });
 
-    const lifecycleEvent = agentEventMocks.emitAgentEvent.mock.calls
+    const events = agentEventMocks.emitAgentEvent.mock.calls
       .map(
         (call) =>
           call[0] as {
@@ -2225,10 +2241,45 @@ describe("dispatchReplyFromConfig", () => {
             stream?: unknown;
           },
       )
-      .find((event) => event.runId === "run-acp-lifecycle-end");
+      .filter((event) => event.runId === "run-acp-lifecycle-end");
+    const lifecycleEvent = events.find(
+      (event) => event.stream === "lifecycle" && event.data?.phase === "end",
+    );
     expect(lifecycleEvent?.sessionKey).toBe("agent:codex-acp:session-1");
     expect(lifecycleEvent?.stream).toBe("lifecycle");
     expect(lifecycleEvent?.data?.phase).toBe("end");
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          stream: "lifecycle",
+          data: expect.objectContaining({ phase: "turn_started" }),
+        }),
+        expect.objectContaining({
+          stream: "status",
+          data: expect.objectContaining({ text: "warming up" }),
+        }),
+        expect.objectContaining({
+          stream: "tool",
+          data: expect.objectContaining({
+            text: "reading",
+            title: "Read file",
+            status: "running",
+          }),
+        }),
+        expect.objectContaining({
+          stream: "assistant",
+          data: expect.objectContaining({ delta: "done" }),
+        }),
+      ]),
+    );
+    expect(events).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          stream: "assistant",
+          data: expect.objectContaining({ delta: "hidden plan" }),
+        }),
+      ]),
+    );
   });
 
   it("emits lifecycle error for ACP turn failures using the current run id", async () => {
@@ -2291,7 +2342,12 @@ describe("dispatchReplyFromConfig", () => {
             stream?: unknown;
           },
       )
-      .find((event) => event.runId === "run-acp-lifecycle-error");
+      .find(
+        (event) =>
+          event.runId === "run-acp-lifecycle-error" &&
+          event.stream === "lifecycle" &&
+          event.data?.phase === "error",
+      );
     expect(lifecycleEvent?.sessionKey).toBe("agent:codex-acp:session-1");
     expect(lifecycleEvent?.stream).toBe("lifecycle");
     expect(lifecycleEvent?.data?.phase).toBe("error");

--- a/src/commands/agent.acp.test.ts
+++ b/src/commands/agent.acp.test.ts
@@ -395,6 +395,86 @@ describe("agentCommand ACP runtime routing", () => {
     });
   });
 
+  it("forwards ACP runtime status and tool events for diagnostics", async () => {
+    await withAcpSessionEnv(async () => {
+      const runTurn = vi.fn(async (paramsUnknown: unknown) => {
+        const params = paramsUnknown as {
+          onEvent?: (event: {
+            type: string;
+            text?: string;
+            tag?: string;
+            mode?: string;
+            requestId?: string;
+            title?: string;
+            status?: string;
+            stopReason?: string;
+          }) => Promise<void>;
+        };
+        await params.onEvent?.({
+          type: "turn_started",
+          mode: "prompt",
+          requestId: "run-acp-diagnostics",
+        });
+        await params.onEvent?.({
+          type: "status",
+          tag: "usage_update",
+          text: "warming up",
+        });
+        await params.onEvent?.({
+          type: "tool_call",
+          title: "Read file",
+          status: "running",
+          text: "reading",
+        });
+        await params.onEvent?.({ type: "text_delta", text: "done" });
+        await params.onEvent?.({ type: "done", stopReason: "stop" });
+      });
+
+      mockAcpManager({
+        runTurn: (params: unknown) => runTurn(params),
+      });
+
+      await agentCommand(
+        {
+          message: "ping",
+          sessionKey: "agent:codex:acp:test",
+          runId: "run-acp-diagnostics",
+        },
+        runtime,
+      );
+
+      const emitted = agentEventMocks.emitAgentEvent.mock.calls.map((call) => call[0]);
+      expect(emitted).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            runId: "run-acp-diagnostics",
+            stream: "lifecycle",
+            data: expect.objectContaining({ phase: "turn_started" }),
+          }),
+          expect.objectContaining({
+            runId: "run-acp-diagnostics",
+            stream: "status",
+            data: expect.objectContaining({ text: "warming up", tag: "usage_update" }),
+          }),
+          expect.objectContaining({
+            runId: "run-acp-diagnostics",
+            stream: "tool",
+            data: expect.objectContaining({
+              text: "reading",
+              title: "Read file",
+              status: "running",
+            }),
+          }),
+          expect.objectContaining({
+            runId: "run-acp-diagnostics",
+            stream: "assistant",
+            data: expect.objectContaining({ delta: "done" }),
+          }),
+        ]),
+      );
+    });
+  });
+
   it("keeps no-reply ACP turns silent", async () => {
     await withAcpSessionEnv(async () => {
       const { assistantEvents, logLines } = await runAcpTurnWithAssistantEvents(["NO_REPLY"]);


### PR DESCRIPTION
Summary
- Add an ACP `turn_started` runtime event and bridge ACP turn/status/tool diagnostics into agent event streams.
- Classify ACP subagent relay stalls as setup, post-handoff silence, runtime activity without assistant output, or post-output silence instead of a generic interactive-input wait.
- Keep dispatch assistant relays behind the ACP reply projector visibility/limits so hidden tags such as `plan` do not leak into parent streams.

Fixes #44810.

Verification
- `node scripts/run-vitest.mjs src/acp/control-plane/manager.test.ts src/commands/agent.acp.test.ts src/agents/acp-spawn-parent-stream.test.ts src/auto-reply/reply/dispatch-from-config.test.ts src/auto-reply/reply/acp-projector.test.ts` (6 files, 240 tests)
- `pnpm check:changed` via Blacksmith Testbox `tbx_01krt961wkqagwrn0cg3mhxrg9` (GitHub Actions run 25983259893)
- `/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --mode local` clean after fixing one accepted finding

Behavior addressed: Codex ACP child runs that accept a turn but produce no assistant output now expose runtime handoff/status/tool progress and report a precise stall reason instead of saying the child may be waiting for interactive input.
Real environment tested: local focused Vitest plus Blacksmith Testbox changed gate.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/acp/control-plane/manager.test.ts src/commands/agent.acp.test.ts src/agents/acp-spawn-parent-stream.test.ts src/auto-reply/reply/dispatch-from-config.test.ts src/auto-reply/reply/acp-projector.test.ts`; `pnpm check:changed`; `codex-review --mode local`.
Evidence after fix: relay tests cover no-turn, post-turn/no-runtime, runtime-activity/no-assistant, and resumed-output classifications; dispatch tests prove hidden `plan` text is not emitted as assistant stream while visible output is.
Observed result after fix: focused tests passed, changed gate passed, Codex review clean.
What was not tested: live Codex ACP network/proxy failure against a real remote gateway; the fix is covered at the ACP manager/event/relay boundary with mocked runtime events.
