### PR TITLE
fix(usage): normalize provider aliases in control ui

### DIFF
--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { normalizeProviderId } from "../../agents/provider-id.js";
 import {
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
@@ -59,6 +60,13 @@ const COST_USAGE_CACHE_TTL_MS = 30_000;
 const COST_USAGE_CACHE_MAX = 256;
 const SESSIONS_USAGE_CACHE_READ_CONCURRENCY = 12;
 const DAY_MS = 24 * 60 * 60 * 1000;
+
+const normalizeUsageProviderId = (provider?: string): string | undefined => {
+  if (!provider) {
+    return undefined;
+  }
+  return normalizeProviderId(provider);
+};
 
 type DateRange = { startMs: number; endMs: number };
 type DateInterpretation =
@@ -632,11 +640,12 @@ function mergeModelUsage(
     target.missingCostEntries += source.missingCostEntries;
   };
   for (const entry of [...(left ?? []), ...(right ?? [])]) {
-    const key = `${entry.provider ?? "unknown"}::${entry.model ?? "unknown"}`;
+    const provider = normalizeUsageProviderId(entry.provider);
+    const key = `${provider ?? "unknown"}::${entry.model ?? "unknown"}`;
     const existing =
       map.get(key) ??
       ({
-        provider: entry.provider,
+        provider,
         model: entry.model,
         count: 0,
         totals: createEmptySessionCostSummary(),
@@ -701,10 +710,11 @@ function mergeDailyModelRows(
 ): SessionCostSummary["dailyModelUsage"] {
   const map = new Map<string, NonNullable<SessionCostSummary["dailyModelUsage"]>[number]>();
   for (const row of [...(left ?? []), ...(right ?? [])]) {
-    const key = `${row.date}:${row.provider ?? "unknown"}:${row.model ?? "unknown"}`;
+    const provider = normalizeUsageProviderId(row.provider);
+    const key = `${row.date}:${provider ?? "unknown"}:${row.model ?? "unknown"}`;
     const existing = map.get(key);
     if (!existing) {
-      map.set(key, { ...row });
+      map.set(key, { ...row, provider });
       continue;
     }
     existing.tokens += row.tokens;
@@ -1214,11 +1224,12 @@ export const usageHandlers: GatewayRequestHandlers = {
 
         if (usage.modelUsage) {
           for (const entry of usage.modelUsage) {
-            const modelKey = `${entry.provider ?? "unknown"}::${entry.model ?? "unknown"}`;
+            const provider = normalizeUsageProviderId(entry.provider);
+            const modelKey = `${provider ?? "unknown"}::${entry.model ?? "unknown"}`;
             const modelExisting =
               byModelMap.get(modelKey) ??
               ({
-                provider: entry.provider,
+                provider,
                 model: entry.model,
                 count: 0,
                 totals: emptyTotals(),
@@ -1227,11 +1238,11 @@ export const usageHandlers: GatewayRequestHandlers = {
             mergeTotals(modelExisting.totals, entry.totals);
             byModelMap.set(modelKey, modelExisting);
 
-            const providerKey = entry.provider ?? "unknown";
+            const providerKey = provider ?? "unknown";
             const providerExisting =
               byProviderMap.get(providerKey) ??
               ({
-                provider: entry.provider,
+                provider,
                 model: undefined,
                 count: 0,
                 totals: emptyTotals(),
@@ -1247,12 +1258,13 @@ export const usageHandlers: GatewayRequestHandlers = {
 
         if (usage.dailyModelUsage) {
           for (const entry of usage.dailyModelUsage) {
-            const key = `${entry.date}::${entry.provider ?? "unknown"}::${entry.model ?? "unknown"}`;
+            const provider = normalizeUsageProviderId(entry.provider);
+            const key = `${entry.date}::${provider ?? "unknown"}::${entry.model ?? "unknown"}`;
             const existing =
               modelDailyMap.get(key) ??
               ({
                 date: entry.date,
-                provider: entry.provider,
+                provider,
                 model: entry.model,
                 tokens: 0,
                 cost: 0,

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import readline from "node:readline";
+import { normalizeProviderId } from "../agents/provider-id.js";
 import type { NormalizedUsage, UsageLike } from "../agents/usage.js";
 import { normalizeUsage } from "../agents/usage.js";
 import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
@@ -67,6 +68,13 @@ export type {
   UsageCacheStatus,
 } from "./session-cost-usage.types.js";
 
+const normalizeUsageProviderId = (provider?: string): string | undefined => {
+  if (!provider) {
+    return undefined;
+  }
+  return normalizeProviderId(provider);
+};
+
 const emptyTotals = (): CostUsageTotals => ({
   input: 0,
   output: 0,
@@ -81,7 +89,7 @@ const emptyTotals = (): CostUsageTotals => ({
   missingCostEntries: 0,
 });
 
-const USAGE_COST_CACHE_VERSION = 3;
+const USAGE_COST_CACHE_VERSION = 4;
 const USAGE_COST_CACHE_FILE = ".usage-cost-cache.json";
 const USAGE_COST_CACHE_LOCK_WRITE_GRACE_MS = 10_000;
 const logger = createSubsystemLogger("usage-cost-cache");
@@ -717,12 +725,13 @@ function buildSessionCostSummaryFromCacheEntry(params: {
       utcQuarterHourTokenMap.set(quarterBucket.key, utcQuarterHourToken);
 
       if (entry.provider || entry.model) {
-        const dailyModelKey = `${dayKey}::${entry.provider ?? "unknown"}::${entry.model ?? "unknown"}`;
+        const provider = normalizeUsageProviderId(entry.provider);
+        const dailyModelKey = `${dayKey}::${provider ?? "unknown"}::${entry.model ?? "unknown"}`;
         const dailyModel =
           dailyModelUsageMap.get(dailyModelKey) ??
           ({
             date: dayKey,
-            provider: entry.provider,
+            provider,
             model: entry.model,
             tokens: 0,
             cost: 0,
@@ -736,11 +745,12 @@ function buildSessionCostSummaryFromCacheEntry(params: {
     }
 
     if (entry.provider || entry.model) {
-      const modelKey = `${entry.provider ?? "unknown"}::${entry.model ?? "unknown"}`;
+      const provider = normalizeUsageProviderId(entry.provider);
+      const modelKey = `${provider ?? "unknown"}::${entry.model ?? "unknown"}`;
       const modelUsage =
         modelUsageMap.get(modelKey) ??
         ({
-          provider: entry.provider,
+          provider,
           model: entry.model,
           count: 0,
           totals: emptyTotals(),

--- a/ui/src/ui/usage-helpers.node.test.ts
+++ b/ui/src/ui/usage-helpers.node.test.ts
@@ -1,6 +1,11 @@
 // @vitest-environment node
 import { describe, expect, it } from "vitest";
-import { extractQueryTerms, filterSessionsByQuery, parseToolSummary } from "./usage-helpers.ts";
+import {
+  extractQueryTerms,
+  filterSessionsByQuery,
+  normalizeUsageProviderId,
+  parseToolSummary,
+} from "./usage-helpers.ts";
 
 function requireFirstTool(tools: Array<[string, number]>): [string, number] {
   const tool = tools[0];
@@ -31,6 +36,26 @@ describe("usage-helpers", () => {
     const b = { key: "b", label: "b", usage: { totalTokens: 5, totalCost: 0 } };
     expect(filterSessionsByQuery([a, b], "minTokens:10").sessions).toEqual([a]);
     expect(filterSessionsByQuery([a, b], "maxTokens:10").sessions).toEqual([b]);
+  });
+
+  it("matches provider filters against canonical provider aliases", () => {
+    const session = {
+      key: "alias-provider",
+      label: "Alias provider",
+      modelProvider: "z-ai",
+      providerOverride: "aws-bedrock",
+      usage: {
+        totalTokens: 10,
+        totalCost: 0,
+        modelUsage: [{ provider: "z.ai", model: "glm-4.5", count: 1, totals: { totalTokens: 10 } }],
+      },
+    };
+
+    expect(normalizeUsageProviderId("z-ai")).toBe("zai");
+    expect(normalizeUsageProviderId("aws-bedrock")).toBe("amazon-bedrock");
+    expect(filterSessionsByQuery([session], "provider:zai").sessions).toEqual([session]);
+    expect(filterSessionsByQuery([session], "provider:z.ai").sessions).toEqual([session]);
+    expect(filterSessionsByQuery([session], "provider:amazon-bedrock").sessions).toEqual([session]);
   });
 
   it("warns on unknown keys and invalid numbers", () => {

--- a/ui/src/ui/usage-helpers.ts
+++ b/ui/src/ui/usage-helpers.ts
@@ -1,3 +1,6 @@
+import { normalizeProviderId } from "../../../src/agents/provider-id.js";
+import { normalizeLowercaseStringOrEmpty } from "./string-coerce.ts";
+
 export type UsageQueryTerm = {
   key?: string;
   value: string;
@@ -52,6 +55,13 @@ const QUERY_KEYS = new Set([
 ]);
 
 const normalizeQueryText = (value: string): string => normalizeLowercaseStringOrEmpty(value);
+
+export const normalizeUsageProviderId = (provider?: string | null): string => {
+  if (!provider) {
+    return "";
+  }
+  return normalizeProviderId(provider);
+};
 
 const globToRegex = (pattern: string): RegExp => {
   const escaped = pattern
@@ -109,17 +119,17 @@ const getSessionText = (session: UsageSessionQueryTarget): string[] => {
 const getSessionProviders = (session: UsageSessionQueryTarget): string[] => {
   const providers = new Set<string>();
   if (session.modelProvider) {
-    providers.add(normalizeLowercaseStringOrEmpty(session.modelProvider));
+    providers.add(normalizeUsageProviderId(session.modelProvider));
   }
   if (session.providerOverride) {
-    providers.add(normalizeLowercaseStringOrEmpty(session.providerOverride));
+    providers.add(normalizeUsageProviderId(session.providerOverride));
   }
   if (session.origin?.provider) {
-    providers.add(normalizeLowercaseStringOrEmpty(session.origin.provider));
+    providers.add(normalizeUsageProviderId(session.origin.provider));
   }
   for (const entry of session.usage?.modelUsage ?? []) {
     if (entry.provider) {
-      providers.add(normalizeLowercaseStringOrEmpty(entry.provider));
+      providers.add(normalizeUsageProviderId(entry.provider));
     }
   }
   return Array.from(providers);
@@ -158,8 +168,10 @@ const matchesUsageQuery = (session: UsageSessionQueryTarget, term: UsageQueryTer
       return normalizeLowercaseStringOrEmpty(session.channel).includes(value);
     case "chat":
       return normalizeLowercaseStringOrEmpty(session.chatType).includes(value);
-    case "provider":
-      return getSessionProviders(session).some((provider) => provider.includes(value));
+    case "provider": {
+      const providerValue = normalizeUsageProviderId(term.value ?? "");
+      return getSessionProviders(session).some((provider) => provider.includes(providerValue));
+    }
     case "model":
       return getSessionModels(session).some((model) => model.includes(value));
     case "tool":
@@ -318,4 +330,3 @@ export function parseToolSummary(content: string) {
     cleanContent: nonToolLines.join("\n").trim(),
   };
 }
-import { normalizeLowercaseStringOrEmpty } from "./string-coerce.ts";

--- a/ui/src/ui/views/usage-metrics.test.ts
+++ b/ui/src/ui/views/usage-metrics.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, afterEach } from "vitest";
 import {
+  buildAggregatesFromSessions,
   buildPeakErrorHours,
   buildUsageMosaicStats,
   getHourAndWeekdayForUtcQuarterBucket,
@@ -262,6 +263,77 @@ describe("buildPeakErrorHours", () => {
     expect(peakErrorSummaries(result)).toStrictEqual([
       { value: "30.00%", sub: "3 errors · 10 msgs" },
     ]);
+  });
+});
+
+describe("buildAggregatesFromSessions", () => {
+  it("groups provider aliases under their canonical provider ids", () => {
+    const sessions = [
+      {
+        key: "zai-a",
+        usage: {
+          totalTokens: 10,
+          totalCost: 0.01,
+          modelUsage: [
+            {
+              provider: "z-ai",
+              model: "glm-4.5",
+              count: 1,
+              totals: { totalTokens: 10, totalCost: 0.01 },
+            },
+          ],
+          dailyModelUsage: [
+            {
+              date: "2026-05-01",
+              provider: "z-ai",
+              model: "glm-4.5",
+              tokens: 10,
+              cost: 0.01,
+              count: 1,
+            },
+          ],
+        },
+      },
+      {
+        key: "zai-b",
+        usage: {
+          totalTokens: 20,
+          totalCost: 0.02,
+          modelUsage: [
+            {
+              provider: "z.ai",
+              model: "glm-4.5",
+              count: 1,
+              totals: { totalTokens: 20, totalCost: 0.02 },
+            },
+          ],
+          dailyModelUsage: [
+            {
+              date: "2026-05-01",
+              provider: "z.ai",
+              model: "glm-4.5",
+              tokens: 20,
+              cost: 0.02,
+              count: 1,
+            },
+          ],
+        },
+      },
+    ] as unknown as UsageSessionEntry[];
+
+    const result = buildAggregatesFromSessions(sessions);
+
+    expect(result.byProvider).toHaveLength(1);
+    expect(result.byProvider[0]?.provider).toBe("zai");
+    expect(result.byProvider[0]?.count).toBe(2);
+    expect(result.byProvider[0]?.totals.totalTokens).toBe(30);
+    expect(result.byModel).toHaveLength(1);
+    expect(result.byModel[0]?.provider).toBe("zai");
+    expect(result.byModel[0]?.count).toBe(2);
+    expect(result.dailyModelUsage).toHaveLength(1);
+    expect(result.dailyModelUsage[0]?.provider).toBe("zai");
+    expect(result.dailyModelUsage[0]?.tokens).toBe(30);
+    expect(result.dailyModelUsage[0]?.count).toBe(2);
   });
 });
 

--- a/ui/src/ui/views/usage-metrics.ts
+++ b/ui/src/ui/views/usage-metrics.ts
@@ -6,6 +6,7 @@ import {
 } from "../../../../src/shared/usage-aggregates.js";
 import { t } from "../../i18n/index.ts";
 import { normalizeLowercaseStringOrEmpty } from "../string-coerce.ts";
+import { normalizeUsageProviderId } from "../usage-helpers.ts";
 import { UsageSessionEntry, UsageTotals, UsageAggregates } from "./usageTypes.ts";
 
 const CHARS_PER_TOKEN = 4;
@@ -572,9 +573,10 @@ const buildAggregatesFromSessions = (
 
     if (usage.modelUsage) {
       for (const entry of usage.modelUsage) {
-        const modelKey = `${entry.provider ?? "unknown"}::${entry.model ?? "unknown"}`;
+        const provider = normalizeUsageProviderId(entry.provider);
+        const modelKey = `${provider || "unknown"}::${entry.model ?? "unknown"}`;
         const modelExisting = modelMap.get(modelKey) ?? {
-          provider: entry.provider,
+          provider: provider || undefined,
           model: entry.model,
           count: 0,
           totals: emptyUsageTotals(),
@@ -583,9 +585,9 @@ const buildAggregatesFromSessions = (
         mergeUsageTotals(modelExisting.totals, entry.totals);
         modelMap.set(modelKey, modelExisting);
 
-        const providerKey = entry.provider ?? "unknown";
+        const providerKey = provider || "unknown";
         const providerExisting = providerMap.get(providerKey) ?? {
-          provider: entry.provider,
+          provider: provider || undefined,
           model: undefined,
           count: 0,
           totals: emptyUsageTotals(),
@@ -638,10 +640,11 @@ const buildAggregatesFromSessions = (
     }
     mergeUsageDailyLatency(dailyLatencyMap, usage.dailyLatency);
     for (const day of usage.dailyModelUsage ?? []) {
-      const key = `${day.date}::${day.provider ?? "unknown"}::${day.model ?? "unknown"}`;
+      const provider = normalizeUsageProviderId(day.provider);
+      const key = `${day.date}::${provider || "unknown"}::${day.model ?? "unknown"}`;
       const existing = modelDailyMap.get(key) ?? {
         date: day.date,
-        provider: day.provider,
+        provider: provider || undefined,
         model: day.model,
         tokens: 0,
         cost: 0,

--- a/ui/src/ui/views/usage-query.node.test.ts
+++ b/ui/src/ui/views/usage-query.node.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import {
+  addQueryToken,
+  buildQuerySuggestions,
+  buildSessionsCsv,
+  removeQueryToken,
+} from "./usage-query.ts";
+import type { UsageAggregates, UsageSessionEntry } from "./usageTypes.ts";
+
+describe("usage-query provider canonicalization", () => {
+  it("uses canonical provider ids in usage CSV exports", () => {
+    const sessions = [
+      {
+        key: "s1",
+        label: "Session one",
+        modelProvider: "z-ai",
+        model: "glm-4.5",
+        usage: { totalTokens: 10, totalCost: 0.01 },
+      } as UsageSessionEntry,
+      {
+        key: "s2",
+        label: "Session two",
+        providerOverride: "aws-bedrock",
+        model: "claude-3.5",
+        usage: { totalTokens: 20, totalCost: 0.02 },
+      } as UsageSessionEntry,
+    ];
+
+    const csv = buildSessionsCsv(sessions);
+
+    expect(csv).toContain("zai");
+    expect(csv).toContain("amazon-bedrock");
+    expect(csv).not.toContain("z-ai");
+    expect(csv).not.toContain("aws-bedrock");
+  });
+
+  it("uses canonical provider ids for query suggestions and chip toggles", () => {
+    const sessions = [
+      { key: "s1", modelProvider: "z-ai", usage: { totalTokens: 10, totalCost: 0 } },
+      { key: "s2", providerOverride: "z.ai", usage: { totalTokens: 10, totalCost: 0 } },
+    ] as UsageSessionEntry[];
+    const aggregates = {
+      byProvider: [
+        { provider: "aws-bedrock", count: 1, totals: { totalTokens: 1, totalCost: 0 } },
+      ],
+      byModel: [],
+      tools: { tools: [] },
+    } as unknown as UsageAggregates;
+
+    expect(buildQuerySuggestions("provider:z", sessions, aggregates)).toEqual([
+      { label: "provider:zai", value: "provider:zai" },
+    ]);
+    expect(buildQuerySuggestions("provider:bedrock", sessions, aggregates)).toEqual([
+      { label: "provider:amazon-bedrock", value: "provider:amazon-bedrock" },
+    ]);
+    expect(addQueryToken("provider:z-ai ", "provider:zai")).toBe("provider:z-ai ");
+    expect(removeQueryToken("provider:z-ai model:glm ", "provider:zai")).toBe("model:glm ");
+  });
+});

--- a/ui/src/ui/views/usage-query.ts
+++ b/ui/src/ui/views/usage-query.ts
@@ -1,5 +1,5 @@
 import { normalizeLowercaseStringOrEmpty } from "../string-coerce.ts";
-import { extractQueryTerms } from "../usage-helpers.ts";
+import { extractQueryTerms, normalizeUsageProviderId } from "../usage-helpers.ts";
 import { CostDailyEntry, UsageAggregates, UsageSessionEntry } from "./usageTypes.ts";
 
 function downloadTextFile(filename: string, content: string, type = "text/plain") {
@@ -61,7 +61,7 @@ const buildSessionsCsv = (sessions: UsageSessionEntry[]): string => {
         session.label ?? "",
         session.agentId ?? "",
         session.channel ?? "",
-        session.modelProvider ?? session.providerOverride ?? "",
+        normalizeUsageProviderId(session.modelProvider ?? session.providerOverride),
         session.model ?? session.modelOverride ?? "",
         session.updatedAt ? new Date(session.updatedAt).toISOString() : "",
         usage?.durationMs ?? "",
@@ -140,7 +140,7 @@ const buildQuerySuggestions = (
     : ["", ""];
 
   const key = normalizeLowercaseStringOrEmpty(rawKey);
-  const value = normalizeLowercaseStringOrEmpty(rawValue);
+  const value = key === "provider" ? normalizeUsageProviderId(rawValue) : normalizeLowercaseStringOrEmpty(rawValue);
 
   const unique = (items: Array<string | undefined>): string[] => {
     const set = new Set<string>();
@@ -155,9 +155,9 @@ const buildQuerySuggestions = (
   const agents = unique(sessions.map((s) => s.agentId)).slice(0, 6);
   const channels = unique(sessions.map((s) => s.channel)).slice(0, 6);
   const providers = unique([
-    ...sessions.map((s) => s.modelProvider),
-    ...sessions.map((s) => s.providerOverride),
-    ...(aggregates?.byProvider.map((p) => p.provider) ?? []),
+    ...sessions.map((s) => normalizeUsageProviderId(s.modelProvider)),
+    ...sessions.map((s) => normalizeUsageProviderId(s.providerOverride)),
+    ...(aggregates?.byProvider.map((p) => normalizeUsageProviderId(p.provider)) ?? []),
   ]).slice(0, 6);
   const models = unique([
     ...sessions.map((s) => s.model),
@@ -238,12 +238,27 @@ const addQueryToken = (query: string, token: string): string => {
   const tokens = trimmed.split(/\s+/);
   const last = tokens[tokens.length - 1] ?? "";
   const tokenKey = token.includes(":") ? token.split(":")[0] : null;
+  const tokenValue = token.includes(":") ? token.slice(token.indexOf(":") + 1) : "";
   const lastKey = last.includes(":") ? last.split(":")[0] : null;
   if (last.endsWith(":") && tokenKey && lastKey === tokenKey) {
     tokens[tokens.length - 1] = token;
     return `${tokens.join(" ")} `;
   }
-  if (tokens.includes(token)) {
+  const hasEquivalentToken = tokens.some((entry) => {
+    if (entry === token) {
+      return true;
+    }
+    if (normalizeQueryText(tokenKey ?? "") !== "provider") {
+      return false;
+    }
+    const entryKey = entry.includes(":") ? entry.split(":")[0] : null;
+    if (normalizeQueryText(entryKey ?? "") !== "provider") {
+      return false;
+    }
+    const entryValue = entry.slice(entry.indexOf(":") + 1);
+    return normalizeUsageProviderId(entryValue) === normalizeUsageProviderId(tokenValue);
+  });
+  if (hasEquivalentToken) {
     return `${tokens.join(" ")} `;
   }
   return `${tokens.join(" ")} ${token} `;
@@ -251,7 +266,22 @@ const addQueryToken = (query: string, token: string): string => {
 
 const removeQueryToken = (query: string, token: string): string => {
   const tokens = query.trim().split(/\s+/).filter(Boolean);
-  const next = tokens.filter((entry) => entry !== token);
+  const tokenKey = token.includes(":") ? token.split(":")[0] : null;
+  const tokenValue = token.includes(":") ? token.slice(token.indexOf(":") + 1) : "";
+  const next = tokens.filter((entry) => {
+    if (entry === token) {
+      return false;
+    }
+    if (normalizeQueryText(tokenKey ?? "") !== "provider") {
+      return true;
+    }
+    const entryKey = entry.includes(":") ? entry.split(":")[0] : null;
+    if (normalizeQueryText(entryKey ?? "") !== "provider") {
+      return true;
+    }
+    const entryValue = entry.slice(entry.indexOf(":") + 1);
+    return normalizeUsageProviderId(entryValue) !== normalizeUsageProviderId(tokenValue);
+  });
   return next.length ? `${next.join(" ")} ` : "";
 };
 

--- a/ui/src/ui/views/usage-render-details.ts
+++ b/ui/src/ui/views/usage-render-details.ts
@@ -2,7 +2,7 @@ import { html, svg, nothing } from "lit";
 import { formatDurationCompact } from "../../../../src/infra/format-time/format-duration.ts";
 import { t } from "../../i18n/index.ts";
 import { normalizeLowercaseStringOrEmpty } from "../string-coerce.ts";
-import { parseToolSummary } from "../usage-helpers.ts";
+import { normalizeUsageProviderId, parseToolSummary } from "../usage-helpers.ts";
 import { charsToTokens, formatCost, formatTokens } from "./usage-metrics.ts";
 import { renderInsightList } from "./usage-render-overview.ts";
 import {
@@ -70,7 +70,7 @@ function renderSessionSummary(
     badges.push(`agent:${session.agentId}`);
   }
   if (session.modelProvider || session.providerOverride) {
-    badges.push(`provider:${session.modelProvider ?? session.providerOverride}`);
+    badges.push(`provider:${normalizeUsageProviderId(session.modelProvider ?? session.providerOverride)}`);
   }
   if (session.model) {
     badges.push(`model:${session.model}`);

--- a/ui/src/ui/views/usage-render-overview.ts
+++ b/ui/src/ui/views/usage-render-overview.ts
@@ -2,6 +2,7 @@ import { html, nothing } from "lit";
 import { formatDurationCompact } from "../../../../src/infra/format-time/format-duration.ts";
 import { t } from "../../i18n/index.ts";
 import { normalizeLowercaseStringOrEmpty } from "../string-coerce.ts";
+import { normalizeUsageProviderId } from "../usage-helpers.ts";
 import {
   formatCost,
   formatDayLabel,
@@ -544,7 +545,7 @@ function renderUsageInsights(
     sub: `${formatTokens(entry.totals.totalTokens)} · ${entry.count} ${t("usage.overview.messagesAbbrev")}`,
   }));
   const topProviders = aggregates.byProvider.slice(0, 5).map((entry) => ({
-    label: entry.provider ?? t("usage.common.unknown"),
+    label: normalizeUsageProviderId(entry.provider) || t("usage.common.unknown"),
     value: formatCost(entry.totals.totalCost),
     sub: `${formatTokens(entry.totals.totalTokens)} · ${entry.count} ${t("usage.overview.messagesAbbrev")}`,
   }));
@@ -728,7 +729,7 @@ function renderSessionsCard(
       parts.push(`agent:${s.agentId}`);
     }
     if (showColumn("provider") && (s.modelProvider || s.providerOverride)) {
-      parts.push(`provider:${s.modelProvider ?? s.providerOverride}`);
+      parts.push(`provider:${normalizeUsageProviderId(s.modelProvider ?? s.providerOverride)}`);
     }
     if (showColumn("model") && s.model) {
       parts.push(`model:${s.model}`);

--- a/ui/src/ui/views/usage.ts
+++ b/ui/src/ui/views/usage.ts
@@ -1,7 +1,11 @@
 import { html, nothing } from "lit";
 import { t } from "../../i18n/index.ts";
 import { getUsageCacheRefreshTitle } from "../usage-cache-status.ts";
-import { extractQueryTerms, filterSessionsByQuery } from "../usage-helpers.ts";
+import {
+  extractQueryTerms,
+  filterSessionsByQuery,
+  normalizeUsageProviderId,
+} from "../usage-helpers.ts";
 import {
   buildAggregatesFromSessions,
   buildPeakErrorHours,
@@ -192,7 +196,7 @@ export function renderUsage(props: UsageProps) {
     const normalized = normalizeQueryText(key);
     return queryTerms
       .filter((term) => normalizeQueryText(term.key ?? "") === normalized)
-      .map((term) => term.value)
+      .map((term) => (normalized === "provider" ? normalizeUsageProviderId(term.value) : term.value))
       .filter(Boolean);
   };
   const unique = (items: Array<string | undefined>) => {
@@ -207,9 +211,9 @@ export function renderUsage(props: UsageProps) {
   const agentOptions = unique(sortedSessions.map((s) => s.agentId)).slice(0, 12);
   const channelOptions = unique(sortedSessions.map((s) => s.channel)).slice(0, 12);
   const providerOptions = unique([
-    ...sortedSessions.map((s) => s.modelProvider),
-    ...sortedSessions.map((s) => s.providerOverride),
-    ...(data.aggregates?.byProvider.map((entry) => entry.provider) ?? []),
+    ...sortedSessions.map((s) => normalizeUsageProviderId(s.modelProvider)),
+    ...sortedSessions.map((s) => normalizeUsageProviderId(s.providerOverride)),
+    ...(data.aggregates?.byProvider.map((entry) => normalizeUsageProviderId(entry.provider)) ?? []),
   ]).slice(0, 12);
   const modelOptions = unique([
     ...sortedSessions.map((s) => s.model),
@@ -680,7 +684,10 @@ export function renderUsage(props: UsageProps) {
             ? html`
                 <div class="usage-query-chips">
                   ${queryTerms.map((term) => {
-                    const label = term.raw;
+                    const label =
+                      normalizeQueryText(term.key ?? "") === "provider"
+                        ? `provider:${normalizeUsageProviderId(term.value)}`
+                        : term.raw;
                     return html`
                       <span class="usage-query-chip">
                         ${label}


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- Canonicalize usage provider ids with the existing `normalizeProviderId()` helper before they become usage/cache/API/UI aggregate keys.
- Normalize Control UI usage provider display paths: filters, query suggestions, CSV export, chips, overview rows, details badges, and client-side aggregates.
- Add focused regressions for `z-ai`/`z.ai` -> `zai` and `aws-bedrock` -> `amazon-bedrock` behavior.

## Test Plan
- `node proof-source-probe.mjs`
- Full Vitest/TypeScript suites were not run locally because this API-only workspace is not a full checkout and has no project `node_modules`; the local `tsc` shim reports that TypeScript is not installed. The PR relies on CI for the full repository checks.

## Real behavior proof

Behavior or issue addressed: Control UI usage provider display and related usage aggregates should use normalized provider ids instead of leaking original config aliases such as `z-ai`, `z.ai`, or `aws-bedrock`.

Real environment tested: API-only source workspace at `/tmp/openclaw-main-47840` based on the current `openclaw/openclaw` main source subset, using Node.js to inspect the actual patched TypeScript files and regression tests.

Exact steps or command run after this patch: `node proof-source-probe.mjs`

Evidence after fix:
```text
$ node proof-source-probe.mjs
PASS provider normalizer maps z-ai/z.ai to zai
PASS provider normalizer maps aws-bedrock to amazon-bedrock
PASS infra imports provider normalizer
PASS infra bumps usage cache version for canonical aggregate keys
PASS infra normalizes daily model aggregate keys
PASS infra normalizes model usage aggregate keys
PASS gateway imports provider normalizer
PASS gateway normalizes merged model usage rows
PASS gateway normalizes merged daily model rows
PASS gateway normalizes response byModel/byProvider aggregation
PASS gateway normalizes response daily model aggregation
PASS ui helper imports provider normalizer
PASS ui helper exports normalizeUsageProviderId
PASS ui helper normalizes metadata providers for filters
PASS ui helper matches provider filters canonically
PASS usage query exports canonical provider CSV
PASS usage query canonicalizes provider suggestions
PASS usage query canonicalizes add/remove provider token equivalence
PASS usage filter options canonicalize provider ids
PASS usage selected provider chips are displayed canonically
PASS usage metrics canonicalizes provider aggregate keys
PASS usage metrics canonicalizes daily model aggregate keys
PASS usage overview renders canonical provider labels
PASS usage details renders canonical provider badges
PASS usage helper regression covers alias matching
PASS usage query regression covers CSV/suggestions/token canonicalization
PASS usage metrics regression covers alias aggregate collapse
All source-level proof checks passed for OpenClaw #47840 provider canonicalization.
```

Observed result after fix: The source-level probe verifies that `z-ai`/`z.ai` canonicalize to `zai`, `aws-bedrock` canonicalizes to `amazon-bedrock`, server/API/UI aggregate keys call the normalizer, visible UI provider labels/badges use canonical values, and tests cover the alias regressions.

What was not tested: Full repository Vitest/TypeScript execution in this API-only workspace; the full project checkout and `node_modules` are unavailable locally, so CI is expected to run the repository test matrix.

## Risk/Notes
- Cache version is bumped so previously cached raw-provider usage aggregate keys are rebuilt.
- The change only normalizes provider identifiers at usage aggregation/display/query seams; it does not change provider routing or model selection behavior.
- This is a Draft PR pending upstream CI.

Fixes #47840
