### PR TITLE
[codex] fix(gateway): clear live model switch on reset

### DIFF
--- a/src/gateway/sessions-patch.test.ts
+++ b/src/gateway/sessions-patch.test.ts
@@ -325,13 +325,15 @@ describe("gateway sessions patch", () => {
     expect(entry.liveModelSwitchPending).toBe(true);
   });
 
-  test("marks model reset patches as pending live model switches", async () => {
+  test("clears pending live model switches for model reset patches", async () => {
     const store: Record<string, SessionEntry> = {
       [MAIN_SESSION_KEY]: {
         sessionId: "sess-live-reset",
         updatedAt: 1,
         providerOverride: "anthropic",
         modelOverride: "claude-sonnet-4-6",
+        modelOverrideSource: "user",
+        liveModelSwitchPending: true,
       } as SessionEntry,
     };
     const entry = expectPatchOk(
@@ -344,7 +346,8 @@ describe("gateway sessions patch", () => {
 
     expect(entry.providerOverride).toBeUndefined();
     expect(entry.modelOverride).toBeUndefined();
-    expect(entry.liveModelSwitchPending).toBe(true);
+    expect(entry.modelOverrideSource).toBeUndefined();
+    expect(entry.liveModelSwitchPending).toBeUndefined();
   });
 
   test.each([

--- a/src/gateway/sessions-patch.ts
+++ b/src/gateway/sessions-patch.ts
@@ -461,8 +461,8 @@ export async function applySessionsPatchToStore(params: {
           model: resolvedDefault.model,
           isDefault: true,
         },
-        markLiveSwitchPending: true,
       });
+      delete next.liveModelSwitchPending;
     } else if (raw !== undefined) {
       const trimmed = normalizeOptionalString(raw) ?? "";
       if (!trimmed) {


### PR DESCRIPTION
## Summary

- Fix `sessions.patch` with `model: null` so an explicit model reset clears `liveModelSwitchPending` instead of leaving the session marked for a live switch.
- Update the focused gateway regression test to cover clearing `providerOverride`, `modelOverride`, `modelOverrideSource`, and `liveModelSwitchPending`.

Fixes #83192.

## Real behavior proof

Behavior addressed: `sessions.patch` with `model: null` cleared the persisted model override fields but left `liveModelSwitchPending: true`, allowing downstream status/model rendering to reconstruct stale model labels from prior session trajectory state.

Real environment tested: macOS local checkout of `openclaw/openclaw` on branch `codex/clear-live-model-switch-on-reset`, Node v22.19.0, pnpm v11.1.0, dependencies installed with `pnpm install`.

Exact steps or command run after this patch:

```bash
node scripts/run-vitest.mjs src/gateway/sessions-patch.test.ts
node scripts/run-vitest.mjs src/agents/live-model-switch.test.ts
git diff --check
```

Evidence after fix: copied live terminal output from the local OpenClaw checkout after the patch.

```text
$ node scripts/run-vitest.mjs src/gateway/sessions-patch.test.ts
Test Files  3 passed (3)
Tests  120 passed (120)

$ node scripts/run-vitest.mjs src/agents/live-model-switch.test.ts
Test Files  2 passed (2)
Tests  38 passed (38)

$ git diff --check
[no output; exited 0]
```

Observed result after fix: The focused `sessions.patch` reset regression now starts from a session with `providerOverride`, `modelOverride`, `modelOverrideSource`, and `liveModelSwitchPending: true`, applies `model: null`, and verifies all four fields are unset. Explicit model switches still use the existing pending live-switch path.

What was not tested: I did not run a live gateway/Telegram reproduction of the downstream ghost label; this PR validates the source-level orphan flag behavior identified in #83192 and the related live-model-switch acceptance test.

## Verification

- [x] `node scripts/run-vitest.mjs src/gateway/sessions-patch.test.ts`
- [x] `node scripts/run-vitest.mjs src/agents/live-model-switch.test.ts`
- [x] `git diff --check`

## Notes

AI-assisted draft prepared with Codex; please review before marking ready.
