### PR TITLE
agents: include allow-list hint in disallowed model override error

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -923,7 +923,7 @@ async function agentCommandInternal(
       const explicitKey = modelKey(explicitRef.provider, explicitRef.model);
       if (!visibilityPolicy.allowsKey(explicitKey)) {
         throw new Error(
-          `Model override "${sanitizeForLog(explicitRef.provider)}/${sanitizeForLog(explicitRef.model)}" is not allowed for agent "${sessionAgentId}".`,
+          `Model override "${sanitizeForLog(explicitRef.provider)}/${sanitizeForLog(explicitRef.model)}" is not allowed for agent "${sessionAgentId}". Add it to agents.defaults.models or pick an allowed model with "openclaw models list".`,
         );
       }
       provider = explicitRef.provider;


### PR DESCRIPTION
## Summary

Append the `agents.defaults.models` allow-list hint to the
`Model override "X" is not allowed for agent "Y"` error thrown by
`src/agents/agent-command.ts`. A peer code path in
`src/auto-reply/reply/get-reply-directives-apply.ts:72` already
includes a helpful hint
(`Add ${rejectedRef} to agents.defaults.models or pick an allowed
model with /model list.`); this brings the agent-command path to
parity.

This PR was originally scoped to include `docs/openai.md` and
`docs/codex-harness.md` rewrites based on observed behavior on the
2026.5.12 stable release. ClawSweeper review on current `main`
correctly pointed out that #82864
(`Fix OpenAI Codex runtime provider routing`) already addresses
the underlying routing / auth-bridging gap, so those docs as
written on `main` are accurate; my proposed rewrites would have
regressed them. I've dropped the docs hunks. **The remaining
change is the additive error-message hint, which ClawSweeper
flagged as "plausible" and is independent of the routing fix.**

## Change

`src/agents/agent-command.ts` (~line 926):

```diff
-          `Model override "${sanitizeForLog(explicitRef.provider)}/${sanitizeForLog(explicitRef.model)}" is not allowed for agent "${sessionAgentId}".`,
+          `Model override "${sanitizeForLog(explicitRef.provider)}/${sanitizeForLog(explicitRef.model)}" is not allowed for agent "${sessionAgentId}". Add it to agents.defaults.models or pick an allowed model with "openclaw models list".`,
```

## Backward compatibility

Existing test (`src/commands/agent.test.ts:1068`) uses
`toThrow(string)` which is substring matching, so the additional
hint at the tail does not break it. No test changes required.

(Optional follow-up: bring `src/gateway/http-utils.ts:105` to
parity — it uses `toEqual({ errorMessage })` exact matching and
would require updating the test, so excluded to keep scope
minimal.)

## Related

- #67670 — same Cloudflare 403 symptom in 2026.5.12 release.
  Resolved on `main` by #82864; this PR is unrelated to that
  routing fix but the user-facing error hint helps anyone who
  encounters the allow-list semantics for unrelated reasons.
- #82978 — companion issue I filed and ClawSweeper closed as
  already implemented (correctly, on `main`).