### PR TITLE
fix(tui): render delta-only assistant streams

### DIFF
--- a/src/gateway/live-chat-projector.ts
+++ b/src/gateway/live-chat-projector.ts
@@ -15,6 +15,23 @@ import {
 
 export const MAX_LIVE_CHAT_BUFFER_CHARS = 500_000;
 
+/** Normalizes assistant event payloads that contain a snapshot, a delta, or both. */
+export function resolveAssistantLiveChatInput(
+  data: unknown,
+): { text: string; delta: string } | undefined {
+  if (!data || typeof data !== "object") {
+    return undefined;
+  }
+  const record = data as { text?: unknown; delta?: unknown };
+  if (typeof record.text !== "string" && typeof record.delta !== "string") {
+    return undefined;
+  }
+  return {
+    text: typeof record.text === "string" ? record.text : "",
+    delta: typeof record.delta === "string" ? record.delta : "",
+  };
+}
+
 function capLiveAssistantBuffer(text: string): string {
   if (text.length <= MAX_LIVE_CHAT_BUFFER_CHARS) {
     return text;

--- a/src/gateway/live-chat-projector.ts
+++ b/src/gateway/live-chat-projector.ts
@@ -63,18 +63,9 @@ export function resolveMergedAssistantText(params: {
   return capLiveAssistantBuffer(previousText);
 }
 
-/** Removes runtime-only context/directive tags from live assistant event text. */
-export function normalizeLiveAssistantEventText(params: { text: string; delta?: unknown }): {
-  text: string;
-  delta: string;
-} {
-  return {
-    text: stripInternalRuntimeContext(stripInlineDirectiveTagsForDisplay(params.text).text),
-    delta:
-      typeof params.delta === "string"
-        ? stripInternalRuntimeContext(stripInlineDirectiveTagsForDisplay(params.delta).text)
-        : "",
-  };
+/** Removes runtime-only context/directive tags from the merged live assistant buffer. */
+export function normalizeLiveAssistantBufferedText(text: string): string {
+  return stripInternalRuntimeContext(stripInlineDirectiveTagsForDisplay(text).text);
 }
 
 /** Projects buffered assistant text into display text or a suppressed/pending state. */

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -151,6 +151,7 @@ describe("agent event handler", () => {
   function emitRun1AssistantText(
     harness: ReturnType<typeof createHarness>,
     text: string,
+    field: "text" | "delta" = "text",
   ): ReturnType<typeof createHarness> {
     harness.chatRunState.registry.add("run-1", {
       sessionKey: "session-1",
@@ -161,7 +162,7 @@ describe("agent event handler", () => {
       seq: 1,
       stream: "assistant",
       ts: Date.now(),
-      data: { text },
+      data: { [field]: text },
     });
     return harness;
   }
@@ -411,10 +412,11 @@ describe("agent event handler", () => {
     expect("isHeartbeat" in normalNodeSend).toBe(false);
   });
 
-  it("emits chat delta for assistant text-only events", () => {
+  it.each(["text", "delta"] as const)("emits chat delta for assistant %s-only events", (field) => {
     const { broadcast, nodeSendToSession, nowSpy } = emitRun1AssistantText(
       createHarness({ now: 1_000 }),
       "Hello world",
+      field,
     );
     const chatCalls = chatBroadcastCalls(broadcast);
     expect(chatCalls).toHaveLength(1);

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -1,6 +1,10 @@
 // Server chat agent-event tests protect event fanout, heartbeat visibility,
 // session lifecycle persistence, and subscriber registry behavior.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  INTERNAL_RUNTIME_CONTEXT_BEGIN,
+  INTERNAL_RUNTIME_CONTEXT_END,
+} from "../agents/internal-runtime-context.js";
 import { formatChannelProgressDraftLine } from "../channels/streaming.js";
 import { registerAgentRunContext, resetAgentRunContextForTest } from "../infra/agent-events.js";
 
@@ -429,6 +433,40 @@ describe("agent event handler", () => {
     expect(payload.deltaText).toBe("Hello world");
     expect(payload.message?.content?.[0]?.text).toBe("Hello world");
     expect(sessionChatCalls(nodeSendToSession)).toHaveLength(1);
+    nowSpy?.mockRestore();
+  });
+
+  it("keeps internal context private when it spans delta-only events", () => {
+    const { broadcast, chatRunState, handler, nowSpy } = createHarness({ now: 1_000 });
+    chatRunState.registry.add("run-split-context", {
+      sessionKey: "session-split-context",
+      clientRunId: "client-split-context",
+    });
+
+    const deltas = [
+      `Visible\n${INTERNAL_RUNTIME_CONTEXT_BEGIN}\n`,
+      "private runtime detail\n",
+      `${INTERNAL_RUNTIME_CONTEXT_END}\nAfter`,
+    ];
+    deltas.forEach((delta, index) => {
+      handler({
+        runId: "run-split-context",
+        seq: index + 1,
+        stream: "assistant",
+        ts: Date.now(),
+        data: { delta },
+      });
+    });
+    emitLifecycleEnd(handler, "run-split-context", 4);
+
+    const chatCalls = chatBroadcastCalls(broadcast);
+    expect(JSON.stringify(chatCalls)).not.toContain("private runtime detail");
+    const finalPayload = chatCalls.at(-1)?.[1] as {
+      state?: string;
+      message?: { content?: Array<{ text?: string }> };
+    };
+    expect(finalPayload.state).toBe("final");
+    expect(finalPayload.message?.content?.[0]?.text).toBe("Visible\n\nAfter");
     nowSpy?.mockRestore();
   });
 

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -14,7 +14,7 @@ import { isAcpSessionKey, isSubagentSessionKey } from "../sessions/session-key-u
 import { resolveAssistantEventPhase } from "../shared/chat-message-content.js";
 import { setSafeTimeout } from "../utils/timer-delay.js";
 import {
-  normalizeLiveAssistantEventText,
+  normalizeLiveAssistantBufferedText,
   projectLiveAssistantBufferedText,
   resolveAssistantLiveChatInput,
   resolveMergedAssistantText,
@@ -757,12 +757,11 @@ export function createAgentEventHandler({
     delta?: unknown,
     opts?: { controlUiVisible?: boolean },
   ) => {
-    const cleaned = normalizeLiveAssistantEventText({ text, delta });
     const previousRawText = chatRunState.rawBuffers.get(clientRunId) ?? "";
     const mergedRawText = resolveMergedAssistantText({
       previousText: previousRawText,
-      nextText: cleaned.text,
-      nextDelta: cleaned.delta,
+      nextText: text,
+      nextDelta: typeof delta === "string" ? delta : "",
     });
     if (!mergedRawText) {
       return;
@@ -770,7 +769,10 @@ export function createAgentEventHandler({
     const now = Date.now();
     chatRunState.rawBuffers.set(clientRunId, mergedRawText);
     chatRunState.bufferUpdatedAt.set(clientRunId, now);
-    const projected = projectLiveAssistantBufferedText(mergedRawText);
+    // Sanitize only after merging. Protected blocks and directive tags can span
+    // delta frames; cleaning each frame independently can expose their contents.
+    const normalizedText = normalizeLiveAssistantBufferedText(mergedRawText);
+    const projected = projectLiveAssistantBufferedText(normalizedText);
     const mergedText = projected.text;
     chatRunState.buffers.set(clientRunId, mergedText);
     if (projected.suppress) {
@@ -822,9 +824,7 @@ export function createAgentEventHandler({
     sourceRunId: string,
     options?: { suppressLeadFragments?: boolean },
   ) => {
-    const bufferedText = normalizeLiveAssistantEventText({
-      text: chatRunState.buffers.get(clientRunId) ?? "",
-    }).text.trim();
+    const bufferedText = (chatRunState.buffers.get(clientRunId) ?? "").trim();
     const normalizedHeartbeatText = normalizeHeartbeatChatFinalText({
       runId: clientRunId,
       sourceRunId,

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -1396,7 +1396,7 @@ export function createAgentEventHandler({
       if (
         !isAborted &&
         evt.stream === "assistant" &&
-        typeof evt.data?.text === "string" &&
+        (typeof evt.data?.text === "string" || typeof evt.data?.delta === "string") &&
         !shouldSuppressAssistantEventForLiveChat(evt.data)
       ) {
         emitChatDelta(

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -16,6 +16,7 @@ import { setSafeTimeout } from "../utils/timer-delay.js";
 import {
   normalizeLiveAssistantEventText,
   projectLiveAssistantBufferedText,
+  resolveAssistantLiveChatInput,
   resolveMergedAssistantText,
   shouldSuppressAssistantEventForLiveChat,
 } from "./live-chat-projector.js";
@@ -1393,10 +1394,11 @@ export function createAgentEventHandler({
           sessionAgentId,
         );
       }
+      const assistantLiveChatInput =
+        evt.stream === "assistant" ? resolveAssistantLiveChatInput(evt.data) : undefined;
       if (
         !isAborted &&
-        evt.stream === "assistant" &&
-        (typeof evt.data?.text === "string" || typeof evt.data?.delta === "string") &&
+        assistantLiveChatInput &&
         !shouldSuppressAssistantEventForLiveChat(evt.data)
       ) {
         emitChatDelta(
@@ -1405,8 +1407,8 @@ export function createAgentEventHandler({
           clientRunId,
           evt.runId,
           evt.seq,
-          evt.data.text,
-          evt.data.delta,
+          assistantLiveChatInput.text,
+          assistantLiveChatInput.delta,
           {
             controlUiVisible: isControlUiVisible,
           },

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -1,5 +1,9 @@
 // Covers embedded backend behavior used by the TUI runtime.
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  INTERNAL_RUNTIME_CONTEXT_BEGIN,
+  INTERNAL_RUNTIME_CONTEXT_END,
+} from "../agents/internal-runtime-context.js";
 import { isEmbeddedMode, setEmbeddedMode } from "../infra/embedded-mode.js";
 import {
   clearEmbeddedPluginApprovalBroker,
@@ -1828,6 +1832,56 @@ describe("EmbeddedTuiBackend", () => {
       { state: "delta", deltaText: "Hello world", replace: undefined },
       { state: "delta", deltaText: "Goodbye world", replace: true },
     ]);
+  });
+
+  it("keeps internal context private when local deltas split its delimiters", async () => {
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const pending = deferred<{
+      payloads: Array<{ text: string }>;
+      meta: Record<string, unknown>;
+    }>();
+    agentCommandFromIngressMock.mockReturnValueOnce(pending.promise);
+
+    const backend = new EmbeddedTuiBackend();
+    const events: Array<{ event: string; payload: unknown }> = [];
+    backend.onEvent = (evt) => {
+      events.push({ event: evt.event, payload: evt.payload });
+    };
+    backend.start();
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "split internal context",
+      runId: "run-local-split-context",
+    });
+
+    const deltas = [
+      `Visible\n${INTERNAL_RUNTIME_CONTEXT_BEGIN}\n`,
+      "private runtime detail\n",
+      `${INTERNAL_RUNTIME_CONTEXT_END}\nAfter`,
+    ];
+    deltas.forEach((delta) => {
+      registeredListener?.({
+        runId: "run-local-split-context",
+        stream: "assistant",
+        data: { delta },
+      });
+    });
+    registeredListener?.({
+      runId: "run-local-split-context",
+      stream: "lifecycle",
+      data: { phase: "end", stopReason: "stop" },
+    });
+    pending.resolve({ payloads: [{ text: "Visible\n\nAfter" }], meta: {} });
+    await flushMicrotasks();
+
+    const chatPayloads = events
+      .filter((entry) => entry.event === "chat")
+      .map((entry) => entry.payload);
+    expect(JSON.stringify(chatPayloads)).not.toContain("private runtime detail");
+    expect(chatPayloads.at(-1)).toMatchObject({
+      state: "final",
+      message: { content: [{ text: "Visible\n\nAfter" }] },
+    });
   });
 
   it("keeps a fallback response deliverable after a retryable lifecycle error", async () => {

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -413,7 +413,7 @@ describe("EmbeddedTuiBackend", () => {
     registeredListener?.({
       runId: "run-local-1",
       stream: "assistant",
-      data: { text: "hello", delta: "hello" },
+      data: { delta: "hello" },
     });
     registeredListener?.({
       runId: "run-local-1",
@@ -430,7 +430,7 @@ describe("EmbeddedTuiBackend", () => {
         payload: {
           runId: "run-local-1",
           stream: "assistant",
-          data: { text: "hello", delta: "hello" },
+          data: { delta: "hello" },
         },
       },
       {

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -35,7 +35,7 @@ import {
 } from "../gateway/chat-display-projection.js";
 import { augmentChatHistoryWithCliSessionImports } from "../gateway/cli-session-history.js";
 import {
-  normalizeLiveAssistantEventText,
+  normalizeLiveAssistantBufferedText,
   projectLiveAssistantBufferedText,
   resolveAssistantLiveChatInput,
   resolveMergedAssistantText,
@@ -946,7 +946,8 @@ export class EmbeddedTuiBackend implements TuiBackend {
   }
 
   private emitChatDelta(runId: string, run: LocalRunState) {
-    const projected = projectLiveAssistantBufferedText(run.buffer.trim(), {
+    const normalizedText = normalizeLiveAssistantBufferedText(run.buffer).trim();
+    const projected = projectLiveAssistantBufferedText(normalizedText, {
       suppressLeadFragments: true,
     });
     const text = projected.text.trim();
@@ -984,7 +985,8 @@ export class EmbeddedTuiBackend implements TuiBackend {
     }
     run.registered = true;
     run.lastBroadcastText = undefined;
-    const projected = projectLiveAssistantBufferedText(run.buffer.trim(), {
+    const normalizedText = normalizeLiveAssistantBufferedText(run.buffer).trim();
+    const projected = projectLiveAssistantBufferedText(normalizedText, {
       suppressLeadFragments: false,
     });
     const text = projected.text.trim();
@@ -1093,14 +1095,10 @@ export class EmbeddedTuiBackend implements TuiBackend {
       !run.isBtw &&
       !shouldSuppressAssistantEventForLiveChat(evt.data)
     ) {
-      const cleaned = normalizeLiveAssistantEventText({
-        text: assistantLiveChatInput.text,
-        delta: assistantLiveChatInput.delta,
-      });
       run.buffer = resolveMergedAssistantText({
         previousText: run.buffer,
-        nextText: cleaned.text,
-        nextDelta: cleaned.delta,
+        nextText: assistantLiveChatInput.text,
+        nextDelta: assistantLiveChatInput.delta,
       });
       this.emitChatDelta(evt.runId, run);
       return;

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -1088,11 +1088,11 @@ export class EmbeddedTuiBackend implements TuiBackend {
     if (
       evt.stream === "assistant" &&
       !run.isBtw &&
-      typeof evt.data?.text === "string" &&
+      (typeof evt.data?.text === "string" || typeof evt.data?.delta === "string") &&
       !shouldSuppressAssistantEventForLiveChat(evt.data)
     ) {
       const cleaned = normalizeLiveAssistantEventText({
-        text: evt.data.text,
+        text: typeof evt.data.text === "string" ? evt.data.text : "",
         delta: evt.data.delta,
       });
       run.buffer = resolveMergedAssistantText({

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -37,6 +37,7 @@ import { augmentChatHistoryWithCliSessionImports } from "../gateway/cli-session-
 import {
   normalizeLiveAssistantEventText,
   projectLiveAssistantBufferedText,
+  resolveAssistantLiveChatInput,
   resolveMergedAssistantText,
   shouldSuppressAssistantEventForLiveChat,
 } from "../gateway/live-chat-projector.js";
@@ -1085,15 +1086,16 @@ export class EmbeddedTuiBackend implements TuiBackend {
       data: evt.data,
     });
 
+    const assistantLiveChatInput =
+      evt.stream === "assistant" ? resolveAssistantLiveChatInput(evt.data) : undefined;
     if (
-      evt.stream === "assistant" &&
+      assistantLiveChatInput &&
       !run.isBtw &&
-      (typeof evt.data?.text === "string" || typeof evt.data?.delta === "string") &&
       !shouldSuppressAssistantEventForLiveChat(evt.data)
     ) {
       const cleaned = normalizeLiveAssistantEventText({
-        text: typeof evt.data.text === "string" ? evt.data.text : "",
-        delta: evt.data.delta,
+        text: assistantLiveChatInput.text,
+        delta: assistantLiveChatInput.delta,
       });
       run.buffer = resolveMergedAssistantText({
         previousText: run.buffer,


### PR DESCRIPTION
Closes #82988

## What Problem This Solves

Fixes an issue where Gateway-backed and embedded TUI sessions could drop live assistant output when a runtime emitted incremental `delta` frames without also repeating the cumulative `text` snapshot. Users saw no progress until the final response, despite the runtime streaming correctly.

## Why This Change Was Made

A shared live-chat input normalizer now accepts snapshot-only, delta-only, and combined assistant events before both TUI backends enter the existing sanitization, merge, suppression, and projection pipeline. The branch was rebased and rewritten on current `main`; unrelated dependency override and lockfile changes were removed.

## User Impact

Streaming text appears incrementally in both normal Gateway TUI sessions and `tui --local`, including runtimes that emit canonical delta-only events. Commentary suppression, abort handling, buffer caps, and final-message behavior are unchanged.

## Evidence

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server-chat.agent-events.test.ts src/gateway/server-chat.stream-text-merge.test.ts` — 109 tests passed.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tui.config.ts src/tui/embedded-backend.test.ts` — 43 tests passed.
- Testbox-through-Crabbox `tbx_01kwrjhsjn8geh91q5w6rnh5j3`: real Gateway + real tmux TUI showed the first `DELTA_` frame before the second frame arrived, then rendered `DELTA_ONLY_VISIBLE` while still streaming.
- Testbox-through-Crabbox `tbx_01kwrjhsjn8geh91q5w6rnh5j3`: `pnpm check:changed` passed, including typechecks, lint, guards, and import-cycle checks.
- `.agents/skills/autoreview/scripts/autoreview --mode local --stream-engine-output` — clean, no accepted/actionable findings.
