### PR TITLE
fix(export-trajectory): preserve direct sessionKey when encoded request omits it (#83282)

### DIFF
--- a/src/commands/export-trajectory.test.ts
+++ b/src/commands/export-trajectory.test.ts
@@ -67,4 +67,51 @@ describe("exportTrajectoryCommand", () => {
     );
     expect(runtime.exit).toHaveBeenCalledWith(1);
   });
+
+  it("preserves direct sessionKey when encoded request omits it (#83282)", async () => {
+    // Encoded request only supplies `output`, no sessionKey. The previous
+    // decode shape returned `sessionKey: ""`, which overwrote the direct
+    // --session-key from opts and tripped the "missing" path.
+    const runtime = createRuntime();
+    const requestJsonBase64 = Buffer.from(
+      JSON.stringify({ output: "/tmp/trajectory.json" }),
+      "utf8",
+    ).toString("base64url");
+
+    await exportTrajectoryCommand(
+      {
+        sessionKey: "agent:main:telegram:direct:456",
+        requestJsonBase64,
+      },
+      runtime,
+    );
+
+    // The direct sessionKey survived the merge: failure must be
+    // "Session not found" (because the store is empty), NOT
+    // "--session-key is required" (which is the pre-fix bug surface).
+    expect(runtime.error).toHaveBeenCalledWith(
+      "Session not found: agent:main:telegram:direct:456. Run openclaw sessions to see available sessions.",
+    );
+    expect(runtime.error).not.toHaveBeenCalledWith(
+      "--session-key is required. Run openclaw sessions to choose a session.",
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("lets encoded sessionKey override when direct sessionKey is not given (#83282)", async () => {
+    // Reverse case: when only the encoded request supplies sessionKey, the
+    // resolved options must pick it up.
+    const runtime = createRuntime();
+    const requestJsonBase64 = Buffer.from(
+      JSON.stringify({ sessionKey: "agent:main:telegram:direct:789" }),
+      "utf8",
+    ).toString("base64url");
+
+    await exportTrajectoryCommand({ requestJsonBase64 }, runtime);
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      "Session not found: agent:main:telegram:direct:789. Run openclaw sessions to see available sessions.",
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
 });

--- a/src/commands/export-trajectory.ts
+++ b/src/commands/export-trajectory.ts
@@ -56,13 +56,34 @@ function decodeExportTrajectoryRequest(encoded: string): Partial<ExportTrajector
     throw new Error("Encoded trajectory export request must be a JSON object");
   }
   const request = decoded as EncodedExportTrajectoryRequest;
-  return {
-    sessionKey: readOptionalString(request.sessionKey) ?? "",
-    output: readOptionalString(request.output),
-    store: readOptionalString(request.store),
-    agent: readOptionalString(request.agent),
-    workspace: readOptionalString(request.workspace),
-  };
+  // #83282: only include keys present in the encoded request so the spread in
+  // resolveExportTrajectoryOptions doesn't overwrite already-defined direct
+  // CLI options (notably sessionKey) with empty placeholders. The previous
+  // `sessionKey: readOptionalString(...) ?? ""` form silently clobbered an
+  // explicit --session-key with "", producing the "--session-key is required"
+  // failure path.
+  const partial: Partial<ExportTrajectoryCommandOptions> = {};
+  const sessionKey = readOptionalString(request.sessionKey);
+  if (sessionKey !== undefined) {
+    partial.sessionKey = sessionKey;
+  }
+  const output = readOptionalString(request.output);
+  if (output !== undefined) {
+    partial.output = output;
+  }
+  const store = readOptionalString(request.store);
+  if (store !== undefined) {
+    partial.store = store;
+  }
+  const agent = readOptionalString(request.agent);
+  if (agent !== undefined) {
+    partial.agent = agent;
+  }
+  const workspace = readOptionalString(request.workspace);
+  if (workspace !== undefined) {
+    partial.workspace = workspace;
+  }
+  return partial;
 }
 
 function resolveExportTrajectoryOptions(


### PR DESCRIPTION
Fixes #83282.

`decodeExportTrajectoryRequest` returned `sessionKey: readOptionalString(...) ?? ""` for every encoded request, so when the encoded payload omitted `sessionKey` the decoded partial carried `sessionKey: ""`. `resolveExportTrajectoryOptions` then spread that empty string over an explicit `--session-key`, and `exportTrajectoryCommand` failed with `--session-key is required` despite the operator having supplied one.

This patch builds the decoded partial only with keys that the encoded request actually carries (non-empty strings), so the spread in `resolveExportTrajectoryOptions` no longer clobbers direct CLI options with placeholders.

Non-empty encoded values still take precedence over direct opts (the original intent of the merge order is preserved).

## Changes

- `src/commands/export-trajectory.ts`: rewrite `decodeExportTrajectoryRequest` to assign each key only when `readOptionalString` returned a non-undefined value. 6-line comment block referencing #83282.
- `src/commands/export-trajectory.test.ts`: 2 new regression cases.

## Real behavior proof

- **Behavior or issue addressed:** Calling `exportTrajectoryCommand({ sessionKey: "agent:...", requestJsonBase64: <encoded {output: "..."}> })` exits with `--session-key is required` because the encoded request decoded a `sessionKey: ""` placeholder that overrode the explicit direct value.

- **Real environment tested:** Local Node 22.x. Probe at `/tmp/probe_83282.mjs` inlines BOTH the pre-fix and post-fix shapes of `decodeExportTrajectoryRequest` + `resolveExportTrajectoryOptions`, replays a real `base64url` round-trip through `node:buffer`, and asserts merge semantics across four scenarios.

- **Exact steps or command run after this patch:** `node /tmp/probe_83282.mjs`

- **Evidence after fix:**

```
OLD resolved sessionKey: ""
NEW resolved sessionKey: "agent:main:telegram:direct:456"

PASS: OLD code clobbered sessionKey to '' (bug confirmed)
PASS: NEW code preserved direct sessionKey
PASS: NEW code honors encoded sessionKey when direct is absent
PASS: NEW code lets non-empty encoded sessionKey override direct (prior intent preserved)

ALL CASES PASS
```

- **Observed result after fix:** Direct `--session-key` survives the encoded-request merge when the encoded payload doesn't carry its own `sessionKey`. The reverse path (encoded carries sessionKey, direct opts empty) still works. The legitimate override path (both present, encoded non-empty) still picks the encoded value, preserving the prior merge order's intent.

- **What was not tested:** End-to-end run through the actual `openclaw export-trajectory` CLI with a real session store on disk — the probe exercises the exact decoder + resolver functions verbatim, and the new vitest cases cover the same invariant via the public `exportTrajectoryCommand` entry point, but a full CLI shell invocation with a populated session store was not run.

## Audit (per CLAUDE rules)

- **Existing-helper check:** Reuses the existing `readOptionalString` helper; no new predicate or validator. PASS
- **Shared-helper caller check:** Both `decodeExportTrajectoryRequest` and `resolveExportTrajectoryOptions` are file-local (no `export`). Only callsite is `exportTrajectoryCommand` 1 line below. PASS
- **Broader-fix rival scan:** No open PRs touching `export-trajectory` / `decodeExportTrajectoryRequest` / `resolveExportTrajectoryOptions` as of branch SHA. PASS
