### PR TITLE
fix(telegram): delete progress draft before final reply

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1161,7 +1161,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(rotationOrder).toBeLessThan(finalUpdateOrder);
   });
 
-  it("keeps progress updates in a draft and sends the final answer normally", async () => {
+  it("deletes progress updates before sending the final answer normally", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
       async ({ dispatcherOptions, replyOptions }) => {
@@ -1186,8 +1186,8 @@ describe("dispatchTelegramMessage draft streaming", () => {
       "Cracking...\n`🛠️ Exec`\n`🛠️ git rev-parse --abbrev-ref HEAD`",
     );
     expect(answerDraftStream.update).not.toHaveBeenCalledWith("Branch is up to date");
-    expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
-    expect(answerDraftStream.clear).not.toHaveBeenCalled();
+    expect(answerDraftStream.clear).toHaveBeenCalledTimes(1);
+    expect(answerDraftStream.forceNewMessage).not.toHaveBeenCalled();
     expectDeliveredReply(0, { text: "Branch is up to date" });
     expect(editMessageTelegram).not.toHaveBeenCalled();
   });

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1125,12 +1125,10 @@ export const dispatchTelegramMessage = async ({
       payload: ReplyPayload,
       text: string,
     ): Promise<LaneDeliveryResult> => {
-      if (activeAnswerDraftIsToolProgressOnly) {
-        await rotateAnswerLaneAfterToolProgress();
-      } else {
-        await answerLane.stream?.clear();
-        resetDraftLaneState(answerLane);
-      }
+      await answerLane.stream?.clear();
+      resetDraftLaneState(answerLane);
+      streamToolProgressSuppressed = true;
+      streamToolProgressLines = [];
       const delivered = await sendPayload(applyTextToPayload(payload, text), { durable: true });
       answerLane.finalized = true;
       return delivered ? { kind: "sent" } : { kind: "skipped" };


### PR DESCRIPTION
## Summary

- delete Telegram progress-mode draft messages before sending the durable final reply
- keep the existing streamed answer rotation behavior outside progress mode
- update the Telegram dispatch regression test to assert cleanup instead of retaining the progress draft

## Verification

- `git diff --check -- extensions/telegram/src/bot-message-dispatch.ts extensions/telegram/src/bot-message-dispatch.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test extensions/telegram/src/bot-message-dispatch.test.ts --testNamePattern "deletes progress updates" --hookTimeout=300000`

