### PR TITLE
Keep legacy Codex OAuth sidecar profiles usable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 - Mac app: avoid a SwiftUI metadata crash when rendering the Cron Jobs settings pane.
 - Agents/subagents: preserve run-mode keep subagent registry entries past the session sweep TTL, so kept subagent runs remain visible after cleanup completes. Fixes #83132. (#83168) Thanks @yetval.
 - Agents/OpenAI streams: yield via `setTimeout(0)` instead of `setImmediate` between bursty Responses chunks so abort timers can fire during the yield, keeping cancel-on-timeout responsive on hot streams. Refs #82462.
+- Agents/Codex: keep legacy `oauthRef`-backed OAuth profiles usable while `openclaw doctor --fix` migrates them back to inline credentials, without creating new sidecar credentials. (#83312) Thanks @joshavant.
 - CLI/config: send SecretRef diagnostics to stderr so JSON command stdout remains parseable.
 - CLI/plugins: ship the bundled memory CLI as a package entry so package-installed `openclaw memory` commands register correctly.
 - CLI/update: defer doctor-time plugin package installs during package swaps and seed post-core repair from the updated install registry, preventing duplicate reinstall failures.

--- a/src/agents/auth-profiles.store.save.test.ts
+++ b/src/agents/auth-profiles.store.save.test.ts
@@ -2,6 +2,8 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import { resolveOAuthDir } from "../config/paths.js";
+import { legacyOAuthSidecarTestUtils } from "./auth-profiles/legacy-oauth-sidecar.js";
 import { resolveAuthStatePath, resolveAuthStorePath } from "./auth-profiles/paths.js";
 import {
   clearRuntimeAuthProfileStoreSnapshots,
@@ -164,6 +166,174 @@ describe("saveAuthProfileStore", () => {
       expect(parsed.profiles["openai-codex:default"]?.access).toBe("new-access-token");
       expect(parsed.profiles["openai-codex:default"]?.refresh).toBe("new-refresh-token");
     } finally {
+      clearRuntimeAuthProfileStoreSnapshots();
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps rehydrated legacy oauthRef sidecar tokens runtime-only during ordinary saves", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-save-oauth-ref-"));
+    const authPath = resolveAuthStorePath(agentDir);
+    const previousOAuthDir = process.env.OPENCLAW_OAUTH_DIR;
+    const previousSecretKey = process.env.OPENCLAW_AUTH_PROFILE_SECRET_KEY;
+    process.env.OPENCLAW_OAUTH_DIR = path.join(agentDir, "credentials");
+    process.env.OPENCLAW_AUTH_PROFILE_SECRET_KEY = "legacy-seed";
+    const oauthRef = {
+      source: "openclaw-credentials" as const,
+      provider: "openai-codex" as const,
+      id: "0123456789abcdef0123456789abcdef",
+    };
+    try {
+      await fs.mkdir(agentDir, { recursive: true });
+      await fs.writeFile(
+        authPath,
+        `${JSON.stringify(
+          {
+            version: 1,
+            profiles: {
+              "openai-codex:default": {
+                type: "oauth",
+                provider: "openai-codex",
+                expires: Date.now() + 60_000,
+                oauthRef,
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+      );
+      const sidecarPath = path.join(resolveOAuthDir(), "auth-profiles", `${oauthRef.id}.json`);
+      await fs.mkdir(path.dirname(sidecarPath), { recursive: true });
+      await fs.writeFile(
+        sidecarPath,
+        `${JSON.stringify(
+          {
+            version: 1,
+            profileId: "openai-codex:default",
+            provider: "openai-codex",
+            encrypted: legacyOAuthSidecarTestUtils.encryptLegacyOAuthMaterial({
+              ref: oauthRef,
+              profileId: "openai-codex:default",
+              provider: "openai-codex",
+              seed: "legacy-seed",
+              material: {
+                access: "legacy-access-token",
+                refresh: "legacy-refresh-token",
+              },
+            }),
+          },
+          null,
+          2,
+        )}\n`,
+      );
+
+      const runtimeStore = ensureAuthProfileStore(agentDir);
+      expectProfileFields(runtimeStore.profiles["openai-codex:default"], {
+        access: "legacy-access-token",
+        refresh: "legacy-refresh-token",
+      });
+
+      delete process.env.OPENCLAW_AUTH_PROFILE_SECRET_KEY;
+      const clonedRuntimeStore = JSON.parse(JSON.stringify(runtimeStore)) as AuthProfileStore;
+      saveAuthProfileStore(clonedRuntimeStore, agentDir);
+
+      const parsed = JSON.parse(await fs.readFile(authPath, "utf8")) as {
+        profiles: Record<string, Record<string, unknown>>;
+      };
+      expect(parsed.profiles["openai-codex:default"]?.oauthRef).toEqual(oauthRef);
+      expect(parsed.profiles["openai-codex:default"]).not.toHaveProperty("access");
+      expect(parsed.profiles["openai-codex:default"]).not.toHaveProperty("refresh");
+    } finally {
+      if (previousOAuthDir === undefined) {
+        delete process.env.OPENCLAW_OAUTH_DIR;
+      } else {
+        process.env.OPENCLAW_OAUTH_DIR = previousOAuthDir;
+      }
+      if (previousSecretKey === undefined) {
+        delete process.env.OPENCLAW_AUTH_PROFILE_SECRET_KEY;
+      } else {
+        process.env.OPENCLAW_AUTH_PROFILE_SECRET_KEY = previousSecretKey;
+      }
+      clearRuntimeAuthProfileStoreSnapshots();
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("writes refreshed legacy sidecar tokens inline when they replace runtime sidecar material", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-auth-save-oauth-ref-"));
+    const authPath = resolveAuthStorePath(agentDir);
+    const previousOAuthDir = process.env.OPENCLAW_OAUTH_DIR;
+    process.env.OPENCLAW_OAUTH_DIR = path.join(agentDir, "credentials");
+    const profileId = "openai-codex:default";
+    const oauthRef = {
+      source: "openclaw-credentials",
+      provider: "openai-codex",
+      id: "0123456789abcdef0123456789abcdef",
+    };
+    try {
+      await fs.mkdir(agentDir, { recursive: true });
+      await fs.writeFile(
+        authPath,
+        `${JSON.stringify(
+          {
+            version: 1,
+            profiles: {
+              [profileId]: {
+                type: "oauth",
+                provider: "openai-codex",
+                expires: Date.now() + 60_000,
+                oauthRef,
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+      );
+      const sidecarPath = path.join(resolveOAuthDir(), "auth-profiles", `${oauthRef.id}.json`);
+      await fs.mkdir(path.dirname(sidecarPath), { recursive: true });
+      await fs.writeFile(
+        sidecarPath,
+        `${JSON.stringify(
+          {
+            version: 1,
+            profileId,
+            provider: "openai-codex",
+            access: "legacy-access-token",
+            refresh: "legacy-refresh-token",
+          },
+          null,
+          2,
+        )}\n`,
+      );
+
+      const runtimeStore = ensureAuthProfileStore(agentDir);
+      const refreshedStore: AuthProfileStore = {
+        ...runtimeStore,
+        profiles: {
+          ...runtimeStore.profiles,
+          [profileId]: {
+            ...runtimeStore.profiles[profileId],
+            access: "refreshed-access-token",
+            refresh: "refreshed-refresh-token",
+          } as AuthProfileStore["profiles"][string],
+        },
+      };
+      saveAuthProfileStore(refreshedStore, agentDir);
+
+      const parsed = JSON.parse(await fs.readFile(authPath, "utf8")) as {
+        profiles: Record<string, Record<string, unknown>>;
+      };
+      expect(parsed.profiles[profileId]).not.toHaveProperty("oauthRef");
+      expect(parsed.profiles[profileId]?.access).toBe("refreshed-access-token");
+      expect(parsed.profiles[profileId]?.refresh).toBe("refreshed-refresh-token");
+    } finally {
+      if (previousOAuthDir === undefined) {
+        delete process.env.OPENCLAW_OAUTH_DIR;
+      } else {
+        process.env.OPENCLAW_OAUTH_DIR = previousOAuthDir;
+      }
       clearRuntimeAuthProfileStoreSnapshots();
       await fs.rm(agentDir, { recursive: true, force: true });
     }

--- a/src/agents/auth-profiles/legacy-oauth-sidecar.ts
+++ b/src/agents/auth-profiles/legacy-oauth-sidecar.ts
@@ -1,0 +1,356 @@
+import * as childProcess from "node:child_process";
+import { createCipheriv, createDecipheriv, createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { resolveOAuthDir, resolveStateDir } from "../../config/paths.js";
+import { loadJsonFile } from "../../infra/json-file.js";
+
+const LEGACY_OAUTH_REF_SOURCE = "openclaw-credentials";
+const LEGACY_OAUTH_REF_PROVIDER = "openai-codex";
+const LEGACY_OAUTH_SECRET_DIRNAME = "auth-profiles";
+const LEGACY_OAUTH_SECRET_VERSION = 1;
+const LEGACY_OAUTH_SECRET_ALGORITHM = "aes-256-gcm";
+const LEGACY_OAUTH_SECRET_KEY_ENV = "OPENCLAW_AUTH_PROFILE_SECRET_KEY";
+const LEGACY_OAUTH_SECRET_KEYCHAIN_SERVICE = "OpenClaw Auth Profile Secrets";
+const LEGACY_OAUTH_SECRET_KEYCHAIN_ACCOUNT = "oauth-profile-master-key";
+const LEGACY_OAUTH_SECRET_KEY_FILE_NAME = "auth-profile-secret-key";
+
+export type LegacyOAuthRef = {
+  source: typeof LEGACY_OAUTH_REF_SOURCE;
+  provider: typeof LEGACY_OAUTH_REF_PROVIDER;
+  id: string;
+};
+
+export type LegacyOAuthSecretMaterial = {
+  access?: string;
+  refresh?: string;
+  idToken?: string;
+};
+
+type LegacyOAuthEncryptedPayload = {
+  algorithm: typeof LEGACY_OAUTH_SECRET_ALGORITHM;
+  iv: string;
+  tag: string;
+  ciphertext: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function readNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+export function isLegacyOAuthRef(value: unknown): value is LegacyOAuthRef {
+  if (!isRecord(value)) {
+    return false;
+  }
+  return (
+    value.source === LEGACY_OAUTH_REF_SOURCE &&
+    value.provider === LEGACY_OAUTH_REF_PROVIDER &&
+    typeof value.id === "string" &&
+    /^[a-f0-9]{32}$/.test(value.id)
+  );
+}
+
+export function resolveLegacyOAuthSidecarPath(
+  ref: LegacyOAuthRef,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  return path.join(resolveOAuthDir(env), LEGACY_OAUTH_SECRET_DIRNAME, `${ref.id}.json`);
+}
+
+function normalizeLegacyOAuthSecretMaterial(raw: unknown): LegacyOAuthSecretMaterial | null {
+  if (!isRecord(raw)) {
+    return null;
+  }
+  const material: LegacyOAuthSecretMaterial = {
+    ...(readNonEmptyString(raw.access) ? { access: readNonEmptyString(raw.access) } : {}),
+    ...(readNonEmptyString(raw.refresh) ? { refresh: readNonEmptyString(raw.refresh) } : {}),
+    ...(readNonEmptyString(raw.idToken) ? { idToken: readNonEmptyString(raw.idToken) } : {}),
+  };
+  return Object.keys(material).length > 0 ? material : null;
+}
+
+function coerceLegacyOAuthEncryptedPayload(raw: unknown): LegacyOAuthEncryptedPayload | null {
+  if (!isRecord(raw)) {
+    return null;
+  }
+  return raw.algorithm === LEGACY_OAUTH_SECRET_ALGORITHM &&
+    typeof raw.iv === "string" &&
+    typeof raw.tag === "string" &&
+    typeof raw.ciphertext === "string"
+    ? {
+        algorithm: raw.algorithm,
+        iv: raw.iv,
+        tag: raw.tag,
+        ciphertext: raw.ciphertext,
+      }
+    : null;
+}
+
+function buildLegacyOAuthSecretAad(params: {
+  ref: LegacyOAuthRef;
+  profileId: string;
+  provider: string;
+}): Buffer {
+  return Buffer.from(`${params.ref.id}\0${params.profileId}\0${params.provider}`, "utf8");
+}
+
+function buildLegacyOAuthSecretKey(seed: string): Buffer {
+  return createHash("sha256").update(`openclaw:auth-profile-oauth:${seed}`).digest();
+}
+
+function encryptLegacyOAuthMaterialForTest(params: {
+  ref: LegacyOAuthRef;
+  profileId: string;
+  provider: string;
+  seed: string;
+  material: Record<string, string>;
+}): LegacyOAuthEncryptedPayload {
+  const iv = Buffer.from("0102030405060708090a0b0c", "hex");
+  const cipher = createCipheriv(
+    LEGACY_OAUTH_SECRET_ALGORITHM,
+    buildLegacyOAuthSecretKey(params.seed),
+    iv,
+  );
+  cipher.setAAD(
+    buildLegacyOAuthSecretAad({
+      ref: params.ref,
+      profileId: params.profileId,
+      provider: params.provider,
+    }),
+  );
+  const ciphertext = Buffer.concat([
+    cipher.update(JSON.stringify(params.material), "utf8"),
+    cipher.final(),
+  ]);
+  return {
+    algorithm: LEGACY_OAUTH_SECRET_ALGORITHM,
+    iv: iv.toString("base64url"),
+    tag: cipher.getAuthTag().toString("base64url"),
+    ciphertext: ciphertext.toString("base64url"),
+  };
+}
+
+function isPathInsideOrEqual(parentDir: string, candidatePath: string): boolean {
+  const relative = path.relative(path.resolve(parentDir), path.resolve(candidatePath));
+  return (
+    relative === "" || (!!relative && !relative.startsWith("..") && !path.isAbsolute(relative))
+  );
+}
+
+function uniquePaths(paths: Array<string | undefined>): string[] {
+  return Array.from(new Set(paths.filter((entry): entry is string => Boolean(entry))));
+}
+
+function resolveLegacyOAuthSecretKeyFileCandidates(env: NodeJS.ProcessEnv): string[] {
+  if (process.platform === "win32") {
+    const home = env.USERPROFILE?.trim() || os.homedir();
+    const root = env.APPDATA?.trim() || (home ? path.join(home, "AppData", "Roaming") : undefined);
+    return uniquePaths([
+      root ? path.join(root, "OpenClaw", LEGACY_OAUTH_SECRET_KEY_FILE_NAME) : undefined,
+      home
+        ? path.join(home, ".openclaw-auth-profile-secrets", LEGACY_OAUTH_SECRET_KEY_FILE_NAME)
+        : undefined,
+    ]);
+  }
+
+  if (process.platform === "darwin") {
+    const home = env.HOME?.trim() || os.homedir();
+    return uniquePaths([
+      home
+        ? path.join(
+            home,
+            "Library",
+            "Application Support",
+            "OpenClaw",
+            LEGACY_OAUTH_SECRET_KEY_FILE_NAME,
+          )
+        : undefined,
+      home
+        ? path.join(home, ".openclaw-auth-profile-secrets", LEGACY_OAUTH_SECRET_KEY_FILE_NAME)
+        : undefined,
+    ]);
+  }
+
+  const home = env.HOME?.trim() || os.homedir();
+  const root = env.XDG_CONFIG_HOME?.trim() || (home ? path.join(home, ".config") : undefined);
+  return uniquePaths([
+    root ? path.join(root, "openclaw", LEGACY_OAUTH_SECRET_KEY_FILE_NAME) : undefined,
+    home
+      ? path.join(home, ".openclaw-auth-profile-secrets", LEGACY_OAUTH_SECRET_KEY_FILE_NAME)
+      : undefined,
+  ]);
+}
+
+function resolveLegacyOAuthSecretKeyFilePath(env: NodeJS.ProcessEnv): string | undefined {
+  const stateDir = resolveStateDir(env);
+  return resolveLegacyOAuthSecretKeyFileCandidates(env).find(
+    (candidate) => !isPathInsideOrEqual(stateDir, candidate),
+  );
+}
+
+function readLegacyOAuthSecretKeyFile(env: NodeJS.ProcessEnv): string | undefined {
+  const keyPath = resolveLegacyOAuthSecretKeyFilePath(env);
+  if (!keyPath) {
+    return undefined;
+  }
+  try {
+    const value = fs.readFileSync(keyPath, "utf8").trim();
+    return value || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readLegacyMacOAuthSecretKeychainKey(params: {
+  allowKeychainPrompt?: boolean;
+  env: NodeJS.ProcessEnv;
+}): string | undefined {
+  if (
+    process.platform !== "darwin" ||
+    params.allowKeychainPrompt === false ||
+    params.env.VITEST === "true" ||
+    params.env.VITEST_WORKER_ID !== undefined
+  ) {
+    return undefined;
+  }
+  try {
+    // Read-only compatibility for #79006 sidecar OAuth profiles. Do not add
+    // writes, creation, prompts, or new OS-level Keychain integrations here.
+    // This exists only to keep affected users working until doctor migrates
+    // them back to inline auth-profiles.json OAuth credentials.
+    return childProcess
+      .execFileSync(
+        "security",
+        [
+          "find-generic-password",
+          "-s",
+          LEGACY_OAUTH_SECRET_KEYCHAIN_SERVICE,
+          "-a",
+          LEGACY_OAUTH_SECRET_KEYCHAIN_ACCOUNT,
+          "-w",
+        ],
+        { encoding: "utf8", timeout: 5000, stdio: ["pipe", "pipe", "pipe"] },
+      )
+      .trim();
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveLegacyOAuthSecretKeySeeds(env: NodeJS.ProcessEnv): string[] {
+  const seeds: string[] = [];
+  const addSeed = (value: string | undefined): void => {
+    const trimmed = value?.trim();
+    if (trimmed && !seeds.includes(trimmed)) {
+      seeds.push(trimmed);
+    }
+  };
+  addSeed(env[LEGACY_OAUTH_SECRET_KEY_ENV]);
+  if (env.NODE_ENV === "test" && env.VITEST === "true") {
+    addSeed("openclaw-test-oauth-profile-secret-key");
+  }
+  addSeed(readLegacyOAuthSecretKeyFile(env));
+  return seeds;
+}
+
+function decryptLegacyOAuthSecretMaterialWithSeed(
+  params: {
+    ref: LegacyOAuthRef;
+    profileId: string;
+    provider: string;
+    encrypted: LegacyOAuthEncryptedPayload;
+  },
+  seed: string,
+): LegacyOAuthSecretMaterial | null {
+  try {
+    const decipher = createDecipheriv(
+      LEGACY_OAUTH_SECRET_ALGORITHM,
+      buildLegacyOAuthSecretKey(seed),
+      Buffer.from(params.encrypted.iv, "base64url"),
+    );
+    decipher.setAAD(
+      buildLegacyOAuthSecretAad({
+        ref: params.ref,
+        profileId: params.profileId,
+        provider: params.provider,
+      }),
+    );
+    decipher.setAuthTag(Buffer.from(params.encrypted.tag, "base64url"));
+    const plaintext = Buffer.concat([
+      decipher.update(Buffer.from(params.encrypted.ciphertext, "base64url")),
+      decipher.final(),
+    ]).toString("utf8");
+    return normalizeLegacyOAuthSecretMaterial(JSON.parse(plaintext) as unknown);
+  } catch {
+    return null;
+  }
+}
+
+function decryptLegacyOAuthSecretMaterial(params: {
+  ref: LegacyOAuthRef;
+  profileId: string;
+  provider: string;
+  encrypted: LegacyOAuthEncryptedPayload;
+  env: NodeJS.ProcessEnv;
+  allowKeychainPrompt?: boolean;
+}): LegacyOAuthSecretMaterial | null {
+  const seeds = resolveLegacyOAuthSecretKeySeeds(params.env);
+  for (const seed of seeds) {
+    const material = decryptLegacyOAuthSecretMaterialWithSeed(params, seed);
+    if (material) {
+      return material;
+    }
+  }
+  const keychainSeed = readLegacyMacOAuthSecretKeychainKey({
+    allowKeychainPrompt: params.allowKeychainPrompt,
+    env: params.env,
+  });
+  if (keychainSeed && !seeds.includes(keychainSeed)) {
+    return decryptLegacyOAuthSecretMaterialWithSeed(params, keychainSeed);
+  }
+  return null;
+}
+
+export function loadLegacyOAuthSidecarMaterial(params: {
+  ref: LegacyOAuthRef;
+  profileId: string;
+  provider: string;
+  allowKeychainPrompt?: boolean;
+  env?: NodeJS.ProcessEnv;
+}): LegacyOAuthSecretMaterial | null {
+  const env = params.env ?? process.env;
+  const raw = loadJsonFile(resolveLegacyOAuthSidecarPath(params.ref, env));
+  if (!isRecord(raw)) {
+    return null;
+  }
+  if (
+    raw.version !== LEGACY_OAUTH_SECRET_VERSION ||
+    raw.profileId !== params.profileId ||
+    raw.provider !== params.provider
+  ) {
+    return null;
+  }
+  const encrypted = coerceLegacyOAuthEncryptedPayload(raw.encrypted);
+  if (encrypted) {
+    return decryptLegacyOAuthSecretMaterial({
+      ref: params.ref,
+      profileId: params.profileId,
+      provider: params.provider,
+      encrypted,
+      env,
+      allowKeychainPrompt: params.allowKeychainPrompt,
+    });
+  }
+  return normalizeLegacyOAuthSecretMaterial(raw);
+}
+
+export const legacyOAuthSidecarTestUtils = {
+  buildLegacyOAuthSecretAad,
+  buildLegacyOAuthSecretKey,
+  encryptLegacyOAuthMaterial: encryptLegacyOAuthMaterialForTest,
+};

--- a/src/agents/auth-profiles/legacy-oauth-sidecar.ts
+++ b/src/agents/auth-profiles/legacy-oauth-sidecar.ts
@@ -100,6 +100,9 @@ function buildLegacyOAuthSecretAad(params: {
 }
 
 function buildLegacyOAuthSecretKey(seed: string): Buffer {
+  // Legacy #79006 compatibility: existing sidecars were encrypted with this
+  // SHA-256 key derivation, so changing it would strand affected users.
+  // codeql[js/insufficient-password-hash]
   return createHash("sha256").update(`openclaw:auth-profile-oauth:${seed}`).digest();
 }
 

--- a/src/agents/auth-profiles/oauth-manager.test.ts
+++ b/src/agents/auth-profiles/oauth-manager.test.ts
@@ -2,10 +2,12 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveOAuthDir } from "../../config/paths.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { captureEnv } from "../../test-utils/env.js";
 import { __testing as externalAuthTesting } from "./external-auth.js";
+import { legacyOAuthSidecarTestUtils } from "./legacy-oauth-sidecar.js";
 import {
   createOAuthManager,
   isSafeToAdoptBootstrapOAuthIdentity,
@@ -13,6 +15,7 @@ import {
   isSafeToOverwriteStoredOAuthIdentity,
   OAuthManagerRefreshError,
 } from "./oauth-manager.js";
+import { resolveAuthStorePath } from "./paths.js";
 import {
   clearRuntimeAuthProfileStoreSnapshots,
   ensureAuthProfileStore,
@@ -33,7 +36,13 @@ function createCredential(overrides: Partial<OAuthCredential> = {}): OAuthCreden
 }
 
 const tempDirs: string[] = [];
-const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR", "OPENCLAW_AGENT_DIR", "PI_CODING_AGENT_DIR"]);
+const envSnapshot = captureEnv([
+  "OPENCLAW_STATE_DIR",
+  "OPENCLAW_AGENT_DIR",
+  "PI_CODING_AGENT_DIR",
+  "OPENCLAW_OAUTH_DIR",
+  "OPENCLAW_AUTH_PROFILE_SECRET_KEY",
+]);
 
 beforeEach(() => {
   externalAuthTesting.setResolveExternalAuthProfilesForTest(() => []);
@@ -446,6 +455,104 @@ describe("createOAuthManager", () => {
     expect(result.credential.provider).toBe("minimax-portal");
     expect(result.credential.access).toBe("rotated-access");
     expect(result.credential.refresh).toBe("rotated-refresh");
+  });
+
+  it("refreshes legacy oauthRef sidecar credentials and writes rotated tokens inline", async () => {
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "oauth-manager-legacy-ref-"));
+    tempDirs.push(tempRoot);
+    process.env.OPENCLAW_STATE_DIR = tempRoot;
+    process.env.OPENCLAW_OAUTH_DIR = path.join(tempRoot, "credentials");
+    process.env.OPENCLAW_AUTH_PROFILE_SECRET_KEY = "legacy-seed";
+    const agentDir = path.join(tempRoot, "agents", "main", "agent");
+    const profileId = "openai-codex:default";
+    const ref = {
+      source: "openclaw-credentials" as const,
+      provider: "openai-codex" as const,
+      id: "0123456789abcdef0123456789abcdef",
+    };
+    await fs.mkdir(agentDir, { recursive: true });
+    await fs.writeFile(
+      resolveAuthStorePath(agentDir),
+      `${JSON.stringify(
+        {
+          version: 1,
+          profiles: {
+            [profileId]: {
+              type: "oauth",
+              provider: "openai-codex",
+              expires: Date.now() - 60_000,
+              oauthRef: ref,
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    const sidecarPath = path.join(resolveOAuthDir(), "auth-profiles", `${ref.id}.json`);
+    await fs.mkdir(path.dirname(sidecarPath), { recursive: true });
+    await fs.writeFile(
+      sidecarPath,
+      `${JSON.stringify(
+        {
+          version: 1,
+          profileId,
+          provider: "openai-codex",
+          encrypted: legacyOAuthSidecarTestUtils.encryptLegacyOAuthMaterial({
+            ref,
+            profileId,
+            provider: "openai-codex",
+            seed: "legacy-seed",
+            material: {
+              access: "legacy-access",
+              refresh: "legacy-refresh",
+            },
+          }),
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    const store = ensureAuthProfileStore(agentDir);
+    const credential = store.profiles[profileId];
+    expect(credential?.type).toBe("oauth");
+    expect(credential).toMatchObject({
+      access: "legacy-access",
+      refresh: "legacy-refresh",
+    });
+    const refreshCredential = vi.fn(async (input: OAuthCredential) => {
+      expect(input.refresh).toBe("legacy-refresh");
+      return {
+        access: "rotated-access",
+        refresh: "rotated-refresh",
+        expires: Date.now() + 60_000,
+      };
+    });
+    const manager = createOAuthManager({
+      buildApiKey: async (_provider, value) => value.access,
+      refreshCredential,
+      readBootstrapCredential: () => null,
+      isRefreshTokenReusedError: () => false,
+    });
+
+    const result = await manager.resolveOAuthAccess({
+      store,
+      profileId,
+      credential: credential as OAuthCredential,
+      agentDir,
+    });
+
+    expect(refreshCredential).toHaveBeenCalledTimes(1);
+    expect(result?.apiKey).toBe("rotated-access");
+    const parsed = JSON.parse(await fs.readFile(resolveAuthStorePath(agentDir), "utf8")) as {
+      profiles: Record<string, Record<string, unknown>>;
+    };
+    expect(parsed.profiles[profileId]).not.toHaveProperty("oauthRef");
+    expect(parsed.profiles[profileId]).toMatchObject({
+      access: "rotated-access",
+      refresh: "rotated-refresh",
+    });
   });
 
   it("redacts the external oauth credential attempted during refresh failures", async () => {

--- a/src/agents/auth-profiles/oauth-manager.ts
+++ b/src/agents/auth-profiles/oauth-manager.ts
@@ -233,6 +233,13 @@ function createRedactedOAuthRefreshCause(cause: unknown, secrets: string[]): Err
   return sanitized;
 }
 
+function loadStoredOAuthRefreshStore(agentDir?: string): AuthProfileStore {
+  return loadAuthProfileStoreWithoutExternalProfiles(agentDir, {
+    allowKeychainPrompt: true,
+    resolveLegacyOAuthSidecars: true,
+  });
+}
+
 async function loadFreshStoredOAuthCredential(params: {
   profileId: string;
   agentDir?: string;
@@ -240,7 +247,7 @@ async function loadFreshStoredOAuthCredential(params: {
   previous?: Pick<OAuthCredential, "access" | "refresh" | "expires">;
   requireChange?: boolean;
 }): Promise<OAuthCredential | null> {
-  const reloadedStore = loadAuthProfileStoreWithoutExternalProfiles(params.agentDir);
+  const reloadedStore = loadStoredOAuthRefreshStore(params.agentDir);
   const reloaded = reloadedStore.profiles[params.profileId];
   if (
     reloaded?.type !== "oauth" ||
@@ -427,7 +434,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
     try {
       return await withFileLock(globalRefreshLockPath, OAUTH_REFRESH_LOCK_OPTIONS, async () =>
         withFileLock(authPath, AUTH_STORE_LOCK_OPTIONS, async () => {
-          const store = loadAuthProfileStoreWithoutExternalProfiles(ownerAgentDir);
+          const store = loadStoredOAuthRefreshStore(ownerAgentDir);
           const cred = store.profiles[params.profileId];
           if (!cred || cred.type !== "oauth") {
             return null;
@@ -446,7 +453,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
 
           if (params.agentDir) {
             try {
-              const mainStore = loadAuthProfileStoreWithoutExternalProfiles(undefined);
+              const mainStore = loadStoredOAuthRefreshStore(undefined);
               const mainCred = mainStore.profiles[params.profileId];
               if (
                 mainCred?.type === "oauth" &&
@@ -645,7 +652,7 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
       });
       return refreshed;
     } catch (error) {
-      const refreshedStore = loadAuthProfileStoreWithoutExternalProfiles(params.agentDir);
+      const refreshedStore = loadStoredOAuthRefreshStore(params.agentDir);
       const refreshed = refreshedStore.profiles[params.profileId];
       if (
         refreshed?.type === "oauth" &&

--- a/src/agents/auth-profiles/path-resolve.ts
+++ b/src/agents/auth-profiles/path-resolve.ts
@@ -53,6 +53,9 @@ export function resolveAuthStatePathForDisplay(agentDir?: string): string {
  */
 export function resolveOAuthRefreshLockPath(provider: string, profileId: string): string {
   const hash = createHash("sha256");
+  // This hashes provider/profile identifiers into a path-safe lock name; it is
+  // not password storage or credential verification.
+  // codeql[js/insufficient-password-hash]
   hash.update(provider, "utf8");
   hash.update("\u0000", "utf8"); // NUL separator: unambiguous boundary.
   hash.update(profileId, "utf8");

--- a/src/agents/auth-profiles/persisted-boundary.test.ts
+++ b/src/agents/auth-profiles/persisted-boundary.test.ts
@@ -1,6 +1,28 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { resolveOAuthDir } from "../../config/paths.js";
 import { AUTH_STORE_VERSION } from "./constants.js";
-import { coercePersistedAuthProfileStore } from "./persisted.js";
+import { legacyOAuthSidecarTestUtils } from "./legacy-oauth-sidecar.js";
+import { resolveAuthStorePath } from "./paths.js";
+import { coercePersistedAuthProfileStore, loadPersistedAuthProfileStore } from "./persisted.js";
+
+function withEnvValue(key: string, value: string | undefined): () => void {
+  const previous = process.env[key];
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+  return () => {
+    if (previous === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = previous;
+    }
+  };
+}
 
 describe("persisted auth profile boundary", () => {
   it("normalizes malformed persisted credentials and state before runtime use", () => {
@@ -101,5 +123,93 @@ describe("persisted auth profile boundary", () => {
     expect(store?.profiles["openai:default"]).not.toHaveProperty("key");
     expect(store?.profiles["openai:default"]).not.toHaveProperty("copyToAgents");
     expect(store?.profiles["codex:default"]).not.toHaveProperty("oauthRef");
+  });
+
+  it("rehydrates legacy oauthRef sidecars read-only for upgraded Codex OAuth users", () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-oauthref-runtime-"));
+    const agentDir = path.join(stateDir, "agents", "main", "agent");
+    const restoreStateDir = withEnvValue("OPENCLAW_STATE_DIR", stateDir);
+    const restoreOAuthDir = withEnvValue("OPENCLAW_OAUTH_DIR", undefined);
+    const restoreSecretKey = withEnvValue("OPENCLAW_AUTH_PROFILE_SECRET_KEY", "legacy-seed");
+    try {
+      fs.mkdirSync(agentDir, { recursive: true });
+      const profileId = "openai-codex:default";
+      const ref = {
+        source: "openclaw-credentials" as const,
+        provider: "openai-codex" as const,
+        id: "0123456789abcdef0123456789abcdef",
+      };
+      fs.writeFileSync(
+        resolveAuthStorePath(agentDir),
+        `${JSON.stringify(
+          {
+            version: AUTH_STORE_VERSION,
+            profiles: {
+              [profileId]: {
+                type: "oauth",
+                provider: "openai-codex",
+                expires: 123456,
+                accountId: "acct-legacy",
+                chatgptPlanType: "plus",
+                oauthRef: ref,
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+      );
+
+      const sidecarPath = path.join(resolveOAuthDir(), "auth-profiles", `${ref.id}.json`);
+      fs.mkdirSync(path.dirname(sidecarPath), { recursive: true });
+      fs.writeFileSync(
+        sidecarPath,
+        `${JSON.stringify(
+          {
+            version: 1,
+            profileId,
+            provider: "openai-codex",
+            encrypted: legacyOAuthSidecarTestUtils.encryptLegacyOAuthMaterial({
+              ref,
+              profileId,
+              provider: "openai-codex",
+              seed: "legacy-seed",
+              material: {
+                access: "legacy-access-token",
+                refresh: "legacy-refresh-token",
+                idToken: "legacy-id-token",
+              },
+            }),
+          },
+          null,
+          2,
+        )}\n`,
+      );
+
+      const unresolved = loadPersistedAuthProfileStore(agentDir)?.profiles[profileId];
+      expect(unresolved).not.toHaveProperty("access");
+      expect(unresolved).not.toHaveProperty("refresh");
+      expect(unresolved).not.toHaveProperty("idToken");
+
+      const credential = loadPersistedAuthProfileStore(agentDir, {
+        resolveLegacyOAuthSidecars: true,
+      })?.profiles[profileId];
+      expect(credential).toMatchObject({
+        type: "oauth",
+        provider: "openai-codex",
+        access: "legacy-access-token",
+        refresh: "legacy-refresh-token",
+        idToken: "legacy-id-token",
+        expires: 123456,
+        accountId: "acct-legacy",
+        chatgptPlanType: "plus",
+      });
+      expect(credential).not.toHaveProperty("oauthRef");
+    } finally {
+      restoreSecretKey();
+      restoreOAuthDir();
+      restoreStateDir();
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/agents/auth-profiles/persisted.ts
+++ b/src/agents/auth-profiles/persisted.ts
@@ -1,8 +1,14 @@
+import { createHash } from "node:crypto";
 import { resolveOAuthPath } from "../../config/paths.js";
 import { coerceSecretRef } from "../../config/types.secrets.js";
 import { loadJsonFile } from "../../infra/json-file.js";
 import { normalizeProviderId } from "../provider-id.js";
 import { AUTH_STORE_VERSION, log } from "./constants.js";
+import {
+  isLegacyOAuthRef,
+  loadLegacyOAuthSidecarMaterial,
+  type LegacyOAuthSecretMaterial,
+} from "./legacy-oauth-sidecar.js";
 import {
   hasOAuthIdentity,
   hasUsableOAuthCredential,
@@ -28,18 +34,18 @@ import type {
 
 export type LegacyAuthStore = Record<string, AuthProfileCredential>;
 
+type LoadPersistedAuthProfileStoreOptions = {
+  allowKeychainPrompt?: boolean;
+  resolveLegacyOAuthSidecars?: boolean;
+};
+
 type CredentialRejectReason = "non_object" | "invalid_type" | "missing_provider";
 type RejectedCredentialEntry = { key: string; reason: CredentialRejectReason };
 
 const AUTH_PROFILE_TYPES = new Set<AuthProfileCredential["type"]>(["api_key", "oauth", "token"]);
-const LEGACY_OAUTH_REF_SOURCE = "openclaw-credentials";
 const LEGACY_OAUTH_REF_PROVIDER = "openai-codex";
-
-type LegacyOAuthRef = {
-  source: typeof LEGACY_OAUTH_REF_SOURCE;
-  provider: typeof LEGACY_OAUTH_REF_PROVIDER;
-  id: string;
-};
+const runtimeLegacyOAuthSidecarCredentials = new WeakSet<OAuthCredential>();
+const runtimeLegacyOAuthSidecarMaterialFingerprints = new Map<string, string>();
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
@@ -53,22 +59,27 @@ function normalizeOptionalCredentialString(value: unknown): string | undefined {
   return trimmed ? value : undefined;
 }
 
-function isLegacyOAuthRef(value: unknown): value is LegacyOAuthRef {
-  if (!isRecord(value)) {
-    return false;
-  }
-  return (
-    value.source === LEGACY_OAUTH_REF_SOURCE &&
-    value.provider === LEGACY_OAUTH_REF_PROVIDER &&
-    typeof value.id === "string" &&
-    /^[a-f0-9]{32}$/.test(value.id)
-  );
-}
-
 function hasInlineOAuthTokenMaterial(credential: OAuthCredential): boolean {
   return [credential.access, credential.refresh, credential.idToken].some(
     (value) => typeof value === "string" && value.trim().length > 0,
   );
+}
+
+function buildRuntimeLegacyOAuthSidecarFingerprintKey(params: {
+  storeKey?: string;
+  profileId: string;
+}): string {
+  return `${params.storeKey ?? ""}\0${params.profileId}`;
+}
+
+function buildLegacyOAuthSecretMaterialFingerprint(
+  material: Pick<OAuthCredential, "access" | "refresh" | "idToken">,
+): string {
+  return createHash("sha256")
+    .update(
+      JSON.stringify([material.access ?? null, material.refresh ?? null, material.idToken ?? null]),
+    )
+    .digest("hex");
 }
 
 function normalizeOptionalCredentialBoolean(value: unknown): boolean | undefined {
@@ -251,6 +262,80 @@ function warnRejectedCredentialEntries(source: string, rejected: RejectedCredent
   });
 }
 
+function resolveLegacyOAuthSidecarCredential(params: {
+  profileId: string;
+  raw: unknown;
+  credential: AuthProfileCredential;
+  storeKey?: string;
+  options?: LoadPersistedAuthProfileStoreOptions;
+}): AuthProfileCredential {
+  if (
+    params.credential.type !== "oauth" ||
+    normalizeProviderId(params.credential.provider) !== LEGACY_OAUTH_REF_PROVIDER ||
+    hasInlineOAuthTokenMaterial(params.credential) ||
+    !isRecord(params.raw) ||
+    !isLegacyOAuthRef(params.raw.oauthRef)
+  ) {
+    return params.credential;
+  }
+  // Read-only compatibility for #79006 sidecar OAuth profiles. Do not add
+  // new writers or OS-level Keychain creation here; doctor remains the path
+  // that migrates users back to canonical inline OAuth credentials.
+  const material = loadLegacyOAuthSidecarMaterial({
+    ref: params.raw.oauthRef,
+    profileId: params.profileId,
+    provider: params.credential.provider,
+    allowKeychainPrompt: params.options?.allowKeychainPrompt,
+  });
+  if (!material) {
+    return params.credential;
+  }
+  const credential = {
+    ...params.credential,
+    ...(material.access ? { access: material.access } : {}),
+    ...(material.refresh ? { refresh: material.refresh } : {}),
+    ...(material.idToken ? { idToken: material.idToken } : {}),
+  };
+  runtimeLegacyOAuthSidecarCredentials.add(credential);
+  runtimeLegacyOAuthSidecarMaterialFingerprints.set(
+    buildRuntimeLegacyOAuthSidecarFingerprintKey({
+      storeKey: params.storeKey,
+      profileId: params.profileId,
+    }),
+    buildLegacyOAuthSecretMaterialFingerprint(credential),
+  );
+  return credential;
+}
+
+export function isRuntimeLegacyOAuthSidecarCredential(
+  credential: AuthProfileCredential | undefined,
+): boolean {
+  return credential?.type === "oauth" && runtimeLegacyOAuthSidecarCredentials.has(credential);
+}
+
+export function matchesRuntimeLegacyOAuthSidecarMaterial(params: {
+  authPath?: string;
+  profileId: string;
+  credential: AuthProfileCredential | undefined;
+}): boolean {
+  if (params.credential?.type !== "oauth") {
+    return false;
+  }
+  if (runtimeLegacyOAuthSidecarCredentials.has(params.credential)) {
+    return true;
+  }
+  const fingerprint = runtimeLegacyOAuthSidecarMaterialFingerprints.get(
+    buildRuntimeLegacyOAuthSidecarFingerprintKey({
+      storeKey: params.authPath,
+      profileId: params.profileId,
+    }),
+  );
+  return (
+    fingerprint !== undefined &&
+    fingerprint === buildLegacyOAuthSecretMaterialFingerprint(params.credential)
+  );
+}
+
 function coerceLegacyAuthStore(raw: unknown): LegacyAuthStore | null {
   if (!isRecord(raw)) {
     return null;
@@ -273,7 +358,11 @@ function coerceLegacyAuthStore(raw: unknown): LegacyAuthStore | null {
   return Object.keys(entries).length > 0 ? entries : null;
 }
 
-export function coercePersistedAuthProfileStore(raw: unknown): AuthProfileStore | null {
+export function coercePersistedAuthProfileStore(
+  raw: unknown,
+  options?: LoadPersistedAuthProfileStoreOptions,
+  storeKey?: string,
+): AuthProfileStore | null {
   if (!isRecord(raw)) {
     return null;
   }
@@ -290,7 +379,16 @@ export function coercePersistedAuthProfileStore(raw: unknown): AuthProfileStore 
       rejected.push({ key, reason: parsed.reason });
       continue;
     }
-    normalized[key] = parsed.credential;
+    normalized[key] =
+      options?.resolveLegacyOAuthSidecars === true
+        ? resolveLegacyOAuthSidecarCredential({
+            profileId: key,
+            raw: value,
+            credential: parsed.credential,
+            storeKey,
+            options,
+          })
+        : parsed.credential;
   }
   warnRejectedCredentialEntries("auth-profiles.json", rejected);
   const version = Number(record.version ?? AUTH_STORE_VERSION);
@@ -647,7 +745,10 @@ export function buildPersistedAuthProfileSecretsStore(
     profileId: string;
     credential: AuthProfileCredential;
   }) => boolean,
-  options?: { existingRaw?: unknown },
+  options?: {
+    existingRaw?: unknown;
+    runtimeLegacyOAuthSidecarProfileIds?: ReadonlySet<string>;
+  },
 ): AuthProfileSecretsStore {
   const profiles = Object.fromEntries(
     Object.entries(store.profiles).flatMap(([profileId, credential]) => {
@@ -672,13 +773,19 @@ export function buildPersistedAuthProfileSecretsStore(
     version: AUTH_STORE_VERSION,
     profiles,
   };
-  return preserveLegacyOAuthRefsForDoctorMigration(payload, options?.existingRaw);
+  return preserveLegacyOAuthRefsForDoctorMigration(payload, options);
 }
 
 function preserveLegacyOAuthRefsForDoctorMigration(
   payload: AuthProfileSecretsStore,
-  existingRaw: unknown,
+  options:
+    | {
+        existingRaw?: unknown;
+        runtimeLegacyOAuthSidecarProfileIds?: ReadonlySet<string>;
+      }
+    | undefined,
 ): AuthProfileSecretsStore {
+  const existingRaw = options?.existingRaw;
   if (!isRecord(existingRaw) || !isRecord(existingRaw.profiles)) {
     return payload;
   }
@@ -690,21 +797,65 @@ function preserveLegacyOAuthRefsForDoctorMigration(
     const credential = payload.profiles[profileId];
     if (
       credential?.type !== "oauth" ||
-      normalizeProviderId(credential.provider) !== LEGACY_OAUTH_REF_PROVIDER ||
-      hasInlineOAuthTokenMaterial(credential)
+      normalizeProviderId(credential.provider) !== LEGACY_OAUTH_REF_PROVIDER
     ) {
       continue;
     }
-    // Removal-only retention for #79006: runtime must not load sidecar
-    // credentials, but doctor still needs the inert ref to migrate users back
-    // to inline auth-profiles.json OAuth credentials.
+    if (hasInlineOAuthTokenMaterial(credential)) {
+      const isRuntimeSidecarMaterial =
+        options?.runtimeLegacyOAuthSidecarProfileIds?.has(profileId) === true;
+      // Untracked inline material may be a real token refresh. Only reread the
+      // sidecar then, and never use Keychain from this save-path check.
+      if (
+        !isRuntimeSidecarMaterial &&
+        !isUnchangedLegacyOAuthSidecarMaterial({ profileId, rawProfile, credential })
+      ) {
+        continue;
+      }
+    }
+    // Removal-only retention for #79006: ordinary runtime saves must not turn
+    // rehydrated sidecar tokens into inline credentials. Doctor remains the
+    // explicit migration path that creates backups and removes sidecars.
     profiles ??= { ...payload.profiles };
+    const sanitized = { ...credential } as Record<string, unknown>;
+    delete sanitized.access;
+    delete sanitized.refresh;
+    delete sanitized.idToken;
     profiles[profileId] = {
-      ...credential,
+      ...sanitized,
       oauthRef: rawProfile.oauthRef,
-    } as AuthProfileCredential;
+    } as unknown as AuthProfileCredential;
   }
   return profiles ? { ...payload, profiles } : payload;
+}
+
+function isUnchangedLegacyOAuthSidecarMaterial(params: {
+  profileId: string;
+  rawProfile: Record<string, unknown>;
+  credential: OAuthCredential;
+}): boolean {
+  if (!isLegacyOAuthRef(params.rawProfile.oauthRef)) {
+    return false;
+  }
+  const material = loadLegacyOAuthSidecarMaterial({
+    ref: params.rawProfile.oauthRef,
+    profileId: params.profileId,
+    provider: params.credential.provider,
+    allowKeychainPrompt: false,
+  });
+  if (!material) {
+    return false;
+  }
+  return isSameLegacyOAuthSecretMaterial(params.credential, material);
+}
+
+function isSameLegacyOAuthSecretMaterial(
+  credential: OAuthCredential,
+  material: LegacyOAuthSecretMaterial,
+): boolean {
+  return (["access", "refresh", "idToken"] as const).every(
+    (field) => (credential[field] ?? undefined) === (material[field] ?? undefined),
+  );
 }
 
 export function applyLegacyAuthStore(store: AuthProfileStore, legacy: LegacyAuthStore): void {
@@ -770,10 +921,13 @@ export function mergeOAuthFileIntoStore(store: AuthProfileStore): boolean {
   return mutated;
 }
 
-export function loadPersistedAuthProfileStore(agentDir?: string): AuthProfileStore | null {
+export function loadPersistedAuthProfileStore(
+  agentDir?: string,
+  options?: LoadPersistedAuthProfileStoreOptions,
+): AuthProfileStore | null {
   const authPath = resolveAuthStorePath(agentDir);
   const raw = loadJsonFile(authPath);
-  const store = coercePersistedAuthProfileStore(raw);
+  const store = coercePersistedAuthProfileStore(raw, options, authPath);
   if (!store) {
     return null;
   }

--- a/src/agents/auth-profiles/profiles.test.ts
+++ b/src/agents/auth-profiles/profiles.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { resolveOAuthDir } from "../../config/paths.js";
 import { AUTH_STORE_VERSION } from "./constants.js";
 import { resolveAuthStorePath } from "./paths.js";
 import { promoteAuthProfileInOrder, upsertAuthProfileWithLock } from "./profiles.js";
@@ -55,7 +56,9 @@ describe("promoteAuthProfileInOrder", () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-profile-upsert-"));
     const agentDir = path.join(stateDir, "agents", "main", "agent");
     const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    const previousOAuthDir = process.env.OPENCLAW_OAUTH_DIR;
     process.env.OPENCLAW_STATE_DIR = stateDir;
+    delete process.env.OPENCLAW_OAUTH_DIR;
     try {
       fs.mkdirSync(agentDir, { recursive: true });
 
@@ -94,6 +97,11 @@ describe("promoteAuthProfileInOrder", () => {
         delete process.env.OPENCLAW_STATE_DIR;
       } else {
         process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      if (previousOAuthDir === undefined) {
+        delete process.env.OPENCLAW_OAUTH_DIR;
+      } else {
+        process.env.OPENCLAW_OAUTH_DIR = previousOAuthDir;
       }
       fs.rmSync(stateDir, { recursive: true, force: true });
     }
@@ -145,6 +153,7 @@ describe("promoteAuthProfileInOrder", () => {
         chatgptPlanType: "plus",
       });
       expect(credential).not.toHaveProperty("oauthRef");
+      expect(fs.existsSync(path.join(resolveOAuthDir(), "auth-profiles"))).toBe(false);
 
       clearRuntimeAuthProfileStoreSnapshots();
       expectOAuthCredentialFields(

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -22,8 +22,10 @@ import {
 import {
   applyLegacyAuthStore,
   buildPersistedAuthProfileSecretsStore,
+  isRuntimeLegacyOAuthSidecarCredential,
   loadLegacyAuthProfileStore,
   loadPersistedAuthProfileStore,
+  matchesRuntimeLegacyOAuthSidecarMaterial,
   mergeAuthProfileStores,
   mergeOAuthFileIntoStore,
 } from "./persisted.js";
@@ -47,6 +49,7 @@ type LoadAuthProfileStoreOptions = {
   config?: OpenClawConfig;
   externalCli?: ExternalCliAuthDiscovery;
   readOnly?: boolean;
+  resolveLegacyOAuthSidecars?: boolean;
   syncExternalCli?: boolean;
   externalCliProviderIds?: Iterable<string>;
   externalCliProfileIds?: Iterable<string>;
@@ -74,6 +77,19 @@ type ExternalCliSyncResult = {
   store: AuthProfileStore;
   cacheable: boolean;
 };
+
+function resolvePersistedLoadOptions(
+  options:
+    | Pick<LoadAuthProfileStoreOptions, "allowKeychainPrompt" | "resolveLegacyOAuthSidecars">
+    | undefined,
+): { allowKeychainPrompt?: boolean; resolveLegacyOAuthSidecars?: boolean } {
+  return {
+    resolveLegacyOAuthSidecars: options?.resolveLegacyOAuthSidecars ?? true,
+    ...(options?.allowKeychainPrompt !== undefined
+      ? { allowKeychainPrompt: options.allowKeychainPrompt }
+      : {}),
+  };
+}
 
 function isInheritedMainOAuthCredential(params: {
   agentDir?: string;
@@ -124,7 +140,10 @@ function shouldUseMainOwnerForLocalOAuthCredential(params: {
   );
 }
 
-function resolveRuntimeAuthProfileStore(agentDir?: string): AuthProfileStore | null {
+function resolveRuntimeAuthProfileStore(
+  agentDir?: string,
+  options?: Pick<LoadAuthProfileStoreOptions, "allowKeychainPrompt">,
+): AuthProfileStore | null {
   const mainKey = resolveAuthStorePath(undefined);
   const requestedKey = resolveAuthStorePath(agentDir);
   const mainStore = getRuntimeAuthProfileStoreSnapshot(undefined);
@@ -144,6 +163,7 @@ function resolveRuntimeAuthProfileStore(agentDir?: string): AuthProfileStore | n
     const persistedMainStore = loadAuthProfileStoreForAgent(undefined, {
       readOnly: true,
       syncExternalCli: false,
+      ...resolvePersistedLoadOptions(options),
     });
     return mergeAuthProfileStores(persistedMainStore, requestedStore);
   }
@@ -306,7 +326,10 @@ function maybeSyncPersistedExternalCliAuthProfiles(params: {
     return { store: params.store, cacheable: false };
   }
   try {
-    const latestStore = loadPersistedAuthProfileStore(params.agentDir) ?? {
+    const latestStore = loadPersistedAuthProfileStore(
+      params.agentDir,
+      resolvePersistedLoadOptions(params.options),
+    ) ?? {
       version: AUTH_STORE_VERSION,
       profiles: {},
     };
@@ -473,7 +496,7 @@ function loadAuthProfileStoreForAgent(
       return cached;
     }
   }
-  const asStore = loadPersistedAuthProfileStore(agentDir);
+  const asStore = loadPersistedAuthProfileStore(agentDir, resolvePersistedLoadOptions(options));
   if (asStore) {
     const synced = maybeSyncPersistedExternalCliAuthProfiles({
       store: asStore,
@@ -564,11 +587,25 @@ export function loadAuthProfileStoreForRuntime(
 }
 
 export function loadAuthProfileStoreForSecretsRuntime(agentDir?: string): AuthProfileStore {
-  return loadAuthProfileStoreForRuntime(agentDir, { readOnly: true, allowKeychainPrompt: false });
+  return loadAuthProfileStoreForRuntime(agentDir, {
+    readOnly: true,
+    allowKeychainPrompt: false,
+    resolveLegacyOAuthSidecars: false,
+  });
 }
 
-export function loadAuthProfileStoreWithoutExternalProfiles(agentDir?: string): AuthProfileStore {
-  const options: LoadAuthProfileStoreOptions = { readOnly: true, allowKeychainPrompt: false };
+export function loadAuthProfileStoreWithoutExternalProfiles(
+  agentDir?: string,
+  loadOptions?: Pick<
+    LoadAuthProfileStoreOptions,
+    "allowKeychainPrompt" | "resolveLegacyOAuthSidecars"
+  >,
+): AuthProfileStore {
+  const options: LoadAuthProfileStoreOptions = {
+    readOnly: true,
+    allowKeychainPrompt: loadOptions?.allowKeychainPrompt ?? false,
+    resolveLegacyOAuthSidecars: loadOptions?.resolveLegacyOAuthSidecars ?? false,
+  };
   const store = loadAuthProfileStoreForAgent(agentDir, options);
   const authPath = resolveAuthStorePath(agentDir);
   const mainAuthPath = resolveAuthStorePath();
@@ -604,7 +641,7 @@ export function ensureAuthProfileStoreWithoutExternalProfiles(
   agentDir?: string,
   options?: { allowKeychainPrompt?: boolean },
 ): AuthProfileStore {
-  const runtimeStore = resolveRuntimeAuthProfileStore(agentDir);
+  const runtimeStore = resolveRuntimeAuthProfileStore(agentDir, options);
   if (runtimeStore) {
     return runtimeStore;
   }
@@ -702,9 +739,19 @@ export function saveAuthProfileStore(
 ): void {
   const authPath = resolveAuthStorePath(agentDir);
   const statePath = resolveAuthStatePath(agentDir);
+  const runtimeLegacyOAuthSidecarProfileIds = new Set(
+    Object.entries(store.profiles)
+      .filter(
+        ([profileId, credential]) =>
+          isRuntimeLegacyOAuthSidecarCredential(credential) ||
+          matchesRuntimeLegacyOAuthSidecarMaterial({ authPath, profileId, credential }),
+      )
+      .map(([profileId]) => profileId),
+  );
   const localStore = buildLocalAuthProfileStoreForSave({ store, agentDir, options });
   const payload = buildPersistedAuthProfileSecretsStore(localStore, undefined, {
     existingRaw: loadJsonFile(authPath),
+    runtimeLegacyOAuthSidecarProfileIds,
   });
   saveJsonFile(authPath, payload);
   savePersistedAuthProfileState(localStore, agentDir);

--- a/src/agents/cli-auth-epoch.ts
+++ b/src/agents/cli-auth-epoch.ts
@@ -38,6 +38,9 @@ export function resetCliAuthEpochTestDeps(): void {
 }
 
 function hashCliAuthEpochPart(value: string): string {
+  // Epoch hashes detect local auth-state changes; they are not password
+  // storage or credential verification.
+  // codeql[js/insufficient-password-hash]
   return crypto.createHash("sha256").update(value).digest("hex");
 }
 

--- a/src/commands/agents.add.test.ts
+++ b/src/commands/agents.add.test.ts
@@ -3,8 +3,10 @@ import os from "node:os";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AUTH_STORE_VERSION } from "../agents/auth-profiles/constants.js";
+import { legacyOAuthSidecarTestUtils } from "../agents/auth-profiles/legacy-oauth-sidecar.js";
 import { saveAuthProfileStore } from "../agents/auth-profiles/store.js";
 import { formatCliCommand } from "../cli/command-format.js";
+import { resolveOAuthDir } from "../config/paths.js";
 import { baseConfigSnapshot, createTestRuntime } from "./test-runtime-config-helpers.js";
 
 const readConfigFileSnapshotMock = vi.hoisted(() => vi.fn());
@@ -253,10 +255,20 @@ describe("agents add command", () => {
 
   it("skips legacy sidecar-backed Codex OAuth profiles when seeding a new agent store", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agents-add-oauth-ref-skip-"));
+    const previousOAuthDir = process.env.OPENCLAW_OAUTH_DIR;
+    const previousSecretKey = process.env.OPENCLAW_AUTH_PROFILE_SECRET_KEY;
+    process.env.OPENCLAW_OAUTH_DIR = path.join(root, "credentials");
+    process.env.OPENCLAW_AUTH_PROFILE_SECRET_KEY = "legacy-seed";
     try {
       const sourceAgentDir = path.join(root, "main", "agent");
       const destAgentDir = path.join(root, "work", "agent");
       const destAuthPath = path.join(destAgentDir, "auth-profiles.json");
+      const profileId = "openai-codex:default";
+      const ref = {
+        source: "openclaw-credentials" as const,
+        provider: "openai-codex" as const,
+        id: "0123456789abcdef0123456789abcdef",
+      };
       await fs.mkdir(sourceAgentDir, { recursive: true });
       await fs.writeFile(
         path.join(sourceAgentDir, "auth-profiles.json"),
@@ -264,18 +276,39 @@ describe("agents add command", () => {
           {
             version: AUTH_STORE_VERSION,
             profiles: {
-              "openai-codex:default": {
+              [profileId]: {
                 type: "oauth",
                 provider: "openai-codex",
                 copyToAgents: true,
                 expires: Date.now() + 60_000,
-                oauthRef: {
-                  source: "openclaw-credentials",
-                  provider: "openai-codex",
-                  id: "0123456789abcdef0123456789abcdef",
-                },
+                oauthRef: ref,
               },
             },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+      const sidecarPath = path.join(resolveOAuthDir(), "auth-profiles", `${ref.id}.json`);
+      await fs.mkdir(path.dirname(sidecarPath), { recursive: true });
+      await fs.writeFile(
+        sidecarPath,
+        `${JSON.stringify(
+          {
+            version: 1,
+            profileId,
+            provider: "openai-codex",
+            encrypted: legacyOAuthSidecarTestUtils.encryptLegacyOAuthMaterial({
+              ref,
+              profileId,
+              provider: "openai-codex",
+              seed: "legacy-seed",
+              material: {
+                access: "legacy-sidecar-access-token",
+                refresh: "legacy-sidecar-refresh-token",
+              },
+            }),
           },
           null,
           2,
@@ -291,6 +324,16 @@ describe("agents add command", () => {
       expect(result).toEqual({ copied: 0, skipped: 1 });
       await expect(fs.stat(destAuthPath)).rejects.toMatchObject({ code: "ENOENT" });
     } finally {
+      if (previousOAuthDir === undefined) {
+        delete process.env.OPENCLAW_OAUTH_DIR;
+      } else {
+        process.env.OPENCLAW_OAUTH_DIR = previousOAuthDir;
+      }
+      if (previousSecretKey === undefined) {
+        delete process.env.OPENCLAW_AUTH_PROFILE_SECRET_KEY;
+      } else {
+        process.env.OPENCLAW_AUTH_PROFILE_SECRET_KEY = previousSecretKey;
+      }
       await fs.rm(root, { recursive: true, force: true });
     }
   });

--- a/src/commands/agents.commands.add.ts
+++ b/src/commands/agents.commands.add.ts
@@ -78,7 +78,9 @@ async function copyPortableAuthProfiles(params: {
   destAuthPath: string;
   sourceAgentDir: string;
 }): Promise<{ copied: number; skipped: number }> {
-  const sourceStore = loadPersistedAuthProfileStore(params.sourceAgentDir);
+  const sourceStore = loadPersistedAuthProfileStore(params.sourceAgentDir, {
+    resolveLegacyOAuthSidecars: false,
+  });
   if (!sourceStore || Object.keys(sourceStore.profiles).length === 0) {
     return { copied: 0, skipped: 0 };
   }
@@ -337,7 +339,9 @@ export async function agentsAddCommand(
         (await pathExists(sourceAuthPath)) &&
         !(await pathExists(destAuthPath))
       ) {
-        const sourceStore = loadPersistedAuthProfileStore(sourceAgentDir);
+        const sourceStore = loadPersistedAuthProfileStore(sourceAgentDir, {
+          resolveLegacyOAuthSidecars: false,
+        });
         const portable = sourceStore
           ? buildPortableAuthProfileSecretsStoreForAgentCopy(sourceStore)
           : undefined;


### PR DESCRIPTION
## Summary
- Restore read-only runtime compatibility for legacy Codex OAuth profiles that store token material in `oauthRef` sidecars.
- Keep new OAuth persistence on the canonical inline `auth-profiles.json` path, and keep metadata/copy paths from treating sidecar-backed credentials as portable.
- Let refresh of a legacy sidecar-backed profile rewrite the refreshed credential inline, while `openclaw doctor --fix` remains the explicit migration and sidecar cleanup path.

## Verification
- `node scripts/run-vitest.mjs src/agents/auth-profiles/oauth-manager.test.ts src/commands/agents.add.test.ts src/agents/auth-profiles.store.save.test.ts src/agents/auth-profiles/persisted-boundary.test.ts src/agents/auth-profiles/profiles.test.ts src/commands/doctor-auth-oauth-sidecar.test.ts`
- `pnpm tsgo:test --pretty false`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode local --reviewer codex --fallback-reviewer none`

## Real behavior proof
Behavior addressed: Legacy Codex OAuth profiles whose token material lives in an `oauthRef` sidecar continue to work after upgrade, refresh back to inline credentials, and do not break another agent that still references the same sidecar.
Real environment tested: Local macOS checkout with isolated `OPENCLAW_STATE_DIR` and `OPENCLAW_OAUTH_DIR`, real OpenAI Codex OAuth credentials, and `openai-codex/gpt-5.4-mini` live agent runs.
Exact steps or command run after this patch: Ran `pnpm openclaw agent --local --agent main|worker --message ... --json --timeout 180` against isolated legacy sidecar fixtures; forced one profile expiry by setting `expires = 1`; inspected resulting auth file shapes without printing token material.
Evidence after fix: Live runs returned `OPENCLAW_FINAL_LEGACY_OK`, `OPENCLAW_FORCED_REFRESH_OK`, `OPENCLAW_NOADOPT_WORKER_BEFORE_OK`, `OPENCLAW_NOADOPT_MAIN_REFRESH_OK`, and `OPENCLAW_NOADOPT_WORKER_AFTER_OK`.
Observed result after fix: Non-expired legacy sidecar profiles authenticate; forced refresh rewrites the refreshed profile inline and removes `oauthRef`; a second agent with mismatched identity metadata remains `oauthRef`-backed and still authenticates from the retained shared sidecar.
What was not tested: Full GitHub CI has not completed yet; the PR will be watched after creation.
