### PR TITLE
feat(codex): add plugin list enable disable commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 - Agents/skills: tighten bundled skill prompts and metadata, quote skill descriptions, refresh current CLI/API guidance, and update embedded sherpa-onnx runtime downloads.
 - Skills: update the Obsidian skill to target the official `obsidian` CLI and require its registered binary instead of the third-party `obsidian-cli`.
 - Skills: add a Python debugging skill for pdb, breakpoint(), post-mortem inspection, and debugpy remote attach.
+- Codex: add `/codex plugins list`, `enable`, and `disable` for managing configured native Codex plugins from chat without editing config by hand.
 - Plugins/messages: add presentation capability limits for channel renderers, adapt rich message controls before native rendering, and mark legacy `interactive`/Slack directive producer APIs as deprecated.
 - Proxy: support HTTPS managed forward-proxy endpoints and scoped `proxy.tls.caFile` CA trust for proxy endpoint TLS. (#79171) Thanks @jesse-merhi.
 - QA-Lab: add first-hour 20-turn and optional 100-turn runtime parity scenarios, with tier metadata for standard and soak QA gates. Fixes #80338; refs #80337. Thanks @100yenadmin.

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -201,6 +201,8 @@ Common command routing:
 | Attach the current chat                               | `/codex bind [--cwd <path>]`                                                                          |
 | Resume an existing Codex thread                       | `/codex resume <thread-id>`                                                                           |
 | List or filter Codex threads                          | `/codex threads [filter]`                                                                             |
+| List native Codex plugins                             | `/codex plugins list`                                                                                 |
+| Enable or disable a configured native Codex plugin    | `/codex plugins enable <name>`, `/codex plugins disable <name>`                                       |
 | Attach an existing Codex CLI session on a paired node | `/codex sessions --host <node> [filter]`, then `/codex resume <session-id> --host <node> --bind here` |
 | Send Codex feedback only                              | `/codex diagnostics [note]`                                                                           |
 | Start an ACP/acpx task                                | ACP/acpx session commands, not `/codex`                                                               |

--- a/docs/plugins/codex-native-plugins.md
+++ b/docs/plugins/codex-native-plugins.md
@@ -81,8 +81,35 @@ config looks like this:
 }
 ```
 
-After changing `codexPlugins`, use `/new`, `/reset`, or restart the gateway so
-future Codex harness sessions start with the updated app set.
+After changing `codexPlugins`, new Codex conversations pick up the updated app
+set automatically. Use `/new` or `/reset` to refresh the current conversation.
+A gateway restart is not required for plugin enable or disable changes.
+
+## Manage plugins from chat
+
+Use `/codex plugins` when you want to inspect or change configured native Codex
+plugins from the same chat where you operate the Codex harness:
+
+```text
+/codex plugins
+/codex plugins list
+/codex plugins disable google-calendar
+/codex plugins enable google-calendar
+```
+
+`/codex plugins` is an alias for `/codex plugins list`. The list output shows
+the configured plugin keys, on/off state, Codex plugin name, and marketplace
+from `plugins.entries.codex.config.codexPlugins.plugins`.
+
+`enable` and `disable` write only to OpenClaw config at
+`~/.openclaw/openclaw.json`; they do not edit `~/.codex/config.toml` or install
+new Codex plugins. Only the owner or a gateway client with the
+`operator.admin` scope can change plugin state.
+
+Enabling a configured plugin also turns on the global
+`codexPlugins.enabled` switch. If the plugin was written disabled because
+migration returned `auth_required`, reauthorize the app in Codex before enabling
+it in OpenClaw.
 
 ## How native plugin setup works
 
@@ -110,7 +137,10 @@ check after migration. Codex harness session setup then computes a restrictive
 thread app config for the enabled and accessible plugin apps.
 
 Thread app config is computed when OpenClaw establishes a Codex harness session
-or replaces a stale Codex thread binding. It is not recomputed on every turn.
+or replaces a stale Codex thread binding. It is not recomputed on every turn, so
+`/codex plugins enable` and `/codex plugins disable` affect new Codex
+conversations. Use `/new` or `/reset` when the current conversation should pick
+up the updated app set.
 
 ## V1 support boundary
 
@@ -228,10 +258,10 @@ apps until ownership and readiness are known.
 **`app_ownership_ambiguous`:** app inventory only matched by display name, so
 the app is not exposed to the Codex thread.
 
-**Config changed but the agent cannot see the plugin:** use `/new`, `/reset`, or
-restart the gateway. Existing Codex thread bindings keep the app config they
-started with until OpenClaw establishes a new harness session or replaces a
-stale binding.
+**Config changed but the agent cannot see the plugin:** use `/codex plugins
+list` to confirm the configured state, then use `/new` or `/reset`. Existing
+Codex thread bindings keep the app config they started with until OpenClaw
+establishes a new harness session or replaces a stale binding.
 
 **Destructive action is declined:** check the global and per-plugin
 `allow_destructive_actions` values. Even when policy is true, unsafe elicitation

--- a/extensions/codex/index.ts
+++ b/extensions/codex/index.ts
@@ -5,6 +5,7 @@ import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { createCodexAppServerAgentHarness } from "./harness.js";
 import { buildCodexMediaUnderstandingProvider } from "./media-understanding-provider.js";
 import { buildCodexProvider } from "./provider.js";
+import type { CodexPluginsConfigBlock } from "./src/command-plugins-management.js";
 import { createCodexCommand } from "./src/commands.js";
 import {
   handleCodexConversationBindingResolved,
@@ -77,9 +78,12 @@ export default definePluginEntry({
               }
               const declared = (codexPlugins as Record<string, unknown>).plugins;
               if (!declared || typeof declared !== "object") {
-                return Promise.resolve({});
+                return Promise.resolve({
+                  enabled: (codexPlugins as Record<string, unknown>).enabled === true,
+                });
               }
               return Promise.resolve({
+                enabled: (codexPlugins as Record<string, unknown>).enabled === true,
                 plugins: declared as Record<string, never>,
               });
             },
@@ -98,7 +102,7 @@ export default definePluginEntry({
                   config.codexPlugins = (config.codexPlugins ?? {}) as Record<string, unknown>;
                   const codexPlugins = config.codexPlugins as Record<string, unknown>;
                   codexPlugins.plugins = (codexPlugins.plugins ?? {}) as Record<string, unknown>;
-                  update(codexPlugins.plugins as Record<string, never>);
+                  update(codexPlugins as CodexPluginsConfigBlock);
                 },
               });
             },

--- a/extensions/codex/index.ts
+++ b/extensions/codex/index.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { mutateConfigFile } from "openclaw/plugin-sdk/config-mutation";
 import { resolveLivePluginConfigObject } from "openclaw/plugin-sdk/plugin-config-runtime";
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import { createCodexAppServerAgentHarness } from "./harness.js";
@@ -51,6 +52,57 @@ export default definePluginEntry({
             listCodexCliSessionsOnNode({ runtime: api.runtime, ...params }),
           resolveCodexCliSessionForBindingOnNode: (params) =>
             resolveCodexCliSessionForBindingOnNode({ runtime: api.runtime, ...params }),
+          codexPluginsManagementIo: {
+            readConfig: () => {
+              const current = (api.runtime.config?.current?.() ?? {}) as OpenClawConfig;
+              const plugins = (current as Record<string, unknown>).plugins;
+              if (!plugins || typeof plugins !== "object") {
+                return Promise.resolve({});
+              }
+              const entries = (plugins as Record<string, unknown>).entries;
+              if (!entries || typeof entries !== "object") {
+                return Promise.resolve({});
+              }
+              const codexEntry = (entries as Record<string, unknown>).codex;
+              if (!codexEntry || typeof codexEntry !== "object") {
+                return Promise.resolve({});
+              }
+              const config = (codexEntry as Record<string, unknown>).config;
+              if (!config || typeof config !== "object") {
+                return Promise.resolve({});
+              }
+              const codexPlugins = (config as Record<string, unknown>).codexPlugins;
+              if (!codexPlugins || typeof codexPlugins !== "object") {
+                return Promise.resolve({});
+              }
+              const declared = (codexPlugins as Record<string, unknown>).plugins;
+              if (!declared || typeof declared !== "object") {
+                return Promise.resolve({});
+              }
+              return Promise.resolve({
+                plugins: declared as Record<string, never>,
+              });
+            },
+            mutate: async (update) => {
+              await mutateConfigFile({
+                mutate: (draft) => {
+                  const root = draft as Record<string, unknown>;
+                  root.plugins = (root.plugins ?? {}) as Record<string, unknown>;
+                  const pluginsBlock = root.plugins as Record<string, unknown>;
+                  pluginsBlock.entries = (pluginsBlock.entries ?? {}) as Record<string, unknown>;
+                  const entries = pluginsBlock.entries as Record<string, unknown>;
+                  entries.codex = (entries.codex ?? {}) as Record<string, unknown>;
+                  const codexEntry = entries.codex as Record<string, unknown>;
+                  codexEntry.config = (codexEntry.config ?? {}) as Record<string, unknown>;
+                  const config = codexEntry.config as Record<string, unknown>;
+                  config.codexPlugins = (config.codexPlugins ?? {}) as Record<string, unknown>;
+                  const codexPlugins = config.codexPlugins as Record<string, unknown>;
+                  codexPlugins.plugins = (codexPlugins.plugins ?? {}) as Record<string, unknown>;
+                  update(codexPlugins.plugins as Record<string, never>);
+                },
+              });
+            },
+          },
         },
       }),
     );

--- a/extensions/codex/src/command-formatters.ts
+++ b/extensions/codex/src/command-formatters.ts
@@ -320,6 +320,7 @@ export function buildHelp(): string {
     "- /codex account",
     "- /codex mcp",
     "- /codex skills",
+    "- /codex plugins [list|enable|disable]",
   ].join("\n");
 }
 

--- a/extensions/codex/src/command-handlers.ts
+++ b/extensions/codex/src/command-handlers.ts
@@ -29,6 +29,10 @@ import {
   readString,
 } from "./command-formatters.js";
 import {
+  handleCodexPluginsSubcommand,
+  type CodexPluginsManagementIO,
+} from "./command-plugins-management.js";
+import {
   codexControlRequest,
   readCodexStatusProbes,
   requestOptions,
@@ -80,6 +84,7 @@ export type CodexCommandDeps = {
   stopCodexConversationTurn: typeof stopCodexConversationTurn;
   listCodexCliSessionsOnNode: ListCodexCliSessionsOnNodeFn;
   resolveCodexCliSessionForBindingOnNode: ResolveCodexCliSessionForBindingOnNodeFn;
+  codexPluginsManagementIo?: CodexPluginsManagementIO;
 };
 
 type CodexControlRequestFn = (
@@ -227,6 +232,16 @@ export async function handleCodexSubcommand(
   const normalized = subcommand.toLowerCase();
   if (normalized === "help") {
     return { text: buildHelp() };
+  }
+  if (normalized === "plugins") {
+    if (!deps.codexPluginsManagementIo) {
+      return {
+        text:
+          "Codex sub-plugin management is not wired up (codexPluginsManagementIo dep is undefined). " +
+          "Edit ~/.openclaw/openclaw.json or use `openclaw config patch` until the runtime exposes the IO.",
+      };
+    }
+    return await handleCodexPluginsSubcommand(ctx, rest, deps.codexPluginsManagementIo);
   }
   if (normalized === "status") {
     if (rest.length > 0) {

--- a/extensions/codex/src/command-plugins-management.test.ts
+++ b/extensions/codex/src/command-plugins-management.test.ts
@@ -26,52 +26,56 @@ const fakeCtx = {
 } as never;
 
 describe("Codex /codex plugins subcommand", () => {
-  it("lists configured plugins with on or off markers and explains the underlying file", async () => {
+  it("lists a configured plugin with its enabled marker and explains the underlying file", async () => {
     const io = inMemoryIO({
-      chrome: { enabled: true, marketplaceName: "openai-bundled", pluginName: "chrome" },
-      documents: {
-        enabled: false,
-        marketplaceName: "openai-primary-runtime",
-        pluginName: "documents",
+      "google-calendar": {
+        enabled: true,
+        marketplaceName: "openai-curated",
+        pluginName: "google-calendar",
       },
     });
 
     const result = await handleCodexPluginsSubcommand(fakeCtx, ["list"], io);
-    expect(result.text).toContain("ON   chrome");
-    expect(result.text).toContain("OFF  documents");
+    expect(result.text).toContain("ON   google-calendar");
     expect(result.text).toContain("openclaw.json");
   });
 
   it("enables and disables a configured plugin and reflects the change in subsequent reads", async () => {
     const io = inMemoryIO({
-      chrome: { enabled: true, marketplaceName: "openai-bundled", pluginName: "chrome" },
+      "google-calendar": {
+        enabled: true,
+        marketplaceName: "openai-curated",
+        pluginName: "google-calendar",
+      },
     });
 
-    const disabled = await handleCodexPluginsSubcommand(fakeCtx, ["disable", "chrome"], io);
+    const disabled = await handleCodexPluginsSubcommand(
+      fakeCtx,
+      ["disable", "google-calendar"],
+      io,
+    );
     expect(disabled.text).toContain("disabled");
-    expect(io.current().chrome.enabled).toBe(false);
+    expect(io.current()["google-calendar"]?.enabled).toBe(false);
 
-    const enabled = await handleCodexPluginsSubcommand(fakeCtx, ["enable", "chrome"], io);
+    const enabled = await handleCodexPluginsSubcommand(fakeCtx, ["enable", "google-calendar"], io);
     expect(enabled.text).toContain("enabled");
-    expect(io.current().chrome.enabled).toBe(true);
+    expect(io.current()["google-calendar"]?.enabled).toBe(true);
   });
 
   it("escapes configured plugin fields before listing them in chat", async () => {
     const io = inMemoryIO({
-      "plugin_@team": {
+      "google-calendar": {
         enabled: true,
-        marketplaceName: "market[`place`]",
-        pluginName: "plugin_*name*",
+        marketplaceName: "openai-curated",
+        pluginName: "google-calendar_@team_*name*",
       },
     });
 
     const result = await handleCodexPluginsSubcommand(fakeCtx, ["list"], io);
-    expect(result.text).toContain("plugin＿＠team");
-    expect(result.text).toContain("plugin＿∗name∗");
-    expect(result.text).toContain("market［｀place｀］");
+    expect(result.text).toContain("google-calendar");
+    expect(result.text).toContain("google-calendar＿＠team＿∗name∗");
     expect(result.text).not.toContain("@team");
     expect(result.text).not.toContain("*name*");
-    expect(result.text).not.toContain("[`place`]");
   });
 
   it("reports when a target plugin is not configured rather than silently no-oping", async () => {
@@ -97,25 +101,9 @@ describe("Codex /codex plugins subcommand", () => {
 
     const extraResult = await handleCodexPluginsSubcommand(
       fakeCtx,
-      ["enable", "chrome", "extra"],
+      ["enable", "google-calendar", "extra"],
       io,
     );
     expect(extraResult.text).toContain("Usage: /codex plugins enable <name>");
-  });
-
-  it("unknown subcommands list only the supported verbs", async () => {
-    const io = inMemoryIO();
-    const result = await handleCodexPluginsSubcommand(fakeCtx, ["help"], io);
-    expect(result.text).toContain("Unknown /codex plugins subcommand: help");
-    expect(result.text).toContain("/codex plugins enable");
-    expect(result.text).toContain("/codex plugins disable");
-    expect(result.text).toContain("/codex plugins list");
-    expect(result.text).not.toContain("/codex plugins toggle");
-    expect(result.text).not.toContain("/codex plugins remove");
-    expect(result.text).not.toContain("/codex plugins add");
-    expect(result.text).not.toContain("/codex plugins help");
-    expect(result.text).not.toContain("/codex plugins menu");
-    expect(result.text).toContain("openclaw.json");
-    expect(result.text).toContain("never to ~/.codex/config.toml");
   });
 });

--- a/extensions/codex/src/command-plugins-management.test.ts
+++ b/extensions/codex/src/command-plugins-management.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  handleCodexPluginsSubcommand,
+  type CodexPluginConfigEntry,
+  type CodexPluginsManagementIO,
+} from "./command-plugins-management.js";
+
+function inMemoryIO(
+  initial: Record<string, CodexPluginConfigEntry> = {},
+): CodexPluginsManagementIO & {
+  current: () => Record<string, CodexPluginConfigEntry>;
+} {
+  const store: Record<string, CodexPluginConfigEntry> = JSON.parse(JSON.stringify(initial));
+  return {
+    current: () => JSON.parse(JSON.stringify(store)),
+    readConfig: () => Promise.resolve({ plugins: JSON.parse(JSON.stringify(store)) }),
+    mutate: async (update) => {
+      update(store);
+    },
+  };
+}
+
+const fakeCtx = {
+  args: "",
+  config: {},
+} as never;
+
+describe("Codex /codex plugins subcommand", () => {
+  it("lists configured plugins with on or off markers and explains the underlying file", async () => {
+    const io = inMemoryIO({
+      chrome: { enabled: true, marketplaceName: "openai-bundled", pluginName: "chrome" },
+      documents: {
+        enabled: false,
+        marketplaceName: "openai-primary-runtime",
+        pluginName: "documents",
+      },
+    });
+
+    const result = await handleCodexPluginsSubcommand(fakeCtx, ["list"], io);
+    expect(result.text).toContain("ON   chrome");
+    expect(result.text).toContain("OFF  documents");
+    expect(result.text).toContain("openclaw.json");
+  });
+
+  it("enables and disables a configured plugin and reflects the change in subsequent reads", async () => {
+    const io = inMemoryIO({
+      chrome: { enabled: true, marketplaceName: "openai-bundled", pluginName: "chrome" },
+    });
+
+    const disabled = await handleCodexPluginsSubcommand(fakeCtx, ["disable", "chrome"], io);
+    expect(disabled.text).toContain("disabled");
+    expect(io.current().chrome.enabled).toBe(false);
+
+    const enabled = await handleCodexPluginsSubcommand(fakeCtx, ["enable", "chrome"], io);
+    expect(enabled.text).toContain("enabled");
+    expect(io.current().chrome.enabled).toBe(true);
+  });
+
+  it("reports when a target plugin is not configured rather than silently no-oping", async () => {
+    const io = inMemoryIO();
+    const result = await handleCodexPluginsSubcommand(fakeCtx, ["disable", "chrome"], io);
+    expect(result.text).toContain("not configured");
+  });
+
+  it("returns usage when list, enable, or disable receives the wrong arity", async () => {
+    const io = inMemoryIO();
+    const listResult = await handleCodexPluginsSubcommand(fakeCtx, ["list", "chrome"], io);
+    expect(listResult.text).toContain("Usage: /codex plugins list");
+
+    const result = await handleCodexPluginsSubcommand(fakeCtx, ["disable"], io);
+    expect(result.text).toContain("Usage: /codex plugins disable <name>");
+    expect(result.presentation).toBeUndefined();
+
+    const enableResult = await handleCodexPluginsSubcommand(fakeCtx, ["enable"], io);
+    expect(enableResult.text).toContain("Usage: /codex plugins enable <name>");
+    expect(enableResult.presentation).toBeUndefined();
+
+    const extraResult = await handleCodexPluginsSubcommand(
+      fakeCtx,
+      ["enable", "chrome", "extra"],
+      io,
+    );
+    expect(extraResult.text).toContain("Usage: /codex plugins enable <name>");
+  });
+
+  it("unknown subcommands list only the supported verbs", async () => {
+    const io = inMemoryIO();
+    const result = await handleCodexPluginsSubcommand(fakeCtx, ["help"], io);
+    expect(result.text).toContain("Unknown /codex plugins subcommand: help");
+    expect(result.text).toContain("/codex plugins enable");
+    expect(result.text).toContain("/codex plugins disable");
+    expect(result.text).toContain("/codex plugins list");
+    expect(result.text).not.toContain("/codex plugins toggle");
+    expect(result.text).not.toContain("/codex plugins remove");
+    expect(result.text).not.toContain("/codex plugins add");
+    expect(result.text).not.toContain("/codex plugins help");
+    expect(result.text).not.toContain("/codex plugins menu");
+    expect(result.text).toContain("openclaw.json");
+    expect(result.text).toContain("never to ~/.codex/config.toml");
+  });
+});

--- a/extensions/codex/src/command-plugins-management.test.ts
+++ b/extensions/codex/src/command-plugins-management.test.ts
@@ -1,3 +1,4 @@
+import type { PluginCommandContext } from "openclaw/plugin-sdk/plugin-entry";
 import { describe, expect, it } from "vitest";
 import {
   handleCodexPluginsSubcommand,
@@ -27,14 +28,17 @@ function inMemoryIO(
   };
 }
 
-const fakeCtx = {
+const fakeCtx: PluginCommandContext = {
   args: "",
   config: {},
   channel: "test",
   isAuthorizedSender: true,
   senderIsOwner: true,
   commandBody: "/codex plugins",
-} as const;
+  requestConversationBinding: async () => ({ status: "error", message: "unused" }),
+  detachConversationBinding: async () => ({ removed: false }),
+  getCurrentConversationBinding: async () => null,
+};
 
 describe("Codex /codex plugins subcommand", () => {
   it("lists a configured plugin with its enabled marker and explains the underlying file", async () => {

--- a/extensions/codex/src/command-plugins-management.test.ts
+++ b/extensions/codex/src/command-plugins-management.test.ts
@@ -56,10 +56,30 @@ describe("Codex /codex plugins subcommand", () => {
     expect(io.current().chrome.enabled).toBe(true);
   });
 
+  it("escapes configured plugin fields before listing them in chat", async () => {
+    const io = inMemoryIO({
+      "plugin_@team": {
+        enabled: true,
+        marketplaceName: "market[`place`]",
+        pluginName: "plugin_*name*",
+      },
+    });
+
+    const result = await handleCodexPluginsSubcommand(fakeCtx, ["list"], io);
+    expect(result.text).toContain("plugin＿＠team");
+    expect(result.text).toContain("plugin＿∗name∗");
+    expect(result.text).toContain("market［｀place｀］");
+    expect(result.text).not.toContain("@team");
+    expect(result.text).not.toContain("*name*");
+    expect(result.text).not.toContain("[`place`]");
+  });
+
   it("reports when a target plugin is not configured rather than silently no-oping", async () => {
     const io = inMemoryIO();
-    const result = await handleCodexPluginsSubcommand(fakeCtx, ["disable", "chrome"], io);
+    const result = await handleCodexPluginsSubcommand(fakeCtx, ["disable", "chrome_@ops"], io);
     expect(result.text).toContain("not configured");
+    expect(result.text).toContain("chrome＿＠ops");
+    expect(result.text).not.toContain("@ops");
   });
 
   it("returns usage when list, enable, or disable receives the wrong arity", async () => {

--- a/extensions/codex/src/command-plugins-management.test.ts
+++ b/extensions/codex/src/command-plugins-management.test.ts
@@ -1,19 +1,26 @@
 import { describe, expect, it } from "vitest";
 import {
   handleCodexPluginsSubcommand,
+  type CodexPluginsConfigBlock,
   type CodexPluginConfigEntry,
   type CodexPluginsManagementIO,
 } from "./command-plugins-management.js";
 
 function inMemoryIO(
   initial: Record<string, CodexPluginConfigEntry> = {},
+  options: { enabled?: boolean } = { enabled: true },
 ): CodexPluginsManagementIO & {
   current: () => Record<string, CodexPluginConfigEntry>;
+  currentConfig: () => CodexPluginsConfigBlock;
 } {
-  const store: Record<string, CodexPluginConfigEntry> = JSON.parse(JSON.stringify(initial));
+  const store: CodexPluginsConfigBlock = {
+    enabled: options.enabled,
+    plugins: JSON.parse(JSON.stringify(initial)),
+  };
   return {
-    current: () => JSON.parse(JSON.stringify(store)),
-    readConfig: () => Promise.resolve({ plugins: JSON.parse(JSON.stringify(store)) }),
+    current: () => JSON.parse(JSON.stringify(store.plugins ?? {})),
+    currentConfig: () => JSON.parse(JSON.stringify(store)),
+    readConfig: () => Promise.resolve(JSON.parse(JSON.stringify(store))),
     mutate: async (update) => {
       update(store);
     },
@@ -23,7 +30,11 @@ function inMemoryIO(
 const fakeCtx = {
   args: "",
   config: {},
-} as never;
+  channel: "test",
+  isAuthorizedSender: true,
+  senderIsOwner: true,
+  commandBody: "/codex plugins",
+} as const;
 
 describe("Codex /codex plugins subcommand", () => {
   it("lists a configured plugin with its enabled marker and explains the underlying file", async () => {
@@ -38,6 +49,23 @@ describe("Codex /codex plugins subcommand", () => {
     const result = await handleCodexPluginsSubcommand(fakeCtx, ["list"], io);
     expect(result.text).toContain("ON   google-calendar");
     expect(result.text).toContain("openclaw.json");
+  });
+
+  it("lists effective disabled status when the global plugin switch is off", async () => {
+    const io = inMemoryIO(
+      {
+        "google-calendar": {
+          enabled: true,
+          marketplaceName: "openai-curated",
+          pluginName: "google-calendar",
+        },
+      },
+      { enabled: false },
+    );
+
+    const result = await handleCodexPluginsSubcommand(fakeCtx, ["list"], io);
+    expect(result.text).toContain("OFF  google-calendar");
+    expect(result.text).toContain("Global codexPlugins.enabled is off");
   });
 
   it("enables and disables a configured plugin and reflects the change in subsequent reads", async () => {
@@ -59,7 +87,38 @@ describe("Codex /codex plugins subcommand", () => {
 
     const enabled = await handleCodexPluginsSubcommand(fakeCtx, ["enable", "google-calendar"], io);
     expect(enabled.text).toContain("enabled");
+    expect(io.currentConfig().enabled).toBe(true);
     expect(io.current()["google-calendar"]?.enabled).toBe(true);
+  });
+
+  it("rejects enable and disable from non-owner non-admin callers", async () => {
+    const io = inMemoryIO({
+      "google-calendar": {
+        enabled: true,
+        marketplaceName: "openai-curated",
+        pluginName: "google-calendar",
+      },
+    });
+    const ctx = { ...fakeCtx, senderIsOwner: false, gatewayClientScopes: ["operator.write"] };
+
+    const result = await handleCodexPluginsSubcommand(ctx, ["disable", "google-calendar"], io);
+    expect(result.text).toContain("Only an owner or operator.admin");
+    expect(io.current()["google-calendar"]?.enabled).toBe(true);
+  });
+
+  it("allows operator.admin gateway callers to enable and disable", async () => {
+    const io = inMemoryIO({
+      "google-calendar": {
+        enabled: true,
+        marketplaceName: "openai-curated",
+        pluginName: "google-calendar",
+      },
+    });
+    const ctx = { ...fakeCtx, senderIsOwner: false, gatewayClientScopes: ["operator.admin"] };
+
+    const result = await handleCodexPluginsSubcommand(ctx, ["disable", "google-calendar"], io);
+    expect(result.text).toContain("disabled");
+    expect(io.current()["google-calendar"]?.enabled).toBe(false);
   });
 
   it("escapes configured plugin fields before listing them in chat", async () => {

--- a/extensions/codex/src/command-plugins-management.ts
+++ b/extensions/codex/src/command-plugins-management.ts
@@ -8,9 +8,10 @@ import { formatCodexDisplayText } from "./command-formatters.js";
  */
 export type CodexPluginsManagementIO = {
   readConfig: () => Promise<{
+    enabled?: boolean;
     plugins?: Record<string, CodexPluginConfigEntry>;
   }>;
-  mutate: (update: (block: Record<string, CodexPluginConfigEntry>) => void) => Promise<void>;
+  mutate: (update: (block: CodexPluginsConfigBlock) => void) => Promise<void>;
 };
 
 export type CodexPluginConfigEntry = {
@@ -18,6 +19,11 @@ export type CodexPluginConfigEntry = {
   marketplaceName?: string;
   pluginName?: string;
   allow_destructive_actions?: boolean;
+};
+
+export type CodexPluginsConfigBlock = {
+  enabled?: boolean;
+  plugins?: Record<string, CodexPluginConfigEntry>;
 };
 
 // Plugin lifecycle changes (enable/disable) write to openclaw.json
@@ -28,7 +34,7 @@ const POLICY_REFRESH_HINT =
   "New Codex conversations pick this up automatically. Use /new or /reset to refresh the current one.";
 
 export async function handleCodexPluginsSubcommand(
-  _ctx: PluginCommandContext,
+  ctx: PluginCommandContext,
   rest: string[],
   io: CodexPluginsManagementIO,
 ): Promise<PluginCommandResult> {
@@ -40,13 +46,20 @@ export async function handleCodexPluginsSubcommand(
       return { text: "Usage: /codex plugins list" };
     }
     const current = await io.readConfig();
-    return { text: formatPluginList(current.plugins ?? {}) };
+    return {
+      text: formatPluginList(current.plugins ?? {}, { globalEnabled: current.enabled === true }),
+    };
   }
 
   const target = args[0];
   if (normalized === "enable" || normalized === "disable") {
     if (!target || args.length > 1) {
       return { text: `Usage: /codex plugins ${normalized} <name>` };
+    }
+    if (!canMutateCodexPlugins(ctx)) {
+      return {
+        text: `Only an owner or operator.admin gateway client can run /codex plugins ${normalized}.`,
+      };
     }
     const wantEnabled = normalized === "enable";
     const current = (await io.readConfig()).plugins ?? {};
@@ -56,7 +69,11 @@ export async function handleCodexPluginsSubcommand(
       };
     }
     await io.mutate((block) => {
-      block[target] = { ...block[target], enabled: wantEnabled };
+      if (wantEnabled) {
+        block.enabled = true;
+      }
+      block.plugins ??= {};
+      block.plugins[target] = { ...block.plugins[target], enabled: wantEnabled };
     });
     return {
       text: `${formatCodexDisplayText(target)}: ${wantEnabled ? "enabled" : "disabled"} in openclaw.json. ${POLICY_REFRESH_HINT}`,
@@ -66,6 +83,13 @@ export async function handleCodexPluginsSubcommand(
   return {
     text: `Unknown /codex plugins subcommand: ${formatCodexDisplayText(verb)}\n\n${buildPluginsHelp()}`,
   };
+}
+
+function canMutateCodexPlugins(ctx: PluginCommandContext): boolean {
+  if (ctx.senderIsOwner === true) {
+    return true;
+  }
+  return ctx.gatewayClientScopes?.includes("operator.admin") === true;
 }
 
 export function buildPluginsHelp(): string {
@@ -78,14 +102,18 @@ export function buildPluginsHelp(): string {
   ].join("\n");
 }
 
-export function formatPluginList(plugins: Record<string, CodexPluginConfigEntry>): string {
+export function formatPluginList(
+  plugins: Record<string, CodexPluginConfigEntry>,
+  options: { globalEnabled?: boolean } = {},
+): string {
+  const globalEnabled = options.globalEnabled === true;
   const keys = Object.keys(plugins).toSorted();
   if (keys.length === 0) {
     return "No Codex sub-plugins configured under plugins.entries.codex.config.codexPlugins.plugins";
   }
   const rows = keys.map((key) => {
     const entry = plugins[key] ?? {};
-    const state = entry.enabled === false ? "OFF" : "ON ";
+    const state = globalEnabled && entry.enabled !== false ? "ON " : "OFF";
     const displayKey = formatCodexDisplayText(key);
     const pluginName = formatCodexDisplayText(entry.pluginName ?? key);
     const marketplace = formatCodexDisplayText(entry.marketplaceName ?? "?");
@@ -101,6 +129,9 @@ export function formatPluginList(plugins: Record<string, CodexPluginConfigEntry>
         `  ${r.state}  ${r.displayKey.padEnd(keyW)}  ${r.pluginName.padEnd(pluginW)}  [${r.marketplace}]`,
     ),
     "",
+    ...(globalEnabled
+      ? []
+      : ["Global codexPlugins.enabled is off; configured sub-plugins are inactive.", ""]),
     "New Codex conversations pick up policy changes automatically; /new or /reset to refresh the current one.",
   ].join("\n");
 }

--- a/extensions/codex/src/command-plugins-management.ts
+++ b/extensions/codex/src/command-plugins-management.ts
@@ -1,0 +1,104 @@
+import type { PluginCommandContext, PluginCommandResult } from "openclaw/plugin-sdk/plugin-entry";
+
+/**
+ * Lightweight read/write surface over the Openclaw config file. Plugged in by
+ * the command registration site so this module stays decoupled from the
+ * concrete `mutateConfigFile` import in tests.
+ */
+export type CodexPluginsManagementIO = {
+  readConfig: () => Promise<{
+    plugins?: Record<string, CodexPluginConfigEntry>;
+  }>;
+  mutate: (update: (block: Record<string, CodexPluginConfigEntry>) => void) => Promise<void>;
+};
+
+export type CodexPluginConfigEntry = {
+  enabled?: boolean;
+  marketplaceName?: string;
+  pluginName?: string;
+  allow_destructive_actions?: boolean;
+};
+
+// Plugin lifecycle changes (enable/disable) write to openclaw.json
+// synchronously. The Codex app-server picks up the new policy when the next
+// thread starts; in-flight conversations keep the old policy until /new or
+// /reset. A full gateway restart is NOT needed.
+const POLICY_REFRESH_HINT =
+  "New Codex conversations pick this up automatically. Use /new or /reset to refresh the current one.";
+
+export async function handleCodexPluginsSubcommand(
+  _ctx: PluginCommandContext,
+  rest: string[],
+  io: CodexPluginsManagementIO,
+): Promise<PluginCommandResult> {
+  const [verb = "list", ...args] = rest;
+  const normalized = verb.toLowerCase();
+
+  if (normalized === "list") {
+    if (args.length > 0) {
+      return { text: "Usage: /codex plugins list" };
+    }
+    const current = await io.readConfig();
+    return { text: formatPluginList(current.plugins ?? {}) };
+  }
+
+  const target = args[0];
+  if (normalized === "enable" || normalized === "disable") {
+    if (!target || args.length > 1) {
+      return { text: `Usage: /codex plugins ${normalized} <name>` };
+    }
+    const wantEnabled = normalized === "enable";
+    const current = (await io.readConfig()).plugins ?? {};
+    if (!current[target]) {
+      return {
+        text: `Codex sub-plugin '${target}' is not configured. Run '/codex plugins list' to see configured plugins.`,
+      };
+    }
+    await io.mutate((block) => {
+      block[target] = { ...block[target], enabled: wantEnabled };
+    });
+    return {
+      text: `${target}: ${wantEnabled ? "enabled" : "disabled"} in openclaw.json. ${POLICY_REFRESH_HINT}`,
+    };
+  }
+
+  return {
+    text: `Unknown /codex plugins subcommand: ${verb}\n\n${buildPluginsHelp()}`,
+  };
+}
+
+export function buildPluginsHelp(): string {
+  return [
+    "Codex sub-plugin management (writes only to ~/.openclaw/openclaw.json, never to ~/.codex/config.toml):",
+    "- /codex plugins                  (alias for list)",
+    "- /codex plugins list             show all configured Codex sub-plugins",
+    "- /codex plugins enable <name>    enable a configured sub-plugin",
+    "- /codex plugins disable <name>   disable a configured sub-plugin",
+  ].join("\n");
+}
+
+export function formatPluginList(plugins: Record<string, CodexPluginConfigEntry>): string {
+  const keys = Object.keys(plugins).sort();
+  if (keys.length === 0) {
+    return "No Codex sub-plugins configured under plugins.entries.codex.config.codexPlugins.plugins";
+  }
+  const rows = keys.map((key) => {
+    const entry = plugins[key] ?? {};
+    const state = entry.enabled === false ? "OFF" : "ON ";
+    const pluginName = entry.pluginName ?? key;
+    const marketplace = entry.marketplaceName ?? "?";
+    return { key, state, pluginName, marketplace };
+  });
+  const keyW = Math.max(...rows.map((r) => r.key.length));
+  const pluginW = Math.max(...rows.map((r) => r.pluginName.length));
+  return [
+    "Codex sub-plugins in Openclaw config (~/.openclaw/openclaw.json):",
+    "",
+    ...rows.map(
+      (r) =>
+        `  ${r.state}  ${r.key.padEnd(keyW)}  ${r.pluginName.padEnd(pluginW)}  [${r.marketplace}]`,
+    ),
+    "",
+    "New Codex conversations pick up policy changes automatically; /new or /reset to refresh the current one.",
+  ].join("\n");
+}

--- a/extensions/codex/src/command-plugins-management.ts
+++ b/extensions/codex/src/command-plugins-management.ts
@@ -1,4 +1,5 @@
 import type { PluginCommandContext, PluginCommandResult } from "openclaw/plugin-sdk/plugin-entry";
+import { formatCodexDisplayText } from "./command-formatters.js";
 
 /**
  * Lightweight read/write surface over the Openclaw config file. Plugged in by
@@ -51,19 +52,19 @@ export async function handleCodexPluginsSubcommand(
     const current = (await io.readConfig()).plugins ?? {};
     if (!current[target]) {
       return {
-        text: `Codex sub-plugin '${target}' is not configured. Run '/codex plugins list' to see configured plugins.`,
+        text: `Codex sub-plugin '${formatCodexDisplayText(target)}' is not configured. Run '/codex plugins list' to see configured plugins.`,
       };
     }
     await io.mutate((block) => {
       block[target] = { ...block[target], enabled: wantEnabled };
     });
     return {
-      text: `${target}: ${wantEnabled ? "enabled" : "disabled"} in openclaw.json. ${POLICY_REFRESH_HINT}`,
+      text: `${formatCodexDisplayText(target)}: ${wantEnabled ? "enabled" : "disabled"} in openclaw.json. ${POLICY_REFRESH_HINT}`,
     };
   }
 
   return {
-    text: `Unknown /codex plugins subcommand: ${verb}\n\n${buildPluginsHelp()}`,
+    text: `Unknown /codex plugins subcommand: ${formatCodexDisplayText(verb)}\n\n${buildPluginsHelp()}`,
   };
 }
 
@@ -78,25 +79,26 @@ export function buildPluginsHelp(): string {
 }
 
 export function formatPluginList(plugins: Record<string, CodexPluginConfigEntry>): string {
-  const keys = Object.keys(plugins).sort();
+  const keys = Object.keys(plugins).toSorted();
   if (keys.length === 0) {
     return "No Codex sub-plugins configured under plugins.entries.codex.config.codexPlugins.plugins";
   }
   const rows = keys.map((key) => {
     const entry = plugins[key] ?? {};
     const state = entry.enabled === false ? "OFF" : "ON ";
-    const pluginName = entry.pluginName ?? key;
-    const marketplace = entry.marketplaceName ?? "?";
-    return { key, state, pluginName, marketplace };
+    const displayKey = formatCodexDisplayText(key);
+    const pluginName = formatCodexDisplayText(entry.pluginName ?? key);
+    const marketplace = formatCodexDisplayText(entry.marketplaceName ?? "?");
+    return { displayKey, state, pluginName, marketplace };
   });
-  const keyW = Math.max(...rows.map((r) => r.key.length));
+  const keyW = Math.max(...rows.map((r) => r.displayKey.length));
   const pluginW = Math.max(...rows.map((r) => r.pluginName.length));
   return [
     "Codex sub-plugins in Openclaw config (~/.openclaw/openclaw.json):",
     "",
     ...rows.map(
       (r) =>
-        `  ${r.state}  ${r.key.padEnd(keyW)}  ${r.pluginName.padEnd(pluginW)}  [${r.marketplace}]`,
+        `  ${r.state}  ${r.displayKey.padEnd(keyW)}  ${r.pluginName.padEnd(pluginW)}  [${r.marketplace}]`,
     ),
     "",
     "New Codex conversations pick up policy changes automatically; /new or /reset to refresh the current one.",

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -22,6 +22,7 @@ import {
   type CodexCommandDeps,
 } from "./command-handlers.js";
 import type {
+  CodexPluginsConfigBlock,
   CodexPluginConfigEntry,
   CodexPluginsManagementIO,
 } from "./command-plugins-management.js";
@@ -79,13 +80,19 @@ function createDeps(overrides: Partial<CodexCommandDeps> = {}): Partial<CodexCom
 
 function inMemoryCodexPluginsIO(
   initial: Record<string, CodexPluginConfigEntry> = {},
+  options: { enabled?: boolean } = { enabled: true },
 ): CodexPluginsManagementIO & {
   current: () => Record<string, CodexPluginConfigEntry>;
+  currentConfig: () => CodexPluginsConfigBlock;
 } {
-  const store: Record<string, CodexPluginConfigEntry> = JSON.parse(JSON.stringify(initial));
+  const store: CodexPluginsConfigBlock = {
+    enabled: options.enabled,
+    plugins: JSON.parse(JSON.stringify(initial)),
+  };
   return {
-    current: () => JSON.parse(JSON.stringify(store)),
-    readConfig: () => Promise.resolve({ plugins: JSON.parse(JSON.stringify(store)) }),
+    current: () => JSON.parse(JSON.stringify(store.plugins ?? {})),
+    currentConfig: () => JSON.parse(JSON.stringify(store)),
+    readConfig: () => Promise.resolve(JSON.parse(JSON.stringify(store))),
     mutate: async (update) => {
       update(store);
     },
@@ -271,6 +278,7 @@ describe("codex command", () => {
       deps: createDeps({ codexPluginsManagementIo }),
     });
     expectResultTextContains(enabled, "google-calendar: enabled in openclaw.json");
+    expect(codexPluginsManagementIo.currentConfig().enabled).toBe(true);
     expect(codexPluginsManagementIo.current()["google-calendar"]?.enabled).toBe(true);
   });
 

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -21,6 +21,10 @@ import {
   resetCodexDiagnosticsFeedbackStateForTests,
   type CodexCommandDeps,
 } from "./command-handlers.js";
+import type {
+  CodexPluginConfigEntry,
+  CodexPluginsManagementIO,
+} from "./command-plugins-management.js";
 import { handleCodexCommand } from "./commands.js";
 
 let tempDir: string;
@@ -70,6 +74,21 @@ function createDeps(overrides: Partial<CodexCommandDeps> = {}): Partial<CodexCom
     ),
     safeCodexControlRequest: vi.fn(),
     ...overrides,
+  };
+}
+
+function inMemoryCodexPluginsIO(
+  initial: Record<string, CodexPluginConfigEntry> = {},
+): CodexPluginsManagementIO & {
+  current: () => Record<string, CodexPluginConfigEntry>;
+} {
+  const store: Record<string, CodexPluginConfigEntry> = JSON.parse(JSON.stringify(initial));
+  return {
+    current: () => JSON.parse(JSON.stringify(store)),
+    readConfig: () => Promise.resolve({ plugins: JSON.parse(JSON.stringify(store)) }),
+    mutate: async (update) => {
+      update(store);
+    },
   };
 }
 
@@ -214,6 +233,57 @@ describe("codex command", () => {
 
     expect(result.text).toContain("Codex command failed: &lt;\uff20U123&gt; loader failed");
     expect(result.text).not.toContain("<@U123>");
+  });
+
+  it("lists Codex sub-plugins through the /codex plugins command surface", async () => {
+    const codexPluginsManagementIo = inMemoryCodexPluginsIO({
+      chrome: { enabled: true, marketplaceName: "openai-bundled", pluginName: "chrome" },
+      documents: {
+        enabled: false,
+        marketplaceName: "openai-primary-runtime",
+        pluginName: "documents",
+      },
+    });
+
+    const result = await handleCodexCommand(createContext("plugins list"), {
+      deps: createDeps({ codexPluginsManagementIo }),
+    });
+
+    expectResultTextContains(result, "ON   chrome");
+    expectResultTextContains(result, "OFF  documents");
+    expectResultTextContains(result, "openclaw.json");
+  });
+
+  it("enables and disables Codex sub-plugins through the /codex plugins command surface", async () => {
+    const codexPluginsManagementIo = inMemoryCodexPluginsIO({
+      chrome: { enabled: true, marketplaceName: "openai-bundled", pluginName: "chrome" },
+    });
+
+    const disabled = await handleCodexCommand(createContext("plugins disable chrome"), {
+      deps: createDeps({ codexPluginsManagementIo }),
+    });
+    expectResultTextContains(disabled, "chrome: disabled in openclaw.json");
+    expect(codexPluginsManagementIo.current().chrome.enabled).toBe(false);
+
+    const enabled = await handleCodexCommand(createContext("plugins enable chrome"), {
+      deps: createDeps({ codexPluginsManagementIo }),
+    });
+    expectResultTextContains(enabled, "chrome: enabled in openclaw.json");
+    expect(codexPluginsManagementIo.current().chrome.enabled).toBe(true);
+  });
+
+  it("limits /codex plugins help text to list, enable, and disable", async () => {
+    const result = await handleCodexCommand(createContext("plugins help"), {
+      deps: createDeps({ codexPluginsManagementIo: inMemoryCodexPluginsIO() }),
+    });
+
+    expectResultTextContains(result, "Unknown /codex plugins subcommand: help");
+    expectResultTextContains(result, "/codex plugins list");
+    expectResultTextContains(result, "/codex plugins enable");
+    expectResultTextContains(result, "/codex plugins disable");
+    expect(result.text).not.toContain("/codex plugins add");
+    expect(result.text).not.toContain("/codex plugins remove");
+    expect(result.text).not.toContain("/codex plugins toggle");
   });
 
   it("attaches the current session to an existing Codex thread", async () => {

--- a/extensions/codex/src/commands.test.ts
+++ b/extensions/codex/src/commands.test.ts
@@ -237,11 +237,10 @@ describe("codex command", () => {
 
   it("lists Codex sub-plugins through the /codex plugins command surface", async () => {
     const codexPluginsManagementIo = inMemoryCodexPluginsIO({
-      chrome: { enabled: true, marketplaceName: "openai-bundled", pluginName: "chrome" },
-      documents: {
-        enabled: false,
-        marketplaceName: "openai-primary-runtime",
-        pluginName: "documents",
+      "google-calendar": {
+        enabled: true,
+        marketplaceName: "openai-curated",
+        pluginName: "google-calendar",
       },
     });
 
@@ -249,41 +248,30 @@ describe("codex command", () => {
       deps: createDeps({ codexPluginsManagementIo }),
     });
 
-    expectResultTextContains(result, "ON   chrome");
-    expectResultTextContains(result, "OFF  documents");
+    expectResultTextContains(result, "ON   google-calendar");
     expectResultTextContains(result, "openclaw.json");
   });
 
   it("enables and disables Codex sub-plugins through the /codex plugins command surface", async () => {
     const codexPluginsManagementIo = inMemoryCodexPluginsIO({
-      chrome: { enabled: true, marketplaceName: "openai-bundled", pluginName: "chrome" },
+      "google-calendar": {
+        enabled: true,
+        marketplaceName: "openai-curated",
+        pluginName: "google-calendar",
+      },
     });
 
-    const disabled = await handleCodexCommand(createContext("plugins disable chrome"), {
+    const disabled = await handleCodexCommand(createContext("plugins disable google-calendar"), {
       deps: createDeps({ codexPluginsManagementIo }),
     });
-    expectResultTextContains(disabled, "chrome: disabled in openclaw.json");
-    expect(codexPluginsManagementIo.current().chrome.enabled).toBe(false);
+    expectResultTextContains(disabled, "google-calendar: disabled in openclaw.json");
+    expect(codexPluginsManagementIo.current()["google-calendar"]?.enabled).toBe(false);
 
-    const enabled = await handleCodexCommand(createContext("plugins enable chrome"), {
+    const enabled = await handleCodexCommand(createContext("plugins enable google-calendar"), {
       deps: createDeps({ codexPluginsManagementIo }),
     });
-    expectResultTextContains(enabled, "chrome: enabled in openclaw.json");
-    expect(codexPluginsManagementIo.current().chrome.enabled).toBe(true);
-  });
-
-  it("limits /codex plugins help text to list, enable, and disable", async () => {
-    const result = await handleCodexCommand(createContext("plugins help"), {
-      deps: createDeps({ codexPluginsManagementIo: inMemoryCodexPluginsIO() }),
-    });
-
-    expectResultTextContains(result, "Unknown /codex plugins subcommand: help");
-    expectResultTextContains(result, "/codex plugins list");
-    expectResultTextContains(result, "/codex plugins enable");
-    expectResultTextContains(result, "/codex plugins disable");
-    expect(result.text).not.toContain("/codex plugins add");
-    expect(result.text).not.toContain("/codex plugins remove");
-    expect(result.text).not.toContain("/codex plugins toggle");
+    expectResultTextContains(enabled, "google-calendar: enabled in openclaw.json");
+    expect(codexPluginsManagementIo.current()["google-calendar"]?.enabled).toBe(true);
   });
 
   it("attaches the current session to an existing Codex thread", async () => {


### PR DESCRIPTION
## Summary

- Adds `/codex plugins list` to show configured Codex sub-plugins from `plugins.entries.codex.config.codexPlugins.plugins`.
- Adds `/codex plugins enable <name>` and `/codex plugins disable <name>` to update the enabled flag in `openclaw.json`.
- Keeps the command surface scoped to `list`, `enable`, and `disable`; unsupported subcommands report help without advertising add/remove/toggle/menu.

## Verification

- `node scripts/run-vitest.mjs extensions/codex/src/command-plugins-management.test.ts extensions/codex/src/commands.test.ts`
- `npx oxfmt --check extensions/codex/src/command-plugins-management.ts extensions/codex/src/command-plugins-management.test.ts`
- `node scripts/run-bundled-extension-oxlint.mjs`
- `git diff --check`
- `pnpm docs:list`
- `pnpm format:docs:check`
- `pnpm docs:check-mdx`

## Real behavior proof

Behavior addressed: `/codex plugins list`, `/codex plugins enable <name>`, and `/codex plugins disable <name>` work through the Codex command surface and mutate the configured Codex sub-plugin policy.
Real environment tested: Local linked OpenClaw worktree on macOS, branch `codex/plugins-list-enable-disable`, using a temporary `OPENCLAW_CONFIG_PATH` with a configured `google-calendar` Codex sub-plugin entry.
Exact steps or command run after this patch: `node --import tsx --input-type=module -e '<script created temp openclaw.json, loaded real config with loadConfig(), mutated it with mutateConfigFile(), and invoked handleCodexPluginsSubcommand for list, disable google-calendar, list, enable google-calendar, list>'`
Evidence after fix: Terminal output from the live config-mutation probe:

```text
$ /codex plugins list
Codex sub-plugins in Openclaw config (~/.openclaw/openclaw.json):

  ON   google-calendar  google-calendar  [openai-curated]

New Codex conversations pick up policy changes automatically; /new or /reset to refresh the current one.
---
$ /codex plugins disable google-calendar
google-calendar: disabled in openclaw.json. New Codex conversations pick this up automatically. Use /new or /reset to refresh the current one.
---
$ /codex plugins list
Codex sub-plugins in Openclaw config (~/.openclaw/openclaw.json):

  OFF  google-calendar  google-calendar  [openai-curated]

New Codex conversations pick up policy changes automatically; /new or /reset to refresh the current one.
---
$ /codex plugins enable google-calendar
google-calendar: enabled in openclaw.json. New Codex conversations pick this up automatically. Use /new or /reset to refresh the current one.
---
$ /codex plugins list
Codex sub-plugins in Openclaw config (~/.openclaw/openclaw.json):

  ON   google-calendar  google-calendar  [openai-curated]

New Codex conversations pick up policy changes automatically; /new or /reset to refresh the current one.
---
final enabled=true
```

Observed result after fix: The Google Calendar Codex sub-plugin starts listed as `ON`, `/codex plugins disable google-calendar` changes the persisted policy to `OFF`, and `/codex plugins enable google-calendar` changes it back to `ON` with `final enabled=true` in the temporary `openclaw.json`.
What was not tested: A real Google Calendar API call was not made; this proof covers OpenClaw's Codex plugin policy command path and persisted config mutation.

