### PR TITLE
Improve Telegram groups config shape diagnostics

### DIFF
--- a/extensions/telegram/src/doctor.test.ts
+++ b/extensions/telegram/src/doctor.test.ts
@@ -5,12 +5,14 @@ import {
   collectTelegramApiRootWarnings,
   collectTelegramEmptyAllowlistExtraWarnings,
   collectTelegramGroupPolicyWarnings,
+  collectTelegramMalformedGroupsWarnings,
   collectTelegramMissingEnvTokenWarnings,
   collectTelegramSelectedQuoteToolProgressWarnings,
   maybeRepairTelegramApiRoots,
   maybeRepairTelegramAllowFromUsernames,
   scanTelegramBotEndpointApiRoots,
   scanTelegramInvalidAllowFromEntries,
+  scanTelegramMalformedGroupsConfig,
   scanTelegramSelectedQuoteToolProgressWarnings,
   telegramDoctor,
 } from "./doctor.js";
@@ -204,6 +206,42 @@ describe("telegram doctor", () => {
         prefix: "channels.telegram",
       }),
     ).toHaveLength(1);
+  });
+
+  it("warns when Telegram groups use a non-object shape", async () => {
+    const cfg = {
+      channels: {
+        telegram: {
+          groups: ["-1001234567890"],
+          accounts: {
+            work: {
+              groups: null,
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const hits = scanTelegramMalformedGroupsConfig(cfg);
+    expect(hits).toEqual([
+      { path: "channels.telegram.groups", actualType: "array" },
+      { path: "channels.telegram.accounts.work.groups", actualType: "null" },
+    ]);
+
+    const warnings = collectTelegramMalformedGroupsWarnings({
+      hits,
+      doctorFixCommand: "openclaw doctor --fix",
+    });
+    expect(warnings[0]).toContain("object map keyed by Telegram group/chat id");
+    expect(warnings[1]).toContain('channels.telegram.groups."-1001234567890".topics."99"');
+    expect(warnings[1]).toContain("openclaw doctor --fix");
+
+    expect(
+      await telegramDoctor.collectPreviewWarnings?.({
+        cfg,
+        doctorFixCommand: "openclaw doctor --fix",
+      }),
+    ).toEqual(expect.arrayContaining(warnings));
   });
 
   it("repairs @username entries to numeric ids", async () => {

--- a/extensions/telegram/src/doctor.ts
+++ b/extensions/telegram/src/doctor.ts
@@ -26,6 +26,7 @@ import {
 import { resolveTelegramPreviewStreamMode } from "./preview-streaming.js";
 
 type TelegramAllowFromInvalidHit = { path: string; entry: string };
+type TelegramMalformedGroupsHit = { path: string; actualType: string };
 type TelegramSelectedQuoteToolProgressHit = { path: string; replyToMode: string };
 type TelegramApiRootBotEndpointHit = {
   path: string;
@@ -129,6 +130,53 @@ function collectTelegramAllowFromLists(
     }
   }
   return refs;
+}
+
+function describeConfigValueType(value: unknown): string {
+  if (Array.isArray(value)) {
+    return "array";
+  }
+  if (value === null) {
+    return "null";
+  }
+  return typeof value;
+}
+
+export function scanTelegramMalformedGroupsConfig(
+  cfg: OpenClawConfig,
+): TelegramMalformedGroupsHit[] {
+  const hits: TelegramMalformedGroupsHit[] = [];
+  for (const scope of collectTelegramAccountScopes(cfg)) {
+    if (!Object.prototype.hasOwnProperty.call(scope.account, "groups")) {
+      continue;
+    }
+    const groups = scope.account.groups;
+    if (asObjectRecord(groups)) {
+      continue;
+    }
+    hits.push({
+      path: `${scope.prefix}.groups`,
+      actualType: describeConfigValueType(groups),
+    });
+  }
+  return hits;
+}
+
+export function collectTelegramMalformedGroupsWarnings(params: {
+  hits: TelegramMalformedGroupsHit[];
+  doctorFixCommand: string;
+}): string[] {
+  if (params.hits.length === 0) {
+    return [];
+  }
+  const sample = params.hits[0] ?? {
+    path: "channels.telegram.groups",
+    actualType: "unknown",
+  };
+  return [
+    `- ${sanitizeForLog(sample.path)} has invalid Telegram groups shape (${sanitizeForLog(sample.actualType)}); expected an object map keyed by Telegram group/chat id, not an array, string, or null.`,
+    `- Example shape: channels.telegram.groups."-1001234567890".topics."99" = { agentId: "support" }. Use topics for forum-topic routing, then rerun ${params.doctorFixCommand} for any remaining Telegram config cleanup.`,
+  ];
 }
 
 export function scanTelegramInvalidAllowFromEntries(
@@ -557,6 +605,10 @@ export const telegramDoctor: ChannelDoctorAdapter = {
   normalizeCompatibilityConfig: normalizeTelegramCompatibilityConfig,
   collectPreviewWarnings: ({ cfg, doctorFixCommand, env }) => [
     ...collectTelegramMissingEnvTokenWarnings({ cfg, env }),
+    ...collectTelegramMalformedGroupsWarnings({
+      hits: scanTelegramMalformedGroupsConfig(cfg),
+      doctorFixCommand,
+    }),
     ...collectTelegramInvalidAllowFromWarnings({
       hits: scanTelegramInvalidAllowFromEntries(cfg),
       doctorFixCommand,

--- a/src/config/validation.channel-metadata.test.ts
+++ b/src/config/validation.channel-metadata.test.ts
@@ -246,6 +246,30 @@ describe("validateConfigObjectRawWithPlugins channel metadata", () => {
 
     expect(result.ok).toBe(true);
   });
+
+  it("explains the Telegram groups object-map shape when raw channel validation rejects it", () => {
+    const result = validateConfigObjectRawWithPlugins({
+      channels: {
+        telegram: {
+          groups: ["-1001234567890"],
+        },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.issues).toContainEqual(
+        expect.objectContaining({
+          path: "channels.telegram.groups",
+          message: expect.stringContaining(
+            "Telegram groups must be an object map keyed by Telegram group/chat id",
+          ),
+        }),
+      );
+      expect(result.issues[0]?.message).toContain("topics");
+      expect(result.issues[0]?.message).toContain("openclaw doctor --fix");
+    }
+  });
 });
 
 describe("validateConfigObjectRawWithPlugins plugin config defaults", () => {

--- a/src/config/validation.channel-metadata.test.ts
+++ b/src/config/validation.channel-metadata.test.ts
@@ -247,7 +247,7 @@ describe("validateConfigObjectRawWithPlugins channel metadata", () => {
     expect(result.ok).toBe(true);
   });
 
-  it("explains the Telegram groups object-map shape when raw channel validation rejects it", () => {
+  it("keeps raw channel validation diagnostics plugin-agnostic", () => {
     const result = validateConfigObjectRawWithPlugins({
       channels: {
         telegram: {
@@ -261,13 +261,11 @@ describe("validateConfigObjectRawWithPlugins channel metadata", () => {
       expect(result.issues).toContainEqual(
         expect.objectContaining({
           path: "channels.telegram.groups",
-          message: expect.stringContaining(
-            "Telegram groups must be an object map keyed by Telegram group/chat id",
-          ),
+          message: expect.stringContaining("invalid config:"),
         }),
       );
-      expect(result.issues[0]?.message).toContain("topics");
-      expect(result.issues[0]?.message).toContain("openclaw doctor --fix");
+      expect(result.issues[0]?.message).not.toContain("Telegram groups");
+      expect(result.issues[0]?.message).not.toContain("openclaw doctor --fix");
     }
   });
 });

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -85,8 +85,6 @@ function stripPreservedLegacyRootKeysForValidation(
 
 const CUSTOM_EXPECTED_ONE_OF_RE = /expected one of ((?:"[^"]+"(?:\|"?[^"]+"?)*)+)/i;
 const SECRETREF_POLICY_DOC_URL = "https://docs.openclaw.ai/reference/secretref-credential-surface";
-const TELEGRAM_GROUPS_SHAPE_HINT =
-  'Telegram groups must be an object map keyed by Telegram group/chat id, for example channels.telegram.groups."-1001234567890".topics."99" for forum topic routing. Do not use an array, string, or null for channels.telegram.groups; fix the shape, then rerun openclaw doctor --fix for any remaining Telegram config cleanup.';
 const bundledChannelSchemaById = new Map<string, unknown>(
   GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA.map(
     (entry) => [entry.channelId, entry.schema] as const,
@@ -227,22 +225,8 @@ function collectAllowedValuesFromBundledChannelSchemaPath(
   return collectAllowedValuesFromJsonSchemaNode(targetNode);
 }
 
-function isTelegramGroupsConfigPath(path: string): boolean {
-  return (
-    path === "channels.telegram.groups" ||
-    /^channels\.telegram\.accounts\.[^.]+\.groups$/.test(path)
-  );
-}
-
-function appendTelegramGroupsShapeHint(path: string, message: string): string {
-  if (!isTelegramGroupsConfigPath(path) || message.includes(TELEGRAM_GROUPS_SHAPE_HINT)) {
-    return message;
-  }
-  return `${message}. ${TELEGRAM_GROUPS_SHAPE_HINT}`;
-}
-
-function formatRawChannelConfigIssueMessage(params: { path: string; message: string }): string {
-  return appendTelegramGroupsShapeHint(params.path, `invalid config: ${params.message}`);
+function formatRawChannelConfigIssueMessage(message: string): string {
+  return `invalid config: ${message}`;
 }
 function collectRawBundledChannelConfigIssues(config: OpenClawConfig): ConfigValidationIssue[] {
   if (!config.channels || !isRecord(config.channels)) {
@@ -270,7 +254,7 @@ function collectRawBundledChannelConfigIssues(config: OpenClawConfig): ConfigVal
         error.path === "<root>" ? `channels.${channelId}` : `channels.${channelId}.${error.path}`;
       issues.push({
         path,
-        message: formatRawChannelConfigIssueMessage({ path, message }),
+        message: formatRawChannelConfigIssueMessage(message),
         allowedValues: error.allowedValues,
         allowedValuesHiddenCount: error.allowedValuesHiddenCount,
       });
@@ -575,14 +559,13 @@ function mapZodIssueToConfigIssue(issue: unknown): ConfigValidationIssue {
     }
   }
 
-  const messageWithShapeHint = appendTelegramGroupsShapeHint(path, message);
   if (!allowedValuesSummary) {
-    return { path, message: messageWithShapeHint };
+    return { path, message };
   }
 
   return {
     path,
-    message: appendAllowedValuesHint(messageWithShapeHint, allowedValuesSummary),
+    message: appendAllowedValuesHint(message, allowedValuesSummary),
     allowedValues: allowedValuesSummary.values,
     allowedValuesHiddenCount: allowedValuesSummary.hiddenCount,
   };
@@ -1341,7 +1324,7 @@ function validateConfigObjectWithPluginsBase(
             error.path === "<root>" ? `channels.${trimmed}` : `channels.${trimmed}.${error.path}`;
           issues.push({
             path,
-            message: formatRawChannelConfigIssueMessage({ path, message: error.message }),
+            message: formatRawChannelConfigIssueMessage(error.message),
             allowedValues: error.allowedValues,
             allowedValuesHiddenCount: error.allowedValuesHiddenCount,
           });

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -85,6 +85,8 @@ function stripPreservedLegacyRootKeysForValidation(
 
 const CUSTOM_EXPECTED_ONE_OF_RE = /expected one of ((?:"[^"]+"(?:\|"?[^"]+"?)*)+)/i;
 const SECRETREF_POLICY_DOC_URL = "https://docs.openclaw.ai/reference/secretref-credential-surface";
+const TELEGRAM_GROUPS_SHAPE_HINT =
+  'Telegram groups must be an object map keyed by Telegram group/chat id, for example channels.telegram.groups."-1001234567890".topics."99" for forum topic routing. Do not use an array, string, or null for channels.telegram.groups; fix the shape, then rerun openclaw doctor --fix for any remaining Telegram config cleanup.';
 const bundledChannelSchemaById = new Map<string, unknown>(
   GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA.map(
     (entry) => [entry.channelId, entry.schema] as const,
@@ -225,6 +227,23 @@ function collectAllowedValuesFromBundledChannelSchemaPath(
   return collectAllowedValuesFromJsonSchemaNode(targetNode);
 }
 
+function isTelegramGroupsConfigPath(path: string): boolean {
+  return (
+    path === "channels.telegram.groups" ||
+    /^channels\.telegram\.accounts\.[^.]+\.groups$/.test(path)
+  );
+}
+
+function appendTelegramGroupsShapeHint(path: string, message: string): string {
+  if (!isTelegramGroupsConfigPath(path) || message.includes(TELEGRAM_GROUPS_SHAPE_HINT)) {
+    return message;
+  }
+  return `${message}. ${TELEGRAM_GROUPS_SHAPE_HINT}`;
+}
+
+function formatRawChannelConfigIssueMessage(params: { path: string; message: string }): string {
+  return appendTelegramGroupsShapeHint(params.path, `invalid config: ${params.message}`);
+}
 function collectRawBundledChannelConfigIssues(config: OpenClawConfig): ConfigValidationIssue[] {
   if (!config.channels || !isRecord(config.channels)) {
     return [];
@@ -247,10 +266,11 @@ function collectRawBundledChannelConfigIssues(config: OpenClawConfig): ConfigVal
       const message = error.additionalProperty
         ? `${error.message}: "${error.additionalProperty}"`
         : error.message;
+      const path =
+        error.path === "<root>" ? `channels.${channelId}` : `channels.${channelId}.${error.path}`;
       issues.push({
-        path:
-          error.path === "<root>" ? `channels.${channelId}` : `channels.${channelId}.${error.path}`,
-        message: `invalid config: ${message}`,
+        path,
+        message: formatRawChannelConfigIssueMessage({ path, message }),
         allowedValues: error.allowedValues,
         allowedValuesHiddenCount: error.allowedValuesHiddenCount,
       });
@@ -555,13 +575,14 @@ function mapZodIssueToConfigIssue(issue: unknown): ConfigValidationIssue {
     }
   }
 
+  const messageWithShapeHint = appendTelegramGroupsShapeHint(path, message);
   if (!allowedValuesSummary) {
-    return { path, message };
+    return { path, message: messageWithShapeHint };
   }
 
   return {
     path,
-    message: appendAllowedValuesHint(message, allowedValuesSummary),
+    message: appendAllowedValuesHint(messageWithShapeHint, allowedValuesSummary),
     allowedValues: allowedValuesSummary.values,
     allowedValuesHiddenCount: allowedValuesSummary.hiddenCount,
   };
@@ -1316,10 +1337,11 @@ function validateConfigObjectWithPluginsBase(
       });
       if (!result.ok) {
         for (const error of result.errors) {
+          const path =
+            error.path === "<root>" ? `channels.${trimmed}` : `channels.${trimmed}.${error.path}`;
           issues.push({
-            path:
-              error.path === "<root>" ? `channels.${trimmed}` : `channels.${trimmed}.${error.path}`,
-            message: `invalid config: ${error.message}`,
+            path,
+            message: formatRawChannelConfigIssueMessage({ path, message: error.message }),
             allowedValues: error.allowedValues,
             allowedValuesHiddenCount: error.allowedValuesHiddenCount,
           });


### PR DESCRIPTION
Fixes #83083.

## Summary

- Add Telegram-owned doctor diagnostics when `channels.telegram.groups` or account-level Telegram `groups` is an array, string, `null`, or another non-object shape.
- Keep core raw channel config validation plugin-agnostic: it still reports the failing path and schema error, but does not mention Telegram-specific repairs.
- Keep the schema strict: this only improves diagnostics and does not auto-migrate arbitrary non-object values.

## Real behavior proof

Behavior addressed: Malformed Telegram group config such as `channels.telegram.groups: ["-1001234567890"]` failed with only a generic raw config validation error, and doctor did not explain the expected Telegram group/topic object-map shape.

Real environment tested: WSL2 Ubuntu 24.04 OpenClaw checkout on PR head `357a224da3`, rebuilt with `pnpm build` so the bundled Telegram runtime entry matched the patch.

Exact steps or command run after this patch:

```bash
pnpm build

cat > "$tmp/openclaw.json" <<'EOF'
{
  "plugins": { "enabled": true },
  "channels": {
    "telegram": {
      "groups": ["-1001234567890"],
      "accounts": {
        "work": { "groups": null }
      }
    }
  }
}
EOF
OPENCLAW_CONFIG_PATH="$tmp/openclaw.json" node openclaw.mjs doctor >"$tmp/doctor.out" 2>&1
rg -n "invalid Telegram groups shape|object map keyed|Example shape|channels.telegram.groups|accounts.work.groups|Config invalid" "$tmp/doctor.out"

node node_modules/vitest/vitest.mjs run \
  src/config/validation.channel-metadata.test.ts \
  extensions/telegram/src/doctor.test.ts \
  --reporter=dot

git diff --check
```

Evidence after fix:

```text
19:│  Config invalid; doctor will run with best-effort config.  │
48:│  - channels.telegram.groups has invalid Telegram groups shape (array);  │
49:│    expected an object map keyed by Telegram group/chat id, not an       │
56:│  - Example shape: channels.telegram.groups."-1001234567890".topics."99"  │
237:- channels.telegram.groups: invalid config: must be object
238:- channels.telegram.accounts.work.groups: invalid config: must be object
exit=0

src/config/validation.channel-metadata.test.ts: 8 tests passed
extensions/telegram/src/doctor.test.ts: 18 tests passed
```

Observed result after fix: `openclaw doctor` now emits the Telegram-owned malformed-groups guidance while the generic raw validation output still reports the invalid config paths without plugin-specific repair text.

What was not tested: No live Telegram bot or forum topic was contacted; this is a config/doctor diagnostic-only change and intentionally does not send Telegram API calls or migrate arbitrary invalid values.

## Verification

- `pnpm build` — passed.
- `OPENCLAW_CONFIG_PATH="$tmp/openclaw.json" node openclaw.mjs doctor` — emitted the malformed Telegram groups warning shown above.
- `node node_modules/vitest/vitest.mjs run src/config/validation.channel-metadata.test.ts extensions/telegram/src/doctor.test.ts --reporter=dot` — passed, 26 tests.
- `git diff --check` — passed.