### PR TITLE
fix(android): prompt on changed TLS thumbprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ Docs: https://docs.openclaw.ai
 - Process/diagnostics: stop counting the active processing turn as queued backlog in liveness warnings so transient max-only event-loop spikes do not surface as gateway warnings.
 - Agents/replies: classify provider conversation-state rejections and return a clear message-channel error instead of auto-resetting or falling back to a generic runner failure. (#82616) Thanks @dutifulbob.
 - Browser plugin: trust managed Chrome CDP diagnostics when launch HTTP probes race cold-start readiness, avoiding false startup failures. Fixes #82904. (#82986) Thanks @kmanan and @hclsys.
+- Android: prompt before replacing a changed Gateway TLS thumbprint, showing the old and new SHA-256 fingerprints so users can accept expected certificate rotations instead of hard failing on pin mismatch. Thanks @sliekens.
 
 ## 2026.5.17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,7 +106,7 @@ Docs: https://docs.openclaw.ai
 - Process/diagnostics: stop counting the active processing turn as queued backlog in liveness warnings so transient max-only event-loop spikes do not surface as gateway warnings.
 - Agents/replies: classify provider conversation-state rejections and return a clear message-channel error instead of auto-resetting or falling back to a generic runner failure. (#82616) Thanks @dutifulbob.
 - Browser plugin: trust managed Chrome CDP diagnostics when launch HTTP probes race cold-start readiness, avoiding false startup failures. Fixes #82904. (#82986) Thanks @kmanan and @hclsys.
-- Android: prompt before replacing a changed Gateway TLS thumbprint, showing the old and new SHA-256 fingerprints so users can accept expected certificate rotations instead of hard failing on pin mismatch. Thanks @sliekens.
+- Android: prompt before replacing a changed Gateway TLS thumbprint, showing the old and new SHA-256 fingerprints so users can accept expected certificate rotations instead of hard failing on pin mismatch. (#83077) Thanks @sliekens.
 
 ## 2026.5.17
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -1123,44 +1123,31 @@ class NodeRuntime(
         tls.expectedFingerprint
           ?.let(::normalizeGatewayTlsFingerprint)
           ?.takeIf { it.isNotBlank() }
-      if (expectedFingerprint == null) {
-        // First-time TLS: capture fingerprint, ask user to verify out-of-band, then store and connect.
-        _statusText.value = "Verify gateway TLS fingerprint…"
-        scope.launch {
-          val tlsProbe = tlsFingerprintProbe(endpoint.host, endpoint.port)
-          if (!isCurrentConnectAttempt(connectAttemptId)) return@launch
-          val fp =
-            tlsProbe.fingerprintSha256 ?: run {
-              _statusText.value = gatewayTlsProbeFailureMessage(tlsProbe.failure)
-              return@launch
-            }
-          val observedFingerprint =
-            normalizeGatewayTlsFingerprint(fp)
-              .takeIf { it.isNotBlank() }
-              ?: fp
-          _pendingGatewayTrust.value =
-            GatewayTrustPrompt(endpoint = endpoint, fingerprintSha256 = observedFingerprint, auth = auth)
-        }
-        return
-      }
-
       _statusText.value = "Verify gateway TLS fingerprint…"
       scope.launch {
         val tlsProbe = tlsFingerprintProbe(endpoint.host, endpoint.port)
         if (!isCurrentConnectAttempt(connectAttemptId)) return@launch
         val fp =
           tlsProbe.fingerprintSha256 ?: run {
-            connectAfterTlsCheck(endpoint = endpoint, auth = auth, connectAttemptId = connectAttemptId)
+            if (expectedFingerprint == null) {
+              _statusText.value = gatewayTlsProbeFailureMessage(tlsProbe.failure)
+            } else {
+              connectAfterTlsCheck(endpoint = endpoint, auth = auth, connectAttemptId = connectAttemptId)
+            }
             return@launch
           }
-        val observedFingerprint = normalizeGatewayTlsFingerprint(fp)
-        if (observedFingerprint != expectedFingerprint) {
+        val observedFingerprint =
+          normalizeGatewayTlsFingerprint(fp)
+            .takeIf { it.isNotBlank() }
+            ?: fp
+        val previousFingerprint = expectedFingerprint?.takeUnless { it == observedFingerprint }
+        if (expectedFingerprint == null || previousFingerprint != null) {
           _pendingGatewayTrust.value =
             GatewayTrustPrompt(
               endpoint = endpoint,
               fingerprintSha256 = observedFingerprint,
               auth = auth,
-              previousFingerprintSha256 = expectedFingerprint,
+              previousFingerprintSha256 = previousFingerprint,
             )
           return@launch
         }

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -12,6 +12,7 @@ import ai.openclaw.app.gateway.GatewayEndpoint
 import ai.openclaw.app.gateway.GatewaySession
 import ai.openclaw.app.gateway.GatewayTlsProbeFailure
 import ai.openclaw.app.gateway.GatewayTlsProbeResult
+import ai.openclaw.app.gateway.normalizeGatewayTlsFingerprint
 import ai.openclaw.app.gateway.probeGatewayTlsFingerprint
 import ai.openclaw.app.node.A2UIHandler
 import ai.openclaw.app.node.CalendarHandler
@@ -248,6 +249,7 @@ class NodeRuntime(
     val endpoint: GatewayEndpoint,
     val fingerprintSha256: String,
     val auth: GatewayConnectAuth,
+    val previousFingerprintSha256: String? = null,
   )
 
   private val _isConnected = MutableStateFlow(false)
@@ -260,6 +262,7 @@ class NodeRuntime(
 
   private val _pendingGatewayTrust = MutableStateFlow<GatewayTrustPrompt?>(null)
   val pendingGatewayTrust: StateFlow<GatewayTrustPrompt?> = _pendingGatewayTrust.asStateFlow()
+  private val connectAttemptSeq = AtomicLong(0)
 
   private fun resolveNodeMainSessionKey(agentId: String? = gatewayDefaultAgentId): String {
     val deviceId = identityStore.loadOrCreate().deviceId
@@ -1112,23 +1115,71 @@ class NodeRuntime(
     endpoint: GatewayEndpoint,
     auth: GatewayConnectAuth,
   ) {
+    val connectAttemptId = connectAttemptSeq.incrementAndGet()
+    _pendingGatewayTrust.value = null
     val tls = connectionManager.resolveTlsParams(endpoint)
-    if (tls?.required == true && tls.expectedFingerprint.isNullOrBlank()) {
-      // First-time TLS: capture fingerprint, ask user to verify out-of-band, then store and connect.
+    if (tls?.required == true) {
+      val expectedFingerprint =
+        tls.expectedFingerprint
+          ?.let(::normalizeGatewayTlsFingerprint)
+          ?.takeIf { it.isNotBlank() }
+      if (expectedFingerprint == null) {
+        // First-time TLS: capture fingerprint, ask user to verify out-of-band, then store and connect.
+        _statusText.value = "Verify gateway TLS fingerprint…"
+        scope.launch {
+          val tlsProbe = tlsFingerprintProbe(endpoint.host, endpoint.port)
+          if (!isCurrentConnectAttempt(connectAttemptId)) return@launch
+          val fp =
+            tlsProbe.fingerprintSha256 ?: run {
+              _statusText.value = gatewayTlsProbeFailureMessage(tlsProbe.failure)
+              return@launch
+            }
+          val observedFingerprint =
+            normalizeGatewayTlsFingerprint(fp)
+              .takeIf { it.isNotBlank() }
+              ?: fp
+          _pendingGatewayTrust.value =
+            GatewayTrustPrompt(endpoint = endpoint, fingerprintSha256 = observedFingerprint, auth = auth)
+        }
+        return
+      }
+
       _statusText.value = "Verify gateway TLS fingerprint…"
       scope.launch {
         val tlsProbe = tlsFingerprintProbe(endpoint.host, endpoint.port)
+        if (!isCurrentConnectAttempt(connectAttemptId)) return@launch
         val fp =
           tlsProbe.fingerprintSha256 ?: run {
-            _statusText.value = gatewayTlsProbeFailureMessage(tlsProbe.failure)
+            connectAfterTlsCheck(endpoint = endpoint, auth = auth, connectAttemptId = connectAttemptId)
             return@launch
           }
-        _pendingGatewayTrust.value =
-          GatewayTrustPrompt(endpoint = endpoint, fingerprintSha256 = fp, auth = auth)
+        val observedFingerprint = normalizeGatewayTlsFingerprint(fp)
+        if (observedFingerprint != expectedFingerprint) {
+          _pendingGatewayTrust.value =
+            GatewayTrustPrompt(
+              endpoint = endpoint,
+              fingerprintSha256 = observedFingerprint,
+              auth = auth,
+              previousFingerprintSha256 = expectedFingerprint,
+            )
+          return@launch
+        }
+        connectAfterTlsCheck(endpoint = endpoint, auth = auth, connectAttemptId = connectAttemptId)
       }
       return
     }
 
+    connectAfterTlsCheck(endpoint = endpoint, auth = auth, connectAttemptId = connectAttemptId)
+  }
+
+  private fun isCurrentConnectAttempt(connectAttemptId: Long): Boolean = connectAttemptSeq.get() == connectAttemptId
+
+  private fun connectAfterTlsCheck(
+    endpoint: GatewayEndpoint,
+    auth: GatewayConnectAuth,
+    connectAttemptId: Long,
+  ) {
+    if (!isCurrentConnectAttempt(connectAttemptId)) return
     connectedEndpoint = endpoint
     operatorStatusText = "Connecting…"
     nodeStatusText = "Connecting…"
@@ -1221,6 +1272,7 @@ class NodeRuntime(
   }
 
   fun disconnect() {
+    connectAttemptSeq.incrementAndGet()
     stopActiveVoiceSession()
     connectedEndpoint = null
     activeGatewayAuth = null

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayTls.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayTls.kt
@@ -53,7 +53,10 @@ fun buildGatewayTlsConfig(
   onStore: ((String) -> Unit)? = null,
 ): GatewayTlsConfig? {
   if (params == null) return null
-  val expected = params.expectedFingerprint?.let(::normalizeFingerprint)
+  val expected =
+    params.expectedFingerprint
+      ?.let(::normalizeGatewayTlsFingerprint)
+      ?.takeIf { it.isNotBlank() }
   val defaultTrust = defaultTrustManager()
 
   @SuppressLint("CustomX509TrustManager")
@@ -200,7 +203,7 @@ private fun sha256Hex(data: ByteArray): String {
   return out.toString()
 }
 
-private fun normalizeFingerprint(raw: String): String {
+fun normalizeGatewayTlsFingerprint(raw: String): String {
   val stripped =
     raw
       .trim()

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/ConnectTabScreen.kt
@@ -100,8 +100,14 @@ fun ConnectTabScreen(viewModel: MainViewModel) {
       containerColor = mobileCardSurface,
       title = { Text("Trust this gateway?", style = mobileHeadline, color = mobileText) },
       text = {
+        val message =
+          if (prompt.previousFingerprintSha256.isNullOrBlank()) {
+            "First-time TLS connection.\n\nVerify this SHA-256 fingerprint before trusting:\n${prompt.fingerprintSha256}"
+          } else {
+            "The gateway TLS certificate changed. Only continue if you expected this.\n\nOld SHA-256 fingerprint:\n${prompt.previousFingerprintSha256}\n\nNew SHA-256 fingerprint:\n${prompt.fingerprintSha256}"
+          }
         Text(
-          "First-time TLS connection.\n\nVerify this SHA-256 fingerprint before trusting:\n${prompt.fingerprintSha256}",
+          message,
           style = mobileCallout,
           color = mobileText,
         )

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -497,8 +497,14 @@ fun OnboardingFlow(
       containerColor = onboardingSurface,
       title = { Text("Trust this gateway?", style = onboardingHeadlineStyle, color = onboardingText) },
       text = {
+        val message =
+          if (prompt.previousFingerprintSha256.isNullOrBlank()) {
+            "First-time TLS connection.\n\nVerify this SHA-256 fingerprint before trusting:\n${prompt.fingerprintSha256}"
+          } else {
+            "The gateway TLS certificate changed. Only continue if you expected this.\n\nOld SHA-256 fingerprint:\n${prompt.previousFingerprintSha256}\n\nNew SHA-256 fingerprint:\n${prompt.fingerprintSha256}"
+          }
         Text(
-          "First-time TLS connection.\n\nVerify this SHA-256 fingerprint before trusting:\n${prompt.fingerprintSha256}",
+          message,
           style = onboardingCalloutStyle,
           color = onboardingText,
         )

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -10,6 +10,7 @@ import ai.openclaw.app.node.InvokeDispatcher
 import ai.openclaw.app.protocol.OpenClawTalkCommand
 import ai.openclaw.app.voice.TalkModeManager
 import android.Manifest
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
@@ -153,7 +154,7 @@ class GatewayBootstrapAuthTest {
         NodeRuntime(
           app,
           prefs,
-          tlsFingerprintProbe = { _, _ -> GatewayTlsProbeResult(fingerprintSha256 = "fp-1") },
+          tlsFingerprintProbe = { _, _ -> GatewayTlsProbeResult(fingerprintSha256 = "fp:1") },
         )
       val endpoint = GatewayEndpoint.manual(host = "gateway.example", port = 18789)
       val explicitAuth =
@@ -169,9 +170,91 @@ class GatewayBootstrapAuthTest {
 
       runtime.acceptGatewayTrustPrompt()
 
-      assertEquals("fp-1", prefs.loadGatewayTlsFingerprint(endpoint.stableId))
-      assertEquals("setup-bootstrap-token", desiredBootstrapToken(runtime, "nodeSession"))
+      assertEquals("f1", prefs.loadGatewayTlsFingerprint(endpoint.stableId))
+      assertEquals("setup-bootstrap-token", waitForDesiredBootstrapToken(runtime, "nodeSession"))
       assertNull(desiredBootstrapToken(runtime, "operatorSession"))
+    }
+
+  @Test
+  fun connect_promptsBeforeReplacingChangedTlsFingerprint() =
+    runBlocking {
+      val app = RuntimeEnvironment.getApplication()
+      val securePrefs =
+        app.getSharedPreferences(
+          "openclaw.node.secure.test.${UUID.randomUUID()}",
+          android.content.Context.MODE_PRIVATE,
+        )
+      val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
+      val endpoint = GatewayEndpoint.manual(host = "gateway.example", port = 18789)
+      prefs.saveGatewayTlsFingerprint(endpoint.stableId, "sha256:aa:aa:aa:aa")
+      val runtime =
+        NodeRuntime(
+          app,
+          prefs,
+          tlsFingerprintProbe = { _, _ -> GatewayTlsProbeResult(fingerprintSha256 = "sha256:bb:bb:bb:bb") },
+        )
+
+      runtime.connect(
+        endpoint,
+        NodeRuntime.GatewayConnectAuth(token = "shared-token", bootstrapToken = null, password = null),
+      )
+
+      val prompt = waitForGatewayTrustPrompt(runtime)
+      assertEquals("aaaaaaaa", prompt.previousFingerprintSha256)
+      assertEquals("bbbbbbbb", prompt.fingerprintSha256)
+      assertEquals("sha256:aa:aa:aa:aa", prefs.loadGatewayTlsFingerprint(endpoint.stableId))
+
+      runtime.declineGatewayTrustPrompt()
+
+      assertEquals("sha256:aa:aa:aa:aa", prefs.loadGatewayTlsFingerprint(endpoint.stableId))
+
+      runtime.connect(
+        endpoint,
+        NodeRuntime.GatewayConnectAuth(token = "shared-token", bootstrapToken = null, password = null),
+      )
+      waitForGatewayTrustPrompt(runtime)
+      runtime.acceptGatewayTrustPrompt()
+
+      assertEquals("bbbbbbbb", prefs.loadGatewayTlsFingerprint(endpoint.stableId))
+    }
+
+  @Test
+  fun connect_ignoresStaleTlsProbeAfterDisconnect() =
+    runBlocking {
+      val app = RuntimeEnvironment.getApplication()
+      val securePrefs =
+        app.getSharedPreferences(
+          "openclaw.node.secure.test.${UUID.randomUUID()}",
+          android.content.Context.MODE_PRIVATE,
+        )
+      val prefs = SecurePrefs(app, securePrefsOverride = securePrefs)
+      val endpoint = GatewayEndpoint.manual(host = "gateway.example", port = 18789)
+      prefs.saveGatewayTlsFingerprint(endpoint.stableId, "aaaaaaaa")
+      val probeStarted = CompletableDeferred<Unit>()
+      val probeResult = CompletableDeferred<GatewayTlsProbeResult>()
+      val runtime =
+        NodeRuntime(
+          app,
+          prefs,
+          tlsFingerprintProbe = { _, _ ->
+            probeStarted.complete(Unit)
+            probeResult.await()
+          },
+        )
+
+      runtime.connect(
+        endpoint,
+        NodeRuntime.GatewayConnectAuth(token = "shared-token", bootstrapToken = null, password = null),
+      )
+      probeStarted.await()
+
+      runtime.disconnect()
+      probeResult.complete(GatewayTlsProbeResult(fingerprintSha256 = "aaaaaaaa"))
+      Thread.sleep(100)
+
+      assertNull(runtime.pendingGatewayTrust.value)
+      assertNull(desiredBootstrapToken(runtime, "nodeSession"))
+      assertEquals("aaaaaaaa", prefs.loadGatewayTlsFingerprint(endpoint.stableId))
     }
 
   @Test
@@ -267,6 +350,21 @@ class GatewayBootstrapAuthTest {
     val session = readField<GatewaySession>(runtime, sessionFieldName)
     val desired = readField<Any?>(session, "desired") ?: return null
     return readField(desired, "bootstrapToken")
+  }
+
+  private fun waitForDesiredBootstrapToken(
+    runtime: NodeRuntime,
+    sessionFieldName: String,
+  ): String {
+    var lastObserved: String? = null
+    repeat(50) {
+      desiredBootstrapToken(runtime, sessionFieldName)?.let { token ->
+        lastObserved = token
+        return token
+      }
+      Thread.sleep(10)
+    }
+    error("Expected desired bootstrap token for $sessionFieldName; last observed=$lastObserved")
   }
 
   private fun <T> readField(


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: Android stored a Gateway TLS certificate thumbprint and hard-failed when the Gateway presented a different certificate.
- Why it matters: Expected Gateway certificate rotations left users stuck offline with no way to inspect or accept the new thumbprint from the app.
- What changed: Android now probes the presented Gateway certificate on thumbprint mismatch, shows the old and new SHA-256 fingerprints, and lets the user accept the replacement or keep the old pin.
- What did NOT change (scope boundary): Initial onboarding pin capture, Gateway TLS behavior, and non-Android clients are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count. Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

- Behavior or issue addressed: Android TLS pin mismatch after the Gateway certificate thumbprint changes.
- Real environment tested: Android play-debug build installed on a Samsung SM-S942B connected to a real OpenClaw Gateway.
- Exact steps or command run after this patch: Installed the play-debug APK, triggered a changed Gateway TLS thumbprint during connection, and accepted the replacement prompt.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Screenshot attached below in the Evidence section.
- Observed result after fix: The app displayed the old and new SHA-256 thumbprints and continued after accepting the new thumbprint.
- What was not tested: Other Android variants, macOS/iOS clients, and non-Gateway TLS endpoints.
- Before evidence (optional but encouraged): N/A.

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: Android treated any stored Gateway TLS pin mismatch as terminal, even when the presented certificate could be inspected and intentionally accepted by the user.
- Missing detection / guardrail: There was no user-mediated recovery flow for expected Gateway certificate rotations.
- Contributing context (if known): Gateway endpoints can legitimately rotate certificates while the Android app still holds the previous thumbprint.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt`
- Scenario the test should lock in: A changed stored TLS pin probes the Gateway certificate, exposes old/new fingerprints to the UI callback, and persists the replacement only when accepted.
- Why this is the smallest reliable guardrail: The mismatch recovery decision is local Android Gateway bootstrap behavior and can be covered without a full device or Gateway process.
- Existing test that already covers this (if any): New coverage in `GatewayBootstrapAuthTest`.

## User-visible / Behavior Changes

Android users now see a confirmation prompt when their stored Gateway TLS thumbprint differs from the certificate currently presented by the Gateway. Accepting updates the stored thumbprint and continues; denying keeps the previous thumbprint and leaves the connection blocked.

## Diagram (if applicable)

```text
Before:
[Gateway certificate rotates] -> [Android detects pin mismatch] -> [connection fails]

After:
[Gateway certificate rotates] -> [Android shows old/new thumbprints] -> [user accepts] -> [stored pin updates] -> [connection continues]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) Yes
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: On pin mismatch, Android performs a bounded certificate probe to the already configured Gateway URL so it can show the presented certificate fingerprint. The old pin remains enforced unless the user explicitly accepts the new fingerprint.

## Repro + Verification

### Environment

- OS: Android on Samsung SM-S942B; macOS development host
- Runtime/container: Android play-debug build
- Model/provider: N/A
- Integration/channel (if any): OpenClaw Android app connecting to Gateway
- Relevant config (redacted): Existing paired Gateway configuration with stored TLS thumbprint

### Steps

1. Pair Android with a Gateway and store the Gateway TLS thumbprint.
2. Present a different Gateway certificate thumbprint for the same Gateway URL.
3. Open the Android app and connect to the Gateway.
4. Accept the changed thumbprint prompt.

### Expected

- Android shows both old and new SHA-256 thumbprints and only replaces the stored pin after explicit acceptance.

### Actual

- Android shows both old and new SHA-256 thumbprints and continues after accepting the replacement.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

Screenshot: 
<img width="270" alt="tls" src="https://github.com/user-attachments/assets/59696337-b829-4e8b-993d-8942e845c864" />


## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Changed Gateway TLS thumbprint prompt displays old/new fingerprints; accepting the prompt allows the app to continue.
- Edge cases checked: Denial path keeps the existing pin; acceptance path stores the new pin; missing certificate probe keeps the mismatch as a failure.
- What you did **not** verify: Release build signing, every Android product flavor, or non-Android clients.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: A user could accept an unexpected certificate if they do not compare fingerprints carefully.
  - Mitigation: The prompt shows both old and new SHA-256 fingerprints and leaves the old pin in place unless the user explicitly accepts.
