### PR TITLE
fix(telegram): preserve forum topic origin targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/webchat: hide internal runtime-context and other `display: false` transcript messages from Chat history and live message events. Fixes #83216. Thanks @EmpireCreator.
 - CLI/help: keep `gateway`, `doctor`, `status`, and `health` help registration out of action/runtime imports so subcommand `--help` stays lightweight in constrained terminals. Fixes #83228. Thanks @dfguerrerom.
 - Cron/Discord: keep explicit announce runs in message-tool-only source-reply mode so scheduled agent turns post once instead of also echoing through automatic visible replies. Fixes #83261. Thanks @Theralley.
+- Telegram: preserve forum-topic origin targets in inbound, audio-preflight, and skipped-message hook contexts so follow-up delivery stays bound to the originating topic. Fixes #83302. Thanks @M00zyx.
 - Mac app: align the Sessions settings pane with the standard Settings page gutter and row spacing.
 - OpenAI/Codex: stop rejecting available `openai-codex` GPT-5.1, GPT-5.2, and GPT-5.3 model refs during config validation, while keeping removed Spark aliases suppressed. Fixes #83303.
 - Codex app-server: preserve streamed native command output in mirrored transcripts and trajectory exports when final snapshots omit aggregated output. (#83200) Thanks @rozmiarD.

--- a/extensions/telegram/src/bot-message-context.body.test.ts
+++ b/extensions/telegram/src/bot-message-context.body.test.ts
@@ -1,11 +1,27 @@
 import { describe, expect, it, vi } from "vitest";
 import { normalizeAllowFrom } from "./bot-access.js";
 
-const transcribeFirstAudioMock = vi.fn();
+const { transcribeFirstAudioMock, triggerInternalHookMock } = vi.hoisted(() => ({
+  transcribeFirstAudioMock: vi.fn(),
+  triggerInternalHookMock: vi.fn<(event: unknown) => Promise<void>>(async () => undefined),
+}));
 
 vi.mock("./media-understanding.runtime.js", () => ({
   transcribeFirstAudio: (...args: unknown[]) => transcribeFirstAudioMock(...args),
 }));
+
+vi.mock("openclaw/plugin-sdk/hook-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/hook-runtime")>(
+    "openclaw/plugin-sdk/hook-runtime",
+  );
+  return {
+    ...actual,
+    fireAndForgetHook: (promise: Promise<unknown>) => {
+      void promise;
+    },
+    triggerInternalHook: (event: unknown) => triggerInternalHookMock(event),
+  };
+});
 
 const { resolveTelegramInboundBody } = await import("./bot-message-context.body.js");
 
@@ -331,6 +347,92 @@ describe("resolveTelegramInboundBody", () => {
     const ctx = transcribeCallContext();
     expect(ctx.OriginatingTo).toBe("telegram:42");
     expect(ctx.MessageThreadId).toBe(77);
+  });
+
+  it("preserves forum topic origin targets in audio preflight context", async () => {
+    transcribeFirstAudioMock.mockReset();
+    transcribeFirstAudioMock.mockResolvedValueOnce("topic audio");
+
+    await resolveTelegramBody({
+      cfg: {
+        channels: { telegram: {} },
+        commands: { useAccessGroups: false },
+        messages: { groupChat: { mentionPatterns: ["\\bbot\\b"] } },
+        tools: { media: { audio: { enabled: true, echoTranscript: true } } },
+      } as never,
+      accountId: "primary",
+      msg: {
+        message_id: 13,
+        message_thread_id: 99,
+        date: 1_700_000_013,
+        chat: { id: -1001234567890, type: "supergroup", title: "Test Forum", is_forum: true },
+        from: { id: 46, first_name: "Eve" },
+        voice: { file_id: "voice-forum-topic-1" },
+        entities: [],
+      } as never,
+      allMedia: [{ path: "/tmp/voice-forum-topic.ogg", contentType: "audio/ogg" }],
+      isGroup: true,
+      chatId: -1001234567890,
+      senderId: "46",
+      groupConfig: { requireMention: true } as never,
+      requireMention: true,
+      resolvedThreadId: 99,
+      replyThreadId: 99,
+      forumOriginThreadSpec: { id: 99, scope: "forum" },
+    });
+
+    const ctx = transcribeCallContext();
+    expect(ctx.OriginatingTo).toBe("telegram:-1001234567890:topic:99");
+    expect(ctx.MessageThreadId).toBe(99);
+  });
+
+  it("preserves forum topic origin targets for skipped-message hooks", async () => {
+    triggerInternalHookMock.mockClear();
+
+    const result = await resolveTelegramBody({
+      cfg: {
+        channels: { telegram: {} },
+        messages: { groupChat: { mentionPatterns: ["\\bbot\\b"] } },
+      } as never,
+      accountId: "primary",
+      msg: {
+        message_id: 14,
+        message_thread_id: 99,
+        date: 1_700_000_014,
+        chat: { id: -1001234567890, type: "supergroup", title: "Test Forum", is_forum: true },
+        from: { id: 46, first_name: "Eve" },
+        text: "ambient chatter",
+        entities: [],
+      } as never,
+      allMedia: [],
+      isGroup: true,
+      chatId: -1001234567890,
+      senderId: "46",
+      sessionKey: "agent:main:telegram:group:-1001234567890:topic:99",
+      groupConfig: { requireMention: true } as never,
+      topicConfig: { ingest: true } as never,
+      requireMention: true,
+      resolvedThreadId: 99,
+      replyThreadId: 99,
+      forumOriginThreadSpec: { id: 99, scope: "forum" },
+    });
+
+    expect(result).toBeNull();
+    const event = triggerInternalHookMock.mock.calls[0]?.[0] as
+      | { context?: { conversationId?: string; metadata?: Record<string, unknown> } }
+      | undefined;
+    expect(event?.context).toEqual(
+      expect.objectContaining({
+        conversationId: "telegram:-1001234567890:topic:99",
+      }),
+    );
+    expect(event?.context?.metadata).toEqual(
+      expect.objectContaining({
+        threadId: 99,
+        to: "telegram:-1001234567890:topic:99",
+      }),
+    );
+    expect(triggerInternalHookMock).toHaveBeenCalledOnce();
   });
 
   it("escapes transcript text before embedding it in the audio framing", async () => {

--- a/extensions/telegram/src/bot-message-context.body.test.ts
+++ b/extensions/telegram/src/bot-message-context.body.test.ts
@@ -378,7 +378,7 @@ describe("resolveTelegramInboundBody", () => {
       requireMention: true,
       resolvedThreadId: 99,
       replyThreadId: 99,
-      forumOriginThreadSpec: { id: 99, scope: "forum" },
+      originatingTo: "telegram:-1001234567890:topic:99",
     });
 
     const ctx = transcribeCallContext();
@@ -414,7 +414,7 @@ describe("resolveTelegramInboundBody", () => {
       requireMention: true,
       resolvedThreadId: 99,
       replyThreadId: 99,
-      forumOriginThreadSpec: { id: 99, scope: "forum" },
+      originatingTo: "telegram:-1001234567890:topic:99",
     });
 
     expect(result).toBeNull();

--- a/extensions/telegram/src/bot-message-context.body.ts
+++ b/extensions/telegram/src/bot-message-context.body.ts
@@ -40,7 +40,11 @@ import {
   hasBotMention,
   resolveTelegramPrimaryMedia,
 } from "./bot/body-helpers.js";
-import { buildTelegramGroupPeerId } from "./bot/helpers.js";
+import {
+  buildTelegramGroupPeerId,
+  buildTelegramRoutingTarget,
+  type TelegramThreadSpec,
+} from "./bot/helpers.js";
 import type { TelegramContext } from "./bot/types.js";
 import { isTelegramForumServiceMessage } from "./forum-service-message.js";
 import { resolveTelegramCommandIngressAuthorization } from "./ingress.js";
@@ -142,6 +146,7 @@ export async function resolveTelegramInboundBody(params: {
   sessionKey?: string;
   resolvedThreadId?: number;
   replyThreadId?: number;
+  forumOriginThreadSpec?: TelegramThreadSpec;
   routeAgentId?: string;
   effectiveGroupAllow: NormalizedAllowFrom;
   effectiveDmAllow: NormalizedAllowFrom;
@@ -166,6 +171,7 @@ export async function resolveTelegramInboundBody(params: {
     sessionKey,
     resolvedThreadId,
     replyThreadId,
+    forumOriginThreadSpec,
     routeAgentId,
     effectiveGroupAllow,
     effectiveDmAllow,
@@ -204,6 +210,9 @@ export async function resolveTelegramInboundBody(params: {
   });
   const commandAuthorized = commandGate.authorized;
   const historyKey = isGroup ? buildTelegramGroupPeerId(chatId, resolvedThreadId) : undefined;
+  const originatingTo = forumOriginThreadSpec
+    ? buildTelegramRoutingTarget(chatId, forumOriginThreadSpec)
+    : `telegram:${chatId}`;
 
   const primaryMedia = resolveTelegramPrimaryMedia(msg);
   let placeholder = primaryMedia?.placeholder ?? "";
@@ -262,7 +271,7 @@ export async function resolveTelegramInboundBody(params: {
         Provider: "telegram",
         Surface: "telegram",
         OriginatingChannel: "telegram",
-        OriginatingTo: `telegram:${chatId}`,
+        OriginatingTo: originatingTo,
         AccountId: accountId,
         MessageThreadId: replyThreadId,
         MediaPaths: allMedia.length > 0 ? allMedia.map((m) => m.path) : undefined,
@@ -386,12 +395,12 @@ export async function resolveTelegramInboundBody(params: {
             sessionKey,
             toInternalMessageReceivedContext({
               from: `telegram:group:${historyKey ?? chatId}`,
-              to: `telegram:${chatId}`,
+              to: originatingTo,
               content: rawBody,
               timestamp: msg.date ? msg.date * 1000 : undefined,
               channelId: "telegram",
               accountId,
-              conversationId: `telegram:${chatId}`,
+              conversationId: originatingTo,
               messageId: typeof msg.message_id === "number" ? String(msg.message_id) : undefined,
               senderId: senderId || undefined,
               senderName: buildSenderName(msg),
@@ -400,7 +409,7 @@ export async function resolveTelegramInboundBody(params: {
               surface: "telegram",
               threadId: resolvedThreadId,
               originatingChannel: "telegram",
-              originatingTo: `telegram:${chatId}`,
+              originatingTo,
               isGroup: true,
               groupId: `telegram:${chatId}`,
             }),

--- a/extensions/telegram/src/bot-message-context.body.ts
+++ b/extensions/telegram/src/bot-message-context.body.ts
@@ -40,11 +40,7 @@ import {
   hasBotMention,
   resolveTelegramPrimaryMedia,
 } from "./bot/body-helpers.js";
-import {
-  buildTelegramGroupPeerId,
-  buildTelegramRoutingTarget,
-  type TelegramThreadSpec,
-} from "./bot/helpers.js";
+import { buildTelegramGroupPeerId, buildTelegramInboundOriginTarget } from "./bot/helpers.js";
 import type { TelegramContext } from "./bot/types.js";
 import { isTelegramForumServiceMessage } from "./forum-service-message.js";
 import { resolveTelegramCommandIngressAuthorization } from "./ingress.js";
@@ -146,7 +142,7 @@ export async function resolveTelegramInboundBody(params: {
   sessionKey?: string;
   resolvedThreadId?: number;
   replyThreadId?: number;
-  forumOriginThreadSpec?: TelegramThreadSpec;
+  originatingTo?: string;
   routeAgentId?: string;
   effectiveGroupAllow: NormalizedAllowFrom;
   effectiveDmAllow: NormalizedAllowFrom;
@@ -171,7 +167,7 @@ export async function resolveTelegramInboundBody(params: {
     sessionKey,
     resolvedThreadId,
     replyThreadId,
-    forumOriginThreadSpec,
+    originatingTo: providedOriginatingTo,
     routeAgentId,
     effectiveGroupAllow,
     effectiveDmAllow,
@@ -210,9 +206,7 @@ export async function resolveTelegramInboundBody(params: {
   });
   const commandAuthorized = commandGate.authorized;
   const historyKey = isGroup ? buildTelegramGroupPeerId(chatId, resolvedThreadId) : undefined;
-  const originatingTo = forumOriginThreadSpec
-    ? buildTelegramRoutingTarget(chatId, forumOriginThreadSpec)
-    : `telegram:${chatId}`;
+  const originatingTo = providedOriginatingTo ?? buildTelegramInboundOriginTarget(chatId);
 
   const primaryMedia = resolveTelegramPrimaryMedia(msg);
   let placeholder = primaryMedia?.placeholder ?? "";

--- a/extensions/telegram/src/bot-message-context.dm-threads.test.ts
+++ b/extensions/telegram/src/bot-message-context.dm-threads.test.ts
@@ -274,6 +274,7 @@ describe("buildTelegramMessageContext group sessions without forum", () => {
     // Session key SHOULD include :topic:99 for forums
     expect(ctx?.ctxPayload?.SessionKey).toBe("agent:main:telegram:group:-1001234567890:topic:99");
     expect(ctx?.ctxPayload?.MessageThreadId).toBe(99);
+    expect(ctx?.ctxPayload?.OriginatingTo).toBe("telegram:-1001234567890:topic:99");
   });
 
   it("surfaces topic name from reply_to_message forum metadata", async () => {

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -35,7 +35,7 @@ import {
   buildSenderLabel,
   buildSenderName,
   buildTelegramGroupFrom,
-  buildTelegramRoutingTarget,
+  buildTelegramInboundOriginTarget,
   describeReplyTarget,
   normalizeForwardedContext,
   type TelegramReplyTarget,
@@ -414,10 +414,7 @@ export async function buildTelegramInboundContextPayload(params: {
   const telegramFrom = isGroup
     ? buildTelegramGroupFrom(chatId, resolvedThreadId)
     : `telegram:${chatId}`;
-  const telegramTo =
-    threadSpec.scope === "forum"
-      ? buildTelegramRoutingTarget(chatId, threadSpec)
-      : `telegram:${chatId}`;
+  const telegramTo = buildTelegramInboundOriginTarget(chatId, threadSpec);
   const locationContext = locationData ? toLocationContext(locationData) : undefined;
   const commandSource = options?.commandSource;
   const unmentionedGroupPolicy = resolveUnmentionedGroupInboundPolicy({

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -35,6 +35,7 @@ import {
   buildSenderLabel,
   buildSenderName,
   buildTelegramGroupFrom,
+  buildTelegramRoutingTarget,
   describeReplyTarget,
   normalizeForwardedContext,
   type TelegramReplyTarget,
@@ -413,7 +414,10 @@ export async function buildTelegramInboundContextPayload(params: {
   const telegramFrom = isGroup
     ? buildTelegramGroupFrom(chatId, resolvedThreadId)
     : `telegram:${chatId}`;
-  const telegramTo = `telegram:${chatId}`;
+  const telegramTo =
+    threadSpec.scope === "forum"
+      ? buildTelegramRoutingTarget(chatId, threadSpec)
+      : `telegram:${chatId}`;
   const locationContext = locationData ? toLocationContext(locationData) : undefined;
   const commandSource = options?.commandSource;
   const unmentionedGroupPolicy = resolveUnmentionedGroupInboundPolicy({

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -443,6 +443,7 @@ export const buildTelegramMessageContext = async ({
     direction: "inbound",
   });
 
+  const forumOriginThreadSpec = threadSpec.scope === "forum" ? threadSpec : undefined;
   const bodyResult = await resolveTelegramInboundBody({
     cfg,
     primaryCtx,
@@ -455,6 +456,7 @@ export const buildTelegramMessageContext = async ({
     senderUsername,
     resolvedThreadId,
     replyThreadId,
+    ...(forumOriginThreadSpec ? { forumOriginThreadSpec } : {}),
     routeAgentId: route.agentId,
     sessionKey,
     effectiveGroupAllow,

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -29,6 +29,7 @@ import {
 } from "./bot-message-context.session.js";
 import type { BuildTelegramMessageContextParams } from "./bot-message-context.types.js";
 import {
+  buildTelegramInboundOriginTarget,
   buildTypingThreadParams,
   extractTelegramForumFlag,
   resolveTelegramForumFlag,
@@ -443,7 +444,7 @@ export const buildTelegramMessageContext = async ({
     direction: "inbound",
   });
 
-  const forumOriginThreadSpec = threadSpec.scope === "forum" ? threadSpec : undefined;
+  const originatingTo = buildTelegramInboundOriginTarget(chatId, threadSpec);
   const bodyResult = await resolveTelegramInboundBody({
     cfg,
     primaryCtx,
@@ -456,7 +457,7 @@ export const buildTelegramMessageContext = async ({
     senderUsername,
     resolvedThreadId,
     replyThreadId,
-    ...(forumOriginThreadSpec ? { forumOriginThreadSpec } : {}),
+    originatingTo,
     routeAgentId: route.agentId,
     sessionKey,
     effectiveGroupAllow,

--- a/extensions/telegram/src/bot/helpers.test.ts
+++ b/extensions/telegram/src/bot/helpers.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  buildTelegramInboundOriginTarget,
   buildTelegramRoutingTarget,
   buildTelegramThreadParams,
   buildTypingThreadParams,
@@ -175,6 +176,37 @@ describe("buildTelegramRoutingTarget", () => {
     },
   ])("$name", ({ chatId, thread, expected }) => {
     expect(buildTelegramRoutingTarget(chatId, thread)).toBe(expected);
+  });
+});
+
+describe("buildTelegramInboundOriginTarget", () => {
+  it.each([
+    {
+      name: "keeps DM topic thread ids out of the origin target",
+      chatId: 42,
+      thread: { id: 77, scope: "dm" as const },
+      expected: "telegram:42",
+    },
+    {
+      name: "keeps regular groups chat-scoped",
+      chatId: -100123,
+      thread: { scope: "none" as const },
+      expected: "telegram:-100123",
+    },
+    {
+      name: "keeps General forum topic chat-scoped",
+      chatId: -100123,
+      thread: { id: 1, scope: "forum" as const },
+      expected: "telegram:-100123",
+    },
+    {
+      name: "includes real forum topic ids",
+      chatId: -100123,
+      thread: { id: 42, scope: "forum" as const },
+      expected: "telegram:-100123:topic:42",
+    },
+  ])("$name", ({ chatId, thread, expected }) => {
+    expect(buildTelegramInboundOriginTarget(chatId, thread)).toBe(expected);
   });
 });
 

--- a/extensions/telegram/src/bot/helpers.ts
+++ b/extensions/telegram/src/bot/helpers.ts
@@ -340,6 +340,20 @@ export function buildTelegramRoutingTarget(
 }
 
 /**
+ * Build the canonical Telegram inbound origin used by queued follow-up routing.
+ * DM thread ids remain metadata-only; real forum topics must be in-band.
+ */
+export function buildTelegramInboundOriginTarget(
+  chatId: number | string,
+  thread?: TelegramThreadSpec | null,
+): string {
+  if (thread?.scope !== "forum") {
+    return `telegram:${chatId}`;
+  }
+  return buildTelegramRoutingTarget(chatId, thread);
+}
+
+/**
  * Build thread params for typing indicators (sendChatAction).
  * Empirically, General topic (id=1) needs message_thread_id for typing to appear.
  */


### PR DESCRIPTION
Fixes #83302.

Summary
- Preserve Telegram forum-topic routing targets when creating inbound session context, audio-preflight context, and skipped-message hook context.
- Centralize inbound origin-target construction in `buildTelegramInboundOriginTarget` so DM thread ids stay metadata-only while real forum topics are encoded in-band for queued follow-up routing.
- Add regression coverage for forum-topic `OriginatingTo`, skipped-message hook delivery metadata, and the origin-target helper contract.

Verification
- Behavior addressed: Telegram forum-topic follow-up delivery keeps `telegram:<chatId>:topic:<message_thread_id>` as the originating target instead of flattening to the chat id while retaining only `MessageThreadId` metadata.
- Real environment tested: local OpenClaw checkout plus Testbox changed-gate run on branch `fix/telegram-topic-originating-to-83302`.
- Exact steps or command run after this patch: `pnpm test extensions/telegram/src/bot/helpers.test.ts extensions/telegram/src/bot-message-context.body.test.ts extensions/telegram/src/bot-message-context.dm-threads.test.ts extensions/telegram/src/bot-message-context.dm-topic-threadid.test.ts`; `.agents/skills/autoreview/scripts/autoreview --mode local`; `pnpm check:changed`.
- Evidence after fix: focused Telegram tests passed 4 files / 107 tests locally; autoreview clean with no accepted/actionable findings; Testbox `tbx_01krwa6t09mdem4845m0pr8qrc` / GitHub Actions run https://github.com/openclaw/openclaw/actions/runs/26008265323 completed with extensions, extensionTests, and docs lanes passing.
- Observed result after fix: inbound, audio-preflight, skipped-message hook, and helper-contract tests all preserve topic-qualified forum origins while DM thread origins remain chat-scoped.
- What was not tested: live Telegram delivery against the Telegram API; this patch is covered by the Telegram context/regression unit path and changed gates.
