### PR TITLE
fix(config-cli): preserve numeric-string object keys in 'config set' mode (#83331)

### DIFF
--- a/src/cli/config-cli.test.ts
+++ b/src/cli/config-cli.test.ts
@@ -401,6 +401,36 @@ describe("config cli", () => {
       expect(written.agents).not.toHaveProperty("defaults");
     });
 
+    it("keeps numeric-string config set path keys as object keys (#83331)", async () => {
+      // channels.discord.guilds is a Record<snowflake, GuildConfig>. The set
+      // mode previously coerced the all-digit snowflake into an array index,
+      // producing `guilds: []` and tripping schema validation with
+      // "must be object". Preserve Record-typed object semantics.
+      const resolved: OpenClawConfig = {
+        channels: {
+          discord: { enabled: true },
+        },
+      } as unknown as OpenClawConfig;
+      setSnapshot(resolved, resolved);
+
+      await runConfigCommand([
+        "config",
+        "set",
+        "channels.discord.guilds.1495587801394184362.requireMention",
+        "true",
+      ]);
+
+      expect(mockWriteConfigFile).toHaveBeenCalledTimes(1);
+      const written = firstWrittenConfig() as {
+        channels?: { discord?: { guilds?: unknown } };
+      };
+      expect(written.channels?.discord?.guilds).toEqual({
+        "1495587801394184362": { requireMention: true },
+      });
+      // Guard against the pre-fix array shape sneaking back in.
+      expect(Array.isArray(written.channels?.discord?.guilds)).toBe(false);
+    });
+
     it("marks set paths explicit so default-equal writes persist", async () => {
       const resolved: OpenClawConfig = {
         channels: {

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -1730,7 +1730,14 @@ async function runConfigOperations(params: {
     explicitSetPaths.push(operation.setPath);
     if (operation.mutation === "merge" || (options.merge && operation.mutation !== "replace")) {
       mergeAtPath(next, operation.setPath, operation.value, {
-        numericObjectKeys: params.successMode === "patch",
+        // #83331: numeric-string keys must be preserved as object keys.
+        // Record-typed config paths (e.g. channels.discord.guilds.<snowflake>,
+        // channels.slack.workspaces.<team-id>) use numeric-looking string keys
+        // that previously got coerced to array indices in `set` mode, making
+        // those paths unreachable via the CLI. Use object-key semantics for
+        // both set and patch; array-index targets must use bracket syntax
+        // (`agents.list[0]`) which goes through parseBracketPathSegment.
+        numericObjectKeys: true,
       });
     } else {
       assertNonDestructiveReplacement({
@@ -1740,7 +1747,8 @@ async function runConfigOperations(params: {
         allowReplace: options.replace || operation.mutation === "replace",
       });
       setAtPath(next, operation.setPath, operation.value, {
-        numericObjectKeys: params.successMode === "patch",
+        // #83331: same as the mergeAtPath call above — object-key semantics.
+        numericObjectKeys: true,
       });
     }
   }


### PR DESCRIPTION
Fixes #83331 (partial — `config set` path).

`runConfigOperations` passed `numericObjectKeys: params.successMode === "patch"` to `setAtPath` / `mergeAtPath`. So `config patch` (already passing `true`) correctly preserved Record-typed numeric-string keys, but `config set` (passing `false`) coerced all-digit segments into array indices when auto-creating containers along the target path. The result: `channels.discord.guilds.<snowflake>` was reachable via patch but unreachable via set, producing `guilds: []` and the `must be object` schema failure described in the issue.

This patch applies `numericObjectKeys: true` for both modes so `config set` matches the already-correct behavior of `config patch` (test at `src/cli/config-cli.test.ts:1996` already asserts this for patch mode). Array-index targets continue to work via bracket syntax (`agents.list[0]`) which routes through `parseBracketPathSegment`.

> Note on the issue's "config patch fails too" claim: I could not reproduce the patch failure under HEAD. The patch path already uses `numericObjectKeys: true` and the existing regression test for `config patch` numeric-key objects passes. If the patch failure repro still holds on the reporter's environment after this PR lands, that's a separate path worth filing (perhaps in the file-loading or schema-validation layer rather than the path walker).

## Changes

- `src/cli/config-cli.ts`: change `numericObjectKeys` from `params.successMode === "patch"` to `true` at both call sites (`mergeAtPath` + `setAtPath` in `runConfigOperations`). 7-line comment block referencing #83331 on the first site; brief follow-up comment on the second.
- `src/cli/config-cli.test.ts`: 1 new regression case (`keeps numeric-string config set path keys as object keys (#83331)`) that mirrors the existing patch-mode test but exercises the set path with the exact Discord snowflake from the issue.

## Real behavior proof

- **Behavior or issue addressed:** `openclaw config set channels.discord.guilds.1495587801394184362.requireMention true` previously wrote `channels.discord.guilds: []` (empty array), tripping the schema validator with `channels.discord.guilds: invalid config: must be object`. Record-typed config paths that use numeric-string keys (Discord snowflakes, Slack workspace IDs, unix timestamps) were unreachable through the set CLI.

- **Real environment tested:** Local Node 22.x. Probe at `/tmp/probe_83331_fix.mjs` replays the exact `setAtPath` function from `src/cli/config-cli.ts` (verbatim) and runs it on the bug-scenario path with the OLD (`numericObjectKeys: false`) vs NEW (`true`) setting. No mocks.

- **Exact steps or command run after this patch:** `node /tmp/probe_83331_fix.mjs`

- **Evidence after fix:**

```
OLD set: {"channels":{"discord":{"guilds":[]}}}
  guilds type: ARRAY
NEW set: {"channels":{"discord":{"guilds":{"1495587801394184362":{"requireMention":true}}}}}
  guilds type: OBJECT

PASS: OLD coerced guilds to ARRAY (bug confirmed)
PASS: NEW preserves OBJECT shape for guilds
PASS: NEW snowflake-key value preserved (requireMention=true)
PASS: non-numeric-string key still produces OBJECT (no regression)

ALL CASES PASS
```

- **Observed result after fix:** `config set <record-path>.<numeric-snowflake>.<field> <value>` produces the correct Record shape and survives schema validation. The non-numeric-key path (`channels.discord.guilds.test-guild.requireMention`) still works (it did before too — confirms no regression). Bracket-syntax array-index targets (`agents.list[0].id`) still route through `parseBracketPathSegment` and produce arrays.

- **What was not tested:** Full end-to-end `openclaw config set <snowflake-path>` against a real on-disk config file with full schema validation (no shell environment available here). The new vitest case covers the exact public CLI entry point through `runConfigCommand` and asserts the written-config shape; the probe covers the path-walker semantic in isolation.

## Audit (per CLAUDE rules)

- **Existing-helper check:** No new helper; flip an existing option from conditional to always-true at two call sites. PASS
- **Shared-helper caller check:** `setAtPath` / `mergeAtPath` are file-local. The `numericObjectKeys` option already existed and was honored at both call sites — the diff is the value passed in, not the helper's contract. PASS
- **Broader-fix rival scan:** No open PRs touching `config-cli.ts` `setAtPath` / `mergeAtPath` / `numericObjectKeys` / `runConfigOperations` as of branch SHA. PASS
