### PR TITLE
fix(gateway): separate finish_reason from content chunks in streaming

### DIFF
--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -792,6 +792,21 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
           .filter((v): v is string => typeof v === "string")
           .join("");
         expect(allContent).toBe("hello");
+
+        // Per OpenAI streaming spec: content chunks have finish_reason: null,
+        // final chunk has finish_reason: "stop" with empty delta
+        const allChoices = jsonChunks.flatMap(
+          (c) => (c.choices as Array<Record<string, unknown>> | undefined) ?? [],
+        );
+        const contentChoices = allChoices.filter(
+          (choice) => (choice.delta as Record<string, unknown> | undefined)?.content !== undefined,
+        );
+        for (const choice of contentChoices) {
+          expect(choice).toHaveProperty("finish_reason", null);
+        }
+        const stopChoice = allChoices.findLast((choice) => choice.finish_reason === "stop");
+        expect(stopChoice).toBeDefined();
+        expect((stopChoice?.delta as Record<string, unknown>)?.content).toBeUndefined();
       }
 
       {
@@ -857,12 +872,21 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
         const errorChunks = errorData
           .filter((d) => d !== "[DONE]")
           .map((d) => JSON.parse(d) as Record<string, unknown>);
-        const stopChoice = errorChunks
-          .flatMap((c) => (c.choices as Array<Record<string, unknown>> | undefined) ?? [])
-          .find((choice) => choice.finish_reason === "stop");
-        expect((stopChoice?.delta as Record<string, unknown> | undefined)?.content).toBe(
-          "Error: internal error",
+        const allChoices = errorChunks.flatMap(
+          (c) => (c.choices as Array<Record<string, unknown>> | undefined) ?? [],
         );
+        // Error content must be in a separate chunk with finish_reason: null
+        const errorContentChoice = allChoices.find(
+          (choice) =>
+            (choice.delta as Record<string, unknown> | undefined)?.content ===
+            "Error: internal error",
+        );
+        expect(errorContentChoice).toBeDefined();
+        expect(errorContentChoice).toHaveProperty("finish_reason", null);
+        // Final stop chunk must have empty delta and finish_reason: "stop"
+        const stopChoice = allChoices.findLast((choice) => choice.finish_reason === "stop");
+        expect(stopChoice).toBeDefined();
+        expect((stopChoice?.delta as Record<string, unknown> | undefined)?.content).toBeUndefined();
       }
     } finally {
       // shared server

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -146,7 +146,7 @@ function writeAssistantRoleChunk(res: ServerResponse, params: { runId: string; m
 
 function writeAssistantContentChunk(
   res: ServerResponse,
-  params: { runId: string; model: string; content: string; finishReason: "stop" | null },
+  params: { runId: string; model: string; content: string },
 ) {
   writeSse(res, {
     id: params.runId,
@@ -157,7 +157,23 @@ function writeAssistantContentChunk(
       {
         index: 0,
         delta: { content: params.content },
-        finish_reason: params.finishReason,
+        finish_reason: null,
+      },
+    ],
+  });
+}
+
+function writeAssistantFinishChunk(res: ServerResponse, params: { runId: string; model: string }) {
+  writeSse(res, {
+    id: params.runId,
+    object: "chat.completion.chunk",
+    created: Math.floor(Date.now() / 1000),
+    model: params.model,
+    choices: [
+      {
+        index: 0,
+        delta: {},
+        finish_reason: "stop",
       },
     ],
   });
@@ -586,7 +602,6 @@ export async function handleOpenAiHttpRequest(
         runId,
         model,
         content,
-        finishReason: null,
       });
       return;
     }
@@ -597,6 +612,9 @@ export async function handleOpenAiHttpRequest(
         closed = true;
         stopWatchingDisconnect();
         unsubscribe();
+        if (phase === "end") {
+          writeAssistantFinishChunk(res, { runId, model });
+        }
         writeDone(res);
         res.end();
       }
@@ -629,7 +647,6 @@ export async function handleOpenAiHttpRequest(
           runId,
           model,
           content,
-          finishReason: null,
         });
       }
     } catch (err) {
@@ -641,8 +658,8 @@ export async function handleOpenAiHttpRequest(
         runId,
         model,
         content: "Error: internal error",
-        finishReason: "stop",
       });
+      writeAssistantFinishChunk(res, { runId, model });
       emitAgentEvent({
         runId,
         stream: "lifecycle",
@@ -653,6 +670,7 @@ export async function handleOpenAiHttpRequest(
         closed = true;
         stopWatchingDisconnect();
         unsubscribe();
+        writeAssistantFinishChunk(res, { runId, model });
         writeDone(res);
         res.end();
       }


### PR DESCRIPTION
## Summary

- Split writeAssistantContentChunk (always finish_reason: null) from a new writeAssistantFinishChunk (empty delta, finish_reason: stop)
- Emit the finish chunk from the lifecycle end handler, the error path, and the finally fallback path
- Updated streaming tests to assert spec-correct behavior

## Test plan

- [x] pnpm test src/gateway/openai-http.test.ts — 7/7 passing
- [x] Normal streaming: content chunks have finish_reason: null, stop chunk has finish_reason: stop with empty delta
- [x] Error path: error content chunk is separate from stop chunk

Closes #55210

🤖 Generated with [Claude Code](https://claude.com/claude-code)