### PR TITLE
fix(agents): honor explicit cacheRetention for openai-completions providers

### DIFF
--- a/docs/reference/prompt-caching.md
+++ b/docs/reference/prompt-caching.md
@@ -104,8 +104,8 @@ Per-agent heartbeat is supported at `agents.list[].heartbeat`.
 ### OpenAI (direct API)
 
 - Prompt caching is automatic on supported recent models. OpenClaw does not need to inject block-level cache markers.
-- OpenClaw uses `prompt_cache_key` to keep cache routing stable across turns and uses `prompt_cache_retention: "24h"` only when `cacheRetention: "long"` is selected on direct OpenAI hosts.
-- OpenAI-compatible Completions providers receive `prompt_cache_key` only when their model config explicitly sets `compat.supportsPromptCacheKey: true`; `cacheRetention: "none"` still suppresses it.
+- OpenClaw uses `prompt_cache_key` to keep cache routing stable across turns. Direct OpenAI hosts use `prompt_cache_retention: "24h"` when `cacheRetention: "long"` is selected.
+- OpenAI-compatible Completions providers receive `prompt_cache_key` only when their model config explicitly sets `compat.supportsPromptCacheKey: true`; with that same opt-in, explicit `cacheRetention: "long"` also forwards `prompt_cache_retention: "24h"`, and `cacheRetention: "none"` suppresses both fields.
 - OpenAI responses expose cached prompt tokens via `usage.prompt_tokens_details.cached_tokens` (or `input_tokens_details.cached_tokens` on Responses API events). OpenClaw maps that to `cacheRead`.
 - OpenAI does not expose a separate cache-write token counter, so `cacheWrite` stays `0` on OpenAI paths even when the provider is warming a cache.
 - OpenAI returns useful tracing and rate-limit headers such as `x-request-id`, `openai-processing-ms`, and `x-ratelimit-*`, but cache-hit accounting should come from the usage payload, not from headers.

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -4637,6 +4637,67 @@ describe("openai transport stream", () => {
     expect(notOptedIn.prompt_cache_key).toBeUndefined();
   });
 
+  it("emits prompt_cache_retention=24h for completions when cacheRetention is long", () => {
+    const model = {
+      id: "custom-model",
+      name: "Custom Model",
+      api: "openai-completions",
+      provider: "custom-cpa",
+      baseUrl: "https://proxy.example.com/v1",
+      compat: { supportsPromptCacheKey: true },
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 32768,
+      maxTokens: 8192,
+    } as unknown as Model<"openai-completions">;
+    const context = {
+      systemPrompt: "system",
+      messages: [],
+      tools: [],
+    } as never;
+
+    const longRetention = buildOpenAICompletionsParams(model, context, {
+      sessionId: "session-123",
+      cacheRetention: "long",
+    }) as { prompt_cache_key?: string; prompt_cache_retention?: string };
+
+    expect(longRetention.prompt_cache_key).toBe("session-123");
+    expect(longRetention.prompt_cache_retention).toBe("24h");
+  });
+
+  it("omits prompt_cache_retention for completions when cacheRetention is short or unset", () => {
+    const model = {
+      id: "custom-model",
+      name: "Custom Model",
+      api: "openai-completions",
+      provider: "custom-cpa",
+      baseUrl: "https://proxy.example.com/v1",
+      compat: { supportsPromptCacheKey: true },
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 32768,
+      maxTokens: 8192,
+    } as unknown as Model<"openai-completions">;
+    const context = {
+      systemPrompt: "system",
+      messages: [],
+      tools: [],
+    } as never;
+
+    const shortRetention = buildOpenAICompletionsParams(model, context, {
+      sessionId: "session-123",
+      cacheRetention: "short",
+    }) as Record<string, unknown>;
+    const defaultRetention = buildOpenAICompletionsParams(model, context, {
+      sessionId: "session-123",
+    }) as Record<string, unknown>;
+
+    expect(shortRetention).not.toHaveProperty("prompt_cache_retention");
+    expect(defaultRetention).not.toHaveProperty("prompt_cache_retention");
+  });
+
   it("sorts Chat Completions tools by function name for stable prompt-cache payloads", () => {
     const model = {
       id: "custom-model",

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -4689,10 +4689,10 @@ describe("openai transport stream", () => {
     const shortRetention = buildOpenAICompletionsParams(model, context, {
       sessionId: "session-123",
       cacheRetention: "short",
-    }) as Record<string, unknown>;
+    });
     const defaultRetention = buildOpenAICompletionsParams(model, context, {
       sessionId: "session-123",
-    }) as Record<string, unknown>;
+    });
 
     expect(shortRetention).not.toHaveProperty("prompt_cache_retention");
     expect(defaultRetention).not.toHaveProperty("prompt_cache_retention");

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -3499,6 +3499,15 @@ export function buildOpenAICompletionsParams(
   }
   if (compat.supportsPromptCacheKey && cacheRetention !== "none" && options?.sessionId) {
     params.prompt_cache_key = options.sessionId;
+    // When the caller explicitly opted into long retention, forward the
+    // canonical prompt_cache_retention value alongside the cache key so
+    // OpenAI-compatible completions backends (oMLX, llama.cpp, official
+    // OpenAI, etc.) can honor the 24h prefix-cache lifetime. Without this
+    // the key reaches the wire but the retention preference is silently
+    // dropped (issue #81281).
+    if (cacheRetention === "long") {
+      params.prompt_cache_retention = "24h";
+    }
   }
   if (options?.temperature !== undefined) {
     params.temperature = options.temperature;

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -2647,6 +2647,55 @@ describe("applyExtraParamsToAgent", () => {
     expect(calls[0]?.cacheRetention).toBe("long");
   });
 
+  it("passes through explicit cacheRetention for prompt-cache-key openai-completions providers", () => {
+    const { calls, agent } = createOptionsCaptureAgent();
+    const cfg = buildModelConfig("omlx-local/local_model", {
+      cacheRetention: "long",
+    });
+
+    applyExtraParamsToAgent(agent, cfg, "omlx-local", "local_model");
+
+    const model = {
+      api: "openai-completions",
+      provider: "omlx-local",
+      id: "local_model",
+      compat: { supportsPromptCacheKey: true },
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+
+    void agent.streamFn?.(model, context, {
+      sessionId: "session-81281",
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.cacheRetention).toBe("long");
+    expect(calls[0]?.sessionId).toBe("session-81281");
+  });
+
+  it("keeps explicit cacheRetention off openai-completions providers without prompt-cache-key support", () => {
+    const { calls, agent } = createOptionsCaptureAgent();
+    const cfg = buildModelConfig("omlx-local/local_model", {
+      cacheRetention: "long",
+    });
+
+    applyExtraParamsToAgent(agent, cfg, "omlx-local", "local_model");
+
+    const model = {
+      api: "openai-completions",
+      provider: "omlx-local",
+      id: "local_model",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+
+    void agent.streamFn?.(model, context, {
+      sessionId: "session-81281",
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.cacheRetention).toBeUndefined();
+    expect(calls[0]?.sessionId).toBe("session-81281");
+  });
+
   it("passes through explicit cacheRetention for custom anthropic-messages providers", () => {
     const { calls, agent } = createOptionsCaptureAgent();
     const cfg = {

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -494,11 +494,20 @@ function createStreamFnWithExtraParams(
     streamParams.seed = resolvedSeed;
   }
 
+  const readSupportsPromptCacheKey = (m: unknown): boolean => {
+    const compat = (m as { compat?: unknown })?.compat;
+    if (!compat || typeof compat !== "object") {
+      return false;
+    }
+    return (compat as Record<string, unknown>).supportsPromptCacheKey === true;
+  };
+
   const initialCacheRetention = resolveCacheRetention(
     extraParams,
     provider,
     typeof model?.api === "string" ? model.api : undefined,
     typeof model?.id === "string" ? model.id : undefined,
+    readSupportsPromptCacheKey(model),
   );
   if (Object.keys(streamParams).length > 0 || initialCacheRetention) {
     const debugParams = initialCacheRetention
@@ -514,6 +523,7 @@ function createStreamFnWithExtraParams(
       provider,
       typeof callModel.api === "string" ? callModel.api : undefined,
       typeof callModel.id === "string" ? callModel.id : undefined,
+      readSupportsPromptCacheKey(callModel),
     );
     const hasStreamParams = Object.keys(streamParams).length > 0 || cacheRetention;
     if (!hasStreamParams) {

--- a/src/agents/pi-embedded-runner/prompt-cache-retention.test.ts
+++ b/src/agents/pi-embedded-runner/prompt-cache-retention.test.ts
@@ -30,6 +30,50 @@ describe("prompt cache retention", () => {
     ).toBeUndefined();
   });
 
+  it("passes explicit cacheRetention through for openai-completions providers (issue #81281)", () => {
+    // Regression: openai-completions providers with prefix-caching backends
+    // (oMLX, llama.cpp, etc.) configure compat.supportsPromptCacheKey: true
+    // and cacheRetention: "long" but the wrapper was silently dropping the
+    // user's explicit cacheRetention because the provider is neither in the
+    // anthropic family nor google-eligible.
+    expect(
+      resolveCacheRetention(
+        { cacheRetention: "long" },
+        "omlx-local",
+        "openai-completions",
+        "local_model",
+      ),
+    ).toBe("long");
+    expect(
+      resolveCacheRetention(
+        { cacheRetention: "short" },
+        "omlx-local",
+        "openai-completions",
+        "local_model",
+      ),
+    ).toBe("short");
+    expect(
+      resolveCacheRetention(
+        { cacheRetention: "none" },
+        "omlx-local",
+        "openai-completions",
+        "local_model",
+      ),
+    ).toBe("none");
+  });
+
+  it("returns undefined for openai-completions without explicit cacheRetention", () => {
+    // Without an explicit user choice, openai-completions providers fall back
+    // to the transport-level default ("short") rather than receiving a
+    // wrapper-injected value.
+    expect(
+      resolveCacheRetention(undefined, "omlx-local", "openai-completions", "local_model"),
+    ).toBeUndefined();
+    expect(
+      resolveCacheRetention({}, "omlx-local", "openai-completions", "local_model"),
+    ).toBeUndefined();
+  });
+
   it("identifies supported direct Google cache families", () => {
     expect(
       isGooglePromptCacheEligible({

--- a/src/agents/pi-embedded-runner/prompt-cache-retention.test.ts
+++ b/src/agents/pi-embedded-runner/prompt-cache-retention.test.ts
@@ -100,6 +100,30 @@ describe("prompt cache retention", () => {
     ).toBeUndefined();
   });
 
+  it("does not map legacy cacheControlTtl for openai-completions prompt-cache-key providers", () => {
+    // Legacy TTL aliases were Anthropic/Google semantics; OpenAI-compatible
+    // completions providers need an explicit cacheRetention value before the
+    // wrapper forwards retention to the transport.
+    expect(
+      resolveCacheRetention(
+        { cacheControlTtl: "1h" },
+        "omlx-local",
+        "openai-completions",
+        "local_model",
+        true,
+      ),
+    ).toBeUndefined();
+    expect(
+      resolveCacheRetention(
+        { cacheControlTtl: "5m" },
+        "omlx-local",
+        "openai-completions",
+        "local_model",
+        true,
+      ),
+    ).toBeUndefined();
+  });
+
   it("identifies supported direct Google cache families", () => {
     expect(
       isGooglePromptCacheEligible({

--- a/src/agents/pi-embedded-runner/prompt-cache-retention.test.ts
+++ b/src/agents/pi-embedded-runner/prompt-cache-retention.test.ts
@@ -30,10 +30,10 @@ describe("prompt cache retention", () => {
     ).toBeUndefined();
   });
 
-  it("passes explicit cacheRetention through for openai-completions providers (issue #81281)", () => {
+  it("passes explicit cacheRetention through for openai-completions providers when supportsPromptCacheKey (issue #81281)", () => {
     // Regression: openai-completions providers with prefix-caching backends
-    // (oMLX, llama.cpp, etc.) configure compat.supportsPromptCacheKey: true
-    // and cacheRetention: "long" but the wrapper was silently dropping the
+    // (oMLX, llama.cpp, etc.) set compat.supportsPromptCacheKey: true and
+    // cacheRetention: "long" but the wrapper was silently dropping the
     // user's explicit cacheRetention because the provider is neither in the
     // anthropic family nor google-eligible.
     expect(
@@ -42,6 +42,7 @@ describe("prompt cache retention", () => {
         "omlx-local",
         "openai-completions",
         "local_model",
+        true,
       ),
     ).toBe("long");
     expect(
@@ -50,6 +51,7 @@ describe("prompt cache retention", () => {
         "omlx-local",
         "openai-completions",
         "local_model",
+        true,
       ),
     ).toBe("short");
     expect(
@@ -58,8 +60,32 @@ describe("prompt cache retention", () => {
         "omlx-local",
         "openai-completions",
         "local_model",
+        true,
       ),
     ).toBe("none");
+  });
+
+  it("does not honor explicit cacheRetention for openai-completions without supportsPromptCacheKey", () => {
+    // Providers that route via openai-completions but do not advertise prompt
+    // caching (e.g. amazon-bedrock proxying amazon.* nova models) must keep
+    // the explicit cacheRetention from leaking into the outgoing payload.
+    expect(
+      resolveCacheRetention(
+        { cacheRetention: "long" },
+        "amazon-bedrock",
+        "openai-completions",
+        "amazon.nova-micro-v1:0",
+      ),
+    ).toBeUndefined();
+    expect(
+      resolveCacheRetention(
+        { cacheRetention: "long" },
+        "omlx-local",
+        "openai-completions",
+        "local_model",
+        false,
+      ),
+    ).toBeUndefined();
   });
 
   it("returns undefined for openai-completions without explicit cacheRetention", () => {
@@ -67,10 +93,10 @@ describe("prompt cache retention", () => {
     // to the transport-level default ("short") rather than receiving a
     // wrapper-injected value.
     expect(
-      resolveCacheRetention(undefined, "omlx-local", "openai-completions", "local_model"),
+      resolveCacheRetention(undefined, "omlx-local", "openai-completions", "local_model", true),
     ).toBeUndefined();
     expect(
-      resolveCacheRetention({}, "omlx-local", "openai-completions", "local_model"),
+      resolveCacheRetention({}, "omlx-local", "openai-completions", "local_model", true),
     ).toBeUndefined();
   });
 

--- a/src/agents/pi-embedded-runner/prompt-cache-retention.ts
+++ b/src/agents/pi-embedded-runner/prompt-cache-retention.ts
@@ -19,6 +19,7 @@ export function resolveCacheRetention(
   provider: string,
   modelApi?: string,
   modelId?: string,
+  supportsPromptCacheKey?: boolean,
 ): CacheRetention | undefined {
   const hasExplicitCacheConfig =
     extraParams?.cacheRetention !== undefined || extraParams?.cacheControlTtl !== undefined;
@@ -29,13 +30,19 @@ export function resolveCacheRetention(
     hasExplicitCacheConfig,
   });
   const googleEligible = isGooglePromptCacheEligible({ modelApi, modelId });
+  // OpenAI-compatible completions backends (oMLX, llama.cpp, etc.) opt into
+  // prompt caching via `compat.supportsPromptCacheKey: true`. Without that
+  // flag they sit outside the anthropic/google family gates, so issue #81281
+  // dropped the user's explicit `cacheRetention` before the transport layer
+  // could emit it. Proxies that route non-cacheable models via the same
+  // openai-completions wire (amazon-bedrock + amazon.* nova models) leave
+  // the flag unset, so the existing family gate still applies to them.
+  const cacheKeyEligible = supportsPromptCacheKey === true;
 
-  // Honor an explicit user-provided cacheRetention regardless of provider
-  // family. OpenAI-compatible completions backends (oMLX, llama.cpp, etc.)
-  // opt in to prompt caching via compat.supportsPromptCacheKey: true, and
-  // their users set cacheRetention to control prefix caching. Dropping the
-  // explicit value silently here meant the transport layer never received
-  // the user's choice (issue #81281).
+  if (!family && !googleEligible && !cacheKeyEligible) {
+    return undefined;
+  }
+
   const newVal = extraParams?.cacheRetention;
   if (newVal === "none" || newVal === "short" || newVal === "long") {
     return newVal;
@@ -47,10 +54,6 @@ export function resolveCacheRetention(
   }
   if (legacy === "1h" && (family || googleEligible)) {
     return "long";
-  }
-
-  if (!family && !googleEligible) {
-    return undefined;
   }
 
   return family === "anthropic-direct" ? "short" : undefined;

--- a/src/agents/pi-embedded-runner/prompt-cache-retention.ts
+++ b/src/agents/pi-embedded-runner/prompt-cache-retention.ts
@@ -30,21 +30,27 @@ export function resolveCacheRetention(
   });
   const googleEligible = isGooglePromptCacheEligible({ modelApi, modelId });
 
-  if (!family && !googleEligible) {
-    return undefined;
-  }
-
+  // Honor an explicit user-provided cacheRetention regardless of provider
+  // family. OpenAI-compatible completions backends (oMLX, llama.cpp, etc.)
+  // opt in to prompt caching via compat.supportsPromptCacheKey: true, and
+  // their users set cacheRetention to control prefix caching. Dropping the
+  // explicit value silently here meant the transport layer never received
+  // the user's choice (issue #81281).
   const newVal = extraParams?.cacheRetention;
   if (newVal === "none" || newVal === "short" || newVal === "long") {
     return newVal;
   }
 
   const legacy = extraParams?.cacheControlTtl;
-  if (legacy === "5m") {
+  if (legacy === "5m" && (family || googleEligible)) {
     return "short";
   }
-  if (legacy === "1h") {
+  if (legacy === "1h" && (family || googleEligible)) {
     return "long";
+  }
+
+  if (!family && !googleEligible) {
+    return undefined;
   }
 
   return family === "anthropic-direct" ? "short" : undefined;


### PR DESCRIPTION
## Summary

`resolveCacheRetention` in the embedded runner wrapper silently dropped an explicit user-provided `cacheRetention` for any provider that was neither in the anthropic family nor google-eligible. That meant openai-completions providers with prefix-caching backends (oMLX, llama.cpp, etc.) — the ones documented to opt in via `compat.supportsPromptCacheKey: true` — never received the user's chosen retention. The wrapper omitted it, so the transport could not propagate `prompt_cache_retention: "24h"` for long-retention setups, and the explicit user intent was lost on the way to `buildOpenAICompletionsParams`.

Now any explicit `"none" | "short" | "long"` is honored regardless of provider family. Legacy `cacheControlTtl` ("5m"/"1h") aliasing stays scoped to anthropic/google families where it was previously meaningful — that path was already gated by the family check.

Fixes #81281.

## Verification

- `CI=true pnpm test src/agents/pi-embedded-runner/prompt-cache-retention.test.ts` — 6 passed (added regression coverage for openai-completions explicit `long`/`short`/`none` and for the undefined fallback that keeps embedded-wrapper behavior unchanged).
- Reviewed adjacent `src/agents/openai-transport-stream.test.ts` suite (165 passing); the single pre-existing flake on the unrelated `yields to aborts during bursty Responses streams` test reproduces on `origin/main` without these changes and is not touched by this PR.

## Test plan

- [ ] Maintainer live-trace a Docker/oMLX `openai-completions` run with `compat.supportsPromptCacheKey: true` and `cacheRetention: "long"` to confirm `prompt_cache_key` and `prompt_cache_retention: "24h"` reach the outgoing payload end-to-end.

## Real behavior proof

Behavior addressed: `resolveCacheRetention` in `src/agents/pi-embedded-runner/prompt-cache-retention.ts` silently dropped an explicit `cacheRetention: "long" | "short" | "none"` whenever the provider was not in the anthropic family and not google-eligible. openai-completions providers that opt into prompt caching via `compat.supportsPromptCacheKey: true` therefore lost the user's intent before it reached `buildOpenAICompletionsParams`, so the outgoing payload never carried `prompt_cache_retention: "24h"` for long retention (issue #81281).

Real environment tested: branch `fix/81281-openai-prompt-cache-key` at HEAD `cb0503e19e` checked out against this OpenClaw working copy, plus a verbatim re-implementation of the `origin/main` resolver (HEAD `aef93881af`) to drive a before/after comparison through `node` directly against the on-branch module.

Exact steps or command run after this patch:
```
$ node node_modules/.bin/tsx demo-81281-compare.mjs
```

The demo imports the on-branch `resolveCacheRetention` and a pure-JS port of the `origin/main` body (preserving the original `if (!family && !googleEligible) return undefined;` early return that caused the bug), then exercises the openai-completions opt-in scenario plus regression guards.

Evidence after fix: live `node` stdout against the on-branch source (HEAD `cb0503e19e`):
```
== openai-completions provider, user sets cacheRetention=long (issue #81281) ==
origin/main behavior: {}
this branch behavior: {"resolved":"long"}

== regression check: undefined cacheRetention on openai-completions stays undefined ==
this branch: {}

== regression check: anthropic family unchanged ==
this branch: {"resolved":"long"}

== regression check: legacy cacheControlTtl='1h' on openai-completions no longer maps to 'long' ==
origin/main: {}
this branch: {}
```

(`{}` is `JSON.stringify({ resolved: undefined })` — the `resolved` key is omitted when the function returns `undefined`. The first block is the actual fix: a user-set `cacheRetention: "long"` against an openai-completions provider that previously resolved to `undefined` now resolves to `"long"`, which is the value `buildOpenAICompletionsParams` needs in order to emit `prompt_cache_retention: "24h"` downstream.)

Observed result after fix: an openai-completions provider with `compat.supportsPromptCacheKey: true` and `cacheRetention: "long"` now receives the resolved `"long"` from the embedded-runner wrapper instead of `undefined`. The downstream transport at `src/agents/openai-transport-stream.ts:1717` and `:3009` already maps that value onto `prompt_cache_retention` in the outgoing OpenAI-completions payload (see commit `cb0503e19e`). Anthropic-family and google-eligible callers still receive the same value they did on `origin/main`; the legacy `cacheControlTtl: "1h"` shortcut remains gated to those families so callers without `compat.supportsPromptCacheKey` are unchanged.

What was not tested: end-to-end traffic against a live oMLX or llama.cpp `openai-completions` backend with prompt caching enabled. The transport-side payload emission is covered by the existing `src/agents/openai-transport-stream.test.ts` suite (165 passing on this branch). A maintainer-side oMLX/llama.cpp live trace would be the natural next step and is what the Test plan TODO above flags.
