### PR TITLE
docs(usage): clarify message-tool footer behavior (#83071)

### DIFF
--- a/docs/concepts/usage-tracking.md
+++ b/docs/concepts/usage-tracking.md
@@ -21,7 +21,8 @@ title: "Usage tracking"
 ## Where it shows up
 
 - `/status` in chats: emoji-rich status card with session tokens + estimated cost (API key only). Provider usage shows for the **current model provider** when available as a normalized `X% left` window.
-- `/usage off|tokens|full` in chats: per-response usage footer (OAuth shows tokens only).
+- `/usage off|tokens|full` in chats: per-response usage footer for normal final replies (OAuth shows tokens only).
+  Explicit message-tool sends, including tool-only group/channel visible replies, do not receive an automatic footer.
 - `/usage cost` in chats: local cost summary aggregated from OpenClaw session logs.
 - CLI: `openclaw status --usage` prints a full per-provider breakdown.
 - CLI: `openclaw channels list` prints the same usage snapshot alongside provider config (use `--no-usage` to skip).

--- a/docs/gateway/config-channels.md
+++ b/docs/gateway/config-channels.md
@@ -789,6 +789,11 @@ Group messages default to **require mention** (metadata mention or safe regex pa
 
 Visible replies are controlled separately. Group/channel rooms default to `messages.groupChat.visibleReplies: "message_tool"`: OpenClaw still processes the turn and asks the agent to use `message(action=send)` for visible room output. If the model returns final text without calling the message tool, that final text stays private and the gateway verbose log records suppressed payload metadata. Set `"automatic"` when you want all visible group replies to use the legacy final-reply path. To apply the same tool-only visible-reply behavior to direct chats too, set `messages.visibleReplies: "message_tool"`; the Codex harness also uses that tool-only behavior as its unset direct-chat default.
 
+Usage footers from `/usage tokens` or `/usage full` are appended to normal
+final replies, not to explicit message-tool sends. In the default tool-only
+group/channel mode, the visible `message(action=send)` output is delivered
+without an automatic usage footer.
+
 Tool-only visible replies require a model/runtime that reliably calls tools. If
 the session log shows assistant text with `didSendViaMessagingTool: false`, the
 model produced private final text instead of calling the message tool. Switch

--- a/docs/reference/api-usage-costs.md
+++ b/docs/reference/api-usage-costs.md
@@ -23,8 +23,12 @@ OpenClaw features that can generate provider usage or paid API calls.
 
 **Per-message cost footer**
 
-- `/usage full` appends a usage footer to every reply, including **estimated cost** (API-key only).
+- `/usage full` appends a usage footer to normal final replies, including **estimated cost** (API-key only).
 - `/usage tokens` shows tokens only; subscription-style OAuth/token and CLI flows hide dollar cost.
+- Explicit message-tool sends do not get an automatic usage footer. In
+  group/channel rooms that use `messages.groupChat.visibleReplies:
+"message_tool"`, the visible message-tool output is delivered without the
+  final-reply footer.
 - Gemini CLI note: when the CLI returns JSON output, OpenClaw reads usage from
   `stats`, normalizes `stats.cached` into `cacheRead`, and derives input tokens
   from `stats.input_tokens - stats.cached` when needed.

--- a/docs/reference/token-use.md
+++ b/docs/reference/token-use.md
@@ -63,9 +63,12 @@ Use these in chat:
 
 - `/status` → **emoji-rich status card** with the session model, context usage,
   last response input/output tokens, and **estimated cost** (API key only).
-- `/usage off|tokens|full` → appends a **per-response usage footer** to every reply.
+- `/usage off|tokens|full` → appends a **per-response usage footer** to normal final replies.
   - Persists per session (stored as `responseUsage`).
   - OAuth auth **hides cost** (tokens only).
+  - Message-tool sends, including group/topic visible replies when
+    `messages.groupChat.visibleReplies: "message_tool"`, do not receive an
+    automatic usage footer.
 - `/usage cost` → shows a local cost summary from OpenClaw session logs.
 
 Other surfaces:


### PR DESCRIPTION
## Summary

Fixes #83071.

Clarifies that `/usage tokens` and `/usage full` append usage footers to normal final replies, not to explicit message-tool sends. This covers the default group/channel `messages.groupChat.visibleReplies: "message_tool"` path where the visible output is delivered through `message(action=send)`.

## Real behavior proof

- Behavior or issue addressed: The public docs said `/usage` appends a footer to every reply, while Telegram/forum topic visible replies in `message_tool` mode are explicit message-tool sends and do not receive the final-reply footer.
- Real environment tested: Local OpenClaw docs tree on the branch `docs-usage-footer-message-tool-83071`, with the same documentation files that users read under `docs/reference`, `docs/concepts`, and `docs/gateway`.
- Exact steps or command run after this patch: `pnpm check:docs` and `pnpm check:changed`
- Evidence after fix: Copied terminal output from the live docs checks:

```text
Docs formatting clean (631 files).
Summary: 0 error(s)
Docs MDX check passed (646 files, 2727ms).
checked_internal_links=4415
broken_links=0
[check:changed] lanes=docs-only
```

- Observed result after fix: The changed docs now explicitly say message-tool sends, including tool-only group/channel visible replies, do not receive an automatic usage footer.
- What was not tested: No Telegram runtime was exercised; this is a documentation clarification for the source-reproduced behavior rather than a runtime behavior change.

## Audit

- Audit A (existing helper): no predicate/validator/classifier introduced; docs-only clarification.
- Audit B (shared callers): no shared helper contract changed; touched docs only.
- Audit C (broader rival): no open or closed PR found for #83071 or the Telegram forum-topic usage-footer message-tool wording.

## Tests

- `pnpm check:docs` -> passed
- `pnpm check:changed` -> passed