### PR TITLE
ci(mantis): allow ClawSweeper telegram proof agent

### DIFF
--- a/.github/workflows/mantis-telegram-desktop-proof.yml
+++ b/.github/workflows/mantis-telegram-desktop-proof.yml
@@ -458,6 +458,7 @@ jobs:
           codex-home: /tmp/mantis-codex-home-${{ github.run_id }}
           safety-strategy: unprivileged-user
           codex-user: codex
+          allow-bot-users: clawsweeper[bot]
 
       - name: Inspect Mantis evidence manifest
         id: inspect

--- a/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
+++ b/test/scripts/mantis-telegram-desktop-proof-workflow.test.ts
@@ -132,6 +132,7 @@ describe("Mantis Telegram Desktop proof workflow", () => {
     expect(workflowText).toContain('eventName === "pull_request_target"');
     expect(workflowText).toContain("context.payload.pull_request?.number");
     expect(workflowText).toContain("Accepted Mantis label trigger");
+    expect(workflowText).toContain("allow-bot-users: clawsweeper[bot]");
   });
 
   it("can publish an existing proof artifact without recapturing", () => {


### PR DESCRIPTION
## Summary

- Problem: Mantis Telegram Desktop Proof label-triggered runs accept ClawSweeper at the workflow gate but fail when codex-action rejects clawsweeper[bot] for lacking write access.
- Why it matters: ClawSweeper-applied `mantis: telegram-visible-proof` labels currently start a proof run that cannot reach the actual proof agent.
- What changed: Added a narrow `allow-bot-users: clawsweeper[bot]` input on the Mantis Telegram codex-action step and locked it with a workflow test assertion.
- What did NOT change (scope boundary): No trigger broadening, no `allow-bots: true`, no ref validation changes, no secret/token scope changes.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #83186
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: ClawSweeper label-triggered Mantis Telegram proof runs were blocked before the Codex proof agent started.
- Real environment tested: Local OpenClaw checkout on macOS, branch `fix/mantis-clawsweeper-codex-allowlist` from latest `origin/main`.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs test/scripts/mantis-telegram-desktop-proof-workflow.test.ts`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): `Test Files 1 passed (1); Tests 12 passed (12)`
- Observed result after fix: The focused workflow test now requires the narrow ClawSweeper bot allowlist alongside the existing label-trigger assertions.
- What was not tested: A live GitHub Actions Mantis Telegram Desktop Proof rerun was not performed from this branch.
- Before evidence (optional but encouraged): Run 25996608073 failed with `Actor clawsweeper[bot] is not permitted to run this action` before producing Mantis evidence.

## Root Cause (if applicable)

- Root cause: Commit 59efd95669 added the `pull_request_target` label trigger and workflow-level acceptance for label events, but the later `openai/codex-action` step still used its default actor permission gate.
- Missing detection / guardrail: The workflow test asserted the label trigger path but did not assert that the Codex action allowed the ClawSweeper bot actor expected to drive it.
- Contributing context (if known): `codex-action` defaults reject bot actors without write access unless they are explicitly allowlisted.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
- [ ] Unit test
- [x] Seam / integration test
- [ ] End-to-end test
- [ ] Existing coverage already sufficient
- Target test or file: `test/scripts/mantis-telegram-desktop-proof-workflow.test.ts`
- Scenario the test should lock in: The Mantis Telegram Desktop proof workflow includes both the ClawSweeper label trigger and the matching narrow Codex action bot allowlist.
- Why this is the smallest reliable guardrail: The bug was a YAML integration mismatch between workflow authorization and codex-action authorization.
- Existing test that already covers this (if any): Existing label-trigger test now also checks `allow-bot-users: clawsweeper[bot]`.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

ClawSweeper-applied Mantis Telegram visible proof labels can now reach the Codex proof agent instead of failing at codex-action actor authorization.

## Diagram (if applicable)

```text
Before:
ClawSweeper label -> workflow authorized -> codex-action rejects clawsweeper[bot]

After:
ClawSweeper label -> workflow authorized -> codex-action narrow bot allowlist -> proof agent starts
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): Yes
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): Yes
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: This lets only `clawsweeper[bot]` bypass codex-action write-access checks for this proof step. Mitigation is a narrow explicit `allow-bot-users` entry, not `allow-bots: true`, with existing trusted-harness checkout and PR-head validation unchanged.

## Repro + Verification

### Environment

- OS: macOS local checkout
- Runtime/container: Node/Vitest through `scripts/run-vitest.mjs`
- Model/provider: N/A
- Integration/channel (if any): GitHub Actions / Mantis Telegram Desktop Proof
- Relevant config (redacted): N/A

### Steps

1. Inspect the failing Actions run for PR #83186.
2. Add the narrow ClawSweeper bot allowlist to the Codex action step.
3. Run `node scripts/run-vitest.mjs test/scripts/mantis-telegram-desktop-proof-workflow.test.ts`.

### Expected

- The workflow test passes and asserts the label trigger plus narrow bot allowlist.

### Actual

- The workflow test passed: 1 file, 12 tests.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Focused workflow test for Mantis Telegram Desktop proof.
- Edge cases checked: Diff scope confirmed to only the workflow and focused test.
- What you did **not** verify: Live Mantis proof execution in GitHub Actions.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: A trusted automation bot can now start the secret-bearing Codex proof step for this workflow.
  - Mitigation: The allowlist names only `clawsweeper[bot]`; it does not enable all bots, and existing trusted checkout plus PR-head validation remains unchanged.
