### PR TITLE
fix(codex): preserve agent scope for bound app-server sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 - Agents/media: deliver failed async image, music, and video generation completions directly when requester-session completion handoff fails, so channel users see provider errors instead of silent fallback stalls.
 - Codex app-server: record native Codex tool calls and results into trajectory artifacts so debug/trajectory exports capture the full Codex-native tool history, not just OpenClaw-bridged turns. Thanks @vyctorbrzezowski.
+- Codex/app-server: keep bound conversation sessions on the owning agent runtime so native Codex control and follow-up turns do not fall back to the default agent client. Fixes #82954. (#82993)
 - CLI/sessions: accept `openclaw sessions list` as an alias for `openclaw sessions`, matching other list-style commands. Fixes #81139. (#81163) Thanks @YB0y.
 - Channels/stream previews: widen compact progress draft lines and cut prose at word boundaries while preserving command/path suffixes, with `streaming.progress.maxLineChars` for channel-specific tuning.
 - CLI/plugins: have `openclaw plugins doctor` warn when a configured runtime needs a missing owner plugin, sharing the same install mapping as `openclaw doctor --fix`. Fixes #81326. (#81674) Thanks @Zavianx.

--- a/extensions/codex/src/command-handlers.ts
+++ b/extensions/codex/src/command-handlers.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import { resolveAgentDir, resolveSessionAgentIds } from "openclaw/plugin-sdk/agent-runtime";
 import type { PluginCommandContext, PluginCommandResult } from "openclaw/plugin-sdk/plugin-entry";
 import { CODEX_CONTROL_METHODS, type CodexControlMethod } from "./app-server/capabilities.js";
 import {
@@ -425,14 +426,19 @@ async function bindConversation(
       text: "Cannot bind Codex because this command did not include an OpenClaw session file.",
     };
   }
+  const scope = resolveCodexConversationControlScope(ctx);
   const workspaceDir = parsed.cwd ?? deps.resolveCodexDefaultWorkspaceDir(pluginConfig);
-  const existingBinding = await deps.readCodexAppServerBinding(ctx.sessionFile);
+  const existingBinding = await deps.readCodexAppServerBinding(ctx.sessionFile, {
+    agentDir: scope.agentDir,
+    config: ctx.config,
+  });
   const authProfileId = existingBinding?.authProfileId;
   const startParams: Parameters<CodexCommandDeps["startCodexConversationThread"]>[0] = {
     pluginConfig,
     config: ctx.config,
     sessionFile: ctx.sessionFile,
     workspaceDir,
+    agentDir: scope.agentDir,
     threadId: parsed.threadId,
     model: parsed.model,
     modelProvider: parsed.provider,
@@ -441,7 +447,10 @@ async function bindConversation(
     startParams.authProfileId = authProfileId;
   }
   const data = await deps.startCodexConversationThread(startParams);
-  const binding = await deps.readCodexAppServerBinding(ctx.sessionFile);
+  const binding = await deps.readCodexAppServerBinding(ctx.sessionFile, {
+    agentDir: scope.agentDir,
+    config: ctx.config,
+  });
   const threadId = binding?.threadId ?? parsed.threadId ?? "new thread";
   const summary = `Codex app-server thread ${formatCodexDisplayText(threadId)} in ${formatCodexDisplayText(workspaceDir)}`;
   let request: Awaited<ReturnType<PluginCommandContext["requestConversationBinding"]>>;
@@ -505,7 +514,10 @@ async function describeConversationBinding(
       "- Active run: not tracked",
     ].join("\n");
   }
-  const threadBinding = await deps.readCodexAppServerBinding(data.sessionFile);
+  const threadBinding = await deps.readCodexAppServerBinding(data.sessionFile, {
+    agentDir: data.agentDir,
+    config: ctx.config,
+  });
   const active = deps.readCodexConversationActiveTurn(data.sessionFile);
   return [
     "Codex conversation binding:",
@@ -634,11 +646,18 @@ async function stopConversationTurn(
   ctx: PluginCommandContext,
   pluginConfig: unknown,
 ): Promise<string> {
-  const sessionFile = await resolveControlSessionFile(ctx);
-  if (!sessionFile) {
+  const target = await resolveControlTarget(ctx);
+  if (!target) {
     return "Cannot stop Codex because this command did not include an OpenClaw session file.";
   }
-  return (await deps.stopCodexConversationTurn({ sessionFile, pluginConfig })).message;
+  return (
+    await deps.stopCodexConversationTurn({
+      sessionFile: target.sessionFile,
+      pluginConfig,
+      agentDir: target.agentDir,
+      config: ctx.config,
+    })
+  ).message;
 }
 
 async function steerConversationTurn(
@@ -647,15 +666,17 @@ async function steerConversationTurn(
   pluginConfig: unknown,
   message: string,
 ): Promise<string> {
-  const sessionFile = await resolveControlSessionFile(ctx);
-  if (!sessionFile) {
+  const target = await resolveControlTarget(ctx);
+  if (!target) {
     return "Cannot steer Codex because this command did not include an OpenClaw session file.";
   }
   return (
     await deps.steerCodexConversationTurn({
-      sessionFile,
+      sessionFile: target.sessionFile,
       pluginConfig,
       message,
+      agentDir: target.agentDir,
+      config: ctx.config,
     })
   ).message;
 }
@@ -669,22 +690,27 @@ async function setConversationModel(
   if (args.length > 1) {
     return "Usage: /codex model <model>";
   }
-  const sessionFile = await resolveControlSessionFile(ctx);
-  if (!sessionFile) {
+  const target = await resolveControlTarget(ctx);
+  if (!target) {
     return "Cannot set Codex model because this command did not include an OpenClaw session file.";
   }
   const [model = ""] = args;
   const normalized = model.trim();
   if (!normalized) {
-    const binding = await deps.readCodexAppServerBinding(sessionFile);
+    const binding = await deps.readCodexAppServerBinding(target.sessionFile, {
+      agentDir: target.agentDir,
+      config: ctx.config,
+    });
     return binding?.model
       ? `Codex model: ${formatCodexDisplayText(binding.model)}`
       : "Usage: /codex model <model>";
   }
   return await deps.setCodexConversationModel({
-    sessionFile,
+    sessionFile: target.sessionFile,
     pluginConfig,
     model: normalized,
+    agentDir: target.agentDir,
+    config: ctx.config,
   });
 }
 
@@ -697,8 +723,8 @@ async function setConversationFastMode(
   if (args.length > 1) {
     return "Usage: /codex fast [on|off|status]";
   }
-  const sessionFile = await resolveControlSessionFile(ctx);
-  if (!sessionFile) {
+  const target = await resolveControlTarget(ctx);
+  if (!target) {
     return "Cannot set Codex fast mode because this command did not include an OpenClaw session file.";
   }
   const value = args[0];
@@ -707,9 +733,11 @@ async function setConversationFastMode(
     return "Usage: /codex fast [on|off|status]";
   }
   return await deps.setCodexConversationFastMode({
-    sessionFile,
+    sessionFile: target.sessionFile,
     pluginConfig,
     enabled: parsed,
+    agentDir: target.agentDir,
+    config: ctx.config,
   });
 }
 
@@ -722,8 +750,8 @@ async function setConversationPermissions(
   if (args.length > 1) {
     return "Usage: /codex permissions [default|yolo|status]";
   }
-  const sessionFile = await resolveControlSessionFile(ctx);
-  if (!sessionFile) {
+  const target = await resolveControlTarget(ctx);
+  if (!target) {
     return "Cannot set Codex permissions because this command did not include an OpenClaw session file.";
   }
   const value = args[0];
@@ -732,16 +760,46 @@ async function setConversationPermissions(
     return "Usage: /codex permissions [default|yolo|status]";
   }
   return await deps.setCodexConversationPermissions({
-    sessionFile,
+    sessionFile: target.sessionFile,
     pluginConfig,
     mode: parsed,
+    agentDir: target.agentDir,
+    config: ctx.config,
   });
 }
 
-async function resolveControlSessionFile(ctx: PluginCommandContext): Promise<string | undefined> {
+type CodexConversationControlTarget = {
+  sessionFile: string;
+  agentDir: string;
+};
+
+async function resolveControlTarget(
+  ctx: PluginCommandContext,
+): Promise<CodexConversationControlTarget | undefined> {
   const binding = await ctx.getCurrentConversationBinding();
   const data = readCodexConversationBindingData(binding);
-  return data?.kind === "codex-app-server-session" ? data.sessionFile : ctx.sessionFile;
+  const scope = resolveCodexConversationControlScope(ctx);
+  if (data?.kind === "codex-app-server-session") {
+    return {
+      sessionFile: data.sessionFile,
+      agentDir: data.agentDir ?? scope.agentDir,
+    };
+  }
+  return ctx.sessionFile ? { sessionFile: ctx.sessionFile, agentDir: scope.agentDir } : undefined;
+}
+
+async function resolveControlSessionFile(ctx: PluginCommandContext): Promise<string | undefined> {
+  return (await resolveControlTarget(ctx))?.sessionFile;
+}
+
+function resolveCodexConversationControlScope(ctx: PluginCommandContext): { agentDir: string } {
+  const { sessionAgentId } = resolveSessionAgentIds({
+    sessionKey: ctx.sessionKey,
+    config: ctx.config,
+  });
+  return {
+    agentDir: resolveAgentDir(ctx.config, sessionAgentId),
+  };
 }
 
 async function handleCodexDiagnosticsFeedback(
@@ -1603,21 +1661,42 @@ async function startThreadAction(
   if (args.length > 0) {
     return `Usage: /codex ${label === "compaction" ? "compact" : label}`;
   }
-  const sessionFile = await resolveControlSessionFile(ctx);
-  if (!sessionFile) {
+  const target = await resolveControlTarget(ctx);
+  if (!target) {
     return `Cannot start Codex ${label} because this command did not include an OpenClaw session file.`;
   }
-  const binding = await deps.readCodexAppServerBinding(sessionFile);
+  const binding = await deps.readCodexAppServerBinding(target.sessionFile, {
+    agentDir: target.agentDir,
+    config: ctx.config,
+  });
   if (!binding?.threadId) {
     return `No Codex thread is attached to this OpenClaw session yet.`;
   }
   if (method === CODEX_CONTROL_METHODS.review) {
-    await deps.codexControlRequest(pluginConfig, method, {
-      threadId: binding.threadId,
-      target: { type: "uncommittedChanges" },
-    });
+    await deps.codexControlRequest(
+      pluginConfig,
+      method,
+      {
+        threadId: binding.threadId,
+        target: { type: "uncommittedChanges" },
+      },
+      {
+        agentDir: target.agentDir,
+        authProfileId: binding.authProfileId,
+        config: ctx.config,
+      },
+    );
   } else {
-    await deps.codexControlRequest(pluginConfig, method, { threadId: binding.threadId });
+    await deps.codexControlRequest(
+      pluginConfig,
+      method,
+      { threadId: binding.threadId },
+      {
+        agentDir: target.agentDir,
+        authProfileId: binding.authProfileId,
+        config: ctx.config,
+      },
+    );
   }
   return `Started Codex ${label} for thread ${formatCodexDisplayText(binding.threadId)}.`;
 }

--- a/extensions/codex/src/command-rpc.ts
+++ b/extensions/codex/src/command-rpc.ts
@@ -23,6 +23,7 @@ type AuthProfileOrderConfig = Parameters<
 export type CodexControlRequestOptions = {
   config?: AuthProfileOrderConfig;
   authProfileId?: string;
+  agentDir?: string;
   isolated?: boolean;
 };
 
@@ -68,6 +69,7 @@ export async function codexControlRequest(
     startOptions: runtime.start,
     config: options.config,
     authProfileId: options.authProfileId,
+    agentDir: options.agentDir,
     isolated: options.isolated,
   });
 }

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -1314,9 +1314,18 @@ describe("codex command", () => {
     ).resolves.toEqual({
       text: "Started Codex compaction for thread thread-123.",
     });
-    expect(codexControlRequest).toHaveBeenCalledWith(undefined, CODEX_CONTROL_METHODS.compact, {
-      threadId: "thread-123",
-    });
+    expect(codexControlRequest).toHaveBeenCalledWith(
+      undefined,
+      CODEX_CONTROL_METHODS.compact,
+      {
+        threadId: "thread-123",
+      },
+      {
+        agentDir: path.join(tempDir, "agents", "main", "agent"),
+        authProfileId: undefined,
+        config: {},
+      },
+    );
   });
 
   it("starts review with the generated app-server target shape", async () => {
@@ -1334,10 +1343,19 @@ describe("codex command", () => {
     ).resolves.toEqual({
       text: "Started Codex review for thread thread-123.",
     });
-    expect(codexControlRequest).toHaveBeenCalledWith(undefined, CODEX_CONTROL_METHODS.review, {
-      threadId: "thread-123",
-      target: { type: "uncommittedChanges" },
-    });
+    expect(codexControlRequest).toHaveBeenCalledWith(
+      undefined,
+      CODEX_CONTROL_METHODS.review,
+      {
+        threadId: "thread-123",
+        target: { type: "uncommittedChanges" },
+      },
+      {
+        agentDir: path.join(tempDir, "agents", "main", "agent"),
+        authProfileId: undefined,
+        config: {},
+      },
+    );
   });
 
   it("rejects malformed compact and review commands before starting thread actions", async () => {
@@ -2666,6 +2684,7 @@ describe("codex command", () => {
       config: {},
       sessionFile,
       workspaceDir: "/repo",
+      agentDir: path.join(tempDir, "agents", "main", "agent"),
       threadId: "thread-123",
       model: "gpt-5.4",
       modelProvider: "openai",
@@ -2724,6 +2743,7 @@ describe("codex command", () => {
       config: {},
       sessionFile,
       workspaceDir: "/repo with space",
+      agentDir: path.join(tempDir, "agents", "main", "agent"),
       threadId: "thread-123",
       model: undefined,
       modelProvider: undefined,
@@ -2971,6 +2991,8 @@ describe("codex command", () => {
     expect(stopCodexConversationTurn).toHaveBeenCalledWith({
       sessionFile,
       pluginConfig: undefined,
+      agentDir: path.join(tempDir, "agents", "main", "agent"),
+      config: {},
     });
   });
 
@@ -3002,6 +3024,8 @@ describe("codex command", () => {
       sessionFile,
       pluginConfig: undefined,
       message: "focus tests first",
+      agentDir: path.join(tempDir, "agents", "main", "agent"),
+      config: {},
     });
   });
 
@@ -3032,16 +3056,22 @@ describe("codex command", () => {
       sessionFile,
       pluginConfig: undefined,
       model: "gpt-5.4",
+      agentDir: path.join(tempDir, "agents", "main", "agent"),
+      config: {},
     });
     expect(setCodexConversationFastMode).toHaveBeenCalledWith({
       sessionFile,
       pluginConfig: undefined,
       enabled: true,
+      agentDir: path.join(tempDir, "agents", "main", "agent"),
+      config: {},
     });
     expect(setCodexConversationPermissions).toHaveBeenCalledWith({
       sessionFile,
       pluginConfig: undefined,
       mode: "yolo",
+      agentDir: path.join(tempDir, "agents", "main", "agent"),
+      config: {},
     });
   });
 
@@ -3161,6 +3191,8 @@ describe("codex command", () => {
       sessionFile: hostSessionFile,
       pluginConfig: undefined,
       enabled: true,
+      agentDir: path.join(tempDir, "agents", "main", "agent"),
+      config: {},
     });
   });
 

--- a/extensions/codex/src/conversation-binding-data.ts
+++ b/extensions/codex/src/conversation-binding-data.ts
@@ -8,6 +8,7 @@ export type CodexAppServerConversationBindingData = {
   version: 1;
   sessionFile: string;
   workspaceDir: string;
+  agentDir?: string;
 };
 
 export type CodexCliNodeConversationBindingData = {
@@ -25,12 +26,15 @@ export type CodexConversationBindingData =
 export function createCodexConversationBindingData(params: {
   sessionFile: string;
   workspaceDir: string;
+  agentDir?: string;
 }): CodexAppServerConversationBindingData {
+  const agentDir = params.agentDir?.trim();
   return {
     kind: "codex-app-server-session",
     version: BINDING_DATA_VERSION,
     sessionFile: params.sessionFile,
     workspaceDir: params.workspaceDir,
+    ...(agentDir ? { agentDir } : {}),
   };
 }
 
@@ -98,6 +102,7 @@ export function readCodexConversationBindingDataRecord(
       typeof data.workspaceDir === "string" && data.workspaceDir.trim()
         ? data.workspaceDir
         : process.cwd(),
+    agentDir: typeof data.agentDir === "string" && data.agentDir.trim() ? data.agentDir : undefined,
   };
 }
 

--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -178,6 +178,30 @@ describe("codex conversation binding", () => {
     ).resolves.not.toContain('"modelProvider": "openai"');
   });
 
+  it("stores and uses the owning agent dir for bound app-server sessions", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const agentDir = path.join(tempDir, "agents", "bot-a", "agent");
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
+      request: vi.fn(async () => ({
+        thread: { id: "thread-new", sessionId: "session-1", cwd: tempDir },
+        model: "gpt-5.4-mini",
+      })),
+    });
+
+    const data = await startCodexConversationThread({
+      sessionFile,
+      workspaceDir: tempDir,
+      agentDir,
+      model: "gpt-5.4-mini",
+    });
+
+    const sharedClientParams = mockCallArg(sharedClientMocks.getSharedCodexAppServerClient) as {
+      agentDir?: unknown;
+    };
+    expect(sharedClientParams?.agentDir).toBe(agentDir);
+    expect(data.agentDir).toBe(agentDir);
+  });
+
   it("clears the Codex app-server sidecar when a pending bind is denied", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const sidecar = `${sessionFile}.codex-app-server.json`;
@@ -416,6 +440,7 @@ describe("codex conversation binding", () => {
 
   it("returns a clean failure reply when app-server turn start rejects", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
+    const agentDir = path.join(tempDir, "agents", "bot-b", "agent");
     await fs.writeFile(
       `${sessionFile}.codex-app-server.json`,
       JSON.stringify({
@@ -467,6 +492,7 @@ describe("codex conversation binding", () => {
               version: 1,
               sessionFile,
               workspaceDir: tempDir,
+              agentDir,
             },
           },
         },
@@ -492,6 +518,7 @@ describe("codex conversation binding", () => {
 
   it("falls back to content when the channel body for agent is blank", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
+    const agentDir = path.join(tempDir, "agents", "bot-b", "agent");
     await fs.writeFile(
       `${sessionFile}.codex-app-server.json`,
       JSON.stringify({
@@ -553,6 +580,7 @@ describe("codex conversation binding", () => {
             version: 1,
             sessionFile,
             workspaceDir: tempDir,
+            agentDir,
           },
         },
       },
@@ -560,6 +588,10 @@ describe("codex conversation binding", () => {
     );
 
     expect(result).toEqual({ handled: true, reply: { text: "done" } });
+    const sharedClientParams = mockCallArg(sharedClientMocks.getSharedCodexAppServerClient) as {
+      agentDir?: unknown;
+    };
+    expect(sharedClientParams?.agentDir).toBe(agentDir);
     expect(turnStartParams[0]?.input).toEqual([
       { type: "text", text: "use the fallback prompt", text_elements: [] },
     ]);

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -65,6 +65,7 @@ type CodexConversationStartParams = {
   config?: Parameters<typeof resolveCodexAppServerAuthProfileIdForAgent>[0]["config"];
   sessionFile: string;
   workspaceDir?: string;
+  agentDir?: string;
   threadId?: string;
   model?: string;
   modelProvider?: string;
@@ -97,12 +98,14 @@ export async function startCodexConversationThread(
 ): Promise<CodexAppServerConversationBindingData> {
   const workspaceDir =
     params.workspaceDir?.trim() || resolveCodexDefaultWorkspaceDir(params.pluginConfig);
+  const agentDir = params.agentDir?.trim();
+  const agentLookup = buildAgentLookup({ agentDir, config: params.config });
   const existingBinding = await readCodexAppServerBinding(params.sessionFile, {
-    config: params.config,
+    ...agentLookup,
   });
   const authProfileId = resolveCodexAppServerAuthProfileIdForAgent({
     authProfileId: params.authProfileId ?? existingBinding?.authProfileId,
-    config: params.config,
+    ...agentLookup,
   });
   if (params.threadId?.trim()) {
     await attachExistingThread({
@@ -110,6 +113,7 @@ export async function startCodexConversationThread(
       sessionFile: params.sessionFile,
       threadId: params.threadId.trim(),
       workspaceDir,
+      ...(agentDir ? { agentDir } : {}),
       model: params.model,
       modelProvider: params.modelProvider,
       authProfileId,
@@ -123,6 +127,7 @@ export async function startCodexConversationThread(
       pluginConfig: params.pluginConfig,
       sessionFile: params.sessionFile,
       workspaceDir,
+      ...(agentDir ? { agentDir } : {}),
       model: params.model,
       modelProvider: params.modelProvider,
       authProfileId,
@@ -135,6 +140,7 @@ export async function startCodexConversationThread(
   return createCodexConversationBindingData({
     sessionFile: params.sessionFile,
     workspaceDir,
+    ...(agentDir ? { agentDir } : {}),
   });
 }
 
@@ -224,6 +230,7 @@ async function attachExistingThread(params: {
   sessionFile: string;
   threadId: string;
   workspaceDir: string;
+  agentDir?: string;
   model?: string;
   modelProvider?: string;
   authProfileId?: string;
@@ -235,15 +242,17 @@ async function attachExistingThread(params: {
   const runtime = resolveCodexAppServerRuntimeOptions({
     pluginConfig: params.pluginConfig,
   });
+  const agentLookup = buildAgentLookup({ agentDir: params.agentDir, config: params.config });
   const modelProvider = resolveThreadRequestModelProvider({
     authProfileId: params.authProfileId,
     modelProvider: params.modelProvider,
-    config: params.config,
+    ...agentLookup,
   });
   const client = await getSharedCodexAppServerClient({
     startOptions: runtime.start,
     timeoutMs: runtime.requestTimeoutMs,
     authProfileId: params.authProfileId,
+    ...agentLookup,
   });
   const response: CodexThreadResumeResponse = await client.request(
     CODEX_CONTROL_METHODS.resumeThread,
@@ -272,16 +281,16 @@ async function attachExistingThread(params: {
       authProfileId: params.authProfileId,
       model: response.model ?? params.model,
       modelProvider: normalizeCodexAppServerBindingModelProvider({
-        config: params.config,
         authProfileId: params.authProfileId,
         modelProvider: response.modelProvider ?? params.modelProvider,
+        ...agentLookup,
       }),
       approvalPolicy: params.approvalPolicy ?? runtimeApprovalPolicy,
       sandbox: params.sandbox ?? runtime.sandbox,
       serviceTier: params.serviceTier ?? runtime.serviceTier,
     },
     {
-      config: params.config,
+      ...agentLookup,
     },
   );
 }
@@ -290,6 +299,7 @@ async function createThread(params: {
   pluginConfig?: unknown;
   sessionFile: string;
   workspaceDir: string;
+  agentDir?: string;
   model?: string;
   modelProvider?: string;
   authProfileId?: string;
@@ -301,15 +311,17 @@ async function createThread(params: {
   const runtime = resolveCodexAppServerRuntimeOptions({
     pluginConfig: params.pluginConfig,
   });
+  const agentLookup = buildAgentLookup({ agentDir: params.agentDir, config: params.config });
   const modelProvider = resolveThreadRequestModelProvider({
     authProfileId: params.authProfileId,
     modelProvider: params.modelProvider,
-    config: params.config,
+    ...agentLookup,
   });
   const client = await getSharedCodexAppServerClient({
     startOptions: runtime.start,
     timeoutMs: runtime.requestTimeoutMs,
     authProfileId: params.authProfileId,
+    ...agentLookup,
   });
   const response: CodexThreadStartResponse = await client.request(
     "thread/start",
@@ -340,16 +352,16 @@ async function createThread(params: {
       authProfileId: params.authProfileId,
       model: response.model ?? params.model,
       modelProvider: normalizeCodexAppServerBindingModelProvider({
-        config: params.config,
         authProfileId: params.authProfileId,
         modelProvider: response.modelProvider ?? params.modelProvider,
+        ...agentLookup,
       }),
       approvalPolicy: params.approvalPolicy ?? runtimeApprovalPolicy,
       sandbox: params.sandbox ?? runtime.sandbox,
       serviceTier: params.serviceTier ?? runtime.serviceTier,
     },
     {
-      config: params.config,
+      ...agentLookup,
     },
   );
 }
@@ -364,7 +376,8 @@ async function runBoundTurn(params: {
   const runtime = resolveCodexAppServerRuntimeOptions({
     pluginConfig: params.pluginConfig,
   });
-  const binding = await readCodexAppServerBinding(params.data.sessionFile);
+  const agentLookup = buildAgentLookup({ agentDir: params.data.agentDir });
+  const binding = await readCodexAppServerBinding(params.data.sessionFile, agentLookup);
   const threadId = binding?.threadId;
   if (!threadId) {
     throw new Error("bound Codex conversation has no thread binding");
@@ -374,6 +387,7 @@ async function runBoundTurn(params: {
     startOptions: runtime.start,
     timeoutMs: runtime.requestTimeoutMs,
     authProfileId: binding.authProfileId,
+    ...agentLookup,
   });
   const collector = createCodexConversationTurnCollector(threadId);
   const notificationCleanup = client.addNotificationHandler((notification) =>
@@ -475,11 +489,13 @@ async function runBoundTurnWithMissingThreadRecovery(params: {
     if (!isCodexThreadNotFoundError(error)) {
       throw error;
     }
-    const binding = await readCodexAppServerBinding(params.data.sessionFile);
+    const agentLookup = buildAgentLookup({ agentDir: params.data.agentDir });
+    const binding = await readCodexAppServerBinding(params.data.sessionFile, agentLookup);
     await startCodexConversationThread({
       pluginConfig: params.pluginConfig,
       sessionFile: params.data.sessionFile,
       workspaceDir: binding?.cwd || params.data.workspaceDir,
+      ...agentLookup,
       model: binding?.model,
       modelProvider: binding?.modelProvider,
       authProfileId: binding?.authProfileId,
@@ -517,6 +533,7 @@ function enqueueBoundTurn<T>(key: string, run: () => Promise<T>): Promise<T> {
 function resolveThreadRequestModelProvider(params: {
   authProfileId?: string;
   modelProvider?: string;
+  agentDir?: string;
   config?: CodexAppServerAuthProfileLookup["config"];
 }): string | undefined {
   const modelProvider = params.modelProvider?.trim();
@@ -530,4 +547,15 @@ function resolveThreadRequestModelProvider(params: {
     return undefined;
   }
   return modelProvider.toLowerCase() === "openai-codex" ? "openai" : modelProvider;
+}
+
+function buildAgentLookup(params: {
+  agentDir?: string;
+  config?: CodexAppServerAuthProfileLookup["config"];
+}): Pick<CodexAppServerAuthProfileLookup, "agentDir" | "config"> {
+  const agentDir = params.agentDir?.trim();
+  return {
+    ...(agentDir ? { agentDir } : {}),
+    ...(params.config ? { config: params.config } : {}),
+  };
 }

--- a/extensions/codex/src/conversation-control.test.ts
+++ b/extensions/codex/src/conversation-control.test.ts
@@ -62,6 +62,7 @@ describe("codex conversation controls", () => {
 
   it("does not persist public OpenAI provider after model changes on native auth bindings", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
+    const agentDir = path.join(tempDir, "agents", "bot-a", "agent");
     upsertAuthProfile({
       profileId: "work",
       credential: {
@@ -87,12 +88,14 @@ describe("codex conversation controls", () => {
       })),
     });
 
-    await expect(setCodexConversationModel({ sessionFile, model: "gpt-5.5" })).resolves.toBe(
-      "Codex model set to gpt-5.5.",
-    );
+    await expect(
+      setCodexConversationModel({ sessionFile, agentDir, model: "gpt-5.5" }),
+    ).resolves.toBe("Codex model set to gpt-5.5.");
 
     const raw = await fs.readFile(`${sessionFile}.codex-app-server.json`, "utf8");
     const binding = await readCodexAppServerBinding(sessionFile);
+    const sharedClientParams = sharedClientMocks.getSharedCodexAppServerClient.mock.calls[0]?.[0];
+    expect(sharedClientParams?.agentDir).toBe(agentDir);
     expect(raw).not.toContain('"modelProvider": "openai"');
     expect(binding?.threadId).toBe("thread-1");
     expect(binding?.authProfileId).toBe("work");

--- a/extensions/codex/src/conversation-control.ts
+++ b/extensions/codex/src/conversation-control.ts
@@ -19,6 +19,8 @@ type ActiveTurn = {
   turnId: string;
 };
 
+type CodexAppServerBindingLookup = NonNullable<Parameters<typeof readCodexAppServerBinding>[1]>;
+
 type PermissionsMode = "default" | "yolo";
 
 const CODEX_CONVERSATION_CONTROL_STATE = Symbol.for("openclaw.codex.conversationControl");
@@ -49,17 +51,21 @@ export function readCodexConversationActiveTurn(sessionFile: string): ActiveTurn
 export async function stopCodexConversationTurn(params: {
   sessionFile: string;
   pluginConfig?: unknown;
+  agentDir?: string;
+  config?: CodexAppServerBindingLookup["config"];
 }): Promise<{ stopped: boolean; message: string }> {
   const active = readCodexConversationActiveTurn(params.sessionFile);
   if (!active) {
     return { stopped: false, message: "No active Codex run to stop." };
   }
   const runtime = resolveCodexAppServerRuntimeOptions({ pluginConfig: params.pluginConfig });
-  const binding = await readCodexAppServerBinding(params.sessionFile);
+  const lookup = buildBindingLookup(params);
+  const binding = await readCodexAppServerBinding(params.sessionFile, lookup);
   const client = await getSharedCodexAppServerClient({
     startOptions: runtime.start,
     timeoutMs: runtime.requestTimeoutMs,
     authProfileId: binding?.authProfileId,
+    ...lookup,
   });
   await client.request(
     "turn/interrupt",
@@ -76,6 +82,8 @@ export async function steerCodexConversationTurn(params: {
   sessionFile: string;
   message: string;
   pluginConfig?: unknown;
+  agentDir?: string;
+  config?: CodexAppServerBindingLookup["config"];
 }): Promise<{ steered: boolean; message: string }> {
   const active = readCodexConversationActiveTurn(params.sessionFile);
   const text = params.message.trim();
@@ -86,11 +94,13 @@ export async function steerCodexConversationTurn(params: {
     return { steered: false, message: "No active Codex run to steer." };
   }
   const runtime = resolveCodexAppServerRuntimeOptions({ pluginConfig: params.pluginConfig });
-  const binding = await readCodexAppServerBinding(params.sessionFile);
+  const lookup = buildBindingLookup(params);
+  const binding = await readCodexAppServerBinding(params.sessionFile, lookup);
   const client = await getSharedCodexAppServerClient({
     startOptions: runtime.start,
     timeoutMs: runtime.requestTimeoutMs,
     authProfileId: binding?.authProfileId,
+    ...lookup,
   });
   await client.request(
     "turn/steer",
@@ -108,28 +118,36 @@ export async function setCodexConversationModel(params: {
   sessionFile: string;
   model: string;
   pluginConfig?: unknown;
+  agentDir?: string;
+  config?: CodexAppServerBindingLookup["config"];
 }): Promise<string> {
   const model = params.model.trim();
   if (!model) {
     return "Usage: /codex model <model>";
   }
-  const binding = await requireThreadBinding(params.sessionFile);
+  const lookup = buildBindingLookup(params);
+  const binding = await requireThreadBinding(params.sessionFile, lookup);
   const runtime = resolveCodexAppServerRuntimeOptions({ pluginConfig: params.pluginConfig });
   const response = await resumeThreadWithOverrides({
     pluginConfig: params.pluginConfig,
     threadId: binding.threadId,
     authProfileId: binding.authProfileId,
+    ...lookup,
     model,
   });
-  await writeCodexAppServerBinding(params.sessionFile, {
-    ...binding,
-    cwd: response.thread.cwd ?? binding.cwd,
-    model: response.model ?? model,
-    modelProvider: response.modelProvider ?? binding.modelProvider,
-    approvalPolicy: binding.approvalPolicy,
-    sandbox: binding.sandbox,
-    serviceTier: binding.serviceTier ?? runtime.serviceTier,
-  });
+  await writeCodexAppServerBinding(
+    params.sessionFile,
+    {
+      ...binding,
+      cwd: response.thread.cwd ?? binding.cwd,
+      model: response.model ?? model,
+      modelProvider: response.modelProvider ?? binding.modelProvider,
+      approvalPolicy: binding.approvalPolicy,
+      sandbox: binding.sandbox,
+      serviceTier: binding.serviceTier ?? runtime.serviceTier,
+    },
+    lookup,
+  );
   return `Codex model set to ${formatCodexDisplayText(response.model ?? model)}.`;
 }
 
@@ -137,18 +155,25 @@ export async function setCodexConversationFastMode(params: {
   sessionFile: string;
   enabled?: boolean;
   pluginConfig?: unknown;
+  agentDir?: string;
+  config?: CodexAppServerBindingLookup["config"];
 }): Promise<string> {
-  const binding = await requireThreadBinding(params.sessionFile);
+  const lookup = buildBindingLookup(params);
+  const binding = await requireThreadBinding(params.sessionFile, lookup);
   if (params.enabled == null) {
     return `Codex fast mode: ${isCodexFastServiceTier(binding.serviceTier) ? "on" : "off"}.`;
   }
   const serviceTier: CodexServiceTier = params.enabled ? "priority" : "flex";
   // Fast mode is sent on each later turn; do not require Codex to accept an
   // immediate thread/resume control request just to persist the preference.
-  await writeCodexAppServerBinding(params.sessionFile, {
-    ...binding,
-    serviceTier,
-  });
+  await writeCodexAppServerBinding(
+    params.sessionFile,
+    {
+      ...binding,
+      serviceTier,
+    },
+    lookup,
+  );
   return `Codex fast mode ${params.enabled ? "enabled" : "disabled"}.`;
 }
 
@@ -156,19 +181,26 @@ export async function setCodexConversationPermissions(params: {
   sessionFile: string;
   mode?: PermissionsMode;
   pluginConfig?: unknown;
+  agentDir?: string;
+  config?: CodexAppServerBindingLookup["config"];
 }): Promise<string> {
-  const binding = await requireThreadBinding(params.sessionFile);
+  const lookup = buildBindingLookup(params);
+  const binding = await requireThreadBinding(params.sessionFile, lookup);
   if (!params.mode) {
     return `Codex permissions: ${formatPermissionsMode(binding)}.`;
   }
   const policy = permissionsForMode(params.mode);
   // Native bound turns pass these settings at turn/start time, so this command
   // can update the local binding even when app-server resume overrides fail.
-  await writeCodexAppServerBinding(params.sessionFile, {
-    ...binding,
-    approvalPolicy: policy.approvalPolicy,
-    sandbox: policy.sandbox,
-  });
+  await writeCodexAppServerBinding(
+    params.sessionFile,
+    {
+      ...binding,
+      approvalPolicy: policy.approvalPolicy,
+      sandbox: policy.sandbox,
+    },
+    lookup,
+  );
   return `Codex permissions set to ${params.mode === "yolo" ? "full access" : "default"}.`;
 }
 
@@ -209,8 +241,8 @@ export function formatPermissionsMode(binding: {
     : "default";
 }
 
-async function requireThreadBinding(sessionFile: string) {
-  const binding = await readCodexAppServerBinding(sessionFile);
+async function requireThreadBinding(sessionFile: string, lookup: CodexAppServerBindingLookup = {}) {
+  const binding = await readCodexAppServerBinding(sessionFile, lookup);
   if (!binding?.threadId) {
     throw new Error("No Codex thread is attached to this OpenClaw session yet.");
   }
@@ -221,6 +253,8 @@ async function resumeThreadWithOverrides(params: {
   pluginConfig?: unknown;
   threadId: string;
   authProfileId?: string;
+  agentDir?: string;
+  config?: CodexAppServerBindingLookup["config"];
   model?: string;
   approvalPolicy?: CodexAppServerApprovalPolicy;
   sandbox?: CodexAppServerSandboxMode;
@@ -231,6 +265,7 @@ async function resumeThreadWithOverrides(params: {
     startOptions: runtime.start,
     timeoutMs: runtime.requestTimeoutMs,
     authProfileId: params.authProfileId,
+    ...buildBindingLookup(params),
   });
   return await client.request(
     CODEX_CONTROL_METHODS.resumeThread,
@@ -245,6 +280,17 @@ async function resumeThreadWithOverrides(params: {
     },
     { timeoutMs: runtime.requestTimeoutMs },
   );
+}
+
+function buildBindingLookup(params: {
+  agentDir?: string;
+  config?: CodexAppServerBindingLookup["config"];
+}): CodexAppServerBindingLookup {
+  const agentDir = params.agentDir?.trim();
+  return {
+    ...(agentDir ? { agentDir } : {}),
+    ...(params.config ? { config: params.config } : {}),
+  };
 }
 
 function permissionsForMode(mode: PermissionsMode): {


### PR DESCRIPTION
Summary
- Preserve the owning agent directory in Codex app-server conversation binding data.
- Route bound Codex follow-up turns and controls through the owning agent runtime/client instead of the default agent client.
- Add regression coverage for binding, controls, and command dispatch, plus changelog.

Fixes #82954.

Verification
- node scripts/run-vitest.mjs extensions/codex/src/commands.test.ts extensions/codex/src/conversation-binding.test.ts extensions/codex/src/conversation-control.test.ts
- git diff --check
- /Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --mode local

Real behavior proof
Behavior addressed: bound Codex app-server conversations now retain and reuse the owning OpenClaw agent directory for follow-up turns, stop/steer/model/fast/permissions controls, and compact/review control RPCs.
Real environment tested: local OpenClaw checkout with focused Codex command, binding, and control Vitest coverage exercising the actual command/binding/control code paths.
Exact steps or command run after this patch: node scripts/run-vitest.mjs extensions/codex/src/commands.test.ts extensions/codex/src/conversation-binding.test.ts extensions/codex/src/conversation-control.test.ts
Evidence after fix: after rebasing on current main, the command completed with "Test Files 3 passed (3)" and "Tests 98 passed (98)"; Codex review helper reported "codex-review clean: no accepted/actionable findings reported".
Observed result after fix: the regression tests assert the stored agentDir is passed to shared app-server clients and command/control deps for bound sessions, including compact/review RPC options.
What was not tested: live two-agent Telegram reproduction against a packaged beta build.
Maintainer proof decision: applied the `proof: override` label for this maintainer-owned fix because the available proof is code-path regression coverage plus review, not a packaged two-agent Telegram replay.
