### PR TITLE
feat(agents): add sessions_send handoff acknowledgements

### DIFF
--- a/docs/concepts/a2a-handoff-phase1.md
+++ b/docs/concepts/a2a-handoff-phase1.md
@@ -1,0 +1,123 @@
+---
+summary: "Phase 1 agent-to-agent handoff contract for sessions_send acknowledgements, control-only outcomes, and audit events."
+read_when:
+  - Changing sessions_send agent-to-agent delivery behavior
+  - Debugging silent NO_REPLY, REPLY_SKIP, or ANNOUNCE_SKIP handoff outcomes
+  - Reviewing the boundary between handoff transport and meeting lifecycle
+title: "Agent-to-agent handoff, Phase 1"
+---
+
+# Agent-to-agent handoff, Phase 1
+
+OpenClaw treats `sessions_send` agent-to-agent delegation as a first-party
+handoff with a stable id, a structured acknowledgement, and an append-only audit
+trail. Phase 1 stays at the transport and acknowledgement layer. It does not
+introduce a meeting lifecycle, durable work queue, retry engine, dashboard, or
+workflow state machine.
+
+## Contract
+
+Every delegated `sessions_send` attempt that resolves to a target session gets
+a `handoff.id`. The existing `status`, `runId`, `reply`, `sessionKey`, and
+`delivery` fields stay in place for compatibility. New callers can inspect the
+`handoff` envelope:
+
+```json
+{
+  "runId": "run_123",
+  "status": "accepted",
+  "sessionKey": "agent:worker:main",
+  "delivery": {
+    "status": "pending",
+    "mode": "announce"
+  },
+  "handoff": {
+    "id": "8b8424a8-3b02-4c2a-9a33-7d7a99f0f4da",
+    "status": "accepted",
+    "delivery": {
+      "status": "pending",
+      "mode": "announce"
+    },
+    "ledger": {
+      "path": "handoffs/sessions-send.jsonl"
+    }
+  }
+}
+```
+
+The `handoff.status` field uses these Phase 1 states:
+
+| State       | Meaning                                                                  |
+| ----------- | ------------------------------------------------------------------------ |
+| `queued`    | OpenClaw created the handoff record before the target run was accepted.  |
+| `accepted`  | The target agent run was accepted or the request reached target runtime. |
+| `delivered` | A terminal visible or control-only outcome was observed.                 |
+| `rejected`  | OpenClaw rejected the handoff before target runtime accepted it.         |
+
+## Control-only outcomes
+
+Control-only target replies must not make transport success look like
+disappeared work. Phase 1 records these outcomes in the handoff ledger and then
+preserves the existing suppression behavior:
+
+| Target output   | Recorded `controlOutcome` | Delivery behavior                               |
+| --------------- | ------------------------- | ----------------------------------------------- |
+| `NO_REPLY`      | `no_reply`                | Do not announce or post visible channel output. |
+| `REPLY_SKIP`    | `reply_skip`              | Stop the reply-back loop without re-injection.  |
+| `ANNOUNCE_SKIP` | `announce_skip`           | Skip final announce delivery.                   |
+| `HEARTBEAT_OK`  | `heartbeat_ok`            | Treat as an internal heartbeat-only result.     |
+
+## Ledger
+
+The append-only ledger lives under the OpenClaw state directory at:
+
+```text
+handoffs/sessions-send.jsonl
+```
+
+Each JSONL entry includes `handoffId`, `type`, `status`, `timestamp`, and
+available routing metadata such as requester session, requester channel, target
+session, and target channel. The ledger intentionally avoids storing original
+prompt or reply text.
+
+Phase 1 events include:
+
+| Event                      | When it is written                                                  |
+| -------------------------- | ------------------------------------------------------------------- |
+| `created`                  | A resolved target handoff is created.                               |
+| `accepted`                 | The target `agent` call returns an accepted run id.                 |
+| `rejected`                 | Validation rejects the target before target runtime.                |
+| `target_reply_observed`    | The target produced a non-control reply.                            |
+| `target_reply_missing`     | A delayed flow could not observe a new target reply.                |
+| `control_outcome_observed` | A control-only target, reply-back, or announce result was observed. |
+| `announce_delivered`       | The final announce message was sent to a channel target.            |
+| `announce_delivery_failed` | Channel delivery for the announce failed.                           |
+| `failed`                   | The target wait or A2A follow-up failed after acceptance.           |
+
+Ledger writes are best-effort. A local state directory failure should not turn
+an otherwise valid agent handoff into a failed `sessions_send` call.
+
+## Non-goals
+
+Phase 1 does not implement:
+
+- meeting or teleconference lifecycle states such as `pending -> active -> closed`
+- pickup queues or cross-agent work claiming
+- one-way dispatch mode
+- retry scheduling or cancellation
+- transcript UI or dashboards
+- database-backed orchestration
+
+Those belong in higher layers after the handoff transport contract is stable.
+
+## Implementation surface
+
+The implementation is intentionally scoped to:
+
+- `src/agents/tools/sessions-send-tool.ts` for the returned acknowledgement
+- `src/agents/tools/sessions-send-tool.a2a.ts` for A2A outcome recording
+- `src/agents/tools/sessions-send-handoff.ts` for handoff types and ledger writes
+- focused tests around accepted sends and control-only outcomes
+
+This keeps the primitive reusable by later meeting or teleconference work
+without making `sessions_send` own the higher-level lifecycle.

--- a/src/agents/tools/sessions-send-handoff.ts
+++ b/src/agents/tools/sessions-send-handoff.ts
@@ -1,0 +1,113 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { HEARTBEAT_TOKEN, SILENT_REPLY_TOKEN, isSilentReplyText } from "../../auto-reply/tokens.js";
+import { resolveStateDir } from "../../config/paths.js";
+import { ANNOUNCE_SKIP_TOKEN, REPLY_SKIP_TOKEN } from "./sessions-send-tokens.js";
+
+export const SESSIONS_SEND_HANDOFF_LEDGER_RELATIVE_PATH = "handoffs/sessions-send.jsonl";
+
+export type SessionsSendHandoffStatus = "queued" | "accepted" | "delivered" | "rejected";
+
+export type SessionsSendHandoffControlOutcome =
+  | "announce_skip"
+  | "heartbeat_ok"
+  | "no_reply"
+  | "reply_skip";
+
+export type SessionsSendHandoffDelivery = {
+  mode: "announce";
+  status: "pending" | "skipped";
+};
+
+export type SessionsSendHandoffAck = {
+  id: string;
+  status: SessionsSendHandoffStatus;
+  delivery: SessionsSendHandoffDelivery;
+  ledger: {
+    path: typeof SESSIONS_SEND_HANDOFF_LEDGER_RELATIVE_PATH;
+  };
+};
+
+export type SessionsSendHandoffEventType =
+  | "accepted"
+  | "announce_delivered"
+  | "announce_delivery_failed"
+  | "control_outcome_observed"
+  | "created"
+  | "failed"
+  | "rejected"
+  | "target_reply_missing"
+  | "target_reply_observed";
+
+export type SessionsSendHandoffEvent = {
+  handoffId: string;
+  type: SessionsSendHandoffEventType;
+  status: SessionsSendHandoffStatus;
+  runId?: string | undefined;
+  requesterSessionKey?: string | undefined;
+  requesterChannel?: string | undefined;
+  targetSessionKey?: string | undefined;
+  targetDisplayKey?: string | undefined;
+  targetChannel?: string | undefined;
+  controlOutcome?: SessionsSendHandoffControlOutcome | undefined;
+  error?: string | undefined;
+  timestamp?: string | undefined;
+};
+
+export function buildSessionsSendHandoffAck(params: {
+  id: string;
+  status: SessionsSendHandoffStatus;
+  delivery: SessionsSendHandoffDelivery;
+}): SessionsSendHandoffAck {
+  return {
+    id: params.id,
+    status: params.status,
+    delivery: params.delivery,
+    ledger: {
+      path: SESSIONS_SEND_HANDOFF_LEDGER_RELATIVE_PATH,
+    },
+  };
+}
+
+export function resolveSessionsSendHandoffLedgerPath(env: NodeJS.ProcessEnv = process.env): string {
+  return path.join(resolveStateDir(env), SESSIONS_SEND_HANDOFF_LEDGER_RELATIVE_PATH);
+}
+
+export function classifySessionsSendControlOutcome(
+  text?: string,
+): SessionsSendHandoffControlOutcome | undefined {
+  if (isSilentReplyText(text, SILENT_REPLY_TOKEN)) {
+    return "no_reply";
+  }
+  if (isSilentReplyText(text, REPLY_SKIP_TOKEN)) {
+    return "reply_skip";
+  }
+  if (isSilentReplyText(text, ANNOUNCE_SKIP_TOKEN)) {
+    return "announce_skip";
+  }
+  if (isSilentReplyText(text, HEARTBEAT_TOKEN)) {
+    return "heartbeat_ok";
+  }
+  return undefined;
+}
+
+export async function recordSessionsSendHandoffEvent(
+  event: SessionsSendHandoffEvent,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+  try {
+    const ledgerPath = resolveSessionsSendHandoffLedgerPath(env);
+    await fs.mkdir(path.dirname(ledgerPath), { recursive: true, mode: 0o700 });
+    await fs.appendFile(
+      ledgerPath,
+      `${JSON.stringify({
+        ...event,
+        timestamp: event.timestamp ?? new Date().toISOString(),
+      })}\n`,
+      { encoding: "utf-8", mode: 0o600 },
+    );
+  } catch {
+    // Handoff ledger writes are audit best-effort; tool delivery must not fail
+    // because the local state directory is temporarily unavailable.
+  }
+}

--- a/src/agents/tools/sessions-send-tool.a2a.test.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CallGatewayOptions } from "../../gateway/call.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
@@ -5,6 +8,7 @@ import { createSessionConversationTestRegistry } from "../../test-utils/session-
 import { readLatestAssistantReplySnapshot, waitForAgentRun } from "../run-wait.js";
 import { runAgentStep } from "./agent-step.js";
 import type { SessionListRow } from "./sessions-helpers.js";
+import { resolveSessionsSendHandoffLedgerPath } from "./sessions-send-handoff.js";
 import { runSessionsSendA2AFlow, __testing } from "./sessions-send-tool.a2a.js";
 
 const callGatewayMock = vi.hoisted(() => vi.fn());
@@ -172,6 +176,46 @@ describe("runSessionsSendA2AFlow announce delivery", () => {
         roundOneReply,
       });
 
+      expect(runAgentStep).not.toHaveBeenCalled();
+      expect(gatewayCalls.find((call) => call.method === "send")).toBeUndefined();
+    },
+  );
+
+  it.each([
+    ["NO_REPLY", "no_reply"],
+    ["REPLY_SKIP", "reply_skip"],
+    ["ANNOUNCE_SKIP", "announce_skip"],
+  ])(
+    "records exact control reply %s as an observable handoff outcome",
+    async (roundOneReply, controlOutcome) => {
+      const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-a2a-handoff-"));
+      vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+
+      await runSessionsSendA2AFlow({
+        targetSessionKey: "agent:main:discord:group:dev",
+        displayKey: "agent:main:discord:group:dev",
+        message: "Test message",
+        announceTimeoutMs: 10_000,
+        maxPingPongTurns: 2,
+        requesterSessionKey: "agent:main:discord:group:req",
+        requesterChannel: "discord",
+        handoffId: "handoff-control-reply",
+        roundOneReply,
+      });
+
+      const rawLedger = await fs.readFile(resolveSessionsSendHandoffLedgerPath(), "utf-8");
+      const entries = rawLedger
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as Record<string, unknown>);
+      expect(entries).toContainEqual(
+        expect.objectContaining({
+          handoffId: "handoff-control-reply",
+          type: "control_outcome_observed",
+          status: "delivered",
+          controlOutcome,
+        }),
+      );
       expect(runAgentStep).not.toHaveBeenCalled();
       expect(gatewayCalls.find((call) => call.method === "send")).toBeUndefined();
     },

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -12,6 +12,10 @@ import {
 import { runAgentStep } from "./agent-step.js";
 import { resolveAnnounceTarget } from "./sessions-announce-target.js";
 import {
+  classifySessionsSendControlOutcome,
+  recordSessionsSendHandoffEvent,
+} from "./sessions-send-handoff.js";
+import {
   buildAgentToAgentAnnounceContext,
   buildAgentToAgentReplyContext,
   isAnnounceSkip,
@@ -43,6 +47,7 @@ export async function runSessionsSendA2AFlow(params: {
   requesterSessionKey?: string;
   requesterChannel?: GatewayMessageChannel;
   baseline?: AssistantReplySnapshot;
+  handoffId?: string;
   roundOneReply?: string;
   waitRunId?: string;
 }) {
@@ -71,9 +76,35 @@ export async function runSessionsSendA2AFlow(params: {
       }
     }
     if (!latestReply) {
+      if (params.handoffId) {
+        await recordSessionsSendHandoffEvent({
+          handoffId: params.handoffId,
+          type: "target_reply_missing",
+          status: "accepted",
+          runId: params.waitRunId,
+          requesterSessionKey: params.requesterSessionKey,
+          requesterChannel: params.requesterChannel,
+          targetSessionKey: params.targetSessionKey,
+          targetDisplayKey: params.displayKey,
+        });
+      }
       return;
     }
-    if (isNonDeliverableSessionsReply(latestReply)) {
+    const initialControlOutcome = classifySessionsSendControlOutcome(latestReply);
+    if (initialControlOutcome || isNonDeliverableSessionsReply(latestReply)) {
+      if (params.handoffId) {
+        await recordSessionsSendHandoffEvent({
+          handoffId: params.handoffId,
+          type: "control_outcome_observed",
+          status: "delivered",
+          runId: params.waitRunId,
+          requesterSessionKey: params.requesterSessionKey,
+          requesterChannel: params.requesterChannel,
+          targetSessionKey: params.targetSessionKey,
+          targetDisplayKey: params.displayKey,
+          controlOutcome: initialControlOutcome,
+        });
+      }
       return;
     }
 
@@ -82,6 +113,19 @@ export async function runSessionsSendA2AFlow(params: {
       displayKey: params.displayKey,
     });
     const targetChannel = announceTarget?.channel ?? "unknown";
+    if (params.handoffId) {
+      await recordSessionsSendHandoffEvent({
+        handoffId: params.handoffId,
+        type: "target_reply_observed",
+        status: "accepted",
+        runId: params.waitRunId,
+        requesterSessionKey: params.requesterSessionKey,
+        requesterChannel: params.requesterChannel,
+        targetSessionKey: params.targetSessionKey,
+        targetDisplayKey: params.displayKey,
+        targetChannel,
+      });
+    }
 
     if (
       params.maxPingPongTurns > 0 &&
@@ -114,7 +158,27 @@ export async function runSessionsSendA2AFlow(params: {
             nextSessionKey === params.requesterSessionKey ? params.requesterChannel : targetChannel,
           sourceTool: "sessions_send",
         });
-        if (!replyText || isReplySkip(replyText) || isNonDeliverableSessionsReply(replyText)) {
+        const replyControlOutcome = classifySessionsSendControlOutcome(replyText);
+        if (
+          !replyText ||
+          isReplySkip(replyText) ||
+          replyControlOutcome ||
+          isNonDeliverableSessionsReply(replyText)
+        ) {
+          if (params.handoffId && replyControlOutcome) {
+            await recordSessionsSendHandoffEvent({
+              handoffId: params.handoffId,
+              type: "control_outcome_observed",
+              status: "delivered",
+              runId: params.waitRunId,
+              requesterSessionKey: params.requesterSessionKey,
+              requesterChannel: params.requesterChannel,
+              targetSessionKey: nextSessionKey,
+              targetDisplayKey: params.displayKey,
+              targetChannel,
+              controlOutcome: replyControlOutcome,
+            });
+          }
           break;
         }
         latestReply = replyText;
@@ -145,10 +209,26 @@ export async function runSessionsSendA2AFlow(params: {
       sourceChannel: params.requesterChannel,
       sourceTool: "sessions_send",
     });
+    const announceControlOutcome = classifySessionsSendControlOutcome(announceReply);
+    if (params.handoffId && announceControlOutcome) {
+      await recordSessionsSendHandoffEvent({
+        handoffId: params.handoffId,
+        type: "control_outcome_observed",
+        status: "delivered",
+        runId: params.waitRunId,
+        requesterSessionKey: params.requesterSessionKey,
+        requesterChannel: params.requesterChannel,
+        targetSessionKey: params.targetSessionKey,
+        targetDisplayKey: params.displayKey,
+        targetChannel,
+        controlOutcome: announceControlOutcome,
+      });
+    }
     if (
       announceTarget &&
       announceReply &&
       announceReply.trim() &&
+      !announceControlOutcome &&
       !isAnnounceSkip(announceReply) &&
       !isNonDeliverableSessionsReply(announceReply)
     ) {
@@ -165,7 +245,34 @@ export async function runSessionsSendA2AFlow(params: {
           },
           timeoutMs: 10_000,
         });
+        if (params.handoffId) {
+          await recordSessionsSendHandoffEvent({
+            handoffId: params.handoffId,
+            type: "announce_delivered",
+            status: "delivered",
+            runId: params.waitRunId,
+            requesterSessionKey: params.requesterSessionKey,
+            requesterChannel: params.requesterChannel,
+            targetSessionKey: params.targetSessionKey,
+            targetDisplayKey: params.displayKey,
+            targetChannel: announceTarget.channel,
+          });
+        }
       } catch (err) {
+        if (params.handoffId) {
+          await recordSessionsSendHandoffEvent({
+            handoffId: params.handoffId,
+            type: "announce_delivery_failed",
+            status: "accepted",
+            runId: params.waitRunId,
+            requesterSessionKey: params.requesterSessionKey,
+            requesterChannel: params.requesterChannel,
+            targetSessionKey: params.targetSessionKey,
+            targetDisplayKey: params.displayKey,
+            targetChannel: announceTarget.channel,
+            error: formatErrorMessage(err),
+          });
+        }
         log.warn("sessions_send announce delivery failed", {
           runId: runContextId,
           channel: announceTarget.channel,
@@ -175,6 +282,19 @@ export async function runSessionsSendA2AFlow(params: {
       }
     }
   } catch (err) {
+    if (params.handoffId) {
+      await recordSessionsSendHandoffEvent({
+        handoffId: params.handoffId,
+        type: "failed",
+        status: "accepted",
+        runId: params.waitRunId,
+        requesterSessionKey: params.requesterSessionKey,
+        requesterChannel: params.requesterChannel,
+        targetSessionKey: params.targetSessionKey,
+        targetDisplayKey: params.displayKey,
+        error: formatErrorMessage(err),
+      });
+    }
     log.warn("sessions_send announce flow failed", {
       runId: runContextId,
       error: formatErrorMessage(err),

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -176,6 +176,23 @@ async function startAgentRun(params: {
   } catch (err) {
     const messageText =
       err instanceof Error ? err.message : typeof err === "string" ? err : "error";
+    const failedHandoff = params.handoff
+      ? buildSessionsSendHandoffAck({
+          id: params.handoff.id,
+          status: "rejected",
+          delivery: params.handoff.delivery,
+        })
+      : undefined;
+    if (failedHandoff) {
+      await recordSessionsSendHandoffEvent({
+        handoffId: failedHandoff.id,
+        type: "failed",
+        status: "rejected",
+        runId: params.runId,
+        targetDisplayKey: params.sessionKey,
+        error: messageText,
+      });
+    }
     return {
       ok: false,
       result: jsonResult({
@@ -183,7 +200,7 @@ async function startAgentRun(params: {
         status: "error",
         error: messageText,
         sessionKey: params.sessionKey,
-        ...(params.handoff ? { handoff: params.handoff } : {}),
+        ...(failedHandoff ? { handoff: failedHandoff } : {}),
       }),
     };
   }

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -41,6 +41,12 @@ import {
   resolveSessionToolContext,
   resolveVisibleSessionReference,
 } from "./sessions-helpers.js";
+import {
+  buildSessionsSendHandoffAck,
+  recordSessionsSendHandoffEvent,
+  type SessionsSendHandoffAck,
+  type SessionsSendHandoffDelivery,
+} from "./sessions-send-handoff.js";
 import { buildAgentToAgentMessageContext, resolvePingPongTurns } from "./sessions-send-helpers.js";
 import { runSessionsSendA2AFlow } from "./sessions-send-tool.a2a.js";
 
@@ -152,6 +158,7 @@ function isTerminalAgentWaitTimeout(result: AgentWaitResult): boolean {
 
 async function startAgentRun(params: {
   callGateway: GatewayCaller;
+  handoff?: SessionsSendHandoffAck;
   runId: string;
   sendParams: Record<string, unknown>;
   sessionKey: string;
@@ -176,6 +183,7 @@ async function startAgentRun(params: {
         status: "error",
         error: messageText,
         sessionKey: params.sessionKey,
+        ...(params.handoff ? { handoff: params.handoff } : {}),
       }),
     };
   }
@@ -357,14 +365,35 @@ export function createSessionsSendTool(opts?: {
       const timeoutMs = timeoutSeconds * 1000;
       const announceTimeoutMs = timeoutSeconds === 0 ? 30_000 : timeoutMs;
       const idempotencyKey = crypto.randomUUID();
+      const handoffId = crypto.randomUUID();
       let runId: string = idempotencyKey;
+      const skippedHandoffDelivery: SessionsSendHandoffDelivery = {
+        status: "skipped",
+        mode: "announce",
+      };
       if (parseSessionThreadInfoFast(resolvedKey).threadId) {
+        const handoff = buildSessionsSendHandoffAck({
+          id: handoffId,
+          status: "rejected",
+          delivery: skippedHandoffDelivery,
+        });
+        await recordSessionsSendHandoffEvent({
+          handoffId,
+          type: "rejected",
+          status: "rejected",
+          requesterSessionKey: effectiveRequesterKey,
+          requesterChannel: opts?.agentChannel,
+          targetSessionKey: resolvedKey,
+          targetDisplayKey: displayKey,
+          error: "thread_session_target",
+        });
         return jsonResult({
           runId: crypto.randomUUID(),
           status: "error",
           error:
             "sessions_send cannot target a thread session for inter-agent coordination. Use the parent channel session key instead.",
           sessionKey: displayKey,
+          handoff,
         });
       }
       const visibilityGuard = await createSessionVisibilityGuard({
@@ -375,11 +404,27 @@ export function createSessionsSendTool(opts?: {
       });
       const access = visibilityGuard.check(resolvedKey);
       if (!access.allowed) {
+        const handoff = buildSessionsSendHandoffAck({
+          id: handoffId,
+          status: "rejected",
+          delivery: skippedHandoffDelivery,
+        });
+        await recordSessionsSendHandoffEvent({
+          handoffId,
+          type: "rejected",
+          status: "rejected",
+          requesterSessionKey: effectiveRequesterKey,
+          requesterChannel: opts?.agentChannel,
+          targetSessionKey: resolvedKey,
+          targetDisplayKey: displayKey,
+          error: access.status,
+        });
         return jsonResult({
           runId: crypto.randomUUID(),
           status: access.status,
           error: access.error,
           sessionKey: displayKey,
+          handoff,
         });
       }
 
@@ -390,11 +435,27 @@ export function createSessionsSendTool(opts?: {
         mainKey,
       });
       if (!ensuredSession.ok) {
+        const handoff = buildSessionsSendHandoffAck({
+          id: handoffId,
+          status: "rejected",
+          delivery: skippedHandoffDelivery,
+        });
+        await recordSessionsSendHandoffEvent({
+          handoffId,
+          type: "rejected",
+          status: "rejected",
+          requesterSessionKey: effectiveRequesterKey,
+          requesterChannel: opts?.agentChannel,
+          targetSessionKey: resolvedKey,
+          targetDisplayKey: displayKey,
+          error: ensuredSession.error,
+        });
         return jsonResult({
           runId: crypto.randomUUID(),
           status: "error",
           error: ensuredSession.error,
           sessionKey: displayKey,
+          handoff,
         });
       }
 
@@ -472,6 +533,21 @@ export function createSessionsSendTool(opts?: {
       const delivery = skipA2AFlow
         ? ({ status: "skipped", mode: "announce" } as const)
         : ({ status: "pending", mode: "announce" } as const);
+      const handoff = buildSessionsSendHandoffAck({
+        id: handoffId,
+        status: "accepted",
+        delivery,
+      });
+
+      await recordSessionsSendHandoffEvent({
+        handoffId,
+        type: "created",
+        status: "queued",
+        requesterSessionKey: effectiveRequesterKey,
+        requesterChannel,
+        targetSessionKey: resolvedKey,
+        targetDisplayKey: displayKey,
+      });
 
       const startA2AFlow = (roundOneReply?: string, waitRunId?: string) => {
         if (skipA2AFlow) {
@@ -486,6 +562,7 @@ export function createSessionsSendTool(opts?: {
           requesterSessionKey,
           requesterChannel,
           baseline: baselineReply,
+          handoffId,
           roundOneReply,
           waitRunId,
         });
@@ -494,6 +571,7 @@ export function createSessionsSendTool(opts?: {
       if (timeoutSeconds === 0) {
         const start = await startAgentRun({
           callGateway: gatewayCall,
+          handoff,
           runId,
           sendParams,
           sessionKey: displayKey,
@@ -502,17 +580,29 @@ export function createSessionsSendTool(opts?: {
           return start.result;
         }
         runId = start.runId;
+        await recordSessionsSendHandoffEvent({
+          handoffId,
+          type: "accepted",
+          status: "accepted",
+          runId,
+          requesterSessionKey: effectiveRequesterKey,
+          requesterChannel,
+          targetSessionKey: resolvedKey,
+          targetDisplayKey: displayKey,
+        });
         startA2AFlow(undefined, runId);
         return jsonResult({
           runId,
           status: "accepted",
           sessionKey: displayKey,
           delivery,
+          handoff,
         });
       }
 
       const start = await startAgentRun({
         callGateway: gatewayCall,
+        handoff,
         runId,
         sendParams,
         sessionKey: displayKey,
@@ -521,6 +611,16 @@ export function createSessionsSendTool(opts?: {
         return start.result;
       }
       runId = start.runId;
+      await recordSessionsSendHandoffEvent({
+        handoffId,
+        type: "accepted",
+        status: "accepted",
+        runId,
+        requesterSessionKey: effectiveRequesterKey,
+        requesterChannel,
+        targetSessionKey: resolvedKey,
+        targetDisplayKey: displayKey,
+      });
       const result = await waitForAgentRunAndReadUpdatedAssistantReply({
         runId,
         sessionKey: resolvedKey,
@@ -538,21 +638,46 @@ export function createSessionsSendTool(opts?: {
             status: "accepted",
             sessionKey: displayKey,
             delivery,
+            handoff,
           });
         }
+        await recordSessionsSendHandoffEvent({
+          handoffId,
+          type: "failed",
+          status: "accepted",
+          runId,
+          requesterSessionKey: effectiveRequesterKey,
+          requesterChannel,
+          targetSessionKey: resolvedKey,
+          targetDisplayKey: displayKey,
+          error: result.error ?? "timeout",
+        });
         return jsonResult({
           runId,
           status: "timeout",
           error: result.error,
           sessionKey: displayKey,
+          handoff,
         });
       }
       if (result.status === "error") {
+        await recordSessionsSendHandoffEvent({
+          handoffId,
+          type: "failed",
+          status: "accepted",
+          runId,
+          requesterSessionKey: effectiveRequesterKey,
+          requesterChannel,
+          targetSessionKey: resolvedKey,
+          targetDisplayKey: displayKey,
+          error: result.error ?? "agent error",
+        });
         return jsonResult({
           runId,
           status: "error",
           error: result.error ?? "agent error",
           sessionKey: displayKey,
+          handoff,
         });
       }
       const reply = result.replyText;
@@ -564,6 +689,7 @@ export function createSessionsSendTool(opts?: {
         reply,
         sessionKey: displayKey,
         delivery,
+        handoff,
       });
     },
   };

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -885,4 +885,53 @@ describe("sessions_send gating", () => {
     expect(entries.map((entry) => entry.type)).toContain("accepted");
     expect(entries.every((entry) => entry.handoffId === handoff.id)).toBe(true);
   });
+
+  it("returns a rejected handoff and terminal ledger event when target start fails", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-handoff-start-fail-"));
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    const tool = createMainSessionsSendTool();
+
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "sessions.list") {
+        return {
+          path: "/tmp/sessions.json",
+          sessions: [{ key: MAIN_AGENT_SESSION_KEY, kind: "direct" }],
+        };
+      }
+      if (request.method === "chat.history") {
+        return { messages: [] };
+      }
+      if (request.method === "agent") {
+        throw new Error("target start failed");
+      }
+      return {};
+    });
+
+    const result = await tool.execute("call-handoff-start-fail", {
+      sessionKey: MAIN_AGENT_SESSION_KEY,
+      message: "ping",
+      timeoutSeconds: 1,
+    });
+
+    const details = requireDetails(result);
+    expect(details.status).toBe("error");
+    expect(details.error).toBe("target start failed");
+    const handoff = requireRecord(details.handoff, "handoff");
+    expect(handoff.status).toBe("rejected");
+    expect(handoff.delivery).toEqual({ status: "pending", mode: "announce" });
+
+    const rawLedger = await fs.readFile(resolveSessionsSendHandoffLedgerPath(), "utf-8");
+    const entries = rawLedger
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(entries.map((entry) => entry.type)).toEqual(["created", "failed"]);
+    expect(entries.at(-1)).toMatchObject({
+      handoffId: handoff.id,
+      type: "failed",
+      status: "rejected",
+      error: "target start failed",
+    });
+  });
 });

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -1,9 +1,11 @@
+import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ChannelMessagingAdapter } from "../../channels/plugins/types.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { extractAssistantText, sanitizeTextContent } from "./sessions-helpers.js";
+import { resolveSessionsSendHandoffLedgerPath } from "./sessions-send-handoff.js";
 
 const callGatewayMock = vi.fn();
 vi.mock("../../gateway/call.js", () => ({
@@ -235,6 +237,10 @@ describe("sanitizeTextContent", () => {
 });
 
 beforeEach(() => {
+  vi.stubEnv(
+    "OPENCLAW_STATE_DIR",
+    path.join(os.tmpdir(), "openclaw-sessions-tools-test", String(process.pid)),
+  );
   loadConfigMock.mockReset();
   loadConfigMock.mockReturnValue({
     session: { scope: "per-sender", mainKey: "main" },
@@ -830,5 +836,53 @@ describe("sessions_send gating", () => {
     expect(details.status).toBe("ok");
     expect(details.reply).toBeUndefined();
     expect(details.sessionKey).toBe(MAIN_AGENT_SESSION_KEY);
+  });
+
+  it("returns a structured handoff acknowledgement and ledger for accepted sends", async () => {
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-handoff-ack-"));
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    const tool = createMainSessionsSendTool();
+
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "sessions.list") {
+        return {
+          path: "/tmp/sessions.json",
+          sessions: [{ key: MAIN_AGENT_SESSION_KEY, kind: "direct" }],
+        };
+      }
+      if (request.method === "agent") {
+        return { runId: "run-handoff-send", acceptedAt: 123 };
+      }
+      if (request.method === "agent.wait") {
+        return { runId: "run-handoff-send", status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        return { messages: [] };
+      }
+      return {};
+    });
+
+    const result = await tool.execute("call-handoff-send", {
+      sessionKey: MAIN_AGENT_SESSION_KEY,
+      message: "ping",
+      timeoutSeconds: 1,
+    });
+
+    const details = requireDetails(result);
+    const handoff = requireRecord(details.handoff, "handoff");
+    expect(handoff.id).toEqual(expect.any(String));
+    expect(handoff.status).toBe("accepted");
+    expect(handoff.delivery).toEqual({ status: "pending", mode: "announce" });
+    expect(handoff.ledger).toEqual({ path: "handoffs/sessions-send.jsonl" });
+
+    const rawLedger = await fs.readFile(resolveSessionsSendHandoffLedgerPath(), "utf-8");
+    const entries = rawLedger
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(entries.map((entry) => entry.type)).toContain("created");
+    expect(entries.map((entry) => entry.type)).toContain("accepted");
+    expect(entries.every((entry) => entry.handoffId === handoff.id)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Implements the Phase 1 A2A handoff acknowledgement contract for `sessions_send`.

This builds on the existing handoff proposal work by adding:

- stable handoff ids for resolved `sessions_send` agent-to-agent delivery
- structured `handoff` acknowledgement data in the `sessions_send` result
- best-effort append-only handoff ledger records
- control-only outcome recording for `NO_REPLY`, `REPLY_SKIP`, `ANNOUNCE_SKIP`, and `HEARTBEAT_OK`
- focused docs for the Phase 1 transport/acknowledgement boundary

This intentionally does not add a meeting lifecycle, durable work queue, retry engine, dashboard, or higher-level workflow state machine.

## Validation

Focused tests:

```bash
pnpm exec vitest run src/agents/tools/sessions-send-tool.a2a.test.ts src/agents/tools/sessions.test.ts
```

Result:

- 4 test files passed
- 88 tests passed

## Notes

This branch is intended as a standalone implementation proposal and should not be mixed into production owned-package hotfix branches.

## Real behavior proof

- Behavior or issue addressed: A `sessions_send` handoff whose target agent start fails must not report `handoff.status: "accepted"`; it should return a rejected handoff and append a terminal failed ledger event.
- Real environment tested: Local macOS source worktree `/tmp/openclaw-pr83094`, Node v25.8.1, branch `proposal/a2a-handoff-phase1-impl`, commit `b2eb2ed3754`.
- Exact steps or command run after this patch:

```bash
node scripts/run-vitest.mjs src/agents/tools/sessions.test.ts src/agents/tools/sessions-send-tool.a2a.test.ts
git diff --check HEAD
```

- Evidence after fix (terminal capture):

```text
Test Files  4 passed (4)
Tests       90 passed (90)
New regression scenario: target `agent` call throws "target start failed".
Observed result details: top-level status is "error", handoff.status is "rejected", and handoff ledger events are ["created", "failed"] with the final event status "rejected" and error "target start failed".
```

- Observed result after fix: The failed target-start path now returns a non-accepted handoff acknowledgement and records a terminal `failed` ledger event, so callers and recovery tooling can distinguish an unaccepted handoff from an accepted/ongoing handoff.
- What was not tested: A live multi-agent gateway run was not exercised in this local pass; this proof covers the changed runtime branch and local state ledger behavior in the source worktree.
