### PR TITLE
[codex] Add presentation capability limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 - Agents/skills: tighten bundled skill prompts and metadata, quote skill descriptions, refresh current CLI/API guidance, and update embedded sherpa-onnx runtime downloads.
 - Skills: update the Obsidian skill to target the official `obsidian` CLI and require its registered binary instead of the third-party `obsidian-cli`.
 - Skills: add a Python debugging skill for pdb, breakpoint(), post-mortem inspection, and debugpy remote attach.
+- Plugins/messages: add presentation capability limits for channel renderers, adapt rich message controls before native rendering, and mark legacy `interactive`/Slack directive producer APIs as deprecated.
 - Proxy: support HTTPS managed forward-proxy endpoints and scoped `proxy.tls.caFile` CA trust for proxy endpoint TLS. (#79171) Thanks @jesse-merhi.
 - QA-Lab: add first-hour 20-turn and optional 100-turn runtime parity scenarios, with tier metadata for standard and soak QA gates. (#80323) Thanks @100yenadmin.
 - QA-Lab: add a live-only Codex Pi-shaped Read vocabulary canary so runtime parity catches native workspace-read prompt compatibility drift. (#80323) Thanks @100yenadmin.

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-df6c2799805dc3c57924dbb1632d11e7ed08ef4d7759f535998b170f1a10a638  plugin-sdk-api-baseline.json
-e3526669b79e5eaa3b92e03bece552402209d3cf5b35343c33b62299f71b2efc  plugin-sdk-api-baseline.jsonl
+c8edc84c93c2077d8f37fd9c3626cfa5ea65d0d65f78899427e8251dfe9eac2e  plugin-sdk-api-baseline.json
+d5e2e3ebc8fc54a311f1da43c326bd5b883bbb5d99c2fec117955c887fcc3bac  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-c8edc84c93c2077d8f37fd9c3626cfa5ea65d0d65f78899427e8251dfe9eac2e  plugin-sdk-api-baseline.json
-d5e2e3ebc8fc54a311f1da43c326bd5b883bbb5d99c2fec117955c887fcc3bac  plugin-sdk-api-baseline.jsonl
+d979b8c2721eeb83380a38853309e9ba0f2c28e040a9ad2ee1e7b2ab10c547db  plugin-sdk-api-baseline.json
+4815f711fe2481483159137cfb97ce3d1c173e0b50a364a2353f49888f4d53df  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-701ff598b929acfe779b728fe5660aac13e317526117baad80eef6bd1c5663c3  plugin-sdk-api-baseline.json
-4bb4bf89bb568ece9c8adbb0126f77cabc33698003190f272d23a2266d6bff84  plugin-sdk-api-baseline.jsonl
+ec9fa02c3af9c210f7dbf6157d2f18e5c7171c29e6ae13b4f539aefcb25d178a  plugin-sdk-api-baseline.json
+2ee394b924edb9843987710a65f9d45523efadd7e7940e01c88ea39dcdcdad7c  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-ec9fa02c3af9c210f7dbf6157d2f18e5c7171c29e6ae13b4f539aefcb25d178a  plugin-sdk-api-baseline.json
-2ee394b924edb9843987710a65f9d45523efadd7e7940e01c88ea39dcdcdad7c  plugin-sdk-api-baseline.jsonl
+df6c2799805dc3c57924dbb1632d11e7ed08ef4d7759f535998b170f1a10a638  plugin-sdk-api-baseline.json
+e3526669b79e5eaa3b92e03bece552402209d3cf5b35343c33b62299f71b2efc  plugin-sdk-api-baseline.jsonl

--- a/docs/channels/mattermost.md
+++ b/docs/channels/mattermost.md
@@ -319,6 +319,8 @@ Config:
 
 Send messages with clickable buttons. When a user clicks a button, the agent receives the selection and can respond.
 
+Normal agent replies can also include semantic `presentation` payloads. OpenClaw renders value buttons as Mattermost interactive buttons, keeps URL buttons visible in the message text, and downgrades select menus to readable text.
+
 Enable buttons by adding `inlineButtons` to the channel capabilities:
 
 ```json5

--- a/docs/channels/msteams.md
+++ b/docs/channels/msteams.md
@@ -867,9 +867,9 @@ OpenClaw sends Teams polls as Adaptive Cards (there is no native Teams poll API)
 
 ## Presentation cards
 
-Send semantic presentation payloads to Teams users or conversations using the `message` tool or CLI. OpenClaw renders them as Teams Adaptive Cards from the generic presentation contract.
+Send semantic presentation payloads to Teams users or conversations using the `message` tool, CLI, or normal reply delivery. OpenClaw renders them as Teams Adaptive Cards from the generic presentation contract.
 
-The `presentation` parameter accepts semantic blocks. When `presentation` is provided, the message text is optional.
+The `presentation` parameter accepts semantic blocks. When `presentation` is provided, the message text is optional. Buttons render as Adaptive Card submit or URL actions. Select menus are not native in the Teams renderer yet, so OpenClaw downgrades them to readable text before delivery.
 
 **Agent tool:**
 

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -1199,6 +1199,9 @@ Slash sessions use isolated keys like `agent:<agentId>:slack:slash:<userId>` and
 ## Interactive replies
 
 Slack can render agent-authored interactive reply controls, but this feature is disabled by default.
+For new agent, CLI, and plugin output, prefer the shared
+`presentation` buttons or select blocks. They use the same Slack interaction
+path while also degrading on other channels.
 
 Enable it globally:
 
@@ -1232,16 +1235,20 @@ Or enable it for one Slack account only:
 }
 ```
 
-When enabled, agents can emit Slack-only reply directives:
+When enabled, agents can still emit deprecated Slack-only reply directives:
 
 - `[[slack_buttons: Approve:approve, Reject:reject]]`
 - `[[slack_select: Choose a target | Canary:canary, Production:production]]`
 
-These directives compile into Slack Block Kit and route clicks or selections back through the existing Slack interaction event path.
+These directives compile into Slack Block Kit and route clicks or selections
+back through the existing Slack interaction event path. Keep them for old
+prompts and Slack-specific escape hatches; use shared presentation for new
+portable controls.
 
 Notes:
 
-- This is Slack-specific UI. Other channels do not translate Slack Block Kit directives into their own button systems.
+- This is Slack-specific legacy UI. Other channels do not translate Slack Block
+  Kit directives into their own button systems.
 - The interactive callback values are OpenClaw-generated opaque tokens, not raw agent-authored values.
 - If generated interactive blocks would exceed Slack Block Kit limits, OpenClaw falls back to the original text reply instead of sending an invalid blocks payload.
 

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -1245,6 +1245,16 @@ back through the existing Slack interaction event path. Keep them for old
 prompts and Slack-specific escape hatches; use shared presentation for new
 portable controls.
 
+The directive compiler APIs are also deprecated for new producer code:
+
+- `compileSlackInteractiveReplies(...)`
+- `parseSlackOptionsLine(...)`
+- `isSlackInteractiveRepliesEnabled(...)`
+- `buildSlackInteractiveBlocks(...)`
+
+Use `presentation` payloads and `buildSlackPresentationBlocks(...)` for new
+Slack-rendered controls.
+
 Notes:
 
 - This is Slack-specific legacy UI. Other channels do not translate Slack Block

--- a/docs/cli/message.md
+++ b/docs/cli/message.md
@@ -288,11 +288,12 @@ Send a Telegram Mini App button through generic presentation:
 
 ```
 openclaw message send --channel telegram --target 123456789 --message "Open app:" \
-  --presentation '{"blocks":[{"type":"buttons","buttons":[{"label":"Launch","web_app":{"url":"https://example.com/app"}}]}]}'
+  --presentation '{"blocks":[{"type":"buttons","buttons":[{"label":"Launch","webApp":{"url":"https://example.com/app"}}]}]}'
 ```
 
-Telegram `web_app` buttons are supported only in private chats between a user
-and the bot.
+Telegram web app buttons are supported only in private chats between a user and
+the bot. Older JSON payloads using `web_app` still parse, but `webApp` is the
+canonical presentation field.
 
 Send a Teams card through generic presentation:
 

--- a/docs/plan/ui-channels.md
+++ b/docs/plan/ui-channels.md
@@ -90,6 +90,9 @@ type MessagePresentationOption = {
 - `interactive` select block maps to `presentation.blocks[].type = "select"`.
 
 The external agent and CLI schemas now use `presentation`; `interactive` remains an internal legacy parser/rendering helper for existing reply producers.
+The public producer-facing API treats `interactive` as deprecated. Runtime
+support remains so existing approval helpers and older plugins continue to
+work while new code emits `presentation`.
 
 ## Delivery metadata
 
@@ -128,6 +131,29 @@ type ChannelPresentationCapabilities = {
   context?: boolean;
   divider?: boolean;
   tones?: MessagePresentationTone[];
+  limits?: {
+    actions?: {
+      maxActions?: number;
+      maxActionsPerRow?: number;
+      maxRows?: number;
+      maxLabelLength?: number;
+      maxValueBytes?: number;
+      supportsStyles?: boolean;
+      supportsDisabled?: boolean;
+      supportsLayoutHints?: boolean;
+    };
+    selects?: {
+      maxOptions?: number;
+      maxLabelLength?: number;
+      maxValueBytes?: number;
+    };
+    text?: {
+      maxLength?: number;
+      encoding?: "characters" | "utf8-bytes" | "utf16-units";
+      markdownDialect?: "plain" | "markdown" | "html" | "slack-mrkdwn" | "discord-markdown";
+      supportsEdit?: boolean;
+    };
+  };
 };
 
 type ChannelDeliveryCapabilities = {
@@ -160,7 +186,8 @@ Core behavior:
 
 - Resolve target channel and runtime adapter.
 - Ask for presentation capabilities.
-- Degrade unsupported blocks before rendering.
+- Degrade unsupported blocks and apply generic capability limits before
+  rendering.
 - Call `renderPresentation`.
 - If no renderer exists, convert presentation to text fallback.
 - After successful send, call `pinDeliveredMessage` when `delivery.pin` is requested and supported.

--- a/docs/plugins/message-presentation.md
+++ b/docs/plugins/message-presentation.md
@@ -391,12 +391,33 @@ New code should accept or produce `MessagePresentation` directly. Existing
 `interactive` payloads are a deprecated subset of `presentation`; runtime
 support remains for older producers.
 
-`presentationToInteractiveReply(...)` preserves visible presentation text by
-mapping the title, text, context, buttons, and selects into the older
-`InteractiveReply` shape. Component renderers that already draw title, text,
-context, and divider blocks natively should use
-`presentationToInteractiveControlsReply(...)` instead, then append only the
-button and select controls.
+The legacy `InteractiveReply*` types and conversion helpers are marked
+`@deprecated` in the SDK:
+
+- `InteractiveReply`, `InteractiveReplyBlock`, `InteractiveReplyButton`,
+  `InteractiveReplyOption`, `InteractiveReplySelectBlock`, and
+  `InteractiveReplyTextBlock`
+- `normalizeInteractiveReply(...)`
+- `hasInteractiveReplyBlocks(...)`
+- `interactiveReplyToPresentation(...)`
+- `presentationToInteractiveReply(...)`
+- `presentationToInteractiveControlsReply(...)`
+- `resolveInteractiveTextFallback(...)`
+- `reduceInteractiveReply(...)`
+
+`presentationToInteractiveReply(...)` and
+`presentationToInteractiveControlsReply(...)` remain available as renderer
+bridges for legacy channel implementations. New producer code should not call
+them; send `presentation` and let core/channel adaptation handle rendering.
+
+Approval helpers also have presentation-first replacements:
+
+- use `buildApprovalPresentationFromActionDescriptors(...)` instead of
+  `buildApprovalInteractiveReplyFromActionDescriptors(...)`
+- use `buildApprovalPresentation(...)` instead of
+  `buildApprovalInteractiveReply(...)`
+- use `buildExecApprovalPresentation(...)` instead of
+  `buildExecApprovalInteractiveReply(...)`
 
 `renderMessagePresentationFallbackText(...)` returns an empty string for
 presentation blocks that have no text fallback, such as a divider-only

--- a/docs/plugins/message-presentation.md
+++ b/docs/plugins/message-presentation.md
@@ -57,7 +57,10 @@ type MessagePresentationButton = {
   value?: string;
   url?: string;
   webApp?: { url: string };
+  /** @deprecated Use webApp. Accepted for legacy JSON payloads only. */
   web_app?: { url: string };
+  priority?: number;
+  disabled?: boolean;
   style?: "primary" | "secondary" | "success" | "danger";
 };
 
@@ -82,11 +85,19 @@ Button semantics:
 - `value` is an application action value routed back through the channel's
   existing interaction path when the channel supports clickable controls.
 - `url` is a link button. It can exist without `value`.
-- `webApp` and `web_app` describe a channel-native web app button. Telegram
-  renders this as `web_app` and only supports it in private chats.
+- `webApp` describes a channel-native web app button. Telegram renders this
+  as `web_app` and only supports it in private chats. `web_app` is still
+  accepted in loose JSON payloads for compatibility, but TypeScript producers
+  should use `webApp`.
 - `label` is required and is also used in text fallback.
 - `style` is advisory. Renderers should map unsupported styles to a safe
   default, not fail the send.
+- `priority` is optional. When a channel advertises action limits and controls
+  must be dropped, core keeps higher-priority buttons first and preserves
+  original order among equal priority buttons. When all controls fit, authored
+  order is preserved.
+- `disabled` is optional. Channels must opt in with `supportsDisabled`; otherwise
+  core degrades the disabled control to non-interactive fallback text.
 
 Select semantics:
 
@@ -205,6 +216,27 @@ const adapter: ChannelOutboundAdapter = {
     selects: true,
     context: true,
     divider: true,
+    limits: {
+      actions: {
+        maxActions: 25,
+        maxActionsPerRow: 5,
+        maxRows: 5,
+        maxLabelLength: 80,
+        maxValueBytes: 100,
+        supportsStyles: true,
+        supportsDisabled: false,
+      },
+      selects: {
+        maxOptions: 25,
+        maxLabelLength: 100,
+        maxValueBytes: 100,
+      },
+      text: {
+        maxLength: 2000,
+        encoding: "characters",
+        markdownDialect: "discord-markdown",
+      },
+    },
   },
   deliveryCapabilities: {
     pin: true,
@@ -218,10 +250,49 @@ const adapter: ChannelOutboundAdapter = {
 };
 ```
 
-Capability fields are intentionally simple booleans. They describe what the
-renderer can make interactive, not every native platform limit. Renderers still
-own platform-specific limits such as maximum button count, block count, and
-card size.
+Capability booleans describe what the renderer can make interactive. Optional
+`limits` describe the generic envelope core can adapt before calling the
+renderer:
+
+```ts
+type ChannelPresentationCapabilities = {
+  supported?: boolean;
+  buttons?: boolean;
+  selects?: boolean;
+  context?: boolean;
+  divider?: boolean;
+  limits?: {
+    actions?: {
+      maxActions?: number;
+      maxActionsPerRow?: number;
+      maxRows?: number;
+      maxLabelLength?: number;
+      maxValueBytes?: number;
+      supportsStyles?: boolean;
+      supportsDisabled?: boolean;
+      supportsLayoutHints?: boolean;
+    };
+    selects?: {
+      maxOptions?: number;
+      maxLabelLength?: number;
+      maxValueBytes?: number;
+    };
+    text?: {
+      maxLength?: number;
+      encoding?: "characters" | "utf8-bytes" | "utf16-units";
+      markdownDialect?: "plain" | "markdown" | "html" | "slack-mrkdwn" | "discord-markdown";
+      supportsEdit?: boolean;
+    };
+  };
+};
+```
+
+Core applies generic limits to semantic controls before rendering. Renderers
+still own final provider-specific validation and clipping for native block
+count, card size, URL limits, and provider quirks that cannot be expressed in
+the generic contract. If limits remove every control from a block, core keeps
+the labels as non-interactive context text so the delivered message still has a
+visible fallback.
 
 ## Core render flow
 
@@ -230,10 +301,12 @@ When a `ReplyPayload` or message action includes `presentation`, core:
 1. Normalizes the presentation payload.
 2. Resolves the target channel's outbound adapter.
 3. Reads `presentationCapabilities`.
-4. Calls `renderPresentation` when the adapter can render the payload.
-5. Falls back to conservative text when the adapter is absent or cannot render.
-6. Sends the resulting payload through the normal channel delivery path.
-7. Applies delivery metadata such as `delivery.pin` after the first successful
+4. Applies generic capability limits such as action count, label length, and
+   select option count when the adapter advertises them.
+5. Calls `renderPresentation` when the adapter can render the payload.
+6. Falls back to conservative text when the adapter is absent or cannot render.
+7. Sends the resulting payload through the normal channel delivery path.
+8. Applies delivery metadata such as `delivery.pin` after the first successful
    sent message.
 
 Core owns fallback behavior so producers can stay channel-agnostic. Channel
@@ -303,15 +376,20 @@ code:
 
 ```ts
 import {
+  adaptMessagePresentationForChannel,
+  applyPresentationActionLimits,
   interactiveReplyToPresentation,
   normalizeMessagePresentation,
+  presentationPageSize,
   presentationToInteractiveControlsReply,
   presentationToInteractiveReply,
   renderMessagePresentationFallbackText,
 } from "openclaw/plugin-sdk/interactive-runtime";
 ```
 
-New code should accept or produce `MessagePresentation` directly.
+New code should accept or produce `MessagePresentation` directly. Existing
+`interactive` payloads are a deprecated subset of `presentation`; runtime
+support remains for older producers.
 
 `presentationToInteractiveReply(...)` preserves visible presentation text by
 mapping the title, text, context, buttons, and selects into the older
@@ -351,7 +429,9 @@ messages where the provider supports those operations.
 - Implement `renderPresentation` in runtime code, not control-plane plugin
   setup code.
 - Keep native UI libraries out of hot setup/catalog paths.
-- Preserve platform limits in the renderer and tests.
+- Declare generic capability limits on `presentationCapabilities.limits` when
+  they are known.
+- Preserve final platform limits in the renderer and tests.
 - Add fallback tests for unsupported buttons, selects, URL buttons, title/text
   duplication, and mixed `message` plus `presentation` sends.
 - Add delivery pin support through `deliveryCapabilities.pin` and

--- a/extensions/discord/src/outbound-adapter.ts
+++ b/extensions/discord/src/outbound-adapter.ts
@@ -120,6 +120,24 @@ export const discordOutbound: ChannelOutboundAdapter = {
     selects: true,
     context: true,
     divider: true,
+    limits: {
+      actions: {
+        maxActions: 25,
+        maxActionsPerRow: 5,
+        maxRows: 5,
+        maxLabelLength: 80,
+      },
+      selects: {
+        maxOptions: 25,
+        maxLabelLength: 100,
+        maxValueBytes: 100,
+      },
+      text: {
+        maxLength: DISCORD_TEXT_CHUNK_LIMIT,
+        encoding: "characters",
+        markdownDialect: "discord-markdown",
+      },
+    },
   },
   deliveryCapabilities: {
     durableFinal: {

--- a/extensions/discord/src/shared-interactive.ts
+++ b/extensions/discord/src/shared-interactive.ts
@@ -1,11 +1,9 @@
-import {
-  presentationToInteractiveControlsReply,
-  reduceInteractiveReply,
-} from "openclaw/plugin-sdk/interactive-runtime";
+import { reduceInteractiveReply } from "openclaw/plugin-sdk/interactive-runtime";
 import type {
   InteractiveButtonStyle,
   InteractiveReply,
   MessagePresentation,
+  MessagePresentationButton,
 } from "openclaw/plugin-sdk/interactive-runtime";
 import type {
   DiscordComponentButtonSpec,
@@ -21,6 +19,9 @@ function resolveDiscordInteractiveButtonStyle(
 
 const DISCORD_INTERACTIVE_BUTTON_ROW_SIZE = 5;
 
+/**
+ * @deprecated Use buildDiscordPresentationComponents with MessagePresentation.
+ */
 export function buildDiscordInteractiveComponents(
   interactive?: InteractiveReply,
 ): DiscordComponentMessageSpec | undefined {
@@ -110,11 +111,51 @@ export function buildDiscordPresentationComponents(
       continue;
     }
   }
-  const interactiveSpec = buildDiscordInteractiveComponents(
-    presentationToInteractiveControlsReply(presentation),
-  );
-  if (interactiveSpec?.blocks?.length) {
-    spec.blocks?.push(...interactiveSpec.blocks);
+  for (const block of presentation.blocks) {
+    if (block.type === "buttons") {
+      appendDiscordPresentationButtonBlocks(spec, block.buttons);
+      continue;
+    }
+    if (block.type === "select" && block.options.length > 0) {
+      spec.blocks?.push({
+        type: "actions",
+        select: {
+          type: "string",
+          placeholder: block.placeholder,
+          options: block.options.map((option) => ({
+            label: option.label,
+            value: option.value,
+          })),
+        },
+      });
+    }
   }
   return spec.blocks?.length ? spec : undefined;
+}
+
+function appendDiscordPresentationButtonBlocks(
+  spec: DiscordComponentMessageSpec,
+  buttons: readonly MessagePresentationButton[],
+) {
+  if (buttons.length === 0) {
+    return;
+  }
+  for (let index = 0; index < buttons.length; index += DISCORD_INTERACTIVE_BUTTON_ROW_SIZE) {
+    spec.blocks?.push({
+      type: "actions",
+      buttons: buttons.slice(index, index + DISCORD_INTERACTIVE_BUTTON_ROW_SIZE).map((button) => {
+        const component: DiscordComponentButtonSpec = {
+          label: button.label,
+          style: button.url ? "link" : resolveDiscordInteractiveButtonStyle(button.style),
+        };
+        if (button.value) {
+          component.callbackData = button.value;
+        }
+        if (button.url) {
+          component.url = button.url;
+        }
+        return component;
+      }),
+    });
+  }
 }

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -1387,6 +1387,19 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
         selects: false,
         context: true,
         divider: true,
+        limits: {
+          actions: {
+            maxActions: 20,
+            maxActionsPerRow: 5,
+            maxLabelLength: 40,
+            maxValueBytes: 1024,
+          },
+          text: {
+            maxLength: 4000,
+            encoding: "characters",
+            markdownDialect: "markdown",
+          },
+        },
       },
       renderPresentation: async (ctx) => {
         const runtime = await loadFeishuChannelRuntime();

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -514,6 +514,19 @@ export const feishuOutbound: ChannelOutboundAdapter = {
     selects: false,
     context: true,
     divider: true,
+    limits: {
+      actions: {
+        maxActions: 20,
+        maxActionsPerRow: 5,
+        maxLabelLength: 40,
+        maxValueBytes: 1024,
+      },
+      text: {
+        maxLength: 4000,
+        encoding: "characters",
+        markdownDialect: "markdown",
+      },
+    },
   },
   renderPresentation: renderFeishuPresentationPayload,
   sendPayload: async (ctx) => {

--- a/extensions/matrix/src/channel.ts
+++ b/extensions/matrix/src/channel.ts
@@ -343,8 +343,6 @@ const matrixChannelOutbound: ChannelOutboundAdapter = {
     divider: true,
     limits: {
       text: {
-        maxLength: 4000,
-        encoding: "characters",
         markdownDialect: "markdown",
         supportsEdit: true,
       },

--- a/extensions/matrix/src/channel.ts
+++ b/extensions/matrix/src/channel.ts
@@ -341,6 +341,14 @@ const matrixChannelOutbound: ChannelOutboundAdapter = {
     selects: true,
     context: true,
     divider: true,
+    limits: {
+      text: {
+        maxLength: 4000,
+        encoding: "characters",
+        markdownDialect: "markdown",
+        supportsEdit: true,
+      },
+    },
   },
   shouldSuppressLocalPayloadPrompt: ({ cfg, accountId, payload }) =>
     shouldSuppressLocalMatrixExecApprovalPrompt({

--- a/extensions/matrix/src/outbound.ts
+++ b/extensions/matrix/src/outbound.ts
@@ -106,8 +106,6 @@ export const matrixOutbound: ChannelOutboundAdapter = {
     divider: true,
     limits: {
       text: {
-        maxLength: 4000,
-        encoding: "characters",
         markdownDialect: "markdown",
         supportsEdit: true,
       },

--- a/extensions/matrix/src/outbound.ts
+++ b/extensions/matrix/src/outbound.ts
@@ -104,6 +104,14 @@ export const matrixOutbound: ChannelOutboundAdapter = {
     selects: true,
     context: true,
     divider: true,
+    limits: {
+      text: {
+        maxLength: 4000,
+        encoding: "characters",
+        markdownDialect: "markdown",
+        supportsEdit: true,
+      },
+    },
   },
   renderPresentation: ({ payload, presentation }) =>
     renderMatrixPresentationPayload({ payload, presentation }),

--- a/extensions/mattermost/src/channel.message-adapter.test.ts
+++ b/extensions/mattermost/src/channel.message-adapter.test.ts
@@ -44,6 +44,16 @@ function requireMediaSender(
   return media;
 }
 
+function requirePayloadSender(
+  adapter: MattermostMessageAdapter,
+): NonNullable<MattermostMessageSender["payload"]> {
+  const payload = adapter.send?.payload;
+  if (!payload) {
+    throw new Error("Expected mattermost message adapter payload sender");
+  }
+  return payload;
+}
+
 describe("mattermost channel message adapter", () => {
   beforeEach(() => {
     sendMessageMattermostMock.mockReset();
@@ -57,6 +67,7 @@ describe("mattermost channel message adapter", () => {
     const adapter = requireMattermostMessageAdapter();
     const sendText = requireTextSender(adapter);
     const sendMedia = requireMediaSender(adapter);
+    const sendPayload = requirePayloadSender(adapter);
 
     const proveText = async () => {
       sendMessageMattermostMock.mockClear();
@@ -130,12 +141,52 @@ describe("mattermost channel message adapter", () => {
       expect(result.receipt.replyToId).toBe("post-parent-1");
     };
 
+    const provePayload = async () => {
+      sendMessageMattermostMock.mockClear();
+      sendMessageMattermostMock.mockResolvedValueOnce({
+        messageId: "post-1",
+        channelId: "channel-1",
+        receipt: {
+          primaryPlatformMessageId: "post-1",
+          platformMessageIds: ["post-1"],
+          parts: [{ platformMessageId: "post-1", kind: "card", index: 0 }],
+          sentAt: Date.now(),
+        },
+      });
+      const result = await sendPayload({
+        cfg: {},
+        to: "channel:team-1",
+        text: "card",
+        accountId: "default",
+        payload: {
+          text: "card",
+          channelData: {
+            mattermost: {
+              presentationButtons: [[{ text: "Open", callback_data: "open" }]],
+            },
+          },
+        },
+      });
+      expect(sendMessageMattermostMock).toHaveBeenLastCalledWith("channel:team-1", "card", {
+        cfg: {},
+        accountId: "default",
+        mediaUrl: undefined,
+        mediaLocalRoots: undefined,
+        mediaReadFile: undefined,
+        replyToId: undefined,
+        buttons: [[{ text: "Open", callback_data: "open" }]],
+      });
+      expect(result.receipt.platformMessageIds).toEqual(["post-1"]);
+      expect(result.receipt.parts[0]?.kind).toBe("card");
+    };
+
     await verifyChannelMessageAdapterCapabilityProofs({
       adapterName: "mattermostMessageAdapter",
       adapter,
       proofs: {
         text: proveText,
         media: proveMedia,
+        payload: provePayload,
         replyTo: proveExplicitReply,
         thread: proveReplyThread,
         messageSendingHooks: () => {

--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -38,6 +38,12 @@ type MattermostSendText = NonNullable<NonNullable<typeof mattermostPlugin.outbou
 type MattermostSendTextParams = Parameters<MattermostSendText>[0];
 type MattermostSendMedia = NonNullable<NonNullable<typeof mattermostPlugin.outbound>["sendMedia"]>;
 type MattermostSendMediaParams = Parameters<MattermostSendMedia>[0];
+type MattermostRenderPresentation = NonNullable<
+  NonNullable<typeof mattermostPlugin.outbound>["renderPresentation"]
+>;
+type MattermostSendPayload = NonNullable<
+  NonNullable<typeof mattermostPlugin.outbound>["sendPayload"]
+>;
 
 function getDescribedActions(cfg: OpenClawConfig, accountId?: string): string[] {
   return [...(mattermostPlugin.actions?.describeMessageTool?.({ cfg, accountId })?.actions ?? [])];
@@ -89,6 +95,22 @@ function requireMattermostChunker() {
     throw new Error("mattermost outbound.chunker missing");
   }
   return chunker;
+}
+
+function requireMattermostRenderPresentation(): MattermostRenderPresentation {
+  const renderPresentation = mattermostPlugin.outbound?.renderPresentation;
+  if (!renderPresentation) {
+    throw new Error("mattermost outbound.renderPresentation missing");
+  }
+  return renderPresentation;
+}
+
+function requireMattermostSendPayload(): MattermostSendPayload {
+  const sendPayload = mattermostPlugin.outbound?.sendPayload;
+  if (!sendPayload) {
+    throw new Error("mattermost outbound.sendPayload missing");
+  }
+  return sendPayload;
 }
 
 function createMattermostActionContext(
@@ -427,6 +449,41 @@ describe("mattermostPlugin", () => {
       expect(options.replyToId).toBe("post-root");
     });
 
+    it("maps presentation buttons without using legacy interactive conversion", async () => {
+      const cfg = createMattermostTestConfig();
+
+      await mattermostPlugin.actions?.handleAction?.(
+        createMattermostActionContext({
+          action: "send",
+          params: {
+            to: "channel:CHAN1",
+            message: "Deploy finished",
+            presentation: {
+              blocks: [
+                {
+                  type: "buttons",
+                  buttons: [
+                    { label: "Open", value: "open", style: "primary" },
+                    { label: "Docs", url: "https://example.com/docs" },
+                  ],
+                },
+              ],
+            },
+          },
+          cfg,
+          accountId: "default",
+        }),
+      );
+
+      const options = expectSingleMattermostSend(
+        "channel:CHAN1",
+        "Deploy finished\n\n- Open\n- Docs: https://example.com/docs",
+      );
+      expect(options.buttons).toStrictEqual([
+        [{ text: "Open", callback_data: "open", style: "primary" }],
+      ]);
+    });
+
     it("falls back to trimmed replyTo when replyToId is blank", async () => {
       const cfg = createMattermostTestConfig();
 
@@ -451,6 +508,86 @@ describe("mattermostPlugin", () => {
   });
 
   describe("outbound", () => {
+    it("renders presentation buttons for normal reply payload delivery", async () => {
+      const renderPresentation = requireMattermostRenderPresentation();
+      const sendPayload = requireMattermostSendPayload();
+      const cfg = createMattermostTestConfig();
+      const presentation = {
+        blocks: [
+          { type: "text" as const, text: "Deploy finished" },
+          {
+            type: "buttons" as const,
+            buttons: [
+              { label: "Open", value: "open", style: "primary" as const },
+              { label: "Docs", url: "https://example.com/docs" },
+            ],
+          },
+        ],
+      };
+      const rendered = await renderPresentation({
+        payload: { presentation },
+        presentation,
+        ctx: {
+          cfg,
+          to: "channel:CHAN1",
+          text: "",
+          payload: { presentation },
+        },
+      });
+
+      expect(rendered).toMatchObject({
+        text: "Deploy finished\n\n- Open\n- Docs: https://example.com/docs",
+        channelData: {
+          mattermost: {
+            presentationButtons: [[{ text: "Open", callback_data: "open", style: "primary" }]],
+          },
+        },
+      });
+
+      await sendPayload({
+        cfg,
+        to: "channel:CHAN1",
+        text: "",
+        payload: rendered!,
+      });
+
+      const options = expectSingleMattermostSend(
+        "channel:CHAN1",
+        "Deploy finished\n\n- Open\n- Docs: https://example.com/docs",
+      );
+      expect(options.buttons).toStrictEqual([
+        [{ text: "Open", callback_data: "open", style: "primary" }],
+      ]);
+    });
+
+    it("keeps multi-media presentation payloads on the text/media fallback path", async () => {
+      const renderPresentation = requireMattermostRenderPresentation();
+      const presentation = {
+        blocks: [
+          {
+            type: "buttons" as const,
+            buttons: [{ label: "Open", value: "open" }],
+          },
+        ],
+      };
+
+      expect(
+        await renderPresentation({
+          payload: {
+            presentation,
+            mediaUrls: ["https://example.com/1.png", "https://example.com/2.png"],
+          },
+          presentation,
+          ctx: {
+            cfg: createMattermostTestConfig(),
+            to: "channel:CHAN1",
+            text: "",
+            payload: { presentation },
+          },
+        }),
+      ).toBeNull();
+    });
+
     it("chunks outbound text without requiring Mattermost runtime initialization", () => {
       const chunker = requireMattermostChunker();
 

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -8,17 +8,19 @@ import { createChannelMessageAdapterFromOutbound } from "openclaw/plugin-sdk/cha
 import { createLoggedPairingApprovalNotifier } from "openclaw/plugin-sdk/channel-pairing";
 import { createRestrictSendersChannelSecurity } from "openclaw/plugin-sdk/channel-policy";
 import {
+  attachChannelToResult,
   createAttachedChannelResultAdapter,
   type ChannelOutboundAdapter,
 } from "openclaw/plugin-sdk/channel-send-result";
 import { createChannelDirectoryAdapter } from "openclaw/plugin-sdk/directory-runtime";
 import { buildPassiveProbedChannelStatusSummary } from "openclaw/plugin-sdk/extension-shared";
 import {
+  type MessagePresentation,
   normalizeMessagePresentation,
-  presentationToInteractiveReply,
   renderMessagePresentationFallbackText,
 } from "openclaw/plugin-sdk/interactive-runtime";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
+import { resolvePayloadMediaUrls, sendTextMediaPayload } from "openclaw/plugin-sdk/reply-payload";
 import { isPrivateNetworkOptInEnabled } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
   createComputedAccountStatusAdapter,
@@ -58,6 +60,49 @@ import { mattermostSetupWizard } from "./setup-surface.js";
 import type { MattermostConfig } from "./types.js";
 
 const loadMattermostChannelRuntime = createLazyRuntimeModule(() => import("./channel.runtime.js"));
+
+function buildMattermostPresentationButtons(presentation: MessagePresentation) {
+  return presentation.blocks
+    .filter((block) => block.type === "buttons")
+    .map((block) =>
+      block.buttons.flatMap((button) =>
+        button.value
+          ? [
+              {
+                text: button.label,
+                callback_data: button.value,
+                style: button.style,
+              },
+            ]
+          : [],
+      ),
+    );
+}
+
+const MATTERMOST_PRESENTATION_CAPABILITIES = {
+  supported: true,
+  buttons: true,
+  selects: false,
+  context: true,
+  divider: false,
+  limits: {
+    text: {
+      markdownDialect: "markdown",
+    },
+  },
+} satisfies ChannelOutboundAdapter["presentationCapabilities"];
+
+function hasMattermostPresentationButtons(presentation: MessagePresentation): boolean {
+  return buildMattermostPresentationButtons(presentation).some((row) => row.length > 0);
+}
+
+function readMattermostPresentationButtons(payload: {
+  channelData?: Record<string, unknown>;
+}): Array<unknown> | undefined {
+  const buttons = (payload.channelData?.mattermost as { presentationButtons?: unknown } | undefined)
+    ?.presentationButtons;
+  return Array.isArray(buttons) ? buttons : undefined;
+}
 
 type MattermostDirectoryListParams = Parameters<
   NonNullable<NonNullable<ChannelPlugin["directory"]>["listGroups"]>
@@ -236,23 +281,7 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
       cfg,
       accountId: resolvedAccountId,
       replyToId,
-      buttons: presentation
-        ? presentationToInteractiveReply(presentation)
-            ?.blocks.filter((block) => block.type === "buttons")
-            .map((block) =>
-              block.buttons.flatMap((button) =>
-                button.value
-                  ? [
-                      {
-                        text: button.label,
-                        callback_data: button.value,
-                        style: button.style,
-                      },
-                    ]
-                  : [],
-              ),
-            )
-        : undefined,
+      buttons: presentation ? buildMattermostPresentationButtons(presentation) : undefined,
       attachmentText: typeof params.attachmentText === "string" ? params.attachmentText : undefined,
       mediaUrl,
     });
@@ -306,10 +335,56 @@ const mattermostOutbound: ChannelOutboundAdapter = {
     durableFinal: {
       text: true,
       media: true,
+      payload: true,
       replyTo: true,
       thread: true,
       messageSendingHooks: true,
     },
+  },
+  presentationCapabilities: MATTERMOST_PRESENTATION_CAPABILITIES,
+  renderPresentation: ({ payload, presentation }) => {
+    if (payload.mediaUrls && payload.mediaUrls.length > 1) {
+      return null;
+    }
+    const buttons = buildMattermostPresentationButtons(presentation);
+    if (!hasMattermostPresentationButtons(presentation)) {
+      return null;
+    }
+    return {
+      ...payload,
+      text: renderMessagePresentationFallbackText({ text: payload.text, presentation }),
+      channelData: {
+        ...payload.channelData,
+        mattermost: {
+          ...(payload.channelData?.mattermost as Record<string, unknown> | undefined),
+          presentationButtons: buttons,
+        },
+      },
+    };
+  },
+  sendPayload: async (ctx) => {
+    const buttons = readMattermostPresentationButtons(ctx.payload);
+    if (buttons?.length) {
+      const mediaUrl = resolvePayloadMediaUrls({
+        ...ctx.payload,
+        mediaUrl: ctx.payload.mediaUrl ?? ctx.mediaUrl,
+      })
+        .map((url) => url.trim())
+        .find(Boolean);
+      const result = await (
+        await loadMattermostChannelRuntime()
+      ).sendMessageMattermost(ctx.to, ctx.payload.text ?? ctx.text, {
+        cfg: ctx.cfg,
+        accountId: ctx.accountId ?? undefined,
+        mediaUrl,
+        mediaLocalRoots: ctx.mediaLocalRoots,
+        mediaReadFile: ctx.mediaReadFile,
+        replyToId: ctx.replyToId ?? (ctx.threadId != null ? String(ctx.threadId) : undefined),
+        buttons,
+      });
+      return attachChannelToResult("mattermost", result);
+    }
+    return await sendTextMediaPayload({ channel: "mattermost", ctx, adapter: mattermostOutbound });
   },
   resolveTarget: ({ to }) => {
     const trimmed = to?.trim();

--- a/extensions/msteams/src/channel.actions.test.ts
+++ b/extensions/msteams/src/channel.actions.test.ts
@@ -549,6 +549,59 @@ describe("msteamsPlugin message actions", () => {
     });
   });
 
+  it("downgrades select blocks when sending presentation cards", async () => {
+    await expectSuccessfulAction({
+      mockFn: sendAdaptiveCardMSTeamsMock,
+      mockResult: {
+        messageId: "msg-card-select-1",
+        conversationId: "conv-card-select-1",
+      },
+      action: "send",
+      actionParams: {
+        to: targetChannelId,
+        presentation: {
+          blocks: [
+            {
+              type: "select",
+              placeholder: "Pick a lane",
+              options: [
+                { label: "Canary", value: "canary" },
+                { label: "Stable", value: "stable" },
+              ],
+            },
+          ],
+        },
+      },
+      runtimeParams: {
+        to: targetChannelId,
+        card: {
+          type: "AdaptiveCard",
+          version: "1.4",
+          body: [
+            {
+              type: "TextBlock",
+              text: "Pick a lane:\n- Canary\n- Stable",
+              wrap: true,
+              isSubtle: true,
+              size: "Small",
+            },
+          ],
+        },
+      },
+      details: {
+        ok: true,
+        channel: "msteams",
+        messageId: "msg-card-select-1",
+      },
+      contentDetails: {
+        ok: true,
+        channel: "msteams",
+        messageId: "msg-card-select-1",
+        conversationId: "conv-card-select-1",
+      },
+    });
+  });
+
   it("reports the allowed reaction types when emoji is missing", async () => {
     await expectActionParamError(
       "react",

--- a/extensions/msteams/src/channel.message-adapter.test.ts
+++ b/extensions/msteams/src/channel.message-adapter.test.ts
@@ -9,6 +9,7 @@ import type { OpenClawConfig } from "../runtime-api.js";
 const mocks = vi.hoisted(() => ({
   sendText: vi.fn(),
   sendMedia: vi.fn(),
+  sendPayload: vi.fn(),
   sendPoll: vi.fn(),
 }));
 
@@ -17,6 +18,7 @@ vi.mock("./channel.runtime.js", () => ({
     msteamsOutbound: {
       sendText: mocks.sendText,
       sendMedia: mocks.sendMedia,
+      sendPayload: mocks.sendPayload,
       sendPoll: mocks.sendPoll,
     },
   },
@@ -55,6 +57,16 @@ function requireMediaSender(
   return media;
 }
 
+function requirePayloadSender(
+  adapter: MSTeamsMessageAdapter,
+): NonNullable<MSTeamsMessageSender["payload"]> {
+  const payload = adapter.send?.payload;
+  if (!payload) {
+    throw new Error("Expected msteams message adapter payload sender");
+  }
+  return payload;
+}
+
 const cfg = {
   channels: {
     msteams: {
@@ -67,6 +79,7 @@ describe("msteams channel message adapter", () => {
   beforeEach(() => {
     mocks.sendText.mockReset();
     mocks.sendMedia.mockReset();
+    mocks.sendPayload.mockReset();
     mocks.sendPoll.mockReset();
     mocks.sendText.mockResolvedValue({
       channel: "msteams",
@@ -78,12 +91,18 @@ describe("msteams channel message adapter", () => {
       messageId: "msg-media-1",
       conversationId: "conv-1",
     });
+    mocks.sendPayload.mockResolvedValue({
+      channel: "msteams",
+      messageId: "msg-payload-1",
+      conversationId: "conv-1",
+    });
   });
 
   it("backs declared durable-final capabilities with outbound send proofs", async () => {
     const adapter = requireMSTeamsMessageAdapter();
     const sendText = requireTextSender(adapter);
     const sendMedia = requireMediaSender(adapter);
+    const sendPayload = requirePayloadSender(adapter);
     expect(adapter.durableFinal?.capabilities?.replyTo).toBeUndefined();
     expect(adapter.durableFinal?.capabilities?.thread).toBeUndefined();
 
@@ -127,12 +146,38 @@ describe("msteams channel message adapter", () => {
       expect(result.receipt.parts[0]?.kind).toBe("media");
     };
 
+    const provePayload = async () => {
+      mocks.sendPayload.mockClear();
+      const payload = {
+        presentation: {
+          blocks: [{ type: "text" as const, text: "card body" }],
+        },
+      };
+      const result = await sendPayload({
+        cfg,
+        to: "conversation:abc",
+        text: "",
+        payload,
+        accountId: "default",
+      });
+      expect(mocks.sendPayload).toHaveBeenLastCalledWith({
+        cfg,
+        to: "conversation:abc",
+        text: "",
+        payload,
+        accountId: "default",
+      });
+      expect(result.receipt.platformMessageIds).toEqual(["msg-payload-1"]);
+      expect(result.receipt.parts[0]?.kind).toBe("card");
+    };
+
     await verifyChannelMessageAdapterCapabilityProofs({
       adapterName: "msteamsMessageAdapter",
       adapter,
       proofs: {
         text: proveText,
         media: proveMedia,
+        payload: provePayload,
         messageSendingHooks: () => {
           expect(sendText).toBeTypeOf("function");
         },

--- a/extensions/msteams/src/channel.ts
+++ b/extensions/msteams/src/channel.ts
@@ -40,7 +40,7 @@ import { msTeamsApprovalAuth } from "./approval-auth.js";
 import { MSTeamsChannelConfigSchema } from "./config-schema.js";
 import { collectMSTeamsMutableAllowlistWarnings } from "./doctor.js";
 import { resolveMSTeamsGroupToolPolicy } from "./policy.js";
-import { buildMSTeamsPresentationCard } from "./presentation.js";
+import { buildMSTeamsPresentationCard, MSTEAMS_PRESENTATION_CAPABILITIES } from "./presentation.js";
 import type { ProbeMSTeamsResult } from "./probe.js";
 import {
   normalizeMSTeamsMessagingTarget,
@@ -418,11 +418,15 @@ const msteamsChannelOutbound: ChannelOutboundAdapter = {
     durableFinal: {
       text: true,
       media: true,
+      payload: true,
       messageSendingHooks: true,
     },
   },
+  presentationCapabilities: MSTEAMS_PRESENTATION_CAPABILITIES,
   ...createRuntimeOutboundDelegates({
     getRuntime: loadMSTeamsChannelRuntime,
+    renderPresentation: { resolve: (runtime) => runtime.msteamsOutbound.renderPresentation },
+    sendPayload: { resolve: (runtime) => runtime.msteamsOutbound.sendPayload },
     sendText: { resolve: (runtime) => runtime.msteamsOutbound.sendText },
     sendMedia: { resolve: (runtime) => runtime.msteamsOutbound.sendMedia },
     sendPoll: { resolve: (runtime) => runtime.msteamsOutbound.sendPoll },

--- a/extensions/msteams/src/outbound.test.ts
+++ b/extensions/msteams/src/outbound.test.ts
@@ -2,12 +2,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../runtime-api.js";
 
 const mocks = vi.hoisted(() => ({
+  sendAdaptiveCardMSTeams: vi.fn(),
   sendMessageMSTeams: vi.fn(),
   sendPollMSTeams: vi.fn(),
   createPoll: vi.fn(),
 }));
 
 vi.mock("./send.js", () => ({
+  sendAdaptiveCardMSTeams: mocks.sendAdaptiveCardMSTeams,
   sendMessageMSTeams: mocks.sendMessageMSTeams,
   sendPollMSTeams: mocks.sendPollMSTeams,
 }));
@@ -20,9 +22,19 @@ vi.mock("./polls.js", () => ({
 
 import { msteamsOutbound } from "./outbound.js";
 
+const cfg = {
+  channels: {
+    msteams: {
+      appId: "resolved-app-id",
+    },
+  },
+} as OpenClawConfig;
+
 type MSTeamsSendText = NonNullable<typeof msteamsOutbound.sendText>;
 type MSTeamsSendMedia = NonNullable<typeof msteamsOutbound.sendMedia>;
+type MSTeamsSendPayload = NonNullable<typeof msteamsOutbound.sendPayload>;
 type MSTeamsSendPoll = NonNullable<typeof msteamsOutbound.sendPoll>;
+type MSTeamsRenderPresentation = NonNullable<typeof msteamsOutbound.renderPresentation>;
 
 function requireSendText(): MSTeamsSendText {
   const sendText = msteamsOutbound.sendText;
@@ -40,12 +52,28 @@ function requireSendMedia(): MSTeamsSendMedia {
   return sendMedia;
 }
 
+function requireSendPayload(): MSTeamsSendPayload {
+  const sendPayload = msteamsOutbound.sendPayload;
+  if (!sendPayload) {
+    throw new Error("Expected msteams outbound sendPayload");
+  }
+  return sendPayload;
+}
+
 function requireSendPoll(): MSTeamsSendPoll {
   const sendPoll = msteamsOutbound.sendPoll;
   if (!sendPoll) {
     throw new Error("Expected msteams outbound sendPoll");
   }
   return sendPoll;
+}
+
+function requireRenderPresentation(): MSTeamsRenderPresentation {
+  const renderPresentation = msteamsOutbound.renderPresentation;
+  if (!renderPresentation) {
+    throw new Error("Expected msteams outbound renderPresentation");
+  }
+  return renderPresentation;
 }
 
 type PollRecord = Record<string, unknown> & { createdAt: string };
@@ -68,6 +96,7 @@ function firstPollRecord(): PollRecord {
 describe("msteamsOutbound cfg threading", () => {
   beforeEach(() => {
     mocks.sendMessageMSTeams.mockReset();
+    mocks.sendAdaptiveCardMSTeams.mockReset();
     mocks.sendPollMSTeams.mockReset();
     mocks.createPoll.mockReset();
     mocks.sendMessageMSTeams.mockResolvedValue({
@@ -79,7 +108,20 @@ describe("msteamsOutbound cfg threading", () => {
       messageId: "msg-poll-1",
       conversationId: "conv-1",
     });
+    mocks.sendAdaptiveCardMSTeams.mockResolvedValue({
+      messageId: "msg-card-1",
+      conversationId: "conv-card-1",
+    });
     mocks.createPoll.mockResolvedValue(undefined);
+  });
+
+  it("advertises durable payload delivery for presentation cards", () => {
+    expect(msteamsOutbound.deliveryCapabilities?.durableFinal).toMatchObject({
+      text: true,
+      media: true,
+      payload: true,
+      messageSendingHooks: true,
+    });
   });
 
   it("passes resolved cfg to sendMessageMSTeams for text sends", async () => {
@@ -128,6 +170,184 @@ describe("msteamsOutbound cfg threading", () => {
       mediaUrl: "file:///tmp/photo.png",
       mediaLocalRoots: ["/tmp"],
     });
+  });
+
+  it("renders and sends presentation payloads as Adaptive Cards", async () => {
+    const presentation = {
+      title: "Deploy",
+      blocks: [
+        { type: "text" as const, text: "Finished" },
+        {
+          type: "buttons" as const,
+          buttons: [{ label: "Open", value: "open" }],
+        },
+      ],
+    };
+    const payload = {
+      text: "Deploy finished",
+      presentation,
+    };
+    const rendered = await requireRenderPresentation()({
+      payload,
+      presentation,
+      ctx: {
+        cfg,
+        to: "conversation:abc",
+        text: "Deploy finished",
+        payload,
+      },
+    });
+
+    expect(rendered?.presentation).toBe(presentation);
+    expect(rendered?.channelData?.msteams).toEqual({
+      presentationCard: {
+        type: "AdaptiveCard",
+        version: "1.4",
+        body: [
+          { type: "TextBlock", text: "Deploy finished", wrap: true },
+          { type: "TextBlock", text: "Deploy", weight: "Bolder", size: "Medium", wrap: true },
+          { type: "TextBlock", text: "Finished", wrap: true },
+        ],
+        actions: [{ type: "Action.Submit", title: "Open", data: { value: "open", label: "Open" } }],
+      },
+    });
+
+    const result = await requireSendPayload()({
+      cfg,
+      to: "conversation:abc",
+      text: "Deploy finished",
+      payload: rendered!,
+    });
+
+    expect(mocks.sendAdaptiveCardMSTeams).toHaveBeenCalledWith({
+      cfg,
+      to: "conversation:abc",
+      card: (rendered?.channelData?.msteams as { presentationCard: unknown }).presentationCard,
+    });
+    expect(result).toEqual({
+      channel: "msteams",
+      messageId: "msg-card-1",
+      conversationId: "conv-card-1",
+    });
+  });
+
+  it("falls back to text/media delivery when payload rendering did not produce a card", async () => {
+    const result = await requireSendPayload()({
+      cfg,
+      to: "conversation:abc",
+      text: "hello",
+      payload: {
+        text: "hello",
+        channelData: { msteams: { traceId: "trace-1" } },
+      },
+    });
+
+    expect(mocks.sendMessageMSTeams).toHaveBeenCalledWith({
+      cfg,
+      to: "conversation:abc",
+      text: "hello",
+    });
+    expect(result).toEqual({
+      channel: "msteams",
+      messageId: "msg-1",
+      conversationId: "conv-1",
+    });
+  });
+
+  it("chunks text fallback payloads that only carry channel metadata", async () => {
+    mocks.sendMessageMSTeams
+      .mockResolvedValueOnce({ messageId: "msg-text-1", conversationId: "conv-text" })
+      .mockResolvedValueOnce({ messageId: "msg-text-2", conversationId: "conv-text" });
+    const text = "x".repeat(4001);
+
+    const result = await requireSendPayload()({
+      cfg,
+      to: "conversation:abc",
+      text,
+      payload: {
+        text,
+        channelData: { msteams: { traceId: "trace-1" } },
+      },
+    });
+
+    expect(mocks.sendMessageMSTeams).toHaveBeenNthCalledWith(1, {
+      cfg,
+      to: "conversation:abc",
+      text: "x".repeat(4000),
+    });
+    expect(mocks.sendMessageMSTeams).toHaveBeenNthCalledWith(2, {
+      cfg,
+      to: "conversation:abc",
+      text: "x",
+    });
+    expect(result).toEqual({
+      channel: "msteams",
+      messageId: "msg-text-2",
+      conversationId: "conv-text",
+    });
+  });
+
+  it("keeps multi-media payloads on the media fallback path", async () => {
+    mocks.sendMessageMSTeams
+      .mockResolvedValueOnce({ messageId: "msg-media-1", conversationId: "conv-media" })
+      .mockResolvedValueOnce({ messageId: "msg-media-2", conversationId: "conv-media" });
+
+    const result = await requireSendPayload()({
+      cfg,
+      to: "conversation:abc",
+      text: "album",
+      payload: {
+        text: "album",
+        mediaUrls: ["file:///tmp/one.png", "file:///tmp/two.png"],
+        channelData: { msteams: { traceId: "trace-1" } },
+      },
+      mediaLocalRoots: ["/tmp"],
+    });
+
+    expect(mocks.sendMessageMSTeams).toHaveBeenNthCalledWith(1, {
+      cfg,
+      to: "conversation:abc",
+      text: "album",
+      mediaUrl: "file:///tmp/one.png",
+      mediaLocalRoots: ["/tmp"],
+      mediaReadFile: undefined,
+    });
+    expect(mocks.sendMessageMSTeams).toHaveBeenNthCalledWith(2, {
+      cfg,
+      to: "conversation:abc",
+      text: "",
+      mediaUrl: "file:///tmp/two.png",
+      mediaLocalRoots: ["/tmp"],
+      mediaReadFile: undefined,
+    });
+    expect(result).toEqual({
+      channel: "msteams",
+      messageId: "msg-media-2",
+      conversationId: "conv-media",
+    });
+  });
+
+  it("lets media payloads use text fallback instead of card rendering", async () => {
+    const payload = {
+      text: "photo",
+      mediaUrl: "file:///tmp/photo.png",
+      presentation: {
+        blocks: [{ type: "buttons" as const, buttons: [{ label: "Open", value: "open" }] }],
+      },
+    };
+    const rendered = await requireRenderPresentation()({
+      payload,
+      presentation: payload.presentation,
+      ctx: {
+        cfg,
+        to: "conversation:abc",
+        text: "photo",
+        mediaUrl: "file:///tmp/photo.png",
+        payload,
+      },
+    });
+
+    expect(rendered).toBeNull();
   });
 
   it("passes resolved cfg to sendPollMSTeams and stores poll metadata", async () => {

--- a/extensions/msteams/src/outbound.ts
+++ b/extensions/msteams/src/outbound.ts
@@ -1,15 +1,142 @@
-import { createAttachedChannelResultAdapter } from "openclaw/plugin-sdk/channel-send-result";
+import {
+  attachChannelToResult,
+  createAttachedChannelResultAdapter,
+} from "openclaw/plugin-sdk/channel-send-result";
 import { resolveOutboundSendDep } from "openclaw/plugin-sdk/outbound-send-deps";
+import {
+  resolvePayloadMediaUrls,
+  resolveTextChunksWithFallback,
+  sendPayloadMediaSequence,
+} from "openclaw/plugin-sdk/reply-payload";
 import { chunkTextForOutbound, type ChannelOutboundAdapter } from "../runtime-api.js";
 import { createMSTeamsPollStoreFs } from "./polls.js";
-import { sendMessageMSTeams, sendPollMSTeams } from "./send.js";
+import { buildMSTeamsPresentationCard, MSTEAMS_PRESENTATION_CAPABILITIES } from "./presentation.js";
+import { sendAdaptiveCardMSTeams, sendMessageMSTeams, sendPollMSTeams } from "./send.js";
+
+function asObjectRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+const MSTEAMS_TEXT_CHUNK_LIMIT = 4000;
 
 export const msteamsOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
   chunker: chunkTextForOutbound,
   chunkerMode: "markdown",
-  textChunkLimit: 4000,
+  textChunkLimit: MSTEAMS_TEXT_CHUNK_LIMIT,
   pollMaxOptions: 12,
+  deliveryCapabilities: {
+    durableFinal: {
+      text: true,
+      media: true,
+      payload: true,
+      messageSendingHooks: true,
+    },
+  },
+  presentationCapabilities: MSTEAMS_PRESENTATION_CAPABILITIES,
+  renderPresentation: ({ payload, presentation }) => {
+    if (payload.mediaUrl || payload.mediaUrls?.length) {
+      return null;
+    }
+    const card = buildMSTeamsPresentationCard({
+      presentation,
+      text: payload.text,
+    });
+    const msteamsData = asObjectRecord(payload.channelData?.msteams) ?? {};
+    return {
+      ...payload,
+      channelData: {
+        ...payload.channelData,
+        msteams: {
+          ...msteamsData,
+          presentationCard: card,
+        },
+      },
+    };
+  },
+  sendPayload: async ({
+    cfg,
+    to,
+    text,
+    mediaUrl,
+    mediaLocalRoots,
+    mediaReadFile,
+    payload,
+    deps,
+  }) => {
+    const msteamsData = asObjectRecord(payload.channelData?.msteams);
+    const presentationCard = msteamsData?.presentationCard;
+    if (
+      presentationCard &&
+      typeof presentationCard === "object" &&
+      !Array.isArray(presentationCard)
+    ) {
+      const result = await sendAdaptiveCardMSTeams({
+        cfg,
+        to,
+        card: presentationCard as Record<string, unknown>,
+      });
+      return attachChannelToResult("msteams", result);
+    }
+    const mediaUrls = resolvePayloadMediaUrls({
+      ...payload,
+      mediaUrl: payload.mediaUrl ?? mediaUrl,
+    })
+      .map((url) => url.trim())
+      .filter(Boolean);
+    if (mediaUrls.length > 0) {
+      type SendFn = (
+        to: string,
+        text: string,
+        opts?: {
+          mediaUrl?: string;
+          mediaLocalRoots?: readonly string[];
+          mediaReadFile?: (filePath: string) => Promise<Buffer>;
+        },
+      ) => Promise<{ messageId: string; conversationId: string }>;
+      const send =
+        resolveOutboundSendDep<SendFn>(deps, "msteams") ??
+        ((to, text, opts) =>
+          sendMessageMSTeams({
+            cfg,
+            to,
+            text,
+            mediaUrl: opts?.mediaUrl,
+            mediaLocalRoots: opts?.mediaLocalRoots,
+            mediaReadFile: opts?.mediaReadFile,
+          }));
+      const result = await sendPayloadMediaSequence({
+        text,
+        mediaUrls,
+        send: async ({ text, mediaUrl }) =>
+          await send(to, text, { mediaUrl, mediaLocalRoots, mediaReadFile }),
+      });
+      if (result) {
+        return attachChannelToResult("msteams", result);
+      }
+    }
+    if (text.trim()) {
+      type SendFn = (
+        to: string,
+        text: string,
+      ) => Promise<{ messageId: string; conversationId: string }>;
+      const send =
+        resolveOutboundSendDep<SendFn>(deps, "msteams") ??
+        ((to, text) => sendMessageMSTeams({ cfg, to, text }));
+      const chunks = resolveTextChunksWithFallback(
+        text,
+        chunkTextForOutbound(text, MSTEAMS_TEXT_CHUNK_LIMIT),
+      );
+      let result: Awaited<ReturnType<SendFn>>;
+      for (const chunk of chunks) {
+        result = await send(to, chunk);
+      }
+      return attachChannelToResult("msteams", result!);
+    }
+    throw new Error("MS Teams payload send requires text, media, or a presentation card.");
+  },
   ...createAttachedChannelResultAdapter({
     channel: "msteams",
     sendText: async ({ cfg, to, text, deps }) => {

--- a/extensions/msteams/src/presentation.ts
+++ b/extensions/msteams/src/presentation.ts
@@ -1,5 +1,26 @@
-import type { MessagePresentation } from "openclaw/plugin-sdk/interactive-runtime";
+import {
+  adaptMessagePresentationForChannel,
+  type MessagePresentation,
+} from "openclaw/plugin-sdk/interactive-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { ChannelOutboundAdapter } from "../runtime-api.js";
+
+export const MSTEAMS_PRESENTATION_CAPABILITIES = {
+  supported: true,
+  buttons: true,
+  selects: false,
+  context: true,
+  divider: true,
+  limits: {
+    actions: {
+      supportsStyles: false,
+      supportsDisabled: false,
+    },
+    text: {
+      markdownDialect: "markdown",
+    },
+  },
+} satisfies ChannelOutboundAdapter["presentationCapabilities"];
 
 export function buildMSTeamsPresentationCard(params: {
   presentation: MessagePresentation;
@@ -14,7 +35,10 @@ export function buildMSTeamsPresentationCard(params: {
       wrap: true,
     });
   }
-  const { presentation } = params;
+  const presentation = adaptMessagePresentationForChannel({
+    presentation: params.presentation,
+    capabilities: MSTEAMS_PRESENTATION_CAPABILITIES,
+  });
   if (presentation.title) {
     body.push({
       type: "TextBlock",
@@ -41,11 +65,12 @@ export function buildMSTeamsPresentationCard(params: {
     }
     if (block.type === "buttons") {
       for (const button of block.buttons) {
-        if (button.url) {
+        const targetUrl = button.url ?? button.webApp?.url ?? button.web_app?.url;
+        if (targetUrl) {
           actions.push({
             type: "Action.OpenUrl",
             title: button.label,
-            url: button.url,
+            url: targetUrl,
           });
           continue;
         }

--- a/extensions/msteams/src/welcome-card.test.ts
+++ b/extensions/msteams/src/welcome-card.test.ts
@@ -23,6 +23,29 @@ describe("buildMSTeamsPresentationCard", () => {
       actions: [{ type: "Action.Submit", title: "Open", data: { value: "open", label: "Open" } }],
     });
   });
+
+  it("renders web app button links as open-url actions", () => {
+    expect(
+      buildMSTeamsPresentationCard({
+        presentation: {
+          blocks: [
+            {
+              type: "buttons",
+              buttons: [
+                { label: "Open app", webApp: { url: "https://example.com/app" } },
+                { label: "Legacy app", web_app: { url: "https://example.com/legacy" } },
+              ],
+            },
+          ],
+        },
+      }),
+    ).toMatchObject({
+      actions: [
+        { type: "Action.OpenUrl", title: "Open app", url: "https://example.com/app" },
+        { type: "Action.OpenUrl", title: "Legacy app", url: "https://example.com/legacy" },
+      ],
+    });
+  });
 });
 
 describe("buildWelcomeCard", () => {

--- a/extensions/slack/src/approval-handler.runtime.ts
+++ b/extensions/slack/src/approval-handler.runtime.ts
@@ -8,7 +8,7 @@ import type {
 } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { createChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { buildChannelApprovalNativeTargetKey } from "openclaw/plugin-sdk/approval-native-runtime";
-import { buildApprovalInteractiveReplyFromActionDescriptors } from "openclaw/plugin-sdk/approval-reply-runtime";
+import { buildApprovalPresentationFromActionDescriptors } from "openclaw/plugin-sdk/approval-reply-runtime";
 import type { ExecApprovalRequest } from "openclaw/plugin-sdk/approval-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { logError } from "openclaw/plugin-sdk/logging-core";
@@ -142,7 +142,7 @@ function buildSlackPendingApprovalBlocks(view: ExecApprovalPendingView): SlackBl
   const interactiveBlocks =
     resolveSlackReplyBlocks({
       text: "",
-      interactive: buildApprovalInteractiveReplyFromActionDescriptors(view.actions),
+      presentation: buildApprovalPresentationFromActionDescriptors(view.actions),
     }) ?? [];
   return [
     {

--- a/extensions/slack/src/blocks-render.ts
+++ b/extensions/slack/src/blocks-render.ts
@@ -1,11 +1,10 @@
 import type { Block, KnownBlock } from "@slack/web-api";
-import {
-  presentationToInteractiveControlsReply,
-  reduceInteractiveReply,
-} from "openclaw/plugin-sdk/interactive-runtime";
+import { reduceInteractiveReply } from "openclaw/plugin-sdk/interactive-runtime";
 import type {
   InteractiveReply,
   MessagePresentation,
+  MessagePresentationButtonsBlock,
+  MessagePresentationSelectBlock,
 } from "openclaw/plugin-sdk/interactive-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { SLACK_REPLY_BUTTON_ACTION_ID, SLACK_REPLY_SELECT_ACTION_ID } from "./reply-action-ids.js";
@@ -232,7 +231,102 @@ export function buildSlackPresentationBlocks(
       blocks.push({ type: "divider" });
     }
   }
-  const interactive = presentationToInteractiveControlsReply(presentation);
-  blocks.push(...buildSlackInteractiveBlocks(interactive, options));
+  let buttonIndex = options.buttonIndexOffset ?? 0;
+  let selectIndex = options.selectIndexOffset ?? 0;
+  for (const block of presentation.blocks) {
+    if (block.type === "buttons") {
+      const rendered = buildSlackPresentationButtonBlock(block, buttonIndex + 1);
+      if (rendered) {
+        buttonIndex += 1;
+        blocks.push(rendered);
+      }
+      continue;
+    }
+    if (block.type === "select") {
+      const rendered = buildSlackPresentationSelectBlock(block, selectIndex + 1);
+      if (rendered) {
+        selectIndex += 1;
+        blocks.push(rendered);
+      }
+    }
+  }
   return blocks;
+}
+
+function buildSlackPresentationButtonBlock(
+  block: MessagePresentationButtonsBlock,
+  buttonIndex: number,
+): SlackBlock | undefined {
+  const elements = block.buttons
+    .flatMap((button, choiceIndex) => {
+      const value =
+        button.value && isWithinSlackLimit(button.value, SLACK_BUTTON_VALUE_MAX)
+          ? button.value
+          : undefined;
+      const url =
+        button.url && isWithinSlackLimit(button.url, SLACK_BUTTON_URL_MAX) ? button.url : undefined;
+      if (!value && !url) {
+        return [];
+      }
+      const style = resolveSlackButtonStyle(button.style);
+      return [
+        {
+          type: "button" as const,
+          action_id: buildSlackReplyButtonActionId(buttonIndex, choiceIndex),
+          text: {
+            type: "plain_text" as const,
+            text: truncateSlackText(button.label, SLACK_PLAIN_TEXT_MAX),
+            emoji: true,
+          },
+          ...(value ? { value } : {}),
+          ...(url ? { url } : {}),
+          ...(style ? { style } : {}),
+        },
+      ];
+    })
+    .slice(0, SLACK_ACTION_BLOCK_ELEMENTS_MAX);
+  return elements.length > 0
+    ? {
+        type: "actions",
+        block_id: `openclaw_reply_buttons_${buttonIndex}`,
+        elements,
+      }
+    : undefined;
+}
+
+function buildSlackPresentationSelectBlock(
+  block: MessagePresentationSelectBlock,
+  selectIndex: number,
+): SlackBlock | undefined {
+  const options = block.options
+    .filter((option) => isWithinSlackLimit(option.value, SLACK_OPTION_VALUE_MAX))
+    .slice(0, SLACK_STATIC_SELECT_OPTIONS_MAX);
+  return options.length > 0
+    ? {
+        type: "actions",
+        block_id: `openclaw_reply_select_${selectIndex}`,
+        elements: [
+          {
+            type: "static_select",
+            action_id: buildSlackReplySelectActionId(selectIndex),
+            placeholder: {
+              type: "plain_text",
+              text: truncateSlackText(
+                normalizeOptionalString(block.placeholder) ?? "Choose an option",
+                SLACK_PLAIN_TEXT_MAX,
+              ),
+              emoji: true,
+            },
+            options: options.map((option) => ({
+              text: {
+                type: "plain_text",
+                text: truncateSlackText(option.label, SLACK_PLAIN_TEXT_MAX),
+                emoji: true,
+              },
+              value: option.value,
+            })),
+          },
+        ],
+      }
+    : undefined;
 }

--- a/extensions/slack/src/blocks-render.ts
+++ b/extensions/slack/src/blocks-render.ts
@@ -63,6 +63,7 @@ function readSlackOpenClawBlockIndex(blockId: string, prefix: string): number | 
   return Number.isSafeInteger(value) && value > 0 ? value : undefined;
 }
 
+/** Resolve existing OpenClaw Block Kit indexes so appended controls keep stable unique IDs. */
 export function resolveSlackInteractiveBlockOffsets(
   blocks?: readonly SlackBlock[],
 ): SlackInteractiveBlockRenderOptions {
@@ -189,6 +190,7 @@ export function buildSlackInteractiveBlocks(
   }).blocks;
 }
 
+/** Render portable presentation blocks as Slack Block Kit blocks. */
 export function buildSlackPresentationBlocks(
   presentation?: MessagePresentation,
   options: SlackInteractiveBlockRenderOptions = {},

--- a/extensions/slack/src/blocks-render.ts
+++ b/extensions/slack/src/blocks-render.ts
@@ -85,6 +85,9 @@ export function resolveSlackInteractiveBlockOffsets(
   return { buttonIndexOffset, selectIndexOffset };
 }
 
+/**
+ * @deprecated Use buildSlackPresentationBlocks with MessagePresentation.
+ */
 export function buildSlackInteractiveBlocks(
   interactive?: InteractiveReply,
   options: SlackInteractiveBlockRenderOptions = {},

--- a/extensions/slack/src/interactive-replies.ts
+++ b/extensions/slack/src/interactive-replies.ts
@@ -162,6 +162,9 @@ function resolveInteractiveRepliesFromCapabilities(capabilities: unknown): boole
   return false;
 }
 
+/**
+ * @deprecated Only needed for legacy Slack reply directives. New producers should emit presentation payloads.
+ */
 export function isSlackInteractiveRepliesEnabled(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
@@ -173,6 +176,9 @@ export function isSlackInteractiveRepliesEnabled(params: {
   return resolveInteractiveRepliesFromCapabilities(account.config.capabilities);
 }
 
+/**
+ * @deprecated Slack reply directives are legacy. New producers should emit presentation payloads.
+ */
 export function compileSlackInteractiveReplies(payload: ReplyPayload): ReplyPayload {
   const text = payload.text;
   if (!text) {
@@ -230,6 +236,9 @@ export function compileSlackInteractiveReplies(payload: ReplyPayload): ReplyPayl
   };
 }
 
+/**
+ * @deprecated Legacy Slack directive fallback. New producers should emit presentation payloads.
+ */
 export function parseSlackOptionsLine(payload: ReplyPayload): ReplyPayload {
   const text = payload.text;
   if (!text || payload.interactive?.blocks?.length || hasSlackBlocks(payload)) {

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -150,6 +150,25 @@ export const slackOutbound: ChannelOutboundAdapter = {
     selects: true,
     context: true,
     divider: true,
+    limits: {
+      actions: {
+        maxActionsPerRow: 25,
+        maxLabelLength: 75,
+        maxValueBytes: 2000,
+        supportsStyles: true,
+      },
+      selects: {
+        maxOptions: 100,
+        maxLabelLength: 75,
+        maxValueBytes: 150,
+      },
+      text: {
+        maxLength: SLACK_TEXT_LIMIT,
+        encoding: "characters",
+        markdownDialect: "slack-mrkdwn",
+        supportsEdit: true,
+      },
+    },
   },
   renderPresentation: ({ payload, presentation }) => {
     const slackData = payload.channelData?.slack as Record<string, unknown> | undefined;

--- a/extensions/slack/src/outbound-adapter.ts
+++ b/extensions/slack/src/outbound-adapter.ts
@@ -173,16 +173,20 @@ export const slackOutbound: ChannelOutboundAdapter = {
   renderPresentation: ({ payload, presentation }) => {
     const slackData = payload.channelData?.slack as Record<string, unknown> | undefined;
     const nativeBlocks = parseSlackBlocksInput(slackData?.blocks) as SlackBlock[] | undefined;
+    const presentationBlocks = buildSlackPresentationBlocks(
+      presentation,
+      resolveSlackInteractiveBlockOffsets(nativeBlocks),
+    );
+    if (presentationBlocks.length === 0) {
+      return null;
+    }
     return {
       ...payload,
       channelData: {
         ...payload.channelData,
         slack: {
           ...slackData,
-          presentationBlocks: buildSlackPresentationBlocks(
-            presentation,
-            resolveSlackInteractiveBlockOffsets(nativeBlocks),
-          ),
+          presentationBlocks,
         },
       },
     };

--- a/extensions/slack/src/outbound-payload.test.ts
+++ b/extensions/slack/src/outbound-payload.test.ts
@@ -1,7 +1,7 @@
 import { installChannelOutboundPayloadContractSuite } from "openclaw/plugin-sdk/channel-contract-testing";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { describe, expect, it } from "vitest";
-import { createSlackOutboundPayloadHarness } from "../test-api.js";
+import { createSlackOutboundPayloadHarness, slackOutbound } from "../test-api.js";
 
 function createHarness(params: {
   payload: ReplyPayload;
@@ -62,6 +62,32 @@ describe("slackOutbound sendPayload", () => {
     expect(sendOptions(call).blocks).toEqual([{ type: "divider" }]);
     expect(result.channel).toBe("slack");
     expect(result.messageId).toBe("sl-1");
+  });
+
+  it("keeps the portable fallback when presentation renders no Slack blocks", async () => {
+    const payload: ReplyPayload = {
+      presentation: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [{ label: "Launch", webApp: { url: "https://example.com/app" } }],
+          },
+        ],
+      },
+    };
+
+    const rendered = await slackOutbound.renderPresentation?.({
+      payload,
+      presentation: payload.presentation!,
+      ctx: {
+        cfg: {},
+        to: "C12345",
+        text: "",
+        payload,
+      },
+    });
+
+    expect(rendered).toBeNull();
   });
 
   it("sends media before a separate interactive blocks message", async () => {

--- a/extensions/slack/src/reply-blocks.ts
+++ b/extensions/slack/src/reply-blocks.ts
@@ -1,16 +1,28 @@
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { parseSlackBlocksInput, SLACK_MAX_BLOCKS } from "./blocks-input.js";
-import { buildSlackInteractiveBlocks, type SlackBlock } from "./blocks-render.js";
+import {
+  buildSlackInteractiveBlocks,
+  buildSlackPresentationBlocks,
+  resolveSlackInteractiveBlockOffsets,
+  type SlackBlock,
+} from "./blocks-render.js";
 
 export function resolveSlackReplyBlocks(payload: ReplyPayload): SlackBlock[] | undefined {
   const slackData = payload.channelData?.slack;
-  const interactiveBlocks = buildSlackInteractiveBlocks(payload.interactive);
   let channelBlocks: SlackBlock[] = [];
   if (slackData && typeof slackData === "object" && !Array.isArray(slackData)) {
     channelBlocks =
       (parseSlackBlocksInput((slackData as { blocks?: unknown }).blocks) as SlackBlock[]) ?? [];
   }
-  const blocks = [...channelBlocks, ...interactiveBlocks];
+  const presentationBlocks = buildSlackPresentationBlocks(
+    payload.presentation,
+    resolveSlackInteractiveBlockOffsets(channelBlocks),
+  );
+  const interactiveBlocks = buildSlackInteractiveBlocks(
+    payload.interactive,
+    resolveSlackInteractiveBlockOffsets([...channelBlocks, ...presentationBlocks]),
+  );
+  const blocks = [...channelBlocks, ...presentationBlocks, ...interactiveBlocks];
   if (blocks.length > SLACK_MAX_BLOCKS) {
     throw new Error(
       `Slack blocks cannot exceed ${SLACK_MAX_BLOCKS} items after interactive render`,

--- a/extensions/slack/src/shared-interactive.test.ts
+++ b/extensions/slack/src/shared-interactive.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { buildSlackInteractiveBlocks } from "./blocks-render.js";
+import { buildSlackInteractiveBlocks, buildSlackPresentationBlocks } from "./blocks-render.js";
+import { resolveSlackReplyBlocks } from "./reply-blocks.js";
 
 describe("buildSlackInteractiveBlocks", () => {
   it("renders shared interactive blocks in authored order", () => {
@@ -304,5 +305,89 @@ describe("buildSlackInteractiveBlocks", () => {
     expect(buttonBlock.elements?.[1]?.style).toBe("danger");
     expect(buttonBlock.elements?.[2]?.style).toBe("primary");
     expect(buttonBlock.elements?.[3]).not.toHaveProperty("style");
+  });
+});
+
+describe("buildSlackPresentationBlocks", () => {
+  it("renders presentation controls without requiring legacy interactive payloads", () => {
+    const blocks = buildSlackPresentationBlocks({
+      blocks: [
+        { type: "text", text: "Pick" },
+        {
+          type: "buttons",
+          buttons: [{ label: "Approve", value: "approve", style: "success" }],
+        },
+      ],
+    });
+
+    expect(blocks).toEqual([
+      {
+        type: "section",
+        text: { type: "mrkdwn", text: "Pick" },
+      },
+      {
+        type: "actions",
+        block_id: "openclaw_reply_buttons_1",
+        elements: [
+          {
+            type: "button",
+            action_id: "openclaw:reply_button:1:1",
+            text: {
+              type: "plain_text",
+              text: "Approve",
+              emoji: true,
+            },
+            value: "approve",
+            style: "primary",
+          },
+        ],
+      },
+    ]);
+  });
+});
+
+describe("resolveSlackReplyBlocks", () => {
+  it("offsets legacy interactive blocks after channel and presentation controls", () => {
+    const blocks = resolveSlackReplyBlocks({
+      channelData: {
+        slack: {
+          blocks: [
+            {
+              type: "actions",
+              block_id: "openclaw_reply_buttons_1",
+              elements: [],
+            },
+          ],
+        },
+      },
+      presentation: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [{ label: "Stage", value: "stage" }],
+          },
+        ],
+      },
+      interactive: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [{ label: "Approve", value: "approve" }],
+          },
+        ],
+      },
+    });
+
+    const presentationButtonBlock = blocks?.[1] as
+      | { elements?: Array<{ action_id?: string }> }
+      | undefined;
+    const legacyButtonBlock = blocks?.[2] as
+      | { elements?: Array<{ action_id?: string }> }
+      | undefined;
+    expect(blocks?.[0]?.block_id).toBe("openclaw_reply_buttons_1");
+    expect(blocks?.[1]?.block_id).toBe("openclaw_reply_buttons_2");
+    expect(presentationButtonBlock?.elements?.[0]?.action_id).toBe("openclaw:reply_button:2:1");
+    expect(blocks?.[2]?.block_id).toBe("openclaw_reply_buttons_3");
+    expect(legacyButtonBlock?.elements?.[0]?.action_id).toBe("openclaw:reply_button:3:1");
   });
 });

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -13,7 +13,6 @@ import {
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   normalizeMessagePresentation,
-  presentationToInteractiveReply,
   renderMessagePresentationFallbackText,
 } from "openclaw/plugin-sdk/interactive-runtime";
 import type { MessagePresentation } from "openclaw/plugin-sdk/interactive-runtime";
@@ -138,7 +137,8 @@ function resolveTelegramButtonsFromParams(
   presentation = normalizeMessagePresentation(params.presentation),
 ) {
   return resolveTelegramInlineButtons({
-    interactive: presentation ? presentationToInteractiveReply(presentation) : params.interactive,
+    presentation,
+    interactive: params.interactive,
   });
 }
 

--- a/extensions/telegram/src/approval-handler.runtime.ts
+++ b/extensions/telegram/src/approval-handler.runtime.ts
@@ -6,7 +6,7 @@ import { createChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/a
 import { buildChannelApprovalNativeTargetKey } from "openclaw/plugin-sdk/approval-native-runtime";
 import { buildPluginApprovalPendingReplyPayload } from "openclaw/plugin-sdk/approval-reply-runtime";
 import {
-  buildApprovalInteractiveReplyFromActionDescriptors,
+  buildApprovalPresentationFromActionDescriptors,
   buildExecApprovalPendingReplyPayload,
 } from "openclaw/plugin-sdk/approval-reply-runtime";
 import type { ExecApprovalPendingReplyParams } from "openclaw/plugin-sdk/approval-reply-runtime";
@@ -92,7 +92,7 @@ function buildPendingPayload(params: {
   return {
     text: payload.text ?? "",
     buttons: resolveTelegramInlineButtons({
-      interactive: buildApprovalInteractiveReplyFromActionDescriptors(params.view.actions),
+      presentation: buildApprovalPresentationFromActionDescriptors(params.view.actions),
     }),
   };
 }

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -36,10 +36,7 @@ import type {
 } from "openclaw/plugin-sdk/config-contracts";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { runInboundReplyTurn } from "openclaw/plugin-sdk/inbound-reply-dispatch";
-import {
-  normalizeMessagePresentation,
-  presentationToInteractiveReply,
-} from "openclaw/plugin-sdk/interactive-runtime";
+import { normalizeMessagePresentation } from "openclaw/plugin-sdk/interactive-runtime";
 import {
   createOutboundPayloadPlan,
   projectOutboundPayloadPlanForDelivery,
@@ -145,12 +142,10 @@ function resolvePayloadTelegramInlineButtons(
     | { buttons?: TelegramInlineButtons }
     | undefined;
   const presentation = normalizeMessagePresentation(payload.presentation);
-  const interactive =
-    payload.interactive ??
-    (presentation ? presentationToInteractiveReply(presentation) : undefined);
   return resolveTelegramInlineButtons({
     buttons: telegramData?.buttons,
-    interactive,
+    presentation,
+    interactive: payload.interactive,
   });
 }
 

--- a/extensions/telegram/src/bot-native-commands.test.ts
+++ b/extensions/telegram/src/bot-native-commands.test.ts
@@ -543,6 +543,37 @@ describe("registerTelegramNativeCommands", () => {
     expect(replyAt(firstDeliverRepliesParams()).mediaUrl).toBe("/tmp/render.png");
   });
 
+  it("falls back to a normal reply when a progress result has presentation controls", async () => {
+    const presentation = {
+      blocks: [
+        {
+          kind: "actions",
+          buttons: [{ label: "Approve", action: { type: "command", value: "/approve yes" } }],
+        },
+      ],
+    };
+    const { handler, sendMessage, deleteMessage } = registerPlugCommand({
+      args: "now",
+      command: {
+        nativeProgressMessages: { telegram: "Working on it..." },
+      },
+      result: {
+        text: "Approval required",
+        presentation,
+      },
+    });
+
+    await handler(createPrivateCommandContext({ match: "now" }));
+
+    expect(sendMessage).toHaveBeenCalledWith(100, "Working on it...", undefined);
+    expect(editMessageTelegram).not.toHaveBeenCalled();
+    expect(deleteMessage).toHaveBeenCalledWith(100, 999);
+    expect(replyAt(firstDeliverRepliesParams())).toMatchObject({
+      text: "Approval required",
+      presentation,
+    });
+  });
+
   it("cleans up the progress placeholder before falling back after an edit failure", async () => {
     const { handler, sendMessage, deleteMessage } = registerPlugCommand({
       args: "now",

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -333,6 +333,7 @@ function isEditableTelegramProgressResult(result: TelegramNativeReplyPayload): b
     result.text.trim() &&
     !result.mediaUrl &&
     (!result.mediaUrls || result.mediaUrls.length === 0) &&
+    !result.presentation &&
     !result.interactive &&
     !result.btw &&
     telegramData?.pin !== true,

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -10,10 +10,7 @@ import {
   toPluginMessageSentEvent,
 } from "openclaw/plugin-sdk/hook-runtime";
 import type { ReplyPayloadDelivery } from "openclaw/plugin-sdk/interactive-runtime";
-import {
-  normalizeMessagePresentation,
-  presentationToInteractiveReply,
-} from "openclaw/plugin-sdk/interactive-runtime";
+import { normalizeMessagePresentation } from "openclaw/plugin-sdk/interactive-runtime";
 import {
   buildOutboundMediaLoadOptions,
   isGifMedia,
@@ -773,9 +770,7 @@ export async function deliverReplies(params: {
         : [];
     const hasMedia = mediaList.length > 0;
     const presentation = normalizeMessagePresentation(reply?.presentation);
-    const interactive =
-      reply?.interactive ??
-      (presentation ? presentationToInteractiveReply(presentation) : undefined);
+    const interactive = reply?.interactive;
     const resolvedReplyText =
       resolveTelegramInteractiveTextFallback({
         text: reply?.text,
@@ -850,6 +845,7 @@ export async function deliverReplies(params: {
       const replyMarkup = buildInlineKeyboard(
         resolveTelegramInlineButtons({
           buttons: telegramData?.buttons,
+          presentation,
           interactive,
         }),
       );

--- a/extensions/telegram/src/button-types.test-helpers.ts
+++ b/extensions/telegram/src/button-types.test-helpers.ts
@@ -81,5 +81,28 @@ export function describeTelegramInteractiveButtonBehavior(): void {
         ],
       ]);
     });
+
+    it("prefers legacy interactive buttons over generic presentation buttons", () => {
+      expect(
+        resolveTelegramInlineButtons({
+          presentation: {
+            blocks: [
+              {
+                type: "buttons",
+                buttons: [{ label: "Generic", value: "generic" }],
+              },
+            ],
+          },
+          interactive: {
+            blocks: [
+              {
+                type: "buttons",
+                buttons: [{ label: "Legacy", value: "legacy" }],
+              },
+            ],
+          },
+        }),
+      ).toEqual([[{ text: "Legacy", callback_data: "legacy", style: undefined }]]);
+    });
   });
 }

--- a/extensions/telegram/src/button-types.test.ts
+++ b/extensions/telegram/src/button-types.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { buildTelegramInteractiveButtons } from "./button-types.js";
+import {
+  buildTelegramInteractiveButtons,
+  buildTelegramPresentationButtons,
+} from "./button-types.js";
 import { describeTelegramInteractiveButtonBehavior } from "./button-types.test-helpers.js";
 
 describeTelegramInteractiveButtonBehavior();
@@ -19,5 +22,29 @@ describe("buildTelegramInteractiveButtons callback limits", () => {
         ],
       }),
     ).toEqual([[{ text: "Keep", callback_data: "ok", style: undefined }]]);
+  });
+});
+
+describe("buildTelegramPresentationButtons", () => {
+  it("builds inline buttons from presentation blocks", () => {
+    expect(
+      buildTelegramPresentationButtons({
+        blocks: [
+          { type: "text", text: "Choose" },
+          {
+            type: "buttons",
+            buttons: [{ label: "Approve", value: "/approve req-1 allow-once", style: "success" }],
+          },
+        ],
+      }),
+    ).toEqual([
+      [
+        {
+          text: "Approve",
+          callback_data: "/approve req-1 allow-once",
+          style: "success",
+        },
+      ],
+    ]);
   });
 });

--- a/extensions/telegram/src/button-types.ts
+++ b/extensions/telegram/src/button-types.ts
@@ -99,6 +99,7 @@ export function buildTelegramInteractiveButtons(
   return rows.length > 0 ? rows : undefined;
 }
 
+/** Convert portable presentation controls to Telegram inline keyboard rows. */
 export function buildTelegramPresentationButtons(
   presentation?: MessagePresentation,
 ): TelegramInlineButtons | undefined {
@@ -122,6 +123,7 @@ export function buildTelegramPresentationButtons(
   return rows.length > 0 ? rows : undefined;
 }
 
+/** Resolve Telegram inline buttons, preserving explicit and legacy button precedence. */
 export function resolveTelegramInlineButtons(params: {
   buttons?: TelegramInlineButtons;
   presentation?: unknown;

--- a/extensions/telegram/src/button-types.ts
+++ b/extensions/telegram/src/button-types.ts
@@ -73,6 +73,9 @@ function chunkInteractiveButtons(
   }
 }
 
+/**
+ * @deprecated Use buildTelegramPresentationButtons with MessagePresentation.
+ */
 export function buildTelegramInteractiveButtons(
   interactive?: InteractiveReply,
 ): TelegramInlineButtons | undefined {

--- a/extensions/telegram/src/button-types.ts
+++ b/extensions/telegram/src/button-types.ts
@@ -1,8 +1,11 @@
 import { reduceInteractiveReply } from "openclaw/plugin-sdk/interactive-runtime";
 import {
+  isMessagePresentationInteractiveBlock,
+  normalizeMessagePresentation,
   normalizeInteractiveReply,
   type InteractiveReply,
-  type InteractiveReplyButton,
+  type MessagePresentation,
+  type MessagePresentationButton,
 } from "openclaw/plugin-sdk/interactive-runtime";
 import { sanitizeTelegramCallbackData } from "./approval-callback-data.js";
 
@@ -21,12 +24,14 @@ export type TelegramInlineButtons = ReadonlyArray<ReadonlyArray<TelegramInlineBu
 const TELEGRAM_INTERACTIVE_ROW_SIZE = 3;
 
 function toTelegramButtonStyle(
-  style?: InteractiveReplyButton["style"],
+  style?: MessagePresentationButton["style"],
 ): TelegramInlineButton["style"] {
   return style === "danger" || style === "success" || style === "primary" ? style : undefined;
 }
 
-function toTelegramInlineButton(button: InteractiveReplyButton): TelegramInlineButton | undefined {
+function toTelegramInlineButton(
+  button: MessagePresentationButton,
+): TelegramInlineButton | undefined {
   const style = toTelegramButtonStyle(button.style);
   if (button.url) {
     return {
@@ -54,7 +59,7 @@ function toTelegramInlineButton(button: InteractiveReplyButton): TelegramInlineB
 }
 
 function chunkInteractiveButtons(
-  buttons: readonly InteractiveReplyButton[],
+  buttons: readonly MessagePresentationButton[],
   rows: TelegramInlineButton[][],
 ) {
   for (let i = 0; i < buttons.length; i += TELEGRAM_INTERACTIVE_ROW_SIZE) {
@@ -94,11 +99,37 @@ export function buildTelegramInteractiveButtons(
   return rows.length > 0 ? rows : undefined;
 }
 
+export function buildTelegramPresentationButtons(
+  presentation?: MessagePresentation,
+): TelegramInlineButtons | undefined {
+  const rows: TelegramInlineButton[][] = [];
+  for (const block of presentation?.blocks ?? []) {
+    if (!isMessagePresentationInteractiveBlock(block)) {
+      continue;
+    }
+    if (block.type === "buttons") {
+      chunkInteractiveButtons(block.buttons, rows);
+      continue;
+    }
+    chunkInteractiveButtons(
+      block.options.map((option) => ({
+        label: option.label,
+        value: option.value,
+      })),
+      rows,
+    );
+  }
+  return rows.length > 0 ? rows : undefined;
+}
+
 export function resolveTelegramInlineButtons(params: {
   buttons?: TelegramInlineButtons;
+  presentation?: unknown;
   interactive?: unknown;
 }): TelegramInlineButtons | undefined {
   return (
-    params.buttons ?? buildTelegramInteractiveButtons(normalizeInteractiveReply(params.interactive))
+    params.buttons ??
+    buildTelegramInteractiveButtons(normalizeInteractiveReply(params.interactive)) ??
+    buildTelegramPresentationButtons(normalizeMessagePresentation(params.presentation))
   );
 }

--- a/extensions/telegram/src/outbound-adapter.test.ts
+++ b/extensions/telegram/src/outbound-adapter.test.ts
@@ -242,6 +242,48 @@ describe("telegramOutbound", () => {
     ]);
   });
 
+  it("preserves legacy interactive buttons when rendering mixed presentation payloads", async () => {
+    sendMessageTelegramMock.mockResolvedValueOnce({
+      messageId: "tg-mixed-buttons",
+      chatId: "12345",
+    });
+    const rendered = await telegramOutbound.renderPresentation?.({
+      payload: {
+        text: "Choose:",
+        interactive: {
+          blocks: [{ type: "buttons", buttons: [{ label: "Legacy", value: "legacy" }] }],
+        },
+      },
+      presentation: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [{ label: "Generic", value: "generic" }],
+          },
+        ],
+      },
+      ctx: {} as never,
+    });
+    if (!rendered) {
+      throw new Error("expected rendered Telegram presentation");
+    }
+
+    expect((rendered.channelData?.telegram as { buttons?: unknown } | undefined)?.buttons).toBe(
+      undefined,
+    );
+
+    await telegramOutbound.sendPayload!({
+      cfg: {} as never,
+      to: "12345",
+      text: "",
+      payload: rendered,
+      deps: { sendTelegram: sendMessageTelegramMock },
+    });
+
+    const options = callOptionsAt(sendMessageTelegramMock, 0, "12345", "Choose:\n\n- Generic");
+    expect(options.buttons).toEqual([[{ text: "Legacy", callback_data: "legacy" }]]);
+  });
+
   it("lets allow-always approval callbacks reach Telegram's callback rewrite", async () => {
     sendMessageTelegramMock.mockResolvedValueOnce({
       messageId: "tg-approval",

--- a/extensions/telegram/src/outbound-adapter.test.ts
+++ b/extensions/telegram/src/outbound-adapter.test.ts
@@ -335,8 +335,8 @@ describe("telegramOutbound", () => {
     ]);
   });
 
-  it("counts presentation text limits in characters", () => {
-    const text = "👍".repeat(3000);
+  it("leaves long presentation text for Telegram chunking", () => {
+    const text = "👍".repeat(5000);
     const presentation = adaptMessagePresentationForChannel({
       presentation: { blocks: [{ type: "text", text }] },
       capabilities: telegramOutbound.presentationCapabilities,

--- a/extensions/telegram/src/outbound-adapter.test.ts
+++ b/extensions/telegram/src/outbound-adapter.test.ts
@@ -216,6 +216,32 @@ describe("telegramOutbound", () => {
     ]);
   });
 
+  it("preserves explicit Telegram buttons when rendering presentation payloads", async () => {
+    const rendered = await telegramOutbound.renderPresentation?.({
+      payload: {
+        text: "Use native buttons:",
+        channelData: {
+          telegram: {
+            buttons: [[{ text: "Native", callback_data: "native" }]],
+          },
+        },
+      },
+      presentation: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [{ label: "Generic", value: "generic" }],
+          },
+        ],
+      },
+      ctx: {} as never,
+    });
+
+    expect((rendered?.channelData?.telegram as { buttons?: unknown })?.buttons).toEqual([
+      [{ text: "Native", callback_data: "native" }],
+    ]);
+  });
+
   it("lets allow-always approval callbacks reach Telegram's callback rewrite", async () => {
     sendMessageTelegramMock.mockResolvedValueOnce({
       messageId: "tg-approval",

--- a/extensions/telegram/src/outbound-adapter.test.ts
+++ b/extensions/telegram/src/outbound-adapter.test.ts
@@ -1,4 +1,5 @@
 import { verifyDurableFinalCapabilityProofs } from "openclaw/plugin-sdk/channel-message";
+import { adaptMessagePresentationForChannel } from "openclaw/plugin-sdk/interactive-runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const sendMessageTelegramMock = vi.fn();
@@ -213,6 +214,67 @@ describe("telegramOutbound", () => {
     expect(options.buttons).toEqual([
       [{ text: "Launch", web_app: { url: "https://example.com/app" } }],
     ]);
+  });
+
+  it("lets allow-always approval callbacks reach Telegram's callback rewrite", async () => {
+    sendMessageTelegramMock.mockResolvedValueOnce({
+      messageId: "tg-approval",
+      chatId: "12345",
+    });
+    const approvalId = "plugin:123e4567-e89b-12d3-a456-426614174000";
+    const presentation = adaptMessagePresentationForChannel({
+      presentation: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [
+              {
+                label: "Allow Always",
+                value: `/approve ${approvalId} allow-always`,
+              },
+            ],
+          },
+        ],
+      },
+      capabilities: telegramOutbound.presentationCapabilities,
+    });
+
+    const rendered = await telegramOutbound.renderPresentation?.({
+      payload: { text: "Approve?" },
+      presentation,
+      ctx: {} as never,
+    });
+    if (!rendered) {
+      throw new Error("expected rendered Telegram approval presentation");
+    }
+
+    await telegramOutbound.sendPayload!({
+      cfg: {} as never,
+      to: "12345",
+      text: "",
+      payload: rendered,
+      deps: { sendTelegram: sendMessageTelegramMock },
+    });
+
+    const options = callOptionsAt(
+      sendMessageTelegramMock,
+      0,
+      "12345",
+      "Approve?\n\n- Allow Always",
+    );
+    expect(options.buttons).toEqual([
+      [{ text: "Allow Always", callback_data: `/approve ${approvalId} always` }],
+    ]);
+  });
+
+  it("counts presentation text limits in characters", () => {
+    const text = "👍".repeat(3000);
+    const presentation = adaptMessagePresentationForChannel({
+      presentation: { blocks: [{ type: "text", text }] },
+      capabilities: telegramOutbound.presentationCapabilities,
+    });
+
+    expect(presentation.blocks).toEqual([{ type: "text", text }]);
   });
 
   it("forwards silent delivery options to Telegram sends", async () => {

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -212,7 +212,7 @@ export function createTelegramOutboundAdapter(
     },
     renderPresentation: ({ payload, presentation }) => {
       const telegramData = payload.channelData?.telegram as Record<string, unknown> | undefined;
-      const hasExplicitButtons = telegramData && "buttons" in telegramData;
+      const hasExplicitButtons = (telegramData && "buttons" in telegramData) || payload.interactive;
       const buttons = hasExplicitButtons
         ? undefined
         : resolveTelegramInlineButtons({ presentation });

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -190,8 +190,6 @@ export function createTelegramOutboundAdapter(
           maxLabelLength: 64,
         },
         text: {
-          maxLength: TELEGRAM_TEXT_CHUNK_LIMIT,
-          encoding: "characters",
           markdownDialect: "html",
         },
       },

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -181,6 +181,23 @@ export function createTelegramOutboundAdapter(
       selects: true,
       context: true,
       divider: false,
+      limits: {
+        actions: {
+          maxActions: 100,
+          maxActionsPerRow: 3,
+          maxLabelLength: 64,
+          supportsStyles: false,
+        },
+        selects: {
+          maxOptions: 100,
+          maxLabelLength: 64,
+        },
+        text: {
+          maxLength: TELEGRAM_TEXT_CHUNK_LIMIT,
+          encoding: "characters",
+          markdownDialect: "html",
+        },
+      },
     },
     deliveryCapabilities: {
       pin: true,

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -5,7 +5,6 @@ import {
 } from "openclaw/plugin-sdk/channel-send-result";
 import {
   normalizeMessagePresentation,
-  presentationToInteractiveReply,
   renderMessagePresentationFallbackText,
 } from "openclaw/plugin-sdk/interactive-runtime";
 import type { OutboundDeliveryFormattingOptions } from "openclaw/plugin-sdk/outbound-runtime";
@@ -118,19 +117,17 @@ export async function sendTelegramPayloadMessages(params: {
   const quoteText =
     typeof telegramData?.quoteText === "string" ? telegramData.quoteText : undefined;
   const presentation = normalizeMessagePresentation(params.payload.presentation);
-  const interactive =
-    params.payload.interactive ??
-    (presentation ? presentationToInteractiveReply(presentation) : undefined);
   const text =
     resolveTelegramInteractiveTextFallback({
       text: params.payload.text,
-      interactive,
+      interactive: params.payload.interactive,
       presentation,
     }) ?? "";
   const mediaUrls = resolvePayloadMediaUrls(params.payload);
   const buttons = resolveTelegramInlineButtons({
     buttons: telegramData?.buttons,
-    interactive,
+    presentation,
+    interactive: params.payload.interactive,
   });
   const payloadOpts = {
     ...params.baseOpts,
@@ -213,11 +210,24 @@ export function createTelegramOutboundAdapter(
         batch: true,
       },
     },
-    renderPresentation: ({ payload, presentation }) => ({
-      ...payload,
-      text: renderMessagePresentationFallbackText({ text: payload.text, presentation }),
-      interactive: presentationToInteractiveReply(presentation),
-    }),
+    renderPresentation: ({ payload, presentation }) => {
+      const telegramData = payload.channelData?.telegram as Record<string, unknown> | undefined;
+      const hasExplicitButtons = telegramData && "buttons" in telegramData;
+      const buttons = hasExplicitButtons
+        ? undefined
+        : resolveTelegramInlineButtons({ presentation });
+      return {
+        ...payload,
+        text: renderMessagePresentationFallbackText({ text: payload.text, presentation }),
+        channelData: {
+          ...payload.channelData,
+          telegram: {
+            ...telegramData,
+            ...(buttons ? { buttons } : {}),
+          },
+        },
+      };
+    },
     pinDeliveredMessage: async ({ cfg, target, messageId, pin }) => {
       const { pinMessageTelegram } = await loadSendModule();
       await pinMessageTelegram(target.to, messageId, {

--- a/src/agents/runtime-plan/types.ts
+++ b/src/agents/runtime-plan/types.ts
@@ -82,15 +82,23 @@ export type AgentRuntimeProviderHandle = {
 
 export type AgentRuntimeInteractiveButtonStyle = "primary" | "secondary" | "success" | "danger";
 
+/** Portable action control exposed to agent runtime reply payloads. */
 export type AgentRuntimeMessagePresentationButton = {
+  /** User-visible button label. */
   label: string;
+  /** Callback command or opaque value sent when pressed. */
   value?: string;
+  /** External URL opened by the button. */
   url?: string;
+  /** Optional visual style hint for renderers that support styled actions. */
   style?: AgentRuntimeInteractiveButtonStyle;
 };
 
+/** Portable select/menu option exposed to agent runtime reply payloads. */
 export type AgentRuntimeMessagePresentationOption = {
+  /** User-visible option label. */
   label: string;
+  /** Callback command or opaque value sent when selected. */
   value: string;
 };
 
@@ -159,8 +167,11 @@ export type AgentRuntimeMessagePresentationBlock =
     };
 
 export type AgentRuntimeMessagePresentation = {
+  /** Optional short heading rendered before blocks when supported. */
   title?: string;
+  /** Optional severity/status tone for renderers that support toned presentations. */
   tone?: AgentRuntimeMessagePresentationTone;
+  /** Ordered portable blocks rendered or downgraded by channel adapters. */
   blocks: AgentRuntimeMessagePresentationBlock[];
 };
 

--- a/src/agents/runtime-plan/types.ts
+++ b/src/agents/runtime-plan/types.ts
@@ -90,6 +90,12 @@ export type AgentRuntimeMessagePresentationButton = {
   value?: string;
   /** External URL opened by the button. */
   url?: string;
+  /** Channel-native web app URL for renderers that support embedded web apps. */
+  webApp?: { url: string };
+  /** Higher values are kept first when channel action limits require dropping controls. */
+  priority?: number;
+  /** Disabled action hint; channels without disabled-state support render fallback text. */
+  disabled?: boolean;
   /** Optional visual style hint for renderers that support styled actions. */
   style?: AgentRuntimeInteractiveButtonStyle;
 };

--- a/src/agents/runtime-plan/types.ts
+++ b/src/agents/runtime-plan/types.ts
@@ -82,18 +82,31 @@ export type AgentRuntimeProviderHandle = {
 
 export type AgentRuntimeInteractiveButtonStyle = "primary" | "secondary" | "success" | "danger";
 
-export type AgentRuntimeInteractiveReplyButton = {
+export type AgentRuntimeMessagePresentationButton = {
   label: string;
   value?: string;
   url?: string;
   style?: AgentRuntimeInteractiveButtonStyle;
 };
 
-export type AgentRuntimeInteractiveReplyOption = {
+export type AgentRuntimeMessagePresentationOption = {
   label: string;
   value: string;
 };
 
+/**
+ * @deprecated Use AgentRuntimeMessagePresentationButton.
+ */
+export type AgentRuntimeInteractiveReplyButton = AgentRuntimeMessagePresentationButton;
+
+/**
+ * @deprecated Use AgentRuntimeMessagePresentationOption.
+ */
+export type AgentRuntimeInteractiveReplyOption = AgentRuntimeMessagePresentationOption;
+
+/**
+ * @deprecated Use AgentRuntimeMessagePresentationBlock.
+ */
 export type AgentRuntimeInteractiveReplyBlock =
   | {
       type: "text";
@@ -109,6 +122,9 @@ export type AgentRuntimeInteractiveReplyBlock =
       options: AgentRuntimeInteractiveReplyOption[];
     };
 
+/**
+ * @deprecated Use AgentRuntimeMessagePresentation.
+ */
 export type AgentRuntimeInteractiveReply = {
   blocks: AgentRuntimeInteractiveReplyBlock[];
 };
@@ -134,12 +150,12 @@ export type AgentRuntimeMessagePresentationBlock =
     }
   | {
       type: "buttons";
-      buttons: AgentRuntimeInteractiveReplyButton[];
+      buttons: AgentRuntimeMessagePresentationButton[];
     }
   | {
       type: "select";
       placeholder?: string;
-      options: AgentRuntimeInteractiveReplyOption[];
+      options: AgentRuntimeMessagePresentationOption[];
     };
 
 export type AgentRuntimeMessagePresentation = {
@@ -166,6 +182,9 @@ export type AgentRuntimeReplyPayload = {
   sensitiveMedia?: boolean;
   presentation?: AgentRuntimeMessagePresentation;
   delivery?: AgentRuntimeReplyPayloadDelivery;
+  /**
+   * @deprecated Use presentation.
+   */
   interactive?: AgentRuntimeInteractiveReply;
   btw?: {
     question: string;

--- a/src/channels/plugins/outbound.types.ts
+++ b/src/channels/plugins/outbound.types.ts
@@ -42,31 +42,52 @@ export type ChannelOutboundPayloadContext = ChannelOutboundContext & {
 };
 
 export type ChannelPresentationCapabilities = {
+  /** Whether the channel accepts structured presentation payloads at all. */
   supported?: boolean;
+  /** Whether the channel can render button action blocks natively. */
   buttons?: boolean;
+  /** Whether the channel can render select/menu blocks natively. */
   selects?: boolean;
+  /** Whether the channel can render low-emphasis context blocks natively. */
   context?: boolean;
+  /** Whether the channel can render divider blocks natively. */
   divider?: boolean;
+  /** Per-channel limits used to adapt portable presentation blocks before rendering. */
   limits?: {
     actions?: {
+      /** Maximum total button/select actions in one message. */
       maxActions?: number;
+      /** Maximum buttons per rendered action row. */
       maxActionsPerRow?: number;
+      /** Maximum action rows in one message. */
       maxRows?: number;
+      /** Maximum user-visible button label length. */
       maxLabelLength?: number;
+      /** Maximum callback/action value size in UTF-8 bytes. */
       maxValueBytes?: number;
+      /** Whether action styles such as primary or danger are preserved. */
       supportsStyles?: boolean;
+      /** Whether disabled button state is preserved. */
       supportsDisabled?: boolean;
+      /** Whether priority/layout hints affect native rendering. */
       supportsLayoutHints?: boolean;
     };
     selects?: {
+      /** Maximum options in one select/menu block. */
       maxOptions?: number;
+      /** Maximum user-visible option label length. */
       maxLabelLength?: number;
+      /** Maximum option callback value size in UTF-8 bytes. */
       maxValueBytes?: number;
     };
     text?: {
+      /** Maximum text length for title, text, and context blocks. */
       maxLength?: number;
+      /** Unit used by maxLength. Defaults to Unicode code points. */
       encoding?: "characters" | "utf8-bytes" | "utf16-units";
+      /** Markdown dialect understood by rendered text blocks. */
       markdownDialect?: "plain" | "markdown" | "html" | "slack-mrkdwn" | "discord-markdown";
+      /** Whether the channel can edit presentation text in-place. */
       supportsEdit?: boolean;
     };
   };
@@ -157,8 +178,10 @@ export type ChannelOutboundAdapter = {
     payload: ReplyPayload;
     results: readonly OutboundDeliveryResult[];
   }) => Promise<void> | void;
+  /** Channel-advertised presentation features and limits used by core adaptation. */
   presentationCapabilities?: ChannelPresentationCapabilities;
   deliveryCapabilities?: ChannelDeliveryCapabilities;
+  /** Render an adapted portable presentation into channel-native payload data. */
   renderPresentation?: (params: {
     payload: ReplyPayload;
     presentation: MessagePresentation;

--- a/src/channels/plugins/outbound.types.ts
+++ b/src/channels/plugins/outbound.types.ts
@@ -47,6 +47,29 @@ export type ChannelPresentationCapabilities = {
   selects?: boolean;
   context?: boolean;
   divider?: boolean;
+  limits?: {
+    actions?: {
+      maxActions?: number;
+      maxActionsPerRow?: number;
+      maxRows?: number;
+      maxLabelLength?: number;
+      maxValueBytes?: number;
+      supportsStyles?: boolean;
+      supportsDisabled?: boolean;
+      supportsLayoutHints?: boolean;
+    };
+    selects?: {
+      maxOptions?: number;
+      maxLabelLength?: number;
+      maxValueBytes?: number;
+    };
+    text?: {
+      maxLength?: number;
+      encoding?: "characters" | "utf8-bytes" | "utf16-units";
+      markdownDialect?: "plain" | "markdown" | "html" | "slack-mrkdwn" | "discord-markdown";
+      supportsEdit?: boolean;
+    };
+  };
 };
 
 export type ChannelDeliveryCapabilities = {

--- a/src/channels/plugins/outbound/interactive.test.ts
+++ b/src/channels/plugins/outbound/interactive.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { reduceInteractiveReply } from "./interactive.js";
+import {
+  adaptMessagePresentationForChannel,
+  applyPresentationActionLimits,
+  presentationPageSize,
+  reduceInteractiveReply,
+} from "./interactive.js";
 
 describe("reduceInteractiveReply", () => {
   it("walks authored blocks in order", () => {
@@ -23,5 +28,678 @@ describe("reduceInteractiveReply", () => {
 
   it("returns the initial state when interactive payload is missing", () => {
     expect(reduceInteractiveReply(undefined, 3, (value) => value + 1)).toBe(3);
+  });
+});
+
+describe("presentation capability limits", () => {
+  it("keeps highest-priority buttons inside action capacity", () => {
+    const buttons = applyPresentationActionLimits(
+      [
+        { label: "Low", value: "low", priority: -1 },
+        { label: "Default", value: "default" },
+        { label: "High", value: "high", priority: 10 },
+        { label: "Next", value: "next", priority: 5 },
+      ],
+      {
+        limits: {
+          actions: {
+            maxActions: 2,
+            maxLabelLength: 4,
+            supportsStyles: false,
+          },
+        },
+      },
+    );
+
+    expect(buttons).toEqual([
+      { label: "High", value: "high", priority: 10 },
+      { label: "Next", value: "next", priority: 5 },
+    ]);
+  });
+
+  it("keeps authored button order when nothing is dropped", () => {
+    const buttons = applyPresentationActionLimits(
+      [
+        { label: "First", value: "first", priority: 1 },
+        { label: "Second", value: "second", priority: 100 },
+        { label: "Third", value: "third" },
+      ],
+      {
+        limits: {
+          actions: {
+            maxActionsPerRow: 5,
+          },
+        },
+      },
+    );
+
+    expect(buttons).toEqual([
+      { label: "First", value: "first", priority: 1 },
+      { label: "Second", value: "second", priority: 100 },
+      { label: "Third", value: "third" },
+    ]);
+  });
+
+  it("adapts button and select blocks without touching text blocks", () => {
+    const presentation = adaptMessagePresentationForChannel({
+      presentation: {
+        title: "Deploy",
+        blocks: [
+          { type: "text", text: "Ready" },
+          {
+            type: "buttons",
+            buttons: [
+              {
+                label: "Approve deployment",
+                value: "approve",
+                style: "success",
+              },
+              { label: "Reject", value: "x".repeat(12), priority: 10 },
+            ],
+          },
+          {
+            type: "select",
+            placeholder: "Environment target",
+            options: [
+              { label: "Canary cluster", value: "canary" },
+              { label: "Production cluster", value: "production" },
+            ],
+          },
+        ],
+      },
+      capabilities: {
+        limits: {
+          actions: {
+            maxActions: 2,
+            maxLabelLength: 7,
+            maxValueBytes: 8,
+            supportsStyles: false,
+            supportsDisabled: false,
+          },
+          selects: {
+            maxOptions: 1,
+            maxLabelLength: 6,
+            maxValueBytes: 20,
+          },
+        },
+      },
+    });
+
+    expect(presentation).toEqual({
+      title: "Deploy",
+      blocks: [
+        { type: "text", text: "Ready" },
+        {
+          type: "buttons",
+          buttons: [{ label: "Approve", value: "approve" }],
+        },
+        { type: "context", text: "Actions:\n- Reject" },
+        {
+          type: "select",
+          placeholder: "Enviro",
+          options: [{ label: "Canary", value: "canary" }],
+        },
+        { type: "context", text: "Environment target:\n- Produc" },
+      ],
+    });
+  });
+
+  it("keeps visible fallback labels when controls exceed channel value limits", () => {
+    const presentation = adaptMessagePresentationForChannel({
+      presentation: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [
+              { label: "Approve deployment", value: "approve-prod" },
+              { label: "Rollback deployment", value: "rollback-prod" },
+            ],
+          },
+          {
+            type: "select",
+            placeholder: "Environment",
+            options: [
+              { label: "Canary cluster", value: "canary-target" },
+              { label: "Production cluster", value: "production-target" },
+            ],
+          },
+        ],
+      },
+      capabilities: {
+        limits: {
+          actions: {
+            maxValueBytes: 4,
+            maxLabelLength: 8,
+          },
+          selects: {
+            maxValueBytes: 4,
+            maxLabelLength: 7,
+          },
+        },
+      },
+    });
+
+    expect(presentation.blocks).toEqual([
+      { type: "context", text: "Actions:\n- Approve\n- Rollback" },
+      { type: "context", text: "Environment:\n- Canary\n- Product" },
+    ]);
+  });
+
+  it("keeps fallback labels for invalid buttons in mixed button blocks", () => {
+    const presentation = adaptMessagePresentationForChannel({
+      presentation: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [
+              { label: "Approve", value: "ok" },
+              { label: "Audit trail", value: "x".repeat(20) },
+              { label: "Docs", value: "x".repeat(20), url: "https://docs.example.test" },
+            ],
+          },
+        ],
+      },
+      capabilities: {
+        limits: {
+          actions: {
+            maxValueBytes: 4,
+          },
+        },
+      },
+    });
+
+    expect(presentation.blocks).toEqual([
+      {
+        type: "buttons",
+        buttons: [
+          { label: "Approve", value: "ok" },
+          { label: "Docs", url: "https://docs.example.test" },
+        ],
+      },
+      { type: "context", text: "Actions:\n- Audit trail" },
+    ]);
+  });
+
+  it("degrades disabled buttons unless the channel supports disabled controls", () => {
+    const unsupported = adaptMessagePresentationForChannel({
+      presentation: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [{ label: "Wait", value: "wait", disabled: true }],
+          },
+        ],
+      },
+      capabilities: {
+        limits: {
+          actions: {},
+        },
+      },
+    });
+    const supported = adaptMessagePresentationForChannel({
+      presentation: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [{ label: "Wait", value: "wait", disabled: true }],
+          },
+        ],
+      },
+      capabilities: {
+        limits: {
+          actions: {
+            supportsDisabled: true,
+          },
+        },
+      },
+    });
+
+    expect(unsupported.blocks).toEqual([{ type: "context", text: "Actions:\n- Wait" }]);
+    expect(supported.blocks).toEqual([
+      {
+        type: "buttons",
+        buttons: [{ label: "Wait", value: "wait", disabled: true }],
+      },
+    ]);
+  });
+
+  it("degrades unsupported controls before channel rendering", () => {
+    const presentation = adaptMessagePresentationForChannel({
+      presentation: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [{ label: "Approve", value: "approve" }],
+          },
+          {
+            type: "select",
+            placeholder: "Target",
+            options: [{ label: "Canary", value: "canary" }],
+          },
+          { type: "divider" },
+          { type: "context", text: "Muted details" },
+        ],
+      },
+      capabilities: {
+        buttons: false,
+        selects: false,
+        context: false,
+        divider: false,
+        limits: {
+          actions: { maxLabelLength: 4 },
+          selects: { maxLabelLength: 6 },
+        },
+      },
+    });
+
+    expect(presentation.blocks).toEqual([
+      { type: "text", text: "Actions:\n- Appr" },
+      { type: "text", text: "Target:\n- Canary" },
+      { type: "text", text: "Muted details" },
+    ]);
+  });
+
+  it("keeps fallback labels for invalid or overflowed select options", () => {
+    const presentation = adaptMessagePresentationForChannel({
+      presentation: {
+        blocks: [
+          {
+            type: "select",
+            placeholder: "Target",
+            options: [
+              { label: "Canary", value: "canary" },
+              { label: "Production", value: "prod" },
+              { label: "Long callback", value: "x".repeat(20) },
+            ],
+          },
+        ],
+      },
+      capabilities: {
+        limits: {
+          selects: {
+            maxOptions: 1,
+            maxValueBytes: 8,
+          },
+        },
+      },
+    });
+
+    expect(presentation.blocks).toEqual([
+      {
+        type: "select",
+        placeholder: "Target",
+        options: [{ label: "Canary", value: "canary" }],
+      },
+      { type: "context", text: "Target:\n- Production\n- Long callback" },
+    ]);
+  });
+
+  it("applies advertised text limits to titles, text, context, and generated fallback", () => {
+    const presentation = adaptMessagePresentationForChannel({
+      presentation: {
+        title: "abcdef",
+        blocks: [
+          { type: "text", text: "hello world" },
+          { type: "context", text: "abcdef" },
+          {
+            type: "buttons",
+            buttons: [{ label: "Deploy", value: "toolong" }],
+          },
+        ],
+      },
+      capabilities: {
+        limits: {
+          actions: {
+            maxValueBytes: 2,
+          },
+          text: {
+            maxLength: 5,
+            encoding: "characters",
+          },
+        },
+      },
+    });
+
+    expect(presentation).toEqual({
+      title: "abcde",
+      blocks: [
+        { type: "text", text: "hello" },
+        { type: "context", text: "abcde" },
+        { type: "context", text: "Actio" },
+      ],
+    });
+  });
+
+  it("does not split code points when applying utf8 byte text limits", () => {
+    const presentation = adaptMessagePresentationForChannel({
+      presentation: {
+        blocks: [{ type: "text", text: "abc😀def" }],
+      },
+      capabilities: {
+        limits: {
+          text: {
+            maxLength: 6,
+            encoding: "utf8-bytes",
+          },
+        },
+      },
+    });
+
+    expect(presentation.blocks).toEqual([{ type: "text", text: "abc" }]);
+  });
+
+  it("does not split code points when applying label limits", () => {
+    const presentation = adaptMessagePresentationForChannel({
+      presentation: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [{ label: "😀😀😀", value: "ok" }],
+          },
+          {
+            type: "select",
+            placeholder: "🚀🚀🚀",
+            options: [{ label: "👍👍👍", value: "yes" }],
+          },
+        ],
+      },
+      capabilities: {
+        limits: {
+          actions: {
+            maxLabelLength: 2,
+          },
+          selects: {
+            maxLabelLength: 2,
+          },
+        },
+      },
+    });
+
+    expect(presentation.blocks).toEqual([
+      {
+        type: "buttons",
+        buttons: [{ label: "😀😀", value: "ok" }],
+      },
+      {
+        type: "select",
+        placeholder: "🚀🚀",
+        options: [{ label: "👍👍", value: "yes" }],
+      },
+    ]);
+  });
+
+  it("preserves link buttons by dropping only over-limit callback values", () => {
+    const presentation = adaptMessagePresentationForChannel({
+      presentation: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [{ label: "Open report", value: "x".repeat(20), url: "https://example.test" }],
+          },
+        ],
+      },
+      capabilities: {
+        limits: {
+          actions: {
+            maxValueBytes: 4,
+          },
+        },
+      },
+    });
+
+    expect(presentation.blocks).toEqual([
+      {
+        type: "buttons",
+        buttons: [{ label: "Open report", url: "https://example.test" }],
+      },
+    ]);
+  });
+
+  it("applies button priority across the shared action budget", () => {
+    const presentation = adaptMessagePresentationForChannel({
+      presentation: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [{ label: "Low", value: "low" }],
+          },
+          {
+            type: "buttons",
+            buttons: [{ label: "High", value: "high", priority: 10 }],
+          },
+        ],
+      },
+      capabilities: {
+        limits: {
+          actions: {
+            maxActions: 1,
+          },
+        },
+      },
+    });
+
+    expect(presentation.blocks).toEqual([
+      { type: "context", text: "Actions:\n- Low" },
+      {
+        type: "buttons",
+        buttons: [{ label: "High", value: "high", priority: 10 }],
+      },
+    ]);
+  });
+
+  it("keeps link targets when overflowed buttons become fallback text", () => {
+    const presentation = adaptMessagePresentationForChannel({
+      presentation: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [{ label: "One", value: "one" }],
+          },
+          {
+            type: "buttons",
+            buttons: [{ label: "Docs", url: "https://docs.example.test" }],
+          },
+        ],
+      },
+      capabilities: {
+        limits: {
+          actions: {
+            maxActions: 1,
+            maxLabelLength: 4,
+          },
+        },
+      },
+    });
+
+    expect(presentation.blocks).toEqual([
+      {
+        type: "buttons",
+        buttons: [{ label: "One", value: "one" }],
+      },
+      { type: "context", text: "Actions:\n- Docs: https://docs.example.test" },
+    ]);
+  });
+
+  it("preserves callback button values when actions do not declare a value limit", () => {
+    const presentation = adaptMessagePresentationForChannel({
+      presentation: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [{ label: "Approve", value: "x".repeat(180) }],
+          },
+        ],
+      },
+      capabilities: {
+        limits: {
+          actions: {
+            maxActions: 5,
+            maxActionsPerRow: 5,
+          },
+        },
+      },
+    });
+
+    expect(presentation.blocks).toEqual([
+      {
+        type: "buttons",
+        buttons: [{ label: "Approve", value: "x".repeat(180) }],
+      },
+    ]);
+  });
+
+  it("reserves action row capacity for select blocks", () => {
+    const presentation = adaptMessagePresentationForChannel({
+      presentation: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [
+              { label: "One", value: "one" },
+              { label: "Two", value: "two" },
+              { label: "Three", value: "three" },
+            ],
+          },
+          {
+            type: "select",
+            placeholder: "Extra",
+            options: [{ label: "Four", value: "four" }],
+          },
+        ],
+      },
+      capabilities: {
+        limits: {
+          actions: {
+            maxActionsPerRow: 2,
+            maxRows: 2,
+          },
+          selects: {
+            maxOptions: 25,
+          },
+        },
+      },
+    });
+
+    expect(presentation.blocks).toEqual([
+      {
+        type: "buttons",
+        buttons: [
+          { label: "One", value: "one" },
+          { label: "Two", value: "two" },
+        ],
+      },
+      { type: "context", text: "Actions:\n- Three" },
+      {
+        type: "select",
+        placeholder: "Extra",
+        options: [{ label: "Four", value: "four" }],
+      },
+    ]);
+  });
+
+  it("splits button blocks by per-row limits even when rows are unlimited", () => {
+    const presentation = adaptMessagePresentationForChannel({
+      presentation: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [
+              { label: "One", value: "one" },
+              { label: "Two", value: "two" },
+              { label: "Three", value: "three" },
+              { label: "Four", value: "four" },
+              { label: "Five", value: "five" },
+              { label: "Six", value: "six" },
+            ],
+          },
+        ],
+      },
+      capabilities: {
+        limits: {
+          actions: {
+            maxActions: 20,
+            maxActionsPerRow: 5,
+          },
+        },
+      },
+    });
+
+    expect(presentation.blocks).toEqual([
+      {
+        type: "buttons",
+        buttons: [
+          { label: "One", value: "one" },
+          { label: "Two", value: "two" },
+          { label: "Three", value: "three" },
+          { label: "Four", value: "four" },
+          { label: "Five", value: "five" },
+        ],
+      },
+      {
+        type: "buttons",
+        buttons: [{ label: "Six", value: "six" }],
+      },
+    ]);
+  });
+
+  it("counts selects against the shared action capacity", () => {
+    const presentation = adaptMessagePresentationForChannel({
+      presentation: {
+        blocks: [
+          {
+            type: "select",
+            placeholder: "Target",
+            options: [{ label: "Canary", value: "canary" }],
+          },
+          {
+            type: "buttons",
+            buttons: [
+              { label: "One", value: "one" },
+              { label: "Two", value: "two" },
+              { label: "Three", value: "three" },
+            ],
+          },
+        ],
+      },
+      capabilities: {
+        limits: {
+          actions: {
+            maxActions: 3,
+            maxActionsPerRow: 5,
+            maxRows: 5,
+          },
+        },
+      },
+    });
+
+    expect(presentation.blocks).toEqual([
+      {
+        type: "select",
+        placeholder: "Target",
+        options: [{ label: "Canary", value: "canary" }],
+      },
+      {
+        type: "buttons",
+        buttons: [
+          { label: "One", value: "one" },
+          { label: "Two", value: "two" },
+        ],
+      },
+      { type: "context", text: "Actions:\n- Three" },
+    ]);
+  });
+
+  it("resolves page size from available action capacity", () => {
+    expect(
+      presentationPageSize(
+        {
+          limits: {
+            actions: { maxActionsPerRow: 5, maxRows: 2 },
+          },
+        },
+        1,
+        20,
+      ),
+    ).toBe(9);
   });
 });

--- a/src/channels/plugins/outbound/interactive.ts
+++ b/src/channels/plugins/outbound/interactive.ts
@@ -5,6 +5,9 @@ export {
   presentationPageSize,
 } from "./presentation-limits.js";
 
+/**
+ * @deprecated Use MessagePresentation helpers for new rendering paths.
+ */
 export function reduceInteractiveReply<TState>(
   interactive: InteractiveReply | undefined,
   initialState: TState,

--- a/src/channels/plugins/outbound/interactive.ts
+++ b/src/channels/plugins/outbound/interactive.ts
@@ -1,4 +1,9 @@
 import type { InteractiveReply, InteractiveReplyBlock } from "../../../interactive/payload.js";
+export {
+  adaptMessagePresentationForChannel,
+  applyPresentationActionLimits,
+  presentationPageSize,
+} from "./presentation-limits.js";
 
 export function reduceInteractiveReply<TState>(
   interactive: InteractiveReply | undefined,

--- a/src/channels/plugins/outbound/presentation-limits.ts
+++ b/src/channels/plugins/outbound/presentation-limits.ts
@@ -434,6 +434,12 @@ function adaptTextBlock(
   return block;
 }
 
+/**
+ * Adapt a portable presentation to the target channel's advertised capabilities.
+ *
+ * Unsupported controls are downgraded to text/context fallback blocks where possible, and
+ * labels, values, rows, options, styles, disabled state, and text are clipped to channel limits.
+ */
 export function adaptMessagePresentationForChannel(params: {
   presentation: MessagePresentation;
   capabilities?: ChannelPresentationCapabilities;
@@ -508,6 +514,7 @@ export function adaptMessagePresentationForChannel(params: {
   };
 }
 
+/** Return the subset of buttons that can still be rendered under action limits. */
 export function applyPresentationActionLimits(
   buttons: readonly MessagePresentationButton[],
   capabilities?: ChannelPresentationCapabilities,
@@ -522,6 +529,7 @@ export function applyPresentationActionLimits(
   return block.flatMap((entry) => (entry.type === "buttons" ? entry.buttons : []));
 }
 
+/** Resolve an action page size that leaves room for reserved actions on the target channel. */
 export function presentationPageSize(
   capabilities?: ChannelPresentationCapabilities,
   reservedActions = 0,

--- a/src/channels/plugins/outbound/presentation-limits.ts
+++ b/src/channels/plugins/outbound/presentation-limits.ts
@@ -1,0 +1,533 @@
+import type {
+  MessagePresentation,
+  MessagePresentationBlock,
+  MessagePresentationButton,
+  MessagePresentationOption,
+} from "../../../interactive/payload.js";
+import type { ChannelPresentationCapabilities } from "../outbound.types.js";
+
+type ActionLimits = NonNullable<NonNullable<ChannelPresentationCapabilities["limits"]>["actions"]>;
+type SelectLimits = NonNullable<NonNullable<ChannelPresentationCapabilities["limits"]>["selects"]>;
+type TextLimits = NonNullable<NonNullable<ChannelPresentationCapabilities["limits"]>["text"]>;
+type ActionBudget = {
+  remainingActions?: number;
+  remainingRows?: number;
+  maxActionsPerRow?: number;
+};
+type ButtonCandidate = {
+  original: MessagePresentationButton;
+  adapted?: MessagePresentationButton;
+};
+type SelectCandidate = {
+  original: MessagePresentationOption;
+  adapted?: MessagePresentationOption;
+};
+type ButtonSelection = ReadonlySet<MessagePresentationButton> | undefined;
+
+function positiveInteger(value: number | undefined): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : undefined;
+}
+
+function truncateText(value: string, maxLength: number | undefined): string {
+  const limit = positiveInteger(maxLength);
+  if (!limit) {
+    return value;
+  }
+  const chars = Array.from(value);
+  return chars.length > limit ? chars.slice(0, limit).join("") : value;
+}
+
+function truncateUtf8Bytes(value: string, limit: number): string {
+  let bytes = 0;
+  let result = "";
+  for (const char of value) {
+    const nextBytes = utf8ByteLength(char);
+    if (bytes + nextBytes > limit) {
+      break;
+    }
+    bytes += nextBytes;
+    result += char;
+  }
+  return result;
+}
+
+function truncatePresentationText(value: string, limits: TextLimits | undefined): string {
+  const limit = positiveInteger(limits?.maxLength);
+  if (!limit) {
+    return value;
+  }
+  if (limits?.encoding === "utf8-bytes") {
+    return truncateUtf8Bytes(value, limit);
+  }
+  if (limits?.encoding === "utf16-units") {
+    return value.length > limit ? value.slice(0, limit) : value;
+  }
+  const chars = Array.from(value);
+  return chars.length > limit ? chars.slice(0, limit).join("") : value;
+}
+
+function utf8ByteLength(value: string): number {
+  return Buffer.byteLength(value, "utf8");
+}
+
+function fitsByteLimit(value: string | undefined, maxBytes: number | undefined): boolean {
+  const limit = positiveInteger(maxBytes);
+  return !value || !limit || utf8ByteLength(value) <= limit;
+}
+
+function fallbackListBlock(params: {
+  blockType: "context" | "text";
+  heading: string;
+  labels: readonly string[];
+  maxLabelLength?: number;
+}): MessagePresentationBlock | undefined {
+  const labels = params.labels
+    .map((label) => truncateText(label, params.maxLabelLength).trim())
+    .filter(Boolean);
+  return labels.length > 0
+    ? {
+        type: params.blockType,
+        text: `${params.heading}:\n${labels.map((label) => `- ${label}`).join("\n")}`,
+      }
+    : undefined;
+}
+
+function buttonFallbackLabel(
+  button: MessagePresentationButton,
+  maxLabelLength: number | undefined,
+): string {
+  const label = truncateText(button.label, maxLabelLength);
+  const target = button.url ?? button.webApp?.url ?? button.web_app?.url;
+  return target ? `${label}: ${target}` : label;
+}
+
+function actionCapacity(limits: ActionLimits | undefined): number | undefined {
+  const maxActions = positiveInteger(limits?.maxActions);
+  const maxRows = positiveInteger(limits?.maxRows);
+  const maxActionsPerRow = positiveInteger(limits?.maxActionsPerRow);
+  const rowCapacity = maxRows && maxActionsPerRow ? maxRows * maxActionsPerRow : undefined;
+  if (maxActions && rowCapacity) {
+    return Math.min(maxActions, rowCapacity);
+  }
+  return maxActions ?? rowCapacity;
+}
+
+function buttonCapacityAfterReservedSelects(
+  limits: ActionLimits | undefined,
+  reservedSelects: number,
+): number | undefined {
+  const maxActions = positiveInteger(limits?.maxActions);
+  const maxRows = positiveInteger(limits?.maxRows);
+  const maxActionsPerRow = positiveInteger(limits?.maxActionsPerRow);
+  const remainingActions =
+    maxActions === undefined ? undefined : Math.max(0, maxActions - reservedSelects);
+  const remainingRows = maxRows === undefined ? undefined : Math.max(0, maxRows - reservedSelects);
+  const rowCapacity =
+    remainingRows !== undefined && maxActionsPerRow !== undefined
+      ? remainingRows * maxActionsPerRow
+      : undefined;
+  if (remainingActions !== undefined && rowCapacity !== undefined) {
+    return Math.min(remainingActions, rowCapacity);
+  }
+  return remainingActions ?? rowCapacity;
+}
+
+function createActionBudget(limits: ActionLimits | undefined): ActionBudget {
+  return {
+    remainingActions: positiveInteger(limits?.maxActions),
+    remainingRows: positiveInteger(limits?.maxRows),
+    maxActionsPerRow: positiveInteger(limits?.maxActionsPerRow),
+  };
+}
+
+function buttonCapacity(budget: ActionBudget): number | undefined {
+  if (budget.remainingActions === 0 || budget.remainingRows === 0) {
+    return 0;
+  }
+  const rowCapacity =
+    budget.remainingRows && budget.maxActionsPerRow
+      ? budget.remainingRows * budget.maxActionsPerRow
+      : undefined;
+  if (budget.remainingActions !== undefined && rowCapacity !== undefined) {
+    return Math.min(budget.remainingActions, rowCapacity);
+  }
+  return budget.remainingActions ?? rowCapacity;
+}
+
+function consumeButtonBudget(budget: ActionBudget, count: number): void {
+  if (count <= 0) {
+    return;
+  }
+  if (budget.remainingActions !== undefined) {
+    budget.remainingActions = Math.max(0, budget.remainingActions - count);
+  }
+  if (budget.remainingRows !== undefined) {
+    const perRow = budget.maxActionsPerRow ?? count;
+    budget.remainingRows = Math.max(0, budget.remainingRows - Math.ceil(count / perRow));
+  }
+}
+
+function chunkButtons(
+  buttons: readonly MessagePresentationButton[],
+  maxActionsPerRow: number | undefined,
+): MessagePresentationButton[][] {
+  const rowSize = positiveInteger(maxActionsPerRow);
+  if (!rowSize) {
+    return buttons.length > 0 ? [[...buttons]] : [];
+  }
+  const rows: MessagePresentationButton[][] = [];
+  for (let index = 0; index < buttons.length; index += rowSize) {
+    rows.push(buttons.slice(index, index + rowSize));
+  }
+  return rows;
+}
+
+function hasActionSlotBudget(budget: ActionBudget): boolean {
+  return budget.remainingActions !== 0 && budget.remainingRows !== 0;
+}
+
+function consumeSelectBudget(budget: ActionBudget): void {
+  if (budget.remainingActions !== undefined) {
+    budget.remainingActions = Math.max(0, budget.remainingActions - 1);
+  }
+  if (budget.remainingRows !== undefined) {
+    budget.remainingRows = Math.max(0, budget.remainingRows - 1);
+  }
+}
+
+function adaptButton(
+  button: MessagePresentationButton,
+  limits: ActionLimits | undefined,
+): MessagePresentationButton | undefined {
+  const hasLinkTarget = Boolean(button.url || button.webApp || button.web_app);
+  const valueFits = fitsByteLimit(button.value, limits?.maxValueBytes);
+  if (
+    (!valueFits && !hasLinkTarget) ||
+    (button.disabled === true && limits?.supportsDisabled !== true)
+  ) {
+    return undefined;
+  }
+  const adapted: MessagePresentationButton = {
+    ...button,
+    label: truncateText(button.label, limits?.maxLabelLength),
+  };
+  if (!valueFits) {
+    delete adapted.value;
+  }
+  if (limits?.supportsStyles === false) {
+    delete adapted.style;
+  }
+  return adapted;
+}
+
+function adaptButtonsBlock(
+  block: Extract<MessagePresentationBlock, { type: "buttons" }>,
+  limits: ActionLimits | undefined,
+  budget: ActionBudget,
+  fallbackBlockType: "context" | "text",
+  buttonSelection: ButtonSelection,
+): MessagePresentationBlock[] {
+  const capacity = buttonCapacity(budget);
+  const candidates: ButtonCandidate[] = block.buttons.map((button) => ({
+    original: button,
+    adapted: adaptButton(button, limits),
+  }));
+  const renderableCandidates = candidates.filter(
+    (candidate): candidate is ButtonCandidate & { adapted: MessagePresentationButton } =>
+      Boolean(candidate.adapted),
+  );
+  const eligibleCandidates = buttonSelection
+    ? renderableCandidates.filter((candidate) => buttonSelection.has(candidate.original))
+    : renderableCandidates;
+  const selectedCandidates =
+    capacity !== undefined && eligibleCandidates.length > capacity
+      ? eligibleCandidates
+          .map((candidate, index) => ({ candidate, index }))
+          .toSorted((left, right) => {
+            const priorityDelta =
+              (right.candidate.adapted.priority ?? 0) - (left.candidate.adapted.priority ?? 0);
+            return priorityDelta || left.index - right.index;
+          })
+          .slice(0, capacity)
+          .map((entry) => entry.candidate)
+      : eligibleCandidates;
+  const selected = new Set<ButtonCandidate>(selectedCandidates);
+  const buttons = selectedCandidates.map((candidate) => candidate.adapted);
+  const droppedLabels = candidates
+    .filter((candidate) => !candidate.adapted || !selected.has(candidate))
+    .map((candidate) => buttonFallbackLabel(candidate.original, limits?.maxLabelLength));
+  consumeButtonBudget(budget, buttons.length);
+  const fallback = fallbackListBlock({
+    blockType: fallbackBlockType,
+    heading: "Actions",
+    labels: droppedLabels,
+  });
+  if (buttons.length === 0) {
+    return fallback ? [fallback] : [];
+  }
+  const blocks: MessagePresentationBlock[] = chunkButtons(buttons, limits?.maxActionsPerRow).map(
+    (row) => ({
+      type: "buttons",
+      buttons: row,
+    }),
+  );
+  if (fallback) {
+    blocks.push(fallback);
+  }
+  return blocks;
+}
+
+function appendAdaptedButtonsBlock(
+  blocks: MessagePresentationBlock[],
+  block: Extract<MessagePresentationBlock, { type: "buttons" }>,
+  limits: ActionLimits | undefined,
+  budget: ActionBudget,
+  fallbackBlockType: "context" | "text",
+  buttonSelection: ButtonSelection,
+): void {
+  blocks.push(...adaptButtonsBlock(block, limits, budget, fallbackBlockType, buttonSelection));
+}
+
+function adaptOption(
+  option: MessagePresentationOption,
+  limits: SelectLimits | undefined,
+): MessagePresentationOption | undefined {
+  if (!fitsByteLimit(option.value, limits?.maxValueBytes)) {
+    return undefined;
+  }
+  return {
+    ...option,
+    label: truncateText(option.label, limits?.maxLabelLength),
+  };
+}
+
+function adaptSelectBlock(
+  block: Extract<MessagePresentationBlock, { type: "select" }>,
+  limits: SelectLimits | undefined,
+  budget: ActionBudget,
+  fallbackBlockType: "context" | "text",
+): MessagePresentationBlock[] {
+  const candidates: SelectCandidate[] = block.options.map((option) => ({
+    original: option,
+    adapted: adaptOption(option, limits),
+  }));
+  const renderableCandidates = candidates.filter(
+    (candidate): candidate is SelectCandidate & { adapted: MessagePresentationOption } =>
+      Boolean(candidate.adapted),
+  );
+  const maxOptions = positiveInteger(limits?.maxOptions);
+  const selectedCandidates = maxOptions
+    ? renderableCandidates.slice(0, maxOptions)
+    : renderableCandidates;
+  const selected = new Set<SelectCandidate>(selectedCandidates);
+  const options = selectedCandidates.map((candidate) => candidate.adapted);
+  const canRenderSelect = options.length > 0 && hasActionSlotBudget(budget);
+  const fallback = fallbackListBlock({
+    blockType: fallbackBlockType,
+    heading: block.placeholder ?? "Options",
+    labels: (canRenderSelect
+      ? candidates.filter((candidate) => !candidate.adapted || !selected.has(candidate))
+      : candidates
+    ).map((candidate) => candidate.original.label),
+    maxLabelLength: limits?.maxLabelLength,
+  });
+  if (!canRenderSelect) {
+    return fallback ? [fallback] : [];
+  }
+  consumeSelectBudget(budget);
+  const blocks: MessagePresentationBlock[] = [
+    {
+      type: "select",
+      placeholder: truncateText(block.placeholder ?? "", limits?.maxLabelLength) || undefined,
+      options,
+    },
+  ];
+  if (fallback) {
+    blocks.push(fallback);
+  }
+  return blocks;
+}
+
+function countRenderableSelectBlocks(
+  blocks: readonly MessagePresentationBlock[],
+  capabilities: ChannelPresentationCapabilities | undefined,
+  limits: SelectLimits | undefined,
+): number {
+  if (capabilities?.selects === false) {
+    return 0;
+  }
+  return blocks.filter((block) => {
+    if (block.type !== "select") {
+      return false;
+    }
+    const maxOptions = positiveInteger(limits?.maxOptions);
+    const renderableOptions = block.options
+      .map((option) => adaptOption(option, limits))
+      .filter(Boolean)
+      .slice(0, maxOptions ?? undefined);
+    return renderableOptions.length > 0;
+  }).length;
+}
+
+function createGlobalButtonSelection(params: {
+  presentation: MessagePresentation;
+  capabilities: ChannelPresentationCapabilities | undefined;
+  limits: ActionLimits | undefined;
+  selectLimits: SelectLimits | undefined;
+}): ButtonSelection {
+  if (params.capabilities?.buttons === false) {
+    return undefined;
+  }
+  const reservedSelectSlots = countRenderableSelectBlocks(
+    params.presentation.blocks,
+    params.capabilities,
+    params.selectLimits,
+  );
+  const capacity = buttonCapacityAfterReservedSelects(params.limits, reservedSelectSlots);
+  if (capacity === undefined) {
+    return undefined;
+  }
+  const candidates = params.presentation.blocks.flatMap((block) => {
+    if (block.type !== "buttons") {
+      return [];
+    }
+    return block.buttons
+      .map((button) => ({
+        original: button,
+        adapted: adaptButton(button, params.limits),
+      }))
+      .filter(
+        (
+          candidate,
+        ): candidate is {
+          original: MessagePresentationButton;
+          adapted: MessagePresentationButton;
+        } => Boolean(candidate.adapted),
+      );
+  });
+  if (candidates.length <= capacity) {
+    return undefined;
+  }
+  return new Set(
+    candidates
+      .map((candidate, index) => ({ candidate, index }))
+      .toSorted((left, right) => {
+        const priorityDelta =
+          (right.candidate.adapted.priority ?? 0) - (left.candidate.adapted.priority ?? 0);
+        return priorityDelta || left.index - right.index;
+      })
+      .slice(0, capacity)
+      .map((entry) => entry.candidate.original),
+  );
+}
+
+function adaptTextBlock(
+  block: MessagePresentationBlock,
+  limits: TextLimits | undefined,
+): MessagePresentationBlock {
+  if (block.type === "text" || block.type === "context") {
+    return {
+      ...block,
+      text: truncatePresentationText(block.text, limits),
+    };
+  }
+  return block;
+}
+
+export function adaptMessagePresentationForChannel(params: {
+  presentation: MessagePresentation;
+  capabilities?: ChannelPresentationCapabilities;
+}): MessagePresentation {
+  const capabilities = params.capabilities;
+  const limits = params.capabilities?.limits;
+  const actionBudget = createActionBudget(limits?.actions);
+  const fallbackBlockType = capabilities?.context === false ? "text" : "context";
+  const buttonSelection = createGlobalButtonSelection({
+    presentation: params.presentation,
+    capabilities,
+    limits: limits?.actions,
+    selectLimits: limits?.selects,
+  });
+  const blocks: MessagePresentationBlock[] = [];
+  for (const block of params.presentation.blocks) {
+    if (block.type === "buttons") {
+      if (capabilities?.buttons === false) {
+        const fallback = fallbackListBlock({
+          blockType: fallbackBlockType,
+          heading: "Actions",
+          labels: block.buttons.map((button) =>
+            buttonFallbackLabel(button, limits?.actions?.maxLabelLength),
+          ),
+        });
+        if (fallback) {
+          blocks.push(fallback);
+        }
+        continue;
+      }
+      appendAdaptedButtonsBlock(
+        blocks,
+        block,
+        limits?.actions,
+        actionBudget,
+        fallbackBlockType,
+        buttonSelection,
+      );
+      continue;
+    }
+    if (block.type === "select") {
+      if (capabilities?.selects === false) {
+        const fallback = fallbackListBlock({
+          blockType: fallbackBlockType,
+          heading: block.placeholder ?? "Options",
+          labels: block.options.map((option) => option.label),
+          maxLabelLength: limits?.selects?.maxLabelLength,
+        });
+        if (fallback) {
+          blocks.push(fallback);
+        }
+        continue;
+      }
+      blocks.push(...adaptSelectBlock(block, limits?.selects, actionBudget, fallbackBlockType));
+      continue;
+    }
+    if (block.type === "context" && capabilities?.context === false) {
+      blocks.push({ type: "text", text: block.text });
+      continue;
+    }
+    if (block.type === "divider" && capabilities?.divider === false) {
+      continue;
+    }
+    blocks.push(block);
+  }
+  return {
+    ...params.presentation,
+    ...(params.presentation.title
+      ? { title: truncatePresentationText(params.presentation.title, limits?.text) }
+      : {}),
+    blocks: blocks.map((block) => adaptTextBlock(block, limits?.text)),
+  };
+}
+
+export function applyPresentationActionLimits(
+  buttons: readonly MessagePresentationButton[],
+  capabilities?: ChannelPresentationCapabilities,
+): MessagePresentationButton[] {
+  const block = adaptButtonsBlock(
+    { type: "buttons", buttons: [...buttons] },
+    capabilities?.limits?.actions,
+    createActionBudget(capabilities?.limits?.actions),
+    capabilities?.context === false ? "text" : "context",
+    undefined,
+  );
+  return block.flatMap((entry) => (entry.type === "buttons" ? entry.buttons : []));
+}
+
+export function presentationPageSize(
+  capabilities?: ChannelPresentationCapabilities,
+  reservedActions = 0,
+  maxPageSize = Number.POSITIVE_INFINITY,
+): number {
+  const capacity = actionCapacity(capabilities?.limits?.actions);
+  const remaining = Math.max(0, (capacity ?? maxPageSize) - Math.max(0, reservedActions));
+  return Math.max(1, Math.min(remaining || 1, maxPageSize));
+}

--- a/src/infra/exec-approval-forwarder.test.ts
+++ b/src/infra/exec-approval-forwarder.test.ts
@@ -96,7 +96,7 @@ function buildTelegramExecApprovalPendingPayloadForTest(params: {
 }): ReplyPayload {
   return {
     text: `Telegram exec approval ${params.request.id}`,
-    interactive: {
+    presentation: {
       blocks: [
         {
           type: "buttons",
@@ -512,7 +512,7 @@ describe("exec approval forwarder", () => {
     expect(deliver).not.toHaveBeenCalled();
   });
 
-  it("attaches shared interactive approval buttons in forwarded fallback payloads", async () => {
+  it("attaches shared presentation approval buttons in forwarded fallback payloads", async () => {
     vi.useFakeTimers();
     const { deliver, forwarder } = createForwarder({
       cfg: makeTargetsCfg([{ channel: "telegram", to: "123" }]),
@@ -535,7 +535,7 @@ describe("exec approval forwarder", () => {
     expect(delivery.to).toBe("123");
     const payload = requireFirstPayload(deliver);
     expect(payload.channelData?.execApproval).toEqual({ approvalId: "req-1" });
-    expect(payload.interactive).toEqual({
+    expect(payload.presentation).toEqual({
       blocks: [
         {
           type: "buttons",
@@ -559,6 +559,7 @@ describe("exec approval forwarder", () => {
         },
       ],
     });
+    expect(payload.interactive).toBeUndefined();
   });
 
   it("stores exec metadata on generic forwarded fallback payloads", async () => {

--- a/src/infra/exec-approval-reply.test.ts
+++ b/src/infra/exec-approval-reply.test.ts
@@ -258,7 +258,7 @@ describe("exec approval reply helpers", () => {
         sessionKey: undefined,
       },
     });
-    expect(payload.interactive).toEqual({
+    expect(payload.presentation).toEqual({
       blocks: [
         {
           type: "buttons",
@@ -282,6 +282,7 @@ describe("exec approval reply helpers", () => {
         },
       ],
     });
+    expect(payload.interactive).toBeUndefined();
     expect(payload.text).toContain("Heads up.");
     expect(payload.text).toContain("```txt\n/approve slug-1 allow-once\n```");
     expect(payload.text).toContain("```sh\necho ok\n```");
@@ -324,7 +325,7 @@ describe("exec approval reply helpers", () => {
     expect(payload.text).toContain(
       "The effective approval policy requires approval every time, so Allow Always is unavailable.",
     );
-    expect(payload.interactive).toEqual({
+    expect(payload.presentation).toEqual({
       blocks: [
         {
           type: "buttons",
@@ -343,6 +344,7 @@ describe("exec approval reply helpers", () => {
         },
       ],
     });
+    expect(payload.interactive).toBeUndefined();
   });
 
   it("stores agent and session metadata for downstream suppression checks", () => {

--- a/src/infra/exec-approval-reply.ts
+++ b/src/infra/exec-approval-reply.ts
@@ -177,6 +177,7 @@ function buildApprovalPresentationButtons(
   }));
 }
 
+/** Build the portable approval button presentation for already-resolved actions. */
 export function buildApprovalPresentationFromActionDescriptors(
   actions: readonly ExecApprovalActionDescriptor[],
 ): MessagePresentation | undefined {
@@ -184,6 +185,7 @@ export function buildApprovalPresentationFromActionDescriptors(
   return buttons.length > 0 ? { blocks: [{ type: "buttons", buttons }] } : undefined;
 }
 
+/** Build the portable approval presentation for an approval id and decision allowlist. */
 export function buildApprovalPresentation(params: {
   approvalId: string;
   ask?: string | null;
@@ -198,6 +200,7 @@ export function buildApprovalPresentation(params: {
   );
 }
 
+/** Build the portable exec-approval presentation for command callback buttons. */
 export function buildExecApprovalPresentation(params: {
   approvalCommandId: string;
   ask?: string | null;

--- a/src/infra/exec-approval-reply.ts
+++ b/src/infra/exec-approval-reply.ts
@@ -1,5 +1,10 @@
 import type { ReplyPayload } from "../auto-reply/types.js";
-import type { InteractiveReply, InteractiveReplyButton } from "../interactive/payload.js";
+import type {
+  InteractiveReply,
+  InteractiveReplyButton,
+  MessagePresentation,
+  MessagePresentationButton,
+} from "../interactive/payload.js";
 import { formatHumanList } from "../shared/human-list.js";
 import {
   normalizeOptionalLowercaseString,
@@ -35,7 +40,7 @@ export type ExecApprovalReplyMetadata = {
 export type ExecApprovalActionDescriptor = {
   decision: ExecApprovalReplyDecision;
   label: string;
-  style: NonNullable<InteractiveReplyButton["style"]>;
+  style: NonNullable<MessagePresentationButton["style"]>;
   command: string;
 };
 
@@ -162,6 +167,52 @@ function buildApprovalInteractiveButtons(
   }));
 }
 
+function buildApprovalPresentationButtons(
+  descriptors: readonly ExecApprovalActionDescriptor[],
+): MessagePresentationButton[] {
+  return descriptors.map((descriptor) => ({
+    label: descriptor.label,
+    value: descriptor.command,
+    style: descriptor.style,
+  }));
+}
+
+export function buildApprovalPresentationFromActionDescriptors(
+  actions: readonly ExecApprovalActionDescriptor[],
+): MessagePresentation | undefined {
+  const buttons = buildApprovalPresentationButtons(actions);
+  return buttons.length > 0 ? { blocks: [{ type: "buttons", buttons }] } : undefined;
+}
+
+export function buildApprovalPresentation(params: {
+  approvalId: string;
+  ask?: string | null;
+  allowedDecisions?: readonly ExecApprovalReplyDecision[];
+}): MessagePresentation | undefined {
+  return buildApprovalPresentationFromActionDescriptors(
+    buildExecApprovalActionDescriptors({
+      approvalCommandId: params.approvalId,
+      ask: params.ask,
+      allowedDecisions: params.allowedDecisions,
+    }),
+  );
+}
+
+export function buildExecApprovalPresentation(params: {
+  approvalCommandId: string;
+  ask?: string | null;
+  allowedDecisions?: readonly ExecApprovalReplyDecision[];
+}): MessagePresentation | undefined {
+  return buildApprovalPresentation({
+    approvalId: params.approvalCommandId,
+    ask: params.ask,
+    allowedDecisions: params.allowedDecisions,
+  });
+}
+
+/**
+ * @deprecated Use buildApprovalPresentationFromActionDescriptors.
+ */
 export function buildApprovalInteractiveReplyFromActionDescriptors(
   actions: readonly ExecApprovalActionDescriptor[],
 ): InteractiveReply | undefined {
@@ -169,6 +220,9 @@ export function buildApprovalInteractiveReplyFromActionDescriptors(
   return buttons.length > 0 ? { blocks: [{ type: "buttons", buttons }] } : undefined;
 }
 
+/**
+ * @deprecated Use buildApprovalPresentation.
+ */
 export function buildApprovalInteractiveReply(params: {
   approvalId: string;
   ask?: string | null;
@@ -183,6 +237,9 @@ export function buildApprovalInteractiveReply(params: {
   );
 }
 
+/**
+ * @deprecated Use buildExecApprovalPresentation.
+ */
 export function buildExecApprovalInteractiveReply(params: {
   approvalCommandId: string;
   ask?: string | null;
@@ -335,7 +392,7 @@ export function buildExecApprovalPendingReplyPayload(
 
   return {
     text: lines.join("\n\n"),
-    interactive: buildApprovalInteractiveReply({
+    presentation: buildApprovalPresentation({
       approvalId: params.approvalId,
       allowedDecisions,
     }),

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -1681,6 +1681,87 @@ describe("deliverOutboundPayloads", () => {
     });
   });
 
+  it("adapts presentation buttons to channel limits before rendering", async () => {
+    const renderPresentation = vi.fn(({ payload }) => ({
+      ...payload,
+      channelData: { rendered: true },
+    }));
+    const sendPayload = vi.fn().mockResolvedValue({
+      channel: "matrix" as const,
+      messageId: "adapted",
+      roomId: "!room",
+    });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "matrix",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "matrix",
+            outbound: {
+              deliveryMode: "direct",
+              presentationCapabilities: {
+                supported: true,
+                buttons: true,
+                limits: {
+                  actions: {
+                    maxActions: 1,
+                    maxLabelLength: 4,
+                    maxValueBytes: 8,
+                    supportsStyles: false,
+                  },
+                },
+              },
+              renderPresentation,
+              sendText: vi.fn(),
+              sendMedia: vi.fn(),
+              sendPayload,
+            },
+          }),
+        },
+      ]),
+    );
+
+    await deliverOutboundPayloads({
+      cfg: {},
+      channel: "matrix",
+      to: "!room",
+      payloads: [
+        {
+          presentation: {
+            blocks: [
+              {
+                type: "buttons",
+                buttons: [
+                  { label: "Reject", value: "reject", priority: 1, style: "danger" },
+                  { label: "Approve", value: "approve", priority: 10, style: "success" },
+                  { label: "Too long", value: "x".repeat(12), priority: 20 },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    const renderArg = requireMockCallArg(renderPresentation, "renderPresentation") as {
+      presentation?: unknown;
+    };
+    expect(renderArg.presentation).toEqual({
+      tone: undefined,
+      blocks: [
+        {
+          type: "buttons",
+          buttons: [{ label: "Appr", value: "approve", priority: 10, style: undefined }],
+        },
+        {
+          type: "context",
+          text: "Actions:\n- Reje\n- Too",
+        },
+      ],
+    });
+  });
+
   it("runs adapter after-delivery hooks with the payload delivery results", async () => {
     const afterDeliverPayload = vi.fn();
     setActivePluginRegistry(

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -8,6 +8,7 @@ import type {
   ChannelMessageSendLifecycleAdapter,
   ChannelMessageSendResult,
 } from "../../channels/message/types.js";
+import { adaptMessagePresentationForChannel } from "../../channels/plugins/outbound/interactive.js";
 import { loadChannelOutboundAdapter } from "../../channels/plugins/outbound/load.js";
 import type {
   ChannelDeliveryCapabilities,
@@ -143,6 +144,7 @@ type ChannelHandler = {
   normalizePayload?: (payload: ReplyPayload) => ReplyPayload | null;
   sendTextOnlyErrorPayloads?: boolean;
   renderPresentation?: (payload: ReplyPayload) => Promise<ReplyPayload | null>;
+  presentationCapabilities?: ChannelOutboundAdapter["presentationCapabilities"];
   pinDeliveredMessage?: (params: {
     target: ChannelOutboundTargetRef;
     messageId: string;
@@ -387,6 +389,7 @@ function createPluginHandler(
           })
       : undefined,
     sendTextOnlyErrorPayloads: outbound?.sendTextOnlyErrorPayloads === true,
+    presentationCapabilities: outbound?.presentationCapabilities,
     renderPresentation: outbound?.renderPresentation
       ? async (payload) => {
           const presentation = normalizeMessagePresentation(payload.presentation);
@@ -950,7 +953,14 @@ async function renderPresentationForDelivery(
   if (!presentation) {
     return payload;
   }
-  const rendered = handler.renderPresentation ? await handler.renderPresentation(payload) : null;
+  const adaptedPresentation = adaptMessagePresentationForChannel({
+    presentation,
+    capabilities: handler.presentationCapabilities,
+  });
+  const adaptedPayload = { ...payload, presentation: adaptedPresentation };
+  const rendered = handler.renderPresentation
+    ? await handler.renderPresentation(adaptedPayload)
+    : null;
   if (rendered) {
     const { presentation: _presentation, ...withoutPresentation } = rendered;
     return withoutPresentation;
@@ -960,7 +970,7 @@ async function renderPresentationForDelivery(
     ...withoutPresentation,
     text: renderMessagePresentationFallbackText({
       text: payload.text,
-      presentation,
+      presentation: adaptedPresentation,
     }),
   };
 }

--- a/src/infra/plugin-approval-forwarder.test.ts
+++ b/src/infra/plugin-approval-forwarder.test.ts
@@ -69,7 +69,7 @@ async function flushPendingDelivery(): Promise<void> {
 }
 
 type DeliveryArgs = {
-  payloads?: Array<{ text?: string; interactive?: unknown }>;
+  payloads?: Array<{ text?: string; presentation?: unknown; interactive?: unknown }>;
 };
 
 function deliveryArgs(deliver: ReturnType<typeof vi.fn>): DeliveryArgs | undefined {
@@ -137,7 +137,7 @@ describe("plugin approval forwarding", () => {
       expect(text).toContain("Sensitive tool call");
       expect(text).toContain("plugin-req-1");
       expect(text).toContain("/approve");
-      expect(payload?.interactive).toEqual({
+      expect(payload?.presentation).toEqual({
         blocks: [
           {
             type: "buttons",
@@ -161,6 +161,7 @@ describe("plugin approval forwarding", () => {
           },
         ],
       });
+      expect(payload?.interactive).toBeUndefined();
     });
 
     it("renders only request-scoped plugin approval decisions", async () => {
@@ -179,7 +180,7 @@ describe("plugin approval forwarding", () => {
       const payload = firstDeliveredPayload(deliver);
       expect(payload?.text).toContain("Reply with: /approve <id> allow-once|deny");
       expect(payload?.text).not.toContain("allow-always");
-      expect(payload?.interactive).toEqual({
+      expect(payload?.presentation).toEqual({
         blocks: [
           {
             type: "buttons",
@@ -198,6 +199,7 @@ describe("plugin approval forwarding", () => {
           },
         ],
       });
+      expect(payload?.interactive).toBeUndefined();
     });
 
     it("includes severity icon for critical", async () => {

--- a/src/interactive/payload.ts
+++ b/src/interactive/payload.ts
@@ -5,14 +5,21 @@ import {
 
 export type InteractiveButtonStyle = "primary" | "secondary" | "success" | "danger";
 
+/** Visual tone for a portable message presentation. */
 export type MessagePresentationTone = "info" | "success" | "warning" | "danger" | "neutral";
 
+/** Button style hint for renderers that support styled actions. */
 export type MessagePresentationButtonStyle = InteractiveButtonStyle;
 
+/** Portable action control rendered as a button or link by channel adapters. */
 export type MessagePresentationButton = {
+  /** User-visible button label. */
   label: string;
+  /** Callback command or opaque value sent when the button is pressed. */
   value?: string;
+  /** External URL opened by the button instead of sending a callback value. */
   url?: string;
+  /** Telegram-style web app launch target. */
   webApp?: {
     url: string;
   };
@@ -22,13 +29,19 @@ export type MessagePresentationButton = {
   web_app?: {
     url: string;
   };
+  /** Higher-priority buttons are kept first when channel limits require truncation. */
   priority?: number;
+  /** Disable the button when the target channel supports disabled controls. */
   disabled?: boolean;
+  /** Optional visual style hint; unsupported channels ignore or normalize it. */
   style?: InteractiveButtonStyle;
 };
 
+/** Portable select/menu option. */
 export type MessagePresentationOption = {
+  /** User-visible option label. */
   label: string;
+  /** Callback command or opaque value sent when the option is selected. */
   value: string;
 };
 
@@ -84,11 +97,13 @@ export type InteractiveReply = {
 
 export type MessagePresentationTextBlock = {
   type: "text";
+  /** Primary markdown-ish text rendered in the message body. */
   text: string;
 };
 
 export type MessagePresentationContextBlock = {
   type: "context";
+  /** Lower-emphasis contextual text, or normal text on channels without context support. */
   text: string;
 };
 
@@ -98,12 +113,15 @@ export type MessagePresentationDividerBlock = {
 
 export type MessagePresentationButtonsBlock = {
   type: "buttons";
+  /** Button row candidates; core may split or truncate them for channel limits. */
   buttons: MessagePresentationButton[];
 };
 
 export type MessagePresentationSelectBlock = {
   type: "select";
+  /** Optional prompt shown above or inside the select control. */
   placeholder?: string;
+  /** Menu options; core may truncate them for channel limits. */
   options: MessagePresentationOption[];
 };
 
@@ -119,8 +137,11 @@ export type MessagePresentationBlock =
   | MessagePresentationSelectBlock;
 
 export type MessagePresentation = {
+  /** Optional short heading rendered before blocks when the channel supports it. */
   title?: string;
+  /** Optional severity/status tone for renderers that support toned presentations. */
   tone?: MessagePresentationTone;
+  /** Ordered portable blocks rendered or downgraded by the target channel adapter. */
   blocks: MessagePresentationBlock[];
 };
 

--- a/src/interactive/payload.ts
+++ b/src/interactive/payload.ts
@@ -5,7 +5,11 @@ import {
 
 export type InteractiveButtonStyle = "primary" | "secondary" | "success" | "danger";
 
-export type InteractiveReplyButton = {
+export type MessagePresentationTone = "info" | "success" | "warning" | "danger" | "neutral";
+
+export type MessagePresentationButtonStyle = InteractiveButtonStyle;
+
+export type MessagePresentationButton = {
   label: string;
   value?: string;
   url?: string;
@@ -23,43 +27,60 @@ export type InteractiveReplyButton = {
   style?: InteractiveButtonStyle;
 };
 
-export type InteractiveReplyOption = {
+export type MessagePresentationOption = {
   label: string;
   value: string;
 };
 
+/**
+ * @deprecated Use MessagePresentationButton.
+ */
+export type InteractiveReplyButton = MessagePresentationButton;
+
+/**
+ * @deprecated Use MessagePresentationOption.
+ */
+export type InteractiveReplyOption = MessagePresentationOption;
+
+/**
+ * @deprecated Use MessagePresentationTextBlock.
+ */
 export type InteractiveReplyTextBlock = {
   type: "text";
   text: string;
 };
 
+/**
+ * @deprecated Use MessagePresentationButtonsBlock.
+ */
 type InteractiveReplyButtonsBlock = {
   type: "buttons";
   buttons: InteractiveReplyButton[];
 };
 
+/**
+ * @deprecated Use MessagePresentationSelectBlock.
+ */
 export type InteractiveReplySelectBlock = {
   type: "select";
   placeholder?: string;
   options: InteractiveReplyOption[];
 };
 
+/**
+ * @deprecated Use MessagePresentationBlock.
+ */
 export type InteractiveReplyBlock =
   | InteractiveReplyTextBlock
   | InteractiveReplyButtonsBlock
   | InteractiveReplySelectBlock;
 
+/**
+ * @deprecated Use MessagePresentation.
+ */
 export type InteractiveReply = {
   blocks: InteractiveReplyBlock[];
 };
-
-export type MessagePresentationTone = "info" | "success" | "warning" | "danger" | "neutral";
-
-export type MessagePresentationButtonStyle = InteractiveButtonStyle;
-
-export type MessagePresentationButton = InteractiveReplyButton;
-
-export type MessagePresentationOption = InteractiveReplyOption;
 
 export type MessagePresentationTextBlock = {
   type: "text";
@@ -215,6 +236,9 @@ function normalizeInteractiveBlock(raw: unknown): InteractiveReplyBlock | undefi
   return undefined;
 }
 
+/**
+ * @deprecated Use normalizeMessagePresentation.
+ */
 export function normalizeInteractiveReply(raw: unknown): InteractiveReply | undefined {
   const record = toRecord(raw);
   if (!record) {
@@ -271,6 +295,9 @@ export function normalizeMessagePresentation(raw: unknown): MessagePresentation 
   };
 }
 
+/**
+ * @deprecated Use hasMessagePresentationBlocks.
+ */
 export function hasInteractiveReplyBlocks(value: unknown): value is InteractiveReply {
   return Boolean(normalizeInteractiveReply(value));
 }
@@ -279,6 +306,9 @@ export function hasMessagePresentationBlocks(value: unknown): value is MessagePr
   return Boolean(normalizeMessagePresentation(value));
 }
 
+/**
+ * @deprecated Avoid producing InteractiveReply payloads; send MessagePresentation directly.
+ */
 export function presentationToInteractiveReply(
   presentation: MessagePresentation,
 ): InteractiveReply | undefined {
@@ -339,6 +369,9 @@ export function isMessagePresentationInteractiveBlock(
   return block.type === "buttons" || block.type === "select";
 }
 
+/**
+ * @deprecated Avoid producing InteractiveReply payloads; send MessagePresentation directly.
+ */
 export function presentationToInteractiveControlsReply(
   presentation: MessagePresentation,
 ): InteractiveReply | undefined {
@@ -347,6 +380,9 @@ export function presentationToInteractiveControlsReply(
   });
 }
 
+/**
+ * @deprecated Legacy bridge for old InteractiveReply payloads. New producers should send MessagePresentation.
+ */
 export function interactiveReplyToPresentation(
   interactive: InteractiveReply,
 ): MessagePresentation | undefined {
@@ -466,6 +502,9 @@ export function hasReplyPayloadContent(
   });
 }
 
+/**
+ * @deprecated Use renderMessagePresentationFallbackText with MessagePresentation.
+ */
 export function resolveInteractiveTextFallback(params: {
   text?: string;
   interactive?: InteractiveReply;

--- a/src/interactive/payload.ts
+++ b/src/interactive/payload.ts
@@ -12,6 +12,14 @@ export type InteractiveReplyButton = {
   webApp?: {
     url: string;
   };
+  /**
+   * @deprecated Use webApp. The snake_case alias is accepted for legacy JSON payloads only.
+   */
+  web_app?: {
+    url: string;
+  };
+  priority?: number;
+  disabled?: boolean;
   style?: InteractiveButtonStyle;
 };
 
@@ -146,11 +154,17 @@ function normalizeButton(raw: unknown): InteractiveReplyButton | undefined {
   if (!label || (!value && !url && !webAppUrl)) {
     return undefined;
   }
+  const priority =
+    typeof record.priority === "number" && Number.isFinite(record.priority)
+      ? record.priority
+      : undefined;
   return {
     label,
     ...(value ? { value } : {}),
     ...(url ? { url } : {}),
     ...(webAppUrl ? { webApp: { url: webAppUrl } } : {}),
+    ...(priority !== undefined ? { priority } : {}),
+    ...(record.disabled === true ? { disabled: true } : {}),
     style: normalizeButtonStyle(record.style),
   };
 }
@@ -279,7 +293,7 @@ export function presentationToInteractiveReply(
     }
     if (block.type === "buttons") {
       const buttons = block.buttons
-        .filter((button) => button.value || button.url || button.webApp)
+        .filter((button) => button.value || button.url || button.webApp || button.web_app)
         .map((button) => {
           const interactiveButton: InteractiveReplyButton = {
             label: button.label,
@@ -291,8 +305,15 @@ export function presentationToInteractiveReply(
           if (button.url) {
             interactiveButton.url = button.url;
           }
-          if (button.webApp) {
-            interactiveButton.webApp = button.webApp;
+          const webApp = button.webApp ?? button.web_app;
+          if (webApp) {
+            interactiveButton.webApp = webApp;
+          }
+          if (button.priority !== undefined) {
+            interactiveButton.priority = button.priority;
+          }
+          if (button.disabled === true) {
+            interactiveButton.disabled = true;
           }
           return interactiveButton;
         });
@@ -370,7 +391,7 @@ export function renderMessagePresentationFallbackText(params: {
     if (block.type === "buttons") {
       const labels = block.buttons
         .map((button) => {
-          const targetUrl = button.url ?? button.webApp?.url;
+          const targetUrl = button.url ?? button.webApp?.url ?? button.web_app?.url;
           return targetUrl ? `${button.label}: ${targetUrl}` : button.label;
         })
         .filter(Boolean);

--- a/src/plugin-sdk/approval-renderers.test.ts
+++ b/src/plugin-sdk/approval-renderers.test.ts
@@ -9,14 +9,14 @@ import {
 describe("plugin-sdk/approval-renderers", () => {
   it.each([
     {
-      name: "builds shared approval payloads with generic interactive commands",
+      name: "builds shared approval payloads with generic presentation commands",
       payload: buildApprovalPendingReplyPayload({
         approvalId: "plugin:approval-123",
         approvalSlug: "plugin:a",
         text: "Approval required @everyone",
       }),
       textExpected: (text: string) => expect(text).toContain("@everyone"),
-      interactiveExpected: {
+      presentationExpected: {
         blocks: [
           {
             type: "buttons",
@@ -63,7 +63,7 @@ describe("plugin-sdk/approval-renderers", () => {
         },
       }),
       textExpected: (text: string) => expect(text).toContain("Plugin approval required"),
-      interactiveExpected: {
+      presentationExpected: {
         blocks: [
           {
             type: "buttons",
@@ -119,7 +119,7 @@ describe("plugin-sdk/approval-renderers", () => {
       }),
       textExpected: (text: string) =>
         expect(text).toContain("Reply with: /approve <id> allow-once|deny"),
-      interactiveExpected: {
+      presentationExpected: {
         blocks: [
           {
             type: "buttons",
@@ -158,7 +158,7 @@ describe("plugin-sdk/approval-renderers", () => {
         text: "resolved @everyone",
       }),
       textExpected: (text: string) => expect(text).toBe("resolved @everyone"),
-      interactiveExpected: undefined,
+      presentationExpected: undefined,
       channelDataExpected: {
         execApproval: {
           approvalId: "req-123",
@@ -183,7 +183,7 @@ describe("plugin-sdk/approval-renderers", () => {
         },
       }),
       textExpected: (text: string) => expect(text).toContain("Plugin approval allowed once"),
-      interactiveExpected: undefined,
+      presentationExpected: undefined,
       channelDataExpected: {
         execApproval: {
           approvalId: "plugin-approval-123",
@@ -195,13 +195,14 @@ describe("plugin-sdk/approval-renderers", () => {
         },
       },
     },
-  ])("$name", ({ payload, textExpected, interactiveExpected, channelDataExpected }) => {
+  ])("$name", ({ payload, textExpected, presentationExpected, channelDataExpected }) => {
     if (payload.text === undefined) {
       throw new Error("expected rendered approval text");
     }
     textExpected(payload.text);
-    if (interactiveExpected) {
-      expect(payload.interactive).toEqual(interactiveExpected);
+    if (presentationExpected) {
+      expect(payload.presentation).toEqual(presentationExpected);
+      expect(payload.interactive).toBeUndefined();
     }
     if (channelDataExpected) {
       expect(payload.channelData).toEqual(channelDataExpected);

--- a/src/plugin-sdk/approval-renderers.ts
+++ b/src/plugin-sdk/approval-renderers.ts
@@ -14,6 +14,7 @@ import type { ReplyPayload } from "./reply-payload.js";
 
 const DEFAULT_ALLOWED_DECISIONS = ["allow-once", "allow-always", "deny"] as const;
 
+/** Build a pending approval reply payload using the portable presentation API. */
 export function buildApprovalPendingReplyPayload(params: {
   approvalKind?: "exec" | "plugin";
   approvalId: string;
@@ -46,6 +47,7 @@ export function buildApprovalPendingReplyPayload(params: {
   };
 }
 
+/** Build a resolved approval reply payload with approval metadata but no controls. */
 export function buildApprovalResolvedReplyPayload(params: {
   approvalId: string;
   approvalSlug: string;

--- a/src/plugin-sdk/approval-renderers.ts
+++ b/src/plugin-sdk/approval-renderers.ts
@@ -1,5 +1,5 @@
 import {
-  buildApprovalInteractiveReply,
+  buildApprovalPresentation,
   type ExecApprovalReplyDecision,
 } from "../infra/exec-approval-reply.js";
 import {
@@ -27,7 +27,7 @@ export function buildApprovalPendingReplyPayload(params: {
   const allowedDecisions = params.allowedDecisions ?? DEFAULT_ALLOWED_DECISIONS;
   return {
     text: params.text,
-    interactive: buildApprovalInteractiveReply({
+    presentation: buildApprovalPresentation({
       approvalId: params.approvalId,
       allowedDecisions,
     }),

--- a/src/plugin-sdk/approval-reply-runtime.ts
+++ b/src/plugin-sdk/approval-reply-runtime.ts
@@ -1,5 +1,8 @@
 export {
   buildApprovalInteractiveReplyFromActionDescriptors,
+  buildApprovalPresentation,
+  buildApprovalPresentationFromActionDescriptors,
+  buildExecApprovalPresentation,
   buildExecApprovalActionDescriptors,
   buildExecApprovalPendingReplyPayload,
   getExecApprovalApproverDmNoticeText,

--- a/src/plugin-sdk/interactive-runtime.ts
+++ b/src/plugin-sdk/interactive-runtime.ts
@@ -1,4 +1,9 @@
-export { reduceInteractiveReply } from "../channels/plugins/outbound/interactive.js";
+export {
+  adaptMessagePresentationForChannel,
+  applyPresentationActionLimits,
+  presentationPageSize,
+  reduceInteractiveReply,
+} from "../channels/plugins/outbound/interactive.js";
 export type {
   InteractiveButtonStyle,
   InteractiveReply,

--- a/src/plugin-sdk/reply-payload.ts
+++ b/src/plugin-sdk/reply-payload.ts
@@ -20,6 +20,9 @@ export type OutboundReplyPayload = {
   mediaUrls?: string[];
   mediaUrl?: string;
   presentation?: InternalReplyPayload["presentation"];
+  /**
+   * @deprecated Use presentation. Runtime support remains for legacy producers.
+   */
   interactive?: InternalReplyPayload["interactive"];
   channelData?: InternalReplyPayload["channelData"];
   sensitiveMedia?: boolean;


### PR DESCRIPTION
## Summary

Adds a portable message `presentation` API for rich, channel-adapted replies and routes bundled plugin renderers through it. The API gives producers one semantic shape for text, context, dividers, buttons, selects, tones, button priority, disabled hints, URL buttons, and Telegram-style `webApp` buttons while letting each channel advertise native limits before rendering.

## New API

The new producer-facing surface is `ReplyPayload.presentation` / `AgentRuntimeReplyPayload.presentation` plus the shared `MessagePresentation` types exported from `openclaw/plugin-sdk/interactive-runtime`. Channel adapters now expose `presentationCapabilities`, including per-channel limits for actions, selects, and text, so core can adapt payloads before native rendering instead of making each channel rediscover its own constraints.

Core helpers added/updated:

- `adaptMessagePresentationForChannel(...)`: applies channel support flags and limits before rendering.
- `applyPresentationActionLimits(...)`: keeps highest-priority controls within action/row/value/label limits and emits readable fallback text for dropped controls.
- `presentationPageSize(...)`: computes page capacity from native action limits.
- `renderMessagePresentationFallbackText(...)`: produces portable fallback text when native rendering is unavailable or incomplete.
- `presentationToInteractiveReply(...)` / `presentationToInteractiveControlsReply(...)`: compatibility bridges for old internal renderers while plugins migrate.

Channel behavior:

- Slack: renders presentation controls into Block Kit, advertises Slack-specific limits, preserves explicit Slack blocks, and falls back to portable text when a presentation has no native Slack blocks.
- Telegram: renders presentation buttons directly, preserves explicit Telegram buttons and legacy interactive precedence, keeps `webApp` support, and leaves long presentation text to Telegram chunking.
- Discord: renders presentation blocks through component specs.
- Mattermost: renders value buttons natively and downgrades unsupported controls to readable text.
- Microsoft Teams: renders presentation payloads as Adaptive Cards for both normal reply delivery and message actions.
- Matrix and Feishu: advertise/render presentation where supported and downgrade unsupported controls cleanly.

## Deprecated API

Legacy producer APIs remain supported at runtime but are now marked `@deprecated` and documented as compatibility-only:

- `ReplyPayload.interactive` and `AgentRuntimeReplyPayload.interactive`; use `presentation`.
- `AgentRuntimeInteractiveReply*` type aliases; use `AgentRuntimeMessagePresentation*`.
- Slack directive/rendering producer APIs: `compileSlackInteractiveReplies(...)`, `parseSlackOptionsLine(...)`, `isSlackInteractiveRepliesEnabled(...)`, and `buildSlackInteractiveBlocks(...)`.
- Discord and Telegram legacy interactive builder helpers now point callers at presentation builders.
- Direct outbound delivery exports were already substrate-only; docs now reinforce the modern message lifecycle helpers.

Bundled/internal approval and channel paths were moved to `presentation` where practical, while legacy interactive parsing remains for old prompts, configs, and compatibility payloads.

## Review fixes folded in

- Aligned agent runtime button typing with the actual presentation schema: `webApp`, `priority`, and `disabled`.
- Preserved Telegram explicit/native and legacy interactive precedence when mixed with presentation payloads.
- Kept long presentation text chunkable for Telegram and Matrix instead of truncating too early.
- Preserved Slack fallback delivery when a semantic presentation renders no native Slack blocks.

## Verification

- `pnpm test extensions/slack/src/outbound-payload.test.ts extensions/slack/src/shared-interactive.test.ts`
- `pnpm plugin-sdk:api:check`
- `git diff --check`
- `node scripts/run-vitest.mjs src/channels/plugins/outbound/interactive.test.ts extensions/msteams/src/outbound.test.ts extensions/slack/src/shared-interactive.test.ts extensions/discord/src/shared-interactive.test.ts extensions/telegram/src/outbound-adapter.test.ts` via Codex review
- Codex review: clean, no accepted/actionable findings
- `pnpm check:changed` via Testbox `tbx_01krv16m7m5gbyck3wtxpd5v8b`, GitHub Actions `25991893555`, exit 0

## Real behavior proof

Behavior addressed: Portable presentation payloads now adapt to per-channel capabilities and limits, render natively on supported channels, and downgrade/fallback without dropping controls or text.

Real environment tested: Blacksmith Testbox from this branch head `8447f093d7408888268a12081419e07a61505350`.

Exact steps or command run after this patch: `pnpm check:changed` delegated to Testbox `tbx_01krv16m7m5gbyck3wtxpd5v8b` / Actions `25991893555`.

Evidence after fix: Changed gate completed with exit 0; focused Slack presentation fallback tests and plugin SDK API check also passed locally.

Observed result after fix: Core, extension, docs, typecheck, lint, import-cycle, and guard lanes passed for the changed surface.

What was not tested: Live Slack/Telegram/Teams/Discord/Mattermost sends against real external workspaces were not run in this PR.
