### PR TITLE
fix(telegram): clarify groups shape validation (#83083)

### DIFF
--- a/extensions/telegram/src/doctor.test.ts
+++ b/extensions/telegram/src/doctor.test.ts
@@ -4,12 +4,14 @@ import {
   collectTelegramInvalidAllowFromWarnings,
   collectTelegramApiRootWarnings,
   collectTelegramEmptyAllowlistExtraWarnings,
+  collectTelegramGroupsShapeWarnings,
   collectTelegramGroupPolicyWarnings,
   collectTelegramMissingEnvTokenWarnings,
   collectTelegramSelectedQuoteToolProgressWarnings,
   maybeRepairTelegramApiRoots,
   maybeRepairTelegramAllowFromUsernames,
   scanTelegramBotEndpointApiRoots,
+  scanTelegramGroupsShapeWarnings,
   scanTelegramInvalidAllowFromEntries,
   scanTelegramSelectedQuoteToolProgressWarnings,
   telegramDoctor,
@@ -291,6 +293,43 @@ describe("telegram doctor", () => {
 
     expect(warnings[0]).toContain("invalid sender entries");
     expect(warnings[1]).toContain("openclaw doctor --fix");
+  });
+
+  it("warns when Telegram groups config is not an object map", async () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          groups: [],
+          accounts: {
+            work: {
+              groups: "ops",
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const hits = scanTelegramGroupsShapeWarnings(cfg);
+    expect(hits).toEqual([
+      { path: "channels.telegram.groups", valueType: "array" },
+      { path: "channels.telegram.accounts.work.groups", valueType: "string" },
+    ]);
+
+    const warnings = collectTelegramGroupsShapeWarnings({
+      hits,
+      doctorFixCommand: "openclaw doctor --fix",
+    });
+    expect(warnings[0]).toContain("object map keyed by group chat ID");
+    expect(warnings[0]).toContain('groups."<chatId>".topics."<threadId>"');
+    expect(warnings[1]).toContain("openclaw doctor --fix");
+    expect(warnings[1]).toContain("repaired manually");
+
+    expect(
+      await telegramDoctor.collectPreviewWarnings?.({
+        cfg,
+        doctorFixCommand: "openclaw doctor --fix",
+      }),
+    ).toEqual(expect.arrayContaining(warnings));
   });
 
   it("warns and repairs Telegram apiRoot values that include the bot endpoint", () => {

--- a/extensions/telegram/src/doctor.ts
+++ b/extensions/telegram/src/doctor.ts
@@ -26,6 +26,7 @@ import {
 import { resolveTelegramPreviewStreamMode } from "./preview-streaming.js";
 
 type TelegramAllowFromInvalidHit = { path: string; entry: string };
+type TelegramGroupsShapeHit = { path: string; valueType: string };
 type TelegramSelectedQuoteToolProgressHit = { path: string; replyToMode: string };
 type TelegramApiRootBotEndpointHit = {
   path: string;
@@ -50,6 +51,16 @@ function asObjectRecord(value: unknown): Record<string, unknown> | null {
 
 function sanitizeForLog(value: string): string {
   return value.replace(/\p{Cc}+/gu, " ").trim();
+}
+
+function describeConfigValueType(value: unknown): string {
+  if (Array.isArray(value)) {
+    return "array";
+  }
+  if (value === null) {
+    return "null";
+  }
+  return typeof value;
 }
 
 function hasAllowFromEntries(values?: DoctorAllowFromList): boolean {
@@ -154,6 +165,40 @@ export function scanTelegramInvalidAllowFromEntries(
     }
   }
   return hits;
+}
+
+export function scanTelegramGroupsShapeWarnings(cfg: OpenClawConfig): TelegramGroupsShapeHit[] {
+  const hits: TelegramGroupsShapeHit[] = [];
+  for (const scope of collectTelegramAccountScopes(cfg)) {
+    if (!Object.prototype.hasOwnProperty.call(scope.account, "groups")) {
+      continue;
+    }
+    if (scope.account.groups === undefined || asObjectRecord(scope.account.groups)) {
+      continue;
+    }
+    hits.push({
+      path: `${scope.prefix}.groups`,
+      valueType: describeConfigValueType(scope.account.groups),
+    });
+  }
+  return hits;
+}
+
+export function collectTelegramGroupsShapeWarnings(params: {
+  hits: TelegramGroupsShapeHit[];
+  doctorFixCommand: string;
+}): string[] {
+  if (params.hits.length === 0) {
+    return [];
+  }
+  const sample = params.hits[0] ?? {
+    path: "channels.telegram.groups",
+    valueType: "unknown",
+  };
+  return [
+    `- ${sanitizeForLog(sample.path)} is ${sanitizeForLog(sample.valueType)}, but Telegram groups must be an object map keyed by group chat ID, with forum topics nested under groups."<chatId>".topics."<threadId>".`,
+    `- Run "${params.doctorFixCommand}" for supported legacy Telegram migrations; non-object groups values must be repaired manually before startup validation can pass.`,
+  ];
 }
 
 export function collectTelegramInvalidAllowFromWarnings(params: {
@@ -557,6 +602,10 @@ export const telegramDoctor: ChannelDoctorAdapter = {
   normalizeCompatibilityConfig: normalizeTelegramCompatibilityConfig,
   collectPreviewWarnings: ({ cfg, doctorFixCommand, env }) => [
     ...collectTelegramMissingEnvTokenWarnings({ cfg, env }),
+    ...collectTelegramGroupsShapeWarnings({
+      hits: scanTelegramGroupsShapeWarnings(cfg),
+      doctorFixCommand,
+    }),
     ...collectTelegramInvalidAllowFromWarnings({
       hits: scanTelegramInvalidAllowFromEntries(cfg),
       doctorFixCommand,

--- a/src/config/validation.channel-metadata.test.ts
+++ b/src/config/validation.channel-metadata.test.ts
@@ -246,6 +246,26 @@ describe("validateConfigObjectRawWithPlugins channel metadata", () => {
 
     expect(result.ok).toBe(true);
   });
+
+  it("adds actionable Telegram groups shape guidance to raw bundled channel errors", () => {
+    const result = validateConfigObjectRawWithPlugins({
+      channels: {
+        telegram: {
+          groups: [],
+        },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const issue = result.issues.find((item) => item.path === "channels.telegram.groups");
+      expect(issue?.message).toContain("invalid config: must be object");
+      expect(issue?.message).toContain("object map keyed by Telegram group chat ID");
+      expect(issue?.message).toContain('channels.telegram.groups."<chatId>".topics."<threadId>"');
+      expect(issue?.message).toContain("openclaw doctor --fix");
+      expect(issue?.message).toContain("repaired manually");
+    }
+  });
 });
 
 describe("validateConfigObjectRawWithPlugins plugin config defaults", () => {

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -85,6 +85,8 @@ function stripPreservedLegacyRootKeysForValidation(
 
 const CUSTOM_EXPECTED_ONE_OF_RE = /expected one of ((?:"[^"]+"(?:\|"?[^"]+"?)*)+)/i;
 const SECRETREF_POLICY_DOC_URL = "https://docs.openclaw.ai/reference/secretref-credential-surface";
+const TELEGRAM_GROUPS_SHAPE_HINT =
+  'expected an object map keyed by Telegram group chat ID; use channels.telegram.groups."<chatId>".topics."<threadId>" for forum-topic overrides. Run "openclaw doctor --fix" for supported legacy Telegram migrations; non-object groups values must be repaired manually.';
 const bundledChannelSchemaById = new Map<string, unknown>(
   GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA.map(
     (entry) => [entry.channelId, entry.schema] as const,
@@ -225,6 +227,25 @@ function collectAllowedValuesFromBundledChannelSchemaPath(
   return collectAllowedValuesFromJsonSchemaNode(targetNode);
 }
 
+function formatChannelJsonSchemaValidationMessage(params: {
+  channelId: string;
+  path: string;
+  message: string;
+  additionalProperty?: string;
+}): string {
+  const baseMessage = params.additionalProperty
+    ? `${params.message}: "${params.additionalProperty}"`
+    : params.message;
+  if (
+    params.channelId === "telegram" &&
+    params.path === "groups" &&
+    /\bmust be object\b/i.test(params.message)
+  ) {
+    return `${baseMessage}; ${TELEGRAM_GROUPS_SHAPE_HINT}`;
+  }
+  return baseMessage;
+}
+
 function collectRawBundledChannelConfigIssues(config: OpenClawConfig): ConfigValidationIssue[] {
   if (!config.channels || !isRecord(config.channels)) {
     return [];
@@ -244,9 +265,12 @@ function collectRawBundledChannelConfigIssues(config: OpenClawConfig): ConfigVal
       continue;
     }
     for (const error of result.errors) {
-      const message = error.additionalProperty
-        ? `${error.message}: "${error.additionalProperty}"`
-        : error.message;
+      const message = formatChannelJsonSchemaValidationMessage({
+        channelId,
+        path: error.path,
+        message: error.message,
+        additionalProperty: error.additionalProperty,
+      });
       issues.push({
         path:
           error.path === "<root>" ? `channels.${channelId}` : `channels.${channelId}.${error.path}`,
@@ -1316,10 +1340,16 @@ function validateConfigObjectWithPluginsBase(
       });
       if (!result.ok) {
         for (const error of result.errors) {
+          const message = formatChannelJsonSchemaValidationMessage({
+            channelId: trimmed,
+            path: error.path,
+            message: error.message,
+            additionalProperty: error.additionalProperty,
+          });
           issues.push({
             path:
               error.path === "<root>" ? `channels.${trimmed}` : `channels.${trimmed}.${error.path}`,
-            message: `invalid config: ${error.message}`,
+            message: `invalid config: ${message}`,
             allowedValues: error.allowedValues,
             allowedValuesHiddenCount: error.allowedValuesHiddenCount,
           });


### PR DESCRIPTION
## Summary
- add a Telegram-specific hint when `channels.telegram.groups` fails schema validation as a non-object
- surface the same object-map/topic-nesting guidance through Telegram doctor preview warnings
- cover raw bundled channel validation and doctor warning behavior

Fixes #83083

## Real behavior proof
Behavior addressed: malformed `channels.telegram.groups` values should fail config validation with actionable guidance for the expected object-map shape, topic nesting, doctor migration command, and manual repair boundary.

Real environment tested: local OpenClaw checkout on branch `fix-telegram-groups-shape-guidance-83083`, commit `e1b66441e0`; rebuilt with `pnpm build:strict-smoke`; isolated temp config via `OPENCLAW_CONFIG_PATH=/tmp/openclaw-real-proof-83083.4Y3L7E/openclaw.json` and isolated state via `OPENCLAW_STATE_DIR=/tmp/openclaw-real-proof-83083.4Y3L7E/state`.

Exact steps or command run after this patch:
1. Write `{"channels":{"telegram":{"groups":[]}}}` to the isolated `openclaw.json`.
2. Run `OPENCLAW_CONFIG_PATH="$tmpdir/openclaw.json" OPENCLAW_STATE_DIR="$tmpdir/state" node openclaw.mjs config validate --json`.

Evidence after fix:
```json
{
  "valid": false,
  "path": "/tmp/openclaw-real-proof-83083.4Y3L7E/openclaw.json",
  "issues": [
    {
      "path": "channels.telegram.groups",
      "message": "invalid config: must be object; expected an object map keyed by Telegram group chat ID; use channels.telegram.groups.\"<chatId>\".topics.\"<threadId>\" for forum-topic overrides. Run \"openclaw doctor --fix\" for supported legacy Telegram migrations; non-object groups values must be repaired manually."
    }
  ]
}
exit_status=1
```

Observed result after fix: the real CLI validation path still fails closed, but now reports the expected schema shape, topic nesting path, `openclaw doctor --fix` hint, and manual repair requirement instead of only `invalid config: must be object`.

Not tested: a live Telegram bot connection was not used because this issue is about local startup/config validation diagnostics before channel runtime startup.

## Tests
- `node scripts/run-vitest.mjs src/config/validation.channel-metadata.test.ts`
- `node scripts/run-vitest.mjs extensions/telegram/src/doctor.test.ts`
- `git diff --check`
- `pnpm check:changed`
- `pnpm build:strict-smoke`
