### PR TITLE
Resolve model aliases for agent run overrides

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -76,11 +76,13 @@ import { runWithModelFallback } from "./model-fallback.js";
 import type { ModelManifestNormalizationContext } from "./model-selection-normalize.js";
 import {
   buildConfiguredModelCatalog,
+  buildModelAliasIndex,
   modelKey,
   normalizeModelRef,
   parseModelRef,
   resolveConfiguredModelRef,
   resolveDefaultModelForAgent,
+  resolveModelRefFromString,
   resolveThinkingDefault,
 } from "./model-selection.js";
 import {
@@ -913,7 +915,17 @@ async function agentCommandInternal(
       const explicitRef = explicitModelOverride
         ? explicitProviderOverride
           ? normalizeModelRef(explicitProviderOverride, explicitModelOverride, modelManifestContext)
-          : parseModelRef(explicitModelOverride, provider, modelManifestContext)
+          : (resolveModelRefFromString({
+              cfg,
+              raw: explicitModelOverride,
+              defaultProvider: provider,
+              aliasIndex: buildModelAliasIndex({
+                cfg,
+                defaultProvider: provider,
+                modelManifestContext,
+              }),
+              modelManifestContext,
+            })?.ref ?? parseModelRef(explicitModelOverride, provider, modelManifestContext))
         : explicitProviderOverride
           ? normalizeModelRef(explicitProviderOverride, model, modelManifestContext)
           : null;

--- a/src/commands/agent-command.test-mocks.ts
+++ b/src/commands/agent-command.test-mocks.ts
@@ -58,7 +58,7 @@ vi.mock("../agents/model-selection.js", () => {
     agents?: {
       defaults?: {
         model?: string | { primary?: string; fallbacks?: string[] };
-        models?: Record<string, { params?: { thinking?: string } } | undefined>;
+        models?: Record<string, { alias?: string; params?: { thinking?: string } } | undefined>;
         thinkingDefault?: string;
       };
     };
@@ -87,6 +87,37 @@ vi.mock("../agents/model-selection.js", () => {
   });
   const modelKey = (provider: string, model: string) =>
     `${provider.trim().toLowerCase()}/${model.trim().toLowerCase()}`;
+  const buildModelAliasIndex = ({ cfg }: { cfg?: ConfigWithModels }) => {
+    const byAlias = new Map<string, { alias: string; ref: ModelRef }>();
+    const modelConfig = cfg?.agents?.defaults?.models ?? {};
+    for (const [raw, entry] of Object.entries(modelConfig)) {
+      const alias = entry?.alias?.trim();
+      if (!alias) {
+        continue;
+      }
+      const parsed = parseModelRefImpl(raw, "openai");
+      if (parsed) {
+        byAlias.set(alias.toLowerCase(), { alias, ref: parsed });
+      }
+    }
+    return { byAlias, byKey: new Map<string, { alias: string; ref: ModelRef }>() };
+  };
+  const resolveModelRefFromString = ({
+    raw,
+    defaultProvider,
+    aliasIndex,
+  }: {
+    raw: string;
+    defaultProvider: string;
+    aliasIndex?: ReturnType<typeof buildModelAliasIndex>;
+  }) => {
+    const aliasMatch = aliasIndex?.byAlias.get(raw.trim().toLowerCase());
+    if (aliasMatch) {
+      return { ref: aliasMatch.ref, alias: aliasMatch.alias };
+    }
+    const parsed = parseModelRefImpl(raw, defaultProvider);
+    return parsed ? { ref: parsed } : null;
+  };
   const isModelKeyAllowedBySet = (allowedKeys: ReadonlySet<string>, key: string) => {
     if (allowedKeys.has(key)) {
       return true;
@@ -180,11 +211,13 @@ vi.mock("../agents/model-selection.js", () => {
       },
     ),
     buildConfiguredModelCatalog: vi.fn(() => []),
+    buildModelAliasIndex: vi.fn(buildModelAliasIndex),
     isModelKeyAllowedBySet,
     isCliProvider: vi.fn(() => false),
     modelKey,
     normalizeModelRef,
     parseModelRef,
+    resolveModelRefFromString: vi.fn(resolveModelRefFromString),
     resolveConfiguredModelRef: vi.fn(
       ({ cfg }: { cfg?: ConfigWithModels; defaultProvider?: string; defaultModel?: string }) =>
         resolveDefaultRef(cfg),

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -979,6 +979,24 @@ describe("agentCommand", () => {
 
       expectLastRunProviderModel("openai", "gpt-4.1-mini");
 
+      mockConfig(home, store, {
+        models: {
+          "anthropic/claude-opus-4-6": {},
+          "openai/gpt-4.1-mini": {},
+          "xai/grok-4.3": { alias: "groktop" },
+        },
+      });
+      await agentCommand(
+        {
+          message: "use an alias override",
+          sessionKey: "agent:main:subagent:alias-run-override",
+          model: "groktop",
+        },
+        runtime,
+      );
+
+      expectLastRunProviderModel("xai", "grok-4.3");
+
       const saved = readSessionStore<{
         providerOverride?: string;
         modelOverride?: string;


### PR DESCRIPTION
## Summary
- resolve explicit agent run model overrides through the configured model alias index before falling back to provider/model parsing
- preserve provider+model override behavior when both fields are supplied
- add a regression case for an alias-only run override such as `--model groktop`

## Test
- `corepack pnpm exec vitest run src/commands/agent.test.ts`