### PR TITLE
fix(gateway): accept delta-only assistant events for live chat projection

### DIFF
--- a/src/gateway/live-chat-projector.test.ts
+++ b/src/gateway/live-chat-projector.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { hasLiveAssistantContent, resolveMergedAssistantText } from "./live-chat-projector.js";
+
+describe("hasLiveAssistantContent", () => {
+  it("returns true for text-only events", () => {
+    expect(hasLiveAssistantContent({ text: "hi" })).toBe(true);
+  });
+
+  it("returns true for delta-only events", () => {
+    expect(hasLiveAssistantContent({ delta: "hi" })).toBe(true);
+  });
+
+  it("returns true when both text and delta are present", () => {
+    expect(hasLiveAssistantContent({ text: "hi", delta: "lo" })).toBe(true);
+  });
+
+  it("returns false when neither text nor delta are strings", () => {
+    expect(hasLiveAssistantContent({})).toBe(false);
+    expect(hasLiveAssistantContent({ text: 1, delta: 2 })).toBe(false);
+    expect(hasLiveAssistantContent({ text: null, delta: undefined })).toBe(false);
+  });
+
+  it("returns false for null, undefined, or non-object data", () => {
+    expect(hasLiveAssistantContent(null)).toBe(false);
+    expect(hasLiveAssistantContent(undefined)).toBe(false);
+    expect(hasLiveAssistantContent("hello")).toBe(false);
+    expect(hasLiveAssistantContent(42)).toBe(false);
+  });
+
+  it("accepts an empty string as valid live content", () => {
+    expect(hasLiveAssistantContent({ text: "" })).toBe(true);
+    expect(hasLiveAssistantContent({ delta: "" })).toBe(true);
+  });
+});
+
+describe("resolveMergedAssistantText delta-only inputs", () => {
+  it("treats delta as the first chunk when previous buffer is empty", () => {
+    const result = resolveMergedAssistantText({
+      previousText: "",
+      nextText: "",
+      nextDelta: "hello",
+    });
+    expect(result).toBe("hello");
+  });
+
+  it("appends delta to the previous buffer when text is absent", () => {
+    const result = resolveMergedAssistantText({
+      previousText: "hello ",
+      nextText: "",
+      nextDelta: "world",
+    });
+    expect(result).toBe("hello world");
+  });
+
+  it("returns the previous buffer when both text and delta are empty", () => {
+    const result = resolveMergedAssistantText({
+      previousText: "buffered",
+      nextText: "",
+      nextDelta: "",
+    });
+    expect(result).toBe("buffered");
+  });
+});

--- a/src/gateway/live-chat-projector.ts
+++ b/src/gateway/live-chat-projector.ts
@@ -88,3 +88,11 @@ export function projectLiveAssistantBufferedText(
 export function shouldSuppressAssistantEventForLiveChat(data: unknown): boolean {
   return resolveAssistantEventPhase(data) === "commentary";
 }
+
+export function hasLiveAssistantContent(data: unknown): boolean {
+  if (typeof data !== "object" || data === null) {
+    return false;
+  }
+  const candidate = data as { text?: unknown; delta?: unknown };
+  return typeof candidate.text === "string" || typeof candidate.delta === "string";
+}

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -8,6 +8,7 @@ import { resolveHeartbeatVisibility } from "../infra/heartbeat-visibility.js";
 import { isAcpSessionKey, isSubagentSessionKey } from "../sessions/session-key-utils.js";
 import { setSafeTimeout } from "../utils/timer-delay.js";
 import {
+  hasLiveAssistantContent,
   normalizeLiveAssistantEventText,
   projectLiveAssistantBufferedText,
   resolveMergedAssistantText,
@@ -953,10 +954,11 @@ export function createAgentEventHandler({
       if (
         !isAborted &&
         evt.stream === "assistant" &&
-        typeof evt.data?.text === "string" &&
+        hasLiveAssistantContent(evt.data) &&
         !shouldSuppressAssistantEventForLiveChat(evt.data)
       ) {
-        emitChatDelta(sessionKey, clientRunId, evt.runId, evt.seq, evt.data.text, evt.data.delta);
+        const eventText = typeof evt.data?.text === "string" ? evt.data.text : "";
+        emitChatDelta(sessionKey, clientRunId, evt.runId, evt.seq, eventText, evt.data?.delta);
       }
     }
 

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -240,6 +240,61 @@ describe("EmbeddedTuiBackend", () => {
     ]);
   });
 
+  it("emits a chat delta for assistant events that only carry delta with no text", async () => {
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    const pending = deferred<{
+      payloads: Array<{ text: string }>;
+      meta: Record<string, unknown>;
+    }>();
+    agentCommandFromIngressMock.mockReturnValueOnce(pending.promise);
+
+    const backend = new EmbeddedTuiBackend();
+    const events: Array<{ event: string; payload: unknown }> = [];
+    backend.onEvent = (evt) => {
+      events.push({ event: evt.event, payload: evt.payload });
+    };
+
+    backend.start();
+    await flushMicrotasks();
+
+    await backend.sendChat({
+      sessionKey: "agent:main:main",
+      message: "hello",
+      runId: "run-delta-only",
+    });
+
+    registeredListener?.({
+      runId: "run-delta-only",
+      stream: "assistant",
+      data: { delta: "hello" },
+    });
+    registeredListener?.({
+      runId: "run-delta-only",
+      stream: "lifecycle",
+      data: { phase: "end", stopReason: "stop" },
+    });
+
+    pending.resolve({ payloads: [{ text: "hello" }], meta: {} });
+    await flushMicrotasks();
+
+    const chatDelta = events.find(
+      (entry) =>
+        entry.event === "chat" &&
+        (entry.payload as { state?: string } | undefined)?.state === "delta",
+    );
+    expect(chatDelta).toBeDefined();
+    expect(chatDelta?.payload).toMatchObject({
+      runId: "run-delta-only",
+      sessionKey: "agent:main:main",
+      state: "delta",
+      deltaText: "hello",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "hello" }],
+      },
+    });
+  });
+
   it("keeps final short replies like No after suppressing lead-fragment deltas", async () => {
     const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
     const pending = deferred<{

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -12,6 +12,7 @@ import {
 } from "../gateway/chat-display-projection.js";
 import { augmentChatHistoryWithCliSessionImports } from "../gateway/cli-session-history.js";
 import {
+  hasLiveAssistantContent,
   normalizeLiveAssistantEventText,
   projectLiveAssistantBufferedText,
   resolveMergedAssistantText,
@@ -531,12 +532,13 @@ export class EmbeddedTuiBackend implements TuiBackend {
     if (
       evt.stream === "assistant" &&
       !run.isBtw &&
-      typeof evt.data?.text === "string" &&
+      hasLiveAssistantContent(evt.data) &&
       !shouldSuppressAssistantEventForLiveChat(evt.data)
     ) {
+      const eventText = typeof evt.data?.text === "string" ? evt.data.text : "";
       const cleaned = normalizeLiveAssistantEventText({
-        text: evt.data.text,
-        delta: evt.data.delta,
+        text: eventText,
+        delta: evt.data?.delta,
       });
       run.buffer = resolveMergedAssistantText({
         previousText: run.buffer,


### PR DESCRIPTION
## Summary

`src/gateway/server-chat.ts` and `src/tui/embedded-backend.ts` both gated live chat projection on a cumulative `data.text` string, dropping canonical assistant events that only carry an incremental `data.delta`. Live UIs lost working/streaming state between run start and final response.

Add a small `hasLiveAssistantContent` helper in `src/gateway/live-chat-projector.ts` so the gate accepts either `text` or `delta`. `emitChatDelta` and `resolveMergedAssistantText` already merge delta-only inputs correctly, so the change is limited to the two gates plus their import.

Fixes #82988

## Real behavior proof

**Behavior addressed:** Gateway and embedded TUI live chat projection drop assistant events that only carry `data.delta`. After this patch, both gates accept either `data.text` or `data.delta`, and the existing `resolveMergedAssistantText` buffer keeps streaming deltas appended into the live chat surface.

**Real environment tested:** Local macOS checkout of `openclaw/openclaw` in a git worktree based on `origin/main` `2c9f68f42b`, Node `v25.5.0`, `tsx` loader from the repo's `node_modules`.

**Exact steps or command run after this patch:**

```
node --import tsx .artifacts/probe-82988.mjs
```

The probe imports the patched `src/gateway/live-chat-projector.ts` directly and exercises (a) the new `hasLiveAssistantContent` predicate that both gates now consult, and (b) the existing `resolveMergedAssistantText` buffer with a delta-only stream that simulates the exact event shape from the issue.

**Evidence after fix:** Live stdout from the probe (real `node` runtime, no test framework):

```
PASS text-only event accepted -> true (expected true)
PASS delta-only event accepted (the #82988 case) -> true (expected true)
PASS text+delta event accepted -> true (expected true)
PASS event without text or delta rejected -> false (expected false)
PASS null data rejected -> false (expected false)
PROBE buffered live chat from delta-only stream: {"firstChunk":"hello","secondChunk":"hello world"}

Result: 5 passed, 0 failed
```

Pre-patch, the delta-only event would have failed the `typeof evt.data?.text === "string"` gate in both `server-chat.ts` and `embedded-backend.ts`, so the chat projection layer would never reach `emitChatDelta` and the buffered `firstChunk` / `secondChunk` would stay empty.

**Observed result after fix:** Assistant events that only carry `data.delta` now pass the live chat gate and are appended to the per-run buffer through the existing `resolveMergedAssistantText` merge path. A delta-only stream of `\"hello\"` followed by `\" world\"` accumulates to `\"hello world\"` in the live chat surface instead of being dropped.

**What was not tested:** End-to-end live run through a real provider that emits delta-only assistant events; the unaffected throttle/coalesce path (`isAgentTextThrottleEvent`) intentionally still requires `data.text` because the issue is scoped to live chat projection.

## Verification

- `node scripts/run-vitest.mjs src/gateway/live-chat-projector.test.ts src/tui/embedded-backend.test.ts` -> 4 files, 38/38 pass (covers the new `hasLiveAssistantContent` cases, the `resolveMergedAssistantText` delta-only path, and a new TUI test `emits a chat delta for assistant events that only carry delta with no text`).
- `node --import tsx .artifacts/probe-82988.mjs` -> 5/5 pass (output above).

The probe script lives at `.artifacts/probe-82988.mjs` in the contributor environment only; it is not part of the committed diff.