### PR TITLE
docs(config): quote bracket config paths

### DIFF
--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -31,7 +31,7 @@ openclaw config get browser.executablePath
 openclaw config set browser.executablePath "/usr/bin/google-chrome"
 openclaw config set browser.profiles.work.executablePath "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
 openclaw config set agents.defaults.heartbeat.every "2h"
-openclaw config set agents.list[0].tools.exec.node "node-id-or-name"
+openclaw config set 'agents.list[0].tools.exec.node' "node-id-or-name"
 openclaw config set agents.defaults.models '{"openai/gpt-5.4":{}}' --strict-json --merge
 openclaw config set channels.discord.token --ref-provider default --ref-source env --ref-id DISCORD_BOT_TOKEN
 openclaw config set secrets.providers.vaultfile --provider-source file --provider-path /etc/openclaw/secrets.json --provider-mode json
@@ -73,18 +73,18 @@ openclaw config schema > openclaw.schema.json
 
 ### Paths
 
-Paths use dot or bracket notation:
+Paths use dot or bracket notation. Quote bracket-notation paths in shell examples so shells such as zsh do not expand `[0]` as a glob before OpenClaw receives the path:
 
 ```bash
 openclaw config get agents.defaults.workspace
-openclaw config get agents.list[0].id
+openclaw config get 'agents.list[0].id'
 ```
 
 Use the agent list index to target a specific agent:
 
 ```bash
 openclaw config get agents.list
-openclaw config set agents.list[1].tools.exec.node "node-id-or-name"
+openclaw config set 'agents.list[1].tools.exec.node' "node-id-or-name"
 ```
 
 ## Values

--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -396,14 +396,14 @@ Per-agent override:
 
 ```bash
 openclaw config get agents.list
-openclaw config set agents.list[0].tools.exec.node "node-id-or-name"
+openclaw config set 'agents.list[0].tools.exec.node' "node-id-or-name"
 ```
 
 Unset to allow any node:
 
 ```bash
 openclaw config unset tools.exec.node
-openclaw config unset agents.list[0].tools.exec.node
+openclaw config unset 'agents.list[0].tools.exec.node'
 ```
 
 ## Permissions map

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -144,7 +144,7 @@ Per-agent node binding (use the agent list index in config):
 
 ```bash
 openclaw config get agents.list
-openclaw config set agents.list[0].tools.exec.node "node-id-or-name"
+openclaw config set 'agents.list[0].tools.exec.node' "node-id-or-name"
 ```
 
 Control UI: the Nodes tab includes a small "Exec node binding" panel for the same settings.

--- a/src/docs/config-path-docs.test.ts
+++ b/src/docs/config-path-docs.test.ts
@@ -1,0 +1,40 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const DOCS_WITH_CONFIG_PATH_EXAMPLES = [
+  "docs/cli/config.md",
+  "docs/tools/exec.md",
+  "docs/nodes/index.md",
+];
+
+function findUnquotedBracketPathExamples(markdown: string, docPath: string): string[] {
+  const failures: string[] = [];
+
+  for (const [index, line] of markdown.split(/\r?\n/).entries()) {
+    const match = line.match(/\bopenclaw\s+config\s+(?:get|set|unset)\s+(\S+)/);
+    if (!match) {
+      continue;
+    }
+
+    const pathArg = match[1];
+    if (pathArg.includes("[") && !pathArg.startsWith("'") && !pathArg.startsWith('"')) {
+      failures.push(`${docPath}:${index + 1}: ${pathArg}`);
+    }
+  }
+
+  return failures;
+}
+
+describe("config path docs", () => {
+  it("quotes bracket-notation config paths in shell examples", async () => {
+    const failures: string[] = [];
+
+    for (const docPath of DOCS_WITH_CONFIG_PATH_EXAMPLES) {
+      const markdown = await fs.readFile(path.join(process.cwd(), docPath), "utf8");
+      failures.push(...findUnquotedBracketPathExamples(markdown, docPath));
+    }
+
+    expect(failures).toEqual([]);
+  });
+});


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- Quote bracket-notation `openclaw config` paths in the affected docs so zsh/bash do not treat `[0]`/`[1]` as glob patterns before OpenClaw receives the argument.
- Add a focused docs regression test that scans config examples and fails on unquoted bracket-notation path arguments.
- Document the quoting rule in the `config` CLI path section.

Fixes #40641

## Test Plan
- TDD RED: `node /tmp/openclaw-auto-40641/proof-doc-config-paths.mjs /tmp/openclaw-auto-40641` failed on the original downloaded docs with the unquoted `agents.list[...]` paths.
- TDD GREEN: `node /tmp/openclaw-auto-40641/proof-doc-config-paths.mjs /tmp/openclaw-auto-40641` passed after the docs update.
- Source hygiene: Python whitespace/final-newline probe passed for the changed docs and new test file.
- Not run: repository Vitest/docs jobs (`pnpm test src/docs/config-path-docs.test.ts`, docs CI) because this cron lane is intentionally API-only with no OpenClaw clone or installed `node_modules`.

## Real behavior proof

**Behavior or issue addressed:** Copy/pasting bracket-notation config examples such as `openclaw config set agents.list[0].tools.exec.node "node-id-or-name"` can fail in shells before OpenClaw sees the path. The patched docs use quoted path arguments like `openclaw config set 'agents.list[0].tools.exec.node' "node-id-or-name"`.

**Real environment tested:** API-only temporary workspace populated from `openclaw/openclaw@main` via GitHub raw contents, then patched locally in `/tmp/openclaw-auto-40641`. No repository clone was used.

**Exact steps or command run after this patch:**

```bash
node /tmp/openclaw-auto-40641/proof-doc-config-paths.mjs /tmp/openclaw-auto-40641
python3 /tmp/openclaw-auto-40641/whitespace-check.py
```

**Evidence after fix:**

```text
$ node /tmp/openclaw-auto-40641/proof-doc-config-paths.mjs /tmp/openclaw-auto-40641
PASS all bracket-notation config paths are shell-quoted
- checked docs/cli/config.md
- checked docs/tools/exec.md
- checked docs/nodes/index.md

$ python3 /tmp/openclaw-auto-40641/whitespace-check.py
PASS whitespace/source hygiene
- checked docs/cli/config.md
- checked docs/tools/exec.md
- checked docs/nodes/index.md
- checked src/docs/config-path-docs.test.ts
```

**Observed result after fix:** The source-level proof found no unquoted bracket-notation path arguments in the three affected docs pages. The new regression test encodes that check for future docs changes.

**What was not tested:** I did not run OpenClaw's full docs/Vitest CI locally because the automation is running in the required no-clone/API-only mode and does not have the repository checkout or `node_modules`. GitHub CI should run the added `src/docs/config-path-docs.test.ts` test in the normal project environment.

## Risk/Notes
- Docs/test-only change; no runtime behavior is modified.
- Prior closed PR #40642 addressed the same issue against older doc paths/localized docs. I rechecked #40641 immediately before opening this PR: the issue is still open and there were no open PRs referencing it.
- English docs are the source of truth per `docs/AGENTS.md`; localized docs are generated outside this repository, so this PR only updates the English docs in `docs/**`.
