### PR TITLE
fix(slack): normalize trust metadata for external system events

### DIFF
--- a/extensions/slack/src/monitor/events/interactions.modal.ts
+++ b/extensions/slack/src/monitor/events/interactions.modal.ts
@@ -398,6 +398,8 @@ async function emitSlackModalLifecycleEvent(params: {
   enqueueSystemEvent(params.formatSystemEvent({ ...eventPayload, ...pluginEventFields }), {
     sessionKey: sessionRouting.sessionKey,
     contextKey: [params.contextPrefix, callbackId, viewId, userId].filter(Boolean).join(":"),
+    forceSenderIsOwnerFalse: true,
+    trusted: false,
   });
 }
 

--- a/extensions/slack/src/monitor/events/interactions.test.ts
+++ b/extensions/slack/src/monitor/events/interactions.test.ts
@@ -2831,7 +2831,7 @@ describe("registerSlackInteractionEvents", () => {
     const options = requireRecord(
       mockCallArg(enqueueSystemEventMock, 0, "enqueueSystemEvent", 1),
       "enqueueSystemEvent options",
-    ) as { sessionKey?: string };
+    ) as { forceSenderIsOwnerFalse?: boolean; sessionKey?: string; trusted?: boolean };
     const payload = JSON.parse(eventText.replace("Slack interaction: ", "")) as {
       interactionType: string;
       actionId: string;
@@ -2866,6 +2866,8 @@ describe("registerSlackInteractionEvents", () => {
         .selectedValues,
     ).toEqual(["canary"]);
     expect(trackEvent).toHaveBeenCalledTimes(1);
+    expect(options.forceSenderIsOwnerFalse).toBe(true);
+    expect(options.trusted).toBe(false);
     expect(options.sessionKey).toBe("agent:main:slack:channel:C99");
   });
 

--- a/extensions/slack/src/monitor/events/members.test.ts
+++ b/extensions/slack/src/monitor/events/members.test.ts
@@ -141,4 +141,14 @@ describe("registerSlackMemberEvents", () => {
 
     expect(trackEvent).toHaveBeenCalledTimes(1);
   });
+
+  it("downgrades Slack member system events from owner authority", async () => {
+    await runMemberCase({ overrides: { dmPolicy: "open" } });
+
+    expect(memberMocks.enqueue).toHaveBeenCalledTimes(1);
+    expect(memberMocks.enqueue.mock.calls[0]?.[1]).toMatchObject({
+      forceSenderIsOwnerFalse: true,
+      trusted: false,
+    });
+  });
 });

--- a/extensions/slack/src/monitor/events/members.ts
+++ b/extensions/slack/src/monitor/events/members.ts
@@ -41,6 +41,8 @@ export function registerSlackMemberEvents(params: {
       enqueueSystemEvent(`Slack: ${userLabel} ${params.verb} ${ingressContext.channelLabel}.`, {
         sessionKey: ingressContext.sessionKey,
         contextKey: `slack:member:${params.verb}:${channelId ?? "unknown"}:${payload.user ?? "unknown"}`,
+        forceSenderIsOwnerFalse: true,
+        trusted: false,
       });
     } catch (err) {
       ctx.runtime.error?.(

--- a/extensions/slack/src/monitor/events/messages.test.ts
+++ b/extensions/slack/src/monitor/events/messages.test.ts
@@ -204,6 +204,19 @@ describe("registerSlackMessageEvents", () => {
     expect(messageQueueMock).toHaveBeenCalledTimes(calls);
   });
 
+  it("downgrades Slack message subtype system events from owner authority", async () => {
+    await runMessageCase({
+      overrides: { dmPolicy: "open" },
+      event: makeChangedEvent(),
+    });
+
+    expect(messageQueueMock).toHaveBeenCalledTimes(1);
+    expect(messageQueueMock.mock.calls[0]?.[1]).toMatchObject({
+      forceSenderIsOwnerFalse: true,
+      trusted: false,
+    });
+  });
+
   it("passes regular message events to the message handler", async () => {
     const { handleSlackMessage } = await invokeRegisteredHandler({
       eventName: "message",

--- a/extensions/slack/src/monitor/events/messages.ts
+++ b/extensions/slack/src/monitor/events/messages.ts
@@ -187,6 +187,8 @@ export function registerSlackMessageEvents(params: {
         enqueueSystemEvent(subtypeHandler.describe(ingressContext.channelLabel), {
           sessionKey: ingressContext.sessionKey,
           contextKey: subtypeHandler.contextKey(message),
+          forceSenderIsOwnerFalse: true,
+          trusted: false,
         });
         return;
       }

--- a/extensions/slack/src/monitor/events/pins.test.ts
+++ b/extensions/slack/src/monitor/events/pins.test.ts
@@ -144,4 +144,14 @@ describe("registerSlackPinEvents", () => {
 
     expect(trackEvent).toHaveBeenCalledTimes(1);
   });
+
+  it("downgrades Slack pin system events from owner authority", async () => {
+    await runPinCase({ overrides: { dmPolicy: "open" } });
+
+    expect(pinEnqueueMock).toHaveBeenCalledTimes(1);
+    expect(pinEnqueueMock.mock.calls[0]?.[1]).toMatchObject({
+      forceSenderIsOwnerFalse: true,
+      trusted: false,
+    });
+  });
 });

--- a/extensions/slack/src/monitor/events/pins.ts
+++ b/extensions/slack/src/monitor/events/pins.ts
@@ -43,6 +43,8 @@ async function handleSlackPinEvent(params: {
       {
         sessionKey: ingressContext.sessionKey,
         contextKey: `slack:pin:${contextKeySuffix}:${channelId ?? "unknown"}:${messageId ?? "unknown"}`,
+        forceSenderIsOwnerFalse: true,
+        trusted: false,
       },
     );
   } catch (err) {


### PR DESCRIPTION
## Summary

- Problem: several Slack event-family handlers enqueue external workspace events without the same explicit non-owner trust metadata used by adjacent Slack handlers.
- Why it matters: member, pin, message subtype, and modal lifecycle events originate outside the local operator context, so their queued system events should carry consistent provenance metadata.
- What changed: add `forceSenderIsOwnerFalse: true` and `trusted: false` to those Slack system-event enqueue paths.
- What did NOT change (scope boundary): Slack routing, Slack authentication, channel policy, event text formatting, and system-event delivery behavior are unchanged.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes: N/A
- Related: N/A
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Slack-originated system events now carry explicit non-owner trust metadata consistently across member, pin, message subtype, and modal lifecycle paths.
- Real environment tested: local macOS development checkout, branch `slack-trust-metadata`, commit `a58360bb461f09637cb5080477f35a15d430040e`.
- Exact steps or command run after this patch:
  - Invoked the real Slack member, pin, and message subtype handlers through the Slack monitor event registration path with a local handler harness.
  - Inspected the queued OpenClaw system-event entries after each handler invocation.
  - Ran targeted Slack regression tests:
    - `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-slack.config.ts extensions/slack/src/monitor/events/members.test.ts extensions/slack/src/monitor/events/pins.test.ts extensions/slack/src/monitor/events/messages.test.ts extensions/slack/src/monitor/events/interactions.test.ts`
  - Ran formatting check:
    - `./node_modules/.bin/oxfmt --check extensions/slack/src/monitor/events/members.ts extensions/slack/src/monitor/events/members.test.ts extensions/slack/src/monitor/events/pins.ts extensions/slack/src/monitor/events/pins.test.ts extensions/slack/src/monitor/events/messages.ts extensions/slack/src/monitor/events/messages.test.ts extensions/slack/src/monitor/events/interactions.modal.ts extensions/slack/src/monitor/events/interactions.test.ts`
- Evidence after fix:

```text
[proof] member_joined_channel: text=Slack: alice joined #direct.
[proof] member_joined_channel: forceSenderIsOwnerFalse=true contextKey=slack:member:joined:d1:u1
[proof] pin_added: text=Slack: alice pinned a message in #direct.
[proof] pin_added: forceSenderIsOwnerFalse=true contextKey=slack:pin:added:d1:123.456
[proof] message_changed: text=Slack message edited in #direct.
[proof] message_changed: forceSenderIsOwnerFalse=true contextKey=slack:message:changed:d1:123.456
[proof] queued events=3
```

- Observed result after fix:
  - Accepted Slack member events enqueue system events with `forceSenderIsOwnerFalse=true`.
  - Accepted Slack pin events enqueue system events with `forceSenderIsOwnerFalse=true`.
  - Accepted Slack message subtype events enqueue system events with `forceSenderIsOwnerFalse=true`.
  - Regression coverage also asserts the modal lifecycle enqueue options include `forceSenderIsOwnerFalse: true` and `trusted: false`.
- What was not tested: live Slack workspace delivery. The proof used the real Slack monitor event handlers with a local handler harness and inspected the resulting OpenClaw system-event queue.
- Before evidence (optional but encouraged): before this change, these Slack event-family handlers passed `sessionKey` and `contextKey` but did not explicitly pass the non-owner trust metadata used by nearby Slack channel, reaction, and block-action handlers.

## Root Cause

- Root cause: these Slack event families were added without the explicit trust metadata already used by nearby Slack channel, reaction, and block-action system events.
- Missing detection / guardrail: tests covered event enqueueing behavior, but did not assert the trust metadata attached to queued system events.
- Contributing context: Slack event handling is split across multiple event-family modules, and system-event metadata drifted between them over time.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/slack/src/monitor/events/members.test.ts`
  - `extensions/slack/src/monitor/events/pins.test.ts`
  - `extensions/slack/src/monitor/events/messages.test.ts`
  - `extensions/slack/src/monitor/events/interactions.test.ts`
- Scenario the test locks in: Slack system-event enqueue options include explicit non-owner trust metadata for member, pin, message subtype, and modal lifecycle events.
- Why this is the smallest reliable guardrail: the changed behavior is local to the Slack event-family enqueue calls.
- Existing test that already covers this: nearby Slack channel, reaction, and block-action tests already assert this metadata; this PR extends that coverage to the remaining event families.

## User-visible / Behavior Changes

None expected. This keeps Slack system-event text and routing unchanged while making provenance metadata consistent.

## Diagram

```text
Before:
Slack external event -> enqueue system event with session/context metadata

After:
Slack external event -> enqueue system event with session/context metadata + non-owner trust metadata
```

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

This is a hardening/consistency change. It makes Slack-originated system events explicit about non-owner provenance and does not add new behavior or access.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: low-level system-event provenance changes could affect downstream code that relied on implicit metadata.
  - Mitigation: the change is limited to external Slack event families and matches existing Slack channel, reaction, and block-action behavior.

## Human Verification

- Verified scenarios: member join event, pin add event, message changed event, targeted regression tests for modal lifecycle enqueue metadata.
- Edge cases checked: unauthorized/disallowed Slack event cases remain covered by existing tests and do not enqueue system events.
- What was not verified: live Slack workspace delivery.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.
