### PR TITLE
fix(export): preserve explicit trajectory session keys

### DIFF
--- a/src/commands/export-trajectory.test.ts
+++ b/src/commands/export-trajectory.test.ts
@@ -57,6 +57,32 @@ describe("exportTrajectoryCommand", () => {
     expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 
+  it("preserves direct options when an encoded request omits them", async () => {
+    const runtime = createRuntime();
+    const requestJsonBase64 = Buffer.from(
+      JSON.stringify({ output: "/tmp/export.json" }),
+      "utf8",
+    ).toString("base64url");
+
+    await exportTrajectoryCommand(
+      {
+        requestJsonBase64,
+        sessionKey: "agent:main:telegram:direct:123",
+        store: "/tmp/direct-store.json",
+      },
+      runtime,
+    );
+
+    expect(mocks.resolveDefaultSessionStorePath).not.toHaveBeenCalled();
+    expect(mocks.loadSessionStore).toHaveBeenCalledWith("/tmp/direct-store.json", {
+      skipCache: true,
+    });
+    expect(runtime.error).toHaveBeenCalledWith(
+      "Session not found: agent:main:telegram:direct:123. Run openclaw sessions to see available sessions.",
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+  });
+
   it("points missing session users at the sessions command", async () => {
     const runtime = createRuntime();
 

--- a/src/commands/export-trajectory.ts
+++ b/src/commands/export-trajectory.ts
@@ -56,13 +56,28 @@ function decodeExportTrajectoryRequest(encoded: string): Partial<ExportTrajector
     throw new Error("Encoded trajectory export request must be a JSON object");
   }
   const request = decoded as EncodedExportTrajectoryRequest;
-  return {
-    sessionKey: readOptionalString(request.sessionKey) ?? "",
-    output: readOptionalString(request.output),
-    store: readOptionalString(request.store),
-    agent: readOptionalString(request.agent),
-    workspace: readOptionalString(request.workspace),
-  };
+  const opts: Partial<ExportTrajectoryCommandOptions> = {};
+  const sessionKey = readOptionalString(request.sessionKey);
+  if (sessionKey !== undefined) {
+    opts.sessionKey = sessionKey;
+  }
+  const output = readOptionalString(request.output);
+  if (output !== undefined) {
+    opts.output = output;
+  }
+  const store = readOptionalString(request.store);
+  if (store !== undefined) {
+    opts.store = store;
+  }
+  const agent = readOptionalString(request.agent);
+  if (agent !== undefined) {
+    opts.agent = agent;
+  }
+  const workspace = readOptionalString(request.workspace);
+  if (workspace !== undefined) {
+    opts.workspace = workspace;
+  }
+  return opts;
 }
 
 function resolveExportTrajectoryOptions(


### PR DESCRIPTION
## Summary
- omit absent/blank decoded trajectory export request fields instead of merging empty placeholders
- preserve direct CLI options such as `sessionKey` and `store` when the encoded request only supplies another option
- add coverage for encoded request merging with explicit direct options

Fixes #83282.

## Real behavior proof

Behavior addressed: encoded trajectory export requests that omit `sessionKey` should not erase an explicit direct `--session-key`/`--store` option.

Real environment tested: WSL Ubuntu OpenClaw source checkout at PR head `978ce2859e5b6df3bfdd4eebfe772f2ddedd29ec` on branch `tmp-pr-83308-proof`.

Exact steps or command run after this patch:

```bash
cd /root/src/openclaw-branches/base
git fetch origin pull/83308/head:tmp-pr-83308-proof --force
git switch tmp-pr-83308-proof
payload=$(node -e 'process.stdout.write(Buffer.from(JSON.stringify({output:"/tmp/trajectory-proof.json"})).toString("base64url"))')
store=$(mktemp /tmp/openclaw-83308-store.XXXXXX.json)
printf '{}\n' > "$store"
node --import tsx src/entry.ts sessions export-trajectory \
  --session-key agent:main:telegram:direct:123 \
  --store "$store" \
  --request-json-base64 "$payload" \
  --json
```

Evidence after fix:

```text
command: node --import tsx src/entry.ts sessions export-trajectory --session-key agent:main:telegram:direct:123 --store /tmp/openclaw-83308-store.SDjoSG.json --request-json-base64 eyJvdXRwdXQiOiIvdG1wL3RyYWplY3RvcnktcHJvb2YuanNvbiJ9 --json
Session not found: agent:main:telegram:direct:123. Run openclaw sessions to see available sessions.
exit=1
Session not found: agent:main:telegram:direct:123. Run openclaw sessions to see available sessions.
```

Observed result after fix: the CLI kept the explicit direct `--session-key` and `--store` while decoding a partial encoded request that only contained `output`. It reached the expected `Session not found: agent:main:telegram:direct:123` path for the empty test store, instead of the pre-fix `--session-key is required` path.

What was not tested: a successful trajectory export against a real stored session transcript; this proof covers the regression path where option merging erased the direct session key before lookup.

## Root Cause
- Root cause: decoded request options included empty placeholders for absent optional fields, then spread them over already-defined CLI options.
- Missing detection / guardrail: no regression coverage for mixing direct options with an encoded request that only supplies a different field.
- Contributing context: the decoder returned a partial options object but populated `sessionKey` even when the encoded JSON omitted it.

## Regression Test Plan
- Coverage level that should have caught this: unit test.
- Target test or file: `src/commands/export-trajectory.test.ts`.
- Scenario the test should lock in: encoded request fields that are absent or blank do not replace direct CLI options.
- Why this is the smallest reliable guardrail: the bug is in option decoding/merge behavior before filesystem export work begins.

## Validation
- `CI=1 node scripts/run-vitest.mjs src/commands/export-trajectory.test.ts`
- `pnpm check:changed`



