### PR TITLE
Fix Telegram topic stop targeting

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -13,10 +13,8 @@ import {
   resolveInboundDebounceMs,
 } from "openclaw/plugin-sdk/channel-inbound-debounce";
 import { resolveStoredModelOverride } from "openclaw/plugin-sdk/command-auth-native";
-import {
-  hasControlCommand,
-  isControlCommandMessage,
-} from "openclaw/plugin-sdk/command-detection";
+import { hasControlCommand, isControlCommandMessage } from "openclaw/plugin-sdk/command-detection";
+import { isAbortRequestText } from "openclaw/plugin-sdk/command-primitives-runtime";
 import { buildCommandsMessagePaginated } from "openclaw/plugin-sdk/command-status";
 import type { DmPolicy, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type {
@@ -1542,6 +1540,7 @@ export const registerTelegramHandlers = ({
     const messageText = getTelegramTextParts(msg).text;
     const botUsername = ctx.me?.username;
     const isControlMessage = isControlCommandMessage(messageText, cfg, { botUsername });
+    const isAbortControlMessage = isAbortRequestText(messageText, { botUsername });
 
     // Text fragment handling - Telegram splits long pastes into multiple inbound messages (~4096 chars).
     // We buffer “near-limit” messages and append immediately-following parts.
@@ -1610,7 +1609,7 @@ export const registerTelegramHandlers = ({
         scheduleTextFragmentFlush(entry);
         return;
       }
-    } else if (text && isControlMessage) {
+    } else if (text && isAbortControlMessage) {
       const senderId = msg.from?.id != null ? String(msg.from.id) : "unknown";
       const threadId = resolvedThreadId ?? dmThreadId;
       const key = `text:${chatId}:${threadId ?? "main"}:${senderId}`;
@@ -1760,7 +1759,7 @@ export const registerTelegramHandlers = ({
           debounceLane,
         })
       : null;
-    if (isControlMessage && debounceKey) {
+    if (isAbortControlMessage && debounceKey) {
       inboundDebouncer.cancelKey(debounceKey);
     }
     await inboundDebouncer.enqueue({

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -13,7 +13,10 @@ import {
   resolveInboundDebounceMs,
 } from "openclaw/plugin-sdk/channel-inbound-debounce";
 import { resolveStoredModelOverride } from "openclaw/plugin-sdk/command-auth-native";
-import { hasControlCommand } from "openclaw/plugin-sdk/command-detection";
+import {
+  hasControlCommand,
+  isControlCommandMessage,
+} from "openclaw/plugin-sdk/command-detection";
 import { buildCommandsMessagePaginated } from "openclaw/plugin-sdk/command-status";
 import type { DmPolicy, OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type {
@@ -1536,11 +1539,15 @@ export const registerTelegramHandlers = ({
       promptContextMinTimestampMs,
     } = params;
 
+    const messageText = getTelegramTextParts(msg).text;
+    const botUsername = ctx.me?.username;
+    const isControlMessage = isControlCommandMessage(messageText, cfg, { botUsername });
+
     // Text fragment handling - Telegram splits long pastes into multiple inbound messages (~4096 chars).
     // We buffer “near-limit” messages and append immediately-following parts.
     const text = typeof msg.text === "string" ? msg.text : undefined;
     const isCommandLike = (text ?? "").trim().startsWith("/");
-    if (text && !isCommandLike) {
+    if (text && !isCommandLike && !isControlMessage) {
       const nowMs = Date.now();
       const senderId = msg.from?.id != null ? String(msg.from.id) : "unknown";
       // Use resolvedThreadId for forum groups, dmThreadId for DM topics
@@ -1602,6 +1609,15 @@ export const registerTelegramHandlers = ({
         textFragmentBuffer.set(key, entry);
         scheduleTextFragmentFlush(entry);
         return;
+      }
+    } else if (text && isControlMessage) {
+      const senderId = msg.from?.id != null ? String(msg.from.id) : "unknown";
+      const threadId = resolvedThreadId ?? dmThreadId;
+      const key = `text:${chatId}:${threadId ?? "main"}:${senderId}`;
+      const existing = textFragmentBuffer.get(key);
+      if (existing) {
+        clearTimeout(existing.timer);
+        textFragmentBuffer.delete(key);
       }
     }
 
@@ -1744,15 +1760,18 @@ export const registerTelegramHandlers = ({
           debounceLane,
         })
       : null;
+    if (isControlMessage && debounceKey) {
+      inboundDebouncer.cancelKey(debounceKey);
+    }
     await inboundDebouncer.enqueue({
       ctx,
       msg,
       allMedia,
       storeAllowFrom,
       receivedAtMs: Date.now(),
-      debounceKey,
+      debounceKey: isControlMessage ? null : debounceKey,
       debounceLane,
-      botUsername: ctx.me?.username,
+      botUsername,
       ...promptContextBoundaryOptions(promptContextMinTimestampMs),
     });
   };

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -83,6 +83,7 @@ import {
   hasBotMention,
   buildTelegramGroupPeerId,
   buildTelegramParentPeer,
+  extractTelegramMessageForumFlag,
   isTelegramCommandsAllowFromConfigured,
   resolveTelegramCommandAuthorization,
   resolveTelegramForumFlag,
@@ -1887,7 +1888,7 @@ export const registerTelegramHandlers = ({
         chatId,
         chatType: callbackMessage.chat.type,
         isGroup,
-        isForum: callbackMessage.chat.is_forum,
+        isForum: extractTelegramMessageForumFlag(callbackMessage),
         getChat,
       });
       const senderId = callback.from?.id ? String(callback.from.id) : "";
@@ -2547,7 +2548,7 @@ export const registerTelegramHandlers = ({
       chatId: msg.chat.id,
       chatType: msg.chat.type,
       isGroup,
-      isForum: msg.chat.is_forum,
+      isForum: extractTelegramMessageForumFlag(msg),
       getChat,
     });
     const normalizedMsg = withResolvedTelegramForumFlag(msg, isForum);
@@ -2681,7 +2682,7 @@ export const registerTelegramHandlers = ({
       chatId: msg.chat.id,
       chatType: msg.chat.type,
       isGroup,
-      isForum: msg.chat.is_forum,
+      isForum: extractTelegramMessageForumFlag(msg),
       getChat,
     });
     const normalizedMsg = withResolvedTelegramForumFlag(msg, isForum);

--- a/extensions/telegram/src/bot-message-context.topic-agentid.test.ts
+++ b/extensions/telegram/src/bot-message-context.topic-agentid.test.ts
@@ -75,6 +75,30 @@ describe("buildTelegramMessageContext per-topic agentId routing", () => {
     expect(ctx?.ctxPayload?.SessionKey).toContain("telegram:group:-1001234567890:topic:3");
   });
 
+  it("routes topic messages when Telegram omits chat.is_forum but sets is_topic_message", async () => {
+    const message = buildForumMessage(3);
+    delete (message.chat as { is_forum?: boolean }).is_forum;
+    const ctx = await buildTelegramMessageContextForTest({
+      message: {
+        ...message,
+        is_topic_message: true,
+      },
+      options: { forceWasMentioned: true },
+      resolveGroupActivation: () => true,
+      resolveTelegramGroupConfig: () => ({
+        groupConfig: { requireMention: false },
+        topicConfig: { agentId: "zu" },
+      }),
+      botApi: {
+        getChat: vi.fn(async () => {
+          throw new Error("lookup unavailable");
+        }),
+      },
+    });
+
+    expect(ctx?.ctxPayload?.SessionKey).toBe("agent:zu:telegram:group:-1001234567890:topic:3");
+  });
+
   it("different topics route to different agents", async () => {
     const buildForTopic = async (threadId: number, agentId: string) =>
       await buildForumContext({ threadId, topicConfig: { agentId } });

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -30,7 +30,7 @@ import {
 import type { BuildTelegramMessageContextParams } from "./bot-message-context.types.js";
 import {
   buildTypingThreadParams,
-  extractTelegramForumFlag,
+  extractTelegramMessageForumFlag,
   resolveTelegramForumFlag,
   resolveTelegramThreadSpec,
   shouldUseTelegramDmThreadSession,
@@ -158,7 +158,7 @@ export const buildTelegramMessageContext = async ({
     chatId,
     chatType: msg.chat.type,
     isGroup,
-    isForum: extractTelegramForumFlag(msg.chat),
+    isForum: extractTelegramMessageForumFlag(msg),
     getChat: getChatApi,
   });
   const threadSpec = resolveTelegramThreadSpec({

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2325,6 +2325,95 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(editMessageTelegram).not.toHaveBeenCalled();
   });
 
+  it("cancels in-flight topic delivery when authorized native stop targets that session", async () => {
+    const topicSessionKey = "agent:main:telegram:group:-1003826723328:topic:8185";
+    let releaseFirstDelivery: (() => void) | undefined;
+    const holdFirstDelivery = new Promise<void>((resolve) => {
+      releaseFirstDelivery = resolve;
+    });
+    let firstDeliveryParams:
+      | (Parameters<NonNullable<TelegramBotDeps["deliverReplies"]>>[0] & {
+          shouldContinue?: () => boolean;
+        })
+      | undefined;
+    const firstDeliveryStarted = new Promise<void>((resolve) => {
+      deliverReplies
+        .mockImplementationOnce(async (params) => {
+          firstDeliveryParams = params as typeof firstDeliveryParams;
+          resolve();
+          await holdFirstDelivery;
+          return { delivered: true };
+        })
+        .mockResolvedValue({ delivered: true });
+    });
+    dispatchReplyWithBufferedBlockDispatcher
+      .mockImplementationOnce(async ({ dispatcherOptions }) => {
+        await dispatcherOptions.deliver({ text: "Old topic reply" }, { kind: "final" });
+        return { queuedFinal: true };
+      })
+      .mockImplementationOnce(async ({ dispatcherOptions }) => {
+        await dispatcherOptions.deliver({ text: "Stopping" }, { kind: "final" });
+        return { queuedFinal: true };
+      });
+
+    const topicContext = (
+      ctxPayload: Partial<TelegramMessageContext["ctxPayload"]>,
+      messageId: number,
+    ) =>
+      createContext({
+        chatId: -1003826723328,
+        isGroup: true,
+        threadSpec: { id: 8185, scope: "forum" },
+        msg: {
+          chat: { id: -1003826723328, type: "supergroup", is_forum: true },
+          message_id: messageId,
+          message_thread_id: 8185,
+          is_topic_message: true,
+        } as never,
+        ctxPayload: {
+          SessionKey: topicSessionKey,
+          ChatType: "group",
+          MessageSid: String(messageId),
+          ...ctxPayload,
+        } as never,
+      });
+
+    const firstDispatch = dispatchWithContext({
+      context: topicContext(
+        {
+          Body: "make a long answer",
+          RawBody: "make a long answer",
+          CommandAuthorized: true,
+        },
+        96431,
+      ),
+      streamMode: "off",
+    });
+    await firstDeliveryStarted;
+
+    expect(firstDeliveryParams?.shouldContinue?.()).toBe(true);
+
+    await dispatchWithContext({
+      context: topicContext(
+        {
+          SessionKey: "agent:main:telegram:group:-1003826723328:control",
+          CommandTargetSessionKey: topicSessionKey,
+          CommandSource: "native",
+          Body: "/stop@vacs_tars_bot",
+          RawBody: "/stop@vacs_tars_bot",
+          CommandBody: "/stop",
+          CommandAuthorized: true,
+        },
+        96442,
+      ),
+      streamMode: "off",
+    });
+
+    expect(firstDeliveryParams?.shouldContinue?.()).toBe(false);
+    releaseFirstDelivery?.();
+    await firstDispatch;
+  });
+
   it("uses configured doneHoldMs when clearing Telegram status reactions after reply", async () => {
     vi.useFakeTimers();
     const reactionApi = vi.fn(async () => true);

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2421,11 +2421,13 @@ describe("dispatchTelegramMessage draft streaming", () => {
       releaseFirstDelivery = resolve;
     });
     let firstDeliverySignal: AbortSignal | undefined;
+    let firstDeliveryShouldContinue: (() => boolean) | undefined;
     const firstDeliveryStarted = new Promise<void>((resolve) => {
       deliverInboundReplyWithMessageSendContext
         .mockImplementationOnce(async (params) => {
-          const request = params as { signal?: AbortSignal };
+          const request = params as { shouldContinue?: () => boolean; signal?: AbortSignal };
           firstDeliverySignal = request.signal;
+          firstDeliveryShouldContinue = request.shouldContinue;
           resolve();
           await holdFirstDelivery;
           return {
@@ -2490,6 +2492,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     await firstDeliveryStarted;
 
     expect(firstDeliverySignal?.aborted).toBe(false);
+    expect(firstDeliveryShouldContinue?.()).toBe(true);
 
     await dispatchWithContext({
       context: topicContext(
@@ -2508,6 +2511,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
 
     expect(firstDeliverySignal?.aborted).toBe(true);
+    expect(firstDeliveryShouldContinue?.()).toBe(false);
     releaseFirstDelivery?.();
     await firstDispatch;
   });

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2414,6 +2414,104 @@ describe("dispatchTelegramMessage draft streaming", () => {
     await firstDispatch;
   });
 
+  it("aborts durable topic delivery when authorized native stop targets that session", async () => {
+    const topicSessionKey = "agent:main:telegram:group:-1003826723328:topic:8185";
+    let releaseFirstDelivery: (() => void) | undefined;
+    const holdFirstDelivery = new Promise<void>((resolve) => {
+      releaseFirstDelivery = resolve;
+    });
+    let firstDeliverySignal: AbortSignal | undefined;
+    const firstDeliveryStarted = new Promise<void>((resolve) => {
+      deliverInboundReplyWithMessageSendContext
+        .mockImplementationOnce(async (params) => {
+          const request = params as { signal?: AbortSignal };
+          firstDeliverySignal = request.signal;
+          resolve();
+          await holdFirstDelivery;
+          return {
+            status: "handled_visible",
+            delivery: {
+              messageIds: ["1001"],
+              visibleReplySent: true,
+            },
+          };
+        })
+        .mockResolvedValue({
+          status: "handled_visible",
+          delivery: {
+            messageIds: ["1002"],
+            visibleReplySent: true,
+          },
+        });
+    });
+    dispatchReplyWithBufferedBlockDispatcher
+      .mockImplementationOnce(async ({ dispatcherOptions }) => {
+        await dispatcherOptions.deliver({ text: "Old durable topic reply" }, { kind: "final" });
+        return { queuedFinal: true };
+      })
+      .mockImplementationOnce(async ({ dispatcherOptions }) => {
+        await dispatcherOptions.deliver({ text: "Stopping" }, { kind: "final" });
+        return { queuedFinal: true };
+      });
+
+    const topicContext = (
+      ctxPayload: Partial<TelegramMessageContext["ctxPayload"]>,
+      messageId: number,
+    ) =>
+      createContext({
+        chatId: -1003826723328,
+        isGroup: true,
+        threadSpec: { id: 8185, scope: "forum" },
+        msg: {
+          chat: { id: -1003826723328, type: "supergroup", is_forum: true },
+          message_id: messageId,
+          message_thread_id: 8185,
+          is_topic_message: true,
+        } as never,
+        ctxPayload: {
+          SessionKey: topicSessionKey,
+          ChatType: "group",
+          MessageSid: String(messageId),
+          ...ctxPayload,
+        } as never,
+      });
+
+    const firstDispatch = dispatchWithContext({
+      context: topicContext(
+        {
+          Body: "make a long durable answer",
+          RawBody: "make a long durable answer",
+          CommandAuthorized: true,
+        },
+        96451,
+      ),
+      streamMode: "off",
+    });
+    await firstDeliveryStarted;
+
+    expect(firstDeliverySignal?.aborted).toBe(false);
+
+    await dispatchWithContext({
+      context: topicContext(
+        {
+          SessionKey: "agent:main:telegram:group:-1003826723328:control",
+          CommandTargetSessionKey: topicSessionKey,
+          CommandSource: "native",
+          Body: "/stop@vacs_tars_bot",
+          RawBody: "/stop@vacs_tars_bot",
+          CommandBody: "/stop",
+          CommandAuthorized: true,
+        },
+        96452,
+      ),
+      streamMode: "off",
+    });
+
+    expect(firstDeliverySignal?.aborted).toBe(true);
+    releaseFirstDelivery?.();
+    await firstDispatch;
+  });
+
   it("uses configured doneHoldMs when clearing Telegram status reactions after reply", async () => {
     vi.useFakeTimers();
     const reactionApi = vi.fn(async () => true);

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1049,6 +1049,7 @@ export const dispatchTelegramMessage = async ({
           });
         }
       : undefined,
+    shouldContinue: () => !isDispatchSuperseded(),
   };
   const silentErrorReplies = telegramCfg.silentErrorReplies === true;
   const isDmTopic = !isGroup && threadSpec.scope === "dm" && threadSpec.id != null;

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -300,6 +300,10 @@ function releaseTelegramReplyFenceAbortController(
   }
 }
 
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
 function shouldSupersedeTelegramReplyFence(ctxPayload: {
   Body?: string;
   RawBody?: string;
@@ -1193,6 +1197,7 @@ export const dispatchTelegramMessage = async ({
           },
           silent,
           signal: deliveryAbortController.signal,
+          shouldContinue: isDeliveryActive,
           requiredCapabilities: deriveDurableFinalDeliveryRequirements({
             payload: deliverablePayload,
             replyToId: deliverablePayload.replyToId,
@@ -1209,7 +1214,11 @@ export const dispatchTelegramMessage = async ({
           return false;
         }
         if (durable.status === "failed") {
-          if (deliveryAbortController.signal.aborted) {
+          if (
+            deliveryAbortController.signal.aborted ||
+            !isDeliveryActive() ||
+            isAbortError(durable.error)
+          ) {
             return false;
           }
           throw durable.error;

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -229,6 +229,7 @@ function beginTelegramReplyFence(params: {
   key: string;
   supersede: boolean;
   abortController?: AbortController;
+  abortControllers?: readonly AbortController[];
 }): number {
   const existing = telegramReplyFenceByKey.get(params.key);
   const state: TelegramReplyFenceState = existing ?? {
@@ -241,6 +242,9 @@ function beginTelegramReplyFence(params: {
   }
   if (params.abortController) {
     (state.abortControllers ??= new Set()).add(params.abortController);
+  }
+  for (const abortController of params.abortControllers ?? []) {
+    (state.abortControllers ??= new Set()).add(abortController);
   }
   state.activeDispatches += 1;
   telegramReplyFenceByKey.set(params.key, state);
@@ -265,12 +269,12 @@ function isTelegramReplyFenceSuperseded(params: { key: string; generation: numbe
   return (telegramReplyFenceByKey.get(params.key)?.generation ?? 0) !== params.generation;
 }
 
-function endTelegramReplyFence(key: string, abortController?: AbortController): void {
+function endTelegramReplyFence(key: string, abortControllers?: readonly AbortController[]): void {
   const state = telegramReplyFenceByKey.get(key);
   if (!state) {
     return;
   }
-  if (abortController) {
+  for (const abortController of abortControllers ?? []) {
     state.abortControllers?.delete(abortController);
   }
   state.activeDispatches = Math.max(0, state.activeDispatches - 1);
@@ -533,6 +537,7 @@ export const dispatchTelegramMessage = async ({
   });
   let replyFenceGeneration: number | undefined;
   const roomEventAbortController = isRoomEvent ? new AbortController() : undefined;
+  const deliveryAbortController = new AbortController();
   let roomEventAbortControllerQueued = false;
   let dispatchWasSuperseded = false;
   const isDispatchSuperseded = () =>
@@ -541,14 +546,24 @@ export const dispatchTelegramMessage = async ({
       key: replyFenceKey.activeKey,
       generation: replyFenceGeneration,
     });
+  const isDeliveryActive = () => !isDispatchSuperseded();
+  const abortDeliveryIfSuperseded = () => {
+    if (isDeliveryActive() || deliveryAbortController.signal.aborted) {
+      return;
+    }
+    deliveryAbortController.abort();
+  };
   const releaseReplyFence = () => {
     if (replyFenceGeneration === undefined) {
       return;
     }
-    endTelegramReplyFence(
-      replyFenceKey.activeKey,
-      roomEventAbortControllerQueued ? undefined : roomEventAbortController,
-    );
+    endTelegramReplyFence(replyFenceKey.activeKey, [
+      deliveryAbortController,
+      ...(roomEventAbortControllerQueued || !roomEventAbortController
+        ? []
+        : [roomEventAbortController]),
+    ]);
+    abortDeliveryIfSuperseded();
     replyFenceGeneration = undefined;
   };
   const draftMaxChars = Math.min(textLimit, 4096);
@@ -940,7 +955,10 @@ export const dispatchTelegramMessage = async ({
   replyFenceGeneration = beginTelegramReplyFence({
     key: replyFenceKey.activeKey,
     supersede: supersedeReplyFence,
-    abortController: roomEventAbortController,
+    abortControllers: [
+      deliveryAbortController,
+      ...(roomEventAbortController ? [roomEventAbortController] : []),
+    ],
   });
 
   const implicitQuoteReplyTargetId =
@@ -1049,7 +1067,7 @@ export const dispatchTelegramMessage = async ({
           });
         }
       : undefined,
-    shouldContinue: () => !isDispatchSuperseded(),
+    shouldContinue: isDeliveryActive,
   };
   const silentErrorReplies = telegramCfg.silentErrorReplies === true;
   const isDmTopic = !isGroup && threadSpec.scope === "dm" && threadSpec.id != null;
@@ -1149,7 +1167,8 @@ export const dispatchTelegramMessage = async ({
       payload: ReplyPayload,
       options?: { durable?: boolean; silent?: boolean },
     ) => {
-      if (isDispatchSuperseded()) {
+      if (!isDeliveryActive()) {
+        abortDeliveryIfSuperseded();
         return false;
       }
       const deliverablePayload = applyQuoteReplyTarget(payload);
@@ -1173,6 +1192,7 @@ export const dispatchTelegramMessage = async ({
             chunkMode,
           },
           silent,
+          signal: deliveryAbortController.signal,
           requiredCapabilities: deriveDurableFinalDeliveryRequirements({
             payload: deliverablePayload,
             replyToId: deliverablePayload.replyToId,
@@ -1184,7 +1204,14 @@ export const dispatchTelegramMessage = async ({
             },
           }),
         });
+        if (!isDeliveryActive()) {
+          abortDeliveryIfSuperseded();
+          return false;
+        }
         if (durable.status === "failed") {
+          if (deliveryAbortController.signal.aborted) {
+            return false;
+          }
           throw durable.error;
         }
         if (durable.status === "handled_visible") {

--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -683,6 +683,37 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     expect(dispatchCall?.ctx?.CommandTargetSharesMessageTimeline).toBe(true);
   });
 
+  it("does not mark identity-linked account-scoped Telegram DMs as target-timeline sharing", async () => {
+    const { handler } = registerAndResolveStatusHandler({
+      cfg: {
+        session: {
+          identityLinks: {
+            primary: ["telegram:200", "telegram:201"],
+          },
+        },
+      },
+      accountId: "personal",
+    });
+    await handler(createTelegramPrivateCommandContext({ userId: 200 }));
+
+    const dispatchCall = (
+      replyMocks.dispatchReplyWithBufferedBlockDispatcher.mock.calls as unknown as Array<
+        [
+          {
+            ctx?: {
+              CommandTargetSessionKey?: string;
+              CommandTargetSharesMessageTimeline?: boolean;
+            };
+          },
+        ]
+      >
+    )[0]?.[0];
+    expect(dispatchCall?.ctx?.CommandTargetSessionKey).toBe(
+      "agent:main:telegram:personal:direct:primary",
+    );
+    expect(dispatchCall?.ctx?.CommandTargetSharesMessageTimeline).toBeUndefined();
+  });
+
   it("uses the target session model when building native argument menus", async () => {
     const cfg = {
       agents: {

--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -1083,12 +1083,21 @@ describe("registerTelegramNativeCommands — session metadata", () => {
 
     const dispatchCall = (
       replyMocks.dispatchReplyWithBufferedBlockDispatcher.mock.calls as unknown as Array<
-        [{ ctx?: { CommandTargetSessionKey?: string; OriginatingTo?: string } }]
+        [
+          {
+            ctx?: {
+              CommandTargetSessionKey?: string;
+              CommandTargetSharesMessageTimeline?: boolean;
+              OriginatingTo?: string;
+            };
+          },
+        ]
       >
     )[0]?.[0];
     expect(dispatchCall?.ctx?.CommandTargetSessionKey).toBe(
       "agent:zu:telegram:group:-1001234567890:topic:42",
     );
+    expect(dispatchCall?.ctx?.CommandTargetSharesMessageTimeline).toBe(true);
     expect(dispatchCall?.ctx?.OriginatingTo).toBe("telegram:-1001234567890:topic:42");
   });
 

--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -1061,6 +1061,37 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     expect(sessionMetaCall?.ctx?.ChatType).toBe("group");
   });
 
+  it("targets topic sessions for native commands when Telegram omits chat.is_forum", async () => {
+    const { handler } = registerAndResolveStatusHandler({
+      cfg: {},
+      allowFrom: ["200"],
+      groupAllowFrom: ["200"],
+      resolveTelegramGroupConfig: () => ({
+        groupConfig: { requireMention: false },
+        topicConfig: { agentId: "zu" },
+      }),
+    });
+    const ctx = createTelegramTopicCommandContext();
+    delete (ctx.message.chat as { is_forum?: boolean }).is_forum;
+    await handler({
+      ...ctx,
+      message: {
+        ...ctx.message,
+        is_topic_message: true,
+      },
+    });
+
+    const dispatchCall = (
+      replyMocks.dispatchReplyWithBufferedBlockDispatcher.mock.calls as unknown as Array<
+        [{ ctx?: { CommandTargetSessionKey?: string; OriginatingTo?: string } }]
+      >
+    )[0]?.[0];
+    expect(dispatchCall?.ctx?.CommandTargetSessionKey).toBe(
+      "agent:zu:telegram:group:-1001234567890:topic:42",
+    );
+    expect(dispatchCall?.ctx?.OriginatingTo).toBe("telegram:-1001234567890:topic:42");
+  });
+
   it("does not mark paired Telegram DM allowlist entries as native group command owners", async () => {
     const { handler, sendMessage } = registerAndResolveStatusHandler({
       cfg: {},

--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -226,6 +226,7 @@ type TelegramPluginCommandSpecs = ReturnType<
 
 function registerAndResolveStatusHandler(params: {
   cfg: OpenClawConfig;
+  accountId?: string;
   allowFrom?: string[];
   groupAllowFrom?: string[];
   storeAllowFrom?: string[];
@@ -237,6 +238,7 @@ function registerAndResolveStatusHandler(params: {
 } {
   const {
     cfg,
+    accountId,
     allowFrom,
     groupAllowFrom,
     storeAllowFrom,
@@ -246,6 +248,7 @@ function registerAndResolveStatusHandler(params: {
   return registerAndResolveCommandHandlerBase({
     commandName: "status",
     cfg,
+    accountId,
     allowFrom: allowFrom ?? ["*"],
     groupAllowFrom: groupAllowFrom ?? [],
     storeAllowFrom,
@@ -258,6 +261,7 @@ function registerAndResolveStatusHandler(params: {
 function registerAndResolveCommandHandlerBase(params: {
   commandName: string;
   cfg: OpenClawConfig;
+  accountId?: string;
   allowFrom: string[];
   groupAllowFrom: string[];
   storeAllowFrom?: string[];
@@ -272,6 +276,7 @@ function registerAndResolveCommandHandlerBase(params: {
   const {
     commandName,
     cfg,
+    accountId,
     allowFrom,
     groupAllowFrom,
     storeAllowFrom,
@@ -302,6 +307,7 @@ function registerAndResolveCommandHandlerBase(params: {
         }),
       } as unknown as NativeCommandTestParams["bot"],
       cfg,
+      accountId,
       allowFrom,
       groupAllowFrom,
       useAccessGroups,
@@ -321,6 +327,7 @@ function registerAndResolveCommandHandlerBase(params: {
 function registerAndResolveCommandHandler(params: {
   commandName: string;
   cfg: OpenClawConfig;
+  accountId?: string;
   allowFrom?: string[];
   groupAllowFrom?: string[];
   storeAllowFrom?: string[];
@@ -335,6 +342,7 @@ function registerAndResolveCommandHandler(params: {
   const {
     commandName,
     cfg,
+    accountId,
     allowFrom,
     groupAllowFrom,
     storeAllowFrom,
@@ -346,6 +354,7 @@ function registerAndResolveCommandHandler(params: {
   return registerAndResolveCommandHandlerBase({
     commandName,
     cfg,
+    accountId,
     allowFrom: allowFrom ?? [],
     groupAllowFrom: groupAllowFrom ?? [],
     storeAllowFrom,
@@ -627,7 +636,7 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     expect(dispatchCall?.ctx?.CommandTargetSharesMessageTimeline).toBeUndefined();
   });
 
-  it("marks isolated Telegram DM peer targets as target-timeline sharing", async () => {
+  it("does not mark account-shared Telegram DM peer targets as target-timeline sharing", async () => {
     const { handler } = registerAndResolveStatusHandler({
       cfg: { session: { dmScope: "per-channel-peer" } },
     });
@@ -646,6 +655,31 @@ describe("registerTelegramNativeCommands — session metadata", () => {
       >
     )[0]?.[0];
     expect(dispatchCall?.ctx?.CommandTargetSessionKey).toBe("agent:main:telegram:direct:200");
+    expect(dispatchCall?.ctx?.CommandTargetSharesMessageTimeline).toBeUndefined();
+  });
+
+  it("marks account-scoped Telegram DM peer targets as target-timeline sharing", async () => {
+    const { handler } = registerAndResolveStatusHandler({
+      cfg: {},
+      accountId: "personal",
+    });
+    await handler(createTelegramPrivateCommandContext());
+
+    const dispatchCall = (
+      replyMocks.dispatchReplyWithBufferedBlockDispatcher.mock.calls as unknown as Array<
+        [
+          {
+            ctx?: {
+              CommandTargetSessionKey?: string;
+              CommandTargetSharesMessageTimeline?: boolean;
+            };
+          },
+        ]
+      >
+    )[0]?.[0];
+    expect(dispatchCall?.ctx?.CommandTargetSessionKey).toBe(
+      "agent:main:telegram:personal:direct:200",
+    );
     expect(dispatchCall?.ctx?.CommandTargetSharesMessageTimeline).toBe(true);
   });
 

--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -714,6 +714,37 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     expect(dispatchCall?.ctx?.CommandTargetSharesMessageTimeline).toBeUndefined();
   });
 
+  it("does not mark identity-linked Telegram DMs as target-timeline sharing when canonical equals the sender", async () => {
+    const { handler } = registerAndResolveStatusHandler({
+      cfg: {
+        session: {
+          identityLinks: {
+            "200": ["telegram:201"],
+          },
+        },
+      },
+      accountId: "personal",
+    });
+    await handler(createTelegramPrivateCommandContext({ userId: 200 }));
+
+    const dispatchCall = (
+      replyMocks.dispatchReplyWithBufferedBlockDispatcher.mock.calls as unknown as Array<
+        [
+          {
+            ctx?: {
+              CommandTargetSessionKey?: string;
+              CommandTargetSharesMessageTimeline?: boolean;
+            };
+          },
+        ]
+      >
+    )[0]?.[0];
+    expect(dispatchCall?.ctx?.CommandTargetSessionKey).toBe(
+      "agent:main:telegram:personal:direct:200",
+    );
+    expect(dispatchCall?.ctx?.CommandTargetSharesMessageTimeline).toBeUndefined();
+  });
+
   it("uses the target session model when building native argument menus", async () => {
     const cfg = {
       agents: {

--- a/extensions/telegram/src/bot-native-commands.session-meta.test.ts
+++ b/extensions/telegram/src/bot-native-commands.session-meta.test.ts
@@ -607,6 +607,48 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     expect(call?.sessionKey).toBe(dispatchCall?.ctx?.CommandTargetSessionKey);
   });
 
+  it("does not mark shared-main Telegram DMs as target-timeline sharing", async () => {
+    const { handler } = registerAndResolveStatusHandler({ cfg: {} });
+    await handler(createTelegramPrivateCommandContext());
+
+    const dispatchCall = (
+      replyMocks.dispatchReplyWithBufferedBlockDispatcher.mock.calls as unknown as Array<
+        [
+          {
+            ctx?: {
+              CommandTargetSessionKey?: string;
+              CommandTargetSharesMessageTimeline?: boolean;
+            };
+          },
+        ]
+      >
+    )[0]?.[0];
+    expect(dispatchCall?.ctx?.CommandTargetSessionKey).toBe("agent:main:main");
+    expect(dispatchCall?.ctx?.CommandTargetSharesMessageTimeline).toBeUndefined();
+  });
+
+  it("marks isolated Telegram DM peer targets as target-timeline sharing", async () => {
+    const { handler } = registerAndResolveStatusHandler({
+      cfg: { session: { dmScope: "per-channel-peer" } },
+    });
+    await handler(createTelegramPrivateCommandContext());
+
+    const dispatchCall = (
+      replyMocks.dispatchReplyWithBufferedBlockDispatcher.mock.calls as unknown as Array<
+        [
+          {
+            ctx?: {
+              CommandTargetSessionKey?: string;
+              CommandTargetSharesMessageTimeline?: boolean;
+            };
+          },
+        ]
+      >
+    )[0]?.[0];
+    expect(dispatchCall?.ctx?.CommandTargetSessionKey).toBe("agent:main:telegram:direct:200");
+    expect(dispatchCall?.ctx?.CommandTargetSharesMessageTimeline).toBe(true);
+  });
+
   it("uses the target session model when building native argument menus", async () => {
     const cfg = {
       agents: {
@@ -1157,10 +1199,18 @@ describe("registerTelegramNativeCommands — session metadata", () => {
     });
     const dispatchCall = (
       replyMocks.dispatchReplyWithBufferedBlockDispatcher.mock.calls as unknown as Array<
-        [{ ctx?: { CommandTargetSessionKey?: string } }]
+        [
+          {
+            ctx?: {
+              CommandTargetSessionKey?: string;
+              CommandTargetSharesMessageTimeline?: boolean;
+            };
+          },
+        ]
       >
     )[0]?.[0];
     expect(dispatchCall?.ctx?.CommandTargetSessionKey).toBe("agent:codex-acp:session-1");
+    expect(dispatchCall?.ctx?.CommandTargetSharesMessageTimeline).toBeUndefined();
     const sessionMetaCall = (
       sessionMocks.recordSessionMetaFromInbound.mock.calls as unknown as Array<
         [{ sessionKey?: string }]

--- a/extensions/telegram/src/bot-native-commands.test.ts
+++ b/extensions/telegram/src/bot-native-commands.test.ts
@@ -19,6 +19,7 @@ import { pluginCommandMocks, resetPluginCommandMocks } from "./test-support/plug
 let registerTelegramNativeCommands: typeof import("./bot-native-commands.js").registerTelegramNativeCommands;
 let parseTelegramNativeCommandCallbackData: typeof import("./bot-native-commands.js").parseTelegramNativeCommandCallbackData;
 let resolveTelegramNativeCommandDisableBlockStreaming: typeof import("./bot-native-commands.js").resolveTelegramNativeCommandDisableBlockStreaming;
+let telegramNativeCommandTesting: typeof import("./bot-native-commands.js").__testing;
 
 type CommandBotHarness = ReturnType<typeof createCommandBot>;
 type TelegramInlineKeyboardReplyMarkup = {
@@ -151,6 +152,7 @@ describe("registerTelegramNativeCommands", () => {
       registerTelegramNativeCommands,
       parseTelegramNativeCommandCallbackData,
       resolveTelegramNativeCommandDisableBlockStreaming,
+      __testing: telegramNativeCommandTesting,
     } = await import("./bot-native-commands.js"));
   });
 
@@ -179,6 +181,22 @@ describe("registerTelegramNativeCommands", () => {
       cfg,
       agentIds: ["butler"],
     });
+  });
+
+  it("retries native runtime imports after a transient dist miss", async () => {
+    let calls = 0;
+    const loader = telegramNativeCommandTesting.createRecoveringTelegramRuntimeLoader(async () => {
+      calls += 1;
+      if (calls === 1) {
+        throw new Error("stable runtime wrapper is not ready");
+      }
+      return { ready: true };
+    });
+
+    await expect(loader()).rejects.toThrow("stable runtime wrapper is not ready");
+    await expect(loader()).resolves.toEqual({ ready: true });
+    await expect(loader()).resolves.toEqual({ ready: true });
+    expect(calls).toBe(2);
   });
 
   it("scopes skill commands to default agent without a matching binding (#15599)", () => {

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -74,6 +74,7 @@ import {
   extractTelegramMessageForumFlag,
   isTelegramCommandsAllowFromConfigured,
   resolveTelegramCommandAuthorization,
+  resolveTelegramDirectPeerId,
   resolveTelegramForumFlag,
   resolveTelegramGroupAllowFromContext,
   resolveTelegramThreadSpec,
@@ -121,6 +122,7 @@ type TelegramResolvedGroupConfig = {
 function telegramCommandTargetSharesMessageTimeline(params: {
   commandTargetSessionKey: string;
   mainSessionKey: string;
+  directPeerId?: string | number | null;
 }): boolean {
   const targetSessionKey = normalizeLowercaseStringOrEmpty(params.commandTargetSessionKey);
   if (
@@ -131,7 +133,17 @@ function telegramCommandTargetSharesMessageTimeline(params: {
   }
   const parsed = parseAgentSessionKey(targetSessionKey);
   const rest = parsed?.rest ?? "";
-  return rest.startsWith("telegram:group:") || /^telegram:[^:]+:direct:/.test(rest);
+  if (rest.startsWith("telegram:group:")) {
+    return true;
+  }
+  const directPeerId = normalizeLowercaseStringOrEmpty(
+    params.directPeerId == null ? "" : String(params.directPeerId),
+  );
+  if (!directPeerId) {
+    return false;
+  }
+  const accountScopedDirect = /^telegram:[^:]+:direct:([^:]+)(?::|$)/.exec(rest);
+  return normalizeLowercaseStringOrEmpty(accountScopedDirect?.[1]) === directPeerId;
 }
 
 type TelegramCommandAuthResult = {
@@ -1156,6 +1168,7 @@ export const registerTelegramNativeCommands = ({
         const commandTargetSharesMessageTimeline = telegramCommandTargetSharesMessageTimeline({
           commandTargetSessionKey,
           mainSessionKey: route.mainSessionKey,
+          directPeerId: isGroup ? undefined : resolveTelegramDirectPeerId({ chatId, senderId }),
         });
         const deliveryBaseOptions = buildCommandDeliveryBaseOptions({
           cfg: executionCfg,

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -71,7 +71,7 @@ import {
   buildTelegramThreadParams,
   buildSenderName,
   buildTelegramGroupFrom,
-  extractTelegramForumFlag,
+  extractTelegramMessageForumFlag,
   isTelegramCommandsAllowFromConfigured,
   resolveTelegramCommandAuthorization,
   resolveTelegramForumFlag,
@@ -377,7 +377,7 @@ async function resolveTelegramNativeCommandThreadContext(params: {
     chatId,
     chatType: msg.chat.type,
     isGroup,
-    isForum: extractTelegramForumFlag(msg.chat),
+    isForum: extractTelegramMessageForumFlag(msg),
     getChat,
   });
   const threadSpec = resolveTelegramThreadSpec({

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -160,24 +160,37 @@ type TelegramNativeCommandThreadContext = {
   threadParams: ReturnType<typeof buildTelegramThreadParams>;
 };
 
-let telegramNativeCommandDeliveryRuntimePromise:
-  | Promise<typeof import("./bot-native-commands.delivery.runtime.js")>
-  | undefined;
-
-async function loadTelegramNativeCommandDeliveryRuntime() {
-  telegramNativeCommandDeliveryRuntimePromise ??=
-    import("./bot-native-commands.delivery.runtime.js");
-  return await telegramNativeCommandDeliveryRuntimePromise;
+function createRecoveringTelegramRuntimeLoader<TModule>(
+  importer: () => Promise<TModule>,
+): () => Promise<TModule> {
+  let runtimePromise: Promise<TModule> | undefined;
+  return async () => {
+    const promise = runtimePromise ?? importer();
+    runtimePromise = promise;
+    try {
+      return await promise;
+    } catch (error) {
+      // A live rebuild can briefly remove the stable runtime wrapper. Do not
+      // poison the long-lived Telegram command process with that transient miss.
+      if (runtimePromise === promise) {
+        runtimePromise = undefined;
+      }
+      throw error;
+    }
+  };
 }
 
-let telegramNativeCommandRuntimePromise:
-  | Promise<typeof import("./bot-native-commands.runtime.js")>
-  | undefined;
+const loadTelegramNativeCommandDeliveryRuntime = createRecoveringTelegramRuntimeLoader(
+  () => import("./bot-native-commands.delivery.runtime.js"),
+);
 
-async function loadTelegramNativeCommandRuntime() {
-  telegramNativeCommandRuntimePromise ??= import("./bot-native-commands.runtime.js");
-  return await telegramNativeCommandRuntimePromise;
-}
+const loadTelegramNativeCommandRuntime = createRecoveringTelegramRuntimeLoader(
+  () => import("./bot-native-commands.runtime.js"),
+);
+
+export const __testing = {
+  createRecoveringTelegramRuntimeLoader,
+};
 
 function resolveTelegramProgressPlaceholder(command: {
   nativeProgressMessages?: Partial<Record<string, string>> & { default?: string };

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -123,6 +123,7 @@ function telegramCommandTargetSharesMessageTimeline(params: {
   commandTargetSessionKey: string;
   mainSessionKey: string;
   directPeerId?: string | number | null;
+  identityLinks?: Record<string, string[]>;
 }): boolean {
   const targetSessionKey = normalizeLowercaseStringOrEmpty(params.commandTargetSessionKey);
   if (
@@ -143,7 +144,50 @@ function telegramCommandTargetSharesMessageTimeline(params: {
     return false;
   }
   const accountScopedDirect = /^telegram:[^:]+:direct:([^:]+)(?::|$)/.exec(rest);
-  return normalizeLowercaseStringOrEmpty(accountScopedDirect?.[1]) === directPeerId;
+  const targetPeerId = normalizeLowercaseStringOrEmpty(accountScopedDirect?.[1]);
+  if (!targetPeerId || targetPeerId !== directPeerId) {
+    return false;
+  }
+  return !telegramIdentityLinksIncludeDirectPeer({
+    identityLinks: params.identityLinks,
+    directPeerId,
+    targetPeerId,
+  });
+}
+
+function telegramIdentityLinksIncludeDirectPeer(params: {
+  identityLinks?: Record<string, string[]>;
+  directPeerId: string;
+  targetPeerId: string;
+}): boolean {
+  const identityLinks = params.identityLinks;
+  if (!identityLinks) {
+    return false;
+  }
+  const candidates = new Set(
+    [
+      params.directPeerId,
+      params.targetPeerId,
+      `telegram:${params.directPeerId}`,
+      `telegram:${params.targetPeerId}`,
+    ]
+      .map((value) => normalizeLowercaseStringOrEmpty(value))
+      .filter(Boolean),
+  );
+  for (const [canonical, ids] of Object.entries(identityLinks)) {
+    if (candidates.has(normalizeLowercaseStringOrEmpty(canonical))) {
+      return true;
+    }
+    if (!Array.isArray(ids)) {
+      continue;
+    }
+    for (const id of ids) {
+      if (candidates.has(normalizeLowercaseStringOrEmpty(id))) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 type TelegramCommandAuthResult = {
@@ -1169,6 +1213,7 @@ export const registerTelegramNativeCommands = ({
           commandTargetSessionKey,
           mainSessionKey: route.mainSessionKey,
           directPeerId: isGroup ? undefined : resolveTelegramDirectPeerId({ chatId, senderId }),
+          identityLinks: executionCfg.session?.identityLinks,
         });
         const deliveryBaseOptions = buildCommandDeliveryBaseOptions({
           cfg: executionCfg,

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -1174,6 +1174,7 @@ export const registerTelegramNativeCommands = ({
           SessionKey: commandSessionKey,
           AccountId: route.accountId,
           CommandTargetSessionKey: commandTargetSessionKey,
+          CommandTargetSharesMessageTimeline: true,
           MessageThreadId: threadSpec.id,
           IsForum: isForum,
           // Originating context for sub-agent announce routing

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -31,7 +31,7 @@ import type {
 } from "openclaw/plugin-sdk/config-contracts";
 import { resolveMarkdownTableMode } from "openclaw/plugin-sdk/markdown-table-runtime";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
-import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
+import { parseAgentSessionKey, resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { getRuntimeConfigSnapshot } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { getChildLogger } from "openclaw/plugin-sdk/runtime-env";
@@ -117,6 +117,26 @@ type TelegramResolvedGroupConfig = {
   groupConfig?: TelegramGroupConfig | TelegramDirectConfig;
   topicConfig?: TelegramTopicConfig;
 };
+
+function telegramCommandTargetSharesMessageTimeline(params: {
+  commandTargetSessionKey: string;
+  mainSessionKey: string;
+}): boolean {
+  const targetSessionKey = normalizeLowercaseStringOrEmpty(params.commandTargetSessionKey);
+  if (
+    !targetSessionKey ||
+    targetSessionKey === normalizeLowercaseStringOrEmpty(params.mainSessionKey)
+  ) {
+    return false;
+  }
+  const parsed = parseAgentSessionKey(targetSessionKey);
+  const rest = parsed?.rest ?? "";
+  return (
+    rest.startsWith("telegram:group:") ||
+    rest.startsWith("telegram:direct:") ||
+    /^telegram:[^:]+:direct:/.test(rest)
+  );
+}
 
 type TelegramCommandAuthResult = {
   chatId: number;
@@ -1124,6 +1144,10 @@ export const registerTelegramNativeCommands = ({
             userId: String(senderId || chatId),
             targetSessionKey: sessionKey,
           });
+        const commandTargetSharesMessageTimeline = telegramCommandTargetSharesMessageTimeline({
+          commandTargetSessionKey,
+          mainSessionKey: route.mainSessionKey,
+        });
         const deliveryBaseOptions = buildCommandDeliveryBaseOptions({
           cfg: executionCfg,
           chatId,
@@ -1174,7 +1198,9 @@ export const registerTelegramNativeCommands = ({
           SessionKey: commandSessionKey,
           AccountId: route.accountId,
           CommandTargetSessionKey: commandTargetSessionKey,
-          CommandTargetSharesMessageTimeline: true,
+          ...(commandTargetSharesMessageTimeline
+            ? { CommandTargetSharesMessageTimeline: true }
+            : {}),
           MessageThreadId: threadSpec.id,
           IsForum: isForum,
           // Originating context for sub-agent announce routing

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -131,11 +131,7 @@ function telegramCommandTargetSharesMessageTimeline(params: {
   }
   const parsed = parseAgentSessionKey(targetSessionKey);
   const rest = parsed?.rest ?? "";
-  return (
-    rest.startsWith("telegram:group:") ||
-    rest.startsWith("telegram:direct:") ||
-    /^telegram:[^:]+:direct:/.test(rest)
-  );
+  return rest.startsWith("telegram:group:") || /^telegram:[^:]+:direct:/.test(rest);
 }
 
 type TelegramCommandAuthResult = {

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -848,6 +848,97 @@ describe("createTelegramBot", () => {
     }
   });
 
+  it("preserves pending debounced text when a non-abort command bypasses the same chat", async () => {
+    const DEBOUNCE_MS = 4321;
+    loadConfig.mockReturnValue({
+      agents: {
+        defaults: {
+          envelopeTimezone: "utc",
+        },
+      },
+      messages: {
+        inbound: {
+          debounceMs: DEBOUNCE_MS,
+        },
+      },
+      channels: {
+        telegram: { dmPolicy: "open", allowFrom: ["*"] },
+      },
+    });
+
+    installPerKeySequentializer();
+
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const startedBodies: string[] = [];
+    replySpy.mockImplementation(async (ctx: MsgContext, opts?: GetReplyOptions) => {
+      await opts?.onReplyStart?.();
+      const body = ctx.Body ?? "";
+      startedBodies.push(body);
+      return { text: `reply:${body}` };
+    });
+
+    const extractLatestDebounceFlush = () => {
+      const debounceCallIndex = setTimeoutSpy.mock.calls.findLastIndex(
+        (call) => call[1] === DEBOUNCE_MS,
+      );
+      expect(debounceCallIndex).toBeGreaterThanOrEqual(0);
+      clearTimeout(
+        setTimeoutSpy.mock.results[debounceCallIndex]?.value as ReturnType<typeof setTimeout>,
+      );
+      return setTimeoutSpy.mock.calls[debounceCallIndex]?.[0] as (() => Promise<void>) | undefined;
+    };
+
+    try {
+      createTelegramBot({ token: "tok" });
+      const messageHandler = getOnHandler("message") as (
+        ctx: TelegramMiddlewareTestContext,
+      ) => Promise<void>;
+
+      await runTelegramMiddlewareChain({
+        ctx: {
+          update: { update_id: 111 },
+          message: {
+            chat: { id: 7, type: "private" },
+            text: "first",
+            date: 1736380800,
+            message_id: 111,
+            from: { id: 42, first_name: "Ada" },
+          },
+          me: { username: "openclaw_bot" },
+          getFile: async () => ({}),
+        },
+        finalHandler: messageHandler,
+      });
+
+      const flushFirst = extractLatestDebounceFlush();
+
+      await runTelegramMiddlewareChain({
+        ctx: {
+          update: { update_id: 112 },
+          message: {
+            chat: { id: 7, type: "private" },
+            text: "/status",
+            date: 1736380801,
+            message_id: 112,
+            from: { id: 42, first_name: "Ada" },
+          },
+          me: { username: "openclaw_bot" },
+          getFile: async () => ({}),
+        },
+        finalHandler: messageHandler,
+      });
+
+      expect(startedBodies.some((body) => body.includes("first"))).toBe(false);
+      await flushFirst?.();
+
+      await vi.waitFor(() => {
+        expect(startedBodies.some((body) => body.includes("first"))).toBe(true);
+      });
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
   it("routes callback_query payloads as messages and answers callbacks", async () => {
     createTelegramBot({ token: "tok" });
     const callbackHandler = requireValue(

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -731,6 +731,123 @@ describe("createTelegramBot", () => {
     }
   });
 
+  it("lets stop bypass an active same-chat inbound debounce chain", async () => {
+    const DEBOUNCE_MS = 4321;
+    loadConfig.mockReturnValue({
+      agents: {
+        defaults: {
+          envelopeTimezone: "utc",
+        },
+      },
+      messages: {
+        inbound: {
+          debounceMs: DEBOUNCE_MS,
+        },
+      },
+      channels: {
+        telegram: { dmPolicy: "open", allowFrom: ["*"] },
+      },
+    });
+
+    installPerKeySequentializer();
+
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const startedBodies: string[] = [];
+    let releaseFirstRun: (() => void) | undefined;
+    const firstRunGate = new Promise<void>((resolve) => {
+      releaseFirstRun = resolve;
+    });
+
+    replySpy.mockImplementation(async (ctx: MsgContext, opts?: GetReplyOptions) => {
+      await opts?.onReplyStart?.();
+      const body = ctx.Body ?? "";
+      startedBodies.push(body);
+      if (body.includes("first")) {
+        await firstRunGate;
+      }
+      return { text: `reply:${body}` };
+    });
+
+    const extractLatestDebounceFlush = () => {
+      const debounceCallIndex = setTimeoutSpy.mock.calls.findLastIndex(
+        (call) => call[1] === DEBOUNCE_MS,
+      );
+      expect(debounceCallIndex).toBeGreaterThanOrEqual(0);
+      clearTimeout(
+        setTimeoutSpy.mock.results[debounceCallIndex]?.value as ReturnType<typeof setTimeout>,
+      );
+      return setTimeoutSpy.mock.calls[debounceCallIndex]?.[0] as (() => Promise<void>) | undefined;
+    };
+
+    try {
+      createTelegramBot({ token: "tok" });
+      const messageHandler = getOnHandler("message") as (
+        ctx: TelegramMiddlewareTestContext,
+      ) => Promise<void>;
+
+      await runTelegramMiddlewareChain({
+        ctx: {
+          update: { update_id: 101 },
+          message: {
+            chat: { id: 7, type: "private" },
+            text: "first",
+            date: 1736380800,
+            message_id: 101,
+            from: { id: 42, first_name: "Ada" },
+          },
+          me: { username: "openclaw_bot" },
+          getFile: async () => ({}),
+        },
+        finalHandler: messageHandler,
+      });
+
+      const flushFirst = extractLatestDebounceFlush();
+      const firstFlush = flushFirst?.();
+
+      await vi.waitFor(() => {
+        expect(startedBodies).toHaveLength(1);
+        expect(startedBodies[0]).toContain("first");
+      });
+
+      await runTelegramMiddlewareChain({
+        ctx: {
+          update: { update_id: 102 },
+          message: {
+            chat: { id: 7, type: "private" },
+            text: "stop",
+            date: 1736380801,
+            message_id: 102,
+            from: { id: 42, first_name: "Ada" },
+          },
+          me: { username: "openclaw_bot" },
+          getFile: async () => ({}),
+        },
+        finalHandler: messageHandler,
+      });
+
+      expect(startedBodies).toHaveLength(2);
+      expect(startedBodies[0]).toContain("first");
+      expect(startedBodies[1]).toContain("stop");
+      expect(sendMessageSpy).toHaveBeenCalledWith(
+        7,
+        expect.stringContaining("reply:"),
+        expect.anything(),
+      );
+
+      if (!releaseFirstRun) {
+        throw new Error("Expected first Telegram run release callback to be initialized");
+      }
+      releaseFirstRun();
+      await firstFlush;
+
+      const sentBodies = sendMessageSpy.mock.calls.map((call) => String(call[1]));
+      expect(sentBodies.some((body) => body.includes("reply:first"))).toBe(false);
+    } finally {
+      releaseFirstRun?.();
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
   it("routes callback_query payloads as messages and answers callbacks", async () => {
     createTelegramBot({ token: "tok" });
     const callbackHandler = requireValue(

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -374,13 +374,15 @@ async function deliverMediaReply(params: {
   let visibleFallbackText: string | undefined;
   let first = true;
   let pendingFollowUpText: string | undefined;
+  const assertActive = () => assertTelegramDeliveryActive(params.shouldContinue);
   for (const mediaUrl of params.mediaList) {
-    assertTelegramDeliveryActive(params.shouldContinue);
+    assertActive();
     const isFirstMedia = first;
     const media = await params.mediaLoader(
       mediaUrl,
       buildOutboundMediaLoadOptions({ mediaLocalRoots: params.mediaLocalRoots }),
     );
+    assertActive();
     const kind = kindFromMime(media.contentType ?? undefined);
     const isGif = isGifMedia({
       contentType: media.contentType,
@@ -405,6 +407,7 @@ async function deliverMediaReply(params: {
     });
     const shouldAttachButtonsToMedia = isFirstMedia && params.replyMarkup && !followUpText;
     const videoDimensions = kind === "video" ? await probeVideoDimensions(media.buffer) : undefined;
+    assertActive();
     const mediaParams: Record<string, unknown> = {
       caption: htmlCaption,
       ...(htmlCaption ? { parse_mode: "HTML" } : {}),
@@ -426,8 +429,10 @@ async function deliverMediaReply(params: {
         runtime: params.runtime,
         thread: params.thread,
         requestParams: mediaParams,
-        send: (effectiveParams) =>
-          params.bot.api.sendAnimation(params.chatId, file, { ...effectiveParams }),
+        send: (effectiveParams) => {
+          assertActive();
+          return params.bot.api.sendAnimation(params.chatId, file, { ...effectiveParams });
+        },
       });
       if (firstDeliveredMessageId == null) {
         firstDeliveredMessageId = result.message_id;
@@ -439,8 +444,10 @@ async function deliverMediaReply(params: {
         runtime: params.runtime,
         thread: params.thread,
         requestParams: mediaParams,
-        send: (effectiveParams) =>
-          params.bot.api.sendPhoto(params.chatId, file, { ...effectiveParams }),
+        send: (effectiveParams) => {
+          assertActive();
+          return params.bot.api.sendPhoto(params.chatId, file, { ...effectiveParams });
+        },
       });
       if (firstDeliveredMessageId == null) {
         firstDeliveredMessageId = result.message_id;
@@ -452,8 +459,10 @@ async function deliverMediaReply(params: {
         runtime: params.runtime,
         thread: params.thread,
         requestParams: mediaParams,
-        send: (effectiveParams) =>
-          params.bot.api.sendVideo(params.chatId, file, { ...effectiveParams }),
+        send: (effectiveParams) => {
+          assertActive();
+          return params.bot.api.sendVideo(params.chatId, file, { ...effectiveParams });
+        },
       });
       if (firstDeliveredMessageId == null) {
         firstDeliveredMessageId = result.message_id;
@@ -477,8 +486,10 @@ async function deliverMediaReply(params: {
             thread: params.thread,
             requestParams,
             shouldLog,
-            send: (effectiveParams) =>
-              params.bot.api.sendVoice(params.chatId, file, { ...effectiveParams }),
+            send: (effectiveParams) => {
+              assertActive();
+              return params.bot.api.sendVoice(params.chatId, file, { ...effectiveParams });
+            },
           });
           if (firstDeliveredMessageId == null) {
             firstDeliveredMessageId = result.message_id;
@@ -486,6 +497,7 @@ async function deliverMediaReply(params: {
           markDelivered(params.progress);
         };
         await params.onVoiceRecording?.();
+        assertActive();
         try {
           await sendVoiceMedia(mediaParams, (err) => !isVoiceMessagesForbidden(err));
         } catch (voiceErr) {
@@ -563,8 +575,10 @@ async function deliverMediaReply(params: {
           runtime: params.runtime,
           thread: params.thread,
           requestParams: mediaParams,
-          send: (effectiveParams) =>
-            params.bot.api.sendAudio(params.chatId, file, { ...effectiveParams }),
+          send: (effectiveParams) => {
+            assertActive();
+            return params.bot.api.sendAudio(params.chatId, file, { ...effectiveParams });
+          },
         });
         if (firstDeliveredMessageId == null) {
           firstDeliveredMessageId = result.message_id;
@@ -577,8 +591,10 @@ async function deliverMediaReply(params: {
         runtime: params.runtime,
         thread: params.thread,
         requestParams: mediaParams,
-        send: (effectiveParams) =>
-          params.bot.api.sendDocument(params.chatId, file, { ...effectiveParams }),
+        send: (effectiveParams) => {
+          assertActive();
+          return params.bot.api.sendDocument(params.chatId, file, { ...effectiveParams });
+        },
       });
       if (firstDeliveredMessageId == null) {
         firstDeliveredMessageId = result.message_id;

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -63,6 +63,7 @@ const silentReplyLogger = createSubsystemLogger("telegram/silent-reply");
 type DeliveryProgress = ReplyThreadDeliveryProgress & {
   deliveredCount: number;
 };
+type ShouldContinueDelivery = () => boolean;
 
 type TelegramReplyChannelData = {
   buttons?: TelegramInlineButtons;
@@ -77,6 +78,23 @@ type TelegramReplyQuoteForSend = {
 };
 
 type ChunkTextFn = (markdown: string) => ReturnType<typeof markdownToTelegramChunks>;
+
+class TelegramDeliveryCancelledError extends Error {
+  constructor() {
+    super("telegram delivery cancelled");
+    this.name = "TelegramDeliveryCancelledError";
+  }
+}
+
+function assertTelegramDeliveryActive(shouldContinue?: ShouldContinueDelivery): void {
+  if (shouldContinue && !shouldContinue()) {
+    throw new TelegramDeliveryCancelledError();
+  }
+}
+
+function isTelegramDeliveryCancelledError(err: unknown): err is TelegramDeliveryCancelledError {
+  return err instanceof TelegramDeliveryCancelledError;
+}
 
 function buildChunkTextResolver(params: {
   textLimit: number;
@@ -176,6 +194,7 @@ async function deliverTextReply(params: {
   replyToId?: number;
   replyToMode: ReplyToMode;
   progress: DeliveryProgress;
+  shouldContinue?: ShouldContinueDelivery;
 }): Promise<number | undefined> {
   let firstDeliveredMessageId: number | undefined;
   const chunks = filterEmptyTelegramTextChunks(params.chunkText(params.replyText));
@@ -188,6 +207,7 @@ async function deliverTextReply(params: {
     replyQuoteText: params.replyQuoteText,
     markDelivered,
     sendChunk: async ({ chunk, replyToMessageId, replyMarkup, replyQuoteText }) => {
+      assertTelegramDeliveryActive(params.shouldContinue);
       const messageId = await sendTelegramText(
         params.bot,
         params.chatId,
@@ -228,6 +248,7 @@ async function sendPendingFollowUpText(params: {
   replyToId?: number;
   replyToMode: ReplyToMode;
   progress: DeliveryProgress;
+  shouldContinue?: ShouldContinueDelivery;
 }): Promise<void> {
   const chunks = filterEmptyTelegramTextChunks(params.chunkText(params.text));
   await sendChunkedTelegramReplyText({
@@ -238,6 +259,7 @@ async function sendPendingFollowUpText(params: {
     replyMarkup: params.replyMarkup,
     markDelivered,
     sendChunk: async ({ chunk, replyToMessageId, replyMarkup }) => {
+      assertTelegramDeliveryActive(params.shouldContinue);
       await sendTelegramText(params.bot, params.chatId, chunk.html, params.runtime, {
         replyToMessageId,
         thread: params.thread,
@@ -290,11 +312,13 @@ async function sendTelegramVoiceFallbackText(opts: {
   silent?: boolean;
   replyMarkup?: ReturnType<typeof buildInlineKeyboard>;
   replyQuoteText?: string;
+  shouldContinue?: ShouldContinueDelivery;
 }): Promise<number | undefined> {
   let firstDeliveredMessageId: number | undefined;
   const chunks = filterEmptyTelegramTextChunks(opts.chunkText(opts.text));
   let appliedReplyTo = false;
   for (let i = 0; i < chunks.length; i += 1) {
+    assertTelegramDeliveryActive(opts.shouldContinue);
     const chunk = chunks[i];
     // Only apply reply reference, quote text, and buttons to the first chunk.
     const replyToForChunk = !appliedReplyTo ? opts.replyToId : undefined;
@@ -344,12 +368,14 @@ async function deliverMediaReply(params: {
   replyToId?: number;
   replyToMode: ReplyToMode;
   progress: DeliveryProgress;
+  shouldContinue?: ShouldContinueDelivery;
 }): Promise<{ firstDeliveredMessageId?: number; visibleFallbackText?: string }> {
   let firstDeliveredMessageId: number | undefined;
   let visibleFallbackText: string | undefined;
   let first = true;
   let pendingFollowUpText: string | undefined;
   for (const mediaUrl of params.mediaList) {
+    assertTelegramDeliveryActive(params.shouldContinue);
     const isFirstMedia = first;
     const media = await params.mediaLoader(
       mediaUrl,
@@ -491,6 +517,7 @@ async function deliverMediaReply(params: {
               silent: params.silent,
               replyMarkup: params.replyMarkup,
               replyQuoteText: params.replyQuoteText,
+              shouldContinue: params.shouldContinue,
             });
             if (firstDeliveredMessageId == null) {
               firstDeliveredMessageId = fallbackMessageId;
@@ -521,6 +548,7 @@ async function deliverMediaReply(params: {
                 linkPreview: params.linkPreview,
                 silent: params.silent,
                 replyMarkup: params.replyMarkup,
+                shouldContinue: params.shouldContinue,
               });
               visibleFallbackText = fallbackText;
             }
@@ -572,6 +600,7 @@ async function deliverMediaReply(params: {
         replyToId: params.replyToId,
         replyToMode: params.replyToMode,
         progress: params.progress,
+        shouldContinue: params.shouldContinue,
       });
       pendingFollowUpText = undefined;
     }
@@ -716,6 +745,8 @@ export async function deliverReplies(params: {
   replyQuoteByMessageId?: TelegramNativeQuoteCandidateByMessageId;
   /** Override media loader (tests). */
   mediaLoader?: typeof loadWebMedia;
+  /** Return false when a newer turn or stop command has superseded this delivery. */
+  shouldContinue?: ShouldContinueDelivery;
   transcriptMirror?: (payload: { text?: string; mediaUrls?: string[] }) => Promise<void> | void;
 }): Promise<{ delivered: boolean }> {
   const progress: DeliveryProgress = {
@@ -762,6 +793,9 @@ export async function deliverReplies(params: {
     });
   }
   for (const originalReply of normalizedReplies) {
+    if (params.shouldContinue && !params.shouldContinue()) {
+      return { delivered: progress.hasDelivered };
+    }
     let reply = originalReply;
     const mediaList = reply?.mediaUrls?.length
       ? reply.mediaUrls
@@ -835,6 +869,9 @@ export async function deliverReplies(params: {
           : { ...reply, text: hookResult.content };
       }
     }
+    if (params.shouldContinue && !params.shouldContinue()) {
+      return { delivered: progress.hasDelivered };
+    }
 
     let contentForSentHook =
       reply.text || (reply.audioAsVoice === true ? resolveVoiceFallbackText(reply) : "") || "";
@@ -868,6 +905,7 @@ export async function deliverReplies(params: {
           replyToId,
           replyToMode: params.replyToMode,
           progress,
+          shouldContinue: params.shouldContinue,
         });
       } else {
         const mediaDelivery = await deliverMediaReply({
@@ -892,6 +930,7 @@ export async function deliverReplies(params: {
           replyToId,
           replyToMode: params.replyToMode,
           progress,
+          shouldContinue: params.shouldContinue,
         });
         firstDeliveredMessageId = mediaDelivery.firstDeliveredMessageId;
         if (mediaDelivery.visibleFallbackText) {
@@ -923,6 +962,9 @@ export async function deliverReplies(params: {
         groupId: params.mirrorGroupId,
       });
     } catch (error) {
+      if (isTelegramDeliveryCancelledError(error)) {
+        return { delivered: progress.hasDelivered };
+      }
       emitMessageSentHooks({
         hookRunner,
         enabled: hasMessageSentHooks,

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -1431,6 +1431,40 @@ describe("deliverReplies", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
+  it("does not send media when the continuation predicate flips false after loading media", async () => {
+    const runtime = createRuntime();
+    const sendPhoto = vi.fn().mockResolvedValue({
+      message_id: 30,
+      chat: { id: "123" },
+    });
+    const bot = createBot({ sendPhoto });
+    let active = true;
+    const mediaLoader = vi.fn(async () => {
+      active = false;
+      return {
+        buffer: Buffer.from("img"),
+        contentType: "image/jpeg",
+        fileName: "a.jpg",
+      };
+    });
+
+    const result = await deliverReplies({
+      replies: [{ mediaUrls: ["https://a.jpg"] }],
+      chatId: "123",
+      token: "tok",
+      runtime,
+      bot,
+      replyToMode: "off",
+      textLimit: 4000,
+      mediaLoader: mediaLoader as typeof loadWebMedia,
+      shouldContinue: () => active,
+    });
+
+    expect(result.delivered).toBe(false);
+    expect(mediaLoader).toHaveBeenCalledTimes(1);
+    expect(sendPhoto).not.toHaveBeenCalled();
+  });
+
   it("replyToMode 'all' applies reply-to to every text chunk", async () => {
     const runtime = createRuntime();
     const sendMessage = vi.fn().mockResolvedValue({

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -1384,6 +1384,53 @@ describe("deliverReplies", () => {
     expect(mockCallArg(sendMessage, 1, 2)).not.toHaveProperty("reply_to_message_id");
   });
 
+  it("stops chunked text delivery when the continuation predicate flips false", async () => {
+    const runtime = createRuntime();
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 20,
+      chat: { id: "123" },
+    });
+    const bot = createBot({ sendMessage });
+
+    const result = await deliverReplies({
+      replies: [{ text: "chunk-one\n\nchunk-two" }],
+      chatId: "123",
+      token: "tok",
+      runtime,
+      bot,
+      replyToMode: "off",
+      textLimit: 12,
+      shouldContinue: () => sendMessage.mock.calls.length === 0,
+    });
+
+    expect(result.delivered).toBe(true);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(firstSendText(sendMessage)).toContain("chunk-one");
+  });
+
+  it("does not send text when the continuation predicate is already false", async () => {
+    const runtime = createRuntime();
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 20,
+      chat: { id: "123" },
+    });
+    const bot = createBot({ sendMessage });
+
+    const result = await deliverReplies({
+      replies: [{ text: "should not send" }],
+      chatId: "123",
+      token: "tok",
+      runtime,
+      bot,
+      replyToMode: "off",
+      textLimit: 4000,
+      shouldContinue: () => false,
+    });
+
+    expect(result.delivered).toBe(false);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
   it("replyToMode 'all' applies reply-to to every text chunk", async () => {
     const runtime = createRuntime();
     const sendMessage = vi.fn().mockResolvedValue({

--- a/extensions/telegram/src/bot/helpers.test.ts
+++ b/extensions/telegram/src/bot/helpers.test.ts
@@ -8,6 +8,7 @@ import {
   getTelegramTextParts,
   hasBotMention,
   isBinaryContent,
+  extractTelegramMessageForumFlag,
   normalizeForwardedContext,
   resolveTelegramDirectPeerId,
   resolveTelegramForumFlag,
@@ -32,6 +33,28 @@ describe("resolveTelegramForumThreadId", () => {
     { isForum: true, messageThreadId: 99, expected: 99 },
   ])("resolves forum topic ids", ({ expected, ...params }) => {
     expect(resolveTelegramForumThreadId(params)).toBe(expected);
+  });
+});
+
+describe("extractTelegramMessageForumFlag", () => {
+  it("uses is_topic_message as a forum hint when chat.is_forum is omitted", () => {
+    expect(
+      extractTelegramMessageForumFlag({
+        chat: { id: -100123, type: "supergroup" },
+        is_topic_message: true,
+        message_thread_id: 42,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps explicit chat.is_forum metadata ahead of topic hints", () => {
+    expect(
+      extractTelegramMessageForumFlag({
+        chat: { id: -100123, type: "supergroup", is_forum: false },
+        is_topic_message: true,
+        message_thread_id: 42,
+      }),
+    ).toBe(false);
   });
 });
 

--- a/extensions/telegram/src/bot/helpers.ts
+++ b/extensions/telegram/src/bot/helpers.ts
@@ -121,6 +121,22 @@ export function extractTelegramForumFlag(value: unknown): boolean | undefined {
   return typeof forum === "boolean" ? forum : undefined;
 }
 
+export function extractTelegramMessageForumFlag(value: unknown): boolean | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const message = value as { chat?: unknown; is_topic_message?: unknown };
+  const chatForum = extractTelegramForumFlag(message.chat);
+  if (typeof chatForum === "boolean") {
+    return chatForum;
+  }
+  const chatType =
+    message.chat && typeof message.chat === "object"
+      ? (message.chat as { type?: unknown }).type
+      : undefined;
+  return chatType === "supergroup" && message.is_topic_message === true ? true : undefined;
+}
+
 export async function resolveTelegramForumFlag(params: {
   chatId: string | number;
   chatType?: Chat["type"];

--- a/extensions/telegram/src/outbound-adapter.test.ts
+++ b/extensions/telegram/src/outbound-adapter.test.ts
@@ -91,6 +91,22 @@ describe("telegramOutbound", () => {
     expect(result).toEqual({ channel: "telegram", messageId: "tg-media" });
   });
 
+  it("forwards abort signals into Telegram sends", async () => {
+    sendMessageTelegramMock.mockResolvedValueOnce({ messageId: "tg-text", chatId: "12345" });
+    const abortController = new AbortController();
+
+    await telegramOutbound.sendText!({
+      cfg: {} as never,
+      to: "12345",
+      text: "hello",
+      deps: { sendTelegram: sendMessageTelegramMock },
+      abortSignal: abortController.signal,
+    });
+
+    const options = lastCallOptions(sendMessageTelegramMock, "12345", "hello");
+    expect(options.abortSignal).toBe(abortController.signal);
+  });
+
   it("sends payload media in sequence and keeps buttons on the first message only", async () => {
     sendMessageTelegramMock
       .mockResolvedValueOnce({ messageId: "tg-1", chatId: "12345" })

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -64,6 +64,7 @@ async function resolveTelegramSendContext(params: {
   threadId?: string | number | null;
   formatting?: OutboundDeliveryFormattingOptions;
   silent?: boolean;
+  abortSignal?: AbortSignal;
   gatewayClientScopes?: readonly string[];
   resolveSend: ResolveTelegramSendFn;
 }): Promise<{
@@ -76,6 +77,7 @@ async function resolveTelegramSendContext(params: {
     replyToMessageId?: number;
     accountId?: string;
     silent?: boolean;
+    abortSignal?: AbortSignal;
     gatewayClientScopes?: readonly string[];
   };
 }> {
@@ -89,6 +91,7 @@ async function resolveTelegramSendContext(params: {
       replyToMessageId: parseTelegramReplyToMessageId(params.replyToId),
       accountId: params.accountId ?? undefined,
       silent: params.silent,
+      ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
       gatewayClientScopes: params.gatewayClientScopes,
       ...(params.formatting?.parseMode === "HTML" ? { textMode: "html" as const } : {}),
     },
@@ -252,6 +255,7 @@ export function createTelegramOutboundAdapter(
         threadId,
         formatting,
         silent,
+        abortSignal,
         gatewayClientScopes,
       }) => {
         const { send, baseOpts } = await resolveTelegramSendContext({
@@ -262,6 +266,7 @@ export function createTelegramOutboundAdapter(
           threadId,
           formatting,
           silent,
+          abortSignal,
           gatewayClientScopes,
           resolveSend,
         });
@@ -283,6 +288,7 @@ export function createTelegramOutboundAdapter(
         formatting,
         forceDocument,
         silent,
+        abortSignal,
         gatewayClientScopes,
       }) => {
         const { send, baseOpts } = await resolveTelegramSendContext({
@@ -293,6 +299,7 @@ export function createTelegramOutboundAdapter(
           threadId,
           formatting,
           silent,
+          abortSignal,
           gatewayClientScopes,
           resolveSend,
         });
@@ -318,6 +325,7 @@ export function createTelegramOutboundAdapter(
       formatting,
       forceDocument,
       silent,
+      abortSignal,
       gatewayClientScopes,
     }) => {
       const { send, baseOpts } = await resolveTelegramSendContext({
@@ -328,6 +336,7 @@ export function createTelegramOutboundAdapter(
         threadId,
         formatting,
         silent,
+        abortSignal,
         gatewayClientScopes,
         resolveSend,
       });

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -801,6 +801,36 @@ describe("sendMessageTelegram", () => {
     ).rejects.toThrow(/returned no message_id/i);
   });
 
+  it("does not send media when the abort signal flips after media loading", async () => {
+    const abortController = new AbortController();
+    const sendPhoto = vi.fn().mockResolvedValue({
+      message_id: 8,
+      chat: { id: "123" },
+    });
+    const api = { sendPhoto } as unknown as {
+      sendPhoto: typeof sendPhoto;
+    };
+    loadWebMedia.mockImplementationOnce(async () => {
+      abortController.abort();
+      return {
+        buffer: Buffer.from("fake-image"),
+        contentType: "image/jpeg",
+        fileName: "photo.jpg",
+      };
+    });
+
+    await expect(
+      sendMessageTelegram("123", "caption", {
+        cfg: TELEGRAM_TEST_CFG,
+        token: "tok",
+        api,
+        mediaUrl: "https://example.com/photo.png",
+        abortSignal: abortController.signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(sendPhoto).not.toHaveBeenCalled();
+  });
+
   it("uses native fetch for BAN compatibility when api is omitted", async () => {
     const originalFetch = globalThis.fetch;
     const originalBun = (globalThis as { Bun?: unknown }).Bun;

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -93,6 +93,7 @@ type TelegramSendOpts = {
   asVideoNote?: boolean;
   /** Send message silently (no notification). Defaults to false. */
   silent?: boolean;
+  abortSignal?: AbortSignal;
   /** Message ID to reply to (for threading) */
   replyToMessageId?: number;
   /** Quote text for Telegram reply_parameters. */
@@ -210,6 +211,14 @@ function createTelegramHttpLogger(cfg: OpenClawConfig) {
     const detail = redactSensitiveText(formatUncaughtError(err.error ?? err));
     diagLogger.warn(`telegram http error (${label}): ${detail}`);
   };
+}
+
+function throwIfTelegramSendAborted(abortSignal?: AbortSignal): void {
+  if (abortSignal?.aborted) {
+    const err = new Error("Operation aborted");
+    err.name = "AbortError";
+    throw err;
+  }
 }
 
 function shouldUseTelegramClientOptionsCache(): boolean {
@@ -606,6 +615,9 @@ export async function sendMessageTelegram(
   text: string,
   opts: TelegramSendOpts,
 ): Promise<TelegramSendResult> {
+  const abortSignal = opts.abortSignal;
+  const assertSendActive = () => throwIfTelegramSendAborted(abortSignal);
+  assertSendActive();
   const { cfg, account, api } = resolveTelegramApiContext(opts);
   const target = parseTelegramTarget(to);
   const chatId = await resolveAndPersistChatId({
@@ -616,6 +628,7 @@ export async function sendMessageTelegram(
     verbose: opts.verbose,
     gatewayClientScopes: opts.gatewayClientScopes,
   });
+  assertSendActive();
   const mediaUrl = opts.mediaUrl?.trim();
   const mediaMaxBytes =
     opts.maxBytes ??
@@ -666,12 +679,14 @@ export async function sendMessageTelegram(
     chunk: TelegramTextChunk,
     params?: TelegramSendMessageParams,
   ) => {
+    assertSendActive();
     return await withTelegramThreadFallback(
       params,
       "message",
       opts.verbose,
       target.chatType !== "direct",
       async (effectiveParams, label) => {
+        assertSendActive();
         const baseParams = effectiveParams ? { ...effectiveParams } : {};
         if (linkPreviewOptions) {
           baseParams.link_preview_options = linkPreviewOptions;
@@ -681,14 +696,16 @@ export async function sendMessageTelegram(
           ...(opts.silent === true ? { disable_notification: true } : {}),
         };
         const hasPlainParams = Object.keys(plainParams).length > 0;
-        const requestPlain = (retryLabel: string) =>
-          requestWithChatNotFound(
+        const requestPlain = (retryLabel: string) => {
+          assertSendActive();
+          return requestWithChatNotFound(
             () =>
               hasPlainParams
                 ? api.sendMessage(chatId, chunk.plainText, plainParams)
                 : api.sendMessage(chatId, chunk.plainText),
             retryLabel,
           );
+        };
         if (!chunk.htmlText) {
           return await requestPlain(label);
         }
@@ -700,11 +717,13 @@ export async function sendMessageTelegram(
         return await withTelegramHtmlParseFallback({
           label,
           verbose: opts.verbose,
-          requestHtml: (retryLabel) =>
-            requestWithChatNotFound(
+          requestHtml: (retryLabel) => {
+            assertSendActive();
+            return requestWithChatNotFound(
               () => api.sendMessage(chatId, htmlText, htmlParams),
               retryLabel,
-            ),
+            );
+          },
           requestPlain,
         });
       },
@@ -730,6 +749,7 @@ export async function sendMessageTelegram(
       if (!chunk) {
         continue;
       }
+      assertSendActive();
       const res = await sendTelegramTextChunk(chunk, buildTextParams(index === chunks.length - 1));
       const messageId = resolveTelegramMessageIdOrThrow(res, context);
       recordSentMessage(chatId, messageId, cfg);
@@ -805,6 +825,7 @@ export async function sendMessageTelegram(
   }
 
   if (mediaUrl) {
+    assertSendActive();
     const media = await loadWebMedia(
       mediaUrl,
       buildOutboundMediaLoadOptions({
@@ -814,6 +835,7 @@ export async function sendMessageTelegram(
         optimizeImages: opts.forceDocument ? false : undefined,
       }),
     );
+    assertSendActive();
     const kind = kindFromMime(media.contentType ?? undefined);
     const isGif = isGifMedia({
       contentType: media.contentType,
@@ -825,6 +847,7 @@ export async function sendMessageTelegram(
       opts.forceDocument === true && (kind === "image" || kind === "video") ? "document" : kind;
     if (deliveryKind === "image" && !isGif) {
       sendImageAsPhoto = await shouldSendTelegramImageAsPhoto(media.buffer);
+      assertSendActive();
     }
     const isVideoNote = deliveryKind === "video" && opts.asVideoNote === true;
     const fileName =
@@ -855,6 +878,7 @@ export async function sendMessageTelegram(
       deliveryKind === "video" && !isVideoNote
         ? await probeVideoDimensions(media.buffer)
         : undefined;
+    assertSendActive();
     const mediaParams = {
       ...(htmlCaption ? { caption: htmlCaption, parse_mode: "HTML" as const } : {}),
       ...baseMediaParams,
@@ -866,15 +890,19 @@ export async function sendMessageTelegram(
       sender: (
         effectiveParams: TelegramThreadScopedParams | undefined,
       ) => Promise<TelegramMessageLike>,
-    ) =>
-      await withTelegramThreadFallback(
+    ) => {
+      assertSendActive();
+      return await withTelegramThreadFallback(
         mediaParams,
         label,
         opts.verbose,
         target.chatType !== "direct",
-        async (effectiveParams, retryLabel) =>
-          requestWithChatNotFound(() => sender(effectiveParams), retryLabel),
+        async (effectiveParams, retryLabel) => {
+          assertSendActive();
+          return requestWithChatNotFound(() => sender(effectiveParams), retryLabel);
+        },
       );
+    };
 
     const mediaSender = (() => {
       if (isGif && deliveryKind !== "document") {
@@ -975,6 +1003,7 @@ export async function sendMessageTelegram(
     // If text was too long for a caption, send it as a separate follow-up message.
     // Use HTML conversion so markdown renders like captions.
     if (needsSeparateText && followUpText) {
+      assertSendActive();
       const textResult = await sendChunkedText(followUpText, "text follow-up send");
       return { messageId: textResult.messageId, chatId: resolvedChatId };
     }
@@ -985,6 +1014,7 @@ export async function sendMessageTelegram(
   if (!text || !text.trim()) {
     throw new Error("Message must be non-empty for Telegram sends");
   }
+  assertSendActive();
   const textResult = await sendChunkedText(text, "text send");
   recordChannelActivity({
     channel: "telegram",

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -170,6 +170,23 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     await flushBuffer(key, buffer);
   };
 
+  const cancelKey = (key: string): boolean => {
+    const buffer = buffers.get(key);
+    if (!buffer) {
+      return false;
+    }
+    if (buffers.get(key) === buffer) {
+      buffers.delete(key);
+    }
+    if (buffer.timeout) {
+      clearTimeout(buffer.timeout);
+      buffer.timeout = null;
+    }
+    buffer.items = [];
+    releaseBuffer(buffer);
+    return true;
+  };
+
   const scheduleFlush = (key: string, buffer: DebounceBuffer<T>) => {
     if (buffer.timeout) {
       clearTimeout(buffer.timeout);
@@ -262,5 +279,5 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     scheduleFlush(key, buffer);
   };
 
-  return { enqueue, flushKey };
+  return { enqueue, flushKey, cancelKey };
 }

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -627,6 +627,29 @@ describe("createInboundDebouncer", () => {
     expect(started).toEqual(["1", "2"]);
   });
 
+  it("cancels buffered keyed turns before they flush", async () => {
+    vi.useFakeTimers();
+    try {
+      const flushed: string[][] = [];
+      const debouncer = createInboundDebouncer<{ key: string; id: string }>({
+        debounceMs: 50,
+        buildKey: (item) => item.key,
+        onFlush: async (items) => {
+          flushed.push(items.map((item) => item.id));
+        },
+      });
+
+      await debouncer.enqueue({ key: "a", id: "1" });
+      expect(debouncer.cancelKey("a")).toBe(true);
+      await vi.advanceTimersByTimeAsync(60);
+
+      expect(flushed).toEqual([]);
+      expect(debouncer.cancelKey("a")).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("swallows onError failures so keyed chains still complete", async () => {
     const calls: string[] = [];
     const debouncer = createInboundDebouncer<{ key: string; id: string }>({

--- a/src/auto-reply/reply/abort-cutoff.ts
+++ b/src/auto-reply/reply/abort-cutoff.ts
@@ -93,7 +93,11 @@ export function shouldSkipMessageByAbortCutoff(params: {
 export function shouldPersistAbortCutoff(params: {
   commandSessionKey?: string;
   targetSessionKey?: string;
+  commandTargetSharesMessageTimeline?: boolean;
 }): boolean {
+  if (params.commandTargetSharesMessageTimeline === true) {
+    return true;
+  }
   const commandSessionKey = normalizeOptionalString(params.commandSessionKey);
   const targetSessionKey = normalizeOptionalString(params.targetSessionKey);
   if (!commandSessionKey || !targetSessionKey) {
@@ -101,6 +105,8 @@ export function shouldPersistAbortCutoff(params: {
   }
   // Native targeted /stop can run from a slash/session-control key while the
   // actual target session uses different message id/timestamp spaces.
-  // Persist cutoff only when command source and target are the same session.
+  // Persist cutoff only when command source and target are the same session,
+  // unless the channel explicitly marks the command turn as sharing the
+  // target session's message timeline.
   return commandSessionKey === targetSessionKey;
 }

--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -118,6 +118,7 @@ describe("abort detection", () => {
     senderId?: string;
     commandSource?: "native" | "text";
     targetSessionKey?: string;
+    targetSharesMessageTimeline?: boolean;
     messageSid?: string;
     timestamp?: number;
   }) {
@@ -134,6 +135,7 @@ describe("abort detection", () => {
         ...(params.senderId ? { SenderId: params.senderId } : {}),
         ...(params.commandSource ? { CommandSource: params.commandSource } : {}),
         ...(params.targetSessionKey ? { CommandTargetSessionKey: params.targetSessionKey } : {}),
+        ...(params.targetSharesMessageTimeline ? { CommandTargetSharesMessageTimeline: true } : {}),
         ...(params.messageSid ? { MessageSid: params.messageSid } : {}),
         ...(typeof params.timestamp === "number" ? { Timestamp: params.timestamp } : {}),
       }),
@@ -568,6 +570,38 @@ describe("abort detection", () => {
     expect(entry.abortedLastRun).toBe(true);
     expect(entry.abortCutoffMessageSid).toBeUndefined();
     expect(entry.abortCutoffTimestamp).toBeUndefined();
+  });
+
+  it("persists cutoff metadata for native /stop when the target shares the message timeline", async () => {
+    const slashSessionKey = "agent:main:telegram:slash:123";
+    const targetSessionKey = "agent:main:telegram:group:-100123:topic:42";
+    const targetSessionId = "session-target";
+    const { storePath, cfg } = await createAbortConfig({
+      sessionIdsByKey: { [targetSessionKey]: targetSessionId },
+    });
+
+    const result = await runStopCommand({
+      cfg,
+      sessionKey: slashSessionKey,
+      from: "telegram:group:-100123:topic:42",
+      to: "slash:123",
+      commandSource: "native",
+      targetSessionKey,
+      targetSharesMessageTimeline: true,
+      messageSid: "1005",
+      timestamp: 1234567890000,
+    });
+
+    expect(result.handled).toBe(true);
+    const store = JSON.parse(await fs.readFile(storePath, "utf8")) as Record<string, unknown>;
+    const entry = store[targetSessionKey] as {
+      abortedLastRun?: boolean;
+      abortCutoffMessageSid?: string;
+      abortCutoffTimestamp?: number;
+    };
+    expect(entry.abortedLastRun).toBe(true);
+    expect(entry.abortCutoffMessageSid).toBe("1005");
+    expect(entry.abortCutoffTimestamp).toBe(1234567890000);
   });
 
   it("fast-abort stops active subagent runs for requester session", async () => {

--- a/src/auto-reply/reply/abort.ts
+++ b/src/auto-reply/reply/abort.ts
@@ -326,6 +326,7 @@ export async function tryFastAbortFromMessage(params: {
     const abortCutoff = shouldPersistAbortCutoff({
       commandSessionKey: ctx.SessionKey,
       targetSessionKey: resolvedTargetKey,
+      commandTargetSharesMessageTimeline: ctx.CommandTargetSharesMessageTimeline,
     })
       ? resolveAbortCutoffFromContext(ctx)
       : undefined;

--- a/src/auto-reply/reply/commands-session-abort.ts
+++ b/src/auto-reply/reply/commands-session-abort.ts
@@ -71,6 +71,7 @@ function resolveAbortCutoffForTarget(params: {
     !shouldPersistAbortCutoff({
       commandSessionKey: params.commandSessionKey,
       targetSessionKey: params.targetSessionKey,
+      commandTargetSharesMessageTimeline: params.ctx.CommandTargetSharesMessageTimeline,
     })
   ) {
     return undefined;

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -230,6 +230,11 @@ export type MsgContext = {
   CommandSource?: "text" | "native";
   CommandTargetSessionKey?: string;
   /**
+   * Internal flag for native commands whose provider message id/timestamp can
+   * safely be used as a cutoff for the targeted conversation session.
+   */
+  CommandTargetSharesMessageTimeline?: boolean;
+  /**
    * Internal flag: command handling prepared trailing prompt text for ACP dispatch.
    * Used for `/new <prompt>` and `/reset <prompt>` on ACP-bound sessions.
    */

--- a/src/channels/inbound-debounce-policy.test.ts
+++ b/src/channels/inbound-debounce-policy.test.ts
@@ -11,6 +11,7 @@ describe("shouldDebounceTextInbound", () => {
     expect(shouldDebounceTextInbound({ text: "   ", cfg })).toBe(false);
     expect(shouldDebounceTextInbound({ text: "hello", cfg, hasMedia: true })).toBe(false);
     expect(shouldDebounceTextInbound({ text: "/status", cfg })).toBe(false);
+    expect(shouldDebounceTextInbound({ text: "stop", cfg })).toBe(false);
   });
 
   it("accepts normal text when debounce is allowed", () => {

--- a/src/channels/inbound-debounce-policy.ts
+++ b/src/channels/inbound-debounce-policy.ts
@@ -1,4 +1,4 @@
-import { hasControlCommand } from "../auto-reply/command-detection.js";
+import { isControlCommandMessage } from "../auto-reply/command-detection.js";
 import type { CommandNormalizeOptions } from "../auto-reply/commands-registry.js";
 import {
   createInboundDebouncer,
@@ -25,7 +25,7 @@ export function shouldDebounceTextInbound(params: {
   if (!text) {
     return false;
   }
-  return !hasControlCommand(text, params.cfg, params.commandOptions);
+  return !isControlCommandMessage(text, params.cfg, params.commandOptions);
 }
 
 export function createChannelInboundDebouncer<T>(

--- a/src/channels/plugins/outbound.types.ts
+++ b/src/channels/plugins/outbound.types.ts
@@ -34,6 +34,7 @@ export type ChannelOutboundContext = {
   identity?: OutboundIdentity;
   deps?: OutboundSendDeps;
   silent?: boolean;
+  abortSignal?: AbortSignal;
   gatewayClientScopes?: readonly string[];
 };
 

--- a/src/channels/turn/durable-delivery.test.ts
+++ b/src/channels/turn/durable-delivery.test.ts
@@ -184,6 +184,27 @@ describe("durable inbound reply delivery", () => {
     expect(latestSendDurableMessageBatchRequest().signal).toBe(controller.signal);
   });
 
+  it("does not send durable replies when the caller stop predicate is already cancelled", async () => {
+    const result = await deliverInboundReplyWithMessageSendContext({
+      cfg: {},
+      channel: "telegram",
+      agentId: "main",
+      info: { kind: "final" },
+      payload: { text: "final" },
+      shouldContinue: () => false,
+      ctxPayload: ctxPayload({
+        OriginatingTo: "chat-1",
+      }),
+    });
+
+    expect(result.status).toBe("failed");
+    if (result.status === "failed") {
+      expect(result.error).toMatchObject({ name: "AbortError" });
+    }
+    expect(mocks.resolveOutboundDurableFinalDeliverySupport).not.toHaveBeenCalled();
+    expect(mocks.sendDurableMessageBatch).not.toHaveBeenCalled();
+  });
+
   it("uses required durability when a caller explicitly requires unknown-send reconciliation", async () => {
     await deliverInboundReplyWithMessageSendContext({
       cfg: {},

--- a/src/channels/turn/durable-delivery.test.ts
+++ b/src/channels/turn/durable-delivery.test.ts
@@ -33,6 +33,7 @@ type SendDurableMessageBatchRequest = {
   to?: string;
   threadId?: string | number | null;
   durability?: string;
+  signal?: AbortSignal;
 };
 
 type DeliverySupportRequest = {
@@ -162,6 +163,25 @@ describe("durable inbound reply delivery", () => {
     });
     expect(mocks.sendDurableMessageBatch).toHaveBeenCalledTimes(1);
     expect(latestSendDurableMessageBatchRequest().durability).toBe("best_effort");
+  });
+
+  it("forwards the caller cancellation signal to durable message delivery", async () => {
+    const controller = new AbortController();
+
+    await deliverInboundReplyWithMessageSendContext({
+      cfg: {},
+      channel: "telegram",
+      agentId: "main",
+      info: { kind: "final" },
+      payload: { text: "final" },
+      signal: controller.signal,
+      ctxPayload: ctxPayload({
+        OriginatingTo: "chat-1",
+      }),
+    });
+
+    expect(mocks.sendDurableMessageBatch).toHaveBeenCalledTimes(1);
+    expect(latestSendDurableMessageBatchRequest().signal).toBe(controller.signal);
   });
 
   it("uses required durability when a caller explicitly requires unknown-send reconciliation", async () => {

--- a/src/channels/turn/durable-delivery.ts
+++ b/src/channels/turn/durable-delivery.ts
@@ -24,6 +24,7 @@ export type DurableInboundReplyDeliveryOptions = Pick<
   replyToId?: string | null;
   requiredCapabilities?: DurableFinalDeliveryRequirements;
   signal?: AbortSignal;
+  shouldContinue?: () => boolean;
 };
 
 export type DurableInboundReplyDeliveryParams = DurableInboundReplyDeliveryOptions & {
@@ -94,6 +95,25 @@ function toDeliveryIntent(intent: OutboundDeliveryIntent): ChannelDeliveryResult
   };
 }
 
+function createDurableDeliveryAbortError(): Error {
+  const err = new Error("Operation aborted");
+  err.name = "AbortError";
+  return err;
+}
+
+function isDurableInboundReplyDeliveryCancelled(
+  params: Pick<DurableInboundReplyDeliveryParams, "shouldContinue" | "signal">,
+): boolean {
+  return params.signal?.aborted === true || params.shouldContinue?.() === false;
+}
+
+function durableDeliveryAbortResult(): Extract<
+  DurableInboundReplyDeliveryResult,
+  { status: "failed" }
+> {
+  return { status: "failed", error: createDurableDeliveryAbortError() };
+}
+
 export function isDurableInboundReplyDeliveryHandled(
   result: DurableInboundReplyDeliveryResult,
 ): result is Extract<
@@ -116,6 +136,9 @@ export async function deliverInboundReplyWithMessageSendContext(
 ): Promise<DurableInboundReplyDeliveryResult> {
   if (params.info.kind !== "final") {
     return { status: "not_applicable", reason: "non_final" };
+  }
+  if (isDurableInboundReplyDeliveryCancelled(params)) {
+    return durableDeliveryAbortResult();
   }
 
   const channel = normalizeDeliverableOutboundChannel(params.channel);
@@ -150,6 +173,9 @@ export async function deliverInboundReplyWithMessageSendContext(
   } catch (err: unknown) {
     return { status: "failed", error: err };
   }
+  if (isDurableInboundReplyDeliveryCancelled(params)) {
+    return durableDeliveryAbortResult();
+  }
   if (!support.ok) {
     return {
       status: "unsupported",
@@ -171,6 +197,9 @@ export async function deliverInboundReplyWithMessageSendContext(
     requesterSenderE164: params.ctxPayload.SenderE164,
   });
 
+  if (isDurableInboundReplyDeliveryCancelled(params)) {
+    return durableDeliveryAbortResult();
+  }
   const send = await sendDurableMessageBatch({
     cfg: params.cfg,
     channel,
@@ -190,6 +219,9 @@ export async function deliverInboundReplyWithMessageSendContext(
     session,
     gatewayClientScopes: params.ctxPayload.GatewayClientScopes,
   });
+  if (isDurableInboundReplyDeliveryCancelled(params)) {
+    return durableDeliveryAbortResult();
+  }
   if (send.status === "failed") {
     return { status: "failed" as const, error: send.error };
   }

--- a/src/channels/turn/durable-delivery.ts
+++ b/src/channels/turn/durable-delivery.ts
@@ -23,6 +23,7 @@ export type DurableInboundReplyDeliveryOptions = Pick<
   to?: string | null;
   replyToId?: string | null;
   requiredCapabilities?: DurableFinalDeliveryRequirements;
+  signal?: AbortSignal;
 };
 
 export type DurableInboundReplyDeliveryParams = DurableInboundReplyDeliveryOptions & {
@@ -185,6 +186,7 @@ export async function deliverInboundReplyWithMessageSendContext(
     mediaAccess: params.mediaAccess,
     silent: params.silent,
     durability,
+    signal: params.signal,
     session,
     gatewayClientScopes: params.ctxPayload.GatewayClientScopes,
   });

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -199,6 +199,7 @@ type ChannelHandlerParams = {
   forceDocument?: boolean;
   silent?: boolean;
   mediaAccess?: OutboundMediaAccess;
+  abortSignal?: AbortSignal;
   gatewayClientScopes?: readonly string[];
   onPlatformSendStart?: () => Promise<void>;
 };
@@ -576,6 +577,7 @@ function createChannelOutboundContextBase(
     mediaAccess: params.mediaAccess,
     mediaLocalRoots: params.mediaAccess?.localRoots,
     mediaReadFile: params.mediaAccess?.readFile,
+    ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
     gatewayClientScopes: params.gatewayClientScopes,
   };
 }
@@ -1381,6 +1383,7 @@ async function deliverOutboundPayloadsCore(
     forceDocument: params.forceDocument,
     silent: params.silent,
     mediaAccess,
+    abortSignal,
     gatewayClientScopes: params.gatewayClientScopes,
     ...(params.onPlatformSendStart ? { onPlatformSendStart: params.onPlatformSendStart } : {}),
   });


### PR DESCRIPTION
## Summary

- Treat Telegram `is_topic_message` as a forum-topic hint when `chat.is_forum` is omitted.
- Keep Telegram message context, native commands, and handler normalization on the same topic route so `stop` and `/stop` target the active topic session.
- Let native Telegram `/stop` persist abort cutoffs only when the target shares the same Telegram message timeline: group/topic keys and account-scoped direct DM keys, not shared-main, account-shared direct DM, or opaque bound sessions.
- Cancel in-flight Telegram delivery loops when a newer user turn or authorized stop supersedes the reply fence, so long chunked/media/voice fallback sends stop after `/stop` instead of continuing to emit queued chunks.
- Recover Telegram native command runtime imports after transient live-build misses so spooled commands and DMs retry in the same gateway process.

## Root Cause

Telegram stop updates were on the fast control lane, but downstream topic detection only trusted `chat.is_forum` or `getChat`. When Telegram omitted `chat.is_forum` and lookup was unavailable, topic messages could resolve to the parent group session instead of `:topic:<id>`.

Native `/stop` also runs under a synthetic `telegram:slash:<user>` command session while targeting the real Telegram peer session. Core cutoff logic skipped different target sessions by design, so targeted native stops needed a Telegram-specific opt-in. That opt-in must be narrow: account-shared `telegram:direct:<user>` DMs can aggregate multiple bot accounts with independent Telegram `message_id` spaces, so only account-scoped direct keys are timeline-safe.

The latest topic `8185` failure exposed another runtime path: even after the stop command superseded the old topic turn, an already-running Telegram delivery loop could keep sending chunked final text because `deliverReplies()` had no cancellation predicate from the reply fence.

A live rebuild also briefly removed the native command runtime wrapper; the long-lived gateway cached the rejected dynamic import, keeping spooled Telegram commands/DMs stuck until process restart.

## Real behavior proof

Behavior addressed: Telegram topic `stop`/`/stop` targets the active topic session, persists safe targeted cutoffs, cancels in-flight Telegram reply delivery, and retries native command runtime imports after transient missing-wrapper failures.

Real environment tested: Temp worktree branch `fix-telegram-topic-stop-immediate` at `2c2b9eabd695cd9533275d79c7830b8dff44c68f`; live `/home/vac/openclaw` after `oc-update --skip-codex` applied PR overlay `#83140` and rebuilt/restarted the gateway.

Exact steps or command run after this patch: `git diff --check`; `node scripts/run-vitest.mjs extensions/telegram/src/bot-native-commands.session-meta.test.ts extensions/telegram/src/bot-native-commands.test.ts extensions/telegram/src/bot/delivery.test.ts extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/bot.create-telegram-bot.test.ts extensions/telegram/src/bot-message-context.topic-agentid.test.ts extensions/telegram/src/sequential-key.test.ts src/auto-reply/reply/abort.test.ts`; `node scripts/build-all.mjs gatewayWatch`; `~/.codex/skills/codex-review/scripts/codex-review --mode branch`; `git push vacopenclaw fix-telegram-topic-stop-immediate`; `oc-update --skip-codex`; `pnpm openclaw gateway status --deep`; live source/dist grep for `shouldContinue`, `TelegramDeliveryCancelledError`, and `telegramCommandTargetSharesMessageTimeline`.

Evidence after fix: Focused Vitest reported `Test Files 8 passed (8)` and `Tests 312 passed (312)`. `node scripts/build-all.mjs gatewayWatch` completed successfully. `codex-review --mode branch` reported `codex-review clean: no accepted/actionable findings reported`. Push updated the PR branch to `2c2b9eabd695cd9533275d79c7830b8dff44c68f`. `oc-update --skip-codex` applied `#83140`, built core/UI, reinstalled the daemon, and health check passed on retry. `pnpm openclaw gateway status --deep` reported runtime `running`, connectivity probe `ok`, and PID `963707`. Live `dist/` contains the new delivery cancellation and native command timeline code.

Observed result after fix: Topic-only Telegram updates preserve `agent:...:telegram:group:<chat>:topic:<id>` routing. Native `/stop` records target cutoffs only for same-timeline Telegram peer sessions. Existing Telegram delivery loops receive `shouldContinue: () => !isDispatchSuperseded()` and stop sending further chunks/media when an authorized stop supersedes the turn. Runtime import misses no longer poison future spooled native command retries.

What was not tested: No fresh human/manual Telegram stop message was sent in topic `8185` after the live overlay deployment. Broad `pnpm check:changed`/full CI was not run locally. `oc-update` security audit still reports pre-existing local config/skill warnings unrelated to this patch.

## Verification

- `git diff --check`
- `node scripts/run-vitest.mjs extensions/telegram/src/bot-native-commands.session-meta.test.ts extensions/telegram/src/bot-native-commands.test.ts extensions/telegram/src/bot/delivery.test.ts extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/bot.create-telegram-bot.test.ts extensions/telegram/src/bot-message-context.topic-agentid.test.ts extensions/telegram/src/sequential-key.test.ts src/auto-reply/reply/abort.test.ts`
- `node scripts/build-all.mjs gatewayWatch`
- `~/.codex/skills/codex-review/scripts/codex-review --mode branch`
- `oc-update --skip-codex`
- `pnpm openclaw gateway status --deep`