### PR TITLE
gateway: standardize URL base to localhost in mcp-http and tools-invoke handlers

### DIFF
--- a/src/gateway/mcp-http.request.ts
+++ b/src/gateway/mcp-http.request.ts
@@ -115,7 +115,7 @@ export function validateMcpLoopbackRequest(params: {
 }): { senderIsOwner: boolean } | null {
   let url: URL;
   try {
-    url = new URL(params.req.url ?? "/", `http://${params.req.headers.host ?? "localhost"}`);
+    url = new URL(params.req.url ?? "/", "http://localhost");
   } catch {
     logMcpLoopbackHttp("reject", { reason: "bad_request_url", method: params.req.method ?? "" });
     params.res.writeHead(400, { "Content-Type": "application/json" });

--- a/src/gateway/tools-invoke-http.ts
+++ b/src/gateway/tools-invoke-http.ts
@@ -29,7 +29,7 @@ export async function handleToolsInvokeHttpRequest(
 ): Promise<boolean> {
   let url: URL;
   try {
-    url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+    url = new URL(req.url ?? "/", "http://localhost");
   } catch {
     res.writeHead(400, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ error: "bad_request", message: "Invalid request URL" }));


### PR DESCRIPTION
## Summary

Switches two remaining gateway HTTP handlers from a Host-header-derived URL base to the literal `"http://localhost"`, matching the pattern already used elsewhere in `src/gateway/` on `main`:

- `src/gateway/mcp-http.request.ts` - `validateMcpLoopbackRequest`
- `src/gateway/tools-invoke-http.ts` - `handleToolsInvokeHttpRequest`

This closes the gap noted in #59696's review (`P3` finding pointing to `mcp-http.request.ts`) and adds the analogous fix in `tools-invoke-http.ts`, while staying on top of current `main`.

## Why this is a separate PR

`main` has independently landed the same `localhost`-base treatment for the other four handlers (`http-endpoint-helpers`, `models-http`, `session-kill-http`, `sessions-history-http`) since #59696 was opened, leaving these two as the remaining stragglers. Rebasing the original branch was not viable (`no merge base` vs current `main`), so a clean two-line PR off `main` HEAD is the lightest path forward. Suggesting #59696 can be closed in favor of this once merged.

## Security

No dependency, workflow, package-script, secret-handling, permission, or third-party execution surface is touched. Only the URL constructor's `base` argument changes value.

cc `@clawsweeper`

## Real behavior proof

- **Behavior or issue addressed**: The remaining gateway URL parsers no longer derive their URL base from the attacker-controlled `Host` header.
- **Real environment tested**: PolyU Linux workspace, OpenClaw checkout refreshed from current `origin/main`, branch `codex-refresh-83010`, inspected with the real `git` and `rg` CLIs against the patched repository.
- **Exact steps or command run after this patch**:

```bash
git diff -- src/gateway/mcp-http.request.ts src/gateway/tools-invoke-http.ts
rg -n 'new URL|http://localhost|headers\.host' src/gateway/mcp-http.request.ts src/gateway/tools-invoke-http.ts
```

- **Evidence after fix**:

```text
src/gateway/mcp-http.request.ts:118:    url = new URL(params.req.url ?? "/", "http://localhost");
src/gateway/tools-invoke-http.ts:32:    url = new URL(req.url ?? "/", "http://localhost");
```

- **Observed result after fix**: Both patched handlers now parse request URLs with a constant localhost base, and no `headers.host`-derived base remains in these two files.
- **What was not tested**: Full project test suite was not run locally because this checkout has no installed `node_modules`; CI should run the complete project checks.
