### PR TITLE
Doctor: convert read-only health checks

### DIFF
--- a/src/commands/doctor-cron.test.ts
+++ b/src/commands/doctor-cron.test.ts
@@ -3,7 +3,11 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
-import { maybeRepairLegacyCronStore, noteLegacyWhatsAppCrontabHealthCheck } from "./doctor-cron.js";
+import {
+  collectLegacyWhatsAppCrontabHealthWarning,
+  maybeRepairLegacyCronStore,
+  noteLegacyWhatsAppCrontabHealthCheck,
+} from "./doctor-cron.js";
 
 type TerminalNote = (message: string, title?: string) => void;
 
@@ -536,7 +540,25 @@ describe("maybeRepairLegacyCronStore", () => {
   });
 });
 
-describe("noteLegacyWhatsAppCrontabHealthCheck", () => {
+describe("legacy WhatsApp crontab health check", () => {
+  it("collects a warning about legacy ensure-whatsapp crontab entries on Linux", async () => {
+    const warning = await collectLegacyWhatsAppCrontabHealthWarning({
+      platform: "linux",
+      readCrontab: async () => ({
+        stdout: [
+          "# keep comments ignored",
+          "*/5 * * * * ~/.openclaw/bin/ensure-whatsapp.sh >> ~/.openclaw/logs/whatsapp-health.log 2>&1",
+          "0 9 * * * /usr/bin/true",
+          "",
+        ].join("\n"),
+      }),
+    });
+
+    expect(warning).toContain("Legacy WhatsApp crontab health check detected");
+    expect(warning).toContain("systemd user bus environment is missing");
+    expect(warning).toContain("Matched 1 entry");
+  });
+
   it("warns about legacy ensure-whatsapp crontab entries on Linux", async () => {
     await noteLegacyWhatsAppCrontabHealthCheck({
       platform: "linux",

--- a/src/commands/doctor-cron.ts
+++ b/src/commands/doctor-cron.ts
@@ -287,37 +287,46 @@ function findLegacyWhatsAppHealthCrontabLines(crontab: unknown): string[] {
     .filter((line) => LEGACY_WHATSAPP_HEALTH_SCRIPT_RE.test(line));
 }
 
-export async function noteLegacyWhatsAppCrontabHealthCheck(
+export async function collectLegacyWhatsAppCrontabHealthWarning(
   params: {
     platform?: NodeJS.Platform;
     readCrontab?: CrontabReader;
   } = {},
-): Promise<void> {
+): Promise<string | null> {
   if ((params.platform ?? process.platform) !== "linux") {
-    return;
+    return null;
   }
 
   let crontab: unknown;
   try {
     crontab = (await (params.readCrontab ?? readUserCrontab)()).stdout;
   } catch {
-    return;
+    return null;
   }
 
   const legacyLines = findLegacyWhatsAppHealthCrontabLines(crontab);
   if (legacyLines.length === 0) {
-    return;
+    return null;
   }
 
-  note(
-    [
-      "Legacy WhatsApp crontab health check detected.",
-      "`~/.openclaw/bin/ensure-whatsapp.sh` is not maintained by current OpenClaw and can misreport `Gateway inactive` from cron when the systemd user bus environment is missing.",
-      `Remove the stale crontab entry with ${formatCliCommand("crontab -e")}; use ${formatCliCommand("openclaw channels status --probe")}, ${formatCliCommand("openclaw doctor")}, and ${formatCliCommand("openclaw gateway status")} for current health checks.`,
-      `Matched ${pluralize(legacyLines.length, "entry")}.`,
-    ].join("\n"),
-    "Cron",
-  );
+  return [
+    "Legacy WhatsApp crontab health check detected.",
+    "`~/.openclaw/bin/ensure-whatsapp.sh` is not maintained by current OpenClaw and can misreport `Gateway inactive` from cron when the systemd user bus environment is missing.",
+    `Remove the stale crontab entry with ${formatCliCommand("crontab -e")}; use ${formatCliCommand("openclaw channels status --probe")}, ${formatCliCommand("openclaw doctor")}, and ${formatCliCommand("openclaw gateway status")} for current health checks.`,
+    `Matched ${pluralize(legacyLines.length, "entry")}.`,
+  ].join("\n");
+}
+
+export async function noteLegacyWhatsAppCrontabHealthCheck(
+  params: {
+    platform?: NodeJS.Platform;
+    readCrontab?: CrontabReader;
+  } = {},
+): Promise<void> {
+  const warning = await collectLegacyWhatsAppCrontabHealthWarning(params);
+  if (warning) {
+    note(warning, "Cron");
+  }
 }
 
 export async function maybeRepairLegacyCronStore(params: {

--- a/src/commands/doctor-lint.test.ts
+++ b/src/commands/doctor-lint.test.ts
@@ -38,6 +38,7 @@ describe("runDoctorLintCli", () => {
       const exitCode = await runDoctorLintCli(runtime, {
         json: true,
         severityMin: "error",
+        onlyIds: ["core/doctor/final-config-validation"],
       });
 
       expect(exitCode).toBe(0);
@@ -62,6 +63,7 @@ describe("runDoctorLintCli", () => {
     try {
       const exitCode = await runDoctorLintCli(runtime, {
         severityMin: "error",
+        onlyIds: ["core/doctor/final-config-validation"],
       });
 
       expect(exitCode).toBe(0);

--- a/src/commands/doctor-lint.test.ts
+++ b/src/commands/doctor-lint.test.ts
@@ -108,6 +108,39 @@ describe("runDoctorLintCli", () => {
     }
   });
 
+  it("rejects unknown --only health check ids instead of reporting a false-clean run", async () => {
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      exists: true,
+      valid: true,
+      config: {},
+      path: "/tmp/openclaw.json",
+    });
+
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    try {
+      const exitCode = await runDoctorLintCli(runtime, {
+        json: true,
+        onlyIds: ["core/doctor/session-locks"],
+      });
+
+      expect(exitCode).toBe(1);
+      const payload = JSON.parse(String(stdout.mock.calls.at(-1)?.[0]));
+      expect(payload).toMatchObject({
+        ok: false,
+        checksRun: 0,
+        findings: [
+          {
+            checkId: "core/doctor/lint-selection",
+            severity: "error",
+            path: "core/doctor/session-locks",
+          },
+        ],
+      });
+    } finally {
+      stdout.mockRestore();
+    }
+  });
+
   it("rejects invalid severity thresholds", async () => {
     await expect(runDoctorLintCli(runtime, { severityMin: "warnng" })).rejects.toThrow(
       "Invalid --severity-min value",

--- a/src/commands/doctor-lint.test.ts
+++ b/src/commands/doctor-lint.test.ts
@@ -7,7 +7,8 @@ const mocks = vi.hoisted(() => ({
   readConfigFileSnapshot: vi.fn(),
 }));
 
-vi.mock("../config/config.js", () => ({
+vi.mock("../config/config.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../config/config.js")>()),
   readConfigFileSnapshot: mocks.readConfigFileSnapshot,
 }));
 
@@ -37,7 +38,6 @@ describe("runDoctorLintCli", () => {
       const exitCode = await runDoctorLintCli(runtime, {
         json: true,
         severityMin: "error",
-        onlyIds: ["core/doctor/gateway-config"],
       });
 
       expect(exitCode).toBe(0);
@@ -62,7 +62,6 @@ describe("runDoctorLintCli", () => {
     try {
       const exitCode = await runDoctorLintCli(runtime, {
         severityMin: "error",
-        onlyIds: ["core/doctor/gateway-config"],
       });
 
       expect(exitCode).toBe(0);

--- a/src/commands/doctor-lint.test.ts
+++ b/src/commands/doctor-lint.test.ts
@@ -37,6 +37,7 @@ describe("runDoctorLintCli", () => {
       const exitCode = await runDoctorLintCli(runtime, {
         json: true,
         severityMin: "error",
+        onlyIds: ["core/doctor/gateway-config"],
       });
 
       expect(exitCode).toBe(0);
@@ -61,12 +62,11 @@ describe("runDoctorLintCli", () => {
     try {
       const exitCode = await runDoctorLintCli(runtime, {
         severityMin: "error",
+        onlyIds: ["core/doctor/gateway-config"],
       });
 
       expect(exitCode).toBe(0);
-      expect(String(stdout.mock.calls[0]?.[0])).toBe(
-        "doctor --lint: ran 6 check(s), 0 finding(s)\n",
-      );
+      expect(String(stdout.mock.calls[0]?.[0])).toContain("0 finding(s)");
       expect(String(stdout.mock.calls[1]?.[0])).toBe("  no findings\n");
     } finally {
       Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: originalIsTTY });

--- a/src/commands/doctor-platform-notes.launchctl-env-overrides.test.ts
+++ b/src/commands/doctor-platform-notes.launchctl-env-overrides.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import {
+  collectMacLaunchAgentOverrideWarning,
+  collectMacLaunchctlGatewayEnvOverrideWarning,
+  collectMacStaleOpenClawUpdateLaunchdJobsWarning,
   noteMacLaunchctlGatewayEnvOverrides,
   noteMacStaleOpenClawUpdateLaunchdJobs,
 } from "./doctor-platform-notes.js";
@@ -14,6 +17,29 @@ function requireNoteCall(noteFn: { mock: { calls: unknown[][] } }, index = 0): u
 }
 
 describe("noteMacLaunchctlGatewayEnvOverrides", () => {
+  it("collects clear unsetenv instructions for token override", async () => {
+    const getenv = vi.fn(async (name: string) =>
+      name === "OPENCLAW_GATEWAY_TOKEN" ? "launchctl-token" : undefined,
+    );
+    const cfg = {
+      gateway: {
+        auth: {
+          token: "config-token",
+        },
+      },
+    } as OpenClawConfig;
+
+    const warning = await collectMacLaunchctlGatewayEnvOverrideWarning(cfg, {
+      platform: "darwin",
+      getenv,
+    });
+
+    expect(warning).toContain("Host-wide launchctl gateway auth overrides detected");
+    expect(warning).toContain("OPENCLAW_GATEWAY_TOKEN");
+    expect(warning).toContain("launchctl unsetenv OPENCLAW_GATEWAY_TOKEN");
+    expect(warning).not.toContain("OPENCLAW_GATEWAY_PASSWORD");
+  });
+
   it("prints clear unsetenv instructions for token override", async () => {
     const noteFn = vi.fn();
     const getenv = vi.fn(async (name: string) =>
@@ -96,6 +122,26 @@ describe("noteMacLaunchctlGatewayEnvOverrides", () => {
 });
 
 describe("noteMacStaleOpenClawUpdateLaunchdJobs", () => {
+  it("collects stale updater job cleanup guidance on macOS", async () => {
+    const findJobs = vi.fn(async () => [
+      {
+        label: "ai.openclaw.update.2026.5.12",
+        lastExitStatus: 127,
+      },
+    ]);
+
+    const warning = await collectMacStaleOpenClawUpdateLaunchdJobsWarning({
+      platform: "darwin",
+      findJobs,
+    });
+
+    expect(findJobs).toHaveBeenCalledTimes(1);
+    expect(warning).toContain("Stale OpenClaw updater launchd job(s) detected");
+    expect(warning).toContain("ai.openclaw.update.2026.5.12");
+    expect(warning).toContain("launchctl remove <label>");
+    expect(warning).toContain("openclaw gateway restart");
+  });
+
   it("prints stale updater job cleanup guidance on macOS", async () => {
     const noteFn = vi.fn();
     const findJobs = vi.fn(async () => [
@@ -131,5 +177,29 @@ describe("noteMacStaleOpenClawUpdateLaunchdJobs", () => {
     });
 
     expect(noteFn).not.toHaveBeenCalled();
+  });
+});
+
+describe("collectMacLaunchAgentOverrideWarning", () => {
+  it("collects guidance when launch agent writes are disabled", () => {
+    const warning = collectMacLaunchAgentOverrideWarning({
+      platform: "darwin",
+      homeDir: "/Users/tester",
+      exists: (candidate) => candidate.includes("disable-launchagent"),
+    });
+
+    expect(warning).toContain("LaunchAgent writes are disabled");
+    expect(warning).toContain("rm ");
+    expect(warning).toContain("disable-launchagent");
+  });
+
+  it("does nothing when launch agent writes are not disabled", () => {
+    expect(
+      collectMacLaunchAgentOverrideWarning({
+        platform: "darwin",
+        homeDir: "/Users/tester",
+        exists: () => false,
+      }),
+    ).toBeNull();
   });
 });

--- a/src/commands/doctor-platform-notes.ts
+++ b/src/commands/doctor-platform-notes.ts
@@ -17,41 +17,51 @@ function resolveHomeDir(): string {
   return process.env.HOME ?? os.homedir();
 }
 
-export async function noteMacLaunchAgentOverrides() {
-  if (process.platform !== "darwin") {
-    return;
+export function collectMacLaunchAgentOverrideWarning(deps?: {
+  platform?: NodeJS.Platform;
+  homeDir?: string;
+  exists?: (candidate: string) => boolean;
+}): string | null {
+  if ((deps?.platform ?? process.platform) !== "darwin") {
+    return null;
   }
-  const home = resolveHomeDir();
+  const home = deps?.homeDir ?? resolveHomeDir();
   const markerCandidates = [path.join(home, ".openclaw", "disable-launchagent")];
-  const markerPath = markerCandidates.find((candidate) => fs.existsSync(candidate));
+  const exists = deps?.exists ?? fs.existsSync;
+  const markerPath = markerCandidates.find((candidate) => exists(candidate));
   if (!markerPath) {
-    return;
+    return null;
   }
 
   const displayMarkerPath = shortenHomePath(markerPath);
-  const lines = [
+  return [
     `- LaunchAgent writes are disabled via ${displayMarkerPath}.`,
     "- To restore default behavior:",
     `  rm ${displayMarkerPath}`,
-  ].filter((line): line is string => Boolean(line));
-  note(lines.join("\n"), "Gateway (macOS)");
+  ].join("\n");
 }
 
-export async function noteMacStaleOpenClawUpdateLaunchdJobs(deps?: {
+export async function noteMacLaunchAgentOverrides() {
+  const warning = collectMacLaunchAgentOverrideWarning();
+  if (warning) {
+    note(warning, "Gateway (macOS)");
+  }
+}
+
+export async function collectMacStaleOpenClawUpdateLaunchdJobsWarning(deps?: {
   platform?: NodeJS.Platform;
   findJobs?: typeof findStaleOpenClawUpdateLaunchdJobs;
-  noteFn?: typeof note;
-}) {
+}): Promise<string | null> {
   const platform = deps?.platform ?? process.platform;
   if (platform !== "darwin") {
-    return;
+    return null;
   }
   const jobs = await (deps?.findJobs ?? findStaleOpenClawUpdateLaunchdJobs)().catch(() => []);
   if (jobs.length === 0) {
-    return;
+    return null;
   }
 
-  const lines = [
+  return [
     "- Stale OpenClaw updater launchd job(s) detected.",
     ...jobs.map((job) => {
       const exitStatus =
@@ -62,8 +72,18 @@ export async function noteMacStaleOpenClawUpdateLaunchdJobs(deps?: {
     "- Fix after confirming no update is running:",
     "  launchctl remove <label>",
     `  ${formatCliCommand("openclaw gateway restart")}`,
-  ];
-  (deps?.noteFn ?? note)(lines.join("\n"), "Gateway (macOS)");
+  ].join("\n");
+}
+
+export async function noteMacStaleOpenClawUpdateLaunchdJobs(deps?: {
+  platform?: NodeJS.Platform;
+  findJobs?: typeof findStaleOpenClawUpdateLaunchdJobs;
+  noteFn?: typeof note;
+}) {
+  const warning = await collectMacStaleOpenClawUpdateLaunchdJobsWarning(deps);
+  if (warning) {
+    (deps?.noteFn ?? note)(warning, "Gateway (macOS)");
+  }
 }
 
 async function launchctlGetenv(name: string): Promise<string | undefined> {
@@ -88,20 +108,19 @@ function hasConfigGatewayCreds(cfg: OpenClawConfig): boolean {
   );
 }
 
-export async function noteMacLaunchctlGatewayEnvOverrides(
+export async function collectMacLaunchctlGatewayEnvOverrideWarning(
   cfg: OpenClawConfig,
   deps?: {
     platform?: NodeJS.Platform;
     getenv?: (name: string) => Promise<string | undefined>;
-    noteFn?: typeof note;
   },
-) {
+): Promise<string | null> {
   const platform = deps?.platform ?? process.platform;
   if (platform !== "darwin") {
-    return;
+    return null;
   }
   if (!hasConfigGatewayCreds(cfg)) {
-    return;
+    return null;
   }
 
   const getenv = deps?.getenv ?? launchctlGetenv;
@@ -118,10 +137,10 @@ export async function noteMacLaunchctlGatewayEnvOverrides(
   const envTokenKey = tokenEntry?.[0];
   const envPasswordKey = passwordEntry?.[0];
   if (!envToken && !envPassword) {
-    return;
+    return null;
   }
 
-  const lines = [
+  return [
     "- Host-wide launchctl gateway auth overrides detected.",
     "- Current managed Gateway installs do not need these values unless config intentionally references the env var.",
     envToken && envTokenKey
@@ -133,9 +152,42 @@ export async function noteMacLaunchctlGatewayEnvOverrides(
     "- Clear overrides and restart the app/gateway:",
     envTokenKey ? `  launchctl unsetenv ${envTokenKey}` : undefined,
     envPasswordKey ? `  launchctl unsetenv ${envPasswordKey}` : undefined,
-  ].filter((line): line is string => Boolean(line));
+  ]
+    .filter((line): line is string => Boolean(line))
+    .join("\n");
+}
 
-  (deps?.noteFn ?? note)(lines.join("\n"), "Gateway (macOS)");
+export async function noteMacLaunchctlGatewayEnvOverrides(
+  cfg: OpenClawConfig,
+  deps?: {
+    platform?: NodeJS.Platform;
+    getenv?: (name: string) => Promise<string | undefined>;
+    noteFn?: typeof note;
+  },
+) {
+  const warning = await collectMacLaunchctlGatewayEnvOverrideWarning(cfg, deps);
+  if (warning) {
+    (deps?.noteFn ?? note)(warning, "Gateway (macOS)");
+  }
+}
+
+export async function collectMacGatewayPlatformWarnings(
+  cfg: OpenClawConfig,
+): Promise<readonly string[]> {
+  const warnings: string[] = [];
+  const launchAgentWarning = collectMacLaunchAgentOverrideWarning();
+  if (launchAgentWarning) {
+    warnings.push(launchAgentWarning);
+  }
+  const staleUpdateWarning = await collectMacStaleOpenClawUpdateLaunchdJobsWarning();
+  if (staleUpdateWarning) {
+    warnings.push(staleUpdateWarning);
+  }
+  const launchctlWarning = await collectMacLaunchctlGatewayEnvOverrideWarning(cfg);
+  if (launchctlWarning) {
+    warnings.push(launchctlWarning);
+  }
+  return warnings;
 }
 
 function isTruthyEnvValue(value: string | undefined): boolean {

--- a/src/commands/doctor-security.ts
+++ b/src/commands/doctor-security.ts
@@ -180,9 +180,11 @@ function collectExecFilesystemPolicyWarnings(cfg: OpenClawConfig): string[] {
   );
 }
 
-export async function noteSecurityWarnings(cfg: OpenClawConfig) {
+export async function collectSecurityWarnings(
+  cfg: OpenClawConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<string[]> {
   const warnings: string[] = [];
-  const auditHint = `- Run: ${formatCliCommand("openclaw security audit --deep")}`;
 
   if (cfg.approvals?.exec?.enabled === false) {
     warnings.push(
@@ -217,7 +219,7 @@ export async function noteSecurityWarnings(cfg: OpenClawConfig) {
 
   const resolvedAuth = resolveGatewayAuth({
     authConfig: cfg.gateway?.auth,
-    env: process.env,
+    env,
     tailscaleMode,
   });
   const authToken = normalizeOptionalString(resolvedAuth.token) ?? "";
@@ -269,7 +271,7 @@ export async function noteSecurityWarnings(cfg: OpenClawConfig) {
     }
   }
 
-  const tokenConflict = resolveGatewayAuthTokenSourceConflict({ cfg, env: process.env });
+  const tokenConflict = resolveGatewayAuthTokenSourceConflict({ cfg, env });
   if (tokenConflict) {
     warnings.push(...tokenConflict.warningLines);
   }
@@ -377,6 +379,12 @@ export async function noteSecurityWarnings(cfg: OpenClawConfig) {
       }
     }
   }
+  return warnings;
+}
+
+export async function noteSecurityWarnings(cfg: OpenClawConfig) {
+  const warnings = await collectSecurityWarnings(cfg);
+  const auditHint = `- Run: ${formatCliCommand("openclaw security audit --deep")}`;
 
   const lines = warnings.length > 0 ? warnings : ["- No channel security warnings detected."];
   lines.push(auditHint);

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -1053,20 +1053,24 @@ export async function noteStateIntegrity(
   }
 }
 
-export function noteWorkspaceBackupTip(workspaceDir: string) {
+export function collectWorkspaceBackupTip(workspaceDir: string): string | null {
   if (!existsDir(workspaceDir)) {
-    return;
+    return null;
   }
   const gitMarker = path.join(workspaceDir, ".git");
   if (fs.existsSync(gitMarker)) {
-    return;
+    return null;
   }
-  note(
-    [
-      "- Tip: back up the workspace in a private git repo (GitHub or GitLab).",
-      "- Keep ~/.openclaw out of git; it contains credentials and session history.",
-      "- Details: /concepts/agent-workspace#git-backup-recommended",
-    ].join("\n"),
-    "Workspace",
-  );
+  return [
+    "- Tip: back up the workspace in a private git repo (GitHub or GitLab).",
+    "- Keep ~/.openclaw out of git; it contains credentials and session history.",
+    "- Details: /concepts/agent-workspace#git-backup-recommended",
+  ].join("\n");
+}
+
+export function noteWorkspaceBackupTip(workspaceDir: string) {
+  const tip = collectWorkspaceBackupTip(workspaceDir);
+  if (tip) {
+    note(tip, "Workspace");
+  }
 }

--- a/src/flows/doctor-core-checks.test.ts
+++ b/src/flows/doctor-core-checks.test.ts
@@ -5,7 +5,6 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   CORE_HEALTH_CHECKS,
-  TRANSITIONAL_DOCTOR_HEALTH_PLACEHOLDER_IDS,
   registerCoreHealthChecks,
   resetCoreHealthChecksForTest,
 } from "./doctor-core-checks.js";
@@ -58,23 +57,35 @@ describe("registerCoreHealthChecks", () => {
     expect(listHealthChecks()).toHaveLength(CORE_HEALTH_CHECKS.length);
   });
 
-  it("registers every core health target named by the doctor conversion inventory", () => {
+  it("registers only implemented core health targets from the doctor conversion inventory", () => {
     registerCoreHealthChecks();
 
     const registeredIds = new Set(listHealthChecks().map((check) => check.id));
-    const coreTargets = doctorHealthConversionRules.flatMap((rule) =>
-      rule.target.filter((target) => target.startsWith("core/doctor/")),
+    const coreTargets = new Set(
+      doctorHealthConversionRules.flatMap((rule) =>
+        rule.target.filter((target) => target.startsWith("core/doctor/")),
+      ),
     );
+    const plannedOnlyTargets = [
+      "core/doctor/auth-profiles/keychain",
+      "core/doctor/session-locks",
+      "core/doctor/gateway-daemon",
+    ];
 
-    expect(coreTargets.filter((target) => !registeredIds.has(target))).toEqual([]);
-  });
-
-  it("keeps transitional no-op health checks explicit", () => {
-    const placeholderIds = CORE_HEALTH_CHECKS.filter((check) =>
-      check.description.endsWith("represented in the health registry."),
-    ).map((check) => check.id);
-
-    expect(placeholderIds).toEqual([...TRANSITIONAL_DOCTOR_HEALTH_PLACEHOLDER_IDS]);
+    for (const id of CORE_HEALTH_CHECKS.map((check) => check.id)) {
+      if (id === "core/doctor/browser-clawd-profile-residue") {
+        continue;
+      }
+      expect(coreTargets.has(id)).toBe(true);
+    }
+    for (const id of plannedOnlyTargets) {
+      expect(registeredIds.has(id)).toBe(false);
+    }
+    expect(
+      CORE_HEALTH_CHECKS.some((check) =>
+        check.description.endsWith("represented in the health registry."),
+      ),
+    ).toBe(false);
   });
 
   it("shows the repair-capable health check shape with skills readiness", async () => {

--- a/src/flows/doctor-core-checks.test.ts
+++ b/src/flows/doctor-core-checks.test.ts
@@ -61,7 +61,7 @@ describe("registerCoreHealthChecks", () => {
     registerCoreHealthChecks();
 
     const registeredIds = new Set(listHealthChecks().map((check) => check.id));
-    const coreTargets = new Set(
+    const coreTargets = new Set<string>(
       doctorHealthConversionRules.flatMap((rule) =>
         rule.target.filter((target) => target.startsWith("core/doctor/")),
       ),

--- a/src/flows/doctor-core-checks.test.ts
+++ b/src/flows/doctor-core-checks.test.ts
@@ -5,9 +5,11 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   CORE_HEALTH_CHECKS,
+  TRANSITIONAL_DOCTOR_HEALTH_PLACEHOLDER_IDS,
   registerCoreHealthChecks,
   resetCoreHealthChecksForTest,
 } from "./doctor-core-checks.js";
+import { doctorHealthConversionRules } from "./doctor-health-conversion-plan.js";
 import {
   clearHealthChecksForTest,
   listHealthChecks,
@@ -33,14 +35,9 @@ describe("registerCoreHealthChecks", () => {
     registerCoreHealthChecks();
     registerCoreHealthChecks();
 
-    expect(listHealthChecks().map((check) => check.id)).toEqual([
-      "core/doctor/gateway-config",
-      "core/doctor/command-owner",
-      "core/doctor/workspace-status",
-      "core/doctor/skills-readiness",
-      "core/doctor/browser-clawd-profile-residue",
-      "core/doctor/final-config-validation",
-    ]);
+    expect(listHealthChecks().map((check) => check.id)).toEqual(
+      CORE_HEALTH_CHECKS.map((check) => check.id),
+    );
   });
 
   it("can retry after a duplicate registration failure is cleared", () => {
@@ -58,7 +55,26 @@ describe("registerCoreHealthChecks", () => {
     clearHealthChecksForTest();
     registerCoreHealthChecks();
 
-    expect(listHealthChecks()).toHaveLength(6);
+    expect(listHealthChecks()).toHaveLength(CORE_HEALTH_CHECKS.length);
+  });
+
+  it("registers every core health target named by the doctor conversion inventory", () => {
+    registerCoreHealthChecks();
+
+    const registeredIds = new Set(listHealthChecks().map((check) => check.id));
+    const coreTargets = doctorHealthConversionRules.flatMap((rule) =>
+      rule.target.filter((target) => target.startsWith("core/doctor/")),
+    );
+
+    expect(coreTargets.filter((target) => !registeredIds.has(target))).toEqual([]);
+  });
+
+  it("keeps transitional no-op health checks explicit", () => {
+    const placeholderIds = CORE_HEALTH_CHECKS.filter((check) =>
+      check.description.endsWith("represented in the health registry."),
+    ).map((check) => check.id);
+
+    expect(placeholderIds).toEqual([...TRANSITIONAL_DOCTOR_HEALTH_PLACEHOLDER_IDS]);
   });
 
   it("shows the repair-capable health check shape with skills readiness", async () => {
@@ -145,6 +161,66 @@ metadata: '{"openclaw":{"requires":{"bins":["openclaw-test-missing-skill-bin"]}}
         kind: "config",
         action: "disable-skill",
         target: "skills.entries.missing-tool.enabled",
+      }),
+    );
+  });
+
+  it("converts security doctor warnings into health findings", async () => {
+    const check = CORE_HEALTH_CHECKS.find((entry) => entry.id === "core/doctor/security");
+
+    const findings = await check?.detect({
+      mode: "lint",
+      runtime: { log() {}, error() {}, exit() {} },
+      cfg: {
+        gateway: {
+          bind: "lan",
+          auth: {
+            mode: "none",
+          },
+        },
+      },
+    });
+
+    expect(findings).toContainEqual(
+      expect.objectContaining({
+        checkId: "core/doctor/security",
+        severity: "error",
+        message: expect.stringContaining("Gateway bound"),
+      }),
+    );
+  });
+
+  it("converts workspace suggestions into info findings", async () => {
+    tmp = await fs.mkdtemp(join(tmpdir(), "openclaw-health-workspace-"));
+    const check = CORE_HEALTH_CHECKS.find(
+      (entry) => entry.id === "core/doctor/workspace-suggestions",
+    );
+
+    const findings = await check?.detect({
+      mode: "lint",
+      runtime: { log() {}, error() {}, exit() {} },
+      cfg: {
+        agents: {
+          defaults: {
+            workspace: tmp,
+          },
+        },
+      },
+      cwd: tmp,
+    });
+
+    expect(findings).toContainEqual(
+      expect.objectContaining({
+        checkId: "core/doctor/workspace-suggestions",
+        severity: "info",
+        message: "Tip: back up the workspace in a private git repo (GitHub or GitLab).",
+      }),
+    );
+    expect(findings).toContainEqual(
+      expect.objectContaining({
+        checkId: "core/doctor/workspace-suggestions",
+        severity: "info",
+        message: "Memory system not found in workspace.",
       }),
     );
   });

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -21,37 +21,6 @@ import type { HealthCheck, HealthFinding } from "./health-checks.js";
 const BROWSER_CLAWD_PROFILE_RESIDUE_CHECK_ID = "core/doctor/browser-clawd-profile-residue";
 const FINAL_CONFIG_VALIDATION_CHECK_ID = "core/doctor/final-config-validation";
 
-export const TRANSITIONAL_DOCTOR_HEALTH_PLACEHOLDER_IDS = [
-  "core/doctor/auth-profiles/flat-store",
-  "core/doctor/auth-profiles/oauth-sidecar",
-  "core/doctor/auth-profiles/oauth-ids",
-  "core/doctor/auth-profiles/keychain",
-  "core/doctor/auth-profiles/codex-provider",
-  "core/doctor/legacy-plugin-manifests",
-  "core/doctor/configured-plugin-installs",
-  "core/doctor/plugin-registry",
-  "core/doctor/state-integrity",
-  "core/doctor/codex-session-routes",
-  "core/doctor/session-locks",
-  "core/doctor/session-transcripts",
-  "core/doctor/config-audit-scrub",
-  "core/doctor/legacy-cron-store",
-  "core/doctor/sandbox/registry-files",
-  "core/doctor/sandbox/images",
-  "core/doctor/sandbox-scope",
-  "core/doctor/gateway-services/extra",
-  "core/doctor/gateway-services/config",
-  "core/doctor/startup-channel-maintenance",
-  "core/doctor/systemd-linger",
-  "core/doctor/shell-completion",
-  "core/doctor/whatsapp-responsiveness",
-  "core/doctor/memory-search",
-  "core/doctor/memory-recall",
-  "core/doctor/memory-gateway-probe",
-  "core/doctor/device-pairing",
-  "core/doctor/gateway-daemon",
-] as const;
-
 export function configValidationIssuesToHealthFindings(
   issues: readonly ConfigValidationIssue[],
 ): readonly HealthFinding[] {
@@ -740,141 +709,17 @@ const workspaceSuggestionsCheck: HealthCheck = {
   },
 };
 
-function createConvertedWorkflowCheck(id: string, description: string): HealthCheck {
-  return {
-    id,
-    kind: "core",
-    description,
-    source: "doctor",
-    async detect() {
-      return [];
-    },
-  };
-}
-
 const convertedWorkflowChecks: readonly HealthCheck[] = [
-  createConvertedWorkflowCheck(
-    "core/doctor/auth-profiles/flat-store",
-    "Legacy flat auth profile stores are represented in the health registry.",
-  ),
-  createConvertedWorkflowCheck(
-    "core/doctor/auth-profiles/oauth-sidecar",
-    "Legacy OAuth sidecar profiles are represented in the health registry.",
-  ),
-  createConvertedWorkflowCheck(
-    "core/doctor/auth-profiles/oauth-ids",
-    "Legacy OAuth profile ids are represented in the health registry.",
-  ),
-  createConvertedWorkflowCheck(
-    "core/doctor/auth-profiles/keychain",
-    "Auth profile keychain readiness is represented in the health registry.",
-  ),
-  createConvertedWorkflowCheck(
-    "core/doctor/auth-profiles/codex-provider",
-    "Legacy Codex provider overrides are represented in the health registry.",
-  ),
   claudeCliCheck,
   gatewayAuthCheck,
   legacyStateCheck,
-  createConvertedWorkflowCheck(
-    "core/doctor/legacy-plugin-manifests",
-    "Legacy plugin manifest contract checks are represented in the health registry.",
-  ),
-  createConvertedWorkflowCheck(
-    "core/doctor/configured-plugin-installs",
-    "Configured plugin install release repairs are represented in the health registry.",
-  ),
-  createConvertedWorkflowCheck(
-    "core/doctor/plugin-registry",
-    "Plugin registry checks are represented in the health registry.",
-  ),
-  createConvertedWorkflowCheck(
-    "core/doctor/state-integrity",
-    "State integrity checks are represented in the health registry.",
-  ),
-  createConvertedWorkflowCheck(
-    "core/doctor/codex-session-routes",
-    "Codex session route checks are represented in the health registry.",
-  ),
-  createConvertedWorkflowCheck(
-    "core/doctor/session-locks",
-    "Session lock checks are represented in the health registry.",
-  ),
-  createConvertedWorkflowCheck(
-    "core/doctor/session-transcripts",
-    "Session transcript checks are represented in the health registry.",
-  ),
-  createConvertedWorkflowCheck(
-    "core/doctor/config-audit-scrub",
-    "Config audit scrub checks are represented in the health registry.",
-  ),
-  createConvertedWorkflowCheck(
-    "core/doctor/legacy-cron-store",
-    "Legacy cron store checks are represented in the health registry.",
-  ),
   legacyWhatsAppCrontabCheck,
-  createConvertedWorkflowCheck(
-    "core/doctor/sandbox/registry-files",
-    "Sandbox registry file checks are represented in the health registry.",
-  ),
-  createConvertedWorkflowCheck(
-    "core/doctor/sandbox/images",
-    "Sandbox image checks are represented in the health registry.",
-  ),
-  createConvertedWorkflowCheck(
-    "core/doctor/sandbox-scope",
-    "Sandbox scope checks are represented in the health registry.",
-  ),
-  createConvertedWorkflowCheck(
-    "core/doctor/gateway-services/extra",
-    "Extra Gateway service checks are represented in the health registry.",
-  ),
-  createConvertedWorkflowCheck(
-    "core/doctor/gateway-services/config",
-    "Gateway service config checks are represented in the health registry.",
-  ),
   gatewayPlatformNotesCheck,
-  createConvertedWorkflowCheck(
-    "core/doctor/startup-channel-maintenance",
-    "Startup channel maintenance is represented in the health registry.",
-  ),
   securityCheck,
   browserCheck,
   openAIOAuthTlsCheck,
   hooksModelCheck,
-  createConvertedWorkflowCheck(
-    "core/doctor/systemd-linger",
-    "systemd linger checks are represented in the health registry.",
-  ),
   bootstrapSizeCheck,
-  createConvertedWorkflowCheck(
-    "core/doctor/shell-completion",
-    "Shell completion checks are represented in the health registry.",
-  ),
-  createConvertedWorkflowCheck(
-    "core/doctor/whatsapp-responsiveness",
-    "WhatsApp responsiveness checks are represented in the health registry.",
-  ),
-  createConvertedWorkflowCheck(
-    "core/doctor/memory-search",
-    "Memory search checks are represented in the health registry.",
-  ),
-  createConvertedWorkflowCheck(
-    "core/doctor/memory-recall",
-    "Memory recall checks are represented in the health registry.",
-  ),
-  createConvertedWorkflowCheck(
-    "core/doctor/memory-gateway-probe",
-    "Memory Gateway probe checks are represented in the health registry.",
-  ),
-  createConvertedWorkflowCheck(
-    "core/doctor/device-pairing",
-    "Device pairing checks are represented in the health registry.",
-  ),
-  createConvertedWorkflowCheck(
-    "core/doctor/gateway-daemon",
-    "Gateway daemon checks are represented in the health registry.",
-  ),
   workspaceSuggestionsCheck,
 ];
 

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -34,7 +34,6 @@ export const TRANSITIONAL_DOCTOR_HEALTH_PLACEHOLDER_IDS = [
   "core/doctor/codex-session-routes",
   "core/doctor/session-locks",
   "core/doctor/session-transcripts",
-  "core/doctor/session-snapshots",
   "core/doctor/config-audit-scrub",
   "core/doctor/legacy-cron-store",
   "core/doctor/sandbox/registry-files",

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -698,7 +698,7 @@ const finalConfigValidationCheck: HealthCheck = {
   source: "doctor",
   async detect() {
     const { readConfigFileSnapshot } = await import("../config/config.js");
-    const snap = await readConfigFileSnapshot();
+    const snap = await readConfigFileSnapshot({ observe: false });
     if (!snap.exists || snap.valid) {
       return [];
     }

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -355,29 +355,50 @@ function inferCapturedNoteSeverity(text: string): HealthFinding["severity"] {
 
 function createNoteCollector(checkId: string): {
   readonly findings: readonly HealthFinding[];
-  noteFn(message: unknown): void;
+  readonly noteFn: (message: unknown) => void;
 } {
   const findings: HealthFinding[] = [];
+  const noteFn = (message: unknown): void => {
+    const text = noteMessageToText(message);
+    if (!text.trim()) {
+      return;
+    }
+    const severity = inferCapturedNoteSeverity(text);
+    if (severity === "info") {
+      return;
+    }
+    findings.push(
+      noteTextToFinding({
+        checkId,
+        severity,
+        text,
+      }),
+    );
+  };
   return {
     findings,
-    noteFn(message: unknown) {
-      const text = message instanceof Error ? message.message : String(message ?? "");
-      if (!text.trim()) {
-        return;
-      }
-      const severity = inferCapturedNoteSeverity(text);
-      if (severity === "info") {
-        return;
-      }
-      findings.push(
-        noteTextToFinding({
-          checkId,
-          severity,
-          text,
-        }),
-      );
-    },
+    noteFn,
   };
+}
+
+function noteMessageToText(message: unknown): string {
+  if (message instanceof Error) {
+    return message.message;
+  }
+  if (message == null) {
+    return "";
+  }
+  if (typeof message === "string") {
+    return message;
+  }
+  if (typeof message === "number" || typeof message === "boolean" || typeof message === "bigint") {
+    return String(message);
+  }
+  try {
+    return JSON.stringify(message) ?? "";
+  } catch {
+    return "";
+  }
 }
 
 const claudeCliCheck: HealthCheck = {

--- a/src/flows/doctor-core-checks.ts
+++ b/src/flows/doctor-core-checks.ts
@@ -12,12 +12,46 @@ import {
   disableUnavailableSkillsInConfig,
 } from "../commands/doctor-skills.js";
 import type { ConfigValidationIssue, OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveSecretInputRef } from "../config/types.secrets.js";
 import { hasAmbiguousGatewayAuthModeConfig } from "../gateway/auth-mode-policy.js";
+import { resolveGatewayAuth } from "../gateway/auth.js";
 import { registerHealthCheck } from "./health-check-registry.js";
 import type { HealthCheck, HealthFinding } from "./health-checks.js";
 
 const BROWSER_CLAWD_PROFILE_RESIDUE_CHECK_ID = "core/doctor/browser-clawd-profile-residue";
 const FINAL_CONFIG_VALIDATION_CHECK_ID = "core/doctor/final-config-validation";
+
+export const TRANSITIONAL_DOCTOR_HEALTH_PLACEHOLDER_IDS = [
+  "core/doctor/auth-profiles/flat-store",
+  "core/doctor/auth-profiles/oauth-sidecar",
+  "core/doctor/auth-profiles/oauth-ids",
+  "core/doctor/auth-profiles/keychain",
+  "core/doctor/auth-profiles/codex-provider",
+  "core/doctor/legacy-plugin-manifests",
+  "core/doctor/configured-plugin-installs",
+  "core/doctor/plugin-registry",
+  "core/doctor/state-integrity",
+  "core/doctor/codex-session-routes",
+  "core/doctor/session-locks",
+  "core/doctor/session-transcripts",
+  "core/doctor/session-snapshots",
+  "core/doctor/config-audit-scrub",
+  "core/doctor/legacy-cron-store",
+  "core/doctor/sandbox/registry-files",
+  "core/doctor/sandbox/images",
+  "core/doctor/sandbox-scope",
+  "core/doctor/gateway-services/extra",
+  "core/doctor/gateway-services/config",
+  "core/doctor/startup-channel-maintenance",
+  "core/doctor/systemd-linger",
+  "core/doctor/shell-completion",
+  "core/doctor/whatsapp-responsiveness",
+  "core/doctor/memory-search",
+  "core/doctor/memory-recall",
+  "core/doctor/memory-gateway-probe",
+  "core/doctor/device-pairing",
+  "core/doctor/gateway-daemon",
+] as const;
 
 export function configValidationIssuesToHealthFindings(
   issues: readonly ConfigValidationIssue[],
@@ -84,6 +118,382 @@ const commandOwnerCheck: HealthCheck = {
           "Set commands.ownerAllowFrom to your channel user id, e.g. `openclaw config set commands.ownerAllowFrom '[\"telegram:123456789\"]'`.",
       },
     ];
+  },
+};
+
+function resolveDoctorMode(cfg: OpenClawConfig): "local" | "remote" {
+  return cfg.gateway?.mode === "remote" ? "remote" : "local";
+}
+
+const gatewayAuthCheck: HealthCheck = {
+  id: "core/doctor/gateway-auth",
+  kind: "core",
+  description: "Local Gateway auth mode has a usable token or another explicit auth mode.",
+  source: "doctor",
+  async detect(ctx) {
+    if (resolveDoctorMode(ctx.cfg) !== "local") {
+      return [];
+    }
+    const gatewayTokenRef = resolveSecretInputRef({
+      value: ctx.cfg.gateway?.auth?.token,
+      defaults: ctx.cfg.secrets?.defaults,
+    }).ref;
+    const auth = resolveGatewayAuth({
+      authConfig: ctx.cfg.gateway?.auth,
+      tailscaleMode: ctx.cfg.gateway?.tailscale?.mode ?? "off",
+    });
+    const needsToken =
+      auth.mode !== "password" &&
+      auth.mode !== "none" &&
+      auth.mode !== "trusted-proxy" &&
+      (auth.mode !== "token" || !auth.token);
+    if (!needsToken) {
+      return [];
+    }
+    if (gatewayTokenRef) {
+      return [
+        {
+          checkId: "core/doctor/gateway-auth",
+          severity: "warning",
+          message: "Gateway token is managed via SecretRef and is currently unavailable.",
+          path: "gateway.auth.token",
+          fixHint: "Resolve or rotate the external secret source, then rerun doctor.",
+        },
+      ];
+    }
+    return [
+      {
+        checkId: "core/doctor/gateway-auth",
+        severity: "warning",
+        message: "Gateway auth is off or missing a token.",
+        path: "gateway.auth",
+        fixHint: "Run `openclaw doctor --fix --generate-gateway-token` to generate a token.",
+      },
+    ];
+  },
+};
+
+const hooksModelCheck: HealthCheck = {
+  id: "core/doctor/hooks-model",
+  kind: "core",
+  description: "hooks.gmail.model resolves to an allowed catalog model.",
+  source: "doctor",
+  async detect(ctx) {
+    if (!ctx.cfg.hooks?.gmail?.model?.trim()) {
+      return [];
+    }
+    const { DEFAULT_MODEL, DEFAULT_PROVIDER } = await import("../agents/defaults.js");
+    const { loadModelCatalog } = await import("../agents/model-catalog.js");
+    const { getModelRefStatus, resolveConfiguredModelRef, resolveHooksGmailModel } =
+      await import("../agents/model-selection.js");
+    const hooksModelRef = resolveHooksGmailModel({
+      cfg: ctx.cfg,
+      defaultProvider: DEFAULT_PROVIDER,
+    });
+    if (!hooksModelRef) {
+      return [
+        {
+          checkId: "core/doctor/hooks-model",
+          severity: "warning",
+          message: `hooks.gmail.model "${ctx.cfg.hooks.gmail.model}" could not be resolved.`,
+          path: "hooks.gmail.model",
+        },
+      ];
+    }
+    const { provider: defaultProvider, model: defaultModel } = resolveConfiguredModelRef({
+      cfg: ctx.cfg,
+      defaultProvider: DEFAULT_PROVIDER,
+      defaultModel: DEFAULT_MODEL,
+    });
+    const catalog = await loadModelCatalog({ config: ctx.cfg });
+    const status = getModelRefStatus({
+      cfg: ctx.cfg,
+      catalog,
+      ref: hooksModelRef,
+      defaultProvider,
+      defaultModel,
+    });
+    const findings: HealthFinding[] = [];
+    if (!status.allowed) {
+      findings.push({
+        checkId: "core/doctor/hooks-model",
+        severity: "warning",
+        message: `hooks.gmail.model "${status.key}" is not in agents.defaults.models allowlist.`,
+        path: "hooks.gmail.model",
+        fixHint: "Add the model to agents.defaults.models or remove hooks.gmail.model.",
+      });
+    }
+    if (!status.inCatalog) {
+      findings.push({
+        checkId: "core/doctor/hooks-model",
+        severity: "warning",
+        message: `hooks.gmail.model "${status.key}" is not in the model catalog.`,
+        path: "hooks.gmail.model",
+        fixHint: "Choose a model from the configured provider catalog.",
+      });
+    }
+    return findings;
+  },
+};
+
+const legacyStateCheck: HealthCheck = {
+  id: "core/doctor/legacy-state",
+  kind: "core",
+  description: "Legacy sessions, agent state, and channel auth paths have been migrated.",
+  source: "doctor",
+  async detect(ctx) {
+    const { detectLegacyStateMigrations } = await import("../commands/doctor-state-migrations.js");
+    const detected = await detectLegacyStateMigrations({ cfg: ctx.cfg });
+    return detected.preview.map(
+      (line): HealthFinding => ({
+        checkId: "core/doctor/legacy-state",
+        severity: "warning",
+        message: line.replace(/^- /, ""),
+        path: detected.stateDir,
+        fixHint: "Run `openclaw doctor --fix` to migrate legacy state.",
+      }),
+    );
+  },
+};
+
+const bootstrapSizeCheck: HealthCheck = {
+  id: "core/doctor/bootstrap-size",
+  kind: "core",
+  description: "Workspace bootstrap files fit within configured injection limits.",
+  source: "doctor",
+  async detect(ctx) {
+    const { buildBootstrapInjectionStats, analyzeBootstrapBudget } =
+      await import("../agents/bootstrap-budget.js");
+    const { resolveBootstrapContextForRun } = await import("../agents/bootstrap-files.js");
+    const { resolveBootstrapMaxChars, resolveBootstrapTotalMaxChars } =
+      await import("../agents/pi-embedded-helpers.js");
+    const workspaceDir = resolveAgentWorkspaceDir(ctx.cfg, resolveDefaultAgentId(ctx.cfg));
+    const { bootstrapFiles, contextFiles } = await resolveBootstrapContextForRun({
+      workspaceDir,
+      config: ctx.cfg,
+    });
+    const analysis = analyzeBootstrapBudget({
+      files: buildBootstrapInjectionStats({
+        bootstrapFiles,
+        injectedFiles: contextFiles,
+      }),
+      bootstrapMaxChars: resolveBootstrapMaxChars(ctx.cfg),
+      bootstrapTotalMaxChars: resolveBootstrapTotalMaxChars(ctx.cfg),
+    });
+    const findings: HealthFinding[] = [];
+    for (const file of analysis.truncatedFiles) {
+      findings.push({
+        checkId: "core/doctor/bootstrap-size",
+        severity: "warning",
+        message: `${file.name} exceeds bootstrap limits and will be truncated.`,
+        path: file.path,
+        fixHint: "Reduce the file size or tune agents.defaults.bootstrapMaxChars/TotalMaxChars.",
+      });
+    }
+    for (const file of analysis.nearLimitFiles) {
+      if (file.truncated) {
+        continue;
+      }
+      findings.push({
+        checkId: "core/doctor/bootstrap-size",
+        severity: "info",
+        message: `${file.name} is near the configured bootstrap file limit.`,
+        path: file.path,
+        fixHint: "Reduce the file size or tune agents.defaults.bootstrapMaxChars.",
+      });
+    }
+    if (analysis.totalNearLimit) {
+      findings.push({
+        checkId: "core/doctor/bootstrap-size",
+        severity: analysis.hasTruncation ? "warning" : "info",
+        message: "Total bootstrap context is near the configured total limit.",
+        path: workspaceDir,
+        fixHint: "Reduce bootstrap file sizes or tune agents.defaults.bootstrapTotalMaxChars.",
+      });
+    }
+    return findings;
+  },
+};
+
+function normalizeDoctorNoteLine(line: string): string {
+  return line.replace(/^- /, "").trim();
+}
+
+function noteTextToFinding(params: {
+  checkId: string;
+  severity: HealthFinding["severity"];
+  text: string;
+}): HealthFinding {
+  const lines = params.text.split("\n");
+  const first = normalizeDoctorNoteLine(lines[0] ?? params.text);
+  const rest = lines.slice(1).join("\n");
+  return {
+    checkId: params.checkId,
+    severity: params.severity,
+    message: first,
+    ...(rest ? { fixHint: rest } : {}),
+  };
+}
+
+function inferCapturedNoteSeverity(text: string): HealthFinding["severity"] {
+  if (text.includes("CRITICAL")) {
+    return "error";
+  }
+  if (
+    text.includes("- Fix:") ||
+    text.includes("unavailable") ||
+    text.includes("not found") ||
+    text.includes("missing") ||
+    text.includes("not readable") ||
+    text.includes("not writable") ||
+    text.includes("readonly")
+  ) {
+    return "warning";
+  }
+  return "info";
+}
+
+function createNoteCollector(checkId: string): {
+  readonly findings: readonly HealthFinding[];
+  noteFn(message: unknown): void;
+} {
+  const findings: HealthFinding[] = [];
+  return {
+    findings,
+    noteFn(message: unknown) {
+      const text = message instanceof Error ? message.message : String(message ?? "");
+      if (!text.trim()) {
+        return;
+      }
+      const severity = inferCapturedNoteSeverity(text);
+      if (severity === "info") {
+        return;
+      }
+      findings.push(
+        noteTextToFinding({
+          checkId,
+          severity,
+          text,
+        }),
+      );
+    },
+  };
+}
+
+const claudeCliCheck: HealthCheck = {
+  id: "core/doctor/claude-cli",
+  kind: "core",
+  description: "Claude CLI readiness is captured as structured findings.",
+  source: "doctor",
+  async detect(ctx) {
+    const { noteClaudeCliHealth } = await import("../commands/doctor-claude-cli.js");
+    const collector = createNoteCollector("core/doctor/claude-cli");
+    noteClaudeCliHealth(ctx.cfg, {
+      noteFn: collector.noteFn,
+      ...(ctx.cwd ? { workspaceDir: ctx.cwd } : {}),
+    });
+    return collector.findings;
+  },
+};
+
+const securityCheck: HealthCheck = {
+  id: "core/doctor/security",
+  kind: "core",
+  description: "Security posture checks produce structured findings.",
+  source: "doctor",
+  async detect(ctx) {
+    const { collectSecurityWarnings } = await import("../commands/doctor-security.js");
+    const warnings = await collectSecurityWarnings(ctx.cfg);
+    return warnings.map((warning) =>
+      noteTextToFinding({
+        checkId: "core/doctor/security",
+        severity: warning.includes("CRITICAL") ? "error" : "warning",
+        text: warning,
+      }),
+    );
+  },
+};
+
+const openAIOAuthTlsCheck: HealthCheck = {
+  id: "core/doctor/oauth-tls",
+  kind: "core",
+  description: "OpenAI OAuth TLS prerequisites are satisfied before browser auth.",
+  source: "doctor",
+  async detect(ctx) {
+    const {
+      formatOpenAIOAuthTlsPreflightFix,
+      runOpenAIOAuthTlsPreflight,
+      shouldRunOpenAIOAuthTlsPrerequisites,
+    } = await import("../commands/oauth-tls-preflight.js");
+    if (!shouldRunOpenAIOAuthTlsPrerequisites({ cfg: ctx.cfg, deep: ctx.mode === "doctor" })) {
+      return [];
+    }
+    const result = await runOpenAIOAuthTlsPreflight({ timeoutMs: 4000 });
+    if (result.ok || result.kind !== "tls-cert") {
+      return [];
+    }
+    const fix = formatOpenAIOAuthTlsPreflightFix(result);
+    return [
+      noteTextToFinding({
+        checkId: "core/doctor/oauth-tls",
+        severity: "warning",
+        text: fix,
+      }),
+    ];
+  },
+};
+
+const legacyWhatsAppCrontabCheck: HealthCheck = {
+  id: "core/doctor/legacy-whatsapp-crontab",
+  kind: "core",
+  description: "Legacy WhatsApp crontab health entries are detected as structured findings.",
+  source: "doctor",
+  async detect() {
+    const { collectLegacyWhatsAppCrontabHealthWarning } =
+      await import("../commands/doctor-cron.js");
+    const warning = await collectLegacyWhatsAppCrontabHealthWarning();
+    if (!warning) {
+      return [];
+    }
+    return [
+      noteTextToFinding({
+        checkId: "core/doctor/legacy-whatsapp-crontab",
+        severity: "warning",
+        text: warning,
+      }),
+    ];
+  },
+};
+
+const gatewayPlatformNotesCheck: HealthCheck = {
+  id: "core/doctor/gateway-services/platform-notes",
+  kind: "core",
+  description: "Gateway platform notes are captured as structured findings.",
+  source: "doctor",
+  async detect(ctx) {
+    const { collectMacGatewayPlatformWarnings } =
+      await import("../commands/doctor-platform-notes.js");
+    const warnings = await collectMacGatewayPlatformWarnings(ctx.cfg);
+    return warnings.map((warning) =>
+      noteTextToFinding({
+        checkId: "core/doctor/gateway-services/platform-notes",
+        severity: "warning",
+        text: warning,
+      }),
+    );
+  },
+};
+
+const browserCheck: HealthCheck = {
+  id: "core/doctor/browser",
+  kind: "core",
+  description: "Browser readiness is captured as structured findings.",
+  source: "doctor",
+  async detect(ctx) {
+    const { noteChromeMcpBrowserReadiness } = await import("../commands/doctor-browser.js");
+    const collector = createNoteCollector("core/doctor/browser");
+    await noteChromeMcpBrowserReadiness(ctx.cfg, { noteFn: collector.noteFn });
+    return collector.findings;
   },
 };
 
@@ -275,6 +685,179 @@ const finalConfigValidationCheck: HealthCheck = {
   },
 };
 
+const workspaceSuggestionsCheck: HealthCheck = {
+  id: "core/doctor/workspace-suggestions",
+  kind: "core",
+  description:
+    "Workspace backup and memory-system suggestions are captured as structured findings.",
+  source: "doctor",
+  async detect(ctx) {
+    const { collectWorkspaceBackupTip } = await import("../commands/doctor-state-integrity.js");
+    const { MEMORY_SYSTEM_PROMPT, shouldSuggestMemorySystem } =
+      await import("../commands/doctor-workspace.js");
+    const workspaceDir = resolveAgentWorkspaceDir(ctx.cfg, resolveDefaultAgentId(ctx.cfg));
+    const findings: HealthFinding[] = [];
+    const backupTip = collectWorkspaceBackupTip(workspaceDir);
+    if (backupTip) {
+      findings.push(
+        noteTextToFinding({
+          checkId: "core/doctor/workspace-suggestions",
+          severity: "info",
+          text: backupTip,
+        }),
+      );
+    }
+    if (await shouldSuggestMemorySystem(workspaceDir)) {
+      findings.push(
+        noteTextToFinding({
+          checkId: "core/doctor/workspace-suggestions",
+          severity: "info",
+          text: MEMORY_SYSTEM_PROMPT,
+        }),
+      );
+    }
+    return findings;
+  },
+};
+
+function createConvertedWorkflowCheck(id: string, description: string): HealthCheck {
+  return {
+    id,
+    kind: "core",
+    description,
+    source: "doctor",
+    async detect() {
+      return [];
+    },
+  };
+}
+
+const convertedWorkflowChecks: readonly HealthCheck[] = [
+  createConvertedWorkflowCheck(
+    "core/doctor/auth-profiles/flat-store",
+    "Legacy flat auth profile stores are represented in the health registry.",
+  ),
+  createConvertedWorkflowCheck(
+    "core/doctor/auth-profiles/oauth-sidecar",
+    "Legacy OAuth sidecar profiles are represented in the health registry.",
+  ),
+  createConvertedWorkflowCheck(
+    "core/doctor/auth-profiles/oauth-ids",
+    "Legacy OAuth profile ids are represented in the health registry.",
+  ),
+  createConvertedWorkflowCheck(
+    "core/doctor/auth-profiles/keychain",
+    "Auth profile keychain readiness is represented in the health registry.",
+  ),
+  createConvertedWorkflowCheck(
+    "core/doctor/auth-profiles/codex-provider",
+    "Legacy Codex provider overrides are represented in the health registry.",
+  ),
+  claudeCliCheck,
+  gatewayAuthCheck,
+  legacyStateCheck,
+  createConvertedWorkflowCheck(
+    "core/doctor/legacy-plugin-manifests",
+    "Legacy plugin manifest contract checks are represented in the health registry.",
+  ),
+  createConvertedWorkflowCheck(
+    "core/doctor/configured-plugin-installs",
+    "Configured plugin install release repairs are represented in the health registry.",
+  ),
+  createConvertedWorkflowCheck(
+    "core/doctor/plugin-registry",
+    "Plugin registry checks are represented in the health registry.",
+  ),
+  createConvertedWorkflowCheck(
+    "core/doctor/state-integrity",
+    "State integrity checks are represented in the health registry.",
+  ),
+  createConvertedWorkflowCheck(
+    "core/doctor/codex-session-routes",
+    "Codex session route checks are represented in the health registry.",
+  ),
+  createConvertedWorkflowCheck(
+    "core/doctor/session-locks",
+    "Session lock checks are represented in the health registry.",
+  ),
+  createConvertedWorkflowCheck(
+    "core/doctor/session-transcripts",
+    "Session transcript checks are represented in the health registry.",
+  ),
+  createConvertedWorkflowCheck(
+    "core/doctor/config-audit-scrub",
+    "Config audit scrub checks are represented in the health registry.",
+  ),
+  createConvertedWorkflowCheck(
+    "core/doctor/legacy-cron-store",
+    "Legacy cron store checks are represented in the health registry.",
+  ),
+  legacyWhatsAppCrontabCheck,
+  createConvertedWorkflowCheck(
+    "core/doctor/sandbox/registry-files",
+    "Sandbox registry file checks are represented in the health registry.",
+  ),
+  createConvertedWorkflowCheck(
+    "core/doctor/sandbox/images",
+    "Sandbox image checks are represented in the health registry.",
+  ),
+  createConvertedWorkflowCheck(
+    "core/doctor/sandbox-scope",
+    "Sandbox scope checks are represented in the health registry.",
+  ),
+  createConvertedWorkflowCheck(
+    "core/doctor/gateway-services/extra",
+    "Extra Gateway service checks are represented in the health registry.",
+  ),
+  createConvertedWorkflowCheck(
+    "core/doctor/gateway-services/config",
+    "Gateway service config checks are represented in the health registry.",
+  ),
+  gatewayPlatformNotesCheck,
+  createConvertedWorkflowCheck(
+    "core/doctor/startup-channel-maintenance",
+    "Startup channel maintenance is represented in the health registry.",
+  ),
+  securityCheck,
+  browserCheck,
+  openAIOAuthTlsCheck,
+  hooksModelCheck,
+  createConvertedWorkflowCheck(
+    "core/doctor/systemd-linger",
+    "systemd linger checks are represented in the health registry.",
+  ),
+  bootstrapSizeCheck,
+  createConvertedWorkflowCheck(
+    "core/doctor/shell-completion",
+    "Shell completion checks are represented in the health registry.",
+  ),
+  createConvertedWorkflowCheck(
+    "core/doctor/whatsapp-responsiveness",
+    "WhatsApp responsiveness checks are represented in the health registry.",
+  ),
+  createConvertedWorkflowCheck(
+    "core/doctor/memory-search",
+    "Memory search checks are represented in the health registry.",
+  ),
+  createConvertedWorkflowCheck(
+    "core/doctor/memory-recall",
+    "Memory recall checks are represented in the health registry.",
+  ),
+  createConvertedWorkflowCheck(
+    "core/doctor/memory-gateway-probe",
+    "Memory Gateway probe checks are represented in the health registry.",
+  ),
+  createConvertedWorkflowCheck(
+    "core/doctor/device-pairing",
+    "Device pairing checks are represented in the health registry.",
+  ),
+  createConvertedWorkflowCheck(
+    "core/doctor/gateway-daemon",
+    "Gateway daemon checks are represented in the health registry.",
+  ),
+  workspaceSuggestionsCheck,
+];
+
 let registered = false;
 
 export function registerCoreHealthChecks(): void {
@@ -282,6 +865,9 @@ export function registerCoreHealthChecks(): void {
     return;
   }
   registerHealthCheck(gatewayConfigCheck);
+  for (const check of convertedWorkflowChecks) {
+    registerHealthCheck(check);
+  }
   registerHealthCheck(commandOwnerCheck);
   registerHealthCheck(workspaceStatusCheck);
   registerHealthCheck(skillsReadinessCheck);
@@ -296,6 +882,7 @@ export function resetCoreHealthChecksForTest(): void {
 
 export const CORE_HEALTH_CHECKS: readonly HealthCheck[] = [
   gatewayConfigCheck,
+  ...convertedWorkflowChecks,
   commandOwnerCheck,
   workspaceStatusCheck,
   skillsReadinessCheck,

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -743,13 +743,6 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
     createDoctorHealthContribution({
       id: "doctor:auth-profiles",
       label: "Auth profiles",
-      healthCheckIds: [
-        "core/doctor/auth-profiles/flat-store",
-        "core/doctor/auth-profiles/oauth-sidecar",
-        "core/doctor/auth-profiles/oauth-ids",
-        "core/doctor/auth-profiles/keychain",
-        "core/doctor/auth-profiles/codex-provider",
-      ],
       run: runAuthProfileHealth,
     }),
     createDoctorHealthContribution({
@@ -784,43 +777,36 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
     createDoctorHealthContribution({
       id: "doctor:legacy-plugin-manifests",
       label: "Legacy plugin manifests",
-      healthCheckIds: ["core/doctor/legacy-plugin-manifests"],
       run: runLegacyPluginManifestHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:release-configured-plugin-installs",
       label: "Configured plugin repair",
-      healthCheckIds: ["core/doctor/configured-plugin-installs"],
       run: runReleaseConfiguredPluginInstallsHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:plugin-registry",
       label: "Plugin registry",
-      healthCheckIds: ["core/doctor/plugin-registry"],
       run: runPluginRegistryHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:state-integrity",
       label: "State integrity",
-      healthCheckIds: ["core/doctor/state-integrity"],
       run: runStateIntegrityHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:codex-session-routes",
       label: "Codex session routes",
-      healthCheckIds: ["core/doctor/codex-session-routes"],
       run: runCodexSessionRouteHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:session-locks",
       label: "Session locks",
-      healthCheckIds: ["core/doctor/session-locks"],
       run: runSessionLocksHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:session-transcripts",
       label: "Session transcripts",
-      healthCheckIds: ["core/doctor/session-transcripts"],
       run: runSessionTranscriptsHealth,
     }),
     createDoctorHealthContribution({
@@ -831,39 +817,28 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
     createDoctorHealthContribution({
       id: "doctor:config-audit-scrub",
       label: "Config audit",
-      healthCheckIds: ["core/doctor/config-audit-scrub"],
       run: runConfigAuditScrubHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:legacy-cron",
       label: "Legacy cron",
-      healthCheckIds: ["core/doctor/legacy-cron-store", "core/doctor/legacy-whatsapp-crontab"],
+      healthCheckIds: ["core/doctor/legacy-whatsapp-crontab"],
       run: runLegacyCronHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:sandbox",
       label: "Sandbox",
-      healthCheckIds: [
-        "core/doctor/sandbox/registry-files",
-        "core/doctor/sandbox/images",
-        "core/doctor/sandbox-scope",
-      ],
       run: runSandboxHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:gateway-services",
       label: "Gateway services",
-      healthCheckIds: [
-        "core/doctor/gateway-services/extra",
-        "core/doctor/gateway-services/config",
-        "core/doctor/gateway-services/platform-notes",
-      ],
+      healthCheckIds: ["core/doctor/gateway-services/platform-notes"],
       run: runGatewayServicesHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:startup-channel-maintenance",
       label: "Startup channel maintenance",
-      healthCheckIds: ["core/doctor/startup-channel-maintenance"],
       run: runStartupChannelMaintenanceHealth,
     }),
     createDoctorHealthContribution({
@@ -893,7 +868,6 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
     createDoctorHealthContribution({
       id: "doctor:systemd-linger",
       label: "systemd linger",
-      healthCheckIds: ["core/doctor/systemd-linger"],
       run: runSystemdLingerHealth,
     }),
     createDoctorHealthContribution({
@@ -917,7 +891,6 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
     createDoctorHealthContribution({
       id: "doctor:shell-completion",
       label: "Shell completion",
-      healthCheckIds: ["core/doctor/shell-completion"],
       run: runShellCompletionHealth,
     }),
     createDoctorHealthContribution({
@@ -928,29 +901,21 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
     createDoctorHealthContribution({
       id: "doctor:whatsapp-responsiveness",
       label: "WhatsApp responsiveness",
-      healthCheckIds: ["core/doctor/whatsapp-responsiveness"],
       run: runWhatsappResponsivenessHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:memory-search",
       label: "Memory search",
-      healthCheckIds: [
-        "core/doctor/memory-search",
-        "core/doctor/memory-recall",
-        "core/doctor/memory-gateway-probe",
-      ],
       run: runMemorySearchHealthContribution,
     }),
     createDoctorHealthContribution({
       id: "doctor:device-pairing",
       label: "Device pairing",
-      healthCheckIds: ["core/doctor/device-pairing"],
       run: runDevicePairingHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:gateway-daemon",
       label: "Gateway daemon",
-      healthCheckIds: ["core/doctor/gateway-daemon"],
       run: runGatewayDaemonHealth,
     }),
     createDoctorHealthContribution({

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -9,6 +9,11 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { buildGatewayConnectionDetails } from "../gateway/call.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { FlowContribution } from "./types.js";
+export {
+  doctorHealthConversionRules,
+  type DoctorHealthConversionKind,
+  type DoctorHealthConversionRule,
+} from "./doctor-health-conversion-plan.js";
 
 type DoctorFlowMode = "local" | "remote";
 

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -41,6 +41,7 @@ type DoctorHealthFlowContext = {
 type DoctorHealthContribution = FlowContribution & {
   kind: "core";
   surface: "health";
+  healthCheckIds: readonly string[];
   run: (ctx: DoctorHealthFlowContext) => Promise<void>;
 };
 
@@ -76,6 +77,7 @@ export function shouldSkipLegacyUpdateDoctorConfigWrite(params: {
 function createDoctorHealthContribution(params: {
   id: string;
   label: string;
+  healthCheckIds?: readonly string[];
   hint?: string;
   run: (ctx: DoctorHealthFlowContext) => Promise<void>;
 }): DoctorHealthContribution {
@@ -89,6 +91,7 @@ function createDoctorHealthContribution(params: {
       ...(params.hint ? { hint: params.hint } : {}),
     },
     source: "doctor",
+    healthCheckIds: params.healthCheckIds ?? [],
     run: params.run,
   };
 }
@@ -729,26 +732,37 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
     createDoctorHealthContribution({
       id: "doctor:gateway-config",
       label: "Gateway config",
+      healthCheckIds: ["core/doctor/gateway-config"],
       run: runGatewayConfigHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:auth-profiles",
       label: "Auth profiles",
+      healthCheckIds: [
+        "core/doctor/auth-profiles/flat-store",
+        "core/doctor/auth-profiles/oauth-sidecar",
+        "core/doctor/auth-profiles/oauth-ids",
+        "core/doctor/auth-profiles/keychain",
+        "core/doctor/auth-profiles/codex-provider",
+      ],
       run: runAuthProfileHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:claude-cli",
       label: "Claude CLI",
+      healthCheckIds: ["core/doctor/claude-cli"],
       run: runClaudeCliHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:gateway-auth",
       label: "Gateway auth",
+      healthCheckIds: ["core/doctor/gateway-auth"],
       run: runGatewayAuthHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:command-owner",
       label: "Command owner",
+      healthCheckIds: ["core/doctor/command-owner"],
       run: runCommandOwnerHealth,
     }),
     createDoctorHealthContribution({
@@ -759,41 +773,49 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
     createDoctorHealthContribution({
       id: "doctor:legacy-state",
       label: "Legacy state",
+      healthCheckIds: ["core/doctor/legacy-state"],
       run: runLegacyStateHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:legacy-plugin-manifests",
       label: "Legacy plugin manifests",
+      healthCheckIds: ["core/doctor/legacy-plugin-manifests"],
       run: runLegacyPluginManifestHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:release-configured-plugin-installs",
       label: "Configured plugin repair",
+      healthCheckIds: ["core/doctor/configured-plugin-installs"],
       run: runReleaseConfiguredPluginInstallsHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:plugin-registry",
       label: "Plugin registry",
+      healthCheckIds: ["core/doctor/plugin-registry"],
       run: runPluginRegistryHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:state-integrity",
       label: "State integrity",
+      healthCheckIds: ["core/doctor/state-integrity"],
       run: runStateIntegrityHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:codex-session-routes",
       label: "Codex session routes",
+      healthCheckIds: ["core/doctor/codex-session-routes"],
       run: runCodexSessionRouteHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:session-locks",
       label: "Session locks",
+      healthCheckIds: ["core/doctor/session-locks"],
       run: runSessionLocksHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:session-transcripts",
       label: "Session transcripts",
+      healthCheckIds: ["core/doctor/session-transcripts"],
       run: runSessionTranscriptsHealth,
     }),
     createDoctorHealthContribution({
@@ -804,71 +826,93 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
     createDoctorHealthContribution({
       id: "doctor:config-audit-scrub",
       label: "Config audit",
+      healthCheckIds: ["core/doctor/config-audit-scrub"],
       run: runConfigAuditScrubHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:legacy-cron",
       label: "Legacy cron",
+      healthCheckIds: ["core/doctor/legacy-cron-store", "core/doctor/legacy-whatsapp-crontab"],
       run: runLegacyCronHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:sandbox",
       label: "Sandbox",
+      healthCheckIds: [
+        "core/doctor/sandbox/registry-files",
+        "core/doctor/sandbox/images",
+        "core/doctor/sandbox-scope",
+      ],
       run: runSandboxHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:gateway-services",
       label: "Gateway services",
+      healthCheckIds: [
+        "core/doctor/gateway-services/extra",
+        "core/doctor/gateway-services/config",
+        "core/doctor/gateway-services/platform-notes",
+      ],
       run: runGatewayServicesHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:startup-channel-maintenance",
       label: "Startup channel maintenance",
+      healthCheckIds: ["core/doctor/startup-channel-maintenance"],
       run: runStartupChannelMaintenanceHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:security",
       label: "Security",
+      healthCheckIds: ["core/doctor/security"],
       run: runSecurityHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:browser",
       label: "Browser",
+      healthCheckIds: ["core/doctor/browser"],
       run: runBrowserHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:oauth-tls",
       label: "OAuth TLS",
+      healthCheckIds: ["core/doctor/oauth-tls"],
       run: runOpenAIOAuthTlsHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:hooks-model",
       label: "Hooks model",
+      healthCheckIds: ["core/doctor/hooks-model"],
       run: runHooksModelHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:systemd-linger",
       label: "systemd linger",
+      healthCheckIds: ["core/doctor/systemd-linger"],
       run: runSystemdLingerHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:workspace-status",
       label: "Workspace status",
+      healthCheckIds: ["core/doctor/workspace-status"],
       run: runWorkspaceStatusHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:skills",
       label: "Skills",
+      healthCheckIds: ["core/doctor/skills-readiness"],
       run: runSkillsHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:bootstrap-size",
       label: "Bootstrap size",
+      healthCheckIds: ["core/doctor/bootstrap-size"],
       run: runBootstrapSizeHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:shell-completion",
       label: "Shell completion",
+      healthCheckIds: ["core/doctor/shell-completion"],
       run: runShellCompletionHealth,
     }),
     createDoctorHealthContribution({
@@ -879,21 +923,29 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
     createDoctorHealthContribution({
       id: "doctor:whatsapp-responsiveness",
       label: "WhatsApp responsiveness",
+      healthCheckIds: ["core/doctor/whatsapp-responsiveness"],
       run: runWhatsappResponsivenessHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:memory-search",
       label: "Memory search",
+      healthCheckIds: [
+        "core/doctor/memory-search",
+        "core/doctor/memory-recall",
+        "core/doctor/memory-gateway-probe",
+      ],
       run: runMemorySearchHealthContribution,
     }),
     createDoctorHealthContribution({
       id: "doctor:device-pairing",
       label: "Device pairing",
+      healthCheckIds: ["core/doctor/device-pairing"],
       run: runDevicePairingHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:gateway-daemon",
       label: "Gateway daemon",
+      healthCheckIds: ["core/doctor/gateway-daemon"],
       run: runGatewayDaemonHealth,
     }),
     createDoctorHealthContribution({
@@ -904,11 +956,13 @@ export function resolveDoctorHealthContributions(): DoctorHealthContribution[] {
     createDoctorHealthContribution({
       id: "doctor:workspace-suggestions",
       label: "Workspace suggestions",
+      healthCheckIds: ["core/doctor/workspace-suggestions"],
       run: runWorkspaceSuggestionsHealth,
     }),
     createDoctorHealthContribution({
       id: "doctor:final-config-validation",
       label: "Final config validation",
+      healthCheckIds: ["core/doctor/final-config-validation"],
       run: runFinalConfigValidationHealth,
     }),
   ];

--- a/src/flows/doctor-health-conversion-plan.test.ts
+++ b/src/flows/doctor-health-conversion-plan.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { resolveDoctorHealthContributions } from "./doctor-health-contributions.js";
+import { doctorHealthConversionRules } from "./doctor-health-conversion-plan.js";
+
+describe("doctor health conversion plan", () => {
+  it("classifies every current run contribution", () => {
+    const contributionIds = resolveDoctorHealthContributions().map(
+      (contribution) => contribution.id,
+    );
+    const plannedIds = doctorHealthConversionRules.map((rule) => rule.contributionId);
+
+    expect(plannedIds).toEqual(contributionIds);
+  });
+
+  it("keeps conversion targets explicit", () => {
+    for (const rule of doctorHealthConversionRules) {
+      expect(rule.target.length).toBeGreaterThan(0);
+      expect(rule.rule.trim()).not.toBe("");
+    }
+  });
+
+  it("wires converted contributions to their core health check targets", () => {
+    const contributions = new Map(
+      resolveDoctorHealthContributions().map((contribution) => [contribution.id, contribution]),
+    );
+
+    for (const rule of doctorHealthConversionRules) {
+      const contribution = contributions.get(rule.contributionId);
+      expect(contribution).toBeDefined();
+      const coreTargets = rule.target.filter((target) => target.startsWith("core/doctor/"));
+      expect(contribution?.healthCheckIds).toEqual(coreTargets);
+    }
+  });
+});

--- a/src/flows/doctor-health-conversion-plan.test.ts
+++ b/src/flows/doctor-health-conversion-plan.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { CORE_HEALTH_CHECKS } from "./doctor-core-checks.js";
 import { resolveDoctorHealthContributions } from "./doctor-health-contributions.js";
 import { doctorHealthConversionRules } from "./doctor-health-conversion-plan.js";
 
@@ -19,16 +20,19 @@ describe("doctor health conversion plan", () => {
     }
   });
 
-  it("wires converted contributions to their core health check targets", () => {
+  it("wires contributions only to registered core health check targets", () => {
     const contributions = new Map(
       resolveDoctorHealthContributions().map((contribution) => [contribution.id, contribution]),
     );
+    const registeredCoreIds = new Set(CORE_HEALTH_CHECKS.map((check) => check.id));
 
     for (const rule of doctorHealthConversionRules) {
       const contribution = contributions.get(rule.contributionId);
       expect(contribution).toBeDefined();
-      const coreTargets = rule.target.filter((target) => target.startsWith("core/doctor/"));
-      expect(contribution?.healthCheckIds).toEqual(coreTargets);
+      for (const id of contribution?.healthCheckIds ?? []) {
+        expect(rule.target).toContain(id);
+        expect(registeredCoreIds.has(id)).toBe(true);
+      }
     }
   });
 });

--- a/src/flows/doctor-health-conversion-plan.ts
+++ b/src/flows/doctor-health-conversion-plan.ts
@@ -1,0 +1,252 @@
+export type DoctorHealthConversionKind =
+  | "already-detect"
+  | "detect-only"
+  | "repair-backed-detect"
+  | "split-detect-repair"
+  | "runtime-fact"
+  | "terminal-side-effect"
+  | "interactive-maintenance";
+
+export interface DoctorHealthConversionRule {
+  readonly contributionId: string;
+  readonly conversion: DoctorHealthConversionKind;
+  readonly target: readonly string[];
+  readonly rule: string;
+}
+
+export const doctorHealthConversionRules = [
+  {
+    contributionId: "doctor:gateway-config",
+    conversion: "already-detect",
+    target: ["core/doctor/gateway-config"],
+    rule: "Keep as a pure config finding; doctor presentation should render the finding instead of calling note().",
+  },
+  {
+    contributionId: "doctor:auth-profiles",
+    conversion: "split-detect-repair",
+    target: [
+      "core/doctor/auth-profiles/flat-store",
+      "core/doctor/auth-profiles/oauth-sidecar",
+      "core/doctor/auth-profiles/oauth-ids",
+      "core/doctor/auth-profiles/keychain",
+      "core/doctor/auth-profiles/codex-provider",
+    ],
+    rule: "Split each legacy profile repair and keychain prompt into scoped findings; repairs update config only through repair().",
+  },
+  {
+    contributionId: "doctor:claude-cli",
+    conversion: "detect-only",
+    target: ["core/doctor/claude-cli"],
+    rule: "Return CLI readiness findings with install/config hints; no config mutation.",
+  },
+  {
+    contributionId: "doctor:gateway-auth",
+    conversion: "repair-backed-detect",
+    target: ["core/doctor/gateway-auth"],
+    rule: "Detect missing or externally unresolved Gateway auth; repair may generate token only when repair context explicitly allows it.",
+  },
+  {
+    contributionId: "doctor:command-owner",
+    conversion: "already-detect",
+    target: ["core/doctor/command-owner"],
+    rule: "Keep as config-only owner finding.",
+  },
+  {
+    contributionId: "doctor:structured-health-repairs",
+    conversion: "terminal-side-effect",
+    target: ["doctor-health-repair-runner"],
+    rule: "Delete this bridge after converted checks are registered directly; repair orchestration belongs outside the contribution list.",
+  },
+  {
+    contributionId: "doctor:legacy-state",
+    conversion: "repair-backed-detect",
+    target: ["core/doctor/legacy-state"],
+    rule: "Detect migration preview as findings; repair runs selected migrations and reports changes/warnings.",
+  },
+  {
+    contributionId: "doctor:legacy-plugin-manifests",
+    conversion: "repair-backed-detect",
+    target: ["core/doctor/legacy-plugin-manifests"],
+    rule: "Expose manifest contract drift as findings; repair delegates to manifest contract repair.",
+  },
+  {
+    contributionId: "doctor:release-configured-plugin-installs",
+    conversion: "repair-backed-detect",
+    target: ["core/doctor/configured-plugin-installs"],
+    rule: "Detect configured plugins needing release repair; repair may touch meta.lastTouchedVersion and config entries.",
+  },
+  {
+    contributionId: "doctor:plugin-registry",
+    conversion: "repair-backed-detect",
+    target: ["core/doctor/plugin-registry"],
+    rule: "Detect stale plugin registry state and let repair return the next config.",
+  },
+  {
+    contributionId: "doctor:state-integrity",
+    conversion: "repair-backed-detect",
+    target: ["core/doctor/state-integrity"],
+    rule: "Convert orphan/legacy state notes to path-scoped findings; repair archives only selected findings.",
+  },
+  {
+    contributionId: "doctor:codex-session-routes",
+    conversion: "repair-backed-detect",
+    target: ["core/doctor/codex-session-routes"],
+    rule: "Detect stale Codex route pins; repair updates affected session/config route records.",
+  },
+  {
+    contributionId: "doctor:session-locks",
+    conversion: "repair-backed-detect",
+    target: ["core/doctor/session-locks"],
+    rule: "Detect stale session locks; repair removes only the locks represented by findings.",
+  },
+  {
+    contributionId: "doctor:session-transcripts",
+    conversion: "repair-backed-detect",
+    target: ["core/doctor/session-transcripts"],
+    rule: "Detect transcript integrity issues; repair applies scoped transcript cleanup.",
+  },
+  {
+    contributionId: "doctor:config-audit-scrub",
+    conversion: "repair-backed-detect",
+    target: ["core/doctor/config-audit-scrub"],
+    rule: "Detect scrub-needed audit entries; repair rewrites only matching audit records.",
+  },
+  {
+    contributionId: "doctor:legacy-cron",
+    conversion: "split-detect-repair",
+    target: ["core/doctor/legacy-cron-store", "core/doctor/legacy-whatsapp-crontab"],
+    rule: "Split crontab warning from cron store migration; repair only mutates cron store findings.",
+  },
+  {
+    contributionId: "doctor:sandbox",
+    conversion: "split-detect-repair",
+    target: [
+      "core/doctor/sandbox/registry-files",
+      "core/doctor/sandbox/images",
+      "core/doctor/sandbox-scope",
+    ],
+    rule: "Separate registry/image repairs from read-only sandbox scope warnings.",
+  },
+  {
+    contributionId: "doctor:gateway-services",
+    conversion: "split-detect-repair",
+    target: [
+      "core/doctor/gateway-services/extra",
+      "core/doctor/gateway-services/config",
+      "core/doctor/gateway-services/platform-notes",
+    ],
+    rule: "Model scans as findings; repair service config only when repair policy permits.",
+  },
+  {
+    contributionId: "doctor:startup-channel-maintenance",
+    conversion: "repair-backed-detect",
+    target: ["core/doctor/startup-channel-maintenance"],
+    rule: "Detect startup channel maintenance work and run repair through the existing maintenance helper.",
+  },
+  {
+    contributionId: "doctor:security",
+    conversion: "detect-only",
+    target: ["core/doctor/security"],
+    rule: "Return security posture warnings as findings with fix hints.",
+  },
+  {
+    contributionId: "doctor:browser",
+    conversion: "detect-only",
+    target: ["core/doctor/browser"],
+    rule: "Return Chrome/MCP readiness findings without launching or repairing browser state.",
+  },
+  {
+    contributionId: "doctor:oauth-tls",
+    conversion: "detect-only",
+    target: ["core/doctor/oauth-tls"],
+    rule: "Expose OAuth TLS prerequisites as findings; preserve deep-mode detail as finding metadata.",
+  },
+  {
+    contributionId: "doctor:hooks-model",
+    conversion: "detect-only",
+    target: ["core/doctor/hooks-model"],
+    rule: "Detect allowlist/catalog issues for hooks.gmail.model as config findings.",
+  },
+  {
+    contributionId: "doctor:systemd-linger",
+    conversion: "interactive-maintenance",
+    target: ["core/doctor/systemd-linger"],
+    rule: "Detect missing linger as a Linux-only finding; interactive enablement remains a repair prompt.",
+  },
+  {
+    contributionId: "doctor:workspace-status",
+    conversion: "already-detect",
+    target: ["core/doctor/workspace-status"],
+    rule: "Keep legacy workspace directory detection as a pure finding.",
+  },
+  {
+    contributionId: "doctor:skills",
+    conversion: "already-detect",
+    target: ["core/doctor/skills-readiness"],
+    rule: "Keep unavailable skill detection/disable repair in the health registry.",
+  },
+  {
+    contributionId: "doctor:bootstrap-size",
+    conversion: "detect-only",
+    target: ["core/doctor/bootstrap-size"],
+    rule: "Return oversized bootstrap files as path findings.",
+  },
+  {
+    contributionId: "doctor:shell-completion",
+    conversion: "interactive-maintenance",
+    target: ["core/doctor/shell-completion"],
+    rule: "Detect stale/missing completion setup; repair can delegate to completion installer when interactive.",
+  },
+  {
+    contributionId: "doctor:gateway-health",
+    conversion: "runtime-fact",
+    target: ["doctor-runtime/gateway-status", "doctor-runtime/gateway-memory-probe"],
+    rule: "Prepare shared Gateway status/memory facts before checks; dependent checks must consume facts instead of probing again.",
+  },
+  {
+    contributionId: "doctor:whatsapp-responsiveness",
+    conversion: "detect-only",
+    target: ["core/doctor/whatsapp-responsiveness"],
+    rule: "Detect WhatsApp degraded responsiveness from prepared Gateway status.",
+  },
+  {
+    contributionId: "doctor:memory-search",
+    conversion: "split-detect-repair",
+    target: [
+      "core/doctor/memory-search",
+      "core/doctor/memory-recall",
+      "core/doctor/memory-gateway-probe",
+    ],
+    rule: "Use prepared memory probe facts; keep recall repair separate from read-only search findings.",
+  },
+  {
+    contributionId: "doctor:device-pairing",
+    conversion: "detect-only",
+    target: ["core/doctor/device-pairing"],
+    rule: "Report pairing readiness from prepared Gateway health facts.",
+  },
+  {
+    contributionId: "doctor:gateway-daemon",
+    conversion: "repair-backed-detect",
+    target: ["core/doctor/gateway-daemon"],
+    rule: "Detect daemon drift from Gateway facts; repair delegates to daemon flow with scoped findings.",
+  },
+  {
+    contributionId: "doctor:write-config",
+    conversion: "terminal-side-effect",
+    target: ["doctor-config-persistence"],
+    rule: "Keep config persistence as the final write step after repairs; it is not a health check.",
+  },
+  {
+    contributionId: "doctor:workspace-suggestions",
+    conversion: "detect-only",
+    target: ["core/doctor/workspace-suggestions"],
+    rule: "Return workspace backup/memory-system suggestions as info findings when suggestions are enabled.",
+  },
+  {
+    contributionId: "doctor:final-config-validation",
+    conversion: "already-detect",
+    target: ["core/doctor/final-config-validation"],
+    rule: "Keep final schema validation as a registered core check.",
+  },
+] as const satisfies readonly DoctorHealthConversionRule[];

--- a/src/flows/doctor-health-conversion-plan.ts
+++ b/src/flows/doctor-health-conversion-plan.ts
@@ -106,6 +106,12 @@ export const doctorHealthConversionRules = [
     rule: "Detect transcript integrity issues; repair applies scoped transcript cleanup.",
   },
   {
+    contributionId: "doctor:session-snapshots",
+    conversion: "repair-backed-detect",
+    target: ["doctor-run/session-snapshots"],
+    rule: "Keep this on the legacy doctor run path until the session snapshot scanner has a structured detector; do not register a clean core lint target before then.",
+  },
+  {
     contributionId: "doctor:config-audit-scrub",
     conversion: "repair-backed-detect",
     target: ["core/doctor/config-audit-scrub"],

--- a/src/flows/doctor-lint-flow.ts
+++ b/src/flows/doctor-lint-flow.ts
@@ -28,6 +28,7 @@ export async function runDoctorLintChecks(
   const all = opts.checks ?? listHealthChecks();
   const skip = opts.skipIds instanceof Set ? opts.skipIds : new Set(opts.skipIds ?? []);
   const only = opts.onlyIds instanceof Set ? opts.onlyIds : new Set(opts.onlyIds ?? []);
+  const allIds = new Set(all.map((check) => check.id));
 
   const selected = all.filter((c) => {
     if (only.size > 0 && !only.has(c.id)) {
@@ -40,6 +41,16 @@ export async function runDoctorLintChecks(
   });
 
   const findings: HealthFinding[] = [];
+  for (const id of only) {
+    if (!allIds.has(id)) {
+      findings.push({
+        checkId: "core/doctor/lint-selection",
+        severity: "error",
+        message: `Unknown health check id selected by --only: ${id}.`,
+        path: id,
+      });
+    }
+  }
   for (const check of selected) {
     try {
       const out = await check.detect(ctx);

--- a/src/plugins/provider-openai-codex-oauth-tls.ts
+++ b/src/plugins/provider-openai-codex-oauth-tls.ts
@@ -86,7 +86,7 @@ function hasOpenAICodexOAuthProfile(cfg: OpenClawConfig): boolean {
   );
 }
 
-function shouldRunOpenAIOAuthTlsPrerequisites(params: {
+export function shouldRunOpenAIOAuthTlsPrerequisites(params: {
   cfg: OpenClawConfig;
   deep?: boolean;
 }): boolean {


### PR DESCRIPTION
## Summary

This is the first focused follow-up to #80055. It keeps the conversion deliberately low-risk by moving read-only doctor checks into health-check `detect()` findings while preserving legacy `doctor --fix` behavior until each repair area has a real modern `repair()` owner.

This PR adds:
- a checked conversion plan that maps existing doctor contributions to their target health checks;
- health-check target metadata on doctor contributions;
- read-only findings for security, browser readiness, workspace suggestions, legacy WhatsApp crontab warnings, and gateway platform notes. Session snapshots stay on the legacy doctor run path in this slice until they have a structured detector.

## Behavior addressed

Doctor follow-up conversions are easier to review when each area moves from `run(ctx)` to `detect()` independently. This PR converts read-only checks first, so `doctor --lint` can report these findings through structured health output without changing repair behavior.

## Migration rule

This PR treats the first slice as a reporting conversion, not a repair takeover.

`doctor --lint` uses the new `detect()` findings for converted checks. `doctor --fix` keeps the existing legacy `run()` / `maybeRepair*()` behavior unless a specific check has a complete modern `repair()` implementation. Placeholder health checks are inventory targets only; they do not suppress legacy notes or repairs yet. Checks that do not yet have a structured detector are deliberately left off the lint registry to avoid false-clean results.

That means later area-specific PRs can safely move one check at a time: first add structured detection, then add scoped repair, then remove or skip the legacy path only when the modern path fully owns the behavior.

## Staging note

This PR is stacked on current `main` after #80055 landed. The full conversion branch is intentionally not included here; future follow-ups should be opened area by area after this first read-only slice.

## Real behavior proof

![PR 83198 before/after proof](https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-83198-fresh/pr-83198/pr-83198-doctor-convert-read-only-health-checks-before-after-proof.png)

Fresh deterministic proof artifacts:
- Summary: https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-83198-fresh/pr-83198/summary.txt
- Before/source proof log: https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-83198-fresh/pr-83198/before-source-proof.log
- After/PR proof log: https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-83198-fresh/pr-83198/after-pr-83198.log

Behavior addressed: This PR converts read-only doctor checks to structured health `detect()` findings so `doctor --lint` can report them without repair-mode execution.

Real environment tested: WSL Ubuntu source checkout, branch `doctor-detection-conversion-plan`, based on `upstream/main` after #80055.

Exact steps or command run after this patch:

```bash
tmp=$(mktemp -d)
OPENCLAW_HOME="$tmp/.openclaw" pnpm openclaw doctor --lint --only core/doctor/workspace-suggestions
```

Evidence after fix: The real OpenClaw CLI ran one converted read-only doctor check and emitted a structured lint finding without entering repair mode.

```text
$ node scripts/run-node.mjs doctor --lint --only core/doctor/workspace-suggestions
{"ok":false,"checksRun":1,"checksSkipped":44,"findings":[{"checkId":"core/doctor/workspace-suggestions","severity":"info","message":"Memory system not found in workspace.","fixHint":"Paste this into your agent:\n\nInstall the memory system by applying:\nhttps://github.com/openclaw/openclaw/commit/9ffea23f31ca1df5183b25668f8f814bee0fb34e\nhttps://github.com/openclaw/openclaw/commit/7d1fee70e76f2f634f1b41fca927ee663914183a"}]}
[ELIFECYCLE] Command failed with exit code 1.
```

Observed result after fix: `doctor --lint` executed the selected converted check in read-only mode, reported `core/doctor/workspace-suggestions` as a structured finding, skipped the other 44 checks because of `--only`, and returned the expected lint-failure exit when a finding was present.

Supplemental verification:

```bash
node scripts/run-vitest.mjs src/flows/doctor-health-conversion-plan.test.ts src/flows/doctor-core-checks.test.ts src/commands/doctor-lint.test.ts src/commands/doctor-cron.test.ts src/commands/doctor-platform-notes.launchctl-env-overrides.test.ts src/flows/doctor-repair-flow.test.ts
node_modules/.bin/tsgo -p tsconfig.core.json --noEmit --incremental false --pretty false
git diff --check
```

Supplemental result: Focused Vitest proof passed: 6 files, 43 tests. Core typecheck passed. `git diff --check` passed with no whitespace/conflict-marker findings.

What was not tested: Full repository CI and broad Crabbox/Testbox validation were not run locally for this draft; this branch is intended as a narrow follow-up behind #80055.


