### PR TITLE
fix: ignore transcript-only assistant mirrors

### DIFF
--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -77,6 +77,78 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     return event;
   }
 
+  it("skips transcript-only OpenClaw assistant messages when reading latest assistant text", async () => {
+    const sessionFile = resolveSessionTranscriptPathInDir(
+      "latest-assistant-text",
+      fixture.sessionsDir(),
+    );
+    fs.writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({ type: "session", version: 1, id: "latest-assistant-text" }),
+        JSON.stringify({
+          type: "message",
+          id: "real-assistant",
+          message: createExactAssistantMessage({ text: "Real Telegram reply" }),
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "delivery-mirror",
+          message: createExactAssistantMessage({
+            text: "Earlier mirrored text",
+            provider: "openclaw",
+            model: "delivery-mirror",
+          }),
+        }),
+        JSON.stringify({
+          type: "message",
+          id: "gateway-injected",
+          message: createExactAssistantMessage({
+            text: "Gateway injected transcript note",
+            provider: "openclaw",
+            model: "gateway-injected",
+          }),
+        }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+
+    await expect(readLatestAssistantTextFromSessionTranscript(sessionFile)).resolves.toEqual({
+      id: "real-assistant",
+      text: "Real Telegram reply",
+      timestamp: expect.any(Number),
+    });
+  });
+
+  it("keeps non-OpenClaw assistant messages with delivery-like model names visible", async () => {
+    const sessionFile = resolveSessionTranscriptPathInDir(
+      "latest-assistant-provider-boundary",
+      fixture.sessionsDir(),
+    );
+    fs.writeFileSync(
+      sessionFile,
+      [
+        JSON.stringify({ type: "session", version: 1, id: "latest-assistant-provider-boundary" }),
+        JSON.stringify({
+          type: "message",
+          id: "external-assistant",
+          message: createExactAssistantMessage({
+            text: "External model reply",
+            provider: "not-openclaw",
+            model: "delivery-mirror",
+          }),
+        }),
+      ].join("\n") + "\n",
+      "utf-8",
+    );
+
+    await expect(readLatestAssistantTextFromSessionTranscript(sessionFile)).resolves.toEqual({
+      id: "external-assistant",
+      text: "External model reply",
+      timestamp: expect.any(Number),
+    });
+  });
+
   it("creates transcript file and appends message for valid session", async () => {
     writeTranscriptStore();
 

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -80,8 +80,10 @@ function parseAssistantTranscriptText(line: string): AssistantTranscriptText | u
     id?: unknown;
     message?: unknown;
   };
-  const message = parsed.message as { role?: unknown; timestamp?: unknown } | undefined;
-  if (!message || message.role !== "assistant") {
+  const message = parsed.message as
+    | { role?: unknown; timestamp?: unknown; provider?: unknown; model?: unknown }
+    | undefined;
+  if (!message || message.role !== "assistant" || isTranscriptOnlyOpenClawAssistant(message)) {
     return undefined;
   }
   const text = extractAssistantVisibleText(message)?.trim();
@@ -95,6 +97,16 @@ function parseAssistantTranscriptText(line: string): AssistantTranscriptText | u
       ? { timestamp: message.timestamp }
       : {}),
   };
+}
+
+function isTranscriptOnlyOpenClawAssistant(message: {
+  provider?: unknown;
+  model?: unknown;
+}): boolean {
+  return (
+    message.provider === "openclaw" &&
+    (message.model === "delivery-mirror" || message.model === "gateway-injected")
+  );
 }
 
 export async function resolveSessionTranscriptFile(params: {


### PR DESCRIPTION
## Summary
- skip OpenClaw transcript-only assistant rows when resolving latest assistant text from session transcripts
- keep the filter scoped to `provider=openclaw` with `delivery-mirror` / `gateway-injected` models
- add regression coverage for mirror/injected rows and provider-boundary behavior

Fixes #83159

## Real behavior proof
- **Behavior or issue addressed:** Telegram finalization must not treat transcript-only OpenClaw assistant rows (`provider=openclaw`, `model=delivery-mirror` or `gateway-injected`) as the latest assistant answer.
- **Real environment tested:** Local OpenClaw source checkout on Node v22.19.0, using the patched runtime `readLatestAssistantTextFromSessionTranscript` implementation against a real temp JSONL session transcript file.
- **Exact steps or command run after this patch:** Ran the following command after the patch in this branch:

```console
$ node --import tsx --input-type=module <<'EOF'
import fs from 'node:fs';
import os from 'node:os';
import path from 'node:path';
import { readLatestAssistantTextFromSessionTranscript } from './src/config/sessions/transcript.ts';

const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'openclaw-real-proof-'));
const sessionFile = path.join(dir, 'session.jsonl');
fs.writeFileSync(sessionFile, [
  JSON.stringify({ type: 'session', version: 1, id: 'proof-session' }),
  JSON.stringify({
    type: 'message',
    id: 'real-current-reply',
    message: {
      role: 'assistant',
      provider: 'anthropic',
      model: 'claude-opus-4-7',
      content: [{ type: 'text', text: 'CURRENT TELEGRAM ANSWER' }],
      timestamp: 1779050000000,
    },
  }),
  JSON.stringify({
    type: 'message',
    id: 'later-delivery-mirror',
    message: {
      role: 'assistant',
      provider: 'openclaw',
      model: 'delivery-mirror',
      content: [{ type: 'text', text: 'EARLIER MIRRORED FRAGMENT' }],
      timestamp: 1779050005000,
    },
  }),
].join('\n') + '\n');
const latest = await readLatestAssistantTextFromSessionTranscript(sessionFile);
console.log(JSON.stringify({ latest }, null, 2));
EOF
```

- **Evidence after fix:** Terminal output from the live command above:

```console
{
  "latest": {
    "id": "real-current-reply",
    "text": "CURRENT TELEGRAM ANSWER",
    "timestamp": 1779050000000
  }
}
```

- **Observed result after fix:** The transcript reader returned the actual Anthropic assistant reply even though a later OpenClaw `delivery-mirror` transcript row existed, so Telegram's final-text candidate does not select the mirrored earlier fragment.
- **What was not tested:** A live Telegram bot delivery with real Telegram credentials was not run; focused Telegram delivery tests and the runtime transcript proof above cover the changed path.

## Verification
- `node scripts/run-vitest.mjs extensions/telegram/src/lane-delivery.test.ts extensions/telegram/src/bot-message-dispatch.test.ts src/config/sessions/transcript.test.ts`
- `corepack pnpm exec oxfmt --check src/config/sessions/transcript.ts src/config/sessions/transcript.test.ts`
- `git diff --check`

Fresh-context verifier: no blockers found.
