### PR TITLE
Add inbound_observed hook for skipped inbound messages

### DIFF
--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -126,6 +126,7 @@ observation-only.
 **Messages and delivery**
 
 - **`inbound_claim`** - claim an inbound message before agent routing (synthetic replies)
+- `inbound_observed` - observe inbound content accepted or skipped by a channel
 - `message_received` - observe inbound content, sender, thread, and metadata
 - **`message_sending`** - rewrite outbound content or cancel delivery
 - `message_sent` - observe outbound delivery success or failure
@@ -366,6 +367,14 @@ generation.
 
 Use message hooks for channel-level routing and delivery policy:
 
+- `inbound_observed`: observe inbound content that the channel runtime has
+  accepted for visibility but has not necessarily dispatched to an agent
+  session. This hook is read-only and fire-and-forget. It is intended for
+  passive archive, audit, and metrics plugins that need visibility into inbound
+  channel events without changing routing or reply behavior. Skipped messages
+  can include `skipped: true` and a stable `skipReason`, such as
+  `requireMention:no-mention`, when a channel drops the message before agent
+  dispatch.
 - `message_received`: observe inbound content, sender, `threadId`, `messageId`,
   `senderId`, optional run/session correlation, and metadata.
 - `message_sending`: rewrite `content` or return `{ cancel: true }`.
@@ -386,6 +395,8 @@ metadata.
 
 Decision rules:
 
+- `inbound_observed` is observation-only. Handler failures are logged and do
+  not create a session, trigger a reply, or change dispatch decisions.
 - `message_sending` with `cancel: true` is terminal.
 - `message_sending` with `cancel: false` is treated as no decision.
 - Rewritten `content` continues to lower-priority hooks unless a later hook

--- a/extensions/telegram/src/bot-message-context.body.test.ts
+++ b/extensions/telegram/src/bot-message-context.body.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import { normalizeAllowFrom } from "./bot-access.js";
 
-const { transcribeFirstAudioMock, triggerInternalHookMock } = vi.hoisted(() => ({
+const { hookRunnerMock, transcribeFirstAudioMock, triggerInternalHookMock } = vi.hoisted(() => ({
+  hookRunnerMock: {
+    hasHooks: vi.fn((_hookName?: string) => false),
+    runInboundObserved: vi.fn(async () => undefined),
+  },
   transcribeFirstAudioMock: vi.fn(),
   triggerInternalHookMock: vi.fn<(event: unknown) => Promise<void>>(async () => undefined),
 }));
@@ -22,6 +26,10 @@ vi.mock("openclaw/plugin-sdk/hook-runtime", async () => {
     triggerInternalHook: (event: unknown) => triggerInternalHookMock(event),
   };
 });
+
+vi.mock("openclaw/plugin-sdk/plugin-runtime", () => ({
+  getGlobalHookRunner: () => hookRunnerMock,
+}));
 
 const { resolveTelegramInboundBody } = await import("./bot-message-context.body.js");
 
@@ -249,6 +257,58 @@ describe("resolveTelegramInboundBody", () => {
     expect(result).toBeNull();
   });
 
+  it("emits inbound_observed for skipped requireMention group messages", async () => {
+    hookRunnerMock.hasHooks.mockImplementation((hookName) => hookName === "inbound_observed");
+    hookRunnerMock.runInboundObserved.mockClear();
+    const logger = { info: vi.fn() };
+
+    const result = await resolveTelegramBody({
+      cfg: {
+        channels: { telegram: {} },
+        messages: { groupChat: { mentionPatterns: ["\\bbot\\b"] } },
+      } as never,
+      msg: {
+        message_id: 123,
+        date: 1_700_000_000,
+        chat: { id: -1001234567890, type: "supergroup", title: "Test Group" },
+        from: { id: 46, first_name: "Eve" },
+        text: "quiet group message",
+        entities: [],
+      } as never,
+      allMedia: [],
+      isGroup: true,
+      chatId: -1001234567890,
+      senderId: "46",
+      senderUsername: "",
+      routeAgentId: undefined,
+      effectiveGroupAllow: normalizeAllowFrom([]),
+      effectiveDmAllow: normalizeAllowFrom([]),
+      groupConfig: { requireMention: true } as never,
+      requireMention: true,
+      logger,
+    });
+
+    expect(result).toBeNull();
+    expect(hookRunnerMock.runInboundObserved).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "telegram",
+        content: "quiet group message",
+        conversationId: "telegram:-1001234567890",
+        isGroup: true,
+        messageId: "123",
+        senderId: "46",
+        skipped: true,
+        skipReason: "requireMention:no-mention",
+      }),
+      expect.objectContaining({
+        channelId: "telegram",
+        conversationId: "telegram:-1001234567890",
+        messageId: "123",
+      }),
+    );
+    hookRunnerMock.hasHooks.mockImplementation(() => false);
+  });
+
   it("still transcribes when commands.useAccessGroups is false", async () => {
     transcribeFirstAudioMock.mockReset();
     transcribeFirstAudioMock.mockResolvedValueOnce("hey bot please help");
@@ -387,6 +447,8 @@ describe("resolveTelegramInboundBody", () => {
   });
 
   it("preserves forum topic origin targets for skipped-message hooks", async () => {
+    hookRunnerMock.hasHooks.mockImplementation((hookName) => hookName === "inbound_observed");
+    hookRunnerMock.runInboundObserved.mockClear();
     triggerInternalHookMock.mockClear();
 
     const result = await resolveTelegramBody({
@@ -432,7 +494,32 @@ describe("resolveTelegramInboundBody", () => {
         to: "telegram:-1001234567890:topic:99",
       }),
     );
+    expect(hookRunnerMock.runInboundObserved).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "telegram",
+        content: "ambient chatter",
+        conversationId: "telegram:-1001234567890:topic:99",
+        isGroup: true,
+        messageId: "14",
+        senderId: "46",
+        skipped: true,
+        skipReason: "requireMention:no-mention",
+        threadId: 99,
+        metadata: expect.objectContaining({
+          groupId: "telegram:-1001234567890",
+          originatingTo: "telegram:-1001234567890:topic:99",
+          threadId: 99,
+          to: "telegram:-1001234567890:topic:99",
+        }),
+      }),
+      expect.objectContaining({
+        channelId: "telegram",
+        conversationId: "telegram:-1001234567890:topic:99",
+        messageId: "14",
+      }),
+    );
     expect(triggerInternalHookMock).toHaveBeenCalledOnce();
+    hookRunnerMock.hasHooks.mockImplementation(() => false);
   });
 
   it("escapes transcript text before embedding it in the audio framing", async () => {

--- a/extensions/telegram/src/bot-message-context.body.ts
+++ b/extensions/telegram/src/bot-message-context.body.ts
@@ -19,8 +19,11 @@ import {
   createInternalHookEvent,
   fireAndForgetHook,
   toInternalMessageReceivedContext,
+  toPluginInboundObservedEvent,
+  toPluginMessageContext,
   triggerInternalHook,
 } from "openclaw/plugin-sdk/hook-runtime";
+import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 import { createChannelHistoryWindow, type HistoryEntry } from "openclaw/plugin-sdk/reply-history";
 import type { MsgContext } from "openclaw/plugin-sdk/reply-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
@@ -59,6 +62,64 @@ function loadStickerVisionRuntime(): Promise<StickerVisionRuntime> {
 function loadMediaUnderstandingRuntime(): Promise<MediaUnderstandingRuntime> {
   mediaUnderstandingRuntimePromise ??= import("./media-understanding.runtime.js");
   return mediaUnderstandingRuntimePromise;
+}
+
+function emitSkippedInboundObserved(params: {
+  accountId?: string;
+  chatId: number | string;
+  historyKey?: string;
+  msg: TelegramContext["message"];
+  originatingTo?: string;
+  rawBody: string;
+  resolvedThreadId?: number;
+  senderId: string;
+  senderUsername: string;
+  wasMentioned: boolean;
+}): void {
+  const hookRunner = getGlobalHookRunner();
+  if (!hookRunner?.hasHooks("inbound_observed")) {
+    return;
+  }
+  const groupId = `telegram:${params.chatId}`;
+  const conversationId = params.originatingTo ?? groupId;
+  const timestamp =
+    typeof params.msg.date === "number" && Number.isFinite(params.msg.date)
+      ? params.msg.date * 1000
+      : undefined;
+  const canonical = {
+    from: `telegram:group:${params.historyKey ?? params.chatId}`,
+    to: conversationId,
+    content: params.rawBody,
+    body: params.rawBody,
+    bodyForAgent: params.rawBody,
+    timestamp,
+    channelId: "telegram",
+    accountId: params.accountId,
+    conversationId,
+    messageId:
+      typeof params.msg.message_id === "number" ? String(params.msg.message_id) : undefined,
+    senderId: params.senderId || undefined,
+    senderName: buildSenderName(params.msg),
+    senderUsername: params.senderUsername || undefined,
+    provider: "telegram",
+    surface: "telegram",
+    threadId: params.resolvedThreadId,
+    originatingChannel: "telegram",
+    originatingTo: conversationId,
+    isGroup: true,
+    groupId,
+  };
+  fireAndForgetHook(
+    hookRunner.runInboundObserved(
+      toPluginInboundObservedEvent(canonical, {
+        skipped: true,
+        skipReason: "requireMention:no-mention",
+        wasMentioned: params.wasMentioned,
+      }),
+      toPluginMessageContext(canonical),
+    ),
+    "telegram: inbound_observed plugin hook failed",
+  );
 }
 
 export type TelegramInboundBodyResult = {
@@ -358,6 +419,18 @@ export async function resolveTelegramInboundBody(params: {
   const effectiveWasMentioned = mentionDecision.effectiveWasMentioned;
   if (isGroup && requireMention && canDetectMention && mentionDecision.shouldSkip) {
     logger.info({ chatId, reason: "no-mention" }, "skipping group message");
+    emitSkippedInboundObserved({
+      accountId,
+      chatId,
+      historyKey,
+      resolvedThreadId,
+      msg,
+      originatingTo,
+      senderId,
+      senderUsername,
+      rawBody,
+      wasMentioned: effectiveWasMentioned,
+    });
     createChannelHistoryWindow({ historyMap: groupHistories }).record({
       historyKey: historyKey ?? "",
       limit: historyLimit,

--- a/extensions/telegram/src/bot-message-context.silent-ingest.test-support.ts
+++ b/extensions/telegram/src/bot-message-context.silent-ingest.test-support.ts
@@ -23,6 +23,8 @@ vi.mock("openclaw/plugin-sdk/hook-runtime", () => {
       ...context,
       metadata: { to: context.to },
     }),
+    toPluginInboundObservedEvent: (context: Record<string, unknown>) => context,
+    toPluginMessageContext: (context: Record<string, unknown>) => context,
     triggerInternalHook: internalHookMocks.triggerInternalHook,
   };
 });

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -8,6 +8,7 @@ import {
 import type {
   PluginHookInboundClaimContext,
   PluginHookInboundClaimEvent,
+  PluginHookInboundObservedEvent,
   PluginHookMessageContext,
   PluginHookMessageReceivedEvent,
   PluginHookMessageSentEvent,
@@ -351,6 +352,56 @@ export function toPluginInboundClaimEvent(
       channelName: canonical.channelName,
       groupId: canonical.groupId,
       topicName: canonical.topicName,
+    },
+  };
+  assignTraceFields(event, canonical.trace);
+  return event;
+}
+
+export function toPluginInboundObservedEvent(
+  canonical: CanonicalInboundMessageHookContext,
+  observed?: {
+    skipped?: boolean;
+    skipReason?: string;
+    wasMentioned?: boolean;
+  },
+): PluginHookInboundObservedEvent {
+  const event: PluginHookInboundObservedEvent = {
+    content: canonical.content,
+    body: canonical.body,
+    bodyForAgent: canonical.bodyForAgent,
+    timestamp: canonical.timestamp,
+    channel: canonical.channelId,
+    accountId: canonical.accountId,
+    conversationId: canonical.conversationId,
+    senderId: canonical.senderId,
+    senderName: canonical.senderName,
+    senderUsername: canonical.senderUsername,
+    threadId: canonical.threadId,
+    messageId: canonical.messageId,
+    isGroup: canonical.isGroup,
+    wasMentioned: observed?.wasMentioned,
+    skipped: observed?.skipped,
+    skipReason: observed?.skipReason,
+    metadata: {
+      from: canonical.from,
+      to: canonical.to,
+      provider: canonical.provider,
+      surface: canonical.surface,
+      threadId: canonical.threadId,
+      originatingChannel: canonical.originatingChannel,
+      originatingTo: canonical.originatingTo,
+      messageId: canonical.messageId,
+      senderId: canonical.senderId,
+      senderName: canonical.senderName,
+      senderUsername: canonical.senderUsername,
+      senderE164: canonical.senderE164,
+      guildId: canonical.guildId,
+      channelName: canonical.channelName,
+      groupId: canonical.groupId,
+      topicName: canonical.topicName,
+      skipped: observed?.skipped,
+      skipReason: observed?.skipReason,
     },
   };
   assignTraceFields(event, canonical.trace);

--- a/src/plugins/hook-message.types.ts
+++ b/src/plugins/hook-message.types.ts
@@ -50,6 +50,30 @@ export type PluginHookInboundClaimEvent = {
   metadata?: Record<string, unknown>;
 };
 
+export type PluginHookInboundObservedEvent = {
+  content: string;
+  body?: string;
+  bodyForAgent?: string;
+  timestamp?: number;
+  channel: string;
+  accountId?: string;
+  conversationId?: string;
+  senderId?: string;
+  senderName?: string;
+  senderUsername?: string;
+  threadId?: string | number;
+  messageId?: string;
+  trace?: DiagnosticTraceContext;
+  traceId?: string;
+  spanId?: string;
+  parentSpanId?: string;
+  isGroup: boolean;
+  wasMentioned?: boolean;
+  skipped?: boolean;
+  skipReason?: string;
+  metadata?: Record<string, unknown>;
+};
+
 export type PluginHookMessageReceivedEvent = {
   from: string;
   content: string;

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -21,6 +21,7 @@ import type { InputGateDecision } from "./hook-decision-types.js";
 import type {
   PluginHookInboundClaimContext,
   PluginHookInboundClaimEvent,
+  PluginHookInboundObservedEvent,
   PluginHookMessageContext,
   PluginHookMessageReceivedEvent,
   PluginHookMessageSendingEvent,
@@ -58,6 +59,7 @@ export type {
 export type {
   PluginHookInboundClaimContext,
   PluginHookInboundClaimEvent,
+  PluginHookInboundObservedEvent,
   PluginHookMessageContext,
   PluginHookMessageReceivedEvent,
   PluginHookMessageSendingEvent,
@@ -80,6 +82,7 @@ export type PluginHookName =
   | "before_compaction"
   | "after_compaction"
   | "before_reset"
+  | "inbound_observed"
   | "inbound_claim"
   | "message_received"
   | "message_sending"
@@ -120,6 +123,7 @@ export const PLUGIN_HOOK_NAMES = [
   "before_compaction",
   "after_compaction",
   "before_reset",
+  "inbound_observed",
   "inbound_claim",
   "message_received",
   "message_sending",
@@ -940,6 +944,10 @@ export type PluginHookHandlerMap = {
     event: PluginHookInboundClaimEvent,
     ctx: PluginHookInboundClaimContext,
   ) => Promise<PluginHookInboundClaimResult | void> | PluginHookInboundClaimResult | void;
+  inbound_observed: (
+    event: PluginHookInboundObservedEvent,
+    ctx: PluginHookMessageContext,
+  ) => Promise<void> | void;
   before_dispatch: (
     event: PluginHookBeforeDispatchEvent,
     ctx: PluginHookBeforeDispatchContext,

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -41,6 +41,7 @@ import type {
   PluginHookInboundClaimContext,
   PluginHookInboundClaimEvent,
   PluginHookInboundClaimResult,
+  PluginHookInboundObservedEvent,
   PluginHookLlmInputEvent,
   PluginHookLlmOutputEvent,
   PluginHookBeforeResetEvent,
@@ -115,6 +116,7 @@ export type {
   PluginHookInboundClaimContext,
   PluginHookInboundClaimEvent,
   PluginHookInboundClaimResult,
+  PluginHookInboundObservedEvent,
   PluginHookAfterCompactionEvent,
   PluginHookMessageContext,
   PluginHookMessageReceivedEvent,
@@ -948,6 +950,17 @@ export function createHookRunner(
   // =========================================================================
 
   /**
+   * Run inbound_observed hook.
+   * Read-only visibility for channel inbound events before later dispatch gates.
+   */
+  async function runInboundObserved(
+    event: PluginHookInboundObservedEvent,
+    ctx: PluginHookMessageContext,
+  ): Promise<void> {
+    return runVoidHook("inbound_observed", event, ctx);
+  }
+
+  /**
    * Run inbound_claim hook.
    * Allows plugins to claim an inbound event before commands/agent dispatch.
    */
@@ -1499,6 +1512,7 @@ export function createHookRunner(
     // Lifecycle gate hooks
     runBeforeAgentRun,
     // Message hooks
+    runInboundObserved,
     runInboundClaim,
     runInboundClaimForPlugin,
     runInboundClaimForPluginOutcome,

--- a/src/plugins/wired-hooks-message.test.ts
+++ b/src/plugins/wired-hooks-message.test.ts
@@ -6,14 +6,18 @@
 import { describe, expect, it, vi } from "vitest";
 import { createHookRunnerWithRegistry } from "./hooks.test-helpers.js";
 import type {
+  PluginHookInboundObservedEvent,
   PluginHookMessageSendingEvent,
   PluginHookMessageSendingResult,
   PluginHookMessageSentEvent,
 } from "./types.js";
 
 async function expectMessageHookCall(params: {
-  hookName: "message_sending" | "message_sent";
-  event: PluginHookMessageSendingEvent | PluginHookMessageSentEvent;
+  hookName: "inbound_observed" | "message_sending" | "message_sent";
+  event:
+    | PluginHookInboundObservedEvent
+    | PluginHookMessageSendingEvent
+    | PluginHookMessageSentEvent;
   hookResult?: PluginHookMessageSendingResult;
   expectedResult?: PluginHookMessageSendingResult;
   channelCtx: { channelId: string };
@@ -22,7 +26,12 @@ async function expectMessageHookCall(params: {
     params.hookResult === undefined ? vi.fn() : vi.fn().mockReturnValue(params.hookResult);
   const { runner } = createHookRunnerWithRegistry([{ hookName: params.hookName, handler }]);
 
-  if (params.hookName === "message_sending") {
+  if (params.hookName === "inbound_observed") {
+    await runner.runInboundObserved(
+      params.event as PluginHookInboundObservedEvent,
+      params.channelCtx,
+    );
+  } else if (params.hookName === "message_sending") {
     const result = await runner.runMessageSending(
       params.event as PluginHookMessageSendingEvent,
       params.channelCtx,
@@ -38,6 +47,25 @@ async function expectMessageHookCall(params: {
 
   expect(handler).toHaveBeenCalledWith(params.event, params.channelCtx);
 }
+
+describe("inbound_observed hook runner", () => {
+  const demoChannelCtx = { channelId: "demo-channel" };
+
+  it("runInboundObserved invokes registered hooks", async () => {
+    await expectMessageHookCall({
+      hookName: "inbound_observed",
+      event: {
+        channel: "demo-channel",
+        content: "quiet room message",
+        conversationId: "room-1",
+        isGroup: true,
+        skipped: true,
+        skipReason: "requireMention:no-mention",
+      },
+      channelCtx: demoChannelCtx,
+    });
+  });
+});
 
 describe("message_sending hook runner", () => {
   const demoChannelCtx = { channelId: "demo-channel" };


### PR DESCRIPTION
## Summary

Adds a read-only `inbound_observed` plugin hook for passive inbound visibility, then emits it from Telegram when a group message is skipped by `requireMention`/mention gating.

This gives archive/audit/history plugins a supported way to observe messages that are visible to the gateway but intentionally do not enter an agent session or trigger a reply.

## Why

`message_received` currently represents messages that have entered the later dispatch/session path. Moving it earlier would risk changing existing plugin semantics. A dedicated observational hook keeps real-time session routing lean while still enabling full-history archive plugins to record skipped inbound messages.

The new hook is intentionally narrow:

- read-only event payload
- fire-and-forget execution
- no session creation
- no reply/routing override
- includes `skipped` and `skipReason` metadata for mention-gated drops

## Validation

- `pnpm vitest run src/plugins/wired-hooks-message.test.ts extensions/telegram/src/bot-message-context.body.test.ts src/hooks/message-hook-mappers.test.ts extensions/telegram/src/bot-message-context.group-body.test.ts`
- `pnpm build`
- `pnpm check:test-types`

## Real behavior proof

**Behavior or issue addressed:** Telegram group messages skipped by `requireMention` were invisible to passive archive/history plugins because they returned before the normal dispatch/session hook path. This patch adds a read-only `inbound_observed` hook and emits it for those skipped Telegram group messages.

**Real environment tested:** Live OpenClaw server on the maintainer's local Mac mini, using the local patched source checkout and the existing `conversation-archive` plugin.

**Exact steps or command run after this patch:**

```text
scripts/source-switch-local.sh
scripts/local-status.sh
scripts/check-conversation-archive.sh --hours 24
node --check /Users/cindy/.openclaw/extensions/conversation-archive/index.js
```

I also ran a plugin-level smoke that invoked `conversation-archive` through `inbound_observed` and wrote a raw archive JSONL entry.

**Evidence after fix:**

Representative redacted live output from the patched server:

```text
OpenClaw status
service check
  launchd: system/ai.openclaw.gateway.headless running
  listener: 17185 (port 18789)

Channels
  Telegram ON OK
  BlueBubbles ON OK
  FoloToy ON OK
  @larksuite/openclaw-lark ON OK

Telegram skipped-group inbound_observed archive hook patch is present
workspace archive directory exists and is writable
workspace latest archive sample includes required fields
workspace-caoz latest archive sample includes required fields
workspace-food-group latest archive sample includes required fields
workspace-wife latest archive sample includes required fields

Conversation archive health: OK
```

The plugin-level smoke wrote a JSONL archive entry with:

```text
source: inbound-observed
chat_type: group
text: quiet group message
```

**Observed result after fix:** A skipped Telegram group message can now reach the passive archive plugin via `inbound_observed` without creating an agent session or triggering a reply, and the archive health check still passes on the live setup.

**What was not tested:** I did not send a real test message into a production Telegram group to avoid posting noise. The live proof used the deployed runtime, archive health checks, and a plugin-level smoke for the new hook path.
