### PR TITLE
fix(subagent): catch fire-and-forget completeSubagentRun rejections (#83114)

### DIFF
--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -335,6 +335,12 @@ function schedulePendingLifecycleError(params: { runId: string; endedAt: number;
     if (entry.endedReason === SUBAGENT_ENDED_REASON_COMPLETE || entry.outcome?.status === "ok") {
       return;
     }
+    // #83114: completeSubagentRun is fire-and-forget here. If it rejects, the
+    // parent never sees the subagent completion signal and the rejection
+    // becomes an unhandled rejection. Attach an explicit catch so the
+    // failure is logged (matching the manager's own retry-warn pattern at
+    // subagent-registry-run-manager.ts:290) instead of being silently
+    // dropped into Node's unhandled-rejection handler.
     void completeSubagentRun({
       runId: params.runId,
       endedAt: pending.endedAt,
@@ -346,6 +352,12 @@ function schedulePendingLifecycleError(params: { runId: string; endedAt: number;
       sendFarewell: true,
       accountId: entry.requesterOrigin?.accountId,
       triggerCleanup: true,
+    }).catch((err) => {
+      log.warn("deferred subagent error completion failed", {
+        runId: params.runId,
+        childSessionKey: entry.childSessionKey,
+        error: err,
+      });
     });
   }, LIFECYCLE_ERROR_RETRY_GRACE_MS);
   timer.unref?.();
@@ -372,6 +384,9 @@ function schedulePendingLifecycleTimeout(params: { runId: string; endedAt: numbe
     if (entry.outcome?.status === "ok") {
       return;
     }
+    // #83114: same fire-and-forget rejection class as the error path above.
+    // Surface the failure so an unhandled rejection cannot mask a stuck
+    // timed-out subagent that never sends its farewell.
     void completeSubagentRun({
       runId: params.runId,
       endedAt: pending.endedAt,
@@ -382,6 +397,12 @@ function schedulePendingLifecycleTimeout(params: { runId: string; endedAt: numbe
       sendFarewell: true,
       accountId: entry.requesterOrigin?.accountId,
       triggerCleanup: true,
+    }).catch((err) => {
+      log.warn("deferred subagent timeout completion failed", {
+        runId: params.runId,
+        childSessionKey: entry.childSessionKey,
+        error: err,
+      });
     });
   }, LIFECYCLE_TIMEOUT_RETRY_GRACE_MS);
   timer.unref?.();


### PR DESCRIPTION
Fixes #83114.

## Problem

`src/agents/subagent-registry.ts` schedules subagent completion via two `setTimeout` callbacks — `schedulePendingLifecycleError` (line 338) and `schedulePendingLifecycleTimeout` (line 375). Both call `void completeSubagentRun({...})` with **no** `.catch()`. If `completeSubagentRun` rejects (registry write failure, gateway RPC error, farewell delivery failure), the rejection escapes the setTimeout body and surfaces as a Node unhandled-rejection. The parent session never sees the subagent completion signal, the farewell is lost, and cleanup is silently dropped.

Same fire-and-forget rejection class as #83116 (gateway signal handlers), same fix shape.

## Fix

`src/agents/subagent-registry.ts`: attach an explicit `.catch()` to each fire-and-forget call. The handler logs the failure through the existing `log` (created at line 74) using the same warn message shape the synchronous-await retry path in `subagent-registry-run-manager.ts:290` already uses, so operators see one structured log line instead of an opaque unhandled-rejection trace.

Behaviour on the success path is unchanged — the `.catch()` callback only runs on rejection.

## Real behavior proof

**Behavior or issue addressed**: Per #83114, two `void completeSubagentRun(...)` callsites in `subagent-registry.ts` have no `.catch()`, so a rejection from the registry write / farewell delivery / gateway RPC becomes an unhandled rejection. The subagent run is marked ended in memory but the parent session never receives the completion signal.

**Real environment tested**: Linux x86_64 (Ubuntu 24.04), Node v22.16, local checkout of `openclaw/openclaw` at branch `fix-subagent-completion-fire-and-forget` rebased on `origin/main` (`2c9f68f42b`). The probe replicates the pre-fix and post-fix call shapes end-to-end against Node's real `unhandledRejection` event probe.

**Exact steps or command run after this patch**:

```
node --input-type=module -e '
const events = [];
process.on("unhandledRejection", (r) => events.push(String(r)));

async function preFix(completeSubagentRun) {
  void completeSubagentRun({ runId: "test" });
}
async function postFix(completeSubagentRun, log) {
  void completeSubagentRun({ runId: "test" }).catch((err) => {
    log({ msg: "deferred subagent completion failed", error: String(err) });
  });
}

(async () => {
  let logs;
  events.length = 0;
  await preFix(async () => { throw new Error("registry write failed"); });
  await new Promise(r => setImmediate(r)); await new Promise(r => setImmediate(r));
  console.log(`pre-fix + reject: unhandled=${events.length} (expect 1)`);

  events.length = 0; logs = [];
  await postFix(async () => { throw new Error("registry write failed"); }, (e) => logs.push(e));
  await new Promise(r => setImmediate(r)); await new Promise(r => setImmediate(r));
  console.log(`post-fix + reject: unhandled=${events.length} logs=${logs.length}`);

  events.length = 0; logs = [];
  await postFix(async () => { /* ok */ }, (e) => logs.push(e));
  await new Promise(r => setImmediate(r)); await new Promise(r => setImmediate(r));
  console.log(`post-fix + success: unhandled=${events.length} logs=${logs.length}`);
})();
'
```

**Evidence after fix**: live stdout from the probe (real `node`, real `unhandledRejection` event subscriber):

```
pre-fix + reject: unhandled=1 (expect 1)
post-fix + reject: unhandled=0 logs=1
post-fix + success: unhandled=0 logs=0
```

- **Pre-fix + reject**: 1 unhandled rejection — confirms the bug exists at the structural pattern level.
- **Post-fix + reject**: 0 unhandled rejections, 1 log line — the rejection is contained and the operator gets a structured warn.
- **Post-fix + success**: 0 unhandled, 0 logs — the success path is unchanged, no spurious warns.

**Observed result after fix**: when the deferred lifecycle-error or lifecycle-timeout `completeSubagentRun` call rejects, the failure is logged at `warn` with `{ runId, childSessionKey, error }` — matching the existing manager-side retry pattern at `subagent-registry-run-manager.ts:290`. The parent session still does not receive the farewell (that requires the registry write to succeed), but the failure is now visible in logs instead of being silently dropped into Node's unhandled-rejection trace.

**What was not tested**: I did not run a live multi-process subagent scenario with a deliberately-failing registry write end-to-end (would require fault-injection into the registry runtime). The patched callsites were probed against the same async-rejection shape Node's `unhandledRejection` event catches in production, and the `.catch()` log message matches the existing manager-side retry warn so operators see one consistent failure surface across both fire-and-forget and synchronous-await paths.

## Pre-implement audit

- **Existing-helper check:** No new helper. Reuses the existing `log` (`createSubsystemLogger("agents/subagent-registry")` at line 74) and the existing warn-shape from `subagent-registry-run-manager.ts:290`. PASS.
- **Shared-helper caller check:** `completeSubagentRun` has many callers across `subagent-registry.ts`, `subagent-registry-lifecycle.ts`, and `subagent-registry-run-manager.ts`. The change is local to the two `void completeSubagentRun(...)` setTimeout callbacks; every other caller (which uses `await`) already has structured error handling and is untouched. PASS.
- **Broader-fix rival scan:** `gh pr list --search "83114 in:body"` returns no rival PRs. The issue cites the audit finding F021 as the source. PASS.
