### PR TITLE
fix: harden clawpatch-reported edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Core/plugins: harden clawpatch-reported edge cases across gateway auth cleanup, Claude session id paths, plugin activation policy, apply-patch hunk handling, diagnostic redaction, and plugin metadata validation.
 - Mac app: keep app-level menu commands and Dashboard failure states reachable when the remote Gateway is disconnected, and keep the Settings sidebar toggle in the leading titlebar area.
 - Gateway/webchat: hide internal runtime-context and other `display: false` transcript messages from Chat history and live message events. Fixes #83216. Thanks @EmpireCreator.
 - CLI/help: keep `gateway`, `doctor`, `status`, and `health` help registration out of action/runtime imports so subcommand `--help` stays lightweight in constrained terminals. Fixes #83228. Thanks @dfguerrerom.

--- a/scripts/lib/ts-topology/analyze.ts
+++ b/scripts/lib/ts-topology/analyze.ts
@@ -206,9 +206,15 @@ function collectReferenceEvents(
       if (!clause?.namedBindings) {
         continue;
       }
+      if (clause.isTypeOnly) {
+        continue;
+      }
 
       if (ts.isNamedImports(clause.namedBindings)) {
         for (const element of clause.namedBindings.elements) {
+          if (element.isTypeOnly) {
+            continue;
+          }
           const importedName = element.propertyName?.text ?? element.name.text;
           const record = recordMap.get(importedName);
           if (!record) {

--- a/scripts/lib/ts-topology/reports.ts
+++ b/scripts/lib/ts-topology/reports.ts
@@ -110,5 +110,9 @@ const reportModules: Record<ReportModule["name"], ReportModule> = {
 };
 
 export function renderTextReport(envelope: TopologyEnvelope, limit: number): string {
-  return reportModules[envelope.report].describe(envelope, limit);
+  const reportModule = reportModules[envelope.report];
+  if (!reportModule) {
+    throw new Error(`Unsupported topology report: ${envelope.report}`);
+  }
+  return reportModule.describe(envelope, limit);
 }

--- a/src/agents/anthropic-payload-log.test.ts
+++ b/src/agents/anthropic-payload-log.test.ts
@@ -64,4 +64,34 @@ describe("createAnthropicPayloadLogger", () => {
     expect(source.sha256).toBe(crypto.createHash("sha256").update("QUJDRA==").digest("hex"));
     expect(event.payloadDigest).toMatch(/^[a-f0-9]{64}$/u);
   });
+
+  it("sanitizes usage and error fields before writing logs", () => {
+    const lines: string[] = [];
+    const logger = createAnthropicPayloadLogger({
+      env: { OPENCLAW_ANTHROPIC_PAYLOAD_LOG: "1" },
+      writer: {
+        filePath: "memory",
+        write: (line) => lines.push(line),
+        flush: async () => undefined,
+      },
+    });
+
+    logger?.recordUsage(
+      [
+        {
+          role: "assistant",
+          content: "",
+          usage: {
+            input: 1,
+            authorization: "Bearer sk-secret", // pragma: allowlist secret
+          },
+        } as never,
+      ],
+      new Error("failed with Bearer sk-secret"), // pragma: allowlist secret
+    );
+
+    const event = JSON.parse(lines[0]?.trim() ?? "{}") as Record<string, unknown>;
+    expect(event.error).toBe("failed with Bearer <redacted>");
+    expect(event.usage).toEqual({ input: 1 });
+  });
 });

--- a/src/agents/anthropic-payload-log.ts
+++ b/src/agents/anthropic-payload-log.ts
@@ -53,16 +53,18 @@ function getWriter(filePath: string): PayloadLogWriter {
 
 function formatError(error: unknown): string | undefined {
   if (error instanceof Error) {
-    return error.message;
+    const redacted = sanitizeDiagnosticPayload(error.message);
+    return typeof redacted === "string" ? redacted : error.message;
   }
   if (typeof error === "string") {
-    return error;
+    const redacted = sanitizeDiagnosticPayload(error);
+    return typeof redacted === "string" ? redacted : error;
   }
   if (typeof error === "number" || typeof error === "boolean" || typeof error === "bigint") {
     return String(error);
   }
   if (error && typeof error === "object") {
-    return safeJsonStringify(error) ?? "unknown error";
+    return safeJsonStringify(sanitizeDiagnosticPayload(error)) ?? "unknown error";
   }
   return undefined;
 }
@@ -173,7 +175,7 @@ export function createAnthropicPayloadLogger(params: {
       ...base,
       ts: new Date().toISOString(),
       stage: "usage",
-      usage,
+      usage: sanitizeDiagnosticPayload(usage) as Record<string, unknown>,
       error: errorMessage,
     });
     log.info("anthropic usage", {

--- a/src/agents/apply-patch-update.ts
+++ b/src/agents/apply-patch-update.ts
@@ -53,10 +53,13 @@ function computeReplacements(
 
     if (chunk.oldLines.length === 0) {
       const insertionIndex =
-        originalLines.length > 0 && originalLines[originalLines.length - 1] === ""
-          ? originalLines.length - 1
-          : originalLines.length;
+        chunk.changeContext && !chunk.isEndOfFile
+          ? lineIndex
+          : originalLines.length > 0 && originalLines[originalLines.length - 1] === ""
+            ? originalLines.length - 1
+            : originalLines.length;
       replacements.push([insertionIndex, 0, chunk.newLines]);
+      lineIndex = insertionIndex;
       continue;
     }
 

--- a/src/agents/apply-patch.test.ts
+++ b/src/agents/apply-patch.test.ts
@@ -131,6 +131,57 @@ describe("applyPatch", () => {
     expect(result.summary.modified).toEqual(["dest.txt"]);
   });
 
+  it("updates in place when move target resolves to the source file", async () => {
+    const memory = createMemoryPatchSandbox({
+      "source.txt": "foo\nbar\n",
+    });
+    const patch = `*** Begin Patch
+*** Update File: source.txt
+*** Move to: ./source.txt
+@@
+ foo
+-bar
++baz
+*** End Patch`;
+
+    const result = await applyPatch(patch, memory.options);
+
+    expect(memory.files.get("/sandbox/source.txt")).toBe("foo\nbaz\n");
+    expect(result.summary.modified).toEqual(["source.txt"]);
+  });
+
+  it("applies context-only insertions at the requested context", async () => {
+    const memory = createMemoryPatchSandbox({
+      "source.txt": "alpha\nanchor\nomega\n",
+    });
+    const patch = `*** Begin Patch
+*** Update File: source.txt
+@@ anchor
++inserted
+*** End Patch`;
+
+    await applyPatch(patch, memory.options);
+
+    expect(memory.files.get("/sandbox/source.txt")).toBe("alpha\nanchor\ninserted\nomega\n");
+  });
+
+  it("keeps later insertion contexts in original file coordinates", async () => {
+    const memory = createMemoryPatchSandbox({
+      "source.txt": "a\nb\nc\n",
+    });
+    const patch = `*** Begin Patch
+*** Update File: source.txt
+@@ a
++after-a
+@@ b
++after-b
+*** End Patch`;
+
+    await applyPatch(patch, memory.options);
+
+    expect(memory.files.get("/sandbox/source.txt")).toBe("a\nafter-a\nb\nafter-b\nc\n");
+  });
+
   it("supports end-of-file inserts", async () => {
     const memory = createMemoryPatchSandbox({
       "end.txt": "line1\n",

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -175,9 +175,21 @@ export async function applyPatch(
       const moveTarget = await resolvePatchPath(hunk.movePath, options);
       await assertPatchParentPath(hunk.movePath, options);
       await ensureDir(moveTarget.resolved, fileOps);
-      await fileOps.writeFile(moveTarget.resolved, applied);
-      await fileOps.remove(target.resolved);
-      recordSummary(summary, seen, "modified", moveTarget.display);
+      const moveResolvesToSource =
+        path.resolve(moveTarget.resolved) === path.resolve(target.resolved);
+      await fileOps.writeFile(
+        moveResolvesToSource ? target.resolved : moveTarget.resolved,
+        applied,
+      );
+      if (!moveResolvesToSource) {
+        await fileOps.remove(target.resolved);
+      }
+      recordSummary(
+        summary,
+        seen,
+        "modified",
+        moveResolvesToSource ? target.display : moveTarget.display,
+      );
     } else {
       await fileOps.writeFile(target.resolved, applied);
       recordSummary(summary, seen, "modified", target.display);

--- a/src/agents/bundle-mcp.test-harness.ts
+++ b/src/agents/bundle-mcp.test-harness.ts
@@ -172,12 +172,17 @@ const transport = new StdioClientTransport({
 });
 const client = new Client({ name: "fake-claude", version: "1.0.0" });
 await client.connect(transport);
-const tools = await client.listTools();
-if (!tools.tools.some((tool) => tool.name === "bundle_probe")) {
-  throw new Error("bundle_probe tool not exposed");
-}
-const result = await client.callTool({ name: "bundle_probe", arguments: {} });
-await transport.close();
+const result = await (async () => {
+  try {
+    const tools = await client.listTools();
+    if (!tools.tools.some((tool) => tool.name === "bundle_probe")) {
+      throw new Error("bundle_probe tool not exposed");
+    }
+    return await client.callTool({ name: "bundle_probe", arguments: {} });
+  } finally {
+    await transport.close();
+  }
+})();
 
 const text = Array.isArray(result.content)
   ? result.content

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -157,6 +157,18 @@ describe("channel-health-monitor", () => {
     vi.useRealTimers();
   });
 
+  it("removes abort listener when stopped manually", () => {
+    const signal = new AbortController().signal;
+    const addEventListener = vi.spyOn(signal, "addEventListener");
+    const removeEventListener = vi.spyOn(signal, "removeEventListener");
+    const monitor = startDefaultMonitor(createMockChannelManager(), { abortSignal: signal });
+
+    monitor.stop();
+
+    expect(addEventListener).toHaveBeenCalledWith("abort", expect.any(Function), { once: true });
+    expect(removeEventListener).toHaveBeenCalledWith("abort", addEventListener.mock.calls[0]?.[1]);
+  });
+
   it("does not run before the grace period", async () => {
     const manager = createMockChannelManager();
     const monitor = startDefaultMonitor(manager, { startupGraceMs: 60_000 });

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -189,6 +189,7 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
       clearInterval(timer);
       timer = null;
     }
+    abortSignal?.removeEventListener("abort", stop);
   }
 
   if (abortSignal?.aborted) {

--- a/src/gateway/cli-session-history.claude.ts
+++ b/src/gateway/cli-session-history.claude.ts
@@ -279,6 +279,17 @@ export function resolveClaudeCliSessionFilePath(params: {
   cliSessionId: string;
   homeDir?: string;
 }): string | undefined {
+  const sessionId = params.cliSessionId.trim();
+  if (
+    !sessionId ||
+    sessionId === "." ||
+    sessionId === ".." ||
+    path.isAbsolute(sessionId) ||
+    sessionId.includes("/") ||
+    sessionId.includes("\\")
+  ) {
+    return undefined;
+  }
   const projectsDir = resolveClaudeProjectsDir(params.homeDir);
   let projectEntries: fs.Dirent[];
   try {
@@ -291,7 +302,12 @@ export function resolveClaudeCliSessionFilePath(params: {
     if (!entry.isDirectory()) {
       continue;
     }
-    const candidate = path.join(projectsDir, entry.name, `${params.cliSessionId}.jsonl`);
+    const projectDir = path.join(projectsDir, entry.name);
+    const candidate = path.resolve(projectDir, `${sessionId}.jsonl`);
+    const resolvedProjectDir = path.resolve(projectDir);
+    if (!candidate.startsWith(`${resolvedProjectDir}${path.sep}`)) {
+      continue;
+    }
     if (fs.existsSync(candidate)) {
       return candidate;
     }

--- a/src/gateway/cli-session-history.test.ts
+++ b/src/gateway/cli-session-history.test.ts
@@ -203,6 +203,20 @@ describe("cli session history", () => {
     });
   });
 
+  it("rejects path-like Claude CLI session ids", async () => {
+    await withClaudeProjectsDir(async ({ homeDir }) => {
+      expect(
+        resolveClaudeCliSessionFilePath({ cliSessionId: "../outside", homeDir }),
+      ).toBeUndefined();
+      expect(
+        resolveClaudeCliSessionFilePath({ cliSessionId: "nested/session", homeDir }),
+      ).toBeUndefined();
+      expect(
+        resolveClaudeCliSessionFilePath({ cliSessionId: "nested\\session", homeDir }),
+      ).toBeUndefined();
+    });
+  });
+
   it("deduplicates imported messages against similar local transcript entries", () => {
     const localMessages = [
       {

--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -246,6 +246,7 @@ async function expectGatewayRequestError(
 function createClientWithIdentity(
   deviceId: string,
   onClose: (code: number, reason: string) => void,
+  overrides: Partial<ConstructorParameters<typeof GatewayClient>[0]> = {},
 ) {
   const identity: DeviceIdentity = {
     deviceId,
@@ -256,6 +257,7 @@ function createClientWithIdentity(
     url: "ws://127.0.0.1:18789",
     deviceIdentity: identity,
     onClose,
+    ...overrides,
   });
 }
 
@@ -662,7 +664,8 @@ describe("GatewayClient close handling", () => {
 
   it("clears stale token on device token mismatch close", () => {
     const onClose = vi.fn();
-    const client = createClientWithIdentity("dev-1", onClose);
+    const env = { OPENCLAW_HOME: "/tmp/custom-openclaw-home" };
+    const client = createClientWithIdentity("dev-1", onClose, { env });
 
     client.start();
     getLatestWs().emitClose(
@@ -670,7 +673,11 @@ describe("GatewayClient close handling", () => {
       "unauthorized: DEVICE token mismatch (rotate/reissue device token)",
     );
 
-    expect(clearDeviceAuthTokenMock).toHaveBeenCalledWith({ deviceId: "dev-1", role: "operator" });
+    expect(clearDeviceAuthTokenMock).toHaveBeenCalledWith({
+      deviceId: "dev-1",
+      role: "operator",
+      env,
+    });
     expect(logDebugMock).toHaveBeenCalledWith("cleared stale device-auth token for device dev-1");
     expect(onClose).toHaveBeenCalledWith(
       1008,
@@ -1493,7 +1500,7 @@ describe("GatewayClient connect auth payload", () => {
     });
     const clearTokenParams = expectRecordFields(
       firstMockArg(clearDeviceAuthTokenMock, "clear device token params"),
-      { role: "operator" },
+      { role: "operator", env: undefined },
       "clear device token params",
     );
     expect(clearTokenParams.deviceId).toBeTypeOf("string");
@@ -1502,6 +1509,38 @@ describe("GatewayClient connect auth payload", () => {
       reason: "connect failed",
       detailCode: "AUTH_DEVICE_TOKEN_MISMATCH",
     });
+  });
+
+  it("clears stale stored device tokens from the configured environment store", async () => {
+    loadDeviceAuthTokenMock.mockReturnValue({
+      token: "stored-device-token",
+      scopes: ["operator.read"],
+    });
+    const env = { OPENCLAW_HOME: "/tmp/custom-openclaw-home" };
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      env,
+    });
+
+    const { ws: ws1, connect: firstConnect } = startClientAndConnect({ client });
+    expect(firstConnect.params?.auth?.token).toBe("stored-device-token");
+    await expectNoReconnectAfterConnectFailure({
+      client,
+      firstWs: ws1,
+      connectId: firstConnect.id,
+      failureDetails: { code: "AUTH_DEVICE_TOKEN_MISMATCH" },
+    });
+
+    expect(
+      expectRecordFields(
+        firstMockArg(clearDeviceAuthTokenMock, "clear device token params"),
+        {
+          role: "operator",
+          env,
+        },
+        "clear device token params",
+      ),
+    ).toHaveProperty("deviceId");
   });
 
   it("does not clear stored device tokens or reconnect on AUTH_SCOPE_MISMATCH", async () => {

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -650,7 +650,7 @@ export class GatewayClient {
         ) {
           const deviceId = this.opts.deviceIdentity.deviceId;
           try {
-            clearDeviceAuthToken({ deviceId, role });
+            clearDeviceAuthToken({ deviceId, role, env: this.opts.env });
             logDebug(`cleared stale device-auth token for device ${deviceId}`);
           } catch (clearErr) {
             logDebug(

--- a/src/plugins/activation-planner.test.ts
+++ b/src/plugins/activation-planner.test.ts
@@ -126,6 +126,24 @@ describe("activation planner", () => {
     ).toEqual(["demo-channel"]);
   });
 
+  it("does not activate manifest-triggered plugins that are disabled in config", () => {
+    expect(
+      resolveManifestActivationPluginIds({
+        config: {
+          plugins: {
+            entries: {
+              "memory-core": { enabled: false },
+            },
+          },
+        },
+        trigger: {
+          kind: "command",
+          command: "memory",
+        },
+      }),
+    ).toEqual([]);
+  });
+
   it("keeps ids-only provider, agent harness, channel, and route planning stable", () => {
     expect(
       resolveManifestActivationPluginIds({

--- a/src/plugins/activation-planner.ts
+++ b/src/plugins/activation-planner.ts
@@ -1,6 +1,8 @@
 import { normalizeProviderId } from "../agents/provider-id.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
+import { normalizePluginsConfig } from "./config-state.js";
+import { passesManifestOwnerBasePolicy } from "./manifest-owner-policy.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import type { PluginDiagnostic } from "./manifest-types.js";
 import type { PluginManifestActivationCapability } from "./manifest.js";
@@ -57,12 +59,14 @@ type ResolveManifestActivationPlanParams = {
   origin?: PluginOrigin;
   onlyPluginIds?: readonly string[];
   manifestRecords?: readonly PluginManifestRecord[];
+  allowRestrictiveAllowlistBypass?: boolean;
 };
 
 export function resolveManifestActivationPlan(
   params: ResolveManifestActivationPlanParams,
 ): PluginActivationPlan {
   const onlyPluginIdSet = createPluginIdScopeSet(normalizePluginIdScope(params.onlyPluginIds));
+  const normalizedConfig = normalizePluginsConfig(params.config?.plugins);
   const registry = params.manifestRecords
     ? { plugins: params.manifestRecords, diagnostics: [] }
     : loadPluginManifestRegistryForPluginRegistry({
@@ -77,6 +81,15 @@ export function resolveManifestActivationPlan(
         return [];
       }
       if (onlyPluginIdSet && !onlyPluginIdSet.has(plugin.id)) {
+        return [];
+      }
+      if (
+        !passesManifestOwnerBasePolicy({
+          plugin,
+          normalizedConfig,
+          allowRestrictiveAllowlistBypass: params.allowRestrictiveAllowlistBypass,
+        })
+      ) {
         return [];
       }
       const reasons = listManifestActivationTriggerReasons(plugin, params.trigger);

--- a/src/plugins/agent-tool-result-middleware.test.ts
+++ b/src/plugins/agent-tool-result-middleware.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { normalizeAgentToolResultMiddlewareRuntimes } from "./agent-tool-result-middleware.js";
+
+describe("normalizeAgentToolResultMiddlewareRuntimes", () => {
+  it("defaults omitted runtimes to every supported runtime", () => {
+    expect(normalizeAgentToolResultMiddlewareRuntimes()).toEqual(["pi", "codex"]);
+  });
+
+  it("preserves an explicit empty runtime list", () => {
+    expect(normalizeAgentToolResultMiddlewareRuntimes({ runtimes: [] })).toEqual([]);
+  });
+
+  it("normalizes legacy harness names", () => {
+    expect(
+      normalizeAgentToolResultMiddlewareRuntimes({ harnesses: ["codex-app-server", "pi"] }),
+    ).toEqual(["codex", "pi"]);
+  });
+
+  it("falls back to legacy harnesses when runtimes is undefined", () => {
+    expect(
+      normalizeAgentToolResultMiddlewareRuntimes({
+        runtimes: undefined,
+        harnesses: ["codex-app-server"],
+      }),
+    ).toEqual(["codex"]);
+  });
+});

--- a/src/plugins/agent-tool-result-middleware.ts
+++ b/src/plugins/agent-tool-result-middleware.ts
@@ -30,7 +30,7 @@ export function normalizeAgentToolResultMiddlewareRuntimes(
   options?: AgentToolResultMiddlewareOptions,
 ): AgentToolResultMiddlewareRuntime[] {
   const requested = options?.runtimes ?? options?.harnesses;
-  if (!requested || requested.length === 0) {
+  if (!requested) {
     return [...AGENT_TOOL_RESULT_MIDDLEWARE_RUNTIMES];
   }
   const normalized: AgentToolResultMiddlewareRuntime[] = [];

--- a/src/plugins/channel-plugin-ids.test.ts
+++ b/src/plugins/channel-plugin-ids.test.ts
@@ -453,6 +453,9 @@ function useManifestRegistryFixture(
 ) {
   const index = createInstalledPluginIndexFixture(registry);
   loadPluginManifestRegistry.mockReset().mockReturnValue(registry);
+  loadPluginManifestRegistryForPluginRegistry
+    .mockReset()
+    .mockImplementation(() => loadPluginManifestRegistry());
   loadPluginRegistrySnapshot.mockReset().mockReturnValue(index);
   return { registry, index };
 }

--- a/src/plugins/channel-presence-policy.ts
+++ b/src/plugins/channel-presence-policy.ts
@@ -475,6 +475,10 @@ function resolveScopedChannelOwnerPluginIds(params: {
         workspaceDir: params.workspaceDir,
         env: params.env,
         manifestRecords: records,
+        allowRestrictiveAllowlistBypass: hasExplicitChannelConfig({
+          config: trustConfig,
+          channelId,
+        }),
       });
     }),
   );

--- a/src/plugins/cli.test.ts
+++ b/src/plugins/cli.test.ts
@@ -219,6 +219,20 @@ describe("registerPluginCliCommands", () => {
     expect(mocks.loadOpenClawPlugins).toHaveBeenCalledTimes(2);
   });
 
+  it("reloads plugin CLI entries when config or environment identity changes", async () => {
+    const program = createProgram();
+    const configA = {} as OpenClawConfig;
+    const configB = { plugins: {} } as OpenClawConfig;
+    const envA = { OPENCLAW_HOME: "/tmp/a" } as NodeJS.ProcessEnv;
+    const envB = { OPENCLAW_HOME: "/tmp/b" } as NodeJS.ProcessEnv;
+
+    await registerPluginCliCommands(program, configA, envA);
+    await registerPluginCliCommands(program, configA, envB);
+    await registerPluginCliCommands(program, configB, envB);
+
+    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledTimes(3);
+  });
+
   it("loads plugin CLI commands from the auto-enabled config snapshot", async () => {
     const { rawConfig, autoEnabledConfig } = createAutoEnabledCliFixture();
     mocks.applyPluginAutoEnable.mockReturnValue({

--- a/src/plugins/cli.ts
+++ b/src/plugins/cli.ts
@@ -26,11 +26,46 @@ const PLUGIN_CLI_ENTRIES_CACHE_KEY = Symbol.for("openclaw.plugin-cli-registratio
 interface ProgramWithEntriesCache {
   [PLUGIN_CLI_ENTRIES_CACHE_KEY]?: {
     primary: string | undefined;
+    inputKey: string;
     entries: PluginCliRegistrationEntries;
   };
 }
 
 const logger = createPluginCliLogger();
+const loaderOptionIds = new WeakMap<object, number>();
+let nextLoaderOptionId = 1;
+
+function stableJsonKey(value: unknown): string {
+  if (value === undefined) {
+    return "undefined";
+  }
+  try {
+    return JSON.stringify(value, (_key, entry) => {
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+        return entry;
+      }
+      return Object.fromEntries(
+        Object.entries(entry).toSorted(([left], [right]) => left.localeCompare(right)),
+      );
+    });
+  } catch {
+    return "unserializable";
+  }
+}
+
+function loaderOptionsKey(loaderOptions: PluginCliLoaderOptions | undefined): string {
+  if (!loaderOptions) {
+    return "undefined";
+  }
+  const existing = loaderOptionIds.get(loaderOptions);
+  if (existing) {
+    return String(existing);
+  }
+  const id = nextLoaderOptionId;
+  nextLoaderOptionId += 1;
+  loaderOptionIds.set(loaderOptions, id);
+  return String(id);
+}
 
 export const loadValidatedConfigForPluginRegistration =
   async (): Promise<OpenClawConfig | null> => {
@@ -58,11 +93,14 @@ export async function registerPluginCliCommands(
 ) {
   const mode = options?.mode ?? "eager";
   const primary = options?.primary ?? undefined;
+  const inputKey = [stableJsonKey(cfg), stableJsonKey(env), loaderOptionsKey(loaderOptions)].join(
+    "\0",
+  );
 
   const programWithCache = program as Command & ProgramWithEntriesCache;
   const cached = programWithCache[PLUGIN_CLI_ENTRIES_CACHE_KEY];
   let entries: PluginCliRegistrationEntries;
-  if (cached && cached.primary === primary) {
+  if (cached && cached.primary === primary && cached.inputKey === inputKey) {
     entries = cached.entries;
   } else {
     entries = await loadPluginCliRegistrationEntriesWithDefaults({
@@ -71,7 +109,7 @@ export async function registerPluginCliCommands(
       loaderOptions,
       primaryCommand: primary,
     });
-    programWithCache[PLUGIN_CLI_ENTRIES_CACHE_KEY] = { primary, entries };
+    programWithCache[PLUGIN_CLI_ENTRIES_CACHE_KEY] = { primary, inputKey, entries };
   }
 
   await registerPluginCliCommandGroups(program, entries, {

--- a/src/plugins/command-registration.ts
+++ b/src/plugins/command-registration.ts
@@ -4,6 +4,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
 } from "../shared/string-coerce.js";
+import { isRecord } from "../utils.js";
 import {
   clearPluginCommands,
   clearPluginCommandsForPlugin,
@@ -165,6 +166,9 @@ export function validatePluginCommandDefinition(
   if (nameError) {
     return nameError;
   }
+  if (command.nativeNames !== undefined && !isRecord(command.nativeNames)) {
+    return "Command nativeNames must be an object";
+  }
   for (const [label, alias] of Object.entries(command.nativeNames ?? {})) {
     if (typeof alias !== "string") {
       continue;
@@ -174,6 +178,9 @@ export function validatePluginCommandDefinition(
       return `Native command alias "${label}" invalid: ${aliasError}`;
     }
   }
+  if (command.nativeProgressMessages !== undefined && !isRecord(command.nativeProgressMessages)) {
+    return "Command nativeProgressMessages must be an object";
+  }
   for (const [label, message] of Object.entries(command.nativeProgressMessages ?? {})) {
     if (typeof message !== "string") {
       return `Native progress message "${label}" must be a string`;
@@ -181,6 +188,12 @@ export function validatePluginCommandDefinition(
     if (!message.trim()) {
       return `Native progress message "${label}" cannot be empty`;
     }
+  }
+  if (
+    command.descriptionLocalizations !== undefined &&
+    !isRecord(command.descriptionLocalizations)
+  ) {
+    return "Command descriptionLocalizations must be an object";
   }
   for (const [locale, description] of Object.entries(command.descriptionLocalizations ?? {})) {
     if (typeof description !== "string") {

--- a/src/plugins/commands.test.ts
+++ b/src/plugins/commands.test.ts
@@ -336,8 +336,21 @@ describe("registerPluginCommand", () => {
         error: "Command channel 2 cannot be empty",
       },
     },
+    {
+      name: "rejects primitive native command metadata",
+      command: {
+        name: "demo",
+        description: "Demo",
+        nativeNames: "demo-native",
+        handler: async () => ({ text: "ok" }),
+      },
+      expected: {
+        ok: false,
+        error: "Command nativeNames must be an object",
+      },
+    },
   ] as const)("$name", ({ command, expected }) => {
-    expect(registerPluginCommand("demo-plugin", command)).toEqual(expected);
+    expect(registerPluginCommand("demo-plugin", command as never)).toEqual(expected);
   });
 
   it("normalizes command metadata for downstream consumers", () => {

--- a/src/plugins/config-contracts.test.ts
+++ b/src/plugins/config-contracts.test.ts
@@ -29,7 +29,10 @@ vi.mock("./plugin-registry.js", () => ({
   loadPluginRegistrySnapshot: mocks.loadPluginRegistrySnapshot,
 }));
 
-import { resolvePluginConfigContractsById } from "./config-contracts.js";
+import {
+  collectPluginConfigContractMatches,
+  resolvePluginConfigContractsById,
+} from "./config-contracts.js";
 
 type PluginManifestRecord = PluginManifestRegistry["plugins"][number];
 
@@ -270,5 +273,30 @@ describe("resolvePluginConfigContractsById", () => {
       }),
     ).toEqual(new Map());
     expect(mocks.loadBundledManifestRegistry).not.toHaveBeenCalled();
+  });
+});
+
+describe("collectPluginConfigContractMatches", () => {
+  it("only accepts canonical array index path segments", () => {
+    const root = { items: ["first", "second"] };
+
+    expect(
+      collectPluginConfigContractMatches({
+        root,
+        pathPattern: "items.1",
+      }),
+    ).toEqual([{ path: "items[1]", value: "second" }]);
+    expect(
+      collectPluginConfigContractMatches({
+        root,
+        pathPattern: "items.1.5",
+      }),
+    ).toEqual([]);
+    expect(
+      collectPluginConfigContractMatches({
+        root,
+        pathPattern: "items.01",
+      }),
+    ).toEqual([]);
   });
 });

--- a/src/plugins/config-contracts.ts
+++ b/src/plugins/config-contracts.ts
@@ -35,6 +35,14 @@ function appendPathSegment(path: string, segment: string): string {
   return /^\d+$/.test(segment) ? `${path}[${segment}]` : `${path}.${segment}`;
 }
 
+function parseCanonicalArrayIndex(segment: string, length: number): number | null {
+  if (!/^(0|[1-9]\d*)$/.test(segment)) {
+    return null;
+  }
+  const index = Number(segment);
+  return Number.isSafeInteger(index) && index >= 0 && index < length ? index : null;
+}
+
 export function collectPluginConfigContractMatches(params: {
   root: unknown;
   pathPattern: string;
@@ -69,8 +77,8 @@ export function collectPluginConfigContractMatches(params: {
         continue;
       }
       if (Array.isArray(state.value)) {
-        const index = Number.parseInt(segment, 10);
-        if (Number.isInteger(index) && index >= 0 && index < state.value.length) {
+        const index = parseCanonicalArrayIndex(segment, state.value.length);
+        if (index !== null) {
           nextStates.push({
             segments: [...state.segments, segment],
             value: state.value[index],

--- a/src/plugins/installed-plugin-index-record-reader.ts
+++ b/src/plugins/installed-plugin-index-record-reader.ts
@@ -15,7 +15,13 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function cloneInstallRecords(
   records: Record<string, PluginInstallRecord> | undefined,
 ): Record<string, PluginInstallRecord> {
-  return structuredClone(records ?? {});
+  return readRecordMap(records) ?? {};
+}
+
+const BLOCKED_RECORD_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+function isSafeRecordKey(key: string): boolean {
+  return !BLOCKED_RECORD_KEYS.has(key);
 }
 
 function readRecordMap(value: unknown): Record<string, PluginInstallRecord> | null {
@@ -26,6 +32,9 @@ function readRecordMap(value: unknown): Record<string, PluginInstallRecord> | nu
   for (const [pluginId, record] of Object.entries(value).toSorted(([left], [right]) =>
     left.localeCompare(right),
   )) {
+    if (!isSafeRecordKey(pluginId)) {
+      continue;
+    }
     if (isRecord(record) && typeof record.source === "string") {
       records[pluginId] = structuredClone(record) as PluginInstallRecord;
     }
@@ -46,6 +55,9 @@ function readStringRecord(value: unknown): Record<string, string> {
   for (const [key, raw] of Object.entries(value).toSorted(([left], [right]) =>
     left.localeCompare(right),
   )) {
+    if (!isSafeRecordKey(key)) {
+      continue;
+    }
     if (typeof raw === "string" && raw.trim()) {
       record[key] = raw.trim();
     }
@@ -149,6 +161,9 @@ function extractPluginInstallRecordsFromPersistedInstalledPluginIndex(
   const records: Record<string, PluginInstallRecord> = {};
   for (const entry of index.plugins) {
     if (!isRecord(entry) || typeof entry.pluginId !== "string" || !isRecord(entry.installRecord)) {
+      continue;
+    }
+    if (!isSafeRecordKey(entry.pluginId)) {
       continue;
     }
     records[entry.pluginId] = structuredClone(entry.installRecord) as PluginInstallRecord;

--- a/src/plugins/installed-plugin-index.test.ts
+++ b/src/plugins/installed-plugin-index.test.ts
@@ -5,6 +5,7 @@ import type { PluginCandidate } from "./discovery.js";
 import { buildInstalledPluginIndexRecords } from "./installed-plugin-index-record-builder.js";
 import {
   loadInstalledPluginIndexInstallRecordsSync,
+  readPersistedInstalledPluginIndexInstallRecordsSync,
   writePersistedInstalledPluginIndexInstallRecords,
 } from "./installed-plugin-index-records.js";
 import {
@@ -199,6 +200,23 @@ function createRichPluginFixture(params: { id?: string; packageVersion?: string 
 }
 
 describe("installed plugin index", () => {
+  it("drops blocked install record keys while reading persisted index records", () => {
+    const root = makeTempDir();
+    const filePath = path.join(root, "installed-plugin-index.json");
+    fs.writeFileSync(
+      filePath,
+      '{"installRecords":{"safe":{"source":"npm","spec":"safe"},"constructor":{"source":"npm","spec":"poison"},"prototype":{"source":"npm","spec":"poison"},"__proto__":{"source":"npm","spec":"poison"}}}',
+      "utf-8",
+    );
+
+    const records = readPersistedInstalledPluginIndexInstallRecordsSync({ filePath });
+
+    expect(records?.safe).toEqual({ source: "npm", spec: "safe" });
+    expect(Object.prototype.hasOwnProperty.call(records ?? {}, "constructor")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(records ?? {}, "prototype")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(records ?? {}, "__proto__")).toBe(false);
+  });
+
   it("builds a runtime-free installed plugin snapshot from manifest and package metadata", () => {
     const fixture = createRichPluginFixture();
 

--- a/src/plugins/manifest-model-suppression.test.ts
+++ b/src/plugins/manifest-model-suppression.test.ts
@@ -235,4 +235,45 @@ describe("manifest model suppression", () => {
       }),
     ).toBeUndefined();
   });
+
+  it("does not apply provider api conditional suppressions when a configured provider omits api", () => {
+    mocks.loadPluginMetadataSnapshot.mockReturnValue(
+      createMetadataSnapshot([
+        {
+          id: "qwen",
+          providers: ["modelstudio"],
+          modelCatalog: {
+            suppressions: [
+              {
+                provider: "modelstudio",
+                model: "qwen3.6-plus",
+                when: {
+                  baseUrlHosts: ["coding-intl.dashscope.aliyuncs.com"],
+                  providerConfigApiIn: ["qwen", "modelstudio"],
+                },
+              },
+            ],
+          },
+        },
+      ]),
+    );
+
+    expect(
+      resolveManifestBuiltInModelSuppression({
+        provider: "modelstudio",
+        id: "qwen3.6-plus",
+        config: {
+          models: {
+            providers: {
+              modelstudio: {
+                baseUrl: "https://coding-intl.dashscope.aliyuncs.com/v1",
+                models: [],
+              },
+            },
+          },
+        },
+        env: process.env,
+      }),
+    ).toBeUndefined();
+  });
 });

--- a/src/plugins/manifest-model-suppression.ts
+++ b/src/plugins/manifest-model-suppression.ts
@@ -93,9 +93,12 @@ function manifestSuppressionMatchesConditions(params: {
     provider: params.provider,
     config: params.config,
   });
-  if (when.providerConfigApiIn?.length && configuredProvider?.api) {
+  if (when.providerConfigApiIn?.length) {
     const allowedApis = new Set(when.providerConfigApiIn.map(normalizeLowercaseStringOrEmpty));
-    if (!allowedApis.has(configuredProvider.api)) {
+    const effectiveApi = configuredProvider
+      ? normalizeLowercaseStringOrEmpty(configuredProvider.api)
+      : params.provider;
+    if (!effectiveApi || !allowedApis.has(effectiveApi)) {
       return false;
     }
   }

--- a/src/plugins/plugin-peer-link.test.ts
+++ b/src/plugins/plugin-peer-link.test.ts
@@ -103,4 +103,27 @@ describe("plugin peer links", () => {
       expect(warnings.join("\n")).toContain("is not a real directory");
     },
   );
+
+  it("does not delete an existing real openclaw package directory", async () => {
+    const root = makeTempDir();
+    const packageDir = path.join(root, "peer-plugin");
+    const existingOpenClawDir = path.join(packageDir, "node_modules", "openclaw");
+    fs.mkdirSync(existingOpenClawDir, { recursive: true });
+    fs.writeFileSync(path.join(existingOpenClawDir, "package.json"), '{"name":"openclaw"}', "utf8");
+
+    const warnings: string[] = [];
+    const result = await linkOpenClawPeerDependencies({
+      installedDir: packageDir,
+      peerDependencies: {
+        openclaw: ">=2026.0.0",
+      },
+      logger: {
+        warn: (message) => warnings.push(message),
+      },
+    });
+
+    expect(result).toEqual({ repaired: 0, skipped: 1 });
+    expect(fs.existsSync(path.join(existingOpenClawDir, "package.json"))).toBe(true);
+    expect(warnings.join("\n")).toContain("already exists and is not a symlink");
+  });
 });

--- a/src/plugins/plugin-peer-link.ts
+++ b/src/plugins/plugin-peer-link.ts
@@ -211,7 +211,21 @@ async function linkOpenClawPeerDependency(params: {
   }
 
   try {
-    await fs.rm(linkPath, { recursive: true, force: true });
+    const existing = await fs.lstat(linkPath).catch((err: NodeJS.ErrnoException) => {
+      if (err.code === "ENOENT") {
+        return null;
+      }
+      throw err;
+    });
+    if (existing) {
+      if (!existing.isSymbolicLink()) {
+        params.logger.warn?.(
+          `Skipping openclaw peerDependency link because ${linkPath} already exists and is not a symlink.`,
+        );
+        return "skipped";
+      }
+      await fs.unlink(linkPath);
+    }
     await fs.symlink(params.hostRoot, linkPath, "junction");
     params.logger.info?.(`Linked peerDependency "${params.peerName}" -> ${params.hostRoot}`);
     return "linked";

--- a/test/scripts/ts-topology.test.ts
+++ b/test/scripts/ts-topology.test.ts
@@ -79,7 +79,7 @@ describe("ts-topology", () => {
     });
   });
 
-  it("counts renamed imports, namespace imports, type-only imports, and test-only consumers", () => {
+  it("counts renamed imports, namespace imports, and test-only consumers without runtime-counting type-only imports", () => {
     const aliasedThing = requireRecordByExport("aliasedThing");
     const sharedType = requireRecordByExport("SharedType");
     const testOnlyThing = requireRecordByExport("testOnlyThing");
@@ -97,15 +97,15 @@ describe("ts-topology", () => {
       internalRefCount: 0,
       isTypeOnlyCandidate: true,
       kind: "type",
-      moveBackToOwnerScore: 0,
-      productionConsumers: ["extensions/alpha/src/use.ts", "extensions/beta/src/use.ts"],
-      productionExtensions: ["alpha", "beta"],
-      productionImportCount: 2,
-      productionOwners: ["extension:alpha", "extension:beta"],
+      moveBackToOwnerScore: 20,
+      productionConsumers: [],
+      productionExtensions: [],
+      productionImportCount: 0,
+      productionOwners: [],
       productionPackages: [],
-      productionRefCount: 2,
+      productionRefCount: 0,
       publicSpecifiers: ["fixture-sdk"],
-      sharednessScore: 75,
+      sharednessScore: 15,
       testConsumers: [],
       testImportCount: 0,
       testRefCount: 0,
@@ -144,16 +144,19 @@ describe("ts-topology", () => {
     expect(singleOwnerEnvelope.records.map((record) => record.exportNames[0])).not.toContain(
       "sharedThing",
     );
-    expect(unusedEnvelope.records.map((record) => record.exportNames[0])).toEqual(["unusedThing"]);
+    expect(unusedEnvelope.records.map((record) => record.exportNames[0])).toEqual([
+      "SharedType",
+      "unusedThing",
+    ]);
   });
 
   it("renders stable text summaries for the public-surface report", () => {
     expect(renderTextReport({ ...publicSurfaceEnvelope, limit: 3 }, 3)).toMatchInlineSnapshot(`
       "Scope: custom
       Public exports analyzed: 6
-      Production-used exports: 4
+      Production-used exports: 3
       Single-owner shared exports: 2
-      Unused public exports: 1
+      Unused public exports: 2
       
       Top 2 candidate-to-move exports:
       - fixture-sdk:aliasedThing -> src/lib/shared.ts:9 (prodRefs=1, owners=extension:alpha, sharedness=35, move=85)
@@ -187,11 +190,23 @@ describe("ts-topology", () => {
 
     expect(renderTextReport(deriveReportEnvelope("consumer-topology"), 2)).toMatchInlineSnapshot(`
       "Scope: custom
-      Records with consumers: 5
+      Records with consumers: 4
       
       Top 2 consumer-topology records:
       - fixture-sdk:sharedThing prod=3 test=0 internal=0
-      - fixture-sdk:SharedType prod=2 test=0 internal=0"
+      - fixture-sdk:aliasedThing prod=1 test=0 internal=0"
     `);
+  });
+
+  it("throws a clear error for invalid text report names", () => {
+    expect(() =>
+      renderTextReport(
+        {
+          ...publicSurfaceEnvelope,
+          report: "missing-report" as typeof publicSurfaceEnvelope.report,
+        },
+        2,
+      ),
+    ).toThrow("Unsupported topology report: missing-report");
   });
 });


### PR DESCRIPTION
## Summary

Fixes clawpatch-reported edge cases across OpenClaw core and plugin surfaces:

- Gateway/session safety: clear stale device-auth env tokens on mismatch/close, reject empty/path-like Claude CLI session ids, and remove channel-health abort listeners on manual stop.
- Plugin activation/policy: respect disable/deny/global/allowlist policy for manifest-trigger activation while preserving explicit bundled-channel config bypasses.
- Plugin runtime metadata: preserve explicit empty agent tool-result middleware runtime scopes, keep legacy harness fallback only when runtimes are omitted, and add regression coverage.
- Plugin CLI/registry validation: key lazy command registration cache by config/env/loader options, reject primitive command metadata records, filter unsafe installed-index record keys, skip replacing real node_modules/openclaw peer dirs, and tighten config contract array traversal.
- Model suppression: require matching effective provider API for providerConfigApiIn conditions and avoid matching configured providers that omit api.
- Agent/tooling correctness: fix apply-patch move-to-self and insertion cursor handling, close bundled MCP test transports in finally, redact Anthropic usage/error diagnostics, and make ts-topology ignore type-only imports in runtime counts with clearer invalid-report errors.
- Changelog: add an Unreleased fix entry for the hardening sweep.

## Verification

- codex-review --mode local: clean; no accepted/actionable findings.
- node scripts/run-vitest.mjs src/agents/anthropic-payload-log.test.ts src/agents/apply-patch.test.ts src/gateway/channel-health-monitor.test.ts src/gateway/cli-session-history.test.ts src/gateway/client.test.ts src/plugins/activation-planner.test.ts src/plugins/agent-tool-result-middleware.test.ts src/plugins/channel-plugin-ids.test.ts src/plugins/cli.test.ts src/plugins/commands.test.ts src/plugins/config-contracts.test.ts src/plugins/installed-plugin-index.test.ts src/plugins/manifest-model-suppression.test.ts src/plugins/plugin-peer-link.test.ts test/scripts/ts-topology.test.ts: 21 files / 511 tests passed.
- pnpm check:changed: passed on Blacksmith Testbox tbx_01krwdndgerafj1tqdc4abr6rz; GitHub Actions run https://github.com/openclaw/openclaw/actions/runs/26009859447.
- git diff --check: passed.

## Real behavior proof

Behavior addressed: Clawpatch-reported OpenClaw edge cases around auth cleanup, session path confinement, manifest/plugin policy, apply-patch behavior, diagnostic logging, config/index parsing, and topology reports.

Real environment tested: Blacksmith Testbox tbx_01krwdndgerafj1tqdc4abr6rz running the OpenClaw changed gate against this rebased branch, plus local macOS checkout for codex-review, targeted Vitest, and diff whitespace checks.

Exact steps or command run after this patch: pnpm check:changed on the rebased branch; codex-review --mode local; node scripts/run-vitest.mjs with the changed targeted test files; git diff --check.

Evidence after fix: Terminal output from Blacksmith Testbox run tbx_01krwdndgerafj1tqdc4abr6rz:

```text
[check:changed] lanes=core, coreTests, docs, tooling
[check:changed] typecheck core
[check:changed] typecheck core tests
[check:changed] lint core
Found 0 warnings and 0 errors.
[check:changed] lint scripts
Found 0 warnings and 0 errors.
Import cycle check: 0 runtime value cycle(s).
blacksmith run summary sync=delegated command=1m53.371s total=1m56.54s exit=0
{"provider":"blacksmith-testbox","leaseId":"tbx_01krwdndgerafj1tqdc4abr6rz","slug":"pearl-krill","exitCode":0}
Testbox tbx_01krwdndgerafj1tqdc4abr6rz stopped (completed)
```

Observed result after fix: The changed gate completed with exit code 0 on the remote Testbox environment; codex-review reported no accepted/actionable findings; targeted Vitest passed 21 files / 511 tests; git diff --check exited 0.

What was not tested: No full release validation or live provider/channel E2E beyond the changed gate.
