### PR TITLE
fix(update): preserve package service state during cutover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/update: preserve managed Gateway service environment during package cutovers so macOS LaunchAgent repair/restart reads the pre-update service state instead of caller shell state. (#83026)
 - Gateway/restart: eager-load the lifecycle runtime before in-place upgrade signal handling so package replacement does not deadlock restart imports. (#84890) Thanks @myps6415.
 - CLI/update: start managed Gateway update handoff helpers from a stable existing directory and tolerate deleted cwd/package roots during macOS LaunchAgent handoff. Fixes #83808. (#83875) Thanks @jason-allen-oneal.
 - Cron: honor `cron.retry.retryOn: ["network"]` for common network error codes such as `EAI_AGAIN`, `EHOSTUNREACH`, and `ENETUNREACH`.

--- a/src/cli/update-cli/update-command.test.ts
+++ b/src/cli/update-cli/update-command.test.ts
@@ -14,6 +14,7 @@ import {
   recoverInstalledLaunchAgentAfterUpdate,
   recoverLaunchAgentAndRecheckGatewayHealth,
   resolvePostCoreUpdateChildStdio,
+  resolvePostUpdateServiceStateReadEnv,
   resolvePostInstallDoctorEnv,
   shouldPrepareUpdatedInstallRestart,
   resolveUpdatedGatewayRestartPort,
@@ -114,6 +115,40 @@ describe("resolveUpdatedGatewayRestartPort", () => {
         serviceEnv: {},
       }),
     ).toBe(19000);
+  });
+});
+
+describe("resolvePostUpdateServiceStateReadEnv", () => {
+  it("keeps package restart preparation anchored to the pre-update service env", () => {
+    const processEnv = {
+      OPENCLAW_STATE_DIR: "/source/state",
+      OPENCLAW_CONFIG_PATH: "/source/openclaw.json",
+    } as NodeJS.ProcessEnv;
+    const prePackageServiceEnv = {
+      OPENCLAW_STATE_DIR: "/managed/state",
+      OPENCLAW_CONFIG_PATH: "/managed/openclaw.json",
+    } as NodeJS.ProcessEnv;
+
+    expect(
+      resolvePostUpdateServiceStateReadEnv({
+        updateMode: "npm",
+        processEnv,
+        prePackageServiceEnv,
+      }),
+    ).toBe(prePackageServiceEnv);
+  });
+
+  it("keeps git updates tied to the caller environment", () => {
+    const processEnv = { OPENCLAW_STATE_DIR: "/source/state" } as NodeJS.ProcessEnv;
+    const prePackageServiceEnv = { OPENCLAW_STATE_DIR: "/managed/state" } as NodeJS.ProcessEnv;
+
+    expect(
+      resolvePostUpdateServiceStateReadEnv({
+        updateMode: "git",
+        processEnv,
+        prePackageServiceEnv,
+      }),
+    ).toBe(processEnv);
   });
 });
 

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -1086,6 +1086,17 @@ export function resolveUpdatedGatewayRestartPort(params: {
   return resolveGatewayPort(params.config, params.serviceEnv ?? params.processEnv ?? process.env);
 }
 
+export function resolvePostUpdateServiceStateReadEnv(params: {
+  updateMode: UpdateRunResult["mode"];
+  processEnv?: NodeJS.ProcessEnv;
+  prePackageServiceEnv?: NodeJS.ProcessEnv;
+}): NodeJS.ProcessEnv {
+  if (isPackageManagerUpdateMode(params.updateMode) && params.prePackageServiceEnv) {
+    return params.prePackageServiceEnv;
+  }
+  return params.processEnv ?? process.env;
+}
+
 type UpdateDryRunPreview = {
   dryRun: true;
   root: string;
@@ -3502,7 +3513,11 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
   if (shouldRestart) {
     try {
       const serviceState = await readGatewayServiceState(resolveGatewayService(), {
-        env: process.env,
+        env: resolvePostUpdateServiceStateReadEnv({
+          updateMode: resultWithPostUpdate.mode,
+          processEnv: process.env,
+          prePackageServiceEnv: prePackageServiceStop?.serviceEnv,
+        }),
       });
       if (
         shouldPrepareUpdatedInstallRestart({

--- a/src/daemon/launchd-plist.ts
+++ b/src/daemon/launchd-plist.ts
@@ -27,6 +27,12 @@ const plistUnescape = (value: string): string =>
     .replaceAll("&lt;", "<")
     .replaceAll("&amp;", "&");
 
+type ReadLaunchAgentProgramArgumentsOptions = {
+  expectedEnvironmentWrapperPath?: string;
+  expectedEnvironmentFilePath?: string;
+  generatedEnvironmentLabel?: string;
+};
+
 function parseGeneratedEnvValue(value: string): string {
   const trimmed = value.trim();
   if (!trimmed.startsWith("'") || !trimmed.endsWith("'")) {
@@ -35,17 +41,93 @@ function parseGeneratedEnvValue(value: string): string {
   return trimmed.slice(1, -1).replaceAll("'\\''", "'");
 }
 
+function includesGeneratedEnvironmentPathToken(value: string | undefined, token: string): boolean {
+  return Boolean(value?.replaceAll("\\", "/").includes(token));
+}
+
+function includesGeneratedEnvironmentDirToken(value: string | undefined): boolean {
+  return Boolean(value?.replaceAll("\\", "/").includes("/service-env/"));
+}
+
+function resolveSiblingGeneratedEnvFilePath(
+  envFilePath: string,
+  options?: ReadLaunchAgentProgramArgumentsOptions,
+): string | undefined {
+  const label = options?.generatedEnvironmentLabel?.trim();
+  if (!label) {
+    return undefined;
+  }
+  const serviceEnvMarker = "/service-env/";
+  const markerIndex = envFilePath.replaceAll("\\", "/").lastIndexOf(serviceEnvMarker);
+  if (markerIndex < 0) {
+    return undefined;
+  }
+  // Custom state dirs can also contain service-env; use the generated env dir closest to the file.
+  const serviceEnvDirEnd = markerIndex + serviceEnvMarker.length - 1;
+  return `${envFilePath.slice(0, serviceEnvDirEnd)}/${label}.env`;
+}
+
+function isGeneratedEnvWrapperArgs(
+  programArguments: string[],
+  options?: ReadLaunchAgentProgramArgumentsOptions,
+): boolean {
+  const wrapperPath = programArguments[0];
+  const envFilePath = programArguments[1];
+  if (!wrapperPath || !envFilePath) {
+    return false;
+  }
+  if (!options) {
+    return wrapperPath.endsWith("-env-wrapper.sh");
+  }
+  if (
+    options.expectedEnvironmentWrapperPath &&
+    options.expectedEnvironmentFilePath &&
+    wrapperPath === options.expectedEnvironmentWrapperPath &&
+    envFilePath === options.expectedEnvironmentFilePath
+  ) {
+    return true;
+  }
+  const label = options.generatedEnvironmentLabel?.trim();
+  if (!label) {
+    return false;
+  }
+  // Legacy/corrupted plists may preserve the label-derived wrapper name inside
+  // a mangled service-env path. Still unwrap it so the next rewrite can repair.
+  return (
+    includesGeneratedEnvironmentDirToken(wrapperPath) &&
+    includesGeneratedEnvironmentDirToken(envFilePath) &&
+    includesGeneratedEnvironmentPathToken(wrapperPath, `${label}-env-wrapper.sh`) &&
+    includesGeneratedEnvironmentPathToken(envFilePath, `${label}.env`)
+  );
+}
+
 async function readLaunchAgentEnvironmentFile(
   programArguments: string[],
+  options?: ReadLaunchAgentProgramArgumentsOptions,
 ): Promise<Record<string, string>> {
   const envFilePath = programArguments[1];
-  if (!programArguments[0]?.endsWith("-env-wrapper.sh") || !envFilePath) {
+  if (!isGeneratedEnvWrapperArgs(programArguments, options) || !envFilePath) {
     return {};
   }
   let content = "";
-  try {
-    content = await fs.readFile(envFilePath, "utf8");
-  } catch {
+  const candidateEnvFilePaths = Array.from(
+    new Set(
+      [
+        envFilePath,
+        resolveSiblingGeneratedEnvFilePath(envFilePath, options),
+        options?.expectedEnvironmentFilePath,
+      ].filter((candidate): candidate is string => Boolean(candidate)),
+    ),
+  );
+  for (const candidate of candidateEnvFilePaths) {
+    try {
+      content = await fs.readFile(candidate, "utf8");
+      break;
+    } catch {
+      // Keep trying; mangled wrapper args may still have the canonical env file.
+    }
+  }
+  if (!content) {
     return {};
   }
   const environment: Record<string, string> = {};
@@ -68,8 +150,11 @@ async function readLaunchAgentEnvironmentFile(
   return environment;
 }
 
-function unwrapGeneratedEnvWrapperArgs(programArguments: string[]): string[] {
-  if (!programArguments[0]?.endsWith("-env-wrapper.sh") || !programArguments[1]) {
+function unwrapGeneratedEnvWrapperArgs(
+  programArguments: string[],
+  options?: ReadLaunchAgentProgramArgumentsOptions,
+): string[] {
+  if (!isGeneratedEnvWrapperArgs(programArguments, options)) {
     return programArguments;
   }
   return programArguments.slice(2);
@@ -95,6 +180,26 @@ const renderEnvDict = (env: Record<string, string | undefined> | undefined): str
 };
 
 export async function readLaunchAgentProgramArgumentsFromFile(plistPath: string): Promise<{
+  programArguments: string[];
+  workingDirectory?: string;
+  environment?: Record<string, string>;
+  environmentValueSources?: Record<string, GatewayServiceEnvironmentValueSource>;
+  sourcePath?: string;
+} | null>;
+export async function readLaunchAgentProgramArgumentsFromFile(
+  plistPath: string,
+  options: ReadLaunchAgentProgramArgumentsOptions,
+): Promise<{
+  programArguments: string[];
+  workingDirectory?: string;
+  environment?: Record<string, string>;
+  environmentValueSources?: Record<string, GatewayServiceEnvironmentValueSource>;
+  sourcePath?: string;
+} | null>;
+export async function readLaunchAgentProgramArgumentsFromFile(
+  plistPath: string,
+  options?: ReadLaunchAgentProgramArgumentsOptions,
+): Promise<{
   programArguments: string[];
   workingDirectory?: string;
   environment?: Record<string, string>;
@@ -128,8 +233,8 @@ export async function readLaunchAgentProgramArgumentsFromFile(plistPath: string)
         inlineEnvironment[key] = value;
       }
     }
-    const fileEnvironment = await readLaunchAgentEnvironmentFile(args);
-    const effectiveProgramArguments = unwrapGeneratedEnvWrapperArgs(args);
+    const fileEnvironment = await readLaunchAgentEnvironmentFile(args, options);
+    const effectiveProgramArguments = unwrapGeneratedEnvWrapperArgs(args, options);
     const environment = { ...inlineEnvironment, ...fileEnvironment };
     const environmentValueSources: Record<string, GatewayServiceEnvironmentValueSource> = {};
     for (const key of Object.keys(inlineEnvironment)) {

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -726,6 +726,63 @@ describe("launchd install", () => {
     expect(command?.environmentValueSources?.OPENAI_API_KEY).toBe("file");
   });
 
+  it("repairs a mangled label-derived service-env wrapper path on restart", async () => {
+    const callerEnv = createDefaultLaunchdEnv();
+    const serviceEnv = {
+      ...callerEnv,
+      OPENCLAW_STATE_DIR: "/Users/test/service-env/custom-state",
+    };
+    await installLaunchAgent({
+      env: serviceEnv,
+      stdout: new PassThrough(),
+      programArguments: defaultProgramArguments,
+      environment: {
+        OPENCLAW_GATEWAY_PORT: "18789",
+        OPENCLAW_STATE_DIR: serviceEnv.OPENCLAW_STATE_DIR,
+      },
+    });
+
+    const plistPath = resolveLaunchAgentPlistPath(callerEnv);
+    const envFilePath = "/Users/test/service-env/custom-state/service-env/ai.openclaw.gateway.env";
+    const wrapperPath =
+      "/Users/test/service-env/custom-state/service-env/ai.openclaw.gateway-env-wrapper.sh";
+    const callerEnvFilePath = "/Users/test/.openclaw/service-env/ai.openclaw.gateway.env";
+    const callerWrapperPath =
+      "/Users/test/.openclaw/service-env/ai.openclaw.gateway-env-wrapper.sh";
+    const mangledEnvFilePath =
+      "/Users/test/service-env/custom-state/service-env/[ai.openclaw.gateway.env](http:/ai.openclaw.gateway.env)";
+    const mangledWrapperPath =
+      "/Users/test/service-env/custom-state/service-env/[ai.openclaw.gateway-env-wrapper.sh](http:/ai.openclaw.gateway-env-wrapper.sh)";
+    state.files.set(
+      plistPath,
+      (state.files.get(plistPath) ?? "")
+        .replace(wrapperPath, mangledWrapperPath)
+        .replace(envFilePath, mangledEnvFilePath),
+    );
+
+    const command = await readLaunchAgentProgramArguments(callerEnv);
+    expect(command?.programArguments).toEqual(defaultProgramArguments);
+    expect(command?.environment?.OPENCLAW_GATEWAY_PORT).toBe("18789");
+    expect(command?.environment?.OPENCLAW_STATE_DIR).toBe(serviceEnv.OPENCLAW_STATE_DIR);
+    expect(command?.environmentValueSources?.OPENCLAW_GATEWAY_PORT).toBe("file");
+
+    await restartLaunchAgent({
+      env: callerEnv,
+      stdout: new PassThrough(),
+    });
+
+    const rewritten = state.files.get(plistPath) ?? "";
+    expect(rewritten).toContain(`<string>${callerWrapperPath}</string>`);
+    expect(rewritten).toContain(`<string>${callerEnvFilePath}</string>`);
+    expect(rewritten).not.toContain(mangledEnvFilePath);
+    expect(rewritten).not.toContain(mangledWrapperPath);
+    const rewrittenEnv = state.files.get(callerEnvFilePath) ?? "";
+    expect(rewrittenEnv).toContain("export OPENCLAW_GATEWAY_PORT='18789'");
+    expect(rewrittenEnv).toContain(
+      "export OPENCLAW_STATE_DIR='/Users/test/service-env/custom-state'",
+    );
+  });
+
   it("creates the LaunchAgent TMPDIR before bootstrap", async () => {
     const env = createDefaultLaunchdEnv();
     const tmpDir = "/Users/test/.openclaw/tmp";

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -232,11 +232,23 @@ export function resolveLaunchAgentPlistPath(env: GatewayServiceEnv): string {
   return resolveLaunchAgentPlistPathForLabel(env, label);
 }
 
+function resolveLaunchAgentEnvironmentReadOptions(env: GatewayServiceEnv, label: string) {
+  return {
+    expectedEnvironmentWrapperPath: resolveLaunchAgentEnvWrapperPath(env, label),
+    expectedEnvironmentFilePath: resolveLaunchAgentEnvFilePath(env, label),
+    generatedEnvironmentLabel: label,
+  };
+}
+
 export async function readLaunchAgentProgramArguments(
   env: GatewayServiceEnv,
 ): Promise<GatewayServiceCommandConfig | null> {
+  const label = resolveLaunchAgentLabel({ env });
   const plistPath = resolveLaunchAgentPlistPath(env);
-  return readLaunchAgentProgramArgumentsFromFile(plistPath);
+  return readLaunchAgentProgramArgumentsFromFile(
+    plistPath,
+    resolveLaunchAgentEnvironmentReadOptions(env, label),
+  );
 }
 
 function buildLaunchAgentPlist({
@@ -926,7 +938,10 @@ async function rewriteLaunchAgentPlistForRestart({
   label: string;
   plistPath: string;
 }): Promise<boolean> {
-  const existing = await readLaunchAgentProgramArgumentsFromFile(plistPath);
+  const existing = await readLaunchAgentProgramArgumentsFromFile(
+    plistPath,
+    resolveLaunchAgentEnvironmentReadOptions(env, label),
+  );
   if (!existing?.programArguments.length) {
     return false;
   }


### PR DESCRIPTION
## Summary

- Problem: dev/source -> stable package cutovers could repair or restart the gateway service using caller/source state instead of the pre-update managed service state.
- Why it matters: a mangled LaunchAgent service-env wrapper could be unwrapped but lose its persisted env, and package-update restart preparation could probe the wrong service/config paths.
- What changed: LaunchAgent plist reads now recognize label-derived generated wrapper/env args, recover the sibling canonical env file next to mangled service-env args, and package update restart prep reads state from the pre-update package service env.
- What did NOT change: no plugin trust boundary, capability semantics, public SDK surface, external plugin compatibility, or service permission model changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #76865
- Related #78462
- Related #75797
- Related #82671
- Related #82622
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: package-update and LaunchAgent restart repair preserve the installed service environment across source/dev -> stable cutover, including markdown-mangled service-env wrapper args and custom state dirs.
- Real environment tested: local macOS source worktree with mocked launchd contract tests; Blacksmith Testbox Linux changed gate for type/lint/import-cycle/core checks.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/daemon/launchd.test.ts src/cli/update-cli/update-command.test.ts`; `node scripts/run-vitest.mjs src/cli/update-cli/update-command.test.ts src/cli/update-cli/post-core-plugin-convergence.test.ts src/cli/update-cli/plugin-payload-validation.test.ts src/daemon/launchd.test.ts src/plugins/effective-plugin-ids.test.ts src/plugins/update.test.ts`; `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --blacksmith-org openclaw --blacksmith-workflow .github/workflows/ci-check-testbox.yml --blacksmith-job check --blacksmith-ref main --idle-timeout 90m --ttl 240m --timing-json -- CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_TEST_PROJECTS_PARALLEL=6 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm check:changed`; `.agents/skills/codex-review/scripts/codex-review --mode auto`.
- Evidence after fix: targeted tests passed 100/100; wider cutover/plugin regression pack passed 208/208; Blacksmith Testbox `tbx_01krtknvceppq0249p5ztn0dsz` / Actions run https://github.com/openclaw/openclaw/actions/runs/25986906644 passed `pnpm check:changed` with exit 0; Codex review completed clean with no accepted/actionable findings.
- Observed result after fix: mangled LaunchAgent wrapper args are unwrapped for repair while file-backed env is preserved, including `OPENCLAW_STATE_DIR`; package-manager update restart state reads use the pre-update service env instead of the source caller env.
- What was not tested: a live macOS package cutover against launchd, WSL2/Windows service managers, and Docker update E2E were not rerun for this narrow patch; the code path is covered by contract tests and the remote changed gate.
- Before evidence (optional but encouraged): #76865 describes the source/dev -> stable cutover incident; the prior packaged runtime-root slice landed in #82671.

## Root Cause (if applicable)

- Root cause: generated LaunchAgent service-env wrapper detection only handled exact wrapper suffix/current canonical paths, and post-update package restart prep read service state from `process.env` even when the package service env had already been captured before update.
- Missing detection / guardrail: no regression covered markdown-mangled service-env wrapper args beside a custom service state dir, and no unit covered package restart state env selection.
- Contributing context (if known): #82671 fixed the bundled/package runtime-root side; this PR covers the remaining service-wrapper/update-state side of #76865.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/daemon/launchd.test.ts`, `src/cli/update-cli/update-command.test.ts`.
- Scenario the test should lock in: markdown-mangled label-derived LaunchAgent wrapper/env args repair without dropping custom service env; package updates read post-update service state from pre-update package service env.
- Why this is the smallest reliable guardrail: it tests the LaunchAgent plist/repair and update restart selection seams directly without changing public service behavior.
- Existing test that already covers this (if any): N/A.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Package-manager updates and `openclaw gateway restart` repair should preserve managed gateway service env more reliably during cutovers. No new config keys or command flags.

## Diagram (if applicable)

```text
Before:
[mangled LaunchAgent plist] -> [unwrap wrapper] -> [env file miss] -> [rewrite loses service env]

After:
[mangled LaunchAgent plist] -> [recover sibling env file] -> [rewrite canonical args with preserved env]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local worktree for contract tests; Linux Blacksmith Testbox for changed gate
- Runtime/container: Node 22 via repo wrappers; Blacksmith Testbox `tbx_01krtknvceppq0249p5ztn0dsz`
- Model/provider: N/A
- Integration/channel (if any): Gateway LaunchAgent/update command
- Relevant config (redacted): synthetic test env with `OPENCLAW_STATE_DIR=/Users/test/custom-state`

### Steps

1. Install a synthetic LaunchAgent with file-backed service env.
2. Mutate its wrapper/env plist args into markdown-mangled service-env paths.
3. Read/restart through the normal caller env and verify canonical rewrite keeps file env.
4. Run targeted update/launchd tests, wider cutover/plugin pack, Codex review, and Testbox `check:changed`.

### Expected

- LaunchAgent repair keeps program args and service env.
- Package update restart state reads from the managed service env.
- Changed checks pass.

### Actual

- All listed tests/checks passed.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted launchd/update tests, wider cutover/plugin regression pack, Codex review, remote Testbox changed gate.
- Edge cases checked: markdown-mangled wrapper + env arg, custom service state dir, package vs git update env selection.
- What you did **not** verify: live launchd package cutover, WSL2/Windows service manager behavior, Docker update E2E.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: LaunchAgent repair now accepts a narrow class of corrupted wrapper/env paths for repair.
  - Mitigation: acceptance is limited to generated service-env paths containing the expected LaunchAgent label-derived wrapper/env filenames; no trust, capability, or execution boundary changes.
