### PR TITLE
fix(channels): protect channel config repair paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,7 +140,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Codex/app-server: cover `/btw` side-question native hooks and app-server command approvals without relying on unsupported turn-scoped hook config. (#82559) Thanks @Kaspre.
-- Gateway/channels: reject login/start for missing or disabled channel config, restart when no-op channel enablement requires a Gateway reload, and fail closed on stale writes that would drop channel or elevated access policy. Fixes #77508, #78404, #79738. Thanks @xooid, @sukhdeepjohar, and @heroeemprendedor.
+- Gateway/channels: reject login/start for missing or disabled channel config, restart when no-op channel enablement requires a Gateway reload, and fail closed on stale writes that would drop channel config or elevated access policy. Fixes #77508, #78404, #79738. Thanks @xooid, @sukhdeepjohar, and @heroeemprendedor.
 - Gateway/Docker: fail closed for non-loopback gateway starts without explicit shared-secret or trusted-proxy auth, and stop the image default command from bypassing config validation. Fixes #82865. (#82866) Thanks @coygeek.
 - Agents/followups: route queued followup turns through CLI runtime backends instead of embedded harness lookup, preventing `claude-cli`/`google-gemini-cli` followups from failing before delivery. Fixes #82847. (#82857) Thanks @hclsys.
 - CLI/sessions: let `openclaw sessions cleanup --fix-missing` prune malformed rows with unresolvable transcript metadata instead of throwing. Fixes #80970. (#82745) Thanks @IWhatsskill.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Codex/app-server: cover `/btw` side-question native hooks and app-server command approvals without relying on unsupported turn-scoped hook config. (#82559) Thanks @Kaspre.
+- Gateway/channels: reject login/start for missing or disabled channel config, restart when no-op channel enablement requires a Gateway reload, and fail closed on stale writes that would drop channel or elevated access policy. Fixes #77508, #78404, #79738. Thanks @xooid, @sukhdeepjohar, and @heroeemprendedor.
 - Gateway/Docker: fail closed for non-loopback gateway starts without explicit shared-secret or trusted-proxy auth, and stop the image default command from bypassing config validation. Fixes #82865. (#82866) Thanks @coygeek.
 - Agents/followups: route queued followup turns through CLI runtime backends instead of embedded harness lookup, preventing `claude-cli`/`google-gemini-cli` followups from failing before delivery. Fixes #82847. (#82857) Thanks @hclsys.
 - CLI/sessions: let `openclaw sessions cleanup --fix-missing` prune malformed rows with unresolvable transcript metadata instead of throwing. Fixes #80970. (#82745) Thanks @IWhatsskill.

--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -11,13 +11,21 @@ Status: production-ready via WhatsApp Web (Baileys). Gateway owns linked session
 
 - Onboarding (`openclaw onboard`) and `openclaw channels add --channel whatsapp`
   prompt to install the WhatsApp plugin the first time you select it.
-- `openclaw channels login --channel whatsapp` also offers the install flow when
-  the plugin is not present yet.
+- `openclaw channels login --channel whatsapp` can offer the plugin install
+  flow when the plugin is not present yet, but it does not create or enable the
+  `channels.whatsapp` config block.
 - Dev channel + git checkout: defaults to the local plugin path.
 - Stable/Beta: installs the official `@openclaw/whatsapp` plugin from ClawHub
   first, with npm as the fallback.
 - The WhatsApp runtime is distributed outside the core OpenClaw npm package so
   WhatsApp-specific runtime dependencies stay with the external plugin.
+- `openclaw channels login --channel whatsapp` requires an existing enabled
+  `channels.whatsapp` config block. Use `openclaw channels add --channel whatsapp`
+  first when starting from an empty config.
+- If you flip `channels.whatsapp.enabled` from `false` to `true` while the
+  Gateway is already running, let hybrid/default reload restart the Gateway or
+  restart it manually. Pure hot-reload mode logs the required restart but does
+  not load the newly enabled WhatsApp runtime.
 
 Manual install stays available:
 

--- a/docs/cli/channels.md
+++ b/docs/cli/channels.md
@@ -105,6 +105,7 @@ openclaw channels logout --channel whatsapp
 
 - `channels login` supports `--verbose`.
 - `channels login` and `logout` can infer the channel when only one supported login target is configured.
+- `channels login --channel <id>` requires `channels.<id>` to exist and be enabled. Use `openclaw channels add --channel <id>` or edit config first; login stores channel auth but does not create the channel config block.
 - `channels logout` prefers the live Gateway path when reachable, so logout stops any active listener before clearing channel auth state. If a local Gateway is not reachable, it falls back to local auth cleanup.
 - Run `channels login` from a terminal on the gateway host. Agent `exec` blocks this interactive login flow; channel-native agent login tools, such as `whatsapp_login`, should be used from chat when available.
 

--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -423,6 +423,8 @@ openclaw config set channels.discord.token \
 
 `openclaw config set` and other OpenClaw-owned config writers validate the full post-change config before committing it to disk. If the new payload fails schema validation or looks like a destructive clobber, the active config is left alone and the rejected payload is saved beside it as `openclaw.json.rejected.*`.
 
+Config writes also fail closed when a stale Gateway/runtime writer would remove or widen owner, command, elevated-tool, or channel sender allowlists. Make intentional allowlist changes through explicit config edits so the write records the touched path.
+
 <Warning>
 The active config path must be a regular file. Symlinked `openclaw.json` layouts are unsupported for writes; use `OPENCLAW_CONFIG_PATH` to point directly at the real file instead.
 </Warning>
@@ -443,7 +445,7 @@ ls -lt "$CONFIG".rejected.* 2>/dev/null | head
 openclaw config validate
 ```
 
-Direct editor writes are still allowed, but the running Gateway treats them as untrusted until they validate. Invalid direct edits fail startup or are skipped by hot reload; Gateway does not rewrite `openclaw.json`. Run `openclaw doctor --fix` to repair prefixed/clobbered config or restore the last-known-good copy. See [Gateway troubleshooting](/gateway/troubleshooting#gateway-rejected-invalid-config).
+Direct editor writes are still allowed, but the running Gateway treats them as untrusted until they validate. Invalid direct edits fail startup or are skipped by hot reload; Gateway does not rewrite `openclaw.json`. Enabling a previously disabled channel can require a Gateway restart; `gateway.reload.mode: "hot"` logs the restart requirement instead of restarting. Run `openclaw doctor --fix` to repair prefixed/clobbered config or restore the last-known-good copy. See [Gateway troubleshooting](/gateway/troubleshooting#gateway-rejected-invalid-config).
 
 Whole-file recovery is reserved for doctor repair. Plugin schema changes or `minHostVersion` skew stay loud instead of rolling back unrelated user settings such as models, providers, auth profiles, channels, gateway exposure, tools, memory, browser, or cron config.
 

--- a/extensions/feishu/src/channel.auth-writeback.test.ts
+++ b/extensions/feishu/src/channel.auth-writeback.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import type { ClawdbotConfig } from "./channel-runtime-api.js";
+import { resolveFeishuLoginExplicitSetPaths } from "./channel.js";
+
+describe("Feishu auth writeback", () => {
+  it("marks only the account fields touched by login as explicit", () => {
+    const previousConfig = {
+      channels: {
+        feishu: {
+          enabled: true,
+          accounts: {
+            primary: {
+              enabled: true,
+              appId: "old-app",
+              allowFrom: ["ou_primary"],
+            },
+            untouched: {
+              enabled: true,
+              appId: "untouched-app",
+              allowFrom: ["ou_untouched"],
+            },
+          },
+        },
+      },
+    } satisfies ClawdbotConfig;
+    const nextConfig = structuredClone(previousConfig);
+    nextConfig.channels.feishu.accounts.primary.appId = "new-app";
+
+    const explicitSetPaths = resolveFeishuLoginExplicitSetPaths({
+      previousConfig,
+      nextConfig,
+    });
+
+    expect(explicitSetPaths).toContainEqual(["channels", "feishu", "accounts", "primary", "appId"]);
+    expect(explicitSetPaths).not.toContainEqual(["channels", "feishu", "accounts", "untouched"]);
+    expect(explicitSetPaths).not.toContainEqual([
+      "channels",
+      "feishu",
+      "accounts",
+      "untouched",
+      "allowFrom",
+    ]);
+  });
+
+  it("marks new account leaf fields without blessing the whole account subtree", () => {
+    const previousConfig = {
+      channels: {
+        feishu: {
+          enabled: true,
+          accounts: {
+            existing: {
+              enabled: true,
+              allowFrom: ["ou_existing"],
+            },
+          },
+        },
+      },
+    } satisfies ClawdbotConfig;
+    const nextConfig = {
+      channels: {
+        feishu: {
+          enabled: true,
+          accounts: {
+            ...previousConfig.channels.feishu.accounts,
+            fresh: {
+              enabled: true,
+              appId: "fresh-app",
+              allowFrom: ["ou_fresh"],
+            },
+          },
+        },
+      },
+    } satisfies ClawdbotConfig;
+
+    const explicitSetPaths = resolveFeishuLoginExplicitSetPaths({
+      previousConfig,
+      nextConfig,
+    });
+
+    expect(explicitSetPaths).toEqual(
+      expect.arrayContaining([
+        ["channels", "feishu", "accounts", "fresh", "enabled"],
+        ["channels", "feishu", "accounts", "fresh", "appId"],
+        ["channels", "feishu", "accounts", "fresh", "allowFrom"],
+      ]),
+    );
+    expect(explicitSetPaths).not.toContainEqual(["channels", "feishu", "accounts", "fresh"]);
+    expect(explicitSetPaths).not.toContainEqual([
+      "channels",
+      "feishu",
+      "accounts",
+      "existing",
+      "allowFrom",
+    ]);
+  });
+});

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -1240,8 +1240,29 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
           const prompter = createClackPrompter();
           const nextCfg = await runFeishuLogin({ cfg, prompter });
           if (nextCfg !== cfg) {
+            const fields = [
+              "appId",
+              "appSecret",
+              "connectionMode",
+              "domain",
+              "dmPolicy",
+              "allowFrom",
+              "groupPolicy",
+              "requireMention",
+            ];
+            const accounts = {
+              ...((cfg.channels?.feishu?.accounts ?? {}) as Record<string, unknown>),
+              ...((nextCfg.channels?.feishu?.accounts ?? {}) as Record<string, unknown>),
+            };
+            const explicitSetPaths = [
+              ...fields.map((field) => ["channels", "feishu", field]),
+              ...Object.keys(accounts).flatMap((accountId) =>
+                fields.map((field) => ["channels", "feishu", "accounts", accountId, field]),
+              ),
+            ];
             await replaceConfigFile({
               nextConfig: nextCfg,
+              writeOptions: { explicitSetPaths },
               afterWrite: { mode: "auto" },
             });
           }

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -1254,8 +1254,23 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
               ...((cfg.channels?.feishu?.accounts ?? {}) as Record<string, unknown>),
               ...((nextCfg.channels?.feishu?.accounts ?? {}) as Record<string, unknown>),
             };
+            const previousAccounts = (cfg.channels?.feishu?.accounts ?? {}) as Record<
+              string,
+              unknown
+            >;
+            const nextAccounts = (nextCfg.channels?.feishu?.accounts ?? {}) as Record<
+              string,
+              unknown
+            >;
             const explicitSetPaths = [
+              ...(nextCfg.channels?.feishu && !cfg.channels?.feishu
+                ? [["channels", "feishu"]]
+                : []),
               ...fields.map((field) => ["channels", "feishu", field]),
+              ...Object.keys(nextAccounts)
+                .filter((accountId) => isRecord(nextAccounts[accountId]))
+                .filter((accountId) => !isRecord(previousAccounts[accountId]))
+                .map((accountId) => ["channels", "feishu", "accounts", accountId]),
               ...Object.keys(accounts).flatMap((accountId) =>
                 fields.map((field) => ["channels", "feishu", "accounts", accountId, field]),
               ),

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -1,3 +1,4 @@
+import { isDeepStrictEqual } from "node:util";
 import { describeAccountSnapshot } from "openclaw/plugin-sdk/account-helpers";
 import { formatAllowFromLowercase } from "openclaw/plugin-sdk/allow-from";
 import {
@@ -105,6 +106,59 @@ function hasLegacyFeishuCardCommandValue(actionValue: unknown): boolean {
     (Boolean(typeof actionValue.command === "string" && actionValue.command.trim()) ||
       Boolean(typeof actionValue.text === "string" && actionValue.text.trim()))
   );
+}
+
+const FEISHU_LOGIN_CONFIG_FIELDS = [
+  "enabled",
+  "appId",
+  "appSecret",
+  "connectionMode",
+  "domain",
+  "dmPolicy",
+  "allowFrom",
+  "groupPolicy",
+  "requireMention",
+] as const;
+
+export function resolveFeishuLoginExplicitSetPaths(params: {
+  previousConfig: ClawdbotConfig;
+  nextConfig: ClawdbotConfig;
+}): string[][] {
+  const previousFeishu = params.previousConfig.channels?.feishu;
+  const nextFeishu = params.nextConfig.channels?.feishu;
+  if (!isRecord(nextFeishu)) {
+    return [];
+  }
+
+  const previousFeishuRecord = isRecord(previousFeishu) ? previousFeishu : {};
+  const paths: string[][] = [];
+  for (const field of FEISHU_LOGIN_CONFIG_FIELDS) {
+    if (!isDeepStrictEqual(previousFeishuRecord[field], nextFeishu[field])) {
+      paths.push(["channels", "feishu", field]);
+    }
+  }
+
+  const previousAccounts = isRecord(previousFeishuRecord.accounts)
+    ? previousFeishuRecord.accounts
+    : {};
+  const nextAccounts = isRecord(nextFeishu.accounts) ? nextFeishu.accounts : {};
+  const accountIds = new Set([...Object.keys(previousAccounts), ...Object.keys(nextAccounts)]);
+  for (const accountId of accountIds) {
+    const nextAccount = nextAccounts[accountId];
+    if (!isRecord(nextAccount)) {
+      continue;
+    }
+    const previousAccount = isRecord(previousAccounts[accountId])
+      ? previousAccounts[accountId]
+      : {};
+    for (const field of FEISHU_LOGIN_CONFIG_FIELDS) {
+      if (!isDeepStrictEqual(previousAccount[field], nextAccount[field])) {
+        paths.push(["channels", "feishu", "accounts", accountId, field]);
+      }
+    }
+  }
+
+  return paths;
 }
 
 function containsLegacyFeishuCardCommandValue(node: unknown): boolean {
@@ -1240,41 +1294,10 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
           const prompter = createClackPrompter();
           const nextCfg = await runFeishuLogin({ cfg, prompter });
           if (nextCfg !== cfg) {
-            const fields = [
-              "appId",
-              "appSecret",
-              "connectionMode",
-              "domain",
-              "dmPolicy",
-              "allowFrom",
-              "groupPolicy",
-              "requireMention",
-            ];
-            const accounts = {
-              ...((cfg.channels?.feishu?.accounts ?? {}) as Record<string, unknown>),
-              ...((nextCfg.channels?.feishu?.accounts ?? {}) as Record<string, unknown>),
-            };
-            const previousAccounts = (cfg.channels?.feishu?.accounts ?? {}) as Record<
-              string,
-              unknown
-            >;
-            const nextAccounts = (nextCfg.channels?.feishu?.accounts ?? {}) as Record<
-              string,
-              unknown
-            >;
-            const explicitSetPaths = [
-              ...(nextCfg.channels?.feishu && !cfg.channels?.feishu
-                ? [["channels", "feishu"]]
-                : []),
-              ...fields.map((field) => ["channels", "feishu", field]),
-              ...Object.keys(nextAccounts)
-                .filter((accountId) => isRecord(nextAccounts[accountId]))
-                .filter((accountId) => !isRecord(previousAccounts[accountId]))
-                .map((accountId) => ["channels", "feishu", "accounts", accountId]),
-              ...Object.keys(accounts).flatMap((accountId) =>
-                fields.map((field) => ["channels", "feishu", "accounts", accountId, field]),
-              ),
-            ];
+            const explicitSetPaths = resolveFeishuLoginExplicitSetPaths({
+              previousConfig: cfg,
+              nextConfig: nextCfg,
+            });
             await replaceConfigFile({
               nextConfig: nextCfg,
               writeOptions: { explicitSetPaths },

--- a/extensions/line/src/channel.logout.test.ts
+++ b/extensions/line/src/channel.logout.test.ts
@@ -91,6 +91,15 @@ describe("linePlugin gateway.logoutAccount", () => {
     expect(result.loggedOut).toBe(true);
     expect(mocks.replaceConfigFile).toHaveBeenCalledWith({
       nextConfig: {},
+      writeOptions: {
+        explicitSetPaths: expect.arrayContaining([
+          ["channels", "line"],
+          ["channels", "line", "tokenFile"],
+          ["channels", "line", "secretFile"],
+          ["channels", "line", "accounts", DEFAULT_ACCOUNT_ID, "tokenFile"],
+          ["channels", "line", "accounts", DEFAULT_ACCOUNT_ID, "secretFile"],
+        ]),
+      },
       afterWrite: { mode: "auto" },
     });
   });
@@ -117,6 +126,60 @@ describe("linePlugin gateway.logoutAccount", () => {
     expect(result.loggedOut).toBe(true);
     expect(mocks.replaceConfigFile).toHaveBeenCalledWith({
       nextConfig: {},
+      writeOptions: {
+        explicitSetPaths: expect.arrayContaining([
+          ["channels", "line"],
+          ["channels", "line", "accounts", "primary"],
+          ["channels", "line", "accounts", "primary", "tokenFile"],
+          ["channels", "line", "accounts", "primary", "secretFile"],
+        ]),
+      },
+      afterWrite: { mode: "auto" },
+    });
+  });
+
+  it("marks removed account path when other accounts remain", async () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        line: {
+          accounts: {
+            primary: {
+              tokenFile: "/tmp/token",
+              secretFile: "/tmp/secret",
+            },
+            standby: {
+              name: "Standby",
+            },
+          },
+        },
+      },
+    };
+    const { result, mocks } = await runLogoutScenario({
+      cfg,
+      accountId: "primary",
+    });
+
+    expect(result.cleared).toBe(true);
+    expect(result.loggedOut).toBe(true);
+    expect(mocks.replaceConfigFile).toHaveBeenCalledWith({
+      nextConfig: {
+        channels: {
+          line: {
+            accounts: {
+              standby: {
+                name: "Standby",
+              },
+            },
+          },
+        },
+      },
+      writeOptions: {
+        explicitSetPaths: expect.arrayContaining([
+          ["channels", "line", "accounts", "primary"],
+          ["channels", "line", "accounts", "primary", "tokenFile"],
+          ["channels", "line", "accounts", "primary", "secretFile"],
+        ]),
+      },
       afterWrite: { mode: "auto" },
     });
   });

--- a/extensions/line/src/gateway.ts
+++ b/extensions/line/src/gateway.ts
@@ -65,6 +65,8 @@ export const lineGatewayAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>[
     const nextLine = { ...lineConfig };
     let cleared = false;
     let changed = false;
+    let removedChannelBlock = false;
+    let removedAccountBlock = false;
 
     if (accountId === DEFAULT_ACCOUNT_ID) {
       if (
@@ -93,6 +95,7 @@ export const lineGatewayAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>[
       if (accountCleanup.cleared) {
         cleared = true;
       }
+      removedAccountBlock = !accountCleanup.nextAccounts?.[accountId];
       if (accountCleanup.nextAccounts) {
         nextLine.accounts = accountCleanup.nextAccounts;
       } else {
@@ -106,14 +109,32 @@ export const lineGatewayAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>[
       } else {
         const nextChannels = { ...nextCfg.channels };
         delete (nextChannels as Record<string, unknown>).line;
+        removedChannelBlock = true;
         if (Object.keys(nextChannels).length > 0) {
           nextCfg.channels = nextChannels;
         } else {
           delete nextCfg.channels;
         }
       }
+      const explicitSetPaths = [
+        ["channels", "line", "channelAccessToken"],
+        ["channels", "line", "channelSecret"],
+        ["channels", "line", "tokenFile"],
+        ["channels", "line", "secretFile"],
+        ["channels", "line", "accounts", accountId, "channelAccessToken"],
+        ["channels", "line", "accounts", accountId, "channelSecret"],
+        ["channels", "line", "accounts", accountId, "tokenFile"],
+        ["channels", "line", "accounts", accountId, "secretFile"],
+      ];
+      if (removedChannelBlock) {
+        explicitSetPaths.push(["channels", "line"]);
+      }
+      if (removedAccountBlock) {
+        explicitSetPaths.push(["channels", "line", "accounts", accountId]);
+      }
       await getLineRuntime().config.replaceConfigFile({
         nextConfig: nextCfg,
+        writeOptions: { explicitSetPaths },
         afterWrite: { mode: "auto" },
       });
     }

--- a/extensions/matrix/src/cli.ts
+++ b/extensions/matrix/src/cli.ts
@@ -327,6 +327,36 @@ async function addMatrixAccount(params: {
   }
   await runtime.config.replaceConfigFile({
     nextConfig: updated as never,
+    writeOptions: {
+      explicitSetPaths: [
+        ["channels", "matrix", "enabled"],
+        ["channels", "matrix", "name"],
+        ["channels", "matrix", "homeserver"],
+        ["channels", "matrix", "network", "dangerouslyAllowPrivateNetwork"],
+        ["channels", "matrix", "proxy"],
+        ["channels", "matrix", "userId"],
+        ["channels", "matrix", "accessToken"],
+        ["channels", "matrix", "password"],
+        ["channels", "matrix", "deviceId"],
+        ["channels", "matrix", "deviceName"],
+        ["channels", "matrix", "avatarUrl"],
+        ["channels", "matrix", "initialSyncLimit"],
+        ["channels", "matrix", "encryption"],
+        ["channels", "matrix", "accounts", accountId, "enabled"],
+        ["channels", "matrix", "accounts", accountId, "name"],
+        ["channels", "matrix", "accounts", accountId, "homeserver"],
+        ["channels", "matrix", "accounts", accountId, "network", "dangerouslyAllowPrivateNetwork"],
+        ["channels", "matrix", "accounts", accountId, "proxy"],
+        ["channels", "matrix", "accounts", accountId, "userId"],
+        ["channels", "matrix", "accounts", accountId, "accessToken"],
+        ["channels", "matrix", "accounts", accountId, "password"],
+        ["channels", "matrix", "accounts", accountId, "deviceId"],
+        ["channels", "matrix", "accounts", accountId, "deviceName"],
+        ["channels", "matrix", "accounts", accountId, "avatarUrl"],
+        ["channels", "matrix", "accounts", accountId, "initialSyncLimit"],
+        ["channels", "matrix", "accounts", accountId, "encryption"],
+      ],
+    },
     afterWrite: { mode: "auto" },
   });
   const accountConfig = resolveMatrixAccountConfig({ cfg: updated, accountId });
@@ -371,6 +401,12 @@ async function addMatrixAccount(params: {
         });
         await runtime.config.replaceConfigFile({
           nextConfig: withAvatar as never,
+          writeOptions: {
+            explicitSetPaths: [
+              ["channels", "matrix", "avatarUrl"],
+              ["channels", "matrix", "accounts", accountId, "avatarUrl"],
+            ],
+          },
           afterWrite: { mode: "auto" },
         });
         resolvedAvatarUrl = synced.resolvedAvatarUrl;
@@ -742,6 +778,12 @@ async function setupMatrixEncryption(params: {
   if (encryptionChanged) {
     await runtime.config.replaceConfigFile({
       nextConfig: updated as never,
+      writeOptions: {
+        explicitSetPaths: [
+          ["channels", "matrix", "encryption"],
+          ["channels", "matrix", "accounts", accountId, "encryption"],
+        ],
+      },
       afterWrite: { mode: "auto" },
     });
   }

--- a/extensions/matrix/src/matrix/monitor/index.ts
+++ b/extensions/matrix/src/matrix/monitor/index.ts
@@ -506,6 +506,14 @@ export async function monitorMatrixProvider(opts: MonitorMatrixOpts = {}): Promi
       replaceConfigFile: async (nextCfg) => {
         await core.config.replaceConfigFile({
           nextConfig: nextCfg,
+          writeOptions: {
+            explicitSetPaths: [
+              ["channels", "matrix", "name"],
+              ["channels", "matrix", "avatarUrl"],
+              ["channels", "matrix", "accounts", effectiveAccountId, "name"],
+              ["channels", "matrix", "accounts", effectiveAccountId, "avatarUrl"],
+            ],
+          },
           afterWrite: { mode: "auto" },
         });
       },

--- a/extensions/matrix/src/profile-update.ts
+++ b/extensions/matrix/src/profile-update.ts
@@ -52,6 +52,14 @@ export async function applyMatrixProfileUpdate(params: {
   });
   await runtime.config.replaceConfigFile({
     nextConfig: updated as never,
+    writeOptions: {
+      explicitSetPaths: [
+        ["channels", "matrix", "name"],
+        ["channels", "matrix", "avatarUrl"],
+        ["channels", "matrix", "accounts", accountId, "name"],
+        ["channels", "matrix", "accounts", accountId, "avatarUrl"],
+      ],
+    },
     afterWrite: { mode: "auto" },
   });
 

--- a/extensions/nextcloud-talk/src/gateway.ts
+++ b/extensions/nextcloud-talk/src/gateway.ts
@@ -48,6 +48,8 @@ export const nextcloudTalkGatewayAdapter: NonNullable<
       : undefined;
     let cleared = false;
     let changed = false;
+    let removedChannelBlock = false;
+    let removedAccountBlock = false;
 
     if (nextSection) {
       if (accountId === DEFAULT_ACCOUNT_ID && nextSection.botSecret) {
@@ -65,6 +67,7 @@ export const nextcloudTalkGatewayAdapter: NonNullable<
         if (accountCleanup.cleared) {
           cleared = true;
         }
+        removedAccountBlock = !accountCleanup.nextAccounts?.[accountId];
         if (accountCleanup.nextAccounts) {
           nextSection.accounts = accountCleanup.nextAccounts as Record<string, unknown>;
         } else {
@@ -79,6 +82,7 @@ export const nextcloudTalkGatewayAdapter: NonNullable<
       } else {
         const nextChannels = { ...nextCfg.channels } as Record<string, unknown>;
         delete nextChannels["nextcloud-talk"];
+        removedChannelBlock = true;
         if (Object.keys(nextChannels).length > 0) {
           nextCfg.channels = nextChannels as OpenClawConfig["channels"];
         } else {
@@ -94,8 +98,19 @@ export const nextcloudTalkGatewayAdapter: NonNullable<
     const loggedOut = resolved.secretSource === "none";
 
     if (changed) {
+      const explicitSetPaths = [
+        ["channels", "nextcloud-talk", "botSecret"],
+        ["channels", "nextcloud-talk", "accounts", accountId, "botSecret"],
+      ];
+      if (removedChannelBlock) {
+        explicitSetPaths.push(["channels", "nextcloud-talk"]);
+      }
+      if (removedAccountBlock) {
+        explicitSetPaths.push(["channels", "nextcloud-talk", "accounts", accountId]);
+      }
       await getNextcloudTalkRuntime().config.replaceConfigFile({
         nextConfig: nextCfg,
+        writeOptions: { explicitSetPaths },
         afterWrite: { mode: "auto" },
       });
     }

--- a/extensions/qqbot/src/bridge/narrowing.ts
+++ b/extensions/qqbot/src/bridge/narrowing.ts
@@ -3,6 +3,10 @@ import type { PluginRuntime } from "openclaw/plugin-sdk/core";
 import type { GatewayAccount } from "../engine/types.js";
 import type { ResolvedQQBotAccount } from "../types.js";
 
+type RuntimeWriteOptions = NonNullable<
+  Parameters<PluginRuntime["config"]["replaceConfigFile"]>[0]["writeOptions"]
+>;
+
 /**
  * Map resolved plugin account to the engine gateway account shape (single assertion on nested config).
  */
@@ -23,9 +27,11 @@ export function toGatewayAccount(account: ResolvedQQBotAccount): GatewayAccount 
 export async function writeOpenClawConfigThroughRuntime(
   runtime: PluginRuntime,
   cfg: OpenClawConfig,
+  writeOptions?: RuntimeWriteOptions,
 ): Promise<void> {
   await runtime.config.replaceConfigFile({
     nextConfig: cfg,
+    ...(writeOptions ? { writeOptions } : {}),
     afterWrite: { mode: "auto" },
   });
 }

--- a/extensions/qqbot/src/channel.logout.test.ts
+++ b/extensions/qqbot/src/channel.logout.test.ts
@@ -2,7 +2,7 @@ import { createRuntimeEnv } from "openclaw/plugin-sdk/plugin-test-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { PluginRuntime } from "openclaw/plugin-sdk/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { resolveQQBotAccount } from "./bridge/config.js";
+import { DEFAULT_ACCOUNT_ID, resolveQQBotAccount } from "./bridge/config.js";
 import { setQQBotRuntime } from "./bridge/runtime.js";
 import { qqbotPlugin } from "./channel.js";
 
@@ -63,6 +63,47 @@ describe("qqbotPlugin gateway.logoutAccount", () => {
         explicitSetPaths: expect.arrayContaining([
           ["channels", "qqbot", "accounts", "work"],
           ["channels", "qqbot", "accounts", "work", "clientSecret"],
+        ]),
+      },
+      afterWrite: { mode: "auto" },
+    });
+  });
+
+  it("marks removed credential-only default account blocks as explicit logout writes", async () => {
+    const cfg = {
+      channels: {
+        qqbot: {
+          accounts: {
+            default: {
+              clientSecret: "secret",
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const { runtime, replaceConfigFile } = createRuntime();
+    setQQBotRuntime(runtime);
+
+    const result = await qqbotPlugin.gateway?.logoutAccount?.({
+      accountId: DEFAULT_ACCOUNT_ID,
+      cfg,
+      account: resolveQQBotAccount(cfg, DEFAULT_ACCOUNT_ID),
+      runtime: createRuntimeEnv(),
+    });
+
+    expect(result).toMatchObject({ ok: true, cleared: true, loggedOut: true });
+    expect(replaceConfigFile).toHaveBeenCalledWith({
+      nextConfig: {
+        channels: {
+          qqbot: {
+            accounts: {},
+          },
+        },
+      },
+      writeOptions: {
+        explicitSetPaths: expect.arrayContaining([
+          ["channels", "qqbot", "accounts", DEFAULT_ACCOUNT_ID],
+          ["channels", "qqbot", "accounts", DEFAULT_ACCOUNT_ID, "clientSecret"],
         ]),
       },
       afterWrite: { mode: "auto" },

--- a/extensions/qqbot/src/channel.logout.test.ts
+++ b/extensions/qqbot/src/channel.logout.test.ts
@@ -1,0 +1,71 @@
+import { createRuntimeEnv } from "openclaw/plugin-sdk/plugin-test-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { PluginRuntime } from "openclaw/plugin-sdk/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveQQBotAccount } from "./bridge/config.js";
+import { setQQBotRuntime } from "./bridge/runtime.js";
+import { qqbotPlugin } from "./channel.js";
+
+function createRuntime(): {
+  runtime: PluginRuntime;
+  replaceConfigFile: ReturnType<typeof vi.fn>;
+} {
+  const replaceConfigFile = vi.fn(async () => ({
+    previousHash: "before",
+    persistedHash: "after",
+    persistedConfig: {},
+    postWrite: { action: "noop" },
+  }));
+  const runtime = {
+    version: "test",
+    config: { replaceConfigFile },
+  } as unknown as PluginRuntime;
+  return { runtime, replaceConfigFile };
+}
+
+describe("qqbotPlugin gateway.logoutAccount", () => {
+  beforeEach(() => {
+    setQQBotRuntime(createRuntime().runtime);
+  });
+
+  it("marks removed credential-only named accounts as explicit logout writes", async () => {
+    const cfg = {
+      channels: {
+        qqbot: {
+          accounts: {
+            work: {
+              clientSecret: "secret",
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const { runtime, replaceConfigFile } = createRuntime();
+    setQQBotRuntime(runtime);
+
+    const result = await qqbotPlugin.gateway?.logoutAccount?.({
+      accountId: "work",
+      cfg,
+      account: resolveQQBotAccount(cfg, "work"),
+      runtime: createRuntimeEnv(),
+    });
+
+    expect(result).toMatchObject({ ok: true, cleared: true, loggedOut: true });
+    expect(replaceConfigFile).toHaveBeenCalledWith({
+      nextConfig: {
+        channels: {
+          qqbot: {
+            accounts: {},
+          },
+        },
+      },
+      writeOptions: {
+        explicitSetPaths: expect.arrayContaining([
+          ["channels", "qqbot", "accounts", "work"],
+          ["channels", "qqbot", "accounts", "work", "clientSecret"],
+        ]),
+      },
+      afterWrite: { mode: "auto" },
+    });
+  });
+});

--- a/extensions/qqbot/src/channel.ts
+++ b/extensions/qqbot/src/channel.ts
@@ -363,7 +363,7 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
           ["channels", "qqbot", "accounts", accountId, "clientSecret"],
           ["channels", "qqbot", "accounts", accountId, "clientSecretFile"],
         ];
-        if (accountId !== DEFAULT_ACCOUNT_ID && !qqbot?.accounts?.[accountId]) {
+        if (!qqbot?.accounts?.[accountId]) {
           explicitSetPaths.push(["channels", "qqbot", "accounts", accountId]);
         }
         await writeOpenClawConfigThroughRuntime(getQQBotRuntime(), nextCfg as OpenClawConfig, {

--- a/extensions/qqbot/src/channel.ts
+++ b/extensions/qqbot/src/channel.ts
@@ -354,7 +354,21 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
       );
 
       if (changed) {
-        await writeOpenClawConfigThroughRuntime(getQQBotRuntime(), nextCfg as OpenClawConfig);
+        const qqbot = (nextCfg as OpenClawConfig).channels?.qqbot as
+          | { accounts?: Record<string, unknown> }
+          | undefined;
+        const explicitSetPaths = [
+          ["channels", "qqbot", "clientSecret"],
+          ["channels", "qqbot", "clientSecretFile"],
+          ["channels", "qqbot", "accounts", accountId, "clientSecret"],
+          ["channels", "qqbot", "accounts", accountId, "clientSecretFile"],
+        ];
+        if (accountId !== DEFAULT_ACCOUNT_ID && !qqbot?.accounts?.[accountId]) {
+          explicitSetPaths.push(["channels", "qqbot", "accounts", accountId]);
+        }
+        await writeOpenClawConfigThroughRuntime(getQQBotRuntime(), nextCfg as OpenClawConfig, {
+          explicitSetPaths,
+        });
       }
 
       const resolved = resolveQQBotAccount((changed ? nextCfg : cfg) as OpenClawConfig, accountId);

--- a/extensions/qqbot/src/engine/commands/builtin/register-streaming.ts
+++ b/extensions/qqbot/src/engine/commands/builtin/register-streaming.ts
@@ -123,7 +123,17 @@ export function registerStreamingCommands(registry: SlashCommandRegistry): void 
           }
         }
 
-        await configApi.replaceConfigFile({ nextConfig: currentCfg, afterWrite: { mode: "auto" } });
+        await configApi.replaceConfigFile({
+          nextConfig: currentCfg,
+          writeOptions: {
+            explicitSetPaths: [
+              ["channels", "qqbot", "streaming"],
+              ["channels", "qqbot", "accounts", accountId, "streaming"],
+              ["channels", "qqbot", "accounts", "default", "streaming"],
+            ],
+          },
+          afterWrite: { mode: "auto" },
+        });
 
         return [
           `✅ 流式消息已${wantOn ? "开启" : "关闭"}`,

--- a/extensions/qqbot/src/engine/gateway/interaction-handler.ts
+++ b/extensions/qqbot/src/engine/gateway/interaction-handler.ts
@@ -101,7 +101,16 @@ async function applyConfigUpdate(
   }
 
   if (changed) {
-    await configApi.replaceConfigFile({ nextConfig: currentCfg, afterWrite: { mode: "auto" } });
+    await configApi.replaceConfigFile({
+      nextConfig: currentCfg,
+      writeOptions: {
+        explicitSetPaths: [
+          ["channels", "qqbot", "groups", groupOpenid, "requireMention"],
+          ["channels", "qqbot", "accounts", accountId, "groups", groupOpenid, "requireMention"],
+        ],
+      },
+      afterWrite: { mode: "auto" },
+    });
     log?.info(
       `Config updated via interaction ${event.id}: require_mention=${String(clawCfgUpdate?.require_mention)}, group=${groupOpenid}`,
     );

--- a/extensions/qqbot/src/engine/gateway/types.ts
+++ b/extensions/qqbot/src/engine/gateway/types.ts
@@ -64,6 +64,9 @@ export interface GatewayPluginRuntime {
     current: () => Record<string, unknown>;
     replaceConfigFile: (params: {
       nextConfig: unknown;
+      writeOptions?: {
+        explicitSetPaths?: readonly (readonly string[])[];
+      };
       afterWrite: { mode: "auto" };
     }) => Promise<unknown>;
   };

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -1049,6 +1049,8 @@ export const telegramPlugin = createChatChannelPlugin({
         const nextTelegram = cfg.channels?.telegram ? { ...cfg.channels.telegram } : undefined;
         let cleared = false;
         let changed = false;
+        let removedChannelBlock = false;
+        let removedAccountBlock = false;
         if (nextTelegram) {
           if (accountId === DEFAULT_ACCOUNT_ID && nextTelegram.botToken) {
             delete nextTelegram.botToken;
@@ -1065,6 +1067,7 @@ export const telegramPlugin = createChatChannelPlugin({
             if (accountCleanup.cleared) {
               cleared = true;
             }
+            removedAccountBlock = !accountCleanup.nextAccounts?.[accountId];
             if (accountCleanup.nextAccounts) {
               nextTelegram.accounts = accountCleanup.nextAccounts;
             } else {
@@ -1078,6 +1081,7 @@ export const telegramPlugin = createChatChannelPlugin({
           } else {
             const nextChannels = { ...nextCfg.channels };
             delete nextChannels.telegram;
+            removedChannelBlock = true;
             if (Object.keys(nextChannels).length > 0) {
               nextCfg.channels = nextChannels;
             } else {
@@ -1091,8 +1095,19 @@ export const telegramPlugin = createChatChannelPlugin({
         });
         const loggedOut = resolved.tokenSource === "none";
         if (changed) {
+          const explicitSetPaths = [
+            ["channels", "telegram", "botToken"],
+            ["channels", "telegram", "accounts", accountId, "botToken"],
+          ];
+          if (removedChannelBlock) {
+            explicitSetPaths.push(["channels", "telegram"]);
+          }
+          if (removedAccountBlock) {
+            explicitSetPaths.push(["channels", "telegram", "accounts", accountId]);
+          }
           await getTelegramRuntime().config.replaceConfigFile({
             nextConfig: nextCfg,
+            writeOptions: { explicitSetPaths },
             afterWrite: { mode: "auto" },
           });
         }

--- a/extensions/telegram/src/target-writeback.ts
+++ b/extensions/telegram/src/target-writeback.ts
@@ -141,6 +141,20 @@ function replaceTelegramDefaultToTargets(params: {
   return changed;
 }
 
+function listTelegramTargetWritebackPaths(cfg: OpenClawConfig): string[][] {
+  const accounts = asObjectRecord(asObjectRecord(cfg.channels?.telegram)?.accounts);
+  return [
+    ["channels", "telegram", "defaultTo"],
+    ...Object.keys(accounts ?? {}).map((accountId) => [
+      "channels",
+      "telegram",
+      "accounts",
+      accountId,
+      "defaultTo",
+    ]),
+  ];
+}
+
 export async function maybePersistResolvedTelegramTarget(params: {
   cfg: OpenClawConfig;
   rawTarget: string;
@@ -182,7 +196,13 @@ export async function maybePersistResolvedTelegramTarget(params: {
       await replaceConfigFile({
         nextConfig,
         snapshot,
-        writeOptions,
+        writeOptions: {
+          ...writeOptions,
+          explicitSetPaths: [
+            ...(writeOptions.explicitSetPaths ?? []),
+            ...listTelegramTargetWritebackPaths(nextConfig),
+          ],
+        },
         afterWrite: { mode: "auto" },
       });
       if (params.verbose) {

--- a/scripts/e2e/npm-onboard-channel-agent-docker.sh
+++ b/scripts/e2e/npm-onboard-channel-agent-docker.sh
@@ -164,14 +164,14 @@ if [ "$missing_whatsapp_login_status" -eq 0 ]; then
   exit 1
 fi
 grep -F "Channel whatsapp is not configured. Add channels.whatsapp to your config before logging in." /tmp/openclaw-missing-whatsapp-login.log >/dev/null
-node -e '"'"'
+node <<'NODE'
 const fs = require("node:fs");
 const path = require("node:path");
 const config = JSON.parse(fs.readFileSync(path.join(process.env.HOME, ".openclaw", "openclaw.json"), "utf8"));
 if (config.channels?.whatsapp) {
   throw new Error("missing-config login unexpectedly created channels.whatsapp");
 }
-'"'"'
+NODE
 
 echo "Checking status surfaces for $CHANNEL..."
 openclaw channels status --json >/tmp/openclaw-channels-status.json 2>/tmp/openclaw-channels-status.err

--- a/scripts/e2e/npm-onboard-channel-agent-docker.sh
+++ b/scripts/e2e/npm-onboard-channel-agent-docker.sh
@@ -103,6 +103,7 @@ dump_debug_logs() {
     /tmp/openclaw-install.log \
     /tmp/openclaw-onboard.json \
     /tmp/openclaw-channel-add.log \
+    /tmp/openclaw-missing-whatsapp-login.log \
     /tmp/openclaw-channels-status.json \
     /tmp/openclaw-channels-status.err \
     /tmp/openclaw-status.txt \
@@ -151,6 +152,26 @@ openclaw_e2e_assert_dep_absent "$DEP_SENTINEL" "$HOME/.openclaw"
 echo "Configuring $CHANNEL..."
 openclaw channels add --channel "$CHANNEL" "${CHANNEL_ADD_ARGS[@]}" >/tmp/openclaw-channel-add.log 2>&1
 node scripts/e2e/lib/npm-onboard-channel-agent/assertions.mjs assert-channel-config "$CHANNEL" "${CHANNEL_CONFIG_TOKENS[@]}"
+
+echo "Checking missing WhatsApp login preflight..."
+set +e
+openclaw channels login --channel whatsapp >/tmp/openclaw-missing-whatsapp-login.log 2>&1
+missing_whatsapp_login_status=$?
+set -e
+if [ "$missing_whatsapp_login_status" -eq 0 ]; then
+  echo "expected missing WhatsApp config login to fail" >&2
+  cat /tmp/openclaw-missing-whatsapp-login.log >&2 || true
+  exit 1
+fi
+grep -F "Channel whatsapp is not configured. Add channels.whatsapp to your config before logging in." /tmp/openclaw-missing-whatsapp-login.log >/dev/null
+node -e '"'"'
+const fs = require("node:fs");
+const path = require("node:path");
+const config = JSON.parse(fs.readFileSync(path.join(process.env.HOME, ".openclaw", "openclaw.json"), "utf8"));
+if (config.channels?.whatsapp) {
+  throw new Error("missing-config login unexpectedly created channels.whatsapp");
+}
+'"'"'
 
 echo "Checking status surfaces for $CHANNEL..."
 openclaw channels status --json >/tmp/openclaw-channels-status.json 2>/tmp/openclaw-channels-status.err

--- a/scripts/e2e/npm-onboard-channel-agent-docker.sh
+++ b/scripts/e2e/npm-onboard-channel-agent-docker.sh
@@ -167,11 +167,7 @@ if (config.channels && Object.hasOwn(config.channels, "whatsapp")) {
 }
 NODE
 cp "$HOME/.openclaw/openclaw.json" /tmp/openclaw-config-before-missing-whatsapp-login.json
-set +e
-openclaw channels login --channel whatsapp >/tmp/openclaw-missing-whatsapp-login.log 2>&1
-missing_whatsapp_login_status=$?
-set -e
-if [ "$missing_whatsapp_login_status" -eq 0 ]; then
+if openclaw channels login --channel whatsapp >/tmp/openclaw-missing-whatsapp-login.log 2>&1; then
   echo "expected missing WhatsApp config login to fail" >&2
   cat /tmp/openclaw-missing-whatsapp-login.log >&2 || true
   exit 1

--- a/scripts/e2e/npm-onboard-channel-agent-docker.sh
+++ b/scripts/e2e/npm-onboard-channel-agent-docker.sh
@@ -103,6 +103,8 @@ dump_debug_logs() {
     /tmp/openclaw-install.log \
     /tmp/openclaw-onboard.json \
     /tmp/openclaw-channel-add.log \
+    /tmp/openclaw-config-before-missing-whatsapp-login.json \
+    /tmp/openclaw-config-after-missing-whatsapp-login.json \
     /tmp/openclaw-missing-whatsapp-login.log \
     /tmp/openclaw-channels-status.json \
     /tmp/openclaw-channels-status.err \
@@ -164,6 +166,7 @@ if (config.channels && Object.hasOwn(config.channels, "whatsapp")) {
   fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
 }
 NODE
+cp "$HOME/.openclaw/openclaw.json" /tmp/openclaw-config-before-missing-whatsapp-login.json
 set +e
 openclaw channels login --channel whatsapp >/tmp/openclaw-missing-whatsapp-login.log 2>&1
 missing_whatsapp_login_status=$?
@@ -174,14 +177,11 @@ if [ "$missing_whatsapp_login_status" -eq 0 ]; then
   exit 1
 fi
 grep -F "Channel whatsapp is not configured. Add channels.whatsapp to your config before logging in." /tmp/openclaw-missing-whatsapp-login.log >/dev/null
-node <<'NODE'
-const fs = require("node:fs");
-const path = require("node:path");
-const config = JSON.parse(fs.readFileSync(path.join(process.env.HOME, ".openclaw", "openclaw.json"), "utf8"));
-if (config.channels && Object.hasOwn(config.channels, "whatsapp")) {
-  throw new Error("missing-config login unexpectedly created channels.whatsapp");
-}
-NODE
+cp "$HOME/.openclaw/openclaw.json" /tmp/openclaw-config-after-missing-whatsapp-login.json
+if ! cmp -s /tmp/openclaw-config-before-missing-whatsapp-login.json /tmp/openclaw-config-after-missing-whatsapp-login.json; then
+  echo "missing-config login unexpectedly mutated openclaw.json" >&2
+  exit 1
+fi
 
 echo "Checking status surfaces for $CHANNEL..."
 openclaw channels status --json >/tmp/openclaw-channels-status.json 2>/tmp/openclaw-channels-status.err

--- a/scripts/e2e/npm-onboard-channel-agent-docker.sh
+++ b/scripts/e2e/npm-onboard-channel-agent-docker.sh
@@ -154,6 +154,16 @@ openclaw channels add --channel "$CHANNEL" "${CHANNEL_ADD_ARGS[@]}" >/tmp/opencl
 node scripts/e2e/lib/npm-onboard-channel-agent/assertions.mjs assert-channel-config "$CHANNEL" "${CHANNEL_CONFIG_TOKENS[@]}"
 
 echo "Checking missing WhatsApp login preflight..."
+node <<'NODE'
+const fs = require("node:fs");
+const path = require("node:path");
+const configPath = path.join(process.env.HOME, ".openclaw", "openclaw.json");
+const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+if (config.channels && Object.hasOwn(config.channels, "whatsapp")) {
+  delete config.channels.whatsapp;
+  fs.writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+}
+NODE
 set +e
 openclaw channels login --channel whatsapp >/tmp/openclaw-missing-whatsapp-login.log 2>&1
 missing_whatsapp_login_status=$?
@@ -168,7 +178,7 @@ node <<'NODE'
 const fs = require("node:fs");
 const path = require("node:path");
 const config = JSON.parse(fs.readFileSync(path.join(process.env.HOME, ".openclaw", "openclaw.json"), "utf8"));
-if (config.channels?.whatsapp) {
+if (config.channels && Object.hasOwn(config.channels, "whatsapp")) {
   throw new Error("missing-config login unexpectedly created channels.whatsapp");
 }
 NODE

--- a/src/channels/config-block.ts
+++ b/src/channels/config-block.ts
@@ -1,0 +1,21 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { isBlockedObjectKey } from "../infra/prototype-keys.js";
+import { isRecord } from "../utils.js";
+
+export function resolveChannelConfigBlockError(params: {
+  cfg: OpenClawConfig;
+  channelId: string;
+  action: string;
+}): string | undefined {
+  const channels = isRecord(params.cfg.channels) ? params.cfg.channels : null;
+  const channelCfg =
+    channels && !isBlockedObjectKey(params.channelId) ? channels[params.channelId] : undefined;
+
+  if (!isRecord(channelCfg)) {
+    return `Channel ${params.channelId} is not configured. Add channels.${params.channelId} to your config before ${params.action}.`;
+  }
+  if (channelCfg.enabled === false) {
+    return `Channel ${params.channelId} is disabled. Enable channels.${params.channelId} before ${params.action}.`;
+  }
+  return undefined;
+}

--- a/src/cli/channel-auth.test.ts
+++ b/src/cli/channel-auth.test.ts
@@ -243,6 +243,59 @@ describe("channel-auth", () => {
     );
   });
 
+  it("rejects explicit login when the channel config block is missing", async () => {
+    mocks.loadConfig.mockReturnValue({ channels: {} });
+
+    await expect(
+      runChannelLogin({ channel: "whatsapp", account: "acct-1" }, runtime),
+    ).rejects.toThrow(
+      "Channel whatsapp is not configured. Add channels.whatsapp to your config before logging in.",
+    );
+    expect(mocks.login).not.toHaveBeenCalled();
+    expect(mocks.callGateway).not.toHaveBeenCalled();
+  });
+
+  it("rejects missing config before installing a catalog-backed channel plugin", async () => {
+    const catalogEntry = {
+      id: "whatsapp",
+      pluginId: "@openclaw/whatsapp",
+      meta: {
+        id: "whatsapp",
+        label: "WhatsApp",
+        selectionLabel: "WhatsApp",
+        docsPath: "/channels/whatsapp",
+        blurb: "wa",
+      },
+      install: {
+        npmSpec: "@openclaw/whatsapp",
+      },
+    };
+    mocks.loadConfig.mockReturnValue({ channels: {} });
+    mocks.getChannelPlugin.mockReturnValue(undefined);
+    mocks.listChannelPluginCatalogEntries.mockReturnValue([catalogEntry]);
+    mocks.loadChannelSetupPluginRegistrySnapshotForChannel.mockReturnValue({
+      channels: [],
+      channelSetups: [],
+    });
+
+    await expect(runChannelLogin({ channel: "whatsapp" }, runtime)).rejects.toThrow(
+      "Channel whatsapp is not configured. Add channels.whatsapp to your config before logging in.",
+    );
+    expect(mocks.ensureChannelSetupPluginInstalled).not.toHaveBeenCalled();
+    expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
+    expect(mocks.login).not.toHaveBeenCalled();
+  });
+
+  it("rejects explicit login when the channel is disabled", async () => {
+    mocks.loadConfig.mockReturnValue({ channels: { whatsapp: { enabled: false } } });
+
+    await expect(
+      runChannelLogin({ channel: "whatsapp", account: "acct-1" }, runtime),
+    ).rejects.toThrow("Channel whatsapp is disabled. Enable channels.whatsapp before logging in.");
+    expect(mocks.login).not.toHaveBeenCalled();
+    expect(mocks.callGateway).not.toHaveBeenCalled();
+  });
+
   it("auto-picks the single configured channel that supports login when opts are empty", async () => {
     await runChannelLogin({}, runtime);
 
@@ -259,28 +312,24 @@ describe("channel-auth", () => {
     expect(mocks.login).not.toHaveBeenCalled();
   });
 
-  it("auto-picks the single auth-capable channel from the auto-enabled config snapshot", async () => {
+  it("rejects login when auto-enable would materialize a missing authored channel block", async () => {
     const autoEnabledCfg = { channels: { whatsapp: {} }, plugins: { allow: ["whatsapp"] } };
     mocks.loadConfig.mockReturnValue({});
     mocks.applyPluginAutoEnable.mockReturnValue({ config: autoEnabledCfg, changes: ["whatsapp"] });
 
-    await runChannelLogin({}, runtime);
+    await expect(runChannelLogin({}, runtime)).rejects.toThrow(
+      "Channel whatsapp is not configured. Add channels.whatsapp to your config before logging in.",
+    );
 
     expect(mocks.applyPluginAutoEnable).toHaveBeenCalledWith({
       config: {},
       env: process.env,
     });
-    expectFields(readFirstCallArg(mocks.login), {
-      cfg: autoEnabledCfg,
-      channelInput: "whatsapp",
-    });
-    expect(mocks.replaceConfigFile).toHaveBeenCalledWith({
-      nextConfig: autoEnabledCfg,
-      baseHash: "config-1",
-    });
+    expect(mocks.login).not.toHaveBeenCalled();
+    expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
   });
 
-  it("persists auto-enabled config during logout auto-pick too", async () => {
+  it("uses auto-enabled config for logout auto-pick without persisting it", async () => {
     const autoEnabledCfg = { channels: { whatsapp: {} }, plugins: { allow: ["whatsapp"] } };
     mocks.loadConfig.mockReturnValue({});
     mocks.applyPluginAutoEnable.mockReturnValue({ config: autoEnabledCfg, changes: ["whatsapp"] });
@@ -291,10 +340,7 @@ describe("channel-auth", () => {
       config: autoEnabledCfg,
       method: "channels.logout",
     });
-    expect(mocks.replaceConfigFile).toHaveBeenCalledWith({
-      nextConfig: autoEnabledCfg,
-      baseHash: "config-1",
-    });
+    expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
   });
 
   it("ignores configured channels that do not support login when channel is omitted", async () => {
@@ -371,7 +417,7 @@ describe("channel-auth", () => {
   });
 
   it("throws when channel does not support login", async () => {
-    mocks.getChannelPlugin.mockReturnValueOnce({
+    mocks.getChannelPlugin.mockReturnValue({
       auth: {},
       gateway: { logoutAccount: mocks.logoutAccount },
       config: { resolveAccount: mocks.resolveAccount },
@@ -397,9 +443,13 @@ describe("channel-auth", () => {
         npmSpec: "@openclaw/whatsapp",
       },
     };
-    mocks.getChannelPlugin.mockReturnValueOnce(undefined);
-    mocks.listChannelPluginCatalogEntries.mockReturnValueOnce([catalogEntry]);
+    mocks.getChannelPlugin.mockReturnValue(undefined);
+    mocks.listChannelPluginCatalogEntries.mockReturnValue([catalogEntry]);
     mocks.loadChannelSetupPluginRegistrySnapshotForChannel
+      .mockReturnValueOnce({
+        channels: [],
+        channelSetups: [],
+      })
       .mockReturnValueOnce({
         channels: [],
         channelSetups: [],
@@ -449,8 +499,8 @@ describe("channel-auth", () => {
         npmSpec: "@openclaw/whatsapp",
       },
     };
-    mocks.getChannelPlugin.mockReturnValueOnce(undefined);
-    mocks.listChannelPluginCatalogEntries.mockReturnValueOnce([catalogEntry]);
+    mocks.getChannelPlugin.mockReturnValue(undefined);
+    mocks.listChannelPluginCatalogEntries.mockReturnValue([catalogEntry]);
     mocks.ensureChannelSetupPluginInstalled.mockResolvedValueOnce({
       cfg: {
         channels: { whatsapp: {} },
@@ -468,6 +518,10 @@ describe("channel-auth", () => {
       pluginId: "whatsapp",
     });
     mocks.loadChannelSetupPluginRegistrySnapshotForChannel
+      .mockReturnValueOnce({
+        channels: [],
+        channelSetups: [],
+      })
       .mockReturnValueOnce({
         channels: [],
         channelSetups: [],
@@ -501,8 +555,8 @@ describe("channel-auth", () => {
 
   it("resolves explicit channel login through the catalog when registry normalize misses", async () => {
     mocks.normalizeChannelId.mockReturnValueOnce(undefined).mockReturnValue("whatsapp");
-    mocks.getChannelPlugin.mockReturnValueOnce(undefined);
-    mocks.listChannelPluginCatalogEntries.mockReturnValueOnce([
+    mocks.getChannelPlugin.mockReturnValue(undefined);
+    mocks.listChannelPluginCatalogEntries.mockReturnValue([
       {
         id: "whatsapp",
         pluginId: "@openclaw/whatsapp",
@@ -519,6 +573,10 @@ describe("channel-auth", () => {
       },
     ]);
     mocks.loadChannelSetupPluginRegistrySnapshotForChannel
+      .mockReturnValueOnce({
+        channels: [],
+        channelSetups: [],
+      })
       .mockReturnValueOnce({
         channels: [],
         channelSetups: [],

--- a/src/cli/channel-auth.test.ts
+++ b/src/cli/channel-auth.test.ts
@@ -175,6 +175,9 @@ describe("channel-auth", () => {
       },
     );
     mocks.callGateway.mockResolvedValue({ ok: true });
+    plugin.config.listAccountIds.mockImplementation((cfg: { channels?: Record<string, unknown> }) =>
+      cfg.channels?.whatsapp ? ["default"] : [],
+    );
     mocks.listChannelPlugins.mockReturnValue([plugin]);
     mocks.resolveDefaultAgentId.mockReturnValue("main");
     mocks.resolveAgentWorkspaceDir.mockReturnValue("/tmp/workspace");
@@ -318,7 +321,7 @@ describe("channel-auth", () => {
     mocks.applyPluginAutoEnable.mockReturnValue({ config: autoEnabledCfg, changes: ["whatsapp"] });
 
     await expect(runChannelLogin({}, runtime)).rejects.toThrow(
-      "Channel whatsapp is not configured. Add channels.whatsapp to your config before logging in.",
+      "No configured channel supports login.",
     );
 
     expect(mocks.applyPluginAutoEnable).toHaveBeenCalledWith({
@@ -326,6 +329,46 @@ describe("channel-auth", () => {
       env: process.env,
     });
     expect(mocks.login).not.toHaveBeenCalled();
+    expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
+  });
+
+  it("auto-picks from authored config instead of transient auto-enabled channels", async () => {
+    const zaloPlugin = {
+      id: "zalouser",
+      auth: { login: vi.fn() },
+      gateway: {},
+      config: {
+        listAccountIds: vi.fn((cfg: { channels?: Record<string, unknown> }) =>
+          cfg.channels?.zalouser ? ["default"] : [],
+        ),
+        resolveAccount: vi.fn().mockReturnValue({ enabled: true }),
+      },
+    };
+    mocks.loadConfig.mockReturnValue({ channels: { whatsapp: {} } });
+    mocks.applyPluginAutoEnable.mockReturnValue({
+      config: { channels: { whatsapp: {}, zalouser: {} } },
+      changes: ["zalouser"],
+    });
+    mocks.listChannelPlugins.mockReturnValue([plugin, zaloPlugin]);
+    mocks.normalizeChannelId.mockImplementation((value) => value);
+    mocks.getChannelPlugin.mockImplementation((value) =>
+      value === "whatsapp"
+        ? plugin
+        : value === "zalouser"
+          ? (zaloPlugin as typeof plugin)
+          : undefined,
+    );
+
+    await runChannelLogin({}, runtime);
+
+    expect(mocks.login).toHaveBeenCalledTimes(1);
+    expect(mocks.login).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfg: { channels: { whatsapp: {} } },
+        channelInput: "whatsapp",
+      }),
+    );
+    expect(zaloPlugin.auth.login).not.toHaveBeenCalled();
     expect(mocks.replaceConfigFile).not.toHaveBeenCalled();
   });
 

--- a/src/cli/channel-auth.ts
+++ b/src/cli/channel-auth.ts
@@ -1,3 +1,4 @@
+import { resolveChannelConfigBlockError } from "../channels/config-block.js";
 import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
 import {
   getChannelPlugin,
@@ -215,15 +216,46 @@ export async function runChannelLogin(
   runtime: RuntimeEnv = defaultRuntime,
 ) {
   const sourceSnapshotPromise = readConfigFileSnapshot().catch(() => null);
+  const authoredCfg = getRuntimeConfig();
   const autoEnabled = applyPluginAutoEnable({
-    config: getRuntimeConfig(),
+    config: authoredCfg,
     env: process.env,
   });
   const loadedCfg = autoEnabled.config;
+  const explicitChannel = opts.channel?.trim();
+  if (explicitChannel) {
+    const normalizedChannelId = normalizeChannelId(explicitChannel);
+    const preflightChannel = await resolveInstallableChannelPlugin({
+      cfg: loadedCfg,
+      runtime,
+      rawChannel: explicitChannel,
+      ...(normalizedChannelId ? { channelId: normalizedChannelId } : {}),
+      allowInstall: false,
+      supports: (candidate) => supportsChannelAuthMode(candidate, "login"),
+    });
+    if (preflightChannel.channelId) {
+      const configBlockError = resolveChannelConfigBlockError({
+        cfg: authoredCfg,
+        channelId: preflightChannel.channelId,
+        action: "logging in",
+      });
+      if (configBlockError) {
+        throw new Error(configBlockError);
+      }
+    }
+  }
   const resolvedChannel = await resolveChannelPluginForMode(opts, "login", loadedCfg, runtime);
   let cfg = resolvedChannel.cfg;
   const { configChanged, channelInput, plugin } = resolvedChannel;
-  if (autoEnabled.changes.length > 0 || configChanged) {
+  const configBlockError = resolveChannelConfigBlockError({
+    cfg: authoredCfg,
+    channelId: plugin.id,
+    action: "logging in",
+  });
+  if (configBlockError) {
+    throw new Error(configBlockError);
+  }
+  if (configChanged) {
     const committed = await commitConfigWithPendingPluginInstalls({
       nextConfig: cfg,
       baseHash: (await sourceSnapshotPromise)?.hash,
@@ -272,7 +304,7 @@ export async function runChannelLogout(
   const resolvedChannel = await resolveChannelPluginForMode(opts, "logout", loadedCfg, runtime);
   let cfg = resolvedChannel.cfg;
   const { configChanged, channelInput, plugin } = resolvedChannel;
-  if (autoEnabled.changes.length > 0 || configChanged) {
+  if (configChanged) {
     const committed = await commitConfigWithPendingPluginInstalls({
       nextConfig: cfg,
       baseHash: (await sourceSnapshotPromise)?.hash,

--- a/src/cli/channel-auth.ts
+++ b/src/cli/channel-auth.ts
@@ -244,7 +244,13 @@ export async function runChannelLogin(
       }
     }
   }
-  const resolvedChannel = await resolveChannelPluginForMode(opts, "login", loadedCfg, runtime);
+  const loginResolutionCfg = explicitChannel ? loadedCfg : authoredCfg;
+  const resolvedChannel = await resolveChannelPluginForMode(
+    opts,
+    "login",
+    loginResolutionCfg,
+    runtime,
+  );
   let cfg = resolvedChannel.cfg;
   const { configChanged, channelInput, plugin } = resolvedChannel;
   const configBlockError = resolveChannelConfigBlockError({

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -428,6 +428,18 @@ describe("config cli", () => {
       ]);
     });
 
+    it("marks channel leaf writes as explicit channel activation when creating a channel", async () => {
+      setSnapshot({}, withRuntimeDefaults({}));
+
+      await runConfigCommand(["config", "set", "channels.telegram.botToken", "tok-abc"]);
+
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+      expect(requireWriteOptions().explicitSetPaths).toEqual([
+        ["channels", "telegram", "botToken"],
+        ["channels", "telegram"],
+      ]);
+    });
+
     it("marks object set paths explicit so nested default-equal writes persist", async () => {
       const resolved: OpenClawConfig = {
         channels: {
@@ -2685,7 +2697,27 @@ describe("config cli", () => {
       expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
       const written = firstWrittenConfig();
       expect(written.agents?.list).toEqual([{ id: "agent-a" }, { id: "agent-c" }]);
-      expect(firstWriteConfigOptions()).toBeUndefined();
+      expect(firstWriteConfigOptions()).toEqual({
+        explicitSetPaths: [["agents", "list", "1"]],
+      });
+    });
+
+    it("marks indexed protected allowlist unsets as explicit writes", async () => {
+      const resolved: OpenClawConfig = {
+        commands: {
+          ownerAllowFrom: ["webchat:owner", "telegram:111"],
+        },
+      };
+      setSnapshot(resolved, withRuntimeDefaults(resolved));
+
+      await runConfigCommand(["config", "unset", "commands.ownerAllowFrom[0]"]);
+
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+      const written = firstWrittenConfig();
+      expect(written.commands?.ownerAllowFrom).toEqual(["telegram:111"]);
+      expect(firstWriteConfigOptions()).toEqual({
+        explicitSetPaths: [["commands", "ownerAllowFrom", "0"]],
+      });
     });
 
     it("preserves write-level unset handling for numeric object keys", async () => {

--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -440,6 +440,31 @@ describe("config cli", () => {
       ]);
     });
 
+    it("marks account leaf writes as explicit account activation when creating an account", async () => {
+      const config: OpenClawConfig = {
+        channels: {
+          telegram: {
+            enabled: true,
+            accounts: {},
+          },
+        },
+      };
+      setSnapshot(config, withRuntimeDefaults(config));
+
+      await runConfigCommand([
+        "config",
+        "set",
+        "channels.telegram.accounts.work.botToken",
+        "tok-abc",
+      ]);
+
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+      expect(requireWriteOptions().explicitSetPaths).toEqual([
+        ["channels", "telegram", "accounts", "work", "botToken"],
+        ["channels", "telegram", "accounts", "work"],
+      ]);
+    });
+
     it("marks object set paths explicit so nested default-equal writes persist", async () => {
       const resolved: OpenClawConfig = {
         channels: {

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -266,6 +266,51 @@ function normalizeConfigMutationExplicitSetPath(path: PathSegment[]): PathSegmen
   return path;
 }
 
+const RESERVED_CHANNEL_CONFIG_KEYS = new Set(["defaults", "modelByChannel"]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function addUniqueExplicitSetPath(paths: PathSegment[][], seen: Set<string>, path: PathSegment[]) {
+  const key = path.join("\u0000");
+  if (seen.has(key)) {
+    return;
+  }
+  seen.add(key);
+  paths.push(path);
+}
+
+function normalizeConfigMutationExplicitSetPaths(params: {
+  previousConfig: unknown;
+  nextConfig: unknown;
+  paths: PathSegment[][];
+}): PathSegment[][] {
+  const normalizedPaths = params.paths.map(normalizeConfigMutationExplicitSetPath);
+  const result: PathSegment[][] = [];
+  const seen = new Set<string>();
+  for (const path of normalizedPaths) {
+    addUniqueExplicitSetPath(result, seen, path);
+    if (path.length < 3 || path[0] !== "channels") {
+      continue;
+    }
+    const channelId = path[1];
+    if (!channelId || RESERVED_CHANNEL_CONFIG_KEYS.has(channelId)) {
+      continue;
+    }
+    const previousChannels = isRecord(params.previousConfig)
+      ? params.previousConfig.channels
+      : undefined;
+    const nextChannels = isRecord(params.nextConfig) ? params.nextConfig.channels : undefined;
+    const previousChannel = isRecord(previousChannels) ? previousChannels[channelId] : undefined;
+    const nextChannel = isRecord(nextChannels) ? nextChannels[channelId] : undefined;
+    if (!isRecord(previousChannel) && isRecord(nextChannel) && nextChannel.enabled !== false) {
+      addUniqueExplicitSetPath(result, seen, ["channels", channelId]);
+    }
+  }
+  return result;
+}
+
 const GATEWAY_AUTH_MODE_PATH: PathSegment[] = ["gateway", "auth", "mode"];
 const SECRET_PROVIDER_PATH_PREFIX: PathSegment[] = ["secrets", "providers"];
 const PLUGIN_INSTALL_RECORD_PATH_PREFIX: PathSegment[] = ["plugins", "installs"];
@@ -1749,7 +1794,11 @@ async function runConfigOperations(params: {
     operations,
   });
   const nextConfig = normalizeConfigMutationModelRefs(next as OpenClawConfig);
-  const normalizedExplicitSetPaths = explicitSetPaths.map(normalizeConfigMutationExplicitSetPath);
+  const normalizedExplicitSetPaths = normalizeConfigMutationExplicitSetPaths({
+    previousConfig: snapshot.resolved,
+    nextConfig,
+    paths: explicitSetPaths,
+  });
   const policyIssues = collectUnsupportedSecretRefPolicyIssues(nextConfig);
   const policyIssueLines = formatConfigIssueLines(policyIssues, "", { normalizeRoot: true }).map(
     (line) => line.trim(),
@@ -2100,7 +2149,7 @@ export async function runConfigUnset(opts: {
       nextConfig: next,
       ...(snapshot.hash !== undefined ? { baseHash: snapshot.hash } : {}),
       ...(unsetResult.leafContainer === "array"
-        ? {}
+        ? { writeOptions: { explicitSetPaths: [parsedPath] } }
         : { writeOptions: { unsetPaths: [parsedPath] } }),
     });
     runtime.log(info(`Removed ${opts.path}. Restart the gateway to apply.`));

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -10,6 +10,7 @@ import {
   normalizeAgentModelRefForConfig,
 } from "../config/model-input.js";
 import { CONFIG_PATH } from "../config/paths.js";
+import { isChannelConfigMetaKey } from "../config/protected-policy.js";
 import { isBlockedObjectKey } from "../config/prototype-keys.js";
 import { redactConfigObject } from "../config/redact-snapshot.js";
 import { readBestEffortRuntimeConfigSchema } from "../config/runtime-schema.js";
@@ -266,8 +267,6 @@ function normalizeConfigMutationExplicitSetPath(path: PathSegment[]): PathSegmen
   return path;
 }
 
-const RESERVED_CHANNEL_CONFIG_KEYS = new Set(["defaults", "modelByChannel"]);
-
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
@@ -295,7 +294,7 @@ function normalizeConfigMutationExplicitSetPaths(params: {
       continue;
     }
     const channelId = path[1];
-    if (!channelId || RESERVED_CHANNEL_CONFIG_KEYS.has(channelId)) {
+    if (!channelId || isChannelConfigMetaKey(channelId)) {
       continue;
     }
     const previousChannels = isRecord(params.previousConfig)

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -307,6 +307,20 @@ function normalizeConfigMutationExplicitSetPaths(params: {
     if (!isRecord(previousChannel) && isRecord(nextChannel) && nextChannel.enabled !== false) {
       addUniqueExplicitSetPath(result, seen, ["channels", channelId]);
     }
+    if (path.length < 5 || path[2] !== "accounts") {
+      continue;
+    }
+    const accountId = path[3];
+    if (!accountId || !isRecord(nextChannel)) {
+      continue;
+    }
+    const previousAccounts = isRecord(previousChannel) ? previousChannel.accounts : undefined;
+    const nextAccounts = nextChannel.accounts;
+    const previousAccount = isRecord(previousAccounts) ? previousAccounts[accountId] : undefined;
+    const nextAccount = isRecord(nextAccounts) ? nextAccounts[accountId] : undefined;
+    if (!isRecord(previousAccount) && isRecord(nextAccount) && nextAccount.enabled !== false) {
+      addUniqueExplicitSetPath(result, seen, ["channels", channelId, "accounts", accountId]);
+    }
   }
   return result;
 }

--- a/src/cli/directory-cli.test.ts
+++ b/src/cli/directory-cli.test.ts
@@ -175,6 +175,9 @@ describe("registerDirectoryCli", () => {
     expect(mocks.replaceConfigFile).toHaveBeenCalledWith({
       nextConfig: autoEnabledConfig,
       baseHash: "config-1",
+      writeOptions: {
+        explicitSetPaths: [["channels", "whatsapp", "enabled"]],
+      },
     });
   });
 

--- a/src/cli/directory-cli.ts
+++ b/src/cli/directory-cli.ts
@@ -17,6 +17,31 @@ import { theme } from "../terminal/theme.js";
 import { formatHelpExamples } from "./help-format.js";
 import { commitConfigWithPendingPluginInstalls } from "./plugins-install-record-commit.js";
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function resolveAutoEnabledChannelWriteOptions(params: {
+  previousConfig: Record<string, unknown>;
+  nextConfig: Record<string, unknown>;
+}): { explicitSetPaths: string[][] } | undefined {
+  const previousChannels = isRecord(params.previousConfig.channels)
+    ? params.previousConfig.channels
+    : {};
+  const nextChannels = isRecord(params.nextConfig.channels) ? params.nextConfig.channels : {};
+  const explicitSetPaths = Object.entries(nextChannels).flatMap(([channelId, nextChannel]) => {
+    if (!isRecord(nextChannel) || nextChannel.enabled === false) {
+      return [];
+    }
+    const previousChannel = previousChannels[channelId];
+    if (!isRecord(previousChannel) || previousChannel.enabled === false) {
+      return [["channels", channelId, "enabled"]];
+    }
+    return [];
+  });
+  return explicitSetPaths.length > 0 ? { explicitSetPaths } : undefined;
+}
+
 function parseLimit(value: unknown): number | null {
   if (typeof value === "number" && Number.isFinite(value)) {
     if (value <= 0) {
@@ -104,11 +129,16 @@ export function registerDirectoryCli(program: Command) {
 
   const resolve = async (opts: { channel?: string; account?: string }) => {
     const sourceSnapshotPromise = readConfigFileSnapshot().catch(() => null);
+    const authoredCfg = getRuntimeConfig();
     const autoEnabled = applyPluginAutoEnable({
-      config: getRuntimeConfig(),
+      config: authoredCfg,
       env: process.env,
     });
     let cfg = autoEnabled.config;
+    const autoEnabledWriteOptions = resolveAutoEnabledChannelWriteOptions({
+      previousConfig: authoredCfg,
+      nextConfig: cfg,
+    });
     const explicitChannel = opts.channel?.trim();
     const resolvedExplicit = explicitChannel
       ? await resolveInstallableChannelPlugin({
@@ -124,12 +154,14 @@ export function registerDirectoryCli(program: Command) {
       const committed = await commitConfigWithPendingPluginInstalls({
         nextConfig: cfg,
         baseHash: (await sourceSnapshotPromise)?.hash,
+        ...(autoEnabledWriteOptions ? { writeOptions: autoEnabledWriteOptions } : {}),
       });
       cfg = committed.config;
     } else if (autoEnabled.changes.length > 0) {
       await replaceConfigFile({
         nextConfig: cfg,
         baseHash: (await sourceSnapshotPromise)?.hash,
+        ...(autoEnabledWriteOptions ? { writeOptions: autoEnabledWriteOptions } : {}),
       });
     }
     const selection = explicitChannel

--- a/src/cli/pairing-cli.test.ts
+++ b/src/cli/pairing-cli.test.ts
@@ -237,8 +237,16 @@ describe("pairing cli", () => {
       const replaceCall = requireFirstMockCall(
         replaceConfigFile.mock.calls,
         "config replace",
-      )[0] as { nextConfig?: { commands?: { ownerAllowFrom?: string[] } } } | undefined;
+      )[0] as
+        | {
+            nextConfig?: { commands?: { ownerAllowFrom?: string[] } };
+            writeOptions?: { explicitSetPaths?: string[][] };
+          }
+        | undefined;
       expect(replaceCall?.nextConfig?.commands?.ownerAllowFrom).toEqual(["telegram:123"]);
+      expect(replaceCall?.writeOptions?.explicitSetPaths).toEqual([
+        ["commands", "ownerAllowFrom"],
+      ]);
       expect(log.mock.calls).toEqual([
         [`${theme.success("Approved")} ${theme.muted("telegram")} sender ${theme.command("123")}.`],
         [

--- a/src/cli/pairing-cli.ts
+++ b/src/cli/pairing-cli.ts
@@ -78,7 +78,13 @@ async function maybeBootstrapCommandOwnerFromPairing(params: {
   await replaceConfigFile({
     nextConfig,
     snapshot,
-    writeOptions,
+    writeOptions: {
+      ...writeOptions,
+      explicitSetPaths: [
+        ...(writeOptions.explicitSetPaths ?? []),
+        ["commands", "ownerAllowFrom"],
+      ],
+    },
     afterWrite: { mode: "auto" },
   });
   return { ownerEntry, bootstrapped: true };

--- a/src/commands/agents.add.test.ts
+++ b/src/commands/agents.add.test.ts
@@ -55,6 +55,7 @@ const transformConfigWithPendingPluginInstallsMock = vi.hoisted(() =>
 
 const wizardMocks = vi.hoisted(() => ({
   createClackPrompter: vi.fn(),
+  setupChannels: vi.fn(),
 }));
 
 vi.mock("../config/config.js", async () => ({
@@ -75,6 +76,10 @@ vi.mock("../wizard/clack-prompter.js", () => ({
   createClackPrompter: wizardMocks.createClackPrompter,
 }));
 
+vi.mock("./onboard-channels.js", () => ({
+  setupChannels: wizardMocks.setupChannels,
+}));
+
 import { WizardCancelledError } from "../wizard/prompts.js";
 import { __testing } from "./agents.commands.add.js";
 import { agentsAddCommand } from "./agents.js";
@@ -88,6 +93,8 @@ describe("agents add command", () => {
     replaceConfigFileMock.mockClear();
     transformConfigWithPendingPluginInstallsMock.mockClear();
     wizardMocks.createClackPrompter.mockClear();
+    wizardMocks.setupChannels.mockReset();
+    wizardMocks.setupChannels.mockImplementation(async (cfg: Record<string, unknown>) => cfg);
     runtime.log.mockClear();
     runtime.error.mockClear();
     runtime.exit.mockClear();
@@ -310,6 +317,41 @@ describe("agents add command", () => {
         sourceIsInheritedMain: true,
       }),
     ).toBe('OAuth profiles stay shared from "main" unless this agent signs in separately.');
+  });
+
+  it("marks interactive channel setup writes as explicit", async () => {
+    readConfigFileSnapshotMock.mockResolvedValue({ ...baseConfigSnapshot, config: {}, sourceConfig: {} });
+    wizardMocks.setupChannels.mockImplementation(
+      async (
+        cfg: Record<string, unknown>,
+        _runtime: unknown,
+        _prompter: unknown,
+        options: { onSelection?: (selection: string[]) => void },
+      ) => {
+        options.onSelection?.(["telegram"]);
+        return {
+          ...cfg,
+          channels: {
+            telegram: { enabled: true },
+          },
+        };
+      },
+    );
+    wizardMocks.createClackPrompter.mockReturnValue({
+      intro: vi.fn(),
+      text: vi.fn().mockResolvedValue("/tmp/work"),
+      confirm: vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(false),
+      note: vi.fn(),
+      outro: vi.fn(),
+    });
+
+    await agentsAddCommand({ name: "Work" }, runtime, { hasFlags: false });
+
+    expect(replaceConfigFileMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        writeOptions: { explicitSetPaths: [["channels", "telegram"]] },
+      }),
+    );
   });
 
   describe("non-interactive config mutation", () => {

--- a/src/commands/agents.commands.add.ts
+++ b/src/commands/agents.commands.add.ts
@@ -467,9 +467,14 @@ export async function agentsAddCommand(
       }
     }
 
+    const writeOptions =
+      selection.length > 0
+        ? { explicitSetPaths: selection.map((channel) => ["channels", channel]) }
+        : undefined;
     const committed = await commitConfigWithPendingPluginInstalls({
       nextConfig,
       ...(baseHash !== undefined ? { baseHash } : {}),
+      ...(writeOptions ? { writeOptions } : {}),
     });
     nextConfig = committed.config;
     logConfigUpdated(runtime);

--- a/src/commands/agents.commands.delete.ts
+++ b/src/commands/agents.commands.delete.ts
@@ -82,7 +82,8 @@ export async function agentsDeleteCommand(
     return;
   }
 
-  if (findAgentEntryIndex(listAgentEntries(cfg), agentId) < 0) {
+  const agentIndex = findAgentEntryIndex(listAgentEntries(cfg), agentId);
+  if (agentIndex < 0) {
     runtime.error(
       `Agent "${agentId}" not found. Run ${formatCliCommand("openclaw agents list")} to see configured agents.`,
     );
@@ -141,7 +142,10 @@ export async function agentsDeleteCommand(
   await replaceConfigFile({
     nextConfig: result.config,
     ...(baseHash !== undefined ? { baseHash } : {}),
-    writeOptions: opts.json ? { skipOutputLogs: true } : undefined,
+    writeOptions: {
+      ...(opts.json ? { skipOutputLogs: true } : {}),
+      explicitSetPaths: [["agents", "list", String(agentIndex)]],
+    },
   });
   if (!opts.json) {
     logConfigUpdated(runtime);

--- a/src/commands/agents.delete.test.ts
+++ b/src/commands/agents.delete.test.ts
@@ -167,11 +167,14 @@ describe("agents delete command", () => {
       expect(runtime.exit).not.toHaveBeenCalled();
       expect(configMocks.replaceConfigFile).toHaveBeenCalledOnce();
       const replaceConfigFileCalls = configMocks.replaceConfigFile.mock.calls as unknown as Array<
-        [{ nextConfig: OpenClawConfig }]
+        [{ nextConfig: OpenClawConfig; writeOptions?: { explicitSetPaths?: string[][] } }]
       >;
       expect(replaceConfigFileCalls[0]?.[0].nextConfig).toEqual({
         agents: { list: [{ id: "main", workspace: path.join(stateDir, "workspace-main") }] },
       });
+      expect(replaceConfigFileCalls[0]?.[0].writeOptions?.explicitSetPaths).toEqual([
+        ["agents", "list", "1"],
+      ]);
       expectSessionStore(storePath, {
         "agent:main:main": { sessionId: "sess-main", updatedAt: now + 3 },
       });

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -652,6 +652,9 @@ describe("channelsAddCommand", () => {
         },
       },
     });
+    expect(commitInstallCall().writeOptions).toEqual({
+      explicitSetPaths: [["channels", "whatsapp"]],
+    });
   });
 
   it("loads external channel setup snapshots for newly installed and existing plugins", async () => {

--- a/src/commands/channels.remove.test.ts
+++ b/src/commands/channels.remove.test.ts
@@ -179,6 +179,13 @@ describe("channelsRemoveCommand", () => {
     expect(registryRefreshMocks.refreshPluginRegistryAfterConfigMutation).not.toHaveBeenCalled();
     const writtenConfig = firstWrittenChannelsConfig();
     expect(writtenConfig?.channels?.["external-chat"]).toBeUndefined();
+    expect(configMocks.replaceConfigFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        writeOptions: {
+          explicitSetPaths: [["channels", "external-chat"]],
+        },
+      }),
+    );
     expect(runtime.error).not.toHaveBeenCalled();
     expect(runtime.exit).not.toHaveBeenCalled();
   });

--- a/src/commands/channels.remove.test.ts
+++ b/src/commands/channels.remove.test.ts
@@ -1,8 +1,9 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelPluginCatalogEntry } from "../channels/plugins/catalog.js";
 import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
-import { createTestRegistry } from "../test-utils/channel-plugins.js";
+import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
 import {
   ensureChannelSetupPluginInstalled,
   loadChannelSetupPluginRegistrySnapshotForChannel,
@@ -26,6 +27,10 @@ const registryRefreshMocks = vi.hoisted(() => ({
 
 const gatewayMocks = vi.hoisted(() => ({
   callGateway: vi.fn(async () => ({ stopped: true })),
+}));
+
+const prompterMocks = vi.hoisted(() => ({
+  confirm: vi.fn(async () => true),
 }));
 
 vi.mock("../channels/plugins/catalog.js", async () => {
@@ -61,6 +66,12 @@ vi.mock("../cli/plugins-registry-refresh.js", () => registryRefreshMocks);
 
 vi.mock("../gateway/call.js", () => ({
   callGateway: gatewayMocks.callGateway,
+}));
+
+vi.mock("../wizard/clack-prompter.js", () => ({
+  createClackPrompter: () => ({
+    confirm: prompterMocks.confirm,
+  }),
 }));
 
 const runtime = createTestRuntime();
@@ -103,6 +114,8 @@ describe("channelsRemoveCommand", () => {
     registryRefreshMocks.refreshPluginRegistryAfterConfigMutation.mockClear();
     gatewayMocks.callGateway.mockClear();
     gatewayMocks.callGateway.mockResolvedValue({ stopped: true });
+    prompterMocks.confirm.mockClear();
+    prompterMocks.confirm.mockResolvedValue(true);
     setActivePluginRegistry(createTestRegistry());
   });
 
@@ -183,6 +196,77 @@ describe("channelsRemoveCommand", () => {
       expect.objectContaining({
         writeOptions: {
           explicitSetPaths: [["channels", "external-chat"]],
+        },
+      }),
+    );
+    expect(runtime.error).not.toHaveBeenCalled();
+    expect(runtime.exit).not.toHaveBeenCalled();
+  });
+
+  it("marks channel disable writes as explicit protected edits", async () => {
+    configMocks.readConfigFileSnapshot.mockResolvedValue({
+      ...baseConfigSnapshot,
+      config: {
+        channels: {
+          "external-chat": {
+            enabled: true,
+            token: "token-1",
+          },
+        },
+      },
+    });
+    const catalogEntry: ChannelPluginCatalogEntry = createExternalChatCatalogEntry();
+    catalogMocks.listChannelPluginCatalogEntries.mockReturnValue([catalogEntry]);
+    const scopedPlugin = {
+      ...createChannelTestPluginBase({
+        id: "external-chat",
+        label: "External Chat",
+        docsPath: "/channels/external-chat",
+      }),
+      config: {
+        ...createChannelTestPluginBase({
+          id: "external-chat",
+          label: "External Chat",
+          docsPath: "/channels/external-chat",
+        }).config,
+        setAccountEnabled: vi.fn(({ cfg, enabled }: { cfg: OpenClawConfig; enabled: boolean }) => ({
+          ...cfg,
+          channels: {
+            ...cfg.channels,
+            "external-chat": {
+              ...(cfg.channels?.["external-chat"] as Record<string, unknown> | undefined),
+              enabled,
+            },
+          },
+        })),
+      },
+    } as ChannelPlugin;
+    vi.mocked(loadChannelSetupPluginRegistrySnapshotForChannel).mockReturnValue(
+      createTestRegistry([
+        {
+          pluginId: "@vendor/external-chat-plugin",
+          plugin: scopedPlugin,
+          source: "test",
+        },
+      ]),
+    );
+
+    await channelsRemoveCommand(
+      {
+        channel: "external-chat",
+        account: "default",
+      },
+      runtime,
+      { hasFlags: true },
+    );
+
+    expect(configMocks.replaceConfigFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        writeOptions: {
+          explicitSetPaths: [
+            ["channels", "external-chat", "enabled"],
+            ["channels", "external-chat", "accounts", "default", "enabled"],
+          ],
         },
       }),
     );

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -1,3 +1,4 @@
+import { isDeepStrictEqual } from "node:util";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { getBundledChannelSetupPlugin } from "../../channels/plugins/bundled.js";
 import { parseOptionalDelimitedEntries } from "../../channels/plugins/helpers.js";
@@ -14,6 +15,7 @@ import {
 import { commitConfigWithPendingPluginInstalls } from "../../cli/plugins-install-record-commit.js";
 import { refreshPluginRegistryAfterConfigMutation } from "../../cli/plugins-registry-refresh.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import type { ConfigWriteOptions } from "../../config/io.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../routing/session-key.js";
 import { defaultRuntime, type RuntimeEnv } from "../../runtime.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
@@ -51,6 +53,30 @@ export type ChannelsAddOptions = {
 
 const CHANNEL_ADD_CONTROL_OPTION_KEYS = new Set(["channel", "account"]);
 const NEXTCLOUD_TALK_CLI_ALIASES = new Set(["nextcloud-talk", "nc-talk", "nc"]);
+const RESERVED_CHANNEL_CONFIG_KEYS = new Set(["defaults", "modelByChannel"]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function resolveChannelAddWriteOptions(params: {
+  previousConfig: OpenClawConfig;
+  nextConfig: OpenClawConfig;
+}): ConfigWriteOptions | undefined {
+  const previousChannels = isRecord(params.previousConfig.channels)
+    ? params.previousConfig.channels
+    : {};
+  const nextChannels = isRecord(params.nextConfig.channels) ? params.nextConfig.channels : {};
+  const changedChannelKeys = new Set([
+    ...Object.keys(previousChannels),
+    ...Object.keys(nextChannels),
+  ]);
+  const explicitSetPaths = [...changedChannelKeys]
+    .filter((key) => !RESERVED_CHANNEL_CONFIG_KEYS.has(key))
+    .filter((key) => !isDeepStrictEqual(previousChannels[key], nextChannels[key]))
+    .map((key) => ["channels", key]);
+  return explicitSetPaths.length > 0 ? { explicitSetPaths } : undefined;
+}
 
 async function resolveCatalogChannelEntry(raw: string, cfg: OpenClawConfig | null) {
   const trimmed = normalizeOptionalLowercaseString(raw);
@@ -279,9 +305,14 @@ async function channelsAddCommandImpl(
       }
     }
 
+    const writeOptions = resolveChannelAddWriteOptions({
+      previousConfig: cfg,
+      nextConfig,
+    });
     const committed = await commitConfigWithPendingPluginInstalls({
       nextConfig,
       ...(baseHash !== undefined ? { baseHash } : {}),
+      ...(writeOptions ? { writeOptions } : {}),
     });
     const writtenConfig = committed.config;
     if (committed.movedInstallRecords) {
@@ -432,9 +463,14 @@ async function channelsAddCommandImpl(
     runtime,
   });
 
+  const writeOptions = resolveChannelAddWriteOptions({
+    previousConfig: cfg,
+    nextConfig,
+  });
   const committed = await commitConfigWithPendingPluginInstalls({
     nextConfig,
     ...(baseHash !== undefined ? { baseHash } : {}),
+    ...(writeOptions ? { writeOptions } : {}),
   });
   const writtenConfig = committed.config;
   if (committed.movedInstallRecords || pluginRegistrySourceChanged) {

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -16,6 +16,7 @@ import { commitConfigWithPendingPluginInstalls } from "../../cli/plugins-install
 import { refreshPluginRegistryAfterConfigMutation } from "../../cli/plugins-registry-refresh.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { ConfigWriteOptions } from "../../config/io.js";
+import { isChannelConfigMetaKey } from "../../config/protected-policy.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../routing/session-key.js";
 import { defaultRuntime, type RuntimeEnv } from "../../runtime.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
@@ -53,7 +54,6 @@ export type ChannelsAddOptions = {
 
 const CHANNEL_ADD_CONTROL_OPTION_KEYS = new Set(["channel", "account"]);
 const NEXTCLOUD_TALK_CLI_ALIASES = new Set(["nextcloud-talk", "nc-talk", "nc"]);
-const RESERVED_CHANNEL_CONFIG_KEYS = new Set(["defaults", "modelByChannel"]);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -72,7 +72,7 @@ function resolveChannelAddWriteOptions(params: {
     ...Object.keys(nextChannels),
   ]);
   const explicitSetPaths = [...changedChannelKeys]
-    .filter((key) => !RESERVED_CHANNEL_CONFIG_KEYS.has(key))
+    .filter((key) => !isChannelConfigMetaKey(key))
     .filter((key) => !isDeepStrictEqual(previousChannels[key], nextChannels[key]))
     .map((key) => ["channels", key]);
   return explicitSetPaths.length > 0 ? { explicitSetPaths } : undefined;

--- a/src/commands/channels/remove.ts
+++ b/src/commands/channels/remove.ts
@@ -10,6 +10,7 @@ import {
 import { commitConfigWithPendingPluginInstalls } from "../../cli/plugins-install-record-commit.js";
 import { refreshPluginRegistryAfterConfigMutation } from "../../cli/plugins-registry-refresh.js";
 import { replaceConfigFile, type OpenClawConfig } from "../../config/config.js";
+import type { ConfigWriteOptions } from "../../config/io.js";
 import { callGateway } from "../../gateway/call.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../../routing/session-key.js";
@@ -25,6 +26,19 @@ export type ChannelsRemoveOptions = {
   account?: string;
   delete?: boolean;
 };
+
+function resolveDeleteWriteOptions(params: {
+  nextConfig: OpenClawConfig;
+  channel: ChatChannel;
+  accountId: string;
+}): ConfigWriteOptions {
+  const nextChannel = params.nextConfig.channels?.[params.channel];
+  const channelPath = ["channels", params.channel] as const;
+  const accountPath = [...channelPath, "accounts", params.accountId] as const;
+  return {
+    explicitSetPaths: [nextChannel && typeof nextChannel === "object" ? accountPath : channelPath],
+  };
+}
 
 function listAccountIds(
   cfg: OpenClawConfig,
@@ -237,10 +251,18 @@ export async function channelsRemoveCommand(
   const shouldMovePluginInstalls = Boolean(
     next.plugins?.installs && Object.keys(next.plugins.installs).length > 0,
   );
+  const writeOptions = deleteConfig
+    ? resolveDeleteWriteOptions({
+        nextConfig: next,
+        channel: resolvedChannelId,
+        accountId: accountKey,
+      })
+    : undefined;
   if (shouldMovePluginInstalls) {
     const committed = await commitConfigWithPendingPluginInstalls({
       nextConfig: next,
       ...(baseHash !== undefined ? { baseHash } : {}),
+      ...(writeOptions ? { writeOptions } : {}),
     });
     next = committed.config;
     await refreshPluginRegistryAfterConfigMutation({
@@ -253,6 +275,7 @@ export async function channelsRemoveCommand(
     await replaceConfigFile({
       nextConfig: next,
       ...(baseHash !== undefined ? { baseHash } : {}),
+      ...(writeOptions ? { writeOptions } : {}),
     });
     if (resolvedPluginState?.pluginInstalled) {
       await refreshPluginRegistryAfterConfigMutation({

--- a/src/commands/channels/remove.ts
+++ b/src/commands/channels/remove.ts
@@ -27,14 +27,20 @@ export type ChannelsRemoveOptions = {
   delete?: boolean;
 };
 
-function resolveDeleteWriteOptions(params: {
+function resolveRemoveWriteOptions(params: {
   nextConfig: OpenClawConfig;
   channel: ChatChannel;
   accountId: string;
+  deleteConfig: boolean;
 }): ConfigWriteOptions {
-  const nextChannel = params.nextConfig.channels?.[params.channel];
   const channelPath = ["channels", params.channel] as const;
   const accountPath = [...channelPath, "accounts", params.accountId] as const;
+  if (!params.deleteConfig) {
+    return {
+      explicitSetPaths: [[...channelPath, "enabled"], [...accountPath, "enabled"]],
+    };
+  }
+  const nextChannel = params.nextConfig.channels?.[params.channel];
   return {
     explicitSetPaths: [nextChannel && typeof nextChannel === "object" ? accountPath : channelPath],
   };
@@ -251,13 +257,12 @@ export async function channelsRemoveCommand(
   const shouldMovePluginInstalls = Boolean(
     next.plugins?.installs && Object.keys(next.plugins.installs).length > 0,
   );
-  const writeOptions = deleteConfig
-    ? resolveDeleteWriteOptions({
-        nextConfig: next,
-        channel: resolvedChannelId,
-        accountId: accountKey,
-      })
-    : undefined;
+  const writeOptions = resolveRemoveWriteOptions({
+    nextConfig: next,
+    channel: resolvedChannelId,
+    accountId: accountKey,
+    deleteConfig,
+  });
   if (shouldMovePluginInstalls) {
     const committed = await commitConfigWithPendingPluginInstalls({
       nextConfig: next,

--- a/src/commands/configure.wizard.test.ts
+++ b/src/commands/configure.wizard.test.ts
@@ -452,6 +452,12 @@ describe("runConfigureWizard", () => {
 
   it("defers channel status checks until a channel is selected", async () => {
     setupBaseWizardState();
+    mocks.setupChannels.mockImplementation(async (cfg: OpenClawConfig) => ({
+      ...cfg,
+      channels: {
+        telegram: { enabled: true },
+      },
+    }));
     queueWizardPrompts({
       select: ["configure"],
       confirm: [],
@@ -465,6 +471,10 @@ describe("runConfigureWizard", () => {
     const setupChannelsOptions = requireRecord(setupChannelsCall?.[3], "setupChannels options");
     expect(setupChannelsOptions.deferStatusUntilSelection).toBe(true);
     expect(setupChannelsOptions.skipStatusNote).toBe(true);
+    const replaceCall = mockCallArg(mocks.replaceConfigFile, "replaceConfigFile") as {
+      writeOptions?: { explicitSetPaths?: string[][] };
+    };
+    expect(replaceCall.writeOptions?.explicitSetPaths).toEqual([["channels", "telegram"]]);
   });
 
   it("still supports keyless web search providers through the shared setup flow", async () => {

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -95,6 +95,27 @@ function mergeWizardConfigOntoLatest(current: unknown, base: unknown, next: unkn
   return structuredClone(next);
 }
 
+const RESERVED_CHANNEL_CONFIG_KEYS = new Set(["defaults", "modelByChannel"]);
+
+function resolveChannelConfigWriteOptions(params: {
+  previousConfig: OpenClawConfig;
+  nextConfig: OpenClawConfig;
+}): { explicitSetPaths: string[][] } | undefined {
+  const previousChannels = isPlainObject(params.previousConfig.channels)
+    ? params.previousConfig.channels
+    : {};
+  const nextChannels = isPlainObject(params.nextConfig.channels) ? params.nextConfig.channels : {};
+  const changedChannelKeys = new Set([
+    ...Object.keys(previousChannels),
+    ...Object.keys(nextChannels),
+  ]);
+  const explicitSetPaths = [...changedChannelKeys]
+    .filter((key) => !RESERVED_CHANNEL_CONFIG_KEYS.has(key))
+    .filter((key) => !isDeepStrictEqual(previousChannels[key], nextChannels[key]))
+    .map((key) => ["channels", key]);
+  return explicitSetPaths.length > 0 ? { explicitSetPaths } : undefined;
+}
+
 async function resolveGatewaySecretInputForWizard(params: {
   cfg: OpenClawConfig;
   value: unknown;
@@ -528,9 +549,14 @@ export async function runConfigureWizard(
       const maxRetries = 3;
       for (let attempt = 0; attempt < maxRetries; attempt++) {
         try {
+          const writeOptions = resolveChannelConfigWriteOptions({
+            previousConfig: mergeBaseConfig,
+            nextConfig,
+          });
           const committed = await commitConfigWithPendingPluginInstalls({
             nextConfig,
             ...(currentBaseHash !== undefined ? { baseHash: currentBaseHash } : {}),
+            ...(writeOptions ? { writeOptions } : {}),
           });
           nextConfig = committed.config;
 

--- a/src/commands/doctor/legacy-config-repair.ts
+++ b/src/commands/doctor/legacy-config-repair.ts
@@ -39,6 +39,7 @@ export async function repairLegacyConfigForUpdateChannel(params: {
     baseHash: params.configSnapshot.hash,
     writeOptions: {
       allowConfigSizeDrop: true,
+      allowProtectedConfigPolicyDrop: true,
       skipOutputLogs: params.jsonMode,
     },
   });

--- a/src/commands/onboard-non-interactive.ts
+++ b/src/commands/onboard-non-interactive.ts
@@ -85,7 +85,7 @@ async function runNonInteractiveMigrationImport(params: {
       await replaceConfigFile({
         nextConfig: config,
         ...(params.baseHash !== undefined ? { baseHash: params.baseHash } : {}),
-        writeOptions: { allowConfigSizeDrop: true },
+        writeOptions: { allowConfigSizeDrop: true, allowProtectedConfigPolicyDrop: true },
       });
       logConfigUpdated(params.runtime);
       return config;

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -207,7 +207,7 @@ export async function runNonInteractiveLocalSetup(params: {
   await replaceConfigFile({
     nextConfig,
     ...(baseHash !== undefined ? { baseHash } : {}),
-    writeOptions: { allowConfigSizeDrop: true },
+    writeOptions: { allowConfigSizeDrop: true, allowProtectedConfigPolicyDrop: true },
   });
   logConfigUpdated(runtime);
 

--- a/src/commands/onboard-non-interactive/remote.ts
+++ b/src/commands/onboard-non-interactive/remote.ts
@@ -44,7 +44,7 @@ export async function runNonInteractiveRemoteSetup(params: {
   await replaceConfigFile({
     nextConfig,
     ...(baseHash !== undefined ? { baseHash } : {}),
-    writeOptions: { allowConfigSizeDrop: true },
+    writeOptions: { allowConfigSizeDrop: true, allowProtectedConfigPolicyDrop: true },
   });
   logConfigUpdated(runtime);
 

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -801,6 +801,14 @@ function appendChannelProtectedPolicyChangeReasons(params: {
       const channelPath = ["channels", channelId] as const;
       const previousChannel = isRecord(previousChannels) ? previousChannels[channelId] : undefined;
       if (!isRecord(previousChannel)) {
+        appendNestedProtectedListChangeReasons({
+          previousConfig: params.previousConfig,
+          nextConfig: params.nextConfig,
+          path: channelPath,
+          protectedKeys: protectedChannelAllowlistKeys,
+          explicitSetPaths: params.explicitSetPaths,
+          reasons: params.reasons,
+        });
         if (
           nextChannel.enabled !== false &&
           !isExplicitChannelActivationPath(channelPath, params.explicitSetPaths)

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -783,7 +783,13 @@ function appendChannelProtectedPolicyChangeReasons(params: {
   explicitSetPaths?: readonly (readonly string[])[];
   reasons: string[];
 }): void {
-  const protectedChannelAllowlistKeys = new Set(["allowFrom", "groupAllowFrom"]);
+  const protectedChannelAllowlistKeys = new Set([
+    "allowFrom",
+    "groupAllowFrom",
+    "approvers",
+    "roles",
+    "users",
+  ]);
   const channelConfigMetaKeys = new Set(["defaults", "modelByChannel"]);
   const previousChannels = getObjectPathValue(params.previousConfig, ["channels"]);
   const nextChannels = getObjectPathValue(params.nextConfig, ["channels"]);

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -230,6 +230,11 @@ export type ConfigWriteOptions = {
    */
   allowConfigSizeDrop?: boolean;
   /**
+   * Allow intentional removal or broadening of channel/command/elevated
+   * allowlists. Normal runtime writers must keep this false.
+   */
+  allowProtectedConfigPolicyDrop?: boolean;
+  /**
    * Suppress human-readable output logs (overwrite/anomaly messages).
    * Useful when the caller wants machine-readable output only (--json mode).
    */
@@ -383,6 +388,560 @@ function normalizeStatId(value: number | bigint | null | undefined): string | nu
   return null;
 }
 
+function getObjectPathValue(value: unknown, pathSegments: readonly string[]): unknown {
+  let current = value;
+  for (const segment of pathSegments) {
+    if (!isRecord(current)) {
+      return undefined;
+    }
+    current = current[segment];
+  }
+  return current;
+}
+
+function hasObjectPathValue(value: unknown, pathSegments: readonly string[]): boolean {
+  let current = value;
+  for (const segment of pathSegments) {
+    if (!isRecord(current) || !Object.prototype.hasOwnProperty.call(current, segment)) {
+      return false;
+    }
+    current = current[segment];
+  }
+  return true;
+}
+
+function formatProtectedConfigPath(pathSegments: readonly string[]): string {
+  return pathSegments.join(".");
+}
+
+function isExplicitConfigWritePath(
+  protectedPath: readonly string[],
+  explicitSetPaths: readonly (readonly string[])[] | undefined,
+): boolean {
+  if (!explicitSetPaths || explicitSetPaths.length === 0) {
+    return false;
+  }
+  return explicitSetPaths.some((explicitPath) => {
+    const sharedLength = Math.min(explicitPath.length, protectedPath.length);
+    for (let index = 0; index < sharedLength; index += 1) {
+      if (explicitPath[index] !== protectedPath[index]) {
+        return false;
+      }
+    }
+    return true;
+  });
+}
+
+function isExplicitConfigWritePathAncestorOrSelf(
+  protectedPath: readonly string[],
+  explicitSetPaths: readonly (readonly string[])[] | undefined,
+): boolean {
+  if (!explicitSetPaths || explicitSetPaths.length === 0) {
+    return false;
+  }
+  return explicitSetPaths.some((explicitPath) => {
+    if (explicitPath.length > protectedPath.length) {
+      return false;
+    }
+    return explicitPath.every((segment, index) => segment === protectedPath[index]);
+  });
+}
+
+function isSameConfigPath(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((segment, index) => segment === right[index]);
+}
+
+function isExplicitChannelActivationPath(
+  channelPath: readonly string[],
+  explicitSetPaths: readonly (readonly string[])[] | undefined,
+): boolean {
+  if (!explicitSetPaths || explicitSetPaths.length === 0) {
+    return false;
+  }
+  const enabledPath = [...channelPath, "enabled"];
+  return explicitSetPaths.some(
+    (explicitPath) =>
+      isSameConfigPath(explicitPath, channelPath) || isSameConfigPath(explicitPath, enabledPath),
+  );
+}
+
+function normalizeProtectedList(value: unknown): string[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  return value.map((entry) => String(entry));
+}
+
+function appendProtectedListValueChangeReasons(params: {
+  previousValue: unknown;
+  nextValue: unknown;
+  nextExists: boolean;
+  pathLabel: string;
+  reasons: string[];
+}): void {
+  const previousList = normalizeProtectedList(params.previousValue);
+  if (!previousList) {
+    return;
+  }
+  if (!params.nextExists) {
+    params.reasons.push(`protected-list-removed:${params.pathLabel}`);
+    return;
+  }
+  const nextList = normalizeProtectedList(params.nextValue);
+  if (!nextList || nextList.length === 0) {
+    if (previousList.length > 0) {
+      params.reasons.push(`protected-list-removed:${params.pathLabel}`);
+    }
+    return;
+  }
+  if (previousList.length === 0) {
+    params.reasons.push(`protected-list-widened:${params.pathLabel}`);
+    return;
+  }
+  const previousSet = new Set(previousList);
+  const nextSet = new Set(nextList);
+  const previousHasWildcard = previousSet.has("*");
+  const nextHasWildcard = nextSet.has("*");
+  if (!previousHasWildcard && nextHasWildcard) {
+    params.reasons.push(`protected-list-widened:${params.pathLabel}`);
+    return;
+  }
+  if (nextList.some((entry) => !previousSet.has(entry))) {
+    params.reasons.push(`protected-list-widened:${params.pathLabel}`);
+    return;
+  }
+  if (previousList.some((entry) => !nextSet.has(entry))) {
+    params.reasons.push(`protected-list-shrunk:${params.pathLabel}`);
+  }
+}
+
+function appendProtectedListChangeReasons(params: {
+  previousConfig: unknown;
+  nextConfig: unknown;
+  path: readonly string[];
+  explicitSetPaths?: readonly (readonly string[])[];
+  reasons: string[];
+}): void {
+  if (isExplicitConfigWritePath(params.path, params.explicitSetPaths)) {
+    return;
+  }
+  const previousExists = hasObjectPathValue(params.previousConfig, params.path);
+  if (!previousExists) {
+    const nextList = normalizeProtectedList(getObjectPathValue(params.nextConfig, params.path));
+    if (nextList && nextList.length > 0) {
+      params.reasons.push(`protected-list-widened:${formatProtectedConfigPath(params.path)}`);
+    }
+    return;
+  }
+  const nextExists = hasObjectPathValue(params.nextConfig, params.path);
+  appendProtectedListValueChangeReasons({
+    previousValue: getObjectPathValue(params.previousConfig, params.path),
+    nextValue: getObjectPathValue(params.nextConfig, params.path),
+    nextExists,
+    pathLabel: formatProtectedConfigPath(params.path),
+    reasons: params.reasons,
+  });
+}
+
+function appendProtectedAllowFromMapChangeReasons(params: {
+  previousConfig: unknown;
+  nextConfig: unknown;
+  path: readonly string[];
+  displayPath?: readonly string[];
+  explicitSetPaths?: readonly (readonly string[])[];
+  reasons: string[];
+}): void {
+  const previousMap = getObjectPathValue(params.previousConfig, params.path);
+  const nextMap = getObjectPathValue(params.nextConfig, params.path);
+  const displayPath = params.displayPath ?? params.path;
+  const pathLabel = formatProtectedConfigPath(displayPath);
+  if (!isRecord(previousMap) || Object.keys(previousMap).length === 0) {
+    if (!isRecord(nextMap)) {
+      return;
+    }
+    if (isExplicitConfigWritePathAncestorOrSelf(params.path, params.explicitSetPaths)) {
+      return;
+    }
+    for (const key of Object.keys(nextMap)) {
+      const protectedPath = [...params.path, key];
+      if (isExplicitConfigWritePath(protectedPath, params.explicitSetPaths)) {
+        continue;
+      }
+      const nextList = normalizeProtectedList(nextMap[key]);
+      if (nextList && nextList.length > 0) {
+        params.reasons.push(
+          `protected-list-widened:${formatProtectedConfigPath([...displayPath, key])}`,
+        );
+      }
+    }
+    return;
+  }
+  if (!isRecord(nextMap)) {
+    const allPreviousEntriesExplicit = Object.keys(previousMap).every((key) =>
+      isExplicitConfigWritePath([...params.path, key], params.explicitSetPaths),
+    );
+    if (
+      isExplicitConfigWritePathAncestorOrSelf(params.path, params.explicitSetPaths) ||
+      allPreviousEntriesExplicit
+    ) {
+      return;
+    }
+    params.reasons.push(`protected-map-removed:${pathLabel}`);
+    return;
+  }
+  for (const key of Object.keys(previousMap)) {
+    const protectedPath = [...params.path, key];
+    if (isExplicitConfigWritePath(protectedPath, params.explicitSetPaths)) {
+      continue;
+    }
+    const previousValue = previousMap[key];
+    const nextExists = Object.prototype.hasOwnProperty.call(nextMap, key);
+    appendProtectedListValueChangeReasons({
+      previousValue,
+      nextValue: nextMap[key],
+      nextExists,
+      pathLabel: formatProtectedConfigPath([...displayPath, key]),
+      reasons: params.reasons,
+    });
+  }
+  for (const key of Object.keys(nextMap)) {
+    if (Object.prototype.hasOwnProperty.call(previousMap, key)) {
+      continue;
+    }
+    const protectedPath = [...params.path, key];
+    if (isExplicitConfigWritePath(protectedPath, params.explicitSetPaths)) {
+      continue;
+    }
+    const nextList = normalizeProtectedList(nextMap[key]);
+    if (nextList && nextList.length > 0) {
+      params.reasons.push(
+        `protected-list-widened:${formatProtectedConfigPath([...displayPath, key])}`,
+      );
+    }
+  }
+}
+
+function appendNestedProtectedListChangeReasons(params: {
+  previousConfig: unknown;
+  nextConfig: unknown;
+  path: readonly string[];
+  protectedKeys: ReadonlySet<string>;
+  explicitSetPaths?: readonly (readonly string[])[];
+  reasons: string[];
+}): void {
+  const previousValue = getObjectPathValue(params.previousConfig, params.path);
+  const nextValue = getObjectPathValue(params.nextConfig, params.path);
+  if (!isRecord(previousValue) && !isRecord(nextValue)) {
+    return;
+  }
+  const previousRecord = isRecord(previousValue) ? previousValue : {};
+  const nextRecord = isRecord(nextValue) ? nextValue : {};
+  const keys = new Set([...Object.keys(previousRecord), ...Object.keys(nextRecord)]);
+  for (const key of keys) {
+    const previousChild = previousRecord[key];
+    const nextChild = nextRecord[key];
+    const childPath = [...params.path, key];
+    if (
+      params.protectedKeys.has(key) &&
+      (Array.isArray(previousChild) || Array.isArray(nextChild))
+    ) {
+      appendProtectedListChangeReasons({
+        previousConfig: params.previousConfig,
+        nextConfig: params.nextConfig,
+        path: childPath,
+        explicitSetPaths: params.explicitSetPaths,
+        reasons: params.reasons,
+      });
+      continue;
+    }
+    if (isRecord(previousChild) || isRecord(nextChild)) {
+      appendNestedProtectedListChangeReasons({
+        previousConfig: params.previousConfig,
+        nextConfig: params.nextConfig,
+        path: childPath,
+        protectedKeys: params.protectedKeys,
+        explicitSetPaths: params.explicitSetPaths,
+        reasons: params.reasons,
+      });
+    }
+  }
+}
+
+function listAgentRelativeExplicitSetPaths(params: {
+  explicitSetPaths?: readonly (readonly string[])[];
+  agentId: string | null;
+  index: number;
+}): readonly (readonly string[])[] | undefined {
+  const relativePaths = params.explicitSetPaths?.flatMap((explicitPath) => {
+    if (explicitPath[0] !== "agents") {
+      return [];
+    }
+    if (explicitPath.length === 1) {
+      return [[]];
+    }
+    if (explicitPath[1] !== "list") {
+      return [];
+    }
+    if (explicitPath.length === 2) {
+      return [[]];
+    }
+    const selector = explicitPath[2];
+    if (selector !== String(params.index) && (!params.agentId || selector !== params.agentId)) {
+      return [];
+    }
+    const relativePath = explicitPath.slice(3);
+    return [relativePath];
+  });
+  return relativePaths && relativePaths.length > 0 ? relativePaths : undefined;
+}
+
+function appendAgentProtectedPolicyChangeReasons(params: {
+  previousConfig: unknown;
+  nextConfig: unknown;
+  explicitSetPaths?: readonly (readonly string[])[];
+  reasons: string[];
+}): void {
+  const previousAgents = getObjectPathValue(params.previousConfig, ["agents", "list"]);
+  const nextAgents = getObjectPathValue(params.nextConfig, ["agents", "list"]);
+  const previousAgentsById = new Map<string, unknown>();
+  if (Array.isArray(previousAgents)) {
+    for (const agent of previousAgents) {
+      const id = isRecord(agent) && typeof agent.id === "string" ? agent.id : null;
+      if (id) {
+        previousAgentsById.set(id, agent);
+      }
+    }
+  }
+  const nextAgentsById = new Map<string, unknown>();
+  if (Array.isArray(nextAgents)) {
+    for (const agent of nextAgents) {
+      const id = isRecord(agent) && typeof agent.id === "string" ? agent.id : null;
+      if (id) {
+        nextAgentsById.set(id, agent);
+      }
+    }
+  }
+  if (Array.isArray(previousAgents)) {
+    previousAgents.forEach((previousAgent, index) => {
+      if (!isRecord(previousAgent)) {
+        return;
+      }
+      const id = typeof previousAgent.id === "string" ? previousAgent.id : null;
+      const nextAgent = id
+        ? nextAgentsById.get(id)
+        : Array.isArray(nextAgents)
+          ? nextAgents[index]
+          : null;
+      appendProtectedAllowFromMapChangeReasons({
+        previousConfig: previousAgent,
+        nextConfig: nextAgent,
+        path: ["tools", "elevated", "allowFrom"],
+        displayPath: ["agents", "list", id ?? String(index), "tools", "elevated", "allowFrom"],
+        explicitSetPaths: listAgentRelativeExplicitSetPaths({
+          explicitSetPaths: params.explicitSetPaths,
+          agentId: id,
+          index,
+        }),
+        reasons: params.reasons,
+      });
+    });
+  }
+  if (!Array.isArray(nextAgents)) {
+    return;
+  }
+  nextAgents.forEach((nextAgent, index) => {
+    if (!isRecord(nextAgent)) {
+      return;
+    }
+    const id = typeof nextAgent.id === "string" ? nextAgent.id : null;
+    const previousAgent = id
+      ? previousAgentsById.get(id)
+      : Array.isArray(previousAgents)
+        ? previousAgents[index]
+        : null;
+    if (isRecord(previousAgent)) {
+      return;
+    }
+    appendProtectedAllowFromMapChangeReasons({
+      previousConfig: previousAgent,
+      nextConfig: nextAgent,
+      path: ["tools", "elevated", "allowFrom"],
+      displayPath: ["agents", "list", id ?? String(index), "tools", "elevated", "allowFrom"],
+      explicitSetPaths: listAgentRelativeExplicitSetPaths({
+        explicitSetPaths: params.explicitSetPaths,
+        agentId: id,
+        index,
+      }),
+      reasons: params.reasons,
+    });
+  });
+}
+
+function appendChannelProtectedPolicyChangeReasons(params: {
+  previousConfig: unknown;
+  nextConfig: unknown;
+  explicitSetPaths?: readonly (readonly string[])[];
+  reasons: string[];
+}): void {
+  const protectedChannelAllowlistKeys = new Set(["allowFrom", "groupAllowFrom"]);
+  const channelConfigMetaKeys = new Set(["defaults", "modelByChannel"]);
+  const previousChannels = getObjectPathValue(params.previousConfig, ["channels"]);
+  const nextChannels = getObjectPathValue(params.nextConfig, ["channels"]);
+  if (!isRecord(previousChannels) && !isRecord(nextChannels)) {
+    return;
+  }
+  if (isRecord(nextChannels)) {
+    for (const [channelId, nextChannel] of Object.entries(nextChannels)) {
+      if (channelConfigMetaKeys.has(channelId)) {
+        continue;
+      }
+      if (!isRecord(nextChannel)) {
+        continue;
+      }
+      const channelPath = ["channels", channelId] as const;
+      const previousChannel = isRecord(previousChannels) ? previousChannels[channelId] : undefined;
+      if (!isRecord(previousChannel)) {
+        if (
+          nextChannel.enabled !== false &&
+          !isExplicitChannelActivationPath(channelPath, params.explicitSetPaths)
+        ) {
+          params.reasons.push(`protected-channel-enabled:${formatProtectedConfigPath(channelPath)}`);
+        }
+        continue;
+      }
+      const nextAccounts = nextChannel.accounts;
+      if (!isRecord(nextAccounts)) {
+        continue;
+      }
+      const previousAccounts = isRecord(previousChannel.accounts) ? previousChannel.accounts : null;
+      for (const [accountId, nextAccount] of Object.entries(nextAccounts)) {
+        if (!isRecord(nextAccount)) {
+          continue;
+        }
+        const accountPath = [...channelPath, "accounts", accountId] as const;
+        if (
+          !isRecord(previousAccounts?.[accountId]) &&
+          nextAccount.enabled !== false &&
+          !isExplicitChannelActivationPath(accountPath, params.explicitSetPaths)
+        ) {
+          params.reasons.push(
+            `protected-channel-enabled:${formatProtectedConfigPath(accountPath)}`,
+          );
+        }
+      }
+    }
+  }
+  if (!isRecord(previousChannels)) {
+    return;
+  }
+  for (const [channelId, previousChannel] of Object.entries(previousChannels)) {
+    if (channelConfigMetaKeys.has(channelId)) {
+      continue;
+    }
+    if (!isRecord(previousChannel)) {
+      continue;
+    }
+    const channelPath = ["channels", channelId] as const;
+    const nextChannel = isRecord(nextChannels) ? nextChannels[channelId] : undefined;
+    const channelRemoved = !isRecord(nextChannel);
+    if (
+      channelRemoved &&
+      previousChannel.enabled !== false &&
+      !isExplicitConfigWritePathAncestorOrSelf(channelPath, params.explicitSetPaths)
+    ) {
+      params.reasons.push(`protected-channel-removed:${formatProtectedConfigPath(channelPath)}`);
+    }
+    appendNestedProtectedListChangeReasons({
+      previousConfig: params.previousConfig,
+      nextConfig: params.nextConfig,
+      path: channelPath,
+      protectedKeys: protectedChannelAllowlistKeys,
+      explicitSetPaths: params.explicitSetPaths,
+      reasons: params.reasons,
+    });
+    const previousAccounts = previousChannel.accounts;
+    if (isRecord(previousAccounts)) {
+      for (const [accountId, previousAccount] of Object.entries(previousAccounts)) {
+        if (!isRecord(previousAccount)) {
+          continue;
+        }
+        const accountPath = [...channelPath, "accounts", accountId] as const;
+        const nextAccount = getObjectPathValue(params.nextConfig, accountPath);
+        if (!isRecord(nextAccount)) {
+          if (
+            previousAccount.enabled !== false &&
+            !isExplicitConfigWritePathAncestorOrSelf(accountPath, params.explicitSetPaths)
+          ) {
+            params.reasons.push(
+              `protected-channel-removed:${formatProtectedConfigPath(accountPath)}`,
+            );
+          }
+          continue;
+        }
+        if (
+          previousAccount.enabled === false &&
+          nextAccount.enabled !== false &&
+          !isExplicitChannelActivationPath(accountPath, params.explicitSetPaths)
+        ) {
+          params.reasons.push(
+            `protected-channel-enabled:${formatProtectedConfigPath(accountPath)}`,
+          );
+        }
+      }
+    }
+    if (
+      !channelRemoved &&
+      previousChannel.enabled === false &&
+      nextChannel.enabled !== false &&
+      !isExplicitChannelActivationPath(channelPath, params.explicitSetPaths)
+    ) {
+      params.reasons.push(`protected-channel-enabled:${formatProtectedConfigPath(channelPath)}`);
+    }
+  }
+}
+
+function listProtectedConfigPolicyChangeReasons(params: {
+  previousConfig: unknown;
+  nextConfig: unknown;
+  explicitSetPaths?: readonly (readonly string[])[];
+}): string[] {
+  const reasons: string[] = [];
+  appendProtectedListChangeReasons({
+    previousConfig: params.previousConfig,
+    nextConfig: params.nextConfig,
+    path: ["commands", "ownerAllowFrom"],
+    explicitSetPaths: params.explicitSetPaths,
+    reasons,
+  });
+  appendProtectedAllowFromMapChangeReasons({
+    previousConfig: params.previousConfig,
+    nextConfig: params.nextConfig,
+    path: ["commands", "allowFrom"],
+    explicitSetPaths: params.explicitSetPaths,
+    reasons,
+  });
+  appendProtectedAllowFromMapChangeReasons({
+    previousConfig: params.previousConfig,
+    nextConfig: params.nextConfig,
+    path: ["tools", "elevated", "allowFrom"],
+    explicitSetPaths: params.explicitSetPaths,
+    reasons,
+  });
+  appendAgentProtectedPolicyChangeReasons({
+    previousConfig: params.previousConfig,
+    nextConfig: params.nextConfig,
+    explicitSetPaths: params.explicitSetPaths,
+    reasons,
+  });
+  appendChannelProtectedPolicyChangeReasons({
+    previousConfig: params.previousConfig,
+    nextConfig: params.nextConfig,
+    explicitSetPaths: params.explicitSetPaths,
+    reasons,
+  });
+  return reasons;
+}
+
 function resolveConfigStatMetadata(
   stat: fs.Stats | null,
 ): Pick<ConfigHealthFingerprint, "dev" | "ino" | "mode" | "nlink" | "uid" | "gid"> {
@@ -403,6 +962,9 @@ function resolveConfigWriteSuspiciousReasons(params: {
   hasMetaBefore: boolean;
   gatewayModeBefore: string | null;
   gatewayModeAfter: string | null;
+  previousConfig: unknown;
+  nextConfig: unknown;
+  explicitSetPaths?: readonly (readonly string[])[];
 }): string[] {
   const reasons: string[] = [];
   if (!params.existsBefore) {
@@ -422,17 +984,41 @@ function resolveConfigWriteSuspiciousReasons(params: {
   if (params.gatewayModeBefore && !params.gatewayModeAfter) {
     reasons.push("gateway-mode-removed");
   }
+  reasons.push(
+    ...listProtectedConfigPolicyChangeReasons({
+      previousConfig: params.previousConfig,
+      nextConfig: params.nextConfig,
+      explicitSetPaths: params.explicitSetPaths,
+    }),
+  );
   return reasons;
 }
 
 function resolveConfigWriteBlockingReasons(
   suspicious: string[],
-  options: Pick<ConfigWriteOptions, "allowConfigSizeDrop"> = {},
+  options: Pick<ConfigWriteOptions, "allowConfigSizeDrop" | "allowProtectedConfigPolicyDrop"> = {},
 ): string[] {
   return suspicious.filter(
     (reason) =>
       (reason.startsWith("size-drop:") && options.allowConfigSizeDrop !== true) ||
-      reason === "gateway-mode-removed",
+      reason === "gateway-mode-removed" ||
+      (reason.startsWith("protected-") && options.allowProtectedConfigPolicyDrop !== true),
+  );
+}
+
+export function resolveProtectedConfigPolicyWriteBlockingReasons(params: {
+  previousConfig: unknown;
+  nextConfig: unknown;
+  explicitSetPaths?: readonly (readonly string[])[];
+  allowProtectedConfigPolicyDrop?: boolean;
+}): string[] {
+  return resolveConfigWriteBlockingReasons(
+    listProtectedConfigPolicyChangeReasons({
+      previousConfig: params.previousConfig,
+      nextConfig: params.nextConfig,
+      explicitSetPaths: params.explicitSetPaths,
+    }),
+    { allowProtectedConfigPolicyDrop: params.allowProtectedConfigPolicyDrop },
   );
 }
 
@@ -2139,6 +2725,7 @@ export function createConfigIO(
     const hasMetaAfter = hasConfigMeta(stampedOutputConfig);
     const gatewayModeBefore = resolveGatewayMode(snapshot.resolved);
     const gatewayModeAfter = resolveGatewayMode(stampedOutputConfig);
+    const protectedPolicyNextConfig = applyUnsetPathsForWrite(cfg, unsetPaths);
     const suspiciousReasons = resolveConfigWriteSuspiciousReasons({
       existsBefore: snapshot.exists,
       previousBytes,
@@ -2146,6 +2733,9 @@ export function createConfigIO(
       hasMetaBefore,
       gatewayModeBefore,
       gatewayModeAfter,
+      previousConfig: snapshot.resolved,
+      nextConfig: protectedPolicyNextConfig,
+      explicitSetPaths: [...(options.explicitSetPaths ?? []), ...unsetPaths],
     });
     const logConfigOverwrite = () => {
       if (!snapshot.exists) {
@@ -2474,6 +3064,7 @@ export async function writeConfigFile(
     afterWrite: options.afterWrite,
     allowDestructiveWrite: options.allowDestructiveWrite,
     allowConfigSizeDrop: options.allowConfigSizeDrop,
+    allowProtectedConfigPolicyDrop: options.allowProtectedConfigPolicyDrop,
     skipRuntimeSnapshotRefresh: options.skipRuntimeSnapshotRefresh,
     skipOutputLogs: options.skipOutputLogs,
     skipPluginValidation: options.skipPluginValidation,

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -82,6 +82,7 @@ import {
   extractShippedPluginInstallConfigRecords,
   stripShippedPluginInstallConfigRecords,
 } from "./plugin-install-config-migration.js";
+import { listProtectedConfigPolicyChangeReasons } from "./protected-policy.js";
 import { applyConfigOverrides } from "./runtime-overrides.js";
 import {
   clearRuntimeConfigSnapshot as clearRuntimeConfigSnapshotState,
@@ -204,6 +205,11 @@ export type ConfigWriteOptions = {
    * persisted even when they equal runtime-injected defaults.
    */
   explicitSetPaths?: readonly (readonly string[])[];
+  /**
+   * Paths that were explicitly changed by the caller for protected-policy
+   * checks only. Unlike explicitSetPaths, these do not force persistence.
+   */
+  explicitProtectedConfigPolicyPaths?: readonly (readonly string[])[];
   /**
    * Internal companion for explicitSetPaths after a wrapper has projected a
    * runtime-shaped config back onto the authored source shape.
@@ -388,593 +394,6 @@ function normalizeStatId(value: number | bigint | null | undefined): string | nu
   return null;
 }
 
-function getObjectPathValue(value: unknown, pathSegments: readonly string[]): unknown {
-  let current = value;
-  for (const segment of pathSegments) {
-    if (!isRecord(current)) {
-      return undefined;
-    }
-    current = current[segment];
-  }
-  return current;
-}
-
-function hasObjectPathValue(value: unknown, pathSegments: readonly string[]): boolean {
-  let current = value;
-  for (const segment of pathSegments) {
-    if (!isRecord(current) || !Object.prototype.hasOwnProperty.call(current, segment)) {
-      return false;
-    }
-    current = current[segment];
-  }
-  return true;
-}
-
-function formatProtectedConfigPath(pathSegments: readonly string[]): string {
-  return pathSegments.join(".");
-}
-
-function isExplicitConfigWritePath(
-  protectedPath: readonly string[],
-  explicitSetPaths: readonly (readonly string[])[] | undefined,
-): boolean {
-  if (!explicitSetPaths || explicitSetPaths.length === 0) {
-    return false;
-  }
-  return explicitSetPaths.some((explicitPath) => {
-    const sharedLength = Math.min(explicitPath.length, protectedPath.length);
-    for (let index = 0; index < sharedLength; index += 1) {
-      if (explicitPath[index] !== protectedPath[index]) {
-        return false;
-      }
-    }
-    return true;
-  });
-}
-
-function isExplicitConfigWritePathAncestorOrSelf(
-  protectedPath: readonly string[],
-  explicitSetPaths: readonly (readonly string[])[] | undefined,
-): boolean {
-  if (!explicitSetPaths || explicitSetPaths.length === 0) {
-    return false;
-  }
-  return explicitSetPaths.some((explicitPath) => {
-    if (explicitPath.length > protectedPath.length) {
-      return false;
-    }
-    return explicitPath.every((segment, index) => segment === protectedPath[index]);
-  });
-}
-
-function isSameConfigPath(left: readonly string[], right: readonly string[]): boolean {
-  return left.length === right.length && left.every((segment, index) => segment === right[index]);
-}
-
-function isExplicitChannelActivationPath(
-  channelPath: readonly string[],
-  explicitSetPaths: readonly (readonly string[])[] | undefined,
-): boolean {
-  if (!explicitSetPaths || explicitSetPaths.length === 0) {
-    return false;
-  }
-  const enabledPath = [...channelPath, "enabled"];
-  return explicitSetPaths.some(
-    (explicitPath) =>
-      isSameConfigPath(explicitPath, enabledPath) ||
-      (explicitPath.length <= channelPath.length &&
-        explicitPath.every((segment, index) => segment === channelPath[index])),
-  );
-}
-
-function normalizeProtectedList(value: unknown): string[] | null {
-  if (!Array.isArray(value)) {
-    return null;
-  }
-  return value.map((entry) => String(entry));
-}
-
-function appendProtectedListValueChangeReasons(params: {
-  previousValue: unknown;
-  nextValue: unknown;
-  nextExists: boolean;
-  pathLabel: string;
-  reasons: string[];
-}): void {
-  const previousList = normalizeProtectedList(params.previousValue);
-  if (!previousList) {
-    return;
-  }
-  if (!params.nextExists) {
-    params.reasons.push(`protected-list-removed:${params.pathLabel}`);
-    return;
-  }
-  const nextList = normalizeProtectedList(params.nextValue);
-  if (!nextList || nextList.length === 0) {
-    if (previousList.length > 0) {
-      params.reasons.push(`protected-list-removed:${params.pathLabel}`);
-    }
-    return;
-  }
-  if (previousList.length === 0) {
-    params.reasons.push(`protected-list-widened:${params.pathLabel}`);
-    return;
-  }
-  const previousSet = new Set(previousList);
-  const nextSet = new Set(nextList);
-  const previousHasWildcard = previousSet.has("*");
-  const nextHasWildcard = nextSet.has("*");
-  if (!previousHasWildcard && nextHasWildcard) {
-    params.reasons.push(`protected-list-widened:${params.pathLabel}`);
-    return;
-  }
-  if (nextList.some((entry) => !previousSet.has(entry))) {
-    params.reasons.push(`protected-list-widened:${params.pathLabel}`);
-    return;
-  }
-  if (previousList.some((entry) => !nextSet.has(entry))) {
-    params.reasons.push(`protected-list-shrunk:${params.pathLabel}`);
-  }
-}
-
-function appendProtectedListChangeReasons(params: {
-  previousConfig: unknown;
-  nextConfig: unknown;
-  path: readonly string[];
-  explicitSetPaths?: readonly (readonly string[])[];
-  reasons: string[];
-}): void {
-  if (isExplicitConfigWritePath(params.path, params.explicitSetPaths)) {
-    return;
-  }
-  const previousExists = hasObjectPathValue(params.previousConfig, params.path);
-  if (!previousExists) {
-    const nextList = normalizeProtectedList(getObjectPathValue(params.nextConfig, params.path));
-    if (nextList && nextList.length > 0) {
-      params.reasons.push(`protected-list-widened:${formatProtectedConfigPath(params.path)}`);
-    }
-    return;
-  }
-  const nextExists = hasObjectPathValue(params.nextConfig, params.path);
-  appendProtectedListValueChangeReasons({
-    previousValue: getObjectPathValue(params.previousConfig, params.path),
-    nextValue: getObjectPathValue(params.nextConfig, params.path),
-    nextExists,
-    pathLabel: formatProtectedConfigPath(params.path),
-    reasons: params.reasons,
-  });
-}
-
-function appendProtectedAllowFromMapChangeReasons(params: {
-  previousConfig: unknown;
-  nextConfig: unknown;
-  path: readonly string[];
-  displayPath?: readonly string[];
-  explicitSetPaths?: readonly (readonly string[])[];
-  reasons: string[];
-}): void {
-  const previousMap = getObjectPathValue(params.previousConfig, params.path);
-  const nextMap = getObjectPathValue(params.nextConfig, params.path);
-  const displayPath = params.displayPath ?? params.path;
-  const pathLabel = formatProtectedConfigPath(displayPath);
-  if (!isRecord(previousMap) || Object.keys(previousMap).length === 0) {
-    if (!isRecord(nextMap)) {
-      return;
-    }
-    if (isExplicitConfigWritePathAncestorOrSelf(params.path, params.explicitSetPaths)) {
-      return;
-    }
-    for (const key of Object.keys(nextMap)) {
-      const protectedPath = [...params.path, key];
-      if (isExplicitConfigWritePath(protectedPath, params.explicitSetPaths)) {
-        continue;
-      }
-      const nextList = normalizeProtectedList(nextMap[key]);
-      if (nextList && nextList.length > 0) {
-        params.reasons.push(
-          `protected-list-widened:${formatProtectedConfigPath([...displayPath, key])}`,
-        );
-      }
-    }
-    return;
-  }
-  if (!isRecord(nextMap)) {
-    const allPreviousEntriesExplicit = Object.keys(previousMap).every((key) =>
-      isExplicitConfigWritePath([...params.path, key], params.explicitSetPaths),
-    );
-    if (
-      isExplicitConfigWritePathAncestorOrSelf(params.path, params.explicitSetPaths) ||
-      allPreviousEntriesExplicit
-    ) {
-      return;
-    }
-    params.reasons.push(`protected-map-removed:${pathLabel}`);
-    return;
-  }
-  for (const key of Object.keys(previousMap)) {
-    const protectedPath = [...params.path, key];
-    if (isExplicitConfigWritePath(protectedPath, params.explicitSetPaths)) {
-      continue;
-    }
-    const previousValue = previousMap[key];
-    const nextExists = Object.prototype.hasOwnProperty.call(nextMap, key);
-    appendProtectedListValueChangeReasons({
-      previousValue,
-      nextValue: nextMap[key],
-      nextExists,
-      pathLabel: formatProtectedConfigPath([...displayPath, key]),
-      reasons: params.reasons,
-    });
-  }
-  for (const key of Object.keys(nextMap)) {
-    if (Object.prototype.hasOwnProperty.call(previousMap, key)) {
-      continue;
-    }
-    const protectedPath = [...params.path, key];
-    if (isExplicitConfigWritePath(protectedPath, params.explicitSetPaths)) {
-      continue;
-    }
-    const nextList = normalizeProtectedList(nextMap[key]);
-    if (nextList && nextList.length > 0) {
-      params.reasons.push(
-        `protected-list-widened:${formatProtectedConfigPath([...displayPath, key])}`,
-      );
-    }
-  }
-}
-
-function appendNestedProtectedListChangeReasons(params: {
-  previousConfig: unknown;
-  nextConfig: unknown;
-  path: readonly string[];
-  protectedKeys: ReadonlySet<string>;
-  explicitSetPaths?: readonly (readonly string[])[];
-  reasons: string[];
-}): void {
-  const previousValue = getObjectPathValue(params.previousConfig, params.path);
-  const nextValue = getObjectPathValue(params.nextConfig, params.path);
-  if (!isRecord(previousValue) && !isRecord(nextValue)) {
-    return;
-  }
-  const previousRecord = isRecord(previousValue) ? previousValue : {};
-  const nextRecord = isRecord(nextValue) ? nextValue : {};
-  const keys = new Set([...Object.keys(previousRecord), ...Object.keys(nextRecord)]);
-  for (const key of keys) {
-    const previousChild = previousRecord[key];
-    const nextChild = nextRecord[key];
-    const childPath = [...params.path, key];
-    if (
-      params.protectedKeys.has(key) &&
-      (Array.isArray(previousChild) || Array.isArray(nextChild))
-    ) {
-      appendProtectedListChangeReasons({
-        previousConfig: params.previousConfig,
-        nextConfig: params.nextConfig,
-        path: childPath,
-        explicitSetPaths: params.explicitSetPaths,
-        reasons: params.reasons,
-      });
-      continue;
-    }
-    if (isRecord(previousChild) || isRecord(nextChild)) {
-      appendNestedProtectedListChangeReasons({
-        previousConfig: params.previousConfig,
-        nextConfig: params.nextConfig,
-        path: childPath,
-        protectedKeys: params.protectedKeys,
-        explicitSetPaths: params.explicitSetPaths,
-        reasons: params.reasons,
-      });
-    }
-  }
-}
-
-function listAgentRelativeExplicitSetPaths(params: {
-  explicitSetPaths?: readonly (readonly string[])[];
-  agentId: string | null;
-  index: number;
-}): readonly (readonly string[])[] | undefined {
-  const relativePaths = params.explicitSetPaths?.flatMap((explicitPath) => {
-    if (explicitPath[0] !== "agents") {
-      return [];
-    }
-    if (explicitPath.length === 1) {
-      return [[]];
-    }
-    if (explicitPath[1] !== "list") {
-      return [];
-    }
-    if (explicitPath.length === 2) {
-      return [[]];
-    }
-    const selector = explicitPath[2];
-    if (selector !== String(params.index) && (!params.agentId || selector !== params.agentId)) {
-      return [];
-    }
-    const relativePath = explicitPath.slice(3);
-    return [relativePath];
-  });
-  return relativePaths && relativePaths.length > 0 ? relativePaths : undefined;
-}
-
-function appendAgentProtectedPolicyChangeReasons(params: {
-  previousConfig: unknown;
-  nextConfig: unknown;
-  explicitSetPaths?: readonly (readonly string[])[];
-  reasons: string[];
-}): void {
-  const previousAgents = getObjectPathValue(params.previousConfig, ["agents", "list"]);
-  const nextAgents = getObjectPathValue(params.nextConfig, ["agents", "list"]);
-  const previousAgentsById = new Map<string, unknown>();
-  if (Array.isArray(previousAgents)) {
-    for (const agent of previousAgents) {
-      const id = isRecord(agent) && typeof agent.id === "string" ? agent.id : null;
-      if (id) {
-        previousAgentsById.set(id, agent);
-      }
-    }
-  }
-  const nextAgentsById = new Map<string, unknown>();
-  if (Array.isArray(nextAgents)) {
-    for (const agent of nextAgents) {
-      const id = isRecord(agent) && typeof agent.id === "string" ? agent.id : null;
-      if (id) {
-        nextAgentsById.set(id, agent);
-      }
-    }
-  }
-  if (Array.isArray(previousAgents)) {
-    previousAgents.forEach((previousAgent, index) => {
-      if (!isRecord(previousAgent)) {
-        return;
-      }
-      const id = typeof previousAgent.id === "string" ? previousAgent.id : null;
-      const nextAgent = id
-        ? nextAgentsById.get(id)
-        : Array.isArray(nextAgents)
-          ? nextAgents[index]
-          : null;
-      appendProtectedAllowFromMapChangeReasons({
-        previousConfig: previousAgent,
-        nextConfig: nextAgent,
-        path: ["tools", "elevated", "allowFrom"],
-        displayPath: ["agents", "list", id ?? String(index), "tools", "elevated", "allowFrom"],
-        explicitSetPaths: listAgentRelativeExplicitSetPaths({
-          explicitSetPaths: params.explicitSetPaths,
-          agentId: id,
-          index,
-        }),
-        reasons: params.reasons,
-      });
-    });
-  }
-  if (!Array.isArray(nextAgents)) {
-    return;
-  }
-  nextAgents.forEach((nextAgent, index) => {
-    if (!isRecord(nextAgent)) {
-      return;
-    }
-    const id = typeof nextAgent.id === "string" ? nextAgent.id : null;
-    const previousAgent = id
-      ? previousAgentsById.get(id)
-      : Array.isArray(previousAgents)
-        ? previousAgents[index]
-        : null;
-    if (isRecord(previousAgent)) {
-      return;
-    }
-    appendProtectedAllowFromMapChangeReasons({
-      previousConfig: previousAgent,
-      nextConfig: nextAgent,
-      path: ["tools", "elevated", "allowFrom"],
-      displayPath: ["agents", "list", id ?? String(index), "tools", "elevated", "allowFrom"],
-      explicitSetPaths: listAgentRelativeExplicitSetPaths({
-        explicitSetPaths: params.explicitSetPaths,
-        agentId: id,
-        index,
-      }),
-      reasons: params.reasons,
-    });
-  });
-}
-
-function appendChannelProtectedPolicyChangeReasons(params: {
-  previousConfig: unknown;
-  nextConfig: unknown;
-  explicitSetPaths?: readonly (readonly string[])[];
-  reasons: string[];
-}): void {
-  const protectedChannelAllowlistKeys = new Set([
-    "allowFrom",
-    "groupAllowFrom",
-    "approvers",
-    "roles",
-    "users",
-  ]);
-  const channelConfigMetaKeys = new Set(["defaults", "modelByChannel"]);
-  const previousChannels = getObjectPathValue(params.previousConfig, ["channels"]);
-  const nextChannels = getObjectPathValue(params.nextConfig, ["channels"]);
-  if (!isRecord(previousChannels) && !isRecord(nextChannels)) {
-    return;
-  }
-  if (isRecord(nextChannels)) {
-    for (const [channelId, nextChannel] of Object.entries(nextChannels)) {
-      if (channelConfigMetaKeys.has(channelId)) {
-        continue;
-      }
-      if (!isRecord(nextChannel)) {
-        continue;
-      }
-      const channelPath = ["channels", channelId] as const;
-      const previousChannel = isRecord(previousChannels) ? previousChannels[channelId] : undefined;
-      if (!isRecord(previousChannel)) {
-        appendNestedProtectedListChangeReasons({
-          previousConfig: params.previousConfig,
-          nextConfig: params.nextConfig,
-          path: channelPath,
-          protectedKeys: protectedChannelAllowlistKeys,
-          explicitSetPaths: params.explicitSetPaths,
-          reasons: params.reasons,
-        });
-        if (
-          nextChannel.enabled !== false &&
-          !isExplicitChannelActivationPath(channelPath, params.explicitSetPaths)
-        ) {
-          params.reasons.push(`protected-channel-enabled:${formatProtectedConfigPath(channelPath)}`);
-        }
-        continue;
-      }
-      const nextAccounts = nextChannel.accounts;
-      if (!isRecord(nextAccounts)) {
-        continue;
-      }
-      const previousAccounts = isRecord(previousChannel.accounts) ? previousChannel.accounts : null;
-      for (const [accountId, nextAccount] of Object.entries(nextAccounts)) {
-        if (!isRecord(nextAccount)) {
-          continue;
-        }
-        const accountPath = [...channelPath, "accounts", accountId] as const;
-        if (
-          !isRecord(previousAccounts?.[accountId]) &&
-          nextAccount.enabled !== false &&
-          !isExplicitChannelActivationPath(accountPath, params.explicitSetPaths)
-        ) {
-          params.reasons.push(
-            `protected-channel-enabled:${formatProtectedConfigPath(accountPath)}`,
-          );
-        }
-      }
-    }
-  }
-  if (!isRecord(previousChannels)) {
-    return;
-  }
-  for (const [channelId, previousChannel] of Object.entries(previousChannels)) {
-    if (channelConfigMetaKeys.has(channelId)) {
-      continue;
-    }
-    if (!isRecord(previousChannel)) {
-      continue;
-    }
-    const channelPath = ["channels", channelId] as const;
-    const nextChannel = isRecord(nextChannels) ? nextChannels[channelId] : undefined;
-    const channelRemoved = !isRecord(nextChannel);
-    if (
-      channelRemoved &&
-      previousChannel.enabled !== false &&
-      !isExplicitConfigWritePathAncestorOrSelf(channelPath, params.explicitSetPaths)
-    ) {
-      params.reasons.push(`protected-channel-removed:${formatProtectedConfigPath(channelPath)}`);
-    }
-    appendNestedProtectedListChangeReasons({
-      previousConfig: params.previousConfig,
-      nextConfig: params.nextConfig,
-      path: channelPath,
-      protectedKeys: protectedChannelAllowlistKeys,
-      explicitSetPaths: params.explicitSetPaths,
-      reasons: params.reasons,
-    });
-    const previousAccounts = previousChannel.accounts;
-    if (isRecord(previousAccounts)) {
-      for (const [accountId, previousAccount] of Object.entries(previousAccounts)) {
-        if (!isRecord(previousAccount)) {
-          continue;
-        }
-        const accountPath = [...channelPath, "accounts", accountId] as const;
-        const nextAccount = getObjectPathValue(params.nextConfig, accountPath);
-        if (!isRecord(nextAccount)) {
-          if (
-            previousAccount.enabled !== false &&
-            !isExplicitConfigWritePathAncestorOrSelf(accountPath, params.explicitSetPaths)
-          ) {
-            params.reasons.push(
-              `protected-channel-removed:${formatProtectedConfigPath(accountPath)}`,
-            );
-          }
-          continue;
-        }
-        if (
-          previousAccount.enabled === false &&
-          nextAccount.enabled !== false &&
-          !isExplicitChannelActivationPath(accountPath, params.explicitSetPaths)
-        ) {
-          params.reasons.push(
-            `protected-channel-enabled:${formatProtectedConfigPath(accountPath)}`,
-          );
-        }
-        if (
-          previousAccount.enabled !== false &&
-          nextAccount.enabled === false &&
-          !isExplicitChannelActivationPath(accountPath, params.explicitSetPaths)
-        ) {
-          params.reasons.push(
-            `protected-channel-disabled:${formatProtectedConfigPath(accountPath)}`,
-          );
-        }
-      }
-    }
-    if (
-      !channelRemoved &&
-      previousChannel.enabled === false &&
-      nextChannel.enabled !== false &&
-      !isExplicitChannelActivationPath(channelPath, params.explicitSetPaths)
-    ) {
-      params.reasons.push(`protected-channel-enabled:${formatProtectedConfigPath(channelPath)}`);
-    }
-    if (
-      !channelRemoved &&
-      previousChannel.enabled !== false &&
-      nextChannel.enabled === false &&
-      !isExplicitChannelActivationPath(channelPath, params.explicitSetPaths)
-    ) {
-      params.reasons.push(`protected-channel-disabled:${formatProtectedConfigPath(channelPath)}`);
-    }
-  }
-}
-
-function listProtectedConfigPolicyChangeReasons(params: {
-  previousConfig: unknown;
-  nextConfig: unknown;
-  explicitSetPaths?: readonly (readonly string[])[];
-}): string[] {
-  const reasons: string[] = [];
-  appendProtectedListChangeReasons({
-    previousConfig: params.previousConfig,
-    nextConfig: params.nextConfig,
-    path: ["commands", "ownerAllowFrom"],
-    explicitSetPaths: params.explicitSetPaths,
-    reasons,
-  });
-  appendProtectedAllowFromMapChangeReasons({
-    previousConfig: params.previousConfig,
-    nextConfig: params.nextConfig,
-    path: ["commands", "allowFrom"],
-    explicitSetPaths: params.explicitSetPaths,
-    reasons,
-  });
-  appendProtectedAllowFromMapChangeReasons({
-    previousConfig: params.previousConfig,
-    nextConfig: params.nextConfig,
-    path: ["tools", "elevated", "allowFrom"],
-    explicitSetPaths: params.explicitSetPaths,
-    reasons,
-  });
-  appendAgentProtectedPolicyChangeReasons({
-    previousConfig: params.previousConfig,
-    nextConfig: params.nextConfig,
-    explicitSetPaths: params.explicitSetPaths,
-    reasons,
-  });
-  appendChannelProtectedPolicyChangeReasons({
-    previousConfig: params.previousConfig,
-    nextConfig: params.nextConfig,
-    explicitSetPaths: params.explicitSetPaths,
-    reasons,
-  });
-  return reasons;
-}
-
 function resolveConfigStatMetadata(
   stat: fs.Stats | null,
 ): Pick<ConfigHealthFingerprint, "dev" | "ino" | "mode" | "nlink" | "uid" | "gid"> {
@@ -998,6 +417,7 @@ function resolveConfigWriteSuspiciousReasons(params: {
   previousConfig: unknown;
   nextConfig: unknown;
   explicitSetPaths?: readonly (readonly string[])[];
+  explicitProtectedConfigPolicyPaths?: readonly (readonly string[])[];
 }): string[] {
   const reasons: string[] = [];
   if (!params.existsBefore) {
@@ -1021,7 +441,10 @@ function resolveConfigWriteSuspiciousReasons(params: {
     ...listProtectedConfigPolicyChangeReasons({
       previousConfig: params.previousConfig,
       nextConfig: params.nextConfig,
-      explicitSetPaths: params.explicitSetPaths,
+      explicitSetPaths: [
+        ...(params.explicitSetPaths ?? []),
+        ...(params.explicitProtectedConfigPolicyPaths ?? []),
+      ],
     }),
   );
   return reasons;
@@ -1043,13 +466,17 @@ export function resolveProtectedConfigPolicyWriteBlockingReasons(params: {
   previousConfig: unknown;
   nextConfig: unknown;
   explicitSetPaths?: readonly (readonly string[])[];
+  explicitProtectedConfigPolicyPaths?: readonly (readonly string[])[];
   allowProtectedConfigPolicyDrop?: boolean;
 }): string[] {
   return resolveConfigWriteBlockingReasons(
     listProtectedConfigPolicyChangeReasons({
       previousConfig: params.previousConfig,
       nextConfig: params.nextConfig,
-      explicitSetPaths: params.explicitSetPaths,
+      explicitSetPaths: [
+        ...(params.explicitSetPaths ?? []),
+        ...(params.explicitProtectedConfigPolicyPaths ?? []),
+      ],
     }),
     { allowProtectedConfigPolicyDrop: params.allowProtectedConfigPolicyDrop },
   );
@@ -2769,6 +2196,7 @@ export function createConfigIO(
       previousConfig: snapshot.resolved,
       nextConfig: protectedPolicyNextConfig,
       explicitSetPaths: [...(options.explicitSetPaths ?? []), ...unsetPaths],
+      explicitProtectedConfigPolicyPaths: options.explicitProtectedConfigPolicyPaths,
     });
     const logConfigOverwrite = () => {
       if (!snapshot.exists) {
@@ -3091,6 +2519,7 @@ export async function writeConfigFile(
     }),
     unsetPaths: resolveManagedUnsetPathsForWrite(options.unsetPaths),
     explicitSetPaths: options.explicitSetPaths,
+    explicitProtectedConfigPolicyPaths: options.explicitProtectedConfigPolicyPaths,
     explicitSetValueSource: options.explicitSetPaths
       ? (options.explicitSetValueSource ?? cfg)
       : undefined,

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -461,7 +461,9 @@ function isExplicitChannelActivationPath(
   const enabledPath = [...channelPath, "enabled"];
   return explicitSetPaths.some(
     (explicitPath) =>
-      isSameConfigPath(explicitPath, channelPath) || isSameConfigPath(explicitPath, enabledPath),
+      isSameConfigPath(explicitPath, enabledPath) ||
+      (explicitPath.length <= channelPath.length &&
+        explicitPath.every((segment, index) => segment === channelPath[index])),
   );
 }
 

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -887,6 +887,15 @@ function appendChannelProtectedPolicyChangeReasons(params: {
             `protected-channel-enabled:${formatProtectedConfigPath(accountPath)}`,
           );
         }
+        if (
+          previousAccount.enabled !== false &&
+          nextAccount.enabled === false &&
+          !isExplicitChannelActivationPath(accountPath, params.explicitSetPaths)
+        ) {
+          params.reasons.push(
+            `protected-channel-disabled:${formatProtectedConfigPath(accountPath)}`,
+          );
+        }
       }
     }
     if (
@@ -896,6 +905,14 @@ function appendChannelProtectedPolicyChangeReasons(params: {
       !isExplicitChannelActivationPath(channelPath, params.explicitSetPaths)
     ) {
       params.reasons.push(`protected-channel-enabled:${formatProtectedConfigPath(channelPath)}`);
+    }
+    if (
+      !channelRemoved &&
+      previousChannel.enabled !== false &&
+      nextChannel.enabled === false &&
+      !isExplicitChannelActivationPath(channelPath, params.explicitSetPaths)
+    ) {
+      params.reasons.push(`protected-channel-disabled:${formatProtectedConfigPath(channelPath)}`);
     }
   }
 }

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -1284,6 +1284,76 @@ describe("config io write", () => {
     });
   });
 
+  it("rejects stale runtime writes that stage broad allowlists on disabled channel scopes", async () => {
+    await withSuiteHome(async (home) => {
+      mockChannelPluginManifestRegistry("whatsapp");
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const original = {
+        meta: { lastTouchedVersion: "2026.5.17" },
+        gateway: { mode: "local" },
+        channels: {},
+      } satisfies ConfigFileSnapshot["config"];
+      const staleRuntime = {
+        ...original,
+        channels: {
+          whatsapp: {
+            enabled: false,
+            allowFrom: ["*"],
+            accounts: {
+              default: {
+                enabled: false,
+                allowFrom: ["*"],
+              },
+            },
+          },
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const originalRaw = `${JSON.stringify(original, null, 2)}\n`;
+      await fs.writeFile(configPath, originalRaw, "utf-8");
+      const io = createConfigIO({
+        env: { VITEST: "true" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+      const baseSnapshot = {
+        path: configPath,
+        exists: true,
+        raw: originalRaw,
+        parsed: original,
+        sourceConfig: original,
+        resolved: original,
+        valid: true,
+        runtimeConfig: original,
+        config: original,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      } satisfies ConfigFileSnapshot;
+
+      await expect(io.writeConfigFile(staleRuntime, { baseSnapshot })).rejects.toMatchObject({
+        code: "CONFIG_WRITE_REJECTED",
+        reasons: expect.arrayContaining([
+          "protected-list-widened:channels.whatsapp.allowFrom",
+          "protected-list-widened:channels.whatsapp.accounts.default.allowFrom",
+        ]),
+      });
+      await expect(
+        io.writeConfigFile(staleRuntime, {
+          baseSnapshot,
+          explicitSetPaths: [["channels", "whatsapp", "enabled"]],
+        }),
+      ).rejects.toMatchObject({
+        code: "CONFIG_WRITE_REJECTED",
+        reasons: expect.arrayContaining([
+          "protected-list-widened:channels.whatsapp.allowFrom",
+          "protected-list-widened:channels.whatsapp.accounts.default.allowFrom",
+        ]),
+      });
+      await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
+    });
+  });
+
   it("rejects stale runtime writes that remove enabled channel blocks without allowlists", async () => {
     await withSuiteHome(async (home) => {
       mockChannelPluginManifestRegistry("whatsapp");

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -2127,11 +2127,29 @@ describe("config io write", () => {
         channels: {
           googlechat: {
             dm: { allowFrom: ["space:trusted"] },
+            groups: {
+              ops: {
+                users: ["users/trusted"],
+              },
+            },
+          },
+          discord: {
+            guilds: {
+              main: {
+                users: ["user:trusted"],
+                channels: {
+                  alerts: {
+                    roles: ["role:trusted"],
+                  },
+                },
+              },
+            },
           },
           matrix: {
             accounts: {
               ops: {
                 dm: { allowFrom: ["@trusted:example.org"] },
+                execApprovals: { approvers: ["@owner:example.org"] },
               },
             },
           },
@@ -2142,11 +2160,29 @@ describe("config io write", () => {
         channels: {
           googlechat: {
             dm: {},
+            groups: {
+              ops: {
+                users: ["users/trusted", "users/stale"],
+              },
+            },
+          },
+          discord: {
+            guilds: {
+              main: {
+                users: [],
+                channels: {
+                  alerts: {
+                    roles: ["role:trusted", "role:stale"],
+                  },
+                },
+              },
+            },
           },
           matrix: {
             accounts: {
               ops: {
                 dm: { allowFrom: ["@trusted:example.org", "@stale:example.org"] },
+                execApprovals: { approvers: [] },
               },
             },
           },
@@ -2178,7 +2214,11 @@ describe("config io write", () => {
         code: "CONFIG_WRITE_REJECTED",
         reasons: expect.arrayContaining([
           "protected-list-removed:channels.googlechat.dm.allowFrom",
+          "protected-list-widened:channels.googlechat.groups.ops.users",
+          "protected-list-removed:channels.discord.guilds.main.users",
+          "protected-list-widened:channels.discord.guilds.main.channels.alerts.roles",
           "protected-list-widened:channels.matrix.accounts.ops.dm.allowFrom",
+          "protected-list-removed:channels.matrix.accounts.ops.execApprovals.approvers",
         ]),
       });
       await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -2,8 +2,10 @@ import fsNode from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { clearCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import { readPersistedInstalledPluginIndex } from "../plugins/installed-plugin-index-store.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
+import { clearLoadPluginMetadataSnapshotMemo } from "../plugins/plugin-metadata-snapshot.js";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { CONFIG_CLOBBER_SNAPSHOT_LIMIT } from "./io.clobber-snapshot.js";
 import {
@@ -73,19 +75,49 @@ describe("config io write", () => {
     return fn(home);
   }
 
+  const mockEmptyPluginManifestRegistry = () => {
+    mockLoadPluginManifestRegistry.mockReturnValue({
+      diagnostics: [],
+      plugins: [],
+    } satisfies PluginManifestRegistry);
+  };
+
+  const mockChannelPluginManifestRegistry = (...channelIds: string[]) => {
+    mockLoadPluginManifestRegistry.mockReturnValue({
+      diagnostics: [],
+      plugins: channelIds.map((channelId) => ({
+        id: `test-${channelId}`,
+        origin: "global",
+        channels: [channelId],
+        providers: [],
+        cliBackends: [],
+        skills: [],
+        hooks: [],
+        rootDir: path.join("/tmp", `openclaw-test-${channelId}`),
+        source: path.join("/tmp", `openclaw-test-${channelId}`, "index.js"),
+        manifestPath: path.join("/tmp", `openclaw-test-${channelId}`, "openclaw.plugin.json"),
+        channelConfigs: {
+          [channelId]: {
+            schema: { type: "object", additionalProperties: true },
+          },
+        },
+      })),
+    } satisfies PluginManifestRegistry);
+  };
+
   beforeAll(async () => {
     await suiteRootTracker.setup();
 
     // Default: return an empty plugin list so existing tests that don't need
     // plugin-owned channel schemas keep working unchanged.
-    mockLoadPluginManifestRegistry.mockReturnValue({
-      diagnostics: [],
-      plugins: [],
-    } satisfies PluginManifestRegistry);
+    mockEmptyPluginManifestRegistry();
   });
 
   afterEach(() => {
     resetConfigRuntimeState();
+    clearCurrentPluginMetadataSnapshot();
+    clearLoadPluginMetadataSnapshotMemo();
+    mockEmptyPluginManifestRegistry();
     mockMaintainConfigBackups.mockReset();
     mockMaintainConfigBackups.mockResolvedValue(undefined);
   });
@@ -901,7 +933,7 @@ describe("config io write", () => {
       expect(rejectedEntries).toHaveLength(1);
       expect(warn.mock.calls).toEqual([
         [
-          `Config write rejected: ${configPath} (gateway-mode-removed). Rejected payload saved to ${path.join(
+          `Config write rejected: ${configPath} (gateway-mode-removed, protected-channel-removed:channels.telegram). Rejected payload saved to ${path.join(
             path.dirname(configPath),
             rejectedEntries[0] ?? "",
           )}.`,
@@ -950,6 +982,7 @@ describe("config io write", () => {
         { meta: original.meta, gateway: { mode: "local" } },
         {
           allowConfigSizeDrop: true,
+          allowProtectedConfigPolicyDrop: true,
           baseSnapshot,
         },
       );
@@ -964,6 +997,1282 @@ describe("config io write", () => {
           },
         ),
       );
+    });
+  });
+
+  it("rejects stale runtime writes that drop protected channel and elevated policy", async () => {
+    await withSuiteHome(async (home) => {
+      mockChannelPluginManifestRegistry("whatsapp");
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const original = {
+        meta: { lastTouchedVersion: "2026.5.17" },
+        gateway: { mode: "local" },
+        commands: {
+          ownerAllowFrom: ["whatsapp:+15550001111", "telegram:111"],
+        },
+        tools: {
+          elevated: {
+            allowFrom: {
+              webchat: ["session:trusted"],
+            },
+          },
+        },
+        agents: {
+          list: [
+            {
+              id: "main",
+              tools: {
+                elevated: {
+                  allowFrom: {
+                    webchat: ["session:trusted"],
+                  },
+                },
+              },
+            },
+          ],
+        },
+        channels: {
+          whatsapp: {
+            enabled: true,
+            allowFrom: ["+15550001111", "+15550002222"],
+            groupAllowFrom: ["+15550001111", "+15550002222"],
+            accounts: {
+              default: {
+                allowFrom: ["+15550003333", "+15550004444"],
+                groupAllowFrom: ["+15550003333", "+15550004444"],
+              },
+            },
+          },
+          telegram: {
+            enabled: false,
+            accounts: {
+              default: {
+                enabled: false,
+              },
+            },
+          },
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const staleRuntime = {
+        ...original,
+        commands: {},
+        tools: {
+          elevated: {
+            allowFrom: {
+              webchat: ["*"],
+            },
+          },
+        },
+        agents: {
+          list: [
+            {
+              id: "main",
+              tools: {
+                elevated: {
+                  allowFrom: {
+                    webchat: ["*"],
+                  },
+                },
+              },
+            },
+          ],
+        },
+        channels: {
+          whatsapp: {
+            enabled: true,
+            allowFrom: ["+15550001111"],
+            groupAllowFrom: ["+15550001111"],
+            accounts: {
+              default: {
+                allowFrom: ["+15550003333"],
+                groupAllowFrom: ["+15550003333"],
+              },
+            },
+          },
+          telegram: {
+            enabled: true,
+            accounts: {
+              default: {
+                enabled: true,
+              },
+            },
+          },
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const originalRaw = `${JSON.stringify(original, null, 2)}\n`;
+      await fs.writeFile(configPath, originalRaw, "utf-8");
+      const io = createConfigIO({
+        env: { VITEST: "true" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+      const baseSnapshot = {
+        path: configPath,
+        exists: true,
+        raw: originalRaw,
+        parsed: original,
+        sourceConfig: original,
+        resolved: original,
+        valid: true,
+        runtimeConfig: original,
+        config: original,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      } satisfies ConfigFileSnapshot;
+
+      await expect(io.writeConfigFile(staleRuntime, { baseSnapshot })).rejects.toMatchObject({
+        code: "CONFIG_WRITE_REJECTED",
+        reasons: expect.arrayContaining([
+          "protected-list-removed:commands.ownerAllowFrom",
+          "protected-list-widened:tools.elevated.allowFrom.webchat",
+          "protected-list-widened:agents.list.main.tools.elevated.allowFrom.webchat",
+          "protected-list-shrunk:channels.whatsapp.allowFrom",
+          "protected-list-shrunk:channels.whatsapp.groupAllowFrom",
+          "protected-list-shrunk:channels.whatsapp.accounts.default.allowFrom",
+          "protected-list-shrunk:channels.whatsapp.accounts.default.groupAllowFrom",
+          "protected-channel-enabled:channels.telegram",
+          "protected-channel-enabled:channels.telegram.accounts.default",
+        ]),
+      });
+      await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
+    });
+  });
+
+  it("compares protected policy against resolved includes for unrelated root writes", async () => {
+    await withSuiteHome(async (home) => {
+      mockChannelPluginManifestRegistry("whatsapp");
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const authoredRoot = {
+        gateway: { mode: "local" },
+        channels: { $include: "./config/channels.json5" },
+      };
+      const sourceConfig = {
+        gateway: { mode: "local" },
+        channels: {
+          whatsapp: {
+            enabled: true,
+            allowFrom: ["+15550001111"],
+          },
+        },
+      } satisfies ConfigFileSnapshot["sourceConfig"];
+      const rootRaw = `${JSON.stringify(authoredRoot, null, 2)}\n`;
+      await fs.writeFile(configPath, rootRaw, "utf-8");
+      const io = createConfigIO({
+        env: { VITEST: "true" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+      const baseSnapshot = {
+        path: configPath,
+        exists: true,
+        raw: rootRaw,
+        parsed: authoredRoot,
+        sourceConfig,
+        resolved: sourceConfig,
+        valid: true,
+        runtimeConfig: sourceConfig,
+        config: sourceConfig,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      } satisfies ConfigFileSnapshot;
+
+      await expect(
+        io.writeConfigFile(
+          {
+            ...sourceConfig,
+            gateway: { mode: "local", port: 18789 },
+          },
+          { baseSnapshot, skipPluginValidation: true },
+        ),
+      ).resolves.toMatchObject({
+        persistedConfig: {
+          gateway: { mode: "local", port: 18789 },
+          channels: { $include: "./config/channels.json5" },
+        },
+      });
+    });
+  });
+
+  it("rejects stale runtime writes that resurrect removed channel scopes", async () => {
+    await withSuiteHome(async (home) => {
+      mockChannelPluginManifestRegistry("whatsapp");
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const original = {
+        meta: { lastTouchedVersion: "2026.5.17" },
+        gateway: { mode: "local" },
+        channels: {
+          telegram: {
+            enabled: true,
+            accounts: {},
+          },
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const staleRuntime = {
+        ...original,
+        channels: {
+          telegram: {
+            enabled: true,
+            accounts: {
+              default: {
+                enabled: true,
+              },
+            },
+          },
+          whatsapp: {
+            enabled: true,
+          },
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const originalRaw = `${JSON.stringify(original, null, 2)}\n`;
+      await fs.writeFile(configPath, originalRaw, "utf-8");
+      const io = createConfigIO({
+        env: { VITEST: "true" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+      const baseSnapshot = {
+        path: configPath,
+        exists: true,
+        raw: originalRaw,
+        parsed: original,
+        sourceConfig: original,
+        resolved: original,
+        valid: true,
+        runtimeConfig: original,
+        config: original,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      } satisfies ConfigFileSnapshot;
+
+      await expect(io.writeConfigFile(staleRuntime, { baseSnapshot })).rejects.toMatchObject({
+        code: "CONFIG_WRITE_REJECTED",
+        reasons: expect.arrayContaining([
+          "protected-channel-enabled:channels.whatsapp",
+          "protected-channel-enabled:channels.telegram.accounts.default",
+        ]),
+      });
+      await expect(
+        io.writeConfigFile(staleRuntime, {
+          baseSnapshot,
+          explicitSetPaths: [["channels", "whatsapp", "sendReadReceipts"]],
+        }),
+      ).rejects.toMatchObject({
+        code: "CONFIG_WRITE_REJECTED",
+        reasons: expect.arrayContaining(["protected-channel-enabled:channels.whatsapp"]),
+      });
+      await expect(
+        io.writeConfigFile(staleRuntime, {
+          baseSnapshot,
+          explicitSetPaths: [["channels", "telegram", "accounts", "default", "authDir"]],
+        }),
+      ).rejects.toMatchObject({
+        code: "CONFIG_WRITE_REJECTED",
+        reasons: expect.arrayContaining([
+          "protected-channel-enabled:channels.telegram.accounts.default",
+        ]),
+      });
+      await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
+    });
+  });
+
+  it("rejects stale runtime writes that remove enabled channel blocks without allowlists", async () => {
+    await withSuiteHome(async (home) => {
+      mockChannelPluginManifestRegistry("whatsapp");
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const original = {
+        meta: { lastTouchedVersion: "2026.5.17" },
+        gateway: { mode: "local" },
+        channels: {
+          whatsapp: {
+            enabled: true,
+            sendReadReceipts: true,
+          },
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const staleRuntime = {
+        ...original,
+        channels: {},
+      } satisfies ConfigFileSnapshot["config"];
+      const originalRaw = `${JSON.stringify(original, null, 2)}\n`;
+      await fs.writeFile(configPath, originalRaw, "utf-8");
+      const io = createConfigIO({
+        env: { VITEST: "true" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+      const baseSnapshot = {
+        path: configPath,
+        exists: true,
+        raw: originalRaw,
+        parsed: original,
+        sourceConfig: original,
+        resolved: original,
+        valid: true,
+        runtimeConfig: original,
+        config: original,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      } satisfies ConfigFileSnapshot;
+
+      await expect(io.writeConfigFile(staleRuntime, { baseSnapshot })).rejects.toMatchObject({
+        code: "CONFIG_WRITE_REJECTED",
+        reasons: expect.arrayContaining(["protected-channel-removed:channels.whatsapp"]),
+      });
+      await expect(
+        io.writeConfigFile(staleRuntime, {
+          baseSnapshot,
+          explicitSetPaths: [["channels", "whatsapp", "sendReadReceipts"]],
+        }),
+      ).rejects.toMatchObject({
+        code: "CONFIG_WRITE_REJECTED",
+        reasons: expect.arrayContaining(["protected-channel-removed:channels.whatsapp"]),
+      });
+      await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
+    });
+  });
+
+  it("rejects stale runtime writes that remove enabled channel accounts without allowlists", async () => {
+    await withSuiteHome(async (home) => {
+      mockChannelPluginManifestRegistry("whatsapp");
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const original = {
+        meta: { lastTouchedVersion: "2026.5.17" },
+        gateway: { mode: "local" },
+        channels: {
+          whatsapp: {
+            enabled: true,
+            accounts: {
+              work: {
+                enabled: true,
+                authDir: "/tmp/auth-work",
+              },
+            },
+          },
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const staleRuntime = {
+        ...original,
+        channels: {
+          whatsapp: {
+            enabled: true,
+            accounts: {},
+          },
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const originalRaw = `${JSON.stringify(original, null, 2)}\n`;
+      await fs.writeFile(configPath, originalRaw, "utf-8");
+      const io = createConfigIO({
+        env: { VITEST: "true" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+      const baseSnapshot = {
+        path: configPath,
+        exists: true,
+        raw: originalRaw,
+        parsed: original,
+        sourceConfig: original,
+        resolved: original,
+        valid: true,
+        runtimeConfig: original,
+        config: original,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      } satisfies ConfigFileSnapshot;
+
+      await expect(io.writeConfigFile(staleRuntime, { baseSnapshot })).rejects.toMatchObject({
+        code: "CONFIG_WRITE_REJECTED",
+        reasons: expect.arrayContaining([
+          "protected-channel-removed:channels.whatsapp.accounts.work",
+        ]),
+      });
+      await expect(
+        io.writeConfigFile(staleRuntime, {
+          baseSnapshot,
+          explicitSetPaths: [["channels", "whatsapp", "accounts", "work", "authDir"]],
+        }),
+      ).rejects.toMatchObject({
+        code: "CONFIG_WRITE_REJECTED",
+        reasons: expect.arrayContaining([
+          "protected-channel-removed:channels.whatsapp.accounts.work",
+        ]),
+      });
+      await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
+    });
+  });
+
+  it("rejects stale runtime writes that reintroduce channel allowlists", async () => {
+    await withSuiteHome(async (home) => {
+      mockChannelPluginManifestRegistry("whatsapp");
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const original = {
+        meta: { lastTouchedVersion: "2026.5.17" },
+        gateway: { mode: "local" },
+        channels: {
+          whatsapp: {
+            enabled: true,
+            dm: {},
+          },
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const staleRuntime = {
+        ...original,
+        channels: {
+          whatsapp: {
+            enabled: true,
+            allowFrom: ["*"],
+            dm: {
+              allowFrom: ["*"],
+            },
+          },
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const originalRaw = `${JSON.stringify(original, null, 2)}\n`;
+      await fs.writeFile(configPath, originalRaw, "utf-8");
+      const io = createConfigIO({
+        env: { VITEST: "true" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+      const baseSnapshot = {
+        path: configPath,
+        exists: true,
+        raw: originalRaw,
+        parsed: original,
+        sourceConfig: original,
+        resolved: original,
+        valid: true,
+        runtimeConfig: original,
+        config: original,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      } satisfies ConfigFileSnapshot;
+
+      await expect(io.writeConfigFile(staleRuntime, { baseSnapshot })).rejects.toMatchObject({
+        code: "CONFIG_WRITE_REJECTED",
+        reasons: expect.arrayContaining([
+          "protected-list-widened:channels.whatsapp.allowFrom",
+          "protected-list-widened:channels.whatsapp.dm.allowFrom",
+        ]),
+      });
+      await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
+    });
+  });
+
+  it("rejects stale runtime writes that resurrect agents with elevated allowlists", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const original = {
+        meta: { lastTouchedVersion: "2026.5.17" },
+        gateway: { mode: "local" },
+        agents: {
+          list: [],
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const staleRuntime = {
+        ...original,
+        agents: {
+          list: [
+            {
+              id: "main",
+              tools: {
+                elevated: {
+                  allowFrom: {
+                    webchat: ["*"],
+                  },
+                },
+              },
+            },
+          ],
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const originalRaw = `${JSON.stringify(original, null, 2)}\n`;
+      await fs.writeFile(configPath, originalRaw, "utf-8");
+      const io = createConfigIO({
+        env: { VITEST: "true" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+      const baseSnapshot = {
+        path: configPath,
+        exists: true,
+        raw: originalRaw,
+        parsed: original,
+        sourceConfig: original,
+        resolved: original,
+        valid: true,
+        runtimeConfig: original,
+        config: original,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      } satisfies ConfigFileSnapshot;
+
+      await expect(io.writeConfigFile(staleRuntime, { baseSnapshot })).rejects.toMatchObject({
+        code: "CONFIG_WRITE_REJECTED",
+        reasons: expect.arrayContaining([
+          "protected-list-widened:agents.list.main.tools.elevated.allowFrom.webchat",
+        ]),
+      });
+      await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
+    });
+  });
+
+  it("does not treat global channels buckets as channel activation policy", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const original = {
+        meta: { lastTouchedVersion: "2026.5.17" },
+        gateway: { mode: "local" },
+        channels: {
+          defaults: {
+            groupPolicy: "open",
+          },
+          modelByChannel: {
+            telegram: {
+              "123": "openai/gpt-5.4",
+            },
+          },
+        },
+      } as unknown as ConfigFileSnapshot["config"];
+      const next = {
+        meta: original.meta,
+        gateway: { mode: "local" },
+        channels: {},
+      } satisfies ConfigFileSnapshot["config"];
+      const originalRaw = `${JSON.stringify(original, null, 2)}\n`;
+      await fs.writeFile(configPath, originalRaw, "utf-8");
+      const io = createConfigIO({
+        env: { VITEST: "true" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+      const baseSnapshot = {
+        path: configPath,
+        exists: true,
+        raw: originalRaw,
+        parsed: original,
+        sourceConfig: original,
+        resolved: original,
+        valid: true,
+        runtimeConfig: original,
+        config: original,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      } satisfies ConfigFileSnapshot;
+
+      const result = await io.writeConfigFile(next, { baseSnapshot });
+
+      expect(result.persistedConfig.channels).toEqual({});
+    });
+  });
+
+  it("keeps env-authored protected policy writable for unrelated runtime edits", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(
+        configPath,
+        `${JSON.stringify(
+          {
+            gateway: { mode: "local" },
+            commands: {
+              ownerAllowFrom: ["${OPENCLAW_TEST_OWNER_ALLOW}"],
+            },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf-8",
+      );
+      const io = createConfigIO({
+        env: {
+          OPENCLAW_CONFIG_PATH: configPath,
+          OPENCLAW_TEST_OWNER_ALLOW: "webchat:owner",
+          VITEST: "true",
+        } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+      const snapshot = await io.readConfigFileSnapshot();
+      expect(snapshot.resolved.commands?.ownerAllowFrom).toEqual(["webchat:owner"]);
+
+      const result = await io.writeConfigFile({
+        ...snapshot.resolved,
+        gateway: { mode: "local", port: 18789 },
+      });
+
+      expect(result.persistedConfig.gateway).toEqual({ mode: "local", port: 18789 });
+      const persisted = JSON.parse(await fs.readFile(configPath, "utf-8")) as {
+        commands?: { ownerAllowFrom?: string[] };
+      };
+      expect(persisted.commands?.ownerAllowFrom).toEqual(["${OPENCLAW_TEST_OWNER_ALLOW}"]);
+    });
+  });
+
+  it("still rejects sibling protected allowlist drops during explicit bucket edits", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const original = {
+        meta: { lastTouchedVersion: "2026.5.17" },
+        gateway: { mode: "local" },
+        tools: {
+          elevated: {
+            allowFrom: {
+              webchat: ["session:trusted"],
+              telegram: ["telegram:111"],
+            },
+          },
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const staleRuntime = {
+        ...original,
+        tools: {
+          elevated: {
+            allowFrom: {
+              webchat: ["session:trusted", "session:second"],
+            },
+          },
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const originalRaw = `${JSON.stringify(original, null, 2)}\n`;
+      await fs.writeFile(configPath, originalRaw, "utf-8");
+      const io = createConfigIO({
+        env: { VITEST: "true" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+      const baseSnapshot = {
+        path: configPath,
+        exists: true,
+        raw: originalRaw,
+        parsed: original,
+        sourceConfig: original,
+        resolved: original,
+        valid: true,
+        runtimeConfig: original,
+        config: original,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      } satisfies ConfigFileSnapshot;
+
+      await expect(
+        io.writeConfigFile(staleRuntime, {
+          baseSnapshot,
+          explicitSetPaths: [["tools", "elevated", "allowFrom", "webchat"]],
+        }),
+      ).rejects.toMatchObject({
+        code: "CONFIG_WRITE_REJECTED",
+        reasons: expect.arrayContaining([
+          "protected-list-removed:tools.elevated.allowFrom.telegram",
+        ]),
+      });
+      await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
+    });
+  });
+
+  it("does not treat unrelated explicit agent list edits as protected policy edits", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const original = {
+        meta: { lastTouchedVersion: "2026.5.17" },
+        gateway: { mode: "local" },
+        agents: {
+          list: [
+            {
+              id: "main",
+              model: "openai/gpt-5.4",
+              tools: {
+                elevated: {
+                  allowFrom: {
+                    webchat: ["session:trusted"],
+                  },
+                },
+              },
+            },
+          ],
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const staleRuntime = {
+        ...original,
+        agents: {
+          list: [
+            {
+              id: "main",
+              model: "openrouter/anthropic/claude-sonnet-4.6",
+              tools: {
+                elevated: {
+                  allowFrom: {},
+                },
+              },
+            },
+          ],
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const originalRaw = `${JSON.stringify(original, null, 2)}\n`;
+      await fs.writeFile(configPath, originalRaw, "utf-8");
+      const io = createConfigIO({
+        env: { VITEST: "true" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+      const baseSnapshot = {
+        path: configPath,
+        exists: true,
+        raw: originalRaw,
+        parsed: original,
+        sourceConfig: original,
+        resolved: original,
+        valid: true,
+        runtimeConfig: original,
+        config: original,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      } satisfies ConfigFileSnapshot;
+
+      await expect(
+        io.writeConfigFile(staleRuntime, {
+          baseSnapshot,
+          explicitSetPaths: [["agents", "list", "0", "model"]],
+        }),
+      ).rejects.toMatchObject({
+        code: "CONFIG_WRITE_REJECTED",
+        reasons: expect.arrayContaining([
+          "protected-list-removed:agents.list.main.tools.elevated.allowFrom.webchat",
+        ]),
+      });
+      await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
+    });
+  });
+
+  it("allows explicit whole-agent edits to protected policy paths", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const original = {
+        meta: { lastTouchedVersion: "2026.5.17" },
+        gateway: { mode: "local" },
+        agents: {
+          list: [
+            {
+              id: "main",
+              tools: {
+                elevated: {
+                  allowFrom: {
+                    webchat: ["session:trusted"],
+                  },
+                },
+              },
+            },
+          ],
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const next = {
+        meta: original.meta,
+        gateway: { mode: "local" },
+        agents: {
+          list: [],
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const originalRaw = `${JSON.stringify(original, null, 2)}\n`;
+      await fs.writeFile(configPath, originalRaw, "utf-8");
+      const io = createConfigIO({
+        env: { VITEST: "true" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+      const baseSnapshot = {
+        path: configPath,
+        exists: true,
+        raw: originalRaw,
+        parsed: original,
+        sourceConfig: original,
+        resolved: original,
+        valid: true,
+        runtimeConfig: original,
+        config: original,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      } satisfies ConfigFileSnapshot;
+
+      const result = await io.writeConfigFile(next, {
+        baseSnapshot,
+        explicitSetPaths: [["agents", "list", "0"]],
+      });
+
+      expect(result.persistedConfig.agents?.list).toEqual([]);
+    });
+  });
+
+  it("rejects stale runtime writes that broaden protected allowlists without wildcards", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const original = {
+        meta: { lastTouchedVersion: "2026.5.17" },
+        gateway: { mode: "local" },
+        commands: {
+          ownerAllowFrom: ["webchat:owner"],
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const staleRuntime = {
+        ...original,
+        commands: {
+          ownerAllowFrom: ["webchat:owner", "telegram:111"],
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const originalRaw = `${JSON.stringify(original, null, 2)}\n`;
+      await fs.writeFile(configPath, originalRaw, "utf-8");
+      const io = createConfigIO({
+        env: { VITEST: "true" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+      const baseSnapshot = {
+        path: configPath,
+        exists: true,
+        raw: originalRaw,
+        parsed: original,
+        sourceConfig: original,
+        resolved: original,
+        valid: true,
+        runtimeConfig: original,
+        config: original,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      } satisfies ConfigFileSnapshot;
+
+      await expect(io.writeConfigFile(staleRuntime, { baseSnapshot })).rejects.toMatchObject({
+        code: "CONFIG_WRITE_REJECTED",
+        reasons: expect.arrayContaining(["protected-list-widened:commands.ownerAllowFrom"]),
+      });
+      await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
+    });
+  });
+
+  it("rejects stale runtime writes that resurrect removed protected allowlist map entries", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const original = {
+        meta: { lastTouchedVersion: "2026.5.17" },
+        gateway: { mode: "local" },
+        tools: {
+          elevated: {
+            allowFrom: {
+              webchat: ["session:trusted"],
+            },
+          },
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const staleRuntime = {
+        ...original,
+        tools: {
+          elevated: {
+            allowFrom: {
+              webchat: ["session:trusted"],
+              telegram: ["telegram:111"],
+            },
+          },
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const originalRaw = `${JSON.stringify(original, null, 2)}\n`;
+      await fs.writeFile(configPath, originalRaw, "utf-8");
+      const io = createConfigIO({
+        env: { VITEST: "true" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+      const baseSnapshot = {
+        path: configPath,
+        exists: true,
+        raw: originalRaw,
+        parsed: original,
+        sourceConfig: original,
+        resolved: original,
+        valid: true,
+        runtimeConfig: original,
+        config: original,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      } satisfies ConfigFileSnapshot;
+
+      await expect(io.writeConfigFile(staleRuntime, { baseSnapshot })).rejects.toMatchObject({
+        code: "CONFIG_WRITE_REJECTED",
+        reasons: expect.arrayContaining([
+          "protected-list-widened:tools.elevated.allowFrom.telegram",
+        ]),
+      });
+      await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
+    });
+  });
+
+  it("rejects stale runtime writes that resurrect removed protected policy blocks", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const original = {
+        meta: { lastTouchedVersion: "2026.5.17" },
+        gateway: { mode: "local" },
+      } satisfies ConfigFileSnapshot["config"];
+      const staleRuntime = {
+        ...original,
+        commands: {
+          ownerAllowFrom: ["webchat:owner"],
+        },
+        tools: {
+          elevated: {
+            allowFrom: {
+              telegram: ["telegram:111"],
+            },
+          },
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const originalRaw = `${JSON.stringify(original, null, 2)}\n`;
+      await fs.writeFile(configPath, originalRaw, "utf-8");
+      const io = createConfigIO({
+        env: { VITEST: "true" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+      const baseSnapshot = {
+        path: configPath,
+        exists: true,
+        raw: originalRaw,
+        parsed: original,
+        sourceConfig: original,
+        resolved: original,
+        valid: true,
+        runtimeConfig: original,
+        config: original,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      } satisfies ConfigFileSnapshot;
+
+      await expect(io.writeConfigFile(staleRuntime, { baseSnapshot })).rejects.toMatchObject({
+        code: "CONFIG_WRITE_REJECTED",
+        reasons: expect.arrayContaining([
+          "protected-list-widened:commands.ownerAllowFrom",
+          "protected-list-widened:tools.elevated.allowFrom.telegram",
+        ]),
+      });
+      await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
+    });
+  });
+
+  it("rejects stale runtime writes that re-open empty protected allowlists", async () => {
+    await withSuiteHome(async (home) => {
+      mockChannelPluginManifestRegistry("whatsapp");
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const original = {
+        meta: { lastTouchedVersion: "2026.5.17" },
+        gateway: { mode: "local" },
+        commands: {
+          ownerAllowFrom: [],
+        },
+        channels: {
+          whatsapp: {
+            allowFrom: [],
+          },
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const staleRuntime = {
+        ...original,
+        commands: {
+          ownerAllowFrom: ["webchat:owner"],
+        },
+        channels: {
+          whatsapp: {
+            allowFrom: ["*"],
+          },
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const originalRaw = `${JSON.stringify(original, null, 2)}\n`;
+      await fs.writeFile(configPath, originalRaw, "utf-8");
+      const io = createConfigIO({
+        env: { VITEST: "true" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+      const baseSnapshot = {
+        path: configPath,
+        exists: true,
+        raw: originalRaw,
+        parsed: original,
+        sourceConfig: original,
+        resolved: original,
+        valid: true,
+        runtimeConfig: original,
+        config: original,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      } satisfies ConfigFileSnapshot;
+
+      await expect(io.writeConfigFile(staleRuntime, { baseSnapshot })).rejects.toMatchObject({
+        code: "CONFIG_WRITE_REJECTED",
+        reasons: expect.arrayContaining([
+          "protected-list-widened:commands.ownerAllowFrom",
+          "protected-list-widened:channels.whatsapp.allowFrom",
+        ]),
+      });
+      await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
+    });
+  });
+
+  it("rejects stale runtime writes that drop nested channel allowlists", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const original = {
+        meta: { lastTouchedVersion: "2026.5.17" },
+        gateway: { mode: "local" },
+        channels: {
+          googlechat: {
+            dm: { allowFrom: ["space:trusted"] },
+          },
+          matrix: {
+            accounts: {
+              ops: {
+                dm: { allowFrom: ["@trusted:example.org"] },
+              },
+            },
+          },
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const staleRuntime = {
+        ...original,
+        channels: {
+          googlechat: {
+            dm: {},
+          },
+          matrix: {
+            accounts: {
+              ops: {
+                dm: { allowFrom: ["@trusted:example.org", "@stale:example.org"] },
+              },
+            },
+          },
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const originalRaw = `${JSON.stringify(original, null, 2)}\n`;
+      await fs.writeFile(configPath, originalRaw, "utf-8");
+      const io = createConfigIO({
+        env: { VITEST: "true" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+      const baseSnapshot = {
+        path: configPath,
+        exists: true,
+        raw: originalRaw,
+        parsed: original,
+        sourceConfig: original,
+        resolved: original,
+        valid: true,
+        runtimeConfig: original,
+        config: original,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      } satisfies ConfigFileSnapshot;
+
+      await expect(io.writeConfigFile(staleRuntime, { baseSnapshot })).rejects.toMatchObject({
+        code: "CONFIG_WRITE_REJECTED",
+        reasons: expect.arrayContaining([
+          "protected-list-removed:channels.googlechat.dm.allowFrom",
+          "protected-list-widened:channels.matrix.accounts.ops.dm.allowFrom",
+        ]),
+      });
+      await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
+    });
+  });
+
+  it("allows explicit config edits to protected policy paths", async () => {
+    await withSuiteHome(async (home) => {
+      mockChannelPluginManifestRegistry("whatsapp");
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const original = {
+        meta: { lastTouchedVersion: "2026.5.17" },
+        gateway: { mode: "local" },
+        channels: {
+          whatsapp: {
+            enabled: true,
+            allowFrom: ["+15550001111", "+15550002222"],
+          },
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const next = {
+        meta: original.meta,
+        gateway: { mode: "local" },
+        channels: {
+          whatsapp: {
+            enabled: true,
+            allowFrom: ["+15550001111"],
+          },
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const originalRaw = `${JSON.stringify(original, null, 2)}\n`;
+      await fs.writeFile(configPath, originalRaw, "utf-8");
+      const io = createConfigIO({
+        env: { VITEST: "true" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+      const baseSnapshot = {
+        path: configPath,
+        exists: true,
+        raw: originalRaw,
+        parsed: original,
+        sourceConfig: original,
+        resolved: original,
+        valid: true,
+        runtimeConfig: original,
+        config: original,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      } satisfies ConfigFileSnapshot;
+
+      const result = await io.writeConfigFile(next, {
+        baseSnapshot,
+        explicitSetPaths: [["channels", "whatsapp", "allowFrom"]],
+      });
+
+      expect(result.persistedConfig.channels?.whatsapp?.allowFrom).toEqual(["+15550001111"]);
+    });
+  });
+
+  it("allows explicit config unsets to protected policy paths", async () => {
+    await withSuiteHome(async (home) => {
+      mockChannelPluginManifestRegistry("whatsapp");
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const original = {
+        meta: { lastTouchedVersion: "2026.5.17" },
+        gateway: { mode: "local" },
+        channels: {
+          whatsapp: {
+            enabled: true,
+            allowFrom: ["+15550001111"],
+          },
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const next = {
+        meta: original.meta,
+        gateway: { mode: "local" },
+        channels: {
+          whatsapp: {
+            enabled: true,
+          },
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const originalRaw = `${JSON.stringify(original, null, 2)}\n`;
+      await fs.writeFile(configPath, originalRaw, "utf-8");
+      const io = createConfigIO({
+        env: { VITEST: "true" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+      const baseSnapshot = {
+        path: configPath,
+        exists: true,
+        raw: originalRaw,
+        parsed: original,
+        sourceConfig: original,
+        resolved: original,
+        valid: true,
+        runtimeConfig: original,
+        config: original,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      } satisfies ConfigFileSnapshot;
+
+      const result = await io.writeConfigFile(next, {
+        baseSnapshot,
+        unsetPaths: [["channels", "whatsapp", "allowFrom"]],
+      });
+
+      expect(result.persistedConfig.channels?.whatsapp?.allowFrom).toBeUndefined();
+    });
+  });
+
+  it("allows explicit unsets that remove the final protected allowFrom map entry", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const original = {
+        meta: { lastTouchedVersion: "2026.5.17" },
+        gateway: { mode: "local" },
+        tools: {
+          elevated: {
+            allowFrom: {
+              webchat: ["session:trusted"],
+            },
+          },
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const next = {
+        meta: original.meta,
+        gateway: { mode: "local" },
+        tools: {
+          elevated: {},
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const originalRaw = `${JSON.stringify(original, null, 2)}\n`;
+      await fs.writeFile(configPath, originalRaw, "utf-8");
+      const io = createConfigIO({
+        env: { VITEST: "true" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+      const baseSnapshot = {
+        path: configPath,
+        exists: true,
+        raw: originalRaw,
+        parsed: original,
+        sourceConfig: original,
+        resolved: original,
+        valid: true,
+        runtimeConfig: original,
+        config: original,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      } satisfies ConfigFileSnapshot;
+
+      const result = await io.writeConfigFile(next, {
+        baseSnapshot,
+        unsetPaths: [["tools", "elevated", "allowFrom", "webchat"]],
+      });
+
+      expect(result.persistedConfig.tools?.elevated?.allowFrom).toBeUndefined();
     });
   });
 

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -1568,14 +1568,14 @@ describe("config io write", () => {
 
   it("rejects stale runtime writes that reintroduce channel allowlists", async () => {
     await withSuiteHome(async (home) => {
-      mockChannelPluginManifestRegistry("whatsapp");
+      mockChannelPluginManifestRegistry("discord");
       const configPath = path.join(home, ".openclaw", "openclaw.json");
       await fs.mkdir(path.dirname(configPath), { recursive: true });
       const original = {
         meta: { lastTouchedVersion: "2026.5.17" },
         gateway: { mode: "local" },
         channels: {
-          whatsapp: {
+          discord: {
             enabled: true,
             dm: {},
           },
@@ -1584,7 +1584,7 @@ describe("config io write", () => {
       const staleRuntime = {
         ...original,
         channels: {
-          whatsapp: {
+          discord: {
             enabled: true,
             allowFrom: ["*"],
             dm: {
@@ -1618,8 +1618,8 @@ describe("config io write", () => {
       await expect(io.writeConfigFile(staleRuntime, { baseSnapshot })).rejects.toMatchObject({
         code: "CONFIG_WRITE_REJECTED",
         reasons: expect.arrayContaining([
-          "protected-list-widened:channels.whatsapp.allowFrom",
-          "protected-list-widened:channels.whatsapp.dm.allowFrom",
+          "protected-list-widened:channels.discord.allowFrom",
+          "protected-list-widened:channels.discord.dm.allowFrom",
         ]),
       });
       await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
@@ -1703,12 +1703,13 @@ describe("config io write", () => {
             },
           },
         },
-      } as unknown as ConfigFileSnapshot["config"];
+      } as OpenClawConfig;
+      const runtimeOriginal = original as ConfigFileSnapshot["config"];
       const next = {
         meta: original.meta,
         gateway: { mode: "local" },
         channels: {},
-      } satisfies ConfigFileSnapshot["config"];
+      } satisfies OpenClawConfig;
       const originalRaw = `${JSON.stringify(original, null, 2)}\n`;
       await fs.writeFile(configPath, originalRaw, "utf-8");
       const io = createConfigIO({
@@ -1721,11 +1722,11 @@ describe("config io write", () => {
         exists: true,
         raw: originalRaw,
         parsed: original,
-        sourceConfig: original,
-        resolved: original,
+        sourceConfig: original as ConfigFileSnapshot["sourceConfig"],
+        resolved: original as ConfigFileSnapshot["resolved"],
         valid: true,
-        runtimeConfig: original,
-        config: original,
+        runtimeConfig: runtimeOriginal,
+        config: runtimeOriginal,
         issues: [],
         warnings: [],
         legacyIssues: [],

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -933,7 +933,7 @@ describe("config io write", () => {
       expect(rejectedEntries).toHaveLength(1);
       expect(warn.mock.calls).toEqual([
         [
-          `Config write rejected: ${configPath} (gateway-mode-removed, protected-channel-removed:channels.telegram). Rejected payload saved to ${path.join(
+          `Config write rejected: ${configPath} (gateway-mode-removed, protected-channel-config-changed:channels.telegram). Rejected payload saved to ${path.join(
             path.dirname(configPath),
             rejectedEntries[0] ?? "",
           )}.`,
@@ -1126,17 +1126,13 @@ describe("config io write", () => {
       await expect(io.writeConfigFile(staleRuntime, { baseSnapshot })).rejects.toMatchObject({
         code: "CONFIG_WRITE_REJECTED",
         reasons: expect.arrayContaining([
-          "protected-list-removed:commands.ownerAllowFrom",
-          "protected-list-widened:tools.elevated.allowFrom.webchat",
-          "protected-list-widened:agents.list.main.tools.elevated.allowFrom.webchat",
-          "protected-list-shrunk:channels.whatsapp.allowFrom",
-          "protected-list-shrunk:channels.whatsapp.groupAllowFrom",
-          "protected-channel-disabled:channels.whatsapp",
-          "protected-list-shrunk:channels.whatsapp.accounts.default.allowFrom",
-          "protected-list-shrunk:channels.whatsapp.accounts.default.groupAllowFrom",
-          "protected-channel-disabled:channels.whatsapp.accounts.default",
-          "protected-channel-enabled:channels.telegram",
-          "protected-channel-enabled:channels.telegram.accounts.default",
+          "protected-command-policy-changed:commands.ownerAllowFrom",
+          "protected-elevated-tools-changed:tools.elevated.allowFrom",
+          "protected-agent-elevated-tools-changed:agents.list.main.tools.elevated.allowFrom",
+          "protected-channel-config-changed:channels.whatsapp",
+          "protected-channel-config-changed:channels.whatsapp.accounts.default",
+          "protected-channel-config-changed:channels.telegram",
+          "protected-channel-config-changed:channels.telegram.accounts.default",
         ]),
       });
       await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
@@ -1256,8 +1252,8 @@ describe("config io write", () => {
       await expect(io.writeConfigFile(staleRuntime, { baseSnapshot })).rejects.toMatchObject({
         code: "CONFIG_WRITE_REJECTED",
         reasons: expect.arrayContaining([
-          "protected-channel-enabled:channels.whatsapp",
-          "protected-channel-enabled:channels.telegram.accounts.default",
+          "protected-channel-config-changed:channels.whatsapp",
+          "protected-channel-config-changed:channels.telegram.accounts.default",
         ]),
       });
       await expect(
@@ -1267,7 +1263,7 @@ describe("config io write", () => {
         }),
       ).rejects.toMatchObject({
         code: "CONFIG_WRITE_REJECTED",
-        reasons: expect.arrayContaining(["protected-channel-enabled:channels.whatsapp"]),
+        reasons: expect.arrayContaining(["protected-channel-config-changed:channels.whatsapp"]),
       });
       await expect(
         io.writeConfigFile(staleRuntime, {
@@ -1277,7 +1273,7 @@ describe("config io write", () => {
       ).rejects.toMatchObject({
         code: "CONFIG_WRITE_REJECTED",
         reasons: expect.arrayContaining([
-          "protected-channel-enabled:channels.telegram.accounts.default",
+          "protected-channel-config-changed:channels.telegram.accounts.default",
         ]),
       });
       await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
@@ -1416,8 +1412,8 @@ describe("config io write", () => {
       await expect(io.writeConfigFile(staleRuntime, { baseSnapshot })).rejects.toMatchObject({
         code: "CONFIG_WRITE_REJECTED",
         reasons: expect.arrayContaining([
-          "protected-list-widened:channels.whatsapp.allowFrom",
-          "protected-list-widened:channels.whatsapp.accounts.default.allowFrom",
+          "protected-channel-config-changed:channels.whatsapp",
+          "protected-channel-config-changed:channels.whatsapp.accounts.default",
         ]),
       });
       await expect(
@@ -1428,8 +1424,8 @@ describe("config io write", () => {
       ).rejects.toMatchObject({
         code: "CONFIG_WRITE_REJECTED",
         reasons: expect.arrayContaining([
-          "protected-list-widened:channels.whatsapp.allowFrom",
-          "protected-list-widened:channels.whatsapp.accounts.default.allowFrom",
+          "protected-channel-config-changed:channels.whatsapp",
+          "protected-channel-config-changed:channels.whatsapp.accounts.default",
         ]),
       });
       await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
@@ -1479,7 +1475,7 @@ describe("config io write", () => {
 
       await expect(io.writeConfigFile(staleRuntime, { baseSnapshot })).rejects.toMatchObject({
         code: "CONFIG_WRITE_REJECTED",
-        reasons: expect.arrayContaining(["protected-channel-removed:channels.whatsapp"]),
+        reasons: expect.arrayContaining(["protected-channel-config-changed:channels.whatsapp"]),
       });
       await expect(
         io.writeConfigFile(staleRuntime, {
@@ -1488,7 +1484,7 @@ describe("config io write", () => {
         }),
       ).rejects.toMatchObject({
         code: "CONFIG_WRITE_REJECTED",
-        reasons: expect.arrayContaining(["protected-channel-removed:channels.whatsapp"]),
+        reasons: expect.arrayContaining(["protected-channel-config-changed:channels.whatsapp"]),
       });
       await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
     });
@@ -1548,7 +1544,7 @@ describe("config io write", () => {
       await expect(io.writeConfigFile(staleRuntime, { baseSnapshot })).rejects.toMatchObject({
         code: "CONFIG_WRITE_REJECTED",
         reasons: expect.arrayContaining([
-          "protected-channel-removed:channels.whatsapp.accounts.work",
+          "protected-channel-config-changed:channels.whatsapp.accounts.work",
         ]),
       });
       await expect(
@@ -1559,7 +1555,7 @@ describe("config io write", () => {
       ).rejects.toMatchObject({
         code: "CONFIG_WRITE_REJECTED",
         reasons: expect.arrayContaining([
-          "protected-channel-removed:channels.whatsapp.accounts.work",
+          "protected-channel-config-changed:channels.whatsapp.accounts.work",
         ]),
       });
       await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
@@ -1617,10 +1613,7 @@ describe("config io write", () => {
 
       await expect(io.writeConfigFile(staleRuntime, { baseSnapshot })).rejects.toMatchObject({
         code: "CONFIG_WRITE_REJECTED",
-        reasons: expect.arrayContaining([
-          "protected-list-widened:channels.discord.allowFrom",
-          "protected-list-widened:channels.discord.dm.allowFrom",
-        ]),
+        reasons: expect.arrayContaining(["protected-channel-config-changed:channels.discord"]),
       });
       await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
     });
@@ -1679,7 +1672,7 @@ describe("config io write", () => {
       await expect(io.writeConfigFile(staleRuntime, { baseSnapshot })).rejects.toMatchObject({
         code: "CONFIG_WRITE_REJECTED",
         reasons: expect.arrayContaining([
-          "protected-list-widened:agents.list.main.tools.elevated.allowFrom.webchat",
+          "protected-agent-elevated-tools-changed:agents.list.main.tools.elevated.allowFrom",
         ]),
       });
       await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
@@ -1735,6 +1728,69 @@ describe("config io write", () => {
       const result = await io.writeConfigFile(next, { baseSnapshot });
 
       expect(result.persistedConfig.channels).toEqual({});
+    });
+  });
+
+  it("rejects stale runtime writes that change unrecognized channel policy fields", async () => {
+    await withSuiteHome(async (home) => {
+      mockChannelPluginManifestRegistry("futurechat");
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const original = {
+        meta: { lastTouchedVersion: "2026.5.17" },
+        gateway: { mode: "local" },
+        channels: {
+          futurechat: {
+            enabled: true,
+            futurePolicy: {
+              allowedTargets: ["session:trusted"],
+            },
+          },
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const staleRuntime = {
+        ...original,
+        channels: {
+          futurechat: {
+            enabled: true,
+            futurePolicy: {
+              allowedTargets: ["*"],
+            },
+          },
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const originalRaw = `${JSON.stringify(original, null, 2)}\n`;
+      await fs.writeFile(configPath, originalRaw, "utf-8");
+      const io = createConfigIO({
+        env: { VITEST: "true" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+      const baseSnapshot = {
+        path: configPath,
+        exists: true,
+        raw: originalRaw,
+        parsed: original,
+        sourceConfig: original,
+        resolved: original,
+        valid: true,
+        runtimeConfig: original,
+        config: original,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      } satisfies ConfigFileSnapshot;
+
+      await expect(
+        io.writeConfigFile(staleRuntime, {
+          baseSnapshot,
+          explicitSetPaths: [["channels", "futurechat", "sendReadReceipts"]],
+        }),
+      ).rejects.toMatchObject({
+        code: "CONFIG_WRITE_REJECTED",
+        reasons: expect.arrayContaining(["protected-channel-config-changed:channels.futurechat"]),
+      });
+      await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
     });
   });
 
@@ -1837,7 +1893,7 @@ describe("config io write", () => {
       ).rejects.toMatchObject({
         code: "CONFIG_WRITE_REJECTED",
         reasons: expect.arrayContaining([
-          "protected-list-removed:tools.elevated.allowFrom.telegram",
+          "protected-elevated-tools-changed:tools.elevated.allowFrom",
         ]),
       });
       await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
@@ -1913,7 +1969,7 @@ describe("config io write", () => {
       ).rejects.toMatchObject({
         code: "CONFIG_WRITE_REJECTED",
         reasons: expect.arrayContaining([
-          "protected-list-removed:agents.list.main.tools.elevated.allowFrom.webchat",
+          "protected-agent-elevated-tools-changed:agents.list.main.tools.elevated.allowFrom",
         ]),
       });
       await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
@@ -2021,7 +2077,7 @@ describe("config io write", () => {
 
       await expect(io.writeConfigFile(staleRuntime, { baseSnapshot })).rejects.toMatchObject({
         code: "CONFIG_WRITE_REJECTED",
-        reasons: expect.arrayContaining(["protected-list-widened:commands.ownerAllowFrom"]),
+        reasons: expect.arrayContaining(["protected-command-policy-changed:commands.ownerAllowFrom"]),
       });
       await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
     });
@@ -2078,7 +2134,7 @@ describe("config io write", () => {
       await expect(io.writeConfigFile(staleRuntime, { baseSnapshot })).rejects.toMatchObject({
         code: "CONFIG_WRITE_REJECTED",
         reasons: expect.arrayContaining([
-          "protected-list-widened:tools.elevated.allowFrom.telegram",
+          "protected-elevated-tools-changed:tools.elevated.allowFrom",
         ]),
       });
       await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
@@ -2131,8 +2187,8 @@ describe("config io write", () => {
       await expect(io.writeConfigFile(staleRuntime, { baseSnapshot })).rejects.toMatchObject({
         code: "CONFIG_WRITE_REJECTED",
         reasons: expect.arrayContaining([
-          "protected-list-widened:commands.ownerAllowFrom",
-          "protected-list-widened:tools.elevated.allowFrom.telegram",
+          "protected-command-policy-changed:commands.ownerAllowFrom",
+          "protected-elevated-tools-changed:tools.elevated.allowFrom",
         ]),
       });
       await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
@@ -2192,8 +2248,8 @@ describe("config io write", () => {
       await expect(io.writeConfigFile(staleRuntime, { baseSnapshot })).rejects.toMatchObject({
         code: "CONFIG_WRITE_REJECTED",
         reasons: expect.arrayContaining([
-          "protected-list-widened:commands.ownerAllowFrom",
-          "protected-list-widened:channels.whatsapp.allowFrom",
+          "protected-command-policy-changed:commands.ownerAllowFrom",
+          "protected-channel-config-changed:channels.whatsapp",
         ]),
       });
       await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
@@ -2296,12 +2352,9 @@ describe("config io write", () => {
       await expect(io.writeConfigFile(staleRuntime, { baseSnapshot })).rejects.toMatchObject({
         code: "CONFIG_WRITE_REJECTED",
         reasons: expect.arrayContaining([
-          "protected-list-removed:channels.googlechat.dm.allowFrom",
-          "protected-list-widened:channels.googlechat.groups.ops.users",
-          "protected-list-removed:channels.discord.guilds.main.users",
-          "protected-list-widened:channels.discord.guilds.main.channels.alerts.roles",
-          "protected-list-widened:channels.matrix.accounts.ops.dm.allowFrom",
-          "protected-list-removed:channels.matrix.accounts.ops.execApprovals.approvers",
+          "protected-channel-config-changed:channels.googlechat",
+          "protected-channel-config-changed:channels.discord",
+          "protected-channel-config-changed:channels.matrix.accounts.ops",
         ]),
       });
       await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(originalRaw);
@@ -2361,6 +2414,175 @@ describe("config io write", () => {
       });
 
       expect(result.persistedConfig.channels?.whatsapp?.allowFrom).toEqual(["+15550001111"]);
+    });
+  });
+
+  it("allows explicit indexed edits to protected policy arrays", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const original = {
+        meta: { lastTouchedVersion: "2026.5.17" },
+        gateway: { mode: "local" },
+        commands: {
+          ownerAllowFrom: ["webchat:owner", "telegram:111"],
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const next = {
+        meta: original.meta,
+        gateway: { mode: "local" },
+        commands: {
+          ownerAllowFrom: ["telegram:111"],
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const originalRaw = `${JSON.stringify(original, null, 2)}\n`;
+      await fs.writeFile(configPath, originalRaw, "utf-8");
+      const io = createConfigIO({
+        env: { VITEST: "true" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+      const baseSnapshot = {
+        path: configPath,
+        exists: true,
+        raw: originalRaw,
+        parsed: original,
+        sourceConfig: original,
+        resolved: original,
+        valid: true,
+        runtimeConfig: original,
+        config: original,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      } satisfies ConfigFileSnapshot;
+
+      const result = await io.writeConfigFile(next, {
+        baseSnapshot,
+        explicitSetPaths: [["commands", "ownerAllowFrom", "0"]],
+      });
+
+      expect(result.persistedConfig.commands?.ownerAllowFrom).toEqual(["telegram:111"]);
+    });
+  });
+
+  it("allows non-policy command settings without protected-policy exemptions", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const original = {
+        meta: { lastTouchedVersion: "2026.5.17" },
+        gateway: { mode: "local" },
+        commands: {
+          text: true,
+          ownerAllowFrom: ["webchat:owner"],
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const next = {
+        meta: original.meta,
+        gateway: { mode: "local" },
+        commands: {
+          text: false,
+          ownerAllowFrom: ["webchat:owner"],
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const originalRaw = `${JSON.stringify(original, null, 2)}\n`;
+      await fs.writeFile(configPath, originalRaw, "utf-8");
+      const io = createConfigIO({
+        env: { VITEST: "true" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+      const baseSnapshot = {
+        path: configPath,
+        exists: true,
+        raw: originalRaw,
+        parsed: original,
+        sourceConfig: original,
+        resolved: original,
+        valid: true,
+        runtimeConfig: original,
+        config: original,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      } satisfies ConfigFileSnapshot;
+
+      const result = await io.writeConfigFile(next, { baseSnapshot });
+
+      expect(result.persistedConfig.commands?.text).toBe(false);
+      expect(result.persistedConfig.commands?.ownerAllowFrom).toEqual(["webchat:owner"]);
+    });
+  });
+
+  it("allows non-explicit writes that materialize empty protected-policy containers", async () => {
+    await withSuiteHome(async (home) => {
+      mockChannelPluginManifestRegistry("whatsapp");
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const original = {
+        meta: { lastTouchedVersion: "2026.5.17" },
+        gateway: { mode: "local" },
+      } satisfies ConfigFileSnapshot["config"];
+      const next = {
+        meta: original.meta,
+        gateway: { mode: "local" },
+        commands: {
+          ownerAllowFrom: [],
+        },
+        tools: {
+          elevated: {
+            allowFrom: {},
+          },
+        },
+        agents: {
+          list: [
+            {
+              id: "main",
+              tools: {
+                elevated: {
+                  allowFrom: {},
+                },
+              },
+            },
+          ],
+        },
+        channels: {
+          whatsapp: {
+            accounts: {
+              default: {},
+            },
+          },
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const originalRaw = `${JSON.stringify(original, null, 2)}\n`;
+      await fs.writeFile(configPath, originalRaw, "utf-8");
+      const io = createConfigIO({
+        env: { VITEST: "true" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+      const baseSnapshot = {
+        path: configPath,
+        exists: true,
+        raw: originalRaw,
+        parsed: original,
+        sourceConfig: original,
+        resolved: original,
+        valid: true,
+        runtimeConfig: original,
+        config: original,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      } satisfies ConfigFileSnapshot;
+
+      await expect(io.writeConfigFile(next, { baseSnapshot })).resolves.toMatchObject({
+        persistedConfig: {
+          commands: { ownerAllowFrom: [] },
+          tools: { elevated: { allowFrom: {} } },
+        },
+      });
     });
   });
 

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -1080,11 +1080,12 @@ describe("config io write", () => {
         },
         channels: {
           whatsapp: {
-            enabled: true,
+            enabled: false,
             allowFrom: ["+15550001111"],
             groupAllowFrom: ["+15550001111"],
             accounts: {
               default: {
+                enabled: false,
                 allowFrom: ["+15550003333"],
                 groupAllowFrom: ["+15550003333"],
               },
@@ -1130,8 +1131,10 @@ describe("config io write", () => {
           "protected-list-widened:agents.list.main.tools.elevated.allowFrom.webchat",
           "protected-list-shrunk:channels.whatsapp.allowFrom",
           "protected-list-shrunk:channels.whatsapp.groupAllowFrom",
+          "protected-channel-disabled:channels.whatsapp",
           "protected-list-shrunk:channels.whatsapp.accounts.default.allowFrom",
           "protected-list-shrunk:channels.whatsapp.accounts.default.groupAllowFrom",
+          "protected-channel-disabled:channels.whatsapp.accounts.default",
           "protected-channel-enabled:channels.telegram",
           "protected-channel-enabled:channels.telegram.accounts.default",
         ]),

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -1284,6 +1284,88 @@ describe("config io write", () => {
     });
   });
 
+  it("allows explicit parent channel edits to activate channel scopes", async () => {
+    await withSuiteHome(async (home) => {
+      mockChannelPluginManifestRegistry("whatsapp");
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      const original = {
+        meta: { lastTouchedVersion: "2026.5.17" },
+        gateway: { mode: "local" },
+        channels: {
+          telegram: {
+            enabled: true,
+            accounts: {},
+          },
+        },
+      } satisfies ConfigFileSnapshot["config"];
+      const originalRaw = `${JSON.stringify(original, null, 2)}\n`;
+      await fs.writeFile(configPath, originalRaw, "utf-8");
+      const io = createConfigIO({
+        env: { VITEST: "true" } as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+      const baseSnapshot = {
+        path: configPath,
+        exists: true,
+        raw: originalRaw,
+        parsed: original,
+        sourceConfig: original,
+        resolved: original,
+        valid: true,
+        runtimeConfig: original,
+        config: original,
+        issues: [],
+        warnings: [],
+        legacyIssues: [],
+      } satisfies ConfigFileSnapshot;
+
+      await expect(
+        io.writeConfigFile(
+          {
+            ...original,
+            channels: {
+              ...original.channels,
+              whatsapp: {},
+            },
+          },
+          { baseSnapshot, explicitSetPaths: [["channels"]] },
+        ),
+      ).resolves.toMatchObject({
+        persistedConfig: {
+          channels: expect.objectContaining({ whatsapp: {} }),
+        },
+      });
+      await fs.writeFile(configPath, originalRaw, "utf-8");
+      await expect(
+        io.writeConfigFile(
+          {
+            ...original,
+            channels: {
+              telegram: {
+                enabled: true,
+                accounts: {
+                  default: {},
+                },
+              },
+            },
+          },
+          { baseSnapshot, explicitSetPaths: [["channels", "telegram", "accounts"]] },
+        ),
+      ).resolves.toMatchObject({
+        persistedConfig: {
+          channels: {
+            telegram: {
+              accounts: { default: {} },
+              enabled: true,
+            },
+          },
+        },
+      });
+    });
+  });
+
   it("rejects stale runtime writes that stage broad allowlists on disabled channel scopes", async () => {
     await withSuiteHome(async (home) => {
       mockChannelPluginManifestRegistry("whatsapp");

--- a/src/config/mutate.test.ts
+++ b/src/config/mutate.test.ts
@@ -18,6 +18,9 @@ type MockValidationResult =
 
 const ioMocks = vi.hoisted(() => ({
   readConfigFileSnapshotForWrite: vi.fn(),
+  resolveProtectedConfigPolicyWriteBlockingReasons: vi.fn(
+    (_params: { explicitSetPaths?: readonly (readonly string[])[] }): string[] => [],
+  ),
   resolveConfigSnapshotHash: vi.fn(),
   writeConfigFile: vi.fn(),
 }));
@@ -91,6 +94,8 @@ describe("config mutate helpers", () => {
     ioMocks.resolveConfigSnapshotHash.mockImplementation(
       (snapshot: { hash?: string }) => snapshot.hash ?? null,
     );
+    ioMocks.resolveProtectedConfigPolicyWriteBlockingReasons.mockReset();
+    ioMocks.resolveProtectedConfigPolicyWriteBlockingReasons.mockReturnValue([]);
     delete process.env.OPENCLAW_NIX_MODE;
   });
 
@@ -131,6 +136,47 @@ describe("config mutate helpers", () => {
         },
       },
       { baseSnapshot: snapshot, expectedConfigPath: snapshot.path, afterWrite: { mode: "auto" } },
+    );
+  });
+
+  it("marks protected policy paths touched by transform mutations as explicit", async () => {
+    const snapshot = createSnapshot({
+      hash: "source-hash",
+      sourceConfig: {
+        channels: { telegram: { enabled: true, allowFrom: ["123"] } },
+        tools: { elevated: { allowFrom: { telegram: ["123"] } } },
+      },
+    });
+    ioMocks.readConfigFileSnapshotForWrite.mockResolvedValue({
+      snapshot,
+      writeOptions: { expectedConfigPath: snapshot.path },
+    });
+
+    await transformConfigFileWithRetry({
+      baseHash: snapshot.hash,
+      base: "source",
+      transform(currentConfig) {
+        return {
+          nextConfig: {
+            ...currentConfig,
+            channels: { telegram: { enabled: true, allowFrom: ["456"] } },
+            tools: { elevated: { allowFrom: { telegram: ["456"] } } },
+          },
+        };
+      },
+    });
+
+    expect(ioMocks.writeConfigFile).toHaveBeenCalledWith(
+      {
+        channels: { telegram: { enabled: true, allowFrom: ["456"] } },
+        tools: { elevated: { allowFrom: { telegram: ["456"] } } },
+      },
+      expect.objectContaining({
+        explicitSetPaths: expect.arrayContaining([
+          ["channels", "telegram", "allowFrom"],
+          ["tools", "elevated", "allowFrom", "telegram"],
+        ]),
+      }),
     );
   });
 
@@ -605,6 +651,197 @@ describe("config mutate helpers", () => {
       entries?: Record<string, unknown>;
     };
     expect(persistedPlugins.entries?.["strict-plugin"]).toEqual({ enabled: true });
+  });
+
+  it("rejects protected policy drops before writing top-level includes", async () => {
+    const home = await suiteRootTracker.make("include-protected-policy");
+    const configPath = path.join(home, ".openclaw", "openclaw.json");
+    const channelsPath = path.join(home, ".openclaw", "config", "channels.json5");
+    await fs.mkdir(path.dirname(channelsPath), { recursive: true });
+    await fs.writeFile(
+      configPath,
+      `${JSON.stringify({ channels: { $include: "./config/channels.json5" } }, null, 2)}\n`,
+      "utf-8",
+    );
+    await fs.writeFile(
+      channelsPath,
+      `${JSON.stringify({ whatsapp: { allowFrom: ["+15550001111"] } }, null, 2)}\n`,
+      "utf-8",
+    );
+    const snapshot = createSnapshot({
+      hash: "hash-include-protected",
+      path: configPath,
+      parsed: { channels: { $include: "./config/channels.json5" } },
+      sourceConfig: {
+        channels: {
+          whatsapp: { allowFrom: ["+15550001111"] },
+        },
+      },
+    });
+    ioMocks.resolveProtectedConfigPolicyWriteBlockingReasons.mockReturnValueOnce([
+      "protected-list-removed:channels.whatsapp.allowFrom",
+    ]);
+
+    await expect(
+      replaceConfigFile({
+        baseHash: snapshot.hash,
+        snapshot,
+        writeOptions: {},
+        nextConfig: { channels: { whatsapp: {} } },
+      }),
+    ).rejects.toMatchObject({
+      code: "CONFIG_WRITE_REJECTED",
+      reasons: ["protected-list-removed:channels.whatsapp.allowFrom"],
+    });
+    await expect(fs.readFile(channelsPath, "utf-8")).resolves.toContain("+15550001111");
+    expect(ioMocks.writeConfigFile).not.toHaveBeenCalled();
+  });
+
+  it("treats include-path unsets as explicit protected policy edits", async () => {
+    const home = await suiteRootTracker.make("include-explicit-unset");
+    const configPath = path.join(home, ".openclaw", "openclaw.json");
+    const channelsPath = path.join(home, ".openclaw", "config", "channels.json5");
+    await fs.mkdir(path.dirname(channelsPath), { recursive: true });
+    await fs.writeFile(
+      configPath,
+      `${JSON.stringify({ channels: { $include: "./config/channels.json5" } }, null, 2)}\n`,
+      "utf-8",
+    );
+    await fs.writeFile(
+      channelsPath,
+      `${JSON.stringify({ whatsapp: { allowFrom: ["+15550001111"] } }, null, 2)}\n`,
+      "utf-8",
+    );
+    const snapshot = createSnapshot({
+      hash: "hash-include-unset",
+      path: configPath,
+      parsed: { channels: { $include: "./config/channels.json5" } },
+      sourceConfig: {
+        channels: {
+          whatsapp: { allowFrom: ["+15550001111"] },
+        },
+      },
+    });
+    ioMocks.resolveProtectedConfigPolicyWriteBlockingReasons.mockImplementationOnce((params) => {
+      expect(params.explicitSetPaths).toEqual(
+        expect.arrayContaining([["channels", "whatsapp", "allowFrom"]]),
+      );
+      return [];
+    });
+
+    await replaceConfigFile({
+      baseHash: snapshot.hash,
+      snapshot,
+      writeOptions: {
+        unsetPaths: [["channels", "whatsapp", "allowFrom"]],
+      },
+      nextConfig: {
+        channels: {
+          whatsapp: { allowFrom: ["+15550001111"] },
+        },
+      },
+    });
+
+    const persistedChannels = JSON.parse(await fs.readFile(channelsPath, "utf-8")) as {
+      whatsapp?: Record<string, unknown>;
+    };
+    expect(persistedChannels.whatsapp?.allowFrom).toBeUndefined();
+    expect(ioMocks.writeConfigFile).not.toHaveBeenCalled();
+  });
+
+  it("falls back to root writes for unsets that remove a top-level include", async () => {
+    const home = await suiteRootTracker.make("include-root-unset");
+    const configPath = path.join(home, ".openclaw", "openclaw.json");
+    const channelsPath = path.join(home, ".openclaw", "config", "channels.json5");
+    await fs.mkdir(path.dirname(channelsPath), { recursive: true });
+    await fs.writeFile(
+      configPath,
+      `${JSON.stringify({ channels: { $include: "./config/channels.json5" } }, null, 2)}\n`,
+      "utf-8",
+    );
+    await fs.writeFile(
+      channelsPath,
+      `${JSON.stringify({ whatsapp: { enabled: true } }, null, 2)}\n`,
+      "utf-8",
+    );
+    const snapshot = createSnapshot({
+      hash: "hash-include-root-unset",
+      path: configPath,
+      parsed: { channels: { $include: "./config/channels.json5" } },
+      sourceConfig: {
+        channels: {
+          whatsapp: { enabled: true },
+        },
+      },
+    });
+
+    await replaceConfigFile({
+      baseHash: snapshot.hash,
+      snapshot,
+      writeOptions: {
+        unsetPaths: [["channels"]],
+      },
+      nextConfig: {
+        channels: {
+          whatsapp: { enabled: true },
+        },
+      },
+    });
+
+    expect(ioMocks.writeConfigFile).toHaveBeenCalledWith(
+      {
+        channels: {
+          whatsapp: { enabled: true },
+        },
+      },
+      expect.objectContaining({
+        baseSnapshot: snapshot,
+        unsetPaths: [["channels"]],
+      }),
+    );
+    await expect(fs.readFile(channelsPath, "utf-8")).resolves.toContain("whatsapp");
+  });
+
+  it("falls back to root writes when a top-level include key is absent from the next config", async () => {
+    const home = await suiteRootTracker.make("include-root-absent");
+    const configPath = path.join(home, ".openclaw", "openclaw.json");
+    const channelsPath = path.join(home, ".openclaw", "config", "channels.json5");
+    await fs.mkdir(path.dirname(channelsPath), { recursive: true });
+    await fs.writeFile(
+      configPath,
+      `${JSON.stringify({ channels: { $include: "./config/channels.json5" } }, null, 2)}\n`,
+      "utf-8",
+    );
+    await fs.writeFile(
+      channelsPath,
+      `${JSON.stringify({ whatsapp: { enabled: true } }, null, 2)}\n`,
+      "utf-8",
+    );
+    const snapshot = createSnapshot({
+      hash: "hash-include-root-absent",
+      path: configPath,
+      parsed: { channels: { $include: "./config/channels.json5" } },
+      sourceConfig: {
+        channels: {
+          whatsapp: { enabled: true },
+        },
+      },
+    });
+
+    await replaceConfigFile({
+      baseHash: snapshot.hash,
+      snapshot,
+      writeOptions: {},
+      nextConfig: {},
+    });
+
+    expect(ioMocks.writeConfigFile).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        baseSnapshot: snapshot,
+      }),
+    );
+    await expect(fs.readFile(channelsPath, "utf-8")).resolves.toContain("whatsapp");
   });
 
   it("rejects invalid base config before skipped-plugin include writes", async () => {

--- a/src/config/mutate.test.ts
+++ b/src/config/mutate.test.ts
@@ -712,7 +712,7 @@ describe("config mutate helpers", () => {
       },
     });
     ioMocks.resolveProtectedConfigPolicyWriteBlockingReasons.mockReturnValueOnce([
-      "protected-list-removed:channels.whatsapp.allowFrom",
+      "protected-channel-config-changed:channels.whatsapp",
     ]);
 
     await expect(
@@ -724,7 +724,7 @@ describe("config mutate helpers", () => {
       }),
     ).rejects.toMatchObject({
       code: "CONFIG_WRITE_REJECTED",
-      reasons: ["protected-list-removed:channels.whatsapp.allowFrom"],
+      reasons: ["protected-channel-config-changed:channels.whatsapp"],
     });
     await expect(fs.readFile(channelsPath, "utf-8")).resolves.toContain("+15550001111");
     expect(ioMocks.writeConfigFile).not.toHaveBeenCalled();

--- a/src/config/mutate.test.ts
+++ b/src/config/mutate.test.ts
@@ -180,6 +180,39 @@ describe("config mutate helpers", () => {
     );
   });
 
+  it("marks newly-created channel configs from transform mutations as explicit", async () => {
+    const snapshot = createSnapshot({
+      hash: "source-hash",
+      sourceConfig: {},
+    });
+    ioMocks.readConfigFileSnapshotForWrite.mockResolvedValue({
+      snapshot,
+      writeOptions: { expectedConfigPath: snapshot.path },
+    });
+
+    await transformConfigFileWithRetry({
+      baseHash: snapshot.hash,
+      base: "source",
+      transform(currentConfig) {
+        return {
+          nextConfig: {
+            ...currentConfig,
+            channels: { whatsapp: { enabled: true } },
+          },
+        };
+      },
+    });
+
+    expect(ioMocks.writeConfigFile).toHaveBeenCalledWith(
+      {
+        channels: { whatsapp: { enabled: true } },
+      },
+      expect.objectContaining({
+        explicitSetPaths: expect.arrayContaining([["channels", "whatsapp"]]),
+      }),
+    );
+  });
+
   it("retries transform mutations on stale config conflicts", async () => {
     const initial = createSnapshot({
       hash: "hash-1",

--- a/src/config/mutate.ts
+++ b/src/config/mutate.ts
@@ -12,6 +12,7 @@ import { INCLUDE_KEY } from "./includes.js";
 import { createInvalidConfigError, formatInvalidConfigDetails } from "./io.invalid-config.js";
 import {
   readConfigFileSnapshotForWrite,
+  resolveProtectedConfigPolicyWriteBlockingReasons,
   resolveConfigSnapshotHash,
   writeConfigFile,
   type ConfigWriteOptions,
@@ -208,6 +209,129 @@ function getChangedTopLevelKeys(base: unknown, next: unknown): string[] {
   return [...keys].filter((key) => !isDeepStrictEqual(base[key], next[key]));
 }
 
+function isPathPrefix(pathSegments: readonly string[], prefix: readonly string[]): boolean {
+  return prefix.every((segment, index) => pathSegments[index] === segment);
+}
+
+function isPolicyConfigMutationPath(pathSegments: readonly string[]): boolean {
+  if (pathSegments.length === 0) {
+    return false;
+  }
+  if (pathSegments[0] === "channels" && pathSegments[1]) {
+    return pathSegments[1] !== "defaults" && pathSegments[1] !== "modelByChannel";
+  }
+  if (isPathPrefix(pathSegments, ["commands", "ownerAllowFrom"])) {
+    return true;
+  }
+  if (isPathPrefix(pathSegments, ["commands", "allowFrom"])) {
+    return true;
+  }
+  if (isPathPrefix(pathSegments, ["tools", "elevated", "allowFrom"])) {
+    return true;
+  }
+  if (
+    pathSegments.length >= 6 &&
+    pathSegments[0] === "agents" &&
+    pathSegments[1] === "list" &&
+    pathSegments[3] === "tools" &&
+    pathSegments[4] === "elevated" &&
+    pathSegments[5] === "allowFrom"
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function hasAgentProtectedPolicy(value: unknown): boolean {
+  return isRecord(value) && isRecord(value.tools) && isRecord(value.tools.elevated)
+    ? isRecord(value.tools.elevated.allowFrom)
+    : false;
+}
+
+function resolveAgentMutationPath(value: unknown, fallbackIndex: number): string[] {
+  return [
+    "agents",
+    "list",
+    isRecord(value) && typeof value.id === "string" ? value.id : String(fallbackIndex),
+  ];
+}
+
+function collectConfigMutationChangedPaths(
+  previous: unknown,
+  next: unknown,
+  pathSegments: string[] = [],
+  paths: string[][] = [],
+): string[][] {
+  if (isDeepStrictEqual(previous, next)) {
+    return paths;
+  }
+  if (
+    pathSegments[0] === "agents" &&
+    pathSegments[1] === "list" &&
+    pathSegments.length === 2 &&
+    Array.isArray(previous) &&
+    Array.isArray(next)
+  ) {
+    const maxLength = Math.max(previous.length, next.length);
+    for (let index = 0; index < maxLength; index += 1) {
+      const previousAgent = previous[index];
+      const nextAgent = next[index];
+      if (isRecord(previousAgent) && isRecord(nextAgent)) {
+        collectConfigMutationChangedPaths(
+          previousAgent,
+          nextAgent,
+          resolveAgentMutationPath(nextAgent, index),
+          paths,
+        );
+        continue;
+      }
+      if (
+        !isDeepStrictEqual(previousAgent, nextAgent) &&
+        (hasAgentProtectedPolicy(previousAgent) || hasAgentProtectedPolicy(nextAgent))
+      ) {
+        paths.push(resolveAgentMutationPath(nextAgent ?? previousAgent, index));
+      }
+    }
+    return paths;
+  }
+  const previousIsObject = isRecord(previous) && !Array.isArray(previous);
+  const nextIsObject = isRecord(next) && !Array.isArray(next);
+  if (!previousIsObject || !nextIsObject) {
+    if (isPolicyConfigMutationPath(pathSegments)) {
+      paths.push(pathSegments);
+    }
+    return paths;
+  }
+
+  const previousRecord = previous as Record<string, unknown>;
+  const nextRecord = next as Record<string, unknown>;
+  const keys = new Set([...Object.keys(previousRecord), ...Object.keys(nextRecord)]);
+  for (const key of keys) {
+    collectConfigMutationChangedPaths(
+      previousRecord[key],
+      nextRecord[key],
+      [...pathSegments, key],
+      paths,
+    );
+  }
+  return paths;
+}
+
+export function withConfigMutationExplicitSetPaths(
+  writeOptions: ConfigWriteOptions,
+  previousConfig: OpenClawConfig,
+  nextConfig: OpenClawConfig,
+): ConfigWriteOptions {
+  const explicitMutationPaths = collectConfigMutationChangedPaths(previousConfig, nextConfig);
+  if (explicitMutationPaths.length === 0) {
+    return writeOptions;
+  }
+  return {
+    ...writeOptions,
+    explicitSetPaths: [...(writeOptions.explicitSetPaths ?? []), ...explicitMutationPaths],
+  };
+}
+
 function getSingleTopLevelIncludeTarget(params: {
   snapshot: ConfigFileSnapshot;
   key: string;
@@ -258,10 +382,8 @@ async function tryWriteSingleTopLevelIncludeMutation(params: {
   writeOptions?: ConfigWriteOptions;
   io?: ConfigMutationIO;
 }): Promise<{ persistedHash: string | null; persistedConfig: OpenClawConfig } | null> {
-  const nextConfig = applyUnsetPathsForWrite(
-    params.nextConfig,
-    resolveManagedUnsetPathsForWrite(params.writeOptions?.unsetPaths),
-  );
+  const unsetPaths = resolveManagedUnsetPathsForWrite(params.writeOptions?.unsetPaths);
+  const nextConfig = applyUnsetPathsForWrite(params.nextConfig, unsetPaths);
   const changedKeys = getChangedTopLevelKeys(params.snapshot.sourceConfig, nextConfig);
   if (changedKeys.length !== 1 || changedKeys[0] === "<root>") {
     return null;
@@ -269,10 +391,33 @@ async function tryWriteSingleTopLevelIncludeMutation(params: {
 
   const key = changedKeys[0];
   const includePath = getSingleTopLevelIncludeTarget({ snapshot: params.snapshot, key });
-  if (!includePath || !isRecord(nextConfig) || !(key in nextConfig)) {
+  if (!includePath || !isRecord(nextConfig)) {
     return null;
   }
   const nextConfigRecord = nextConfig as Record<string, unknown>;
+  if (unsetPaths.some((unsetPath) => unsetPath.length === 1 && unsetPath[0] === key)) {
+    return null;
+  }
+  const hasNestedUnsetUnderKey = unsetPaths.some(
+    (unsetPath) => unsetPath.length > 1 && unsetPath[0] === key,
+  );
+  if (!(key in nextConfigRecord) && !hasNestedUnsetUnderKey) {
+    return null;
+  }
+  const nextIncludeValue = key in nextConfigRecord ? nextConfigRecord[key] : {};
+  const blockingReasons = resolveProtectedConfigPolicyWriteBlockingReasons({
+    previousConfig: params.snapshot.sourceConfig,
+    nextConfig,
+    explicitSetPaths: [...(params.writeOptions?.explicitSetPaths ?? []), ...unsetPaths],
+    allowProtectedConfigPolicyDrop: params.writeOptions?.allowProtectedConfigPolicyDrop,
+  });
+  if (blockingReasons.length > 0 && params.writeOptions?.allowDestructiveWrite !== true) {
+    const message = `Config include write rejected: ${includePath} (${blockingReasons.join(", ")}).`;
+    throw Object.assign(new Error(message), {
+      code: "CONFIG_WRITE_REJECTED",
+      reasons: blockingReasons,
+    });
+  }
 
   const validated = validateConfigObjectWithPlugins(
     nextConfig,
@@ -289,7 +434,7 @@ async function tryWriteSingleTopLevelIncludeMutation(params: {
   const runtimeConfigSourceSnapshot = getRuntimeConfigSourceSnapshot();
   const hadRuntimeSnapshot = Boolean(runtimeConfigSnapshot);
   const hadBothSnapshots = Boolean(runtimeConfigSnapshot && runtimeConfigSourceSnapshot);
-  await writeJsonFileAtomic(includePath, nextConfigRecord[key]);
+  await writeJsonFileAtomic(includePath, nextIncludeValue);
   if (
     params.writeOptions?.skipRuntimeSnapshotRefresh &&
     !hadRuntimeSnapshot &&
@@ -468,7 +613,11 @@ async function transformConfigFileAttempt<T>(
     nextConfig: transformed.nextConfig,
     snapshot,
     ...(previousHash !== null ? { baseHash: previousHash } : {}),
-    writeOptions: mergedWriteOptions,
+    writeOptions: withConfigMutationExplicitSetPaths(
+      mergedWriteOptions,
+      baseConfig,
+      transformed.nextConfig,
+    ),
     afterWrite,
     io: params.io,
   });

--- a/src/config/mutate.ts
+++ b/src/config/mutate.ts
@@ -421,6 +421,7 @@ async function tryWriteSingleTopLevelIncludeMutation(params: {
     previousConfig: params.snapshot.sourceConfig,
     nextConfig,
     explicitSetPaths: [...(params.writeOptions?.explicitSetPaths ?? []), ...unsetPaths],
+    explicitProtectedConfigPolicyPaths: params.writeOptions?.explicitProtectedConfigPolicyPaths,
     allowProtectedConfigPolicyDrop: params.writeOptions?.allowProtectedConfigPolicyDrop,
   });
   if (blockingReasons.length > 0 && params.writeOptions?.allowDestructiveWrite !== true) {

--- a/src/config/mutate.ts
+++ b/src/config/mutate.ts
@@ -301,11 +301,7 @@ function collectConfigMutationChangedPaths(
       paths.push(pathSegments);
       return paths;
     }
-    const childRecord = previousIsObject
-      ? (previous as Record<string, unknown>)
-      : nextIsObject
-        ? (next as Record<string, unknown>)
-        : null;
+    const childRecord = previousIsObject ? previous : nextIsObject ? next : null;
     if (childRecord) {
       for (const key of Object.keys(childRecord)) {
         collectConfigMutationChangedPaths(
@@ -319,8 +315,8 @@ function collectConfigMutationChangedPaths(
     return paths;
   }
 
-  const previousRecord = previous as Record<string, unknown>;
-  const nextRecord = next as Record<string, unknown>;
+  const previousRecord = previous;
+  const nextRecord = next;
   const keys = new Set([...Object.keys(previousRecord), ...Object.keys(nextRecord)]);
   for (const key of keys) {
     collectConfigMutationChangedPaths(

--- a/src/config/mutate.ts
+++ b/src/config/mutate.ts
@@ -299,6 +299,22 @@ function collectConfigMutationChangedPaths(
   if (!previousIsObject || !nextIsObject) {
     if (isPolicyConfigMutationPath(pathSegments)) {
       paths.push(pathSegments);
+      return paths;
+    }
+    const childRecord = previousIsObject
+      ? (previous as Record<string, unknown>)
+      : nextIsObject
+        ? (next as Record<string, unknown>)
+        : null;
+    if (childRecord) {
+      for (const key of Object.keys(childRecord)) {
+        collectConfigMutationChangedPaths(
+          previousIsObject ? childRecord[key] : undefined,
+          nextIsObject ? childRecord[key] : undefined,
+          [...pathSegments, key],
+          paths,
+        );
+      }
     }
     return paths;
   }

--- a/src/config/protected-policy.ts
+++ b/src/config/protected-policy.ts
@@ -1,0 +1,555 @@
+import { isDeepStrictEqual } from "node:util";
+import { isRecord } from "../utils.js";
+
+export const CHANNEL_CONFIG_META_KEYS = new Set(["defaults", "modelByChannel"]);
+
+export function isChannelConfigMetaKey(key: string): boolean {
+  return CHANNEL_CONFIG_META_KEYS.has(key);
+}
+
+export function startsWithConfigPath(
+  path: readonly string[],
+  prefix: readonly string[],
+): boolean {
+  return prefix.every((segment, index) => path[index] === segment);
+}
+
+export function isSameConfigPath(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((segment, index) => segment === right[index]);
+}
+
+export function isExplicitConfigWritePathAncestorOrSelf(
+  changedPath: readonly string[],
+  explicitSetPaths: readonly (readonly string[])[] | undefined,
+): boolean {
+  if (!explicitSetPaths || explicitSetPaths.length === 0) {
+    return false;
+  }
+  return explicitSetPaths.some((explicitPath) => startsWithConfigPath(changedPath, explicitPath));
+}
+
+function formatProtectedConfigPath(pathSegments: readonly string[]): string {
+  return pathSegments.length > 0 ? pathSegments.join(".") : "<root>";
+}
+
+function getObjectPathValue(value: unknown, pathSegments: readonly string[]): unknown {
+  let current = value;
+  for (const segment of pathSegments) {
+    if (Array.isArray(current)) {
+      const index = Number(segment);
+      if (!Number.isInteger(index) || index < 0 || String(index) !== segment) {
+        return undefined;
+      }
+      current = current[index];
+      continue;
+    }
+    if (!isRecord(current)) {
+      return undefined;
+    }
+    current = current[segment];
+  }
+  return current;
+}
+
+function isEmptyProtectedPolicyValue(value: unknown): boolean {
+  if (value === undefined) {
+    return true;
+  }
+  if (Array.isArray(value)) {
+    return value.length === 0;
+  }
+  if (!isRecord(value)) {
+    return false;
+  }
+  return Object.values(value).every(isEmptyProtectedPolicyValue);
+}
+
+function isEmptyProtectedPolicyContainerChange(params: {
+  previousConfig: unknown;
+  nextConfig: unknown;
+  changedPath: readonly string[];
+}): boolean {
+  return (
+    isEmptyProtectedPolicyValue(getObjectPathValue(params.previousConfig, params.changedPath)) &&
+    isEmptyProtectedPolicyValue(getObjectPathValue(params.nextConfig, params.changedPath))
+  );
+}
+
+function findChangedArrayPath(
+  previousConfig: unknown,
+  nextConfig: unknown,
+  changedPath: readonly string[],
+): string[] | null {
+  for (let length = changedPath.length; length >= 0; length -= 1) {
+    const candidatePath = changedPath.slice(0, length);
+    if (
+      Array.isArray(getObjectPathValue(previousConfig, candidatePath)) ||
+      Array.isArray(getObjectPathValue(nextConfig, candidatePath))
+    ) {
+      return candidatePath;
+    }
+  }
+  return null;
+}
+
+function isExplicitConfigWritePathForChange(params: {
+  previousConfig: unknown;
+  nextConfig: unknown;
+  changedPath: readonly string[];
+  explicitSetPaths: readonly (readonly string[])[] | undefined;
+}): boolean {
+  if (isExplicitConfigWritePathAncestorOrSelf(params.changedPath, params.explicitSetPaths)) {
+    return true;
+  }
+  if (!params.explicitSetPaths || params.explicitSetPaths.length === 0) {
+    return false;
+  }
+  const arrayPath = findChangedArrayPath(
+    params.previousConfig,
+    params.nextConfig,
+    params.changedPath,
+  );
+  if (!arrayPath) {
+    return false;
+  }
+  return params.explicitSetPaths.some((explicitPath) =>
+    startsWithConfigPath(explicitPath, arrayPath),
+  );
+}
+
+function collectChangedConfigPaths(
+  previousValue: unknown,
+  nextValue: unknown,
+  path: readonly string[],
+  output: string[][],
+): void {
+  if (isDeepStrictEqual(previousValue, nextValue)) {
+    return;
+  }
+  const previousArray = Array.isArray(previousValue);
+  const nextArray = Array.isArray(nextValue);
+  if (previousArray || nextArray) {
+    if (
+      (previousArray || previousValue === undefined) &&
+      (nextArray || nextValue === undefined)
+    ) {
+      const previousList = previousArray ? previousValue : [];
+      const nextList = nextArray ? nextValue : [];
+      const max = Math.max(previousList.length, nextList.length);
+      if (max === 0) {
+        output.push([...path]);
+        return;
+      }
+      for (let index = 0; index < max; index += 1) {
+        collectChangedConfigPaths(
+          previousList[index],
+          nextList[index],
+          [...path, String(index)],
+          output,
+        );
+      }
+      return;
+    }
+    output.push([...path]);
+    return;
+  }
+  const previousRecord = isRecord(previousValue);
+  const nextRecord = isRecord(nextValue);
+  if (previousRecord || nextRecord) {
+    const keys = new Set([
+      ...(previousRecord ? Object.keys(previousValue) : []),
+      ...(nextRecord ? Object.keys(nextValue) : []),
+    ]);
+    if (keys.size === 0) {
+      output.push([...path]);
+      return;
+    }
+    for (const key of keys) {
+      collectChangedConfigPaths(
+        previousRecord ? previousValue[key] : undefined,
+        nextRecord ? nextValue[key] : undefined,
+        [...path, key],
+        output,
+      );
+    }
+    return;
+  }
+  output.push([...path]);
+}
+
+function addProtectedReason(reasons: Set<string>, prefix: string, path: readonly string[]): void {
+  reasons.add(`${prefix}:${formatProtectedConfigPath(path)}`);
+}
+
+function appendProtectedRootChangeReasons(params: {
+  previousConfig: unknown;
+  nextConfig: unknown;
+  rootPath: readonly string[];
+  reasonPrefix: string;
+  explicitSetPaths?: readonly (readonly string[])[];
+  reasons: Set<string>;
+}): void {
+  const changedPaths: string[][] = [];
+  collectChangedConfigPaths(
+    getObjectPathValue(params.previousConfig, params.rootPath),
+    getObjectPathValue(params.nextConfig, params.rootPath),
+    [...params.rootPath],
+    changedPaths,
+  );
+  for (const changedPath of changedPaths) {
+    if (
+      isEmptyProtectedPolicyContainerChange({
+        previousConfig: params.previousConfig,
+        nextConfig: params.nextConfig,
+        changedPath,
+      })
+    ) {
+      continue;
+    }
+    if (
+      isExplicitConfigWritePathForChange({
+        previousConfig: params.previousConfig,
+        nextConfig: params.nextConfig,
+        changedPath,
+        explicitSetPaths: params.explicitSetPaths,
+      })
+    ) {
+      continue;
+    }
+    addProtectedReason(params.reasons, params.reasonPrefix, params.rootPath);
+  }
+}
+
+function listAgentRelativeExplicitSetPaths(params: {
+  explicitSetPaths?: readonly (readonly string[])[];
+  agentId: string | null;
+  index: number;
+}): readonly (readonly string[])[] | undefined {
+  const relativePaths = params.explicitSetPaths?.flatMap((explicitPath) => {
+    if (explicitPath[0] !== "agents") {
+      return [];
+    }
+    if (explicitPath.length === 1) {
+      return [[]];
+    }
+    if (explicitPath[1] !== "list") {
+      return [];
+    }
+    if (explicitPath.length === 2) {
+      return [[]];
+    }
+    const selector = explicitPath[2];
+    if (selector !== String(params.index) && (!params.agentId || selector !== params.agentId)) {
+      return [];
+    }
+    const relativePath = explicitPath.slice(3);
+    return [relativePath];
+  });
+  return relativePaths && relativePaths.length > 0 ? relativePaths : undefined;
+}
+
+function appendAgentElevatedToolsChangeReasons(params: {
+  previousAgent: unknown;
+  nextAgent: unknown;
+  agentId: string | null;
+  index: number;
+  explicitSetPaths?: readonly (readonly string[])[];
+  reasons: Set<string>;
+}): void {
+  const rootPath = ["tools", "elevated", "allowFrom"];
+  const displayRootPath = [
+    "agents",
+    "list",
+    params.agentId ?? String(params.index),
+    "tools",
+    "elevated",
+    "allowFrom",
+  ];
+  const changedPaths: string[][] = [];
+  collectChangedConfigPaths(
+    getObjectPathValue(params.previousAgent, rootPath),
+    getObjectPathValue(params.nextAgent, rootPath),
+    rootPath,
+    changedPaths,
+  );
+  const relativeExplicitSetPaths = listAgentRelativeExplicitSetPaths({
+    explicitSetPaths: params.explicitSetPaths,
+    agentId: params.agentId,
+    index: params.index,
+  });
+  for (const changedPath of changedPaths) {
+    if (
+      isEmptyProtectedPolicyContainerChange({
+        previousConfig: params.previousAgent,
+        nextConfig: params.nextAgent,
+        changedPath,
+      })
+    ) {
+      continue;
+    }
+    if (
+      isExplicitConfigWritePathForChange({
+        previousConfig: params.previousAgent,
+        nextConfig: params.nextAgent,
+        changedPath,
+        explicitSetPaths: relativeExplicitSetPaths,
+      })
+    ) {
+      continue;
+    }
+    addProtectedReason(
+      params.reasons,
+      "protected-agent-elevated-tools-changed",
+      displayRootPath,
+    );
+  }
+}
+
+function appendAgentProtectedPolicyChangeReasons(params: {
+  previousConfig: unknown;
+  nextConfig: unknown;
+  explicitSetPaths?: readonly (readonly string[])[];
+  reasons: Set<string>;
+}): void {
+  const previousAgents = getObjectPathValue(params.previousConfig, ["agents", "list"]);
+  const nextAgents = getObjectPathValue(params.nextConfig, ["agents", "list"]);
+  const previousAgentsById = new Map<string, { agent: unknown; index: number }>();
+  if (Array.isArray(previousAgents)) {
+    previousAgents.forEach((agent, index) => {
+      const id = isRecord(agent) && typeof agent.id === "string" ? agent.id : null;
+      if (id) {
+        previousAgentsById.set(id, { agent, index });
+      }
+    });
+  }
+  const nextAgentsById = new Map<string, { agent: unknown; index: number }>();
+  if (Array.isArray(nextAgents)) {
+    nextAgents.forEach((agent, index) => {
+      const id = isRecord(agent) && typeof agent.id === "string" ? agent.id : null;
+      if (id) {
+        nextAgentsById.set(id, { agent, index });
+      }
+    });
+  }
+  const handledNextIndexes = new Set<number>();
+  if (Array.isArray(previousAgents)) {
+    previousAgents.forEach((previousAgent, index) => {
+      if (!isRecord(previousAgent)) {
+        return;
+      }
+      const id = typeof previousAgent.id === "string" ? previousAgent.id : null;
+      const nextEntry = id
+        ? nextAgentsById.get(id)
+        : Array.isArray(nextAgents)
+          ? { agent: nextAgents[index], index }
+          : undefined;
+      if (nextEntry) {
+        handledNextIndexes.add(nextEntry.index);
+      }
+      appendAgentElevatedToolsChangeReasons({
+        previousAgent,
+        nextAgent: nextEntry?.agent,
+        agentId: id,
+        index,
+        explicitSetPaths: params.explicitSetPaths,
+        reasons: params.reasons,
+      });
+    });
+  }
+  if (!Array.isArray(nextAgents)) {
+    return;
+  }
+  nextAgents.forEach((nextAgent, index) => {
+    if (!isRecord(nextAgent) || handledNextIndexes.has(index)) {
+      return;
+    }
+    const id = typeof nextAgent.id === "string" ? nextAgent.id : null;
+    if (id && previousAgentsById.has(id)) {
+      return;
+    }
+    appendAgentElevatedToolsChangeReasons({
+      previousAgent: undefined,
+      nextAgent,
+      agentId: id,
+      index,
+      explicitSetPaths: params.explicitSetPaths,
+      reasons: params.reasons,
+    });
+  });
+}
+
+function resolveChannelProtectedRoot(path: readonly string[]): string[] | null {
+  if (path[0] !== "channels") {
+    return null;
+  }
+  const channelId = path[1];
+  if (!channelId || isChannelConfigMetaKey(channelId)) {
+    return null;
+  }
+  if (path[2] === "accounts" && path[3]) {
+    return ["channels", channelId, "accounts", path[3]];
+  }
+  return ["channels", channelId];
+}
+
+function appendChannelProtectedPolicyChangeReasons(params: {
+  previousConfig: unknown;
+  nextConfig: unknown;
+  explicitSetPaths?: readonly (readonly string[])[];
+  reasons: Set<string>;
+}): void {
+  const previousChannels = getObjectPathValue(params.previousConfig, ["channels"]);
+  const nextChannels = getObjectPathValue(params.nextConfig, ["channels"]);
+  const channelIds = new Set([
+    ...(isRecord(previousChannels) ? Object.keys(previousChannels) : []),
+    ...(isRecord(nextChannels) ? Object.keys(nextChannels) : []),
+  ]);
+  for (const channelId of channelIds) {
+    if (isChannelConfigMetaKey(channelId)) {
+      continue;
+    }
+    const channelPath = ["channels", channelId];
+    const changedPaths: string[][] = [];
+    collectChangedConfigPaths(
+      isRecord(previousChannels) ? previousChannels[channelId] : undefined,
+      isRecord(nextChannels) ? nextChannels[channelId] : undefined,
+      channelPath,
+      changedPaths,
+    );
+    for (const changedPath of changedPaths) {
+      if (
+        isEmptyProtectedPolicyContainerChange({
+          previousConfig: params.previousConfig,
+          nextConfig: params.nextConfig,
+          changedPath,
+        })
+      ) {
+        continue;
+      }
+      if (
+        isExplicitConfigWritePathForChange({
+          previousConfig: params.previousConfig,
+          nextConfig: params.nextConfig,
+          changedPath,
+          explicitSetPaths: params.explicitSetPaths,
+        })
+      ) {
+        continue;
+      }
+      const protectedRoot = resolveChannelProtectedRoot(changedPath);
+      if (protectedRoot) {
+        addProtectedReason(params.reasons, "protected-channel-config-changed", protectedRoot);
+      }
+    }
+  }
+}
+
+export function listProtectedConfigPolicyChangeReasons(params: {
+  previousConfig: unknown;
+  nextConfig: unknown;
+  explicitSetPaths?: readonly (readonly string[])[];
+}): string[] {
+  const reasons = new Set<string>();
+  appendProtectedRootChangeReasons({
+    previousConfig: params.previousConfig,
+    nextConfig: params.nextConfig,
+    rootPath: ["commands", "ownerAllowFrom"],
+    reasonPrefix: "protected-command-policy-changed",
+    explicitSetPaths: params.explicitSetPaths,
+    reasons,
+  });
+  appendProtectedRootChangeReasons({
+    previousConfig: params.previousConfig,
+    nextConfig: params.nextConfig,
+    rootPath: ["commands", "allowFrom"],
+    reasonPrefix: "protected-command-policy-changed",
+    explicitSetPaths: params.explicitSetPaths,
+    reasons,
+  });
+  appendProtectedRootChangeReasons({
+    previousConfig: params.previousConfig,
+    nextConfig: params.nextConfig,
+    rootPath: ["tools", "elevated", "allowFrom"],
+    reasonPrefix: "protected-elevated-tools-changed",
+    explicitSetPaths: params.explicitSetPaths,
+    reasons,
+  });
+  appendAgentProtectedPolicyChangeReasons({
+    previousConfig: params.previousConfig,
+    nextConfig: params.nextConfig,
+    explicitSetPaths: params.explicitSetPaths,
+    reasons,
+  });
+  appendChannelProtectedPolicyChangeReasons({
+    previousConfig: params.previousConfig,
+    nextConfig: params.nextConfig,
+    explicitSetPaths: params.explicitSetPaths,
+    reasons,
+  });
+  return [...reasons];
+}
+
+export function resolveProtectedConfigPolicyWriteBlockingReasons(params: {
+  previousConfig: unknown;
+  nextConfig: unknown;
+  explicitSetPaths?: readonly (readonly string[])[];
+  allowProtectedConfigPolicyDrop?: boolean;
+}): string[] {
+  const reasons = listProtectedConfigPolicyChangeReasons({
+    previousConfig: params.previousConfig,
+    nextConfig: params.nextConfig,
+    explicitSetPaths: params.explicitSetPaths,
+  });
+  if (params.allowProtectedConfigPolicyDrop === true) {
+    return [];
+  }
+  return reasons;
+}
+
+export function resolveProtectedConfigPolicyPath(
+  changedPath: readonly string[],
+): string[] | null {
+  if (changedPath[0] === "commands") {
+    if (changedPath.length === 1) {
+      return ["commands"];
+    }
+    const key = changedPath[1];
+    return key === "ownerAllowFrom" || key === "allowFrom" ? ["commands", key] : null;
+  }
+  if (changedPath[0] === "tools") {
+    if (
+      changedPath.length === 1 ||
+      (changedPath[1] === "elevated" &&
+        (changedPath.length === 2 || changedPath[2] === "allowFrom"))
+    ) {
+      return ["tools", "elevated", "allowFrom"];
+    }
+    return null;
+  }
+  if (changedPath[0] === "agents") {
+    if (changedPath.length === 1 || changedPath.length === 2) {
+      return ["agents", "list"];
+    }
+    if (
+      changedPath[1] === "list" &&
+      changedPath[2] &&
+      changedPath[3] === "tools" &&
+      changedPath[4] === "elevated" &&
+      (changedPath.length === 5 || changedPath[5] === "allowFrom")
+    ) {
+      return ["agents", "list", changedPath[2], "tools", "elevated", "allowFrom"];
+    }
+    return null;
+  }
+  if (changedPath[0] === "channels") {
+    const channelId = changedPath[1];
+    if (!channelId) {
+      return ["channels"];
+    }
+    if (isChannelConfigMetaKey(channelId)) {
+      return null;
+    }
+    return ["channels", channelId];
+  }
+  return null;
+}

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -622,6 +622,8 @@ async function runWriteConfigHealth(ctx: DoctorHealthFlowContext): Promise<void>
       afterWrite: { mode: "auto" },
       writeOptions: {
         allowConfigSizeDrop: ctx.configResult.shouldWriteConfig === true || updateDoctorRun,
+        allowProtectedConfigPolicyDrop:
+          ctx.configResult.shouldWriteConfig === true || updateDoctorRun,
         skipPluginValidation:
           ctx.configResult.skipPluginValidationOnWrite === true || updateDoctorRun,
         preservedLegacyRootKeys: ctx.configResult.preservedLegacyRootKeys,

--- a/src/gateway/config-diff.ts
+++ b/src/gateway/config-diff.ts
@@ -1,21 +1,30 @@
 import { isDeepStrictEqual } from "node:util";
 import { isPlainObject } from "../utils.js";
 
-export function diffConfigPaths(prev: unknown, next: unknown, prefix = ""): string[] {
+export type ConfigPathSegments = string[];
+
+function formatConfigPath(segments: readonly string[]): string {
+  return segments.length > 0 ? segments.join(".") : "<root>";
+}
+
+export function diffConfigPathSegments(
+  prev: unknown,
+  next: unknown,
+  prefix: readonly string[] = [],
+): ConfigPathSegments[] {
   if (prev === next) {
     return [];
   }
   if (isPlainObject(prev) && isPlainObject(next)) {
     const keys = new Set([...Object.keys(prev), ...Object.keys(next)]);
-    const paths: string[] = [];
+    const paths: ConfigPathSegments[] = [];
     for (const key of keys) {
       const prevValue = prev[key];
       const nextValue = next[key];
       if (prevValue === undefined && nextValue === undefined) {
         continue;
       }
-      const childPrefix = prefix ? `${prefix}.${key}` : key;
-      const childPaths = diffConfigPaths(prevValue, nextValue, childPrefix);
+      const childPaths = diffConfigPathSegments(prevValue, nextValue, [...prefix, key]);
       if (childPaths.length > 0) {
         paths.push(...childPaths);
       }
@@ -29,5 +38,9 @@ export function diffConfigPaths(prev: unknown, next: unknown, prefix = ""): stri
       return [];
     }
   }
-  return [prefix || "<root>"];
+  return [[...prefix]];
+}
+
+export function diffConfigPaths(prev: unknown, next: unknown): string[] {
+  return diffConfigPathSegments(prev, next).map(formatConfigPath);
 }

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -1,4 +1,5 @@
 import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   getActivePluginChannelRegistryVersion,
   getActivePluginRegistry,
@@ -376,4 +377,150 @@ export function buildGatewayReloadPlan(
   }
 
   return plan;
+}
+
+function readChannelEnabled(config: OpenClawConfig, channelId: string): unknown {
+  const channels = isPlainObject(config.channels) ? config.channels : null;
+  const channelCfg = channels && isPlainObject(channels[channelId]) ? channels[channelId] : null;
+  return channelCfg?.enabled;
+}
+
+function readChannelAccountEnabled(
+  config: OpenClawConfig,
+  channelId: string,
+  accountId: string,
+): unknown {
+  const channels = isPlainObject(config.channels) ? config.channels : null;
+  const channelCfg = channels && isPlainObject(channels[channelId]) ? channels[channelId] : null;
+  const accounts = channelCfg && isPlainObject(channelCfg.accounts) ? channelCfg.accounts : null;
+  const accountCfg = accounts && isPlainObject(accounts[accountId]) ? accounts[accountId] : null;
+  return accountCfg?.enabled;
+}
+
+function hasChannelConfig(config: OpenClawConfig, channelId: string): boolean {
+  const channels = isPlainObject(config.channels) ? config.channels : null;
+  return Boolean(channels && isPlainObject(channels[channelId]));
+}
+
+function hasChannelAccountConfig(
+  config: OpenClawConfig,
+  channelId: string,
+  accountId: string,
+): boolean {
+  const channels = isPlainObject(config.channels) ? config.channels : null;
+  const channelCfg = channels && isPlainObject(channels[channelId]) ? channels[channelId] : null;
+  const accounts = channelCfg && isPlainObject(channelCfg.accounts) ? channelCfg.accounts : null;
+  return Boolean(accounts && isPlainObject(accounts[accountId]));
+}
+
+function hasEnabledChannelAccountActivation(params: {
+  previousConfig: OpenClawConfig;
+  nextConfig: OpenClawConfig;
+  channelId: string;
+}): boolean {
+  if (readChannelEnabled(params.nextConfig, params.channelId) === false) {
+    return false;
+  }
+  const channels = isPlainObject(params.nextConfig.channels) ? params.nextConfig.channels : null;
+  const channelCfg =
+    channels && isPlainObject(channels[params.channelId]) ? channels[params.channelId] : null;
+  const accounts = channelCfg && isPlainObject(channelCfg.accounts) ? channelCfg.accounts : null;
+  if (!accounts) {
+    return false;
+  }
+  return Object.entries(accounts).some(([accountId, accountCfg]) => {
+    if (!isPlainObject(accountCfg) || accountCfg.enabled === false) {
+      return false;
+    }
+    return (
+      !hasChannelAccountConfig(params.previousConfig, params.channelId, accountId) ||
+      readChannelAccountEnabled(params.previousConfig, params.channelId, accountId) === false
+    );
+  });
+}
+
+function listNoopEnabledChannelActivationReasons(params: {
+  previousConfig: OpenClawConfig;
+  nextConfig: OpenClawConfig;
+  changedPaths: string[];
+  plan: GatewayReloadPlan;
+}): string[] {
+  const noopPaths = new Set(params.plan.noopPaths);
+  const reasons: string[] = [];
+  for (const changedPath of params.changedPaths) {
+    if (!noopPaths.has(changedPath)) {
+      continue;
+    }
+    const channelMatch = /^channels\.([^.]+)(?:\.enabled)?$/.exec(changedPath);
+    const accountMatch = /^channels\.([^.]+)\.accounts\.([^.]+)(?:\.enabled)?$/.exec(changedPath);
+    const accountMapMatch = /^channels\.([^.]+)\.accounts$/.exec(changedPath);
+    const channelId = (channelMatch?.[1] ?? accountMatch?.[1] ?? accountMapMatch?.[1])
+      ?.trim()
+      .toLowerCase();
+    if (!channelId) {
+      continue;
+    }
+    if (accountMapMatch) {
+      if (
+        hasEnabledChannelAccountActivation({
+          previousConfig: params.previousConfig,
+          nextConfig: params.nextConfig,
+          channelId,
+        })
+      ) {
+        reasons.push(`${changedPath}: enabled channel account activation requires gateway restart`);
+      }
+      continue;
+    }
+    if (accountMatch) {
+      const accountId = accountMatch[2]?.trim();
+      if (!accountId) {
+        continue;
+      }
+      const channelEnabled = readChannelEnabled(params.nextConfig, channelId) !== false;
+      const hadAccountConfig = hasChannelAccountConfig(params.previousConfig, channelId, accountId);
+      const wasEnabled =
+        hadAccountConfig &&
+        readChannelAccountEnabled(params.previousConfig, channelId, accountId) !== false;
+      const isEnabled =
+        channelEnabled &&
+        hasChannelAccountConfig(params.nextConfig, channelId, accountId) &&
+        readChannelAccountEnabled(params.nextConfig, channelId, accountId) !== false;
+      if (!wasEnabled && isEnabled) {
+        reasons.push(`${changedPath}: enabled channel account activation requires gateway restart`);
+      }
+      continue;
+    }
+    const hadChannelConfig = hasChannelConfig(params.previousConfig, channelId);
+    const wasEnabled =
+      hadChannelConfig && readChannelEnabled(params.previousConfig, channelId) !== false;
+    const isEnabled =
+      hasChannelConfig(params.nextConfig, channelId) &&
+      readChannelEnabled(params.nextConfig, channelId) !== false;
+    if (!wasEnabled && isEnabled) {
+      reasons.push(`${changedPath}: enabled channel activation requires gateway restart`);
+    }
+  }
+  return reasons;
+}
+
+export function applyNoopEnabledChannelActivationRestarts(params: {
+  plan: GatewayReloadPlan;
+  previousConfig: OpenClawConfig;
+  nextConfig: OpenClawConfig;
+  changedPaths: string[];
+}): GatewayReloadPlan {
+  const restartReasons = listNoopEnabledChannelActivationReasons(params);
+  if (restartReasons.length === 0) {
+    return params.plan;
+  }
+  const restartReasonPaths = new Set(
+    restartReasons.flatMap((reason) => reason.match(/^([^:]+):/)?.[1] ?? []),
+  );
+  return {
+    ...params.plan,
+    restartGateway: true,
+    restartReasons: [...params.plan.restartReasons, ...restartReasons],
+    noopPaths: params.plan.noopPaths.filter((path) => !restartReasonPaths.has(path)),
+  };
 }

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -439,7 +439,37 @@ function hasEnabledChannelAccountActivation(params: {
   });
 }
 
-function listNoopEnabledChannelActivationReasons(params: {
+function hasEnabledChannelAccountDeactivation(params: {
+  previousConfig: OpenClawConfig;
+  nextConfig: OpenClawConfig;
+  channelId: string;
+}): boolean {
+  if (readChannelEnabled(params.previousConfig, params.channelId) === false) {
+    return false;
+  }
+  const channels = isPlainObject(params.previousConfig.channels)
+    ? params.previousConfig.channels
+    : null;
+  const channelCfg =
+    channels && isPlainObject(channels[params.channelId]) ? channels[params.channelId] : null;
+  const accounts = channelCfg && isPlainObject(channelCfg.accounts) ? channelCfg.accounts : null;
+  if (!accounts) {
+    return false;
+  }
+  const channelEnabled = readChannelEnabled(params.nextConfig, params.channelId) !== false;
+  return Object.entries(accounts).some(([accountId, accountCfg]) => {
+    if (!isPlainObject(accountCfg) || accountCfg.enabled === false) {
+      return false;
+    }
+    return (
+      !channelEnabled ||
+      !hasChannelAccountConfig(params.nextConfig, params.channelId, accountId) ||
+      readChannelAccountEnabled(params.nextConfig, params.channelId, accountId) === false
+    );
+  });
+}
+
+function listNoopEnabledChannelLifecycleReasons(params: {
   previousConfig: OpenClawConfig;
   nextConfig: OpenClawConfig;
   changedPaths: string[];
@@ -470,6 +500,17 @@ function listNoopEnabledChannelActivationReasons(params: {
       ) {
         reasons.push(`${changedPath}: enabled channel account activation requires gateway restart`);
       }
+      if (
+        hasEnabledChannelAccountDeactivation({
+          previousConfig: params.previousConfig,
+          nextConfig: params.nextConfig,
+          channelId,
+        })
+      ) {
+        reasons.push(
+          `${changedPath}: enabled channel account deactivation requires gateway restart`,
+        );
+      }
       continue;
     }
     if (accountMatch) {
@@ -489,6 +530,11 @@ function listNoopEnabledChannelActivationReasons(params: {
       if (!wasEnabled && isEnabled) {
         reasons.push(`${changedPath}: enabled channel account activation requires gateway restart`);
       }
+      if (wasEnabled && !isEnabled) {
+        reasons.push(
+          `${changedPath}: enabled channel account deactivation requires gateway restart`,
+        );
+      }
       continue;
     }
     const hadChannelConfig = hasChannelConfig(params.previousConfig, channelId);
@@ -500,6 +546,9 @@ function listNoopEnabledChannelActivationReasons(params: {
     if (!wasEnabled && isEnabled) {
       reasons.push(`${changedPath}: enabled channel activation requires gateway restart`);
     }
+    if (wasEnabled && !isEnabled) {
+      reasons.push(`${changedPath}: enabled channel deactivation requires gateway restart`);
+    }
   }
   return reasons;
 }
@@ -510,7 +559,7 @@ export function applyNoopEnabledChannelActivationRestarts(params: {
   nextConfig: OpenClawConfig;
   changedPaths: string[];
 }): GatewayReloadPlan {
-  const restartReasons = listNoopEnabledChannelActivationReasons(params);
+  const restartReasons = listNoopEnabledChannelLifecycleReasons(params);
   if (restartReasons.length === 0) {
     return params.plan;
   }

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -1327,6 +1327,386 @@ describe("startGatewayConfigReloader", () => {
     await harness.reloader.stop();
   });
 
+  it("queues restart when enabling a no-op channel config from disabled", async () => {
+    const whatsappPlugin: ChannelPlugin = {
+      id: "whatsapp",
+      meta: {
+        id: "whatsapp",
+        label: "WhatsApp",
+        selectionLabel: "WhatsApp",
+        docsPath: "/channels/whatsapp",
+        blurb: "test",
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => [],
+        resolveAccount: () => ({}),
+      },
+      reload: { configPrefixes: [], noopPrefixes: ["channels.whatsapp"] },
+    };
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "whatsapp", plugin: whatsappPlugin, source: "test" }]),
+    );
+    const previousConfig: OpenClawConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      channels: { whatsapp: { enabled: false } },
+    };
+    const nextConfig: OpenClawConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      channels: { whatsapp: { enabled: true } },
+    };
+    const readSnapshot = vi.fn<() => Promise<ConfigFileSnapshot>>().mockResolvedValueOnce(
+      makeSnapshot({
+        sourceConfig: nextConfig,
+        runtimeConfig: nextConfig,
+        config: nextConfig,
+        hash: "whatsapp-enable-1",
+      }),
+    );
+    const harness = createReloaderHarness(readSnapshot, { initialCompareConfig: previousConfig });
+
+    try {
+      harness.watcher.emit("change");
+      await vi.runOnlyPendingTimersAsync();
+
+      expect(harness.onHotReload).not.toHaveBeenCalled();
+      const [plan, restartedConfig] = getOnlyRestartCall(harness);
+      expect(plan.restartGateway).toBe(true);
+      expect(plan.restartReasons).toEqual([
+        "channels.whatsapp.enabled: enabled channel activation requires gateway restart",
+      ]);
+      expect(plan.noopPaths).toEqual([]);
+      expect(restartedConfig).toBe(nextConfig);
+    } finally {
+      resetPluginRuntimeStateForTest();
+      await harness.reloader.stop();
+    }
+  });
+
+  it("queues restart when enabling a no-op channel account config from disabled", async () => {
+    const whatsappPlugin: ChannelPlugin = {
+      id: "whatsapp",
+      meta: {
+        id: "whatsapp",
+        label: "WhatsApp",
+        selectionLabel: "WhatsApp",
+        docsPath: "/channels/whatsapp",
+        blurb: "test",
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => [],
+        resolveAccount: () => ({}),
+      },
+      reload: { configPrefixes: [], noopPrefixes: ["channels.whatsapp"] },
+    };
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "whatsapp", plugin: whatsappPlugin, source: "test" }]),
+    );
+    const previousConfig: OpenClawConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      channels: { whatsapp: { accounts: { work: { enabled: false } } } },
+    };
+    const nextConfig: OpenClawConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      channels: { whatsapp: { accounts: { work: { enabled: true } } } },
+    };
+    const readSnapshot = vi.fn<() => Promise<ConfigFileSnapshot>>().mockResolvedValueOnce(
+      makeSnapshot({
+        sourceConfig: nextConfig,
+        runtimeConfig: nextConfig,
+        config: nextConfig,
+        hash: "whatsapp-account-enable-1",
+      }),
+    );
+    const harness = createReloaderHarness(readSnapshot, { initialCompareConfig: previousConfig });
+
+    try {
+      harness.watcher.emit("change");
+      await vi.runOnlyPendingTimersAsync();
+
+      expect(harness.onHotReload).not.toHaveBeenCalled();
+      const [plan, restartedConfig] = getOnlyRestartCall(harness);
+      expect(plan.restartReasons).toEqual([
+        "channels.whatsapp.accounts.work.enabled: enabled channel account activation requires gateway restart",
+      ]);
+      expect(plan.noopPaths).toEqual([]);
+      expect(restartedConfig).toBe(nextConfig);
+    } finally {
+      resetPluginRuntimeStateForTest();
+      await harness.reloader.stop();
+    }
+  });
+
+  it("queues restart when adding the first enabled no-op channel accounts map", async () => {
+    const whatsappPlugin: ChannelPlugin = {
+      id: "whatsapp",
+      meta: {
+        id: "whatsapp",
+        label: "WhatsApp",
+        selectionLabel: "WhatsApp",
+        docsPath: "/channels/whatsapp",
+        blurb: "test",
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => [],
+        resolveAccount: () => ({}),
+      },
+      reload: { configPrefixes: [], noopPrefixes: ["channels.whatsapp"] },
+    };
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "whatsapp", plugin: whatsappPlugin, source: "test" }]),
+    );
+    const previousConfig: OpenClawConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      channels: { whatsapp: {} },
+    };
+    const nextConfig: OpenClawConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      channels: { whatsapp: { accounts: { work: {} } } },
+    };
+    const readSnapshot = vi.fn<() => Promise<ConfigFileSnapshot>>().mockResolvedValueOnce(
+      makeSnapshot({
+        sourceConfig: nextConfig,
+        runtimeConfig: nextConfig,
+        config: nextConfig,
+        hash: "whatsapp-accounts-add-1",
+      }),
+    );
+    const harness = createReloaderHarness(readSnapshot, { initialCompareConfig: previousConfig });
+
+    try {
+      harness.watcher.emit("change");
+      await vi.runOnlyPendingTimersAsync();
+
+      expect(harness.onHotReload).not.toHaveBeenCalled();
+      const [plan, restartedConfig] = getOnlyRestartCall(harness);
+      expect(plan.restartReasons).toEqual([
+        "channels.whatsapp.accounts: enabled channel account activation requires gateway restart",
+      ]);
+      expect(plan.noopPaths).toEqual([]);
+      expect(restartedConfig).toBe(nextConfig);
+    } finally {
+      resetPluginRuntimeStateForTest();
+      await harness.reloader.stop();
+    }
+  });
+
+  it("queues restart when adding an enabled no-op channel config block", async () => {
+    const whatsappPlugin: ChannelPlugin = {
+      id: "whatsapp",
+      meta: {
+        id: "whatsapp",
+        label: "WhatsApp",
+        selectionLabel: "WhatsApp",
+        docsPath: "/channels/whatsapp",
+        blurb: "test",
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => [],
+        resolveAccount: () => ({}),
+      },
+      reload: { configPrefixes: [], noopPrefixes: ["channels.whatsapp"] },
+    };
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "whatsapp", plugin: whatsappPlugin, source: "test" }]),
+    );
+    const previousConfig: OpenClawConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      channels: {},
+    };
+    const nextConfig: OpenClawConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      channels: { whatsapp: {} },
+    };
+    const readSnapshot = vi.fn<() => Promise<ConfigFileSnapshot>>().mockResolvedValueOnce(
+      makeSnapshot({
+        sourceConfig: nextConfig,
+        runtimeConfig: nextConfig,
+        config: nextConfig,
+        hash: "whatsapp-add-1",
+      }),
+    );
+    const harness = createReloaderHarness(readSnapshot, { initialCompareConfig: previousConfig });
+
+    try {
+      harness.watcher.emit("change");
+      await vi.runOnlyPendingTimersAsync();
+
+      expect(harness.onHotReload).not.toHaveBeenCalled();
+      const [plan, restartedConfig] = getOnlyRestartCall(harness);
+      expect(plan.restartReasons).toEqual([
+        "channels.whatsapp: enabled channel activation requires gateway restart",
+      ]);
+      expect(restartedConfig).toBe(nextConfig);
+    } finally {
+      resetPluginRuntimeStateForTest();
+      await harness.reloader.stop();
+    }
+  });
+
+  it("queues restart when adding an enabled external no-op channel config block", async () => {
+    const externalPlugin: ChannelPlugin = {
+      id: "line",
+      meta: {
+        id: "line",
+        label: "LINE",
+        selectionLabel: "LINE",
+        docsPath: "/channels/line",
+        blurb: "test",
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => [],
+        resolveAccount: () => ({}),
+      },
+      reload: { configPrefixes: [], noopPrefixes: ["channels.line"] },
+    };
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "line", plugin: externalPlugin, source: "test" }]),
+    );
+    const previousConfig: OpenClawConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      channels: {},
+    };
+    const nextConfig: OpenClawConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      channels: { line: {} },
+    };
+    const readSnapshot = vi.fn<() => Promise<ConfigFileSnapshot>>().mockResolvedValueOnce(
+      makeSnapshot({
+        sourceConfig: nextConfig,
+        runtimeConfig: nextConfig,
+        config: nextConfig,
+        hash: "line-add-1",
+      }),
+    );
+    const harness = createReloaderHarness(readSnapshot, { initialCompareConfig: previousConfig });
+
+    try {
+      harness.watcher.emit("change");
+      await vi.runOnlyPendingTimersAsync();
+
+      expect(harness.onHotReload).not.toHaveBeenCalled();
+      const [plan, restartedConfig] = getOnlyRestartCall(harness);
+      expect(plan.restartReasons).toEqual([
+        "channels.line: enabled channel activation requires gateway restart",
+      ]);
+      expect(restartedConfig).toBe(nextConfig);
+    } finally {
+      resetPluginRuntimeStateForTest();
+      await harness.reloader.stop();
+    }
+  });
+
+  it("warns instead of restarting enabled no-op channels when reload mode is hot", async () => {
+    const whatsappPlugin: ChannelPlugin = {
+      id: "whatsapp",
+      meta: {
+        id: "whatsapp",
+        label: "WhatsApp",
+        selectionLabel: "WhatsApp",
+        docsPath: "/channels/whatsapp",
+        blurb: "test",
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => [],
+        resolveAccount: () => ({}),
+      },
+      reload: { configPrefixes: [], noopPrefixes: ["channels.whatsapp"] },
+    };
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "whatsapp", plugin: whatsappPlugin, source: "test" }]),
+    );
+    const previousConfig: OpenClawConfig = {
+      gateway: { reload: { debounceMs: 0, mode: "hot" } },
+      channels: { whatsapp: { enabled: false } },
+    };
+    const nextConfig: OpenClawConfig = {
+      gateway: { reload: { debounceMs: 0, mode: "hot" } },
+      channels: { whatsapp: { enabled: true } },
+    };
+    const readSnapshot = vi.fn<() => Promise<ConfigFileSnapshot>>().mockResolvedValueOnce(
+      makeSnapshot({
+        sourceConfig: nextConfig,
+        runtimeConfig: nextConfig,
+        config: nextConfig,
+        hash: "whatsapp-enable-hot-1",
+      }),
+    );
+    const harness = createReloaderHarness(readSnapshot, { initialCompareConfig: previousConfig });
+
+    try {
+      harness.watcher.emit("change");
+      await vi.runOnlyPendingTimersAsync();
+
+      expect(harness.onHotReload).not.toHaveBeenCalled();
+      expect(harness.onRestart).not.toHaveBeenCalled();
+      expect(harness.log.warn).toHaveBeenCalledWith(
+        "config reload requires gateway restart; hot mode ignoring (channels.whatsapp.enabled: enabled channel activation requires gateway restart)",
+      );
+    } finally {
+      resetPluginRuntimeStateForTest();
+      await harness.reloader.stop();
+    }
+  });
+
+  it("keeps enabled no-op channels parked when reload mode is off", async () => {
+    const whatsappPlugin: ChannelPlugin = {
+      id: "whatsapp",
+      meta: {
+        id: "whatsapp",
+        label: "WhatsApp",
+        selectionLabel: "WhatsApp",
+        docsPath: "/channels/whatsapp",
+        blurb: "test",
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => [],
+        resolveAccount: () => ({}),
+      },
+      reload: { configPrefixes: [], noopPrefixes: ["channels.whatsapp"] },
+    };
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "whatsapp", plugin: whatsappPlugin, source: "test" }]),
+    );
+    const previousConfig: OpenClawConfig = {
+      gateway: { reload: { debounceMs: 0, mode: "off" } },
+      channels: { whatsapp: { enabled: false } },
+    };
+    const nextConfig: OpenClawConfig = {
+      gateway: { reload: { debounceMs: 0, mode: "off" } },
+      channels: { whatsapp: { enabled: true } },
+    };
+    const readSnapshot = vi.fn<() => Promise<ConfigFileSnapshot>>().mockResolvedValueOnce(
+      makeSnapshot({
+        sourceConfig: nextConfig,
+        runtimeConfig: nextConfig,
+        config: nextConfig,
+        hash: "whatsapp-enable-off-1",
+      }),
+    );
+    const harness = createReloaderHarness(readSnapshot, { initialCompareConfig: previousConfig });
+
+    try {
+      harness.watcher.emit("change");
+      await vi.runOnlyPendingTimersAsync();
+
+      expect(harness.onHotReload).not.toHaveBeenCalled();
+      expect(harness.onRestart).not.toHaveBeenCalled();
+      expect(harness.log.info).toHaveBeenCalledWith(
+        "config reload disabled (gateway.reload.mode=off)",
+      );
+    } finally {
+      resetPluginRuntimeStateForTest();
+      await harness.reloader.stop();
+    }
+  });
+
   it("queues restart when an external plugin source write also changes plugin config", async () => {
     const previousConfig: OpenClawConfig = {
       gateway: { reload: { debounceMs: 0 } },

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -20,6 +20,7 @@ import {
 import { createTestRegistry } from "../test-utils/channel-plugins.js";
 import {
   buildGatewayReloadPlan,
+  diffConfigPathSegments,
   diffConfigPaths,
   type GatewayReloadPlan,
   listPluginInstallTimestampMetadataPaths,
@@ -122,6 +123,32 @@ describe("diffConfigPaths", () => {
       "plugins.installs.lossless.resolvedAt",
       "plugins.installs.lossless.resolvedAt",
     ]);
+  });
+
+  it("preserves path segment boundaries for dotted keys", () => {
+    const prev = {
+      channels: {
+        matrix: {
+          groups: {
+            "!room:example.org": { users: ["@old:example.org"] },
+          },
+        },
+      },
+    };
+    const next = {
+      channels: {
+        matrix: {
+          groups: {
+            "!room:example.org": { users: ["@new:example.org"] },
+          },
+        },
+      },
+    };
+
+    expect(diffConfigPathSegments(prev, next)).toEqual([
+      ["channels", "matrix", "groups", "!room:example.org", "users"],
+    ]);
+    expect(diffConfigPaths(prev, next)).toEqual(["channels.matrix.groups.!room:example.org.users"]);
   });
 });
 

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -1383,6 +1383,61 @@ describe("startGatewayConfigReloader", () => {
     }
   });
 
+  it("queues restart when disabling a no-op channel config", async () => {
+    const whatsappPlugin: ChannelPlugin = {
+      id: "whatsapp",
+      meta: {
+        id: "whatsapp",
+        label: "WhatsApp",
+        selectionLabel: "WhatsApp",
+        docsPath: "/channels/whatsapp",
+        blurb: "test",
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => [],
+        resolveAccount: () => ({}),
+      },
+      reload: { configPrefixes: [], noopPrefixes: ["channels.whatsapp"] },
+    };
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "whatsapp", plugin: whatsappPlugin, source: "test" }]),
+    );
+    const previousConfig: OpenClawConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      channels: { whatsapp: { enabled: true } },
+    };
+    const nextConfig: OpenClawConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      channels: { whatsapp: { enabled: false } },
+    };
+    const readSnapshot = vi.fn<() => Promise<ConfigFileSnapshot>>().mockResolvedValueOnce(
+      makeSnapshot({
+        sourceConfig: nextConfig,
+        runtimeConfig: nextConfig,
+        config: nextConfig,
+        hash: "whatsapp-disable-1",
+      }),
+    );
+    const harness = createReloaderHarness(readSnapshot, { initialCompareConfig: previousConfig });
+
+    try {
+      harness.watcher.emit("change");
+      await vi.runOnlyPendingTimersAsync();
+
+      expect(harness.onHotReload).not.toHaveBeenCalled();
+      const [plan, restartedConfig] = getOnlyRestartCall(harness);
+      expect(plan.restartReasons).toEqual([
+        "channels.whatsapp.enabled: enabled channel deactivation requires gateway restart",
+      ]);
+      expect(plan.noopPaths).toEqual([]);
+      expect(restartedConfig).toBe(nextConfig);
+    } finally {
+      resetPluginRuntimeStateForTest();
+      await harness.reloader.stop();
+    }
+  });
+
   it("queues restart when enabling a no-op channel account config from disabled", async () => {
     const whatsappPlugin: ChannelPlugin = {
       id: "whatsapp",
@@ -1429,6 +1484,61 @@ describe("startGatewayConfigReloader", () => {
       const [plan, restartedConfig] = getOnlyRestartCall(harness);
       expect(plan.restartReasons).toEqual([
         "channels.whatsapp.accounts.work.enabled: enabled channel account activation requires gateway restart",
+      ]);
+      expect(plan.noopPaths).toEqual([]);
+      expect(restartedConfig).toBe(nextConfig);
+    } finally {
+      resetPluginRuntimeStateForTest();
+      await harness.reloader.stop();
+    }
+  });
+
+  it("queues restart when removing an enabled no-op channel account config", async () => {
+    const whatsappPlugin: ChannelPlugin = {
+      id: "whatsapp",
+      meta: {
+        id: "whatsapp",
+        label: "WhatsApp",
+        selectionLabel: "WhatsApp",
+        docsPath: "/channels/whatsapp",
+        blurb: "test",
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: {
+        listAccountIds: () => [],
+        resolveAccount: () => ({}),
+      },
+      reload: { configPrefixes: [], noopPrefixes: ["channels.whatsapp"] },
+    };
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "whatsapp", plugin: whatsappPlugin, source: "test" }]),
+    );
+    const previousConfig: OpenClawConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      channels: { whatsapp: { accounts: { work: { enabled: true } } } },
+    };
+    const nextConfig: OpenClawConfig = {
+      gateway: { reload: { debounceMs: 0 } },
+      channels: { whatsapp: { accounts: {} } },
+    };
+    const readSnapshot = vi.fn<() => Promise<ConfigFileSnapshot>>().mockResolvedValueOnce(
+      makeSnapshot({
+        sourceConfig: nextConfig,
+        runtimeConfig: nextConfig,
+        config: nextConfig,
+        hash: "whatsapp-account-remove-1",
+      }),
+    );
+    const harness = createReloaderHarness(readSnapshot, { initialCompareConfig: previousConfig });
+
+    try {
+      harness.watcher.emit("change");
+      await vi.runOnlyPendingTimersAsync();
+
+      expect(harness.onHotReload).not.toHaveBeenCalled();
+      const [plan, restartedConfig] = getOnlyRestartCall(harness);
+      expect(plan.restartReasons).toEqual([
+        "channels.whatsapp.accounts.work: enabled channel account deactivation requires gateway restart",
       ]);
       expect(plan.noopPaths).toEqual([]);
       expect(restartedConfig).toBe(nextConfig);

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -11,6 +11,7 @@ import {
 } from "../plugins/installed-plugin-index-records.js";
 import { diffConfigPaths } from "./config-diff.js";
 import {
+  applyNoopEnabledChannelActivationRestarts,
   buildGatewayReloadPlan,
   listPluginInstallTimestampMetadataPaths,
   listPluginInstallWholeRecordPaths,
@@ -182,13 +183,14 @@ export function startGatewayConfigReloader(opts: {
     nextCompareConfig: OpenClawConfig,
     afterWrite?: ConfigWriteNotification["afterWrite"],
   ) => {
-    const configChangedPaths = diffConfigPaths(currentCompareConfig, nextCompareConfig);
+    const previousCompareConfig = currentCompareConfig;
+    const configChangedPaths = diffConfigPaths(previousCompareConfig, nextCompareConfig);
     const configPluginInstallTimestampNoopPaths = listPluginInstallTimestampMetadataPaths(
-      currentCompareConfig,
+      previousCompareConfig,
       nextCompareConfig,
     );
     const configPluginInstallWholeRecordPaths = listPluginInstallWholeRecordPaths(
-      currentCompareConfig,
+      previousCompareConfig,
       nextCompareConfig,
     );
     let nextPluginInstallRecords = currentPluginInstallRecords;
@@ -244,9 +246,14 @@ export function startGatewayConfigReloader(opts: {
       opts.log.info(`config reload skipped by writer intent (${followUp.reason})`);
       return;
     }
-    const plan = buildGatewayReloadPlan(changedPaths, {
-      noopPaths: pluginInstallTimestampNoopPaths,
-      forceChangedPaths: pluginInstallWholeRecordPaths,
+    const plan = applyNoopEnabledChannelActivationRestarts({
+      plan: buildGatewayReloadPlan(changedPaths, {
+        noopPaths: pluginInstallTimestampNoopPaths,
+        forceChangedPaths: pluginInstallWholeRecordPaths,
+      }),
+      previousConfig: previousCompareConfig,
+      nextConfig: nextCompareConfig,
+      changedPaths,
     });
     if (isNoopReloadPlan(plan) && !followUp.requiresRestart) {
       return;

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -9,7 +9,7 @@ import {
   loadInstalledPluginIndexInstallRecords,
   loadInstalledPluginIndexInstallRecordsSync,
 } from "../plugins/installed-plugin-index-records.js";
-import { diffConfigPaths } from "./config-diff.js";
+import { diffConfigPathSegments, diffConfigPaths } from "./config-diff.js";
 import {
   applyNoopEnabledChannelActivationRestarts,
   buildGatewayReloadPlan,
@@ -21,6 +21,7 @@ import { resolveGatewayReloadSettings } from "./config-reload-settings.js";
 
 export {
   buildGatewayReloadPlan,
+  diffConfigPathSegments,
   diffConfigPaths,
   listPluginInstallTimestampMetadataPaths,
   listPluginInstallWholeRecordPaths,

--- a/src/gateway/server-methods/agents-config-mutations.ts
+++ b/src/gateway/server-methods/agents-config-mutations.ts
@@ -93,6 +93,9 @@ export async function deleteAgentConfigEntry(params: { agentId: string }): Promi
 }> {
   const committed = await mutateConfigFileWithRetry<AgentDeleteMutationResult>({
     afterWrite: { mode: "auto" },
+    writeOptions: {
+      explicitSetPaths: [["agents", "list", params.agentId]],
+    },
     mutate: (draft) => {
       if (!isConfiguredAgent(draft, params.agentId)) {
         throw new AgentConfigPreconditionError("not-found", params.agentId);

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -70,6 +70,7 @@ vi.mock("../../config/config.js", async () => {
       await mocks.writeConfigFile(params.nextConfig),
     mutateConfigFileWithRetry: async (params: {
       mutate: (draft: Record<string, unknown>, context: unknown) => unknown;
+      writeOptions?: unknown;
     }) => {
       const draft = structuredClone(mocks.loadConfigReturn);
       const result = await params.mutate(draft, {
@@ -77,7 +78,7 @@ vi.mock("../../config/config.js", async () => {
         previousHash: "test-hash",
         attempt: 0,
       });
-      await mocks.writeConfigFile(draft);
+      await mocks.writeConfigFile(draft, params.writeOptions);
       return {
         path: "/tmp/openclaw/config.json",
         previousHash: "test-hash",
@@ -1127,6 +1128,12 @@ describe("agents.delete", () => {
       undefined,
     );
     expect(mocks.writeConfigFile).toHaveBeenCalled();
+    expect(mocks.writeConfigFile).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        explicitSetPaths: [["agents", "list", "test-agent"]],
+      }),
+    );
     // moveToTrashBestEffort calls fs.access then movePathToTrash for each dir
     expect(mocks.movePathToTrash).toHaveBeenCalled();
   });

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -10,7 +10,7 @@ const mocks = vi.hoisted(() => ({
   findAgentEntryIndex: vi.fn((_list?: unknown, _agentId?: string) => -1),
   applyAgentConfig: vi.fn((_cfg: unknown, _opts: unknown) => ({})),
   pruneAgentConfig: vi.fn(() => ({ config: {}, removedBindings: 0 })),
-  writeConfigFile: vi.fn(async (_nextConfig?: unknown) => {}),
+  writeConfigFile: vi.fn(async (_nextConfig?: unknown, _options?: unknown) => {}),
   ensureAgentWorkspace: vi.fn(
     async (params?: { dir?: string }): Promise<{ dir: string; identityPathCreated: boolean }> => ({
       dir: params?.dir

--- a/src/gateway/server-methods/channels.start.test.ts
+++ b/src/gateway/server-methods/channels.start.test.ts
@@ -7,6 +7,8 @@ const mocks = vi.hoisted(() => ({
   readConfigFileSnapshot: vi.fn(),
   applyPluginAutoEnable: vi.fn(),
   getChannelPlugin: vi.fn(),
+  normalizeChannelId: vi.fn<(value: string) => string | null>((value: string) => value),
+  normalizeChatChannelId: vi.fn<(value: string) => string | null>(() => null),
 }));
 
 vi.mock("../../config/config.js", () => ({
@@ -21,7 +23,12 @@ vi.mock("../../config/plugin-auto-enable.js", () => ({
 vi.mock("../../channels/plugins/index.js", () => ({
   listChannelPlugins: vi.fn(),
   getChannelPlugin: mocks.getChannelPlugin,
-  normalizeChannelId: (value: string) => value,
+  normalizeChannelId: mocks.normalizeChannelId,
+}));
+
+vi.mock("../../channels/ids.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../channels/ids.js")>()),
+  normalizeChatChannelId: mocks.normalizeChatChannelId,
 }));
 
 import { channelsHandlers } from "./channels.js";
@@ -67,8 +74,10 @@ function createOptions(
 describe("channelsHandlers channels.start", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.getRuntimeConfig.mockReturnValue({});
+    mocks.getRuntimeConfig.mockReturnValue({ channels: { whatsapp: {} } });
     mocks.applyPluginAutoEnable.mockImplementation(({ config }) => ({ config, changes: [] }));
+    mocks.normalizeChannelId.mockImplementation((value: string) => value);
+    mocks.normalizeChatChannelId.mockImplementation(() => null);
     mocks.getChannelPlugin.mockReturnValue({
       id: "whatsapp",
       gateway: { startAccount: vi.fn() },
@@ -78,6 +87,101 @@ describe("channelsHandlers channels.start", () => {
         resolveAccount: () => ({}),
       },
     });
+  });
+
+  it("reports missing channel config before trying to start the runtime", async () => {
+    const startChannel = vi.fn();
+    const respond = vi.fn();
+    mocks.getRuntimeConfig.mockReturnValue({ channels: {} });
+
+    await channelsHandlers["channels.start"](
+      createOptions(
+        { channel: "whatsapp" },
+        {
+          respond,
+          context: {
+            getRuntimeConfig: mocks.getRuntimeConfig,
+            startChannel,
+            getRuntimeSnapshot: vi.fn(
+              (): ChannelRuntimeSnapshot => ({ channels: {}, channelAccounts: {} }),
+            ),
+          } as unknown as GatewayRequestHandlerOptions["context"],
+        },
+      ),
+    );
+
+    expect(startChannel).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "INVALID_REQUEST",
+        message:
+          "Channel whatsapp is not configured. Add channels.whatsapp to your config before starting it.",
+      }),
+    );
+  });
+
+  it("rejects auto-enabled channel config that is missing from the runtime config", async () => {
+    const startChannel = vi.fn();
+    const respond = vi.fn();
+    mocks.getRuntimeConfig.mockReturnValue({});
+    mocks.applyPluginAutoEnable.mockReturnValue({
+      config: { channels: { whatsapp: {} } },
+      changes: ["whatsapp"],
+    });
+
+    await channelsHandlers["channels.start"](
+      createOptions(
+        { channel: "whatsapp" },
+        {
+          respond,
+          context: {
+            getRuntimeConfig: mocks.getRuntimeConfig,
+            startChannel,
+            getRuntimeSnapshot: vi.fn(
+              (): ChannelRuntimeSnapshot => ({ channels: {}, channelAccounts: {} }),
+            ),
+          } as unknown as GatewayRequestHandlerOptions["context"],
+        },
+      ),
+    );
+
+    expect(mocks.applyPluginAutoEnable).toHaveBeenCalledWith({
+      config: {},
+      env: process.env,
+    });
+    expect(startChannel).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "INVALID_REQUEST",
+        message:
+          "Channel whatsapp is not configured. Add channels.whatsapp to your config before starting it.",
+      }),
+    );
+  });
+
+  it("uses the bundled channel catalog fallback when registry normalization misses", async () => {
+    const respond = vi.fn();
+    mocks.normalizeChannelId.mockReturnValueOnce(null);
+    mocks.normalizeChatChannelId.mockReturnValueOnce("whatsapp");
+    mocks.getChannelPlugin.mockReturnValueOnce(undefined);
+    mocks.getRuntimeConfig.mockReturnValue({ channels: {} });
+
+    await channelsHandlers["channels.start"](createOptions({ channel: "whatsapp" }, { respond }));
+
+    expect(mocks.getChannelPlugin).toHaveBeenCalledWith("whatsapp");
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "INVALID_REQUEST",
+        message:
+          "Channel whatsapp is not configured. Add channels.whatsapp to your config before starting it.",
+      }),
+    );
   });
 
   it("resolves the default account and starts the channel runtime", async () => {
@@ -116,7 +220,7 @@ describe("channelsHandlers channels.start", () => {
     );
 
     expect(mocks.applyPluginAutoEnable).toHaveBeenCalledWith({
-      config: {},
+      config: { channels: { whatsapp: {} } },
       env: process.env,
     });
     expect(startChannel).toHaveBeenCalledWith("whatsapp", "default-account");

--- a/src/gateway/server-methods/channels.start.test.ts
+++ b/src/gateway/server-methods/channels.start.test.ts
@@ -163,7 +163,7 @@ describe("channelsHandlers channels.start", () => {
     );
   });
 
-  it("uses the bundled channel catalog fallback when registry normalization misses", async () => {
+  it("reports unknown channel before suggesting config for an unloaded plugin", async () => {
     const respond = vi.fn();
     mocks.normalizeChannelId.mockReturnValueOnce(null);
     mocks.normalizeChatChannelId.mockReturnValueOnce("whatsapp");
@@ -178,8 +178,7 @@ describe("channelsHandlers channels.start", () => {
       undefined,
       expect.objectContaining({
         code: "INVALID_REQUEST",
-        message:
-          "Channel whatsapp is not configured. Add channels.whatsapp to your config before starting it.",
+        message: "unknown channel: whatsapp",
       }),
     );
   });

--- a/src/gateway/server-methods/channels.ts
+++ b/src/gateway/server-methods/channels.ts
@@ -1,3 +1,5 @@
+import { resolveChannelConfigBlockError } from "../../channels/config-block.js";
+import { normalizeChatChannelId } from "../../channels/ids.js";
 import { buildChannelUiCatalog } from "../../channels/plugins/catalog.js";
 import { resolveChannelDefaultAccountId } from "../../channels/plugins/helpers.js";
 import {
@@ -552,7 +554,10 @@ export const channelsHandlers: GatewayRequestHandlers = {
       return;
     }
     const rawChannel = (params as { channel?: unknown }).channel;
-    const channelId = typeof rawChannel === "string" ? normalizeChannelId(rawChannel) : null;
+    const channelId =
+      typeof rawChannel === "string"
+        ? (normalizeChannelId(rawChannel) ?? normalizeChatChannelId(rawChannel))
+        : null;
     if (!channelId) {
       respond(
         false,
@@ -561,13 +566,30 @@ export const channelsHandlers: GatewayRequestHandlers = {
       );
       return;
     }
+    const runtimeConfig = context.getRuntimeConfig();
+    const configBlockError = resolveChannelConfigBlockError({
+      cfg: runtimeConfig,
+      channelId,
+      action: "starting it",
+    });
+    const cfg = applyPluginAutoEnable({
+      config: runtimeConfig,
+      env: process.env,
+    }).config;
     const plugin = getChannelPlugin(channelId);
     if (!plugin) {
       respond(
         false,
         undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, `unknown channel: ${formatForLog(rawChannel)}`),
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          configBlockError ?? `unknown channel: ${formatForLog(rawChannel)}`,
+        ),
       );
+      return;
+    }
+    if (configBlockError) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, configBlockError));
       return;
     }
     if (!plugin.gateway?.startAccount) {
@@ -579,10 +601,6 @@ export const channelsHandlers: GatewayRequestHandlers = {
       return;
     }
     try {
-      const cfg = applyPluginAutoEnable({
-        config: context.getRuntimeConfig(),
-        env: process.env,
-      }).config;
       const payload = await startChannelAccount({
         channelId,
         accountId: (params as { accountId?: string | null }).accountId,

--- a/src/gateway/server-methods/channels.ts
+++ b/src/gateway/server-methods/channels.ts
@@ -567,11 +567,6 @@ export const channelsHandlers: GatewayRequestHandlers = {
       return;
     }
     const runtimeConfig = context.getRuntimeConfig();
-    const configBlockError = resolveChannelConfigBlockError({
-      cfg: runtimeConfig,
-      channelId,
-      action: "starting it",
-    });
     const cfg = applyPluginAutoEnable({
       config: runtimeConfig,
       env: process.env,
@@ -581,13 +576,15 @@ export const channelsHandlers: GatewayRequestHandlers = {
       respond(
         false,
         undefined,
-        errorShape(
-          ErrorCodes.INVALID_REQUEST,
-          configBlockError ?? `unknown channel: ${formatForLog(rawChannel)}`,
-        ),
+        errorShape(ErrorCodes.INVALID_REQUEST, `unknown channel: ${formatForLog(rawChannel)}`),
       );
       return;
     }
+    const configBlockError = resolveChannelConfigBlockError({
+      cfg: runtimeConfig,
+      channelId,
+      action: "starting it",
+    });
     if (configBlockError) {
       respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, configBlockError));
       return;

--- a/src/gateway/server-methods/config-write-flow.ts
+++ b/src/gateway/server-methods/config-write-flow.ts
@@ -14,7 +14,10 @@ import {
 import { scheduleGatewaySigusr1Restart } from "../../infra/restart.js";
 import { getActiveSecretsRuntimeSnapshot } from "../../secrets/runtime-state.js";
 import { resolveEffectiveSharedGatewayAuth, resolveGatewayAuth } from "../auth.js";
-import { buildGatewayReloadPlan } from "../config-reload-plan.js";
+import {
+  applyNoopEnabledChannelActivationRestarts,
+  buildGatewayReloadPlan,
+} from "../config-reload-plan.js";
 import { resolveGatewayReloadSettings } from "../config-reload-settings.js";
 import { formatControlPlaneActor, type ControlPlaneActor } from "../control-plane-audit.js";
 import { parseRestartRequestParams } from "./restart-request.js";
@@ -129,13 +132,19 @@ function queueSharedGatewayAuthGenerationRefresh(
 
 function shouldScheduleDirectConfigRestart(params: {
   changedPaths: string[];
+  previousConfig: OpenClawConfig;
   nextConfig: OpenClawConfig;
 }): boolean {
   const reloadSettings = resolveGatewayReloadSettings(params.nextConfig);
   if (reloadSettings.mode === "off") {
     return true;
   }
-  const plan = buildGatewayReloadPlan(params.changedPaths);
+  const plan = applyNoopEnabledChannelActivationRestarts({
+    plan: buildGatewayReloadPlan(params.changedPaths),
+    previousConfig: params.previousConfig,
+    nextConfig: params.nextConfig,
+    changedPaths: params.changedPaths,
+  });
   if (reloadSettings.mode === "hot" && plan.restartGateway) {
     return true;
   }
@@ -234,6 +243,7 @@ export async function resolveGatewayConfigRestartWriteResult(params: {
   mode: "config.patch" | "config.apply";
   configPath: string;
   changedPaths: string[];
+  previousConfig: OpenClawConfig;
   nextConfig: OpenClawConfig;
   actor: ControlPlaneActor;
   context?: GatewayRequestContext;
@@ -256,6 +266,7 @@ export async function resolveGatewayConfigRestartWriteResult(params: {
   const sentinelPath = await tryWriteRestartSentinelPayload(payload);
   const restart = shouldScheduleDirectConfigRestart({
     changedPaths: params.changedPaths,
+    previousConfig: params.previousConfig,
     nextConfig: params.nextConfig,
   })
     ? scheduleGatewaySigusr1Restart({

--- a/src/gateway/server-methods/config.shared-auth.test.ts
+++ b/src/gateway/server-methods/config.shared-auth.test.ts
@@ -214,11 +214,11 @@ describe("config shared auth disconnects", () => {
       },
       tools: {
         elevated: {
-          allowFrom: ["webchat:admin"],
+          allowFrom: { webchat: ["admin"] },
         },
       },
       agents: {
-        list: [{ id: "ops", directory: "/tmp/ops" }],
+        list: [{ id: "ops", workspace: "/tmp/ops" }],
       },
       channels: {
         whatsapp: {

--- a/src/gateway/server-methods/config.shared-auth.test.ts
+++ b/src/gateway/server-methods/config.shared-auth.test.ts
@@ -175,6 +175,79 @@ describe("config shared auth disconnects", () => {
     expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
   });
 
+  it("marks protected config.patch edits as explicit control-plane writes", async () => {
+    const prevConfig: OpenClawConfig = {
+      commands: {
+        ownerAllowFrom: ["webchat:old"],
+      },
+    };
+    const nextConfig: OpenClawConfig = {
+      commands: {
+        ownerAllowFrom: ["webchat:new"],
+      },
+    };
+    readConfigFileSnapshotForWriteMock.mockResolvedValue(createConfigWriteSnapshot(prevConfig));
+
+    const { options } = createConfigHandlerHarness({
+      method: "config.patch",
+      params: {
+        baseHash: "base-hash",
+        raw: JSON.stringify({ commands: { ownerAllowFrom: ["webchat:new"] } }),
+      },
+    });
+
+    await configHandlers["config.patch"](options);
+    await flushConfigHandlerMicrotasks();
+
+    expect(writeConfigFileMock).toHaveBeenCalledWith(
+      nextConfig,
+      expect.objectContaining({
+        explicitSetPaths: [["commands", "ownerAllowFrom"]],
+      }),
+    );
+  });
+
+  it("marks protected parent removals as explicit control-plane writes", async () => {
+    const prevConfig: OpenClawConfig = {
+      commands: {
+        ownerAllowFrom: ["webchat:owner"],
+      },
+      tools: {
+        elevated: {
+          allowFrom: ["webchat:admin"],
+        },
+      },
+      agents: {
+        list: [{ id: "ops", directory: "/tmp/ops" }],
+      },
+      channels: {
+        whatsapp: {
+          enabled: true,
+        },
+      },
+    };
+    const nextConfig: OpenClawConfig = {};
+    readConfigFileSnapshotForWriteMock.mockResolvedValue(createConfigWriteSnapshot(prevConfig));
+
+    const { options } = createConfigHandlerHarness({
+      method: "config.set",
+      params: {
+        raw: JSON.stringify(nextConfig),
+        baseHash: "base-hash",
+      },
+    });
+
+    await configHandlers["config.set"](options);
+    await flushConfigHandlerMicrotasks();
+
+    expect(writeConfigFileMock).toHaveBeenCalledWith(
+      nextConfig,
+      expect.objectContaining({
+        explicitSetPaths: [["commands"], ["tools"], ["agents"], ["channels"]],
+      }),
+    );
+  });
+
   it("lets the config reloader own hybrid-mode auth restarts", async () => {
     const prevConfig: OpenClawConfig = {
       gateway: {
@@ -368,6 +441,49 @@ describe("config shared auth disconnects", () => {
     await configHandlers["config.patch"](options);
     await flushConfigHandlerMicrotasks();
 
+    expect(scheduleGatewaySigusr1RestartMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("schedules a direct hot-mode restart when config.patch enables an unloaded channel", async () => {
+    const prevConfig: OpenClawConfig = {
+      gateway: {
+        reload: {
+          mode: "hot",
+        },
+      },
+      channels: {},
+    };
+    readConfigFileSnapshotForWriteMock.mockResolvedValue(createConfigWriteSnapshot(prevConfig));
+
+    const { options } = createConfigHandlerHarness({
+      method: "config.patch",
+      params: {
+        baseHash: "base-hash",
+        raw: JSON.stringify({ channels: { whatsapp: { enabled: true } } }),
+        restartDelayMs: 1_000,
+      },
+    });
+
+    await configHandlers["config.patch"](options);
+    await flushConfigHandlerMicrotasks();
+
+    expect(writeConfigFileMock).toHaveBeenCalledWith(
+      {
+        gateway: {
+          reload: {
+            mode: "hot",
+          },
+        },
+        channels: {
+          whatsapp: {
+            enabled: true,
+          },
+        },
+      },
+      expect.objectContaining({
+        explicitSetPaths: [["channels", "whatsapp"]],
+      }),
+    );
     expect(scheduleGatewaySigusr1RestartMock).toHaveBeenCalledTimes(1);
   });
 

--- a/src/gateway/server-methods/config.shared-auth.test.ts
+++ b/src/gateway/server-methods/config.shared-auth.test.ts
@@ -207,6 +207,54 @@ describe("config shared auth disconnects", () => {
     );
   });
 
+  it("preserves dotted channel policy keys when marking explicit writes", async () => {
+    const prevConfig: OpenClawConfig = {
+      channels: {
+        matrix: {
+          groups: {
+            "!room:example.org": { users: ["@old:example.org"] },
+          },
+        },
+      },
+    };
+    const nextConfig: OpenClawConfig = {
+      channels: {
+        matrix: {
+          groups: {
+            "!room:example.org": { users: ["@new:example.org"] },
+          },
+        },
+      },
+    };
+    readConfigFileSnapshotForWriteMock.mockResolvedValue(createConfigWriteSnapshot(prevConfig));
+
+    const { options } = createConfigHandlerHarness({
+      method: "config.patch",
+      params: {
+        baseHash: "base-hash",
+        raw: JSON.stringify({
+          channels: {
+            matrix: {
+              groups: {
+                "!room:example.org": { users: ["@new:example.org"] },
+              },
+            },
+          },
+        }),
+      },
+    });
+
+    await configHandlers["config.patch"](options);
+    await flushConfigHandlerMicrotasks();
+
+    expect(writeConfigFileMock).toHaveBeenCalledWith(
+      nextConfig,
+      expect.objectContaining({
+        explicitSetPaths: [["channels", "matrix", "groups", "!room:example.org", "users"]],
+      }),
+    );
+  });
+
   it("marks protected parent removals as explicit control-plane writes", async () => {
     const prevConfig: OpenClawConfig = {
       commands: {

--- a/src/gateway/server-methods/config.shared-auth.test.ts
+++ b/src/gateway/server-methods/config.shared-auth.test.ts
@@ -203,6 +203,58 @@ describe("config shared auth disconnects", () => {
       nextConfig,
       expect.objectContaining({
         explicitSetPaths: [["commands", "ownerAllowFrom"]],
+        explicitProtectedConfigPolicyPaths: [["commands", "ownerAllowFrom"]],
+      }),
+    );
+  });
+
+  it("keeps protected control-plane exemptions at exact leaf paths", async () => {
+    const prevConfig: OpenClawConfig = {
+      tools: {
+        elevated: {
+          allowFrom: {
+            webchat: ["session:old"],
+            telegram: ["telegram:unchanged"],
+          },
+        },
+      },
+    };
+    const nextConfig: OpenClawConfig = {
+      tools: {
+        elevated: {
+          allowFrom: {
+            webchat: ["session:new"],
+            telegram: ["telegram:unchanged"],
+          },
+        },
+      },
+    };
+    readConfigFileSnapshotForWriteMock.mockResolvedValue(createConfigWriteSnapshot(prevConfig));
+
+    const { options } = createConfigHandlerHarness({
+      method: "config.patch",
+      params: {
+        baseHash: "base-hash",
+        raw: JSON.stringify({
+          tools: {
+            elevated: {
+              allowFrom: {
+                webchat: ["session:new"],
+              },
+            },
+          },
+        }),
+      },
+    });
+
+    await configHandlers["config.patch"](options);
+    await flushConfigHandlerMicrotasks();
+
+    expect(writeConfigFileMock).toHaveBeenCalledWith(
+      nextConfig,
+      expect.objectContaining({
+        explicitSetPaths: [["tools", "elevated", "allowFrom", "webchat"]],
+        explicitProtectedConfigPolicyPaths: [["tools", "elevated", "allowFrom", "webchat"]],
       }),
     );
   });
@@ -251,6 +303,9 @@ describe("config shared auth disconnects", () => {
       nextConfig,
       expect.objectContaining({
         explicitSetPaths: [["channels", "matrix", "groups", "!room:example.org", "users"]],
+        explicitProtectedConfigPolicyPaths: [
+          ["channels", "matrix", "groups", "!room:example.org", "users"],
+        ],
       }),
     );
   });
@@ -292,6 +347,12 @@ describe("config shared auth disconnects", () => {
       nextConfig,
       expect.objectContaining({
         explicitSetPaths: [["commands"], ["tools"], ["agents"], ["channels"]],
+        explicitProtectedConfigPolicyPaths: [
+          ["commands"],
+          ["tools"],
+          ["agents"],
+          ["channels"],
+        ],
       }),
     );
   });
@@ -530,6 +591,7 @@ describe("config shared auth disconnects", () => {
       },
       expect.objectContaining({
         explicitSetPaths: [["channels", "whatsapp"]],
+        explicitProtectedConfigPolicyPaths: [["channels", "whatsapp"]],
       }),
     );
     expect(scheduleGatewaySigusr1RestartMock).toHaveBeenCalledTimes(1);

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -59,6 +59,43 @@ let configSchemaResponseCache: {
   response: ConfigSchemaResponse;
 } | null = null;
 
+const PROTECTED_CONTROL_PLANE_CONFIG_PATHS = [
+  "commands.ownerAllowFrom",
+  "commands.allowFrom",
+  "tools.elevated.allowFrom",
+  "agents.list",
+  "channels",
+] as const;
+
+function isProtectedControlPlaneConfigPath(path: string): boolean {
+  return PROTECTED_CONTROL_PLANE_CONFIG_PATHS.some(
+    (protectedPath) =>
+      path === protectedPath ||
+      path.startsWith(`${protectedPath}.`) ||
+      protectedPath.startsWith(`${path}.`),
+  );
+}
+
+function splitConfigPath(path: string): string[] {
+  return path === "<root>" ? [] : path.split(".");
+}
+
+function withExplicitProtectedControlPlanePaths(
+  writeOptions: Awaited<ReturnType<typeof readConfigFileSnapshotForWrite>>["writeOptions"],
+  changedPaths: readonly string[],
+): Awaited<ReturnType<typeof readConfigFileSnapshotForWrite>>["writeOptions"] {
+  const explicitSetPaths = changedPaths
+    .filter(isProtectedControlPlaneConfigPath)
+    .map(splitConfigPath);
+  if (explicitSetPaths.length === 0) {
+    return writeOptions;
+  }
+  return {
+    ...writeOptions,
+    explicitSetPaths: [...(writeOptions.explicitSetPaths ?? []), ...explicitSetPaths],
+  };
+}
+
 type ConfigOpenCommand = {
   command: string;
   args: string[];
@@ -353,9 +390,10 @@ export const configHandlers: GatewayRequestHandlers = {
     if (!(await ensureResolvableSecretRefsOrRespond({ config: parsed.config, respond }))) {
       return;
     }
+    const changedPaths = diffConfigPaths(snapshot.config, parsed.config);
     const writeResult = await commitGatewayConfigWrite({
       snapshot,
-      writeOptions,
+      writeOptions: withExplicitProtectedControlPlanePaths(writeOptions, changedPaths),
       nextConfig: parsed.config,
       context,
     });
@@ -487,7 +525,7 @@ export const configHandlers: GatewayRequestHandlers = {
       });
     const writeResult = await commitGatewayConfigWrite({
       snapshot,
-      writeOptions,
+      writeOptions: withExplicitProtectedControlPlanePaths(writeOptions, changedPaths),
       nextConfig: validated.config,
       context,
       disconnectSharedAuthClients,
@@ -500,6 +538,7 @@ export const configHandlers: GatewayRequestHandlers = {
       mode: "config.patch",
       configPath: writeResult.path,
       changedPaths,
+      previousConfig: snapshot.config,
       nextConfig: writeResult.config,
       actor,
       context,
@@ -554,7 +593,7 @@ export const configHandlers: GatewayRequestHandlers = {
       });
     const writeResult = await commitGatewayConfigWrite({
       snapshot,
-      writeOptions,
+      writeOptions: withExplicitProtectedControlPlanePaths(writeOptions, changedPaths),
       nextConfig: parsed.config,
       context,
       disconnectSharedAuthClients,
@@ -567,6 +606,7 @@ export const configHandlers: GatewayRequestHandlers = {
       mode: "config.apply",
       configPath: writeResult.path,
       changedPaths,
+      previousConfig: snapshot.config,
       nextConfig: writeResult.config,
       actor,
       context,

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -14,6 +14,7 @@ import {
   redactConfigSnapshot,
   restoreRedactedValues,
 } from "../../config/redact-snapshot.js";
+import { resolveProtectedConfigPolicyPath } from "../../config/protected-policy.js";
 import { loadGatewayRuntimeConfigSchema } from "../../config/runtime-schema.js";
 import { lookupConfigSchema, type ConfigSchemaResponse } from "../../config/schema.js";
 import type { ConfigValidationIssue, OpenClawConfig } from "../../config/types.openclaw.js";
@@ -59,41 +60,35 @@ let configSchemaResponseCache: {
   response: ConfigSchemaResponse;
 } | null = null;
 
-const PROTECTED_CONTROL_PLANE_CONFIG_PATHS = [
-  ["commands", "ownerAllowFrom"],
-  ["commands", "allowFrom"],
-  ["tools", "elevated", "allowFrom"],
-  ["agents", "list"],
-  ["channels"],
-] as const;
-
-function startsWithConfigPath(path: readonly string[], prefix: readonly string[]): boolean {
-  return prefix.every((segment, index) => path[index] === segment);
-}
-
-function isProtectedControlPlaneConfigPath(path: readonly string[]): boolean {
-  return PROTECTED_CONTROL_PLANE_CONFIG_PATHS.some(
-    (protectedPath) =>
-      startsWithConfigPath(path, protectedPath) || startsWithConfigPath(protectedPath, path),
-  );
-}
-
 function withExplicitProtectedControlPlanePaths(
   writeOptions: Awaited<ReturnType<typeof readConfigFileSnapshotForWrite>>["writeOptions"],
   changedPaths: readonly (readonly string[])[],
 ): Awaited<ReturnType<typeof readConfigFileSnapshotForWrite>>["writeOptions"] {
-  const explicitSetPaths: string[][] = [];
+  const exactSetPaths: string[][] = [];
+  const explicitProtectedConfigPolicyPaths: string[][] = [];
+  const seenExact = new Set<string>();
   for (const path of changedPaths) {
-    if (isProtectedControlPlaneConfigPath(path)) {
-      explicitSetPaths.push([...path]);
+    const protectedPath = resolveProtectedConfigPolicyPath(path);
+    if (!protectedPath) {
+      continue;
+    }
+    const exactKey = path.join("\u0000");
+    if (!seenExact.has(exactKey)) {
+      seenExact.add(exactKey);
+      exactSetPaths.push([...path]);
+      explicitProtectedConfigPolicyPaths.push([...path]);
     }
   }
-  if (explicitSetPaths.length === 0) {
+  if (explicitProtectedConfigPolicyPaths.length === 0) {
     return writeOptions;
   }
   return {
     ...writeOptions,
-    explicitSetPaths: [...(writeOptions.explicitSetPaths ?? []), ...explicitSetPaths],
+    explicitSetPaths: [...(writeOptions.explicitSetPaths ?? []), ...exactSetPaths],
+    explicitProtectedConfigPolicyPaths: [
+      ...(writeOptions.explicitProtectedConfigPolicyPaths ?? []),
+      ...explicitProtectedConfigPolicyPaths,
+    ],
   };
 }
 

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -22,7 +22,7 @@ import {
   prepareSecretsRuntimeSnapshot,
   type PreparedSecretsRuntimeSnapshot,
 } from "../../secrets/runtime.js";
-import { diffConfigPaths } from "../config-diff.js";
+import { diffConfigPathSegments, diffConfigPaths } from "../config-diff.js";
 import {
   formatControlPlaneActor,
   resolveControlPlaneActor,
@@ -60,33 +60,31 @@ let configSchemaResponseCache: {
 } | null = null;
 
 const PROTECTED_CONTROL_PLANE_CONFIG_PATHS = [
-  "commands.ownerAllowFrom",
-  "commands.allowFrom",
-  "tools.elevated.allowFrom",
-  "agents.list",
-  "channels",
+  ["commands", "ownerAllowFrom"],
+  ["commands", "allowFrom"],
+  ["tools", "elevated", "allowFrom"],
+  ["agents", "list"],
+  ["channels"],
 ] as const;
 
-function isProtectedControlPlaneConfigPath(path: string): boolean {
-  return PROTECTED_CONTROL_PLANE_CONFIG_PATHS.some(
-    (protectedPath) =>
-      path === protectedPath ||
-      path.startsWith(`${protectedPath}.`) ||
-      protectedPath.startsWith(`${path}.`),
-  );
+function startsWithConfigPath(path: readonly string[], prefix: readonly string[]): boolean {
+  return prefix.every((segment, index) => path[index] === segment);
 }
 
-function splitConfigPath(path: string): string[] {
-  return path === "<root>" ? [] : path.split(".");
+function isProtectedControlPlaneConfigPath(path: readonly string[]): boolean {
+  return PROTECTED_CONTROL_PLANE_CONFIG_PATHS.some(
+    (protectedPath) =>
+      startsWithConfigPath(path, protectedPath) || startsWithConfigPath(protectedPath, path),
+  );
 }
 
 function withExplicitProtectedControlPlanePaths(
   writeOptions: Awaited<ReturnType<typeof readConfigFileSnapshotForWrite>>["writeOptions"],
-  changedPaths: readonly string[],
+  changedPaths: readonly (readonly string[])[],
 ): Awaited<ReturnType<typeof readConfigFileSnapshotForWrite>>["writeOptions"] {
   const explicitSetPaths = changedPaths
     .filter(isProtectedControlPlaneConfigPath)
-    .map(splitConfigPath);
+    .map((path) => [...path]);
   if (explicitSetPaths.length === 0) {
     return writeOptions;
   }
@@ -390,10 +388,10 @@ export const configHandlers: GatewayRequestHandlers = {
     if (!(await ensureResolvableSecretRefsOrRespond({ config: parsed.config, respond }))) {
       return;
     }
-    const changedPaths = diffConfigPaths(snapshot.config, parsed.config);
+    const changedPathSegments = diffConfigPathSegments(snapshot.config, parsed.config);
     const writeResult = await commitGatewayConfigWrite({
       snapshot,
-      writeOptions: withExplicitProtectedControlPlanePaths(writeOptions, changedPaths),
+      writeOptions: withExplicitProtectedControlPlanePaths(writeOptions, changedPathSegments),
       nextConfig: parsed.config,
       context,
     });
@@ -489,6 +487,7 @@ export const configHandlers: GatewayRequestHandlers = {
       return;
     }
     const changedPaths = diffConfigPaths(snapshot.config, validated.config);
+    const changedPathSegments = diffConfigPathSegments(snapshot.config, validated.config);
     const actor = resolveControlPlaneActor(client);
 
     // No-op: if the validated config is identical to the current config,
@@ -525,7 +524,7 @@ export const configHandlers: GatewayRequestHandlers = {
       });
     const writeResult = await commitGatewayConfigWrite({
       snapshot,
-      writeOptions: withExplicitProtectedControlPlanePaths(writeOptions, changedPaths),
+      writeOptions: withExplicitProtectedControlPlanePaths(writeOptions, changedPathSegments),
       nextConfig: validated.config,
       context,
       disconnectSharedAuthClients,
@@ -579,6 +578,7 @@ export const configHandlers: GatewayRequestHandlers = {
       return;
     }
     const changedPaths = diffConfigPaths(snapshot.config, parsed.config);
+    const changedPathSegments = diffConfigPathSegments(snapshot.config, parsed.config);
     const actor = resolveControlPlaneActor(client);
     context?.logGateway?.info(
       `config.apply write ${formatControlPlaneActor(actor)} changedPaths=${summarizeChangedPaths(changedPaths)} restartReason=config.apply`,
@@ -593,7 +593,7 @@ export const configHandlers: GatewayRequestHandlers = {
       });
     const writeResult = await commitGatewayConfigWrite({
       snapshot,
-      writeOptions: withExplicitProtectedControlPlanePaths(writeOptions, changedPaths),
+      writeOptions: withExplicitProtectedControlPlanePaths(writeOptions, changedPathSegments),
       nextConfig: parsed.config,
       context,
       disconnectSharedAuthClients,

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -82,9 +82,12 @@ function withExplicitProtectedControlPlanePaths(
   writeOptions: Awaited<ReturnType<typeof readConfigFileSnapshotForWrite>>["writeOptions"],
   changedPaths: readonly (readonly string[])[],
 ): Awaited<ReturnType<typeof readConfigFileSnapshotForWrite>>["writeOptions"] {
-  const explicitSetPaths = changedPaths
-    .filter(isProtectedControlPlaneConfigPath)
-    .map((path) => [...path]);
+  const explicitSetPaths: string[][] = [];
+  for (const path of changedPaths) {
+    if (isProtectedControlPlaneConfigPath(path)) {
+      explicitSetPaths.push([...path]);
+    }
+  }
   if (explicitSetPaths.length === 0) {
     return writeOptions;
   }

--- a/src/plugins/runtime/types-core.ts
+++ b/src/plugins/runtime/types-core.ts
@@ -25,6 +25,7 @@ type RuntimeWriteConfigOptions = {
   envSnapshotForRestore?: Record<string, string | undefined>;
   expectedConfigPath?: string;
   unsetPaths?: string[][];
+  explicitSetPaths?: readonly (readonly string[])[];
 };
 
 export type DeepReadonly<T> = T extends (...args: never[]) => unknown

--- a/src/security/fix.test.ts
+++ b/src/security/fix.test.ts
@@ -209,6 +209,46 @@ describe("security fix", () => {
     expect(accounts.a1.groupAllowFrom).toEqual(["+15550001111"]);
   });
 
+  it("persists WhatsApp allowlist repairs through the protected config guard", async () => {
+    const stateDir = await createStateDir("protected-policy-repair");
+    const configPath = path.join(stateDir, "openclaw.json");
+    await fs.writeFile(
+      configPath,
+      `${JSON.stringify(
+        {
+          meta: { lastTouchedVersion: "2026.5.17" },
+          gateway: { mode: "local" },
+          channels: {
+            whatsapp: {
+              groupPolicy: "allowlist",
+              accounts: {
+                work: { groupPolicy: "allowlist" },
+              },
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf-8",
+    );
+
+    const res = await fixSecurityFootguns({
+      env: createFixEnv(stateDir, configPath),
+      stateDir,
+      configPath,
+      channelPlugins: [createWhatsAppConfigFixTestPlugin(["+15550001111"])],
+    });
+
+    expect(res.ok).toBe(true);
+    const written = JSON.parse(await fs.readFile(configPath, "utf-8")) as OpenClawConfig;
+    const whatsapp = written.channels?.whatsapp as
+      | { groupAllowFrom?: unknown; accounts?: Record<string, { groupAllowFrom?: unknown }> }
+      | undefined;
+    expect(whatsapp?.groupAllowFrom).toEqual(["+15550001111"]);
+    expect(whatsapp?.accounts?.work?.groupAllowFrom).toEqual(["+15550001111"]);
+  });
+
   it("does not seed WhatsApp groupAllowFrom if allowFrom is set", async () => {
     const { res, channels } = await fixWhatsAppConfigScenario({
       whatsapp: {

--- a/src/security/fix.ts
+++ b/src/security/fix.ts
@@ -424,7 +424,10 @@ export async function fixSecurityFootguns(opts?: {
         await replaceConfigFile({
           nextConfig: fixed.cfg,
           snapshot: snap,
-          writeOptions,
+          writeOptions: {
+            ...writeOptions,
+            allowProtectedConfigPolicyDrop: true,
+          },
           io,
           afterWrite: { mode: "auto" },
         });

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -61,7 +61,11 @@ async function writeWizardConfigFile(config: OpenClawConfig): Promise<OpenClawCo
     commit: async (nextConfig, writeOptions) => {
       return await replaceConfigFile({
         nextConfig,
-        writeOptions: { ...writeOptions, allowConfigSizeDrop: true },
+        writeOptions: {
+          ...writeOptions,
+          allowConfigSizeDrop: true,
+          allowProtectedConfigPolicyDrop: true,
+        },
         afterWrite: { mode: "auto" },
       });
     },


### PR DESCRIPTION
## Summary

- replace protected channel-key enumeration with structural ownership-root protection under concrete `channels.<id>` and `channels.<id>.accounts.<account>` roots
- keep shared channel metadata (`channels.defaults`, `channels.modelByChannel`) outside concrete channel protection
- split gateway control-plane exact persistence paths from protected-policy exemption paths so leaf edits do not bless sibling stale policy changes
- keep command/elevated checks scoped to actual policy roots, and allow benign empty protected-policy container materialization
- update channel/config helpers and changelog for the maintainer replacement fix

Fixes #77508.
Fixes #78404.
Fixes #79738.

Supersedes the narrower open PRs #77630 and #78414 if this lands.

Not fixed here: #42538 is still distinct health/status behavior and should stay open.

## Verification

- Testbox-through-Crabbox, provider `blacksmith-testbox`, focused id `tbx_01krwyr3cradym3wxrbwh6c8mk`, Actions run https://github.com/openclaw/openclaw/actions/runs/26018908928
- Testbox-through-Crabbox, provider `blacksmith-testbox`, changed-gate id `tbx_01krwytwxchyem72aakf7cg45k`, Actions run https://github.com/openclaw/openclaw/actions/runs/26018967895
- exact remote commands: `pnpm test:serial src/gateway/server-methods/config.shared-auth.test.ts src/config/io.write-config.test.ts src/config/mutate.test.ts src/cli/config-cli.test.ts src/commands/channels.add.test.ts` and `pnpm check:changed`
- exact current head: `7551d79de50ac5fb69cbbfe01b1ed5d478db6b39`

Behavior addressed: stale config writers fail closed before dropping channel-owned config or elevated policy, without maintaining an allowlist of every channel/plugin policy key.
Real environment tested: Blacksmith Testbox-through-Crabbox for the focused config/channel suite and repo changed gate on the PR branch.
Exact steps or command run after this patch: `pnpm test:serial src/gateway/server-methods/config.shared-auth.test.ts src/config/io.write-config.test.ts src/config/mutate.test.ts src/cli/config-cli.test.ts src/commands/channels.add.test.ts`; `pnpm check:changed`.
Evidence after fix: focused suite passed 4 Vitest shards with 200 tests total; changed gate passed typecheck, lint, runtime import-cycle, package/dependency guards, and changed-surface checks.
Observed result after fix: concrete channel/account roots are protected structurally, exact gateway leaf edits no longer exempt sibling stale policy changes, and empty protected-policy containers remain writable no-ops.
What was not tested: true live WhatsApp QR/device auth was not exercised in this final pass; no local test commands are used as proof for this revision.
