### PR TITLE
fix(android): use realtime relay for talk mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Docs: https://docs.openclaw.ai
 - QA-Lab: add the personal-agent approval-denial scenario so the benchmark pack verifies denied local reads stop cleanly without tool progress or fixture leaks. (#83150) Thanks @iFiras-Max1.
 - QA-Lab: extend the personal-agent benchmark pack with a local task followthrough scenario for proof-backed pending, blocked, and done status reporting. Thanks @iFiras-Max1.
 - Gateway/performance: add `pnpm test:restart:gateway` benchmark tooling for repeated restart readiness, downtime, trace, and resource-slope evidence. (#83299) Thanks @samzong.
+- Android: switch Talk Mode to realtime Gateway relay voice sessions with streaming mic input, realtime audio playback, tool-result bridging, and on-screen transcripts. (#83130) Thanks @sliekens.
 
 ### Fixes
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/MainViewModel.kt
@@ -118,6 +118,8 @@ class MainViewModel(
   val talkModeListening: StateFlow<Boolean> = runtimeState(initial = false) { it.talkModeListening }
   val talkModeSpeaking: StateFlow<Boolean> = runtimeState(initial = false) { it.talkModeSpeaking }
   val talkModeStatusText: StateFlow<String> = runtimeState(initial = "Off") { it.talkModeStatusText }
+  val talkModeConversation: StateFlow<List<VoiceConversationEntry>> =
+    runtimeState(initial = emptyList()) { it.talkModeConversation }
 
   val chatSessionKey: StateFlow<String> = runtimeState(initial = "main") { it.chatSessionKey }
   val chatSessionId: StateFlow<String?> = runtimeState(initial = null) { it.chatSessionId }

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -539,6 +539,9 @@ class NodeRuntime(
   val talkModeStatusText: StateFlow<String>
     get() = talkMode.statusText
 
+  val talkModeConversation: StateFlow<List<VoiceConversationEntry>>
+    get() = talkMode.conversation
+
   private fun syncMainSessionKey(agentId: String?) {
     val resolvedKey = resolveNodeMainSessionKey(agentId)
     // Always push the resolved session key into TalkMode, even when the

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -50,6 +50,7 @@ import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.SystemClock
+import android.util.Base64
 import android.util.Log
 import androidx.core.content.ContextCompat
 import kotlinx.coroutines.CoroutineScope
@@ -425,6 +426,42 @@ class NodeRuntime(
     MicCaptureManager(
       context = appContext,
       scope = scope,
+      createTranscriptionSession = {
+        val params =
+          buildJsonObject {
+            put("mode", JsonPrimitive("transcription"))
+            put("transport", JsonPrimitive("gateway-relay"))
+            put("brain", JsonPrimitive("none"))
+          }
+        val response =
+          operatorSession.request(
+            "talk.session.create",
+            params.toString(),
+            timeoutMs = 15_000,
+          )
+        parseTalkSessionId(response)
+      },
+      appendTranscriptionAudio = { sessionId, audio, onError ->
+        val params =
+          buildJsonObject {
+            put("sessionId", JsonPrimitive(sessionId))
+            put("audioBase64", JsonPrimitive(Base64.encodeToString(audio, Base64.NO_WRAP)))
+            put("timestamp", JsonPrimitive(SystemClock.elapsedRealtime()))
+          }
+        operatorSession.sendRequestFrame(
+          "talk.session.appendAudio",
+          params.toString(),
+          timeoutMs = 8_000,
+        ) { error -> onError(error.message) }
+      },
+      closeTranscriptionSession = { sessionId ->
+        val params = buildJsonObject { put("sessionId", JsonPrimitive(sessionId)) }
+        operatorSession.request(
+          "talk.session.close",
+          params.toString(),
+          timeoutMs = 5_000,
+        )
+      },
       sendToGateway = { message, onRunIdKnown ->
         val idempotencyKey = UUID.randomUUID().toString()
         // Notify MicCaptureManager of the idempotency key *before* the network
@@ -1417,6 +1454,17 @@ class NodeRuntime(
     } catch (_: Throwable) {
       null
     }
+  }
+
+  private fun parseTalkSessionId(response: String): String {
+    val root = json.parseToJsonElement(response).asObjectOrNull()
+    val sessionId =
+      root?.get("transcriptionSessionId").asStringOrNull()
+        ?: root?.get("sessionId").asStringOrNull()
+    if (sessionId.isNullOrBlank()) {
+      throw IllegalStateException("talk.session.create returned no session id")
+    }
+    return sessionId
   }
 
   private suspend fun refreshBrandingFromGateway() {

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -486,6 +486,7 @@ class NodeRuntime(
       isConnected = { operatorConnected },
       onBeforeSpeak = { micCapture.pauseForTts() },
       onAfterSpeak = { micCapture.resumeAfterTts() },
+      onStoppedByRelay = { finishTalkModeAfterRelayClose() },
     )
   }
 
@@ -967,6 +968,14 @@ class NodeRuntime(
       NodeForegroundService.setVoiceCaptureMode(appContext, VoiceCaptureMode.Off)
       externalAudioCaptureActive.value = false
     }
+  }
+
+  private fun finishTalkModeAfterRelayClose() {
+    if (_voiceCaptureMode.value != VoiceCaptureMode.TalkMode) return
+    _voiceCaptureMode.value = VoiceCaptureMode.Off
+    talkMode.ttsOnAllResponses = false
+    NodeForegroundService.setVoiceCaptureMode(appContext, VoiceCaptureMode.Off)
+    externalAudioCaptureActive.value = false
   }
 
   val speakerEnabled: StateFlow<Boolean>

--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -1660,7 +1660,16 @@ internal fun resolveOperatorSessionConnectAuth(
     )
   }
 
-  return null
+  val explicitBootstrapToken = auth.bootstrapToken?.trim()?.takeIf { it.isNotEmpty() }
+  if (explicitBootstrapToken != null) {
+    return null
+  }
+
+  return NodeRuntime.GatewayConnectAuth(
+    token = null,
+    bootstrapToken = null,
+    password = null,
+  )
 }
 
 internal fun shouldConnectOperatorSession(

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -316,6 +316,22 @@ class GatewaySession(
     return RpcResult(ok = res.ok, payloadJson = res.payloadJson, error = res.error)
   }
 
+  suspend fun sendRequestFrame(
+    method: String,
+    paramsJson: String?,
+    timeoutMs: Long = 15_000,
+    onError: (ErrorShape) -> Unit = {},
+  ) {
+    val conn = currentConnection ?: throw IllegalStateException("not connected")
+    val params =
+      if (paramsJson.isNullOrBlank()) {
+        null
+      } else {
+        json.parseToJsonElement(paramsJson)
+      }
+    conn.sendRequestFrame(method = method, params = params, timeoutMs = timeoutMs, onError = onError)
+  }
+
   private data class RpcResponse(
     val id: String,
     val ok: Boolean,
@@ -360,14 +376,12 @@ class GatewaySession(
       val id = UUID.randomUUID().toString()
       val deferred = CompletableDeferred<RpcResponse>()
       pending[id] = deferred
-      val frame =
-        buildJsonObject {
-          put("type", JsonPrimitive("req"))
-          put("id", JsonPrimitive(id))
-          put("method", JsonPrimitive(method))
-          if (params != null) put("params", params)
-        }
-      sendJson(frame)
+      try {
+        sendJson(buildRequestFrame(id = id, method = method, params = params))
+      } catch (err: Throwable) {
+        pending.remove(id)
+        throw err
+      }
       return try {
         withTimeout(timeoutMs) { deferred.await() }
       } catch (err: TimeoutCancellationException) {
@@ -376,12 +390,56 @@ class GatewaySession(
       }
     }
 
+    suspend fun sendRequestFrame(
+      method: String,
+      params: JsonElement?,
+      timeoutMs: Long,
+      onError: (ErrorShape) -> Unit,
+    ) {
+      val id = UUID.randomUUID().toString()
+      val deferred = CompletableDeferred<RpcResponse>()
+      pending[id] = deferred
+      try {
+        sendJson(buildRequestFrame(id = id, method = method, params = params))
+      } catch (err: Throwable) {
+        pending.remove(id)
+        throw err
+      }
+      scope.launch(Dispatchers.IO) {
+        val response =
+          try {
+            withTimeout(timeoutMs) { deferred.await() }
+          } catch (_: TimeoutCancellationException) {
+            pending.remove(id)
+            onError(ErrorShape("UNAVAILABLE", "request timeout"))
+            return@launch
+          }
+        if (!response.ok) {
+          onError(response.error ?: ErrorShape("UNAVAILABLE", "request failed"))
+        }
+      }
+    }
+
     suspend fun sendJson(obj: JsonObject) {
       val jsonString = obj.toString()
       writeLock.withLock {
-        socket?.send(jsonString)
+        if (socket?.send(jsonString) != true) {
+          throw IllegalStateException("gateway send failed")
+        }
       }
     }
+
+    private fun buildRequestFrame(
+      id: String,
+      method: String,
+      params: JsonElement?,
+    ): JsonObject =
+      buildJsonObject {
+        put("type", JsonPrimitive("req"))
+        put("id", JsonPrimitive(id))
+        put("method", JsonPrimitive(method))
+        if (params != null) put("params", params)
+      }
 
     suspend fun awaitClose() = closedDeferred.await()
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceTabScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceTabScreen.kt
@@ -347,10 +347,8 @@ fun VoiceTabScreen(viewModel: MainViewModel) {
           voiceCaptureMode == VoiceCaptureMode.TalkMode && talkModeSpeaking -> "Talk speaking"
           voiceCaptureMode == VoiceCaptureMode.TalkMode && talkModeListening -> "Talk listening"
           voiceCaptureMode == VoiceCaptureMode.TalkMode -> "Talk on"
+          micEnabled || micIsSending || micCooldown -> micStatusText
           queueCount > 0 -> "$queueCount queued"
-          micIsSending -> "Sending"
-          micCooldown -> "Cooldown"
-          micEnabled -> "Listening"
           else -> "Mic off"
         }
       val stateColor =

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceTabScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/VoiceTabScreen.kt
@@ -96,8 +96,10 @@ fun VoiceTabScreen(viewModel: MainViewModel) {
   val talkModeEnabled by viewModel.talkModeEnabled.collectAsState()
   val talkModeListening by viewModel.talkModeListening.collectAsState()
   val talkModeSpeaking by viewModel.talkModeSpeaking.collectAsState()
+  val talkModeConversation by viewModel.talkModeConversation.collectAsState()
 
-  val hasStreamingAssistant = micConversation.any { it.role == VoiceConversationRole.Assistant && it.isStreaming }
+  val activeConversation = if (voiceCaptureMode == VoiceCaptureMode.TalkMode) talkModeConversation else micConversation
+  val hasStreamingAssistant = activeConversation.any { it.role == VoiceConversationRole.Assistant && it.isStreaming }
   val showThinkingBubble = micIsSending && !hasStreamingAssistant
 
   var hasMicPermission by remember { mutableStateOf(context.hasRecordAudioPermission()) }
@@ -131,8 +133,8 @@ fun VoiceTabScreen(viewModel: MainViewModel) {
       pendingVoicePermissionAction = null
     }
 
-  LaunchedEffect(micConversation.size, showThinkingBubble) {
-    val total = micConversation.size + if (showThinkingBubble) 1 else 0
+  LaunchedEffect(voiceCaptureMode, activeConversation.size, showThinkingBubble) {
+    val total = activeConversation.size + if (showThinkingBubble) 1 else 0
     if (total > 0) {
       listState.animateScrollToItem(total - 1)
     }
@@ -154,7 +156,7 @@ fun VoiceTabScreen(viewModel: MainViewModel) {
       contentPadding = PaddingValues(vertical = 4.dp),
       verticalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-      if (micConversation.isEmpty() && !showThinkingBubble) {
+      if (activeConversation.isEmpty() && !showThinkingBubble) {
         item {
           Box(
             modifier = Modifier.fillParentMaxHeight().fillMaxWidth(),
@@ -185,7 +187,7 @@ fun VoiceTabScreen(viewModel: MainViewModel) {
         }
       }
 
-      items(items = micConversation, key = { it.id }) { entry ->
+      items(items = activeConversation, key = { it.id }) { entry ->
         VoiceTurnBubble(entry = entry)
       }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt
@@ -50,9 +50,9 @@ class MicCaptureManager(
 ) {
   companion object {
     private const val tag = "MicCapture"
-    private const val speechMinSessionMs = 30_000L
-    private const val speechCompleteSilenceMs = 1_500L
-    private const val speechPossibleSilenceMs = 900L
+    private const val speechMinSessionMs = 30_000
+    private const val speechCompleteSilenceMs = 1_500
+    private const val speechPossibleSilenceMs = 900
     private const val transcriptIdleFlushMs = 1_600L
     private const val maxConversationEntries = 40
     private const val pendingRunTimeoutMs = 45_000L
@@ -625,8 +625,8 @@ class MicCaptureManager(
           when (error) {
             SpeechRecognizer.ERROR_AUDIO -> "Audio error"
             SpeechRecognizer.ERROR_CLIENT -> "Client error"
-            SpeechRecognizer.ERROR_NETWORK -> "Network error"
-            SpeechRecognizer.ERROR_NETWORK_TIMEOUT -> "Network timeout"
+            SpeechRecognizer.ERROR_NETWORK -> "Speech network error"
+            SpeechRecognizer.ERROR_NETWORK_TIMEOUT -> "Speech network timeout"
             SpeechRecognizer.ERROR_NO_MATCH -> "Listening"
             SpeechRecognizer.ERROR_RECOGNIZER_BUSY -> "Recognizer busy"
             SpeechRecognizer.ERROR_SERVER -> "Server error"
@@ -638,8 +638,6 @@ class MicCaptureManager(
             SpeechRecognizer.ERROR_TOO_MANY_REQUESTS -> "Speech requests limited; retrying"
             else -> "Speech error ($error)"
           }
-        _statusText.value = status
-
         if (
           error == SpeechRecognizer.ERROR_INSUFFICIENT_PERMISSIONS ||
           error == SpeechRecognizer.ERROR_LANGUAGE_NOT_SUPPORTED ||
@@ -654,9 +652,17 @@ class MicCaptureManager(
             SpeechRecognizer.ERROR_NO_MATCH,
             SpeechRecognizer.ERROR_SPEECH_TIMEOUT,
             -> 1_200L
+            SpeechRecognizer.ERROR_AUDIO,
+            SpeechRecognizer.ERROR_CLIENT,
+            SpeechRecognizer.ERROR_NETWORK,
+            SpeechRecognizer.ERROR_NETWORK_TIMEOUT,
+            SpeechRecognizer.ERROR_RECOGNIZER_BUSY,
+            SpeechRecognizer.ERROR_SERVER,
+            SpeechRecognizer.ERROR_SERVER_DISCONNECTED,
             SpeechRecognizer.ERROR_TOO_MANY_REQUESTS -> 2_500L
             else -> 600L
           }
+        _statusText.value = if (status == "Listening") status else "$status · retrying"
         scheduleRestart(delayMs = restartDelayMs)
       }
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/MicCaptureManager.kt
@@ -1,29 +1,30 @@
 package ai.openclaw.app.voice
 
 import android.Manifest
+import android.annotation.SuppressLint
 import android.content.Context
-import android.content.Intent
 import android.content.pm.PackageManager
-import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
-import android.speech.RecognitionListener
-import android.speech.RecognizerIntent
-import android.speech.SpeechRecognizer
+import android.media.AudioFormat
+import android.media.AudioRecord
+import android.media.MediaRecorder
 import android.util.Log
 import androidx.core.content.ContextCompat
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import java.util.UUID
+import kotlin.coroutines.coroutineContext
 
 enum class VoiceConversationRole {
   User,
@@ -40,6 +41,13 @@ data class VoiceConversationEntry(
 class MicCaptureManager(
   private val context: Context,
   private val scope: CoroutineScope,
+  private val createTranscriptionSession: suspend () -> String,
+  private val appendTranscriptionAudio: suspend (
+    sessionId: String,
+    audio: ByteArray,
+    onError: (String) -> Unit,
+  ) -> Unit,
+  private val closeTranscriptionSession: suspend (sessionId: String) -> Unit,
   /**
    * Send [message] to the gateway and return the run ID.
    * [onRunIdKnown] is called with the idempotency key *before* the network
@@ -50,15 +58,15 @@ class MicCaptureManager(
 ) {
   companion object {
     private const val tag = "MicCapture"
-    private const val speechMinSessionMs = 30_000
-    private const val speechCompleteSilenceMs = 1_500
-    private const val speechPossibleSilenceMs = 900
+    private const val transcriptionSampleRateHz = 8_000
+    private const val transcriptionAudioFrameMs = 100
+    private const val pcmuBias = 0x84
+    private const val pcmuClip = 32635
     private const val transcriptIdleFlushMs = 1_600L
     private const val maxConversationEntries = 40
     private const val pendingRunTimeoutMs = 45_000L
   }
 
-  private val mainHandler = Handler(Looper.getMainLooper())
   private val json = Json { ignoreUnknownKeys = true }
 
   private val _micEnabled = MutableStateFlow(false)
@@ -95,9 +103,11 @@ class MicCaptureManager(
   private var pendingAssistantEntryId: String? = null
   private var gatewayConnected = false
 
-  private var recognizer: SpeechRecognizer? = null
-  private var restartJob: Job? = null
-  private var drainJob: Job? = null
+  @Volatile private var transcriptionSessionId: String? = null
+  private var transcriptionStartJob: Job? = null
+  private var transcriptionCaptureJob: Job? = null
+  private var transcriptionAppendJob: Job? = null
+  private var transcriptionDrainJob: Job? = null
   private var transcriptFlushJob: Job? = null
   private var pendingRunTimeoutJob: Job? = null
   private var stopRequested = false
@@ -153,23 +163,23 @@ class MicCaptureManager(
         _statusText.value = if (_isSending.value) "Speaking · waiting for reply" else "Speaking…"
         return
       }
+      transcriptionDrainJob?.cancel()
+      transcriptionDrainJob = null
+      _micCooldown.value = false
       start()
       sendQueuedIfIdle()
     } else {
-      // Give the recognizer time to finish processing buffered audio.
-      // Cancel any prior drain to prevent duplicate sends on rapid toggle.
-      drainJob?.cancel()
+      transcriptionDrainJob?.cancel()
       _micCooldown.value = true
-      drainJob =
+      transcriptionDrainJob =
         scope.launch {
           delay(2000L)
           stop()
-          // Capture any partial transcript that didn't get a final result from the recognizer
           val partial = _liveTranscript.value?.trim().orEmpty()
           if (partial.isNotEmpty()) {
             queueRecognizedMessage(partial)
           }
-          drainJob = null
+          transcriptionDrainJob = null
           _micCooldown.value = false
           sendQueuedIfIdle()
         }
@@ -182,11 +192,9 @@ class MicCaptureManager(
         ttsPauseDepth += 1
         if (ttsPauseDepth > 1) return@synchronized false
         resumeMicAfterTts = _micEnabled.value
-        val active = resumeMicAfterTts || recognizer != null || _isListening.value
+        val active = resumeMicAfterTts || transcriptionSessionId != null || _isListening.value
         if (!active) return@synchronized false
         stopRequested = true
-        restartJob?.cancel()
-        restartJob = null
         transcriptFlushJob?.cancel()
         transcriptFlushJob = null
         _isListening.value = false
@@ -196,11 +204,7 @@ class MicCaptureManager(
         true
       }
     if (!shouldPause) return
-    withContext(Dispatchers.Main) {
-      recognizer?.cancel()
-      recognizer?.destroy()
-      recognizer = null
-    }
+    stopTranscription(preserveStatus = true)
   }
 
   suspend fun resumeAfterTts() {
@@ -231,9 +235,14 @@ class MicCaptureManager(
   fun onGatewayConnectionChanged(connected: Boolean) {
     gatewayConnected = connected
     if (connected) {
+      if (_micEnabled.value && transcriptionSessionId == null) {
+        start()
+      }
       sendQueuedIfIdle()
       return
     }
+    stopRequested = true
+    stopTranscription(preserveStatus = true)
     pendingRunTimeoutJob?.cancel()
     pendingRunTimeoutJob = null
     pendingRunId = null
@@ -248,6 +257,10 @@ class MicCaptureManager(
     event: String,
     payloadJson: String?,
   ) {
+    if (event == "talk.event") {
+      handleTranscriptionEvent(payloadJson)
+      return
+    }
     if (event != "chat") return
     if (payloadJson.isNullOrBlank()) return
     val payload =
@@ -304,93 +317,96 @@ class MicCaptureManager(
 
   private fun start() {
     stopRequested = false
-    if (!SpeechRecognizer.isRecognitionAvailable(context)) {
-      _statusText.value = "Speech recognizer unavailable"
-      _micEnabled.value = false
-      return
-    }
     if (!hasMicPermission()) {
       _statusText.value = "Microphone permission required"
       _micEnabled.value = false
       return
     }
-
-    mainHandler.post {
-      try {
-        if (recognizer == null) {
-          recognizer = SpeechRecognizer.createSpeechRecognizer(context).also { it.setRecognitionListener(listener) }
-        }
-        startListeningSession()
-      } catch (err: Throwable) {
-        _statusText.value = "Start failed: ${err.message ?: err::class.simpleName}"
-        _micEnabled.value = false
-      }
+    if (!gatewayConnected) {
+      _statusText.value = "Mic on · waiting for gateway"
+      return
     }
+    if (transcriptionSessionId != null || transcriptionStartJob?.isActive == true) return
+
+    val startJob =
+      scope.launch {
+        var restartAfterCancellation = false
+        try {
+          val sessionId = createTranscriptionSession()
+          if (stopRequested || !_micEnabled.value) {
+            closeTranscriptionSession(sessionId)
+            return@launch
+          }
+          transcriptionSessionId = sessionId
+          _isListening.value = true
+          _statusText.value = listeningStatus()
+          startTranscriptionCapture(sessionId)
+          Log.d(tag, "transcription session started sessionId=$sessionId")
+        } catch (err: Throwable) {
+          if (err is CancellationException) {
+            restartAfterCancellation = _micEnabled.value && gatewayConnected && !stopRequested
+            return@launch
+          }
+          _statusText.value = "Transcription unavailable: ${err.message ?: err::class.simpleName}"
+          _micEnabled.value = false
+          stopTranscription(preserveStatus = true)
+        } finally {
+          if (transcriptionStartJob === coroutineContext[Job]) {
+            transcriptionStartJob = null
+          }
+          if (restartAfterCancellation) {
+            start()
+          }
+        }
+      }
+    transcriptionStartJob = startJob
   }
 
   private fun stop() {
     stopRequested = true
-    restartJob?.cancel()
-    restartJob = null
+    stopTranscription()
+  }
+
+  private fun stopTranscription(preserveStatus: Boolean = false) {
+    val status = _statusText.value
+    val sessionId = transcriptionSessionId
+    transcriptionSessionId = null
+    if (sessionId != null) {
+      transcriptionStartJob?.cancel()
+      transcriptionStartJob = null
+    } else if (transcriptionStartJob?.isActive != true) {
+      transcriptionStartJob = null
+    }
+    transcriptionCaptureJob?.cancel()
+    transcriptionAppendJob?.cancel()
+    transcriptionCaptureJob = null
+    transcriptionAppendJob = null
     transcriptFlushJob?.cancel()
     transcriptFlushJob = null
     _isListening.value = false
-    _statusText.value = if (_isSending.value) "Mic off · sending…" else "Mic off"
     _inputLevel.value = 0f
-    mainHandler.post {
-      recognizer?.cancel()
-      recognizer?.destroy()
-      recognizer = null
+    if (!preserveStatus) {
+      _statusText.value = if (_isSending.value) "Mic off · sending…" else "Mic off"
+    } else {
+      _statusText.value = status
     }
-  }
-
-  private fun startListeningSession() {
-    val recognizerInstance = recognizer ?: return
-    val intent =
-      Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
-        putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
-        putExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, true)
-        putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 3)
-        putExtra(RecognizerIntent.EXTRA_CALLING_PACKAGE, context.packageName)
-        putExtra(RecognizerIntent.EXTRA_SPEECH_INPUT_MINIMUM_LENGTH_MILLIS, speechMinSessionMs)
-        putExtra(RecognizerIntent.EXTRA_SPEECH_INPUT_COMPLETE_SILENCE_LENGTH_MILLIS, speechCompleteSilenceMs)
-        putExtra(
-          RecognizerIntent.EXTRA_SPEECH_INPUT_POSSIBLY_COMPLETE_SILENCE_LENGTH_MILLIS,
-          speechPossibleSilenceMs,
-        )
-      }
-    _statusText.value =
-      when {
-        _isSending.value -> "Listening · sending queued voice"
-        hasQueuedMessages() -> "Listening · ${queuedMessageCount()} queued"
-        else -> "Listening"
-      }
-    _isListening.value = true
-    recognizerInstance.startListening(intent)
-  }
-
-  private fun scheduleRestart(delayMs: Long = 300L) {
-    if (stopRequested) return
-    if (!_micEnabled.value) return
-    restartJob?.cancel()
-    restartJob =
+    if (!sessionId.isNullOrBlank()) {
       scope.launch {
-        delay(delayMs)
-        mainHandler.post {
-          if (stopRequested || !_micEnabled.value) return@post
-          try {
-            startListeningSession()
-          } catch (_: Throwable) {
-            // retry through onError
+        try {
+          closeTranscriptionSession(sessionId)
+        } catch (err: Throwable) {
+          if (err !is CancellationException) {
+            Log.d(tag, "transcription close ignored: ${err.message ?: err::class.simpleName}")
           }
         }
       }
+    }
   }
 
   private fun queueRecognizedMessage(text: String) {
     val message = text.trim()
     _liveTranscript.value = null
-    if (message.isEmpty()) return
+    if (!message.hasTranscriptContent()) return
     appendConversation(
       role = VoiceConversationRole.User,
       text = message,
@@ -572,21 +588,208 @@ class MicCaptureManager(
     }
   }
 
-  private fun disableMic(status: String) {
-    stopRequested = true
-    restartJob?.cancel()
-    restartJob = null
-    transcriptFlushJob?.cancel()
-    transcriptFlushJob = null
-    _micEnabled.value = false
-    _isListening.value = false
-    _inputLevel.value = 0f
-    _statusText.value = status
-    mainHandler.post {
-      recognizer?.cancel()
-      recognizer?.destroy()
-      recognizer = null
+  @SuppressLint("MissingPermission")
+  private fun startTranscriptionCapture(sessionId: String) {
+    transcriptionCaptureJob?.cancel()
+    transcriptionAppendJob?.cancel()
+    val audioFrames =
+      Channel<ByteArray>(
+        capacity = 4,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+      )
+    transcriptionAppendJob =
+      scope.launch(Dispatchers.IO) {
+        for (frame in audioFrames) {
+          if (transcriptionSessionId != sessionId) continue
+          try {
+            appendTranscriptionAudio(sessionId, pcm16ToPcmu(frame)) { message ->
+              failTranscription(sessionId, message)
+            }
+          } catch (err: Throwable) {
+            if (err is CancellationException) throw err
+            failTranscription(sessionId, err.message ?: err::class.simpleName ?: "request failed")
+          }
+        }
+      }
+    transcriptionCaptureJob =
+      scope.launch(Dispatchers.IO) {
+        var audioRecord: AudioRecord? = null
+        try {
+          val frameBytes = transcriptionSampleRateHz * 2 * transcriptionAudioFrameMs / 1000
+          val minBuffer =
+            AudioRecord.getMinBufferSize(
+              transcriptionSampleRateHz,
+              AudioFormat.CHANNEL_IN_MONO,
+              AudioFormat.ENCODING_PCM_16BIT,
+            )
+          if (minBuffer <= 0) {
+            throw IllegalStateException("AudioRecord buffer unavailable")
+          }
+          audioRecord =
+            AudioRecord
+              .Builder()
+              .setAudioSource(MediaRecorder.AudioSource.VOICE_RECOGNITION)
+              .setAudioFormat(
+                AudioFormat
+                  .Builder()
+                  .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+                  .setSampleRate(transcriptionSampleRateHz)
+                  .setChannelMask(AudioFormat.CHANNEL_IN_MONO)
+                  .build(),
+              ).setBufferSizeInBytes(maxOf(minBuffer, frameBytes * 4))
+              .build()
+          val buffer = ByteArray(frameBytes)
+          audioRecord.startRecording()
+          while (coroutineContext.isActive && _micEnabled.value && transcriptionSessionId == sessionId) {
+            val read = audioRecord.read(buffer, 0, buffer.size)
+            if (read <= 0) continue
+            _inputLevel.value = pcm16Level(buffer, read)
+            audioFrames.trySend(buffer.copyOf(read))
+          }
+        } catch (err: Throwable) {
+          if (err is CancellationException) throw err
+          failTranscription(sessionId, err.message ?: err::class.simpleName ?: "capture failed")
+        } finally {
+          audioFrames.close()
+          audioRecord?.let { record ->
+            try {
+              record.stop()
+            } catch (_: Throwable) {
+            }
+            record.release()
+          }
+        }
+      }
+  }
+
+  private fun handleTranscriptionEvent(payloadJson: String?) {
+    if (payloadJson.isNullOrBlank()) return
+    val obj =
+      try {
+        json.parseToJsonElement(payloadJson).asObjectOrNull()
+      } catch (_: Throwable) {
+        null
+      } ?: return
+    val sessionId = obj["transcriptionSessionId"].asStringOrNull() ?: obj["sessionId"].asStringOrNull()
+    val currentSessionId = transcriptionSessionId
+    if (currentSessionId == null || sessionId != currentSessionId) return
+
+    when (obj["type"].asStringOrNull()) {
+      "ready", "inputAudio", "speechStart" -> {
+        _isListening.value = true
+        _statusText.value = listeningStatus()
+      }
+      "partial" -> {
+        val text = obj["text"].asStringOrNull()?.trim().orEmpty()
+        if (text.isNotEmpty()) {
+          _liveTranscript.value = text
+          scheduleTranscriptFlush(text)
+        }
+      }
+      "transcript" -> {
+        transcriptFlushJob?.cancel()
+        transcriptFlushJob = null
+        val text = obj["text"].asStringOrNull()?.trim().orEmpty()
+        if (text.isNotEmpty()) {
+          if (text != flushedPartialTranscript) {
+            queueRecognizedMessage(text)
+            sendQueuedIfIdle()
+          } else {
+            flushedPartialTranscript = null
+            _liveTranscript.value = null
+          }
+        }
+      }
+      "error" -> {
+        val message =
+          obj["message"]
+            .asStringOrNull()
+            ?.trim()
+            .orEmpty()
+            .ifEmpty { "transcription failed" }
+        failTranscription(currentSessionId, message)
+      }
+      "close" -> {
+        _micEnabled.value = false
+        stopTranscription()
+      }
     }
+  }
+
+  private fun failTranscription(
+    sessionId: String,
+    message: String,
+  ) {
+    if (transcriptionSessionId != sessionId) return
+    _statusText.value = "Transcription failed: $message"
+    _micEnabled.value = false
+    stopTranscription(preserveStatus = true)
+  }
+
+  private fun listeningStatus(): String =
+    when {
+      _isSending.value -> "Listening · sending queued voice"
+      hasQueuedMessages() -> "Listening · ${queuedMessageCount()} queued"
+      else -> "Listening"
+    }
+
+  private fun pcm16Level(
+    frame: ByteArray,
+    length: Int,
+  ): Float {
+    var total = 0L
+    var count = 0
+    var index = 0
+    val limit = length - (length % 2)
+    while (index < limit) {
+      val sample =
+        (frame[index].toInt() and 0xff) or
+          (frame[index + 1].toInt() shl 8)
+      total += kotlin.math.abs(sample.toShort().toInt())
+      count += 1
+      index += 2
+    }
+    if (count == 0) return 0f
+    return ((total / count).toFloat() / Short.MAX_VALUE).coerceIn(0f, 1f)
+  }
+
+  private fun pcm16ToPcmu(pcm16: ByteArray): ByteArray {
+    val output = ByteArray(pcm16.size / 2)
+    var inputIndex = 0
+    var outputIndex = 0
+    while (inputIndex + 1 < pcm16.size) {
+      val sample =
+        ((pcm16[inputIndex].toInt() and 0xff) or
+          (pcm16[inputIndex + 1].toInt() shl 8))
+          .toShort()
+          .toInt()
+      output[outputIndex] = linear16ToPcmu(sample)
+      inputIndex += 2
+      outputIndex += 1
+    }
+    return output
+  }
+
+  private fun linear16ToPcmu(sample: Int): Byte {
+    var sign = 0
+    var magnitude = sample
+    if (magnitude < 0) {
+      sign = 0x80
+      magnitude = -magnitude
+    }
+    if (magnitude > pcmuClip) {
+      magnitude = pcmuClip
+    }
+    magnitude += pcmuBias
+
+    var exponent = 7
+    var mask = 0x4000
+    while ((magnitude and mask) == 0 && exponent > 0) {
+      exponent -= 1
+      mask = mask shr 1
+    }
+    val mantissa = (magnitude shr (exponent + 3)) and 0x0f
+    return (sign or (exponent shl 4) or mantissa).inv().toByte()
   }
 
   private fun hasMicPermission(): Boolean =
@@ -596,109 +799,10 @@ class MicCaptureManager(
     )
 
   private fun parseAssistantText(payload: JsonObject): String? = ChatEventText.assistantTextFromPayload(payload)
-
-  private val listener =
-    object : RecognitionListener {
-      override fun onReadyForSpeech(params: Bundle?) {
-        _isListening.value = true
-      }
-
-      override fun onBeginningOfSpeech() {}
-
-      override fun onRmsChanged(rmsdB: Float) {
-        val level = ((rmsdB + 2f) / 12f).coerceIn(0f, 1f)
-        _inputLevel.value = level
-      }
-
-      override fun onBufferReceived(buffer: ByteArray?) {}
-
-      override fun onEndOfSpeech() {
-        _inputLevel.value = 0f
-        scheduleRestart()
-      }
-
-      override fun onError(error: Int) {
-        if (stopRequested) return
-        _isListening.value = false
-        _inputLevel.value = 0f
-        val status =
-          when (error) {
-            SpeechRecognizer.ERROR_AUDIO -> "Audio error"
-            SpeechRecognizer.ERROR_CLIENT -> "Client error"
-            SpeechRecognizer.ERROR_NETWORK -> "Speech network error"
-            SpeechRecognizer.ERROR_NETWORK_TIMEOUT -> "Speech network timeout"
-            SpeechRecognizer.ERROR_NO_MATCH -> "Listening"
-            SpeechRecognizer.ERROR_RECOGNIZER_BUSY -> "Recognizer busy"
-            SpeechRecognizer.ERROR_SERVER -> "Server error"
-            SpeechRecognizer.ERROR_SPEECH_TIMEOUT -> "Listening"
-            SpeechRecognizer.ERROR_INSUFFICIENT_PERMISSIONS -> "Microphone permission required"
-            SpeechRecognizer.ERROR_LANGUAGE_NOT_SUPPORTED -> "Language not supported on this device"
-            SpeechRecognizer.ERROR_LANGUAGE_UNAVAILABLE -> "Language unavailable on this device"
-            SpeechRecognizer.ERROR_SERVER_DISCONNECTED -> "Speech service disconnected"
-            SpeechRecognizer.ERROR_TOO_MANY_REQUESTS -> "Speech requests limited; retrying"
-            else -> "Speech error ($error)"
-          }
-        if (
-          error == SpeechRecognizer.ERROR_INSUFFICIENT_PERMISSIONS ||
-          error == SpeechRecognizer.ERROR_LANGUAGE_NOT_SUPPORTED ||
-          error == SpeechRecognizer.ERROR_LANGUAGE_UNAVAILABLE
-        ) {
-          disableMic(status)
-          return
-        }
-
-        val restartDelayMs =
-          when (error) {
-            SpeechRecognizer.ERROR_NO_MATCH,
-            SpeechRecognizer.ERROR_SPEECH_TIMEOUT,
-            -> 1_200L
-            SpeechRecognizer.ERROR_AUDIO,
-            SpeechRecognizer.ERROR_CLIENT,
-            SpeechRecognizer.ERROR_NETWORK,
-            SpeechRecognizer.ERROR_NETWORK_TIMEOUT,
-            SpeechRecognizer.ERROR_RECOGNIZER_BUSY,
-            SpeechRecognizer.ERROR_SERVER,
-            SpeechRecognizer.ERROR_SERVER_DISCONNECTED,
-            SpeechRecognizer.ERROR_TOO_MANY_REQUESTS -> 2_500L
-            else -> 600L
-          }
-        _statusText.value = if (status == "Listening") status else "$status · retrying"
-        scheduleRestart(delayMs = restartDelayMs)
-      }
-
-      override fun onResults(results: Bundle?) {
-        transcriptFlushJob?.cancel()
-        transcriptFlushJob = null
-        val text = results?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION).orEmpty().firstOrNull()
-        if (!text.isNullOrBlank()) {
-          val trimmed = text.trim()
-          if (trimmed != flushedPartialTranscript) {
-            queueRecognizedMessage(trimmed)
-            sendQueuedIfIdle()
-          } else {
-            flushedPartialTranscript = null
-            _liveTranscript.value = null
-          }
-        }
-        scheduleRestart()
-      }
-
-      override fun onPartialResults(partialResults: Bundle?) {
-        val text = partialResults?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION).orEmpty().firstOrNull()
-        if (!text.isNullOrBlank()) {
-          val trimmed = text.trim()
-          _liveTranscript.value = trimmed
-          scheduleTranscriptFlush(trimmed)
-        }
-      }
-
-      override fun onEvent(
-        eventType: Int,
-        params: Bundle?,
-      ) {}
-    }
 }
 
 private fun kotlinx.serialization.json.JsonElement?.asObjectOrNull(): JsonObject? = this as? JsonObject
 
 private fun kotlinx.serialization.json.JsonElement?.asStringOrNull(): String? = (this as? JsonPrimitive)?.takeIf { it.isString }?.content
+
+private fun String.hasTranscriptContent(): Boolean = any { it.isLetterOrDigit() }

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeGatewayConfig.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeGatewayConfig.kt
@@ -11,7 +11,13 @@ internal data class TalkModeGatewayConfigState(
   val mainSessionKey: String,
   val interruptOnSpeech: Boolean?,
   val silenceTimeoutMs: Long,
+  val executionMode: TalkModeExecutionMode,
 )
+
+internal enum class TalkModeExecutionMode {
+  Native,
+  RealtimeRelay,
+}
 
 internal object TalkModeGatewayConfigParser {
   fun parse(config: JsonObject?): TalkModeGatewayConfigState {
@@ -21,7 +27,20 @@ internal object TalkModeGatewayConfigParser {
       mainSessionKey = normalizeMainKey(sessionCfg?.get("mainKey").asStringOrNull()),
       interruptOnSpeech = talk?.get("interruptOnSpeech").asBooleanOrNull(),
       silenceTimeoutMs = resolvedSilenceTimeoutMs(talk),
+      executionMode = resolvedExecutionMode(talk),
     )
+  }
+
+  fun resolvedExecutionMode(talk: JsonObject?): TalkModeExecutionMode {
+    val realtime = talk?.get("realtime").asObjectOrNull() ?: return TalkModeExecutionMode.Native
+    val mode = realtime["mode"].asStringOrNull()
+    val transport = realtime["transport"].asStringOrNull()
+    val brain = realtime["brain"].asStringOrNull()
+    return if (mode == "realtime" && transport == "gateway-relay" && (brain == null || brain == "agent-consult")) {
+      TalkModeExecutionMode.RealtimeRelay
+    } else {
+      TalkModeExecutionMode.Native
+    }
   }
 
   fun resolvedSilenceTimeoutMs(talk: JsonObject?): Long {

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -2,12 +2,17 @@ package ai.openclaw.app.voice
 
 import ai.openclaw.app.gateway.GatewaySession
 import android.Manifest
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.media.AudioAttributes
 import android.media.AudioFocusRequest
+import android.media.AudioFormat
 import android.media.AudioManager
+import android.media.AudioRecord
+import android.media.AudioTrack
+import android.media.MediaRecorder
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -17,6 +22,7 @@ import android.speech.RecognizerIntent
 import android.speech.SpeechRecognizer
 import android.speech.tts.TextToSpeech
 import android.speech.tts.UtteranceProgressListener
+import android.util.Base64
 import android.util.Log
 import androidx.core.content.ContextCompat
 import kotlinx.coroutines.CancellationException
@@ -28,6 +34,7 @@ import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
@@ -36,6 +43,7 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
+import java.util.LinkedHashMap
 import java.util.Locale
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicLong
@@ -75,6 +83,8 @@ class TalkModeManager internal constructor(
 ) {
   companion object {
     private const val tag = "TalkMode"
+    private const val realtimeSampleRateHz = 24_000
+    private const val realtimeAudioFrameMs = 100
     private const val listenWatchdogMs = 12_000L
     private const val chatFinalWaitWithSubscribeMs = 45_000L
     private const val chatFinalWaitWithoutSubscribeMs = 6_000L
@@ -126,6 +136,12 @@ class TalkModeManager internal constructor(
   private val completedRunTexts = LinkedHashMap<String, String>()
   private var chatSubscribedSessionKey: String? = null
   private var configLoaded = false
+  @Volatile private var realtimeSessionId: String? = null
+  private var realtimeCaptureJob: Job? = null
+  private val realtimeToolRuns = LinkedHashMap<String, String>()
+  private val realtimePlaybackLock = Any()
+  private var realtimeAudioTrack: AudioTrack? = null
+  @Volatile private var realtimeOutputSuppressed = false
 
   @Volatile private var playbackEnabled = true
   private val playbackGeneration = AtomicLong(0L)
@@ -359,6 +375,10 @@ class TalkModeManager internal constructor(
     if (ttsOnAllResponses) {
       Log.d(tag, "gateway event: $event")
     }
+    if (event == "talk.event") {
+      handleRealtimeTalkEvent(payloadJson)
+      return
+    }
     if (event == "agent" && ttsOnAllResponses) {
       return
     }
@@ -378,6 +398,8 @@ class TalkModeManager internal constructor(
     val eventSession = obj["sessionKey"]?.asStringOrNull()
     val activeSession = mainSessionKey.ifBlank { "main" }
     if (eventSession != null && eventSession != activeSession) return
+
+    maybeCompleteRealtimeToolCall(runId = runId, state = state, messageEl = obj["message"])
 
     // If this is a response we initiated, handle normally below.
     // Otherwise, if ttsOnAllResponses, finish streaming TTS on terminal events.
@@ -423,6 +445,7 @@ class TalkModeManager internal constructor(
     if (playbackEnabled == enabled) return
     playbackEnabled = enabled
     if (!enabled) {
+      stopRealtimePlayback()
       stopSpeaking()
     }
   }
@@ -442,36 +465,18 @@ class TalkModeManager internal constructor(
   }
 
   private fun start() {
-    mainHandler.post {
-      if (_isListening.value) return@post
-      stopRequested = false
-      listeningMode = true
-      Log.d(tag, "start")
-
-      if (!SpeechRecognizer.isRecognitionAvailable(context)) {
-        _statusText.value = "Speech recognizer unavailable"
-        Log.w(tag, "speech recognizer unavailable")
-        return@post
-      }
-
-      val micOk =
-        ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) ==
-          PackageManager.PERMISSION_GRANTED
-      if (!micOk) {
-        _statusText.value = "Microphone permission required"
-        Log.w(tag, "microphone permission required")
-        return@post
-      }
-
+    if (realtimeSessionId != null || realtimeCaptureJob?.isActive == true) return
+    stopRequested = false
+    listeningMode = true
+    Log.d(tag, "start realtime")
+    scope.launch {
       try {
-        recognizer?.destroy()
-        recognizer = SpeechRecognizer.createSpeechRecognizer(context).also { it.setRecognitionListener(listener) }
-        startListeningInternal(markListening = true)
-        startSilenceMonitor()
-        Log.d(tag, "listening")
+        startRealtimeRelay()
       } catch (err: Throwable) {
+        if (err is CancellationException) return@launch
         _statusText.value = "Start failed: ${err.message ?: err::class.simpleName}"
-        Log.w(tag, "start failed: ${err.message ?: err::class.simpleName}")
+        Log.w(tag, "realtime start failed: ${err.message ?: err::class.simpleName}")
+        stopRealtimeRelay(closeSession = false)
       }
     }
   }
@@ -494,6 +499,7 @@ class TalkModeManager internal constructor(
     lastHeardAtMs = null
     _isListening.value = false
     _statusText.value = "Off"
+    stopRealtimeRelay()
     stopSpeaking()
     chatSubscribedSessionKey = null
     pendingRunId = null
@@ -510,6 +516,369 @@ class TalkModeManager internal constructor(
       recognizer = null
     }
     shutdownTextToSpeech()
+  }
+
+  private suspend fun startRealtimeRelay() {
+    if (!isConnected()) {
+      _statusText.value = "Gateway not connected"
+      Log.w(tag, "realtime start: gateway not connected")
+      return
+    }
+
+    val micOk =
+      ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) ==
+        PackageManager.PERMISSION_GRANTED
+    if (!micOk) {
+      _statusText.value = "Microphone permission required"
+      Log.w(tag, "realtime start: microphone permission required")
+      return
+    }
+
+    ensureConfigLoaded()
+    cancelActivePlayback()
+    stopTextToSpeechPlayback()
+    withContext(Dispatchers.Main) {
+      recognizer?.cancel()
+      recognizer?.destroy()
+      recognizer = null
+    }
+
+    _statusText.value = "Connecting…"
+    val params =
+      buildJsonObject {
+        put("sessionKey", JsonPrimitive(mainSessionKey.ifBlank { "main" }))
+        put("mode", JsonPrimitive("realtime"))
+        put("transport", JsonPrimitive("gateway-relay"))
+        put("brain", JsonPrimitive("agent-consult"))
+      }
+    val payload = session.request("talk.session.create", params.toString(), timeoutMs = 15_000)
+    val root = json.parseToJsonElement(payload).asObjectOrNull()
+    val relaySession = root?.get("relaySessionId").asStringOrNull()
+    val sessionId = relaySession ?: root?.get("sessionId").asStringOrNull()
+    if (sessionId.isNullOrBlank()) {
+      throw IllegalStateException("talk.session.create returned no session id")
+    }
+
+    realtimeSessionId = sessionId
+    realtimeOutputSuppressed = false
+    _isListening.value = true
+    _statusText.value = "Listening"
+    startRealtimeCapture(sessionId)
+    Log.d(tag, "realtime session started relaySessionId=$sessionId")
+  }
+
+  @SuppressLint("MissingPermission")
+  private fun startRealtimeCapture(sessionId: String) {
+    realtimeCaptureJob?.cancel()
+    realtimeCaptureJob =
+      scope.launch(Dispatchers.IO) {
+        var audioRecord: AudioRecord? = null
+        try {
+          val frameBytes = realtimeSampleRateHz * 2 * realtimeAudioFrameMs / 1000
+          val minBuffer =
+            AudioRecord.getMinBufferSize(
+              realtimeSampleRateHz,
+              AudioFormat.CHANNEL_IN_MONO,
+              AudioFormat.ENCODING_PCM_16BIT,
+            )
+          if (minBuffer <= 0) {
+            throw IllegalStateException("AudioRecord buffer unavailable")
+          }
+          audioRecord =
+            AudioRecord
+              .Builder()
+              .setAudioSource(MediaRecorder.AudioSource.VOICE_RECOGNITION)
+              .setAudioFormat(
+                AudioFormat
+                  .Builder()
+                  .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+                  .setSampleRate(realtimeSampleRateHz)
+                  .setChannelMask(AudioFormat.CHANNEL_IN_MONO)
+                  .build(),
+              ).setBufferSizeInBytes(maxOf(minBuffer, frameBytes * 4))
+              .build()
+          val buffer = ByteArray(frameBytes)
+          audioRecord.startRecording()
+          while (coroutineContext.isActive && _isEnabled.value && realtimeSessionId == sessionId) {
+            val read = audioRecord.read(buffer, 0, buffer.size)
+            if (read <= 0) continue
+            val audioBase64 = Base64.encodeToString(buffer.copyOf(read), Base64.NO_WRAP)
+            val params =
+              buildJsonObject {
+                put("sessionId", JsonPrimitive(sessionId))
+                put("audioBase64", JsonPrimitive(audioBase64))
+                put("timestamp", JsonPrimitive(SystemClock.elapsedRealtime()))
+              }
+            try {
+              session.request("talk.session.appendAudio", params.toString(), timeoutMs = 8_000)
+            } catch (err: Throwable) {
+              if (err is CancellationException) throw err
+              Log.w(tag, "realtime appendAudio failed: ${err.message ?: err::class.simpleName}")
+              _statusText.value = "Talk failed: ${err.message ?: err::class.simpleName}"
+              stopRealtimeRelay(cancelCapture = false)
+              return@launch
+            }
+          }
+        } catch (err: Throwable) {
+          if (err is CancellationException) throw err
+          Log.w(tag, "realtime capture failed: ${err.message ?: err::class.simpleName}")
+          _statusText.value = "Talk failed: ${err.message ?: err::class.simpleName}"
+          stopRealtimeRelay(cancelCapture = false)
+        } finally {
+          audioRecord?.let { record ->
+            try {
+              record.stop()
+            } catch (_: Throwable) {
+            }
+            record.release()
+          }
+        }
+      }
+  }
+
+  private fun handleRealtimeTalkEvent(payloadJson: String?) {
+    if (payloadJson.isNullOrBlank()) return
+    val obj =
+      try {
+        json.parseToJsonElement(payloadJson).asObjectOrNull()
+      } catch (_: Throwable) {
+        null
+      } ?: return
+    val sessionId = obj["relaySessionId"].asStringOrNull() ?: obj["sessionId"].asStringOrNull()
+    val currentSessionId = realtimeSessionId
+    if (currentSessionId == null || sessionId != currentSessionId) return
+
+    when (val type = obj["type"].asStringOrNull()) {
+      "ready" -> {
+        _isListening.value = true
+        _statusText.value = "Listening"
+      }
+      "inputAudio" -> {
+        _isListening.value = true
+      }
+      "audio" -> {
+        if (realtimeOutputSuppressed) return
+        val audioBase64 = obj["audioBase64"].asStringOrNull() ?: return
+        val bytes =
+          try {
+            Base64.decode(audioBase64, Base64.DEFAULT)
+          } catch (err: Throwable) {
+            Log.w(tag, "realtime audio decode failed: ${err.message ?: err::class.simpleName}")
+            return
+          }
+        playRealtimeAudio(bytes)
+      }
+      "clear" -> stopRealtimePlayback()
+      "mark" -> Unit
+      "transcript" -> {
+        val role = obj["role"].asStringOrNull()
+        val text = obj["text"].asStringOrNull()?.trim().orEmpty()
+        val isFinal = obj["final"].asBooleanOrNull() == true
+        if (role == "assistant" && text.isNotEmpty()) {
+          _lastAssistantText.value = text
+        }
+        if (isFinal && role == "user") {
+          realtimeOutputSuppressed = false
+          _statusText.value = "Thinking…"
+        } else if (isFinal && role == "assistant") {
+          _statusText.value = "Listening"
+        }
+      }
+      "toolCall" -> {
+        val callId = obj["callId"].asStringOrNull() ?: return
+        val name = obj["name"].asStringOrNull() ?: return
+        handleRealtimeToolCall(
+          callId = callId,
+          name = name,
+          args = obj["args"],
+        )
+      }
+      "toolResult" -> Unit
+      "error" -> {
+        val message = obj["message"].asStringOrNull() ?: "realtime talk error"
+        _statusText.value = "Talk failed: $message"
+        Log.w(tag, "realtime error: $message")
+      }
+      "close" -> {
+        Log.d(tag, "realtime close reason=${obj["reason"].asStringOrNull()}")
+        stopRealtimeRelay(closeSession = false)
+        if (_isEnabled.value) {
+          _isEnabled.value = false
+          _statusText.value = "Off"
+        }
+      }
+      else -> {
+        if (type != null) Log.d(tag, "ignored realtime event type=$type")
+      }
+    }
+  }
+
+  private fun playRealtimeAudio(bytes: ByteArray) {
+    if (!playbackEnabled || realtimeOutputSuppressed || bytes.isEmpty()) return
+    synchronized(realtimePlaybackLock) {
+      val track =
+        realtimeAudioTrack ?: run {
+          val minBuffer =
+            AudioTrack.getMinBufferSize(
+              realtimeSampleRateHz,
+              AudioFormat.CHANNEL_OUT_MONO,
+              AudioFormat.ENCODING_PCM_16BIT,
+            )
+          val created =
+            AudioTrack
+              .Builder()
+              .setAudioAttributes(
+                AudioAttributes
+                  .Builder()
+                  .setUsage(AudioAttributes.USAGE_MEDIA)
+                  .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                  .build(),
+              ).setAudioFormat(
+                AudioFormat
+                  .Builder()
+                  .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+                  .setSampleRate(realtimeSampleRateHz)
+                  .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
+                  .build(),
+              ).setTransferMode(AudioTrack.MODE_STREAM)
+              .setBufferSizeInBytes(maxOf(minBuffer, bytes.size * 4))
+              .build()
+          created.play()
+          realtimeAudioTrack = created
+          created
+        }
+      _isSpeaking.value = true
+      _statusText.value = "Speaking…"
+      track.write(bytes, 0, bytes.size)
+    }
+  }
+
+  private fun stopRealtimePlayback() {
+    synchronized(realtimePlaybackLock) {
+      realtimeAudioTrack?.let { track ->
+        try {
+          track.pause()
+          track.flush()
+          track.stop()
+        } catch (_: Throwable) {
+        }
+        track.release()
+      }
+      realtimeAudioTrack = null
+    }
+    _isSpeaking.value = false
+    if (_isEnabled.value) {
+      _statusText.value = "Listening"
+    }
+  }
+
+  private fun stopRealtimeRelay(
+    closeSession: Boolean = true,
+    cancelCapture: Boolean = true,
+  ) {
+    val sessionId = realtimeSessionId
+    realtimeSessionId = null
+    realtimeOutputSuppressed = false
+    if (cancelCapture) {
+      realtimeCaptureJob?.cancel()
+    }
+    realtimeCaptureJob = null
+    realtimeToolRuns.clear()
+    stopRealtimePlayback()
+    _isListening.value = false
+    if (closeSession && !sessionId.isNullOrBlank()) {
+      scope.launch {
+        try {
+          val params = buildJsonObject { put("sessionId", JsonPrimitive(sessionId)) }
+          session.request("talk.session.close", params.toString(), timeoutMs = 5_000)
+        } catch (err: Throwable) {
+          if (err !is CancellationException) {
+            Log.d(tag, "realtime close ignored: ${err.message ?: err::class.simpleName}")
+          }
+        }
+      }
+    }
+  }
+
+  private fun handleRealtimeToolCall(
+    callId: String,
+    name: String,
+    args: JsonElement?,
+  ) {
+    val relaySessionId = realtimeSessionId ?: return
+    scope.launch {
+      try {
+        val params =
+          buildJsonObject {
+            put("sessionKey", JsonPrimitive(mainSessionKey.ifBlank { "main" }))
+            put("callId", JsonPrimitive(callId))
+            put("name", JsonPrimitive(name))
+            put("relaySessionId", JsonPrimitive(relaySessionId))
+            if (args != null) put("args", args)
+          }
+        val response = session.request("talk.client.toolCall", params.toString(), timeoutMs = 15_000)
+        val runId = parseRunId(response)
+        if (!runId.isNullOrBlank()) {
+          realtimeToolRuns[runId] = callId
+          _statusText.value = "Thinking…"
+        } else {
+          submitRealtimeToolError(callId, "tool call returned no run id")
+        }
+      } catch (err: Throwable) {
+        if (err is CancellationException) throw err
+        Log.w(tag, "realtime toolCall failed: ${err.message ?: err::class.simpleName}")
+        submitRealtimeToolError(callId, err.message ?: "tool call failed")
+      }
+    }
+  }
+
+  private fun maybeCompleteRealtimeToolCall(
+    runId: String,
+    state: String,
+    messageEl: JsonElement?,
+  ) {
+    val callId = realtimeToolRuns[runId] ?: return
+    when (state) {
+      "final" -> {
+        realtimeToolRuns.remove(runId)
+        val text = extractTextFromChatEventMessage(messageEl).orEmpty()
+        scope.launch {
+          submitRealtimeToolResult(callId, buildJsonObject { put("text", JsonPrimitive(text)) })
+        }
+      }
+      "aborted", "error" -> {
+        realtimeToolRuns.remove(runId)
+        scope.launch {
+          submitRealtimeToolError(callId, state)
+        }
+      }
+    }
+  }
+
+  private suspend fun submitRealtimeToolError(
+    callId: String,
+    message: String,
+  ) {
+    submitRealtimeToolResult(callId, buildJsonObject { put("error", JsonPrimitive(message)) })
+  }
+
+  private suspend fun submitRealtimeToolResult(
+    callId: String,
+    result: JsonObject,
+  ) {
+    val sessionId = realtimeSessionId ?: return
+    val params =
+      buildJsonObject {
+        put("sessionId", JsonPrimitive(sessionId))
+        put("callId", JsonPrimitive(callId))
+        put("result", result)
+      }
+    try {
+      session.request("talk.session.submitToolResult", params.toString(), timeoutMs = 15_000)
+    } catch (err: Throwable) {
+      if (err is CancellationException) throw err
+      Log.w(tag, "realtime submitToolResult failed: ${err.message ?: err::class.simpleName}")
+    }
   }
 
   private fun startListeningInternal(markListening: Boolean) {
@@ -1077,9 +1446,30 @@ class TalkModeManager internal constructor(
   }
 
   fun stopTts() {
+    realtimeOutputSuppressed = true
+    stopRealtimePlayback()
+    cancelRealtimeOutput(reason = "android-stop-tts")
     stopSpeaking(resetInterrupt = true)
     _isSpeaking.value = false
     _statusText.value = "Listening"
+  }
+
+  private fun cancelRealtimeOutput(reason: String) {
+    val sessionId = realtimeSessionId ?: return
+    scope.launch {
+      try {
+        val params =
+          buildJsonObject {
+            put("sessionId", JsonPrimitive(sessionId))
+            put("reason", JsonPrimitive(reason))
+          }
+        session.request("talk.session.cancelOutput", params.toString(), timeoutMs = 5_000)
+      } catch (err: Throwable) {
+        if (err !is CancellationException) {
+          Log.d(tag, "realtime cancelOutput ignored: ${err.message ?: err::class.simpleName}")
+        }
+      }
+    }
   }
 
   private fun stopSpeaking(resetInterrupt: Boolean = true) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -98,10 +98,6 @@ class TalkModeManager internal constructor(
     private const val tag = "TalkMode"
     private const val realtimeSampleRateHz = 24_000
     private const val realtimeAudioFrameMs = 100
-    private const val realtimeSpeechStartAverageAmplitude = 800
-    private const val realtimeSpeechContinueAverageAmplitude = 800
-    private const val realtimeSpeechStartFrameCount = 3
-    private const val realtimeSpeechHangoverMs = 700L
     private const val listenWatchdogMs = 12_000L
     private const val chatFinalWaitWithSubscribeMs = 45_000L
     private const val chatFinalWaitWithoutSubscribeMs = 6_000L
@@ -166,8 +162,6 @@ class TalkModeManager internal constructor(
   private var realtimeAudioTrack: AudioTrack? = null
   private var realtimePlaybackIdleJob: Job? = null
   @Volatile private var realtimePlaybackEndsAtMs = 0L
-  @Volatile private var realtimeSpeechActiveUntilMs = 0L
-  private var realtimeSpeechCandidateFrames = 0
 
   @Volatile private var realtimeOutputSuppressed = false
 
@@ -641,7 +635,6 @@ class TalkModeManager internal constructor(
 
     realtimeSessionId = sessionId
     realtimeOutputSuppressed = false
-    resetRealtimeSpeechGate()
     _isListening.value = true
     _statusText.value = "Listening"
     startRealtimeCapture(sessionId)
@@ -734,7 +727,7 @@ class TalkModeManager internal constructor(
           while (coroutineContext.isActive && _isEnabled.value && realtimeSessionId == sessionId) {
             val read = audioRecord.read(buffer, 0, buffer.size)
             if (read <= 0) continue
-            if (!shouldAppendRealtimeCapturedFrame(buffer, read)) continue
+            if (!shouldAppendRealtimeCapturedFrame(read)) continue
             audioFrames.trySend(buffer.copyOf(read))
           }
         } catch (err: Throwable) {
@@ -754,61 +747,11 @@ class TalkModeManager internal constructor(
       }
   }
 
-  private fun shouldAppendRealtimeCapturedFrame(
-    frame: ByteArray,
-    length: Int = frame.size,
-  ): Boolean {
-    if (isRealtimePlaybackActive()) {
-      resetRealtimeSpeechGate()
-      return false
-    }
-    val now = SystemClock.elapsedRealtime()
-    val average = pcm16AverageAmplitude(frame, length)
-    if (now < realtimeSpeechActiveUntilMs) {
-      if (average >= realtimeSpeechContinueAverageAmplitude) {
-        realtimeSpeechActiveUntilMs = now + realtimeSpeechHangoverMs
-      }
-      return true
-    }
-    if (average >= realtimeSpeechStartAverageAmplitude) {
-      realtimeSpeechCandidateFrames += 1
-      if (realtimeSpeechCandidateFrames >= realtimeSpeechStartFrameCount) {
-        realtimeSpeechActiveUntilMs = now + realtimeSpeechHangoverMs
-        return true
-      }
-      return false
-    }
-    realtimeSpeechCandidateFrames = 0
-    return false
-  }
+  private fun shouldAppendRealtimeCapturedFrame(length: Int): Boolean =
+    !isRealtimePlaybackActive() && length > 0
 
   private fun isRealtimePlaybackActive(): Boolean =
     _isSpeaking.value || SystemClock.elapsedRealtime() < realtimePlaybackEndsAtMs
-
-  private fun resetRealtimeSpeechGate() {
-    realtimeSpeechActiveUntilMs = 0L
-    realtimeSpeechCandidateFrames = 0
-  }
-
-  private fun pcm16AverageAmplitude(
-    frame: ByteArray,
-    length: Int,
-  ): Int {
-    var total = 0L
-    var count = 0
-    var index = 0
-    val limit = length - (length % 2)
-    while (index < limit) {
-      val sample =
-        (frame[index].toInt() and 0xff) or
-          (frame[index + 1].toInt() shl 8)
-      val amplitude = kotlin.math.abs(sample.toShort().toInt())
-      total += amplitude
-      count += 1
-      index += 2
-    }
-    return if (count == 0) 0 else (total / count).toInt()
-  }
 
   private fun handleRealtimeTalkEvent(payloadJson: String?) {
     if (payloadJson.isNullOrBlank()) return

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -102,6 +102,7 @@ class TalkModeManager internal constructor(
     private const val chatFinalWaitWithSubscribeMs = 45_000L
     private const val chatFinalWaitWithoutSubscribeMs = 6_000L
     private const val maxCachedRunCompletions = 128
+    private const val maxConversationEntries = 40
   }
 
   private val mainHandler = Handler(Looper.getMainLooper())
@@ -120,6 +121,9 @@ class TalkModeManager internal constructor(
 
   private val _lastAssistantText = MutableStateFlow<String?>(null)
   val lastAssistantText: StateFlow<String?> = _lastAssistantText
+
+  private val _conversation = MutableStateFlow<List<VoiceConversationEntry>>(emptyList())
+  val conversation: StateFlow<List<VoiceConversationEntry>> = _conversation
 
   private var recognizer: SpeechRecognizer? = null
   private var restartJob: Job? = null
@@ -158,6 +162,8 @@ class TalkModeManager internal constructor(
   private val realtimeToolRuns = LinkedHashMap<String, RealtimeToolRun>()
   private val pendingRealtimeToolCalls = LinkedHashSet<String>()
   private val pendingRealtimeToolCompletions = LinkedHashMap<String, RealtimeToolCompletion>()
+  private var realtimeUserEntryId: String? = null
+  private var realtimeAssistantEntryId: String? = null
   private val realtimePlaybackLock = Any()
   private var realtimeAudioTrack: AudioTrack? = null
   private var realtimePlaybackIdleJob: Job? = null
@@ -791,6 +797,12 @@ class TalkModeManager internal constructor(
         val role = obj["role"].asStringOrNull()
         val text = obj["text"].asStringOrNull()?.trim().orEmpty()
         val isFinal = obj["final"].asBooleanOrNull() == true
+        if (text.isNotEmpty()) {
+          when (role) {
+            "user" -> upsertRealtimeConversation(VoiceConversationRole.User, text, isFinal)
+            "assistant" -> upsertRealtimeConversation(VoiceConversationRole.Assistant, text, isFinal)
+          }
+        }
         if (role == "assistant" && text.isNotEmpty()) {
           _lastAssistantText.value = text
         }
@@ -936,6 +948,8 @@ class TalkModeManager internal constructor(
     realtimeToolRuns.clear()
     pendingRealtimeToolCalls.clear()
     pendingRealtimeToolCompletions.clear()
+    realtimeUserEntryId = null
+    realtimeAssistantEntryId = null
     stopRealtimePlayback()
     if (preserveStatus) {
       _statusText.value = status
@@ -1082,6 +1096,61 @@ class TalkModeManager internal constructor(
       if (err is CancellationException) throw err
       Log.w(tag, "realtime submitToolResult failed: ${err.message ?: err::class.simpleName}")
     }
+  }
+
+  private fun upsertRealtimeConversation(
+    role: VoiceConversationRole,
+    text: String,
+    isFinal: Boolean,
+  ) {
+    val entryId =
+      when (role) {
+        VoiceConversationRole.User -> realtimeUserEntryId
+        VoiceConversationRole.Assistant -> realtimeAssistantEntryId
+      }
+    val resolvedEntryId =
+      if (entryId == null) {
+        appendConversation(role = role, text = text, isStreaming = !isFinal)
+      } else {
+        updateConversationEntry(id = entryId, text = text, isStreaming = !isFinal)
+        entryId
+      }
+    when (role) {
+      VoiceConversationRole.User -> realtimeUserEntryId = if (isFinal) null else resolvedEntryId
+      VoiceConversationRole.Assistant -> realtimeAssistantEntryId = if (isFinal) null else resolvedEntryId
+    }
+  }
+
+  private fun appendConversation(
+    role: VoiceConversationRole,
+    text: String,
+    isStreaming: Boolean,
+  ): String {
+    val id = UUID.randomUUID().toString()
+    _conversation.value =
+      (_conversation.value + VoiceConversationEntry(id = id, role = role, text = text, isStreaming = isStreaming))
+        .takeLast(maxConversationEntries)
+    return id
+  }
+
+  private fun updateConversationEntry(
+    id: String,
+    text: String,
+    isStreaming: Boolean,
+  ) {
+    val current = _conversation.value
+    val targetIndex =
+      when {
+        current.isEmpty() -> -1
+        current[current.lastIndex].id == id -> current.lastIndex
+        else -> current.indexOfFirst { it.id == id }
+      }
+    if (targetIndex < 0) return
+    val entry = current[targetIndex]
+    if (entry.text == text && entry.isStreaming == isStreaming) return
+    val updated = current.toMutableList()
+    updated[targetIndex] = entry.copy(text = text, isStreaming = isStreaming)
+    _conversation.value = updated
   }
 
   private fun startListeningInternal(markListening: Boolean) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -1086,8 +1086,8 @@ class TalkModeManager internal constructor(
         putExtra(RecognizerIntent.EXTRA_CALLING_PACKAGE, context.packageName)
         // Use cloud recognition — it handles natural speech and pauses better
         // than on-device which cuts off aggressively after short silences.
-        putExtra(RecognizerIntent.EXTRA_SPEECH_INPUT_COMPLETE_SILENCE_LENGTH_MILLIS, 2500L)
-        putExtra(RecognizerIntent.EXTRA_SPEECH_INPUT_POSSIBLY_COMPLETE_SILENCE_LENGTH_MILLIS, 1800L)
+        putExtra(RecognizerIntent.EXTRA_SPEECH_INPUT_COMPLETE_SILENCE_LENGTH_MILLIS, 2500)
+        putExtra(RecognizerIntent.EXTRA_SPEECH_INPUT_POSSIBLY_COMPLETE_SILENCE_LENGTH_MILLIS, 1800)
       }
 
     if (markListening) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -98,6 +98,10 @@ class TalkModeManager internal constructor(
     private const val tag = "TalkMode"
     private const val realtimeSampleRateHz = 24_000
     private const val realtimeAudioFrameMs = 100
+    private const val realtimeSpeechStartAverageAmplitude = 800
+    private const val realtimeSpeechContinueAverageAmplitude = 800
+    private const val realtimeSpeechStartFrameCount = 3
+    private const val realtimeSpeechHangoverMs = 700L
     private const val listenWatchdogMs = 12_000L
     private const val chatFinalWaitWithSubscribeMs = 45_000L
     private const val chatFinalWaitWithoutSubscribeMs = 6_000L
@@ -161,7 +165,9 @@ class TalkModeManager internal constructor(
   private val realtimePlaybackLock = Any()
   private var realtimeAudioTrack: AudioTrack? = null
   private var realtimePlaybackIdleJob: Job? = null
-  private var realtimePlaybackEndsAtMs = 0L
+  @Volatile private var realtimePlaybackEndsAtMs = 0L
+  @Volatile private var realtimeSpeechActiveUntilMs = 0L
+  private var realtimeSpeechCandidateFrames = 0
 
   @Volatile private var realtimeOutputSuppressed = false
 
@@ -635,6 +641,7 @@ class TalkModeManager internal constructor(
 
     realtimeSessionId = sessionId
     realtimeOutputSuppressed = false
+    resetRealtimeSpeechGate()
     _isListening.value = true
     _statusText.value = "Listening"
     startRealtimeCapture(sessionId)
@@ -671,6 +678,7 @@ class TalkModeManager internal constructor(
       scope.launch(Dispatchers.IO) {
         for (frame in audioFrames) {
           if (realtimeSessionId != sessionId) continue
+          if (isRealtimePlaybackActive()) continue
           val audioBase64 = Base64.encodeToString(frame, Base64.NO_WRAP)
           val params =
             buildJsonObject {
@@ -726,6 +734,7 @@ class TalkModeManager internal constructor(
           while (coroutineContext.isActive && _isEnabled.value && realtimeSessionId == sessionId) {
             val read = audioRecord.read(buffer, 0, buffer.size)
             if (read <= 0) continue
+            if (!shouldAppendRealtimeCapturedFrame(buffer, read)) continue
             audioFrames.trySend(buffer.copyOf(read))
           }
         } catch (err: Throwable) {
@@ -743,6 +752,62 @@ class TalkModeManager internal constructor(
           }
         }
       }
+  }
+
+  private fun shouldAppendRealtimeCapturedFrame(
+    frame: ByteArray,
+    length: Int = frame.size,
+  ): Boolean {
+    if (isRealtimePlaybackActive()) {
+      resetRealtimeSpeechGate()
+      return false
+    }
+    val now = SystemClock.elapsedRealtime()
+    val average = pcm16AverageAmplitude(frame, length)
+    if (now < realtimeSpeechActiveUntilMs) {
+      if (average >= realtimeSpeechContinueAverageAmplitude) {
+        realtimeSpeechActiveUntilMs = now + realtimeSpeechHangoverMs
+      }
+      return true
+    }
+    if (average >= realtimeSpeechStartAverageAmplitude) {
+      realtimeSpeechCandidateFrames += 1
+      if (realtimeSpeechCandidateFrames >= realtimeSpeechStartFrameCount) {
+        realtimeSpeechActiveUntilMs = now + realtimeSpeechHangoverMs
+        return true
+      }
+      return false
+    }
+    realtimeSpeechCandidateFrames = 0
+    return false
+  }
+
+  private fun isRealtimePlaybackActive(): Boolean =
+    _isSpeaking.value || SystemClock.elapsedRealtime() < realtimePlaybackEndsAtMs
+
+  private fun resetRealtimeSpeechGate() {
+    realtimeSpeechActiveUntilMs = 0L
+    realtimeSpeechCandidateFrames = 0
+  }
+
+  private fun pcm16AverageAmplitude(
+    frame: ByteArray,
+    length: Int,
+  ): Int {
+    var total = 0L
+    var count = 0
+    var index = 0
+    val limit = length - (length % 2)
+    while (index < limit) {
+      val sample =
+        (frame[index].toInt() and 0xff) or
+          (frame[index + 1].toInt() shl 8)
+      val amplitude = kotlin.math.abs(sample.toShort().toInt())
+      total += amplitude
+      count += 1
+      index += 2
+    }
+    return if (count == 0) 0 else (total / count).toInt()
   }
 
   private fun handleRealtimeTalkEvent(payloadJson: String?) {

--- a/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/voice/TalkModeManager.kt
@@ -31,6 +31,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -70,6 +72,16 @@ data class TalkPttStopPayload(
     }.toString()
 }
 
+internal data class RealtimeToolRun(
+  val callId: String,
+  val relaySessionId: String,
+)
+
+private data class RealtimeToolCompletion(
+  val state: String,
+  val messageEl: JsonElement?,
+)
+
 class TalkModeManager internal constructor(
   private val context: Context,
   private val scope: CoroutineScope,
@@ -78,6 +90,7 @@ class TalkModeManager internal constructor(
   private val isConnected: () -> Boolean,
   private val onBeforeSpeak: suspend () -> Unit = {},
   private val onAfterSpeak: suspend () -> Unit = {},
+  private val onStoppedByRelay: () -> Unit = {},
   private val talkSpeakClient: TalkSpeechSynthesizing = TalkSpeakClient(session = session),
   private val talkAudioPlayer: TalkAudioPlaying = TalkAudioPlayer(context),
 ) {
@@ -136,11 +149,20 @@ class TalkModeManager internal constructor(
   private val completedRunTexts = LinkedHashMap<String, String>()
   private var chatSubscribedSessionKey: String? = null
   private var configLoaded = false
+  private var executionMode = TalkModeExecutionMode.Native
+  private val startGeneration = AtomicLong(0L)
+
   @Volatile private var realtimeSessionId: String? = null
   private var realtimeCaptureJob: Job? = null
-  private val realtimeToolRuns = LinkedHashMap<String, String>()
+  private var realtimeAppendJob: Job? = null
+  private val realtimeToolRuns = LinkedHashMap<String, RealtimeToolRun>()
+  private val pendingRealtimeToolCalls = LinkedHashSet<String>()
+  private val pendingRealtimeToolCompletions = LinkedHashMap<String, RealtimeToolCompletion>()
   private val realtimePlaybackLock = Any()
   private var realtimeAudioTrack: AudioTrack? = null
+  private var realtimePlaybackIdleJob: Job? = null
+  private var realtimePlaybackEndsAtMs = 0L
+
   @Volatile private var realtimeOutputSuppressed = false
 
   @Volatile private var playbackEnabled = true
@@ -372,12 +394,12 @@ class TalkModeManager internal constructor(
     event: String,
     payloadJson: String?,
   ) {
-    if (ttsOnAllResponses) {
-      Log.d(tag, "gateway event: $event")
-    }
     if (event == "talk.event") {
       handleRealtimeTalkEvent(payloadJson)
       return
+    }
+    if (ttsOnAllResponses) {
+      Log.d(tag, "gateway event: $event")
     }
     if (event == "agent" && ttsOnAllResponses) {
       return
@@ -399,7 +421,12 @@ class TalkModeManager internal constructor(
     val activeSession = mainSessionKey.ifBlank { "main" }
     if (eventSession != null && eventSession != activeSession) return
 
-    maybeCompleteRealtimeToolCall(runId = runId, state = state, messageEl = obj["message"])
+    if (maybeCompleteRealtimeToolCall(runId = runId, state = state, messageEl = obj["message"])) {
+      return
+    }
+    if (holdPendingRealtimeToolCompletion(runId = runId, state = state, messageEl = obj["message"])) {
+      return
+    }
 
     // If this is a response we initiated, handle normally below.
     // Otherwise, if ttsOnAllResponses, finish streaming TTS on terminal events.
@@ -466,18 +493,58 @@ class TalkModeManager internal constructor(
 
   private fun start() {
     if (realtimeSessionId != null || realtimeCaptureJob?.isActive == true) return
+    val generation = startGeneration.incrementAndGet()
     stopRequested = false
     listeningMode = true
-    Log.d(tag, "start realtime")
+    Log.d(tag, "start")
     scope.launch {
       try {
-        startRealtimeRelay()
+        ensureConfigLoaded()
+        if (generation != startGeneration.get() || !_isEnabled.value || stopRequested) return@launch
+        if (executionMode == TalkModeExecutionMode.RealtimeRelay) {
+          startRealtimeRelay(generation)
+        } else {
+          startNativeRecognition(generation)
+        }
       } catch (err: Throwable) {
         if (err is CancellationException) return@launch
         _statusText.value = "Start failed: ${err.message ?: err::class.simpleName}"
-        Log.w(tag, "realtime start failed: ${err.message ?: err::class.simpleName}")
-        stopRealtimeRelay(closeSession = false)
+        Log.w(tag, "start failed: ${err.message ?: err::class.simpleName}")
+        if (executionMode == TalkModeExecutionMode.RealtimeRelay) {
+          stopRealtimeRelay(closeSession = false, preserveStatus = true)
+          disableRealtimeModeAndNotifyOwner()
+        }
       }
+    }
+  }
+
+  private suspend fun startNativeRecognition(generation: Long) {
+    withContext(Dispatchers.Main) {
+      if (generation != startGeneration.get()) return@withContext
+      if (!_isEnabled.value || stopRequested) return@withContext
+      if (_isListening.value) return@withContext
+      Log.d(tag, "start native")
+
+      if (!SpeechRecognizer.isRecognitionAvailable(context)) {
+        _statusText.value = "Speech recognizer unavailable"
+        Log.w(tag, "speech recognizer unavailable")
+        return@withContext
+      }
+
+      val micOk =
+        ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO) ==
+          PackageManager.PERMISSION_GRANTED
+      if (!micOk) {
+        _statusText.value = "Microphone permission required"
+        Log.w(tag, "microphone permission required")
+        return@withContext
+      }
+
+      recognizer?.destroy()
+      recognizer = SpeechRecognizer.createSpeechRecognizer(context).also { it.setRecognitionListener(listener) }
+      startListeningInternal(markListening = true)
+      startSilenceMonitor()
+      Log.d(tag, "listening")
     }
   }
 
@@ -489,6 +556,7 @@ class TalkModeManager internal constructor(
     pttAutoStopEnabled = false
     pttCompletion?.cancel()
     pttCompletion = null
+    startGeneration.incrementAndGet()
     pttTimeoutJob?.cancel()
     pttTimeoutJob = null
     restartJob?.cancel()
@@ -518,10 +586,11 @@ class TalkModeManager internal constructor(
     shutdownTextToSpeech()
   }
 
-  private suspend fun startRealtimeRelay() {
+  private suspend fun startRealtimeRelay(generation: Long) {
     if (!isConnected()) {
       _statusText.value = "Gateway not connected"
       Log.w(tag, "realtime start: gateway not connected")
+      disableRealtimeModeAndNotifyOwner()
       return
     }
 
@@ -531,6 +600,7 @@ class TalkModeManager internal constructor(
     if (!micOk) {
       _statusText.value = "Microphone permission required"
       Log.w(tag, "realtime start: microphone permission required")
+      disableRealtimeModeAndNotifyOwner()
       return
     }
 
@@ -558,6 +628,10 @@ class TalkModeManager internal constructor(
     if (sessionId.isNullOrBlank()) {
       throw IllegalStateException("talk.session.create returned no session id")
     }
+    if (generation != startGeneration.get() || !_isEnabled.value || stopRequested) {
+      closeRealtimeSession(sessionId)
+      throw CancellationException("realtime talk stopped while connecting")
+    }
 
     realtimeSessionId = sessionId
     realtimeOutputSuppressed = false
@@ -567,9 +641,59 @@ class TalkModeManager internal constructor(
     Log.d(tag, "realtime session started relaySessionId=$sessionId")
   }
 
+  private fun disableRealtimeModeAndNotifyOwner() {
+    if (!_isEnabled.value) return
+    _isEnabled.value = false
+    _isListening.value = false
+    onStoppedByRelay()
+  }
+
+  private fun failRealtimeRelay(
+    sessionId: String,
+    message: String,
+  ) {
+    if (realtimeSessionId != sessionId) return
+    _statusText.value = "Talk failed: $message"
+    stopRealtimeRelay(cancelCapture = false, cancelAppend = false, preserveStatus = true)
+    disableRealtimeModeAndNotifyOwner()
+  }
+
   @SuppressLint("MissingPermission")
   private fun startRealtimeCapture(sessionId: String) {
     realtimeCaptureJob?.cancel()
+    realtimeAppendJob?.cancel()
+    val audioFrames =
+      Channel<ByteArray>(
+        capacity = 4,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+      )
+    realtimeAppendJob =
+      scope.launch(Dispatchers.IO) {
+        for (frame in audioFrames) {
+          if (realtimeSessionId != sessionId) continue
+          val audioBase64 = Base64.encodeToString(frame, Base64.NO_WRAP)
+          val params =
+            buildJsonObject {
+              put("sessionId", JsonPrimitive(sessionId))
+              put("audioBase64", JsonPrimitive(audioBase64))
+              put("timestamp", JsonPrimitive(SystemClock.elapsedRealtime()))
+            }
+          try {
+            session.sendRequestFrame(
+              "talk.session.appendAudio",
+              params.toString(),
+              timeoutMs = 8_000,
+            ) { error ->
+              Log.w(tag, "realtime appendAudio failed: ${error.message}")
+              failRealtimeRelay(sessionId, error.message)
+            }
+          } catch (err: Throwable) {
+            if (err is CancellationException) throw err
+            Log.w(tag, "realtime appendAudio failed: ${err.message ?: err::class.simpleName}")
+            failRealtimeRelay(sessionId, err.message ?: err::class.simpleName ?: "request failed")
+          }
+        }
+      }
     realtimeCaptureJob =
       scope.launch(Dispatchers.IO) {
         var audioRecord: AudioRecord? = null
@@ -602,29 +726,14 @@ class TalkModeManager internal constructor(
           while (coroutineContext.isActive && _isEnabled.value && realtimeSessionId == sessionId) {
             val read = audioRecord.read(buffer, 0, buffer.size)
             if (read <= 0) continue
-            val audioBase64 = Base64.encodeToString(buffer.copyOf(read), Base64.NO_WRAP)
-            val params =
-              buildJsonObject {
-                put("sessionId", JsonPrimitive(sessionId))
-                put("audioBase64", JsonPrimitive(audioBase64))
-                put("timestamp", JsonPrimitive(SystemClock.elapsedRealtime()))
-              }
-            try {
-              session.request("talk.session.appendAudio", params.toString(), timeoutMs = 8_000)
-            } catch (err: Throwable) {
-              if (err is CancellationException) throw err
-              Log.w(tag, "realtime appendAudio failed: ${err.message ?: err::class.simpleName}")
-              _statusText.value = "Talk failed: ${err.message ?: err::class.simpleName}"
-              stopRealtimeRelay(cancelCapture = false)
-              return@launch
-            }
+            audioFrames.trySend(buffer.copyOf(read))
           }
         } catch (err: Throwable) {
           if (err is CancellationException) throw err
           Log.w(tag, "realtime capture failed: ${err.message ?: err::class.simpleName}")
-          _statusText.value = "Talk failed: ${err.message ?: err::class.simpleName}"
-          stopRealtimeRelay(cancelCapture = false)
+          failRealtimeRelay(sessionId, err.message ?: err::class.simpleName ?: "capture failed")
         } finally {
+          audioFrames.close()
           audioRecord?.let { record ->
             try {
               record.stop()
@@ -681,7 +790,7 @@ class TalkModeManager internal constructor(
           realtimeOutputSuppressed = false
           _statusText.value = "Thinking…"
         } else if (isFinal && role == "assistant") {
-          _statusText.value = "Listening"
+          scheduleRealtimePlaybackIdle()
         }
       }
       "toolCall" -> {
@@ -705,6 +814,7 @@ class TalkModeManager internal constructor(
         if (_isEnabled.value) {
           _isEnabled.value = false
           _statusText.value = "Off"
+          onStoppedByRelay()
         }
       }
       else -> {
@@ -750,10 +860,35 @@ class TalkModeManager internal constructor(
       _isSpeaking.value = true
       _statusText.value = "Speaking…"
       track.write(bytes, 0, bytes.size)
+      val durationMs = ((bytes.size / 2.0) / realtimeSampleRateHz * 1000.0).toLong()
+      val now = SystemClock.elapsedRealtime()
+      realtimePlaybackEndsAtMs = maxOf(now, realtimePlaybackEndsAtMs) + durationMs
+      scheduleRealtimePlaybackIdle()
     }
   }
 
+  private fun scheduleRealtimePlaybackIdle() {
+    realtimePlaybackIdleJob?.cancel()
+    val delayMs = maxOf(0L, realtimePlaybackEndsAtMs - SystemClock.elapsedRealtime())
+    realtimePlaybackIdleJob =
+      scope.launch {
+        delay(delayMs)
+        val idle =
+          synchronized(realtimePlaybackLock) {
+            val playbackIdle = SystemClock.elapsedRealtime() >= realtimePlaybackEndsAtMs
+            if (playbackIdle) _isSpeaking.value = false
+            playbackIdle
+          }
+        if (idle && _isEnabled.value && realtimeSessionId != null) {
+          _statusText.value = "Listening"
+        }
+      }
+  }
+
   private fun stopRealtimePlayback() {
+    realtimePlaybackIdleJob?.cancel()
+    realtimePlaybackIdleJob = null
+    realtimePlaybackEndsAtMs = 0L
     synchronized(realtimePlaybackLock) {
       realtimeAudioTrack?.let { track ->
         try {
@@ -775,27 +910,43 @@ class TalkModeManager internal constructor(
   private fun stopRealtimeRelay(
     closeSession: Boolean = true,
     cancelCapture: Boolean = true,
+    cancelAppend: Boolean = true,
+    preserveStatus: Boolean = false,
   ) {
+    val status = _statusText.value
     val sessionId = realtimeSessionId
     realtimeSessionId = null
     realtimeOutputSuppressed = false
     if (cancelCapture) {
       realtimeCaptureJob?.cancel()
     }
+    if (cancelAppend) {
+      realtimeAppendJob?.cancel()
+    }
     realtimeCaptureJob = null
+    realtimeAppendJob = null
     realtimeToolRuns.clear()
+    pendingRealtimeToolCalls.clear()
+    pendingRealtimeToolCompletions.clear()
     stopRealtimePlayback()
+    if (preserveStatus) {
+      _statusText.value = status
+    }
     _isListening.value = false
     if (closeSession && !sessionId.isNullOrBlank()) {
       scope.launch {
-        try {
-          val params = buildJsonObject { put("sessionId", JsonPrimitive(sessionId)) }
-          session.request("talk.session.close", params.toString(), timeoutMs = 5_000)
-        } catch (err: Throwable) {
-          if (err !is CancellationException) {
-            Log.d(tag, "realtime close ignored: ${err.message ?: err::class.simpleName}")
-          }
-        }
+        closeRealtimeSession(sessionId)
+      }
+    }
+  }
+
+  private suspend fun closeRealtimeSession(sessionId: String) {
+    try {
+      val params = buildJsonObject { put("sessionId", JsonPrimitive(sessionId)) }
+      session.request("talk.session.close", params.toString(), timeoutMs = 5_000)
+    } catch (err: Throwable) {
+      if (err !is CancellationException) {
+        Log.d(tag, "realtime close ignored: ${err.message ?: err::class.simpleName}")
       }
     }
   }
@@ -806,6 +957,7 @@ class TalkModeManager internal constructor(
     args: JsonElement?,
   ) {
     val relaySessionId = realtimeSessionId ?: return
+    pendingRealtimeToolCalls.add(callId)
     scope.launch {
       try {
         val params =
@@ -816,60 +968,103 @@ class TalkModeManager internal constructor(
             put("relaySessionId", JsonPrimitive(relaySessionId))
             if (args != null) put("args", args)
           }
-        val response = session.request("talk.client.toolCall", params.toString(), timeoutMs = 15_000)
+        val response =
+          session.request("talk.client.toolCall", params.toString(), timeoutMs = 15_000)
         val runId = parseRunId(response)
         if (!runId.isNullOrBlank()) {
-          realtimeToolRuns[runId] = callId
-          _statusText.value = "Thinking…"
+          if (realtimeSessionId != relaySessionId) return@launch
+          realtimeToolRuns[runId] =
+            RealtimeToolRun(callId = callId, relaySessionId = relaySessionId)
+          val completion = pendingRealtimeToolCompletions.remove(runId)
+          if (completion != null) {
+            maybeCompleteRealtimeToolCall(
+              runId = runId,
+              state = completion.state,
+              messageEl = completion.messageEl,
+            )
+          } else {
+            _statusText.value = "Thinking…"
+          }
         } else {
-          submitRealtimeToolError(callId, "tool call returned no run id")
+          submitRealtimeToolError(callId, "tool call returned no run id", relaySessionId)
         }
       } catch (err: Throwable) {
         if (err is CancellationException) throw err
         Log.w(tag, "realtime toolCall failed: ${err.message ?: err::class.simpleName}")
-        submitRealtimeToolError(callId, err.message ?: "tool call failed")
+        submitRealtimeToolError(callId, err.message ?: "tool call failed", relaySessionId)
+      } finally {
+        pendingRealtimeToolCalls.remove(callId)
       }
     }
+  }
+
+  private fun holdPendingRealtimeToolCompletion(
+    runId: String,
+    state: String,
+    messageEl: JsonElement?,
+  ): Boolean {
+    if (realtimeSessionId == null || pendingRealtimeToolCalls.isEmpty()) return false
+    if (state != "final" && state != "aborted" && state != "error") return false
+    pendingRealtimeToolCompletions[runId] =
+      RealtimeToolCompletion(state = state, messageEl = messageEl)
+    return true
   }
 
   private fun maybeCompleteRealtimeToolCall(
     runId: String,
     state: String,
     messageEl: JsonElement?,
-  ) {
-    val callId = realtimeToolRuns[runId] ?: return
+  ): Boolean {
+    val toolRun = realtimeToolRuns[runId] ?: return false
+    if (toolRun.relaySessionId != realtimeSessionId) {
+      realtimeToolRuns.remove(runId)
+      return true
+    }
     when (state) {
       "final" -> {
         realtimeToolRuns.remove(runId)
         val text = extractTextFromChatEventMessage(messageEl).orEmpty()
         scope.launch {
-          submitRealtimeToolResult(callId, buildJsonObject { put("text", JsonPrimitive(text)) })
+          submitRealtimeToolResult(
+            callId = toolRun.callId,
+            result = buildJsonObject { put("text", JsonPrimitive(text)) },
+            sessionId = toolRun.relaySessionId,
+          )
         }
+        return true
       }
       "aborted", "error" -> {
         realtimeToolRuns.remove(runId)
         scope.launch {
-          submitRealtimeToolError(callId, state)
+          submitRealtimeToolError(toolRun.callId, state, toolRun.relaySessionId)
         }
+        return true
       }
     }
+    return false
   }
 
   private suspend fun submitRealtimeToolError(
     callId: String,
     message: String,
+    sessionId: String? = realtimeSessionId,
   ) {
-    submitRealtimeToolResult(callId, buildJsonObject { put("error", JsonPrimitive(message)) })
+    submitRealtimeToolResult(
+      callId = callId,
+      result = buildJsonObject { put("error", JsonPrimitive(message)) },
+      sessionId = sessionId,
+    )
   }
 
   private suspend fun submitRealtimeToolResult(
     callId: String,
     result: JsonObject,
+    sessionId: String? = realtimeSessionId,
   ) {
-    val sessionId = realtimeSessionId ?: return
+    val activeSessionId = sessionId ?: return
     val params =
       buildJsonObject {
-        put("sessionId", JsonPrimitive(sessionId))
+        put("sessionId", JsonPrimitive(activeSessionId))
         put("callId", JsonPrimitive(callId))
         put("result", result)
       }
@@ -1635,9 +1830,11 @@ class TalkModeManager internal constructor(
       val parsed = TalkModeGatewayConfigParser.parse(root?.get("config").asObjectOrNull())
       silenceWindowMs = parsed.silenceTimeoutMs
       parsed.interruptOnSpeech?.let { interruptOnSpeech = it }
+      executionMode = parsed.executionMode
       configLoaded = true
     } catch (_: Throwable) {
       silenceWindowMs = TalkDefaults.defaultSilenceTimeoutMs
+      executionMode = TalkModeExecutionMode.Native
       configLoaded = false
     }
   }

--- a/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/GatewayBootstrapAuthTest.kt
@@ -65,7 +65,7 @@ class GatewayBootstrapAuthTest {
         storedOperatorToken = "stored-token",
       ),
     )
-    assertFalse(
+    assertTrue(
       shouldConnectOperatorSession(
         NodeRuntime.GatewayConnectAuth(token = null, bootstrapToken = "", password = null),
         storedOperatorToken = null,
@@ -93,6 +93,17 @@ class GatewayBootstrapAuthTest {
       )
 
     assertNull(resolved)
+  }
+
+  @Test
+  fun resolveOperatorSessionConnectAuthUsesNoAuthWhenGatewayHasNoAuth() {
+    val resolved =
+      resolveOperatorSessionConnectAuth(
+        auth = NodeRuntime.GatewayConnectAuth(token = null, bootstrapToken = null, password = null),
+        storedOperatorToken = null,
+      )
+
+    assertEquals(NodeRuntime.GatewayConnectAuth(token = null, bootstrapToken = null, password = null), resolved)
   }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/MicCaptureManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/MicCaptureManagerTest.kt
@@ -1,0 +1,258 @@
+package ai.openclaw.app.voice
+
+import android.Manifest
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34])
+class MicCaptureManagerTest {
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun transcriptionFinalQueuesGatewayMessage() =
+    runTest {
+      val sentMessages = mutableListOf<String>()
+      val manager =
+        createManager(
+          scope = this,
+          sendToGateway = { message, onRunIdKnown ->
+            sentMessages += message
+            onRunIdKnown("run-1")
+            null
+          },
+        )
+
+      setPrivateField(manager, "transcriptionSessionId", "transcription-1")
+      manager.onGatewayConnectionChanged(true)
+      manager.handleGatewayEvent(
+        "talk.event",
+        """{"transcriptionSessionId":"transcription-1","type":"partial","text":"hello"}""",
+      )
+      manager.handleGatewayEvent(
+        "talk.event",
+        """{"transcriptionSessionId":"transcription-1","type":"transcript","text":"hello world","final":true}""",
+      )
+      runCurrent()
+      manager.handleGatewayEvent("chat", chatFinalPayload(runId = "run-1", text = "reply"))
+      advanceUntilIdle()
+
+      assertNull(manager.liveTranscript.value)
+      assertEquals(listOf("hello world"), sentMessages)
+      val conversation = manager.conversation.value.first()
+      assertEquals(VoiceConversationRole.User, conversation.role)
+      assertEquals("hello world", conversation.text)
+    }
+
+  @Test
+  fun transcriptionErrorDisablesMic() {
+    val manager = createManager()
+
+    setPrivateField(manager, "transcriptionSessionId", "transcription-1")
+    manager.handleGatewayEvent(
+      "talk.event",
+      """{"transcriptionSessionId":"transcription-1","type":"error","message":"provider unavailable"}""",
+    )
+
+    assertEquals(false, manager.micEnabled.value)
+    assertEquals("Transcription failed: provider unavailable", manager.statusText.value)
+  }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun punctuationOnlyTranscriptDoesNotSendTurn() =
+    runTest {
+      val sentMessages = mutableListOf<String>()
+      val manager =
+        createManager(
+          scope = this,
+          sendToGateway = { message, onRunIdKnown ->
+            sentMessages += message
+            onRunIdKnown("run-1")
+            "run-1"
+          },
+        )
+
+      setPrivateField(manager, "transcriptionSessionId", "transcription-1")
+      manager.onGatewayConnectionChanged(true)
+      manager.handleGatewayEvent(
+        "talk.event",
+        """{"transcriptionSessionId":"transcription-1","type":"transcript","text":".","final":true}""",
+      )
+      advanceUntilIdle()
+
+      assertEquals(emptyList<String>(), sentMessages)
+      assertEquals(emptyList<VoiceConversationEntry>(), manager.conversation.value)
+    }
+
+  @Test
+  fun pcm16FramesAreEncodedAsPcmuFrames() {
+    val manager = createManager()
+    val method = manager.javaClass.getDeclaredMethod("pcm16ToPcmu", ByteArray::class.java)
+    method.isAccessible = true
+
+    val encoded = method.invoke(manager, byteArrayOf(0, 0, 0, 0)) as ByteArray
+
+    assertEquals(2, encoded.size)
+    assertEquals(0xff.toByte(), encoded[0])
+    assertEquals(0xff.toByte(), encoded[1])
+  }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun disablingMicDuringSessionCreateClosesReturnedSession() =
+    runTest {
+      val createdSession = CompletableDeferred<String>()
+      val closedSessions = mutableListOf<String>()
+      val manager =
+        createManager(
+          scope = this,
+          createTranscriptionSession = { createdSession.await() },
+          closeTranscriptionSession = { sessionId -> closedSessions += sessionId },
+        )
+
+      manager.onGatewayConnectionChanged(true)
+      manager.setMicEnabled(true)
+      manager.setMicEnabled(false)
+      createdSession.complete("transcription-1")
+      advanceUntilIdle()
+
+      assertEquals(listOf("transcription-1"), closedSessions)
+      assertEquals(false, manager.isListening.value)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun disablingMicKeepsSessionOpenForFinalTranscript() =
+    runTest {
+      val manager = createManager(scope = this)
+
+      setPrivateMutableStateFlowValue(manager, "_micEnabled", true)
+      setPrivateField(manager, "transcriptionSessionId", "transcription-1")
+      manager.setMicEnabled(false)
+      manager.handleGatewayEvent(
+        "talk.event",
+        """{"transcriptionSessionId":"transcription-1","type":"transcript","text":"testing testing 1 2 3","final":true}""",
+      )
+      runCurrent()
+
+      assertEquals("testing testing 1 2 3", manager.conversation.value.single().text)
+      assertEquals("transcription-1", privateField<String?>(manager, "transcriptionSessionId"))
+      privateField<Job?>(manager, "transcriptionDrainJob")?.cancel()
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun reconnectRestartsAfterPendingCreateCancellation() =
+    runTest {
+      val firstCreate = CompletableDeferred<String>()
+      val secondCreate = CompletableDeferred<String>()
+      var createCalls = 0
+      val manager =
+        createManager(
+          scope = this,
+          createTranscriptionSession = {
+            createCalls += 1
+            if (createCalls == 1) firstCreate.await() else secondCreate.await()
+          },
+        )
+
+      manager.onGatewayConnectionChanged(true)
+      manager.setMicEnabled(true)
+      runCurrent()
+      manager.onGatewayConnectionChanged(false)
+      manager.onGatewayConnectionChanged(true)
+      firstCreate.completeExceptionally(CancellationException("connection closed"))
+      runCurrent()
+
+      assertEquals(2, createCalls)
+      assertEquals(true, manager.micEnabled.value)
+      manager.setMicEnabled(false)
+      secondCreate.completeExceptionally(CancellationException("test complete"))
+      runCurrent()
+    }
+
+  private fun createManager(
+    scope: CoroutineScope = CoroutineScope(Dispatchers.Unconfined),
+    createTranscriptionSession: suspend () -> String = { "transcription-1" },
+    closeTranscriptionSession: suspend (String) -> Unit = { _ -> },
+    sendToGateway: suspend (String, (String) -> Unit) -> String? = { _, onRunIdKnown ->
+      onRunIdKnown("run-1")
+      "run-1"
+    },
+  ): MicCaptureManager =
+    MicCaptureManager(
+      context =
+        RuntimeEnvironment.getApplication().also { app ->
+          shadowOf(app).grantPermissions(Manifest.permission.RECORD_AUDIO)
+        },
+      scope = scope,
+      createTranscriptionSession = createTranscriptionSession,
+      appendTranscriptionAudio = { _, _, _ -> },
+      closeTranscriptionSession = closeTranscriptionSession,
+      sendToGateway = sendToGateway,
+    )
+
+  private fun setPrivateField(
+    target: Any,
+    name: String,
+    value: Any?,
+  ) {
+    val field = target.javaClass.getDeclaredField(name)
+    field.isAccessible = true
+    field.set(target, value)
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  private fun setPrivateMutableStateFlowValue(
+    target: Any,
+    name: String,
+    value: Boolean,
+  ) {
+    val field = target.javaClass.getDeclaredField(name)
+    field.isAccessible = true
+    (field.get(target) as MutableStateFlow<Boolean>).value = value
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  private fun <T> privateField(
+    target: Any,
+    name: String,
+  ): T {
+    val field = target.javaClass.getDeclaredField(name)
+    field.isAccessible = true
+    return field.get(target) as T
+  }
+
+  private fun chatFinalPayload(
+    runId: String,
+    text: String,
+  ): String =
+    """
+    {
+      "runId": "$runId",
+      "state": "final",
+      "message": {
+        "role": "assistant",
+        "content": [
+          { "type": "text", "text": "$text" }
+        ]
+      }
+    }
+    """.trimIndent()
+}

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeConfigParsingTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeConfigParsingTest.kt
@@ -62,4 +62,37 @@ class TalkModeConfigParsingTest {
       TalkModeGatewayConfigParser.resolvedSilenceTimeoutMs(talk),
     )
   }
+
+  @Test
+  fun defaultsToNativeTalkMode() {
+    val talk =
+      buildJsonObject {
+        put("realtime", buildJsonObject { put("transport", "webrtc") })
+      }
+
+    assertEquals(
+      TalkModeExecutionMode.Native,
+      TalkModeGatewayConfigParser.resolvedExecutionMode(talk),
+    )
+  }
+
+  @Test
+  fun usesRealtimeRelayWhenGatewayRelayIsConfigured() {
+    val talk =
+      buildJsonObject {
+        put(
+          "realtime",
+          buildJsonObject {
+            put("mode", "realtime")
+            put("transport", "gateway-relay")
+            put("brain", "agent-consult")
+          },
+        )
+      }
+
+    assertEquals(
+      TalkModeExecutionMode.RealtimeRelay,
+      TalkModeGatewayConfigParser.resolvedExecutionMode(talk),
+    )
+  }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -111,6 +111,34 @@ class TalkModeManagerTest {
   }
 
   @Test
+  fun realtimeTranscriptsPopulateVoiceConversation() {
+    val manager = createManager()
+
+    setPrivateField(manager, "realtimeSessionId", "relay-1")
+
+    manager.handleGatewayEvent("talk.event", realtimeTranscriptPayload(role = "user", text = "hello"))
+    manager.handleGatewayEvent("talk.event", realtimeTranscriptPayload(role = "user", text = "hello world", final = true))
+    manager.handleGatewayEvent("talk.event", realtimeTranscriptPayload(role = "assistant", text = "hi"))
+    manager.handleGatewayEvent("talk.event", realtimeTranscriptPayload(role = "assistant", text = "hi there", final = true))
+
+    assertEquals(
+      listOf(
+        VoiceConversationEntry(
+          id = manager.conversation.value[0].id,
+          role = VoiceConversationRole.User,
+          text = "hello world",
+        ),
+        VoiceConversationEntry(
+          id = manager.conversation.value[1].id,
+          role = VoiceConversationRole.Assistant,
+          text = "hi there",
+        ),
+      ),
+      manager.conversation.value,
+    )
+  }
+
+  @Test
   @OptIn(ExperimentalCoroutinesApi::class)
   fun realtimeStartWithoutGatewayTurnsTalkOff() =
     runTest {
@@ -285,6 +313,21 @@ class TalkModeManagerTest {
           { "type": "text", "text": "$text" }
         ]
       }
+    }
+    """.trimIndent()
+
+  private fun realtimeTranscriptPayload(
+    role: String,
+    text: String,
+    final: Boolean = false,
+  ): String =
+    """
+    {
+      "relaySessionId": "relay-1",
+      "type": "transcript",
+      "role": "$role",
+      "text": "$text",
+      "final": $final
     }
     """.trimIndent()
 }

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -7,9 +7,11 @@ import ai.openclaw.app.gateway.GatewaySession
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -19,6 +21,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 
 @RunWith(RobolectricTestRunner::class)
@@ -92,6 +95,59 @@ class TalkModeManagerTest {
   }
 
   @Test
+  fun realtimeToolFinalDoesNotUseAllResponseTts() {
+    val manager = createManager()
+
+    manager.ttsOnAllResponses = true
+    setPrivateField(manager, "realtimeSessionId", "relay-1")
+    realtimeToolRuns(manager)["run-tool"] =
+      RealtimeToolRun(callId = "call-1", relaySessionId = "relay-1")
+
+    manager.handleGatewayEvent("chat", chatFinalPayload(runId = "run-tool", text = "tool result"))
+
+    assertEquals(0L, playbackGeneration(manager).get())
+    assertTrue(realtimeToolRuns(manager).isEmpty())
+  }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun realtimeStartWithoutGatewayTurnsTalkOff() =
+    runTest {
+      val stoppedByRelay = AtomicBoolean(false)
+      val manager =
+        createManager(
+          scope = this,
+          isConnected = { false },
+          onStoppedByRelay = { stoppedByRelay.set(true) },
+        )
+
+      setPrivateField(manager, "executionMode", TalkModeExecutionMode.RealtimeRelay)
+      setPrivateField(manager, "configLoaded", true)
+      manager.setEnabled(true)
+      advanceUntilIdle()
+
+      assertFalse(manager.isEnabled.value)
+      assertFalse(manager.isListening.value)
+      assertEquals("Gateway not connected", manager.statusText.value)
+      assertTrue(stoppedByRelay.get())
+    }
+
+  @Test
+  fun staleRealtimeToolFinalDoesNotUseAllResponseTts() {
+    val manager = createManager()
+
+    manager.ttsOnAllResponses = true
+    setPrivateField(manager, "realtimeSessionId", "relay-2")
+    realtimeToolRuns(manager)["run-tool"] =
+      RealtimeToolRun(callId = "call-1", relaySessionId = "relay-1")
+
+    manager.handleGatewayEvent("chat", chatFinalPayload(runId = "run-tool", text = "stale result"))
+
+    assertEquals(0L, playbackGeneration(manager).get())
+    assertTrue(realtimeToolRuns(manager).isEmpty())
+  }
+
+  @Test
   fun textReadyDoesNotEnterSpeakingUntilAudioPlaybackStarts() =
     runTest {
       val talkSpeakClient = FakeTalkSpeechSynthesizer()
@@ -128,6 +184,9 @@ class TalkModeManagerTest {
   private fun createManager(
     talkSpeakClient: TalkSpeechSynthesizing = TalkSpeakClient(),
     talkAudioPlayer: TalkAudioPlaying? = null,
+    scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+    isConnected: () -> Boolean = { true },
+    onStoppedByRelay: () -> Unit = {},
   ): TalkModeManager {
     val app = RuntimeEnvironment.getApplication()
     val sessionJob = SupervisorJob()
@@ -142,10 +201,11 @@ class TalkModeManagerTest {
       )
     return TalkModeManager(
       context = app,
-      scope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+      scope = scope,
       session = session,
       supportsChatSubscribe = false,
-      isConnected = { true },
+      isConnected = isConnected,
+      onStoppedByRelay = onStoppedByRelay,
       talkSpeakClient = talkSpeakClient,
       talkAudioPlayer = talkAudioPlayer ?: TalkAudioPlayer(app),
     )
@@ -153,6 +213,10 @@ class TalkModeManagerTest {
 
   @Suppress("UNCHECKED_CAST")
   private fun playbackGeneration(manager: TalkModeManager): AtomicLong = readPrivateField(manager, "playbackGeneration") as AtomicLong
+
+  @Suppress("UNCHECKED_CAST")
+  private fun realtimeToolRuns(manager: TalkModeManager): MutableMap<String, RealtimeToolRun> =
+    readPrivateField(manager, "realtimeToolRuns") as MutableMap<String, RealtimeToolRun>
 
   private fun setPrivateField(
     target: Any,

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -232,10 +232,11 @@ class TalkModeManagerTest {
   }
 
   @Suppress("UNCHECKED_CAST")
-  private fun playbackGeneration(manager: TalkModeManager): AtomicLong = readPrivateField(manager, "playbackGeneration") as AtomicLong
+  private fun playbackGeneration(manager: TalkModeManager) =
+    readPrivateField(manager, "playbackGeneration") as AtomicLong
 
   @Suppress("UNCHECKED_CAST")
-  private fun realtimeToolRuns(manager: TalkModeManager): MutableMap<String, RealtimeToolRun> =
+  private fun realtimeToolRuns(manager: TalkModeManager) =
     readPrivateField(manager, "realtimeToolRuns") as MutableMap<String, RealtimeToolRun>
 
   private fun setPrivateField(
@@ -282,9 +283,7 @@ class TalkModeManagerTest {
     return frame
   }
 
-  private fun pcm16Frame(amplitude: Int): ByteArray {
-    return pcm16Frame(amplitude.toShort())
-  }
+  private fun pcm16Frame(amplitude: Int): ByteArray = pcm16Frame(amplitude.toShort())
 
   private fun chatFinalPayload(
     runId: String,

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -4,6 +4,7 @@ import ai.openclaw.app.gateway.DeviceAuthEntry
 import ai.openclaw.app.gateway.DeviceAuthTokenStore
 import ai.openclaw.app.gateway.DeviceIdentityStore
 import ai.openclaw.app.gateway.GatewaySession
+import android.os.SystemClock
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -181,6 +182,25 @@ class TalkModeManagerTest {
       job.join()
     }
 
+  @Test
+  fun realtimeAudioFramesAreMutedDuringPlaybackAndSilence() {
+    val manager = createManager()
+
+    assertFalse(shouldAppendRealtimeCapturedFrame(manager, pcm16Frame(0)))
+    assertFalse(shouldAppendRealtimeCapturedFrame(manager, pcm16Frame(1_200)))
+    assertFalse(shouldAppendRealtimeCapturedFrame(manager, pcm16Frame(1_200)))
+    assertTrue(shouldAppendRealtimeCapturedFrame(manager, pcm16Frame(1_200)))
+    assertTrue(shouldAppendRealtimeCapturedFrame(manager, pcm16Frame(0)))
+
+    setPrivateField(manager, "realtimePlaybackEndsAtMs", SystemClock.elapsedRealtime() + 1_000)
+
+    assertFalse(shouldAppendRealtimeCapturedFrame(manager, pcm16Frame(1_200)))
+
+    setPrivateField(manager, "realtimePlaybackEndsAtMs", SystemClock.elapsedRealtime() - 1)
+
+    assertFalse(shouldAppendRealtimeCapturedFrame(manager, pcm16Frame(0)))
+  }
+
   private fun createManager(
     talkSpeakClient: TalkSpeechSynthesizing = TalkSpeakClient(),
     talkAudioPlayer: TalkAudioPlaying? = null,
@@ -235,6 +255,35 @@ class TalkModeManagerTest {
     val field = target.javaClass.getDeclaredField(name)
     field.isAccessible = true
     return field.get(target)
+  }
+
+  private fun shouldAppendRealtimeCapturedFrame(
+    manager: TalkModeManager,
+    frame: ByteArray,
+  ): Boolean {
+    val method =
+      manager.javaClass.getDeclaredMethod(
+        "shouldAppendRealtimeCapturedFrame",
+        ByteArray::class.java,
+        Int::class.javaPrimitiveType,
+      )
+    method.isAccessible = true
+    return method.invoke(manager, frame, frame.size) as Boolean
+  }
+
+  private fun pcm16Frame(amplitude: Short): ByteArray {
+    val frame = ByteArray(16)
+    var index = 0
+    while (index < frame.size) {
+      frame[index] = (amplitude.toInt() and 0xff).toByte()
+      frame[index + 1] = ((amplitude.toInt() shr 8) and 0xff).toByte()
+      index += 2
+    }
+    return frame
+  }
+
+  private fun pcm16Frame(amplitude: Int): ByteArray {
+    return pcm16Frame(amplitude.toShort())
   }
 
   private fun chatFinalPayload(

--- a/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/voice/TalkModeManagerTest.kt
@@ -183,22 +183,20 @@ class TalkModeManagerTest {
     }
 
   @Test
-  fun realtimeAudioFramesAreMutedDuringPlaybackAndSilence() {
+  fun realtimeAudioFramesStreamUntilPlaybackStarts() {
     val manager = createManager()
 
-    assertFalse(shouldAppendRealtimeCapturedFrame(manager, pcm16Frame(0)))
-    assertFalse(shouldAppendRealtimeCapturedFrame(manager, pcm16Frame(1_200)))
-    assertFalse(shouldAppendRealtimeCapturedFrame(manager, pcm16Frame(1_200)))
-    assertTrue(shouldAppendRealtimeCapturedFrame(manager, pcm16Frame(1_200)))
-    assertTrue(shouldAppendRealtimeCapturedFrame(manager, pcm16Frame(0)))
+    assertFalse(shouldAppendRealtimeCapturedFrame(manager, 0))
+    assertTrue(shouldAppendRealtimeCapturedFrame(manager, 16))
+    assertTrue(shouldAppendRealtimeCapturedFrame(manager, 4_800))
 
     setPrivateField(manager, "realtimePlaybackEndsAtMs", SystemClock.elapsedRealtime() + 1_000)
 
-    assertFalse(shouldAppendRealtimeCapturedFrame(manager, pcm16Frame(1_200)))
+    assertFalse(shouldAppendRealtimeCapturedFrame(manager, 4_800))
 
     setPrivateField(manager, "realtimePlaybackEndsAtMs", SystemClock.elapsedRealtime() - 1)
 
-    assertFalse(shouldAppendRealtimeCapturedFrame(manager, pcm16Frame(0)))
+    assertTrue(shouldAppendRealtimeCapturedFrame(manager, 4_800))
   }
 
   private fun createManager(
@@ -260,30 +258,16 @@ class TalkModeManagerTest {
 
   private fun shouldAppendRealtimeCapturedFrame(
     manager: TalkModeManager,
-    frame: ByteArray,
+    length: Int,
   ): Boolean {
     val method =
       manager.javaClass.getDeclaredMethod(
         "shouldAppendRealtimeCapturedFrame",
-        ByteArray::class.java,
         Int::class.javaPrimitiveType,
       )
     method.isAccessible = true
-    return method.invoke(manager, frame, frame.size) as Boolean
+    return method.invoke(manager, length) as Boolean
   }
-
-  private fun pcm16Frame(amplitude: Short): ByteArray {
-    val frame = ByteArray(16)
-    var index = 0
-    while (index < frame.size) {
-      frame[index] = (amplitude.toInt() and 0xff).toByte()
-      frame[index + 1] = ((amplitude.toInt() shr 8) and 0xff).toByte()
-      index += 2
-    }
-    return frame
-  }
-
-  private fun pcm16Frame(amplitude: Int): ByteArray = pcm16Frame(amplitude.toShort())
 
   private fun chatFinalPayload(
     runId: String,

--- a/docs/nodes/talk.md
+++ b/docs/nodes/talk.md
@@ -10,6 +10,7 @@ Talk mode has two runtime shapes:
 
 - Native macOS/iOS/Android Talk uses local speech recognition, Gateway chat, and `talk.speak` TTS. Nodes advertise the `talk` capability and declare the `talk.*` commands they support.
 - Browser Talk uses `talk.client.create` for client-owned `webrtc` and `provider-websocket` sessions, or `talk.session.create` for Gateway-owned `gateway-relay` sessions. `managed-room` is reserved for Gateway handoff and walkie-talkie rooms.
+- Android Talk can opt into Gateway-owned realtime relay sessions with `talk.realtime.mode: "realtime"` and `talk.realtime.transport: "gateway-relay"`. Otherwise it stays on native speech recognition, Gateway chat, and `talk.speak`.
 - Transcription-only clients use `talk.session.create({ mode: "transcription", transport: "gateway-relay", brain: "none" })`, then `talk.session.appendAudio`, `talk.session.cancelTurn`, and `talk.session.close` when they need captions or dictation without an assistant voice response.
 
 Native Talk is a continuous voice conversation loop:
@@ -108,6 +109,7 @@ Defaults:
 - `realtime.provider`: selects the active browser/server realtime voice provider. Use `openai` for WebRTC, `google` for provider WebSocket, or a bridge-only provider through Gateway relay.
 - `realtime.providers.<provider>` stores provider-owned realtime config. The browser receives only ephemeral or constrained session credentials, never a standard API key.
 - `realtime.providers.openai.voice`: built-in OpenAI Realtime voice id. Current `gpt-realtime-2` voices are `alloy`, `ash`, `ballad`, `coral`, `echo`, `sage`, `shimmer`, `verse`, `marin`, and `cedar`; `marin` and `cedar` are recommended for best quality.
+- `realtime.transport`: `webrtc` and `provider-websocket` are browser realtime transports. Android uses realtime relay only when this is `gateway-relay`; otherwise Android Talk uses its native STT/TTS loop.
 - `realtime.brain`: `agent-consult` routes realtime tool calls through Gateway policy; `direct-tools` is owner-only compatibility behavior; `none` is for transcription or external orchestration.
 - `realtime.instructions`: appends provider-facing system instructions to OpenClaw's built-in realtime prompt. Use it for voice style and tone; OpenClaw keeps the default `openclaw_agent_consult` guidance.
 - `talk.catalog` exposes each provider's valid modes, transports, brain strategies, realtime audio formats, and capability flags so first-party Talk clients can avoid unsupported combinations.

--- a/docs/platforms/android.md
+++ b/docs/platforms/android.md
@@ -216,7 +216,8 @@ See [Camera node](/nodes/camera) for parameters and CLI helpers.
 
 - Voice tab: Android has two explicit capture modes. **Mic** is a manual Voice-tab session that sends each pause as a chat turn and stops when the app leaves the foreground or the user leaves the Voice tab. **Talk** is continuous Talk Mode and keeps listening until toggled off or the node disconnects.
 - Talk Mode promotes the existing foreground service from `dataSync` to `dataSync|microphone` before capture starts, then demotes it when Talk Mode stops. Android 14+ requires the `FOREGROUND_SERVICE_MICROPHONE` declaration, the `RECORD_AUDIO` runtime grant, and the microphone service type at runtime.
-- Spoken replies use `talk.speak` through the configured gateway Talk provider. Local system TTS is used only when `talk.speak` is unavailable.
+- By default, Android Talk uses native speech recognition, Gateway chat, and `talk.speak` through the configured gateway Talk provider. Local system TTS is used only when `talk.speak` is unavailable.
+- Android Talk uses realtime Gateway relay only when `talk.realtime.mode` is `realtime` and `talk.realtime.transport` is `gateway-relay`.
 - Voice wake remains disabled in the Android UX/runtime.
 - Additional Android command families (availability depends on device + permissions):
   - `device.status`, `device.info`, `device.permissions`, `device.health`

--- a/src/gateway/server-methods/talk.test.ts
+++ b/src/gateway/server-methods/talk.test.ts
@@ -629,7 +629,7 @@ describe("talk.session unified handlers", () => {
       mode: "transcription",
       transport: "gateway-relay",
       transcriptionSessionId: "stt-unified-1",
-      audio: { inputEncoding: "pcm16", inputSampleRateHz: 24000 },
+      audio: { inputEncoding: "g711_ulaw", inputSampleRateHz: 8000 },
       expiresAt: 1_797_986_400,
     });
 
@@ -666,7 +666,6 @@ describe("talk.session unified handlers", () => {
       transport: "gateway-relay",
       brain: "none",
     });
-
     const inputRespond = vi.fn();
     await talkHandlers["talk.session.appendAudio"]({
       req: { type: "req", id: "2", method: "talk.session.appendAudio" },

--- a/src/gateway/talk-realtime-relay.test.ts
+++ b/src/gateway/talk-realtime-relay.test.ts
@@ -229,6 +229,8 @@ describe("talk realtime gateway relay", () => {
       providerConfig: { model: "provider-model" },
       audioFormat: { encoding: "pcm16", sampleRateHz: 24000, channels: 1 },
       instructions: "be brief",
+      autoRespondToAudio: false,
+      interruptResponseOnInputAudio: false,
     });
 
     const readyPayload = findEventPayload(events, (payload) => payload.type === "ready");
@@ -335,6 +337,7 @@ describe("talk realtime gateway relay", () => {
     stopTalkRealtimeRelaySession({ relaySessionId: session.relaySessionId, connId: "conn-1" });
 
     expect(bridge.sendAudio).toHaveBeenCalledWith(Buffer.from("audio-in"));
+    expect(bridge.sendUserMessage).toHaveBeenCalledWith("hello");
     expect(bridge.setMediaTimestamp).toHaveBeenCalledWith(123);
     expect(bridge.submitToolResult).toHaveBeenNthCalledWith(
       1,

--- a/src/gateway/talk-realtime-relay.ts
+++ b/src/gateway/talk-realtime-relay.ts
@@ -177,6 +177,7 @@ export function createTalkRealtimeRelaySession(
     { onEvent: recordTalkObservabilityEvent },
   );
   let relay: RelaySession | undefined;
+  let bridgeSession: RealtimeVoiceBridgeSession | undefined;
   const emit = (event: TalkRealtimeRelayEventPayload, talkEvent?: TalkEventInput) =>
     broadcastToOwner(params.context, params.connId, {
       ...event,
@@ -188,6 +189,8 @@ export function createTalkRealtimeRelaySession(
     providerConfig: params.providerConfig,
     audioFormat: REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
     instructions: params.instructions,
+    autoRespondToAudio: false,
+    interruptResponseOnInputAudio: false,
     tools: params.tools,
     markStrategy: "ack-immediately",
     audioSink: {
@@ -252,6 +255,9 @@ export function createTalkRealtimeRelaySession(
           final,
         },
       );
+      if (role === "user" && final && text.trim()) {
+        bridgeSession?.sendUserMessage(text.trim());
+      }
     },
     onToolCall: (toolCall) => {
       const turnId = relay ? ensureRelayTurn(relay) : undefined;
@@ -295,6 +301,7 @@ export function createTalkRealtimeRelaySession(
       );
     },
   });
+  bridgeSession = bridge;
   relay = {
     id: relaySessionId,
     connId: params.connId,

--- a/src/gateway/talk-transcription-relay.test.ts
+++ b/src/gateway/talk-transcription-relay.test.ts
@@ -113,8 +113,8 @@ describe("talk transcription gateway relay", () => {
       transport: "gateway-relay",
     });
     expectRecordFields(session.audio, "session audio", {
-      inputEncoding: "pcm16",
-      inputSampleRateHz: 24000,
+      inputEncoding: "g711_ulaw",
+      inputSampleRateHz: 8000,
     });
     expectRecordFields(sttRequest, "stt request", {
       providerConfig: { model: "stt-model" },
@@ -198,6 +198,35 @@ describe("talk transcription gateway relay", () => {
       type: "session.closed",
       final: true,
     });
+  });
+
+  it("rejects provider configs that do not match relay audio input", () => {
+    const sttSession = {
+      connect: vi.fn(async () => {}),
+      sendAudio: vi.fn(),
+      close: vi.fn(),
+      isConnected: vi.fn(() => true),
+    };
+    const provider: RealtimeTranscriptionProviderPlugin = {
+      id: "stt-test",
+      label: "STT Test",
+      isConfigured: () => true,
+      createSession: vi.fn(() => sttSession),
+    };
+    const context = {
+      getRuntimeConfig: () => ({}),
+      broadcastToConnIds: vi.fn(),
+    } as never;
+
+    expect(() =>
+      createTalkTranscriptionRelaySession({
+        context,
+        connId: "conn-1",
+        provider,
+        providerConfig: { encoding: "linear16", sampleRate: 16000 },
+      }),
+    ).toThrow("Gateway transcription relay requires g711_ulaw/8000 audio");
+    expect(provider.createSession).not.toHaveBeenCalled();
   });
 
   it("cancels an active transcription turn and closes the provider session", async () => {

--- a/src/gateway/talk-transcription-relay.ts
+++ b/src/gateway/talk-transcription-relay.ts
@@ -15,6 +15,8 @@ const MAX_AUDIO_BASE64_BYTES = 512 * 1024;
 const MAX_TRANSCRIPTION_SESSIONS_PER_CONN = 2;
 const MAX_TRANSCRIPTION_SESSIONS_GLOBAL = 64;
 const TRANSCRIPTION_EVENT = "talk.event";
+const RELAY_INPUT_ENCODING = "g711_ulaw";
+const RELAY_INPUT_SAMPLE_RATE_HZ = 8000;
 
 type TalkTranscriptionRelayEventPayload =
   | { transcriptionSessionId: string; type: "ready" }
@@ -54,13 +56,91 @@ type TalkTranscriptionRelaySessionResult = {
   transport: "gateway-relay";
   transcriptionSessionId: string;
   audio: {
-    inputEncoding: "pcm16";
-    inputSampleRateHz: 24000;
+    inputEncoding: "g711_ulaw";
+    inputSampleRateHz: 8000;
   };
   expiresAt: number;
 };
 
 const transcriptionSessions = new Map<string, TranscriptionRelaySession>();
+
+function normalizeRelayInputEncoding(
+  value: unknown,
+): "g711_ulaw" | "g711_alaw" | "pcm16" | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) {
+    return undefined;
+  }
+  if (
+    normalized === "mulaw" ||
+    normalized === "ulaw" ||
+    normalized === "g711_ulaw" ||
+    normalized === "g711-mulaw" ||
+    normalized === "pcm_mulaw" ||
+    normalized === "audio/pcmu" ||
+    normalized === "ulaw_8000"
+  ) {
+    return "g711_ulaw";
+  }
+  if (
+    normalized === "alaw" ||
+    normalized === "g711_alaw" ||
+    normalized === "g711-alaw" ||
+    normalized === "pcm_alaw"
+  ) {
+    return "g711_alaw";
+  }
+  if (
+    normalized === "pcm" ||
+    normalized === "pcm16" ||
+    normalized === "linear16" ||
+    normalized === "pcm_s16le"
+  ) {
+    return "pcm16";
+  }
+  return undefined;
+}
+
+function readFiniteNumber(value: unknown): number | undefined {
+  const next =
+    typeof value === "number"
+      ? value
+      : typeof value === "string"
+        ? Number.parseFloat(value)
+        : undefined;
+  return Number.isFinite(next) ? next : undefined;
+}
+
+function inferSampleRateFromAudioFormat(value: unknown): number | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const match = value.match(/_(\d+)$/);
+  return match ? readFiniteNumber(match[1]) : undefined;
+}
+
+function assertRelayInputAudioConfig(providerConfig: RealtimeTranscriptionProviderConfig): void {
+  const encodingValue =
+    providerConfig.encoding ?? providerConfig.audioFormat ?? providerConfig.audio_format;
+  const encoding = normalizeRelayInputEncoding(encodingValue);
+  if (encoding && encoding !== RELAY_INPUT_ENCODING) {
+    throw new Error(
+      `Gateway transcription relay requires ${RELAY_INPUT_ENCODING}/${RELAY_INPUT_SAMPLE_RATE_HZ} audio`,
+    );
+  }
+
+  const sampleRate =
+    readFiniteNumber(providerConfig.sampleRate ?? providerConfig.sample_rate) ??
+    inferSampleRateFromAudioFormat(encodingValue);
+  if (sampleRate && sampleRate !== RELAY_INPUT_SAMPLE_RATE_HZ) {
+    throw new Error(
+      `Gateway transcription relay requires ${RELAY_INPUT_ENCODING}/${RELAY_INPUT_SAMPLE_RATE_HZ} audio`,
+    );
+  }
+}
 
 function broadcastToOwner(
   context: GatewayRequestContext,
@@ -137,6 +217,7 @@ export function createTalkTranscriptionRelaySession(
   params: CreateTalkTranscriptionRelaySessionParams,
 ): TalkTranscriptionRelaySessionResult {
   enforceTranscriptionSessionLimits(params.connId);
+  assertRelayInputAudioConfig(params.providerConfig);
   const transcriptionSessionId = randomUUID();
   const expiresAtMs = Date.now() + TRANSCRIPTION_SESSION_TTL_MS;
   const talk = createTalkSessionController(
@@ -262,8 +343,8 @@ export function createTalkTranscriptionRelaySession(
     transport: "gateway-relay",
     transcriptionSessionId,
     audio: {
-      inputEncoding: "pcm16",
-      inputSampleRateHz: 24000,
+      inputEncoding: RELAY_INPUT_ENCODING,
+      inputSampleRateHz: RELAY_INPUT_SAMPLE_RATE_HZ,
     },
     expiresAt: Math.floor(expiresAtMs / 1000),
   };


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: Android Talk Mode still used the legacy SpeechRecognizer -> chat.send -> TTS flow, so it was not using the realtime voice session path that newer surfaces rely on.
- Why it matters: realtime Talk Mode needs the Gateway relay voice session API for low-latency streaming audio and realtime tool-call/result handling.
- What changed: Android Talk Mode now creates realtime `talk.session` Gateway relay sessions, streams mic PCM16 audio through `talk.session.appendAudio`, plays `talk.event` audio deltas with streaming `AudioTrack`, and bridges realtime tool calls through `talk.client.toolCall` plus `talk.session.submitToolResult`.
- What changed now: the Android Voice tab also shows realtime transcript bubbles for what the provider heard and what OpenClaw said, using the same conversation surface as manual mic turns.
- What did NOT change (scope boundary): this PR does not change the Gateway realtime protocol, provider implementations, Android node runtime wiring, or the legacy push-to-talk helper flow.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count. Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

- Behavior or issue addressed: Android realtime Talk Mode used the legacy STT/chat/TTS pipeline instead of a realtime Gateway relay voice session.
- Real environment tested: Android Play debug app installed on connected device `27044b56` against local Gateway `127.0.0.1:18789`, with the OpenAI-backed realtime provider configured through the existing Gateway relay.
- Exact steps or command run after this patch: 
  - `./gradlew :app:testPlayDebugUnitTest --tests ai.openclaw.app.voice.TalkModeManagerTest`
  - `./gradlew :app:installPlayDebug`
  - `adb reverse tcp:18789 tcp:18789`
  - `adb shell am start -n ai.openclaw.app/.MainActivity`
  - In the installed app: Voice tab -> Talk on.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Live Android/runtime proof from the installed APK. Screenshot artifact on the tester machine: `/tmp/openclaw-talk-transcript-ui.png`. The Voice tab displayed provider-heard transcript bubbles (`You: Testing`, `You: Testing, testing, one, two, three.`) and an `OpenClaw` response bubble while Talk Mode was connected. Redacted Gateway log excerpt from realtime session `4f4fcb15`: `16:09:18.627 realtime session started`, Android `AudioRecord` started at `sampleRate 24000`, and no `Talk failed`/capture failure lines were present.
- Observed result after fix: Realtime Talk Mode holds a live Gateway relay session from the deployed Android app, captures mic audio at 24 kHz, displays the provider transcript in the Voice tab, and displays OpenClaw reply text alongside spoken output.
- What was not tested: Bluetooth/audio-route matrix, extended soak, every Android OEM audio stack, and quiet-room false-positive behavior beyond this connected-device probe.
- Before evidence (optional but encouraged): Android Talk Mode previously used SpeechRecognizer/chat.send/TTS and did not use the realtime `talk.session` APIs.

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: Android Talk Mode had not been migrated from the older local speech-recognition/chat/TTS implementation to the newer realtime Gateway relay voice API.
- Missing detection / guardrail: existing Android tests covered the legacy manager behavior but did not assert that Talk Mode used realtime `talk.session` APIs.
- Contributing context (if known): other realtime surfaces had already moved to the realtime voice session architecture.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: Android Talk Mode manager/gateway integration coverage.
- Scenario the test should lock in: enabling Android Talk Mode creates a realtime Gateway relay session, streams microphone audio frames, handles realtime audio events, and submits tool results.
- Why this is the smallest reliable guardrail: the bug was an integration mismatch between the Android manager and Gateway realtime Talk APIs, not just a pure parsing or UI-state issue.
- Existing test that already covers this (if any): none directly; focused existing tests were run to catch regressions in surrounding Android talk/gateway behavior.
- If no new test is added, why not: this patch is a focused migration of the Android manager path and was verified with existing focused tests, build, install, and manual realtime behavior on a real device.

## User-visible / Behavior Changes

Android Talk Mode now uses realtime streaming voice instead of the legacy SpeechRecognizer/chat/TTS flow when Talk Mode is enabled.

## Diagram (if applicable)

```text
Before:
[Android Talk Mode] -> [SpeechRecognizer] -> [chat.send] -> [talk.speak/local TTS]

After:
[Android Talk Mode] -> [talk.session.create gateway-relay]
                   -> [appendAudio PCM16 mic frames]
                   -> [talk.event audio/transcript/toolCall]
                   -> [AudioTrack playback + submitToolResult]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) Yes
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: Android Talk Mode now uses existing authenticated Gateway realtime Talk RPCs instead of legacy chat/TTS RPCs. This uses existing operator-scoped methods and does not add new credentials or server-side permissions.

## Repro + Verification

### Environment

- OS: macOS development host, Android debug app on connected device
- Runtime/container: Android Play debug build
- Model/provider: configured OpenClaw realtime voice provider
- Integration/channel (if any): Android app Talk Mode
- Relevant config (redacted): existing local OpenClaw realtime Talk configuration

### Steps

1. Build the Android Play debug app.
2. Install the APK on a connected Android device.
3. Enable Talk Mode and speak through the Android app.
4. Verify realtime voice responds.

### Expected

- Android Talk Mode uses realtime Gateway relay voice and responds with realtime audio.

### Actual

- Android Talk Mode uses realtime Gateway relay voice and responds with realtime audio.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Focused command output from local verification:

```text
> Task :app:testPlayDebugUnitTest

BUILD SUCCESSFUL in 4s
```

```text
> Task :app:assemblePlayDebug

BUILD SUCCESSFUL in 888ms
```

```text
Performing Streamed Install
Success
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: focused Android unit tests, Play debug APK build, APK install on connected Android device, and manual realtime Talk Mode behavior.
- Edge cases checked: missing microphone permission handling remains guarded before capture starts; realtime session close and playback cleanup are handled on stop/close/error paths.
- What you did **not** verify: broad audio-device routing, extended session soak, and every supported Android device/OEM.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: realtime mic streaming can be sensitive to device audio-stack behavior.
  - Mitigation: use Android `AudioRecord`/PCM16 at the Gateway relay's expected 24 kHz mono format and keep cleanup paths explicit.
- Risk: realtime provider tool calls could stall if the chat run result is not returned.
  - Mitigation: bridge `talk.client.toolCall` chat completions back through `talk.session.submitToolResult` for final/error states.
