### PR TITLE
fix(channels): bypass debounce for bare abort triggers [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 - CLI/agents: allow `openclaw agent --session-key` to target explicit session keys, including agent-scoped legacy keys. (#85121) Thanks @Kaspre.
 - Auto-reply/ACP: wait for same-channel block reply delivery before starting tool work, while still honoring ACP dispatch aborts so stopped turns do not wait on slow channel sends. (#83722) Thanks @IWhatsskill.
 - Codex/ACP: mark required child-run completions that only report progress, omit a final deliverable, or fail requester delivery as blocked while preserving real final reports. (#85110) Thanks @IWhatsskill.
+- Channels: treat bare abort messages such as `stop`, `abort`, and `wait` as immediate control commands in inbound debounce paths so stop requests are not delayed behind pending message coalescing. (#83348) Thanks @IWhatsskill.
 - Agents/subagents: surface blocked child-run completions as errors instead of successful subagent finishes. (#80886) Thanks @TurboTheTurtle.
 - Agents/Pi: treat accepted embedded `sessions_spawn` child-session handoffs as terminal progress so parent turns no longer report false non-deliverable failures. (#85054) Thanks @samzong.
 - WhatsApp: update Baileys to `7.0.0-rc13` and drop the obsolete logger type patch.

--- a/extensions/feishu/src/monitor.message-handler.ts
+++ b/extensions/feishu/src/monitor.message-handler.ts
@@ -262,7 +262,7 @@ export function createFeishuMessageReceiveHandler({
         return false;
       }
       const text = resolveDebounceText(event);
-      return Boolean(text) && !core.channel.text.hasControlCommand(text, cfg);
+      return Boolean(text) && !core.channel.commands.isControlCommandMessage(text, cfg);
     },
     onFlush: async (entries) => {
       const last = entries.at(-1);

--- a/extensions/feishu/src/monitor.reaction.test.ts
+++ b/extensions/feishu/src/monitor.reaction.test.ts
@@ -2,7 +2,7 @@ import {
   createInboundDebouncer,
   resolveInboundDebounceMs,
 } from "openclaw/plugin-sdk/channel-inbound-debounce";
-import { hasControlCommand } from "openclaw/plugin-sdk/command-detection";
+import { hasControlCommand, isControlCommandMessage } from "openclaw/plugin-sdk/command-detection";
 import { createNonExitingRuntimeEnv } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClawdbotConfig, PluginRuntime } from "../runtime-api.js";
@@ -255,10 +255,14 @@ function mentionOpenIds(event: FeishuMessageEvent): string[] {
 function createFeishuMonitorRuntime(params?: {
   createInboundDebouncer?: PluginRuntime["channel"]["debounce"]["createInboundDebouncer"];
   resolveInboundDebounceMs?: PluginRuntime["channel"]["debounce"]["resolveInboundDebounceMs"];
+  isControlCommandMessage?: PluginRuntime["channel"]["commands"]["isControlCommandMessage"];
   hasControlCommand?: PluginRuntime["channel"]["text"]["hasControlCommand"];
 }): PluginRuntime {
   return {
     channel: {
+      commands: {
+        isControlCommandMessage: params?.isControlCommandMessage ?? isControlCommandMessage,
+      },
       debounce: {
         createInboundDebouncer: params?.createInboundDebouncer ?? createInboundDebouncer,
         resolveInboundDebounceMs: params?.resolveInboundDebounceMs ?? resolveInboundDebounceMs,
@@ -531,6 +535,32 @@ describe("Feishu inbound debounce regressions", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
+  });
+
+  it("releases pending text before a bare abort trigger instead of debouncing it", async () => {
+    setDedupPassThroughMocks();
+    const onMessage = await setupDebounceMonitor();
+
+    await enqueueDebouncedMessage(onMessage, createTextEvent({ messageId: "om_1", text: "first" }));
+    expect(handleFeishuMessageMock).not.toHaveBeenCalled();
+
+    await enqueueDebouncedMessage(
+      onMessage,
+      createTextEvent({ messageId: "om_stop", text: "stop" }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(handleFeishuMessageMock).toHaveBeenCalledTimes(2);
+    const first = getFirstDispatchedEvent();
+    const secondCall = mockCallAt(handleFeishuMessageMock, 1, "Feishu stop dispatch")[0] as
+      | { event?: FeishuMessageEvent }
+      | undefined;
+    const second = secondCall?.event;
+    expect(JSON.parse(first.message.content)).toEqual({ text: "first" });
+    expect(second?.message.message_id).toBe("om_stop");
+    expect(JSON.parse(second?.message.content ?? "{}")).toEqual({ text: "stop" });
   });
 
   it("keeps bot mention when per-message mention keys collide across non-forward messages", async () => {

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -444,6 +444,73 @@ describe("mattermost inbound user posts", () => {
     expect(ctx?.Provider).toBe("mattermost");
   });
 
+  it("does not drop inline command-looking group text from non-command-authorized senders", async () => {
+    const socket = new FakeWebSocket();
+    const abortController = new AbortController();
+    mockState.abortController = abortController;
+    const inlineCommandConfig: OpenClawConfig = {
+      commands: { useAccessGroups: true },
+      channels: {
+        mattermost: {
+          enabled: true,
+          baseUrl: "https://mattermost.example.com",
+          botToken: "bot-token",
+          chatmode: "onmessage",
+          dmPolicy: "open",
+          groupPolicy: "open",
+        },
+      },
+    };
+    const isControlCommandMessage = vi.fn(() => false);
+    const shouldComputeCommandAuthorized = vi.fn(() => true);
+    mockState.runtimeCore = createRuntimeCore(inlineCommandConfig, undefined, {
+      isControlCommandMessage,
+      shouldComputeCommandAuthorized,
+      shouldHandleTextCommands: () => true,
+    });
+
+    const monitor = monitorMattermostProvider({
+      config: inlineCommandConfig,
+      runtime: testRuntime(),
+      abortSignal: abortController.signal,
+      webSocketFactory: () => socket,
+    });
+
+    await vi.waitFor(() => {
+      expect(socket.openListenerCount).toBeGreaterThan(0);
+    });
+    socket.emitOpen();
+
+    await socket.emitMessage({
+      event: "posted",
+      data: {
+        channel_id: "chan-1",
+        channel_name: "town-square",
+        channel_display_name: "Town Square",
+        sender_name: "alice",
+        post: JSON.stringify({
+          id: "post-inline-command",
+          channel_id: "chan-1",
+          user_id: "user-1",
+          message: "hello /status",
+          create_at: 1_714_000_000_000,
+        }),
+      },
+      broadcast: {
+        channel_id: "chan-1",
+        user_id: "user-1",
+      },
+    });
+    socket.emitClose(1000);
+    await monitor;
+
+    expect(isControlCommandMessage).toHaveBeenCalledWith("hello /status", inlineCommandConfig);
+    expect(mockState.dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+    const ctx = mockState.dispatchReplyFromConfig.mock.calls.at(0)?.[0].ctx;
+    expect(ctx?.BodyForAgent).toBe("hello /status");
+    expect(ctx?.CommandAuthorized).toBe(false);
+  });
+
   it("uses websocket channel type when REST channel lookup fails", async () => {
     const socket = new FakeWebSocket();
     const abortController = new AbortController();

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -1,3 +1,4 @@
+import { createInboundDebouncer } from "openclaw/plugin-sdk/channel-inbound-debounce";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { monitorMattermostProvider } from "./monitor.js";
 import type { OpenClawConfig, RuntimeEnv } from "./runtime-api.js";
@@ -148,6 +149,14 @@ function createRuntimeCore(
     mainSessionKey?: string;
     sessionKey?: string;
   },
+  overrides: {
+    inboundDebounceMs?: number;
+    isControlCommandMessage?: (text?: string) => boolean;
+    shouldComputeCommandAuthorized?: (text?: string) => boolean;
+    shouldHandleTextCommands?: () => boolean;
+    textHasControlCommand?: (text?: string) => boolean;
+    createInboundDebouncer?: typeof createInboundDebouncer;
+  } = {},
 ) {
   const runPrepared = vi.fn(
     async (turn: {
@@ -230,21 +239,23 @@ function createRuntimeCore(
         record: vi.fn(),
       },
       commands: {
-        isControlCommandMessage: () => false,
-        shouldHandleTextCommands: () => false,
+        isControlCommandMessage: overrides.isControlCommandMessage ?? (() => false),
+        shouldComputeCommandAuthorized: overrides.shouldComputeCommandAuthorized ?? (() => false),
+        shouldHandleTextCommands: overrides.shouldHandleTextCommands ?? (() => false),
       },
       debounce: {
-        resolveInboundDebounceMs: () => 0,
-        createInboundDebouncer: <T>(params: {
-          onFlush: (entries: T[]) => Promise<void> | void;
-        }) => ({
-          enqueue: async (entry: T) => {
-            await params.onFlush([entry]);
-          },
-        }),
+        resolveInboundDebounceMs: () => overrides.inboundDebounceMs ?? 0,
+        createInboundDebouncer:
+          overrides.createInboundDebouncer ??
+          (<T>(params: { onFlush: (entries: T[]) => Promise<void> | void }) => ({
+            enqueue: async (entry: T) => {
+              await params.onFlush([entry]);
+            },
+          })),
       },
       groups: {
-        resolveRequireMention: () => false,
+        resolveRequireMention: (params: { requireMentionOverride?: boolean }) =>
+          params.requireMentionOverride ?? false,
       },
       media: {
         readRemoteMediaBuffer: vi.fn(),
@@ -317,7 +328,7 @@ function createRuntimeCore(
       text: {
         chunkMarkdownTextWithMode: (text: string) => [text],
         convertMarkdownTables: (text: string) => text,
-        hasControlCommand: () => false,
+        hasControlCommand: overrides.textHasControlCommand ?? (() => false),
         resolveChunkMode: () => "off",
         resolveMarkdownTableMode: () => "off",
         resolveTextChunkLimit: () => 4000,
@@ -542,6 +553,98 @@ describe("mattermost inbound user posts", () => {
 
     expect(mockState.dispatchReplyFromConfig).not.toHaveBeenCalled();
     expect(runtimeCore.channel.session.recordInboundSession).not.toHaveBeenCalled();
+  });
+
+  it("flushes pending group text before authorizing a bare abort without a mention", async () => {
+    const socket = new FakeWebSocket();
+    const abortController = new AbortController();
+    mockState.abortController = abortController;
+    const mentionConfig: OpenClawConfig = {
+      commands: { useAccessGroups: false },
+      messages: { inbound: { debounceMs: 60_000 } },
+      channels: {
+        mattermost: {
+          enabled: true,
+          baseUrl: "https://mattermost.example.com",
+          botToken: "bot-token",
+          chatmode: "oncall",
+          dmPolicy: "open",
+          groupPolicy: "open",
+        },
+      },
+    };
+    const isBareAbort = (text?: string) => ["abort", "stop"].includes(text?.trim() ?? "");
+    const runtimeCore = createRuntimeCore(mentionConfig, undefined, {
+      inboundDebounceMs: 60_000,
+      createInboundDebouncer,
+      isControlCommandMessage: isBareAbort,
+      shouldComputeCommandAuthorized: isBareAbort,
+      shouldHandleTextCommands: () => true,
+      textHasControlCommand: () => false,
+    });
+    mockState.runtimeCore = runtimeCore;
+
+    const monitor = monitorMattermostProvider({
+      config: mentionConfig,
+      runtime: testRuntime(),
+      abortSignal: abortController.signal,
+      webSocketFactory: () => socket,
+    });
+
+    await vi.waitFor(() => {
+      expect(socket.openListenerCount).toBeGreaterThan(0);
+    });
+    socket.emitOpen();
+
+    await socket.emitMessage({
+      event: "posted",
+      data: {
+        channel_id: "chan-1",
+        channel_name: "town-square",
+        channel_display_name: "Town Square",
+        sender_name: "alice",
+        post: JSON.stringify({
+          id: "post-pending",
+          channel_id: "chan-1",
+          user_id: "user-1",
+          message: "pending text",
+          create_at: 1_714_000_000_000,
+        }),
+      },
+      broadcast: {
+        channel_id: "chan-1",
+        user_id: "user-1",
+      },
+    });
+    expect(mockState.dispatchReplyFromConfig).not.toHaveBeenCalled();
+
+    await socket.emitMessage({
+      event: "posted",
+      data: {
+        channel_id: "chan-1",
+        channel_name: "town-square",
+        channel_display_name: "Town Square",
+        sender_name: "alice",
+        post: JSON.stringify({
+          id: "post-abort",
+          channel_id: "chan-1",
+          user_id: "user-1",
+          message: "abort",
+          create_at: 1_714_000_000_100,
+        }),
+      },
+      broadcast: {
+        channel_id: "chan-1",
+        user_id: "user-1",
+      },
+    });
+    socket.emitClose(1000);
+    await monitor;
+
+    expect(mockState.dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+    const ctx = mockState.dispatchReplyFromConfig.mock.calls.at(0)?.[0].ctx;
+    expect(ctx?.BodyForAgent).toBe("abort");
+    expect(ctx?.CommandAuthorized).toBe(true);
   });
 
   it("pins direct-message main route updates to the configured owner", async () => {

--- a/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts
@@ -230,6 +230,7 @@ function createRuntimeCore(
         record: vi.fn(),
       },
       commands: {
+        isControlCommandMessage: () => false,
         shouldHandleTextCommands: () => false,
       },
       debounce: {

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -2090,7 +2090,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       if (!text) {
         return false;
       }
-      return !core.channel.text.hasControlCommand(text, cfg);
+      return !core.channel.commands.isControlCommandMessage(text, cfg);
     },
     onFlush: async (entries) => {
       const last = entries.at(-1);

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1320,8 +1320,6 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         });
         const isControlCommand =
           allowTextCommands && core.channel.commands.isControlCommandMessage(rawText, cfg);
-        const shouldComputeCommandAuthorized =
-          allowTextCommands && core.channel.commands.shouldComputeCommandAuthorized(rawText, cfg);
         const accessDecision = await resolveMattermostMonitorInboundAccess({
           account,
           cfg,
@@ -1332,7 +1330,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           groupPolicy,
           readStoreAllowFrom: pairing.readAllowFromStore,
           allowTextCommands,
-          hasControlCommand: shouldComputeCommandAuthorized,
+          hasControlCommand: isControlCommand,
           eventKind: "message",
           mayPair: true,
         });

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1318,8 +1318,10 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           cfg,
           surface: "mattermost",
         });
-        const hasControlCommand = core.channel.text.hasControlCommand(rawText, cfg);
-        const isControlCommand = allowTextCommands && hasControlCommand;
+        const isControlCommand =
+          allowTextCommands && core.channel.commands.isControlCommandMessage(rawText, cfg);
+        const shouldComputeCommandAuthorized =
+          allowTextCommands && core.channel.commands.shouldComputeCommandAuthorized(rawText, cfg);
         const accessDecision = await resolveMattermostMonitorInboundAccess({
           account,
           cfg,
@@ -1330,7 +1332,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           groupPolicy,
           readStoreAllowFrom: pairing.readAllowFromStore,
           allowTextCommands,
-          hasControlCommand,
+          hasControlCommand: shouldComputeCommandAuthorized,
           eventKind: "message",
           mayPair: true,
         });

--- a/extensions/msteams/src/monitor-handler.test-helpers.ts
+++ b/extensions/msteams/src/monitor-handler.test-helpers.ts
@@ -79,6 +79,9 @@ export function installMSTeamsTestRuntime(options: MSTeamsTestRuntimeOptions = {
         readAllowFromStore: options.readAllowFromStore ?? vi.fn(async () => []),
         upsertPairingRequest: options.upsertPairingRequest ?? vi.fn(async () => null),
       },
+      commands: {
+        isControlCommandMessage: options.hasControlCommand ?? (() => false),
+      },
       text: {
         hasControlCommand: options.hasControlCommand ?? (() => false),
         resolveChunkMode: () => "length",

--- a/extensions/msteams/src/monitor-handler.test-helpers.ts
+++ b/extensions/msteams/src/monitor-handler.test-helpers.ts
@@ -15,6 +15,11 @@ type MSTeamsTestRuntimeOptions = {
   recordInboundSession?: ReturnType<typeof vi.fn>;
   resolveAgentRoute?: (params: RuntimeRoutePeer) => unknown;
   hasControlCommand?: PluginRuntime["channel"]["text"]["hasControlCommand"];
+  isControlCommandMessage?: PluginRuntime["channel"]["commands"]["isControlCommandMessage"];
+  shouldComputeCommandAuthorized?: PluginRuntime["channel"]["commands"]["shouldComputeCommandAuthorized"];
+  shouldHandleTextCommands?: PluginRuntime["channel"]["commands"]["shouldHandleTextCommands"];
+  createInboundDebouncer?: PluginRuntime["channel"]["debounce"]["createInboundDebouncer"];
+  resolveInboundDebounceMs?: PluginRuntime["channel"]["debounce"]["resolveInboundDebounceMs"];
   resolveTextChunkLimit?: () => number;
   resolveStorePath?: () => string;
 };
@@ -66,21 +71,29 @@ export function installMSTeamsTestRuntime(options: MSTeamsTestRuntimeOptions = {
     system: { enqueueSystemEvent: options.enqueueSystemEvent ?? vi.fn() },
     channel: {
       debounce: {
-        resolveInboundDebounceMs: () => 0,
-        createInboundDebouncer: <T>(params: {
-          onFlush: (entries: T[]) => Promise<void>;
-        }): { enqueue: (entry: T) => Promise<void> } => ({
-          enqueue: async (entry: T) => {
-            await params.onFlush([entry]);
-          },
-        }),
+        resolveInboundDebounceMs:
+          options.resolveInboundDebounceMs ??
+          ((() => 0) as PluginRuntime["channel"]["debounce"]["resolveInboundDebounceMs"]),
+        createInboundDebouncer:
+          options.createInboundDebouncer ??
+          (<T>(params: {
+            onFlush: (entries: T[]) => Promise<void>;
+          }): { enqueue: (entry: T) => Promise<void> } => ({
+            enqueue: async (entry: T) => {
+              await params.onFlush([entry]);
+            },
+          })),
       },
       pairing: {
         readAllowFromStore: options.readAllowFromStore ?? vi.fn(async () => []),
         upsertPairingRequest: options.upsertPairingRequest ?? vi.fn(async () => null),
       },
       commands: {
-        isControlCommandMessage: options.hasControlCommand ?? (() => false),
+        isControlCommandMessage:
+          options.isControlCommandMessage ?? options.hasControlCommand ?? (() => false),
+        shouldComputeCommandAuthorized:
+          options.shouldComputeCommandAuthorized ?? options.hasControlCommand ?? (() => false),
+        shouldHandleTextCommands: options.shouldHandleTextCommands ?? (() => true),
       },
       text: {
         hasControlCommand: options.hasControlCommand ?? (() => false),

--- a/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
@@ -1,3 +1,4 @@
+import { createInboundDebouncer } from "openclaw/plugin-sdk/channel-inbound-debounce";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig, PluginRuntime } from "../../runtime-api.js";
 import type { GraphThreadMessage } from "../graph-thread.js";
@@ -84,6 +85,11 @@ describe("msteams monitor handler authz", () => {
     cfg: OpenClawConfig,
     options: {
       hasControlCommand?: PluginRuntime["channel"]["text"]["hasControlCommand"];
+      isControlCommandMessage?: PluginRuntime["channel"]["commands"]["isControlCommandMessage"];
+      shouldComputeCommandAuthorized?: PluginRuntime["channel"]["commands"]["shouldComputeCommandAuthorized"];
+      shouldHandleTextCommands?: PluginRuntime["channel"]["commands"]["shouldHandleTextCommands"];
+      createInboundDebouncer?: PluginRuntime["channel"]["debounce"]["createInboundDebouncer"];
+      resolveInboundDebounceMs?: PluginRuntime["channel"]["debounce"]["resolveInboundDebounceMs"];
     } = {},
   ) {
     const readAllowFromStore = vi.fn(async () => ["attacker-aad"]);
@@ -100,6 +106,11 @@ describe("msteams monitor handler authz", () => {
         accountId: "default",
       })),
       hasControlCommand: options.hasControlCommand,
+      isControlCommandMessage: options.isControlCommandMessage,
+      shouldComputeCommandAuthorized: options.shouldComputeCommandAuthorized,
+      shouldHandleTextCommands: options.shouldHandleTextCommands,
+      createInboundDebouncer: options.createInboundDebouncer,
+      resolveInboundDebounceMs: options.resolveInboundDebounceMs,
     });
   }
 
@@ -604,6 +615,47 @@ describe("msteams monitor handler authz", () => {
     expect(hasControlCommand).toHaveBeenCalledWith("/config set foo bar", deps.cfg);
     expect(conversationStore.upsert).not.toHaveBeenCalled();
     expect(runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher).not.toHaveBeenCalled();
+  });
+
+  it("flushes pending group text before authorizing a bare abort without a mention", async () => {
+    resetThreadMocks();
+    const isBareAbort = vi.fn((text?: string) =>
+      ["abort", "stop"].includes(text?.trim().toLowerCase() ?? ""),
+    );
+    const { deps } = createDeps(
+      {
+        commands: { useAccessGroups: false },
+        messages: { inbound: { debounceMs: 60_000 } },
+        channels: {
+          msteams: {
+            groupPolicy: "open",
+            requireMention: true,
+          },
+        },
+      } as OpenClawConfig,
+      {
+        hasControlCommand: vi.fn(() => false),
+        isControlCommandMessage: isBareAbort,
+        shouldComputeCommandAuthorized: isBareAbort,
+        shouldHandleTextCommands: vi.fn(() => true),
+        createInboundDebouncer,
+        resolveInboundDebounceMs: vi.fn(() => 60_000),
+      },
+    );
+
+    const handler = createMSTeamsMessageHandler(deps);
+    await handler(createAttackerGroupActivity({ text: "pending text" }));
+    expect(runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher).not.toHaveBeenCalled();
+
+    await handler(createAttackerGroupActivity({ text: "abort" }));
+
+    expect(runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher).toHaveBeenCalledTimes(
+      1,
+    );
+    const dispatched = firstSettledDispatch();
+    const ctxPayload = recordFromMockCall(dispatched.ctxPayload);
+    expect(ctxPayload.BodyForAgent).toBe("abort");
+    expect(ctxPayload.CommandAuthorized).toBe(true);
   });
 
   it("marks skipped channel message system events as non-owner", async () => {

--- a/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.authz.test.ts
@@ -617,6 +617,39 @@ describe("msteams monitor handler authz", () => {
     expect(runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher).not.toHaveBeenCalled();
   });
 
+  it("does not drop inline command-looking group text from non-command-authorized senders", async () => {
+    resetThreadMocks();
+    const isControlCommandMessage = vi.fn(() => false);
+    const shouldComputeCommandAuthorized = vi.fn(() => true);
+    const { deps } = createDeps(
+      {
+        commands: { useAccessGroups: true },
+        channels: {
+          msteams: {
+            groupPolicy: "open",
+            requireMention: false,
+          },
+        },
+      } as OpenClawConfig,
+      {
+        isControlCommandMessage,
+        shouldComputeCommandAuthorized,
+      },
+    );
+
+    const handler = createMSTeamsMessageHandler(deps);
+    await handler(createAttackerGroupActivity({ text: "hello /status" }));
+
+    expect(isControlCommandMessage).toHaveBeenCalledWith("hello /status", deps.cfg);
+    expect(runtimeApiMockState.dispatchReplyFromConfigWithSettledDispatcher).toHaveBeenCalledTimes(
+      1,
+    );
+    const dispatched = firstSettledDispatch();
+    const ctxPayload = recordFromMockCall(dispatched.ctxPayload);
+    expect(ctxPayload.BodyForAgent).toBe("hello /status");
+    expect(ctxPayload.CommandAuthorized).toBe(false);
+  });
+
   it("flushes pending group text before authorizing a bare abort without a mention", async () => {
     resetThreadMocks();
     const isBareAbort = vi.fn((text?: string) =>

--- a/extensions/msteams/src/monitor-handler/message-handler.test-support.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.test-support.ts
@@ -12,6 +12,11 @@ type MessageHandlerDepsOptions = {
   recordInboundSession?: ReturnType<typeof vi.fn>;
   resolveAgentRoute?: (params: { peer: { kind: string; id: string } }) => unknown;
   hasControlCommand?: PluginRuntime["channel"]["text"]["hasControlCommand"];
+  isControlCommandMessage?: PluginRuntime["channel"]["commands"]["isControlCommandMessage"];
+  shouldComputeCommandAuthorized?: PluginRuntime["channel"]["commands"]["shouldComputeCommandAuthorized"];
+  shouldHandleTextCommands?: PluginRuntime["channel"]["commands"]["shouldHandleTextCommands"];
+  createInboundDebouncer?: PluginRuntime["channel"]["debounce"]["createInboundDebouncer"];
+  resolveInboundDebounceMs?: PluginRuntime["channel"]["debounce"]["resolveInboundDebounceMs"];
 };
 
 export function createMessageHandlerDeps(
@@ -41,6 +46,11 @@ export function createMessageHandlerDeps(
     recordInboundSession,
     resolveAgentRoute,
     hasControlCommand: options.hasControlCommand,
+    isControlCommandMessage: options.isControlCommandMessage,
+    shouldComputeCommandAuthorized: options.shouldComputeCommandAuthorized,
+    shouldHandleTextCommands: options.shouldHandleTextCommands,
+    createInboundDebouncer: options.createInboundDebouncer,
+    resolveInboundDebounceMs: options.resolveInboundDebounceMs,
     resolveTextChunkLimit: () => 4000,
     resolveStorePath: () => "/tmp/test-store",
   });

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -938,7 +938,7 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       if (entry.attachments.length > 0) {
         return false;
       }
-      return !core.channel.text.hasControlCommand(entry.text, cfg);
+      return !core.channel.commands.isControlCommandMessage(entry.text, cfg);
     },
     onFlush: async (entries) => {
       const last = entries.at(-1);

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -281,6 +281,14 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       threadId,
     });
 
+    const allowTextCommands = core.channel.commands.shouldHandleTextCommands({
+      cfg,
+      surface: "msteams",
+    });
+    const isControlCommand =
+      allowTextCommands && core.channel.commands.isControlCommandMessage(text, cfg);
+    const shouldComputeCommandAuthorized =
+      allowTextCommands && core.channel.commands.shouldComputeCommandAuthorized(text, cfg);
     const {
       dmPolicy,
       senderId,
@@ -295,7 +303,7 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
     } = await resolveMSTeamsSenderAccess({
       cfg,
       activity,
-      hasControlCommand: core.channel.text.hasControlCommand(text, cfg),
+      hasControlCommand: shouldComputeCommandAuthorized,
     });
     const commandAuthorized = commandAccess.requested ? commandAccess.authorized : undefined;
     const effectiveDmAllowFrom = senderAccess.effectiveAllowFrom;
@@ -522,9 +530,9 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       policy: {
         isGroup: !isDirectMessage,
         requireMention,
-        allowTextCommands: false,
-        hasControlCommand: false,
-        commandAuthorized: false,
+        allowTextCommands,
+        hasControlCommand: isControlCommand,
+        commandAuthorized: commandAuthorized === true,
       },
     });
 

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -287,8 +287,6 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
     });
     const isControlCommand =
       allowTextCommands && core.channel.commands.isControlCommandMessage(text, cfg);
-    const shouldComputeCommandAuthorized =
-      allowTextCommands && core.channel.commands.shouldComputeCommandAuthorized(text, cfg);
     const {
       dmPolicy,
       senderId,
@@ -303,7 +301,7 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
     } = await resolveMSTeamsSenderAccess({
       cfg,
       activity,
-      hasControlCommand: shouldComputeCommandAuthorized,
+      hasControlCommand: isControlCommand,
     });
     const commandAuthorized = commandAccess.requested ? commandAccess.authorized : undefined;
     const effectiveDmAllowFrom = senderAccess.effectiveAllowFrom;

--- a/extensions/whatsapp/src/auto-reply/monitor.ts
+++ b/extensions/whatsapp/src/auto-reply/monitor.ts
@@ -1,7 +1,7 @@
 import { resolveAccountEntry } from "openclaw/plugin-sdk/account-core";
 import { resolveInboundDebounceMs } from "openclaw/plugin-sdk/channel-inbound-debounce";
 import { formatCliCommand } from "openclaw/plugin-sdk/cli-runtime";
-import { hasControlCommand } from "openclaw/plugin-sdk/command-detection";
+import { isControlCommandMessage } from "openclaw/plugin-sdk/command-detection";
 import { drainPendingDeliveries } from "openclaw/plugin-sdk/delivery-queue-runtime";
 import { DEFAULT_GROUP_HISTORY_LIMIT } from "openclaw/plugin-sdk/reply-history";
 import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
@@ -299,7 +299,7 @@ export async function monitorWebChannel(
         if (msg.replyToId || msg.replyToBody) {
           return false;
         }
-        return !hasControlCommand(msg.body, cfg);
+        return !isControlCommandMessage(msg.body, cfg);
       };
 
       let connection;

--- a/src/channels/inbound-debounce-policy.test.ts
+++ b/src/channels/inbound-debounce-policy.test.ts
@@ -11,6 +11,9 @@ describe("shouldDebounceTextInbound", () => {
     expect(shouldDebounceTextInbound({ text: "   ", cfg })).toBe(false);
     expect(shouldDebounceTextInbound({ text: "hello", cfg, hasMedia: true })).toBe(false);
     expect(shouldDebounceTextInbound({ text: "/status", cfg })).toBe(false);
+    expect(shouldDebounceTextInbound({ text: "stop", cfg })).toBe(false);
+    expect(shouldDebounceTextInbound({ text: "abort", cfg })).toBe(false);
+    expect(shouldDebounceTextInbound({ text: "wait", cfg })).toBe(false);
   });
 
   it("accepts normal text when debounce is allowed", () => {

--- a/src/channels/inbound-debounce-policy.ts
+++ b/src/channels/inbound-debounce-policy.ts
@@ -1,4 +1,4 @@
-import { hasControlCommand } from "../auto-reply/command-detection.js";
+import { isControlCommandMessage } from "../auto-reply/command-detection.js";
 import type { CommandNormalizeOptions } from "../auto-reply/commands-registry.js";
 import {
   createInboundDebouncer,
@@ -25,7 +25,7 @@ export function shouldDebounceTextInbound(params: {
   if (!text) {
     return false;
   }
-  return !hasControlCommand(text, params.cfg, params.commandOptions);
+  return !isControlCommandMessage(text, params.cfg, params.commandOptions);
 }
 
 export function createChannelInboundDebouncer<T>(


### PR DESCRIPTION
## Summary

- Problem: inbound debounce bypassed slash/text commands, but standalone abort phrases like `stop`, `abort`, and `wait` were still treated as normal debounceable text.
- Why it matters: a user trying to stop an active or queued turn can wait behind the debounce window instead of interrupting immediately.
- What changed: shared and plugin-local debounce predicates now use the abort-aware control-command detector; focused coverage was added for the shared policy and a Feishu plugin debounce path.
- What did NOT change (scope boundary): command auth, mention gating, and the documented iMessage/BlueBubbles coalescing path were not changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #48684
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: standalone abort phrases bypass inbound debounce while normal text still waits for the debounce window.
- Real environment tested: local OpenClaw source checkout on Windows, Node 24, no external channel credentials or network calls.
- Exact steps or command run after this patch: ran a local Node/tsx source proof against the real `createInboundDebouncer()` and `shouldDebounceTextInbound()` implementations.
- Evidence after fix (copied live output):

```text
hello -> shouldDebounce=true
stop -> shouldDebounce=false
abort -> shouldDebounce=false
wait -> shouldDebounce=false
/status -> shouldDebounce=false
after hello enqueue -> []
after stop enqueue -> ["hello","stop"]
```

- Observed result after fix: normal text remains pending, then `stop` forces the pending text out and runs as a separate immediate flush.
- What was not tested: live delivery through real Feishu, Mattermost, Teams, or WhatsApp accounts.
- Before evidence (optional but encouraged): current-main source inspection showed `shouldDebounceTextInbound()` and the local plugin debounce predicates used `hasControlCommand()`, which does not include bare abort triggers.

## Root Cause (if applicable)

- Root cause: the debounce layer used slash-command detection instead of the broader control-command detector that already recognizes abort phrases.
- Missing detection / guardrail: debounce regression coverage checked `/status`, but not `stop`, `abort`, or `wait`.
- Contributing context (if known): some bundled plugins kept local debounce predicates instead of using only the shared helper.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/channels/inbound-debounce-policy.test.ts`
  - `extensions/feishu/src/monitor.reaction.test.ts`
- Scenario the test should lock in: `/status` and bare abort phrases bypass debounce, normal text still debounces, and a plugin-local debounce path flushes pending text before handling `stop`.
- Why this is the smallest reliable guardrail: it exercises the shared predicate plus one real plugin-local debounce wrapper without requiring channel credentials.
- Existing test that already covers this (if any): command-control and abort tests cover command recognition, but not the debounce boundary.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Bare abort messages such as `stop`, `abort`, and `wait` should no longer sit behind inbound debounce delays.

## Diagram (if applicable)

```text
Before:
normal text -> debounce buffer
stop        -> same debounce buffer -> delayed

After:
normal text -> debounce buffer
stop        -> flush pending text -> immediate stop message
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: local source checkout, Node 24
- Model/provider: N/A
- Integration/channel (if any): shared channel debounce plus Feishu/Mattermost/MSTeams/WhatsApp debounce predicates
- Relevant config (redacted): no credentials; synthetic config only

### Steps

1. Enqueue normal text through the real inbound debouncer.
2. Enqueue `stop` through the same key.
3. Verify normal text stays pending until `stop` arrives, then both flush separately without waiting for the debounce timer.

### Expected

- Normal text is debounceable.
- `/status`, `stop`, `abort`, and `wait` bypass debounce.
- `stop` flushes any pending same-key text before running immediately.

### Actual

- Matches expected after this patch.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `node scripts/run-vitest.mjs src/channels/inbound-debounce-policy.test.ts src/auto-reply/command-control.test.ts src/auto-reply/reply/abort.test.ts` -> 3 files / 73 tests passed
  - `node scripts/run-vitest.mjs extensions/feishu/src/monitor.reaction.test.ts` -> 1 file / 24 tests passed
  - `node scripts/run-vitest.mjs extensions/mattermost/src/mattermost/monitor.inbound-system-event.test.ts extensions/msteams/src/monitor-handler/message-handler.authz.test.ts extensions/whatsapp/src/auto-reply/monitor/process-message.test.ts` -> 3 files / 22 tests passed
  - `oxfmt --check` on touched files plus `extensions/imessage/src/monitor/monitor-provider.ts` -> clean
  - `oxlint` focused core and extension touched files -> clean
  - `tsgo` core, core tests, extensions, and extension tests -> clean
  - `git diff --check` -> clean
  - local source proof copied above
- Edge cases checked:
  - normal text still debounces
  - `/status`, `stop`, `abort`, and `wait` bypass debounce
  - plugin-local Feishu debounce flushes pending text before `stop`
  - command-auth and mention-gating call sites were left on their existing slash-command semantics
  - iMessage coalescing code was not changed
- What you did **not** verify:
  - full `pnpm check:changed` wrapper, because this local desktop environment does not have `pnpm` on PATH; the relevant underlying lint/typecheck/test lanes were run directly.
  - live external channel accounts.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: using the broader detector outside debounce could affect auth or mention-gating semantics.
  - Mitigation: the change is limited to debounce predicates; auth and mention gates were left unchanged.
