### PR TITLE
[codex] Guard Control UI protocol in npm release check

### DIFF
--- a/scripts/openclaw-npm-release-check.ts
+++ b/scripts/openclaw-npm-release-check.ts
@@ -71,6 +71,8 @@ const REQUIRED_PACKED_PATHS = [
   ...WORKSPACE_TEMPLATE_PACK_PATHS,
 ];
 const CONTROL_UI_ASSET_PREFIX = "dist/control-ui/assets/";
+const CONTROL_UI_JS_ASSET_RE = /^dist\/control-ui\/assets\/.*\.js$/u;
+const PROTOCOL_VERSION_SOURCE_PATH = "src/gateway/protocol/version.ts";
 const FORBIDDEN_PACKED_PATH_RULES = [
   ...LOCAL_BUILD_METADATA_DIST_PATHS.map((prefix) => ({
     prefix,
@@ -589,6 +591,7 @@ function collectPackedTarballErrors(): string[] {
     ...collectControlUiPackErrors(packedPaths),
     ...collectForbiddenPackedPathErrors(packedPaths),
     ...collectForbiddenPackedContentErrors(packedPaths),
+    ...collectControlUiProtocolPackErrors(packedPaths),
     ...collectPackedTestCargoErrors(packedPaths),
   ];
 }
@@ -638,6 +641,83 @@ export function collectForbiddenPackedContentErrors(
       `npm package must not include private QA lab marker "${matchedMarker}" in "${packedPath}".`,
     );
   }
+  return errors.toSorted((left, right) => left.localeCompare(right));
+}
+
+type GatewayProtocolLevels = {
+  min: number;
+  max: number;
+};
+
+function parseProtocolConstant(source: string, name: string): number | null {
+  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = new RegExp(
+    `export\\s+const\\s+${escapedName}\\s*=\\s*(\\d+)\\s+as\\s+const`,
+    "u",
+  ).exec(source);
+  return match ? Number(match[1]) : null;
+}
+
+function readGatewayProtocolLevels(rootDir: string): GatewayProtocolLevels | null {
+  let source: string;
+  try {
+    source = readFileSync(pathToFileURL(join(rootDir, PROTOCOL_VERSION_SOURCE_PATH)), "utf8");
+  } catch {
+    return null;
+  }
+
+  const min = parseProtocolConstant(source, "MIN_CLIENT_PROTOCOL_VERSION");
+  const max = parseProtocolConstant(source, "PROTOCOL_VERSION");
+  if (min === null || max === null) {
+    return null;
+  }
+  return { min, max };
+}
+
+function collectControlUiConnectProtocolLevels(content: string): GatewayProtocolLevels[] {
+  const levels: GatewayProtocolLevels[] = [];
+  const pairPattern = /minProtocol\s*:\s*(\d+)\s*,\s*maxProtocol\s*:\s*(\d+)/gu;
+  for (const match of content.matchAll(pairPattern)) {
+    levels.push({ min: Number(match[1]), max: Number(match[2]) });
+  }
+  return levels;
+}
+
+export function collectControlUiProtocolPackErrors(
+  paths: Iterable<string>,
+  rootDir = process.cwd(),
+): string[] {
+  const expected = readGatewayProtocolLevels(rootDir);
+  if (!expected) {
+    return [
+      `Could not read Gateway protocol levels from "${PROTOCOL_VERSION_SOURCE_PATH}" while validating packed Control UI assets.`,
+    ];
+  }
+
+  const errors: string[] = [];
+  for (const packedPath of paths) {
+    if (!CONTROL_UI_JS_ASSET_RE.test(packedPath)) {
+      continue;
+    }
+
+    let content: string;
+    try {
+      content = readFileSync(pathToFileURL(join(rootDir, packedPath)), "utf8");
+    } catch {
+      continue;
+    }
+
+    const advertisedLevels = collectControlUiConnectProtocolLevels(content);
+    for (const actual of advertisedLevels) {
+      if (actual.min === expected.min && actual.max === expected.max) {
+        continue;
+      }
+      errors.push(
+        `Packed Control UI asset "${packedPath}" advertises Gateway protocol min=${actual.min} max=${actual.max}, but "${PROTOCOL_VERSION_SOURCE_PATH}" expects min=${expected.min} max=${expected.max}. Rebuild Control UI assets before publishing.`,
+      );
+    }
+  }
+
   return errors.toSorted((left, right) => left.localeCompare(right));
 }
 

--- a/test/openclaw-npm-release-check.test.ts
+++ b/test/openclaw-npm-release-check.test.ts
@@ -8,6 +8,7 @@ import {
   collectControlUiPackErrors,
   collectForbiddenPackedContentErrors,
   collectForbiddenPackedPathErrors,
+  collectControlUiProtocolPackErrors,
   collectPackedTestCargoErrors,
   collectReleasePackageMetadataErrors,
   collectReleaseTagErrors,
@@ -468,6 +469,70 @@ describe("collectForbiddenPackedPathErrors", () => {
       ).toEqual([
         'npm package must not include private QA lab marker "qa-lab/runtime-api.js" in "dist/postinstall-inventory.json".',
       ]);
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("collectControlUiProtocolPackErrors", () => {
+  it("rejects stale Control UI bundles that advertise an old gateway protocol", () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "openclaw-pack-ui-protocol-"));
+
+    try {
+      mkdirSync(join(rootDir, "src/gateway/protocol"), { recursive: true });
+      mkdirSync(join(rootDir, "dist/control-ui/assets"), { recursive: true });
+      writeFileSync(
+        join(rootDir, "src/gateway/protocol/version.ts"),
+        [
+          "export const PROTOCOL_VERSION = 5 as const;",
+          "export const MIN_CLIENT_PROTOCOL_VERSION = 5 as const;",
+          "export const MIN_PROBE_PROTOCOL_VERSION = 5 as const;",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+      writeFileSync(
+        join(rootDir, "dist/control-ui/assets/index-stale.js"),
+        "const params={minProtocol:4,maxProtocol:4};\n",
+        "utf8",
+      );
+
+      expect(
+        collectControlUiProtocolPackErrors(["dist/control-ui/assets/index-stale.js"], rootDir),
+      ).toEqual([
+        'Packed Control UI asset "dist/control-ui/assets/index-stale.js" advertises Gateway protocol min=4 max=4, but "src/gateway/protocol/version.ts" expects min=5 max=5. Rebuild Control UI assets before publishing.',
+      ]);
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts Control UI bundles that advertise the current gateway protocol", () => {
+    const rootDir = mkdtempSync(join(tmpdir(), "openclaw-pack-ui-protocol-"));
+
+    try {
+      mkdirSync(join(rootDir, "src/gateway/protocol"), { recursive: true });
+      mkdirSync(join(rootDir, "dist/control-ui/assets"), { recursive: true });
+      writeFileSync(
+        join(rootDir, "src/gateway/protocol/version.ts"),
+        [
+          "export const PROTOCOL_VERSION = 5 as const;",
+          "export const MIN_CLIENT_PROTOCOL_VERSION = 5 as const;",
+          "export const MIN_PROBE_PROTOCOL_VERSION = 5 as const;",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+      writeFileSync(
+        join(rootDir, "dist/control-ui/assets/index-current.js"),
+        "const params={minProtocol:5,maxProtocol:5};\n",
+        "utf8",
+      );
+
+      expect(
+        collectControlUiProtocolPackErrors(["dist/control-ui/assets/index-current.js"], rootDir),
+      ).toStrictEqual([]);
     } finally {
       rmSync(rootDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- add an npm release-package guard that scans packed Control UI JS assets for advertised Gateway protocol levels
- compare those advertised `minProtocol` / `maxProtocol` values against `src/gateway/protocol/version.ts`
- cover stale and current Control UI bundle cases in the release-check tests

## Why

A local upgrade to `2026.5.16-beta.4` shipped a Control UI asset advertising protocol `4` while the bundled gateway expected protocol `5`, causing dashboard entry to fail with `protocol mismatch` even though the gateway was healthy.

Fixes #82970.

## Validation

- `pnpm exec vitest run test/openclaw-npm-release-check.test.ts`
- `pnpm exec oxfmt --check --threads=1 scripts/openclaw-npm-release-check.ts test/openclaw-npm-release-check.test.ts`
- `git diff --check`
