### PR TITLE
fix(gateway): add .catch() to SIGTERM/SIGUSR1 signal handlers

### DIFF
--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -1401,6 +1401,91 @@ describe("runGatewayLoop", () => {
       await expect(exited).resolves.toBe(0);
     });
   });
+
+  it("catches SIGTERM handler errors, logs them, and falls back to stop (#83131)", async () => {
+    vi.clearAllMocks();
+    consumeGatewayRestartIntentPayloadSync.mockImplementationOnce(() => {
+      throw new Error("dynamic import failed");
+    });
+
+    await withIsolatedSignals(async ({ captureSignal }) => {
+      const { close, runtime, exited } = await createSignaledLoopHarness();
+      const sigterm = captureSignal("SIGTERM");
+
+      sigterm();
+
+      await expect(exited).resolves.toBe(0);
+      expect(gatewayLog.error).toHaveBeenCalledWith(
+        "failed to handle SIGTERM: Error: dynamic import failed",
+      );
+      expect(close).toHaveBeenCalledWith({
+        reason: "gateway stopping",
+        restartExpectedMs: null,
+      });
+      expect(runtime.exit).toHaveBeenCalledWith(0);
+    });
+  });
+
+  it("catches SIGUSR1 handler errors even when token cleanup throws (#83131)", async () => {
+    vi.clearAllMocks();
+    consumeGatewayRestartIntentPayloadSync.mockImplementationOnce(() => {
+      throw new Error("lifecycle module corrupted");
+    });
+    markGatewaySigusr1RestartHandled.mockImplementationOnce(() => {
+      throw new Error("recovery import also failed");
+    });
+
+    await withIsolatedSignals(async ({ captureSignal }) => {
+      const { close, start, exited } = await createSignaledLoopHarness();
+      const sigusr1 = captureSignal("SIGUSR1");
+      const sigterm = captureSignal("SIGTERM");
+
+      sigusr1();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(gatewayLog.error).toHaveBeenCalledWith(
+        "SIGUSR1 handler failed: lifecycle module corrupted",
+      );
+      expect(markGatewaySigusr1RestartHandled).toHaveBeenCalled();
+      expect(close).not.toHaveBeenCalled();
+      expect(start).toHaveBeenCalledTimes(1);
+
+      sigterm();
+      await expect(exited).resolves.toBe(0);
+    });
+  });
+
+  it("catches SIGUSR1 handler errors, clears restart token, and does not crash (#83131)", async () => {
+    vi.clearAllMocks();
+    consumeGatewayRestartIntentPayloadSync.mockImplementationOnce(() => {
+      throw new Error("sigusr1 lifecycle import failed");
+    });
+
+    await withIsolatedSignals(async ({ captureSignal }) => {
+      const { close, start, exited } = await createSignaledLoopHarness();
+      const sigusr1 = captureSignal("SIGUSR1");
+      const sigterm = captureSignal("SIGTERM");
+
+      sigusr1();
+      // The catch handler clears the restart token from the eagerly-loaded
+      // lifecycle runtime, so wait for the async signal body to reject.
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(gatewayLog.error).toHaveBeenCalledWith(
+        "SIGUSR1 handler failed: sigusr1 lifecycle import failed",
+      );
+      // Restart token must be cleared so future SIGUSR1 restarts are not
+      // permanently coalesced as "already in-flight".
+      expect(markGatewaySigusr1RestartHandled).toHaveBeenCalled();
+      expect(close).not.toHaveBeenCalled();
+      expect(start).toHaveBeenCalledTimes(1);
+
+      sigterm();
+      await expect(exited).resolves.toBe(0);
+    });
+  });
 });
 
 describe("gateway discover routing helpers", () => {

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -716,7 +716,10 @@ export async function runGatewayLoop(params: {
         restartIntent?.reason,
         restartIntent ?? undefined,
       );
-    })();
+    })().catch((err: unknown) => {
+      gatewayLog.error(`failed to handle SIGTERM: ${String(err)}`);
+      request("stop", "SIGTERM");
+    });
   };
   const onSigint = () => {
     gatewayLog.info("signal SIGINT received");


### PR DESCRIPTION
## Summary

- Fixes the gateway run-loop SIGTERM async handler so lifecycle-runtime failures are caught, logged, and fall back to the normal stop path.
- Keeps the existing main-branch SIGUSR1 recovery behavior: SIGUSR1 handler failures are logged and the already-eager lifecycle runtime is used to clear the restart token.
- Rebased the PR onto current `origin/main`; the original conflicting SIGUSR1 fail-closed implementation was replaced by main's cleaner eager-runtime recovery path.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #83116

## Real behavior proof

Behavior addressed: SIGTERM used a discarded async IIFE in the gateway run-loop. If lifecycle-runtime loading or restart-intent consumption rejected inside that handler, the gateway never called the stop/restart request path. This patch catches that rejection, logs it, and falls back to `request("stop", "SIGTERM")`.

Real environment tested: Local OpenClaw source checkout on macOS, Node 24 toolchain, current branch `fix/signal-handler-catch` rebased onto `origin/main` at `372c906c88`.

Exact steps or command run after this patch:
Step 1 -- build OpenClaw from the patched source. Step 2 -- rename the lazily-loaded lifecycle runtime module to force an import failure. Step 3 -- start the gateway and let `timeout` send SIGTERM after 12 seconds. Step 4 -- observe the catch handler fire in the gateway log.
```bash
cd /tmp/fix-83131
CI=true pnpm install --frozen-lockfile && pnpm build
mv dist/cli/gateway-lifecycle.runtime.js dist/cli/gateway-lifecycle.runtime.js.bak
timeout 12 node openclaw.mjs gateway
mv dist/cli/gateway-lifecycle.runtime.js.bak dist/cli/gateway-lifecycle.runtime.js
```

Evidence after fix: terminal output copied below.

**Fault injection proof: SIGTERM catch handler fires in real gateway**

```console
2026-05-22T11:52:30.782-07:00 [gateway] ready
2026-05-22T11:52:42.941-07:00 [gateway] signal SIGTERM received
2026-05-22T11:52:42.942-07:00 [gateway] failed to handle SIGTERM: Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/tmp/fix-83131/dist/cli/gateway-lifecycle.runtime.js' imported from /tmp/fix-83131/dist/run-FhSmksEV.js
2026-05-22T11:52:42.943-07:00 [gateway] received SIGTERM; shutting down
2026-05-22T11:52:43.025-07:00 [shutdown] completed cleanly in 73ms
```

**Line-by-line analysis:**
- `[gateway] ready`: Gateway fully started with 8 plugins.
- `[gateway] signal SIGTERM received`: `timeout` sent SIGTERM after 12 seconds.
- **`[gateway] failed to handle SIGTERM: Error [ERR_MODULE_NOT_FOUND]`**: The `.catch()` handler fired. The dynamic `import("./cli/gateway-lifecycle.runtime.js")` failed because the module was renamed. The catch logged the error via `gatewayLog.error()` (compiled line 569).
- `[gateway] received SIGTERM; shutting down`: The fallback `request("stop", "SIGTERM")` in the catch handler (compiled line 570) triggered the normal shutdown path.
- `[shutdown] completed cleanly in 73ms`: Gateway shut down gracefully despite the lifecycle module being unavailable.

Before this fix, the same scenario would produce an **unhandled promise rejection** (no `.catch()` on the async IIFE), and the gateway would hang indefinitely because `request("stop")` was never called.

**Compiled code verification:**
```console
$ grep -n "failed to handle SIGTERM" dist/run-FhSmksEV.js
569:gatewayLog$1.error(`failed to handle SIGTERM: ${String(err)}`);

$ sed -n '568,571p' dist/run-FhSmksEV.js
}).catch((err) => {
gatewayLog$1.error(`failed to handle SIGTERM: ${String(err)}`);
request("stop", "SIGTERM");
});
```

**Supplemental: Vitest test suite (31 tests)**
```console
$ node scripts/run-vitest.mjs src/cli/gateway-cli/run-loop.test.ts
 Test Files  1 passed (1)
      Tests  31 passed (31)
```

Observed result after fix: The SIGTERM catch handler fires correctly when the lifecycle runtime module is unavailable, logs the error, and calls the fallback `request("stop", "SIGTERM")` to shut down gracefully. The gateway exits cleanly in 73ms. Before the fix, the same error would be an unhandled rejection and the gateway would hang. All 31 tests pass.

What was not tested: SIGUSR1 fault injection was not re-run after the rebase. The current branch relies on main's eager lifecycle runtime recovery for SIGUSR1, covered by the run-loop tests.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: If SIGTERM restart-intent consumption fails, the fallback stops instead of restarting.
- Mitigation: This is safer than hanging; the failure is logged and the operator can restart normally.

