### PR TITLE
fix(cron): suppress auto source reply on explicit announce delivery

### DIFF
--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -238,6 +238,7 @@ export function createCronPromptExecutor(params: {
           agentAccountId: params.resolvedDelivery.accountId,
           messageTo: params.resolvedDelivery.to,
           messageThreadId: params.resolvedDelivery.threadId,
+          sourceReplyDeliveryMode: params.resolvedDelivery.to ? "message_tool_only" : undefined,
           currentChannelId,
           sessionFile,
           agentDir: params.agentDir,

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -565,6 +565,35 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     });
   });
 
+  // Regression for https://github.com/openclaw/openclaw/issues/83261:
+  // explicit cron announce delivery must suppress automatic source replies so a
+  // single assistant turn does not produce both a message-tool send and an
+  // auto-reply echo when groupChat.visibleReplies = automatic.
+  it("forces message_tool_only source delivery when announce delivery has an explicit to", async () => {
+    mockRunCronFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue(makeAnnounceDeliveryPlan());
+
+    await runCronIsolatedAgentTurn({
+      ...makeParams(),
+      job: makeAnnounceMessageToolJob(),
+    });
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    expect(runEmbeddedPiAgentMock.mock.calls[0]?.[0]?.sourceReplyDeliveryMode).toBe(
+      "message_tool_only",
+    );
+  });
+
+  it("leaves sourceReplyDeliveryMode unset when no explicit delivery target is resolved", async () => {
+    mockRunCronFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue({ requested: false, mode: "none" });
+
+    await runCronIsolatedAgentTurn(makeParams());
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    expect(runEmbeddedPiAgentMock.mock.calls[0]?.[0]?.sourceReplyDeliveryMode).toBeUndefined();
+  });
+
   it("keeps automatic exec completion notifications when announce delivery is active", async () => {
     mockRunCronFallbackPassthrough();
     resolveCronDeliveryPlanMock.mockReturnValue(makeAnnounceDeliveryPlan());


### PR DESCRIPTION
## Summary

- Problem: Cron `agentTurn` with explicit `delivery.to` on a Discord channel duplicated assistant messages (2–3 copies) when `messages.groupChat.visibleReplies: automatic`.
- Why it matters: P1 message-loss/duplication on cron-driven Discord posts. 100% reproducible per #83261.
- What changed: When the cron run-executor calls `runEmbeddedPiAgent` with an explicit resolved delivery target, it now sets `sourceReplyDeliveryMode: "message_tool_only"`. The visible-reply policy then suppresses the automatic source echo, leaving the message tool (and the cron fallback dedupe) as the single delivery path.
- What did NOT change: No behavior change when no explicit delivery target is resolved (`sourceReplyDeliveryMode` remains `undefined`, preserving group/channel automatic visible-reply policy for non-cron flows). No change to `skipMessagingToolDelivery` dedup logic or Discord target normalization.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #83261
- [x] This PR fixes a bug or regression

## Real behavior proof

- Behavior or issue addressed: explicit cron announce delivery must suppress the automatic source visible-reply when groupChat `visibleReplies = automatic`, so a single assistant turn produces exactly one Discord message.
- Real environment tested: I do not have access to the reporter's Discord guild `1466160679496056935` / channel `1503132078122995814`, so I could not run a live Discord cron job. The fix is proven at the source-level boundary that the visible-reply policy reads (`sourceReplyDeliveryMode`), exercised through the runtime path used by Discord (`runCronIsolatedAgentTurn` → `executeCronRun` → `runEmbeddedPiAgent`).
- Exact steps or command run after this patch:

```bash
node scripts/run-vitest.mjs src/cron/isolated-agent/run.message-tool-policy.test.ts
node scripts/run-vitest.mjs src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
```

- Evidence after fix:

```text
RUN  v4.1.6 /private/tmp/openclaw-83261
 Test Files  1 passed (1)
      Tests  31 passed (31)
   Duration  7.84s
   (includes 2 new regression tests for #83261)

RUN  v4.1.6 /private/tmp/openclaw-83261
 Test Files  1 passed (1)
      Tests  65 passed (65)
   Duration  948ms
```

The two new regression tests assert the exact value the embedded run receives:
- `forces message_tool_only source delivery when announce delivery has an explicit to` — asserts `runEmbeddedPiAgent` is called with `sourceReplyDeliveryMode === "message_tool_only"`.
- `leaves sourceReplyDeliveryMode unset when no explicit delivery target is resolved` — asserts the parameter is `undefined` for non-explicit cases.

- Observed result after fix: with `sourceReplyDeliveryMode: "message_tool_only"`, `resolveSourceReplyVisibilityPolicy` (`src/auto-reply/reply/source-reply-delivery-mode.ts:57`) sets `suppressAutomaticSourceDelivery = true`, suppressing the automatic source-channel echo that paired with the message-tool send to produce duplicates.
- What was not tested: live Discord cron job in the reporter's guild. A maintainer with that setup can confirm by re-running the original repro config (`delivery.mode: "announce"`, `delivery.to: "1503132078122995814"`, `messages.groupChat.visibleReplies: "automatic"`) and verifying exactly one Discord message appears per cron firing.
- Before evidence: ClawSweeper's earlier review on #83261 confirmed at source level that the cron embedded path was not setting any `sourceReplyDeliveryMode` override, so automatic visible-reply policy could still select `automatic` alongside the explicit announce target.

## Root Cause

- Root cause: `src/cron/isolated-agent/run-executor.ts` invoked `runEmbeddedPiAgent` with delivery context (`messageChannel`, `messageTo`, `messageThreadId`) but did not pass `sourceReplyDeliveryMode`. With it undefined, `resolveSourceReplyDeliveryMode` fell through to the group/channel chat policy, returning `"automatic"` when `visibleReplies: automatic` was set — letting the same assistant turn be delivered via both the message tool (chosen by explicit announce) and the automatic source-reply path.
- Missing detection / guardrail: no test asserted that explicit cron announce delivery propagates `message_tool_only` into the embedded run; `delivery-dispatch.ts skipMessagingToolDelivery` only covers the cron fallback dedupe, not the automatic source reply.
- Contributing context: `messages.groupChat.visibleReplies: automatic` is the default for group/channel chats, so any cron `agentTurn` posting to a Discord channel hits this path.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/cron/isolated-agent/run.message-tool-policy.test.ts`
- Scenario the test should lock in: cron `runCronIsolatedAgentTurn` with `delivery.mode: "announce"` and an explicit `to` invokes `runEmbeddedPiAgent` with `sourceReplyDeliveryMode: "message_tool_only"`; without an explicit target, `sourceReplyDeliveryMode` stays `undefined`.
- Why this is the smallest reliable guardrail: the bug is a single missing parameter on the embedded-run call boundary; pinning that parameter at the seam catches any future regression without needing a Discord live-run harness.
- Existing test that already covers this: none; existing message-tool-policy tests covered `disableMessageTool` / `forceMessageTool` / fallback dedupe, not source-reply mode propagation.

## User-visible / Behavior Changes

Cron `agentTurn` jobs with explicit `delivery.to` (including `mode: "announce"`) no longer double-deliver via the automatic visible-reply path when `messages.groupChat.visibleReplies` or `messages.visibleReplies` is `"automatic"`. Other code paths are unchanged.

## Diagram

N/A