### PR TITLE
fix(telegram): keep Node 22 Bot API DNS IPv4-first

### DIFF
--- a/extensions/telegram/src/network-config.test.ts
+++ b/extensions/telegram/src/network-config.test.ts
@@ -244,6 +244,14 @@ describe("resolveTelegramDnsResultOrderDecision", () => {
     expect(decision).toEqual({ value: "ipv4first", source: "default-node22" });
   });
 
+  it("prefers the Telegram Node 22 ipv4first default over the process verbatim default", () => {
+    const decision = resolveTelegramDnsResultOrderDecision({
+      defaultResultOrder: "verbatim",
+      nodeMajor: 22,
+    });
+    expect(decision).toEqual({ value: "ipv4first", source: "default-node22" });
+  });
+
   it("returns null when no dns decision applies", () => {
     const decision = resolveTelegramDnsResultOrderDecision({
       defaultResultOrder: null,

--- a/extensions/telegram/src/network-config.ts
+++ b/extensions/telegram/src/network-config.ts
@@ -67,8 +67,9 @@ export function resolveTelegramAutoSelectFamilyDecision(params?: {
  * Priority:
  * 1. Environment variable OPENCLAW_TELEGRAM_DNS_RESULT_ORDER
  * 2. Config: channels.telegram.network.dnsResultOrder
- * 3. Process default: dns.getDefaultResultOrder()
+ * 3. Process default: dns.getDefaultResultOrder() when it already prefers IPv4
  * 4. Default: "ipv4first" on Node 22+ (to work around common IPv6 issues)
+ * 5. Other process defaults on older Node versions
  */
 export function resolveTelegramDnsResultOrderDecision(params?: {
   network?: TelegramNetworkConfig;
@@ -101,13 +102,17 @@ export function resolveTelegramDnsResultOrderDecision(params?: {
       ? params.defaultResultOrder
       : dns.getDefaultResultOrder?.(),
   );
-  if (processDefaultValue === "ipv4first" || processDefaultValue === "verbatim") {
+  if (processDefaultValue === "ipv4first") {
     return { value: processDefaultValue, source: "process-default" };
   }
 
   // Default to ipv4first on Node 22+ to avoid IPv6 issues
   if (Number.isFinite(nodeMajor) && nodeMajor >= 22) {
     return { value: "ipv4first", source: "default-node22" };
+  }
+
+  if (processDefaultValue === "verbatim") {
+    return { value: processDefaultValue, source: "process-default" };
   }
 
   return { value: null };


### PR DESCRIPTION
## Summary

- Problem: Telegram Bot API calls on Node 22 can still inherit a process-wide DNS result order of `verbatim`, letting broken IPv6 routes win even though Telegram has a Node 22 IPv4-first default.
- Why it matters: On WSL2/systemd hosts where IPv6 to `api.telegram.org` returns `ENETUNREACH` but IPv4 works, bootstrap calls like `getMe` can fail before the bot initializes.
- What changed: Telegram DNS resolution now keeps explicit Telegram env/config overrides first, honors a process default that already prefers IPv4, and otherwise applies the Node 22 Telegram-specific `ipv4first` default before falling back to older process defaults.
- What did NOT change (scope boundary): No credential, token, proxy, service, webhook, polling, or global DNS configuration changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #82994
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count. Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

- Behavior or issue addressed: Telegram Bot API transport should prefer IPv4 on Node 22 even when the process default DNS result order is `verbatim`.
- Real environment tested: Local macOS development checkout, Node test harness only.
- Exact steps or command run after this patch: See Repro + Verification below.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Unit red/green evidence: the new regression test failed before the source change with received `{ value: "verbatim", source: "process-default" }`, then passed after the fix.
- Observed result after fix: Focused Telegram network, fetch, probe, and polling tests pass; extension TypeScript check passes.
- What was not tested: Live WSL2/systemd Telegram bot startup with a real bot token and intentionally broken IPv6 route.
- Before evidence (optional but encouraged): `node scripts/run-vitest.mjs extensions/telegram/src/network-config.test.ts --reporter=verbose` failed the new test before implementation: expected `ipv4first/default-node22`, received `verbatim/process-default`.

## Root Cause (if applicable)

- Root cause: The Telegram DNS decision helper accepted `dns.getDefaultResultOrder() === "verbatim"` before applying its Node 22 Telegram-specific `ipv4first` default, so a process-wide default could bypass the Telegram IPv4 mitigation.
- Missing detection / guardrail: Existing tests covered Node 22 defaulting to `ipv4first` only when there was no process default, but not when the process default was `verbatim`.
- Contributing context (if known): The issue report describes WSL2/systemd with Node v22.22.2 where Node/undici gets `ENETUNREACH` to Telegram while curl/Python can reach the IPv4 path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/telegram/src/network-config.test.ts`
- Scenario the test should lock in: On Node 22, a process default of `verbatim` does not override Telegram's `ipv4first` default.
- Why this is the smallest reliable guardrail: The regression is in the pure DNS decision function, before transport dispatchers are constructed.
- Existing test that already covers this (if any): Existing fallback transport tests cover sticky IPv4 fallback and probe forceFallback, but not this process-default precedence gap.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Telegram Bot API calls on Node 22 prefer IPv4 by default unless explicitly overridden by Telegram env/config. This is scoped to Telegram network configuration.

## Diagram (if applicable)

```text
Before:
[Node 22 + process DNS verbatim] -> [Telegram inherits verbatim] -> [IPv6 may win] -> [ENETUNREACH]

After:
[Node 22 + process DNS verbatim] -> [Telegram default ipv4first] -> [IPv4 preferred] -> [Bot API reachable when IPv4 works]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local development checkout
- Runtime/container: Node/Vitest via repository scripts
- Model/provider: N/A
- Integration/channel (if any): Telegram extension
- Relevant config (redacted): No live Telegram token or service config used

### Steps

1. Add a regression test for Node 22 with `defaultResultOrder: "verbatim"`.
2. Run the test before implementation and observe the failure.
3. Update the Telegram DNS precedence.
4. Run focused Telegram tests and extension typecheck.

### Expected

- Telegram Node 22 DNS decision returns `{ value: "ipv4first", source: "default-node22" }` when process default is `verbatim`.

### Actual

- Before fix: returned `{ value: "verbatim", source: "process-default" }`.
- After fix: returns `{ value: "ipv4first", source: "default-node22" }`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Red test failed before implementation; focused Telegram suite passed after implementation; extension typecheck passed after implementation.
- Edge cases checked: Env/config overrides still take priority; process `ipv4first` is still honored; older Node can still inherit process `verbatim`.
- What you did **not** verify: Live WSL2/systemd Telegram startup/send/receive against a real bot token with broken IPv6 route.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: A user relying on a process-wide `verbatim` default for Telegram on Node 22 will now get Telegram's IPv4-first default.
  - Mitigation: Explicit Telegram env/config `dnsResultOrder: "verbatim"` still wins when deliberately configured.

