### PR TITLE
fix(doctor): warn for untrusted external channel plugins

### DIFF
--- a/src/commands/doctor/shared/channel-plugin-blockers.test.ts
+++ b/src/commands/doctor/shared/channel-plugin-blockers.test.ts
@@ -1,29 +1,62 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as manifestRegistry from "../../../plugins/manifest-registry.js";
-import { scanConfiguredChannelPluginBlockers } from "./channel-plugin-blockers.js";
+import {
+  collectConfiguredChannelPluginBlockerWarnings,
+  scanConfiguredChannelPluginBlockers,
+} from "./channel-plugin-blockers.js";
 
 describe("channel plugin blockers", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
   });
 
-  it("skips plugin registry work when config has no plugin blocker surfaces", () => {
+  it("skips plugin registry work when config has no configured channel surfaces", () => {
     const registrySpy = vi.spyOn(manifestRegistry, "loadPluginManifestRegistry");
 
     const hits = scanConfiguredChannelPluginBlockers({
       channels: {
-        slack: {
-          accounts: {
-            work: {
-              allowFrom: ["alice"],
-            },
-          },
+        defaults: {
+          groupPolicy: "disabled",
         },
       },
     });
 
     expect(hits).toStrictEqual([]);
     expect(registrySpy).not.toHaveBeenCalled();
+  });
+
+  it("reports external channel plugins that are installed but not explicitly enabled", () => {
+    vi.spyOn(manifestRegistry, "loadPluginManifestRegistry").mockReturnValue({
+      plugins: [
+        {
+          id: "discord",
+          origin: "global",
+          channels: ["discord"],
+          enabledByDefault: false,
+        },
+      ],
+      diagnostics: [],
+    } as unknown as ReturnType<typeof manifestRegistry.loadPluginManifestRegistry>);
+
+    const hits = scanConfiguredChannelPluginBlockers({
+      channels: {
+        discord: {
+          enabled: true,
+          token: "configured",
+        },
+      },
+    });
+
+    expect(hits).toEqual([
+      {
+        channelId: "discord",
+        pluginId: "discord",
+        reason: "missing explicit enablement",
+      },
+    ]);
+    expect(collectConfiguredChannelPluginBlockerWarnings(hits)).toEqual([
+      '- channels.discord: channel is configured, but external plugin "discord" is installed without explicit trust. Add plugins.entries.discord.enabled=true or include "discord" in plugins.allow. Fix plugin enablement before relying on setup guidance for this channel.',
+    ]);
   });
 
   it("still evaluates configured channels when plugins are disabled globally", () => {

--- a/src/commands/doctor/shared/channel-plugin-blockers.ts
+++ b/src/commands/doctor/shared/channel-plugin-blockers.ts
@@ -14,35 +14,13 @@ import { sanitizeForLog } from "../../../terminal/ansi.js";
 export type ChannelPluginBlockerHit = {
   channelId: string;
   pluginId: string;
-  reason: "disabled in config" | "plugins disabled";
+  reason: "disabled in config" | "plugins disabled" | "missing explicit enablement";
 };
-
-function hasExplicitChannelPluginBlockerConfig(cfg: OpenClawConfig): boolean {
-  if (cfg.plugins?.enabled === false) {
-    return true;
-  }
-  const entries = cfg.plugins?.entries;
-  if (!entries || typeof entries !== "object") {
-    return false;
-  }
-  return Object.values(entries).some((entry) => {
-    return (
-      entry &&
-      typeof entry === "object" &&
-      !Array.isArray(entry) &&
-      "enabled" in entry &&
-      (entry as { enabled?: unknown }).enabled === false
-    );
-  });
-}
 
 export function scanConfiguredChannelPluginBlockers(
   cfg: OpenClawConfig,
   env: NodeJS.ProcessEnv = process.env,
 ): ChannelPluginBlockerHit[] {
-  if (!hasExplicitChannelPluginBlockerConfig(cfg)) {
-    return [];
-  }
   const configuredChannelIds = new Set(
     listExplicitConfiguredChannelIdsForConfig(cfg)
       .map((channelId) => normalizeOptionalLowercaseString(channelId))
@@ -58,15 +36,19 @@ export function scanConfiguredChannelPluginBlockers(
     env,
     includeDisabled: true,
   });
+  const presencePolicy = resolveConfiguredChannelPresencePolicy({
+    config: cfg,
+    env,
+    includePersistedAuthState: false,
+    manifestRecords: registry.plugins,
+  });
   const activeConfiguredChannelIds = new Set(
-    resolveConfiguredChannelPresencePolicy({
-      config: cfg,
-      env,
-      includePersistedAuthState: false,
-      manifestRecords: registry.plugins,
-    })
-      .filter((entry) => entry.effective)
-      .map((entry) => entry.channelId),
+    presencePolicy.filter((entry) => entry.effective).map((entry) => entry.channelId),
+  );
+  const blockedReasonsByChannelId = new Map(
+    presencePolicy
+      .filter((entry) => !entry.effective)
+      .map((entry) => [entry.channelId, new Set(entry.blockedReasons)] as const),
   );
   const hits: ChannelPluginBlockerHit[] = [];
 
@@ -110,6 +92,38 @@ export function scanConfiguredChannelPluginBlockers(
     }
   }
 
+  const channelsWithExplicitBlockerHits = new Set(hits.map((hit) => hit.channelId));
+
+  for (const plugin of registry.plugins) {
+    if (plugin.origin === "bundled" || plugin.channels.length === 0) {
+      continue;
+    }
+
+    for (const rawChannelId of plugin.channels) {
+      const channelId = normalizeOptionalLowercaseString(rawChannelId);
+      if (!channelId) {
+        continue;
+      }
+      if (!configuredChannelIds.has(channelId)) {
+        continue;
+      }
+      if (channelsWithExplicitBlockerHits.has(channelId)) {
+        continue;
+      }
+      if (activeConfiguredChannelIds.has(channelId)) {
+        continue;
+      }
+      if (!blockedReasonsByChannelId.get(channelId)?.has("untrusted-plugin")) {
+        continue;
+      }
+      hits.push({
+        channelId,
+        pluginId: plugin.id,
+        reason: "missing explicit enablement",
+      });
+    }
+  }
+
   return hits;
 }
 
@@ -119,6 +133,9 @@ function formatReason(hit: ChannelPluginBlockerHit): string {
   }
   if (hit.reason === "plugins disabled") {
     return `plugins.enabled=false blocks channel plugins globally.`;
+  }
+  if (hit.reason === "missing explicit enablement") {
+    return `external plugin "${sanitizeForLog(hit.pluginId)}" is installed without explicit trust. Add plugins.entries.${sanitizeForLog(hit.pluginId)}.enabled=true or include "${sanitizeForLog(hit.pluginId)}" in plugins.allow.`;
   }
   return `plugin "${sanitizeForLog(hit.pluginId)}" is not loadable (${sanitizeForLog(hit.reason)}).`;
 }


### PR DESCRIPTION
## Summary
- Scan configured channel plugin blockers whenever a concrete channel surface is configured, even when there is no explicit `plugins.enabled=false` or `plugins.entries.*.enabled=false` blocker.
- Use `resolveConfiguredChannelPresencePolicy(...)` to detect installed external channel plugins blocked by missing explicit trust.
- Add a Discord regression that points users to `plugins.entries.discord.enabled=true` or `plugins.allow` instead of silently omitting the setup blocker.

Fixes #83212

## Real behavior proof
Behavior addressed: `channels.discord` can be configured while the external Discord plugin is installed but not explicitly trusted/enabled. In that state the channel remains ineffective via the existing `untrusted-plugin` policy, but doctor/setup guidance did not emit a channel plugin blocker. This keeps the explicit trust boundary and adds an actionable warning for that missing trust case.
Real environment tested: Local OpenClaw worktree on macOS, based on `openclaw/openclaw@bacc18a575ebbd12d83dd68d25e5b660c6045d26`, with Node/Vitest dependencies from `pnpm install --frozen-lockfile --ignore-scripts`.
Exact steps or command run after this patch:
- `OPENCLAW_TEST_PROJECTS_SERIAL=1 OPENCLAW_VITEST_MAX_WORKERS=1 RAYON_NUM_THREADS=1 TOKIO_WORKER_THREADS=1 CI=1 node scripts/run-vitest.mjs run src/commands/doctor/shared/channel-plugin-blockers.test.ts`
- `OPENCLAW_TEST_PROJECTS_SERIAL=1 OPENCLAW_VITEST_MAX_WORKERS=1 RAYON_NUM_THREADS=1 TOKIO_WORKER_THREADS=1 CI=1 node scripts/run-vitest.mjs run src/commands/doctor/shared/preview-warnings.test.ts src/plugins/channel-plugin-ids.test.ts src/commands/status-all/channels.test.ts`
- `git diff --check -- src/commands/doctor/shared/channel-plugin-blockers.ts src/commands/doctor/shared/channel-plugin-blockers.test.ts`
- `OPENCLAW_TEST_PROJECTS_SERIAL=1 OPENCLAW_VITEST_MAX_WORKERS=1 RAYON_NUM_THREADS=1 TOKIO_WORKER_THREADS=1 CI=1 pnpm --config.verify-deps-before-run=false check:changed src/commands/doctor/shared/channel-plugin-blockers.ts src/commands/doctor/shared/channel-plugin-blockers.test.ts`
Evidence after fix: Terminal output showed `channel-plugin-blockers.test.ts` passed 6 tests, including `reports external channel plugins that are installed but not explicitly enabled`; the related preview/channel/status tests passed 132 tests; `git diff --check` exited 0; and `check:changed` completed successfully with core/core-test typechecks, lint, and runtime guards green.
Observed result after fix: The new regression returns a blocker hit for configured Discord with an installed external `discord` plugin lacking explicit trust: `{ channelId: "discord", pluginId: "discord", reason: "missing explicit enablement" }`. The warning now tells users to add `plugins.entries.discord.enabled=true` or include `"discord"` in `plugins.allow` before relying on setup guidance for that channel.
What was not tested: The entire repository-wide test suite was not run; validation was limited to the focused doctor/channel/plugin tests above plus the changed-file gate.
