### PR TITLE
Fix stale Codex auth routing for OpenAI PI runs

### DIFF
--- a/src/agents/openai-codex-routing.test.ts
+++ b/src/agents/openai-codex-routing.test.ts
@@ -74,6 +74,15 @@ describe("OpenAI Codex routing policy", () => {
         harnessRuntime: "pi",
         config,
       }),
+    ).toBe("openai");
+    expect(
+      resolveSelectedOpenAIPiRuntimeProvider({
+        provider: "openai",
+        harnessRuntime: "pi",
+        authProfileProvider: "openai-codex",
+        authProfileId: "openai-codex:work",
+        config,
+      }),
     ).toBe("openai-codex");
     expect(
       resolveOpenAIRuntimeProviderForPi({

--- a/src/agents/openai-codex-routing.ts
+++ b/src/agents/openai-codex-routing.ts
@@ -187,11 +187,7 @@ export function resolveSelectedOpenAIPiRuntimeProvider(params: {
   if (runtime === "codex") {
     return OPENAI_CODEX_PROVIDER_ID;
   }
-  return runtime === "pi" &&
-    !params.authProfileId?.trim() &&
-    configuredOpenAIAuthOrderStartsWithCodexProfile(params.config)
-    ? OPENAI_CODEX_PROVIDER_ID
-    : params.provider;
+  return params.provider;
 }
 
 export function resolveContextConfigProviderForRuntime(params: {

--- a/src/agents/pi-embedded-runner.e2e.test.ts
+++ b/src/agents/pi-embedded-runner.e2e.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import "./test-helpers/fast-coding-tools.js";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AuthProfileStore } from "./auth-profiles.js";
 import {
   buildEmbeddedRunnerAssistant,
   cleanupEmbeddedPiRunnerTestWorkspace,
@@ -155,6 +156,8 @@ const installRunEmbeddedMocks = () => {
 
 let runEmbeddedPiAgent: typeof import("./pi-embedded-runner/run.js").runEmbeddedPiAgent;
 let SessionManager: typeof import("@earendil-works/pi-coding-agent").SessionManager;
+let clearRuntimeAuthProfileStoreSnapshots: typeof import("./auth-profiles.js").clearRuntimeAuthProfileStoreSnapshots;
+let replaceRuntimeAuthProfileStoreSnapshots: typeof import("./auth-profiles.js").replaceRuntimeAuthProfileStoreSnapshots;
 let e2eWorkspace: EmbeddedPiRunnerTestWorkspace | undefined;
 let agentDir: string;
 let workspaceDir: string;
@@ -167,17 +170,21 @@ beforeAll(async () => {
   installRunEmbeddedMocks();
   ({ runEmbeddedPiAgent } = await import("./pi-embedded-runner/run.js"));
   ({ SessionManager } = await import("@earendil-works/pi-coding-agent"));
+  ({ clearRuntimeAuthProfileStoreSnapshots, replaceRuntimeAuthProfileStoreSnapshots } =
+    await import("./auth-profiles.js"));
   e2eWorkspace = await createEmbeddedPiRunnerTestWorkspace("openclaw-embedded-agent-");
   ({ agentDir, workspaceDir } = e2eWorkspace);
 }, 180_000);
 
 afterAll(async () => {
+  clearRuntimeAuthProfileStoreSnapshots?.();
   await cleanupEmbeddedPiRunnerTestWorkspace(e2eWorkspace);
   e2eWorkspace = undefined;
 });
 
 beforeEach(() => {
   vi.useRealTimers();
+  clearRuntimeAuthProfileStoreSnapshots();
   runEmbeddedAttemptMock.mockReset();
   disposeSessionMcpRuntimeMock.mockReset();
   resolveSessionKeyForRequestMock.mockReset();
@@ -305,6 +312,100 @@ function firstRunEmbeddedAttemptParams(): { sessionKey?: string } {
   return firstMockCall(runEmbeddedAttemptMock, "embedded attempt")[0] as { sessionKey?: string };
 }
 
+function replaceAuthProfileStoreForTest(store: AuthProfileStore) {
+  replaceRuntimeAuthProfileStoreSnapshots([
+    { store: { version: 1, profiles: {} } },
+    { agentDir, store },
+  ]);
+}
+
+function createOpenAIPiRuntimeConfig(params?: { authOrder?: string[]; providerAuth?: "api-key" }) {
+  const baseConfig = createEmbeddedPiRunnerOpenAiConfig(["mock-1"]);
+  const openAIProvider = baseConfig.models?.providers?.openai;
+  if (!openAIProvider) {
+    throw new Error("expected OpenAI provider test config");
+  }
+  return {
+    ...baseConfig,
+    models: {
+      providers: {
+        openai: {
+          ...openAIProvider,
+          ...(params?.providerAuth ? { auth: params.providerAuth } : {}),
+          baseUrl: "https://api.openai.com/v1",
+        },
+      },
+    },
+    agents: {
+      defaults: {
+        models: {
+          "openai/mock-1": {
+            agentRuntime: { id: "pi" },
+          },
+        },
+      },
+    },
+    ...(params?.authOrder
+      ? {
+          auth: {
+            order: {
+              openai: params.authOrder,
+            },
+          },
+        }
+      : {}),
+  };
+}
+
+async function runOpenAIPiRuntimeTurn(
+  cfg: ReturnType<typeof createOpenAIPiRuntimeConfig>,
+  runId: string,
+) {
+  runEmbeddedAttemptMock.mockResolvedValueOnce(
+    makeEmbeddedRunnerAttempt({
+      assistantTexts: ["ok"],
+      lastAssistant: buildEmbeddedRunnerAssistant({
+        content: [{ type: "text", text: "ok" }],
+      }),
+    }),
+  );
+
+  await runEmbeddedPiAgent({
+    sessionId: runId,
+    sessionFile: nextSessionFile(),
+    workspaceDir,
+    config: cfg,
+    prompt: "hello",
+    provider: "openai",
+    model: "mock-1",
+    timeoutMs: 5_000,
+    agentDir,
+    runId: nextRunId(runId),
+    enqueue: immediateEnqueue,
+  });
+}
+
+function expectModelResolutionProvider(
+  callIndex: number,
+  provider: string,
+  cfg: ReturnType<typeof createOpenAIPiRuntimeConfig>,
+) {
+  expect(resolveModelAsyncMock).toHaveBeenNthCalledWith(
+    callIndex,
+    provider,
+    "mock-1",
+    agentDir,
+    cfg,
+    expect.objectContaining({ skipPiDiscovery: true }),
+  );
+}
+
+function expectAttemptModelProvider(provider: string) {
+  expect(
+    (firstRunEmbeddedAttemptParams() as { model?: { provider?: string } }).model?.provider,
+  ).toBe(provider);
+}
+
 describe("runEmbeddedPiAgent", () => {
   it("skips models.json generation when dynamic model resolution succeeds", async () => {
     const sessionFile = nextSessionFile();
@@ -344,79 +445,104 @@ describe("runEmbeddedPiAgent", () => {
   });
 
   it("resolves explicit OpenAI PI runs through Codex when auth order starts with Codex OAuth", async () => {
-    const sessionFile = nextSessionFile();
-    const baseConfig = createEmbeddedPiRunnerOpenAiConfig(["mock-1"]);
-    const openAIProvider = baseConfig.models?.providers?.openai;
-    if (!openAIProvider) {
-      throw new Error("expected OpenAI provider test config");
-    }
-    const cfg = {
-      ...baseConfig,
-      models: {
-        providers: {
-          openai: {
-            ...openAIProvider,
-            baseUrl: "https://api.openai.com/v1",
-          },
+    const cfg = createOpenAIPiRuntimeConfig({
+      authOrder: ["openai-codex:work", "openai:backup"],
+    });
+    replaceAuthProfileStoreForTest({
+      version: 1,
+      profiles: {
+        "openai-codex:work": {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "access-token",
+          refresh: "refresh-token",
+          expires: Date.now() + 60_000,
         },
       },
-      agents: {
-        defaults: {
-          models: {
-            "openai/mock-1": {
-              agentRuntime: { id: "pi" },
-            },
-          },
-        },
-      },
-      auth: {
-        order: {
-          openai: ["openai-codex:work", "openai:backup"],
-        },
-      },
-    };
-    runEmbeddedAttemptMock.mockResolvedValueOnce(
-      makeEmbeddedRunnerAttempt({
-        assistantTexts: ["ok"],
-        lastAssistant: buildEmbeddedRunnerAssistant({
-          content: [{ type: "text", text: "ok" }],
-        }),
-      }),
-    );
-
-    await runEmbeddedPiAgent({
-      sessionId: "codex-first-pi",
-      sessionFile,
-      workspaceDir,
-      config: cfg,
-      prompt: "hello",
-      provider: "openai",
-      model: "mock-1",
-      timeoutMs: 5_000,
-      agentDir,
-      runId: nextRunId("codex-first-pi"),
-      enqueue: immediateEnqueue,
     });
 
-    expect(resolveModelAsyncMock).toHaveBeenNthCalledWith(
-      1,
-      "openai",
-      "mock-1",
-      agentDir,
-      cfg,
-      expect.objectContaining({ skipPiDiscovery: true }),
-    );
-    expect(resolveModelAsyncMock).toHaveBeenNthCalledWith(
-      2,
-      "openai-codex",
-      "mock-1",
-      agentDir,
-      cfg,
-      expect.objectContaining({ skipPiDiscovery: true }),
-    );
-    expect(
-      (firstRunEmbeddedAttemptParams() as { model?: { provider?: string } }).model?.provider,
-    ).toBe("openai-codex");
+    await runOpenAIPiRuntimeTurn(cfg, "codex-first-pi");
+
+    expectModelResolutionProvider(1, "openai", cfg);
+    expectModelResolutionProvider(2, "openai-codex", cfg);
+    expectAttemptModelProvider("openai-codex");
+  });
+
+  it("does not route explicit OpenAI PI runs through stale Codex auth-order entries", async () => {
+    const cfg = createOpenAIPiRuntimeConfig({
+      authOrder: ["openai-codex:legacy-repro"],
+    });
+    replaceAuthProfileStoreForTest({
+      version: 1,
+      profiles: {
+        "openai-codex:legacy-repro": {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "",
+          refresh: "",
+          expires: Date.now() + 60_000,
+        },
+      },
+    });
+
+    await runOpenAIPiRuntimeTurn(cfg, "stale-codex-first-pi");
+
+    expect(resolveModelAsyncMock).toHaveBeenCalledTimes(1);
+    expectModelResolutionProvider(1, "openai", cfg);
+    expectAttemptModelProvider("openai");
+  });
+
+  it("routes OpenAI PI runs through later eligible Codex auth-order entries", async () => {
+    const cfg = createOpenAIPiRuntimeConfig({
+      authOrder: ["openai-codex:legacy-repro", "openai-codex:work"],
+    });
+    replaceAuthProfileStoreForTest({
+      version: 1,
+      profiles: {
+        "openai-codex:legacy-repro": {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "",
+          refresh: "",
+          expires: Date.now() + 60_000,
+        },
+        "openai-codex:work": {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "access-token",
+          refresh: "refresh-token",
+          expires: Date.now() + 60_000,
+        },
+      },
+    });
+
+    await runOpenAIPiRuntimeTurn(cfg, "later-codex-first-pi");
+
+    expectModelResolutionProvider(1, "openai", cfg);
+    expectModelResolutionProvider(2, "openai-codex", cfg);
+    expectAttemptModelProvider("openai-codex");
+  });
+
+  it("does not route OpenAI PI runs through stored Codex backup profiles", async () => {
+    const cfg = createOpenAIPiRuntimeConfig({ providerAuth: "api-key" });
+    replaceAuthProfileStoreForTest({
+      version: 1,
+      profiles: {
+        "openai-codex:work": {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "access-token",
+          refresh: "refresh-token",
+          expires: Date.now() + 60_000,
+        },
+      },
+    });
+
+    await runOpenAIPiRuntimeTurn(cfg, "stored-codex-backup-pi");
+
+    expect(resolveModelAsyncMock).toHaveBeenCalledTimes(1);
+    expectModelResolutionProvider(1, "openai", cfg);
+    expectAttemptModelProvider("openai");
   });
 
   it("backfills a trimmed session key from sessionId when the embedded run omits it", async () => {

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -827,6 +827,107 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
     });
   });
 
+  it("skips Codex auth bootstrap when configured Codex profiles are not eligible", async () => {
+    const codexAuthStorage = {
+      setRuntimeApiKey: vi.fn(),
+      getApiKey: vi.fn(async () => "stored-test-key"),
+    };
+    const codexAuthStore = {
+      version: 1 as const,
+      profiles: {
+        "openai-codex:legacy-repro": {
+          type: "oauth" as const,
+          provider: "openai-codex",
+          access: "",
+          refresh: "",
+          expires: Date.now() + 60_000,
+        },
+      },
+    };
+    const runtimePlan = makeForwardedRuntimePlan({
+      resolvedRef: {
+        provider: "openai-codex",
+        modelId: "gpt-5.5",
+        harnessId: "codex",
+      },
+      auth: {
+        providerForAuth: "openai-codex",
+        authProfileProviderForAuth: "openai-codex",
+        harnessAuthProvider: "openai-codex",
+      },
+    });
+    mockedEnsureAuthProfileStore.mockReturnValueOnce(codexAuthStore);
+    mockedResolveAuthProfileOrder.mockReturnValueOnce([]);
+    mockedResolveModelAsync
+      .mockResolvedValueOnce({
+        model: {
+          id: "gpt-5.5",
+          provider: "openai",
+          contextWindow: 200000,
+          api: "openai-responses",
+        },
+        error: null,
+        authStorage: { setRuntimeApiKey: vi.fn() },
+        modelRegistry: {},
+      })
+      .mockResolvedValueOnce({
+        model: {
+          id: "gpt-5.5",
+          provider: "openai-codex",
+          contextWindow: 200000,
+          api: "openai-codex-responses",
+        },
+        error: null,
+        authStorage: codexAuthStorage,
+        modelRegistry: {},
+      });
+    mockedBuildAgentRuntimePlan.mockReturnValueOnce(runtimePlan);
+    mockedGetApiKeyForModel.mockImplementation(async () => {
+      throw new Error("generic auth should be skipped");
+    });
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      config: {
+        agents: {
+          defaults: {
+            agentRuntime: { id: "codex" },
+          },
+        },
+        auth: {
+          order: {
+            openai: ["openai-codex:legacy-repro"],
+          },
+        },
+      },
+      runId: "forced-openai-codex-responses-skips-stale-bootstrap",
+    });
+
+    expect(mockedEnsureAuthProfileStore).toHaveBeenCalledTimes(1);
+    expectRecordFields(mockCallArg(mockedEnsureAuthProfileStore, 0, 1), {
+      externalCliProviderIds: ["openai-codex"],
+      allowKeychainPrompt: false,
+    });
+    expect(mockedEnsureAuthProfileStoreWithoutExternalProfiles).not.toHaveBeenCalled();
+    expectMockCallFields(mockedResolveAuthProfileOrder, {
+      provider: "openai-codex",
+      store: codexAuthStore,
+    });
+    expect(mockedGetApiKeyForModel).not.toHaveBeenCalled();
+    expect(codexAuthStorage.setRuntimeApiKey).not.toHaveBeenCalled();
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    const pluginParams = expectMockCallFields(mockedRunEmbeddedAttempt, {
+      provider: "openai-codex",
+      authProfileId: undefined,
+      resolvedApiKey: undefined,
+    });
+    const authProfileStore = expectRecordFields(pluginParams.authProfileStore, {});
+    expect(authProfileStore.profiles).toEqual({});
+  });
+
   it("refreshes bootstrapped Codex OAuth credentials when rotating profiles", async () => {
     const { clearAgentHarnesses, registerAgentHarness } = await import("../harness/registry.js");
     const subscriptionLimit = new Error(

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -64,6 +64,7 @@ import {
 import { ensureOpenClawModelsJson } from "../models-config.js";
 import {
   OPENAI_CODEX_PROVIDER_ID,
+  hasOpenAICodexAuthProfileOverride,
   listOpenAIAuthProfileProvidersForAgentRuntime,
   resolveContextConfigProviderForRuntime,
   resolveSelectedOpenAIPiRuntimeProvider,
@@ -90,6 +91,7 @@ import {
 } from "../pi-embedded-helpers.js";
 import { resolveProcessToolScopeKey } from "../pi-tools.js";
 import { resolveProviderIdForAuth } from "../provider-auth-aliases.js";
+import { findNormalizedProviderValue } from "../provider-id.js";
 import { runAgentCleanupStep } from "../run-cleanup-timeout.js";
 import { buildAgentRuntimeAuthPlan } from "../runtime-plan/auth.js";
 import { buildAgentRuntimePlan } from "../runtime-plan/build.js";
@@ -205,6 +207,44 @@ function resolveAttemptDispatchApiKey(params: {
     return undefined;
   }
   return params.apiKeyInfo?.apiKey;
+}
+
+function resolveSelectedRuntimeAuthProfileId(params: {
+  provider: string;
+  harnessRuntime: string;
+  authProfileId?: string;
+  config: RunEmbeddedPiAgentParams["config"];
+  authStore: AuthProfileStore;
+}): string | undefined {
+  const requestedProfileId = params.authProfileId?.trim();
+  if (requestedProfileId) {
+    return requestedProfileId;
+  }
+  if (shouldPreferExplicitConfigApiKeyAuth(params.config, params.provider)) {
+    return undefined;
+  }
+  const firstAuthProvider = listOpenAIAuthProfileProvidersForAgentRuntime({
+    provider: params.provider,
+    harnessRuntime: params.harnessRuntime,
+    agentHarnessId: params.harnessRuntime,
+    config: params.config,
+  })[0];
+  if (firstAuthProvider !== OPENAI_CODEX_PROVIDER_ID) {
+    return undefined;
+  }
+  const configuredOrder = findNormalizedProviderValue(params.config?.auth?.order, params.provider);
+  const configuredProfileId = configuredOrder
+    ?.find((profileId) => typeof profileId === "string" && profileId.trim().length > 0)
+    ?.trim();
+  if (!hasOpenAICodexAuthProfileOverride(configuredProfileId)) {
+    return undefined;
+  }
+  const eligibleProfileIds = resolveAuthProfileOrder({
+    cfg: params.config,
+    store: params.authStore,
+    provider: OPENAI_CODEX_PROVIDER_ID,
+  });
+  return eligibleProfileIds[0]?.trim();
 }
 
 function resolveEmbeddedRunLaneTimeoutMs(timeoutMs: number): number | undefined {
@@ -611,12 +651,27 @@ export async function runEmbeddedPiAgent(
       });
       const pluginHarnessOwnsTransport = agentHarness.id !== "pi";
       const modelConfigProvider = provider;
+      const piRuntimeAuthProfileStore =
+        agentHarness.id === "pi"
+          ? ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
+              allowKeychainPrompt: false,
+            })
+          : undefined;
+      const selectedRuntimeAuthProfileId = piRuntimeAuthProfileStore
+        ? resolveSelectedRuntimeAuthProfileId({
+            provider,
+            harnessRuntime: agentHarness.id,
+            authProfileId: params.authProfileId,
+            config: params.config,
+            authStore: piRuntimeAuthProfileStore,
+          })
+        : params.authProfileId;
       const selectedPiRuntimeProvider = resolveSelectedOpenAIPiRuntimeProvider({
         provider,
         harnessRuntime: agentHarness.id,
         agentHarnessId: agentHarness.id,
-        authProfileProvider: params.authProfileId?.split(":", 1)[0],
-        authProfileId: params.authProfileId,
+        authProfileProvider: selectedRuntimeAuthProfileId?.split(":", 1)[0],
+        authProfileId: selectedRuntimeAuthProfileId,
         config: params.config,
         workspaceDir: resolvedWorkspace,
       });
@@ -699,9 +754,10 @@ export async function runEmbeddedPiAgent(
                 externalCliProviderIds: [OPENAI_CODEX_PROVIDER_ID],
                 allowKeychainPrompt: false,
               })
-            : ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
+            : (piRuntimeAuthProfileStore ??
+              ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
                 allowKeychainPrompt: false,
-              });
+              }));
       const attemptAuthProfileStore =
         pluginHarnessOwnsTransport && !pluginHarnessNeedsOpenClawAuthBootstrap
           ? ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -742,14 +742,14 @@ export async function runEmbeddedPiAgent(
       startupStages.mark("model-resolution");
       notifyExecutionPhase("model_resolution", { provider, model: modelId });
 
-      const pluginHarnessNeedsOpenClawAuthBootstrap =
+      const pluginHarnessSupportsOpenClawAuthBootstrap =
         pluginHarnessOwnsTransport &&
         provider === OPENAI_CODEX_PROVIDER_ID &&
         effectiveModel.api === "openai-codex-responses";
       const authStore =
-        pluginHarnessOwnsTransport && !pluginHarnessNeedsOpenClawAuthBootstrap
+        pluginHarnessOwnsTransport && !pluginHarnessSupportsOpenClawAuthBootstrap
           ? createEmptyAuthProfileStore()
-          : pluginHarnessNeedsOpenClawAuthBootstrap
+          : pluginHarnessSupportsOpenClawAuthBootstrap
             ? ensureAuthProfileStore(agentDir, {
                 externalCliProviderIds: [OPENAI_CODEX_PROVIDER_ID],
                 allowKeychainPrompt: false,
@@ -759,7 +759,7 @@ export async function runEmbeddedPiAgent(
                 allowKeychainPrompt: false,
               }));
       const attemptAuthProfileStore =
-        pluginHarnessOwnsTransport && !pluginHarnessNeedsOpenClawAuthBootstrap
+        pluginHarnessOwnsTransport && !pluginHarnessSupportsOpenClawAuthBootstrap
           ? ensureAuthProfileStoreWithoutExternalProfiles(agentDir, {
               allowKeychainPrompt: false,
             })
@@ -823,6 +823,8 @@ export async function runEmbeddedPiAgent(
       const pluginHarnessProfileOrder = pluginHarnessOwnsTransport
         ? resolvePluginHarnessProfileOrder()
         : [];
+      const pluginHarnessNeedsOpenClawAuthBootstrap =
+        pluginHarnessSupportsOpenClawAuthBootstrap && pluginHarnessProfileOrder.length > 0;
       const resolvePluginHarnessPreferredProfileId = (): string | undefined =>
         pluginHarnessProfileOrder[0];
       const preferredProfileId = pluginHarnessOwnsTransport


### PR DESCRIPTION
## Summary

- Stop PI OpenAI provider selection from switching to `openai-codex` based only on raw `auth.order.openai` contents.
- Resolve an eligible selected runtime auth profile before provider switching, preserving valid Codex OAuth routing while ignoring stale-only Codex entries and API-key-preferred OpenAI configs.
- Skip generic OpenClaw Codex auth bootstrap when the Codex harness has no eligible forwarded auth profile, so stale/empty `openai-codex:*` profiles do not fail before the harness runtime can run.
- Add focused runner coverage for valid Codex order, stale-only Codex order, stale-then-valid Codex order, stored Codex backup profiles, and the no-eligible-profile Codex bootstrap path.

## Verification

- `node scripts/run-vitest.mjs src/agents/openai-codex-routing.test.ts src/agents/pi-embedded-runner.e2e.test.ts src/agents/pi-embedded-runner/run.overflow-compaction.test.ts` exited 0.
- `git diff --check` exited 0.
- `.agents/skills/autoreview/scripts/autoreview --mode local` reported no accepted/actionable findings.
- `OPENCLAW_FORCE_BUILD=1 OPENCLAW_STATE_DIR="$STATE" CODEX_HOME="$STATE/codex-home" XDG_CONFIG_HOME="$STATE/xdg" OPENAI_API_KEY= OPENAI_BASE_URL= OPENAI_ORG_ID= OPENAI_ORGANIZATION= node scripts/run-node.mjs agent --local --session-id repro-83345-after --message "Return exactly OK" --timeout 15 --json` was run against an isolated state containing the repro config and a fake empty legacy Codex OAuth profile.

## Real behavior proof

Behavior addressed: OpenAI PI runs no longer fail in generic auth bootstrap with `No API key found for provider "openai-codex"` just because `auth.order.openai` starts with a stale `openai-codex:*` profile.

Real environment tested: Local source-built checkout on `codex/fix-openai-codex-auth-routing` at `f769d04c07`, with an isolated `OPENCLAW_STATE_DIR`, `CODEX_HOME`, and `XDG_CONFIG_HOME`; `OPENAI_API_KEY`, `OPENAI_BASE_URL`, `OPENAI_ORG_ID`, and `OPENAI_ORGANIZATION` were unset. The state had `agents.defaults.model.primary = "openai/gpt-5.5"`, `auth.order.openai = ["openai-codex:legacy-repro"]`, and a fake `openai-codex:legacy-repro` OAuth profile with empty access/refresh material.

Exact steps or command run after this patch:

```sh
STATE="$(mktemp -d)"
mkdir -p "$STATE/agents/repro-83345-after/agent"
printf '{"agents":{"defaults":{"model":{"primary":"openai/gpt-5.5"}}},"auth":{"order":{"openai":["openai-codex:legacy-repro"]}}}\n' > "$STATE/config.json"
printf '{"version":1,"profiles":{"openai-codex:legacy-repro":{"type":"oauth","provider":"openai-codex","access":"","refresh":"","expires":4070908800000}}}\n' > "$STATE/agents/repro-83345-after/agent/auth-profiles.json"
OPENCLAW_FORCE_BUILD=1 \
OPENCLAW_STATE_DIR="$STATE" \
CODEX_HOME="$STATE/codex-home" \
XDG_CONFIG_HOME="$STATE/xdg" \
OPENAI_API_KEY= \
OPENAI_BASE_URL= \
OPENAI_ORG_ID= \
OPENAI_ORGANIZATION= \
node scripts/run-node.mjs agent --local --session-id repro-83345-after --message "Return exactly OK" --timeout 15 --json
```

Evidence after fix:

```text
[agent/embedded] strict-agentic execution contract active: runId=repro-83345-after sessionId=repro-83345-after provider=openai-codex/gpt-5.5 harness=codex configured=unspecified
[agent/embedded] embedded run failover decision: runId=repro-83345-after stage=prompt decision=surface_error reason=auth from=openai-codex/gpt-5.5 profile=- rawError=unexpected status 401 Unauthorized: Missing bearer or basic authentication in header, url: https://api.openai.com/v1/responses, cf-ray: [redacted], request id: [redacted]
[model-fallback/decision] model fallback decision: decision=candidate_failed requested=openai/gpt-5.5 candidate=openai/gpt-5.5 reason=auth next=none detail=unexpected status 401 Unauthorized: Missing bearer or basic authentication in header, url: https://api.openai.com/v1/responses, cf-ray: [redacted], request id: sha256:[redacted]
FailoverError: unexpected status 401 Unauthorized: Missing bearer or basic authentication in header, url: https://api.openai.com/v1/responses, cf-ray: [redacted], request id: [redacted]
command_exit_status=1
```

Observed result after fix: The stale-provider failure is gone. With no real credentials in the isolated state, the run now reaches the actual Codex/OpenAI request path and fails with the expected `401 Unauthorized: Missing bearer or basic authentication in header`, instead of failing before execution with `No API key found for provider "openai-codex"`. Valid eligible Codex OAuth profiles remain covered by tests and still route PI OpenAI runs through the Codex harness path.

What was not tested: A successful live model response with real OpenAI/Codex credentials; this proof intentionally used an isolated fake profile and unset OpenAI environment variables.