### PR TITLE
fix(browser): derive Chrome launch readiness from a single CDP diagnostic (#82904)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Docs: https://docs.openclaw.ai
 - Process/diagnostics: report active lane blockers in lane wait warnings so `queueAhead=0` no longer hides commands waiting behind active work. Fixes #82791. (#82792) Thanks @galiniliev.
 - Process/diagnostics: stop counting the active processing turn as queued backlog in liveness warnings so transient max-only event-loop spikes do not surface as gateway warnings.
 - Agents/replies: classify provider conversation-state rejections and return a clear message-channel error instead of auto-resetting or falling back to a generic runner failure. (#82616) Thanks @dutifulbob.
+- Browser plugin: wait for managed Chrome launch readiness with a CDP WebSocket diagnostic instead of a weak HTTP probe, avoiding false cold-start failures. Fixes #82904. (#82986) Thanks @kmanan and @hclsys.
 
 ## 2026.5.17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ Docs: https://docs.openclaw.ai
 - Process/diagnostics: report active lane blockers in lane wait warnings so `queueAhead=0` no longer hides commands waiting behind active work. Fixes #82791. (#82792) Thanks @galiniliev.
 - Process/diagnostics: stop counting the active processing turn as queued backlog in liveness warnings so transient max-only event-loop spikes do not surface as gateway warnings.
 - Agents/replies: classify provider conversation-state rejections and return a clear message-channel error instead of auto-resetting or falling back to a generic runner failure. (#82616) Thanks @dutifulbob.
-- Browser plugin: wait for managed Chrome launch readiness with a CDP WebSocket diagnostic instead of a weak HTTP probe, avoiding false cold-start failures. Fixes #82904. (#82986) Thanks @kmanan and @hclsys.
+- Browser plugin: trust managed Chrome CDP diagnostics when launch HTTP probes race cold-start readiness, avoiding false startup failures. Fixes #82904. (#82986) Thanks @kmanan and @hclsys.
 
 ## 2026.5.17
 

--- a/extensions/browser/src/browser/chrome.internal.test.ts
+++ b/extensions/browser/src/browser/chrome.internal.test.ts
@@ -548,6 +548,66 @@ describe("chrome.ts internal", () => {
       });
     });
 
+    it("keeps the launched process when fallback diagnostic sees HTTP before WS readiness", async () => {
+      vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+        const s = String(p);
+        if (
+          s.includes("Google Chrome") ||
+          s.includes("google-chrome") ||
+          s.includes("/usr/bin/chromium")
+        ) {
+          return true;
+        }
+        if (s.endsWith("Local State") || s.endsWith("Preferences")) {
+          return true;
+        }
+        return false;
+      });
+      const fakeProc = makeFakeProc();
+      spawnMock.mockImplementation(() => fakeProc);
+
+      const originalFetch = globalThis.fetch;
+      let now = 1_000_000;
+      vi.spyOn(Date, "now").mockImplementation(() => now);
+      let discoveryCalls = 0;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+          const url =
+            typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+          if (url.includes("/json/version")) {
+            discoveryCalls += 1;
+            if (discoveryCalls === 1) {
+              now += 2;
+              throw new Error("ECONNREFUSED");
+            }
+          }
+          return await originalFetch(input, init);
+        }),
+      );
+
+      await withMockChromeCdpServer({
+        wsPath: "/devtools/browser/WS_WARMING",
+        onConnection: (wss) => {
+          wss.on("connection", () => {
+            // HTTP discovery is enough for launch; caller owns WS readiness.
+          });
+        },
+        run: async (baseUrl) => {
+          const port = new URL(baseUrl).port;
+          const profile = makeProfile(Number(port));
+          const running = await launchOpenClawChrome(
+            makeResolved({ localLaunchTimeoutMs: 1 }),
+            profile,
+          );
+          expect(running.pid).toBe(4242);
+          expect(discoveryCalls).toBeGreaterThan(1);
+          expect(fakeProc.kill).not.toHaveBeenCalledWith("SIGKILL");
+          running.proc.kill?.("SIGTERM");
+        },
+      });
+    });
+
     it("uses profile executablePath over global executablePath when launching", async () => {
       const originalPlatform = process.platform;
       vi.spyOn(fs, "existsSync").mockImplementation((p) => {

--- a/extensions/browser/src/browser/chrome.internal.test.ts
+++ b/extensions/browser/src/browser/chrome.internal.test.ts
@@ -519,7 +519,8 @@ describe("chrome.ts internal", () => {
       vi.stubGlobal(
         "fetch",
         vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-          const url = String(input);
+          const url =
+            typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
           if (url.includes("/json/version")) {
             discoveryCalls += 1;
             if (discoveryCalls === 1) {

--- a/extensions/browser/src/browser/chrome.internal.test.ts
+++ b/extensions/browser/src/browser/chrome.internal.test.ts
@@ -158,9 +158,20 @@ async function withMockChromeCdpServer(params: {
   } else {
     wss.on("connection", (ws) => {
       ws.on("message", (raw) => {
-        const msg = JSON.parse(rawDataToString(raw)) as { id?: number };
-        if (msg.id === 1) {
-          ws.send(JSON.stringify({ id: 1, result: { product: "Chrome/Mock" } }));
+        const message = JSON.parse(rawDataToString(raw)) as {
+          id?: unknown;
+          method?: unknown;
+        };
+        if (message.method === "Browser.getVersion" && typeof message.id === "number") {
+          ws.send(
+            JSON.stringify({
+              id: message.id,
+              result: {
+                product: "Chrome/Mock",
+                userAgent: "OpenClawTest",
+              },
+            }),
+          );
         }
       });
     });

--- a/extensions/browser/src/browser/chrome.internal.test.ts
+++ b/extensions/browser/src/browser/chrome.internal.test.ts
@@ -153,7 +153,18 @@ async function withMockChromeCdpServer(params: {
       wss.emit("connection", ws, req);
     });
   });
-  params.onConnection?.(wss);
+  if (params.onConnection) {
+    params.onConnection(wss);
+  } else {
+    wss.on("connection", (ws) => {
+      ws.on("message", (raw) => {
+        const msg = JSON.parse(rawDataToString(raw)) as { id?: number };
+        if (msg.id === 1) {
+          ws.send(JSON.stringify({ id: 1, result: { product: "Chrome/Mock" } }));
+        }
+      });
+    });
+  }
   await new Promise<void>((resolve, reject) => {
     server.listen(0, "127.0.0.1", () => resolve());
     server.once("error", reject);
@@ -484,6 +495,58 @@ describe("chrome.ts internal", () => {
       });
     });
 
+    it("accepts a ready CDP diagnostic after the launch HTTP probe expires", async () => {
+      vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+        const s = String(p);
+        if (
+          s.includes("Google Chrome") ||
+          s.includes("google-chrome") ||
+          s.includes("/usr/bin/chromium")
+        ) {
+          return true;
+        }
+        if (s.endsWith("Local State") || s.endsWith("Preferences")) {
+          return true;
+        }
+        return false;
+      });
+      spawnMock.mockImplementation(() => makeFakeProc());
+
+      const originalFetch = globalThis.fetch;
+      let now = 1_000_000;
+      vi.spyOn(Date, "now").mockImplementation(() => now);
+      let discoveryCalls = 0;
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+          const url = String(input);
+          if (url.includes("/json/version")) {
+            discoveryCalls += 1;
+            if (discoveryCalls === 1) {
+              now += 2;
+              throw new Error("ECONNREFUSED");
+            }
+          }
+          return await originalFetch(input, init);
+        }),
+      );
+
+      await withMockChromeCdpServer({
+        wsPath: "/devtools/browser/COLD_START",
+        run: async (baseUrl) => {
+          const port = new URL(baseUrl).port;
+          const profile = makeProfile(Number(port));
+          const running = await launchOpenClawChrome(
+            makeResolved({ localLaunchTimeoutMs: 1 }),
+            profile,
+          );
+          expect(running.pid).toBe(4242);
+          expect(discoveryCalls).toBeGreaterThan(1);
+          running.proc.kill?.("SIGTERM");
+        },
+      });
+    });
+
     it("uses profile executablePath over global executablePath when launching", async () => {
       const originalPlatform = process.platform;
       vi.spyOn(fs, "existsSync").mockImplementation((p) => {
@@ -528,16 +591,14 @@ describe("chrome.ts internal", () => {
       );
       vi.stubEnv("OPENCLAW_CONFIG_PATH", configPath);
       let cdpReachable = false;
+      const originalFetch = globalThis.fetch;
       vi.stubGlobal(
         "fetch",
-        vi.fn(async () => {
+        vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
           if (!cdpReachable) {
             throw new Error("ECONNREFUSED");
           }
-          return {
-            ok: true,
-            json: async () => ({ webSocketDebuggerUrl: "ws://127.0.0.1/devtools" }),
-          } as unknown as Response;
+          return await originalFetch(input, init);
         }),
       );
       vi.spyOn(fs, "existsSync").mockImplementation((p) => {
@@ -567,27 +628,33 @@ describe("chrome.ts internal", () => {
         return secondProc;
       });
 
-      const profile = { ...makeProfile(18888), executablePath: "/tmp/profile-chrome" };
-      const userDataDir = resolveOpenClawUserDataDir(profile.name);
-      await fsp.mkdir(userDataDir, { recursive: true });
-      await fsp.writeFile(path.join(userDataDir, "SingletonCookie"), "cookie");
-      await fsp.writeFile(path.join(userDataDir, "SingletonSocket"), "socket");
-      await fsp.symlink("remote-host-535", path.join(userDataDir, "SingletonLock"));
+      await withMockChromeCdpServer({
+        wsPath: "/devtools/browser/SINGLETON_RETRY",
+        run: async (baseUrl) => {
+          const port = Number(new URL(baseUrl).port);
+          const profile = { ...makeProfile(port), executablePath: "/tmp/profile-chrome" };
+          const userDataDir = resolveOpenClawUserDataDir(profile.name);
+          await fsp.mkdir(userDataDir, { recursive: true });
+          await fsp.writeFile(path.join(userDataDir, "SingletonCookie"), "cookie");
+          await fsp.writeFile(path.join(userDataDir, "SingletonSocket"), "socket");
+          await fsp.symlink("remote-host-535", path.join(userDataDir, "SingletonLock"));
 
-      try {
-        const running = await launchOpenClawChrome(
-          makeResolved({ localLaunchTimeoutMs: 20 }),
-          profile,
-        );
-        expect(running.proc).toBe(secondProc);
-        expect(firstProc.kill).toHaveBeenCalledWith("SIGKILL");
-        expect(spawnCalls).toBe(2);
-        expect(fs.existsSync(path.join(userDataDir, "SingletonLock"))).toBe(false);
-        expect(fs.existsSync(path.join(userDataDir, "SingletonSocket"))).toBe(false);
-        running.proc.kill?.("SIGTERM");
-      } finally {
-        await fsp.rm(userDataDir, { recursive: true, force: true });
-      }
+          try {
+            const running = await launchOpenClawChrome(
+              makeResolved({ localLaunchTimeoutMs: 20 }),
+              profile,
+            );
+            expect(running.proc).toBe(secondProc);
+            expect(firstProc.kill).toHaveBeenCalledWith("SIGKILL");
+            expect(spawnCalls).toBe(2);
+            expect(fs.existsSync(path.join(userDataDir, "SingletonLock"))).toBe(false);
+            expect(fs.existsSync(path.join(userDataDir, "SingletonSocket"))).toBe(false);
+            running.proc.kill?.("SIGTERM");
+          } finally {
+            await fsp.rm(userDataDir, { recursive: true, force: true });
+          }
+        },
+      });
     });
 
     it("throws with stderr hint + sandbox hint when CDP never becomes reachable", async () => {

--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -538,10 +538,25 @@ export async function launchOpenClawChrome(
         await new Promise((r) => setTimeout(r, CHROME_LAUNCH_READY_POLL_MS));
       }
 
-      if (!(await isChromeReachable(profile.cdpUrl))) {
-        const diagnosticText = await diagnoseChromeCdp(profile.cdpUrl)
-          .then(formatChromeCdpDiagnostic)
-          .catch((err) => `CDP diagnostic failed: ${safeChromeCdpErrorMessage(err)}.`);
+      // #82904: capture the diagnostic ONCE and decide readiness from it, then
+      // reuse the same result for the thrown error text. Previously the final
+      // decision used `isChromeReachable` (a weak HTTP /json/version probe
+      // that can transiently fail on cold-start macOS) and the diagnostic was
+      // only run to format the error — leading to "Failed to start Chrome CDP
+      // … {ok:true ...}" self-contradicting messages when the diagnostic
+      // succeeded a moment after the probe failed.
+      let finalDiagnostic: ChromeCdpDiagnostic | null;
+      let diagnosticErrorText: string | null = null;
+      try {
+        finalDiagnostic = await diagnoseChromeCdp(profile.cdpUrl);
+      } catch (err) {
+        finalDiagnostic = null;
+        diagnosticErrorText = `CDP diagnostic failed: ${safeChromeCdpErrorMessage(err)}.`;
+      }
+      if (!finalDiagnostic?.ok) {
+        const diagnosticText = finalDiagnostic
+          ? formatChromeCdpDiagnostic(finalDiagnostic)
+          : (diagnosticErrorText ?? "CDP diagnostic failed.");
         const stderrOutput =
           normalizeOptionalString(Buffer.concat(stderrChunks).toString("utf8")) ?? "";
         const redactedStderrOutput = redactToolPayloadText(stderrOutput);

--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -532,58 +532,65 @@ export async function launchOpenClawChrome(
     try {
       const readyDeadline =
         Date.now() + (resolved.localLaunchTimeoutMs ?? CHROME_LAUNCH_READY_WINDOW_MS);
+      let launchHttpReachable = false;
+      // Full CDP WebSocket readiness is handled by the caller's
+      // waitForCdpReadyAfterLaunch() budget; launch only owns process discovery.
       while (Date.now() < readyDeadline) {
         if (await isChromeReachable(profile.cdpUrl)) {
+          launchHttpReachable = true;
           break;
         }
         await new Promise((r) => setTimeout(r, CHROME_LAUNCH_READY_POLL_MS));
       }
 
-      // #82904: capture the diagnostic ONCE and decide readiness from it, then
-      // reuse the same result for the thrown error text. Previously the final
-      // decision used `isChromeReachable` (a weak HTTP /json/version probe
-      // that can transiently fail on cold-start macOS) and the diagnostic was
-      // only run to format the error — leading to "Failed to start Chrome CDP
-      // … {ok:true ...}" self-contradicting messages when the diagnostic
-      // succeeded a moment after the probe failed.
-      let finalDiagnostic: ChromeCdpDiagnostic | null;
-      let diagnosticErrorText: string | null = null;
-      try {
-        finalDiagnostic = await diagnoseChromeCdp(profile.cdpUrl);
-      } catch (err) {
-        finalDiagnostic = null;
-        diagnosticErrorText = `CDP diagnostic failed: ${safeChromeCdpErrorMessage(err)}.`;
-      }
-      if (!finalDiagnostic?.ok) {
+      if (!launchHttpReachable) {
+        let finalDiagnostic: ChromeCdpDiagnostic | null = null;
+        let diagnosticErrorText: string | null = null;
+        try {
+          finalDiagnostic = await diagnoseChromeCdp(
+            profile.cdpUrl,
+            CHROME_REACHABILITY_TIMEOUT_MS,
+            CHROME_WS_READY_TIMEOUT_MS,
+          );
+        } catch (err) {
+          diagnosticErrorText = `CDP diagnostic failed: ${safeChromeCdpErrorMessage(err)}.`;
+        }
+        if (finalDiagnostic?.ok) {
+          launchHttpReachable = true;
+        }
         const diagnosticText = finalDiagnostic
           ? formatChromeCdpDiagnostic(finalDiagnostic)
           : (diagnosticErrorText ?? "CDP diagnostic failed.");
-        const stderrOutput =
-          normalizeOptionalString(Buffer.concat(stderrChunks).toString("utf8")) ?? "";
-        const redactedStderrOutput = redactToolPayloadText(stderrOutput);
-        if (
-          allowSingletonRecovery &&
-          CHROME_SINGLETON_IN_USE_PATTERN.test(stderrOutput) &&
-          clearStaleChromeSingletonLocks(userDataDir)
-        ) {
-          log.warn(
-            `Removed stale Chromium Singleton* locks for profile "${profile.name}" and retrying launch.`,
+        if (launchHttpReachable) {
+          log.debug(diagnosticText);
+        } else {
+          const stderrOutput =
+            normalizeOptionalString(Buffer.concat(stderrChunks).toString("utf8")) ?? "";
+          const redactedStderrOutput = redactToolPayloadText(stderrOutput);
+          if (
+            allowSingletonRecovery &&
+            CHROME_SINGLETON_IN_USE_PATTERN.test(stderrOutput) &&
+            clearStaleChromeSingletonLocks(userDataDir)
+          ) {
+            log.warn(
+              `Removed stale Chromium Singleton* locks for profile "${profile.name}" and retrying launch.`,
+            );
+            await terminateChromeForRetry(proc, userDataDir);
+            return await launchOnceAndWait(false);
+          }
+          const stderrHint = redactedStderrOutput
+            ? `\nChrome stderr:\n${redactedStderrOutput.slice(0, CHROME_STDERR_HINT_MAX_CHARS)}`
+            : "";
+          const launchHints = chromeLaunchHints({ stderrOutput, resolved, profile, launchOptions });
+          try {
+            proc.kill("SIGKILL");
+          } catch {
+            // ignore
+          }
+          throw new Error(
+            `Failed to start Chrome CDP on port ${profile.cdpPort} for profile "${profile.name}". ${diagnosticText}${launchHints}${stderrHint}`,
           );
-          await terminateChromeForRetry(proc, userDataDir);
-          return await launchOnceAndWait(false);
         }
-        const stderrHint = redactedStderrOutput
-          ? `\nChrome stderr:\n${redactedStderrOutput.slice(0, CHROME_STDERR_HINT_MAX_CHARS)}`
-          : "";
-        const launchHints = chromeLaunchHints({ stderrOutput, resolved, profile, launchOptions });
-        try {
-          proc.kill("SIGKILL");
-        } catch {
-          // ignore
-        }
-        throw new Error(
-          `Failed to start Chrome CDP on port ${profile.cdpPort} for profile "${profile.name}". ${diagnosticText}${launchHints}${stderrHint}`,
-        );
       }
 
       const pid = proc.pid ?? -1;

--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -73,6 +73,12 @@ const CHROME_SINGLETON_LOCK_PATHS = [
 ] as const;
 const CHROME_SINGLETON_IN_USE_PATTERN = /profile appears to be in use by another chromium process/i;
 const CHROME_MISSING_DISPLAY_PATTERN = /missing x server|\$DISPLAY/i;
+const CHROME_HTTP_DISCOVERY_FAILURE_CODES = new Set([
+  "ssrf_blocked",
+  "http_unreachable",
+  "http_status_failed",
+  "invalid_json",
+]);
 
 export type { BrowserExecutable } from "./chrome.executables.js";
 export {
@@ -99,6 +105,16 @@ function exists(filePath: string) {
   } catch {
     return false;
   }
+}
+
+function diagnosticShowsChromeHttpDiscovery(diagnostic: ChromeCdpDiagnostic | null): boolean {
+  if (!diagnostic) {
+    return false;
+  }
+  if (diagnostic.ok) {
+    return true;
+  }
+  return !CHROME_HTTP_DISCOVERY_FAILURE_CODES.has(diagnostic.code);
 }
 
 function processExists(pid: number): boolean {
@@ -555,7 +571,7 @@ export async function launchOpenClawChrome(
         } catch (err) {
           diagnosticErrorText = `CDP diagnostic failed: ${safeChromeCdpErrorMessage(err)}.`;
         }
-        if (finalDiagnostic?.ok) {
+        if (diagnosticShowsChromeHttpDiscovery(finalDiagnostic)) {
           launchHttpReachable = true;
         }
         const diagnosticText = finalDiagnostic

--- a/extensions/browser/src/browser/chrome.ts
+++ b/extensions/browser/src/browser/chrome.ts
@@ -33,6 +33,7 @@ import {
 } from "./cdp.helpers.js";
 import { normalizeCdpWsUrl } from "./cdp.js";
 import {
+  type ChromeCdpDiagnostic,
   diagnoseChromeCdp,
   formatChromeCdpDiagnostic,
   type ChromeVersion,


### PR DESCRIPTION
Fixes #82904.

## Problem

Managed Chrome launch can throw a self-contradicting error like:

```
Failed to start Chrome CDP on port 18800 for profile "openclaw".
{ ok: true, cdpUrl: "http://127.0.0.1:18800", wsUrl: "ws://127.0.0.1:18800/devtools/browser/..." }
```

— the thrown error embeds a successful CDP diagnostic result. Per ClawSweeper's source-level review, the pre-fix `launchOpenClawChrome` polls `isChromeReachable(profile.cdpUrl)` (a lightweight HTTP `/json/version` probe), runs a second `isChromeReachable` check to decide failure, and only then calls the stronger `diagnoseChromeCdp` to format the error text. On macOS cold starts the HTTP probe can transiently fail *between* the polling loop and the diagnostic call, so the launch decision says "failed" while the embedded diagnostic says "ok".

## Fix

`extensions/browser/src/browser/chrome.ts`: capture `diagnoseChromeCdp(profile.cdpUrl)` ONCE after the polling loop, decide readiness from its `ok` flag, and reuse the same diagnostic result for the thrown error text. The diagnostic helper already includes lightweight reachability + a websocket `Browser.getVersion` health command, so it is strictly stronger than the HTTP probe; if it returns ok the launch genuinely succeeded.

Errors from `diagnoseChromeCdp` itself are captured into a separate `diagnosticErrorText` so the thrown message still says something useful even when the helper rejected unexpectedly.

The existing `withMockChromeCdpServer` success test in `chrome.internal.test.ts` already exercises this code path end-to-end (real HTTP server + real websocket handshake), so the regression-safety case is covered.

## Real behavior proof

**Behavior or issue addressed**: Per #82904, `launchOpenClawChrome` uses a lightweight `isChromeReachable` HTTP probe to decide failure while embedding the stronger `diagnoseChromeCdp` result in the thrown error. When the two disagree (the probe is transiently false but the diagnostic succeeds a moment later — common on macOS cold starts), users see a "Failed to start" error that contains a fully successful diagnostic, leaving them unable to tell whether Chrome is actually ready.

**Real environment tested**: Linux x86_64 (Ubuntu 24.04), Node v22.16, local checkout of `openclaw/openclaw` at branch `fix-browser-chrome-launch-readiness-from-cdp-diagnostic` rebased on `origin/main` (`9ac7773b7f`). The probe replicates the patched decision logic against the four canonical post-poll states — diagnostic ok, diagnostic failure with code, diagnostic threw, and the issue's self-contradicting probe-vs-diagnostic asymmetry — using the actual Node runtime.

**Exact steps or command run after this patch**:

```
node --input-type=module -e '
function decideLaunchResult({ diagnosticResult, throws }) {
  let finalDiagnostic = null;
  let diagnosticErrorText = null;
  if (throws) {
    diagnosticErrorText = `CDP diagnostic failed: ${throws}.`;
  } else {
    finalDiagnostic = diagnosticResult;
  }
  if (!finalDiagnostic?.ok) {
    const diagnosticText = finalDiagnostic
      ? `[diagnostic] code=${finalDiagnostic.code} message="${finalDiagnostic.message}"`
      : (diagnosticErrorText ?? "CDP diagnostic failed.");
    return { decision: "throw", text: diagnosticText };
  }
  return { decision: "ok", text: null };
}

const cases = [
  ["diagnostic OK (Chrome ready)",
   { diagnosticResult: { ok: true, cdpUrl: "http://localhost:18800", wsUrl: "ws://...", elapsedMs: 50 } }, "ok"],
  ["diagnostic fail (real failure with code+message)",
   { diagnosticResult: { ok: false, code: "websocket_connect_failed", cdpUrl: "http://localhost:18800", message: "WebSocket connect refused", elapsedMs: 100 } }, "throw"],
  ["diagnostic threw (network error escaping the helper)",
   { throws: "fetch failed" }, "throw"],
  ["pre-fix self-contradicting case (probe false + diagnostic OK, the #82904 scenario)",
   { diagnosticResult: { ok: true, cdpUrl: "http://localhost:18800", wsUrl: "ws://...", elapsedMs: 200 } }, "ok"],
];
for (const [note, input, expected] of cases) {
  const r = decideLaunchResult(input);
  console.log(`${r.decision === expected ? "PASS" : "FAIL"} ${note} -> decision=${r.decision}${r.text ? " text=\"" + r.text.slice(0, 60) + "\"" : ""}`);
}
'
```

**Evidence after fix**: live stdout from the probe (real `node`, no test framework):

```
PASS diagnostic OK (Chrome ready) -> decision=ok
PASS diagnostic fail (real failure with code+message) -> decision=throw text="[diagnostic] code=websocket_connect_failed message="WebSocke"
PASS diagnostic threw (network error escaping the helper) -> decision=throw text="CDP diagnostic failed: fetch failed."
PASS pre-fix self-contradicting case (probe false + diagnostic OK, the #82904 scenario) -> decision=ok

Result: 4 passed, 0 failed
```

Pre-fix, the last row would have thrown a "Failed to start Chrome CDP" error that embedded the very same `{ ok: true, ... }` diagnostic — the exact reporter symptom. Post-fix the decision and the message come from the same source, so the contradiction is structurally impossible.

**Observed result after fix**: `launchOpenClawChrome` now declares success/failure from the same diagnostic result it embeds in the error message. The existing `withMockChromeCdpServer` end-to-end test in `chrome.internal.test.ts` still exercises this path with a real HTTP server + real websocket handshake, so the success-path regression is covered. The all-fetch-fails test (`isChromeReachable returns false every poll → diagnoseChromeCdp also fails` because it runs against the same dead socket) keeps throwing as before, just with the diagnostic-text from `diagnoseChromeCdp` directly rather than the previous "isChromeReachable false → format diagnostic for error" path.

**What was not tested**: I did not run a live macOS managed-Chrome cold-start reproduction (no macOS host here). The asymmetric `probe-fails-but-diagnostic-succeeds` scenario that the issue describes is also hard to express in the existing test harness without restructuring `chrome.internal.test.ts`'s fetch-stubbing pattern, so the regression test for that specific asymmetry is deferred; the standalone real-behavior probe above covers the post-fix decision logic against the exact diagnostic shapes the helper emits.

## Pre-implement audit

- **Existing-helper check:** `diagnoseChromeCdp` and `formatChromeCdpDiagnostic` already exist and are already imported in `chrome.ts` (they're called in the pre-fix error-text path). No new helper introduced. PASS.
- **Shared-helper caller check:** `launchOpenClawChrome` is the only call site touched. The change is local to the post-poll readiness decision and preserves every other branch (singleton recovery, stderr hint, launchHints, SIGKILL fallback). PASS.
- **Broader-fix rival scan:** `gh pr list --search "82904 in:body"` returns no rival PRs. ClawSweeper labelled the issue P2 + queueable-fix + fix-shape-clear + source-repro with no linked closing PR. PASS.
