### PR TITLE
Fix config patch restart-required notices

### DIFF
--- a/src/gateway/server-methods/config-write-flow.ts
+++ b/src/gateway/server-methods/config-write-flow.ts
@@ -132,21 +132,40 @@ function queueSharedGatewayAuthGenerationRefresh(
   });
 }
 
-function shouldScheduleDirectConfigRestart(params: {
+function isNoopConfigReloadPlan(plan: ReturnType<typeof buildGatewayReloadPlan>): boolean {
+  return (
+    !plan.restartGateway &&
+    plan.hotReasons.length === 0 &&
+    !plan.reloadHooks &&
+    !plan.restartGmailWatcher &&
+    !plan.restartCron &&
+    !plan.restartHeartbeat &&
+    !plan.restartHealthMonitor &&
+    !plan.reloadPlugins &&
+    !plan.disposeMcpRuntimes &&
+    plan.restartChannels.size === 0
+  );
+}
+
+function resolveConfigRestartRequirement(params: {
   changedPaths: string[];
   nextConfig: OpenClawConfig;
-}): boolean {
+}): { requiresRestart: boolean; scheduleDirectRestart: boolean } {
   const reloadSettings = resolveGatewayReloadSettings(params.nextConfig);
-  if (reloadSettings.mode === "off") {
-    return true;
-  }
-  // Hybrid mode lets hot-reload own non-gateway restarts; only paths the reload
-  // plan marks as gateway-owned get a direct process restart here.
   const plan = buildGatewayReloadPlan(params.changedPaths);
-  if (reloadSettings.mode === "hot" && plan.restartGateway) {
-    return true;
+  if (isNoopConfigReloadPlan(plan)) {
+    return { requiresRestart: false, scheduleDirectRestart: false };
   }
-  return false;
+  if (reloadSettings.mode === "off") {
+    return { requiresRestart: true, scheduleDirectRestart: true };
+  }
+  if (reloadSettings.mode === "restart") {
+    return { requiresRestart: true, scheduleDirectRestart: false };
+  }
+  if (plan.restartGateway) {
+    return { requiresRestart: true, scheduleDirectRestart: reloadSettings.mode === "hot" };
+  }
+  return { requiresRestart: false, scheduleDirectRestart: false };
 }
 
 function resolveConfigRestartRequest(params: unknown): {
@@ -182,6 +201,7 @@ function buildConfigRestartSentinelPayload(params: {
   kind: RestartSentinelPayload["kind"];
   mode: string;
   configPath: string;
+  requiresRestart: boolean;
   sessionKey: string | undefined;
   deliveryContext: ReturnType<typeof extractDeliveryInfo>["deliveryContext"];
   threadId: ReturnType<typeof extractDeliveryInfo>["threadId"];
@@ -199,6 +219,7 @@ function buildConfigRestartSentinelPayload(params: {
     stats: {
       mode: params.mode,
       root: params.configPath,
+      requiresRestart: params.requiresRestart,
     },
   };
 }
@@ -260,20 +281,22 @@ export async function resolveGatewayConfigRestartWriteResult(params: {
 }> {
   const { sessionKey, note, restartDelayMs, deliveryContext, threadId } =
     resolveConfigRestartRequest(params.requestParams);
+  const restartRequirement = resolveConfigRestartRequirement({
+    changedPaths: params.changedPaths,
+    nextConfig: params.nextConfig,
+  });
   const payload = buildConfigRestartSentinelPayload({
     kind: params.kind,
     mode: params.mode,
     configPath: params.configPath,
+    requiresRestart: restartRequirement.requiresRestart,
     sessionKey,
     deliveryContext,
     threadId,
     note,
   });
   const sentinelPersisted = await tryWriteRestartSentinelPayload(payload);
-  const restart = shouldScheduleDirectConfigRestart({
-    changedPaths: params.changedPaths,
-    nextConfig: params.nextConfig,
-  })
+  const restart = restartRequirement.scheduleDirectRestart
     ? scheduleGatewaySigusr1Restart({
         delayMs: restartDelayMs,
         reason: params.mode,

--- a/src/gateway/server-methods/config.shared-auth.test.ts
+++ b/src/gateway/server-methods/config.shared-auth.test.ts
@@ -353,6 +353,33 @@ describe("config shared auth disconnects", () => {
     await runConfigPatch({ gateway: { port: 19001 } });
 
     expect(scheduleGatewaySigusr1RestartMock).toHaveBeenCalledTimes(1);
+    const payload = restartSentinelMocks.writeRestartSentinel.mock.calls.at(-1)?.[0];
+    expect(payload?.stats?.requiresRestart).toBe(true);
+  });
+
+  it("marks hot-reloaded config.patch writes as not restart required", async () => {
+    const prevConfig: OpenClawConfig = {
+      gateway: {
+        channelHealthCheckMinutes: 10,
+      },
+    };
+    readConfigFileSnapshotForWriteMock.mockResolvedValue(createConfigWriteSnapshot(prevConfig));
+
+    const { options } = createConfigHandlerHarness({
+      method: "config.patch",
+      params: {
+        baseHash: "base-hash",
+        raw: JSON.stringify({ gateway: { channelHealthCheckMinutes: 15 } }),
+        restartDelayMs: 1_000,
+      },
+    });
+
+    await configHandlers["config.patch"](options);
+    await flushConfigHandlerMicrotasks();
+
+    expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
+    const payload = restartSentinelMocks.writeRestartSentinel.mock.calls.at(-1)?.[0];
+    expect(payload?.stats?.requiresRestart).toBe(false);
   });
 
   it("does not add an agent continuation from generic control-plane sessionKey params", async () => {

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -458,12 +458,8 @@ describe("scheduleRestartSentinelWake", () => {
     });
     expect(mocks.ackDelivery).toHaveBeenCalledWith("queue-1");
     expect(mocks.failDelivery).not.toHaveBeenCalled();
-    expect(mocks.formatRestartSentinelMessage).toHaveBeenCalledWith(expect.anything(), {
-      state: "completed",
-    });
-    expect(mocks.summarizeRestartSentinel).toHaveBeenCalledWith(expect.anything(), {
-      state: "completed",
-    });
+    expect(mocks.formatRestartSentinelMessage).toHaveBeenCalledWith(expect.anything());
+    expect(mocks.summarizeRestartSentinel).toHaveBeenCalledWith(expect.anything());
     expect(mockCallArg(mocks.enqueueSystemEvent)).toBe("restart message");
     expectNthSystemEventFields(0, {
       sessionKey: "agent:main:main",

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -426,6 +426,8 @@ describe("scheduleRestartSentinelWake", () => {
     mocks.finalizeUpdateRestartSentinelRunningVersion.mockReset();
     mocks.finalizeUpdateRestartSentinelRunningVersion.mockResolvedValue(null);
     mocks.clearRestartSentinel.mockClear();
+    mocks.formatRestartSentinelMessage.mockClear();
+    mocks.summarizeRestartSentinel.mockClear();
     mocks.injectTimestamp.mockClear();
     mocks.timestampOptsFromConfig.mockClear();
     mocks.recordInboundSessionAndDispatchReply.mockReset();
@@ -456,6 +458,12 @@ describe("scheduleRestartSentinelWake", () => {
     });
     expect(mocks.ackDelivery).toHaveBeenCalledWith("queue-1");
     expect(mocks.failDelivery).not.toHaveBeenCalled();
+    expect(mocks.formatRestartSentinelMessage).toHaveBeenCalledWith(expect.anything(), {
+      state: "completed",
+    });
+    expect(mocks.summarizeRestartSentinel).toHaveBeenCalledWith(expect.anything(), {
+      state: "completed",
+    });
     expect(mockCallArg(mocks.enqueueSystemEvent)).toBe("restart message");
     expectNthSystemEventFields(0, {
       sessionKey: "agent:main:main",

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -453,8 +453,8 @@ async function loadRestartSentinelStartupTask(params: {
     recordLatestUpdateRestartSentinel(payload);
   }
   const sessionKey = payload.sessionKey?.trim();
-  const message = formatRestartSentinelMessage(payload, { state: "completed" });
-  const summary = summarizeRestartSentinel(payload, { state: "completed" });
+  const message = formatRestartSentinelMessage(payload);
+  const summary = summarizeRestartSentinel(payload);
   const wakeDeliveryContext = mergeDeliveryContext(
     payload.threadId != null
       ? { ...payload.deliveryContext, threadId: payload.threadId }

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -453,8 +453,8 @@ async function loadRestartSentinelStartupTask(params: {
     recordLatestUpdateRestartSentinel(payload);
   }
   const sessionKey = payload.sessionKey?.trim();
-  const message = formatRestartSentinelMessage(payload);
-  const summary = summarizeRestartSentinel(payload);
+  const message = formatRestartSentinelMessage(payload, { state: "completed" });
+  const summary = summarizeRestartSentinel(payload, { state: "completed" });
   const wakeDeliveryContext = mergeDeliveryContext(
     payload.threadId != null
       ? { ...payload.deliveryContext, threadId: payload.threadId }

--- a/src/infra/restart-sentinel.test.ts
+++ b/src/infra/restart-sentinel.test.ts
@@ -297,6 +297,9 @@ describe("restart sentinel", () => {
       ].join("\n"),
     );
     expect(summarizeRestartSentinel(payload)).toBe("Gateway restart required (config.patch)");
+    expect(summarizeRestartSentinel(payload, { state: "pending" })).toBe(
+      "Gateway restart required (config.patch)",
+    );
     expect(summarizeRestartSentinel(payload, { state: "completed" })).toBe(
       "Gateway restart completed (config.patch)",
     );

--- a/src/infra/restart-sentinel.test.ts
+++ b/src/infra/restart-sentinel.test.ts
@@ -281,6 +281,7 @@ describe("restart sentinel", () => {
       status: "ok" as const,
       ts: Date.now(),
       message: "Run restart-gateway.ps1 to apply config changes.",
+      doctorHint: "Run openclaw doctor --non-interactive",
       stats: { mode: "config.patch", requiresRestart: true },
     };
 
@@ -288,13 +289,11 @@ describe("restart sentinel", () => {
       [
         "Gateway restart required (config.patch)",
         "Run restart-gateway.ps1 to apply config changes.",
+        "Run openclaw doctor --non-interactive",
       ].join("\n"),
     );
     expect(formatRestartSentinelMessage(payload, { state: "completed" })).toBe(
-      [
-        "Gateway restart completed (config.patch)",
-        "Run restart-gateway.ps1 to apply config changes.",
-      ].join("\n"),
+      "Gateway restart completed (config.patch)",
     );
     expect(summarizeRestartSentinel(payload)).toBe("Gateway restart required (config.patch)");
     expect(summarizeRestartSentinel(payload, { state: "pending" })).toBe(

--- a/src/infra/restart-sentinel.test.ts
+++ b/src/infra/restart-sentinel.test.ts
@@ -196,7 +196,7 @@ describe("restart sentinel", () => {
 
   it("keeps old config restart sentinels readable without restart-required stats", async () => {
     await withRestartSentinelStateDir(async () => {
-      const filePath = resolveRestartSentinelPath();
+      const filePath = path.join(process.env.OPENCLAW_STATE_DIR ?? "", "restart-sentinel.json");
       const payload = {
         kind: "config-patch" as const,
         status: "ok" as const,

--- a/src/infra/restart-sentinel.test.ts
+++ b/src/infra/restart-sentinel.test.ts
@@ -194,6 +194,39 @@ describe("restart sentinel", () => {
     });
   });
 
+  it("keeps old config restart sentinels readable without restart-required stats", async () => {
+    await withRestartSentinelStateDir(async () => {
+      const filePath = resolveRestartSentinelPath();
+      const payload = {
+        kind: "config-patch" as const,
+        status: "ok" as const,
+        ts: Date.now(),
+        message: "Config updated successfully",
+        stats: { mode: "config.patch" },
+      };
+      await fs.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.writeFile(filePath, JSON.stringify({ version: 1, payload }, null, 2), "utf-8");
+
+      const read = await readRestartSentinel();
+
+      expect(read?.payload).toEqual(payload);
+      if (!read) {
+        throw new Error("Expected old restart sentinel to be readable");
+      }
+      expect(summarizeRestartSentinel(read.payload)).toBe(
+        "Gateway restart config-patch ok (config.patch)",
+      );
+      expect(summarizeRestartSentinel(read.payload, { state: "completed" })).toBe(
+        "Gateway restart config-patch ok (config.patch)",
+      );
+      expect(formatRestartSentinelMessage(read.payload)).toBe(
+        ["Gateway restart config-patch ok (config.patch)", "Config updated successfully"].join(
+          "\n",
+        ),
+      );
+    });
+  });
+
   it("formatRestartSentinelMessage uses custom message when present", () => {
     const payload = {
       kind: "config-apply" as const,

--- a/src/infra/restart-sentinel.test.ts
+++ b/src/infra/restart-sentinel.test.ts
@@ -216,9 +216,6 @@ describe("restart sentinel", () => {
       expect(summarizeRestartSentinel(read.payload)).toBe(
         "Gateway restart config-patch ok (config.patch)",
       );
-      expect(summarizeRestartSentinel(read.payload, { state: "completed" })).toBe(
-        "Gateway restart config-patch ok (config.patch)",
-      );
       expect(formatRestartSentinelMessage(read.payload)).toBe(
         ["Gateway restart config-patch ok (config.patch)", "Config updated successfully"].join(
           "\n",
@@ -292,16 +289,7 @@ describe("restart sentinel", () => {
         "Run openclaw doctor --non-interactive",
       ].join("\n"),
     );
-    expect(formatRestartSentinelMessage(payload, { state: "completed" })).toBe(
-      "Gateway restart completed (config.patch)",
-    );
     expect(summarizeRestartSentinel(payload)).toBe("Gateway restart required (config.patch)");
-    expect(summarizeRestartSentinel(payload, { state: "pending" })).toBe(
-      "Gateway restart required (config.patch)",
-    );
-    expect(summarizeRestartSentinel(payload, { state: "completed" })).toBe(
-      "Gateway restart completed (config.patch)",
-    );
 
     expect(
       summarizeRestartSentinel({

--- a/src/infra/restart-sentinel.test.ts
+++ b/src/infra/restart-sentinel.test.ts
@@ -242,6 +242,55 @@ describe("restart sentinel", () => {
     expect(result).toContain("Gateway restart");
   });
 
+  it("formats config write success notices as restart required when marked", () => {
+    const payload = {
+      kind: "config-patch" as const,
+      status: "ok" as const,
+      ts: Date.now(),
+      message: "Run restart-gateway.ps1 to apply config changes.",
+      stats: { mode: "config.patch", requiresRestart: true },
+    };
+
+    expect(formatRestartSentinelMessage(payload)).toBe(
+      [
+        "Gateway restart required (config.patch)",
+        "Run restart-gateway.ps1 to apply config changes.",
+      ].join("\n"),
+    );
+    expect(formatRestartSentinelMessage(payload, { state: "completed" })).toBe(
+      [
+        "Gateway restart completed (config.patch)",
+        "Run restart-gateway.ps1 to apply config changes.",
+      ].join("\n"),
+    );
+    expect(summarizeRestartSentinel(payload)).toBe("Gateway restart required (config.patch)");
+    expect(summarizeRestartSentinel(payload, { state: "completed" })).toBe(
+      "Gateway restart completed (config.patch)",
+    );
+
+    expect(
+      summarizeRestartSentinel({
+        kind: "config-apply",
+        status: "ok",
+        ts: Date.now(),
+        stats: { mode: "config.apply", requiresRestart: true },
+      }),
+    ).toBe("Gateway restart required (config.apply)");
+  });
+
+  it("does not mark hot-reloaded config patch notices as restart required", () => {
+    const payload = {
+      kind: "config-patch" as const,
+      status: "ok" as const,
+      ts: Date.now(),
+      stats: { mode: "config.patch", requiresRestart: false },
+    };
+
+    expect(summarizeRestartSentinel(payload)).toBe(
+      "Gateway restart config-patch ok (config.patch)",
+    );
+  });
+
   it("formats summary, distinct reason, and doctor hint together", () => {
     const payload = {
       kind: "config-patch" as const,

--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -76,10 +76,6 @@ export type RestartSentinel = {
   payload: RestartSentinelPayload;
 };
 
-export type RestartSentinelFormatOptions = {
-  state?: "pending" | "completed";
-};
-
 const RESTART_SENTINEL_KEY = "current";
 const LEGACY_RESTART_SENTINEL_FILENAME = "restart-sentinel.json";
 type GatewayRestartSentinelDatabase = Pick<OpenClawStateKyselyDatabase, "gateway_restart_sentinel">;
@@ -326,17 +322,12 @@ export async function hasRestartSentinel(env: NodeJS.ProcessEnv = process.env): 
   }
 }
 
-export function formatRestartSentinelMessage(
-  payload: RestartSentinelPayload,
-  options?: RestartSentinelFormatOptions,
-): string {
-  const completedConfigRestart =
-    isRestartRequiredConfigWriteSentinel(payload) && options?.state === "completed";
-  const message = completedConfigRestart ? undefined : payload.message?.trim();
+export function formatRestartSentinelMessage(payload: RestartSentinelPayload): string {
+  const message = payload.message?.trim();
   if (message && (!payload.stats || payload.kind === "config-auto-recovery")) {
     return message;
   }
-  const lines: string[] = [summarizeRestartSentinel(payload, options)];
+  const lines: string[] = [summarizeRestartSentinel(payload)];
   if (message) {
     lines.push(message);
   }
@@ -344,7 +335,7 @@ export function formatRestartSentinelMessage(
   if (reason && reason !== message) {
     lines.push(`Reason: ${reason}`);
   }
-  if (!completedConfigRestart && payload.doctorHint?.trim()) {
+  if (payload.doctorHint?.trim()) {
     lines.push(payload.doctorHint.trim());
   }
   return lines.join("\n");
@@ -358,18 +349,12 @@ function isRestartRequiredConfigWriteSentinel(payload: RestartSentinelPayload): 
   );
 }
 
-export function summarizeRestartSentinel(
-  payload: RestartSentinelPayload,
-  options?: RestartSentinelFormatOptions,
-): string {
+export function summarizeRestartSentinel(payload: RestartSentinelPayload): string {
   if (payload.kind === "config-auto-recovery") {
     return "Gateway auto-recovery";
   }
   if (isRestartRequiredConfigWriteSentinel(payload)) {
     const mode = payload.stats?.mode ? ` (${payload.stats.mode})` : "";
-    if (options?.state === "completed") {
-      return `Gateway restart completed${mode}`.trim();
-    }
     return `Gateway restart required${mode}`.trim();
   }
   const kind = payload.kind;

--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -348,6 +348,14 @@ export function formatRestartSentinelMessage(
   return lines.join("\n");
 }
 
+function isRestartRequiredConfigWriteSentinel(payload: RestartSentinelPayload): boolean {
+  return (
+    (payload.kind === "config-apply" || payload.kind === "config-patch") &&
+    payload.status === "ok" &&
+    payload.stats?.requiresRestart === true
+  );
+}
+
 export function summarizeRestartSentinel(
   payload: RestartSentinelPayload,
   options?: RestartSentinelFormatOptions,
@@ -355,11 +363,7 @@ export function summarizeRestartSentinel(
   if (payload.kind === "config-auto-recovery") {
     return "Gateway auto-recovery";
   }
-  if (
-    (payload.kind === "config-apply" || payload.kind === "config-patch") &&
-    payload.status === "ok" &&
-    payload.stats?.requiresRestart === true
-  ) {
+  if (isRestartRequiredConfigWriteSentinel(payload)) {
     const mode = payload.stats?.mode ? ` (${payload.stats.mode})` : "";
     if (options?.state === "completed") {
       return `Gateway restart completed${mode}`.trim();

--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -330,7 +330,9 @@ export function formatRestartSentinelMessage(
   payload: RestartSentinelPayload,
   options?: RestartSentinelFormatOptions,
 ): string {
-  const message = payload.message?.trim();
+  const completedConfigRestart =
+    isRestartRequiredConfigWriteSentinel(payload) && options?.state === "completed";
+  const message = completedConfigRestart ? undefined : payload.message?.trim();
   if (message && (!payload.stats || payload.kind === "config-auto-recovery")) {
     return message;
   }
@@ -342,7 +344,7 @@ export function formatRestartSentinelMessage(
   if (reason && reason !== message) {
     lines.push(`Reason: ${reason}`);
   }
-  if (payload.doctorHint?.trim()) {
+  if (!completedConfigRestart && payload.doctorHint?.trim()) {
     lines.push(payload.doctorHint.trim());
   }
   return lines.join("\n");

--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -33,6 +33,7 @@ export type RestartSentinelStep = {
 export type RestartSentinelStats = {
   mode?: string;
   root?: string;
+  requiresRestart?: boolean;
   handoffId?: string;
   before?: Record<string, unknown> | null;
   after?: Record<string, unknown> | null;
@@ -73,6 +74,10 @@ export type RestartSentinelPayload = {
 export type RestartSentinel = {
   version: 1;
   payload: RestartSentinelPayload;
+};
+
+export type RestartSentinelFormatOptions = {
+  state?: "pending" | "completed";
 };
 
 const RESTART_SENTINEL_KEY = "current";
@@ -321,12 +326,15 @@ export async function hasRestartSentinel(env: NodeJS.ProcessEnv = process.env): 
   }
 }
 
-export function formatRestartSentinelMessage(payload: RestartSentinelPayload): string {
+export function formatRestartSentinelMessage(
+  payload: RestartSentinelPayload,
+  options?: RestartSentinelFormatOptions,
+): string {
   const message = payload.message?.trim();
   if (message && (!payload.stats || payload.kind === "config-auto-recovery")) {
     return message;
   }
-  const lines: string[] = [summarizeRestartSentinel(payload)];
+  const lines: string[] = [summarizeRestartSentinel(payload, options)];
   if (message) {
     lines.push(message);
   }
@@ -340,9 +348,23 @@ export function formatRestartSentinelMessage(payload: RestartSentinelPayload): s
   return lines.join("\n");
 }
 
-export function summarizeRestartSentinel(payload: RestartSentinelPayload): string {
+export function summarizeRestartSentinel(
+  payload: RestartSentinelPayload,
+  options?: RestartSentinelFormatOptions,
+): string {
   if (payload.kind === "config-auto-recovery") {
     return "Gateway auto-recovery";
+  }
+  if (
+    (payload.kind === "config-apply" || payload.kind === "config-patch") &&
+    payload.status === "ok" &&
+    payload.stats?.requiresRestart === true
+  ) {
+    const mode = payload.stats?.mode ? ` (${payload.stats.mode})` : "";
+    if (options?.state === "completed") {
+      return `Gateway restart completed${mode}`.trim();
+    }
+    return `Gateway restart required${mode}`.trim();
   }
   const kind = payload.kind;
   const status = payload.status;


### PR DESCRIPTION
## Summary

Fixes #46797.

This makes config write restart sentinel payloads carry whether the write actually requires a gateway restart, so pending/status summaries can say `Gateway restart required (...)` instead of `Gateway restart config-patch ok (...)`.

It also keeps startup-consumed restart sentinel messages in the completed context, so automatic restart follow-up notices say the restart completed instead of telling the user a completed restart is still required.

## Verification

- `node scripts/run-vitest.mjs src/infra/restart-sentinel.test.ts src/gateway/server-methods/config.shared-auth.test.ts -- --reporter=verbose`
- `node scripts/run-vitest.mjs src/gateway/server-restart-sentinel.test.ts src/gateway/server.config-patch.test.ts -- --reporter=verbose`
- `./node_modules/.bin/oxfmt --check --threads=1 src/infra/restart-sentinel.ts src/infra/restart-sentinel.test.ts src/gateway/server-methods/config-write-flow.ts src/gateway/server-methods/config.shared-auth.test.ts src/gateway/server-restart-sentinel.ts src/gateway/server-restart-sentinel.test.ts src/gateway/server.config-patch.test.ts CHANGELOG.md`
- `git diff --check`
- `.agents/skills/codex-review/scripts/codex-review --mode local`

Focused tests passed with 3 files / 42 tests, adjacent gateway tests passed with 2 files / 47 tests, formatting check passed, diff whitespace check passed, and Codex review reported no accepted/actionable findings.

## Real behavior proof

Behavior addressed: `config.patch` and `config.apply` restart-required sentinel summaries now use `Gateway restart required (...)` only when the reload plan requires a restart; hot-reloaded config patch writes are explicitly marked as not restart-required.

Real environment tested: Local OpenClaw source checkout on macOS, loading the real `src/infra/restart-sentinel.ts` module with `node --import tsx`.

Exact steps or command run after this patch: Ran a live Node command against the real OpenClaw restart sentinel formatter:

```bash
node --import tsx --input-type=module <<'EOF'
import {
  formatRestartSentinelMessage,
  summarizeRestartSentinel,
} from "./src/infra/restart-sentinel.ts";

const restartRequiredPayload = {
  kind: "config-patch",
  status: "ok",
  ts: Date.now(),
  message: "Run restart-gateway.ps1 to apply config changes.",
  stats: { mode: "config.patch", requiresRestart: true },
};
const hotReloadedPayload = {
  kind: "config-patch",
  status: "ok",
  ts: Date.now(),
  stats: { mode: "config.patch", requiresRestart: false },
};

console.log("pending summary:", summarizeRestartSentinel(restartRequiredPayload));
console.log("pending message:");
console.log(formatRestartSentinelMessage(restartRequiredPayload));
console.log("completed message:");
console.log(formatRestartSentinelMessage(restartRequiredPayload, { state: "completed" }));
console.log("hot-reloaded summary:", summarizeRestartSentinel(hotReloadedPayload));
EOF
```

Evidence after fix: Terminal output from that live command:

```text
pending summary: Gateway restart required (config.patch)
pending message:
Gateway restart required (config.patch)
Run restart-gateway.ps1 to apply config changes.
completed message:
Gateway restart completed (config.patch)
Run restart-gateway.ps1 to apply config changes.
hot-reloaded summary: Gateway restart config-patch ok (config.patch)
```

Observed result after fix: Pending restart-required config patch payloads show `Gateway restart required (config.patch)` with the note preserved underneath; startup/completed context shows `Gateway restart completed (config.patch)`; hot-reloaded config patch payloads do not show `restart required`.

What was not tested: Live Windows/manual gateway restart behavior was not exercised locally; the local Crabbox preflight was blocked because the `crabbox` binary is unavailable in this checkout.
