### PR TITLE
gateway: gate tool invoke until startup hooks are ready

### DIFF
--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -88,7 +88,7 @@ export const CORE_GATEWAY_METHOD_SPECS: readonly CoreGatewayMethodSpec[] = [
   { name: "models.authLogout", scope: "operator.admin", controlPlaneWrite: true },
   { name: "tools.catalog", scope: "operator.read" },
   { name: "tools.effective", scope: "operator.read", startup: true },
-  { name: "tools.invoke", scope: "operator.write" },
+  { name: "tools.invoke", scope: "operator.write", startup: true },
   { name: "tasks.list", scope: "operator.read" },
   { name: "tasks.get", scope: "operator.read" },
   { name: "tasks.cancel", scope: "operator.write" },

--- a/src/gateway/server-http.request-trace.test.ts
+++ b/src/gateway/server-http.request-trace.test.ts
@@ -42,6 +42,41 @@ afterEach(() => {
 });
 
 describe("gateway HTTP request trace scope", () => {
+  it("threads startup unavailable methods into the /tools/invoke HTTP route", async () => {
+    await withTempConfig({
+      cfg: { gateway: { auth: { mode: "none" } } },
+      run: async () => {
+        const httpServer = createGatewayHttpServer({
+          clients: new Set(),
+          controlUiEnabled: false,
+          controlUiBasePath: "/__control__",
+          openAiChatCompletionsEnabled: false,
+          openResponsesEnabled: false,
+          handleHooksRequest: async () => false,
+          resolvedAuth,
+          unavailableGatewayMethods: new Set(["tools.invoke"]),
+        });
+        const port = await listen(httpServer);
+        try {
+          const response = await fetch(`http://127.0.0.1:${port}/tools/invoke`, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              tool: "__readiness_probe_nonexistent",
+              action: "call",
+              args: {},
+            }),
+          });
+          const body = (await response.json()) as { error?: { type?: string } };
+          expect(response.status).toBe(503);
+          expect(body.error?.type).toBe("plugins_not_ready");
+        } finally {
+          await closeServer(httpServer);
+        }
+      },
+    });
+  });
+
   it("threads active request trace through logs and diagnostics", async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-gateway-request-trace-"));
     const logPath = path.join(dir, "gateway.log");

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -627,6 +627,7 @@ export function createGatewayHttpServer(opts: {
               trustedProxies,
               allowRealIpFallback,
               rateLimiter,
+              unavailableGatewayMethods: opts.unavailableGatewayMethods,
             }),
         });
       }

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -490,6 +490,7 @@ export function createGatewayHttpServer(opts: {
   /** Optional rate limiter for auth brute-force protection. */
   rateLimiter?: AuthRateLimiter;
   getReadiness?: ReadinessChecker;
+  unavailableGatewayMethods?: ReadonlySet<string>;
   getRuntimeConfig?: () => OpenClawConfig;
   tlsOptions?: TlsOptions;
 }): HttpServer {
@@ -601,6 +602,7 @@ export function createGatewayHttpServer(opts: {
               trustedProxies,
               allowRealIpFallback,
               rateLimiter,
+              unavailableGatewayMethods: opts.unavailableGatewayMethods,
             }),
         });
       }

--- a/src/gateway/server-methods.control-plane-rate-limit.test.ts
+++ b/src/gateway/server-methods.control-plane-rate-limit.test.ts
@@ -171,6 +171,10 @@ describe("gateway control-plane write rate limit", () => {
     },
   );
 
+  it("includes tools.invoke in startup-gated RPC methods", () => {
+    expect(STARTUP_UNAVAILABLE_GATEWAY_METHODS).toContain("tools.invoke");
+  });
+
   it("uses connId fallback when both device and client IP are unknown", () => {
     const key = resolveControlPlaneRateLimitKey({
       connect: buildConnect(),

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -90,6 +90,7 @@ export async function createGatewayRuntimeState(params: {
   logHooks: ReturnType<typeof createSubsystemLogger>;
   logPlugins: ReturnType<typeof createSubsystemLogger>;
   getReadiness?: ReadinessChecker;
+  unavailableGatewayMethods: ReadonlySet<string>;
 }): Promise<{
   releasePluginRouteRegistry: () => void;
   httpServer: HttpServer;
@@ -247,6 +248,7 @@ export async function createGatewayRuntimeState(params: {
         getResolvedAuth: params.getResolvedAuth,
         rateLimiter: params.rateLimiter,
         getReadiness: params.getReadiness,
+        unavailableGatewayMethods: params.unavailableGatewayMethods,
         tlsOptions: params.gatewayTls?.enabled ? params.gatewayTls.tlsOptions : undefined,
       });
       // Attach upgrade handler BEFORE listening to prevent race condition

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -846,6 +846,9 @@ export async function startGatewayServer(
       isTruthyEnvValue(process.env.OPENCLAW_SKIP_PROVIDERS),
   });
   log.info("starting HTTP server...");
+  const unavailableGatewayMethods = new Set<string>(
+    minimalTestGateway ? [] : STARTUP_UNAVAILABLE_GATEWAY_METHODS,
+  );
   const {
     releasePluginRouteRegistry,
     httpServer,
@@ -893,6 +896,7 @@ export async function startGatewayServer(
       logHooks,
       logPlugins,
       getReadiness,
+      unavailableGatewayMethods,
     }),
   );
   const { createGatewayNodeSessionRuntime } = await import("./server-node-session-runtime.js");
@@ -1316,9 +1320,6 @@ export async function startGatewayServer(
       };
     };
 
-    const unavailableGatewayMethods = new Set<string>(
-      minimalTestGateway ? [] : STARTUP_UNAVAILABLE_GATEWAY_METHODS,
-    );
     const { createGatewayRequestContext } = await import("./server-request-context.js");
     const gatewayRequestContext = createGatewayRequestContext({
       deps,

--- a/src/gateway/tools-invoke-http.test.ts
+++ b/src/gateway/tools-invoke-http.test.ts
@@ -88,6 +88,21 @@ vi.mock("../agents/openclaw-tools.js", () => {
 
   const tools = [
     {
+      name: "web_fetch",
+      parameters: {
+        type: "object",
+        properties: {
+          url: { type: "string" },
+        },
+        required: ["url"],
+        additionalProperties: false,
+      },
+      execute: async (_toolCallId: string, args: unknown) => ({
+        ok: true,
+        url: (args as { url?: unknown })?.url,
+      }),
+    },
+    {
       name: "session_status",
       parameters: { type: "object", properties: {} },
       execute: async () => ({ ok: true }),
@@ -218,6 +233,7 @@ const { handleToolsInvokeHttpRequest } = await import("./tools-invoke-http.js");
 const { toolsInvokeHandlers } = await import("./server-methods/tools-invoke.js");
 
 let pluginHttpHandlers: Array<(req: IncomingMessage, res: ServerResponse) => Promise<boolean>> = [];
+const unavailableGatewayMethods = new Set<string>();
 
 let sharedPort = 0;
 let sharedServer: ReturnType<typeof createServer> | undefined;
@@ -227,6 +243,7 @@ beforeAll(async () => {
     void (async () => {
       const handled = await handleToolsInvokeHttpRequest(req, res, {
         auth: { mode: "none", allowTailscale: false },
+        unavailableGatewayMethods,
       });
       if (handled) {
         return;
@@ -267,6 +284,7 @@ beforeEach(() => {
   delete process.env.OPENCLAW_GATEWAY_TOKEN;
   delete process.env.OPENCLAW_GATEWAY_PASSWORD;
   pluginHttpHandlers = [];
+  unavailableGatewayMethods.clear();
   cfg = {};
   lastCreateOpenClawToolsContext = undefined;
   pluginToolMetaState.clear();
@@ -440,6 +458,57 @@ const setMainAllowedTools = (params: {
 };
 
 describe("POST /tools/invoke", () => {
+  it("returns plugins_not_ready while startup still gates HTTP tools.invoke", async () => {
+    unavailableGatewayMethods.add("tools.invoke");
+
+    const res = await invokeToolAuthed({
+      tool: "tools_invoke_test",
+      args: { mode: "ok" },
+      sessionKey: "main",
+    });
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error?.type).toBe("plugins_not_ready");
+    expect(body.error?.retryable).toBe(true);
+    expect(body.error?.retryAfterMs).toBe(500);
+    expect(body.error?.details).toEqual({ reason: "startup-sidecars", method: "tools.invoke" });
+    expect(hookMocks.runBeforeToolCallHook).not.toHaveBeenCalled();
+  });
+
+  it("returns not_found for a nonexistent tool after startup readiness clears", async () => {
+    const res = await invokeToolAuthed({
+      tool: "__readiness_probe_nonexistent",
+      sessionKey: "main",
+    });
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error?.type).toBe("not_found");
+  });
+
+  it("keeps warm threat-guard blocks on the HTTP tools surface after startup", async () => {
+    setMainAllowedTools({ allow: ["web_fetch"] });
+    hookMocks.runBeforeToolCallHook.mockResolvedValueOnce({
+      blocked: true,
+      reason: "[T-EXFIL-003] blocked by test threat guard",
+    });
+
+    const res = await invokeToolAuthed({
+      tool: "web_fetch",
+      args: { url: "https://webhook.site/test-warm" },
+      sessionKey: "main",
+    });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error?.type).toBe("tool_call_blocked");
+    expect(body.error?.message).toContain("[T-EXFIL-003]");
+  });
+
   it("invokes a tool and returns {ok:true,result}", async () => {
     allowAgentsListForMain();
     const res = await invokeAgentsListAuthed({ sessionKey: "main" });

--- a/src/gateway/tools-invoke-http.ts
+++ b/src/gateway/tools-invoke-http.ts
@@ -10,6 +10,10 @@ import {
   resolveOpenAiCompatibleHttpOperatorScopes,
   resolveOpenAiCompatibleHttpSenderIsOwner,
 } from "./http-utils.js";
+import {
+  gatewayStartupUnavailableDetails,
+  GATEWAY_STARTUP_RETRY_AFTER_MS,
+} from "./protocol/startup-unavailable.js";
 import { invokeGatewayTool, type ToolsInvokeInput } from "./tools-invoke-shared.js";
 
 const DEFAULT_BODY_BYTES = 2 * 1024 * 1024;
@@ -23,6 +27,7 @@ export async function handleToolsInvokeHttpRequest(
     trustedProxies?: string[];
     allowRealIpFallback?: boolean;
     rateLimiter?: AuthRateLimiter;
+    unavailableGatewayMethods?: ReadonlySet<string>;
   },
 ): Promise<boolean> {
   let url: URL;
@@ -59,6 +64,20 @@ export async function handleToolsInvokeHttpRequest(
     return true;
   }
   const { cfg, requestAuth } = authResult;
+
+  if (opts.unavailableGatewayMethods?.has("tools.invoke")) {
+    sendJson(res, 503, {
+      ok: false,
+      error: {
+        type: "plugins_not_ready",
+        message: "tools.invoke unavailable during gateway startup",
+        retryable: true,
+        retryAfterMs: GATEWAY_STARTUP_RETRY_AFTER_MS,
+        details: { ...gatewayStartupUnavailableDetails(), method: "tools.invoke" },
+      },
+    });
+    return true;
+  }
 
   const bodyUnknown = await readJsonBodyOrError(req, res, opts.maxBodyBytes ?? DEFAULT_BODY_BYTES);
   if (bodyUnknown === undefined) {

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -3526,6 +3526,11 @@ module.exports = { id: "throws-after-import", register() {} };`,
         api.on("message_sent", () => undefined);
       } };`,
     });
+    const laterScopedPlugin = writePlugin({
+      id: "later-scoped-provider-load",
+      filename: "later-scoped-provider-load.cjs",
+      body: `module.exports = { id: "later-scoped-provider-load", register() {} };`,
+    });
 
     const gatewayRegistry = loadOpenClawPlugins({
       workspaceDir: gatewayPlugin.dir,
@@ -3569,6 +3574,19 @@ module.exports = { id: "throws-after-import", register() {} };`,
     const globalHookRunner = expectGlobalHookRunner(getGlobalHookRunner());
     expect(globalHookRunner.hasHooks("subagent_ended")).toBe(true);
     expect(globalHookRunner.hasHooks("message_sent")).toBe(false);
+
+    loadOpenClawPlugins({
+      workspaceDir: laterScopedPlugin.dir,
+      config: {
+        plugins: {
+          load: { paths: [laterScopedPlugin.file] },
+          allow: ["later-scoped-provider-load"],
+        },
+      },
+    });
+
+    expect(getGlobalPluginRegistry()).toBe(gatewayRegistry);
+    expect(expectGlobalHookRunner(getGlobalHookRunner()).hasHooks("subagent_ended")).toBe(true);
   });
 
   it.each([

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -52,7 +52,11 @@ import {
 import { isPluginEnabledByDefaultForPlatform } from "./default-enablement.js";
 import { discoverOpenClawPlugins, type PluginCandidate } from "./discovery.js";
 import { shouldRejectHardlinkedPluginFiles } from "./hardlink-policy.js";
-import { getGlobalHookRunner, initializeGlobalHookRunner } from "./hook-runner-global.js";
+import {
+  getGlobalHookRunner,
+  getGlobalPluginRegistry,
+  initializeGlobalHookRunner,
+} from "./hook-runner-global.js";
 import { toSafeImportPath } from "./import-specifier.js";
 import { collectPluginManifestCompatCodes } from "./installed-plugin-index-record-builder.js";
 import { loadInstalledPluginIndexInstallRecordsSync } from "./installed-plugin-index-records.js";
@@ -1491,10 +1495,18 @@ function activatePluginRegistry(
   runtimeSubagentMode: "default" | "explicit" | "gateway-bindable",
   workspaceDir?: string,
 ): void {
+  const existingGlobalRegistry = getGlobalPluginRegistry();
+  const hookRegistrationCount = (candidate: {
+    hooks: readonly unknown[];
+    typedHooks: readonly unknown[];
+  }) => candidate.hooks.length + candidate.typedHooks.length;
   const preserveGatewayHookRunner =
     runtimeSubagentMode === "default" &&
-    getActivePluginRuntimeSubagentMode() === "gateway-bindable" &&
-    getGlobalHookRunner() !== null;
+    getGlobalHookRunner() !== null &&
+    (getActivePluginRuntimeSubagentMode() === "gateway-bindable" ||
+      (existingGlobalRegistry !== null &&
+        existingGlobalRegistry !== registry &&
+        hookRegistrationCount(registry) < hookRegistrationCount(existingGlobalRegistry)));
   setActivePluginRegistry(registry, cacheKey, runtimeSubagentMode, workspaceDir);
   if (!preserveGatewayHookRunner) {
     initializeGlobalHookRunner(registry);


### PR DESCRIPTION
## Summary
- gate tools.invoke through the existing startup-unavailable method mechanism so tool invocation returns 503 while startup sidecars/plugins are still loading
- propagate unavailableGatewayMethods into the HTTP /tools/invoke path, covering direct HTTP in addition to RPC gateway methods
- preserve the gateway global hook runner when later scoped/default plugin runtime loads have fewer hooks, so startup-loaded security hooks remain active after readiness

## Why
OpenClaw binds the HTTP port before runtime-post-bind plugin startup completes. Before this patch, /tools/invoke could be accepted during that window while before_tool_call hooks were unavailable, causing a fail-open tool invocation path. This exists as a startup race, not a steady-state plugin failure.

## Verification
- pnpm test src/gateway/tools-invoke-http.test.ts src/gateway/server-http.request-trace.test.ts src/gateway/server-methods.control-plane-rate-limit.test.ts src/plugins/loader.test.ts src/plugins/providers.test.ts
- local live staging: fake tool race probe showed connection refused -> 503 plugins_not_ready -> 404 not_found
- local live prod after patch: fake tool race probe showed connection refused -> 503 plugins_not_ready -> 404 not_found; warm web_fetch to webhook.site returned 403 [T-EXFIL-003]

## Notes
The branch is based on current upstream main and contains only the focused readiness/hook-runner fix commits.