### PR TITLE
perf(gateway): cache compiled regexes used by oversized-transcript field extract

### DIFF
--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -284,8 +284,33 @@ function isOversizedTranscriptLine(line: string): boolean {
   return Buffer.byteLength(line, "utf8") > MAX_TRANSCRIPT_PARSE_LINE_BYTES;
 }
 
+// Cache compiled regexes per field name. The oversized transcript path calls
+// these helpers several times per record (id / parentId / type / timestamp /
+// role); without the cache each call recompiles RegExp objects on the
+// transcript-tail hot path.
+const TRANSCRIPT_FIELD_REGEX_CACHE = new Map<
+  string,
+  { stringRe: RegExp; nullRe: RegExp }
+>();
+
+function getTranscriptFieldRegexes(field: string): {
+  stringRe: RegExp;
+  nullRe: RegExp;
+} {
+  let cached = TRANSCRIPT_FIELD_REGEX_CACHE.get(field);
+  if (!cached) {
+    const escapedField = escapeRegExp(field);
+    cached = {
+      stringRe: new RegExp(`"${escapedField}"\\s*:\\s*"((?:\\\\.|[^"\\\\])*)"`),
+      nullRe: new RegExp(`"${escapedField}"\\s*:\\s*null`),
+    };
+    TRANSCRIPT_FIELD_REGEX_CACHE.set(field, cached);
+  }
+  return cached;
+}
+
 function extractJsonStringFieldPrefix(prefix: string, field: string): string | undefined {
-  const match = new RegExp(`"${escapeRegExp(field)}"\\s*:\\s*"((?:\\\\.|[^"\\\\])*)"`).exec(prefix);
+  const match = getTranscriptFieldRegexes(field).stringRe.exec(prefix);
   if (!match) {
     return undefined;
   }
@@ -301,7 +326,7 @@ function extractJsonNullableStringFieldPrefix(
   prefix: string,
   field: string,
 ): string | null | undefined {
-  if (new RegExp(`"${escapeRegExp(field)}"\\s*:\\s*null`).test(prefix)) {
+  if (getTranscriptFieldRegexes(field).nullRe.test(prefix)) {
     return null;
   }
   return extractJsonStringFieldPrefix(prefix, field);


### PR DESCRIPTION
## Summary

`src/gateway/session-utils.fs.ts:extractJsonStringFieldPrefix` and `extractJsonNullableStringFieldPrefix` recompile fresh regex objects on every invocation. `buildOversizedTranscriptRecord` calls them repeatedly for oversized records (`id`, `parentId`, `type`, `role`), so each oversized record recompiles the same regexes on the transcript-tail path used by session-history streams.

## Fix

Add a module-level `Map<string, { stringRe, nullRe }>` cache keyed on field name. Both extract helpers route through `getTranscriptFieldRegexes(field)`, which lazy-fills the cache and preserves the existing `escapeRegExp(field)` handling before constructing regexes.

## Scope

Outside the oversized-transcript path the cache is never touched, so the change is a no-op for the vast majority of session-history records that pass through the normal `JSON.parse` route.

## Diff size

Single file, no new dependencies.

## Real behavior proof

- **Behavior or issue addressed**: Oversized transcript string/null field extraction now reuses regex objects instead of recompiling the same field regexes for every call.
- **Real environment tested**: PolyU Linux workspace, OpenClaw checkout refreshed from current `origin/main`, branch `codex-refresh-83043`, inspected with the real `git` and `rg` CLIs against the patched repository.
- **Exact steps or command run after this patch**:

```bash
git diff -- src/gateway/session-utils.fs.ts
rg -n 'TRANSCRIPT_FIELD_REGEX_CACHE|getTranscriptFieldRegexes|new RegExp' src/gateway/session-utils.fs.ts
```

- **Evidence after fix**:

```text
src/gateway/session-utils.fs.ts:291:const TRANSCRIPT_FIELD_REGEX_CACHE = new Map<
src/gateway/session-utils.fs.ts:296:function getTranscriptFieldRegexes(field: string): {
src/gateway/session-utils.fs.ts:300:  let cached = TRANSCRIPT_FIELD_REGEX_CACHE.get(field);
src/gateway/session-utils.fs.ts:304:      stringRe: new RegExp(`"${escapedField}"\\s*:\\s*"((?:\\\\.|[^"\\\\])*)"`),
src/gateway/session-utils.fs.ts:305:      nullRe: new RegExp(`"${escapedField}"\\s*:\\s*null`),
src/gateway/session-utils.fs.ts:307:    TRANSCRIPT_FIELD_REGEX_CACHE.set(field, cached);
src/gateway/session-utils.fs.ts:313:  const match = getTranscriptFieldRegexes(field).stringRe.exec(prefix);
src/gateway/session-utils.fs.ts:329:  if (getTranscriptFieldRegexes(field).nullRe.test(prefix)) {
```

- **Observed result after fix**: The patched string and nullable-string extractors use the shared cache, while the existing escaped field name is still used when building each cached regex pair.
- **What was not tested**: Full project test suite was not run locally because this checkout has no installed `node_modules`; CI should run the complete project checks.
