### PR TITLE
fix(openai): mark mp3 TTS voice output compatible

### DIFF
--- a/extensions/openai/speech-provider.test.ts
+++ b/extensions/openai/speech-provider.test.ts
@@ -266,7 +266,7 @@ describe("buildOpenAISpeechProvider", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it("honors explicit responseFormat overrides and clears voice-note compatibility when not opus", async () => {
+  it("honors explicit responseFormat overrides and clears voice-note compatibility for wav", async () => {
     const provider = buildOpenAISpeechProvider();
     mockSpeechFetchExpectingFormat("wav");
 
@@ -287,6 +287,28 @@ describe("buildOpenAISpeechProvider", () => {
     expect(result.outputFormat).toBe("wav");
     expect(result.fileExtension).toBe(".wav");
     expect(result.voiceCompatible).toBe(false);
+  });
+
+  it("marks configured mp3 output as voice-compatible for voice-note synthesis", async () => {
+    const provider = buildOpenAISpeechProvider();
+    mockSpeechFetchExpectingFormat("mp3");
+
+    const result = await provider.synthesize({
+      text: "hello",
+      cfg: {} as never,
+      providerConfig: {
+        apiKey: "sk-test",
+        model: "gpt-4o-mini-tts",
+        voice: "alloy",
+        responseFormat: "mp3",
+      },
+      target: "voice-note",
+      timeoutMs: 1_000,
+    });
+
+    expect(result.outputFormat).toBe("mp3");
+    expect(result.fileExtension).toBe(".mp3");
+    expect(result.voiceCompatible).toBe(true);
   });
 
   it("passes extra_body config through to OpenAI-compatible speech requests", async () => {

--- a/extensions/openai/speech-provider.ts
+++ b/extensions/openai/speech-provider.ts
@@ -1,3 +1,4 @@
+import { isVoiceCompatibleAudio } from "openclaw/plugin-sdk/media-runtime";
 import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
 import type {
   SpeechDirectiveTokenParseContext,
@@ -95,6 +96,10 @@ function responseFormatToFileExtension(
     default:
       return ".mp3";
   }
+}
+
+function isOpenAISpeechVoiceCompatibleResponseFormat(format: OpenAiSpeechResponseFormat): boolean {
+  return isVoiceCompatibleAudio({ fileName: `speech${responseFormatToFileExtension(format)}` });
 }
 
 function readExtraBody(value: unknown): Record<string, unknown> | undefined {
@@ -317,7 +322,9 @@ export function buildOpenAISpeechProvider(): SpeechProviderPlugin {
         audioBuffer,
         outputFormat: responseFormat,
         fileExtension: responseFormatToFileExtension(responseFormat),
-        voiceCompatible: req.target === "voice-note" && responseFormat === "opus",
+        voiceCompatible:
+          req.target === "voice-note" &&
+          isOpenAISpeechVoiceCompatibleResponseFormat(responseFormat),
       };
     },
     synthesizeTelephony: async (req) => {

--- a/extensions/speech-core/src/tts.test.ts
+++ b/extensions/speech-core/src/tts.test.ts
@@ -262,6 +262,23 @@ describe("speech-core native voice-note routing", () => {
     });
   });
 
+  it("keeps provider-compatible mp3 voice-note synthesis as Telegram voice delivery", async () => {
+    await expectTtsPayloadResult({
+      channel: "telegram",
+      prefsName: "openclaw-speech-core-tts-telegram-mp3-test",
+      text: "This Telegram reply should be delivered as a native voice note.",
+      target: "voice-note",
+      audioAsVoice: true,
+      mediaExtension: "mp3",
+      providerResult: {
+        audioBuffer: Buffer.from("mp3"),
+        outputFormat: "mp3",
+        fileExtension: ".mp3",
+        voiceCompatible: true,
+      },
+    });
+  });
+
   it("keeps compatible audio-file synthesis deliverable as a voice memo", async () => {
     await expectTtsPayloadResult({
       channel: "voice-memo-chat",


### PR DESCRIPTION
Fixes #80317.

## Summary

- Fixes OpenAI-compatible TTS voice-note compatibility for configured `responseFormat: "mp3"`.
- Reuses the shared media runtime voice-compatibility contract instead of hard-coding OpenAI response formats.
- Adds provider and speech-core regressions so provider-compatible MP3 output continues to route as Telegram voice delivery.

## Problem summary

The OpenAI speech provider only marked voice-note synthesis as voice-compatible when `responseFormat === "opus"`. That made OpenAI-compatible local TTS servers configured for MP3 produce an audio file result even though the shared media contract and Telegram send path already allow MP3 voice delivery.

## Root cause

`extensions/openai/speech-provider.ts` used a provider-local equality check for `opus`, while the rest of the TTS/channel path uses `isVoiceCompatibleAudio()` to decide whether a produced audio asset can be delivered as a voice note. Microsoft/Edge TTS already follows that shared helper path for MP3 output, so OpenAI-compatible MP3 output diverged from the existing runtime contract.

## Architectural reasoning

This keeps the behavior at the provider boundary: the OpenAI provider still reports compatibility only for a `voice-note` synthesis target, but it now asks the shared media runtime whether the selected container extension is voice-compatible. The change does not alter provider selection, gateway/session flow, async cleanup, request timing, or Telegram transport behavior. It only corrects the metadata emitted by OpenAI-compatible synthesis results so the existing speech-core and Telegram delivery contracts can do what they already support.

## Testing performed

Local proof on refreshed head `7d6773b18c4679697f5ca65c9d1fa7b1ac382b5b`:

- `pnpm test extensions/openai/speech-provider.test.ts extensions/speech-core/src/tts.test.ts -- --reporter=verbose` passed: OpenAI provider 10/10, speech-core 28/28.
- `pnpm test extensions/telegram/src/send.test.ts -- --reporter=verbose -t "routes audio media to sendAudio/sendVoice based on voice compatibility"` passed: 1/1 selected, 102 skipped.
- Local OpenAI-compatible HTTP proof using production `buildOpenAISpeechProvider()` captured `POST /v1/audio/speech` with `response_format: "mp3"`; the returned result was `outputFormat: "mp3"`, `fileExtension: ".mp3"`, and `voiceCompatible: true`.
- `pnpm format:check -- extensions/openai/speech-provider.ts extensions/openai/speech-provider.test.ts extensions/speech-core/src/tts.test.ts`
- `pnpm check:changed`
- `git diff --check upstream/main..HEAD`

GitHub Actions on `7d6773b18c4679697f5ca65c9d1fa7b1ac382b5b`:

- Workflow Sanity #201563: success
- OpenGrep PR Diff #21199: success
- CI #207277: success
- CodeQL Critical Quality #17155: success

## Real behavior proof

Behavior addressed: OpenAI-compatible TTS configured with `responseFormat: "mp3"` should mark voice-note synthesis output as voice-compatible so Telegram delivery can use the voice path instead of falling back to audio-file delivery.

Real environment tested: Local Windows checkout on branch `Hemant/fix-openai-tts-mp3-voice`, Node `v22.15.0` with the repository's existing engine warning. The branch was rebased onto upstream/main `6baa2b38b2712384d7de460d90b127cd78dbb3a5`; upstream moved to `bc4f27c89a3c5aa40b7fb9e507a91b6e6c753307` while checks ran, and GitHub reported the PR mergeable against the live base after push. The extra proof used the production OpenAI speech provider against a real local HTTP OpenAI-compatible speech endpoint with redacted auth.

Exact steps or command run after this patch: Started a local HTTP server, invoked `buildOpenAISpeechProvider().synthesize()` with `baseUrl` pointed at that server, `responseFormat: "mp3"`, and `target: "voice-note"`, then captured the outbound OpenAI-compatible request and provider result.

Evidence after fix:

```json
{
  "capturedRequest": {
    "method": "POST",
    "url": "/v1/audio/speech",
    "responseFormat": "mp3",
    "model": "local-compatible-tts",
    "voice": "alloy"
  },
  "outputFormat": "mp3",
  "fileExtension": ".mp3",
  "voiceCompatible": true,
  "audioBytes": 6
}
```

Observed result after fix: The production provider requests MP3 from the OpenAI-compatible speech endpoint and returns MP3 voice-note synthesis as voice-compatible. The speech-core regression keeps that provider-compatible MP3 result on Telegram voice delivery, and the Telegram send regression confirms compatible MP3 voice delivery maps to `sendVoice`.

What was not tested: I did not send a live Telegram message or call a credentialed third-party OpenAI-compatible TTS server. The local HTTP proof exercises the same production provider request/result path without secrets.

## Risk analysis

- Runtime behavior: Narrow metadata correction for OpenAI-compatible TTS results only.
- Concurrency/session/gateway flows: No changes.
- Cleanup/lifecycle handling: No changes.
- API behavior: No public config or SDK shape changes.
- Backward compatibility: Existing Opus voice-note behavior stays compatible; WAV remains non-voice-compatible through the shared helper.
- Developer ergonomics: Removes duplicated provider-local format policy and aligns OpenAI with the shared media contract already used by other providers.

## Backward compatibility

Backward compatible. Users who explicitly configured `responseFormat: "mp3"` for OpenAI-compatible TTS now get the expected voice-compatible metadata for voice-note targets. Non-voice targets and formats that are not accepted by the shared media helper keep their previous fallback behavior.