### PR TITLE
fix(agents): guard stale session lock removal

### DIFF
--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -264,6 +264,28 @@ describe("acquireSessionWriteLock", () => {
     }
   });
 
+  it("does not remove a changed lock file during stale acquisition recovery", async () => {
+    await withTempSessionLockFile(async ({ sessionFile, lockPath }) => {
+      await fs.writeFile(
+        lockPath,
+        JSON.stringify({ pid: 2 ** 30, createdAt: new Date(Date.now() - 60_000).toISOString() }),
+        "utf8",
+      );
+
+      let hookCalls = 0;
+      __testing.setBeforeStaleLockRemovalForTest(async ({ lockPath: staleLockPath }) => {
+        hookCalls += 1;
+        await fs.writeFile(staleLockPath, "{}", "utf8");
+      });
+
+      await expect(
+        acquireSessionWriteLock({ sessionFile, timeoutMs: 75, staleMs: 10_000 }),
+      ).rejects.toThrow(/session file locked/);
+      expect(hookCalls).toBe(1);
+      await expect(fs.readFile(lockPath, "utf8")).resolves.toBe("{}");
+    });
+  });
+
   it("does not reclaim fresh malformed lock files during contention", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-"));
     try {

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -65,6 +65,13 @@ type LockInspectionDetails = Pick<
 
 const SESSION_LOCKS = createFileLockManager("openclaw.session-write-lock");
 let resolveProcessStartTimeForLock = getProcessStartTime;
+let beforeStaleLockRemovalForTest:
+  | ((params: {
+      lockPath: string;
+      normalizedSessionFile: string;
+      payload: LockFilePayload | null;
+    }) => void | Promise<void>)
+  | null = null;
 
 function isFileLockError(error: unknown, code: string): boolean {
   return (error as { code?: unknown } | null)?.code === code;
@@ -552,27 +559,36 @@ function sessionLockHeldByThisProcess(normalizedSessionFile: string): boolean {
   );
 }
 
-async function removeReportedStaleLockIfStillStale(params: {
+async function shouldRemoveReportedStaleLock(params: {
   lockPath: string;
   normalizedSessionFile: string;
+  payload: LockFilePayload | null;
   staleMs: number;
   readOwnerProcessArgs?: SessionLockOwnerProcessArgsReader;
 }): Promise<boolean> {
   const nowMs = Date.now();
-  const payload = await readLockPayload(params.lockPath);
   const inspected = inspectLockPayloadForSession({
-    payload,
+    payload: params.payload,
     staleMs: params.staleMs,
     nowMs,
     heldByThisProcess: sessionLockHeldByThisProcess(params.normalizedSessionFile),
     reclaimLockWithoutStarttime: true,
     readOwnerProcessArgs: params.readOwnerProcessArgs ?? readProcessArgsSync,
   });
-  if (!(await shouldReclaimContendedLockFile(params.lockPath, inspected, params.staleMs, nowMs))) {
-    return false;
+  const shouldRemove = await shouldReclaimContendedLockFile(
+    params.lockPath,
+    inspected,
+    params.staleMs,
+    nowMs,
+  );
+  if (shouldRemove) {
+    await beforeStaleLockRemovalForTest?.({
+      lockPath: params.lockPath,
+      normalizedSessionFile: params.normalizedSessionFile,
+      payload: params.payload,
+    });
   }
-  await fs.rm(params.lockPath, { force: true });
-  return true;
+  return shouldRemove;
 }
 
 function shouldTreatAsOrphanSelfLock(params: {
@@ -763,21 +779,17 @@ export async function acquireSessionWriteLock(params: {
           });
           return await shouldReclaimContendedLockFile(lockPath, inspected, staleMs, nowMs);
         },
+        staleRecovery: "remove-if-unchanged",
+        shouldRemoveStaleLock: async ({ lockPath, normalizedTargetPath, payload }) =>
+          await shouldRemoveReportedStaleLock({
+            lockPath,
+            normalizedSessionFile: normalizedTargetPath,
+            payload: payload as LockFilePayload | null,
+            staleMs,
+          }),
       });
       return { release: lock.release };
     } catch (err) {
-      if (isFileLockError(err, "file_lock_stale")) {
-        const staleLockPath = (err as { lockPath?: string }).lockPath ?? lockPath;
-        if (
-          await removeReportedStaleLockIfStillStale({
-            lockPath: staleLockPath,
-            normalizedSessionFile,
-            staleMs,
-          })
-        ) {
-          continue;
-        }
-      }
       if (!isFileLockError(err, "file_lock_timeout")) {
         throw err;
       }
@@ -797,6 +809,17 @@ export const __testing = {
   setProcessStartTimeResolverForTest(resolver: ((pid: number) => number | null) | null): void {
     resolveProcessStartTimeForLock = resolver ?? getProcessStartTime;
   },
+  setBeforeStaleLockRemovalForTest(
+    hook:
+      | ((params: {
+          lockPath: string;
+          normalizedSessionFile: string;
+          payload: LockFilePayload | null;
+        }) => void | Promise<void>)
+      | null,
+  ): void {
+    beforeStaleLockRemovalForTest = hook;
+  },
 };
 
 export async function drainSessionWriteLockStateForTest(): Promise<void> {
@@ -810,4 +833,5 @@ export function resetSessionWriteLockStateForTest(): void {
   stopWatchdogTimer();
   unregisterCleanupHandlers();
   resolveProcessStartTimeForLock = getProcessStartTime;
+  beforeStaleLockRemovalForTest = null;
 }


### PR DESCRIPTION
## Summary

Fixes #57019.

Session write-lock stale recovery now uses `@openclaw/fs-safe`'s snapshot-safe `staleRecovery: "remove-if-unchanged"` path instead of re-reading a reported stale lock and deleting it directly by path in OpenClaw's wrapper.

## Problem summary

When `SESSION_LOCKS.acquire()` reported `file_lock_stale`, `acquireSessionWriteLock()` re-read the lock file and called `fs.rm(lockPath, { force: true })` itself before retrying. That second path was not tied to the exact sidecar snapshot that fs-safe had observed, so a lock file that changed between stale detection and cleanup could still be removed by path.

## Root cause

The session-lock wrapper duplicated stale cleanup outside the file-lock dependency. `@openclaw/fs-safe` already has a remove-if-unchanged recovery mode that re-reads the sidecar and compares the raw content/file identity before unlinking; OpenClaw was not opting into that contract and instead performed a path-only removal after `file_lock_stale`.

## Architectural reasoning

The stale-owner policy remains in `src/agents/session-write-lock.ts`: dead PID, recycled PID, non-OpenClaw owner, orphan self-PID, payloadless, and mtime fallback decisions still use the existing `inspectLockPayloadForSession()` and `shouldReclaimContendedLockFile()` logic.

The actual deletion now belongs to the lower-level lock manager, which is the component that owns the observed sidecar snapshot. This avoids a hidden coupling between stale classification and path deletion while preserving the existing retry/acquire behavior for genuinely stale locks.

## Behavior proof

Behavior addressed: session lock stale recovery no longer deletes a lock file if the file changes after stale classification but before removal.

Real environment tested: local Windows checkout on branch `Hemant/session-lock-stale-snapshot`, Node v22.15.0 (below the repo's declared >=22.16.0 engine; commands completed with the existing engine warning). The branch was rebased onto upstream/main `73ca3cf3c3dd3940b82f4680e6a38fc36e272d81`; upstream moved again while checks ran, and GitHub reported the PR mergeable after push.

Exact steps or command run after this patch:

```text
pnpm test src/agents/session-write-lock.test.ts -- --reporter=verbose
pnpm format:check -- src/agents/session-write-lock.ts src/agents/session-write-lock.test.ts
pnpm check:changed
git diff --check upstream/main..HEAD
rtk node --import tsx --input-type=module -e "<one-off script invoking production acquireSessionWriteLock with a deterministic stale-removal race hook>"
```

Evidence after fix: `src/agents/session-write-lock.test.ts` passed 35/35 tests, including the regression `does not remove a changed lock file during stale acquisition recovery`; format check passed for the two touched files; `pnpm check:changed` exited 0; `git diff --check upstream/main..HEAD` exited 0. GitHub Workflow Sanity, OpenGrep, CI, CodeQL, and CodeQL Critical Quality all passed on the refreshed head.

Additional terminal behavior proof:

```json
{
  "behavior": "changed stale lock preserved during recovery",
  "hookCalls": 1,
  "finalRaw": "{}",
  "lockPreserved": true,
  "acquired": false,
  "errorName": "SessionWriteLockTimeoutError",
  "errorMessage": "session file locked (timeout 75ms): unknown <temp>/sessions.json.lock"
}
```

Observed result after fix: stale recovery still reclaims the existing stale lock cases, but both the focused regression and terminal proof mutate the lock during the approved removal window and verify acquisition fails closed with the changed lock file still present instead of unlinking it.

What was not tested: full `pnpm test` was not run locally. I relied on the focused session-lock test plus `check:changed`; CI completed successfully on this PR.

## Testing performed

Local proof on refreshed head `d21c47374092b4b4ee7d2afc810fb4ffed661123`:

- `pnpm test src/agents/session-write-lock.test.ts -- --reporter=verbose` passed: 35/35.
- `pnpm format:check -- src/agents/session-write-lock.ts src/agents/session-write-lock.test.ts`
- `pnpm check:changed`
- `git diff --check upstream/main..HEAD`
- `rtk node --import tsx --input-type=module -e "<one-off script invoking production acquireSessionWriteLock with a deterministic stale-removal race hook>"`

GitHub Actions on `d21c47374092b4b4ee7d2afc810fb4ffed661123`:

- Workflow Sanity #201593: success
- OpenGrep PR Diff #21215: success
- CI #207307: success
- CodeQL #17038: success
- CodeQL Critical Quality #17171: success

## Risk analysis

Risk is low-to-medium because this touches session lock cleanup and contention handling. The change is narrow: stale classification logic is unchanged, lock release logic is unchanged, and the deletion operation moves to fs-safe's existing snapshot guard. The main behavioral difference is fail-closed behavior if the lock file changes during stale recovery, which is the intended safety property for mutual exclusion.

## Backward compatibility

No public API, config, gateway protocol, or session file format changes. Existing stale lock recovery semantics are preserved for unchanged stale lock files; changed files are now protected from path-only deletion.