### PR TITLE
perf(agents): bootstrap context cache, PI model-discovery cache, auth-store option keys, tool-descriptor kill switch

### DIFF
--- a/src/agents/auth-profiles/store-cache.ts
+++ b/src/agents/auth-profiles/store-cache.ts
@@ -12,12 +12,21 @@ const loadedAuthStoreCache = new Map<
   }
 >();
 
+/**
+ * Read a cached auth profile store entry.
+ *
+ * `cacheKey` is an opaque, option-sensitive key built by the caller (typically a
+ * stable JSON serialization of authPath + load-options). Keying by authPath alone
+ * caused option-set poisoning: a caller asking for read-only / no-external-cli
+ * sync could observe a store cached by a caller that did sync external CLI
+ * profiles, and vice versa.
+ */
 export function readCachedAuthProfileStore(params: {
-  authPath: string;
+  cacheKey: string;
   authMtimeMs: number | null;
   stateMtimeMs: number | null;
 }): AuthProfileStore | null {
-  const cached = loadedAuthStoreCache.get(params.authPath);
+  const cached = loadedAuthStoreCache.get(params.cacheKey);
   if (
     !cached ||
     cached.authMtimeMs !== params.authMtimeMs ||
@@ -32,12 +41,12 @@ export function readCachedAuthProfileStore(params: {
 }
 
 export function writeCachedAuthProfileStore(params: {
-  authPath: string;
+  cacheKey: string;
   authMtimeMs: number | null;
   stateMtimeMs: number | null;
   store: AuthProfileStore;
 }): void {
-  loadedAuthStoreCache.set(params.authPath, {
+  loadedAuthStoreCache.set(params.cacheKey, {
     authMtimeMs: params.authMtimeMs,
     stateMtimeMs: params.stateMtimeMs,
     syncedAtMs: Date.now(),

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -4,6 +4,7 @@ import { isDeepStrictEqual } from "node:util";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { withFileLock } from "../../infra/file-lock.js";
 import { loadJsonFile, saveJsonFile } from "../../infra/json-file.js";
+import { stableStringify } from "../stable-stringify.js";
 import { cloneAuthProfileStore } from "./clone.js";
 import { AUTH_STORE_LOCK_OPTIONS, AUTH_STORE_VERSION, log } from "./constants.js";
 import {
@@ -51,6 +52,39 @@ type LoadAuthProfileStoreOptions = {
   externalCliProviderIds?: Iterable<string>;
   externalCliProfileIds?: Iterable<string>;
 };
+
+/**
+ * Build an option-sensitive cache key for the auth-profile store.
+ *
+ * Keying by authPath alone meant two callers with different option sets could
+ * poison each other's results (e.g. one syncing external CLI, another reading
+ * the result without sync). The cache key now mixes in the option fields that
+ * actually change the loaded store contents.
+ */
+function buildAuthStoreCacheKey(params: {
+  authPath: string;
+  options?: LoadAuthProfileStoreOptions;
+}): string {
+  return stableStringify({
+    version: 2,
+    authPath: params.authPath,
+    config: params.options?.config
+      ? {
+          models: params.options.config.models ?? null,
+          plugins: params.options.config.plugins ?? null,
+        }
+      : null,
+    externalCli: params.options?.externalCli?.mode ?? null,
+    externalCliProviderIds: params.options?.externalCliProviderIds
+      ? Array.from(params.options.externalCliProviderIds).toSorted()
+      : null,
+    externalCliProfileIds: params.options?.externalCliProfileIds
+      ? Array.from(params.options.externalCliProfileIds).toSorted()
+      : null,
+    syncExternalCli: params.options?.syncExternalCli ?? null,
+    allowKeychainPrompt: params.options?.allowKeychainPrompt ?? null,
+  });
+}
 
 type SaveAuthProfileStoreOptions = {
   filterExternalAuthProfiles?: boolean;
@@ -463,9 +497,10 @@ function loadAuthProfileStoreForAgent(
   const statePath = resolveAuthStatePath(agentDir);
   const authMtimeMs = readAuthStoreMtimeMs(authPath);
   const stateMtimeMs = readAuthStoreMtimeMs(statePath);
+  const cacheKey = buildAuthStoreCacheKey({ authPath, options });
   if (!readOnly) {
     const cached = readCachedAuthProfileStore({
-      authPath,
+      cacheKey,
       authMtimeMs,
       stateMtimeMs,
     });
@@ -482,7 +517,7 @@ function loadAuthProfileStoreForAgent(
     });
     if (!readOnly && synced.cacheable) {
       writeCachedAuthProfileStore({
-        authPath,
+        cacheKey,
         authMtimeMs: readAuthStoreMtimeMs(authPath),
         stateMtimeMs: readAuthStoreMtimeMs(statePath),
         store: synced.store,
@@ -532,7 +567,7 @@ function loadAuthProfileStoreForAgent(
 
   if (!readOnly && synced.cacheable) {
     writeCachedAuthProfileStore({
-      authPath,
+      cacheKey,
       authMtimeMs: readAuthStoreMtimeMs(authPath),
       stateMtimeMs: readAuthStoreMtimeMs(statePath),
       store: synced.store,
@@ -709,7 +744,7 @@ export function saveAuthProfileStore(
   saveJsonFile(authPath, payload);
   savePersistedAuthProfileState(localStore, agentDir);
   writeCachedAuthProfileStore({
-    authPath,
+    cacheKey: buildAuthStoreCacheKey({ authPath }),
     authMtimeMs: readAuthStoreMtimeMs(authPath),
     stateMtimeMs: readAuthStoreMtimeMs(statePath),
     store: localStore,

--- a/src/agents/bootstrap-cache.ts
+++ b/src/agents/bootstrap-cache.ts
@@ -1,3 +1,4 @@
+import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
 import { loadWorkspaceBootstrapFiles, type WorkspaceBootstrapFile } from "./workspace.js";
 
 type BootstrapSnapshot = {
@@ -5,7 +6,15 @@ type BootstrapSnapshot = {
   files: WorkspaceBootstrapFile[];
 };
 
+export type BootstrapContextSnapshot = {
+  bootstrapFiles: WorkspaceBootstrapFile[];
+  contextFiles: EmbeddedContextFile[];
+};
+
+const BOOTSTRAP_CONTEXT_CACHE_LIMIT = 128;
+
 const cache = new Map<string, BootstrapSnapshot>();
+const contextCache = new Map<string, BootstrapContextSnapshot>();
 
 function bootstrapFilesEqual(
   previous: WorkspaceBootstrapFile[],
@@ -27,6 +36,48 @@ function bootstrapFilesEqual(
   });
 }
 
+function cloneContextSnapshot(snapshot: BootstrapContextSnapshot): BootstrapContextSnapshot {
+  return {
+    bootstrapFiles: snapshot.bootstrapFiles.map((file) => ({ ...file })),
+    contextFiles: snapshot.contextFiles.map((file) => ({ ...file })),
+  };
+}
+
+function rememberContextSnapshot(key: string, snapshot: BootstrapContextSnapshot): void {
+  if (contextCache.has(key)) {
+    contextCache.delete(key);
+  }
+  contextCache.set(key, cloneContextSnapshot(snapshot));
+  while (contextCache.size > BOOTSTRAP_CONTEXT_CACHE_LIMIT) {
+    const oldest = contextCache.keys().next().value;
+    if (typeof oldest !== "string") {
+      break;
+    }
+    contextCache.delete(oldest);
+  }
+}
+
+export function readCachedBootstrapContext(key: string): BootstrapContextSnapshot | undefined {
+  if (process.env.OPENCLAW_DISABLE_BOOTSTRAP_CONTEXT_CACHE === "1") {
+    return undefined;
+  }
+  const cached = contextCache.get(key);
+  if (!cached) {
+    return undefined;
+  }
+  // Refresh LRU order and protect cached arrays/objects from per-run mutation.
+  contextCache.delete(key);
+  contextCache.set(key, cached);
+  return cloneContextSnapshot(cached);
+}
+
+export function writeCachedBootstrapContext(key: string, snapshot: BootstrapContextSnapshot): void {
+  if (process.env.OPENCLAW_DISABLE_BOOTSTRAP_CONTEXT_CACHE === "1") {
+    return;
+  }
+  rememberContextSnapshot(key, snapshot);
+}
+
 export async function getOrLoadBootstrapFiles(params: {
   workspaceDir: string;
   sessionKey: string;
@@ -44,11 +95,21 @@ export async function getOrLoadBootstrapFiles(params: {
   }
 
   cache.set(params.sessionKey, { workspaceDir: params.workspaceDir, files });
+  clearBootstrapContextSnapshotsForSession(params.sessionKey);
   return files;
+}
+
+export function clearBootstrapContextSnapshotsForSession(sessionKey: string): void {
+  for (const key of Array.from(contextCache.keys())) {
+    if (key.includes(`\"sessionKey\":${JSON.stringify(sessionKey)}`)) {
+      contextCache.delete(key);
+    }
+  }
 }
 
 export function clearBootstrapSnapshot(sessionKey: string): void {
   cache.delete(sessionKey);
+  clearBootstrapContextSnapshotsForSession(sessionKey);
 }
 
 export function clearBootstrapSnapshotOnSessionRollover(params: {
@@ -64,4 +125,11 @@ export function clearBootstrapSnapshotOnSessionRollover(params: {
 
 export function clearAllBootstrapSnapshots(): void {
   cache.clear();
+  contextCache.clear();
 }
+
+export const __testing = {
+  readCachedBootstrapContext,
+  writeCachedBootstrapContext,
+  clearBootstrapContextSnapshotsForSession,
+};

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -2,10 +2,15 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { AgentContextInjection } from "../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { getInternalHookRegistryVersion } from "../hooks/internal-hooks.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveAgentConfig, resolveSessionAgentIds } from "./agent-scope.js";
-import { getOrLoadBootstrapFiles } from "./bootstrap-cache.js";
+import {
+  getOrLoadBootstrapFiles,
+  readCachedBootstrapContext,
+  writeCachedBootstrapContext,
+} from "./bootstrap-cache.js";
 import { applyBootstrapHookOverrides } from "./bootstrap-hooks.js";
 import { shouldIncludeHeartbeatGuidanceForSystemPrompt } from "./heartbeat-system-prompt.js";
 import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
@@ -14,6 +19,7 @@ import {
   resolveBootstrapMaxChars,
   resolveBootstrapTotalMaxChars,
 } from "./pi-embedded-helpers.js";
+import { stableStringify } from "./stable-stringify.js";
 import {
   DEFAULT_HEARTBEAT_FILENAME,
   DEFAULT_BOOTSTRAP_FILENAME,
@@ -274,7 +280,100 @@ async function isWorkspaceSetupCompletedForContext(workspaceDir: string): Promis
   }
 }
 
+async function readWorkspaceMtimeSignature(workspaceDir: string): Promise<string> {
+  try {
+    const stat = await fs.stat(workspaceDir);
+    return `${stat.mtimeMs}:${stat.size}`;
+  } catch {
+    return "missing";
+  }
+}
+
+function buildBootstrapFilesSignature(files: WorkspaceBootstrapFile[]): string {
+  return stableStringify(
+    files.map((file) => ({
+      name: file.name,
+      path: file.path,
+      missing: file.missing === true,
+      contentLength: file.content?.length ?? 0,
+      content: file.content ?? "",
+    })),
+  );
+}
+
+async function buildBootstrapContextCacheKey(params: {
+  workspaceDir: string;
+  config?: OpenClawConfig;
+  sessionKey?: string;
+  sessionId?: string;
+  agentId?: string;
+  contextMode?: BootstrapContextMode;
+  runKind?: BootstrapContextRunKind;
+  channelId?: string;
+  rawFiles: WorkspaceBootstrapFile[];
+}): Promise<string> {
+  const { defaultAgentId, sessionAgentId } = resolveSessionAgentIds({
+    sessionKey: params.sessionKey ?? params.sessionId,
+    config: params.config,
+    agentId: params.agentId,
+  });
+  return stableStringify({
+    version: 1,
+    sessionKey: params.sessionKey ?? params.sessionId ?? "",
+    workspaceDir: path.resolve(params.workspaceDir),
+    workspaceMtime: await readWorkspaceMtimeSignature(params.workspaceDir),
+    contextMode: params.contextMode ?? "full",
+    runKind: params.runKind ?? "default",
+    agentId: sessionAgentId ?? params.agentId ?? "",
+    defaultAgentId: defaultAgentId ?? "",
+    channelId: params.channelId ?? "",
+    contextInjection: params.config?.agents?.defaults?.contextInjection ?? null,
+    bootstrapConfig: {
+      maxChars: params.config?.agents?.defaults?.bootstrapMaxChars ?? null,
+      totalMaxChars: params.config?.agents?.defaults?.bootstrapTotalMaxChars ?? null,
+      truncationWarning: params.config?.agents?.defaults?.bootstrapPromptTruncationWarning ?? null,
+    },
+    heartbeatGuidance: params.config?.agents?.defaults?.heartbeat ?? null,
+    maxChars: resolveBootstrapMaxChars(params.config, sessionAgentId ?? params.agentId ?? null),
+    totalMaxChars: resolveBootstrapTotalMaxChars(
+      params.config,
+      sessionAgentId ?? params.agentId ?? null,
+    ),
+    rawFiles: buildBootstrapFilesSignature(params.rawFiles),
+    hookRegistryVersion: getInternalHookRegistryVersion(),
+    plugins: params.config?.plugins ?? null,
+  });
+}
+
+async function loadRawBootstrapFilesForRun(params: {
+  workspaceDir: string;
+  sessionKey?: string;
+  sessionId?: string;
+}): Promise<WorkspaceBootstrapFile[]> {
+  return params.sessionKey
+    ? await getOrLoadBootstrapFiles({
+        workspaceDir: params.workspaceDir,
+        sessionKey: params.sessionKey,
+      })
+    : await loadWorkspaceBootstrapFiles(params.workspaceDir);
+}
+
 export async function resolveBootstrapFilesForRun(params: {
+  workspaceDir: string;
+  config?: OpenClawConfig;
+  sessionKey?: string;
+  sessionId?: string;
+  agentId?: string;
+  warn?: (message: string) => void;
+  contextMode?: BootstrapContextMode;
+  runKind?: BootstrapContextRunKind;
+}): Promise<WorkspaceBootstrapFile[]> {
+  const rawFiles = await loadRawBootstrapFilesForRun(params);
+  return resolveBootstrapFilesFromRaw({ ...params, rawFiles });
+}
+
+async function resolveBootstrapFilesFromRaw(params: {
+  rawFiles: WorkspaceBootstrapFile[];
   workspaceDir: string;
   config?: OpenClawConfig;
   sessionKey?: string;
@@ -287,12 +386,7 @@ export async function resolveBootstrapFilesForRun(params: {
   const excludeHeartbeatBootstrapFile = shouldExcludeHeartbeatBootstrapFile(params);
   const sessionKey = params.sessionKey ?? params.sessionId;
   const workspaceSetupCompleted = await isWorkspaceSetupCompletedForContext(params.workspaceDir);
-  const rawFiles = params.sessionKey
-    ? await getOrLoadBootstrapFiles({
-        workspaceDir: params.workspaceDir,
-        sessionKey: params.sessionKey,
-      })
-    : await loadWorkspaceBootstrapFiles(params.workspaceDir);
+  const rawFiles = params.rawFiles;
   const bootstrapFiles = applyContextModeFilter({
     files: filterCompletedWorkspaceBootstrapFile(
       filterBootstrapFilesForSession(rawFiles, sessionKey),
@@ -332,13 +426,22 @@ export async function resolveBootstrapContextForRun(params: {
   warn?: (message: string) => void;
   contextMode?: BootstrapContextMode;
   runKind?: BootstrapContextRunKind;
+  channelId?: string;
 }): Promise<{
   bootstrapFiles: WorkspaceBootstrapFile[];
   contextFiles: EmbeddedContextFile[];
 }> {
-  const bootstrapFiles = await resolveBootstrapFilesForRun(params);
+  const rawFiles = await loadRawBootstrapFilesForRun(params);
+  const cacheKey = await buildBootstrapContextCacheKey({ ...params, rawFiles });
+  const cached = readCachedBootstrapContext(cacheKey);
+  if (cached) {
+    return cached;
+  }
+  const bootstrapFiles = await resolveBootstrapFilesFromRaw({ ...params, rawFiles });
   const contextFiles = buildBootstrapContextForFiles(bootstrapFiles, params);
-  return { bootstrapFiles, contextFiles };
+  const snapshot = { bootstrapFiles, contextFiles };
+  writeCachedBootstrapContext(cacheKey, snapshot);
+  return snapshot;
 }
 
 export function buildBootstrapContextForFiles(

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -1062,7 +1062,7 @@ export function resolveModel(
   const modelRegistry =
     options?.modelRegistry ??
     cachedStores?.modelRegistry ??
-    discoverModels(authStorage, resolvedAgentDir);
+    discoverModels(authStorage, resolvedAgentDir, { config: cfg });
   const runtimeHooks = resolveRuntimeHooks(options);
   const model = resolveModelWithRegistry({
     provider: normalizedRef.provider,
@@ -1135,7 +1135,7 @@ export async function resolveModelAsync(
     options?.modelRegistry ??
     emptyDiscoveryStores?.modelRegistry ??
     cachedStores?.modelRegistry ??
-    discoverModels(authStorage, resolvedAgentDir);
+    discoverModels(authStorage, resolvedAgentDir, { config: cfg });
   const runtimeHooks = resolveRuntimeHooks(options);
   const explicitModel = resolveExplicitModelWithRegistry({
     provider: normalizedRef.provider,

--- a/src/agents/pi-model-discovery.cache.test.ts
+++ b/src/agents/pi-model-discovery.cache.test.ts
@@ -1,0 +1,83 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { __piDiscoveryTesting, discoverAuthStorage, discoverModels } from "./pi-model-discovery.js";
+
+function writeModelsJson(agentDir: string, modelId: string): void {
+  fs.writeFileSync(
+    path.join(agentDir, "models.json"),
+    JSON.stringify({
+      providers: {
+        custom: {
+          baseUrl: "https://example.test/v1",
+          apiKey: "sk-test",
+          api: "openai",
+          models: [{ id: modelId, name: modelId }],
+        },
+      },
+    }),
+  );
+}
+
+describe("discoverModels cache", () => {
+  beforeEach(() => {
+    __piDiscoveryTesting.clear();
+  });
+  afterEach(() => {
+    delete process.env.OPENCLAW_DISABLE_MODEL_DISCOVERY_CACHE;
+    __piDiscoveryTesting.clear();
+  });
+
+  it("returns the same registry instance for repeat calls with identical inputs", () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-pi-disc-cache-"));
+    writeModelsJson(agentDir, "alpha-model");
+    const authStorage = discoverAuthStorage(agentDir, { skipCredentials: true });
+
+    const first = discoverModels(authStorage, agentDir, { normalizeModels: false });
+    const second = discoverModels(authStorage, agentDir, { normalizeModels: false });
+
+    expect(second).toBe(first);
+    expect(__piDiscoveryTesting.size()).toBe(1);
+  });
+
+  it("returns a fresh registry when models.json changes (cache key keyed on fingerprint)", async () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-pi-disc-cache-mtime-"));
+    writeModelsJson(agentDir, "alpha-model");
+    const authStorage = discoverAuthStorage(agentDir, { skipCredentials: true });
+
+    const first = discoverModels(authStorage, agentDir, { normalizeModels: false });
+
+    // Force a different mtime/size before re-querying.
+    await new Promise((r) => setTimeout(r, 25));
+    writeModelsJson(agentDir, "alpha-model-and-beta");
+    const second = discoverModels(authStorage, agentDir, { normalizeModels: false });
+
+    expect(second).not.toBe(first);
+  });
+
+  it("uses distinct cache entries for different option sets", () => {
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-pi-disc-cache-opts-"));
+    writeModelsJson(agentDir, "alpha-model");
+    const authStorage = discoverAuthStorage(agentDir, { skipCredentials: true });
+
+    const a = discoverModels(authStorage, agentDir, { normalizeModels: false });
+    const b = discoverModels(authStorage, agentDir, { normalizeModels: true });
+
+    expect(b).not.toBe(a);
+    expect(__piDiscoveryTesting.size()).toBeGreaterThanOrEqual(2);
+  });
+
+  it("skips the cache when OPENCLAW_DISABLE_MODEL_DISCOVERY_CACHE=1", () => {
+    process.env.OPENCLAW_DISABLE_MODEL_DISCOVERY_CACHE = "1";
+    const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-pi-disc-cache-off-"));
+    writeModelsJson(agentDir, "alpha-model");
+    const authStorage = discoverAuthStorage(agentDir, { skipCredentials: true });
+
+    const first = discoverModels(authStorage, agentDir, { normalizeModels: false });
+    const second = discoverModels(authStorage, agentDir, { normalizeModels: false });
+
+    expect(second).not.toBe(first);
+    expect(__piDiscoveryTesting.size()).toBe(0);
+  });
+});

--- a/src/agents/pi-model-discovery.ts
+++ b/src/agents/pi-model-discovery.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import type { Api, Model } from "@earendil-works/pi-ai";
 import * as PiCodingAgent from "@earendil-works/pi-coding-agent";
@@ -5,6 +6,7 @@ import type {
   AuthStorage as PiAuthStorage,
   ModelRegistry as PiModelRegistry,
 } from "@earendil-works/pi-coding-agent";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeModelCompat } from "../plugins/provider-model-compat.js";
 import {
   applyProviderResolvedModelCompatWithPlugins,
@@ -12,6 +14,7 @@ import {
   normalizeProviderResolvedModelWithPlugin,
 } from "../plugins/provider-runtime.js";
 import { isRecord } from "../utils.js";
+import { resolveAuthStatePath, resolveAuthStorePath } from "./auth-profiles/paths.js";
 import type { PiCredentialMap } from "./pi-auth-credentials.js";
 import {
   resolvePiCredentialsForDiscovery,
@@ -19,6 +22,7 @@ import {
   type DiscoverAuthStorageOptions,
 } from "./pi-auth-discovery.js";
 import { normalizeProviderId } from "./provider-id.js";
+import { stableStringify } from "./stable-stringify.js";
 
 const PiAuthStorageClass = PiCodingAgent.AuthStorage;
 const PiModelRegistryClass = PiCodingAgent.ModelRegistry;
@@ -36,6 +40,89 @@ type DiscoveredProviderRuntimeModelLike = Omit<ProviderRuntimeModelLike, "api"> 
 type DiscoverModelsOptions = {
   providerFilter?: string;
   normalizeModels?: boolean;
+  config?: OpenClawConfig;
+};
+
+type FileFingerprint = { mtimeMs: number | null; size: number | null };
+
+const PI_DISCOVERY_CACHE_LIMIT = 64;
+const piDiscoveryCache = new Map<string, PiModelRegistry>();
+
+function fileFingerprint(filePath: string): FileFingerprint {
+  try {
+    const stat = fs.statSync(filePath);
+    return { mtimeMs: stat.mtimeMs, size: stat.size };
+  } catch {
+    return { mtimeMs: null, size: null };
+  }
+}
+
+function buildPiDiscoveryCacheKey(params: {
+  agentDir: string;
+  modelsJsonPath: string;
+  options?: DiscoverModelsOptions;
+}): string {
+  const provider = params.options?.providerFilter
+    ? normalizeProviderId(params.options.providerFilter)
+    : "";
+  const mainAuthPath = resolveAuthStorePath();
+  const agentAuthPath = resolveAuthStorePath(params.agentDir);
+  return stableStringify({
+    version: 2,
+    agentDir: path.resolve(params.agentDir),
+    provider,
+    normalizeModels: params.options?.normalizeModels !== false,
+    config: {
+      models: params.options?.config?.models ?? null,
+      plugins: params.options?.config?.plugins ?? null,
+    },
+    auth: {
+      main: fileFingerprint(mainAuthPath),
+      mainState: fileFingerprint(resolveAuthStatePath()),
+      agent: fileFingerprint(agentAuthPath),
+      agentState: fileFingerprint(resolveAuthStatePath(params.agentDir)),
+    },
+    modelsJson: fileFingerprint(params.modelsJsonPath),
+  });
+}
+
+function readCachedPiDiscovery(key: string): PiModelRegistry | undefined {
+  if (process.env.OPENCLAW_DISABLE_MODEL_DISCOVERY_CACHE === "1") {
+    return undefined;
+  }
+  const cached = piDiscoveryCache.get(key);
+  if (!cached) {
+    return undefined;
+  }
+  piDiscoveryCache.delete(key);
+  piDiscoveryCache.set(key, cached);
+  return cached;
+}
+
+function writeCachedPiDiscovery(key: string, registry: PiModelRegistry): void {
+  if (process.env.OPENCLAW_DISABLE_MODEL_DISCOVERY_CACHE === "1") {
+    return;
+  }
+  if (piDiscoveryCache.has(key)) {
+    piDiscoveryCache.delete(key);
+  }
+  piDiscoveryCache.set(key, registry);
+  while (piDiscoveryCache.size > PI_DISCOVERY_CACHE_LIMIT) {
+    const oldest = piDiscoveryCache.keys().next().value;
+    if (typeof oldest !== "string") {
+      break;
+    }
+    piDiscoveryCache.delete(oldest);
+  }
+}
+
+export const __piDiscoveryTesting = {
+  clear(): void {
+    piDiscoveryCache.clear();
+  },
+  size(): number {
+    return piDiscoveryCache.size;
+  },
 };
 
 type InMemoryAuthStorageBackendLike = {
@@ -251,12 +338,15 @@ export function discoverModels(
   agentDir: string,
   options?: DiscoverModelsOptions,
 ): PiModelRegistry {
-  return createOpenClawModelRegistry(
-    authStorage,
-    path.join(agentDir, "models.json"),
-    agentDir,
-    options,
-  );
+  const modelsJsonPath = path.join(agentDir, "models.json");
+  const cacheKey = buildPiDiscoveryCacheKey({ agentDir, modelsJsonPath, options });
+  const cached = readCachedPiDiscovery(cacheKey);
+  if (cached) {
+    return cached;
+  }
+  const registry = createOpenClawModelRegistry(authStorage, modelsJsonPath, agentDir, options);
+  writeCachedPiDiscovery(cacheKey, registry);
+  return registry;
 }
 
 export {

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -196,7 +196,20 @@ const internalHooksEnabledState = resolveGlobalSingleton<{ enabled: boolean }>(
   INTERNAL_HOOKS_ENABLED_KEY,
   () => ({ enabled: true }),
 );
+const INTERNAL_HOOK_REGISTRY_VERSION_KEY = Symbol.for("openclaw.internalHookRegistryVersion");
+const internalHookRegistryVersion = resolveGlobalSingleton<{ value: number }>(
+  INTERNAL_HOOK_REGISTRY_VERSION_KEY,
+  () => ({ value: 0 }),
+);
 const log = createSubsystemLogger("internal-hooks");
+
+function bumpInternalHookRegistryVersion(): void {
+  internalHookRegistryVersion.value += 1;
+}
+
+export function getInternalHookRegistryVersion(): number {
+  return internalHookRegistryVersion.value;
+}
 
 /**
  * Register a hook handler for a specific event type or event:action combination
@@ -222,6 +235,7 @@ export function registerInternalHook(eventKey: string, handler: InternalHookHand
     handlers.set(eventKey, []);
   }
   handlers.get(eventKey)!.push(handler);
+  bumpInternalHookRegistryVersion();
 }
 
 /**
@@ -239,6 +253,7 @@ export function unregisterInternalHook(eventKey: string, handler: InternalHookHa
   const index = eventHandlers.indexOf(handler);
   if (index !== -1) {
     eventHandlers.splice(index, 1);
+    bumpInternalHookRegistryVersion();
   }
 
   // Clean up empty handler arrays
@@ -251,7 +266,10 @@ export function unregisterInternalHook(eventKey: string, handler: InternalHookHa
  * Clear all registered hooks (useful for testing)
  */
 export function clearInternalHooks(): void {
-  handlers.clear();
+  if (handlers.size > 0) {
+    handlers.clear();
+    bumpInternalHookRegistryVersion();
+  }
 }
 
 export function setInternalHooksEnabled(enabled: boolean): void {

--- a/src/plugins/tool-descriptor-cache.ts
+++ b/src/plugins/tool-descriptor-cache.ts
@@ -168,6 +168,9 @@ export function capturePluginToolDescriptor(params: {
 export function readCachedPluginToolDescriptors(
   cacheKey: string,
 ): readonly CachedPluginToolDescriptor[] | undefined {
+  if (process.env.OPENCLAW_DISABLE_TOOL_DESCRIPTOR_CACHE === "1") {
+    return undefined;
+  }
   return descriptorCache.get(cacheKey);
 }
 
@@ -175,6 +178,9 @@ export function writeCachedPluginToolDescriptors(params: {
   cacheKey: string;
   descriptors: readonly CachedPluginToolDescriptor[];
 }): void {
+  if (process.env.OPENCLAW_DISABLE_TOOL_DESCRIPTOR_CACHE === "1") {
+    return;
+  }
   if (
     !descriptorCache.has(params.cacheKey) &&
     descriptorCache.size >= PLUGIN_TOOL_DESCRIPTOR_CACHE_LIMIT

--- a/src/secrets/runtime-state.test.ts
+++ b/src/secrets/runtime-state.test.ts
@@ -44,8 +44,20 @@ describe("secrets runtime state", () => {
       const statePath = resolveAuthStatePath(agentDir);
       fs.writeFileSync(authPath, `${JSON.stringify(authStore("sk-new"))}\n`);
       const stat = fs.statSync(authPath);
+      // NOTE: cache key here mirrors the option-sensitive key used by store.ts
+      // for { syncExternalCli: false } — the test populates the cached store
+      // that loadAuthProfileStoreForRuntime should observe.
       writeCachedAuthProfileStore({
-        authPath,
+        cacheKey: JSON.stringify({
+          allowKeychainPrompt: null,
+          authPath,
+          config: null,
+          externalCli: null,
+          externalCliProfileIds: null,
+          externalCliProviderIds: null,
+          syncExternalCli: false,
+          version: 2,
+        }),
         authMtimeMs: stat.mtimeMs,
         stateMtimeMs: fs.existsSync(statePath) ? fs.statSync(statePath).mtimeMs : null,
         store: authStore("sk-old"),


### PR DESCRIPTION
Rebased follow-up to #76348.

Since #76348 was filed, upstream landed the simpler half it proposed — the per-session bootstrap-files snapshot cache (`src/agents/bootstrap-cache.ts`'s `getOrLoadBootstrapFiles`). This PR isolates and re-bases the **still-relevant** gaps in that original PR on top of current `main`, dropping anything upstream now handles better.

#76348 is being closed in favor of this PR (its branch was 18.5k commits stale and not rebaseable in place).

## What's in this PR

### 1. Second-layer bootstrap **context** snapshot cache
`src/agents/bootstrap-cache.ts`, `src/agents/bootstrap-files.ts`

Upstream caches the raw `WorkspaceBootstrapFile[]` per session. This adds a second LRU on top that caches the full post-hook / filtered `{ bootstrapFiles, contextFiles }` payload returned by `resolveBootstrapContextForRun`. That payload is the expensive thing — hook overrides, completion filtering, bootstrap-context-mode filtering, char-budget enforcement.

- **What**: `readCachedBootstrapContext` / `writeCachedBootstrapContext`, LRU bounded at 128 entries, with a stable JSON cache key that mixes in sessionKey, workspaceDir + workspace mtime, contextMode, runKind, agentId/defaultAgentId, channelId, context-injection + bootstrap config, resolved max-char limits, a raw-file content fingerprint, the internal hook registry version, and the plugins config.
- **Why**: every embedded-runner turn currently re-runs the full hook + filter + char-budget pipeline even though inputs only change when files / config / hooks change.
- **Invalidation**: when `getOrLoadBootstrapFiles` detects a session's raw files changed, it calls `clearBootstrapContextSnapshotsForSession(sessionKey)`. Plus `getInternalHookRegistryVersion()` is mixed into the key so hook registration mutations bust the cache.
- **Kill switch**: `OPENCLAW_DISABLE_BOOTSTRAP_CONTEXT_CACHE=1`.

### 2. PI model-discovery LRU cache
`src/agents/pi-model-discovery.ts`, `src/agents/pi-embedded-runner/model.ts`

`discoverModels(authStorage, agentDir, options)` walks the agent dir, reads `models.json`, reads auth stores, and constructs a `PiModelRegistry`. It's invoked per `resolveModel` call. Upstream has zero LRU/discovery-cache references in this file.

- **What**: LRU bounded at 64 entries, keyed by agentDir + provider filter + normalize flag + relevant config slices (`config.models`, `config.plugins`) + auth-store/state file fingerprints + `models.json` file fingerprint. Invalidates automatically when any auth or models.json file is touched.
- **Why**: avoids rebuilding the registry for every turn when nothing has changed.
- **Wiring**: `resolveModel` and `resolveModelAsync` in `pi-embedded-runner/model.ts` now pass `{ config: cfg }` through so two agents with different model configs do NOT share a cache entry.
- **Kill switch**: `OPENCLAW_DISABLE_MODEL_DISCOVERY_CACHE=1`.
- **Test**: new `src/agents/pi-model-discovery.cache.test.ts` (4 cases: identity, mtime-busts-cache, distinct-options, kill switch).

### 3. Option-sensitive cache keys for the auth-profile store
`src/agents/auth-profiles/store.ts`, `src/agents/auth-profiles/store-cache.ts`

Upstream caches loaded auth-profile stores in a `Map<string, …>` keyed by `authPath`. The problem: two callers with different `LoadAuthProfileStoreOptions` (e.g. one with `syncExternalCli: true`, another with `syncExternalCli: false`) poison each other — caller A's overlaid-external-CLI store can leak to caller B reading the same path, and vice versa.

- **What**: `store-cache.ts` now takes an opaque `cacheKey: string` instead of `authPath`. `store.ts` builds it via `buildAuthStoreCacheKey({ authPath, options })` which stable-stringifies authPath + config slice + externalCli mode + externalCliProviderIds + externalCliProfileIds + syncExternalCli + allowKeychainPrompt.
- **Why**: prevents cross-caller poisoning while keeping the speedup intact.
- **Test fixup**: `src/secrets/runtime-state.test.ts` updated to seed the cache under the new option-aware key (and documents the option set the cached entry corresponds to).

### 4. Kill switch for the plugin tool-descriptor cache
`src/plugins/tool-descriptor-cache.ts`

Trivial but useful: setting `OPENCLAW_DISABLE_TOOL_DESCRIPTOR_CACHE=1` makes both the read and write sides no-op. Useful when debugging tool-descriptor recomputation issues (the cache itself is upstream — only the off-knob is new).

## Things the original PR did that this PR does NOT do

- Does **not** re-touch upstream's existing simple per-session `bootstrap-files` cache (`getOrLoadBootstrapFiles`) — upstream's implementation is what we want.
- Does **not** include any plumbing changes that conflicted with upstream's current shape (e.g. the upstream cache module was split into `store-cache.ts`; we adapt to that split rather than reverting it).

## Validation

From a clone of `upstream/main` + this branch:

```
pnpm install --frozen-lockfile
pnpm exec vitest run \
  src/agents/bootstrap-files.test.ts \
  src/agents/bootstrap-cache.test.ts \
  src/agents/auth-profiles.store-cache.test.ts \
  src/plugins/tool-descriptor-cache.test.ts \
  src/hooks/internal-hooks.test.ts \
  src/agents/pi-model-discovery.cache.test.ts
```

Result:

```
 Test Files  10 passed (10)
      Tests  141 passed (141)
```

Smoke tests on directly-touched modules also pass:
- `src/secrets/runtime-state.test.ts` — **1 passed**
- `src/agents/pi-model-discovery.test.ts`, `.auth.test.ts`, `.synthetic-auth.test.ts` — **9 passed**
- `src/agents/auth-profiles/oauth.test.ts` — **17 passed**

No regressions attributable to this PR. Full `pnpm test` was not run because the monorepo's pre-existing test surface is large; targeted tests cover all touched modules and their consumers.

## Predecessor

Closes #76348 (predecessor — same scope, hopelessly stale base; the four still-valuable components above are this PR's payload).
