### PR TITLE
fix(outbound): warn when partial failDelivery rejects (#83113)

### DIFF
--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -2540,6 +2540,22 @@ describe("deliverOutboundPayloads", () => {
     );
   });
 
+  it("warns when recording bestEffort partial failure rejects", async () => {
+    queueMocks.failDelivery.mockRejectedValueOnce(new Error("queue write failed"));
+
+    const { results } = await runBestEffortPartialFailureDelivery();
+
+    expect(results).toEqual([{ channel: "matrix", messageId: "m2", roomId: "!room:example" }]);
+    expect(queueMocks.ackDelivery).not.toHaveBeenCalled();
+    expect(queueMocks.failDelivery).toHaveBeenCalledWith(
+      "mock-queue-id",
+      "partial delivery failure (bestEffort)",
+    );
+    expect(logMocks.warn).toHaveBeenCalledWith(
+      "failed to mark queued delivery mock-queue-id as failed after partial best-effort delivery: queue write failed",
+    );
+  });
+
   it("writes raw payloads to the queue before normalization", async () => {
     const sendMatrix = vi.fn().mockResolvedValue({ messageId: "m-raw", roomId: "!room:example" });
     const rawPayloads: DeliverOutboundPayload[] = [

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -1295,7 +1295,13 @@ async function deliverOutboundPayloadsWithQueueCleanup(
     }
     if (queueId) {
       if (hadPartialFailure) {
-        await failDelivery(queueId, "partial delivery failure (bestEffort)").catch(() => {});
+        await failDelivery(queueId, "partial delivery failure (bestEffort)").catch(
+          (err: unknown) => {
+            log.warn(
+              `failed to mark queued delivery ${queueId} as failed after partial best-effort delivery: ${formatErrorMessage(err)}`,
+            );
+          },
+        );
       } else {
         if (platformSendStarted) {
           await markQueuedPlatformOutcomeUnknown({


### PR DESCRIPTION
Fixes #83113.

## Summary

`deliverOutboundPayloadsWithQueueCleanup` already records best-effort partial delivery failures by calling `failDelivery(queueId, "partial delivery failure (bestEffort)")`, but the rejection path used an empty catch. If the queue write failed, operators got no signal that retry metadata was not recorded.

This keeps the existing best-effort return behavior and adds a warning for that queue-update failure.

## Changes

- Replace the empty `failDelivery(...).catch(() => {})` in the best-effort partial-failure cleanup path with a `log.warn(...)` that includes the queue id and formatted error.
- Add a regression test that makes `failDelivery` reject after a partial best-effort delivery and verifies:
  - delivery still returns the successfully sent payload result
  - `ackDelivery` is not called
  - `failDelivery` is attempted with the partial-failure reason
  - the warning is emitted

## Real behavior proof

**Behavior addressed:** when best-effort outbound delivery partially succeeds and `failDelivery` itself rejects, OpenClaw now logs the queue-update failure instead of silently swallowing it.

**Real environment tested:** local `openclaw/openclaw` checkout, branch `fix-outbound-faildelivery-warning-83113`, commit `f20695db44`, Linux x86_64, repo Node/Vitest harness.

**Exact steps or command run after this patch:**

```bash
node scripts/run-vitest.mjs src/infra/outbound/deliver.test.ts -t "partial failure"
node scripts/run-vitest.mjs src/infra/outbound/deliver.test.ts
git diff --check
pnpm check:changed
```

**Evidence after fix:**

```text
node scripts/run-vitest.mjs src/infra/outbound/deliver.test.ts -t "partial failure"
Test Files  1 passed (1)
Tests       3 passed | 80 skipped (83)

node scripts/run-vitest.mjs src/infra/outbound/deliver.test.ts
Test Files  1 passed (1)
Tests       83 passed (83)

git diff --check: pass, no output
pnpm check:changed: pass
```

**Observed result after fix:** the focused regression forces `queueMocks.failDelivery` to reject with `queue write failed`; `deliverOutboundPayloads` still returns the successful matrix result and `logMocks.warn` receives `failed to mark queued delivery mock-queue-id as failed after partial best-effort delivery: queue write failed`.

**Not tested:** no live channel delivery was run. The regression uses the existing outbound delivery test seam and mocked queue storage to exercise the affected cleanup branch directly.

## Pre-implement audit

- **Existing-helper check:** no new predicate/validator/classifier introduced; reused existing `formatErrorMessage` in the same file.
- **Shared-helper caller check:** `deliverOutboundPayloadsWithQueueCleanup` behavior is preserved for callers; only the previously empty catch now logs a warning.
- **Broader rival scan:** `gh pr list --repo openclaw/openclaw --state open --search '83113 in:title,body'` returned no rival PRs before implementation.
