### PR TITLE
feat(diagnostics): trace secret preparation timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 - Docs: clarify media provider credentials, Codex/OpenClaw code-mode boundaries, Slack and Telegram ack reactions, Feishu dynamic agents, secrets plaintext boundaries, memory guidance, and Chinese glossary terms. Thanks @nielskaspers, @cosmopolitan033, @drclaw-iq, @alexgduarte, @zccyman, @chengoak, and @cassthebandit.
 - Packaging: exclude documentation images and assets from the npm tarball, reducing published package size without affecting runtime docs search or CLI behavior. Thanks @SebTardif.
 - Media understanding: stop auto-probing Gemini CLI and use Antigravity CLI only as a lower-priority image/video fallback after configured provider APIs.
+- Diagnostics: emit sanitized `secrets.prepare` timeline spans for Gateway secret preparation so operators can distinguish secret startup latency without exposing provider names, secret ids, or secret values. (#83019) Thanks @samzong.
 - Agents/subagents: limit default sub-agent bootstrap context to `AGENTS.md` and `TOOLS.md`, keeping persona, identity, user, memory, heartbeat, and setup files out of delegated workers by default. (#85283) Thanks @100yenadmin.
 - Maintainer skills: exclude plugin SDK/API boundary work from `openclaw-landable-bug-sweep` so bugbash sweeps stay focused on small paper-cut fixes.
 - QA-Lab/diagnostics: extend the OpenTelemetry smoke harness to prove trace, metric, and log export, and add first-class Prometheus and observability smoke aliases.

--- a/src/gateway/server-startup-config.secrets.test.ts
+++ b/src/gateway/server-startup-config.secrets.test.ts
@@ -1,9 +1,10 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { loadAuthProfileStoreWithoutExternalProfiles } from "../agents/auth-profiles.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.js";
+import { measureDiagnosticsTimelineSpan } from "../infra/diagnostics-timeline.js";
 import type { PreparedSecretsRuntimeSnapshot, SecretResolverWarning } from "../secrets/runtime.js";
 import { KNOWN_WEAK_GATEWAY_TOKEN_PLACEHOLDERS } from "./known-weak-gateway-secrets.js";
 import {
@@ -115,6 +116,14 @@ function runtimeSecretsActivatorForTest(params: {
   });
 }
 
+function readTimelineEvents(filePath: string): Array<Record<string, unknown>> {
+  return readFileSync(filePath, "utf8")
+    .trim()
+    .split(/\r?\n/u)
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
 function installGatewayStartupSecretsRuntimeMock(state: GatewayStartupSecretsRuntimeMock) {
   (
     globalThis as typeof globalThis & {
@@ -204,6 +213,122 @@ describe("gateway startup config secret preflight", () => {
       "config.auth.runtime-startup-overrides",
       "config.auth.secrets-activate",
     ]);
+  });
+
+  it("emits sanitized diagnostics timeline spans for secrets preparation", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "openclaw-startup-secrets-timeline-"));
+    const timelinePath = path.join(root, "timeline.jsonl");
+    const previousDiagnostics = process.env.OPENCLAW_DIAGNOSTICS;
+    const previousTimelinePath = process.env.OPENCLAW_DIAGNOSTICS_TIMELINE_PATH;
+    process.env.OPENCLAW_DIAGNOSTICS = "timeline";
+    process.env.OPENCLAW_DIAGNOSTICS_TIMELINE_PATH = timelinePath;
+    try {
+      const config = gatewaySecretRefSnapshot().config;
+      const prepareRuntimeSecretsSnapshot = vi.fn(async ({ config }) => preparedSnapshot(config));
+
+      const activateRuntimeSecrets = createRuntimeSecretsActivator({
+        logSecrets: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+        },
+        emitStateEvent: vi.fn(),
+        prepareRuntimeSecretsSnapshot,
+        activateRuntimeSecretsSnapshot: vi.fn(),
+      });
+
+      await activateRuntimeSecrets(config, { reason: "startup", activate: false });
+
+      const events = readTimelineEvents(timelinePath);
+      expect(events).toHaveLength(2);
+      expect(events.map((event) => event.type)).toEqual(["span.start", "span.end"]);
+      for (const event of events) {
+        expect(event.name).toBe("secrets.prepare");
+        expect(event.phase).toBe("startup");
+        expect(event.attributes).toEqual({
+          activate: false,
+          gatewayAuthSecretRef: true,
+          reason: "startup",
+        });
+      }
+      expect(JSON.stringify(events)).not.toContain("GATEWAY_TOKEN_REF");
+    } finally {
+      if (previousDiagnostics === undefined) {
+        delete process.env.OPENCLAW_DIAGNOSTICS;
+      } else {
+        process.env.OPENCLAW_DIAGNOSTICS = previousDiagnostics;
+      }
+      if (previousTimelinePath === undefined) {
+        delete process.env.OPENCLAW_DIAGNOSTICS_TIMELINE_PATH;
+      } else {
+        process.env.OPENCLAW_DIAGNOSTICS_TIMELINE_PATH = previousTimelinePath;
+      }
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it("omits secret preparation error messages from diagnostics timeline spans", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "openclaw-startup-secrets-timeline-"));
+    const timelinePath = path.join(root, "timeline.jsonl");
+    const previousDiagnostics = process.env.OPENCLAW_DIAGNOSTICS;
+    const previousTimelinePath = process.env.OPENCLAW_DIAGNOSTICS_TIMELINE_PATH;
+    process.env.OPENCLAW_DIAGNOSTICS = "timeline";
+    process.env.OPENCLAW_DIAGNOSTICS_TIMELINE_PATH = timelinePath;
+    try {
+      const prepareRuntimeSecretsSnapshot = vi.fn(async () => {
+        throw new Error('Secret provider "default" is not configured for GATEWAY_TOKEN_REF.');
+      });
+
+      const activateRuntimeSecrets = createRuntimeSecretsActivator({
+        logSecrets: {
+          info: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+        },
+        emitStateEvent: vi.fn(),
+        prepareRuntimeSecretsSnapshot,
+        activateRuntimeSecretsSnapshot: vi.fn(),
+      });
+
+      await expect(
+        prepareGatewayStartupConfig({
+          configSnapshot: gatewaySecretRefSnapshot(),
+          activateRuntimeSecrets,
+          measure: (name, run, options) =>
+            measureDiagnosticsTimelineSpan(name, run, {
+              env: process.env,
+              omitErrorMessage: options?.omitErrorMessage,
+              phase: "startup",
+            }),
+        }),
+      ).rejects.toThrow("Startup failed: required secrets are unavailable.");
+
+      const events = readTimelineEvents(timelinePath);
+      const errorEvents = events.filter((event) => event.type === "span.error");
+      expect(errorEvents.map((event) => event.name)).toEqual([
+        "secrets.prepare",
+        "config.auth.secret-preflight",
+      ]);
+      for (const event of errorEvents) {
+        expect(event.phase).toBe("startup");
+        expect(event.errorName).toBe("Error");
+        expect(event.errorMessage).toBeUndefined();
+      }
+      expect(JSON.stringify(events)).not.toContain("GATEWAY_TOKEN_REF");
+      expect(JSON.stringify(events)).not.toContain("default");
+    } finally {
+      if (previousDiagnostics === undefined) {
+        delete process.env.OPENCLAW_DIAGNOSTICS;
+      } else {
+        process.env.OPENCLAW_DIAGNOSTICS = previousDiagnostics;
+      }
+      if (previousTimelinePath === undefined) {
+        delete process.env.OPENCLAW_DIAGNOSTICS_TIMELINE_PATH;
+      } else {
+        process.env.OPENCLAW_DIAGNOSTICS_TIMELINE_PATH = previousTimelinePath;
+      }
+      rmSync(root, { force: true, recursive: true });
+    }
   });
 
   it("wraps startup secret activation failures without emitting reload state events", async () => {

--- a/src/gateway/server-startup-config.ts
+++ b/src/gateway/server-startup-config.ts
@@ -10,6 +10,7 @@ import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { applyConfigOverrides } from "../config/runtime-overrides.js";
 import type { GatewayAuthConfig, GatewayTailscaleConfig } from "../config/types.gateway.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.openclaw.js";
+import { measureDiagnosticsTimelineSpan } from "../infra/diagnostics-timeline.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import {
@@ -68,7 +69,22 @@ type GatewayStartupConfigOverrides = {
   tailscale?: GatewayTailscaleConfig;
 };
 
-type GatewayStartupConfigMeasure = <T>(name: string, run: () => T | Promise<T>) => Promise<T>;
+type GatewayStartupConfigMeasure = <T>(
+  name: string,
+  run: () => T | Promise<T>,
+  options?: { omitErrorMessage?: boolean },
+) => Promise<T>;
+
+function secretsPrepareTimelineAttributes(
+  config: OpenClawConfig,
+  activationParams: RuntimeSecretsActivationParams,
+) {
+  return {
+    activate: activationParams.activate,
+    gatewayAuthSecretRef: hasActiveGatewayAuthSecretRef(config),
+    reason: activationParams.reason,
+  };
+}
 
 export type GatewayStartupConfigSnapshotLoadResult = {
   snapshot: ConfigFileSnapshot;
@@ -295,10 +311,21 @@ export function createRuntimeSecretsActivator(params: {
             : await loadSecretsRuntime();
         const prepareRuntimeSecretsSnapshot =
           params.prepareRuntimeSecretsSnapshot ?? secretsRuntime!.prepareSecretsRuntimeSnapshot;
-        const prepared = await prepareRuntimeSecretsSnapshot({
-          config: pruneSkippedStartupSecretSurfaces(config),
-          ...(loadAuthStore ? { loadAuthStore } : {}),
-        });
+        const prepared = await measureDiagnosticsTimelineSpan(
+          "secrets.prepare",
+          () =>
+            prepareRuntimeSecretsSnapshot({
+              config: pruneSkippedStartupSecretSurfaces(config),
+              ...(loadAuthStore ? { loadAuthStore } : {}),
+            }),
+          {
+            attributes: secretsPrepareTimelineAttributes(config, activationParams),
+            config,
+            env: process.env,
+            omitErrorMessage: true,
+            phase: activationParams.reason,
+          },
+        );
         return await finishPreparedSnapshot(prepared, activationParams);
       } catch (err) {
         return handleSecretsActivationError(err, activationParams, config);
@@ -358,16 +385,20 @@ export async function prepareGatewayStartupConfig(params: {
     hasActiveGatewayAuthSecretRef(startupPreflightConfig),
   );
   let preflightPrepared: PreparedRuntimeSecretsSnapshot | undefined;
-  const preflightConfig = await measure("config.auth.secret-preflight", async () => {
-    if (!needsAuthSecretPreflight) {
-      return startupPreflightConfig;
-    }
-    preflightPrepared = await params.activateRuntimeSecrets(startupPreflightConfig, {
-      reason: "startup",
-      activate: false,
-    });
-    return preflightPrepared.config;
-  });
+  const preflightConfig = await measure(
+    "config.auth.secret-preflight",
+    async () => {
+      if (!needsAuthSecretPreflight) {
+        return startupPreflightConfig;
+      }
+      preflightPrepared = await params.activateRuntimeSecrets(startupPreflightConfig, {
+        reason: "startup",
+        activate: false,
+      });
+      return preflightPrepared.config;
+    },
+    { omitErrorMessage: true },
+  );
   const canReusePreflightPreparedSnapshot = (config: OpenClawConfig): boolean =>
     Boolean(
       preflightPrepared &&
@@ -418,8 +449,10 @@ export async function prepareGatewayStartupConfig(params: {
     }),
   );
   const activatedConfig = (
-    await measure("config.auth.secrets-activate", () =>
-      activateStartupSecrets(runtimeStartupConfig),
+    await measure(
+      "config.auth.secrets-activate",
+      () => activateStartupSecrets(runtimeStartupConfig),
+      { omitErrorMessage: true },
     )
   ).config;
   return {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -362,7 +362,11 @@ function createGatewayStartupTrace() {
         timelineOptions(),
       );
     },
-    async measure<T>(name: string, run: () => Promise<T> | T): Promise<T> {
+    async measure<T>(
+      name: string,
+      run: () => Promise<T> | T,
+      options: { omitErrorMessage?: boolean } = {},
+    ): Promise<T> {
       const before = performance.now();
       const spanId = `gateway-startup-${++spanSequence}`;
       emitDiagnosticsTimelineEvent(
@@ -401,7 +405,9 @@ function createGatewayStartupTrace() {
             durationMs: now - before,
             attributes: name === mapTimelineName(name) ? undefined : { traceName: name },
             errorName: error instanceof Error ? error.name : typeof error,
-            errorMessage: error instanceof Error ? error.message : String(error),
+            ...(options.omitErrorMessage
+              ? {}
+              : { errorMessage: error instanceof Error ? error.message : String(error) }),
           },
           timelineOptions(),
         );
@@ -601,14 +607,17 @@ export async function startGatewayServer(
   const startupRuntimeConfig = applyConfigOverrides(configSnapshot.config);
   startupTrace.setConfig(startupRuntimeConfig);
   const { prepareGatewayStartupConfig } = await startupConfigModulePromise;
-  const authBootstrap = await startupTrace.measure("config.auth", () =>
-    prepareGatewayStartupConfig({
-      configSnapshot,
-      authOverride: opts.auth,
-      tailscaleOverride: opts.tailscale,
-      activateRuntimeSecrets,
-      measure: (name, run) => startupTrace.measure(name, run),
-    }),
+  const authBootstrap = await startupTrace.measure(
+    "config.auth",
+    () =>
+      prepareGatewayStartupConfig({
+        configSnapshot,
+        authOverride: opts.auth,
+        tailscaleOverride: opts.tailscale,
+        activateRuntimeSecrets,
+        measure: (name, run, measureOptions) => startupTrace.measure(name, run, measureOptions),
+      }),
+    { omitErrorMessage: true },
   );
   cfgAtStart = authBootstrap.cfg;
   startupTrace.setConfig(cfgAtStart);

--- a/src/infra/diagnostics-timeline.test.ts
+++ b/src/infra/diagnostics-timeline.test.ts
@@ -208,6 +208,30 @@ describe("diagnostics timeline", () => {
     expect(errorEvent.errorMessage).toBe("bad plugin");
   });
 
+  it("can omit sensitive span error messages", async () => {
+    const { env, path } = await createTimelineEnv();
+
+    await expect(
+      measureDiagnosticsTimelineSpan(
+        "secrets.prepare",
+        () => {
+          throw new Error('Secret provider "prod" failed for ref "TOKEN_ID"');
+        },
+        { env, omitErrorMessage: true, phase: "startup" },
+      ),
+    ).rejects.toThrow("TOKEN_ID");
+
+    const events = await readTimeline(path);
+    expect(events).toHaveLength(2);
+    const errorEvent = eventRecord(events, 1);
+    expect(errorEvent.type).toBe("span.error");
+    expect(errorEvent.name).toBe("secrets.prepare");
+    expect(errorEvent.errorName).toBe("Error");
+    expect(errorEvent.errorMessage).toBeUndefined();
+    expect(JSON.stringify(events)).not.toContain("TOKEN_ID");
+    expect(JSON.stringify(events)).not.toContain("prod");
+  });
+
   it("records synchronous spans", async () => {
     const { env, path } = await createTimelineEnv();
 

--- a/src/infra/diagnostics-timeline.ts
+++ b/src/infra/diagnostics-timeline.ts
@@ -54,6 +54,7 @@ type DiagnosticsTimelineSpanOptions = {
   attributes?: DiagnosticsTimelineAttributes;
   config?: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
+  omitErrorMessage?: boolean;
 };
 
 type DiagnosticsTimelineOptions = {
@@ -251,7 +252,9 @@ export async function measureDiagnosticsTimelineSpan<T>(
         durationMs: performance.now() - startedAt,
         attributes: options.attributes,
         errorName: error instanceof Error ? error.name : typeof error,
-        errorMessage: error instanceof Error ? error.message : String(error),
+        ...(options.omitErrorMessage
+          ? {}
+          : { errorMessage: error instanceof Error ? error.message : String(error) }),
       },
       { config: options.config, env },
     );
@@ -319,7 +322,9 @@ export function measureDiagnosticsTimelineSpanSync<T>(
         durationMs: performance.now() - startedAt,
         attributes: options.attributes,
         errorName: error instanceof Error ? error.name : typeof error,
-        errorMessage: error instanceof Error ? error.message : String(error),
+        ...(options.omitErrorMessage
+          ? {}
+          : { errorMessage: error instanceof Error ? error.message : String(error) }),
       },
       { config: options.config, env },
     );


### PR DESCRIPTION
## Summary
- rewrites the broad secrets diagnostics PR into a narrow Gateway startup diagnostics slice
- emits sanitized `secrets.prepare` timeline spans with only bounded activation/reason/auth-surface metadata
- omits startup secret/auth timeline error messages so provider names, secret ids, and secret values do not leak into exported diagnostics
- adds focused regression coverage and an unreleased changelog entry crediting @samzong

## Verification
- `git diff --check origin/main...HEAD`
- `AUTOREVIEW_AUTO_TESTS=0 AUTOREVIEW_OPENCLAW_MAINTAINER_VALIDATION=1 .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- AWS Crabbox `run_66637edcfc5d`, lease `cbx_a2e85c0288b0`, provider `aws`, machine `c7a.8xlarge`: `pnpm test:serial src/gateway/server-startup-config.secrets.test.ts src/infra/diagnostics-timeline.test.ts`
- AWS Crabbox fresh-PR `run_db70af42da6d`, lease `cbx_74d6d7f959bd`, provider `aws`, machine `c7a.8xlarge`: `pnpm check:changed`

## Real behavior proof
Behavior addressed: Gateway startup can spend meaningful time preparing runtime secrets, but operators lacked a sanitized timing signal that distinguished this path without exposing secret material or provider-specific values.
Real environment tested: AWS Crabbox Linux `c7a.8xlarge`; focused tests ran from the rebased branch and `check:changed` ran from a fresh checkout of #83019.
Exact steps or command run after this patch: `git diff --check origin/main...HEAD`; the autoreview command above; AWS Crabbox focused `pnpm test:serial src/gateway/server-startup-config.secrets.test.ts src/infra/diagnostics-timeline.test.ts`; AWS Crabbox fresh-PR `pnpm check:changed`.
Evidence after fix: terminal output from AWS Crabbox showed focused gateway/timeline proof and a fresh-PR changed gate at the exact PR head:

```text
run_66637edcfc5d provider=aws lease=cbx_a2e85c0288b0 machine=c7a.8xlarge
src/infra/diagnostics-timeline.test.ts (9 tests) passed
src/gateway/server-startup-config.secrets.test.ts (16 tests) passed
run_db70af42da6d provider=aws lease=cbx_74d6d7f959bd machine=c7a.8xlarge
[check:changed] lanes=core, coreTests, docs
[check:changed] typecheck core
[check:changed] typecheck core tests
[check:changed] lint core
command complete in 2m53.574s total=3m10.233s
exitCode=0
```

Observed result after fix: sanitized `secrets.prepare` success/error timeline spans are covered, sensitive timeline error messages are omitted for secret/auth startup spans, autoreview reported no accepted/actionable findings, and fresh-PR `check:changed` passed.
What was not tested: no local pnpm/Vitest/check commands were run by request; no live external secret-provider integration was exercised because the change is limited to the existing secret preparation timing/timeline wrapper and sanitized error export behavior.
