### PR TITLE
[Perf] Overlap gateway startup work before ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 - Dependencies: update Pi packages to 0.75.1 and raise the minimum supported Node.js 22 line to 22.19.
 - Docker/Podman: add `OPENCLAW_IMAGE_APT_PACKAGES` as the runtime-neutral image build arg for extra apt packages while keeping `OPENCLAW_DOCKER_APT_PACKAGES` as a legacy fallback. (#62431) Thanks @urtabajev.
 - Gateway/ACPX: attribute startup probe, config, runtime, and resource-count costs in restart traces without changing readiness behavior. (#83300) Thanks @samzong.
+- Gateway: overlap startup logging and plugin-service startup with channel sidecars to reduce restart ready latency while preserving `/readyz` sidecar gating. (#83301) Thanks @samzong.
 - Mac app: redesign Settings pages with consistent card layouts, cached navigation, cleaner permissions/voice/skills/cron/exec/debug panes, and steadier spacing around the native sidebar.
 - Skills: rename the repo-local Codex closeout review skill and helper to `autoreview` while preserving the Codex-first fallback behavior.
 - Skills: add a meme-maker skill for curated template search, local SVG/PNG rendering, Imgflip hosted rendering, and Know Your Meme provenance links.

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -383,6 +383,48 @@ describe("startGatewayPostAttachRuntime", () => {
     expect(events).toEqual(["sidecars", "returned", "sentinel"]);
   });
 
+  it("starts sidecars while startup logging is still pending", async () => {
+    const events: string[] = [];
+    let finishStartupLog: (() => void) | undefined;
+    const logGatewayStartup = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          events.push("startup-log-start");
+          finishStartupLog = () => {
+            events.push("startup-log-end");
+            resolve();
+          };
+        }),
+    );
+    const startGatewaySidecars = vi.fn(async () => {
+      events.push("sidecars");
+      return { pluginServices: null, postReadySidecars: [] };
+    });
+
+    const runtimePromise = startGatewayPostAttachRuntime(
+      createPostAttachParams(),
+      createPostAttachRuntimeDeps({
+        logGatewayStartup,
+        refreshLatestUpdateRestartSentinel: vi.fn(async () => null),
+        startGatewaySidecars,
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(logGatewayStartup).toHaveBeenCalledTimes(1);
+      expect(startGatewaySidecars).toHaveBeenCalledTimes(1);
+    });
+    expect(events).toEqual(["startup-log-start", "sidecars"]);
+
+    if (!finishStartupLog) {
+      throw new Error("Expected startup log release callback to be initialized");
+    }
+    finishStartupLog();
+    await runtimePromise;
+
+    expect(events).toEqual(["startup-log-start", "sidecars", "startup-log-end"]);
+  });
+
   it("skips heavy restart sentinel refresh when no sentinel file exists", async () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-no-sentinel-"));
     vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
@@ -796,6 +838,50 @@ describe("startGatewayPostAttachRuntime", () => {
         }
         resolvePrewarm();
         await Promise.resolve();
+      },
+    );
+  });
+
+  it("starts and reports plugin services before channel startup completion", async () => {
+    await withEnvAsync(
+      { OPENCLAW_SKIP_CHANNELS: undefined, OPENCLAW_SKIP_PROVIDERS: undefined },
+      async () => {
+        let releaseChannels: (() => void) | undefined;
+        const pluginServices = { stop: vi.fn(async () => {}) } as never;
+        const onPluginServices = vi.fn();
+        const onSidecarsReady = vi.fn();
+        const startChannels = vi.fn(
+          () =>
+            new Promise<void>((resolve) => {
+              releaseChannels = resolve;
+            }),
+        );
+        hoisted.startPluginServices.mockResolvedValueOnce(pluginServices);
+
+        await startGatewayPostAttachRuntime({
+          ...createPostAttachParams({
+            deferSidecars: true,
+            onPluginServices,
+            onSidecarsReady,
+          }),
+          startChannels,
+        });
+
+        await vi.waitFor(() => {
+          expect(startChannels).toHaveBeenCalledTimes(1);
+          expect(hoisted.startPluginServices).toHaveBeenCalledTimes(1);
+          expect(onPluginServices).toHaveBeenCalledWith(pluginServices);
+        });
+        expect(onSidecarsReady).not.toHaveBeenCalled();
+
+        if (!releaseChannels) {
+          throw new Error("Expected channel startup release callback to be initialized");
+        }
+        releaseChannels();
+        await vi.waitFor(() => {
+          expect(onSidecarsReady).toHaveBeenCalledTimes(1);
+        });
+        expect(onPluginServices).toHaveBeenCalledTimes(1);
       },
     );
   });

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -886,6 +886,65 @@ describe("startGatewayPostAttachRuntime", () => {
     );
   });
 
+  it("returns plugin services already reported by deferred sidecars", async () => {
+    await withEnvAsync(
+      { OPENCLAW_SKIP_CHANNELS: undefined, OPENCLAW_SKIP_PROVIDERS: undefined },
+      async () => {
+        let releaseStartupLog: (() => void) | undefined;
+        let releaseChannels: (() => void) | undefined;
+        const pluginServices = { stop: vi.fn(async () => {}) } as never;
+        const onPluginServices = vi.fn();
+        const onSidecarsReady = vi.fn();
+        const logGatewayStartup = vi.fn(
+          () =>
+            new Promise<void>((resolve) => {
+              releaseStartupLog = resolve;
+            }),
+        );
+        const startChannels = vi.fn(
+          () =>
+            new Promise<void>((resolve) => {
+              releaseChannels = resolve;
+            }),
+        );
+        hoisted.startPluginServices.mockResolvedValueOnce(pluginServices);
+
+        const runtimePromise = startGatewayPostAttachRuntime(
+          {
+            ...createPostAttachParams({
+              deferSidecars: true,
+              onPluginServices,
+              onSidecarsReady,
+            }),
+            startChannels,
+          },
+          createPostAttachRuntimeDeps({
+            logGatewayStartup,
+            startGatewaySidecars,
+          }),
+        );
+
+        await vi.waitFor(() => {
+          expect(onPluginServices).toHaveBeenCalledWith(pluginServices);
+        });
+
+        if (!releaseStartupLog) {
+          throw new Error("Expected startup log release callback to be initialized");
+        }
+        releaseStartupLog();
+        await expect(runtimePromise).resolves.toMatchObject({ pluginServices });
+
+        if (!releaseChannels) {
+          throw new Error("Expected channel startup release callback to be initialized");
+        }
+        releaseChannels();
+        await vi.waitFor(() => {
+          expect(onSidecarsReady).toHaveBeenCalledTimes(1);
+        });
+      },
+    );
+  });
+
   it("emits a startup trace span when channel startup is skipped", async () => {
     const trace = createStartupTraceRecorder();
     const logChannels = { info: vi.fn(), error: vi.fn() };

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -413,6 +413,7 @@ export async function startGatewaySidecars(params: {
   deps: CliDeps;
   startChannels: () => Promise<void>;
   prewarmPrimaryModel?: typeof prewarmConfiguredPrimaryModel;
+  onPluginServices?: (pluginServices: PluginServicesHandle | null) => void;
   log: { warn: (msg: string) => void };
   logHooks: {
     info: (msg: string) => void;
@@ -444,6 +445,31 @@ export async function startGatewaySidecars(params: {
       params.logHooks.error(`failed to load hooks: ${String(err)}`);
     }
   });
+
+  const pluginServicesPromise = measureStartup(
+    params.startupTrace,
+    "sidecars.plugin-services",
+    async () => {
+      try {
+        const { startPluginServices } = await import("../plugins/services.js");
+        return await startPluginServices({
+          registry: params.pluginRegistry,
+          config: params.cfg,
+          workspaceDir: params.defaultWorkspaceDir,
+          startupTrace: params.startupTrace,
+        });
+      } catch (err) {
+        params.log.warn(`plugin services failed to start: ${String(err)}`);
+        return null;
+      }
+    },
+  );
+  const pluginServicesReportPromise = params.onPluginServices
+    ? pluginServicesPromise.then((pluginServices) => {
+        params.onPluginServices?.(pluginServices);
+        return pluginServices;
+      })
+    : pluginServicesPromise;
 
   const skipChannels =
     isTruthyEnvValue(process.env.OPENCLAW_SKIP_CHANNELS) ||
@@ -492,20 +518,7 @@ export async function startGatewaySidecars(params: {
     }, 250);
   }
 
-  let pluginServices: PluginServicesHandle | null = null;
-  await measureStartup(params.startupTrace, "sidecars.plugin-services", async () => {
-    try {
-      const { startPluginServices } = await import("../plugins/services.js");
-      pluginServices = await startPluginServices({
-        registry: params.pluginRegistry,
-        config: params.cfg,
-        workspaceDir: params.defaultWorkspaceDir,
-        startupTrace: params.startupTrace,
-      });
-    } catch (err) {
-      params.log.warn(`plugin services failed to start: ${String(err)}`);
-    }
-  });
+  const pluginServices = await pluginServicesReportPromise;
 
   if (params.cfg.acp?.enabled) {
     void (async () => {
@@ -804,7 +817,7 @@ export async function startGatewayPostAttachRuntime(
     await params.onStartupPluginsLoaded?.(loaded);
   }
 
-  await measureStartup(params.startupTrace, "post-attach.log", () =>
+  const startupLogPromise = measureStartup(params.startupTrace, "post-attach.log", () =>
     runtimeDeps.logGatewayStartup({
       cfg: params.cfgAtStart,
       bindHost: params.bindHost,
@@ -849,6 +862,12 @@ export async function startGatewayPostAttachRuntime(
           }),
         );
 
+  let pluginServicesReported = false;
+  const reportPluginServices = (pluginServices: PluginServicesHandle | null) => {
+    pluginServicesReported = true;
+    params.onPluginServices?.(pluginServices);
+  };
+
   const sidecarsPromise = params.minimalTestGateway
     ? Promise.resolve({ pluginServices: null, pluginRegistry, postReadySidecars: [] })
     : new Promise<void>((resolve) => setImmediate(resolve)).then(async () => {
@@ -865,6 +884,7 @@ export async function startGatewayPostAttachRuntime(
             logHooks: params.logHooks,
             logChannels: params.logChannels,
             startupTrace: params.startupTrace,
+            onPluginServices: reportPluginServices,
           }),
         );
         const loaderStatsAfter = getPluginModuleLoaderStats();
@@ -884,7 +904,9 @@ export async function startGatewayPostAttachRuntime(
         for (const method of STARTUP_UNAVAILABLE_GATEWAY_METHODS) {
           params.unavailableGatewayMethods.delete(method);
         }
-        params.onPluginServices?.(result.pluginServices);
+        if (!pluginServicesReported) {
+          reportPluginServices(result.pluginServices);
+        }
         params.onPostReadySidecars?.(result.postReadySidecars);
         params.onSidecarsReady?.();
         params.startupTrace?.detail("sidecars.ready", [
@@ -937,7 +959,8 @@ export async function startGatewayPostAttachRuntime(
     });
 
   if (params.deferSidecars !== true) {
-    const [stopGatewayUpdateCheck, tailscaleCleanup, sidecarsResult] = await Promise.all([
+    const [, stopGatewayUpdateCheck, tailscaleCleanup, sidecarsResult] = await Promise.all([
+      startupLogPromise,
       stopGatewayUpdateCheckPromise,
       tailscaleCleanupPromise,
       sidecarsPromise,
@@ -949,7 +972,8 @@ export async function startGatewayPostAttachRuntime(
     };
   }
 
-  const [stopGatewayUpdateCheck, tailscaleCleanup] = await Promise.all([
+  const [, stopGatewayUpdateCheck, tailscaleCleanup] = await Promise.all([
+    startupLogPromise,
     stopGatewayUpdateCheckPromise,
     tailscaleCleanupPromise,
   ]);

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -863,8 +863,10 @@ export async function startGatewayPostAttachRuntime(
         );
 
   let pluginServicesReported = false;
+  let reportedPluginServices: PluginServicesHandle | null = null;
   const reportPluginServices = (pluginServices: PluginServicesHandle | null) => {
     pluginServicesReported = true;
+    reportedPluginServices = pluginServices;
     params.onPluginServices?.(pluginServices);
   };
 
@@ -978,7 +980,7 @@ export async function startGatewayPostAttachRuntime(
     tailscaleCleanupPromise,
   ]);
 
-  return { stopGatewayUpdateCheck, tailscaleCleanup, pluginServices: null };
+  return { stopGatewayUpdateCheck, tailscaleCleanup, pluginServices: reportedPluginServices };
 }
 
 export const __testing = {


### PR DESCRIPTION
## Summary

- Problem: Gateway startup waited for some independent startup work serially before ready, even when ACPX probe semantics still required plugin services to complete before readiness.
- Why it matters: ACPX probe must stay default-on and awaited, but unrelated startup work can be overlapped to reduce restart ready latency without weakening the ready contract.
- What changed: Starts plugin services earlier, overlaps startup logging with sidecar startup, reports plugin service handles as soon as they are available, and keeps ready blocked until sidecars complete.
- What did NOT change (scope boundary): ACPX probe remains enabled and awaited before ready. Channel startup, sidecar readiness, and startup log completion are still awaited before returning ready.
- AI-assisted: Yes.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: #82396
- Related: #82603
- Related: #79596
- [ ] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: Reduces Gateway startup ready latency by overlapping independent post-attach startup work while preserving sidecar and ACPX readiness semantics.
- Real environment tested: Local macOS/Darwin arm64 checkout, Node v25.9.0, built `dist/entry.js` from this PR branch.
- Exact steps or command run after this patch: `node --import tsx scripts/bench-gateway-startup.ts --case skipChannels --runs 1 --warmup 0 --timeout-ms 30000 --json`
- Evidence after fix: Terminal output from live Gateway startup benchmark from this branch:

  ```text
  [gateway-startup-bench] skipChannels run 1/1: healthz=2944.9ms readyz=6721.9ms httpListen=2846.4ms gatewayReady=6638.0ms cpu=3930.0ms cpuCore=0.585 rss=697.5MB heap=294.1MB
  gatewayReadyLogLine: 2026-05-18T07:14:44.652+08:00 [gateway] ready
  httpListenLogLine: 2026-05-18T07:14:40.860+08:00 [gateway] http server listening (8 plugins: acpx, bonjour, canvas, device-pair, file-transfer, memory-core, phone-control, talk-voice; 2.1s)
  healthz.status=200 readyz.status=200 exitCode=0 signal=null
  outputTail included: sidecars.ready, runtime.post-attach, ready, heartbeat started, SIGTERM shutdown completed cleanly in 11ms
  ```
- Observed result after fix: The real Gateway process reached ready with sidecars complete, `/healthz` and `/readyz` returned 200, and shutdown stopped cleanly after the benchmark probe.
- What was not tested: Cross-OS behavior and multi-run benchmark statistics were not run locally.
- Before evidence (optional but encouraged): Pre-overlap benchmark from the earlier combined local change set recorded `skipChannelsAcpxProbe` `restart.ready` p50 at 812.2ms.

## Root Cause (if applicable)

- Root cause: Some startup work was serialized even though it did not need to block plugin service startup from beginning.
- Missing detection / guardrail: Existing tests checked ready ordering but did not assert that plugin services can start before channel startup completes, that startup logging can overlap sidecars, or that deferred early plugin-service handles survive the post-attach return path.
- Contributing context (if known): ACPX probe must stay on the ready path because earlier fixes made Gateway ready wait for ACPX registration.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server-startup-post-attach.test.ts`
- Scenario the test should lock in: sidecars start while startup logging is pending, plugin services start/report before channel startup completion, deferred early plugin-service handles are preserved, and ready still waits for sidecar completion.
- Why this is the smallest reliable guardrail: The change is scheduling inside `startGatewayPostAttachRuntime` and `startGatewaySidecars`; focused lifecycle tests directly control pending promises and ordering.
- Existing test that already covers this (if any): Existing post-attach tests covered sidecar readiness but not this overlap ordering.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Gateway restart readiness can complete sooner in the ACPX-probe-on path. No defaults, config, permissions, or ACPX behavior change.

## Diagram (if applicable)

```text
Before:
startup log -> sidecars -> plugin services -> channels -> ready

After:
startup log -----------\
plugin services ----\   -> sidecars complete -> ready
channels ------------/
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Darwin arm64
- Runtime/container: Local Node v25.9.0 checkout
- Model/provider: N/A
- Integration/channel (if any): Gateway startup sidecars and ACPX startup probe path
- Relevant config (redacted): `OPENCLAW_SKIP_CHANNELS=1`, Gateway auth none in benchmark config

### Steps

1. Run the targeted Gateway post-attach lifecycle tests.
2. Run core TS wrapper check.
3. Run a live Gateway startup benchmark against built `dist/entry.js`.

### Expected

- Startup logging and plugin service startup can overlap independent work.
- Ready still waits for sidecar completion and ACPX startup probe semantics remain intact.
- Deferred-sidecar startup does not overwrite an early plugin-services handle with `null`.

### Actual

- Targeted tests and core TS wrapper check passed.
- Live Gateway startup benchmark reached ready, `/healthz` 200, `/readyz` 200, and clean shutdown.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: startup log overlap, plugin service early start/report, deferred early plugin-service handle preservation, no unstaged work, core TS wrapper check, live Gateway startup readiness.
- Edge cases checked: plugin service handle is reported before channel startup finishes and the deferred post-attach return preserves it for shutdown paths.
- What you did **not** verify: Cross-OS behavior and multi-run benchmark statistics.

Verification commands:

- `node scripts/run-vitest.mjs src/gateway/server-startup-post-attach.test.ts`: passed, 34 tests
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`: passed
- `git diff --check`: passed
- `node scripts/run-node.mjs gateway run --help`: passed; rebuilt stale `dist/entry.js` before printing CLI help
- `node --import tsx scripts/bench-gateway-startup.ts --case skipChannels --runs 1 --warmup 0 --timeout-ms 30000 --json`: passed; live Gateway reached ready, `/healthz` 200, `/readyz` 200, clean shutdown
- `codex review --base main`: attempted locally before this update but tool-blocked; no clean Codex review verdict was produced.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

Automated review feedback about preserving deferred early plugin-service handles was addressed in code and covered by `src/gateway/server-startup-post-attach.test.ts`.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: More concurrency in startup can hide ordering assumptions.
  - Mitigation: Added lifecycle tests for startup logging overlap, plugin services starting/reporting before channel completion, preserving deferred early plugin-service handles, and ready still waiting for sidecar completion.

