### PR TITLE
fix(cli-runner): keep recent tail when reseed history exceeds maxHistoryChars

### DIFF
--- a/src/agents/cli-runner/session-history.test.ts
+++ b/src/agents/cli-runner/session-history.test.ts
@@ -647,15 +647,16 @@ describe("buildCliSessionHistoryPrompt", () => {
     expect(prompt).toContain("<next_user_message>\nnext ask\n</next_user_message>");
   });
 
-  it("caps oversize compaction summary; drops post-summary tail when summary alone exceeds the budget", () => {
+  it("caps oversize compaction summary while preserving recent post-summary tail", () => {
     // Two regressions covered here:
     // 1. `tailRaw.slice(-0)` would return the entire tail (JS quirk:
-    //    `String.prototype.slice(-0) === slice(0)`), defeating the cap
-    //    when the summary block consumes the budget.
+    //    `String.prototype.slice(-0) === slice(0)`), defeating the cap when
+    //    the summary block consumes the budget.
     // 2. Pinning the full summary as-is when the summary itself exceeds
     //    `maxHistoryChars` would blow past the cap that prevents
     //    reseeding fresh CLI sessions with unexpectedly huge prompts.
-    //    The summary must itself be truncated to fit the budget.
+    //    The summary must itself be truncated to fit the budget while still
+    //    preserving the recent post-summary exact turns.
     const summaryText = "OVERSIZE_SUMMARY_MARKER ".repeat(50).trim();
     const maxHistoryChars = 200;
     const prompt = buildCliSessionHistoryPrompt({
@@ -689,10 +690,10 @@ describe("buildCliSessionHistoryPrompt", () => {
     // The full untruncated summary must NOT appear — that would defeat
     // the cap.
     expect(prompt).not.toContain(summaryText);
-    // Post-summary content must be dropped — no leak from the
-    // `slice(-0) === full string` regression.
-    expect(prompt).not.toContain("POST_SUMMARY_USER_DROPPED");
-    expect(prompt).not.toContain("POST_SUMMARY_ASSISTANT_DROPPED");
+    // Post-summary exact turns are newer than the summary and must still
+    // survive inside the reserved tail budget.
+    expect(prompt).toContain("POST_SUMMARY_USER_DROPPED");
+    expect(prompt).toContain("POST_SUMMARY_ASSISTANT_DROPPED");
     expect(prompt).toContain("<next_user_message>\nnext ask\n</next_user_message>");
   });
 });

--- a/src/agents/cli-runner/session-history.test.ts
+++ b/src/agents/cli-runner/session-history.test.ts
@@ -732,5 +732,8 @@ describe("buildCliSessionHistoryPrompt", () => {
     expect(renderedHistory.length).toBeLessThanOrEqual(maxHistoryChars);
     // Marker is still present so the prompt announces what was discarded.
     expect(prompt).toContain("[OpenClaw reseed history truncated; older turns dropped]");
+    // Near-cap summaries still reserve room for the newest exact turns.
+    expect(prompt).toContain("POST_SUMMARY_TAIL_USER");
+    expect(prompt).toContain("POST_SUMMARY_TAIL_ASSISTANT");
   });
 });

--- a/src/agents/cli-runner/session-history.test.ts
+++ b/src/agents/cli-runner/session-history.test.ts
@@ -577,13 +577,122 @@ describe("buildCliSessionHistoryPrompt", () => {
 
   it("caps rendered reseed history before adding the next user message", () => {
     const prompt = buildCliSessionHistoryPrompt({
-      messages: [{ role: "compactionSummary", summary: "x".repeat(100) }],
+      messages: [
+        { role: "user", content: "x".repeat(100) },
+        { role: "assistant", content: "y".repeat(100) },
+      ],
       prompt: "current ask must survive",
       maxHistoryChars: 20,
     });
 
-    expect(prompt).toContain("[OpenClaw reseed history truncated]");
+    expect(prompt).toContain("[OpenClaw reseed history truncated; older turns dropped]");
     expect(prompt).toContain("<next_user_message>\ncurrent ask must survive\n</next_user_message>");
+    // Older 100-char prefix must be dropped by the tail slice; the
+    // post-cap rendered tail is shorter than the dropped prefix.
     expect(prompt).not.toContain("x".repeat(80));
+  });
+
+  it("keeps the most recent turns when rendered history exceeds the cap", () => {
+    // Older turns plus a final marker turn whose content is exactly what a
+    // head-slice would drop first. Asserting the marker survives in the
+    // rendered prompt locks in tail-slice semantics: a session-recovery
+    // feature must keep the latest context, not the oldest.
+    const prompt = buildCliSessionHistoryPrompt({
+      messages: [
+        { role: "user", content: "x".repeat(8000) },
+        { role: "assistant", content: "y".repeat(8000) },
+        { role: "user", content: "FINAL_USER_MARKER" },
+        { role: "assistant", content: "FINAL_ASSISTANT_MARKER" },
+      ],
+      prompt: "next ask",
+    });
+
+    expect(prompt).toBeDefined();
+    expect(prompt).toContain("FINAL_USER_MARKER");
+    expect(prompt).toContain("FINAL_ASSISTANT_MARKER");
+    expect(prompt).toContain("[OpenClaw reseed history truncated; older turns dropped]");
+    // The oldest 8000-char block must have been dropped — a head-slice
+    // would have kept it instead of the recent tail.
+    expect(prompt).not.toContain("x".repeat(8000));
+    expect(prompt).toContain("<next_user_message>\nnext ask\n</next_user_message>");
+  });
+
+  it("preserves the compaction summary when the post-summary transcript exceeds the cap", () => {
+    // loadCliSessionReseedMessages places a compactionSummary entry first
+    // so the compacted prior context survives reseed. A blind tail slice
+    // of the joined history would drop that summary whenever the
+    // post-summary tail alone exceeds the cap. The structure-aware
+    // truncation pins the summary as a prefix and caps only the tail.
+    const prompt = buildCliSessionHistoryPrompt({
+      messages: [
+        { role: "compactionSummary", summary: "COMPACTION_SUMMARY_MARKER pinned context" },
+        { role: "user", content: "z".repeat(8000) },
+        { role: "assistant", content: "w".repeat(8000) },
+        { role: "user", content: "POST_SUMMARY_FINAL_USER" },
+        { role: "assistant", content: "POST_SUMMARY_FINAL_ASSISTANT" },
+      ],
+      prompt: "next ask",
+    });
+
+    expect(prompt).toBeDefined();
+    // Compaction summary must be pinned as a prefix, not sliced away.
+    expect(prompt).toContain("Compaction summary: COMPACTION_SUMMARY_MARKER pinned context");
+    // Recent tail still preserved within the post-summary budget.
+    expect(prompt).toContain("POST_SUMMARY_FINAL_USER");
+    expect(prompt).toContain("POST_SUMMARY_FINAL_ASSISTANT");
+    expect(prompt).toContain("[OpenClaw reseed history truncated; older turns dropped]");
+    // Head of post-summary tail (oldest 8000-char `z` block) must be
+    // dropped so the cap is honored.
+    expect(prompt).not.toContain("z".repeat(8000));
+    expect(prompt).toContain("<next_user_message>\nnext ask\n</next_user_message>");
+  });
+
+  it("caps oversize compaction summary; drops post-summary tail when summary alone exceeds the budget", () => {
+    // Two regressions covered here:
+    // 1. `tailRaw.slice(-0)` would return the entire tail (JS quirk:
+    //    `String.prototype.slice(-0) === slice(0)`), defeating the cap
+    //    when the summary block consumes the budget.
+    // 2. Pinning the full summary as-is when the summary itself exceeds
+    //    `maxHistoryChars` would blow past the cap that prevents
+    //    reseeding fresh CLI sessions with unexpectedly huge prompts.
+    //    The summary must itself be truncated to fit the budget.
+    const summaryText = "OVERSIZE_SUMMARY_MARKER ".repeat(50).trim();
+    const maxHistoryChars = 200;
+    const prompt = buildCliSessionHistoryPrompt({
+      messages: [
+        { role: "compactionSummary", summary: summaryText },
+        { role: "user", content: "POST_SUMMARY_USER_DROPPED" },
+        { role: "assistant", content: "POST_SUMMARY_ASSISTANT_DROPPED" },
+      ],
+      prompt: "next ask",
+      // Cap well below the rendered summary block so the summary itself
+      // must be truncated and the tail budget would naively be 0.
+      maxHistoryChars,
+    });
+
+    expect(prompt).toBeDefined();
+    // The truncated summary still leads with recognizable load-bearing
+    // text — head-slicing preserves the orientation/intro of the summary.
+    expect(prompt).toContain("OVERSIZE_SUMMARY_MARKER");
+    expect(prompt).toContain("Compaction summary:");
+    // The leading truncation marker is present so the prompt announces
+    // what was discarded.
+    expect(prompt).toContain("[OpenClaw reseed history truncated; older turns dropped]");
+    // The cap is honored: the rendered <conversation_history> block
+    // must not blow past `maxHistoryChars` plus a small wrapper allowance.
+    const historyMatch = prompt?.match(
+      /<conversation_history>\n([\s\S]*?)\n<\/conversation_history>/,
+    );
+    expect(historyMatch).not.toBeNull();
+    const renderedHistory = historyMatch?.[1] ?? "";
+    expect(renderedHistory.length).toBeLessThanOrEqual(maxHistoryChars);
+    // The full untruncated summary must NOT appear — that would defeat
+    // the cap.
+    expect(prompt).not.toContain(summaryText);
+    // Post-summary content must be dropped — no leak from the
+    // `slice(-0) === full string` regression.
+    expect(prompt).not.toContain("POST_SUMMARY_USER_DROPPED");
+    expect(prompt).not.toContain("POST_SUMMARY_ASSISTANT_DROPPED");
+    expect(prompt).toContain("<next_user_message>\nnext ask\n</next_user_message>");
   });
 });

--- a/src/agents/cli-runner/session-history.test.ts
+++ b/src/agents/cli-runner/session-history.test.ts
@@ -696,4 +696,41 @@ describe("buildCliSessionHistoryPrompt", () => {
     expect(prompt).toContain("POST_SUMMARY_ASSISTANT_DROPPED");
     expect(prompt).toContain("<next_user_message>\nnext ask\n</next_user_message>");
   });
+
+  it("honors the cap when the summary block plus marker crosses it", () => {
+    // Edge case: `summaryRendered.length < maxHistoryChars` (the gate that
+    // routes to the oversize-summary branch is not taken) BUT
+    // `summaryBlock.length >= maxHistoryChars` once the `\n\n` separator
+    // is appended, making `remainingBudget <= 0`. Without summary
+    // truncation in that branch, the rendered history block is
+    // `summary + separator + marker` — well over `maxHistoryChars`. A
+    // 199-char rendered summary under a 200-char cap would otherwise
+    // produce a 257-char history block.
+    const maxHistoryChars = 200;
+    // `renderHistoryMessage` prefixes "Compaction summary: " (20 chars)
+    // before the summary text, so a 179-char summary renders to 199 chars
+    // — strictly less than the cap, but `summaryBlock = rendered + "\n\n"`
+    // is 201 chars and `remainingBudget` is negative.
+    const summaryPrefix = "Compaction summary: ";
+    const summaryText = "S".repeat(maxHistoryChars - 1 - summaryPrefix.length);
+    const prompt = buildCliSessionHistoryPrompt({
+      messages: [
+        { role: "compactionSummary", summary: summaryText },
+        { role: "user", content: "POST_SUMMARY_TAIL_USER" },
+        { role: "assistant", content: "POST_SUMMARY_TAIL_ASSISTANT" },
+      ],
+      prompt: "next ask",
+      maxHistoryChars,
+    });
+
+    expect(prompt).toBeDefined();
+    const historyMatch = prompt?.match(
+      /<conversation_history>\n([\s\S]*?)\n<\/conversation_history>/,
+    );
+    expect(historyMatch).not.toBeNull();
+    const renderedHistory = historyMatch?.[1] ?? "";
+    expect(renderedHistory.length).toBeLessThanOrEqual(maxHistoryChars);
+    // Marker is still present so the prompt announces what was discarded.
+    expect(prompt).toContain("[OpenClaw reseed history truncated; older turns dropped]");
+  });
 });

--- a/src/agents/cli-runner/session-history.ts
+++ b/src/agents/cli-runner/session-history.ts
@@ -114,41 +114,103 @@ function loadContextEngineMessagesFromEntries(entries: unknown[]): AgentMessage[
   });
 }
 
+function renderHistoryMessage(message: unknown): string | undefined {
+  if (!message || typeof message !== "object") {
+    return undefined;
+  }
+  const entry = message as HistoryMessage;
+  const role =
+    entry.role === "assistant"
+      ? "Assistant"
+      : entry.role === "user"
+        ? "User"
+        : entry.role === "compactionSummary"
+          ? "Compaction summary"
+          : undefined;
+  if (!role) {
+    return undefined;
+  }
+  const text =
+    entry.role === "compactionSummary" && typeof entry.summary === "string"
+      ? entry.summary.trim()
+      : coerceHistoryText(entry.content);
+  return text ? `${role}: ${text}` : undefined;
+}
+
 export function buildCliSessionHistoryPrompt(params: {
   messages: unknown[];
   prompt: string;
   maxHistoryChars?: number;
 }): string | undefined {
   const maxHistoryChars = params.maxHistoryChars ?? MAX_CLI_SESSION_RESEED_HISTORY_CHARS;
-  const renderedHistoryRaw = params.messages
+
+  // loadCliSessionReseedMessages deliberately places a `compactionSummary`
+  // entry first when the session was compacted, so the compacted prior
+  // context survives reseed. Pin that summary as a prefix and only
+  // tail-truncate the post-summary transcript — a blind tail-slice of the
+  // joined history would drop the summary whenever the post-summary tail
+  // alone exceeds the cap.
+  const firstEntry = params.messages[0];
+  const firstIsCompaction =
+    !!firstEntry &&
+    typeof firstEntry === "object" &&
+    (firstEntry as HistoryMessage).role === "compactionSummary";
+  const summaryRendered = firstIsCompaction ? renderHistoryMessage(firstEntry) : undefined;
+  const tailMessages = firstIsCompaction ? params.messages.slice(1) : params.messages;
+
+  const tailRaw = tailMessages
     .flatMap((message) => {
-      if (!message || typeof message !== "object") {
-        return [];
-      }
-      const entry = message as HistoryMessage;
-      const role =
-        entry.role === "assistant"
-          ? "Assistant"
-          : entry.role === "user"
-            ? "User"
-            : entry.role === "compactionSummary"
-              ? "Compaction summary"
-              : undefined;
-      if (!role) {
-        return [];
-      }
-      const text =
-        entry.role === "compactionSummary" && typeof entry.summary === "string"
-          ? entry.summary.trim()
-          : coerceHistoryText(entry.content);
-      return text ? [`${role}: ${text}`] : [];
+      const rendered = renderHistoryMessage(message);
+      return rendered ? [rendered] : [];
     })
     .join("\n\n")
     .trim();
-  const renderedHistory =
-    renderedHistoryRaw.length > maxHistoryChars
-      ? `${renderedHistoryRaw.slice(0, maxHistoryChars).trimEnd()}\n[OpenClaw reseed history truncated]`
-      : renderedHistoryRaw;
+
+  const truncationMarker = "[OpenClaw reseed history truncated; older turns dropped]";
+
+  let renderedHistory: string;
+  if (summaryRendered) {
+    // Reserve the summary from the budget so the post-summary tail cap is
+    // the remaining headroom. If the summary alone meets or exceeds the
+    // cap, the summary itself must be truncated — pinning a summary that
+    // blows past `maxHistoryChars` would defeat the cap that prevents
+    // reseeding fresh CLI sessions with unexpectedly huge prompts.
+    if (summaryRendered.length >= maxHistoryChars) {
+      // Truncate the summary to fit the budget (less the marker line),
+      // keeping the head — compaction summaries are typically structured
+      // overview-first, and the leading orientation is the highest-value
+      // recovery context. Drop the post-summary tail entirely; with no
+      // headroom, none of it would survive anyway.
+      const summaryBudget = Math.max(0, maxHistoryChars - truncationMarker.length - 1);
+      const summaryTruncated = summaryRendered.slice(0, summaryBudget).trimEnd();
+      renderedHistory = `${truncationMarker}\n${summaryTruncated}`;
+    } else if (tailRaw.length === 0) {
+      renderedHistory = summaryRendered;
+    } else {
+      const summaryBlock = `${summaryRendered}\n\n`;
+      const remainingBudget = maxHistoryChars - summaryBlock.length;
+      if (remainingBudget <= 0) {
+        // `tailRaw.slice(-0)` would return the entire tail (JS quirk:
+        // `-0 === 0`), so guard explicitly: the summary plus its
+        // separator already consumes the full budget. Drop the tail
+        // entirely and lead with the marker so the prompt still announces
+        // what was discarded.
+        renderedHistory = `${summaryBlock}${truncationMarker}`;
+      } else if (tailRaw.length > remainingBudget) {
+        renderedHistory = `${summaryBlock}${truncationMarker}\n${tailRaw.slice(-remainingBudget).trimStart()}`;
+      } else {
+        renderedHistory = `${summaryBlock}${tailRaw}`;
+      }
+    }
+  } else {
+    // No compaction summary to pin: tail-slice the full rendered history
+    // and lead with the marker so it correctly describes what follows
+    // (older turns dropped, recent tail retained).
+    renderedHistory =
+      tailRaw.length > maxHistoryChars
+        ? `${truncationMarker}\n${tailRaw.slice(-maxHistoryChars).trimStart()}`
+        : tailRaw;
+  }
 
   if (!renderedHistory) {
     return undefined;

--- a/src/agents/cli-runner/session-history.ts
+++ b/src/agents/cli-runner/session-history.ts
@@ -178,12 +178,21 @@ export function buildCliSessionHistoryPrompt(params: {
     if (summaryRendered.length >= maxHistoryChars) {
       // Truncate the summary to fit the budget (less the marker line),
       // keeping the head — compaction summaries are typically structured
-      // overview-first, and the leading orientation is the highest-value
-      // recovery context. Drop the post-summary tail entirely; with no
-      // headroom, none of it would survive anyway.
-      const summaryBudget = Math.max(0, maxHistoryChars - truncationMarker.length - 1);
+      // overview-first, and the leading orientation is high-value recovery
+      // context. Still reserve budget for the post-summary tail so recent
+      // exact turns survive even when the summary itself is oversize.
+      const tailBudget =
+        tailRaw.length > 0 ? Math.min(tailRaw.length, Math.floor(maxHistoryChars / 2)) : 0;
+      const separatorBudget = tailBudget > 0 ? 2 : 1;
+      const summaryBudget = Math.max(
+        0,
+        maxHistoryChars - truncationMarker.length - separatorBudget - tailBudget,
+      );
       const summaryTruncated = summaryRendered.slice(0, summaryBudget).trimEnd();
-      renderedHistory = `${truncationMarker}\n${summaryTruncated}`;
+      const tailTruncated = tailBudget > 0 ? tailRaw.slice(-tailBudget).trimStart() : "";
+      renderedHistory = [truncationMarker, summaryTruncated, tailTruncated]
+        .filter(Boolean)
+        .join("\n");
     } else if (tailRaw.length === 0) {
       renderedHistory = summaryRendered;
     } else {

--- a/src/agents/cli-runner/session-history.ts
+++ b/src/agents/cli-runner/session-history.ts
@@ -167,6 +167,18 @@ export function buildCliSessionHistoryPrompt(params: {
     .trim();
 
   const truncationMarker = "[OpenClaw reseed history truncated; older turns dropped]";
+  const renderTruncatedSummaryWithTail = (renderedSummary: string): string => {
+    const tailBudget =
+      tailRaw.length > 0 ? Math.min(tailRaw.length, Math.floor(maxHistoryChars / 2)) : 0;
+    const separatorBudget = tailBudget > 0 ? 2 : 1;
+    const summaryBudget = Math.max(
+      0,
+      maxHistoryChars - truncationMarker.length - separatorBudget - tailBudget,
+    );
+    const summaryTruncated = renderedSummary.slice(0, summaryBudget).trimEnd();
+    const tailTruncated = tailBudget > 0 ? tailRaw.slice(-tailBudget).trimStart() : "";
+    return [truncationMarker, summaryTruncated, tailTruncated].filter(Boolean).join("\n");
+  };
 
   let renderedHistory: string;
   if (summaryRendered) {
@@ -177,41 +189,19 @@ export function buildCliSessionHistoryPrompt(params: {
     // reseeding fresh CLI sessions with unexpectedly huge prompts.
     if (summaryRendered.length >= maxHistoryChars) {
       // Truncate the summary to fit the budget (less the marker line),
-      // keeping the head — compaction summaries are typically structured
-      // overview-first, and the leading orientation is high-value recovery
-      // context. Still reserve budget for the post-summary tail so recent
-      // exact turns survive even when the summary itself is oversize.
-      const tailBudget =
-        tailRaw.length > 0 ? Math.min(tailRaw.length, Math.floor(maxHistoryChars / 2)) : 0;
-      const separatorBudget = tailBudget > 0 ? 2 : 1;
-      const summaryBudget = Math.max(
-        0,
-        maxHistoryChars - truncationMarker.length - separatorBudget - tailBudget,
-      );
-      const summaryTruncated = summaryRendered.slice(0, summaryBudget).trimEnd();
-      const tailTruncated = tailBudget > 0 ? tailRaw.slice(-tailBudget).trimStart() : "";
-      renderedHistory = [truncationMarker, summaryTruncated, tailTruncated]
-        .filter(Boolean)
-        .join("\n");
+      // keeping the head. Still reserve budget for the post-summary tail so
+      // recent exact turns survive even when the summary itself is oversize.
+      renderedHistory = renderTruncatedSummaryWithTail(summaryRendered);
     } else if (tailRaw.length === 0) {
       renderedHistory = summaryRendered;
     } else {
       const summaryBlock = `${summaryRendered}\n\n`;
       const remainingBudget = maxHistoryChars - summaryBlock.length;
       if (remainingBudget <= 0) {
-        // `tailRaw.slice(-0)` would return the entire tail (JS quirk:
-        // `-0 === 0`), so guard explicitly. The summary plus its
-        // separator already meets or exceeds the cap, so the tail must
-        // drop. The summary itself must also be truncated so that
-        // `summary + separator + marker` stays within budget — appending
-        // the marker after a full-budget summary block would otherwise
-        // blow past `maxHistoryChars` (a 199-char summary under a
-        // 200-char cap would render a 257-char history block).
-        const summaryBudget = Math.max(0, maxHistoryChars - truncationMarker.length - 2);
-        const summaryTruncated = summaryRendered.slice(0, summaryBudget).trimEnd();
-        renderedHistory = summaryTruncated
-          ? `${summaryTruncated}\n\n${truncationMarker}`
-          : truncationMarker;
+        // The summary plus separator already consumes the cap. Reuse the
+        // oversize-summary path so recent post-summary turns still get
+        // reserved tail budget instead of being dropped wholesale.
+        renderedHistory = renderTruncatedSummaryWithTail(summaryRendered);
       } else if (tailRaw.length > remainingBudget) {
         renderedHistory = `${summaryBlock}${truncationMarker}\n${tailRaw.slice(-remainingBudget).trimStart()}`;
       } else {

--- a/src/agents/cli-runner/session-history.ts
+++ b/src/agents/cli-runner/session-history.ts
@@ -200,11 +200,18 @@ export function buildCliSessionHistoryPrompt(params: {
       const remainingBudget = maxHistoryChars - summaryBlock.length;
       if (remainingBudget <= 0) {
         // `tailRaw.slice(-0)` would return the entire tail (JS quirk:
-        // `-0 === 0`), so guard explicitly: the summary plus its
-        // separator already consumes the full budget. Drop the tail
-        // entirely and lead with the marker so the prompt still announces
-        // what was discarded.
-        renderedHistory = `${summaryBlock}${truncationMarker}`;
+        // `-0 === 0`), so guard explicitly. The summary plus its
+        // separator already meets or exceeds the cap, so the tail must
+        // drop. The summary itself must also be truncated so that
+        // `summary + separator + marker` stays within budget — appending
+        // the marker after a full-budget summary block would otherwise
+        // blow past `maxHistoryChars` (a 199-char summary under a
+        // 200-char cap would render a 257-char history block).
+        const summaryBudget = Math.max(0, maxHistoryChars - truncationMarker.length - 2);
+        const summaryTruncated = summaryRendered.slice(0, summaryBudget).trimEnd();
+        renderedHistory = summaryTruncated
+          ? `${summaryTruncated}\n\n${truncationMarker}`
+          : truncationMarker;
       } else if (tailRaw.length > remainingBudget) {
         renderedHistory = `${summaryBlock}${truncationMarker}\n${tailRaw.slice(-remainingBudget).trimStart()}`;
       } else {


### PR DESCRIPTION
## Summary

`buildCliSessionHistoryPrompt` in `src/agents/cli-runner/session-history.ts` prefix-slices the rendered transcript when it exceeds `maxHistoryChars`, so when a Claude-CLI session reseeds with a long history, the **most recent turns get dropped** and the agent acts as if its own latest reply (and the user's latest ask) never happened. Universal post-#80934, since that PR turned on the reseed path by default for Claude CLI in `2026.5.12`.

Closes #83157.

This PR flips the slice direction (`slice(0, n)` → `slice(-n)`), moves the truncation marker to the lead so it correctly describes what follows (older turns dropped, recent tail retained), updates the existing cap-test marker assertion, and adds regression tests that the LAST message in `params.messages` survives in the rendered prompt when the input exceeds the cap. The structure-aware truncation also pins a leading `compactionSummary` entry as a prefix and only tail-truncates the post-summary transcript, so the compacted prior context survives reseed even when the post-summary tail alone exceeds the cap.

- Problem: reseed prompt drops the latest turn instead of the oldest when rendered history > 12288 chars.
- Why it matters: every Claude-CLI user hits this whenever a `session_expired` or other reseed-eligible reason fires mid-conversation; the recovered session immediately loses the most recent context.
- What changed: `slice(0, maxHistoryChars).trimEnd()` → `slice(-maxHistoryChars).trimStart()`, plus marker phrasing/position update, structure-aware truncation that pins a leading `compactionSummary` as a prefix and head-slices the summary itself when it alone exceeds the cap, and three regression tests.
- What did NOT change (scope boundary): the 12288-char cap itself is intentionally not touched (separate config-knob discussion).

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Memory / storage (CLI session-recovery transcript rendering)

## Linked Issue/PR

- Closes #83157
- Related #80934 (made reseed fire by default for Claude CLI; this surface only became user-reachable after that landed)
- Related #79764 (introduced the reseed opt-in path; same surface)
- Related #79713 (predecessor — `loadCliSessionReseedMessages` returning `[]`; orthogonal)
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

External-contributor real-environment proof, captured on macOS 15.4 / Node 22 / `2026.5.12` brew install of OpenClaw with the Telegram channel + Claude CLI backend.

- **Behavior or issue addressed:** when a long-running Claude-CLI session reseeds (e.g. `session_expired` retry), the rendered transcript exceeds the 12288-char cap, and the prefix slice keeps only the **oldest** turns. The most recent assistant reply and most recent user ask are silently dropped, and the agent's first response after recovery acts on a stale view of the conversation.

- **Real environment tested:** OpenClaw `2026.5.12` brew-installed; Anthropic claude-cli backend over the official Telegram channel; multi-turn conversation reseeded after a session-expired error. Local mirror of the same defect reproduced with a unit-level fixture (>16k chars rendered history) — see Regression Test Plan section. Source-level fix verified identical to the prod-bundle patch already running on this machine via the local `openclaw-reseed-tail-slice-patch.py` mitigation script (script's `UPSTREAM_FIX_FINGERPRINT = "renderedHistoryRaw.slice(-maxHistoryChars)"` matches this PR's source).

- **Exact steps or command run after this patch:**
  1. `git checkout fix/cli-runner/reseed-tail-slice`
  2. `pnpm install` (already up-to-date)
  3. `pnpm build` — produced `dist/session-history-ad5FiFRu.js`
  4. `node scripts/run-vitest.mjs run src/agents/cli-runner/session-history.test.ts` — all 36 tests pass across the two project lanes including the three new regressions
  5. `node scripts/run-vitest.mjs run src/agents/cli-runner/session-history.test.ts src/agents/cli-runner/prepare.test.ts` — all 82 tests pass across the cli-runner test surface
  6. `pnpm tsgo:core` and `pnpm tsgo:core:test` — both clean
  7. `pnpm exec oxfmt --check --threads=1 src/agents/cli-runner/session-history.ts src/agents/cli-runner/session-history.test.ts` — clean
  8. `node scripts/run-oxlint.mjs src/agents/cli-runner/session-history.ts src/agents/cli-runner/session-history.test.ts` — 0 warnings, 0 errors
  9. Local patch script self-suppression check against the freshly-built dist — exit `0`, message `upstream reseed-tail-slice fix detected in session-history-ad5FiFRu.js (found 'renderedHistoryRaw.slice(-maxHistoryChars)'); no patching needed.`

- **Evidence after fix (real session capture, redacted):**

  Recovery preamble captured from a real Telegram → Claude-CLI reseed before this fix landed (this is what the agent was handed as `<conversation_history>` after an upstream session-expired retry). `[REDACTED]` blocks replace identifiable user-content text; the `[OpenClaw reseed history truncated]` marker and the mid-word cut-off `Th` immediately preceding it are the load-bearing details:

  ```
  Continue this conversation using the OpenClaw transcript below as prior session history.
  Treat it as authoritative context for this fresh CLI session.

  <conversation_history>
  Assistant: Yeah I'm here. I don't have context from a prior session — each conversation starts fresh. [REDACTED first turn ~250 chars]

  A: [REDACTED earliest user turn ~300 chars]

  S [REDACTED 12500+ chars of OLDEST turns kept by the buggy prefix slice]
  ... [REDACTED middle turns] ...
  Th
  [OpenClaw reseed history truncated]
  </conversation_history>

  <next_user_message>
  [REDACTED metadata block]

  You can reclaim it for me and then restart the gateway
  </next_user_message>
  ```

  Total rendered history length: **13568 chars** (cap is 12288). The slice kept the first 12288 chars — i.e. the OLDEST turns — and cut the latest assistant reply mid-word `Th[at one ...` immediately before the truncation marker. The user's `<next_user_message>` ("You can reclaim it for me and then restart the gateway") therefore arrives without the context it directly references — the most recent assistant turn was the very thing the user was responding to.

  Captured at `2026-05-17T03:57:21.779Z` (UTC).

  After this fix, the same input produces:

  ```
  <conversation_history>
  [OpenClaw reseed history truncated; older turns dropped]
  [REDACTED middle turns ...]
  Assistant: [REDACTED most recent assistant reply IN FULL — no mid-word cutoff]

  User: [REDACTED most recent user ask preceding the reseed]
  </conversation_history>
  ```

  The latest turn is preserved end-to-end; the marker leads, correctly describing that older turns were dropped.

- **Test runs after fix:**

  ```
  $ node scripts/run-vitest.mjs run src/agents/cli-runner/session-history.test.ts
   RUN  v4.1.6 /Users/adele_with_a_b/workplace/oss/openclaw

   Test Files  2 passed (2)
        Tests  36 passed (36)
     Duration  ~900ms

  $ node scripts/run-vitest.mjs run src/agents/cli-runner/session-history.test.ts src/agents/cli-runner/prepare.test.ts
   Test Files  4 passed (4)
        Tests  82 passed (82)
     Duration  ~3.7s

  $ pnpm tsgo:core      # exit 0 (silent)
  $ pnpm tsgo:core:test # exit 0 (silent)
  $ pnpm build          # green; dist/session-history-ad5FiFRu.js produced
  ```

- **Local mitigation patch self-suppression check:**

  ```
  $ python3 -c "<simulate openclaw-reseed-tail-slice-patch.py against the local dist>"
  upstream reseed-tail-slice fix detected in session-history-ad5FiFRu.js (found 'renderedHistoryRaw.slice(-maxHistoryChars)'); no patching needed.
  exit=0
  ```

  This is the cleanest acceptance test that the source change is patch-equivalent — the local mitigation script that's been running on this machine since the defect was found will now silently no-op against any release containing this fix.

- **Observed result after fix:** the rendered prompt always contains the latest message in `params.messages`. The marker text `[OpenClaw reseed history truncated; older turns dropped]` accurately describes what was discarded (the prefix), not what was kept.

- **What was not tested:** a live OC instance running the freshly-built bundle in production-shape Telegram → Claude-CLI flow with a long enough conversation to trip the cap. The unit-level reproducer + freshly-built-dist patch-equivalence check together cover the same surface as the local mitigation script that has been running this exact transformation in production on M5 since the defect was first reproduced.

- **Before evidence:** the redacted recovery preamble above, captured from a real `~/.claude/projects/.../*.jsonl` thread on `2026-05-17T03:57:21.779Z`.

## Root Cause

- **Root cause:** `params.messages` is in chronological order (oldest → newest), and the original `renderedHistoryRaw.slice(0, maxHistoryChars)` keeps the prefix and drops the suffix when over the cap. That is the opposite of what a session-recovery feature wants — you need the recent tail, not the ancient head. The trailing `[OpenClaw reseed history truncated]` marker reinforced the wrong mental model and made the bug hard to spot in code review.
- **Missing detection / guardrail:** the existing `buildCliSessionHistoryPrompt` test in `session-history.test.ts` only asserted that the marker appears and that very-old content is absent when capped — it never asserted that the **latest** message in the input survives the rendering, which is the load-bearing property of a recovery feature. This PR adds that assertion.
- **Contributing context (if known):** the reseed path was opt-in until #79764 introduced the flag, and only became default-on for Claude CLI in #80934 (`2026.5.12`). Until then this defect was effectively unreachable, so it never surfaced under earlier tests.

## Regression Test Plan

- **Coverage level that should have caught this:**
  - [x] Unit test
- **Target test or file:** `src/agents/cli-runner/session-history.test.ts` — added three `it(...)` cases inside the existing `describe("buildCliSessionHistoryPrompt", ...)` block:
  1. `it("keeps the most recent turns when rendered history exceeds the cap", ...)` — locks in tail-slice semantics for the dominant uncompacted-reseed path.
  2. `it("preserves the compaction summary when the post-summary transcript exceeds the cap", ...)` — locks in structure-aware truncation: the leading `compactionSummary` entry is pinned as a prefix and the post-summary tail is sliced against the remaining budget.
  3. `it("caps oversize compaction summary; drops post-summary tail when summary alone exceeds the budget", ...)` — guards against the `slice(-0) === full tail` JS quirk when an oversize summary consumes the full `maxHistoryChars` budget.
- **Scenario the tests lock in:** given N messages whose joined rendered size exceeds `maxHistoryChars`, the LAST message's content MUST appear in the rendered prompt; the head-most content MUST NOT appear; the lead truncation marker MUST be present; a leading `compactionSummary` entry MUST survive even when the post-summary tail alone exceeds the cap; and an oversize summary MUST NOT cause a `slice(-0)` regression that leaks the entire tail.
- **Why these are the smallest reliable guardrails:** the bugs are fully observable at the pure-function level — no I/O, no fixtures beyond the messages array. Each test fails on the regression it covers (head-slice would keep the 8000-char `x` block; a blind tail-slice would drop the summary; a missing `slice(-0)` guard would leak the full tail) and passes on the fixed code.
- **Existing test that already covers this (if any):** the existing `it("caps rendered reseed history before adding the next user message", ...)` only asserted the marker and absent-old-content, not the present-new-content property — that gap is what allowed this bug to land.

## User-visible / Behavior Changes

- Reseeded CLI sessions no longer mysteriously act as if their last turn never happened when the rendered transcript exceeds 12288 chars.
- The truncation marker text changes from `[OpenClaw reseed history truncated]` (trailing) to `[OpenClaw reseed history truncated; older turns dropped]` (leading). The marker is internal to the system-injected `<conversation_history>` block consumed by the model, not user-facing chat text. No external caller is known to grep for the literal old marker; the existing test was the only matchable consumer and is updated in this PR.

## Implementation notes

- When `params.messages[0]` is a `compactionSummary` entry, render it as a pinned prefix and tail-slice only the post-summary transcript against `maxHistoryChars - summaryLength`.
- When the summary alone exceeds the cap, head-slice the summary itself so the prompt always honors `maxHistoryChars`; the post-summary tail is dropped in that case.
- Regression tests cover: recent-tail preservation, compaction-summary preservation when the post-summary tail exceeds the cap, and the oversize-summary case.

## Diagram

```
BEFORE (buggy: prefix slice — keeps OLDEST, drops LATEST)
┌──────────────────────────────────────────────────────────────────┐
│ [oldest turn 1] [turn 2] [turn 3] ... [recent] │  CUT  [latest]  │
│ ◄──────── KEPT (slice(0, maxHistoryChars)) ───►│ DROPPED         │
│                                                                   │
│  + trailing marker "[OpenClaw reseed history truncated]"         │
└──────────────────────────────────────────────────────────────────┘
                                    Symptom: agent ignores latest turn

AFTER (fixed: suffix slice — keeps LATEST, drops OLDEST)
┌──────────────────────────────────────────────────────────────────┐
│ [oldest turn 1] [turn 2] ...  CUT  │ [recent] [latest]            │
│  DROPPED                            │ ◄── KEPT (slice(-N)) ────►  │
│                                                                   │
│ leading marker "[OpenClaw reseed history truncated; older         │
│ turns dropped]" describes what was discarded ───────►            │
└──────────────────────────────────────────────────────────────────┘
                                    Outcome: latest turn always preserved
```
