### PR TITLE
fix(cron): suppress source replies for announce delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 - Mac app: keep app-level menu commands and Dashboard failure states reachable when the remote Gateway is disconnected, and keep the Settings sidebar toggle in the leading titlebar area.
 - Gateway/webchat: hide internal runtime-context and other `display: false` transcript messages from Chat history and live message events. Fixes #83216. Thanks @EmpireCreator.
 - CLI/help: keep `gateway`, `doctor`, `status`, and `health` help registration out of action/runtime imports so subcommand `--help` stays lightweight in constrained terminals. Fixes #83228. Thanks @dfguerrerom.
+- Cron/Discord: keep explicit announce runs in message-tool-only source-reply mode so scheduled agent turns post once instead of also echoing through automatic visible replies. Fixes #83261. Thanks @Theralley.
 - Mac app: align the Sessions settings pane with the standard Settings page gutter and row spacing.
 - OpenAI/Codex: stop rejecting available `openai-codex` GPT-5.1, GPT-5.2, and GPT-5.3 model refs during config validation, while keeping removed Spark aliases suppressed. Fixes #83303.
 - Codex app-server: preserve streamed native command output in mirrored transcripts and trajectory exports when final snapshots omit aggregated output. (#83200) Thanks @rozmiarD.

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -2,6 +2,7 @@ import type { BootstrapContextMode } from "../../agents/bootstrap-files.js";
 import { resolveCliRuntimeExecutionProvider } from "../../agents/model-runtime-aliases.js";
 import type { SkillSnapshot } from "../../agents/skills.js";
 import { normalizeToolList } from "../../agents/tool-policy.js";
+import type { SourceReplyDeliveryMode } from "../../auto-reply/get-reply-options.types.js";
 import type { ThinkLevel, VerboseLevel } from "../../auto-reply/thinking.js";
 import type { AgentDefaultsConfig } from "../../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -116,6 +117,7 @@ export function createCronPromptExecutor(params: {
     to?: string;
     threadId?: string | number;
   };
+  sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   toolPolicy: {
     requireExplicitMessageTarget: boolean;
     disableMessageTool: boolean;
@@ -202,6 +204,7 @@ export function createCronPromptExecutor(params: {
             cliSessionId,
             skillsSnapshot: params.skillsSnapshot,
             messageChannel: params.messageChannel,
+            sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
             abortSignal: params.abortSignal,
             onExecutionStarted: params.onExecutionStarted,
             onExecutionPhase: params.onExecutionPhase,
@@ -273,6 +276,7 @@ export function createCronPromptExecutor(params: {
                 notifyOnExitEmptySuccess: false,
               }
             : undefined,
+          sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
           runId: params.cronSession.sessionEntry.sessionId,
           requireExplicitMessageTarget: params.toolPolicy.requireExplicitMessageTarget,
           disableMessageTool: params.toolPolicy.disableMessageTool,
@@ -326,6 +330,7 @@ export async function executeCronRun(params: {
     to?: string;
     threadId?: string | number;
   };
+  sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   toolPolicy: {
     requireExplicitMessageTarget: boolean;
     disableMessageTool: boolean;
@@ -380,6 +385,7 @@ export async function executeCronRun(params: {
     messageChannel: params.resolvedDelivery.channel,
     suppressExecNotifyOnExit: params.suppressExecNotifyOnExit,
     resolvedDelivery: params.resolvedDelivery,
+    sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
     toolPolicy: params.toolPolicy,
     skillsSnapshot: params.skillsSnapshot,
     agentPayload: params.agentPayload,

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -565,6 +565,25 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     });
   });
 
+  it("keeps cron announce source replies message-tool-only", async () => {
+    mockRunCronFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue(makeAnnounceDeliveryPlan());
+
+    await runCronIsolatedAgentTurn({
+      ...makeParams(),
+      job: makeAnnounceMessageToolJob(),
+    });
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    expectEmbeddedRunFields({
+      sourceReplyDeliveryMode: "message_tool_only",
+      forceMessageTool: true,
+      messageChannel: "messagechat",
+      messageTo: "123",
+      currentChannelId: "123",
+    });
+  });
+
   it("keeps automatic exec completion notifications when announce delivery is active", async () => {
     mockRunCronFallbackPassthrough();
     resolveCronDeliveryPlanMock.mockReturnValue(makeAnnounceDeliveryPlan());

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -4,6 +4,7 @@ import { listOpenAIAuthProfileProvidersForAgentRuntime } from "../../agents/open
 import { retireSessionMcpRuntime } from "../../agents/pi-bundle-mcp-tools.js";
 import type { MessagingToolSend } from "../../agents/pi-embedded-messaging.types.js";
 import type { SkillSnapshot } from "../../agents/skills.js";
+import type { SourceReplyDeliveryMode } from "../../auto-reply/get-reply-options.types.js";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { CliDeps } from "../../cli/outbound-send-deps.js";
 import type { AgentDefaultsConfig } from "../../config/types.agent-defaults.js";
@@ -326,6 +327,21 @@ function resolveCronToolPolicy(params: { deliveryMode: "announce" | "webhook" | 
   };
 }
 
+function resolveCronSourceReplyDeliveryMode(params: {
+  deliveryPlan: CronDeliveryPlan;
+  resolvedDelivery: ResolvedCronDeliveryTarget;
+  toolPolicy: ReturnType<typeof resolveCronToolPolicy>;
+}): SourceReplyDeliveryMode | undefined {
+  if (
+    params.deliveryPlan.mode !== "announce" ||
+    params.toolPolicy.disableMessageTool ||
+    !params.resolvedDelivery.ok
+  ) {
+    return undefined;
+  }
+  return "message_tool_only";
+}
+
 function canPromptForMessageTool(params: {
   disableMessageTool: boolean;
   toolsAllow?: string[];
@@ -470,6 +486,7 @@ type PreparedCronRunContext = {
   deliveryPlan: CronDeliveryPlan;
   resolvedDelivery: ResolvedCronDeliveryTarget;
   deliveryRequested: boolean;
+  sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
   suppressExecNotifyOnExit: boolean;
   senderIsOwner: boolean;
   toolPolicy: ReturnType<typeof resolveCronToolPolicy>;
@@ -701,6 +718,11 @@ async function prepareCronRunContext(params: {
       job: input.job,
       agentId,
     });
+  const sourceReplyDeliveryMode = resolveCronSourceReplyDeliveryMode({
+    deliveryPlan,
+    resolvedDelivery,
+    toolPolicy,
+  });
 
   const { formattedTime, timeLine } = resolveCronStyleNow(input.cfg, now);
   const base = `[cron:${input.job.id} ${input.job.name}] ${input.message}`.trim();
@@ -833,6 +855,7 @@ async function prepareCronRunContext(params: {
       deliveryPlan,
       resolvedDelivery,
       deliveryRequested,
+      sourceReplyDeliveryMode,
       suppressExecNotifyOnExit: deliveryPlan.mode === "none",
       senderIsOwner: !isExternalHook,
       toolPolicy,
@@ -1179,6 +1202,7 @@ export async function runCronIsolatedAgentTurn(params: {
         accountId: prepared.context.resolvedDelivery.accountId,
         threadId: prepared.context.resolvedDelivery.threadId,
       },
+      sourceReplyDeliveryMode: prepared.context.sourceReplyDeliveryMode,
       toolPolicy: prepared.context.toolPolicy,
       skillsSnapshot: prepared.context.skillsSnapshot,
       agentPayload: prepared.context.agentPayload,


### PR DESCRIPTION
Fixes #83261

## Summary
- Keep cron announce turns with resolved chat delivery targets in message-tool-only source-reply mode.
- Forward that mode through both CLI and embedded cron runners so normal final replies stay private while message tool/fallback owns visible delivery.
- Add regression coverage and a changelog entry for the Discord duplicate-posting report.

## Verification
Behavior addressed: Cron agentTurn announce delivery to Discord/chat targets no longer also uses automatic visible source replies; visible delivery is owned by message tool/fallback.
Real environment tested: Local source checkout on macOS, focused cron source/type/lint gates.
Exact steps or command run after this patch:
- git diff --check
- pnpm format:check src/cron/isolated-agent/run.ts src/cron/isolated-agent/run-executor.ts src/cron/isolated-agent/run.message-tool-policy.test.ts CHANGELOG.md
- node scripts/run-oxlint.mjs src/cron/isolated-agent/run.ts src/cron/isolated-agent/run-executor.ts src/cron/isolated-agent/run.message-tool-policy.test.ts
- node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.test.src.json --incremental --tsBuildInfoFile /tmp/clawdbot4-cron-test-src.tsbuildinfo --pretty false
- node scripts/run-vitest.mjs src/cron/isolated-agent/run.message-tool-policy.test.ts
- .agents/skills/autoreview/scripts/autoreview --mode local --output /tmp/clawdbot4-83261-autoreview-2.txt
Evidence after fix: Regression test asserts cron announce forwards sourceReplyDeliveryMode: "message_tool_only" with forceMessageTool and resolved message channel/target.
Observed result after fix: diff check, format, oxlint, test-src tsgo, focused Vitest, and autoreview passed locally.
What was not tested: No live Discord cron run was performed.
