### PR TITLE
fix(skills): add YAML frontmatter to canvas SKILL.md (#83036)

### DIFF
--- a/skills/canvas/SKILL.md
+++ b/skills/canvas/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: canvas
+description: Display HTML content (games, visualizations, dashboards, generated pages, interactive demos) on connected OpenClaw nodes (Mac app, iOS, Android) via a Tailscale-backed canvas host. Use when the user asks to show, render, present, or push HTML/web content to a node's canvas view, or wants to surface generated visualizations on a paired device.
+---
+
 # Canvas Skill
 
 Display HTML content on connected OpenClaw nodes (Mac app, iOS, Android).


### PR DESCRIPTION
Fixes #83036.

## Problem

Shipped `skills/canvas/SKILL.md` started directly with the markdown `# Canvas Skill` heading instead of a `---`-delimited YAML frontmatter block. The description-based skill resolver therefore had no `name` or `description` to match user intent against, so the canvas capability was a "dark skill" — the runtime feature shipped but users asking the agent to display HTML / dashboards / games / visualizations on a connected node could not trigger the matching skill via natural language. The skill could still be invoked by direct path read, but that defeats progressive disclosure.

The body of `skills/canvas/SKILL.md` is correct and informative — this is purely a frontmatter omission, matching the issue reporter's description.

## Fix

`skills/canvas/SKILL.md`: prepend a standard YAML frontmatter block with `name: canvas` and a description covering the canvas surfaces (Mac app, iOS, Android via the Tailscale-backed canvas host) and the trigger verbs (show, render, present, push, surface). Body unchanged. The frontmatter shape matches sibling skills in the repo (`nano-pdf`, `openai-whisper-api`, `ordercli`, etc.) which all begin with `---\nname: ...\ndescription: ...\n---`.

## Real behavior proof

**Behavior or issue addressed**: Per #83036, `skills/canvas/SKILL.md` ships without YAML frontmatter on current main, so the resolver cannot match it against user intent. Verified via `head -3 skills/canvas/SKILL.md` on `origin/main` (`2c9f68f42b`) before the fix — file begins with `# Canvas Skill`.

**Real environment tested**: Linux x86_64 (Ubuntu 24.04), Node v22.16, local checkout of `openclaw/openclaw` at branch `fix-canvas-skill-missing-frontmatter` rebased on `origin/main` (`2c9f68f42b`). Reads the patched file directly off disk and parses the frontmatter the same way the description-based resolver does.

**Exact steps or command run after this patch**:

```
node --input-type=module -e '
import fs from "node:fs";
const content = fs.readFileSync("skills/canvas/SKILL.md", "utf8");
const lines = content.split("\n");

const hasFrontmatter = lines[0] === "---";
console.log("PASS first line is `---`:", hasFrontmatter);

const endIdx = lines.slice(1).findIndex(l => l === "---");
console.log("PASS closing `---` found at line", endIdx + 2);

const fm = lines.slice(1, endIdx + 1).join("\n");
const nameMatch = fm.match(/^name:\s*(.+)$/m);
const descMatch = fm.match(/^description:\s*(.+)$/m);
console.log("PASS name:", nameMatch?.[1]);
console.log("PASS description present:", !!descMatch, "(len:", descMatch?.[1].length, ")");

console.log("\nPre-fix first line: # Canvas Skill");
console.log("Post-fix first line:", lines[0]);
console.log("Resolver match available:", nameMatch?.[1] === "canvas" ? "YES" : "NO");
'
```

**Evidence after fix**: live stdout from the probe (real `node`, real filesystem):

```
PASS first line is `---`: true
PASS closing `---` found at line 4
PASS name: canvas
PASS description present: true (len: 344 )

Pre-fix first line: # Canvas Skill
Post-fix first line: ---
Resolver match available: YES
```

Pre-fix the resolver had nothing to match (`name` parse fails because there's no frontmatter to even open); post-fix `name === "canvas"` and the 344-char description gives the description-based matcher concrete trigger verbs to fire on.

**Observed result after fix**: `skills/canvas/SKILL.md` now matches the same `---\nname: ...\ndescription: ...\n---` shape as every other bundled skill in `skills/*/SKILL.md` (`nano-pdf`, `openai-whisper-api`, `ordercli`, etc.). Description-based skill resolution can match user requests like "show this HTML on the canvas" / "display this dashboard on my Mac node" against the canvas skill. The skill body is unchanged, so no other consumer is affected.

**What was not tested**: I did not run a live agent session with the canvas tool to confirm a full end-to-end resolver → skill → canvas-host roundtrip (no paired Mac/iOS/Android node here). The fix is structural — a missing frontmatter block — and the patched file now parses identically to sibling skills that the resolver already matches successfully.

## Pre-implement audit

- **Existing-helper check:** No code change. Pure content fix to a single skill manifest. PASS.
- **Shared-helper caller check:** N/A — no shared helper edited. The skill resolver is unchanged; we're only making the canvas skill discoverable to it. PASS.
- **Broader-fix rival scan:** `gh pr list --search "83036 in:body"` returns no rival PRs. ClawSweeper labelled the issue P2 + queueable-fix + fix-shape-clear + impact:session-state + current-main-repro with no linked closing PR. PASS.
