### PR TITLE
fix(gateway): catch unhandled rejection in SIGTERM/SIGUSR1 signal handlers (#83116)

### DIFF
--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -677,15 +677,27 @@ export async function runGatewayLoop(params: {
 
   const onSigterm = () => {
     gatewayLog.info("signal SIGTERM received");
+    // #83116: fire-and-forget async path used to swallow rejections from
+    // loadGatewayLifecycleRuntimeModule (and any downstream lifecycle helper)
+    // straight into Node's unhandled-rejection handler, leaving the gateway
+    // wedged with no shutdown request submitted. Locally catch the failure,
+    // log it, and fall back to the deterministic plain-stop request so the
+    // shutdown path is never skipped silently.
     void (async () => {
-      const { consumeGatewayRestartIntentPayloadSync } = await loadGatewayLifecycleRuntimeModule();
-      const restartIntent = consumeGatewayRestartIntentPayloadSync();
-      request(
-        restartIntent ? "restart" : "stop",
-        "SIGTERM",
-        restartIntent?.reason,
-        restartIntent ?? undefined,
-      );
+      try {
+        const { consumeGatewayRestartIntentPayloadSync } =
+          await loadGatewayLifecycleRuntimeModule();
+        const restartIntent = consumeGatewayRestartIntentPayloadSync();
+        request(
+          restartIntent ? "restart" : "stop",
+          "SIGTERM",
+          restartIntent?.reason,
+          restartIntent ?? undefined,
+        );
+      } catch (err) {
+        gatewayLog.warn("SIGTERM lifecycle import failed; falling back to plain stop", { err });
+        request("stop", "SIGTERM");
+      }
     })();
   };
   const onSigint = () => {
@@ -694,41 +706,50 @@ export async function runGatewayLoop(params: {
   };
   const onSigusr1 = () => {
     gatewayLog.info("signal SIGUSR1 received");
+    // #83116: same fire-and-forget rejection class as SIGTERM. If the
+    // lifecycle module fails to load, the gateway must not leave SIGUSR1 in
+    // an "authorized but never handled" state — log the failure and fall
+    // through to the same authorization-denied warning path operators
+    // already see when commands.restart=false.
     void (async () => {
-      const {
-        consumeGatewayRestartIntentPayloadSync,
-        consumeGatewaySigusr1RestartAuthorization,
-        isGatewaySigusr1RestartExternallyAllowed,
-        markGatewaySigusr1RestartHandled,
-        peekGatewaySigusr1RestartReason,
-        scheduleGatewaySigusr1Restart,
-      } = await loadGatewayLifecycleRuntimeModule();
-      const restartIntent = consumeGatewayRestartIntentPayloadSync();
-      if (restartIntent) {
-        request("restart", "SIGUSR1", restartIntent.reason ?? "gateway.restart", restartIntent);
-        return;
-      }
-      const authorized = consumeGatewaySigusr1RestartAuthorization();
-      if (!authorized) {
+      try {
+        const {
+          consumeGatewayRestartIntentPayloadSync,
+          consumeGatewaySigusr1RestartAuthorization,
+          isGatewaySigusr1RestartExternallyAllowed,
+          markGatewaySigusr1RestartHandled,
+          peekGatewaySigusr1RestartReason,
+          scheduleGatewaySigusr1Restart,
+        } = await loadGatewayLifecycleRuntimeModule();
+        const restartIntent = consumeGatewayRestartIntentPayloadSync();
+        if (restartIntent) {
+          request("restart", "SIGUSR1", restartIntent.reason ?? "gateway.restart", restartIntent);
+          return;
+        }
+        const authorized = consumeGatewaySigusr1RestartAuthorization();
+        if (!authorized) {
+          markGatewaySigusr1RestartHandled();
+          if (!isGatewaySigusr1RestartExternallyAllowed()) {
+            gatewayLog.warn(
+              "SIGUSR1 restart ignored (not authorized; commands.restart=false or use gateway tool).",
+            );
+            return;
+          }
+          if (shuttingDown) {
+            gatewayLog.info("received SIGUSR1 during shutdown; ignoring");
+            return;
+          }
+          // External SIGUSR1 requests should still reuse the in-process restart
+          // scheduler so idle drain and restart coalescing stay consistent.
+          scheduleGatewaySigusr1Restart({ delayMs: 0, reason: "SIGUSR1" });
+          return;
+        }
+        const restartReason = peekGatewaySigusr1RestartReason();
         markGatewaySigusr1RestartHandled();
-        if (!isGatewaySigusr1RestartExternallyAllowed()) {
-          gatewayLog.warn(
-            "SIGUSR1 restart ignored (not authorized; commands.restart=false or use gateway tool).",
-          );
-          return;
-        }
-        if (shuttingDown) {
-          gatewayLog.info("received SIGUSR1 during shutdown; ignoring");
-          return;
-        }
-        // External SIGUSR1 requests should still reuse the in-process restart
-        // scheduler so idle drain and restart coalescing stay consistent.
-        scheduleGatewaySigusr1Restart({ delayMs: 0, reason: "SIGUSR1" });
-        return;
+        request("restart", "SIGUSR1", restartReason);
+      } catch (err) {
+        gatewayLog.warn("SIGUSR1 lifecycle import failed; restart skipped this cycle", { err });
       }
-      const restartReason = peekGatewaySigusr1RestartReason();
-      markGatewaySigusr1RestartHandled();
-      request("restart", "SIGUSR1", restartReason);
     })();
   };
 


### PR DESCRIPTION
Fixes #83116.

## Problem

`src/cli/gateway-cli/run-loop.ts` registers SIGTERM and SIGUSR1 listeners that fire-and-forget an `await loadGatewayLifecycleRuntimeModule()` inside `void (async () => { ... })()` with no try/catch. If the lifecycle import rejects (cold-start race, disk reshuffle, or any downstream lifecycle helper that throws before `request(...)` runs), the rejection escapes as a Node unhandled-rejection and the gateway is left with no shutdown or restart request submitted. Per ClawSweeper review, this is a `impact:crash-loop` regression that escapes the deterministic shutdown/restart path.

ClawSweeper recommendation: "Make the gateway signal handlers own their async failure path: log lifecycle import failures, drive deterministic shutdown/recovery fallback."

## Fix

`src/cli/gateway-cli/run-loop.ts`:

- **SIGTERM** — wrap the existing async body in try/catch. On lifecycle-import failure, log a warn and fall back to the deterministic plain `request("stop", "SIGTERM")` so shutdown is never silently skipped.
- **SIGUSR1** — wrap in try/catch. On failure, log a warn and skip the restart cycle. Operators already see this pattern when `commands.restart=false`, so the failure mode is recognisable. No restart is scheduled because we cannot tell whether the previous SIGUSR1 was authorized when the module failed to load.
- **SIGINT** — unchanged. It calls `request("stop", "SIGINT")` synchronously without awaiting any module load.

No behaviour change on the success path (the existing logic is preserved verbatim inside the try block).

## Real behavior proof

**Behavior or issue addressed**: Per #83116, when `loadGatewayLifecycleRuntimeModule()` rejects inside either signal listener, the async IIFE rejects before `request(...)` runs and Node surfaces it as an unhandled rejection. The gateway is then wedged with no shutdown/restart request submitted.

**Real environment tested**: Linux x86_64 (Ubuntu 24.04), Node v22.16, local checkout of `openclaw/openclaw` at branch `fix-gateway-signal-handler-unhandled-rejection` rebased on `origin/main` (`2c9f68f42b`). The probe replicates the handler structure end-to-end against three event sequences — success path, rejection path (post-fix), and a pre-fix simulation — using real Node `process.on("unhandledRejection")` and real microtask drain timing.

**Exact steps or command run after this patch**:

```
node --input-type=module -e '
function makeHandler({ loadModule, makeRequest, fallback }) {
  return () => {
    void (async () => {
      try {
        const mod = await loadModule();
        makeRequest("primary", mod);
      } catch (err) {
        fallback(err);
      }
    })();
  };
}

const events = [];
process.on("unhandledRejection", (reason) => events.push({ type: "unhandled", reason: String(reason) }));

async function runCase(name, loadModule) {
  events.length = 0;
  const requests = [];
  const fallbacks = [];
  const handler = makeHandler({
    loadModule,
    makeRequest: (kind, mod) => requests.push({ kind, mod }),
    fallback: (err) => fallbacks.push(String(err)),
  });
  handler();
  await new Promise((r) => setImmediate(r));
  await new Promise((r) => setImmediate(r));
  console.log(`${name}: requests=${requests.length} fallbacks=${fallbacks.length} unhandled=${events.length}`);
}

(async () => {
  await runCase("success path", async () => ({ ok: true }));
  await runCase("rejection path (issue scenario)", async () => { throw new Error("import failed"); });

  // Pre-fix simulation: no try/catch.
  function preFix() { void (async () => { throw new Error("import failed"); })(); }
  events.length = 0;
  preFix();
  await new Promise((r) => setImmediate(r));
  await new Promise((r) => setImmediate(r));
  console.log(`pre-fix simulation: unhandled=${events.length}`);
})();
'
```

**Evidence after fix**: live stdout (real `node`, real `unhandledRejection` event probe):

```
success path: requests=1 fallbacks=0 unhandled=0
rejection path (issue scenario): requests=0 fallbacks=1 unhandled=0
pre-fix simulation: unhandled=1
```

- **Success path**: 1 primary request, 0 fallbacks, 0 unhandled — regression-safe identity.
- **Rejection path (post-fix)**: 0 primary requests, 1 fallback fires (and would call `request("stop", "SIGTERM")` in production), 0 unhandled — the rejection is contained.
- **Pre-fix simulation**: 1 unhandled rejection — confirms the bug existed without the try/catch.

**Observed result after fix**: `SIGTERM` always submits a shutdown request — either the rich `consumeGatewayRestartIntentPayloadSync()`-aware path (success) or the deterministic `request("stop", "SIGTERM")` fallback (failure). `SIGUSR1` no longer leaves the gateway in an "authorized but never handled" state; the failure is logged at warn and the restart cycle is skipped, matching the existing `commands.restart=false` behaviour operators already see. No more crash-loop-by-unhandled-rejection.

**What was not tested**: I did not force a real gateway boot with a deliberately-broken `loadGatewayLifecycleRuntimeModule` import (would require monkey-patching the runtime loader at module level). The patched handler structure was probed against the same async-rejection shape Node's `unhandledRejection` event catches in production, and the success path is exercised end-to-end by every existing gateway boot.

## Pre-implement audit

- **Existing-helper check:** No new helper. Only wraps the existing async body in try/catch and reuses the already-bound `request` and `gatewayLog`. PASS.
- **Shared-helper caller check:** `loadGatewayLifecycleRuntimeModule` is the same lazy lifecycle loader the rest of the run loop already calls (`run-loop.ts:133`, `:167`, `:348`, `:358`, `:454`). The new try/catch is local to the SIGTERM/SIGUSR1 listeners; no contract change for any other consumer. PASS.
- **Broader-fix rival scan:** `gh pr list --search "83116 in:body"` returns no rival PRs. ClawSweeper labelled the issue P2 + queueable-fix + fix-shape-clear + source-repro + impact:crash-loop with no linked closing PR. PASS.
