### PR TITLE
fix(codex): surface declined native tool as lastToolError (#83093)

### DIFF
--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -1757,6 +1757,105 @@ describe("CodexAppServerEventProjector", () => {
     expect(toolResult.isError).toBe(true);
   });
 
+  it("surfaces declined Codex-native tool result as attempt-level lastToolError (#83093)", async () => {
+    const projector = await createProjector();
+
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "commandExecution",
+          id: "cmd-declined",
+          command: "rm -rf /tmp/work",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "declined",
+          commandActions: [],
+          aggregatedOutput: null,
+          exitCode: null,
+          durationMs: null,
+        },
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("turn/completed", {
+        turn: { id: TURN_ID, status: "interrupted", items: [] },
+      }),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+
+    expect(result.aborted).toBe(true);
+    expect(result.assistantTexts).toEqual([]);
+    expect(result.lastToolError).toBeDefined();
+    expect(result.lastToolError?.toolName).toBe("bash");
+    expect(result.lastToolError?.error).toBe("codex native tool blocked");
+    expect(result.lastToolError?.meta).toBeTruthy();
+  });
+
+  it("surfaces failed Codex-native tool result with output text as lastToolError", async () => {
+    const projector = await createProjector();
+
+    await projector.handleNotification(
+      forCurrentTurn("turn/completed", {
+        turn: {
+          id: TURN_ID,
+          status: "completed",
+          items: [
+            {
+              type: "commandExecution",
+              id: "cmd-failed",
+              command: "ls /no-such-path",
+              cwd: "/workspace",
+              processId: null,
+              source: "agent",
+              status: "failed",
+              commandActions: [],
+              aggregatedOutput: "ls: cannot access '/no-such-path': No such file or directory",
+              exitCode: 2,
+              durationMs: 5,
+            },
+          ],
+        },
+      }),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+
+    expect(result.lastToolError).toBeDefined();
+    expect(result.lastToolError?.toolName).toBe("bash");
+    expect(result.lastToolError?.error).toBe(
+      "ls: cannot access '/no-such-path': No such file or directory",
+    );
+    expect(result.lastToolError?.meta).toBeTruthy();
+  });
+
+  it("does not set lastToolError when all native tool items succeed", async () => {
+    const projector = await createProjector();
+
+    await projector.handleNotification(
+      forCurrentTurn("item/completed", {
+        item: {
+          type: "commandExecution",
+          id: "cmd-ok",
+          command: "echo hi",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "completed",
+          commandActions: [],
+          aggregatedOutput: "hi\n",
+          exitCode: 0,
+          durationMs: 2,
+        },
+      }),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+
+    expect(result.lastToolError).toBeUndefined();
+  });
+
   it("leaves Codex dynamic tool item progress to item/tool/call normalization", async () => {
     const onAgentEvent = vi.fn();
     const projector = await createProjector({ ...(await createParams()), onAgentEvent });

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -144,6 +144,12 @@ export class CodexAppServerEventProjector {
   private guardianReviewCount = 0;
   private completedCompactionCount = 0;
   private latestRateLimits: JsonValue | undefined;
+  // Last non-success native Codex tool (commandExecution, fileChange, webSearch,
+  // mcpToolCall) seen during this turn. Surfaced as
+  // `EmbeddedRunAttemptResult.lastToolError` so the embedded-run payload layer
+  // can emit a visible warning when the turn otherwise aborts with no
+  // assistant text (see #83093).
+  private lastNativeToolError?: NonNullable<EmbeddedRunAttemptResult["lastToolError"]>;
   private readonly nativeSubagentTaskMirror: CodexNativeSubagentTaskMirror;
 
   constructor(
@@ -341,6 +347,7 @@ export class CodexAppServerEventProjector {
       },
       yieldDetected: options?.yieldDetected || false,
       didSendDeterministicApprovalPrompt: this.guardianReviewCount > 0 ? false : undefined,
+      ...(this.lastNativeToolError ? { lastToolError: this.lastNativeToolError } : {}),
     };
   }
 
@@ -538,6 +545,7 @@ export class CodexAppServerEventProjector {
       });
     }
     this.recordToolMeta(item);
+    this.recordNativeToolError(item);
     this.emitStandardItemEvent({ phase: "end", item });
     this.emitNormalizedToolItemEvent({ phase: "result", item });
     this.recordNativeToolTranscriptCall(item);
@@ -646,6 +654,7 @@ export class CodexAppServerEventProjector {
         this.emitPlanUpdate({ explanation: undefined, steps: splitPlanText(item.text) });
       }
       this.recordToolMeta(item);
+      this.recordNativeToolError(item);
       this.emitSnapshotOnlyNativeToolProgress(item);
       this.recordNativeToolTranscriptCall(item);
       this.recordNativeToolTranscriptResult(item);
@@ -1123,6 +1132,27 @@ export class CodexAppServerEventProjector {
       toolName,
       ...(meta ? { meta } : {}),
     });
+  }
+
+  private recordNativeToolError(item: CodexThreadItem | undefined): void {
+    if (!item || !shouldSynthesizeToolProgressForItem(item)) {
+      return;
+    }
+    const status = itemStatus(item);
+    if (!isNonSuccessItemStatus(status)) {
+      return;
+    }
+    const toolName = itemName(item);
+    if (!toolName) {
+      return;
+    }
+    const meta = itemMeta(item, this.toolProgressDetailMode());
+    const error = itemToolError(item, status);
+    this.lastNativeToolError = {
+      toolName,
+      ...(meta ? { meta } : {}),
+      ...(error ? { error } : {}),
+    };
   }
 
   private recordNativeToolTranscriptCall(item: CodexThreadItem | undefined): void {


### PR DESCRIPTION
## Summary

Closes #83093. When a Codex app-server native tool call (`commandExecution`, `fileChange`, `webSearch`, or `mcpToolCall`) terminates with `status: "declined"` or `"failed"`, `CodexAppServerEventProjector.buildResult` previously returned an attempt result with `lastToolError: undefined`. On an aborted, empty-text turn the embedded-run payload layer then emitted **no reply payload at all** — external channel users saw a silent non-response. This is the exact gap clawsweeper called out at [`event-projector.ts:302`](https://github.com/openclaw/openclaw/blob/cdd817669a95/extensions/codex/src/app-server/event-projector.ts#L302).

The projector already maps `status: "declined" → "blocked"`, maps `commandExecution → "bash"`, and formats the error string via `itemToolError` (`"codex native tool blocked"`). The existing `buildEmbeddedRunPayloads` path at [`payloads.ts:472`](https://github.com/openclaw/openclaw/blob/cdd817669a95/src/agents/pi-embedded-runner/run/payloads.ts#L472) is already wired to convert `lastToolError` into a visible `⚠️` warning payload — including the cron-friendly mutating-action branch at [`payloads.ts:162`](https://github.com/openclaw/openclaw/blob/cdd817669a95/src/agents/pi-embedded-runner/run/payloads.ts#L162) that `bash`/`apply_patch` already trigger via `isLikelyMutatingToolName`.

So the fix is narrow:

| File | Change |
|---|---|
| `extensions/codex/src/app-server/event-projector.ts` | Adds a `lastNativeToolError` field, populates it from `handleItemCompleted` and the `handleTurnCompleted` snapshot loop using the existing `itemToolError` / `itemName` / `itemMeta` helpers, and includes it on the `buildResult` return only when set. No new SDK seams; uses the type already exposed via `EmbeddedRunAttemptResult["lastToolError"]`. |
| `extensions/codex/src/app-server/event-projector.test.ts` | Three new regression cases. |

No change to the dynamic-tool path: those already flow through the OpenClaw-side `pi-embedded-subscribe.handlers.tools.ts` error path. This patch only fills in the missing native-tool branch.

## Real behavior proof

**Behavior addressed**: Closes #83093. On `extensions/codex/src/app-server/event-projector.ts:302` the projector's `buildResult` returns no `lastToolError` for declined/failed native tool items. The downstream `buildEmbeddedRunPayloads` at `src/agents/pi-embedded-runner/run/payloads.ts:472` gates the visible `⚠️` warning on `params.lastToolError`, so an aborted turn with empty `assistantTexts` produces zero payloads and the external channel sees a silent non-response.

**Real environment tested**: macOS 26.4.1 arm64, Node v25.1.0, pnpm v11.1.0, `tsx` driving the production source modules directly. Live terminal capture below is from a single-file Node script that constructs the **production** `CodexAppServerEventProjector`, feeds it the same `item/completed` notification shape the Codex app-server emits for a declined `commandExecution`, then feeds the resulting `EmbeddedRunAttemptResult` into the **production** `buildEmbeddedRunPayloads` builder — no mocks, no test doubles, the exact code paths that ship.

**Exact steps or command run after this patch**:

```
pnpm install
node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.test.ts
node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/payloads.errors.test.ts
node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
pnpm exec tsx /tmp/oc-83093-proof.mjs   # production projector + payload builder, end-to-end
```

**Evidence after fix**: Live terminal capture from a fork checkout at commit `aa761075` running `tsx` against the patched source. The same reproduction script run against the unpatched baseline (commit `cdd81766` with the fix stashed out) is shown for contrast.

*Before this PR (baseline `cdd81766`, fix stashed out):*

```
=== buildResult shape (relevant fields) ===
{
  "aborted": true,
  "assistantTexts": [],
  "itemLifecycle": {
    "startedCount": 1,
    "completedCount": 1,
    "activeCount": 0
  }
}

=== buildEmbeddedRunPayloads output (what the channel actually sends) ===
[]
```

`lastToolError` is absent, payloads array is empty → the external channel emits nothing.

*After this PR:*

```
=== buildResult shape (relevant fields) ===
{
  "aborted": true,
  "assistantTexts": [],
  "lastToolError": {
    "toolName": "bash",
    "meta": "remove /tmp/work (in /tmp/oc-83093-ws)",
    "error": "codex native tool blocked"
  },
  "itemLifecycle": {
    "startedCount": 1,
    "completedCount": 1,
    "activeCount": 0
  }
}

=== buildEmbeddedRunPayloads output (what the channel actually sends) ===
[
  {
    "text": "⚠️ 🛠️ remove /tmp/work (in /tmp/oc-83093-ws) failed",
    "isError": true
  }
]
```

`lastToolError` is populated with the existing `ToolErrorSummary` shape; `buildEmbeddedRunPayloads` then converts it into a visible `isError: true` payload through the unchanged production path.

*Targeted test runs:*

```
$ node scripts/run-vitest.mjs extensions/codex/src/app-server/event-projector.test.ts
 Test Files  1 passed (1)
      Tests  50 passed (50)

$ node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/payloads.errors.test.ts
 Test Files  1 passed (1)
      Tests  43 passed (43)

$ node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
 Test Files  2 passed (2)
      Tests  190 passed (190)
```

All three suites listed in the clawsweeper review's "Acceptance criteria" pass.

*Lint + type check:*

```
$ node scripts/run-oxlint.mjs extensions/codex/src/app-server/event-projector.ts extensions/codex/src/app-server/event-projector.test.ts
Found 0 warnings and 0 errors.
Finished in 2.8s on 2 files with 216 rules using 1 threads.

$ node scripts/run-tsgo.mjs -p extensions/codex/tsconfig.json --noEmit ; echo EXIT=$?
EXIT=0
```

**Observed result after fix**: The unchanged `buildEmbeddedRunPayloads` warning branch (`payloads.ts:472`) fires because `lastToolError` is now populated; `isLikelyMutatingToolName("bash")` is already `true` in `src/agents/tool-mutation.ts:7-22`, so the mutating branch of `resolveToolErrorWarningPolicy` (`payloads.ts:162`) takes over and emits the warning as long as the assistant did not already surface its own user-facing acknowledgement (`!hasUserFacingErrorReply && !hasUserFacingFailureAcknowledgement`). For the bug scenario (aborted turn, empty `assistantTexts`) both gates are trivially satisfied. The new 3-case regression block in `event-projector.test.ts` plus the existing 47 cases assert that the same path stays a no-op when all native tools succeed, so non-failing turns are unaffected.

**What was not tested**: A full live Telegram round-trip with a real Codex app-server `userApproval`-declined turn end-to-end — that needs a live Codex login plus a Telegram channel install and a real human declining the approval prompt, which is out of scope for an external contributor without that setup. The reproduction script above exercises every changed line of the projector (the new `lastNativeToolError` field, the `recordNativeToolError` helper called from both `handleItemCompleted` and the `handleTurnCompleted` snapshot loop, and the `buildResult` plumbing) plus the unchanged production `buildEmbeddedRunPayloads` call site, end-to-end, against the same shape the Codex app-server emits today.

## Duplicate-check

5-vector sweep before opening — all returned 0 PRs touching this fix:

```
$ gh pr list --repo openclaw/openclaw --state all --search "83093 in:title,body"   → 0
$ gh pr list --repo openclaw/openclaw --state open --search "declined native tool" → 0
$ gh pr list --repo openclaw/openclaw --state open --search "blocked native tool"  → 0 relevant
$ gh pr list --repo openclaw/openclaw --state open --search "buildResult lastToolError" → 0
$ gh pr list --repo openclaw/openclaw --state open --search "Codex silently drops" → 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
