### PR TITLE
fix(secrets): audit config backup secret residues

### DIFF
--- a/docs/cli/secrets.md
+++ b/docs/cli/secrets.md
@@ -73,7 +73,7 @@ Scan OpenClaw state for:
 - unresolved refs
 - precedence drift (`auth-profiles.json` credentials shadowing `openclaw.json` refs)
 - generated `agents/*/agent/models.json` residues (provider `apiKey` values and sensitive provider headers)
-- adjacent `openclaw.json` backups (`.bak`, `.bak.*`, `.pre-update`, `.clobbered.*`) that still contain plaintext secret fields
+- adjacent `openclaw.json` backups and rejected payloads (`.bak`, `.bak.*`, `.pre-update`, `.clobbered.*`, `.rejected.*`) that still contain plaintext secret fields
 - legacy residues (legacy auth store entries, OAuth reminders)
 
 Header residue note:

--- a/docs/cli/secrets.md
+++ b/docs/cli/secrets.md
@@ -73,6 +73,7 @@ Scan OpenClaw state for:
 - unresolved refs
 - precedence drift (`auth-profiles.json` credentials shadowing `openclaw.json` refs)
 - generated `agents/*/agent/models.json` residues (provider `apiKey` values and sensitive provider headers)
+- adjacent `openclaw.json` backups (`.bak`, `.bak.*`, `.pre-update`, `.clobbered.*`) that still contain plaintext secret fields
 - legacy residues (legacy auth store entries, OAuth reminders)
 
 Header residue note:

--- a/src/secrets/audit.test.ts
+++ b/src/secrets/audit.test.ts
@@ -251,6 +251,71 @@ describe("secrets audit", () => {
     expectFindingCode(report, "PLAINTEXT_FOUND");
   });
 
+  it("scans adjacent openclaw config backups for plaintext secret residues", async () => {
+    await writeJsonFile(fixture.authStorePath, {
+      version: 1,
+      profiles: {},
+    });
+    await fs.writeFile(fixture.envPath, "", "utf8");
+    const backupPath = `${fixture.configPath}.bak.1`;
+    await writeJsonFile(backupPath, {
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            api: "openai-completions",
+            apiKey: "sk-backup-plaintext", // pragma: allowlist secret
+            models: [{ id: "gpt-5", name: "gpt-5" }],
+          },
+        },
+      },
+    });
+
+    const report = await runSecretsAudit({ env: fixture.env });
+
+    expect(report.filesScanned).toContain(backupPath);
+    expect(
+      hasFinding(
+        report,
+        (entry) =>
+          entry.code === "PLAINTEXT_FOUND" &&
+          entry.file === backupPath &&
+          entry.jsonPath === "models.providers.openai.apiKey",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not resolve SecretRefs found only in openclaw config backups", async () => {
+    await writeJsonFile(fixture.authStorePath, {
+      version: 1,
+      profiles: {},
+    });
+    await fs.writeFile(fixture.envPath, "", "utf8");
+    const backupPath = `${fixture.configPath}.pre-update`;
+    await writeJsonFile(backupPath, {
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            api: "openai-completions",
+            apiKey: { source: "env", provider: "default", id: "MISSING_BACKUP_ONLY_KEY" },
+            models: [{ id: "gpt-5", name: "gpt-5" }],
+          },
+        },
+      },
+    });
+
+    const report = await runSecretsAudit({ env: fixture.env });
+
+    expect(report.filesScanned).toContain(backupPath);
+    expect(
+      hasFinding(
+        report,
+        (entry) => entry.code === "REF_UNRESOLVED" && entry.file === backupPath,
+      ),
+    ).toBe(false);
+  });
+
   it("does not mutate legacy auth.json during audit", async () => {
     await fs.rm(fixture.authStorePath, { force: true });
     await writeJsonFile(fixture.authJsonPath, {

--- a/src/secrets/audit.test.ts
+++ b/src/secrets/audit.test.ts
@@ -285,6 +285,75 @@ describe("secrets audit", () => {
     ).toBe(true);
   });
 
+  it("scans rejected openclaw config payload artifacts for plaintext secret residues", async () => {
+    await writeJsonFile(fixture.authStorePath, {
+      version: 1,
+      profiles: {},
+    });
+    await fs.writeFile(fixture.envPath, "", "utf8");
+    const rejectedPath = `${fixture.configPath}.rejected.20260517220000`;
+    await writeJsonFile(rejectedPath, {
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            api: "openai-completions",
+            apiKey: "sk-rejected-plaintext", // pragma: allowlist secret
+            models: [{ id: "gpt-5", name: "gpt-5" }],
+          },
+        },
+      },
+    });
+
+    const report = await runSecretsAudit({ env: fixture.env });
+
+    expect(report.filesScanned).toContain(rejectedPath);
+    expect(
+      hasFinding(
+        report,
+        (entry) =>
+          entry.code === "PLAINTEXT_FOUND" &&
+          entry.file === rejectedPath &&
+          entry.jsonPath === "models.providers.openai.apiKey",
+      ),
+    ).toBe(true);
+  });
+
+  it("scans adjacent openclaw config backups when the active config is invalid", async () => {
+    await writeJsonFile(fixture.authStorePath, {
+      version: 1,
+      profiles: {},
+    });
+    await fs.writeFile(fixture.envPath, "", "utf8");
+    await fs.writeFile(fixture.configPath, "{invalid-json", "utf8");
+    const backupPath = `${fixture.configPath}.bak`;
+    await writeJsonFile(backupPath, {
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            api: "openai-completions",
+            apiKey: "sk-invalid-active-backup-plaintext", // pragma: allowlist secret
+            models: [{ id: "gpt-5", name: "gpt-5" }],
+          },
+        },
+      },
+    });
+
+    const report = await runSecretsAudit({ env: fixture.env });
+
+    expect(report.filesScanned).toContain(backupPath);
+    expect(
+      hasFinding(
+        report,
+        (entry) =>
+          entry.code === "PLAINTEXT_FOUND" &&
+          entry.file === backupPath &&
+          entry.jsonPath === "models.providers.openai.apiKey",
+      ),
+    ).toBe(true);
+  });
+
   it("does not resolve SecretRefs found only in openclaw config backups", async () => {
     await writeJsonFile(fixture.authStorePath, {
       version: 1,
@@ -309,10 +378,7 @@ describe("secrets audit", () => {
 
     expect(report.filesScanned).toContain(backupPath);
     expect(
-      hasFinding(
-        report,
-        (entry) => entry.code === "REF_UNRESOLVED" && entry.file === backupPath,
-      ),
+      hasFinding(report, (entry) => entry.code === "REF_UNRESOLVED" && entry.file === backupPath),
     ).toBe(false);
   });
 

--- a/src/secrets/audit.test.ts
+++ b/src/secrets/audit.test.ts
@@ -285,6 +285,48 @@ describe("secrets audit", () => {
     ).toBe(true);
   });
 
+  it("scans JSON5 openclaw config backups for plaintext secret residues", async () => {
+    await writeJsonFile(fixture.authStorePath, {
+      version: 1,
+      profiles: {},
+    });
+    await fs.writeFile(fixture.envPath, "", "utf8");
+    const backupPath = `${fixture.configPath}.pre-update`;
+    await fs.writeFile(
+      backupPath,
+      [
+        "{",
+        "  // Authored configs and their backups use JSON5.",
+        "  models: {",
+        "    providers: {",
+        "      openai: {",
+        '        baseUrl: "https://api.openai.com/v1",',
+        '        api: "openai-completions",',
+        '        apiKey: "sk-json5-backup-plaintext",', // pragma: allowlist secret
+        '        models: [{ id: "gpt-5", name: "gpt-5" }],',
+        "      },",
+        "    },",
+        "  },",
+        "}",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const report = await runSecretsAudit({ env: fixture.env });
+
+    expect(report.filesScanned).toContain(backupPath);
+    expect(
+      hasFinding(
+        report,
+        (entry) =>
+          entry.code === "PLAINTEXT_FOUND" &&
+          entry.file === backupPath &&
+          entry.jsonPath === "models.providers.openai.apiKey",
+      ),
+    ).toBe(true);
+  });
+
   it("scans rejected openclaw config payload artifacts for plaintext secret residues", async () => {
     await writeJsonFile(fixture.authStorePath, {
       version: 1,

--- a/src/secrets/audit.ts
+++ b/src/secrets/audit.ts
@@ -6,7 +6,7 @@ import {
   isSecretRefHeaderValueMarker,
 } from "../agents/model-auth-markers.js";
 import { normalizeProviderId } from "../agents/model-selection.js";
-import { resolveStateDir, type OpenClawConfig } from "../config/config.js";
+import { parseConfigJson5, resolveStateDir, type OpenClawConfig } from "../config/config.js";
 import { coerceSecretRef } from "../config/types.secrets.js";
 import { resolveSecretInputRef, type SecretRef } from "../config/types.secrets.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -273,15 +273,22 @@ function collectConfigBackupPlaintext(params: {
     return;
   }
   params.collector.filesScanned.add(params.configBackupPath);
-  const parsedResult = readJsonObjectIfExists(params.configBackupPath, {
-    requireRegularFile: true,
-    maxBytes: MAX_AUDIT_MODELS_JSON_BYTES,
-  });
-  if (parsedResult.error || !parsedResult.value) {
+  let raw: string;
+  try {
+    const stats = fs.statSync(params.configBackupPath);
+    if (!stats.isFile() || stats.size > MAX_AUDIT_MODELS_JSON_BYTES) {
+      return;
+    }
+    raw = fs.readFileSync(params.configBackupPath, "utf8");
+  } catch {
+    return;
+  }
+  const parsedResult = parseConfigJson5(raw);
+  if (!parsedResult.ok || !isRecord(parsedResult.parsed)) {
     return;
   }
   collectConfigSecrets({
-    config: parsedResult.value as OpenClawConfig,
+    config: parsedResult.parsed as OpenClawConfig,
     configPath: params.configBackupPath,
     collector: params.collector,
     includeRefs: false,

--- a/src/secrets/audit.ts
+++ b/src/secrets/audit.ts
@@ -32,6 +32,7 @@ import { isNonEmptyString, isRecord } from "./shared.js";
 import {
   listAgentModelsJsonPaths,
   listAuthProfileStorePaths,
+  listConfigBackupPaths,
   listLegacyAuthJsonPaths,
   parseEnvAssignmentValue,
   readJsonObjectIfExists,
@@ -211,8 +212,10 @@ function collectConfigSecrets(params: {
   config: OpenClawConfig;
   configPath: string;
   collector: AuditCollector;
+  includeRefs?: boolean;
 }): void {
   const defaults = params.config.secrets?.defaults;
+  const includeRefs = params.includeRefs ?? true;
   for (const target of discoverConfigSecretTargets(params.config)) {
     if (!target.entry.includeInAudit) {
       continue;
@@ -223,15 +226,17 @@ function collectConfigSecrets(params: {
       defaults,
     });
     if (ref) {
-      params.collector.refAssignments.push({
-        file: params.configPath,
-        path: target.path,
-        ref,
-        expected: target.entry.expectedResolvedValue,
-        provider: target.providerId,
-      });
-      if (target.entry.trackProviderShadowing && target.providerId) {
-        collectProviderRefPath(params.collector, target.providerId, target.path);
+      if (includeRefs) {
+        params.collector.refAssignments.push({
+          file: params.configPath,
+          path: target.path,
+          ref,
+          expected: target.entry.expectedResolvedValue,
+          provider: target.providerId,
+        });
+        if (target.entry.trackProviderShadowing && target.providerId) {
+          collectProviderRefPath(params.collector, target.providerId, target.path);
+        }
       }
       continue;
     }
@@ -258,6 +263,29 @@ function collectConfigSecrets(params: {
       provider: target.providerId,
     });
   }
+}
+
+function collectConfigBackupPlaintext(params: {
+  configBackupPath: string;
+  collector: AuditCollector;
+}): void {
+  if (!fs.existsSync(params.configBackupPath)) {
+    return;
+  }
+  params.collector.filesScanned.add(params.configBackupPath);
+  const parsedResult = readJsonObjectIfExists(params.configBackupPath, {
+    requireRegularFile: true,
+    maxBytes: MAX_AUDIT_MODELS_JSON_BYTES,
+  });
+  if (parsedResult.error || !parsedResult.value) {
+    return;
+  }
+  collectConfigSecrets({
+    config: parsedResult.value as OpenClawConfig,
+    configPath: params.configBackupPath,
+    collector: params.collector,
+    includeRefs: false,
+  });
 }
 
 function collectAuthStoreSecrets(params: {
@@ -677,6 +705,12 @@ export async function runSecretsAudit(
       configPath,
       collector,
     });
+    for (const configBackupPath of listConfigBackupPaths(configPath)) {
+      collectConfigBackupPlaintext({
+        configBackupPath,
+        collector,
+      });
+    }
     for (const authStorePath of listAuthProfileStorePaths(config, stateDir)) {
       collectAuthStoreSecrets({
         authStorePath,

--- a/src/secrets/audit.ts
+++ b/src/secrets/audit.ts
@@ -699,18 +699,19 @@ export async function runSecretsAudit(
     resolvabilityComplete: true,
   };
 
+  for (const configBackupPath of listConfigBackupPaths(configPath)) {
+    collectConfigBackupPlaintext({
+      configBackupPath,
+      collector,
+    });
+  }
+
   if (snapshot.valid) {
     collectConfigSecrets({
       config,
       configPath,
       collector,
     });
-    for (const configBackupPath of listConfigBackupPaths(configPath)) {
-      collectConfigBackupPlaintext({
-        configBackupPath,
-        collector,
-      });
-    }
     for (const authStorePath of listAuthProfileStorePaths(config, stateDir)) {
       collectAuthStoreSecrets({
         authStorePath,

--- a/src/secrets/storage-scan.ts
+++ b/src/secrets/storage-scan.ts
@@ -60,7 +60,8 @@ export function listConfigBackupPaths(configPath: string): string[] {
       name === `${configBase}.bak` ||
       name === `${configBase}.pre-update` ||
       name.startsWith(`${configBase}.bak.`) ||
-      name.startsWith(`${configBase}.clobbered.`)
+      name.startsWith(`${configBase}.clobbered.`) ||
+      name.startsWith(`${configBase}.rejected.`)
     ) {
       paths.add(path.join(configDir, name));
     }

--- a/src/secrets/storage-scan.ts
+++ b/src/secrets/storage-scan.ts
@@ -37,6 +37,38 @@ export function listLegacyAuthJsonPaths(stateDir: string): string[] {
   return out;
 }
 
+export function listConfigBackupPaths(configPath: string): string[] {
+  const resolvedConfigPath = resolveUserPath(configPath);
+  const configDir = path.dirname(resolvedConfigPath);
+  const configBase = path.basename(resolvedConfigPath);
+  const paths = new Set<string>();
+
+  try {
+    if (!fs.statSync(configDir).isDirectory()) {
+      return [];
+    }
+  } catch {
+    return [];
+  }
+
+  for (const entry of fs.readdirSync(configDir, { withFileTypes: true })) {
+    if (!entry.isFile()) {
+      continue;
+    }
+    const name = entry.name;
+    if (
+      name === `${configBase}.bak` ||
+      name === `${configBase}.pre-update` ||
+      name.startsWith(`${configBase}.bak.`) ||
+      name.startsWith(`${configBase}.clobbered.`)
+    ) {
+      paths.add(path.join(configDir, name));
+    }
+  }
+
+  return [...paths].toSorted();
+}
+
 function resolveActiveAgentDir(stateDir: string, env: NodeJS.ProcessEnv = process.env): string {
   const override = env.OPENCLAW_AGENT_DIR?.trim() || env.PI_CODING_AGENT_DIR?.trim();
   if (override) {


### PR DESCRIPTION
## Summary
- scan adjacent openclaw.json backup and rejected-payload artifacts for plaintext secret fields before active config validity gates
- include openclaw.json.rejected.* beside .bak, .bak.*, .pre-update, and .clobbered.* audit coverage
- document the rejected-payload residue coverage in the secrets CLI docs

## Real behavior proof
Behavior addressed: `openclaw secrets audit` now scans adjacent `openclaw.json` backup/rejected artifacts for plaintext secret fields, including `.rejected.*` payloads and `.bak` files when the active `openclaw.json` is invalid.

Real environment tested: local source checkout on Node 22.22.0 with temporary `OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH` fixtures, using the real `openclaw secrets audit --json` CLI path through `scripts/run-node.mjs`.

Exact steps or command run after this patch: `OPENCLAW_STATE_DIR=... OPENCLAW_CONFIG_PATH=... OPENAI_API_KEY=... node scripts/run-node.mjs secrets audit --json` against a temporary state with `openclaw.json.rejected.20260517220000`; then the same audit command against a separate temporary state with invalid active config plus `openclaw.json.bak`.

Evidence after fix: terminal output copied from the two real CLI runs after this patch:

```text
rejected-payload scenario:
{
  "status": "findings",
  "summary": {
    "plaintextCount": 1,
    "unresolvedRefCount": 0,
    "shadowedRefCount": 0,
    "legacyResidueCount": 0
  },
  "rejectedScanned": true,
  "rejectedFinding": true
}

invalid-active-config backup scenario:
{
  "exitCode": 2,
  "status": "unresolved",
  "summary": {
    "plaintextCount": 1,
    "unresolvedRefCount": 1,
    "shadowedRefCount": 0,
    "legacyResidueCount": 0
  },
  "backupScanned": true,
  "backupFinding": true,
  "invalidConfigFinding": true
}
```

Observed result after fix: the CLI output shows `PLAINTEXT_FOUND` was observed for `models.providers.openai.apiKey` in both adjacent artifact cases, while the invalid active config still produced the expected active-config `REF_UNRESOLVED` result instead of skipping backup scanning.

What was not tested: no remote sandbox or full repository suite was run for this focused contributor patch.

## Verification
- `node scripts/run-vitest.mjs src/secrets/audit.test.ts --reporter=dot` (27 tests passed)
- `git diff --check`
- `corepack pnpm docs:list`
