### PR TITLE
[Fix] Speed up secrets runtime startup

### DIFF
--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -4,10 +4,8 @@ import { selectApplicableRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { callGateway } from "../gateway/call.js";
 import { isEmbeddedMode } from "../infra/embedded-mode.js";
-import {
-  getActiveRuntimeWebToolsMetadata,
-  getActiveSecretsRuntimeSnapshot,
-} from "../secrets/runtime.js";
+import { getActiveSecretsRuntimeSnapshot } from "../secrets/runtime-state.js";
+import { getActiveRuntimeWebToolsMetadata } from "../secrets/runtime-web-tools-state.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import type { GatewayMessageChannel } from "../utils/message-channel.js";
 import { resolveAgentWorkspaceDir, resolveSessionAgentIds } from "./agent-scope.js";

--- a/src/agents/tools/web-fetch.provider-fallback.test.ts
+++ b/src/agents/tools/web-fetch.provider-fallback.test.ts
@@ -14,7 +14,7 @@ const runtimeState = vi.hoisted(() => ({
 vi.mock("../../web-fetch/runtime.js", () => ({
   resolveWebFetchDefinition: resolveWebFetchDefinitionMock,
 }));
-vi.mock("../../secrets/runtime.js", () => ({
+vi.mock("../../secrets/runtime-state.js", () => ({
   getActiveSecretsRuntimeSnapshot: () => runtimeState.activeSecretsRuntimeSnapshot,
 }));
 vi.mock("../../secrets/runtime-web-tools-state.js", () => ({

--- a/src/agents/tools/web-search.late-bind.test.ts
+++ b/src/agents/tools/web-search.late-bind.test.ts
@@ -21,7 +21,7 @@ vi.mock("../../secrets/runtime-web-tools-state.js", () => ({
   getActiveRuntimeWebToolsMetadata: mocks.getActiveRuntimeWebToolsMetadata,
 }));
 
-vi.mock("../../secrets/runtime.js", () => ({
+vi.mock("../../secrets/runtime-state.js", () => ({
   getActiveSecretsRuntimeSnapshot: mocks.getActiveSecretsRuntimeSnapshot,
 }));
 

--- a/src/agents/tools/web-tool-runtime-context.test.ts
+++ b/src/agents/tools/web-tool-runtime-context.test.ts
@@ -18,7 +18,7 @@ vi.mock("../../secrets/runtime-web-tools-state.js", () => ({
   getActiveRuntimeWebToolsMetadata: mocks.getActiveRuntimeWebToolsMetadata,
 }));
 
-vi.mock("../../secrets/runtime.js", () => ({
+vi.mock("../../secrets/runtime-state.js", () => ({
   getActiveSecretsRuntimeSnapshot: mocks.getActiveSecretsRuntimeSnapshot,
 }));
 

--- a/src/agents/tools/web-tool-runtime-context.ts
+++ b/src/agents/tools/web-tool-runtime-context.ts
@@ -1,11 +1,11 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveManifestContractOwnerPluginId } from "../../plugins/plugin-registry.js";
+import { getActiveSecretsRuntimeSnapshot } from "../../secrets/runtime-state.js";
 import { getActiveRuntimeWebToolsMetadata } from "../../secrets/runtime-web-tools-state.js";
 import type {
   RuntimeWebFetchMetadata,
   RuntimeWebSearchMetadata,
 } from "../../secrets/runtime-web-tools.types.js";
-import { getActiveSecretsRuntimeSnapshot } from "../../secrets/runtime.js";
 
 type WebProviderKind = "fetch" | "search";
 

--- a/src/agents/tools/web-tools.enabled-defaults.test.ts
+++ b/src/agents/tools/web-tools.enabled-defaults.test.ts
@@ -39,7 +39,7 @@ function readConfiguredSearchProvider(config: unknown): string | undefined {
   return typeof provider === "string" ? provider : undefined;
 }
 
-vi.mock("../../secrets/runtime.js", () => ({
+vi.mock("../../secrets/runtime-state.js", () => ({
   getActiveSecretsRuntimeSnapshot: () => activeSecretsRuntimeSnapshot.current,
 }));
 

--- a/src/gateway/server-aux-handlers.ts
+++ b/src/gateway/server-aux-handlers.ts
@@ -7,9 +7,9 @@ import {
   type CommandSecretAssignment,
 } from "../secrets/runtime-command-secrets.js";
 import {
-  activateSecretsRuntimeSnapshot,
   getActiveSecretsRuntimeSnapshot,
-} from "../secrets/runtime.js";
+  type PreparedSecretsRuntimeSnapshot,
+} from "../secrets/runtime-state.js";
 import { diffConfigPaths } from "./config-diff.js";
 import {
   buildGatewayReloadPlan,
@@ -37,6 +37,13 @@ type GatewayAuxHandlerLogger = {
 type ReloadSecretsResult = {
   warningCount: number;
 };
+
+async function activateSecretsRuntimeSnapshot(
+  snapshot: PreparedSecretsRuntimeSnapshot,
+): Promise<void> {
+  const runtime = await import("../secrets/runtime.js");
+  runtime.activateSecretsRuntimeSnapshot(snapshot);
+}
 
 function createLazyHandler(
   method: string,
@@ -193,7 +200,7 @@ export function createGatewayAuxHandlers(params: {
                 }
                 return { warningCount: prepared.warnings.length };
               } catch (err) {
-                activateSecretsRuntimeSnapshot(previousSnapshot);
+                await activateSecretsRuntimeSnapshot(previousSnapshot);
                 params.sharedGatewaySessionGenerationState.current =
                   previousSharedGatewaySessionGeneration;
                 params.sharedGatewaySessionGenerationState.required =

--- a/src/gateway/server-import-boundary.test.ts
+++ b/src/gateway/server-import-boundary.test.ts
@@ -39,6 +39,10 @@ describe("gateway startup import boundaries", () => {
     expect(serverImpl).not.toContain('from "../tasks/task-registry.js"');
     expect(serverImpl).not.toContain('from "../tasks/task-registry.maintenance.js"');
     expect(serverImpl).toContain('import("../tasks/task-registry.maintenance.js")');
+    expect(serverImpl).not.toContain('from "../secrets/runtime.js"');
+    expect(readSource("src/gateway/server-reload-handlers.ts")).not.toContain(
+      'from "../secrets/runtime.js"',
+    );
     const wsConnection = readSource("src/gateway/server/ws-connection.ts");
     expect(wsConnection).not.toMatch(
       /import\s+\{[^}]*attachGatewayWsMessageHandler[^}]*\}\s+from "\.\/ws-connection\/message-handler\.js"/s,

--- a/src/gateway/server-methods/config-write-flow.ts
+++ b/src/gateway/server-methods/config-write-flow.ts
@@ -12,7 +12,7 @@ import {
   writeRestartSentinel,
 } from "../../infra/restart-sentinel.js";
 import { scheduleGatewaySigusr1Restart } from "../../infra/restart.js";
-import { getActiveSecretsRuntimeSnapshot } from "../../secrets/runtime.js";
+import { getActiveSecretsRuntimeSnapshot } from "../../secrets/runtime-state.js";
 import { resolveEffectiveSharedGatewayAuth, resolveGatewayAuth } from "../auth.js";
 import { buildGatewayReloadPlan } from "../config-reload-plan.js";
 import { resolveGatewayReloadSettings } from "../config-reload-settings.js";

--- a/src/gateway/server-methods/config.shared-auth.test.ts
+++ b/src/gateway/server-methods/config.shared-auth.test.ts
@@ -53,8 +53,11 @@ vi.mock("../../config/runtime-schema.js", () => ({
 }));
 
 vi.mock("../../secrets/runtime.js", () => ({
-  getActiveSecretsRuntimeSnapshot: () => null,
   prepareSecretsRuntimeSnapshot: prepareSecretsRuntimeSnapshotMock,
+}));
+
+vi.mock("../../secrets/runtime-state.js", () => ({
+  getActiveSecretsRuntimeSnapshot: () => null,
 }));
 
 vi.mock("../../infra/restart.js", () => ({

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -21,10 +21,10 @@ import {
 } from "../infra/restart.js";
 import { getTotalQueueSize } from "../process/command-queue.js";
 import {
-  activateSecretsRuntimeSnapshot,
   clearSecretsRuntimeSnapshot,
   getActiveSecretsRuntimeSnapshot,
-} from "../secrets/runtime.js";
+  type PreparedSecretsRuntimeSnapshot,
+} from "../secrets/runtime-state.js";
 import {
   getInspectableActiveTaskRestartBlockers,
   type ActiveTaskRestartBlocker,
@@ -58,6 +58,13 @@ type GatewayHotReloadState = {
   cronState: GatewayCronState;
   channelHealthMonitor: ChannelHealthMonitor | null;
 };
+
+async function activateSecretsRuntimeSnapshot(
+  snapshot: PreparedSecretsRuntimeSnapshot,
+): Promise<void> {
+  const runtime = await import("../secrets/runtime.js");
+  runtime.activateSecretsRuntimeSnapshot(snapshot);
+}
 
 type GatewayReloadLog = {
   info: (msg: string) => void;
@@ -605,7 +612,7 @@ export function startManagedGatewayConfigReloader(params: ManagedGatewayConfigRe
         await applyHotReload(plan, prepared.config);
       } catch (err) {
         if (previousSnapshot) {
-          activateSecretsRuntimeSnapshot(previousSnapshot);
+          await activateSecretsRuntimeSnapshot(previousSnapshot);
         } else {
           clearSecretsRuntimeSnapshot();
         }
@@ -638,7 +645,7 @@ export function startManagedGatewayConfigReloader(params: ManagedGatewayConfigRe
         const restartQueued = requestGatewayRestart(plan, nextConfig);
         if (!restartQueued) {
           if (previousSharedGatewaySessionGeneration !== nextSharedGatewaySessionGeneration) {
-            activateSecretsRuntimeSnapshot(prepared);
+            await activateSecretsRuntimeSnapshot(prepared);
             setCurrentSharedGatewaySessionGeneration(
               params.sharedGatewaySessionGenerationState,
               nextSharedGatewaySessionGeneration,

--- a/src/gateway/server-startup-config.secrets.test.ts
+++ b/src/gateway/server-startup-config.secrets.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { loadAuthProfileStoreWithoutExternalProfiles } from "../agents/auth-profiles.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.js";
@@ -500,5 +503,309 @@ describe("gateway startup config secret preflight", () => {
     expect(result.auth.token).toBe("resolved-gateway-token");
     expect(prepareRuntimeSecretsSnapshot).toHaveBeenCalledTimes(2);
     expect(activateRuntimeSecretsSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it("activates no-SecretRef startup config without importing the full secrets runtime", async () => {
+    vi.resetModules();
+    const agentDir = mkdtempSync(path.join(tmpdir(), "openclaw-startup-fast-path-"));
+    const runtimeImport = vi.fn();
+    const prepareRuntimeSecretsSnapshot = vi.fn(async ({ config }) => preparedSnapshot(config));
+    const activateRuntimeSecretsSnapshot = vi.fn();
+    const loadAuthProfileStoreWithoutExternalProfilesMock = vi.fn(() => ({
+      version: 1,
+      profiles: {},
+    }));
+    (
+      globalThis as typeof globalThis & {
+        __gatewayStartupSecretsRuntimeMock?: {
+          runtimeImport: typeof runtimeImport;
+          prepareRuntimeSecretsSnapshot: typeof prepareRuntimeSecretsSnapshot;
+          activateRuntimeSecretsSnapshot: typeof activateRuntimeSecretsSnapshot;
+        };
+      }
+    ).__gatewayStartupSecretsRuntimeMock = {
+      runtimeImport,
+      prepareRuntimeSecretsSnapshot,
+      activateRuntimeSecretsSnapshot,
+    };
+    vi.doMock("../agents/auth-profiles.js", () => ({
+      loadAuthProfileStoreWithoutExternalProfiles: loadAuthProfileStoreWithoutExternalProfilesMock,
+    }));
+    vi.doMock("../secrets/runtime.js", () => {
+      const state = (
+        globalThis as typeof globalThis & {
+          __gatewayStartupSecretsRuntimeMock?: {
+            runtimeImport: typeof runtimeImport;
+            prepareRuntimeSecretsSnapshot: typeof prepareRuntimeSecretsSnapshot;
+            activateRuntimeSecretsSnapshot: typeof activateRuntimeSecretsSnapshot;
+          };
+        }
+      ).__gatewayStartupSecretsRuntimeMock;
+      if (!state) {
+        throw new Error("missing gateway startup secrets runtime mock");
+      }
+      state.runtimeImport();
+      return {
+        prepareSecretsRuntimeSnapshot: state.prepareRuntimeSecretsSnapshot,
+        activateSecretsRuntimeSnapshot: state.activateRuntimeSecretsSnapshot,
+      };
+    });
+
+    try {
+      const { createRuntimeSecretsActivator: createActivator } =
+        await import("./server-startup-config.js");
+      const { clearSecretsRuntimeSnapshot, getActiveSecretsRuntimeSnapshot } =
+        await import("../secrets/runtime-state.js");
+      const { getRuntimeConfigSnapshotRefreshHandler } =
+        await import("../config/runtime-snapshot.js");
+      const result = await createActivator({
+        logSecrets: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+        },
+        emitStateEvent: vi.fn(),
+      })(
+        gatewayTokenConfig(
+          asConfig({
+            agents: {
+              list: [{ id: "default", agentDir }],
+            },
+          }),
+        ),
+        {
+          reason: "startup",
+          activate: true,
+        },
+      );
+
+      expect(runtimeImport).not.toHaveBeenCalled();
+      expect(prepareRuntimeSecretsSnapshot).not.toHaveBeenCalled();
+      expect(activateRuntimeSecretsSnapshot).not.toHaveBeenCalled();
+      expect(loadAuthProfileStoreWithoutExternalProfilesMock).not.toHaveBeenCalled();
+      expect(result.config.gateway?.auth?.token).toBe("startup-test-token");
+      expect(getActiveSecretsRuntimeSnapshot()?.config.gateway?.auth?.token).toBe(
+        "startup-test-token",
+      );
+      const refreshHandler = getRuntimeConfigSnapshotRefreshHandler();
+      await expect(
+        refreshHandler?.refresh({
+          sourceConfig: gatewayTokenConfig(
+            asConfig({
+              agents: {
+                list: [{ id: "default", agentDir }],
+              },
+            }),
+          ),
+        }),
+      ).resolves.toBe(true);
+      expect(runtimeImport).toHaveBeenCalledTimes(1);
+      const refreshInput = callArg<{
+        loadAuthStore?: unknown;
+      }>(prepareRuntimeSecretsSnapshot);
+      expect(refreshInput.loadAuthStore).toBeUndefined();
+      clearSecretsRuntimeSnapshot();
+    } finally {
+      vi.doUnmock("../agents/auth-profiles.js");
+      vi.doUnmock("../secrets/runtime.js");
+      delete (
+        globalThis as typeof globalThis & {
+          __gatewayStartupSecretsRuntimeMock?: unknown;
+        }
+      ).__gatewayStartupSecretsRuntimeMock;
+      rmSync(agentDir, { recursive: true, force: true });
+      vi.resetModules();
+    }
+  });
+
+  it("keeps the full secrets runtime path when startup config has a SecretRef", async () => {
+    vi.resetModules();
+    const agentDir = mkdtempSync(path.join(tmpdir(), "openclaw-startup-secret-ref-"));
+    const runtimeImport = vi.fn();
+    const prepareRuntimeSecretsSnapshot = vi.fn(async ({ config }) => preparedSnapshot(config));
+    const activateRuntimeSecretsSnapshot = vi.fn();
+    (
+      globalThis as typeof globalThis & {
+        __gatewayStartupSecretsRuntimeMock?: {
+          runtimeImport: typeof runtimeImport;
+          prepareRuntimeSecretsSnapshot: typeof prepareRuntimeSecretsSnapshot;
+          activateRuntimeSecretsSnapshot: typeof activateRuntimeSecretsSnapshot;
+        };
+      }
+    ).__gatewayStartupSecretsRuntimeMock = {
+      runtimeImport,
+      prepareRuntimeSecretsSnapshot,
+      activateRuntimeSecretsSnapshot,
+    };
+    vi.doMock("../agents/auth-profiles.js", () => ({
+      loadAuthProfileStoreWithoutExternalProfiles: vi.fn(() => ({
+        version: 1,
+        profiles: {},
+      })),
+    }));
+    vi.doMock("../secrets/runtime.js", () => {
+      const state = (
+        globalThis as typeof globalThis & {
+          __gatewayStartupSecretsRuntimeMock?: {
+            runtimeImport: typeof runtimeImport;
+            prepareRuntimeSecretsSnapshot: typeof prepareRuntimeSecretsSnapshot;
+            activateRuntimeSecretsSnapshot: typeof activateRuntimeSecretsSnapshot;
+          };
+        }
+      ).__gatewayStartupSecretsRuntimeMock;
+      if (!state) {
+        throw new Error("missing gateway startup secrets runtime mock");
+      }
+      state.runtimeImport();
+      return {
+        prepareSecretsRuntimeSnapshot: state.prepareRuntimeSecretsSnapshot,
+        activateSecretsRuntimeSnapshot: state.activateRuntimeSecretsSnapshot,
+      };
+    });
+
+    try {
+      const { createRuntimeSecretsActivator: createActivator } =
+        await import("./server-startup-config.js");
+      await createActivator({
+        logSecrets: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+        },
+        emitStateEvent: vi.fn(),
+      })(
+        gatewayTokenConfig(
+          asConfig({
+            agents: {
+              list: [{ id: "default", agentDir }],
+            },
+            models: {
+              providers: {
+                openai: {
+                  models: [],
+                  apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+                },
+              },
+            },
+          }),
+        ),
+        {
+          reason: "startup",
+          activate: true,
+        },
+      );
+
+      expect(runtimeImport).toHaveBeenCalledTimes(1);
+      expect(prepareRuntimeSecretsSnapshot).toHaveBeenCalledTimes(1);
+      expect(activateRuntimeSecretsSnapshot).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.doUnmock("../agents/auth-profiles.js");
+      vi.doUnmock("../secrets/runtime.js");
+      delete (
+        globalThis as typeof globalThis & {
+          __gatewayStartupSecretsRuntimeMock?: unknown;
+        }
+      ).__gatewayStartupSecretsRuntimeMock;
+      rmSync(agentDir, { recursive: true, force: true });
+      vi.resetModules();
+    }
+  });
+
+  it("keeps the full secrets runtime path when auth profile files are present", async () => {
+    vi.resetModules();
+    const agentDir = mkdtempSync(path.join(tmpdir(), "openclaw-startup-auth-store-"));
+    writeFileSync(
+      path.join(agentDir, "auth-profiles.json"),
+      `${JSON.stringify({
+        version: 1,
+        profiles: {
+          "openai:default": {
+            type: "api_key",
+            provider: "openai",
+            key: "sk-test",
+          },
+        },
+      })}\n`,
+    );
+    const runtimeImport = vi.fn();
+    const prepareRuntimeSecretsSnapshot = vi.fn(async ({ config }) => preparedSnapshot(config));
+    const activateRuntimeSecretsSnapshot = vi.fn();
+    (
+      globalThis as typeof globalThis & {
+        __gatewayStartupSecretsRuntimeMock?: {
+          runtimeImport: typeof runtimeImport;
+          prepareRuntimeSecretsSnapshot: typeof prepareRuntimeSecretsSnapshot;
+          activateRuntimeSecretsSnapshot: typeof activateRuntimeSecretsSnapshot;
+        };
+      }
+    ).__gatewayStartupSecretsRuntimeMock = {
+      runtimeImport,
+      prepareRuntimeSecretsSnapshot,
+      activateRuntimeSecretsSnapshot,
+    };
+    vi.doMock("../agents/auth-profiles.js", () => ({
+      loadAuthProfileStoreWithoutExternalProfiles: vi.fn(() => ({
+        version: 1,
+        profiles: {},
+      })),
+    }));
+    vi.doMock("../secrets/runtime.js", () => {
+      const state = (
+        globalThis as typeof globalThis & {
+          __gatewayStartupSecretsRuntimeMock?: {
+            runtimeImport: typeof runtimeImport;
+            prepareRuntimeSecretsSnapshot: typeof prepareRuntimeSecretsSnapshot;
+            activateRuntimeSecretsSnapshot: typeof activateRuntimeSecretsSnapshot;
+          };
+        }
+      ).__gatewayStartupSecretsRuntimeMock;
+      if (!state) {
+        throw new Error("missing gateway startup secrets runtime mock");
+      }
+      state.runtimeImport();
+      return {
+        prepareSecretsRuntimeSnapshot: state.prepareRuntimeSecretsSnapshot,
+        activateSecretsRuntimeSnapshot: state.activateRuntimeSecretsSnapshot,
+      };
+    });
+
+    try {
+      const { createRuntimeSecretsActivator: createActivator } =
+        await import("./server-startup-config.js");
+      await createActivator({
+        logSecrets: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+        },
+        emitStateEvent: vi.fn(),
+      })(
+        gatewayTokenConfig(
+          asConfig({
+            agents: {
+              list: [{ id: "default", agentDir }],
+            },
+          }),
+        ),
+        {
+          reason: "startup",
+          activate: true,
+        },
+      );
+
+      expect(runtimeImport).toHaveBeenCalledTimes(1);
+      expect(prepareRuntimeSecretsSnapshot).toHaveBeenCalledTimes(1);
+      expect(activateRuntimeSecretsSnapshot).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.doUnmock("../agents/auth-profiles.js");
+      vi.doUnmock("../secrets/runtime.js");
+      delete (
+        globalThis as typeof globalThis & {
+          __gatewayStartupSecretsRuntimeMock?: unknown;
+        }
+      ).__gatewayStartupSecretsRuntimeMock;
+      rmSync(agentDir, { recursive: true, force: true });
+      vi.resetModules();
+    }
   });
 });

--- a/src/gateway/server-startup-config.ts
+++ b/src/gateway/server-startup-config.ts
@@ -13,9 +13,16 @@ import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.opencla
 import { isTruthyEnvValue } from "../infra/env.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import {
+  prepareSecretsRuntimeFastPathSnapshot,
+  resolveRefreshAgentDirs,
+} from "../secrets/runtime-fast-path.js";
+import {
   GATEWAY_AUTH_SURFACE_PATHS,
   evaluateGatewayAuthSurfaceStates,
 } from "../secrets/runtime-gateway-auth-surfaces.js";
+import {
+  activateSecretsRuntimeSnapshotState,
+} from "../secrets/runtime-state.js";
 import { resolveGatewayAuth } from "./auth.js";
 import { assertGatewayAuthNotKnownWeak } from "./known-weak-gateway-secrets.js";
 import {
@@ -222,17 +229,64 @@ export function createRuntimeSecretsActivator(params: {
   const activateRuntimeSecrets = (async (config, activationParams) =>
     await runWithSecretsActivationLock(async () => {
       try {
+        const startupPreflight =
+          activationParams.reason === "startup" || activationParams.reason === "restart-check";
+        if (
+          activationParams.reason === "startup" &&
+          activationParams.activate &&
+          !params.prepareRuntimeSecretsSnapshot &&
+          !params.activateRuntimeSecretsSnapshot
+        ) {
+          const fastPath = prepareSecretsRuntimeFastPathSnapshot({
+            config: pruneSkippedStartupSecretSurfaces(config),
+          });
+          if (fastPath) {
+            const prepared = fastPath.snapshot;
+            assertRuntimeGatewayAuthNotKnownWeak(prepared.config);
+            activateSecretsRuntimeSnapshotState({
+              snapshot: prepared,
+              refreshContext: fastPath.refreshContext,
+              refreshHandler: {
+                refresh: async ({ sourceConfig }) => {
+                  const secretsRuntime = await loadSecretsRuntime();
+                  const refreshed = await secretsRuntime.prepareSecretsRuntimeSnapshot({
+                    config: sourceConfig,
+                    env: fastPath.refreshContext.env,
+                    agentDirs: resolveRefreshAgentDirs(sourceConfig, fastPath.refreshContext),
+                    loadablePluginOrigins: fastPath.refreshContext.loadablePluginOrigins,
+                    ...(fastPath.usesAuthStoreFallback || !fastPath.refreshContext.loadAuthStore
+                      ? {}
+                      : { loadAuthStore: fastPath.refreshContext.loadAuthStore }),
+                  });
+                  secretsRuntime.activateSecretsRuntimeSnapshot(refreshed);
+                  return true;
+                },
+              },
+            });
+            logGatewayAuthSurfaceDiagnostics(prepared, params.logSecrets);
+            if (secretsDegraded) {
+              const recoveredMessage =
+                "Secret resolution recovered; runtime remained on last-known-good during the outage.";
+              params.logSecrets.info(`[SECRETS_RELOADER_RECOVERED] ${recoveredMessage}`);
+              params.emitStateEvent(
+                "SECRETS_RELOADER_RECOVERED",
+                recoveredMessage,
+                prepared.config,
+              );
+            }
+            secretsDegraded = false;
+            return prepared;
+          }
+        }
+        const loadAuthStore = startupPreflight
+          ? (await loadAuthProfiles()).loadAuthProfileStoreWithoutExternalProfiles
+          : undefined;
         const secretsRuntime =
           params.prepareRuntimeSecretsSnapshot && params.activateRuntimeSecretsSnapshot
             ? null
             : await loadSecretsRuntime();
         const prepareRuntimeSecretsSnapshot =
           params.prepareRuntimeSecretsSnapshot ?? secretsRuntime!.prepareSecretsRuntimeSnapshot;
-        const startupPreflight =
-          activationParams.reason === "startup" || activationParams.reason === "restart-check";
-        const loadAuthStore = startupPreflight
-          ? (await loadAuthProfiles()).loadAuthProfileStoreWithoutExternalProfiles
-          : undefined;
         const prepared = await prepareRuntimeSecretsSnapshot({
           config: pruneSkippedStartupSecretSurfaces(config),
           ...(loadAuthStore ? { loadAuthStore } : {}),

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -54,7 +54,7 @@ import type { RuntimeEnv } from "../runtime.js";
 import {
   clearSecretsRuntimeSnapshot,
   getActiveSecretsRuntimeSnapshot,
-} from "../secrets/runtime.js";
+} from "../secrets/runtime-state.js";
 import { createAuthRateLimiter, type AuthRateLimiter } from "./auth-rate-limit.js";
 import { resolveGatewayAuth } from "./auth.js";
 import { ADMIN_SCOPE } from "./method-scopes.js";
@@ -552,7 +552,6 @@ export async function startGatewayServer(
   }
   const startupTrace = createGatewayStartupTrace();
   const startupConfigModulePromise = import("./server-startup-config.js");
-  const reloadHandlersModulePromise = import("./server-reload-handlers.js");
   let startupPluginsModulePromise: Promise<typeof import("./server-startup-plugins.js")> | null =
     null;
   const loadStartupPluginsModule = () => {
@@ -1553,7 +1552,7 @@ export async function startGatewayServer(
     postAttachRuntimeReturned = true;
     activateScheduledServicesWhenReady();
 
-    const { startManagedGatewayConfigReloader } = await reloadHandlersModulePromise;
+    const { startManagedGatewayConfigReloader } = await import("./server-reload-handlers.js");
     runtimeState.configReloader = startManagedGatewayConfigReloader({
       minimalTestGateway,
       initialConfig: cfgAtStart,

--- a/src/secrets/runtime-command-secrets.ts
+++ b/src/secrets/runtime-command-secrets.ts
@@ -9,9 +9,12 @@ import {
   type CommandSecretAssignment,
 } from "./command-config.js";
 import { getPath, setPathExistingStrict } from "./path-utils.js";
+import {
+  getActiveSecretsRuntimeEnv,
+  getActiveSecretsRuntimeSnapshot,
+} from "./runtime-state.js";
 import { createResolverContext } from "./runtime-shared.js";
 import { resolveRuntimeWebTools } from "./runtime-web-tools.js";
-import { getActiveSecretsRuntimeEnv, getActiveSecretsRuntimeSnapshot } from "./runtime.js";
 import { discoverConfigSecretTargetsByIds } from "./target-registry.js";
 
 export type { CommandSecretAssignment } from "./command-config.js";

--- a/src/secrets/runtime-fast-path.ts
+++ b/src/secrets/runtime-fast-path.ts
@@ -1,0 +1,306 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+import {
+  listAgentIds,
+  resolveAgentDir,
+  resolveDefaultAgentDir,
+} from "../agents/agent-scope-config.js";
+import {
+  AUTH_PROFILE_FILENAME,
+  AUTH_STATE_FILENAME,
+  LEGACY_AUTH_FILENAME,
+} from "../agents/auth-profiles/path-constants.js";
+import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
+import { resolveOAuthPath } from "../config/paths.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { coerceSecretRef } from "../config/types.secrets.js";
+import type { PluginOrigin } from "../plugins/plugin-origin.types.js";
+import { resolveUserPath } from "../utils.js";
+import type {
+  PreparedSecretsRuntimeSnapshot,
+  SecretsRuntimeRefreshContext,
+} from "./runtime-state.js";
+import type { RuntimeWebToolsMetadata } from "./runtime-web-tools.types.js";
+
+const RUNTIME_PATH_ENV_KEYS = [
+  "HOME",
+  "USERPROFILE",
+  "HOMEDRIVE",
+  "HOMEPATH",
+  "OPENCLAW_HOME",
+  "OPENCLAW_STATE_DIR",
+  "OPENCLAW_CONFIG_PATH",
+  "OPENCLAW_AGENT_DIR",
+  "PI_CODING_AGENT_DIR",
+  "OPENCLAW_TEST_FAST",
+] as const;
+
+export function mergeSecretsRuntimeEnv(
+  env: NodeJS.ProcessEnv | Record<string, string | undefined> | undefined,
+): Record<string, string | undefined> {
+  const merged = { ...(env ?? process.env) } as Record<string, string | undefined>;
+  for (const key of RUNTIME_PATH_ENV_KEYS) {
+    if (merged[key] !== undefined) {
+      continue;
+    }
+    const processValue = process.env[key];
+    if (processValue !== undefined) {
+      merged[key] = processValue;
+    }
+  }
+  return merged;
+}
+
+export function collectCandidateAgentDirs(
+  config: OpenClawConfig,
+  env: NodeJS.ProcessEnv | Record<string, string | undefined> = process.env,
+): string[] {
+  const dirs = new Set<string>();
+  dirs.add(resolveUserPath(resolveDefaultAgentDir(config, env), env));
+  for (const agentId of listAgentIds(config)) {
+    dirs.add(resolveUserPath(resolveAgentDir(config, agentId, env), env));
+  }
+  return [...dirs];
+}
+
+export function resolveRefreshAgentDirs(
+  config: OpenClawConfig,
+  context: SecretsRuntimeRefreshContext,
+): string[] {
+  const configDerived = collectCandidateAgentDirs(config, context.env);
+  if (!context.explicitAgentDirs || context.explicitAgentDirs.length === 0) {
+    return configDerived;
+  }
+  return [...new Set([...context.explicitAgentDirs, ...configDerived])];
+}
+
+function resolveCandidateAgentDirs(params: {
+  config: OpenClawConfig;
+  env: NodeJS.ProcessEnv | Record<string, string | undefined>;
+  agentDirs?: string[];
+}): string[] {
+  return params.agentDirs?.length
+    ? [...new Set(params.agentDirs.map((entry) => resolveUserPath(entry, params.env)))]
+    : collectCandidateAgentDirs(params.config, params.env);
+}
+
+function hasCandidateAuthProfileStoreSource(agentDir: string): boolean {
+  return (
+    existsSync(path.join(agentDir, AUTH_PROFILE_FILENAME)) ||
+    existsSync(path.join(agentDir, AUTH_STATE_FILENAME)) ||
+    existsSync(path.join(agentDir, LEGACY_AUTH_FILENAME))
+  );
+}
+
+export function hasCandidateAuthProfileStoreSources(params: {
+  config: OpenClawConfig;
+  env: NodeJS.ProcessEnv | Record<string, string | undefined>;
+  agentDirs?: string[];
+}): boolean {
+  const candidateDirs = resolveCandidateAgentDirs(params);
+  const mainAgentDir = resolveUserPath(resolveDefaultAgentDir({}, params.env), params.env);
+  return (
+    candidateDirs.some((agentDir) => hasCandidateAuthProfileStoreSource(agentDir)) ||
+    hasCandidateAuthProfileStoreSource(mainAgentDir) ||
+    existsSync(resolveOAuthPath(params.env as NodeJS.ProcessEnv))
+  );
+}
+
+export function createEmptyRuntimeWebToolsMetadata(): RuntimeWebToolsMetadata {
+  return {
+    search: {
+      providerSource: "none",
+      diagnostics: [],
+    },
+    fetch: {
+      providerSource: "none",
+      diagnostics: [],
+    },
+    diagnostics: [],
+  };
+}
+
+const WEB_FETCH_CREDENTIAL_FIELD_NAMES = new Set(["apikey", "key", "token", "secret", "password"]);
+
+function hasCredentialBearingWebFetchValue(
+  value: unknown,
+  defaults: Parameters<typeof coerceSecretRef>[1],
+  seen = new WeakSet<object>(),
+): boolean {
+  if (coerceSecretRef(value, defaults)) {
+    return true;
+  }
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  if (seen.has(value)) {
+    return false;
+  }
+  seen.add(value);
+  if (Array.isArray(value)) {
+    return value.some((entry) => hasCredentialBearingWebFetchValue(entry, defaults, seen));
+  }
+  return Object.entries(value as Record<string, unknown>).some(([rawKey, entry]) => {
+    const key = rawKey.toLowerCase();
+    if (WEB_FETCH_CREDENTIAL_FIELD_NAMES.has(key) && entry != null && entry !== "") {
+      return true;
+    }
+    return hasCredentialBearingWebFetchValue(entry, defaults, seen);
+  });
+}
+
+function hasActiveRuntimeWebFetchProviderSurface(
+  fetch: unknown,
+  defaults: Parameters<typeof coerceSecretRef>[1],
+): boolean {
+  if (!fetch || typeof fetch !== "object" || Array.isArray(fetch)) {
+    return false;
+  }
+  const fetchConfig = fetch as Record<string, unknown>;
+  if (fetchConfig.enabled === false) {
+    return false;
+  }
+  if (typeof fetchConfig.provider === "string" && fetchConfig.provider.trim()) {
+    return true;
+  }
+  return hasCredentialBearingWebFetchValue(fetchConfig, defaults);
+}
+
+function hasRuntimeWebToolConfigSurface(config: OpenClawConfig): boolean {
+  const web = config.tools?.web;
+  const defaults = config.secrets?.defaults;
+  const fetchExplicitlyDisabled =
+    web &&
+    typeof web === "object" &&
+    !Array.isArray(web) &&
+    typeof (web as Record<string, unknown>).fetch === "object" &&
+    (web as { fetch?: { enabled?: unknown } }).fetch?.enabled === false;
+  if (web && typeof web === "object" && !Array.isArray(web)) {
+    const webRecord = web as Record<string, unknown>;
+    if ("search" in webRecord || "x_search" in webRecord) {
+      return true;
+    }
+    if (
+      "fetch" in webRecord &&
+      hasActiveRuntimeWebFetchProviderSurface(webRecord.fetch, defaults)
+    ) {
+      return true;
+    }
+  }
+  const entries = config.plugins?.entries;
+  if (!entries || typeof entries !== "object" || Array.isArray(entries)) {
+    return false;
+  }
+  return Object.values(entries).some((entry) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      return false;
+    }
+    const pluginConfig = (entry as { config?: unknown }).config;
+    return (
+      !!pluginConfig &&
+      typeof pluginConfig === "object" &&
+      !Array.isArray(pluginConfig) &&
+      ("webSearch" in pluginConfig || (!fetchExplicitlyDisabled && "webFetch" in pluginConfig))
+    );
+  });
+}
+
+function hasSecretRefCandidate(
+  value: unknown,
+  defaults: Parameters<typeof coerceSecretRef>[1],
+  seen = new WeakSet<object>(),
+): boolean {
+  if (coerceSecretRef(value, defaults)) {
+    return true;
+  }
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  if (seen.has(value)) {
+    return false;
+  }
+  seen.add(value);
+  if (Array.isArray(value)) {
+    return value.some((entry) => hasSecretRefCandidate(entry, defaults, seen));
+  }
+  return Object.values(value as Record<string, unknown>).some((entry) =>
+    hasSecretRefCandidate(entry, defaults, seen),
+  );
+}
+
+export function canUseSecretsRuntimeFastPath(params: {
+  sourceConfig: OpenClawConfig;
+  authStores: Array<{ agentDir: string; store: AuthProfileStore }>;
+}): boolean {
+  if (hasRuntimeWebToolConfigSurface(params.sourceConfig)) {
+    return false;
+  }
+  const defaults = params.sourceConfig.secrets?.defaults;
+  if (hasSecretRefCandidate(params.sourceConfig, defaults)) {
+    return false;
+  }
+  return !params.authStores.some((entry) => hasSecretRefCandidate(entry.store, defaults));
+}
+
+export function prepareSecretsRuntimeFastPathSnapshot(params: {
+  config: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  agentDirs?: string[];
+  includeAuthStoreRefs?: boolean;
+  loadAuthStore?: (agentDir?: string) => AuthProfileStore;
+  loadablePluginOrigins?: ReadonlyMap<string, PluginOrigin>;
+}): {
+  snapshot: PreparedSecretsRuntimeSnapshot;
+  refreshContext: SecretsRuntimeRefreshContext;
+  usesAuthStoreFallback: boolean;
+} | null {
+  const runtimeEnv = mergeSecretsRuntimeEnv(params.env);
+  const sourceConfig = structuredClone(params.config);
+  const resolvedConfig = structuredClone(params.config);
+  const includeAuthStoreRefs = params.includeAuthStoreRefs ?? true;
+  const candidateDirs = resolveCandidateAgentDirs({
+    config: resolvedConfig,
+    env: runtimeEnv,
+    agentDirs: params.agentDirs,
+  });
+  let authStores: Array<{ agentDir: string; store: AuthProfileStore }> = [];
+  if (includeAuthStoreRefs) {
+    if (!params.loadAuthStore) {
+      if (
+        hasCandidateAuthProfileStoreSources({
+          config: resolvedConfig,
+          env: runtimeEnv,
+          agentDirs: candidateDirs,
+        })
+      ) {
+        return null;
+      }
+    } else {
+      const loadAuthStore = params.loadAuthStore;
+      authStores = candidateDirs.map((agentDir) => ({
+        agentDir,
+        store: structuredClone(loadAuthStore(agentDir)),
+      }));
+    }
+  }
+  if (!canUseSecretsRuntimeFastPath({ sourceConfig, authStores })) {
+    return null;
+  }
+  const snapshot = {
+    sourceConfig,
+    config: resolvedConfig,
+    authStores,
+    warnings: [],
+    webTools: createEmptyRuntimeWebToolsMetadata(),
+  };
+  return {
+    snapshot,
+    usesAuthStoreFallback: !params.loadAuthStore,
+    refreshContext: {
+      env: runtimeEnv,
+      explicitAgentDirs: params.agentDirs?.length ? [...candidateDirs] : null,
+      loadablePluginOrigins: params.loadablePluginOrigins ?? new Map<string, PluginOrigin>(),
+      ...(params.loadAuthStore ? { loadAuthStore: params.loadAuthStore } : {}),
+    },
+  };
+}

--- a/src/secrets/runtime-state.ts
+++ b/src/secrets/runtime-state.ts
@@ -1,0 +1,143 @@
+import {
+  clearRuntimeAuthProfileStoreSnapshots,
+  replaceRuntimeAuthProfileStoreSnapshots,
+} from "../agents/auth-profiles/runtime-snapshots.js";
+import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshotRefreshHandler,
+  type RuntimeConfigSnapshotRefreshHandler,
+} from "../config/runtime-snapshot.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginOrigin } from "../plugins/plugin-origin.types.js";
+import type { SecretResolverWarning } from "./runtime-shared.js";
+import {
+  clearActiveRuntimeWebToolsMetadata,
+  setActiveRuntimeWebToolsMetadata,
+} from "./runtime-web-tools-state.js";
+import type { RuntimeWebToolsMetadata } from "./runtime-web-tools.types.js";
+
+export type PreparedSecretsRuntimeSnapshot = {
+  sourceConfig: OpenClawConfig;
+  config: OpenClawConfig;
+  authStores: Array<{ agentDir: string; store: AuthProfileStore }>;
+  warnings: SecretResolverWarning[];
+  webTools: RuntimeWebToolsMetadata;
+};
+
+export type SecretsRuntimeRefreshContext = {
+  env: Record<string, string | undefined>;
+  explicitAgentDirs: string[] | null;
+  loadAuthStore?: (agentDir?: string) => AuthProfileStore;
+  loadablePluginOrigins: ReadonlyMap<string, PluginOrigin>;
+};
+
+let activeSnapshot: PreparedSecretsRuntimeSnapshot | null = null;
+let activeRefreshContext: SecretsRuntimeRefreshContext | null = null;
+const clearHooks = new Set<() => void>();
+const preparedSnapshotRefreshContext = new WeakMap<
+  PreparedSecretsRuntimeSnapshot,
+  SecretsRuntimeRefreshContext
+>();
+
+export function cloneSecretsRuntimeRefreshContext(
+  context: SecretsRuntimeRefreshContext,
+): SecretsRuntimeRefreshContext {
+  const cloned: SecretsRuntimeRefreshContext = {
+    env: { ...context.env },
+    explicitAgentDirs: context.explicitAgentDirs ? [...context.explicitAgentDirs] : null,
+    loadablePluginOrigins: new Map(context.loadablePluginOrigins),
+  };
+  if (context.loadAuthStore) {
+    cloned.loadAuthStore = context.loadAuthStore;
+  }
+  return cloned;
+}
+
+function cloneSnapshot(snapshot: PreparedSecretsRuntimeSnapshot): PreparedSecretsRuntimeSnapshot {
+  return {
+    sourceConfig: structuredClone(snapshot.sourceConfig),
+    config: structuredClone(snapshot.config),
+    authStores: snapshot.authStores.map((entry) => ({
+      agentDir: entry.agentDir,
+      store: structuredClone(entry.store),
+    })),
+    warnings: snapshot.warnings.map((warning) => ({ ...warning })),
+    webTools: structuredClone(snapshot.webTools),
+  };
+}
+
+export function setPreparedSecretsRuntimeSnapshotRefreshContext(
+  snapshot: PreparedSecretsRuntimeSnapshot,
+  context: SecretsRuntimeRefreshContext,
+): void {
+  preparedSnapshotRefreshContext.set(snapshot, cloneSecretsRuntimeRefreshContext(context));
+}
+
+export function getPreparedSecretsRuntimeSnapshotRefreshContext(
+  snapshot: PreparedSecretsRuntimeSnapshot,
+): SecretsRuntimeRefreshContext | null {
+  const context = preparedSnapshotRefreshContext.get(snapshot);
+  return context ? cloneSecretsRuntimeRefreshContext(context) : null;
+}
+
+export function getActiveSecretsRuntimeRefreshContext(): SecretsRuntimeRefreshContext | null {
+  return activeRefreshContext ? cloneSecretsRuntimeRefreshContext(activeRefreshContext) : null;
+}
+
+export function getActiveSecretsRuntimeEnv(): NodeJS.ProcessEnv {
+  return {
+    ...(activeRefreshContext?.env ?? process.env),
+  } as NodeJS.ProcessEnv;
+}
+
+export function registerSecretsRuntimeStateClearHook(clearHook: () => void): void {
+  clearHooks.add(clearHook);
+}
+
+export function activateSecretsRuntimeSnapshotState(params: {
+  snapshot: PreparedSecretsRuntimeSnapshot;
+  refreshContext: SecretsRuntimeRefreshContext | null;
+  refreshHandler: RuntimeConfigSnapshotRefreshHandler | null;
+}): void {
+  const next = cloneSnapshot(params.snapshot);
+  const nextRefreshContext = params.refreshContext
+    ? cloneSecretsRuntimeRefreshContext(params.refreshContext)
+    : null;
+  setRuntimeConfigSnapshot(next.config, next.sourceConfig);
+  replaceRuntimeAuthProfileStoreSnapshots(next.authStores);
+  activeSnapshot = next;
+  activeRefreshContext = nextRefreshContext;
+  if (nextRefreshContext) {
+    preparedSnapshotRefreshContext.set(next, cloneSecretsRuntimeRefreshContext(nextRefreshContext));
+  }
+  setActiveRuntimeWebToolsMetadata(next.webTools);
+  setRuntimeConfigSnapshotRefreshHandler(params.refreshHandler);
+}
+
+export function getActiveSecretsRuntimeSnapshot(): PreparedSecretsRuntimeSnapshot | null {
+  if (!activeSnapshot) {
+    return null;
+  }
+  const snapshot = cloneSnapshot(activeSnapshot);
+  if (activeRefreshContext) {
+    preparedSnapshotRefreshContext.set(
+      snapshot,
+      cloneSecretsRuntimeRefreshContext(activeRefreshContext),
+    );
+  }
+  return snapshot;
+}
+
+export function clearSecretsRuntimeSnapshot(): void {
+  activeSnapshot = null;
+  activeRefreshContext = null;
+  clearActiveRuntimeWebToolsMetadata();
+  setRuntimeConfigSnapshotRefreshHandler(null);
+  clearRuntimeConfigSnapshot();
+  clearRuntimeAuthProfileStoreSnapshots();
+  for (const clearHook of clearHooks) {
+    clearHook();
+  }
+}

--- a/src/secrets/runtime.fast-path.test.ts
+++ b/src/secrets/runtime.fast-path.test.ts
@@ -1,6 +1,12 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveDefaultAgentDir } from "../agents/agent-scope-config.js";
 import type { AuthProfileStore } from "../agents/auth-profiles.js";
+import { AUTH_PROFILE_FILENAME } from "../agents/auth-profiles/path-constants.js";
 import { clearConfigCache, clearRuntimeConfigSnapshot } from "../config/config.js";
+import { resolveOAuthPath } from "../config/paths.js";
 import { createEmptyPluginRegistry } from "../plugins/registry.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { clearSecretsRuntimeSnapshot } from "./runtime.js";
@@ -46,6 +52,23 @@ function requireGatewayAuth(
     throw new Error("expected gateway auth config");
   }
   return auth;
+}
+
+function writeAuthProfileStore(agentDir: string): void {
+  mkdirSync(agentDir, { recursive: true });
+  writeFileSync(
+    path.join(agentDir, AUTH_PROFILE_FILENAME),
+    `${JSON.stringify({
+      version: 1,
+      profiles: {
+        "openai:default": {
+          type: "api_key",
+          provider: "openai",
+          key: "sk-test",
+        },
+      },
+    })}\n`,
+  );
 }
 
 describe("secrets runtime fast path", () => {
@@ -178,5 +201,101 @@ describe("secrets runtime fast path", () => {
     });
 
     expect(resolveRuntimeWebToolsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    {
+      name: "oauth credentials file",
+      setup: (env: NodeJS.ProcessEnv, _mainAgentDir: string, _agentDir: string) => {
+        const credentialsPath = resolveOAuthPath(env);
+        mkdirSync(path.dirname(credentialsPath), { recursive: true });
+        writeFileSync(
+          credentialsPath,
+          `${JSON.stringify({
+            "openai-codex": {
+              access: "access-token",
+              refresh: "refresh-token",
+              expires: Date.now() + 60_000,
+            },
+          })}\n`,
+        );
+      },
+    },
+    {
+      name: "inherited main auth store",
+      setup: (_env: NodeJS.ProcessEnv, mainAgentDir: string, _agentDir: string) => {
+        writeAuthProfileStore(mainAgentDir);
+      },
+    },
+  ])("skips the startup-only fast path when $name exists", async ({ setup }) => {
+    const { prepareSecretsRuntimeFastPathSnapshot } = await import("./runtime-fast-path.js");
+    const root = mkdtempSync(path.join(tmpdir(), "openclaw-runtime-fast-path-"));
+    const env: NodeJS.ProcessEnv = {
+      HOME: root,
+      OPENCLAW_STATE_DIR: root,
+    };
+    const mainAgentDir = resolveDefaultAgentDir({}, env);
+    const agentDir = path.join(root, "custom-agent");
+    mkdirSync(agentDir, { recursive: true });
+    setup(env, mainAgentDir, agentDir);
+
+    try {
+      const snapshot = prepareSecretsRuntimeFastPathSnapshot({
+        config: asConfig({
+          agents: {
+            list: [{ id: "default", agentDir }],
+          },
+        }),
+        env,
+      });
+
+      expect(snapshot).toBeNull();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("refreshes startup-only fast-path snapshots from persisted auth stores after startup", async () => {
+    const { prepareSecretsRuntimeFastPathSnapshot } = await import("./runtime-fast-path.js");
+    const { activateSecretsRuntimeSnapshotState, getActiveSecretsRuntimeSnapshot } =
+      await import("./runtime-state.js");
+    const { refreshActiveSecretsRuntimeSnapshot } = await import("./runtime.js");
+    const root = mkdtempSync(path.join(tmpdir(), "openclaw-runtime-fast-path-refresh-"));
+    const env: NodeJS.ProcessEnv = {
+      HOME: root,
+      OPENCLAW_STATE_DIR: root,
+    };
+    const agentDir = path.join(root, "custom-agent");
+    mkdirSync(agentDir, { recursive: true });
+
+    try {
+      const fastPath = prepareSecretsRuntimeFastPathSnapshot({
+        config: asConfig({
+          agents: {
+            list: [{ id: "default", agentDir }],
+          },
+        }),
+        env,
+      });
+
+      expect(fastPath).not.toBeNull();
+      activateSecretsRuntimeSnapshotState({
+        snapshot: fastPath!.snapshot,
+        refreshContext: fastPath!.refreshContext,
+        refreshHandler: null,
+      });
+      writeAuthProfileStore(agentDir);
+
+      await expect(refreshActiveSecretsRuntimeSnapshot()).resolves.toBe(true);
+      const active = getActiveSecretsRuntimeSnapshot();
+      expect(active?.authStores[0]?.agentDir).toBe(agentDir);
+      expect(active?.authStores[0]?.store.profiles["openai:default"]).toMatchObject({
+        type: "api_key",
+        provider: "openai",
+        key: "sk-test",
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/src/secrets/runtime.ts
+++ b/src/secrets/runtime.ts
@@ -1,70 +1,40 @@
-import {
-  listAgentIds,
-  resolveAgentDir,
-  resolveAgentWorkspaceDir,
-  resolveDefaultAgentDir,
-  resolveDefaultAgentId,
-} from "../agents/agent-scope.js";
+import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope-config.js";
 import {
   clearRuntimeAuthProfileStoreSnapshots,
   loadAuthProfileStoreForSecretsRuntime,
   loadAuthProfileStoreWithoutExternalProfiles,
-  replaceRuntimeAuthProfileStoreSnapshots,
 } from "../agents/auth-profiles.js";
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
-import {
-  clearRuntimeConfigSnapshot,
-  setRuntimeConfigSnapshotRefreshHandler,
-  setRuntimeConfigSnapshot,
-  type OpenClawConfig,
-} from "../config/config.js";
-import { coerceSecretRef } from "../config/types.secrets.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginOrigin } from "../plugins/plugin-origin.types.js";
 import { resolveUserPath } from "../utils.js";
-import { type SecretResolverWarning } from "./runtime-shared.js";
 import {
-  clearActiveRuntimeWebToolsMetadata,
-  getActiveRuntimeWebToolsMetadata as getActiveRuntimeWebToolsMetadataFromState,
-  setActiveRuntimeWebToolsMetadata,
-} from "./runtime-web-tools-state.js";
-import type { RuntimeWebToolsMetadata } from "./runtime-web-tools.js";
+  canUseSecretsRuntimeFastPath,
+  collectCandidateAgentDirs,
+  createEmptyRuntimeWebToolsMetadata,
+  mergeSecretsRuntimeEnv,
+  resolveRefreshAgentDirs,
+} from "./runtime-fast-path.js";
+import {
+  activateSecretsRuntimeSnapshotState,
+  clearSecretsRuntimeSnapshot as clearSecretsRuntimeSnapshotState,
+  getActiveSecretsRuntimeEnv as getActiveSecretsRuntimeEnvState,
+  getActiveSecretsRuntimeRefreshContext,
+  getActiveSecretsRuntimeSnapshot as getActiveSecretsRuntimeSnapshotState,
+  getPreparedSecretsRuntimeSnapshotRefreshContext,
+  registerSecretsRuntimeStateClearHook,
+  setPreparedSecretsRuntimeSnapshotRefreshContext,
+  type PreparedSecretsRuntimeSnapshot,
+  type SecretsRuntimeRefreshContext,
+} from "./runtime-state.js";
+import { getActiveRuntimeWebToolsMetadata as getActiveRuntimeWebToolsMetadataFromState } from "./runtime-web-tools-state.js";
+import type { RuntimeWebToolsMetadata } from "./runtime-web-tools.types.js";
 
 export type { SecretResolverWarning } from "./runtime-shared.js";
+export type { PreparedSecretsRuntimeSnapshot } from "./runtime-state.js";
 
-export type PreparedSecretsRuntimeSnapshot = {
-  sourceConfig: OpenClawConfig;
-  config: OpenClawConfig;
-  authStores: Array<{ agentDir: string; store: AuthProfileStore }>;
-  warnings: SecretResolverWarning[];
-  webTools: RuntimeWebToolsMetadata;
-};
+registerSecretsRuntimeStateClearHook(clearRuntimeAuthProfileStoreSnapshots);
 
-type SecretsRuntimeRefreshContext = {
-  env: Record<string, string | undefined>;
-  explicitAgentDirs: string[] | null;
-  loadAuthStore: (agentDir?: string) => AuthProfileStore;
-  loadablePluginOrigins: ReadonlyMap<string, PluginOrigin>;
-};
-
-const RUNTIME_PATH_ENV_KEYS = [
-  "HOME",
-  "USERPROFILE",
-  "HOMEDRIVE",
-  "HOMEPATH",
-  "OPENCLAW_HOME",
-  "OPENCLAW_STATE_DIR",
-  "OPENCLAW_CONFIG_PATH",
-  "OPENCLAW_AGENT_DIR",
-  "PI_CODING_AGENT_DIR",
-  "OPENCLAW_TEST_FAST",
-] as const;
-
-let activeSnapshot: PreparedSecretsRuntimeSnapshot | null = null;
-let activeRefreshContext: SecretsRuntimeRefreshContext | null = null;
-const preparedSnapshotRefreshContext = new WeakMap<
-  PreparedSecretsRuntimeSnapshot,
-  SecretsRuntimeRefreshContext
->();
 let runtimeManifestPromise: Promise<typeof import("./runtime-manifest.runtime.js")> | null = null;
 let runtimePreparePromise: Promise<typeof import("./runtime-prepare.runtime.js")> | null = null;
 
@@ -76,60 +46,6 @@ function loadRuntimeManifestHelpers() {
 function loadRuntimePrepareHelpers() {
   runtimePreparePromise ??= import("./runtime-prepare.runtime.js");
   return runtimePreparePromise;
-}
-
-function cloneSnapshot(snapshot: PreparedSecretsRuntimeSnapshot): PreparedSecretsRuntimeSnapshot {
-  return {
-    sourceConfig: structuredClone(snapshot.sourceConfig),
-    config: structuredClone(snapshot.config),
-    authStores: snapshot.authStores.map((entry) => ({
-      agentDir: entry.agentDir,
-      store: structuredClone(entry.store),
-    })),
-    warnings: snapshot.warnings.map((warning) => ({ ...warning })),
-    webTools: structuredClone(snapshot.webTools),
-  };
-}
-
-function cloneRefreshContext(context: SecretsRuntimeRefreshContext): SecretsRuntimeRefreshContext {
-  return {
-    env: { ...context.env },
-    explicitAgentDirs: context.explicitAgentDirs ? [...context.explicitAgentDirs] : null,
-    loadAuthStore: context.loadAuthStore,
-    loadablePluginOrigins: new Map(context.loadablePluginOrigins),
-  };
-}
-
-function clearActiveSecretsRuntimeState(): void {
-  activeSnapshot = null;
-  activeRefreshContext = null;
-  clearActiveRuntimeWebToolsMetadata();
-  setRuntimeConfigSnapshotRefreshHandler(null);
-  clearRuntimeConfigSnapshot();
-  clearRuntimeAuthProfileStoreSnapshots();
-}
-
-function collectCandidateAgentDirs(
-  config: OpenClawConfig,
-  env: NodeJS.ProcessEnv = process.env,
-): string[] {
-  const dirs = new Set<string>();
-  dirs.add(resolveUserPath(resolveDefaultAgentDir(config, env), env));
-  for (const agentId of listAgentIds(config)) {
-    dirs.add(resolveUserPath(resolveAgentDir(config, agentId, env), env));
-  }
-  return [...dirs];
-}
-
-function resolveRefreshAgentDirs(
-  config: OpenClawConfig,
-  context: SecretsRuntimeRefreshContext,
-): string[] {
-  const configDerived = collectCandidateAgentDirs(config, context.env);
-  if (!context.explicitAgentDirs || context.explicitAgentDirs.length === 0) {
-    return configDerived;
-  }
-  return [...new Set([...context.explicitAgentDirs, ...configDerived])];
 }
 
 async function resolveLoadablePluginOrigins(params: {
@@ -150,22 +66,6 @@ async function resolveLoadablePluginOrigins(params: {
   return listPluginOriginsFromMetadataSnapshot(snapshot);
 }
 
-function mergeSecretsRuntimeEnv(
-  env: NodeJS.ProcessEnv | Record<string, string | undefined> | undefined,
-): Record<string, string | undefined> {
-  const merged = { ...(env ?? process.env) } as Record<string, string | undefined>;
-  for (const key of RUNTIME_PATH_ENV_KEYS) {
-    if (merged[key] !== undefined) {
-      continue;
-    }
-    const processValue = process.env[key];
-    if (processValue !== undefined) {
-      merged[key] = processValue;
-    }
-  }
-  return merged;
-}
-
 function hasConfiguredPluginEntries(config: OpenClawConfig): boolean {
   const entries = config.plugins?.entries;
   return (
@@ -184,142 +84,6 @@ function hasConfiguredChannelEntries(config: OpenClawConfig): boolean {
     !Array.isArray(channels) &&
     Object.keys(channels).some((channelId) => channelId !== "defaults")
   );
-}
-
-function createEmptyRuntimeWebToolsMetadata(): RuntimeWebToolsMetadata {
-  return {
-    search: {
-      providerSource: "none",
-      diagnostics: [],
-    },
-    fetch: {
-      providerSource: "none",
-      diagnostics: [],
-    },
-    diagnostics: [],
-  };
-}
-
-const WEB_FETCH_CREDENTIAL_FIELD_NAMES = new Set(["apikey", "key", "token", "secret", "password"]);
-
-function hasCredentialBearingWebFetchValue(
-  value: unknown,
-  defaults: Parameters<typeof coerceSecretRef>[1],
-  seen = new WeakSet<object>(),
-): boolean {
-  if (coerceSecretRef(value, defaults)) {
-    return true;
-  }
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  if (seen.has(value)) {
-    return false;
-  }
-  seen.add(value);
-  if (Array.isArray(value)) {
-    return value.some((entry) => hasCredentialBearingWebFetchValue(entry, defaults, seen));
-  }
-  return Object.entries(value as Record<string, unknown>).some(([rawKey, entry]) => {
-    const key = rawKey.toLowerCase();
-    if (WEB_FETCH_CREDENTIAL_FIELD_NAMES.has(key) && entry != null && entry !== "") {
-      return true;
-    }
-    return hasCredentialBearingWebFetchValue(entry, defaults, seen);
-  });
-}
-
-function hasActiveRuntimeWebFetchProviderSurface(
-  fetch: unknown,
-  defaults: Parameters<typeof coerceSecretRef>[1],
-): boolean {
-  if (!fetch || typeof fetch !== "object" || Array.isArray(fetch)) {
-    return false;
-  }
-  const fetchConfig = fetch as Record<string, unknown>;
-  if (fetchConfig.enabled === false) {
-    return false;
-  }
-  if (typeof fetchConfig.provider === "string" && fetchConfig.provider.trim()) {
-    return true;
-  }
-  return hasCredentialBearingWebFetchValue(fetchConfig, defaults);
-}
-
-function hasRuntimeWebToolConfigSurface(config: OpenClawConfig): boolean {
-  const web = config.tools?.web;
-  const defaults = config.secrets?.defaults;
-  const fetchExplicitlyDisabled =
-    web &&
-    typeof web === "object" &&
-    !Array.isArray(web) &&
-    typeof (web as Record<string, unknown>).fetch === "object" &&
-    (web as { fetch?: { enabled?: unknown } }).fetch?.enabled === false;
-  if (web && typeof web === "object" && !Array.isArray(web)) {
-    const webRecord = web as Record<string, unknown>;
-    if ("search" in webRecord || "x_search" in webRecord) {
-      return true;
-    }
-    if (
-      "fetch" in webRecord &&
-      hasActiveRuntimeWebFetchProviderSurface(webRecord.fetch, defaults)
-    ) {
-      return true;
-    }
-  }
-  const entries = config.plugins?.entries;
-  if (!entries || typeof entries !== "object" || Array.isArray(entries)) {
-    return false;
-  }
-  return Object.values(entries).some((entry) => {
-    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
-      return false;
-    }
-    const pluginConfig = (entry as { config?: unknown }).config;
-    return (
-      !!pluginConfig &&
-      typeof pluginConfig === "object" &&
-      !Array.isArray(pluginConfig) &&
-      ("webSearch" in pluginConfig || (!fetchExplicitlyDisabled && "webFetch" in pluginConfig))
-    );
-  });
-}
-
-function hasSecretRefCandidate(
-  value: unknown,
-  defaults: Parameters<typeof coerceSecretRef>[1],
-  seen = new WeakSet<object>(),
-): boolean {
-  if (coerceSecretRef(value, defaults)) {
-    return true;
-  }
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  if (seen.has(value)) {
-    return false;
-  }
-  seen.add(value);
-  if (Array.isArray(value)) {
-    return value.some((entry) => hasSecretRefCandidate(entry, defaults, seen));
-  }
-  return Object.values(value as Record<string, unknown>).some((entry) =>
-    hasSecretRefCandidate(entry, defaults, seen),
-  );
-}
-
-function canUseSecretsRuntimeFastPath(params: {
-  sourceConfig: OpenClawConfig;
-  authStores: Array<{ agentDir: string; store: AuthProfileStore }>;
-}): boolean {
-  if (hasRuntimeWebToolConfigSurface(params.sourceConfig)) {
-    return false;
-  }
-  const defaults = params.sourceConfig.secrets?.defaults;
-  if (hasSecretRefCandidate(params.sourceConfig, defaults)) {
-    return false;
-  }
-  return !params.authStores.some((entry) => hasSecretRefCandidate(entry.store, defaults));
 }
 
 export async function prepareSecretsRuntimeSnapshot(params: {
@@ -356,7 +120,7 @@ export async function prepareSecretsRuntimeSnapshot(params: {
       warnings: [],
       webTools: createEmptyRuntimeWebToolsMetadata(),
     };
-    preparedSnapshotRefreshContext.set(snapshot, {
+    setPreparedSecretsRuntimeSnapshotRefreshContext(snapshot, {
       env: runtimeEnv,
       explicitAgentDirs: params.agentDirs?.length ? [...candidateDirs] : null,
       loadAuthStore: fastPathLoadAuthStore,
@@ -430,7 +194,7 @@ export async function prepareSecretsRuntimeSnapshot(params: {
       context,
     }),
   };
-  preparedSnapshotRefreshContext.set(snapshot, {
+  setPreparedSecretsRuntimeSnapshotRefreshContext(snapshot, {
     env: runtimeEnv,
     explicitAgentDirs: params.agentDirs?.length ? [...candidateDirs] : null,
     loadAuthStore: params.loadAuthStore ?? loadAuthProfileStoreForSecretsRuntime,
@@ -440,40 +204,43 @@ export async function prepareSecretsRuntimeSnapshot(params: {
 }
 
 export function activateSecretsRuntimeSnapshot(snapshot: PreparedSecretsRuntimeSnapshot): void {
-  const next = cloneSnapshot(snapshot);
   const refreshContext =
-    preparedSnapshotRefreshContext.get(snapshot) ??
-    activeRefreshContext ??
+    getPreparedSecretsRuntimeSnapshotRefreshContext(snapshot) ??
+    getActiveSecretsRuntimeRefreshContext() ??
     ({
       env: { ...process.env } as Record<string, string | undefined>,
       explicitAgentDirs: null,
       loadAuthStore: loadAuthProfileStoreForSecretsRuntime,
       loadablePluginOrigins: new Map<string, PluginOrigin>(),
     } satisfies SecretsRuntimeRefreshContext);
-  setRuntimeConfigSnapshot(next.config, next.sourceConfig);
-  replaceRuntimeAuthProfileStoreSnapshots(next.authStores);
-  activeSnapshot = next;
-  activeRefreshContext = cloneRefreshContext(refreshContext);
-  setActiveRuntimeWebToolsMetadata(next.webTools);
-  setRuntimeConfigSnapshotRefreshHandler({
-    refresh: async ({ sourceConfig }) => {
-      if (!activeSnapshot || !activeRefreshContext) {
-        return false;
-      }
-      const refreshed = await prepareSecretsRuntimeSnapshot({
-        config: sourceConfig,
-        env: activeRefreshContext.env,
-        agentDirs: resolveRefreshAgentDirs(sourceConfig, activeRefreshContext),
-        loadAuthStore: activeRefreshContext.loadAuthStore,
-        loadablePluginOrigins: activeRefreshContext.loadablePluginOrigins,
-      });
-      activateSecretsRuntimeSnapshot(refreshed);
-      return true;
+  activateSecretsRuntimeSnapshotState({
+    snapshot,
+    refreshContext,
+    refreshHandler: {
+      refresh: async ({ sourceConfig }) => {
+        const activeRefreshContext = getActiveSecretsRuntimeRefreshContext();
+        if (!getActiveSecretsRuntimeSnapshotState() || !activeRefreshContext) {
+          return false;
+        }
+        const refreshed = await prepareSecretsRuntimeSnapshot({
+          config: sourceConfig,
+          env: activeRefreshContext.env,
+          agentDirs: resolveRefreshAgentDirs(sourceConfig, activeRefreshContext),
+          loadablePluginOrigins: activeRefreshContext.loadablePluginOrigins,
+          ...(activeRefreshContext.loadAuthStore
+            ? { loadAuthStore: activeRefreshContext.loadAuthStore }
+            : {}),
+        });
+        activateSecretsRuntimeSnapshot(refreshed);
+        return true;
+      },
     },
   });
 }
 
 export async function refreshActiveSecretsRuntimeSnapshot(): Promise<boolean> {
+  const activeSnapshot = getActiveSecretsRuntimeSnapshotState();
+  const activeRefreshContext = getActiveSecretsRuntimeRefreshContext();
   if (!activeSnapshot || !activeRefreshContext) {
     return false;
   }
@@ -481,28 +248,21 @@ export async function refreshActiveSecretsRuntimeSnapshot(): Promise<boolean> {
     config: activeSnapshot.sourceConfig,
     env: activeRefreshContext.env,
     agentDirs: resolveRefreshAgentDirs(activeSnapshot.sourceConfig, activeRefreshContext),
-    loadAuthStore: activeRefreshContext.loadAuthStore,
     loadablePluginOrigins: activeRefreshContext.loadablePluginOrigins,
+    ...(activeRefreshContext.loadAuthStore
+      ? { loadAuthStore: activeRefreshContext.loadAuthStore }
+      : {}),
   });
   activateSecretsRuntimeSnapshot(refreshed);
   return true;
 }
 
 export function getActiveSecretsRuntimeSnapshot(): PreparedSecretsRuntimeSnapshot | null {
-  if (!activeSnapshot) {
-    return null;
-  }
-  const snapshot = cloneSnapshot(activeSnapshot);
-  if (activeRefreshContext) {
-    preparedSnapshotRefreshContext.set(snapshot, cloneRefreshContext(activeRefreshContext));
-  }
-  return snapshot;
+  return getActiveSecretsRuntimeSnapshotState();
 }
 
 export function getActiveSecretsRuntimeEnv(): NodeJS.ProcessEnv {
-  return {
-    ...(activeRefreshContext?.env ?? process.env),
-  } as NodeJS.ProcessEnv;
+  return getActiveSecretsRuntimeEnvState();
 }
 
 export function getActiveRuntimeWebToolsMetadata(): RuntimeWebToolsMetadata | null {
@@ -510,5 +270,5 @@ export function getActiveRuntimeWebToolsMetadata(): RuntimeWebToolsMetadata | nu
 }
 
 export function clearSecretsRuntimeSnapshot(): void {
-  clearActiveSecretsRuntimeState();
+  clearSecretsRuntimeSnapshotState();
 }


### PR DESCRIPTION
## Summary

- Problem: Gateway startup imported the full secrets runtime even when config/auth surfaces had no SecretRefs or persisted auth sources.
- Why it matters: That makes the common plain-config startup path pay resolver/runtime import cost that is only needed for richer secrets/auth cases.
- What changed: Split active runtime state into `src/secrets/runtime-state.ts`, added a guarded startup-only fast path in `src/secrets/runtime-fast-path.ts`, and wired gateway/web-tool/config-write readers to the lightweight state module.
- What did NOT change (scope boundary): No config schema, plugin API, channel contract, provider contract, migration behavior, or live credential format changes.

This is 19 files and over 500 insertions because the state extraction, gateway activation wiring, and regression coverage need to be reviewed together; there are no unrelated product/docs/changelog changes in this PR.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Gateway startup can activate a lightweight secrets runtime snapshot for the plain no-SecretRef config/auth path and still bring the Gateway to ready state.
- Real environment tested: Local OpenClaw source checkout in a Codex worktree on macOS, Node 24.14.0, isolated temporary `HOME`/`OPENCLAW_HOME`, `--dev --reset --auth none`, no live provider/channel credentials.
- Exact steps or command run after this patch:
  - `HOME=[temp-home] OPENCLAW_HOME=[temp-home] OPENCLAW_CONFIG_PATH=[temp-home]/.openclaw-dev/openclaw.json pnpm openclaw gateway run --dev --reset --auth none --port 51099 --ws-log compact`
  - After `[gateway] ready`, send `SIGTERM` to stop the foreground gateway.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
  ```text
  $ HOME=[temp-home] OPENCLAW_HOME=[temp-home] OPENCLAW_CONFIG_PATH=[temp-home]/.openclaw-dev/openclaw.json pnpm openclaw gateway run --dev --reset --auth none --port 51099 --ws-log compact
  $ node scripts/run-node.mjs gateway run --dev --reset --auth none --port 51099 --ws-log compact
  2026-05-17T16:20:13.461+08:00 Dev config ready: $OPENCLAW_HOME/.openclaw-dev/openclaw.json
  2026-05-17T16:20:13.466+08:00 Dev workspace ready: $OPENCLAW_HOME/.openclaw/workspace-dev
  2026-05-17T16:20:13.470+08:00 [gateway] loading configuration…
  2026-05-17T16:20:13.536+08:00 [gateway] resolving authentication…
  2026-05-17T16:20:13.543+08:00 [gateway] auth mode=none explicitly configured; all gateway connections are unauthenticated.
  2026-05-17T16:20:13.546+08:00 [gateway] starting...
  2026-05-17T16:20:15.638+08:00 [gateway] starting HTTP server...
  2026-05-17T16:20:16.908+08:00 [gateway] http server listening (9 plugins: acpx, bonjour, browser, canvas, device-pair, file-transfer, memory-core, phone-control, talk-voice; 3.4s)
  2026-05-17T16:20:17.457+08:00 [gateway] ready
  2026-05-17T16:20:32.792+08:00 [gateway] signal SIGTERM received
  2026-05-17T16:20:32.870+08:00 [shutdown] completed cleanly in 62ms
  ```
- Observed result after fix: The isolated dev Gateway started with plain no-SecretRef auth/config state, reached `[gateway] ready`, and shut down cleanly after SIGTERM.
- What was not tested: Real provider/channel credentials, broad Testbox or `pnpm check:changed`, and GitHub Actions CI.
- Before evidence (optional but encouraged): Startup import-boundary tests showed the old path imported full secrets runtime on the plain no-SecretRef startup path.

## Root Cause (if applicable)

- Root cause: Gateway startup read active secrets runtime state through `src/secrets/runtime.ts`, coupling plain startup to resolver/runtime modules that are only needed for SecretRefs, web provider credentials, persisted auth stores, OAuth credentials, or plugin/channel resolver contracts.
- Missing detection / guardrail: Existing tests covered resolver behavior but not the import boundary for a plain startup config or the startup-only refresh context after auth store creation.
- Contributing context (if known): Active runtime state and full resolver loading lived behind the same module boundary.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/secrets/runtime.fast-path.test.ts`, `src/gateway/server-startup-config.secrets.test.ts`, `src/gateway/server-import-boundary.test.ts`, and affected web-tool/config shared-auth tests.
- Scenario the test should lock in: Plain no-SecretRef startup uses the lightweight fast path, while SecretRefs, explicit web provider auth, persisted auth profile files, OAuth credentials, inherited main auth stores, and later refreshes fall back to or preserve full auth-loading behavior.
- Why this is the smallest reliable guardrail: These tests exercise the startup decision boundary and the consumers that read active runtime state without requiring live credentials or broad gateway E2E setup.
- Existing test that already covers this (if any): Existing resolver/auth tests covered full-runtime behavior but not this startup import boundary.
- If no new test is added, why not: N/A; regression tests were added.

## User-visible / Behavior Changes

Gateway startup can avoid loading the full secrets runtime for plain no-SecretRef config/auth state. Behavior should otherwise remain unchanged.

## Diagram (if applicable)

```text
Before:
[gateway startup] -> [src/secrets/runtime.ts] -> [full resolver/runtime imports]

After:
[gateway startup] -> [startup fast-path guard]
                  -> [plain config/auth] -> [lightweight runtime state]
                  -> [SecretRefs/auth stores/OAuth/web providers] -> [full runtime]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: Secrets/auth startup selection changed. The fast path is conservative and falls back to the full resolver whenever persisted auth files, OAuth credentials, inherited main auth, SecretRefs, or web provider surfaces are present; tests cover those fallback cases. No secrets are printed.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Local OpenClaw source checkout in a Codex worktree, Node 24.14.0
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): No live provider/channel credentials used

### Steps

1. Run `git diff --check upstream/main..HEAD`.
2. Run `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/secrets/runtime.fast-path.test.ts src/gateway/server-startup-config.secrets.test.ts src/gateway/server-import-boundary.test.ts src/secrets/runtime-command-secrets.test.ts src/agents/tools/web-tool-runtime-context.test.ts src/agents/tools/web-search.late-bind.test.ts src/agents/tools/web-fetch.provider-fallback.test.ts src/agents/tools/web-tools.enabled-defaults.test.ts src/gateway/server-methods/config.shared-auth.test.ts`.
3. Run `codex review --base upstream/main`.

### Expected

- Plain no-SecretRef startup path does not import the full secrets runtime.
- SecretRef, web provider, persisted auth profile, OAuth credential, inherited main-auth-store, and post-startup refresh paths continue to use or preserve full auth loading.
- Targeted tests and review pass.

### Actual

- `git diff --check` passed.
- Targeted Vitest passed 14 files and 93 tests.
- Final Codex review found no introduced correctness issue.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Before/after evidence is represented by the startup import-boundary and fast-path regression tests added in this PR, plus the passing targeted Vitest run listed above.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: No-SecretRef startup fast path, SecretRef fallback, explicit web provider fallback, persisted auth profile fallback, OAuth credential fallback, inherited main auth store fallback, startup-only refresh after auth store creation, stale web-tool/config shared-auth mocks.
- Edge cases checked: Empty/plain auth state does not install a refresh context that permanently ignores later disk auth stores; full resolver path remains available when the fast path is unsafe.
- What you did **not** verify: Real provider/channel credentials; broad Testbox or `pnpm check:changed`; GitHub Actions CI.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No GitHub review conversations existed when this PR body was updated.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: The startup fast path could incorrectly skip full auth loading for a non-plain auth source.
  - Mitigation: Guarded fallback checks cover SecretRefs, web provider surfaces, persisted auth profile files, OAuth credentials, and inherited main auth stores.
- Risk: Later refreshes could keep using startup-only empty auth state.
  - Mitigation: The refresh context does not install a dummy auth-store loader; regression coverage verifies auth stores written after startup are read on refresh.
