### PR TITLE
fix(cli): keep subcommand help lightweight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 
 - Mac app: keep app-level menu commands and Dashboard failure states reachable when the remote Gateway is disconnected, and keep the Settings sidebar toggle in the leading titlebar area.
 - Gateway/webchat: hide internal runtime-context and other `display: false` transcript messages from Chat history and live message events. Fixes #83216. Thanks @EmpireCreator.
+- CLI/help: keep `gateway`, `doctor`, `status`, and `health` help registration out of action/runtime imports so subcommand `--help` stays lightweight in constrained terminals. Fixes #83228. Thanks @dfguerrerom.
 - Mac app: align the Sessions settings pane with the standard Settings page gutter and row spacing.
 - OpenAI/Codex: stop rejecting available `openai-codex` GPT-5.1, GPT-5.2, and GPT-5.3 model refs during config validation, while keeping removed Spark aliases suppressed. Fixes #83303.
 - Codex app-server: preserve streamed native command output in mirrored transcripts and trajectory exports when final snapshots omit aggregated output. (#83200) Thanks @rozmiarD.

--- a/scripts/check-cli-bootstrap-imports.mjs
+++ b/scripts/check-cli-bootstrap-imports.mjs
@@ -7,7 +7,10 @@ import { fileURLToPath } from "node:url";
 
 const DEFAULT_ENTRYPOINTS = ["dist/entry.js", "dist/cli/run-main.js"];
 const DEFAULT_GATEWAY_RUN_CHUNK_MAX_BYTES = 70 * 1024;
-const GATEWAY_RUN_CHUNK_MARKERS = ["const GATEWAY_RUN_VALUE_KEYS", "function addGatewayRunCommand"];
+const GATEWAY_RUN_CHUNK_MARKER_SETS = [
+  ["const GATEWAY_AUTH_MODES", "function addGatewayRunCommand"],
+  ["const GATEWAY_RUN_VALUE_KEYS", "function addGatewayRunCommand"],
+];
 const GATEWAY_RUN_FORBIDDEN_STATIC_IMPORTS = [
   "control-ui-assets",
   "diagnostic-stability-bundle",
@@ -164,7 +167,11 @@ export function collectGatewayRunChunkBudgetErrors(params = {}) {
     } catch {
       continue;
     }
-    if (GATEWAY_RUN_CHUNK_MARKERS.every((marker) => source.includes(marker))) {
+    if (
+      GATEWAY_RUN_CHUNK_MARKER_SETS.some((markers) =>
+        markers.every((marker) => source.includes(marker)),
+      )
+    ) {
       chunks.push({ filePath, source });
     }
   }

--- a/src/cli/gateway-cli/register.option-collisions.test.ts
+++ b/src/cli/gateway-cli/register.option-collisions.test.ts
@@ -55,7 +55,7 @@ vi.mock("./call.js", () => ({
     mocks.callGatewayCli(method, opts, params),
 }));
 
-vi.mock("./run.js", () => ({
+vi.mock("./run-command.js", () => ({
   addGatewayRunCommand: (cmd: Command) =>
     cmd
       .option("--token <token>", "Gateway token")

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -1,14 +1,11 @@
 import type { Command } from "commander";
 import type { HealthSummary } from "../../commands/health.js";
-import { formatGatewayTransportErrorJson } from "../../gateway/call.js";
 import type { CostUsageSummary } from "../../infra/session-cost-usage.js";
 import type {
   DiagnosticStabilityBundle,
   ReadDiagnosticStabilityBundleResult,
 } from "../../logging/diagnostic-stability-bundle.js";
 import {
-  normalizeDiagnosticStabilityQuery,
-  selectDiagnosticStabilitySnapshot,
   type DiagnosticStabilityEventRecord,
   type DiagnosticStabilitySnapshot,
 } from "../../logging/diagnostic-stability.js";
@@ -17,21 +14,12 @@ import { defaultRuntime } from "../../runtime.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { formatDocsLink } from "../../terminal/links.js";
 import { colorize, isRich, theme } from "../../terminal/theme.js";
-import { runCommandWithRuntime } from "../cli-utils.js";
 import { inheritOptionFromParent } from "../command-options.js";
 import { addGatewayServiceCommands } from "../daemon-cli/register-service-commands.js";
 import { formatHelpExamples } from "../help-format.js";
-import { withProgress } from "../progress.js";
-import { callGatewayCli, gatewayCallOpts, type GatewayRpcOpts } from "./call.js";
+import type { GatewayRpcOpts } from "./call.js";
 import type { GatewayDiscoverOpts } from "./discover.js";
-import {
-  dedupeBeacons,
-  parseDiscoverTimeoutMs,
-  pickBeaconHost,
-  pickGatewayPort,
-  renderBeaconLines,
-} from "./discover.js";
-import { addGatewayRunCommand } from "./run.js";
+import { addGatewayRunCommand } from "./run-command.js";
 
 const configModuleLoader = createLazyImportLoader(
   () => import("../../config/read-best-effort-config.runtime.js"),
@@ -98,9 +86,31 @@ function loadDaemonStatusGatherModule() {
   return daemonStatusGatherModuleLoader.load();
 }
 
-function runGatewayCommand(action: () => Promise<void>, label?: string, opts?: { json?: boolean }) {
-  return runCommandWithRuntime(defaultRuntime, action, (err) => {
+function gatewayCallOpts(cmd: Command): Command {
+  return cmd
+    .option("--url <url>", "Gateway WebSocket URL (defaults to gateway.remote.url when configured)")
+    .option("--token <token>", "Gateway token (if required)")
+    .option("--password <password>", "Gateway password (password auth)")
+    .option("--timeout <ms>", "Timeout in ms", "10000")
+    .option("--expect-final", "Wait for final response (agent)", false)
+    .option("--json", "Output JSON", false);
+}
+
+async function callGatewayCli(method: string, opts: GatewayRpcOpts, params?: unknown) {
+  const mod = await import("./call.js");
+  return mod.callGatewayCli(method, opts, params);
+}
+
+async function runGatewayCommand(
+  action: () => Promise<void>,
+  label?: string,
+  opts?: { json?: boolean },
+) {
+  try {
+    await action();
+  } catch (err) {
     if (opts?.json) {
+      const { formatGatewayTransportErrorJson } = await import("../../gateway/call.js");
       const payload = formatGatewayTransportErrorJson(err);
       if (payload) {
         defaultRuntime.writeJson(payload);
@@ -111,7 +121,7 @@ function runGatewayCommand(action: () => Promise<void>, label?: string, opts?: {
     const message = String(err);
     defaultRuntime.error(label ? `${label}: ${message}` : message);
     defaultRuntime.exit(1);
-  });
+  }
 }
 
 function parseDaysOption(raw: unknown, fallback = 30): number {
@@ -550,6 +560,8 @@ export function registerGatewayCli(program: Command) {
       .option("--output <path>", "Diagnostics export output .zip path")
       .action(async (opts, command) => {
         await runGatewayCommand(async () => {
+          const { normalizeDiagnosticStabilityQuery, selectDiagnosticStabilitySnapshot } =
+            await import("../../logging/diagnostic-stability.js");
           const rpcOpts = resolveGatewayRpcOptions(opts, command);
           const query = normalizeDiagnosticStabilityQuery(
             {
@@ -676,10 +688,20 @@ export function registerGatewayCli(program: Command) {
           { readSourceConfigBestEffort },
           { discoverGatewayBeacons },
           { resolveWideAreaDiscoveryDomain },
+          {
+            dedupeBeacons,
+            parseDiscoverTimeoutMs,
+            pickBeaconHost,
+            pickGatewayPort,
+            renderBeaconLines,
+          },
+          { withProgress },
         ] = await Promise.all([
           loadConfigModule(),
           loadBonjourDiscoveryModule(),
           loadWideAreaDnsModule(),
+          import("./discover.js"),
+          import("../progress.js"),
         ]);
         const cfg = await readSourceConfigBestEffort();
         const wideAreaDomain = resolveWideAreaDiscoveryDomain({

--- a/src/cli/gateway-cli/run-command.ts
+++ b/src/cli/gateway-cli/run-command.ts
@@ -1,0 +1,60 @@
+import type { Command } from "commander";
+
+const GATEWAY_AUTH_MODES = ["none", "token", "password", "trusted-proxy"] as const;
+const GATEWAY_TAILSCALE_MODES = ["off", "serve", "funnel"] as const;
+
+function formatModeChoices(modes: readonly string[]): string {
+  return modes.map((mode) => `"${mode}"`).join("|");
+}
+
+export function addGatewayRunCommand(cmd: Command): Command {
+  return cmd
+    .option("--port <port>", "Port for the gateway WebSocket")
+    .option(
+      "--bind <mode>",
+      'Bind mode ("loopback"|"lan"|"tailnet"|"auto"|"custom"). Defaults to config gateway.bind (or loopback).',
+    )
+    .option(
+      "--token <token>",
+      "Shared token required in connect.params.auth.token (default: OPENCLAW_GATEWAY_TOKEN env if set)",
+    )
+    .option("--auth <mode>", `Gateway auth mode (${formatModeChoices(GATEWAY_AUTH_MODES)})`)
+    .option("--password <password>", "Password for auth mode=password")
+    .option("--password-file <path>", "Read gateway password from file")
+    .option(
+      "--tailscale <mode>",
+      `Tailscale exposure mode (${formatModeChoices(GATEWAY_TAILSCALE_MODES)})`,
+    )
+    .option(
+      "--tailscale-reset-on-exit",
+      "Reset Tailscale serve/funnel configuration on shutdown",
+      false,
+    )
+    .option(
+      "--allow-unconfigured",
+      "Allow gateway start without enforcing gateway.mode=local in config (does not repair config)",
+      false,
+    )
+    .option("--dev", "Create a dev config + workspace if missing (no BOOTSTRAP.md)", false)
+    .option(
+      "--reset",
+      "Reset dev config + credentials + sessions + workspace (requires --dev)",
+      false,
+    )
+    .option("--force", "Kill any existing listener on the target port before starting", false)
+    .option("--verbose", "Verbose logging to stdout/stderr", false)
+    .option(
+      "--cli-backend-logs",
+      "Only show CLI backend logs in the console (includes stdout/stderr)",
+      false,
+    )
+    .option("--claude-cli-logs", "Deprecated alias for --cli-backend-logs", false)
+    .option("--ws-log <style>", 'WebSocket log style ("auto"|"full"|"compact")', "auto")
+    .option("--compact", 'Alias for "--ws-log compact"', false)
+    .option("--raw-stream", "Log raw model stream events to jsonl", false)
+    .option("--raw-stream-path <path>", "Raw stream jsonl path")
+    .action(async (opts, command) => {
+      const { resolveGatewayRunOptions, runGatewayCommand } = await import("./run.js");
+      await runGatewayCommand(resolveGatewayRunOptions(opts, command));
+    });
+}

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -199,11 +199,11 @@ vi.mock("./run-loop.js", () => ({
 }));
 
 describe("gateway run option collisions", () => {
-  let addGatewayRunCommand: typeof import("./run.js").addGatewayRunCommand;
+  let addGatewayRunCommand: typeof import("./run-command.js").addGatewayRunCommand;
   let sharedProgram: Command;
 
   beforeAll(async () => {
-    ({ addGatewayRunCommand } = await import("./run.js"));
+    ({ addGatewayRunCommand } = await import("./run-command.js"));
     sharedProgram = new Command();
     sharedProgram.exitOverride();
     const gateway = addGatewayRunCommand(sharedProgram.command("gateway"));

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -200,10 +200,6 @@ function parseEnumOption<T extends string>(
   return (allowed as readonly string[]).includes(raw) ? (raw as T) : null;
 }
 
-function formatModeChoices(modes: readonly string[]): string {
-  return modes.map((mode) => `"${mode}"`).join("|");
-}
-
 function formatModeErrorList(modes: readonly string[]): string {
   const quoted = modes.map((mode) => `"${mode}"`);
   if (quoted.length === 0) {
@@ -303,7 +299,7 @@ async function readGatewayStartupConfig(params: {
   };
 }
 
-function resolveGatewayRunOptions(opts: GatewayRunOpts, command?: Command): GatewayRunOpts {
+export function resolveGatewayRunOptions(opts: GatewayRunOpts, command?: Command): GatewayRunOpts {
   const resolved: GatewayRunOpts = { ...opts };
 
   for (const key of GATEWAY_RUN_VALUE_KEYS) {
@@ -467,7 +463,7 @@ async function maybeWriteGatewayStartupFailureBundle(err: unknown): Promise<void
   }
 }
 
-async function runGatewayCommand(opts: GatewayRunOpts) {
+export async function runGatewayCommand(opts: GatewayRunOpts) {
   installQaParentWatchdog();
   const isDevProfile = normalizeOptionalLowercaseString(process.env.OPENCLAW_PROFILE) === "dev";
   const devMode = Boolean(opts.dev) || isDevProfile;
@@ -866,54 +862,3 @@ export const __testing = {
   resolveGatewayLockErrorExitCode,
   runGatewayLoopWithSupervisedLockRecovery,
 };
-
-export function addGatewayRunCommand(cmd: Command): Command {
-  return cmd
-    .option("--port <port>", "Port for the gateway WebSocket")
-    .option(
-      "--bind <mode>",
-      'Bind mode ("loopback"|"lan"|"tailnet"|"auto"|"custom"). Defaults to config gateway.bind (or loopback).',
-    )
-    .option(
-      "--token <token>",
-      "Shared token required in connect.params.auth.token (default: OPENCLAW_GATEWAY_TOKEN env if set)",
-    )
-    .option("--auth <mode>", `Gateway auth mode (${formatModeChoices(GATEWAY_AUTH_MODES)})`)
-    .option("--password <password>", "Password for auth mode=password")
-    .option("--password-file <path>", "Read gateway password from file")
-    .option(
-      "--tailscale <mode>",
-      `Tailscale exposure mode (${formatModeChoices(GATEWAY_TAILSCALE_MODES)})`,
-    )
-    .option(
-      "--tailscale-reset-on-exit",
-      "Reset Tailscale serve/funnel configuration on shutdown",
-      false,
-    )
-    .option(
-      "--allow-unconfigured",
-      "Allow gateway start without enforcing gateway.mode=local in config (does not repair config)",
-      false,
-    )
-    .option("--dev", "Create a dev config + workspace if missing (no BOOTSTRAP.md)", false)
-    .option(
-      "--reset",
-      "Reset dev config + credentials + sessions + workspace (requires --dev)",
-      false,
-    )
-    .option("--force", "Kill any existing listener on the target port before starting", false)
-    .option("--verbose", "Verbose logging to stdout/stderr", false)
-    .option(
-      "--cli-backend-logs",
-      "Only show CLI backend logs in the console (includes stdout/stderr)",
-      false,
-    )
-    .option("--claude-cli-logs", "Deprecated alias for --cli-backend-logs", false)
-    .option("--ws-log <style>", 'WebSocket log style ("auto"|"full"|"compact")', "auto")
-    .option("--compact", 'Alias for "--ws-log compact"', false)
-    .option("--raw-stream", "Log raw model stream events to jsonl", false)
-    .option("--raw-stream-path <path>", "Raw stream jsonl path")
-    .action(async (opts, command) => {
-      await runGatewayCommand(resolveGatewayRunOptions(opts, command));
-    });
-}

--- a/src/cli/help-cold-imports.test.ts
+++ b/src/cli/help-cold-imports.test.ts
@@ -1,0 +1,183 @@
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const loaded = vi.hoisted(() => {
+  const modules = new Set<string>();
+  return {
+    modules,
+    mark(name: string) {
+      modules.add(name);
+    },
+  };
+});
+
+vi.mock("./gateway-cli/run.js", () => {
+  loaded.mark("gateway-run-runtime");
+  return {
+    resolveGatewayRunOptions: vi.fn((opts) => opts),
+    runGatewayCommand: vi.fn(async () => {}),
+  };
+});
+
+vi.mock("./gateway-cli/call.js", () => {
+  loaded.mark("gateway-call-runtime");
+  return {
+    callGatewayCli: vi.fn(async () => ({})),
+  };
+});
+
+vi.mock("../gateway/call.js", () => {
+  loaded.mark("gateway-transport-runtime");
+  return {
+    formatGatewayTransportErrorJson: vi.fn(() => null),
+  };
+});
+
+vi.mock("./progress.js", () => {
+  loaded.mark("cli-progress-runtime");
+  return {
+    withProgress: vi.fn(async (_opts, run) => await run({})),
+  };
+});
+
+vi.mock("../commands/doctor.js", () => {
+  loaded.mark("doctor-command");
+  return { doctorCommand: vi.fn(async () => {}) };
+});
+
+vi.mock("../commands/dashboard.js", () => {
+  loaded.mark("dashboard-command");
+  return { dashboardCommand: vi.fn(async () => {}) };
+});
+
+vi.mock("../commands/reset.js", () => {
+  loaded.mark("reset-command");
+  return { resetCommand: vi.fn(async () => {}) };
+});
+
+vi.mock("../commands/uninstall.js", () => {
+  loaded.mark("uninstall-command");
+  return { uninstallCommand: vi.fn(async () => {}) };
+});
+
+vi.mock("../commands/status.js", () => {
+  loaded.mark("status-command");
+  return { statusCommand: vi.fn(async () => {}) };
+});
+
+vi.mock("../commands/health.js", () => {
+  loaded.mark("health-command");
+  return {
+    formatHealthChannelLines: vi.fn(() => []),
+    healthCommand: vi.fn(async () => {}),
+  };
+});
+
+vi.mock("../commands/sessions.js", () => {
+  loaded.mark("sessions-command");
+  return { sessionsCommand: vi.fn(async () => {}) };
+});
+
+vi.mock("../commands/sessions-cleanup.js", () => {
+  loaded.mark("sessions-cleanup-command");
+  return { sessionsCleanupCommand: vi.fn(async () => {}) };
+});
+
+vi.mock("../commands/export-trajectory.js", () => {
+  loaded.mark("export-trajectory-command");
+  return { exportTrajectoryCommand: vi.fn(async () => {}) };
+});
+
+vi.mock("../commands/commitments.js", () => {
+  loaded.mark("commitments-command");
+  return {
+    commitmentsDismissCommand: vi.fn(async () => {}),
+    commitmentsListCommand: vi.fn(async () => {}),
+  };
+});
+
+vi.mock("../commands/tasks.js", () => {
+  loaded.mark("tasks-command");
+  return {
+    tasksAuditCommand: vi.fn(async () => {}),
+    tasksCancelCommand: vi.fn(async () => {}),
+    tasksListCommand: vi.fn(async () => {}),
+    tasksMaintenanceCommand: vi.fn(async () => {}),
+    tasksNotifyCommand: vi.fn(async () => {}),
+    tasksShowCommand: vi.fn(async () => {}),
+  };
+});
+
+vi.mock("../commands/flows.js", () => {
+  loaded.mark("flows-command");
+  return {
+    flowsCancelCommand: vi.fn(async () => {}),
+    flowsListCommand: vi.fn(async () => {}),
+    flowsShowCommand: vi.fn(async () => {}),
+  };
+});
+
+function makeProgram(): Command {
+  const program = new Command();
+  program.name("openclaw");
+  program.exitOverride();
+  return program;
+}
+
+async function expectHelpExit(program: Command, argv: string[]): Promise<void> {
+  await expect(program.parseAsync(argv, { from: "user" })).rejects.toMatchObject({
+    exitCode: 0,
+  });
+}
+
+describe("subcommand help cold imports", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    loaded.modules.clear();
+  });
+
+  it("keeps gateway help out of gateway action/runtime modules", async () => {
+    const { registerGatewayCli } = await import("./gateway-cli/register.js");
+    const program = makeProgram();
+
+    registerGatewayCli(program);
+    await expectHelpExit(program, ["gateway", "--help"]);
+
+    expect(loaded.modules).not.toContain("gateway-run-runtime");
+    expect(loaded.modules).not.toContain("gateway-call-runtime");
+    expect(loaded.modules).not.toContain("gateway-transport-runtime");
+    expect(loaded.modules).not.toContain("cli-progress-runtime");
+  });
+
+  it("keeps maintenance help out of command action modules", async () => {
+    const { registerMaintenanceCommands } = await import("./program/register.maintenance.js");
+    const program = makeProgram();
+
+    registerMaintenanceCommands(program);
+    await expectHelpExit(program, ["doctor", "--help"]);
+
+    expect(loaded.modules).not.toContain("doctor-command");
+    expect(loaded.modules).not.toContain("dashboard-command");
+    expect(loaded.modules).not.toContain("reset-command");
+    expect(loaded.modules).not.toContain("uninstall-command");
+  });
+
+  it("keeps status and health help out of command action modules", async () => {
+    const { registerStatusHealthSessionsCommands } =
+      await import("./program/register.status-health-sessions.js");
+    const program = makeProgram();
+
+    registerStatusHealthSessionsCommands(program);
+    await expectHelpExit(program, ["status", "--help"]);
+    await expectHelpExit(program, ["health", "--help"]);
+
+    expect(loaded.modules).not.toContain("status-command");
+    expect(loaded.modules).not.toContain("health-command");
+    expect(loaded.modules).not.toContain("sessions-command");
+    expect(loaded.modules).not.toContain("sessions-cleanup-command");
+    expect(loaded.modules).not.toContain("export-trajectory-command");
+    expect(loaded.modules).not.toContain("commitments-command");
+    expect(loaded.modules).not.toContain("tasks-command");
+    expect(loaded.modules).not.toContain("flows-command");
+  });
+});

--- a/src/cli/program/register.maintenance.ts
+++ b/src/cli/program/register.maintenance.ts
@@ -1,8 +1,4 @@
 import type { Command } from "commander";
-import { dashboardCommand } from "../../commands/dashboard.js";
-import { doctorCommand } from "../../commands/doctor.js";
-import { resetCommand } from "../../commands/reset.js";
-import { uninstallCommand } from "../../commands/uninstall.js";
 import { defaultRuntime } from "../../runtime.js";
 import { formatDocsLink } from "../../terminal/links.js";
 import { theme } from "../../terminal/theme.js";
@@ -72,6 +68,7 @@ export function registerMaintenanceCommands(program: Command) {
         return;
       }
       await runCommandWithRuntime(defaultRuntime, async () => {
+        const { doctorCommand } = await import("../../commands/doctor.js");
         await doctorCommand(defaultRuntime, {
           workspaceSuggestions: opts.workspaceSuggestions,
           yes: Boolean(opts.yes),
@@ -97,6 +94,7 @@ export function registerMaintenanceCommands(program: Command) {
     .option("--yes", "Start/install the gateway without prompting when needed", false)
     .action(async (opts) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
+        const { dashboardCommand } = await import("../../commands/dashboard.js");
         await dashboardCommand(defaultRuntime, {
           noOpen: opts.open === false,
           yes: Boolean(opts.yes),
@@ -118,6 +116,7 @@ export function registerMaintenanceCommands(program: Command) {
     .option("--dry-run", "Print actions without removing files", false)
     .action(async (opts) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
+        const { resetCommand } = await import("../../commands/reset.js");
         await resetCommand(defaultRuntime, {
           scope: opts.scope,
           yes: Boolean(opts.yes),
@@ -145,6 +144,7 @@ export function registerMaintenanceCommands(program: Command) {
     .option("--dry-run", "Print actions without removing files", false)
     .action(async (opts) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
+        const { uninstallCommand } = await import("../../commands/uninstall.js");
         await uninstallCommand(defaultRuntime, {
           service: Boolean(opts.service),
           state: Boolean(opts.state),

--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -1,19 +1,4 @@
 import type { Command } from "commander";
-import { commitmentsDismissCommand, commitmentsListCommand } from "../../commands/commitments.js";
-import { exportTrajectoryCommand } from "../../commands/export-trajectory.js";
-import { flowsCancelCommand, flowsListCommand, flowsShowCommand } from "../../commands/flows.js";
-import { healthCommand } from "../../commands/health.js";
-import { sessionsCleanupCommand } from "../../commands/sessions-cleanup.js";
-import { sessionsCommand } from "../../commands/sessions.js";
-import { statusCommand } from "../../commands/status.js";
-import {
-  tasksAuditCommand,
-  tasksCancelCommand,
-  tasksListCommand,
-  tasksMaintenanceCommand,
-  tasksNotifyCommand,
-  tasksShowCommand,
-} from "../../commands/tasks.js";
 import { setVerbose } from "../../globals.js";
 import { defaultRuntime } from "../../runtime.js";
 import { formatDocsLink } from "../../terminal/links.js";
@@ -64,6 +49,7 @@ function mergeSessionsListOptions(
 
 async function runSessionsListCli(opts: SessionsListCliOptions): Promise<void> {
   setVerbose(Boolean(opts.verbose));
+  const { sessionsCommand } = await import("../../commands/sessions.js");
   await sessionsCommand(
     {
       json: Boolean(opts.json),
@@ -135,6 +121,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     )
     .action(async (opts) => {
       await runWithVerboseAndTimeout(opts, async ({ verbose, timeoutMs }) => {
+        const { statusCommand } = await import("../../commands/status.js");
         await statusCommand(
           {
             json: Boolean(opts.json),
@@ -163,6 +150,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     )
     .action(async (opts) => {
       await runWithVerboseAndTimeout(opts, async ({ verbose, timeoutMs }) => {
+        const { healthCommand } = await import("../../commands/health.js");
         await healthCommand(
           {
             json: Boolean(opts.json),
@@ -261,6 +249,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
           }
         | undefined;
       await runCommandWithRuntime(defaultRuntime, async () => {
+        const { sessionsCleanupCommand } = await import("../../commands/sessions-cleanup.js");
         await sessionsCleanupCommand(
           {
             store: (opts.store as string | undefined) ?? parentOpts?.store,
@@ -297,6 +286,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
           }
         | undefined;
       await runCommandWithRuntime(defaultRuntime, async () => {
+        const { exportTrajectoryCommand } = await import("../../commands/export-trajectory.js");
         await exportTrajectoryCommand(
           {
             sessionKey: opts.sessionKey as string | undefined,
@@ -331,6 +321,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     )
     .action(async (opts) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
+        const { commitmentsListCommand } = await import("../../commands/commitments.js");
         await commitmentsListCommand(
           {
             json: Boolean(opts.json),
@@ -356,6 +347,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
         | { json?: boolean; agent?: string; status?: string; all?: boolean }
         | undefined;
       await runCommandWithRuntime(defaultRuntime, async () => {
+        const { commitmentsListCommand } = await import("../../commands/commitments.js");
         await commitmentsListCommand(
           {
             json: Boolean(opts.json || parentOpts?.json),
@@ -375,6 +367,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     .action(async (ids: string[], opts, command) => {
       const parentOpts = command.parent?.opts() as { json?: boolean } | undefined;
       await runCommandWithRuntime(defaultRuntime, async () => {
+        const { commitmentsDismissCommand } = await import("../../commands/commitments.js");
         await commitmentsDismissCommand(
           {
             ids,
@@ -396,6 +389,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     )
     .action(async (opts) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
+        const { tasksListCommand } = await import("../../commands/tasks.js");
         await tasksListCommand(
           {
             json: Boolean(opts.json),
@@ -426,6 +420,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
           }
         | undefined;
       await runCommandWithRuntime(defaultRuntime, async () => {
+        const { tasksListCommand } = await import("../../commands/tasks.js");
         await tasksListCommand(
           {
             json: Boolean(opts.json || parentOpts?.json),
@@ -450,6 +445,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     .action(async (opts, command) => {
       const parentOpts = command.parent?.opts() as { json?: boolean } | undefined;
       await runCommandWithRuntime(defaultRuntime, async () => {
+        const { tasksAuditCommand } = await import("../../commands/tasks.js");
         await tasksAuditCommand(
           {
             json: Boolean(opts.json || parentOpts?.json),
@@ -483,6 +479,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     .action(async (opts, command) => {
       const parentOpts = command.parent?.opts() as { json?: boolean } | undefined;
       await runCommandWithRuntime(defaultRuntime, async () => {
+        const { tasksMaintenanceCommand } = await import("../../commands/tasks.js");
         await tasksMaintenanceCommand(
           {
             json: Boolean(opts.json || parentOpts?.json),
@@ -501,6 +498,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     .action(async (lookup, opts, command) => {
       const parentOpts = command.parent?.opts() as { json?: boolean } | undefined;
       await runCommandWithRuntime(defaultRuntime, async () => {
+        const { tasksShowCommand } = await import("../../commands/tasks.js");
         await tasksShowCommand(
           {
             lookup,
@@ -518,6 +516,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     .argument("<notify>", "Notify policy (done_only, state_changes, silent)")
     .action(async (lookup, notify) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
+        const { tasksNotifyCommand } = await import("../../commands/tasks.js");
         await tasksNotifyCommand(
           {
             lookup,
@@ -534,6 +533,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     .argument("<lookup>", "Task id, run id, or session key")
     .action(async (lookup) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
+        const { tasksCancelCommand } = await import("../../commands/tasks.js");
         await tasksCancelCommand(
           {
             lookup,
@@ -557,6 +557,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     )
     .action(async (opts) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
+        const { flowsListCommand } = await import("../../commands/flows.js");
         await flowsListCommand(
           {
             json: Boolean(opts.json),
@@ -574,6 +575,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     .option("--json", "Output as JSON", false)
     .action(async (lookup, opts) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
+        const { flowsShowCommand } = await import("../../commands/flows.js");
         await flowsShowCommand(
           {
             lookup,
@@ -590,6 +592,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     .argument("<lookup>", "Flow id or owner key")
     .action(async (lookup) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
+        const { flowsCancelCommand } = await import("../../commands/flows.js");
         await flowsCancelCommand(
           {
             lookup,

--- a/src/cli/program/register.subclis-core.ts
+++ b/src/cli/program/register.subclis-core.ts
@@ -47,7 +47,7 @@ function shouldRegisterGatewayRunOnly(name: string, argv: string[]): boolean {
 }
 
 async function registerGatewayRunOnly(program: Command): Promise<void> {
-  const { addGatewayRunCommand } = await import("../gateway-cli/run.js");
+  const { addGatewayRunCommand } = await import("../gateway-cli/run-command.js");
   removeCommandByName(program, "gateway");
   const gateway = addGatewayRunCommand(
     program.command("gateway").description("Run, inspect, and query the WebSocket Gateway"),

--- a/src/cli/program/register.subclis.test.ts
+++ b/src/cli/program/register.subclis.test.ts
@@ -68,7 +68,7 @@ const { addGatewayRunCommand, gatewayRunAction, registerGatewayCli } = vi.hoiste
 
 vi.mock("../acp-cli.js", () => ({ registerAcpCli }));
 vi.mock("../gateway-cli.js", () => ({ registerGatewayCli }));
-vi.mock("../gateway-cli/run.js", () => ({ addGatewayRunCommand }));
+vi.mock("../gateway-cli/run-command.js", () => ({ addGatewayRunCommand }));
 vi.mock("../nodes-cli.js", () => ({ registerNodesCli }));
 vi.mock("../capability-cli.js", () => ({ registerCapabilityCli }));
 vi.mock("../plugins-cli.js", () => ({ registerPluginsCli }));

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -98,7 +98,7 @@ vi.mock("./route.js", () => ({
   tryRouteCli: tryRouteCliMock,
 }));
 
-vi.mock("./gateway-cli/run.js", () => ({
+vi.mock("./gateway-cli/run-command.js", () => ({
   addGatewayRunCommand: addGatewayRunCommandMock,
 }));
 

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -162,7 +162,7 @@ async function tryRunGatewayRunFastPath(
   ] = await startupTrace.measure("gateway-run-imports", () =>
     Promise.all([
       import("commander"),
-      import("./gateway-cli/run.js"),
+      import("./gateway-cli/run-command.js"),
       import("../version.js"),
       import("./banner.js"),
       import("./command-startup-policy.js"),

--- a/test/scripts/check-cli-bootstrap-imports.test.ts
+++ b/test/scripts/check-cli-bootstrap-imports.test.ts
@@ -30,7 +30,7 @@ function writeGatewayRunChunk(root: string, source = ""): void {
     "dist/run-gateway.js",
     [
       'import "./string-coerce.js";',
-      "const GATEWAY_RUN_VALUE_KEYS = [];",
+      "const GATEWAY_AUTH_MODES = [];",
       "function addGatewayRunCommand(cmd) { return cmd; }",
       source,
     ].join("\n"),

--- a/test/scripts/plugin-prerelease-test-plan.test.ts
+++ b/test/scripts/plugin-prerelease-test-plan.test.ts
@@ -317,7 +317,7 @@ describe("scripts/lib/plugin-prerelease-test-plan.mjs", () => {
     expect(workflow.jobs["check-shard"].strategy.matrix.include[3]).toEqual({
       check_name: "check-dependencies",
       task: "dependencies",
-      runner: "ubuntu-24.04",
+      runner: "blacksmith-8vcpu-ubuntu-2404",
     });
     expect(
       workflow.jobs["check-shard"].steps.find((step) => step.name === "Run check shard").run,


### PR DESCRIPTION
Summary
- Keep `openclaw gateway --help`, `doctor --help`, `status --help`, and `health --help` on metadata-only registration paths.
- Move gateway run/call/discover/progress and status/doctor command implementations behind lazy action imports.
- Add cold-import regression coverage for the affected help paths and update the CLI bootstrap guard for the new lightweight gateway run chunk.

Verification
- `pnpm test src/cli/help-cold-imports.test.ts src/cli/gateway-cli/run.option-collisions.test.ts src/cli/gateway-cli/register.option-collisions.test.ts src/cli/program/register.subclis.test.ts src/cli/run-main.exit.test.ts -- --reporter=verbose`
- `pnpm test test/scripts/plugin-prerelease-test-plan.test.ts test/scripts/check-cli-bootstrap-imports.test.ts -- --reporter=verbose`
- `pnpm openclaw gateway --help`
- `pnpm openclaw doctor --help`
- `pnpm openclaw status --help`
- `pnpm openclaw health --help`
- `pnpm build:ci-artifacts`
- `pnpm check:changed`
- `codex-review --mode local`

## Real behavior proof
Behavior addressed: Subcommand help no longer imports gateway/status/doctor action/runtime modules before rendering help.
Real environment tested: macOS local checkout plus delegated Blacksmith Testbox changed gate.
Exact steps or command run after this patch: `pnpm openclaw gateway --help`; `pnpm openclaw doctor --help`; `pnpm openclaw status --help`; `pnpm openclaw health --help`; `pnpm build:ci-artifacts`; `pnpm check:changed`.
Evidence after fix: Terminal output from the real CLI help commands showed `Usage: openclaw gateway [options] [command]`, `Usage: openclaw doctor [options]`, `Usage: openclaw status [options]`, and `Usage: openclaw health [options]`. `pnpm build:ci-artifacts` printed `CLI bootstrap import guard passed.` Blacksmith Testbox `tbx_01krw7kg3vn27tb0n5nb9cv3j7` exited 0 via https://github.com/openclaw/openclaw/actions/runs/26007120335.
Observed result after fix: Help output rendered successfully from the real `openclaw` CLI entrypoint, and the build artifact guard found the lightweight gateway run chunk.
What was not tested: Fedora 44 rootless Podman native segfault reproduction was not available locally.

Fixes #83228
