### PR TITLE
fix(ui): clarify imported insights cluster tabs

### DIFF
--- a/ui/src/styles/dreams.css
+++ b/ui/src/styles/dreams.css
@@ -838,6 +838,29 @@
   display: none;
 }
 
+.dreams-diary__cluster-nav {
+  display: grid;
+  gap: 8px;
+  width: min(100%, 920px);
+  max-width: 100%;
+  min-width: 0;
+  margin: 0 0 14px;
+  position: relative;
+  z-index: 1;
+}
+
+.dreams-diary__cluster-nav-label {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 650;
+  letter-spacing: 0;
+}
+
+.dreams-diary__cluster-tabs {
+  gap: 8px;
+  padding: 2px 0 4px;
+}
+
 .dreams-diary__day-chip {
   padding: 4px 12px;
   border-radius: 999px;
@@ -864,6 +887,30 @@
   border-color: color-mix(in oklab, var(--accent) 44%, transparent);
   background: color-mix(in oklab, var(--accent-subtle) 88%, transparent);
   color: var(--text);
+}
+
+.dreams-diary__cluster-tab {
+  min-height: 38px;
+  padding: 8px 14px;
+  border-radius: 8px;
+  background: color-mix(in oklab, var(--panel) 94%, var(--bg));
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 650;
+  box-shadow: 0 1px 0 color-mix(in oklab, var(--border) 34%, transparent);
+}
+
+.dreams-diary__cluster-tab:hover {
+  border-color: color-mix(in oklab, var(--accent) 46%, var(--border));
+  background: color-mix(in oklab, var(--panel) 98%, var(--accent-subtle));
+}
+
+.dreams-diary__cluster-tab--active {
+  border-color: color-mix(in oklab, var(--accent) 58%, transparent);
+  background: color-mix(in oklab, var(--accent-subtle) 72%, var(--panel));
+  box-shadow:
+    0 0 0 1px color-mix(in oklab, var(--accent) 18%, transparent),
+    0 1px 0 color-mix(in oklab, var(--accent) 18%, transparent);
 }
 
 .dreams-diary__prose {

--- a/ui/src/ui/views/dreaming.test.ts
+++ b/ui/src/ui/views/dreaming.test.ts
@@ -6,6 +6,7 @@ import {
   renderDreaming,
   setDreamAdvancedWaitingSort,
   setDreamDiarySubTab,
+  setDiaryPage,
   setDreamSubTab,
   type DreamingProps,
 } from "./dreaming.ts";
@@ -310,8 +311,41 @@ describe("dreaming view", () => {
       { label: "Imported Insights", active: true },
       { label: "Memory Palace", active: false },
     ]);
+    expect(compactText(container.querySelector(".dreams-diary__cluster-nav-label"))).toBe(
+      "Filter by cluster",
+    );
+    const clusterTabs = [
+      ...container.querySelectorAll<HTMLButtonElement>(
+        '[role="tablist"][aria-label="Imported insight clusters"] [role="tab"]',
+      ),
+    ].map((tab) => ({
+      label: compactText(tab),
+      selected: tab.getAttribute("aria-selected"),
+      controls: tab.getAttribute("aria-controls"),
+      tabIndex: tab.tabIndex,
+      active: tab.classList.contains("dreams-diary__cluster-tab--active"),
+    }));
+    expect(clusterTabs).toEqual([
+      {
+        label: "Travel · 1 chat · 1 signal",
+        selected: "true",
+        controls: "imported-insights-cluster-panel",
+        tabIndex: 0,
+        active: true,
+      },
+      {
+        label: "Health · 1 chat · 1 sensitive",
+        selected: "false",
+        controls: "imported-insights-cluster-panel",
+        tabIndex: -1,
+        active: false,
+      },
+    ]);
+    expect(container.querySelector('[role="tabpanel"]')?.getAttribute("aria-labelledby")).toBe(
+      "imported-insights-cluster-tab-0",
+    );
     expect(compactText(container.querySelector(".dreams-diary__date"))).toBe(
-      "Travel · 1 chats · 1 signals",
+      "Travel · 1 chat · 1 signal",
     );
     const insight = container.querySelector(".dreams-diary__insight-card");
     expect(insight?.querySelector(".dreams-diary__insight-title")?.textContent).toBe(
@@ -325,6 +359,57 @@ describe("dreaming view", () => {
     );
     setDreamDiarySubTab("dreams");
     setDreamSubTab("scene");
+  });
+
+  it("supports keyboard navigation between imported insight cluster tabs", async () => {
+    setDreamSubTab("diary");
+    setDreamDiarySubTab("insights");
+    setDiaryPage(0);
+    const container = document.createElement("div");
+    document.body.append(container);
+    let props: DreamingProps;
+    const rerender = () => render(renderDreaming(props), container);
+    props = buildProps({ onRequestUpdate: rerender });
+    try {
+      rerender();
+
+      const firstTab = container.querySelector<HTMLButtonElement>(
+        "#imported-insights-cluster-tab-0",
+      );
+      expect(firstTab).toBeInstanceOf(HTMLButtonElement);
+      if (!(firstTab instanceof HTMLButtonElement)) {
+        throw new Error("Expected first imported insights cluster tab");
+      }
+
+      firstTab.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+      await Promise.resolve();
+
+      const tabs = [
+        ...container.querySelectorAll<HTMLButtonElement>(
+          '[role="tablist"][aria-label="Imported insight clusters"] [role="tab"]',
+        ),
+      ].map((tab) => ({
+        id: tab.id,
+        selected: tab.getAttribute("aria-selected"),
+        tabIndex: tab.tabIndex,
+      }));
+      expect(tabs).toEqual([
+        { id: "imported-insights-cluster-tab-0", selected: "false", tabIndex: -1 },
+        { id: "imported-insights-cluster-tab-1", selected: "true", tabIndex: 0 },
+      ]);
+      expect(container.querySelector('[role="tabpanel"]')?.getAttribute("aria-labelledby")).toBe(
+        "imported-insights-cluster-tab-1",
+      );
+      expect(compactText(container.querySelector(".dreams-diary__date"))).toBe(
+        "Health · 1 chat · 1 sensitive",
+      );
+      expect(document.activeElement?.id).toBe("imported-insights-cluster-tab-1");
+    } finally {
+      setDiaryPage(0);
+      setDreamDiarySubTab("dreams");
+      setDreamSubTab("scene");
+      container.remove();
+    }
   });
 
   it("opens the full imported source page from diary cards", async () => {

--- a/ui/src/ui/views/dreaming.ts
+++ b/ui/src/ui/views/dreaming.ts
@@ -3,6 +3,7 @@ import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { t } from "../../i18n/index.ts";
 import type {
   DreamingEntry,
+  WikiImportInsightCluster,
   WikiImportInsights,
   WikiMemoryPalace,
 } from "../controllers/dreaming.ts";
@@ -514,6 +515,63 @@ function formatImportBadge(item: {
   return "unknown risk";
 }
 
+function formatCount(value: number, singular: string, plural = `${singular}s`): string {
+  return `${value} ${value === 1 ? singular : plural}`;
+}
+
+function formatImportClusterSummary(cluster: WikiImportInsightCluster): string {
+  const parts = [cluster.label, formatCount(cluster.itemCount, "chat")];
+  if (cluster.highRiskCount > 0) {
+    parts.push(formatCount(cluster.highRiskCount, "sensitive", "sensitive"));
+  }
+  if (cluster.preferenceSignalCount > 0) {
+    parts.push(formatCount(cluster.preferenceSignalCount, "signal"));
+  }
+  return parts.join(" · ");
+}
+
+function focusImportClusterTab(index: number): void {
+  queueMicrotask(() => {
+    document.getElementById(`imported-insights-cluster-tab-${index}`)?.focus();
+  });
+}
+
+function selectImportCluster(index: number, props: DreamingProps): void {
+  setDiaryPage(index);
+  props.onRequestUpdate?.();
+}
+
+function handleImportClusterKeydown(
+  event: KeyboardEvent,
+  index: number,
+  count: number,
+  props: DreamingProps,
+): void {
+  let nextIndex: number | null = null;
+  switch (event.key) {
+    case "ArrowRight":
+    case "ArrowDown":
+      nextIndex = (index + 1) % count;
+      break;
+    case "ArrowLeft":
+    case "ArrowUp":
+      nextIndex = (index - 1 + count) % count;
+      break;
+    case "Home":
+      nextIndex = 0;
+      break;
+    case "End":
+      nextIndex = count - 1;
+      break;
+    default:
+      return;
+  }
+
+  event.preventDefault();
+  selectImportCluster(nextIndex, props);
+  focusImportClusterTab(nextIndex);
+}
+
 function toggleExpandedCard(bucket: Set<string>, key: string, requestUpdate?: () => void): void {
   if (bucket.has(key)) {
     bucket.delete(key);
@@ -955,33 +1013,45 @@ function renderDiaryImportsSection(props: DreamingProps) {
   const cluster = clusters[clusterIndex];
 
   return html`
-    <div class="dreams-diary__daychips">
-      ${clusters.map(
-        (entry, index) => html`
-          <button
-            class="dreams-diary__day-chip ${index === clusterIndex
-              ? "dreams-diary__day-chip--active"
-              : ""}"
-            @click=${() => {
-              setDiaryPage(index);
-              props.onRequestUpdate?.();
-            }}
-          >
-            ${entry.label}
-          </button>
-        `,
-      )}
+    <div class="dreams-diary__cluster-nav">
+      <div class="dreams-diary__cluster-nav-label">Filter by cluster</div>
+      <div
+        class="dreams-diary__daychips dreams-diary__cluster-tabs"
+        role="tablist"
+        aria-label="Imported insight clusters"
+      >
+        ${clusters.map(
+          (entry, index) => html`
+            <button
+              id=${`imported-insights-cluster-tab-${index}`}
+              type="button"
+              role="tab"
+              aria-selected=${index === clusterIndex ? "true" : "false"}
+              aria-controls="imported-insights-cluster-panel"
+              tabindex=${index === clusterIndex ? "0" : "-1"}
+              class="dreams-diary__day-chip dreams-diary__cluster-tab ${index === clusterIndex
+                ? "dreams-diary__day-chip--active dreams-diary__cluster-tab--active"
+                : ""}"
+              @click=${() => selectImportCluster(index, props)}
+              @keydown=${(event: KeyboardEvent) =>
+                handleImportClusterKeydown(event, index, clusters.length, props)}
+            >
+              ${formatImportClusterSummary(entry)}
+            </button>
+          `,
+        )}
+      </div>
     </div>
 
-    <article class="dreams-diary__entry" key="imports-${cluster.key}">
+    <article
+      id="imported-insights-cluster-panel"
+      class="dreams-diary__entry"
+      key="imports-${cluster.key}"
+      role="tabpanel"
+      aria-labelledby=${`imported-insights-cluster-tab-${clusterIndex}`}
+    >
       <div class="dreams-diary__accent"></div>
-      <div class="dreams-diary__date">
-        ${cluster.label} · ${cluster.itemCount} chats
-        ${cluster.highRiskCount > 0 ? html`· ${cluster.highRiskCount} sensitive` : nothing}
-        ${cluster.preferenceSignalCount > 0
-          ? html`· ${cluster.preferenceSignalCount} signals`
-          : nothing}
-      </div>
+      <div class="dreams-diary__date">${formatImportClusterSummary(cluster)}</div>
       <div class="dreams-diary__prose">
         <p class="dreams-diary__para">
           Imported chats clustered around ${cluster.label.toLowerCase()}.


### PR DESCRIPTION
Fixes #80301.

## Summary

- Turns the Imported Insights cluster chips into a labeled, more prominent horizontal tab bar.
- Adds cluster counts directly to each tab so users can scan chats, sensitive clusters, and candidate signals before switching.
- Adds ARIA tab semantics with roving focus and keyboard navigation, plus focused Dreaming view regressions.

## Problem summary

Dreaming -> Diary -> Imported Insights already exposed cluster navigation, but the controls were small label-only chips. The useful counts were only visible after selecting a cluster, which made the row easy to miss and hard to scan in large imports.

## Root cause

`renderDiaryImportsSection` reused the generic diary day-chip style and rendered only `cluster.label` in each control. The memory-wiki import insight payload already carries the relevant counts, but the view did not surface them in the navigation row or provide stronger selected/focus semantics for this cluster-switching control.

## Architectural reasoning

This stays entirely in the Control UI presentation layer. The memory-wiki plugin remains the source of cluster data and ordering, the Dreaming controller contract is unchanged, and the view only formats the existing `WikiImportInsightCluster` fields. The patch does not alter runtime behavior outside the Dreaming UI, gateway/session flows, concurrency, cleanup logic, API behavior, or plugin contracts. Sort controls are intentionally not included because the issue discussion calls the exact sort dimensions a product/UX choice; preserving backend order keeps this PR narrow and reviewable.

## Testing performed

Local proof on refreshed head `ab1d6b0f92865eac250049059de1364a459b6480`:

- `pnpm test ui/src/ui/views/dreaming.test.ts -- --reporter=verbose` passed: 16/16.
- `pnpm format:check -- ui/src/ui/views/dreaming.ts ui/src/ui/views/dreaming.test.ts ui/src/styles/dreams.css`
- `pnpm check:changed`
- `pnpm ui:build`
- `git diff --check upstream/main..HEAD`

GitHub Actions on `ab1d6b0f92865eac250049059de1364a459b6480`:

- Workflow Sanity #201587: success
- CI #207301: success

## Real behavior proof

Behavior addressed: Imported Insights cluster navigation is now visually prominent, labeled as `Filter by cluster`, shows useful counts in each control, and exposes correct tab selection/focus semantics.

Real environment tested: Local Windows checkout on branch `Hemant/improve-imported-insights-tabs`, Node `v22.15.0` with pnpm running under the repository install and the repo's existing engine warning. The branch was rebased onto upstream/main `11d7499db107f7669d89ead56bf2c5f5187bfe73`, and GitHub reported the PR mergeable after push.

Exact steps or command run after this patch: Ran the Dreaming view Vitest file after the rebase with `pnpm test ui/src/ui/views/dreaming.test.ts -- --reporter=verbose`, then ran formatting, changed checks, diff whitespace checks, and the Control UI production build with `pnpm ui:build`. The refreshed GitHub PR checks then passed on the current head SHA.

Evidence after fix: The Dreaming view test asserts the Imported Insights cluster tab label, count-rich tab text, `role="tablist"`/`role="tab"`, `aria-selected`, `aria-controls`, roving `tabIndex`, `role="tabpanel"`, and ArrowRight keyboard navigation from Travel to Health. The production Control UI build also completed successfully, and GitHub Actions passed on the pushed head.

Observed result after fix: The focused Dreaming view test passed with 16 tests, including the keyboard navigation regression. Formatting, changed checks, whitespace checks, Control UI Vite production build, Workflow Sanity, and CI all passed.

What was not tested: I did not attach a live browser screenshot or recording from a real imported ChatGPT dataset. The visual behavior was verified through the jsdom view test harness and production Control UI build; a maintainer or contributor with screenshot upload access should attach redacted UI proof if required by review automation.

## Risk analysis

- Runtime behavior: Limited to Control UI rendering for Dreaming -> Diary -> Imported Insights.
- Concurrency/session/gateway flows: No changes.
- Cleanup/lifecycle handling: No changes.
- API behavior: No public API, gateway protocol, plugin manifest, or controller payload changes.
- Tests: Adds focused coverage for the new tab label/count semantics and keyboard navigation.
- Backward compatibility: Existing memory-wiki data contracts and backend cluster ordering are preserved.
- Developer ergonomics: The count formatter is typed against `WikiImportInsightCluster` and keeps the display logic local to the view.

## Backward compatibility

Backward compatible. Existing Imported Insights data renders through the same `wikiImportInsights.clusters` payload; this only changes presentation and accessibility semantics for the cluster selector.