### PR TITLE
fix(push): use valid default VAPID subject [AI-assisted]

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -215,7 +215,7 @@ Override the VAPID keypair through env vars on the Gateway process when you want
 
 - `OPENCLAW_VAPID_PUBLIC_KEY`
 - `OPENCLAW_VAPID_PRIVATE_KEY`
-- `OPENCLAW_VAPID_SUBJECT` (defaults to `mailto:openclaw@localhost`)
+- `OPENCLAW_VAPID_SUBJECT` (defaults to `https://openclaw.ai`)
 
 The Control UI uses these scope-gated Gateway methods to register and test browser subscriptions:
 

--- a/src/infra/push-web.test.ts
+++ b/src/infra/push-web.test.ts
@@ -58,7 +58,11 @@ describe("resolveVapidKeys", () => {
     const keys = await resolveVapidKeys(tmpDir);
     expect(keys.publicKey).toBe("test-public-key-base64url");
     expect(keys.privateKey).toBe("test-private-key-base64url");
-    expect(keys.subject).toMatch(/^mailto:/);
+    expect(keys.subject).toBe("https://openclaw.ai");
+    const persistedKeys = JSON.parse(
+      await fs.readFile(path.join(tmpDir, "push", "vapid-keys.json"), "utf8"),
+    ) as { subject?: string };
+    expect(persistedKeys.subject).toBe("https://openclaw.ai");
 
     // Second call returns same keys.
     const keys2 = await resolveVapidKeys(tmpDir);
@@ -211,7 +215,7 @@ describe("sending", () => {
     expect(result.ok).toBe(true);
     expect(vi.mocked(webPush.setVapidDetails)).toHaveBeenCalledTimes(1);
     expect(vi.mocked(webPush.setVapidDetails)).toHaveBeenCalledWith(
-      "mailto:openclaw@localhost",
+      "https://openclaw.ai",
       "test-public-key-base64url",
       "test-private-key-base64url",
     );

--- a/src/infra/push-web.ts
+++ b/src/infra/push-web.ts
@@ -36,7 +36,7 @@ const WEB_PUSH_STATE_FILENAME = "push/web-push-subscriptions.json";
 const VAPID_KEYS_FILENAME = "push/vapid-keys.json";
 const MAX_ENDPOINT_LENGTH = 2048;
 const MAX_KEY_LENGTH = 512;
-const DEFAULT_VAPID_SUBJECT = "mailto:openclaw@localhost";
+const DEFAULT_VAPID_SUBJECT = "https://openclaw.ai";
 
 const withLock = createAsyncLock();
 


### PR DESCRIPTION
## Summary

- Problem: Web Push VAPID keys defaulted to `mailto:openclaw@localhost`, which Apple Web Push rejects for iOS PWA pushes.
- Why it matters: first-install Control UI PWA push can fail before operators know they need an override.
- What changed: the built-in VAPID subject default is now `https://openclaw.ai`; focused tests and Control UI docs were updated.
- What did NOT change: `OPENCLAW_VAPID_SUBJECT` still overrides the default, and no new config surface was added.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #83134
- Related #83181
- [x] This PR fixes a bug or regression

## Real behavior proof

- Behavior or issue addressed: no-env Web Push VAPID key generation should no longer produce a localhost subject.
- Real environment tested: local OpenClaw checkout on current `origin/main`, Node 22.
- Exact steps or command run after this patch:

```bash
node --import tsx --input-type=module -e "import { resolveVapidKeys } from './src/infra/push-web.ts'; /* run in disposable state with VAPID env vars cleared, then with OPENCLAW_VAPID_SUBJECT set */"
```

- Evidence after fix:

```text
source: src/infra/push-web.ts
no-env returned subject: https://openclaw.ai
no-env persisted subject: https://openclaw.ai
env override subject: mailto:ops@example.com
```

- Observed result after fix: the patched OpenClaw source returns and persists an Apple-acceptable `https:` subject by default, while the env override path still wins.
- What was not tested: I did not send a live Apple Web Push request.
- Before evidence: current main and v2026.5.12 default to `mailto:openclaw@localhost`, as documented on #83134.

## Root Cause

- Root cause: the module-private Web Push VAPID fallback subject used a localhost mailbox.
- Missing detection / guardrail: the existing test only required a `mailto:` subject, so it accepted the invalid localhost default.
- Contributing context: `OPENCLAW_VAPID_SUBJECT` already existed as an operator override; the broken path was the no-env default.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/push-web.test.ts`
- Scenario the test should lock in: generated and sent Web Push VAPID details use `https://openclaw.ai` when no env override is set.
- Why this is the smallest reliable guardrail: the bug is the default subject selected by `resolveVapidKeys()` and passed to `web-push`.
- Existing test that already covers this: `src/gateway/server-methods/push.test.ts` still covers the adjacent push handler path.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

New Web Push VAPID keys generated without `OPENCLAW_VAPID_SUBJECT` now use `https://openclaw.ai` instead of `mailto:openclaw@localhost`.

## Diagram

N/A

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: local Windows desktop
- Runtime/container: Node 22
- Model/provider: N/A
- Integration/channel: Control UI Web Push
- Relevant config: `OPENCLAW_VAPID_*` env vars cleared for the default case; `OPENCLAW_VAPID_SUBJECT=mailto:ops@example.com` for override check

### Steps

1. Clear `OPENCLAW_VAPID_PUBLIC_KEY`, `OPENCLAW_VAPID_PRIVATE_KEY`, and `OPENCLAW_VAPID_SUBJECT`.
2. Import `resolveVapidKeys()` from `src/infra/push-web.ts`.
3. Resolve keys in a disposable state dir and read the generated `push/vapid-keys.json`.
4. Set `OPENCLAW_VAPID_SUBJECT=mailto:ops@example.com` and resolve again.

### Expected

- Default returned and persisted subject is a valid non-localhost VAPID subject.
- Env override still wins.

### Actual

- Default returned and persisted subject: `https://openclaw.ai`
- Env override subject: `mailto:ops@example.com`

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers

Focused checks:

```text
node scripts/run-vitest.mjs src/infra/push-web.test.ts src/gateway/server-methods/push.test.ts
Test Files  3 passed (3)
Tests  27 passed (27)

git diff --check
clean
```

## Human Verification

- Verified scenarios: default VAPID key generation, persisted subject, direct send VAPID details, env subject override.
- Edge cases checked: no-env default and explicit env override.
- What you did **not** verify: live Apple Web Push delivery.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? Yes, the no-env default value changes; no new env var or config key is added.
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: operators who expected the localhost default value may see a different generated subject.
  - Mitigation: `OPENCLAW_VAPID_SUBJECT` remains the explicit override for operator-specific subjects.
