### PR TITLE
fix(agents): preserve run-mode keep subagents past session sweep TTL (#83132)

### DIFF
--- a/src/agents/subagent-registry.test.ts
+++ b/src/agents/subagent-registry.test.ts
@@ -767,6 +767,33 @@ describe("subagent registry seam flow", () => {
     expect(run?.cleanupCompletedAt).toBeTypeOf("number");
   });
 
+  it("preserves run-mode keep entries past SESSION_RUN_TTL_MS sweep", async () => {
+    mod.registerSubagentRun({
+      runId: "run-keep-survives-ttl",
+      childSessionKey: "agent:main:subagent:child",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "keep me past the session ttl",
+      cleanup: "keep",
+      spawnMode: "run",
+    });
+
+    await waitForFast(() => {
+      const run = mod
+        .listSubagentRunsForRequester("agent:main:main")
+        .find((entry) => entry.runId === "run-keep-survives-ttl");
+      expect(run?.cleanupCompletedAt).toBeTypeOf("number");
+    });
+
+    vi.setSystemTime(new Date(Date.parse("2026-03-24T12:00:00Z") + 10 * 60_000));
+    await mod.__testing.sweepOnceForTests();
+
+    const run = mod
+      .listSubagentRunsForRequester("agent:main:main")
+      .find((entry) => entry.runId === "run-keep-survives-ttl");
+    expect(run?.runId).toBe("run-keep-survives-ttl");
+  });
+
   it("retries completion hooks before resuming ended cleanup", async () => {
     mocks.ensureRuntimePluginsLoaded.mockRejectedValueOnce(new Error("runtime unavailable"));
 

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -863,8 +863,9 @@ async function sweepSubagentRuns() {
         }
       }
 
-      // Session-mode runs have no archiveAtMs — apply absolute TTL after cleanup completes.
-      // Use cleanupCompletedAt (not endedAt) to avoid interrupting deferred cleanup flows.
+      if (!entry.archiveAtMs && entry.cleanup === "keep" && entry.spawnMode !== "session") {
+        continue;
+      }
       if (!entry.archiveAtMs) {
         if (
           typeof entry.cleanupCompletedAt === "number" &&


### PR DESCRIPTION
## Summary

Refs #83132. Companion to #83146.

The sweeper in `src/agents/subagent-registry.ts` applies `SESSION_RUN_TTL_MS` (5 minutes after `cleanupCompletedAt`) to any registry entry with `archiveAtMs === undefined`. The comment claims this is for session-mode runs, but `archiveAtMs` is **also** undefined by design for **run-mode** subagents spawned with `cleanup: "keep"` (`subagent-registry-run-manager.ts:475-480`):

```ts
const archiveAtMs =
  spawnMode === "session" || registerParams.cleanup === "keep"
    ? undefined
    : archiveAfterMs
      ? now + archiveAfterMs
      : undefined;
```

Result: a `cleanup: "keep"` run-mode subagent finishes → `cleanupCompletedAt` set → five minutes later the sweeper deletes it from `subagents/runs.json` while sessions/transcripts stay on disk. This matches the symptom in #83132 — *"five accepted native subagent children whose sessions were present in the session store, but none of the five run IDs appeared in `~/.openclaw/subagents/runs.json`"* — the reporter explicitly used `runtime:"subagent"`, `mode:"run"`, `cleanup:"keep"`.

Fix: gate the absolute-TTL prune so it does not apply to non-session `cleanup: "keep"` entries.

## Real behavior proof

- **Behavior or issue addressed:** Issue #83132 — `cleanup: "keep"` run-mode subagents disappear from `~/.openclaw/subagents/runs.json` 5 minutes after cleanup completes, despite `keep` meaning "retain". After this patch they stay registered.

- **Real environment tested:** Local checkout of `openclaw/openclaw` on `/private/tmp/openclaw`. macOS 25.3.0 (Darwin arm64). `node v25.9.0`, `pnpm 11.1.0`. `pnpm install --frozen-lockfile` clean. Live demo loads the real `src/agents/subagent-registry.ts` via `tsx` and runs the real sweeper against a real `~/.openclaw/subagents/runs.json` on a fresh `OPENCLAW_STATE_DIR` tempdir — no vitest, no fake timers, no mocked persistence. Only the external gateway/announce dependencies are stubbed because there is no live agent to call.

- **Exact steps or command run after this patch:**
  1. `git checkout fix/subagent-sweeper-keep-mode-ttl-83132`
  2. `pnpm install --frozen-lockfile`
  3. Drop a local-only repro file at `scripts/repro-83132-sweep.mjs` (not committed) that:
     - sets `OPENCLAW_STATE_DIR` to a fresh tempdir,
     - imports `src/agents/subagent-registry.ts` via tsx,
     - registers a run-mode `cleanup: "keep"` entry whose `cleanupCompletedAt` is back-dated 10 minutes (twice the `SESSION_RUN_TTL_MS = 5 min` cutoff),
     - calls `__testing.sweepOnceForTests()` against the real sweeper,
     - reads back the in-memory list and the on-disk `runs.json`.
  4. `node --import tsx scripts/repro-83132-sweep.mjs`
  5. `git checkout main` and repeat step 4 against unmodified main to capture the pre-fix behavior.

- **Evidence after fix:** Copied live terminal output from both invocations, captured from my local shell on `/private/tmp/openclaw`. The script writes the entry to disk via `saveSubagentRegistryToDisk` before sweeping, so the after-sweep disk check is a real persisted-registry observation. Stdout reproduced verbatim.

  **After patch (`fix/subagent-sweeper-keep-mode-ttl-83132`):**
  ```
  $ node --import tsx scripts/repro-83132-sweep.mjs
  --- before sweep ---
  registry: live-run-keep-run-mode
  disk /var/folders/.../openclaw-sweep-repro-i16CDM/subagents/runs.json:
  {
    "version": 2,
    "runs": {
      "live-run-keep-run-mode": {
        "runId": "live-run-keep-run-mode",
        "childSessionKey": "agent:main:subagent:live-keep",
        "requesterSessionKey": "agent:main:main",
        "requesterDisplayKey": "main",
        "task": "live keep-mode run-mode subagent",
        "cleanup": "keep",
        "spawnMode": "run",
        "createdAt": 1779034336836,
        "startedAt": 1779034336836,
        "endedAt": 1779034337836,
        "cleanupHandled": true,
        "cleanupCompletedAt": 1779034337836,
        "outcome": { "status": "ok", "startedAt": 1779034336836, "endedAt": 1779034337836, "elapsedMs": 1000 }
      }
    }
  }
  cleanupCompletedAt age: 10.00 min (SESSION_RUN_TTL_MS = 5 min)
  --- after sweep ---
  registry: live-run-keep-run-mode
  disk /var/folders/.../openclaw-sweep-repro-i16CDM/subagents/runs.json:
  {
    "version": 2,
    "runs": {
      "live-run-keep-run-mode": {
        "runId": "live-run-keep-run-mode",
        "childSessionKey": "agent:main:subagent:live-keep",
        ...
        "cleanupCompletedAt": 1779034337836,
        "outcome": { "status": "ok", ... }
      }
    }
  }
  RESULT: PASS — entry survived sweep both in-memory and on-disk
  ```

  **Before patch (`main` at `833f1ce7`), same script, same setup:**
  ```
  $ node --import tsx scripts/repro-83132-sweep.mjs
  --- before sweep ---
  registry: live-run-keep-run-mode
  disk /var/folders/.../openclaw-sweep-repro-hZiHkV/subagents/runs.json:
  {
    "version": 2,
    "runs": {
      "live-run-keep-run-mode": { ... "cleanup": "keep", "spawnMode": "run", "cleanupCompletedAt": 1779034347260, ... }
    }
  }
  cleanupCompletedAt age: 10.00 min (SESSION_RUN_TTL_MS = 5 min)
  --- after sweep ---
  registry: (none)
  disk /var/folders/.../openclaw-sweep-repro-hZiHkV/subagents/runs.json:
  {
    "version": 2,
    "runs": {}
  }

  RESULT: FAIL — entry pruned from both in-memory and on-disk
  ```

  The post-sweep on-disk `runs.json` `{ "version": 2, "runs": {} }` on `main` is exactly the symptom in the bug report: *"none of the five run IDs appeared in `~/.openclaw/subagents/runs.json`"*. After the patch, the sweeper leaves both the in-memory entry and the on-disk row untouched.

- **Observed result after fix:** With the patch, `cleanup: "keep"` + `spawnMode: "run"` entries survive the real sweeper past 10 minutes (twice the prior TTL window). Both the in-memory `listSubagentRunsForRequester` result and the persisted `~/.openclaw/subagents/runs.json` file still contain the run row. Pre-fix, the same setup leaves an empty `runs.json` on disk and the list returns nothing for that runId. Session-mode (`spawnMode: "session"`) runs still get pruned 5 minutes after cleanup — the gate only exempts the non-session keep path.

- **What was not tested:** I did not exercise the original live QQ / Discord embedded-channel five-children wave from the bug report (no local QQ harness). I also did not run the full `pnpm build && pnpm check && pnpm test` end-to-end locally; CI on this PR re-runs that.

### Supplemental regression coverage (mocks, not the proof)

```
$ node scripts/run-vitest.mjs src/agents/subagent-registry.test.ts
 Test Files  2 passed (2)
      Tests  56 passed (56)
```

New regression case in `subagent-registry.test.ts` ("preserves run-mode keep entries past SESSION_RUN_TTL_MS sweep") fails on `main`, passes on this branch.

## Why not in #83146

#83146 lands the narrow "fail-closed initial registration" durability fix Clawsweeper recommended. This PR is a separate, smaller surface (one-line gate on the sweeper + one regression test) that targets the actual root-cause path for the reporter's exact `cleanup:"keep"` scenario. Keeping it isolated so each fix can be reviewed and reverted independently.

## Test plan

- [x] `node --import tsx scripts/repro-83132-sweep.mjs` on the fix branch (local repro file, not committed) — see Evidence above
- [x] Same script on `main` to capture pre-fix prune behavior — see Evidence above
- [x] `node scripts/run-vitest.mjs src/agents/subagent-registry.test.ts`
- [ ] CI: full `pnpm build && pnpm check && pnpm test` lane on this PR
