### PR TITLE
fix(telegram): warn when a media group silently drops failed photos [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Docs: https://docs.openclaw.ai
 - Agents/memory: explain that memory-triggered compaction exposes only `read` and append-only `write` when configured core tools are unavailable in `tools.allow` warnings. Fixes #82941. Thanks @galiniliev.
 - Agents/OpenAI: preserve deterministic tool payload ordering for prompt-cache reuse across OpenAI Responses and chat completions calls. (#82940) Thanks @galiniliev.
 - ACP/Codex: honor terminal ACP turn results so failed Codex/acpx runs are not recorded as successful after only progress text. Fixes #79522. Thanks @dudaefj.
+- Telegram: warn when a media group drops photos that fail to download, including albums where every photo is skipped. Fixes #55216. (#82987) Thanks @eldar702.
 - Agents/skills: apply the full effective tool policy pipeline to inline `command-dispatch: tool` skill dispatch before owner-only filtering, preserving configured allow, deny, sandbox, sender, group, and subagent restrictions. (#78525)
 - Codex: avoid spawning native hook relay subprocesses for post-tool/finalize events with no registered hook handlers while preserving pre-tool safety and approval relays. Fixes #76552. (#78004) Thanks @evgyur.
 - Channel accounts: keep top-level default channel accounts visible when named accounts are added alongside default credential material, so mixed legacy/new account configs keep resolving `default` instead of silently dropping it.

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -794,7 +794,7 @@ export const registerTelegramHandlers = ({
         }
       }
 
-      if (skippedCount > 0 && allMedia.length > 0) {
+      if (skippedCount > 0) {
         const total = entry.messages.length;
         const wasOrWere = skippedCount === 1 ? "was" : "were";
         await withTelegramApiErrorLogging({

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -794,7 +794,7 @@ export const registerTelegramHandlers = ({
         }
       }
 
-      if (false && skippedCount > 0 && allMedia.length > 0) {
+      if (skippedCount > 0 && allMedia.length > 0) {
         const total = entry.messages.length;
         const wasOrWere = skippedCount === 1 ? "was" : "were";
         await withTelegramApiErrorLogging({

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -764,6 +764,7 @@ export const registerTelegramHandlers = ({
       }
 
       const allMedia: TelegramMediaRef[] = [];
+      let skippedCount = 0;
       for (const { ctx } of entry.messages) {
         let media;
         try {
@@ -779,6 +780,7 @@ export const registerTelegramHandlers = ({
           runtime.log?.(
             warn(`media group: skipping photo that failed to fetch: ${String(mediaErr)}`),
           );
+          skippedCount++;
           continue;
         }
         if (media) {
@@ -787,7 +789,29 @@ export const registerTelegramHandlers = ({
             contentType: media.contentType,
             stickerMetadata: media.stickerMetadata,
           });
+        } else {
+          skippedCount++;
         }
+      }
+
+      if (false && skippedCount > 0 && allMedia.length > 0) {
+        const total = entry.messages.length;
+        const wasOrWere = skippedCount === 1 ? "was" : "were";
+        await withTelegramApiErrorLogging({
+          operation: "sendMessage",
+          runtime,
+          fn: () =>
+            bot.api.sendMessage(
+              primaryEntry.msg.chat.id,
+              `⚠️ Received ${allMedia.length} of ${total} images — ${skippedCount} could not be fetched and ${wasOrWere} skipped.`,
+              {
+                reply_parameters: {
+                  message_id: primaryEntry.msg.message_id,
+                  allow_sending_without_reply: true,
+                },
+              },
+            ),
+        }).catch(() => {});
       }
 
       await processMessageWithReplyChain(

--- a/extensions/telegram/src/bot.create-telegram-bot.media-group-skip-warning.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.media-group-skip-warning.test.ts
@@ -1,10 +1,5 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-// Resolve a real photo to a stored path for "p1.jpg" while making "p2.jpg"
-// (and "p3.jpg") fail with a *real* MediaFetchError so that
-// isRecoverableMediaGroupError() (which checks `instanceof MediaFetchError`
-// against openclaw/plugin-sdk/media-runtime) treats the failure as a
-// recoverable per-photo skip rather than dropping the whole album.
 const saveRemoteMedia = vi.fn();
 const saveMediaBuffer = vi.fn();
 const readRemoteMediaBuffer = vi.fn();
@@ -171,15 +166,11 @@ describe("createTelegramBot media-group skip warning (#55216)", () => {
         ...opts,
         telegramDeps: telegramBotDepsForTest,
       });
-    setTelegramBotRuntimeForTest(
-      telegramBotRuntimeForTest as unknown as Parameters<typeof setTelegramBotRuntimeForTest>[0],
-    );
+    setTelegramBotRuntimeForTest(telegramBotRuntimeForTest);
   });
 
   beforeEach(() => {
-    setTelegramBotRuntimeForTest(
-      telegramBotRuntimeForTest as unknown as Parameters<typeof setTelegramBotRuntimeForTest>[0],
-    );
+    setTelegramBotRuntimeForTest(telegramBotRuntimeForTest);
     saveRemoteMedia.mockReset();
     saveMediaBuffer.mockReset();
     readRemoteMediaBuffer.mockReset();
@@ -227,7 +218,7 @@ describe("createTelegramBot media-group skip warning (#55216)", () => {
     }
   });
 
-  it("does not send a media-drop warning when every photo fails", async () => {
+  it("warns the user when every album image fails", async () => {
     setOpenChannelPostConfig();
     saveRemoteMedia.mockImplementation(async (...args: unknown[]) => {
       throw new MediaFetchError("fetch_failed", `Failed to fetch media from ${urlOf(args)}`);
@@ -243,7 +234,10 @@ describe("createTelegramBot media-group skip warning (#55216)", () => {
       });
       await flushChannelPostMediaGroup(setTimeoutSpy);
 
-      expect(sendMessageSpy).not.toHaveBeenCalled();
+      expect(sendMessageSpy).toHaveBeenCalledTimes(1);
+      const warningText = String(sendMessageSpy.mock.calls[0]?.[1]);
+      expect(warningText).toContain("0 of 2 images");
+      expect(warningText).toContain("2 could not be fetched and were skipped");
     } finally {
       setTimeoutSpy.mockRestore();
     }

--- a/extensions/telegram/src/bot.create-telegram-bot.media-group-skip-warning.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.media-group-skip-warning.test.ts
@@ -1,0 +1,280 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Resolve a real photo to a stored path for "p1.jpg" while making "p2.jpg"
+// (and "p3.jpg") fail with a *real* MediaFetchError so that
+// isRecoverableMediaGroupError() (which checks `instanceof MediaFetchError`
+// against openclaw/plugin-sdk/media-runtime) treats the failure as a
+// recoverable per-photo skip rather than dropping the whole album.
+const saveRemoteMedia = vi.fn();
+const saveMediaBuffer = vi.fn();
+const readRemoteMediaBuffer = vi.fn();
+const rootRead = vi.fn();
+
+vi.mock("openclaw/plugin-sdk/file-access-runtime", () => ({
+  root: async (rootDir: string) => ({
+    read: async (relativePath: string, options?: { maxBytes?: number }) =>
+      await rootRead({ rootDir, relativePath, maxBytes: options?.maxBytes }),
+  }),
+}));
+
+vi.mock("./bot/delivery.resolve-media.runtime.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/telegram-media.runtime.js")>(
+    "./telegram-media.runtime.js",
+  );
+  return {
+    readRemoteMediaBuffer: (...args: unknown[]) => readRemoteMediaBuffer(...args),
+    formatErrorMessage: (err: unknown) => (err instanceof Error ? err.message : String(err)),
+    logVerbose: () => {},
+    MediaFetchError: actual.MediaFetchError,
+    resolveTelegramApiBase: (apiRoot?: string) =>
+      apiRoot?.trim() ? apiRoot.replace(/\/+$/u, "") : "https://api.telegram.org",
+    retryAsync: async (fn: () => unknown) => await fn(),
+    saveMediaBuffer: (...args: unknown[]) => saveMediaBuffer(...args),
+    saveRemoteMedia: (...args: unknown[]) => saveRemoteMedia(...args),
+    shouldRetryTelegramTransportFallback: vi.fn(() => false),
+    warn: (s: string) => s,
+  };
+});
+
+vi.mock("./sticker-cache.js", () => ({
+  cacheSticker: () => {},
+  getCachedSticker: () => null,
+  getCacheStats: () => ({ count: 0 }),
+  searchStickers: () => [],
+  getAllCachedStickers: () => [],
+  describeStickerImage: async () => null,
+}));
+
+const harness = await import("./bot.create-telegram-bot.test-harness.js");
+const {
+  getLoadConfigMock,
+  getOnHandler,
+  replySpy,
+  sendMessageSpy,
+  telegramBotDepsForTest,
+  telegramBotRuntimeForTest,
+} = harness;
+const { createTelegramBotCore: createTelegramBotBase, setTelegramBotRuntimeForTest } =
+  await import("./bot-core.js");
+const { MediaFetchError } = await import("./telegram-media.runtime.js");
+
+let createTelegramBot: (
+  opts: import("./bot.types.js").TelegramBotOptions,
+) => ReturnType<typeof import("./bot-core.js").createTelegramBotCore>;
+
+const loadConfig = getLoadConfigMock();
+
+const TELEGRAM_TEST_TIMINGS = {
+  mediaGroupFlushMs: 20,
+  textFragmentGapMs: 30,
+} as const;
+
+const CHANNEL_ID = -100777111222;
+
+function setOpenChannelPostConfig() {
+  loadConfig.mockReturnValue({
+    channels: {
+      telegram: {
+        groupPolicy: "open",
+        groups: {
+          "-100777111222": {
+            enabled: true,
+            requireMention: false,
+          },
+        },
+      },
+    },
+  });
+}
+
+function getChannelPostHandler() {
+  createTelegramBot({ token: "tok", testTimings: TELEGRAM_TEST_TIMINGS });
+  return getOnHandler("channel_post") as (ctx: Record<string, unknown>) => Promise<void>;
+}
+
+function resolveFlushTimer(setTimeoutSpy: ReturnType<typeof vi.spyOn>) {
+  const delayMs = TELEGRAM_TEST_TIMINGS.mediaGroupFlushMs;
+  const flushTimerCallIndex = setTimeoutSpy.mock.calls.findLastIndex(
+    (call: Parameters<typeof setTimeout>) => call[1] === delayMs,
+  );
+  const flushTimer =
+    flushTimerCallIndex >= 0
+      ? (setTimeoutSpy.mock.calls[flushTimerCallIndex]?.[0] as (() => unknown) | undefined)
+      : undefined;
+  if (flushTimerCallIndex >= 0) {
+    clearTimeout(
+      setTimeoutSpy.mock.results[flushTimerCallIndex]?.value as ReturnType<typeof setTimeout>,
+    );
+  }
+  return flushTimer;
+}
+
+async function flushChannelPostMediaGroup(setTimeoutSpy: ReturnType<typeof vi.spyOn>) {
+  const flushTimer = resolveFlushTimer(setTimeoutSpy);
+  expect(flushTimer).toBeTypeOf("function");
+  await flushTimer?.();
+}
+
+function createChannelPostContext(params: {
+  messageId: number;
+  date: number;
+  caption?: string;
+  mediaGroupId: string;
+  photoFileId: string;
+}) {
+  return {
+    channelPost: {
+      chat: { id: CHANNEL_ID, type: "channel", title: "Wake Channel" },
+      message_id: params.messageId,
+      date: params.date,
+      ...(params.caption ? { caption: params.caption } : {}),
+      media_group_id: params.mediaGroupId,
+      photo: [{ file_id: params.photoFileId }],
+    },
+    me: { username: "openclaw_bot" },
+    getFile: async () => ({ file_path: `photos/${params.photoFileId}.jpg` }),
+  };
+}
+
+async function queueChannelPostAlbum(
+  handler: (ctx: Record<string, unknown>) => Promise<void>,
+  params: { caption: string; mediaGroupId: string; photoFileIds: string[] },
+) {
+  const baseMessageId = 600;
+  const calls = params.photoFileIds.map((fileId, index) =>
+    handler(
+      createChannelPostContext({
+        messageId: baseMessageId + index,
+        date: 1736380800 + index,
+        ...(index === 0 ? { caption: params.caption } : {}),
+        mediaGroupId: params.mediaGroupId,
+        photoFileId: fileId,
+      }),
+    ),
+  );
+  await Promise.all(calls);
+  return baseMessageId;
+}
+
+function urlOf(args: unknown[]): string {
+  const opts = args[0];
+  if (opts && typeof opts === "object" && "url" in opts) {
+    return String((opts as { url: unknown }).url);
+  }
+  return "";
+}
+
+describe("createTelegramBot media-group skip warning (#55216)", () => {
+  beforeAll(() => {
+    createTelegramBot = (opts) =>
+      createTelegramBotBase({
+        ...opts,
+        telegramDeps: telegramBotDepsForTest,
+      });
+    setTelegramBotRuntimeForTest(
+      telegramBotRuntimeForTest as unknown as Parameters<typeof setTelegramBotRuntimeForTest>[0],
+    );
+  });
+
+  beforeEach(() => {
+    setTelegramBotRuntimeForTest(
+      telegramBotRuntimeForTest as unknown as Parameters<typeof setTelegramBotRuntimeForTest>[0],
+    );
+    saveRemoteMedia.mockReset();
+    saveMediaBuffer.mockReset();
+    readRemoteMediaBuffer.mockReset();
+    rootRead.mockReset();
+    sendMessageSpy.mockClear();
+    replySpy.mockClear();
+  });
+
+  it("warns the user once when an album drops some images", async () => {
+    setOpenChannelPostConfig();
+    saveRemoteMedia.mockImplementation(async (...args: unknown[]) => {
+      const url = urlOf(args);
+      if (url.includes("photos/p1.jpg")) {
+        return { path: "/tmp/p1.jpg", contentType: "image/png" };
+      }
+      throw new MediaFetchError("fetch_failed", `Failed to fetch media from ${url}`);
+    });
+
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    try {
+      const handler = getChannelPostHandler();
+      const baseMessageId = await queueChannelPostAlbum(handler, {
+        caption: "album caption",
+        mediaGroupId: "skip-warn-album-1",
+        photoFileIds: ["p1", "p2"],
+      });
+      expect(sendMessageSpy).not.toHaveBeenCalled();
+      await flushChannelPostMediaGroup(setTimeoutSpy);
+
+      expect(sendMessageSpy).toHaveBeenCalledTimes(1);
+      expect(sendMessageSpy).toHaveBeenCalledWith(
+        CHANNEL_ID,
+        expect.stringContaining("1 of 2 images"),
+        expect.objectContaining({
+          reply_parameters: expect.objectContaining({
+            message_id: baseMessageId,
+            allow_sending_without_reply: true,
+          }),
+        }),
+      );
+      const warningText = String(sendMessageSpy.mock.calls[0]?.[1]);
+      expect(warningText).toContain("1 could not be fetched and was skipped");
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
+  it("does not send a media-drop warning when every photo fails", async () => {
+    setOpenChannelPostConfig();
+    saveRemoteMedia.mockImplementation(async (...args: unknown[]) => {
+      throw new MediaFetchError("fetch_failed", `Failed to fetch media from ${urlOf(args)}`);
+    });
+
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    try {
+      const handler = getChannelPostHandler();
+      await queueChannelPostAlbum(handler, {
+        caption: "all-fail album",
+        mediaGroupId: "skip-warn-album-2",
+        photoFileIds: ["p1", "p2"],
+      });
+      await flushChannelPostMediaGroup(setTimeoutSpy);
+
+      expect(sendMessageSpy).not.toHaveBeenCalled();
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
+  it("pluralizes correctly for 2+ skipped", async () => {
+    setOpenChannelPostConfig();
+    saveRemoteMedia.mockImplementation(async (...args: unknown[]) => {
+      const url = urlOf(args);
+      if (url.includes("photos/p1.jpg")) {
+        return { path: "/tmp/p1.jpg", contentType: "image/png" };
+      }
+      throw new MediaFetchError("fetch_failed", `Failed to fetch media from ${url}`);
+    });
+
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    try {
+      const handler = getChannelPostHandler();
+      await queueChannelPostAlbum(handler, {
+        caption: "plural album",
+        mediaGroupId: "skip-warn-album-3",
+        photoFileIds: ["p1", "p2", "p3"],
+      });
+      await flushChannelPostMediaGroup(setTimeoutSpy);
+
+      expect(sendMessageSpy).toHaveBeenCalledTimes(1);
+      const warningText = String(sendMessageSpy.mock.calls[0]?.[1]);
+      expect(warningText).toContain("1 of 3 images");
+      expect(warningText).toContain("2 could not be fetched and were skipped");
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes Telegram media groups that silently lost photos when one or more album items failed to download.
- Tracks every skipped album item, including recoverable download errors and `null` media resolves.
- Sends one warning anchored to the album's first message with the delivered/skipped counts.
- Preserves normal album handling when every photo downloads successfully.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Linked Issue/PR

- Closes #55216

## Real behavior proof

Behavior addressed: Telegram albums with failed photo downloads now produce a user-visible warning instead of silently passing an incomplete album to the agent.

Real environment tested: Live Telegram test group with the driver bot sending a two-photo media group to the SUT bot. SUT gateway ran from PR commit `62ce661007b44ec24d153ee25d0f16f7b1b67c4e` in the isolated PR worktree, using the repo mock OpenAI server and a temporary Telegram `mediaMaxMb: 0.05` config so Telegram delivery was real while one downloaded image exceeded the SUT media cap.

Exact steps or command run after this patch:

```sh
node /tmp/openclaw-telegram-media-group-proof.mjs \
  --output /tmp/openclaw-telegram-media-group-proof-82987.json

node scripts/run-vitest.mjs run \
  extensions/telegram/src/bot.create-telegram-bot.media-group-skip-warning.test.ts \
  extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts \
  extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts \
  extensions/telegram/src/bot-message-context.body.test.ts

bunx oxfmt@0.49.0 --check --threads=1 \
  extensions/telegram/src/bot-handlers.runtime.ts \
  extensions/telegram/src/bot.create-telegram-bot.media-group-skip-warning.test.ts

git diff --check
```

Evidence after fix: live Telegram proof wrote `/tmp/openclaw-telegram-media-group-proof-82987-rebased.json`; uploaded media sizes were 69 bytes and 2,431,333 bytes; Telegram album message ids were `11654` and `11655`; the SUT warning was message `11656`, replying to album message `11654`.

Observed result after fix: the driver bot observed the SUT bot reply with `⚠️ Received 1 of 2 images — 1 could not be fetched and was skipped.` Scoped Vitest passed: 4 files, 55 tests. Format check and `git diff --check` passed.

What was not tested: live all-failed album proof. That case is covered by the regression test added in this PR.

## Root Cause

`processMediaGroup` ignored recoverable per-photo failures while continuing to process the surviving photos, so users had no signal that the album seen by the agent was incomplete.

## Regression Test Plan

- New regression test: `extensions/telegram/src/bot.create-telegram-bot.media-group-skip-warning.test.ts`.
- Locks partial album warning, all-failed album warning, and singular/plural wording.

## User-visible / Behavior Changes

When a Telegram album has photos that cannot be fetched, the bot sends one warning like `⚠️ Received 1 of 2 images — 1 could not be fetched and was skipped.`

## AI Disclosure

This PR was authored with AI assistance.
