### PR TITLE
fix(channels): scope DM last-route updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Docs: https://docs.openclaw.ai
 - Control UI: include the Control UI and Gateway protocol versions in protocol-mismatch errors so stale app/dashboard pairings identify which side needs rebuilding or restarting.
 - Gateway/protocol: restore Gateway WS protocol v4 and keep `message.action` room-event metadata on the existing `inboundTurnKind` wire field while preserving internal inbound-event classification.
 - Agents/tools: prefer non-webchat session-key routes when the message tool has stale webchat context, so message-tool-only replies keep delivering to the originating channel. Fixes #82911. (#83004) Thanks @joshavant.
+- Channels: keep direct-message last-route writes on isolated `per-channel-peer` sessions instead of contaminating the agent main session with channel delivery context. Fixes #36614. Thanks @aspenas.
 - Mac app: move the Settings sidebar toggle into the native titlebar and tighten the General pane width.
 - Mac app: keep visited Settings panes mounted so switching tabs no longer blanks and reloads their content.
 - Mac app: make Config settings open from shallow schema lookups and load selected paths on demand instead of fetching and rendering the full generated config schema up front.

--- a/extensions/discord/src/monitor/agent-components.dispatch.ts
+++ b/extensions/discord/src/monitor/agent-components.dispatch.ts
@@ -111,6 +111,7 @@ export async function dispatchDiscordComponentEvent(params: {
   const sessionKey = params.routeOverrides?.sessionKey ?? route.sessionKey;
   const agentId = params.routeOverrides?.agentId ?? route.agentId;
   const accountId = params.routeOverrides?.accountId ?? route.accountId;
+  const inboundLastRouteSessionKey = sessionKey;
   const fromLabel = buildDiscordComponentConversationLabel({
     interactionCtx,
     interaction,
@@ -286,23 +287,24 @@ export async function dispatchDiscordComponentEvent(params: {
         record: {
           updateLastRoute: interactionCtx.isDirectMessage
             ? {
-                sessionKey: route.mainSessionKey,
+                sessionKey: inboundLastRouteSessionKey,
                 channel: "discord",
                 to:
                   resolveDiscordComponentOriginatingTo(interactionCtx) ??
                   `user:${interactionCtx.userId}`,
                 accountId,
-                mainDmOwnerPin: pinnedMainDmOwner
-                  ? {
-                      ownerRecipient: pinnedMainDmOwner,
-                      senderRecipient: interactionCtx.userId,
-                      onSkip: ({ ownerRecipient, senderRecipient }) => {
-                        logVerbose(
-                          `discord: skip main-session last route for ${senderRecipient} (pinned owner ${ownerRecipient})`,
-                        );
-                      },
-                    }
-                  : undefined,
+                mainDmOwnerPin:
+                  inboundLastRouteSessionKey === route.mainSessionKey && pinnedMainDmOwner
+                    ? {
+                        ownerRecipient: pinnedMainDmOwner,
+                        senderRecipient: interactionCtx.userId,
+                        onSkip: ({ ownerRecipient, senderRecipient }) => {
+                          logVerbose(
+                            `discord: skip main-session last route for ${senderRecipient} (pinned owner ${ownerRecipient})`,
+                          );
+                        },
+                      }
+                    : undefined,
               }
             : undefined,
           onRecordError: (err) => {

--- a/extensions/discord/src/monitor/monitor.test.ts
+++ b/extensions/discord/src/monitor/monitor.test.ts
@@ -366,6 +366,19 @@ describe("discord component interactions", () => {
     expect(lastDispatchCtx?.To).toBe("channel:dm-channel");
     expect(getLastRecordedCtx()?.OriginatingTo).toBe("user:123456789");
     expect(getLastRecordedCtx()?.To).toBe("channel:dm-channel");
+    const recordParams = mockCallArg(recordInboundSessionMock, -1, "recordInboundSession") as {
+      updateLastRoute?: {
+        channel?: string;
+        mainDmOwnerPin?: unknown;
+        sessionKey?: string;
+        to?: string;
+      };
+    };
+    expect(recordParams.updateLastRoute?.sessionKey).toBe("session-1");
+    expect(recordParams.updateLastRoute?.sessionKey).not.toBe("agent:agent-1:main");
+    expect(recordParams.updateLastRoute?.channel).toBe("discord");
+    expect(recordParams.updateLastRoute?.to).toBe("user:123456789");
+    expect(recordParams.updateLastRoute?.mainDmOwnerPin).toBeUndefined();
   });
 
   it("uses raw callbackData for built-in fallback when no plugin handler matches", async () => {

--- a/extensions/imessage/src/monitor.last-route.test.ts
+++ b/extensions/imessage/src/monitor.last-route.test.ts
@@ -1,0 +1,139 @@
+import type { MsgContext } from "openclaw/plugin-sdk/reply-runtime";
+import type { waitForTransportReady } from "openclaw/plugin-sdk/transport-ready-runtime";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { createIMessageRpcClient } from "./client.js";
+import { monitorIMessageProvider } from "./monitor.js";
+
+const waitForTransportReadyMock = vi.hoisted(() =>
+  vi.fn<typeof waitForTransportReady>(async () => {}),
+);
+const createIMessageRpcClientMock = vi.hoisted(() => vi.fn<typeof createIMessageRpcClient>());
+const readChannelAllowFromStoreMock = vi.hoisted(() => vi.fn(async () => [] as string[]));
+const recordInboundSessionMock = vi.hoisted(() => vi.fn(async (_params: unknown) => {}));
+const dispatchInboundMessageMock = vi.hoisted(() =>
+  vi.fn(
+    async (_params: { ctx: MsgContext }) =>
+      ({ queuedFinal: false, counts: { tool: 0, block: 0, final: 0 } }) as const,
+  ),
+);
+
+vi.mock("openclaw/plugin-sdk/transport-ready-runtime", () => ({
+  waitForTransportReady: waitForTransportReadyMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/conversation-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/conversation-runtime")>();
+  return {
+    ...actual,
+    readChannelAllowFromStore: readChannelAllowFromStoreMock,
+    recordInboundSession: recordInboundSessionMock,
+    upsertChannelPairingRequest: vi.fn(),
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/channel-inbound", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/channel-inbound")>();
+  return {
+    ...actual,
+    createChannelInboundDebouncer: vi.fn((opts) => ({
+      debouncer: {
+        enqueue: async (entry: unknown) => await opts.onFlush([entry]),
+      },
+    })),
+    shouldDebounceTextInbound: vi.fn(() => false),
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/reply-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/reply-runtime")>();
+  return {
+    ...actual,
+    dispatchInboundMessage: dispatchInboundMessageMock,
+  };
+});
+
+vi.mock("./client.js", () => ({
+  createIMessageRpcClient: createIMessageRpcClientMock,
+}));
+
+vi.mock("./monitor/abort-handler.js", () => ({
+  attachIMessageMonitorAbortHandler: vi.fn(() => () => {}),
+}));
+
+describe("iMessage monitor last-route updates", () => {
+  beforeEach(() => {
+    waitForTransportReadyMock.mockReset().mockResolvedValue(undefined);
+    createIMessageRpcClientMock.mockReset();
+    readChannelAllowFromStoreMock.mockReset().mockResolvedValue([]);
+    recordInboundSessionMock.mockClear();
+    dispatchInboundMessageMock.mockClear();
+  });
+
+  it("keeps per-channel-peer direct-message last-route writes on the isolated session", async () => {
+    const runtimeErrorMock = vi.fn();
+    let onNotification: ((message: { method: string; params: unknown }) => void) | undefined;
+    const client = {
+      request: vi.fn(async () => ({ subscription: 1 })),
+      waitForClose: vi.fn(async () => {
+        onNotification?.({
+          method: "message",
+          params: {
+            message: {
+              id: 1,
+              chat_id: 123,
+              sender: "+15550001111",
+              is_from_me: false,
+              text: "hello from imessage",
+              is_group: false,
+              date: 1_714_000_000_000,
+            },
+          },
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+      }),
+      stop: vi.fn(async () => {}),
+    };
+    createIMessageRpcClientMock.mockImplementation(async (params) => {
+      if (!params?.onNotification) {
+        throw new Error("expected iMessage notification handler");
+      }
+      onNotification = params.onNotification;
+      return client as never;
+    });
+
+    await monitorIMessageProvider({
+      config: {
+        channels: { imessage: { dmPolicy: "allowlist", allowFrom: ["+15550001111"] } },
+        messages: { inbound: { debounceMs: 0 } },
+        session: { dmScope: "per-channel-peer", mainKey: "main" },
+      } as never,
+      runtime: { error: runtimeErrorMock, exit: vi.fn(), log: vi.fn() },
+    });
+
+    await vi.waitFor(() => {
+      expect(readChannelAllowFromStoreMock).toHaveBeenCalledTimes(1);
+    });
+    expect(runtimeErrorMock).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(recordInboundSessionMock).toHaveBeenCalledTimes(1);
+    });
+    const recordParams = recordInboundSessionMock.mock.calls.at(0)?.[0] as
+      | {
+          sessionKey?: string;
+          updateLastRoute?: {
+            channel?: string;
+            mainDmOwnerPin?: unknown;
+            sessionKey?: string;
+            to?: string;
+          };
+        }
+      | undefined;
+    expect(recordParams?.sessionKey).toBe("agent:main:imessage:direct:+15550001111");
+    expect(recordParams?.updateLastRoute?.sessionKey).toBe(recordParams?.sessionKey);
+    expect(recordParams?.updateLastRoute?.sessionKey).not.toBe("agent:main:main");
+    expect(recordParams?.updateLastRoute?.channel).toBe("imessage");
+    expect(recordParams?.updateLastRoute?.to).toBe("+15550001111");
+    expect(recordParams?.updateLastRoute?.mainDmOwnerPin).toBeUndefined();
+  });
+});

--- a/extensions/imessage/src/monitor/monitor-provider.ts
+++ b/extensions/imessage/src/monitor/monitor-provider.ts
@@ -23,6 +23,7 @@ import { resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-runtime";
 import { dispatchInboundMessage } from "openclaw/plugin-sdk/reply-runtime";
 import { createReplyDispatcherWithTyping } from "openclaw/plugin-sdk/reply-runtime";
 import { settleReplyDispatcher } from "openclaw/plugin-sdk/reply-runtime";
+import { resolveInboundLastRouteSessionKey } from "openclaw/plugin-sdk/routing";
 import { getRuntimeConfig } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { danger, logVerbose, shouldLogVerbose, warn } from "openclaw/plugin-sdk/runtime-env";
 import {
@@ -675,6 +676,10 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         runtime.error?.(danger(`imessage ${info.kind} reply failed: ${String(err)}`));
       },
     });
+    const inboundLastRouteSessionKey = resolveInboundLastRouteSessionKey({
+      route: decision.route,
+      sessionKey: decision.route.sessionKey,
+    });
 
     await runInboundReplyTurn({
       channel: "imessage",
@@ -700,12 +705,14 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
             updateLastRoute:
               !decision.isGroup && updateTarget
                 ? {
-                    sessionKey: decision.route.mainSessionKey,
+                    sessionKey: inboundLastRouteSessionKey,
                     channel: "imessage",
                     to: updateTarget,
                     accountId: decision.route.accountId,
                     mainDmOwnerPin:
-                      pinnedMainDmOwner && decision.senderNormalized
+                      inboundLastRouteSessionKey === decision.route.mainSessionKey &&
+                      pinnedMainDmOwner &&
+                      decision.senderNormalized
                         ? {
                             ownerRecipient: pinnedMainDmOwner,
                             senderRecipient: decision.senderNormalized,

--- a/extensions/line/src/bot-message-context.test.ts
+++ b/extensions/line/src/bot-message-context.test.ts
@@ -233,6 +233,32 @@ describe("buildLineMessageContext", () => {
     expect(context?.ctxPayload.CommandAuthorized).toBe(false);
   });
 
+  it("keeps per-channel-peer direct-message last-route writes on the isolated session", async () => {
+    const event = createMessageEvent({ type: "user", userId: "user-1" });
+    const directCfg: OpenClawConfig = {
+      session: { store: storePath, dmScope: "per-channel-peer" },
+    };
+
+    const context = await buildLineMessageContext({
+      event,
+      allMedia: [],
+      cfg: directCfg,
+      account: {
+        ...account,
+        config: { allowFrom: ["user-1"] },
+      },
+      commandAuthorized: true,
+    });
+
+    expect(context?.route.sessionKey).toBe("agent:main:line:direct:user-1");
+    const updateLastRoute = context?.turn.record.updateLastRoute;
+    expect(updateLastRoute?.sessionKey).toBe(context?.route.sessionKey);
+    expect(updateLastRoute?.sessionKey).not.toBe("agent:main:main");
+    expect(updateLastRoute?.channel).toBe("line");
+    expect(updateLastRoute?.to).toBe("user-1");
+    expect(updateLastRoute?.mainDmOwnerPin).toBeUndefined();
+  });
+
   it("sets CommandAuthorized on postback context", async () => {
     const event = createPostbackEvent({ type: "user", userId: "user-pb" });
 

--- a/extensions/line/src/bot-message-context.ts
+++ b/extensions/line/src/bot-message-context.ts
@@ -15,7 +15,7 @@ import {
 } from "openclaw/plugin-sdk/conversation-runtime";
 import { finalizeInboundContext } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import { createChannelHistoryWindow, type HistoryEntry } from "openclaw/plugin-sdk/reply-history";
-import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
+import { resolveAgentRoute, resolveInboundLastRouteSessionKey } from "openclaw/plugin-sdk/routing";
 import { logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { normalizeAllowFrom } from "./bot-access.js";
@@ -377,6 +377,10 @@ async function finalizeLineInboundContext(params: {
         normalizeEntry: (entry) => normalizeAllowFrom([entry]).entries[0],
       })
     : null;
+  const inboundLastRouteSessionKey = resolveInboundLastRouteSessionKey({
+    route: params.route,
+    sessionKey: params.route.sessionKey,
+  });
   if (shouldLogVerbose()) {
     const preview = body.slice(0, 200).replace(/\n/g, "\\n");
     const mediaInfo =
@@ -397,12 +401,14 @@ async function finalizeLineInboundContext(params: {
       record: {
         updateLastRoute: !params.source.isGroup
           ? {
-              sessionKey: params.route.mainSessionKey,
+              sessionKey: inboundLastRouteSessionKey,
               channel: "line",
               to: params.source.userId ?? params.source.peerId,
               accountId: params.route.accountId,
               mainDmOwnerPin:
-                pinnedMainDmOwner && params.source.userId
+                inboundLastRouteSessionKey === params.route.mainSessionKey &&
+                pinnedMainDmOwner &&
+                params.source.userId
                   ? {
                       ownerRecipient: pinnedMainDmOwner,
                       senderRecipient: params.source.userId,

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -30,6 +30,7 @@ import {
   getReplyPayloadTtsSupplement,
 } from "openclaw/plugin-sdk/reply-payload";
 import type { GetReplyOptions } from "openclaw/plugin-sdk/reply-runtime";
+import { resolveInboundLastRouteSessionKey } from "openclaw/plugin-sdk/routing";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/security-runtime";
 import {
   loadSessionStore,
@@ -2052,6 +2053,11 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
           })()
         : null;
 
+      const inboundLastRouteSessionKey = resolveInboundLastRouteSessionKey({
+        route: _route,
+        sessionKey: _route.sessionKey,
+      });
+
       const turnResult = await core.channel.turn.run({
         channel: "matrix",
         accountId: _route.accountId,
@@ -2075,27 +2081,28 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
             record: {
               updateLastRoute: isDirectMessage
                 ? {
-                    sessionKey: _route.mainSessionKey,
+                    sessionKey: inboundLastRouteSessionKey,
                     channel: "matrix",
                     to: `room:${roomId}`,
                     accountId: _route.accountId,
-                    mainDmOwnerPin: pinnedMainDmOwner
-                      ? {
-                          ownerRecipient: pinnedMainDmOwner,
-                          senderRecipient: normalizeMatrixUserId(senderId),
-                          onSkip: ({
-                            ownerRecipient,
-                            senderRecipient,
-                          }: {
-                            ownerRecipient: string;
-                            senderRecipient: string;
-                          }) => {
-                            logVerboseMessage(
-                              `matrix: skip main-session last route for ${senderRecipient} (pinned owner ${ownerRecipient})`,
-                            );
-                          },
-                        }
-                      : undefined,
+                    mainDmOwnerPin:
+                      inboundLastRouteSessionKey === _route.mainSessionKey && pinnedMainDmOwner
+                        ? {
+                            ownerRecipient: pinnedMainDmOwner,
+                            senderRecipient: normalizeMatrixUserId(senderId),
+                            onSkip: ({
+                              ownerRecipient,
+                              senderRecipient,
+                            }: {
+                              ownerRecipient: string;
+                              senderRecipient: string;
+                            }) => {
+                              logVerboseMessage(
+                                `matrix: skip main-session last route for ${senderRecipient} (pinned owner ${ownerRecipient})`,
+                              );
+                            },
+                          }
+                        : undefined,
                   }
                 : undefined,
               onRecordError: (err) => {

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -138,7 +138,16 @@ vi.mock("./runtime-api.js", async () => {
   };
 });
 
-function createRuntimeCore(cfg: OpenClawConfig) {
+function createRuntimeCore(
+  cfg: OpenClawConfig,
+  routeOverride?: {
+    accountId?: string;
+    agentId?: string;
+    lastRoutePolicy?: "main" | "session";
+    mainSessionKey?: string;
+    sessionKey?: string;
+  },
+) {
   const runPrepared = vi.fn(
     async (turn: {
       storePath: string;
@@ -268,10 +277,11 @@ function createRuntimeCore(cfg: OpenClawConfig) {
       },
       routing: {
         resolveAgentRoute: () => ({
-          accountId: "default",
-          agentId: "main",
-          mainSessionKey: "mattermost:default:channel:chan-1",
-          sessionKey: "mattermost:default:channel:chan-1",
+          accountId: routeOverride?.accountId ?? "default",
+          agentId: routeOverride?.agentId ?? "main",
+          lastRoutePolicy: routeOverride?.lastRoutePolicy ?? "main",
+          mainSessionKey: routeOverride?.mainSessionKey ?? "mattermost:default:channel:chan-1",
+          sessionKey: routeOverride?.sessionKey ?? "mattermost:default:channel:chan-1",
         }),
       },
       session: {
@@ -498,5 +508,83 @@ describe("mattermost inbound user posts", () => {
     expect(recordCall?.createIfMissing).toBeUndefined();
     expect(recordCall?.groupResolution).toBeUndefined();
     expect(recordCall?.onRecordError).toBeInstanceOf(Function);
+  });
+
+  it("keeps per-channel direct-message route updates on the isolated session", async () => {
+    const socket = new FakeWebSocket();
+    const abortController = new AbortController();
+    mockState.abortController = abortController;
+    const directConfig: OpenClawConfig = {
+      session: { dmScope: "per-channel-peer" },
+      channels: {
+        mattermost: {
+          enabled: true,
+          baseUrl: "https://mattermost.example.com",
+          botToken: "bot-token",
+          chatmode: "onmessage",
+          dmPolicy: "allowlist",
+          groupPolicy: "open",
+          allowFrom: ["user-1"],
+        },
+      },
+    };
+    const runtimeCore = createRuntimeCore(directConfig, {
+      lastRoutePolicy: "session",
+      mainSessionKey: "agent:main:main",
+      sessionKey: "agent:main:mattermost:direct:user-1",
+    });
+    mockState.runtimeCore = runtimeCore;
+    mockState.resolveChannelInfo.mockResolvedValue({
+      id: "dm-1",
+      name: "",
+      display_name: "",
+      team_id: "team-1",
+      type: "D",
+    });
+    const { monitorMattermostProvider } = await import("./monitor.js");
+
+    const monitor = monitorMattermostProvider({
+      config: directConfig,
+      runtime: testRuntime(),
+      abortSignal: abortController.signal,
+      webSocketFactory: () => socket,
+    });
+
+    await vi.waitFor(() => {
+      expect(socket.openListenerCount).toBeGreaterThan(0);
+    });
+    socket.emitOpen();
+
+    await socket.emitMessage({
+      event: "posted",
+      data: {
+        channel_id: "dm-1",
+        sender_name: "alice",
+        post: JSON.stringify({
+          id: "post-dm-2",
+          channel_id: "dm-1",
+          user_id: "user-1",
+          message: "isolated direct hello",
+          create_at: 1_714_000_000_000,
+        }),
+      },
+      broadcast: {
+        channel_id: "dm-1",
+        user_id: "user-1",
+      },
+    });
+    socket.emitClose(1000);
+    await monitor;
+
+    expect(runtimeCore.channel.session.recordInboundSession).toHaveBeenCalledTimes(1);
+    const [recordCall] = runtimeCore.channel.session.recordInboundSession.mock.calls.at(0) ?? [];
+    expect(recordCall?.sessionKey).toBe("agent:main:mattermost:direct:user-1");
+    const updateLastRoute = recordCall?.updateLastRoute;
+    expect(updateLastRoute?.sessionKey).toBe("agent:main:mattermost:direct:user-1");
+    expect(updateLastRoute?.sessionKey).not.toBe("agent:main:main");
+    expect(updateLastRoute?.channel).toBe("mattermost");
+    expect(updateLastRoute?.to).toBe("user:user-1");
+    expect(updateLastRoute?.accountId).toBe("default");
+    expect(updateLastRoute?.mainDmOwnerPin).toBeUndefined();
   });
 });

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -13,6 +13,7 @@ import {
   getReplyPayloadTtsSupplement,
   isReasoningReplyPayload,
 } from "openclaw/plugin-sdk/reply-payload";
+import { resolveInboundLastRouteSessionKey } from "openclaw/plugin-sdk/routing";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/security-runtime";
 import { isPrivateNetworkOptInEnabled } from "openclaw/plugin-sdk/ssrf-runtime";
 import {
@@ -1763,6 +1764,11 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             },
           });
 
+        const inboundLastRouteSessionKey = resolveInboundLastRouteSessionKey({
+          route,
+          sessionKey: route.sessionKey,
+        });
+
         let dispatchSettledBeforeStart = false;
         try {
           await core.channel.turn.run({
@@ -1789,27 +1795,28 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                   updateLastRoute:
                     kind === "direct"
                       ? {
-                          sessionKey: route.mainSessionKey,
+                          sessionKey: inboundLastRouteSessionKey,
                           channel: "mattermost",
                           to,
                           accountId: route.accountId,
-                          mainDmOwnerPin: pinnedMainDmOwner
-                            ? {
-                                ownerRecipient: pinnedMainDmOwner,
-                                senderRecipient: normalizeMattermostAllowEntry(senderId),
-                                onSkip: ({
-                                  ownerRecipient,
-                                  senderRecipient,
-                                }: {
-                                  ownerRecipient: string;
-                                  senderRecipient: string;
-                                }) => {
-                                  logVerboseMessage(
-                                    `mattermost: skip main-session last route for ${senderRecipient} (pinned owner ${ownerRecipient})`,
-                                  );
-                                },
-                              }
-                            : undefined,
+                          mainDmOwnerPin:
+                            inboundLastRouteSessionKey === route.mainSessionKey && pinnedMainDmOwner
+                              ? {
+                                  ownerRecipient: pinnedMainDmOwner,
+                                  senderRecipient: normalizeMattermostAllowEntry(senderId),
+                                  onSkip: ({
+                                    ownerRecipient,
+                                    senderRecipient,
+                                  }: {
+                                    ownerRecipient: string;
+                                    senderRecipient: string;
+                                  }) => {
+                                    logVerboseMessage(
+                                      `mattermost: skip main-session last route for ${senderRecipient} (pinned owner ${ownerRecipient})`,
+                                    );
+                                  },
+                                }
+                              : undefined,
                         }
                       : undefined,
                   onRecordError: (err) => {

--- a/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
+++ b/extensions/signal/src/monitor/event-handler.inbound-context.test.ts
@@ -13,6 +13,7 @@ const {
   sendReadReceiptMock,
   dispatchInboundMessageMock,
   enqueueSystemEventMock,
+  recordInboundSessionMock,
   capture,
 } = vi.hoisted(() => {
   const captureState: { ctx?: MsgContext } = {};
@@ -20,6 +21,7 @@ const {
     sendTypingMock: vi.fn(),
     sendReadReceiptMock: vi.fn(),
     enqueueSystemEventMock: vi.fn(),
+    recordInboundSessionMock: vi.fn(),
     dispatchInboundMessageMock: vi.fn(
       async (params: {
         ctx: MsgContext;
@@ -58,6 +60,7 @@ vi.mock("openclaw/plugin-sdk/conversation-runtime", async () => {
   );
   return {
     ...actual,
+    recordInboundSession: recordInboundSessionMock,
     readChannelAllowFromStore: vi.fn().mockResolvedValue([]),
     upsertChannelPairingRequest: vi.fn(),
   };
@@ -86,6 +89,7 @@ describe("signal createSignalEventHandler inbound context", () => {
     sendTypingMock.mockReset().mockResolvedValue(true);
     sendReadReceiptMock.mockReset().mockResolvedValue(true);
     enqueueSystemEventMock.mockReset();
+    recordInboundSessionMock.mockReset().mockResolvedValue(undefined);
     dispatchInboundMessageMock.mockClear();
   });
 
@@ -139,6 +143,51 @@ describe("signal createSignalEventHandler inbound context", () => {
     expect(context.ChatType).toBe("direct");
     expect(context.To).toBe("+15550002222");
     expect(context.OriginatingTo).toBe("+15550002222");
+  });
+
+  it("keeps per-channel-peer direct-message last-route writes on the isolated session", async () => {
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        cfg: {
+          session: { dmScope: "per-channel-peer" },
+          messages: { inbound: { debounceMs: 0 } },
+          channels: { signal: { dmPolicy: "open", allowFrom: ["*"] } },
+        } as any,
+        historyLimit: 0,
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        sourceNumber: "+15550002222",
+        sourceName: "Bob",
+        timestamp: 1700000000001,
+        dataMessage: {
+          message: "hello",
+          attachments: [],
+        },
+      }),
+    );
+
+    const context = requireCapturedContext();
+    expect(context.SessionKey).toBe("agent:main:signal:direct:+15550002222");
+    const recordParams = recordInboundSessionMock.mock.calls.at(-1)?.[0] as
+      | {
+          sessionKey?: string;
+          updateLastRoute?: {
+            channel?: string;
+            mainDmOwnerPin?: unknown;
+            sessionKey?: string;
+            to?: string;
+          };
+        }
+      | undefined;
+    expect(recordParams?.sessionKey).toBe(context.SessionKey);
+    expect(recordParams?.updateLastRoute?.sessionKey).toBe(context.SessionKey);
+    expect(recordParams?.updateLastRoute?.sessionKey).not.toBe("agent:main:main");
+    expect(recordParams?.updateLastRoute?.channel).toBe("signal");
+    expect(recordParams?.updateLastRoute?.to).toBe("+15550002222");
+    expect(recordParams?.updateLastRoute?.mainDmOwnerPin).toBeUndefined();
   });
 
   it("keeps direct chat text in BodyForAgent while Body remains the legacy envelope", async () => {

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -31,7 +31,7 @@ import { dispatchInboundMessage } from "openclaw/plugin-sdk/reply-runtime";
 import { finalizeInboundContext } from "openclaw/plugin-sdk/reply-runtime";
 import { createReplyDispatcherWithTyping } from "openclaw/plugin-sdk/reply-runtime";
 import { settleReplyDispatcher } from "openclaw/plugin-sdk/reply-runtime";
-import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
+import { resolveAgentRoute, resolveInboundLastRouteSessionKey } from "openclaw/plugin-sdk/routing";
 import { danger, logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "openclaw/plugin-sdk/security-runtime";
 import { readSessionUpdatedAt, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
@@ -280,6 +280,10 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
         deps.runtime.error?.(danger(`signal ${info.kind} reply failed: ${String(err)}`));
       },
     });
+    const inboundLastRouteSessionKey = resolveInboundLastRouteSessionKey({
+      route,
+      sessionKey: route.sessionKey,
+    });
 
     await runInboundReplyTurn({
       channel: "signal",
@@ -302,11 +306,14 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
           record: {
             updateLastRoute: !entry.isGroup
               ? {
-                  sessionKey: route.mainSessionKey,
+                  sessionKey: inboundLastRouteSessionKey,
                   channel: "signal",
                   to: entry.senderRecipient,
                   accountId: route.accountId,
                   mainDmOwnerPin: (() => {
+                    if (inboundLastRouteSessionKey !== route.mainSessionKey) {
+                      return undefined;
+                    }
                     const pinnedOwner = resolvePinnedMainDmOwnerFromAllowlist({
                       dmScope: deps.cfg.session?.dmScope,
                       allowFrom: deps.allowFrom,

--- a/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts
@@ -35,6 +35,7 @@ let mockedNativeStreaming = false;
 let mockedBlockStreamingEnabled: boolean | undefined = false;
 let mockedSlackStreamingMode: "off" | "partial" | "block" | "progress" = "partial";
 let mockedSlackDraftMode: "replace" | "status_final" | "append" = "append";
+let mockedPinnedMainDmOwner: string | undefined;
 let capturedReplyOptions:
   | {
       disableBlockStreaming?: boolean;
@@ -586,7 +587,7 @@ vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
 }));
 
 vi.mock("openclaw/plugin-sdk/security-runtime", () => ({
-  resolvePinnedMainDmOwnerFromAllowlist: () => undefined,
+  resolvePinnedMainDmOwnerFromAllowlist: () => mockedPinnedMainDmOwner,
 }));
 
 vi.mock("openclaw/plugin-sdk/string-coerce-runtime", () => ({
@@ -788,6 +789,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
     mockedBlockStreamingEnabled = false;
     mockedSlackStreamingMode = "partial";
     mockedSlackDraftMode = "append";
+    mockedPinnedMainDmOwner = undefined;
     capturedReplyOptions = undefined;
     capturedStatusReactionOptions = undefined;
     capturedTyping = undefined;
@@ -982,6 +984,7 @@ describe("dispatchPreparedSlackMessage preview fallback", () => {
   });
 
   it("updates non-main DM last-route metadata on the prepared direct session", async () => {
+    mockedPinnedMainDmOwner = "U2";
     await dispatchPreparedSlackMessage(
       createPreparedSlackMessage({
         cfg: { session: { dmScope: "per-channel-peer" } },

--- a/extensions/slack/src/monitor/message-handler/dispatch.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch.ts
@@ -371,7 +371,12 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       normalizeEntry: normalizeSlackAllowOwnerEntry,
     });
     const senderRecipient = normalizeOptionalLowercaseString(message.user);
+    const inboundLastRouteSessionKey = resolveInboundLastRouteSessionKey({
+      route,
+      sessionKey: prepared.ctxPayload.SessionKey ?? route.sessionKey,
+    });
     const skipMainUpdate =
+      inboundLastRouteSessionKey === route.mainSessionKey &&
       pinnedMainDmOwner &&
       senderRecipient &&
       normalizeOptionalLowercaseString(pinnedMainDmOwner) !== senderRecipient;
@@ -382,10 +387,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     } else {
       await updateLastRoute({
         storePath,
-        sessionKey: resolveInboundLastRouteSessionKey({
-          route,
-          sessionKey: prepared.ctxPayload.SessionKey ?? route.sessionKey,
-        }),
+        sessionKey: inboundLastRouteSessionKey,
         deliveryContext: {
           channel: "slack",
           to: `user:${message.user}`,

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -1379,6 +1379,8 @@ export async function prepareSlackMessage(params: {
     logVerbose(`slack inbound: channel=${message.channel} from=${slackFrom} preview="${preview}"`);
   }
 
+  const updateLastRouteSessionKey = resolveInboundLastRouteSessionKey({ route, sessionKey });
+
   return {
     ctx,
     account,
@@ -1392,13 +1394,15 @@ export async function prepareSlackMessage(params: {
       record: {
         updateLastRoute: isDirectMessage
           ? {
-              sessionKey: resolveInboundLastRouteSessionKey({ route, sessionKey }),
+              sessionKey: updateLastRouteSessionKey,
               channel: "slack",
               to: `user:${message.user}`,
               accountId: route.accountId,
               threadId: effectiveMessageThreadId,
               mainDmOwnerPin:
-                pinnedMainDmOwner && message.user
+                updateLastRouteSessionKey === route.mainSessionKey &&
+                pinnedMainDmOwner &&
+                message.user
                   ? {
                       ownerRecipient: pinnedMainDmOwner,
                       senderRecipient: normalizeLowercaseStringOrEmpty(message.user),


### PR DESCRIPTION
## Summary
- Fixes https://github.com/openclaw/openclaw/issues/36614 by keeping direct-message `updateLastRoute` writes on the resolved inbound session when the route is isolated (`per-channel-peer`, bound session, component session).
- Applies the main-DM owner pin only when the update target is the agent main session across iMessage, Signal, Mattermost, LINE, Matrix, Slack, and Discord component interactions.
- Adds focused regressions for the touched channel paths and a changelog entry.

## Related / Separate Lanes
- Gemini provider-owned refresh behavior stays with https://github.com/openclaw/openclaw/pull/78030.
- Broader OAuth cooldown/logging policy from https://github.com/openclaw/openclaw/issues/42541 is a separate lane.
- Semantic-map leftovers outside this carveout: anthropic-transport-stream, agent-command, auth order/API-key rotation, and broader provider auth surfaces.
- Feishu wrong-session behavior remains tracked separately in https://github.com/openclaw/openclaw/issues/78274 pending targeted/live repro.
- Related session-routing guardrails already landed in https://github.com/openclaw/openclaw/pull/83004 and https://github.com/openclaw/openclaw/pull/83029.

## Verification
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/imessage/src/monitor.last-route.test.ts extensions/signal/src/monitor/event-handler.inbound-context.test.ts extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts extensions/discord/src/monitor/monitor.test.ts extensions/line/src/bot-message-context.test.ts extensions/slack/src/monitor/message-handler/prepare.test.ts extensions/slack/src/monitor/message-handler/dispatch.preview-fallback.test.ts` -> 7 files passed, 170 tests passed.
- `.agents/skills/codex-review/scripts/codex-review --mode branch` -> clean, no accepted/actionable findings reported.
- `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --blacksmith-org openclaw --blacksmith-workflow .github/workflows/ci-check-testbox.yml --blacksmith-job check --blacksmith-ref main --idle-timeout 90m --ttl 240m --timing-json -- CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_TEST_PROJECTS_PARALLEL=6 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm check:changed` -> passed on Testbox-through-Crabbox (`provider=blacksmith-testbox`, id `tbx_01krtsnj79cb6wtq8e6v348hzn`, Actions run https://github.com/openclaw/openclaw/actions/runs/25989049967).

## Real Behavior Proof
Behavior addressed: Direct-message last-route writes no longer contaminate `agent:<id>:main` when the inbound route is scoped to an isolated DM/session key.
Real environment tested: Blacksmith Testbox through Crabbox (`provider=blacksmith-testbox`, id `tbx_01krtsnj79cb6wtq8e6v348hzn`, run https://github.com/openclaw/openclaw/actions/runs/25989049967).
Exact steps or command run after this patch: `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --blacksmith-org openclaw --blacksmith-workflow .github/workflows/ci-check-testbox.yml --blacksmith-job check --blacksmith-ref main --idle-timeout 90m --ttl 240m --timing-json -- CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_TEST_PROJECTS_PARALLEL=6 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm check:changed`.
Evidence after fix: `pnpm check:changed` completed successfully on head `9545f83ef06e10769027bea88c4042b0ae4ff33f`.
Observed result after fix: extension type/lint/changed checks passed; focused channel regressions prove `updateLastRoute` targets the isolated session and suppresses main-owner pin on non-main updates.
What was not tested: live iMessage/Signal/Mattermost/LINE/Matrix/Slack/Discord accounts; this patch is covered by focused harness tests and the changed gate.

Fixes https://github.com/openclaw/openclaw/issues/36614
