### PR TITLE
feishu: return deliveryOrigin from subagent_spawning hook

### DIFF
--- a/extensions/feishu/src/subagent-hooks.test.ts
+++ b/extensions/feishu/src/subagent-hooks.test.ts
@@ -54,7 +54,11 @@ describe("feishu subagent hook handlers", () => {
       {},
     );
 
-    expect(result).toEqual({ status: "ok", threadBindingReady: true });
+    expect(result).toEqual({
+      status: "ok",
+      threadBindingReady: true,
+      deliveryOrigin: { channel: "feishu", accountId: "work", to: "user:ou_sender_1" },
+    });
 
     const deliveryTargetHandler = getRequiredHookHandler(handlers, "subagent_delivery_target");
     await expect(
@@ -141,7 +145,16 @@ describe("feishu subagent hook handlers", () => {
       {},
     );
 
-    expect(result).toEqual({ status: "ok", threadBindingReady: true });
+    expect(result).toEqual({
+      status: "ok",
+      threadBindingReady: true,
+      deliveryOrigin: {
+        channel: "feishu",
+        accountId: "work",
+        to: "chat:oc_group_chat",
+        threadId: "om_topic_root",
+      },
+    });
     await expect(
       deliveryHandler(
         {
@@ -204,7 +217,16 @@ describe("feishu subagent hook handlers", () => {
       },
     );
 
-    expect(reboundResult).toEqual({ status: "ok", threadBindingReady: true });
+    expect(reboundResult).toEqual({
+      status: "ok",
+      threadBindingReady: true,
+      deliveryOrigin: {
+        channel: "feishu",
+        accountId: "work",
+        to: "chat:oc_group_chat",
+        threadId: "om_topic_root",
+      },
+    });
     const childBindings = manager.listBySessionKey("agent:main:subagent:sender-child");
     expect(childBindings).toHaveLength(1);
     expect(childBindings[0]?.conversationId).toBe(

--- a/extensions/feishu/src/subagent-hooks.ts
+++ b/extensions/feishu/src/subagent-hooks.ts
@@ -270,7 +270,16 @@ type FeishuSubagentEndedEvent = {
 };
 
 type FeishuSubagentSpawningResult =
-  | { status: "ok"; threadBindingReady?: boolean }
+  | {
+      status: "ok";
+      threadBindingReady?: boolean;
+      deliveryOrigin?: {
+        channel: string;
+        accountId: string;
+        to: string;
+        threadId?: string;
+      };
+    }
   | { status: "error"; error: string }
   | undefined;
 
@@ -347,6 +356,13 @@ export async function handleFeishuSubagentSpawning(
     return {
       status: "ok" as const,
       threadBindingReady: true,
+      deliveryOrigin: resolveFeishuDeliveryOrigin({
+        conversationId: binding.conversationId,
+        parentConversationId: binding.parentConversationId,
+        accountId: binding.accountId,
+        deliveryTo: binding.deliveryTo,
+        deliveryThreadId: binding.deliveryThreadId,
+      }),
     };
   } catch (err) {
     return {


### PR DESCRIPTION
## Summary
- **Problem**: Feishu/Lark `subagent_spawning` hook (`handleFeishuSubagentSpawning`) binds the child session to a conversation and returns `{ status: "ok", threadBindingReady: true }`, but omits the `deliveryOrigin` needed by the core spawn flow to deliver the initial child run directly to the bound target.
- **Why it matters**: Without `deliveryOrigin`, `ensureThreadBindingForSubagentSpawn` in `src/agents/subagent-spawn.ts` cannot set `deliverInitialChildRunDirectly = true`. The initial child run falls back to the requester route/behavior instead of being delivered to the bound DM or topic conversation.
- **What changed**: After successful `bindConversation`, `handleFeishuSubagentSpawning` now returns `deliveryOrigin` computed by the already-existing `resolveFeishuDeliveryOrigin` helper using the binding record's `conversationId`, `parentConversationId`, `accountId`, `deliveryTo`, and `deliveryThreadId`. The local `FeishuSubagentSpawningResult` type was updated to reflect the new field, and 3 test assertions were updated to verify the origin.
- **What did NOT change**: No changes to core (`src/agents/subagent-spawn.ts`, hooks runner, types), no changes to other extensions (Discord, Matrix), no dependency changes, no new helpers. Entirely within the Feishu plugin boundary.
## Change Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra
## Scope
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations (Feishu/Lark channel plugin)
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra
## Linked Issue/PR
- Closes #83189
- Related #83170, #83172
## Real behavior proof
- **Behavior or issue addressed**: Feishu subagent `deliveryOrigin` missing from `subagent_spawning` hook return, preventing direct initial child run delivery.
- **Real environment tested**: Unit tests in development checkout (Linux, Node 22+).
- **Exact steps or command run after this patch**: `pnpm test extensions/feishu/src/subagent-hooks.test.ts`
- **Evidence after fix**: All 11 tests pass. Before: 3 assertions verified `{ status: "ok", threadBindingReady: true }` with no `deliveryOrigin`. After: same 3 assertions verify `deliveryOrigin` is present with correct channel/accountId/to/threadId values.
- **Observed result after fix**:
  Test Files  1 passed (1)
       Tests  11 passed (11)
- **What was not tested**: Live Feishu end-to-end (requires Feishu bot credentials and running gateway). The `resolveFeishuDeliveryOrigin` helper that produces the delivery origin is already used in production by the `handleFeishuSubagentDeliveryTarget` hook — this change simply surfaces the same data earlier in the lifecycle.
- **Before evidence**: The 3 assertions previously read `expect(result).toEqual({ status: "ok", threadBindingReady: true })` — no `deliveryOrigin` field.
## Root Cause
- **Root cause**: `handleFeishuSubagentSpawning` in `extensions/feishu/src/subagent-hooks.ts:347-350` returned only `{ status: "ok", threadBindingReady: true }` after a successful `bindConversation`, despite `bindConversation` already storing `deliveryTo` and `deliveryThreadId` on the binding record, and `resolveFeishuDeliveryOrigin` already being available in the same module.
- **Missing detection / guardrail**: The existing tests only asserted `threadBindingReady: true` and did not check for `deliveryOrigin`. No regression coverage existed for the spawn hook's delivery origin output.
- **Contributing context**: This is the Feishu analogue of the Discord fix in PR #83172 — both channels create thread bindings during `subagent_spawning` but were omitting the `deliveryOrigin` field.
## Regression Test Plan
- **Coverage level that should have caught this**:
- [x] Unit test
- [ ] Seam / integration test
- [ ] End-to-end test
- [ ] Existing coverage already sufficient
- **Target test or file**: `extensions/feishu/src/subagent-hooks.test.ts` — the 3 existing tests for DM spawn, topic spawn, and rebound topic spawn.
- **Scenario the test should lock in**: After a successful `subagent_spawning` hook call with a valid Feishu requester, the returned result includes `deliveryOrigin` with the correct `channel`, `accountId`, `to` (and `threadId` for topics) that matches what `handleFeishuSubagentDeliveryTarget` later resolves.
- **Why this is the smallest reliable guardrail**: These tests already exercise the full binding → delivery pipeline. Adding the `deliveryOrigin` assertion at the spawn stage is the minimal change needed to prevent regression.
- **Existing test that already covers this (if any)**: Lines 57, 144, and 207 in `subagent-hooks.test.ts` were updated.
- **If no new test is added, why not**: N/A — existing tests were updated.
## User-visible / Behavior Changes
None directly visible to users. The change enables the core spawn flow (`ensureThreadBindingForSubagentSpawn`) to detect a routable `deliveryOrigin` and set `deliverInitialChildRunDirectly = true`, so Feishu subagent initial runs are delivered to the correct DM/topic conversation on first invocation instead of falling back to an alternative route.
## Diagram
```text
Before:
[subagent_spawning] -> bindConversation -> { status: "ok", threadBindingReady: true }
                   -> ensureThreadBindingForSubagentSpawn: no deliveryOrigin
                   -> deliverInitialChildRunDirectly = false
                   -> initial run delivered via fallback route
After:
[subagent_spawning] -> bindConversation -> { status: "ok", threadBindingReady: true,
                                           deliveryOrigin: { channel: "feishu", ... } }
                   -> ensureThreadBindingForSubagentSpawn: deliveryOrigin present
                   -> deliverInitialChildRunDirectly = true
                   -> initial run delivered to bound DM/topic conversation
Security Impact
- 
New permissions/capabilities? (No)
- 
Secrets/tokens handling changed? (No)
- 
New/changed network calls? (No)
- 
Command/tool execution surface changed? (No)
- 
Data access scope changed? (No)
Compatibility / Migration
- 
Backward compatible? (Yes) — deliveryOrigin was already optional in the hook return type; existing consumers that didn't read it continue to work.
- 
Config/env changes? (No)
- 
Migration needed? (No)
Risks and Mitigations
- 
Risk: If bindConversation returns a record with stale/incorrect deliveryTo/deliveryThreadId (e.g., from an existing binding via the ?? existing?.deliveryTo fallback in thread-bindings.ts:178), the returned deliveryOrigin may not match the current requester.
- 
Mitigation: Same deliveryTo/deliveryThreadId fields are already used by handleFeishuSubagentDeliveryTarget for completion routing — this change doesn't introduce a new data source, it surfaces existing data earlier. resolveFeishuDeliveryOrigin is an already-deployed helper.