### PR TITLE
feat(skills): add python debugpy skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 - Skills: add node inspector debugging, fused diagram generation, and throwaway spike workflow skills.
 - CLI/plugins: add `defineToolPlugin` plus `openclaw plugins build`, `validate`, and `init` for typed simple tool plugins with generated manifest metadata, optional tool declarations, and context factories.
 - Agents/skills: tighten bundled skill prompts and metadata, quote skill descriptions, refresh current CLI/API guidance, and update embedded sherpa-onnx runtime downloads.
+- Skills: add a Python debugging skill for pdb, breakpoint(), post-mortem inspection, and debugpy remote attach.
 - Proxy: support HTTPS managed forward-proxy endpoints and scoped `proxy.tls.caFile` CA trust for proxy endpoint TLS. (#79171) Thanks @jesse-merhi.
 - QA-Lab: add first-hour 20-turn and optional 100-turn runtime parity scenarios, with tier metadata for standard and soak QA gates. (#80323) Thanks @100yenadmin.
 - QA-Lab: add a live-only Codex Pi-shaped Read vocabulary canary so runtime parity catches native workspace-read prompt compatibility drift. (#80323) Thanks @100yenadmin.

--- a/skills/python-debugpy/SKILL.md
+++ b/skills/python-debugpy/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: python-debugpy
+description: Debug Python with pdb, breakpoint(), post-mortem inspection, and debugpy remote attach.
+metadata: { "openclaw": { "requires": { "bins": ["python3"] } } }
+---
+
+# Python Debugpy
+
+Use when Python code needs interactive debugging: hidden locals, confusing state mutation, failing tests, subprocesses, long-running services, or remote/headless attach.
+
+Pick the smallest debugger that reaches the bad frame.
+
+## Choose
+
+- `breakpoint()`: local code, source edits ok, fastest path.
+- `python3 -m pdb`: no source edit, launch from the beginning.
+- `python3 -m pdb -c continue`: stop at an unhandled exception.
+- `debugpy`: remote/headless process, DAP client, already-running PID, or service startup race.
+
+## Commands
+
+```bash
+python3 -m pdb path/to/script.py arg1
+python3 -m pdb -c continue path/to/script.py
+python3 -c "import debugpy" || python3 -m pip install debugpy
+python3 -m debugpy --listen 127.0.0.1:5678 --wait-for-client path/to/script.py
+python3 -m debugpy --listen 127.0.0.1:5678 --wait-for-client -m package.module
+python3 -m debugpy --listen 127.0.0.1:5678 --pid <pid>
+```
+
+For source-edit attach:
+
+```py
+import debugpy
+
+debugpy.listen(("127.0.0.1", 5678))
+debugpy.wait_for_client()
+debugpy.breakpoint()
+```
+
+For post-mortem:
+
+```py
+import pdb, sys
+
+try:
+    run()
+except Exception:
+    pdb.post_mortem(sys.exc_info()[2])
+    raise
+```
+
+## pdb
+
+- Flow: `n`, `s`, `r`, `c`, `q`.
+- Stack/source: `w`, `u`, `d`, `a`, `l`, `ll`.
+- Values: `p expr`, `pp expr`, `display expr`.
+- Breakpoints: `b file.py:42`, `b func`, `b file.py:42, condition`, `cl <num>`.
+- Mutate/evaluate: `!statement`; full REPL: `interact`.
+
+## Rules
+
+- Reproduce with the smallest command/test first.
+- Disable parallel test workers for pdb; interactive stdin usually breaks inside worker pools.
+- Keep `debugpy` in the active env; do not add it as a project dependency unless the project already wants it.
+- Bind debug servers to `127.0.0.1`; do not expose `0.0.0.0` unless isolated or tunnelled.
+- Use unique ports for parallel sessions.
+- Treat `debugpy --pid` as injection; avoid security-sensitive or production targets unless explicitly approved.
+- If PID attach fails on Linux, check ptrace/container privileges before changing the target.
+- Cleanup before commit: `rg -n 'breakpoint\\(|pdb\\.set_trace|debugpy\\.' --type py`.
+- Rerun the normal project test/gate without the debugger.
+- `PYTHONBREAKPOINT=0` disables `breakpoint()`.
+- If a process is stuck after debugger detach, confirm it is not still paused at a breakpoint.


### PR DESCRIPTION
## Summary

- Add a bundled `python-debugpy` skill for compact Python debugger routing.
- Cover `breakpoint()`, `python -m pdb`, post-mortem inspection, and `debugpy` remote launch/attach.
- Add the Unreleased changelog entry.

## Verification

- `python3 skills/skill-creator/scripts/quick_validate.py skills/python-debugpy`
- `git diff --check origin/main...HEAD`
- `pnpm changed:lanes --json`
- `pnpm --silent openclaw skills list --json`
- `/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --mode local`

## Real behavior proof

Behavior addressed: Adds a token-efficient Python debugging skill with clear pdb/debugpy selection and safety guidance.
Real environment tested: Local OpenClaw checkout on macOS, branch `feat/python-debugpy-skill` at `ebdf5c48777`.
Exact steps or command run after this patch: `pnpm --silent openclaw skills list --json` was run after the patch and parsed for `python-debugpy`.
Evidence after fix: Terminal output from the live OpenClaw skills list command:

```json
{
  "present": true,
  "name": "python-debugpy",
  "total": 68
}
```

Observed result after fix: OpenClaw lists 68 skills including `python-debugpy`.
What was not tested: No live Python debugger session was launched; this is skill documentation only.
