### PR TITLE
fix: hide display-hidden chat transcript messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Mac app: keep app-level menu commands and Dashboard failure states reachable when the remote Gateway is disconnected, and keep the Settings sidebar toggle in the leading titlebar area.
+- Gateway/webchat: hide internal runtime-context and other `display: false` transcript messages from Chat history and live message events. Fixes #83216. Thanks @EmpireCreator.
 - Mac app: align the Sessions settings pane with the standard Settings page gutter and row spacing.
 - Codex app-server: preserve streamed native command output in mirrored transcripts and trajectory exports when final snapshots omit aggregated output. (#83200) Thanks @rozmiarD.
 - Codex app-server: fail closed when chat or sender policy denies tools, disabling native code, app, environment, and user MCP surfaces for restricted turns. (#82374) Thanks @VACInc.

--- a/src/gateway/chat-display-projection.ts
+++ b/src/gateway/chat-display-projection.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { OPENCLAW_RUNTIME_CONTEXT_CUSTOM_TYPE } from "../agents/internal-runtime-context.js";
 import { isHeartbeatOkResponse, isHeartbeatUserMessage } from "../auto-reply/heartbeat-filter.js";
 import { HEARTBEAT_PROMPT } from "../auto-reply/heartbeat.js";
 import {
@@ -680,7 +681,17 @@ function isSubagentAnnounceInterSessionUserMessage(message: Record<string, unkno
   );
 }
 
+function isDisplayHiddenProjectedMessage(message: Record<string, unknown>): boolean {
+  if (message.display === false) {
+    return true;
+  }
+  return message.role === "custom" && message.customType === OPENCLAW_RUNTIME_CONTEXT_CUSTOM_TYPE;
+}
+
 function shouldHideProjectedHistoryMessage(message: Record<string, unknown>): boolean {
+  if (isDisplayHiddenProjectedMessage(message)) {
+    return true;
+  }
   const roleContent = asRoleContentMessage(message);
   if (!roleContent) {
     return false;

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -589,6 +589,13 @@ describe("projectRecentChatDisplayMessages", () => {
         { role: "assistant", content: "older answer", timestamp: 2 },
         { role: "assistant", content: "NO_REPLY", timestamp: 3 },
         { role: "assistant", content: "ANNOUNCE_SKIP", timestamp: 4 },
+        {
+          role: "custom",
+          customType: "openclaw.runtime-context",
+          content: "hidden runtime context",
+          display: false,
+          timestamp: 5,
+        },
       ],
       { maxMessages: 1 },
     );

--- a/src/gateway/session-history-state.test.ts
+++ b/src/gateway/session-history-state.test.ts
@@ -310,6 +310,34 @@ describe("SessionHistorySseState", () => {
     ]);
   });
 
+  test("drops hidden runtime-context custom messages from projected history", () => {
+    const snapshot = buildSessionHistorySnapshot({
+      rawMessages: [
+        {
+          role: "custom",
+          customType: "openclaw.runtime-context",
+          content: "secret runtime context",
+          display: false,
+          __openclaw: { seq: 1 },
+        },
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "visible answer" }],
+          __openclaw: { seq: 2 },
+        },
+      ],
+    });
+
+    expect(snapshot.history.messages).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "visible answer" }],
+        __openclaw: { seq: 2 },
+      },
+    ]);
+    expect(snapshot.rawTranscriptSeq).toBe(2);
+  });
+
   test("drops subagent announce inter-session user messages from projected history", () => {
     const snapshot = buildSessionHistorySnapshot({
       rawMessages: [
@@ -412,6 +440,16 @@ describe("SessionHistorySseState", () => {
         message: {
           role: "assistant",
           content: [{ type: "text", text: "HEARTBEAT_OK" }],
+        },
+      }),
+    ).toBeNull();
+    expect(
+      state.appendInlineMessage({
+        message: {
+          role: "custom",
+          customType: "openclaw.runtime-context",
+          content: "secret runtime context",
+          display: false,
         },
       }),
     ).toBeNull();

--- a/src/gateway/session-message-events.test.ts
+++ b/src/gateway/session-message-events.test.ts
@@ -389,6 +389,58 @@ describe("session.message websocket events", () => {
     });
   });
 
+  test("does not broadcast hidden runtime-context custom messages as live chat messages", async () => {
+    const storePath = await createSessionStoreFile();
+    await writeSessionStore({
+      entries: {
+        "hidden-runtime": {
+          sessionId: "sess-hidden-runtime",
+          updatedAt: Date.now(),
+        },
+      },
+      storePath,
+    });
+
+    await withOperatorSessionSubscriber(async (ws) => {
+      const changedEventPromise = waitForSessionsChangedMessagePhase(
+        ws,
+        "agent:main:hidden-runtime",
+      );
+      await expectNoMessageWithin({
+        watch: (timeoutMs) =>
+          onceMessage(
+            ws,
+            (message) =>
+              message.type === "event" &&
+              message.event === "session.message" &&
+              (message.payload as { sessionKey?: string } | undefined)?.sessionKey ===
+                "agent:main:hidden-runtime",
+            timeoutMs,
+          ),
+        action: () => {
+          emitSessionTranscriptUpdate({
+            sessionFile: path.join(path.dirname(storePath), "sess-hidden-runtime.jsonl"),
+            sessionKey: "agent:main:hidden-runtime",
+            messageId: "runtime-context-1",
+            messageSeq: 1,
+            message: {
+              role: "custom",
+              customType: "openclaw.runtime-context",
+              content: "secret runtime context",
+              display: false,
+            },
+          });
+        },
+      });
+
+      const changedEvent = await changedEventPromise;
+      expectRecordFields(changedEvent.payload, {
+        sessionKey: "agent:main:hidden-runtime",
+        phase: "message",
+      });
+    });
+  });
+
   test("includes live usage metadata on session.message and sessions.changed transcript events", async () => {
     const storePath = await createSessionStoreFile();
     await writeSessionStore({


### PR DESCRIPTION
Summary
- Hide transcript messages marked `display: false` before gateway Chat history projection and live `session.message` broadcasts.
- Defensively hide `openclaw.runtime-context` custom messages even if the display flag is missing.
- Add regression coverage for historical projection, incremental SSE state, server-method limiting, and live websocket events.

Fixes #83216.

Verification
- `node scripts/run-vitest.mjs src/gateway/session-history-state.test.ts src/gateway/server-methods/server-methods.test.ts src/gateway/session-message-events.test.ts`
- `pnpm exec oxfmt --write --threads=1 src/gateway/chat-display-projection.ts src/gateway/server-methods/server-methods.test.ts src/gateway/session-history-state.test.ts src/gateway/session-message-events.test.ts`
- `node scripts/run-vitest.mjs src/gateway/session-history-state.test.ts src/gateway/server-methods/server-methods.test.ts src/gateway/session-message-events.test.ts`
- `git diff --check`
- `pnpm exec oxfmt --check --threads=1 src/gateway/chat-display-projection.ts src/gateway/server-methods/server-methods.test.ts src/gateway/session-history-state.test.ts src/gateway/session-message-events.test.ts`
- Autoreview: clean, no accepted/actionable findings. Its nested websocket rerun was blocked by `listen EPERM: operation not permitted 127.0.0.1`; the same focused suite passed in the normal checkout.

Behavior addressed: Hidden runtime context and other `display: false` transcript messages are no longer exposed in gateway Chat history or live chat message events.
Real environment tested: Local macOS checkout, focused gateway Vitest suite with websocket harness.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/gateway/session-history-state.test.ts src/gateway/server-methods/server-methods.test.ts src/gateway/session-message-events.test.ts`
Evidence after fix: 7 test files passed, 172 tests passed, including regression coverage for hidden runtime-context history and live event filtering.
Observed result after fix: Visible assistant/user messages remain projected; hidden runtime-context messages are dropped while `sessions.changed` message-phase events still advance.
What was not tested: Full repository check suite and live Telegram/web UI manual session.
