### PR TITLE
fix(update): require integer timeout values

### DIFF
--- a/src/cli/update-cli/shared.command-runner.test.ts
+++ b/src/cli/update-cli/shared.command-runner.test.ts
@@ -59,10 +59,11 @@ describe("createGlobalCommandRunner", () => {
       expect(parseTimeoutMsOrExit("10abc")).toBeNull();
       expect(parseTimeoutMsOrExit("0")).toBeNull();
       expect(parseTimeoutMsOrExit("-1")).toBeNull();
+      expect(parseTimeoutMsOrExit("   ")).toBeNull();
 
-      expect(error).toHaveBeenCalledTimes(4);
+      expect(error).toHaveBeenCalledTimes(5);
       expect(error).toHaveBeenCalledWith("--timeout must be a positive integer (seconds)");
-      expect(exit).toHaveBeenCalledTimes(4);
+      expect(exit).toHaveBeenCalledTimes(5);
       expect(exit).toHaveBeenCalledWith(1);
     } finally {
       error.mockRestore();

--- a/src/cli/update-cli/shared.command-runner.test.ts
+++ b/src/cli/update-cli/shared.command-runner.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createGlobalCommandRunner } from "./shared.js";
+import { defaultRuntime } from "../../runtime.js";
+import { createGlobalCommandRunner, parseTimeoutMsOrExit } from "./shared.js";
 
 const runCommandWithTimeout = vi.hoisted(() => vi.fn());
 
@@ -47,5 +48,41 @@ describe("createGlobalCommandRunner", () => {
       stderr: "err",
       code: 17,
     });
+  });
+
+  it("requires timeout values to be complete positive integer seconds", () => {
+    const error = vi.spyOn(defaultRuntime, "error").mockImplementation(() => undefined);
+    const exit = vi.spyOn(defaultRuntime, "exit").mockImplementation(() => undefined as never);
+
+    try {
+      expect(parseTimeoutMsOrExit("1.5")).toBeNull();
+      expect(parseTimeoutMsOrExit("10abc")).toBeNull();
+      expect(parseTimeoutMsOrExit("0")).toBeNull();
+      expect(parseTimeoutMsOrExit("-1")).toBeNull();
+
+      expect(error).toHaveBeenCalledTimes(4);
+      expect(error).toHaveBeenCalledWith("--timeout must be a positive integer (seconds)");
+      expect(exit).toHaveBeenCalledTimes(4);
+      expect(exit).toHaveBeenCalledWith(1);
+    } finally {
+      error.mockRestore();
+      exit.mockRestore();
+    }
+  });
+
+  it("parses complete positive integer timeout values as milliseconds", () => {
+    const error = vi.spyOn(defaultRuntime, "error").mockImplementation(() => undefined);
+    const exit = vi.spyOn(defaultRuntime, "exit").mockImplementation(() => undefined as never);
+
+    try {
+      expect(parseTimeoutMsOrExit(" 10 ")).toBe(10_000);
+      expect(parseTimeoutMsOrExit("001")).toBe(1_000);
+      expect(parseTimeoutMsOrExit()).toBeUndefined();
+      expect(error).not.toHaveBeenCalled();
+      expect(exit).not.toHaveBeenCalled();
+    } finally {
+      error.mockRestore();
+      exit.mockRestore();
+    }
   });
 });

--- a/src/cli/update-cli/shared.ts
+++ b/src/cli/update-cli/shared.ts
@@ -54,10 +54,10 @@ export type UpdateWizardOptions = {
 const INVALID_TIMEOUT_ERROR = "--timeout must be a positive integer (seconds)";
 
 export function parseTimeoutMsOrExit(timeout?: string): number | undefined | null {
-  const trimmed = timeout?.trim();
-  if (!trimmed) {
+  if (timeout === undefined) {
     return undefined;
   }
+  const trimmed = timeout.trim();
   const seconds = Number(trimmed);
   if (!/^\d+$/u.test(trimmed) || !Number.isSafeInteger(seconds) || seconds <= 0) {
     defaultRuntime.error(INVALID_TIMEOUT_ERROR);

--- a/src/cli/update-cli/shared.ts
+++ b/src/cli/update-cli/shared.ts
@@ -54,13 +54,17 @@ export type UpdateWizardOptions = {
 const INVALID_TIMEOUT_ERROR = "--timeout must be a positive integer (seconds)";
 
 export function parseTimeoutMsOrExit(timeout?: string): number | undefined | null {
-  const timeoutMs = timeout ? Number.parseInt(timeout, 10) * 1000 : undefined;
-  if (timeoutMs !== undefined && (Number.isNaN(timeoutMs) || timeoutMs <= 0)) {
+  const trimmed = timeout?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const seconds = Number(trimmed);
+  if (!/^\d+$/u.test(trimmed) || !Number.isSafeInteger(seconds) || seconds <= 0) {
     defaultRuntime.error(INVALID_TIMEOUT_ERROR);
     defaultRuntime.exit(1);
     return null;
   }
-  return timeoutMs;
+  return seconds * 1000;
 }
 
 const OPENCLAW_REPO_URL = "https://github.com/openclaw/openclaw.git";


### PR DESCRIPTION
## Summary
- require `--timeout` values to be complete positive integer second values
- reject partial numeric strings such as `1.5` and `10abc`
- add parser coverage for invalid and valid timeout inputs

Fixes #83281.

## Real behavior proof
- **Behavior or issue addressed:** update `--timeout` now rejects values that are not complete positive integer seconds instead of accepting numeric prefixes.
- **Real environment tested:** WSL Ubuntu-24.04 source worktrees for `origin/main` and `fix-update-timeout-integer-83281`; proof generated with the established deterministic before/after image artifact pattern and published to `proof-artifacts/pr-83310-fresh`.
- **Exact steps or command run after this patch:** Ran the same source-level CLI parser command on `origin/main` and PR head: `node --import tsx /tmp/pr83310-timeout-proof.mjs`, importing the real `parseTimeoutMsOrExit()` implementation and exercising `1.5`, `10abc`, `0`, `-1`, ` 10 `, `001`, and omitted timeout.
- **Evidence after fix:** ![PR 83310 before/after proof](https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-83310-fresh/pr-83310/pr-83310-update-timeout-before-after-proof.png)

  Fresh deterministic proof artifacts:
  - Summary: https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-83310-fresh/pr-83310/summary.txt
  - Before log: https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-83310-fresh/pr-83310/before-origin-main-with-regression-proof.log
  - After log: https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-83310-fresh/pr-83310/after-pr-83310.log

  ```console
  before_origin_main_status=1
  after_pr_83310_status=0
  ```
- **Observed result after fix:** `origin/main` accepts partial numeric prefixes such as `1.5` => `1000` ms and `10abc` => `10000` ms, so the regression proof fails before the patch. PR head rejects `1.5`, `10abc`, `0`, and `-1` with the invalid-timeout path while still accepting complete positive integer strings like ` 10 ` and `001`.
- **What was not tested:** A full live package update was not run; this proof isolates the real CLI timeout parser before any network/package-manager update work begins.
- **Before evidence:** The linked before log shows `origin/main` returning `1000` for `1.5` and `10000` for `10abc`, followed by `ASSERTION FAILED: --timeout must reject partial numeric strings and non-positive values.`.

## Root Cause
- Root cause: the parser used `Number.parseInt`, which accepts numeric prefixes instead of requiring the full string to match the option contract.
- Missing detection / guardrail: no focused parser coverage for fractional or suffixed timeout values.
- Contributing context: the existing check only rejected `NaN` and non-positive parsed values.

## Regression Test Plan
- Coverage level that should have caught this: unit test.
- Target test or file: `src/cli/update-cli/shared.command-runner.test.ts`.
- Scenario the test should lock in: timeout parsing rejects partial numeric strings and accepts complete positive integer strings.
- Why this is the smallest reliable guardrail: the behavior is isolated to `parseTimeoutMsOrExit` before any update command runs.

## Validation
- `CI=1 node scripts/run-vitest.mjs src/cli/update-cli/shared.command-runner.test.ts`
- `pnpm check:changed`
