### PR TITLE
fix(codex): surface blocked/failed native tools as lastToolError (#83093)

### DIFF
--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -1755,6 +1755,11 @@ describe("CodexAppServerEventProjector", () => {
     expect(toolResult.toolCallId).toBe("cmd-declined");
     expect(toolResult.status).toBe("blocked");
     expect(toolResult.isError).toBe(true);
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+    expect(result.lastToolError).toEqual({
+      toolName: "bash",
+      error: "codex_native_tool_blocked",
+    });
   });
 
   it("leaves Codex dynamic tool item progress to item/tool/call normalization", async () => {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -132,6 +132,17 @@ export class CodexAppServerEventProjector {
   private readonly toolTranscriptResultIds = new Set<string>();
   private readonly nativeGeneratedMediaUrls = new Set<string>();
   private readonly diagnosticToolStartedAtByItem = new Map<string, number>();
+  // #83093: When a Codex native tool (e.g. declined `commandExecution`) ends in
+  // a non-success state, the diagnostic projector previously only fired a
+  // tool.execution.blocked / tool.execution.error event without recording the
+  // failure on the attempt result, so `buildResult` returned no
+  // `lastToolError` and the embedded-runner's empty-turn fallback could
+  // silently drop the user's visible reply. Track the last non-success native
+  // tool here so `buildResult` can emit a structured `ToolErrorSummary`
+  // through the existing payload-error path.
+  private lastNonSuccessNativeTool:
+    | { toolName: string; status: "blocked" | "failed"; meta?: string }
+    | undefined;
   private readonly afterToolCallObservedItemIds = new Set<string>();
   private assistantStarted = false;
   private reasoningStarted = false;
@@ -316,6 +327,22 @@ export class CodexAppServerEventProjector {
       assistantTexts,
       toolMetas: [...this.toolMetas.values()],
       lastAssistant,
+      // #83093: surface the most recent blocked/failed Codex native tool so
+      // the embedded-runner's empty-turn fallback path receives a structured
+      // `ToolErrorSummary` instead of an aborted empty payload. Only set when
+      // a non-success native tool was actually observed; otherwise leave
+      // `lastToolError` undefined so existing success paths are unchanged.
+      ...(this.lastNonSuccessNativeTool
+        ? {
+            lastToolError: {
+              toolName: this.lastNonSuccessNativeTool.toolName,
+              error:
+                this.lastNonSuccessNativeTool.status === "blocked"
+                  ? "codex_native_tool_blocked"
+                  : "codex_native_tool_error",
+            },
+          }
+        : {}),
       didSendViaMessagingTool: toolTelemetry.didSendViaMessagingTool,
       messagingToolSentTexts: toolTelemetry.messagingToolSentTexts,
       messagingToolSentMediaUrls: toolTelemetry.messagingToolSentMediaUrls,
@@ -980,6 +1007,16 @@ export class CodexAppServerEventProjector {
               durationMs,
             };
     emitTrustedDiagnosticEvent({ ...base, ...terminalEvent });
+    // #83093: surface non-success native tool terminations through the
+    // attempt result so the embedded-runner's payload-error path can decide
+    // what to render. Last-write wins because the runner only reads the most
+    // recent error for the abort/empty-turn fallback.
+    if (params.status === "blocked" || params.status === "failed") {
+      this.lastNonSuccessNativeTool = {
+        toolName: params.name,
+        status: params.status,
+      };
+    }
   }
 
   private emitAfterToolCallObservation(item: CodexThreadItem): void {


### PR DESCRIPTION
Fixes #83093.

## Problem

When a Codex app-server native tool, such as a declined `commandExecution`, ends in a non-success state, the projector fired only the diagnostic `tool.execution.blocked` / `tool.execution.error` event. It did not record the failure on the attempt result.

The embedded runner already gates the empty-turn payload-error path on `attempt.lastToolError`, so an aborted empty Codex turn could drop the user's visible reply even though the diagnostic stream knew the native tool was blocked.

## Fix

`extensions/codex/src/app-server/event-projector.ts`:

1. Track the most recent blocked/failed Codex-native tool in projector state.
2. Preserve the existing diagnostic event behavior.
3. Emit that state from `buildResult()` as the existing `ToolErrorSummary` shape only when a non-success native tool was observed.

`extensions/codex/src/app-server/event-projector.test.ts`:

1. Extend the real projector regression for declined `commandExecution`.
2. Assert the actual patched `buildResult()` returns:

```ts
{ toolName: "bash", error: "codex_native_tool_blocked" }
```

## Real behavior proof

**Behavior addressed:** declined Codex-native tools now surface as `lastToolError` in the real app-server projector result instead of only emitting diagnostic progress.

**Real environment tested:** local `openclaw/openclaw` checkout on branch `fix-codex-app-server-native-tool-error`, commit `1d61fbd168`, Linux x86_64, Node via repo test harness.

**Exact steps or command run after this patch:**

```bash
node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.test.ts
git diff --check
```

**Evidence after fix:**

```text
Test Files  1 passed (1)
Tests       47 passed (47)
Duration    9.71s

git diff --check: pass, no output
```

The regression test drives the real `CodexAppServerEventProjector` with an `item/completed` notification for a declined `commandExecution`, verifies the emitted tool result is blocked, and then verifies the real patched `projector.buildResult(buildEmptyToolTelemetry()).lastToolError` equals `{ toolName: "bash", error: "codex_native_tool_blocked" }`.

**Observed result after fix:** the attempt result now carries a structured `ToolErrorSummary` for a blocked native command, so the existing embedded-runner payload-error path has the field it already consumes. Success-only runs remain unchanged because `lastToolError` is omitted unless a blocked/failed native tool was observed.

**Not tested:** I did not run a live Codex OAuth app-server denial path end-to-end in this environment. The added test exercises the real patched projector and the exact declined native-tool event shape that feeds the downstream runner.

## Pre-implement audit

- **Existing-helper check:** reused the existing downstream `ToolErrorSummary` contract shape instead of adding a new payload type.
- **Shared-helper caller check:** `buildResult()` remains additive; success paths omit `lastToolError` as before.
- **Broader-fix rival scan:** no open rival PR was found for `#83093` before this PR was opened.
