### PR TITLE
fix(failover): classify Moonshot balance 429 as billing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ Docs: https://docs.openclaw.ai
 - Browser plugin: trust managed Chrome CDP diagnostics when launch HTTP probes race cold-start readiness, avoiding false startup failures. Fixes #82904. (#82986) Thanks @kmanan and @hclsys.
 - Android: prompt before replacing a changed Gateway TLS thumbprint, showing the old and new SHA-256 fingerprints so users can accept expected certificate rotations instead of hard failing on pin mismatch. (#83077) Thanks @sliekens.
 - CLI/status: render extra gateway-like service diagnostics as warning/info output instead of error output. Fixes #46930. (#82922) thanks @giodl73-repo.
+- Agents/failover: classify Moonshot/Kimi exhausted-balance HTTP 429 payloads as billing instead of generic rate limits, preserving billing guidance and fallback behavior. Fixes #43447. (#83079) Thanks @leno23.
 
 ## 2026.5.17
 

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -21,6 +21,9 @@ const GEMINI_RESOURCE_EXHAUSTED_MESSAGE =
   "RESOURCE_EXHAUSTED: Resource has been exhausted (e.g. check quota).";
 // OpenRouter 402 billing example: https://openrouter.ai/docs/api-reference/errors
 const OPENROUTER_CREDITS_MESSAGE = "Payment Required: insufficient credits";
+// Issue-backed Moonshot/Kimi exhausted-balance shape surfaced under HTTP 429 (#43447).
+const MOONSHOT_INSUFFICIENT_BALANCE_429_PAYLOAD =
+  '{"error":{"type":"rate_limit_reached","message":"Insufficient account balance. Please recharge your Moonshot account."}}';
 const OPENROUTER_MODEL_NOT_FOUND_PAYLOAD =
   '{"error":{"message":"Healer Alpha was a stealth model revealed on March 18th as an early testing version of MiMo-V2-Omni. Find it here: https://openrouter.ai/xiaomi/mimo-v2-omni","code":404},"user_id":"user_33GTyP8uDSYYbaeBO48AGHXyuMC"}';
 const TOGETHER_MONTHLY_SPEND_CAP_MESSAGE =
@@ -291,6 +294,46 @@ describe("failover-error", () => {
         message: GROQ_SERVICE_UNAVAILABLE_MESSAGE,
       }),
     ).toBe("overloaded");
+  });
+
+  it("lets Moonshot/Kimi billing-shaped 429 payloads win over generic rate limit status", () => {
+    expect(
+      resolveFailoverReasonFromError({
+        provider: "moonshot",
+        status: 429,
+        message: MOONSHOT_INSUFFICIENT_BALANCE_429_PAYLOAD,
+      }),
+    ).toBe("billing");
+    expect(
+      resolveFailoverReasonFromError(
+        {
+          status: 429,
+          message: MOONSHOT_INSUFFICIENT_BALANCE_429_PAYLOAD,
+        },
+        "kimi-claw",
+      ),
+    ).toBe("billing");
+    expect(
+      resolveFailoverReasonFromError({
+        provider: "moonshot",
+        status: 429,
+        message: OPENAI_RATE_LIMIT_MESSAGE,
+      }),
+    ).toBe("rate_limit");
+    expect(
+      resolveFailoverReasonFromError({
+        provider: "openai",
+        status: 429,
+        message: MOONSHOT_INSUFFICIENT_BALANCE_429_PAYLOAD,
+      }),
+    ).toBe("rate_limit");
+    expect(
+      classifyFailoverSignal({
+        provider: "moonshot",
+        status: 429,
+        message: MOONSHOT_INSUFFICIENT_BALANCE_429_PAYLOAD,
+      }),
+    ).toEqual({ kind: "reason", reason: "billing" });
   });
 
   it("classifies OpenRouter no-endpoints 404s as model_not_found", () => {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -652,10 +652,11 @@ function classifyFailoverClassificationFromHttpStatus(
   }
   if (status === 429) {
     if (
-      messageReason === "billing" &&
-      (isProvider(provider, "moonshot") || isProvider(provider, "kimi"))
+      message &&
+      (isProvider(provider, "moonshot") || isProvider(provider, "kimi")) &&
+      isBillingErrorMessage(message)
     ) {
-      return messageClassification;
+      return toReasonClassification("billing");
     }
     return toReasonClassification("rate_limit");
   }

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -612,7 +612,13 @@ export function classifyFailoverReasonFromHttpStatus(
     ? classifyFailoverClassificationFromMessage(message, opts?.provider)
     : null;
   return failoverReasonFromClassification(
-    classifyFailoverClassificationFromHttpStatus(status, message, messageClassification, status),
+    classifyFailoverClassificationFromHttpStatus(
+      status,
+      message,
+      messageClassification,
+      status,
+      opts?.provider,
+    ),
   );
 }
 
@@ -621,6 +627,7 @@ function classifyFailoverClassificationFromHttpStatus(
   message: string | undefined,
   messageClassification: FailoverClassification | null,
   explicitStatus: number | undefined,
+  provider?: string,
 ): FailoverClassification | null {
   const messageReason = failoverReasonFromClassification(messageClassification);
   if (typeof status !== "number" || !Number.isFinite(status)) {
@@ -644,6 +651,12 @@ function classifyFailoverClassificationFromHttpStatus(
     return toReasonClassification(classify402Message(message));
   }
   if (status === 429) {
+    if (
+      messageReason === "billing" &&
+      (isProvider(provider, "moonshot") || isProvider(provider, "kimi"))
+    ) {
+      return messageClassification;
+    }
     return toReasonClassification("rate_limit");
   }
   if (status === 401 || status === 403) {
@@ -910,6 +923,7 @@ export function classifyFailoverSignal(signal: FailoverSignal): FailoverClassifi
     signal.message,
     messageClassification,
     signal.status,
+    signal.provider,
   );
   if (statusClassification) {
     return statusClassification;


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- Fixes Moonshot/Kimi exhausted-balance responses that arrive as HTTP 429 from being classified as generic `rate_limit`.
- Keeps the override narrow by checking high-confidence billing text only for Moonshot/Kimi before the generic HTTP 429 status rule returns `rate_limit`.
- Keeps the existing regression coverage for Moonshot/Kimi balance-shaped 429 payloads, ordinary Moonshot 429 rate limits, and non-Moonshot providers.

## Test Plan
- `node --import tsx ./tmp-openclaw-pr-83079-green-probe.mjs`
- `git diff --check`
- Attempted: `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=180000 node scripts/run-vitest.mjs run src/agents/failover-error.test.ts -t "lets Moonshot/Kimi billing-shaped 429 payloads win over generic rate limit status"` (local runner stalled before test output; see Real behavior proof caveat)

## Real behavior proof
Behavior addressed: a Moonshot/Kimi response with HTTP 429 and an `Insufficient account balance` / `Please recharge` payload should surface as `billing`, not `rate_limit`, so OpenClaw can show billing/recharge guidance instead of rate-limit behavior.

Real environment tested: local OpenClaw source checkout using Node.js v22.18.0 after applying commit `14b33d7160f964a2f5606d5e37a8973bef216577` on this PR branch. No live Moonshot credentials were used.

Exact steps or command run after this patch: created a temporary repo-root probe that imports `src/agents/failover-error.ts` and `src/agents/pi-embedded-helpers/errors.ts`, then ran `node --import tsx ./tmp-openclaw-pr-83079-green-probe.mjs`; also ran `git diff --check`.

Evidence after fix:
```text
$ node --import tsx ./tmp-openclaw-pr-83079-green-probe.mjs
{"cases":[["moonshot balance 429","billing","billing"],["kimi provider hint balance 429","billing","billing"],["moonshot ordinary 429","rate_limit","rate_limit"],["openai balance-shaped 429","rate_limit","rate_limit"]],"signal":{"kind":"reason","reason":"billing"}}

$ git diff --check
(passed with no output)
```

Observed result after fix: Moonshot and Kimi billing-shaped 429 payloads resolve to `billing`; an ordinary Moonshot 429 remains `rate_limit`; the same balance-shaped 429 payload from `openai` remains `rate_limit`; `classifyFailoverSignal()` returns `{ kind: "reason", reason: "billing" }` for the Moonshot balance-shaped 429 signal.

What was not tested: live Moonshot/Kimi depleted-account behavior was not tested because this run has no provider credentials. The focused Vitest command stalled locally before producing test output (`no output for 180000ms; terminating stalled Vitest process group`), so CI is expected to provide the official runner result.

## Risk / Notes
- Scope is intentionally narrow: only Moonshot/Kimi billing-shaped 429 responses are allowed to override the generic 429 → `rate_limit` rule.
- The fix addresses the matcher-order review finding by checking `isBillingErrorMessage(message)` directly inside the provider-specific 429 branch, instead of depending on the earlier message classification.

Fixes #43447
