### PR TITLE
fix(feishu): return subagent thread delivery origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Feishu: return bound subagent delivery origins from session thread setup so Feishu subagent completions route back to the same DM or topic. (#83190) Thanks @100menotu001.
 - CLI/update: tailor post-update Gateway recovery hints by platform, showing systemd, LaunchAgent, Scheduled Task, or generic service-manager guidance instead of macOS-only recovery text. (#83096) Thanks @rubencu.
 - Plugins: apply a default 15-second timeout to legacy `before_agent_start` hooks so hung plugin handlers no longer block agent startup. Fixes #48534. (#83136) Thanks @therahul-yo.
 - Feishu: refresh inbound session delivery context for DM, group, and broadcast turns so later replies do not inherit stale WebChat routing. Fixes #78274.

--- a/extensions/feishu/src/subagent-hooks.test.ts
+++ b/extensions/feishu/src/subagent-hooks.test.ts
@@ -54,7 +54,15 @@ describe("feishu subagent hook handlers", () => {
       {},
     );
 
-    expect(result).toEqual({ status: "ok", threadBindingReady: true });
+    expect(result).toEqual({
+      status: "ok",
+      threadBindingReady: true,
+      deliveryOrigin: {
+        channel: "feishu",
+        accountId: "work",
+        to: "user:ou_sender_1",
+      },
+    });
 
     const deliveryTargetHandler = getRequiredHookHandler(handlers, "subagent_delivery_target");
     await expect(
@@ -141,7 +149,16 @@ describe("feishu subagent hook handlers", () => {
       {},
     );
 
-    expect(result).toEqual({ status: "ok", threadBindingReady: true });
+    expect(result).toEqual({
+      status: "ok",
+      threadBindingReady: true,
+      deliveryOrigin: {
+        channel: "feishu",
+        accountId: "work",
+        to: "chat:oc_group_chat",
+        threadId: "om_topic_root",
+      },
+    });
     await expect(
       deliveryHandler(
         {
@@ -204,7 +221,16 @@ describe("feishu subagent hook handlers", () => {
       },
     );
 
-    expect(reboundResult).toEqual({ status: "ok", threadBindingReady: true });
+    expect(reboundResult).toEqual({
+      status: "ok",
+      threadBindingReady: true,
+      deliveryOrigin: {
+        channel: "feishu",
+        accountId: "work",
+        to: "chat:oc_group_chat",
+        threadId: "om_topic_root",
+      },
+    });
     const childBindings = manager.listBySessionKey("agent:main:subagent:sender-child");
     expect(childBindings).toHaveLength(1);
     expect(childBindings[0]?.conversationId).toBe(

--- a/extensions/feishu/src/subagent-hooks.ts
+++ b/extensions/feishu/src/subagent-hooks.ts
@@ -270,7 +270,16 @@ type FeishuSubagentEndedEvent = {
 };
 
 type FeishuSubagentSpawningResult =
-  | { status: "ok"; threadBindingReady?: boolean }
+  | {
+      status: "ok";
+      threadBindingReady?: boolean;
+      deliveryOrigin?: {
+        channel: "feishu";
+        accountId?: string;
+        to?: string;
+        threadId?: string | number;
+      };
+    }
   | { status: "error"; error: string }
   | undefined;
 
@@ -347,6 +356,13 @@ export async function handleFeishuSubagentSpawning(
     return {
       status: "ok" as const,
       threadBindingReady: true,
+      deliveryOrigin: resolveFeishuDeliveryOrigin({
+        conversationId: binding.conversationId,
+        parentConversationId: binding.parentConversationId,
+        accountId: binding.accountId,
+        deliveryTo: binding.deliveryTo,
+        deliveryThreadId: binding.deliveryThreadId,
+      }),
     };
   } catch (err) {
     return {


### PR DESCRIPTION
## Summary
- return the Feishu/Lark bound conversation delivery origin from `subagent_spawning` after a child session bind succeeds
- extend Feishu hook coverage for DM, topic, and sender-scoped topic thread-bound subagent spawns

Closes #83189.
Complements #83172 / #83170 by applying the same delivery-origin contract to Feishu/Lark.

## Why
The generic `sessions_spawn(thread=true, mode="session")` path can only deliver the initial child run directly to the bound child conversation when the channel hook returns a routable `deliveryOrigin`. Feishu already had the bound conversation data but returned only `threadBindingReady=true`.

## Real Behavior Proof
- **Behavior or issue addressed:** Feishu/Lark `subagent_spawning` now returns the bound conversation `deliveryOrigin` after a successful thread-bound child session bind, so the generic spawn path has a routable initial child delivery target.
- **Real environment tested:** Local OpenClaw source checkout on macOS using the real Feishu hook and thread binding manager modules from this branch; no mocked hook result was injected.
- **Exact steps or command run after this patch:** Ran a direct Node/tsx proof command that created a Feishu thread binding manager, invoked `handleFeishuSubagentSpawning`, and printed the returned hook result for a topic conversation.
- **Evidence after fix:** Terminal output from the real hook path:

```json
{
  "status": "ok",
  "threadBindingReady": true,
  "deliveryOrigin": {
    "channel": "feishu",
    "accountId": "work",
    "to": "chat:oc_group_chat",
    "threadId": "om_topic_root"
  }
}
```

- **Observed result after fix:** The Feishu hook result includes `deliveryOrigin.channel="feishu"`, `deliveryOrigin.to="chat:oc_group_chat"`, and `deliveryOrigin.threadId="om_topic_root"` immediately after binding succeeds. Before this patch the same code path returned only `{ status: "ok", threadBindingReady: true }`.
- **What was not tested:** Live Feishu network delivery with real Feishu credentials was not tested in this local environment; this PR is limited to the in-process hook return contract that the generic `sessions_spawn` delivery path consumes.

## Verification
- `./node_modules/.bin/vitest run extensions/feishu/src/subagent-hooks.test.ts`
  - `Test Files 1 passed (1)`
  - `Tests 11 passed (11)`
- `./node_modules/.bin/oxfmt --check --threads=1 extensions/feishu/src/subagent-hooks.ts extensions/feishu/src/subagent-hooks.test.ts`
- `git diff --check HEAD~1..HEAD`

## Risk
Low. The change is limited to the Feishu/Lark subagent hook result and uses the same delivery-origin resolver already used by completion delivery.