### PR TITLE
fix(update): keep gateway recovery guidance platform-specific

### DIFF
--- a/src/cli/update-cli/update-command.test.ts
+++ b/src/cli/update-cli/update-command.test.ts
@@ -362,10 +362,9 @@ describe("formatPostUpdateGatewayRecoveryInstructions", () => {
   it("uses systemd wording on Linux instead of macOS LaunchAgent instructions", () => {
     const [line] = formatPostUpdateGatewayRecoveryInstructions(result, "linux");
 
-    expect(line).toContain("the systemd user service");
-    expect(line).toContain("openclaw gateway restart");
-    expect(line).toContain("openclaw gateway install --force");
-    expect(line).toContain("openclaw gateway status --deep");
+    expect(line).toBe(
+      "Recovery: run `openclaw gateway restart`; if the systemd user service is missing, stale, or not active, run `openclaw gateway install --force` from the same user account, then rerun `openclaw gateway status --deep`.",
+    );
     expect(line).not.toContain("Linux reports");
     expect(line).not.toContain("macOS");
     expect(line).not.toContain("LaunchAgent");
@@ -374,14 +373,18 @@ describe("formatPostUpdateGatewayRecoveryInstructions", () => {
   it("keeps LaunchAgent recovery wording on macOS", () => {
     const [line] = formatPostUpdateGatewayRecoveryInstructions(result, "darwin");
 
-    expect(line).toContain("the LaunchAgent is installed but not loaded");
-    expect(line).toContain("logged-in macOS user session");
+    expect(line).toBe(
+      "Recovery: run `openclaw gateway restart`; if the LaunchAgent is installed but not loaded, run `openclaw gateway install --force` from the logged-in macOS user session, then rerun `openclaw gateway status --deep`.",
+    );
+    expect(line).not.toContain("macOS reports");
   });
 
   it("uses Windows service-manager wording on Windows", () => {
     const [line] = formatPostUpdateGatewayRecoveryInstructions(result, "win32");
 
-    expect(line).toContain("the gateway Scheduled Task or Windows login item");
+    expect(line).toBe(
+      "Recovery: run `openclaw gateway restart`; if the gateway Scheduled Task or Windows login item is missing, stale, or not running, run `openclaw gateway install --force` from the same user account, then rerun `openclaw gateway status --deep`.",
+    );
     expect(line).not.toContain("LaunchAgent");
     expect(line).not.toContain("Startup-folder");
   });
@@ -389,7 +392,10 @@ describe("formatPostUpdateGatewayRecoveryInstructions", () => {
   it("uses generic service-manager wording for unsupported Node platforms", () => {
     const [line] = formatPostUpdateGatewayRecoveryInstructions(result, "freebsd");
 
-    expect(line).toContain("local service manager");
+    expect(line).toBe(
+      "Recovery: run `openclaw gateway restart`; if the local gateway service is missing, stale, or not running, run `openclaw gateway install --force` from the same user account, then rerun `openclaw gateway status --deep`.",
+    );
+    expect(line).not.toContain("reports");
     expect(line).not.toContain("systemd");
     expect(line).not.toContain("LaunchAgent");
     expect(line).not.toContain("Scheduled Task");

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -703,6 +703,33 @@ export async function recoverLaunchAgentAndRecheckGatewayHealth(params: {
   return { health, launchAgentRecovery };
 }
 
+type PostUpdateGatewayRecoveryCopy = {
+  condition: string;
+  installContext: string;
+};
+
+const POST_UPDATE_GATEWAY_RECOVERY_COPY: Partial<
+  Record<NodeJS.Platform, PostUpdateGatewayRecoveryCopy>
+> = {
+  darwin: {
+    condition: "the LaunchAgent is installed but not loaded",
+    installContext: "the logged-in macOS user session",
+  },
+  linux: {
+    condition: "the systemd user service is missing, stale, or not active",
+    installContext: "the same user account",
+  },
+  win32: {
+    condition: "the gateway Scheduled Task or Windows login item is missing, stale, or not running",
+    installContext: "the same user account",
+  },
+};
+
+const FALLBACK_POST_UPDATE_GATEWAY_RECOVERY_COPY: PostUpdateGatewayRecoveryCopy = {
+  condition: "the local gateway service is missing, stale, or not running",
+  installContext: "the same user account",
+};
+
 function formatPostUpdateGatewayRecoveryLine(platform: NodeJS.Platform): string {
   const restartCommand = replaceCliName(formatCliCommand("openclaw gateway restart"), CLI_NAME);
   const installCommand = replaceCliName(
@@ -713,16 +740,9 @@ function formatPostUpdateGatewayRecoveryLine(platform: NodeJS.Platform): string 
     formatCliCommand("openclaw gateway status --deep"),
     CLI_NAME,
   );
-  if (platform === "darwin") {
-    return `Recovery: run \`${restartCommand}\`; if the LaunchAgent is installed but not loaded, run \`${installCommand}\` from the logged-in macOS user session, then rerun \`${statusCommand}\`.`;
-  }
-  if (platform === "linux") {
-    return `Recovery: run \`${restartCommand}\`; if the systemd user service is missing, stale, or not active, run \`${installCommand}\` from the same user account, then rerun \`${statusCommand}\`.`;
-  }
-  if (platform === "win32") {
-    return `Recovery: run \`${restartCommand}\`; if the gateway Scheduled Task or Windows login item is missing, stale, or not running, run \`${installCommand}\` from the same user account, then rerun \`${statusCommand}\`.`;
-  }
-  return `Recovery: run \`${restartCommand}\`; if the local service manager reports the gateway service is missing, stale, or not running, run \`${installCommand}\` from the same user account, then rerun \`${statusCommand}\`.`;
+  const copy =
+    POST_UPDATE_GATEWAY_RECOVERY_COPY[platform] ?? FALLBACK_POST_UPDATE_GATEWAY_RECOVERY_COPY;
+  return `Recovery: run \`${restartCommand}\`; if ${copy.condition}, run \`${installCommand}\` from ${copy.installContext}, then rerun \`${statusCommand}\`.`;
 }
 
 export function formatPostUpdateGatewayRecoveryInstructions(


### PR DESCRIPTION
## Summary

- Problem: `openclaw update` recovery output can be shown on non-macOS machines, so the bug to guard against is an Ubuntu/VPS operator seeing macOS LaunchAgent recovery guidance.
- Why it matters: these are copy-paste recovery commands. Platform-specific service-manager wording must stay tied to the actual Node platform instead of leaking macOS instructions into Ubuntu, Windows, or fallback output.
- What changed: centralize the per-platform recovery condition and install context in a typed lookup table, remove the fallback "reports" wording, and assert the complete emitted recovery line for each supported platform plus the unsupported Node-platform fallback.
- What did NOT change (scope boundary): no restart/install/rollback behavior changed; no new config, flags, env vars, or platform support was added.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #83096
- Related #83191
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: post-update Gateway recovery output stays platform-specific, so the Linux/Ubuntu path emits systemd user-service guidance and does not mention macOS or LaunchAgent.
- Real environment tested: Linux PR worktree at `1f4f8cfe36c89f18f4a63ee1689d2e177e0e9c80`; `uname -a` reported `Linux rubencu-devbox 6.8.0-90-generic #91-Ubuntu SMP PREEMPT_DYNAMIC Tue Nov 18 14:14:30 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux`.
- Exact steps or command run after this patch: `node_modules/.bin/tsx <<'TS' ... formatPostUpdateGatewayRecoveryInstructions(result, platform) for linux, darwin, win32, and one unsupported Node-platform fallback sample ... TS`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
linux: Recovery: run `openclaw gateway restart`; if the systemd user service is missing, stale, or not active, run `openclaw gateway install --force` from the same user account, then rerun `openclaw gateway status --deep`.
darwin: Recovery: run `openclaw gateway restart`; if the LaunchAgent is installed but not loaded, run `openclaw gateway install --force` from the logged-in macOS user session, then rerun `openclaw gateway status --deep`.
win32: Recovery: run `openclaw gateway restart`; if the gateway Scheduled Task or Windows login item is missing, stale, or not running, run `openclaw gateway install --force` from the same user account, then rerun `openclaw gateway status --deep`.
unsupported fallback sample (`freebsd`, not a supported OpenClaw platform): Recovery: run `openclaw gateway restart`; if the local gateway service is missing, stale, or not running, run `openclaw gateway install --force` from the same user account, then rerun `openclaw gateway status --deep`.
```

- Observed result after fix: the Linux/Ubuntu path uses systemd wording and does not include `macOS`, `LaunchAgent`, `macOS reports`, or `Linux reports`; the unsupported fallback does not include `local service manager reports`.
- What was not tested: full package update plus forced Gateway health failure on macOS/Windows; this proof exercises the production formatter directly from the PR head without mutating a managed Gateway install.
- Before evidence (optional but encouraged): #83191 removed the original cross-platform macOS recovery sentence; this follow-up keeps that actual bug centered by locking the complete emitted lines and tightening the remaining fallback wording.

## Root Cause (if applicable)

- Root cause: the original bug came from a single macOS LaunchAgent recovery sentence being reused for all platforms.
- Missing detection / guardrail: tests did not assert the complete emitted line for each platform, which made it easier for stale macOS wording to reappear outside macOS.
- Contributing context (if known): #83191 made the output platform-aware; this follow-up keeps the platform copy in one table and strengthens the exact-line guardrail.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cli/update-cli/update-command.test.ts`.
- Scenario the test should lock in: the Linux/Ubuntu path emits systemd guidance with no macOS/LaunchAgent text, while macOS, Windows, and the unsupported fallback path emit their own exact expected recovery lines.
- Why this is the smallest reliable guardrail: the affected behavior is a pure formatter, so direct unit coverage catches copy drift without running a real Gateway update.
- Existing test that already covers this (if any): `formatPostUpdateGatewayRecoveryInstructions` coverage added by #83191, strengthened here.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

The Linux/Ubuntu recovery line remains systemd-specific and is now exact-line tested against macOS/LaunchAgent leakage. Unsupported Node platforms now say `if the local gateway service is missing, stale, or not running` instead of `if the local service manager reports the gateway service is missing, stale, or not running`.

## Diagram (if applicable)

N/A.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 local PR worktree
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run `pnpm install` because the fresh worktree had no local dependencies.
2. Run `node_modules/.bin/oxfmt --check --threads=1 src/cli/update-cli/update-command.ts src/cli/update-cli/update-command.test.ts`.
3. Run `git diff --check`.
4. Run `node scripts/run-vitest.mjs src/cli/update-cli/update-command.test.ts`.
5. Run the formatter through `node_modules/.bin/tsx` for Linux, macOS, Windows, and unsupported fallback output.
6. Run `codex review --base origin/main`.

### Expected

- Recovery copy stays platform-specific; Linux/Ubuntu output uses systemd guidance and avoids macOS/LaunchAgent text.

### Actual

- Formatter output matched the expected platform-specific copy; focused tests passed; Codex review reported no correctness issue.

## Evidence

- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: exact Linux/Ubuntu, macOS, Windows, and unsupported fallback recovery formatter output from the local PR head; focused formatter/unit tests; formatting and whitespace checks.
- Edge cases checked: unsupported Node-platform fallback via `freebsd` as a sample fallback value, not as a supported OpenClaw platform; absence of stale `macOS`, `LaunchAgent`, `macOS reports`, `Linux reports`, and `local service manager reports` strings from the Linux/fallback recovery paths.
- What you did **not** verify: a destructive full update/restart failure on a production Gateway service.
