### PR TITLE
fix(telegram): move preview-streamed dedup to channel layer (#80520)

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -544,6 +544,85 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.clear).toHaveBeenCalledTimes(1);
   });
 
+  it("dedups a text-only final whose content already streamed into the preview", async () => {
+    // Preview "Hello" is established (messageId set). Final "Hello" matches the
+    // preview content exactly, so it should be suppressed without producing a
+    // duplicate sendMessage and without deleting the preview message — the
+    // regression scenario from openclaw#80520.
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Hello" });
+        await dispatcherOptions.deliver({ text: "Hello" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({ context: createContext() });
+
+    expect(answerDraftStream.update).toHaveBeenCalledWith("Hello");
+    expect(deliverReplies).not.toHaveBeenCalled();
+    expect(answerDraftStream.clear).not.toHaveBeenCalled();
+  });
+
+  it("dedups each per-block final against a multi-block preview", async () => {
+    // Preview streams "First block\n\nSecond block" once; the reply pipeline
+    // then emits two separate final payloads ("First block" and "Second block")
+    // for the paragraph-split delivery shape. Both should be suppressed.
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "First block\n\nSecond block" });
+        await dispatcherOptions.deliver({ text: "First block" }, { kind: "final" });
+        await dispatcherOptions.deliver({ text: "Second block" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({ context: createContext() });
+
+    expect(deliverReplies).not.toHaveBeenCalled();
+    expect(answerDraftStream.clear).not.toHaveBeenCalled();
+  });
+
+  it("does not dedup a final when the preview has no Telegram message id yet", async () => {
+    // setupDraftStreams without answerMessageId leaves stream.messageId()
+    // returning undefined, simulating a preview that never landed. The final
+    // is the user's only chance to see anything, so dedup must not fire.
+    const { answerDraftStream } = setupDraftStreams();
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Hello" });
+        await dispatcherOptions.deliver({ text: "Hello" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({ context: createContext() });
+
+    expect(answerDraftStream.update).toHaveBeenCalledWith("Hello");
+    expect(deliverReplies).toHaveBeenCalled();
+  });
+
+  it("does not dedup error finals even when their text matches the preview", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Agent failed." });
+        await dispatcherOptions.deliver(
+          { text: "Agent failed.", isError: true },
+          { kind: "final" },
+        );
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({ context: createContext() });
+
+    expect(answerDraftStream.update).toHaveBeenCalledWith("Agent failed.");
+    expect(deliverReplies).toHaveBeenCalled();
+  });
+
   it("keeps retained overflow draft previews", async () => {
     const draftStream = createDraftStream();
     const bot = createBot();

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -585,6 +585,39 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(answerDraftStream.clear).not.toHaveBeenCalled();
   });
 
+  it("mirrors deduped preview finals before returning", async () => {
+    setupDraftStreams({ answerMessageId: 2001 });
+    const context = createContext();
+    context.ctxPayload.SessionKey = "agent:default:telegram:direct:123";
+    loadSessionStore.mockReturnValue({
+      "agent:default:telegram:direct:123": { sessionId: "s1" },
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Final answer" });
+        await dispatcherOptions.deliver({ text: "Final answer" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({ context });
+
+    expect(deliverReplies).not.toHaveBeenCalled();
+    expectRecordFields(mockCallArg(emitInternalMessageSentHook), {
+      content: "Final answer",
+      messageId: 2001,
+    });
+    const transcriptCall = expectRecordFields(mockCallArg(appendSessionTranscriptMessage), {
+      transcriptPath: "/tmp/session.jsonl",
+    });
+    expectRecordFields(transcriptCall.message, {
+      role: "assistant",
+      provider: "openclaw",
+      model: "delivery-mirror",
+      content: [{ type: "text", text: "Final answer" }],
+    });
+  });
+
   it("does not dedup a final when the preview has no Telegram message id yet", async () => {
     // setupDraftStreams without answerMessageId leaves stream.messageId()
     // returning undefined, simulating a preview that never landed. The final

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -565,6 +565,31 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(answerDraftStream.clear).not.toHaveBeenCalled();
   });
 
+  it("attaches buttons before deduping a preview-streamed final", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    const buttons = [[{ text: "OK", callback_data: "ok" }]];
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Choose" });
+        await dispatcherOptions.deliver(
+          { text: "Choose", channelData: { telegram: { buttons } } },
+          { kind: "final" },
+        );
+        return { queuedFinal: true };
+      },
+    );
+
+    await dispatchWithContext({ context: createContext() });
+
+    expect(answerDraftStream.update).toHaveBeenCalledWith("Choose");
+    expect(mockCallArg(editMessageTelegram)).toBe(123);
+    expect(mockCallArg(editMessageTelegram, 0, 1)).toBe(2001);
+    expect(mockCallArg(editMessageTelegram, 0, 2)).toBe("Choose");
+    expectRecordFields(mockCallArg(editMessageTelegram, 0, 3), { buttons });
+    expect(deliverReplies).not.toHaveBeenCalled();
+    expect(answerDraftStream.clear).not.toHaveBeenCalled();
+  });
+
   it("dedups each per-block final against a multi-block preview", async () => {
     // Preview streams "First block\n\nSecond block" once; the reply pipeline
     // then emits two separate final payloads ("First block" and "Second block")

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -12,6 +12,7 @@ import {
 } from "openclaw/plugin-sdk/channel-feedback";
 import {
   createChannelMessageReplyPipeline,
+  createPreviewMessageReceipt,
   deriveDurableFinalDeliveryRequirements,
 } from "openclaw/plugin-sdk/channel-message";
 import {
@@ -1372,6 +1373,14 @@ export const dispatchTelegramMessage = async ({
                         if (isPreviewStreamedText(effectivePayload.text, previewDedupeText)) {
                           answerLane.finalized = true;
                           deliveryState.markDelivered();
+                          emitPreviewFinalizedHook({
+                            kind: "preview-finalized",
+                            delivery: {
+                              content: effectivePayload.text ?? "",
+                              messageId: previewMessageId,
+                              receipt: createPreviewMessageReceipt({ id: previewMessageId }),
+                            },
+                          });
                           return;
                         }
                       }

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1345,6 +1345,7 @@ export const dispatchTelegramMessage = async ({
                       return;
                     }
                     const effectivePayload = deduped;
+                    const telegramButtons = resolvePayloadTelegramInlineButtons(effectivePayload);
 
                     // Preview-streamed final dedup (channel-layer replacement
                     // for the previous core-layer suppression introduced by
@@ -1371,6 +1372,26 @@ export const dispatchTelegramMessage = async ({
                           answerLane.lastPartialText,
                         );
                         if (isPreviewStreamedText(effectivePayload.text, previewDedupeText)) {
+                          if (telegramButtons) {
+                            try {
+                              await (telegramDeps.editMessageTelegram ?? editMessageTelegram)(
+                                chatId,
+                                previewMessageId,
+                                effectivePayload.text ?? answerLane.lastPartialText,
+                                {
+                                  api: bot.api,
+                                  cfg,
+                                  accountId: route.accountId,
+                                  linkPreview: telegramCfg.linkPreview,
+                                  buttons: telegramButtons,
+                                },
+                              );
+                            } catch (err) {
+                              logVerbose(
+                                `telegram: preview-finalized button edit failed: ${formatErrorMessage(err)}`,
+                              );
+                            }
+                          }
                           answerLane.finalized = true;
                           deliveryState.markDelivered();
                           emitPreviewFinalizedHook({
@@ -1399,7 +1420,6 @@ export const dispatchTelegramMessage = async ({
                       queuedFinal = true;
                       return;
                     }
-                    const telegramButtons = resolvePayloadTelegramInlineButtons(effectivePayload);
                     const split = splitTextIntoLaneSegments(
                       { text: effectivePayload.text },
                       payload.isReasoning,

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -105,6 +105,7 @@ import {
   type LaneName,
 } from "./lane-delivery.js";
 import { createNativeTelegramToolProgressDraft } from "./native-tool-progress-draft.js";
+import { buildPreviewDedupeTextSet, isPreviewStreamedText } from "./preview-dedup.js";
 import {
   createTelegramReasoningStepState,
   splitTelegramReasoningText,
@@ -1343,6 +1344,38 @@ export const dispatchTelegramMessage = async ({
                       return;
                     }
                     const effectivePayload = deduped;
+
+                    // Preview-streamed final dedup (channel-layer replacement
+                    // for the previous core-layer suppression introduced by
+                    // PR #82625 / commit bd51d8f2dd). When the answer lane has
+                    // already shown this text via partial-preview streaming,
+                    // sending it again as a final would duplicate. Skip the
+                    // send, but mark the lane as finalized so the
+                    // unfinalized-preview cleanup does not delete the preview
+                    // message — the regression reported in openclaw#80520.
+                    //
+                    // Scope:
+                    //  - Text-only finals (media payloads keep their existing
+                    //    lane-delivery-text-deliverer.ts hasMedia branch, which
+                    //    already strips duplicate captions while keeping media).
+                    //  - Only fires when the preview actually has an established
+                    //    Telegram message (messageId is a number). If the
+                    //    preview never landed, the final still needs to flow
+                    //    through sendPayload so the user receives something.
+                    if (info.kind === "final" && !effectivePayload.isError) {
+                      const reply = resolveSendableOutboundReplyParts(effectivePayload);
+                      const previewMessageId = answerLane.stream?.messageId();
+                      if (!reply.hasMedia && typeof previewMessageId === "number") {
+                        const previewDedupeText = buildPreviewDedupeTextSet(
+                          answerLane.lastPartialText,
+                        );
+                        if (isPreviewStreamedText(effectivePayload.text, previewDedupeText)) {
+                          answerLane.finalized = true;
+                          deliveryState.markDelivered();
+                          return;
+                        }
+                      }
+                    }
 
                     if (info.kind === "final") {
                       await enqueueDraftLaneEvent(async () => {});

--- a/extensions/telegram/src/preview-dedup.test.ts
+++ b/extensions/telegram/src/preview-dedup.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPreviewDedupeTextSet,
+  isPreviewStreamedText,
+  normalizePreviewDedupeText,
+} from "./preview-dedup.js";
+
+describe("normalizePreviewDedupeText", () => {
+  it("returns empty string for undefined or whitespace-only input", () => {
+    expect(normalizePreviewDedupeText(undefined)).toBe("");
+    expect(normalizePreviewDedupeText("")).toBe("");
+    expect(normalizePreviewDedupeText("   \n\t  ")).toBe("");
+  });
+
+  it("collapses any whitespace run to a single space and trims edges", () => {
+    expect(normalizePreviewDedupeText("  hi   there  ")).toBe("hi there");
+    expect(normalizePreviewDedupeText("a\nb\tc")).toBe("a b c");
+    expect(normalizePreviewDedupeText("multi\n\nblock")).toBe("multi block");
+  });
+});
+
+describe("buildPreviewDedupeTextSet", () => {
+  it("returns an empty set when the input is empty", () => {
+    expect(buildPreviewDedupeTextSet(undefined).size).toBe(0);
+    expect(buildPreviewDedupeTextSet("").size).toBe(0);
+    expect(buildPreviewDedupeTextSet("   ").size).toBe(0);
+  });
+
+  it("contains the normalized whole text and each paragraph block", () => {
+    const set = buildPreviewDedupeTextSet("First block\n\nSecond block");
+    expect(set.has("First block Second block")).toBe(true);
+    expect(set.has("First block")).toBe(true);
+    expect(set.has("Second block")).toBe(true);
+  });
+
+  it("treats three or more newlines as a single block boundary", () => {
+    const set = buildPreviewDedupeTextSet("A\n\n\n\nB");
+    expect(set.has("A")).toBe(true);
+    expect(set.has("B")).toBe(true);
+  });
+
+  it("does not split on a single newline (those stay inside one block)", () => {
+    const set = buildPreviewDedupeTextSet("line1\nline2");
+    expect(set.has("line1 line2")).toBe(true);
+    expect(set.has("line1")).toBe(false);
+    expect(set.has("line2")).toBe(false);
+  });
+});
+
+describe("isPreviewStreamedText", () => {
+  it("returns false when the preview dedupe set is empty", () => {
+    expect(isPreviewStreamedText("anything", new Set())).toBe(false);
+  });
+
+  it("returns false for empty/undefined candidate", () => {
+    const set = buildPreviewDedupeTextSet("First block\n\nSecond block");
+    expect(isPreviewStreamedText(undefined, set)).toBe(false);
+    expect(isPreviewStreamedText("", set)).toBe(false);
+    expect(isPreviewStreamedText("   ", set)).toBe(false);
+  });
+
+  it("matches an individual block from a multi-block preview", () => {
+    const set = buildPreviewDedupeTextSet("First block\n\nSecond block");
+    expect(isPreviewStreamedText("First block", set)).toBe(true);
+    expect(isPreviewStreamedText("Second block", set)).toBe(true);
+  });
+
+  it("matches whole-preview text", () => {
+    const set = buildPreviewDedupeTextSet("First block\n\nSecond block");
+    expect(isPreviewStreamedText("First block Second block", set)).toBe(true);
+  });
+
+  it("ignores incidental whitespace differences", () => {
+    const set = buildPreviewDedupeTextSet("Hello   world");
+    expect(isPreviewStreamedText("Hello world", set)).toBe(true);
+    expect(isPreviewStreamedText("  Hello world  ", set)).toBe(true);
+    expect(isPreviewStreamedText("Hello\nworld", set)).toBe(true);
+  });
+
+  it("does not suppress unrelated short text just because it appears inside preview", () => {
+    const set = buildPreviewDedupeTextSet("Working on item 3");
+    expect(isPreviewStreamedText("3", set)).toBe(false);
+    expect(isPreviewStreamedText("item", set)).toBe(false);
+    expect(isPreviewStreamedText("Working", set)).toBe(false);
+  });
+
+  it("returns false for a final that differs from any preview block", () => {
+    const set = buildPreviewDedupeTextSet("Working...");
+    expect(isPreviewStreamedText("Done.", set)).toBe(false);
+  });
+});

--- a/extensions/telegram/src/preview-dedup.ts
+++ b/extensions/telegram/src/preview-dedup.ts
@@ -1,0 +1,45 @@
+/**
+ * Detect when a final reply payload's text was already delivered to the user
+ * via the partial-preview stream (editMessageText), so the channel dispatcher
+ * can skip the duplicate send while still finalizing the lane.
+ *
+ * Equivalent semantics to the previous core-layer suppressPreviewStreamedPayloads
+ * (PR #82625 / commit bd51d8f2dd), but kept here so the suppression and the
+ * lane-finalized signal stay co-located: the dispatcher updates
+ * lane.finalized = true at the same place it decides to skip the send, which
+ * prevents the unfinalized-preview cleanup from deleting the preview message
+ * when all finals are suppressed (the regression reported in openclaw#80520).
+ */
+
+export function normalizePreviewDedupeText(value: string | undefined): string {
+  return (value ?? "").replace(/\s+/g, " ").trim();
+}
+
+export function buildPreviewDedupeTextSet(value: string | undefined): Set<string> {
+  const set = new Set<string>();
+  const whole = normalizePreviewDedupeText(value);
+  if (whole) {
+    set.add(whole);
+  }
+  for (const block of (value ?? "").split(/\n{2,}/u)) {
+    const normalized = normalizePreviewDedupeText(block);
+    if (normalized) {
+      set.add(normalized);
+    }
+  }
+  return set;
+}
+
+export function isPreviewStreamedText(
+  candidate: string | undefined,
+  previewDedupeText: Set<string>,
+): boolean {
+  if (previewDedupeText.size === 0) {
+    return false;
+  }
+  const normalized = normalizePreviewDedupeText(candidate);
+  if (!normalized) {
+    return false;
+  }
+  return previewDedupeText.has(normalized);
+}


### PR DESCRIPTION
## Summary

Fixes the Telegram "reply appears briefly then disappears" regression reported in #80520. The previous core-layer dedup (#82625 / commit `bd51d8f2dd`) suppressed final payloads matching preview-streamed text but had no path to also signal the channel's `lane.finalized` state. When every final was suppressed (e.g., embedded harness + reasoning-model paragraph-split deliveries), the lane stayed unfinalized and the end-of-turn cleanup deleted the preview message.

This PR moves the dedup from the channel-agnostic core to the Telegram channel layer so the "skip duplicate send" and "mark lane finalized" steps happen atomically.

## Commits

1. **Revert "Deduplicate preview-streamed final replies (#82625)"** — undoes the previous dedup, which could not observe channel state.

2. **fix(telegram): move preview-streamed final dedup to channel layer (#80520)** — equivalent dedup at the channel layer:
   - New `extensions/telegram/src/preview-dedup.ts` helpers (whole + per-block normalization, exact-match check). 13 unit tests in `preview-dedup.test.ts`.
   - In `bot-message-dispatch.ts`, the dispatcher's `deliver` callback checks each text-only final against the answer lane's `lastPartialText`. On match: `answerLane.finalized = true`, `deliveryState.markDelivered()`, skip the send.
   - **Guards with a `previewMessageId` check** — only fires when the preview actually has an established Telegram message. If the preview never landed (e.g., transient failure), the final still flows through `sendPayload` so the user receives something. The previous core-layer dedup had no access to this state.
   - Media + caption payloads keep their existing path through `lane-delivery-text-deliverer.ts`'s `hasMedia` branch, which already handles caption stripping.

## Real behavior proof

Behavior addressed: Telegram "reply appears briefly then disappears" regression for embedded-harness + reasoning-model + `streaming.mode=partial` paths (#80520).

Real environment tested: macOS, managed gateway service running this branch's `dist/`. Live Telegram bot configured with `model.primary = zai/glm-5.1` (reasoning model) via the embedded harness with `streaming.mode=partial`.

Exact steps or command run after this patch:
1. `git checkout dev/telegram-preview-dedup && pnpm build` (build the patched `dist/`).
2. `openclaw gateway stop && openclaw gateway start` (run a live gateway on the patched build).
3. Sent a short (3-char) conversational message to the live agent through the Telegram client.
4. Sent an 80-char prompt asking the live agent to fetch and summarize an external URL; the model produced a 10-paragraph, ~1297-char markdown summary — the paragraph-split delivery shape this regression originally manifested on.
5. (Supplemental) Ran `pnpm test extensions/telegram` against the patched branch — 118 files, 1735 tests pass, including 4 new integration cases for the channel-layer dedup, the `previewMessageId` guard, multi-block deliveries, and error preservation.

Evidence after fix:

Redacted live `gateway.log` excerpt covering the 80-char inbound prompt and the subsequent long-reply turn on the live gateway (chat id and bot handle redacted as `<chat>` and `<bot>`; nothing else inside this turn was logged):

```
[telegram] Inbound message <chat> -> @<bot> (direct, 80 chars)
(no other [telegram] outbound line for this account between the inbound
 and 3 minutes later — no sendMessage, no deliverReplies, no
 editMessageTelegram from the channel adapter for this turn)
```

The absence of any outbound `[telegram]` line is the load-bearing observation from the live gateway: the 1297-char, 10-paragraph reply was delivered entirely through the existing preview-streaming `editMessageText` path on the already-established preview message id. On `main` without this PR, the previous `suppressPreviewStreamedPayloads` would have dropped each paragraph's final payload at the runner layer and `clearUnfinalizedStream` would have then deleted the preview message — the regression described in #80520.

Redacted live session jsonl excerpt for the same turn (assistant payload metadata as written by the running gateway; reply text and tool inputs/outputs omitted):

```json
{
  "type": "message",
  "message": {
    "role": "assistant",
    "provider": "zai",
    "model": "glm-5.1",
    "api": "openai-completions",
    "stopReason": "stop",
    "usage": {
      "input": 10445,
      "output": 585,
      "cacheRead": 130176,
      "totalTokens": 141206,
      "cost": { "input": 0.012534, "output": 0.00234, "cacheRead": 0.031242, "total": 0.046116 }
    },
    "content": [
      { "type": "text", "text": "<redacted: ~1297-char markdown reply with 10 paragraph blocks separated by blank lines>" }
    ]
  }
}
```

The same turn also wrote a `provider=openclaw, model=delivery-mirror` mirror entry ~11 s later with the same `content[0].text` value, confirming the channel side accepted the reply as delivered and finalized the lane — the cleanup did not fire and the preview message remained intact in the Telegram chat.

Before this PR on `main` (the parent of `56b09263ef`, before reverting `bd51d8f2dd`), the same setup repeatedly produced a preview message that flashed into the chat and disappeared without any visible final, matching the report on #80520. Reverting `bd51d8f2dd` alone restored delivery (with paragraph duplicates); this PR adds the channel-layer dedup that also removes the duplicates.

Observed result after fix:
- The 10-paragraph, ~1297-char live reply lands as a single Telegram chat bubble that contains every paragraph (not 10 separate messages) and stays in the chat permanently.
- No flashing/disappearing during or after streaming.
- No paragraph-split duplicates.
- Short conversational replies behave the same way (single message, stable).

What was not tested:
- Slack, MSTeams, Mattermost (the analogous dispatchers in those channels were not modified by this PR; whether they need similar treatment is follow-up work).
- Codex-harness paths (different code path, not affected by this PR).
- Live multi-instance / concurrent-turn scenarios.

## Test plan

- [x] `pnpm test extensions/telegram` — 1735/1735 pass
- [x] Manual Telegram E2E with `zai/glm-5.1` embedded harness: short reply + 10-paragraph URL summary
- [ ] Maintainer to confirm whether Slack/MSTeams dispatchers need analogous treatment in a follow-up

Closes #80520.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


