### PR TITLE
fix: surface reply media failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 
 - QA-Lab: wake qa-bus long polls that arrive with stale future cursors after a bus restart, preserving reconnect readiness for harness clients. (#67142) Thanks @hxy91819.
 - QA-Lab: stage Multipass transfer scripts under OpenClaw's preferred temp root instead of raw OS temp paths, keeping the VM runner inside temp-path guardrails. (#64098) Thanks @ImLukeF.
+- Agents/replies: keep surviving reply media and append a warning when other media references fail, so partial media normalization no longer drops failures silently. Thanks @Jerry-Xin.
 - Config/models: accept `thinkingFormat: "together"` in model compat config so Together routes can opt into the Together-specific thinking response shape.
 - Plugins/tokenjuice: bump the bundled tokenjuice runtime to 0.7.1, bringing Codex hook approval compatibility, pre-tool command wrapping fixes, and Rolldown/Vitest output compaction improvements into the OpenClaw plugin.
 - Agents/OpenAI: stop post-processing GPT-5 final replies with hardcoded brevity caps, preserving full channel responses instead of appending synthetic ellipses, and log when strict-agentic GPT-5 execution activates. Fixes #82910.

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -60,6 +60,18 @@ export type ReplyPayloadTtsSupplement = {
   visibleTextAlreadyDelivered?: boolean;
 };
 
+export const REPLY_MEDIA_FAILURE_WARNING = "⚠️ Media failed.";
+
+export function appendReplyMediaFailureWarning(text: string | undefined): string {
+  if (!text?.trim()) {
+    return REPLY_MEDIA_FAILURE_WARNING;
+  }
+  if (text.includes(REPLY_MEDIA_FAILURE_WARNING)) {
+    return text;
+  }
+  return `${text}\n${REPLY_MEDIA_FAILURE_WARNING}`;
+}
+
 function normalizeTtsSupplementSpokenText(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value : undefined;
 }

--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -186,7 +186,7 @@ describe("buildReplyPayloads media filter integration", () => {
 
     expect(replyPayloads).toHaveLength(2);
     expectFields(replyPayloads[0], {
-      text: "keep text",
+      text: "keep text\n⚠️ Media failed.",
       mediaUrl: undefined,
       mediaUrls: undefined,
       audioAsVoice: false,
@@ -713,6 +713,26 @@ describe("buildReplyPayloads media filter integration", () => {
     });
 
     expect(replyPayloads).toHaveLength(0);
+  });
+
+  it("surfaces a warning when non-silent media payloads fail normalization", async () => {
+    const normalizeMediaPaths = async () => {
+      throw new Error("file not found");
+    };
+
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      payloads: [{ text: "MEDIA: ./missing.png" }],
+      normalizeMediaPaths,
+    });
+
+    expect(replyPayloads).toHaveLength(1);
+    expectFields(replyPayloads[0], {
+      text: "⚠️ Media failed.",
+      mediaUrl: undefined,
+      mediaUrls: undefined,
+      audioAsVoice: false,
+    });
   });
 
   it("extracts markdown image replies into final payload media urls", async () => {

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -7,6 +7,7 @@ import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { stripLegacyBracketToolCallBlocks } from "../../shared/text/assistant-visible-text.js";
 import { stripHeartbeatToken } from "../heartbeat.js";
 import {
+  appendReplyMediaFailureWarning,
   copyReplyPayloadMetadata,
   getReplyPayloadMetadata,
   setReplyPayloadMetadata,
@@ -35,6 +36,7 @@ function loadReplyPayloadsDedupeRuntime() {
 async function normalizeReplyPayloadMedia(params: {
   payload: ReplyPayload;
   normalizeMediaPaths?: (payload: ReplyPayload) => Promise<ReplyPayload>;
+  suppressMediaFailureWarning?: boolean;
 }): Promise<ReplyPayload> {
   if (!params.normalizeMediaPaths || !resolveSendableOutboundReplyParts(params.payload).hasMedia) {
     return params.payload;
@@ -47,6 +49,9 @@ async function normalizeReplyPayloadMedia(params: {
     logVerbose(`reply payload media normalization failed: ${String(err)}`);
     return copyReplyPayloadMetadata(params.payload, {
       ...params.payload,
+      text: params.suppressMediaFailureWarning
+        ? params.payload.text
+        : appendReplyMediaFailureWarning(params.payload.text),
       mediaUrl: undefined,
       mediaUrls: undefined,
       audioAsVoice: false,
@@ -223,8 +228,9 @@ export async function buildReplyPayloads(params: {
       const mediaNormalizedPayload = await normalizeReplyPayloadMedia({
         payload: parsed.payload,
         normalizeMediaPaths: params.normalizeMediaPaths,
+        suppressMediaFailureWarning: parsed.isSilent,
       });
-      if (parsed.isSilent && !resolveSendableOutboundReplyParts(mediaNormalizedPayload).hasMedia) {
+      if (parsed.isSilent) {
         mediaNormalizedPayload.text = undefined;
       }
       return mediaNormalizedPayload;

--- a/src/auto-reply/reply/reply-delivery.test.ts
+++ b/src/auto-reply/reply/reply-delivery.test.ts
@@ -318,6 +318,43 @@ describe("createBlockReplyDeliveryHandler", () => {
     });
   });
 
+  it("suppresses generated media-failure warning text for silent block replies", async () => {
+    const blockReplyPipeline = {
+      enqueue: vi.fn(),
+    } as unknown as BlockReplyPipelineLike;
+    const absPath = path.join("/tmp/home", "openclaw", "survived.png");
+
+    const handler = createBlockReplyDeliveryHandler({
+      onBlockReply: vi.fn(async () => {}),
+      normalizeStreamingText: (payload) => ({ text: payload.text, skip: false }),
+      applyReplyToMode: (payload) => payload,
+      normalizeMediaPaths: async (payload) => ({
+        ...payload,
+        text: "⚠️ Media failed.",
+        mediaUrl: absPath,
+        mediaUrls: [absPath],
+      }),
+      typingSignals: {
+        signalTextDelta: vi.fn(async () => {}),
+      } as unknown as TypingSignaler,
+      blockStreamingEnabled: true,
+      blockReplyPipeline,
+      directlySentBlockKeys: new Set(),
+    });
+
+    await handler({ text: "NO_REPLY\nMEDIA: ./missing.png\nMEDIA: ./survived.png" });
+
+    expect(blockReplyPipeline.enqueue).toHaveBeenCalledWith({
+      text: undefined,
+      mediaUrl: absPath,
+      mediaUrls: [absPath],
+      replyToId: undefined,
+      replyToCurrent: undefined,
+      replyToTag: false,
+      audioAsVoice: false,
+    });
+  });
+
   it("preserves reply payload metadata across block-reply normalization", async () => {
     const enqueue = vi.fn();
     const blockReplyPipeline = {

--- a/src/auto-reply/reply/reply-delivery.ts
+++ b/src/auto-reply/reply/reply-delivery.ts
@@ -125,6 +125,9 @@ export function createBlockReplyDeliveryHandler(params: {
     const mediaNormalizedPayload = params.normalizeMediaPaths
       ? await params.normalizeMediaPaths(normalized.payload)
       : normalized.payload;
+    if (normalized.isSilent) {
+      mediaNormalizedPayload.text = undefined;
+    }
     const blockPayload = copyReplyPayloadMetadata(
       payload,
       params.applyReplyToMode(mediaNormalizedPayload),

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -403,6 +403,23 @@ describe("createReplyMediaPathNormalizer", () => {
     expectNoMedia(result);
   });
 
+  it("keeps surviving media and appends a warning when some reply media is dropped", async () => {
+    resolveOutboundAttachmentFromUrl.mockRejectedValueOnce(new Error("file not found"));
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: {},
+      sessionKey: "session-key",
+      workspaceDir: "/tmp/agent-workspace",
+    });
+
+    const result = await normalize({
+      text: "Here is the surviving attachment",
+      mediaUrls: ["./out/missing.png", "https://example.com/ok.png"],
+    });
+
+    expect(result.text).toBe("Here is the surviving attachment\n⚠️ Media failed.");
+    expectMedia(result, "https://example.com/ok.png", ["https://example.com/ok.png"]);
+  });
+
   it("returns a warning-only text reply when media-only output is dropped upstream", async () => {
     resolveOutboundAttachmentFromUrl.mockRejectedValueOnce(new Error("file not found"));
     const normalize = createReplyMediaPathNormalizer({

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -15,6 +15,7 @@ import { isPassThroughRemoteMediaSource } from "../../media/media-source-url.js"
 import { resolveOutboundAttachmentFromUrl } from "../../media/outbound-attachment.js";
 import { resolveAgentScopedOutboundMediaAccess } from "../../media/read-capability.js";
 import { MEDIA_MAX_BYTES } from "../../media/store.js";
+import { appendReplyMediaFailureWarning } from "../reply-payload.js";
 import type { ReplyPayload } from "../types.js";
 
 const FILE_URL_RE = /^file:\/\//i;
@@ -50,10 +51,6 @@ function resolveReplyMediaMaxBytes(params: {
   return typeof limitMb === "number" && Number.isFinite(limitMb) && limitMb > 0
     ? Math.floor(limitMb * 1024 * 1024)
     : MEDIA_MAX_BYTES;
-}
-
-function formatBlockedReplyMediaWarning(): string {
-  return "⚠️ Media failed.";
 }
 
 export function createReplyMediaPathNormalizer(params: {
@@ -220,11 +217,15 @@ export function createReplyMediaPathNormalizer(params: {
       normalizedMedia.push(normalized);
     }
 
+    const text =
+      firstMediaDropError === undefined
+        ? payload.text
+        : appendReplyMediaFailureWarning(payload.text);
+
     if (normalizedMedia.length === 0) {
-      const warning = firstMediaDropError ? formatBlockedReplyMediaWarning() : undefined;
       return {
         ...payload,
-        text: warning ? (payload.text ? `${payload.text}\n${warning}` : warning) : payload.text,
+        text,
         mediaUrl: undefined,
         mediaUrls: undefined,
       };
@@ -232,6 +233,7 @@ export function createReplyMediaPathNormalizer(params: {
 
     return {
       ...payload,
+      text,
       mediaUrl: normalizedMedia[0],
       mediaUrls: normalizedMedia,
     };


### PR DESCRIPTION
Summary
- Keep surviving reply media when one media reference fails normalization, and append the existing generic media-failure warning to the visible reply text.
- Preserve silent NO_REPLY behavior by suppressing generated media-failure warning text while still allowing surviving silent media payloads through the block path.
- Add regression coverage for partial media drops, catastrophic final-payload media normalization failures, and silent block replies.
- Replaces the bugfix part of #69310 with a narrower patch; commit keeps Jerry-Xin as co-author.

Verification
- pnpm test src/auto-reply/reply/reply-media-paths.test.ts src/auto-reply/reply/agent-runner-payloads.test.ts src/auto-reply/reply/reply-delivery.test.ts
- pnpm check:test-types
- git diff --check
- pnpm check:changed via Blacksmith Testbox tbx_01krtkmeqk64qhhceq55dn719f
- codex-review --mode local: clean, no accepted/actionable findings

Behavior addressed
Failed reply media normalization no longer silently drops failed attachments from otherwise visible replies. Partial media failures keep surviving attachments and add a short warning; all failed non-silent media still produces a warning-only reply.

Real environment tested
Local source checkout plus Blacksmith Testbox changed gate against the pushed diff.

Exact steps or command run after this patch
pnpm test src/auto-reply/reply/reply-media-paths.test.ts src/auto-reply/reply/agent-runner-payloads.test.ts src/auto-reply/reply/reply-delivery.test.ts
pnpm check:test-types
git diff --check
pnpm check:changed
/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --mode local

Evidence after fix
Focused Vitest covered 3 files / 76 tests. Testbox tbx_01krtkmeqk64qhhceq55dn719f ran changed core lanes, typecheck, lint, import cycles, and guards with exit code 0. Codex review reported no accepted/actionable findings.

Observed result after fix
A failed media reference appends ⚠️ Media failed. without dropping surviving media, non-silent catastrophic media normalization yields the warning-only reply, and silent NO_REPLY media failures do not leak warning text.

What was not tested
Full release suite and live channel delivery were not run.
