### PR TITLE
[AI-assisted] fix(matrix): accept bracketed display-name mentions

### DIFF
--- a/extensions/matrix/src/matrix/monitor/handler.test.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.test.ts
@@ -844,6 +844,31 @@ describe("matrix monitor handler pairing account scope", () => {
     expect(recordInboundSession).toHaveBeenCalled();
   });
 
+  it("processes room messages mentioned via bracketed @displayName in formatted_body", async () => {
+    const recordInboundSession = vi.fn(async () => {});
+    const { handler } = createMatrixHandlerTestHarness({
+      isDirectMessage: false,
+      getMemberDisplayName: async () => "Display Name",
+      recordInboundSession,
+    });
+
+    await handler(
+      "!room:example.org",
+      createMatrixRoomMessageEvent({
+        eventId: "$bracketed-display-name-mention",
+        content: {
+          msgtype: "m.text",
+          body: "@[Display Name] hello",
+          formatted_body:
+            '<a href="https://matrix.to/#/@bot:example.org">@[Display Name]</a> hello',
+          "m.mentions": { user_ids: ["@bot:example.org"] },
+        },
+      }),
+    );
+
+    expect(recordInboundSession).toHaveBeenCalled();
+  });
+
   it("does not fetch self displayName for plain-text room mentions", async () => {
     const getMemberDisplayName = vi.fn(async () => "Tom Servo");
     const { handler, recordInboundSession } = createMatrixHandlerTestHarness({

--- a/extensions/matrix/src/matrix/monitor/mentions.test.ts
+++ b/extensions/matrix/src/matrix/monitor/mentions.test.ts
@@ -227,6 +227,23 @@ describe("resolveMentions", () => {
       expect(result.hasExplicitMention).toBe(true);
     });
 
+    it("detects mention when the visible label is bracketed @displayName", () => {
+      const result = resolveMentions({
+        content: {
+          msgtype: "m.text",
+          body: "@[Display Name] hello",
+          formatted_body: '<a href="https://matrix.to/#/@bot:matrix.org">@[Display Name]</a> hello',
+          "m.mentions": { user_ids: ["@bot:matrix.org"] },
+        },
+        userId,
+        displayName: "Display Name",
+        text: "@[Display Name] hello",
+        mentionRegexes: [],
+      });
+      expect(result.wasMentioned).toBe(true);
+      expect(result.hasExplicitMention).toBe(true);
+    });
+
     it("ignores out-of-range hexadecimal HTML entities in visible labels", () => {
       expect(
         resolveMentions({

--- a/extensions/matrix/src/matrix/monitor/mentions.ts
+++ b/extensions/matrix/src/matrix/monitor/mentions.ts
@@ -157,6 +157,7 @@ function isVisibleMentionLabel(params: {
     localpart ? extractVisibleMentionText(`@${localpart}`) : null,
     params.displayName ? extractVisibleMentionText(params.displayName) : null,
     params.displayName ? extractVisibleMentionText(`@${params.displayName}`) : null,
+    params.displayName ? extractVisibleMentionText(`@[${params.displayName}]`) : null,
   ].filter((value): value is string => Boolean(value));
   return candidates.includes(cleaned);
 }


### PR DESCRIPTION
## Summary

- Problem: Matrix can send a valid mention as a Matrix URI whose visible label is `@[Display Name]`, while `m.mentions.user_ids` contains the bot user id.
- Why it matters: OpenClaw treated that shape as not visible enough and skipped the room message, even though the mention metadata and visible link label match the bot.
- What changed: Matrix mention parsing now accepts the bracketed display-name label form, and the room handler has regression coverage for the reported shape.
- What did NOT change (scope boundary): Metadata-only mentions are still rejected when there is no matching visible text/link label.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #83142
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Matrix room messages with `m.mentions.user_ids` and a visible `@[Display Name]` link label now reach the normal mentioned-message handling path.
- Real environment tested: Local OpenClaw checkout using the Matrix monitor parser and room handler.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/matrix/src/matrix/monitor/mentions.test.ts extensions/matrix/src/matrix/monitor/handler.test.ts --reporter=dot`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
Test Files  2 passed (2)
Tests  128 passed (128)
```

- Observed result after fix: The bracketed display-name mention is detected by the parser and processed by the room handler.
- What was not tested: Live Matrix homeserver delivery with a real bot account.
- Before evidence (optional but encouraged): The new regression tests encode the previously skipped message shape.

## Root Cause (if applicable)

- Root cause: The Matrix mention candidate list accepted the raw display name and `@displayName`, but not the Matrix URI visible-label form `@[displayName]`.
- Missing detection / guardrail: There was no regression test for bracketed Matrix URI display-name labels.
- Contributing context (if known): The existing metadata-backed mention safety guard intentionally requires a visible label, so the fix needed to add only the missing valid label form.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/matrix/src/matrix/monitor/mentions.test.ts`, `extensions/matrix/src/matrix/monitor/handler.test.ts`
- Scenario the test should lock in: `m.mentions.user_ids` plus a formatted Matrix URI whose visible label is `@[Display Name]`.
- Why this is the smallest reliable guardrail: It covers the parser and the room-message handling seam without needing live Matrix credentials.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Matrix group messages that mention the bot with a valid bracketed display-name label are no longer skipped.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows local checkout
- Runtime/container: Node test runner
- Model/provider: N/A
- Integration/channel (if any): Matrix
- Relevant config (redacted): N/A

### Steps

1. Add a Matrix event with `m.mentions.user_ids` containing the bot user id.
2. Set `formatted_body` to a Matrix URI link whose visible label is `@[Display Name]`.
3. Run the focused Matrix mention parser and handler tests.

### Expected

- The message is treated as mentioning the bot.

### Actual

- The focused parser and handler tests pass after this patch.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: parser detection and room-handler processing for bracketed display-name mentions.
- Edge cases checked: metadata-backed mention still requires matching visible text/link label.
- What you did **not** verify: live Matrix homeserver delivery with a real bot account.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.
