### PR TITLE
fix(telegram): bound isolated long-poll timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Docs: https://docs.openclaw.ai
 - Feishu: detect SecretRef top-level credentials as a configured default account instead of treating object-backed app secrets as missing.
 - Gateway/restart: keep ordinary unmanaged SIGUSR1/config restarts in-process instead of detach-spawning an orphaned child, preserving custom supervisor PID tracking while leaving update restarts on the fresh-process path. Fixes #65668.
 - CLI/completion: resolve concrete PowerShell profile paths and reload commands during setup and doctor completion installation. Fixes #44296. (#83059) Thanks @yu-xin-c.
+- Telegram: keep isolated long polling below the hard `getUpdates` request guard so idle bot accounts with high `timeoutSeconds` do not false-disconnect and restart-loop. Fixes #83264. Thanks @riccodecarvalho.
 - Providers/Google: preserve and recover Gemini 3 tool-call thought signatures during native replay so function-calling turns no longer fail with missing `thought_signature` 400s. Fixes #72879. (#80358) Thanks @abnershang.
 - Memory/QMD: keep lexical search on raw hyphenated queries while normalizing semantic QMD sub-searches, avoiding fallback to the builtin index for dashed identifiers and dates. Fixes #81328.
 - Memory-core: distinguish sqlite-vec load failures from missing semantic vector embeddings in degraded `memory index` warnings, so vector recall diagnostics point at unresolved dimensions instead of blaming sqlite-vec when the store is ready. Fixes #75624. (#83056) Thanks @xuruiray and @Noah3521.

--- a/extensions/telegram/src/request-timeouts.test.ts
+++ b/extensions/telegram/src/request-timeouts.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  resolveTelegramLongPollTimeoutSeconds,
   resolveTelegramRequestTimeoutMs,
   resolveTelegramStartupProbeTimeoutMs,
 } from "./request-timeouts.js";
@@ -40,6 +41,20 @@ describe("resolveTelegramRequestTimeoutMs", () => {
   it("does not assign hard timeouts to unrelated Telegram methods", () => {
     expect(resolveTelegramRequestTimeoutMs("answercallbackquery")).toBeUndefined();
     expect(resolveTelegramRequestTimeoutMs(null)).toBeUndefined();
+  });
+});
+
+describe("resolveTelegramLongPollTimeoutSeconds", () => {
+  it("uses Telegram's default long-poll duration when no client timeout is configured", () => {
+    expect(resolveTelegramLongPollTimeoutSeconds(undefined)).toBe(30);
+  });
+
+  it("keeps isolated long polling below the getUpdates request abort guard", () => {
+    expect(resolveTelegramLongPollTimeoutSeconds(90)).toBe(40);
+  });
+
+  it("honors lower configured long-poll durations", () => {
+    expect(resolveTelegramLongPollTimeoutSeconds(10)).toBe(10);
   });
 });
 

--- a/extensions/telegram/src/request-timeouts.ts
+++ b/extensions/telegram/src/request-timeouts.ts
@@ -1,5 +1,7 @@
 export const TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS = 45_000;
 const TELEGRAM_OUTBOUND_TEXT_REQUEST_TIMEOUT_MS = 60_000;
+const TELEGRAM_DEFAULT_LONG_POLL_TIMEOUT_SECONDS = 30;
+const TELEGRAM_LONG_POLL_ABORT_MARGIN_SECONDS = 5;
 
 const TELEGRAM_REQUEST_TIMEOUTS_MS = {
   // Bound startup/control-plane calls so the gateway cannot report Telegram as
@@ -48,6 +50,19 @@ export function resolveTelegramRequestTimeoutMs(
     return baseTimeoutMs;
   }
   return Math.max(baseTimeoutMs, resolveConfiguredTelegramRequestTimeoutMs(timeoutSeconds) ?? 0);
+}
+
+export function resolveTelegramLongPollTimeoutSeconds(timeoutSeconds: unknown): number {
+  const maxLongPollTimeoutSeconds = Math.max(
+    1,
+    Math.floor(TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS / 1000) -
+      TELEGRAM_LONG_POLL_ABORT_MARGIN_SECONDS,
+  );
+  const configuredTimeoutSeconds =
+    typeof timeoutSeconds === "number" && Number.isFinite(timeoutSeconds)
+      ? Math.max(1, Math.floor(timeoutSeconds))
+      : TELEGRAM_DEFAULT_LONG_POLL_TIMEOUT_SECONDS;
+  return Math.min(configuredTimeoutSeconds, maxLongPollTimeoutSeconds);
 }
 
 export function resolveTelegramStartupProbeTimeoutMs(timeoutSeconds: unknown): number {

--- a/extensions/telegram/src/telegram-ingress-worker.runtime.ts
+++ b/extensions/telegram/src/telegram-ingress-worker.runtime.ts
@@ -4,7 +4,10 @@ import { normalizeTelegramApiRoot } from "./api-root.js";
 import { resolveTelegramTransport } from "./fetch.js";
 import { isRecoverableTelegramNetworkError } from "./network-errors.js";
 import { makeProxyFetch } from "./proxy.js";
-import { TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS } from "./request-timeouts.js";
+import {
+  TELEGRAM_GET_UPDATES_REQUEST_TIMEOUT_MS,
+  resolveTelegramLongPollTimeoutSeconds,
+} from "./request-timeouts.js";
 import { writeTelegramSpooledUpdate } from "./telegram-ingress-spool.js";
 import type {
   TelegramIngressWorkerMessage,
@@ -91,10 +94,7 @@ async function main(): Promise<void> {
   const fetchImpl = transport.fetch ?? globalThis.fetch;
   const apiRoot = normalizeTelegramApiRoot(options.apiRoot ?? "https://api.telegram.org");
   const getUpdatesUrl = `${apiRoot}/bot${options.token}/getUpdates`;
-  const pollTimeoutSeconds =
-    typeof options.timeoutSeconds === "number" && Number.isFinite(options.timeoutSeconds)
-      ? Math.max(1, Math.floor(options.timeoutSeconds))
-      : 30;
+  const pollTimeoutSeconds = resolveTelegramLongPollTimeoutSeconds(options.timeoutSeconds);
   let lastUpdateId = options.initialUpdateId;
   let failures = 0;
 


### PR DESCRIPTION
## Summary

- Problem: idle Telegram bot accounts could false-disconnect when isolated ingress used a high `channels.telegram.timeoutSeconds` value for Bot API long polling.
- Why it matters: the 45s hard `getUpdates` request guard could abort an idle long poll before Telegram returned an empty successful response, leaving health stuck disconnected and causing restart loops.
- What changed: isolated ingress now caps the Bot API long-poll `timeout` below the hard `getUpdates` abort guard while preserving outbound/startup timeout behavior.
- What did NOT change: no health-monitor policy changes, no new config flag, no outbound send timeout behavior changes.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Integrations

## Linked Issue/PR

- Closes #83264
- [x] This PR fixes a bug or regression

## Real behavior proof

Behavior addressed: Telegram isolated polling no longer lets high `channels.telegram.timeoutSeconds` produce a Bot API long-poll timeout that outlives OpenClaw's hard `getUpdates` request guard.

Real environment tested: local OpenClaw source checkout on macOS; Blacksmith Testbox delegated check for changed extension lanes.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/telegram/src/request-timeouts.test.ts extensions/telegram/src/polling-session.test.ts extensions/telegram/src/bot.fetch-abort.test.ts`

Evidence after fix: focused Vitest passed with 3 files and 57 tests; `pnpm check:changed` passed on Blacksmith Testbox `tbx_01krw5ea9xgg2e1t3hk6tdm9xz`; Codex review reported no accepted/actionable findings.

Observed result after fix: `resolveTelegramLongPollTimeoutSeconds(90)` returns `40`, keeping isolated long polling below the 45s hard request guard, while empty poll-success liveness and outbound timeout behavior remain covered by existing tests.

What was not tested: no live Telegram account was exercised in this PR; the fix is covered at the timeout contract and polling-session seam.

Proof gate note: maintainer override label applied because live Telegram credentials were not exercised; the proof gap is stated above.

## Root Cause

- Root cause: isolated polling ingress passed account `timeoutSeconds` directly as Telegram Bot API `getUpdates` long-poll `timeout`, while the fetch request still had a fixed 45s hard abort guard.
- Missing guardrail: no focused helper/test asserted that isolated long-poll duration must stay below the hard `getUpdates` request timeout.
- Context: non-isolated grammY client fetch already treated `getUpdates` specially, but the isolated worker used its own raw fetch path.

## Regression Test Plan

- Added coverage in `extensions/telegram/src/request-timeouts.test.ts` for default, capped high, and preserved low long-poll timeouts.
- Existing polling/session and fetch abort tests also run.

## User-visible / Behavior Changes

Telegram polling accounts with high `channels.telegram.timeoutSeconds` should stop false-disconnecting during idle long polls. No config migration required.

## Diagram

```text
Before:
timeoutSeconds=90 -> getUpdates timeout=90s -> hard abort at 45s -> no poll-success -> disconnected restart

After:
timeoutSeconds=90 -> getUpdates timeout=40s -> empty success before hard abort -> poll-success -> healthy
```

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS local checkout; Blacksmith Testbox for changed checks
- Runtime/container: Node/OpenClaw repo test harness
- Integration/channel: Telegram
- Relevant config: `channels.telegram.timeoutSeconds` greater than 45s

### Steps

1. Run focused timeout and polling tests.
2. Run changed-lane type/lint/guard checks.
3. Run Codex review on the local diff.

### Expected

- High Telegram timeout values do not configure isolated `getUpdates` long polls past the hard request guard.

### Actual

- Focused tests and changed checks passed; helper caps 90s to 40s.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers

## Human Verification

- Verified scenarios: high timeout capping, default 30s long-poll timeout, lower configured long-poll timeout preservation, existing empty poll-success liveness path, existing hard getUpdates abort path.
- Edge cases checked: undefined timeout, high timeout, low timeout.
- What you did not verify: live Telegram idle account restart behavior.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: deployments that intentionally used high Telegram `timeoutSeconds` for longer idle poll cadence will now poll at most every 40s in isolated ingress.
- Mitigation: this matches OpenClaw's hard `getUpdates` request guard and prevents false disconnects; outbound/startup timeout behavior is unchanged.
