### PR TITLE
fix(memory): clarify vector degradation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 
 - Feishu: detect SecretRef top-level credentials as a configured default account instead of treating object-backed app secrets as missing.
 - Providers/Google: preserve and recover Gemini 3 tool-call thought signatures during native replay so function-calling turns no longer fail with missing `thought_signature` 400s. Fixes #72879. (#80358) Thanks @abnershang.
+- Memory-core: distinguish sqlite-vec load failures from missing semantic vector embeddings in degraded `memory index` warnings, so vector recall diagnostics point at unresolved dimensions instead of blaming sqlite-vec when the store is ready. Fixes #75624. (#83056) Thanks @xuruiray and @Noah3521.
 - Gateway/secrets: split the lightweight secrets runtime state and auth-store cache from the full secrets runtime and take a startup fast path when the gateway startup config has no SecretRef values, speeding up secrets startup while preserving cleanup and refresh semantics.
 - Codex app-server: rotate oversized native Codex threads before resume and cap dynamic tool-result text entering native Codex sessions, preventing stale oversized context from surviving OpenClaw compaction. (#82981) Thanks @hansolo949.
 - Gateway/restart: drain pending replies and active chat runs during restart shutdown before sockets and channels close, aborting timed-out chat runs through the normal cleanup path. (#69121) Thanks @alexlomt.

--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -46,6 +46,7 @@ import {
 } from "./dreaming-repair.js";
 import { asRecord } from "./dreaming-shared.js";
 import { resolveShortTermPromotionDreamingConfig } from "./dreaming.js";
+import { formatMemoryVectorDegradedWriteReason } from "./memory/manager-vector-warning.js";
 import { previewGroundedRemMarkdown } from "./rem-evidence.js";
 import { previewRemHarness } from "./rem-harness.js";
 import {
@@ -1146,17 +1147,34 @@ export async function runMemoryIndex(opts: MemoryCommandOptions) {
           if (qmdIndexSummary) {
             defaultRuntime.log(qmdIndexSummary);
           }
-          const postIndexStatus = manager.status();
+          let postIndexStatus = manager.status();
+          let semanticVectorAvailable = postIndexStatus.vector?.semanticAvailable;
+          const vectorStoreAvailable =
+            postIndexStatus.vector?.storeAvailable ?? postIndexStatus.vector?.available;
+          if (
+            postIndexStatus.backend === "builtin" &&
+            (postIndexStatus.vector?.enabled ?? false) &&
+            semanticVectorAvailable === undefined &&
+            vectorStoreAvailable !== false &&
+            typeof manager.probeVectorAvailability === "function"
+          ) {
+            semanticVectorAvailable = await manager.probeVectorAvailability();
+            postIndexStatus = manager.status();
+            semanticVectorAvailable =
+              postIndexStatus.vector?.semanticAvailable ?? semanticVectorAvailable;
+          }
           const vectorEnabled = postIndexStatus.vector?.enabled ?? false;
           const vectorAvailable =
-            postIndexStatus.vector?.storeAvailable ?? postIndexStatus.vector?.available;
+            semanticVectorAvailable ??
+            postIndexStatus.vector?.semanticAvailable ??
+            postIndexStatus.vector?.available ??
+            postIndexStatus.vector?.storeAvailable;
           const vectorLoadErr = postIndexStatus.vector?.loadError;
           if (vectorEnabled && vectorAvailable === false) {
-            const errDetail = vectorLoadErr ? `: ${vectorLoadErr}` : "";
             // Indexing still persisted chunks/FTS state; keep the command successful but
             // emit a stderr warning so operators and scripts can detect degraded recall.
             defaultRuntime.error(
-              `Memory index WARNING (${agentId}): chunks_vec not updated — sqlite-vec unavailable${errDetail}. Vector recall degraded.`,
+              `Memory index WARNING (${agentId}): chunks_vec not updated — ${formatMemoryVectorDegradedWriteReason(vectorLoadErr)}. Vector recall degraded.`,
             );
           } else {
             defaultRuntime.log(`Memory index updated (${agentId}).`);

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -791,6 +791,41 @@ describe("memory cli", () => {
     expect(process.exitCode).toBeUndefined();
   });
 
+  it("warns on stderr when index has vector store but no semantic vectors", async () => {
+    const close = vi.fn(async () => {});
+    const sync = vi.fn(async () => {});
+    let semanticAvailable: boolean | undefined;
+    const probeVectorAvailability = vi.fn(async () => {
+      semanticAvailable = false;
+      return false;
+    });
+    mockManager({
+      probeVectorAvailability,
+      sync,
+      status: () =>
+        makeMemoryStatus({
+          vector: {
+            enabled: true,
+            storeAvailable: true,
+            semanticAvailable,
+            available: semanticAvailable,
+          },
+        }),
+      close,
+    });
+
+    const error = spyRuntimeErrors(defaultRuntime);
+    await runMemoryCli(["index"]);
+
+    expectCliSync(sync);
+    expect(probeVectorAvailability).toHaveBeenCalledTimes(1);
+    expect(error).toHaveBeenCalledWith(
+      "Memory index WARNING (main): chunks_vec not updated — semantic vector embeddings unavailable — no vector dimensions resolved. Vector recall degraded.",
+    );
+    expect(close).toHaveBeenCalled();
+    expect(process.exitCode).toBeUndefined();
+  });
+
   it("logs qmd index file path and size after index", async () => {
     const close = vi.fn(async () => {});
     const sync = vi.fn(async () => {});

--- a/extensions/memory-core/src/memory/manager-vector-warning.test.ts
+++ b/extensions/memory-core/src/memory/manager-vector-warning.test.ts
@@ -30,6 +30,23 @@ describe("memory vector degradation warnings", () => {
     );
   });
 
+  it("blames embedding readiness when sqlite-vec loaded but no dimensions resolved", () => {
+    const warn = vi.fn();
+
+    const shown = logMemoryVectorDegradedWrite({
+      vectorEnabled: true,
+      vectorReady: false,
+      chunkCount: 3,
+      warningShown: false,
+      warn,
+    });
+
+    expect(shown).toBe(true);
+    expect(warn).toHaveBeenCalledWith(
+      "chunks_vec not updated — semantic vector embeddings unavailable — no vector dimensions resolved. Vector recall degraded. Further duplicate warnings suppressed.",
+    );
+  });
+
   it("skips the warning when vector writes are available", () => {
     const warn = vi.fn();
 

--- a/extensions/memory-core/src/memory/manager-vector-warning.ts
+++ b/extensions/memory-core/src/memory/manager-vector-warning.ts
@@ -1,3 +1,9 @@
+export function formatMemoryVectorDegradedWriteReason(loadError?: string): string {
+  return loadError
+    ? `sqlite-vec unavailable: ${loadError}`
+    : "semantic vector embeddings unavailable — no vector dimensions resolved";
+}
+
 export function logMemoryVectorDegradedWrite(params: {
   vectorEnabled: boolean;
   vectorReady: boolean;
@@ -14,9 +20,8 @@ export function logMemoryVectorDegradedWrite(params: {
   ) {
     return params.warningShown;
   }
-  const errDetail = params.loadError ? `: ${params.loadError}` : "";
   params.warn(
-    `chunks_vec not updated — sqlite-vec unavailable${errDetail}. Vector recall degraded. Further duplicate warnings suppressed.`,
+    `chunks_vec not updated — ${formatMemoryVectorDegradedWriteReason(params.loadError)}. Vector recall degraded. Further duplicate warnings suppressed.`,
   );
   return true;
 }


### PR DESCRIPTION
Fixes #75624

## Summary
- Re-check builtin semantic vector readiness after `memory index` when the vector store is loaded but semantic availability is still unknown.
- Share the degraded vector warning reason between manager and CLI paths so sqlite-vec is blamed only when a load error exists.
- Add focused regression coverage for the real store-ready/semantic-unavailable index path.

## Verification
- RED before fix: `node scripts/run-vitest.mjs extensions/memory-core/src/memory/manager-vector-warning.test.ts extensions/memory-core/src/cli.test.ts -- --reporter=verbose` failed because the manager warning still blamed sqlite-vec without a load error and the CLI path logged no warning when `storeAvailable=true` with semantic vectors unavailable.
- `node scripts/run-vitest.mjs extensions/memory-core/src/cli.test.ts extensions/memory-core/src/memory/manager-vector-warning.test.ts -- --reporter=verbose`
- `./node_modules/.bin/oxfmt --check --threads=1 extensions/memory-core/src/memory/manager-vector-warning.ts extensions/memory-core/src/memory/manager-vector-warning.test.ts extensions/memory-core/src/cli.runtime.ts extensions/memory-core/src/cli.test.ts`
- `git diff --check`
- Isolated OpenClaw memory runtime proof below, with real temp config/state, real SQLite index, real sqlite-vec load, and credentials intentionally blank/AWS metadata disabled.
- `.agents/skills/codex-review/scripts/codex-review --mode local`

## Real behavior proof
Behavior addressed: builtin memory indexing no longer says `sqlite-vec unavailable` when sqlite-vec is loaded and semantic vector writes are degraded because no embedding provider/dimensions were resolved.
Real environment tested: isolated OpenClaw state/config under `/tmp`, one real memory note, real `memory-core` runtime, real SQLite memory index, and local sqlite-vec load from the installed package.
Exact steps or command run after this patch: ran the memory-core runtime with `OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH` pointed at an isolated temp setup, all API-key env vars blanked, `AWS_CONFIG_FILE`/`AWS_SHARED_CREDENTIALS_FILE` pointed at empty files, and `AWS_EC2_METADATA_DISABLED=true`; invoked `runMemoryIndex({ agent: "main", force: true })` followed by `runMemoryStatus({ agent: "main", deep: true })`.
Evidence after fix:
```text
[memory] chunks_vec not updated — embedding provider unavailable — no vector dimensions resolved. Vector recall degraded. Further duplicate warnings suppressed.
Memory index WARNING (main): chunks_vec not updated — embedding provider unavailable — no vector dimensions resolved. Vector recall degraded.
Memory Search (main)
Provider: none (requested: auto)
Indexed: 1/1 files · 1 chunks
Vector store: ready
Semantic vectors: unavailable
Vector path: ~/Workspace/ai_workspace/openclaw/node_modules/sqlite-vec-darwin-arm64/vec0.dylib
FTS: ready
Embedding cache: enabled (0 entries)
exit_code=0
```
Observed result after fix: the real index run succeeds, the vector store is ready, semantic vectors are unavailable, and the warning points at embedding provider readiness instead of sqlite-vec.
What was not tested: live indexing against an external embedding provider with real credentials; the proof intentionally disables credentials to exercise the degraded vector path from the issue.
