### PR TITLE
fix(gateway): isolate hot reload channel restart failures (#83054)

### DIFF
--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -585,6 +585,92 @@ describe("gateway Gmail hot reload handlers", () => {
   });
 });
 
+describe("gateway channel hot reload handlers", () => {
+  it("continues restarting remaining channels when one channel restart fails", async () => {
+    const previousSkipChannels = process.env.OPENCLAW_SKIP_CHANNELS;
+    const previousSkipProviders = process.env.OPENCLAW_SKIP_PROVIDERS;
+    delete process.env.OPENCLAW_SKIP_CHANNELS;
+    delete process.env.OPENCLAW_SKIP_PROVIDERS;
+    const setState = vi.fn();
+    const logChannels = { info: vi.fn(), error: vi.fn() };
+    const startChannel = vi.fn(async () => {});
+    const stopChannel = vi.fn(async (name: ChannelKind) => {
+      if (name === "discord") {
+        throw new Error("discord stop timed out");
+      }
+    });
+    const { applyHotReload } = createGatewayReloadHandlers({
+      deps: {} as never,
+      broadcast: vi.fn(),
+      getState: () => ({
+        hooksConfig: {} as never,
+        hookClientIpConfig: {} as never,
+        heartbeatRunner: { stop: vi.fn(), updateConfig: vi.fn() } as never,
+        cronState: {
+          cron: { start: vi.fn(async () => {}), stop: vi.fn() },
+          storePath: "/tmp/cron.json",
+          cronEnabled: false,
+        } as never,
+        channelHealthMonitor: null,
+      }),
+      setState,
+      startChannel,
+      stopChannel,
+      reloadPlugins: vi.fn(
+        async (): Promise<GatewayPluginReloadResult> => ({
+          restartChannels: new Set(),
+          activeChannels: new Set(),
+        }),
+      ),
+      logHooks: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      logChannels,
+      logCron: { error: vi.fn() },
+      logReload: { info: vi.fn(), warn: vi.fn() },
+      createHealthMonitor: () => null,
+    });
+
+    try {
+      await applyHotReload(
+        {
+          changedPaths: ["channels.discord.token", "channels.telegram.botToken"],
+          restartGateway: false,
+          restartReasons: [],
+          hotReasons: ["channels"],
+          reloadHooks: false,
+          restartGmailWatcher: false,
+          restartCron: false,
+          restartHeartbeat: false,
+          restartHealthMonitor: false,
+          reloadPlugins: false,
+          restartChannels: new Set<ChannelKind>(["discord", "telegram"]),
+          disposeMcpRuntimes: false,
+          noopPaths: [],
+        },
+        { channels: { discord: { token: "next" }, telegram: { botToken: "next" } } } as never,
+      );
+    } finally {
+      if (previousSkipChannels === undefined) {
+        delete process.env.OPENCLAW_SKIP_CHANNELS;
+      } else {
+        process.env.OPENCLAW_SKIP_CHANNELS = previousSkipChannels;
+      }
+      if (previousSkipProviders === undefined) {
+        delete process.env.OPENCLAW_SKIP_PROVIDERS;
+      } else {
+        process.env.OPENCLAW_SKIP_PROVIDERS = previousSkipProviders;
+      }
+    }
+
+    expect(stopChannel.mock.calls.map(([name]) => name)).toEqual(["discord", "telegram"]);
+    expect(startChannel).not.toHaveBeenCalledWith("discord");
+    expect(startChannel).toHaveBeenCalledWith("telegram");
+    expect(logChannels.error).toHaveBeenCalledWith(
+      expect.stringContaining("[discord] hot-reload restart failed"),
+    );
+    expect(setState).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("gateway plugin hot reload handlers", () => {
   it("stops removed channel plugins from broad activation before swapping plugin runtime", async () => {
     const previousSkipChannels = process.env.OPENCLAW_SKIP_CHANNELS;

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -430,7 +430,15 @@ export function createGatewayReloadHandlers(params: GatewayReloadHandlerParams) 
           await params.startChannel(name);
         };
         for (const channel of channelsToRestart) {
-          await restartChannel(channel);
+          try {
+            await restartChannel(channel);
+          } catch (err) {
+            params.logChannels.error(
+              `[${channel}] hot-reload restart failed; continuing remaining channels: ${String(
+                err,
+              )}`,
+            );
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

Fixes #83054.

When hot reload restarts multiple channels, one channel stop/start failure should not abort the entire loop. This wraps each final channel restart independently, logs the failing channel, and continues with the remaining restart targets.

## Real behavior proof

- Behavior or issue addressed: Gateway hot reload previously awaited `restartChannel(channel)` directly in the final restart loop, so one rejected `stopChannel("discord")` aborted `applyHotReload()` before later channels such as `telegram` could restart.
- Real environment tested: Local OpenClaw checkout on Node 24-compatible test runner path, executing the real `createGatewayReloadHandlers().applyHotReload()` implementation from `src/gateway/server-reload-handlers.ts`; rerun also forced `OPENCLAW_SKIP_CHANNELS=1 OPENCLAW_SKIP_PROVIDERS=1` in the parent shell to prove the test isolates CI skip env before exercising the restart loop.
- Exact steps or command run after this patch: `OPENCLAW_SKIP_CHANNELS=1 OPENCLAW_SKIP_PROVIDERS=1 node scripts/run-vitest.mjs src/gateway/server-reload-handlers.test.ts`
- Evidence after fix: Copied terminal output from the live command run after the patch:

```text
RUN  v4.1.6 /home/chenglunhu/code/openclaw

Test Files  1 passed (1)
Tests       7 passed (7)
Duration    11.38s
```

- Observed result after fix: The new regression path drove `restartChannels: new Set(["discord", "telegram"])` with `stopChannel("discord")` throwing `Error("discord stop timed out")`; observed output/assertions show `stopChannel` reached both channels, `startChannel` was skipped for failed `discord`, `startChannel` still ran for `telegram`, `logChannels.error` recorded the failed `discord` restart, and `setState` still ran once.
- What was not tested: Full external Discord/Telegram network reconnect was not tested; the proof covers the in-process gateway hot-reload restart loop and failure isolation.

## Audit

- Audit A (existing helper): no predicate/validator/classifier added; existing `String(err)` logging style matches nearby reload code.
- Audit B (shared callers): `createGatewayReloadHandlers` is shared by managed config reload and gateway reload tests; contract preserved because `applyHotReload` remains best-effort for channel restart side effects and continues applying state.
- Audit C (broader rival): no open PR found for #83054 or the restartChannel hot-reload failure shape.

## Tests

- `OPENCLAW_SKIP_CHANNELS=1 OPENCLAW_SKIP_PROVIDERS=1 node scripts/run-vitest.mjs src/gateway/server-reload-handlers.test.ts` -> 7/7 passed
- `pnpm check:changed` -> passed