### PR TITLE
feat(browser): surface observed dialogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 - Mac app: redesign Settings pages with consistent card layouts, cached navigation, cleaner permissions/voice/skills/cron/exec/debug panes, and steadier spacing around the native sidebar.
 - Skills: rename the repo-local Codex closeout review skill and helper to `autoreview` while preserving the Codex-first fallback behavior.
 - Skills: add a meme-maker skill for curated template search, local SVG/PNG rendering, Imgflip hosted rendering, and Know Your Meme provenance links.
+- Browser: surface pending and recently handled modal dialogs in snapshots, return `blockedByDialog` when an action opens a modal, and allow `browser dialog --dialog-id` to answer pending dialogs.
 - Agents/tools: shorten built-in tool descriptions and schema hints across media, messaging, sessions, cron, Gateway, web, image/PDF, TTS, nodes, and plan tools while preserving routing guardrails.
 - Skills: add node inspector debugging, fused diagram generation, and throwaway spike workflow skills.
 - CLI/plugins: add `defineToolPlugin` plus `openclaw plugins build`, `validate`, and `init` for typed simple tool plugins with generated manifest metadata, optional tool declarations, and context factories.

--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -204,12 +204,17 @@ openclaw browser upload /tmp/openclaw/uploads/file.pdf --ref <ref>
 openclaw browser waitfordownload
 openclaw browser download <ref> report.pdf
 openclaw browser dialog --accept
+openclaw browser dialog --dismiss --dialog-id d1
 ```
 
 Managed Chrome profiles save ordinary click-triggered downloads into the OpenClaw
 downloads directory (`/tmp/openclaw/downloads` by default, or the configured temp
 root). Use `waitfordownload` or `download` when the agent needs to wait for a
 specific file and return its path; those explicit waiters own the next download.
+When an action opens a modal dialog, the action response returns
+`blockedByDialog` with `browserState.dialogs.pending`; pass `--dialog-id` to
+answer it directly. Dialogs handled outside OpenClaw appear under
+`browserState.dialogs.recent`.
 
 ## State and storage
 

--- a/docs/tools/browser-control.md
+++ b/docs/tools/browser-control.md
@@ -193,6 +193,7 @@ openclaw browser waitfordownload report.pdf
 openclaw browser upload /tmp/openclaw/uploads/file.pdf
 openclaw browser fill --fields '[{"ref":"1","type":"text","value":"Ada"}]'
 openclaw browser dialog --accept
+openclaw browser dialog --dismiss --dialog-id d1
 openclaw browser wait --text "Done"
 openclaw browser wait "#main" --url "**/dash" --load networkidle --fn "window.ready===true"
 openclaw browser evaluate --fn '(el) => el.textContent' --ref 7
@@ -228,7 +229,7 @@ openclaw browser set device "iPhone 14"
 
 Notes:
 
-- `upload` and `dialog` are **arming** calls; run them before the click/press that triggers the chooser/dialog.
+- `upload` and `dialog` are **arming** calls; run them before the click/press that triggers the chooser/dialog. If an action opens a modal, the action response includes `blockedByDialog` and `browserState.dialogs.pending`; pass that `dialogId` to respond directly. Dialogs handled outside OpenClaw appear under `browserState.dialogs.recent`.
 - `click`/`type`/etc require a `ref` from `snapshot` (numeric `12`, role ref `e12`, or actionable ARIA ref `ax12`). CSS selectors are intentionally not supported for actions. Use `click-coords` when the visible viewport position is the only reliable target.
 - Download, trace, and upload paths are constrained to OpenClaw temp roots: `/tmp/openclaw{,/downloads,/uploads}` (fallback: `${os.tmpdir()}/openclaw/...`).
 - `upload` can also set file inputs directly via `--input-ref` or `--element`.

--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -646,7 +646,8 @@ Compared to the managed `openclaw` profile, existing-session drivers are more co
 
 - **Screenshots** - page captures and `--ref` element captures work; CSS `--element` selectors do not. `--full-page` cannot combine with `--ref` or `--element`. Playwright is not required for page or ref-based element screenshots.
 - **Actions** - `click`, `type`, `hover`, `scrollIntoView`, `drag`, and `select` require snapshot refs (no CSS selectors). `click-coords` clicks visible viewport coordinates and does not require a snapshot ref. `click` is left-button only. `type` does not support `slowly=true`; use `fill` or `press`. `press` does not support `delayMs`. `type`, `hover`, `scrollIntoView`, `drag`, `select`, `fill`, and `evaluate` do not support per-call timeouts. `select` accepts a single value.
-- **Wait / upload / dialog** - `wait --url` supports exact, substring, and glob patterns; `wait --load networkidle` is not supported. Upload hooks require `ref` or `inputRef`, one file at a time, no CSS `element`. Dialog hooks do not support timeout overrides.
+- **Wait / upload / dialog** - `wait --url` supports exact, substring, and glob patterns; `wait --load networkidle` is not supported. Upload hooks require `ref` or `inputRef`, one file at a time, no CSS `element`. Dialog hooks do not support timeout overrides or `dialogId`.
+- **Dialog visibility** - Managed browser action responses include `blockedByDialog` and `browserState.dialogs.pending` when an action opens a modal dialog; snapshots also include pending dialog state. Respond with `browser dialog --accept/--dismiss --dialog-id <id>` while a dialog is pending. Dialogs handled outside OpenClaw appear under `browserState.dialogs.recent`.
 - **Managed-only features** - batch actions, PDF export, download interception, and `responsebody` still require the managed browser path.
 
 </Accordion>

--- a/extensions/browser/src/browser-tool.actions.ts
+++ b/extensions/browser/src/browser-tool.actions.ts
@@ -404,6 +404,31 @@ export async function executeSnapshotAction(params: {
   }
   params.onTabActivity?.(readStringValue(snapshot.targetId) ?? targetId);
   if (snapshot.format === "ai") {
+    const dialogStateFields = {
+      ...(snapshot.blockedByDialog ? { blockedByDialog: true } : {}),
+      ...(snapshot.browserState !== undefined ? { browserState: snapshot.browserState } : {}),
+    };
+    if (snapshot.blockedByDialog) {
+      const wrapped = wrapBrowserExternalJson({
+        kind: "snapshot",
+        payload: {
+          format: snapshot.format,
+          targetId: snapshot.targetId,
+          url: snapshot.url,
+          ...dialogStateFields,
+        },
+      });
+      return {
+        content: [{ type: "text" as const, text: wrapped.wrappedText }],
+        details: {
+          ...wrapped.safeDetails,
+          format: snapshot.format,
+          targetId: snapshot.targetId,
+          url: snapshot.url,
+          ...dialogStateFields,
+        },
+      };
+    }
     const extractedText = snapshot.snapshot ?? "";
     const wrappedSnapshot = wrapExternalContent(extractedText, {
       source: "browser",
@@ -423,6 +448,7 @@ export async function executeSnapshotAction(params: {
       imagePath: snapshot.imagePath,
       imageType: snapshot.imageType,
       refsFallback,
+      ...dialogStateFields,
       externalContent: {
         untrusted: true,
         source: "browser",
@@ -457,6 +483,8 @@ export async function executeSnapshotAction(params: {
         targetId: snapshot.targetId,
         url: snapshot.url,
         nodeCount: snapshot.nodes.length,
+        ...(snapshot.blockedByDialog ? { blockedByDialog: true } : {}),
+        ...(snapshot.browserState !== undefined ? { browserState: snapshot.browserState } : {}),
         externalContent: {
           untrusted: true,
           source: "browser",

--- a/extensions/browser/src/browser-tool.schema.ts
+++ b/extensions/browser/src/browser-tool.schema.ts
@@ -118,6 +118,7 @@ export const BrowserToolSchema = Type.Object({
   paths: Type.Optional(Type.Array(Type.String())),
   inputRef: Type.Optional(Type.String()),
   timeoutMs: Type.Optional(Type.Number()),
+  dialogId: Type.Optional(Type.String()),
   accept: Type.Optional(Type.Boolean()),
   promptText: Type.Optional(Type.String()),
   // Legacy flattened act params (preferred: request={...})

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -1230,6 +1230,35 @@ describe("browser tool external content wrapping", () => {
     expect(details.nodeCount).toBe(1);
   });
 
+  it("preserves pending dialog state in ai snapshot results", async () => {
+    browserClientMocks.browserSnapshot.mockResolvedValueOnce({
+      ok: true,
+      format: "ai",
+      targetId: "t1",
+      url: "https://example.com",
+      snapshot: "",
+      blockedByDialog: true,
+      browserState: {
+        dialogs: {
+          pending: [{ id: "d1", type: "confirm", message: "Continue?" }],
+          recent: [],
+        },
+      },
+    });
+
+    const tool = createBrowserTool();
+    const result = await tool.execute?.("call-1", { action: "snapshot", snapshotFormat: "ai" });
+    const text = firstResultText(result);
+    expect(text).toContain('"blockedByDialog": true');
+    expect(text).toContain('"id": "d1"');
+    const details = externalContentDetails(result, "snapshot") as {
+      blockedByDialog?: unknown;
+      browserState?: { dialogs?: { pending?: Array<{ id?: string }> } };
+    };
+    expect(details.blockedByDialog).toBe(true);
+    expect(details.browserState?.dialogs?.pending?.[0]?.id).toBe("d1");
+  });
+
   it("wraps tabs output as external content", async () => {
     browserClientMocks.browserTabs.mockResolvedValueOnce([
       {

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -867,6 +867,7 @@ export function createBrowserTool(opts?: {
         case "dialog": {
           const accept = Boolean(params.accept);
           const promptText = readStringValue(params.promptText);
+          const dialogId = readStringValue(params.dialogId);
           const { targetId, timeoutMs } = readOptionalTargetAndTimeout(params);
           if (proxyRequest) {
             const result = await proxyRequest({
@@ -876,6 +877,7 @@ export function createBrowserTool(opts?: {
               body: {
                 accept,
                 promptText,
+                dialogId,
                 targetId,
                 timeoutMs,
               },
@@ -885,6 +887,7 @@ export function createBrowserTool(opts?: {
           const result = await browserToolDeps.browserArmDialog(baseUrl, {
             accept,
             promptText,
+            dialogId,
             targetId,
             timeoutMs,
             profile,

--- a/extensions/browser/src/browser/client-actions-core.ts
+++ b/extensions/browser/src/browser/client-actions-core.ts
@@ -19,6 +19,8 @@ type BrowserActResponse = {
   url?: string;
   result?: unknown;
   results?: Array<{ ok: boolean; error?: string }>;
+  blockedByDialog?: boolean;
+  browserState?: unknown;
 };
 
 const BROWSER_ACT_REQUEST_TIMEOUT_SLACK_MS = 5_000;
@@ -66,6 +68,7 @@ export async function browserArmDialog(
   opts: {
     accept: boolean;
     promptText?: string;
+    dialogId?: string;
     targetId?: string;
     timeoutMs?: number;
     profile?: string;
@@ -78,6 +81,7 @@ export async function browserArmDialog(
     body: JSON.stringify({
       accept: opts.accept,
       promptText: opts.promptText,
+      dialogId: opts.dialogId,
       targetId: opts.targetId,
       timeoutMs: opts.timeoutMs,
     }),

--- a/extensions/browser/src/browser/client.ts
+++ b/extensions/browser/src/browser/client.ts
@@ -44,6 +44,8 @@ export type SnapshotResult =
       targetId: string;
       url: string;
       nodes: SnapshotAriaNode[];
+      blockedByDialog?: boolean;
+      browserState?: unknown;
     }
   | {
       ok: true;
@@ -64,6 +66,8 @@ export type SnapshotResult =
       labelsSkipped?: number;
       imagePath?: string;
       imageType?: "png" | "jpeg";
+      blockedByDialog?: boolean;
+      browserState?: unknown;
     };
 
 export async function browserStatus(

--- a/extensions/browser/src/browser/pw-ai.ts
+++ b/extensions/browser/src/browser/pw-ai.ts
@@ -10,9 +10,16 @@ export {
   ensurePageState,
   forceDisconnectPlaywrightForTarget,
   focusPageByTargetIdViaPlaywright,
+  createObservedDialogAbortSignalForPage,
+  getObservedBrowserStateForPage,
+  getObservedBrowserStateViaPlaywright,
   getPageForTargetId,
+  isBrowserObservedDialogBlockedError,
   listPagesViaPlaywright,
+  markObservedDialogsHandledRemotelyForPage,
   refLocator,
+  respondToObservedDialogOnPage,
+  respondToObservedDialogViaPlaywright,
 } from "./pw-session.js";
 
 export {

--- a/extensions/browser/src/browser/pw-session.dialogs.test.ts
+++ b/extensions/browser/src/browser/pw-session.dialogs.test.ts
@@ -1,0 +1,139 @@
+import type { Dialog, Page } from "playwright-core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  armObservedDialogResponseOnPage,
+  createObservedDialogAbortSignalForPage,
+  ensurePageState,
+  getObservedBrowserStateForPage,
+  isBrowserObservedDialogBlockedError,
+  markObservedDialogsHandledRemotelyForPage,
+  respondToObservedDialogOnPage,
+} from "./pw-session.js";
+
+type Handler = (arg: unknown) => void;
+
+function createPageHarness() {
+  const handlers = new Map<string, Handler[]>();
+  const page = {
+    on: (event: string, handler: Handler) => {
+      handlers.set(event, [...(handlers.get(event) ?? []), handler]);
+      return page;
+    },
+  };
+  return {
+    page: page as unknown as Page,
+    emit: (event: string, arg: unknown) => {
+      for (const handler of handlers.get(event) ?? []) {
+        handler(arg);
+      }
+    },
+  };
+}
+
+function createDialog(
+  overrides: Partial<{
+    type: string;
+    message: string;
+    defaultValue: string;
+  }> = {},
+) {
+  return {
+    type: vi.fn(() => overrides.type ?? "confirm"),
+    message: vi.fn(() => overrides.message ?? "Continue?"),
+    defaultValue: vi.fn(() => overrides.defaultValue ?? ""),
+    accept: vi.fn(async (_promptText?: string) => {}),
+    dismiss: vi.fn(async () => {}),
+  } as unknown as Dialog & {
+    accept: ReturnType<typeof vi.fn>;
+    dismiss: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("observed browser dialogs", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("surfaces pending dialogs and lets callers respond by id", async () => {
+    const { page, emit } = createPageHarness();
+    ensurePageState(page);
+    const dialog = createDialog({ message: "Ship it?" });
+
+    emit("dialog", dialog);
+
+    expect(getObservedBrowserStateForPage(page).dialogs.pending).toMatchObject([
+      { id: "d1", type: "confirm", message: "Ship it?" },
+    ]);
+
+    const closed = await respondToObservedDialogOnPage({
+      page,
+      dialogId: "d1",
+      accept: true,
+      promptText: "yes",
+    });
+
+    expect(dialog.accept).toHaveBeenCalledWith("yes");
+    expect(closed.closedBy).toBe("agent");
+    expect(getObservedBrowserStateForPage(page).dialogs.pending).toEqual([]);
+    expect(getObservedBrowserStateForPage(page).dialogs.recent).toMatchObject([
+      { id: "d1", closedBy: "agent" },
+    ]);
+  });
+
+  it("keeps arm-next-dialog behavior through the observed dialog path", async () => {
+    const { page, emit } = createPageHarness();
+    ensurePageState(page);
+    const dialog = createDialog({ type: "alert", message: "Heads up" });
+    const observed = createObservedDialogAbortSignalForPage({ page });
+
+    armObservedDialogResponseOnPage({ page, accept: false, timeoutMs: 1000 });
+    emit("dialog", dialog);
+    await Promise.resolve();
+
+    expect(observed.signal.aborted).toBe(false);
+    expect(dialog.dismiss).toHaveBeenCalledOnce();
+    expect(getObservedBrowserStateForPage(page).dialogs.pending).toEqual([]);
+    expect(getObservedBrowserStateForPage(page).dialogs.recent).toMatchObject([
+      { id: "d1", type: "alert", closedBy: "armed" },
+    ]);
+    observed.cleanup();
+  });
+
+  it("aborts in-flight actions while keeping unarmed dialogs pending", async () => {
+    const { page, emit } = createPageHarness();
+    ensurePageState(page);
+    const dialog = createDialog({ type: "alert", message: "Heads up" });
+    const observed = createObservedDialogAbortSignalForPage({ page });
+
+    emit("dialog", dialog);
+
+    expect(observed.signal.aborted).toBe(true);
+    expect(isBrowserObservedDialogBlockedError(observed.signal.reason)).toBe(true);
+    expect(getObservedBrowserStateForPage(page).dialogs.pending).toMatchObject([
+      { id: "d1", type: "alert", message: "Heads up" },
+    ]);
+
+    expect(dialog.dismiss).not.toHaveBeenCalled();
+    await respondToObservedDialogOnPage({ page, dialogId: "d1", accept: false });
+    observed.cleanup();
+
+    expect(dialog.dismiss).toHaveBeenCalledOnce();
+    expect(getObservedBrowserStateForPage(page).dialogs.pending).toEqual([]);
+    expect(getObservedBrowserStateForPage(page).dialogs.recent).toMatchObject([
+      { id: "d1", type: "alert", closedBy: "agent" },
+    ]);
+  });
+
+  it("moves remotely handled pending dialogs into recent state", () => {
+    const { page, emit } = createPageHarness();
+    ensurePageState(page);
+    emit("dialog", createDialog({ type: "confirm", message: "Continue?" }));
+
+    const state = markObservedDialogsHandledRemotelyForPage(page);
+
+    expect(state.dialogs.pending).toEqual([]);
+    expect(state.dialogs.recent).toMatchObject([
+      { id: "d1", type: "confirm", message: "Continue?", closedBy: "remote" },
+    ]);
+  });
+});

--- a/extensions/browser/src/browser/pw-session.ts
+++ b/extensions/browser/src/browser/pw-session.ts
@@ -5,6 +5,7 @@ import type {
   Browser,
   BrowserContext,
   ConsoleMessage,
+  Dialog,
   Page,
   Request,
   Response,
@@ -67,6 +68,52 @@ export type BrowserNetworkRequest = {
   failureText?: string;
 };
 
+export type BrowserObservedDialogRecord = {
+  id: string;
+  type: string;
+  message: string;
+  defaultValue?: string;
+  openedAt: string;
+  closedAt?: string;
+  closedBy?: "agent" | "armed" | "auto" | "timeout" | "remote";
+};
+
+export type BrowserObservedDialogState = {
+  pending: BrowserObservedDialogRecord[];
+  recent: BrowserObservedDialogRecord[];
+};
+
+export type BrowserObservedState = {
+  dialogs: BrowserObservedDialogState;
+};
+
+export class BrowserObservedDialogBlockedError extends Error {
+  readonly browserState: BrowserObservedState;
+
+  constructor(browserState: BrowserObservedState) {
+    super("Browser action blocked by a modal dialog.");
+    this.name = "BrowserObservedDialogBlockedError";
+    this.browserState = browserState;
+  }
+}
+
+export function isBrowserObservedDialogBlockedError(
+  err: unknown,
+): err is BrowserObservedDialogBlockedError {
+  return err instanceof BrowserObservedDialogBlockedError;
+}
+
+type PendingObservedDialog = BrowserObservedDialogRecord & {
+  dialog: Dialog;
+};
+
+type ArmedDialogResponse = {
+  accept: boolean;
+  promptText?: string;
+  expiresAt: number;
+  timer?: ReturnType<typeof setTimeout>;
+};
+
 type TargetInfoResponse = {
   targetInfo?: {
     targetId?: string;
@@ -86,9 +133,13 @@ type PageState = {
   requestIds: WeakMap<Request, string>;
   nextRequestId: number;
   armIdUpload: number;
-  armIdDialog: number;
   armIdDownload: number;
   downloadWaiterDepth: number;
+  nextObservedDialogId: number;
+  pendingDialogs: PendingObservedDialog[];
+  recentDialogs: BrowserObservedDialogRecord[];
+  armedDialogResponse?: ArmedDialogResponse;
+  dialogAbortControllers: Set<AbortController>;
   /**
    * Role-based refs from the last role snapshot (e.g. e1/e2).
    * Mode "role" refs are generated from ariaSnapshot and resolved via getByRole.
@@ -123,6 +174,8 @@ const MAX_ROLE_REFS_CACHE = 50;
 const MAX_CONSOLE_MESSAGES = 500;
 const MAX_PAGE_ERRORS = 200;
 const MAX_NETWORK_REQUESTS = 500;
+const MAX_RECENT_DIALOGS = 20;
+const OBSERVED_DIALOG_TIMEOUT_MS = 120_000;
 
 const cachedByCdpUrl = new Map<string, ConnectedBrowser>();
 const connectingByCdpUrl = new Map<string, Promise<ConnectedBrowser>>();
@@ -181,6 +234,135 @@ function findNetworkRequestById(state: PageState, id: string): BrowserNetworkReq
     }
   }
   return undefined;
+}
+
+function appendRecentDialog(state: PageState, record: BrowserObservedDialogRecord): void {
+  state.recentDialogs.push(record);
+  while (state.recentDialogs.length > MAX_RECENT_DIALOGS) {
+    state.recentDialogs.shift();
+  }
+}
+
+function serializeDialogRecord(dialog: BrowserObservedDialogRecord): BrowserObservedDialogRecord {
+  return {
+    id: dialog.id,
+    type: dialog.type,
+    message: dialog.message,
+    ...(dialog.defaultValue !== undefined ? { defaultValue: dialog.defaultValue } : {}),
+    openedAt: dialog.openedAt,
+    ...(dialog.closedAt !== undefined ? { closedAt: dialog.closedAt } : {}),
+    ...(dialog.closedBy !== undefined ? { closedBy: dialog.closedBy } : {}),
+  };
+}
+
+function serializePendingDialog(dialog: PendingObservedDialog): BrowserObservedDialogRecord {
+  return serializeDialogRecord(dialog);
+}
+
+function serializeObservedBrowserState(state: PageState): BrowserObservedState {
+  return {
+    dialogs: {
+      pending: state.pendingDialogs.map(serializePendingDialog),
+      recent: state.recentDialogs.map(serializeDialogRecord),
+    },
+  };
+}
+
+function clearArmedDialogResponse(state: PageState): void {
+  if (state.armedDialogResponse?.timer) {
+    clearTimeout(state.armedDialogResponse.timer);
+  }
+  state.armedDialogResponse = undefined;
+}
+
+function abortActionsBlockedByDialog(state: PageState): void {
+  if (state.dialogAbortControllers.size === 0) {
+    return;
+  }
+  const err = new BrowserObservedDialogBlockedError(serializeObservedBrowserState(state));
+  for (const controller of state.dialogAbortControllers) {
+    if (!controller.signal.aborted) {
+      controller.abort(err);
+    }
+  }
+  state.dialogAbortControllers.clear();
+}
+
+function isNoDialogShowingError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return message.toLowerCase().includes("no dialog is showing");
+}
+
+async function settleObservedDialog(params: {
+  state: PageState;
+  pending: PendingObservedDialog;
+  accept: boolean;
+  promptText?: string;
+  closedBy: NonNullable<BrowserObservedDialogRecord["closedBy"]>;
+}): Promise<BrowserObservedDialogRecord> {
+  const { state, pending } = params;
+  state.pendingDialogs = state.pendingDialogs.filter((dialog) => dialog.id !== pending.id);
+
+  let closedBy = params.closedBy;
+  try {
+    if (params.accept) {
+      await pending.dialog.accept(params.promptText);
+    } else {
+      await pending.dialog.dismiss();
+    }
+  } catch (err) {
+    if (!isNoDialogShowingError(err)) {
+      if (params.closedBy === "agent") {
+        state.pendingDialogs.push(pending);
+      }
+      throw err;
+    }
+    closedBy = "remote";
+  }
+
+  const record: BrowserObservedDialogRecord = {
+    id: pending.id,
+    type: pending.type,
+    message: pending.message,
+    ...(pending.defaultValue !== undefined ? { defaultValue: pending.defaultValue } : {}),
+    openedAt: pending.openedAt,
+    closedAt: new Date().toISOString(),
+    closedBy,
+  };
+  appendRecentDialog(state, record);
+  return record;
+}
+
+function observeDialog(pageState: PageState, dialog: Dialog): void {
+  pageState.nextObservedDialogId += 1;
+  const type = dialog.type();
+  const defaultValue = dialog.defaultValue();
+  const pending: PendingObservedDialog = {
+    id: `d${pageState.nextObservedDialogId}`,
+    type,
+    message: dialog.message(),
+    openedAt: new Date().toISOString(),
+    dialog,
+    ...(type === "prompt" ? { defaultValue } : {}),
+  };
+  pageState.pendingDialogs.push(pending);
+
+  const armed = pageState.armedDialogResponse;
+  if (armed && armed.expiresAt >= Date.now()) {
+    clearArmedDialogResponse(pageState);
+    void settleObservedDialog({
+      state: pageState,
+      pending,
+      accept: armed.accept,
+      ...(armed.promptText !== undefined ? { promptText: armed.promptText } : {}),
+      closedBy: "armed",
+    }).catch(() => {});
+    return;
+  }
+  if (armed) {
+    clearArmedDialogResponse(pageState);
+  }
+  abortActionsBlockedByDialog(pageState);
 }
 
 function targetKey(cdpUrl: string, targetId: string) {
@@ -380,9 +562,12 @@ export function ensurePageState(page: Page): PageState {
     requestIds: new WeakMap(),
     nextRequestId: 0,
     armIdUpload: 0,
-    armIdDialog: 0,
     armIdDownload: 0,
     downloadWaiterDepth: 0,
+    nextObservedDialogId: 0,
+    pendingDialogs: [],
+    recentDialogs: [],
+    dialogAbortControllers: new Set(),
   };
   pageStates.set(page, state);
 
@@ -451,6 +636,9 @@ export function ensurePageState(page: Page): PageState {
       rec.failureText = req.failure()?.errorText;
       rec.ok = false;
     });
+    page.on("dialog", (dialog: Dialog) => {
+      observeDialog(state, dialog);
+    });
     page.on(
       "download",
       (download: {
@@ -481,12 +669,172 @@ export function ensurePageState(page: Page): PageState {
       },
     );
     page.on("close", () => {
+      clearArmedDialogResponse(state);
+      for (const controller of state.dialogAbortControllers) {
+        if (!controller.signal.aborted) {
+          controller.abort(new Error("Page closed before browser action completed."));
+        }
+      }
+      state.dialogAbortControllers.clear();
+      state.pendingDialogs = [];
       pageStates.delete(page);
       observedPages.delete(page);
     });
   }
 
   return state;
+}
+
+export function getObservedBrowserStateForPage(page: Page): BrowserObservedState {
+  const state = ensurePageState(page);
+  return serializeObservedBrowserState(state);
+}
+
+export async function getObservedBrowserStateViaPlaywright(opts: {
+  cdpUrl: string;
+  targetId?: string;
+  ssrfPolicy?: SsrFPolicy;
+}): Promise<BrowserObservedState> {
+  const page = await getPageForTargetId(opts);
+  return getObservedBrowserStateForPage(page);
+}
+
+function resolvePendingDialogForResponse(params: {
+  state: PageState;
+  dialogId?: string;
+}): PendingObservedDialog {
+  const dialogId = normalizeOptionalString(params.dialogId);
+  if (dialogId) {
+    const found = params.state.pendingDialogs.find((dialog) => dialog.id === dialogId);
+    if (found) {
+      return found;
+    }
+    throw new Error(`Dialog "${dialogId}" is not pending.`);
+  }
+  if (params.state.pendingDialogs.length === 1) {
+    return params.state.pendingDialogs[0];
+  }
+  if (params.state.pendingDialogs.length > 1) {
+    throw new Error("Multiple dialogs are pending; pass dialogId.");
+  }
+  throw new Error("No dialog is pending.");
+}
+
+export async function respondToObservedDialogOnPage(opts: {
+  page: Page;
+  dialogId?: string;
+  accept: boolean;
+  promptText?: string;
+  closedBy?: "agent" | "armed";
+}): Promise<BrowserObservedDialogRecord> {
+  const state = ensurePageState(opts.page);
+  const pending = resolvePendingDialogForResponse({
+    state,
+    ...(opts.dialogId !== undefined ? { dialogId: opts.dialogId } : {}),
+  });
+  return await settleObservedDialog({
+    state,
+    pending,
+    accept: opts.accept,
+    ...(opts.promptText !== undefined ? { promptText: opts.promptText } : {}),
+    closedBy: opts.closedBy ?? "agent",
+  });
+}
+
+export async function respondToObservedDialogViaPlaywright(opts: {
+  cdpUrl: string;
+  targetId?: string;
+  dialogId?: string;
+  accept: boolean;
+  promptText?: string;
+  ssrfPolicy?: SsrFPolicy;
+}): Promise<BrowserObservedDialogRecord> {
+  const page = await getPageForTargetId(opts);
+  return await respondToObservedDialogOnPage({
+    page,
+    accept: opts.accept,
+    ...(opts.dialogId !== undefined ? { dialogId: opts.dialogId } : {}),
+    ...(opts.promptText !== undefined ? { promptText: opts.promptText } : {}),
+  });
+}
+
+export function markObservedDialogsHandledRemotelyForPage(page: Page): BrowserObservedState {
+  const state = ensurePageState(page);
+  const pending = state.pendingDialogs.splice(0);
+  const closedAt = new Date().toISOString();
+  for (const dialog of pending) {
+    appendRecentDialog(state, {
+      id: dialog.id,
+      type: dialog.type,
+      message: dialog.message,
+      ...(dialog.defaultValue !== undefined ? { defaultValue: dialog.defaultValue } : {}),
+      openedAt: dialog.openedAt,
+      closedAt,
+      closedBy: "remote",
+    });
+  }
+  return serializeObservedBrowserState(state);
+}
+
+export function armObservedDialogResponseOnPage(opts: {
+  page: Page;
+  accept: boolean;
+  promptText?: string;
+  timeoutMs?: number;
+}): void {
+  const state = ensurePageState(opts.page);
+  clearArmedDialogResponse(state);
+  const timeoutMs = Math.max(1, Math.floor(opts.timeoutMs ?? OBSERVED_DIALOG_TIMEOUT_MS));
+  const response: ArmedDialogResponse = {
+    accept: opts.accept,
+    expiresAt: Date.now() + timeoutMs,
+    ...(opts.promptText !== undefined ? { promptText: opts.promptText } : {}),
+  };
+  response.timer = setTimeout(() => {
+    if (state.armedDialogResponse === response) {
+      state.armedDialogResponse = undefined;
+    }
+  }, timeoutMs);
+  state.armedDialogResponse = response;
+}
+
+export function createObservedDialogAbortSignalForPage(opts: {
+  page: Page;
+  parentSignal?: AbortSignal;
+}): { signal: AbortSignal; cleanup: () => void } {
+  const state = ensurePageState(opts.page);
+  const controller = new AbortController();
+  const abortForCurrentDialog = () => {
+    if (!controller.signal.aborted) {
+      controller.abort(new BrowserObservedDialogBlockedError(serializeObservedBrowserState(state)));
+    }
+  };
+  const abortForParent = () => {
+    if (!controller.signal.aborted) {
+      controller.abort(opts.parentSignal?.reason ?? new Error("aborted"));
+    }
+  };
+
+  if (state.pendingDialogs.length > 0) {
+    abortForCurrentDialog();
+  } else {
+    state.dialogAbortControllers.add(controller);
+  }
+  if (opts.parentSignal) {
+    if (opts.parentSignal.aborted) {
+      abortForParent();
+    } else {
+      opts.parentSignal.addEventListener("abort", abortForParent, { once: true });
+    }
+  }
+
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      state.dialogAbortControllers.delete(controller);
+      opts.parentSignal?.removeEventListener("abort", abortForParent);
+    },
+  };
 }
 
 function observeContext(context: BrowserContext) {

--- a/extensions/browser/src/browser/pw-tools-core.browser-ssrf-guard.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.browser-ssrf-guard.test.ts
@@ -17,7 +17,9 @@ const sessionMocks = vi.hoisted(() => ({
     return pageState.page;
   }),
   gotoPageWithNavigationGuard: vi.fn(async () => null),
+  isBrowserObservedDialogBlockedError: vi.fn(() => false),
   isPolicyDenyNavigationError: vi.fn(() => false),
+  markObservedDialogsHandledRemotelyForPage: vi.fn(() => ({})),
   refLocator: vi.fn(() => {
     if (!pageState.locator) {
       throw new Error("missing locator");

--- a/extensions/browser/src/browser/pw-tools-core.downloads.ts
+++ b/extensions/browser/src/browser/pw-tools-core.downloads.ts
@@ -5,13 +5,14 @@ import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 import { writeExternalFileWithinOutputRoot } from "./output-files.js";
 import { DEFAULT_UPLOAD_DIR, resolveStrictExistingPathsWithinRoot } from "./paths.js";
 import {
+  armObservedDialogResponseOnPage,
   ensurePageState,
   getPageForTargetId,
   refLocator,
+  respondToObservedDialogOnPage,
   restoreRoleRefsForTarget,
 } from "./pw-session.js";
 import {
-  bumpDialogArmId,
   bumpDownloadArmId,
   bumpUploadArmId,
   normalizeTimeoutMs,
@@ -191,32 +192,34 @@ export async function armFileUploadViaPlaywright(opts: {
 export async function armDialogViaPlaywright(opts: {
   cdpUrl: string;
   targetId?: string;
+  dialogId?: string;
   accept: boolean;
   promptText?: string;
   timeoutMs?: number;
 }): Promise<void> {
   const page = await getPageForTargetId(opts);
-  const state = ensurePageState(page);
   const timeout = normalizeTimeoutMs(opts.timeoutMs, 120_000);
-
-  state.armIdDialog = bumpDialogArmId();
-  const armId = state.armIdDialog;
-
-  void page
-    .waitForEvent("dialog", { timeout })
-    .then(async (dialog) => {
-      if (state.armIdDialog !== armId) {
-        return;
-      }
-      if (opts.accept) {
-        await dialog.accept(opts.promptText);
-      } else {
-        await dialog.dismiss();
-      }
-    })
-    .catch(() => {
-      // Ignore timeouts; the dialog may never appear.
+  try {
+    await respondToObservedDialogOnPage({
+      page,
+      accept: opts.accept,
+      closedBy: "agent",
+      ...(opts.dialogId !== undefined ? { dialogId: opts.dialogId } : {}),
+      ...(opts.promptText !== undefined ? { promptText: opts.promptText } : {}),
     });
+    return;
+  } catch (err) {
+    if (opts.dialogId || (err instanceof Error && !err.message.includes("No dialog is pending"))) {
+      throw err;
+    }
+  }
+
+  armObservedDialogResponseOnPage({
+    page,
+    accept: opts.accept,
+    timeoutMs: timeout,
+    ...(opts.promptText !== undefined ? { promptText: opts.promptText } : {}),
+  });
 }
 
 export async function waitForDownloadViaPlaywright(opts: {

--- a/extensions/browser/src/browser/pw-tools-core.interactions.batch.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.batch.test.ts
@@ -14,6 +14,8 @@ const getPageForTargetId = vi.fn(async () => {
 const ensurePageState = vi.fn(() => {});
 const assertPageNavigationCompletedSafely = vi.fn(async () => {});
 const forceDisconnectPlaywrightForTarget = vi.fn(async () => {});
+const isBrowserObservedDialogBlockedError = vi.fn(() => false);
+const markObservedDialogsHandledRemotelyForPage = vi.fn(() => ({}));
 const refLocator = vi.fn(() => {
   throw new Error("test: refLocator should not be called");
 });
@@ -27,6 +29,8 @@ vi.mock("./pw-session.js", () => ({
   ensurePageState,
   forceDisconnectPlaywrightForTarget,
   getPageForTargetId,
+  isBrowserObservedDialogBlockedError,
+  markObservedDialogsHandledRemotelyForPage,
   refLocator,
   restoreRoleRefsForTarget,
 }));

--- a/extensions/browser/src/browser/pw-tools-core.interactions.evaluate.abort.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.evaluate.abort.test.ts
@@ -13,6 +13,10 @@ const getPageForTargetId = vi.fn(async () => {
 const ensurePageState = vi.fn(() => {});
 const assertPageNavigationCompletedSafely = vi.fn(async () => {});
 const restoreRoleRefsForTarget = vi.fn(() => {});
+const isBrowserObservedDialogBlockedError = vi.fn(
+  (err: unknown) => err instanceof Error && err.name === "BrowserObservedDialogBlockedError",
+);
+const markObservedDialogsHandledRemotelyForPage = vi.fn(() => ({}));
 const refLocator = vi.fn(() => {
   if (!locator) {
     throw new Error("test: locator not set");
@@ -26,6 +30,8 @@ vi.mock("./pw-session.js", () => {
     ensurePageState,
     forceDisconnectPlaywrightForTarget,
     getPageForTargetId,
+    isBrowserObservedDialogBlockedError,
+    markObservedDialogsHandledRemotelyForPage,
     refLocator,
     restoreRoleRefsForTarget,
   };
@@ -92,5 +98,38 @@ describe("evaluateViaPlaywright (abort)", () => {
 
     await expect(p).rejects.toThrow("aborted by test");
     expect(forceDisconnectPlaywrightForTarget).toHaveBeenCalled();
+  });
+
+  it("does not disconnect when evaluate is blocked by an observed dialog", async () => {
+    const ctrl = new AbortController();
+    const pending = createPendingEval();
+    let resolveEval: (value: unknown) => void = () => {};
+    const pendingPromise = new Promise((resolve) => {
+      resolveEval = resolve;
+    });
+    page = {
+      evaluate: vi.fn(() => {
+        pending.resolveEvalCalled();
+        return pendingPromise;
+      }),
+      url: vi.fn(() => "https://example.com/current"),
+    };
+
+    const p = evaluateViaPlaywright({
+      cdpUrl: "http://127.0.0.1:9222",
+      fn: "() => alert('x')",
+      signal: ctrl.signal,
+    });
+
+    await pending.evalCalledPromise;
+    const err = new Error("blocked by dialog");
+    err.name = "BrowserObservedDialogBlockedError";
+    ctrl.abort(err);
+
+    await expect(p).rejects.toThrow("blocked by dialog");
+    expect(forceDisconnectPlaywrightForTarget).not.toHaveBeenCalled();
+    resolveEval(true);
+    await Promise.resolve();
+    expect(markObservedDialogsHandledRemotelyForPage).toHaveBeenCalled();
   });
 });

--- a/extensions/browser/src/browser/pw-tools-core.interactions.set-input-files.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.set-input-files.test.ts
@@ -11,6 +11,8 @@ const getPageForTargetId = vi.fn(async () => {
 });
 const ensurePageState = vi.fn(() => ({}));
 const restoreRoleRefsForTarget = vi.fn(() => {});
+const isBrowserObservedDialogBlockedError = vi.fn(() => false);
+const markObservedDialogsHandledRemotelyForPage = vi.fn(() => ({}));
 const refLocator = vi.fn(() => {
   if (!locator) {
     throw new Error("test: locator not set");
@@ -27,6 +29,8 @@ vi.mock("./pw-session.js", () => {
     ensurePageState,
     forceDisconnectPlaywrightForTarget,
     getPageForTargetId,
+    isBrowserObservedDialogBlockedError,
+    markObservedDialogsHandledRemotelyForPage,
     refLocator,
     restoreRoleRefsForTarget,
   };

--- a/extensions/browser/src/browser/pw-tools-core.interactions.ts
+++ b/extensions/browser/src/browser/pw-tools-core.interactions.ts
@@ -19,9 +19,12 @@ import {
 import { DEFAULT_UPLOAD_DIR, resolveStrictExistingPathsWithinRoot } from "./paths.js";
 import {
   assertPageNavigationCompletedSafely,
+  createObservedDialogAbortSignalForPage,
   ensurePageState,
   forceDisconnectPlaywrightForTarget,
   getPageForTargetId,
+  isBrowserObservedDialogBlockedError,
+  markObservedDialogsHandledRemotelyForPage,
   refLocator,
   restoreRoleRefsForTarget,
 } from "./pw-session.js";
@@ -64,6 +67,16 @@ async function getRestoredPageForTarget(opts: TargetOpts) {
   ensurePageState(page);
   restoreRoleRefsForTarget({ cdpUrl: opts.cdpUrl, targetId: opts.targetId, page });
   return page;
+}
+
+function toFriendlyInteractionError(err: unknown, label: string): Error {
+  return isBrowserObservedDialogBlockedError(err) ? err : toAIFriendlyError(err, label);
+}
+
+function reconcileRemoteDialogAfterActionSettled(page: Page, signal?: AbortSignal): void {
+  if (isBrowserObservedDialogBlockedError(signal?.reason)) {
+    markObservedDialogsHandledRemotelyForPage(page);
+  }
 }
 
 const resolveInteractionTimeoutMs = resolveActInteractionTimeoutMs;
@@ -426,6 +439,7 @@ async function assertInteractionNavigationCompletedSafely<T>(opts: {
 async function awaitActionWithAbort<T>(
   actionPromise: Promise<T>,
   abortPromise?: Promise<never>,
+  onActionResolvedAfterAbort?: () => void,
 ): Promise<T> {
   if (!abortPromise) {
     return await actionPromise;
@@ -434,7 +448,10 @@ async function awaitActionWithAbort<T>(
     return await Promise.race([actionPromise, abortPromise]);
   } catch (err) {
     // If abort wins the race, the action may reject later; avoid unhandled rejections.
-    void actionPromise.catch(() => {});
+    void actionPromise.then(
+      () => onActionResolvedAfterAbort?.(),
+      () => {},
+    );
     throw err;
   }
 }
@@ -448,7 +465,7 @@ function createAbortPromise(signal?: AbortSignal): {
 
 function createAbortPromiseWithListener(
   signal?: AbortSignal,
-  onAbort?: () => void,
+  onAbort?: (reason: unknown) => void,
 ): {
   abortPromise?: Promise<never>;
   cleanup: () => void;
@@ -459,12 +476,12 @@ function createAbortPromiseWithListener(
   let abortListener: (() => void) | undefined;
   const abortPromise: Promise<never> = signal.aborted
     ? (() => {
-        onAbort?.();
+        onAbort?.(signal.reason);
         return Promise.reject(signal.reason ?? new Error("aborted"));
       })()
     : new Promise((_, reject) => {
         abortListener = () => {
-          onAbort?.();
+          onAbort?.(signal.reason);
           reject(signal.reason ?? new Error("aborted"));
         };
         signal.addEventListener("abort", abortListener, { once: true });
@@ -490,7 +507,7 @@ export async function highlightViaPlaywright(opts: {
   try {
     await refLocator(page, ref).highlight();
   } catch (err) {
-    throw toAIFriendlyError(err, ref);
+    throw toFriendlyInteractionError(err, ref);
   }
 }
 
@@ -525,6 +542,9 @@ export async function clickViaPlaywright(opts: {
     });
     void abortPromise.catch(() => {});
     const disconnect = () => {
+      if (isBrowserObservedDialogBlockedError(signal.reason)) {
+        return;
+      }
       void forceDisconnectPlaywrightForTarget({
         cdpUrl: opts.cdpUrl,
         targetId: opts.targetId,
@@ -545,6 +565,7 @@ export async function clickViaPlaywright(opts: {
       throw signal.reason ?? new Error("aborted");
     }
   }
+  const reconcileRemoteDialog = () => reconcileRemoteDialogAfterActionSettled(page, signal);
   try {
     await assertInteractionNavigationCompletedSafely({
       action: async () => {
@@ -554,7 +575,11 @@ export async function clickViaPlaywright(opts: {
           ACT_MAX_CLICK_DELAY_MS,
         );
         if (delayMs > 0) {
-          await awaitActionWithAbort(locator.hover({ timeout }), abortPromise);
+          await awaitActionWithAbort(
+            locator.hover({ timeout }),
+            abortPromise,
+            reconcileRemoteDialog,
+          );
           await new Promise((resolve) => setTimeout(resolve, delayMs));
         }
         if (opts.doubleClick) {
@@ -565,6 +590,7 @@ export async function clickViaPlaywright(opts: {
               modifiers: opts.modifiers,
             }),
             abortPromise,
+            reconcileRemoteDialog,
           );
           return;
         }
@@ -575,6 +601,7 @@ export async function clickViaPlaywright(opts: {
             modifiers: opts.modifiers,
           }),
           abortPromise,
+          reconcileRemoteDialog,
         );
       },
       cdpUrl: opts.cdpUrl,
@@ -584,7 +611,7 @@ export async function clickViaPlaywright(opts: {
       targetId: opts.targetId,
     });
   } catch (err) {
-    throw toAIFriendlyError(err, label);
+    throw toFriendlyInteractionError(err, label);
   } finally {
     if (signal && abortListener) {
       signal.removeEventListener("abort", abortListener);
@@ -602,23 +629,30 @@ export async function clickCoordsViaPlaywright(opts: {
   delayMs?: number;
   timeoutMs?: number;
   ssrfPolicy?: SsrFPolicy;
+  signal?: AbortSignal;
 }): Promise<void> {
   const page = await getRestoredPageForTarget(opts);
   const previousUrl = page.url();
+  const { abortPromise, cleanup } = createAbortPromise(opts.signal);
+  const reconcileRemoteDialog = () => reconcileRemoteDialogAfterActionSettled(page, opts.signal);
   await assertInteractionNavigationCompletedSafely({
     action: async () => {
-      await page.mouse.click(opts.x, opts.y, {
-        button: opts.button,
-        clickCount: opts.doubleClick ? 2 : 1,
-        delay: resolveBoundedDelayMs(opts.delayMs, "clickCoords delayMs", ACT_MAX_CLICK_DELAY_MS),
-      });
+      await awaitActionWithAbort(
+        page.mouse.click(opts.x, opts.y, {
+          button: opts.button,
+          clickCount: opts.doubleClick ? 2 : 1,
+          delay: resolveBoundedDelayMs(opts.delayMs, "clickCoords delayMs", ACT_MAX_CLICK_DELAY_MS),
+        }),
+        abortPromise,
+        reconcileRemoteDialog,
+      );
     },
     cdpUrl: opts.cdpUrl,
     page,
     previousUrl,
     ssrfPolicy: opts.ssrfPolicy,
     targetId: opts.targetId,
-  });
+  }).finally(cleanup);
 }
 
 export async function hoverViaPlaywright(opts: {
@@ -627,6 +661,7 @@ export async function hoverViaPlaywright(opts: {
   ref?: string;
   selector?: string;
   timeoutMs?: number;
+  signal?: AbortSignal;
 }): Promise<void> {
   const resolved = requireRefOrSelector(opts.ref, opts.selector);
   const page = await getRestoredPageForTarget(opts);
@@ -634,12 +669,20 @@ export async function hoverViaPlaywright(opts: {
   const locator = resolved.ref
     ? refLocator(page, requireRef(resolved.ref))
     : page.locator(resolved.selector!);
+  const { abortPromise, cleanup } = createAbortPromise(opts.signal);
+  const reconcileRemoteDialog = () => reconcileRemoteDialogAfterActionSettled(page, opts.signal);
   try {
-    await locator.hover({
-      timeout: resolveInteractionTimeoutMs(opts.timeoutMs),
-    });
+    await awaitActionWithAbort(
+      locator.hover({
+        timeout: resolveInteractionTimeoutMs(opts.timeoutMs),
+      }),
+      abortPromise,
+      reconcileRemoteDialog,
+    );
   } catch (err) {
-    throw toAIFriendlyError(err, label);
+    throw toFriendlyInteractionError(err, label);
+  } finally {
+    cleanup();
   }
 }
 
@@ -651,6 +694,7 @@ export async function dragViaPlaywright(opts: {
   endRef?: string;
   endSelector?: string;
   timeoutMs?: number;
+  signal?: AbortSignal;
 }): Promise<void> {
   const resolvedStart = requireRefOrSelector(opts.startRef, opts.startSelector);
   const resolvedEnd = requireRefOrSelector(opts.endRef, opts.endSelector);
@@ -663,12 +707,20 @@ export async function dragViaPlaywright(opts: {
     : page.locator(resolvedEnd.selector!);
   const startLabel = resolvedStart.ref ?? resolvedStart.selector!;
   const endLabel = resolvedEnd.ref ?? resolvedEnd.selector!;
+  const { abortPromise, cleanup } = createAbortPromise(opts.signal);
+  const reconcileRemoteDialog = () => reconcileRemoteDialogAfterActionSettled(page, opts.signal);
   try {
-    await startLocator.dragTo(endLocator, {
-      timeout: resolveInteractionTimeoutMs(opts.timeoutMs),
-    });
+    await awaitActionWithAbort(
+      startLocator.dragTo(endLocator, {
+        timeout: resolveInteractionTimeoutMs(opts.timeoutMs),
+      }),
+      abortPromise,
+      reconcileRemoteDialog,
+    );
   } catch (err) {
-    throw toAIFriendlyError(err, `${startLabel} -> ${endLabel}`);
+    throw toFriendlyInteractionError(err, `${startLabel} -> ${endLabel}`);
+  } finally {
+    cleanup();
   }
 }
 
@@ -680,6 +732,7 @@ export async function selectOptionViaPlaywright(opts: {
   values: string[];
   timeoutMs?: number;
   ssrfPolicy?: SsrFPolicy;
+  signal?: AbortSignal;
 }): Promise<void> {
   const resolved = requireRefOrSelector(opts.ref, opts.selector);
   if (!opts.values?.length) {
@@ -691,12 +744,18 @@ export async function selectOptionViaPlaywright(opts: {
     ? refLocator(page, requireRef(resolved.ref))
     : page.locator(resolved.selector!);
   const previousUrl = page.url();
+  const { abortPromise, cleanup } = createAbortPromise(opts.signal);
+  const reconcileRemoteDialog = () => reconcileRemoteDialogAfterActionSettled(page, opts.signal);
   try {
     await assertInteractionNavigationCompletedSafely({
       action: async () => {
-        await locator.selectOption(opts.values, {
-          timeout: resolveInteractionTimeoutMs(opts.timeoutMs),
-        });
+        await awaitActionWithAbort(
+          locator.selectOption(opts.values, {
+            timeout: resolveInteractionTimeoutMs(opts.timeoutMs),
+          }),
+          abortPromise,
+          reconcileRemoteDialog,
+        );
       },
       cdpUrl: opts.cdpUrl,
       page,
@@ -705,7 +764,9 @@ export async function selectOptionViaPlaywright(opts: {
       targetId: opts.targetId,
     });
   } catch (err) {
-    throw toAIFriendlyError(err, label);
+    throw toFriendlyInteractionError(err, label);
+  } finally {
+    cleanup();
   }
 }
 
@@ -715,6 +776,7 @@ export async function pressKeyViaPlaywright(opts: {
   key: string;
   delayMs?: number;
   ssrfPolicy?: SsrFPolicy;
+  signal?: AbortSignal;
 }): Promise<void> {
   const key = normalizeOptionalString(opts.key) ?? "";
   if (!key) {
@@ -723,18 +785,28 @@ export async function pressKeyViaPlaywright(opts: {
   const page = await getPageForTargetId(opts);
   ensurePageState(page);
   const previousUrl = page.url();
-  await assertInteractionNavigationCompletedSafely({
-    action: async () => {
-      await page.keyboard.press(key, {
-        delay: Math.max(0, Math.floor(opts.delayMs ?? 0)),
-      });
-    },
-    cdpUrl: opts.cdpUrl,
-    page,
-    previousUrl,
-    ssrfPolicy: opts.ssrfPolicy,
-    targetId: opts.targetId,
-  });
+  const { abortPromise, cleanup } = createAbortPromise(opts.signal);
+  const reconcileRemoteDialog = () => reconcileRemoteDialogAfterActionSettled(page, opts.signal);
+  try {
+    await assertInteractionNavigationCompletedSafely({
+      action: async () => {
+        await awaitActionWithAbort(
+          page.keyboard.press(key, {
+            delay: Math.max(0, Math.floor(opts.delayMs ?? 0)),
+          }),
+          abortPromise,
+          reconcileRemoteDialog,
+        );
+      },
+      cdpUrl: opts.cdpUrl,
+      page,
+      previousUrl,
+      ssrfPolicy: opts.ssrfPolicy,
+      targetId: opts.targetId,
+    });
+  } finally {
+    cleanup();
+  }
 }
 
 export async function typeViaPlaywright(opts: {
@@ -747,6 +819,7 @@ export async function typeViaPlaywright(opts: {
   slowly?: boolean;
   timeoutMs?: number;
   ssrfPolicy?: SsrFPolicy;
+  signal?: AbortSignal;
 }): Promise<void> {
   const resolved = requireRefOrSelector(opts.ref, opts.selector);
   const text = opts.text ?? "";
@@ -756,15 +829,29 @@ export async function typeViaPlaywright(opts: {
     ? refLocator(page, requireRef(resolved.ref))
     : page.locator(resolved.selector!);
   const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
+  const { abortPromise, cleanup } = createAbortPromise(opts.signal);
+  const reconcileRemoteDialog = () => reconcileRemoteDialogAfterActionSettled(page, opts.signal);
   try {
     const previousUrl = page.url();
     if (opts.slowly) {
       await assertInteractionNavigationCompletedSafely({
         action: async () => {
-          await locator.click({ timeout });
-          await locator.type(text, { timeout, delay: 75 });
+          await awaitActionWithAbort(
+            locator.click({ timeout }),
+            abortPromise,
+            reconcileRemoteDialog,
+          );
+          await awaitActionWithAbort(
+            locator.type(text, { timeout, delay: 75 }),
+            abortPromise,
+            reconcileRemoteDialog,
+          );
           if (opts.submit) {
-            await locator.press("Enter", { timeout });
+            await awaitActionWithAbort(
+              locator.press("Enter", { timeout }),
+              abortPromise,
+              reconcileRemoteDialog,
+            );
           }
         },
         cdpUrl: opts.cdpUrl,
@@ -776,9 +863,17 @@ export async function typeViaPlaywright(opts: {
     } else {
       await assertInteractionNavigationCompletedSafely({
         action: async () => {
-          await locator.fill(text, { timeout });
+          await awaitActionWithAbort(
+            locator.fill(text, { timeout }),
+            abortPromise,
+            reconcileRemoteDialog,
+          );
           if (opts.submit) {
-            await locator.press("Enter", { timeout });
+            await awaitActionWithAbort(
+              locator.press("Enter", { timeout }),
+              abortPromise,
+              reconcileRemoteDialog,
+            );
           }
         },
         cdpUrl: opts.cdpUrl,
@@ -789,7 +884,9 @@ export async function typeViaPlaywright(opts: {
       });
     }
   } catch (err) {
-    throw toAIFriendlyError(err, label);
+    throw toFriendlyInteractionError(err, label);
+  } finally {
+    cleanup();
   }
 }
 
@@ -799,31 +896,60 @@ export async function fillFormViaPlaywright(opts: {
   fields: BrowserFormField[];
   timeoutMs?: number;
   ssrfPolicy?: SsrFPolicy;
+  signal?: AbortSignal;
 }): Promise<void> {
   const page = await getRestoredPageForTarget(opts);
   const timeout = resolveInteractionTimeoutMs(opts.timeoutMs);
-  for (const field of opts.fields) {
-    const ref = field.ref.trim();
-    const type = (field.type || DEFAULT_FILL_FIELD_TYPE).trim() || DEFAULT_FILL_FIELD_TYPE;
-    const rawValue = field.value;
-    const value =
-      typeof rawValue === "string"
-        ? rawValue
-        : typeof rawValue === "number" || typeof rawValue === "boolean"
-          ? String(rawValue)
-          : "";
-    if (!ref) {
-      continue;
-    }
-    const locator = refLocator(page, ref);
-    if (type === "checkbox" || type === "radio") {
-      const checked =
-        rawValue === true || rawValue === 1 || rawValue === "1" || rawValue === "true";
+  const { abortPromise, cleanup } = createAbortPromise(opts.signal);
+  const reconcileRemoteDialog = () => reconcileRemoteDialogAfterActionSettled(page, opts.signal);
+  try {
+    for (const field of opts.fields) {
+      const ref = field.ref.trim();
+      const type = (field.type || DEFAULT_FILL_FIELD_TYPE).trim() || DEFAULT_FILL_FIELD_TYPE;
+      const rawValue = field.value;
+      const value =
+        typeof rawValue === "string"
+          ? rawValue
+          : typeof rawValue === "number" || typeof rawValue === "boolean"
+            ? String(rawValue)
+            : "";
+      if (!ref) {
+        continue;
+      }
+      const locator = refLocator(page, ref);
+      if (type === "checkbox" || type === "radio") {
+        const checked =
+          rawValue === true || rawValue === 1 || rawValue === "1" || rawValue === "true";
+        try {
+          const previousUrl = page.url();
+          await assertInteractionNavigationCompletedSafely({
+            action: async () => {
+              await awaitActionWithAbort(
+                locator.setChecked(checked, { timeout }),
+                abortPromise,
+                reconcileRemoteDialog,
+              );
+            },
+            cdpUrl: opts.cdpUrl,
+            page,
+            previousUrl,
+            ssrfPolicy: opts.ssrfPolicy,
+            targetId: opts.targetId,
+          });
+        } catch (err) {
+          throw toFriendlyInteractionError(err, ref);
+        }
+        continue;
+      }
       try {
         const previousUrl = page.url();
         await assertInteractionNavigationCompletedSafely({
           action: async () => {
-            await locator.setChecked(checked, { timeout });
+            await awaitActionWithAbort(
+              locator.fill(value, { timeout }),
+              abortPromise,
+              reconcileRemoteDialog,
+            );
           },
           cdpUrl: opts.cdpUrl,
           page,
@@ -832,25 +958,11 @@ export async function fillFormViaPlaywright(opts: {
           targetId: opts.targetId,
         });
       } catch (err) {
-        throw toAIFriendlyError(err, ref);
+        throw toFriendlyInteractionError(err, ref);
       }
-      continue;
     }
-    try {
-      const previousUrl = page.url();
-      await assertInteractionNavigationCompletedSafely({
-        action: async () => {
-          await locator.fill(value, { timeout });
-        },
-        cdpUrl: opts.cdpUrl,
-        page,
-        previousUrl,
-        ssrfPolicy: opts.ssrfPolicy,
-        targetId: opts.targetId,
-      });
-    } catch (err) {
-      throw toAIFriendlyError(err, ref);
-    }
+  } finally {
+    cleanup();
   }
 }
 
@@ -882,7 +994,10 @@ export async function evaluateViaPlaywright(opts: {
   evaluateTimeout = Math.min(evaluateTimeout, outerTimeout);
 
   const signal = opts.signal;
-  const { abortPromise, cleanup } = createAbortPromiseWithListener(signal, () => {
+  const { abortPromise, cleanup } = createAbortPromiseWithListener(signal, (reason) => {
+    if (isBrowserObservedDialogBlockedError(reason)) {
+      return;
+    }
     void forceDisconnectPlaywrightForTarget({
       cdpUrl: opts.cdpUrl,
       targetId: opts.targetId,
@@ -935,8 +1050,9 @@ export async function evaluateViaPlaywright(opts: {
         fnBody: fnText,
         timeoutMs: evaluateTimeout,
       });
+      const reconcileRemoteDialog = () => reconcileRemoteDialogAfterActionSettled(page, signal);
       const result = await assertInteractionNavigationCompletedSafely({
-        action: () => awaitActionWithAbort(evalPromise, abortPromise),
+        action: () => awaitActionWithAbort(evalPromise, abortPromise, reconcileRemoteDialog),
         cdpUrl: opts.cdpUrl,
         page,
         previousUrl,
@@ -973,8 +1089,9 @@ export async function evaluateViaPlaywright(opts: {
       fnBody: fnText,
       timeoutMs: evaluateTimeout,
     });
+    const reconcileRemoteDialog = () => reconcileRemoteDialogAfterActionSettled(page, signal);
     const result = await assertInteractionNavigationCompletedSafely({
-      action: () => awaitActionWithAbort(evalPromise, abortPromise),
+      action: () => awaitActionWithAbort(evalPromise, abortPromise, reconcileRemoteDialog),
       cdpUrl: opts.cdpUrl,
       page,
       previousUrl,
@@ -993,6 +1110,7 @@ export async function scrollIntoViewViaPlaywright(opts: {
   ref?: string;
   selector?: string;
   timeoutMs?: number;
+  signal?: AbortSignal;
 }): Promise<void> {
   const resolved = requireRefOrSelector(opts.ref, opts.selector);
   const page = await getRestoredPageForTarget(opts);
@@ -1002,10 +1120,18 @@ export async function scrollIntoViewViaPlaywright(opts: {
   const locator = resolved.ref
     ? refLocator(page, requireRef(resolved.ref))
     : page.locator(resolved.selector!);
+  const { abortPromise, cleanup } = createAbortPromise(opts.signal);
+  const reconcileRemoteDialog = () => reconcileRemoteDialogAfterActionSettled(page, opts.signal);
   try {
-    await locator.scrollIntoViewIfNeeded({ timeout });
+    await awaitActionWithAbort(
+      locator.scrollIntoViewIfNeeded({ timeout }),
+      abortPromise,
+      reconcileRemoteDialog,
+    );
   } catch (err) {
-    throw toAIFriendlyError(err, label);
+    throw toFriendlyInteractionError(err, label);
+  } finally {
+    cleanup();
   }
 }
 
@@ -1026,8 +1152,9 @@ export async function waitForViaPlaywright(opts: {
   ensurePageState(page);
   const timeout = resolveActWaitTimeoutMs(opts.timeoutMs);
   const { abortPromise, cleanup } = createAbortPromise(opts.signal);
+  const reconcileRemoteDialog = () => reconcileRemoteDialogAfterActionSettled(page, opts.signal);
   const waitForStep = async <T>(stepPromise: Promise<T>) => {
-    await awaitActionWithAbort(stepPromise, abortPromise);
+    await awaitActionWithAbort(stepPromise, abortPromise, reconcileRemoteDialog);
   };
 
   try {
@@ -1281,7 +1408,7 @@ export async function setInputFilesViaPlaywright(opts: {
   try {
     await locator.setInputFiles(resolvedPaths);
   } catch (err) {
-    throw toAIFriendlyError(err, inputRef || element);
+    throw toFriendlyInteractionError(err, inputRef || element);
   }
   try {
     const handle = await locator.elementHandle();
@@ -1324,6 +1451,7 @@ async function executeSingleAction(
         delayMs: action.delayMs,
         timeoutMs: action.timeoutMs,
         ssrfPolicy,
+        signal,
       });
       break;
     case "clickCoords":
@@ -1337,6 +1465,7 @@ async function executeSingleAction(
         delayMs: action.delayMs,
         timeoutMs: action.timeoutMs,
         ssrfPolicy,
+        signal,
       });
       break;
     case "type":
@@ -1350,6 +1479,7 @@ async function executeSingleAction(
         slowly: action.slowly,
         timeoutMs: action.timeoutMs,
         ssrfPolicy,
+        signal,
       });
       break;
     case "press":
@@ -1359,6 +1489,7 @@ async function executeSingleAction(
         key: action.key,
         delayMs: action.delayMs,
         ssrfPolicy,
+        signal,
       });
       break;
     case "hover":
@@ -1368,6 +1499,7 @@ async function executeSingleAction(
         ref: action.ref,
         selector: action.selector,
         timeoutMs: action.timeoutMs,
+        signal,
       });
       break;
     case "scrollIntoView":
@@ -1377,6 +1509,7 @@ async function executeSingleAction(
         ref: action.ref,
         selector: action.selector,
         timeoutMs: action.timeoutMs,
+        signal,
       });
       break;
     case "drag":
@@ -1388,6 +1521,7 @@ async function executeSingleAction(
         endRef: action.endRef,
         endSelector: action.endSelector,
         timeoutMs: action.timeoutMs,
+        signal,
       });
       break;
     case "select":
@@ -1399,6 +1533,7 @@ async function executeSingleAction(
         values: action.values,
         timeoutMs: action.timeoutMs,
         ssrfPolicy,
+        signal,
       });
       break;
     case "fill":
@@ -1408,6 +1543,7 @@ async function executeSingleAction(
         fields: action.fields,
         timeoutMs: action.timeoutMs,
         ssrfPolicy,
+        signal,
       });
       break;
     case "resize":
@@ -1483,32 +1619,52 @@ export async function executeActViaPlaywright(opts: {
 }): Promise<{
   result?: unknown;
   results?: Array<{ ok: boolean; error?: string }>;
+  blockedByDialog?: boolean;
+  browserState?: unknown;
 }> {
-  if (opts.action.kind === "batch") {
-    const batch = await batchViaPlaywright({
-      cdpUrl: opts.cdpUrl,
-      targetId: opts.targetId,
-      ssrfPolicy: opts.ssrfPolicy,
-      actions: opts.action.actions,
-      stopOnError: opts.action.stopOnError,
-      evaluateEnabled: opts.evaluateEnabled,
-      signal: opts.signal,
-    });
-    return { results: batch.results };
+  const page = await getPageForTargetId({
+    cdpUrl: opts.cdpUrl,
+    targetId: opts.targetId,
+    ssrfPolicy: opts.ssrfPolicy,
+  });
+  const dialogAbort = createObservedDialogAbortSignalForPage({
+    page,
+    parentSignal: opts.signal,
+  });
+  try {
+    if (opts.action.kind === "batch") {
+      const batch = await batchViaPlaywright({
+        cdpUrl: opts.cdpUrl,
+        targetId: opts.targetId,
+        ssrfPolicy: opts.ssrfPolicy,
+        actions: opts.action.actions,
+        stopOnError: opts.action.stopOnError,
+        evaluateEnabled: opts.evaluateEnabled,
+        signal: dialogAbort.signal,
+      });
+      return { results: batch.results };
+    }
+    const result = await executeSingleAction(
+      opts.action,
+      opts.cdpUrl,
+      opts.targetId,
+      opts.evaluateEnabled,
+      opts.ssrfPolicy,
+      0,
+      dialogAbort.signal,
+    );
+    if (opts.action.kind === "evaluate") {
+      return { result };
+    }
+    return {};
+  } catch (err) {
+    if (isBrowserObservedDialogBlockedError(err)) {
+      return { blockedByDialog: true, browserState: err.browserState };
+    }
+    throw err;
+  } finally {
+    dialogAbort.cleanup();
   }
-  const result = await executeSingleAction(
-    opts.action,
-    opts.cdpUrl,
-    opts.targetId,
-    opts.evaluateEnabled,
-    opts.ssrfPolicy,
-    0,
-    opts.signal,
-  );
-  if (opts.action.kind === "evaluate") {
-    return { result };
-  }
-  return {};
 }
 
 export async function batchViaPlaywright(opts: {
@@ -1545,6 +1701,9 @@ export async function batchViaPlaywright(opts: {
       );
       results.push({ ok: true });
     } catch (err) {
+      if (isBrowserObservedDialogBlockedError(err)) {
+        throw err;
+      }
       const message = formatErrorMessage(err);
       results.push({ ok: false, error: message });
       if (opts.stopOnError !== false) {

--- a/extensions/browser/src/browser/pw-tools-core.last-file-chooser-arm-wins.test.ts
+++ b/extensions/browser/src/browser/pw-tools-core.last-file-chooser-arm-wins.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { DEFAULT_UPLOAD_DIR } from "./paths.js";
 import {
+  getPwToolsCoreSessionMocks,
   installPwToolsCoreTestHooks,
   setPwToolsCoreCurrentPage,
 } from "./pw-tools-core.test-harness.js";
@@ -74,38 +75,42 @@ describe("pw-tools-core", () => {
     }
   });
   it("arms the next dialog and accepts/dismisses (default timeout)", async () => {
-    const accept = vi.fn(async () => {});
-    const dismiss = vi.fn(async () => {});
-    const dialog = { accept, dismiss };
-    const waitForEvent = vi.fn(async () => dialog);
-    setPwToolsCoreCurrentPage({
-      waitForEvent,
-    });
+    const sessionMocks = getPwToolsCoreSessionMocks();
+    const page = {};
+    setPwToolsCoreCurrentPage(page);
 
     await mod.armDialogViaPlaywright({
       cdpUrl: "http://127.0.0.1:18792",
       accept: true,
       promptText: "x",
     });
-    await Promise.resolve();
 
-    expect(waitForEvent).toHaveBeenCalledWith("dialog", { timeout: 120_000 });
-    expect(accept).toHaveBeenCalledWith("x");
-    expect(dismiss).not.toHaveBeenCalled();
+    expect(sessionMocks.respondToObservedDialogOnPage).toHaveBeenCalledWith({
+      page,
+      accept: true,
+      promptText: "x",
+      closedBy: "agent",
+    });
+    expect(sessionMocks.armObservedDialogResponseOnPage).toHaveBeenCalledWith({
+      page,
+      accept: true,
+      promptText: "x",
+      timeoutMs: 120_000,
+    });
 
-    accept.mockClear();
-    dismiss.mockClear();
-    waitForEvent.mockClear();
+    sessionMocks.respondToObservedDialogOnPage.mockClear();
+    sessionMocks.armObservedDialogResponseOnPage.mockClear();
 
     await mod.armDialogViaPlaywright({
       cdpUrl: "http://127.0.0.1:18792",
       accept: false,
     });
-    await Promise.resolve();
 
-    expect(waitForEvent).toHaveBeenCalledWith("dialog", { timeout: 120_000 });
-    expect(dismiss).toHaveBeenCalled();
-    expect(accept).not.toHaveBeenCalled();
+    expect(sessionMocks.armObservedDialogResponseOnPage).toHaveBeenCalledWith({
+      page,
+      accept: false,
+      timeoutMs: 120_000,
+    });
   });
   it("waits for selector, url, load state, and function", async () => {
     const waitForSelector = vi.fn(async () => {});

--- a/extensions/browser/src/browser/pw-tools-core.shared.ts
+++ b/extensions/browser/src/browser/pw-tools-core.shared.ts
@@ -3,17 +3,11 @@ import { formatErrorMessage } from "../infra/errors.js";
 import { parseRoleRef } from "./pw-role-snapshot.js";
 
 let nextUploadArmId = 0;
-let nextDialogArmId = 0;
 let nextDownloadArmId = 0;
 
 export function bumpUploadArmId(): number {
   nextUploadArmId += 1;
   return nextUploadArmId;
-}
-
-export function bumpDialogArmId(): number {
-  nextDialogArmId += 1;
-  return nextDialogArmId;
 }
 
 export function bumpDownloadArmId(): number {

--- a/extensions/browser/src/browser/pw-tools-core.test-harness.ts
+++ b/extensions/browser/src/browser/pw-tools-core.test-harness.ts
@@ -5,13 +5,11 @@ let currentRefLocator: Record<string, unknown> | null = null;
 let pageState: {
   console: unknown[];
   armIdUpload: number;
-  armIdDialog: number;
   armIdDownload: number;
   downloadWaiterDepth: number;
 } = {
   console: [],
   armIdUpload: 0,
-  armIdDialog: 0,
   armIdDownload: 0,
   downloadWaiterDepth: 0,
 };
@@ -42,6 +40,15 @@ const sessionMocks = vi.hoisted(() => ({
     return err.name === "SsrFBlockedError" || err.name === "InvalidBrowserNavigationUrlError";
   }),
   restoreRoleRefsForTarget: vi.fn(() => {}),
+  respondToObservedDialogOnPage: vi.fn(async () => {
+    throw new Error("No dialog is pending.");
+  }),
+  armObservedDialogResponseOnPage: vi.fn(() => {}),
+  createObservedDialogAbortSignalForPage: vi.fn((opts?: { parentSignal?: AbortSignal }) => ({
+    signal: opts?.parentSignal ?? new AbortController().signal,
+    cleanup: vi.fn(() => {}),
+  })),
+  isBrowserObservedDialogBlockedError: vi.fn(() => false),
   storeRoleRefsForTarget: vi.fn(() => {}),
   refLocator: vi.fn(() => {
     if (!currentRefLocator) {
@@ -89,7 +96,6 @@ export function installPwToolsCoreTestHooks() {
     pageState = {
       console: [],
       armIdUpload: 0,
-      armIdDialog: 0,
       armIdDownload: 0,
       downloadWaiterDepth: 0,
     };

--- a/extensions/browser/src/browser/routes/agent.act.hooks.ts
+++ b/extensions/browser/src/browser/routes/agent.act.hooks.ts
@@ -119,6 +119,7 @@ export function registerBrowserAgentActHookRoutes(
       const accept = toBoolean(body.accept);
       const promptText = toStringOrEmpty(body.promptText) || undefined;
       const timeoutMs = toNumber(body.timeoutMs);
+      const dialogId = toStringOrEmpty(body.dialogId) || undefined;
       if (accept === undefined) {
         return jsonError(res, 400, "accept is required");
       }
@@ -130,6 +131,9 @@ export function registerBrowserAgentActHookRoutes(
         targetId,
         run: async ({ profileCtx, cdpUrl, tab }) => {
           if (getBrowserProfileCapabilities(profileCtx.profile).usesChromeMcp) {
+            if (dialogId) {
+              return jsonError(res, 501, EXISTING_SESSION_LIMITS.hooks.dialogId);
+            }
             if (timeoutMs) {
               return jsonError(res, 501, EXISTING_SESSION_LIMITS.hooks.dialogTimeout);
             }
@@ -186,6 +190,7 @@ export function registerBrowserAgentActHookRoutes(
           await pw.armDialogViaPlaywright({
             cdpUrl,
             targetId: tab.targetId,
+            dialogId,
             accept,
             promptText,
             timeoutMs: timeoutMs ?? undefined,

--- a/extensions/browser/src/browser/routes/agent.act.ts
+++ b/extensions/browser/src/browser/routes/agent.act.ts
@@ -654,6 +654,12 @@ export function registerBrowserAgentActRoutes(
             ssrfPolicy,
             signal: req.signal,
           });
+          if (result.blockedByDialog) {
+            return await jsonOk({
+              blockedByDialog: true,
+              browserState: result.browserState,
+            });
+          }
           switch (action.kind) {
             case "batch":
               return await jsonOk(

--- a/extensions/browser/src/browser/routes/agent.debug.ts
+++ b/extensions/browser/src/browser/routes/agent.debug.ts
@@ -97,6 +97,31 @@ export function registerBrowserAgentDebugRoutes(
     }),
   );
 
+  app.get(
+    "/dialogs",
+    asyncBrowserRoute(async (req, res) => {
+      const targetId = resolveTargetIdFromQuery(req.query);
+
+      await withPlaywrightRouteContext({
+        req,
+        res,
+        ctx,
+        targetId,
+        feature: "dialog state",
+        enforceCurrentUrlAllowed: true,
+        run: async ({ cdpUrl, tab, pw, resolveTabUrl }) => {
+          const browserState = await pw.getObservedBrowserStateViaPlaywright({
+            cdpUrl,
+            targetId: tab.targetId,
+            ssrfPolicy: ctx.state().resolved.ssrfPolicy,
+          });
+          const url = await resolveTabUrl(tab.url);
+          res.json({ ok: true, targetId: tab.targetId, ...(url ? { url } : {}), browserState });
+        },
+      });
+    }),
+  );
+
   app.post(
     "/trace/start",
     asyncBrowserRoute(async (req, res) => {

--- a/extensions/browser/src/browser/routes/agent.existing-session.test.ts
+++ b/extensions/browser/src/browser/routes/agent.existing-session.test.ts
@@ -74,6 +74,7 @@ vi.mock("../../media/store.js", () => ({
 vi.mock("./agent.shared.js", () => createExistingSessionAgentSharedModule());
 
 const { registerBrowserAgentActRoutes } = await import("./agent.act.js");
+const { registerBrowserAgentActHookRoutes } = await import("./agent.act.hooks.js");
 const { registerBrowserAgentSnapshotRoutes } = await import("./agent.snapshot.js");
 
 function getSnapshotGetHandler(ssrfPolicy?: unknown) {
@@ -102,6 +103,16 @@ function getActPostHandler() {
     state: () => ({ resolved: { evaluateEnabled: true } }),
   } as never);
   const handler = postHandlers.get("/act");
+  expect(handler).toBeTypeOf("function");
+  return handler;
+}
+
+function getDialogHookPostHandler() {
+  const { app, postHandlers } = createBrowserRouteApp();
+  registerBrowserAgentActHookRoutes(app, {
+    state: () => ({ resolved: {} }),
+  } as never);
+  const handler = postHandlers.get("/hooks/dialog");
   expect(handler).toBeTypeOf("function");
   return handler;
 }
@@ -284,6 +295,24 @@ describe("existing-session browser routes", () => {
     const body = requireRecord(response.body, "response body");
     expect(String(body.error)).toContain("type does not support timeoutMs");
     expect(chromeMcpMocks.fillChromeMcpElement).not.toHaveBeenCalled();
+  });
+
+  it("fails closed for existing-session dialogId responses", async () => {
+    const handler = getDialogHookPostHandler();
+    const response = createBrowserRouteResponse();
+    await handler?.(
+      {
+        params: {},
+        query: {},
+        body: { accept: true, dialogId: "d1" },
+      },
+      response.res,
+    );
+
+    expect(response.statusCode).toBe(501);
+    const body = requireRecord(response.body, "response body");
+    expect(String(body.error)).toContain("dialogId");
+    expect(chromeMcpMocks.evaluateChromeMcpScript).not.toHaveBeenCalled();
   });
 
   it("supports glob URL waits for existing-session profiles", async () => {

--- a/extensions/browser/src/browser/routes/agent.snapshot.ts
+++ b/extensions/browser/src/browser/routes/agent.snapshot.ts
@@ -248,6 +248,26 @@ async function saveBrowserMediaResponse(params: {
   });
 }
 
+function hasObservableBrowserState(state: unknown): boolean {
+  if (!state || typeof state !== "object") {
+    return false;
+  }
+  const dialogs = (state as { dialogs?: { pending?: unknown[]; recent?: unknown[] } }).dialogs;
+  return Boolean(dialogs?.pending?.length || dialogs?.recent?.length);
+}
+
+function hasPendingDialogs(state: unknown): boolean {
+  if (!state || typeof state !== "object") {
+    return false;
+  }
+  const dialogs = (state as { dialogs?: { pending?: unknown[] } }).dialogs;
+  return Boolean(dialogs?.pending?.length);
+}
+
+function browserStateResponseFields(state: unknown): { browserState?: unknown } {
+  return hasObservableBrowserState(state) ? { browserState: state } : {};
+}
+
 export function registerBrowserAgentSnapshotRoutes(
   app: BrowserRouteRegistrar,
   ctx: BrowserRouteContext,
@@ -524,11 +544,26 @@ export function registerBrowserAgentSnapshotRoutes(
 
       try {
         const tab = await profileCtx.ensureTabAvailable(targetId || undefined);
+        const usesChromeMcp = getBrowserProfileCapabilities(profileCtx.profile).usesChromeMcp;
+        const ssrfPolicyOpts = browserNavigationPolicyForProfile(ctx, profileCtx);
+        let observedBrowserState: unknown;
+        if (!usesChromeMcp && pwModule) {
+          await assertBrowserNavigationResultAllowed({
+            url: tab.url,
+            ...ssrfPolicyOpts,
+          });
+          observedBrowserState = await pwModule
+            .getObservedBrowserStateViaPlaywright({
+              cdpUrl: profileCtx.profile.cdpUrl,
+              targetId: tab.targetId,
+              ssrfPolicy: ctx.state().resolved.ssrfPolicy,
+            })
+            .catch(() => undefined);
+        }
         if ((plan.labels || plan.mode === "efficient") && plan.format === "aria") {
           return jsonError(res, 400, "labels/mode=efficient require format=ai");
         }
-        if (getBrowserProfileCapabilities(profileCtx.profile).usesChromeMcp) {
-          const ssrfPolicyOpts = browserNavigationPolicyForProfile(ctx, profileCtx);
+        if (usesChromeMcp) {
           if (plan.selectorValue || plan.frameSelectorValue) {
             return jsonError(res, 400, EXISTING_SESSION_LIMITS.snapshot.snapshotSelector);
           }
@@ -628,6 +663,17 @@ export function registerBrowserAgentSnapshotRoutes(
             ...builtWithUrls,
           });
         }
+        if (hasPendingDialogs(observedBrowserState)) {
+          return res.json({
+            ok: true,
+            format: plan.format,
+            targetId: tab.targetId,
+            url: tab.url,
+            blockedByDialog: true,
+            ...browserStateResponseFields(observedBrowserState),
+            ...(plan.format === "aria" ? { nodes: [] } : { snapshot: "", refs: {} }),
+          });
+        }
         if (plan.format === "ai") {
           const roleSnapshotArgs = {
             cdpUrl: profileCtx.profile.cdpUrl,
@@ -715,6 +761,7 @@ export function registerBrowserAgentSnapshotRoutes(
               format: plan.format,
               targetId: tab.targetId,
               url: tab.url,
+              ...browserStateResponseFields(observedBrowserState),
               labels: true,
               labelsCount: labeled.labels,
               labelsSkipped: labeled.skipped,
@@ -729,6 +776,7 @@ export function registerBrowserAgentSnapshotRoutes(
             format: plan.format,
             targetId: tab.targetId,
             url: tab.url,
+            ...browserStateResponseFields(observedBrowserState),
             ...snap,
           });
         }
@@ -771,6 +819,7 @@ export function registerBrowserAgentSnapshotRoutes(
           format: plan.format,
           targetId: tab.targetId,
           url: tab.url,
+          ...browserStateResponseFields(observedBrowserState),
           ...resolved,
         });
       } catch (err) {

--- a/extensions/browser/src/browser/routes/existing-session-limits.ts
+++ b/extensions/browser/src/browser/routes/existing-session-limits.ts
@@ -28,6 +28,7 @@ export const EXISTING_SESSION_LIMITS = {
       "existing-session file uploads do not support element selectors; use ref/inputRef.",
     uploadSingleFile: "existing-session file uploads currently support one file at a time.",
     uploadRefRequired: "existing-session file uploads require ref or inputRef.",
+    dialogId: "existing-session dialog handling does not support dialogId.",
     dialogTimeout: "existing-session dialog handling does not support timeoutMs.",
   },
   download: {

--- a/extensions/browser/src/browser/server.agent-contract-core.test.ts
+++ b/extensions/browser/src/browser/server.agent-contract-core.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_AI_SNAPSHOT_MAX_CHARS } from "./constants.js";
+import { BROWSER_NAVIGATION_BLOCKED_MESSAGE } from "./errors.js";
 import {
   installAgentContractHooks,
   postJson,
@@ -17,6 +18,8 @@ import {
   setBrowserControlServerEvaluateEnabled,
   setBrowserControlServerProfiles,
   setBrowserControlServerReachable,
+  setBrowserControlServerSsrFPolicy,
+  setBrowserControlServerTabUrl,
   startBrowserControlServerFromConfig,
 } from "./server.control-server.test-harness.js";
 import { getBrowserTestFetch } from "./test-support/fetch.js";
@@ -224,6 +227,46 @@ describe("browser control server", () => {
   );
 
   it(
+    "returns blocked dialog state for action-triggered modals",
+    async () => {
+      const base = await startServerAndBase();
+      pwMocks.executeActViaPlaywright.mockResolvedValueOnce({
+        blockedByDialog: true,
+        browserState: {
+          dialogs: {
+            pending: [
+              {
+                id: "d1",
+                type: "confirm",
+                message: "Continue?",
+                openedAt: "2026-05-17T12:00:00.000Z",
+              },
+            ],
+            recent: [],
+          },
+        },
+      });
+
+      const response = await postJson<{
+        ok: boolean;
+        blockedByDialog?: boolean;
+        browserState?: { dialogs?: { pending?: Array<{ id?: string; message?: string }> } };
+      }>(`${base}/act`, {
+        kind: "click",
+        ref: "5",
+      });
+
+      expect(response.ok).toBe(true);
+      expect(response.blockedByDialog).toBe(true);
+      expect(response.browserState?.dialogs?.pending?.[0]).toMatchObject({
+        id: "d1",
+        message: "Continue?",
+      });
+    },
+    slowTimeoutMs,
+  );
+
+  it(
     "returns ACT_SELECTOR_UNSUPPORTED for selector on unsupported action kinds",
     async () => {
       const base = await startServerAndBase();
@@ -336,6 +379,67 @@ describe("browser control server", () => {
         maxDepth: undefined,
       },
     });
+  });
+
+  it("agent contract: snapshot surfaces pending dialog state without reading the blocked page", async () => {
+    const base = await startServerAndBase();
+    const realFetch = getBrowserTestFetch();
+    pwMocks.getObservedBrowserStateViaPlaywright.mockResolvedValueOnce({
+      dialogs: {
+        pending: [
+          {
+            id: "d1",
+            type: "confirm",
+            message: "Continue?",
+            openedAt: "2026-05-17T12:00:00.000Z",
+          },
+        ],
+        recent: [],
+      },
+    });
+
+    const snap = (await realFetch(`${base}/snapshot?format=ai`).then((r) => r.json())) as {
+      ok: boolean;
+      blockedByDialog?: boolean;
+      browserState?: { dialogs?: { pending?: Array<{ id?: string; message?: string }> } };
+      snapshot?: string;
+    };
+
+    expect(snap.ok).toBe(true);
+    expect(snap.blockedByDialog).toBe(true);
+    expect(snap.snapshot).toBe("");
+    expect(snap.browserState?.dialogs?.pending?.[0]).toMatchObject({
+      id: "d1",
+      message: "Continue?",
+    });
+    expect(pwMocks.snapshotAiViaPlaywright).not.toHaveBeenCalled();
+  });
+
+  it("agent contract: snapshot blocks pending dialog state on disallowed current tab URLs", async () => {
+    setBrowserControlServerSsrFPolicy({ allowPrivateNetwork: false });
+    setBrowserControlServerTabUrl("http://127.0.0.1:8080/admin");
+    const base = await startServerAndBase();
+    const realFetch = getBrowserTestFetch();
+    pwMocks.getObservedBrowserStateViaPlaywright.mockResolvedValueOnce({
+      dialogs: {
+        pending: [
+          {
+            id: "d1",
+            type: "alert",
+            message: "blocked secret",
+            openedAt: "2026-05-17T12:00:00.000Z",
+          },
+        ],
+        recent: [],
+      },
+    });
+
+    const res = await realFetch(`${base}/snapshot?format=ai`);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error?: unknown };
+    expect(body.error).toBe(BROWSER_NAVIGATION_BLOCKED_MESSAGE);
+    expect(pwMocks.getObservedBrowserStateViaPlaywright).not.toHaveBeenCalled();
+    expect(pwMocks.snapshotAiViaPlaywright).not.toHaveBeenCalled();
   });
 
   it("agent contract: doctor deep runs a live snapshot probe", async () => {

--- a/extensions/browser/src/browser/server.agent-contract-form-layout-act-commands.test.ts
+++ b/extensions/browser/src/browser/server.agent-contract-form-layout-act-commands.test.ts
@@ -437,9 +437,16 @@ describe("browser control server", () => {
 
     const dialog = await postJson(`${base}/hooks/dialog`, {
       accept: true,
+      dialogId: "d1",
       timeoutMs: 5678,
     });
     expectOkResult(dialog);
+    expectBrowserCallFields(pwMocks.armDialogViaPlaywright, {
+      targetId: "abcd1234",
+      accept: true,
+      dialogId: "d1",
+      timeoutMs: 5678,
+    });
 
     const waitDownload = await postJson(`${base}/wait/download`, {
       path: "report.pdf",

--- a/extensions/browser/src/browser/server.control-server.test-harness.ts
+++ b/extensions/browser/src/browser/server.control-server.test-harness.ts
@@ -176,6 +176,9 @@ const pwMocks = vi.hoisted(() => ({
   fillFormViaPlaywright: vi.fn(async (_opts?: unknown) => {}),
   getConsoleMessagesViaPlaywright: vi.fn(async () => []),
   getNetworkRequestsViaPlaywright: vi.fn(async () => ({ requests: [] })),
+  getObservedBrowserStateViaPlaywright: vi.fn(async () => ({
+    dialogs: { pending: [], recent: [] },
+  })),
   getPageErrorsViaPlaywright: vi.fn(async () => ({ errors: [] })),
   hoverViaPlaywright: vi.fn(async (_opts?: unknown) => {}),
   scrollIntoViewViaPlaywright: vi.fn(async (_opts?: unknown) => {}),

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.files-downloads.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.files-downloads.ts
@@ -175,6 +175,7 @@ export function registerBrowserFilesAndDownloadsCommands(
     .option("--accept", "Accept the dialog", false)
     .option("--dismiss", "Dismiss the dialog", false)
     .option("--prompt <text>", "Prompt response text")
+    .option("--dialog-id <id>", "Pending dialog id from snapshot/browser state")
     .option("--target-id <id>", "CDP target id (or unique prefix)")
     .option(
       "--timeout-ms <ms>",
@@ -202,6 +203,7 @@ export function registerBrowserFilesAndDownloadsCommands(
         body: {
           accept,
           promptText: normalizeOptionalString(opts.prompt),
+          dialogId: normalizeOptionalString(opts.dialogId),
           targetId,
           timeoutMs,
         },


### PR DESCRIPTION
## Summary
- track managed-browser modal dialogs as pending/recent browser state and expose that state through action, snapshot, and debug responses
- let browser dialog actions answer a still-pending dialog by id while preserving arm-next-dialog behavior
- guard dialog state with current-URL policy, reject unsupported existing-session dialog ids, and document the CLI/docs behavior

## Verification
- `node scripts/run-vitest.mjs extensions/browser/src/browser-tool.test.ts extensions/browser/src/browser/pw-session.dialogs.test.ts extensions/browser/src/browser/pw-tools-core.interactions.evaluate.abort.test.ts extensions/browser/src/browser/server.agent-contract-core.test.ts extensions/browser/src/browser/server.agent-contract-form-layout-act-commands.test.ts extensions/browser/src/browser/routes/agent.existing-session.test.ts`
- `node scripts/run-vitest.mjs extensions/browser/src/browser/client.test.ts extensions/browser/src/browser-tool.test.ts extensions/browser/src/browser/pw-session.dialogs.test.ts extensions/browser/src/browser/server.agent-contract-core.test.ts`
- `git diff --check`
- `env CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_TEST_PROJECTS_PARALLEL=6 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 pnpm check:changed`
- `/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review`

Behavior addressed: Managed browser actions and snapshots now expose pending modal dialog state, and dialog actions can target a still-pending dialog id.
Real environment tested: local browser test harness and local changed gate in this checkout
Exact steps or command run after this patch: see Verification
Evidence after fix: focused dialog/control-server/browser-tool tests passed; `pnpm check:changed` passed for extensions, extensionTests, and docs lanes; Codex review reported no actionable findings
Observed result after fix: action-triggered dialogs return `blockedByDialog` with pending ids, pending dialog text is URL-policy guarded, unsupported existing-session dialog ids fail closed, and blocked AI snapshots preserve recovery state
What was not tested: live Chrome UI session; Blacksmith Testbox changed gate was blocked because the configured hydrate workflow has no testbox step, and AWS fallback was a raw box without `pnpm`
