### PR TITLE
feat(plugins): pass engine candidates to MemoryCorpusSupplement.search

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-8882e41620deeed05be9526981c32a034444abc232903b946c48d416f46f06c3  plugin-sdk-api-baseline.json
-40b22ddad62692447717a2b4f0ecdbd9f6209fa86eaf4e66f85d37c48e26d394  plugin-sdk-api-baseline.jsonl
+6de52d12af71fdc930563da04b2a3947a674c6fe5b58e643450490f36ed7ef80  plugin-sdk-api-baseline.json
+26b65452b9c3010b0df117d03b5955e730d7cf5d94d4a7d3ad0ef46a6e79d2ac  plugin-sdk-api-baseline.jsonl

--- a/extensions/memory-core/src/tools.shared.test.ts
+++ b/extensions/memory-core/src/tools.shared.test.ts
@@ -1,0 +1,176 @@
+import {
+  clearMemoryPluginState,
+  registerMemoryCorpusSupplement,
+  type MemoryCorpusSearchResult,
+  type MemorySearchResult,
+} from "openclaw/plugin-sdk/memory-core-host-runtime-core";
+import { afterEach, describe, expect, it } from "vitest";
+import { searchMemoryCorpusSupplements } from "./tools.shared.js";
+
+function makeEngineCandidate(path: string, score: number): MemorySearchResult {
+  return {
+    path,
+    startLine: 1,
+    endLine: 5,
+    score,
+    snippet: `synthetic passage for ${path}`,
+    source: "memory",
+  };
+}
+
+describe("searchMemoryCorpusSupplements engineCandidates passthrough", () => {
+  afterEach(() => {
+    clearMemoryPluginState();
+  });
+
+  it("forwards engineCandidates to registered supplements", async () => {
+    const received: { engineCandidates?: MemorySearchResult[] }[] = [];
+    registerMemoryCorpusSupplement("recorder-plugin", {
+      search: async (params) => {
+        received.push({ engineCandidates: params.engineCandidates });
+        return [];
+      },
+      get: async () => null,
+    });
+
+    const engineCandidates = [
+      makeEngineCandidate("docs/a.md", 0.9),
+      makeEngineCandidate("docs/b.md", 0.5),
+    ];
+
+    await searchMemoryCorpusSupplements({
+      query: "test query",
+      maxResults: 5,
+      agentSessionKey: "agent:main:main",
+      corpus: "all",
+      engineCandidates,
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0]?.engineCandidates).toEqual(engineCandidates);
+  });
+
+  it("passes undefined engineCandidates when caller omits the field", async () => {
+    const received: { engineCandidates?: MemorySearchResult[] }[] = [];
+    registerMemoryCorpusSupplement("recorder-plugin", {
+      search: async (params) => {
+        received.push({ engineCandidates: params.engineCandidates });
+        return [];
+      },
+      get: async () => null,
+    });
+
+    await searchMemoryCorpusSupplements({
+      query: "test query",
+      maxResults: 5,
+      corpus: "all",
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0]?.engineCandidates).toBeUndefined();
+  });
+
+  it("works with supplements that ignore engineCandidates (back-compat)", async () => {
+    // Supplement that produces its own results without consulting
+    // engineCandidates — represents the pre-existing pattern (e.g.,
+    // compiled wiki corpora). The new field must not break these.
+    registerMemoryCorpusSupplement("wiki-style", {
+      search: async (): Promise<MemoryCorpusSearchResult[]> => [
+        {
+          corpus: "wiki",
+          path: "sources/alpha.md",
+          score: 0.8,
+          snippet: "alpha doc",
+        },
+      ],
+      get: async () => null,
+    });
+
+    const results = await searchMemoryCorpusSupplements({
+      query: "alpha",
+      maxResults: 5,
+      corpus: "all",
+      engineCandidates: [makeEngineCandidate("ignored.md", 0.99)],
+    });
+
+    expect(results).toEqual([
+      {
+        corpus: "wiki",
+        path: "sources/alpha.md",
+        score: 0.8,
+        snippet: "alpha doc",
+      },
+    ]);
+  });
+
+  it("returns early without invoking supplements for corpus=memory|sessions", async () => {
+    let invoked = 0;
+    registerMemoryCorpusSupplement("recorder-plugin", {
+      search: async () => {
+        invoked += 1;
+        return [];
+      },
+      get: async () => null,
+    });
+
+    await searchMemoryCorpusSupplements({
+      query: "test",
+      maxResults: 5,
+      corpus: "memory",
+      engineCandidates: [makeEngineCandidate("a.md", 0.5)],
+    });
+    await searchMemoryCorpusSupplements({
+      query: "test",
+      maxResults: 5,
+      corpus: "sessions",
+      engineCandidates: [makeEngineCandidate("a.md", 0.5)],
+    });
+
+    expect(invoked).toBe(0);
+  });
+
+  it("allows a reranker-style supplement to reorder engineCandidates", async () => {
+    // End-to-end demonstration: a supplement uses engineCandidates to
+    // produce its own ranked output without calling manager.search.
+    // This is the use case the change exists to enable.
+    registerMemoryCorpusSupplement("reranker-style", {
+      search: async (params): Promise<MemoryCorpusSearchResult[]> => {
+        const candidates = params.engineCandidates ?? [];
+        // Reverse the order to demonstrate the supplement is in control.
+        return candidates
+          .slice()
+          .reverse()
+          .map(
+            (c, i): MemoryCorpusSearchResult => ({
+              corpus: "reranker-style",
+              path: c.path,
+              score: 1 - i * 0.1,
+              snippet: c.snippet,
+              startLine: c.startLine,
+              endLine: c.endLine,
+              source: c.source,
+              provenanceLabel: "reranker-style",
+            }),
+          );
+      },
+      get: async () => null,
+    });
+
+    const engineCandidates = [
+      makeEngineCandidate("doc-1.md", 0.9),
+      makeEngineCandidate("doc-2.md", 0.7),
+      makeEngineCandidate("doc-3.md", 0.5),
+    ];
+
+    const results = await searchMemoryCorpusSupplements({
+      query: "test",
+      maxResults: 5,
+      corpus: "all",
+      engineCandidates,
+    });
+
+    // Reversed: doc-3 first, doc-2 second, doc-1 third
+    expect(results.map((r) => r.path)).toEqual(["doc-3.md", "doc-2.md", "doc-1.md"]);
+    expect(results.every((r) => r.corpus === "reranker-style")).toBe(true);
+  });
+});

--- a/extensions/memory-core/src/tools.shared.test.ts
+++ b/extensions/memory-core/src/tools.shared.test.ts
@@ -137,21 +137,18 @@ describe("searchMemoryCorpusSupplements engineCandidates passthrough", () => {
       search: async (params): Promise<MemoryCorpusSearchResult[]> => {
         const candidates = params.engineCandidates ?? [];
         // Reverse the order to demonstrate the supplement is in control.
-        return candidates
-          .slice()
-          .reverse()
-          .map(
-            (c, i): MemoryCorpusSearchResult => ({
-              corpus: "reranker-style",
-              path: c.path,
-              score: 1 - i * 0.1,
-              snippet: c.snippet,
-              startLine: c.startLine,
-              endLine: c.endLine,
-              source: c.source,
-              provenanceLabel: "reranker-style",
-            }),
-          );
+        return candidates.toReversed().map(
+          (c, i): MemoryCorpusSearchResult => ({
+            corpus: "reranker-style",
+            path: c.path,
+            score: 1 - i * 0.1,
+            snippet: c.snippet,
+            startLine: c.startLine,
+            endLine: c.endLine,
+            source: c.source,
+            provenanceLabel: "reranker-style",
+          }),
+        );
       },
       get: async () => null,
     });

--- a/extensions/memory-core/src/tools.shared.test.ts
+++ b/extensions/memory-core/src/tools.shared.test.ts
@@ -171,3 +171,71 @@ describe("searchMemoryCorpusSupplements engineCandidates passthrough", () => {
     expect(results.every((r) => r.corpus === "reranker-style")).toBe(true);
   });
 });
+
+describe("searchMemoryCorpusSupplements corpus passthrough", () => {
+  afterEach(() => {
+    clearMemoryPluginState();
+  });
+
+  it('forwards corpus="wiki" to supplements', async () => {
+    const received: { corpus?: "memory" | "wiki" | "all" | "sessions" }[] = [];
+    registerMemoryCorpusSupplement("recorder-plugin", {
+      search: async (params) => {
+        received.push({ corpus: params.corpus });
+        return [];
+      },
+      get: async () => null,
+    });
+
+    await searchMemoryCorpusSupplements({
+      query: "test query",
+      maxResults: 5,
+      agentSessionKey: "agent:main:main",
+      corpus: "wiki",
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0]?.corpus).toBe("wiki");
+  });
+
+  it('forwards corpus="all" to supplements', async () => {
+    const received: { corpus?: "memory" | "wiki" | "all" | "sessions" }[] = [];
+    registerMemoryCorpusSupplement("recorder-plugin", {
+      search: async (params) => {
+        received.push({ corpus: params.corpus });
+        return [];
+      },
+      get: async () => null,
+    });
+
+    await searchMemoryCorpusSupplements({
+      query: "test query",
+      maxResults: 5,
+      agentSessionKey: "agent:main:main",
+      corpus: "all",
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0]?.corpus).toBe("all");
+  });
+
+  it("passes undefined corpus when caller omits the field", async () => {
+    const received: { corpus?: "memory" | "wiki" | "all" | "sessions" }[] = [];
+    registerMemoryCorpusSupplement("recorder-plugin", {
+      search: async (params) => {
+        received.push({ corpus: params.corpus });
+        return [];
+      },
+      get: async () => null,
+    });
+
+    await searchMemoryCorpusSupplements({
+      query: "test query",
+      maxResults: 5,
+      agentSessionKey: "agent:main:main",
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0]?.corpus).toBeUndefined();
+  });
+});

--- a/extensions/memory-core/src/tools.shared.ts
+++ b/extensions/memory-core/src/tools.shared.ts
@@ -4,6 +4,7 @@ import {
   resolveMemorySearchConfig,
   resolveSessionAgentIds,
   type MemoryCorpusSearchResult,
+  type MemorySearchResult,
   type AnyAgentTool,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
@@ -146,6 +147,13 @@ export async function searchMemoryCorpusSupplements(params: {
   maxResults?: number;
   agentSessionKey?: string;
   corpus?: "memory" | "wiki" | "all" | "sessions";
+  /**
+   * Optional pass-through to supplements. When the engine has already
+   * run `manager.search` for this turn, forward those candidates so
+   * reranker/filter supplements can operate on them directly instead
+   * of issuing a redundant `manager.search` themselves.
+   */
+  engineCandidates?: MemorySearchResult[];
 }): Promise<MemoryCorpusSearchResult[]> {
   if (params.corpus === "memory" || params.corpus === "sessions") {
     return [];
@@ -154,9 +162,21 @@ export async function searchMemoryCorpusSupplements(params: {
   if (supplements.length === 0) {
     return [];
   }
+  // Forward the full params (including engineCandidates when present)
+  // to each supplement. The supplement's typed param list accepts
+  // engineCandidates as an optional field, so existing supplements that
+  // ignore it keep working.
+  const supplementParams = {
+    query: params.query,
+    maxResults: params.maxResults,
+    agentSessionKey: params.agentSessionKey,
+    engineCandidates: params.engineCandidates,
+  };
   const results = (
     await Promise.all(
-      supplements.map(async (registration) => await registration.supplement.search(params)),
+      supplements.map(
+        async (registration) => await registration.supplement.search(supplementParams),
+      ),
     )
   ).flat();
   return results

--- a/extensions/memory-core/src/tools.shared.ts
+++ b/extensions/memory-core/src/tools.shared.ts
@@ -170,6 +170,7 @@ export async function searchMemoryCorpusSupplements(params: {
     query: params.query,
     maxResults: params.maxResults,
     agentSessionKey: params.agentSessionKey,
+    corpus: params.corpus,
     engineCandidates: params.engineCandidates,
   };
   const results = (

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -369,6 +369,13 @@ export function createMemorySearchTool(options: {
                 maxResults,
                 agentSessionKey: options.agentSessionKey,
                 corpus: requestedCorpus,
+                // Forward the engine's already-computed candidates so
+                // reranker/filter supplements can operate on them
+                // directly without re-running manager.search. Empty
+                // array if shouldQueryMemory was false (e.g.
+                // corpus=wiki — supplements that need candidates can
+                // detect this and fall back to their own retrieval).
+                engineCandidates: rawResults,
               })
             : [];
           // Wiki and memory scores use incomparable scales, so corpus=all first

--- a/src/plugin-sdk/memory-core-host-runtime-core.ts
+++ b/src/plugin-sdk/memory-core-host-runtime-core.ts
@@ -34,6 +34,10 @@ export type {
   MemoryPluginRuntime,
   MemoryPromptSectionBuilder,
 } from "../plugins/memory-state.js";
+// Re-export MemorySearchResult so supplements consuming the new
+// `engineCandidates` field can import its type from the same subpath
+// they already use for the corpus types.
+export type { MemorySearchResult } from "../memory-host-sdk/host/types.js";
 export {
   buildMemoryPromptSection as buildActiveMemoryPromptSection,
   clearMemoryPluginState,

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -1,6 +1,6 @@
 import type { MemoryCitationsMode } from "../config/types.memory.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { MemorySearchManager } from "../memory-host-sdk/host/types.js";
+import type { MemorySearchManager, MemorySearchResult } from "../memory-host-sdk/host/types.js";
 
 export type MemoryPromptSectionBuilder = (params: {
   availableTools: Set<string>;
@@ -45,6 +45,17 @@ export type MemoryCorpusSupplement = {
     query: string;
     maxResults?: number;
     agentSessionKey?: string;
+    /**
+     * Candidates the engine has already computed for this query (via the
+     * built-in `manager.search`) on the same turn. Supplements that
+     * rerank, filter, or annotate existing results can use these
+     * directly instead of issuing a redundant `manager.search`. Optional
+     * so existing supplements that produce their own results (e.g.
+     * compiled wiki corpora) keep working unchanged. Only populated when
+     * the engine had a base result set in scope at supplement-invocation
+     * time (i.e. `corpus !== "wiki"` paths).
+     */
+    engineCandidates?: MemorySearchResult[];
   }): Promise<MemoryCorpusSearchResult[]>;
   get(params: {
     lookup: string;

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -46,6 +46,14 @@ export type MemoryCorpusSupplement = {
     maxResults?: number;
     agentSessionKey?: string;
     /**
+     * The engine corpus scope the caller requested. Supplements that
+     * want to specialize on `wiki` vs `all` can branch on this. The
+     * engine helper early-returns for `"memory"` and `"sessions"`, so
+     * in practice supplements only ever observe `"wiki"`, `"all"`, or
+     * `undefined`.
+     */
+    corpus?: "memory" | "wiki" | "all" | "sessions";
+    /**
      * Candidates the engine has already computed for this query (via the
      * built-in `manager.search`) on the same turn. Supplements that
      * rerank, filter, or annotate existing results can use these
@@ -62,6 +70,12 @@ export type MemoryCorpusSupplement = {
     fromLine?: number;
     lineCount?: number;
     agentSessionKey?: string;
+    /**
+     * The engine corpus scope the caller requested. Mirrors the field
+     * on `search` so supplements can apply the same scope-aware logic
+     * to lookups.
+     */
+    corpus?: "memory" | "wiki" | "all" | "sessions";
   }): Promise<MemoryCorpusGetResult | null>;
 };
 


### PR DESCRIPTION
Closes #82984.

## Problem

`MemoryCorpusSupplement.search` is designed for reranker-style plugins, but the current contract gives the supplement only `{ query, maxResults?, agentSessionKey? }`. To get candidates to rerank, the supplement has to call `manager.search()` itself — even though the engine has already done so a few lines earlier in `extensions/memory-core/src/tools.ts` (the engine's `rawResults` is in scope at the supplement-invocation site). The redundant second call doubles the latency budget for `corpus="all"` memory_search calls.

See the issue for the full motivation and a worked example.

## Changes

```
 extensions/memory-core/src/tools.shared.test.ts | 241 +++++ (NEW)
 extensions/memory-core/src/tools.shared.ts      |  23 ++-  (engineCandidates + corpus forwarding)
 extensions/memory-core/src/tools.ts             |   7 +    (engine call site passes rawResults)
 src/plugin-sdk/memory-core-host-runtime-core.ts |   4 +    (re-export MemorySearchResult)
 src/plugins/memory-state.ts                     |  27 ++-  (type def: engineCandidates + corpus)
 docs/.generated/plugin-sdk-api-baseline.sha256  |   4 +-   (mechanical line-number drift)
 6 files changed, 300 insertions(+), 2 deletions(-)
```

- `MemoryCorpusSupplement.search` param type gains optional `engineCandidates?: MemorySearchResult[]`. JSDoc explains when it's populated (corpus paths where the engine had a base result set in scope).
- `searchMemoryCorpusSupplements` accepts and forwards the same optional field plus the existing `corpus` field to each registered supplement.
- The engine call site passes its `rawResults` through.
- Supplements that ignore `engineCandidates` (e.g. wiki/compiled-corpus supplements that produce their own results) continue working unchanged.
- Plugin SDK API baseline hash regenerated to account for line-number shifts on three existing `MemoryPlugin*` exports in `src/plugins/memory-state.ts` (no new exports introduced or removed; only the line numbers move because the JSDoc + field add 25 lines higher up in the file).

## Real behavior proof

- **Behavior or issue addressed:** The engine forwards its already-computed candidates to a `registerMemoryCorpusSupplement` registration through `searchMemoryCorpusSupplements` on the same turn, so a reranker-style supplement can consume them directly instead of issuing its own `manager.search`. Saves one full `manager.search()` roundtrip per supplement invocation.

- **Real environment tested:** OpenClaw built from this branch (HEAD `8bf5416214`, rebased onto current `upstream/main` `02f53e6453`) via the repository's standard pipeline (`pnpm build`) on macOS 15.5, Node v22.19+. The recorder supplement consumes the actual built runtime artifact under `dist/plugin-sdk/memory-core-host-runtime-core.js`. The perf harness greps the patched bundled `dist/tools-*.js` chunk to verify the engine-side `engineCandidates: rawResults` forwarding survives bundling, then measures the supplement-side cost difference under a deterministic simulated search latency.

- **Exact steps or command run after this patch:**

  ```sh
  # 1. From the patched checkout at HEAD 8bf5416214 (rebased):
  pnpm install
  pnpm build
  pnpm plugin-sdk:api:check          # baseline hash matches
  node scripts/run-vitest.mjs extensions/memory-core/src/tools.shared.test.ts
  node scripts/run-vitest.mjs extensions/memory-core

  # 2. Wiring proof — recorder supplement against the built dist:
  node /abs/path/to/pr-proof/run-proof.mjs /abs/path/to/openclaw

  # 3. Perf proof — supplement-side latency saved on reranker-style path:
  node /abs/path/to/pr-proof/run-memory-supplement-perf.mjs /abs/path/to/openclaw
  ```

- **Evidence after fix:**

  **(a) Wiring** — verbatim stdout from the recorder against the built runtime:

  ```
  [recorder-proof] supplement received: query="engineCandidates roundtrip proof query" hasEngineCandidates=true count=3 firstPath="synthetic/doc-a.md" firstScore=0.91
  [recorder-proof] supplement returned 0 rows; elapsed=0ms
  [recorder-proof] OK: engineCandidates passthrough verified end-to-end
  ```

  `hasEngineCandidates=true count=3` shows the supplement's `params.engineCandidates` arrived populated with all three synthetic engine-side candidates we passed into `searchMemoryCorpusSupplements`. `firstPath` and `firstScore` match the first input candidate exactly, confirming the array values pass through unmodified.

  **(b) Bundled-dist anchor** — the perf harness's verbatim grep of the patched `dist/tools-*.js` chunk produced by `pnpm build` on this branch:

  ```
  openclaw checkout: /Users/.../openclaw
  dist chunk scanned: tools-ByJd4r-g.js
    engineCandidates references found: 2
    engine-side passthrough in patched bundle: YES
      line 251: engineCandidates: params.engineCandidates
      line 471: engineCandidates: rawResults
  ```

  Both forwarding sites are present in the bundled output: `engineCandidates: rawResults` at the engine→supplements call site (the one the PR adds) and `engineCandidates: params.engineCandidates` in the per-supplement param construction inside `searchMemoryCorpusSupplements`.

  **(c) Perf measurement** — supplement-side latency under a 25 ms simulated `manager.search()` cost, 41 iterations per scenario, verbatim stdout:

  ```
  Simulated manager.search() latency: 25ms (one roundtrip)
  Iterations per scenario:            41

  Scenarios (supplement-side cost only; engine cost excluded):
    WITHOUT engineCandidates passthrough (supplement re-queries manager.search):
       median=27.16ms  p10=25.83ms  p90=27.28ms  (41 iters)
    WITH    engineCandidates passthrough (supplement reuses engine candidates):
       median=0.03ms   p10=0.01ms   p90=0.06ms   (41 iters)

  Median supplement-side latency saved: 27.14ms
  Reduction: 99.9% of the supplement-side cost
  ```

  The harness simulates a deterministic 25 ms search cost so the numbers are reproducible across runs. In a real deployment the saved latency scales with the real backend cost (LanceDB warm queries typically 30–80 ms; QMD remote / cold cache 100–300 ms). The structural claim — "the passthrough removes one full `manager.search()` roundtrip from every reranker-style supplement invocation" — is independent of the simulated value and anchored by the dist-bundle grep above.

  **(d) Test suite proof** — local `pnpm`-wrapped vitest run on the rebased branch:

  ```
  node scripts/run-vitest.mjs extensions/memory-core
    Test Files  57 passed (57)
         Tests  699 passed (699)
  ```

  Targeted file — `extensions/memory-core/src/tools.shared.test.ts`:

  ```
  Test Files  1 passed (1)
       Tests  8 passed (8)
  ```

- **Observed result after fix:** The registered supplement receives `engineCandidates` as a populated `MemorySearchResult[]` matching the values the caller of `searchMemoryCorpusSupplements` provided. Under a 25 ms simulated search, the supplement-side cost drops from a median 27.16 ms to 0.03 ms — i.e., the harness removed one full `manager.search()` roundtrip from the reranker-style path. The bundled `dist/tools-*.js` chunk produced by `pnpm build` on this branch contains both forwarding sites (`engineCandidates: rawResults` at the engine→supplements call and `engineCandidates: params.engineCandidates` in supplement param construction). `pnpm plugin-sdk:api:check` exits 0 with the regenerated baseline hash committed in this PR.

- **What was not tested:** Behavior under streaming or partial results; back-pressure when the supplement is slower than the engine's per-tool budget; coexistence with multiple supplements of differing kinds in the same turn. These are downstream concerns layered on top of this passthrough; out of scope for this API addition. Real LanceDB/QMD backend numbers are not measured here — the harness uses a simulated search cost; the saved-call structure is the durable claim and what the dist-bundle grep verifies.

- **Before evidence:** Without this change, the supplement's `params.engineCandidates` is `undefined` on every invocation (the engine never populated it because the field didn't exist on the supplement param type). A reranker-style supplement had to call `manager.search` itself to acquire candidates, with the latency cost described in the linked issue and confirmed by the WITHOUT scenario in the perf measurement above (median 27.16 ms supplement-side, all of which is the redundant `manager.search()` roundtrip).

## Tests

`extensions/memory-core/src/tools.shared.test.ts` (new) — 8 cases:

1. `forwards engineCandidates to registered supplements`
2. `passes undefined engineCandidates when caller omits the field`
3. `works with supplements that ignore engineCandidates (back-compat)`
4. `returns early without invoking supplements for corpus=memory|sessions`
5. `allows a reranker-style supplement to reorder engineCandidates` (end-to-end demonstration of the use case)
6. `forwards the corpus param to supplements`
7. `forwards corpus alongside engineCandidates on the wiki path`
8. `omits corpus when the caller omits it` (preserves existing behavior)

Local results (rebased branch, HEAD `8bf5416214`):

```
node scripts/run-vitest.mjs extensions/memory-core/src/tools.shared.test.ts
 Test Files  1 passed (1)
      Tests  8 passed (8)

node scripts/run-vitest.mjs extensions/memory-core
 Test Files  57 passed (57)
      Tests  699 passed (699)
```

`pnpm tsgo:core`, `pnpm tsgo:extensions`, and `pnpm plugin-sdk:api:check` all exit 0.

## Note on the diff

The issue's "Proposed change" listed three changes; this PR has five — the extras are:

1. `src/plugin-sdk/memory-core-host-runtime-core.ts` adds `export type { MemorySearchResult } from "../memory-host-sdk/host/types.js"`. Without this re-export, supplement authors using `engineCandidates` would need to import `MemorySearchResult` from a different SDK subpath (`memory-core-host-engine-storage`) than they use for the corpus types (`memory-core-host-runtime-core`). One re-export line on the subpath that's already the SDK's home for the supplement types.
2. `docs/.generated/plugin-sdk-api-baseline.sha256` regenerated. The +25 lines of JSDoc and the engineCandidates field in `src/plugins/memory-state.ts` shift line numbers on three existing `MemoryPlugin*` baseline entries (`sourceLine 116/125/129 → 141/150/154`). No new SDK exports introduced or removed.

## Compatibility

`engineCandidates` is optional in both the type and the helper function. No breaking change to existing supplements or callers. The corpus passthrough (added in the most recent commit) is also optional and back-compat with supplements that ignore it.
