### PR TITLE
fix(canvas): prefer path-scoped capability tokens

### DIFF
--- a/extensions/canvas/src/host/a2ui-shared.ts
+++ b/extensions/canvas/src/host/a2ui-shared.ts
@@ -54,9 +54,8 @@ export function injectCanvasLiveReload(html: string): string {
   try {
     const pathCap = (() => {
       const prefix = "/__openclaw__/cap/";
-      const idx = location.pathname.indexOf(prefix);
-      if (idx < 0) return "";
-      const rest = location.pathname.slice(idx + prefix.length);
+      if (!location.pathname.startsWith(prefix)) return "";
+      const rest = location.pathname.slice(prefix.length);
       const slash = rest.indexOf("/");
       if (slash <= 0) return "";
       try {

--- a/extensions/canvas/src/host/a2ui-shared.ts
+++ b/extensions/canvas/src/host/a2ui-shared.ts
@@ -52,7 +52,20 @@ export function injectCanvasLiveReload(html: string): string {
   globalThis.openclawSendUserAction = sendUserAction;
 
   try {
-    const cap = new URLSearchParams(location.search).get("oc_cap");
+    const pathCap = (() => {
+      const prefix = "/__openclaw__/cap/";
+      const idx = location.pathname.indexOf(prefix);
+      if (idx < 0) return "";
+      const rest = location.pathname.slice(idx + prefix.length);
+      const slash = rest.indexOf("/");
+      if (slash <= 0) return "";
+      try {
+        return decodeURIComponent(rest.slice(0, slash));
+      } catch {
+        return "";
+      }
+    })();
+    const cap = pathCap || new URLSearchParams(location.search).get("oc_cap");
     const proto = location.protocol === "https:" ? "wss" : "ws";
     const capQuery = cap ? "?oc_cap=" + encodeURIComponent(cap) : "";
     const ws = new WebSocket(proto + "://" + location.host + ${JSON.stringify(CANVAS_WS_PATH)} + capQuery);

--- a/extensions/canvas/src/host/server.test.ts
+++ b/extensions/canvas/src/host/server.test.ts
@@ -177,6 +177,8 @@ describe("canvas host", () => {
   it("injects live reload script", () => {
     const out = injectCanvasLiveReload("<html><body>Hello</body></html>");
     expect(out).toContain(CANVAS_WS_PATH);
+    expect(out).toContain("/__openclaw__/cap/");
+    expect(out).toContain("const cap = pathCap || new URLSearchParams(location.search).get");
     expect(out).toContain("location.reload");
     expect(out).toContain("openclawCanvasA2UIAction");
     expect(out).toContain("openclawSendUserAction");

--- a/extensions/canvas/src/host/server.test.ts
+++ b/extensions/canvas/src/host/server.test.ts
@@ -178,6 +178,8 @@ describe("canvas host", () => {
     const out = injectCanvasLiveReload("<html><body>Hello</body></html>");
     expect(out).toContain(CANVAS_WS_PATH);
     expect(out).toContain("/__openclaw__/cap/");
+    expect(out).toContain("location.pathname.startsWith(prefix)");
+    expect(out).not.toContain("location.pathname.indexOf(prefix)");
     expect(out).toContain("const cap = pathCap || new URLSearchParams(location.search).get");
     expect(out).toContain("location.reload");
     expect(out).toContain("openclawCanvasA2UIAction");

--- a/src/gateway/plugin-node-capability.test.ts
+++ b/src/gateway/plugin-node-capability.test.ts
@@ -54,6 +54,19 @@ describe("plugin node capability helpers", () => {
     });
   });
 
+  test("path-scoped capabilities override stale query capabilities", () => {
+    const normalized = normalizePluginNodeCapabilityScopedUrl(
+      "/__openclaw__/cap/current-token/__openclaw__/canvas/?oc_cap=stale-token&download=1",
+    );
+    expect(normalized).toEqual({
+      pathname: "/__openclaw__/canvas/",
+      capability: "current-token",
+      rewrittenUrl: "/__openclaw__/canvas/?oc_cap=current-token&download=1",
+      scopedPath: true,
+      malformedScopedPath: false,
+    });
+  });
+
   test("replaces scoped capability tokens without nesting capability prefixes", () => {
     expect(
       replacePluginNodeCapabilityInScopedHostUrl(

--- a/src/gateway/plugin-node-capability.ts
+++ b/src/gateway/plugin-node-capability.ts
@@ -166,9 +166,7 @@ export function normalizePluginNodeCapabilityScopedUrl(
         malformedScopedPath = true;
       } else {
         url.pathname = canonicalPath;
-        if (!url.searchParams.has(PLUGIN_NODE_CAPABILITY_QUERY_PARAM)) {
-          url.searchParams.set(PLUGIN_NODE_CAPABILITY_QUERY_PARAM, capabilityFromPath);
-        }
+        url.searchParams.set(PLUGIN_NODE_CAPABILITY_QUERY_PARAM, capabilityFromPath);
         rewrittenUrl = `${url.pathname}${url.search}`;
       }
     }


### PR DESCRIPTION
## Summary

- Problem: Canvas path-scoped capability URLs could keep a stale `oc_cap` query parameter after Gateway URL normalization.
- Solution: make the path-scoped capability token authoritative when both path and query tokens are present.
- What changed: Gateway normalization now overwrites stale query-string `oc_cap` values with the path token, and injected Canvas live-reload code reads a scoped path token before falling back to the query string.
- What did NOT change (scope boundary): capability minting, TTLs, route authorization, Canvas file serving, and the node-host Canvas implementation are unchanged.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes: N/A
- Related: N/A
- [x] This PR fixes a bug or regression

## Motivation

Canvas pages can be opened through path-scoped capability URLs. If the same URL also carries an older `oc_cap` query parameter, Gateway HTTP handling and the injected live-reload WebSocket path can disagree about which token is current. The path-scoped token is the scoped authority in that URL shape, so it should replace stale query fallback state consistently.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Canvas capability handling now prefers the current path-scoped token over a stale query-string `oc_cap`.
- Real environment tested: local macOS development checkout, branch `canvas-capability`, head `c577a4d3cc`.
- Exact steps or command run after this patch:
  - Started a real local Canvas host with live reload enabled.
  - Normalized a path-scoped Canvas URL with a conflicting stale query token using the Gateway capability normalizer.
  - Fetched the rewritten Canvas URL from the local Canvas host.
  - Confirmed the served HTML includes the injected path-token parser and path-first fallback.
  - `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/plugin-node-capability.test.ts`
  - `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts extensions/canvas/src/host/server.test.ts`
  - `./node_modules/.bin/oxfmt --check extensions/canvas/src/host/a2ui-shared.ts extensions/canvas/src/host/server.test.ts src/gateway/plugin-node-capability.ts src/gateway/plugin-node-capability.test.ts`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): copied local Canvas host and normalizer output:

```text
[runtime] canvas host listening on http://127.0.0.1:<port> (root <temp-canvas-root>)
[proof] normalized capability=current-token
[proof] normalized pathname=/__openclaw__/canvas/
[proof] rewritten url=/__openclaw__/canvas/?oc_cap=current-token&download=1
[proof] canvas http status=200
[proof] served canvas body=present
[proof] injected path capability parser=present
[proof] injected path-first fallback=present
```

- Observed result after fix: a request path shaped like `/__openclaw__/cap/current-token/__openclaw__/canvas/?oc_cap=stale-token&download=1` normalizes to capability `current-token`; the rewritten Canvas URL carries `oc_cap=current-token`, not the stale query token; the live Canvas host serves the rewritten Canvas URL successfully; the injected live-reload script reads the scoped path token before query-string fallback.
- What was not tested: full browser WebSocket live-reload round trip. The proof used the real Canvas host HTTP path and the Gateway capability normalizer, then verified the injected live-reload script in the served HTML.
- Before evidence (optional but encouraged): before this change, URL normalization preserved an existing stale `oc_cap` query value even when the path-scoped token was newer.

## Root Cause

- Root cause: scoped capability URL normalization only added `oc_cap` when the query parameter was absent, and the injected Canvas script only read `oc_cap` from `location.search`.
- Missing detection / guardrail: there was no regression test for path-scoped capability URLs that also contain a stale query-string token.
- Contributing context: path-scoped URLs and query-string fallback both exist for compatibility, but the path-scoped token is the current scoped authority.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/gateway/plugin-node-capability.test.ts`
  - `extensions/canvas/src/host/server.test.ts`
- Scenario the test locks in: a path-scoped capability token replaces a stale `oc_cap` query token, and injected Canvas live-reload code reads the path token before query fallback.
- Why this is the smallest reliable guardrail: the changed behavior is local to URL normalization and Canvas live-reload injection.
- Existing test that already covers this: none before this PR.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Canvas pages served from path-scoped capability URLs keep HTTP and live-reload WebSocket capability handling aligned when a stale `oc_cap` query parameter is present.

## Diagram

```text
Before:
/__openclaw__/cap/current-token/__openclaw__/canvas/?oc_cap=stale-token
  -> /__openclaw__/canvas/?oc_cap=stale-token

After:
/__openclaw__/cap/current-token/__openclaw__/canvas/?oc_cap=stale-token
  -> /__openclaw__/canvas/?oc_cap=current-token
```

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local development checkout
- Model/provider: N/A
- Integration/channel: Canvas extension
- Relevant config: temporary local Canvas host root and loopback HTTP port

### Steps

1. Start a local Canvas host with live reload enabled.
2. Normalize a path-scoped Canvas URL containing both `current-token` in the path and `stale-token` in `oc_cap`.
3. Fetch the rewritten Canvas URL from the local Canvas host.
4. Verify the served HTML includes the path-token parser and path-first fallback.
5. Run targeted regression tests and formatting checks.

### Expected

- The path-scoped token is authoritative.
- The rewritten URL uses `oc_cap=current-token`.
- The injected live-reload script reads the path-scoped token before query fallback.

### Actual

- Matches expected in the local Canvas host proof and targeted regression tests.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers

## Human Verification

- Verified scenarios: stale query token is replaced by the path token; local Canvas host serves the rewritten URL; injected live-reload script includes the path-token parser and path-first fallback.
- Edge cases checked: stale query token plus an unrelated query parameter; scoped path parsing only runs for pathnames starting with `/__openclaw__/cap/`.
- What was not verified: full browser WebSocket live-reload round trip.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a URL with both a path-scoped token and a query token now treats the path token as authoritative.
  - Mitigation: this matches the scoped URL structure and only affects conflicting duplicated capability tokens.
