### PR TITLE
fix(migrate): count hidden config conflicts in preview

### DIFF
--- a/src/commands/migrate/output.test.ts
+++ b/src/commands/migrate/output.test.ts
@@ -81,6 +81,27 @@ describe("formatMigrationPreview", () => {
     expect(output).not.toContain("codex-plugins-root");
   });
 
+  it("counts hidden config conflicts in the preview header", () => {
+    const output = formatMigrationPreview({
+      ...plan([skillItem(1), { ...configItem(), status: "conflict", sensitive: true }]),
+      summary: {
+        total: 2,
+        planned: 1,
+        migrated: 0,
+        skipped: 0,
+        conflicts: 1,
+        errors: 0,
+        sensitive: 1,
+      },
+    })
+      .map(stripAnsi)
+      .join("\n");
+
+    expect(output).toContain("1 item, 1 conflict, 1 sensitive item");
+    expect(output).not.toContain("Config:");
+    expect(output).not.toContain("codex-plugins-root");
+  });
+
   it("renders migration warnings with a warning glyph", () => {
     const output = formatMigrationPreview({
       ...plan([skillItem(1)]),

--- a/src/commands/migrate/output.ts
+++ b/src/commands/migrate/output.ts
@@ -16,13 +16,11 @@ function formatPlanHeader(plan: MigrationPlan, heading: string): string[] {
     lines.push(`Target: ${plan.target}`);
   }
   const visible = plan.items.filter((item) => !HIDDEN_KINDS.has(item.kind));
-  const visibleConflicts = visible.filter((item) => item.status === "conflict").length;
-  const visibleSensitive = visible.filter((item) => item.sensitive === true).length;
   lines.push(
     [
       formatCount(visible.length, "item"),
-      formatCount(visibleConflicts, "conflict"),
-      formatCount(visibleSensitive, "sensitive item"),
+      formatCount(plan.summary.conflicts, "conflict"),
+      formatCount(plan.summary.sensitive, "sensitive item"),
     ].join(", "),
   );
   return lines;


### PR DESCRIPTION
## Summary
- keep config migration items hidden from text preview detail output
- use plan summary counts for preview header conflicts and sensitive items
- add regression coverage for hidden config conflicts in migration preview output

Fixes #83284.

## Real behavior proof

![PR 83314 before/after proof](https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-83314-fresh/pr-83314/pr-83314-fix-migrate-count-hidden-config-conflicts-in-pre-before-after-proof.png)

Fresh deterministic proof artifacts:
- Summary: https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-83314-fresh/pr-83314/summary.txt
- Before/source proof log: https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-83314-fresh/pr-83314/before-source-proof.log
- After/PR proof log: https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-83314-fresh/pr-83314/after-pr-83314.log

- Behavior or issue addressed: migration previews should not hide blocking conflict counts when the only conflicting item is hidden config.
- Real environment tested: WSL Ubuntu OpenClaw worktree at `/root/src/openclaw-branches/fix-migrate-hidden-conflict-count-83284`.
- Exact steps or command run after this patch: `CI=1 node scripts/run-vitest.mjs src/commands/migrate/output.test.ts` and `pnpm check:changed`.
- Evidence after fix (terminal capture):

```text
RUN  v4.1.6 /root/src/openclaw-branches/fix-migrate-hidden-conflict-count-83284

✓ unit-fast  ../../src/commands/migrate/output.test.ts (9 tests) 4ms

Test Files  1 passed (1)
Tests  9 passed (9)

[check:changed] src/commands/migrate/output.test.ts: core test
[check:changed] src/commands/migrate/output.ts: core production
Import cycle check: 0 runtime value cycle(s).
```

- Observed result after fix: a plan with one visible skill and one hidden conflicting sensitive config item renders `1 item, 1 conflict, 1 sensitive item` while still omitting `Config:` and `codex-plugins-root` from the preview details.
- What was not tested: a live Codex migration run against real config files.
- Before evidence (terminal/code capture from `origin/main`):

```text
src/commands/migrate/output.ts before this patch counted only visible items:
  const visible = plan.items.filter((item) => !HIDDEN_KINDS.has(item.kind));
  const visibleConflicts = visible.filter((item) => item.status === "conflict").length;
  const visibleSensitive = visible.filter((item) => item.sensitive === true).length;

A hidden config conflict could therefore render as:
  1 item, 0 conflicts, 0 sensitive items
while assertConflictFreePlan still blocks on plan.summary.conflicts > 0.
```

## Root Cause
- Root cause: the text preview header derived conflict and sensitive counts from visible items, while apply-time blocking uses `plan.summary`.
- Missing detection / guardrail: no preview test covered hidden config items that were conflicts or sensitive.
- Contributing context: config item details are intentionally hidden, but the summary count also became hidden by using the filtered item list.

## Regression Test Plan
- Coverage level that should have caught this: unit test.
- Target test or file: `src/commands/migrate/output.test.ts`.
- Scenario the test should lock in: hidden config details remain redacted while summary conflict/sensitive counts stay accurate.
- Why this is the smallest reliable guardrail: the bug is isolated to text formatting and does not require a full migration run.

## Validation
- `CI=1 node scripts/run-vitest.mjs src/commands/migrate/output.test.ts`
- `pnpm check:changed`
