### PR TITLE
fix(legacy-web-search-migrate): preserve unrelated record-valued keys under tools.web.search (#83287)

### DIFF
--- a/src/commands/doctor/shared/legacy-web-search-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-web-search-migrate.test.ts
@@ -62,6 +62,72 @@ describe("legacy web search config", () => {
     ]);
   });
 
+  it("preserves unrelated record-valued tools.web.search keys (#83287)", () => {
+    // Previous shape dropped any record-valued key not in a short modern
+    // allowlist, silently erasing operator-added custom provider configs that
+    // happened to live under tools.web.search.
+    const res = migrateLegacyWebSearchConfig<OpenClawConfig>({
+      tools: {
+        web: {
+          search: {
+            provider: "grok",
+            apiKey: "brave-key",
+            grok: {
+              apiKey: "xai-key",
+              model: "grok-4-search",
+            },
+            "custom-provider": {
+              endpoint: "https://example.com/search",
+              apiKey: "custom-key",
+            },
+          },
+        },
+      } as unknown as OpenClawConfig["tools"],
+    } as OpenClawConfig);
+
+    expect(res.config.tools?.web?.search).toEqual({
+      provider: "grok",
+      "custom-provider": {
+        endpoint: "https://example.com/search",
+        apiKey: "custom-key",
+      },
+    });
+    expect(res.config.plugins?.entries?.xai).toEqual({
+      enabled: true,
+      config: {
+        webSearch: {
+          apiKey: "xai-key",
+          model: "grok-4-search",
+        },
+      },
+    });
+    expect(res.config.plugins?.entries?.["custom-provider"]).toBeUndefined();
+  });
+
+  it("preserves openaiCodex scoped web search config (#83287 regression)", () => {
+    // Confirms the previously-allowlisted modern key still survives now that
+    // the allowlist was widened to "preserve everything that wasn't a legacy
+    // provider".
+    const res = migrateLegacyWebSearchConfig<OpenClawConfig>({
+      tools: {
+        web: {
+          search: {
+            apiKey: "brave-key",
+            openaiCodex: {
+              provider: "openai",
+              limit: 5,
+            },
+          },
+        },
+      } as unknown as OpenClawConfig["tools"],
+    } as OpenClawConfig);
+
+    expect(res.config.tools?.web?.search?.openaiCodex).toEqual({
+      provider: "openai",
+      limit: 5,
+    });
+  });
+
   it("lists legacy paths for metadata-owned provider config", () => {
     expect(
       listLegacyWebSearchConfigPaths({

--- a/src/commands/doctor/shared/legacy-web-search-migrate.ts
+++ b/src/commands/doctor/shared/legacy-web-search-migrate.ts
@@ -7,8 +7,6 @@ import {
   type JsonRecord,
 } from "./legacy-config-record-shared.js";
 
-const MODERN_SCOPED_WEB_SEARCH_KEYS = new Set(["openaiCodex"]);
-
 const BUNDLED_LEGACY_WEB_SEARCH_OWNERS = new Map<string, string>([
   ["brave", "brave"],
   ["duckduckgo", "duckduckgo"],
@@ -200,16 +198,21 @@ function normalizeLegacyWebSearchConfigRecord<T extends JsonRecord>(
   const nextSearch: JsonRecord = {};
   const changes: string[] = [];
 
+  const legacyProviderIds = getLegacyWebSearchProviderIdSet(owners);
   for (const [key, value] of Object.entries(search)) {
     if (key === "apiKey") {
       continue;
     }
-    if (getLegacyWebSearchProviderIdSet(owners).has(key) && isRecord(value)) {
+    if (legacyProviderIds.has(key) && isRecord(value)) {
       continue;
     }
-    if (MODERN_SCOPED_WEB_SEARCH_KEYS.has(key) || !isRecord(value)) {
-      nextSearch[key] = value;
-    }
+    // #83287: previously this branch only preserved a short modern-key
+    // allowlist + non-record values; any other record-valued key — including
+    // unrelated custom provider configs the operator may have added under
+    // tools.web.search — was silently dropped. Preserve any key that survived
+    // the legacy-provider drop above; only the apiKey + explicit legacy
+    // provider records are migrated.
+    nextSearch[key] = value;
   }
   web.search = nextSearch;
 


### PR DESCRIPTION
Fixes #83287.

`normalizeLegacyWebSearchConfigRecord` only kept a key from `tools.web.search` when it was in a short `MODERN_SCOPED_WEB_SEARCH_KEYS` allowlist (sole member: `openaiCodex`) **or** was a non-record value. Any other record-valued key — including operator-added custom provider configs that legitimately live under `tools.web.search` — was silently dropped during legacy web search migration.

This patch widens the keep rule to "anything that survived the `apiKey` + legacy-provider drops above". The narrow modern-key allowlist becomes redundant (its sole member is now preserved by the broader rule) and the unused constant is removed.

## Changes

- `src/commands/doctor/shared/legacy-web-search-migrate.ts`: drop the `MODERN_SCOPED_WEB_SEARCH_KEYS || !isRecord(value)` filter so any non-legacy, non-`apiKey` key is preserved; remove now-unused constant; add 6-line comment referencing #83287.
- `src/commands/doctor/shared/legacy-web-search-migrate.test.ts`: 2 new regression cases (`custom-provider` unrelated record preserved + no phantom plugin entry; `openaiCodex` still preserved as before).

## Real behavior proof

- **Behavior or issue addressed:** Calling `migrateLegacyWebSearchConfig` on a config whose `tools.web.search` contained a known legacy provider plus an unrelated record-valued key (e.g. `"custom-provider": { endpoint: "...", apiKey: "..." }`) silently lost the unrelated key.

- **Real environment tested:** Local Node 22.x. Probe at `/tmp/probe_83287.mjs` replays BOTH the pre-fix and post-fix shapes of the keep-loop with the actual production legacy-provider id set (12 owners minus `tavily` per `NON_MIGRATED_LEGACY_WEB_SEARCH_PROVIDER_IDS`).

- **Exact steps or command run after this patch:** `node /tmp/probe_83287.mjs`

- **Evidence after fix:**

```
OLD result: {"provider":"grok","openaiCodex":{"provider":"openai","limit":5}}
NEW result: {"provider":"grok","custom-provider":{"endpoint":"https://example.com/search","apiKey":"custom-key"},"openaiCodex":{"provider":"openai","limit":5}}

PASS: OLD dropped custom-provider (bug confirmed)
PASS: NEW preserved custom-provider record
PASS: NEW preserved openaiCodex (no regression)
PASS: NEW still drops legacy provider grok
PASS: NEW preserves string-valued provider field
PASS: NEW still drops global apiKey

ALL CASES PASS
```

- **Observed result after fix:** Unrelated record-valued keys under `tools.web.search` survive the migration. All other invariants are preserved: known legacy providers (`grok`, `kimi`, etc.) are still drained into their plugin entries; the global `apiKey` is still drained; non-record values (`provider: "grok"`) are still kept; the previously-allowlisted modern key (`openaiCodex`) is still preserved (under the broader rule). No phantom `plugins.entries.custom-provider` is created.

- **What was not tested:** End-to-end `openclaw doctor --fix` invocation with a real on-disk config containing a custom unrelated key. The probe + new vitest cases cover the keep-loop invariant precisely; a full doctor-cli shell invocation against a synthetic config was not run.

## Audit (per CLAUDE rules)

- **Existing-helper check:** Reuses `getLegacyWebSearchProviderIdSet`, `isRecord`. No new predicate. PASS
- **Shared-helper caller check:** `normalizeLegacyWebSearchConfigRecord` is file-local (no `export`). Sole caller is `migrateLegacyWebSearchConfig` 12 lines above. PASS
- **Broader-fix rival scan:** No open PRs touching `legacy-web-search-migrate.ts` or `normalizeLegacyWebSearchConfigRecord` as of branch SHA. PASS
