### PR TITLE
Avoid writing plaintext profile keys to models.json

### DIFF
--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -169,14 +169,24 @@ export async function planOpenClawModelsJsonWithDeps(
     secretRefManagedProviders,
   });
   const normalizedMergedProviders =
-    normalizeProviderCatalogModelsForConfig(mergedProviders) ?? mergedProviders;
-  const secretEnforcedProviders =
-    enforceSourceManagedProviderSecrets({
-      providers: normalizedMergedProviders,
+    normalizeProviders({
+      providers: mergedProviders,
+      agentDir,
+      env,
+      secretDefaults: cfg.secrets?.defaults,
       sourceProviders: params.sourceConfigForSecrets?.models?.providers,
       sourceSecretDefaults: params.sourceConfigForSecrets?.secrets?.defaults,
       secretRefManagedProviders,
-    }) ?? normalizedMergedProviders;
+    }) ?? mergedProviders;
+  const normalizedCatalogProviders =
+    normalizeProviderCatalogModelsForConfig(normalizedMergedProviders) ?? normalizedMergedProviders;
+  const secretEnforcedProviders =
+    enforceSourceManagedProviderSecrets({
+      providers: normalizedCatalogProviders,
+      sourceProviders: params.sourceConfigForSecrets?.models?.providers,
+      sourceSecretDefaults: params.sourceConfigForSecrets?.secrets?.defaults,
+      secretRefManagedProviders,
+    }) ?? normalizedCatalogProviders;
   const finalProviders = applyNativeStreamingUsageCompat(secretEnforcedProviders);
   const nextContents = `${JSON.stringify({ providers: finalProviders }, null, 2)}\n`;
 

--- a/src/agents/models-config.providers.normalize-keys.test.ts
+++ b/src/agents/models-config.providers.normalize-keys.test.ts
@@ -3,7 +3,9 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { saveAuthProfileStore } from "./auth-profiles/store.js";
 import { NON_ENV_SECRETREF_MARKER } from "./model-auth-markers.js";
+import { planOpenClawModelsJsonWithDeps } from "./models-config.plan.js";
 import { normalizeProviders } from "./models-config.providers.normalize.js";
 import { resolveApiKeyFromProfiles } from "./models-config.providers.secret-helpers.js";
 import { enforceSourceManagedProviderSecrets } from "./models-config.providers.source-managed.js";
@@ -15,7 +17,10 @@ function normalizeLmstudioBaseUrl(baseUrl: string): string {
 
 vi.mock("./models-config.providers.policy.runtime.js", () => {
   return {
-    applyProviderNativeStreamingUsagePolicy: () => undefined,
+    applyProviderNativeStreamingUsagePolicy: (
+      _providerKey: string,
+      provider: { baseUrl?: unknown } | undefined,
+    ) => provider,
     normalizeProviderConfigPolicy: (
       providerKey: string,
       provider: { baseUrl?: unknown } | undefined,
@@ -248,6 +253,142 @@ describe("normalizeProviders", () => {
     }
   });
 
+  it("does not add plaintext auth-profile keys to generated provider config", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-"));
+    const env = { ...process.env } as NodeJS.ProcessEnv;
+    delete env.OPENAI_API_KEY;
+    try {
+      saveAuthProfileStore(
+        {
+          version: 1,
+          profiles: {
+            "openai:default": {
+              type: "api_key",
+              provider: "openai",
+              key: "sk-profile-plaintext-secret", // pragma: allowlist secret
+            },
+          },
+        },
+        agentDir,
+      );
+      const providers: NonNullable<NonNullable<OpenClawConfig["models"]>["providers"]> = {
+        openai: {
+          baseUrl: "https://api.openai.com/v1",
+          api: "openai-completions",
+          models: [createModel()],
+        },
+      };
+
+      const normalized = normalizeProviders({ providers, agentDir, env });
+
+      expect(normalized?.openai?.apiKey).toBeUndefined();
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("strips provider apiKey values that match plaintext auth-profile keys", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-"));
+    const env = { ...process.env } as NodeJS.ProcessEnv;
+    delete env.OPENAI_API_KEY;
+    try {
+      saveAuthProfileStore(
+        {
+          version: 1,
+          profiles: {
+            "openai:default": {
+              type: "api_key",
+              provider: "openai",
+              key: "sk-profile-plaintext-secret", // pragma: allowlist secret
+            },
+          },
+        },
+        agentDir,
+      );
+      const providers: NonNullable<NonNullable<OpenClawConfig["models"]>["providers"]> = {
+        openai: {
+          baseUrl: "https://api.openai.com/v1",
+          apiKey: "sk-profile-plaintext-secret", // pragma: allowlist secret
+          api: "openai-completions",
+          models: [createModel()],
+        },
+      };
+
+      const normalized = normalizeProviders({ providers, agentDir, env });
+
+      expect(normalized?.openai?.apiKey).toBeUndefined();
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("strips profile-backed plaintext keys preserved by models.json merge mode", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-"));
+    const env = { ...process.env } as NodeJS.ProcessEnv;
+    delete env.OPENAI_API_KEY;
+    try {
+      saveAuthProfileStore(
+        {
+          version: 1,
+          profiles: {
+            "openai:default": {
+              type: "api_key",
+              provider: "openai",
+              key: "sk-profile-plaintext-secret", // pragma: allowlist secret
+            },
+          },
+        },
+        agentDir,
+      );
+
+      const plan = await planOpenClawModelsJsonWithDeps(
+        {
+          cfg: { models: { mode: "merge", providers: {} } },
+          agentDir,
+          env,
+          existingRaw: "",
+          existingParsed: {
+            providers: {
+              openai: {
+                baseUrl: "https://api.openai.com/v1",
+                apiKey: "sk-profile-plaintext-secret", // pragma: allowlist secret
+                api: "openai-completions",
+                models: [createModel({ id: "gpt-proof" })],
+              },
+              custom: {
+                baseUrl: "https://custom.example/v1",
+                apiKey: "CUSTOM_PROXY_API_KEY", // pragma: allowlist secret
+                api: "openai-completions",
+                models: [createModel({ id: "custom-model" })],
+              },
+            },
+          },
+        },
+        {
+          resolveImplicitProviders: async () => ({
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              api: "openai-completions",
+              models: [createModel({ id: "gpt-proof" })],
+            },
+          }),
+        },
+      );
+
+      expect(plan.action).toBe("write");
+      if (plan.action !== "write") {
+        throw new Error("Expected models.json write plan");
+      }
+      const parsed = JSON.parse(plan.contents) as {
+        providers?: Record<string, { apiKey?: string }>;
+      };
+      expect(parsed.providers?.openai?.apiKey).toBeUndefined();
+      expect(parsed.providers?.custom?.apiKey).toBe("CUSTOM_PROXY_API_KEY");
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
   it("normalizes SecretRef-managed provider apiKey values to env markers", async () => {
     const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-"));
     const secretRefManagedProviders = new Set<string>();
@@ -392,6 +533,73 @@ describe("normalizeProviders", () => {
 
       const normalized = normalizeProviders({ providers, agentDir });
       expect(normalized?.lmstudio?.baseUrl).toBe("http://localhost:1234/v1");
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("strips profile-backed plaintext keys from merge-preserved providers without models", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-"));
+    const env = { ...process.env } as NodeJS.ProcessEnv;
+    delete env.OPENAI_API_KEY;
+    try {
+      saveAuthProfileStore(
+        {
+          version: 1,
+          profiles: {
+            "openai:default": {
+              type: "api_key",
+              provider: "openai",
+              key: "sk-profile-plaintext-secret", // pragma: allowlist secret
+            },
+          },
+        },
+        agentDir,
+      );
+
+      const plan = await planOpenClawModelsJsonWithDeps(
+        {
+          cfg: {
+            models: {
+              mode: "merge",
+              providers: {
+                custom: {
+                  baseUrl: "https://custom.example/v1",
+                  apiKey: "CUSTOM_PROXY_API_KEY", // pragma: allowlist secret
+                  api: "openai-completions",
+                  models: [createModel({ id: "custom-model" })],
+                },
+              },
+            },
+          },
+          agentDir,
+          env,
+          existingRaw: "",
+          existingParsed: {
+            providers: {
+              openai: {
+                baseUrl: "https://api.openai.com/v1",
+                apiKey: "sk-profile-plaintext-secret", // pragma: allowlist secret
+                api: "openai-completions",
+                models: [],
+              },
+            },
+          },
+        },
+        {
+          resolveImplicitProviders: async () => ({}),
+        },
+      );
+
+      expect(plan.action).toBe("write");
+      if (plan.action !== "write") {
+        throw new Error("Expected models.json write plan");
+      }
+      const parsed = JSON.parse(plan.contents) as {
+        providers?: Record<string, { apiKey?: string }>;
+      };
+      expect(parsed.providers?.openai?.apiKey).toBeUndefined();
+      expect(parsed.providers?.custom?.apiKey).toBe("CUSTOM_PROXY_API_KEY");
     } finally {
       await fs.rm(agentDir, { recursive: true, force: true });
     }

--- a/src/agents/models-config.providers.normalize.ts
+++ b/src/agents/models-config.providers.normalize.ts
@@ -12,6 +12,7 @@ import {
   normalizeResolvedEnvApiKey,
   resolveApiKeyFromProfiles,
   resolveMissingProviderApiKey,
+  stripProfileBackedPlaintextProviderApiKey,
 } from "./models-config.providers.secret-helpers.js";
 import { enforceSourceManagedProviderSecrets } from "./models-config.providers.source-managed.js";
 
@@ -177,9 +178,10 @@ export function normalizeProviders(params: {
       normalizedProvider = providerWithResolvedEnvApiKey;
     }
 
+    const hasProviderModels =
+      Array.isArray(normalizedProvider.models) && normalizedProvider.models.length > 0;
     const needsProfileApiKey =
-      Array.isArray(normalizedProvider.models) &&
-      normalizedProvider.models.length > 0 &&
+      hasProviderModels &&
       !(
         (typeof normalizedProvider.apiKey === "string" && normalizedProvider.apiKey.trim()) ||
         normalizedProvider.apiKey
@@ -199,6 +201,19 @@ export function normalizeProviders(params: {
     if (providerWithApiKey !== normalizedProvider) {
       mutated = true;
       normalizedProvider = providerWithApiKey;
+    }
+
+    const hasProviderApiKey =
+      typeof normalizedProvider.apiKey === "string" && normalizedProvider.apiKey.trim().length > 0;
+    const profileApiKeyForStrip =
+      hasProviderApiKey && !profileApiKey ? resolveProfileApiKey(normalizedKey) : profileApiKey;
+    const providerWithoutProfileBackedPlaintextApiKey = stripProfileBackedPlaintextProviderApiKey({
+      provider: normalizedProvider,
+      profileApiKey: profileApiKeyForStrip,
+    });
+    if (providerWithoutProfileBackedPlaintextApiKey !== normalizedProvider) {
+      mutated = true;
+      normalizedProvider = providerWithoutProfileBackedPlaintextApiKey;
     }
 
     const providerSpecificNormalized = normalizeProviderSpecificConfig(

--- a/src/agents/models-config.providers.secret-helpers.ts
+++ b/src/agents/models-config.providers.secret-helpers.ts
@@ -306,7 +306,9 @@ export function resolveMissingProviderApiKey(params: {
   }
 
   const fromEnv = resolveEnvApiKeyVarName(params.providerKey, params.env);
-  const apiKey = fromEnv ?? params.profileApiKey?.apiKey;
+  const profileApiKey =
+    params.profileApiKey?.source === "plaintext" ? undefined : params.profileApiKey?.apiKey;
+  const apiKey = fromEnv ?? profileApiKey;
   if (!apiKey?.trim()) {
     return params.provider;
   }
@@ -317,4 +319,23 @@ export function resolveMissingProviderApiKey(params: {
     ...params.provider,
     apiKey,
   };
+}
+
+export function stripProfileBackedPlaintextProviderApiKey(params: {
+  provider: ProviderConfig;
+  profileApiKey: ProfileApiKeyResolution | undefined;
+}): ProviderConfig {
+  if (params.profileApiKey?.source !== "plaintext") {
+    return params.provider;
+  }
+  const currentApiKey = normalizeOptionalSecretInput(params.provider.apiKey);
+  if (!currentApiKey || currentApiKey !== params.profileApiKey.apiKey.trim()) {
+    return params.provider;
+  }
+  if (isNonSecretApiKeyMarker(currentApiKey)) {
+    return params.provider;
+  }
+  const providerWithoutApiKey = { ...params.provider };
+  delete providerWithoutApiKey.apiKey;
+  return providerWithoutApiKey;
 }


### PR DESCRIPTION
## Summary

This keeps plaintext auth-profile API keys out of generated `models.json`.

The provider normalization path already preserves env and SecretRef-backed credentials as markers. Plaintext auth-profile keys could still be copied into the generated provider config when a provider had models but no configured `apiKey`, when a generated provider `apiKey` matched the plaintext profile key, or when merge mode preserved an existing `models.json` value after the first normalization pass.

This PR skips plaintext profile keys for `models.json` persistence, strips matching plaintext values during provider normalization, and re-normalizes after merge mode preserves existing provider fields. The strip also applies to merge-preserved provider entries with no model rows, so old plaintext profile keys do not survive just because `models` is empty. Unrelated user-managed provider keys stay intact.

## Real behavior proof

Behavior or issue addressed: plaintext auth-profile API keys should not be persisted into generated `models.json` provider entries, including merge-mode regeneration from an existing `models.json` and merge-preserved provider entries with `models: []`.

Real environment tested: local OpenClaw checkout on Android/arm64 Termux with Node v24.13.0. I used a temp agent directory with a real `auth-profiles.json` entry containing a plaintext `openai:default` key. The merge-mode proof used an existing parsed `models.json` with an OpenAI provider whose `apiKey` matched that plaintext profile key, `models: []`, plus a separate custom provider with an unrelated user-managed key.

Exact steps or command run after this patch: ran a `node --import tsx --input-type=module` script that saved the plaintext auth profile, called `planOpenClawModelsJsonWithDeps` in `models.mode = \"merge\"`, parsed the generated contents, and printed whether the merged OpenAI provider still had an `apiKey` property and whether the unrelated custom provider key was preserved.

Evidence after fix: terminal output from the proof command:

```json
{
  "action": "write",
  "openaiModelsLength": 0,
  "openaiHasApiKeyProperty": false,
  "openaiApiKeyValue": null,
  "customApiKeyPreserved": true,
  "providerIds": [
    "openai",
    "custom"
  ]
}
```

Observed result after fix: merge mode keeps the OpenAI and custom provider entries, removes the OpenAI `apiKey` value that matched the plaintext auth profile even though the OpenAI provider has no models, and preserves the unrelated custom provider `apiKey`.

What was not tested: full native `tsgo` in this environment, because `@typescript/native-preview-android-arm64` is unavailable. Plain `tsc` on the full core test project also ran out of heap locally.

## Tests

- `node_modules/.bin/vitest run --config test/vitest/vitest.agents.config.ts src/agents/models-config.providers.normalize-keys.test.ts`
- `node_modules/.bin/vitest run --config test/vitest/vitest.agents.config.ts src/agents/models-config.applies-config-env-vars.test.ts src/agents/models-config.merge.test.ts`
- `node_modules/.bin/oxlint src/agents/models-config.plan.ts src/agents/models-config.providers.normalize.ts src/agents/models-config.providers.secret-helpers.ts src/agents/models-config.providers.normalize-keys.test.ts`
- `git diff --check`


Addresses #11829
