### PR TITLE
ci: skip changelog-only workflow runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ on:
       - "docs/**"
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    paths-ignore:
+      - "CHANGELOG.md"
 
 permissions:
   contents: read

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "**/*.md"
       - "docs/**"
+      - "!CHANGELOG.md"
 
 permissions:
   contents: read

--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -2,8 +2,12 @@ name: Workflow Sanity
 
 on:
   pull_request:
+    paths-ignore:
+      - "CHANGELOG.md"
   push:
     branches: [main]
+    paths-ignore:
+      - "CHANGELOG.md"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- Problem: root `CHANGELOG.md` updates currently cause broad pull request and push workflow activity, including CI and workflow sanity fanout, even though changelog-only edits do not touch product, runtime, docs site, or workflow logic.
- Why it matters: the PR workflow (`review`, `prepare`, and `land`) can add or adjust `CHANGELOG.md` entries while processing otherwise-ready PRs. Those changelog-only updates retrigger gates, delay landing, and create avoidable contention when several PRs are being landed close together.
- What changed: `CI` now ignores pull requests whose only changed path is `CHANGELOG.md`; `Workflow Sanity` ignores changelog-only pull requests and main-branch pushes; `Docs` keeps its markdown/docs trigger but excludes root `CHANGELOG.md` from the push path set.
- What did NOT change (scope boundary): metadata-only automation such as labelers, auto-response, real behavior proof, or external GitHub apps can still run on PR events because those workflows are event-driven rather than file-scope CI. Other markdown files, docs files, and workflow files still trigger their existing checks.

## Change Type (select all)

- [x] Chore/infra

## Scope (select all touched areas)

- [x] CI/CD / infra

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Changelog-only changes should not start broad CI, docs push, or workflow sanity workflows that are intended for source/docs/workflow surfaces.
- Real environment tested: Local Windows checkout, rebased onto current `openclaw/openclaw:main`, then pushed to the contributor fork branch.
- Exact steps or command run after this patch: `git diff --check origin/main..HEAD`; `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.11 .github/workflows/ci.yml .github/workflows/docs.yml .github/workflows/workflow-sanity.yml`; `git diff --stat origin/main..HEAD`; `git push --force-with-lease g changelog`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Terminal capture from the patched branch:

```text
> git diff --check origin/main..HEAD
# no output; exit 0

> go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.11 .github/workflows/ci.yml .github/workflows/docs.yml .github/workflows/workflow-sanity.yml
# no output; exit 0

> git diff --stat origin/main..HEAD
 .github/workflows/ci.yml              | 2 ++
 .github/workflows/docs.yml            | 1 +
 .github/workflows/workflow-sanity.yml | 4 ++++
 3 files changed, 7 insertions(+)

> git log -1 --oneline
b2abffb4ed ci: skip changelog-only workflow runs
```

- Observed result after fix: The edited workflow files are valid under `actionlint` v1.7.11, the diff has no whitespace errors, and the only changed files are the intended workflow trigger definitions.
- What was not tested: A future changelog-only PR/push event was not live-fired after merge. This PR itself changes workflow files, so it is expected to trigger workflow-surface checks.
- Before evidence (optional but encouraged): Prior PR status showed changelog/workflow-scope PRs fan out into many `CI` and `Workflow Sanity` checks, including skipped matrix jobs that were not relevant to root changelog-only content.

## Root Cause (if applicable)

- Root cause: `CI` had a `push` markdown ignore but no equivalent `pull_request` `paths-ignore`, `Workflow Sanity` had no path filters, and `Docs` matched every root markdown file on main pushes.
- Missing detection / guardrail: The changed-lane scripts already classify `CHANGELOG.md` as release metadata, but GitHub event filters run before those scripts can prevent the workflow from starting.
- Contributing context (if known): Root `CHANGELOG.md` is release metadata, not docs-site content, but broad markdown triggers treated it like docs workflow input.

## User-visible / Behavior Changes

None for OpenClaw runtime behavior. Maintainers should see fewer irrelevant CI/docs/workflow-sanity runs for future root `CHANGELOG.md`-only PRs or pushes, especially during review/prepare/land flows that only touch changelog entries.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows / PowerShell
- Runtime/container: Go 1.26.2 for `actionlint`; GitHub Actions workflow YAML only
- Integration/channel (if any): GitHub Actions
- Relevant config (redacted): No secrets or private config used

### Steps

1. Rebase `changelog` on current `origin/main`.
2. Validate the workflow diff with `git diff --check origin/main..HEAD`.
3. Validate edited workflows with `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.11 .github/workflows/ci.yml .github/workflows/docs.yml .github/workflows/workflow-sanity.yml`.
4. Push the branch to fork remote `g`.

### Expected

- Edited workflow YAML is valid.
- Only CI/docs/workflow-sanity trigger filters change.
- Future changelog-only changes avoid the broad workflows this PR filters.

### Actual

- `git diff --check` passed with no output.
- `actionlint` v1.7.11 passed with no output.
- The pushed branch contains only the three intended workflow files.

## Human Verification (required)

- Verified scenarios: inspected the workflow trigger surfaces; verified root changelog is already release metadata in changed-lane routing; validated edited workflow syntax and whitespace.
- Edge cases checked: kept markdown/docs triggers for other markdown files and docs paths; did not path-filter metadata-only PR automation that does not run untrusted code.
- What you did **not** verify: did not live-fire a post-merge changelog-only PR or main push event.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: A required workflow that is path-filtered out by GitHub can remain pending if branch protection requires that exact check for changelog-only PRs.
  - Mitigation: Scope the path filters only to root `CHANGELOG.md` and call out the branch-protection caveat for reviewer confirmation. Metadata automation remains available for PR policy checks.
- Risk: Root changelog content might still need some docs validation.
  - Mitigation: `CHANGELOG.md` is release metadata, not docs-site content, and changelog formatting remains covered by maintainer release/changelog tooling when applicable.
