### PR TITLE
fix(anthropic): preserve unsafe integer tool inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/Anthropic: preserve unsafe integer tool-call input values in streamed Anthropic tool-use JSON, preventing Discord-style IDs from being rounded before dispatch. Fixes #47229. (#83063) Thanks @leno23.
 - CLI/agents: allow `openclaw agent --session-key` to target explicit session keys, including agent-scoped legacy keys. (#85121) Thanks @Kaspre.
 - Agents/subagents: surface blocked child-run completions as errors instead of successful subagent finishes. (#80886) Thanks @TurboTheTurtle.
 - Agents/Pi: treat accepted embedded `sessions_spawn` child-session handoffs as terminal progress so parent turns no longer report false non-deliverable failures. (#85054) Thanks @samzong.

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -416,6 +416,63 @@ describe("anthropic transport stream", () => {
     expect(result.errorMessage).toBe("OpenClaw transport error: malformed_streaming_fragment");
   });
 
+  it("preserves unsafe integer Anthropic tool-use input deltas", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      createSseResponse([
+        {
+          type: "message_start",
+          message: { id: "msg_unsafe", usage: { input_tokens: 10, output_tokens: 0 } },
+        },
+        {
+          type: "content_block_start",
+          index: 0,
+          content_block: {
+            type: "tool_use",
+            id: "tool_unsafe",
+            name: "send_message",
+            input: {},
+          },
+        },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: {
+            type: "input_json_delta",
+            partial_json:
+              '{"to":1481220477346119781,"safe":42,"maxSafe":9007199254740991,"nested":{"ids":[9007199254740993,-9007199254740992]}}',
+          },
+        },
+        { type: "content_block_stop", index: 0 },
+        {
+          type: "message_delta",
+          delta: { stop_reason: "tool_use" },
+          usage: { input_tokens: 10, output_tokens: 5 },
+        },
+      ]),
+    );
+
+    const result = await runTransportStream(
+      makeAnthropicTransportModel(),
+      {
+        messages: [{ role: "user", content: "message this channel" }],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+      } as AnthropicStreamOptions,
+    );
+
+    const toolCall = findRecord(
+      result.content,
+      (record) => record.type === "toolCall" && record.name === "send_message",
+    );
+    expect(toolCall.arguments).toEqual({
+      to: "1481220477346119781",
+      safe: 42,
+      maxSafe: 9007199254740991,
+      nested: { ids: ["9007199254740993", "-9007199254740992"] },
+    });
+  });
+
   it("preserves Anthropic OAuth identity and tool-name remapping with transport overrides", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -11,6 +11,7 @@ import {
 } from "@earendil-works/pi-ai";
 import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../shared/assistant-error-format.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
+import { parseJsonObjectPreservingUnsafeIntegers } from "./json-unsafe-integers.js";
 import {
   applyAnthropicPayloadPolicyToParams,
   resolveAnthropicPayloadPolicy,
@@ -495,6 +496,10 @@ function convertAnthropicTools(tools: Context["tools"], isOAuthToken: boolean) {
     });
   }
   return converted;
+}
+
+function parseAnthropicToolCallArguments(inputJson: string): unknown {
+  return parseJsonObjectPreservingUnsafeIntegers(inputJson) ?? parseStreamingJson(inputJson);
 }
 
 function mapStopReason(reason: string | undefined): string {
@@ -1268,7 +1273,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
               typeof delta.partial_json === "string"
             ) {
               block.partialJson += delta.partial_json;
-              block.arguments = parseStreamingJson(block.partialJson);
+              block.arguments = parseAnthropicToolCallArguments(block.partialJson);
               stream.push({
                 type: "toolcall_delta",
                 contentIndex: index,
@@ -1316,7 +1321,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
             }
             if (block.type === "toolCall") {
               if (typeof block.partialJson === "string" && block.partialJson.length > 0) {
-                block.arguments = parseStreamingJson(block.partialJson);
+                block.arguments = parseAnthropicToolCallArguments(block.partialJson);
               }
               delete block.partialJson;
               stream.push({

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -11,12 +11,12 @@ import {
 } from "@earendil-works/pi-ai";
 import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../shared/assistant-error-format.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
-import { parseJsonObjectPreservingUnsafeIntegers } from "./json-unsafe-integers.js";
 import {
   applyAnthropicPayloadPolicyToParams,
   resolveAnthropicPayloadPolicy,
 } from "./anthropic-payload-policy.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./copilot-dynamic-headers.js";
+import { parseJsonObjectPreservingUnsafeIntegers } from "./json-unsafe-integers.js";
 import { resolveProviderEndpoint } from "./provider-attribution.js";
 import { buildGuardedModelFetch } from "./provider-transport-fetch.js";
 import { transformTransportMessages } from "./transport-message-transform.js";
@@ -1272,8 +1272,9 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
               delta?.type === "input_json_delta" &&
               typeof delta.partial_json === "string"
             ) {
-              block.partialJson += delta.partial_json;
-              block.arguments = parseAnthropicToolCallArguments(block.partialJson);
+              const partialJson = `${block.partialJson ?? ""}${delta.partial_json}`;
+              block.partialJson = partialJson;
+              block.arguments = parseAnthropicToolCallArguments(partialJson);
               stream.push({
                 type: "toolcall_delta",
                 contentIndex: index,

--- a/src/agents/json-unsafe-integers.ts
+++ b/src/agents/json-unsafe-integers.ts
@@ -1,0 +1,143 @@
+const MAX_SAFE_INTEGER_ABS_STR = String(Number.MAX_SAFE_INTEGER);
+
+function isAsciiDigit(ch: string | undefined): boolean {
+  return ch !== undefined && ch >= "0" && ch <= "9";
+}
+
+function parseJsonNumberToken(
+  input: string,
+  start: number,
+): { token: string; end: number; isInteger: boolean } | null {
+  let idx = start;
+  if (input[idx] === "-") {
+    idx += 1;
+  }
+  if (idx >= input.length) {
+    return null;
+  }
+
+  if (input[idx] === "0") {
+    idx += 1;
+  } else if (isAsciiDigit(input[idx]) && input[idx] !== "0") {
+    while (isAsciiDigit(input[idx])) {
+      idx += 1;
+    }
+  } else {
+    return null;
+  }
+
+  let isInteger = true;
+  if (input[idx] === ".") {
+    isInteger = false;
+    idx += 1;
+    if (!isAsciiDigit(input[idx])) {
+      return null;
+    }
+    while (isAsciiDigit(input[idx])) {
+      idx += 1;
+    }
+  }
+
+  if (input[idx] === "e" || input[idx] === "E") {
+    isInteger = false;
+    idx += 1;
+    if (input[idx] === "+" || input[idx] === "-") {
+      idx += 1;
+    }
+    if (!isAsciiDigit(input[idx])) {
+      return null;
+    }
+    while (isAsciiDigit(input[idx])) {
+      idx += 1;
+    }
+  }
+
+  return {
+    token: input.slice(start, idx),
+    end: idx,
+    isInteger,
+  };
+}
+
+function isUnsafeIntegerLiteral(token: string): boolean {
+  const digits = token[0] === "-" ? token.slice(1) : token;
+  if (digits.length < MAX_SAFE_INTEGER_ABS_STR.length) {
+    return false;
+  }
+  if (digits.length > MAX_SAFE_INTEGER_ABS_STR.length) {
+    return true;
+  }
+  return digits > MAX_SAFE_INTEGER_ABS_STR;
+}
+
+export function quoteUnsafeIntegerLiterals(input: string): string {
+  let out = "";
+  let inString = false;
+  let escaped = false;
+  let idx = 0;
+
+  while (idx < input.length) {
+    const ch = input[idx] ?? "";
+    if (inString) {
+      out += ch;
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      idx += 1;
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = true;
+      out += ch;
+      idx += 1;
+      continue;
+    }
+
+    if (ch === "-" || isAsciiDigit(ch)) {
+      const parsed = parseJsonNumberToken(input, idx);
+      if (parsed) {
+        if (parsed.isInteger && isUnsafeIntegerLiteral(parsed.token)) {
+          out += `"${parsed.token}"`;
+        } else {
+          out += parsed.token;
+        }
+        idx = parsed.end;
+        continue;
+      }
+    }
+
+    out += ch;
+    idx += 1;
+  }
+
+  return out;
+}
+
+export function parseJsonPreservingUnsafeIntegers(input: string): unknown {
+  return JSON.parse(quoteUnsafeIntegerLiterals(input)) as unknown;
+}
+
+export function parseJsonObjectPreservingUnsafeIntegers(
+  value: unknown,
+): Record<string, unknown> | null {
+  if (typeof value === "string") {
+    try {
+      const parsed = parseJsonPreservingUnsafeIntegers(value);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      return null;
+    }
+    return null;
+  }
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return null;
+}


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- Add a core JSON helper that quotes integer literals larger than Number.MAX_SAFE_INTEGER before JSON.parse.
- Route Anthropic streamed tool_use input_json_delta parsing through that helper for complete object JSON, with the existing parseStreamingJson path kept as a fallback for partial/malformed streaming fragments.
- Add an Anthropic transport regression covering Discord-style unsafe IDs, nested unsafe integers, safe integers, and max-safe integers.

## Test Plan
- node /tmp/openclaw-api-47229/proof-source-probe.mjs
- Local full `node scripts/run-vitest.mjs src/agents/anthropic-transport-stream.test.ts` was not run because this workflow stayed API-only without a full OpenClaw checkout/node_modules after clone was unavailable.

## Real behavior proof

Behavior or issue addressed: Anthropic Messages streaming currently parses complete `tool_use` `input_json_delta` buffers through plain JSON parsing inside `parseStreamingJson`, which rounds unsafe integer IDs such as Discord snowflakes before OpenClaw records tool arguments. This patch preserves unsafe integer literals as strings while keeping safe integers numeric and retaining the existing streaming fallback for incomplete JSON.

Real environment tested: API-only reconstructed OpenClaw source workspace on this machine, using the current upstream files downloaded from GitHub into `/tmp/openclaw-api-47229` and Node.js for a deterministic source/behavior probe.

Exact steps or command run after this patch:
```bash
node /tmp/openclaw-api-47229/proof-source-probe.mjs
```

Evidence after fix:
```text
PASS baseline JSON.parse rounds the reported unsafe Anthropic tool_use integer
PASS shared helper exports unsafe-integer quoting
PASS shared helper exports object parser
PASS shared helper only quotes unsafe integer literals
PASS shared helper parses quoted unsafe integers with JSON.parse
PASS Anthropic transport imports shared unsafe-integer parser
PASS Anthropic transport has a narrow parser wrapper
PASS Anthropic wrapper preserves complete object JSON and falls back to streaming parser
PASS Anthropic delta and final stop parse points use unsafe-integer-preserving wrapper
PASS Anthropic transport no longer assigns tool arguments through raw parseStreamingJson
PASS regression test names the Anthropic unsafe integer behavior
PASS regression test exercises input_json_delta partial_json path
PASS regression test expects Discord-style unsafe id as string
PASS regression test keeps safe integers numeric
PASS regression test keeps max safe integer numeric
PASS regression test covers nested positive and negative unsafe integers
RESULT source-level proof passed for OpenClaw #47229 Anthropic unsafe integer guard
```

Observed result after fix: The probe first demonstrates that baseline `JSON.parse` rounds the reported unsafe integer class, then verifies the new shared helper, Anthropic import/wrapper, both Anthropic delta/final parse points, and the regression test expectations. All 16 assertions passed.

What was not tested: I did not run the full local Vitest/Crabbox acceptance suite because this patch was prepared API-only without a full OpenClaw checkout or node_modules. GitHub PR checks should run the repository validation after the branch is opened.

## Risk/Notes
- The Anthropic path only uses the new parser for complete JSON object strings; incomplete streaming fragments still fall back to the existing `parseStreamingJson` behavior.
- Safe integers, decimals, exponents, and values already inside JSON strings are left unchanged.
- This avoids importing plugin-private Ollama code into core by adding a narrow core helper.

Fixes #47229
