### PR TITLE
fix(slack): surface arg-menu fallback warning

### DIFF
--- a/extensions/slack/src/monitor/slash.test.ts
+++ b/extensions/slack/src/monitor/slash.test.ts
@@ -584,10 +584,11 @@ describe("Slack native command argument menus", () => {
     expect(testHarness.optionsReceiverContexts[0]).toBe(testHarness.app);
   });
 
-  it("falls back to static menus when app.options() throws during registration", async () => {
+  it("falls back to static menus and emits a visible warning when app.options() throws", async () => {
     const commands = new Map<string, (args: unknown) => Promise<void>>();
     const actions = new Map<string | RegExp, (args: unknown) => Promise<void>>();
     const postEphemeral = vi.fn().mockResolvedValue({ ok: true });
+    const runtimeError = vi.fn();
     const app = {
       client: { chat: { postEphemeral } },
       command: (name: string, handler: (args: unknown) => Promise<void>) => {
@@ -603,7 +604,7 @@ describe("Slack native command argument menus", () => {
     };
     const ctx = {
       cfg: { commands: { native: true, nativeSkills: false } },
-      runtime: {},
+      runtime: { error: runtimeError },
       botToken: "bot-token",
       botUserId: "bot",
       teamId: "T1",
@@ -636,6 +637,12 @@ describe("Slack native command argument menus", () => {
     // Registration should not throw despite app.options() throwing
     await registerCommands(ctx, account);
     expect(commands.size).toBeGreaterThan(0);
+    expect(runtimeError).toHaveBeenCalledTimes(1);
+    const visibleWarning = String(runtimeError.mock.calls[0]?.[0] ?? "");
+    expect(visibleWarning).toContain("slack: external arg-menu registration failed");
+    expect(visibleWarning).toContain("falling back to static menus");
+    expect(visibleWarning).toContain("external arg search is disabled");
+    expect(visibleWarning).not.toContain("listeners");
     expect(
       Array.from(actions.keys()).some(
         (key) => key instanceof RegExp && String(key) === String(/^openclaw_cmdarg/),

--- a/extensions/slack/src/monitor/slash.ts
+++ b/extensions/slack/src/monitor/slash.ts
@@ -17,7 +17,7 @@ import {
 } from "openclaw/plugin-sdk/native-command-config-runtime";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
-import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { danger, logVerbose, warn } from "openclaw/plugin-sdk/runtime-env";
 import { loadSessionStore, resolveStorePath } from "openclaw/plugin-sdk/session-store-runtime";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -913,9 +913,10 @@ export async function registerSlackMonitorSlashCommands(params: {
     registerArgOptions();
   } catch (err) {
     supportsExternalArgMenus = false;
-    logVerbose(
-      `slack: external arg-menu registration failed, falling back to static menus: ${formatErrorMessage(err)}`,
-    );
+    const visibleWarning =
+      "slack: external arg-menu registration failed; falling back to static menus; external arg search is disabled";
+    logVerbose(`${visibleWarning}: ${formatErrorMessage(err)}`);
+    runtime.error?.(warn(visibleWarning));
   }
 
   const registerArgAction = (actionId: string | RegExp) => {


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary

- Emit a visible, sanitized warning when Slack `app.options()` registration for external argument menus fails.
- Keep provider startup non-fatal by preserving the existing static-menu fallback.
- Keep detailed exception text in verbose logs only, while the operator-visible signal says external arg search is disabled.
- Expand the existing fallback regression test to assert the visible warning path.

Fixes #44297

## Test Plan

- [x] TDD RED source-level probe: after adding the regression assertion but before the source fix, the probe failed because the fallback only logged verbosely and did not import/use `warn`.
- [x] TDD GREEN source-level probe: after the source fix, the probe passed all checks.
- [x] Source hygiene probe: verified edited files have no trailing whitespace and end with a newline.
- [ ] Full Vitest/TypeScript suite not run in this API-only temp workspace because the OpenClaw repository was not cloned and dependencies are not installed here.

## Real behavior proof

- **Behavior or issue addressed:** Slack native command external arg-menu registration failures now emit a visible operator warning while preserving the non-fatal static-menu fallback. The visible warning states that external arg search is disabled and does not include raw exception text.
- **Real environment tested:** API-only OpenClaw temp workspace at `/tmp/openclaw-auto-44297.J76ehy`; relevant source files were fetched from `openclaw/openclaw` `main` and patched locally. Runtime tools: Node `v22.18.0`, Python `3.11.7`, GitHub CLI `2.86.0`.
- **Exact steps or command run after this patch:**
  1. Ran `node /tmp/openclaw-auto-44297.J76ehy/proof-source-probe.mjs /tmp/openclaw-auto-44297.J76ehy` against the patched `slash.ts` and `slash.test.ts`.
  2. Ran a Python source-hygiene probe over the two edited files.
- **Before evidence optional:** RED probe output after the regression assertion and before the source fix:

```text
$ node /tmp/openclaw-auto-44297.J76ehy/proof-source-probe.mjs /tmp/openclaw-auto-44297.J76ehy
PASS regression test requires a visible warning on app.options() registration failure
PASS fallback remains non-fatal when external arg-menu registration throws
FAIL operators get a non-verbose warning about disabled external arg search
  detail: catch block should emit runtime.error(warn(...)) without requiring verbose logs
FAIL visible warning does not include raw exception text
  detail: visible warning should be sanitized; detailed exception text can remain in logVerbose
FAIL source imports warning formatter used by the visible signal
  detail: slash.ts should import warn alongside existing runtime-env helpers
RESULT FAIL 3/5 checks failed
```

- **Evidence after fix:** Terminal output from the patched source-level probe:

```text
$ node /tmp/openclaw-auto-44297.J76ehy/proof-source-probe.mjs /tmp/openclaw-auto-44297.J76ehy
PASS regression test requires a visible warning on app.options() registration failure
PASS fallback remains non-fatal when external arg-menu registration throws
PASS operators get a non-verbose warning about disabled external arg search
PASS visible warning does not include raw exception text
PASS source imports warning formatter used by the visible signal
RESULT PASS 5/5 checks passed
```

Source hygiene output:

```text
$ python3 source-hygiene-probe
source-hygiene: PASS
```

- **Observed result after fix:** The patched fallback path contains `runtime.error?.(warn(visibleWarning))`, so the degraded-mode signal is visible without verbose logging; the same catch block still sets `supportsExternalArgMenus = false` and preserves the static Slack menu fallback. The visible warning text is sanitized, and detailed exception text remains limited to `logVerbose`.
- **What was not tested:** Full Vitest/TypeScript suite was not run because this job is restricted to API-only source work without cloning OpenClaw or installing repo dependencies.

## Risk/Notes

- Draft PR for maintainer review.
- The visible warning is intentionally sanitized; detailed registration errors remain available via `logVerbose`.
- The behavior remains best-effort: static Slack menus continue to register when external arg-menu registration fails.
