### PR TITLE
fix(discord): return subagent thread delivery origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Discord/OpenAI: keep realtime Discord voice sessions hearing follow-up turns with OpenAI realtime and prebuffer assistant playback to avoid choppy starts. (#80505) Thanks @Solvely-Colin.
+- Discord/subagents: route the initial reply from thread-bound delegated sessions into the bound Discord thread instead of the parent channel. Fixes #83170. (#83172) Thanks @100menotu001.
 - Media: prevent image metadata probing from invoking external decoder delegates on unrecognized image bytes, and stop fallback chaining after real processing errors.
 - Media: install Sharp with the root package and fall back to sips, Windows native imaging, ImageMagick, GraphicsMagick, or ffmpeg for image resizing/conversion when Sharp is unavailable. Fixes #83401. Thanks @scotthuang.
 - Telegram: deliver generated media completions back into forum topics by preserving topic IDs across requester-agent handoff. (#83556) Thanks @fuller-stack-dev.

--- a/extensions/discord/src/subagent-hooks.test.ts
+++ b/extensions/discord/src/subagent-hooks.test.ts
@@ -339,7 +339,16 @@ describe("discord subagent hook handlers", () => {
     });
 
     expect(hookMocks.autoBindSpawnedDiscordSubagent).toHaveBeenCalledTimes(1);
-    expect(result).toStrictEqual({ status: "ok", threadBindingReady: true });
+    expect(result).toMatchObject({
+      status: "ok",
+      threadBindingReady: true,
+      deliveryOrigin: {
+        channel: "discord",
+        accountId: "work",
+        to: "channel:thread-1",
+        threadId: "thread-1",
+      },
+    });
   });
 
   it("defaults thread-bound subagent spawn to enabled when unset", async () => {
@@ -352,7 +361,16 @@ describe("discord subagent hook handlers", () => {
     });
 
     expect(hookMocks.autoBindSpawnedDiscordSubagent).toHaveBeenCalledTimes(1);
-    expect(result).toStrictEqual({ status: "ok", threadBindingReady: true });
+    expect(result).toMatchObject({
+      status: "ok",
+      threadBindingReady: true,
+      deliveryOrigin: {
+        channel: "discord",
+        accountId: "work",
+        to: "channel:thread-1",
+        threadId: "thread-1",
+      },
+    });
   });
 
   it("no-ops when thread binding is requested on non-discord channel", async () => {

--- a/extensions/discord/src/subagent-hooks.test.ts
+++ b/extensions/discord/src/subagent-hooks.test.ts
@@ -234,7 +234,16 @@ describe("discord subagent hook handlers", () => {
       label: "banana",
       boundBy: "system",
     });
-    expect(result).toStrictEqual({ status: "ok", threadBindingReady: true });
+    expect(result).toMatchObject({
+      status: "ok",
+      threadBindingReady: true,
+      deliveryOrigin: {
+        channel: "discord",
+        accountId: "work",
+        to: "channel:thread-1",
+        threadId: "thread-1",
+      },
+    });
   });
 
   it("returns error when thread-bound subagent spawn is disabled", async () => {

--- a/extensions/discord/src/subagent-hooks.ts
+++ b/extensions/discord/src/subagent-hooks.ts
@@ -58,7 +58,16 @@ type DiscordSubagentDeliveryTargetEvent = {
 };
 
 type DiscordSubagentSpawningResult =
-  | { status: "ok"; threadBindingReady?: boolean }
+  | {
+      status: "ok";
+      threadBindingReady?: boolean;
+      deliveryOrigin?: {
+        channel: "discord";
+        accountId?: string;
+        to: string;
+        threadId?: string | number;
+      };
+    }
   | { status: "error"; error: string }
   | undefined;
 
@@ -142,7 +151,16 @@ export async function handleDiscordSubagentSpawning(
           "Unable to create or bind a Discord thread for this subagent session. Session mode is unavailable for this target.",
       };
     }
-    return { status: "ok" as const, threadBindingReady: true };
+    return {
+      status: "ok" as const,
+      threadBindingReady: true,
+      deliveryOrigin: {
+        channel: "discord",
+        accountId: account.accountId,
+        to: `channel:${binding.threadId}`,
+        threadId: binding.threadId,
+      },
+    };
   } catch (err) {
     return {
       status: "error" as const,


### PR DESCRIPTION
## Summary

- Problem: Discord delegated sessions can bind a thread successfully but still post the initial child reply into the parent channel.
- Why it matters: thread-bound delegation looks broken even when the binding exists, weakening isolation for delegated work.
- What changed: the Discord `subagent_spawning` hook now returns a routable Discord `deliveryOrigin` after `autoBindSpawnedDiscordSubagent` succeeds, and the hook test asserts that contract.
- What did NOT change (scope boundary): no generic spawn-path refactor, no session-store schema change, and no non-Discord behavior change.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #83170
- Related #42986
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Discord thread-bound `sessions_spawn` accepted a child session and created the binding, but the initial child reply still landed in the parent channel.
- Real environment tested: local managed OpenClaw runtime on macOS with Discord thread bindings enabled, plus this local source checkout.
- Exact steps or command run after this patch: `pnpm test extensions/discord/src/subagent-hooks.test.ts` plus a one-off PR-head Discord API proof script that exercised `subagent_spawning`, `subagent_delivery_target`, send, and readback against a configured Discord text channel.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): targeted hook regression test passes, and the redacted live proof below shows PR-head Discord API thread creation, delivery-origin routing, send receipt, and message readback all targeting the bound thread.
- Observed result after fix: the Discord hook returns a routable `deliveryOrigin` for the bound thread in the covered test path.
- What was not tested: a full model-generated child transcript screenshot. The follow-up proof uses the PR-head hook path plus Discord API send/readback and keeps Discord UI identifiers redacted.
- Before evidence (optional but encouraged): live managed-runtime repro before the patch showed `sessions_spawn(thread=true, mode=session)` accepted while the child still resolved to the parent channel.

## Root Cause (if applicable)

- Root cause: `extensions/discord/src/subagent-hooks.ts` created the thread binding but returned only `threadBindingReady: true`. The generic spawn path only switches the initial child run onto the thread when `subagent_spawning` also returns a routable `deliveryOrigin`.
- Missing detection / guardrail: the Discord hook test asserted binding readiness but did not assert the returned delivery target.
- Contributing context (if known): the completion-delivery hook already knew how to derive a bound Discord thread target, but the initial child run path depended on the spawning hook.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/discord/src/subagent-hooks.test.ts`
- Scenario the test should lock in: when Discord `subagent_spawning` successfully binds a thread, it must return `deliveryOrigin` pointing at the bound Discord thread.
- Why this is the smallest reliable guardrail: the failure is in the Discord hook contract, not in generic spawn orchestration.
- Existing test that already covers this (if any): the existing bind-on-spawn test in the same file, now extended.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Discord thread-bound delegated child sessions can route their initial reply into the bound thread instead of falling back to the parent channel.

## Diagram (if applicable)

```text
Before:
Discord sessions_spawn(thread=true) -> thread binding created -> initial child reply falls back to parent channel

After:
Discord sessions_spawn(thread=true) -> thread binding created -> deliveryOrigin returned -> initial child reply routes to bound thread
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local source checkout plus local managed OpenClaw runtime repro
- Model/provider: `openai/gpt-5.4` in the observed repro
- Integration/channel (if any): Discord
- Relevant config (redacted): Discord thread bindings enabled; `spawnSubagentSessions` enabled

### Steps

1. Enable Discord thread bindings for delegated spawns.
2. Call `sessions_spawn` with `thread=true` and `mode=session` from a Discord channel.
3. Observe where the initial child reply lands.

### Expected

- Initial child reply lands in the bound Discord thread.

### Actual

- Before fix, the initial child reply fell back to the parent channel even though binding succeeded.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: traced the live repro in the managed runtime; verified the hook-level regression test passes; verified PR-head Discord hook deliveryOrigin, delivery-target resolution, send receipt, and message readback route to the bound thread.
- Edge cases checked: scope stays Discord-only and does not alter the generic spawn path.
- What you did **not** verify: a full model-generated child transcript screenshot; the direct proof below avoids exposing Discord UI PII while verifying the route Discord actually received.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Discord thread targets may expect a different routable shape than `channel:<threadId>` in some edge account mode.
  - Mitigation: this patch mirrors the existing Discord `subagent_delivery_target` behavior, and the regression test locks in that contract.

## Redacted Live Proof

- Generated: 2026-05-17T19:42:41.448Z
- PR head: `50e3c7e87d7286ffe229c2ef7e8650d5dcaa2058`
- Proof status: pass
- Proof method: one-off PR-head Discord proof against the configured Discord API path; secrets stayed in the local token resolver and were not printed.
- Redacted IDs: account `37a8eec1ce19`, parent channel `527d50fab9ab`, created thread `ad20902de816`, child session `9eadd11f51d4`, ACK message `6440e0c64279`.
- Surface checked: parent channel type `0` (Discord guild text), created thread type `11` (public thread), created thread parent hash `527d50fab9ab`.
- PR-head hook result: `subagent_spawning` returned `status=ok`, `threadBindingReady=true`, and `deliveryOrigin` with shape `channel:<thread-id>` for thread hash `ad20902de816`.
- Completion-route hook result: `subagent_delivery_target` resolved the same `channel:<thread-id>` target for thread hash `ad20902de816`.
- Delivery/readback result: an ACK sent through the returned `deliveryOrigin` produced a Discord send receipt with channel hash `ad20902de816`, and readback from the bound thread found the ACK with message `channel_id` hash `ad20902de816`.
- Parent-channel guard: the ACK send receipt and bound-thread readback channel hashes differ from the parent channel hash `527d50fab9ab`, so the proof message was posted to the bound thread target, not the parent channel target.
- Redaction: no bot token, raw Discord IDs, usernames, chat titles, local config, or local filesystem paths are included.
