### PR TITLE
fix(github-copilot): sanitize unsafe reasoning replay ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- GitHub Copilot: drop unsafe native Responses reasoning replay items with non-replayable IDs before dispatch, preventing affected Copilot sessions from failing with `invalid_request_body`. Fixes #83220. Thanks @galiniliev.
 - Core/plugins: harden clawpatch-reported edge cases across gateway auth cleanup, Claude session id paths, plugin activation policy, apply-patch hunk handling, diagnostic redaction, and plugin metadata validation.
 - Mac app: keep app-level menu commands and Dashboard failure states reachable when the remote Gateway is disconnected, and keep the Settings sidebar toggle in the leading titlebar area.
 - Gateway/webchat: hide internal runtime-context and other `display: false` transcript messages from Chat history and live message events. Fixes #83216. Thanks @EmpireCreator.

--- a/extensions/github-copilot/connection-bound-ids.test.ts
+++ b/extensions/github-copilot/connection-bound-ids.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   rewriteCopilotConnectionBoundResponseIds,
   rewriteCopilotResponsePayloadConnectionBoundIds,
+  sanitizeCopilotReplayResponseIds,
 } from "./connection-bound-ids.js";
 
 describe("github-copilot connection-bound response IDs", () => {
@@ -35,7 +36,7 @@ describe("github-copilot connection-bound response IDs", () => {
     expect(input[4]?.id).toMatch(/^msg_[a-f0-9]{16}$/);
   });
 
-  it("preserves reasoning IDs regardless of encrypted_content", () => {
+  it("preserves valid reasoning IDs regardless of encrypted_content", () => {
     const withEncrypted = Buffer.from(`reasoning-${"e".repeat(24)}`).toString("base64");
     const withNull = Buffer.from(`reasoning-${"n".repeat(24)}`).toString("base64");
     const withoutField = Buffer.from(`reasoning-${"a".repeat(24)}`).toString("base64");
@@ -49,6 +50,38 @@ describe("github-copilot connection-bound response IDs", () => {
     expect(input[0]?.id).toBe(withEncrypted);
     expect(input[1]?.id).toBe(withNull);
     expect(input[2]?.id).toBe(withoutField);
+  });
+
+  it("preserves valid base64-ish reasoning IDs with and without encrypted content", () => {
+    const withEncrypted = "abcDEF0123+/=";
+    const withoutEncrypted = "reasoning/abc+123=";
+    const input = [
+      { id: withEncrypted, type: "reasoning", encrypted_content: "opaque-encrypted-payload" },
+      { id: withoutEncrypted, type: "reasoning" },
+    ];
+
+    expect(sanitizeCopilotReplayResponseIds(input)).toBe(false);
+    expect(input.map((item) => item.id)).toEqual([withEncrypted, withoutEncrypted]);
+  });
+
+  it("drops unsafe reasoning replay items instead of stripping their IDs", () => {
+    const overlongId = `5PX6gLHXT5wE+Y2tPmUV4gn+${"B".repeat(384)}`;
+    const input = [
+      {
+        id: overlongId,
+        type: "reasoning",
+        encrypted_content: "encrypted-replay-payload",
+        summary: [],
+      },
+      { type: "reasoning", encrypted_content: "missing-id", summary: [] },
+      { id: 123, type: "reasoning", encrypted_content: "non-string-id", summary: [] },
+      { id: "rs_valid", type: "reasoning", encrypted_content: "valid", summary: [] },
+    ];
+
+    expect(sanitizeCopilotReplayResponseIds(input)).toBe(true);
+    expect(input).toEqual([
+      { id: "rs_valid", type: "reasoning", encrypted_content: "valid", summary: [] },
+    ]);
   });
 
   it("patches response payload input arrays only", () => {

--- a/extensions/github-copilot/connection-bound-ids.ts
+++ b/extensions/github-copilot/connection-bound-ids.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 
 // Copilot's OpenAI-compatible `/responses` endpoint can emit replay item IDs
 // that encode upstream connection state. Those IDs are rejected after the
-// connection changes, so normalize them at the provider boundary before send.
+// connection changes, so sanitize them at the provider boundary before send.
 
 function looksLikeConnectionBoundId(id: string): boolean {
   if (id.length < 24) {
@@ -25,21 +25,36 @@ function deriveReplacementId(type: string | undefined, originalId: string): stri
 
 type InputItem = Record<string, unknown> & { id?: unknown; type?: unknown };
 
-export function rewriteCopilotConnectionBoundResponseIds(input: unknown): boolean {
+function isInputItem(value: unknown): value is InputItem {
+  return !!value && typeof value === "object";
+}
+
+function isValidReasoningReplayId(id: unknown): id is string {
+  return typeof id === "string" && id.length > 0 && id.length <= 64;
+}
+
+export function sanitizeCopilotReplayResponseIds(input: unknown): boolean {
   if (!Array.isArray(input)) {
     return false;
   }
   let rewrote = false;
-  for (const item of input as InputItem[]) {
-    const id = item.id;
-    if (typeof id !== "string" || id.length === 0) {
+  for (let index = input.length - 1; index >= 0; index -= 1) {
+    const item = input[index];
+    if (!isInputItem(item)) {
       continue;
     }
+    const id = item.id;
     // Reasoning items always reference server-side encrypted state bound to the
-    // original item ID. Rewriting the ID — even when encrypted_content is absent
-    // or null — breaks Copilot's server-side lookup and causes a 400 validation
-    // failure regardless of whether the client included encrypted_content.
+    // original item ID. Rewriting or stripping that ID can turn replay into an
+    // invalid or ambiguous server-state lookup, so drop unsafe reasoning items.
     if (item.type === "reasoning") {
+      if (!isValidReasoningReplayId(id)) {
+        input.splice(index, 1);
+        rewrote = true;
+      }
+      continue;
+    }
+    if (typeof id !== "string" || id.length === 0) {
       continue;
     }
     if (looksLikeConnectionBoundId(id)) {
@@ -50,9 +65,17 @@ export function rewriteCopilotConnectionBoundResponseIds(input: unknown): boolea
   return rewrote;
 }
 
-export function rewriteCopilotResponsePayloadConnectionBoundIds(payload: unknown): boolean {
+export function rewriteCopilotConnectionBoundResponseIds(input: unknown): boolean {
+  return sanitizeCopilotReplayResponseIds(input);
+}
+
+export function sanitizeCopilotReplayResponsePayloadIds(payload: unknown): boolean {
   if (!payload || typeof payload !== "object") {
     return false;
   }
-  return rewriteCopilotConnectionBoundResponseIds((payload as { input?: unknown }).input);
+  return sanitizeCopilotReplayResponseIds((payload as { input?: unknown }).input);
+}
+
+export function rewriteCopilotResponsePayloadConnectionBoundIds(payload: unknown): boolean {
+  return sanitizeCopilotReplayResponsePayloadIds(payload);
 }

--- a/extensions/github-copilot/stream.test.ts
+++ b/extensions/github-copilot/stream.test.ts
@@ -118,14 +118,21 @@ describe("wrapCopilotAnthropicStream", () => {
     expect(baseStreamFn.mock.calls).toEqual([[model, context, options]]);
   });
 
-  it("adds Copilot headers, preserves reasoning IDs, and rewrites message IDs before payload send", () => {
+  it("adds Copilot headers, sanitizes reasoning replay, and rewrites message IDs before payload send", () => {
     const reasoningId = Buffer.from(`reasoning-${"x".repeat(24)}`).toString("base64");
+    const overlongReasoningId = `5PX6gLHXT5wE+Y2tPmUV4gn+${"B".repeat(384)}`;
     const messageId = Buffer.from(`message-${"y".repeat(24)}`).toString("base64");
     const payloads: Array<{ input: Array<Record<string, unknown>> }> = [];
     const baseStreamFn = vi.fn((_model, _context, options) => {
       const payload = {
         input: [
-          { id: reasoningId, type: "reasoning" },
+          { id: reasoningId, type: "reasoning", encrypted_content: "valid-encrypted-payload" },
+          {
+            id: overlongReasoningId,
+            type: "reasoning",
+            encrypted_content: "invalid-encrypted-payload",
+            summary: [],
+          },
           { id: messageId, type: "message" },
         ],
       };
@@ -174,6 +181,7 @@ describe("wrapCopilotAnthropicStream", () => {
       onPayload: options.onPayload,
     });
     expect(payloads[0]?.input[0]?.id).toBe(reasoningId);
+    expect(payloads[0]?.input.map((item) => item.type)).toEqual(["reasoning", "message"]);
     expect(payloads[0]?.input[1]?.id).toMatch(/^msg_[a-f0-9]{16}$/);
   });
 


### PR DESCRIPTION
## Summary

- Problem: GitHub Copilot native Responses replay could still send provider-generated `reasoning` replay items with overlong/non-replayable IDs after tool-call replay IDs were repaired.
- Why it matters: Copilot rejects this request body before generation with opaque `invalid_request_body` schema failures, so affected web chat and scheduled agent turns cannot continue.
- What changed: the GitHub Copilot adapter now sanitizes Copilot replay IDs at the provider boundary: it preserves valid reasoning replay IDs, drops unsafe reasoning replay items instead of stripping their IDs, and continues rewriting message/function-call connection-bound IDs.
- What did NOT change (scope boundary): shared OpenAI Responses replay behavior is unchanged; this does not change non-Copilot providers, provider routing, session-file repair, or tool-call pairing semantics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #83220
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: GitHub Copilot native Responses replay no longer sends invalid overlong `reasoning.id` values after overlong replay tool IDs are normalized; unsafe Copilot reasoning replay items are removed at the Copilot adapter boundary.
- Real environment tested: Local Windows source worktree using Node v24.15.0, OpenClaw source branch `bug-019-copilot-replay-reasoning-ids`, model route represented as `github-copilot/gpt-5.5` native Responses.
- Exact steps or command run after this patch: `node node_modules\vitest\vitest.mjs run extensions\github-copilot\connection-bound-ids.test.ts -t "github-copilot connection-bound response IDs" --reporter=verbose --pool=threads --maxWorkers=1 --testTimeout=30000`; then `node node_modules\vitest\vitest.mjs run extensions\github-copilot\stream.test.ts -t "sanitizes reasoning replay" --reporter=verbose --pool=threads --maxWorkers=1 --testTimeout=30000`; then `node node_modules\vitest\vitest.mjs run src\agents\openai-transport-stream.test.ts -t "overlong Copilot Responses replay" --reporter=verbose --pool=threads --maxWorkers=1 --testTimeout=30000`; then `git diff --check`.
- Evidence after fix: Terminal capture, with local checkout path redacted:

```shell
RUN  v4.1.6 [redacted local worktree]
✓ |extension-providers| ../../extensions/github-copilot/connection-bound-ids.test.ts > github-copilot connection-bound response IDs > rewrites opaque message response item IDs deterministically 105ms
✓ |extension-providers| ../../extensions/github-copilot/connection-bound-ids.test.ts > github-copilot connection-bound response IDs > uses response item type prefixes and preserves local IDs 1ms
✓ |extension-providers| ../../extensions/github-copilot/connection-bound-ids.test.ts > github-copilot connection-bound response IDs > preserves valid reasoning IDs regardless of encrypted_content 1ms
✓ |extension-providers| ../../extensions/github-copilot/connection-bound-ids.test.ts > github-copilot connection-bound response IDs > preserves valid base64-ish reasoning IDs with and without encrypted content 1ms
✓ |extension-providers| ../../extensions/github-copilot/connection-bound-ids.test.ts > github-copilot connection-bound response IDs > drops unsafe reasoning replay items instead of stripping their IDs 0ms
✓ |extension-providers| ../../extensions/github-copilot/connection-bound-ids.test.ts > github-copilot connection-bound response IDs > patches response payload input arrays only 1ms
Test Files  1 passed (1)
Tests  6 passed (6)

RUN  v4.1.6 [redacted local worktree]
✓ |extension-providers| ../../extensions/github-copilot/stream.test.ts > wrapCopilotAnthropicStream > adds Copilot headers, sanitizes reasoning replay, and rewrites message IDs before payload send 23ms
Test Files  1 passed (1)
Tests  1 passed | 6 skipped (7)

RUN  v4.1.6 [redacted local worktree]
✓ |agents-core| ../../src/agents/openai-transport-stream.test.ts > openai transport stream > normalizes overlong Copilot Responses replay tool ids before dispatch 151ms
✓ |agents-core| ../../src/agents/openai-transport-stream.test.ts > openai transport stream > keeps distinct overlong Copilot Responses replay item ids distinct 3ms
Test Files  2 passed (2)
Tests  4 passed | 328 skipped (332)

git diff --check
(no output; exit 0)
```

- Observed result after fix: The Copilot sanitizer preserves valid provider-issued reasoning IDs up to 64 characters, including base64-ish characters such as `+`, `/`, and `=`, drops overlong/missing/non-string reasoning replay items as whole items, and still rewrites message/function-call connection-bound IDs to stable Copilot-safe IDs.
- What was not tested: A live Copilot replay against the private affected agent session was not rerun because it requires private session history and provider credentials. Broad `pnpm check:changed` was not run locally because this is a Codex worktree. `oxfmt --write` was attempted on the touched files but failed in this worktree with Windows `spawn EPERM`; `git diff --check` passed.
- Before evidence (optional but encouraged): Redacted runtime evidence from 2026-05-17 and 2026-05-18 showed at least 20 post-fix GitHub Copilot native Responses failures from 2026-05-17 06:40 UTC through 2026-05-18 00:45 UTC. Copilot returned `400 {"message":"","code":"invalid_request_body"}` with `providerRuntimeFailureKind="schema"` and stable failure hash `sha256:3c08634b4d9f`. A sanitized structural probe of the affected replay showed `functionCalls=114`, `functionOutputs=114`, `callIdsOver64=0`, `orphanOutputs=0`, and `duplicateIds=0`, but still had `idsOver64=53`, all on `reasoning` items, with `maxIdLen=408`. The first offending item was same-provider Copilot native Responses `reasoning` with keys `encrypted_content,id,summary,type` and non-safe/overlong ID content.

## Root Cause (if applicable)

- Root cause: shared Responses replay rebuilt same-provider reasoning items from persisted `thinkingSignature` JSON, while the Copilot adapter's existing connection-bound ID sanitizer intentionally skipped reasoning items. After the prior tool-ID repair, overlong function-call IDs were fixed but overlong Copilot reasoning item IDs still reached the native Responses request body.
- Missing detection / guardrail: Existing Copilot replay tests covered overlong function-call IDs and connection-bound message IDs, but not Copilot reasoning replay items with encrypted content and invalid IDs.
- Contributing context (if known): Copilot reports this invalid request shape as an opaque `invalid_request_body`, so once tool IDs were repaired the remaining reasoning ID failures no longer named the exact offending field.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/github-copilot/connection-bound-ids.test.ts`; `extensions/github-copilot/stream.test.ts`; adjacent unchanged coverage in `src/agents/openai-transport-stream.test.ts`.
- Scenario the test should lock in: Copilot Responses replay preserves valid provider-issued reasoning IDs, drops unsafe reasoning replay items as whole items, and still rewrites message/function-call connection-bound IDs before payload send.
- Why this is the smallest reliable guardrail: The failure occurs at the Copilot provider payload boundary before any model generation, and the adapter hook is the narrowest place that owns Copilot-specific replay ID rules.
- Existing test that already covers this (if any): Existing overlong Copilot replay tool-ID tests still cover the shared tool-call normalization half.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Copilot-backed agent sessions with invalid persisted reasoning replay item IDs should resume instead of failing before generation with a schema/tool-payload rejection. Valid Copilot reasoning replay IDs are still preserved.

## Diagram (if applicable)

```text
Before:
[persisted Copilot reasoning item id >64 chars] -> [shared Responses payload] -> [Copilot invalid_request_body]

After:
[persisted Copilot reasoning item id >64 chars] -> [Copilot adapter drops unsafe reasoning replay item] -> [provider-valid replay payload]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows source worktree for tests; original failing runtime setup identifiers redacted.
- Runtime/container: Node v24.15.0 local source checkout.
- Model/provider: `github-copilot/gpt-5.5` native Responses.
- Integration/channel (if any): Agent runtime replay; no external channel surface changed.
- Relevant config (redacted): Provider route `github-copilot` + `openai-responses`; private agent/session identifiers omitted.

### Steps

1. Build or intercept a Copilot Responses request from replay history containing an overlong provider-generated reasoning item ID and overlong tool-call IDs.
2. Run the Copilot adapter payload sanitizer before dispatch.
3. Verify the generated input payload and run the focused Vitest filters listed above.

### Expected

- Unsafe Copilot `reasoning` replay items with missing, non-string, or overlong IDs are dropped as whole items.
- Valid Copilot `reasoning.id` values of length 1-64 are preserved, including base64-ish characters.
- Non-reasoning connection-bound IDs are rewritten to stable provider-safe IDs, and function-call outputs remain paired with normalized function-call IDs.

### Actual

- Before this patch, the payload still contained 53 overlong `reasoning.id` values in the affected session structure after tool-call IDs had been normalized.
- After this patch, the Copilot adapter removes unsafe reasoning replay items while preserving valid reasoning replay and existing tool-call/message ID normalization.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Copilot replay ID sanitizer unit coverage; Copilot Responses wrapper payload-hook coverage; existing overlong Copilot replay tool-ID tests; `git diff --check`.
- Edge cases checked: Valid short reasoning IDs with and without `encrypted_content`; base64-ish valid IDs containing `+`, `/`, and `=`; overlong, missing, and non-string reasoning IDs; deterministic rewriting for message/function-call IDs.
- What you did **not** verify: Live Copilot replay against the private affected session, broad changed gates, and formatter completion due to the local `spawn EPERM` blocker noted above.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Dropping unsafe reasoning replay items can reduce reasoning-state continuity for a repaired Copilot turn.
  - Mitigation: the adapter only drops reasoning items whose ID cannot be replayed safely for Copilot; valid provider-issued reasoning IDs are preserved, and invalid ones already caused request rejection before generation.


