### PR TITLE
fix(cron): remove /2 divisor from pre-execution watchdog formula

### DIFF
--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -390,7 +390,7 @@ function formatCronAgentExecutionPhase(execution?: CronAgentExecutionStarted): s
 function resolveCronAgentPreExecutionWatchdogMs(jobTimeoutMs: number): number {
   return Math.max(
     CRON_AGENT_PRE_EXECUTION_MIN_WATCHDOG_MS,
-    Math.min(CRON_AGENT_PRE_EXECUTION_WATCHDOG_MS, Math.floor(jobTimeoutMs / 2)),
+    Math.min(CRON_AGENT_PRE_EXECUTION_WATCHDOG_MS, jobTimeoutMs),
   );
 }
 


### PR DESCRIPTION
## Problem

`resolveCronAgentPreExecutionWatchdogMs()` halves the job timeout when calculating the stale-progress watchdog ceiling:

```typescript
Math.min(CRON_AGENT_PRE_EXECUTION_WATCHDOG_MS, Math.floor(jobTimeoutMs / 2))
```

This means any cron job whose tool execution runs silently (no intermediate phase events) for more than half its configured `timeoutSeconds` is killed by the pre-execution watchdog — even though the job-level timeout has not been reached.

## Root Cause

The `/2` divisor was likely intended as a safety margin: if nothing has happened in half the job timeout, something is probably wrong. However, this assumption breaks for shell commands that legitimately run silently for their entire duration:

- `rclone sync` (cloud backup transfers)
- `rsync` (large file syncs)
- `pg_dump` (database dumps)
- Any long-running CLI tool invoked via the Codex shell

These tools produce a single `tool_execution_started` phase event, then silence until completion. The stale-progress watchdog interprets this silence as a stall and aborts.

## Fix

Remove the `/2` divisor:

```typescript
Math.min(CRON_AGENT_PRE_EXECUTION_WATCHDOG_MS, jobTimeoutMs)
```

The job-level timeout (`startTimeout()`) already provides the hard upper bound for total run duration. The stale-progress detector should catch genuinely stalled processes (where the cap constant applies), not penalize active-but-silent ones by halving their allowed time.

## Production Evidence

Tested on OpenClaw 2026.5.12 (Raspberry Pi 5, ARM64):

| Attempt | Watchdog Cap | Formula | Job Timeout | Result |
|---------|-------------|---------|-------------|--------|
| 1 | 180s | `jobTimeoutMs/2` | 600s | ❌ `aborted=true` at 180s |
| 2 | 600s | `jobTimeoutMs/2` | 600s | ❌ `aborted=true` at 300s (600/2) |
| 3 | 600s | `jobTimeoutMs/2` | 1800s | ❌ `aborted=true` at 600s (cap) |
| 4 | 1800s | `jobTimeoutMs` | 1800s | ✅ `aborted=false` at 301s |

The actual `rclone sync` only needs ~5 minutes, but attempts 2 and 3 show the `/2` divisor killing it prematurely at exactly half the effective ceiling.

## Related

- #83110 — issue report with full analysis
- #83066 — makes the watchdog constants configurable (complementary; addresses the cap being too low on modest hardware)
- #82223 — original report of isolated cron agent timeout failures

## Files Changed

- `src/cron/service/timer.ts` — one-line change in `resolveCronAgentPreExecutionWatchdogMs()`