### PR TITLE
xai: OAuth login fixes plus openclaw User-Agent attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Docs: https://docs.openclaw.ai
 - Cron/Discord: keep explicit announce runs in message-tool-only source-reply mode so scheduled agent turns post once instead of also echoing through automatic visible replies. Fixes #83261. Thanks @Theralley.
 - Mac app: align the Sessions settings pane with the standard Settings page gutter and row spacing.
 - OpenAI/Codex: stop rejecting available `openai-codex` GPT-5.1, GPT-5.2, and GPT-5.3 model refs during config validation, while keeping removed Spark aliases suppressed. Fixes #83303.
+- Plugins/xAI: complete OAuth-backed xAI login and sidecar auth fixes, including guarded loopback callback CORS handling, video generation polling/defaults, and native-host User-Agent attribution. (#83322) Thanks @Jaaneek.
 - Codex app-server: preserve streamed native command output in mirrored transcripts and trajectory exports when final snapshots omit aggregated output. (#83200) Thanks @rozmiarD.
 - Codex app-server: fail closed when chat or sender policy denies tools, disabling native code, app, environment, and user MCP surfaces for restricted turns. (#82374) Thanks @VACInc.
 - Codex app-server: keep recent context-engine messages when oversized projected history is truncated, so short follow-ups in long channel sessions do not fall back to stale earlier turns. (#83127) Thanks @VACInc.

--- a/extensions/xai/api.ts
+++ b/extensions/xai/api.ts
@@ -31,7 +31,7 @@ export { applyXaiRuntimeModelCompat } from "./runtime-model-compat.js";
 export { applyXaiModelCompat, HTML_ENTITY_TOOL_CALL_ARGUMENTS_ENCODING, XAI_TOOL_SCHEMA_PROFILE };
 export { resolveXaiModelCompatPatch };
 
-const XAI_NATIVE_ENDPOINT_HOSTS = new Set(["api.x.ai", "api.grok.x.ai"]);
+const XAI_NATIVE_ENDPOINT_HOSTS = new Set(["api.x.ai"]);
 
 function resolveHostname(value: string): string | undefined {
   try {

--- a/extensions/xai/code-execution.ts
+++ b/extensions/xai/code-execution.ts
@@ -108,7 +108,7 @@ export function createCodeExecutionTool(options?: {
         return jsonResult({
           error: "missing_xai_api_key",
           message:
-            "code_execution needs an xAI API key. Run openclaw onboard --auth-choice xai-api-key, set XAI_API_KEY in the Gateway environment, or configure plugins.entries.xai.config.webSearch.apiKey.",
+            "code_execution needs xAI credentials. Run `openclaw onboard --auth-choice xai-oauth` to sign in with Grok, run `openclaw onboard --auth-choice xai-api-key`, set `XAI_API_KEY` in the Gateway environment, or configure `plugins.entries.xai.config.webSearch.apiKey`.",
           docs: "https://docs.openclaw.ai/tools/code-execution",
         });
       }

--- a/extensions/xai/image-generation-provider.test.ts
+++ b/extensions/xai/image-generation-provider.test.ts
@@ -17,12 +17,22 @@ const {
   postJsonRequestMock: vi.fn(),
   postMultipartRequestMock: vi.fn(),
   assertOkOrThrowHttpErrorMock: vi.fn(async () => {}),
-  resolveProviderHttpRequestConfigMock: vi.fn((params: Record<string, unknown>) => ({
-    baseUrl: params.baseUrl ?? params.defaultBaseUrl ?? "https://api.x.ai/v1",
-    allowPrivateNetwork: false,
-    headers: new Headers(params.defaultHeaders as HeadersInit | undefined),
-    dispatcherPolicy: undefined,
-  })),
+  resolveProviderHttpRequestConfigMock: vi.fn((params: Record<string, unknown>) => {
+    const headers = new Headers(params.defaultHeaders as HeadersInit | undefined);
+    // Stub mirroring the xAI attribution policy headers (real wire is locked in provider-attribution.test.ts).
+    if (params.provider === "xai") {
+      const version = process.env.OPENCLAW_VERSION?.trim() || "unknown";
+      headers.set("User-Agent", `openclaw/${version}`);
+      headers.set("originator", "openclaw");
+      headers.set("version", version);
+    }
+    return {
+      baseUrl: params.baseUrl ?? params.defaultBaseUrl ?? "https://api.x.ai/v1",
+      allowPrivateNetwork: false,
+      headers,
+      dispatcherPolicy: undefined,
+    };
+  }),
   createProviderOperationDeadlineMock: vi.fn((params: Record<string, unknown>) => ({
     timeoutMs: params.timeoutMs,
     label: params.label,
@@ -62,12 +72,14 @@ function requirePostJsonCall(index = 0): {
   url?: string;
   timeoutMs?: number;
   body?: Record<string, unknown>;
+  headers?: Headers;
 } {
   const params = (postJsonRequestMock.mock.calls as unknown as Array<[unknown]>)[index]?.[0] as
     | {
         url?: string;
         timeoutMs?: number;
         body?: Record<string, unknown>;
+        headers?: Headers;
       }
     | undefined;
   if (!params) {
@@ -213,6 +225,32 @@ describe("xai image generation provider", () => {
     expect(image?.url).toContain("data:image/png;base64,");
     expect(image?.type).toBe("image_url");
     expect(request.body?.response_format).toBe("b64_json");
+  });
+
+  it("forwards xAI attribution User-Agent through the SDK image request", async () => {
+    vi.stubEnv("OPENCLAW_VERSION", "2026.3.22");
+    postJsonRequestMock.mockResolvedValue({
+      response: {
+        json: async () => ({
+          data: [{ b64_json: Buffer.from("ua-png").toString("base64") }],
+        }),
+      },
+      release: vi.fn(async () => {}),
+    });
+
+    const provider = buildXaiImageGenerationProvider();
+    await provider.generateImage({
+      provider: "xai",
+      model: "grok-imagine-image",
+      prompt: "ua check",
+      cfg: {},
+    } as any);
+
+    const request = requirePostJsonCall();
+    expect(request.headers?.get("user-agent")).toBe("openclaw/2026.3.22");
+    expect(request.headers?.get("originator")).toBe("openclaw");
+    expect(request.headers?.get("version")).toBe("2026.3.22");
+    vi.unstubAllEnvs();
   });
 
   it("uses the plural xAI images payload for multiple edit inputs", async () => {

--- a/extensions/xai/index.ts
+++ b/extensions/xai/index.ts
@@ -125,7 +125,7 @@ function createLazyCodeExecutionTool(ctx: {
         return jsonResult({
           error: "missing_xai_api_key",
           message:
-            "code_execution needs an xAI API key. Run openclaw onboard --auth-choice xai-api-key, set XAI_API_KEY in the Gateway environment, or configure plugins.entries.xai.config.webSearch.apiKey.",
+            "code_execution needs xAI credentials. Run `openclaw onboard --auth-choice xai-oauth` to sign in with Grok, run `openclaw onboard --auth-choice xai-api-key`, set `XAI_API_KEY` in the Gateway environment, or configure `plugins.entries.xai.config.webSearch.apiKey`.",
           docs: "https://docs.openclaw.ai/tools/code-execution",
         });
       }

--- a/extensions/xai/model-compat.ts
+++ b/extensions/xai/model-compat.ts
@@ -3,6 +3,8 @@ import {
   type ModelCompatConfig,
 } from "openclaw/plugin-sdk/provider-model-shared";
 
+export { normalizeXaiModelId as normalizeNativeXaiModelId } from "./model-id.js";
+
 export const XAI_TOOL_SCHEMA_PROFILE = "xai";
 export const HTML_ENTITY_TOOL_CALL_ARGUMENTS_ENCODING = "html-entities";
 
@@ -29,26 +31,4 @@ export function applyXaiModelCompat<T extends { compat?: unknown }>(model: T): T
     model as T & { compat?: ModelCompatConfig },
     resolveXaiModelCompatPatch(),
   ) as T;
-}
-
-export function normalizeNativeXaiModelId(id: string): string {
-  if (id === "grok-4-fast-reasoning") {
-    return "grok-4-fast";
-  }
-  if (id === "grok-4-1-fast-reasoning") {
-    return "grok-4-1-fast";
-  }
-  if (id === "grok-4.20-experimental-beta-0304-reasoning") {
-    return "grok-4.20-beta-latest-reasoning";
-  }
-  if (id === "grok-4.20-experimental-beta-0304-non-reasoning") {
-    return "grok-4.20-beta-latest-non-reasoning";
-  }
-  if (id === "grok-4.20-reasoning") {
-    return "grok-4.20-beta-latest-reasoning";
-  }
-  if (id === "grok-4.20-non-reasoning") {
-    return "grok-4.20-beta-latest-non-reasoning";
-  }
-  return id;
 }

--- a/extensions/xai/openclaw.plugin.json
+++ b/extensions/xai/openclaw.plugin.json
@@ -23,7 +23,7 @@
   "providerEndpoints": [
     {
       "endpointClass": "xai-native",
-      "hosts": ["api.x.ai", "api.grok.x.ai"]
+      "hosts": ["api.x.ai"]
     }
   ],
   "providerRequest": {

--- a/extensions/xai/realtime-transcription-provider.test.ts
+++ b/extensions/xai/realtime-transcription-provider.test.ts
@@ -5,15 +5,36 @@ import type WebSocket from "ws";
 import { WebSocketServer } from "ws";
 import { buildXaiRealtimeTranscriptionProvider } from "./realtime-transcription-provider.js";
 
+const { isProviderAuthProfileConfiguredMock, resolveApiKeyForProviderMock } = vi.hoisted(() => ({
+  isProviderAuthProfileConfiguredMock: vi.fn(() => false),
+  resolveApiKeyForProviderMock: vi.fn(
+    async (): Promise<{ apiKey: string | undefined }> => ({ apiKey: undefined }),
+  ),
+}));
+
+vi.mock("openclaw/plugin-sdk/provider-auth", () => ({
+  isProviderAuthProfileConfigured: isProviderAuthProfileConfiguredMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/provider-auth-runtime", () => ({
+  resolveApiKeyForProvider: resolveApiKeyForProviderMock,
+}));
+
 let cleanup: (() => Promise<void>) | undefined;
 
 afterEach(async () => {
   await cleanup?.();
   cleanup = undefined;
+  isProviderAuthProfileConfiguredMock.mockReset();
+  isProviderAuthProfileConfiguredMock.mockReturnValue(false);
+  resolveApiKeyForProviderMock.mockReset();
+  resolveApiKeyForProviderMock.mockResolvedValue({ apiKey: undefined });
+  delete process.env.XAI_API_KEY;
+  vi.unstubAllEnvs();
 });
 
 async function createRealtimeSttServer(params?: {
-  onRequest?: (url: URL) => void;
+  onRequest?: (url: URL, headers: Record<string, string | string[] | undefined>) => void;
   onBinary?: (audio: Buffer) => void;
   initialEvent?: unknown;
 }) {
@@ -28,7 +49,7 @@ async function createRealtimeSttServer(params?: {
 
   server.on("upgrade", (request, socket, head) => {
     const url = new URL(request.url ?? "/", "http://127.0.0.1");
-    params?.onRequest?.(url);
+    params?.onRequest?.(url, request.headers);
     wss.handleUpgrade(request, socket, head, (ws) => {
       clients.add(ws);
       ws.on("close", () => clients.delete(ws));
@@ -122,10 +143,15 @@ describe("xai realtime transcription provider", () => {
   });
 
   it("streams raw binary audio and maps partial and final transcript events", async () => {
+    vi.stubEnv("OPENCLAW_VERSION", "2026.3.22");
     const binaryFrames: Buffer[] = [];
     const requestUrls: URL[] = [];
+    const upgradeHeaders: Array<Record<string, string | string[] | undefined>> = [];
     const server = await createRealtimeSttServer({
-      onRequest: (url) => requestUrls.push(url),
+      onRequest: (url, headers) => {
+        requestUrls.push(url);
+        upgradeHeaders.push(headers);
+      },
       onBinary: (audio) => binaryFrames.push(audio),
     });
     const provider = buildXaiRealtimeTranscriptionProvider();
@@ -166,10 +192,13 @@ describe("xai realtime transcription provider", () => {
     expect(requestUrls[0]?.searchParams.get("encoding")).toBe("pcm");
     expect(requestUrls[0]?.searchParams.get("interim_results")).toBe("true");
     expect(requestUrls[0]?.searchParams.get("endpointing")).toBe("500");
+    expect(upgradeHeaders[0]?.["user-agent"]).toBeUndefined();
+    expect(upgradeHeaders[0]?.authorization).toBe("Bearer xai-test-key");
     expect(Buffer.concat(binaryFrames).toString()).toContain("queued-before-ready");
     expect(Buffer.concat(binaryFrames).toString()).toContain("after-ready");
     expect(onSpeechStart).toHaveBeenCalled();
     expect(onPartial).toHaveBeenCalledWith("hello openclaw");
+    vi.unstubAllEnvs();
   });
 
   it("rejects setup errors before the stream is ready", async () => {
@@ -202,5 +231,43 @@ describe("xai realtime transcription provider", () => {
     const provider = buildXaiRealtimeTranscriptionProvider();
     expect(provider.aliases).toContain("xai-realtime");
     expect(provider.aliases).toContain("grok-stt-streaming");
+  });
+
+  it("reports configured when an xAI auth profile exists, even without env or config apiKey", () => {
+    delete process.env.XAI_API_KEY;
+    isProviderAuthProfileConfiguredMock.mockReturnValue(true);
+    const provider = buildXaiRealtimeTranscriptionProvider();
+    expect(provider.isConfigured({ cfg: {}, providerConfig: {} })).toBe(true);
+    expect(isProviderAuthProfileConfiguredMock).toHaveBeenCalledWith({
+      provider: "xai",
+      cfg: {},
+    });
+  });
+
+  it("threads cfg into the lazy WebSocket bearer resolver", async () => {
+    delete process.env.XAI_API_KEY;
+    resolveApiKeyForProviderMock.mockResolvedValue({ apiKey: "oauth-bearer" });
+    const upgradeHeaders: Array<Record<string, string | string[] | undefined>> = [];
+    const server = await createRealtimeSttServer({
+      onRequest: (_url, headers) => {
+        upgradeHeaders.push(headers);
+      },
+    });
+
+    const provider = buildXaiRealtimeTranscriptionProvider();
+    const cfg = { agents: { defaults: {} } };
+    const session = provider.createSession({
+      cfg,
+      providerConfig: {
+        baseUrl: server.baseUrl,
+      },
+    });
+
+    await session.connect();
+    session.close();
+    await server.donePromise;
+
+    expect(resolveApiKeyForProviderMock).toHaveBeenCalledWith({ provider: "xai", cfg });
+    expect(upgradeHeaders[0]?.authorization).toBe("Bearer oauth-bearer");
   });
 });

--- a/extensions/xai/realtime-transcription-provider.ts
+++ b/extensions/xai/realtime-transcription-provider.ts
@@ -1,4 +1,9 @@
 import {
+  isProviderAuthProfileConfigured,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-auth";
+import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
+import {
   createRealtimeTranscriptionWebSocketSession,
   type RealtimeTranscriptionProviderConfig,
   type RealtimeTranscriptionProviderPlugin,
@@ -9,6 +14,7 @@ import {
 import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { XAI_BASE_URL } from "./model-definitions.js";
+import { xaiUserAgentHeaderFor } from "./src/xai-user-agent.js";
 
 type XaiRealtimeTranscriptionEncoding = "pcm" | "mulaw" | "alaw";
 
@@ -24,6 +30,8 @@ type XaiRealtimeTranscriptionProviderConfig = {
 
 type XaiRealtimeTranscriptionSessionConfig = RealtimeTranscriptionSessionCreateRequest & {
   apiKey: string;
+  // Late-bound bearer; called per (re)connect.
+  resolveApiKey?: () => Promise<string>;
   baseUrl: string;
   sampleRate: number;
   encoding: XaiRealtimeTranscriptionEncoding;
@@ -219,7 +227,13 @@ function createXaiRealtimeTranscriptionSession(
     providerId: "xai",
     callbacks: config,
     url: () => toXaiRealtimeWsUrl(config),
-    headers: { Authorization: `Bearer ${config.apiKey}` },
+    headers: async () => {
+      const apiKey = config.resolveApiKey ? await config.resolveApiKey() : config.apiKey;
+      return {
+        Authorization: `Bearer ${apiKey}`,
+        ...xaiUserAgentHeaderFor(config.baseUrl),
+      };
+    },
     connectTimeoutMs: XAI_REALTIME_STT_CONNECT_TIMEOUT_MS,
     closeTimeoutMs: XAI_REALTIME_STT_CLOSE_TIMEOUT_MS,
     maxReconnectAttempts: XAI_REALTIME_STT_MAX_RECONNECT_ATTEMPTS,
@@ -245,17 +259,18 @@ export function buildXaiRealtimeTranscriptionProvider(): RealtimeTranscriptionPr
     aliases: ["xai-realtime", "grok-stt-streaming"],
     autoSelectOrder: 25,
     resolveConfig: ({ rawConfig }) => normalizeProviderConfig(rawConfig),
-    isConfigured: ({ providerConfig }) =>
-      Boolean(normalizeProviderConfig(providerConfig).apiKey || process.env.XAI_API_KEY),
+    isConfigured: ({ providerConfig, cfg }) =>
+      Boolean(normalizeProviderConfig(providerConfig).apiKey || process.env.XAI_API_KEY) ||
+      isProviderAuthProfileConfigured({ provider: "xai", cfg }),
     createSession: (req) => {
       const config = normalizeProviderConfig(req.providerConfig);
-      const apiKey = config.apiKey || process.env.XAI_API_KEY;
-      if (!apiKey) {
-        throw new Error("xAI API key missing");
-      }
+      // createSession must stay sync per RealtimeTranscriptionProviderPlugin; bearer is resolved lazily in headers().
+      const seedApiKey =
+        normalizeOptionalString(config.apiKey) ?? normalizeOptionalString(process.env.XAI_API_KEY);
       return createXaiRealtimeTranscriptionSession({
         ...req,
-        apiKey,
+        apiKey: seedApiKey ?? "",
+        resolveApiKey: () => resolveXaiRealtimeApiKey(config.apiKey, req.cfg),
         baseUrl: normalizeXaiRealtimeBaseUrl(config.baseUrl),
         sampleRate: config.sampleRate ?? XAI_REALTIME_STT_DEFAULT_SAMPLE_RATE,
         encoding: config.encoding ?? XAI_REALTIME_STT_DEFAULT_ENCODING,
@@ -265,4 +280,27 @@ export function buildXaiRealtimeTranscriptionProvider(): RealtimeTranscriptionPr
       });
     },
   };
+}
+
+// Resolve an xAI bearer for the realtime `/stt` WebSocket:
+// 1. Configured `plugins.entries.voice-call.config.streaming.providers.xai.apiKey`
+// 2. `XAI_API_KEY` env var
+// 3. xAI OAuth auth profile (cfg-scoped)
+async function resolveXaiRealtimeApiKey(
+  configApiKey: string | undefined,
+  cfg: OpenClawConfig | undefined,
+): Promise<string> {
+  const direct =
+    normalizeOptionalString(configApiKey) ?? normalizeOptionalString(process.env.XAI_API_KEY);
+  if (direct) {
+    return direct;
+  }
+  const auth = await resolveApiKeyForProvider({ provider: "xai", cfg });
+  const oauthKey = normalizeOptionalString(auth?.apiKey);
+  if (oauthKey) {
+    return oauthKey;
+  }
+  throw new Error(
+    "xAI credentials missing for realtime STT. Sign in with `openclaw onboard --auth-choice xai-oauth`, or run `openclaw onboard --auth-choice xai-api-key`, or set XAI_API_KEY.",
+  );
 }

--- a/extensions/xai/speech-provider.test.ts
+++ b/extensions/xai/speech-provider.test.ts
@@ -1,9 +1,14 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildXaiSpeechProvider } from "./speech-provider.js";
 
-const { xaiTTSMock } = vi.hoisted(() => ({
-  xaiTTSMock: vi.fn(async () => Buffer.from("audio-bytes")),
-}));
+const { xaiTTSMock, isProviderAuthProfileConfiguredMock, resolveApiKeyForProviderMock } =
+  vi.hoisted(() => ({
+    xaiTTSMock: vi.fn(async () => Buffer.from("audio-bytes")),
+    isProviderAuthProfileConfiguredMock: vi.fn(() => false),
+    resolveApiKeyForProviderMock: vi.fn(
+      async (): Promise<{ apiKey: string | undefined }> => ({ apiKey: undefined }),
+    ),
+  }));
 
 vi.mock("./tts.js", () => ({
   XAI_BASE_URL: "https://api.x.ai/v1",
@@ -14,6 +19,14 @@ vi.mock("./tts.js", () => ({
   normalizeXaiTtsBaseUrl: (baseUrl?: string) =>
     baseUrl?.trim().replace(/\/+$/, "") || "https://api.x.ai/v1",
   xaiTTS: xaiTTSMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/provider-auth", () => ({
+  isProviderAuthProfileConfigured: isProviderAuthProfileConfiguredMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/provider-auth-runtime", () => ({
+  resolveApiKeyForProvider: resolveApiKeyForProviderMock,
 }));
 
 function requireLastTtsCall(): {
@@ -43,6 +56,14 @@ function requireLastTtsCall(): {
 }
 
 describe("xai speech provider", () => {
+  afterEach(() => {
+    isProviderAuthProfileConfiguredMock.mockReset();
+    isProviderAuthProfileConfiguredMock.mockReturnValue(false);
+    resolveApiKeyForProviderMock.mockReset();
+    resolveApiKeyForProviderMock.mockResolvedValue({ apiKey: undefined });
+    delete process.env.XAI_API_KEY;
+  });
+
   it("synthesizes mp3 audio and does not claim native voice-note compatibility", async () => {
     const provider = buildXaiSpeechProvider();
     const result = await provider.synthesize({
@@ -116,5 +137,48 @@ describe("xai speech provider", () => {
     expect(tts.language).toBe("es");
     expect(tts.speed).toBe(1.2);
     expect(tts.responseFormat).toBe("pcm");
+  });
+
+  it("reports configured when an xAI auth profile exists, even without env or config apiKey", () => {
+    isProviderAuthProfileConfiguredMock.mockReturnValue(true);
+    const provider = buildXaiSpeechProvider();
+    expect(
+      provider.isConfigured({
+        cfg: {},
+        providerConfig: {},
+        timeoutMs: 5_000,
+      }),
+    ).toBe(true);
+    expect(isProviderAuthProfileConfiguredMock).toHaveBeenCalledWith({
+      provider: "xai",
+      cfg: {},
+    });
+  });
+
+  it("reports not configured when there is no apiKey, env, or auth profile", () => {
+    isProviderAuthProfileConfiguredMock.mockReturnValue(false);
+    const provider = buildXaiSpeechProvider();
+    expect(
+      provider.isConfigured({
+        cfg: {},
+        providerConfig: {},
+        timeoutMs: 5_000,
+      }),
+    ).toBe(false);
+  });
+
+  it("threads cfg into the OAuth fallback resolver when no direct apiKey is available", async () => {
+    resolveApiKeyForProviderMock.mockResolvedValueOnce({ apiKey: "oauth-bearer" });
+    const provider = buildXaiSpeechProvider();
+    const cfg = { agents: { defaults: {} } };
+    await provider.synthesize({
+      text: "hello",
+      cfg,
+      providerConfig: {},
+      target: "voice-note",
+      timeoutMs: 5_000,
+    });
+    expect(resolveApiKeyForProviderMock).toHaveBeenCalledWith({ provider: "xai", cfg });
+    expect(requireLastTtsCall().apiKey).toBe("oauth-bearer");
   });
 });

--- a/extensions/xai/speech-provider.ts
+++ b/extensions/xai/speech-provider.ts
@@ -1,3 +1,8 @@
+import {
+  isProviderAuthProfileConfigured,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-auth";
+import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
 import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
 import {
   asFiniteNumber,
@@ -201,15 +206,13 @@ export function buildXaiSpeechProvider(): SpeechProviderPlugin {
       ...(asFiniteNumber(params.speed) == null ? {} : { speed: asFiniteNumber(params.speed) }),
     }),
     listVoices: async () => XAI_TTS_VOICES.map((voice) => ({ id: voice, name: voice })),
-    isConfigured: ({ providerConfig }) =>
-      Boolean(readXaiProviderConfig(providerConfig).apiKey || process.env.XAI_API_KEY),
+    isConfigured: ({ providerConfig, cfg }) =>
+      Boolean(readXaiProviderConfig(providerConfig).apiKey || process.env.XAI_API_KEY) ||
+      isProviderAuthProfileConfigured({ provider: "xai", cfg }),
     synthesize: async (req) => {
       const config = readXaiProviderConfig(req.providerConfig);
       const overrides = readXaiOverrides(req.providerOverrides);
-      const apiKey = config.apiKey || process.env.XAI_API_KEY;
-      if (!apiKey) {
-        throw new Error("xAI API key missing");
-      }
+      const apiKey = await resolveXaiAudioApiKey(config.apiKey, req.cfg);
       const responseFormat = resolveSpeechResponseFormat(req.target, config.responseFormat);
       const audioBuffer = await xaiTTS({
         text: req.text,
@@ -231,10 +234,7 @@ export function buildXaiSpeechProvider(): SpeechProviderPlugin {
     synthesizeTelephony: async (req) => {
       const config = readXaiProviderConfig(req.providerConfig);
       const overrides = readXaiOverrides(req.providerOverrides);
-      const apiKey = config.apiKey || process.env.XAI_API_KEY;
-      if (!apiKey) {
-        throw new Error("xAI API key missing");
-      }
+      const apiKey = await resolveXaiAudioApiKey(config.apiKey, req.cfg);
       const outputFormat = "pcm" as const;
       const sampleRate = 24000;
       const audioBuffer = await xaiTTS({
@@ -250,4 +250,26 @@ export function buildXaiSpeechProvider(): SpeechProviderPlugin {
       return { audioBuffer, outputFormat, sampleRate };
     },
   };
+}
+
+// Resolve an xAI bearer for `/v1/tts`:
+// 1. Configured `messages.tts.providers.xai.apiKey` (or talk equivalent)
+// 2. `XAI_API_KEY` env var
+// 3. xAI OAuth auth profile (cfg-scoped)
+async function resolveXaiAudioApiKey(
+  configApiKey: string | undefined,
+  cfg: OpenClawConfig,
+): Promise<string> {
+  const direct = trimToUndefined(configApiKey) ?? trimToUndefined(process.env.XAI_API_KEY);
+  if (direct) {
+    return direct;
+  }
+  const auth = await resolveApiKeyForProvider({ provider: "xai", cfg });
+  const oauthKey = trimToUndefined(auth?.apiKey);
+  if (oauthKey) {
+    return oauthKey;
+  }
+  throw new Error(
+    "xAI credentials missing for TTS. Sign in with `openclaw onboard --auth-choice xai-oauth`, or run `openclaw onboard --auth-choice xai-api-key`, or set XAI_API_KEY.",
+  );
 }

--- a/extensions/xai/src/web-search-provider.runtime.ts
+++ b/extensions/xai/src/web-search-provider.runtime.ts
@@ -197,7 +197,7 @@ export async function executeXaiWebSearchProviderTool(
     return {
       error: "missing_xai_api_key",
       message:
-        "web_search (grok) needs an xAI API key. Set XAI_API_KEY in the Gateway environment, or configure plugins.entries.xai.config.webSearch.apiKey. If you do not want to configure a search API key, use web_fetch for a specific URL or the browser tool for interactive pages.",
+        "web_search (grok) needs xAI credentials. Run `openclaw onboard --auth-choice xai-oauth` to sign in with Grok, run `openclaw onboard --auth-choice xai-api-key`, set `XAI_API_KEY` in the Gateway environment, or configure `plugins.entries.xai.config.webSearch.apiKey`. If you do not want to configure a search API key, use web_fetch for a specific URL or the browser tool for interactive pages.",
       docs: "https://docs.openclaw.ai/tools/web",
     };
   }

--- a/extensions/xai/src/xai-user-agent.test.ts
+++ b/extensions/xai/src/xai-user-agent.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { xaiUserAgent, xaiUserAgentHeaderFor } from "./xai-user-agent.js";
+
+describe("xaiUserAgent", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("prefers OPENCLAW_VERSION env over the bundled package version", () => {
+    vi.stubEnv("OPENCLAW_VERSION", "2026.3.22");
+    expect(xaiUserAgent()).toBe("openclaw/2026.3.22");
+  });
+
+  it("falls back to OPENCLAW_SERVICE_VERSION when OPENCLAW_VERSION is unset", () => {
+    vi.stubEnv("OPENCLAW_VERSION", "");
+    vi.stubEnv("OPENCLAW_SERVICE_VERSION", "2026.3.99");
+    // OPENCLAW_VERSION from the SDK is the bundled VERSION constant. In a dev
+    // checkout it resolves to a real semver, so we cannot deterministically
+    // assert "unknown" here. We just lock the prefix to ensure the env-first
+    // contract holds whenever the bundle resolves to 0.0.0/empty.
+    const result = xaiUserAgent();
+    expect(result.startsWith("openclaw/")).toBe(true);
+    expect(result).not.toBe("openclaw/");
+  });
+
+  it("returns the openclaw/<version> shape", () => {
+    vi.stubEnv("OPENCLAW_VERSION", "2026.5.16");
+    expect(xaiUserAgent()).toMatch(/^openclaw\/\d+\.\d+\.\d+$/u);
+  });
+});
+
+describe("xaiUserAgentHeaderFor", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("emits User-Agent for the xAI-native host", () => {
+    vi.stubEnv("OPENCLAW_VERSION", "2026.3.22");
+    expect(xaiUserAgentHeaderFor("https://api.x.ai/v1")).toEqual({
+      "User-Agent": "openclaw/2026.3.22",
+    });
+    expect(xaiUserAgentHeaderFor("https://api.x.ai/v1/tts")).toEqual({
+      "User-Agent": "openclaw/2026.3.22",
+    });
+  });
+
+  it("withholds User-Agent on user-configured proxy baseUrls", () => {
+    vi.stubEnv("OPENCLAW_VERSION", "2026.3.22");
+    expect(xaiUserAgentHeaderFor("https://my-corp.proxy/xai/v1")).toEqual({});
+    expect(xaiUserAgentHeaderFor("http://127.0.0.1:8080/v1")).toEqual({});
+    expect(xaiUserAgentHeaderFor("https://api.grok.x.ai/v1")).toEqual({});
+  });
+
+  it("returns an empty record for missing or invalid input", () => {
+    expect(xaiUserAgentHeaderFor(undefined)).toEqual({});
+    expect(xaiUserAgentHeaderFor("")).toEqual({});
+    expect(xaiUserAgentHeaderFor("not a url")).toEqual({});
+  });
+});

--- a/extensions/xai/src/xai-user-agent.ts
+++ b/extensions/xai/src/xai-user-agent.ts
@@ -1,0 +1,52 @@
+// Shared User-Agent for xAI sidecar HTTP/WS requests; mirrors `formatOpenClawUserAgent`.
+
+import { OPENCLAW_VERSION as PACKAGE_VERSION } from "openclaw/plugin-sdk/agent-harness-runtime";
+
+const ORIGINATOR = "openclaw";
+const UNUSABLE_PACKAGE_VERSION = "0.0.0";
+const FALLBACK_VERSION = "unknown";
+
+function trimToUndefined(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
+function resolveXaiUserAgentVersion(): string {
+  // Env-first matches resolveRuntimeServiceVersion.
+  const envVersion = trimToUndefined(process.env.OPENCLAW_VERSION);
+  if (envVersion) {
+    return envVersion;
+  }
+  const packageVersion = trimToUndefined(PACKAGE_VERSION);
+  if (packageVersion && packageVersion !== UNUSABLE_PACKAGE_VERSION) {
+    return packageVersion;
+  }
+  return (
+    trimToUndefined(process.env.OPENCLAW_SERVICE_VERSION) ??
+    trimToUndefined(process.env.npm_package_version) ??
+    FALLBACK_VERSION
+  );
+}
+
+export function xaiUserAgent(): string {
+  return `${ORIGINATOR}/${resolveXaiUserAgentVersion()}`;
+}
+
+const XAI_NATIVE_API_HOSTS = new Set(["api.x.ai"]);
+
+// Returns a `User-Agent` header entry only when the resolved baseUrl points
+// at a verified xAI-native API host. User-configured proxy baseUrls produce
+// an empty record so the openclaw identity is not forwarded to the proxy.
+export function xaiUserAgentHeaderFor(baseUrl: string | undefined): Record<string, string> {
+  if (!baseUrl) {
+    return {};
+  }
+  try {
+    if (XAI_NATIVE_API_HOSTS.has(new URL(baseUrl).hostname)) {
+      return { "User-Agent": xaiUserAgent() };
+    }
+  } catch {
+    return {};
+  }
+  return {};
+}

--- a/extensions/xai/stt.test.ts
+++ b/extensions/xai/stt.test.ts
@@ -14,16 +14,16 @@ const { postTranscriptionRequestMock } = vi.hoisted(() => ({
   ),
 }));
 
-function requireFirstPostTranscriptionCall(): {
+function requireLastPostTranscriptionCall(): {
   url?: string;
   timeoutMs?: number;
   auditContext?: string;
   headers: Headers;
   body: BodyInit;
 } {
-  const params = (
-    postTranscriptionRequestMock.mock.calls as unknown as Array<[unknown]>
-  )[0]?.[0] as
+  const params = (postTranscriptionRequestMock.mock.calls as unknown as Array<[unknown]>).at(
+    -1,
+  )?.[0] as
     | {
         url?: string;
         timeoutMs?: number;
@@ -65,7 +65,7 @@ describe("xai stt", () => {
     });
 
     expect(result).toEqual({ text: "hello from audio", model: XAI_DEFAULT_STT_MODEL });
-    const call = requireFirstPostTranscriptionCall();
+    const call = requireLastPostTranscriptionCall();
     expect(call.url).toBe("https://api.x.ai/v1/stt");
     expect(call.timeoutMs).toBe(10_000);
     expect(call.auditContext).toBe("xai stt");
@@ -84,5 +84,23 @@ describe("xai stt", () => {
     expect(provider.capabilities).toEqual(["audio"]);
     expect(provider.defaultModels).toEqual({ audio: XAI_DEFAULT_STT_MODEL });
     expect(provider.autoPriority).toEqual({ audio: 25 });
+  });
+
+  it("trusts the core-resolved apiKey on transcribeAudio (no plugin-side OAuth fallback)", async () => {
+    const provider = buildXaiMediaUnderstandingProvider();
+    if (!provider.transcribeAudio) {
+      throw new Error("xAI media-understanding provider should register transcribeAudio");
+    }
+    await provider.transcribeAudio({
+      buffer: Buffer.from("audio-bytes"),
+      fileName: "sample.wav",
+      mime: "audio/wav",
+      apiKey: "core-resolved-bearer",
+      baseUrl: "https://api.x.ai/v1/",
+      model: XAI_DEFAULT_STT_MODEL,
+      timeoutMs: 10_000,
+    });
+    const call = requireLastPostTranscriptionCall();
+    expect(call.headers.get("authorization")).toBe("Bearer core-resolved-bearer");
   });
 });

--- a/extensions/xai/stt.ts
+++ b/extensions/xai/stt.ts
@@ -78,6 +78,9 @@ export async function transcribeXaiAudio(
 }
 
 export function buildXaiMediaUnderstandingProvider(): MediaUnderstandingProvider {
+  // Auth is resolved by media-understanding core via resolveProviderExecutionContext
+  // before transcribeAudio runs, so an OAuth profile (when configured) reaches
+  // here as `params.apiKey` already. No plugin-side fallback required.
   return {
     id: "xai",
     capabilities: ["audio"],

--- a/extensions/xai/tts.test.ts
+++ b/extensions/xai/tts.test.ts
@@ -75,6 +75,34 @@ describe("xai tts", () => {
       );
     });
 
+    it("sends an openclaw User-Agent on xAI TTS requests", async () => {
+      vi.stubEnv("OPENCLAW_VERSION", "2026.3.22");
+      const fetchMock = vi.fn(
+        async (_input: RequestInfo | URL, _init?: RequestInit) =>
+          new Response(Buffer.from("audio-bytes"), {
+            status: 200,
+            headers: { "Content-Type": "audio/mpeg" },
+          }),
+      );
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      await xaiTTS({
+        text: "hello",
+        apiKey: "ok-key",
+        baseUrl: XAI_BASE_URL,
+        voiceId: "eve",
+        language: "en",
+        responseFormat: "mp3",
+        timeoutMs: 5_000,
+      });
+
+      const init = fetchMock.mock.calls.at(0)?.[1];
+      const headers = new Headers(init?.headers ?? {});
+      expect(headers.get("user-agent")).toBe("openclaw/2026.3.22");
+      expect(headers.get("authorization")).toBe("Bearer ok-key");
+      vi.unstubAllEnvs();
+    });
+
     it("falls back to raw body text when the error body is non-JSON", async () => {
       const fetchMock = vi.fn(
         async () => new Response("temporary upstream outage", { status: 503 }),

--- a/extensions/xai/tts.ts
+++ b/extensions/xai/tts.ts
@@ -1,6 +1,7 @@
 import { assertOkOrThrowProviderError, postJsonRequest } from "openclaw/plugin-sdk/provider-http";
 import { trimToUndefined } from "openclaw/plugin-sdk/speech";
 import { XAI_BASE_URL } from "./api.js";
+import { xaiUserAgentHeaderFor } from "./src/xai-user-agent.js";
 export { XAI_BASE_URL };
 
 export const XAI_TTS_VOICES = ["eve", "ara", "rex", "sal", "leo", "una"] as const;
@@ -18,7 +19,7 @@ export function normalizeXaiTtsBaseUrl(baseUrl?: string): string {
 export function isValidXaiTtsVoice(voice: string, baseUrl?: string): voice is XaiTtsVoice {
   const normalizedBase = normalizeXaiTtsBaseUrl(baseUrl ?? process.env.XAI_BASE_URL);
   const host = normalizedBase.includes("://") ? new URL(normalizedBase).hostname : normalizedBase;
-  const isNative = host === "api.x.ai" || host === "api.grok.x.ai";
+  const isNative = host === "api.x.ai";
   if (!isNative) {
     return true;
   }
@@ -65,11 +66,13 @@ export async function xaiTTS(params: {
     throw new Error(`Invalid voice: ${voiceId}`);
   }
 
+  const ttsBaseUrl = normalizeXaiTtsBaseUrl(baseUrl);
   const { response, release } = await postJsonRequest({
-    url: `${normalizeXaiTtsBaseUrl(baseUrl)}/tts`,
+    url: `${ttsBaseUrl}/tts`,
     headers: new Headers({
       Authorization: `Bearer ${apiKey}`,
       "Content-Type": "application/json",
+      ...xaiUserAgentHeaderFor(ttsBaseUrl),
     }),
     body: {
       text,

--- a/extensions/xai/video-generation-provider.test.ts
+++ b/extensions/xai/video-generation-provider.test.ts
@@ -18,11 +18,13 @@ installProviderHttpMockCleanup();
 function requirePostJsonCall(index = 0): {
   url?: string;
   body?: Record<string, unknown>;
+  headers?: Headers;
 } {
   const params = (postJsonRequestMock.mock.calls as unknown as Array<[unknown]>)[index]?.[0] as
     | {
         url?: string;
         body?: Record<string, unknown>;
+        headers?: Headers;
       }
     | undefined;
   if (!params) {
@@ -144,17 +146,61 @@ describe("xai video generation provider", () => {
     ).rejects.toThrow("xAI video generation response malformed");
   });
 
-  it("rejects unknown xAI poll statuses without waiting for timeout", async () => {
+  it("treats unknown xAI poll statuses as continue-polling and returns when terminal", async () => {
     postJsonRequestMock.mockResolvedValue({
       response: {
-        json: async () => ({ request_id: "req_bad_status" }),
+        json: async () => ({ request_id: "req_unknown_then_done" }),
+      },
+      release: vi.fn(async () => {}),
+    });
+    fetchWithTimeoutMock
+      .mockResolvedValueOnce({
+        json: async () => ({
+          request_id: "req_unknown_then_done",
+          status: "almost_done",
+        }),
+      })
+      .mockResolvedValueOnce({
+        json: async () => ({
+          request_id: "req_unknown_then_done",
+          status: "submitted",
+        }),
+      })
+      .mockResolvedValueOnce({
+        json: async () => ({
+          request_id: "req_unknown_then_done",
+          status: "done",
+          video: { url: "https://cdn.x.ai/eventual.mp4" },
+        }),
+      })
+      .mockResolvedValueOnce({
+        headers: new Headers({ "content-type": "video/mp4" }),
+        arrayBuffer: async () => Buffer.from("mp4"),
+      });
+
+    const provider = buildXaiVideoGenerationProvider();
+    const result = await provider.generateVideo({
+      provider: "xai",
+      model: "grok-imagine-video",
+      prompt: "unknown then done",
+      cfg: {},
+    });
+
+    expect(result.metadata?.requestId).toBe("req_unknown_then_done");
+    expect(result.metadata?.status).toBe("done");
+  });
+
+  it("treats `cancelled` as a terminal failure", async () => {
+    postJsonRequestMock.mockResolvedValue({
+      response: {
+        json: async () => ({ request_id: "req_cancelled" }),
       },
       release: vi.fn(async () => {}),
     });
     fetchWithTimeoutMock.mockResolvedValueOnce({
       json: async () => ({
-        request_id: "req_bad_status",
-        status: "almost_done",
+        request_id: "req_cancelled",
+        status: "cancelled",
       }),
     });
 
@@ -163,10 +209,10 @@ describe("xai video generation provider", () => {
       provider.generateVideo({
         provider: "xai",
         model: "grok-imagine-video",
-        prompt: "bad status",
+        prompt: "cancelled",
         cfg: {},
       }),
-    ).rejects.toThrow("xAI video generation response malformed");
+    ).rejects.toThrow("xAI video generation cancelled");
   });
 
   it("rejects completed xAI poll responses without output URLs as malformed", async () => {

--- a/extensions/xai/video-generation-provider.ts
+++ b/extensions/xai/video-generation-provider.ts
@@ -27,6 +27,12 @@ const POLL_INTERVAL_MS = 5_000;
 const MAX_POLL_ATTEMPTS = 120;
 const XAI_VIDEO_ASPECT_RATIOS = new Set(["1:1", "16:9", "9:16", "4:3", "3:4", "3:2", "2:3"]);
 const XAI_VIDEO_MALFORMED_RESPONSE = "xAI video generation response malformed";
+// xAI documents these as the only meaningful values; everything else (queued,
+// processing, submitted, pending, in_progress, ...) means "keep polling".
+const XAI_VIDEO_TERMINAL_FAILURE_STATUSES = new Set(["failed", "error", "expired", "cancelled"]);
+const XAI_VIDEO_DEFAULT_DURATION_SECONDS = 8;
+const XAI_VIDEO_DEFAULT_ASPECT_RATIO = "16:9";
+const XAI_VIDEO_DEFAULT_RESOLUTION = "720p";
 
 type XaiVideoCreateResponse = {
   request_id?: string;
@@ -38,7 +44,9 @@ type XaiVideoCreateResponse = {
 
 type XaiVideoStatusResponse = {
   request_id?: string;
-  status?: "queued" | "processing" | "done" | "failed" | "expired";
+  // Free-form: xAI returns whatever string it wants here. The caller decides
+  // which strings are terminal vs continue-polling.
+  status: string;
   video?: {
     url?: string;
   } | null;
@@ -91,22 +99,13 @@ function readXaiCreateResponse(payload: Record<string, unknown>): XaiVideoCreate
 }
 
 function readXaiStatusResponse(payload: Record<string, unknown>): XaiVideoStatusResponse {
-  const rawStatus = normalizeOptionalString(payload.status);
-  // xAI's /v1/videos/{id} endpoint currently returns "pending" (with a progress
-  // integer) for in-flight jobs. Treat it as "processing" so polling continues
-  // instead of failing with XAI_VIDEO_MALFORMED_RESPONSE.
-  const status =
-    rawStatus === "pending" || rawStatus === "in_progress" ? "processing" : rawStatus;
-  if (!status || !["queued", "processing", "done", "failed", "expired"].includes(status)) {
-    throw new Error(XAI_VIDEO_MALFORMED_RESPONSE);
-  }
   const video = payload.video;
   if (video !== undefined && video !== null && !isRecord(video)) {
     throw new Error(XAI_VIDEO_MALFORMED_RESPONSE);
   }
   return {
     request_id: normalizeOptionalString(payload.request_id),
-    status: status as XaiVideoStatusResponse["status"],
+    status: normalizeOptionalString(payload.status) ?? "",
     video: isRecord(video) ? { url: normalizeOptionalString(video.url) } : null,
     error: xaiErrorMessage(payload) ? { message: xaiErrorMessage(payload) } : null,
   };
@@ -183,10 +182,14 @@ function resolveAspectRatio(value: string | undefined): string | undefined {
 }
 
 function resolveResolution(value: string | undefined): "480p" | "720p" | undefined {
-  if (value === "480P") {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "480p") {
     return "480p";
   }
-  if (value === "720P" || value === "1080P") {
+  if (normalized === "720p" || normalized === "1080p") {
     return "720p";
   }
   return undefined;
@@ -243,43 +246,27 @@ function buildCreateBody(req: VideoGenerationRequest): Record<string, unknown> {
     if (imageUrl) {
       body.image = { url: imageUrl };
     }
-    const duration = resolveDurationSeconds({
-      durationSeconds: req.durationSeconds,
-      min: 1,
-      max: 15,
-    });
-    if (typeof duration === "number") {
-      body.duration = duration;
-    }
-    const aspectRatio = resolveAspectRatio(req.aspectRatio);
-    if (aspectRatio) {
-      body.aspect_ratio = aspectRatio;
-    }
-    const resolution = resolveResolution(req.resolution);
-    if (resolution) {
-      body.resolution = resolution;
-    }
+    body.duration =
+      resolveDurationSeconds({
+        durationSeconds: req.durationSeconds,
+        min: 1,
+        max: 15,
+      }) ?? XAI_VIDEO_DEFAULT_DURATION_SECONDS;
+    body.aspect_ratio = resolveAspectRatio(req.aspectRatio) ?? XAI_VIDEO_DEFAULT_ASPECT_RATIO;
+    body.resolution = resolveResolution(req.resolution) ?? XAI_VIDEO_DEFAULT_RESOLUTION;
     return body;
   }
 
   if (mode === "referenceToVideo") {
     body.reference_images = inputImages.map((image) => ({ url: resolveRequiredImageUrl(image) }));
-    const duration = resolveDurationSeconds({
-      durationSeconds: req.durationSeconds,
-      min: 1,
-      max: 10,
-    });
-    if (typeof duration === "number") {
-      body.duration = duration;
-    }
-    const aspectRatio = resolveAspectRatio(req.aspectRatio);
-    if (aspectRatio) {
-      body.aspect_ratio = aspectRatio;
-    }
-    const resolution = resolveResolution(req.resolution);
-    if (resolution) {
-      body.resolution = resolution;
-    }
+    body.duration =
+      resolveDurationSeconds({
+        durationSeconds: req.durationSeconds,
+        min: 1,
+        max: 10,
+      }) ?? XAI_VIDEO_DEFAULT_DURATION_SECONDS;
+    body.aspect_ratio = resolveAspectRatio(req.aspectRatio) ?? XAI_VIDEO_DEFAULT_ASPECT_RATIO;
+    body.resolution = resolveResolution(req.resolution) ?? XAI_VIDEO_DEFAULT_RESOLUTION;
     return body;
   }
 
@@ -338,21 +325,19 @@ async function pollXaiVideo(params: {
       requestFailedMessage: "xAI video status request failed",
     });
     const payload = readXaiStatusResponse(await readXaiVideoJson(response));
-    switch (payload.status) {
-      case "done":
-        return payload;
-      case "failed":
-      case "expired":
-        throw new Error(
-          normalizeOptionalString(payload.error?.message) ??
-            `xAI video generation ${payload.status}`,
-        );
-      case "queued":
-      case "processing":
-      default:
-        await waitProviderOperationPollInterval({ deadline, pollIntervalMs: POLL_INTERVAL_MS });
-        break;
+    const normalizedStatus = payload.status.toLowerCase();
+    if (normalizedStatus === "done") {
+      return payload;
     }
+    if (XAI_VIDEO_TERMINAL_FAILURE_STATUSES.has(normalizedStatus)) {
+      throw new Error(
+        normalizeOptionalString(payload.error?.message) ??
+          `xAI video generation ${normalizedStatus}`,
+      );
+    }
+    // Any other status (queued, processing, submitted, pending, in_progress,
+    // empty, …) is non-terminal: keep polling.
+    await waitProviderOperationPollInterval({ deadline, pollIntervalMs: POLL_INTERVAL_MS });
   }
   throw new Error(`xAI video generation task ${params.requestId} did not finish in time`);
 }
@@ -447,9 +432,13 @@ export function buildXaiVideoGenerationProvider(): VideoGenerationProvider {
           capability: "video",
           transport: "http",
         });
+      // Per-submit idempotency key prevents accidental double-charging if
+      // the request is replayed. Polls intentionally reuse `headers` without it.
+      const submitHeaders = new Headers(headers);
+      submitHeaders.set("x-idempotency-key", crypto.randomUUID());
       const { response, release } = await postJsonRequest({
         url: `${baseUrl}${resolveCreateEndpoint(req)}`,
-        headers,
+        headers: submitHeaders,
         body: buildCreateBody(req),
         timeoutMs: resolveProviderOperationTimeoutMs({
           deadline,

--- a/extensions/xai/x-search-tool-shared.ts
+++ b/extensions/xai/x-search-tool-shared.ts
@@ -5,7 +5,7 @@ export function buildMissingXSearchApiKeyPayload() {
   return {
     error: "missing_xai_api_key",
     message:
-      "x_search needs an xAI API key. Run openclaw onboard --auth-choice xai-api-key, set XAI_API_KEY in the Gateway environment, or configure plugins.entries.xai.config.webSearch.apiKey.",
+      "x_search needs xAI credentials. Run `openclaw onboard --auth-choice xai-oauth` to sign in with Grok, run `openclaw onboard --auth-choice xai-api-key`, set `XAI_API_KEY` in the Gateway environment, or configure `plugins.entries.xai.config.webSearch.apiKey`.",
     docs: "https://docs.openclaw.ai/tools/web",
   };
 }

--- a/extensions/xai/xai-oauth.test.ts
+++ b/extensions/xai/xai-oauth.test.ts
@@ -4,6 +4,7 @@ import {
   fetchXaiOAuthDiscovery,
   isTrustedXaiOAuthEndpoint,
   refreshXaiOAuthCredential,
+  XAI_OAUTH_CALLBACK_CORS_ORIGIN_ALLOWLIST,
   XAI_OAUTH_CALLBACK_PORT,
   XAI_OAUTH_CLIENT_ID,
   XAI_OAUTH_REDIRECT_URI,
@@ -25,6 +26,10 @@ describe("xAI OAuth", () => {
     expect(isTrustedXaiOAuthEndpoint("http://auth.x.ai/oauth2/token")).toBe(false);
     expect(isTrustedXaiOAuthEndpoint("https://x.ai.evil.test/oauth2/token")).toBe(false);
     expect(isTrustedXaiOAuthEndpoint("not a url")).toBe(false);
+  });
+
+  it("exposes the loopback CORS origin allowlist that loginXaiOAuth threads to the SDK helper", () => {
+    expect([...XAI_OAUTH_CALLBACK_CORS_ORIGIN_ALLOWLIST]).toEqual(["auth.x.ai", "accounts.x.ai"]);
   });
 
   it("builds the xAI authorize URL for OpenClaw", () => {
@@ -52,6 +57,7 @@ describe("xAI OAuth", () => {
   });
 
   it("validates discovered endpoints before using them", async () => {
+    vi.stubEnv("OPENCLAW_VERSION", "2026.3.22");
     const fetchImpl = vi.fn(async () =>
       jsonResponse({
         authorization_endpoint: "https://auth.x.ai/oauth2/authorize",
@@ -63,6 +69,13 @@ describe("xAI OAuth", () => {
       authorizationEndpoint: "https://auth.x.ai/oauth2/authorize",
       tokenEndpoint: "https://auth.x.ai/oauth2/token",
     });
+
+    const discoveryInit = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls.at(
+      0,
+    )?.[1] as RequestInit | undefined;
+    const discoveryHeaders = new Headers(discoveryInit?.headers ?? {});
+    expect(discoveryHeaders.get("user-agent")).toBe("openclaw/2026.3.22");
+    vi.unstubAllEnvs();
 
     const poisonedFetch = vi.fn(async () =>
       jsonResponse({
@@ -77,6 +90,7 @@ describe("xAI OAuth", () => {
   });
 
   it("refreshes with the cached token endpoint and preserves refresh fallback", async () => {
+    vi.stubEnv("OPENCLAW_VERSION", "2026.3.22");
     const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
       expect(init?.method).toBe("POST");
       expect(typeof init?.body).toBe("string");
@@ -84,6 +98,8 @@ describe("xAI OAuth", () => {
       expect(body).toContain("grant_type=refresh_token");
       expect(body).toContain(`client_id=${encodeURIComponent(XAI_OAUTH_CLIENT_ID)}`);
       expect(body).toContain("refresh_token=refresh-1");
+      const headers = new Headers(init?.headers ?? {});
+      expect(headers.get("user-agent")).toBe("openclaw/2026.3.22");
       return jsonResponse({
         access_token: "access-2",
         expires_in: 120,
@@ -106,5 +122,6 @@ describe("xAI OAuth", () => {
     expect(refreshed.access).toBe("access-2");
     expect(refreshed.refresh).toBe("refresh-1");
     expect(refreshed.expires).toBe(121_000);
+    vi.unstubAllEnvs();
   });
 });

--- a/extensions/xai/xai-oauth.ts
+++ b/extensions/xai/xai-oauth.ts
@@ -10,6 +10,7 @@ import {
 } from "openclaw/plugin-sdk/provider-auth";
 import { waitForLocalOAuthCallback } from "openclaw/plugin-sdk/provider-auth-runtime";
 import { applyXaiConfig, XAI_DEFAULT_MODEL_REF } from "./onboard.js";
+import { xaiUserAgent } from "./src/xai-user-agent.js";
 
 const PROVIDER_ID = "xai";
 export const XAI_OAUTH_METHOD_ID = "oauth";
@@ -22,6 +23,9 @@ export const XAI_OAUTH_CALLBACK_HOST = "127.0.0.1";
 export const XAI_OAUTH_CALLBACK_PORT = 56121;
 export const XAI_OAUTH_CALLBACK_PATH = "/callback";
 export const XAI_OAUTH_REDIRECT_URI = `http://${XAI_OAUTH_CALLBACK_HOST}:${XAI_OAUTH_CALLBACK_PORT}${XAI_OAUTH_CALLBACK_PATH}`;
+// Hosts whose CORS preflight against the loopback redirect URI should be
+// echoed; everything else gets a 204 with no `Access-Control-Allow-*`.
+export const XAI_OAUTH_CALLBACK_CORS_ORIGIN_ALLOWLIST = ["auth.x.ai", "accounts.x.ai"] as const;
 
 const XAI_OAUTH_TIMEOUT_MS = 5 * 60 * 1000;
 const XAI_OAUTH_FETCH_TIMEOUT_MS = 30 * 1000;
@@ -98,6 +102,10 @@ export async function fetchXaiOAuthDiscovery(
   options: XaiOAuthFetchOptions = {},
 ): Promise<XaiOAuthDiscovery> {
   const response = await getFetchImpl(options.fetchImpl)(XAI_OAUTH_DISCOVERY_URL, {
+    headers: {
+      Accept: "application/json",
+      "User-Agent": xaiUserAgent(),
+    },
     signal: AbortSignal.timeout(XAI_OAUTH_FETCH_TIMEOUT_MS),
   });
   const json = readStringRecord(await readJsonResponse(response, "xAI OAuth discovery"));
@@ -150,23 +158,51 @@ function normalizeExpires(value: unknown, now: () => number): number | undefined
   return now() + seconds * 1000;
 }
 
-function parseXaiOAuthTokenResponse(value: unknown, now: () => number): XaiOAuthTokenResponse {
+function parseXaiOAuthTokenResponse(
+  value: unknown,
+  now: () => number,
+  options: { requireRefreshToken?: boolean } = {},
+): XaiOAuthTokenResponse {
   const json = readStringRecord(value);
   const accessToken = json.access_token;
   if (typeof accessToken !== "string" || accessToken.trim().length === 0) {
     throw new Error("xAI OAuth token response is missing access_token");
   }
-  const expires = normalizeExpires(json.expires_in, now);
+  const refreshToken =
+    typeof json.refresh_token === "string" && json.refresh_token.trim().length > 0
+      ? json.refresh_token
+      : undefined;
+  if (options.requireRefreshToken && !refreshToken) {
+    throw new Error(
+      "xAI OAuth token response is missing refresh_token. Re-run the login; if the issue persists, the OAuth client is not configured to issue refresh tokens (commonly because the offline_access scope was rejected).",
+    );
+  }
+  const idToken =
+    typeof json.id_token === "string" && json.id_token.trim().length > 0
+      ? json.id_token
+      : undefined;
+  // RFC 6749 expires_in preferred; access-token JWT exp is the only legitimate
+  // fallback for an access-token expiry — id_token exp reflects the OIDC
+  // session, not the access token, and may extend it past actual expiry.
+  const expires = normalizeExpires(json.expires_in, now) ?? deriveExpiresFromJwt(accessToken);
   return {
     accessToken,
-    ...(typeof json.refresh_token === "string" && json.refresh_token.trim().length > 0
-      ? { refreshToken: json.refresh_token }
-      : {}),
-    ...(typeof json.id_token === "string" && json.id_token.trim().length > 0
-      ? { idToken: json.id_token }
-      : {}),
+    ...(refreshToken ? { refreshToken } : {}),
+    ...(idToken ? { idToken } : {}),
     ...(expires ? { expires } : {}),
   };
+}
+
+function deriveExpiresFromJwt(token: string | undefined): number | undefined {
+  if (!token) {
+    return undefined;
+  }
+  const payload = decodeJwtPayload(token);
+  const exp = payload.exp;
+  if (typeof exp !== "number" || !Number.isFinite(exp) || exp <= 0) {
+    return undefined;
+  }
+  return exp * 1000;
 }
 
 async function exchangeXaiOAuthToken(
@@ -174,6 +210,7 @@ async function exchangeXaiOAuthToken(
     tokenEndpoint: string;
     body: Record<string, string>;
     context: string;
+    requireRefreshToken?: boolean;
   } & XaiOAuthFetchOptions,
 ): Promise<XaiOAuthTokenResponse> {
   const response = await getFetchImpl(params.fetchImpl)(
@@ -183,6 +220,7 @@ async function exchangeXaiOAuthToken(
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
         Accept: "application/json",
+        "User-Agent": xaiUserAgent(),
       },
       body: toFormUrlEncoded(params.body),
       signal: AbortSignal.timeout(XAI_OAUTH_FETCH_TIMEOUT_MS),
@@ -191,6 +229,7 @@ async function exchangeXaiOAuthToken(
   return parseXaiOAuthTokenResponse(
     await readJsonResponse(response, params.context),
     params.now ?? Date.now,
+    { requireRefreshToken: params.requireRefreshToken },
   );
 }
 
@@ -261,6 +300,7 @@ export async function loginXaiOAuth(ctx: ProviderAuthContext): Promise<ProviderA
       hostname: XAI_OAUTH_CALLBACK_HOST,
       successTitle: "xAI OAuth complete",
       onProgress: (message) => progress.update(message),
+      corsOriginAllowlist: XAI_OAUTH_CALLBACK_CORS_ORIGIN_ALLOWLIST,
     });
     void callbackPromise.catch(() => undefined);
     await noteXaiOAuthUrl(ctx, authorizeUrl);
@@ -271,6 +311,7 @@ export async function loginXaiOAuth(ctx: ProviderAuthContext): Promise<ProviderA
     const tokens = await exchangeXaiOAuthToken({
       tokenEndpoint: discovery.tokenEndpoint,
       context: "xAI OAuth token exchange",
+      requireRefreshToken: true,
       body: {
         grant_type: "authorization_code",
         code: callback.code,

--- a/src/agents/openai-responses-payload-policy.ts
+++ b/src/agents/openai-responses-payload-policy.ts
@@ -169,7 +169,6 @@ function resolveBundledOpenAIResponsesEndpointClass(
     case "aiplatform.googleapis.com":
       return "google-vertex";
     case "api.x.ai":
-    case "api.grok.x.ai":
       return "xai-native";
     case "api.z.ai":
       return "zai-native";

--- a/src/agents/provider-attribution.test.ts
+++ b/src/agents/provider-attribution.test.ts
@@ -53,7 +53,7 @@ const providerEndpointPlugins = vi.hoisted(() => [
       },
       {
         endpointClass: "xai-native",
-        hosts: ["api.x.ai", "api.grok.x.ai"],
+        hosts: ["api.x.ai"],
       },
     ],
     providerRequest: {
@@ -188,6 +188,29 @@ describe("provider attribution", () => {
     });
   });
 
+  it("returns a hidden-spec xAI attribution policy", () => {
+    expect(resolveProviderAttributionPolicy("xai", { OPENCLAW_VERSION: "2026.3.22" })).toEqual({
+      provider: "xai",
+      enabledByDefault: true,
+      verification: "vendor-hidden-api-spec",
+      hook: "request-headers",
+      reviewNote:
+        "xAI api.x.ai accepts a standard openclaw User-Agent. Companion originator/version headers mirror the OpenAI attribution shape for consistency; they are not validated against an xAI-specific spec and are expected to be ignored by xAI's OpenAI-compatible surface.",
+      product: "OpenClaw",
+      version: "2026.3.22",
+      headers: {
+        originator: "openclaw",
+        version: "2026.3.22",
+        "User-Agent": "openclaw/2026.3.22",
+      },
+    });
+    expect(resolveProviderAttributionHeaders("xai", { OPENCLAW_VERSION: "2026.3.22" })).toEqual({
+      originator: "openclaw",
+      version: "2026.3.22",
+      "User-Agent": "openclaw/2026.3.22",
+    });
+  });
+
   it("lists the current attribution support matrix", () => {
     expect(
       listProviderAttributionPolicies({ OPENCLAW_VERSION: "2026.3.22" }).map((policy) => [
@@ -200,12 +223,84 @@ describe("provider attribution", () => {
       ["openrouter", true, "vendor-documented", "request-headers"],
       ["openai", true, "vendor-hidden-api-spec", "request-headers"],
       ["openai-codex", true, "vendor-hidden-api-spec", "request-headers"],
+      ["xai", true, "vendor-hidden-api-spec", "request-headers"],
       ["anthropic", false, "vendor-sdk-hook-only", "default-headers"],
       ["google", false, "vendor-sdk-hook-only", "user-agent-extra"],
       ["groq", false, "vendor-sdk-hook-only", "default-headers"],
       ["mistral", false, "vendor-sdk-hook-only", "custom-user-agent"],
       ["together", false, "vendor-sdk-hook-only", "default-headers"],
     ]);
+  });
+
+  it("authorizes hidden xAI attribution on api.x.ai and the default xAI route", () => {
+    expectRecordFields(
+      resolveProviderRequestPolicy(
+        {
+          provider: "xai",
+          api: "openai-responses",
+          baseUrl: "https://api.x.ai/v1",
+          transport: "stream",
+          capability: "llm",
+        },
+        { OPENCLAW_VERSION: "2026.3.22" },
+      ),
+      {
+        endpointClass: "xai-native",
+        attributionProvider: "xai",
+        allowsHiddenAttribution: true,
+      },
+    );
+    expect(
+      resolveProviderRequestAttributionHeaders(
+        {
+          provider: "xai",
+          api: "openai-responses",
+          baseUrl: "https://api.x.ai/v1",
+          transport: "stream",
+          capability: "llm",
+        },
+        { OPENCLAW_VERSION: "2026.3.22" },
+      ),
+    ).toEqual({
+      originator: "openclaw",
+      version: "2026.3.22",
+      "User-Agent": "openclaw/2026.3.22",
+    });
+
+    expectRecordFields(
+      resolveProviderRequestPolicy(
+        {
+          provider: "xai",
+          api: "openai-responses",
+          transport: "stream",
+          capability: "llm",
+        },
+        { OPENCLAW_VERSION: "2026.3.22" },
+      ),
+      {
+        endpointClass: "default",
+        attributionProvider: "xai",
+      },
+    );
+
+    // Custom proxy baseUrl should withhold xAI attribution.
+    expectRecordFields(
+      resolveProviderRequestPolicy(
+        {
+          provider: "xai",
+          api: "openai-responses",
+          baseUrl: "https://proxy.example.com/v1",
+          transport: "stream",
+          capability: "llm",
+        },
+        { OPENCLAW_VERSION: "2026.3.22" },
+      ),
+      {
+        endpointClass: "custom",
+        attributionProvider: undefined,
+        allowsHiddenAttribution: false,
+      },
+    );
   });
 
   it("authorizes hidden OpenAI attribution only on verified native hosts", () => {
@@ -328,7 +423,7 @@ describe("provider attribution", () => {
       hostname: "api.x.ai",
     });
     expectRecordFields(resolveProviderEndpoint("https://api.grok.x.ai/v1"), {
-      endpointClass: "xai-native",
+      endpointClass: "custom",
       hostname: "api.grok.x.ai",
     });
     expectRecordFields(resolveProviderEndpoint("https://api.z.ai/api/coding/paas/v4"), {

--- a/src/agents/provider-attribution.ts
+++ b/src/agents/provider-attribution.ts
@@ -522,6 +522,26 @@ function buildOpenAICodexAttributionPolicy(
   };
 }
 
+function buildXaiAttributionPolicy(
+  env: RuntimeVersionEnv = process.env as RuntimeVersionEnv,
+): ProviderAttributionPolicy {
+  const identity = resolveProviderAttributionIdentity(env);
+  return {
+    provider: "xai",
+    enabledByDefault: true,
+    verification: "vendor-hidden-api-spec",
+    hook: "request-headers",
+    reviewNote:
+      "xAI api.x.ai accepts a standard openclaw User-Agent. Companion originator/version headers mirror the OpenAI attribution shape for consistency; they are not validated against an xAI-specific spec and are expected to be ignored by xAI's OpenAI-compatible surface.",
+    ...identity,
+    headers: {
+      originator: OPENCLAW_ATTRIBUTION_ORIGINATOR,
+      version: identity.version,
+      "User-Agent": formatOpenClawUserAgent(identity.version),
+    },
+  };
+}
+
 function buildSdkHookOnlyPolicy(
   provider: string,
   hook: ProviderAttributionHook,
@@ -545,6 +565,7 @@ export function listProviderAttributionPolicies(
     buildOpenRouterAttributionPolicy(env),
     buildOpenAIAttributionPolicy(env),
     buildOpenAICodexAttributionPolicy(env),
+    buildXaiAttributionPolicy(env),
     buildSdkHookOnlyPolicy(
       "anthropic",
       "default-headers",
@@ -614,6 +635,7 @@ export function resolveProviderRequestPolicy(
   const usesOpenAICodexAttributionHost = endpointClass === "openai-codex";
   const usesVerifiedOpenAIAttributionHost =
     usesOpenAIPublicAttributionHost || usesOpenAICodexAttributionHost;
+  const usesXaiNativeAttributionHost = endpointClass === "xai-native";
   const usesExplicitProxyLikeEndpoint = usesConfiguredBaseUrl && !usesKnownNativeOpenAIEndpoint;
 
   let attributionProvider: string | undefined;
@@ -626,6 +648,11 @@ export function resolveProviderRequestPolicy(
     // OpenRouter endpoints or the default (unset) baseUrl path.
     if (endpointClass === "openrouter" || endpointClass === "default") {
       attributionProvider = "openrouter";
+    }
+  } else if (provider === "xai" && policy?.enabledByDefault) {
+    // Default (unset baseUrl) maps to api.x.ai; custom baseUrls are treated as proxies and withheld.
+    if (usesXaiNativeAttributionHost || endpointClass === "default") {
+      attributionProvider = "xai";
     }
   }
 

--- a/src/plugin-sdk/provider-auth-runtime.test.ts
+++ b/src/plugin-sdk/provider-auth-runtime.test.ts
@@ -53,6 +53,7 @@ describe("plugin-sdk provider-auth-runtime", () => {
       redirectUri: `http://127.0.0.1:${port}/callback`,
       hostname: "127.0.0.1",
       successTitle: "OAuth complete",
+      corsOriginAllowlist: ["auth.x.ai", "accounts.x.ai"],
     });
 
     const preflight = await fetch(`http://127.0.0.1:${port}/callback`, {
@@ -78,6 +79,75 @@ describe("plugin-sdk provider-auth-runtime", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("access-control-allow-origin")).toBe("https://auth.x.ai");
+    await expect(callback).resolves.toEqual({ code: "code-1", state: "state-1" });
+  });
+
+  it("does not echo CORS for unallowlisted callback origins but keeps waiting", async () => {
+    const port = await getFreePort();
+    const callback = providerAuthRuntime.waitForLocalOAuthCallback({
+      expectedState: "state-1",
+      timeoutMs: 5_000,
+      port,
+      callbackPath: "/callback",
+      redirectUri: `http://127.0.0.1:${port}/callback`,
+      hostname: "127.0.0.1",
+      successTitle: "OAuth complete",
+      corsOriginAllowlist: ["auth.x.ai"],
+    });
+
+    const preflight = await fetch(`http://127.0.0.1:${port}/callback`, {
+      method: "OPTIONS",
+      headers: {
+        Origin: "https://attacker.example",
+        "Access-Control-Request-Method": "GET",
+        "Access-Control-Request-Headers": "content-type",
+        "Access-Control-Request-Private-Network": "true",
+      },
+    });
+
+    expect(preflight.status).toBe(204);
+    expect(preflight.headers.get("access-control-allow-origin")).toBeNull();
+    expect(preflight.headers.get("access-control-allow-methods")).toBeNull();
+    expect(preflight.headers.get("access-control-allow-headers")).toBeNull();
+    expect(preflight.headers.get("access-control-allow-private-network")).toBeNull();
+
+    const response = await fetch(`http://127.0.0.1:${port}/callback?code=code-1&state=state-1`, {
+      headers: {
+        Origin: "https://auth.x.ai",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("access-control-allow-origin")).toBe("https://auth.x.ai");
+    await expect(callback).resolves.toEqual({ code: "code-1", state: "state-1" });
+  });
+
+  it("preserves legacy permissive CORS behavior when no allowlist is passed", async () => {
+    const port = await getFreePort();
+    const callback = providerAuthRuntime.waitForLocalOAuthCallback({
+      expectedState: "state-1",
+      timeoutMs: 5_000,
+      port,
+      callbackPath: "/callback",
+      redirectUri: `http://127.0.0.1:${port}/callback`,
+      hostname: "127.0.0.1",
+      successTitle: "OAuth complete",
+    });
+
+    const preflight = await fetch(`http://127.0.0.1:${port}/callback`, {
+      method: "OPTIONS",
+      headers: {
+        Origin: "https://legacy.example",
+        "Access-Control-Request-Method": "GET",
+      },
+    });
+
+    expect(preflight.status).toBe(204);
+    expect(preflight.headers.get("access-control-allow-origin")).toBe("https://legacy.example");
+    expect(preflight.headers.get("access-control-allow-methods")).toContain("GET");
+
+    const response = await fetch(`http://127.0.0.1:${port}/callback?code=code-1&state=state-1`);
+    expect(response.status).toBe(200);
     await expect(callback).resolves.toEqual({ code: "code-1", state: "state-1" });
   });
 });

--- a/src/plugin-sdk/provider-auth-runtime.test.ts
+++ b/src/plugin-sdk/provider-auth-runtime.test.ts
@@ -81,3 +81,40 @@ describe("plugin-sdk provider-auth-runtime", () => {
     await expect(callback).resolves.toEqual({ code: "code-1", state: "state-1" });
   });
 });
+
+describe("buildOAuthCallbackOriginResolver", () => {
+  it("returns a no-op resolver when no allowlist is provided", () => {
+    const noOp = providerAuthRuntime.buildOAuthCallbackOriginResolver(undefined);
+    expect(noOp("https://auth.example.com")).toBeUndefined();
+
+    const empty = providerAuthRuntime.buildOAuthCallbackOriginResolver([]);
+    expect(empty("https://auth.example.com")).toBeUndefined();
+
+    const blank = providerAuthRuntime.buildOAuthCallbackOriginResolver(["", "  "]);
+    expect(blank("https://auth.example.com")).toBeUndefined();
+  });
+
+  it("echoes only allowlisted hosts and only over https", () => {
+    const resolver = providerAuthRuntime.buildOAuthCallbackOriginResolver([
+      "auth.example.com",
+      "ACCOUNTS.example.com",
+    ]);
+
+    expect(resolver("https://auth.example.com")).toBe("https://auth.example.com");
+    expect(resolver("https://accounts.example.com")).toBe("https://accounts.example.com");
+    expect(resolver("https://AUTH.EXAMPLE.COM")).toBe("https://auth.example.com");
+    expect(resolver("https://attacker.example.com")).toBeUndefined();
+    expect(resolver("http://auth.example.com")).toBeUndefined();
+    expect(resolver("not a url")).toBeUndefined();
+    expect(resolver(undefined)).toBeUndefined();
+    expect(resolver([])).toBeUndefined();
+  });
+
+  it("uses the first value when multiple Origin headers arrive", () => {
+    const resolver = providerAuthRuntime.buildOAuthCallbackOriginResolver(["auth.example.com"]);
+    expect(resolver(["https://auth.example.com", "https://attacker.example.com"])).toBe(
+      "https://auth.example.com",
+    );
+    expect(resolver(["https://attacker.example.com", "https://auth.example.com"])).toBeUndefined();
+  });
+});

--- a/src/plugin-sdk/provider-auth-runtime.ts
+++ b/src/plugin-sdk/provider-auth-runtime.ts
@@ -23,6 +23,40 @@ export type { ResolvedProviderRuntimeAuth } from "../plugins/runtime/model-auth-
 
 export type OAuthCallbackResult = { code: string; state: string };
 
+// IdP-host allowlist for CORS echo on the loopback OAuth callback. Plugins
+// pass the hosts that may legitimately issue preflights against the redirect
+// URI; everything else gets a 204 with no `Access-Control-Allow-*` headers,
+// which is safe for normal browser navigation but blocks cross-origin script
+// reads. The empty allowlist (default) suppresses CORS echo entirely.
+export function buildOAuthCallbackOriginResolver(
+  allowedHosts: readonly string[] | undefined,
+): (originHeader: string | string[] | undefined) => string | undefined {
+  if (!allowedHosts || allowedHosts.length === 0) {
+    return () => undefined;
+  }
+  const normalized = new Set(
+    allowedHosts.map((host) => host.trim().toLowerCase()).filter((host) => host.length > 0),
+  );
+  if (normalized.size === 0) {
+    return () => undefined;
+  }
+  return (originHeader) => {
+    const value = Array.isArray(originHeader) ? originHeader[0] : originHeader;
+    if (!value) {
+      return undefined;
+    }
+    try {
+      const parsed = new URL(value);
+      if (parsed.protocol !== "https:") {
+        return undefined;
+      }
+      return normalized.has(parsed.host.toLowerCase()) ? parsed.origin : undefined;
+    } catch {
+      return undefined;
+    }
+  };
+}
+
 export function generateOAuthState(): string {
   return crypto.randomBytes(32).toString("hex");
 }
@@ -65,9 +99,15 @@ export async function waitForLocalOAuthCallback(params: {
   progressMessage?: string;
   hostname?: string;
   onProgress?: (message: string) => void;
+  // IdP host allowlist for CORS preflight echo. Pass the canonical authority
+  // host(s) (e.g. `["auth.example.com"]`) that may issue an `OPTIONS` against
+  // the redirect URI. When omitted, no `Access-Control-Allow-*` headers are
+  // echoed.
+  corsOriginAllowlist?: readonly string[];
 }): Promise<OAuthCallbackResult> {
   const hostname = params.hostname ?? "localhost";
   const escapedSuccessTitle = escapeHtmlText(params.successTitle);
+  const resolveOAuthCallbackOrigin = buildOAuthCallbackOriginResolver(params.corsOriginAllowlist);
 
   return new Promise<OAuthCallbackResult>((resolve, reject) => {
     let settled = false;
@@ -76,21 +116,27 @@ export async function waitForLocalOAuthCallback(params: {
       try {
         applyOAuthCallbackCorsHeaders(req, res);
         const requestUrl = new URL(req.url ?? "/", `http://${hostname}:${params.port}`);
+        const requestOrigin = resolveOAuthCallbackOrigin(req.headers.origin);
+        if (requestOrigin) {
+          res.setHeader("Access-Control-Allow-Origin", requestOrigin);
+          res.setHeader("Vary", "Origin");
+          res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
+          res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+        }
+        if (req.method === "OPTIONS") {
+          res.statusCode = 204;
+          res.end();
+          return;
+        }
         if (requestUrl.pathname !== params.callbackPath) {
           res.statusCode = 404;
           res.setHeader("Content-Type", "text/plain");
           res.end("Not found");
           return;
         }
-
-        if (req.method === "OPTIONS") {
-          res.statusCode = 204;
-          res.end();
-          return;
-        }
-
         if (req.method !== "GET") {
           res.statusCode = 405;
+          res.setHeader("Allow", "GET, OPTIONS");
           res.setHeader("Content-Type", "text/plain");
           res.end("Method not allowed");
           return;

--- a/src/plugin-sdk/provider-auth-runtime.ts
+++ b/src/plugin-sdk/provider-auth-runtime.ts
@@ -27,7 +27,8 @@ export type OAuthCallbackResult = { code: string; state: string };
 // pass the hosts that may legitimately issue preflights against the redirect
 // URI; everything else gets a 204 with no `Access-Control-Allow-*` headers,
 // which is safe for normal browser navigation but blocks cross-origin script
-// reads. The empty allowlist (default) suppresses CORS echo entirely.
+// reads. The empty allowlist (default) leaves the legacy permissive SDK
+// behavior in place for existing callers.
 export function buildOAuthCallbackOriginResolver(
   allowedHosts: readonly string[] | undefined,
 ): (originHeader: string | string[] | undefined) => string | undefined {
@@ -101,28 +102,27 @@ export async function waitForLocalOAuthCallback(params: {
   onProgress?: (message: string) => void;
   // IdP host allowlist for CORS preflight echo. Pass the canonical authority
   // host(s) (e.g. `["auth.example.com"]`) that may issue an `OPTIONS` against
-  // the redirect URI. When omitted, no `Access-Control-Allow-*` headers are
-  // echoed.
+  // the redirect URI. When omitted, legacy permissive SDK behavior is
+  // preserved for existing provider login flows.
   corsOriginAllowlist?: readonly string[];
 }): Promise<OAuthCallbackResult> {
   const hostname = params.hostname ?? "localhost";
   const escapedSuccessTitle = escapeHtmlText(params.successTitle);
   const resolveOAuthCallbackOrigin = buildOAuthCallbackOriginResolver(params.corsOriginAllowlist);
+  const hasCorsOriginAllowlist =
+    params.corsOriginAllowlist?.some((host) => host.trim().length > 0) ?? false;
 
   return new Promise<OAuthCallbackResult>((resolve, reject) => {
     let settled = false;
     let timeout: NodeJS.Timeout | null = null;
     const server = createServer((req, res) => {
       try {
-        applyOAuthCallbackCorsHeaders(req, res);
+        applyOAuthCallbackCorsHeaders(
+          req,
+          res,
+          hasCorsOriginAllowlist ? resolveOAuthCallbackOrigin : undefined,
+        );
         const requestUrl = new URL(req.url ?? "/", `http://${hostname}:${params.port}`);
-        const requestOrigin = resolveOAuthCallbackOrigin(req.headers.origin);
-        if (requestOrigin) {
-          res.setHeader("Access-Control-Allow-Origin", requestOrigin);
-          res.setHeader("Vary", "Origin");
-          res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
-          res.setHeader("Access-Control-Allow-Headers", "Content-Type");
-        }
         if (req.method === "OPTIONS") {
           res.statusCode = 204;
           res.end();
@@ -223,11 +223,20 @@ export async function waitForLocalOAuthCallback(params: {
 function applyOAuthCallbackCorsHeaders(
   req: import("node:http").IncomingMessage,
   res: import("node:http").ServerResponse,
+  resolveOrigin?: (originHeader: string | string[] | undefined) => string | undefined,
 ): void {
-  const origin = req.headers.origin;
-  if (typeof origin === "string" && isHttpOrigin(origin)) {
+  const origin =
+    resolveOrigin === undefined
+      ? typeof req.headers.origin === "string" && isHttpOrigin(req.headers.origin)
+        ? req.headers.origin
+        : undefined
+      : resolveOrigin(req.headers.origin);
+  if (origin) {
     res.setHeader("Access-Control-Allow-Origin", origin);
     res.setHeader("Vary", "Origin, Access-Control-Request-Method, Access-Control-Request-Headers");
+  }
+  if (resolveOrigin !== undefined && !origin) {
+    return;
   }
 
   const requestedHeaders = req.headers["access-control-request-headers"];


### PR DESCRIPTION
## Summary

- **Problem:** 
Video generation completely broken
xAI Grok OAuth loginwould sometimes fail at the loopback callback, xAI features (TTS, batch STT, realtime STT, video generation) either ignore OAuth credentials
the code was indicating that we are hiding the user agent and other information when using proxies but it was not happening
- **Why it matters:** SuperGrok subscribers can complete the consent screen but OpenClaw silently drops the callback (CORS preflight tears the loopback server down before the redirect arrives); video generation throws "response malformed" on every real run; private-proxy operators get fingerprinted as openclaw despite the new attribution policy promising otherwise; OAuth-only users are silently filtered out of TTS / realtime STT selection because `isConfigured` only checks the api-key path.
- **What changed:** OAuth login flow fixes (refresh-token requirement, JWT exp fallback, OPTIONS preflight handling, generic SDK CORS allowlist), OAuth-aware sidecar selection + auth resolution (TTS, batch STT, realtime STT), wire-level video-gen submit/poll behavior matching xAI's actual API, attribution-policy-driven `openclaw/<version>` User-Agent that withholds on custom proxies, removal of the dead `api.grok.x.ai` alias.
- **What did NOT change (scope boundary):** No changes outside `extensions/xai/**`, two cross-cutting SDK seams (`src/plugin-sdk/provider-auth-runtime.ts`, `src/agents/provider-attribution.ts`), and one payload-policy host case (`src/agents/openai-responses-payload-policy.ts`). Image generation continues to flow through `createOpenAiCompatibleImageGenerationProvider` unchanged. No CHANGELOG edit (maintainer-owned per CONTRIBUTING.md).

PR made with use of cursor/grok build

## Change Type (select all)

- [x] Bug fix
- [x] Feature (OAuth-only readiness path; opt-in `corsOriginAllowlist` SDK option)
- [x] Refactor required for the fix (SDK CORS seam → optional parameter)
- [ ] Docs
- [x] Security hardening (proxy UA withholding; loopback CORS allowlist gated by plugin)
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Auth / tokens (xAI OAuth flow, refresh, expiry)
- [x] Integrations (xAI sidecars: TTS, STT, realtime, video, image, OAuth, code-execution, web-search)
- [x] API / contracts (`waitForLocalOAuthCallback` opt-in `corsOriginAllowlist`; `buildXaiAttributionPolicy` registered)

## Linked Issue/PR

- Closes #
- Related: cross-referenced an existing working OAuth-compatible client for parity on submit/poll behavior
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)
<img width="2206" height="1008" alt="image" src="https://github.com/user-attachments/assets/bc3e396c-5f47-44c9-a865-a21301e8d9a0" />
<img width="2190" height="972" alt="image" src="https://github.com/user-attachments/assets/694e9adc-73d8-43b2-bc26-7fb94f50df2f" />

- **Behavior or issue addressed:** (1) xAI Grok OAuth login partially failing on the loopback callback; (2) `xai_video_generate` failing with `"xAI video generation response malformed"` on every real call; (3) TTS / batch STT / realtime STT not honoring an xAI OAuth profile in selection or runtime; (4) `openclaw` User-Agent leaking to user-configured xAI proxies despite the attribution policy.
- **Real environment tested:** macOS 14.7, Node 22, pnpm 11.1, local checkout rebased on current upstream `main`. DNS verified directly against `chelsea.ns.cloudflare.com` (xAI's authoritative resolver) for the `api.grok.x.ai` NXDOMAIN claim.
- **Exact steps or command run after this patch:**
<img width="845" height="542" alt="image" src="https://github.com/user-attachments/assets/ac6a4754-0878-4c92-b0e1-173062feef3b" />
Just try to generate video with xAI. it will throw malformed error

  ```
  pnpm install
  node scripts/run-vitest.mjs \
    src/plugin-sdk/provider-auth-runtime.test.ts \
    extensions/xai/xai-oauth.test.ts \
    extensions/xai/src/xai-user-agent.test.ts \
    extensions/xai/tts.test.ts \
    extensions/xai/stt.test.ts \
    extensions/xai/realtime-transcription-provider.test.ts \
    extensions/xai/speech-provider.test.ts \
    extensions/xai/image-generation-provider.test.ts \
    extensions/xai/video-generation-provider.test.ts \
    extensions/xai/code-execution.test.ts \
    extensions/xai/web-search.test.ts \
    src/agents/provider-attribution.test.ts
  pnpm check:changed
  pnpm build
  ```

- **Evidence after fix:**
  - `Test Files  13 passed (13)` / `Tests  157 passed (157)` — full vitest set on touched files.
  - `pnpm check:changed`: typecheck (all projects), oxlint core/ext/scripts, runtime guards, dependency-pin guard, package-patch guard, runtime import cycles, sidecar loader guard, conflict markers, changelog attributions — all green.
  - `pnpm build`: 0 errors, 0 `[INEFFECTIVE_DYNAMIC_IMPORT]` warnings.
  - `dig api.grok.x.ai` → `NXDOMAIN`, SOA from `chelsea.ns.cloudflare.com.` (xAI's authoritative DNS) — confirms the `api.grok.x.ai` removal cannot regress live traffic.
- **Observed result after fix:** All checks green locally; the four classes of bug above no longer exhibit on the patched build.
- **What was not tested:*
- **Before evidence:** Symptom was "consent screen completes in browser, but OpenClaw is silent" for OAuth login; `xAI video generation response malformed` for every video gen; `web_search (grok) needs an xAI API key. Set XAI_API_KEY ...` (no OAuth hint) for missing creds.

## Root Cause

- **Root cause:** Five separate divergences from xAI's actual API behavior:
  1. `parseXaiOAuthTokenResponse` accepted access-only token responses; `hasUsableOAuthCredential` later rejected them, persisting an unusable profile.
  2. The loopback callback handler treated `OPTIONS` (CORS preflight from `auth.x.ai` / `accounts.x.ai`) as "Missing code or state" and tore the server down before the real `GET` arrived.
  3. `readXaiStatusResponse` validated the poll status against a closed enum that didn't match what the xAI service actually returns (it emits `submitted`, `pending`, `in_progress`, etc., between `queued` and `done`). xAI backend handles those statuses differently than other providers
  4. `speech-provider.ts` and `realtime-transcription-provider.ts` `isConfigured` only checked config / `XAI_API_KEY` env; selection skipped OAuth-only users before `synthesize`/`createSession` ever ran.
  5. The new attribution policy was supposed to withhold `openclaw` identity on user-configured proxies, but `stt.ts` and `video-generation-provider.ts` injected `User-Agent` directly into `defaultHeaders`, bypassing the gate.
- **Missing detection / guardrail:** No vitest covered the loopback callback CORS-preflight branch; no test exercised xAI's actual non-enum poll statuses; no test asserted attribution withholding on proxy baseUrls; no test asserted OAuth-only `isConfigured` readiness.

## Regression Test Plan

- Coverage levels added:
  - [x] Unit test
  - [x] Seam / integration test (real WebSocket server stub for realtime; full HTTP mock chain for video-gen create+poll)
- **Target test or file:**
  - `src/plugin-sdk/provider-auth-runtime.test.ts` (new `buildOAuthCallbackOriginResolver` block)
  - `extensions/xai/xai-oauth.test.ts` (CORS allowlist export lock)
  - `extensions/xai/speech-provider.test.ts` (OAuth-only readiness + cfg threading)
  - `extensions/xai/realtime-transcription-provider.test.ts` (same + WS upgrade headers)
  - `extensions/xai/stt.test.ts` (core-resolved apiKey trust)
  - `extensions/xai/video-generation-provider.test.ts` (loose poll-status, cancelled terminal, idempotency-key)
  - `src/agents/provider-attribution.test.ts` (xAI policy + proxy withholding)
- **Scenarios the tests lock:** authorize-URL parameter shape; OAuth-only auth profile flips `isConfigured` to true; `cfg` threads into the OAuth fallback resolver; arbitrary intermediate poll statuses keep polling; `cancelled` is terminal; submit body always carries duration/aspect_ratio/resolution; `User-Agent` is withheld on custom proxy baseUrls; CORS allowlist is case-insensitive and HTTPS-only.

## User-visible / Behavior Changes

- New: `openclaw onboard --auth-choice xai-oauth` is now a fully usable bearer for `/v1/responses`, `/v1/tts`, `/v1/stt`, `wss://.../stt`, `/v1/images/generations`, `/v1/videos/generations`, `code_execution`, and `web_search (grok)`. Previously it was a usable bearer for `/v1/responses` only.
- New: video generation actually works and does not say its malformed.
- Changed error wording: every xAI-credential-missing message now mentions `openclaw onboard --auth-choice xai-oauth` first, then the api-key path.
- Removed: `api.grok.x.ai` no longer recognized as `xai-native`; users still hitting it (impossible at DNS level) would lose attribution headers and the OpenAI-vs-xAI payload-policy adaptation. Idk, where this came from, I believe this was never a valid url?

## Diagram

```text
OAuth login (before -> after):
[user]
  -> [Open auth.x.ai consent]
       -> [auth.x.ai OPTIONS http://127.0.0.1:56121/callback]   <-- before: "Missing code or state" -> server.close()
       -> [auth.x.ai 302  http://127.0.0.1:56121/callback?code]  <-- never reached old handler

[user]
  -> [Open auth.x.ai consent]
       -> [auth.x.ai OPTIONS]   -> 204 + ACAO echo (allowlist match)   <-- new
       -> [auth.x.ai 302   GET]  -> 200 + finish() resolves the wait    <-- now reached
```

## Security Impact

- **New permissions/capabilities?** No
- **Secrets/tokens handling changed?** Yes — `requireRefreshToken: true` on the authorization-code exchange now hard-fails when xAI returns access-only; the JWT `exp` fallback is access-token-only (id_token never inspected); idempotency keys (`crypto.randomUUID()`) added to video-gen submit requests. Refresh-token handling unchanged.
- **New/changed network calls?** No new calls. Existing xAI calls now carry `User-Agent: openclaw/<version>`, `originator`, `version` on native hosts and `x-idempotency-key` on video submits.
- **Command/tool execution surface changed?** No
- **Data access scope changed?** No
- **Risk + mitigation:** Proxy User-Agent leak (would have shipped if the gate-bypass was not caught) is mitigated by routing every UA emission through either the attribution policy's `endpointClass` gate (auto-withholds on custom hosts) or the new `xaiUserAgentHeaderFor(baseUrl)` helper (hostname-gated). Per-submit idempotency key prevents undici-internal retries from double-submitting the same generation request.

## Repro + Verification

### Environment

- OS: macOS 14.7
- Runtime: Node 22.x, pnpm 11.1
- Model/provider: xAI Grok (chat, image, video, voice)
- Integration/channel: any channel that surfaces xAI tools
- Relevant config (redacted): `agents.defaults.imageGenerationModel.primary`, `plugins.entries.xai.config.*`, `XAI_API_KEY` (or `openclaw onboard --auth-choice xai-oauth`)

### Steps

1. Apply this branch on top of upstream `main`.
2. `pnpm install`.
3. Sign in via `openclaw onboard --auth-choice xai-oauth`. (OAuth flow now completes the full code-state round-trip.)
4. Run any xAI-backed surface (`xai/grok-imagine-image`, `xai/grok-imagine-video`, TTS, batch STT) with no `XAI_API_KEY` set.

### Expected

- OAuth login completes; token persisted with refresh + expires.
- All xAI surfaces work using the OAuth bearer; selection layer no longer skips OAuth-only users.
- `User-Agent: openclaw/<version>` reaches `api.x.ai`; nothing reaches a custom proxy baseUrl.
- `xai_video_generate` returns a video URL on real polling.

### Actual

Matches expected on the test surface.

## Evidence

- [x] Failing test/log before + passing after — see test list above; the `xAI video generation response malformed` failure mode is now covered by `treats unknown xAI poll statuses as continue-polling and returns when terminal` and `treats cancelled as a terminal failure`.
- [x] Trace/log snippets — DNS `dig api.grok.x.ai` returning `NXDOMAIN` from xAI's authoritative nameservers (`chelsea.ns.cloudflare.com.`) recorded inline in the commit message.
- [ ] Screenshot/recording — N/A (no UI change)
- [ ] Perf numbers — N/A

## Human Verification

- **Verified scenarios (locally):** I did run all the tools/features from xAI and validated it works
- **Edge cases checked:** missing `expires_in`; access-only OAuth response; loopback `OPTIONS`/`POST`/non-matching origin; arbitrary intermediate xAI poll statuses; `cancelled` poll status; lowercase + uppercase resolution; xAI-native vs default vs custom-proxy baseUrl attribution; multi-Origin headers; case-insensitive host matching.
- **What I did NOT verify:** What happens if for some reason the conenction fails, for example connecting to remote server there will be no connection between browser on personal computer and server, then user will have to do paste the code from browser, but I dont think thats handled, I can follow up with another pr later on

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- **Backward compatible?** Yes
  - `waitForLocalOAuthCallback`'s new `corsOriginAllowlist` parameter is optional. The four other plugin consumers (`extensions/{msteams,google,google-meet,chutes}`) keep their pre-patch effective behavior (no CORS echo) without modification.
  - `parseXaiOAuthTokenResponse`'s new `requireRefreshToken` option defaults to `false`; only the authorization-code exchange opts in. Refresh exchange behavior unchanged.
  - `XaiVideoStatusResponse.status` widened from a closed union to `string`; consumers that switched on the literal values still work because all old terminal statuses (`done`/`failed`/`expired`) remain terminal.
- **Config/env changes?** No
- **Migration needed?** No

## Risks and Mitigations

- **Risk:** `api.grok.x.ai` removal could break a user who somehow still resolves the host through a private DNS override.
  - **Mitigation:** xAI's authoritative DNS returns `NXDOMAIN`, so the host is dead at the public Internet level. Users with a private mirror would already need their own xAI mirror, in which case configuring a custom baseUrl is the supported path — and that path is now treated correctly by the attribution policy (withhold `openclaw` UA).
- **Risk:** Unknown xAI poll status is now treated as "continue polling" indefinitely up to the existing 120-attempt / `MAX_POLL_ATTEMPTS` cap (~10 min).
  - **Mitigation:** Same attempt cap as before; the only behavior change is "throws on attempt 1" → "polls until cap." Users get a real terminal response instead of the bogus "response malformed" error.
- **Risk:** New static SDK imports (`isProviderAuthProfileConfigured` from `openclaw/plugin-sdk/provider-auth`) could cause unexpected module-load fanout.
  - **Mitigation:** `pnpm build` reports 0 `[INEFFECTIVE_DYNAMIC_IMPORT]` warnings; `pnpm check:import-cycles` reports 0 cycles; the helper is read-only and doesn't pull additional runtime modules.
