### PR TITLE
fix(doctor): clear stale runtime override pins

### DIFF
--- a/extensions/anthropic/doctor-contract-api.ts
+++ b/extensions/anthropic/doctor-contract-api.ts
@@ -1,1 +1,14 @@
+import type { DoctorSessionRouteStateOwner } from "openclaw/plugin-sdk/runtime-doctor";
+
 export const legacyConfigRules = [];
+
+export const sessionRouteStateOwners: DoctorSessionRouteStateOwner[] = [
+  {
+    id: "anthropic",
+    label: "Anthropic",
+    providerIds: ["anthropic", "claude-cli"],
+    runtimeIds: ["claude-cli"],
+    cliSessionKeys: ["claude-cli"],
+    authProfilePrefixes: ["anthropic:", "claude-cli:"],
+  },
+];

--- a/extensions/google/doctor-contract-api.ts
+++ b/extensions/google/doctor-contract-api.ts
@@ -1,0 +1,12 @@
+import type { DoctorSessionRouteStateOwner } from "openclaw/plugin-sdk/runtime-doctor";
+
+export const sessionRouteStateOwners: DoctorSessionRouteStateOwner[] = [
+  {
+    id: "google",
+    label: "Google",
+    providerIds: ["google", "google-gemini-cli", "google-vertex"],
+    runtimeIds: ["google-gemini-cli"],
+    cliSessionKeys: ["google-gemini-cli", "gemini-cli"],
+    authProfilePrefixes: ["google:", "google-gemini-cli:", "google-vertex:", "gemini-cli:"],
+  },
+];

--- a/src/commands/doctor-session-state-providers.test.ts
+++ b/src/commands/doctor-session-state-providers.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { SessionEntry } from "../config/sessions.js";
 import {
   applySessionRouteStateRepair,
   resolveConfiguredDoctorSessionStateRoute,
@@ -13,6 +14,15 @@ const codexOwner = {
   runtimeIds: ["codex", "codex-cli"],
   cliSessionKeys: ["codex-cli"],
   authProfilePrefixes: ["codex:", "codex-cli:", "openai-codex:"],
+};
+
+const anthropicOwner = {
+  id: "anthropic",
+  label: "Anthropic",
+  providerIds: ["anthropic", "claude-cli"],
+  runtimeIds: ["claude-cli"],
+  cliSessionKeys: ["claude-cli"],
+  authProfilePrefixes: ["anthropic:", "claude-cli:"],
 };
 
 describe("doctor session state provider routes", () => {
@@ -103,6 +113,7 @@ describe("doctor session state provider routes", () => {
       fallbackNoticeActiveModel: "openai-codex/gpt-5.4",
       fallbackNoticeReason: "rate-limit",
       agentHarnessId: "codex",
+      agentRuntimeOverride: "codex-cli",
       authProfileOverride: "openai-codex:default",
       authProfileOverrideSource: "auto",
       authProfileOverrideCompactionCount: 2,
@@ -162,6 +173,7 @@ describe("doctor session state provider routes", () => {
     expect(entry.contextTokens).toBeUndefined();
     expect(entry.systemPromptReport).toBeUndefined();
     expect(entry.agentHarnessId).toBeUndefined();
+    expect(entry.agentRuntimeOverride).toBeUndefined();
     expect(entry.authProfileOverride).toBeUndefined();
     expect(entry.authProfileOverrideSource).toBeUndefined();
     expect(entry.authProfileOverrideCompactionCount).toBeUndefined();
@@ -262,5 +274,71 @@ describe("doctor session state provider routes", () => {
     });
 
     expect(scan).toEqual({ repairs: [], manualReview: [] });
+  });
+
+  it("clears stale runtime override-only pins when the owner is no longer configured", () => {
+    const sessionKey = "agent:main:telegram:direct:claude-stale";
+    const entry: SessionEntry & Record<string, unknown> = {
+      sessionId: "sess-stale-claude-cli",
+      updatedAt: 1,
+      agentRuntimeOverride: "claude-cli",
+    };
+
+    expect(storeMayContainPluginSessionRouteState({ [sessionKey]: entry })).toBe(true);
+
+    const scan = scanSessionRouteStateOwners({
+      owners: [anthropicOwner],
+      store: { [sessionKey]: entry },
+      routes: {
+        [sessionKey]: {
+          defaultProvider: "openai",
+          configuredModelRefs: ["openai/gpt-5.5"],
+          runtime: "pi",
+        },
+      },
+    });
+
+    expect(scan).toEqual({
+      manualReview: [],
+      repairs: [
+        {
+          key: sessionKey,
+          ownerId: "anthropic",
+          ownerLabel: "Anthropic",
+          cliSessionKeys: ["claude-cli"],
+          reasons: ["pinned runtime"],
+        },
+      ],
+    });
+
+    expect(applySessionRouteStateRepair({ entry, repair: scan.repairs[0], now: 456 })).toBe(true);
+    expect(entry).toStrictEqual({
+      sessionId: "sess-stale-claude-cli",
+      updatedAt: 456,
+    });
+  });
+
+  it("keeps runtime override-only pins when the owner runtime is still configured", () => {
+    const sessionKey = "agent:main:telegram:direct:claude-current";
+    const entry: Record<string, unknown> = {
+      sessionId: "sess-current-claude-cli",
+      updatedAt: 1,
+      agentRuntimeOverride: "claude-cli",
+    };
+
+    const scan = scanSessionRouteStateOwners({
+      owners: [anthropicOwner],
+      store: { [sessionKey]: entry },
+      routes: {
+        [sessionKey]: {
+          defaultProvider: "anthropic",
+          configuredModelRefs: ["anthropic/claude-sonnet-4-6"],
+          runtime: "claude-cli",
+        },
+      },
+    });
+
+    expect(scan).toEqual({ repairs: [], manualReview: [] });
+    expect(entry.agentRuntimeOverride).toBe("claude-cli");
   });
 });

--- a/src/commands/doctor-session-state-providers.ts
+++ b/src/commands/doctor-session-state-providers.ts
@@ -114,6 +114,7 @@ function entryMayContainPluginSessionRouteState(entry: SessionEntry): boolean {
     normalizeString(record.modelProvider) !== undefined ||
     normalizeString(record.model) !== undefined ||
     normalizeString(record.agentHarnessId) !== undefined ||
+    normalizeString(record.agentRuntimeOverride) !== undefined ||
     record.cliSessionBindings !== undefined ||
     record.cliSessionIds !== undefined ||
     normalizeString(record.authProfileOverride) !== undefined ||
@@ -285,7 +286,11 @@ function scanEntryForOwner(params: {
       addReason(reasons, "runtime model state");
     }
     const harnessId = normalizeString(params.entry.agentHarnessId);
-    if (harnessId && runtimeIds.has(normalizeProviderId(harnessId))) {
+    const runtimeOverride = normalizeString(params.entry.agentRuntimeOverride);
+    if (
+      (harnessId && runtimeIds.has(normalizeProviderId(harnessId))) ||
+      (runtimeOverride && runtimeIds.has(normalizeProviderId(runtimeOverride)))
+    ) {
       addReason(reasons, "pinned runtime");
     }
     if (hasOwnedCliSession({ entry: params.entry, cliSessionKeys })) {
@@ -397,6 +402,7 @@ export function applySessionRouteStateRepair(params: {
   }
   if (params.repair.reasons.includes("pinned runtime")) {
     clear("agentHarnessId");
+    clear("agentRuntimeOverride");
   }
   if (params.repair.reasons.includes("CLI session binding")) {
     changed =


### PR DESCRIPTION
## Summary

- Teach doctor session route-state scanning to notice `agentRuntimeOverride`-only entries.
- Treat plugin-owned `agentRuntimeOverride` values like stale pinned runtime state and clear them with `agentHarnessId` during `doctor --fix` repair.
- Register Anthropic and Google doctor session route-state ownership metadata so stale `claude-cli` / `google-gemini-cli` pins can be detected beyond the legacy Codex path.

## Change Type

- [x] Bug fix

## Scope

- [x] CLI / doctor
- [x] Plugin contracts
- [x] Tests

## Linked Issue/PR

- Closes #83098
- [x] This PR fixes a bug or regression

## Real behavior proof

Behavior or issue addressed: `doctor --fix` previously only cleaned legacy Codex stale route pins. A session containing only `agentRuntimeOverride: "claude-cli"` was not even scanned, so stale Claude/other CLI runtime pins could persist after the configured route moved back to PI/OpenAI.

Real environment tested: macOS source checkout of `openclaw/openclaw`, branch `fix/83098-doctor-runtime-pins`, Node/pnpm workspace with existing dependencies, rebased onto `upstream/main` at `aaf85166`, commit `94789d296944c442faf64e7ccb3b16c6971cbf34`.

Exact steps or command run after this patch:

```bash
pnpm --config.verify-deps-before-run=false test src/commands/doctor-session-state-providers.test.ts -- --reporter=dot
pnpm --config.verify-deps-before-run=false test src/commands/doctor-session-state-providers.test.ts src/plugins/doctor-contract-registry.test.ts -- --reporter=dot
pnpm --config.verify-deps-before-run=false exec oxfmt --check --threads=1 src/commands/doctor-session-state-providers.ts src/commands/doctor-session-state-providers.test.ts extensions/anthropic/doctor-contract-api.ts extensions/google/doctor-contract-api.ts
git diff --cached --check
pnpm --config.verify-deps-before-run=false check:changed --staged
```

Evidence after fix:

```text
$ pnpm --config.verify-deps-before-run=false test src/commands/doctor-session-state-providers.test.ts -- --reporter=dot
[test] passed 1 Vitest shard in 46.62s
Test Files  1 passed (1)
Tests  9 passed (9)

$ pnpm --config.verify-deps-before-run=false test src/commands/doctor-session-state-providers.test.ts src/plugins/doctor-contract-registry.test.ts -- --reporter=dot
[test] passed 2 Vitest shards in 79.70s
Test Files  1 passed (1) / 1 passed (1)
Tests  9 passed (9) / 9 passed (9)

$ pnpm --config.verify-deps-before-run=false exec oxfmt --check --threads=1 src/commands/doctor-session-state-providers.ts src/commands/doctor-session-state-providers.test.ts extensions/anthropic/doctor-contract-api.ts extensions/google/doctor-contract-api.ts
All matched files use the correct format.
Finished in 198ms on 4 files using 1 threads.

$ pnpm --config.verify-deps-before-run=false check:changed --staged
[check:changed] lanes=core, coreTests, extensions, extensionTests
[check:changed] typecheck core
[check:changed] typecheck core tests
[check:changed] typecheck extensions
[check:changed] typecheck extension tests
[check:changed] lint core
Found 0 warnings and 0 errors.
[check:changed] lint extensions
Found 0 warnings and 0 errors.
[check:changed] runtime import cycles
Import cycle check: 0 runtime value cycle(s).
(exit code 0)
```

Observed result after fix: the new regression proves an entry with only `agentRuntimeOverride: "claude-cli"` makes `storeMayContainPluginSessionRouteState(...)` return true, scans as a stale Anthropic pinned runtime when the configured route is PI/OpenAI, and `applySessionRouteStateRepair(...)` removes `agentRuntimeOverride` while updating `updatedAt`. A negative control keeps the runtime override when the route is still configured for the Anthropic/Claude runtime.

What was not tested: a live `openclaw doctor --fix` run against a user's real session-store file; the behavior is covered at the doctor session route-state repair seam with in-memory session entries and plugin owner metadata, without touching local user state.

Before evidence: in a temporary upstream-main red worktree, the new regression failed because runtime override-only entries were skipped and stale `agentRuntimeOverride` was not removed by pinned-runtime repair. After this patch the same regression passes in the focused Vitest command above.

## Root Cause

- `storeMayContainPluginSessionRouteState(...)` did not include `agentRuntimeOverride`, so runtime override-only session entries skipped plugin route-state scanning.
- The stale pinned runtime detector looked only at `agentHarnessId`, not `agentRuntimeOverride`.
- The repair path for `pinned runtime` cleared `agentHarnessId` but left `agentRuntimeOverride` behind.
- Anthropic/Google plugins did not expose doctor `sessionRouteStateOwners`, leaving their CLI runtime pins outside the generic cleanup path.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Seam / integration test
- Target test file: `src/commands/doctor-session-state-providers.test.ts`
- Scenario locked in: runtime override-only stale pins are detected and repaired when their owner is no longer configured, while current configured runtime overrides are preserved.
- Existing adjacent coverage: `src/plugins/doctor-contract-registry.test.ts` confirms plugin doctor contracts still load through the registry.

## User-visible / Behavior Changes

`openclaw doctor --fix` can now clean stale plugin-owned CLI runtime overrides such as `claude-cli` / `google-gemini-cli`, not just legacy Codex `agentHarnessId` state, when the session route no longer allows that owner.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: doctor could over-clear a runtime override that is still valid for the current route.
  - Mitigation: the scan still checks configured provider/model/runtime ownership first; the negative regression keeps `claude-cli` when the route is configured for Anthropic/Claude.
- Risk: new plugin owner metadata could classify aliases too broadly.
  - Mitigation: ownership is limited to the plugin's provider/runtime/session-key prefixes and uses the existing doctor route-state ownership API.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.
