### PR TITLE
fix(doctor): clear stale runtime override pins [AI-assisted]

### DIFF
--- a/extensions/anthropic/doctor-contract-api.test.ts
+++ b/extensions/anthropic/doctor-contract-api.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { legacyConfigRules, sessionRouteStateOwners } from "./doctor-contract-api.js";
+
+describe("anthropic doctor contract", () => {
+  it("owns Claude CLI session route state for doctor cleanup", () => {
+    expect(legacyConfigRules).toEqual([]);
+    expect(sessionRouteStateOwners).toEqual([
+      {
+        id: "anthropic",
+        label: "Anthropic",
+        providerIds: ["anthropic", "claude-cli"],
+        runtimeIds: ["claude-cli"],
+        cliSessionKeys: ["claude-cli"],
+        authProfilePrefixes: ["anthropic:", "claude-cli:"],
+      },
+    ]);
+  });
+});

--- a/extensions/google/doctor-contract-api.test.ts
+++ b/extensions/google/doctor-contract-api.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { sessionRouteStateOwners } from "./doctor-contract-api.js";
+
+describe("google doctor contract", () => {
+  it("owns Gemini CLI session route state for doctor cleanup", () => {
+    expect(sessionRouteStateOwners).toEqual([
+      {
+        id: "google",
+        label: "Google",
+        providerIds: ["google", "google-gemini-cli", "google-vertex"],
+        runtimeIds: ["google-gemini-cli"],
+        cliSessionKeys: ["google-gemini-cli"],
+        authProfilePrefixes: ["google:", "google-gemini-cli:", "google-vertex:"],
+      },
+    ]);
+  });
+});

--- a/src/commands/doctor-session-state-providers.test.ts
+++ b/src/commands/doctor-session-state-providers.test.ts
@@ -15,6 +15,24 @@ const codexOwner = {
   authProfilePrefixes: ["codex:", "codex-cli:", "openai-codex:"],
 };
 
+const anthropicOwner = {
+  id: "anthropic",
+  label: "Anthropic",
+  providerIds: ["anthropic", "claude-cli"],
+  runtimeIds: ["claude-cli"],
+  cliSessionKeys: ["claude-cli"],
+  authProfilePrefixes: ["anthropic:", "claude-cli:"],
+};
+
+const googleOwner = {
+  id: "google",
+  label: "Google",
+  providerIds: ["google", "google-gemini-cli", "google-vertex"],
+  runtimeIds: ["google-gemini-cli"],
+  cliSessionKeys: ["google-gemini-cli"],
+  authProfilePrefixes: ["google:", "google-gemini-cli:", "google-vertex:"],
+};
+
 describe("doctor session state provider routes", () => {
   it("skips plugin route-state scans for unrelated recovery metadata", () => {
     expect(
@@ -113,6 +131,7 @@ describe("doctor session state provider routes", () => {
       fallbackNoticeActiveModel: "openai-codex/gpt-5.4",
       fallbackNoticeReason: "rate-limit",
       agentHarnessId: "codex",
+      agentRuntimeOverride: "codex",
       authProfileOverride: "openai-codex:default",
       authProfileOverrideSource: "auto",
       authProfileOverrideCompactionCount: 2,
@@ -145,7 +164,7 @@ describe("doctor session state provider routes", () => {
         ownerId: "codex",
         ownerLabel: "Codex",
         cliSessionKeys: ["codex-cli"],
-        pinnedRuntimeKeys: ["agentHarnessId"],
+        pinnedRuntimeKeys: ["agentHarnessId", "agentRuntimeOverride"],
         reasons: [
           "auto model override",
           "pinned runtime",
@@ -173,6 +192,7 @@ describe("doctor session state provider routes", () => {
     expect(entry.contextTokens).toBeUndefined();
     expect(entry.systemPromptReport).toBeUndefined();
     expect(entry.agentHarnessId).toBeUndefined();
+    expect(entry.agentRuntimeOverride).toBeUndefined();
     expect(entry.authProfileOverride).toBeUndefined();
     expect(entry.authProfileOverrideSource).toBeUndefined();
     expect(entry.authProfileOverrideCompactionCount).toBeUndefined();
@@ -269,6 +289,47 @@ describe("doctor session state provider routes", () => {
     });
   });
 
+  it.each([
+    { owner: anthropicOwner, runtime: "claude-cli", sessionId: "sess-claude-cli" },
+    { owner: googleOwner, runtime: "google-gemini-cli", sessionId: "sess-gemini-cli" },
+  ])("clears stale runtime override-only state for $runtime", ({ owner, runtime, sessionId }) => {
+    const sessionKey = `agent:main:telegram:direct:${runtime}`;
+    const entry: Record<string, unknown> = {
+      sessionId,
+      updatedAt: 1,
+      agentRuntimeOverride: runtime,
+    };
+
+    const scan = scanSessionRouteStateOwners({
+      owners: [owner],
+      store: { [sessionKey]: entry },
+      routes: {
+        [sessionKey]: {
+          defaultProvider: "openai",
+          configuredModelRefs: ["openai/gpt-5.5"],
+          runtime: "pi",
+        },
+      },
+    });
+
+    expect(scan.manualReview).toStrictEqual([]);
+    expect(scan.repairs).toEqual([
+      {
+        key: sessionKey,
+        ownerId: owner.id,
+        ownerLabel: owner.label,
+        cliSessionKeys: [runtime],
+        pinnedRuntimeKeys: ["agentRuntimeOverride"],
+        reasons: ["pinned runtime"],
+      },
+    ]);
+
+    expect(applySessionRouteStateRepair({ entry, repair: scan.repairs[0], now: 456 })).toBe(true);
+    expect(entry.sessionId).toBe(sessionId);
+    expect(entry.updatedAt).toBe(456);
+    expect(entry.agentRuntimeOverride).toBeUndefined();
+  });
+
   it("keeps owner CLI state when owner runtime is still configured", () => {
     const sessionKey = "agent:main:telegram:direct:4";
     const entry: Record<string, unknown> = {
@@ -276,6 +337,7 @@ describe("doctor session state provider routes", () => {
       updatedAt: 1,
       modelProvider: "codex-cli",
       model: "gpt-5.5",
+      agentRuntimeOverride: "codex-cli",
       cliSessionBindings: {
         "codex-cli": { sessionId: "codex-cli-session" },
       },

--- a/src/commands/doctor-session-state-providers.test.ts
+++ b/src/commands/doctor-session-state-providers.test.ts
@@ -237,7 +237,7 @@ describe("doctor session state provider routes", () => {
     ]);
   });
 
-  it("clears stale runtime pins while preserving configured owner model state", () => {
+  it("keeps owner state when owner remains in the configured route", () => {
     const sessionKey = "agent:main:telegram:direct:3";
     const entry: Record<string, unknown> = {
       sessionId: "sess-configured-codex",
@@ -260,33 +260,12 @@ describe("doctor session state provider routes", () => {
         [sessionKey]: {
           defaultProvider: "github-copilot",
           configuredModelRefs: ["github-copilot/gpt-5-mini", "openai-codex/gpt-5.4"],
-          runtime: "pi",
+          runtime: "codex",
         },
       },
     });
 
-    expect(scan.manualReview).toStrictEqual([]);
-    expect(scan.repairs).toEqual([
-      {
-        key: sessionKey,
-        ownerId: "codex",
-        ownerLabel: "Codex",
-        cliSessionKeys: ["codex-cli"],
-        pinnedRuntimeKeys: ["agentHarnessId"],
-        reasons: ["pinned runtime"],
-      },
-    ]);
-
-    expect(applySessionRouteStateRepair({ entry, repair: scan.repairs[0], now: 123 })).toBe(true);
-    expect(entry.updatedAt).toBe(123);
-    expect(entry.providerOverride).toBe("openai-codex");
-    expect(entry.modelOverride).toBe("gpt-5.4");
-    expect(entry.modelProvider).toBe("openai-codex");
-    expect(entry.model).toBe("gpt-5.4");
-    expect(entry.agentHarnessId).toBeUndefined();
-    expect(entry.cliSessionBindings).toStrictEqual({
-      "codex-cli": { sessionId: "codex-session-3" },
-    });
+    expect(scan).toEqual({ repairs: [], manualReview: [] });
   });
 
   it.each([
@@ -327,6 +306,48 @@ describe("doctor session state provider routes", () => {
     expect(applySessionRouteStateRepair({ entry, repair: scan.repairs[0], now: 456 })).toBe(true);
     expect(entry.sessionId).toBe(sessionId);
     expect(entry.updatedAt).toBe(456);
+    expect(entry.agentRuntimeOverride).toBeUndefined();
+  });
+
+  it("clears stale CLI runtime pins even when the provider still matches", () => {
+    const sessionKey = "agent:main:telegram:direct:same-provider";
+    const entry: Record<string, unknown> = {
+      sessionId: "sess-anthropic-pi",
+      updatedAt: 1,
+      modelProvider: "anthropic",
+      model: "claude-opus-4-7",
+      agentRuntimeOverride: "claude-cli",
+    };
+
+    const scan = scanSessionRouteStateOwners({
+      owners: [anthropicOwner],
+      store: { [sessionKey]: entry },
+      routes: {
+        [sessionKey]: {
+          defaultProvider: "anthropic",
+          configuredModelRefs: ["anthropic/claude-opus-4-7"],
+          runtime: "pi",
+        },
+      },
+    });
+
+    expect(scan.manualReview).toStrictEqual([]);
+    expect(scan.repairs).toEqual([
+      {
+        key: sessionKey,
+        ownerId: "anthropic",
+        ownerLabel: "Anthropic",
+        cliSessionKeys: ["claude-cli"],
+        pinnedRuntimeKeys: ["agentRuntimeOverride"],
+        reasons: ["pinned runtime"],
+      },
+    ]);
+
+    expect(applySessionRouteStateRepair({ entry, repair: scan.repairs[0], now: 789 })).toBe(true);
+    expect(entry.sessionId).toBe("sess-anthropic-pi");
+    expect(entry.updatedAt).toBe(789);
+    expect(entry.modelProvider).toBe("anthropic");
+    expect(entry.model).toBe("claude-opus-4-7");
     expect(entry.agentRuntimeOverride).toBeUndefined();
   });
 

--- a/src/commands/doctor-session-state-providers.ts
+++ b/src/commands/doctor-session-state-providers.ts
@@ -235,8 +235,7 @@ function scanEntryForOwner(params: {
   const authProfilePrefixes = normalizePrefixList(params.owner.authProfilePrefixes);
   const routeAllowsOwner = routeAllowsOwnerState({ owner: params.owner, route: params.route });
   const routeRuntime = normalizeString(params.route?.runtime);
-  const routeAllowsOwnerRuntime =
-    routeRuntime !== undefined && runtimeIds.has(normalizeProviderId(routeRuntime));
+  const routeRuntimeId = routeRuntime ? normalizeProviderId(routeRuntime) : undefined;
   const reasons: string[] = [];
   const pinnedRuntimeKeys: string[] = [];
   const directOverride = resolvePersistedOverrideModelRef({
@@ -280,17 +279,21 @@ function scanEntryForOwner(params: {
 
   const explicitOwnedOverride =
     directOverrideIsOwned && directOverrideSource !== undefined && directOverrideSource !== "auto";
-  if (!routeAllowsOwnerRuntime && !explicitOwnedOverride) {
-    const harnessId = normalizeString(params.entry.agentHarnessId);
-    if (harnessId && runtimeIds.has(normalizeProviderId(harnessId))) {
-      addReason(reasons, "pinned runtime");
-      pinnedRuntimeKeys.push("agentHarnessId");
+  if (!explicitOwnedOverride) {
+    for (const key of ["agentHarnessId", "agentRuntimeOverride"] as const) {
+      const runtimeId = normalizeString(params.entry[key]);
+      const normalizedRuntimeId = runtimeId ? normalizeProviderId(runtimeId) : undefined;
+      if (
+        normalizedRuntimeId &&
+        runtimeIds.has(normalizedRuntimeId) &&
+        normalizedRuntimeId !== routeRuntimeId
+      ) {
+        pinnedRuntimeKeys.push(key);
+      }
     }
-    const runtimeOverride = normalizeString(params.entry.agentRuntimeOverride);
-    if (runtimeOverride && runtimeIds.has(normalizeProviderId(runtimeOverride))) {
-      addReason(reasons, "pinned runtime");
-      pinnedRuntimeKeys.push("agentRuntimeOverride");
-    }
+  }
+  if (pinnedRuntimeKeys.length > 0) {
+    addReason(reasons, "pinned runtime");
   }
   if (!routeAllowsOwner && !explicitOwnedOverride) {
     const runtimeModel = normalizeString(params.entry.model);


### PR DESCRIPTION
## Summary

- Problem: `openclaw doctor --fix` could miss stale non-Codex session runtime pins stored only in `agentRuntimeOverride`.
- Why it matters: old CLI runtime choices could keep later channel replies pinned to a runtime after the configured default moved back to PI or another provider.
- What changed: the generic Doctor session-route cleanup now treats plugin-owned `agentRuntimeOverride` values like `agentHarnessId`, and Anthropic/Google expose Doctor ownership for `claude-cli` / `google-gemini-cli`.
- What did NOT change (scope boundary): runtime selection, model config shape, and explicit user model overrides are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #83098
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: stale plugin-owned session route state stored only in `agentRuntimeOverride`, including the case where the provider still matches but the configured route runtime is PI.
- Real environment tested: disposable local OpenClaw state home on the current beta.4 source checkout, no real credentials or network provider calls.
- Exact steps or command run after this patch: seeded a real `sessions.json` with an `anthropic/claude-opus-4-7` session still carrying a stale `claude-cli` runtime override while the configured route runtime was `pi`, then ran the Doctor state-integrity repair path with repairs accepted.
- Evidence after fix:

```text
[sessions/store] pruned stale session entries
proof: disposable local OpenClaw home
configured route: anthropic/claude-opus-4-7 on pi
prompt: Clear stale Anthropic session routing state for 1 session?
change: Cleared stale Anthropic session routing state for 1 session.
same-provider claude runtime override: <removed>
same-provider model state: anthropic/claude-opus-4-7
current pi runtime override: <preserved>
```

- Observed result after fix: Doctor removed the stale Anthropic `claude-cli` runtime override even though the provider still matched, preserved the Anthropic model state, and preserved the current `pi` runtime override.
- What was not tested: live provider execution or external channel delivery.

## Root Cause (if applicable)

- Root cause: the generic plugin session-route cleanup prefilter did not consider `agentRuntimeOverride`, and the pinned-runtime repair only cleared `agentHarnessId`.
- Missing detection / guardrail: coverage for runtime-override-only stored session rows owned by non-Codex CLI plugins.
- Contributing context (if known): Codex had adjacent route-scoped cleanup, but the generic Doctor path did not cover non-Codex CLI runtime pins.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/commands/doctor-session-state-providers.test.ts`, `extensions/anthropic/doctor-contract-api.test.ts`, `extensions/google/doctor-contract-api.test.ts`
- Scenario the test should lock in: stale `agentRuntimeOverride` rows for `claude-cli` and `google-gemini-cli` are repaired when the current route no longer uses that runtime, including same-provider canonical routes on PI.
- Why this is the smallest reliable guardrail: it hits the generic Doctor repair layer and the plugin-owned runtime metadata without changing live provider execution.
- Existing test that already covers this (if any): Codex route cleanup tests cover an adjacent Codex-specific path.

## User-visible / Behavior Changes

`openclaw doctor --fix` can now clear stale Anthropic/Gemini CLI runtime pins from session state when the current configured route no longer uses those runtimes.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: local disposable Windows checkout
- Runtime/container: Node 24 source-test runtime
- Model/provider: configured default `openai/gpt-5.5`, current runtime `pi`; stale stored runtime `claude-cli`
- Integration/channel (if any): session route-state repair path
- Relevant config (redacted): no secrets; disposable local state only

### Steps

1. Seed `sessions.json` with one `anthropic/claude-opus-4-7` row carrying stale `agentRuntimeOverride: "claude-cli"` while the configured route runtime is `pi`, plus one current `agentRuntimeOverride: "pi"` row.
2. Run the Doctor state-integrity repair path with repairs accepted.
3. Re-read `sessions.json`.

### Expected

- Stale `claude-cli` runtime override is removed even though the provider/model still matches.
- Anthropic model state is preserved.
- Current `pi` runtime override is preserved.

### Actual

- Stale `claude-cli` runtime override was removed.
- Anthropic model state was preserved.
- Current `pi` runtime override was preserved.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: stale same-provider `claude-cli` runtime override cleanup, Anthropic model-state preservation, current `pi` runtime preservation, Google Gemini CLI owner coverage, Codex adjacent cleanup still green.
- Edge cases checked: runtime-override-only rows, owner runtime still configured, explicit user-owned model overrides left for manual review.
- What you did **not** verify: live provider execution and external channel delivery.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.
