### PR TITLE
Target managed service package root during updates

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -1886,6 +1886,57 @@ describe("update-cli", () => {
     ).toContain("Low disk space near");
   });
 
+  it("targets the managed service package root when it differs from the shell CLI root", async () => {
+    const tempDir = await createTrackedTempDir("openclaw-update-managed-root-");
+    const shellRoot = path.join(tempDir, "nvm", "lib", "node_modules", "openclaw");
+    const serviceRoot = path.join(tempDir, "managed", "lib", "node_modules", "openclaw");
+    const serviceEntry = path.join(serviceRoot, "dist", "index.js");
+    mockPackageInstallStatus(shellRoot);
+    await fs.mkdir(path.dirname(serviceEntry), { recursive: true });
+    await fs.writeFile(
+      path.join(serviceRoot, "package.json"),
+      JSON.stringify({ name: "openclaw", version: "1.0.0" }),
+      "utf-8",
+    );
+    await fs.writeFile(serviceEntry, "export {};\n", "utf-8");
+    const serviceRootReal = await fs.realpath(serviceRoot);
+    serviceReadCommand.mockResolvedValue({
+      programArguments: [process.execPath, serviceEntry, "gateway", "run"],
+    });
+    serviceLoaded.mockResolvedValue(true);
+    serviceReadRuntime.mockResolvedValue({
+      status: "running",
+      pid: 4242,
+      state: "running",
+    });
+
+    await updateCommand({ yes: true });
+
+    expect(resolveGlobalManager).toHaveBeenCalledWith(
+      expect.objectContaining({
+        root: serviceRootReal,
+        installKind: "package",
+      }),
+    );
+    expect(readPackageVersion).toHaveBeenCalledWith(serviceRootReal);
+    expect(readPackageVersion).not.toHaveBeenCalledWith(shellRoot);
+    expectPackageInstallSpec("openclaw@latest");
+    const logs = vi.mocked(defaultRuntime.log).mock.calls.map((call) => String(call[0]));
+    const managedRootLogIndex = logs.findIndex((line) =>
+      line.includes(
+        `Managed gateway service uses ${serviceRootReal}; updating that package root instead of ${shellRoot}.`,
+      ),
+    );
+    expect(managedRootLogIndex).toBeGreaterThanOrEqual(0);
+    const managedRootLogOrder = vi.mocked(defaultRuntime.log).mock.invocationCallOrder[
+      managedRootLogIndex
+    ];
+    const serviceStopOrder = serviceStop.mock.invocationCallOrder[0];
+    expect(requireValue(managedRootLogOrder, "managed root log order")).toBeLessThan(
+      requireValue(serviceStopOrder, "service stop order"),
+    );
+  });
+
   it("allows package updates from inherited gateway service env when the managed gateway is not running", async () => {
     mockPackageInstallStatus(createCaseDir("openclaw-update"));
     serviceReadRuntime.mockResolvedValueOnce({

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -32,6 +32,7 @@ import { GATEWAY_SERVICE_KIND, GATEWAY_SERVICE_MARKER } from "../../daemon/const
 import { resolveGatewayInstallEntrypoint } from "../../daemon/gateway-entrypoint.js";
 import { disableCurrentOpenClawUpdateLaunchdJob } from "../../daemon/launchd.js";
 import { resolveGatewayRestartLogPath } from "../../daemon/restart-logs.js";
+import { summarizeGatewayServiceLayout } from "../../daemon/service-layout.js";
 import {
   readGatewayServiceState,
   resolveGatewayService,
@@ -747,6 +748,75 @@ type PrePackageServiceStop = {
   blockMessage?: string;
   serviceEnv?: NodeJS.ProcessEnv;
 };
+
+type ManagedServicePackageRootSelection = {
+  root: string;
+  previousRoot: string;
+};
+
+async function resolveComparableRootPath(root: string): Promise<string> {
+  const resolved = path.resolve(root);
+  try {
+    return await fs.realpath(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
+function sameResolvedRoot(left: string, right: string): boolean {
+  return path.resolve(left) === path.resolve(right);
+}
+
+async function resolveManagedServicePackageUpdateRoot(params: {
+  root: string;
+}): Promise<ManagedServicePackageRootSelection | null> {
+  let command: Awaited<ReturnType<GatewayService["readCommand"]>>;
+  try {
+    command = await resolveGatewayService().readCommand(process.env);
+  } catch {
+    return null;
+  }
+
+  if (!command) {
+    return null;
+  }
+
+  let layout: Awaited<ReturnType<typeof summarizeGatewayServiceLayout>>;
+  try {
+    layout = await summarizeGatewayServiceLayout(command);
+  } catch {
+    return null;
+  }
+
+  if (!layout?.packageRoot || layout.entrypointSourceCheckout) {
+    return null;
+  }
+
+  const previousRootReal = await resolveComparableRootPath(params.root);
+  const rootReal = layout.packageRootReal ?? (await resolveComparableRootPath(layout.packageRoot));
+  if (sameResolvedRoot(previousRootReal, rootReal)) {
+    return null;
+  }
+
+  return {
+    root: layout.packageRoot,
+    previousRoot: params.root,
+  };
+}
+
+function logManagedServicePackageRootSelection(
+  selection: ManagedServicePackageRootSelection | null,
+  jsonMode: boolean,
+): void {
+  if (!selection || jsonMode) {
+    return;
+  }
+  defaultRuntime.log(
+    theme.muted(
+      `Managed gateway service uses ${selection.root}; updating that package root instead of ${selection.previousRoot}.`,
+    ),
+  );
+}
 
 function formatGatewayAncestryBlockMessage(pid: number): string {
   return `openclaw update detected it is running inside the gateway process tree.
@@ -2722,7 +2792,7 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
   }
   const updateStepTimeoutMs = timeoutMs ?? DEFAULT_UPDATE_STEP_TIMEOUT_MS;
 
-  const root = await resolveUpdateRoot();
+  let root = await resolveUpdateRoot();
   if (postCoreUpdateResume) {
     if (
       postCoreUpdateChannel !== "stable" &&
@@ -2844,6 +2914,12 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
   const devTargetRef =
     channel === "dev" ? process.env.OPENCLAW_UPDATE_DEV_TARGET_REF?.trim() || undefined : undefined;
 
+  const managedServicePackageRootSelection =
+    updateInstallKind === "package" ? await resolveManagedServicePackageUpdateRoot({ root }) : null;
+  if (managedServicePackageRootSelection) {
+    root = managedServicePackageRootSelection.root;
+  }
+
   const explicitTag = normalizeTag(opts.tag);
   let tag = explicitTag ?? channelToNpmTag(channel);
   let currentVersion: string | null = null;
@@ -2932,6 +3008,11 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
     if (explicitTag && !canResolveRegistryVersionForPackageTarget(tag)) {
       notes.push("Non-registry package specs skip npm version lookup and downgrade previews.");
     }
+    if (managedServicePackageRootSelection) {
+      notes.push(
+        `Managed gateway service package root differs from this CLI root; package update targets ${managedServicePackageRootSelection.root}.`,
+      );
+    }
 
     printDryRunPreview(
       {
@@ -3008,6 +3089,7 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
     defaultRuntime.log(theme.heading("Updating OpenClaw..."));
     defaultRuntime.log("");
   }
+  logManagedServicePackageRootSelection(managedServicePackageRootSelection, Boolean(opts.json));
 
   const { progress, stop } = createUpdateProgress(showProgress);
   const startedAt = Date.now();


### PR DESCRIPTION
## Summary
- detect the managed gateway service package root before package updates
- when the service package root differs from the shell CLI root, update the service package root instead
- log the selected managed-service root before stopping the gateway service, and show it in dry-run notes
- add a CLI regression test for the shell-root/service-root mismatch

## Why
A machine can have multiple OpenClaw package installs at once, for example a pnpm or nvm global CLI plus a managed gateway service package root. Package updates should mutate the package root that the managed service actually runs, not whichever shim happened to invoke `openclaw update`.

This keeps source-checkout service commands out of package-root redirection, so dev checkout service layouts still use the existing git/dev update path.

## Verification
- `pnpm test src/cli/update-cli.test.ts -- --reporter=verbose`
  - `[test] passed 1 Vitest shard in 34.68s`
  - `src/cli/update-cli.test.ts`: `109 passed`
  - includes `targets the managed service package root when it differs from the shell CLI root`
- `pnpm exec oxfmt --check --threads=1 src/cli/update-cli/update-command.ts src/cli/update-cli.test.ts`
  - `All matched files use the correct format.`
- `pnpm tsgo:core`
  - `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `git diff --check`
  - no output

## Real behavior proof
- **Behavior or issue addressed**: A managed gateway service can run from a package root that is different from the CLI root used to invoke `openclaw update`. In that setup, package-mode update planning must select the managed service package root, not the invoking CLI/source root.
- **Real environment tested**: macOS 26.3.1 (Darwin 25.3.0 arm64), Node v23.11.1, npm 10.9.2, pnpm 11.1.0, PR branch `codex/update-managed-service-root` at `f0c4a31bceb1`. Shell `openclaw` shims were `$HOME/.local/bin/openclaw`, `$HOME/Library/pnpm/openclaw`, and `$HOME/.nvm/versions/node/v23.11.1/bin/openclaw`; the managed LaunchAgent package root was `$HOME/.openclaw/npm/node_modules/openclaw`.
- **Exact steps or command run after this patch**: Ran `pnpm openclaw gateway status --deep --json` from this PR branch and extracted the real service command, then ran `pnpm openclaw update --dry-run --channel stable --yes --timeout 10000`. The dry-run path exercises the real service definition and root selection without stopping or mutating the active LaunchAgent install.
- **Evidence after fix**: Copied live terminal output, with `$HOME` redacted:

```text
$ pnpm openclaw gateway status --deep --json
{
  "cli": {
    "version": "2026.5.17",
    "entrypoint": "$HOME/workspace/openclaw/openclaw.mjs"
  },
  "service": {
    "label": "LaunchAgent",
    "loaded": true,
    "programArguments": [
      "$HOME/.nvm/versions/node/v23.11.1/bin/node",
      "$HOME/.openclaw/npm/node_modules/openclaw/dist/index.js",
      "gateway",
      "--port",
      "18789"
    ],
    "workingDirectory": "$HOME/.openclaw",
    "sourcePath": "$HOME/Library/LaunchAgents/ai.openclaw.gateway.plist"
  }
}

$ pnpm openclaw update --dry-run --channel stable --yes --timeout 10000
Update dry-run
No changes were applied.

  Root: $HOME/.openclaw/npm/node_modules/openclaw
  Install kind: git
  Mode: npm
  Channel: stable
  Tag/spec: openclaw@latest
  Target version: 2026.5.12

Planned actions:
  - Persist update.channel=stable in config
  - Switch install mode from git to package manager (npm)
  - Run plugin update sync after core update
  - Refresh shell completion cache (if needed)
  - Restart gateway service and run doctor checks

Notes:
  - Managed gateway service package root differs from this CLI root; package update targets $HOME/.openclaw/npm/node_modules/openclaw.
```

- **Observed result after fix**: The real LaunchAgent service command resolves to `$HOME/.openclaw/npm/node_modules/openclaw/dist/index.js`, while the invoking PR-branch CLI entrypoint is `$HOME/workspace/openclaw/openclaw.mjs` and shell shims also point elsewhere. The after-fix dry-run selected `Root: $HOME/.openclaw/npm/node_modules/openclaw` and emitted the managed-root mismatch note before any stop/update step, proving the package update plan targets the service package root. The command reported `No changes were applied.`
- **What was not tested**: A destructive full package replacement was intentionally skipped on the live user machine. The real after-fix proof uses dry-run because it exercises the actual LaunchAgent service command parser and root-selection logic without stopping or mutating the active gateway install.
