### PR TITLE
fix(matrix): accept bracketed display-name mentions

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler.strip-mention.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.strip-mention.test.ts
@@ -40,6 +40,15 @@ describe("stripMatrixMentionPrefix", () => {
     expect(result).toBe("/model");
   });
 
+  it("strips bracketed @display name syntax", () => {
+    const result = stripMatrixMentionPrefix({
+      text: "@[OpenClaw Bot] /model",
+      displayName: "OpenClaw Bot",
+      mentionRegexes: [],
+    });
+    expect(result).toBe("/model");
+  });
+
   it("returns original text when text is empty", () => {
     const result = stripMatrixMentionPrefix({
       text: "",

--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -913,6 +913,31 @@ describe("matrix monitor handler pairing account scope", () => {
     expect(recordInboundSession).toHaveBeenCalled();
   });
 
+  it("processes room messages mentioned via bracketed @displayName in formatted_body", async () => {
+    const recordInboundSession = vi.fn(async () => {});
+    const { handler } = createMatrixHandlerTestHarness({
+      isDirectMessage: false,
+      getMemberDisplayName: async () => "Display Name",
+      recordInboundSession,
+    });
+
+    await handler(
+      "!room:example.org",
+      createMatrixRoomMessageEvent({
+        eventId: "$bracketed-display-name-mention",
+        content: {
+          msgtype: "m.text",
+          body: "@[Display Name] please reply",
+          formatted_body:
+            '<a href="https://matrix.to/#/@bot:example.org">@[Display Name]</a> please reply',
+          "m.mentions": { user_ids: ["@bot:example.org"] },
+        },
+      }),
+    );
+
+    expect(recordInboundSession).toHaveBeenCalled();
+  });
+
   it("does not fetch self displayName for plain-text room mentions", async () => {
     const getMemberDisplayName = vi.fn(async () => "Tom Servo");
     const { handler, recordInboundSession } = createMatrixHandlerTestHarness({

--- a/extensions/matrix/src/matrix/monitor/mentions.test.ts
+++ b/extensions/matrix/src/matrix/monitor/mentions.test.ts
@@ -228,6 +228,24 @@ describe("resolveMentions", () => {
       expect(result.hasExplicitMention).toBe(true);
     });
 
+    it("detects mention when the visible label is bracketed @displayName text", () => {
+      const result = resolveMentions({
+        content: {
+          msgtype: "m.text",
+          body: "@[Display Name] please reply",
+          formatted_body:
+            '<a href="https://matrix.to/#/@bot:matrix.org">@[Display Name]</a> please reply',
+          "m.mentions": { user_ids: ["@bot:matrix.org"] },
+        },
+        userId,
+        displayName: "Display Name",
+        text: "@[Display Name] please reply",
+        mentionRegexes: [],
+      });
+      expect(result.wasMentioned).toBe(true);
+      expect(result.hasExplicitMention).toBe(true);
+    });
+
     it("ignores out-of-range hexadecimal HTML entities in visible labels", () => {
       expect(
         resolveMentions({

--- a/extensions/matrix/src/matrix/monitor/mentions.ts
+++ b/extensions/matrix/src/matrix/monitor/mentions.ts
@@ -89,6 +89,7 @@ function resolveMatrixMentionPrefixCandidates(params: {
   append(localpart ? `@${localpart}` : null);
   append(params.displayName);
   append(params.displayName ? `@${params.displayName}` : null);
+  append(params.displayName ? `@[${params.displayName}]` : null);
 
   return candidates;
 }
@@ -158,6 +159,7 @@ function isVisibleMentionLabel(params: {
     localpart ? extractVisibleMentionText(`@${localpart}`) : null,
     params.displayName ? extractVisibleMentionText(params.displayName) : null,
     params.displayName ? extractVisibleMentionText(`@${params.displayName}`) : null,
+    params.displayName ? extractVisibleMentionText(`@[${params.displayName}]`) : null,
   ].filter((value): value is string => Boolean(value));
   return candidates.includes(cleaned);
 }


### PR DESCRIPTION
## Summary

- accept `@[Display Name]` as a visible Matrix mention label for formatted `matrix.to` links
- strip leading `@[Display Name]` mention prefixes before command handling
- add Matrix monitor regression coverage for parser, prefix stripping, and room handler behavior

Fixes #83142.

## Real behavior proof

- Behavior or issue addressed: FluffyChat can send Matrix room mentions whose visible formatted-body anchor text is `@[Display Name]` while `m.mentions.user_ids` correctly contains the bot MXID. OpenClaw skipped those messages as `no-mention` because the visible-label candidate list did not accept the bracketed display-name form.
- Real environment tested: Local real OpenClaw gateway using the installed `@openclaw/matrix@2026.5.12` package, patched with the same candidate-list behavior as this PR, connected to a real Matrix room. Private Matrix identifiers and homeserver details are redacted below.
- Exact steps or command run after this patch: Applied the same mention-candidate change to the installed Matrix extension bundle, ran `openclaw gateway restart`, then sent a FluffyChat room message mentioning the OpenClaw bot with visible text `@[Display Name]`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied live output from the real Matrix event and runtime behavior, redacted:

```text
Before patch:
FluffyChat event content:
body: @[Display Name] hi
formatted_body: <a href="https://matrix.to/#/@bot:example.org">@[Display Name]</a> hi
m.mentions.user_ids: ["@bot:example.org"]

OpenClaw runtime result:
skipping room message
reason: no-mention

After patch:
command: openclaw gateway restart
sent from FluffyChat: @[Display Name] hi
OpenClaw runtime result: bot replied successfully in the same Matrix room
```

- Observed result after fix: The same FluffyChat `@[Display Name]` mention shape that previously logged `no-mention` successfully triggered the OpenClaw bot response after the fix and gateway restart.
- What was not tested: No known gaps for this bug path. This proof verifies the FluffyChat bracketed display-name path in a real Matrix room; the PR also preserves the existing metadata-backed visible mention guard.
- Before evidence (optional but encouraged): Before the fix, the real FluffyChat message shape above was skipped with `skipping room message` / `reason: no-mention`.

## Testing

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-matrix.config.ts`
