### PR TITLE
fix(google): recover Gemini tool-call thought signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Providers/Google: preserve and recover Gemini 3 tool-call thought signatures during native replay so function-calling turns no longer fail with missing `thought_signature` 400s. Fixes #72879. (#80358) Thanks @abnershang.
 - Gateway/secrets: split the lightweight secrets runtime state and auth-store cache from the full secrets runtime and take a startup fast path when the gateway startup config has no SecretRef values, speeding up secrets startup while preserving cleanup and refresh semantics.
 - QA-Lab: wake qa-bus long polls that arrive with stale future cursors after a bus restart, preserving reconnect readiness for harness clients. (#67142) Thanks @hxy91819.
 - QA-Lab: stage Multipass transfer scripts under OpenClaw's preferred temp root instead of raw OS temp paths, keeping the VM runner inside temp-path guardrails. (#64098) Thanks @ImLukeF.

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -170,6 +170,82 @@ function requireThinkingConfig(config: Record<string, unknown>): Record<string, 
   return thinkingConfig as Record<string, unknown>;
 }
 
+type GoogleTestContentTurn = Record<string, unknown> & {
+  parts: Array<Record<string, unknown>>;
+};
+
+function isModelTurnWithParts(content: Record<string, unknown>): content is GoogleTestContentTurn {
+  return content.role === "model" && Array.isArray(content.parts);
+}
+
+function getFirstModelTurn(contents: Array<Record<string, unknown>>): GoogleTestContentTurn {
+  const turn = contents.find(isModelTurnWithParts);
+  if (!turn) {
+    throw new Error("Expected at least one Google model turn");
+  }
+  return turn;
+}
+
+function getLastModelTurn(contents: Array<Record<string, unknown>>): GoogleTestContentTurn {
+  const turn = contents.toReversed().find(isModelTurnWithParts);
+  if (!turn) {
+    throw new Error("Expected at least one Google model turn");
+  }
+  return turn;
+}
+
+function googleToolCallAssistantTurn({
+  timestamp = 0,
+  provider = "google",
+  api = "google-generative-ai",
+  model = "gemini-3.1-pro-preview",
+  id = "call_1",
+  name = "lookup",
+  args = { q: "hello" },
+  thoughtSignature,
+}: {
+  timestamp?: number;
+  provider?: string;
+  api?: string;
+  model?: string;
+  id?: string;
+  name?: string;
+  args?: Record<string, unknown>;
+  thoughtSignature?: string;
+} = {}): Record<string, unknown> {
+  return {
+    role: "assistant",
+    provider,
+    api,
+    model,
+    stopReason: "toolUse",
+    timestamp,
+    content: [
+      {
+        type: "toolCall",
+        id,
+        name,
+        arguments: args,
+        ...(thoughtSignature ? { thoughtSignature } : {}),
+      },
+    ],
+  };
+}
+
+function toolResultTurn(toolCallId = "call_1", timestamp = 1): Record<string, unknown> {
+  return {
+    role: "toolResult",
+    timestamp,
+    content: [
+      {
+        type: "toolResult",
+        toolCallId,
+        content: [{ type: "text", text: "ok" }],
+      },
+    ],
+  };
+}
+
 describe("google transport stream", () => {
   beforeAll(async () => {
     ({
@@ -328,6 +404,103 @@ describe("google transport stream", () => {
     expect(result.content[2]).toHaveProperty("name", "lookup");
     expect(result.content[2]).toHaveProperty("arguments", { q: "hello" });
     expect(result.content[2]).toHaveProperty("thoughtSignature", "call_sig_1");
+  });
+
+  it("merges tool-call thought signatures from sibling SSE parts", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      buildSseResponse([
+        {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    functionCall: { id: "call_1", name: "lookup", args: { q: "hello" } },
+                  },
+                  { thoughtSignature: "call_sig_merged_1" },
+                ],
+              },
+              finishReason: "STOP",
+            },
+          ],
+        },
+      ]),
+    );
+
+    const streamFn = createGoogleGenerativeAiTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        buildGeminiModel({
+          id: "gemini-3.1-pro-preview",
+          name: "Gemini 3.1 Pro Preview",
+        }),
+        {
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        } as never,
+      ),
+    );
+    const result = await stream.result();
+
+    expect(result.content).toEqual([
+      {
+        type: "toolCall",
+        id: "call_1",
+        name: "lookup",
+        arguments: { q: "hello" },
+        thoughtSignature: "call_sig_merged_1",
+      },
+    ]);
+  });
+
+  it("keeps explicit thinking signatures after tool-call SSE parts", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      buildSseResponse([
+        {
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    functionCall: { id: "call_1", name: "lookup", args: { q: "hello" } },
+                  },
+                  { thought: true, thoughtSignature: "thought_sig_after_call" },
+                  { thought: true, text: "draft" },
+                  { text: "answer" },
+                ],
+              },
+              finishReason: "STOP",
+            },
+          ],
+        },
+      ]),
+    );
+
+    const streamFn = createGoogleGenerativeAiTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        buildGeminiModel({
+          id: "gemini-3.1-pro-preview",
+          name: "Gemini 3.1 Pro Preview",
+        }),
+        {
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        } as never,
+      ),
+    );
+    const result = await stream.result();
+
+    expect(result.content[0]).toMatchObject({
+      type: "toolCall",
+      id: "call_1",
+      name: "lookup",
+      arguments: { q: "hello" },
+    });
+    expect(result.content[1]).toEqual({
+      type: "thinking",
+      thinking: "draft",
+      thinkingSignature: "thought_sig_after_call",
+    });
+    expect(result.content[2]).toEqual({ type: "text", text: "answer" });
   });
 
   it("builds a lean Gemini 3 first-response retry payload", () => {
@@ -726,7 +899,7 @@ describe("google transport stream", () => {
     });
   });
 
-  it("uses Gemini skip-validator thought signatures for cross-provider tool-call replay", () => {
+  it("re-attaches replayed Gemini thought signatures when a later tool call is missing one", () => {
     const model = buildGeminiModel({
       id: "gemini-3.1-pro-preview",
       name: "Gemini 3.1 Pro Preview",
@@ -734,19 +907,81 @@ describe("google transport stream", () => {
 
     const params = buildGoogleGenerativeAiParams(model, {
       messages: [
+        googleToolCallAssistantTurn({ thoughtSignature: "call_sig_replay_1" }),
+        toolResultTurn(),
+        googleToolCallAssistantTurn({ timestamp: 2 }),
+      ],
+    } as never);
+
+    // Find the last model-role content; should carry the replayed signature
+    // even though the second stored toolCall block had none.
+    expect(getLastModelTurn(params.contents)).toMatchObject({
+      role: "model",
+      parts: [
+        {
+          thoughtSignature: "call_sig_replay_1",
+          functionCall: { name: "lookup", args: { q: "hello" } },
+        },
+      ],
+    });
+  });
+
+  it("treats the Google transport alias as the same route for signature replay", () => {
+    const model = {
+      ...buildGeminiModel({
+        id: "gemini-3.1-pro-preview",
+        name: "Gemini 3.1 Pro Preview",
+      }),
+      api: "openclaw-google-generative-ai-transport",
+    } as Model<"openclaw-google-generative-ai-transport">;
+
+    const params = buildGoogleGenerativeAiParams(model, {
+      messages: [
+        googleToolCallAssistantTurn({ thoughtSignature: "call_sig_alias_1" }),
+        toolResultTurn(),
+        googleToolCallAssistantTurn({ timestamp: 2 }),
+      ],
+    } as never);
+
+    expect(getLastModelTurn(params.contents)).toMatchObject({
+      role: "model",
+      parts: [
+        {
+          thoughtSignature: "call_sig_alias_1",
+          functionCall: { name: "lookup", args: { q: "hello" } },
+        },
+      ],
+    });
+  });
+
+  it("keeps text and thinking signatures when the request uses the Google transport alias", () => {
+    const model = {
+      ...buildGeminiModel({
+        id: "gemini-3.1-pro-preview",
+        name: "Gemini 3.1 Pro Preview",
+      }),
+      api: "openclaw-google-generative-ai-transport",
+    } as Model<"openclaw-google-generative-ai-transport">;
+
+    const params = buildGoogleGenerativeAiParams(model, {
+      messages: [
         {
           role: "assistant",
-          provider: "anthropic",
-          api: "anthropic-messages",
-          model: "claude-opus-4-7",
-          stopReason: "toolUse",
+          provider: "google",
+          api: "google-generative-ai",
+          model: "gemini-3.1-pro-preview",
+          stopReason: "stop",
           timestamp: 0,
           content: [
             {
-              type: "toolCall",
-              id: "call_1",
-              name: "lookup",
-              arguments: { q: "hello" },
+              type: "thinking",
+              thinking: "plan",
+              thinkingSignature: "think_sig_alias_1",
+            },
+            {
+              type: "text",
+              text: "answer",
+              textSignature: "text_sig_alias_1",
             },
           ],
         },
@@ -757,10 +992,305 @@ describe("google transport stream", () => {
       role: "model",
       parts: [
         {
+          thought: true,
+          text: "plan",
+          thoughtSignature: "think_sig_alias_1",
+        },
+        {
+          text: "answer",
+          thoughtSignature: "text_sig_alias_1",
+        },
+      ],
+    });
+  });
+
+  it("preserves opaque same-route Gemini thought signatures during replay", () => {
+    const model = buildGeminiModel({
+      id: "gemini-3.1-pro-preview",
+      name: "Gemini 3.1 Pro Preview",
+    });
+
+    const params = buildGoogleGenerativeAiParams(model, {
+      messages: [
+        googleToolCallAssistantTurn({ thoughtSignature: "opaque.sig-url_safe~1" }),
+        toolResultTurn(),
+        googleToolCallAssistantTurn({ timestamp: 2 }),
+      ],
+    } as never);
+
+    expect(getLastModelTurn(params.contents)).toMatchObject({
+      role: "model",
+      parts: [
+        {
+          thoughtSignature: "opaque.sig-url_safe~1",
+          functionCall: { name: "lookup", args: { q: "hello" } },
+        },
+      ],
+    });
+  });
+
+  it("keeps a tool call's own Gemini thought signature before replay fallback", () => {
+    const model = buildGeminiModel({
+      id: "gemini-3.1-pro-preview",
+      name: "Gemini 3.1 Pro Preview",
+    });
+
+    const params = buildGoogleGenerativeAiParams(model, {
+      messages: [
+        googleToolCallAssistantTurn({ thoughtSignature: "call_sig_first_1" }),
+        toolResultTurn(),
+        googleToolCallAssistantTurn({
+          timestamp: 2,
+          thoughtSignature: "call_sig_second_1",
+        }),
+      ],
+    } as never);
+
+    const modelTurns = params.contents.filter(isModelTurnWithParts);
+    expect(modelTurns).toHaveLength(2);
+    expect(modelTurns[0]).toMatchObject({
+      parts: [
+        {
+          thoughtSignature: "call_sig_first_1",
+          functionCall: { name: "lookup", args: { q: "hello" } },
+        },
+      ],
+    });
+    expect(modelTurns[1]).toMatchObject({
+      parts: [
+        {
+          thoughtSignature: "call_sig_second_1",
+          functionCall: { name: "lookup", args: { q: "hello" } },
+        },
+      ],
+    });
+  });
+
+  it("does not replay Gemini thought signatures from later turns", () => {
+    const model = buildGeminiModel({
+      id: "gemini-3.1-pro-preview",
+      name: "Gemini 3.1 Pro Preview",
+    });
+
+    const params = buildGoogleGenerativeAiParams(model, {
+      messages: [
+        googleToolCallAssistantTurn(),
+        toolResultTurn(),
+        googleToolCallAssistantTurn({
+          timestamp: 2,
+          thoughtSignature: "call_sig_future_1",
+        }),
+      ],
+    } as never);
+
+    const modelTurns = params.contents.filter(isModelTurnWithParts);
+    expect(modelTurns).toHaveLength(2);
+    expect(modelTurns[0]).toMatchObject({
+      parts: [
+        {
           thoughtSignature: "skip_thought_signature_validator",
           functionCall: { name: "lookup", args: { q: "hello" } },
         },
       ],
+    });
+    expect(modelTurns[1]).toMatchObject({
+      parts: [
+        {
+          thoughtSignature: "call_sig_future_1",
+          functionCall: { name: "lookup", args: { q: "hello" } },
+        },
+      ],
+    });
+  });
+
+  it("does not re-attach replayed Gemini thought signatures to a different tool-call part", () => {
+    const model = buildGeminiModel({
+      id: "gemini-3.1-pro-preview",
+      name: "Gemini 3.1 Pro Preview",
+    });
+
+    const params = buildGoogleGenerativeAiParams(model, {
+      messages: [
+        googleToolCallAssistantTurn({ thoughtSignature: "call_sig_replay_1" }),
+        toolResultTurn(),
+        googleToolCallAssistantTurn({ timestamp: 2, args: { q: "hello-again" } }),
+      ],
+    } as never);
+
+    expect(getLastModelTurn(params.contents)).toMatchObject({
+      role: "model",
+      parts: [
+        {
+          thoughtSignature: "skip_thought_signature_validator",
+          functionCall: { name: "lookup", args: { q: "hello-again" } },
+        },
+      ],
+    });
+  });
+
+  it("does not replay tool-call thought signatures from a different provider route", () => {
+    const model = buildGeminiModel({
+      id: "gemini-3.1-pro-preview",
+      name: "Gemini 3.1 Pro Preview",
+    });
+
+    // Prior turn came from an Anthropic route — its signature looks valid base64
+    // but must NOT be replayed into a Gemini request.
+    const params = buildGoogleGenerativeAiParams(model, {
+      messages: [
+        googleToolCallAssistantTurn({
+          provider: "anthropic",
+          api: "anthropic",
+          model: "claude-sonnet-4",
+          id: "call_foreign",
+          // Plausible-looking base64 from a non-Gemini provider.
+          thoughtSignature: "msg_01XFDUDYJgAACcnSM2TTgQsA",
+        }),
+        toolResultTurn("call_foreign"),
+        {
+          role: "user",
+          content: [{ type: "text", text: "Continue." }],
+        },
+      ],
+    } as never);
+
+    // The foreign signature should not be replayed into the Gemini payload.
+    // Gemini 3 still needs the documented skip fallback for unsigned function
+    // calls that came from another route.
+    const firstModelTurn = getFirstModelTurn(params.contents);
+    expect(firstModelTurn).toMatchObject({
+      role: "model",
+      parts: [
+        {
+          thoughtSignature: "skip_thought_signature_validator",
+          functionCall: { name: "lookup", args: { q: "hello" } },
+        },
+      ],
+    });
+    expect(firstModelTurn.parts[0].thoughtSignature).not.toBe("msg_01XFDUDYJgAACcnSM2TTgQsA");
+  });
+
+  it("does not replay prior Gemini thought signatures onto a later foreign route", () => {
+    const model = buildGeminiModel({
+      id: "gemini-3.1-pro-preview",
+      name: "Gemini 3.1 Pro Preview",
+    });
+
+    const params = buildGoogleGenerativeAiParams(model, {
+      messages: [
+        googleToolCallAssistantTurn({ thoughtSignature: "call_sig_google_1" }),
+        toolResultTurn(),
+        googleToolCallAssistantTurn({
+          provider: "anthropic",
+          api: "anthropic",
+          model: "claude-sonnet-4",
+          timestamp: 2,
+        }),
+      ],
+    } as never);
+
+    const modelTurns = params.contents.filter(isModelTurnWithParts);
+    expect(modelTurns).toHaveLength(2);
+    expect(modelTurns[1]).toMatchObject({
+      parts: [
+        {
+          thoughtSignature: "skip_thought_signature_validator",
+          functionCall: { name: "lookup", args: { q: "hello" } },
+        },
+      ],
+    });
+    expect(modelTurns[1]?.parts[0].thoughtSignature).not.toBe("call_sig_google_1");
+  });
+
+  it("replaces invalid Gemini tool-call sentinel signatures with the skip fallback", () => {
+    const model = buildGeminiModel({
+      id: "gemini-3.1-pro-preview",
+      name: "Gemini 3.1 Pro Preview",
+    });
+
+    const params = buildGoogleGenerativeAiParams(model, {
+      messages: [googleToolCallAssistantTurn({ thoughtSignature: "reasoning" })],
+    } as never);
+
+    const part = (params.contents[0] as { parts: Array<Record<string, unknown>> }).parts[0];
+    expect(part).toMatchObject({
+      thoughtSignature: "skip_thought_signature_validator",
+      functionCall: { name: "lookup", args: { q: "hello" } },
+    });
+  });
+
+  it("preserves the skip-validator fallback for unsigned Gemini tool-call replay", () => {
+    const model = buildGeminiModel({
+      id: "gemini-3.1-pro-preview",
+      name: "Gemini 3.1 Pro Preview",
+    });
+
+    const params = buildGoogleGenerativeAiParams(model, {
+      messages: [
+        googleToolCallAssistantTurn({ thoughtSignature: "skip_thought_signature_validator" }),
+      ],
+    } as never);
+
+    const part = (params.contents[0] as { parts: Array<Record<string, unknown>> }).parts[0];
+    expect(part).toMatchObject({
+      thoughtSignature: "skip_thought_signature_validator",
+      functionCall: { name: "lookup", args: { q: "hello" } },
+    });
+  });
+
+  it("adds skip-validator fallback to unsigned sibling Gemini 3 tool calls", () => {
+    const model = buildGeminiModel({
+      id: "gemini-3.1-pro-preview",
+      name: "Gemini 3.1 Pro Preview",
+    });
+
+    const params = buildGoogleGenerativeAiParams(model, {
+      messages: [
+        {
+          role: "assistant",
+          provider: "google",
+          api: "google-generative-ai",
+          model: "gemini-3.1-pro-preview",
+          stopReason: "toolUse",
+          timestamp: 0,
+          content: [
+            {
+              type: "toolCall",
+              id: "call_math",
+              name: "math_eval",
+              arguments: { expression: "17*23" },
+              thoughtSignature: "real_sig_1",
+            },
+            {
+              type: "toolCall",
+              id: "call_lookup",
+              name: "lookup_fact",
+              arguments: { key: "beta" },
+            },
+            {
+              type: "toolCall",
+              id: "call_transform",
+              name: "string_transform",
+              arguments: { text: "claw", mode: "reverse" },
+            },
+          ],
+        },
+      ],
+    } as never);
+
+    const parts = (params.contents[0] as { parts: Array<Record<string, unknown>> }).parts;
+    expect(parts).toHaveLength(3);
+    expect(parts[0]).toMatchObject({
+      thoughtSignature: "real_sig_1",
+      functionCall: { name: "math_eval", args: { expression: "17*23" } },
+    });
+    expect(parts[1]).toMatchObject({
+      thoughtSignature: "skip_thought_signature_validator",
+      functionCall: { name: "lookup_fact", args: { key: "beta" } },
+    });
+    expect(parts[2]).toMatchObject({
+      thoughtSignature: "skip_thought_signature_validator",
+      functionCall: { name: "string_transform", args: { text: "claw", mode: "reverse" } },
     });
   });
 

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -38,7 +38,8 @@ import {
   resolveGoogleVertexAuthorizedUserHeaders,
 } from "./vertex-adc.js";
 
-type GoogleTransportApi = "google-generative-ai" | "google-vertex";
+type CanonicalGoogleTransportApi = "google-generative-ai" | "google-vertex";
+type GoogleTransportApi = CanonicalGoogleTransportApi | "openclaw-google-generative-ai-transport";
 
 type GoogleTransportModel = Model<GoogleTransportApi> & {
   headers?: Record<string, string>;
@@ -91,7 +92,7 @@ type GoogleTransportContentBlock =
 type MutableAssistantOutput = {
   role: "assistant";
   content: Array<GoogleTransportContentBlock>;
-  api: GoogleTransportApi;
+  api: CanonicalGoogleTransportApi;
   provider: string;
   model: string;
   usage: {
@@ -164,6 +165,106 @@ function retainThoughtSignature(existing: string | undefined, incoming: string |
     return incoming;
   }
   return existing;
+}
+
+function stableStringifyGoogleToolCallValue(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringifyGoogleToolCallValue(item)).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record)
+      .toSorted()
+      .map((key) => `${JSON.stringify(key)}:${stableStringifyGoogleToolCallValue(record[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function isJsonLikeThoughtSignature(value: string): boolean {
+  const trimmed = value.trim();
+  return (
+    trimmed.startsWith("{") ||
+    trimmed.startsWith("[") ||
+    trimmed.includes('":') ||
+    trimmed.includes('","') ||
+    trimmed.includes('"type"')
+  );
+}
+
+function sanitizeGeminiToolCallThoughtSignature(
+  thoughtSignature: string | undefined,
+): string | undefined {
+  if (typeof thoughtSignature !== "string") {
+    return undefined;
+  }
+  const trimmed = thoughtSignature.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (isJsonLikeThoughtSignature(trimmed)) {
+    return undefined;
+  }
+  const lowered = normalizeLowercaseStringOrEmpty(trimmed);
+  if (
+    lowered === "reasoning" ||
+    lowered === normalizeLowercaseStringOrEmpty(GEMINI_THOUGHT_SIGNATURE_VALIDATOR_SKIP)
+  ) {
+    return undefined;
+  }
+  return trimmed;
+}
+
+function isSameGoogleTransportRoute(
+  source: { api?: string; provider?: string; model?: string },
+  model: GoogleTransportModel,
+): boolean {
+  return (
+    source.provider === model.provider &&
+    normalizeGoogleTransportRouteApi(source.api) === normalizeGoogleTransportRouteApi(model.api) &&
+    source.model === model.id
+  );
+}
+
+function normalizeGoogleTransportRouteApi(
+  api: string | undefined,
+): CanonicalGoogleTransportApi | undefined {
+  switch (api) {
+    case "google-generative-ai":
+    case "openclaw-google-generative-ai-transport":
+      return "google-generative-ai";
+    case "google-vertex":
+      return "google-vertex";
+    default:
+      return undefined;
+  }
+}
+
+function normalizeGoogleTransportModelRoute(model: GoogleTransportModel): GoogleTransportModel {
+  const api = normalizeGoogleTransportRouteApi(model.api);
+  return api && api !== model.api ? Object.assign({}, model, { api }) : model;
+}
+
+function normalizeGoogleTransportMessageRoutes(messages: Context["messages"]): Context["messages"] {
+  return messages.map((msg) => {
+    if (msg.role !== "assistant") {
+      return msg;
+    }
+    const api = normalizeGoogleTransportRouteApi(msg.api);
+    return api && api !== msg.api ? Object.assign({}, msg, { api }) : msg;
+  });
+}
+
+function toolCallThoughtSignatureReplayKey(block: {
+  id: string;
+  name: string;
+  arguments: unknown;
+}): string {
+  return [
+    block.id,
+    block.name,
+    stableStringifyGoogleToolCallValue(coerceTransportToolCallArguments(block.arguments)),
+  ].join("\u0000");
 }
 
 function mapToolChoice(
@@ -385,9 +486,12 @@ function normalizeGoogleThinkingConfig(
 
 function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
   const contents: Array<Record<string, unknown>> = [];
+  const replayToolCallThoughtSignatures = new Map<string, string>();
+  const shouldReplayToolCallThoughtSignature = requiresToolCallThoughtSignature(model.id);
+  const routeModel = normalizeGoogleTransportModelRoute(model);
   const transformedMessages = transformTransportMessages(
-    context.messages,
-    model,
+    normalizeGoogleTransportMessageRoutes(context.messages),
+    routeModel,
     (id) => (requiresToolCallId(model.id) ? normalizeToolCallId(id) : id),
     {
       preserveCrossModelToolCallThoughtSignature: requiresToolCallThoughtSignature(model.id),
@@ -422,8 +526,9 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
     }
 
     if (msg.role === "assistant") {
-      const isSameProviderAndModel = msg.provider === model.provider && msg.model === model.id;
+      const isSameRoute = isSameGoogleTransportRoute(msg, model);
       const parts: Array<Record<string, unknown>> = [];
+      const nextReplayToolCallThoughtSignatures = new Map<string, string>();
       for (const block of msg.content) {
         if (block.type === "text") {
           if (!block.text.trim()) {
@@ -431,7 +536,7 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
           }
           parts.push({
             text: sanitizeTransportPayloadText(block.text),
-            ...(isSameProviderAndModel && block.textSignature
+            ...(isSameRoute && block.textSignature
               ? { thoughtSignature: block.textSignature }
               : {}),
           });
@@ -441,7 +546,7 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
           if (!block.thinking.trim()) {
             continue;
           }
-          if (isSameProviderAndModel) {
+          if (isSameRoute) {
             parts.push({
               thought: true,
               text: sanitizeTransportPayloadText(block.thinking),
@@ -453,9 +558,25 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
           continue;
         }
         if (block.type === "toolCall") {
+          const replayKey = toolCallThoughtSignatureReplayKey(block);
+          const replayedThoughtSignature =
+            shouldReplayToolCallThoughtSignature && isSameRoute
+              ? replayToolCallThoughtSignatures.get(replayKey)
+              : undefined;
+          // Use a block's own same-route signature first; otherwise fall back
+          // to a same-route replayed value from already-converted context.
+          // Never replay signatures from foreign providers — Gemini requires
+          // its own signatures returned exactly as issued.
+          const ownSignature = isSameRoute
+            ? sanitizeGeminiToolCallThoughtSignature(block.thoughtSignature)
+            : undefined;
+          if (ownSignature) {
+            nextReplayToolCallThoughtSignatures.set(replayKey, ownSignature);
+          }
           const thoughtSignature =
-            (isSameProviderAndModel ? block.thoughtSignature : undefined) ??
-            (requiresToolCallThoughtSignature(model.id)
+            ownSignature ??
+            replayedThoughtSignature ??
+            (shouldReplayToolCallThoughtSignature
               ? GEMINI_THOUGHT_SIGNATURE_VALIDATOR_SKIP
               : undefined);
           parts.push({
@@ -467,6 +588,9 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
             ...(thoughtSignature ? { thoughtSignature } : {}),
           });
         }
+      }
+      for (const [key, signature] of nextReplayToolCallThoughtSignatures) {
+        replayToolCallThoughtSignatures.set(key, signature);
       }
       if (parts.length > 0) {
         contents.push({ role: "model", parts });
@@ -640,7 +764,7 @@ async function buildGoogleVertexHeaders(
 }
 
 function buildGoogleTransportRequestUrl(
-  kind: GoogleTransportApi,
+  kind: CanonicalGoogleTransportApi,
   model: GoogleTransportModel,
   options: GoogleTransportOptions | undefined,
 ): string {
@@ -673,7 +797,7 @@ function resolveGoogleGemini3FirstResponseRetryMs(env = process.env): number {
 }
 
 function shouldRetryGoogleGemini3FirstResponse(params: {
-  kind: GoogleTransportApi;
+  kind: CanonicalGoogleTransportApi;
   model: GoogleTransportModel;
 }): boolean {
   if (params.kind !== "google-generative-ai") {
@@ -846,7 +970,7 @@ async function openGoogleSseAttempt(params: {
 }
 
 async function openGoogleSseChunks(params: {
-  kind: GoogleTransportApi;
+  kind: CanonicalGoogleTransportApi;
   model: GoogleTransportModel;
   options: GoogleTransportOptions | undefined;
   guardedFetch: ReturnType<typeof buildGuardedModelFetch>;
@@ -927,7 +1051,7 @@ async function openGoogleSseChunks(params: {
 }
 
 async function buildGoogleTransportHeaders(params: {
-  kind: GoogleTransportApi;
+  kind: CanonicalGoogleTransportApi;
   model: GoogleTransportModel;
   apiKey: string | undefined;
   optionHeaders: Record<string, string> | undefined;
@@ -1042,7 +1166,7 @@ function pushTextBlockEnd(
   }
 }
 
-function createGoogleTransportStreamFn(kind: GoogleTransportApi): StreamFn {
+function createGoogleTransportStreamFn(kind: CanonicalGoogleTransportApi): StreamFn {
   return (rawModel, context, rawOptions) => {
     const model = rawModel as GoogleTransportModel;
     const options = rawOptions as GoogleTransportOptions | undefined;
@@ -1102,6 +1226,16 @@ function createGoogleTransportStreamFn(kind: GoogleTransportApi): StreamFn {
                 typeof part.thoughtSignature === "string" && part.thoughtSignature.length > 0;
               const hasText = typeof part.text === "string";
               if (hasText || (hasThoughtSignature && !part.functionCall)) {
+                if (hasThoughtSignature && !hasText && part.thought !== true) {
+                  const latestBlock = output.content[output.content.length - 1];
+                  if (latestBlock?.type === "toolCall") {
+                    latestBlock.thoughtSignature = retainThoughtSignature(
+                      latestBlock.thoughtSignature,
+                      part.thoughtSignature,
+                    );
+                    continue;
+                  }
+                }
                 const isThinking = part.thought === true || !hasText;
                 const currentBlock = output.content[currentBlockIndex];
                 if (
@@ -1168,6 +1302,15 @@ function createGoogleTransportStreamFn(kind: GoogleTransportApi): StreamFn {
                 const isDuplicate = output.content.some(
                   (block) => block.type === "toolCall" && block.id === providedId,
                 );
+                const existingToolCall =
+                  typeof providedId === "string"
+                    ? output.content.find(
+                        (
+                          block,
+                        ): block is Extract<GoogleTransportContentBlock, { type: "toolCall" }> =>
+                          block.type === "toolCall" && block.id === providedId,
+                      )
+                    : undefined;
                 const toolCallId =
                   providedId && !isDuplicate
                     ? providedId
@@ -1177,7 +1320,10 @@ function createGoogleTransportStreamFn(kind: GoogleTransportApi): StreamFn {
                   id: toolCallId,
                   name: part.functionCall.name || "",
                   arguments: part.functionCall.args ?? {},
-                  thoughtSignature: part.thoughtSignature,
+                  thoughtSignature: retainThoughtSignature(
+                    existingToolCall?.thoughtSignature,
+                    part.thoughtSignature,
+                  ),
                 };
                 output.content.push(toolCall);
                 const blockIndex = output.content.length - 1;


### PR DESCRIPTION
## Summary

- Recover and preserve Gemini 3 tool-call thought signatures for native Google replay.
- Add focused replay coverage for captured, recovered, sentinel, and cross-route signatures.
- Add changelog credit for @abnershang and fix #72879.

## Verification

- pnpm exec oxfmt --check --threads=1 extensions/google/transport-stream.ts extensions/google/transport-stream.test.ts CHANGELOG.md
- pnpm exec oxlint extensions/google/transport-stream.ts extensions/google/transport-stream.test.ts
- git diff --check origin/main
- node scripts/run-vitest.mjs extensions/google/transport-stream.test.ts (50 passed)
- codex-review --mode branch: clean, no accepted/actionable findings

## Real behavior proof

Behavior addressed: Gemini 3 native replay of prior tool-call turns now keeps exact Google thought signatures when available and uses the provider-recognized skip sentinel only where OpenClaw cannot safely replay one.
Real environment tested: Live Google Gemini API with gemini-3-flash-preview plus local OpenClaw Google transport stream tests.
Exact steps or command run after this patch: pnpm exec oxfmt --check --threads=1 extensions/google/transport-stream.ts extensions/google/transport-stream.test.ts CHANGELOG.md; pnpm exec oxlint extensions/google/transport-stream.ts extensions/google/transport-stream.test.ts; git diff --check origin/main; node scripts/run-vitest.mjs extensions/google/transport-stream.test.ts; direct Gemini replay probe.
Evidence after fix: Copied live output from the Gemini replay probe: {"model":"gemini-3-flash-preview","first":{"stopReason":"STOP","toolName":"lookup_temperature","retainedThoughtSignature":true,"signatureLength":72},"missingSignatureReplay":{"ok":false,"status":400,"messageIncludesThoughtSignature":true},"exactSignatureReplay":{"ok":true,"status":200,"stopReason":"STOP","text":"replay ok"}}
Observed result after fix: Live output shows missing-signature replay failed with 400 and thought_signature in the error, while exact-signature replay succeeded with 200 and text replay ok. OpenClaw focused tests passed 50 Google transport-stream cases after the patch.
What was not tested: Full CI was not run locally; replacement PR CI will cover repo-wide required checks.

Supersedes #80358 because pushing maintainer fixups to the contributor fork was blocked with 403 despite maintainer edits being enabled.
