### PR TITLE
refactor: shorten agent tool descriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ Skills own workflows; root owns hard policy and routing.
 - Protocol version bumps: explicit owner confirmation only; never automatic/generated.
 - Config contract: exported types, schema/help, metadata, baselines, docs aligned. Retired public keys stay retired; compat in raw migration/doctor only.
 - Prompt cache: deterministic ordering for maps/sets/registries/plugin lists/files/network results before model/tool payloads. Preserve old transcript bytes when possible.
+- Agent tool schema cleanup: remove stale args cleanly; no hidden compat for model-facing params just to avoid churn.
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Skills: add a meme-maker skill for curated template search, local SVG/PNG rendering, Imgflip hosted rendering, and Know Your Meme provenance links.
+- Agents/tools: shorten built-in tool descriptions and schema hints across media, messaging, sessions, cron, Gateway, web, image/PDF, TTS, nodes, and plan tools while preserving routing guardrails.
 - Proxy: support HTTPS managed forward-proxy endpoints and scoped `proxy.tls.caFile` CA trust for proxy endpoint TLS. (#79171) Thanks @jesse-merhi.
 - QA-Lab: add first-hour 20-turn and optional 100-turn runtime parity scenarios, with tier metadata for standard and soak QA gates. (#80323) Thanks @100yenadmin.
 - QA-Lab: add a live-only Codex Pi-shaped Read vocabulary canary so runtime parity catches native workspace-read prompt compatibility drift. (#80323) Thanks @100yenadmin.

--- a/src/agents/openclaw-tools.update-plan.test.ts
+++ b/src/agents/openclaw-tools.update-plan.test.ts
@@ -133,7 +133,7 @@ describe("openclaw-tools update_plan gating", () => {
     } as OpenClawConfig;
 
     expectUpdatePlanEnabled({ config }, true);
-    expect(createUpdatePlanTool().displaySummary).toBe("Track a short structured work plan.");
+    expect(createUpdatePlanTool().displaySummary).toBe("Track short work plan.");
   });
 
   it("registers update_plan when the runtime allowlist explicitly requests it", () => {

--- a/src/agents/tool-description-presets.ts
+++ b/src/agents/tool-description-presets.ts
@@ -1,36 +1,33 @@
-export const EXEC_TOOL_DISPLAY_SUMMARY = "Run shell commands that start now.";
-export const PROCESS_TOOL_DISPLAY_SUMMARY = "Inspect and control running exec sessions.";
-export const CRON_TOOL_DISPLAY_SUMMARY = "Schedule cron jobs, reminders, and wake events.";
-export const SESSIONS_LIST_TOOL_DISPLAY_SUMMARY =
-  "List visible sessions with mailbox filters and optional previews.";
-export const SESSIONS_HISTORY_TOOL_DISPLAY_SUMMARY =
-  "Read sanitized message history for a visible session.";
-export const SESSIONS_SEND_TOOL_DISPLAY_SUMMARY =
-  "Send a message to another visible session or configured agent.";
-export const SESSIONS_SPAWN_TOOL_DISPLAY_SUMMARY = "Spawn sub-agent or ACP sessions.";
-export const SESSIONS_SPAWN_SUBAGENT_TOOL_DISPLAY_SUMMARY = "Spawn sub-agent sessions.";
-export const SESSION_STATUS_TOOL_DISPLAY_SUMMARY = "Show session status, usage, and model state.";
-export const UPDATE_PLAN_TOOL_DISPLAY_SUMMARY = "Track a short structured work plan.";
+export const EXEC_TOOL_DISPLAY_SUMMARY = "Run shell now.";
+export const PROCESS_TOOL_DISPLAY_SUMMARY = "Inspect/control exec sessions.";
+export const CRON_TOOL_DISPLAY_SUMMARY = "Schedule reminders, cron, wake events.";
+export const SESSIONS_LIST_TOOL_DISPLAY_SUMMARY = "List visible sessions; filters/previews.";
+export const SESSIONS_HISTORY_TOOL_DISPLAY_SUMMARY = "Read sanitized session history.";
+export const SESSIONS_SEND_TOOL_DISPLAY_SUMMARY = "Message session or configured agent.";
+export const SESSIONS_SPAWN_TOOL_DISPLAY_SUMMARY = "Spawn subagent or ACP session.";
+export const SESSIONS_SPAWN_SUBAGENT_TOOL_DISPLAY_SUMMARY = "Spawn subagent session.";
+export const SESSION_STATUS_TOOL_DISPLAY_SUMMARY = "Show session status/model/usage.";
+export const UPDATE_PLAN_TOOL_DISPLAY_SUMMARY = "Track short work plan.";
 
 export function describeSessionsListTool(): string {
   return [
-    "List visible sessions with optional filters for kind, label, agentId, search, recent activity, derived titles, and last-message previews.",
-    "Use this to discover a target session before calling sessions_history or sessions_send.",
+    "List visible sessions; filter by kind, label, agentId, search, activity.",
+    "Use before sessions_history or sessions_send target selection.",
   ].join(" ");
 }
 
 export function describeSessionsHistoryTool(): string {
   return [
-    "Fetch sanitized message history for a visible session.",
-    "Supports limits and optional tool messages; use this to inspect another session before replying, debugging, or resuming work.",
+    "Fetch sanitized history for visible session.",
+    "Use before replying, debugging, resuming; supports limits/tool messages.",
   ].join(" ");
 }
 
 export function describeSessionsSendTool(): string {
   return [
-    "Send a message into another visible session by sessionKey or label, or to a configured agent by agentId.",
-    "Thread-scoped chat sessions are rejected; target the parent channel session for inter-agent coordination.",
-    "Missing configured agent main sessions are created before send; waits for the target run and returns the updated assistant reply when available.",
+    "Send message to visible session by sessionKey/label, or configured agent by agentId.",
+    "Thread-scoped chats rejected; target parent channel session.",
+    "Creates missing configured-agent main session; waits for reply when available.",
   ].join(" ");
 }
 
@@ -38,46 +35,43 @@ export function describeSessionsSpawnTool(options?: {
   acpAvailable?: boolean;
   threadAvailable?: boolean;
 }): string {
+  const runtimeDescription =
+    options?.acpAvailable === false
+      ? 'Spawn clean child session; default `runtime="subagent"`.'
+      : 'Spawn clean child session; default `runtime="subagent"`; set `runtime="acp"` explicitly for ACP.';
   const baseDescription = [
-    'Spawn a clean isolated session by default with `runtime="subagent"` or `runtime="acp"`.',
+    runtimeDescription,
     options?.threadAvailable
-      ? '`mode="run"` is one-shot and `mode="session"` is persistent and thread-bound.'
-      : '`mode="run"` is one-shot background work.',
-    "Subagents inherit the parent workspace directory automatically.",
-    "Native subagents receive the delegated task in their first visible `[Subagent Task]` message.",
-    'For native subagents only, set `context="fork"` when the child needs the current transcript context; otherwise omit it or use `context="isolated"`.',
-    "Use this when the work should happen in a fresh child session instead of the current one.",
+      ? '`mode="run"` one-shot; `mode="session"` persistent/thread-bound.'
+      : '`mode="run"` one-shot background work.',
+    "Subagents inherit parent workspace.",
+    "Native subagents get task in first visible `[Subagent Task]` message.",
+    'Native only: `context="fork"` only when child needs current transcript; else omit or `isolated`.',
+    "Use for fresh child-session work.",
   ];
   if (options?.acpAvailable === false) {
-    return baseDescription
-      .map((line) =>
-        line.replace(
-          ' with `runtime="subagent"` or `runtime="acp"`',
-          " with the native subagent runtime",
-        ),
-      )
-      .join(" ");
+    return baseDescription.join(" ");
   }
   return [
     ...baseDescription.slice(0, 3),
-    '`runtime="acp"` is for external ACP harness ids such as codex, claude, gemini, or opencode, or agents configured with `agents.list[].runtime.type="acp"`.',
+    '`runtime="acp"` for ACP harness ids: codex, claude, gemini, opencode, or agent ACP runtime config.',
     ...baseDescription.slice(3),
   ].join(" ");
 }
 
 export function describeSessionStatusTool(): string {
   return [
-    "Show a /status-equivalent session status card for the current or another visible session, including usage, time, cost when available, and linked background task context.",
-    'Use `sessionKey="current"` for the current session; do not use UI/client labels such as `openclaw-tui` as session keys.',
-    "Optional `model` sets a per-session model override; `model=default` resets overrides.",
-    "Use this for questions like what model is active or how a session is configured.",
+    "Show /status-like card for current/visible session: model, usage, time, cost, tasks.",
+    'Use `sessionKey="current"` for current session; UI labels like `openclaw-tui` are not keys.',
+    "`model` sets session override; `model=default` resets.",
+    "Use for active model/session config questions.",
   ].join(" ");
 }
 
 export function describeUpdatePlanTool(): string {
   return [
-    "Update the current structured work plan for this run.",
-    "Use this for non-trivial multi-step work so the plan stays current while execution continues.",
-    "Keep steps short, mark at most one step as `in_progress`, and skip this tool for simple one-step tasks.",
+    "Update current run plan.",
+    "Use for non-trivial multi-step work; keep plan current while executing.",
+    "Short steps; max one `in_progress`; skip for simple one-step work.",
   ].join(" ");
 }

--- a/src/agents/tools/agents-list-tool.ts
+++ b/src/agents/tools/agents-list-tool.ts
@@ -34,8 +34,7 @@ export function createAgentsListTool(opts?: {
   return {
     label: "Agents",
     name: "agents_list",
-    description:
-      'List OpenClaw agent ids you can target with `sessions_spawn` when `runtime="subagent"` (based on subagent allowlists).',
+    description: 'List agent ids allowed for `sessions_spawn runtime="subagent"`.',
     parameters: AgentsListToolSchema,
     execute: async () => {
       const cfg = getRuntimeConfig();

--- a/src/agents/tools/cron-tool.schema.test.ts
+++ b/src/agents/tools/cron-tool.schema.test.ts
@@ -78,8 +78,8 @@ describe("CronToolSchema", () => {
     const jobStagger = propertyAt(schemaRecord, "job.schedule.staggerMs");
     const patchStagger = propertyAt(schemaRecord, "patch.schedule.staggerMs");
 
-    expect(jobStagger?.description).toBe("Random jitter in ms (kind=cron)");
-    expect(patchStagger?.description).toBe("Random jitter in ms (kind=cron)");
+    expect(jobStagger?.description).toBe("Jitter ms (kind=cron)");
+    expect(patchStagger?.description).toBe("Jitter ms (kind=cron)");
   });
 
   it("describes cron expressions as local wall-clock time in the supplied timezone", () => {

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -70,9 +70,7 @@ describe("cron tool", () => {
     expect(tool.description).toContain("local wall-clock time");
     expect(tool.description).toContain("do not convert the requested local time to UTC first");
     expect(tool.description).toContain("Gateway host local timezone");
-    expect(tool.description).toContain(
-      'For schedule.kind="at", ISO timestamps without an explicit timezone are treated as UTC.',
-    );
+    expect(tool.description).toContain('For "at", ISO timestamps without timezone are UTC.');
     expect(tool.description).toContain('"expr": "0 18 * * *"');
     expect(tool.description).toContain('"tz": "Asia/Shanghai"');
   });
@@ -435,10 +433,10 @@ describe("cron tool", () => {
   it("documents deferred follow-up guidance in the tool description", () => {
     const tool = createTestCronTool();
     expect(tool.description).toContain(
-      'Use this for reminders, "check back later" requests, delayed follow-ups, and recurring tasks.',
+      "reminders, check-back-later, delayed follow-ups, recurring work",
     );
     expect(tool.description).toContain(
-      "Do not emulate scheduling with exec sleep or process polling.",
+      "Do not emulate scheduling with exec sleep/process polling.",
     );
   });
 

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -139,15 +139,15 @@ function nullableStringArraySchema(description: string) {
 function cronPayloadObjectSchema(params: { toolsAllow: TSchema }) {
   return Type.Object(
     {
-      kind: optionalStringEnum(CRON_PAYLOAD_KINDS, { description: "Payload type" }),
-      text: Type.Optional(Type.String({ description: "Message text (kind=systemEvent)" })),
-      message: Type.Optional(Type.String({ description: "Agent prompt (kind=agentTurn)" })),
+      kind: optionalStringEnum(CRON_PAYLOAD_KINDS, { description: "Payload kind" }),
+      text: Type.Optional(Type.String({ description: "systemEvent text" })),
+      message: Type.Optional(Type.String({ description: "agentTurn prompt" })),
       model: Type.Optional(Type.String({ description: "Model override" })),
-      thinking: Type.Optional(Type.String({ description: "Thinking level override" })),
+      thinking: Type.Optional(Type.String({ description: "Thinking override" })),
       timeoutSeconds: Type.Optional(Type.Number()),
       lightContext: Type.Optional(Type.Boolean()),
       allowUnsafeExternalContent: Type.Optional(Type.Boolean()),
-      fallbacks: Type.Optional(Type.Array(Type.String(), { description: "Fallback model ids" })),
+      fallbacks: Type.Optional(Type.Array(Type.String(), { description: "Fallback models" })),
       toolsAllow: params.toolsAllow,
     },
     { additionalProperties: true },
@@ -157,25 +157,23 @@ function cronPayloadObjectSchema(params: { toolsAllow: TSchema }) {
 const CronScheduleSchema = Type.Optional(
   Type.Object(
     {
-      kind: optionalStringEnum(CRON_SCHEDULE_KINDS, { description: "Schedule type" }),
-      at: Type.Optional(Type.String({ description: "ISO-8601 timestamp (kind=at)" })),
-      everyMs: Type.Optional(Type.Number({ description: "Interval in milliseconds (kind=every)" })),
-      anchorMs: Type.Optional(
-        Type.Number({ description: "Optional start anchor in milliseconds (kind=every)" }),
-      ),
+      kind: optionalStringEnum(CRON_SCHEDULE_KINDS, { description: "Schedule kind" }),
+      at: Type.Optional(Type.String({ description: "ISO-8601 time (kind=at)" })),
+      everyMs: Type.Optional(Type.Number({ description: "Interval ms (kind=every)" })),
+      anchorMs: Type.Optional(Type.Number({ description: "Start anchor ms (kind=every)" })),
       expr: Type.Optional(
         Type.String({
           description:
-            'Cron expression (kind=cron) written in the supplied tz\'s local wall-clock time, or the Gateway host local timezone when tz is omitted; do not convert the requested local time to UTC first. Example: 6pm Shanghai daily is "0 18 * * *" with tz "Asia/Shanghai".',
+            'Cron expr in tz local time; no UTC conversion. Example 6pm Shanghai daily: expr "0 18 * * *", tz "Asia/Shanghai".',
         }),
       ),
       tz: Type.Optional(
         Type.String({
           description:
-            'IANA timezone for interpreting cron wall-clock fields (kind=cron), e.g. "Asia/Shanghai"; if omitted, cron uses the Gateway host local timezone.',
+            'IANA tz for cron fields, e.g. "Asia/Shanghai"; omitted => Gateway host local tz.',
         }),
       ),
-      staggerMs: Type.Optional(Type.Number({ description: "Random jitter in ms (kind=cron)" })),
+      staggerMs: Type.Optional(Type.Number({ description: "Jitter ms (kind=cron)" })),
     },
     { additionalProperties: true },
   ),
@@ -183,7 +181,7 @@ const CronScheduleSchema = Type.Optional(
 
 const CronPayloadSchema = Type.Optional(
   cronPayloadObjectSchema({
-    toolsAllow: Type.Optional(Type.Array(Type.String(), { description: "Allowed tool ids" })),
+    toolsAllow: Type.Optional(Type.Array(Type.String(), { description: "Allowed tools" })),
   }),
 );
 
@@ -195,11 +193,11 @@ const CronDeliverySchema = Type.Optional(
       to: Type.Optional(Type.String({ description: "Delivery target" })),
       threadId: Type.Optional(
         Type.Union([Type.String(), Type.Number()], {
-          description: "Thread/topic id for channels that support threaded delivery",
+          description: "Thread/topic id",
         }),
       ),
       bestEffort: Type.Optional(Type.Boolean()),
-      accountId: Type.Optional(Type.String({ description: "Account target for delivery" })),
+      accountId: Type.Optional(Type.String({ description: "Delivery account" })),
       failureDestination: Type.Optional(
         Type.Object(
           {
@@ -225,19 +223,18 @@ const CronFailureAlertSchema = Type.Optional(
   Type.Unsafe<Record<string, unknown> | false>({
     type: "object",
     properties: {
-      after: Type.Optional(Type.Number({ description: "Failures before alerting" })),
+      after: Type.Optional(Type.Number({ description: "Failures before alert" })),
       channel: Type.Optional(Type.String({ description: "Alert channel" })),
       to: Type.Optional(Type.String({ description: "Alert target" })),
-      cooldownMs: Type.Optional(Type.Number({ description: "Cooldown between alerts in ms" })),
+      cooldownMs: Type.Optional(Type.Number({ description: "Alert cooldown ms" })),
       includeSkipped: Type.Optional(
-        Type.Boolean({ description: "Count consecutive skipped runs toward alerting" }),
+        Type.Boolean({ description: "Skipped runs count toward alert" }),
       ),
       mode: optionalStringEnum(["announce", "webhook"] as const),
       accountId: Type.Optional(Type.String()),
     },
     additionalProperties: true,
-    description:
-      "Failure alert config object, or the boolean value false to disable alerts for this job",
+    description: "Failure alert object; false disables alerts",
   }),
 );
 
@@ -248,16 +245,16 @@ const CronJobObjectSchema = Type.Optional(
       schedule: CronScheduleSchema,
       sessionTarget: Type.Optional(
         Type.String({
-          description: 'Session target: "main", "isolated", "current", or "session:<id>"',
+          description: "main | isolated | current | session:<id>",
         }),
       ),
-      wakeMode: optionalStringEnum(CRON_WAKE_MODES, { description: "When to wake the session" }),
+      wakeMode: optionalStringEnum(CRON_WAKE_MODES, { description: "Wake timing" }),
       payload: CronPayloadSchema,
       delivery: CronDeliverySchema,
       agentId: nullableStringSchema("Agent id, or null to keep it unset"),
-      description: Type.Optional(Type.String({ description: "Human-readable description" })),
+      description: Type.Optional(Type.String({ description: "Human description" })),
       enabled: Type.Optional(Type.Boolean()),
-      deleteAfterRun: Type.Optional(Type.Boolean({ description: "Delete after first execution" })),
+      deleteAfterRun: Type.Optional(Type.Boolean({ description: "Delete after first run" })),
       sessionKey: nullableStringSchema("Explicit session key, or null to clear it"),
       failureAlert: CronFailureAlertSchema,
     },
@@ -307,7 +304,7 @@ export const CronToolSchema = Type.Object(
     contextMessages: Type.Optional(
       Type.Number({ minimum: 0, maximum: REMINDER_CONTEXT_MESSAGES_MAX }),
     ),
-    agentId: Type.Optional(Type.String({ description: "Filter by agent id (list action)" })),
+    agentId: Type.Optional(Type.String({ description: "List filter: agent id" })),
   },
   { additionalProperties: true },
 );
@@ -497,83 +494,83 @@ export function createCronTool(opts?: CronToolOptions, deps?: CronToolDeps): Any
     name: "cron",
     ownerOnly: isOpenClawOwnerOnlyCoreToolName("cron"),
     displaySummary: CRON_TOOL_DISPLAY_SUMMARY,
-    description: `Manage Gateway cron jobs (status/list/get/add/update/remove/run/runs) and send wake events. Use this for reminders, "check back later" requests, delayed follow-ups, and recurring tasks. Do not emulate scheduling with exec sleep or process polling.
+    description: `Manage Gateway cron jobs and wake events: reminders, check-back-later, delayed follow-ups, recurring work. Do not emulate scheduling with exec sleep/process polling.
 
-Main-session cron jobs enqueue system events for heartbeat handling. Isolated cron jobs create background task runs that appear in \`openclaw tasks\`.
+Main cron => system events for heartbeat. Isolated cron => background task in \`openclaw tasks\`.
 
 ACTIONS:
-- status: Check cron scheduler status
-- list: List jobs (use includeDisabled:true to include disabled; agentId filters by agent, auto-filled from session)
-- get: Get one job by id (requires jobId)
-- add: Create job (requires job object, see schema below)
-- update: Modify job (requires jobId + patch object)
-- remove: Delete job (requires jobId)
-- run: Trigger job immediately (requires jobId)
-- runs: Get job run history (requires jobId)
-- wake: Send wake event (requires text, optional mode)
+- status: scheduler status
+- list: jobs; includeDisabled true includes disabled; agentId filter auto-filled from session
+- get: one job; needs jobId
+- add: create job; needs job object
+- update: patch job; needs jobId + patch
+- remove: delete job; needs jobId
+- run: trigger now; needs jobId
+- runs: run history; needs jobId
+- wake: send wake event; needs text, optional mode
 
 JOB SCHEMA (for add action):
 {
-  "name": "string (optional)",
-  "schedule": { ... },      // Required: when to run
-  "payload": { ... },       // Required: what to execute
-  "delivery": { ... },      // Optional: announce summary (isolated/current/session:xxx only) or webhook POST
-  "sessionTarget": "main" | "isolated" | "current" | "session:<custom-id>",  // Optional, defaults based on context
-  "enabled": true | false   // Optional, default true
+  "name": "string",
+  "schedule": { ... },      // required
+  "payload": { ... },       // required
+  "delivery": { ... },      // optional announce for isolated/current/session, webhook for any target
+  "sessionTarget": "main" | "isolated" | "current" | "session:<id>",
+  "enabled": true | false   // default true
 }
 
 SESSION TARGET OPTIONS:
-- "main": Run in the main session (requires payload.kind="systemEvent")
-- "isolated": Run in an ephemeral isolated session (requires payload.kind="agentTurn")
-- "current": Bind to the current session where the cron is created (resolved at creation time)
-- "session:<custom-id>": Run in a persistent named session (e.g., "session:project-alpha-daily")
+- "main": main session; requires payload.kind="systemEvent"
+- "isolated": ephemeral isolated session; requires payload.kind="agentTurn"
+- "current": bind current session at creation
+- "session:<id>": persistent named session
 
-DEFAULT BEHAVIOR (unchanged for backward compatibility):
+DEFAULTS:
 - payload.kind="systemEvent" → defaults to "main"
 - payload.kind="agentTurn" → defaults to "isolated"
-To use current session binding, explicitly set sessionTarget="current".
+Current binding needs sessionTarget="current".
 
 SCHEDULE TYPES (schedule.kind):
-- "at": One-shot at absolute time
+- "at": one-shot absolute time
   { "kind": "at", "at": "<ISO-8601 timestamp>" }
-- "every": Recurring interval
-  { "kind": "every", "everyMs": <interval-ms>, "anchorMs": <optional-start-ms> }
-- "cron": Cron expression evaluated in the supplied timezone, or the Gateway host local timezone when tz is omitted
+- "every": recurring interval
+  { "kind": "every", "everyMs": <ms>, "anchorMs": <optional-ms> }
+- "cron": expr in supplied timezone, or Gateway host local timezone when tz omitted
   { "kind": "cron", "expr": "<cron-expression>", "tz": "<optional-IANA-timezone>" }
-  Write expr in the selected timezone's local wall-clock time; do not convert the requested local time to UTC first.
-  If tz is omitted, do not assume UTC; the Gateway host local timezone is used.
-  Example: "Remind me every day at 6pm Shanghai time" -> { "kind": "cron", "expr": "0 18 * * *", "tz": "Asia/Shanghai" }
+  Write expr in local wall-clock time; do not convert the requested local time to UTC first.
+  tz omitted => Gateway host local timezone, not UTC.
+  Example 6pm Shanghai daily: { "kind": "cron", "expr": "0 18 * * *", "tz": "Asia/Shanghai" }
 
-For schedule.kind="at", ISO timestamps without an explicit timezone are treated as UTC.
+For "at", ISO timestamps without timezone are UTC.
 
 PAYLOAD TYPES (payload.kind):
-- "systemEvent": Injects text as system event into session
+- "systemEvent": inject text as system event
   { "kind": "systemEvent", "text": "<message>" }
-- "agentTurn": Runs agent with message (isolated sessions only)
-  { "kind": "agentTurn", "message": "<prompt>", "model": "<optional>", "thinking": "<optional>", "timeoutSeconds": <optional, 0 means no timeout> }
+- "agentTurn": run agent with prompt; isolated/current/session only
+  { "kind": "agentTurn", "message": "<prompt>", "model": "<optional>", "thinking": "<optional>", "timeoutSeconds": <optional, 0=no timeout> }
 
 DELIVERY (top-level):
   { "mode": "none|announce|webhook", "channel": "<optional>", "to": "<optional>", "threadId": "<optional>", "bestEffort": <optional-bool> }
-  - Default for isolated agentTurn jobs (when delivery omitted): "announce"
-  - announce: send to chat channel (optional channel/to target)
-  - threadId: chat thread/topic id for channels that support threaded delivery
-  - webhook: send finished-run event as HTTP POST to delivery.to (URL required)
-  - If the task needs to send to a specific chat/recipient, set announce delivery.channel/to; do not call messaging tools inside the run.
+  - isolated agentTurn default when omitted: "announce"
+  - announce: send to chat channel; isolated/current/session only; optional channel/to
+  - threadId: chat thread/topic id
+  - webhook: POST finished-run event to delivery.to URL
+  - Specific chat/recipient: set announce delivery.channel/to; do not call messaging tools inside run.
 
 CRITICAL CONSTRAINTS:
 - sessionTarget="main" REQUIRES payload.kind="systemEvent"
 - sessionTarget="isolated" | "current" | "session:xxx" REQUIRES payload.kind="agentTurn"
-- For webhook callbacks, use delivery.mode="webhook" with delivery.to set to a URL.
+- Webhook: delivery.mode="webhook" and delivery.to URL.
 Default: prefer isolated agentTurn jobs unless the user explicitly wants current-session binding.
 
 RESTRICTED CRON RUNS:
-- Some isolated cron runs receive a narrow cron grant for self-cleanup. In that mode, read-only status and list are for self-introspection only, get/runs are allowed for the current job only, and mutation actions remain limited to removing the current cron job.
+- Some isolated cron runs get narrow self-cleanup grant: status/list self-only, get/runs current job only, mutation only remove current job.
 
 WAKE MODES (for wake action):
-- "next-heartbeat" (default): Wake on next heartbeat
-- "now": Wake immediately
+- "next-heartbeat" default: wake next heartbeat
+- "now": wake immediately
 
-Use jobId as the canonical identifier; id is accepted for compatibility. Use contextMessages (0-10) to add previous messages as context to the job text.`,
+Use jobId canonical; id accepted compat. contextMessages (0-10) adds previous messages as job context.`,
     parameters: CronToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -164,13 +164,13 @@ const CronScheduleSchema = Type.Optional(
       expr: Type.Optional(
         Type.String({
           description:
-            'Cron expr in tz local time; no UTC conversion. Example 6pm Shanghai daily: expr "0 18 * * *", tz "Asia/Shanghai".',
+            'Cron expr in tz wall-clock time; do not convert to UTC. Omitted tz => Gateway host local timezone. Example 6pm Shanghai daily: expr "0 18 * * *", tz "Asia/Shanghai".',
         }),
       ),
       tz: Type.Optional(
         Type.String({
           description:
-            'IANA tz for cron fields, e.g. "Asia/Shanghai"; omitted => Gateway host local tz.',
+            'IANA timezone for cron wall-clock fields, e.g. "Asia/Shanghai"; omitted => Gateway host local timezone.',
         }),
       ),
       staggerMs: Type.Optional(Type.Number({ description: "Jitter ms (kind=cron)" })),

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -372,7 +372,7 @@ export function createGatewayTool(opts?: {
     name: "gateway",
     ownerOnly: isOpenClawOwnerOnlyCoreToolName("gateway"),
     description:
-      "Restart, inspect a specific config schema path, apply config, or update the gateway in-place (SIGUSR1). Use config.schema.lookup with a targeted dot path before config edits. Use config.patch for safe partial config updates (merges with existing). Use config.apply only when replacing entire config. Config writes hot-reload when possible and restart when required. Always pass a human-readable completion message via the `note` parameter so the system can deliver it to the user after restart. If restarting during a user task and you still owe the user a reply, pass a specific one-shot `continuationMessage` for what to verify or report after boot; do not write restart sentinel files directly.",
+      "Gateway restart/config/update. Before config edits, use config.schema.lookup with targeted dot path. Prefer config.patch for partial merge; config.apply only full replace. Writes hot-reload or restart as needed. Always pass human `note` for post-restart delivery. If still owe the user a reply, pass one-shot `continuationMessage`; do not write restart sentinel files directly.",
     parameters: GatewayToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;

--- a/src/agents/tools/heartbeat-response-tool.ts
+++ b/src/agents/tools/heartbeat-response-tool.ts
@@ -39,9 +39,9 @@ export function createHeartbeatResponseTool(): AnyAgentTool {
   return {
     label: "Heartbeat",
     name: HEARTBEAT_RESPONSE_TOOL_NAME,
-    displaySummary: "Record a heartbeat outcome and whether it should notify the user.",
+    displaySummary: "Record heartbeat outcome/notify choice.",
     description:
-      "Record the result of a heartbeat run. Use notify=false when nothing should be sent visibly. Use notify=true with notificationText when the user should receive a concise heartbeat alert.",
+      "Record heartbeat result. `notify=false` no visible send. `notify=true` needs concise notificationText.",
     parameters: HeartbeatResponseToolSchema,
     execute: async (_toolCallId, args) => {
       if (!isRecord(args)) {

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -113,94 +113,88 @@ const log = createSubsystemLogger("agents/tools/image-generate");
 const ImageGenerateToolSchema = Type.Object({
   action: Type.Optional(
     Type.String({
-      description:
-        'Optional action: "generate" (default), "status" to inspect the active session task, or "list" to inspect available providers/models.',
+      description: '"generate" default, "status" active task, "list" providers/models.',
     }),
   ),
-  prompt: Type.Optional(Type.String({ description: "Image generation prompt." })),
+  prompt: Type.Optional(Type.String({ description: "Image prompt." })),
   image: Type.Optional(
     Type.String({
-      description: "Optional reference image path or URL for edit mode.",
+      description: "Reference image path/URL for edit.",
     }),
   ),
   images: Type.Optional(
     Type.Array(Type.String(), {
-      description: `Optional reference images for edit mode (up to ${MAX_INPUT_IMAGES}).`,
+      description: `Reference images for edit; max ${MAX_INPUT_IMAGES}.`,
     }),
   ),
   model: Type.Optional(
     Type.String({
       description:
-        "Optional provider/model override, e.g. openai/gpt-image-2; use openai/gpt-image-1.5 for transparent OpenAI backgrounds.",
+        "Provider/model override, e.g. openai/gpt-image-2; transparent OpenAI: openai/gpt-image-1.5.",
     }),
   ),
   filename: Type.Optional(
     Type.String({
-      description:
-        "Optional output filename hint. OpenClaw preserves the basename and saves under its managed media directory.",
+      description: "Output filename hint; basename preserved in managed media dir.",
     }),
   ),
   size: Type.Optional(
     Type.String({
-      description:
-        "Optional size hint like 1024x1024, 1536x1024, 1024x1536, 2048x2048, or 3840x2160.",
+      description: "Size hint: 1024x1024, 1536x1024, 1024x1536, 2048x2048, 3840x2160.",
     }),
   ),
   aspectRatio: Type.Optional(
     Type.String({
-      description:
-        "Optional aspect ratio hint: 1:1, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, or 21:9.",
+      description: "Aspect ratio: 1:1, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9.",
     }),
   ),
   resolution: Type.Optional(
     Type.String({
-      description:
-        "Optional resolution hint: 1K, 2K, or 4K. Useful for Google edit/generation flows.",
+      description: "Resolution: 1K, 2K, 4K; useful for Google.",
     }),
   ),
   quality: optionalStringEnum(SUPPORTED_QUALITIES, {
-    description: "Optional quality hint: low, medium, high, or auto when the provider supports it.",
+    description: "Quality: low, medium, high, auto.",
   }),
   outputFormat: optionalStringEnum(SUPPORTED_OUTPUT_FORMATS, {
-    description: "Optional output format hint: png, jpeg, or webp when the provider supports it.",
+    description: "Output format: png, jpeg, webp.",
   }),
   background: optionalStringEnum(SUPPORTED_BACKGROUNDS, {
-    description:
-      "Optional background hint: transparent, opaque, or auto when the provider supports it. For transparent output use outputFormat png or webp.",
+    description: "Background: transparent, opaque, auto. Transparent needs png/webp output.",
   }),
   openai: Type.Optional(
     Type.Object({
       background: optionalStringEnum(SUPPORTED_BACKGROUNDS, {
         description:
-          "OpenAI-only background hint: transparent, opaque, or auto. For transparent output use outputFormat png or webp; OpenClaw routes the default OpenAI image model to gpt-image-1.5 for this mode.",
+          "OpenAI background: transparent, opaque, auto. Transparent needs png/webp; default model routes to gpt-image-1.5.",
       }),
       moderation: optionalStringEnum(SUPPORTED_OPENAI_MODERATIONS, {
-        description: "OpenAI-only moderation hint: low or auto.",
+        description: "OpenAI moderation: low, auto.",
       }),
       outputCompression: Type.Optional(
         Type.Number({
-          description: "OpenAI-only compression level for jpeg/webp outputFormat, 0-100.",
+          description: "OpenAI jpeg/webp compression 0-100.",
           minimum: 0,
           maximum: 100,
         }),
       ),
       user: Type.Optional(
         Type.String({
-          description: "OpenAI-only stable end-user identifier for abuse monitoring.",
+          description: "OpenAI stable end-user id.",
         }),
       ),
     }),
   ),
   count: Type.Optional(
     Type.Number({
-      description: `Optional number of images to request (1-${MAX_COUNT}).`,
+      description: `Image count 1-${MAX_COUNT}.`,
       minimum: 1,
       maximum: MAX_COUNT,
     }),
   ),
   timeoutMs: Type.Optional(
     Type.Number({
-      description: "Optional provider request timeout in milliseconds.",
+      description: "Provider timeout ms.",
       minimum: 1,
     }),
   ),
@@ -797,7 +791,7 @@ export function createImageGenerateTool(options?: {
     label: "Image Generation",
     name: "image_generate",
     description:
-      'Generate new images or edit reference images with the configured or inferred image-generation model. In session-backed chats, generation runs as a background task; do not call image_generate again for the same request, wait for the completion event, then send the generated attachments through the message tool. For transparent backgrounds, use outputFormat="png" or "webp" and background="transparent"; OpenAI also accepts openai.background and OpenClaw routes the default OpenAI image model to gpt-image-1.5 for that mode. Set agents.defaults.imageGenerationModel.primary to pick a provider/model. Providers declare their own auth/readiness; use action="list" to inspect registered providers, models, readiness, and auth hints; use action="status" to inspect the active task.',
+      'Create/edit images. Session chats: background task; do not call image_generate again for same request; wait completion, then send attachments via message tool. Transparent: outputFormat="png" or "webp" + background="transparent"; OpenAI also supports openai.background and routes default model to gpt-image-1.5. Use action="list" for providers/models/readiness/auth, "status" for active task.',
     parameters: ImageGenerateToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -1474,9 +1474,9 @@ describe("image tool implicit imageModel config", () => {
         type: "object",
         properties: {
           prompt: { type: "string" },
-          image: { description: "Single image path or URL.", type: "string" },
+          image: { description: "One image path/URL.", type: "string" },
           images: {
-            description: "Multiple image paths or URLs (up to maxImages, default 20).",
+            description: "Image paths/URLs; maxImages default 20.",
             type: "array",
             items: { type: "string" },
           },

--- a/src/agents/tools/image-tool.ts
+++ b/src/agents/tools/image-tool.ts
@@ -498,10 +498,10 @@ export function createImageTool(options?: {
   // If model has native vision, images in the prompt are auto-injected
   // so this tool is only needed when image wasn't provided in the prompt
   const description = options?.modelHasVision
-    ? "Analyze one or more images with a vision model. Use image for a single path/URL, or images for multiple (up to 20). Only use this tool when images were NOT already provided in the user's message. Images mentioned in the prompt are automatically visible to you."
+    ? "Analyze images with vision model. Use image for one path/URL, images for max 20. Only use this tool when images were NOT already provided; prompt images already visible."
     : explicitImageModelConfig
-      ? "Analyze one or more images with the configured image model (agents.defaults.imageModel). Use image for a single path/URL, or images for multiple (up to 20). Provide a prompt describing what to analyze."
-      : "Analyze one or more images with an available vision model. Use image for a single path/URL, or images for multiple (up to 20). Provide a prompt describing what to analyze.";
+      ? "Analyze images with configured image model. Use image for one path/URL, images for max 20. Prompt says what to inspect."
+      : "Analyze images with available vision model. Use image for one path/URL, images for max 20. Prompt says what to inspect.";
 
   return {
     label: "Image",
@@ -509,10 +509,10 @@ export function createImageTool(options?: {
     description,
     parameters: Type.Object({
       prompt: Type.Optional(Type.String()),
-      image: Type.Optional(Type.String({ description: "Single image path or URL." })),
+      image: Type.Optional(Type.String({ description: "One image path/URL." })),
       images: Type.Optional(
         Type.Array(Type.String(), {
-          description: "Multiple image paths or URLs (up to maxImages, default 20).",
+          description: "Image paths/URLs; maxImages default 20.",
         }),
       ),
       model: Type.Optional(Type.String()),

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -1386,7 +1386,7 @@ describe("message tool schema scoping", () => {
     expect(getActionEnum(properties)).toContain("read");
     expectStringSchema(properties.messageId, {
       description:
-        "Target message id for read, reaction, edit, delete, pin, or unpin. If omitted for reaction-like actions, defaults to the current inbound message id when available.",
+        "Target message id for read/react/edit/delete/pin/unpin. Reaction-like defaults current inbound id when available.",
     });
   });
 });

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -162,7 +162,7 @@ const presentationMessageSchema = Type.Object(
   },
   {
     description:
-      "Shared presentation payload for rich text, buttons, selects, and context. Core degrades unsupported blocks to text.",
+      "Rich message payload: text/buttons/selects/context. Unsupported blocks degrade to text.",
   },
 );
 
@@ -171,21 +171,19 @@ function buildSendSchema(options: { includePresentation: boolean; includeDeliver
     message: Type.Optional(Type.String()),
     effectId: Type.Optional(
       Type.String({
-        description: "Message effect name/id for sendWithEffect (e.g., invisible ink).",
+        description: "Effect id/name for sendWithEffect.",
       }),
     ),
-    effect: Type.Optional(
-      Type.String({ description: "Alias for effectId (e.g., invisible-ink, balloons)." }),
-    ),
+    effect: Type.Optional(Type.String({ description: "Alias for effectId." })),
     media: Type.Optional(
       Type.String({
-        description: "Media URL or local path. data: URLs are not supported here, use buffer.",
+        description: "Media URL/path. data: use buffer.",
       }),
     ),
     filename: Type.Optional(Type.String()),
     buffer: Type.Optional(
       Type.String({
-        description: "Base64 payload for attachments (optionally a data: URL).",
+        description: "Base64 attachment payload; data URL ok.",
       }),
     ),
     contentType: Type.Optional(Type.String()),
@@ -208,7 +206,7 @@ function buildSendSchema(options: { includePresentation: boolean; includeDeliver
         }),
         {
           description:
-            "Structured media attachments to send with the message. Each item needs media/mediaUrl/path/filePath/fileUrl/url.",
+            "Structured attachments; each needs media/mediaUrl/path/filePath/fileUrl/url.",
         },
       ),
     ),
@@ -216,20 +214,17 @@ function buildSendSchema(options: { includePresentation: boolean; includeDeliver
     threadId: Type.Optional(Type.String()),
     asVoice: Type.Optional(Type.Boolean()),
     silent: Type.Optional(Type.Boolean()),
-    quoteText: Type.Optional(
-      Type.String({ description: "Quote text for Telegram reply_parameters" }),
-    ),
+    quoteText: Type.Optional(Type.String({ description: "Telegram reply quote text." })),
     bestEffort: Type.Optional(Type.Boolean()),
     gifPlayback: Type.Optional(Type.Boolean()),
     forceDocument: Type.Optional(
       Type.Boolean({
-        description: "Send image/GIF/video as document to avoid channel compression.",
+        description: "Send image/GIF/video as document; avoids compression.",
       }),
     ),
     asDocument: Type.Optional(
       Type.Boolean({
-        description:
-          "Send image/GIF/video as document to avoid channel compression. Alias for forceDocument.",
+        description: "Alias for forceDocument.",
       }),
     ),
   };
@@ -252,8 +247,7 @@ function buildSendSchema(options: { includePresentation: boolean; includeDeliver
           ),
         },
         {
-          description:
-            "Shared delivery preferences. pin requests that the sent message be pinned when the channel supports it.",
+          description: "Delivery prefs. pin requests pin when channel supports it.",
         },
       ),
     );
@@ -266,14 +260,13 @@ function buildReactionSchema() {
     messageId: Type.Optional(
       Type.String({
         description:
-          "Target message id for read, reaction, edit, delete, pin, or unpin. If omitted for reaction-like actions, defaults to the current inbound message id when available.",
+          "Target message id for read/react/edit/delete/pin/unpin. Reaction-like defaults current inbound id when available.",
       }),
     ),
     message_id: Type.Optional(
       Type.String({
         // Intentional duplicate alias for tool-schema discoverability in LLMs.
-        description:
-          "snake_case alias of messageId. If omitted for reaction-like actions, defaults to the current inbound message id when available.",
+        description: "snake_case alias of messageId; same defaults.",
       }),
     ),
     emoji: Type.Optional(Type.String()),
@@ -281,7 +274,7 @@ function buildReactionSchema() {
     trackToolCalls: Type.Optional(
       Type.Boolean({
         description:
-          "When true for a reaction to the current inbound message, use that reacted message as the status-reaction target for subsequent tool progress when the channel supports it.",
+          "For current-message reaction, make reacted message the tool-progress reaction target.",
       }),
     ),
     track_tool_calls: Type.Optional(
@@ -313,28 +306,25 @@ function buildPollSchema() {
     pollId: Type.Optional(Type.String()),
     pollOptionId: Type.Optional(
       Type.String({
-        description: "Poll answer id to vote for. Use when the channel exposes stable answer ids.",
+        description: "Poll answer id.",
       }),
     ),
     pollOptionIds: Type.Optional(
       Type.Array(
         Type.String({
-          description:
-            "Poll answer ids to vote for in a multiselect poll. Use when the channel exposes stable answer ids.",
+          description: "Poll answer ids for multiselect.",
         }),
       ),
     ),
     pollOptionIndex: Type.Optional(
       Type.Number({
-        description:
-          "1-based poll option number to vote for, matching the rendered numbered poll choices.",
+        description: "1-based poll option number.",
       }),
     ),
     pollOptionIndexes: Type.Optional(
       Type.Array(
         Type.Number({
-          description:
-            "1-based poll option numbers to vote for in a multiselect poll, matching the rendered numbered poll choices.",
+          description: "1-based poll option numbers for multiselect.",
         }),
       ),
     ),
@@ -361,15 +351,9 @@ function buildPollSchema() {
 
 function buildChannelTargetSchema() {
   return {
-    channelId: Type.Optional(
-      Type.String({ description: "Channel id filter (search/thread list/event create)." }),
-    ),
-    chatId: Type.Optional(
-      Type.String({ description: "Chat id for chat-scoped metadata actions." }),
-    ),
-    channelIds: Type.Optional(
-      Type.Array(Type.String({ description: "Channel id filter (repeatable)." })),
-    ),
+    channelId: Type.Optional(Type.String({ description: "Channel id filter." })),
+    chatId: Type.Optional(Type.String({ description: "Chat id for chat metadata." })),
+    channelIds: Type.Optional(Type.Array(Type.String({ description: "Channel id filter." }))),
     memberId: Type.Optional(Type.String()),
     memberIdType: Type.Optional(Type.String()),
     guildId: Type.Optional(Type.String()),
@@ -416,9 +400,7 @@ function buildEventSchema() {
     endTime: Type.Optional(Type.String()),
     desc: Type.Optional(Type.String()),
     location: Type.Optional(Type.String()),
-    image: Type.Optional(
-      Type.String({ description: "Cover image URL or local file path for the event." }),
-    ),
+    image: Type.Optional(Type.String({ description: "Event cover image URL/path." })),
     durationMin: Type.Optional(Type.Number()),
     until: Type.Optional(Type.String()),
   };
@@ -448,19 +430,17 @@ function buildPresenceSchema() {
     ),
     activityName: Type.Optional(
       Type.String({
-        description: "Activity name shown in sidebar (e.g. 'with fire'). Ignored for custom type.",
+        description: "Activity name shown in sidebar; ignored for custom.",
       }),
     ),
     activityUrl: Type.Optional(
       Type.String({
-        description:
-          "Streaming URL (Twitch or YouTube). Only used with streaming type; may not render for bots.",
+        description: "Streaming URL; streaming type only.",
       }),
     ),
     activityState: Type.Optional(
       Type.String({
-        description:
-          "State text. For custom type this is the status text; for others it shows in the flyout.",
+        description: "State text; custom type uses as status text.",
       }),
     ),
     status: Type.Optional(
@@ -474,8 +454,7 @@ function buildChannelManagementSchema() {
     name: Type.Optional(Type.String()),
     channelType: Type.Optional(
       Type.Number({
-        description:
-          "Numeric channel type (e.g. Discord channel type). Renamed from `type` to avoid JSON Schema keyword collisions that break some OpenAI-compatible providers (notably NVIDIA NIM).",
+        description: "Numeric channel type, e.g. Discord. Avoids JSON Schema `type` collision.",
       }),
     ),
     parentId: Type.Optional(Type.String()),
@@ -486,7 +465,7 @@ function buildChannelManagementSchema() {
     categoryId: Type.Optional(Type.String()),
     clearParent: Type.Optional(
       Type.Boolean({
-        description: "Clear the parent/category when supported by the provider.",
+        description: "Clear parent/category when supported.",
       }),
     ),
   };
@@ -810,7 +789,7 @@ function buildMessageToolDescription(options?: {
   requesterSenderId?: string;
   senderIsOwner?: boolean;
 }): string {
-  const baseDescription = "Send, delete, and manage messages via channel plugins.";
+  const baseDescription = "Send/delete/manage channel messages.";
   const resolvedOptions = options ?? {};
   const messageToolDiscoveryParams = resolvedOptions.config
     ? {
@@ -862,8 +841,8 @@ function appendMessageToolVisibleReplyHint(
   }
   const targetGuidance = requireExplicitTarget
     ? "Include target when sending."
-    : "The target defaults to the current source conversation, so omit target unless sending elsewhere.";
-  return `${description} For this turn, use action="send" with message for visible replies to the current source conversation. ${targetGuidance} Normal final answers stay private.`;
+    : "target defaults to the current source conversation; omit unless sending elsewhere.";
+  return `${description} This turn: use action="send" with message for visible replies to the current source conversation. ${targetGuidance} Normal final answers stay private.`;
 }
 
 function appendMessageToolReadHint(

--- a/src/agents/tools/music-generate-tool.ts
+++ b/src/agents/tools/music-generate-tool.ts
@@ -87,11 +87,10 @@ const MIN_MUSIC_GENERATION_TIMEOUT_MS = 120_000;
 const MusicGenerateToolSchema = Type.Object({
   action: Type.Optional(
     Type.String({
-      description:
-        'Optional action: "generate" (default), "status" to inspect the active session task, or "list" to inspect available providers/models.',
+      description: '"generate" default, "status" active task, "list" providers/models.',
     }),
   ),
-  prompt: Type.Optional(Type.String({ description: "Music generation prompt." })),
+  prompt: Type.Optional(Type.String({ description: "Music prompt: style, genre, mood, purpose." })),
   lyrics: Type.Optional(
     Type.String({
       description:
@@ -100,39 +99,38 @@ const MusicGenerateToolSchema = Type.Object({
   ),
   instrumental: Type.Optional(
     Type.Boolean({
-      description: "Optional toggle for instrumental-only output when the provider supports it.",
+      description: "Instrumental-only toggle.",
     }),
   ),
   image: Type.Optional(
     Type.String({
-      description: "Optional single reference image path or URL.",
+      description: "Reference image path/URL.",
     }),
   ),
   images: Type.Optional(
     Type.Array(Type.String(), {
-      description: `Optional reference images (up to ${MAX_INPUT_IMAGES}).`,
+      description: `Reference images; max ${MAX_INPUT_IMAGES}.`,
     }),
   ),
   model: Type.Optional(
     Type.String({
-      description: "Optional provider/model override, e.g. google/lyria-3-pro-preview.",
+      description: "Provider/model override, e.g. google/lyria-3-pro-preview.",
     }),
   ),
   durationSeconds: Type.Optional(
     Type.Number({
-      description: "Optional target duration in seconds when the provider supports duration hints.",
+      description: "Target seconds; provider may clamp.",
       minimum: 1,
     }),
   ),
   format: Type.Optional(
     Type.String({
-      description: 'Optional output format hint: "mp3" or "wav" when the provider supports it.',
+      description: "Output format: mp3, wav.",
     }),
   ),
   filename: Type.Optional(
     Type.String({
-      description:
-        "Optional output filename hint. OpenClaw preserves the basename and saves under its managed media directory.",
+      description: "Output filename hint; basename preserved in managed media dir.",
     }),
   ),
 });
@@ -601,7 +599,7 @@ export function createMusicGenerateTool(options?: {
     name: "music_generate",
     displaySummary: "Generate music",
     description:
-      'Create actual audio/music tracks from song, jingle, beat, loop, soundtrack, anthem, or instrumental requests. If the user asks to make/generate/create a song or music, call music_generate; do not just write lyrics unless they ask for lyrics/text only. Put style, genre, mood, tempo, instruments, and purpose in prompt. Use lyrics only for exact sung words. In session-backed chats, generation runs as a background task; do not call music_generate again for the same request, wait for the completion event, then send the generated attachments through the message tool. Use action="status" to inspect the active task.',
+      'Create audio/music for song, jingle, beat, loop, soundtrack, anthem, instrumental requests. If user asks make/generate/create song/music, call music_generate; do not just write lyrics unless lyrics/text only. Prompt gets style/genre/mood/tempo/instruments/purpose. lyrics only exact sung words. Session chats: background task; do not call again for same request; wait completion, send attachments via message tool. "status" checks active task.',
     parameters: MusicGenerateToolSchema,
     execute: async (_toolCallId, rawArgs) => {
       const args = rawArgs as Record<string, unknown>;

--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -138,7 +138,7 @@ export function createNodesTool(options?: {
     name: "nodes",
     ownerOnly: isOpenClawOwnerOnlyCoreToolName("nodes"),
     description:
-      "Discover and control paired nodes (status/describe/pairing/notify/camera/photos/screen/location/notifications/invoke). For file retrieval, use the dedicated file_fetch tool.",
+      "Discover/control paired nodes: status, describe, pairing, notify, camera/photos/screen/location/notifications/invoke. Use file_fetch for files.",
     parameters: NodesToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;

--- a/src/agents/tools/pdf-tool.test.ts
+++ b/src/agents/tools/pdf-tool.test.ts
@@ -199,7 +199,7 @@ describe("createPdfTool", () => {
     await withConfiguredPdfTool(async (tool) => {
       expect(tool.name).toBe("pdf");
       expect(tool.label).toBe("PDF");
-      expect(tool.description).toContain("PDF documents");
+      expect(tool.description).toContain("Analyze PDFs");
     });
   });
 

--- a/src/agents/tools/pdf-tool.ts
+++ b/src/agents/tools/pdf-tool.ts
@@ -58,15 +58,15 @@ const PDF_MAX_PIXELS = 4_000_000;
 
 export const PdfToolSchema = Type.Object({
   prompt: Type.Optional(Type.String()),
-  pdf: Type.Optional(Type.String({ description: "Single PDF path or URL." })),
+  pdf: Type.Optional(Type.String({ description: "One PDF path/URL." })),
   pdfs: Type.Optional(
     Type.Array(Type.String(), {
-      description: "Multiple PDF paths or URLs (up to 10).",
+      description: "PDF paths/URLs; max 10.",
     }),
   ),
   pages: Type.Optional(
     Type.String({
-      description: 'Page range to process, e.g. "1-5", "1,3,5-7". Defaults to all pages.',
+      description: 'Pages, e.g. "1-5", "1,3,5-7"; default all.',
     }),
   ),
   model: Type.Optional(Type.String()),
@@ -314,7 +314,7 @@ export function createPdfTool(options?: {
       : DEFAULT_MAX_PAGES;
 
   const description =
-    "Analyze one or more PDF documents with a model. Supports native PDF analysis for Anthropic and Google models, with text/image extraction fallback for other providers. Use pdf for a single path/URL, or pdfs for multiple (up to 10). Provide a prompt describing what to analyze.";
+    "Analyze PDFs with model. Anthropic/Google native PDF when supported; else text/image extraction. Use pdf for one, pdfs for max 10; prompt says what to inspect.";
   const remoteMediaSsrfPolicy = resolveRemoteMediaSsrfPolicy(options?.config);
 
   return {

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -117,7 +117,7 @@ describe("sessions_spawn tool", () => {
       };
     };
 
-    expect(tool.displaySummary).toBe("Spawn sub-agent sessions.");
+    expect(tool.displaySummary).toBe("Spawn subagent session.");
     expect(tool.description).not.toContain("ACP");
     expect(tool.description).not.toContain('runtime="acp"');
     expect(schema.properties?.runtime?.enum).toEqual(["subagent"]);
@@ -137,7 +137,7 @@ describe("sessions_spawn tool", () => {
       };
     };
 
-    expect(tool.displaySummary).toBe("Spawn sub-agent or ACP sessions.");
+    expect(tool.displaySummary).toBe("Spawn subagent or ACP session.");
     expect(tool.description).toContain('runtime="acp"');
     expect(schema.properties?.runtime?.enum).toEqual(["subagent", "acp"]);
     const resumeSessionId = requireSchemaProperty(schema.properties, "resumeSessionId");
@@ -350,7 +350,7 @@ describe("sessions_spawn tool", () => {
     };
 
     expect(requireSchemaProperty(schema.properties, "taskName").description).toContain(
-      "Stable optional alias",
+      "Stable alias",
     );
 
     const result = await tool.execute("call-task-name", {

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -162,7 +162,7 @@ function createSessionsSpawnToolSchema(params: {
     taskName: Type.Optional(
       Type.String({
         description:
-          "Stable optional alias for later subagents targeting. Use lowercase letters, digits, and underscores, starting with a letter.",
+          "Stable alias for later targeting; lowercase letters/digits/underscores, starts letter.",
       }),
     ),
     label: Type.Optional(Type.String()),
@@ -181,7 +181,7 @@ function createSessionsSpawnToolSchema(params: {
           thread: Type.Optional(
             Type.Boolean({
               description:
-                'Bind the spawned session to a new chat thread when the current channel/account supports thread-bound session spawns. `thread=true` defaults mode to "session".',
+                'Bind spawn to new chat thread when supported. `thread=true` defaults mode="session".',
             }),
           ),
         }
@@ -191,12 +191,11 @@ function createSessionsSpawnToolSchema(params: {
     sandbox: optionalStringEnum(SESSIONS_SPAWN_SANDBOX_MODES),
     context: optionalStringEnum(SUBAGENT_SPAWN_CONTEXT_MODES, {
       description:
-        'Native subagent context mode. Omit or use "isolated" for a clean child session; use "fork" only when the child needs the requester transcript context.',
+        'Native context. Omit/"isolated" for clean child; "fork" only when child needs requester transcript.',
     }),
     lightContext: Type.Optional(
       Type.Boolean({
-        description:
-          "When true, spawned subagent runs use lightweight bootstrap context. Only applies to runtime='subagent'.",
+        description: 'Light bootstrap context; runtime="subagent" only.',
       }),
     ),
 
@@ -225,12 +224,12 @@ function createSessionsSpawnToolSchema(params: {
           resumeSessionId: Type.Optional(
             Type.String({
               description:
-                'ACP-only resume target. Only meaningful with runtime="acp"; ignored for runtime="subagent". Use only an ACP/harness session ID already recorded for this requester so the ACP backend replays conversation history instead of starting fresh.',
+                'ACP-only resume target; ignored for runtime="subagent". Use id already recorded for this requester.',
             }),
           ),
           streamTo: optionalStringEnum(SESSIONS_SPAWN_ACP_STREAM_TARGETS, {
             description:
-              'ACP-only stream target. Only meaningful with runtime="acp"; ignored for runtime="subagent". Use "parent" to stream the ACP turn back to the requester instead of tracking it as a background sessions_spawn run.',
+              'ACP-only stream target; ignored for runtime="subagent". Use "parent" to stream turn to requester.',
           }),
         }
       : {}),

--- a/src/agents/tools/sessions-yield-tool.ts
+++ b/src/agents/tools/sessions-yield-tool.ts
@@ -13,8 +13,7 @@ export function createSessionsYieldTool(opts?: {
   return {
     label: "Yield",
     name: "sessions_yield",
-    description:
-      "End your current turn. Use after spawning subagents to receive their results as the next message.",
+    description: "End current turn. Use after spawning subagents; results arrive as next message.",
     parameters: SessionsYieldToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;

--- a/src/agents/tools/subagents-tool.test.ts
+++ b/src/agents/tools/subagents-tool.test.ts
@@ -6,7 +6,7 @@ describe("subagents tool", () => {
     const tool = createSubagentsTool();
 
     expect(tool.description).toBe(
-      "On-demand list, kill, or steer spawned sub-agents for this requester session. If sessions_yield is available, use it to wait for completion events; do not poll this tool in wait loops.",
+      "List/kill/steer spawned subagents for requester session. If sessions_yield exists, use it for completion; do not poll wait loops.",
     );
   });
 });

--- a/src/agents/tools/subagents-tool.ts
+++ b/src/agents/tools/subagents-tool.ts
@@ -35,7 +35,7 @@ export function createSubagentsTool(opts?: { agentSessionKey?: string }): AnyAge
     label: "Subagents",
     name: "subagents",
     description:
-      "On-demand list, kill, or steer spawned sub-agents for this requester session. If sessions_yield is available, use it to wait for completion events; do not poll this tool in wait loops.",
+      "List/kill/steer spawned subagents for requester session. If sessions_yield exists, use it for completion; do not poll wait loops.",
     parameters: SubagentsToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;

--- a/src/agents/tools/tts-tool.ts
+++ b/src/agents/tools/tts-tool.ts
@@ -7,13 +7,11 @@ import type { AnyAgentTool } from "./common.js";
 import { ToolInputError, readNumberParam, readStringParam } from "./common.js";
 
 const TtsToolSchema = Type.Object({
-  text: Type.String({ description: "Text to convert to speech." }),
-  channel: Type.Optional(
-    Type.String({ description: "Optional channel id to pick output format." }),
-  ),
+  text: Type.String({ description: "Text to speak." }),
+  channel: Type.Optional(Type.String({ description: "Channel id; output-format hint." })),
   timeoutMs: Type.Optional(
     Type.Number({
-      description: "Optional provider request timeout in milliseconds.",
+      description: "Provider timeout ms.",
       minimum: 1,
     }),
   ),
@@ -62,10 +60,9 @@ export function createTtsTool(opts?: {
   return {
     label: "TTS",
     name: "tts",
-    displaySummary: "Convert text to speech and return audio.",
+    displaySummary: "Text to speech audio.",
     description:
-      "Use only for explicit audio intent (audio, voice, speech, TTS) or active TTS config. Never use for ordinary text replies. " +
-      "Audio is delivered automatically from the tool result. After a successful call, follow the current conversation's reply instructions and avoid sending a duplicate text/audio response.",
+      "Use only for explicit audio intent (voice/speech/TTS) or active TTS config. Never use for ordinary text replies. Audio auto-delivered from tool result; after success follow reply instructions, no duplicate text/audio.",
     parameters: TtsToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;

--- a/src/agents/tools/update-plan-tool.ts
+++ b/src/agents/tools/update-plan-tool.ts
@@ -11,22 +11,22 @@ const PLAN_STEP_STATUSES = ["pending", "in_progress", "completed"] as const;
 const UpdatePlanToolSchema = Type.Object({
   explanation: Type.Optional(
     Type.String({
-      description: "Optional short note explaining what changed in the plan.",
+      description: "Short note: what changed.",
     }),
   ),
   plan: Type.Array(
     Type.Object(
       {
-        step: Type.String({ description: "Short plan step." }),
+        step: Type.String({ description: "Short step." }),
         status: stringEnum(PLAN_STEP_STATUSES, {
-          description: 'One of "pending", "in_progress", or "completed".',
+          description: "pending | in_progress | completed.",
         }),
       },
       { additionalProperties: true },
     ),
     {
       minItems: 1,
-      description: "Ordered list of plan steps. At most one step may be in_progress.",
+      description: "Ordered steps; max one in_progress.",
     },
   ),
 });

--- a/src/agents/tools/video-generate-tool.ts
+++ b/src/agents/tools/video-generate-tool.ts
@@ -89,128 +89,108 @@ const MAX_INPUT_AUDIOS = 3;
 const VideoGenerateToolSchema = Type.Object({
   action: Type.Optional(
     Type.String({
-      description:
-        'Optional action: "generate" (default), "status" to inspect the active session task, or "list" to inspect available providers/models.',
+      description: '"generate" default, "status" active task, "list" providers/models.',
     }),
   ),
-  prompt: Type.Optional(Type.String({ description: "Video generation prompt." })),
+  prompt: Type.Optional(Type.String({ description: "Video prompt." })),
   image: Type.Optional(
     Type.String({
-      description: "Optional single reference image path or URL.",
+      description: "One reference image path/URL.",
     }),
   ),
   images: Type.Optional(
     Type.Array(Type.String(), {
-      description: `Optional reference images (up to ${MAX_INPUT_IMAGES}).`,
+      description: `Reference images; max ${MAX_INPUT_IMAGES}.`,
     }),
   ),
   imageRoles: Type.Optional(
     Type.Array(Type.String(), {
       description:
-        "Optional semantic roles for the combined reference image list, parallel by index. " +
-        "The list is `image` (if provided) followed by each entry in `images`, in order, " +
-        "after de-duplication. " +
-        'Canonical values: "first_frame", "last_frame", "reference_image". ' +
-        "Providers may accept additional role strings. " +
-        "Must not have more entries than the combined image list; use an empty string to leave a position unset.",
+        "`image` + `images` roles by index after de-dupe. Values: first_frame, last_frame, reference_image; empty string leaves unset.",
     }),
   ),
   video: Type.Optional(
     Type.String({
-      description: "Optional single reference video path or URL.",
+      description: "One reference video path/URL.",
     }),
   ),
   videos: Type.Optional(
     Type.Array(Type.String(), {
-      description: `Optional reference videos (up to ${MAX_INPUT_VIDEOS}).`,
+      description: `Reference videos; max ${MAX_INPUT_VIDEOS}.`,
     }),
   ),
   videoRoles: Type.Optional(
     Type.Array(Type.String(), {
       description:
-        "Optional semantic roles for the combined reference video list, parallel by index. " +
-        "The list is `video` (if provided) followed by each entry in `videos`, in order, " +
-        "after de-duplication. " +
-        'Canonical value: "reference_video". Providers may accept additional role strings. ' +
-        "Must not have more entries than the combined video list; use an empty string to leave a position unset.",
+        "`video` + `videos` roles by index after de-dupe. Value: reference_video; empty string leaves unset.",
     }),
   ),
   audioRef: Type.Optional(
     Type.String({
-      description: "Optional single reference audio path or URL (e.g. background music).",
+      description: "One reference audio path/URL, e.g. music.",
     }),
   ),
   audioRefs: Type.Optional(
     Type.Array(Type.String(), {
-      description: `Optional reference audios (up to ${MAX_INPUT_AUDIOS}).`,
+      description: `Reference audios; max ${MAX_INPUT_AUDIOS}.`,
     }),
   ),
   audioRoles: Type.Optional(
     Type.Array(Type.String(), {
       description:
-        "Optional semantic roles for the combined reference audio list, parallel by index. " +
-        "The list is `audioRef` (if provided) followed by each entry in `audioRefs`, in order, " +
-        "after de-duplication. " +
-        'Canonical value: "reference_audio". Providers may accept additional role strings. ' +
-        "Must not have more entries than the combined audio list; use an empty string to leave a position unset.",
+        "`audioRef` + `audioRefs` roles by index after de-dupe. Value: reference_audio; empty string leaves unset.",
     }),
   ),
   model: Type.Optional(
-    Type.String({ description: "Optional provider/model override, e.g. qwen/wan2.6-t2v." }),
+    Type.String({ description: "Provider/model override, e.g. qwen/wan2.6-t2v." }),
   ),
   filename: Type.Optional(
     Type.String({
-      description:
-        "Optional output filename hint. OpenClaw preserves the basename and saves under its managed media directory.",
+      description: "Output filename hint; basename preserved in managed media dir.",
     }),
   ),
   size: Type.Optional(
     Type.String({
-      description: "Optional size hint like 1280x720 or 1920x1080 when the provider supports it.",
+      description: "Size hint, e.g. 1280x720, 1920x1080.",
     }),
   ),
   aspectRatio: Type.Optional(
     Type.String({
       description:
-        'Optional aspect ratio hint such as 1:1, 16:9, 9:16, "adaptive", or a provider-specific value. OpenClaw normalizes or ignores unsupported values per provider.',
+        'Aspect ratio: 1:1, 16:9, 9:16, "adaptive", or provider value; unsupported normalized/ignored.',
     }),
   ),
   resolution: Type.Optional(
     Type.String({
       description:
-        "Optional resolution hint such as 480P, 720P, 768P, 1080P, 4K, or a provider-specific value. OpenClaw normalizes or ignores unsupported values per provider.",
+        "Resolution: 480P, 720P, 768P, 1080P, 4K, or provider value; unsupported normalized/ignored.",
     }),
   ),
   durationSeconds: Type.Optional(
     Type.Number({
-      description:
-        "Optional target duration in seconds. OpenClaw may round this to the nearest provider-supported duration.",
+      description: "Target seconds; may round to nearest supported duration.",
       minimum: 1,
     }),
   ),
   audio: Type.Optional(
     Type.Boolean({
-      description: "Optional audio toggle when the provider supports generated audio.",
+      description: "Generated-audio toggle.",
     }),
   ),
   watermark: Type.Optional(
     Type.Boolean({
-      description: "Optional watermark toggle when the provider supports it.",
+      description: "Watermark toggle.",
     }),
   ),
   providerOptions: Type.Optional(
     Type.Record(Type.String(), Type.Unknown(), {
       description:
-        'Optional provider-specific options as a JSON object, e.g. `{"seed": 42, "draft": true}`. ' +
-        "Each provider declares its own accepted keys and primitive types (number/boolean/string) " +
-        "via its capabilities; unknown keys or type mismatches skip the candidate during fallback " +
-        "and never silently reach the wrong provider. Run `video_generate action=list` to see which " +
-        "keys each provider accepts.",
+        'Provider JSON options, e.g. {"seed":42}. Keys/types must match provider capabilities; mismatch skips candidate. Use action=list for accepted keys.',
     }),
   ),
   timeoutMs: Type.Optional(
     Type.Number({
-      description: "Optional provider request timeout in milliseconds.",
+      description: "Provider timeout ms.",
       minimum: 1,
     }),
   ),
@@ -839,7 +819,7 @@ export function createVideoGenerateTool(options?: {
     name: "video_generate",
     displaySummary: "Generate videos",
     description:
-      'Generate videos using configured providers. In session-backed chats, generation runs as a background task; do not call video_generate again for the same request, wait for the completion event, then send the generated attachments through the message tool. Use action="status" to inspect the active task. Duration requests may be rounded to the nearest provider-supported value.',
+      'Create videos. Session chats: background task; do not call video_generate again for same request; wait completion, then send attachments via message tool. "status" checks active task. Duration may round to provider-supported value.',
     parameters: VideoGenerateToolSchema,
     execute: async (_toolCallId, rawArgs) => {
       const args = rawArgs as Record<string, unknown>;

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -51,16 +51,16 @@ const DEFAULT_FETCH_USER_AGENT =
 const FETCH_CACHE = new Map<string, CacheEntry<Record<string, unknown>>>();
 
 const WebFetchSchema = Type.Object({
-  url: Type.String({ description: "HTTP or HTTPS URL to fetch." }),
+  url: Type.String({ description: "HTTP(S) URL." }),
   extractMode: Type.Optional(
     stringEnum(EXTRACT_MODES, {
-      description: 'Extraction mode ("markdown" or "text").',
+      description: "Extract as markdown/text.",
       default: "markdown",
     }),
   ),
   maxChars: Type.Optional(
     Type.Number({
-      description: "Maximum characters to return (truncates when exceeded).",
+      description: "Max chars returned; truncates.",
       minimum: 100,
     }),
   ),
@@ -628,7 +628,7 @@ export function createWebFetchTool(options?: {
     label: "Web Fetch",
     name: "web_fetch",
     description:
-      "Fetch and extract readable content from a URL (HTML → markdown/text). Use for lightweight page access without browser automation.",
+      "Fetch URL and extract readable markdown/text. Lightweight page access; no browser automation.",
     parameters: WebFetchSchema,
     execute: async (_toolCallId, args) => {
       const { config, preferRuntimeProviders, runtimeWebFetch } = resolveWebFetchToolRuntimeContext(

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -10,55 +10,55 @@ const WebSearchSchema = {
   type: "object",
   required: ["query"],
   properties: {
-    query: { type: "string", description: "Search query string." },
+    query: { type: "string", description: "Search query." },
     count: {
       type: "number",
-      description: "Number of results to return.",
+      description: "Result count.",
       minimum: 1,
       maximum: MAX_SEARCH_COUNT,
     },
     country: {
       type: "string",
-      description: "2-letter country code for region-specific results.",
+      description: "2-letter country code.",
     },
     language: {
       type: "string",
-      description: "ISO 639-1 language code for results.",
+      description: "ISO 639-1 language.",
     },
     freshness: {
       type: "string",
-      description: "Filter by time: day, week, month, or year.",
+      description: "Time filter: day/week/month/year.",
     },
     date_after: {
       type: "string",
-      description: "Only results published after this date (YYYY-MM-DD).",
+      description: "Published after YYYY-MM-DD.",
     },
     date_before: {
       type: "string",
-      description: "Only results published before this date (YYYY-MM-DD).",
+      description: "Published before YYYY-MM-DD.",
     },
     search_lang: {
       type: "string",
-      description: "Brave search result language code.",
+      description: "Brave result language.",
     },
     ui_lang: {
       type: "string",
-      description: "Brave UI locale code in language-region format.",
+      description: "Brave UI locale.",
     },
     domain_filter: {
       type: "array",
       items: { type: "string" },
-      description: "Perplexity native Search API domain filter.",
+      description: "Perplexity domain filter.",
     },
     max_tokens: {
       type: "number",
-      description: "Perplexity native Search API total content budget.",
+      description: "Perplexity total token budget.",
       minimum: 1,
       maximum: 1000000,
     },
     max_tokens_per_page: {
       type: "number",
-      description: "Perplexity native Search API max tokens extracted per page.",
+      description: "Perplexity tokens per page.",
       minimum: 1,
     },
   },
@@ -82,8 +82,7 @@ export function createWebSearchTool(options?: {
   return {
     label: "Web Search",
     name: "web_search",
-    description:
-      "Search the web. Returns provider-normalized results for current information lookup.",
+    description: "Search web for current info; returns normalized provider results.",
     parameters: WebSearchSchema,
     execute: async (_toolCallId, args, signal) => {
       const { config, preferRuntimeProviders, runtimeWebSearch } =

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -1,7 +1,7 @@
 [
   {
     "deferLoading": true,
-    "description": "Discover and control paired nodes (status/describe/pairing/notify/camera/photos/screen/location/notifications/invoke). For file retrieval, use the dedicated file_fetch tool.",
+    "description": "Discover/control paired nodes: status, describe, pairing, notify, camera/photos/screen/location/notifications/invoke. Use file_fetch for files.",
     "inputSchema": {
       "properties": {
         "action": {
@@ -137,7 +137,7 @@
   },
   {
     "deferLoading": true,
-    "description": "Manage Gateway cron jobs (status/list/get/add/update/remove/run/runs) and send wake events. Use this for reminders, \"check back later\" requests, delayed follow-ups, and recurring tasks. Do not emulate scheduling with exec sleep or process polling.\n\nMain-session cron jobs enqueue system events for heartbeat handling. Isolated cron jobs create background task runs that appear in `openclaw tasks`.\n\nACTIONS:\n- status: Check cron scheduler status\n- list: List jobs (use includeDisabled:true to include disabled; agentId filters by agent, auto-filled from session)\n- get: Get one job by id (requires jobId)\n- add: Create job (requires job object, see schema below)\n- update: Modify job (requires jobId + patch object)\n- remove: Delete job (requires jobId)\n- run: Trigger job immediately (requires jobId)\n- runs: Get job run history (requires jobId)\n- wake: Send wake event (requires text, optional mode)\n\nJOB SCHEMA (for add action):\n{\n  \"name\": \"string (optional)\",\n  \"schedule\": { ... },      // Required: when to run\n  \"payload\": { ... },       // Required: what to execute\n  \"delivery\": { ... },      // Optional: announce summary (isolated/current/session:xxx only) or webhook POST\n  \"sessionTarget\": \"main\" | \"isolated\" | \"current\" | \"session:<custom-id>\",  // Optional, defaults based on context\n  \"enabled\": true | false   // Optional, default true\n}\n\nSESSION TARGET OPTIONS:\n- \"main\": Run in the main session (requires payload.kind=\"systemEvent\")\n- \"isolated\": Run in an ephemeral isolated session (requires payload.kind=\"agentTurn\")\n- \"current\": Bind to the current session where the cron is created (resolved at creation time)\n- \"session:<custom-id>\": Run in a persistent named session (e.g., \"session:project-alpha-daily\")\n\nDEFAULT BEHAVIOR (unchanged for backward compatibility):\n- payload.kind=\"systemEvent\" → defaults to \"main\"\n- payload.kind=\"agentTurn\" → defaults to \"isolated\"\nTo use current session binding, explicitly set sessionTarget=\"current\".\n\nSCHEDULE TYPES (schedule.kind):\n- \"at\": One-shot at absolute time\n  { \"kind\": \"at\", \"at\": \"<ISO-8601 timestamp>\" }\n- \"every\": Recurring interval\n  { \"kind\": \"every\", \"everyMs\": <interval-ms>, \"anchorMs\": <optional-start-ms> }\n- \"cron\": Cron expression evaluated in the supplied timezone, or the Gateway host local timezone when tz is omitted\n  { \"kind\": \"cron\", \"expr\": \"<cron-expression>\", \"tz\": \"<optional-IANA-timezone>\" }\n  Write expr in the selected timezone's local wall-clock time; do not convert the requested local time to UTC first.\n  If tz is omitted, do not assume UTC; the Gateway host local timezone is used.\n  Example: \"Remind me every day at 6pm Shanghai time\" -> { \"kind\": \"cron\", \"expr\": \"0 18 * * *\", \"tz\": \"Asia/Shanghai\" }\n\nFor schedule.kind=\"at\", ISO timestamps without an explicit timezone are treated as UTC.\n\nPAYLOAD TYPES (payload.kind):\n- \"systemEvent\": Injects text as system event into session\n  { \"kind\": \"systemEvent\", \"text\": \"<message>\" }\n- \"agentTurn\": Runs agent with message (isolated sessions only)\n  { \"kind\": \"agentTurn\", \"message\": \"<prompt>\", \"model\": \"<optional>\", \"thinking\": \"<optional>\", \"timeoutSeconds\": <optional, 0 means no timeout> }\n\nDELIVERY (top-level):\n  { \"mode\": \"none|announce|webhook\", \"channel\": \"<optional>\", \"to\": \"<optional>\", \"threadId\": \"<optional>\", \"bestEffort\": <optional-bool> }\n  - Default for isolated agentTurn jobs (when delivery omitted): \"announce\"\n  - announce: send to chat channel (optional channel/to target)\n  - threadId: chat thread/topic id for channels that support threaded delivery\n  - webhook: send finished-run event as HTTP POST to delivery.to (URL required)\n  - If the task needs to send to a specific chat/recipient, set announce delivery.channel/to; do not call messaging tools inside the run.\n\nCRITICAL CONSTRAINTS:\n- sessionTarget=\"main\" REQUIRES payload.kind=\"systemEvent\"\n- sessionTarget=\"isolated\" | \"current\" | \"session:xxx\" REQUIRES payload.kind=\"agentTurn\"\n- For webhook callbacks, use delivery.mode=\"webhook\" with delivery.to set to a URL.\nDefault: prefer isolated agentTurn jobs unless the user explicitly wants current-session binding.\n\nRESTRICTED CRON RUNS:\n- Some isolated cron runs receive a narrow cron grant for self-cleanup. In that mode, read-only status and list are for self-introspection only, get/runs are allowed for the current job only, and mutation actions remain limited to removing the current cron job.\n\nWAKE MODES (for wake action):\n- \"next-heartbeat\" (default): Wake on next heartbeat\n- \"now\": Wake immediately\n\nUse jobId as the canonical identifier; id is accepted for compatibility. Use contextMessages (0-10) to add previous messages as context to the job text.",
+    "description": "Manage Gateway cron jobs and wake events: reminders, check-back-later, delayed follow-ups, recurring work. Do not emulate scheduling with exec sleep/process polling.\n\nMain cron => system events for heartbeat. Isolated cron => background task in `openclaw tasks`.\n\nACTIONS:\n- status: scheduler status\n- list: jobs; includeDisabled true includes disabled; agentId filter auto-filled from session\n- get: one job; needs jobId\n- add: create job; needs job object\n- update: patch job; needs jobId + patch\n- remove: delete job; needs jobId\n- run: trigger now; needs jobId\n- runs: run history; needs jobId\n- wake: send wake event; needs text, optional mode\n\nJOB SCHEMA (for add action):\n{\n  \"name\": \"string\",\n  \"schedule\": { ... },      // required\n  \"payload\": { ... },       // required\n  \"delivery\": { ... },      // optional announce for isolated/current/session, webhook for any target\n  \"sessionTarget\": \"main\" | \"isolated\" | \"current\" | \"session:<id>\",\n  \"enabled\": true | false   // default true\n}\n\nSESSION TARGET OPTIONS:\n- \"main\": main session; requires payload.kind=\"systemEvent\"\n- \"isolated\": ephemeral isolated session; requires payload.kind=\"agentTurn\"\n- \"current\": bind current session at creation\n- \"session:<id>\": persistent named session\n\nDEFAULTS:\n- payload.kind=\"systemEvent\" → defaults to \"main\"\n- payload.kind=\"agentTurn\" → defaults to \"isolated\"\nCurrent binding needs sessionTarget=\"current\".\n\nSCHEDULE TYPES (schedule.kind):\n- \"at\": one-shot absolute time\n  { \"kind\": \"at\", \"at\": \"<ISO-8601 timestamp>\" }\n- \"every\": recurring interval\n  { \"kind\": \"every\", \"everyMs\": <ms>, \"anchorMs\": <optional-ms> }\n- \"cron\": expr in supplied timezone, or Gateway host local timezone when tz omitted\n  { \"kind\": \"cron\", \"expr\": \"<cron-expression>\", \"tz\": \"<optional-IANA-timezone>\" }\n  Write expr in local wall-clock time; do not convert the requested local time to UTC first.\n  tz omitted => Gateway host local timezone, not UTC.\n  Example 6pm Shanghai daily: { \"kind\": \"cron\", \"expr\": \"0 18 * * *\", \"tz\": \"Asia/Shanghai\" }\n\nFor \"at\", ISO timestamps without timezone are UTC.\n\nPAYLOAD TYPES (payload.kind):\n- \"systemEvent\": inject text as system event\n  { \"kind\": \"systemEvent\", \"text\": \"<message>\" }\n- \"agentTurn\": run agent with prompt; isolated/current/session only\n  { \"kind\": \"agentTurn\", \"message\": \"<prompt>\", \"model\": \"<optional>\", \"thinking\": \"<optional>\", \"timeoutSeconds\": <optional, 0=no timeout> }\n\nDELIVERY (top-level):\n  { \"mode\": \"none|announce|webhook\", \"channel\": \"<optional>\", \"to\": \"<optional>\", \"threadId\": \"<optional>\", \"bestEffort\": <optional-bool> }\n  - isolated agentTurn default when omitted: \"announce\"\n  - announce: send to chat channel; isolated/current/session only; optional channel/to\n  - threadId: chat thread/topic id\n  - webhook: POST finished-run event to delivery.to URL\n  - Specific chat/recipient: set announce delivery.channel/to; do not call messaging tools inside run.\n\nCRITICAL CONSTRAINTS:\n- sessionTarget=\"main\" REQUIRES payload.kind=\"systemEvent\"\n- sessionTarget=\"isolated\" | \"current\" | \"session:xxx\" REQUIRES payload.kind=\"agentTurn\"\n- Webhook: delivery.mode=\"webhook\" and delivery.to URL.\nDefault: prefer isolated agentTurn jobs unless the user explicitly wants current-session binding.\n\nRESTRICTED CRON RUNS:\n- Some isolated cron runs get narrow self-cleanup grant: status/list self-only, get/runs current job only, mutation only remove current job.\n\nWAKE MODES (for wake action):\n- \"next-heartbeat\" default: wake next heartbeat\n- \"now\": wake immediately\n\nUse jobId canonical; id accepted compat. contextMessages (0-10) adds previous messages as job context.",
     "inputSchema": {
       "additionalProperties": true,
       "properties": {
@@ -146,7 +146,7 @@
           "type": "string"
         },
         "agentId": {
-          "description": "Filter by agent id (list action)",
+          "description": "List filter: agent id",
           "type": "string"
         },
         "contextMessages": {
@@ -174,14 +174,14 @@
               "type": "string"
             },
             "deleteAfterRun": {
-              "description": "Delete after first execution",
+              "description": "Delete after first run",
               "type": "boolean"
             },
             "delivery": {
               "additionalProperties": true,
               "properties": {
                 "accountId": {
-                  "description": "Account target for delivery",
+                  "description": "Delivery account",
                   "type": "string"
                 },
                 "bestEffort": {
@@ -224,7 +224,7 @@
                       "type": "number"
                     }
                   ],
-                  "description": "Thread/topic id for channels that support threaded delivery"
+                  "description": "Thread/topic id"
                 },
                 "to": {
                   "description": "Delivery target",
@@ -234,7 +234,7 @@
               "type": "object"
             },
             "description": {
-              "description": "Human-readable description",
+              "description": "Human description",
               "type": "string"
             },
             "enabled": {
@@ -242,13 +242,13 @@
             },
             "failureAlert": {
               "additionalProperties": true,
-              "description": "Failure alert config object, or the boolean value false to disable alerts for this job",
+              "description": "Failure alert object; false disables alerts",
               "properties": {
                 "accountId": {
                   "type": "string"
                 },
                 "after": {
-                  "description": "Failures before alerting",
+                  "description": "Failures before alert",
                   "type": "number"
                 },
                 "channel": {
@@ -256,11 +256,11 @@
                   "type": "string"
                 },
                 "cooldownMs": {
-                  "description": "Cooldown between alerts in ms",
+                  "description": "Alert cooldown ms",
                   "type": "number"
                 },
                 "includeSkipped": {
-                  "description": "Count consecutive skipped runs toward alerting",
+                  "description": "Skipped runs count toward alert",
                   "type": "boolean"
                 },
                 "mode": {
@@ -285,14 +285,14 @@
                   "type": "boolean"
                 },
                 "fallbacks": {
-                  "description": "Fallback model ids",
+                  "description": "Fallback models",
                   "items": {
                     "type": "string"
                   },
                   "type": "array"
                 },
                 "kind": {
-                  "description": "Payload type",
+                  "description": "Payload kind",
                   "enum": ["systemEvent", "agentTurn"],
                   "type": "string"
                 },
@@ -300,7 +300,7 @@
                   "type": "boolean"
                 },
                 "message": {
-                  "description": "Agent prompt (kind=agentTurn)",
+                  "description": "agentTurn prompt",
                   "type": "string"
                 },
                 "model": {
@@ -308,18 +308,18 @@
                   "type": "string"
                 },
                 "text": {
-                  "description": "Message text (kind=systemEvent)",
+                  "description": "systemEvent text",
                   "type": "string"
                 },
                 "thinking": {
-                  "description": "Thinking level override",
+                  "description": "Thinking override",
                   "type": "string"
                 },
                 "timeoutSeconds": {
                   "type": "number"
                 },
                 "toolsAllow": {
-                  "description": "Allowed tool ids",
+                  "description": "Allowed tools",
                   "items": {
                     "type": "string"
                   },
@@ -332,32 +332,32 @@
               "additionalProperties": true,
               "properties": {
                 "anchorMs": {
-                  "description": "Optional start anchor in milliseconds (kind=every)",
+                  "description": "Start anchor ms (kind=every)",
                   "type": "number"
                 },
                 "at": {
-                  "description": "ISO-8601 timestamp (kind=at)",
+                  "description": "ISO-8601 time (kind=at)",
                   "type": "string"
                 },
                 "everyMs": {
-                  "description": "Interval in milliseconds (kind=every)",
+                  "description": "Interval ms (kind=every)",
                   "type": "number"
                 },
                 "expr": {
-                  "description": "Cron expression (kind=cron) written in the supplied tz's local wall-clock time, or the Gateway host local timezone when tz is omitted; do not convert the requested local time to UTC first. Example: 6pm Shanghai daily is \"0 18 * * *\" with tz \"Asia/Shanghai\".",
+                  "description": "Cron expr in tz local time; no UTC conversion. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
                   "type": "string"
                 },
                 "kind": {
-                  "description": "Schedule type",
+                  "description": "Schedule kind",
                   "enum": ["at", "every", "cron"],
                   "type": "string"
                 },
                 "staggerMs": {
-                  "description": "Random jitter in ms (kind=cron)",
+                  "description": "Jitter ms (kind=cron)",
                   "type": "number"
                 },
                 "tz": {
-                  "description": "IANA timezone for interpreting cron wall-clock fields (kind=cron), e.g. \"Asia/Shanghai\"; if omitted, cron uses the Gateway host local timezone.",
+                  "description": "IANA tz for cron fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local tz.",
                   "type": "string"
                 }
               },
@@ -368,11 +368,11 @@
               "type": "string"
             },
             "sessionTarget": {
-              "description": "Session target: \"main\", \"isolated\", \"current\", or \"session:<id>\"",
+              "description": "main | isolated | current | session:<id>",
               "type": "string"
             },
             "wakeMode": {
-              "description": "When to wake the session",
+              "description": "Wake timing",
               "enum": ["now", "next-heartbeat"],
               "type": "string"
             }
@@ -400,7 +400,7 @@
               "additionalProperties": true,
               "properties": {
                 "accountId": {
-                  "description": "Account target for delivery",
+                  "description": "Delivery account",
                   "type": "string"
                 },
                 "bestEffort": {
@@ -443,7 +443,7 @@
                       "type": "number"
                     }
                   ],
-                  "description": "Thread/topic id for channels that support threaded delivery"
+                  "description": "Thread/topic id"
                 },
                 "to": {
                   "description": "Delivery target",
@@ -460,13 +460,13 @@
             },
             "failureAlert": {
               "additionalProperties": true,
-              "description": "Failure alert config object, or the boolean value false to disable alerts for this job",
+              "description": "Failure alert object; false disables alerts",
               "properties": {
                 "accountId": {
                   "type": "string"
                 },
                 "after": {
-                  "description": "Failures before alerting",
+                  "description": "Failures before alert",
                   "type": "number"
                 },
                 "channel": {
@@ -474,11 +474,11 @@
                   "type": "string"
                 },
                 "cooldownMs": {
-                  "description": "Cooldown between alerts in ms",
+                  "description": "Alert cooldown ms",
                   "type": "number"
                 },
                 "includeSkipped": {
-                  "description": "Count consecutive skipped runs toward alerting",
+                  "description": "Skipped runs count toward alert",
                   "type": "boolean"
                 },
                 "mode": {
@@ -503,14 +503,14 @@
                   "type": "boolean"
                 },
                 "fallbacks": {
-                  "description": "Fallback model ids",
+                  "description": "Fallback models",
                   "items": {
                     "type": "string"
                   },
                   "type": "array"
                 },
                 "kind": {
-                  "description": "Payload type",
+                  "description": "Payload kind",
                   "enum": ["systemEvent", "agentTurn"],
                   "type": "string"
                 },
@@ -518,7 +518,7 @@
                   "type": "boolean"
                 },
                 "message": {
-                  "description": "Agent prompt (kind=agentTurn)",
+                  "description": "agentTurn prompt",
                   "type": "string"
                 },
                 "model": {
@@ -526,11 +526,11 @@
                   "type": "string"
                 },
                 "text": {
-                  "description": "Message text (kind=systemEvent)",
+                  "description": "systemEvent text",
                   "type": "string"
                 },
                 "thinking": {
-                  "description": "Thinking level override",
+                  "description": "Thinking override",
                   "type": "string"
                 },
                 "timeoutSeconds": {
@@ -550,32 +550,32 @@
               "additionalProperties": true,
               "properties": {
                 "anchorMs": {
-                  "description": "Optional start anchor in milliseconds (kind=every)",
+                  "description": "Start anchor ms (kind=every)",
                   "type": "number"
                 },
                 "at": {
-                  "description": "ISO-8601 timestamp (kind=at)",
+                  "description": "ISO-8601 time (kind=at)",
                   "type": "string"
                 },
                 "everyMs": {
-                  "description": "Interval in milliseconds (kind=every)",
+                  "description": "Interval ms (kind=every)",
                   "type": "number"
                 },
                 "expr": {
-                  "description": "Cron expression (kind=cron) written in the supplied tz's local wall-clock time, or the Gateway host local timezone when tz is omitted; do not convert the requested local time to UTC first. Example: 6pm Shanghai daily is \"0 18 * * *\" with tz \"Asia/Shanghai\".",
+                  "description": "Cron expr in tz local time; no UTC conversion. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
                   "type": "string"
                 },
                 "kind": {
-                  "description": "Schedule type",
+                  "description": "Schedule kind",
                   "enum": ["at", "every", "cron"],
                   "type": "string"
                 },
                 "staggerMs": {
-                  "description": "Random jitter in ms (kind=cron)",
+                  "description": "Jitter ms (kind=cron)",
                   "type": "number"
                 },
                 "tz": {
-                  "description": "IANA timezone for interpreting cron wall-clock fields (kind=cron), e.g. \"Asia/Shanghai\"; if omitted, cron uses the Gateway host local timezone.",
+                  "description": "IANA tz for cron fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local tz.",
                   "type": "string"
                 }
               },
@@ -614,7 +614,7 @@
     "namespace": "openclaw"
   },
   {
-    "description": "Send, delete, and manage messages via channel plugins. Supports actions: send.",
+    "description": "Send/delete/manage channel messages. Supports actions: send.",
     "inputSchema": {
       "properties": {
         "accountId": {
@@ -625,14 +625,14 @@
           "type": "string"
         },
         "asDocument": {
-          "description": "Send image/GIF/video as document to avoid channel compression. Alias for forceDocument.",
+          "description": "Alias for forceDocument.",
           "type": "boolean"
         },
         "asVoice": {
           "type": "boolean"
         },
         "attachments": {
-          "description": "Structured media attachments to send with the message. Each item needs media/mediaUrl/path/filePath/fileUrl/url.",
+          "description": "Structured attachments; each needs media/mediaUrl/path/filePath/fileUrl/url.",
           "items": {
             "properties": {
               "filePath": {
@@ -672,7 +672,7 @@
           "type": "boolean"
         },
         "buffer": {
-          "description": "Base64 payload for attachments (optionally a data: URL).",
+          "description": "Base64 attachment payload; data URL ok.",
           "type": "string"
         },
         "caption": {
@@ -688,11 +688,11 @@
           "type": "boolean"
         },
         "effect": {
-          "description": "Alias for effectId (e.g., invisible-ink, balloons).",
+          "description": "Alias for effectId.",
           "type": "string"
         },
         "effectId": {
-          "description": "Message effect name/id for sendWithEffect (e.g., invisible ink).",
+          "description": "Effect id/name for sendWithEffect.",
           "type": "string"
         },
         "filename": {
@@ -702,7 +702,7 @@
           "type": "string"
         },
         "forceDocument": {
-          "description": "Send image/GIF/video as document to avoid channel compression.",
+          "description": "Send image/GIF/video as document; avoids compression.",
           "type": "boolean"
         },
         "gatewayToken": {
@@ -715,7 +715,7 @@
           "type": "boolean"
         },
         "media": {
-          "description": "Media URL or local path. data: URLs are not supported here, use buffer.",
+          "description": "Media URL/path. data: use buffer.",
           "type": "string"
         },
         "message": {
@@ -728,7 +728,7 @@
           "type": "string"
         },
         "quoteText": {
-          "description": "Quote text for Telegram reply_parameters",
+          "description": "Telegram reply quote text.",
           "type": "string"
         },
         "replyTo": {
@@ -762,19 +762,19 @@
   },
   {
     "deferLoading": true,
-    "description": "Use only for explicit audio intent (audio, voice, speech, TTS) or active TTS config. Never use for ordinary text replies. Audio is delivered automatically from the tool result. After a successful call, follow the current conversation's reply instructions and avoid sending a duplicate text/audio response.",
+    "description": "Use only for explicit audio intent (voice/speech/TTS) or active TTS config. Never use for ordinary text replies. Audio auto-delivered from tool result; after success follow reply instructions, no duplicate text/audio.",
     "inputSchema": {
       "properties": {
         "channel": {
-          "description": "Optional channel id to pick output format.",
+          "description": "Channel id; output-format hint.",
           "type": "string"
         },
         "text": {
-          "description": "Text to convert to speech.",
+          "description": "Text to speak.",
           "type": "string"
         },
         "timeoutMs": {
-          "description": "Optional provider request timeout in milliseconds.",
+          "description": "Provider timeout ms.",
           "minimum": 1,
           "type": "number"
         }
@@ -787,7 +787,7 @@
   },
   {
     "deferLoading": true,
-    "description": "Restart, inspect a specific config schema path, apply config, or update the gateway in-place (SIGUSR1). Use config.schema.lookup with a targeted dot path before config edits. Use config.patch for safe partial config updates (merges with existing). Use config.apply only when replacing entire config. Config writes hot-reload when possible and restart when required. Always pass a human-readable completion message via the `note` parameter so the system can deliver it to the user after restart. If restarting during a user task and you still owe the user a reply, pass a specific one-shot `continuationMessage` for what to verify or report after boot; do not write restart sentinel files directly.",
+    "description": "Gateway restart/config/update. Before config edits, use config.schema.lookup with targeted dot path. Prefer config.patch for partial merge; config.apply only full replace. Writes hot-reload or restart as needed. Always pass human `note` for post-restart delivery. If still owe the user a reply, pass one-shot `continuationMessage`; do not write restart sentinel files directly.",
     "inputSchema": {
       "properties": {
         "action": {
@@ -846,7 +846,7 @@
   },
   {
     "deferLoading": true,
-    "description": "List OpenClaw agent ids you can target with `sessions_spawn` when `runtime=\"subagent\"` (based on subagent allowlists).",
+    "description": "List agent ids allowed for `sessions_spawn runtime=\"subagent\"`.",
     "inputSchema": {
       "properties": {},
       "type": "object"
@@ -856,7 +856,7 @@
   },
   {
     "deferLoading": true,
-    "description": "List visible sessions with optional filters for kind, label, agentId, search, recent activity, derived titles, and last-message previews. Use this to discover a target session before calling sessions_history or sessions_send.",
+    "description": "List visible sessions; filter by kind, label, agentId, search, activity. Use before sessions_history or sessions_send target selection.",
     "inputSchema": {
       "properties": {
         "activeMinutes": {
@@ -904,7 +904,7 @@
   },
   {
     "deferLoading": true,
-    "description": "Fetch sanitized message history for a visible session. Supports limits and optional tool messages; use this to inspect another session before replying, debugging, or resuming work.",
+    "description": "Fetch sanitized history for visible session. Use before replying, debugging, resuming; supports limits/tool messages.",
     "inputSchema": {
       "properties": {
         "includeTools": {
@@ -926,7 +926,7 @@
   },
   {
     "deferLoading": true,
-    "description": "Send a message into another visible session by sessionKey or label, or to a configured agent by agentId. Thread-scoped chat sessions are rejected; target the parent channel session for inter-agent coordination. Missing configured agent main sessions are created before send; waits for the target run and returns the updated assistant reply when available.",
+    "description": "Send message to visible session by sessionKey/label, or configured agent by agentId. Thread-scoped chats rejected; target parent channel session. Creates missing configured-agent main session; waits for reply when available.",
     "inputSchema": {
       "properties": {
         "agentId": {
@@ -958,7 +958,7 @@
   },
   {
     "deferLoading": true,
-    "description": "Spawn a clean isolated session by default with the native subagent runtime. `mode=\"run\"` is one-shot and `mode=\"session\"` is persistent and thread-bound. Subagents inherit the parent workspace directory automatically. Native subagents receive the delegated task in their first visible `[Subagent Task]` message. For native subagents only, set `context=\"fork\"` when the child needs the current transcript context; otherwise omit it or use `context=\"isolated\"`. Use this when the work should happen in a fresh child session instead of the current one.",
+    "description": "Spawn clean child session; default `runtime=\"subagent\"`. `mode=\"run\"` one-shot; `mode=\"session\"` persistent/thread-bound. Subagents inherit parent workspace. Native subagents get task in first visible `[Subagent Task]` message. Native only: `context=\"fork\"` only when child needs current transcript; else omit or `isolated`. Use for fresh child-session work.",
     "inputSchema": {
       "properties": {
         "agentId": {
@@ -1000,7 +1000,7 @@
           "type": "string"
         },
         "context": {
-          "description": "Native subagent context mode. Omit or use \"isolated\" for a clean child session; use \"fork\" only when the child needs the requester transcript context.",
+          "description": "Native context. Omit/\"isolated\" for clean child; \"fork\" only when child needs requester transcript.",
           "enum": ["isolated", "fork"],
           "type": "string"
         },
@@ -1011,7 +1011,7 @@
           "type": "string"
         },
         "lightContext": {
-          "description": "When true, spawned subagent runs use lightweight bootstrap context. Only applies to runtime='subagent'.",
+          "description": "Light bootstrap context; runtime=\"subagent\" only.",
           "type": "boolean"
         },
         "mode": {
@@ -1037,14 +1037,14 @@
           "type": "string"
         },
         "taskName": {
-          "description": "Stable optional alias for later subagents targeting. Use lowercase letters, digits, and underscores, starting with a letter.",
+          "description": "Stable alias for later targeting; lowercase letters/digits/underscores, starts letter.",
           "type": "string"
         },
         "thinking": {
           "type": "string"
         },
         "thread": {
-          "description": "Bind the spawned session to a new chat thread when the current channel/account supports thread-bound session spawns. `thread=true` defaults mode to \"session\".",
+          "description": "Bind spawn to new chat thread when supported. `thread=true` defaults mode=\"session\".",
           "type": "boolean"
         },
         "timeoutSeconds": {
@@ -1059,7 +1059,7 @@
     "namespace": "openclaw"
   },
   {
-    "description": "End your current turn. Use after spawning subagents to receive their results as the next message.",
+    "description": "End current turn. Use after spawning subagents; results arrive as next message.",
     "inputSchema": {
       "properties": {
         "message": {
@@ -1072,7 +1072,7 @@
   },
   {
     "deferLoading": true,
-    "description": "On-demand list, kill, or steer spawned sub-agents for this requester session. If sessions_yield is available, use it to wait for completion events; do not poll this tool in wait loops.",
+    "description": "List/kill/steer spawned subagents for requester session. If sessions_yield exists, use it for completion; do not poll wait loops.",
     "inputSchema": {
       "properties": {
         "action": {
@@ -1097,7 +1097,7 @@
   },
   {
     "deferLoading": true,
-    "description": "Show a /status-equivalent session status card for the current or another visible session, including usage, time, cost when available, and linked background task context. Use `sessionKey=\"current\"` for the current session; do not use UI/client labels such as `openclaw-tui` as session keys. Optional `model` sets a per-session model override; `model=default` resets overrides. Use this for questions like what model is active or how a session is configured.",
+    "description": "Show /status-like card for current/visible session: model, usage, time, cost, tasks. Use `sessionKey=\"current\"` for current session; UI labels like `openclaw-tui` are not keys. `model` sets session override; `model=default` resets. Use for active model/session config questions.",
     "inputSchema": {
       "properties": {
         "model": {
@@ -1114,63 +1114,63 @@
   },
   {
     "deferLoading": true,
-    "description": "Search the web. Returns provider-normalized results for current information lookup.",
+    "description": "Search web for current info; returns normalized provider results.",
     "inputSchema": {
       "properties": {
         "count": {
-          "description": "Number of results to return.",
+          "description": "Result count.",
           "maximum": 10,
           "minimum": 1,
           "type": "number"
         },
         "country": {
-          "description": "2-letter country code for region-specific results.",
+          "description": "2-letter country code.",
           "type": "string"
         },
         "date_after": {
-          "description": "Only results published after this date (YYYY-MM-DD).",
+          "description": "Published after YYYY-MM-DD.",
           "type": "string"
         },
         "date_before": {
-          "description": "Only results published before this date (YYYY-MM-DD).",
+          "description": "Published before YYYY-MM-DD.",
           "type": "string"
         },
         "domain_filter": {
-          "description": "Perplexity native Search API domain filter.",
+          "description": "Perplexity domain filter.",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "freshness": {
-          "description": "Filter by time: day, week, month, or year.",
+          "description": "Time filter: day/week/month/year.",
           "type": "string"
         },
         "language": {
-          "description": "ISO 639-1 language code for results.",
+          "description": "ISO 639-1 language.",
           "type": "string"
         },
         "max_tokens": {
-          "description": "Perplexity native Search API total content budget.",
+          "description": "Perplexity total token budget.",
           "maximum": 1000000,
           "minimum": 1,
           "type": "number"
         },
         "max_tokens_per_page": {
-          "description": "Perplexity native Search API max tokens extracted per page.",
+          "description": "Perplexity tokens per page.",
           "minimum": 1,
           "type": "number"
         },
         "query": {
-          "description": "Search query string.",
+          "description": "Search query.",
           "type": "string"
         },
         "search_lang": {
-          "description": "Brave search result language code.",
+          "description": "Brave result language.",
           "type": "string"
         },
         "ui_lang": {
-          "description": "Brave UI locale code in language-region format.",
+          "description": "Brave UI locale.",
           "type": "string"
         }
       },
@@ -1182,22 +1182,22 @@
   },
   {
     "deferLoading": true,
-    "description": "Fetch and extract readable content from a URL (HTML → markdown/text). Use for lightweight page access without browser automation.",
+    "description": "Fetch URL and extract readable markdown/text. Lightweight page access; no browser automation.",
     "inputSchema": {
       "properties": {
         "extractMode": {
           "default": "markdown",
-          "description": "Extraction mode (\"markdown\" or \"text\").",
+          "description": "Extract as markdown/text.",
           "enum": ["markdown", "text"],
           "type": "string"
         },
         "maxChars": {
-          "description": "Maximum characters to return (truncates when exceeded).",
+          "description": "Max chars returned; truncates.",
           "minimum": 100,
           "type": "number"
         },
         "url": {
-          "description": "HTTP or HTTPS URL to fetch.",
+          "description": "HTTP(S) URL.",
           "type": "string"
         }
       },

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.discord-group.json
@@ -344,7 +344,7 @@
                   "type": "number"
                 },
                 "expr": {
-                  "description": "Cron expr in tz local time; no UTC conversion. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
+                  "description": "Cron expr in tz wall-clock time; do not convert to UTC. Omitted tz => Gateway host local timezone. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
                   "type": "string"
                 },
                 "kind": {
@@ -357,7 +357,7 @@
                   "type": "number"
                 },
                 "tz": {
-                  "description": "IANA tz for cron fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local tz.",
+                  "description": "IANA timezone for cron wall-clock fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local timezone.",
                   "type": "string"
                 }
               },
@@ -562,7 +562,7 @@
                   "type": "number"
                 },
                 "expr": {
-                  "description": "Cron expr in tz local time; no UTC conversion. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
+                  "description": "Cron expr in tz wall-clock time; do not convert to UTC. Omitted tz => Gateway host local timezone. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
                   "type": "string"
                 },
                 "kind": {
@@ -575,7 +575,7 @@
                   "type": "number"
                 },
                 "tz": {
-                  "description": "IANA tz for cron fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local tz.",
+                  "description": "IANA timezone for cron wall-clock fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local timezone.",
                   "type": "string"
                 }
               },

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -1,7 +1,7 @@
 [
   {
     "deferLoading": true,
-    "description": "Discover and control paired nodes (status/describe/pairing/notify/camera/photos/screen/location/notifications/invoke). For file retrieval, use the dedicated file_fetch tool.",
+    "description": "Discover/control paired nodes: status, describe, pairing, notify, camera/photos/screen/location/notifications/invoke. Use file_fetch for files.",
     "inputSchema": {
       "properties": {
         "action": {
@@ -137,7 +137,7 @@
   },
   {
     "deferLoading": true,
-    "description": "Manage Gateway cron jobs (status/list/get/add/update/remove/run/runs) and send wake events. Use this for reminders, \"check back later\" requests, delayed follow-ups, and recurring tasks. Do not emulate scheduling with exec sleep or process polling.\n\nMain-session cron jobs enqueue system events for heartbeat handling. Isolated cron jobs create background task runs that appear in `openclaw tasks`.\n\nACTIONS:\n- status: Check cron scheduler status\n- list: List jobs (use includeDisabled:true to include disabled; agentId filters by agent, auto-filled from session)\n- get: Get one job by id (requires jobId)\n- add: Create job (requires job object, see schema below)\n- update: Modify job (requires jobId + patch object)\n- remove: Delete job (requires jobId)\n- run: Trigger job immediately (requires jobId)\n- runs: Get job run history (requires jobId)\n- wake: Send wake event (requires text, optional mode)\n\nJOB SCHEMA (for add action):\n{\n  \"name\": \"string (optional)\",\n  \"schedule\": { ... },      // Required: when to run\n  \"payload\": { ... },       // Required: what to execute\n  \"delivery\": { ... },      // Optional: announce summary (isolated/current/session:xxx only) or webhook POST\n  \"sessionTarget\": \"main\" | \"isolated\" | \"current\" | \"session:<custom-id>\",  // Optional, defaults based on context\n  \"enabled\": true | false   // Optional, default true\n}\n\nSESSION TARGET OPTIONS:\n- \"main\": Run in the main session (requires payload.kind=\"systemEvent\")\n- \"isolated\": Run in an ephemeral isolated session (requires payload.kind=\"agentTurn\")\n- \"current\": Bind to the current session where the cron is created (resolved at creation time)\n- \"session:<custom-id>\": Run in a persistent named session (e.g., \"session:project-alpha-daily\")\n\nDEFAULT BEHAVIOR (unchanged for backward compatibility):\n- payload.kind=\"systemEvent\" → defaults to \"main\"\n- payload.kind=\"agentTurn\" → defaults to \"isolated\"\nTo use current session binding, explicitly set sessionTarget=\"current\".\n\nSCHEDULE TYPES (schedule.kind):\n- \"at\": One-shot at absolute time\n  { \"kind\": \"at\", \"at\": \"<ISO-8601 timestamp>\" }\n- \"every\": Recurring interval\n  { \"kind\": \"every\", \"everyMs\": <interval-ms>, \"anchorMs\": <optional-start-ms> }\n- \"cron\": Cron expression evaluated in the supplied timezone, or the Gateway host local timezone when tz is omitted\n  { \"kind\": \"cron\", \"expr\": \"<cron-expression>\", \"tz\": \"<optional-IANA-timezone>\" }\n  Write expr in the selected timezone's local wall-clock time; do not convert the requested local time to UTC first.\n  If tz is omitted, do not assume UTC; the Gateway host local timezone is used.\n  Example: \"Remind me every day at 6pm Shanghai time\" -> { \"kind\": \"cron\", \"expr\": \"0 18 * * *\", \"tz\": \"Asia/Shanghai\" }\n\nFor schedule.kind=\"at\", ISO timestamps without an explicit timezone are treated as UTC.\n\nPAYLOAD TYPES (payload.kind):\n- \"systemEvent\": Injects text as system event into session\n  { \"kind\": \"systemEvent\", \"text\": \"<message>\" }\n- \"agentTurn\": Runs agent with message (isolated sessions only)\n  { \"kind\": \"agentTurn\", \"message\": \"<prompt>\", \"model\": \"<optional>\", \"thinking\": \"<optional>\", \"timeoutSeconds\": <optional, 0 means no timeout> }\n\nDELIVERY (top-level):\n  { \"mode\": \"none|announce|webhook\", \"channel\": \"<optional>\", \"to\": \"<optional>\", \"threadId\": \"<optional>\", \"bestEffort\": <optional-bool> }\n  - Default for isolated agentTurn jobs (when delivery omitted): \"announce\"\n  - announce: send to chat channel (optional channel/to target)\n  - threadId: chat thread/topic id for channels that support threaded delivery\n  - webhook: send finished-run event as HTTP POST to delivery.to (URL required)\n  - If the task needs to send to a specific chat/recipient, set announce delivery.channel/to; do not call messaging tools inside the run.\n\nCRITICAL CONSTRAINTS:\n- sessionTarget=\"main\" REQUIRES payload.kind=\"systemEvent\"\n- sessionTarget=\"isolated\" | \"current\" | \"session:xxx\" REQUIRES payload.kind=\"agentTurn\"\n- For webhook callbacks, use delivery.mode=\"webhook\" with delivery.to set to a URL.\nDefault: prefer isolated agentTurn jobs unless the user explicitly wants current-session binding.\n\nRESTRICTED CRON RUNS:\n- Some isolated cron runs receive a narrow cron grant for self-cleanup. In that mode, read-only status and list are for self-introspection only, get/runs are allowed for the current job only, and mutation actions remain limited to removing the current cron job.\n\nWAKE MODES (for wake action):\n- \"next-heartbeat\" (default): Wake on next heartbeat\n- \"now\": Wake immediately\n\nUse jobId as the canonical identifier; id is accepted for compatibility. Use contextMessages (0-10) to add previous messages as context to the job text.",
+    "description": "Manage Gateway cron jobs and wake events: reminders, check-back-later, delayed follow-ups, recurring work. Do not emulate scheduling with exec sleep/process polling.\n\nMain cron => system events for heartbeat. Isolated cron => background task in `openclaw tasks`.\n\nACTIONS:\n- status: scheduler status\n- list: jobs; includeDisabled true includes disabled; agentId filter auto-filled from session\n- get: one job; needs jobId\n- add: create job; needs job object\n- update: patch job; needs jobId + patch\n- remove: delete job; needs jobId\n- run: trigger now; needs jobId\n- runs: run history; needs jobId\n- wake: send wake event; needs text, optional mode\n\nJOB SCHEMA (for add action):\n{\n  \"name\": \"string\",\n  \"schedule\": { ... },      // required\n  \"payload\": { ... },       // required\n  \"delivery\": { ... },      // optional announce for isolated/current/session, webhook for any target\n  \"sessionTarget\": \"main\" | \"isolated\" | \"current\" | \"session:<id>\",\n  \"enabled\": true | false   // default true\n}\n\nSESSION TARGET OPTIONS:\n- \"main\": main session; requires payload.kind=\"systemEvent\"\n- \"isolated\": ephemeral isolated session; requires payload.kind=\"agentTurn\"\n- \"current\": bind current session at creation\n- \"session:<id>\": persistent named session\n\nDEFAULTS:\n- payload.kind=\"systemEvent\" → defaults to \"main\"\n- payload.kind=\"agentTurn\" → defaults to \"isolated\"\nCurrent binding needs sessionTarget=\"current\".\n\nSCHEDULE TYPES (schedule.kind):\n- \"at\": one-shot absolute time\n  { \"kind\": \"at\", \"at\": \"<ISO-8601 timestamp>\" }\n- \"every\": recurring interval\n  { \"kind\": \"every\", \"everyMs\": <ms>, \"anchorMs\": <optional-ms> }\n- \"cron\": expr in supplied timezone, or Gateway host local timezone when tz omitted\n  { \"kind\": \"cron\", \"expr\": \"<cron-expression>\", \"tz\": \"<optional-IANA-timezone>\" }\n  Write expr in local wall-clock time; do not convert the requested local time to UTC first.\n  tz omitted => Gateway host local timezone, not UTC.\n  Example 6pm Shanghai daily: { \"kind\": \"cron\", \"expr\": \"0 18 * * *\", \"tz\": \"Asia/Shanghai\" }\n\nFor \"at\", ISO timestamps without timezone are UTC.\n\nPAYLOAD TYPES (payload.kind):\n- \"systemEvent\": inject text as system event\n  { \"kind\": \"systemEvent\", \"text\": \"<message>\" }\n- \"agentTurn\": run agent with prompt; isolated/current/session only\n  { \"kind\": \"agentTurn\", \"message\": \"<prompt>\", \"model\": \"<optional>\", \"thinking\": \"<optional>\", \"timeoutSeconds\": <optional, 0=no timeout> }\n\nDELIVERY (top-level):\n  { \"mode\": \"none|announce|webhook\", \"channel\": \"<optional>\", \"to\": \"<optional>\", \"threadId\": \"<optional>\", \"bestEffort\": <optional-bool> }\n  - isolated agentTurn default when omitted: \"announce\"\n  - announce: send to chat channel; isolated/current/session only; optional channel/to\n  - threadId: chat thread/topic id\n  - webhook: POST finished-run event to delivery.to URL\n  - Specific chat/recipient: set announce delivery.channel/to; do not call messaging tools inside run.\n\nCRITICAL CONSTRAINTS:\n- sessionTarget=\"main\" REQUIRES payload.kind=\"systemEvent\"\n- sessionTarget=\"isolated\" | \"current\" | \"session:xxx\" REQUIRES payload.kind=\"agentTurn\"\n- Webhook: delivery.mode=\"webhook\" and delivery.to URL.\nDefault: prefer isolated agentTurn jobs unless the user explicitly wants current-session binding.\n\nRESTRICTED CRON RUNS:\n- Some isolated cron runs get narrow self-cleanup grant: status/list self-only, get/runs current job only, mutation only remove current job.\n\nWAKE MODES (for wake action):\n- \"next-heartbeat\" default: wake next heartbeat\n- \"now\": wake immediately\n\nUse jobId canonical; id accepted compat. contextMessages (0-10) adds previous messages as job context.",
     "inputSchema": {
       "additionalProperties": true,
       "properties": {
@@ -146,7 +146,7 @@
           "type": "string"
         },
         "agentId": {
-          "description": "Filter by agent id (list action)",
+          "description": "List filter: agent id",
           "type": "string"
         },
         "contextMessages": {
@@ -174,14 +174,14 @@
               "type": "string"
             },
             "deleteAfterRun": {
-              "description": "Delete after first execution",
+              "description": "Delete after first run",
               "type": "boolean"
             },
             "delivery": {
               "additionalProperties": true,
               "properties": {
                 "accountId": {
-                  "description": "Account target for delivery",
+                  "description": "Delivery account",
                   "type": "string"
                 },
                 "bestEffort": {
@@ -224,7 +224,7 @@
                       "type": "number"
                     }
                   ],
-                  "description": "Thread/topic id for channels that support threaded delivery"
+                  "description": "Thread/topic id"
                 },
                 "to": {
                   "description": "Delivery target",
@@ -234,7 +234,7 @@
               "type": "object"
             },
             "description": {
-              "description": "Human-readable description",
+              "description": "Human description",
               "type": "string"
             },
             "enabled": {
@@ -242,13 +242,13 @@
             },
             "failureAlert": {
               "additionalProperties": true,
-              "description": "Failure alert config object, or the boolean value false to disable alerts for this job",
+              "description": "Failure alert object; false disables alerts",
               "properties": {
                 "accountId": {
                   "type": "string"
                 },
                 "after": {
-                  "description": "Failures before alerting",
+                  "description": "Failures before alert",
                   "type": "number"
                 },
                 "channel": {
@@ -256,11 +256,11 @@
                   "type": "string"
                 },
                 "cooldownMs": {
-                  "description": "Cooldown between alerts in ms",
+                  "description": "Alert cooldown ms",
                   "type": "number"
                 },
                 "includeSkipped": {
-                  "description": "Count consecutive skipped runs toward alerting",
+                  "description": "Skipped runs count toward alert",
                   "type": "boolean"
                 },
                 "mode": {
@@ -285,14 +285,14 @@
                   "type": "boolean"
                 },
                 "fallbacks": {
-                  "description": "Fallback model ids",
+                  "description": "Fallback models",
                   "items": {
                     "type": "string"
                   },
                   "type": "array"
                 },
                 "kind": {
-                  "description": "Payload type",
+                  "description": "Payload kind",
                   "enum": ["systemEvent", "agentTurn"],
                   "type": "string"
                 },
@@ -300,7 +300,7 @@
                   "type": "boolean"
                 },
                 "message": {
-                  "description": "Agent prompt (kind=agentTurn)",
+                  "description": "agentTurn prompt",
                   "type": "string"
                 },
                 "model": {
@@ -308,18 +308,18 @@
                   "type": "string"
                 },
                 "text": {
-                  "description": "Message text (kind=systemEvent)",
+                  "description": "systemEvent text",
                   "type": "string"
                 },
                 "thinking": {
-                  "description": "Thinking level override",
+                  "description": "Thinking override",
                   "type": "string"
                 },
                 "timeoutSeconds": {
                   "type": "number"
                 },
                 "toolsAllow": {
-                  "description": "Allowed tool ids",
+                  "description": "Allowed tools",
                   "items": {
                     "type": "string"
                   },
@@ -332,32 +332,32 @@
               "additionalProperties": true,
               "properties": {
                 "anchorMs": {
-                  "description": "Optional start anchor in milliseconds (kind=every)",
+                  "description": "Start anchor ms (kind=every)",
                   "type": "number"
                 },
                 "at": {
-                  "description": "ISO-8601 timestamp (kind=at)",
+                  "description": "ISO-8601 time (kind=at)",
                   "type": "string"
                 },
                 "everyMs": {
-                  "description": "Interval in milliseconds (kind=every)",
+                  "description": "Interval ms (kind=every)",
                   "type": "number"
                 },
                 "expr": {
-                  "description": "Cron expression (kind=cron) written in the supplied tz's local wall-clock time, or the Gateway host local timezone when tz is omitted; do not convert the requested local time to UTC first. Example: 6pm Shanghai daily is \"0 18 * * *\" with tz \"Asia/Shanghai\".",
+                  "description": "Cron expr in tz local time; no UTC conversion. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
                   "type": "string"
                 },
                 "kind": {
-                  "description": "Schedule type",
+                  "description": "Schedule kind",
                   "enum": ["at", "every", "cron"],
                   "type": "string"
                 },
                 "staggerMs": {
-                  "description": "Random jitter in ms (kind=cron)",
+                  "description": "Jitter ms (kind=cron)",
                   "type": "number"
                 },
                 "tz": {
-                  "description": "IANA timezone for interpreting cron wall-clock fields (kind=cron), e.g. \"Asia/Shanghai\"; if omitted, cron uses the Gateway host local timezone.",
+                  "description": "IANA tz for cron fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local tz.",
                   "type": "string"
                 }
               },
@@ -368,11 +368,11 @@
               "type": "string"
             },
             "sessionTarget": {
-              "description": "Session target: \"main\", \"isolated\", \"current\", or \"session:<id>\"",
+              "description": "main | isolated | current | session:<id>",
               "type": "string"
             },
             "wakeMode": {
-              "description": "When to wake the session",
+              "description": "Wake timing",
               "enum": ["now", "next-heartbeat"],
               "type": "string"
             }
@@ -400,7 +400,7 @@
               "additionalProperties": true,
               "properties": {
                 "accountId": {
-                  "description": "Account target for delivery",
+                  "description": "Delivery account",
                   "type": "string"
                 },
                 "bestEffort": {
@@ -443,7 +443,7 @@
                       "type": "number"
                     }
                   ],
-                  "description": "Thread/topic id for channels that support threaded delivery"
+                  "description": "Thread/topic id"
                 },
                 "to": {
                   "description": "Delivery target",
@@ -460,13 +460,13 @@
             },
             "failureAlert": {
               "additionalProperties": true,
-              "description": "Failure alert config object, or the boolean value false to disable alerts for this job",
+              "description": "Failure alert object; false disables alerts",
               "properties": {
                 "accountId": {
                   "type": "string"
                 },
                 "after": {
-                  "description": "Failures before alerting",
+                  "description": "Failures before alert",
                   "type": "number"
                 },
                 "channel": {
@@ -474,11 +474,11 @@
                   "type": "string"
                 },
                 "cooldownMs": {
-                  "description": "Cooldown between alerts in ms",
+                  "description": "Alert cooldown ms",
                   "type": "number"
                 },
                 "includeSkipped": {
-                  "description": "Count consecutive skipped runs toward alerting",
+                  "description": "Skipped runs count toward alert",
                   "type": "boolean"
                 },
                 "mode": {
@@ -503,14 +503,14 @@
                   "type": "boolean"
                 },
                 "fallbacks": {
-                  "description": "Fallback model ids",
+                  "description": "Fallback models",
                   "items": {
                     "type": "string"
                   },
                   "type": "array"
                 },
                 "kind": {
-                  "description": "Payload type",
+                  "description": "Payload kind",
                   "enum": ["systemEvent", "agentTurn"],
                   "type": "string"
                 },
@@ -518,7 +518,7 @@
                   "type": "boolean"
                 },
                 "message": {
-                  "description": "Agent prompt (kind=agentTurn)",
+                  "description": "agentTurn prompt",
                   "type": "string"
                 },
                 "model": {
@@ -526,11 +526,11 @@
                   "type": "string"
                 },
                 "text": {
-                  "description": "Message text (kind=systemEvent)",
+                  "description": "systemEvent text",
                   "type": "string"
                 },
                 "thinking": {
-                  "description": "Thinking level override",
+                  "description": "Thinking override",
                   "type": "string"
                 },
                 "timeoutSeconds": {
@@ -550,32 +550,32 @@
               "additionalProperties": true,
               "properties": {
                 "anchorMs": {
-                  "description": "Optional start anchor in milliseconds (kind=every)",
+                  "description": "Start anchor ms (kind=every)",
                   "type": "number"
                 },
                 "at": {
-                  "description": "ISO-8601 timestamp (kind=at)",
+                  "description": "ISO-8601 time (kind=at)",
                   "type": "string"
                 },
                 "everyMs": {
-                  "description": "Interval in milliseconds (kind=every)",
+                  "description": "Interval ms (kind=every)",
                   "type": "number"
                 },
                 "expr": {
-                  "description": "Cron expression (kind=cron) written in the supplied tz's local wall-clock time, or the Gateway host local timezone when tz is omitted; do not convert the requested local time to UTC first. Example: 6pm Shanghai daily is \"0 18 * * *\" with tz \"Asia/Shanghai\".",
+                  "description": "Cron expr in tz local time; no UTC conversion. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
                   "type": "string"
                 },
                 "kind": {
-                  "description": "Schedule type",
+                  "description": "Schedule kind",
                   "enum": ["at", "every", "cron"],
                   "type": "string"
                 },
                 "staggerMs": {
-                  "description": "Random jitter in ms (kind=cron)",
+                  "description": "Jitter ms (kind=cron)",
                   "type": "number"
                 },
                 "tz": {
-                  "description": "IANA timezone for interpreting cron wall-clock fields (kind=cron), e.g. \"Asia/Shanghai\"; if omitted, cron uses the Gateway host local timezone.",
+                  "description": "IANA tz for cron fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local tz.",
                   "type": "string"
                 }
               },
@@ -614,7 +614,7 @@
     "namespace": "openclaw"
   },
   {
-    "description": "Send, delete, and manage messages via channel plugins. Supports actions: send.",
+    "description": "Send/delete/manage channel messages. Supports actions: send.",
     "inputSchema": {
       "properties": {
         "accountId": {
@@ -625,14 +625,14 @@
           "type": "string"
         },
         "asDocument": {
-          "description": "Send image/GIF/video as document to avoid channel compression. Alias for forceDocument.",
+          "description": "Alias for forceDocument.",
           "type": "boolean"
         },
         "asVoice": {
           "type": "boolean"
         },
         "attachments": {
-          "description": "Structured media attachments to send with the message. Each item needs media/mediaUrl/path/filePath/fileUrl/url.",
+          "description": "Structured attachments; each needs media/mediaUrl/path/filePath/fileUrl/url.",
           "items": {
             "properties": {
               "filePath": {
@@ -672,7 +672,7 @@
           "type": "boolean"
         },
         "buffer": {
-          "description": "Base64 payload for attachments (optionally a data: URL).",
+          "description": "Base64 attachment payload; data URL ok.",
           "type": "string"
         },
         "caption": {
@@ -688,11 +688,11 @@
           "type": "boolean"
         },
         "effect": {
-          "description": "Alias for effectId (e.g., invisible-ink, balloons).",
+          "description": "Alias for effectId.",
           "type": "string"
         },
         "effectId": {
-          "description": "Message effect name/id for sendWithEffect (e.g., invisible ink).",
+          "description": "Effect id/name for sendWithEffect.",
           "type": "string"
         },
         "filename": {
@@ -702,7 +702,7 @@
           "type": "string"
         },
         "forceDocument": {
-          "description": "Send image/GIF/video as document to avoid channel compression.",
+          "description": "Send image/GIF/video as document; avoids compression.",
           "type": "boolean"
         },
         "gatewayToken": {
@@ -715,7 +715,7 @@
           "type": "boolean"
         },
         "media": {
-          "description": "Media URL or local path. data: URLs are not supported here, use buffer.",
+          "description": "Media URL/path. data: use buffer.",
           "type": "string"
         },
         "message": {
@@ -728,7 +728,7 @@
           "type": "string"
         },
         "quoteText": {
-          "description": "Quote text for Telegram reply_parameters",
+          "description": "Telegram reply quote text.",
           "type": "string"
         },
         "replyTo": {
@@ -762,7 +762,7 @@
   },
   {
     "deferLoading": true,
-    "description": "Record the result of a heartbeat run. Use notify=false when nothing should be sent visibly. Use notify=true with notificationText when the user should receive a concise heartbeat alert.",
+    "description": "Record heartbeat result. `notify=false` no visible send. `notify=true` needs concise notificationText.",
     "inputSchema": {
       "additionalProperties": false,
       "properties": {
@@ -798,19 +798,19 @@
   },
   {
     "deferLoading": true,
-    "description": "Use only for explicit audio intent (audio, voice, speech, TTS) or active TTS config. Never use for ordinary text replies. Audio is delivered automatically from the tool result. After a successful call, follow the current conversation's reply instructions and avoid sending a duplicate text/audio response.",
+    "description": "Use only for explicit audio intent (voice/speech/TTS) or active TTS config. Never use for ordinary text replies. Audio auto-delivered from tool result; after success follow reply instructions, no duplicate text/audio.",
     "inputSchema": {
       "properties": {
         "channel": {
-          "description": "Optional channel id to pick output format.",
+          "description": "Channel id; output-format hint.",
           "type": "string"
         },
         "text": {
-          "description": "Text to convert to speech.",
+          "description": "Text to speak.",
           "type": "string"
         },
         "timeoutMs": {
-          "description": "Optional provider request timeout in milliseconds.",
+          "description": "Provider timeout ms.",
           "minimum": 1,
           "type": "number"
         }
@@ -823,7 +823,7 @@
   },
   {
     "deferLoading": true,
-    "description": "Restart, inspect a specific config schema path, apply config, or update the gateway in-place (SIGUSR1). Use config.schema.lookup with a targeted dot path before config edits. Use config.patch for safe partial config updates (merges with existing). Use config.apply only when replacing entire config. Config writes hot-reload when possible and restart when required. Always pass a human-readable completion message via the `note` parameter so the system can deliver it to the user after restart. If restarting during a user task and you still owe the user a reply, pass a specific one-shot `continuationMessage` for what to verify or report after boot; do not write restart sentinel files directly.",
+    "description": "Gateway restart/config/update. Before config edits, use config.schema.lookup with targeted dot path. Prefer config.patch for partial merge; config.apply only full replace. Writes hot-reload or restart as needed. Always pass human `note` for post-restart delivery. If still owe the user a reply, pass one-shot `continuationMessage`; do not write restart sentinel files directly.",
     "inputSchema": {
       "properties": {
         "action": {
@@ -882,7 +882,7 @@
   },
   {
     "deferLoading": true,
-    "description": "List OpenClaw agent ids you can target with `sessions_spawn` when `runtime=\"subagent\"` (based on subagent allowlists).",
+    "description": "List agent ids allowed for `sessions_spawn runtime=\"subagent\"`.",
     "inputSchema": {
       "properties": {},
       "type": "object"
@@ -892,7 +892,7 @@
   },
   {
     "deferLoading": true,
-    "description": "List visible sessions with optional filters for kind, label, agentId, search, recent activity, derived titles, and last-message previews. Use this to discover a target session before calling sessions_history or sessions_send.",
+    "description": "List visible sessions; filter by kind, label, agentId, search, activity. Use before sessions_history or sessions_send target selection.",
     "inputSchema": {
       "properties": {
         "activeMinutes": {
@@ -940,7 +940,7 @@
   },
   {
     "deferLoading": true,
-    "description": "Fetch sanitized message history for a visible session. Supports limits and optional tool messages; use this to inspect another session before replying, debugging, or resuming work.",
+    "description": "Fetch sanitized history for visible session. Use before replying, debugging, resuming; supports limits/tool messages.",
     "inputSchema": {
       "properties": {
         "includeTools": {
@@ -962,7 +962,7 @@
   },
   {
     "deferLoading": true,
-    "description": "Send a message into another visible session by sessionKey or label, or to a configured agent by agentId. Thread-scoped chat sessions are rejected; target the parent channel session for inter-agent coordination. Missing configured agent main sessions are created before send; waits for the target run and returns the updated assistant reply when available.",
+    "description": "Send message to visible session by sessionKey/label, or configured agent by agentId. Thread-scoped chats rejected; target parent channel session. Creates missing configured-agent main session; waits for reply when available.",
     "inputSchema": {
       "properties": {
         "agentId": {
@@ -994,7 +994,7 @@
   },
   {
     "deferLoading": true,
-    "description": "Spawn a clean isolated session by default with the native subagent runtime. `mode=\"run\"` is one-shot background work. Subagents inherit the parent workspace directory automatically. Native subagents receive the delegated task in their first visible `[Subagent Task]` message. For native subagents only, set `context=\"fork\"` when the child needs the current transcript context; otherwise omit it or use `context=\"isolated\"`. Use this when the work should happen in a fresh child session instead of the current one.",
+    "description": "Spawn clean child session; default `runtime=\"subagent\"`. `mode=\"run\"` one-shot background work. Subagents inherit parent workspace. Native subagents get task in first visible `[Subagent Task]` message. Native only: `context=\"fork\"` only when child needs current transcript; else omit or `isolated`. Use for fresh child-session work.",
     "inputSchema": {
       "properties": {
         "agentId": {
@@ -1036,7 +1036,7 @@
           "type": "string"
         },
         "context": {
-          "description": "Native subagent context mode. Omit or use \"isolated\" for a clean child session; use \"fork\" only when the child needs the requester transcript context.",
+          "description": "Native context. Omit/\"isolated\" for clean child; \"fork\" only when child needs requester transcript.",
           "enum": ["isolated", "fork"],
           "type": "string"
         },
@@ -1047,7 +1047,7 @@
           "type": "string"
         },
         "lightContext": {
-          "description": "When true, spawned subagent runs use lightweight bootstrap context. Only applies to runtime='subagent'.",
+          "description": "Light bootstrap context; runtime=\"subagent\" only.",
           "type": "boolean"
         },
         "mode": {
@@ -1073,7 +1073,7 @@
           "type": "string"
         },
         "taskName": {
-          "description": "Stable optional alias for later subagents targeting. Use lowercase letters, digits, and underscores, starting with a letter.",
+          "description": "Stable alias for later targeting; lowercase letters/digits/underscores, starts letter.",
           "type": "string"
         },
         "thinking": {
@@ -1091,7 +1091,7 @@
     "namespace": "openclaw"
   },
   {
-    "description": "End your current turn. Use after spawning subagents to receive their results as the next message.",
+    "description": "End current turn. Use after spawning subagents; results arrive as next message.",
     "inputSchema": {
       "properties": {
         "message": {
@@ -1104,7 +1104,7 @@
   },
   {
     "deferLoading": true,
-    "description": "On-demand list, kill, or steer spawned sub-agents for this requester session. If sessions_yield is available, use it to wait for completion events; do not poll this tool in wait loops.",
+    "description": "List/kill/steer spawned subagents for requester session. If sessions_yield exists, use it for completion; do not poll wait loops.",
     "inputSchema": {
       "properties": {
         "action": {
@@ -1129,7 +1129,7 @@
   },
   {
     "deferLoading": true,
-    "description": "Show a /status-equivalent session status card for the current or another visible session, including usage, time, cost when available, and linked background task context. Use `sessionKey=\"current\"` for the current session; do not use UI/client labels such as `openclaw-tui` as session keys. Optional `model` sets a per-session model override; `model=default` resets overrides. Use this for questions like what model is active or how a session is configured.",
+    "description": "Show /status-like card for current/visible session: model, usage, time, cost, tasks. Use `sessionKey=\"current\"` for current session; UI labels like `openclaw-tui` are not keys. `model` sets session override; `model=default` resets. Use for active model/session config questions.",
     "inputSchema": {
       "properties": {
         "model": {
@@ -1146,63 +1146,63 @@
   },
   {
     "deferLoading": true,
-    "description": "Search the web. Returns provider-normalized results for current information lookup.",
+    "description": "Search web for current info; returns normalized provider results.",
     "inputSchema": {
       "properties": {
         "count": {
-          "description": "Number of results to return.",
+          "description": "Result count.",
           "maximum": 10,
           "minimum": 1,
           "type": "number"
         },
         "country": {
-          "description": "2-letter country code for region-specific results.",
+          "description": "2-letter country code.",
           "type": "string"
         },
         "date_after": {
-          "description": "Only results published after this date (YYYY-MM-DD).",
+          "description": "Published after YYYY-MM-DD.",
           "type": "string"
         },
         "date_before": {
-          "description": "Only results published before this date (YYYY-MM-DD).",
+          "description": "Published before YYYY-MM-DD.",
           "type": "string"
         },
         "domain_filter": {
-          "description": "Perplexity native Search API domain filter.",
+          "description": "Perplexity domain filter.",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "freshness": {
-          "description": "Filter by time: day, week, month, or year.",
+          "description": "Time filter: day/week/month/year.",
           "type": "string"
         },
         "language": {
-          "description": "ISO 639-1 language code for results.",
+          "description": "ISO 639-1 language.",
           "type": "string"
         },
         "max_tokens": {
-          "description": "Perplexity native Search API total content budget.",
+          "description": "Perplexity total token budget.",
           "maximum": 1000000,
           "minimum": 1,
           "type": "number"
         },
         "max_tokens_per_page": {
-          "description": "Perplexity native Search API max tokens extracted per page.",
+          "description": "Perplexity tokens per page.",
           "minimum": 1,
           "type": "number"
         },
         "query": {
-          "description": "Search query string.",
+          "description": "Search query.",
           "type": "string"
         },
         "search_lang": {
-          "description": "Brave search result language code.",
+          "description": "Brave result language.",
           "type": "string"
         },
         "ui_lang": {
-          "description": "Brave UI locale code in language-region format.",
+          "description": "Brave UI locale.",
           "type": "string"
         }
       },
@@ -1214,22 +1214,22 @@
   },
   {
     "deferLoading": true,
-    "description": "Fetch and extract readable content from a URL (HTML → markdown/text). Use for lightweight page access without browser automation.",
+    "description": "Fetch URL and extract readable markdown/text. Lightweight page access; no browser automation.",
     "inputSchema": {
       "properties": {
         "extractMode": {
           "default": "markdown",
-          "description": "Extraction mode (\"markdown\" or \"text\").",
+          "description": "Extract as markdown/text.",
           "enum": ["markdown", "text"],
           "type": "string"
         },
         "maxChars": {
-          "description": "Maximum characters to return (truncates when exceeded).",
+          "description": "Max chars returned; truncates.",
           "minimum": 100,
           "type": "number"
         },
         "url": {
-          "description": "HTTP or HTTPS URL to fetch.",
+          "description": "HTTP(S) URL.",
           "type": "string"
         }
       },

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.heartbeat-turn.json
@@ -344,7 +344,7 @@
                   "type": "number"
                 },
                 "expr": {
-                  "description": "Cron expr in tz local time; no UTC conversion. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
+                  "description": "Cron expr in tz wall-clock time; do not convert to UTC. Omitted tz => Gateway host local timezone. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
                   "type": "string"
                 },
                 "kind": {
@@ -357,7 +357,7 @@
                   "type": "number"
                 },
                 "tz": {
-                  "description": "IANA tz for cron fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local tz.",
+                  "description": "IANA timezone for cron wall-clock fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local timezone.",
                   "type": "string"
                 }
               },
@@ -562,7 +562,7 @@
                   "type": "number"
                 },
                 "expr": {
-                  "description": "Cron expr in tz local time; no UTC conversion. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
+                  "description": "Cron expr in tz wall-clock time; do not convert to UTC. Omitted tz => Gateway host local timezone. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
                   "type": "string"
                 },
                 "kind": {
@@ -575,7 +575,7 @@
                   "type": "number"
                 },
                 "tz": {
-                  "description": "IANA tz for cron fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local tz.",
+                  "description": "IANA timezone for cron wall-clock fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local timezone.",
                   "type": "string"
                 }
               },

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -1,7 +1,7 @@
 [
   {
     "deferLoading": true,
-    "description": "Discover and control paired nodes (status/describe/pairing/notify/camera/photos/screen/location/notifications/invoke). For file retrieval, use the dedicated file_fetch tool.",
+    "description": "Discover/control paired nodes: status, describe, pairing, notify, camera/photos/screen/location/notifications/invoke. Use file_fetch for files.",
     "inputSchema": {
       "properties": {
         "action": {
@@ -137,7 +137,7 @@
   },
   {
     "deferLoading": true,
-    "description": "Manage Gateway cron jobs (status/list/get/add/update/remove/run/runs) and send wake events. Use this for reminders, \"check back later\" requests, delayed follow-ups, and recurring tasks. Do not emulate scheduling with exec sleep or process polling.\n\nMain-session cron jobs enqueue system events for heartbeat handling. Isolated cron jobs create background task runs that appear in `openclaw tasks`.\n\nACTIONS:\n- status: Check cron scheduler status\n- list: List jobs (use includeDisabled:true to include disabled; agentId filters by agent, auto-filled from session)\n- get: Get one job by id (requires jobId)\n- add: Create job (requires job object, see schema below)\n- update: Modify job (requires jobId + patch object)\n- remove: Delete job (requires jobId)\n- run: Trigger job immediately (requires jobId)\n- runs: Get job run history (requires jobId)\n- wake: Send wake event (requires text, optional mode)\n\nJOB SCHEMA (for add action):\n{\n  \"name\": \"string (optional)\",\n  \"schedule\": { ... },      // Required: when to run\n  \"payload\": { ... },       // Required: what to execute\n  \"delivery\": { ... },      // Optional: announce summary (isolated/current/session:xxx only) or webhook POST\n  \"sessionTarget\": \"main\" | \"isolated\" | \"current\" | \"session:<custom-id>\",  // Optional, defaults based on context\n  \"enabled\": true | false   // Optional, default true\n}\n\nSESSION TARGET OPTIONS:\n- \"main\": Run in the main session (requires payload.kind=\"systemEvent\")\n- \"isolated\": Run in an ephemeral isolated session (requires payload.kind=\"agentTurn\")\n- \"current\": Bind to the current session where the cron is created (resolved at creation time)\n- \"session:<custom-id>\": Run in a persistent named session (e.g., \"session:project-alpha-daily\")\n\nDEFAULT BEHAVIOR (unchanged for backward compatibility):\n- payload.kind=\"systemEvent\" → defaults to \"main\"\n- payload.kind=\"agentTurn\" → defaults to \"isolated\"\nTo use current session binding, explicitly set sessionTarget=\"current\".\n\nSCHEDULE TYPES (schedule.kind):\n- \"at\": One-shot at absolute time\n  { \"kind\": \"at\", \"at\": \"<ISO-8601 timestamp>\" }\n- \"every\": Recurring interval\n  { \"kind\": \"every\", \"everyMs\": <interval-ms>, \"anchorMs\": <optional-start-ms> }\n- \"cron\": Cron expression evaluated in the supplied timezone, or the Gateway host local timezone when tz is omitted\n  { \"kind\": \"cron\", \"expr\": \"<cron-expression>\", \"tz\": \"<optional-IANA-timezone>\" }\n  Write expr in the selected timezone's local wall-clock time; do not convert the requested local time to UTC first.\n  If tz is omitted, do not assume UTC; the Gateway host local timezone is used.\n  Example: \"Remind me every day at 6pm Shanghai time\" -> { \"kind\": \"cron\", \"expr\": \"0 18 * * *\", \"tz\": \"Asia/Shanghai\" }\n\nFor schedule.kind=\"at\", ISO timestamps without an explicit timezone are treated as UTC.\n\nPAYLOAD TYPES (payload.kind):\n- \"systemEvent\": Injects text as system event into session\n  { \"kind\": \"systemEvent\", \"text\": \"<message>\" }\n- \"agentTurn\": Runs agent with message (isolated sessions only)\n  { \"kind\": \"agentTurn\", \"message\": \"<prompt>\", \"model\": \"<optional>\", \"thinking\": \"<optional>\", \"timeoutSeconds\": <optional, 0 means no timeout> }\n\nDELIVERY (top-level):\n  { \"mode\": \"none|announce|webhook\", \"channel\": \"<optional>\", \"to\": \"<optional>\", \"threadId\": \"<optional>\", \"bestEffort\": <optional-bool> }\n  - Default for isolated agentTurn jobs (when delivery omitted): \"announce\"\n  - announce: send to chat channel (optional channel/to target)\n  - threadId: chat thread/topic id for channels that support threaded delivery\n  - webhook: send finished-run event as HTTP POST to delivery.to (URL required)\n  - If the task needs to send to a specific chat/recipient, set announce delivery.channel/to; do not call messaging tools inside the run.\n\nCRITICAL CONSTRAINTS:\n- sessionTarget=\"main\" REQUIRES payload.kind=\"systemEvent\"\n- sessionTarget=\"isolated\" | \"current\" | \"session:xxx\" REQUIRES payload.kind=\"agentTurn\"\n- For webhook callbacks, use delivery.mode=\"webhook\" with delivery.to set to a URL.\nDefault: prefer isolated agentTurn jobs unless the user explicitly wants current-session binding.\n\nRESTRICTED CRON RUNS:\n- Some isolated cron runs receive a narrow cron grant for self-cleanup. In that mode, read-only status and list are for self-introspection only, get/runs are allowed for the current job only, and mutation actions remain limited to removing the current cron job.\n\nWAKE MODES (for wake action):\n- \"next-heartbeat\" (default): Wake on next heartbeat\n- \"now\": Wake immediately\n\nUse jobId as the canonical identifier; id is accepted for compatibility. Use contextMessages (0-10) to add previous messages as context to the job text.",
+    "description": "Manage Gateway cron jobs and wake events: reminders, check-back-later, delayed follow-ups, recurring work. Do not emulate scheduling with exec sleep/process polling.\n\nMain cron => system events for heartbeat. Isolated cron => background task in `openclaw tasks`.\n\nACTIONS:\n- status: scheduler status\n- list: jobs; includeDisabled true includes disabled; agentId filter auto-filled from session\n- get: one job; needs jobId\n- add: create job; needs job object\n- update: patch job; needs jobId + patch\n- remove: delete job; needs jobId\n- run: trigger now; needs jobId\n- runs: run history; needs jobId\n- wake: send wake event; needs text, optional mode\n\nJOB SCHEMA (for add action):\n{\n  \"name\": \"string\",\n  \"schedule\": { ... },      // required\n  \"payload\": { ... },       // required\n  \"delivery\": { ... },      // optional announce for isolated/current/session, webhook for any target\n  \"sessionTarget\": \"main\" | \"isolated\" | \"current\" | \"session:<id>\",\n  \"enabled\": true | false   // default true\n}\n\nSESSION TARGET OPTIONS:\n- \"main\": main session; requires payload.kind=\"systemEvent\"\n- \"isolated\": ephemeral isolated session; requires payload.kind=\"agentTurn\"\n- \"current\": bind current session at creation\n- \"session:<id>\": persistent named session\n\nDEFAULTS:\n- payload.kind=\"systemEvent\" → defaults to \"main\"\n- payload.kind=\"agentTurn\" → defaults to \"isolated\"\nCurrent binding needs sessionTarget=\"current\".\n\nSCHEDULE TYPES (schedule.kind):\n- \"at\": one-shot absolute time\n  { \"kind\": \"at\", \"at\": \"<ISO-8601 timestamp>\" }\n- \"every\": recurring interval\n  { \"kind\": \"every\", \"everyMs\": <ms>, \"anchorMs\": <optional-ms> }\n- \"cron\": expr in supplied timezone, or Gateway host local timezone when tz omitted\n  { \"kind\": \"cron\", \"expr\": \"<cron-expression>\", \"tz\": \"<optional-IANA-timezone>\" }\n  Write expr in local wall-clock time; do not convert the requested local time to UTC first.\n  tz omitted => Gateway host local timezone, not UTC.\n  Example 6pm Shanghai daily: { \"kind\": \"cron\", \"expr\": \"0 18 * * *\", \"tz\": \"Asia/Shanghai\" }\n\nFor \"at\", ISO timestamps without timezone are UTC.\n\nPAYLOAD TYPES (payload.kind):\n- \"systemEvent\": inject text as system event\n  { \"kind\": \"systemEvent\", \"text\": \"<message>\" }\n- \"agentTurn\": run agent with prompt; isolated/current/session only\n  { \"kind\": \"agentTurn\", \"message\": \"<prompt>\", \"model\": \"<optional>\", \"thinking\": \"<optional>\", \"timeoutSeconds\": <optional, 0=no timeout> }\n\nDELIVERY (top-level):\n  { \"mode\": \"none|announce|webhook\", \"channel\": \"<optional>\", \"to\": \"<optional>\", \"threadId\": \"<optional>\", \"bestEffort\": <optional-bool> }\n  - isolated agentTurn default when omitted: \"announce\"\n  - announce: send to chat channel; isolated/current/session only; optional channel/to\n  - threadId: chat thread/topic id\n  - webhook: POST finished-run event to delivery.to URL\n  - Specific chat/recipient: set announce delivery.channel/to; do not call messaging tools inside run.\n\nCRITICAL CONSTRAINTS:\n- sessionTarget=\"main\" REQUIRES payload.kind=\"systemEvent\"\n- sessionTarget=\"isolated\" | \"current\" | \"session:xxx\" REQUIRES payload.kind=\"agentTurn\"\n- Webhook: delivery.mode=\"webhook\" and delivery.to URL.\nDefault: prefer isolated agentTurn jobs unless the user explicitly wants current-session binding.\n\nRESTRICTED CRON RUNS:\n- Some isolated cron runs get narrow self-cleanup grant: status/list self-only, get/runs current job only, mutation only remove current job.\n\nWAKE MODES (for wake action):\n- \"next-heartbeat\" default: wake next heartbeat\n- \"now\": wake immediately\n\nUse jobId canonical; id accepted compat. contextMessages (0-10) adds previous messages as job context.",
     "inputSchema": {
       "additionalProperties": true,
       "properties": {
@@ -146,7 +146,7 @@
           "type": "string"
         },
         "agentId": {
-          "description": "Filter by agent id (list action)",
+          "description": "List filter: agent id",
           "type": "string"
         },
         "contextMessages": {
@@ -174,14 +174,14 @@
               "type": "string"
             },
             "deleteAfterRun": {
-              "description": "Delete after first execution",
+              "description": "Delete after first run",
               "type": "boolean"
             },
             "delivery": {
               "additionalProperties": true,
               "properties": {
                 "accountId": {
-                  "description": "Account target for delivery",
+                  "description": "Delivery account",
                   "type": "string"
                 },
                 "bestEffort": {
@@ -224,7 +224,7 @@
                       "type": "number"
                     }
                   ],
-                  "description": "Thread/topic id for channels that support threaded delivery"
+                  "description": "Thread/topic id"
                 },
                 "to": {
                   "description": "Delivery target",
@@ -234,7 +234,7 @@
               "type": "object"
             },
             "description": {
-              "description": "Human-readable description",
+              "description": "Human description",
               "type": "string"
             },
             "enabled": {
@@ -242,13 +242,13 @@
             },
             "failureAlert": {
               "additionalProperties": true,
-              "description": "Failure alert config object, or the boolean value false to disable alerts for this job",
+              "description": "Failure alert object; false disables alerts",
               "properties": {
                 "accountId": {
                   "type": "string"
                 },
                 "after": {
-                  "description": "Failures before alerting",
+                  "description": "Failures before alert",
                   "type": "number"
                 },
                 "channel": {
@@ -256,11 +256,11 @@
                   "type": "string"
                 },
                 "cooldownMs": {
-                  "description": "Cooldown between alerts in ms",
+                  "description": "Alert cooldown ms",
                   "type": "number"
                 },
                 "includeSkipped": {
-                  "description": "Count consecutive skipped runs toward alerting",
+                  "description": "Skipped runs count toward alert",
                   "type": "boolean"
                 },
                 "mode": {
@@ -285,14 +285,14 @@
                   "type": "boolean"
                 },
                 "fallbacks": {
-                  "description": "Fallback model ids",
+                  "description": "Fallback models",
                   "items": {
                     "type": "string"
                   },
                   "type": "array"
                 },
                 "kind": {
-                  "description": "Payload type",
+                  "description": "Payload kind",
                   "enum": ["systemEvent", "agentTurn"],
                   "type": "string"
                 },
@@ -300,7 +300,7 @@
                   "type": "boolean"
                 },
                 "message": {
-                  "description": "Agent prompt (kind=agentTurn)",
+                  "description": "agentTurn prompt",
                   "type": "string"
                 },
                 "model": {
@@ -308,18 +308,18 @@
                   "type": "string"
                 },
                 "text": {
-                  "description": "Message text (kind=systemEvent)",
+                  "description": "systemEvent text",
                   "type": "string"
                 },
                 "thinking": {
-                  "description": "Thinking level override",
+                  "description": "Thinking override",
                   "type": "string"
                 },
                 "timeoutSeconds": {
                   "type": "number"
                 },
                 "toolsAllow": {
-                  "description": "Allowed tool ids",
+                  "description": "Allowed tools",
                   "items": {
                     "type": "string"
                   },
@@ -332,32 +332,32 @@
               "additionalProperties": true,
               "properties": {
                 "anchorMs": {
-                  "description": "Optional start anchor in milliseconds (kind=every)",
+                  "description": "Start anchor ms (kind=every)",
                   "type": "number"
                 },
                 "at": {
-                  "description": "ISO-8601 timestamp (kind=at)",
+                  "description": "ISO-8601 time (kind=at)",
                   "type": "string"
                 },
                 "everyMs": {
-                  "description": "Interval in milliseconds (kind=every)",
+                  "description": "Interval ms (kind=every)",
                   "type": "number"
                 },
                 "expr": {
-                  "description": "Cron expression (kind=cron) written in the supplied tz's local wall-clock time, or the Gateway host local timezone when tz is omitted; do not convert the requested local time to UTC first. Example: 6pm Shanghai daily is \"0 18 * * *\" with tz \"Asia/Shanghai\".",
+                  "description": "Cron expr in tz local time; no UTC conversion. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
                   "type": "string"
                 },
                 "kind": {
-                  "description": "Schedule type",
+                  "description": "Schedule kind",
                   "enum": ["at", "every", "cron"],
                   "type": "string"
                 },
                 "staggerMs": {
-                  "description": "Random jitter in ms (kind=cron)",
+                  "description": "Jitter ms (kind=cron)",
                   "type": "number"
                 },
                 "tz": {
-                  "description": "IANA timezone for interpreting cron wall-clock fields (kind=cron), e.g. \"Asia/Shanghai\"; if omitted, cron uses the Gateway host local timezone.",
+                  "description": "IANA tz for cron fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local tz.",
                   "type": "string"
                 }
               },
@@ -368,11 +368,11 @@
               "type": "string"
             },
             "sessionTarget": {
-              "description": "Session target: \"main\", \"isolated\", \"current\", or \"session:<id>\"",
+              "description": "main | isolated | current | session:<id>",
               "type": "string"
             },
             "wakeMode": {
-              "description": "When to wake the session",
+              "description": "Wake timing",
               "enum": ["now", "next-heartbeat"],
               "type": "string"
             }
@@ -400,7 +400,7 @@
               "additionalProperties": true,
               "properties": {
                 "accountId": {
-                  "description": "Account target for delivery",
+                  "description": "Delivery account",
                   "type": "string"
                 },
                 "bestEffort": {
@@ -443,7 +443,7 @@
                       "type": "number"
                     }
                   ],
-                  "description": "Thread/topic id for channels that support threaded delivery"
+                  "description": "Thread/topic id"
                 },
                 "to": {
                   "description": "Delivery target",
@@ -460,13 +460,13 @@
             },
             "failureAlert": {
               "additionalProperties": true,
-              "description": "Failure alert config object, or the boolean value false to disable alerts for this job",
+              "description": "Failure alert object; false disables alerts",
               "properties": {
                 "accountId": {
                   "type": "string"
                 },
                 "after": {
-                  "description": "Failures before alerting",
+                  "description": "Failures before alert",
                   "type": "number"
                 },
                 "channel": {
@@ -474,11 +474,11 @@
                   "type": "string"
                 },
                 "cooldownMs": {
-                  "description": "Cooldown between alerts in ms",
+                  "description": "Alert cooldown ms",
                   "type": "number"
                 },
                 "includeSkipped": {
-                  "description": "Count consecutive skipped runs toward alerting",
+                  "description": "Skipped runs count toward alert",
                   "type": "boolean"
                 },
                 "mode": {
@@ -503,14 +503,14 @@
                   "type": "boolean"
                 },
                 "fallbacks": {
-                  "description": "Fallback model ids",
+                  "description": "Fallback models",
                   "items": {
                     "type": "string"
                   },
                   "type": "array"
                 },
                 "kind": {
-                  "description": "Payload type",
+                  "description": "Payload kind",
                   "enum": ["systemEvent", "agentTurn"],
                   "type": "string"
                 },
@@ -518,7 +518,7 @@
                   "type": "boolean"
                 },
                 "message": {
-                  "description": "Agent prompt (kind=agentTurn)",
+                  "description": "agentTurn prompt",
                   "type": "string"
                 },
                 "model": {
@@ -526,11 +526,11 @@
                   "type": "string"
                 },
                 "text": {
-                  "description": "Message text (kind=systemEvent)",
+                  "description": "systemEvent text",
                   "type": "string"
                 },
                 "thinking": {
-                  "description": "Thinking level override",
+                  "description": "Thinking override",
                   "type": "string"
                 },
                 "timeoutSeconds": {
@@ -550,32 +550,32 @@
               "additionalProperties": true,
               "properties": {
                 "anchorMs": {
-                  "description": "Optional start anchor in milliseconds (kind=every)",
+                  "description": "Start anchor ms (kind=every)",
                   "type": "number"
                 },
                 "at": {
-                  "description": "ISO-8601 timestamp (kind=at)",
+                  "description": "ISO-8601 time (kind=at)",
                   "type": "string"
                 },
                 "everyMs": {
-                  "description": "Interval in milliseconds (kind=every)",
+                  "description": "Interval ms (kind=every)",
                   "type": "number"
                 },
                 "expr": {
-                  "description": "Cron expression (kind=cron) written in the supplied tz's local wall-clock time, or the Gateway host local timezone when tz is omitted; do not convert the requested local time to UTC first. Example: 6pm Shanghai daily is \"0 18 * * *\" with tz \"Asia/Shanghai\".",
+                  "description": "Cron expr in tz local time; no UTC conversion. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
                   "type": "string"
                 },
                 "kind": {
-                  "description": "Schedule type",
+                  "description": "Schedule kind",
                   "enum": ["at", "every", "cron"],
                   "type": "string"
                 },
                 "staggerMs": {
-                  "description": "Random jitter in ms (kind=cron)",
+                  "description": "Jitter ms (kind=cron)",
                   "type": "number"
                 },
                 "tz": {
-                  "description": "IANA timezone for interpreting cron wall-clock fields (kind=cron), e.g. \"Asia/Shanghai\"; if omitted, cron uses the Gateway host local timezone.",
+                  "description": "IANA tz for cron fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local tz.",
                   "type": "string"
                 }
               },
@@ -614,7 +614,7 @@
     "namespace": "openclaw"
   },
   {
-    "description": "Send, delete, and manage messages via channel plugins. Supports actions: send.",
+    "description": "Send/delete/manage channel messages. Supports actions: send.",
     "inputSchema": {
       "properties": {
         "accountId": {
@@ -625,14 +625,14 @@
           "type": "string"
         },
         "asDocument": {
-          "description": "Send image/GIF/video as document to avoid channel compression. Alias for forceDocument.",
+          "description": "Alias for forceDocument.",
           "type": "boolean"
         },
         "asVoice": {
           "type": "boolean"
         },
         "attachments": {
-          "description": "Structured media attachments to send with the message. Each item needs media/mediaUrl/path/filePath/fileUrl/url.",
+          "description": "Structured attachments; each needs media/mediaUrl/path/filePath/fileUrl/url.",
           "items": {
             "properties": {
               "filePath": {
@@ -672,7 +672,7 @@
           "type": "boolean"
         },
         "buffer": {
-          "description": "Base64 payload for attachments (optionally a data: URL).",
+          "description": "Base64 attachment payload; data URL ok.",
           "type": "string"
         },
         "caption": {
@@ -688,11 +688,11 @@
           "type": "boolean"
         },
         "effect": {
-          "description": "Alias for effectId (e.g., invisible-ink, balloons).",
+          "description": "Alias for effectId.",
           "type": "string"
         },
         "effectId": {
-          "description": "Message effect name/id for sendWithEffect (e.g., invisible ink).",
+          "description": "Effect id/name for sendWithEffect.",
           "type": "string"
         },
         "filename": {
@@ -702,7 +702,7 @@
           "type": "string"
         },
         "forceDocument": {
-          "description": "Send image/GIF/video as document to avoid channel compression.",
+          "description": "Send image/GIF/video as document; avoids compression.",
           "type": "boolean"
         },
         "gatewayToken": {
@@ -715,7 +715,7 @@
           "type": "boolean"
         },
         "media": {
-          "description": "Media URL or local path. data: URLs are not supported here, use buffer.",
+          "description": "Media URL/path. data: use buffer.",
           "type": "string"
         },
         "message": {
@@ -728,7 +728,7 @@
           "type": "string"
         },
         "quoteText": {
-          "description": "Quote text for Telegram reply_parameters",
+          "description": "Telegram reply quote text.",
           "type": "string"
         },
         "replyTo": {
@@ -762,19 +762,19 @@
   },
   {
     "deferLoading": true,
-    "description": "Use only for explicit audio intent (audio, voice, speech, TTS) or active TTS config. Never use for ordinary text replies. Audio is delivered automatically from the tool result. After a successful call, follow the current conversation's reply instructions and avoid sending a duplicate text/audio response.",
+    "description": "Use only for explicit audio intent (voice/speech/TTS) or active TTS config. Never use for ordinary text replies. Audio auto-delivered from tool result; after success follow reply instructions, no duplicate text/audio.",
     "inputSchema": {
       "properties": {
         "channel": {
-          "description": "Optional channel id to pick output format.",
+          "description": "Channel id; output-format hint.",
           "type": "string"
         },
         "text": {
-          "description": "Text to convert to speech.",
+          "description": "Text to speak.",
           "type": "string"
         },
         "timeoutMs": {
-          "description": "Optional provider request timeout in milliseconds.",
+          "description": "Provider timeout ms.",
           "minimum": 1,
           "type": "number"
         }
@@ -787,7 +787,7 @@
   },
   {
     "deferLoading": true,
-    "description": "Restart, inspect a specific config schema path, apply config, or update the gateway in-place (SIGUSR1). Use config.schema.lookup with a targeted dot path before config edits. Use config.patch for safe partial config updates (merges with existing). Use config.apply only when replacing entire config. Config writes hot-reload when possible and restart when required. Always pass a human-readable completion message via the `note` parameter so the system can deliver it to the user after restart. If restarting during a user task and you still owe the user a reply, pass a specific one-shot `continuationMessage` for what to verify or report after boot; do not write restart sentinel files directly.",
+    "description": "Gateway restart/config/update. Before config edits, use config.schema.lookup with targeted dot path. Prefer config.patch for partial merge; config.apply only full replace. Writes hot-reload or restart as needed. Always pass human `note` for post-restart delivery. If still owe the user a reply, pass one-shot `continuationMessage`; do not write restart sentinel files directly.",
     "inputSchema": {
       "properties": {
         "action": {
@@ -846,7 +846,7 @@
   },
   {
     "deferLoading": true,
-    "description": "List OpenClaw agent ids you can target with `sessions_spawn` when `runtime=\"subagent\"` (based on subagent allowlists).",
+    "description": "List agent ids allowed for `sessions_spawn runtime=\"subagent\"`.",
     "inputSchema": {
       "properties": {},
       "type": "object"
@@ -856,7 +856,7 @@
   },
   {
     "deferLoading": true,
-    "description": "List visible sessions with optional filters for kind, label, agentId, search, recent activity, derived titles, and last-message previews. Use this to discover a target session before calling sessions_history or sessions_send.",
+    "description": "List visible sessions; filter by kind, label, agentId, search, activity. Use before sessions_history or sessions_send target selection.",
     "inputSchema": {
       "properties": {
         "activeMinutes": {
@@ -904,7 +904,7 @@
   },
   {
     "deferLoading": true,
-    "description": "Fetch sanitized message history for a visible session. Supports limits and optional tool messages; use this to inspect another session before replying, debugging, or resuming work.",
+    "description": "Fetch sanitized history for visible session. Use before replying, debugging, resuming; supports limits/tool messages.",
     "inputSchema": {
       "properties": {
         "includeTools": {
@@ -926,7 +926,7 @@
   },
   {
     "deferLoading": true,
-    "description": "Send a message into another visible session by sessionKey or label, or to a configured agent by agentId. Thread-scoped chat sessions are rejected; target the parent channel session for inter-agent coordination. Missing configured agent main sessions are created before send; waits for the target run and returns the updated assistant reply when available.",
+    "description": "Send message to visible session by sessionKey/label, or configured agent by agentId. Thread-scoped chats rejected; target parent channel session. Creates missing configured-agent main session; waits for reply when available.",
     "inputSchema": {
       "properties": {
         "agentId": {
@@ -958,7 +958,7 @@
   },
   {
     "deferLoading": true,
-    "description": "Spawn a clean isolated session by default with the native subagent runtime. `mode=\"run\"` is one-shot background work. Subagents inherit the parent workspace directory automatically. Native subagents receive the delegated task in their first visible `[Subagent Task]` message. For native subagents only, set `context=\"fork\"` when the child needs the current transcript context; otherwise omit it or use `context=\"isolated\"`. Use this when the work should happen in a fresh child session instead of the current one.",
+    "description": "Spawn clean child session; default `runtime=\"subagent\"`. `mode=\"run\"` one-shot background work. Subagents inherit parent workspace. Native subagents get task in first visible `[Subagent Task]` message. Native only: `context=\"fork\"` only when child needs current transcript; else omit or `isolated`. Use for fresh child-session work.",
     "inputSchema": {
       "properties": {
         "agentId": {
@@ -1000,7 +1000,7 @@
           "type": "string"
         },
         "context": {
-          "description": "Native subagent context mode. Omit or use \"isolated\" for a clean child session; use \"fork\" only when the child needs the requester transcript context.",
+          "description": "Native context. Omit/\"isolated\" for clean child; \"fork\" only when child needs requester transcript.",
           "enum": ["isolated", "fork"],
           "type": "string"
         },
@@ -1011,7 +1011,7 @@
           "type": "string"
         },
         "lightContext": {
-          "description": "When true, spawned subagent runs use lightweight bootstrap context. Only applies to runtime='subagent'.",
+          "description": "Light bootstrap context; runtime=\"subagent\" only.",
           "type": "boolean"
         },
         "mode": {
@@ -1037,7 +1037,7 @@
           "type": "string"
         },
         "taskName": {
-          "description": "Stable optional alias for later subagents targeting. Use lowercase letters, digits, and underscores, starting with a letter.",
+          "description": "Stable alias for later targeting; lowercase letters/digits/underscores, starts letter.",
           "type": "string"
         },
         "thinking": {
@@ -1055,7 +1055,7 @@
     "namespace": "openclaw"
   },
   {
-    "description": "End your current turn. Use after spawning subagents to receive their results as the next message.",
+    "description": "End current turn. Use after spawning subagents; results arrive as next message.",
     "inputSchema": {
       "properties": {
         "message": {
@@ -1068,7 +1068,7 @@
   },
   {
     "deferLoading": true,
-    "description": "On-demand list, kill, or steer spawned sub-agents for this requester session. If sessions_yield is available, use it to wait for completion events; do not poll this tool in wait loops.",
+    "description": "List/kill/steer spawned subagents for requester session. If sessions_yield exists, use it for completion; do not poll wait loops.",
     "inputSchema": {
       "properties": {
         "action": {
@@ -1093,7 +1093,7 @@
   },
   {
     "deferLoading": true,
-    "description": "Show a /status-equivalent session status card for the current or another visible session, including usage, time, cost when available, and linked background task context. Use `sessionKey=\"current\"` for the current session; do not use UI/client labels such as `openclaw-tui` as session keys. Optional `model` sets a per-session model override; `model=default` resets overrides. Use this for questions like what model is active or how a session is configured.",
+    "description": "Show /status-like card for current/visible session: model, usage, time, cost, tasks. Use `sessionKey=\"current\"` for current session; UI labels like `openclaw-tui` are not keys. `model` sets session override; `model=default` resets. Use for active model/session config questions.",
     "inputSchema": {
       "properties": {
         "model": {
@@ -1110,63 +1110,63 @@
   },
   {
     "deferLoading": true,
-    "description": "Search the web. Returns provider-normalized results for current information lookup.",
+    "description": "Search web for current info; returns normalized provider results.",
     "inputSchema": {
       "properties": {
         "count": {
-          "description": "Number of results to return.",
+          "description": "Result count.",
           "maximum": 10,
           "minimum": 1,
           "type": "number"
         },
         "country": {
-          "description": "2-letter country code for region-specific results.",
+          "description": "2-letter country code.",
           "type": "string"
         },
         "date_after": {
-          "description": "Only results published after this date (YYYY-MM-DD).",
+          "description": "Published after YYYY-MM-DD.",
           "type": "string"
         },
         "date_before": {
-          "description": "Only results published before this date (YYYY-MM-DD).",
+          "description": "Published before YYYY-MM-DD.",
           "type": "string"
         },
         "domain_filter": {
-          "description": "Perplexity native Search API domain filter.",
+          "description": "Perplexity domain filter.",
           "items": {
             "type": "string"
           },
           "type": "array"
         },
         "freshness": {
-          "description": "Filter by time: day, week, month, or year.",
+          "description": "Time filter: day/week/month/year.",
           "type": "string"
         },
         "language": {
-          "description": "ISO 639-1 language code for results.",
+          "description": "ISO 639-1 language.",
           "type": "string"
         },
         "max_tokens": {
-          "description": "Perplexity native Search API total content budget.",
+          "description": "Perplexity total token budget.",
           "maximum": 1000000,
           "minimum": 1,
           "type": "number"
         },
         "max_tokens_per_page": {
-          "description": "Perplexity native Search API max tokens extracted per page.",
+          "description": "Perplexity tokens per page.",
           "minimum": 1,
           "type": "number"
         },
         "query": {
-          "description": "Search query string.",
+          "description": "Search query.",
           "type": "string"
         },
         "search_lang": {
-          "description": "Brave search result language code.",
+          "description": "Brave result language.",
           "type": "string"
         },
         "ui_lang": {
-          "description": "Brave UI locale code in language-region format.",
+          "description": "Brave UI locale.",
           "type": "string"
         }
       },
@@ -1178,22 +1178,22 @@
   },
   {
     "deferLoading": true,
-    "description": "Fetch and extract readable content from a URL (HTML → markdown/text). Use for lightweight page access without browser automation.",
+    "description": "Fetch URL and extract readable markdown/text. Lightweight page access; no browser automation.",
     "inputSchema": {
       "properties": {
         "extractMode": {
           "default": "markdown",
-          "description": "Extraction mode (\"markdown\" or \"text\").",
+          "description": "Extract as markdown/text.",
           "enum": ["markdown", "text"],
           "type": "string"
         },
         "maxChars": {
-          "description": "Maximum characters to return (truncates when exceeded).",
+          "description": "Max chars returned; truncates.",
           "minimum": 100,
           "type": "number"
         },
         "url": {
-          "description": "HTTP or HTTPS URL to fetch.",
+          "description": "HTTP(S) URL.",
           "type": "string"
         }
       },

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -344,7 +344,7 @@
                   "type": "number"
                 },
                 "expr": {
-                  "description": "Cron expr in tz local time; no UTC conversion. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
+                  "description": "Cron expr in tz wall-clock time; do not convert to UTC. Omitted tz => Gateway host local timezone. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
                   "type": "string"
                 },
                 "kind": {
@@ -357,7 +357,7 @@
                   "type": "number"
                 },
                 "tz": {
-                  "description": "IANA tz for cron fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local tz.",
+                  "description": "IANA timezone for cron wall-clock fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local timezone.",
                   "type": "string"
                 }
               },
@@ -562,7 +562,7 @@
                   "type": "number"
                 },
                 "expr": {
-                  "description": "Cron expr in tz local time; no UTC conversion. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
+                  "description": "Cron expr in tz wall-clock time; do not convert to UTC. Omitted tz => Gateway host local timezone. Example 6pm Shanghai daily: expr \"0 18 * * *\", tz \"Asia/Shanghai\".",
                   "type": "string"
                 },
                 "kind": {
@@ -575,7 +575,7 @@
                   "type": "number"
                 },
                 "tz": {
-                  "description": "IANA tz for cron fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local tz.",
+                  "description": "IANA timezone for cron wall-clock fields, e.g. \"Asia/Shanghai\"; omitted => Gateway host local timezone.",
                   "type": "string"
                 }
               },

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -217,8 +217,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 140
   },
   "dynamicToolsJson": {
-    "chars": 44351,
-    "roughTokens": 11088
+    "chars": 40291,
+    "roughTokens": 10073
   },
   "openClawDeveloperInstructions": {
     "chars": 5436,
@@ -229,8 +229,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 7129
   },
   "totalWithDynamicToolsJson": {
-    "chars": 72869,
-    "roughTokens": 18218
+    "chars": 68809,
+    "roughTokens": 17203
   },
   "userInputText": {
     "chars": 870,
@@ -591,7 +591,7 @@ Full JSON: `codex-dynamic-tools.discord-group.json`
 ```json
 [
   {
-    "description": "Send, delete, and manage messages via channel plugins. Supports actions: send.",
+    "description": "Send/delete/manage channel messages. Supports actions: send.",
     "inputSchema": {
       "properties": {
         "accountId": {
@@ -602,14 +602,14 @@ Full JSON: `codex-dynamic-tools.discord-group.json`
           "type": "string"
         },
         "asDocument": {
-          "description": "Send image/GIF/video as document to avoid channel compression. Alias for forceDocument.",
+          "description": "Alias for forceDocument.",
           "type": "boolean"
         },
         "asVoice": {
           "type": "boolean"
         },
         "attachments": {
-          "description": "Structured media attachments to send with the message. Each item needs media/mediaUrl/path/filePath/fileUrl/url.",
+          "description": "Structured attachments; each needs media/mediaUrl/path/filePath/fileUrl/url.",
           "items": {
             "properties": {
               "filePath": {
@@ -649,7 +649,7 @@ Full JSON: `codex-dynamic-tools.discord-group.json`
           "type": "boolean"
         },
         "buffer": {
-          "description": "Base64 payload for attachments (optionally a data: URL).",
+          "description": "Base64 attachment payload; data URL ok.",
           "type": "string"
         },
         "caption": {
@@ -665,11 +665,11 @@ Full JSON: `codex-dynamic-tools.discord-group.json`
           "type": "boolean"
         },
         "effect": {
-          "description": "Alias for effectId (e.g., invisible-ink, balloons).",
+          "description": "Alias for effectId.",
           "type": "string"
         },
         "effectId": {
-          "description": "Message effect name/id for sendWithEffect (e.g., invisible ink).",
+          "description": "Effect id/name for sendWithEffect.",
           "type": "string"
         },
         "filename": {
@@ -679,7 +679,7 @@ Full JSON: `codex-dynamic-tools.discord-group.json`
           "type": "string"
         },
         "forceDocument": {
-          "description": "Send image/GIF/video as document to avoid channel compression.",
+          "description": "Send image/GIF/video as document; avoids compression.",
           "type": "boolean"
         },
         "gatewayToken": {
@@ -692,7 +692,7 @@ Full JSON: `codex-dynamic-tools.discord-group.json`
           "type": "boolean"
         },
         "media": {
-          "description": "Media URL or local path. data: URLs are not supported here, use buffer.",
+          "description": "Media URL/path. data: use buffer.",
           "type": "string"
         },
         "message": {
@@ -705,7 +705,7 @@ Full JSON: `codex-dynamic-tools.discord-group.json`
           "type": "string"
         },
         "quoteText": {
-          "description": "Quote text for Telegram reply_parameters",
+          "description": "Telegram reply quote text.",
           "type": "string"
         },
         "replyTo": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -217,8 +217,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 140
   },
   "dynamicToolsJson": {
-    "chars": 40291,
-    "roughTokens": 10073
+    "chars": 40441,
+    "roughTokens": 10111
   },
   "openClawDeveloperInstructions": {
     "chars": 5436,
@@ -229,8 +229,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 7129
   },
   "totalWithDynamicToolsJson": {
-    "chars": 68809,
-    "roughTokens": 17203
+    "chars": 68959,
+    "roughTokens": 17240
   },
   "userInputText": {
     "chars": 870,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -217,8 +217,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 140
   },
   "dynamicToolsJson": {
-    "chars": 44042,
-    "roughTokens": 11011
+    "chars": 40066,
+    "roughTokens": 10017
   },
   "openClawDeveloperInstructions": {
     "chars": 4412,
@@ -229,8 +229,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6748
   },
   "totalWithDynamicToolsJson": {
-    "chars": 71036,
-    "roughTokens": 17759
+    "chars": 67060,
+    "roughTokens": 16765
   },
   "userInputText": {
     "chars": 370,
@@ -568,7 +568,7 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
 ```json
 [
   {
-    "description": "Send, delete, and manage messages via channel plugins. Supports actions: send.",
+    "description": "Send/delete/manage channel messages. Supports actions: send.",
     "inputSchema": {
       "properties": {
         "accountId": {
@@ -579,14 +579,14 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
           "type": "string"
         },
         "asDocument": {
-          "description": "Send image/GIF/video as document to avoid channel compression. Alias for forceDocument.",
+          "description": "Alias for forceDocument.",
           "type": "boolean"
         },
         "asVoice": {
           "type": "boolean"
         },
         "attachments": {
-          "description": "Structured media attachments to send with the message. Each item needs media/mediaUrl/path/filePath/fileUrl/url.",
+          "description": "Structured attachments; each needs media/mediaUrl/path/filePath/fileUrl/url.",
           "items": {
             "properties": {
               "filePath": {
@@ -626,7 +626,7 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
           "type": "boolean"
         },
         "buffer": {
-          "description": "Base64 payload for attachments (optionally a data: URL).",
+          "description": "Base64 attachment payload; data URL ok.",
           "type": "string"
         },
         "caption": {
@@ -642,11 +642,11 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
           "type": "boolean"
         },
         "effect": {
-          "description": "Alias for effectId (e.g., invisible-ink, balloons).",
+          "description": "Alias for effectId.",
           "type": "string"
         },
         "effectId": {
-          "description": "Message effect name/id for sendWithEffect (e.g., invisible ink).",
+          "description": "Effect id/name for sendWithEffect.",
           "type": "string"
         },
         "filename": {
@@ -656,7 +656,7 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
           "type": "string"
         },
         "forceDocument": {
-          "description": "Send image/GIF/video as document to avoid channel compression.",
+          "description": "Send image/GIF/video as document; avoids compression.",
           "type": "boolean"
         },
         "gatewayToken": {
@@ -669,7 +669,7 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
           "type": "boolean"
         },
         "media": {
-          "description": "Media URL or local path. data: URLs are not supported here, use buffer.",
+          "description": "Media URL/path. data: use buffer.",
           "type": "string"
         },
         "message": {
@@ -682,7 +682,7 @@ Full JSON: `codex-dynamic-tools.telegram-direct.json`
           "type": "string"
         },
         "quoteText": {
-          "description": "Quote text for Telegram reply_parameters",
+          "description": "Telegram reply quote text.",
           "type": "string"
         },
         "replyTo": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -217,8 +217,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 140
   },
   "dynamicToolsJson": {
-    "chars": 40066,
-    "roughTokens": 10017
+    "chars": 40216,
+    "roughTokens": 10054
   },
   "openClawDeveloperInstructions": {
     "chars": 4412,
@@ -229,8 +229,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 6748
   },
   "totalWithDynamicToolsJson": {
-    "chars": 67060,
-    "roughTokens": 16765
+    "chars": 67210,
+    "roughTokens": 16803
   },
   "userInputText": {
     "chars": 370,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -218,8 +218,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 140
   },
   "dynamicToolsJson": {
-    "chars": 45220,
-    "roughTokens": 11305
+    "chars": 41161,
+    "roughTokens": 10291
   },
   "openClawDeveloperInstructions": {
     "chars": 4412,
@@ -230,8 +230,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 7155
   },
   "totalWithDynamicToolsJson": {
-    "chars": 73841,
-    "roughTokens": 18461
+    "chars": 69782,
+    "roughTokens": 17446
   },
   "userInputText": {
     "chars": 608,
@@ -585,7 +585,7 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
 ```json
 [
   {
-    "description": "Send, delete, and manage messages via channel plugins. Supports actions: send.",
+    "description": "Send/delete/manage channel messages. Supports actions: send.",
     "inputSchema": {
       "properties": {
         "accountId": {
@@ -596,14 +596,14 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
           "type": "string"
         },
         "asDocument": {
-          "description": "Send image/GIF/video as document to avoid channel compression. Alias for forceDocument.",
+          "description": "Alias for forceDocument.",
           "type": "boolean"
         },
         "asVoice": {
           "type": "boolean"
         },
         "attachments": {
-          "description": "Structured media attachments to send with the message. Each item needs media/mediaUrl/path/filePath/fileUrl/url.",
+          "description": "Structured attachments; each needs media/mediaUrl/path/filePath/fileUrl/url.",
           "items": {
             "properties": {
               "filePath": {
@@ -643,7 +643,7 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
           "type": "boolean"
         },
         "buffer": {
-          "description": "Base64 payload for attachments (optionally a data: URL).",
+          "description": "Base64 attachment payload; data URL ok.",
           "type": "string"
         },
         "caption": {
@@ -659,11 +659,11 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
           "type": "boolean"
         },
         "effect": {
-          "description": "Alias for effectId (e.g., invisible-ink, balloons).",
+          "description": "Alias for effectId.",
           "type": "string"
         },
         "effectId": {
-          "description": "Message effect name/id for sendWithEffect (e.g., invisible ink).",
+          "description": "Effect id/name for sendWithEffect.",
           "type": "string"
         },
         "filename": {
@@ -673,7 +673,7 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
           "type": "string"
         },
         "forceDocument": {
-          "description": "Send image/GIF/video as document to avoid channel compression.",
+          "description": "Send image/GIF/video as document; avoids compression.",
           "type": "boolean"
         },
         "gatewayToken": {
@@ -686,7 +686,7 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
           "type": "boolean"
         },
         "media": {
-          "description": "Media URL or local path. data: URLs are not supported here, use buffer.",
+          "description": "Media URL/path. data: use buffer.",
           "type": "string"
         },
         "message": {
@@ -699,7 +699,7 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
           "type": "string"
         },
         "quoteText": {
-          "description": "Quote text for Telegram reply_parameters",
+          "description": "Telegram reply quote text.",
           "type": "string"
         },
         "replyTo": {
@@ -733,7 +733,7 @@ Full JSON: `codex-dynamic-tools.heartbeat-turn.json`
   },
   {
     "deferLoading": true,
-    "description": "Record the result of a heartbeat run. Use notify=false when nothing should be sent visibly. Use notify=true with notificationText when the user should receive a concise heartbeat alert.",
+    "description": "Record heartbeat result. `notify=false` no visible send. `notify=true` needs concise notificationText.",
     "inputSchema": {
       "additionalProperties": false,
       "properties": {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -218,8 +218,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 140
   },
   "dynamicToolsJson": {
-    "chars": 41161,
-    "roughTokens": 10291
+    "chars": 41311,
+    "roughTokens": 10328
   },
   "openClawDeveloperInstructions": {
     "chars": 4412,
@@ -230,8 +230,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 7155
   },
   "totalWithDynamicToolsJson": {
-    "chars": 69782,
-    "roughTokens": 17446
+    "chars": 69932,
+    "roughTokens": 17483
   },
   "userInputText": {
     "chars": 608,


### PR DESCRIPTION
## Summary
- Shorten built-in agent tool descriptions, display summaries, and hot schema hints across media, messaging, sessions, cron, Gateway, web, image/PDF, TTS, nodes, and plan tools.
- Strengthen music routing so song/music creation requests use `music_generate`, while lyrics-only requests stay text-only.
- Preserve routing-critical constraints for message-tool visible replies, cron timezone and delivery rules, async media completion handoff, native image attachment guards, TTS intent, ACP spawn selection, and Gateway continuation handling.
- Regenerate Codex prompt snapshots for the updated dynamic tool catalog.

## Verification
Behavior addressed: Tool descriptions and schema hints are shorter and less formal while preserving routing/safety instructions, including song/music requests choosing `music_generate`.
Real environment tested: Local macOS checkout, Node/Vitest via repo runners.
Exact steps or command run after this patch:
- `pnpm exec oxfmt --write --threads=1 ...`
- `pnpm build`
- `node scripts/run-vitest.mjs src/agents/tools/message-tool.test.ts src/agents/tools/image-generate-tool.test.ts src/agents/tools/video-generate-tool.test.ts src/agents/tools/music-generate-tool.test.ts src/agents/tools/image-tool.test.ts src/agents/tools/cron-tool.test.ts src/agents/tools/sessions.test.ts src/agents/tools-effective-inventory.test.ts src/auto-reply/status.tools.test.ts`
- `node scripts/run-vitest.mjs src/agents/bash-tools.test.ts src/agents/tools/tts-tool.test.ts src/agents/openclaw-tools.tts-config.test.ts src/agents/tools/gateway-tool.test.ts src/agents/tools/subagents-tool.test.ts src/agents/tools/pdf-tool.test.ts src/agents/tools/sessions-spawn-tool.test.ts src/gateway/server-methods/tools-catalog.test.ts`
- `node scripts/run-vitest.mjs src/agents/tools/cron-tool.test.ts src/agents/tools/sessions-spawn-tool.test.ts src/agents/openclaw-tools.update-plan.test.ts`
- `node scripts/run-vitest.mjs src/agents/tools/cron-tool.test.ts src/agents/tools/message-tool.test.ts src/agents/tools/sessions-spawn-tool.test.ts src/agents/openclaw-tools.update-plan.test.ts`
- `node scripts/run-vitest.mjs src/agents/tools/cron-tool.test.ts src/agents/tools/image-tool.test.ts src/agents/tools/message-tool.test.ts src/agents/tools/pdf-tool.test.ts src/agents/tools/sessions-spawn-tool.test.ts src/agents/tools/subagents-tool.test.ts src/agents/openclaw-tools.update-plan.test.ts`
- `pnpm prompt:snapshots:check`
- `git diff --check`
- `codex-review` helper until clean
Evidence after fix: Focused tool suites passed, prompt snapshots current (7 files), build passed, and final codex-review reported no accepted/actionable findings.
Observed result after fix: Built-in tool catalog text is shorter, prompt snapshots are updated, and music/song prompts route more clearly to audio generation instead of lyric-only replies.
What was not tested: Full test suite, live provider/media generation, live channel delivery.
