### PR TITLE
fix(gateway): keep unmanaged restarts in-process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Docs: https://docs.openclaw.ai
 - CLI/plugins: ship the bundled memory CLI as a package entry so package-installed `openclaw memory` commands register correctly.
 - CLI/update: defer doctor-time plugin package installs during package swaps and seed post-core repair from the updated install registry, preventing duplicate reinstall failures.
 - Feishu: detect SecretRef top-level credentials as a configured default account instead of treating object-backed app secrets as missing.
+- Gateway/restart: keep ordinary unmanaged SIGUSR1/config restarts in-process instead of detach-spawning an orphaned child, preserving custom supervisor PID tracking while leaving update restarts on the fresh-process path. Fixes #65668.
 - CLI/completion: resolve concrete PowerShell profile paths and reload commands during setup and doctor completion installation. Fixes #44296. (#83059) Thanks @yu-xin-c.
 - Providers/Google: preserve and recover Gemini 3 tool-call thought signatures during native replay so function-calling turns no longer fail with missing `thought_signature` 400s. Fixes #72879. (#80358) Thanks @abnershang.
 - Memory-core: distinguish sqlite-vec load failures from missing semantic vector embeddings in degraded `memory index` warnings, so vector recall diagnostics point at unresolved dimensions instead of blaming sqlite-vec when the store is ready. Fixes #75624. (#83056) Thanks @xuruiray and @Noah3521.

--- a/docs/install/raspberry-pi.md
+++ b/docs/install/raspberry-pi.md
@@ -145,6 +145,8 @@ EOF
 source ~/.bashrc
 ```
 
+`OPENCLAW_NO_RESPAWN=1` keeps routine Gateway restarts in-process, which avoids extra process handoffs and keeps PID tracking simple on small hosts.
+
 **Reduce memory usage** -- For headless setups, free GPU memory and disable unused services:
 
 ```bash

--- a/docs/vps.md
+++ b/docs/vps.md
@@ -90,7 +90,7 @@ source ~/.bashrc
 ```
 
 - `NODE_COMPILE_CACHE` improves repeated command startup times.
-- `OPENCLAW_NO_RESPAWN=1` avoids extra startup overhead from a self-respawn path.
+- `OPENCLAW_NO_RESPAWN=1` keeps routine Gateway restarts in-process, which avoids extra process handoffs and keeps PID tracking simple on small hosts.
 - First command run warms the cache; subsequent runs are faster.
 - For Raspberry Pi specifics, see [Raspberry Pi](/install/raspberry-pi).
 

--- a/src/commands/doctor-platform-notes.startup-optimization.test.ts
+++ b/src/commands/doctor-platform-notes.startup-optimization.test.ts
@@ -36,7 +36,7 @@ describe("noteStartupOptimizationHints", () => {
     expect(message).toBe(
       [
         "- NODE_COMPILE_CACHE points to /tmp; use /var/tmp so cache survives reboots and warms startup reliably.",
-        "- OPENCLAW_NO_RESPAWN is not set to 1; set it to avoid extra startup overhead from self-respawn.",
+        "- OPENCLAW_NO_RESPAWN is not set to 1; set it when you want routine gateway restarts to stay in-process instead of handing off to a managed supervisor.",
         "- Suggested env for low-power hosts:",
         "  export NODE_COMPILE_CACHE=/var/tmp/openclaw-compile-cache",
         "  mkdir -p /var/tmp/openclaw-compile-cache",

--- a/src/commands/doctor-platform-notes.ts
+++ b/src/commands/doctor-platform-notes.ts
@@ -197,7 +197,7 @@ export function noteStartupOptimizationHints(
 
   if (noRespawn !== "1") {
     lines.push(
-      "- OPENCLAW_NO_RESPAWN is not set to 1; set it to avoid extra startup overhead from self-respawn.",
+      "- OPENCLAW_NO_RESPAWN is not set to 1; set it when you want routine gateway restarts to stay in-process instead of handing off to a managed supervisor.",
     );
   }
 

--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -133,7 +133,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
-  it("spawns detached child with current exec argv", () => {
+  it("uses in-process restart on unmanaged Unix so custom supervisors keep the tracked PID", () => {
     delete process.env.OPENCLAW_NO_RESPAWN;
     clearSupervisorHints();
     setPlatform("linux");
@@ -143,16 +143,11 @@ describe("restartGatewayProcessWithFreshPid", () => {
 
     const result = restartGatewayProcessWithFreshPid();
 
-    expect(result).toEqual({ mode: "spawned", pid: 4242 });
-    expect(spawnMock).toHaveBeenCalledWith(
-      process.execPath,
-      ["--import", "tsx", "/repo/dist/index.js", "gateway", "run"],
-      {
-        detached: true,
-        env: process.env,
-        stdio: "inherit",
-      },
-    );
+    expect(result).toEqual({
+      mode: "disabled",
+      detail: "unmanaged: use in-process restart to keep custom supervisor PID tracking stable",
+    });
+    expect(spawnMock).not.toHaveBeenCalled();
   });
 
   it("returns supervised when OPENCLAW_LAUNCHD_LABEL is set (stock launchd plist)", () => {
@@ -186,12 +181,15 @@ describe("restartGatewayProcessWithFreshPid", () => {
     setPlatform("linux");
     process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
     process.env.OPENCLAW_SERVICE_KIND = "gateway";
-    spawnMock.mockReturnValue({ pid: 4242, unref: vi.fn() });
 
     const result = restartGatewayProcessWithFreshPid();
 
-    expect(result).toEqual({ mode: "spawned", pid: 4242 });
+    expect(result).toEqual({
+      mode: "disabled",
+      detail: "unmanaged: use in-process restart to keep custom supervisor PID tracking stable",
+    });
     expect(triggerOpenClawRestartMock).not.toHaveBeenCalled();
+    expect(spawnMock).not.toHaveBeenCalled();
   });
 
   it("returns disabled on Windows without Scheduled Task markers", () => {
@@ -235,7 +233,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
-  it("returns failed when spawn throws", () => {
+  it("does not attempt detached spawn on unmanaged Unix even if spawn would throw", () => {
     delete process.env.OPENCLAW_NO_RESPAWN;
     clearSupervisorHints();
     setPlatform("linux");
@@ -244,8 +242,11 @@ describe("restartGatewayProcessWithFreshPid", () => {
       throw new Error("spawn failed");
     });
     const result = restartGatewayProcessWithFreshPid();
-    expect(result.mode).toBe("failed");
-    expect(result.detail).toContain("spawn failed");
+    expect(result).toEqual({
+      mode: "disabled",
+      detail: "unmanaged: use in-process restart to keep custom supervisor PID tracking stable",
+    });
+    expect(spawnMock).not.toHaveBeenCalled();
   });
 });
 
@@ -285,5 +286,20 @@ describe("respawnGatewayProcessForUpdate", () => {
         stdio: "inherit",
       },
     );
+  });
+
+  it("returns failed when update detached respawn throws", () => {
+    delete process.env.OPENCLAW_NO_RESPAWN;
+    clearSupervisorHints();
+    setPlatform("linux");
+
+    spawnMock.mockImplementation(() => {
+      throw new Error("spawn failed");
+    });
+
+    const result = respawnGatewayProcessForUpdate();
+
+    expect(result.mode).toBe("failed");
+    expect(result.detail).toContain("spawn failed");
   });
 });

--- a/src/infra/process-respawn.ts
+++ b/src/infra/process-respawn.ts
@@ -43,10 +43,11 @@ function spawnDetachedGatewayProcess(opts: GatewayRespawnOptions = {}): {
  * Attempt to restart this process with a fresh PID.
  * - supervised environments (launchd/systemd/schtasks): caller should exit and let supervisor restart
  * - OPENCLAW_NO_RESPAWN=1: caller should keep in-process restart behavior (tests/dev)
- * - otherwise: spawn detached child with current argv/execArgv, then caller exits
+ * - unmanaged environments: caller should keep in-process restart behavior so
+ *   custom supervisors keep tracking the same gateway PID
  */
 export function restartGatewayProcessWithFreshPid(
-  opts: GatewayRespawnOptions = {},
+  _opts: GatewayRespawnOptions = {},
 ): GatewayRespawnResult {
   if (isTruthy(process.env.OPENCLAW_NO_RESPAWN)) {
     return { mode: "disabled" };
@@ -82,13 +83,10 @@ export function restartGatewayProcessWithFreshPid(
     };
   }
 
-  try {
-    const { pid } = spawnDetachedGatewayProcess(opts);
-    return { mode: "spawned", pid };
-  } catch (err) {
-    const detail = formatErrorMessage(err);
-    return { mode: "failed", detail };
-  }
+  return {
+    mode: "disabled",
+    detail: "unmanaged: use in-process restart to keep custom supervisor PID tracking stable",
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

- keep ordinary unmanaged gateway restarts in-process instead of detached-spawning a replacement child
- preserve trusted supervisor handoff behavior and keep `update.run` on the fresh-process replacement path
- update the focused respawn tests plus low-power host doctor/docs wording for the new restart contract

## Validation

- `node scripts/run-vitest.mjs src/infra/process-respawn.test.ts src/cli/gateway-cli/run-loop.test.ts src/commands/doctor-platform-notes.startup-optimization.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/infra/process-respawn.ts src/infra/process-respawn.test.ts src/commands/doctor-platform-notes.ts src/commands/doctor-platform-notes.startup-optimization.test.ts docs/vps.md docs/install/raspberry-pi.md CHANGELOG.md`
- `pnpm check:changed --base upstream/main`
- `git diff --check`

## Real behavior proof

- **Behavior or issue addressed**: ordinary unmanaged gateway restarts no longer detach-spawn a replacement child that can orphan from a custom supervisor; they return `disabled` so the run loop uses its in-process restart fallback.
- **Real environment tested**: local Linux source checkout at `21b538ee68` with dependencies installed, running the patched restart helper in a real Node 24 process without Vitest or module mocks.
- **Exact steps or command run after this patch**:

```bash
node --import tsx --input-type=module -e '
import { restartGatewayProcessWithFreshPid } from "./src/infra/process-respawn.ts";
import { SUPERVISOR_HINT_ENV_VARS } from "./src/infra/supervisor-markers.ts";
for (const key of SUPERVISOR_HINT_ENV_VARS) delete process.env[key];
delete process.env.OPENCLAW_NO_RESPAWN;
const result = restartGatewayProcessWithFreshPid();
console.log(JSON.stringify({ platform: process.platform, supervisorHintsCleared: true, result, spawnedDetachedChild: result.mode === "spawned" }, null, 2));
'
```

- **Evidence after fix**:

```json
{
  "platform": "linux",
  "supervisorHintsCleared": true,
  "result": {
    "mode": "disabled",
    "detail": "unmanaged: use in-process restart to keep custom supervisor PID tracking stable"
  },
  "spawnedDetachedChild": false
}
```

- **Observed result after fix**: with no trusted supervisor hints and `OPENCLAW_NO_RESPAWN` unset, the real helper returns the in-process fallback result and does not detach-spawn a child.
- **What was not tested**: I did not run a full live non-container bash/Python supervisor loop against an active gateway; the focused tests cover the run-loop fallback and preserve the separate `update.run` fresh-process path.

Fixes #65668
