### PR TITLE
feat: add simple tool plugin authoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 - Skills: add a meme-maker skill for curated template search, local SVG/PNG rendering, Imgflip hosted rendering, and Know Your Meme provenance links.
 - Agents/tools: shorten built-in tool descriptions and schema hints across media, messaging, sessions, cron, Gateway, web, image/PDF, TTS, nodes, and plan tools while preserving routing guardrails.
 - Skills: add node inspector debugging, fused diagram generation, and throwaway spike workflow skills.
+- CLI/plugins: add `defineToolPlugin` plus `openclaw plugins build`, `validate`, and `init` for typed simple tool plugins with generated manifest metadata, optional tool declarations, and context factories.
 - Proxy: support HTTPS managed forward-proxy endpoints and scoped `proxy.tls.caFile` CA trust for proxy endpoint TLS. (#79171) Thanks @jesse-merhi.
 - QA-Lab: add first-hour 20-turn and optional 100-turn runtime parity scenarios, with tier metadata for standard and soak QA gates. (#80323) Thanks @100yenadmin.
 - QA-Lab: add a live-only Codex Pi-shaped Read vocabulary canary so runtime parity catches native workspace-read prompt compatibility drift. (#80323) Thanks @100yenadmin.

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-be07626349862f372f4674118440eb65046b94f96306299a8e485920b0842507  plugin-sdk-api-baseline.json
-c2921821a5e913d5329e0df199a7fb726b5a9771a28c0ed55bb6b36d70cdb7e7  plugin-sdk-api-baseline.jsonl
+01ca0f76d382abbd2ffc8f8cc447528f7242be47295d04a7c86465637a14e6ae  plugin-sdk-api-baseline.json
+9f8c361b4a6dab528497d80e5bb34a58ff41630a62659af2dc9fe370609f4d55  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-01ca0f76d382abbd2ffc8f8cc447528f7242be47295d04a7c86465637a14e6ae  plugin-sdk-api-baseline.json
-9f8c361b4a6dab528497d80e5bb34a58ff41630a62659af2dc9fe370609f4d55  plugin-sdk-api-baseline.jsonl
+701ff598b929acfe779b728fe5660aac13e317526117baad80eef6bd1c5663c3  plugin-sdk-api-baseline.json
+4bb4bf89bb568ece9c8adbb0126f77cabc33698003190f272d23a2266d6bff84  plugin-sdk-api-baseline.jsonl

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -652,6 +652,18 @@
     "target": "插件 SDK"
   },
   {
+    "source": "Tool plugins",
+    "target": "工具插件"
+  },
+  {
+    "source": "Plugin SDK subpaths",
+    "target": "插件 SDK 子路径"
+  },
+  {
+    "source": "Plugins CLI",
+    "target": "插件 CLI"
+  },
+  {
     "source": "Plugins",
     "target": "插件"
   },

--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -1,7 +1,8 @@
 ---
-summary: "CLI reference for `openclaw plugins` (list, install, marketplace, uninstall, enable/disable, doctor)"
+summary: "CLI reference for `openclaw plugins` (init, build, validate, list, install, marketplace, uninstall, enable/disable, doctor)"
 read_when:
   - You want to install or manage Gateway plugins or compatible bundles
+  - You want to scaffold or validate a simple tool plugin
   - You want to debug plugin load failures
 title: "Plugins"
 sidebarTitle: "Plugins"
@@ -53,6 +54,11 @@ openclaw plugins update <id-or-npm-spec>
 openclaw plugins update --all
 openclaw plugins marketplace list <marketplace>
 openclaw plugins marketplace list <marketplace> --json
+openclaw plugins init <id>
+openclaw plugins init <id> --directory ./my-plugin --name "My Plugin"
+openclaw plugins build --entry ./dist/index.js
+openclaw plugins build --entry ./dist/index.js --check
+openclaw plugins validate --entry ./dist/index.js
 ```
 
 For slow install, inspect, uninstall, or registry-refresh investigation, run the
@@ -70,6 +76,27 @@ Native OpenClaw plugins must ship `openclaw.plugin.json` with an inline JSON Sch
 
 `plugins list` shows `Format: openclaw` or `Format: bundle`. Verbose list/info output also shows the bundle subtype (`codex`, `claude`, or `cursor`) plus detected bundle capabilities.
 </Note>
+
+### Author
+
+```bash
+openclaw plugins init stock-quotes --name "Stock Quotes"
+cd stock-quotes
+npm run plugin:build
+npm run plugin:validate
+```
+
+`plugins init` creates a minimal TypeScript tool plugin that uses
+`defineToolPlugin`. `plugins build` imports that entry, reads its static tool
+metadata, writes `openclaw.plugin.json`, and keeps `package.json`
+`openclaw.extensions` aligned. `plugins validate` checks that the generated
+manifest, package metadata, and current entry export still agree.
+
+The scaffold writes TypeScript source but generates metadata from the built
+`./dist/index.js` entry so the workflow also works with the published CLI. Use
+`--entry <path>` when the entry is not the default package entry. Use
+`plugins build --check` in CI to fail when generated metadata is stale without
+rewriting files.
 
 ### Install
 

--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -90,7 +90,8 @@ npm run plugin:validate
 `defineToolPlugin`. `plugins build` imports that entry, reads its static tool
 metadata, writes `openclaw.plugin.json`, and keeps `package.json`
 `openclaw.extensions` aligned. `plugins validate` checks that the generated
-manifest, package metadata, and current entry export still agree.
+manifest, package metadata, and current entry export still agree. See
+[Tool Plugins](/plugins/tool-plugins) for the full authoring workflow.
 
 The scaffold writes TypeScript source but generates metadata from the built
 `./dist/index.js` entry so the workflow also works with the published CLI. Use

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1220,6 +1220,7 @@
                 "group": "Building plugins",
                 "pages": [
                   "plugins/building-plugins",
+                  "plugins/tool-plugins",
                   "plugins/sdk-channel-plugins",
                   "plugins/sdk-provider-plugins",
                   "plugins/cli-backend-plugins",

--- a/docs/plugins/building-plugins.md
+++ b/docs/plugins/building-plugins.md
@@ -97,10 +97,12 @@ and provider plugins have dedicated guides linked above.
 
     Every plugin needs a manifest, even with no config. Runtime-registered tools
     must be listed in `contracts.tools` so OpenClaw can discover the owning
-    plugin without loading every plugin runtime. Plugins should also declare
-    `activation.onStartup` intentionally. This example sets it to `true`. See
-    [Manifest](/plugins/manifest) for the full schema. The canonical ClawHub
-    publish snippets live in `docs/snippets/plugin-publish/`.
+    plugin without loading every plugin runtime. For simple tool-only plugins,
+    prefer `defineToolPlugin` plus `openclaw plugins build` so tool names and
+    the empty config schema are generated from one source of truth. Plugins
+    should also declare `activation.onStartup` intentionally. This example sets
+    it to `true`. See [Manifest](/plugins/manifest) for the full schema. The
+    canonical ClawHub publish snippets live in `docs/snippets/plugin-publish/`.
 
   </Step>
 
@@ -108,29 +110,49 @@ and provider plugins have dedicated guides linked above.
 
     ```typescript
     // index.ts
-    import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
-    import { Type } from "@sinclair/typebox";
+    import { Type } from "typebox";
+    import { defineToolPlugin } from "openclaw/plugin-sdk/tool-plugin";
 
-    export default definePluginEntry({
+    export default defineToolPlugin({
       id: "my-plugin",
       name: "My Plugin",
       description: "Adds a custom tool to OpenClaw",
-      register(api) {
-        api.registerTool({
+      tools: (tool) => [
+        tool({
           name: "my_tool",
           description: "Do a thing",
           parameters: Type.Object({ input: Type.String() }),
-          async execute(_id, params) {
-            return { content: [{ type: "text", text: `Got: ${params.input}` }] };
+          async execute({ input }) {
+            return { message: `Got: ${input}` };
           },
-        });
-      },
+        }),
+      ],
     });
     ```
 
-    `definePluginEntry` is for non-channel plugins. For channels, use
-    `defineChannelPluginEntry` - see [Channel Plugins](/plugins/sdk-channel-plugins).
-    For full entry point options, see [Entry Points](/plugins/sdk-entrypoints).
+    `defineToolPlugin` is for simple agent-tool plugins. For providers, hooks,
+    services, and other advanced non-channel plugins, use `definePluginEntry`.
+    For channels, use `defineChannelPluginEntry` - see
+    [Channel Plugins](/plugins/sdk-channel-plugins). For full entry point
+    options, see [Entry Points](/plugins/sdk-entrypoints).
+
+  </Step>
+
+  <Step title="Generate and validate metadata">
+
+    ```bash
+    npm run build
+    openclaw plugins build --entry ./dist/index.js
+    openclaw plugins validate --entry ./dist/index.js
+    ```
+
+    `openclaw plugins build` writes `openclaw.plugin.json` and keeps
+    `package.json` `openclaw.extensions` pointed at the entry module. For
+    published packages, point it at built JavaScript such as `./dist/index.js`.
+    The generated manifest is the cold-load contract that OpenClaw reads before
+    runtime import. `openclaw plugins validate` imports the entry only during
+    author validation and checks that the manifest and package metadata match
+    the static `defineToolPlugin` metadata.
 
   </Step>
 
@@ -374,7 +396,7 @@ reserved surfaces, not as the default pattern for new third-party plugins.
 
 <Check>**package.json** has correct `openclaw` metadata</Check>
 <Check>**openclaw.plugin.json** manifest is present and valid</Check>
-<Check>Entry point uses `defineChannelPluginEntry` or `definePluginEntry`</Check>
+<Check>Entry point uses `defineToolPlugin`, `defineChannelPluginEntry`, or `definePluginEntry`</Check>
 <Check>All imports use focused `plugin-sdk/<subpath>` paths</Check>
 <Check>Internal imports use local modules, not SDK self-imports</Check>
 <Check>Tests pass (`pnpm test -- <bundled-plugin-root>/my-plugin/`)</Check>

--- a/docs/plugins/building-plugins.md
+++ b/docs/plugins/building-plugins.md
@@ -253,6 +253,12 @@ See [Plugin hooks](/plugins/hooks) for examples and the hook reference.
 Tools are typed functions the LLM can call. They can be required (always
 available) or optional (user opt-in):
 
+For simple plugins that only own a fixed set of tools, prefer
+[`defineToolPlugin`](/plugins/tool-plugins). It generates manifest metadata and
+keeps `contracts.tools` aligned. Use the lower-level `api.registerTool(...)`
+surface when the plugin also owns channels, providers, hooks, services,
+commands, or fully dynamic tool registration.
+
 ```typescript
 register(api) {
   // Required tool - always available

--- a/docs/plugins/building-plugins.md
+++ b/docs/plugins/building-plugins.md
@@ -38,8 +38,11 @@ install from npm during the launch cutover.
   <Card title="CLI backend plugin" icon="terminal" href="/plugins/cli-backend-plugins">
     Map a local AI CLI into OpenClaw's text fallback runner
   </Card>
-  <Card title="Tool / hook plugin" icon="wrench" href="/plugins/hooks">
-    Register agent tools, event hooks, or services - continue below
+  <Card title="Tool plugin" icon="wrench" href="/plugins/tool-plugins">
+    Add simple typed agent tools with generated manifest metadata
+  </Card>
+  <Card title="Hook plugin" icon="plug" href="/plugins/hooks">
+    Register event hooks, services, or advanced runtime integrations
   </Card>
 </CardGroup>
 
@@ -53,6 +56,7 @@ until the plugin is installed.
 
 This walkthrough creates a minimal plugin that registers an agent tool. Channel
 and provider plugins have dedicated guides linked above.
+For the detailed tool-only workflow, see [Tool Plugins](/plugins/tool-plugins).
 
 <Steps>
   <Step title="Create the package and manifest">
@@ -133,8 +137,9 @@ and provider plugins have dedicated guides linked above.
     `defineToolPlugin` is for simple agent-tool plugins. For providers, hooks,
     services, and other advanced non-channel plugins, use `definePluginEntry`.
     For channels, use `defineChannelPluginEntry` - see
-    [Channel Plugins](/plugins/sdk-channel-plugins). For full entry point
-    options, see [Entry Points](/plugins/sdk-entrypoints).
+    [Channel Plugins](/plugins/sdk-channel-plugins). For the full
+    `defineToolPlugin` workflow, see [Tool Plugins](/plugins/tool-plugins). For
+    full entry point options, see [Entry Points](/plugins/sdk-entrypoints).
 
   </Step>
 

--- a/docs/plugins/sdk-entrypoints.md
+++ b/docs/plugins/sdk-entrypoints.md
@@ -1,14 +1,14 @@
 ---
-summary: "Reference for definePluginEntry, defineChannelPluginEntry, and defineSetupPluginEntry"
+summary: "Reference for defineToolPlugin, definePluginEntry, defineChannelPluginEntry, and defineSetupPluginEntry"
 title: "Plugin entry points"
 sidebarTitle: "Entry Points"
 read_when:
-  - You need the exact type signature of definePluginEntry or defineChannelPluginEntry
+  - You need the exact type signature of defineToolPlugin, definePluginEntry, or defineChannelPluginEntry
   - You want to understand registration mode (full vs setup vs CLI metadata)
   - You are looking up entry point options
 ---
 
-Every plugin exports a default entry object. The SDK provides three helpers for
+Every plugin exports a default entry object. The SDK provides helpers for
 creating them.
 
 For installed plugins, `package.json` should point runtime loading at built
@@ -44,12 +44,57 @@ and inferred built JavaScript peers do not make an escaping `extensions` or
   or [Provider Plugins](/plugins/sdk-provider-plugins) for step-by-step guides.
 </Tip>
 
+## `defineToolPlugin`
+
+**Import:** `openclaw/plugin-sdk/tool-plugin`
+
+For simple plugins that only add agent tools. `defineToolPlugin` keeps the
+authoring source small, infers config and tool parameter types from TypeBox
+schemas, wraps plain return values in the OpenClaw tool-result format, and
+exposes static metadata that `openclaw plugins build` writes into the plugin
+manifest.
+
+```typescript
+import { Type } from "typebox";
+import { defineToolPlugin } from "openclaw/plugin-sdk/tool-plugin";
+
+export default defineToolPlugin({
+  id: "stock-quotes",
+  name: "Stock Quotes",
+  description: "Fetch stock quotes.",
+  configSchema: Type.Object({
+    apiKey: Type.Optional(Type.String({ description: "API key." })),
+  }),
+  tools: (tool) => [
+    tool({
+      name: "quote",
+      label: "Quote",
+      description: "Fetch a quote.",
+      parameters: Type.Object({
+        symbol: Type.String({ description: "Ticker symbol." }),
+      }),
+      execute: async ({ symbol }, config) => ({ symbol, hasKey: Boolean(config.apiKey) }),
+    }),
+  ],
+});
+```
+
+- `configSchema` is optional. When omitted, OpenClaw uses a strict empty object
+  schema and the generated manifest still includes `configSchema`.
+- `execute` returns a plain string or JSON-serializable value. The helper wraps
+  it as a text tool result with `details`.
+- Tool names are static. `openclaw plugins build` derives `contracts.tools`
+  from the declared tools, so authors do not duplicate names by hand.
+- Runtime loading stays strict. Installed plugins still need
+  `openclaw.plugin.json` and `package.json` `openclaw.extensions`; OpenClaw does
+  not execute plugin code to infer missing manifest data.
+
 ## `definePluginEntry`
 
 **Import:** `openclaw/plugin-sdk/plugin-entry`
 
-For provider plugins, tool plugins, hook plugins, and anything that is **not**
-a messaging channel.
+For provider plugins, advanced tool plugins, hook plugins, and anything that is
+**not** a messaging channel.
 
 ```typescript
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";

--- a/docs/plugins/sdk-entrypoints.md
+++ b/docs/plugins/sdk-entrypoints.md
@@ -40,8 +40,9 @@ and inferred built JavaScript peers do not make an escaping `extensions` or
 `setupEntry` source path valid.
 
 <Tip>
-  **Looking for a walkthrough?** See [Channel Plugins](/plugins/sdk-channel-plugins)
-  or [Provider Plugins](/plugins/sdk-provider-plugins) for step-by-step guides.
+  **Looking for a walkthrough?** See [Tool Plugins](/plugins/tool-plugins),
+  [Channel Plugins](/plugins/sdk-channel-plugins), or
+  [Provider Plugins](/plugins/sdk-provider-plugins) for step-by-step guides.
 </Tip>
 
 ## `defineToolPlugin`

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -107,6 +107,10 @@ methods:
 
 ### Tools and commands
 
+Use [`defineToolPlugin`](/plugins/tool-plugins) for simple tool-only plugins
+with fixed tool names. Use `api.registerTool(...)` directly for mixed plugins
+or fully dynamic tool registration.
+
 | Method                          | What it registers                             |
 | ------------------------------- | --------------------------------------------- |
 | `api.registerTool(tool, opts?)` | Agent tool (required or `{ optional: true }`) |

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -257,6 +257,7 @@ focused channel/runtime subpaths, `config-contracts`, `string-coerce-runtime`,
     | `plugin-sdk/request-url` | Extract string URLs from fetch/request-like inputs |
     | `plugin-sdk/run-command` | Timed command runner with normalized stdout/stderr results |
     | `plugin-sdk/param-readers` | Common tool/CLI param readers |
+    | `plugin-sdk/tool-plugin` | Define a simple typed agent-tool plugin and expose static metadata for manifest generation |
     | `plugin-sdk/tool-payload` | Extract normalized payloads from tool result objects |
     | `plugin-sdk/tool-send` | Extract canonical send target fields from tool args |
     | `plugin-sdk/temp-path` | Shared temp-download path helpers and private secure temp workspaces |

--- a/docs/plugins/tool-plugins.md
+++ b/docs/plugins/tool-plugins.md
@@ -109,6 +109,48 @@ export default defineToolPlugin({
 Tool names are the stable API. Pick names that are unique, lowercase, and
 specific enough to avoid collisions with core tools or other plugins.
 
+## Optional and factory tools
+
+Set `optional: true` when users should explicitly allowlist the tool before it
+is sent to a model:
+
+```typescript
+tool({
+  name: "workflow_run",
+  description: "Run an external workflow.",
+  parameters: Type.Object({ goal: Type.String() }),
+  optional: true,
+  execute: ({ goal }) => ({ queued: true, goal }),
+});
+```
+
+`openclaw plugins build` writes the matching `toolMetadata.<tool>.optional`
+manifest entry, so OpenClaw can discover the tool without loading plugin
+runtime code.
+
+Use `factory` when a tool needs the runtime tool context before it can be
+created. The factory keeps metadata static while letting the tool opt out for a
+specific run, inspect sandbox state, or bind runtime helpers.
+
+```typescript
+tool({
+  name: "local_workflow",
+  description: "Run a local workflow outside sandboxed sessions.",
+  parameters: Type.Object({ goal: Type.String() }),
+  optional: true,
+  factory({ api, toolContext }) {
+    if (toolContext.sandboxed) {
+      return null;
+    }
+    return createLocalWorkflowTool(api);
+  },
+});
+```
+
+Factories are still for fixed tool names. Use `definePluginEntry` directly when
+the plugin computes tool names dynamically or combines tools with hooks,
+services, providers, commands, or other runtime surfaces.
+
 ## Return values
 
 `defineToolPlugin` wraps plain return values into the OpenClaw tool-result
@@ -140,10 +182,10 @@ tool({
 });
 ```
 
-Use `definePluginEntry` instead of `defineToolPlugin` when you need to return a
-custom `AgentToolResult`, stream custom progress semantics, register dynamic
-tools, or combine tools with hooks, services, providers, commands, or other
-advanced surfaces.
+Use a factory tool when you need to return a custom `AgentToolResult` or reuse
+an existing `api.registerTool` implementation. Use `definePluginEntry` instead
+of `defineToolPlugin` when you need fully dynamic tools or mixed plugin
+capabilities.
 
 ## Configuration
 

--- a/docs/plugins/tool-plugins.md
+++ b/docs/plugins/tool-plugins.md
@@ -1,0 +1,369 @@
+---
+summary: "Build simple typed agent tools with defineToolPlugin and openclaw plugins init/build/validate"
+title: "Tool plugins"
+sidebarTitle: "Tool Plugins"
+read_when:
+  - You want to build a simple OpenClaw plugin that only adds agent tools
+  - You want to use defineToolPlugin instead of hand-writing plugin manifest metadata
+  - You need to scaffold, generate, validate, test, or publish a tool-only plugin
+---
+
+Tool plugins add agent-callable tools to OpenClaw without adding a channel,
+model provider, hook, service, or setup backend. Use `defineToolPlugin` when the
+plugin owns a fixed list of tools and you want OpenClaw to generate the manifest
+metadata that keeps those tools discoverable without loading runtime code.
+
+The recommended flow is:
+
+1. Scaffold a package with `openclaw plugins init`.
+2. Write tools with `defineToolPlugin`.
+3. Build JavaScript.
+4. Generate `openclaw.plugin.json` and `package.json` metadata with
+   `openclaw plugins build`.
+5. Validate the generated metadata before publishing or installing.
+
+For provider, channel, hook, service, or mixed-capability plugins, start with
+[Building plugins](/plugins/building-plugins), [Channel Plugins](/plugins/sdk-channel-plugins),
+or [Provider Plugins](/plugins/sdk-provider-plugins) instead.
+
+## Requirements
+
+- Node >= 22.
+- TypeScript ESM package output.
+- `typebox` for config and tool parameter schemas.
+- `openclaw >=2026.5.17`, the first OpenClaw version that exports
+  `openclaw/plugin-sdk/tool-plugin`.
+- A package root that can ship `dist/`, `openclaw.plugin.json`, and
+  `package.json`.
+
+The generated plugin imports `typebox` at runtime, so keep `typebox` in
+`dependencies`, not only `devDependencies`.
+
+## Quickstart
+
+Create a new plugin package:
+
+```bash
+openclaw plugins init stock-quotes --name "Stock Quotes"
+cd stock-quotes
+npm install
+npm run plugin:build
+npm run plugin:validate
+npm test
+```
+
+The scaffold creates:
+
+- `src/index.ts`: a `defineToolPlugin` entry with an `echo` tool.
+- `src/index.test.ts`: a small metadata test.
+- `tsconfig.json`: NodeNext TypeScript output to `dist/`.
+- `package.json`: scripts, runtime dependencies, and
+  `openclaw.extensions: ["./dist/index.js"]`.
+- `openclaw.plugin.json`: generated manifest metadata for the initial tool.
+
+Expected validation output:
+
+```text
+Plugin stock-quotes is valid.
+```
+
+## Write a tool
+
+`defineToolPlugin` takes plugin identity, an optional config schema, and a
+static list of tools. Parameter and config types are inferred from TypeBox
+schemas.
+
+```typescript
+import { Type } from "typebox";
+import { defineToolPlugin } from "openclaw/plugin-sdk/tool-plugin";
+
+export default defineToolPlugin({
+  id: "stock-quotes",
+  name: "Stock Quotes",
+  description: "Fetch stock quote snapshots.",
+  configSchema: Type.Object({
+    apiKey: Type.Optional(Type.String({ description: "Quote API key." })),
+    baseUrl: Type.Optional(Type.String({ description: "Quote API base URL." })),
+  }),
+  tools: (tool) => [
+    tool({
+      name: "stock_quote",
+      label: "Stock Quote",
+      description: "Fetch a stock quote snapshot.",
+      parameters: Type.Object({
+        symbol: Type.String({ description: "Ticker symbol, for example OPEN." }),
+      }),
+      async execute({ symbol }, config, context) {
+        context.signal?.throwIfAborted();
+        return {
+          symbol: symbol.toUpperCase(),
+          configured: Boolean(config.apiKey),
+          baseUrl: config.baseUrl ?? "https://api.example.com",
+        };
+      },
+    }),
+  ],
+});
+```
+
+Tool names are the stable API. Pick names that are unique, lowercase, and
+specific enough to avoid collisions with core tools or other plugins.
+
+## Return values
+
+`defineToolPlugin` wraps plain return values into the OpenClaw tool-result
+format:
+
+- Return a string when the model should see that exact text.
+- Return a JSON-compatible value when you want the model to see formatted JSON
+  and OpenClaw to keep the original value in `details`.
+
+```typescript
+tool({
+  name: "echo_text",
+  description: "Echo input text.",
+  parameters: Type.Object({
+    input: Type.String(),
+  }),
+  execute: ({ input }) => input,
+});
+```
+
+```typescript
+tool({
+  name: "echo_json",
+  description: "Echo input as structured JSON.",
+  parameters: Type.Object({
+    input: Type.String(),
+  }),
+  execute: ({ input }) => ({ input, length: input.length }),
+});
+```
+
+Use `definePluginEntry` instead of `defineToolPlugin` when you need to return a
+custom `AgentToolResult`, stream custom progress semantics, register dynamic
+tools, or combine tools with hooks, services, providers, commands, or other
+advanced surfaces.
+
+## Configuration
+
+`configSchema` is optional. If you omit it, OpenClaw uses a strict empty object
+schema and the generated manifest still includes `configSchema`.
+
+```typescript
+export default defineToolPlugin({
+  id: "no-config-tools",
+  name: "No Config Tools",
+  description: "Adds tools that do not need configuration.",
+  tools: () => [],
+});
+```
+
+When you include `configSchema`, the second `execute` argument is typed from the
+schema:
+
+```typescript
+const configSchema = Type.Object({
+  apiKey: Type.String(),
+});
+
+export default defineToolPlugin({
+  id: "configured-tools",
+  name: "Configured Tools",
+  description: "Adds configured tools.",
+  configSchema,
+  tools: (tool) => [
+    tool({
+      name: "configured_ping",
+      description: "Check whether configuration is available.",
+      parameters: Type.Object({}),
+      execute: (_params, config) => ({ hasKey: config.apiKey.length > 0 }),
+    }),
+  ],
+});
+```
+
+OpenClaw reads plugin config from the plugin entry in the Gateway config. Do not
+hard-code secrets in source or in docs examples. Use config, environment
+variables, or SecretRefs according to the plugin's security model.
+
+## Generated metadata
+
+OpenClaw discovers installed plugins from cold metadata. It must be able to read
+the plugin manifest before importing plugin runtime code. `defineToolPlugin`
+therefore exposes static metadata, and `openclaw plugins build` writes that
+metadata into the package.
+
+Run the generator after changing plugin id, name, description, config schema,
+activation, or tool names:
+
+```bash
+npm run build
+openclaw plugins build --entry ./dist/index.js
+```
+
+For a one-tool plugin, the generated manifest looks like this:
+
+```json
+{
+  "id": "stock-quotes",
+  "name": "Stock Quotes",
+  "description": "Fetch stock quote snapshots.",
+  "version": "0.1.0",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  },
+  "activation": {
+    "onStartup": true
+  },
+  "contracts": {
+    "tools": ["stock_quote"]
+  }
+}
+```
+
+`contracts.tools` is the important discovery contract. It tells OpenClaw which
+plugin owns each tool without loading every installed plugin runtime. If the
+manifest is stale, the tool may be missing from discovery or the wrong plugin
+may be blamed for a registration error.
+
+## Package metadata
+
+For the simple tool-plugin workflow, `openclaw plugins build` aligns
+`package.json` to the selected single runtime entry:
+
+```json
+{
+  "type": "module",
+  "files": ["dist", "openclaw.plugin.json", "README.md"],
+  "dependencies": {
+    "typebox": "^1.1.38"
+  },
+  "peerDependencies": {
+    "openclaw": ">=2026.5.17"
+  },
+  "openclaw": {
+    "extensions": ["./dist/index.js"]
+  }
+}
+```
+
+Use built JavaScript such as `./dist/index.js` for installed packages. Source
+entries are useful in workspace development, but published packages should not
+depend on TypeScript runtime loading.
+
+## Validate in CI
+
+Use `plugins build --check` to fail CI when generated metadata is stale without
+rewriting files:
+
+```bash
+npm run build
+openclaw plugins build --entry ./dist/index.js --check
+openclaw plugins validate --entry ./dist/index.js
+npm test
+```
+
+`plugins validate` checks that:
+
+- `openclaw.plugin.json` exists and passes the normal manifest loader.
+- The current entry exports `defineToolPlugin` metadata.
+- Generated manifest fields match the entry metadata.
+- `contracts.tools` matches the declared tool names.
+- `package.json` points `openclaw.extensions` at the selected runtime entry.
+
+## Install and inspect locally
+
+From a separate OpenClaw checkout or installed CLI, install the package path:
+
+```bash
+openclaw plugins install ./stock-quotes
+openclaw plugins inspect stock-quotes --runtime
+```
+
+For a packaged smoke, pack first and install the tarball:
+
+```bash
+npm pack
+openclaw plugins install npm-pack:./openclaw-plugin-stock-quotes-0.1.0.tgz
+openclaw plugins inspect stock-quotes --runtime --json
+```
+
+After installation, start or restart the Gateway and ask the agent to use the
+tool. If you are debugging tool visibility, inspect the plugin runtime and the
+effective tool catalog before changing the code.
+
+## Publish
+
+Publish through ClawHub when the package is ready:
+
+```bash
+clawhub package publish your-org/stock-quotes --dry-run
+clawhub package publish your-org/stock-quotes
+```
+
+Install with an explicit ClawHub locator:
+
+```bash
+openclaw plugins install clawhub:your-org/stock-quotes
+```
+
+Bare npm package specs remain supported during the launch cutover, but ClawHub
+is the preferred discovery and distribution surface for OpenClaw plugins.
+
+## Troubleshooting
+
+### `plugin entry not found: ./dist/index.js`
+
+The selected entry file does not exist. Run `npm run build`, then rerun
+`openclaw plugins build --entry ./dist/index.js` or
+`openclaw plugins validate --entry ./dist/index.js`.
+
+### `plugin entry does not expose defineToolPlugin metadata`
+
+The entry did not export a value created by `defineToolPlugin`. Check that the
+module default export is the `defineToolPlugin(...)` result, or pass the correct
+entry with `--entry`.
+
+### `openclaw.plugin.json generated metadata is stale`
+
+The manifest no longer matches the entry metadata. Run:
+
+```bash
+npm run build
+openclaw plugins build --entry ./dist/index.js
+```
+
+Commit both `openclaw.plugin.json` and `package.json` changes.
+
+### `package.json openclaw.extensions must include ./dist/index.js`
+
+The package metadata points at a different runtime entry. Run
+`openclaw plugins build --entry ./dist/index.js` so the generator aligns the
+package metadata with the entry you intend to ship.
+
+### `Cannot find package 'typebox'`
+
+The built plugin imports `typebox` at runtime. Keep `typebox` in
+`dependencies`, reinstall package dependencies, rebuild, and rerun validation.
+
+### Tool does not appear after install
+
+Check these in order:
+
+1. `openclaw plugins inspect <plugin-id> --runtime`
+2. `openclaw plugins validate --root <plugin-root> --entry ./dist/index.js`
+3. `openclaw.plugin.json` has `contracts.tools` with the expected tool names.
+4. `package.json` has `openclaw.extensions: ["./dist/index.js"]`.
+5. The Gateway was restarted or reloaded after installing the plugin.
+
+## See also
+
+- [Building plugins](/plugins/building-plugins)
+- [Plugin entry points](/plugins/sdk-entrypoints)
+- [Plugin SDK subpaths](/plugins/sdk-subpaths)
+- [Plugin manifest](/plugins/manifest)
+- [Plugins CLI](/cli/plugins)
+- [ClawHub publishing](/clawhub/publishing)

--- a/extensions/llm-task/index.ts
+++ b/extensions/llm-task/index.ts
@@ -1,11 +1,32 @@
-import { definePluginEntry, type AnyAgentTool, type OpenClawPluginApi } from "./api.js";
-import { createLlmTaskTool } from "./src/llm-task-tool.js";
+import { defineToolPlugin } from "openclaw/plugin-sdk/tool-plugin";
+import { Type } from "typebox";
+import type { AnyAgentTool } from "./api.js";
+import { createLlmTaskTool, llmTaskToolDefinition } from "./src/llm-task-tool.js";
 
-export default definePluginEntry({
+export default defineToolPlugin({
   id: "llm-task",
   name: "LLM Task",
-  description: "Optional tool for structured subtask execution",
-  register(api: OpenClawPluginApi) {
-    api.registerTool(createLlmTaskTool(api) as unknown as AnyAgentTool, { optional: true });
-  },
+  description: "Generic JSON-only LLM tool for structured tasks callable from workflows.",
+  configSchema: Type.Object(
+    {
+      defaultProvider: Type.Optional(Type.String()),
+      defaultModel: Type.Optional(Type.String()),
+      defaultAuthProfileId: Type.Optional(Type.String()),
+      allowedModels: Type.Optional(
+        Type.Array(Type.String(), {
+          description: "Allowlist of provider/model keys like openai-codex/gpt-5.2.",
+        }),
+      ),
+      maxTokens: Type.Optional(Type.Number()),
+      timeoutMs: Type.Optional(Type.Number()),
+    },
+    { additionalProperties: false },
+  ),
+  tools: (tool) => [
+    tool({
+      ...llmTaskToolDefinition,
+      optional: true,
+      factory: ({ api }) => createLlmTaskTool(api) as unknown as AnyAgentTool,
+    }),
+  ],
 });

--- a/extensions/llm-task/openclaw.plugin.json
+++ b/extensions/llm-task/openclaw.plugin.json
@@ -5,28 +5,43 @@
   },
   "name": "LLM Task",
   "description": "Generic JSON-only LLM tool for structured tasks callable from workflows.",
+  "configSchema": {
+    "type": "object",
+    "properties": {
+      "defaultProvider": {
+        "type": "string"
+      },
+      "defaultModel": {
+        "type": "string"
+      },
+      "defaultAuthProfileId": {
+        "type": "string"
+      },
+      "allowedModels": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "Allowlist of provider/model keys like openai-codex/gpt-5.2."
+      },
+      "maxTokens": {
+        "type": "number"
+      },
+      "timeoutMs": {
+        "type": "number"
+      }
+    },
+    "additionalProperties": false
+  },
+  "version": "2026.5.17",
   "contracts": {
-    "tools": ["llm-task"]
+    "tools": [
+      "llm-task"
+    ]
   },
   "toolMetadata": {
     "llm-task": {
       "optional": true
-    }
-  },
-  "configSchema": {
-    "type": "object",
-    "additionalProperties": false,
-    "properties": {
-      "defaultProvider": { "type": "string" },
-      "defaultModel": { "type": "string" },
-      "defaultAuthProfileId": { "type": "string" },
-      "allowedModels": {
-        "type": "array",
-        "items": { "type": "string" },
-        "description": "Allowlist of provider/model keys like openai-codex/gpt-5.2."
-      },
-      "maxTokens": { "type": "number" },
-      "timeoutMs": { "type": "number" }
     }
   }
 }

--- a/extensions/llm-task/src/llm-task-tool.ts
+++ b/extensions/llm-task/src/llm-task-tool.ts
@@ -106,6 +106,29 @@ type LlmTaskParams = {
 
 type ThinkingPolicy = ReturnType<OpenClawPluginApi["runtime"]["agent"]["resolveThinkingPolicy"]>;
 
+export const llmTaskToolDefinition = {
+  name: "llm-task",
+  label: "LLM Task",
+  description:
+    "Run a generic JSON-only LLM task and return schema-validated JSON. Designed for orchestration from Lobster workflows via openclaw.invoke.",
+  parameters: Type.Object({
+    prompt: Type.String({ description: "Task instruction for the LLM." }),
+    input: Type.Optional(Type.Unknown({ description: "Optional input payload for the task." })),
+    schema: Type.Optional(
+      Type.Unknown({ description: "Optional JSON Schema to validate the returned JSON." }),
+    ),
+    provider: Type.Optional(
+      Type.String({ description: "Provider override (e.g. openai-codex, anthropic)." }),
+    ),
+    model: Type.Optional(Type.String({ description: "Model id override." })),
+    thinking: Type.Optional(Type.String({ description: "Thinking level override." })),
+    authProfileId: Type.Optional(Type.String({ description: "Auth profile override." })),
+    temperature: Type.Optional(Type.Number({ description: "Best-effort temperature override." })),
+    maxTokens: Type.Optional(Type.Number({ description: "Best-effort maxTokens override." })),
+    timeoutMs: Type.Optional(Type.Number({ description: "Timeout for the LLM run." })),
+  }),
+};
+
 function formatThinkingPolicy(policy: ThinkingPolicy): string {
   return policy.levels.map((level) => level.label).join(", ");
 }
@@ -119,26 +142,7 @@ function supportsThinkingPolicyLevel(
 
 export function createLlmTaskTool(api: OpenClawPluginApi) {
   return {
-    name: "llm-task",
-    label: "LLM Task",
-    description:
-      "Run a generic JSON-only LLM task and return schema-validated JSON. Designed for orchestration from Lobster workflows via openclaw.invoke.",
-    parameters: Type.Object({
-      prompt: Type.String({ description: "Task instruction for the LLM." }),
-      input: Type.Optional(Type.Unknown({ description: "Optional input payload for the task." })),
-      schema: Type.Optional(
-        Type.Unknown({ description: "Optional JSON Schema to validate the returned JSON." }),
-      ),
-      provider: Type.Optional(
-        Type.String({ description: "Provider override (e.g. openai-codex, anthropic)." }),
-      ),
-      model: Type.Optional(Type.String({ description: "Model id override." })),
-      thinking: Type.Optional(Type.String({ description: "Thinking level override." })),
-      authProfileId: Type.Optional(Type.String({ description: "Auth profile override." })),
-      temperature: Type.Optional(Type.Number({ description: "Best-effort temperature override." })),
-      maxTokens: Type.Optional(Type.Number({ description: "Best-effort maxTokens override." })),
-      timeoutMs: Type.Optional(Type.Number({ description: "Timeout for the LLM run." })),
-    }),
+    ...llmTaskToolDefinition,
 
     async execute(_id: string, params: LlmTaskParams) {
       const prompt = typeof params.prompt === "string" ? params.prompt : "";

--- a/package.json
+++ b/package.json
@@ -1300,6 +1300,10 @@
       "types": "./dist/plugin-sdk/text-utility-runtime.d.ts",
       "default": "./dist/plugin-sdk/text-utility-runtime.js"
     },
+    "./plugin-sdk/tool-plugin": {
+      "types": "./dist/plugin-sdk/tool-plugin.d.ts",
+      "default": "./dist/plugin-sdk/tool-plugin.js"
+    },
     "./plugin-sdk/tool-payload": {
       "types": "./dist/plugin-sdk/tool-payload.d.ts",
       "default": "./dist/plugin-sdk/tool-payload.js"

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -300,6 +300,7 @@
   "telegram-command-config",
   "text-autolink-runtime",
   "text-utility-runtime",
+  "tool-plugin",
   "tool-payload",
   "tool-send",
   "webhook-ingress",

--- a/src/cli/plugins-authoring-command.test.ts
+++ b/src/cli/plugins-authoring-command.test.ts
@@ -236,6 +236,51 @@ describe("plugin authoring commands", () => {
     ).rejects.toThrow("plugin entry not found: ./dist/index.js");
   });
 
+  it("loads source entries that import the OpenClaw plugin SDK package subpath", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-source-"));
+    const sourceDir = path.join(tmpDir, "src");
+    fs.mkdirSync(sourceDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, "package.json"),
+      JSON.stringify(
+        {
+          name: "openclaw-plugin-source-demo",
+          type: "module",
+          openclaw: { extensions: ["./src/index.ts"] },
+        },
+        null,
+        2,
+      ),
+    );
+    fs.writeFileSync(
+      path.join(sourceDir, "index.ts"),
+      `import { defineToolPlugin } from "openclaw/plugin-sdk/tool-plugin";
+
+export default defineToolPlugin({
+  id: "source-demo",
+  name: "Source Demo",
+  description: "Source demo plugin.",
+  tools: (tool) => [
+    tool({
+      name: "source_echo",
+      description: "Echo input.",
+      parameters: { type: "object", additionalProperties: false, properties: {} },
+      execute: async () => ({ ok: true }),
+    }),
+  ],
+});
+`,
+    );
+
+    const loaded = await loadToolPlugin({
+      rootDir: tmpDir,
+      entryPath: path.join(sourceDir, "index.ts"),
+    });
+
+    expect(loaded.metadata.id).toBe("source-demo");
+    expect(loaded.metadata.tools.map((tool) => tool.name)).toEqual(["source_echo"]);
+  });
+
   it("scaffolds a dist-entry tool plugin project", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-init-"));
     const projectDir = path.join(tmpDir, "stock-quotes");

--- a/src/cli/plugins-authoring-command.test.ts
+++ b/src/cli/plugins-authoring-command.test.ts
@@ -95,6 +95,86 @@ describe("plugin authoring commands", () => {
     });
   });
 
+  it("preserves manifest-owned metadata while updating generated fields", () => {
+    const metadata = createOptionalDemoMetadata();
+    const existingManifest = {
+      id: "old-id",
+      name: "Old name",
+      uiHints: { apiKey: { secret: true } },
+      contracts: {
+        tools: ["stale_tool"],
+        agentToolResultMiddleware: ["existing-middleware"],
+      },
+      toolMetadata: {
+        demo_optional_echo: {
+          authSignals: [{ provider: "demo", envVars: ["DEMO_API_KEY"] }],
+          configSignals: [{ rootPath: "plugins.entries.optional-demo-tools.config.apiKey" }],
+        },
+        stale_tool: {
+          optional: true,
+        },
+      },
+    };
+
+    const manifest = buildToolPluginManifest({
+      metadata,
+      packageManifest: { version: "1.2.3" },
+      existingManifest,
+    });
+
+    expect(manifest).toMatchObject({
+      id: "optional-demo-tools",
+      name: "Optional Demo Tools",
+      uiHints: { apiKey: { secret: true } },
+      contracts: {
+        tools: ["demo_optional_echo"],
+        agentToolResultMiddleware: ["existing-middleware"],
+      },
+      toolMetadata: {
+        demo_optional_echo: {
+          optional: true,
+          authSignals: [{ provider: "demo", envVars: ["DEMO_API_KEY"] }],
+          configSignals: [{ rootPath: "plugins.entries.optional-demo-tools.config.apiKey" }],
+        },
+      },
+    });
+    expect((manifest.toolMetadata as Record<string, unknown>).stale_tool).toBeUndefined();
+    expect(
+      validateToolPluginProject({
+        metadata,
+        entry: "./src/index.ts",
+        manifest,
+        packageManifest: { version: "1.2.3", openclaw: { extensions: ["./src/index.ts"] } },
+      }),
+    ).toEqual([]);
+  });
+
+  it("drops stale manifest-owned tool metadata when no generated metadata remains", () => {
+    const metadata = createDemoMetadata();
+    const packageManifest = { version: "1.2.3", openclaw: { extensions: ["./src/index.ts"] } };
+    const manifest = buildToolPluginManifest({
+      metadata,
+      packageManifest,
+      existingManifest: {
+        id: "demo-tools",
+        name: "Demo Tools",
+        toolMetadata: {
+          stale_tool: { optional: true },
+        },
+      },
+    });
+
+    expect(manifest.toolMetadata).toBeUndefined();
+    expect(
+      validateToolPluginProject({
+        metadata,
+        entry: "./src/index.ts",
+        manifest,
+        packageManifest,
+      }),
+    ).toEqual([]);
+  });
+
   it("aligns package metadata with the selected runtime extension entry", () => {
     expect(
       buildToolPluginPackageManifest({

--- a/src/cli/plugins-authoring-command.test.ts
+++ b/src/cli/plugins-authoring-command.test.ts
@@ -33,6 +33,28 @@ function createDemoMetadata() {
   return metadata;
 }
 
+function createOptionalDemoMetadata() {
+  const entry = defineToolPlugin({
+    id: "optional-demo-tools",
+    name: "Optional Demo Tools",
+    description: "Optional demo tool plugin.",
+    tools: (tool) => [
+      tool({
+        name: "demo_optional_echo",
+        description: "Echo input.",
+        parameters: Type.Object({ input: Type.String() }),
+        optional: true,
+        execute: ({ input }) => ({ input }),
+      }),
+    ],
+  });
+  const metadata = getToolPluginMetadata(entry);
+  if (!metadata) {
+    throw new Error("missing metadata");
+  }
+  return metadata;
+}
+
 describe("plugin authoring commands", () => {
   it("generates manifest metadata from defineToolPlugin metadata", () => {
     const metadata = createDemoMetadata();
@@ -49,6 +71,27 @@ describe("plugin authoring commands", () => {
       },
       activation: { onStartup: true },
       contracts: { tools: ["demo_echo"] },
+    });
+  });
+
+  it("generates optional tool metadata for optional tool plugins", () => {
+    const metadata = createOptionalDemoMetadata();
+
+    expect(buildToolPluginManifest({ metadata, packageManifest: { version: "1.2.3" } })).toEqual({
+      id: "optional-demo-tools",
+      name: "Optional Demo Tools",
+      description: "Optional demo tool plugin.",
+      version: "1.2.3",
+      configSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {},
+      },
+      activation: { onStartup: true },
+      contracts: { tools: ["demo_optional_echo"] },
+      toolMetadata: {
+        demo_optional_echo: { optional: true },
+      },
     });
   });
 

--- a/src/cli/plugins-authoring-command.test.ts
+++ b/src/cli/plugins-authoring-command.test.ts
@@ -1,0 +1,166 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Type } from "typebox";
+import { describe, expect, it } from "vitest";
+import { defineToolPlugin, getToolPluginMetadata } from "../plugin-sdk/tool-plugin.js";
+import {
+  buildToolPluginManifest,
+  buildToolPluginPackageManifest,
+  loadToolPlugin,
+  runPluginsInitCommand,
+  validateToolPluginProject,
+} from "./plugins-authoring-command.js";
+
+function createDemoMetadata() {
+  const entry = defineToolPlugin({
+    id: "demo-tools",
+    name: "Demo Tools",
+    description: "Demo tool plugin.",
+    tools: (tool) => [
+      tool({
+        name: "demo_echo",
+        description: "Echo input.",
+        parameters: Type.Object({ input: Type.String() }),
+        execute: ({ input }) => ({ input }),
+      }),
+    ],
+  });
+  const metadata = getToolPluginMetadata(entry);
+  if (!metadata) {
+    throw new Error("missing metadata");
+  }
+  return metadata;
+}
+
+describe("plugin authoring commands", () => {
+  it("generates manifest metadata from defineToolPlugin metadata", () => {
+    const metadata = createDemoMetadata();
+
+    expect(buildToolPluginManifest({ metadata, packageManifest: { version: "1.2.3" } })).toEqual({
+      id: "demo-tools",
+      name: "Demo Tools",
+      description: "Demo tool plugin.",
+      version: "1.2.3",
+      configSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {},
+      },
+      activation: { onStartup: true },
+      contracts: { tools: ["demo_echo"] },
+    });
+  });
+
+  it("aligns package metadata with the selected runtime extension entry", () => {
+    expect(
+      buildToolPluginPackageManifest({
+        packageManifest: {
+          name: "demo",
+          openclaw: { setupEntry: "./setup.ts", extensions: ["./src/other.ts"] },
+        },
+        entry: "./src/index.ts",
+      }),
+    ).toEqual({
+      name: "demo",
+      openclaw: {
+        setupEntry: "./setup.ts",
+        extensions: ["./src/index.ts"],
+      },
+    });
+  });
+
+  it("validates manifest tools and package entry metadata", () => {
+    const metadata = createDemoMetadata();
+    const packageManifest = { version: "1.2.3", openclaw: { extensions: ["./src/index.ts"] } };
+
+    expect(
+      validateToolPluginProject({
+        metadata,
+        entry: "./src/index.ts",
+        manifest: buildToolPluginManifest({ metadata, packageManifest }),
+        packageManifest,
+      }),
+    ).toEqual([]);
+  });
+
+  it("reports stale manifest contracts", () => {
+    const metadata = createDemoMetadata();
+
+    expect(
+      validateToolPluginProject({
+        metadata,
+        entry: "./src/index.ts",
+        manifest: {
+          id: "demo-tools",
+          configSchema: {},
+          contracts: { tools: ["other_tool"] },
+        },
+        packageManifest: { openclaw: { extensions: ["./src/index.ts"] } },
+      }),
+    ).toEqual([
+      "openclaw.plugin.json generated metadata is stale. Run openclaw plugins build.",
+      "openclaw.plugin.json contracts.tools is missing: demo_echo",
+      "openclaw.plugin.json contracts.tools has no matching defineToolPlugin tool: other_tool",
+    ]);
+  });
+
+  it("reports missing entries with an author-facing path", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-missing-"));
+
+    await expect(
+      loadToolPlugin({ rootDir: tmpDir, entryPath: path.join(tmpDir, "dist/index.js") }),
+    ).rejects.toThrow("plugin entry not found: ./dist/index.js");
+  });
+
+  it("scaffolds a dist-entry tool plugin project", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-plugin-init-"));
+    const projectDir = path.join(tmpDir, "stock-quotes");
+
+    await runPluginsInitCommand("stock-quotes", {
+      directory: projectDir,
+      name: 'Stock "Quotes"',
+    });
+
+    expect(fs.readFileSync(path.join(projectDir, "src/index.ts"), "utf8")).toContain(
+      'name: "Stock \\"Quotes\\""',
+    );
+    expect(
+      JSON.parse(fs.readFileSync(path.join(projectDir, "package.json"), "utf8")),
+    ).toMatchObject({
+      dependencies: {
+        typebox: "^1.1.38",
+      },
+      peerDependencies: {
+        openclaw: ">=2026.5.17",
+      },
+      devDependencies: {
+        openclaw: "latest",
+        typescript: "^5.9.0",
+        vitest: "^3.2.0",
+      },
+      scripts: {
+        "plugin:build": "npm run build && openclaw plugins build --entry ./dist/index.js",
+        "plugin:validate": "npm run build && openclaw plugins validate --entry ./dist/index.js",
+      },
+      openclaw: {
+        extensions: ["./dist/index.js"],
+      },
+    });
+    expect(
+      JSON.parse(fs.readFileSync(path.join(projectDir, "openclaw.plugin.json"), "utf8")),
+    ).toMatchObject({
+      id: "stock-quotes",
+      name: 'Stock "Quotes"',
+      configSchema: {
+        type: "object",
+        additionalProperties: false,
+        properties: {},
+      },
+      contracts: { tools: ["echo"] },
+    });
+    expect(fs.readFileSync(path.join(projectDir, "src/index.test.ts"), "utf8")).toContain(
+      "getToolPluginMetadata",
+    );
+  });
+});

--- a/src/cli/plugins-authoring-command.ts
+++ b/src/cli/plugins-authoring-command.ts
@@ -117,6 +117,7 @@ export function buildToolPluginManifest(params: {
   metadata: ToolPluginMetadata;
   packageManifest: JsonObject;
 }): JsonObject {
+  const optionalTools = params.metadata.tools.filter((tool) => tool.optional);
   return {
     id: params.metadata.id,
     name: params.metadata.name,
@@ -128,6 +129,13 @@ export function buildToolPluginManifest(params: {
     contracts: {
       tools: params.metadata.tools.map((tool) => tool.name),
     },
+    ...(optionalTools.length > 0
+      ? {
+          toolMetadata: Object.fromEntries(
+            optionalTools.map((tool) => [tool.name, { optional: true }]),
+          ),
+        }
+      : {}),
   };
 }
 

--- a/src/cli/plugins-authoring-command.ts
+++ b/src/cli/plugins-authoring-command.ts
@@ -8,6 +8,7 @@ import {
   resolvePackageExtensionEntries,
 } from "../plugins/manifest.js";
 import { defaultRuntime } from "../runtime.js";
+import { isRecord } from "../utils.js";
 
 type JsonObject = Record<string, unknown>;
 
@@ -116,9 +117,19 @@ export async function loadToolPlugin(params: {
 export function buildToolPluginManifest(params: {
   metadata: ToolPluginMetadata;
   packageManifest: JsonObject;
+  existingManifest?: JsonObject;
 }): JsonObject {
-  const optionalTools = params.metadata.tools.filter((tool) => tool.optional);
+  const toolMetadata = buildToolPluginToolMetadata(params.metadata, params.existingManifest);
+  const existingContracts = isRecord(params.existingManifest?.contracts)
+    ? params.existingManifest.contracts
+    : {};
+  const {
+    contracts: _existingContracts,
+    toolMetadata: _existingToolMetadata,
+    ...existingManifestFields
+  } = params.existingManifest ?? {};
   return {
+    ...existingManifestFields,
     id: params.metadata.id,
     name: params.metadata.name,
     description: params.metadata.description,
@@ -127,16 +138,33 @@ export function buildToolPluginManifest(params: {
     configSchema: params.metadata.configSchema,
     activation: params.metadata.activation,
     contracts: {
+      ...existingContracts,
       tools: params.metadata.tools.map((tool) => tool.name),
     },
-    ...(optionalTools.length > 0
-      ? {
-          toolMetadata: Object.fromEntries(
-            optionalTools.map((tool) => [tool.name, { optional: true }]),
-          ),
-        }
-      : {}),
+    ...(toolMetadata ? { toolMetadata } : {}),
   };
+}
+
+function buildToolPluginToolMetadata(
+  metadata: ToolPluginMetadata,
+  existingManifest: JsonObject | undefined,
+): Record<string, unknown> | undefined {
+  const existingToolMetadata = isRecord(existingManifest?.toolMetadata)
+    ? existingManifest.toolMetadata
+    : {};
+  const nextEntries = metadata.tools
+    .map((tool) => {
+      const existingValue = existingToolMetadata[tool.name];
+      const existing = isRecord(existingValue) ? { ...existingValue } : {};
+      if (tool.optional) {
+        existing.optional = true;
+      } else {
+        delete existing.optional;
+      }
+      return [tool.name, existing] as const;
+    })
+    .filter(([, value]) => Object.keys(value).length > 0);
+  return nextEntries.length > 0 ? Object.fromEntries(nextEntries) : undefined;
 }
 
 export function buildToolPluginPackageManifest(params: {
@@ -168,6 +196,7 @@ export function validateToolPluginProject(params: {
   const expectedManifest = buildToolPluginManifest({
     metadata: params.metadata,
     packageManifest: params.packageManifest,
+    existingManifest: params.manifest,
   });
   if (JSON.stringify(params.manifest) !== JSON.stringify(expectedManifest)) {
     errors.push("openclaw.plugin.json generated metadata is stale. Run openclaw plugins build.");
@@ -217,15 +246,19 @@ export async function runPluginsBuildCommand(opts: PluginsBuildOptions): Promise
   const packagePath = path.join(rootDir, "package.json");
   const packageManifest = readPackageManifest(rootDir);
   const { metadata } = await loadToolPlugin({ rootDir, entryPath });
-  const manifest = buildToolPluginManifest({ metadata, packageManifest });
+  const manifestPath = path.join(rootDir, PLUGIN_MANIFEST_FILENAME);
+  const currentManifest = fs.existsSync(manifestPath) ? readJsonFile(manifestPath) : undefined;
+  const manifest = buildToolPluginManifest({
+    metadata,
+    packageManifest,
+    existingManifest: currentManifest,
+  });
   const nextPackageManifest = buildToolPluginPackageManifest({
     packageManifest,
     entry: entryRelative,
   });
-  const manifestPath = path.join(rootDir, PLUGIN_MANIFEST_FILENAME);
 
   if (opts.check) {
-    const currentManifest = fs.existsSync(manifestPath) ? readJsonFile(manifestPath) : undefined;
     const currentPackage = readJsonFile(packagePath);
     if (
       JSON.stringify(currentManifest) !== JSON.stringify(manifest) ||

--- a/src/cli/plugins-authoring-command.ts
+++ b/src/cli/plugins-authoring-command.ts
@@ -1,0 +1,393 @@
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { getToolPluginMetadata, type ToolPluginMetadata } from "../plugin-sdk/tool-plugin.js";
+import {
+  loadPluginManifest,
+  PLUGIN_MANIFEST_FILENAME,
+  resolvePackageExtensionEntries,
+} from "../plugins/manifest.js";
+import { defaultRuntime } from "../runtime.js";
+
+type JsonObject = Record<string, unknown>;
+
+export type PluginsBuildOptions = {
+  root?: string;
+  entry?: string;
+  check?: boolean;
+};
+
+export type PluginsValidateOptions = {
+  root?: string;
+  entry?: string;
+};
+
+export type PluginsInitOptions = {
+  directory?: string;
+  force?: boolean;
+  name?: string;
+};
+
+type LoadedToolPlugin = {
+  entry: unknown;
+  metadata: ToolPluginMetadata;
+};
+
+function readJsonFile(filePath: string): JsonObject {
+  return JSON.parse(fs.readFileSync(filePath, "utf8")) as JsonObject;
+}
+
+function writeJsonFile(filePath: string, value: unknown): void {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function jsStringLiteral(value: string): string {
+  return JSON.stringify(value);
+}
+
+function normalizeRelativePath(rootDir: string, targetPath: string): string {
+  const relative = path
+    .relative(rootDir, path.resolve(rootDir, targetPath))
+    .replaceAll(path.sep, "/");
+  if (relative === ".." || relative.startsWith("../")) {
+    throw new Error(`entry must stay inside plugin root: ${targetPath}`);
+  }
+  return relative.startsWith(".") ? relative : `./${relative}`;
+}
+
+function resolveRootDir(input: string | undefined): string {
+  return path.resolve(input ?? process.cwd());
+}
+
+function resolveEntryPath(rootDir: string, entry: string | undefined): string {
+  if (entry) {
+    return path.resolve(rootDir, entry);
+  }
+  const packagePath = path.join(rootDir, "package.json");
+  if (fs.existsSync(packagePath)) {
+    const extensionResolution = resolvePackageExtensionEntries(readJsonFile(packagePath));
+    if (extensionResolution.status === "ok" && extensionResolution.entries[0]) {
+      return path.resolve(rootDir, extensionResolution.entries[0]);
+    }
+  }
+  return path.resolve(rootDir, "src/index.ts");
+}
+
+function readPackageManifest(rootDir: string): JsonObject {
+  const packagePath = path.join(rootDir, "package.json");
+  if (!fs.existsSync(packagePath)) {
+    throw new Error(`package.json not found: ${packagePath}`);
+  }
+  return readJsonFile(packagePath);
+}
+
+async function importToolPluginEntry(entryPath: string): Promise<unknown> {
+  const mod = (await import(pathToFileURL(entryPath).href)) as {
+    default?: unknown;
+    createEntry?: unknown;
+    entry?: unknown;
+  };
+  const candidate = mod.default ?? mod.createEntry ?? mod.entry;
+  return typeof candidate === "function" ? (candidate as () => unknown)() : candidate;
+}
+
+export async function loadToolPlugin(params: {
+  rootDir: string;
+  entryPath: string;
+}): Promise<LoadedToolPlugin> {
+  if (!fs.existsSync(params.entryPath)) {
+    throw new Error(
+      `plugin entry not found: ${normalizeRelativePath(params.rootDir, params.entryPath)}`,
+    );
+  }
+  const entry = await importToolPluginEntry(params.entryPath);
+  const metadata = getToolPluginMetadata(entry);
+  if (!metadata) {
+    throw new Error(
+      `plugin entry does not expose defineToolPlugin metadata: ${normalizeRelativePath(
+        params.rootDir,
+        params.entryPath,
+      )}`,
+    );
+  }
+  return { entry, metadata };
+}
+
+export function buildToolPluginManifest(params: {
+  metadata: ToolPluginMetadata;
+  packageManifest: JsonObject;
+}): JsonObject {
+  return {
+    id: params.metadata.id,
+    name: params.metadata.name,
+    description: params.metadata.description,
+    version:
+      typeof params.packageManifest.version === "string" ? params.packageManifest.version : "0.0.0",
+    configSchema: params.metadata.configSchema,
+    activation: params.metadata.activation,
+    contracts: {
+      tools: params.metadata.tools.map((tool) => tool.name),
+    },
+  };
+}
+
+export function buildToolPluginPackageManifest(params: {
+  packageManifest: JsonObject;
+  entry: string;
+}): JsonObject {
+  const openclaw =
+    params.packageManifest.openclaw &&
+    typeof params.packageManifest.openclaw === "object" &&
+    !Array.isArray(params.packageManifest.openclaw)
+      ? { ...(params.packageManifest.openclaw as JsonObject) }
+      : {};
+  return {
+    ...params.packageManifest,
+    openclaw: {
+      ...openclaw,
+      extensions: [params.entry],
+    },
+  };
+}
+
+export function validateToolPluginProject(params: {
+  metadata: ToolPluginMetadata;
+  manifest: JsonObject;
+  packageManifest: JsonObject;
+  entry: string;
+}): string[] {
+  const errors: string[] = [];
+  const expectedManifest = buildToolPluginManifest({
+    metadata: params.metadata,
+    packageManifest: params.packageManifest,
+  });
+  if (JSON.stringify(params.manifest) !== JSON.stringify(expectedManifest)) {
+    errors.push("openclaw.plugin.json generated metadata is stale. Run openclaw plugins build.");
+  }
+  if (params.manifest.id !== params.metadata.id) {
+    errors.push(
+      `openclaw.plugin.json id (${String(params.manifest.id)}) must match entry id (${params.metadata.id})`,
+    );
+  }
+  if (!params.manifest.configSchema || typeof params.manifest.configSchema !== "object") {
+    errors.push("openclaw.plugin.json must include object configSchema");
+  }
+  const manifestContracts = params.manifest.contracts as { tools?: unknown } | undefined;
+  const manifestTools = Array.isArray(manifestContracts?.tools)
+    ? manifestContracts.tools.filter((tool): tool is string => typeof tool === "string")
+    : [];
+  const metadataTools = params.metadata.tools.map((tool) => tool.name);
+  const missing = metadataTools.filter((tool) => !manifestTools.includes(tool));
+  const extra = manifestTools.filter((tool) => !metadataTools.includes(tool));
+  if (missing.length > 0) {
+    errors.push(`openclaw.plugin.json contracts.tools is missing: ${missing.join(", ")}`);
+  }
+  if (extra.length > 0) {
+    errors.push(
+      `openclaw.plugin.json contracts.tools has no matching defineToolPlugin tool: ${extra.join(
+        ", ",
+      )}`,
+    );
+  }
+  const extensionResolution = resolvePackageExtensionEntries(params.packageManifest);
+  if (extensionResolution.status !== "ok") {
+    errors.push(
+      extensionResolution.status === "missing" || extensionResolution.status === "empty"
+        ? "package.json must include openclaw.extensions"
+        : extensionResolution.error,
+    );
+  } else if (!extensionResolution.entries.includes(params.entry)) {
+    errors.push(`package.json openclaw.extensions must include ${params.entry}`);
+  }
+  return errors;
+}
+
+export async function runPluginsBuildCommand(opts: PluginsBuildOptions): Promise<void> {
+  const rootDir = resolveRootDir(opts.root);
+  const entryPath = resolveEntryPath(rootDir, opts.entry);
+  const entryRelative = normalizeRelativePath(rootDir, entryPath);
+  const packagePath = path.join(rootDir, "package.json");
+  const packageManifest = readPackageManifest(rootDir);
+  const { metadata } = await loadToolPlugin({ rootDir, entryPath });
+  const manifest = buildToolPluginManifest({ metadata, packageManifest });
+  const nextPackageManifest = buildToolPluginPackageManifest({
+    packageManifest,
+    entry: entryRelative,
+  });
+  const manifestPath = path.join(rootDir, PLUGIN_MANIFEST_FILENAME);
+
+  if (opts.check) {
+    const currentManifest = fs.existsSync(manifestPath) ? readJsonFile(manifestPath) : undefined;
+    const currentPackage = readJsonFile(packagePath);
+    if (
+      JSON.stringify(currentManifest) !== JSON.stringify(manifest) ||
+      JSON.stringify(currentPackage) !== JSON.stringify(nextPackageManifest)
+    ) {
+      defaultRuntime.error("Generated plugin metadata is out of date. Run openclaw plugins build.");
+      return defaultRuntime.exit(1);
+    }
+    defaultRuntime.log("Plugin metadata is up to date.");
+    return;
+  }
+
+  writeJsonFile(manifestPath, manifest);
+  writeJsonFile(packagePath, nextPackageManifest);
+  defaultRuntime.log(
+    `Wrote ${path.relative(process.cwd(), manifestPath) || PLUGIN_MANIFEST_FILENAME}`,
+  );
+  defaultRuntime.log(`Updated ${path.relative(process.cwd(), packagePath) || "package.json"}`);
+}
+
+export async function runPluginsValidateCommand(opts: PluginsValidateOptions): Promise<void> {
+  const rootDir = resolveRootDir(opts.root);
+  const entryPath = resolveEntryPath(rootDir, opts.entry);
+  const entryRelative = normalizeRelativePath(rootDir, entryPath);
+  const packageManifest = readPackageManifest(rootDir);
+  const manifestResult = loadPluginManifest(rootDir, false);
+  if (!manifestResult.ok) {
+    defaultRuntime.error(manifestResult.error);
+    return defaultRuntime.exit(1);
+  }
+  const manifest = readJsonFile(path.join(rootDir, PLUGIN_MANIFEST_FILENAME));
+  const { metadata } = await loadToolPlugin({ rootDir, entryPath });
+  const errors = validateToolPluginProject({
+    metadata,
+    manifest,
+    packageManifest,
+    entry: entryRelative,
+  });
+  if (errors.length > 0) {
+    for (const error of errors) {
+      defaultRuntime.error(error);
+    }
+    return defaultRuntime.exit(1);
+  }
+  defaultRuntime.log(`Plugin ${metadata.id} is valid.`);
+}
+
+function assertCanCreate(filePath: string, force: boolean): void {
+  if (!force && fs.existsSync(filePath)) {
+    throw new Error(`Refusing to overwrite existing path: ${filePath}`);
+  }
+}
+
+function titleFromId(id: string): string {
+  return id
+    .split(/[-_]/u)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export async function runPluginsInitCommand(id: string, opts: PluginsInitOptions): Promise<void> {
+  const rootDir = path.resolve(opts.directory ?? id);
+  const force = opts.force === true;
+  const name = opts.name ?? titleFromId(id);
+  assertCanCreate(rootDir, force);
+  fs.mkdirSync(path.join(rootDir, "src"), { recursive: true });
+
+  const packageManifest = {
+    name: `openclaw-plugin-${id}`,
+    version: "0.1.0",
+    type: "module",
+    private: true,
+    scripts: {
+      build: "tsc -p tsconfig.json",
+      "plugin:build": "npm run build && openclaw plugins build --entry ./dist/index.js",
+      "plugin:validate": "npm run build && openclaw plugins validate --entry ./dist/index.js",
+      test: "vitest run",
+    },
+    files: ["dist", "openclaw.plugin.json", "README.md"],
+    peerDependencies: {
+      openclaw: ">=2026.5.17",
+    },
+    dependencies: {
+      typebox: "^1.1.38",
+    },
+    devDependencies: {
+      openclaw: "latest",
+      typescript: "^5.9.0",
+      vitest: "^3.2.0",
+    },
+    openclaw: {
+      extensions: ["./dist/index.js"],
+    },
+  };
+  const idLiteral = jsStringLiteral(id);
+  const nameLiteral = jsStringLiteral(name);
+  const descriptionLiteral = jsStringLiteral(`Add ${name} tools to OpenClaw.`);
+  const indexSource = `import { Type } from "typebox";
+import { defineToolPlugin } from "openclaw/plugin-sdk/tool-plugin";
+
+export default defineToolPlugin({
+  id: ${idLiteral},
+  name: ${nameLiteral},
+  description: ${descriptionLiteral},
+  tools: (tool) => [
+    tool({
+      name: "echo",
+      description: "Echo input text.",
+      parameters: Type.Object({
+        input: Type.String({ description: "Text to echo." }),
+      }),
+      execute: async ({ input }) => ({ input }),
+    }),
+  ],
+});
+`;
+  const testSource = `import { describe, expect, it } from "vitest";
+import entry from "./index.js";
+import { getToolPluginMetadata } from "openclaw/plugin-sdk/tool-plugin";
+
+describe(${idLiteral}, () => {
+  it("declares tool metadata", () => {
+    expect(getToolPluginMetadata(entry)?.tools.map((tool) => tool.name)).toEqual(["echo"]);
+  });
+});
+`;
+  const readmeSource = `# ${name}
+
+Simple OpenClaw tool plugin.
+
+## Build
+
+\`\`\`bash
+npm install
+npm run plugin:build
+npm run plugin:validate
+npm test
+\`\`\`
+`;
+  const tsconfig = {
+    compilerOptions: {
+      target: "ES2022",
+      module: "NodeNext",
+      moduleResolution: "NodeNext",
+      strict: true,
+      declaration: true,
+      outDir: "dist",
+      skipLibCheck: true,
+    },
+    include: ["src/**/*.ts"],
+  };
+
+  writeJsonFile(path.join(rootDir, "package.json"), packageManifest);
+  fs.writeFileSync(path.join(rootDir, "src/index.ts"), indexSource);
+  fs.writeFileSync(path.join(rootDir, "src/index.test.ts"), testSource);
+  fs.writeFileSync(path.join(rootDir, "README.md"), readmeSource);
+  writeJsonFile(path.join(rootDir, "tsconfig.json"), tsconfig);
+  writeJsonFile(path.join(rootDir, PLUGIN_MANIFEST_FILENAME), {
+    id,
+    name,
+    description: `Add ${name} tools to OpenClaw.`,
+    version: packageManifest.version,
+    configSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: {},
+    },
+    activation: { onStartup: true },
+    contracts: { tools: ["echo"] },
+  });
+  defaultRuntime.log(`Created ${path.relative(process.cwd(), rootDir) || "."}`);
+}

--- a/src/cli/plugins-authoring-command.ts
+++ b/src/cli/plugins-authoring-command.ts
@@ -1,13 +1,19 @@
 import fs from "node:fs";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
 import { getToolPluginMetadata, type ToolPluginMetadata } from "../plugin-sdk/tool-plugin.js";
 import {
   loadPluginManifest,
   PLUGIN_MANIFEST_FILENAME,
   resolvePackageExtensionEntries,
 } from "../plugins/manifest.js";
+import { unwrapDefaultModuleExport } from "../plugins/module-export.js";
+import {
+  createPluginModuleLoaderCache,
+  getCachedPluginModuleLoader,
+} from "../plugins/plugin-module-loader-cache.js";
+import { buildPluginLoaderAliasMap } from "../plugins/sdk-alias.js";
 import { defaultRuntime } from "../runtime.js";
+import { toSafeImportPath } from "../shared/import-specifier.js";
 import { isRecord } from "../utils.js";
 
 type JsonObject = Record<string, unknown>;
@@ -33,6 +39,8 @@ type LoadedToolPlugin = {
   entry: unknown;
   metadata: ToolPluginMetadata;
 };
+
+const toolPluginEntryModuleLoaders = createPluginModuleLoaderCache();
 
 function readJsonFile(filePath: string): JsonObject {
   return JSON.parse(fs.readFileSync(filePath, "utf8")) as JsonObject;
@@ -83,12 +91,21 @@ function readPackageManifest(rootDir: string): JsonObject {
 }
 
 async function importToolPluginEntry(entryPath: string): Promise<unknown> {
-  const mod = (await import(pathToFileURL(entryPath).href)) as {
-    default?: unknown;
-    createEntry?: unknown;
-    entry?: unknown;
-  };
-  const candidate = mod.default ?? mod.createEntry ?? mod.entry;
+  const loader = getCachedPluginModuleLoader({
+    cache: toolPluginEntryModuleLoaders,
+    modulePath: entryPath,
+    importerUrl: import.meta.url,
+    loaderFilename: entryPath,
+    aliasMap: buildPluginLoaderAliasMap(entryPath, process.argv[1], import.meta.url),
+  });
+  const loaded = loader(toSafeImportPath(entryPath));
+  const mod =
+    loaded && typeof loaded === "object"
+      ? (loaded as { default?: unknown; createEntry?: unknown; entry?: unknown })
+      : undefined;
+  const candidate = unwrapDefaultModuleExport(
+    mod?.default ?? mod?.createEntry ?? mod?.entry ?? loaded,
+  );
   return typeof candidate === "function" ? (candidate as () => unknown)() : candidate;
 }
 

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -33,6 +33,23 @@ export type PluginRegistryOptions = {
   refresh?: boolean;
 };
 
+export type PluginAuthoringBuildOptions = {
+  root?: string;
+  entry?: string;
+  check?: boolean;
+};
+
+export type PluginAuthoringValidateOptions = {
+  root?: string;
+  entry?: string;
+};
+
+export type PluginAuthoringInitOptions = {
+  directory?: string;
+  force?: boolean;
+  name?: string;
+};
+
 export function registerPluginsCli(program: Command) {
   const plugins = program
     .command("plugins")
@@ -178,6 +195,39 @@ export function registerPluginsCli(program: Command) {
     .action(async () => {
       const { runPluginsDoctorCommand } = await import("./plugins-cli.runtime.js");
       await runPluginsDoctorCommand();
+    });
+
+  plugins
+    .command("build")
+    .description("Generate simple tool plugin metadata")
+    .option("--root <path>", "Plugin package root")
+    .option("--entry <path>", "Plugin entry module relative to --root")
+    .option("--check", "Fail if generated metadata is out of date", false)
+    .action(async (opts: PluginAuthoringBuildOptions) => {
+      const { runPluginsBuildCommand } = await import("./plugins-authoring-command.js");
+      await runPluginsBuildCommand(opts);
+    });
+
+  plugins
+    .command("validate")
+    .description("Validate simple tool plugin metadata")
+    .option("--root <path>", "Plugin package root")
+    .option("--entry <path>", "Plugin entry module relative to --root")
+    .action(async (opts: PluginAuthoringValidateOptions) => {
+      const { runPluginsValidateCommand } = await import("./plugins-authoring-command.js");
+      await runPluginsValidateCommand(opts);
+    });
+
+  plugins
+    .command("init")
+    .description("Create a simple tool plugin project")
+    .argument("<id>", "Plugin id")
+    .option("--directory <path>", "Output directory")
+    .option("--name <name>", "Display name")
+    .option("--force", "Overwrite an existing output directory", false)
+    .action(async (id: string, opts: PluginAuthoringInitOptions) => {
+      const { runPluginsInitCommand } = await import("./plugins-authoring-command.js");
+      await runPluginsInitCommand(id, opts);
     });
 
   const marketplace = plugins

--- a/src/plugin-sdk/tool-plugin.test.ts
+++ b/src/plugin-sdk/tool-plugin.test.ts
@@ -74,6 +74,98 @@ describe("defineToolPlugin", () => {
     });
   });
 
+  it("passes optional tools through to runtime registration and metadata", () => {
+    const entry = defineToolPlugin({
+      id: "optional-tools",
+      name: "Optional Tools",
+      description: "Optional tool demo.",
+      tools: (tool) => [
+        tool({
+          name: "optional_echo",
+          description: "Echo input.",
+          parameters: Type.Object({ input: Type.String() }),
+          optional: true,
+          execute: ({ input }) => input,
+        }),
+      ],
+    });
+    const captured = createCapturedPluginRegistration({ id: "optional-tools" });
+    const registerTool = vi.fn();
+    captured.api.registerTool = registerTool as typeof captured.api.registerTool;
+
+    entry.register(captured.api);
+
+    expect(registerTool).toHaveBeenCalledWith(expect.objectContaining({ name: "optional_echo" }), {
+      optional: true,
+    });
+    expect(getToolPluginMetadata(entry)?.tools).toMatchObject([
+      { name: "optional_echo", optional: true },
+    ]);
+  });
+
+  it("supports context factories while keeping static tool metadata", () => {
+    const entry = defineToolPlugin({
+      id: "factory-tools",
+      name: "Factory Tools",
+      description: "Factory tool demo.",
+      configSchema: Type.Object({ prefix: Type.String() }),
+      tools: (tool) => [
+        tool({
+          name: "factory_echo",
+          label: "Factory Echo",
+          description: "Echo input.",
+          parameters: Type.Object({ input: Type.String() }),
+          optional: true,
+          factory({ config, toolContext }) {
+            if (toolContext.sandboxed) {
+              return null;
+            }
+            return {
+              name: "factory_echo",
+              label: "Factory Echo",
+              description: "Echo input.",
+              parameters: Type.Object({ input: Type.String() }),
+              async execute(_toolCallId: string, params: { input?: unknown }) {
+                const input = typeof params.input === "string" ? params.input : "";
+                return {
+                  content: [
+                    {
+                      type: "text",
+                      text: `${config.prefix}:${input}`,
+                    },
+                  ],
+                  details: undefined,
+                };
+              },
+            };
+          },
+        }),
+      ],
+    });
+    const captured = createCapturedPluginRegistration({ id: "factory-tools" });
+    captured.api.pluginConfig = { prefix: "ctx" };
+    const registerTool = vi.fn();
+    captured.api.registerTool = registerTool as typeof captured.api.registerTool;
+
+    entry.register(captured.api);
+
+    expect(registerTool).toHaveBeenCalledWith(expect.any(Function), {
+      name: "factory_echo",
+      optional: true,
+    });
+    expect(getToolPluginMetadata(entry)?.tools).toMatchObject([
+      {
+        name: "factory_echo",
+        label: "Factory Echo",
+        optional: true,
+      },
+    ]);
+
+    const factory = registerTool.mock.calls[0]?.[0] as (ctx: { sandboxed?: boolean }) => unknown;
+    expect(factory({ sandboxed: true })).toBeNull();
+    expect(factory({ sandboxed: false })).toMatchObject({ name: "factory_echo" });
+  });
+
   it("defaults author config to a strict empty object schema", () => {
     const entry = defineToolPlugin({
       id: "empty-config",

--- a/src/plugin-sdk/tool-plugin.test.ts
+++ b/src/plugin-sdk/tool-plugin.test.ts
@@ -1,0 +1,121 @@
+import { Type } from "typebox";
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
+import { createCapturedPluginRegistration } from "../plugins/captured-registration.js";
+import { defineToolPlugin, getToolPluginMetadata } from "./tool-plugin.js";
+
+describe("defineToolPlugin", () => {
+  it("registers declared tools and wraps plain object results", async () => {
+    const entry = defineToolPlugin({
+      id: "stock-quotes",
+      name: "Stock Quotes",
+      description: "Fetch stock quotes.",
+      configSchema: Type.Object({
+        apiKey: Type.String(),
+      }),
+      tools: (tool) => [
+        tool({
+          name: "quote",
+          label: "Quote",
+          description: "Fetch a quote.",
+          parameters: Type.Object({
+            symbol: Type.String(),
+          }),
+          async execute(params, config) {
+            expectTypeOf(params.symbol).toEqualTypeOf<string>();
+            expectTypeOf(config.apiKey).toEqualTypeOf<string>();
+            return { symbol: params.symbol, configured: config.apiKey === "test-key" };
+          },
+        }),
+      ],
+    });
+    const captured = createCapturedPluginRegistration({
+      config: { plugins: { entries: { "stock-quotes": { config: { apiKey: "test-key" } } } } },
+      id: "stock-quotes",
+    });
+    captured.api.pluginConfig = { apiKey: "test-key" };
+
+    entry.register(captured.api);
+
+    expect(captured.tools).toHaveLength(1);
+    expect(captured.tools[0]).toMatchObject({
+      name: "quote",
+      label: "Quote",
+      description: "Fetch a quote.",
+    });
+    const result = await captured.tools[0].execute("call-1", { symbol: "OPEN" });
+    expect(result.details).toEqual({ symbol: "OPEN", configured: true });
+    expect(result.content).toEqual([
+      { type: "text", text: JSON.stringify({ symbol: "OPEN", configured: true }, null, 2) },
+    ]);
+  });
+
+  it("wraps plain string results", async () => {
+    const entry = defineToolPlugin({
+      id: "echo",
+      name: "Echo",
+      description: "Echo input.",
+      tools: (tool) => [
+        tool({
+          name: "echo",
+          description: "Echo input.",
+          parameters: Type.Object({ input: Type.String() }),
+          execute: ({ input }) => input,
+        }),
+      ],
+    });
+    const captured = createCapturedPluginRegistration({ id: "echo" });
+
+    entry.register(captured.api);
+
+    const result = await captured.tools[0].execute("call-1", { input: "hello" });
+    expect(result).toEqual({
+      content: [{ type: "text", text: "hello" }],
+      details: "hello",
+    });
+  });
+
+  it("defaults author config to a strict empty object schema", () => {
+    const entry = defineToolPlugin({
+      id: "empty-config",
+      name: "Empty Config",
+      description: "No config.",
+      tools: () => [],
+    });
+
+    expect(entry.configSchema.jsonSchema).toEqual({
+      type: "object",
+      additionalProperties: false,
+      properties: {},
+    });
+    expect(getToolPluginMetadata(entry)?.configSchema).toEqual({
+      type: "object",
+      additionalProperties: false,
+      properties: {},
+    });
+  });
+
+  it("exposes static metadata for manifest generation without running tools", () => {
+    const execute = vi.fn();
+    const entry = defineToolPlugin({
+      id: "metadata-demo",
+      name: "Metadata Demo",
+      description: "Static metadata.",
+      activation: { onCapabilities: ["tool"] },
+      tools: (tool) => [
+        tool({
+          name: "metadata_tool",
+          description: "Static tool.",
+          parameters: Type.Object({ input: Type.String() }),
+          execute,
+        }),
+      ],
+    });
+
+    expect(execute).not.toHaveBeenCalled();
+    expect(getToolPluginMetadata(entry)).toMatchObject({
+      id: "metadata-demo",
+      activation: { onCapabilities: ["tool"] },
+      tools: [{ name: "metadata_tool", description: "Static tool." }],
+    });
+  });
+});

--- a/src/plugin-sdk/tool-plugin.ts
+++ b/src/plugin-sdk/tool-plugin.ts
@@ -6,7 +6,9 @@ import type { JsonSchemaObject } from "../shared/json-schema.types.js";
 import {
   buildJsonPluginConfigSchema,
   definePluginEntry,
+  type AnyAgentTool,
   type OpenClawPluginApi,
+  type OpenClawPluginToolContext,
 } from "./plugin-entry.js";
 
 const EMPTY_TOOL_PLUGIN_CONFIG_SCHEMA = Type.Object({}, { additionalProperties: false });
@@ -28,24 +30,51 @@ type ToolPluginToolFactory<TConfig> = <TParamsSchema extends TSchema>(
   definition: ToolPluginToolDefinition<TConfig, TParamsSchema>,
 ) => DefinedToolPluginTool;
 
-export type ToolPluginToolDefinition<TConfig, TParamsSchema extends TSchema> = {
+export type ToolPluginFactoryContext<TConfig> = {
+  api: OpenClawPluginApi;
+  config: TConfig;
+  toolContext: OpenClawPluginToolContext;
+};
+
+type ToolPluginToolDefinitionBase<TParamsSchema extends TSchema> = {
   name: string;
   label?: string;
   description: string;
   parameters: TParamsSchema;
-  execute: (
-    params: Static<TParamsSchema>,
-    config: TConfig,
-    context: ToolPluginExecutionContext,
-  ) => unknown;
+  optional?: boolean;
 };
+
+export type ToolPluginToolDefinition<
+  TConfig,
+  TParamsSchema extends TSchema,
+> = ToolPluginToolDefinitionBase<TParamsSchema> &
+  (
+    | {
+        execute: (
+          params: Static<TParamsSchema>,
+          config: TConfig,
+          context: ToolPluginExecutionContext,
+        ) => unknown;
+        factory?: never;
+      }
+    | {
+        factory: (
+          context: ToolPluginFactoryContext<TConfig>,
+        ) => AnyAgentTool | AnyAgentTool[] | null | undefined;
+        execute?: never;
+      }
+  );
 
 type DefinedToolPluginTool = {
   name: string;
   label: string;
   description: string;
   parameters: TSchema;
-  execute: (params: unknown, config: unknown, context: ToolPluginExecutionContext) => unknown;
+  optional: boolean;
+  execute?: (params: unknown, config: unknown, context: ToolPluginExecutionContext) => unknown;
+  factory?: (
+    context: ToolPluginFactoryContext<unknown>,
+  ) => AnyAgentTool | AnyAgentTool[] | null | undefined;
 };
 
 export type ToolPluginStaticToolMetadata = {
@@ -53,6 +82,7 @@ export type ToolPluginStaticToolMetadata = {
   label: string;
   description: string;
   parameters: JsonSchemaObject;
+  optional?: boolean;
 };
 
 export type ToolPluginMetadata = {
@@ -92,7 +122,9 @@ function createToolPluginToolFactory<TConfig>(): ToolPluginToolFactory<TConfig> 
     label: definition.label ?? definition.name,
     description: definition.description,
     parameters: definition.parameters,
+    optional: definition.optional === true,
     execute: definition.execute as DefinedToolPluginTool["execute"],
+    factory: definition.factory as DefinedToolPluginTool["factory"],
   })) as ToolPluginToolFactory<TConfig>;
 }
 
@@ -118,6 +150,7 @@ export function defineToolPlugin<TConfigSchema extends TSchema | undefined = und
       label: tool.label,
       description: tool.description,
       parameters: tool.parameters as JsonSchemaObject,
+      ...(tool.optional ? { optional: true } : {}),
     })),
   };
 
@@ -129,21 +162,44 @@ export function defineToolPlugin<TConfigSchema extends TSchema | undefined = und
     register(api) {
       const config = (api.pluginConfig ?? {}) as ToolPluginConfig<TConfigSchema>;
       for (const tool of tools) {
-        api.registerTool({
+        const opts = {
           name: tool.name,
-          label: tool.label,
-          description: tool.description,
-          parameters: tool.parameters,
-          execute: async (toolCallId, params, signal, onUpdate) =>
-            wrapToolPluginResult(
-              await tool.execute(params, config, {
+          ...(tool.optional ? { optional: true } : {}),
+        };
+        if (tool.factory) {
+          api.registerTool(
+            (toolContext) =>
+              tool.factory?.({
                 api,
-                signal,
-                toolCallId,
-                onUpdate,
+                config,
+                toolContext,
               }),
-            ),
-        });
+            opts,
+          );
+          continue;
+        }
+        const execute = tool.execute;
+        if (!execute) {
+          throw new Error(`tool plugin tool ${tool.name} must define execute or factory`);
+        }
+        api.registerTool(
+          {
+            name: tool.name,
+            label: tool.label,
+            description: tool.description,
+            parameters: tool.parameters,
+            execute: async (toolCallId, params, signal, onUpdate) =>
+              wrapToolPluginResult(
+                await execute(params, config, {
+                  api,
+                  signal,
+                  toolCallId,
+                  onUpdate,
+                }),
+              ),
+          },
+          tool.optional ? { optional: true } : undefined,
+        );
       }
     },
   }) as DefinedToolPluginEntry;

--- a/src/plugin-sdk/tool-plugin.ts
+++ b/src/plugin-sdk/tool-plugin.ts
@@ -1,0 +1,167 @@
+import type { AgentToolResult, AgentToolUpdateCallback } from "@earendil-works/pi-agent-core";
+import { Type, type Static, type TSchema } from "typebox";
+import { jsonResult, textResult } from "../agents/tools/common.js";
+import type { PluginManifestActivation } from "../plugins/manifest.js";
+import type { JsonSchemaObject } from "../shared/json-schema.types.js";
+import {
+  buildJsonPluginConfigSchema,
+  definePluginEntry,
+  type OpenClawPluginApi,
+} from "./plugin-entry.js";
+
+const EMPTY_TOOL_PLUGIN_CONFIG_SCHEMA = Type.Object({}, { additionalProperties: false });
+
+export const toolPluginMetadataSymbol = Symbol.for("openclaw.plugin-sdk.tool-plugin.metadata");
+
+export type ToolPluginExecutionContext = {
+  api: OpenClawPluginApi;
+  signal?: AbortSignal;
+  toolCallId: string;
+  onUpdate?: AgentToolUpdateCallback<unknown>;
+};
+
+type ToolPluginConfig<TConfigSchema extends TSchema | undefined> = TConfigSchema extends TSchema
+  ? Static<TConfigSchema>
+  : Record<string, never>;
+
+type ToolPluginToolFactory<TConfig> = <TParamsSchema extends TSchema>(
+  definition: ToolPluginToolDefinition<TConfig, TParamsSchema>,
+) => DefinedToolPluginTool;
+
+export type ToolPluginToolDefinition<TConfig, TParamsSchema extends TSchema> = {
+  name: string;
+  label?: string;
+  description: string;
+  parameters: TParamsSchema;
+  execute: (
+    params: Static<TParamsSchema>,
+    config: TConfig,
+    context: ToolPluginExecutionContext,
+  ) => unknown;
+};
+
+type DefinedToolPluginTool = {
+  name: string;
+  label: string;
+  description: string;
+  parameters: TSchema;
+  execute: (params: unknown, config: unknown, context: ToolPluginExecutionContext) => unknown;
+};
+
+export type ToolPluginStaticToolMetadata = {
+  name: string;
+  label: string;
+  description: string;
+  parameters: JsonSchemaObject;
+};
+
+export type ToolPluginMetadata = {
+  id: string;
+  name: string;
+  description: string;
+  activation: PluginManifestActivation;
+  configSchema: JsonSchemaObject;
+  tools: ToolPluginStaticToolMetadata[];
+};
+
+export type DefineToolPluginOptions<TConfigSchema extends TSchema | undefined = undefined> = {
+  id: string;
+  name: string;
+  description: string;
+  activation?: PluginManifestActivation;
+  configSchema?: TConfigSchema;
+  tools: (
+    tool: ToolPluginToolFactory<ToolPluginConfig<TConfigSchema>>,
+  ) => readonly DefinedToolPluginTool[];
+};
+
+export type DefinedToolPluginEntry = ReturnType<typeof definePluginEntry> & {
+  [toolPluginMetadataSymbol]: ToolPluginMetadata;
+};
+
+function wrapToolPluginResult(result: unknown): AgentToolResult<unknown> {
+  if (typeof result === "string") {
+    return textResult(result, result);
+  }
+  return jsonResult(result);
+}
+
+function createToolPluginToolFactory<TConfig>(): ToolPluginToolFactory<TConfig> {
+  return ((definition: ToolPluginToolDefinition<TConfig, TSchema>) => ({
+    name: definition.name,
+    label: definition.label ?? definition.name,
+    description: definition.description,
+    parameters: definition.parameters,
+    execute: definition.execute as DefinedToolPluginTool["execute"],
+  })) as ToolPluginToolFactory<TConfig>;
+}
+
+export function defineToolPlugin<TConfigSchema extends TSchema | undefined = undefined>(
+  definition: DefineToolPluginOptions<TConfigSchema>,
+): DefinedToolPluginEntry {
+  const configSchema = (definition.configSchema ??
+    EMPTY_TOOL_PLUGIN_CONFIG_SCHEMA) as JsonSchemaObject;
+  const pluginConfigSchema = buildJsonPluginConfigSchema(configSchema);
+  const normalizedConfigSchema = pluginConfigSchema.jsonSchema ?? configSchema;
+  const tools = [
+    ...definition.tools(createToolPluginToolFactory<ToolPluginConfig<TConfigSchema>>()),
+  ];
+  const activation = definition.activation ?? { onStartup: true };
+  const metadata: ToolPluginMetadata = {
+    id: definition.id,
+    name: definition.name,
+    description: definition.description,
+    activation,
+    configSchema: normalizedConfigSchema,
+    tools: tools.map((tool) => ({
+      name: tool.name,
+      label: tool.label,
+      description: tool.description,
+      parameters: tool.parameters as JsonSchemaObject,
+    })),
+  };
+
+  const entry = definePluginEntry({
+    id: definition.id,
+    name: definition.name,
+    description: definition.description,
+    configSchema: pluginConfigSchema,
+    register(api) {
+      const config = (api.pluginConfig ?? {}) as ToolPluginConfig<TConfigSchema>;
+      for (const tool of tools) {
+        api.registerTool({
+          name: tool.name,
+          label: tool.label,
+          description: tool.description,
+          parameters: tool.parameters,
+          execute: async (toolCallId, params, signal, onUpdate) =>
+            wrapToolPluginResult(
+              await tool.execute(params, config, {
+                api,
+                signal,
+                toolCallId,
+                onUpdate,
+              }),
+            ),
+        });
+      }
+    },
+  }) as DefinedToolPluginEntry;
+
+  Object.defineProperty(entry, toolPluginMetadataSymbol, {
+    value: metadata,
+    enumerable: false,
+  });
+  return entry;
+}
+
+export function getToolPluginMetadata(entry: unknown): ToolPluginMetadata | undefined {
+  if (!entry || typeof entry !== "object") {
+    return undefined;
+  }
+  const metadata = (entry as { [toolPluginMetadataSymbol]?: unknown })[toolPluginMetadataSymbol];
+  if (!metadata || typeof metadata !== "object") {
+    return undefined;
+  }
+  return metadata as ToolPluginMetadata;
+}


### PR DESCRIPTION
## Summary

- Add `defineToolPlugin` as a typed SDK helper for simple tool-only plugins, including optional tool metadata and context-backed factories.
- Add `openclaw plugins init`, `build`, and `validate` so generated `openclaw.plugin.json` and `package.json` extension entries stay in sync with the plugin entry.
- Dogfood the helper in the bundled `llm-task` plugin and document the npm/package authoring workflow in `docs/plugins/tool-plugins.md` plus the CLI/plugin SDK reference pages.

## Verification

- `node scripts/run-vitest.mjs src/plugin-sdk/tool-plugin.test.ts src/cli/plugins-authoring-command.test.ts` (16 tests passed; rerun by Codex review)
- `node scripts/run-vitest.mjs src/plugin-sdk/tool-plugin.test.ts src/cli/plugins-authoring-command.test.ts extensions/llm-task/src/llm-task-tool.test.ts -- --reporter=verbose` (31 tests passed before final source-loader fix)
- `pnpm check:changed` (Testbox `tbx_01krtr5zy3aabxe6pejqha1bev`, Actions run https://github.com/openclaw/openclaw/actions/runs/25988511278, passed)
- `pnpm openclaw plugins build --root extensions/llm-task --check && pnpm openclaw plugins validate --root extensions/llm-task` (`Plugin metadata is up to date.` and `Plugin llm-task is valid.`)
- `pnpm check:docs`
- `pnpm plugin-sdk:api:check`
- `node scripts/check-plugin-sdk-subpath-exports.mjs`
- `git diff --check`
- Codex review: clean after fixing the accepted source-entry loader finding

## Real behavior proof

Behavior addressed: simple tool-only plugin authoring through `defineToolPlugin`, generated plugin metadata, optional tool declarations, and source or dist entry validation.

Real environment tested: local OpenClaw checkout using the OpenClaw CLI against the bundled `extensions/llm-task` plugin, plus Blacksmith Testbox changed gate for the full touched surface.

Exact steps or command run after this patch: `pnpm openclaw plugins build --root extensions/llm-task --check && pnpm openclaw plugins validate --root extensions/llm-task`

Evidence after fix: the command loaded the package source entry `./index.ts`, resolved `openclaw/plugin-sdk/tool-plugin` through the plugin SDK alias loader, checked generated metadata, then validated the manifest/package/entry agreement.

Observed result after fix: `Plugin metadata is up to date.` followed by `Plugin llm-task is valid.` Testbox `tbx_01krtr5zy3aabxe6pejqha1bev` also passed `pnpm check:changed` for head `9ec68e3eda390aaea9a4eeba7712ea97e2f7af6a`.

What was not tested: publishing a third-party npm package to the public registry; the scaffold and docs cover npm packaging, but no package was published from this PR.
