### PR TITLE
fix(codex): surface declined native tool replies

### DIFF
--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -1406,6 +1406,46 @@ describe("CodexAppServerEventProjector", () => {
     expect(toolResult.result).toEqual({ status: "completed", exitCode: 0, durationMs: 42 });
   });
 
+  it("uses streamed command output for failed native tool errors", async () => {
+    const projector = await createProjector();
+
+    await projector.handleNotification(
+      forCurrentTurn("item/commandExecution/outputDelta", {
+        itemId: "cmd-streamed-failure",
+        delta: "fatal: missing fixture\n",
+      }),
+    );
+    await projector.handleNotification(
+      turnCompleted([
+        {
+          type: "commandExecution",
+          id: "cmd-streamed-failure",
+          command: "pnpm test extensions/codex",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "failed",
+          commandActions: [],
+          aggregatedOutput: null,
+          exitCode: 1,
+          durationMs: 42,
+        },
+      ]),
+    );
+
+    expect(projector.buildResult(buildEmptyToolTelemetry()).lastToolError).toEqual({
+      toolName: "bash",
+      meta: "run tests (workspace)",
+      error: "fatal: missing fixture",
+      mutatingAction: true,
+      actionFingerprint: JSON.stringify({
+        type: "commandExecution",
+        command: "pnpm test extensions/codex",
+        cwd: "/workspace",
+      }),
+    });
+  });
+
   it("does not duplicate native tool starts when the snapshot completes a started item", async () => {
     const onAgentEvent = vi.fn();
     const trajectoryRecorder = {
@@ -1609,6 +1649,121 @@ describe("CodexAppServerEventProjector", () => {
         toolCallId: "cmd-declined",
       },
     ]);
+    expect(projector.buildResult(buildEmptyToolTelemetry()).lastToolError).toEqual({
+      toolName: "bash",
+      meta: "run tests (workspace)",
+      error: "codex native tool blocked",
+      mutatingAction: true,
+      actionFingerprint: JSON.stringify({
+        type: "commandExecution",
+        command: "pnpm test extensions/codex",
+        cwd: "/workspace",
+      }),
+    });
+  });
+
+  it("clears a recovered declined native tool error", async () => {
+    const projector = await createProjector();
+
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "commandExecution",
+          id: "cmd-declined",
+          command: "pnpm test extensions/codex",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "declined",
+          commandActions: [],
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: 1,
+        },
+      }),
+    );
+    expect(projector.buildResult(buildEmptyToolTelemetry()).lastToolError).toEqual({
+      toolName: "bash",
+      meta: "run tests (workspace)",
+      error: "codex native tool blocked",
+      mutatingAction: true,
+      actionFingerprint: JSON.stringify({
+        type: "commandExecution",
+        command: "pnpm test extensions/codex",
+        cwd: "/workspace",
+      }),
+    });
+
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "commandExecution",
+          id: "cmd-recovered",
+          command: "pnpm test extensions/codex",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "completed",
+          commandActions: [],
+          aggregatedOutput: "ok",
+          exitCode: 0,
+          durationMs: 42,
+        },
+      }),
+    );
+
+    expect(projector.buildResult(buildEmptyToolTelemetry()).lastToolError).toBeUndefined();
+  });
+
+  it("does not clear a declined native tool error with a different action", async () => {
+    const projector = await createProjector();
+
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "commandExecution",
+          id: "cmd-declined",
+          command: "pnpm test extensions/codex",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "declined",
+          commandActions: [],
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: 1,
+        },
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "commandExecution",
+          id: "cmd-unrelated-success",
+          command: "pnpm test src/foo.test.ts",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "completed",
+          commandActions: [],
+          aggregatedOutput: "ok",
+          exitCode: 0,
+          durationMs: 42,
+        },
+      }),
+    );
+
+    expect(projector.buildResult(buildEmptyToolTelemetry()).lastToolError).toEqual({
+      toolName: "bash",
+      meta: "run tests (workspace)",
+      error: "codex native tool blocked",
+      mutatingAction: true,
+      actionFingerprint: JSON.stringify({
+        type: "commandExecution",
+        command: "pnpm test extensions/codex",
+        cwd: "/workspace",
+      }),
+    });
   });
 
   it("emits after_tool_call observations for Codex-native tool item completions", async () => {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -152,6 +152,7 @@ export class CodexAppServerEventProjector {
   private readonly toolTranscriptCallIds = new Set<string>();
   private readonly toolTranscriptResultIds = new Set<string>();
   private readonly transcriptToolProgressCallIds = new Set<string>();
+  private lastNativeToolError: EmbeddedRunAttemptResult["lastToolError"];
   private readonly nativeGeneratedMediaUrls = new Set<string>();
   private readonly diagnosticToolStartedAtByItem = new Map<string, number>();
   private readonly afterToolCallObservedItemIds = new Set<string>();
@@ -338,6 +339,7 @@ export class CodexAppServerEventProjector {
       assistantTexts,
       toolMetas: [...this.toolMetas.values()],
       lastAssistant,
+      ...(this.lastNativeToolError ? { lastToolError: this.lastNativeToolError } : {}),
       didSendViaMessagingTool: toolTelemetry.didSendViaMessagingTool,
       messagingToolSentTexts: toolTelemetry.messagingToolSentTexts,
       messagingToolSentMediaUrls: toolTelemetry.messagingToolSentMediaUrls,
@@ -907,15 +909,18 @@ export class CodexAppServerEventProjector {
     }
     const status = params.phase === "result" ? itemStatus(item) : "running";
     const args = itemToolArgs(item);
+    const meta = itemMeta(item, this.toolProgressDetailMode());
     this.recordToolTrajectoryEvent({ phase: params.phase, item, name, args, status });
     this.emitDiagnosticToolExecutionEvent({ phase: params.phase, item, name, status });
+    if (params.phase === "result") {
+      this.recordNativeToolError({ item, name, meta, status });
+    }
     if (!shouldEmitTranscriptToolProgress(name, args)) {
       if (params.phase === "result") {
         this.emitAfterToolCallObservation(item);
       }
       return;
     }
-    const meta = itemMeta(item, this.toolProgressDetailMode());
     this.emitAgentEvent({
       stream: "tool",
       data: {
@@ -937,6 +942,41 @@ export class CodexAppServerEventProjector {
     if (params.phase === "result") {
       this.emitAfterToolCallObservation(item);
     }
+  }
+
+  private recordNativeToolError(params: {
+    item: CodexThreadItem;
+    name: string;
+    meta?: string;
+    status: ReturnType<typeof itemStatus>;
+  }): void {
+    if (!isNonSuccessItemStatus(params.status)) {
+      if (!this.lastNativeToolError) {
+        return;
+      }
+      if (!this.lastNativeToolError.mutatingAction) {
+        this.lastNativeToolError = undefined;
+        return;
+      }
+      const actionFingerprint = nativeToolActionFingerprint(params.item);
+      if (
+        this.lastNativeToolError.actionFingerprint &&
+        actionFingerprint &&
+        this.lastNativeToolError.actionFingerprint === actionFingerprint
+      ) {
+        this.lastNativeToolError = undefined;
+      }
+      return;
+    }
+    const error = itemToolError(params.item, params.status, this.toolResultOutputTextByItem);
+    const actionFingerprint = nativeToolActionFingerprint(params.item);
+    this.lastNativeToolError = {
+      toolName: params.name,
+      ...(params.meta ? { meta: params.meta } : {}),
+      ...(error ? { error } : {}),
+      ...(isMutatingNativeToolItem(params.item) ? { mutatingAction: true } : {}),
+      ...(actionFingerprint ? { actionFingerprint } : {}),
+    };
   }
 
   private recordToolTrajectoryEvent(params: {
@@ -1707,6 +1747,27 @@ function shouldSynthesizeToolProgressForItem(item: CodexThreadItem): boolean {
     default:
       return false;
   }
+}
+
+function isMutatingNativeToolItem(item: CodexThreadItem): boolean {
+  return item.type === "commandExecution" || item.type === "fileChange";
+}
+
+function nativeToolActionFingerprint(item: CodexThreadItem): string | undefined {
+  if (item.type === "commandExecution" && typeof item.command === "string") {
+    return JSON.stringify({
+      type: item.type,
+      command: item.command,
+      cwd: typeof item.cwd === "string" ? item.cwd : "",
+    });
+  }
+  if (item.type === "fileChange") {
+    return JSON.stringify({
+      type: item.type,
+      changes: itemFileChanges(item),
+    });
+  }
+  return undefined;
 }
 
 function isNativePostToolUseRelayItem(item: CodexThreadItem): boolean {

--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -363,6 +363,23 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     });
   });
 
+  it("surfaces declined Codex native command errors for aborted empty turns", () => {
+    const payloads = buildPayloads({
+      assistantTexts: [],
+      lastToolError: {
+        toolName: "bash",
+        error: "codex native tool blocked",
+        mutatingAction: true,
+      },
+      runAborted: true,
+    });
+
+    expectSingleToolErrorPayload(payloads, {
+      title: "Bash",
+      absentDetail: "codex native tool blocked",
+    });
+  });
+
   it("surfaces exec tool errors for cron sessions even when verbose mode is off", () => {
     const payloads = buildPayloads({
       lastToolError: {


### PR DESCRIPTION
## Summary

Fixes #83093 by preserving declined Codex native tool failures at the attempt boundary so aborted empty turns still produce a visible channel reply.

- Records non-success Codex native commandExecution / fileChange results as lastToolError.
- Marks mutating native tool failures so the existing payload warning policy surfaces them even with verbose output off.
- Adds regressions for declined native command projection and aborted empty payload emission.

## Validation

- CI=1 node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.test.ts src/agents/pi-embedded-runner/run/payloads.test.ts
- ./node_modules/.bin/oxfmt --check --threads=1 extensions/codex/src/app-server/event-projector.ts extensions/codex/src/app-server/event-projector.test.ts src/agents/pi-embedded-runner/run/payloads.test.ts && git diff --check
- pnpm check:changed

## Real behavior proof

- Behavior or issue addressed: A Codex app-server native commandExecution item with status declined could terminate an external-channel turn with no assistant text and no lastToolError, so the payload builder emitted no visible reply.
- Real environment tested: WSL Ubuntu 24.04, with two fresh git worktrees: current upstream/main at 44c3d8ea2efd01d04b7ef861b54a5a46a05f4dfa and this PR head at 2b15eb6588464298b7441d5d0a26a89270b68ace.
- Exact steps or command run after this patch: Ran pr-83108/real-behavior-proof-runner.mts in both fresh worktrees. The runner imports and executes the production CodexAppServerEventProjector and production buildEmbeddedRunPayloads modules, feeds item/started, item/completed(status=declined), and turn/completed(status=interrupted) for a Codex-native bash commandExecution, then records the external-channel ReplyPayload objects the payload builder returns.
- Evidence after fix: ![Real before/after proof](https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-83108-fresh/pr-83108/codex-native-decline-reply-real-before-after.png) Raw artifacts: [summary](https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-83108-fresh/pr-83108/summary.txt), [before main JSON](https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-83108-fresh/pr-83108/before-main-real-app-server.json), [after PR JSON](https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-83108-fresh/pr-83108/after-pr-83108-real-app-server.json), [proof runner](https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-83108-fresh/pr-83108/real-behavior-proof-runner.mts)
- Observed result after fix: Before, current main projects the declined native command as an aborted attempt with lastToolError=null and buildEmbeddedRunPayloads returns zero external-channel payloads. After this PR, the projector records lastToolError={toolName:bash, error:codex native tool blocked, mutatingAction:true}, and buildEmbeddedRunPayloads returns one error ReplyPayload: "⚠️ 🛠️ run tests (in /workspace/openclaw) failed".
- What was not tested: A hosted Telegram/Slack transport was not used; the proof stops at the ReplyPayload handoff consumed by external channel transports.

## Root Cause

- Root cause: The Codex app-server projector mapped declined native tools to blocked diagnostics, but did not carry the non-success native tool into EmbeddedRunAttemptResult.lastToolError.
- Missing detection / guardrail: There was no regression for an aborted empty Codex turn with a declined native command producing a user-visible payload.
- Contributing context: The payload layer already knows how to surface mutating tool failures, but it never received the native command failure summary.

## Regression Test Plan

- Coverage level that should have caught this: Seam / integration test.
- Target test or file: extensions/codex/src/app-server/event-projector.test.ts and src/agents/pi-embedded-runner/run/payloads.test.ts.
- Scenario the test should lock in: declined Codex native commandExecution produces lastToolError, and an aborted empty attempt with that error emits a visible Bash error payload.
- Why this is the smallest reliable guardrail: It covers the projector-to-payload seam without requiring a live external channel or real native tool decline.