### PR TITLE
fix(#82959): make duplicate same-handle clearActiveEmbeddedRun idempotent

### DIFF
--- a/src/agents/pi-embedded-runner/runs.ts
+++ b/src/agents/pi-embedded-runner/runs.ts
@@ -549,9 +549,15 @@ export function clearActiveEmbeddedRun(
       diag.debug(`run cleared: sessionId=${sessionId} totalActive=${ACTIVE_EMBEDDED_RUNS.size}`);
     }
     notifyEmbeddedRunEnded(sessionId);
-  } else {
+  } else if (ACTIVE_EMBEDDED_RUNS.has(sessionId)) {
+    // Some other handle now owns this session — keep the diagnostic because
+    // it usually indicates a stale handle that did not observe a takeover.
     diag.debug(`run clear skipped: sessionId=${sessionId} reason=handle_mismatch`);
   }
+  // Otherwise the entry has already been removed (e.g. terminal lifecycle
+  // cleanup cleared the run before the attempt `finally` path got here).
+  // That is a benign idempotent duplicate clear and should not surface as
+  // handle_mismatch noise — see issue #82959.
 }
 
 export function forceClearEmbeddedPiRun(


### PR DESCRIPTION
## Summary

Fixes #82959.

Embedded runner cleanup can clear the same run twice along two independent paths (terminal lifecycle cleanup, then attempt `finally`). Today the second `clearActiveEmbeddedRun` finds the active map entry already removed and indiscriminately logs:

```
run clear skipped: sessionId=... reason=handle_mismatch
```

even though the absence of the entry is the **expected** state after the first clean. The issue reports 265 of these noise lines correlated with `no_active_run` traces.

## Fix

Split the `else` branch in `src/agents/pi-embedded-runner/runs.ts:clearActiveEmbeddedRun` into two cases:

```ts
if (ACTIVE_EMBEDDED_RUNS.get(sessionId) === handle) {
  // ... happy path (run cleared)
} else if (ACTIVE_EMBEDDED_RUNS.has(sessionId)) {
  // Another handle owns the session — genuine mismatch, keep the diagnostic
  diag.debug(`run clear skipped: sessionId=${sessionId} reason=handle_mismatch`);
}
// Otherwise the entry is gone (terminal lifecycle already cleared it).
// Benign idempotent duplicate clear — silent.
```

## Behavior table

| State | Caller handle | Active map state | Before | After |
|---|---|---|---|---|
| happy | `A` | sessionId → `A` | cleared ✅ | cleared ✅ (unchanged) |
| **duplicate** (this PR) | `A` | sessionId removed (already cleared) | `handle_mismatch` noise 🔴 | **silent ✅** |
| real mismatch | `A` | sessionId → `B` | `handle_mismatch` ✅ | `handle_mismatch` ✅ (unchanged) |

The issue's described scenario — "terminal lifecycle path clears the active embedded run before emitting terminal lifecycle events; later attempt `finally` clears the same run handle again" — falls under the duplicate row and is now silent.

## Real behavior proof

```
S1 (active=handleA, clear handleA):       cleared
S2 (already cleared, clear handleA dup):  idempotent-silent
S3 (active=handleB, clear handleA stale): handle_mismatch (real)
```

S1 / S3 unchanged from current behavior. Only S2 — the noise case from the issue — now flips from `handle_mismatch (real)` to `idempotent-silent`.

## Scope

Single file, 6-line `else` → `else if` + comment split. `forceClearEmbeddedPiRun` already short-circuits through `ACTIVE_EMBEDDED_RUNS.has(sessionId)` before deleting, so it's unaffected.