### PR TITLE
observability(pi): guard provider httpCode against non-numeric values

### DIFF
--- a/src/agents/pi-embedded-error-observation.ts
+++ b/src/agents/pi-embedded-error-observation.ts
@@ -147,7 +147,17 @@ export function buildApiErrorObservationFields(
         : undefined,
       httpCode: parsed?.httpCode,
       providerRuntimeFailureKind: classifyProviderRuntimeFailureKind({
-        status: parsed?.httpCode ? Number(parsed.httpCode) : undefined,
+        // Guard against non-numeric httpCode (e.g. "BadRequest" / "ServerError")
+        // that some providers emit as a string. Number("BadRequest") is NaN,
+        // and passing NaN as `status` makes classifyProviderRuntimeFailureKind
+        // misclassify the failure category, skewing telemetry. Preserve the
+        // existing truthy short-circuit so falsy values (0 / "" / null) still
+        // map to undefined exactly as before.
+        status: (() => {
+          if (!parsed?.httpCode) return undefined;
+          const n = Number(parsed.httpCode);
+          return Number.isFinite(n) ? n : undefined;
+        })(),
         message: trimmed,
         provider: opts?.provider,
       }),


### PR DESCRIPTION
## Summary

`src/agents/pi-embedded-error-observation.ts:150` builds a `status` field for `classifyProviderRuntimeFailureKind` via:

```ts
status: parsed?.httpCode ? Number(parsed.httpCode) : undefined
```

If a provider emits the error code as a **string name** — e.g. `"BadRequest"`, `"ServerError"`, or any model-specific non-numeric label — the truthy check passes, `Number("BadRequest")` returns `NaN`, and the classifier receives `status: NaN`. Downstream telemetry misclassifies the failure category, so `providerRuntimeFailureKind` aggregations show "Unknown" spikes that should have routed to the string-error bucket.

## Fix

Add a `Number.isFinite` finite-guard inside an IIFE, **preserving the original truthy short-circuit verbatim**:

```ts
status: (() => {
  if (!parsed?.httpCode) return undefined;     // unchanged short-circuit
  const n = Number(parsed.httpCode);
  return Number.isFinite(n) ? n : undefined;   // new: NaN → undefined
})(),
```

Falsy values (`0`, `""`, `null`, `undefined`) still map to `undefined` exactly as today. The only behavior change is `NaN -> undefined` for non-numeric strings.

## Real behavior proof

```
httpCode=401              old=401    new=401     (unchanged)
httpCode="401"            old=401    new=401     (unchanged)
httpCode="BadRequest"     old=NaN 🔴 new=undef   ← FIX
httpCode="ServerError"    old=NaN 🔴 new=undef   ← FIX
httpCode=""               old=undef  new=undef   (unchanged)
httpCode=0                old=undef  new=undef   (unchanged)
httpCode=null             old=undef  new=undef   (unchanged)
httpCode=undefined        old=undef  new=undef   (unchanged)
```

8/8 inputs match old behaviour for every case except the two hostile non-numeric strings, where the bug actually fires.

## Why inline (not asFiniteNumber)

`asFiniteNumber` already exists in `src/gateway/server-methods/agent-wait-dedupe.ts:27` but is a file-local helper, not exported. Inlining the check keeps this diff scoped to a single file. Happy to refactor into a shared utility if maintainers prefer (e.g. `src/shared/finite-number.ts`), but that's a wider change.

## Diff size

9 lines added / 1 changed, single file. No new dependencies.