### PR TITLE
test(config): keep agent model overrides selection-only

### DIFF
--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -390,6 +390,44 @@ describe("config schema", () => {
     ).toBe(false);
   });
 
+  it("keeps per-agent model overrides limited to model selection", () => {
+    const result = OpenClawSchema.safeParse({
+      agents: {
+        list: [
+          {
+            id: "main",
+            model: {
+              primary: "openai/gpt-5.5",
+              timeoutMs: 30_000,
+            },
+          },
+        ],
+      },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects per-agent subagent model timeout config", () => {
+    const result = OpenClawSchema.safeParse({
+      agents: {
+        list: [
+          {
+            id: "main",
+            subagents: {
+              model: {
+                primary: "openai/gpt-5.5",
+                timeoutMs: 30_000,
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
   it("accepts exec command highlighting config in global and agent scopes", () => {
     const tools = ToolsSchema.parse({
       exec: {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -982,7 +982,17 @@ export const AgentEntrySchema = z
       .object({
         delegationMode: z.enum(["suggest", "prefer"]).optional(),
         allowAgents: z.array(z.string()).optional(),
-        model: AgentModelSchema.optional(),
+        model: z
+          .union([
+            z.string(),
+            z
+              .object({
+                primary: z.string().optional(),
+                fallbacks: z.array(z.string()).optional(),
+              })
+              .strict(),
+          ])
+          .optional(),
         thinking: z.string().optional(),
         requireAgentId: z.boolean().optional(),
       })

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -982,17 +982,7 @@ export const AgentEntrySchema = z
       .object({
         delegationMode: z.enum(["suggest", "prefer"]).optional(),
         allowAgents: z.array(z.string()).optional(),
-        model: z
-          .union([
-            z.string(),
-            z
-              .object({
-                primary: z.string().optional(),
-                fallbacks: z.array(z.string()).optional(),
-              })
-              .strict(),
-          ])
-          .optional(),
+        model: AgentModelSchema.optional(),
         thinking: z.string().optional(),
         requireAgentId: z.boolean().optional(),
       })


### PR DESCRIPTION
## Summary
- keep `agents.list[].model` on the same selection-only schema as other agent model overrides
- keep `agents.list[].subagents.model` selection-only as well
- add regression coverage so `timeoutMs` stays limited to the tool/media model config surfaces that actually consume it

Follow-up to #83339. Supersedes the original timeout-support direction for #83291.

## Real behavior proof

Behavior addressed: agent and subagent model override config should not silently accept `timeoutMs`; timeout config belongs on the tool/media model schemas that consume it.
Real environment tested: WSL2 Ubuntu 24.04 OpenClaw checkout on this PR head `44c6d6753f4c`.
Exact steps or command run after this patch:

```text
cat > "$tmp/agent-model-timeout.json" <<'EOF'
{"agents":{"list":[{"id":"main","model":{"primary":"openai/gpt-5.5","timeoutMs":30000}}]}}
EOF
OPENCLAW_CONFIG_PATH="$tmp/agent-model-timeout.json" node openclaw.mjs config validate --json

cat > "$tmp/subagent-model-timeout.json" <<'EOF'
{"agents":{"list":[{"id":"main","subagents":{"model":{"primary":"openai/gpt-5.5","timeoutMs":30000}}}]}}
EOF
OPENCLAW_CONFIG_PATH="$tmp/subagent-model-timeout.json" node openclaw.mjs config validate --json

CI=1 OPENCLAW_VITEST_MAX_WORKERS=1 node node_modules/vitest/vitest.mjs run src/config/schema.test.ts --maxWorkers=1 --reporter=dot
git diff --check
```

Evidence after fix:

```text
agent-model-timeout.json
{
  "valid": false,
  "path": "/tmp/tmp.JzVJTwEgS8/agent-model-timeout.json",
  "issues": [
    {
      "path": "agents.list.0.model",
      "message": "Invalid input"
    }
  ]
}
exit=1

subagent-model-timeout.json
{
  "valid": false,
  "path": "/tmp/tmp.JzVJTwEgS8/subagent-model-timeout.json",
  "issues": [
    {
      "path": "agents.list.0.subagents.model",
      "message": "Invalid input"
    }
  ]
}
exit=1

Test Files  1 passed (1)
Tests  43 passed (43)
```

Observed result after fix: `openclaw config validate --json` rejects both invalid timeout locations, while the schema regression test locks the same contract.
What was not tested: live agent runtime execution, because this PR only locks the config schema contract and does not change runtime model execution.

## Root Cause
The original PR direction treated model selection objects like tool model config objects. Current main now separates those contracts: model selection chooses a model (`primary`/`fallbacks`), while timeout values belong to surfaces that own timeout behavior.

## Regression Test Plan
- Coverage level: focused config schema unit test plus real CLI validation for both invalid config paths.
- Target file: `src/config/schema.test.ts`.
- Scenario locked in: per-agent model and subagent model overrides reject `timeoutMs`.

## Validation
- `OPENCLAW_CONFIG_PATH="$tmp/agent-model-timeout.json" node openclaw.mjs config validate --json`
- `OPENCLAW_CONFIG_PATH="$tmp/subagent-model-timeout.json" node openclaw.mjs config validate --json`
- `CI=1 OPENCLAW_VITEST_MAX_WORKERS=1 node node_modules/vitest/vitest.mjs run src/config/schema.test.ts --maxWorkers=1 --reporter=dot`
- `git diff --check`