### PR TITLE
fix: resume yielded parent sessions

### DIFF
--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -77,6 +77,7 @@ vi.mock("../../config/sessions.js", async () => {
     await fs.writeFile(storePath, JSON.stringify(store, null, 2), "utf8");
   };
   return {
+    DEFAULT_PAUSED_SESSION_RESUME_TTL_MS: 30 * 60 * 1_000,
     mergeSessionEntry: (existing: SessionEntry | undefined, patch: Partial<SessionEntry>) => ({
       ...existing,
       ...patch,
@@ -223,6 +224,148 @@ describe("updateSessionStoreAfterAgentRun", () => {
 
       expect(sessionStore[sessionKey]?.contextTokens).toBe(400_000);
       expect(loadSessionStore(storePath)[sessionKey]?.contextTokens).toBe(400_000);
+    });
+  });
+
+  it("records a bounded paused session binding for yielded runs", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const cfg = {} as OpenClawConfig;
+      const sessionKey = "agent:main:telegram:default:direct:yielded-parent";
+      const sessionId = "yielded-parent-session";
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
+          sessionId,
+          updatedAt: 1,
+        },
+      };
+      await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
+
+      const result: EmbeddedPiRunResult = {
+        meta: {
+          durationMs: 1,
+          yielded: true,
+          livenessState: "paused",
+          agentMeta: {
+            sessionId,
+            provider: "openai-codex",
+            model: "gpt-5.5",
+          },
+        },
+      };
+
+      await updateSessionStoreAfterAgentRun({
+        cfg,
+        sessionId,
+        sessionKey,
+        storePath,
+        sessionStore,
+        defaultProvider: "openai-codex",
+        defaultModel: "gpt-5.5",
+        result,
+      });
+
+      const persisted = loadSessionStore(storePath)[sessionKey];
+      expect(sessionStore[sessionKey]?.pausedSessionId).toBe(sessionId);
+      expect(persisted?.pausedSessionId).toBe(sessionId);
+      expect(typeof persisted?.pausedSessionAt).toBe("number");
+      expect(typeof persisted?.pausedSessionExpiresAt).toBe("number");
+      expect((persisted?.pausedSessionExpiresAt ?? 0) - (persisted?.pausedSessionAt ?? 0)).toBe(
+        30 * 60 * 1_000,
+      );
+    });
+  });
+
+  it("clears the paused session binding after the yielded session resumes and finishes", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const cfg = {} as OpenClawConfig;
+      const sessionKey = "agent:main:telegram:default:direct:resumed-parent";
+      const sessionId = "resumed-parent-session";
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
+          sessionId,
+          updatedAt: 1,
+          pausedSessionId: sessionId,
+          pausedSessionAt: Date.now() - 1_000,
+          pausedSessionExpiresAt: Date.now() + 60_000,
+        },
+      };
+      await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
+
+      const result: EmbeddedPiRunResult = {
+        meta: {
+          durationMs: 1,
+          livenessState: "idle",
+          agentMeta: {
+            sessionId,
+            provider: "openai-codex",
+            model: "gpt-5.5",
+          },
+        },
+      };
+
+      await updateSessionStoreAfterAgentRun({
+        cfg,
+        sessionId,
+        sessionKey,
+        storePath,
+        sessionStore,
+        defaultProvider: "openai-codex",
+        defaultModel: "gpt-5.5",
+        result,
+      });
+
+      const persisted = loadSessionStore(storePath)[sessionKey];
+      expect(sessionStore[sessionKey]?.pausedSessionId).toBeUndefined();
+      expect(persisted?.pausedSessionId).toBeUndefined();
+      expect(persisted?.pausedSessionAt).toBeUndefined();
+      expect(persisted?.pausedSessionExpiresAt).toBeUndefined();
+    });
+  });
+
+  it("does not clear a valid paused binding from an unrelated non-yield run", async () => {
+    await withTempSessionStore(async ({ storePath }) => {
+      const cfg = {} as OpenClawConfig;
+      const sessionKey = "agent:main:telegram:default:direct:unrelated-run";
+      const pausedSessionId = "still-paused-parent-session";
+      const sessionStore: Record<string, SessionEntry> = {
+        [sessionKey]: {
+          sessionId: "route-session",
+          updatedAt: 1,
+          pausedSessionId,
+          pausedSessionAt: Date.now() - 1_000,
+          pausedSessionExpiresAt: Date.now() + 60_000,
+        },
+      };
+      await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2));
+
+      const result: EmbeddedPiRunResult = {
+        meta: {
+          durationMs: 1,
+          livenessState: "idle",
+          agentMeta: {
+            sessionId: "background-heartbeat-session",
+            provider: "openai-codex",
+            model: "gpt-5.5",
+          },
+        },
+      };
+
+      await updateSessionStoreAfterAgentRun({
+        cfg,
+        sessionId: "background-heartbeat-session",
+        sessionKey,
+        storePath,
+        sessionStore,
+        defaultProvider: "openai-codex",
+        defaultModel: "gpt-5.5",
+        result,
+        preserveRuntimeModel: true,
+        touchInteraction: false,
+      });
+
+      const persisted = loadSessionStore(storePath)[sessionKey];
+      expect(sessionStore[sessionKey]?.pausedSessionId).toBe(pausedSessionId);
+      expect(persisted?.pausedSessionId).toBe(pausedSessionId);
     });
   });
 

--- a/src/agents/command/session-store.ts
+++ b/src/agents/command/session-store.ts
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_PAUSED_SESSION_RESUME_TTL_MS,
   mergeSessionEntry,
   setSessionRuntimeModel,
   type SessionEntry,
@@ -126,6 +127,18 @@ export async function updateSessionStoreAfterAgentRun(params: {
           contextTokens,
         }),
   };
+  if (result.meta.yielded === true || result.meta.livenessState === "paused") {
+    next.pausedSessionId = sessionId;
+    next.pausedSessionAt = now;
+    next.pausedSessionExpiresAt = now + DEFAULT_PAUSED_SESSION_RESUME_TTL_MS;
+  } else if (
+    entry.pausedSessionId === sessionId ||
+    (typeof entry.pausedSessionExpiresAt === "number" && entry.pausedSessionExpiresAt <= now)
+  ) {
+    next.pausedSessionId = undefined;
+    next.pausedSessionAt = undefined;
+    next.pausedSessionExpiresAt = undefined;
+  }
   if (preserveRuntimeModel) {
     // Keep the pre-existing runtime model and context window so a background
     // heartbeat turn using a different model does not bleed into the main

--- a/src/agents/command/session.ts
+++ b/src/agents/command/session.ts
@@ -19,7 +19,10 @@ import {
 import { resolveChannelResetConfig, resolveSessionResetType } from "../../config/sessions/reset.js";
 import { resolveSessionKey } from "../../config/sessions/session-key.js";
 import { loadSessionStore } from "../../config/sessions/store-load.js";
-import type { SessionEntry } from "../../config/sessions/types.js";
+import {
+  resolvePausedSessionIdForResume,
+  type SessionEntry,
+} from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   buildAgentMainSessionKey,
@@ -325,9 +328,14 @@ export function resolveSession(opts: {
         policy: resetPolicy,
       }).fresh
     : false;
+  const pausedSessionId = resolvePausedSessionIdForResume(sessionEntry, now);
+  const resumesPausedSession = Boolean(!opts.sessionId && pausedSessionId);
   const sessionId =
-    opts.sessionId?.trim() || (fresh ? sessionEntry?.sessionId : undefined) || crypto.randomUUID();
-  const isNewSession = !fresh && !opts.sessionId;
+    opts.sessionId?.trim() ||
+    pausedSessionId ||
+    (fresh ? sessionEntry?.sessionId : undefined) ||
+    crypto.randomUUID();
+  const isNewSession = !fresh && !opts.sessionId && !pausedSessionId;
 
   clearBootstrapSnapshotOnSessionRollover({
     sessionKey,
@@ -335,11 +343,11 @@ export function resolveSession(opts: {
   });
 
   const persistedThinking =
-    fresh && sessionEntry?.thinkingLevel
+    (fresh || resumesPausedSession) && sessionEntry?.thinkingLevel
       ? normalizeThinkLevel(sessionEntry.thinkingLevel)
       : undefined;
   const persistedVerbose =
-    fresh && sessionEntry?.verboseLevel
+    (fresh || resumesPausedSession) && sessionEntry?.verboseLevel
       ? normalizeVerboseLevel(sessionEntry.verboseLevel)
       : undefined;
 

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -18,6 +18,7 @@ import {
   dispatchGatewayMethodInProcess as runtimeDispatchGatewayMethodInProcess,
   sendMessage as runtimeSendMessage,
 } from "./subagent-announce-delivery.runtime.js";
+import type { SessionEntry } from "../config/sessions.js";
 import { resolveAnnounceOrigin } from "./subagent-announce-origin.js";
 
 afterEach(() => {
@@ -130,6 +131,7 @@ async function deliverSlackThreadAnnouncement(params: {
   callGateway: typeof runtimeCallGateway;
   isActive: boolean;
   sessionId: string;
+  requesterEntry?: SessionEntry;
   expectsCompletionMessage: boolean;
   directIdempotencyKey: string;
   queueEmbeddedPiMessageWithOutcome?: QueueEmbeddedPiMessageWithOutcome;
@@ -143,6 +145,15 @@ async function deliverSlackThreadAnnouncement(params: {
       sessionId: params.sessionId,
       isActive: params.isActive,
     }),
+    ...(params.requesterEntry
+      ? {
+          loadRequesterSessionEntry: (requesterSessionKey: string) => ({
+            cfg: {} as never,
+            canonicalKey: requesterSessionKey,
+            entry: params.requesterEntry,
+          }),
+        }
+      : {}),
     getRuntimeConfig: () => ({}) as never,
     ...(params.queueEmbeddedPiMessageWithOutcome
       ? { queueEmbeddedPiMessageWithOutcome: params.queueEmbeddedPiMessageWithOutcome }
@@ -1457,6 +1468,60 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
     });
     expect(callGateway).toHaveBeenCalledTimes(1);
     expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("pins completion direct fallback to the yielded requester session", async () => {
+    const callGateway = createGatewayMock({
+      result: {
+        payloads: [{ text: "continued parent run" }],
+      },
+    });
+    const queueEmbeddedPiMessageWithOutcome = createQueueOutcomeMock(false);
+    const pausedSessionExpiresAt = Date.now() + 60_000;
+
+    const result = await deliverSlackThreadAnnouncement({
+      callGateway,
+      sessionId: "current-route-session",
+      requesterEntry: {
+        sessionId: "current-route-session",
+        updatedAt: Date.now() - 60_000,
+        pausedSessionId: "yielded-parent-session",
+        pausedSessionAt: Date.now() - 1_000,
+        pausedSessionExpiresAt,
+      },
+      isActive: false,
+      expectsCompletionMessage: true,
+      directIdempotencyKey: "announce-thread-yielded-parent-session",
+      queueEmbeddedPiMessageWithOutcome,
+      internalEvents: [
+        {
+          type: "task_completion",
+          source: "subagent",
+          childSessionKey: "agent:worker:subagent:child",
+          childSessionId: "child-session-id",
+          announceType: "subagent task",
+          taskLabel: "yielded parent smoke",
+          status: "ok",
+          statusLabel: "completed successfully",
+          result: "child completion output",
+          replyInstruction: "Continue the parent task.",
+        },
+      ],
+    });
+
+    expectRecordFields(result, {
+      delivered: true,
+      path: "direct",
+    });
+    expectGatewayAgentParams(callGateway, {
+      sessionKey: "agent:main:slack:channel:C123:thread:171.222",
+      sessionId: "yielded-parent-session",
+      deliver: true,
+      channel: "slack",
+      accountId: "acct-1",
+      to: "channel:C123",
+      threadId: "171.222",
+    });
   });
 
   it("reports failure for completion DMs when announce-agent returns no visible output", async () => {

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -1,4 +1,8 @@
 import { completionRequiresMessageToolDelivery } from "../auto-reply/reply/completion-delivery-policy.js";
+import {
+  resolvePausedSessionIdForResume,
+  type SessionEntry,
+} from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ConversationRef } from "../infra/outbound/session-binding-service.js";
 import { stringifyRouteThreadId } from "../plugin-sdk/channel-route.js";
@@ -68,6 +72,11 @@ const AGENT_MEDIATED_COMPLETION_TOOLS = new Set([
 type SubagentAnnounceDeliveryDeps = {
   dispatchGatewayMethodInProcess: typeof dispatchGatewayMethodInProcess;
   getRuntimeConfig: typeof getRuntimeConfig;
+  loadRequesterSessionEntry: (requesterSessionKey: string) => {
+    cfg: OpenClawConfig;
+    entry?: SessionEntry;
+    canonicalKey: string;
+  };
   getRequesterSessionActivity: (requesterSessionKey: string) => {
     sessionId?: string;
     isActive: boolean;
@@ -82,10 +91,13 @@ type SubagentAnnounceDeliveryDeps = {
 const defaultSubagentAnnounceDeliveryDeps: SubagentAnnounceDeliveryDeps = {
   dispatchGatewayMethodInProcess,
   getRuntimeConfig,
+  loadRequesterSessionEntry: loadRequesterSessionEntryFromStore,
   getRequesterSessionActivity: (requesterSessionKey: string) => {
+    const { entry } = loadRequesterSessionEntry(requesterSessionKey);
     const sessionId =
       resolveActiveEmbeddedRunSessionId(requesterSessionKey) ??
-      loadRequesterSessionEntry(requesterSessionKey).entry?.sessionId;
+      resolvePausedSessionIdForResume(entry) ??
+      entry?.sessionId;
     return {
       sessionId,
       isActive: Boolean(sessionId && isEmbeddedPiRunActive(sessionId)),
@@ -197,7 +209,7 @@ function resolveRequesterSessionActivity(requesterSessionKey: string) {
     return activity;
   }
   const { entry } = loadRequesterSessionEntry(requesterSessionKey);
-  const sessionId = entry?.sessionId;
+  const sessionId = resolvePausedSessionIdForResume(entry) ?? entry?.sessionId;
   return {
     sessionId,
     isActive: Boolean(sessionId && isEmbeddedPiRunActive(sessionId)),
@@ -430,7 +442,7 @@ export async function resolveSubagentCompletionOrigin(params: {
   }
 }
 
-export function loadRequesterSessionEntry(requesterSessionKey: string) {
+function loadRequesterSessionEntryFromStore(requesterSessionKey: string) {
   const cfg = subagentAnnounceDeliveryDeps.getRuntimeConfig();
   const canonicalKey = resolveRequesterStoreKey(cfg, requesterSessionKey);
   const agentId = resolveAgentIdFromSessionKey(canonicalKey);
@@ -438,6 +450,10 @@ export function loadRequesterSessionEntry(requesterSessionKey: string) {
   const store = loadSessionStore(storePath);
   const entry = store[canonicalKey];
   return { cfg, entry, canonicalKey };
+}
+
+export function loadRequesterSessionEntry(requesterSessionKey: string) {
+  return subagentAnnounceDeliveryDeps.loadRequesterSessionEntry(requesterSessionKey);
 }
 
 export function loadSessionEntryByKey(sessionKey: string) {
@@ -639,6 +655,7 @@ async function sendSubagentAnnounceDirectly(params: {
       ? effectiveDirectOrigin
       : requesterSessionOrigin;
     const requesterEntry = loadRequesterSessionEntry(params.targetRequesterSessionKey).entry;
+    const pausedRequesterSessionId = resolvePausedSessionIdForResume(requesterEntry);
     const deliveryTarget = !params.requesterIsSubagent
       ? resolveExternalBestEffortDeliveryTarget({
           channel: effectiveDirectOrigin?.channel,
@@ -727,6 +744,9 @@ async function sendSubagentAnnounceDirectly(params: {
     }
     const directAgentParams: Record<string, unknown> = {
       sessionKey: canonicalRequesterSessionKey,
+      ...(params.expectsCompletionMessage && pausedRequesterSessionId
+        ? { sessionId: pausedRequesterSessionId }
+        : {}),
       message: params.triggerMessage,
       deliver: shouldDeliverAgentFinal,
       bestEffortDeliver: params.bestEffortDeliver,

--- a/src/commands/agent.session.test.ts
+++ b/src/commands/agent.session.test.ts
@@ -145,6 +145,53 @@ describe("agent session resolution", () => {
     });
   });
 
+  it("resumes a bounded paused session even after the route entry is stale", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      const now = Date.now();
+      writeSessionStoreSeed(store, {
+        main: {
+          sessionId: "stale-route-session",
+          updatedAt: now - 2 * 24 * 60 * 60_000,
+          sessionStartedAt: now - 2 * 24 * 60 * 60_000,
+          pausedSessionId: "yielded-parent-session",
+          pausedSessionAt: now - 60_000,
+          pausedSessionExpiresAt: now + 60_000,
+        },
+      });
+      const cfg = mockConfig(home, store);
+
+      const resolution = resolveSession({ cfg, sessionKey: "main" });
+
+      expect(resolution.sessionId).toBe("yielded-parent-session");
+      expect(resolution.isNewSession).toBe(false);
+    });
+  });
+
+  it("does not resume an expired paused session binding", async () => {
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      const now = Date.now();
+      writeSessionStoreSeed(store, {
+        main: {
+          sessionId: "stale-route-session",
+          updatedAt: now - 2 * 24 * 60 * 60_000,
+          sessionStartedAt: now - 2 * 24 * 60 * 60_000,
+          pausedSessionId: "expired-yielded-parent-session",
+          pausedSessionAt: now - 2 * 60_000,
+          pausedSessionExpiresAt: now - 60_000,
+        },
+      });
+      const cfg = mockConfig(home, store);
+
+      const resolution = resolveSession({ cfg, sessionKey: "main" });
+
+      expect(resolution.sessionId).not.toBe("expired-yielded-parent-session");
+      expect(resolution.sessionId).not.toBe("stale-route-session");
+      expect(resolution.isNewSession).toBe(true);
+    });
+  });
+
   it("forwards resolved outbound session context when resuming by sessionId", async () => {
     await withCrossAgentResumeFixture(async ({ sessionId, sessionKey, cfg }) => {
       const resolution = resolveSession({ cfg, sessionId });

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -12,6 +12,8 @@ export type SessionChannelId = ChannelId;
 
 export type SessionChatType = ChatType;
 
+export const DEFAULT_PAUSED_SESSION_RESUME_TTL_MS = 30 * 60 * 1_000;
+
 export type SessionOrigin = {
   label?: string;
   provider?: string;
@@ -195,6 +197,12 @@ export type SessionEntry = {
   pluginNextTurnInjections?: Record<string, SessionPluginNextTurnInjection[]>;
   sessionId: string;
   updatedAt: number;
+  /** Session id of a yielded/paused run that should be resumed before route rollover. */
+  pausedSessionId?: string;
+  /** Timestamp (ms) when pausedSessionId was recorded. */
+  pausedSessionAt?: number;
+  /** Timestamp (ms) after which pausedSessionId must no longer be preferred. */
+  pausedSessionExpiresAt?: number;
   sessionFile?: string;
   /** Parent session key that spawned this session (used for sandbox session-tool scoping). */
   spawnedBy?: string;
@@ -522,6 +530,21 @@ export function mergeSessionEntry(
   patch: Partial<SessionEntry>,
 ): SessionEntry {
   return mergeSessionEntryWithPolicy(existing, patch);
+}
+
+export function resolvePausedSessionIdForResume(
+  entry: SessionEntry | undefined,
+  now = Date.now(),
+): string | undefined {
+  const pausedSessionId = normalizeOptionalString(entry?.pausedSessionId);
+  if (!pausedSessionId) {
+    return undefined;
+  }
+  const expiresAt = entry?.pausedSessionExpiresAt;
+  if (typeof expiresAt !== "number" || !Number.isFinite(expiresAt) || expiresAt <= now) {
+    return undefined;
+  }
+  return pausedSessionId;
 }
 
 export function mergeSessionEntryPreserveActivity(


### PR DESCRIPTION
## Summary

Fixes yielded subagent completion routing so a subagent completion resumes the paused parent session instead of starting a fresh inter-session run on the same route.

Changes:
- Persist a bounded paused-session binding on yielded/paused embedded runs.
- Prefer valid paused-session bindings during route/session resolution before stale-route rollover.
- Pin subagent completion direct fallback with the paused session id when present.
- Ignore expired paused bindings and clear bindings only when the paused session itself finishes or the binding expires.

## Validation

- `pnpm test src/agents/command/session-store.test.ts src/commands/agent.session.test.ts src/agents/subagent-announce-delivery.test.ts`
- `pnpm check:changed`
- `git diff --check`

## Safety

This is source-only. It does not change package install flow or gateway startup behavior.