### PR TITLE
fix(#82961): surface cleanup-step diagnostic state on agent cleanup timeout

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -4490,6 +4490,20 @@ export async function runEmbeddedAttempt(
         cleanup: async () => {
           await trajectoryRecorder?.flush();
         },
+        getCleanupDiagnostic: () => {
+          // Bounded, non-secret snapshot of what the flush is waiting on.
+          // Trajectory recorder is constructed lazily; if it was never
+          // initialized for this attempt, the flush hung on the
+          // `trajectoryRecorder?.flush()` Promise chain itself, not on writer IO.
+          if (!trajectoryRecorder) {
+            return "writer=none";
+          }
+          // The TrajectoryRuntimeRecorder interface does not yet surface
+          // queued-write / queued-byte counters; once it does (follow-up to
+          // this PR), expose them here. For now, signal at least that the
+          // writer existed and the flush was actually entered.
+          return "writer=present recorderType=runtime";
+        },
       });
       // Always tear down the session (and release the lock) before we leave this attempt.
       //

--- a/src/agents/run-cleanup-timeout.ts
+++ b/src/agents/run-cleanup-timeout.ts
@@ -57,6 +57,13 @@ export async function runAgentCleanupStep(params: {
   log: AgentCleanupLogger;
   env?: NodeJS.ProcessEnv;
   timeoutMs?: number;
+  /**
+   * Optional callback evaluated on timeout. Should return a short, bounded,
+   * non-secret summary of what the cleanup step is waiting on (queued bytes,
+   * pending operation, etc.) so the timeout warning is actionable instead of
+   * just reporting the envelope. See issue #82961.
+   */
+  getCleanupDiagnostic?: () => string | undefined;
 }): Promise<void> {
   const timeoutMs = resolveAgentCleanupStepTimeoutMs({
     step: params.step,
@@ -88,8 +95,16 @@ export async function runAgentCleanupStep(params: {
     clearTimeout(timeoutHandle);
   }
   if (result === "timeout") {
+    let diagnostic: string | undefined;
+    try {
+      diagnostic = params.getCleanupDiagnostic?.();
+    } catch (error) {
+      // Diagnostic capture must never break the timeout warning itself.
+      diagnostic = `diagnosticError=${formatErrorMessage(error)}`;
+    }
+    const diagnosticSuffix = diagnostic ? ` ${diagnostic}` : "";
     params.log.warn(
-      `agent cleanup timed out: runId=${params.runId} sessionId=${params.sessionId} step=${params.step} timeoutMs=${timeoutMs}`,
+      `agent cleanup timed out: runId=${params.runId} sessionId=${params.sessionId} step=${params.step} timeoutMs=${timeoutMs}${diagnosticSuffix}`,
     );
     void cleanupPromise.catch((error) => {
       params.log.warn(


### PR DESCRIPTION
## Summary

Addresses #82961. (Re-opens the previously-closed #83049 with a clean two-file diff — that PR accidentally bundled untracked audit-tool output files.)

Current `runAgentCleanupStep` timeout warning is just the envelope:

```
agent cleanup timed out: runId=... sessionId=... step=pi-trajectory-flush timeoutMs=10000
```

It tells operators nothing about what the flush is waiting on (queued writer work, event-loop yield, or file append IO). The issue asks for "bounded, non-secret state" alongside the timeout.

## Fix

Add an optional `getCleanupDiagnostic?: () => string | undefined` parameter to `runAgentCleanupStep`. If provided, the callback is evaluated **on timeout** (inside a try/catch so a misbehaving probe cannot suppress the warning itself) and its return value is appended:

```ts
let diagnostic: string | undefined;
try {
  diagnostic = params.getCleanupDiagnostic?.();
} catch (error) {
  diagnostic = `diagnosticError=${formatErrorMessage(error)}`;
}
const diagnosticSuffix = diagnostic ? ` ${diagnostic}` : "";
params.log.warn(`agent cleanup timed out: ... timeoutMs=${timeoutMs}${diagnosticSuffix}`);
```

Wire the trajectory caller (`src/agents/pi-embedded-runner/run/attempt.ts:4485`) to pass a probe that reports whether the trajectory recorder was constructed for the attempt — minimal at this stage; full queued-writer counters (queuedWrites / queuedBytes / activeOp / appendSize) require `TrajectoryRuntimeRecorder` to expose those fields, which is a follow-up refactor that plugs into the new hook trivially.

## Real behavior proof

```
--- OLD warning (no diagnostic):
  warn> agent cleanup timed out: runId=run-123 sessionId=sess-456 step=pi-trajectory-flush timeoutMs=10000

--- NEW warning (no recorder constructed):
  warn> agent cleanup timed out: runId=run-123 sessionId=sess-456 step=pi-trajectory-flush timeoutMs=10000 writer=none

--- NEW warning (recorder present):
  warn> agent cleanup timed out: runId=run-123 sessionId=sess-456 step=pi-trajectory-flush timeoutMs=10000 writer=present recorderType=runtime

--- NEW warning (probe itself threw):
  warn> agent cleanup timed out: runId=run-123 sessionId=sess-456 step=pi-trajectory-flush timeoutMs=10000 diagnosticError=boom
```

## Behaviour

* **No callback** → byte-identical warning to before this PR (full backward compat for every other `runAgentCleanupStep` caller).
* **Callback returns string** → appended after `timeoutMs=...`.
* **Callback throws** → message is captured as `diagnosticError=...`; the timeout warning itself never fails.
* **Success path** unchanged.

## Scope

Two-file diff. The hook is general enough for any future cleanup step (`bundle-mcp-retire`, etc.) to plug into; only `pi-trajectory-flush` is wired now per the issue's scope.

## Follow-up (out of scope)

`TrajectoryRuntimeRecorder.diagnosticString?(): string` to expose `queuedBytes / queuedWrites / activeOp / appendSize / acceptedRuntimeBytes / droppedEvents`. Trivial to plug in once that interface lands — just call the recorder method inside the existing `getCleanupDiagnostic` closure in `attempt.ts`. Happy to do that as a separate PR.