### PR TITLE
fix(reply): use channel-neutral direct-chat context in CLI reuse hash (#83250)

### DIFF
--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -75,6 +75,7 @@ vi.mock("./body.js", () => ({
 
 vi.mock("./groups.js", () => ({
   buildDirectChatContext: vi.fn().mockReturnValue(""),
+  buildDirectChatContextForReuseHash: vi.fn().mockReturnValue(""),
   buildGroupIntro: vi.fn().mockReturnValue(""),
   buildGroupChatContext: vi.fn().mockReturnValue(""),
   resolveGroupSilentReplyBehavior: vi.fn(

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -60,6 +60,7 @@ import { shouldUseReplyFastTestRuntime } from "./get-reply-fast-path.js";
 import { resolvePreparedReplyQueueState } from "./get-reply-run-queue.js";
 import {
   buildDirectChatContext,
+  buildDirectChatContextForReuseHash,
   buildGroupChatContext,
   buildGroupIntro,
   resolveGroupSilentReplyBehavior,
@@ -539,8 +540,19 @@ export async function runPreparedReply(
     }),
   ].filter(Boolean);
   // Static parts only (no per-message inbound metadata) for CLI session reuse hashing.
+  // #83250: substitute the channel-neutral direct-chat context here. The live
+  // prompt above still carries the real provider label, but under
+  // `session.dmScope:"main"` one CLI binding can serve direct messages from
+  // multiple channels — and the provider token flipping between e.g.
+  // "Telegram" and "WebChat" was the entire cause of the spurious
+  // `reuse=invalidated:system-prompt` resets on channel switch.
+  const directChatContextForReuseHash = isDirectChat
+    ? buildDirectChatContextForReuseHash({
+        sourceReplyDeliveryMode: opts?.sourceReplyDeliveryMode,
+      })
+    : "";
   const extraSystemPromptStaticParts = [
-    directChatContext,
+    directChatContextForReuseHash,
     groupChatContext,
     groupIntro,
     groupSystemPrompt,

--- a/src/auto-reply/reply/groups.test.ts
+++ b/src/auto-reply/reply/groups.test.ts
@@ -63,6 +63,44 @@ describe("group runtime loading", () => {
     vi.doUnmock("./groups.runtime.js");
   });
 
+  it("emits channel-neutral reuse-hash direct chat context across providers (#83250)", () => {
+    // The live prompt carries the real provider label and so flips between
+    // channels:
+    const telegramLive = groups.buildDirectChatContext({
+      sessionCtx: { ChatType: "direct", Provider: "telegram" },
+    });
+    const webchatLive = groups.buildDirectChatContext({
+      sessionCtx: { ChatType: "direct", Provider: "webchat" },
+    });
+    expect(telegramLive).toContain("Telegram");
+    expect(webchatLive).toContain("WebChat");
+    expect(telegramLive).not.toBe(webchatLive);
+
+    // The reuse-hash variant MUST be byte-identical regardless of provider,
+    // so a `session.dmScope:"main"` CLI binding's extraSystemPromptHash does
+    // not flip on channel switch.
+    const telegramHash = groups.buildDirectChatContextForReuseHash({});
+    const webchatHash = groups.buildDirectChatContextForReuseHash({});
+    expect(telegramHash).toBe(webchatHash);
+    expect(telegramHash).not.toContain("Telegram");
+    expect(telegramHash).not.toContain("WebChat");
+    expect(telegramHash).toContain("direct conversation");
+
+    // sourceReplyDeliveryMode parity is preserved between the live builder
+    // and the reuse-hash builder (so the hash still reflects message-tool
+    // mode changes, which are legitimate identity differences):
+    const liveToolOnly = groups.buildDirectChatContext({
+      sessionCtx: { ChatType: "direct", Provider: "telegram" },
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+    const hashToolOnly = groups.buildDirectChatContextForReuseHash({
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+    expect(liveToolOnly).toContain("message tool with action=send");
+    expect(hashToolOnly).toContain("message tool with action=send");
+    expect(hashToolOnly).not.toBe(telegramHash);
+  });
+
   it("builds direct chat context without silent-token guidance", () => {
     expect(
       groups.buildDirectChatContext({

--- a/src/auto-reply/reply/groups.ts
+++ b/src/auto-reply/reply/groups.ts
@@ -281,9 +281,42 @@ export function buildDirectChatContext(params: {
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
 }): string {
   const providerLabel = resolveProviderLabel(params.sessionCtx.Provider);
+  return renderDirectChatContext({
+    providerLabel,
+    sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+  });
+}
+
+/**
+ * Channel-neutral variant of {@link buildDirectChatContext} for inclusion in
+ * the CLI session reuse hash. See #83250: under `session.dmScope:"main"`, a
+ * single CLI session binding can serve direct messages from multiple
+ * channels. The live prompt should still carry the real provider label, but
+ * the reuse-hash identity must not flip between e.g. "Telegram" and "WebChat"
+ * on the same logical DM — otherwise every channel switch invalidates the
+ * session with `reason=system-prompt` and wipes conversational context.
+ *
+ * Sibling of the #82812 mitigation that excluded per-turn `inboundMetaPrompt`
+ * from the hash; this excludes the provider token from the channel context.
+ */
+export function buildDirectChatContextForReuseHash(params: {
+  sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
+}): string {
+  return renderDirectChatContext({
+    providerLabel: REUSE_HASH_PROVIDER_LABEL,
+    sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
+  });
+}
+
+const REUSE_HASH_PROVIDER_LABEL = "chat";
+
+function renderDirectChatContext(params: {
+  providerLabel: string;
+  sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
+}): string {
   const messageToolOnly = params.sourceReplyDeliveryMode === "message_tool_only";
   const lines: string[] = [];
-  lines.push(`You are in a ${providerLabel} direct conversation.`);
+  lines.push(`You are in a ${params.providerLabel} direct conversation.`);
   if (messageToolOnly) {
     lines.push(
       "Normal final replies are private and are not automatically sent to this conversation. To post visible output here, use the message tool with action=send; the target defaults to this conversation.",


### PR DESCRIPTION
Fixes #83250.

`extraSystemPromptStaticParts` (in `src/auto-reply/reply/get-reply-run.ts`) feeds the CLI session reuse hash via `extraSystemPromptHash = hashCliSessionText(...)`. The #82812 mitigation correctly excluded per-turn `inboundMetaPrompt` from that input, but one of the remaining "static" parts — `directChatContext` from `buildDirectChatContext()` in `src/auto-reply/reply/groups.ts` — embeds the channel/provider label (`"Telegram"`, `"WebChat"`, …).

Under `session.dmScope:"main"`, a single CLI binding serves direct messages from multiple channels. Alternating the delivery channel of one logical DM flips the provider token in `directChatContext`, which changes `extraSystemPromptHash`. `resolveCliSessionReuse` then returns `invalidatedReason: "system-prompt"` and `reuse=invalidated:system-prompt` with `historyPrompt=none` — a total context wipe on every channel switch.

This patch applies option (a) from the issue's suggested directions: keep the live system prompt's channel context (UX preserved), but feed a channel-neutral variant into the reuse-hash input only.

## Changes

- `src/auto-reply/reply/groups.ts`: factor `renderDirectChatContext` out of `buildDirectChatContext` and add a sibling `buildDirectChatContextForReuseHash` that injects the literal `"chat"` provider label. The original export is unchanged.
- `src/auto-reply/reply/get-reply-run.ts`: substitute `buildDirectChatContextForReuseHash(...)` for `directChatContext` inside `extraSystemPromptStaticParts` only. The full prompt above still carries the real provider label.
- `src/auto-reply/reply/groups.test.ts`: 1 new regression case asserting (a) live variants differ across channels, (b) reuse-hash variants are byte-identical across channels, (c) `message_tool_only` mode parity is preserved in both builders, (d) the reuse-hash output does not contain `"Telegram"` or `"WebChat"`.

## Real behavior proof

- **Behavior or issue addressed:** With `session.dmScope:"main"`, switching the delivery channel of one logical DM invalidates the CLI session every turn (`reuse=invalidated:system-prompt`, `historyPrompt=none`). Root cause: `buildDirectChatContext` puts the provider token (`"Telegram"`/`"WebChat"`) into `extraSystemPromptStaticParts`, which feeds the reuse hash.

- **Real environment tested:** Local Node 22.x (`node --version` reports v22.x). Probe at `/tmp/probe_83250.mjs` replays the exact `resolveProviderLabel` / `renderDirectChatContext` / `buildDirectChatContext` / `buildDirectChatContextForReuseHash` functions from the patched `groups.ts` and hashes the result with `node:crypto` `createHash("sha256")`. No mocks.

- **Exact steps or command run after this patch:** `node /tmp/probe_83250.mjs`

- **Evidence after fix:**

```
Live Telegram: You are in a Telegram direct conversation. Your replies are automatically sent to this conversation.
Live WebChat:  You are in a WebChat direct conversation. Your replies are automatically sent to this conversation.
Live identical: false

Reuse-hash Telegram: You are in a chat direct conversation. Your replies are automatically sent to this conversation.
Reuse-hash WebChat:  You are in a chat direct conversation. Your replies are automatically sent to this conversation.
Reuse-hash identical: true
sha-input(hash variant) Telegram: f403f0256ed05c8d
sha-input(hash variant) WebChat:  f403f0256ed05c8d

OLD-CODE sha-input(live variant) Telegram: 00e0a0c0f9ac7374
OLD-CODE sha-input(live variant) WebChat:  f4ec1ef8a151aba5
OLD-CODE hashes differ (the bug): true

ALL CASES PASS
- live prompts retain provider label (UX preserved)
- reuse-hash variant is channel-neutral (bug fixed)
- old code produced different hashes per channel (root cause confirmed)
- message_tool_only mode parity preserved in both variants
```

- **Observed result after fix:** `extraSystemPromptHash` is identical for the same logical DM across delivery channels (Telegram ↔ WebChat), so `resolveCliSessionReuse` no longer trips the `system-prompt` invalidation path. Provider-specific UX in the *live* prompt is unchanged — the live `buildDirectChatContext` still emits `"You are in a Telegram direct conversation."` etc.

- **What was not tested:** End-to-end with a running OpenClaw gateway + actual `claude-cli` resume flow + dual-channel binding under `session.dmScope:"main"` (no gateway+claude-cli available in this environment). The unit-test layer covers the channel-neutrality invariant; the probe demonstrates the exact hash-input divergence that the issue's logs (`cli session reset: reason=system-prompt`) describe.

## Audit (per CLAUDE rules)

- **Existing-helper check:** No new predicate/validator. The new function `buildDirectChatContextForReuseHash` *re-uses* the shared `renderDirectChatContext` factored out of the existing builder. PASS
- **Shared-helper caller check:** `buildDirectChatContext` is only imported by `src/auto-reply/reply/get-reply-run.ts` and `src/auto-reply/reply/groups.test.ts` (verified via grep). Its export signature is unchanged. PASS
- **Broader-fix rival scan:** No open PRs touching `directChatContext` / `extraSystemPromptStaticParts` / `resolveProviderLabel` as of branch SHA. PASS

## Followup (not in this PR, mentioned for the record)

`buildGroupChatContext` embeds the same provider label (`"You are in a ${providerLabel} group chat."`). If `session.dmScope:"main"`-style collapse is ever extended to group routes, the same fix shape (channel-neutral group context in the reuse hash) will be needed. Out of scope for #83250 which is direct-conversation-specific.
