### PR TITLE
fix(sessions): robust delivery-mirror dedup with visible-text comparison

### DIFF
--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -344,6 +344,102 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     }
   });
 
+  it("dedupes delivery mirror when text differs only by whitespace normalization", async () => {
+    writeTranscriptStore();
+
+    // Exact assistant has "extra" spaces in its content text
+    const exactResult = await appendExactAssistantMessageToSessionTranscript({
+      sessionKey,
+      storePath: fixture.storePath(),
+      message: createExactAssistantMessage({
+        content: [{ type: "text", text: "Hello   world!" }],
+      }),
+    });
+    expect(exactResult.ok).toBe(true);
+
+    // Mirror has the same text with normal spacing
+    const mirrorResult = await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      text: "Hello world!",
+      storePath: fixture.storePath(),
+    });
+
+    expect(mirrorResult.ok).toBe(true);
+    if (exactResult.ok && mirrorResult.ok) {
+      expect(mirrorResult.messageId).toBe(exactResult.messageId);
+      // Only 2 lines: header + original assistant (no duplicate)
+      const lines = fs.readFileSync(mirrorResult.sessionFile, "utf-8").trim().split("\n");
+      expect(lines.length).toBe(2);
+    }
+  });
+
+  it("dedupes delivery mirror when assistant has phased commentary + final answer", async () => {
+    writeTranscriptStore();
+
+    // Exact assistant has both commentary (thinking) and final_answer phases
+    const exactResult = await appendExactAssistantMessageToSessionTranscript({
+      sessionKey,
+      storePath: fixture.storePath(),
+      message: createExactAssistantMessage({
+        content: [
+          {
+            type: "text",
+            text: "Let me think about this...\nI need to consider several factors.",
+            textSignature: JSON.stringify({ v: 1, id: "thinking", phase: "commentary" }),
+          },
+          {
+            type: "text",
+            text: "The answer is 42.",
+            textSignature: JSON.stringify({ v: 1, id: "final", phase: "final_answer" }),
+          },
+        ],
+      }),
+    });
+    expect(exactResult.ok).toBe(true);
+
+    // Mirror has only the visible final-answer text
+    const mirrorResult = await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      text: "The answer is 42.",
+      storePath: fixture.storePath(),
+    });
+
+    expect(mirrorResult.ok).toBe(true);
+    if (exactResult.ok && mirrorResult.ok) {
+      expect(mirrorResult.messageId).toBe(exactResult.messageId);
+      const lines = fs.readFileSync(mirrorResult.sessionFile, "utf-8").trim().split("\n");
+      expect(lines.length).toBe(2);
+    }
+  });
+
+  it("dedupes delivery mirror when assistant text has extra newlines", async () => {
+    writeTranscriptStore();
+
+    // Exact assistant has trailing newline that differs from mirror
+    const exactResult = await appendExactAssistantMessageToSessionTranscript({
+      sessionKey,
+      storePath: fixture.storePath(),
+      message: createExactAssistantMessage({
+        content: [{ type: "text", text: "Hello from Codex!\n" }],
+      }),
+    });
+    expect(exactResult.ok).toBe(true);
+
+    // Mirror has same text without trailing newline
+    const mirrorResult = await appendAssistantMessageToSessionTranscript({
+      sessionKey,
+      text: "Hello from Codex!",
+      storePath: fixture.storePath(),
+    });
+
+    expect(mirrorResult.ok).toBe(true);
+    if (exactResult.ok && mirrorResult.ok) {
+      expect(mirrorResult.messageId).toBe(exactResult.messageId);
+      const lines = fs.readFileSync(mirrorResult.sessionFile, "utf-8").trim().split("\n");
+      expect(lines.length).toBe(2);
+    }
+  });
+
   it("keeps delivery mirrors in transcripts while repair preserves real tool results", async () => {
     writeTranscriptStore();
     const sessionFile = resolveSessionTranscriptPathInDir(sessionId, fixture.sessionsDir());

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -379,6 +379,15 @@ function extractAssistantMessageText(message: SessionTranscriptAssistantMessage)
   return parts.length > 0 ? parts.join("\n").trim() : null;
 }
 
+/**
+ * Collapse all whitespace (including newlines) to single spaces and trim,
+ * making text comparison tolerant of formatting differences such as line
+ * wrapping or extra spacing between content blocks.
+ */
+function normalizeTextForComparison(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
 async function findLatestEquivalentAssistantMessageId(
   transcriptPath: string,
   message: SessionTranscriptAssistantMessage,
@@ -390,6 +399,7 @@ async function findLatestEquivalentAssistantMessageId(
   if (!expectedText) {
     return undefined;
   }
+  const normalizedExpected = normalizeTextForComparison(expectedText);
 
   for await (const line of streamSessionTranscriptLinesReverse(transcriptPath)) {
     try {
@@ -401,13 +411,23 @@ async function findLatestEquivalentAssistantMessageId(
       if (!candidate || candidate.role !== "assistant") {
         continue;
       }
-      const candidateText = extractAssistantMessageText(
+      // Compare visible text (excluding thinking/commentary phases) so that
+      // a delivery-mirror entry with only the final answer can match a real
+      // assistant response that also contains internal reasoning.
+      const candidateVisibleText = extractAssistantVisibleText(
         redactTranscriptMessage(
           candidate as AgentMessage,
           config,
-        ) as unknown as SessionTranscriptAssistantMessage,
+        ),
       );
-      if (candidateText !== expectedText) {
+      if (!candidateVisibleText) {
+        continue;
+      }
+      if (
+        normalizeTextForComparison(candidateVisibleText) !== normalizedExpected
+      ) {
+        // Most recent assistant differs — this is a different response, not
+        // a duplicate mirror. Abort rather than matching an older turn.
         return undefined;
       }
       if (typeof parsed.id === "string" && parsed.id) {
@@ -420,4 +440,5 @@ async function findLatestEquivalentAssistantMessageId(
   }
 
   return undefined;
+
 }


### PR DESCRIPTION
## Problem

The delivery-mirror dedup guard in `findLatestEquivalentAssistantMessageId` failed to match the mirror text against the real assistant transcript in two key scenarios:

1. **Phased content mismatch**: Real assistant messages contain commentary/thinking text parts alongside the final answer. `extractAssistantMessageText` joins ALL text parts, so "thinking...\nFinal answer" never matched the mirror's "Final answer".

2. **Whitespace differences**: Extra spaces, trailing newlines, or different line breaks between how text is stored in the transcript vs constructed by the mirror path caused exact comparison to fail.

## Root Cause

`findLatestEquivalentAssistantMessageId` compares ALL text content (including thinking phases) and uses exact string comparison. When text doesn't match, it immediately returns `undefined` instead of continuing to scan, and the mirror write proceeds — creating a duplicate.

## Solution

1. **Visible-text comparison**: Use `extractAssistantVisibleText` (the same function used by transcript parsers) on the candidate transcript entry, which skips commentary/thinking phases and extracts only the final answer text.

2. **Whitespace normalization**: Collapse all whitespace (including newlines) to single spaces via `normalizeTextForComparison` before comparing, tolerating minor formatting differences.

3. **Abort discipline preserved**: If the latest assistant's visible text genuinely differs from the mirror text, the function still returns `undefined` — preventing cross-turn matching of older messages.

## Testing

- Added test: whitespace differences (extra spaces in candidate)
- Added test: phased commentary + final_answer content in candidate
- Added test: trailing newline differences
- All 17 existing tests continue to pass

## Related

Supersedes and complements PR #67185 which added the initial delivery-mirror dedup.
