### PR TITLE
docs(usage): clarify that the per-response usage footer only attaches to normal final replies (#83071)

### DIFF
--- a/docs/concepts/context.md
+++ b/docs/concepts/context.md
@@ -23,7 +23,7 @@ Context is _not the same thing_ as "memory": memory can be stored on disk and re
 - `/context list` → what's injected + rough sizes (per file + totals).
 - `/context detail` → deeper breakdown: per-file, per-tool schema sizes, per-skill entry sizes, and system prompt size.
 - `/context map` → WinDirStat-style treemap image of the current session's tracked context contributors.
-- `/usage tokens` → append per-reply usage footer to normal replies.
+- `/usage tokens` → append per-reply usage footer to **normal final replies**. Replies sent via the `message` tool (`action: send`) — including the `messages.groupChat.visibleReplies: "message_tool"` path — are delivered as authored without a footer.
 - `/compact` → summarize older history into a compact entry to free window space.
 
 See also: [Slash commands](/tools/slash-commands), [Token use & costs](/reference/token-use), [Compaction](/concepts/compaction).

--- a/docs/concepts/usage-tracking.md
+++ b/docs/concepts/usage-tracking.md
@@ -21,7 +21,7 @@ title: "Usage tracking"
 ## Where it shows up
 
 - `/status` in chats: emoji-rich status card with session tokens + estimated cost (API key only). Provider usage shows for the **current model provider** when available as a normalized `X% left` window.
-- `/usage off|tokens|full` in chats: per-response usage footer (OAuth shows tokens only).
+- `/usage off|tokens|full` in chats: per-response usage footer appended to the **normal final reply** after the agent run (OAuth shows tokens only). Replies sent via the `message` tool (`action: send`) — including the `messages.groupChat.visibleReplies: "message_tool"` path on Telegram forum topics and similar group-chat surfaces — are delivered as authored and do **not** receive the post-turn footer.
 - `/usage cost` in chats: local cost summary aggregated from OpenClaw session logs.
 - CLI: `openclaw status --usage` prints a full per-provider breakdown.
 - CLI: `openclaw channels list` prints the same usage snapshot alongside provider config (use `--no-usage` to skip).

--- a/docs/reference/token-use.md
+++ b/docs/reference/token-use.md
@@ -63,7 +63,7 @@ Use these in chat:
 
 - `/status` → **emoji-rich status card** with the session model, context usage,
   last response input/output tokens, and **estimated cost** (API key only).
-- `/usage off|tokens|full` → appends a **per-response usage footer** to every reply.
+- `/usage off|tokens|full` → appends a **per-response usage footer** to **normal final replies** after the agent run. Replies sent via the `message` tool (`action: send`) — including the `messages.groupChat.visibleReplies: "message_tool"` path on Telegram forum topics and similar group-chat surfaces — are delivered as authored and do **not** receive the footer.
   - Persists per session (stored as `responseUsage`).
   - OAuth auth **hides cost** (tokens only).
 - `/usage cost` → shows a local cost summary from OpenClaw session logs.


### PR DESCRIPTION
Fixes #83071.

## Problem

Per the reporter, the `/usage` footer is missing from Telegram forum-topic visible replies sent via the `message` tool. ClawSweeper's review confirms the actual contract: `appendUsageLine` runs on the **normal final reply** path (`src/auto-reply/reply/agent-runner.ts:1881`) and never touches the message-tool outbound path. With `messages.groupChat.visibleReplies: "message_tool"` enabled, the agent's visible output goes through `message(action: send)` and is delivered as-authored — no footer.

The reporter's expectation came from the public docs, which broadly promise the footer on every reply. Per ClawSweeper acceptance criteria the right fix is a docs-only clarification: runtime footer injection after an explicit tool send would be a separate behavior change that maintainers haven't accepted.

## Fix

Three doc files updated with the same clarifying sentence (message-tool sends, including the `messages.groupChat.visibleReplies: "message_tool"` path, are delivered as-authored and do NOT receive the footer):

- `docs/concepts/usage-tracking.md` — "Where it shows up" section
- `docs/concepts/context.md` — `/usage tokens` cheat-sheet line
- `docs/reference/token-use.md` — canonical token-use reference that previously said "every reply"

No runtime code changed. No test changes.

## Real behavior proof

**Behavior or issue addressed**: Per #83071, the docs say the `/usage` footer appends to "every reply" while the runtime only appends to the normal final reply path. Visible replies sent through `message(action: send)` (including `messages.groupChat.visibleReplies: "message_tool"` on Telegram forum topics) are delivered as authored without a footer. This makes operators expect a feature that does not exist for that path.

**Real environment tested**: Linux x86_64 (Ubuntu 24.04), local checkout of `openclaw/openclaw` at branch `docs-usage-footer-clarify-message-tool` rebased on `origin/main` (`2c9f68f42b`). Verified the three changed doc files by re-reading them off disk and checking that each now mentions the message-tool carve-out.

**Exact steps or command run after this patch**:

```
grep -n 'message tool\|message_tool' \
  docs/concepts/usage-tracking.md \
  docs/concepts/context.md \
  docs/reference/token-use.md
```

**Evidence after fix**: live stdout — three doc files, three matches, each anchoring the carve-out to the canonical command line that previously over-promised:

```
docs/concepts/usage-tracking.md:24:- `/usage off|tokens|full` in chats: per-response usage footer appended to the **normal final reply** after the agent run (OAuth shows tokens only). Replies sent via the `message` tool (`action: send`) — including the `messages.groupChat.visibleReplies: "message_tool"` path on Telegram forum topics and similar group-chat surfaces — are delivered as authored and do **not** receive the post-turn footer.
docs/reference/token-use.md:66:- `/usage off|tokens|full` → appends a **per-response usage footer** to **normal final replies** after the agent run. Replies sent via the `message` tool (`action: send`) — including the `messages.groupChat.visibleReplies: "message_tool"` path on Telegram forum topics and similar group-chat surfaces — are delivered as authored and do **not** receive the footer.
docs/concepts/context.md:26:- `/usage tokens` → append per-reply usage footer to **normal final replies**. Replies sent via the `message` tool (`action: send`) — including the `messages.groupChat.visibleReplies: "message_tool"` path — are delivered as authored without a footer.
```

Pre-fix the same `grep` returned zero matches — the docs never mentioned the carve-out, and `docs/reference/token-use.md:66` explicitly said "every reply". Post-fix the carve-out is stated in the three places operators actually read when they hit this surface (the conceptual usage-tracking page, the in-chat cheat sheet in context, and the canonical token-use reference).

**Observed result after fix**: operators using `messages.groupChat.visibleReplies: "message_tool"` (the Telegram forum-topic / Feishu group / Slack channel-visible path) and similar `message(action: send)` flows now have written documentation that matches the runtime — no expectation gap, no missing-feature reports for a feature that was never wired through the outbound message-tool path.

**What was not tested**: I did not run a live Telegram forum-topic delivery to confirm the runtime side because this PR is docs-only and ClawSweeper explicitly recommended NOT changing runtime footer semantics in this PR. The runtime side ("should message-tool sends also receive a footer?") is tracked separately as a maintainer product decision per ClawSweeper review.

## Pre-implement audit

- **Existing-helper check:** No code change. Pure docs clarification. PASS.
- **Shared-helper caller check:** N/A — no shared helper edited. PASS.
- **Broader-fix rival scan:** `gh pr list --search "83071 in:body"` returns no rival PRs. ClawSweeper labelled the issue P3 + queueable-fix + fix-shape-clear + source-repro with no linked closing PR. PASS.
