### PR TITLE
feat(admin-http-rpc): allow web QR login methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 - Docker/Podman: add `OPENCLAW_IMAGE_APT_PACKAGES` as the runtime-neutral image build arg for extra apt packages while keeping `OPENCLAW_DOCKER_APT_PACKAGES` as a legacy fallback. (#62431) Thanks @urtabajev.
 - Gateway/ACPX: attribute startup probe, config, runtime, and resource-count costs in restart traces without changing readiness behavior. (#83300) Thanks @samzong.
 - Gateway: overlap startup logging and plugin-service startup with channel sidecars to reduce restart ready latency while preserving `/readyz` sidecar gating. (#83301) Thanks @samzong.
+- Plugins/admin-http-rpc: allow trusted admin HTTP RPC clients to start and wait for web QR login flows. (#83259) Thanks @liorb-mountapps.
 - Mac app: redesign Settings pages with consistent card layouts, cached navigation, cleaner permissions/voice/skills/cron/exec/debug panes, and steadier spacing around the native sidebar.
 - Skills: rename the repo-local Codex closeout review skill and helper to `autoreview` while preserving the Codex-first fallback behavior.
 - Skills: add a meme-maker skill for curated template search, local SVG/PNG rendering, Imgflip hosted rendering, and Know Your Meme provenance links.

--- a/docs/plugins/admin-http-rpc.md
+++ b/docs/plugins/admin-http-rpc.md
@@ -171,6 +171,7 @@ HTTP status follows the Gateway error when possible. For example, `INVALID_REQUE
 - gateway: `health`, `status`, `logs.tail`, `usage.status`, `usage.cost`, `gateway.restart.request`
 - config: `config.get`, `config.schema`, `config.schema.lookup`, `config.set`, `config.patch`, `config.apply`
 - channels: `channels.status`, `channels.start`, `channels.stop`, `channels.logout`
+- web: `web.login.start`, `web.login.wait`
 - models: `models.list`, `models.authStatus`
 - agents: `agents.list`, `agents.create`, `agents.update`, `agents.delete`
 - approvals: `exec.approvals.get`, `exec.approvals.set`, `exec.approvals.node.get`, `exec.approvals.node.set`

--- a/extensions/admin-http-rpc/src/handler.test.ts
+++ b/extensions/admin-http-rpc/src/handler.test.ts
@@ -105,6 +105,33 @@ describe("admin-http-rpc plugin handler", () => {
     });
   });
 
+  it.each([
+    ["web.login.start", { force: true, timeoutMs: 1000 }],
+    ["web.login.wait", { timeoutMs: 1000 }],
+  ] as const)(
+    "allows web QR login method %s through the authenticated plugin request scope",
+    async (method, params) => {
+      dispatchGatewayMethod.mockResolvedValueOnce({
+        ok: true,
+        payload: { status: "ok" },
+      });
+
+      const result = await invoke({
+        id: "web-login",
+        method,
+        params,
+      });
+
+      expect(dispatchGatewayMethod).toHaveBeenCalledWith(method, params);
+      expect(result.captured.statusCode).toBe(200);
+      expect(result.json).toEqual({
+        id: "web-login",
+        ok: true,
+        payload: { status: "ok" },
+      });
+    },
+  );
+
   it("rejects methods outside the admin HTTP RPC allowlist", async () => {
     const result = await invoke({ id: "bad", method: "sessions.send" });
 

--- a/extensions/admin-http-rpc/src/methods.ts
+++ b/extensions/admin-http-rpc/src/methods.ts
@@ -17,6 +17,7 @@ const ADMIN_HTTP_RPC_ALLOWED_METHOD_GROUPS = {
     "config.apply",
   ],
   channels: ["channels.status", "channels.start", "channels.stop", "channels.logout"],
+  web: ["web.login.start", "web.login.wait"],
   models: ["models.list", "models.authStatus"],
   agents: ["agents.list", "agents.create", "agents.update", "agents.delete"],
   approvals: [

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md
@@ -77,7 +77,7 @@
   "approvalsReviewer": "user",
   "config": {
     "features.code_mode": true,
-    "features.code_mode_only": true,
+    "features.code_mode_only": false,
     "instructions": "OpenClaw loaded these user-editable workspace files. Treat them as project/user context. Codex loads AGENTS.md natively, so AGENTS.md is not repeated here.\n\n# Project Context\n\nThe following project context files have been loaded:\nSOUL.md: persona/tone. Follow it unless higher-priority instructions override.\n\n## /tmp/openclaw-happy-path/workspace/SOUL.md\n\n<SOUL.md contents will be here>\n\n## /tmp/openclaw-happy-path/workspace/TOOLS.md\n\n<TOOLS.md contents will be here>\n\n## /tmp/openclaw-happy-path/workspace/HEARTBEAT.md\n\n<HEARTBEAT.md contents will be here>"
   },
   "cwd": "/tmp/openclaw-happy-path/workspace",
@@ -115,7 +115,7 @@
   "approvalsReviewer": "user",
   "config": {
     "features.code_mode": true,
-    "features.code_mode_only": true,
+    "features.code_mode_only": false,
     "instructions": "OpenClaw loaded these user-editable workspace files. Treat them as project/user context. Codex loads AGENTS.md natively, so AGENTS.md is not repeated here.\n\n# Project Context\n\nThe following project context files have been loaded:\nSOUL.md: persona/tone. Follow it unless higher-priority instructions override.\n\n## /tmp/openclaw-happy-path/workspace/SOUL.md\n\n<SOUL.md contents will be here>\n\n## /tmp/openclaw-happy-path/workspace/TOOLS.md\n\n<TOOLS.md contents will be here>\n\n## /tmp/openclaw-happy-path/workspace/HEARTBEAT.md\n\n<HEARTBEAT.md contents will be here>"
   },
   "developerInstructions": "<see Reconstructed Model-Bound Prompt Layers>",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -77,7 +77,7 @@
   "approvalsReviewer": "user",
   "config": {
     "features.code_mode": true,
-    "features.code_mode_only": true,
+    "features.code_mode_only": false,
     "instructions": "OpenClaw loaded these user-editable workspace files. Treat them as project/user context. Codex loads AGENTS.md natively, so AGENTS.md is not repeated here.\n\n# Project Context\n\nThe following project context files have been loaded:\nSOUL.md: persona/tone. Follow it unless higher-priority instructions override.\n\n## /tmp/openclaw-happy-path/workspace/SOUL.md\n\n<SOUL.md contents will be here>\n\n## /tmp/openclaw-happy-path/workspace/TOOLS.md\n\n<TOOLS.md contents will be here>\n\n## /tmp/openclaw-happy-path/workspace/HEARTBEAT.md\n\n<HEARTBEAT.md contents will be here>"
   },
   "cwd": "/tmp/openclaw-happy-path/workspace",
@@ -115,7 +115,7 @@
   "approvalsReviewer": "user",
   "config": {
     "features.code_mode": true,
-    "features.code_mode_only": true,
+    "features.code_mode_only": false,
     "instructions": "OpenClaw loaded these user-editable workspace files. Treat them as project/user context. Codex loads AGENTS.md natively, so AGENTS.md is not repeated here.\n\n# Project Context\n\nThe following project context files have been loaded:\nSOUL.md: persona/tone. Follow it unless higher-priority instructions override.\n\n## /tmp/openclaw-happy-path/workspace/SOUL.md\n\n<SOUL.md contents will be here>\n\n## /tmp/openclaw-happy-path/workspace/TOOLS.md\n\n<TOOLS.md contents will be here>\n\n## /tmp/openclaw-happy-path/workspace/HEARTBEAT.md\n\n<HEARTBEAT.md contents will be here>"
   },
   "developerInstructions": "<see Reconstructed Model-Bound Prompt Layers>",

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md
@@ -77,7 +77,7 @@
   "approvalsReviewer": "user",
   "config": {
     "features.code_mode": true,
-    "features.code_mode_only": true,
+    "features.code_mode_only": false,
     "instructions": "OpenClaw loaded these user-editable workspace files. Treat them as project/user context. Codex loads AGENTS.md natively, so AGENTS.md is not repeated here.\n\n# Project Context\n\nThe following project context files have been loaded:\nSOUL.md: persona/tone. Follow it unless higher-priority instructions override.\n\n## /tmp/openclaw-happy-path/workspace/SOUL.md\n\n<SOUL.md contents will be here>\n\n## /tmp/openclaw-happy-path/workspace/TOOLS.md\n\n<TOOLS.md contents will be here>\n\n## /tmp/openclaw-happy-path/workspace/HEARTBEAT.md\n\n<HEARTBEAT.md contents will be here>"
   },
   "cwd": "/tmp/openclaw-happy-path/workspace",
@@ -116,7 +116,7 @@
   "approvalsReviewer": "user",
   "config": {
     "features.code_mode": true,
-    "features.code_mode_only": true,
+    "features.code_mode_only": false,
     "instructions": "OpenClaw loaded these user-editable workspace files. Treat them as project/user context. Codex loads AGENTS.md natively, so AGENTS.md is not repeated here.\n\n# Project Context\n\nThe following project context files have been loaded:\nSOUL.md: persona/tone. Follow it unless higher-priority instructions override.\n\n## /tmp/openclaw-happy-path/workspace/SOUL.md\n\n<SOUL.md contents will be here>\n\n## /tmp/openclaw-happy-path/workspace/TOOLS.md\n\n<TOOLS.md contents will be here>\n\n## /tmp/openclaw-happy-path/workspace/HEARTBEAT.md\n\n<HEARTBEAT.md contents will be here>"
   },
   "developerInstructions": "<see Reconstructed Model-Bound Prompt Layers>",


### PR DESCRIPTION
## Summary

Allow web QR login methods in Admin HTTP RPC by adding the existing admin-scoped Gateway methods `web.login.start` and `web.login.wait` to the explicit allowlist.

This lets trusted admin clients run the same structured QR login flow as the CLI.

## Verification

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extensions.config.ts extensions/admin-http-rpc --reporter=verbose`
- `git diff --check`
- `node scripts/docs-list.js`
- `corepack pnpm build`

## Real behavior proof

Behavior or issue addressed: allow web QR login methods in Admin HTTP RPC. Before this patch, Admin HTTP RPC used an explicit allowlist that did not include `web.login.start` or `web.login.wait`, even though the Gateway already has those admin-scoped methods.

Real environment tested: Windows local OpenClaw checkout on branch `feat/admin-http-rpc-web-qr-login`, built with `corepack pnpm build`, running a local branch Gateway on loopback port `18789` with Gateway token auth. The `admin-http-rpc` plugin and WhatsApp plugin were enabled only for this test, then disabled afterward.

Exact steps or command run after this patch:

1. Built the branch with `corepack pnpm build`.
2. Enabled `admin-http-rpc` and started the branch Gateway locally.
3. Called `POST http://127.0.0.1:18789/api/v1/admin/rpc` with the configured Gateway bearer token and method `commands.list`.
4. Enabled WhatsApp test config and restarted the branch Gateway.
5. Called the same Admin HTTP RPC endpoint with method `web.login.start` and params `{ "force": true, "timeoutMs": 30000, "verbose": true }`.
6. Called the same Admin HTTP RPC endpoint with method `web.login.wait` and params `{ "timeoutMs": 60000 }`.
7. Stopped the branch Gateway and removed the test-only local plugin/channel config.

Evidence after fix: copied terminal output from the local branch Gateway Admin HTTP RPC calls, with token and QR image content omitted.

```text
commands.list over Admin HTTP RPC:
{
  "httpStatus": 200,
  "ok": true,
  "hasWebLoginStart": true,
  "hasWebLoginWait": true,
  "methodCount": 53
}

web.login.start over Admin HTTP RPC:
{
  "httpStatus": 200,
  "ok": true,
  "connected": false,
  "hasQrDataUrl": true,
  "payloadKeys": ["message"]
}

web.login.wait over Admin HTTP RPC:
{
  "httpStatus": 200,
  "ok": true,
  "connected": false,
  "hasQrDataUrl": false,
  "payloadKeys": ["connected", "message"]
}
```

Observed result after fix: Admin HTTP RPC returned HTTP 200 for `commands.list`, included both `web.login.start` and `web.login.wait`, returned HTTP 200 for `web.login.start`, and produced a QR data URL. `web.login.wait` also returned HTTP 200 through Admin HTTP RPC. This proves both web QR login methods are allowed and dispatch through the trusted Admin HTTP RPC path.

What was not tested: A completed WhatsApp pairing was not tested because the QR was not scanned in the 60 second test window. Sending or receiving WhatsApp messages after pairing was not tested. This PR only changes the Admin HTTP RPC allowlist and docs; it does not change WhatsApp pairing behavior.

## AI assistance

Prepared with AI assistance and human-reviewed before opening.