### PR TITLE
fix(slack): ignore reply directives inside code spans and fences

### DIFF
--- a/extensions/slack/src/interactive-replies.test.ts
+++ b/extensions/slack/src/interactive-replies.test.ts
@@ -83,6 +83,47 @@ describe("compileSlackInteractiveReplies", () => {
     });
   });
 
+  it("ignores directives inside single-backtick code spans", () => {
+    const result = compileSlackInteractiveReplies({
+      text: "Use the syntax `[[slack_buttons: Yes:yes, No:no]]` to add buttons.",
+    });
+
+    expect(result.text).toBe("Use the syntax `[[slack_buttons: Yes:yes, No:no]]` to add buttons.");
+    expect(result.interactive).toBeUndefined();
+  });
+
+  it("ignores directives inside triple-backtick code fences", () => {
+    const result = compileSlackInteractiveReplies({
+      text: "Example:\n```\n[[slack_buttons: Yes:yes, No:no]]\n```\nDone.",
+    });
+
+    expect(result.text).toBe("Example:\n```\n[[slack_buttons: Yes:yes, No:no]]\n```\nDone.");
+    expect(result.interactive).toBeUndefined();
+  });
+
+  it("renders only the bare directive when one is quoted in a code span and one is live", () => {
+    const result = compileSlackInteractiveReplies({
+      text: "Docs: `[[slack_buttons: A:a, B:b]]` and live:\n[[slack_buttons: Ok:ok, Skip:skip]]",
+    });
+
+    expect(result.text).toBe("Docs: `[[slack_buttons: A:a, B:b]]` and live:");
+    expect(result.interactive).toEqual({
+      blocks: [
+        {
+          type: "text",
+          text: "Docs: `[[slack_buttons: A:a, B:b]]` and live:",
+        },
+        {
+          type: "buttons",
+          buttons: [
+            { label: "Ok", value: "ok" },
+            { label: "Skip", value: "skip" },
+          ],
+        },
+      ],
+    });
+  });
+
   it("leaves complex Options lines as plain text", () => {
     const result = compileSlackInteractiveReplies({
       text: "ACP runtime choices.\nOptions: host=auto|sandbox|gateway|node, security=deny|allowlist|full.",

--- a/extensions/slack/src/interactive-replies.ts
+++ b/extensions/slack/src/interactive-replies.ts
@@ -126,6 +126,61 @@ function hasSlackBlocks(payload: ReplyPayload): boolean {
   return Array.isArray(blocks) && blocks.length > 0;
 }
 
+/**
+ * Returns the [start, end) byte ranges in `text` that fall inside Slack code
+ * spans (single backticks) or code fences (triple backticks). The renderer
+ * uses this to skip directive matches that appear inside quoted code, so
+ * documenting the literal syntax in chat does not produce broken blocks.
+ *
+ * Notes:
+ * - Single-backtick spans must close on the same line (Slack rule).
+ * - Triple-backtick fences are matched non-greedily across lines; if a fence
+ *   never closes, the rest of the message is treated as code.
+ */
+function buildCodeRegionMask(text: string): Array<[number, number]> {
+  const regions: Array<[number, number]> = [];
+  const len = text.length;
+  let i = 0;
+  while (i < len) {
+    if (text[i] === "`") {
+      if (text.startsWith("```", i)) {
+        const end = text.indexOf("```", i + 3);
+        if (end === -1) {
+          regions.push([i, len]);
+          break;
+        }
+        regions.push([i, end + 3]);
+        i = end + 3;
+        continue;
+      }
+      const end = text.indexOf("`", i + 1);
+      if (end === -1) {
+        i += 1;
+        continue;
+      }
+      if (text.slice(i + 1, end).includes("\n")) {
+        // Slack single-backtick spans don't span newlines; ignore this opener.
+        i += 1;
+        continue;
+      }
+      regions.push([i, end + 1]);
+      i = end + 1;
+      continue;
+    }
+    i += 1;
+  }
+  return regions;
+}
+
+function isIndexInsideRegions(index: number, regions: Array<[number, number]>): boolean {
+  for (const [start, end] of regions) {
+    if (index >= start && index < end) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function parseSimpleSlackOptions(raw: string): SlackChoice[] | null {
   const entries = raw
     .split(",")
@@ -185,6 +240,7 @@ export function compileSlackInteractiveReplies(payload: ReplyPayload): ReplyPayl
     return payload;
   }
 
+  const codeRegions = buildCodeRegionMask(text);
   const generatedBlocks: NonNullable<ReplyPayload["interactive"]>["blocks"] = [];
   const visibleTextParts: string[] = [];
   let cursor = 0;
@@ -193,11 +249,16 @@ export function compileSlackInteractiveReplies(payload: ReplyPayload): ReplyPayl
   SLACK_DIRECTIVE_RE.lastIndex = 0;
 
   for (const match of text.matchAll(SLACK_DIRECTIVE_RE)) {
-    matchedDirective = true;
     const matchText = match[0];
     const directiveType = match[1];
     const body = match[2];
     const index = match.index ?? 0;
+    if (isIndexInsideRegions(index, codeRegions)) {
+      // Directive is inside a backtick code span or triple-backtick fence:
+      // treat it as literal text so users can document the syntax in chat.
+      continue;
+    }
+    matchedDirective = true;
     const precedingText = text.slice(cursor, index);
     visibleTextParts.push(precedingText);
     const section = buildTextBlock(precedingText);


### PR DESCRIPTION
## Summary

The Slack outbound interactive-replies compiler matches `[[slack_buttons:...]]` / `[[slack_select:...]]` directives anywhere in `payload.text`, including inside single-backtick code spans and triple-backtick code fences. That means there is no safe way to document the directive syntax in a Slack message — any quoted example gets parsed, generates a real interactive block (or an empty / broken one when the body is a stale demo), and the literal backticks that wrapped it are left behind in the visible text.

This PR teaches the compiler to skip matches whose start index falls inside a backtick code span or triple-backtick code fence. Bare directives still render as buttons / select; quoted ones are preserved verbatim.

## Repro (before)

In a Slack message:

```
Use the syntax `[[slack_buttons: Yes:yes, No:no]]` to add buttons.
```

is delivered to Slack with the directive consumed, an interactive block generated for `Yes:yes, No:no`, and two stray ` `` ` characters left in the visible text. Same thing inside a triple-backtick fence: the literal example is silently turned into a live button block plus an awkward leftover fence.

## After

The same input renders the literal text intact and produces no interactive block. A bare directive in the same message still renders normally.

## Implementation

- `buildCodeRegionMask(text)` walks the text once and records `[start, end)` ranges for:
  - single-backtick spans (must close on the same line, matching Slack's mrkdwn behavior — newlines abort the span and the opener is treated as plain text)
  - triple-backtick fences (non-greedy, multi-line; unclosed fence treats the rest of the message as code)
- `compileSlackInteractiveReplies` consults the mask and `continue`s past any match whose index sits inside one of those ranges, so the directive falls through as ordinary text.

No behavioral change for messages that don't quote the syntax.

## Tests

Three new vitest cases in `extensions/slack/src/interactive-replies.test.ts`:

1. directive inside a single-backtick code span → preserved as text, no blocks
2. directive inside a triple-backtick fence → preserved as text, no blocks
3. mixed message with one quoted and one live directive → only the bare one renders; the quoted one stays literal

```
$ pnpm test:extension slack
…
✓ extensions/slack/src/interactive-replies.test.ts (7 tests)
…
Test Files  95 passed (95)
     Tests  1099 passed (1099)
```

Lint and types:

```
$ node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/slack/src/interactive-replies.ts extensions/slack/src/interactive-replies.test.ts
Found 0 warnings and 0 errors.

$ pnpm tsgo:extensions
(exit 0)
```

## Real behavior proof

I'm running OpenClaw on a Mac mini hosting a 7-agent multi-agent system (Atlas Pet Company). I hit this bug in production: my own agent's documented example of the directive syntax was being parsed and rendering as broken empty button blocks in `#openclaw-dev` (see screenshot the user sent at 2026-05-17 14:58 MDT).

I patched the equivalent code in the bundled `dist/interactive-replies-*.js` of the running gateway (`/opt/homebrew/lib/node_modules/openclaw/dist/interactive-replies-BoZyT6bY.js`), backed up the original, restarted the gateway (`openclaw gateway restart` → pid 99971, probe ok), and verified:

- a Slack message containing a bare directive renders the buttons as before;
- the same message with the directive wrapped in single backticks renders the literal text and no buttons;
- the same with a triple-backtick fence does the same;
- a mixed message renders only the live directive's buttons and keeps the code-quoted one as literal text.

This PR brings the source-of-truth change so the fix survives the next `npm i -g openclaw`.

## Notes

- AI-assisted PR (Claude via OpenClaw). The author understands what the code does.
- No CHANGELOG edit, per CONTRIBUTING.md.
- Scope is intentionally small and limited to `extensions/slack/src/interactive-replies.ts` + its colocated test.
