### PR TITLE
[Fix] Reuse gateway startup auth preflight snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,7 @@ Docs: https://docs.openclaw.ai
 - Providers/OAuth: let browser-hosted identity provider pages read successful localhost callback responses, preventing xAI Grok OAuth from showing a false connection failure after OpenClaw completes login.
 - Gateway/security: reject malformed HTTP and WebSocket request targets with the existing auth failure response instead of letting invalid URL parsing crash the Gateway. Fixes GHSA-6hc3-f4rg-377m.
 - Browser/CDP: redact credential-bearing Chrome MCP and managed Chrome launch diagnostics, and require exact loopback entries before treating `NO_PROXY` as already covering local CDP proxy bypasses.
+- Gateway/auth: reuse prepared startup auth SecretRef snapshots when the gateway startup config is unchanged, avoiding duplicate runtime secret preparation. (#82991) Thanks @samzong.
 - Gateway/diagnostics: redact credential-bearing gateway target URLs and client diagnostics while preserving raw connection URLs for programmatic use, so connect-failure logs no longer surface embedded tokens.
 - Gateway/auth: honor `OPENCLAW_GATEWAY_TOKEN` as the remote interactive fallback when no remote token is configured, keeping remote TUI setup aligned with documented auth precedence.
 - Providers/xAI: continue polling video generations while xAI reports in-flight jobs as `pending`, so Grok video requests no longer fail before the final `done` response. (#82610) Thanks @Manzojunior.

--- a/src/gateway/server-startup-config.secrets.test.ts
+++ b/src/gateway/server-startup-config.secrets.test.ts
@@ -386,8 +386,9 @@ describe("gateway startup config secret preflight", () => {
   });
 
   it("uses gateway auth strings resolved during startup preflight for bootstrap auth", async () => {
-    const prepareRuntimeSecretsSnapshot = vi.fn(async ({ config }) =>
-      preparedSnapshot({
+    const prepareRuntimeSecretsSnapshot = vi.fn(async ({ config }) => ({
+      ...preparedSnapshot(config),
+      config: {
         ...config,
         gateway: {
           ...config.gateway,
@@ -396,8 +397,9 @@ describe("gateway startup config secret preflight", () => {
             token: "resolved-gateway-token",
           },
         },
-      }),
-    );
+      },
+    }));
+    const activateRuntimeSecretsSnapshot = vi.fn();
 
     const result = await prepareGatewayStartupConfig({
       configSnapshot: buildSnapshot({
@@ -421,12 +423,82 @@ describe("gateway startup config secret preflight", () => {
         },
         emitStateEvent: vi.fn(),
         prepareRuntimeSecretsSnapshot,
-        activateRuntimeSecretsSnapshot: vi.fn(),
+        activateRuntimeSecretsSnapshot,
+      }),
+    });
+
+    expect(result.auth.mode).toBe("token");
+    expect(result.auth.token).toBe("resolved-gateway-token");
+    expect(result.cfg.gateway?.auth?.token).toBe("resolved-gateway-token");
+    expect(prepareRuntimeSecretsSnapshot).toHaveBeenCalledTimes(1);
+    expect(activateRuntimeSecretsSnapshot).toHaveBeenCalledTimes(1);
+    expect(activateRuntimeSecretsSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          gateway: expect.objectContaining({
+            auth: expect.objectContaining({
+              token: "resolved-gateway-token",
+            }),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("falls back to a fresh startup activation when the preflight snapshot source is not reusable", async () => {
+    const prepareRuntimeSecretsSnapshot = vi.fn(async ({ config }) => ({
+      ...preparedSnapshot(
+        prepareRuntimeSecretsSnapshot.mock.calls.length === 1
+          ? {
+              ...config,
+              diagnostics: {
+                enabled: true,
+              },
+            }
+          : config,
+      ),
+      config: {
+        ...config,
+        gateway: {
+          ...config.gateway,
+          auth: {
+            ...config.gateway?.auth,
+            token: "resolved-gateway-token",
+          },
+        },
+      },
+    }));
+    const activateRuntimeSecretsSnapshot = vi.fn();
+
+    const result = await prepareGatewayStartupConfig({
+      configSnapshot: buildSnapshot({
+        secrets: {
+          providers: {
+            default: { source: "env" },
+          },
+        },
+        gateway: {
+          auth: {
+            mode: "token",
+            token: { source: "env", provider: "default", id: "GATEWAY_TOKEN_REF" },
+          },
+        },
+      }),
+      activateRuntimeSecrets: createRuntimeSecretsActivator({
+        logSecrets: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+        },
+        emitStateEvent: vi.fn(),
+        prepareRuntimeSecretsSnapshot,
+        activateRuntimeSecretsSnapshot,
       }),
     });
 
     expect(result.auth.mode).toBe("token");
     expect(result.auth.token).toBe("resolved-gateway-token");
     expect(prepareRuntimeSecretsSnapshot).toHaveBeenCalledTimes(2);
+    expect(activateRuntimeSecretsSnapshot).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/gateway/server-startup-config.ts
+++ b/src/gateway/server-startup-config.ts
@@ -1,3 +1,4 @@
+import { isDeepStrictEqual } from "node:util";
 import { formatInvalidConfigRecoveryHint } from "../cli/config-recovery-hints.js";
 import {
   type ReadConfigFileSnapshotWithPluginMetadataResult,
@@ -31,17 +32,26 @@ type GatewayStartupLog = {
 
 type GatewaySecretsStateEventCode = "SECRETS_RELOADER_DEGRADED" | "SECRETS_RELOADER_RECOVERED";
 
-export type ActivateRuntimeSecrets = (
-  config: OpenClawConfig,
-  params: { reason: "startup" | "reload" | "restart-check"; activate: boolean },
-) => Promise<
-  Awaited<ReturnType<typeof import("../secrets/runtime.js").prepareSecretsRuntimeSnapshot>>
->;
-
 type PrepareRuntimeSecretsSnapshot =
   typeof import("../secrets/runtime.js").prepareSecretsRuntimeSnapshot;
 type ActivateRuntimeSecretsSnapshot =
   typeof import("../secrets/runtime.js").activateSecretsRuntimeSnapshot;
+type PreparedRuntimeSecretsSnapshot = Awaited<ReturnType<PrepareRuntimeSecretsSnapshot>>;
+
+type RuntimeSecretsActivationParams = {
+  reason: "startup" | "reload" | "restart-check";
+  activate: boolean;
+};
+
+export type ActivateRuntimeSecrets = ((
+  config: OpenClawConfig,
+  params: RuntimeSecretsActivationParams,
+) => Promise<PreparedRuntimeSecretsSnapshot>) & {
+  activatePreparedSnapshot?: (
+    snapshot: PreparedRuntimeSecretsSnapshot,
+    params: RuntimeSecretsActivationParams,
+  ) => Promise<PreparedRuntimeSecretsSnapshot>;
+};
 
 type GatewayStartupConfigOverrides = {
   auth?: GatewayAuthConfig;
@@ -152,7 +162,64 @@ export function createRuntimeSecretsActivator(params: {
     return await run;
   };
 
-  return async (config, activationParams) =>
+  const loadActivateRuntimeSecretsSnapshot = async () => {
+    if (params.activateRuntimeSecretsSnapshot) {
+      return params.activateRuntimeSecretsSnapshot;
+    }
+    return (await loadSecretsRuntime()).activateSecretsRuntimeSnapshot;
+  };
+
+  const finishPreparedSnapshot = async (
+    prepared: PreparedRuntimeSecretsSnapshot,
+    activationParams: RuntimeSecretsActivationParams,
+  ) => {
+    assertRuntimeGatewayAuthNotKnownWeak(prepared.config);
+    if (activationParams.activate) {
+      const activateRuntimeSecretsSnapshot = await loadActivateRuntimeSecretsSnapshot();
+      activateRuntimeSecretsSnapshot(prepared);
+      logGatewayAuthSurfaceDiagnostics(prepared, params.logSecrets);
+    }
+    for (const warning of prepared.warnings) {
+      params.logSecrets.warn(`[${warning.code}] ${warning.message}`);
+    }
+    if (secretsDegraded) {
+      const recoveredMessage =
+        "Secret resolution recovered; runtime remained on last-known-good during the outage.";
+      params.logSecrets.info(`[SECRETS_RELOADER_RECOVERED] ${recoveredMessage}`);
+      params.emitStateEvent("SECRETS_RELOADER_RECOVERED", recoveredMessage, prepared.config);
+    }
+    secretsDegraded = false;
+    return prepared;
+  };
+
+  const handleSecretsActivationError = (
+    err: unknown,
+    activationParams: RuntimeSecretsActivationParams,
+    eventConfig: OpenClawConfig,
+  ): never => {
+    const details = String(err);
+    if (!secretsDegraded) {
+      params.logSecrets.error?.(`[SECRETS_RELOADER_DEGRADED] ${details}`);
+      if (activationParams.reason !== "startup") {
+        params.emitStateEvent(
+          "SECRETS_RELOADER_DEGRADED",
+          `Secret resolution failed; runtime remains on last-known-good snapshot. ${details}`,
+          eventConfig,
+        );
+      }
+    } else {
+      params.logSecrets.warn(`[SECRETS_RELOADER_DEGRADED] ${details}`);
+    }
+    secretsDegraded = true;
+    if (activationParams.reason === "startup") {
+      throw new Error(`Startup failed: required secrets are unavailable. ${details}`, {
+        cause: err,
+      });
+    }
+    throw err;
+  };
+
+  const activateRuntimeSecrets = (async (config, activationParams) =>
     await runWithSecretsActivationLock(async () => {
       try {
         const secretsRuntime =
@@ -161,8 +228,6 @@ export function createRuntimeSecretsActivator(params: {
             : await loadSecretsRuntime();
         const prepareRuntimeSecretsSnapshot =
           params.prepareRuntimeSecretsSnapshot ?? secretsRuntime!.prepareSecretsRuntimeSnapshot;
-        const activateRuntimeSecretsSnapshot =
-          params.activateRuntimeSecretsSnapshot ?? secretsRuntime!.activateSecretsRuntimeSnapshot;
         const startupPreflight =
           activationParams.reason === "startup" || activationParams.reason === "restart-check";
         const loadAuthStore = startupPreflight
@@ -172,45 +237,22 @@ export function createRuntimeSecretsActivator(params: {
           config: pruneSkippedStartupSecretSurfaces(config),
           ...(loadAuthStore ? { loadAuthStore } : {}),
         });
-        assertRuntimeGatewayAuthNotKnownWeak(prepared.config);
-        if (activationParams.activate) {
-          activateRuntimeSecretsSnapshot(prepared);
-          logGatewayAuthSurfaceDiagnostics(prepared, params.logSecrets);
-        }
-        for (const warning of prepared.warnings) {
-          params.logSecrets.warn(`[${warning.code}] ${warning.message}`);
-        }
-        if (secretsDegraded) {
-          const recoveredMessage =
-            "Secret resolution recovered; runtime remained on last-known-good during the outage.";
-          params.logSecrets.info(`[SECRETS_RELOADER_RECOVERED] ${recoveredMessage}`);
-          params.emitStateEvent("SECRETS_RELOADER_RECOVERED", recoveredMessage, prepared.config);
-        }
-        secretsDegraded = false;
-        return prepared;
+        return await finishPreparedSnapshot(prepared, activationParams);
       } catch (err) {
-        const details = String(err);
-        if (!secretsDegraded) {
-          params.logSecrets.error?.(`[SECRETS_RELOADER_DEGRADED] ${details}`);
-          if (activationParams.reason !== "startup") {
-            params.emitStateEvent(
-              "SECRETS_RELOADER_DEGRADED",
-              `Secret resolution failed; runtime remains on last-known-good snapshot. ${details}`,
-              config,
-            );
-          }
-        } else {
-          params.logSecrets.warn(`[SECRETS_RELOADER_DEGRADED] ${details}`);
-        }
-        secretsDegraded = true;
-        if (activationParams.reason === "startup") {
-          throw new Error(`Startup failed: required secrets are unavailable. ${details}`, {
-            cause: err,
-          });
-        }
-        throw err;
+        return handleSecretsActivationError(err, activationParams, config);
+      }
+    })) as ActivateRuntimeSecrets;
+
+  activateRuntimeSecrets.activatePreparedSnapshot = async (snapshot, activationParams) =>
+    await runWithSecretsActivationLock(async () => {
+      try {
+        return await finishPreparedSnapshot(snapshot, activationParams);
+      } catch (err) {
+        return handleSecretsActivationError(err, activationParams, snapshot.sourceConfig);
       }
     });
+
+  return activateRuntimeSecrets;
 }
 
 export function assertValidGatewayStartupConfigSnapshot(
@@ -253,17 +295,38 @@ export async function prepareGatewayStartupConfig(params: {
   const needsAuthSecretPreflight = await measure("config.auth.secret-surface", () =>
     hasActiveGatewayAuthSecretRef(startupPreflightConfig),
   );
+  let preflightPrepared: PreparedRuntimeSecretsSnapshot | undefined;
   const preflightConfig = await measure("config.auth.secret-preflight", async () => {
     if (!needsAuthSecretPreflight) {
       return startupPreflightConfig;
     }
-    return (
-      await params.activateRuntimeSecrets(startupPreflightConfig, {
-        reason: "startup",
-        activate: false,
-      })
-    ).config;
+    preflightPrepared = await params.activateRuntimeSecrets(startupPreflightConfig, {
+      reason: "startup",
+      activate: false,
+    });
+    return preflightPrepared.config;
   });
+  const canReusePreflightPreparedSnapshot = (config: OpenClawConfig): boolean =>
+    Boolean(
+      preflightPrepared &&
+        params.activateRuntimeSecrets.activatePreparedSnapshot &&
+        isDeepStrictEqual(
+          pruneSkippedStartupSecretSurfaces(config),
+          preflightPrepared.sourceConfig,
+        ),
+    );
+  const activateStartupSecrets = async (config: OpenClawConfig) => {
+    if (preflightPrepared && canReusePreflightPreparedSnapshot(config)) {
+      return await params.activateRuntimeSecrets.activatePreparedSnapshot!(preflightPrepared, {
+        reason: "startup",
+        activate: true,
+      });
+    }
+    return await params.activateRuntimeSecrets(config, {
+      reason: "startup",
+      activate: true,
+    });
+  };
   const preflightAuthOverride = await measure("config.auth.preflight-override", () =>
     typeof preflightConfig.gateway?.auth?.token === "string" ||
     typeof preflightConfig.gateway?.auth?.password === "string"
@@ -296,12 +359,7 @@ export async function prepareGatewayStartupConfig(params: {
     }),
   );
   const activatedConfig = (
-    await measure("config.auth.secrets-activate", () =>
-      params.activateRuntimeSecrets(runtimeStartupConfig, {
-        reason: "startup",
-        activate: true,
-      }),
-    )
+    await measure("config.auth.secrets-activate", () => activateStartupSecrets(runtimeStartupConfig))
   ).config;
   return {
     ...authBootstrap,


### PR DESCRIPTION
## Summary

- Problem: gateway startup secret preflight could resolve gateway auth strings, then run a fresh secrets activation for the same source config.
- Why it matters: startup auth should reuse prepared runtime secret work when the final startup config still matches the preflight source, while keeping the existing safe fallback when it does not.
- What changed: `prepareGatewayStartupConfig` now reuses a prepared startup secrets snapshot when the pruned startup config equals the snapshot source, and `createRuntimeSecretsActivator` exposes a prepared-snapshot activation path that shares the existing warning, weak-token, recovery, and error handling.
- What did NOT change (scope boundary): non-gateway secret reload behavior, config schema, public gateway auth settings, and fallback fresh activation remain unchanged.
- AI-assisted: Yes, Codex helped implement and review this change.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- N/A - no linked issue.
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: Gateway startup auth secret preflight can reuse the prepared runtime secrets snapshot when the final pruned startup config still matches the prepared snapshot source, and falls back to fresh activation when it does not.
- Real environment tested: Local OpenClaw checkout on macOS in a Codex worktree, using Node 24.14.0 and the repo's `tsx` loader.
- Exact steps or command run after this patch: Ran `node --import tsx --input-type=module` with an inline runtime probe that imports `./src/gateway/server-startup-config.ts`, calls `prepareGatewayStartupConfig`, exercises the reusable and non-reusable preflight paths, and prints the activation counts.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```json
{
  "reusable": {
    "authToken": "resolved-runtime-token",
    "configToken": "resolved-runtime-token",
    "prepareCalls": 1,
    "activateCalls": 1
  },
  "fallback": {
    "authToken": "resolved-runtime-token",
    "configToken": "resolved-runtime-token",
    "prepareCalls": 2,
    "activateCalls": 1
  }
}
```

- Observed result after fix: The reusable path resolves gateway auth and activates with one prepare call; the mismatched source path resolves gateway auth and falls back to a second prepare call before activation.
- What was not tested: Full managed gateway process startup, external secret provider I/O, and broad CI/Testbox lanes.
- Before evidence (optional but encouraged): N/A - this PR locks the regression with focused before/after behavior coverage instead of preserving a failing runtime log.

## Root Cause (if applicable)

- Root cause: Startup auth secret preflight returned a prepared secrets snapshot only as a resolved config, so later startup secret activation had no way to activate the already prepared snapshot when the activation source was unchanged.
- Missing detection / guardrail: Existing coverage verified resolved gateway auth strings but did not assert that startup avoided a duplicate prepare call on the reusable path.
- Contributing context (if known): Startup auth can apply overrides and generated auth after preflight, so reuse needs an equality guard and must retain the fresh activation fallback.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server-startup-config.secrets.test.ts`
- Scenario the test should lock in: preflight-resolved gateway auth is reused for bootstrap activation when the source config still matches, and falls back to fresh activation when the prepared source is not reusable.
- Why this is the smallest reliable guardrail: the bug lives in `prepareGatewayStartupConfig` and `createRuntimeSecretsActivator`; the focused test covers their boundary without starting unrelated gateway sidecars.
- Existing test that already covers this (if any): N/A - this PR extends the existing startup secret preflight suite.
- If no new test is added, why not: N/A - new focused assertions were added.

## User-visible / Behavior Changes

Gateway startup avoids redundant runtime secret preparation for reusable gateway auth preflight snapshots. No config, API, or auth behavior changes are intended.

## Diagram (if applicable)

```text
Before:
[startup config with gateway auth SecretRef] -> [preflight resolves auth] -> [fresh secrets activation repeats prepare]

After:
[startup config with gateway auth SecretRef] -> [preflight resolves auth] -> [activate prepared snapshot when source matches] -> [fresh activation only when source differs]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: Gateway auth secret resolution now reuses a prepared snapshot only after comparing the pruned activation config with the prepared snapshot source. The fallback path still performs a fresh activation when the source differs, and the shared activation helper preserves weak-token rejection and warning/recovery handling.

## Repro + Verification

### Environment

- OS: macOS local checkout
- Runtime/container: Node 24.14.0, repo `node` wrappers, Codex worktree
- Model/provider: N/A
- Integration/channel (if any): Gateway startup auth secret preflight
- Relevant config (redacted): `gateway.auth.token` as an env-backed SecretRef; proof output uses synthetic `resolved-runtime-token`

### Steps

1. Run the inline `node --import tsx --input-type=module` runtime probe described in Real behavior proof.
2. Run `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/review-core.tsbuildinfo`.
3. Run `node scripts/run-vitest.mjs src/gateway/server-startup-config.secrets.test.ts`.
4. Run `gtimeout --kill-after=30s 10m command codex review --commit HEAD`.

### Expected

- The reusable startup preflight path prepares once and activates once.
- The non-reusable startup preflight path falls back to a second prepare call and activates once.
- Typecheck, focused tests, and committed-diff review pass.

### Actual

- Runtime probe printed `prepareCalls: 1` for the reusable path and `prepareCalls: 2` for the fallback path.
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/review-core.tsbuildinfo` passed.
- `node scripts/run-vitest.mjs src/gateway/server-startup-config.secrets.test.ts` passed with 11 tests.
- `gtimeout --kill-after=30s 10m command codex review --commit HEAD` exited 0 with no discrete regression found.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reusable prepared snapshot activation, fallback fresh activation when the prepared source differs, TypeScript core check, focused gateway startup secret tests, and committed-diff review.
- Edge cases checked: mismatched prepared snapshot source does not reuse the snapshot and still resolves the gateway token through fresh activation.
- What you did **not** verify: full gateway process startup, external secret provider I/O, and broad CI/Testbox lanes.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR. N/A - no PR review conversations existed before opening this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment. N/A - no unresolved review conversations exist.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A - no migration needed.

## Risks and Mitigations

- Risk: Reusing a prepared snapshot after startup auth changes could activate stale secret state.
  - Mitigation: reuse is gated by deep equality between the pruned activation config and the prepared snapshot source; mismatches fall back to fresh activation.
