### PR TITLE
fix(codex): preserve streamed command output

### DIFF
--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -1338,6 +1338,74 @@ describe("CodexAppServerEventProjector", () => {
     });
   });
 
+  it("uses streamed command output when final command snapshots omit aggregated output", async () => {
+    const onAgentEvent = vi.fn();
+    const trajectoryRecorder = {
+      filePath: "trajectory.jsonl",
+      recordEvent: vi.fn(),
+      flush: vi.fn(async () => undefined),
+    };
+    const projector = await createProjector(
+      {
+        ...(await createParams()),
+        onAgentEvent,
+      },
+      {
+        trajectoryRecorder,
+      },
+    );
+
+    await projector.handleNotification(
+      forCurrentTurn("item/commandExecution/outputDelta", {
+        itemId: "cmd-1",
+        delta: "status passed\n",
+      }),
+    );
+    await projector.handleNotification(
+      forCurrentTurn("item/commandExecution/outputDelta", {
+        itemId: "cmd-1",
+        delta: "json /tmp/scenario.json\n",
+      }),
+    );
+    await projector.handleNotification(
+      turnCompleted([
+        {
+          type: "commandExecution",
+          id: "cmd-1",
+          command: "python scripts/run_demo_scenario.py",
+          cwd: "/workspace",
+          processId: null,
+          source: "agent",
+          status: "completed",
+          commandActions: [],
+          aggregatedOutput: null,
+          exitCode: 0,
+          durationMs: 42,
+        },
+      ]),
+    );
+
+    const result = projector.buildResult(buildEmptyToolTelemetry());
+    const toolResultMessage = requireRecord(result.messagesSnapshot[2], "tool result message");
+    const toolResultContent = requireArray(toolResultMessage.content, "tool result content");
+    const toolResultContentItem = requireRecord(toolResultContent[0], "tool result content item");
+    expect(toolResultContentItem.content).toBe("status passed\njson /tmp/scenario.json");
+    expect(trajectoryRecorder.recordEvent).toHaveBeenCalledWith(
+      "tool.result",
+      expect.objectContaining({
+        itemId: "cmd-1",
+        output: "status passed\njson /tmp/scenario.json",
+      }),
+    );
+    const toolResult = findAgentEvent(onAgentEvent, {
+      stream: "tool",
+      phase: "result",
+      itemId: "cmd-1",
+      name: "bash",
+    }).data;
+    expect(toolResult.result).toEqual({ status: "completed", exitCode: 0, durationMs: 42 });
+  });
+
   it("does not duplicate native tool starts when the snapshot completes a started item", async () => {
     const onAgentEvent = vi.fn();
     const trajectoryRecorder = {

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -126,6 +126,7 @@ export class CodexAppServerEventProjector {
     string,
     { chars: number; messages: number; truncated: boolean }
   >();
+  private readonly toolResultOutputTextByItem = new Map<string, string>();
   private readonly toolMetas = new Map<string, { toolName: string; meta?: string }>();
   private readonly toolTranscriptMessages: AgentMessage[] = [];
   private readonly toolTranscriptCallIds = new Set<string>();
@@ -685,7 +686,11 @@ export class CodexAppServerEventProjector {
   private handleOutputDelta(params: JsonObject, toolName: string): void {
     const itemId = readString(params, "itemId");
     const delta = readString(params, "delta");
-    if (!itemId || !delta || !this.shouldEmitToolOutput()) {
+    if (!itemId || !delta) {
+      return;
+    }
+    appendToolOutputDeltaText(this.toolResultOutputTextByItem, itemId, delta);
+    if (!this.shouldEmitToolOutput()) {
       return;
     }
     const state = this.toolResultOutputDeltaState.get(itemId) ?? {
@@ -920,7 +925,7 @@ export class CodexAppServerEventProjector {
       return;
     }
     const toolResult = itemToolResult(params.item).result;
-    const output = itemOutputText(params.item);
+    const output = itemOutputText(params.item, this.toolResultOutputTextByItem);
     this.options.trajectoryRecorder?.recordEvent("tool.result", {
       threadId: this.threadId,
       turnId: this.turnId,
@@ -1061,7 +1066,7 @@ export class CodexAppServerEventProjector {
       return;
     }
     const toolName = itemName(item);
-    const output = itemOutputText(item);
+    const output = itemOutputText(item, this.toolResultOutputTextByItem);
     if (!toolName || !output) {
       return;
     }
@@ -1151,7 +1156,7 @@ export class CodexAppServerEventProjector {
     this.recordToolTranscriptResult({
       id: item.id,
       name,
-      text: itemTranscriptResultText(item),
+      text: itemTranscriptResultText(item, this.toolResultOutputTextByItem),
       isError: isNonSuccessItemStatus(itemStatus(item)),
     });
   }
@@ -1716,9 +1721,12 @@ function itemMeta(
   return undefined;
 }
 
-function itemOutputText(item: CodexThreadItem): string | undefined {
+function itemOutputText(
+  item: CodexThreadItem,
+  outputTextByItem?: ReadonlyMap<string, string>,
+): string | undefined {
   if (item.type === "commandExecution") {
-    return item.aggregatedOutput?.trim() || undefined;
+    return item.aggregatedOutput?.trim() || outputTextByItem?.get(item.id)?.trim() || undefined;
   }
   if (item.type === "dynamicToolCall") {
     return collectDynamicToolContentText(item.contentItems).trim() || undefined;
@@ -1732,13 +1740,30 @@ function itemOutputText(item: CodexThreadItem): string | undefined {
   return undefined;
 }
 
-function itemTranscriptResultText(item: CodexThreadItem): string | undefined {
-  const output = itemOutputText(item);
+function itemTranscriptResultText(
+  item: CodexThreadItem,
+  outputTextByItem?: ReadonlyMap<string, string>,
+): string | undefined {
+  const output = itemOutputText(item, outputTextByItem);
   if (output) {
     return output;
   }
   const result = itemToolResult(item).result;
   return result ? stringifyJsonValue(result) : itemStatus(item);
+}
+
+function appendToolOutputDeltaText(
+  outputTextByItem: Map<string, string>,
+  itemId: string,
+  delta: string,
+): void {
+  const current = outputTextByItem.get(itemId) ?? "";
+  if (current.length >= TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS) {
+    return;
+  }
+  const remaining = TOOL_TRANSCRIPT_OUTPUT_MAX_CHARS - current.length;
+  const next = current + (delta.length > remaining ? delta.slice(0, remaining) : delta);
+  outputTextByItem.set(itemId, next);
 }
 
 function normalizeToolTranscriptArguments(value: unknown): Record<string, unknown> {


### PR DESCRIPTION
## Summary

- buffer Codex `item/commandExecution/outputDelta` text per command item
- use the buffered text as a fallback when the final `commandExecution.aggregatedOutput` is empty
- cover the transcript, trajectory recorder, and app-server tool result path with a regression test

Fixes #83199.

## Test

```sh
OPENCLAW_VITEST_INCLUDE_FILE=/tmp/openclaw-vitest-include.json npm exec --prefix /tmp --yes --package=node@22.20.0 -- node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts
```

Result:

```
Test Files  1 passed (1)
Tests  48 passed (48)
```

Note: I used Node 22.20.0 for this local run because the system Node 22.22.0 in my environment fails before Vitest starts with `Missing internal module 'internal/deps/brace-expansion'` from `node:path.matchesGlob()`.

<!-- real-behavior-proof-83199 -->

## Real behavior proof

**Behavior or issue addressed:** Codex command execution stdout was missing from OpenClaw's final tool result/transcript when the command output arrived through the Codex app-server command-output stream and the final command snapshot did not provide usable aggregated output. This proof verifies the after-fix behavior: a real Codex-backed OpenClaw run executes native `bash`, and the command stdout is present in the final `toolResult` transcript entry and final assistant response.

**Real environment tested:** OpenClaw 2026.5.12 gateway on Linux, with this PR's command-output fallback behavior applied locally; Codex app-server runtime via `openai-codex/gpt-5.5`; session id `proof-codex-outputdelta-83199-real`; exported redacted trajectory bundle at `.openclaw/trajectory-exports/proof-83199-real`.

**Exact steps or command run after this patch:** Terminal capture from the live command:

```sh
openclaw agent \
  --session-id proof-codex-outputdelta-83199-real \
  --model openai-codex/gpt-5.5 \
  --message "Real behavior proof for OpenClaw PR #83200. Please use the bash/tool command exactly once to run: printf 'OPENCLAW_OUTPUT_DELTA_PROOF_83199=passed\\n'. Then reply with the exact output line and nothing sensitive." \
  --timeout 240 \
  --json
```

**Evidence after fix:** Redacted live output and runtime log excerpt from the real OpenClaw Codex run:

```json
{
  "runId": "1b0178d4-9aa9-43f9-8776-6cdb6667cb60",
  "status": "ok",
  "result": {
    "payloads": [
      {
        "text": "OPENCLAW_OUTPUT_DELTA_PROOF_83199=passed",
        "mediaUrl": null
      }
    ],
    "meta": {
      "agentMeta": {
        "sessionId": "proof-codex-outputdelta-83199-real",
        "provider": "openai-codex",
        "model": "gpt-5.5",
        "agentHarnessId": "codex"
      },
      "finalAssistantVisibleText": "OPENCLAW_OUTPUT_DELTA_PROOF_83199=passed",
      "toolSummary": {
        "calls": 1,
        "tools": ["bash"],
        "failures": 0
      }
    }
  }
}
```

Redacted exported trajectory excerpt from `.openclaw/trajectory-exports/proof-83199-real/events.jsonl`:

```json
{
  "source": "runtime",
  "type": "model.completed",
  "provider": "openai-codex",
  "modelId": "gpt-5.5",
  "modelApi": "openai-codex-responses",
  "data": {
    "timedOut": false,
    "aborted": false,
    "assistantTexts": ["OPENCLAW_OUTPUT_DELTA_PROOF_83199=passed"],
    "messagesSnapshot": [
      {
        "role": "assistant",
        "content": [
          {
            "type": "toolCall",
            "id": "exec-e41658ea-435f-4e17-b3b4-2ee1ee45d2d6",
            "name": "bash",
            "arguments": {
              "command": "/bin/bash -lc \"printf 'OPENCLAW_OUTPUT_DELTA_PROOF_83199=passed\\\\n'\"",
              "cwd": "$WORKSPACE_DIR/.openclaw/workspace"
            }
          }
        ],
        "stopReason": "toolUse"
      },
      {
        "role": "toolResult",
        "toolCallId": "exec-e41658ea-435f-4e17-b3b4-2ee1ee45d2d6",
        "toolName": "bash",
        "isError": false,
        "content": [
          {
            "type": "toolResult",
            "content": "OPENCLAW_OUTPUT_DELTA_PROOF_83199=passed",
            "text": "OPENCLAW_OUTPUT_DELTA_PROOF_83199=passed"
          }
        ]
      },
      {
        "role": "assistant",
        "content": [
          {
            "type": "text",
            "text": "OPENCLAW_OUTPUT_DELTA_PROOF_83199=passed"
          }
        ],
        "stopReason": "stop"
      }
    ]
  }
}
```

**Observed result after fix:** The real OpenClaw Codex app-server run completed successfully, executed exactly one native `bash` command, preserved stdout as `OPENCLAW_OUTPUT_DELTA_PROOF_83199=passed` in the final `toolResult` transcript entry, and returned the same line as the final assistant-visible text. No private paths or secrets are included in the redacted excerpt.

**What was not tested:** No known gaps for this focused projector fallback. I did not test unrelated providers, non-Codex runtimes, or destructive command flows.
