### PR TITLE
fix(models): resolve set aliases from runtime config [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 
 - Agents/subagents: surface blocked child-run completions as errors instead of successful subagent finishes. (#80886) Thanks @TurboTheTurtle.
 - Agents/Pi: treat accepted embedded `sessions_spawn` child-session handoffs as terminal progress so parent turns no longer report false non-deliverable failures. (#85054) Thanks @samzong.
+- CLI/models: resolve `openclaw models set` aliases from the runtime config while keeping authored aliases ahead of runtime-only defaults. (#83262) Thanks @IWhatsskill.
 - WhatsApp: update Baileys to `7.0.0-rc13` and drop the obsolete logger type patch.
 - Install/update: reject OpenClaw GitHub source package targets early and point moving-main users at the dev/git install path instead of the broken npm source-install flow.
 - Gateway: mirror successful same-source message-tool sends into session transcripts so delivered replies stay in later history/context. (#84837) Thanks @iFiras-Max1.

--- a/src/commands/models.set.e2e.test.ts
+++ b/src/commands/models.set.e2e.test.ts
@@ -9,8 +9,17 @@ vi.mock("./models/shared.js", async () => {
   const actual = await vi.importActual<typeof import("./models/shared.js")>("./models/shared.js");
   return {
     ...actual,
-    updateConfig: async (mutator: (cfg: Record<string, unknown>) => Record<string, unknown>) => {
-      const next = mutator(structuredClone(mocks.currentConfig));
+    updateConfig: async (
+      mutator: (
+        cfg: Record<string, unknown>,
+        context: {
+          runtimeConfig: Record<string, unknown>;
+        },
+      ) => Record<string, unknown>,
+    ) => {
+      const sourceConfig = structuredClone(mocks.currentConfig);
+      const runtimeConfig = structuredClone(mocks.currentConfig);
+      const next = mutator(sourceConfig, { runtimeConfig });
       mocks.writtenConfig = next;
       return next;
     },

--- a/src/commands/models/set.test.ts
+++ b/src/commands/models/set.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { RuntimeEnv } from "../../runtime.js";
+
+const mocks = vi.hoisted(() => ({
+  logConfigUpdated: vi.fn(),
+  readConfigFileSnapshot: vi.fn(),
+  repairCodexRuntimePluginInstallForModelSelection: vi.fn(),
+  replaceConfigFile: vi.fn(),
+}));
+
+vi.mock("../../config/config.js", () => ({
+  readConfigFileSnapshot: (...args: unknown[]) => mocks.readConfigFileSnapshot(...args),
+  replaceConfigFile: (...args: unknown[]) => mocks.replaceConfigFile(...args),
+}));
+
+vi.mock("../../config/logging.js", () => ({
+  logConfigUpdated: (...args: unknown[]) => mocks.logConfigUpdated(...args),
+}));
+
+vi.mock("../codex-runtime-plugin-install.js", () => ({
+  repairCodexRuntimePluginInstallForModelSelection: (...args: unknown[]) =>
+    mocks.repairCodexRuntimePluginInstallForModelSelection(...args),
+}));
+
+import { modelsSetCommand } from "./set.js";
+
+function makeRuntime(): RuntimeEnv {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  } as unknown as RuntimeEnv;
+}
+
+describe("modelsSetCommand", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.replaceConfigFile.mockResolvedValue(undefined);
+    mocks.repairCodexRuntimePluginInstallForModelSelection.mockResolvedValue({ warnings: [] });
+  });
+
+  it("resolves aliases from runtime config while writing only source config", async () => {
+    const sourceConfig = {
+      agents: {
+        defaults: {
+          models: {
+            "anthropic/claude-sonnet-4-6": {},
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const runtimeConfig = {
+      agents: {
+        defaults: {
+          models: {
+            "anthropic/claude-sonnet-4-6": { alias: "sonnet" },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      valid: true,
+      hash: "config-hash",
+      sourceConfig,
+      runtimeConfig,
+      config: runtimeConfig,
+    });
+    const runtime = makeRuntime();
+
+    await modelsSetCommand("sonnet", runtime);
+
+    expect(mocks.replaceConfigFile).toHaveBeenCalledOnce();
+    const [replaceParams] = mocks.replaceConfigFile.mock.calls[0] ?? [];
+    expect(replaceParams?.nextConfig.agents?.defaults?.model).toEqual({
+      primary: "anthropic/claude-sonnet-4-6",
+    });
+    expect(replaceParams?.nextConfig.agents?.defaults?.models).toEqual({
+      "anthropic/claude-sonnet-4-6": {},
+    });
+    expect(replaceParams?.nextConfig.agents?.defaults?.models).not.toHaveProperty("openai/sonnet");
+    expect(mocks.repairCodexRuntimePluginInstallForModelSelection).toHaveBeenCalledWith({
+      cfg: replaceParams?.nextConfig,
+      model: "anthropic/claude-sonnet-4-6",
+    });
+    expect(runtime.log).toHaveBeenCalledWith("Default model: anthropic/claude-sonnet-4-6");
+  });
+});

--- a/src/commands/models/set.test.ts
+++ b/src/commands/models/set.test.ts
@@ -85,4 +85,50 @@ describe("modelsSetCommand", () => {
     });
     expect(runtime.log).toHaveBeenCalledWith("Default model: anthropic/claude-sonnet-4-6");
   });
+
+  it("keeps authored aliases ahead of runtime-only aliases", async () => {
+    const sourceConfig = {
+      agents: {
+        defaults: {
+          models: {
+            "openai/gpt-5.5": { alias: "sonnet" },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const runtimeConfig = {
+      agents: {
+        defaults: {
+          models: {
+            "openai/gpt-5.5": { alias: "sonnet" },
+            "anthropic/claude-sonnet-4-6": { alias: "sonnet" },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      valid: true,
+      hash: "config-hash",
+      sourceConfig,
+      runtimeConfig,
+      config: runtimeConfig,
+    });
+    const runtime = makeRuntime();
+
+    await modelsSetCommand("sonnet", runtime);
+
+    expect(mocks.replaceConfigFile).toHaveBeenCalledOnce();
+    const [replaceParams] = mocks.replaceConfigFile.mock.calls[0] ?? [];
+    expect(replaceParams?.nextConfig.agents?.defaults?.model).toEqual({
+      primary: "openai/gpt-5.5",
+    });
+    expect(replaceParams?.nextConfig.agents?.defaults?.models).toEqual({
+      "openai/gpt-5.5": { alias: "sonnet" },
+    });
+    expect(mocks.repairCodexRuntimePluginInstallForModelSelection).toHaveBeenCalledWith({
+      cfg: replaceParams?.nextConfig,
+      model: "openai/gpt-5.5",
+    });
+    expect(runtime.log).toHaveBeenCalledWith("Default model: openai/gpt-5.5");
+  });
 });

--- a/src/commands/models/set.ts
+++ b/src/commands/models/set.ts
@@ -5,8 +5,13 @@ import { repairCodexRuntimePluginInstallForModelSelection } from "../codex-runti
 import { applyDefaultModelPrimaryUpdate, updateConfig } from "./shared.js";
 
 export async function modelsSetCommand(modelRaw: string, runtime: RuntimeEnv) {
-  const updated = await updateConfig((cfg) => {
-    return applyDefaultModelPrimaryUpdate({ cfg, modelRaw, field: "model" });
+  const updated = await updateConfig((cfg, context) => {
+    return applyDefaultModelPrimaryUpdate({
+      cfg,
+      resolveCfg: context.runtimeConfig,
+      modelRaw,
+      field: "model",
+    });
   });
   const repaired = await repairCodexRuntimePluginInstallForModelSelection({
     cfg: updated,

--- a/src/commands/models/shared.test.ts
+++ b/src/commands/models/shared.test.ts
@@ -61,4 +61,36 @@ describe("models/shared", () => {
     expect(replaceParams?.nextConfig.update).toEqual({ channel: "beta" });
     expect(replaceParams?.baseHash).toBe("config-1");
   });
+
+  it("updateConfig exposes runtime config without writing runtime defaults", async () => {
+    const sourceConfig = {
+      agents: { defaults: { models: { "anthropic/claude-sonnet-4-6": {} } } },
+    } as unknown as OpenClawConfig;
+    const runtimeConfig = {
+      agents: {
+        defaults: {
+          models: { "anthropic/claude-sonnet-4-6": { alias: "sonnet" } },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    mocks.readConfigFileSnapshot.mockResolvedValue({
+      valid: true,
+      hash: "config-2",
+      sourceConfig,
+      runtimeConfig,
+      config: runtimeConfig,
+    });
+    mocks.replaceConfigFile.mockResolvedValue(undefined);
+
+    await updateConfig((current, context) => {
+      expect(current).toEqual(sourceConfig);
+      expect(context.runtimeConfig).toEqual(runtimeConfig);
+      return current;
+    });
+
+    expect(mocks.replaceConfigFile).toHaveBeenCalledOnce();
+    const [replaceParams] = mocks.replaceConfigFile.mock.calls[0] ?? [];
+    expect(replaceParams?.nextConfig).toEqual(sourceConfig);
+    expect(replaceParams?.baseHash).toBe("config-2");
+  });
 });

--- a/src/commands/models/shared.ts
+++ b/src/commands/models/shared.ts
@@ -59,15 +59,21 @@ export async function loadValidConfigOrThrow(): Promise<OpenClawConfig> {
   return snapshot.runtimeConfig ?? snapshot.config;
 }
 
+export type UpdateConfigContext = {
+  runtimeConfig: OpenClawConfig;
+};
+
 export async function updateConfig(
-  mutator: (cfg: OpenClawConfig) => OpenClawConfig,
+  mutator: (cfg: OpenClawConfig, context: UpdateConfigContext) => OpenClawConfig,
 ): Promise<OpenClawConfig> {
   const snapshot = await readConfigFileSnapshot();
   if (!snapshot.valid) {
     const issues = formatConfigIssueLines(snapshot.issues, "-").join("\n");
     throw new Error(`Invalid config at ${snapshot.path}\n${issues}`);
   }
-  const next = mutator(structuredClone(snapshot.sourceConfig ?? snapshot.config));
+  const sourceConfig = structuredClone(snapshot.sourceConfig ?? snapshot.config);
+  const runtimeConfig = structuredClone(snapshot.runtimeConfig ?? snapshot.config);
+  const next = mutator(sourceConfig, { runtimeConfig });
   await replaceConfigFile({
     nextConfig: next,
     baseHash: snapshot.hash,
@@ -209,10 +215,14 @@ export function mergePrimaryFallbackConfig(
 
 export function applyDefaultModelPrimaryUpdate(params: {
   cfg: OpenClawConfig;
+  resolveCfg?: OpenClawConfig;
   modelRaw: string;
   field: "model" | "imageModel";
 }): OpenClawConfig {
-  const resolved = resolveModelTarget({ raw: params.modelRaw, cfg: params.cfg });
+  const resolved = resolveModelTarget({
+    raw: params.modelRaw,
+    cfg: params.resolveCfg ?? params.cfg,
+  });
   const nextModels = {
     ...params.cfg.agents?.defaults?.models,
   } as Record<string, AgentModelEntryConfig>;

--- a/src/commands/models/shared.ts
+++ b/src/commands/models/shared.ts
@@ -100,6 +100,22 @@ export function resolveModelTarget(params: { raw: string; cfg: OpenClawConfig })
   return resolved.ref;
 }
 
+function resolveAuthoredModelAliasTarget(params: {
+  raw: string;
+  cfg: OpenClawConfig;
+}): { provider: string; model: string } | undefined {
+  const aliasIndex = buildModelAliasIndex({
+    cfg: params.cfg,
+    defaultProvider: DEFAULT_PROVIDER,
+  });
+  const resolved = resolveModelRefFromString({
+    raw: params.raw,
+    defaultProvider: DEFAULT_PROVIDER,
+    aliasIndex,
+  });
+  return resolved?.alias ? resolved.ref : undefined;
+}
+
 export function resolveModelKeysFromEntries(params: {
   cfg: OpenClawConfig;
   entries: readonly string[];
@@ -219,10 +235,20 @@ export function applyDefaultModelPrimaryUpdate(params: {
   modelRaw: string;
   field: "model" | "imageModel";
 }): OpenClawConfig {
-  const resolved = resolveModelTarget({
-    raw: params.modelRaw,
-    cfg: params.resolveCfg ?? params.cfg,
-  });
+  const resolved =
+    params.resolveCfg && params.resolveCfg !== params.cfg
+      ? (resolveAuthoredModelAliasTarget({
+          raw: params.modelRaw,
+          cfg: params.cfg,
+        }) ??
+        resolveModelTarget({
+          raw: params.modelRaw,
+          cfg: params.resolveCfg,
+        }))
+      : resolveModelTarget({
+          raw: params.modelRaw,
+          cfg: params.cfg,
+        });
   const nextModels = {
     ...params.cfg.agents?.defaults?.models,
   } as Record<string, AgentModelEntryConfig>;


### PR DESCRIPTION
## Summary

- Problem: `openclaw models set sonnet` could save `openai/sonnet` when the alias only exists in the effective runtime defaults.
- Why it matters: `models list` showed `sonnet` as a valid alias, but setting it could silently write a bogus model id.
- What changed: `models set` now resolves the input against the runtime alias table, then persists only the canonical provider/model id into the authored config.
- What did NOT change (scope boundary): no provider/auth behavior, no config-shape change, no migration, and no change to fallback or image-model commands.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- Related #83233
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `models set sonnet` should resolve to `anthropic/claude-sonnet-4-6`, not `openai/sonnet`.
- Real environment tested: local Windows source checkout with a disposable `OPENCLAW_CONFIG_PATH`.
- Exact steps or command run after this patch: seeded a temp config containing `agents.defaults.models["anthropic/claude-sonnet-4-6"] = {}`, then ran `models list`, `models set sonnet`, and `models status --plain` through the real source CLI.
- Evidence after fix:

```text
$ openclaw models list
Model                                      Input      Ctx         Local Auth  Tags
openai/gpt-5.5                             text       195k        no    no    default
anthropic/claude-sonnet-4-6                text       195k        no    no    configured,alias:sonnet

$ openclaw models set sonnet
Updated config: <tmp>/openclaw.json
  Backup: <tmp>/openclaw.json.bak
Default model: anthropic/claude-sonnet-4-6

$ openclaw models status --plain
anthropic/claude-sonnet-4-6

$ cat <tmp>/openclaw.json
{
  "agents": {
    "defaults": {
      "models": {
        "anthropic/claude-sonnet-4-6": {}
      },
      "model": {
        "primary": "anthropic/claude-sonnet-4-6"
      }
    }
  },
  "meta": {
    "lastTouchedVersion": "2026.5.17",
    "lastTouchedAt": "<timestamp>"
  }
}
```

- Observed result after fix: the alias resolves to `anthropic/claude-sonnet-4-6`, and no `openai/sonnet` entry is written.
- What was not tested: a packaged npm install; this proof used the same CLI path from the source checkout.
- Before evidence (optional but encouraged): #83233 includes the beta/stable transcript showing the old `Default model: openai/sonnet` behavior.

## Root Cause (if applicable)

- Root cause: `models set` mutated the authored source config and also resolved aliases against that source config, while built-in model aliases can be added only in the effective runtime config.
- Missing detection / guardrail: there was no regression test for a source config where the model exists but its default alias is only present after runtime default materialization.
- Contributing context (if known): `resolveModelRefFromString` falls back bare `sonnet` to the default provider when no alias match is available.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
- Target test or file: `src/commands/models/set.test.ts`, `src/commands/models/shared.test.ts`, and existing model alias/model-selection coverage.
- Scenario the test should lock in: source config keeps the canonical model entry, runtime config provides `alias: sonnet`, and `models set sonnet` writes `anthropic/claude-sonnet-4-6` without adding `openai/sonnet`.
- Why this is the smallest reliable guardrail: it exercises the write resolver boundary directly without starting providers or the gateway.
- Existing test that already covers this (if any): default alias materialization is already covered in `src/config/model-alias-defaults.test.ts`; the write path was missing coverage.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

`openclaw models set <alias>` now matches the alias users see in `models list` when that alias comes from runtime defaults.

## Diagram (if applicable)

```text
Before:
models list shows alias -> models set resolves against source config -> openai/sonnet

After:
models list shows alias -> models set resolves against runtime config -> canonical model id is written
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: local source checkout, Node 24
- Model/provider: Anthropic model alias default, no provider call
- Integration/channel (if any): N/A
- Relevant config (redacted): `agents.defaults.models["anthropic/claude-sonnet-4-6"] = {}`

### Steps

1. Seed a disposable config with the Anthropic Sonnet model entry but no authored alias.
2. Confirm `models list` shows `configured,alias:sonnet`.
3. Run `models set sonnet`.
4. Run `models status --plain` and inspect the written config.

### Expected

- `sonnet` resolves to `anthropic/claude-sonnet-4-6`.
- No `openai/sonnet` entry is written.

### Actual

- Matches expected after this patch.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

## Human Verification (required)

- Verified scenarios: focused vitest regression coverage and real local CLI write path with disposable config.
- Edge cases checked: authored config stays canonical/minimal while runtime alias data is used only for resolution.
- What you did **not** verify: packaged npm install and live provider calls.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: another model write command may have a similar source/runtime alias mismatch.
  - Mitigation: this PR keeps the fix scoped to the reported `models set` regression; fallback/image paths can be handled separately if maintainers want that expanded.
