### PR TITLE
[codex] test one-chunk progress/final payload selection

### DIFF
--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -116,6 +116,38 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     );
   });
 
+  it("uses the final assistant answer when one streamed text contains progress and final text", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["Need inspect.\n\nDone."],
+      lastAssistant: {
+        role: "assistant",
+        stopReason: "stop",
+        content: [
+          {
+            type: "text",
+            text: "Need inspect.",
+            textSignature: JSON.stringify({
+              v: 1,
+              id: "item_commentary",
+              phase: "commentary",
+            }),
+          },
+          {
+            type: "text",
+            text: "Done.",
+            textSignature: JSON.stringify({
+              v: 1,
+              id: "item_final",
+              phase: "final_answer",
+            }),
+          },
+        ],
+      } as AssistantMessage,
+    });
+
+    expectSinglePayloadText(payloads, "Done.");
+  });
+
   it("keeps a current one-chunk reply when only a stale transcript assistant is available", () => {
     const payloads = buildPayloads({
       assistantTexts: ["Current room event reply."],


### PR DESCRIPTION
## Summary

- Add a focused regression test for a single streamed assistant text that contains both progress/commentary and final-answer text.
- Lock in that payload assembly still sends only the structured `final_answer` when phase metadata is available.
- No runtime code changes.

AI-assisted: yes, implemented with Codex and manually inspected/verified.

## Change Type

- [x] Test
- [ ] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Chore/infra

## Scope

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Follow-up to #82850
- Supersedes test coverage from #82645

## Real Behavior Proof

No runtime behavior changed. This PR only adds regression coverage for existing payload-selection behavior on current `main`.

Local verification run:

```text
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/payloads.test.ts

Test Files  1 passed (1)
Tests       29 passed (29)
```

Formatting:

```text
pnpm exec oxfmt --check --threads=1 src/agents/pi-embedded-runner/run/payloads.test.ts

All matched files use the correct format.
```

Independent clean-checkout verification:

- OS: Ubuntu 24.04.4 LTS, Linux 6.8.0-106-generic x86_64 GNU/Linux
- Node: `v24.15.0`
- Checked-out commit: `6e231c0c3c837987f7388395e9408a4f42ff0e97`

Changed files:

```text
src/agents/pi-embedded-runner/run/payloads.test.ts
```

Commands and output:

```console
$ git diff --name-only origin/main...HEAD
src/agents/pi-embedded-runner/run/payloads.test.ts
```

```console
$ OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/payloads.test.ts
[PLUGIN_TIMINGS] Your build spent significant time in plugin inject-file-scope-variables. See https://rolldown.rs/options/checks#plugintimings for more details.
[PLUGIN_TIMINGS] Your build spent significant time in plugin externalize-deps. See https://rolldown.rs/options/checks#plugintimings for more details.

 RUN v4.1.6 /tmp/openclaw-pr-83139/.../openclaw

 Test Files 1 passed (1)
 Tests 29 passed (29)
 Start at 19:45:12
 Duration 6.42s (transform 4.75s, setup 0ms, import 5.86s, tests 67ms, environment 0ms)
```

```console
$ pnpm exec oxfmt --check --threads=1 src/agents/pi-embedded-runner/run/payloads.test.ts
Checking formatting...

All matched files use the correct format.
Finished in 91ms on 1 files using 1 threads.
```

Observed result: PR #83139 only changes `payloads.test.ts`; the focused regression passes and proves phase metadata makes the final payload use the structured `final_answer` when one streamed assistant text contains both progress/commentary and final-answer text.

Caveat: no live gateway/channel runtime was exercised; this PR is test-only and the independent verification confirms the focused regression passes in a clean checkout.


## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
