### PR TITLE
fix(mantis): remove ambiguous GitHub trigger mention

### DIFF
--- a/.github/workflows/mantis-discord-status-reactions.yml
+++ b/.github/workflows/mantis-discord-status-reactions.yml
@@ -46,9 +46,8 @@ jobs:
           github.event_name == 'issue_comment' &&
           github.event.issue.pull_request &&
           (
-            contains(github.event.comment.body, '@Mantis') ||
-            contains(github.event.comment.body, '@mantis') ||
-            contains(github.event.comment.body, '/mantis')
+            contains(github.event.comment.body, '@openclaw-mantis') ||
+            contains(github.event.comment.body, '/openclaw-mantis')
           )
         )
       }}
@@ -121,7 +120,7 @@ jobs:
 
             const normalized = body.toLowerCase();
             const requested =
-              (normalized.includes("@mantis") || normalized.includes("/mantis")) &&
+              (normalized.includes("@openclaw-mantis") || normalized.includes("/openclaw-mantis")) &&
               normalized.includes("discord") &&
               normalized.includes("status") &&
               normalized.includes("reaction");

--- a/.github/workflows/mantis-discord-thread-attachment.yml
+++ b/.github/workflows/mantis-discord-thread-attachment.yml
@@ -46,9 +46,8 @@ jobs:
           github.event_name == 'issue_comment' &&
           github.event.issue.pull_request &&
           (
-            contains(github.event.comment.body, '@Mantis') ||
-            contains(github.event.comment.body, '@mantis') ||
-            contains(github.event.comment.body, '/mantis')
+            contains(github.event.comment.body, '@openclaw-mantis') ||
+            contains(github.event.comment.body, '/openclaw-mantis')
           )
         )
       }}
@@ -121,7 +120,7 @@ jobs:
 
             const normalized = body.toLowerCase();
             const requested =
-              (normalized.includes("@mantis") || normalized.includes("/mantis")) &&
+              (normalized.includes("@openclaw-mantis") || normalized.includes("/openclaw-mantis")) &&
               normalized.includes("discord") &&
               normalized.includes("thread") &&
               (normalized.includes("attachment") ||

--- a/.github/workflows/mantis-telegram-live.yml
+++ b/.github/workflows/mantis-telegram-live.yml
@@ -56,9 +56,8 @@ jobs:
           github.event_name == 'issue_comment' &&
           github.event.issue.pull_request &&
           (
-            contains(github.event.comment.body, '@Mantis') ||
-            contains(github.event.comment.body, '@mantis') ||
-            contains(github.event.comment.body, '/mantis')
+            contains(github.event.comment.body, '@openclaw-mantis') ||
+            contains(github.event.comment.body, '/openclaw-mantis')
           )
         )
       }}
@@ -134,7 +133,7 @@ jobs:
 
             const normalized = body.toLowerCase();
             const requested =
-              (normalized.includes("@mantis") || normalized.includes("/mantis")) &&
+              (normalized.includes("@openclaw-mantis") || normalized.includes("/openclaw-mantis")) &&
               normalized.includes("telegram");
             if (!requested) {
               core.notice("Comment mentioned Mantis but did not request Telegram live QA.");

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -1629,7 +1629,7 @@ openclaw logs --follow
           // Molty listens to all bot-authored Discord messages.
           allowBots: true,
           mentionAliases: {
-            // Lets Molty write "@Mantis" and send a real Discord mention.
+            // Lets Molty write a Mantis Discord mention with the configured user id.
             Mantis: "MANTIS_DISCORD_USER_ID",
           },
           botLoopProtection: {

--- a/docs/concepts/mantis.md
+++ b/docs/concepts/mantis.md
@@ -252,7 +252,7 @@ Telegram Web login state is not required for normal Mantis automation.
 
 `Mantis Telegram Desktop Proof` is the agentic native Telegram Desktop
 before/after wrapper. A maintainer can trigger it from a PR comment with
-`@Mantis telegram desktop proof`, from the Actions UI with freeform
+`@openclaw-mantis telegram desktop proof`, from the Actions UI with freeform
 instructions, or through the generic `Mantis Scenario` dispatcher. The workflow
 hands the PR, baseline ref, candidate ref, and maintainer instructions to Codex.
 The agent reads the PR, decides what Telegram-visible behavior proves the
@@ -351,7 +351,7 @@ region, and public URL values directly. The reusable publisher requires:
 You can also trigger the status-reactions run directly from a PR comment:
 
 ```text
-@Mantis discord status reactions
+@openclaw-mantis discord status reactions
 ```
 
 The comment trigger is intentionally narrow. It only runs on pull request
@@ -361,15 +361,15 @@ and the current PR head SHA as the candidate. Maintainers can override either
 ref:
 
 ```text
-@Mantis discord status reactions baseline=origin/main candidate=HEAD
+@openclaw-mantis discord status reactions baseline=origin/main candidate=HEAD
 ```
 
 Telegram live QA can also be triggered from a PR comment:
 
 ```text
-@Mantis telegram
-@Mantis telegram scenario=telegram-status-command
-@Mantis telegram scenarios=telegram-status-command,telegram-mentioned-message-reply
+@openclaw-mantis telegram
+@openclaw-mantis telegram scenario=telegram-status-command
+@openclaw-mantis telegram scenarios=telegram-status-command,telegram-mentioned-message-reply
 ```
 
 By default it uses the current PR head SHA as the candidate and runs

--- a/docs/help/testing.md
+++ b/docs/help/testing.md
@@ -335,9 +335,9 @@ start it from the Actions UI through `Mantis Scenario` (`scenario_id:
 telegram-live`) or directly from a pull request comment:
 
 ```text
-@Mantis telegram
-@Mantis telegram scenario=telegram-status-command
-@Mantis telegram scenarios=telegram-status-command,telegram-mentioned-message-reply
+@openclaw-mantis telegram
+@openclaw-mantis telegram scenario=telegram-status-command
+@openclaw-mantis telegram scenarios=telegram-status-command,telegram-mentioned-message-reply
 ```
 
 `Mantis Telegram Desktop Proof` is the agentic native Telegram Desktop
@@ -346,7 +346,7 @@ freeform `instructions`, through `Mantis Scenario` (`scenario_id:
 telegram-desktop-proof`), or from a PR comment:
 
 ```text
-@Mantis telegram desktop proof
+@openclaw-mantis telegram desktop proof
 ```
 
 The Mantis agent reads the PR, decides what Telegram-visible behavior proves the


### PR DESCRIPTION
## Summary
- removes @Mantis/@mantis and /mantis as GitHub PR-comment triggers for Mantis workflows
- requires the OpenClaw-owned @openclaw-mantis or /openclaw-mantis trigger spelling instead
- updates maintainer-facing Mantis docs and examples to avoid mentioning the real GitHub account

## Validation
- rg -n "@Mantis|@mantis" .github/workflows docs README.md (no matches)
- git diff --check -- .github/workflows/mantis-discord-status-reactions.yml .github/workflows/mantis-discord-thread-attachment.yml .github/workflows/mantis-telegram-live.yml docs/concepts/mantis.md docs/help/testing.md docs/channels/discord.md
- CI=true pnpm docs:list
- CI=true pnpm check:workflows (passed after allowing actionlint dependency download)