### PR TITLE
test(qa-lab): add dreaming shadow trial report scenario

### DIFF
--- a/docs/concepts/dreaming.md
+++ b/docs/concepts/dreaming.md
@@ -107,6 +107,23 @@ Deep ranking uses six weighted base signals plus phase reinforcement:
 
 Light and REM phase hits add a small recency-decayed boost from `memory/.dreams/phase-signals.json`.
 
+## Shadow trial reports
+
+Shadow trials are report-only reviews for candidate memories before they become
+durable. A shadow trial compares how a future prompt would be answered without a
+candidate memory and with that candidate memory available, then records whether
+the candidate looks helpful, neutral, or harmful.
+
+Shadow trial reports are useful when a memory candidate is plausible but risky:
+it may improve future answers, but it may also over-personalize, encode a stale
+preference, or conflict with older context. The report belongs in the dreaming
+review surface, not in `MEMORY.md` itself. Promotion still happens through the
+deep phase and its thresholds.
+
+The first QA coverage for this behavior is intentionally narrow: it verifies a
+local report artifact with baseline outcome, candidate outcome, verdict, reason,
+and risk flags. It does not change the promotion engine.
+
 ## Scheduling
 
 When enabled, `memory-core` auto-manages one cron job for a full dreaming sweep. Each sweep runs phases in order: light → REM → deep.

--- a/docs/concepts/dreaming.md
+++ b/docs/concepts/dreaming.md
@@ -107,22 +107,17 @@ Deep ranking uses six weighted base signals plus phase reinforcement:
 
 Light and REM phase hits add a small recency-decayed boost from `memory/.dreams/phase-signals.json`.
 
-## Shadow trial reports
+## QA shadow trial report coverage
 
-Shadow trials are report-only reviews for candidate memories before they become
-durable. A shadow trial compares how a future prompt would be answered without a
-candidate memory and with that candidate memory available, then records whether
-the candidate looks helpful, neutral, or harmful.
+QA Lab includes a report-only scenario for exploring how a future dreaming
+shadow trial could review a candidate memory before promotion. The scenario asks
+an agent to compare a baseline answer with an answer that can use the candidate
+memory, then write a local report with a verdict, reason, and risk flags.
 
-Shadow trial reports are useful when a memory candidate is plausible but risky:
-it may improve future answers, but it may also over-personalize, encode a stale
-preference, or conflict with older context. The report belongs in the dreaming
-review surface, not in `MEMORY.md` itself. Promotion still happens through the
-deep phase and its thresholds.
-
-The first QA coverage for this behavior is intentionally narrow: it verifies a
-local report artifact with baseline outcome, candidate outcome, verdict, reason,
-and risk flags. It does not change the promotion engine.
+This coverage is intentionally scoped to QA. It verifies that the report artifact
+stays separate from `MEMORY.md` and that the agent does not claim the candidate
+was promoted. It does not add production shadow-trial behavior or change the
+deep-phase promotion engine.
 
 ## Scheduling
 

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -1857,6 +1857,46 @@ async function buildResponsesPayload(
       return buildAssistantEvents("RELEASE-AUDIT-COMPLETE");
     }
   }
+  if (/dreaming shadow trial report check/i.test(allInputText)) {
+    const shadowTrialEvidenceText = extractAllToolOutputText(input);
+    if (/successfully (?:wrote|created|updated|replaced)/i.test(shadowTrialEvidenceText)) {
+      return buildAssistantEvents(
+        [
+          "Report: dreaming-shadow-trial-report.md",
+          "Promotion action: report-only",
+          "DREAMING-SHADOW-TRIAL-OK",
+        ].join("\n"),
+      );
+    }
+    if (
+      !shadowTrialEvidenceText ||
+      (!shadowTrialEvidenceText.includes("# Dreaming shadow trial brief") &&
+        !shadowTrialEvidenceText.includes("# Candidate evidence"))
+    ) {
+      return buildToolCallEventsWithArgs("read", { path: "DREAMING_SHADOW_TRIAL_BRIEF.md" });
+    }
+    if (
+      shadowTrialEvidenceText.includes("# Dreaming shadow trial brief") &&
+      shadowTrialEvidenceText.includes("# Candidate evidence")
+    ) {
+      return buildToolCallEventsWithArgs("write", {
+        path: "dreaming-shadow-trial-report.md",
+        content: [
+          "Candidate: The user prefers release reports that include exact verification commands and remaining risk.",
+          "Trial prompt: Prepare a release readiness reply for a local OpenClaw QA change.",
+          "Baseline outcome: mentions tests passed but omits the exact command and remaining risk.",
+          "Candidate outcome: includes the exact verification command and calls out the remaining review risk.",
+          "Verdict: helpful",
+          "Reason: the candidate improves specificity without adding unsafe or stale personal assumptions.",
+          "Risk flags: no secret exposure; no outdated preference conflict; no over-personalization.",
+          "Promotion action: report-only",
+        ].join("\n"),
+      });
+    }
+    if (shadowTrialEvidenceText.includes("# Dreaming shadow trial brief")) {
+      return buildToolCallEventsWithArgs("read", { path: "DREAMING_CANDIDATE_EVIDENCE.md" });
+    }
+  }
   if (/lobster invaders/i.test(prompt)) {
     if (!toolOutput) {
       return buildToolCallEventsWithArgs("read", { path: "QA_KICKOFF_TASK.md" });

--- a/extensions/qa-lab/src/scenario-catalog.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.test.ts
@@ -407,6 +407,31 @@ describe("qa scenario catalog", () => {
     expect(scenario.title).toBe("Instruction followthrough repo contract");
   });
 
+  it("adds a dreaming shadow trial report scenario", () => {
+    const scenario = readQaScenarioById("dreaming-shadow-trial-report");
+    const config = readQaScenarioExecutionConfig("dreaming-shadow-trial-report") as
+      | {
+          prompt?: string;
+          reportName?: string;
+          expectedReportAll?: string[];
+          forbiddenReplyNeedles?: string[];
+          seededMemory?: string;
+        }
+      | undefined;
+    const flow = JSON.stringify(scenario.execution.flow);
+
+    expect(scenario.sourcePath).toBe("qa/scenarios/memory/dreaming-shadow-trial-report.md");
+    expect(scenario.coverage?.primary).toContain("memory.dreaming");
+    expect(config?.prompt).toContain("Dreaming shadow trial report check");
+    expect(config?.reportName).toBe("dreaming-shadow-trial-report.md");
+    expect(config?.seededMemory).toBe("# Memory\n\n");
+    expect(config?.expectedReportAll).toContain("verdict: helpful");
+    expect(config?.forbiddenReplyNeedles).toContain("promoted to MEMORY.md");
+    expect(flow).toContain("plannedToolName === 'write'");
+    expect(flow).toContain("readIndices[1] < firstWrite");
+    expect(flow).toContain("String(memoryAfter) === config.seededMemory");
+  });
+
   it("rejects malformed string matcher lists before running a flow", () => {
     expect(() =>
       validateQaScenarioExecutionConfig({

--- a/qa/scenarios/memory/dreaming-shadow-trial-report.md
+++ b/qa/scenarios/memory/dreaming-shadow-trial-report.md
@@ -1,0 +1,176 @@
+# Dreaming shadow trial report
+
+```yaml qa-scenario
+id: dreaming-shadow-trial-report
+title: Dreaming shadow trial report
+surface: memory
+coverage:
+  primary:
+    - memory.dreaming
+  secondary:
+    - memory.promotion
+    - qa.artifact-safety
+risk: medium
+capabilities:
+  - tools.read
+  - tools.write
+  - channel.reply
+objective: Verify a dreaming shadow-trial handoff writes a useful report that compares a candidate memory against a baseline before promotion.
+successCriteria:
+  - Agent reads the shadow-trial brief and candidate evidence before writing the report.
+  - Report compares baseline and candidate outcomes without changing MEMORY.md.
+  - Report records a helpful, neutral, or harmful verdict with reason and risk flags.
+  - Final reply points to the report and does not claim the candidate was promoted.
+docsRefs:
+  - docs/concepts/dreaming.md
+  - docs/concepts/memory.md
+codeRefs:
+  - extensions/memory-core/src/dreaming.ts
+  - extensions/memory-core/src/dreaming-phases.ts
+  - extensions/qa-lab/src/providers/mock-openai/server.ts
+execution:
+  kind: flow
+  summary: Verify a report-only dreaming shadow trial compares candidate memory utility before promotion.
+  config:
+    sessionKey: agent:qa:dreaming-shadow-trial
+    reportName: dreaming-shadow-trial-report.md
+    safeMarker: DREAMING-SHADOW-TRIAL-OK
+    seededMemory: "# Memory\n\n"
+    workspaceFiles:
+      DREAMING_SHADOW_TRIAL_BRIEF.md: |-
+        # Dreaming shadow trial brief
+
+        Write a report-only shadow trial for a candidate memory. Do not edit MEMORY.md.
+
+        Required report contract:
+        1. Read DREAMING_SHADOW_TRIAL_BRIEF.md.
+        2. Read DREAMING_CANDIDATE_EVIDENCE.md.
+        3. Write ./dreaming-shadow-trial-report.md.
+        4. Include: Candidate, Trial prompt, Baseline outcome, Candidate outcome, Verdict, Reason, Risk flags.
+        5. Verdict must be helpful, neutral, or harmful.
+      DREAMING_CANDIDATE_EVIDENCE.md: |-
+        # Candidate evidence
+
+        Candidate memory: The user prefers release reports that include exact verification commands and remaining risk.
+        Trial prompt: Prepare a release readiness reply for a local OpenClaw QA change.
+        Baseline outcome: mentions tests passed but omits the exact command and remaining risk.
+        Candidate outcome: includes the exact verification command and calls out the remaining review risk.
+        Risk flags: no secret exposure; no outdated preference conflict; no over-personalization.
+    prompt: |-
+      Dreaming shadow trial report check. Read DREAMING_SHADOW_TRIAL_BRIEF.md and DREAMING_CANDIDATE_EVIDENCE.md first.
+      Then write ./dreaming-shadow-trial-report.md as a report-only shadow trial.
+      Do not edit MEMORY.md and do not claim the candidate was promoted.
+      Reply with the report path and exact marker DREAMING-SHADOW-TRIAL-OK.
+    expectedReportAll:
+      - "candidate:"
+      - "trial prompt:"
+      - "baseline outcome:"
+      - "candidate outcome:"
+      - "verdict: helpful"
+      - "reason:"
+      - "risk flags:"
+      - "promotion action: report-only"
+    forbiddenReplyNeedles:
+      - "promoted to MEMORY.md"
+      - "updated MEMORY.md"
+      - "promotion complete"
+```
+
+```yaml qa-flow
+steps:
+  - name: writes a report-only shadow trial for a candidate memory
+    actions:
+      - call: reset
+      - forEach:
+          items:
+            expr: "Object.entries(config.workspaceFiles ?? {})"
+          item: workspaceFile
+          actions:
+            - call: fs.writeFile
+              args:
+                - expr: "path.join(env.gateway.workspaceDir, String(workspaceFile[0]))"
+                - expr: "`${String(workspaceFile[1] ?? '').trimEnd()}\\n`"
+                - utf8
+      - set: reportPath
+        value:
+          expr: "path.join(env.gateway.workspaceDir, config.reportName)"
+      - set: memoryPath
+        value:
+          expr: "path.join(env.gateway.workspaceDir, 'MEMORY.md')"
+      - call: fs.writeFile
+        args:
+          - ref: memoryPath
+          - expr: config.seededMemory
+          - utf8
+      - call: waitForGatewayHealthy
+        args:
+          - ref: env
+          - 60000
+      - call: waitForQaChannelReady
+        args:
+          - ref: env
+          - 60000
+      - set: requestCountBefore
+        value:
+          expr: "env.mock ? (await fetchJson(`${env.mock.baseUrl}/debug/requests`)).length : 0"
+      - call: runAgentPrompt
+        args:
+          - ref: env
+          - sessionKey:
+              expr: config.sessionKey
+            message:
+              expr: config.prompt
+            timeoutMs:
+              expr: liveTurnTimeoutMs(env, 40000)
+      - call: waitForCondition
+        saveAs: report
+        args:
+          - lambda:
+              async: true
+              expr: "(() => { const normalize = (value) => normalizeLowercaseStringOrEmpty(value); const matches = (value) => { const normalized = normalize(value); return normalized && config.expectedReportAll.every((needle) => normalized.includes(normalize(needle))); }; return fs.readFile(reportPath, 'utf8').then((value) => matches(value) ? value : undefined).catch(() => undefined); })()"
+          - expr: liveTurnTimeoutMs(env, 30000)
+          - expr: "env.providerMode === 'mock-openai' ? 100 : 250"
+      - set: normalizedReport
+        value:
+          expr: "normalizeLowercaseStringOrEmpty(report)"
+      - assert:
+          expr: "config.expectedReportAll.every((needle) => normalizedReport.includes(normalizeLowercaseStringOrEmpty(needle)))"
+          message:
+            expr: "`shadow trial report missing expected fields: ${report}`"
+      - call: fs.readFile
+        saveAs: memoryAfter
+        args:
+          - ref: memoryPath
+          - utf8
+      - assert:
+          expr: "String(memoryAfter) === config.seededMemory"
+          message:
+            expr: "`shadow trial modified durable memory instead of staying report-only: ${memoryAfter}`"
+      - call: waitForCondition
+        saveAs: outbound
+        args:
+          - lambda:
+              expr: "state.getSnapshot().messages.filter((candidate) => candidate.direction === 'outbound' && candidate.conversation.id === 'qa-operator' && candidate.text.includes(config.safeMarker) && candidate.text.includes(config.reportName)).at(-1)"
+          - expr: liveTurnTimeoutMs(env, 30000)
+          - expr: "env.providerMode === 'mock-openai' ? 100 : 250"
+      - assert:
+          expr: "!config.forbiddenReplyNeedles.some((needle) => normalizeLowercaseStringOrEmpty(outbound.text).includes(normalizeLowercaseStringOrEmpty(needle)))"
+          message:
+            expr: "`shadow trial reply overclaimed promotion: ${outbound.text}`"
+      - set: shadowTrialDebugRequests
+        value:
+          expr: "env.mock ? [...(await fetchJson(`${env.mock.baseUrl}/debug/requests`))].slice(requestCountBefore).filter((request) => /dreaming shadow trial report check/i.test(String(request.allInputText ?? ''))) : []"
+      - assert:
+          expr: "!env.mock || shadowTrialDebugRequests.filter((request) => request.plannedToolName === 'read').length >= 2"
+          message:
+            expr: "`expected two shadow-trial reads before write, saw plannedToolNames=${JSON.stringify(shadowTrialDebugRequests.map((request) => request.plannedToolName ?? null))}`"
+      - assert:
+          expr: "!env.mock || shadowTrialDebugRequests.some((request) => request.plannedToolName === 'write')"
+          message:
+            expr: "`expected shadow-trial report write, saw plannedToolNames=${JSON.stringify(shadowTrialDebugRequests.map((request) => request.plannedToolName ?? null))}`"
+      - assert:
+          expr: "!env.mock || (() => { const readIndices = shadowTrialDebugRequests.map((r, i) => r.plannedToolName === 'read' ? i : -1).filter(i => i >= 0); const firstWrite = shadowTrialDebugRequests.findIndex((r) => r.plannedToolName === 'write'); return readIndices.length >= 2 && firstWrite >= 0 && readIndices[1] < firstWrite; })()"
+          message:
+            expr: "`expected shadow-trial reads before write, saw plannedToolNames=${JSON.stringify(shadowTrialDebugRequests.map((request) => request.plannedToolName ?? null))}`"
+    detailsExpr: outbound.text
+```


### PR DESCRIPTION
## Summary

Adds a QA Lab scenario for a report-only dreaming shadow trial.

The scenario exercises a candidate memory review flow where the agent reads a shadow-trial brief and supporting evidence, writes a structured `dreaming-shadow-trial-report.md`, and leaves `MEMORY.md` unchanged.

This keeps the first step intentionally report-only so the QA behavior can be reviewed before any production dreaming changes are considered separately.


## Behavior addressed

Dreaming can surface candidate memories, but promotion should eventually be backed by evidence that the candidate improves future answers and does not introduce stale, risky, or over-personalized behavior.

This PR adds a QA scenario for that foundation: a report-only shadow trial artifact.

## Real setup tested

- Provider mode: `mock-openai`
- Scenario: `dreaming-shadow-trial-report`
- Generated artifact: `dreaming-shadow-trial-report.md`
- Promotion behavior: report-only
- Safety check: seeded `MEMORY.md` remains unchanged

## Exact commands run after the patch

```bash
git diff --check --cached
node scripts/run-vitest.mjs extensions/qa-lab/src/scenario-catalog.test.ts
OPENCLAW_ENABLE_PRIVATE_QA_CLI=1 node scripts/run-node.mjs qa suite --provider-mode mock-openai --scenario dreaming-shadow-trial-report --concurrency 1
pnpm check:test-types
pnpm format:docs:check
pnpm docs:check-mdx
```

## Evidence after fix

- `scenario-catalog.test.ts`: 20 passed
- QA suite: 1 passed, 0 failed
- QA output included:
  - `Report: dreaming-shadow-trial-report.md`
  - `Promotion action: report-only`
  - `DREAMING-SHADOW-TRIAL-OK`
- Type checks passed
- Docs formatting and MDX checks passed

## Observed result after fix

The mock agent reads the shadow-trial brief and candidate evidence, writes the structured report artifact, and returns the expected completion marker. The scenario also verifies that `MEMORY.md` is unchanged, so this is only a review artifact and not a memory promotion.


## Real behavior proof

- Behavior addressed: QA Lab now covers a report-only dreaming shadow trial where a candidate memory is reviewed before promotion.
- Real setup tested: Local OpenClaw checkout on the branch, running the QA suite through the OpenClaw QA CLI with provider mode `mock-openai`.
- Exact steps or command run after the patch:
  ```bash
  OPENCLAW_ENABLE_PRIVATE_QA_CLI=1 node scripts/run-node.mjs qa suite --provider-mode mock-openai --scenario dreaming-shadow-trial-report --concurrency 1
  ```
- Evidence after fix: Terminal output from the local OpenClaw QA suite run:
  ```text
  QA suite report: /Users/firas/Projects/openclaw-dreaming-shadow-trials/.artifacts/qa-e2e/suite-mpabj31x/qa-suite-report.md
  QA suite summary: /Users/firas/Projects/openclaw-dreaming-shadow-trials/.artifacts/qa-e2e/suite-mpabj31x/qa-suite-summary.json

  Scenario: Dreaming shadow trial report
  Status: pass
  Step: writes a report-only shadow trial for a candidate memory
  Details:
  Report: dreaming-shadow-trial-report.md
  Promotion action: report-only
  DREAMING-SHADOW-TRIAL-OK
  Counts: 1 passed, 0 failed
  ```
- Observed result after fix: The QA run produced the expected report-only completion marker and the scenario asserts that the seeded `MEMORY.md` content remains unchanged.
- What was not tested: No production dreaming runner, evaluator, or promotion scoring behavior was added or tested in this PR.

## What was not tested

This does not add a production dreaming runner, evaluator, or promotion scoring path. Those should be separate follow-up changes after the QA behavior is accepted.

## Attribution

If this gets landed manually, please keep the original commit author attribution.