### PR TITLE
fix(plugins): default 15s timeout for before_agent_start hook (#48534)

### DIFF
--- a/src/plugins/hook-lifecycle-gates.test.ts
+++ b/src/plugins/hook-lifecycle-gates.test.ts
@@ -341,6 +341,82 @@ describe("before_agent_run invalid ask outcome", () => {
   });
 });
 
+describe("before_agent_start hook default timeout (#48534)", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fails open with a warning when a handler exceeds the default 15s budget", async () => {
+    vi.useFakeTimers();
+    const errors: string[] = [];
+    const logger = {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: (msg: string) => {
+        errors.push(msg);
+      },
+    };
+    const registry = makeRegistry([
+      {
+        pluginId: "hanging-plugin",
+        hookName: "before_agent_start",
+        handler: async () => await new Promise<never>(() => {}),
+        source: "test",
+      },
+    ]);
+    const runner = createHookRunner(registry, { logger });
+    const resultPromise = runner.runBeforeAgentStart({ prompt: "hello" }, ctx);
+
+    await vi.advanceTimersByTimeAsync(15_000);
+    const result = await resultPromise;
+
+    // Fail-open: a hung handler must not block the run, and the runner
+    // returns undefined so the embedded setup path proceeds without hook
+    // modifications. The hook-runner logs the timeout for operator triage.
+    expect(result).toBeUndefined();
+    expect(errors).toContain(
+      "[hooks] before_agent_start handler from hanging-plugin failed: timed out after 15000ms",
+    );
+  });
+
+  it("does not block when one handler hangs and a second is registered", async () => {
+    vi.useFakeTimers();
+    const errors: string[] = [];
+    const logger = {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: (msg: string) => {
+        errors.push(msg);
+      },
+    };
+    const registry = makeRegistry([
+      {
+        pluginId: "hanging-plugin",
+        hookName: "before_agent_start",
+        priority: 100,
+        handler: async () => await new Promise<never>(() => {}),
+        source: "test",
+      },
+      {
+        pluginId: "fast-plugin",
+        hookName: "before_agent_start",
+        priority: 50,
+        handler: async () => ({ modelOverride: "fallback-model" }),
+        source: "test",
+      },
+    ]);
+    const runner = createHookRunner(registry, { logger });
+    const resultPromise = runner.runBeforeAgentStart({ prompt: "hello" }, ctx);
+    await vi.advanceTimersByTimeAsync(15_000);
+    const result = await resultPromise;
+
+    expect(result?.modelOverride).toBe("fallback-model");
+    expect(errors.some((msg) => msg.includes("hanging-plugin"))).toBe(true);
+  });
+});
+
 describe("before_tool_call channelId forwarding", () => {
   it("passes channelId through to before_tool_call handlers", async () => {
     let receivedCtx: unknown;

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -192,6 +192,13 @@ const DEFAULT_VOID_HOOK_TIMEOUT_MS_BY_HOOK: Partial<Record<PluginHookName, numbe
 };
 const DEFAULT_MODIFYING_HOOK_TIMEOUT_MS_BY_HOOK: Partial<Record<PluginHookName, number>> = {
   before_agent_run: 15_000,
+  // Defensive default for the legacy compatibility hook (#48534). With
+  // before_agent_start unbudgeted, an unresponsive handler (e.g. a memory
+  // plugin waiting on a hung subprocess) blocked the entire agent pipeline
+  // because both the embedded setup and prompt-build paths await this hook.
+  // The runner is fail-open for this hook name, so a timed-out handler is
+  // logged and the run proceeds without its modifications.
+  before_agent_start: 15_000,
   before_prompt_build: 15_000,
 };
 


### PR DESCRIPTION
## Summary

Closes #48534. The legacy compatibility hook `before_agent_start` has no entry in `DEFAULT_MODIFYING_HOOK_TIMEOUT_MS_BY_HOOK` at [`src/plugins/hooks.ts:193`](https://github.com/openclaw/openclaw/blob/7554deef3027/src/plugins/hooks.ts#L193), so `getModifyingHookTimeoutMs` at [`hooks.ts:484`](https://github.com/openclaw/openclaw/blob/7554deef3027/src/plugins/hooks.ts#L484) returns `undefined` and `runModifyingHook` at [`hooks.ts:590`](https://github.com/openclaw/openclaw/blob/7554deef3027/src/plugins/hooks.ts#L590) awaits the handler directly. When a plugin (the reporter's case was `memory-openviking` waiting on a hung Python subprocess) returns a never-settling promise, both the embedded setup path at [`pi-embedded-runner/run/setup.ts:72`](https://github.com/openclaw/openclaw/blob/7554deef3027/src/agents/pi-embedded-runner/run/setup.ts#L72) and the prompt-build helper at [`attempt.prompt-helpers.ts:165`](https://github.com/openclaw/openclaw/blob/7554deef3027/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts#L165) wedge permanently — the agent run silently drops every user message until the gateway is restarted, and no log line below `debug` ever fires.

This patch adds one entry to the default-timeout map:

```ts
const DEFAULT_MODIFYING_HOOK_TIMEOUT_MS_BY_HOOK: Partial<Record<PluginHookName, number>> = {
  before_agent_run: 15_000,
  before_agent_start: 15_000, // ← #48534
  before_prompt_build: 15_000,
};
```

`before_agent_start`'s failure policy is fail-open by default (see `shouldCatchHookErrors` at `hooks.ts:277-278`), so a timed-out handler is caught by `handleHookError`, logged through the existing `[hooks] before_agent_start handler from <plugin> failed: timed out after 15000ms` path, and the run proceeds without the handler's modifications. Plugins that legitimately need a longer or shorter budget can still override via `timeoutMs` on their registration — `normalizePositiveTimeoutMs(hook.timeoutMs)` is preferred over the default.

| File | Change |
|---|---|
| `src/plugins/hooks.ts` | +7 LOC. One new map entry plus a comment explaining the failure mode it guards against. |
| `src/plugins/hook-lifecycle-gates.test.ts` | +76 LOC. Two regression cases: (1) a single hanging handler resolves to `undefined` with the expected timeout log; (2) a mixed registry where a hanging priority-100 handler does not block a priority-50 fallback handler from contributing its `modelOverride`. |

No new SDK seam, no new config key, no changes to the prompt-build/setup callers — purely a defense-in-depth default at the runner level.

## Real behavior proof

**Behavior addressed**: Closes #48534. Before this patch, `runner.runBeforeAgentStart(...)` against a registered handler that returns `new Promise(() => {})` does not resolve at any wall-clock bound: the missing entry in `DEFAULT_MODIFYING_HOOK_TIMEOUT_MS_BY_HOOK` (`hooks.ts:193`) causes `getModifyingHookTimeoutMs` to return `undefined`, and `runModifyingHook` (`hooks.ts:590`) falls through to `await promise` with no race. The embedded setup path (`setup.ts:72`) and the prompt-build helper (`attempt.prompt-helpers.ts:165`) both await this hook on the agent hot path, so a single hung plugin wedges the whole pipeline.

**Real environment tested**: macOS 26.4.1 arm64, Node v25.1.0, pnpm v11.1.0, `tsx` driving the production source modules directly. Live capture below is from a single-file Node script that constructs the **production** hook runner via `createHookRunner`, registers a single `before_agent_start` handler returning a never-settling promise (the exact failure mode the reporter saw), and prints the wall-clock elapsed time, the resolved value, and the captured error log lines. No mocks, no fake timers.

**Exact steps or command run after this patch**:

```
pnpm install
node scripts/run-vitest.mjs src/plugins/hook-lifecycle-gates.test.ts src/plugins/hooks.before-agent-start.test.ts src/plugins/hooks.model-override-wiring.test.ts src/plugins/loader.test.ts
node scripts/run-oxlint.mjs src/plugins/hooks.ts src/plugins/hook-lifecycle-gates.test.ts
node scripts/run-tsgo.mjs -p tsconfig.core.json --noEmit
pnpm exec tsx /tmp/oc-48534-proof.mjs   # production hook runner, end-to-end
```

**Evidence after fix**: Live terminal capture from a fork checkout at commit `dde…` running `tsx` against the patched source. Same reproduction script run against the unpatched baseline (commit `7554deef` with the fix stashed out) is shown for contrast. The script has a 20s hard-cap so the "before" run terminates instead of hanging forever.

*Before this PR (baseline `7554deef`, fix stashed out — `pnpm exec tsx oc-48534-proof.mjs`):*

```
{
  "elapsedMs": 20001,
  "hardCapMs": 20000,
  "resolvedTo": "HARD_CAP_HIT (still hung)",
  "errorLines": []
}
EXIT=1
```

The hook does not resolve in 20 seconds. Zero error log lines. Matches the reporter's "no log line below `debug`, gateway requires external restart" exactly.

*After this PR:*

```
{
  "elapsedMs": 15006,
  "hardCapMs": 20000,
  "errorLines": [
    "[hooks] before_agent_start handler from memory-openviking failed: timed out after 15000ms"
  ]
}
EXIT=0
```

Hook resolves to `undefined` (omitted by `JSON.stringify` because it's `undefined`) after the 15s default budget. The expected error line fires through the existing `handleHookError` path. The agent run can proceed.

*Targeted test runs (the four files clawsweeper listed in the acceptance criteria):*

```
$ node scripts/run-vitest.mjs src/plugins/hook-lifecycle-gates.test.ts src/plugins/hooks.before-agent-start.test.ts src/plugins/hooks.model-override-wiring.test.ts src/plugins/loader.test.ts
 Test Files  4 passed (4)
      Tests  167 passed (167)
```

*Lint and type check:*

```
$ node scripts/run-oxlint.mjs src/plugins/hooks.ts src/plugins/hook-lifecycle-gates.test.ts
Found 0 warnings and 0 errors.
Finished in 2.5s on 2 files with 216 rules using 1 threads.

$ node scripts/run-tsgo.mjs -p tsconfig.core.json --noEmit ; echo EXIT=$?
EXIT=0
```

**Observed result after fix**: The hung handler now resolves through the existing timeout race in `runModifyingHook` (`hooks.ts:590`) at the 15000ms default. `runModifyingHook`'s try/catch catches the timeout error, `handleHookError` (`hooks.ts:444-455`) sees `before_agent_start` is fail-open (`failurePolicyByHook` only marks `before_agent_run` as fail-closed at `hooks.ts:264-266`), logs the failure, and returns `undefined`. The caller in `setup.ts:72` and `attempt.prompt-helpers.ts:165` receives `undefined` exactly as it does today when no `before_agent_start` handlers are registered at all — a code path that is already exercised everywhere and produces a normal agent run. The two new regression cases in `hook-lifecycle-gates.test.ts` lock both halves: the bare hang and the mixed-priority scenario where a hanging high-priority handler must not starve a working lower-priority handler.

**What was not tested**: A full live gateway run with the actual `memory-openviking` plugin against a deliberately-hung Python subprocess — that needs the openviking binary, a long warm-up window, and a Telegram/Discord channel install end-to-end. The reproduction script above exercises every changed line of the patch (the new map entry, the timeout race it activates, the catch+log path, the merger continuing past the hung handler) against the production hook runner with the same failure shape the reporter observed.

## Duplicate-check

5-vector sweep before opening — all returned 0 open PRs touching this fix at the runner-default-map layer:

```
$ gh pr list --repo openclaw/openclaw --state open --search "48534 in:title,body"        → 0
$ gh pr list --repo openclaw/openclaw --state open --search "before_agent_start timeout" → 0
$ gh pr list --repo openclaw/openclaw --state open --search "hook timeout default"       → 0
$ gh pr list --repo openclaw/openclaw --state open --search "DEFAULT_MODIFYING_HOOK_TIMEOUT_MS_BY_HOOK" → 0
$ gh pr list --repo openclaw/openclaw --state open --search "plugin hook hang"           → 0
```

(The clawsweeper review references a previously-attempted PR by `Jerry-Xin` at commit `6cee5bdccafd` — that PR is closed unmerged and used a different approach (new config key plus loader plumbing); this PR is the narrower runner-default-map fix the review recommended.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
