### PR TITLE
fix(codex): deliver Telegram verbose tool progress

### DIFF
--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -1715,6 +1715,256 @@ describe("CodexAppServerEventProjector", () => {
     expect(toolResultContent.content).toBe("opened");
   });
 
+  it("emits verbose summaries for transcript-recorded dynamic tool calls", async () => {
+    const onAgentEvent = vi.fn();
+    const onToolResult = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      verboseLevel: "on",
+      onAgentEvent,
+      onToolResult,
+    });
+
+    projector.recordDynamicToolCall({
+      callId: "call-browser-1",
+      tool: "browser",
+      arguments: { action: "open", url: "http://127.0.0.1:3000" },
+    });
+
+    const toolEvents = onAgentEvent.mock.calls.filter(([event]) => {
+      const record = requireRecord(event, "agent event");
+      return record.stream === "tool";
+    });
+    expect(toolEvents).toHaveLength(0);
+    expect(onToolResult).toHaveBeenCalledTimes(1);
+    const payload = mockCallArg(onToolResult, 0, 0, "onToolResult") as { text?: string };
+    expect(payload.text).toContain("Browser");
+  });
+
+  it("does not replay transcript summaries when only tool output is enabled", async () => {
+    const onToolResult = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      onToolResult,
+      shouldEmitToolResult: () => false,
+      shouldEmitToolOutput: () => true,
+    });
+
+    projector.recordDynamicToolCall({
+      callId: "call-browser-1",
+      tool: "browser",
+      arguments: { action: "open", url: "http://127.0.0.1:3000" },
+    });
+    projector.recordDynamicToolResult({
+      callId: "call-browser-1",
+      tool: "browser",
+      success: true,
+      contentItems: [{ type: "inputText", text: "opened" }],
+    });
+
+    expect(onToolResult).toHaveBeenCalledTimes(1);
+    const payload = mockCallArg(onToolResult, 0, 0, "onToolResult") as { text?: string };
+    expect(payload.text).toContain("opened");
+    expect(payload.text).toContain("```txt\nopened\n```");
+  });
+
+  it("suppresses transcript progress for message-like tools", async () => {
+    const onAgentEvent = vi.fn();
+    const onToolResult = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      verboseLevel: "on",
+      onAgentEvent,
+      onToolResult,
+    });
+
+    projector.recordDynamicToolCall({
+      callId: "call-message-1",
+      tool: "message",
+      arguments: { action: "send", text: "hello" },
+    });
+    projector.recordDynamicToolResult({
+      callId: "call-message-1",
+      tool: "message",
+      success: true,
+      contentItems: [{ type: "inputText", text: "sent" }],
+    });
+
+    const toolEvents = onAgentEvent.mock.calls.filter(([event]) => {
+      const record = requireRecord(event, "agent event");
+      return record.stream === "tool";
+    });
+    expect(toolEvents).toHaveLength(0);
+    expect(onToolResult).not.toHaveBeenCalled();
+  });
+
+  it("suppresses transcript progress for activity-log bash commands", async () => {
+    const onAgentEvent = vi.fn();
+    const onToolResult = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      verboseLevel: "on",
+      onAgentEvent,
+      onToolResult,
+    });
+
+    projector.recordDynamicToolCall({
+      callId: "call-log-activity-1",
+      tool: "bash",
+      arguments: {
+        command:
+          '/bin/bash -lc \'/home/openclaw/.openclaw/workspace/bin/log_activity.sh "web_search" "Grilled salmon research"\'',
+        cwd: "/workspace",
+      },
+    });
+    projector.recordDynamicToolResult({
+      callId: "call-log-activity-1",
+      tool: "bash",
+      success: true,
+      contentItems: [{ type: "inputText", text: "Logged: [web_search] Grilled salmon research" }],
+    });
+
+    const toolEvents = onAgentEvent.mock.calls.filter(([event]) => {
+      const record = requireRecord(event, "agent event");
+      return record.stream === "tool";
+    });
+    expect(toolEvents).toHaveLength(0);
+    expect(onToolResult).not.toHaveBeenCalled();
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+    expect(result.messagesSnapshot.some((message) => message.role === "toolResult")).toBe(true);
+  });
+
+  it("keeps diagnostics for exact message-like native tool items while suppressing progress", async () => {
+    const onAgentEvent = vi.fn();
+    const onToolResult = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      verboseLevel: "on",
+      onAgentEvent,
+      onToolResult,
+    });
+    const diagnosticEvents: DiagnosticEventPayload[] = [];
+    const unsubscribe = onInternalDiagnosticEvent((event) => diagnosticEvents.push(event));
+
+    try {
+      await projector.handleNotification(
+        forCurrentTurn("item/started", {
+          item: {
+            type: "mcpToolCall",
+            id: "mcp-message-1",
+            server: null,
+            tool: "message",
+            arguments: { text: "hello" },
+            status: "inProgress",
+            result: null,
+            error: null,
+            durationMs: null,
+          },
+        }),
+      );
+      await projector.handleNotification(
+        forCurrentTurn("item/completed", {
+          item: {
+            type: "mcpToolCall",
+            id: "mcp-message-1",
+            server: null,
+            tool: "message",
+            arguments: { text: "hello" },
+            status: "completed",
+            result: { ok: true },
+            error: null,
+            durationMs: 7,
+          },
+        }),
+      );
+      await flushDiagnosticEvents();
+    } finally {
+      unsubscribe();
+    }
+
+    const toolEvents = onAgentEvent.mock.calls.filter(([event]) => {
+      const record = requireRecord(event, "agent event");
+      return record.stream === "tool";
+    });
+    expect(toolEvents).toHaveLength(0);
+    expect(onToolResult).not.toHaveBeenCalled();
+
+    const toolDiagnosticEvents = diagnosticEvents.filter(
+      (
+        event,
+      ): event is Extract<
+        DiagnosticEventPayload,
+        {
+          type:
+            | "tool.execution.started"
+            | "tool.execution.completed"
+            | "tool.execution.error"
+            | "tool.execution.blocked";
+        }
+      > => event.type.startsWith("tool.execution."),
+    );
+    expect(
+      toolDiagnosticEvents.map((event) => ({
+        type: event.type,
+        toolName: event.toolName,
+        toolCallId: event.toolCallId,
+        durationMs: "durationMs" in event ? event.durationMs : undefined,
+      })),
+    ).toEqual([
+      {
+        type: "tool.execution.started",
+        toolName: "message",
+        toolCallId: "mcp-message-1",
+        durationMs: undefined,
+      },
+      {
+        type: "tool.execution.completed",
+        toolName: "message",
+        toolCallId: "mcp-message-1",
+        durationMs: 7,
+      },
+    ]);
+  });
+
+  it("does not suppress qualified external tools that end with message-like names", async () => {
+    const onAgentEvent = vi.fn();
+    const onToolResult = vi.fn();
+    const projector = await createProjector({
+      ...(await createParams()),
+      verboseLevel: "on",
+      onAgentEvent,
+      onToolResult,
+    });
+
+    await projector.handleNotification(
+      forCurrentTurn("item/started", {
+        item: {
+          type: "mcpToolCall",
+          id: "mcp-email-send-1",
+          server: "email",
+          tool: "send",
+          arguments: { to: "user@example.com" },
+          status: "inProgress",
+          result: null,
+          error: null,
+          durationMs: null,
+        },
+      }),
+    );
+
+    const toolStart = findAgentEvent(onAgentEvent, {
+      stream: "tool",
+      phase: "start",
+      itemId: "mcp-email-send-1",
+      name: "email.send",
+    }).data;
+    expect(toolStart.toolCallId).toBe("mcp-email-send-1");
+    expect(onToolResult).toHaveBeenCalledWith({
+      text: "🧩 Email.send: `user@example.com`",
+    });
+  });
+
   it("marks declined Codex-native tool results as non-success", async () => {
     const onAgentEvent = vi.fn();
     const projector = await createProjector({ ...(await createParams()), onAgentEvent });
@@ -1888,7 +2138,7 @@ describe("CodexAppServerEventProjector", () => {
     );
 
     const text = (mockCallArg(onToolResult, 0, 0, "onToolResult") as { text?: string }).text;
-    expect(text).toContain("sk-123…ZZZZ");
+    expect(text).toContain("OPENAI_API_KEY=*** pnpm test");
     expect(text).not.toContain("sk-1234567890abcdefZZZZ");
   });
 

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -94,6 +94,24 @@ const CODEX_PROMPT_TOTAL_INPUT_KEYS = [
 
 const MAX_TOOL_OUTPUT_DELTA_MESSAGES_PER_ITEM = 20;
 const TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS = 12_000;
+const TRANSCRIPT_PROGRESS_SUPPRESSED_TOOL_NAMES = new Set([
+  "message",
+  "messages",
+  "reply",
+  "send",
+  "reaction",
+  "react",
+  "typing",
+]);
+
+export function shouldEmitTranscriptToolProgress(toolName: unknown, args?: unknown): boolean {
+  const normalized = typeof toolName === "string" ? toolName.trim().toLowerCase() : "";
+  return Boolean(
+    normalized &&
+    !TRANSCRIPT_PROGRESS_SUPPRESSED_TOOL_NAMES.has(normalized) &&
+    !isActivityLogCommandProgress(normalized, args),
+  );
+}
 
 type ToolTranscriptCallInput = {
   id: string;
@@ -122,6 +140,8 @@ export class CodexAppServerEventProjector {
   private readonly toolResultSummaryItemIds = new Set<string>();
   private readonly toolResultOutputItemIds = new Set<string>();
   private readonly toolResultOutputStreamedItemIds = new Set<string>();
+  private readonly transcriptToolProgressSuppressedIds = new Set<string>();
+  private readonly toolTranscriptArgumentsById = new Map<string, unknown>();
   private readonly toolResultOutputDeltaState = new Map<
     string,
     { chars: number; messages: number; truncated: boolean }
@@ -130,6 +150,7 @@ export class CodexAppServerEventProjector {
   private readonly toolTranscriptMessages: AgentMessage[] = [];
   private readonly toolTranscriptCallIds = new Set<string>();
   private readonly toolTranscriptResultIds = new Set<string>();
+  private readonly transcriptToolProgressCallIds = new Set<string>();
   private readonly nativeGeneratedMediaUrls = new Set<string>();
   private readonly diagnosticToolStartedAtByItem = new Map<string, number>();
   private readonly afterToolCallObservedItemIds = new Set<string>();
@@ -688,6 +709,12 @@ export class CodexAppServerEventProjector {
     if (!itemId || !delta || !this.shouldEmitToolOutput()) {
       return;
     }
+    if (
+      this.transcriptToolProgressSuppressedIds.has(itemId) ||
+      !shouldEmitTranscriptToolProgress(toolName, this.toolTranscriptArgumentsById.get(itemId))
+    ) {
+      return;
+    }
     const state = this.toolResultOutputDeltaState.get(itemId) ?? {
       chars: 0,
       messages: 0,
@@ -873,11 +900,17 @@ export class CodexAppServerEventProjector {
     if (!name) {
       return;
     }
-    const meta = itemMeta(item, this.toolProgressDetailMode());
-    const args = params.phase === "start" ? itemToolArgs(item) : undefined;
     const status = params.phase === "result" ? itemStatus(item) : "running";
+    const args = itemToolArgs(item);
     this.recordToolTrajectoryEvent({ phase: params.phase, item, name, args, status });
     this.emitDiagnosticToolExecutionEvent({ phase: params.phase, item, name, status });
+    if (!shouldEmitTranscriptToolProgress(name, args)) {
+      if (params.phase === "result") {
+        this.emitAfterToolCallObservation(item);
+      }
+      return;
+    }
+    const meta = itemMeta(item, this.toolProgressDetailMode());
     this.emitAgentEvent({
       stream: "tool",
       data: {
@@ -886,7 +919,7 @@ export class CodexAppServerEventProjector {
         itemId: item.id,
         toolCallId: item.id,
         ...(meta ? { meta } : {}),
-        ...(args ? { args } : {}),
+        ...(params.phase === "start" && args ? { args } : {}),
         ...(params.phase === "result"
           ? {
               status,
@@ -1041,6 +1074,9 @@ export class CodexAppServerEventProjector {
     if (!toolName) {
       return;
     }
+    if (!shouldEmitTranscriptToolProgress(toolName, itemToolArgs(item))) {
+      return;
+    }
     this.toolResultSummaryItemIds.add(itemId);
     const meta = itemMeta(item, this.toolProgressDetailMode());
     this.emitToolResultMessage({
@@ -1063,6 +1099,9 @@ export class CodexAppServerEventProjector {
     const toolName = itemName(item);
     const output = itemOutputText(item);
     if (!toolName || !output) {
+      return;
+    }
+    if (!shouldEmitTranscriptToolProgress(toolName, itemToolArgs(item))) {
       return;
     }
     this.emitToolResultMessage({
@@ -1161,6 +1200,13 @@ export class CodexAppServerEventProjector {
       return;
     }
     this.toolTranscriptCallIds.add(params.id);
+    this.toolTranscriptArgumentsById.set(params.id, params.arguments);
+    if (!shouldEmitTranscriptToolProgress(params.name, params.arguments)) {
+      this.transcriptToolProgressSuppressedIds.add(params.id);
+    } else {
+      this.transcriptToolProgressSuppressedIds.delete(params.id);
+    }
+    this.emitTranscriptToolCallProgress(params);
     this.toolTranscriptMessages.push(
       attachCodexMirrorIdentity(
         this.createToolCallMessage(params),
@@ -1174,12 +1220,73 @@ export class CodexAppServerEventProjector {
       return;
     }
     this.toolTranscriptResultIds.add(params.id);
+    this.emitTranscriptToolResultProgress(params);
     this.toolTranscriptMessages.push(
       attachCodexMirrorIdentity(
         this.createToolResultMessage(params),
         `${this.turnId}:tool:${params.id}:result`,
       ),
     );
+  }
+
+  private emitTranscriptToolCallProgress(params: ToolTranscriptCallInput): void {
+    if (!shouldEmitTranscriptToolProgress(params.name, params.arguments)) {
+      return;
+    }
+    this.transcriptToolProgressCallIds.add(params.id);
+    const args = normalizeToolTranscriptArguments(params.arguments);
+    const meta = inferToolMetaFromArgs(params.name, args, {
+      detailMode: this.toolProgressDetailMode(),
+    });
+    if (
+      !this.params.onToolResult ||
+      !this.shouldEmitToolResult() ||
+      this.toolResultSummaryItemIds.has(params.id) ||
+      this.toolResultOutputStreamedItemIds.has(params.id)
+    ) {
+      return;
+    }
+    this.toolResultSummaryItemIds.add(params.id);
+    this.emitToolResultMessage({
+      itemId: params.id,
+      text: formatToolSummary(params.name, meta),
+    });
+  }
+
+  private emitTranscriptToolResultProgress(params: ToolTranscriptResultInput): void {
+    if (
+      this.transcriptToolProgressSuppressedIds.has(params.id) ||
+      !shouldEmitTranscriptToolProgress(
+        params.name,
+        this.toolTranscriptArgumentsById.get(params.id),
+      )
+    ) {
+      return;
+    }
+    if (!this.transcriptToolProgressCallIds.has(params.id)) {
+      this.emitTranscriptToolCallProgress({
+        id: params.id,
+        name: params.name,
+        arguments: {},
+      });
+    }
+    if (
+      !this.params.onToolResult ||
+      !this.shouldEmitToolOutput() ||
+      this.toolResultOutputItemIds.has(params.id) ||
+      this.toolResultOutputStreamedItemIds.has(params.id)
+    ) {
+      return;
+    }
+    const text = params.text?.trim();
+    if (!text) {
+      return;
+    }
+    this.emitToolResultMessage({
+      itemId: params.id,
+      text: formatToolOutput(params.name, undefined, text),
+      finalOutput: true,
+    });
   }
 
   private formatCodexErrorMessage(params: JsonObject): string | undefined {
@@ -1746,6 +1853,31 @@ function normalizeToolTranscriptArguments(value: unknown): Record<string, unknow
     return {};
   }
   return value as Record<string, unknown>;
+}
+
+function isActivityLogCommandProgress(toolName: string, args: unknown): boolean {
+  if (toolName !== "bash" && toolName !== "exec" && toolName !== "shell") {
+    return false;
+  }
+  const command = readToolCommandText(args);
+  return Boolean(command && command.includes("log_activity.sh"));
+}
+
+function readToolCommandText(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  for (const key of ["command", "cmd", "shellCommand", "script"]) {
+    const text = record[key];
+    if (typeof text === "string" && text) {
+      return text;
+    }
+  }
+  return undefined;
 }
 
 function collectDynamicToolContentText(contentItems: CodexThreadItem["contentItems"]): string {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -655,9 +655,7 @@ describe("runCodexAppServerAttempt", () => {
     };
 
     expect(
-      __testing
-        .filterCodexDynamicTools(tools, {}, privateQaCodexEnv)
-        .map((tool) => tool.name),
+      __testing.filterCodexDynamicTools(tools, {}, privateQaCodexEnv).map((tool) => tool.name),
     ).toEqual(["read", "write", "image_generate", "message"]);
     expect(__testing.resolveCodexDynamicToolsLoading({}, privateQaCodexEnv)).toBe("direct");
   });
@@ -1426,9 +1424,9 @@ describe("runCodexAppServerAttempt", () => {
         turnId: "turn-1",
         callId: "call-1",
         namespace: null,
-        tool: "message",
+        tool: "lookup",
         arguments: {
-          action: "send",
+          action: "search",
           token: "plain-secret-value-12345",
           text: "hello",
         },
@@ -1439,9 +1437,7 @@ describe("runCodexAppServerAttempt", () => {
     };
     expect(toolResult.success).toBe(false);
     expect(toolResult.contentItems?.[0]?.type).toBe("inputText");
-    expect(toolResult.contentItems?.[0]?.text).toMatch(
-      /^(Unknown OpenClaw tool: message|Action send requires a target\.)$/u,
-    );
+    expect(toolResult.contentItems?.[0]?.text).toMatch(/^Unknown OpenClaw tool: lookup$/u);
 
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     await run;
@@ -1460,15 +1456,18 @@ describe("runCodexAppServerAttempt", () => {
     const startEvent = agentEvents.find(
       (event) => event.stream === "tool" && event.data?.phase === "start",
     );
-    expect(startEvent?.data?.name).toBe("message");
+    expect(startEvent?.data?.name).toBe("lookup");
     expect(startEvent?.data?.toolCallId).toBe("call-1");
-    expect(startEvent?.data?.args?.action).toBe("send");
+    expect(startEvent?.data?.args?.action).toBe("search");
     expect(startEvent?.data?.args?.token).toBe("plain-…2345");
     expect(startEvent?.data?.args?.text).toBe("hello");
     const resultEvent = agentEvents.find(
-      (event) => event.stream === "tool" && event.data?.phase === "result",
+      (event) =>
+        event.stream === "tool" &&
+        event.data?.phase === "result" &&
+        event.data.result !== undefined,
     );
-    expect(resultEvent?.data?.name).toBe("message");
+    expect(resultEvent?.data?.name).toBe("lookup");
     expect(resultEvent?.data?.toolCallId).toBe("call-1");
     expect(resultEvent?.data?.isError).toBe(true);
     expect(resultEvent?.data?.result?.success).toBe(false);
@@ -1478,7 +1477,7 @@ describe("runCodexAppServerAttempt", () => {
     );
     expect(globalStartEvent?.runId).toBe("run-1");
     expect(globalStartEvent?.sessionKey).toBe("agent:main:session-1");
-    expect(globalStartEvent?.data.name).toBe("message");
+    expect(globalStartEvent?.data.name).toBe("lookup");
     expect(onExecutionPhase).toHaveBeenCalledWith({
       phase: "turn_accepted",
       provider: "codex",
@@ -1490,7 +1489,7 @@ describe("runCodexAppServerAttempt", () => {
       provider: "codex",
       model: "gpt-5.4-codex",
       backend: "codex-app-server",
-      tool: "message",
+      tool: "lookup",
       toolCallId: "call-1",
     });
   });
@@ -1502,6 +1501,7 @@ describe("runCodexAppServerAttempt", () => {
       createMockPluginRegistry([{ hookName: "after_tool_call", handler: afterToolCall }]),
     );
     __testing.setOpenClawCodingToolsFactoryForTests(() => [createRuntimeDynamicTool("echo")]);
+
     const params = createParams(
       path.join(tempDir, "session.jsonl"),
       path.join(tempDir, "workspace"),
@@ -1545,6 +1545,44 @@ describe("runCodexAppServerAttempt", () => {
 
     await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
     await run;
+  });
+
+  it("suppresses normalized tool progress for activity-log dynamic bash requests", async () => {
+    const harness = createStartedThreadHarness();
+    const onRunAgentEvent = vi.fn();
+    const params = createParams(
+      path.join(tempDir, "session.jsonl"),
+      path.join(tempDir, "workspace"),
+    );
+    params.onAgentEvent = onRunAgentEvent;
+
+    const run = runCodexAppServerAttempt(params);
+    await harness.waitForMethod("thread/start");
+
+    await harness.handleServerRequest({
+      id: "request-tool-activity-log",
+      method: "item/tool/call",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        callId: "call-log-activity-1",
+        namespace: null,
+        tool: "bash",
+        arguments: {
+          command:
+            '/bin/bash -lc \'/home/openclaw/.openclaw/workspace/bin/log_activity.sh "web_search" "Grilled salmon research"\'',
+        },
+      },
+    });
+
+    await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+    await run;
+
+    const toolEvents = onRunAgentEvent.mock.calls.filter(([event]) => {
+      const record = event as { stream?: string };
+      return record.stream === "tool";
+    });
+    expect(toolEvents).toHaveLength(0);
   });
 
   it("releases the session when Codex never completes after a dynamic tool response", async () => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -89,7 +89,10 @@ import {
 } from "./dynamic-tool-profile.js";
 import { createCodexDynamicToolBridge, type CodexDynamicToolBridge } from "./dynamic-tools.js";
 import { handleCodexAppServerElicitationRequest } from "./elicitation-bridge.js";
-import { CodexAppServerEventProjector } from "./event-projector.js";
+import {
+  CodexAppServerEventProjector,
+  shouldEmitTranscriptToolProgress,
+} from "./event-projector.js";
 import {
   buildCodexNativeHookRelayDisabledConfig,
   buildCodexNativeHookRelayConfig,
@@ -1996,16 +1999,19 @@ export async function runCodexAppServerAttempt(
       const toolProgressDetailMode = resolveCodexToolProgressDetailMode(params.toolProgressDetail);
       const toolMeta = inferCodexDynamicToolMeta(call, toolProgressDetailMode);
       const toolArgs = sanitizeCodexToolArguments(call.arguments);
-      emitCodexAppServerEvent(params, {
-        stream: "tool",
-        data: {
-          phase: "start",
-          name: call.tool,
-          toolCallId: call.callId,
-          ...(toolMeta ? { meta: toolMeta } : {}),
-          ...(toolArgs ? { args: toolArgs } : {}),
-        },
-      });
+      const shouldEmitDynamicToolProgress = shouldEmitTranscriptToolProgress(call.tool, toolArgs);
+      if (shouldEmitDynamicToolProgress) {
+        emitCodexAppServerEvent(params, {
+          stream: "tool",
+          data: {
+            phase: "start",
+            name: call.tool,
+            toolCallId: call.callId,
+            ...(toolMeta ? { meta: toolMeta } : {}),
+            ...(toolArgs ? { args: toolArgs } : {}),
+          },
+        });
+      }
       const dynamicToolTimeoutMs = resolveDynamicToolCallTimeoutMs({
         call,
         config: params.config,
@@ -2039,17 +2045,19 @@ export async function runCodexAppServerAttempt(
         success: response.success,
         contentItems: response.contentItems,
       });
-      emitCodexAppServerEvent(params, {
-        stream: "tool",
-        data: {
-          phase: "result",
-          name: call.tool,
-          toolCallId: call.callId,
-          ...(toolMeta ? { meta: toolMeta } : {}),
-          isError: !response.success,
-          result: sanitizeCodexToolResponse(response),
-        },
-      });
+      if (shouldEmitDynamicToolProgress) {
+        emitCodexAppServerEvent(params, {
+          stream: "tool",
+          data: {
+            phase: "result",
+            name: call.tool,
+            toolCallId: call.callId,
+            ...(toolMeta ? { meta: toolMeta } : {}),
+            isError: !response.success,
+            result: sanitizeCodexToolResponse(response),
+          },
+        });
+      }
       return response as JsonValue;
     } finally {
       if (requestCountsAsTurnActivity) {

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1674,7 +1674,7 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(notice);
   });
 
-  it("renders plain-text plan updates and concise approval progress when verbose is enabled", async () => {
+  it("renders plain-text plan updates without generic working statuses when verbose is enabled", async () => {
     setNoAbort();
     const cfg = {
       ...emptyConfig,
@@ -1713,17 +1713,11 @@ describe("dispatchReplyFromConfig", () => {
     expect(firstToolResultPayload(dispatcher)?.text).toBe(
       "Inspect code, patch it, run tests.\n\n1. Inspect code\n2. Patch code\n3. Run tests",
     );
-    const secondToolPayload = firstMockArg(
-      dispatcher.sendToolResult as ReturnType<typeof vi.fn>,
-      "tool result",
-      1,
-    ) as ReplyPayload;
-    expect(secondToolPayload.text).toBe("Working: awaiting approval: pnpm test");
-    expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(2);
+    expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(1);
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
   });
 
-  it("renders concise patch summaries when verbose is enabled", async () => {
+  it("suppresses generic patch working statuses when verbose is enabled", async () => {
     setNoAbort();
     const cfg = {
       ...emptyConfig,
@@ -1754,8 +1748,7 @@ describe("dispatchReplyFromConfig", () => {
 
     await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
 
-    expect(firstToolResultPayload(dispatcher)?.text).toBe("Working: 1 added, 2 modified");
-    expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(1);
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
   });
 
@@ -1914,7 +1907,7 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
   });
 
-  it("delivers plan and working-status progress when verbose overrides preview suppression", async () => {
+  it("delivers plan progress without generic working status when verbose overrides preview suppression", async () => {
     setNoAbort();
     sessionStoreMocks.currentEntry = {
       verboseLevel: "on",
@@ -1956,10 +1949,115 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendToolResult).toHaveBeenNthCalledWith(1, {
       text: "Inspect code.\n\n1. Patch code",
     });
-    expect(dispatcher.sendToolResult).toHaveBeenNthCalledWith(2, {
-      text: "Working: awaiting approval: pnpm test",
-    });
+    expect(dispatcher.sendToolResult).toHaveBeenCalledTimes(1);
     expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({ text: "done" });
+  });
+
+  it("delivers verbose tool summaries despite message-tool-only source suppression", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+      verboseLevel: "on",
+    };
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "telegram",
+      ChatType: "direct",
+      SessionKey: "agent:main:main",
+    });
+
+    const replyResolver = async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      await opts?.onToolResult?.({ text: "🛠️ `pwd (agent)`" });
+      return { text: "done" } satisfies ReplyPayload;
+    };
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        sourceReplyDeliveryMode: "message_tool_only",
+      },
+    });
+
+    expect(result.sourceReplyDeliveryMode).toBe("message_tool_only");
+    expect(dispatcher.sendToolResult).toHaveBeenCalledWith({ text: "🛠️ `pwd (agent)`" });
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+  });
+
+  it("keeps verbose tool summaries suppressed for room events", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+      verboseLevel: "on",
+    };
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      ChatType: "channel",
+      InboundEventKind: "room_event",
+      SessionKey: "agent:main:discord:channel:C1",
+    });
+
+    const replyResolver = async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      await opts?.onToolResult?.({ text: "🛠️ `pwd (agent)`" });
+      return { text: "done" } satisfies ReplyPayload;
+    };
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        sourceReplyDeliveryMode: "message_tool_only",
+      },
+    });
+
+    expect(result.sourceReplyDeliveryMode).toBe("message_tool_only");
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+  });
+
+  it("keeps verbose tool summaries suppressed for channel message-tool-only turns", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+      verboseLevel: "on",
+    };
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "discord",
+      ChatType: "channel",
+      IsForum: true,
+      SessionKey: "agent:main:discord:channel:C1",
+    });
+
+    const replyResolver = async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      await opts?.onToolResult?.({ text: "🛠️ `pwd (agent)`" });
+      return { text: "done" } satisfies ReplyPayload;
+    };
+
+    const result = await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        sourceReplyDeliveryMode: "message_tool_only",
+      },
+    });
+
+    expect(result.sourceReplyDeliveryMode).toBe("message_tool_only");
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
   });
 
   it("still delivers media-only tool payloads when preview tool-progress suppression is enabled", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1043,7 +1043,14 @@ export async function dispatchReplyFromConfig(
     const shouldSendVerboseProgressMessages =
       !isSlackNonDirectSurface && (ctx.ChatType !== "group" || ctx.IsForum === true);
     const shouldSendToolSummaries = shouldSendVerboseProgressMessages;
-    const shouldSendToolStartStatuses = shouldSendVerboseProgressMessages;
+    const shouldSendToolStartStatuses = false;
+    const shouldDeliverVerboseProgressDespiteSourceSuppression = () =>
+      suppressAutomaticSourceDelivery &&
+      chatType === "direct" &&
+      ctx.InboundEventKind !== "room_event" &&
+      !sendPolicyDenied &&
+      shouldEmitVerboseProgress() &&
+      shouldSendVerboseProgressMessages;
     const sendFinalPayload = async (
       payload: ReplyPayload,
     ): Promise<{ queuedFinal: boolean; routedFinalCount: number }> => {
@@ -1207,7 +1214,7 @@ export async function dispatchReplyFromConfig(
       return parts.join("\n\n").trim() || "Planning next steps.";
     };
     const maybeSendWorkingStatus = async (label: string): Promise<void> => {
-      if (suppressDelivery) {
+      if (suppressDelivery && !shouldDeliverVerboseProgressDespiteSourceSuppression()) {
         return;
       }
       const normalizedLabel = normalizeWorkingLabel(label);
@@ -1236,7 +1243,11 @@ export async function dispatchReplyFromConfig(
       explanation?: string;
       steps?: string[];
     }): Promise<void> => {
-      if (suppressDelivery || !shouldEmitVerboseProgress() || !shouldSendVerboseProgressMessages) {
+      if (
+        (suppressDelivery && !shouldDeliverVerboseProgressDespiteSourceSuppression()) ||
+        !shouldEmitVerboseProgress() ||
+        !shouldSendVerboseProgressMessages
+      ) {
         return;
       }
       const replyPayload: ReplyPayload = {
@@ -1409,7 +1420,7 @@ export async function dispatchReplyFromConfig(
               if (!suppressAutomaticSourceDelivery) {
                 await onToolResultFromReplyOptions?.(payload);
               }
-              if (suppressDelivery) {
+              if (suppressDelivery && !shouldDeliverVerboseProgressDespiteSourceSuppression()) {
                 return;
               }
               const ttsPayload = await maybeApplyTtsToReplyPayload({


### PR DESCRIPTION
## Summary

- Problem: Telegram direct chats with /verbose enabled could show no Codex tool-call progress bubbles at all in message-tool-only/source-suppressed turns.
- Why it matters: users expect /verbose on to show the agent work between prompt and final answer, including the actual tool calls used to produce the answer.
- What changed: deliver verbose tool summaries for direct message-tool-only turns, emit transcript-backed dynamic tool summaries, and filter follow-up noise discovered while fixing this, including generic Working statuses and message/log-activity progress.
- What did NOT change (scope boundary): no changes to Telegram message chunking/splitting, model behavior, or channel delivery for room/channel message-tool-only turns.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #82917
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: /verbose on in a Telegram direct chat should show Codex tool-call progress without generic Working status messages, and should still deliver the final answer.
- Real environment tested: Hetzner VPS running OpenClaw gateway from this PR branch, Telegram direct chat with @SuperDuperChimpBot, Codex provider openai-codex/gpt-5.5.
- Exact steps or command run after this patch: restarted the gateway against the built PR branch, then sent in Telegram: `PR branch verbose test: research with exa how to grow a pear tree`.
- Evidence after fix: Telegram screenshot from 2026-05-17 shows two `mcporter call 'exa.web_search_exa(...)'` tool-call bubbles, then a normal final answer. No generic `Working:` bubbles appear.
- Observed result after fix: verbose tool-call bubbles appeared in Telegram, generic Working noise was absent, and the final pear-tree answer arrived.
- What was not tested: non-Telegram channels in a live external environment; channel/group message-tool-only behavior was covered by unit tests.
- Before evidence (optional but encouraged): prior Telegram testing showed either no verbose tool calls on official beta, or noisy `Working: bash...` messages before this patch.

## Root Cause (if applicable)

- Root cause: Codex could generate verbose tool summaries, but direct message-tool-only/source-suppressed dispatch paths returned before delivering those summaries to Telegram. Separately, transcript-recorded dynamic tools did not emit concise verbose summaries, while message/log-activity tools could produce noisy progress.
- Missing detection / guardrail: no regression test covered direct Telegram-style message-tool-only source suppression while /verbose was enabled.
- Contributing context (if known): #82917 restores snapshot-only Codex native tool progress generation; this PR complements it by ensuring the direct Telegram delivery path emits the verbose summaries.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/dispatch-from-config.test.ts`, `extensions/codex/src/app-server/event-projector.test.ts`, `extensions/codex/src/app-server/run-attempt.test.ts`.
- Scenario the test should lock in: direct message-tool-only turns with /verbose enabled deliver tool summaries, suppress generic Working statuses, preserve room/channel suppression, and filter message/log-activity progress noise.
- Why this is the smallest reliable guardrail: it directly covers the dispatch source-suppression branch and Codex projector transcript paths without requiring live Telegram.
- Existing test that already covers this (if any): none before this PR.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Telegram direct chats with /verbose enabled now show concise tool-call summaries in message-tool-only/source-suppressed turns. Generic `Working:` status messages are suppressed.

## Diagram (if applicable)

```text
Before:
Telegram direct /verbose on -> sourceReplyDeliveryMode=message_tool_only -> tool summary generated -> suppressed before Telegram

After:
Telegram direct /verbose on -> sourceReplyDeliveryMode=message_tool_only -> direct verbose exception -> Telegram tool bubble -> final answer
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux on Hetzner VPS
- Runtime/container: Node 24.14.1, OpenClaw gateway built from this branch
- Model/provider: openai-codex/gpt-5.5
- Integration/channel (if any): Telegram direct chat
- Relevant config (redacted): /verbose enabled; source replies delivered through message-tool-only behavior

### Steps

1. Build this branch with `pnpm build`.
2. Run gateway from `dist/entry.js gateway --port 18789`.
3. In Telegram direct chat, ensure /verbose is enabled.
4. Send: `PR branch verbose test: research with exa how to grow a pear tree`.

### Expected

- Telegram shows tool-call progress bubbles.
- Telegram does not show generic `Working:` bubbles.
- Telegram receives the final answer.

### Actual

- Tool-call progress bubbles appeared for Exa searches.
- No generic `Working:` bubbles appeared.
- Final answer arrived.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

Local validation run:

- `pnpm exec vitest run extensions/codex/src/app-server/event-projector.test.ts extensions/codex/src/app-server/run-attempt.test.ts src/auto-reply/reply/dispatch-from-config.test.ts` - 3 files, 326 tests passed.
- `pnpm test:extension codex` - 54 files, 857 tests passed.
- `pnpm build` - passed.
- Targeted oxlint on touched core/extension files - passed.
- `codex review --base origin/main` - no actionable findings.

Notes:

- `pnpm format:check` currently reports unrelated formatting issues on current main outside this PR's touched files; the six touched files were formatted directly.
- `pnpm check:changed` passed guardrails and core/extension typechecks, but `lint core` was SIGKILLed by local resource pressure while running `tsgolint`.
- `pnpm test:contracts:channels` currently fails on unrelated `qa-channel` plugin metadata on current main.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: live Telegram direct chat with /verbose enabled shows Exa tool-call bubbles, no generic Working messages, final answer delivered.
- Edge cases checked: unit tests cover room/channel message-tool-only suppression and message/log-activity noise suppression.
- What you did **not** verify: live Slack/Discord/Matrix behavior.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: direct Telegram verbose turns could surface too much low-value progress.
  - Mitigation: generic Working messages and message/log-activity tools are filtered; room/channel message-tool-only suppression remains covered by tests.


