### PR TITLE
fix(control-ui): avoid protected local avatar image URLs

### DIFF
--- a/ui/src/ui/app-render.assistant-avatar.test.ts
+++ b/ui/src/ui/app-render.assistant-avatar.test.ts
@@ -231,6 +231,46 @@ describe("renderApp assistant avatar routing", () => {
     expect(quickSettingsProps.current?.assistantAvatarOverride).toBe(dataUrl);
   });
 
+  it("passes the authenticated blob URL to Quick Settings for local assistant avatars", () => {
+    renderApp(
+      createState({
+        assistantAvatar: "/avatar/main",
+        assistantAvatarSource: "assets/avatars/nova-portrait.png",
+        assistantAvatarStatus: "local",
+        assistantAvatarReason: null,
+        chatAvatarUrl: "blob:nova-avatar",
+        chatAvatarStatus: "local",
+        chatAvatarReason: null,
+      }),
+    );
+
+    expect(quickSettingsProps.current?.assistantAvatar).toBeNull();
+    expect(quickSettingsProps.current?.assistantAvatarUrl).toBe("blob:nova-avatar");
+    expect(quickSettingsProps.current?.assistantAvatarSource).toBe(
+      "assets/avatars/nova-portrait.png",
+    );
+    expect(quickSettingsProps.current?.assistantAvatarStatus).toBe("local");
+    expect(quickSettingsProps.current?.assistantAvatarReason).toBeNull();
+  });
+
+  it("does not pass protected local avatar routes to Quick Settings before blob fetch completes", () => {
+    renderApp(
+      createState({
+        assistantAvatar: "/avatar/main",
+        assistantAvatarSource: "assets/avatars/nova-portrait.png",
+        assistantAvatarStatus: "local",
+        assistantAvatarReason: null,
+        chatAvatarUrl: null,
+        chatAvatarStatus: null,
+        chatAvatarReason: null,
+      }),
+    );
+
+    expect(quickSettingsProps.current?.assistantAvatar).toBeNull();
+    expect(quickSettingsProps.current?.assistantAvatarUrl).toBeNull();
+    expect(quickSettingsProps.current?.assistantAvatarStatus).toBe("local");
+  });
+
   it("applies the configured chat message width as a shell CSS variable", () => {
     const container = document.createElement("div");
 

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -664,12 +664,6 @@ function resolveAssistantAvatarOverride(config: unknown): string | null {
   return normalizeOptionalString((assistant as { avatar?: unknown }).avatar) ?? null;
 }
 
-function buildAssistantAvatarRoute(basePathValue: string | null | undefined, agentId: string) {
-  const basePath = normalizeBasePath(basePathValue ?? "");
-  const encoded = encodeURIComponent(agentId);
-  return basePath ? `${basePath}/avatar/${encoded}` : `/avatar/${encoded}`;
-}
-
 // ── Quick Settings data extraction helpers ──
 
 const KNOWN_CHANNEL_IDS = [
@@ -951,10 +945,10 @@ export function renderApp(state: AppViewState) {
       : state.assistantAvatar);
   const configAssistantAvatarUrl =
     localAssistantAvatarOverride ??
-    (configAssistantAvatarStatus === "local" && state.assistantAgentId
-      ? buildAssistantAvatarRoute(state.basePath, state.assistantAgentId)
-      : (state.chatAvatarUrl ??
-        (configAssistantAvatarMissing ? null : (assistantAvatarUrl ?? null))));
+    state.chatAvatarUrl ??
+    (configAssistantAvatarMissing || configAssistantAvatarStatus === "local"
+      ? null
+      : (assistantAvatarUrl ?? null));
   const configValue =
     state.configForm ?? (state.configSnapshot?.config as Record<string, unknown> | null);
   const configuredDreaming = resolveConfiguredDreaming(configValue);

--- a/ui/src/ui/views/config-quick.test.ts
+++ b/ui/src/ui/views/config-quick.test.ts
@@ -217,7 +217,28 @@ describe("renderQuickSettings", () => {
     expect(container.querySelector(".qs-assistant-avatar")?.getAttribute("src")).toBe("blob:nova");
   });
 
-  it("renders same-origin assistant avatar routes from IDENTITY.md", () => {
+  it("renders fetched blob URLs for local assistant avatar routes", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderQuickSettings(
+        createProps({
+          assistantName: "Nova",
+          assistantAvatar: null,
+          assistantAvatarUrl: "blob:nova-avatar",
+          assistantAvatarSource: "assets/avatars/nova-portrait.png",
+          assistantAvatarStatus: "local",
+        }),
+      ),
+      container,
+    );
+
+    expect(container.querySelector(".qs-assistant-avatar")?.getAttribute("src")).toBe(
+      "blob:nova-avatar",
+    );
+  });
+
+  it("does not render protected local assistant avatar routes directly", () => {
     const container = document.createElement("div");
 
     render(
@@ -234,7 +255,7 @@ describe("renderQuickSettings", () => {
     );
 
     expect(container.querySelector(".qs-assistant-avatar")?.getAttribute("src")).toBe(
-      "/avatar/main",
+      "apple-touch-icon.png",
     );
   });
 

--- a/ui/src/ui/views/config-quick.ts
+++ b/ui/src/ui/views/config-quick.ts
@@ -199,6 +199,10 @@ function resolveAssistantPreviewAvatarUrl(props: QuickSettingsProps): string | n
   if (props.assistantAvatarStatus === "none" && props.assistantAvatarReason === "missing") {
     return null;
   }
+  const avatarUrl = normalizeOptionalString(props.assistantAvatarUrl);
+  if (props.assistantAvatarStatus === "local" && avatarUrl?.startsWith("/")) {
+    return null;
+  }
   return resolveChatAvatarRenderUrl(props.assistantAvatarUrl, {
     identity: {
       avatar: props.assistantAvatar ?? undefined,


### PR DESCRIPTION
## Summary
- stop passing protected same-origin /avatar routes directly into Quick Settings image tags for local assistant avatars
- use the authenticated blob URL when the avatar fetch has completed, and fall back while it is still loading
- add UI regression coverage for blob-backed local avatars and the protected-route loading state

## Real behavior proof
behavior: Quick Settings must not render a protected `/avatar/:agentId` route directly for a local assistant avatar when Control UI auth is token/hash based. It should use the authenticated blob URL produced by the existing avatar fetch path, or fallback while that blob is still loading.

environment: Local OpenClaw Gateway `2026.5.12` on macOS, Control UI at `http://127.0.0.1:18789`, assistant avatar override configured as `assets/nina-ui-avatar.jpg` for `main`.

steps:
1. Read live bootstrap config with bearer auth.
2. Fetch `/avatar/main` without bearer auth.
3. Fetch `/avatar/main` with bearer auth.
4. Run focused patched UI tests for Quick Settings/app render avatar routing.

evidence:
```console
$ curl -sS -H "Authorization: Bearer <redacted>" http://127.0.0.1:18789/__openclaw/control-ui-config.json | jq '{assistantAvatar,assistantAvatarSource,assistantAvatarStatus,assistantAvatarReason,assistantAgentId}'
{
  "assistantAvatar": "/avatar/main",
  "assistantAvatarSource": "assets/nina-ui-avatar.jpg",
  "assistantAvatarStatus": "local",
  "assistantAvatarReason": null,
  "assistantAgentId": "main"
}

$ curl -sS -o /tmp/avatar-unauth.json -w "%{http_code} %{content_type}\n" http://127.0.0.1:18789/avatar/main; cat /tmp/avatar-unauth.json
401 application/json; charset=utf-8
{"error":{"message":"Unauthorized","type":"unauthorized"}}

$ curl -sS -o /tmp/avatar-auth.jpg -w "%{http_code} %{content_type} %{size_download}\n" -H "Authorization: Bearer <redacted>" http://127.0.0.1:18789/avatar/main
200 image/jpeg 511250

$ file /tmp/avatar-auth.jpg
/tmp/avatar-auth.jpg: JPEG image data, JFIF standard 1.01, aspect ratio, density 1x1, segment length 16, progressive, precision 8, 2816x1536, components 3

$ pnpm --dir ui test src/ui/app-render.assistant-avatar.test.ts src/ui/views/config-quick.test.ts --reporter=verbose
Test Files  2 passed (2)
     Tests  20 passed (20)
```

observedResult: The live setup proves `/avatar/main` is the correct configured local avatar but unauthenticated direct image loads fail with 401, while authenticated fetch returns the real JPEG. The patch prevents Quick Settings from emitting the protected route directly and only renders the authenticated blob URL once available.

notTested: Full browser screenshot automation was not captured because the available OpenClaw browser tool blocked localhost navigation in this cron environment. The live Gateway/avatar route behavior and focused UI regression tests cover the failure path.

## Tests
- `pnpm --dir ui test src/ui/app-render.assistant-avatar.test.ts src/ui/views/config-quick.test.ts --reporter=verbose` (20 passed)

## Review
- Self-review: checked the Quick Settings avatar data path and focused UI diff for scope/secrets/debug leftovers.
