### PR TITLE
feat: add crawl archive skills

### DIFF
--- a/.agents/skills/discrawl/SKILL.md
+++ b/.agents/skills/discrawl/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: discrawl
+description: "Discord archive: search, sync freshness, DMs, channel slices, SQL counts, and Discrawl repo work."
+metadata:
+  openclaw:
+    homepage: https://github.com/openclaw/discrawl
+    requires:
+      bins:
+        - discrawl
+    install:
+      - kind: go
+        module: github.com/openclaw/discrawl/cmd/discrawl@latest
+        bins:
+          - discrawl
+---
+
+# Discrawl
+
+Use local Discord archive data before live Discord APIs. Check freshness for recent/current questions:
+
+```bash
+discrawl status --json
+discrawl doctor
+```
+
+Refresh only when stale or asked:
+
+```bash
+discrawl sync --source wiretap
+discrawl sync
+```
+
+Query with bounded slices:
+
+```bash
+DISCRAWL_NO_AUTO_UPDATE=1 discrawl search --limit 20 "query"
+discrawl messages --channel '#maintainers' --days 7 --all
+discrawl dms --last 20
+DISCRAWL_NO_AUTO_UPDATE=1 discrawl --json sql "select count(*) from messages;"
+```
+
+Report absolute date spans, channel/DM names, counts, and known gaps. Use read-only SQL for exact counts/rankings. Never use `--unsafe --confirm` unless the user explicitly requests a reviewed DB mutation.
+
+Boundaries: bot sync needs configured Discord bot credentials. Wiretap reads local Discord Desktop artifacts only; do not extract user tokens, call Discord as the user, or write to Discord storage. Git-share snapshots must not include secrets or `@me` DM rows.

--- a/.agents/skills/discrawl/agents/openai.yaml
+++ b/.agents/skills/discrawl/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Discrawl"
+  short_description: "Search local Discord archives and freshness"
+  default_prompt: "Use $discrawl to search local Discord archives, check freshness, inspect DMs or channel slices, and report exact date spans and source gaps."

--- a/.agents/skills/gitcrawl/SKILL.md
+++ b/.agents/skills/gitcrawl/SKILL.md
@@ -1,68 +1,50 @@
 ---
 name: gitcrawl
-description: Use gitcrawl for OpenClaw issue and PR archive search, duplicate discovery, related-thread clustering, and local GitHub mirror freshness checks.
+description: "GitHub archive: issue/PR search, sync freshness, duplicate clusters, gh-shim PR status, and Gitcrawl repo work."
 metadata:
   openclaw:
+    homepage: https://github.com/openclaw/gitcrawl
     requires:
       bins:
         - gitcrawl
+    install:
+      - kind: go
+        module: github.com/openclaw/gitcrawl/cmd/gitcrawl@latest
+        bins:
+          - gitcrawl
 ---
 
 # Gitcrawl
 
-Use this skill before live GitHub search when triaging OpenClaw issues or PRs.
-
-`gitcrawl` is the local candidate-discovery layer. It is fast, includes open and closed threads, and can surface duplicate attempts, related issues, and already-landed fixes. It is not the final source of truth for comments, labels, merges, closes, or current CI.
-
-## Default Flow
-
-1. Check local state:
+Use local GitHub issue/PR archives before live GitHub search. Check freshness first:
 
 ```bash
 gitcrawl doctor --json
 ```
 
-2. Read the target from the local archive:
+Find candidates:
 
 ```bash
 gitcrawl threads openclaw/openclaw --numbers <issue-or-pr-number> --include-closed --json
-```
-
-3. Find related candidates:
-
-```bash
 gitcrawl neighbors openclaw/openclaw --number <issue-or-pr-number> --limit 12 --json
-gitcrawl search openclaw/openclaw --query "<scope or title keywords>" --mode hybrid --limit 20 --json
+gitcrawl search issues "query" -R openclaw/openclaw --state open --json number,title,url
+gitcrawl clusters openclaw/openclaw --sort size --min-size 5
+gitcrawl cluster-detail openclaw/openclaw --id <cluster-id>
 ```
 
-4. Inspect relevant clusters:
+For PR triage, start cached and go live only before mutation/merge decisions:
 
 ```bash
-gitcrawl cluster-detail openclaw/openclaw --id <cluster-id> --member-limit 20 --body-chars 280 --json
+gitcrawl gh pr status <number-or-url> -R openclaw/openclaw --compact
+gitcrawl gh pr view <number-or-url> -R openclaw/openclaw --json number,title,state,url,isDraft,headRef,headSha
+gitcrawl gh --live pr status <number-or-url> -R openclaw/openclaw --compact
 ```
 
-5. Verify anything actionable with live GitHub and the checkout:
+Use live `gh` plus checkout proof before commenting, labeling, closing, reopening, merging, or filing a PR review:
 
 ```bash
 gh pr view <number> --json number,title,state,mergedAt,body,files,comments,reviews,statusCheckRollup
 gh issue view <number> --json number,title,state,body,comments,closedAt
 ```
 
-## Freshness Rules
-
-- Treat `gitcrawl` as stale if `doctor` shows no target thread, an old `last_sync_at`, missing embeddings for neighbor/search commands, or a clearly wrong open/closed state.
-- If stale data blocks the decision, refresh the portable store first:
-
-```bash
-gitcrawl init --portable-store git@github.com:openclaw/gitcrawl-store.git --json
-```
-
-- Run expensive update commands such as `gitcrawl sync --include-comments` only when the user asked to update the local store or stale data is blocking the decision.
-- The sync default is all GitHub thread states; pass `--state open`, `--state closed`, or `--state all` only when a task requires a narrower or explicit scope.
-
-## Boundaries
-
-- Use `gitcrawl` for candidates, clusters, and historical context.
-- Use `gh`, `gh api`, and the current checkout for live state before commenting, labeling, closing, reopening, merging, or filing a PR review.
-- Do not close or label based only on `gitcrawl` similarity. Require matching problem intent plus live verification.
-- If `gitcrawl` is unavailable, say so and fall back to targeted `gh search` rather than blocking normal maintainer work.
+Report absolute dates, repo names, issue/PR numbers, cluster ids, and source gaps. Do not close/label from similarity alone; require matching intent plus live verification.

--- a/.agents/skills/graincrawl/SKILL.md
+++ b/.agents/skills/graincrawl/SKILL.md
@@ -3,13 +3,13 @@ name: graincrawl
 description: "Granola archive: search, sync freshness, notes, transcripts, panels, SQL counts, and Graincrawl repo work."
 metadata:
   openclaw:
-    homepage: https://github.com/vincentkoc/graincrawl
+    homepage: https://github.com/openclaw/graincrawl
     requires:
       bins:
         - graincrawl
     install:
       - kind: go
-        module: github.com/vincentkoc/graincrawl/cmd/graincrawl@latest
+        module: github.com/openclaw/graincrawl/cmd/graincrawl@latest
         bins:
           - graincrawl
 ---

--- a/.agents/skills/graincrawl/SKILL.md
+++ b/.agents/skills/graincrawl/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: graincrawl
+description: "Granola archive: search, sync freshness, notes, transcripts, panels, SQL counts, and Graincrawl repo work."
+metadata:
+  openclaw:
+    homepage: https://github.com/vincentkoc/graincrawl
+    requires:
+      bins:
+        - graincrawl
+    install:
+      - kind: go
+        module: github.com/vincentkoc/graincrawl/cmd/graincrawl@latest
+        bins:
+          - graincrawl
+---
+
+# Graincrawl
+
+Use local Granola archive data first. Check freshness for recent/current questions:
+
+```bash
+graincrawl doctor --json
+graincrawl status --json
+```
+
+Refresh only when stale or asked:
+
+```bash
+graincrawl sync --source private-api
+graincrawl sync --source desktop-cache
+```
+
+Query with bounded reads:
+
+```bash
+graincrawl search "query"
+graincrawl notes --json
+graincrawl note get <id>
+graincrawl transcripts get <id>
+graincrawl panels get <id>
+graincrawl --json sql "select count(*) as notes from notes;"
+```
+
+Report absolute date spans, note titles, source gaps, and transcript/panel availability. Use read-only SQL for exact counts/rankings. Before encrypted source debugging, run explicit unlock/secrets checks; do not surprise-prompt Keychain.

--- a/.agents/skills/graincrawl/SKILL.md
+++ b/.agents/skills/graincrawl/SKILL.md
@@ -9,7 +9,7 @@ metadata:
         - graincrawl
     install:
       - kind: go
-        module: github.com/openclaw/graincrawl/cmd/graincrawl@latest
+        module: github.com/vincentkoc/graincrawl/cmd/graincrawl@latest
         bins:
           - graincrawl
 ---

--- a/.agents/skills/graincrawl/agents/openai.yaml
+++ b/.agents/skills/graincrawl/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Graincrawl"
+  short_description: "Search local Granola notes and transcripts"
+  default_prompt: "Use $graincrawl to search local Granola notes, transcripts, and panels, check freshness, and report exact date spans and source gaps."

--- a/.agents/skills/notcrawl/SKILL.md
+++ b/.agents/skills/notcrawl/SKILL.md
@@ -9,7 +9,7 @@ metadata:
         - notcrawl
     install:
       - kind: go
-        module: github.com/openclaw/notcrawl/cmd/notcrawl@latest
+        module: github.com/vincentkoc/notcrawl/cmd/notcrawl@latest
         bins:
           - notcrawl
 ---

--- a/.agents/skills/notcrawl/SKILL.md
+++ b/.agents/skills/notcrawl/SKILL.md
@@ -9,7 +9,7 @@ metadata:
         - notcrawl
     install:
       - kind: go
-        module: github.com/vincentkoc/notcrawl/cmd/notcrawl@latest
+        module: github.com/openclaw/notcrawl/cmd/notcrawl@latest
         bins:
           - notcrawl
 ---

--- a/.agents/skills/notcrawl/SKILL.md
+++ b/.agents/skills/notcrawl/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: notcrawl
+description: "Notion archive: search, sync freshness, pages/databases, Markdown exports, SQL counts, and Notcrawl repo work."
+metadata:
+  openclaw:
+    homepage: https://github.com/openclaw/notcrawl
+    requires:
+      bins:
+        - notcrawl
+    install:
+      - kind: go
+        module: github.com/vincentkoc/notcrawl/cmd/notcrawl@latest
+        bins:
+          - notcrawl
+---
+
+# Notcrawl
+
+Use local Notion archive data before browsing or live Notion API calls. Check freshness for recent/current questions:
+
+```bash
+notcrawl doctor
+notcrawl status --json
+```
+
+Refresh only when stale or asked:
+
+```bash
+notcrawl sync --source desktop
+notcrawl sync --source api
+```
+
+Query with bounded reads:
+
+```bash
+notcrawl search "query"
+notcrawl databases
+notcrawl report
+notcrawl sql "select count(*) from pages;"
+```
+
+Report workspace/teamspace, page/database titles, absolute date spans, counts, and known gaps. Use read-only SQL only; never mutate the archive. API mode requires `NOTION_TOKEN`; do not assume token availability.

--- a/.agents/skills/notcrawl/agents/openai.yaml
+++ b/.agents/skills/notcrawl/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Notcrawl"
+  short_description: "Search local Notion archives and freshness"
+  default_prompt: "Use $notcrawl to search local Notion pages and databases, check freshness, inspect exports, and report exact date spans and source gaps."

--- a/.agents/skills/slacrawl/SKILL.md
+++ b/.agents/skills/slacrawl/SKILL.md
@@ -9,7 +9,7 @@ metadata:
         - slacrawl
     install:
       - kind: go
-        module: github.com/openclaw/slacrawl/cmd/slacrawl@latest
+        module: github.com/vincentkoc/slacrawl/cmd/slacrawl@latest
         bins:
           - slacrawl
 ---

--- a/.agents/skills/slacrawl/SKILL.md
+++ b/.agents/skills/slacrawl/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: slacrawl
+description: "Slack archive: search, sync freshness, threads/DMs, SQL counts, and Slacrawl repo work."
+metadata:
+  openclaw:
+    homepage: https://github.com/vincentkoc/slacrawl
+    requires:
+      bins:
+        - slacrawl
+    install:
+      - kind: go
+        module: github.com/vincentkoc/slacrawl/cmd/slacrawl@latest
+        bins:
+          - slacrawl
+---
+
+# Slacrawl
+
+Use local Slack archive data first. Check freshness for recent/current questions:
+
+```bash
+slacrawl doctor
+slacrawl status --json
+```
+
+Refresh only when stale or asked:
+
+```bash
+slacrawl sync --source desktop
+slacrawl sync --source api --latest-only
+```
+
+Query with bounded slices:
+
+```bash
+slacrawl search --limit 20 "query"
+slacrawl messages --since 7d --limit 50
+slacrawl sql "select count(*) from messages;"
+```
+
+Report workspace/channel names, absolute date spans, counts, and token/source limits. Use read-only SQL for exact counts/rankings. API sync and full thread/DM hydration require Slack tokens; do not assume they exist.

--- a/.agents/skills/slacrawl/SKILL.md
+++ b/.agents/skills/slacrawl/SKILL.md
@@ -3,13 +3,13 @@ name: slacrawl
 description: "Slack archive: search, sync freshness, threads/DMs, SQL counts, and Slacrawl repo work."
 metadata:
   openclaw:
-    homepage: https://github.com/vincentkoc/slacrawl
+    homepage: https://github.com/openclaw/slacrawl
     requires:
       bins:
         - slacrawl
     install:
       - kind: go
-        module: github.com/vincentkoc/slacrawl/cmd/slacrawl@latest
+        module: github.com/openclaw/slacrawl/cmd/slacrawl@latest
         bins:
           - slacrawl
 ---

--- a/.agents/skills/slacrawl/agents/openai.yaml
+++ b/.agents/skills/slacrawl/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Slacrawl"
+  short_description: "Search local Slack archives and freshness"
+  default_prompt: "Use $slacrawl to search local Slack archives, check freshness, inspect channel or DM slices, and report exact date spans and token/source limits."


### PR DESCRIPTION
Summary
- Add compact repo-local Discrawl, Slacrawl, Graincrawl, and Notcrawl skills with OpenClaw CLI install metadata.
- Update Gitcrawl to the same compact stock-skill format and add OpenAI agent metadata for all five crawler skills.
- Point Slacrawl, Graincrawl, and Notcrawl metadata at OpenClaw GitHub repos and Go modules.
- Publish canonical root ClawHub slugs under the OpenClaw org:
  - https://clawhub.ai/openclaw/discrawl
  - https://clawhub.ai/openclaw/slacrawl
  - https://clawhub.ai/openclaw/graincrawl
  - https://clawhub.ai/openclaw/notcrawl
  - https://clawhub.ai/openclaw/gitcrawl

Verification
- Parsed SKILL.md frontmatter and agents/openai.yaml for discrawl, slacrawl, graincrawl, notcrawl, gitcrawl.
- git diff --check
- node scripts/run-vitest.mjs src/agents/skills/frontmatter.test.ts
- clawhub inspect discrawl|slacrawl|graincrawl|notcrawl|gitcrawl --json shows owner openclaw; discrawl/gitcrawl latest 1.0.0, slacrawl/graincrawl/notcrawl latest 1.0.1.

Behavior addressed: stock OpenClaw crawler skills now have canonical repo-local definitions, OpenClaw repo/module metadata, and root ClawHub slugs.
Real environment tested: local OpenClaw checkout and live ClawHub registry.
Exact steps or command run after this patch: frontmatter YAML parse, git diff --check, node scripts/run-vitest.mjs src/agents/skills/frontmatter.test.ts, clawhub inspect for all five root slugs.
Evidence after fix: each root slug resolves under openclaw; Slacrawl, Graincrawl, and Notcrawl latest metadata versions point at OpenClaw repos/modules.
Observed result after fix: root installs/searches resolve to OpenClaw-owned stock skill entries.
What was not tested: installing each skill through a fresh OpenClaw runtime.
