### PR TITLE
docs(mantis): prefer openclaw mantis mention

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -1629,7 +1629,7 @@ openclaw logs --follow
           // Molty listens to all bot-authored Discord messages.
           allowBots: true,
           mentionAliases: {
-            // Lets Molty write "@Mantis" and send a real Discord mention.
+            // Lets Molty write an OpenClaw Mantis mention and send a real Discord mention.
             Mantis: "MANTIS_DISCORD_USER_ID",
           },
           botLoopProtection: {

--- a/docs/concepts/mantis.md
+++ b/docs/concepts/mantis.md
@@ -252,7 +252,7 @@ Telegram Web login state is not required for normal Mantis automation.
 
 `Mantis Telegram Desktop Proof` is the agentic native Telegram Desktop
 before/after wrapper. A maintainer can trigger it from a PR comment with
-`@Mantis telegram desktop proof`, from the Actions UI with freeform
+`@openclaw-mantis telegram desktop proof`, from the Actions UI with freeform
 instructions, or through the generic `Mantis Scenario` dispatcher. The workflow
 hands the PR, baseline ref, candidate ref, and maintainer instructions to Codex.
 The agent reads the PR, decides what Telegram-visible behavior proves the
@@ -348,10 +348,12 @@ region, and public URL values directly. The reusable publisher requires:
 - `MANTIS_ARTIFACT_R2_REGION`
 - `MANTIS_ARTIFACT_R2_PUBLIC_BASE_URL`
 
-You can also trigger the status-reactions run directly from a PR comment:
+You can also trigger the status-reactions run directly from a PR comment. Use
+the full OpenClaw-owned Mantis account name in maintainer examples; the short
+historical mention is ambiguous on GitHub and should be treated as legacy:
 
 ```text
-@Mantis discord status reactions
+@openclaw-mantis discord status reactions
 ```
 
 The comment trigger is intentionally narrow. It only runs on pull request
@@ -361,15 +363,15 @@ and the current PR head SHA as the candidate. Maintainers can override either
 ref:
 
 ```text
-@Mantis discord status reactions baseline=origin/main candidate=HEAD
+@openclaw-mantis discord status reactions baseline=origin/main candidate=HEAD
 ```
 
 Telegram live QA can also be triggered from a PR comment:
 
 ```text
-@Mantis telegram
-@Mantis telegram scenario=telegram-status-command
-@Mantis telegram scenarios=telegram-status-command,telegram-mentioned-message-reply
+@openclaw-mantis telegram
+@openclaw-mantis telegram scenario=telegram-status-command
+@openclaw-mantis telegram scenarios=telegram-status-command,telegram-mentioned-message-reply
 ```
 
 By default it uses the current PR head SHA as the candidate and runs

--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -335,9 +335,9 @@ start it from the Actions UI through `Mantis Scenario` (`scenario_id:
 telegram-live`) or directly from a pull request comment:
 
 ```text
-@Mantis telegram
-@Mantis telegram scenario=telegram-status-command
-@Mantis telegram scenarios=telegram-status-command,telegram-mentioned-message-reply
+@openclaw-mantis telegram
+@openclaw-mantis telegram scenario=telegram-status-command
+@openclaw-mantis telegram scenarios=telegram-status-command,telegram-mentioned-message-reply
 ```
 
 `Mantis Telegram Desktop Proof` is the agentic native Telegram Desktop
@@ -346,7 +346,7 @@ freeform `instructions`, through `Mantis Scenario` (`scenario_id:
 telegram-desktop-proof`), or from a PR comment:
 
 ```text
-@Mantis telegram desktop proof
+@openclaw-mantis telegram desktop proof
 ```
 
 The Mantis agent reads the PR, decides what Telegram-visible behavior proves the


### PR DESCRIPTION
Summary
- Prefer `@openclaw-mantis` in Mantis maintainer-facing docs.
- Remove ambiguous `@Mantis` examples from docs while leaving workflow compatibility unchanged.
- Clarify the full OpenClaw-owned account name should be used in maintainer examples.

Verification
- `git diff --check -- docs/concepts/mantis.md docs/help/testing.md docs/channels/discord.md`
- `rg -n "@Mantis|@mantis" docs README.md`
- `CI=true pnpm docs:list`
