### PR TITLE
Fix recent context loss in long Codex sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 - Mac app: align the Sessions settings pane with the standard Settings page gutter and row spacing.
 - Codex app-server: preserve streamed native command output in mirrored transcripts and trajectory exports when final snapshots omit aggregated output. (#83200) Thanks @rozmiarD.
 - Codex app-server: fail closed when chat or sender policy denies tools, disabling native code, app, environment, and user MCP surfaces for restricted turns. (#82374) Thanks @VACInc.
+- Codex app-server: keep recent context-engine messages when oversized projected history is truncated, so short follow-ups in long channel sessions do not fall back to stale earlier turns. (#83127) Thanks @VACInc.
 - Feishu: return bound subagent delivery origins from session thread setup so Feishu subagent completions route back to the same DM or topic. (#83190) Thanks @100menotu001.
 - CLI/update: tailor post-update Gateway recovery hints by platform, showing systemd, LaunchAgent, Scheduled Task, or generic service-manager guidance instead of macOS-only recovery text. (#83096) Thanks @rubencu.
 - Plugins: apply a default 15-second timeout to legacy `before_agent_start` hooks so hung plugin handlers no longer block agent startup. Fixes #48534. (#83136) Thanks @therahul-yo.

--- a/extensions/codex/src/app-server/context-engine-projection.test.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.test.ts
@@ -154,6 +154,32 @@ describe("projectContextEngineAssemblyForCodex", () => {
     expect(result.promptText.length).toBeLessThan(25_000);
   });
 
+  it("keeps recent context when the rendered conversation overflows", () => {
+    const result = projectContextEngineAssemblyForCodex({
+      assembledMessages: [
+        textMessage("assistant", `old discrawl setup from previous day ${"x".repeat(5_850)}`),
+        ...Array.from({ length: 5 }, (_, index) =>
+          textMessage("assistant", `stale filler ${index}:${"x".repeat(5_850)}`),
+        ),
+        textMessage(
+          "user",
+          "have Codex CLI do it via /goal. tell it in a SEPARATE repo; create recrawl",
+        ),
+        textMessage("assistant", "codex exec -C /tmp/recrawl started"),
+      ],
+      originalHistoryMessages: [],
+      prompt: "?",
+    });
+
+    expect(result.promptText).toContain("[truncated ");
+    expect(result.promptText).toContain("from older context");
+    expect(result.promptText).not.toContain("old discrawl setup from previous day");
+    expect(result.promptText).toContain("create recrawl");
+    expect(result.promptText).toContain("codex exec -C /tmp/recrawl started");
+    expect(result.promptText).toContain("Current user request:\n?");
+    expect(result.promptText.length).toBeLessThan(25_000);
+  });
+
   it("can scale the rendered context cap for larger Codex context windows", () => {
     const result = projectContextEngineAssemblyForCodex({
       assembledMessages: Array.from({ length: 12 }, (_, index) =>

--- a/extensions/codex/src/app-server/context-engine-projection.ts
+++ b/extensions/codex/src/app-server/context-engine-projection.ts
@@ -47,7 +47,7 @@ export function projectContextEngineAssemblyForCodex(params: {
         CONTEXT_SAFETY_NOTE,
         "",
         CONTEXT_OPEN,
-        truncateText(renderedContext, maxRenderedContextChars),
+        truncateOlderContext(renderedContext, maxRenderedContextChars),
         CONTEXT_CLOSE,
         "",
         REQUEST_HEADER,
@@ -380,4 +380,24 @@ function truncateText(text: string, maxChars: number): string {
   return text.length > maxChars
     ? `${text.slice(0, maxChars)}\n[truncated ${text.length - maxChars} chars]`
     : text;
+}
+
+function truncateOlderContext(text: string, maxChars: number): string {
+  if (text.length <= maxChars) {
+    return text;
+  }
+  if (maxChars <= 0) {
+    return "";
+  }
+
+  const buildMarker = (omittedChars: number): string =>
+    `[truncated ${omittedChars} chars from older context]\n`;
+  let marker = buildMarker(text.length - maxChars);
+  let tailChars = Math.max(0, maxChars - marker.length);
+  marker = buildMarker(text.length - tailChars);
+  if (marker.length >= maxChars) {
+    return marker.slice(0, maxChars);
+  }
+  tailChars = maxChars - marker.length;
+  return `${marker}${text.slice(text.length - tailChars).trimStart()}`;
 }


### PR DESCRIPTION
## Summary

- Preserve all rendered Codex app-server context-engine history when it fits the projection budget.
- When projected history is too large and must be clipped, truncate from the older side so the newest turns survive.
- Add regression coverage for a long stale session followed by recent recrawl/Codex CLI context, plus a maintainer changelog entry.

## Root Cause

Codex app-server context-engine projection rendered assembled conversation context in chronological order and then truncated the whole rendered block from the front. That clipping was not an intentional compaction boundary; it was a projection-size guard. In long channel sessions, the guard preserved stale earlier context while silently dropping the recent user turns and native Codex CLI activity that the follow-up depended on.

## Real behavior proof

Behavior addressed: Short follow-ups in long Codex-backed channel sessions should keep recent session context. If projected history exceeds the Codex prompt budget, the newest assembled turns must be retained instead of being clipped away.
Real environment tested: Maintainer checkout `/Users/steipete/Projects/clawdbot4`, PR branch `telegram-short-followup-context-fix` rebased onto `origin/main` at `691d62630f61b59ef362b6e675131cc4ba2efbe8`, head `7c14af42e9e7d6ece8b3e0d743e997f008ce9cc1`; sibling Codex source checkout `/Users/steipete/Projects/codex` inspected to confirm Codex accepts the projected text as ordinary current user input.
Exact steps or command run after this patch: `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --parallel-tests "node scripts/run-vitest.mjs extensions/codex/src/app-server/context-engine-projection.test.ts extensions/codex/src/app-server/run-attempt.context-engine.test.ts"`
Evidence after fix: Terminal capture from the maintainer run reported `Test Files 2 passed (2)`, `Tests 26 passed (26)`, `autoreview exit: 0`, `tests exit: 0`, and `autoreview clean: no accepted/actionable findings reported`.
Observed result after fix: The regression keeps `create recrawl` and `codex exec -C /tmp/recrawl started` in the projected context while omitting only older overflow text; the sibling Codex read confirmed no downstream Codex layer reconstructs recent turns after OpenClaw clips them from the current user-message text.
What was not tested: Live Telegram topic replay against the original private topic and full repository CI were not run for this maintainer rebase.

## Verification

- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main --parallel-tests "node scripts/run-vitest.mjs extensions/codex/src/app-server/context-engine-projection.test.ts extensions/codex/src/app-server/run-attempt.context-engine.test.ts"`
