### PR TITLE
fix(doctor): anchor WhatsApp TUI process matching

### DIFF
--- a/src/commands/doctor-whatsapp-responsiveness.test.ts
+++ b/src/commands/doctor-whatsapp-responsiveness.test.ts
@@ -29,12 +29,17 @@ describe("doctor WhatsApp responsiveness", () => {
         " 102 /usr/bin/node /usr/lib/node_modules/openclaw/dist/index.js gateway --port 18789",
         " 103 openclaw channels",
         " 104 openclaw tui --local",
+        " 105 /usr/bin/openclaw chat",
+        " 106 helper --note 'openclaw tui'",
+        " 107 openclaw-helper openclaw terminal",
+        " 108 openclaw --flag tui",
       ].join("\n"),
     });
 
     expect(listLocalTuiProcesses()).toEqual([
       { pid: 101, command: "openclaw-tui" },
       { pid: 104, command: "openclaw tui --local" },
+      { pid: 105, command: "/usr/bin/openclaw chat" },
     ]);
   });
 

--- a/src/commands/doctor-whatsapp-responsiveness.ts
+++ b/src/commands/doctor-whatsapp-responsiveness.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import path from "node:path";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { note } from "../terminal/note.js";
@@ -15,8 +16,24 @@ type ProcessController = {
   kill: (pid: number, signal: ProcessSignal | 0) => boolean;
 };
 
-const LOCAL_TUI_CMD_RE =
-  /(?:^|\s)(?:openclaw-tui|openclaw\s+tui|openclaw\s+chat|openclaw\s+terminal)(?:\s|$)/;
+const LOCAL_TUI_SUBCOMMANDS = new Set(["chat", "terminal", "tui"]);
+
+function tokenizeCommandLine(command: string): string[] {
+  return command.trim().split(/\s+/u).filter(Boolean);
+}
+
+function normalizeExecutableName(value: string | undefined): string {
+  return path.basename(value ?? "").replace(/\.exe$/iu, "");
+}
+
+function isLocalTuiCommand(command: string): boolean {
+  const argv = tokenizeCommandLine(command);
+  const executable = normalizeExecutableName(argv[0]);
+  if (executable === "openclaw-tui") {
+    return true;
+  }
+  return executable === "openclaw" && LOCAL_TUI_SUBCOMMANDS.has(argv[1] ?? "");
+}
 
 function parsePsPidLine(line: string): LocalTuiProcess | null {
   const match = line.match(/^\s*(\d+)\s+(.+)$/);
@@ -28,7 +45,7 @@ function parsePsPidLine(line: string): LocalTuiProcess | null {
     return null;
   }
   const command = match[2]?.trim() ?? "";
-  if (!LOCAL_TUI_CMD_RE.test(command)) {
+  if (!isLocalTuiCommand(command)) {
     return null;
   }
   return { pid, command };


### PR DESCRIPTION
## Summary
- replace broad WhatsApp doctor TUI process regex matching with executable/subcommand-aware matching
- only match `openclaw-tui` or `openclaw` with known local TUI subcommands
- add regression coverage for unrelated commands whose argv contains matching words

Fixes #83283.

## Real behavior proof

![PR 83313 before/after proof](https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-83313-fresh/pr-83313/pr-83313-fix-doctor-anchor-whatsapp-tui-process-matching-before-after-proof.png)


Live WSL process-discovery proof added after ClawSweeper feedback:

```text
live ps rows used for proof:
 260353 openclaw-tui 45
 260354 openclaw tui
 260355 helper openclaw tui

listLocalTuiProcesses() result for proof pids:
[
  {
    "pid": 260353,
    "command": "openclaw-tui 45"
  },
  {
    "pid": 260354,
    "command": "openclaw tui"
  }
]
proof ok: real TUI processes detected; helper argv false positive ignored
```

Command: `bash .artifacts/pr-review/83313-live-ps-proof.sh` from the PR worktree under WSL Ubuntu. The helper process intentionally had `openclaw tui` in argv but was not returned because its executable was `helper`.
Fresh deterministic proof artifacts:
- Summary: https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-83313-fresh/pr-83313/summary.txt
- Before/source proof log: https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-83313-fresh/pr-83313/before-source-proof.log
- After/PR proof log: https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-83313-fresh/pr-83313/after-pr-83313.log

- Behavior or issue addressed: WhatsApp responsiveness repair should not select unrelated processes just because their argv contains words like `openclaw tui` or `openclaw terminal`.
- Real environment tested: WSL Ubuntu OpenClaw worktree at `/root/src/openclaw-branches/fix-whatsapp-tui-process-match-83283`.
- Exact steps or command run after this patch: `CI=1 node scripts/run-vitest.mjs src/commands/doctor-whatsapp-responsiveness.test.ts` and `pnpm check:changed`.
- Evidence after fix (terminal capture):

```text
RUN  v4.1.6 /root/src/openclaw-branches/fix-whatsapp-tui-process-match-83283

✓ commands  ../../src/commands/doctor-whatsapp-responsiveness.test.ts (4 tests) 102ms

Test Files  1 passed (1)
Tests  4 passed (4)

[check:changed] src/commands/doctor-whatsapp-responsiveness.test.ts: core test
[check:changed] src/commands/doctor-whatsapp-responsiveness.ts: core production
Import cycle check: 0 runtime value cycle(s).
```

- Observed result after fix: mocked `ps` rows such as `helper --note 'openclaw tui'`, `openclaw-helper openclaw terminal`, and `openclaw --flag tui` are ignored; actual `openclaw-tui`, `openclaw tui --local`, and `/usr/bin/openclaw chat` remain recognized.
- What was not tested: sending signals to real local TUI processes.
- Before evidence (terminal/code capture from `origin/main`):

```text
src/commands/doctor-whatsapp-responsiveness.ts before this patch used a broad command-line regex:
  /(?:^|\s)(?:openclaw-tui|openclaw\s+tui|openclaw\s+chat|openclaw\s+terminal)(?:\s|$)/

That matched unrelated argv text such as:
  helper --note 'openclaw tui'
  openclaw-helper openclaw terminal
```

## Root Cause
- Root cause: process discovery treated the full command line as free text and matched any occurrence of OpenClaw TUI terms, instead of checking the executable and expected subcommand position.
- Missing detection / guardrail: no regression coverage for unrelated processes containing matching words in argv.
- Contributing context: the repair path passes discovered PIDs directly into the termination helper.

## Regression Test Plan
- Coverage level that should have caught this: unit test.
- Target test or file: `src/commands/doctor-whatsapp-responsiveness.test.ts`.
- Scenario the test should lock in: process discovery accepts only expected TUI command shapes and rejects unrelated argv containing matching words.
- Why this is the smallest reliable guardrail: the bug is isolated to local process discovery before any signal is sent.

## Validation
- `CI=1 node scripts/run-vitest.mjs src/commands/doctor-whatsapp-responsiveness.test.ts`
- `pnpm check:changed`

