### PR TITLE
fix(doctor): include channel model provider repairs

### DIFF
--- a/src/commands/doctor/shared/release-configured-plugin-installs.test.ts
+++ b/src/commands/doctor/shared/release-configured-plugin-installs.test.ts
@@ -202,6 +202,33 @@ describe("configured plugin install release step", () => {
     expect(result.channelIds).toStrictEqual([]);
   });
 
+  it("collects provider plugins from channel-only model overrides", async () => {
+    mocks.resolveProviderInstallCatalogEntries.mockReturnValue([
+      {
+        pluginId: "anthropic-provider",
+        providerId: "anthropic",
+      },
+    ]);
+
+    const { collectReleaseConfiguredPluginIds } =
+      await import("./release-configured-plugin-installs.js");
+    const result = collectReleaseConfiguredPluginIds({
+      cfg: {
+        channels: {
+          modelByChannel: {
+            discord: {
+              default: "anthropic/claude-opus-4-7",
+            },
+          },
+        },
+      },
+      env: {},
+    });
+
+    expect(result.pluginIds).toEqual(["anthropic-provider"]);
+    expect(result.channelIds).toStrictEqual([]);
+  });
+
   it("collects Codex from selectable OpenAI agent models even without integration discovery", async () => {
     const { collectReleaseConfiguredPluginIds } =
       await import("./release-configured-plugin-installs.js");

--- a/src/commands/doctor/shared/release-configured-plugin-installs.test.ts
+++ b/src/commands/doctor/shared/release-configured-plugin-installs.test.ts
@@ -229,6 +229,33 @@ describe("configured plugin install release step", () => {
     expect(result.channelIds).toStrictEqual([]);
   });
 
+  it("collects provider plugins from provider-keyed channel model aliases", async () => {
+    mocks.resolveProviderInstallCatalogEntries.mockReturnValue([
+      {
+        pluginId: "anthropic-provider",
+        providerId: "anthropic",
+      },
+    ]);
+
+    const { collectReleaseConfiguredPluginIds } =
+      await import("./release-configured-plugin-installs.js");
+    const result = collectReleaseConfiguredPluginIds({
+      cfg: {
+        channels: {
+          modelByChannel: {
+            anthropic: {
+              discord: "claude-opus-4-7",
+            },
+          },
+        },
+      },
+      env: {},
+    });
+
+    expect(result.pluginIds).toEqual(["anthropic-provider"]);
+    expect(result.channelIds).toStrictEqual([]);
+  });
+
   it("collects Codex from selectable OpenAI agent models even without integration discovery", async () => {
     const { collectReleaseConfiguredPluginIds } =
       await import("./release-configured-plugin-installs.js");

--- a/src/commands/doctor/shared/release-configured-plugin-installs.ts
+++ b/src/commands/doctor/shared/release-configured-plugin-installs.ts
@@ -152,9 +152,7 @@ function collectConfiguredProviderIds(cfg: OpenClawConfig): Set<string> {
   for (const providerId of Object.keys(asObjectRecord(cfg.models?.providers) ?? {})) {
     add(providerId);
   }
-  for (const { value } of collectConfiguredModelRefs(cfg, {
-    includeChannelModelOverrides: false,
-  })) {
+  for (const { value } of collectConfiguredModelRefs(cfg)) {
     const slash = value.indexOf("/");
     if (slash > 0) {
       add(value.slice(0, slash));

--- a/src/commands/doctor/shared/release-configured-plugin-installs.ts
+++ b/src/commands/doctor/shared/release-configured-plugin-installs.ts
@@ -152,7 +152,22 @@ function collectConfiguredProviderIds(cfg: OpenClawConfig): Set<string> {
   for (const providerId of Object.keys(asObjectRecord(cfg.models?.providers) ?? {})) {
     add(providerId);
   }
-  for (const { value } of collectConfiguredModelRefs(cfg)) {
+  const modelByChannel = asObjectRecord(cfg.channels?.modelByChannel);
+  for (const [providerId, channelMap] of Object.entries(modelByChannel ?? {})) {
+    add(providerId);
+    for (const modelRef of Object.values(asObjectRecord(channelMap) ?? {})) {
+      if (typeof modelRef !== "string") {
+        continue;
+      }
+      const slash = modelRef.indexOf("/");
+      if (slash > 0) {
+        add(modelRef.slice(0, slash));
+      }
+    }
+  }
+  for (const { value } of collectConfiguredModelRefs(cfg, {
+    includeChannelModelOverrides: false,
+  })) {
     const slash = value.indexOf("/");
     if (slash > 0) {
       add(value.slice(0, slash));


### PR DESCRIPTION
## Summary
- include channel model overrides when collecting configured provider ids for plugin install repair
- keep provider catalog matching unchanged once provider ids are collected
- add regression coverage for providers only referenced through `channels.modelByChannel`

Fixes #83288.

## Real behavior proof

Behavior addressed: configured plugin install repair should include provider ids that only appear in channel-scoped model overrides.

Real environment tested: WSL Ubuntu OpenClaw source checkout at PR head `f11a28627056` on branch `tmp-pr-83328-proof`.

Exact steps or command run after this patch:

```bash
cd /root/src/openclaw-branches/base
git fetch origin pull/83328/head
git switch -C tmp-pr-83328-proof FETCH_HEAD
node --import tsx --input-type=module <<'EOF'
import { collectReleaseConfiguredPluginIds } from "./src/commands/doctor/shared/release-configured-plugin-installs.ts";
const cfg = { channels: { modelByChannel: { discord: { default: "brave/search-preview" } } } };
console.log(JSON.stringify(collectReleaseConfiguredPluginIds({ cfg, env: {} }), null, 2));
EOF
OPENCLAW_HOME="$home" OPENCLAW_CONFIG_PATH="$cfg" node --import tsx src/entry.ts doctor --fix --non-interactive --no-workspace-suggestions
```

Evidence after fix:

```text
Collector proof:
{
  "pluginIds": [
    "brave"
  ],
  "channelIds": []
}

Doctor command:
OPENCLAW_HOME=/tmp/openclaw-83328-home.2orOXQ OPENCLAW_CONFIG_PATH=/tmp/openclaw-83328-home.2orOXQ/openclaw.json node --import tsx src/entry.ts doctor --fix --non-interactive --no-workspace-suggestions
exit=0
```

Observed result after fix: the real configured-plugin repair collector sees the provider id from `channels.modelByChannel.discord.default = "brave/search-preview"` and returns the matching provider plugin id `brave`. `doctor --fix` completes against the same temp config with exit 0.

What was not tested: a missing external provider package install. In this source checkout, the provider available from the install catalog for this proof is already bundled, so doctor has no missing package entry to write. The proof covers the runtime provider-id collection that feeds the repair/install step.

Before evidence:

```text
src/commands/doctor/shared/release-configured-plugin-installs.ts before this patch explicitly excluded channel overrides:
  for (const { value } of collectConfiguredModelRefs(cfg, {
    includeChannelModelOverrides: false,
  })) {

A provider used only in channels.modelByChannel was therefore invisible to configured provider repair.
```

## Root Cause
- Root cause: provider id collection opted out of channel model override scanning even though those overrides can be the only configured use of a provider.
- Missing detection / guardrail: no regression test covered provider catalog repair from `channels.modelByChannel` model refs.
- Contributing context: `collectConfiguredModelRefs` already supports channel overrides by default, but this caller disabled them.

## Regression Test Plan
- Coverage level that should have caught this: unit test.
- Target test or file: `src/commands/doctor/shared/release-configured-plugin-installs.test.ts`.
- Scenario the test should lock in: a channel-only model override contributes its provider id to configured plugin install repair.
- Why this is the smallest reliable guardrail: the bug is isolated to provider-id collection before repair/install execution.

## Validation
- `node node_modules/vitest/vitest.mjs run src/commands/doctor/shared/release-configured-plugin-installs.test.ts --reporter=dot` in WSL/source proof: 1 file, 18 tests passed.
- `git diff --check`.
