### PR TITLE
fix(telegram): stamp bot api user agent

### DIFF
--- a/extensions/telegram/src/fetch.test.ts
+++ b/extensions/telegram/src/fetch.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { resolveFetch } from "openclaw/plugin-sdk/fetch-runtime";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import telegramPackageJson from "../package.json" with { type: "json" };
 
 const setDefaultResultOrder = vi.hoisted(() => vi.fn());
 const getDefaultResultOrder = vi.hoisted(() => vi.fn(() => "ipv4first"));
@@ -14,6 +15,7 @@ const loggerWarn = vi.hoisted(() => vi.fn());
 const undiciFetch = vi.hoisted(() => vi.fn());
 const setGlobalDispatcher = vi.hoisted(() => vi.fn());
 const TEST_UNDICI_RUNTIME_DEPS_KEY = "__OPENCLAW_TEST_UNDICI_RUNTIME_DEPS__";
+const EXPECTED_TELEGRAM_USER_AGENT = `OpenClawBot/${telegramPackageJson.version}`;
 type MockDispatcherInstance = {
   options?: Record<string, unknown> | string;
   destroy: ReturnType<typeof vi.fn>;
@@ -185,6 +187,14 @@ function getDispatcherFromUndiciCall(nth: number) {
     throw new Error(`missing dispatcher for undici fetch call #${nth}`);
   }
   return dispatcher;
+}
+
+function getHeadersFromUndiciCall(nth: number): Headers {
+  const call = undiciFetch.mock.calls[nth - 1] as [RequestInfo | URL, RequestInit?] | undefined;
+  if (!call) {
+    throw new Error(`missing undici fetch call #${nth}`);
+  }
+  return new Headers(call[1]?.headers);
 }
 
 function constructorOptions(ctor: ReturnType<typeof vi.fn>, label: string): unknown {
@@ -392,13 +402,19 @@ describe("resolveTelegramFetch", () => {
     expect(undiciFetch).not.toHaveBeenCalled();
   });
 
-  it("does not double-wrap an already wrapped proxy fetch", () => {
-    const proxyFetch = vi.fn(async () => ({ ok: true }) as Response) as unknown as typeof fetch;
+  it("wraps an already wrapped proxy fetch only at the Telegram header boundary", async () => {
+    const proxyFetchMock = vi.fn(async () => ({ ok: true }) as Response);
+    const proxyFetch = proxyFetchMock as unknown as typeof fetch;
     const wrapped = resolveFetch(proxyFetch);
 
     const resolved = resolveTelegramFetch(wrapped);
 
-    expect(resolved).toBe(wrapped);
+    expect(resolved).not.toBe(wrapped);
+    await resolved("https://api.telegram.org/botx/getMe");
+
+    expect(proxyFetchMock).toHaveBeenCalledTimes(1);
+    const proxyCall = proxyFetchMock.mock.calls[0] as unknown as [RequestInfo | URL, RequestInit?];
+    expect(new Headers(proxyCall[1]?.headers).get("User-Agent")).toBe(EXPECTED_TELEGRAM_USER_AGENT);
   });
 
   it("uses resolver-scoped Agent dispatcher with configured transport policy", async () => {
@@ -421,6 +437,38 @@ describe("resolveTelegramFetch", () => {
     expect(dispatcher?.options?.connect?.autoSelectFamily).toBe(true);
     expect(dispatcher?.options?.connect?.autoSelectFamilyAttemptTimeout).toBe(300);
     expect(typeof dispatcher?.options?.connect?.lookup).toBe("function");
+  });
+
+  it("stamps a versioned OpenClaw User-Agent on Telegram Bot API requests", async () => {
+    undiciFetch.mockResolvedValue({ ok: true } as Response);
+
+    const resolved = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: false,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+
+    await resolved("https://api.telegram.org/botx/getMe");
+
+    expect(getHeadersFromUndiciCall(1).get("User-Agent")).toBe(EXPECTED_TELEGRAM_USER_AGENT);
+  });
+
+  it("preserves an explicitly supplied User-Agent", async () => {
+    undiciFetch.mockResolvedValue({ ok: true } as Response);
+
+    const resolved = resolveTelegramFetchOrThrow(undefined, {
+      network: {
+        autoSelectFamily: false,
+        dnsResultOrder: "ipv4first",
+      },
+    });
+
+    await resolved("https://api.telegram.org/botx/getMe", {
+      headers: { "User-Agent": "CustomTelegramClient/1.0" },
+    });
+
+    expect(getHeadersFromUndiciCall(1).get("User-Agent")).toBe("CustomTelegramClient/1.0");
   });
 
   it("emits default transport decisions at debug level", () => {
@@ -536,7 +584,8 @@ describe("resolveTelegramFetch", () => {
 
   it("preserves caller-provided custom fetch when OPENCLAW_PROXY_URL is present", async () => {
     vi.stubEnv("OPENCLAW_PROXY_URL", "http://127.0.0.1:7788");
-    const proxyFetch = vi.fn(async () => ({ ok: true }) as Response) as unknown as typeof fetch;
+    const proxyFetchMock = vi.fn(async () => ({ ok: true }) as Response);
+    const proxyFetch = proxyFetchMock as unknown as typeof fetch;
 
     const transport = resolveTelegramTransport(proxyFetch, {
       network: {
@@ -547,7 +596,9 @@ describe("resolveTelegramFetch", () => {
 
     await transport.fetch("https://api.telegram.org/botTOKEN/getMe");
 
-    expect(proxyFetch).toHaveBeenCalledTimes(1);
+    expect(proxyFetchMock).toHaveBeenCalledTimes(1);
+    const proxyCall = proxyFetchMock.mock.calls[0] as unknown as [RequestInfo | URL, RequestInit?];
+    expect(new Headers(proxyCall[1]?.headers).get("User-Agent")).toBe(EXPECTED_TELEGRAM_USER_AGENT);
     expect(undiciFetch).not.toHaveBeenCalled();
     expect(ProxyAgentCtor).not.toHaveBeenCalled();
     expect(EnvHttpProxyAgentCtor).not.toHaveBeenCalled();
@@ -636,8 +687,11 @@ describe("resolveTelegramFetch", () => {
     ).resolves.toEqual({ ok: true });
     expect(undiciFetch).toHaveBeenCalledWith(
       "https://api.telegram.org/botTOKEN/getFile",
-      undefined,
+      expect.objectContaining({
+        headers: expect.any(Headers),
+      }),
     );
+    expect(getHeadersFromUndiciCall(1).get("User-Agent")).toBe(EXPECTED_TELEGRAM_USER_AGENT);
     expect(transport.fetch).not.toBe(transport.sourceFetch);
     expect(transport.dispatcherAttempts).toHaveLength(3);
 

--- a/extensions/telegram/src/fetch.ts
+++ b/extensions/telegram/src/fetch.ts
@@ -19,6 +19,7 @@ import { resolveRequestUrl } from "openclaw/plugin-sdk/request-url";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { Agent, fetch as undiciFetch } from "undici";
+import telegramPackageJson from "../package.json" with { type: "json" };
 import { normalizeTelegramApiRoot } from "./api-root.js";
 import {
   resolveTelegramAutoSelectFamilyDecision,
@@ -47,6 +48,11 @@ const TELEGRAM_STICKY_FALLBACK_PRIMARY_PROBE_SUCCESS_THRESHOLD = 5;
 const TELEGRAM_TRANSPORT_ATTEMPT_FAILURE_THRESHOLD = 5;
 const TELEGRAM_TRANSPORT_ATTEMPT_INITIAL_COOLDOWN_MS = 10_000;
 const TELEGRAM_TRANSPORT_ATTEMPT_MAX_COOLDOWN_MS = 60_000;
+const TELEGRAM_PLUGIN_VERSION =
+  typeof telegramPackageJson.version === "string" && telegramPackageJson.version.trim().length > 0
+    ? telegramPackageJson.version.trim()
+    : "unknown";
+const TELEGRAM_BOT_USER_AGENT = `OpenClawBot/${TELEGRAM_PLUGIN_VERSION}`;
 
 type TelegramAgentPoolOptions = {
   allowH2: false;
@@ -576,6 +582,31 @@ async function destroyOwnedDispatchers(dispatchers: Iterable<TelegramDispatcher>
   );
 }
 
+function headersFromRequestInput(input: RequestInfo | URL): HeadersInit | undefined {
+  if (typeof Request !== "function" || !(input instanceof Request)) {
+    return undefined;
+  }
+  return input.headers;
+}
+
+function withTelegramUserAgent(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): RequestInitWithDispatcher {
+  const nextInit = { ...(init ?? {}) } as RequestInitWithDispatcher;
+  const headers = new Headers(init?.headers ?? headersFromRequestInput(input));
+  if (!headers.has("User-Agent")) {
+    headers.set("User-Agent", TELEGRAM_BOT_USER_AGENT);
+  }
+  nextInit.headers = headers;
+  return nextInit;
+}
+
+function wrapTelegramUserAgentFetch(sourceFetch: typeof fetch): typeof fetch {
+  return ((input: RequestInfo | URL, init?: RequestInit) =>
+    sourceFetch(input, withTelegramUserAgent(input, init))) as typeof fetch;
+}
+
 export function resolveTelegramTransport(
   proxyFetch?: typeof fetch,
   options?: { network?: TelegramNetworkConfig },
@@ -605,11 +636,12 @@ export function resolveTelegramTransport(
     !effectiveProxyFetch && !hasEnvProxy ? resolveOpenClawProxyUrlForTelegram() : undefined;
   const resolvedExplicitProxyUrl = explicitProxyUrl ?? managedProxyUrl;
   const undiciSourceFetch = resolveWrappedFetch(undiciFetch as unknown as typeof fetch);
-  const sourceFetch = resolvedExplicitProxyUrl
+  const rawSourceFetch = resolvedExplicitProxyUrl
     ? undiciSourceFetch
     : effectiveProxyFetch
       ? resolveWrappedFetch(effectiveProxyFetch)
       : undiciSourceFetch;
+  const sourceFetch = wrapTelegramUserAgentFetch(rawSourceFetch);
   const dnsResultOrder = normalizeDnsResultOrder(dnsDecision.value);
   if (effectiveProxyFetch && !explicitProxyUrl) {
     // The caller owns the underlying dispatcher lifecycle; nothing to close here.
@@ -764,13 +796,14 @@ export function resolveTelegramTransport(
     let err: unknown;
 
     if (callerProvidedDispatcher) {
+      const requestInit = withTelegramUserAgent(input, init);
       try {
-        const response = await sourceFetch(input, init);
+        const response = await rawSourceFetch(input, requestInit);
         captureHttpExchange({
           url: resolveRequestUrl(input),
-          method: init?.method ?? "GET",
-          requestHeaders: init?.headers as Headers | Record<string, string> | undefined,
-          requestBody: (init as RequestInit & { body?: BodyInit | null })?.body ?? null,
+          method: requestInit.method ?? "GET",
+          requestHeaders: requestInit.headers as Headers | Record<string, string> | undefined,
+          requestBody: requestInit.body ?? null,
           response,
           flowId: randomUUID(),
           meta: { subsystem: "telegram-fetch" },
@@ -780,7 +813,7 @@ export function resolveTelegramTransport(
         if (!shouldUseTelegramTransportFallback(caught)) {
           throw caught;
         }
-        return sourceFetch(input, init ?? {});
+        return rawSourceFetch(input, requestInit);
       }
     }
 
@@ -799,15 +832,16 @@ export function resolveTelegramTransport(
         continue;
       }
       try {
-        const response = await sourceFetch(
-          input,
-          withDispatcherIfMissing(init, attempt.createDispatcher()),
+        const requestInit = withDispatcherIfMissing(
+          withTelegramUserAgent(input, init),
+          attempt.createDispatcher(),
         );
+        const response = await rawSourceFetch(input, requestInit);
         captureHttpExchange({
           url: resolveRequestUrl(input),
-          method: init?.method ?? "GET",
-          requestHeaders: init?.headers as Headers | Record<string, string> | undefined,
-          requestBody: (init as RequestInit & { body?: BodyInit | null })?.body ?? null,
+          method: requestInit.method ?? "GET",
+          requestHeaders: requestInit.headers as Headers | Record<string, string> | undefined,
+          requestBody: requestInit.body ?? null,
           response,
           flowId: randomUUID(),
           meta:

--- a/extensions/telegram/src/fetch.ts
+++ b/extensions/telegram/src/fetch.ts
@@ -593,7 +593,7 @@ function withTelegramUserAgent(
   input: RequestInfo | URL,
   init?: RequestInit,
 ): RequestInitWithDispatcher {
-  const nextInit = { ...(init ?? {}) } as RequestInitWithDispatcher;
+  const nextInit = { ...init } as RequestInitWithDispatcher;
   const headers = new Headers(init?.headers ?? headersFromRequestInput(input));
   if (!headers.has("User-Agent")) {
     headers.set("User-Agent", TELEGRAM_BOT_USER_AGENT);


### PR DESCRIPTION
Fixes #80446.

## Summary

- Stamps Telegram Bot API outbound fetches with a stable versioned `User-Agent` of `OpenClawBot/<telegram-plugin-version>` when callers have not explicitly provided one.
- Applies the header at the Telegram transport boundary, including direct `transport.sourceFetch` media-download callers and custom proxy fetches.
- Preserves existing proxy selection, dispatcher fallback, abort wrapping, caller-provided dispatchers, and explicit caller `User-Agent` headers.

## Problem summary

Telegram requests were allowed to fall through to the runtime fetch default User-Agent. For Node/undici transports that creates a low-cardinality runtime fingerprint, which the issue reports as a trigger for ISP throttling during sustained Telegram operation.

## Root cause

`resolveTelegramTransport` selected either undici fetch or a caller proxy fetch as the transport source, then called it without normalizing request headers. When no caller header was present, the underlying runtime supplied its own generic default.

## Architectural reasoning

The fix stays inside `extensions/telegram/src/fetch.ts`, which already owns Telegram Bot API transport, proxy dispatchers, sticky fallback, and media-download source fetches. Core fetch behavior and other plugins are unchanged. The wrapper clones request init, preserves dispatcher/body/method/signal fields, uses request-object headers as a base when present, and only supplies OpenClaw's Telegram User-Agent if no caller User-Agent exists.

## Testing performed

Local proof on refreshed head `5aed0e8180aee13f7d71ef6ede5ea0a38c686691`:

- `pnpm test extensions/telegram/src/fetch.test.ts -- --reporter=verbose` passed: 39/39.
- `pnpm format:check -- extensions/telegram/src/fetch.ts extensions/telegram/src/fetch.test.ts`
- `pnpm check:changed`
- `pnpm lint --threads=8`
- `./node_modules/.bin/oxlint -c .oxlintrc.json extensions/telegram/src/fetch.ts extensions/telegram/src/fetch.test.ts`
- `git diff --check upstream/main..HEAD`
- Local HTTP capture through production `resolveTelegramTransport()` verified default User-Agent stamping and explicit User-Agent preservation.

GitHub Actions on `5aed0e8180aee13f7d71ef6ede5ea0a38c686691`:

- Workflow Sanity #201567: success
- OpenGrep PR Diff #21202: success
- CI #207281: success
- CodeQL Critical Quality #17158: success

## Real behavior proof

Behavior addressed: Telegram Bot API requests created through the Telegram transport no longer rely on the undici/runtime default User-Agent when no caller User-Agent is supplied.

Real environment tested: Local OpenClaw source checkout on Windows, Node v22.15.0 with the repository's existing engine warning, using the production Telegram transport against a real local HTTP server plus the focused Telegram transport unit tests. The branch was rebased onto upstream/main `6baa2b38b2712384d7de460d90b127cd78dbb3a5`; upstream moved to `bc4f27c89a3c5aa40b7fb9e507a91b6e6c753307` while checks ran, and GitHub reported the PR mergeable against the live base after push.

Exact steps or command run after this patch: Started a local HTTP server, invoked production `resolveTelegramTransport().fetch()` against it once without caller headers and once with an explicit `User-Agent`, then captured the request headers received by the server.

Evidence after fix:

```json
{
  "defaultUserAgent": "OpenClawBot/2026.5.17",
  "explicitUserAgent": "CustomProbe/1.0",
  "requestCount": 2
}
```

Observed result after fix: The production transport sends the versioned OpenClaw User-Agent when the caller leaves it absent, and preserves an explicit caller User-Agent unchanged. The focused tests also cover default Bot API fetch, direct media source fetch, custom proxy fetch, dispatcher preservation, fallback behavior, and cleanup lifecycle.

What was not tested: Live Telegram credentials and the reporter's ISP throttling path were not available locally. The local HTTP capture exercises the production transport/header path without secrets.

## Risk analysis

Risk is low. The behavior change is limited to Telegram outbound HTTP headers and only fills in a missing User-Agent. Existing explicit caller headers still win, so custom Bot API proxies can keep their own header policy. Dispatcher fallback and cleanup lifecycle stay on the existing path.

## Backward compatibility

Backward compatible. No config, schema, Gateway protocol, or public plugin SDK surface changes. Existing callers still receive the same transport shape, with request headers enriched only when absent.