### PR TITLE
fix(xai): remove extra Grok OAuth authorize params

### DIFF
--- a/extensions/xai/xai-oauth.test.ts
+++ b/extensions/xai/xai-oauth.test.ts
@@ -46,8 +46,20 @@ describe("xAI OAuth", () => {
     expect(url.searchParams.get("code_challenge_method")).toBe("S256");
     expect(url.searchParams.get("state")).toBe("state-1");
     expect(url.searchParams.get("nonce")).toBe("nonce-1");
-    expect(url.searchParams.get("plan")).toBe("generic");
-    expect(url.searchParams.get("referrer")).toBe("openclaw");
+    expect(url.searchParams.get("plan")).toBeNull();
+    expect(url.searchParams.get("referrer")).toBeNull();
+    expect([...url.searchParams.keys()].toSorted()).toEqual(
+      [
+        "client_id",
+        "code_challenge",
+        "code_challenge_method",
+        "nonce",
+        "redirect_uri",
+        "response_type",
+        "scope",
+        "state",
+      ].toSorted(),
+    );
     expect(XAI_OAUTH_REDIRECT_URI).toContain(`:${XAI_OAUTH_CALLBACK_PORT}/`);
   });
 

--- a/extensions/xai/xai-oauth.ts
+++ b/extensions/xai/xai-oauth.ts
@@ -132,8 +132,6 @@ export function buildXaiOAuthAuthorizeUrl(params: {
   url.searchParams.set("nonce", params.nonce);
   url.searchParams.set("code_challenge", params.challenge);
   url.searchParams.set("code_challenge_method", "S256");
-  url.searchParams.set("plan", "generic");
-  url.searchParams.set("referrer", "openclaw");
   return url.toString();
 }
 


### PR DESCRIPTION
## Summary

## Update: pre-patch live retest

After the initial patch proof, we retested the exact `v2026.5.16-beta.4` code path in an isolated `--profile xai-before` profile. That pre-patch URL still included `plan=generic` and `referrer=openclaw`, but the account-holder browser OAuth callback completed successfully and a one-shot `xai/grok-4.3` request returned `OK`. This means the original `invalid_request` report is real, but the extra params are no longer proven to be the sole cause. The patch remains a narrow cleanup to align the authorize URL with xAI's OpenID/PKCE metadata and remove unneeded params.

- Problem: the xAI Grok OAuth flow shipped in `v2026.5.16-beta.4` appended OpenClaw-specific `plan=generic` and `referrer=openclaw` authorize parameters; the reported browser callback came back as `error=invalid_request` before token exchange, though a later pre-patch retest did not reproduce that failure.
- Why it matters: SuperGrok OAuth sign-in can fail for `xai/*` models and xAI media/tool providers even though the xAI OpenID metadata supports the client scopes and PKCE flow.
- What changed: build the authorize URL with only the xAI OpenID/PKCE parameters and update the xAI OAuth unit test to lock out the removed params.
- What did NOT change (scope boundary): client id, scopes, redirect URI, token exchange, refresh, credential storage, xAI API-key auth, and model/provider runtime behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related https://github.com/openclaw/openclaw/releases/tag/v2026.5.16-beta.4
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: xAI Grok OAuth authorize URLs generated after this patch no longer include `plan` or `referrer`; they use only the standard OpenID/PKCE params that xAI's live metadata advertises.
- Real environment tested: Local OpenClaw source checkout on Node `v22.22.2`, with live metadata fetched from `https://auth.x.ai/.well-known/openid-configuration`.
- Exact steps or command run after this patch: `node --import tsx --input-type=module` imported `extensions/xai/xai-oauth.ts` and called `buildXaiOAuthAuthorizeUrl`; `node --input-type=module` fetched xAI OpenID metadata; `node scripts/run-vitest.mjs extensions/xai/xai-oauth.test.ts` ran the regression test.
- Evidence after fix: Copied terminal output from the after-fix URL-generation probe:

```json
{
  "authorizeEndpoint": "https://auth.x.ai/oauth2/authorize",
  "authorizeParamKeys": [
    "client_id",
    "code_challenge",
    "code_challenge_method",
    "nonce",
    "redirect_uri",
    "response_type",
    "scope",
    "state"
  ],
  "hasPlanParam": false,
  "hasReferrerParam": false
}
```

Copied terminal output from the live xAI metadata probe:

```json
{
  "discoveryIssuer": "https://auth.x.ai",
  "authorizationEndpoint": "https://auth.x.ai/oauth2/authorize",
  "tokenEndpoint": "https://auth.x.ai/oauth2/token",
  "supportedScopes": true,
  "supportsAuthorizationCode": true,
  "supportsRefreshToken": true,
  "supportsS256": true
}
```

Copied, redacted terminal output from the live browser OAuth callback and model run:

```text
xAI OAuth complete
Updated config: ~/.openclaw/openclaw.json
Auth profile: xai:<redacted> (xai/oauth)
Default model available: xai/grok-4.3 (use --set-default to apply)
```

```json
{
  "ok": true,
  "capability": "model.run",
  "transport": "local",
  "provider": "xai",
  "model": "grok-4.3",
  "outputs": [
    {
      "text": "OK",
      "mediaUrl": null
    }
  ]
}
```

- Observed result after fix: OpenClaw's xAI OAuth authorize URL now contains the xAI-supported OIDC/PKCE parameters only; the account-holder OAuth browser callback completed; the resulting xAI OAuth profile successfully ran `xai/grok-4.3`; and the regression test passes with the removed params absent.
- What was not tested: A clean first-ever xAI account/client-consent browser session before and after the patch; long-running conversation/tool-use behavior after OAuth. Current proof covers patched browser OAuth callback, token storage, auth profile resolution, a one-shot `xai/grok-4.3` request, and a later pre-patch retest that also succeeded.
- Before evidence (optional but encouraged): `v2026.5.16-beta.4` release notes announced xAI Grok OAuth, and the release tag's `extensions/xai/xai-oauth.ts` adds `plan=generic` and `referrer=openclaw` to the authorize URL; the user-reported callback failed with `OAuth error: invalid_request`. A subsequent live retest of the exact beta URL in an isolated OpenClaw profile completed successfully, so the failure is not currently reproduced.

## Root Cause (if applicable)

- Root cause: the xAI OAuth plugin added provider-specific routing/branding query params beyond the OpenID/PKCE authorize contract used by the Grok OAuth consent flow.
- Missing detection / guardrail: the authorize URL test asserted that the extra params were present instead of asserting the standard xAI parameter set.
- Contributing context (if known): the failure was reported against the `v2026.5.16-beta.4` beta release that first announced xAI Grok OAuth for SuperGrok subscribers.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/xai/xai-oauth.test.ts`
- Scenario the test should lock in: xAI OAuth authorize URLs include only `response_type`, `client_id`, `redirect_uri`, `scope`, `state`, `nonce`, `code_challenge`, and `code_challenge_method`.
- Why this is the smallest reliable guardrail: the reported failure is caused by the generated authorize URL before callback/token exchange, so a URL-shape unit test catches the regression without requiring live account credentials.
- Existing test that already covers this (if any): existing test covered the URL builder but expected the wrong extra params.
- If no new test is added, why not: N/A; the URL builder test was updated.

## User-visible / Behavior Changes

xAI Grok OAuth no longer sends `plan=generic` or `referrer=openclaw` on the browser authorize URL. No new config surface.

## Diagram (if applicable)

```text
Before:
openclaw xAI OAuth -> authorize URL + plan/referrer -> xAI callback error=invalid_request

After:
openclaw xAI OAuth -> standard OIDC/PKCE authorize URL -> xAI Grok consent flow
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux source checkout
- Runtime/container: Node `v22.22.2`, pnpm `v11.1.0`
- Model/provider: xAI / Grok OAuth provider
- Integration/channel (if any): Provider auth flow
- Relevant config (redacted): none; URL-generation and discovery probes do not use secrets

### Steps

1. Compare the reported beta release tag and current source for `extensions/xai/xai-oauth.ts`.
2. Generate the xAI OAuth authorize URL through `buildXaiOAuthAuthorizeUrl` after the patch.
3. Fetch xAI OpenID metadata and confirm requested scopes, authorization-code/refresh grants, and PKCE `S256` are advertised.
4. Run `node scripts/run-vitest.mjs extensions/xai/xai-oauth.test.ts`.
5. Complete live browser OAuth with `pnpm openclaw models auth login --provider xai --method oauth`.
6. Run `pnpm openclaw infer model run --local --model xai/grok-4.3 --prompt 'Reply with exactly: OK' --json`.
7. Run `codex review --base origin/main`.
8. In a detached `v2026.5.16-beta.4` worktree, run `pnpm openclaw --profile xai-before models auth login --provider xai --method oauth` and `pnpm openclaw --profile xai-before infer model run --local --model xai/grok-4.3 --prompt 'Reply with exactly: OK' --json`.

### Expected

- The xAI authorize URL contains only the standard OpenID/PKCE params.
- xAI OAuth URL generation regression coverage fails if `plan` or `referrer` are reintroduced.

### Actual

- URL-generation probe printed `hasPlanParam: false` and `hasReferrerParam: false`.
- Live xAI metadata probe printed `supportedScopes: true`, `supportsAuthorizationCode: true`, `supportsRefreshToken: true`, and `supportsS256: true`.
- Focused Vitest passed: `1 passed (1)`, `4 passed (4)`.
- Live browser OAuth completed with an xAI OAuth profile, and the local one-shot `xai/grok-4.3` request returned `OK`.
- Pre-patch `v2026.5.16-beta.4` browser OAuth also completed in isolated profile `xai-before`, and its one-shot `xai/grok-4.3` request returned `OK`; this means the original `invalid_request` is not reproduced by the extra params alone in the current account/browser state.
- `codex review --base origin/main` reported no actionable correctness issues.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: inspected the beta release/source that shipped xAI Grok OAuth, generated the patched authorize URL from the real xAI plugin module, fetched live xAI OpenID metadata, ran the focused xAI OAuth Vitest file, completed live account-holder xAI OAuth onboarding, ran a real local `xai/grok-4.3` model request through the resulting OAuth profile, and ran local Codex review.
- Edge cases checked: trusted endpoint validation remains covered; token refresh with cached token endpoint remains covered; removed params stay absent from the authorize URL.
- What you did **not** verify: long-running conversation/tool-use behavior after OAuth; the live proof is a minimal one-shot model call.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: xAI may require one of the removed non-standard params for a separate future auth surface.
  - Mitigation: the current SuperGrok OAuth flow is grounded in xAI OpenID discovery and the regression test locks only the shipped Grok OAuth path; API-key auth remains unchanged.


