### PR TITLE
fix: seed control UI origins for bind aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Docs: https://docs.openclaw.ai
 - Agents/OpenAI streams: yield via `setTimeout(0)` instead of `setImmediate` between bursty Responses chunks so abort timers can fire during the yield, keeping cancel-on-timeout responsive on hot streams. Refs #82462.
 - Agents/Codex: keep legacy `oauthRef`-backed OAuth profiles usable while `openclaw doctor --fix` migrates them back to inline credentials, without creating new sidecar credentials. (#83312) Thanks @joshavant.
 - CLI/config: send SecretRef diagnostics to stderr so JSON command stdout remains parseable.
+- CLI/doctor: seed Control UI allowed origins when migrating legacy non-loopback gateway bind host aliases like `0.0.0.0`. Fixes #83286. Thanks @giodl73-repo.
 - CLI/plugins: ship the bundled memory CLI as a package entry so package-installed `openclaw memory` commands register correctly.
 - CLI/update: defer doctor-time plugin package installs during package swaps and seed post-core repair from the updated install registry, preventing duplicate reinstall failures.
 - Feishu: detect SecretRef top-level credentials as a configured default account instead of treating object-backed app secrets as missing.

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -945,4 +945,34 @@ describe("legacy migrate controlUi.allowedOrigins seed (issue #29385)", () => {
       "http://127.0.0.1:18789",
     ]);
   });
+
+  it("seeds allowedOrigins for non-loopback host aliases before normalizing bind", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: {
+        bind: "0.0.0.0",
+        auth: { mode: "token", token: "tok" },
+      },
+    });
+    expect(res.config?.gateway?.bind).toBe("lan");
+    expect(res.config?.gateway?.controlUi?.allowedOrigins).toEqual([
+      "http://localhost:18789",
+      "http://127.0.0.1:18789",
+    ]);
+    expect(res.changes).toStrictEqual([
+      'Seeded gateway.controlUi.allowedOrigins ["http://localhost:18789","http://127.0.0.1:18789"] for bind=lan. Required since v2026.2.26. Add other machine origins to gateway.controlUi.allowedOrigins if needed.',
+      'Normalized gateway.bind "0.0.0.0" → "lan".',
+    ]);
+  });
+
+  it("does not seed allowedOrigins for loopback host aliases", () => {
+    const res = migrateLegacyConfigForTest({
+      gateway: {
+        bind: "localhost",
+        auth: { mode: "token", token: "tok" },
+      },
+    });
+    expect(res.config?.gateway?.bind).toBe("loopback");
+    expect(res.config?.gateway?.controlUi).toBeUndefined();
+    expect(res.changes).toStrictEqual(['Normalized gateway.bind "localhost" → "loopback".']);
+  });
 });

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.gateway.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.gateway.ts
@@ -22,9 +22,13 @@ const GATEWAY_BIND_RULE: LegacyConfigRule = {
 };
 
 function isLegacyGatewayBindHostAlias(value: unknown): boolean {
+  return normalizeLegacyGatewayBindHostAlias(value) !== null;
+}
+
+function normalizeLegacyGatewayBindHostAlias(value: unknown): "lan" | "loopback" | null {
   const normalized = normalizeOptionalLowercaseString(value);
   if (!normalized) {
-    return false;
+    return null;
   }
   if (
     normalized === "auto" ||
@@ -33,18 +37,25 @@ function isLegacyGatewayBindHostAlias(value: unknown): boolean {
     normalized === "tailnet" ||
     normalized === "custom"
   ) {
-    return false;
+    return null;
   }
-  return (
+  if (
     normalized === "0.0.0.0" ||
     normalized === "::" ||
     normalized === "[::]" ||
-    normalized === "*" ||
+    normalized === "*"
+  ) {
+    return "lan";
+  }
+  if (
     normalized === "127.0.0.1" ||
     normalized === "localhost" ||
     normalized === "::1" ||
     normalized === "[::1]"
-  );
+  ) {
+    return "loopback";
+  }
+  return null;
 }
 
 function escapeControlForLog(value: string): string {
@@ -60,7 +71,7 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_GATEWAY: LegacyConfigMigrationSpec
       if (!gateway) {
         return;
       }
-      const bind = gateway.bind;
+      const bind = normalizeLegacyGatewayBindHostAlias(gateway.bind) ?? gateway.bind;
       if (!isGatewayNonLoopbackBindMode(bind)) {
         return;
       }
@@ -107,22 +118,7 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_GATEWAY: LegacyConfigMigrationSpec
       if (!normalized) {
         return;
       }
-      let mapped: "lan" | "loopback" | undefined;
-      if (
-        normalized === "0.0.0.0" ||
-        normalized === "::" ||
-        normalized === "[::]" ||
-        normalized === "*"
-      ) {
-        mapped = "lan";
-      } else if (
-        normalized === "127.0.0.1" ||
-        normalized === "localhost" ||
-        normalized === "::1" ||
-        normalized === "[::1]"
-      ) {
-        mapped = "loopback";
-      }
+      const mapped = normalizeLegacyGatewayBindHostAlias(bindRaw);
 
       if (!mapped || normalized === mapped) {
         return;


### PR DESCRIPTION
## Summary

- Resolve legacy gateway bind host aliases before the Control UI allowed-origin seed decides whether the bind is non-loopback.
- Reuse the alias mapping for the later bind-mode migration so the two doctor steps stay aligned.
- Add regression coverage for `0.0.0.0` seeding to `lan` and `localhost` staying loopback-only.

## Verification

- `OPENCLAW_CONFIG_PATH=/tmp/openclaw-83286-proof.o9Rlof/openclaw.json OPENCLAW_STATE_DIR=/tmp/openclaw-83286-proof.o9Rlof/state OPENCLAW_HOME=/tmp/openclaw-83286-proof.o9Rlof/home pnpm openclaw doctor --fix --non-interactive --yes`
- `pnpm test src/commands/doctor/shared/legacy-config-migrate.test.ts -- --reporter=verbose`
- `pnpm changed:lanes --json`
- `git diff --check`
- `pnpm check:changed` via Blacksmith Testbox `tbx_01krw63cm4nzha6yw55pn6dw49` / run https://github.com/openclaw/openclaw/actions/runs/26006514336
- `/Users/steipete/Projects/agent-scripts/skills/codex-review/scripts/codex-review --mode local`

## Real behavior proof

Behavior addressed: `openclaw doctor --fix` legacy config migration normalized `gateway.bind: "0.0.0.0"` to `lan` but skipped `gateway.controlUi.allowedOrigins` seeding because the seed checked the raw host alias before alias normalization.

Real environment tested: a real OpenClaw CLI doctor repair run from this source checkout against an isolated temp config/state/home directory. The temp config contained `gateway.mode: "local"`, `gateway.bind: "0.0.0.0"`, and token auth with a dummy test token.

Exact steps or command run after this patch: created `/tmp/openclaw-83286-proof.o9Rlof/openclaw.json`, then ran `OPENCLAW_CONFIG_PATH=/tmp/openclaw-83286-proof.o9Rlof/openclaw.json OPENCLAW_STATE_DIR=/tmp/openclaw-83286-proof.o9Rlof/state OPENCLAW_HOME=/tmp/openclaw-83286-proof.o9Rlof/home pnpm openclaw doctor --fix --non-interactive --yes`, followed by a JSON readback of the migrated config.

Evidence after fix: doctor printed `Seeded gateway.controlUi.allowedOrigins ["http://localhost:18789","http://127.0.0.1:18789"] for bind=lan.` and `Normalized gateway.bind "0.0.0.0" → "lan".` The final config readback printed:

```json
{
  "gateway": {
    "mode": "local",
    "bind": "lan",
    "controlUi": {
      "allowedOrigins": [
        "http://localhost:18789",
        "http://127.0.0.1:18789"
      ]
    },
    "auth": {
      "mode": "token",
      "token": "test-token"
    }
  }
}
```

Observed result after fix: the real doctor repair completed and wrote the migrated config with `gateway.bind: "lan"` plus the expected Control UI allowed origins. The focused migration test also passed 46 tests, and Testbox `check:changed` exited 0.

What was not tested: no packaged upgrade or running Gateway smoke; this patch is confined to doctor migration logic and was proven with a real doctor repair command plus focused migration and changed-gate coverage.

Fixes #83286
