### PR TITLE
fix(cron): increase watchdog timeouts and make them configurable

### DIFF
--- a/src/config/types.cron.ts
+++ b/src/config/types.cron.ts
@@ -58,4 +58,14 @@ export type CronConfig = {
   failureAlert?: CronFailureAlertConfig;
   /** Default destination for failure notifications across all cron jobs. */
   failureDestination?: CronFailureDestinationConfig;
+  /**
+   * Max milliseconds to wait for the agent runner to start before aborting
+   * an isolated cron job.  Default: 180_000 (3 minutes).
+   */
+  setupWatchdogMs?: number;
+  /**
+   * Max milliseconds to wait for the execution phase (first model call) after
+   * the runner starts.  Capped at `jobTimeoutMs / 2`.  Default: 180_000 (3 minutes).
+   */
+  preExecutionWatchdogMs?: number;
 };

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -56,8 +56,8 @@ export { DEFAULT_JOB_TIMEOUT_MS } from "./timeout-policy.js";
 
 const MAX_TIMER_DELAY_MS = 60_000;
 const CRON_TIMEOUT_CLEANUP_GUARD_MS = 20_000;
-const CRON_AGENT_SETUP_WATCHDOG_MS = 60_000;
-const CRON_AGENT_PRE_EXECUTION_WATCHDOG_MS = 60_000;
+const DEFAULT_CRON_AGENT_SETUP_WATCHDOG_MS = 180_000;
+const DEFAULT_CRON_AGENT_PRE_EXECUTION_WATCHDOG_MS = 180_000;
 const CRON_AGENT_PRE_EXECUTION_MIN_WATCHDOG_MS = 1_000;
 
 /**
@@ -176,6 +176,7 @@ export async function executeJobCoreWithTimeout(
     deferUntilRunner: deferTimeoutUntilExecutionStart,
     jobTimeoutMs,
     triggerTimeout,
+    cronConfig: state.deps.cronConfig,
   });
   const corePromise = executeJobCore(state, job, runAbortController.signal, {
     onExecutionStarted: deferTimeoutUntilExecutionStart ? watchdog.noteRunnerStarted : undefined,
@@ -214,6 +215,7 @@ function createCronAgentWatchdog(params: {
   deferUntilRunner: boolean;
   jobTimeoutMs: number;
   triggerTimeout: (reason: string) => void;
+  cronConfig?: CronConfig;
 }): CronAgentWatchdog {
   let state: CronAgentWatchdogState = params.deferUntilRunner ? "waiting_for_runner" : "executing";
   let timeoutId: NodeJS.Timeout | undefined;
@@ -258,7 +260,7 @@ function createCronAgentWatchdog(params: {
       if (state === "waiting_for_execution") {
         setTimedOut(preExecutionTimeoutErrorMessage(activeExecution));
       }
-    }, resolveCronAgentPreExecutionWatchdogMs(params.jobTimeoutMs));
+    }, resolveCronAgentPreExecutionWatchdogMs(params.jobTimeoutMs, params.cronConfig));
   };
   const noteExecutionProgress = (info?: CronAgentExecutionStarted) => {
     if (!info) {
@@ -289,7 +291,7 @@ function createCronAgentWatchdog(params: {
           if (state === "waiting_for_runner") {
             setTimedOut(setupTimeoutErrorMessage(activeExecution));
           }
-        }, CRON_AGENT_SETUP_WATCHDOG_MS);
+        }, resolveCronAgentSetupWatchdogMs(params.cronConfig));
         return;
       }
       startTimeout();
@@ -387,10 +389,23 @@ function formatCronAgentExecutionPhase(execution?: CronAgentExecutionStarted): s
   return formatEmbeddedAgentExecutionPhase(execution?.phase);
 }
 
-function resolveCronAgentPreExecutionWatchdogMs(jobTimeoutMs: number): number {
+function resolveCronAgentSetupWatchdogMs(cronConfig?: CronConfig): number {
+  const raw = cronConfig?.setupWatchdogMs;
+  if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) {
+    return Math.floor(raw);
+  }
+  return DEFAULT_CRON_AGENT_SETUP_WATCHDOG_MS;
+}
+
+function resolveCronAgentPreExecutionWatchdogMs(jobTimeoutMs: number, cronConfig?: CronConfig): number {
+  const cap = typeof cronConfig?.preExecutionWatchdogMs === "number"
+    && Number.isFinite(cronConfig.preExecutionWatchdogMs)
+    && cronConfig.preExecutionWatchdogMs > 0
+    ? Math.floor(cronConfig.preExecutionWatchdogMs)
+    : DEFAULT_CRON_AGENT_PRE_EXECUTION_WATCHDOG_MS;
   return Math.max(
     CRON_AGENT_PRE_EXECUTION_MIN_WATCHDOG_MS,
-    Math.min(CRON_AGENT_PRE_EXECUTION_WATCHDOG_MS, Math.floor(jobTimeoutMs / 2)),
+    Math.min(cap, Math.floor(jobTimeoutMs / 2)),
   );
 }
 


### PR DESCRIPTION
## Problem

All isolated-session cron jobs (`sessionTarget: "isolated"`, `payload.kind: "agentTurn"`) fail with:

```
cron: isolated agent setup timed out before runner start
```

or silently abort at exactly 60 seconds when the Codex app-server harness takes longer than 60s to spawn and reach the first model call.

## Root Cause

Two hardcoded 60-second watchdog constants in `src/cron/service/timer.ts`:

- `CRON_AGENT_SETUP_WATCHDOG_MS` — fires if the runner never starts within 60s
- `CRON_AGENT_PRE_EXECUTION_WATCHDOG_MS` — fires if execution phase (first model call) is not reached within 60s of runner start

These are too aggressive for environments where Codex app-server startup involves OAuth token resolution, sandbox provisioning, and model prewarm — all of which routinely exceed 60s on modest hardware (Raspberry Pi, low-end VPS).

Meanwhile, the per-job `timeoutSeconds` (default 300s) is generous enough. The watchdogs fire long before the job timeout would.

## Changes

- Increase default `CRON_AGENT_SETUP_WATCHDOG_MS` from 60s to **180s**
- Increase default `CRON_AGENT_PRE_EXECUTION_WATCHDOG_MS` from 60s to **180s**
- Make both configurable via `cronConfig.setupWatchdogMs` and `cronConfig.preExecutionWatchdogMs`
- Backward compatible: no config change needed, just better defaults

## Why 180s?

- Codex app-server startup on a Pi 5: consistently 70–90s (process spawn → stdio handshake → OAuth → sandbox → session binding)
- Pre-execution phase adds: model resolution → context assembly → turn dispatch → first model call (another 30–60s)
- 180s = 2× safety margin while still catching genuinely stalled processes before the 300s job timeout

## Testing

Patched the compiled JS on OpenClaw 2026.5.12 (f066dd2):
- **Before**: 19/19 isolated cron jobs failing
- **After**: Jobs complete successfully (e.g. `durationMs=130542 aborted=false`)
