### PR TITLE
fix(update): tailor gateway recovery hints by platform

### DIFF
--- a/src/cli/update-cli/update-command.test.ts
+++ b/src/cli/update-cli/update-command.test.ts
@@ -6,9 +6,11 @@ import {
   buildGatewayInstallEntrypointCandidates as resolveGatewayInstallEntrypointCandidates,
   resolveGatewayInstallEntrypoint,
 } from "../../daemon/gateway-entrypoint.js";
+import type { UpdateRunResult } from "../../infra/update-runner.js";
 import {
   buildInvalidConfigPostCoreUpdateResult,
   collectMissingPluginInstallPayloads,
+  formatPostUpdateGatewayRecoveryInstructions,
   recoverInstalledLaunchAgentAfterUpdate,
   recoverLaunchAgentAndRecheckGatewayHealth,
   resolvePostCoreUpdateChildStdio,
@@ -348,6 +350,52 @@ describe("shouldUseLegacyProcessRestartAfterUpdate", () => {
     expect(shouldUseLegacyProcessRestartAfterUpdate({ updateMode: "unknown" })).toBe(true);
   });
 });
+
+describe("formatPostUpdateGatewayRecoveryInstructions", () => {
+  const result: UpdateRunResult = {
+    status: "error",
+    mode: "git",
+    steps: [],
+    durationMs: 0,
+  };
+
+  it("uses systemd wording on Linux instead of macOS LaunchAgent instructions", () => {
+    const [line] = formatPostUpdateGatewayRecoveryInstructions(result, "linux");
+
+    expect(line).toContain("the systemd user service");
+    expect(line).toContain("openclaw gateway restart");
+    expect(line).toContain("openclaw gateway install --force");
+    expect(line).toContain("openclaw gateway status --deep");
+    expect(line).not.toContain("Linux reports");
+    expect(line).not.toContain("macOS");
+    expect(line).not.toContain("LaunchAgent");
+  });
+
+  it("keeps LaunchAgent recovery wording on macOS", () => {
+    const [line] = formatPostUpdateGatewayRecoveryInstructions(result, "darwin");
+
+    expect(line).toContain("the LaunchAgent is installed but not loaded");
+    expect(line).toContain("logged-in macOS user session");
+  });
+
+  it("uses Windows service-manager wording on Windows", () => {
+    const [line] = formatPostUpdateGatewayRecoveryInstructions(result, "win32");
+
+    expect(line).toContain("the gateway Scheduled Task or Windows login item");
+    expect(line).not.toContain("LaunchAgent");
+    expect(line).not.toContain("Startup-folder");
+  });
+
+  it("uses generic service-manager wording for unsupported Node platforms", () => {
+    const [line] = formatPostUpdateGatewayRecoveryInstructions(result, "freebsd");
+
+    expect(line).toContain("local service manager");
+    expect(line).not.toContain("systemd");
+    expect(line).not.toContain("LaunchAgent");
+    expect(line).not.toContain("Scheduled Task");
+  });
+});
+
 describe("recoverInstalledLaunchAgentAfterUpdate", () => {
   it("re-bootstraps an installed-but-not-loaded macOS LaunchAgent after update", async () => {
     const service = {} as never;

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -702,10 +702,33 @@ export async function recoverLaunchAgentAndRecheckGatewayHealth(params: {
   return { health, launchAgentRecovery };
 }
 
-function formatPostUpdateGatewayRecoveryInstructions(result: UpdateRunResult): string[] {
-  const lines = [
-    `Recovery: run \`${replaceCliName(formatCliCommand("openclaw gateway restart"), CLI_NAME)}\`; if macOS reports the LaunchAgent is installed but not loaded, run \`${replaceCliName(formatCliCommand("openclaw gateway install --force"), CLI_NAME)}\` from the logged-in user session, then rerun \`${replaceCliName(formatCliCommand("openclaw gateway status --deep"), CLI_NAME)}\`.`,
-  ];
+function formatPostUpdateGatewayRecoveryLine(platform: NodeJS.Platform): string {
+  const restartCommand = replaceCliName(formatCliCommand("openclaw gateway restart"), CLI_NAME);
+  const installCommand = replaceCliName(
+    formatCliCommand("openclaw gateway install --force"),
+    CLI_NAME,
+  );
+  const statusCommand = replaceCliName(
+    formatCliCommand("openclaw gateway status --deep"),
+    CLI_NAME,
+  );
+  if (platform === "darwin") {
+    return `Recovery: run \`${restartCommand}\`; if the LaunchAgent is installed but not loaded, run \`${installCommand}\` from the logged-in macOS user session, then rerun \`${statusCommand}\`.`;
+  }
+  if (platform === "linux") {
+    return `Recovery: run \`${restartCommand}\`; if the systemd user service is missing, stale, or not active, run \`${installCommand}\` from the same user account, then rerun \`${statusCommand}\`.`;
+  }
+  if (platform === "win32") {
+    return `Recovery: run \`${restartCommand}\`; if the gateway Scheduled Task or Windows login item is missing, stale, or not running, run \`${installCommand}\` from the same user account, then rerun \`${statusCommand}\`.`;
+  }
+  return `Recovery: run \`${restartCommand}\`; if the local service manager reports the gateway service is missing, stale, or not running, run \`${installCommand}\` from the same user account, then rerun \`${statusCommand}\`.`;
+}
+
+export function formatPostUpdateGatewayRecoveryInstructions(
+  result: UpdateRunResult,
+  platform: NodeJS.Platform = process.platform,
+): string[] {
+  const lines = [formatPostUpdateGatewayRecoveryLine(platform)];
   const beforeVersion = normalizeOptionalString(result.before?.version);
   if (isPackageManagerUpdateMode(result.mode) && beforeVersion) {
     lines.push(


### PR DESCRIPTION
## Summary

- Problem: `openclaw update` could print macOS LaunchAgent recovery advice after a failed gateway restart even on Linux/Ubuntu systems.
- Why it matters: Ubuntu VPS operators need recovery steps that match the actual service manager instead of misleading macOS-only instructions.
- What changed: post-update gateway recovery guidance now formats the recovery sentence by platform: Linux systemd user service, macOS LaunchAgent, Windows Scheduled Task / Startup-folder item, or generic local service manager.
- What did NOT change (scope boundary): no gateway restart behavior, service installation behavior, rollback behavior, config surface, or update flow was changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Linux post-update gateway recovery guidance no longer mentions macOS LaunchAgent recovery.
- Real environment tested: Linux PR worktree at `a7d36d23c0e4855b906940f4bd92464e33a738e9`; `uname -a` reported `Linux rubencu-devbox 6.8.0-90-generic #91-Ubuntu SMP PREEMPT_DYNAMIC Tue Nov 18 14:14:30 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux`.
- Exact steps or command run after this patch: `node_modules/.bin/tsx -e 'import { formatPostUpdateGatewayRecoveryInstructions } from "./src/cli/update-cli/update-command.ts"; const result = { status: "error", mode: "git", root: process.cwd(), steps: [], durationMs: 0 }; console.log(formatPostUpdateGatewayRecoveryInstructions(result, "linux").join("\\n"));'`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): terminal output from the exact PR head:

```text
Recovery: run `openclaw gateway restart`; if the systemd user service is missing, stale, or not active, run `openclaw gateway install --force` from the same user account, then rerun `openclaw gateway status --deep`.
```

- Observed result after fix: the copied live output names the systemd user service, and it does not include `Linux reports`, `macOS`, or `LaunchAgent`.
- What was not tested: full package update plus forced gateway health failure on a production Ubuntu VPS; the proof uses the production recovery formatter at the PR head to avoid mutating a real managed gateway install.
- Before evidence (optional but encouraged): the pre-patch formatter had a single hard-coded recovery sentence: `Recovery: run ...; if macOS reports the LaunchAgent is installed but not loaded, run ...`.

## Root Cause (if applicable)

- Root cause: `formatPostUpdateGatewayRecoveryInstructions` used one hard-coded macOS recovery sentence for all platforms.
- Missing detection / guardrail: there was no focused test for Linux recovery text in the post-update gateway restart failure path.
- Contributing context (if known): update restart recovery already had platform-specific service managers, but this final user-visible recovery sentence did not use that platform contract.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cli/update-cli/update-command.test.ts`
- Scenario the test should lock in: Linux recovery guidance mentions the systemd user service and excludes macOS/LaunchAgent wording; macOS and Windows wording remain platform-specific.
- Why this is the smallest reliable guardrail: the bug is isolated to recovery instruction formatting, and the existing update-command test file already covers nearby update restart helpers.
- Existing test that already covers this (if any): none for the platform-specific recovery sentence before this PR.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Failed post-update gateway restart diagnostics now show OS-appropriate recovery guidance. No new config surface.

## Diagram (if applicable)

N/A

```text
Before:
[Linux update restart failure] -> [macOS LaunchAgent recovery hint]

After:
[Linux update restart failure] -> [Linux systemd user service recovery hint]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux Ubuntu devbox (`6.8.0-90-generic`)
- Runtime/container: Node 22+ repo dev environment, `pnpm install` completed in the PR worktree
- Model/provider: N/A
- Integration/channel (if any): Gateway update CLI recovery text
- Relevant config (redacted): default local environment; no secrets used

### Steps

1. From the PR worktree, invoke the production recovery formatter for `platform: "linux"` with `node_modules/.bin/tsx`.
2. Run the focused update-command Vitest file.
3. Run formatting and diff whitespace checks.
4. Run `codex review --base origin/main` after the patch and again before publishing.

### Expected

- Linux recovery output references Linux/systemd user service recovery and does not mention macOS LaunchAgent.

### Actual

- Linux recovery output references Linux/systemd user service recovery and does not mention macOS LaunchAgent.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verification commands run:

```text
pnpm docs:list
pnpm install
node scripts/run-vitest.mjs src/cli/update-cli/update-command.test.ts
node_modules/.bin/oxfmt --check --threads=1 src/cli/update-cli/update-command.ts src/cli/update-cli/update-command.test.ts
git diff --check
node_modules/.bin/tsx -e 'import { formatPostUpdateGatewayRecoveryInstructions } from "./src/cli/update-cli/update-command.ts"; const result = { status: "error", mode: "git", root: process.cwd(), steps: [], durationMs: 0 }; console.log(formatPostUpdateGatewayRecoveryInstructions(result, "linux").join("\\n"));'
codex review --base origin/main
```

Focused Vitest result: `Test Files 1 passed (1)`, `Tests 30 passed (30)`.

Local Codex review result: no actionable correctness issues found; the final review noted that the platform-specific recovery wording preserves rollback behavior and is covered by the focused tests.

Broad validation: GitHub PR CI.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Linux recovery formatter output from the exact PR head; focused update-command regression tests; formatting and diff whitespace checks; local Codex review against `origin/main`.
- Edge cases checked: Linux wording excludes macOS/LaunchAgent; macOS keeps LaunchAgent guidance; Windows mentions Scheduled Task / Startup-folder item.
- What you did **not** verify: full package update plus forced gateway health failure on a production Ubuntu VPS. Owner final manual verification happens outside this agent run.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Recovery instructions could drift from actual service-manager names.
  - Mitigation: wording now follows the platform contract used by the gateway service registry, and tests pin Linux/macOS/Windows text.


