### PR TITLE
fix(a2a): resolve direct/dm announce target from session-key fallback

### DIFF
--- a/src/agents/tools/sessions-send-helpers.test.ts
+++ b/src/agents/tools/sessions-send-helpers.test.ts
@@ -2,6 +2,7 @@
 // turn limits for agent-to-agent announce flows.
 import { beforeEach, describe, expect, it } from "vitest";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { createSessionConversationTestRegistry } from "../../test-utils/session-conversation-registry.js";
 import { resolveAnnounceTargetFromKey, resolvePingPongTurns } from "./sessions-send-helpers.js";
 
@@ -63,6 +64,58 @@ describe("resolveAnnounceTargetFromKey", () => {
     ).toEqual({
       channel: "feishu",
       to: "oc_group_chat:topic:om_topic_root:sender:ou_topic_user",
+      threadId: undefined,
+    });
+  });
+
+  it("supports direct session keys for feishu announce targets", () => {
+    expect(resolveAnnounceTargetFromKey("agent:main:feishu:direct:ou_direct_user")).toEqual({
+      channel: "feishu",
+      to: "user:ou_direct_user",
+      threadId: undefined,
+    });
+  });
+
+  it("supports dm alias in direct announce target parsing", () => {
+    expect(resolveAnnounceTargetFromKey("agent:main:feishu:dm:ou_direct_user")).toEqual({
+      channel: "feishu",
+      to: "user:ou_direct_user",
+      threadId: undefined,
+    });
+  });
+
+  it("does not crash when resolveDeliveryTarget returns null", () => {
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "feishu",
+          source: "test",
+          plugin: {
+            id: "feishu",
+            meta: {
+              id: "feishu",
+              label: "Feishu",
+              selectionLabel: "Feishu",
+              docsPath: "/channels/feishu",
+              blurb: "Feishu test stub.",
+            },
+            capabilities: { chatTypes: ["direct", "group", "thread"] },
+            messaging: {
+              resolveDeliveryTarget: () => null,
+              normalizeTarget: (raw: string) => raw.replace(/^user:/, ""),
+            },
+            config: {
+              listAccountIds: () => ["default"],
+              resolveAccount: () => ({}),
+            },
+          },
+        },
+      ]),
+    );
+
+    expect(resolveAnnounceTargetFromKey("agent:main:feishu:direct:ou_direct_user")).toEqual({
+      channel: "feishu",
+      to: "ou_direct_user",
       threadId: undefined,
     });
   });

--- a/src/agents/tools/sessions-send-helpers.test.ts
+++ b/src/agents/tools/sessions-send-helpers.test.ts
@@ -84,6 +84,23 @@ describe("resolveAnnounceTargetFromKey", () => {
     });
   });
 
+  it("supports account-scoped direct session keys", () => {
+    expect(
+      resolveAnnounceTargetFromKey("agent:main:feishu:acct_main:direct:ou_direct_user"),
+    ).toEqual({
+      channel: "feishu",
+      to: "user:ou_direct_user",
+      accountId: "acct_main",
+      threadId: undefined,
+    });
+    expect(resolveAnnounceTargetFromKey("agent:main:feishu:acct_main:dm:ou_direct_user")).toEqual({
+      channel: "feishu",
+      to: "user:ou_direct_user",
+      accountId: "acct_main",
+      threadId: undefined,
+    });
+  });
+
   it("does not crash when resolveDeliveryTarget returns null", () => {
     setActivePluginRegistry(
       createTestRegistry([
@@ -116,6 +133,14 @@ describe("resolveAnnounceTargetFromKey", () => {
     expect(resolveAnnounceTargetFromKey("agent:main:feishu:direct:ou_direct_user")).toEqual({
       channel: "feishu",
       to: "ou_direct_user",
+      threadId: undefined,
+    });
+    expect(
+      resolveAnnounceTargetFromKey("agent:main:feishu:acct_main:direct:ou_direct_user"),
+    ).toEqual({
+      channel: "feishu",
+      to: "ou_direct_user",
+      accountId: "acct_main",
       threadId: undefined,
     });
   });

--- a/src/agents/tools/sessions-send-helpers.ts
+++ b/src/agents/tools/sessions-send-helpers.ts
@@ -10,6 +10,7 @@ import {
 import { resolveSessionConversationRef } from "../../channels/plugins/session-conversation.js";
 import { normalizeChannelId as normalizeChatChannelId } from "../../channels/registry.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { parseThreadSessionSuffix } from "../../sessions/session-key-utils.js";
 import { ANNOUNCE_SKIP_TOKEN, REPLY_SKIP_TOKEN } from "./sessions-send-tokens.js";
 export {
   isAnnounceSkip,
@@ -31,7 +32,34 @@ export type AnnounceTarget = {
 export function resolveAnnounceTargetFromKey(sessionKey: string): AnnounceTarget | null {
   const parsed = resolveSessionConversationRef(sessionKey);
   if (!parsed) {
-    return null;
+    const rawParts = sessionKey
+      .split(":")
+      .filter(Boolean);
+    const isAgentScoped = rawParts[0]?.toLowerCase() === "agent";
+    const raw = rawParts.slice(isAgentScoped ? 2 : 0);
+    if (raw.length < 3) {
+      return null;
+    }
+    const channel = normalizeAnyChannelId(raw[0]) ?? normalizeChatChannelId(raw[0]) ?? raw[0];
+    const kind = raw[1]?.toLowerCase();
+    if (kind !== "direct" && kind !== "dm") {
+      return null;
+    }
+    const parsedThread = parseThreadSessionSuffix(raw.slice(2).join(":"));
+    const id = parsedThread.baseSessionKey?.trim();
+    if (!id) {
+      return null;
+    }
+    const plugin = getChannelPlugin(channel);
+    const routed =
+      plugin?.messaging?.resolveDeliveryTarget?.({ conversationId: id })?.to ??
+      plugin?.messaging?.normalizeTarget?.(`user:${id}`) ??
+      id;
+    return {
+      channel,
+      to: routed,
+      threadId: parsedThread.threadId,
+    };
   }
   const normalizedChannel =
     normalizeAnyChannelId(parsed.channel) ?? normalizeChatChannelId(parsed.channel);

--- a/src/agents/tools/sessions-send-helpers.ts
+++ b/src/agents/tools/sessions-send-helpers.ts
@@ -41,11 +41,14 @@ export function resolveAnnounceTargetFromKey(sessionKey: string): AnnounceTarget
       return null;
     }
     const channel = normalizeAnyChannelId(raw[0]) ?? normalizeChatChannelId(raw[0]) ?? raw[0];
-    const kind = raw[1]?.toLowerCase();
+    const hasAccountScopedDirectKind = raw.length >= 4 && (raw[2] === "direct" || raw[2] === "dm");
+    const accountId = hasAccountScopedDirectKind ? raw[1] : undefined;
+    const kind = (hasAccountScopedDirectKind ? raw[2] : raw[1])?.toLowerCase();
     if (kind !== "direct" && kind !== "dm") {
       return null;
     }
-    const parsedThread = parseThreadSessionSuffix(raw.slice(2).join(":"));
+    const idStartIndex = hasAccountScopedDirectKind ? 3 : 2;
+    const parsedThread = parseThreadSessionSuffix(raw.slice(idStartIndex).join(":"));
     const id = parsedThread.baseSessionKey?.trim();
     if (!id) {
       return null;
@@ -58,6 +61,7 @@ export function resolveAnnounceTargetFromKey(sessionKey: string): AnnounceTarget
     return {
       channel,
       to: routed,
+      accountId,
       threadId: parsedThread.threadId,
     };
   }


### PR DESCRIPTION
## Summary
- Fix announce target resolution fallback for direct-session keys like `agent:main:<channel>:direct:<peerId>` and `...:dm:<peerId>`.
- Keep channel plugin routing first (`resolveDeliveryTarget`) and fallback safely when plugin returns null.
- Add focused regression tests for direct, dm alias, and null-delivery-target fallback.

## Linked Issue
Closes #83046

## Scope
- Included: `resolveAnnounceTargetFromKey` fallback parsing for agent-scoped direct/dm keys.
- Not included: any group/thread routing behavior change.

## Files
- `src/agents/tools/sessions-send-helpers.ts`
- `src/agents/tools/sessions-send-helpers.test.ts`

## Verification
- Added unit coverage for:
  - `agent:main:feishu:direct:<id>`
  - `agent:main:feishu:dm:<id>`
  - plugin `resolveDeliveryTarget()` returns null fallback
- Manual scenario validated in direct-chat A2A flow.

## Evidence
- Screenshot artifacts (local verification set):
  - `projects-ref/snapshot/ScreenShot_2026-05-17_180432_929.png`
  - `projects-ref/snapshot/Weixin Image_20260517180546_90_1.png`

Note: The second artifact contains personal watermark text; I can provide a redacted copy if maintainers require public attachment.

## Real behavior proof
Behavior addressed:
- Validate announce target fallback resolves direct and account-scoped direct/dm session keys instead of returning null.

Real environment tested:
- Runtime: OpenClaw gateway + A2A flow in a real direct-chat setup.
- Channel context: WeCom direct chat.
- Redaction: peer/account identifiers and personal watermark/email text removed.

Exact steps or command run after the patch:
1. Trigger A2A flow that emits a direct session key for announce target resolution.
2. Verify fallback parsing path resolves the direct target.
3. Repeat with account-scoped direct key shape.
4. Confirm receiver side gets the announce message in direct chat context.

Evidence after fix:
- Redacted live output excerpt (console output):
```text
sessionKey=agent:main:wecom:direct:<redacted_peer_id>
[A2A-verify] source_agent=main target_agent=main channel_type=wecom-direct ...
```
- Redacted screenshot artifacts are available locally and can be attached as redacted copies on maintainer request.

Observed result after fix:
- Announce target resolution succeeds for direct and account-scoped direct/dm key shapes.
- Receiver side confirms message arrival in direct chat context after the fix.

What was not tested:
- Full cross-channel matrix for all providers.
- End-to-end validation in every dmScope variant beyond the reproduced direct/account-scoped direct cases.
