### PR TITLE
fix(agents): classify embedded provider business denials for fallback

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -1390,6 +1390,8 @@ describe("classifyFailoverReason provider messages", () => {
     // Auth errors
     expect(classifyFailoverReason("无权访问该模型")).toBe("auth");
     expect(classifyFailoverReason("403 您无权访问glm-5.1。")).toBe("auth");
+    expect(classifyFailoverReason("当前ak因违规请求被禁止访问该模型")).toBe("auth");
+    expect(classifyFailoverReason('{"success":false,"code":"CE-011"}')).toBe("auth");
     expect(classifyFailoverReason("认证失败")).toBe("auth");
     expect(classifyFailoverReason("鉴权失败，请检查API Key")).toBe("auth");
     expect(classifyFailoverReason("密钥无效")).toBe("auth");

--- a/src/agents/pi-embedded-helpers/failover-matches.ts
+++ b/src/agents/pi-embedded-helpers/failover-matches.ts
@@ -46,6 +46,10 @@ const CJK_AUTH_ERROR_PATTERNS = [
   "鉴权失败",
   "密钥无效",
   "apikey 无效",
+  "当前ak",
+  "违规请求",
+  "禁止访问",
+  /\bce-011\b/i,
 ] as const satisfies readonly ErrorPattern[];
 
 const ZAI_BILLING_CODE_1311_RE = /"code"\s*:\s*1311\b/;

--- a/src/agents/pi-embedded-runner/result-fallback-classifier.test.ts
+++ b/src/agents/pi-embedded-runner/result-fallback-classifier.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { classifyEmbeddedPiRunResultForModelFallback } from "./result-fallback-classifier.js";
+
+describe("classifyEmbeddedPiRunResultForModelFallback", () => {
+  it("classifies provider business-denial error payloads as fallback-worthy", () => {
+    const result = classifyEmbeddedPiRunResultForModelFallback({
+      provider: "zai",
+      model: "glm-5.1",
+      result: {
+        payloads: [
+          {
+            isError: true,
+            text: '{"success":false,"code":"CE-011","message":"当前ak因违规请求被禁止访问该模型"}',
+          },
+        ],
+        meta: {
+          durationMs: 42,
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      message:
+        'zai/glm-5.1 ended with a provider error: {"success":false,"code":"CE-011","message":"当前ak因违规请求被禁止访问该模型"}',
+      reason: "auth",
+      code: "embedded_error_payload",
+      rawError:
+        '{"success":false,"code":"CE-011","message":"当前ak因违规请求被禁止访问该模型"}',
+    });
+  });
+
+  it("does not retry unclassified non-GPT error payloads", () => {
+    const result = classifyEmbeddedPiRunResultForModelFallback({
+      provider: "custom",
+      model: "llama-3.1",
+      result: {
+        payloads: [
+          {
+            isError: true,
+            text: "the model produced an application-level error",
+          },
+        ],
+        meta: {
+          durationMs: 42,
+        },
+      },
+    });
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/agents/pi-embedded-runner/result-fallback-classifier.ts
+++ b/src/agents/pi-embedded-runner/result-fallback-classifier.ts
@@ -1,4 +1,5 @@
 import { isSilentReplyPayloadText } from "../../auto-reply/tokens.js";
+import { classifyFailoverReason } from "../pi-embedded-helpers/errors.js";
 import { isGpt5ModelId } from "../gpt5-prompt-overlay.js";
 import type { ModelFallbackResultClassification } from "../model-fallback.js";
 import { hasOutboundDeliveryEvidence, hasVisibleAgentPayload } from "./delivery-evidence.js";
@@ -99,6 +100,15 @@ export function classifyEmbeddedPiRunResultForModelFallback(params: {
       message: `${params.provider}/${params.model} ended with an incomplete terminal response`,
       reason: "format",
       code: "incomplete_result",
+    };
+  }
+  const failoverReason = classifyFailoverReason(errorText, { provider: params.provider });
+  if (failoverReason) {
+    return {
+      message: `${params.provider}/${params.model} ended with a provider error: ${errorText}`,
+      reason: failoverReason,
+      code: "embedded_error_payload",
+      rawError: errorText,
     };
   }
 


### PR DESCRIPTION
## Summary

- classify embedded Pi `isError` payload text with the existing failover reason matcher before non-GPT runs are treated as success
- recognize the reported `CE-011` / `当前ak因违规请求被禁止访问该模型` business-denial shape as an auth failover signal
- add focused regression coverage for both the matcher and embedded result classifier

Fixes #48680.

## Verification

- `pnpm install --frozen-lockfile --ignore-scripts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/agents/pi-embedded-runner/result-fallback-classifier.test.ts src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts`
- `node --import tsx --input-type=module` classifier probe shown below
- `node --check src/agents/pi-embedded-helpers/failover-matches.ts`
- `node --check src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts`
- `node --check src/agents/pi-embedded-runner/result-fallback-classifier.ts`
- `node --check src/agents/pi-embedded-runner/result-fallback-classifier.test.ts`
- `rg -n $'\\t| +$'` on changed files

## Real behavior proof

- Behavior or issue addressed: Embedded Pi runs that return only an `isError` provider business-denial payload such as `{"success":false,"code":"CE-011","message":"当前ak因违规请求被禁止访问该模型"}` are now classified as fallback-worthy instead of letting the model candidate be treated as successful.
- Real environment tested: Local macOS Codex workspace using the OpenClaw source files downloaded from this PR branch (`yu-xin-c/openclaw:fix/embedded-provider-business-denial-fallback-48680`), with Node.js v24.15.0, pnpm v11.1.0, tsx, and Vitest installed from the repository lockfile.
- Exact steps or command run after this patch: Installed dependencies from `pnpm-lock.yaml`, ran the two changed/affected Vitest files, then executed the changed TypeScript classifier path directly with the reported CE-011 payload.
- Evidence after fix: Terminal output from the local shell:

```text
$ node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts src/agents/pi-embedded-runner/result-fallback-classifier.test.ts src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts

 RUN  v4.1.6 /private/tmp/openclaw-83042-proof

 Test Files  2 passed (2)
      Tests  142 passed (142)
   Start at  18:30:01
   Duration  579ms (transform 586ms, setup 0ms, import 805ms, tests 24ms, environment 0ms)
```

```text
$ node --import tsx --input-type=module
> import { classifyEmbeddedPiRunResultForModelFallback } from './src/agents/pi-embedded-runner/result-fallback-classifier.ts';
> const payload = '{"success":false,"code":"CE-011","message":"当前ak因违规请求被禁止访问该模型"}';
> console.log(JSON.stringify(classifyEmbeddedPiRunResultForModelFallback({ provider: 'zai', model: 'glm-5.1', result: { payloads: [{ isError: true, text: payload }], meta: { durationMs: 42 } } }), null, 2));
{
  "message": "zai/glm-5.1 ended with a provider error: {\"success\":false,\"code\":\"CE-011\",\"message\":\"当前ak因违规请求被禁止访问该模型\"}",
  "reason": "auth",
  "code": "embedded_error_payload",
  "rawError": "{\"success\":false,\"code\":\"CE-011\",\"message\":\"当前ak因违规请求被禁止访问该模型\"}"
}
```

- Observed result after fix: The changed classifier path executes on the CE-011 embedded error payload and returns `reason: "auth"`, `code: "embedded_error_payload"`, and the original `rawError`, so model fallback can advance instead of treating the non-GPT candidate as successful.
- What was not tested: No live provider account was used to replay the exact upstream business-denial response; this proof uses the reported provider payload against the actual PR branch classifier code.