### PR TITLE
fix(update): harden legacy package upgrade handoff

### DIFF
--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -1957,6 +1957,7 @@ async function maybeRestartService(params: {
         defaultRuntime.log("");
         await createUpdateConfigSnapshot();
         process.env.OPENCLAW_UPDATE_IN_PROGRESS = "1";
+        process.env[UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV] = "1";
         process.env[UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV] = "1";
         try {
           const interactiveDoctor =
@@ -1968,6 +1969,7 @@ async function maybeRestartService(params: {
           defaultRuntime.log(theme.warn(`Doctor failed: ${String(err)}`));
         } finally {
           delete process.env.OPENCLAW_UPDATE_IN_PROGRESS;
+          delete process.env[UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV];
           delete process.env[UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV];
         }
       }

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -116,6 +116,7 @@ vi.mock("../../../plugins/clawhub.js", () => ({
   CLAWHUB_INSTALL_ERROR_CODE: {
     PACKAGE_NOT_FOUND: "package_not_found",
     VERSION_NOT_FOUND: "version_not_found",
+    ARTIFACT_DOWNLOAD_UNAVAILABLE: "artifact_download_unavailable",
   },
   installPluginFromClawHub: mocks.installPluginFromClawHub,
 }));
@@ -344,6 +345,47 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       ok: false,
       code: "package_not_found",
       error: "Package not found on ClawHub.",
+    });
+    mocks.listChannelPluginCatalogEntries.mockReturnValue([
+      {
+        id: "matrix",
+        pluginId: "matrix",
+        meta: { label: "Matrix" },
+        install: {
+          clawhubSpec: "clawhub:@openclaw/plugin-matrix@stable",
+          npmSpec: "@openclaw/plugin-matrix@1.2.3",
+        },
+        trustedSourceLinkedOfficialInstall: true,
+      },
+    ]);
+
+    const { repairMissingPluginInstallsForIds } =
+      await import("./missing-configured-plugin-install.js");
+    const result = await repairMissingPluginInstallsForIds({
+      cfg: {},
+      pluginIds: [],
+      channelIds: ["matrix"],
+      env: {},
+    });
+
+    expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
+      spec: "@openclaw/plugin-matrix@1.2.3",
+      expectedPluginId: "matrix",
+      trustedSourceLinkedOfficialInstall: true,
+    });
+    expect(result.changes).toEqual([
+      'ClawHub clawhub:@openclaw/plugin-matrix@stable unavailable for "matrix"; falling back to npm @openclaw/plugin-matrix@1.2.3.',
+      'Installed missing configured plugin "matrix" from @openclaw/plugin-matrix@1.2.3.',
+    ]);
+    expect(result.warnings).toStrictEqual([]);
+  });
+
+  it("falls back to npm when a ClawHub package artifact is temporarily unavailable", async () => {
+    mocks.installPluginFromClawHub.mockResolvedValueOnce({
+      ok: false,
+      code: "artifact_download_unavailable",
+      error:
+        'ClawHub artifact download for "@openclaw/plugin-matrix@1.2.3" is not available yet.',
     });
     mocks.listChannelPluginCatalogEntries.mockReturnValue([
       {
@@ -1020,6 +1062,58 @@ describe("repairMissingConfiguredPluginInstalls", () => {
       env: {
         OPENCLAW_UPDATE_IN_PROGRESS: "1",
         OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: "1",
+      },
+    });
+
+    expect(mocks.updateNpmInstalledPlugins).toHaveBeenCalledTimes(1);
+    expect(result.warnings).toEqual([]);
+    expect(result.changes[0]).toBe('Repaired missing configured plugin "discord".');
+    expectRecordFields(result.records.discord, {
+      source: "npm",
+      installPath: "/repaired/discord",
+    });
+  });
+
+  it("repairs missing external payload during legacy update handoff", async () => {
+    const records = {
+      discord: {
+        source: "npm",
+        spec: "@openclaw/discord",
+        installPath: "/missing/discord",
+      },
+    };
+    mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(records);
+    mocks.listChannelPluginCatalogEntries.mockReturnValue([
+      {
+        id: "discord",
+        pluginId: "discord",
+        meta: { label: "Discord" },
+        install: { npmSpec: "@openclaw/discord" },
+      },
+    ]);
+    mocks.updateNpmInstalledPlugins.mockResolvedValue({
+      config: {
+        plugins: {
+          installs: { discord: { source: "npm", installPath: "/repaired/discord" } },
+        },
+      },
+      changed: true,
+      outcomes: [{ pluginId: "discord", status: "updated", message: "ok" }],
+    });
+
+    const { repairMissingConfiguredPluginInstalls } =
+      await import("./missing-configured-plugin-install.js");
+    const result = await repairMissingConfiguredPluginInstalls({
+      cfg: {
+        plugins: {
+          entries: { discord: { enabled: true } },
+        },
+        channels: {
+          discord: { enabled: true },
+        },
+      },
+      env: {
+        OPENCLAW_UPDATE_IN_PROGRESS: "1",
       },
     });
 

--- a/src/commands/doctor/shared/missing-configured-plugin-install.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.ts
@@ -83,7 +83,8 @@ const REPAIRABLE_PACKAGE_ENTRY_DIAGNOSTIC_MARKERS = [
 function shouldFallbackClawHubToNpm(result: { ok: false; code?: string }): boolean {
   return (
     result.code === CLAWHUB_INSTALL_ERROR_CODE.PACKAGE_NOT_FOUND ||
-    result.code === CLAWHUB_INSTALL_ERROR_CODE.VERSION_NOT_FOUND
+    result.code === CLAWHUB_INSTALL_ERROR_CODE.VERSION_NOT_FOUND ||
+    result.code === CLAWHUB_INSTALL_ERROR_CODE.ARTIFACT_DOWNLOAD_UNAVAILABLE
   );
 }
 

--- a/src/commands/doctor/shared/release-configured-plugin-installs.test.ts
+++ b/src/commands/doctor/shared/release-configured-plugin-installs.test.ts
@@ -331,7 +331,7 @@ describe("configured plugin install release step", () => {
     expect(result.completed).toBe(true);
   });
 
-  it("does not stamp config during update-time deferred install repair", async () => {
+  it("does not stamp config during current-parent update-time deferred install repair", async () => {
     mocks.repairMissingPluginInstallsForIds.mockResolvedValue({
       changes: [
         'Skipped package-manager repair for configured plugin "codex" during package update; rerun "openclaw doctor --fix" after the update completes.',
@@ -374,9 +374,9 @@ describe("configured plugin install release step", () => {
     });
   });
 
-  it("defers package-manager plugin repair when an older updater supports post-doctor config writes", async () => {
+  it("allows legacy update handoff doctor to repair installs before the old parent resumes", async () => {
     mocks.repairMissingPluginInstallsForIds.mockResolvedValue({
-      changes: [],
+      changes: ['Installed missing configured plugin "discord".'],
       warnings: [],
     });
 
@@ -398,15 +398,17 @@ describe("configured plugin install release step", () => {
       },
     });
 
-    expect(readOnlyMissingPluginInstallRepairCall().env).toEqual({
+    const repairCall = readOnlyMissingPluginInstallRepairCall();
+    expect(repairCall.pluginIds).toEqual(["discord"]);
+    expect(repairCall.env).toEqual({
       OPENCLAW_UPDATE_IN_PROGRESS: "1",
       OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE: "1",
     });
     expect(result).toEqual({
-      changes: [],
+      changes: ['Installed missing configured plugin "discord".'],
       warnings: [],
-      completed: false,
-      touchedConfig: false,
+      completed: true,
+      touchedConfig: true,
     });
   });
 

--- a/src/commands/doctor/shared/update-phase.test.ts
+++ b/src/commands/doctor/shared/update-phase.test.ts
@@ -11,10 +11,25 @@ import {
 } from "./update-phase.js";
 
 describe("update-phase env helpers", () => {
-  it("treats only OPENCLAW_UPDATE_IN_PROGRESS=1 as package-swap-in-progress", () => {
-    expect(isUpdatePackageSwapInProgress({ [UPDATE_IN_PROGRESS_ENV]: "1" })).toBe(true);
+  it("treats current update parents as package-swap-in-progress", () => {
+    expect(
+      isUpdatePackageSwapInProgress({
+        [UPDATE_IN_PROGRESS_ENV]: "1",
+        [UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV]: "1",
+      }),
+    ).toBe(true);
     expect(isUpdatePackageSwapInProgress({ [UPDATE_IN_PROGRESS_ENV]: "0" })).toBe(false);
     expect(isUpdatePackageSwapInProgress({})).toBe(false);
+  });
+
+  it("does not defer repairs for legacy update parents", () => {
+    expect(isUpdatePackageSwapInProgress({ [UPDATE_IN_PROGRESS_ENV]: "1" })).toBe(true);
+    expect(
+      shouldDeferConfiguredPluginInstallRepair({
+        [UPDATE_IN_PROGRESS_ENV]: "1",
+        [UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV]: "1",
+      }),
+    ).toBe(false);
   });
 
   it("treats post-core convergence as a separate phase", () => {
@@ -52,7 +67,7 @@ describe("update-phase env helpers", () => {
         [UPDATE_IN_PROGRESS_ENV]: "1",
         [UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV]: "1",
       }),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       shouldDeferConfiguredPluginInstallRepair({
         [UPDATE_IN_PROGRESS_ENV]: "1",
@@ -79,7 +94,7 @@ describe("update-phase env helpers", () => {
         [UPDATE_IN_PROGRESS_ENV]: "1",
         [UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV]: "1",
       }),
-    ).toBe(false);
+    ).toBe(true);
     expect(
       isLegacyPackageUpdateDoctorPass({
         [UPDATE_IN_PROGRESS_ENV]: "1",

--- a/src/commands/doctor/shared/update-phase.ts
+++ b/src/commands/doctor/shared/update-phase.ts
@@ -19,6 +19,14 @@ export const UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV =
  * convergence (post-core wins). This lets a parent process re-enter doctor
  * with both flags set and still get repair behavior.
  *
+ * Older package-update parents set only OPENCLAW_UPDATE_IN_PROGRESS (and may
+ * set OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE) and then run their
+ * own stale post-core convergence code. Treat the candidate doctor as
+ * repair-capable in that legacy handoff so it can pre-install/repair plugins
+ * with current fallback logic before control returns to the old parent. New
+ * parents explicitly set OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR,
+ * so they still defer package-manager repairs to their updated post-core pass.
+ *
  * NOTE: only consumers that route through this helper observe the
  * "post-core wins" semantics. Files that still read
  * `OPENCLAW_UPDATE_IN_PROGRESS` directly (`commands/doctor-update.ts`,
@@ -47,8 +55,7 @@ export function isUpdatePackageSwapInProgress(env: NodeJS.ProcessEnv): boolean {
 export function shouldDeferConfiguredPluginInstallRepair(env: NodeJS.ProcessEnv): boolean {
   return (
     isUpdatePackageSwapInProgress(env) &&
-    (isTruthyEnvValue(env[UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV]) ||
-      isTruthyEnvValue(env[UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV]))
+    isTruthyEnvValue(env[UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV])
   );
 }
 

--- a/src/commands/onboarding-plugin-install.test.ts
+++ b/src/commands/onboarding-plugin-install.test.ts
@@ -48,6 +48,7 @@ vi.mock("../plugins/clawhub.js", () => ({
   CLAWHUB_INSTALL_ERROR_CODE: {
     PACKAGE_NOT_FOUND: "package_not_found",
     VERSION_NOT_FOUND: "version_not_found",
+    ARTIFACT_DOWNLOAD_UNAVAILABLE: "artifact_download_unavailable",
   },
   installPluginFromClawHub,
 }));
@@ -765,6 +766,54 @@ describe("ensureOnboardingPluginInstalled", () => {
       ok: false,
       code: "package_not_found",
       error: "Package not found on ClawHub.",
+    });
+    installPluginFromNpmSpec.mockResolvedValueOnce({
+      ok: true,
+      pluginId: "demo-plugin",
+      targetDir: "/tmp/demo-plugin",
+      version: "2026.5.2",
+      npmResolution: {
+        name: "@openclaw/demo-plugin",
+        version: "2026.5.2",
+        resolvedSpec: "@openclaw/demo-plugin@2026.5.2",
+        resolvedAt: "2026-05-01T00:00:00.000Z",
+      },
+    });
+
+    const result = await ensureOnboardingPluginInstalled({
+      cfg: {},
+      entry: {
+        pluginId: "demo-plugin",
+        label: "Demo Plugin",
+        install: {
+          clawhubSpec: "clawhub:demo-plugin@2026.5.2",
+          npmSpec: "@openclaw/demo-plugin@2026.5.2",
+          defaultChoice: "clawhub",
+        },
+      },
+      prompter: {
+        select: vi.fn(async () => "clawhub"),
+        confirm: vi.fn(async () => true),
+        note: vi.fn(async () => {}),
+        progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+      } as never,
+      runtime: {} as never,
+      promptInstall: false,
+    });
+
+    const [npmCall] = readFirstMockCall(installPluginFromNpmSpec, "installPluginFromNpmSpec") as [
+      NpmSpecInstallCall,
+    ];
+    expect(npmCall.spec).toBe("@openclaw/demo-plugin@2026.5.2");
+    expect(npmCall.expectedPluginId).toBe("demo-plugin");
+    expect(result.installed).toBe(true);
+  });
+
+  it("falls back from ClawHub to npm when the artifact download is unavailable", async () => {
+    installPluginFromClawHub.mockResolvedValueOnce({
+      ok: false,
+      code: "artifact_download_unavailable",
+      error: "ClawHub artifact download is not available yet.",
     });
     installPluginFromNpmSpec.mockResolvedValueOnce({
       ok: true,

--- a/src/commands/onboarding-plugin-install.ts
+++ b/src/commands/onboarding-plugin-install.ts
@@ -65,7 +65,8 @@ export type OnboardingPluginInstallResult = {
 function shouldFallbackClawHubToNpm(result: { ok: false; code?: string }): boolean {
   return (
     result.code === CLAWHUB_INSTALL_ERROR_CODE.PACKAGE_NOT_FOUND ||
-    result.code === CLAWHUB_INSTALL_ERROR_CODE.VERSION_NOT_FOUND
+    result.code === CLAWHUB_INSTALL_ERROR_CODE.VERSION_NOT_FOUND ||
+    result.code === CLAWHUB_INSTALL_ERROR_CODE.ARTIFACT_DOWNLOAD_UNAVAILABLE
   );
 }
 

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -203,10 +203,22 @@ describe("doctor health contributions", () => {
       shouldSkipLegacyUpdateDoctorConfigWrite({
         env: {
           OPENCLAW_UPDATE_IN_PROGRESS: "1",
+          OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR: "1",
           OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE: "1",
         },
       }),
     ).toBe(false);
+  });
+
+  it("skips writes when older update parents only advertise doctor-write support", () => {
+    expect(
+      shouldSkipLegacyUpdateDoctorConfigWrite({
+        env: {
+          OPENCLAW_UPDATE_IN_PROGRESS: "1",
+          OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE: "1",
+        },
+      }),
+    ).toBe(true);
   });
 
   it("treats falsey update env values as normal writes", () => {
@@ -253,6 +265,7 @@ describe("doctor health contributions", () => {
     it("allows config size drops when OPENCLAW_UPDATE_IN_PROGRESS=1", async () => {
       const ctx = buildWriteConfigCtx({
         OPENCLAW_UPDATE_IN_PROGRESS: "1",
+        OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR: "1",
         OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE: "1",
       });
       await writeConfigContribution.run(ctx);
@@ -268,6 +281,7 @@ describe("doctor health contributions", () => {
     it("skips plugin schema validation during update doctor writes", async () => {
       const ctx = buildWriteConfigCtx({
         OPENCLAW_UPDATE_IN_PROGRESS: "1",
+        OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR: "1",
         OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE: "1",
       });
       await writeConfigContribution.run(ctx);
@@ -296,6 +310,7 @@ describe("doctor health contributions", () => {
       vi.mocked(fs.existsSync).mockImplementation((value) => String(value).endsWith(".pre-update"));
       const ctx = buildWriteConfigCtx({
         OPENCLAW_UPDATE_IN_PROGRESS: "1",
+        OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR: "1",
         OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE: "1",
       });
 

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -210,7 +210,7 @@ describe("doctor health contributions", () => {
     ).toBe(false);
   });
 
-  it("skips writes when older update parents only advertise doctor-write support", () => {
+  it("keeps older update parents with doctor-write support writable", () => {
     expect(
       shouldSkipLegacyUpdateDoctorConfigWrite({
         env: {
@@ -218,7 +218,7 @@ describe("doctor health contributions", () => {
           OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE: "1",
         },
       }),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("treats falsey update env values as normal writes", () => {

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -49,8 +49,8 @@ function resolveDoctorMode(cfg: OpenClawConfig): DoctorFlowMode {
   return cfg.gateway?.mode === "remote" ? "remote" : "local";
 }
 
-const UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV =
-  "OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE";
+const UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV =
+  "OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR";
 
 function isTruthyEnvValue(value: string | undefined): boolean {
   if (!value) {
@@ -66,7 +66,7 @@ export function shouldSkipLegacyUpdateDoctorConfigWrite(params: {
   if (!isTruthyEnvValue(params.env.OPENCLAW_UPDATE_IN_PROGRESS)) {
     return false;
   }
-  if (isTruthyEnvValue(params.env[UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV])) {
+  if (isTruthyEnvValue(params.env[UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV])) {
     return false;
   }
   return true;

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -49,8 +49,8 @@ function resolveDoctorMode(cfg: OpenClawConfig): DoctorFlowMode {
   return cfg.gateway?.mode === "remote" ? "remote" : "local";
 }
 
-const UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV =
-  "OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR";
+const UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV =
+  "OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE";
 
 function isTruthyEnvValue(value: string | undefined): boolean {
   if (!value) {
@@ -66,7 +66,7 @@ export function shouldSkipLegacyUpdateDoctorConfigWrite(params: {
   if (!isTruthyEnvValue(params.env.OPENCLAW_UPDATE_IN_PROGRESS)) {
     return false;
   }
-  if (isTruthyEnvValue(params.env[UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV])) {
+  if (isTruthyEnvValue(params.env[UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV])) {
     return false;
   }
   return true;

--- a/src/plugins/clawhub.test.ts
+++ b/src/plugins/clawhub.test.ts
@@ -747,6 +747,7 @@ describe("installPluginFromClawHub", () => {
     });
 
     const failure = expectInstallFailure(result);
+    expect(failure.code).toBe(CLAWHUB_INSTALL_ERROR_CODE.ARTIFACT_DOWNLOAD_UNAVAILABLE);
     expect(failure.error).toBe(
       'ClawHub artifact download for "demo@2026.3.22" is not available yet (ClawHub /api/v1/packages/demo/versions/2026.3.22/artifact/download failed (404): Not Found). Use "npm:demo@2026.3.22" for launch installs while ClawHub artifact routing is being rolled out.',
     );

--- a/src/plugins/clawhub.ts
+++ b/src/plugins/clawhub.ts
@@ -47,6 +47,7 @@ export const CLAWHUB_INSTALL_ERROR_CODE = {
   PRIVATE_PACKAGE: "private_package",
   INCOMPATIBLE_PLUGIN_API: "incompatible_plugin_api",
   INCOMPATIBLE_GATEWAY: "incompatible_gateway",
+  ARTIFACT_DOWNLOAD_UNAVAILABLE: "artifact_download_unavailable",
   MISSING_ARCHIVE_INTEGRITY: "missing_archive_integrity",
   ARCHIVE_INTEGRITY_MISMATCH: "archive_integrity_mismatch",
 } as const;
@@ -1147,6 +1148,9 @@ export async function installPluginFromClawHub(
             version: versionState.version,
           })
         : formatErrorMessage(error),
+      expectedClawPackSha256 && error instanceof ClawHubRequestError
+        ? CLAWHUB_INSTALL_ERROR_CODE.ARTIFACT_DOWNLOAD_UNAVAILABLE
+        : undefined,
     );
   }
   try {


### PR DESCRIPTION
## Summary

Fixes #83359.

Fixes the beta upgrade handoff path for older package update parents.

- Avoids writing config metadata with the candidate version when an old updater parent will resume after candidate `doctor` runs.
- Lets the candidate doctor repair configured plugin installs during legacy update handoff, so current repair/fallback logic runs before old post-core code resumes.
- Adds a structured ClawHub `artifact_download_unavailable` install error and treats it as safe to fall back to npm in doctor repair and onboarding while preserving fail-closed behavior for integrity/security failures.

## Motivation

While testing `openclaw@2026.5.16-beta.4` to the beta5 candidate, the upgrade flow exposed two old-parent handoff problems:

1. the candidate doctor could stamp config with the candidate/current version before the beta4 parent resumed, causing beta4 to reject the config as written by a newer OpenClaw;
2. after that was fixed, beta4's stale post-core plugin convergence still tried to install Matrix from a ClawHub beta artifact that currently points users to the npm fallback.

New update parents already run post-core plugin convergence in the updated process. This keeps that safer behavior, while allowing legacy parents to benefit from the candidate doctor's current repair logic before control returns to old code.

## Verification

- `node scripts/run-vitest.mjs src/flows/doctor-health-contributions.test.ts`
- `node scripts/run-vitest.mjs src/commands/doctor/shared/update-phase.test.ts src/commands/doctor/shared/release-configured-plugin-installs.test.ts src/commands/doctor/shared/missing-configured-plugin-install.test.ts src/plugins/clawhub.test.ts src/commands/onboarding-plugin-install.test.ts`

## Real behavior proof

Behavior addressed: `openclaw update` from `openclaw@2026.5.16-beta.4` to a candidate package should not fail because the old parent resumes after candidate doctor with a future-stamped config or stale ClawHub-only plugin convergence.

Real environment tested: GitHub Actions Package Acceptance, Docker `published-upgrade-survivor` lane, baseline `openclaw@2026.5.16-beta.4`, candidate package built from this branch.

Exact steps or command run after this patch: `gh workflow run package-acceptance.yml --repo openclaw/openclaw --ref main -f workflow_ref=main -f source=ref -f package_ref=fix-beta-upgrade-post-core -f suite_profile=custom -f docker_lanes=published-upgrade-survivor -f published_upgrade_survivor_baseline=openclaw@2026.5.16-beta.4 -f published_upgrade_survivor_scenarios=reported-issues -f telegram_mode=none`

Evidence after fix: after-fix Docker artifact: https://github.com/openclaw/openclaw/actions/runs/26007310160/artifacts/7047735217. The copied runtime log excerpt from that artifact shows the beta4 baseline updating to the candidate tarball, with neither the future-stamped config rejection nor the stale `clawhub:@openclaw/matrix@beta` artifact failure appearing after this patch:

```text
==> [published-upgrade-survivor] command: ... pnpm test:docker:published-upgrade-survivor
Installing baseline package: openclaw@2026.5.16-beta.4
Updating baseline openclaw@2026.5.16-beta.4 to candidate tarball:/tmp/openclaw-current.tgz (2026.5.17)
Upgrade survivor summary: /tmp/openclaw-upgrade-survivor-artifacts/summary.json
{
  "status": "passed",
  "baseline": { "spec": "openclaw@2026.5.16-beta.4", "version": "2026.5.16-beta.4" }
}
```

Observed result after fix: the after-fix Docker artifact gets through the reported upgrade handoff failures and records an upgrade survivor summary with `"status": "passed"`; local targeted regression tests also pass.

What was not tested: the Package Acceptance workflow wrapper still timed out after the Docker lane wrote the passing summary. I kicked a fresh current-head Package Acceptance run at https://github.com/openclaw/openclaw/actions/runs/26008821445 and will update this section if it produces a newer artifact.

![PR 83350 before/after proof](https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-83350-fresh/pr-83350/pr-83350-fix-update-harden-legacy-package-upgrade-handoff-before-after-proof.png)

Fresh deterministic proof artifacts:

- Summary: https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-83350-fresh/pr-83350/summary.txt
- Before/source proof log: https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-83350-fresh/pr-83350/before-source-proof.log
- After/PR proof log: https://raw.githubusercontent.com/giodl73-repo/openclaw/proof-artifacts/pr-83350-fresh/pr-83350/after-pr-83350.log

Proof images:

![Config stamp failure log snippet](https://gist.githubusercontent.com/giodl73-repo/72caef78386f499b4cf7ba0e1c78c54b/raw/34405c5057242700af87a12849ea2b6aa8e08a01/pr83350-config-stamp-failure-log.svg)

![Matrix ClawHub artifact failure log snippet](https://gist.githubusercontent.com/giodl73-repo/72caef78386f499b4cf7ba0e1c78c54b/raw/267879bb5118cabaee3e8277431bf8f5c62a8fb9/pr83350-matrix-artifact-failure-log.svg)

![Targeted regression test proof log snippet](https://gist.githubusercontent.com/giodl73-repo/72caef78386f499b4cf7ba0e1c78c54b/raw/b76520c73e92b24609f1819ffac173adae3c5dba/pr83350-regression-tests-log.svg)

![After-fix Docker lane log snippet](https://gist.githubusercontent.com/giodl73-repo/72caef78386f499b4cf7ba0e1c78c54b/raw/a0ccb24f979c2277d520e06149149b45ef38d432/pr83350-after-fix-docker-log.svg)

Earlier targeted Package Acceptance runs reproduced the config-stamp failure and then the Matrix ClawHub post-core failure: https://github.com/openclaw/openclaw/actions/runs/26005923944 and https://github.com/openclaw/openclaw/actions/runs/26006842269.