### PR TITLE
fix(openai): allow available Codex OAuth models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Mac app: align the Sessions settings pane with the standard Settings page gutter and row spacing.
+- OpenAI/Codex: stop rejecting available `openai-codex` GPT-5.1, GPT-5.2, and GPT-5.3 model refs during config validation, while keeping removed Spark aliases suppressed. Fixes #83303.
 - Codex app-server: preserve streamed native command output in mirrored transcripts and trajectory exports when final snapshots omit aggregated output. (#83200) Thanks @rozmiarD.
 - Codex app-server: fail closed when chat or sender policy denies tools, disabling native code, app, environment, and user MCP surfaces for restricted turns. (#82374) Thanks @VACInc.
 - Codex app-server: keep recent context-engine messages when oversized projected history is truncated, so short follow-ups in long channel sessions do not fall back to stale earlier turns. (#83127) Thanks @VACInc.

--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -149,7 +149,7 @@ Anthropic staff told us OpenClaw-style Claude CLI usage is allowed again, so Ope
 - Policy note: OpenAI Codex OAuth is explicitly supported for external tools/workflows like OpenClaw.
 - For the common subscription plus native Codex runtime route, sign in with `openai-codex` auth but configure `openai/gpt-5.5`; OpenAI agent turns select Codex by default.
 - Use provider/model `agentRuntime.id: "pi"` only when you want a compatibility route through PI; otherwise keep `openai/gpt-5.5` on the default Codex harness.
-- Older `openai-codex/gpt-5.1*`, `openai-codex/gpt-5.2*`, and `openai-codex/gpt-5.3*` refs are suppressed because ChatGPT/Codex OAuth accounts reject them; use `openai-codex/gpt-5.5` or the native Codex runtime route instead.
+- `openai-codex/gpt-*` refs remain a legacy PI route. Prefer `openai/gpt-5.5` on the native Codex runtime for new agent config, and run `openclaw doctor --fix` when you want to migrate old `openai-codex/*` refs to canonical `openai/*` refs.
 
 ```json5
 {

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -248,10 +248,10 @@ Choose your preferred auth method and follow the setup steps.
     | `codex-cli/gpt-5.5` | repaired by doctor | Legacy CLI route rewritten to `openai/gpt-5.5` | Codex app-server auth |
 
     <Warning>
-    Do not configure older `openai-codex/gpt-5.1*`, `openai-codex/gpt-5.2*`, or
-    `openai-codex/gpt-5.3*` model refs. ChatGPT/Codex OAuth accounts now reject
-    those models. Use `openai/gpt-5.5`; OpenAI agent turns now select the Codex
-    runtime by default.
+    Prefer `openai/gpt-5.5` for new subscription-backed agent config. Older
+    `openai-codex/gpt-*` refs are legacy PI routes, not the native Codex runtime
+    path; run `openclaw doctor --fix` when you want to migrate them to canonical
+    `openai/*` refs.
     </Warning>
 
     <Note>

--- a/extensions/openai/openclaw.plugin.json
+++ b/extensions/openai/openclaw.plugin.json
@@ -733,56 +733,6 @@
         "provider": "openai-codex",
         "model": "gpt-5.3-codex-spark",
         "reason": "gpt-5.3-codex-spark is no longer exposed by the OpenAI or Codex catalogs. Use openai/gpt-5.5."
-      },
-      {
-        "provider": "openai-codex",
-        "model": "gpt-5.1",
-        "reason": "gpt-5.1 is no longer supported for ChatGPT/Codex OAuth accounts. Use openai/gpt-5.5 through the Codex runtime."
-      },
-      {
-        "provider": "openai-codex",
-        "model": "gpt-5.1-codex",
-        "reason": "gpt-5.1-codex is no longer supported for ChatGPT/Codex OAuth accounts. Use openai/gpt-5.5 through the Codex runtime."
-      },
-      {
-        "provider": "openai-codex",
-        "model": "gpt-5.1-codex-mini",
-        "reason": "gpt-5.1-codex-mini is no longer supported for ChatGPT/Codex OAuth accounts. Use openai/gpt-5.5 through the Codex runtime."
-      },
-      {
-        "provider": "openai-codex",
-        "model": "gpt-5.1-codex-max",
-        "reason": "gpt-5.1-codex-max is no longer supported for ChatGPT/Codex OAuth accounts. Use openai/gpt-5.5 through the Codex runtime."
-      },
-      {
-        "provider": "openai-codex",
-        "model": "gpt-5.2",
-        "reason": "gpt-5.2 is no longer supported for ChatGPT/Codex OAuth accounts. Use openai/gpt-5.5 through the Codex runtime."
-      },
-      {
-        "provider": "openai-codex",
-        "model": "gpt-5.2-codex",
-        "reason": "gpt-5.2-codex is no longer supported for ChatGPT/Codex OAuth accounts. Use openai/gpt-5.5 through the Codex runtime."
-      },
-      {
-        "provider": "openai-codex",
-        "model": "gpt-5.2-pro",
-        "reason": "gpt-5.2-pro is no longer supported for ChatGPT/Codex OAuth accounts. Use openai/gpt-5.5 through the Codex runtime."
-      },
-      {
-        "provider": "openai-codex",
-        "model": "gpt-5.3",
-        "reason": "gpt-5.3 is no longer supported for ChatGPT/Codex OAuth accounts. Use openai/gpt-5.5 through the Codex runtime."
-      },
-      {
-        "provider": "openai-codex",
-        "model": "gpt-5.3-codex",
-        "reason": "gpt-5.3-codex is no longer supported for ChatGPT/Codex OAuth accounts. Use openai/gpt-5.5 through the Codex runtime."
-      },
-      {
-        "provider": "openai-codex",
-        "model": "gpt-5.3-chat-latest",
-        "reason": "gpt-5.3-chat-latest is no longer supported for ChatGPT/Codex OAuth accounts. Use openai/gpt-5.5 through the Codex runtime."
       }
     ]
   },

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -29,28 +29,11 @@ function isSuppressedModel(provider?: string, id?: string): boolean {
   if (!modelId) {
     return false;
   }
-  if (
+  return (
     (provider === "openai" ||
       provider === "azure-openai-responses" ||
       provider === "openai-codex") &&
     modelId === "gpt-5.3-codex-spark"
-  ) {
-    return true;
-  }
-  return (
-    provider === "openai-codex" &&
-    [
-      "gpt-5.1",
-      "gpt-5.1-codex",
-      "gpt-5.1-codex-mini",
-      "gpt-5.1-codex-max",
-      "gpt-5.2",
-      "gpt-5.2-codex",
-      "gpt-5.2-pro",
-      "gpt-5.3",
-      "gpt-5.3-codex",
-      "gpt-5.3-chat-latest",
-    ].includes(modelId)
   );
 }
 
@@ -790,7 +773,7 @@ describe("loadModelCatalog", () => {
     expectNoCatalogEntry(result, "openai-codex", "gpt-5.3-codex-spark");
   });
 
-  it("filters stale openai-codex 5.1/5.2/5.3 built-ins from the catalog", async () => {
+  it("keeps available openai-codex 5.1/5.2/5.3 built-ins in the catalog", async () => {
     mockPiDiscoveryModels([
       {
         id: "gpt-5.1-codex-mini",
@@ -827,9 +810,11 @@ describe("loadModelCatalog", () => {
     ]);
 
     const result = await loadModelCatalog({ config: {} as OpenClawConfig });
-    expectNoCatalogEntry(result, "openai-codex", "gpt-5.1-codex-mini");
-    expectNoCatalogEntry(result, "openai-codex", "gpt-5.2-codex");
-    expectNoCatalogEntry(result, "openai-codex", "gpt-5.3-codex");
+    expect(requireCatalogEntry(result, "openai-codex", "gpt-5.1-codex-mini").name).toBe(
+      "GPT-5.1 Codex Mini",
+    );
+    expect(requireCatalogEntry(result, "openai-codex", "gpt-5.2-codex").name).toBe("GPT-5.2 Codex");
+    expect(requireCatalogEntry(result, "openai-codex", "gpt-5.3-codex").name).toBe("GPT-5.3 Codex");
     expect(requireCatalogEntry(result, "openai-codex", "gpt-5.5").name).toBe("GPT-5.5");
   });
 

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -52,25 +52,6 @@ vi.mock("../model-suppression.js", () => {
     return undefined;
   }
 
-  const staleOpenAICodexModelIds = new Set([
-    "gpt-5.1",
-    "gpt-5.1-codex",
-    "gpt-5.1-codex-mini",
-    "gpt-5.1-codex-max",
-    "gpt-5.2",
-    "gpt-5.2-codex",
-    "gpt-5.2-pro",
-    "gpt-5.3",
-    "gpt-5.3-codex",
-    "gpt-5.3-chat-latest",
-  ]);
-
-  function isStaleOpenAICodexModel(provider?: string, id?: string): boolean {
-    return (
-      provider === "openai-codex" && staleOpenAICodexModelIds.has(id?.trim().toLowerCase() ?? "")
-    );
-  }
-
   return {
     shouldSuppressBuiltInModel: ({
       provider,
@@ -83,9 +64,6 @@ vi.mock("../model-suppression.js", () => {
       baseUrl?: string;
       config?: unknown;
     }) => {
-      if (isStaleOpenAICodexModel(provider, id)) {
-        return true;
-      }
       if (
         (provider === "openai" ||
           provider === "azure-openai-responses" ||
@@ -101,9 +79,6 @@ vi.mock("../model-suppression.js", () => {
       );
     },
     shouldUnconditionallySuppress: ({ provider, id }: { provider?: string; id?: string }) => {
-      if (isStaleOpenAICodexModel(provider, id)) {
-        return true;
-      }
       if (
         (provider === "openai" ||
           provider === "azure-openai-responses" ||
@@ -129,10 +104,6 @@ vi.mock("../model-suppression.js", () => {
         isQwenCodingPlanBaseUrl(resolveConfiguredQwenBaseUrl(config))
       ) {
         return "Unknown model: qwen/qwen3.6-plus. qwen3.6-plus is not supported on the Qwen Coding Plan endpoint; use a Standard pay-as-you-go Qwen endpoint or choose qwen/qwen3.5-plus.";
-      }
-      if (isStaleOpenAICodexModel(provider, id)) {
-        const modelId = id?.trim().toLowerCase() ?? "";
-        return `Unknown model: openai-codex/${modelId}. ${modelId} is no longer supported for ChatGPT/Codex OAuth accounts. Use openai/gpt-5.5 through the Codex runtime.`;
       }
       if (
         (provider === "openai" ||
@@ -1954,7 +1925,7 @@ describe("resolveModel", () => {
     });
   });
 
-  it("rejects stale exact openai-codex gpt-5.3-codex registry metadata", () => {
+  it("accepts available exact openai-codex gpt-5.3-codex registry metadata", () => {
     vi.mocked(discoverModels).mockReturnValue({
       find: vi.fn((provider: string, modelId: string) => {
         if (provider !== "openai-codex") {
@@ -1974,10 +1945,12 @@ describe("resolveModel", () => {
 
     const result = resolveModelForTest("openai-codex", "gpt-5.3-codex", "/tmp/agent");
 
-    expect(result.model).toBeUndefined();
-    expect(result.error).toBe(
-      "Unknown model: openai-codex/gpt-5.3-codex. gpt-5.3-codex is no longer supported for ChatGPT/Codex OAuth accounts. Use openai/gpt-5.5 through the Codex runtime.",
-    );
+    expect(result.error).toBeUndefined();
+    expectRecordFields(result.model, {
+      provider: "openai-codex",
+      id: "gpt-5.3-codex",
+      contextWindow: 272000,
+    });
   });
 
   it("canonicalizes the legacy openai-codex gpt-5.4-codex alias at runtime", () => {

--- a/src/config/config.model-ref-validation.test.ts
+++ b/src/config/config.model-ref-validation.test.ts
@@ -2,9 +2,6 @@ import { describe, expect, it } from "vitest";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { validateConfigObjectWithPlugins } from "./validation.js";
 
-const staleOpenAICodexReason =
-  "is no longer supported for ChatGPT/Codex OAuth accounts. Use openai/gpt-5.5 through the Codex runtime.";
-
 function createModelSuppressionRegistry(): PluginManifestRegistry {
   return {
     diagnostics: [],
@@ -28,16 +25,6 @@ function createModelSuppressionRegistry(): PluginManifestRegistry {
               model: "gpt-5.3-codex-spark",
               reason:
                 "gpt-5.3-codex-spark is no longer exposed by the OpenAI or Codex catalogs. Use openai/gpt-5.5.",
-            },
-            {
-              provider: "openai-codex",
-              model: "gpt-5.2-codex",
-              reason: `gpt-5.2-codex ${staleOpenAICodexReason}`,
-            },
-            {
-              provider: "openai-codex",
-              model: "gpt-5.3-codex",
-              reason: `gpt-5.3-codex ${staleOpenAICodexReason}`,
             },
           ],
         },
@@ -99,7 +86,7 @@ describe("config model reference validation", () => {
     expect(res.ok).toBe(true);
   });
 
-  it("rejects stale openai-codex fallback model pairs", () => {
+  it("accepts available openai-codex fallback model pairs", () => {
     const res = validateConfigObjectWithPlugins(
       {
         agents: {
@@ -118,21 +105,6 @@ describe("config model reference validation", () => {
       },
     );
 
-    expect(res.ok).toBe(false);
-    if (res.ok) {
-      return;
-    }
-    expect(res.issues).toEqual([
-      {
-        path: "agents.defaults.model.fallbacks.0",
-        message:
-          "Unknown model: openai-codex/gpt-5.2-codex. gpt-5.2-codex is no longer supported for ChatGPT/Codex OAuth accounts. Use openai/gpt-5.5 through the Codex runtime.",
-      },
-      {
-        path: "agents.defaults.model.fallbacks.1",
-        message:
-          "Unknown model: openai-codex/gpt-5.3-codex. gpt-5.3-codex is no longer supported for ChatGPT/Codex OAuth accounts. Use openai/gpt-5.5 through the Codex runtime.",
-      },
-    ]);
+    expect(res.ok).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Remove stale OpenAI/Codex suppressions for available GPT-5.1, GPT-5.2, and GPT-5.3 model refs.
- Keep removed Spark aliases suppressed.
- Update config validation, model catalog, runtime tests, docs, and changelog for #83303.

Fixes #83303

## Verification

- `node scripts/run-vitest.mjs src/config/config.model-ref-validation.test.ts src/agents/model-catalog.test.ts src/agents/pi-embedded-runner/model.test.ts`
- `git diff --check`
- `pnpm docs:list`

## Real behavior proof

Behavior addressed: Existing configs using available openai-codex GPT-5.1/GPT-5.2/GPT-5.3 refs no longer fail config validation solely because of stale manifest suppressions; removed Spark aliases remain rejected.
Real environment tested: Local source checkout on macOS, targeted Vitest via repo node wrapper.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/config/config.model-ref-validation.test.ts src/agents/model-catalog.test.ts src/agents/pi-embedded-runner/model.test.ts`
Evidence after fix: Config validation accepts openai-codex/gpt-5.2-codex and openai-codex/gpt-5.3-codex fallbacks; catalog/runtime tests keep available Codex rows and resolve openai-codex/gpt-5.3-codex.
Observed result after fix: 5 test files and 227 tests passed.
What was not tested: Live ChatGPT/Codex OAuth request to gpt-5.3-codex and full Docker setup path.
