### PR TITLE
fix(codex): prefer native tokens for resume budget

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -6204,6 +6204,65 @@ describe("runCodexAppServerAttempt", () => {
     expect(savedBinding?.threadId).toBe("thread-1");
   });
 
+  it("resumes a bound Codex thread when stale mirrored token totals remain over budget", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const agentDir = path.join(tempDir, "agent");
+    await writeExistingBinding(sessionFile, workspaceDir, { dynamicToolsFingerprint: "[]" });
+    await fs.writeFile(
+      path.join(path.dirname(sessionFile), "sessions.json"),
+      JSON.stringify({
+        "agent:main:session-1": {
+          sessionFile,
+          totalTokens: 96_000,
+        },
+      }),
+    );
+    const rolloutDir = path.join(agentDir, "codex-home", "sessions");
+    await fs.mkdir(rolloutDir, { recursive: true });
+    await fs.writeFile(
+      path.join(rolloutDir, "rollout-thread-existing.jsonl"),
+      `${JSON.stringify({
+        payload: {
+          type: "token_count",
+          info: {
+            total_token_usage: {
+              total_tokens: 97_000,
+            },
+            last_token_usage: {
+              total_tokens: 12_000,
+            },
+          },
+        },
+      })}\n`,
+    );
+    const { requests, waitForMethod, completeTurn } = createResumeHarness();
+    const params = createParams(sessionFile, workspaceDir);
+    params.agentDir = agentDir;
+    params.config = {
+      agents: {
+        defaults: {
+          compaction: {
+            truncateAfterCompaction: true,
+            maxActiveTranscriptBytes: "1mb",
+          },
+        },
+      },
+    } as never;
+
+    const run = runCodexAppServerAttempt(params, {
+      pluginConfig: { appServer: { mode: "yolo" } },
+    });
+    await waitForMethod("turn/start");
+    await completeTurn({ threadId: "thread-existing", turnId: "turn-1" });
+    await run;
+
+    expect(requests.map((entry) => entry.method)).toContain("thread/resume");
+    expect(requests.map((entry) => entry.method)).not.toContain("thread/start");
+    const savedBinding = await readCodexAppServerBinding(sessionFile);
+    expect(savedBinding?.threadId).toBe("thread-existing");
+  });
+
   it("preserves bound auth when rotating an over-budget native rollout", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -705,7 +705,7 @@ async function rotateOversizedCodexAppServerStartupBinding(params: {
     Number.isFinite(sessionRecord.totalTokens)
       ? sessionRecord.totalTokens
       : undefined;
-  const tokenCount = maxFiniteNumber([sessionTokens, nativeTokens]);
+  const tokenCount = nativeTokens ?? sessionTokens;
   if (tokenCount !== undefined && tokenCount >= CODEX_APP_SERVER_NATIVE_THREAD_MAX_TOKENS) {
     embeddedAgentLog.warn(
       "codex app-server native transcript exceeded active token limit; starting a fresh thread",


### PR DESCRIPTION
## Summary

This is the narrow follow-up for the remaining Codex app-server resume-budget edge case. Upstream `main` already has the broader native rollout guard and dynamic tool-result cap; this patch only changes token precedence when both native rollout usage and mirrored OpenClaw session totals are present.

## Real behavior proof

Behavior or issue addressed: OpenClaw can keep a high mirrored session token total after Codex app-server compaction. Current `main` reads native `last_token_usage`, but still evaluates the resume guard with `max(sessionTokens, nativeTokens)`, so a stale mirrored total can rotate a healthy compacted native thread. This patch prefers `nativeTokens ?? sessionTokens`.

Real environment tested: Han local OpenClaw install on macOS, OpenClaw `2026.5.16-beta.3`, Gateway running against the main agent with WebChat/Codex app-server bindings.

Exact steps or command run after this patch: Applied the same one-line runtime patch locally, restarted/checked OpenClaw, verified the installed runtime contains `const tokenCount = nativeTokens ?? sessionTokens;`, and ran the focused app-server regression lane in this rebased PR worktree.

Evidence after fix: Live terminal output from the local OpenClaw setup after the patch:

```text
$ rg -n "const tokenCount = nativeTokens \\?\\? sessionTokens" /usr/local/lib/node_modules/openclaw/dist/run-attempt-DEhr_oag.js
/usr/local/lib/node_modules/openclaw/dist/run-attempt-DEhr_oag.js:2543:\tconst tokenCount = nativeTokens ?? sessionTokens;

$ openclaw health --json | jq '{ok,eventLoop:.eventLoop,telegram:.channels.telegram.connected}'
{
  "ok": true,
  "eventLoop": {
    "degraded": false,
    "reasons": [],
    "delayP99Ms": 22.8,
    "utilization": 0.021,
    "cpuCoreRatio": 0.022
  },
  "telegram": true
}
```

Observed result after fix: The local installed runtime now uses native Codex rollout token usage first, so a compacted native thread is not forced to rotate solely because OpenClaw mirrored session totals are stale. Gateway stayed healthy after the patch. The rebased PR regression also passed: `Test Files 1 passed (1); Tests 7 passed | 151 skipped (158)`.

What was not tested: Full repository test suite and a live upstream CI WebChat session. The live local Gateway/runtime check and focused app-server regression were tested.

## Supplemental validation

```bash
node_modules/.bin/oxfmt --check --threads=1 extensions/codex/src/app-server/run-attempt.ts extensions/codex/src/app-server/run-attempt.test.ts
git diff --check
tmp=$(mktemp); printf '%s\n' '["codex/src/app-server/run-attempt.test.ts"]' > "$tmp"
OPENCLAW_VITEST_INCLUDE_FILE="$tmp" OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts --testNamePattern 'native rollout|stale mirrored'
```

Supplemental results: oxfmt passed, git diff whitespace passed, focused Vitest passed.
