### PR TITLE
fix(outbound): log failDelivery rejection on bestEffort partial failure (#83113)

### DIFF
--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -2540,6 +2540,22 @@ describe("deliverOutboundPayloads", () => {
     );
   });
 
+  it("logs a warning when failDelivery itself rejects on bestEffort partial failure (#83113)", async () => {
+    queueMocks.failDelivery.mockRejectedValueOnce(new Error("queue storage down"));
+
+    await runBestEffortPartialFailureDelivery();
+
+    expect(queueMocks.failDelivery).toHaveBeenCalledWith(
+      "mock-queue-id",
+      "partial delivery failure (bestEffort)",
+    );
+    const warnCall = requireMockCall(logMocks.warn, "warn");
+    const warnMessage = String(warnCall[0]);
+    expect(warnMessage).toContain("failed to fail queued delivery");
+    expect(warnMessage).toContain("mock-queue-id");
+    expect(warnMessage).toContain("queue storage down");
+  });
+
   it("writes raw payloads to the queue before normalization", async () => {
     const sendMatrix = vi.fn().mockResolvedValue({ messageId: "m-raw", roomId: "!room:example" });
     const rawPayloads: DeliverOutboundPayload[] = [

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -1295,7 +1295,13 @@ async function deliverOutboundPayloadsWithQueueCleanup(
     }
     if (queueId) {
       if (hadPartialFailure) {
-        await failDelivery(queueId, "partial delivery failure (bestEffort)").catch(() => {});
+        await failDelivery(queueId, "partial delivery failure (bestEffort)").catch(
+          (err: unknown) => {
+            log.warn(
+              `failed to fail queued delivery ${queueId} after partial delivery failure; queue entry may be retried: ${formatErrorMessage(err)}`,
+            );
+          },
+        );
       } else {
         if (platformSendStarted) {
           await markQueuedPlatformOutcomeUnknown({


### PR DESCRIPTION
Closes #83113

## Problem

In `src/infra/outbound/deliver.ts` (around line 1298), when best-effort partial delivery occurs the queue entry is marked failed via `failDelivery()` so the retry count is incremented. The previous code wrapped that call in `.catch(() => {})`, silently swallowing any rejection from `failDelivery` itself.

If `failDelivery` rejects (e.g. queue storage write fails), the entry's retry count is never incremented, recovery may retry the un-acked entry, and the operator gets no journal-facing hint that anything went wrong. This is inconsistent with the surrounding `ackDelivery` path (~lines 1305-1316) which logs warnings via `log.warn` + `formatErrorMessage`.

## Fix

Replace the silent `.catch(() => {})` with a `log.warn` that includes:

- the queue id
- a hint that the queue entry may be retried
- `formatErrorMessage(err)` for the underlying cause

This matches the existing `ackDelivery` warning style. The non-required best-effort branch keeps continuing (no rethrow) so behavior on success paths is unchanged — only the silent-failure observability gap is closed.

## Test

Added regression test `logs a warning when failDelivery itself rejects on bestEffort partial failure` in `src/infra/outbound/deliver.test.ts` that mocks `failDelivery` to reject and asserts the warn line contains the queue id and underlying error message.

```
node scripts/run-vitest.mjs src/infra/outbound/deliver.test.ts
# 83 tests passed (1 new)
```

Lint clean (`oxlint`), no other call sites touched. Narrowly scoped to the specifically-flagged path; the other `failDelivery(...).catch(() => {})` on line ~1328 is a different control flow (the outer catch already has a logged error to work from) and is intentionally left untouched to keep the PR small.

## Found by

Codebase audit (finding F019), reported in #83113.