### PR TITLE
fix(cli): show concrete PowerShell completion profile path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 
 - Agents/OpenAI streams: yield via `setTimeout(0)` instead of `setImmediate` between bursty Responses chunks so abort timers can fire during the yield, keeping cancel-on-timeout responsive on hot streams. Refs #82462.
 - Feishu: detect SecretRef top-level credentials as a configured default account instead of treating object-backed app secrets as missing.
+- CLI/completion: resolve concrete PowerShell profile paths and reload commands during setup and doctor completion installation. Fixes #44296. (#83059) Thanks @yu-xin-c.
 - Providers/Google: preserve and recover Gemini 3 tool-call thought signatures during native replay so function-calling turns no longer fail with missing `thought_signature` 400s. Fixes #72879. (#80358) Thanks @abnershang.
 - Memory-core: distinguish sqlite-vec load failures from missing semantic vector embeddings in degraded `memory index` warnings, so vector recall diagnostics point at unresolved dimensions instead of blaming sqlite-vec when the store is ready. Fixes #75624. (#83056) Thanks @xuruiray and @Noah3521.
 - Agents/subagents: preserve sandbox-peer controller ownership while routing completion announcements back to the originating run session, keeping subagent control and completion delivery scoped correctly. Fixes #80201. (#80242) Thanks @Jerry-Xin.

--- a/src/cli/completion-runtime.test.ts
+++ b/src/cli/completion-runtime.test.ts
@@ -1,0 +1,61 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  formatCompletionReloadCommand,
+  formatCompletionSourceLine,
+  installCompletion,
+  resolveCompletionCachePath,
+  resolveCompletionProfilePath,
+} from "./completion-runtime.js";
+
+describe("completion-runtime", () => {
+  const originalHome = process.env.HOME;
+  const originalStateDir = process.env.OPENCLAW_STATE_DIR;
+
+  afterEach(() => {
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+    if (originalStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = originalStateDir;
+    }
+  });
+
+  it("formats PowerShell source and reload commands with single-quoted paths", () => {
+    expect(
+      formatCompletionSourceLine("powershell", "openclaw", "C:\\Users\\Ada\\open'claw.ps1"),
+    ).toBe(". 'C:\\Users\\Ada\\open''claw.ps1'");
+    expect(formatCompletionReloadCommand("powershell", "C:\\Users\\Ada\\profile.ps1")).toBe(
+      ". 'C:\\Users\\Ada\\profile.ps1'",
+    );
+  });
+
+  it("installs PowerShell completion into the concrete profile path", async () => {
+    const homeDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-completion-home-"));
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-completion-state-"));
+
+    process.env.HOME = homeDir;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    try {
+      const cachePath = resolveCompletionCachePath("powershell", "openclaw");
+      await fs.mkdir(path.dirname(cachePath), { recursive: true });
+      await fs.writeFile(cachePath, "# powershell completion\n", "utf-8");
+
+      await installCompletion("powershell", true, "openclaw");
+
+      const profilePath = resolveCompletionProfilePath("powershell");
+      const profile = await fs.readFile(profilePath, "utf-8");
+      expect(profile).toBe(`# OpenClaw Completion\n. '${cachePath}'\n`);
+    } finally {
+      await fs.rm(homeDir, { recursive: true, force: true });
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/completion-runtime.test.ts
+++ b/src/cli/completion-runtime.test.ts
@@ -8,6 +8,7 @@ import {
   installCompletion,
   resolveCompletionCachePath,
   resolveCompletionProfilePath,
+  resolveShellFromEnv,
 } from "./completion-runtime.js";
 
 describe("completion-runtime", () => {
@@ -33,6 +34,54 @@ describe("completion-runtime", () => {
     ).toBe(". 'C:\\Users\\Ada\\open''claw.ps1'");
     expect(formatCompletionReloadCommand("powershell", "C:\\Users\\Ada\\profile.ps1")).toBe(
       ". 'C:\\Users\\Ada\\profile.ps1'",
+    );
+  });
+
+  it("detects PowerShell shell names from Windows paths", () => {
+    expect(resolveShellFromEnv({ SHELL: "C:\\Program Files\\PowerShell\\7\\pwsh.exe" })).toBe(
+      "powershell",
+    );
+    expect(
+      resolveShellFromEnv({
+        SHELL: "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+      }),
+    ).toBe("powershell");
+  });
+
+  it("resolves Windows PowerShell and pwsh profile directories", () => {
+    expect(
+      resolveCompletionProfilePath("powershell", {
+        env: {
+          SHELL: "C:\\Program Files\\PowerShell\\7\\pwsh.exe",
+          USERPROFILE: "C:\\Users\\Ada",
+        },
+        homeDir: () => "C:\\Users\\Ada",
+        platform: "win32",
+      }),
+    ).toBe(
+      path.win32.join(
+        "C:\\Users\\Ada",
+        "Documents",
+        "PowerShell",
+        "Microsoft.PowerShell_profile.ps1",
+      ),
+    );
+    expect(
+      resolveCompletionProfilePath("powershell", {
+        env: {
+          SHELL: "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+          USERPROFILE: "C:\\Users\\Ada",
+        },
+        homeDir: () => "C:\\Users\\Ada",
+        platform: "win32",
+      }),
+    ).toBe(
+      path.win32.join(
+        "C:\\Users\\Ada",
+        "Documents",
+        "WindowsPowerShell",
+        "Microsoft.PowerShell_profile.ps1",
+      ),
     );
   });
 

--- a/src/cli/completion-runtime.ts
+++ b/src/cli/completion-runtime.ts
@@ -63,15 +63,29 @@ export async function completionCacheExists(
   return pathExists(cachePath);
 }
 
-function formatCompletionSourceLine(
+function escapePowerShellSingleQuotedString(value: string): string {
+  return value.replace(/'/g, "''");
+}
+
+export function formatCompletionSourceLine(
   shell: CompletionShell,
   _binName: string,
   cachePath: string,
 ): string {
+  if (shell === "powershell") {
+    return `. '${escapePowerShellSingleQuotedString(cachePath)}'`;
+  }
   if (shell === "fish") {
     return `test -f "${cachePath}"; and source "${cachePath}"`;
   }
   return `[ -f "${cachePath}" ] && source "${cachePath}"`;
+}
+
+export function formatCompletionReloadCommand(shell: CompletionShell, profilePath: string): string {
+  if (shell === "powershell") {
+    return `. '${escapePowerShellSingleQuotedString(profilePath)}'`;
+  }
+  return `source ${profilePath}`;
 }
 
 function isCompletionProfileHeader(line: string): boolean {
@@ -126,8 +140,18 @@ function updateCompletionProfile(
   return { next, changed: next !== content, hadExisting };
 }
 
-function getShellProfilePath(shell: CompletionShell): string {
-  const home = process.env.HOME || os.homedir();
+export function resolveCompletionProfilePath(
+  shell: CompletionShell,
+  options: {
+    env?: NodeJS.ProcessEnv;
+    homeDir?: () => string;
+    platform?: NodeJS.Platform;
+  } = {},
+): string {
+  const env = options.env ?? process.env;
+  const homeDir = options.homeDir ?? os.homedir;
+  const platform = options.platform ?? process.platform;
+  const home = env.HOME || homeDir();
   if (shell === "zsh") {
     return path.join(home, ".zshrc");
   }
@@ -137,9 +161,9 @@ function getShellProfilePath(shell: CompletionShell): string {
   if (shell === "fish") {
     return path.join(home, ".config", "fish", "config.fish");
   }
-  if (process.platform === "win32") {
-    return path.join(
-      process.env.USERPROFILE || home,
+  if (platform === "win32") {
+    return path.win32.join(
+      env.USERPROFILE || home,
       "Documents",
       "PowerShell",
       "Microsoft.PowerShell_profile.ps1",
@@ -152,7 +176,7 @@ export async function isCompletionInstalled(
   shell: CompletionShell,
   binName = "openclaw",
 ): Promise<boolean> {
-  const profilePath = getShellProfilePath(shell);
+  const profilePath = resolveCompletionProfilePath(shell);
 
   if (!(await pathExists(profilePath))) {
     return false;
@@ -174,7 +198,7 @@ export async function usesSlowDynamicCompletion(
   shell: CompletionShell,
   binName = "openclaw",
 ): Promise<boolean> {
-  const profilePath = getShellProfilePath(shell);
+  const profilePath = resolveCompletionProfilePath(shell);
 
   if (!(await pathExists(profilePath))) {
     return false;
@@ -193,7 +217,6 @@ export async function usesSlowDynamicCompletion(
 }
 
 export async function installCompletion(shell: string, yes: boolean, binName = "openclaw") {
-  const home = process.env.HOME || os.homedir();
   let profilePath = "";
   let sourceLine = "";
 
@@ -213,19 +236,23 @@ export async function installCompletion(shell: string, yes: boolean, binName = "
   }
 
   if (shell === "zsh") {
-    profilePath = path.join(home, ".zshrc");
+    profilePath = resolveCompletionProfilePath("zsh");
     sourceLine = formatCompletionSourceLine("zsh", binName, cachePath);
   } else if (shell === "bash") {
-    profilePath = path.join(home, ".bashrc");
+    profilePath = resolveCompletionProfilePath("bash");
     try {
       await fs.access(profilePath);
     } catch {
+      const home = process.env.HOME || os.homedir();
       profilePath = path.join(home, ".bash_profile");
     }
     sourceLine = formatCompletionSourceLine("bash", binName, cachePath);
   } else if (shell === "fish") {
-    profilePath = path.join(home, ".config", "fish", "config.fish");
+    profilePath = resolveCompletionProfilePath("fish");
     sourceLine = formatCompletionSourceLine("fish", binName, cachePath);
+  } else if (shell === "powershell") {
+    profilePath = resolveCompletionProfilePath("powershell");
+    sourceLine = formatCompletionSourceLine("powershell", binName, cachePath);
   } else {
     console.error(`Automated installation not supported for ${shell} yet.`);
     return;
@@ -258,7 +285,9 @@ export async function installCompletion(shell: string, yes: boolean, binName = "
 
     await fs.writeFile(profilePath, update.next, "utf-8");
     if (!yes) {
-      console.log(`Completion installed. Restart your shell or run: source ${profilePath}`);
+      console.log(
+        `Completion installed. Restart your shell or run: ${formatCompletionReloadCommand(shell, profilePath)}`,
+      );
     }
   } catch (err) {
     console.error(`Failed to install completion: ${err as string}`);

--- a/src/cli/completion-runtime.ts
+++ b/src/cli/completion-runtime.ts
@@ -16,9 +16,20 @@ export function isCompletionShell(value: string): value is CompletionShell {
   return COMPLETION_SHELLS.includes(value as CompletionShell);
 }
 
+function resolveShellBasename(
+  shellPath: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  const platformBasename =
+    platform === "win32" ? path.win32.basename(shellPath) : path.basename(shellPath);
+  const winBasename = path.win32.basename(shellPath);
+  const basename = winBasename.length < platformBasename.length ? winBasename : platformBasename;
+  return normalizeLowercaseStringOrEmpty(basename.replace(/\.(?:exe|cmd|bat)$/i, ""));
+}
+
 export function resolveShellFromEnv(env: NodeJS.ProcessEnv = process.env): CompletionShell {
   const shellPath = normalizeOptionalString(env.SHELL) ?? "";
-  const shellName = shellPath ? normalizeLowercaseStringOrEmpty(path.basename(shellPath)) : "";
+  const shellName = shellPath ? resolveShellBasename(shellPath) : "";
   if (shellName === "zsh") {
     return "zsh";
   }
@@ -162,10 +173,13 @@ export function resolveCompletionProfilePath(
     return path.join(home, ".config", "fish", "config.fish");
   }
   if (platform === "win32") {
+    const shellPath = normalizeOptionalString(env.SHELL) ?? "";
+    const shellName = shellPath ? resolveShellBasename(shellPath, platform) : "";
+    const profileDirectory = shellName === "powershell" ? "WindowsPowerShell" : "PowerShell";
     return path.win32.join(
       env.USERPROFILE || home,
       "Documents",
-      "PowerShell",
+      profileDirectory,
       "Microsoft.PowerShell_profile.ps1",
     );
   }
@@ -217,9 +231,6 @@ export async function usesSlowDynamicCompletion(
 }
 
 export async function installCompletion(shell: string, yes: boolean, binName = "openclaw") {
-  let profilePath = "";
-  let sourceLine = "";
-
   const isShellSupported = isCompletionShell(shell);
   if (!isShellSupported) {
     console.error(`Automated installation not supported for ${shell} yet.`);
@@ -235,27 +246,31 @@ export async function installCompletion(shell: string, yes: boolean, binName = "
     return;
   }
 
-  if (shell === "zsh") {
-    profilePath = resolveCompletionProfilePath("zsh");
-    sourceLine = formatCompletionSourceLine("zsh", binName, cachePath);
-  } else if (shell === "bash") {
-    profilePath = resolveCompletionProfilePath("bash");
-    try {
-      await fs.access(profilePath);
-    } catch {
-      const home = process.env.HOME || os.homedir();
-      profilePath = path.join(home, ".bash_profile");
-    }
-    sourceLine = formatCompletionSourceLine("bash", binName, cachePath);
-  } else if (shell === "fish") {
-    profilePath = resolveCompletionProfilePath("fish");
-    sourceLine = formatCompletionSourceLine("fish", binName, cachePath);
-  } else if (shell === "powershell") {
-    profilePath = resolveCompletionProfilePath("powershell");
-    sourceLine = formatCompletionSourceLine("powershell", binName, cachePath);
-  } else {
-    console.error(`Automated installation not supported for ${shell} yet.`);
-    return;
+  let profilePath: string;
+  let sourceLine: string;
+  switch (shell) {
+    case "zsh":
+      profilePath = resolveCompletionProfilePath("zsh");
+      sourceLine = formatCompletionSourceLine("zsh", binName, cachePath);
+      break;
+    case "bash":
+      profilePath = resolveCompletionProfilePath("bash");
+      try {
+        await fs.access(profilePath);
+      } catch {
+        const home = process.env.HOME || os.homedir();
+        profilePath = path.join(home, ".bash_profile");
+      }
+      sourceLine = formatCompletionSourceLine("bash", binName, cachePath);
+      break;
+    case "fish":
+      profilePath = resolveCompletionProfilePath("fish");
+      sourceLine = formatCompletionSourceLine("fish", binName, cachePath);
+      break;
+    case "powershell":
+      profilePath = resolveCompletionProfilePath("powershell");
+      sourceLine = formatCompletionSourceLine("powershell", binName, cachePath);
+      break;
   }
 
   try {

--- a/src/commands/doctor-completion.ts
+++ b/src/commands/doctor-completion.ts
@@ -3,9 +3,11 @@ import path from "node:path";
 import { resolveCliName } from "../cli/cli-name.js";
 import {
   completionCacheExists,
+  formatCompletionReloadCommand,
   installCompletion,
   isCompletionInstalled,
   resolveCompletionCachePath,
+  resolveCompletionProfilePath,
   resolveShellFromEnv,
   usesSlowDynamicCompletion,
 } from "../cli/completion-runtime.js";
@@ -17,6 +19,21 @@ import type { DoctorPrompter } from "./doctor-prompter.js";
 type CompletionShell = "zsh" | "bash" | "fish" | "powershell";
 
 const COMPLETION_CACHE_WRITE_TIMEOUT_MS = 30_000;
+
+function resolveCompletionReloadPath(shell: CompletionShell): string {
+  if (shell === "powershell") {
+    return resolveCompletionProfilePath("powershell");
+  }
+  return `~/.${shell === "zsh" ? "zshrc" : shell === "bash" ? "bashrc" : "config/fish/config.fish"}`;
+}
+
+function formatCompletionReloadNote(
+  shell: CompletionShell,
+  action: "installed" | "upgraded",
+): string {
+  const profilePath = resolveCompletionReloadPath(shell);
+  return `Shell completion ${action}. Restart your shell or run: ${formatCompletionReloadCommand(shell, profilePath)}`;
+}
 
 /** Generate the completion cache by spawning the CLI. */
 async function generateCompletionCache(): Promise<boolean> {
@@ -107,10 +124,7 @@ export async function doctorShellCompletion(
 
     // Upgrade profile to use cached file
     await installCompletion(status.shell, true, cliName);
-    note(
-      `Shell completion upgraded. Restart your shell or run: source ~/.${status.shell === "zsh" ? "zshrc" : status.shell === "bash" ? "bashrc" : "config/fish/config.fish"}`,
-      "Shell completion",
-    );
+    note(formatCompletionReloadNote(status.shell, "upgraded"), "Shell completion");
     return;
   }
 
@@ -157,10 +171,7 @@ export async function doctorShellCompletion(
 
       // Then install to profile
       await installCompletion(status.shell, true, cliName);
-      note(
-        `Shell completion installed. Restart your shell or run: source ~/.${status.shell === "zsh" ? "zshrc" : status.shell === "bash" ? "bashrc" : "config/fish/config.fish"}`,
-        "Shell completion",
-      );
+      note(formatCompletionReloadNote(status.shell, "installed"), "Shell completion");
     }
   }
 }

--- a/src/wizard/i18n/locales/en.ts
+++ b/src/wizard/i18n/locales/en.ts
@@ -116,7 +116,7 @@ export const en = {
       cacheFailed: "Failed to generate completion cache. Run `{command}` later.",
       enable: "Enable {shell} shell completion for {cli}?",
       installed: "Shell completion installed. {reloadHint}",
-      reloadPowerShell: "Restart your shell (or reload your PowerShell profile).",
+      reloadPowerShell: "Restart your shell or run: {command}",
       reloadShell: "Restart your shell or run: source {profile}",
       title: "Shell completion",
     },

--- a/src/wizard/i18n/locales/zh-CN.ts
+++ b/src/wizard/i18n/locales/zh-CN.ts
@@ -115,7 +115,7 @@ export const zh_CN = {
       cacheFailed: "生成 completion 缓存失败。稍后运行 `{command}`。",
       enable: "为 {cli} 启用 {shell} shell completion？",
       installed: "Shell completion 已安装。{reloadHint}",
-      reloadPowerShell: "重启 shell（或重新加载 PowerShell profile）。",
+      reloadPowerShell: "重启 shell 或运行：{command}",
       reloadShell: "重启 shell 或运行：source {profile}",
       title: "Shell completion",
     },

--- a/src/wizard/i18n/locales/zh-TW.ts
+++ b/src/wizard/i18n/locales/zh-TW.ts
@@ -115,7 +115,7 @@ export const zh_TW = {
       cacheFailed: "產生 completion 快取失敗。稍後執行 `{command}`。",
       enable: "為 {cli} 啟用 {shell} shell completion？",
       installed: "Shell completion 已安裝。{reloadHint}",
-      reloadPowerShell: "重新啟動 shell（或重新載入 PowerShell profile）。",
+      reloadPowerShell: "重新啟動 shell 或執行：{command}",
       reloadShell: "重新啟動 shell 或執行：source {profile}",
       title: "Shell completion",
     },

--- a/src/wizard/setup.completion.test.ts
+++ b/src/wizard/setup.completion.test.ts
@@ -1,4 +1,6 @@
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import { resolveCompletionProfilePath } from "../cli/completion-runtime.js";
 import { setupWizardShellCompletion } from "./setup.completion.js";
 
 async function withLocale(locale: string, run: () => Promise<void>): Promise<void> {
@@ -22,14 +24,14 @@ function createPrompter(confirmValue = false) {
   };
 }
 
-function createDeps() {
+function createDeps(shell: "zsh" | "bash" | "fish" | "powershell" = "zsh") {
   const deps: NonNullable<Parameters<typeof setupWizardShellCompletion>[0]["deps"]> = {
     resolveCliName: () => "openclaw",
     checkShellCompletionStatus: vi.fn(async (_binName: string) => ({
-      shell: "zsh" as const,
+      shell,
       profileInstalled: false,
       cacheExists: false,
-      cachePath: "/tmp/openclaw.zsh",
+      cachePath: `/tmp/openclaw.${shell === "powershell" ? "ps1" : shell}`,
       usesSlowPattern: false,
     })),
     ensureCompletionCacheExists: vi.fn(async (_binName: string) => true),
@@ -80,5 +82,45 @@ describe("setupWizardShellCompletion", () => {
         "Shell completion",
       );
     });
+  });
+
+  it("resolves the concrete Windows PowerShell profile path", () => {
+    expect(
+      resolveCompletionProfilePath("powershell", {
+        env: { USERPROFILE: "C:\\Users\\Ada" },
+        homeDir: () => "C:\\Users\\Ada",
+        platform: "win32",
+      }),
+    ).toBe(
+      path.win32.join(
+        "C:\\Users\\Ada",
+        "Documents",
+        "PowerShell",
+        "Microsoft.PowerShell_profile.ps1",
+      ),
+    );
+  });
+
+  it("shows a concrete PowerShell profile reload command after setup", async () => {
+    const previousHome = process.env.HOME;
+    process.env.HOME = "/Users/ada";
+    try {
+      const prompter = createPrompter();
+      const deps = createDeps("powershell");
+
+      await setupWizardShellCompletion({ flow: "quickstart", prompter, deps });
+
+      expect(deps.installCompletion).toHaveBeenCalledWith("powershell", true, "openclaw");
+      expect(prompter.note).toHaveBeenCalledWith(
+        "Shell completion installed. Restart your shell or run: . '/Users/ada/.config/powershell/Microsoft.PowerShell_profile.ps1'",
+        "Shell completion",
+      );
+    } finally {
+      if (previousHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = previousHome;
+      }
+    }
   });
 });

--- a/src/wizard/setup.completion.ts
+++ b/src/wizard/setup.completion.ts
@@ -1,7 +1,11 @@
 import os from "node:os";
 import path from "node:path";
 import { resolveCliName } from "../cli/cli-name.js";
-import { installCompletion } from "../cli/completion-runtime.js";
+import {
+  formatCompletionReloadCommand,
+  installCompletion,
+  resolveCompletionProfilePath,
+} from "../cli/completion-runtime.js";
 import type { ShellCompletionStatus } from "../commands/doctor-completion.js";
 import {
   checkShellCompletionStatus,
@@ -31,13 +35,14 @@ async function resolveProfileHint(shell: ShellCompletionStatus["shell"]): Promis
   if (shell === "fish") {
     return "~/.config/fish/config.fish";
   }
-  // Best-effort. PowerShell profile path varies; restart hint is still correct.
-  return "$PROFILE";
+  return resolveCompletionProfilePath("powershell");
 }
 
 function formatReloadHint(shell: ShellCompletionStatus["shell"], profileHint: string): string {
   if (shell === "powershell") {
-    return t("wizard.completion.reloadPowerShell");
+    return t("wizard.completion.reloadPowerShell", {
+      command: formatCompletionReloadCommand("powershell", profileHint),
+    });
   }
   return t("wizard.completion.reloadShell", { profile: profileHint });
 }


### PR DESCRIPTION
## Summary

- share PowerShell completion profile path/source/reload formatting from the completion runtime
- show a concrete PowerShell profile reload command during setup/doctor completion guidance instead of `$PROFILE` or generic text
- support automated PowerShell completion installation by writing a quoted dot-source line into the resolved profile
- add focused regression coverage for Windows profile path resolution, PowerShell setup notes, and PowerShell profile installation

Fixes #44296.

## Verification

- `node scripts/run-vitest.mjs run src/wizard/setup.completion.test.ts src/cli/completion-runtime.test.ts src/cli/completion-cli.test.ts src/cli/completion-cli.write-state.test.ts`
- `./node_modules/.bin/oxfmt --check --threads=1 src/cli/completion-runtime.ts src/cli/completion-runtime.test.ts src/wizard/setup.completion.ts src/wizard/setup.completion.test.ts src/commands/doctor-completion.ts src/wizard/i18n/locales/en.ts src/wizard/i18n/locales/zh-CN.ts src/wizard/i18n/locales/zh-TW.ts`
- `rg -n $'\\t| +$'` on changed files

## Real behavior proof

- Behavior or issue addressed: PowerShell shell-completion onboarding no longer tells users to reload a generic `$PROFILE`; it resolves the concrete PowerShell profile path and prints a runnable dot-source command.
- Real environment tested: Local macOS Codex workspace using OpenClaw source from the patch branch, Node.js v24.15.0, pnpm v11.1.0 dependencies installed from the repository lockfile, and tsx/Vitest from the repo toolchain.
- Exact steps or command run after this patch: Ran the focused completion/setup Vitest files, ran oxfmt on the touched files, and executed the changed runtime helpers directly with a Windows PowerShell profile scenario.
- Evidence after fix: Terminal output from the local shell:

```text
$ node scripts/run-vitest.mjs run src/wizard/setup.completion.test.ts src/cli/completion-runtime.test.ts src/cli/completion-cli.test.ts src/cli/completion-cli.write-state.test.ts

 RUN  v4.1.6 /private/tmp/openclaw-44296-work

 Test Files  4 passed (4)
      Tests  13 passed (13)
   Start at  18:42:29
   Duration  539ms (transform 156ms, setup 134ms, import 76ms, tests 222ms, environment 0ms)
```

```text
$ node --import tsx --input-type=module
{
  "windowsProfile": "C:\\Users\\Ada\\Documents\\PowerShell\\Microsoft.PowerShell_profile.ps1",
  "sourceLine": ". 'C:\\Users\\Ada\\AppData\\Local\\openclaw\\completions\\openclaw.ps1'",
  "reloadCommand": ". 'C:\\Users\\Ada\\Documents\\PowerShell\\Microsoft.PowerShell_profile.ps1'"
}
```

```text
$ ./node_modules/.bin/oxfmt --check --threads=1 src/cli/completion-runtime.ts src/cli/completion-runtime.test.ts src/wizard/setup.completion.ts src/wizard/setup.completion.test.ts src/commands/doctor-completion.ts src/wizard/i18n/locales/en.ts src/wizard/i18n/locales/zh-CN.ts src/wizard/i18n/locales/zh-TW.ts
Checking formatting...

All matched files use the correct format.
Finished in 6ms on 8 files using 1 threads.
```

- Observed result after fix: The PowerShell profile resolver returns `C:\Users\Ada\Documents\PowerShell\Microsoft.PowerShell_profile.ps1`, the source/reload helpers emit PowerShell dot-source commands with single-quoted paths, and setup notes now include the concrete command.
- What was not tested: No live Windows terminal session was launched; the Windows path branch and onboarding message are covered by focused tests and direct helper execution.