### PR TITLE
[Feat] Attribute ACPX startup probe cost in restart traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 - Dependencies: update Pi packages to 0.75.1 and raise the minimum supported Node.js 22 line to 22.19.
 - Docker/Podman: add `OPENCLAW_IMAGE_APT_PACKAGES` as the runtime-neutral image build arg for extra apt packages while keeping `OPENCLAW_DOCKER_APT_PACKAGES` as a legacy fallback. (#62431) Thanks @urtabajev.
+- Gateway/ACPX: attribute startup probe, config, runtime, and resource-count costs in restart traces without changing readiness behavior. (#83300) Thanks @samzong.
 - Mac app: redesign Settings pages with consistent card layouts, cached navigation, cleaner permissions/voice/skills/cron/exec/debug panes, and steadier spacing around the native sidebar.
 - Skills: rename the repo-local Codex closeout review skill and helper to `autoreview` while preserving the Codex-first fallback behavior.
 - Skills: add a meme-maker skill for curated template search, local SVG/PNG rendering, Imgflip hosted rendering, and Know Your Meme provenance links.

--- a/extensions/acpx/src/service.test.ts
+++ b/extensions/acpx/src/service.test.ts
@@ -89,6 +89,7 @@ vi.mock("./process-reaper.js", () => ({
 }));
 
 import { getAcpRuntimeBackend } from "../runtime-api.js";
+import type { OpenClawPluginServiceContext } from "../runtime-api.js";
 import { createAcpxRuntimeService } from "./service.js";
 
 const tempDirs: string[] = [];
@@ -129,7 +130,7 @@ afterEach(async () => {
   }
 });
 
-function createServiceContext(workspaceDir: string) {
+function createServiceContext(workspaceDir: string): OpenClawPluginServiceContext {
   return {
     workspaceDir,
     stateDir: path.join(workspaceDir, ".openclaw-plugin-state"),
@@ -153,6 +154,27 @@ function createMockRuntime(overrides: Record<string, unknown> = {}) {
     isHealthy: vi.fn(() => true),
     doctor: vi.fn(async () => ({ ok: true, message: "ok" })),
     ...overrides,
+  };
+}
+
+function createStartupTraceRecorder() {
+  const measured: string[] = [];
+  const details: Array<{
+    name: string;
+    metrics: ReadonlyArray<readonly [string, number | string]>;
+  }> = [];
+  return {
+    measured,
+    details,
+    startupTrace: {
+      measure: async <T>(name: string, run: () => T | Promise<T>): Promise<T> => {
+        measured.push(name);
+        return await run();
+      },
+      detail: (name: string, metrics: ReadonlyArray<readonly [string, number | string]>) => {
+        details.push({ name, metrics });
+      },
+    },
   };
 }
 
@@ -257,6 +279,46 @@ describe("createAcpxRuntimeService", () => {
 
     expect(resolved).toBe(true);
     expect(ctx.logger.info).toHaveBeenCalledWith("embedded acpx runtime backend ready");
+
+    await service.stop?.(ctx);
+  });
+
+  it("emits ACPX-owned startup trace subspans", async () => {
+    delete process.env.OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE;
+    const workspaceDir = await makeTempDir();
+    const ctx = createServiceContext(workspaceDir);
+    const trace = createStartupTraceRecorder();
+    ctx.startupTrace = trace.startupTrace;
+    const runtime = createMockRuntime();
+    const service = createAcpxRuntimeService({
+      runtimeFactory: () => runtime as never,
+    });
+
+    await service.start(ctx);
+
+    expect(trace.measured).toEqual([
+      "sidecars.plugin-services.acpx.acpx-runtime.config.resolve",
+      "sidecars.plugin-services.acpx.acpx-runtime.config.prepare-codex-auth",
+      "sidecars.plugin-services.acpx.acpx-runtime.filesystem.prepare",
+      "sidecars.plugin-services.acpx.acpx-runtime.gateway-instance-id",
+      "sidecars.plugin-services.acpx.acpx-runtime.process-leases.reap",
+      "sidecars.plugin-services.acpx.acpx-runtime.runtime.create",
+      "sidecars.plugin-services.acpx.acpx-runtime.backend.register",
+      "sidecars.plugin-services.acpx.acpx-runtime.probe.availability",
+    ]);
+    expect(trace.details).toEqual([
+      {
+        name: "sidecars.plugin-services.acpx.acpx-runtime.probe-policy",
+        metrics: [
+          ["startupProbeEnabledCount", 1],
+          ["probeAgent", "default"],
+        ],
+      },
+      {
+        name: "sidecars.plugin-services.acpx.acpx-runtime.probe.result",
+        metrics: [["healthyCount", 1]],
+      },
+    ]);
 
     await service.stop?.(ctx);
   });

--- a/extensions/acpx/src/service.test.ts
+++ b/extensions/acpx/src/service.test.ts
@@ -297,25 +297,25 @@ describe("createAcpxRuntimeService", () => {
     await service.start(ctx);
 
     expect(trace.measured).toEqual([
-      "sidecars.plugin-services.acpx.acpx-runtime.config.resolve",
-      "sidecars.plugin-services.acpx.acpx-runtime.config.prepare-codex-auth",
-      "sidecars.plugin-services.acpx.acpx-runtime.filesystem.prepare",
-      "sidecars.plugin-services.acpx.acpx-runtime.gateway-instance-id",
-      "sidecars.plugin-services.acpx.acpx-runtime.process-leases.reap",
-      "sidecars.plugin-services.acpx.acpx-runtime.runtime.create",
-      "sidecars.plugin-services.acpx.acpx-runtime.backend.register",
-      "sidecars.plugin-services.acpx.acpx-runtime.probe.availability",
+      "config.resolve",
+      "config.prepare-codex-auth",
+      "filesystem.prepare",
+      "gateway-instance-id",
+      "process-leases.reap",
+      "runtime.create",
+      "backend.register",
+      "probe.availability",
     ]);
     expect(trace.details).toEqual([
       {
-        name: "sidecars.plugin-services.acpx.acpx-runtime.probe-policy",
+        name: "probe-policy",
         metrics: [
           ["startupProbeEnabledCount", 1],
           ["probeAgent", "default"],
         ],
       },
       {
-        name: "sidecars.plugin-services.acpx.acpx-runtime.probe.result",
+        name: "probe.result",
         metrics: [["healthyCount", 1]],
       },
     ]);

--- a/extensions/acpx/src/service.ts
+++ b/extensions/acpx/src/service.ts
@@ -41,6 +41,7 @@ type AcpRuntimeTurnResult = Awaited<AcpRuntimeTurn["result"]>;
 const ENABLE_STARTUP_PROBE_ENV = "OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE";
 const SKIP_RUNTIME_PROBE_ENV = "OPENCLAW_SKIP_ACPX_RUNTIME_PROBE";
 const ACPX_BACKEND_ID = "acpx";
+const ACPX_STARTUP_TRACE_PREFIX = "sidecars.plugin-services.acpx.acpx-runtime";
 
 type AcpxRuntimeModule = typeof import("./runtime.js");
 let runtimeModulePromise: Promise<AcpxRuntimeModule> | null = null;
@@ -374,6 +375,24 @@ function resolveAllowedAgentsProbeAgent(ctx: OpenClawPluginServiceContext): stri
   return undefined;
 }
 
+async function measureAcpxStartup<T>(
+  ctx: OpenClawPluginServiceContext,
+  name: string,
+  run: () => T | Promise<T>,
+): Promise<T> {
+  return ctx.startupTrace
+    ? await ctx.startupTrace.measure(`${ACPX_STARTUP_TRACE_PREFIX}.${name}`, run)
+    : await run();
+}
+
+function detailAcpxStartup(
+  ctx: OpenClawPluginServiceContext,
+  name: string,
+  metrics: ReadonlyArray<readonly [string, number | string]>,
+): void {
+  ctx.startupTrace?.detail?.(`${ACPX_STARTUP_TRACE_PREFIX}.${name}`, metrics);
+}
+
 function shouldRunStartupProbe(env: NodeJS.ProcessEnv = process.env): boolean {
   return env[ENABLE_STARTUP_PROBE_ENV] !== "0";
 }
@@ -490,29 +509,39 @@ export function createAcpxRuntimeService(
         return;
       }
 
-      const basePluginConfig = resolveAcpxPluginConfig({
-        rawConfig: params.pluginConfig,
-        workspaceDir: ctx.workspaceDir,
-      });
+      const basePluginConfig = await measureAcpxStartup(ctx, "config.resolve", () =>
+        resolveAcpxPluginConfig({
+          rawConfig: params.pluginConfig,
+          workspaceDir: ctx.workspaceDir,
+        }),
+      );
       const effectiveBasePluginConfig: ResolvedAcpxPluginConfig = {
         ...basePluginConfig,
         probeAgent: basePluginConfig.probeAgent ?? resolveAllowedAgentsProbeAgent(ctx),
       };
-      const pluginConfig = await prepareAcpxCodexAuthConfig({
-        pluginConfig: effectiveBasePluginConfig,
-        stateDir: ctx.stateDir,
-        logger: ctx.logger,
-      });
+      const pluginConfig = await measureAcpxStartup(ctx, "config.prepare-codex-auth", () =>
+        prepareAcpxCodexAuthConfig({
+          pluginConfig: effectiveBasePluginConfig,
+          stateDir: ctx.stateDir,
+          logger: ctx.logger,
+        }),
+      );
       const wrapperRoot = path.join(ctx.stateDir, "acpx");
-      await fs.mkdir(pluginConfig.stateDir, { recursive: true });
-      await fs.mkdir(wrapperRoot, { recursive: true });
-      const gatewayInstanceId = await resolveGatewayInstanceId(ctx.stateDir);
-      const processLeaseStore = createAcpxProcessLeaseStore({ stateDir: wrapperRoot });
-      const startupReap = await reapOpenAcpxProcessLeases({
-        gatewayInstanceId,
-        leaseStore: processLeaseStore,
-        deps: params.processCleanupDeps,
+      await measureAcpxStartup(ctx, "filesystem.prepare", async () => {
+        await fs.mkdir(pluginConfig.stateDir, { recursive: true });
+        await fs.mkdir(wrapperRoot, { recursive: true });
       });
+      const gatewayInstanceId = await measureAcpxStartup(ctx, "gateway-instance-id", () =>
+        resolveGatewayInstanceId(ctx.stateDir),
+      );
+      const processLeaseStore = createAcpxProcessLeaseStore({ stateDir: wrapperRoot });
+      const startupReap = await measureAcpxStartup(ctx, "process-leases.reap", () =>
+        reapOpenAcpxProcessLeases({
+          gatewayInstanceId,
+          leaseStore: processLeaseStore,
+          deps: params.processCleanupDeps,
+        }),
+      );
       if (startupReap.terminatedPids.length > 0) {
         ctx.logger.info(
           `reaped ${startupReap.terminatedPids.length} stale OpenClaw-owned ACPX process${startupReap.terminatedPids.length === 1 ? "" : "es"}`,
@@ -523,29 +552,38 @@ export function createAcpxRuntimeService(
         logger: ctx.logger,
       });
 
-      runtime = params.runtimeFactory
-        ? await params.runtimeFactory({
-            pluginConfig,
-            gatewayInstanceId,
-            processLeaseStore,
-            wrapperRoot,
-            logger: ctx.logger,
-          })
-        : createLazyDefaultRuntime({
-            pluginConfig,
-            gatewayInstanceId,
-            processLeaseStore,
-            wrapperRoot,
-            logger: ctx.logger,
-          });
+      const startedRuntime = await measureAcpxStartup(ctx, "runtime.create", () =>
+        params.runtimeFactory
+          ? params.runtimeFactory({
+              pluginConfig,
+              gatewayInstanceId,
+              processLeaseStore,
+              wrapperRoot,
+              logger: ctx.logger,
+            })
+          : createLazyDefaultRuntime({
+              pluginConfig,
+              gatewayInstanceId,
+              processLeaseStore,
+              wrapperRoot,
+              logger: ctx.logger,
+            }),
+      );
+      runtime = startedRuntime;
 
       const shouldProbeRuntime = shouldProbeRuntimeAtStartup();
-      registerAcpRuntimeBackend({
-        id: ACPX_BACKEND_ID,
-        runtime,
-        ...(shouldProbeRuntime ? { healthy: () => runtime?.isHealthy() ?? false } : {}),
+      detailAcpxStartup(ctx, "probe-policy", [
+        ["startupProbeEnabledCount", shouldProbeRuntime ? 1 : 0],
+        ["probeAgent", pluginConfig.probeAgent ?? "default"],
+      ]);
+      await measureAcpxStartup(ctx, "backend.register", () => {
+        registerAcpRuntimeBackend({
+          id: ACPX_BACKEND_ID,
+          runtime: startedRuntime,
+          ...(shouldProbeRuntime ? { healthy: () => runtime?.isHealthy() ?? false } : {}),
+        });
+        ctx.logger.info(`embedded acpx runtime backend registered (cwd: ${pluginConfig.cwd})`);
       });
-      ctx.logger.info(`embedded acpx runtime backend registered (cwd: ${pluginConfig.cwd})`);
 
       if (!shouldProbeRuntime) {
         return;
@@ -554,23 +592,27 @@ export function createAcpxRuntimeService(
       lifecycleRevision += 1;
       const currentRevision = lifecycleRevision;
       try {
-        if (runtime) {
-          await withStartupProbeTimeout({
-            promise: runtime.probeAvailability(),
+        await measureAcpxStartup(ctx, "probe.availability", () =>
+          withStartupProbeTimeout({
+            promise: startedRuntime.probeAvailability(),
             timeoutSeconds: pluginConfig.timeoutSeconds ?? DEFAULT_ACPX_TIMEOUT_SECONDS,
-          });
-        }
+          }),
+        );
         if (currentRevision !== lifecycleRevision) {
           return;
         }
-        if (runtime?.isHealthy()) {
+        if (startedRuntime.isHealthy()) {
+          detailAcpxStartup(ctx, "probe.result", [["healthyCount", 1]]);
           ctx.logger.info("embedded acpx runtime backend ready");
           return;
         }
-        const doctorReport = await runtime?.doctor?.();
+        const doctorReport = await measureAcpxStartup(ctx, "probe.doctor", () =>
+          startedRuntime.doctor?.(),
+        );
         if (currentRevision !== lifecycleRevision) {
           return;
         }
+        detailAcpxStartup(ctx, "probe.result", [["healthyCount", 0]]);
         ctx.logger.warn(
           `embedded acpx runtime backend probe failed: ${doctorReport ? formatDoctorFailureMessage(doctorReport) : "backend remained unhealthy after probe"}`,
         );
@@ -578,6 +620,7 @@ export function createAcpxRuntimeService(
         if (currentRevision !== lifecycleRevision) {
           return;
         }
+        detailAcpxStartup(ctx, "probe.result", [["healthyCount", 0]]);
         ctx.logger.warn(`embedded acpx runtime setup failed: ${formatErrorMessage(err)}`);
       }
     },

--- a/extensions/acpx/src/service.ts
+++ b/extensions/acpx/src/service.ts
@@ -41,7 +41,6 @@ type AcpRuntimeTurnResult = Awaited<AcpRuntimeTurn["result"]>;
 const ENABLE_STARTUP_PROBE_ENV = "OPENCLAW_ACPX_RUNTIME_STARTUP_PROBE";
 const SKIP_RUNTIME_PROBE_ENV = "OPENCLAW_SKIP_ACPX_RUNTIME_PROBE";
 const ACPX_BACKEND_ID = "acpx";
-const ACPX_STARTUP_TRACE_PREFIX = "sidecars.plugin-services.acpx.acpx-runtime";
 
 type AcpxRuntimeModule = typeof import("./runtime.js");
 let runtimeModulePromise: Promise<AcpxRuntimeModule> | null = null;
@@ -380,9 +379,7 @@ async function measureAcpxStartup<T>(
   name: string,
   run: () => T | Promise<T>,
 ): Promise<T> {
-  return ctx.startupTrace
-    ? await ctx.startupTrace.measure(`${ACPX_STARTUP_TRACE_PREFIX}.${name}`, run)
-    : await run();
+  return ctx.startupTrace ? await ctx.startupTrace.measure(name, run) : await run();
 }
 
 function detailAcpxStartup(
@@ -390,7 +387,7 @@ function detailAcpxStartup(
   name: string,
   metrics: ReadonlyArray<readonly [string, number | string]>,
 ): void {
-  ctx.startupTrace?.detail?.(`${ACPX_STARTUP_TRACE_PREFIX}.${name}`, metrics);
+  ctx.startupTrace?.detail?.(name, metrics);
 }
 
 function shouldRunStartupProbe(env: NodeJS.ProcessEnv = process.env): boolean {

--- a/src/cron/isolated-agent.model-overrides.test.ts
+++ b/src/cron/isolated-agent.model-overrides.test.ts
@@ -1,5 +1,5 @@
 import "./isolated-agent.mocks.js";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { loadModelCatalog } from "../agents/model-catalog.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 import { BASE_THINKING_LEVELS } from "../auto-reply/thinking.shared.js";
@@ -68,11 +68,16 @@ const OPENAI_PI_RUNTIME_CONFIG: Partial<OpenClawConfig> = {
 
 describe("runCronIsolatedAgentTurn model overrides", () => {
   beforeEach(() => {
+    vi.useRealTimers();
     resetPluginRuntimeStateForTest();
     installThinkingTestProviders();
     vi.spyOn(isolatedAgentRunRuntime, "resolveThinkingDefault").mockReturnValue("off");
     vi.mocked(runEmbeddedPiAgent).mockClear();
     vi.mocked(loadModelCatalog).mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("treats blank model overrides as unset", async () => {

--- a/src/gateway/restart-trace.test.ts
+++ b/src/gateway/restart-trace.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { createGatewayRestartTraceHandoffEnv } from "./restart-trace.js";
+import {
+  collectGatewayProcessMemoryUsageMb,
+  createGatewayRestartTraceHandoffEnv,
+} from "./restart-trace.js";
 
 describe("gateway restart trace handoff", () => {
   it("keeps timing for slow but valid drains", () => {
@@ -15,5 +18,14 @@ describe("gateway restart trace handoff", () => {
       OPENCLAW_GATEWAY_RESTART_TRACE_STARTED_AT_MS: String(startedAt),
       OPENCLAW_GATEWAY_RESTART_TRACE_LAST_AT_MS: String(lastAt),
     });
+  });
+
+  it("includes restart resource counts with ready memory metrics", () => {
+    const metrics = Object.fromEntries(collectGatewayProcessMemoryUsageMb());
+
+    expect(metrics.rssMb).toEqual(expect.any(Number));
+    expect(metrics.processSigusr1ListenersCount).toEqual(expect.any(Number));
+    expect(metrics.processSigtermListenersCount).toEqual(expect.any(Number));
+    expect(metrics.processSigintListenersCount).toEqual(expect.any(Number));
   });
 });

--- a/src/gateway/restart-trace.test.ts
+++ b/src/gateway/restart-trace.test.ts
@@ -24,8 +24,20 @@ describe("gateway restart trace handoff", () => {
     const metrics = Object.fromEntries(collectGatewayProcessMemoryUsageMb());
 
     expect(metrics.rssMb).toEqual(expect.any(Number));
+    expect(metrics.activeTimersCount).toEqual(expect.any(Number));
     expect(metrics.processSigusr1ListenersCount).toEqual(expect.any(Number));
     expect(metrics.processSigtermListenersCount).toEqual(expect.any(Number));
     expect(metrics.processSigintListenersCount).toEqual(expect.any(Number));
+  });
+
+  it("counts active timer resources", () => {
+    const timer = setTimeout(() => {}, 10_000);
+    try {
+      const metrics = Object.fromEntries(collectGatewayProcessMemoryUsageMb());
+
+      expect(metrics.activeTimersCount).toBeGreaterThanOrEqual(1);
+    } finally {
+      clearTimeout(timer);
+    }
   });
 });

--- a/src/gateway/restart-trace.ts
+++ b/src/gateway/restart-trace.ts
@@ -203,9 +203,11 @@ function collectGatewayProcessResourceCounts(): ReadonlyArray<readonly [string, 
   const processWithResourceAccess = process as NodeJS.Process & {
     _getActiveHandles?: () => unknown[];
     _getActiveRequests?: () => unknown[];
+    getActiveResourcesInfo?: () => string[];
   };
   const activeHandles = processWithResourceAccess._getActiveHandles?.();
   const activeRequests = processWithResourceAccess._getActiveRequests?.();
+  const activeResources = processWithResourceAccess.getActiveResourcesInfo?.();
   const metrics: Array<readonly [string, number]> = [
     ["processSigintListenersCount", process.listenerCount("SIGINT")],
     ["processSigtermListenersCount", process.listenerCount("SIGTERM")],
@@ -213,15 +215,27 @@ function collectGatewayProcessResourceCounts(): ReadonlyArray<readonly [string, 
   ];
   if (activeHandles) {
     metrics.push(["activeHandlesCount", activeHandles.length]);
-    metrics.push(["activeTimersCount", countActiveTimers(activeHandles)]);
   }
   if (activeRequests) {
     metrics.push(["activeRequestsCount", activeRequests.length]);
   }
+  const activeTimersCount = activeResources
+    ? countActiveTimersFromResourceInfo(activeResources)
+    : activeHandles
+      ? countActiveTimersFromHandles(activeHandles)
+      : undefined;
+  if (activeTimersCount !== undefined) {
+    metrics.push(["activeTimersCount", activeTimersCount]);
+  }
   return metrics.length > 0 ? metrics : null;
 }
 
-function countActiveTimers(activeHandles: readonly unknown[]): number {
+function countActiveTimersFromResourceInfo(activeResources: readonly string[]): number {
+  return activeResources.filter((resource) => resource === "Timeout" || resource === "Timer")
+    .length;
+}
+
+function countActiveTimersFromHandles(activeHandles: readonly unknown[]): number {
   let count = 0;
   for (const handle of activeHandles) {
     if (typeof handle !== "object" || handle === null) {

--- a/src/gateway/restart-trace.ts
+++ b/src/gateway/restart-trace.ts
@@ -185,13 +185,54 @@ export function recordGatewayRestartTraceDetail(name: string, metrics: RestartTr
 export function collectGatewayProcessMemoryUsageMb(): ReadonlyArray<readonly [string, number]> {
   const usage = process.memoryUsage();
   const toMb = (bytes: number) => bytes / 1024 / 1024;
-  return [
+  const metrics: Array<readonly [string, number]> = [
     ["rssMb", toMb(usage.rss)],
     ["heapTotalMb", toMb(usage.heapTotal)],
     ["heapUsedMb", toMb(usage.heapUsed)],
     ["externalMb", toMb(usage.external)],
     ["arrayBuffersMb", toMb(usage.arrayBuffers)],
   ];
+  const resources = collectGatewayProcessResourceCounts();
+  if (resources) {
+    metrics.push(...resources);
+  }
+  return metrics;
+}
+
+function collectGatewayProcessResourceCounts(): ReadonlyArray<readonly [string, number]> | null {
+  const processWithResourceAccess = process as NodeJS.Process & {
+    _getActiveHandles?: () => unknown[];
+    _getActiveRequests?: () => unknown[];
+  };
+  const activeHandles = processWithResourceAccess._getActiveHandles?.();
+  const activeRequests = processWithResourceAccess._getActiveRequests?.();
+  const metrics: Array<readonly [string, number]> = [
+    ["processSigintListenersCount", process.listenerCount("SIGINT")],
+    ["processSigtermListenersCount", process.listenerCount("SIGTERM")],
+    ["processSigusr1ListenersCount", process.listenerCount("SIGUSR1")],
+  ];
+  if (activeHandles) {
+    metrics.push(["activeHandlesCount", activeHandles.length]);
+    metrics.push(["activeTimersCount", countActiveTimers(activeHandles)]);
+  }
+  if (activeRequests) {
+    metrics.push(["activeRequestsCount", activeRequests.length]);
+  }
+  return metrics.length > 0 ? metrics : null;
+}
+
+function countActiveTimers(activeHandles: readonly unknown[]): number {
+  let count = 0;
+  for (const handle of activeHandles) {
+    if (typeof handle !== "object" || handle === null) {
+      continue;
+    }
+    const constructorName = (handle as { constructor?: { name?: string } }).constructor?.name;
+    if (constructorName === "Timeout" || constructorName === "Timer") {
+      count += 1;
+    }
+  }
+  return count;
 }
 
 function normalizeRestartTraceHandoff(value: unknown): GatewayRestartTraceHandoff | null {

--- a/src/plugins/services.test.ts
+++ b/src/plugins/services.test.ts
@@ -232,18 +232,56 @@ describe("startPluginServices", () => {
     ]);
   });
 
-  it("passes startup trace through service context for owned subspans", async () => {
+  it("passes a scoped startup trace through service context for owned subspans", async () => {
     const contexts: OpenClawPluginServiceContext[] = [];
+    const measured: string[] = [];
+    const details: Array<{
+      name: string;
+      metrics: ReadonlyArray<readonly [string, number | string]>;
+    }> = [];
     const startupTrace: NonNullable<Parameters<typeof startPluginServices>[0]["startupTrace"]> = {
-      measure: async (_name, run) => await run(),
+      measure: async (name, run) => {
+        measured.push(name);
+        return await run();
+      },
+      detail: (name, metrics) => {
+        details.push({ name, metrics });
+      },
     };
 
     await startTrackingServices({
-      services: [createTrackingService("service-a", { contexts })],
+      services: [
+        {
+          id: "service-a",
+          start: async (ctx) => {
+            contexts.push(ctx);
+            ctx.startupTrace?.detail?.("probe.result", [["healthyCount", 1]]);
+            await ctx.startupTrace?.measure("config:resolve", async () => {});
+          },
+        },
+      ],
       startupTrace,
     });
 
-    expect(contexts[0]?.startupTrace).toBe(startupTrace);
+    expect(contexts[0]?.startupTrace).not.toBe(startupTrace);
+    expect(measured).toEqual([
+      "sidecars.plugin-services.plugin~003Atest.service-a",
+      "sidecars.plugin-services.plugin~003Atest.service-a.config~003Aresolve",
+    ]);
+    expect(details).toEqual([
+      {
+        name: "sidecars.plugin-services.plugin~003Atest.service-a.probe.result",
+        metrics: [["healthyCount", 1]],
+      },
+      {
+        name: "sidecars.plugin-services.summary",
+        metrics: [
+          ["serviceCount", 1],
+          ["startedCount", 1],
+          ["failedCount", 0],
+        ],
+      },
+    ]);
   });
 
   it("keeps distinct service trace ownership keys non-colliding", async () => {

--- a/src/plugins/services.test.ts
+++ b/src/plugins/services.test.ts
@@ -232,6 +232,20 @@ describe("startPluginServices", () => {
     ]);
   });
 
+  it("passes startup trace through service context for owned subspans", async () => {
+    const contexts: OpenClawPluginServiceContext[] = [];
+    const startupTrace: NonNullable<Parameters<typeof startPluginServices>[0]["startupTrace"]> = {
+      measure: async (_name, run) => await run(),
+    };
+
+    await startTrackingServices({
+      services: [createTrackingService("service-a", { contexts })],
+      startupTrace,
+    });
+
+    expect(contexts[0]?.startupTrace).toBe(startupTrace);
+  });
+
   it("keeps distinct service trace ownership keys non-colliding", async () => {
     const measured: string[] = [];
     const startupTrace: NonNullable<Parameters<typeof startPluginServices>[0]["startupTrace"]> = {

--- a/src/plugins/services.ts
+++ b/src/plugins/services.ts
@@ -22,6 +22,7 @@ function createPluginLogger(): PluginLogger {
 
 function createServiceContext(params: {
   config: OpenClawConfig;
+  startupTrace?: PluginServiceStartupTrace;
   workspaceDir?: string;
   service?: PluginServiceRegistration;
 }): OpenClawPluginServiceContext {
@@ -38,6 +39,7 @@ function createServiceContext(params: {
     workspaceDir: params.workspaceDir,
     stateDir: STATE_DIR,
     logger: createPluginLogger(),
+    ...(params.startupTrace ? { startupTrace: params.startupTrace } : {}),
     ...(grantsInternalDiagnostics
       ? {
           internalDiagnostics: {
@@ -73,6 +75,7 @@ export async function startPluginServices(params: {
     const service = entry.service;
     const serviceContext = createServiceContext({
       config: params.config,
+      startupTrace: params.startupTrace,
       workspaceDir: params.workspaceDir,
       service: entry,
     });

--- a/src/plugins/services.ts
+++ b/src/plugins/services.ts
@@ -24,7 +24,7 @@ function createServiceContext(params: {
   config: OpenClawConfig;
   startupTrace?: PluginServiceStartupTrace;
   workspaceDir?: string;
-  service?: PluginServiceRegistration;
+  service: PluginServiceRegistration;
 }): OpenClawPluginServiceContext {
   const isDiagnosticsExporter =
     params.service?.pluginId === params.service?.service.id &&
@@ -39,13 +39,43 @@ function createServiceContext(params: {
     workspaceDir: params.workspaceDir,
     stateDir: STATE_DIR,
     logger: createPluginLogger(),
-    ...(params.startupTrace ? { startupTrace: params.startupTrace } : {}),
+    ...(params.startupTrace
+      ? {
+          startupTrace: createScopedPluginServiceStartupTrace(
+            params.startupTrace,
+            createPluginServiceTraceName(params.service),
+          ),
+        }
+      : {}),
     ...(grantsInternalDiagnostics
       ? {
           internalDiagnostics: {
             emit: emitTrustedDiagnosticEvent,
             onEvent: onInternalDiagnosticEvent,
           },
+        }
+      : {}),
+  };
+}
+
+function createPluginServiceTraceName(entry: PluginServiceRegistration): string {
+  return `sidecars.plugin-services.${encodeStartupTraceSegment(entry.pluginId)}.${encodeStartupTraceSegment(entry.service.id)}`;
+}
+
+function createScopedPluginServiceStartupTrace(
+  startupTrace: PluginServiceStartupTrace,
+  prefix: string,
+): PluginServiceStartupTrace {
+  const scopeName = (name: string) =>
+    `${prefix}.${name
+      .split(".")
+      .map((segment) => encodeStartupTraceSegment(segment))
+      .join(".")}`;
+  return {
+    measure: (name, run) => startupTrace.measure(scopeName(name), run),
+    ...(startupTrace.detail
+      ? {
+          detail: (name, metrics) => startupTrace.detail?.(scopeName(name), metrics),
         }
       : {}),
   };
@@ -73,6 +103,7 @@ export async function startPluginServices(params: {
   let failedCount = 0;
   for (const entry of params.registry.services) {
     const service = entry.service;
+    const traceName = createPluginServiceTraceName(entry);
     const serviceContext = createServiceContext({
       config: params.config,
       startupTrace: params.startupTrace,
@@ -81,7 +112,6 @@ export async function startPluginServices(params: {
     });
     try {
       const startService = () => service.start(serviceContext);
-      const traceName = `sidecars.plugin-services.${encodeStartupTraceSegment(entry.pluginId)}.${encodeStartupTraceSegment(service.id)}`;
       if (params.startupTrace) {
         await params.startupTrace.measure(traceName, startService);
       } else {

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -2277,6 +2277,10 @@ export type OpenClawPluginServiceContext = {
   workspaceDir?: string;
   stateDir: string;
   logger: PluginLogger;
+  startupTrace?: {
+    detail?: (name: string, metrics: ReadonlyArray<readonly [string, number | string]>) => void;
+    measure: <T>(name: string, run: () => T | Promise<T>) => Promise<T>;
+  };
   internalDiagnostics?: {
     emit: (event: DiagnosticEventInput) => void;
     onEvent: (


### PR DESCRIPTION
## Summary

- Problem: Gateway restart traces showed plugin-service cost, but ACPX startup probe cost was not attributed to ACPX-owned subspans.
- Why it matters: ACPX startup probe is intentionally awaited before ready, so maintainers need precise owner attribution before considering performance changes.
- What changed: Threaded scoped `startupTrace` into plugin service context, added restart resource-count metrics, and instrumented ACPX config, filesystem, runtime creation, backend registration, and probe spans.
- What did NOT change (scope boundary): ACPX startup probe remains default-on and awaited before Gateway ready. No ACPX behavior, auth, session, runtime, or probe policy is changed.
- AI-assisted: Yes.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: #82396
- Related: #82603
- Related: #79596
- [ ] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: Attributes ACPX startup probe work inside Gateway startup/restart traces without changing readiness semantics, while scoping plugin service trace writes under the owning plugin/service prefix.
- Real environment tested: Local macOS/Darwin arm64 checkout, Node v25.9.0, built `dist/entry.js`, Gateway benchmark default case with bundled ACPX enabled.
- Exact steps or command run after this patch: `pnpm build`; `pnpm test:startup:gateway -- --case default --runs 1 --warmup 0 --json --output .artifacts/pr-83300-gateway-startup.json`
- Evidence after fix: Copied live output / terminal output from the local Gateway startup benchmark: `[gateway-startup-bench] default run 1/1: healthz=2877.1ms readyz=6699.7ms httpListen=2741.3ms gatewayReady=6554.1ms cpu=4030.0ms cpuCore=0.602 rss=699.5MB`; copied live startup trace keys included `sidecars.plugin-services.acpx.acpx-runtime.probe.availability=3685.6`, `sidecars.plugin-services.acpx.acpx-runtime.probe.result.healthyCount=1`, and `sidecars.plugin-services.summary.startedCount=4`.
- Observed result after fix: ACPX startup probe cost is visible under ACPX-owned trace names, Gateway reached `/healthz` 200 and `/readyz` 200, and the startup probe remained enabled and awaited.
- What was not tested: Direct ACP session/chat behavior was not changed or smoke-tested; the benchmark was a single local default Gateway startup sample, not a multi-run performance study.
- Before evidence (optional but encouraged): Before this PR, ACPX probe cost was visible only as broad plugin-service time, making the owner and subphase unclear.

## Root Cause (if applicable)

- Root cause: N/A.
- Missing detection / guardrail: Plugin services had a startup trace seam, but ACPX service startup did not emit owner-specific subspans.
- Contributing context (if known): Prior readiness fixes intentionally kept ACPX probe on the ready path, so attribution must be precise before optimizing that path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/acpx/src/service.test.ts`, `src/plugins/services.test.ts`, `src/gateway/restart-trace.test.ts`
- Scenario the test should lock in: plugin service context carries startup trace, ACPX emits owned startup subspans, and restart traces include resource-count metrics.
- Why this is the smallest reliable guardrail: The change is instrumentation and context plumbing, so focused seam tests verify the contract without starting a full Gateway.
- Existing test that already covers this (if any): Existing restart trace tests covered memory metrics but not resource counts or ACPX-owned subspans.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Developer-visible trace output gets more detailed ACPX startup attribution. Runtime behavior is unchanged.

## Diagram (if applicable)

```text
Before:
Gateway ready trace -> sidecars.plugin-services -> broad ACPX time

After:
Gateway ready trace -> sidecars.plugin-services -> acpx-runtime -> probe.availability
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Darwin arm64
- Runtime/container: Local Node v25.9.0 checkout
- Model/provider: N/A
- Integration/channel (if any): ACPX bundled plugin startup instrumentation
- Relevant config (redacted): Default ACPX startup probe policy

### Steps

1. Run the targeted Vitest files for ACPX service, plugin services, and restart trace.
2. Run core and extension TS wrapper checks.
3. Confirm the staged diff has no whitespace errors.

### Expected

- Startup trace context is available to plugin services.
- ACPX emits owned startup subspans.
- Existing ACPX startup semantics remain unchanged.

### Actual

- Targeted tests and TS wrapper checks passed.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ACPX startup trace subspans, plugin service trace context forwarding, restart resource count metrics.
- Edge cases checked: startup probe disabled policy detail still records policy, failed probe path records unhealthy result.
- What you did **not** verify: Full Gateway runtime benchmark on this split branch; direct ACP session behavior.

Verification commands:

- `node scripts/run-vitest.mjs src/plugins/services.test.ts extensions/acpx/src/service.test.ts src/gateway/restart-trace.test.ts --run --maxWorkers=1`: passed, 32 tests
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo`: passed
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`: passed
- `pnpm build`: passed
- `pnpm test:startup:gateway -- --case default --runs 1 --warmup 0 --json --output .artifacts/pr-83300-gateway-startup.json`: passed; Gateway reached `/healthz` 200 and `/readyz` 200 with ACPX trace keys copied above
- `git diff --check`: passed
- `/Users/x/git/openclaw--gateway-restart-repeated-benchmark/.agents/skills/autoreview/scripts/autoreview --mode local --reviewer codex --fallback-reviewer none`: clean, no accepted/actionable findings

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No existing PR review conversations were addressed by this PR.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Trace names become part of maintainer debugging workflows.
  - Mitigation: New names are ACPX-owned and additive; existing broad plugin-service span remains.

