### PR TITLE
fix(gateway): preserve raw external session aliases

### DIFF
--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -133,6 +133,7 @@ import {
   migrateAndPruneGatewaySessionStoreKey,
   resolveGatewayModelSupportsImages,
   resolveSessionModelRef,
+  writeGatewaySessionStoreEntry,
 } from "../session-utils.js";
 import { formatForLog } from "../ws-log.js";
 import { waitForAgentJob } from "./agent-job.js";
@@ -1272,13 +1273,18 @@ export const agentHandlers: GatewayRequestHandlers = {
         if (storePath) {
           const requestedStoreKey = requestedSessionKey;
           const persisted = await updateSessionStore(storePath, (store) => {
-            const { primaryKey } = migrateAndPruneGatewaySessionStoreKey({
+            const { preservedAliasKeys, primaryKey } = migrateAndPruneGatewaySessionStoreKey({
               cfg,
               key: requestedStoreKey,
               store,
             });
             const merged = mergeSessionEntry(store[primaryKey], nextEntryPatch);
-            store[primaryKey] = merged;
+            writeGatewaySessionStoreEntry({
+              store,
+              primaryKey,
+              aliasKeys: preservedAliasKeys,
+              entry: merged,
+            });
             return merged;
           });
           sessionEntry = persisted;

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -108,6 +108,7 @@ import {
   resolveSessionModelRef,
   resolveSessionTranscriptCandidates,
   syncGatewaySessionStoreAliases,
+  writeGatewaySessionStoreEntry,
   type SessionsPatchResult,
   type SessionsPreviewEntry,
   type SessionsPreviewResult,
@@ -1646,7 +1647,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       return;
     }
     const loaded = loadSessionEntry(key);
-    const { entry, canonicalKey, storePath } = loaded;
+    const { cfg, entry, canonicalKey, storePath } = loaded;
     if (!entry?.sessionId) {
       respond(
         false,
@@ -1699,7 +1700,17 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     });
 
     await updateSessionStore(storePath, (store) => {
-      store[canonicalKey] = nextEntry;
+      const { preservedAliasKeys, primaryKey } = migrateAndPruneGatewaySessionStoreKey({
+        cfg,
+        key,
+        store,
+      });
+      writeGatewaySessionStoreEntry({
+        store,
+        primaryKey,
+        aliasKeys: preservedAliasKeys,
+        entry: nextEntry,
+      });
     });
 
     respond(

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -2251,8 +2251,12 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     );
     // Lock + read in a short critical section; transcript work happens outside.
     const compactTarget = await updateSessionStore(storePath, (store) => {
-      const { entry, primaryKey } = migrateAndPruneGatewaySessionStoreKey({ cfg, key, store });
-      return { entry, primaryKey };
+      const { entry, preservedAliasKeys, primaryKey } = migrateAndPruneGatewaySessionStoreKey({
+        cfg,
+        key,
+        store,
+      });
+      return { entry, preservedAliasKeys, primaryKey };
     });
     const entry = compactTarget.entry;
     const sessionId = entry?.sessionId;
@@ -2384,6 +2388,12 @@ export const sessionsHandlers: GatewayRequestHandlers = {
             delete entryToUpdate.totalTokens;
             delete entryToUpdate.totalTokensFresh;
           }
+          writeGatewaySessionStoreEntry({
+            store,
+            primaryKey: entryKey,
+            aliasKeys: compactTarget.preservedAliasKeys,
+            entry: entryToUpdate,
+          });
         });
       }
 
@@ -2445,6 +2455,12 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       delete entryToUpdate.totalTokens;
       delete entryToUpdate.totalTokensFresh;
       entryToUpdate.updatedAt = Date.now();
+      writeGatewaySessionStoreEntry({
+        store,
+        primaryKey: entryKey,
+        aliasKeys: compactTarget.preservedAliasKeys,
+        entry: entryToUpdate,
+      });
     });
 
     respond(

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -91,6 +91,7 @@ import { reactivateCompletedSubagentSession } from "../session-subagent-reactiva
 import {
   archiveFileOnDisk,
   buildGatewaySessionRow,
+  deleteGatewaySessionStoreEntry,
   listSessionsFromStoreAsync,
   loadCombinedSessionStoreForGateway,
   loadGatewaySessionRow,
@@ -106,6 +107,7 @@ import {
   resolveSessionDisplayModelIdentityRef,
   resolveSessionModelRef,
   resolveSessionTranscriptCandidates,
+  syncGatewaySessionStoreAliases,
   type SessionsPatchResult,
   type SessionsPreviewEntry,
   type SessionsPreviewResult,
@@ -1908,14 +1910,26 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       context.getRuntimeConfig(),
     );
     const applied = await updateSessionStore(storePath, async (store) => {
-      const { primaryKey } = migrateAndPruneGatewaySessionStoreKey({ cfg, key, store });
-      return await applySessionsPatchToStore({
+      const { preservedAliasKeys, primaryKey } = migrateAndPruneGatewaySessionStoreKey({
+        cfg,
+        key,
+        store,
+      });
+      const applied = await applySessionsPatchToStore({
         cfg,
         store,
         storeKey: primaryKey,
         patch: p,
         loadGatewayModelCatalog: context.loadGatewayModelCatalog,
       });
+      if (applied.ok) {
+        syncGatewaySessionStoreAliases({
+          store,
+          primaryKey,
+          aliasKeys: preservedAliasKeys,
+        });
+      }
+      return applied;
     });
     if (!applied.ok) {
       respond(false, undefined, applied.error);
@@ -2120,12 +2134,16 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     }
     const sessionId = entry?.sessionId;
     const deleted = await updateSessionStore(storePath, (store) => {
-      const { primaryKey } = migrateAndPruneGatewaySessionStoreKey({ cfg, key, store });
-      const hadEntry = Boolean(store[primaryKey]);
-      if (hadEntry) {
-        delete store[primaryKey];
-      }
-      return hadEntry;
+      const { preservedAliasKeys, primaryKey } = migrateAndPruneGatewaySessionStoreKey({
+        cfg,
+        key,
+        store,
+      });
+      return deleteGatewaySessionStoreEntry({
+        store,
+        primaryKey,
+        aliasKeys: preservedAliasKeys,
+      });
     });
 
     const archivedTranscripts =

--- a/src/gateway/server-node-events.runtime.ts
+++ b/src/gateway/server-node-events.runtime.ts
@@ -22,5 +22,6 @@ export {
   migrateAndPruneGatewaySessionStoreKey,
   resolveGatewayModelSupportsImages,
   resolveSessionModelRef,
+  writeGatewaySessionStoreEntry,
 } from "./session-utils.js";
 export { formatForLog } from "./ws-log.js";

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -87,6 +87,7 @@ const runtimeMocks = vi.hoisted(() => ({
       target: { canonicalKey: key, storeKeys: [key] },
       primaryKey: key,
       entry: store[key],
+      preservedAliasKeys: [],
     }),
   ),
   normalizeChannelId: normalizeChannelIdMock,
@@ -134,6 +135,26 @@ const runtimeMocks = vi.hoisted(() => ({
       : wakeOptions;
   }),
   updateSessionStore: vi.fn(),
+  writeGatewaySessionStoreEntry: vi.fn(
+    ({
+      aliasKeys,
+      entry,
+      primaryKey,
+      store,
+    }: {
+      aliasKeys: Iterable<string>;
+      entry: unknown;
+      primaryKey: string;
+      store: Record<string, unknown>;
+    }) => {
+      store[primaryKey] = entry;
+      for (const aliasKey of aliasKeys) {
+        if (aliasKey !== primaryKey) {
+          store[aliasKey] = entry;
+        }
+      }
+    },
+  ),
 }));
 
 vi.mock("./server-node-events.runtime.js", () => runtimeMocks);

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -41,6 +41,7 @@ import {
   scopedHeartbeatWakeOptions,
   sendDurableMessageBatch,
   updateSessionStore,
+  writeGatewaySessionStoreEntry,
 } from "./server-node-events.runtime.js";
 
 const MAX_EXEC_EVENT_OUTPUT_CHARS = 180;
@@ -249,26 +250,31 @@ async function touchSessionStore(params: {
     return;
   }
   await updateSessionStore(storePath, (store) => {
-    const { primaryKey } = migrateAndPruneGatewaySessionStoreKey({
+    const { preservedAliasKeys, primaryKey } = migrateAndPruneGatewaySessionStoreKey({
       cfg: params.cfg,
       key: params.sessionKey,
       store,
     });
-    store[primaryKey] = {
-      ...store[primaryKey],
-      sessionId: params.sessionId,
-      updatedAt: params.now,
-      thinkingLevel: params.entry?.thinkingLevel,
-      fastMode: params.entry?.fastMode,
-      verboseLevel: params.entry?.verboseLevel,
-      reasoningLevel: params.entry?.reasoningLevel,
-      systemSent: params.entry?.systemSent,
-      sendPolicy: params.entry?.sendPolicy,
-      lastChannel: params.entry?.lastChannel,
-      lastTo: params.entry?.lastTo,
-      lastAccountId: params.entry?.lastAccountId,
-      lastThreadId: params.entry?.lastThreadId,
-    };
+    writeGatewaySessionStoreEntry({
+      store,
+      primaryKey,
+      aliasKeys: preservedAliasKeys,
+      entry: {
+        ...store[primaryKey],
+        sessionId: params.sessionId,
+        updatedAt: params.now,
+        thinkingLevel: params.entry?.thinkingLevel,
+        fastMode: params.entry?.fastMode,
+        verboseLevel: params.entry?.verboseLevel,
+        reasoningLevel: params.entry?.reasoningLevel,
+        systemSent: params.entry?.systemSent,
+        sendPolicy: params.entry?.sendPolicy,
+        lastChannel: params.entry?.lastChannel,
+        lastTo: params.entry?.lastTo,
+        lastAccountId: params.entry?.lastAccountId,
+        lastThreadId: params.entry?.lastThreadId,
+      },
+    });
   });
 }
 

--- a/src/gateway/server.sessions.compaction.test.ts
+++ b/src/gateway/server.sessions.compaction.test.ts
@@ -443,6 +443,151 @@ test("sessions.compact without maxLines runs embedded manual compaction for chec
   ws.close();
 });
 
+test("sessions.compact synchronizes raw external aliases after manual compaction", async () => {
+  const { dir, storePath } = await createSessionStoreDir();
+  const rawKey = "conversation:pair:user_a::user_b:space:space_123";
+  const canonicalKey = `agent:main:${rawKey}`;
+  const sessionFile = path.join(dir, "sess-raw-manual.jsonl");
+  await fs.writeFile(
+    sessionFile,
+    `${JSON.stringify({ role: "user", content: "hello" })}\n`,
+    "utf-8",
+  );
+  const entry = sessionStoreEntry("sess-raw-manual", {
+    sessionFile,
+    inputTokens: 7,
+    outputTokens: 11,
+    totalTokens: 120,
+    totalTokensFresh: false,
+  });
+  await writeSessionStore({
+    entries: {
+      [canonicalKey]: entry,
+      [rawKey]: { ...entry },
+    },
+  });
+
+  const { ws } = await openClient();
+  const compacted = await rpcReq<{
+    ok: true;
+    key: string;
+    compacted: boolean;
+    result?: { tokensAfter?: number };
+  }>(ws, "sessions.compact", {
+    key: rawKey,
+  });
+
+  expect(compacted.ok).toBe(true);
+  expect(compacted.payload?.key).toBe(canonicalKey);
+  expect(compacted.payload?.compacted).toBe(true);
+  expect(embeddedRunMock.compactEmbeddedPiSession).toHaveBeenCalledTimes(1);
+
+  const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+    string,
+    {
+      compactionCount?: number;
+      inputTokens?: number;
+      outputTokens?: number;
+      sessionId?: string;
+      totalTokens?: number;
+      totalTokensFresh?: boolean;
+    }
+  >;
+  expect(store[canonicalKey]?.sessionId).toBe("sess-raw-manual");
+  expect(store[rawKey]).toEqual(store[canonicalKey]);
+  expect(store[canonicalKey]?.compactionCount).toBe(1);
+  expect(store[rawKey]?.compactionCount).toBe(1);
+  expect(store[canonicalKey]?.totalTokens).toBe(80);
+  expect(store[rawKey]?.totalTokens).toBe(80);
+  expect(store[canonicalKey]?.totalTokensFresh).toBe(true);
+  expect(store[rawKey]?.totalTokensFresh).toBe(true);
+  expect("inputTokens" in store[canonicalKey]).toBe(false);
+  expect("outputTokens" in store[rawKey]).toBe(false);
+
+  const listedSessions = await rpcReq<{ sessions: Array<{ key: string }> }>(ws, "sessions.list");
+  expect(listedSessions.ok).toBe(true);
+  expect(
+    listedSessions.payload?.sessions
+      .map((session) => session.key)
+      .filter((key) => key === canonicalKey || key === rawKey),
+  ).toEqual([canonicalKey]);
+
+  ws.close();
+});
+
+test("sessions.compact maxLines synchronizes raw external aliases", async () => {
+  const { dir, storePath } = await createSessionStoreDir();
+  const rawKey = "conversation:pair:user_a::user_b:space:space_123";
+  const canonicalKey = `agent:main:${rawKey}`;
+  const sessionFile = path.join(dir, "sess-raw-lines.jsonl");
+  await fs.writeFile(
+    sessionFile,
+    [
+      JSON.stringify({ role: "user", content: "one" }),
+      JSON.stringify({ role: "assistant", content: "two" }),
+      JSON.stringify({ role: "user", content: "three" }),
+    ].join("\n") + "\n",
+    "utf-8",
+  );
+  const entry = sessionStoreEntry("sess-raw-lines", {
+    sessionFile,
+    inputTokens: 7,
+    outputTokens: 11,
+    totalTokens: 120,
+    totalTokensFresh: true,
+  });
+  await writeSessionStore({
+    entries: {
+      [canonicalKey]: entry,
+      [rawKey]: { ...entry },
+    },
+  });
+
+  const { ws } = await openClient();
+  const compacted = await rpcReq<{
+    ok: true;
+    key: string;
+    compacted: boolean;
+    kept?: number;
+  }>(ws, "sessions.compact", {
+    key: rawKey,
+    maxLines: 2,
+  });
+
+  expect(compacted.ok).toBe(true);
+  expect(compacted.payload?.key).toBe(canonicalKey);
+  expect(compacted.payload?.compacted).toBe(true);
+  expect(compacted.payload?.kept).toBe(2);
+  expect(embeddedRunMock.compactEmbeddedPiSession).not.toHaveBeenCalled();
+
+  const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+    string,
+    {
+      inputTokens?: number;
+      outputTokens?: number;
+      sessionId?: string;
+      totalTokens?: number;
+      totalTokensFresh?: boolean;
+    }
+  >;
+  expect(store[canonicalKey]?.sessionId).toBe("sess-raw-lines");
+  expect(store[rawKey]).toEqual(store[canonicalKey]);
+  expect("inputTokens" in store[canonicalKey]).toBe(false);
+  expect("outputTokens" in store[rawKey]).toBe(false);
+  expect("totalTokens" in store[canonicalKey]).toBe(false);
+  expect("totalTokensFresh" in store[rawKey]).toBe(false);
+
+  const listedSessions = await rpcReq<{ sessions: Array<{ key: string }> }>(ws, "sessions.list");
+  expect(listedSessions.ok).toBe(true);
+  expect(
+    listedSessions.payload?.sessions
+      .map((session) => session.key)
+      .filter((key) => key === canonicalKey || key === rawKey),
+  ).toEqual([canonicalKey]);
+
+  ws.close();
+});
+
 test("sessions.patch preserves nested model ids under provider overrides", async () => {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-sessions-nested-"));
   const storePath = path.join(dir, "sessions.json");

--- a/src/gateway/server.sessions.compaction.test.ts
+++ b/src/gateway/server.sessions.compaction.test.ts
@@ -210,6 +210,9 @@ test("sessions.compaction.* lists checkpoints and branches or restores from pre-
     restoreSessionManagerOpenSpy.mockRestore();
     restoreSessionManagerForkFromSpy.mockRestore();
   }
+  if (!restored.ok) {
+    throw new Error(`restore failed: ${JSON.stringify(restored.error)}`);
+  }
   expect(restored.ok).toBe(true);
   expect(restored.payload?.key).toBe("agent:main:main");
   expect(restored.payload?.sessionId).not.toBe(fixture.sessionId);
@@ -229,6 +232,80 @@ test("sessions.compaction.* lists checkpoints and branches or restores from pre-
   >;
   expect(storeAfterRestore["agent:main:main"]?.sessionId).toBe(restored.payload?.sessionId);
   expect(storeAfterRestore["agent:main:main"]?.compactionCheckpoints).toHaveLength(1);
+
+  ws.close();
+});
+
+test("sessions.compaction.restore synchronizes raw external session aliases", async () => {
+  const { dir, storePath } = await createSessionStoreDir();
+  const fixture = await createCheckpointFixture(dir);
+  const rawKey = "conversation:pair:user_a::user_b:space:space_123";
+  const canonicalKey = `agent:main:${rawKey}`;
+  const checkpointCreatedAt = Date.now();
+  const checkpoint = {
+    checkpointId: "checkpoint-raw",
+    sessionKey: canonicalKey,
+    sessionId: fixture.sessionId,
+    createdAt: checkpointCreatedAt,
+    reason: "manual" as const,
+    tokensBefore: 123,
+    preCompaction: {
+      sessionId: fixture.preCompactionSession.getSessionId(),
+      sessionFile: fixture.preCompactionSessionFile,
+      leafId: fixture.preCompactionLeafId,
+    },
+    postCompaction: {
+      sessionId: fixture.sessionId,
+      sessionFile: fixture.sessionFile,
+      leafId: fixture.postCompactionLeafId,
+    },
+  };
+  const entry = sessionStoreEntry(fixture.sessionId, {
+    sessionFile: fixture.sessionFile,
+    compactionCheckpoints: [checkpoint],
+  });
+  await writeSessionStore({
+    entries: {
+      [canonicalKey]: entry,
+      [rawKey]: { ...entry },
+    },
+  });
+
+  const { ws } = await openClient();
+  const restored = await rpcReq<{
+    ok: true;
+    key: string;
+    sessionId: string;
+    entry: { sessionId: string; compactionCheckpoints?: unknown[] };
+  }>(ws, "sessions.compaction.restore", {
+    key: rawKey,
+    checkpointId: "checkpoint-raw",
+  });
+
+  if (!restored.ok) {
+    throw new Error(`restore failed: ${JSON.stringify(restored.error)}`);
+  }
+  expect(restored.ok).toBe(true);
+  expect(restored.payload?.key).toBe(canonicalKey);
+  expect(restored.payload?.sessionId).not.toBe(fixture.sessionId);
+
+  const storeAfterRestore = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+    string,
+    { compactionCheckpoints?: unknown[]; sessionId?: string }
+  >;
+  expect(storeAfterRestore[canonicalKey]?.sessionId).toBe(restored.payload?.sessionId);
+  expect(storeAfterRestore[rawKey]?.sessionId).toBe(restored.payload?.sessionId);
+  expect(storeAfterRestore[rawKey]?.compactionCheckpoints).toEqual(
+    storeAfterRestore[canonicalKey]?.compactionCheckpoints,
+  );
+
+  const listedSessions = await rpcReq<{ sessions: Array<{ key: string }> }>(ws, "sessions.list");
+  expect(listedSessions.ok).toBe(true);
+  expect(
+    listedSessions.payload?.sessions
+      .map((session) => session.key)
+      .filter((key) => key === canonicalKey || key === rawKey),
+  ).toEqual([canonicalKey]);
 
   ws.close();
 });

--- a/src/gateway/server.sessions.reset-cleanup.test.ts
+++ b/src/gateway/server.sessions.reset-cleanup.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import { expect, test, vi } from "vitest";
+import { clearSessionStoreCacheForTest } from "../config/sessions/store.js";
 import { enqueueSystemEvent, peekSystemEvents } from "../infra/system-events.js";
 import { embeddedRunMock, writeSessionStore } from "./test-helpers.js";
 import {
@@ -19,6 +20,14 @@ import {
 } from "./test/server-sessions.test-helpers.js";
 
 const { createSessionStoreDir, seedActiveMainSession } = setupGatewaySessionsTestHarness();
+
+async function writeRawSessionStore(
+  storePath: string,
+  entries: Record<string, Record<string, unknown>>,
+) {
+  await fs.writeFile(storePath, JSON.stringify(entries, null, 2), "utf-8");
+  clearSessionStoreCacheForTest();
+}
 
 function expectResetAcpState(
   acp:
@@ -106,6 +115,37 @@ test("sessions.reset aborts active runs and clears queues", async () => {
     targetSessionKey: "agent:main:main",
     reason: "session-reset",
   });
+});
+
+test("sessions.reset updates preserved raw external aliases", async () => {
+  const { storePath } = await createSessionStoreDir();
+  await writeSessionStore({ entries: {}, storePath });
+  const rawKey = "conversation:pair:user_a::user_b:space:space_123";
+  const canonicalKey = `agent:main:${rawKey}`;
+  await writeRawSessionStore(storePath, {
+    [rawKey]: {
+      sessionId: "sess-raw",
+      updatedAt: 1,
+    },
+  });
+
+  const reset = await directSessionReq<{
+    ok: true;
+    key: string;
+    entry: { sessionId: string };
+  }>("sessions.reset", {
+    key: rawKey,
+  });
+
+  expect(reset.ok).toBe(true);
+  expect(reset.payload?.key).toBe(canonicalKey);
+  expect(reset.payload?.entry.sessionId).not.toBe("sess-raw");
+  const storeAfterReset = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+    string,
+    { sessionId?: string }
+  >;
+  expect(storeAfterReset[canonicalKey]?.sessionId).toBe(reset.payload?.entry.sessionId);
+  expect(storeAfterReset[rawKey]?.sessionId).toBe(reset.payload?.entry.sessionId);
 });
 
 test("sessions.reset closes ACP runtime handles for ACP sessions", async () => {

--- a/src/gateway/server.sessions.store-rpc.test.ts
+++ b/src/gateway/server.sessions.store-rpc.test.ts
@@ -490,15 +490,43 @@ test("sessions.patch and sessions.delete keep raw external aliases in sync", asy
   expect(patched.payload?.entry.sendPolicy).toBe("deny");
   const storeAfterPatch = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
     string,
-    { sessionId?: string; sendPolicy?: string }
+    { label?: string; sessionId?: string; sendPolicy?: string }
   >;
   expect(storeAfterPatch[canonicalKey]?.sessionId).toBe("sess-raw");
   expect(storeAfterPatch[canonicalKey]?.sendPolicy).toBe("deny");
   expect(storeAfterPatch[rawKey]?.sessionId).toBe("sess-raw");
   expect(storeAfterPatch[rawKey]?.sendPolicy).toBe("deny");
 
+  const listed = await directSessionHandlerReq<{ sessions: Array<{ key: string }> }>(
+    "sessions.list",
+    {},
+  );
+  expect(listed.ok).toBe(true);
+  expect(listed.payload?.sessions.map((session) => session.key)).toEqual([canonicalKey]);
+  const visibleKey = listed.payload?.sessions[0]?.key;
+  expect(visibleKey).toBe(canonicalKey);
+
+  const patchedVisible = await directSessionHandlerReq<{
+    ok: true;
+    key: string;
+    entry: { label?: string; sessionId?: string; sendPolicy?: string };
+  }>("sessions.patch", {
+    key: visibleKey,
+    label: "Canonical visible row",
+  });
+  expect(patchedVisible.ok).toBe(true);
+  expect(patchedVisible.payload?.key).toBe(canonicalKey);
+  expect(patchedVisible.payload?.entry.label).toBe("Canonical visible row");
+  const storeAfterVisiblePatch = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+    string,
+    { label?: string; sessionId?: string; sendPolicy?: string }
+  >;
+  expect(storeAfterVisiblePatch[canonicalKey]?.label).toBe("Canonical visible row");
+  expect(storeAfterVisiblePatch[rawKey]?.label).toBe("Canonical visible row");
+  expect(storeAfterVisiblePatch[rawKey]?.sendPolicy).toBe("deny");
+
   const deleted = await directSessionHandlerReq<{ ok: true; deleted: boolean }>("sessions.delete", {
-    key: rawKey,
+    key: visibleKey,
     deleteTranscript: false,
   });
   expect(deleted.ok).toBe(true);

--- a/src/gateway/server.sessions.store-rpc.test.ts
+++ b/src/gateway/server.sessions.store-rpc.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { expect, test, vi } from "vitest";
+import { clearSessionStoreCacheForTest } from "../config/sessions/store.js";
 import { piSdkMock, rpcReq, testState, writeSessionStore } from "./test-helpers.js";
 import {
   directSessionReq as directSessionHandlerReq,
@@ -30,6 +31,14 @@ function expectSinglePrefixedFilename(files: string[], prefix: string): string {
   }
   expect(match.length).toBeGreaterThan(prefix.length);
   return match;
+}
+
+async function writeRawSessionStore(
+  storePath: string,
+  entries: Record<string, Record<string, unknown>>,
+) {
+  await fs.writeFile(storePath, JSON.stringify(entries, null, 2), "utf-8");
+  clearSessionStoreCacheForTest();
 }
 
 test("lists and patches session store via sessions.* RPC", async () => {
@@ -453,6 +462,53 @@ test("lists and patches session store via sessions.* RPC", async () => {
   expect((badThinking.error as { message?: unknown } | undefined)?.message ?? "").toMatch(
     /invalid thinkinglevel/i,
   );
+});
+
+test("sessions.patch and sessions.delete keep raw external aliases in sync", async () => {
+  const { storePath } = await createSessionStoreDir();
+  await writeSessionStore({ entries: {}, storePath });
+  const rawKey = "conversation:pair:user_a::user_b:space:space_123";
+  const canonicalKey = `agent:main:${rawKey}`;
+  await writeRawSessionStore(storePath, {
+    [rawKey]: {
+      sessionId: "sess-raw",
+      updatedAt: 1,
+    },
+  });
+
+  const patched = await directSessionHandlerReq<{
+    ok: true;
+    key: string;
+    entry: { sessionId?: string; sendPolicy?: string };
+  }>("sessions.patch", {
+    key: rawKey,
+    sendPolicy: "deny",
+  });
+  expect(patched.ok).toBe(true);
+  expect(patched.payload?.key).toBe(canonicalKey);
+  expect(patched.payload?.entry.sessionId).toBe("sess-raw");
+  expect(patched.payload?.entry.sendPolicy).toBe("deny");
+  const storeAfterPatch = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+    string,
+    { sessionId?: string; sendPolicy?: string }
+  >;
+  expect(storeAfterPatch[canonicalKey]?.sessionId).toBe("sess-raw");
+  expect(storeAfterPatch[canonicalKey]?.sendPolicy).toBe("deny");
+  expect(storeAfterPatch[rawKey]?.sessionId).toBe("sess-raw");
+  expect(storeAfterPatch[rawKey]?.sendPolicy).toBe("deny");
+
+  const deleted = await directSessionHandlerReq<{ ok: true; deleted: boolean }>("sessions.delete", {
+    key: rawKey,
+    deleteTranscript: false,
+  });
+  expect(deleted.ok).toBe(true);
+  expect(deleted.payload?.deleted).toBe(true);
+  const storeAfterDelete = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+    string,
+    unknown
+  >;
+  expect(storeAfterDelete[canonicalKey]).toBeUndefined();
+  expect(storeAfterDelete[rawKey]).toBeUndefined();
 });
 
 test("sessions.list configuredAgentsOnly keeps configured-agent children and hides unrelated stores", async () => {

--- a/src/gateway/session-compaction-checkpoints.test.ts
+++ b/src/gateway/session-compaction-checkpoints.test.ts
@@ -492,4 +492,62 @@ describe("session-compaction-checkpoints", () => {
       Object.values(nextStore).find((entry) => entry.compactionCheckpoints)?.compactionCheckpoints,
     ).toHaveLength(25);
   });
+
+  test("persist synchronizes raw external aliases with checkpoint metadata", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-checkpoint-alias-"));
+    tempDirs.push(dir);
+
+    const storePath = path.join(dir, "sessions.json");
+    const rawKey = "conversation:pair:user_a::user_b:space:space_123";
+    const canonicalKey = `agent:main:${rawKey}`;
+    const sessionId = "sess-alias";
+    const now = Date.now();
+    const baseEntry = { sessionId, updatedAt: now };
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          [canonicalKey]: baseEntry,
+          [rawKey]: baseEntry,
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const snapshotFile = path.join(
+      dir,
+      "sess-alias.checkpoint.99999999-9999-4999-8999-999999999999.jsonl",
+    );
+    await fs.writeFile(snapshotFile, "current", "utf-8");
+
+    const stored = await persistSessionCompactionCheckpoint({
+      cfg: {
+        session: { store: storePath },
+        agents: { list: [{ id: "main", default: true }] },
+      } as OpenClawConfig,
+      sessionKey: rawKey,
+      sessionId,
+      reason: "manual",
+      snapshot: {
+        sessionId,
+        sessionFile: snapshotFile,
+        leafId: "current-leaf",
+      },
+      createdAt: now + 100,
+    });
+
+    expect(stored?.sessionKey).toBe(canonicalKey);
+    const nextStore = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+      string,
+      { compactionCheckpoints?: unknown[]; sessionId?: string }
+    >;
+    expect(nextStore[canonicalKey]?.sessionId).toBe(sessionId);
+    expect(nextStore[rawKey]?.sessionId).toBe(sessionId);
+    expect(nextStore[canonicalKey]?.compactionCheckpoints).toHaveLength(1);
+    expect(nextStore[rawKey]?.compactionCheckpoints).toEqual(
+      nextStore[canonicalKey]?.compactionCheckpoints,
+    );
+  });
 });

--- a/src/gateway/session-compaction-checkpoints.ts
+++ b/src/gateway/session-compaction-checkpoints.ts
@@ -17,7 +17,11 @@ import { isCompactionCheckpointTranscriptFileName } from "../config/sessions/art
 import { streamSessionTranscriptLines } from "../config/sessions/transcript-stream.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { resolveGatewaySessionStoreTarget } from "./session-utils.js";
+import {
+  migrateAndPruneGatewaySessionStoreKey,
+  resolveGatewaySessionStoreTarget,
+  writeGatewaySessionStoreEntry,
+} from "./session-utils.js";
 
 const log = createSubsystemLogger("gateway/session-compaction-checkpoints");
 const MAX_COMPACTION_CHECKPOINTS_PER_SESSION = 25;
@@ -444,18 +448,31 @@ export async function persistSessionCompactionCheckpoint(params: {
       }
     | undefined;
   await updateSessionStore(target.storePath, (store) => {
-    const existing = store[target.canonicalKey];
+    const {
+      entry: existing,
+      preservedAliasKeys,
+      primaryKey,
+    } = migrateAndPruneGatewaySessionStoreKey({
+      cfg: params.cfg,
+      key: params.sessionKey,
+      store,
+    });
     if (!existing?.sessionId) {
       return;
     }
     const checkpoints = sessionStoreCheckpoints(existing);
     checkpoints.push(checkpoint);
     trimmedCheckpoints = trimSessionCheckpoints(checkpoints);
-    store[target.canonicalKey] = {
-      ...existing,
-      updatedAt: Math.max(existing.updatedAt ?? 0, createdAt),
-      compactionCheckpoints: trimmedCheckpoints.kept,
-    };
+    writeGatewaySessionStoreEntry({
+      store,
+      primaryKey,
+      aliasKeys: preservedAliasKeys,
+      entry: {
+        ...existing,
+        updatedAt: Math.max(existing.updatedAt ?? 0, createdAt),
+        compactionCheckpoints: trimmedCheckpoints.kept,
+      },
+    });
     stored = true;
   });
 

--- a/src/gateway/session-reset-service.ts
+++ b/src/gateway/session-reset-service.ts
@@ -59,6 +59,7 @@ import {
   readSessionMessagesAsync,
   resolveGatewaySessionStoreTarget,
   resolveSessionModelRef,
+  writeGatewaySessionStoreEntry,
 } from "./session-utils.js";
 
 const ACP_RUNTIME_CLEANUP_TIMEOUT_MS = 15_000;
@@ -690,7 +691,7 @@ export async function performGatewaySessionReset(params: {
   let oldSessionFile: string | undefined;
   let resetSourceEntry: SessionEntry | undefined;
   const next = await updateSessionStore(storePath, (store) => {
-    const { primaryKey } = migrateAndPruneGatewaySessionStoreKey({
+    const { preservedAliasKeys, primaryKey } = migrateAndPruneGatewaySessionStoreKey({
       cfg,
       key: params.key,
       store,
@@ -799,7 +800,12 @@ export async function performGatewaySessionReset(params: {
     if (!isSubagentSessionKey(primaryKey)) {
       clearAllCliSessions(nextEntry);
     }
-    store[primaryKey] = nextEntry;
+    writeGatewaySessionStoreEntry({
+      store,
+      primaryKey,
+      aliasKeys: preservedAliasKeys,
+      entry: nextEntry,
+    });
     return nextEntry;
   });
   await emitGatewayBeforeResetPluginHook({

--- a/src/gateway/session-store-aliases.ts
+++ b/src/gateway/session-store-aliases.ts
@@ -1,0 +1,152 @@
+import type { SessionEntry } from "../config/sessions.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { normalizeMainKey, parseAgentSessionKey } from "../routing/session-key.js";
+import { normalizeSessionKeyPreservingOpaquePeerIds } from "../sessions/session-key-utils.js";
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalString,
+} from "../shared/string-coerce.js";
+
+function resolvePreservedRawExternalStoreKeyCandidate(params: {
+  cfg: OpenClawConfig;
+  key: string;
+  canonicalKey: string;
+}): string | undefined {
+  const key = normalizeSessionKeyPreservingOpaquePeerIds(params.key);
+  if (!key || key === params.canonicalKey || !key.includes(":")) {
+    return undefined;
+  }
+  const lowered = normalizeLowercaseStringOrEmpty(key);
+  const mainKey = normalizeMainKey(params.cfg.session?.mainKey);
+  if (
+    lowered === "global" ||
+    lowered === "unknown" ||
+    lowered === "main" ||
+    lowered === mainKey ||
+    lowered.startsWith("agent:") ||
+    parseAgentSessionKey(key)
+  ) {
+    return undefined;
+  }
+  return key;
+}
+
+function resolveAgentSessionRestPreservingSeparators(key: string): string | undefined {
+  const normalized = normalizeSessionKeyPreservingOpaquePeerIds(key);
+  const match = /^agent:([^:]+):(.+)$/.exec(normalized);
+  const rest = match?.[2];
+  return rest ? rest : undefined;
+}
+
+export function resolvePreservedRawExternalStoreKey(params: {
+  cfg: OpenClawConfig;
+  key: string;
+  canonicalKey: string;
+}): { key: string; preserveMissingAlias: boolean } | undefined {
+  const directKey = resolvePreservedRawExternalStoreKeyCandidate(params);
+  if (directKey) {
+    return { key: directKey, preserveMissingAlias: true };
+  }
+  const canonicalRest = resolveAgentSessionRestPreservingSeparators(params.canonicalKey);
+  if (!canonicalRest) {
+    return undefined;
+  }
+  const canonicalRawKey = resolvePreservedRawExternalStoreKeyCandidate({
+    cfg: params.cfg,
+    key: canonicalRest,
+    canonicalKey: params.canonicalKey,
+  });
+  return canonicalRawKey ? { key: canonicalRawKey, preserveMissingAlias: false } : undefined;
+}
+
+export function normalizeSessionStoreKeys(keys: Iterable<string | undefined>): string[] {
+  const normalized = new Set<string>();
+  for (const key of keys) {
+    const trimmed = normalizeOptionalString(key ?? "") ?? "";
+    if (trimmed) {
+      normalized.add(trimmed);
+    }
+  }
+  return Array.from(normalized);
+}
+
+export function resolvePreservedRawExternalAliasKeys(params: {
+  preservedRawKey: string | undefined;
+  preserveMissingAlias: boolean;
+  storeKeys: Iterable<string>;
+}): string[] {
+  if (!params.preservedRawKey) {
+    return [];
+  }
+  const aliases = Array.from(params.storeKeys).filter(
+    (key) => normalizeSessionKeyPreservingOpaquePeerIds(key) === params.preservedRawKey,
+  );
+  if (!params.preserveMissingAlias && aliases.length === 0) {
+    return [];
+  }
+  aliases.push(params.preservedRawKey);
+  return normalizeSessionStoreKeys(aliases);
+}
+
+export function resolveGatewaySessionStorePreservedAliasKeys(params: {
+  cfg: OpenClawConfig;
+  key: string;
+  canonicalKey: string;
+  storeKeys: Iterable<string>;
+}): string[] {
+  const preservedRaw = resolvePreservedRawExternalStoreKey({
+    cfg: params.cfg,
+    key: params.key,
+    canonicalKey: params.canonicalKey,
+  });
+  return resolvePreservedRawExternalAliasKeys({
+    preservedRawKey: preservedRaw?.key,
+    preserveMissingAlias: preservedRaw?.preserveMissingAlias === true,
+    storeKeys: params.storeKeys,
+  });
+}
+
+export function syncGatewaySessionStoreAliases(params: {
+  store: Record<string, SessionEntry>;
+  primaryKey: string;
+  aliasKeys: Iterable<string>;
+}) {
+  const entry = params.store[params.primaryKey];
+  if (!entry) {
+    return;
+  }
+  for (const aliasKey of normalizeSessionStoreKeys(params.aliasKeys)) {
+    if (aliasKey !== params.primaryKey) {
+      params.store[aliasKey] = entry;
+    }
+  }
+}
+
+export function writeGatewaySessionStoreEntry(params: {
+  store: Record<string, SessionEntry>;
+  primaryKey: string;
+  aliasKeys: Iterable<string>;
+  entry: SessionEntry;
+}) {
+  params.store[params.primaryKey] = params.entry;
+  syncGatewaySessionStoreAliases({
+    store: params.store,
+    primaryKey: params.primaryKey,
+    aliasKeys: params.aliasKeys,
+  });
+}
+
+export function deleteGatewaySessionStoreEntry(params: {
+  store: Record<string, SessionEntry>;
+  primaryKey: string;
+  aliasKeys: Iterable<string>;
+}): boolean {
+  let hadEntry = false;
+  for (const key of normalizeSessionStoreKeys([params.primaryKey, ...params.aliasKeys])) {
+    if (params.store[key]) {
+      hadEntry = true;
+    }
+    delete params.store[key];
+  }
+  return hadEntry;
+}

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1282,6 +1282,94 @@ describe("gateway session utils", () => {
     expect(store[rawKey]).toBeUndefined();
   });
 
+  test("preserved raw external aliases are rediscovered from canonical keys", () => {
+    const cfg = {
+      session: { mainKey: "main" },
+      agents: { list: [{ id: "main", default: true }] },
+    } as OpenClawConfig;
+    const rawKey = "conversation:pair:user_a::user_b:space:space_123";
+    const canonicalKey = `agent:main:${rawKey}`;
+    const store: Record<string, SessionEntry> = {
+      [canonicalKey]: {
+        sessionId: "sess-canonical",
+        updatedAt: 3,
+      } as SessionEntry,
+      [rawKey]: {
+        sessionId: "sess-raw",
+        updatedAt: 2,
+      } as SessionEntry,
+    };
+
+    const migrated = migrateAndPruneGatewaySessionStoreKey({
+      cfg,
+      key: canonicalKey,
+      store,
+    });
+
+    expect(migrated.primaryKey).toBe(canonicalKey);
+    expect(migrated.preservedAliasKeys).toEqual([rawKey]);
+    const nextEntry = {
+      sessionId: "sess-next",
+      updatedAt: 4,
+    } as SessionEntry;
+
+    writeGatewaySessionStoreEntry({
+      store,
+      primaryKey: migrated.primaryKey,
+      aliasKeys: migrated.preservedAliasKeys,
+      entry: nextEntry,
+    });
+
+    expect(store[canonicalKey]).toBe(nextEntry);
+    expect(store[rawKey]).toBe(nextEntry);
+    expect(
+      deleteGatewaySessionStoreEntry({
+        store,
+        primaryKey: migrated.primaryKey,
+        aliasKeys: migrated.preservedAliasKeys,
+      }),
+    ).toBe(true);
+    expect(store[canonicalKey]).toBeUndefined();
+    expect(store[rawKey]).toBeUndefined();
+  });
+
+  test("canonical-only external session keys do not create raw aliases", () => {
+    const cfg = {
+      session: { mainKey: "main" },
+      agents: { list: [{ id: "main", default: true }] },
+    } as OpenClawConfig;
+    const rawKey = "conversation:pair:user_a::user_b:space:space_123";
+    const canonicalKey = `agent:main:${rawKey}`;
+    const store: Record<string, SessionEntry> = {
+      [canonicalKey]: {
+        sessionId: "sess-canonical",
+        updatedAt: 3,
+      } as SessionEntry,
+    };
+
+    const migrated = migrateAndPruneGatewaySessionStoreKey({
+      cfg,
+      key: canonicalKey,
+      store,
+    });
+
+    expect(migrated.primaryKey).toBe(canonicalKey);
+    expect(migrated.preservedAliasKeys).toEqual([]);
+    const nextEntry = {
+      sessionId: "sess-next",
+      updatedAt: 4,
+    } as SessionEntry;
+    writeGatewaySessionStoreEntry({
+      store,
+      primaryKey: migrated.primaryKey,
+      aliasKeys: migrated.preservedAliasKeys,
+      entry: nextEntry,
+    });
+
+    expect(store[canonicalKey]).toBe(nextEntry);
+    expect(store[rawKey]).toBeUndefined();
+  });
+
   test("listAgentsForGateway rejects avatar symlink escapes outside workspace", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "session-utils-avatar-outside-"));
     const workspace = path.join(root, "workspace");

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -208,7 +208,7 @@ describe("gateway session utils", () => {
     const rawOnly = listSessionsFromStore({
       cfg,
       storePath: "",
-      store: { [rawKey]: store[rawKey]! },
+      store: { [rawKey]: store[rawKey] },
       opts: {},
     });
     expect(rawOnly.sessions.map((session) => session.key)).toEqual([rawKey]);

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -215,6 +215,82 @@ describe("gateway session utils", () => {
     expect(rawOnly.totalCount).toBe(1);
   });
 
+  test("preserved Signal group raw aliases keep opaque peer id casing", () => {
+    const cfg = createModelDefaultsConfig({ primary: "openai/gpt-5.4" });
+    const groupId = "GroupOpaqueID-AbC123";
+    const rawKey = `Signal:Group:${groupId}`;
+    const preservedRawKey = `signal:group:${groupId}`;
+    const foldedRawKey = `signal:group:${groupId.toLowerCase()}`;
+    const canonicalKey = `agent:main:${preservedRawKey}`;
+    const store = {
+      [rawKey]: {
+        sessionId: "sess-signal",
+        subject: "Signal Alias",
+        updatedAt: 20,
+      },
+      [canonicalKey]: {
+        sessionId: "sess-older",
+        subject: "Old Signal Alias",
+        updatedAt: 10,
+      },
+      [foldedRawKey]: {
+        sessionId: "sess-folded",
+        subject: "Folded Signal Alias",
+        updatedAt: 5,
+      },
+    } satisfies Record<string, SessionEntry>;
+
+    const { preservedAliasKeys, primaryKey } = migrateAndPruneGatewaySessionStoreKey({
+      cfg,
+      key: rawKey,
+      store,
+    });
+
+    expect(primaryKey).toBe(canonicalKey);
+    expect(preservedAliasKeys.toSorted()).toEqual([preservedRawKey, rawKey].toSorted());
+    expect(store[canonicalKey]?.sessionId).toBe("sess-signal");
+    expect(store[preservedRawKey]?.sessionId).toBe("sess-signal");
+    expect(store[rawKey]?.sessionId).toBe("sess-signal");
+    expect(store[foldedRawKey]).toBeUndefined();
+
+    writeGatewaySessionStoreEntry({
+      store,
+      primaryKey,
+      aliasKeys: preservedAliasKeys,
+      entry: {
+        sessionId: "sess-write",
+        subject: "Signal Alias",
+        updatedAt: 30,
+        sendPolicy: "deny",
+      },
+    });
+
+    expect(store[preservedRawKey]).toBe(store[canonicalKey]);
+    expect(store[rawKey]).toBe(store[canonicalKey]);
+    expect(store[preservedRawKey]?.sessionId).toBe("sess-write");
+
+    const listed = listSessionsFromStore({
+      cfg,
+      storePath: "",
+      store,
+      opts: {},
+    });
+    expect(listed.sessions.map((session) => session.key)).toEqual([canonicalKey]);
+    expect(listed.count).toBe(1);
+    expect(listed.totalCount).toBe(1);
+
+    expect(
+      deleteGatewaySessionStoreEntry({
+        store,
+        primaryKey,
+        aliasKeys: preservedAliasKeys,
+      }),
+    ).toBe(true);
+    expect(store[canonicalKey]).toBeUndefined();
+    expect(store[preservedRawKey]).toBeUndefined();
+    expect(store[rawKey]).toBeUndefined();
+  });
+
   test("parseGroupKey handles group keys", () => {
     expect(parseGroupKey("discord:group:dev")).toEqual({
       channel: "discord",

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1085,6 +1085,32 @@ describe("gateway session utils", () => {
     expect(store["agent:main:MAIN"]).toBeUndefined();
   });
 
+  test("migrateAndPruneGatewaySessionStoreKey preserves raw structured external aliases", () => {
+    const cfg = {
+      session: { mainKey: "main" },
+      agents: { list: [{ id: "main", default: true }] },
+    } as OpenClawConfig;
+    const rawKey = "conversation:pair:user_a::user_b:space:space_123";
+    const canonicalKey = `agent:main:${rawKey}`;
+    const store: Record<string, SessionEntry> = {
+      [rawKey]: {
+        sessionId: "sess-raw",
+        updatedAt: 2,
+      } as SessionEntry,
+    };
+
+    const result = migrateAndPruneGatewaySessionStoreKey({
+      cfg,
+      key: rawKey,
+      store,
+    });
+
+    expect(result.primaryKey).toBe(canonicalKey);
+    expect(result.entry?.sessionId).toBe("sess-raw");
+    expect(store[canonicalKey]?.sessionId).toBe("sess-raw");
+    expect(store[rawKey]?.sessionId).toBe("sess-raw");
+  });
+
   test("listAgentsForGateway rejects avatar symlink escapes outside workspace", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "session-utils-avatar-outside-"));
     const workspace = path.join(root, "workspace");

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -13,6 +13,7 @@ import {
   buildGatewaySessionRow,
   capArrayByJsonBytes,
   classifySessionKey,
+  deleteGatewaySessionStoreEntry,
   deriveSessionTitle,
   getSessionDefaults,
   listAgentsForGateway,
@@ -29,6 +30,7 @@ import {
   resolveSessionModelIdentityRef,
   resolveSessionModelRef,
   resolveSessionStoreKey,
+  writeGatewaySessionStoreEntry,
 } from "./session-utils.js";
 
 function resolveSyncRealpath(filePath: string): string {
@@ -1107,8 +1109,53 @@ describe("gateway session utils", () => {
 
     expect(result.primaryKey).toBe(canonicalKey);
     expect(result.entry?.sessionId).toBe("sess-raw");
+    expect(result.preservedAliasKeys).toEqual([rawKey]);
     expect(store[canonicalKey]?.sessionId).toBe("sess-raw");
     expect(store[rawKey]?.sessionId).toBe("sess-raw");
+  });
+
+  test("preserved raw external aliases follow replacement and delete operations", () => {
+    const cfg = {
+      session: { mainKey: "main" },
+      agents: { list: [{ id: "main", default: true }] },
+    } as OpenClawConfig;
+    const rawKey = "conversation:pair:user_a::user_b:space:space_123";
+    const canonicalKey = `agent:main:${rawKey}`;
+    const store: Record<string, SessionEntry> = {
+      [rawKey]: {
+        sessionId: "sess-raw",
+        updatedAt: 2,
+      } as SessionEntry,
+    };
+
+    const migrated = migrateAndPruneGatewaySessionStoreKey({
+      cfg,
+      key: rawKey,
+      store,
+    });
+    const nextEntry = {
+      sessionId: "sess-next",
+      updatedAt: 3,
+    } as SessionEntry;
+
+    writeGatewaySessionStoreEntry({
+      store,
+      primaryKey: migrated.primaryKey,
+      aliasKeys: migrated.preservedAliasKeys,
+      entry: nextEntry,
+    });
+
+    expect(store[canonicalKey]).toBe(nextEntry);
+    expect(store[rawKey]).toBe(nextEntry);
+    expect(
+      deleteGatewaySessionStoreEntry({
+        store,
+        primaryKey: migrated.primaryKey,
+        aliasKeys: migrated.preservedAliasKeys,
+      }),
+    ).toBe(true);
+    expect(store[canonicalKey]).toBeUndefined();
+    expect(store[rawKey]).toBeUndefined();
   });
 
   test("listAgentsForGateway rejects avatar symlink escapes outside workspace", () => {

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -167,6 +167,54 @@ describe("gateway session utils", () => {
     expect(listed.hasMore).toBe(true);
   });
 
+  test("session lists collapse preserved raw external aliases", () => {
+    const cfg = createModelDefaultsConfig({ primary: "openai/gpt-5.4" });
+    const rawKey = "conversation:pair:user_a::user_b:space:space_123";
+    const canonicalKey = `agent:main:${rawKey}`;
+    const store = {
+      [rawKey]: {
+        sessionId: "sess-raw",
+        subject: "Alias Needle",
+        updatedAt: 20,
+      },
+      [canonicalKey]: {
+        sessionId: "sess-raw",
+        subject: "Alias Needle",
+        updatedAt: 30,
+      },
+    } satisfies Record<string, SessionEntry>;
+
+    const listed = listSessionsFromStore({
+      cfg,
+      storePath: "",
+      store,
+      opts: {},
+    });
+    expect(listed.sessions.map((session) => session.key)).toEqual([canonicalKey]);
+    expect(listed.count).toBe(1);
+    expect(listed.totalCount).toBe(1);
+    expect(listed.hasMore).toBe(false);
+
+    const searched = listSessionsFromStore({
+      cfg,
+      storePath: "",
+      store,
+      opts: { search: "alias needle" },
+    });
+    expect(searched.sessions.map((session) => session.key)).toEqual([canonicalKey]);
+    expect(searched.count).toBe(1);
+    expect(searched.totalCount).toBe(1);
+
+    const rawOnly = listSessionsFromStore({
+      cfg,
+      storePath: "",
+      store: { [rawKey]: store[rawKey]! },
+      opts: {},
+    });
+    expect(rawOnly.sessions.map((session) => session.key)).toEqual([rawKey]);
+    expect(rawOnly.totalCount).toBe(1);
+  });
+
   test("parseGroupKey handles group keys", () => {
     expect(parseGroupKey("discord:group:dev")).toEqual({
       channel: "discord",

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -2175,13 +2175,47 @@ function sortAndLimitSessionEntries(
   return limit === undefined ? sorted : sorted.slice(0, limit);
 }
 
+function isPreservedRawExternalAliasEntry(params: {
+  cfg: OpenClawConfig;
+  store: Record<string, SessionEntry>;
+  key: string;
+  entry: SessionEntry;
+}): boolean {
+  const canonicalKey = resolveSessionStoreKey({
+    cfg: params.cfg,
+    sessionKey: params.key,
+  });
+  if (!canonicalKey || canonicalKey === params.key) {
+    return false;
+  }
+  const preservedRawKey = resolvePreservedRawExternalStoreKey({
+    cfg: params.cfg,
+    key: params.key,
+    canonicalKey,
+  });
+  if (!preservedRawKey) {
+    return false;
+  }
+  const canonicalEntry = params.store[canonicalKey];
+  if (!canonicalEntry) {
+    return false;
+  }
+  if (canonicalEntry === params.entry) {
+    return true;
+  }
+  const sessionId = normalizeOptionalString(params.entry.sessionId) ?? "";
+  const canonicalSessionId = normalizeOptionalString(canonicalEntry.sessionId) ?? "";
+  return Boolean(sessionId && canonicalSessionId && sessionId === canonicalSessionId);
+}
+
 function filterSessionEntries(params: {
+  cfg: OpenClawConfig;
   store: Record<string, SessionEntry>;
   opts: import("./protocol/index.js").SessionsListParams;
   now: number;
   rowContext?: SessionListRowContext;
 }): SessionEntryPair[] {
-  const { store, opts, now } = params;
+  const { cfg, store, opts, now } = params;
   const rowContext = params.rowContext;
   const includeGlobal = opts.includeGlobal === true;
   const includeUnknown = opts.includeUnknown === true;
@@ -2195,6 +2229,7 @@ function filterSessionEntries(params: {
       : undefined;
 
   let entries = Object.entries(store)
+    .filter(([key, entry]) => !isPreservedRawExternalAliasEntry({ cfg, store, key, entry }))
     .filter(([key]) => {
       if (isCronRunSessionKey(key)) {
         return false;
@@ -2277,6 +2312,7 @@ function filterSessionEntries(params: {
 }
 
 function selectSessionEntries(params: {
+  cfg: OpenClawConfig;
   store: Record<string, SessionEntry>;
   opts: import("./protocol/index.js").SessionsListParams;
   now: number;
@@ -2294,6 +2330,7 @@ function selectSessionEntries(params: {
 }
 
 export function filterAndSortSessionEntries(params: {
+  cfg: OpenClawConfig;
   store: Record<string, SessionEntry>;
   opts: import("./protocol/index.js").SessionsListParams;
   now: number;
@@ -2323,6 +2360,7 @@ export function listSessionsFromStore(params: {
   const hasSpawnedByFilter = typeof opts.spawnedBy === "string" && opts.spawnedBy.length > 0;
 
   const selection = selectSessionEntries({
+    cfg,
     store,
     opts,
     now,
@@ -2392,6 +2430,7 @@ export async function listSessionsFromStoreAsync(params: {
   const hasSpawnedByFilter = typeof opts.spawnedBy === "string" && opts.spawnedBy.length > 0;
 
   const selection = selectSessionEntries({
+    cfg,
     store,
     opts,
     now,

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -913,6 +913,76 @@ function resolvePreservedRawExternalStoreKey(params: {
   return lowered;
 }
 
+function normalizeSessionStoreKeys(keys: Iterable<string | undefined>): string[] {
+  const normalized = new Set<string>();
+  for (const key of keys) {
+    const trimmed = normalizeOptionalString(key ?? "") ?? "";
+    if (trimmed) {
+      normalized.add(trimmed);
+    }
+  }
+  return Array.from(normalized);
+}
+
+function resolvePreservedRawExternalAliasKeys(params: {
+  preservedRawKey: string | undefined;
+  storeKeys: Iterable<string>;
+}): string[] {
+  if (!params.preservedRawKey) {
+    return [];
+  }
+  const aliases = Array.from(params.storeKeys).filter(
+    (key) => normalizeLowercaseStringOrEmpty(key) === params.preservedRawKey,
+  );
+  aliases.push(params.preservedRawKey);
+  return normalizeSessionStoreKeys(aliases);
+}
+
+export function syncGatewaySessionStoreAliases(params: {
+  store: Record<string, SessionEntry>;
+  primaryKey: string;
+  aliasKeys: Iterable<string>;
+}) {
+  const entry = params.store[params.primaryKey];
+  if (!entry) {
+    return;
+  }
+  for (const aliasKey of normalizeSessionStoreKeys(params.aliasKeys)) {
+    if (aliasKey !== params.primaryKey) {
+      params.store[aliasKey] = entry;
+    }
+  }
+}
+
+export function writeGatewaySessionStoreEntry(params: {
+  store: Record<string, SessionEntry>;
+  primaryKey: string;
+  aliasKeys: Iterable<string>;
+  entry: SessionEntry;
+}) {
+  params.store[params.primaryKey] = params.entry;
+  syncGatewaySessionStoreAliases({
+    store: params.store,
+    primaryKey: params.primaryKey,
+    aliasKeys: params.aliasKeys,
+  });
+}
+
+export function deleteGatewaySessionStoreEntry(params: {
+  store: Record<string, SessionEntry>;
+  primaryKey: string;
+  aliasKeys: Iterable<string>;
+}): boolean {
+  let hadEntry = false;
+  for (const key of normalizeSessionStoreKeys([params.primaryKey, ...params.aliasKeys])) {
+    if (params.store[key]) {
+      hadEntry = true;
+    }
+    delete params.store[key];
+  }
+  return hadEntry;
+}
+
 export function migrateAndPruneGatewaySessionStoreKey(params: {
   cfg: OpenClawConfig;
   key: string;
@@ -928,6 +998,10 @@ export function migrateAndPruneGatewaySessionStoreKey(params: {
     cfg: params.cfg,
     key: params.key,
     canonicalKey: primaryKey,
+  });
+  const preservedAliasKeys = resolvePreservedRawExternalAliasKeys({
+    preservedRawKey,
+    storeKeys: target.storeKeys,
   });
   const freshestMatch = resolveFreshestSessionStoreMatchFromStoreKeys(
     params.store,
@@ -946,10 +1020,12 @@ export function migrateAndPruneGatewaySessionStoreKey(params: {
       (key) => normalizeLowercaseStringOrEmpty(key) !== preservedRawKey,
     ),
   });
-  if (preservedRawKey && params.store[primaryKey]) {
-    params.store[preservedRawKey] = params.store[primaryKey];
-  }
-  return { target, primaryKey, entry: params.store[primaryKey] };
+  syncGatewaySessionStoreAliases({
+    store: params.store,
+    primaryKey,
+    aliasKeys: preservedAliasKeys,
+  });
+  return { target, primaryKey, entry: params.store[primaryKey], preservedAliasKeys };
 }
 
 export function classifySessionKey(key: string, entry?: SessionEntry): GatewaySessionRow["kind"] {

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -892,7 +892,7 @@ export function pruneLegacyStoreKeys(params: {
   }
 }
 
-function resolvePreservedRawExternalStoreKey(params: {
+function resolvePreservedRawExternalStoreKeyCandidate(params: {
   cfg: OpenClawConfig;
   key: string;
   canonicalKey: string;
@@ -916,6 +916,34 @@ function resolvePreservedRawExternalStoreKey(params: {
   return key;
 }
 
+function resolveAgentSessionRestPreservingSeparators(key: string): string | undefined {
+  const normalized = normalizeSessionKeyPreservingOpaquePeerIds(key);
+  const match = /^agent:([^:]+):(.+)$/.exec(normalized);
+  const rest = match?.[2];
+  return rest ? rest : undefined;
+}
+
+function resolvePreservedRawExternalStoreKey(params: {
+  cfg: OpenClawConfig;
+  key: string;
+  canonicalKey: string;
+}): { key: string; preserveMissingAlias: boolean } | undefined {
+  const directKey = resolvePreservedRawExternalStoreKeyCandidate(params);
+  if (directKey) {
+    return { key: directKey, preserveMissingAlias: true };
+  }
+  const canonicalRest = resolveAgentSessionRestPreservingSeparators(params.canonicalKey);
+  if (!canonicalRest) {
+    return undefined;
+  }
+  const canonicalRawKey = resolvePreservedRawExternalStoreKeyCandidate({
+    cfg: params.cfg,
+    key: canonicalRest,
+    canonicalKey: params.canonicalKey,
+  });
+  return canonicalRawKey ? { key: canonicalRawKey, preserveMissingAlias: false } : undefined;
+}
+
 function normalizeSessionStoreKeys(keys: Iterable<string | undefined>): string[] {
   const normalized = new Set<string>();
   for (const key of keys) {
@@ -929,6 +957,7 @@ function normalizeSessionStoreKeys(keys: Iterable<string | undefined>): string[]
 
 function resolvePreservedRawExternalAliasKeys(params: {
   preservedRawKey: string | undefined;
+  preserveMissingAlias: boolean;
   storeKeys: Iterable<string>;
 }): string[] {
   if (!params.preservedRawKey) {
@@ -937,6 +966,9 @@ function resolvePreservedRawExternalAliasKeys(params: {
   const aliases = Array.from(params.storeKeys).filter(
     (key) => normalizeSessionKeyPreservingOpaquePeerIds(key) === params.preservedRawKey,
   );
+  if (!params.preserveMissingAlias && aliases.length === 0) {
+    return [];
+  }
   aliases.push(params.preservedRawKey);
   return normalizeSessionStoreKeys(aliases);
 }
@@ -997,14 +1029,15 @@ export function migrateAndPruneGatewaySessionStoreKey(params: {
     store: params.store,
   });
   const primaryKey = target.canonicalKey;
-  const preservedRawKey = resolvePreservedRawExternalStoreKey({
+  const preservedRaw = resolvePreservedRawExternalStoreKey({
     cfg: params.cfg,
     key: params.key,
     canonicalKey: primaryKey,
   });
   const preservedAliasKeys = resolvePreservedRawExternalAliasKeys({
-    preservedRawKey,
-    storeKeys: target.storeKeys,
+    preservedRawKey: preservedRaw?.key,
+    preserveMissingAlias: preservedRaw?.preserveMissingAlias === true,
+    storeKeys: [...target.storeKeys, ...Object.keys(params.store)],
   });
   const freshestMatch = resolveFreshestSessionStoreMatchFromStoreKeys(
     params.store,
@@ -1020,7 +1053,7 @@ export function migrateAndPruneGatewaySessionStoreKey(params: {
     store: params.store,
     canonicalKey: primaryKey,
     candidates: target.storeKeys.filter(
-      (key) => normalizeSessionKeyPreservingOpaquePeerIds(key) !== preservedRawKey,
+      (key) => normalizeSessionKeyPreservingOpaquePeerIds(key) !== preservedRaw?.key,
     ),
   });
   syncGatewaySessionStoreAliases({

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -889,6 +889,30 @@ export function pruneLegacyStoreKeys(params: {
   }
 }
 
+function resolvePreservedRawExternalStoreKey(params: {
+  cfg: OpenClawConfig;
+  key: string;
+  canonicalKey: string;
+}): string | undefined {
+  const key = normalizeOptionalString(params.key) ?? "";
+  if (!key || key === params.canonicalKey || !key.includes(":")) {
+    return undefined;
+  }
+  const lowered = normalizeLowercaseStringOrEmpty(key);
+  const mainKey = normalizeMainKey(params.cfg.session?.mainKey);
+  if (
+    lowered === "global" ||
+    lowered === "unknown" ||
+    lowered === "main" ||
+    lowered === mainKey ||
+    lowered.startsWith("agent:") ||
+    parseAgentSessionKey(key)
+  ) {
+    return undefined;
+  }
+  return lowered;
+}
+
 export function migrateAndPruneGatewaySessionStoreKey(params: {
   cfg: OpenClawConfig;
   key: string;
@@ -900,6 +924,11 @@ export function migrateAndPruneGatewaySessionStoreKey(params: {
     store: params.store,
   });
   const primaryKey = target.canonicalKey;
+  const preservedRawKey = resolvePreservedRawExternalStoreKey({
+    cfg: params.cfg,
+    key: params.key,
+    canonicalKey: primaryKey,
+  });
   const freshestMatch = resolveFreshestSessionStoreMatchFromStoreKeys(
     params.store,
     target.storeKeys,
@@ -913,8 +942,13 @@ export function migrateAndPruneGatewaySessionStoreKey(params: {
   pruneLegacyStoreKeys({
     store: params.store,
     canonicalKey: primaryKey,
-    candidates: target.storeKeys,
+    candidates: target.storeKeys.filter(
+      (key) => normalizeLowercaseStringOrEmpty(key) !== preservedRawKey,
+    ),
   });
+  if (preservedRawKey && params.store[primaryKey]) {
+    params.store[preservedRawKey] = params.store[primaryKey];
+  }
   return { target, primaryKey, entry: params.store[primaryKey] };
 }
 

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -64,7 +64,10 @@ import {
   normalizeMainKey,
   parseAgentSessionKey,
 } from "../routing/session-key.js";
-import { isCronRunSessionKey } from "../sessions/session-key-utils.js";
+import {
+  isCronRunSessionKey,
+  normalizeSessionKeyPreservingOpaquePeerIds,
+} from "../sessions/session-key-utils.js";
 import {
   AVATAR_MAX_BYTES,
   isAvatarDataUrl,
@@ -894,7 +897,7 @@ function resolvePreservedRawExternalStoreKey(params: {
   key: string;
   canonicalKey: string;
 }): string | undefined {
-  const key = normalizeOptionalString(params.key) ?? "";
+  const key = normalizeSessionKeyPreservingOpaquePeerIds(params.key);
   if (!key || key === params.canonicalKey || !key.includes(":")) {
     return undefined;
   }
@@ -910,7 +913,7 @@ function resolvePreservedRawExternalStoreKey(params: {
   ) {
     return undefined;
   }
-  return lowered;
+  return key;
 }
 
 function normalizeSessionStoreKeys(keys: Iterable<string | undefined>): string[] {
@@ -932,7 +935,7 @@ function resolvePreservedRawExternalAliasKeys(params: {
     return [];
   }
   const aliases = Array.from(params.storeKeys).filter(
-    (key) => normalizeLowercaseStringOrEmpty(key) === params.preservedRawKey,
+    (key) => normalizeSessionKeyPreservingOpaquePeerIds(key) === params.preservedRawKey,
   );
   aliases.push(params.preservedRawKey);
   return normalizeSessionStoreKeys(aliases);
@@ -1017,7 +1020,7 @@ export function migrateAndPruneGatewaySessionStoreKey(params: {
     store: params.store,
     canonicalKey: primaryKey,
     candidates: target.storeKeys.filter(
-      (key) => normalizeLowercaseStringOrEmpty(key) !== preservedRawKey,
+      (key) => normalizeSessionKeyPreservingOpaquePeerIds(key) !== preservedRawKey,
     ),
   });
   syncGatewaySessionStoreAliases({

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -85,6 +85,13 @@ import { normalizeSessionDeliveryFields } from "../utils/delivery-context.shared
 import type { ModelCostConfig } from "../utils/usage-format.js";
 import { estimateUsageCost, resolveModelCostConfig } from "../utils/usage-format.js";
 import {
+  deleteGatewaySessionStoreEntry,
+  resolvePreservedRawExternalAliasKeys,
+  resolvePreservedRawExternalStoreKey,
+  syncGatewaySessionStoreAliases,
+  writeGatewaySessionStoreEntry,
+} from "./session-store-aliases.js";
+import {
   resolveSessionStoreAgentId,
   resolveSessionStoreKey,
   resolveStoredSessionKeyForAgentStore,
@@ -126,6 +133,11 @@ export {
 } from "./session-utils.fs.js";
 export type { ReadSessionMessagesAsyncOptions } from "./session-utils.fs.js";
 export { canonicalizeSpawnedByForAgent, resolveSessionStoreKey } from "./session-store-key.js";
+export {
+  deleteGatewaySessionStoreEntry,
+  syncGatewaySessionStoreAliases,
+  writeGatewaySessionStoreEntry,
+} from "./session-store-aliases.js";
 export type {
   GatewayAgentRow,
   GatewaySessionRow,
@@ -890,132 +902,6 @@ export function pruneLegacyStoreKeys(params: {
   for (const key of keysToDelete) {
     delete params.store[key];
   }
-}
-
-function resolvePreservedRawExternalStoreKeyCandidate(params: {
-  cfg: OpenClawConfig;
-  key: string;
-  canonicalKey: string;
-}): string | undefined {
-  const key = normalizeSessionKeyPreservingOpaquePeerIds(params.key);
-  if (!key || key === params.canonicalKey || !key.includes(":")) {
-    return undefined;
-  }
-  const lowered = normalizeLowercaseStringOrEmpty(key);
-  const mainKey = normalizeMainKey(params.cfg.session?.mainKey);
-  if (
-    lowered === "global" ||
-    lowered === "unknown" ||
-    lowered === "main" ||
-    lowered === mainKey ||
-    lowered.startsWith("agent:") ||
-    parseAgentSessionKey(key)
-  ) {
-    return undefined;
-  }
-  return key;
-}
-
-function resolveAgentSessionRestPreservingSeparators(key: string): string | undefined {
-  const normalized = normalizeSessionKeyPreservingOpaquePeerIds(key);
-  const match = /^agent:([^:]+):(.+)$/.exec(normalized);
-  const rest = match?.[2];
-  return rest ? rest : undefined;
-}
-
-function resolvePreservedRawExternalStoreKey(params: {
-  cfg: OpenClawConfig;
-  key: string;
-  canonicalKey: string;
-}): { key: string; preserveMissingAlias: boolean } | undefined {
-  const directKey = resolvePreservedRawExternalStoreKeyCandidate(params);
-  if (directKey) {
-    return { key: directKey, preserveMissingAlias: true };
-  }
-  const canonicalRest = resolveAgentSessionRestPreservingSeparators(params.canonicalKey);
-  if (!canonicalRest) {
-    return undefined;
-  }
-  const canonicalRawKey = resolvePreservedRawExternalStoreKeyCandidate({
-    cfg: params.cfg,
-    key: canonicalRest,
-    canonicalKey: params.canonicalKey,
-  });
-  return canonicalRawKey ? { key: canonicalRawKey, preserveMissingAlias: false } : undefined;
-}
-
-function normalizeSessionStoreKeys(keys: Iterable<string | undefined>): string[] {
-  const normalized = new Set<string>();
-  for (const key of keys) {
-    const trimmed = normalizeOptionalString(key ?? "") ?? "";
-    if (trimmed) {
-      normalized.add(trimmed);
-    }
-  }
-  return Array.from(normalized);
-}
-
-function resolvePreservedRawExternalAliasKeys(params: {
-  preservedRawKey: string | undefined;
-  preserveMissingAlias: boolean;
-  storeKeys: Iterable<string>;
-}): string[] {
-  if (!params.preservedRawKey) {
-    return [];
-  }
-  const aliases = Array.from(params.storeKeys).filter(
-    (key) => normalizeSessionKeyPreservingOpaquePeerIds(key) === params.preservedRawKey,
-  );
-  if (!params.preserveMissingAlias && aliases.length === 0) {
-    return [];
-  }
-  aliases.push(params.preservedRawKey);
-  return normalizeSessionStoreKeys(aliases);
-}
-
-export function syncGatewaySessionStoreAliases(params: {
-  store: Record<string, SessionEntry>;
-  primaryKey: string;
-  aliasKeys: Iterable<string>;
-}) {
-  const entry = params.store[params.primaryKey];
-  if (!entry) {
-    return;
-  }
-  for (const aliasKey of normalizeSessionStoreKeys(params.aliasKeys)) {
-    if (aliasKey !== params.primaryKey) {
-      params.store[aliasKey] = entry;
-    }
-  }
-}
-
-export function writeGatewaySessionStoreEntry(params: {
-  store: Record<string, SessionEntry>;
-  primaryKey: string;
-  aliasKeys: Iterable<string>;
-  entry: SessionEntry;
-}) {
-  params.store[params.primaryKey] = params.entry;
-  syncGatewaySessionStoreAliases({
-    store: params.store,
-    primaryKey: params.primaryKey,
-    aliasKeys: params.aliasKeys,
-  });
-}
-
-export function deleteGatewaySessionStoreEntry(params: {
-  store: Record<string, SessionEntry>;
-  primaryKey: string;
-  aliasKeys: Iterable<string>;
-}): boolean {
-  let hadEntry = false;
-  for (const key of normalizeSessionStoreKeys([params.primaryKey, ...params.aliasKeys])) {
-    if (params.store[key]) {
-      hadEntry = true;
-    }
-    delete params.store[key];
-  }
-  return hadEntry;
 }
 
 export function migrateAndPruneGatewaySessionStoreKey(params: {

--- a/src/gateway/sessions-resolve.test.ts
+++ b/src/gateway/sessions-resolve.test.ts
@@ -65,7 +65,10 @@ describe("resolveSessionKeyFromResolveParams", () => {
       storeKeys: [canonicalKey, legacyKey],
       storePath,
     });
-    hoisted.migrateAndPruneGatewaySessionStoreKeyMock.mockReturnValue({ primaryKey: canonicalKey });
+    hoisted.migrateAndPruneGatewaySessionStoreKeyMock.mockReturnValue({
+      primaryKey: canonicalKey,
+      preservedAliasKeys: [],
+    });
     hoisted.updateSessionStoreMock.mockImplementation(
       async (_path: string, updater: (store: Record<string, SessionEntry>) => void) => {
         const store = hoisted.loadSessionStoreMock.mock.results[0]?.value as

--- a/src/gateway/sessions-resolve.ts
+++ b/src/gateway/sessions-resolve.ts
@@ -66,6 +66,7 @@ function isResolvedSessionKeyVisible(params: {
     return true;
   }
   return filterAndSortSessionEntries({
+    cfg: params.cfg,
     store: params.store,
     now: Date.now(),
     opts: resolveSessionVisibilityFilterOptions(params.p),
@@ -73,12 +74,14 @@ function isResolvedSessionKeyVisible(params: {
 }
 
 function findVisibleSessionIdMatches(params: {
+  cfg: OpenClawConfig;
   store: Record<string, SessionEntry>;
   p: SessionsResolveParams;
   sessionId: string;
 }): Array<[string, SessionEntry]> {
   const now = Date.now();
   const entries = filterAndSortSessionEntries({
+    cfg: params.cfg,
     store: params.store,
     now,
     opts: resolveSessionVisibilityFilterOptions(params.p),
@@ -176,7 +179,7 @@ export async function resolveSessionKeyFromResolveParams(params: {
 
   if (hasSessionId) {
     const { store } = loadCombinedSessionStoreForGateway(cfg, { agentId: p.agentId });
-    const matches = findVisibleSessionIdMatches({ store, p, sessionId });
+    const matches = findVisibleSessionIdMatches({ cfg, store, p, sessionId });
     const selection = resolveSessionIdMatchSelection(matches, sessionId);
     if (selection.kind === "none") {
       return {

--- a/src/gateway/sessions-resolve.ts
+++ b/src/gateway/sessions-resolve.ts
@@ -16,6 +16,7 @@ import {
   migrateAndPruneGatewaySessionStoreKey,
   resolveDeletedAgentIdFromSessionKey,
   resolveGatewaySessionStoreTarget,
+  syncGatewaySessionStoreAliases,
 } from "./session-utils.js";
 
 export type SessionsResolveResult = { ok: true; key: string } | { ok: false; error: ErrorShape };
@@ -141,10 +142,19 @@ export async function resolveSessionKeyFromResolveParams(params: {
       return noSessionFoundResult(key);
     }
     await updateSessionStore(target.storePath, (s) => {
-      const { primaryKey } = migrateAndPruneGatewaySessionStoreKey({ cfg, key, store: s });
+      const { preservedAliasKeys, primaryKey } = migrateAndPruneGatewaySessionStoreKey({
+        cfg,
+        key,
+        store: s,
+      });
       if (!s[primaryKey] && s[legacyKey]) {
         s[primaryKey] = s[legacyKey];
       }
+      syncGatewaySessionStoreAliases({
+        store: s,
+        primaryKey,
+        aliasKeys: preservedAliasKeys,
+      });
     });
     if (
       !isResolvedSessionKeyVisible({

--- a/src/plugins/contracts/host-hooks.contract.test.ts
+++ b/src/plugins/contracts/host-hooks.contract.test.ts
@@ -1332,6 +1332,107 @@ describe("host-hook fixture plugin contract", () => {
     }
   });
 
+  it("syncs canonical next-turn injections to preserved raw session aliases", async () => {
+    const registry = createEmptyPluginRegistry();
+    registry.plugins.push(
+      createPluginRecord({
+        id: "alias-injector",
+        name: "Alias Injector",
+        status: "loaded",
+      }),
+    );
+    setActivePluginRegistry(registry);
+    const stateDir = await fs.mkdtemp(
+      path.join(resolvePreferredOpenClawTmpDir(), "openclaw-host-hooks-alias-injection-"),
+    );
+    const storePath = path.join(stateDir, "sessions.json");
+    const tempConfig = {
+      session: { store: storePath },
+    };
+    const rawKey = "conversation:pair:user_a::user_b:space:space_123";
+    const canonicalKey = `agent:main:${rawKey}`;
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    try {
+      process.env.OPENCLAW_STATE_DIR = stateDir;
+      await withTempConfig({
+        cfg: tempConfig,
+        run: async () => {
+          const baseTime = Date.now();
+          await updateSessionStore(storePath, (store) => {
+            store[canonicalKey] = {
+              sessionId: "session-raw-alias",
+              updatedAt: baseTime,
+            };
+            store[rawKey] = {
+              sessionId: "session-raw-alias",
+              updatedAt: baseTime - 1,
+              pluginNextTurnInjections: {
+                "alias-injector": [
+                  {
+                    id: "stale",
+                    pluginId: "alias-injector",
+                    text: "stale raw alias",
+                    placement: "prepend_context",
+                    createdAt: baseTime - 1,
+                  },
+                ],
+              },
+            };
+            return undefined;
+          });
+
+          const enqueued = await enqueuePluginNextTurnInjection({
+            cfg: tempConfig,
+            pluginId: "alias-injector",
+            injection: {
+              sessionKey: canonicalKey,
+              text: "canonical queued injection",
+              placement: "prepend_context",
+              idempotencyKey: "alias:resume",
+            },
+            now: baseTime + 100,
+          });
+
+          expect(enqueued.enqueued).toBe(true);
+          expect(enqueued.sessionKey).toBe(canonicalKey);
+          const afterEnqueue = loadSessionStore(storePath, { skipCache: true });
+          expect(afterEnqueue[canonicalKey]?.pluginNextTurnInjections?.["alias-injector"]).toEqual([
+            expect.objectContaining({
+              id: enqueued.id,
+              text: "canonical queued injection",
+              idempotencyKey: "alias:resume",
+            }),
+          ]);
+          expect(afterEnqueue[rawKey]?.pluginNextTurnInjections?.["alias-injector"]).toEqual(
+            afterEnqueue[canonicalKey]?.pluginNextTurnInjections?.["alias-injector"],
+          );
+
+          const drained = await drainPluginNextTurnInjections({
+            cfg: tempConfig,
+            sessionKey: canonicalKey,
+            now: baseTime + 101,
+          });
+          expect(drained).toHaveLength(1);
+          expectRecordFields(drained[0], {
+            id: enqueued.id,
+            pluginId: "alias-injector",
+            text: "canonical queued injection",
+          });
+          const afterDrain = loadSessionStore(storePath, { skipCache: true });
+          expect(afterDrain[canonicalKey]?.pluginNextTurnInjections).toBeUndefined();
+          expect(afterDrain[rawKey]?.pluginNextTurnInjections).toBeUndefined();
+        },
+      });
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
   it("suppresses stale next-turn injections from plugins that are no longer loaded", async () => {
     const registry = createEmptyPluginRegistry();
     registry.plugins.push(

--- a/src/plugins/contracts/session-entry-projection.contract.test.ts
+++ b/src/plugins/contracts/session-entry-projection.contract.test.ts
@@ -132,6 +132,110 @@ describe("plugin session extension SessionEntry projection", () => {
     }
   });
 
+  it("syncs canonical plugin extension patches to preserved raw session aliases", async () => {
+    const { config, registry } = createPluginRegistryFixture();
+    registerTestPlugin({
+      registry,
+      config,
+      record: createPluginRecord({ id: "alias-plugin", name: "Alias" }),
+      register(api) {
+        api.registerSessionExtension({
+          namespace: "workflow",
+          description: "alias workflow",
+          sessionEntrySlotKey: "approvalSnapshot",
+          sessionEntrySlotSchema: { type: "object" },
+          project: (ctx) => {
+            if (!ctx.state || typeof ctx.state !== "object" || Array.isArray(ctx.state)) {
+              return undefined;
+            }
+            const state = ctx.state as Record<string, PluginJsonValue>;
+            return { state: state.state ?? null };
+          },
+        });
+      },
+    });
+    setActivePluginRegistry(registry.registry);
+
+    const stateDir = await fs.mkdtemp(
+      path.join(resolvePreferredOpenClawTmpDir(), "openclaw-host-hooks-slot-alias-"),
+    );
+    const storePath = path.join(stateDir, "sessions.json");
+    const tempConfig = { session: { store: storePath } };
+    const rawKey = "conversation:pair:user_a::user_b:space:space_123";
+    const canonicalKey = `agent:main:${rawKey}`;
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    try {
+      process.env.OPENCLAW_STATE_DIR = stateDir;
+      await withTempConfig({
+        cfg: tempConfig,
+        run: async () => {
+          const baseTime = Date.now();
+          await updateSessionStore(storePath, (store) => {
+            store[canonicalKey] = {
+              sessionId: "session-raw-alias",
+              updatedAt: baseTime,
+            } as unknown as SessionEntry;
+            store[rawKey] = {
+              sessionId: "session-raw-alias",
+              updatedAt: baseTime - 1,
+              pluginExtensions: {
+                "alias-plugin": {
+                  workflow: { state: "stale" },
+                },
+              },
+              approvalSnapshot: { state: "stale" },
+            } as unknown as SessionEntry;
+          });
+
+          const patchResult = await patchPluginSessionExtension({
+            cfg: tempConfig as never,
+            sessionKey: canonicalKey,
+            pluginId: "alias-plugin",
+            namespace: "workflow",
+            value: { state: "patched" },
+          });
+          expect(patchResult.ok).toBe(true);
+          const afterPatch = loadSessionStore(storePath, { skipCache: true });
+          const canonicalEntry = afterPatch[canonicalKey] as unknown as Record<string, unknown>;
+          const rawEntry = afterPatch[rawKey] as unknown as Record<string, unknown>;
+          expect(extensionNamespace(canonicalEntry, "alias-plugin", "workflow")).toEqual({
+            state: "patched",
+          });
+          expect(extensionNamespace(rawEntry, "alias-plugin", "workflow")).toEqual({
+            state: "patched",
+          });
+          expect(rawEntry.approvalSnapshot).toEqual(canonicalEntry.approvalSnapshot);
+
+          const unsetResult = await patchPluginSessionExtension({
+            cfg: tempConfig as never,
+            sessionKey: canonicalKey,
+            pluginId: "alias-plugin",
+            namespace: "workflow",
+            unset: true,
+          });
+          expect(unsetResult.ok).toBe(true);
+          const afterUnset = loadSessionStore(storePath, { skipCache: true });
+          const canonicalAfterUnset = afterUnset[canonicalKey] as unknown as Record<
+            string,
+            unknown
+          >;
+          const rawAfterUnset = afterUnset[rawKey] as unknown as Record<string, unknown>;
+          expect(canonicalAfterUnset.pluginExtensions).toBeUndefined();
+          expect(rawAfterUnset.pluginExtensions).toBeUndefined();
+          expect(canonicalAfterUnset.approvalSnapshot).toBeUndefined();
+          expect(rawAfterUnset.approvalSnapshot).toBeUndefined();
+        },
+      });
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      await fs.rm(stateDir, { recursive: true, force: true });
+    }
+  });
+
   it("clears promoted SessionEntry slots when projectors fail", async () => {
     const { config, registry } = createPluginRegistryFixture();
     registerTestPlugin({

--- a/src/plugins/host-hook-state.ts
+++ b/src/plugins/host-hook-state.ts
@@ -8,6 +8,11 @@ import {
 } from "../config/sessions/targets.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
+  normalizeSessionStoreKeys,
+  resolveGatewaySessionStorePreservedAliasKeys,
+  syncGatewaySessionStoreAliases,
+} from "../gateway/session-store-aliases.js";
+import {
   resolveSessionStoreAgentId,
   resolveSessionStoreKey,
 } from "../gateway/session-store-key.js";
@@ -170,6 +175,7 @@ function loadPluginHostHookSessionEntry(params: { cfg: OpenClawConfig; sessionKe
   entry?: SessionEntry;
   canonicalKey: string;
   storeKey: string;
+  aliasKeys: string[];
 } {
   const key = normalizeOptionalString(params.sessionKey) ?? "";
   const cfg = params.cfg;
@@ -181,20 +187,35 @@ function loadPluginHostHookSessionEntry(params: { cfg: OpenClawConfig; sessionKe
     agentId,
     storePath: resolveStorePath(cfg.session?.store, { agentId }),
   };
+  const fallbackStore = loadSessionStore(fallback.storePath);
+  let selectedAliasKeys = resolvePluginHostHookSessionAliasKeys({
+    cfg,
+    key,
+    canonicalKey,
+    store: fallbackStore,
+  });
   let selectedStorePath = fallback.storePath;
-  let selectedMatch = findFreshestStoreMatch(loadSessionStore(fallback.storePath), ...scanTargets);
+  let selectedMatch = findFreshestStoreMatch(fallbackStore, ...scanTargets, ...selectedAliasKeys);
   for (let index = 1; index < candidates.length; index += 1) {
     const candidate = candidates[index];
     if (!candidate) {
       continue;
     }
-    const match = findFreshestStoreMatch(loadSessionStore(candidate.storePath), ...scanTargets);
+    const store = loadSessionStore(candidate.storePath);
+    const aliasKeys = resolvePluginHostHookSessionAliasKeys({
+      cfg,
+      key,
+      canonicalKey,
+      store,
+    });
+    const match = findFreshestStoreMatch(store, ...scanTargets, ...aliasKeys);
     if (
       match &&
       (!selectedMatch || (match.entry.updatedAt ?? 0) >= (selectedMatch.entry.updatedAt ?? 0))
     ) {
       selectedStorePath = candidate.storePath;
       selectedMatch = match;
+      selectedAliasKeys = aliasKeys;
     }
   }
   return {
@@ -202,7 +223,42 @@ function loadPluginHostHookSessionEntry(params: { cfg: OpenClawConfig; sessionKe
     entry: selectedMatch?.entry,
     canonicalKey,
     storeKey: selectedMatch?.key ?? canonicalKey,
+    aliasKeys: selectedAliasKeys,
   };
+}
+
+function resolvePluginHostHookSessionAliasKeys(params: {
+  cfg: OpenClawConfig;
+  key: string;
+  canonicalKey: string;
+  store: Record<string, SessionEntry>;
+}): string[] {
+  const preservedAliasKeys = resolveGatewaySessionStorePreservedAliasKeys({
+    cfg: params.cfg,
+    key: params.key,
+    canonicalKey: params.canonicalKey,
+    storeKeys: [params.key, params.canonicalKey, ...Object.keys(params.store)],
+  });
+  return normalizeSessionStoreKeys([params.canonicalKey, ...preservedAliasKeys]);
+}
+
+function findPluginHostHookWritableSessionEntry(
+  store: Record<string, SessionEntry>,
+  loaded: ReturnType<typeof loadPluginHostHookSessionEntry>,
+): { entry: SessionEntry; key: string } | undefined {
+  return findFreshestStoreMatch(store, loaded.storeKey, loaded.canonicalKey, ...loaded.aliasKeys);
+}
+
+function syncPluginHostHookSessionAliases(
+  store: Record<string, SessionEntry>,
+  primaryKey: string,
+  loaded: ReturnType<typeof loadPluginHostHookSessionEntry>,
+) {
+  syncGatewaySessionStoreAliases({
+    store,
+    primaryKey,
+    aliasKeys: loaded.aliasKeys,
+  });
 }
 
 function isPluginPromptInjectionEnabled(cfg: OpenClawConfig, pluginId: string): boolean {
@@ -292,10 +348,11 @@ export async function enqueuePluginNextTurnInjection(params: {
   let enqueued = false;
   let resultId = record.id;
   await updateSessionStore(loaded.storePath, (store) => {
-    const entry = store[loaded.storeKey];
-    if (!entry) {
+    const match = findPluginHostHookWritableSessionEntry(store, loaded);
+    if (!match) {
       return;
     }
+    const entry = match.entry;
     const injections = { ...entry.pluginNextTurnInjections };
     // Guard against malformed/hand-edited persisted state — a non-array value
     // here would crash the spread/filter and break the whole session's enqueue.
@@ -310,17 +367,16 @@ export async function enqueuePluginNextTurnInjection(params: {
       resultId = duplicate.id;
       injections[params.pluginId] = existing;
       entry.pluginNextTurnInjections = injections;
-      return;
-    }
-    if (existing.length >= MAX_PLUGIN_NEXT_TURN_INJECTIONS_PER_SESSION) {
+    } else if (existing.length >= MAX_PLUGIN_NEXT_TURN_INJECTIONS_PER_SESSION) {
       injections[params.pluginId] = existing;
       entry.pluginNextTurnInjections = injections;
-      return;
+    } else {
+      injections[params.pluginId] = [...existing, record];
+      entry.pluginNextTurnInjections = injections;
+      entry.updatedAt = now;
+      enqueued = true;
     }
-    injections[params.pluginId] = [...existing, record];
-    entry.pluginNextTurnInjections = injections;
-    entry.updatedAt = now;
-    enqueued = true;
+    syncPluginHostHookSessionAliases(store, match.key, loaded);
   });
   return { enqueued, id: resultId, sessionKey: canonicalKey };
 }
@@ -350,10 +406,11 @@ export async function drainPluginNextTurnInjections(params: {
   }
   const now = params.now ?? Date.now();
   return await updateSessionStore(loaded.storePath, (store) => {
-    const entry = store[loaded.storeKey];
-    if (!entry?.pluginNextTurnInjections) {
+    const match = findPluginHostHookWritableSessionEntry(store, loaded);
+    if (!match?.entry.pluginNextTurnInjections) {
       return [];
     }
+    const entry = match.entry;
     const activePluginIds = new Set(
       (getActivePluginRegistry()?.plugins ?? [])
         .filter((plugin) => plugin.status === "loaded")
@@ -381,6 +438,7 @@ export async function drainPluginNextTurnInjections(params: {
     if (drained.length > 0) {
       entry.updatedAt = now;
     }
+    syncPluginHostHookSessionAliases(store, match.key, loaded);
     return drained;
   });
 }
@@ -482,10 +540,11 @@ export async function patchPluginSessionExtension(params: {
   }
   const slotKey = normalizedSlotKey?.ok === true ? normalizedSlotKey.key : undefined;
   const nextValue = await updateSessionStore(loaded.storePath, (store) => {
-    const entry = store[loaded.storeKey];
-    if (!entry) {
+    const match = findPluginHostHookWritableSessionEntry(store, loaded);
+    if (!match) {
       return undefined;
     }
+    const entry = match.entry;
     const entryRecord = entry as Record<string, unknown>;
     const pluginExtensions = { ...entry.pluginExtensions };
     const pluginState = { ...pluginExtensions[pluginId] };
@@ -539,6 +598,7 @@ export async function patchPluginSessionExtension(params: {
       }
     }
     entry.updatedAt = Date.now();
+    syncPluginHostHookSessionAliases(store, match.key, loaded);
     return pluginState[namespace] as PluginJsonValue | undefined;
   });
   return { ok: true, key: canonicalKey, value: nextValue };


### PR DESCRIPTION
Closes #63005.

## Behavior addressed

External raw session keys such as `conversation:pair:...` and opaque provider keys such as `Signal:Group:<mixed-case-id>` should survive gateway session-key canonicalization. Any follow-up mutation should keep the raw key and the visible `agent:<id>:` canonical key pointing at the same session entry instead of splitting history or plugin-owned state.

## Root cause

`migrateAndPruneGatewaySessionStoreKey` canonicalized raw external keys before preserving the raw-key store entry as an alias of the canonical agent key. The first fix preserved that raw alias, but some write paths still replaced, mutated, or deleted only one key.

The later review findings exposed the remaining gaps:

- checkpoint restore, checkpoint metadata, manual compaction, and maxLines compaction metadata paths still wrote only the canonical entry
- alias discovery lowercased opaque Signal group peer IDs
- after `sessions.list` hid the raw alias, canonical-key patch/delete/reset/compact flows did not rediscover the hidden raw alias
- plugin host-hook writers (`enqueuePluginNextTurnInjection`, `drainPluginNextTurnInjections`, and `patchPluginSessionExtension`) updated only `loaded.storeKey`, leaving hidden raw aliases with stale plugin state

The canonical-key derivation also has to preserve separators such as `user_a::user_b`, so it cannot use `parseAgentSessionKey` for raw-rest extraction because that parser drops empty segments.

## Fix

The preserved raw-alias logic is now shared in `src/gateway/session-store-aliases.ts`, with alias-aware write, sync, and delete helpers.

Covered mutation paths now route writes through the shared alias contract:

- `sessions.patch`
- `sessions.delete`
- `sessions.reset`
- agent writeback
- node-event store touches
- resolver sync
- `sessions.compaction.restore`
- compaction checkpoint metadata persistence
- `sessions.compact` manual metadata updates
- `sessions.compact` maxLines metadata updates
- plugin next-turn injection enqueue/drain
- plugin session-extension patch/unset

Preserved raw aliases stay internal-only for lookup continuity: `sessions.list` filtering/search/count collapses a raw+canonical alias pair into one visible canonical session row.

Canonical visible keys now rediscover an existing hidden raw alias by stripping the `agent:<id>:` prefix while preserving the rest of the key exactly. Canonical-only sessions do not grow a new raw alias.

Opaque Signal group peer IDs are preserved when deriving raw aliases, so mixed-case group IDs do not create lowercased duplicate logical session rows.

## Real Behavior Proof

**Behavior or issue addressed:** Raw external session aliases are preserved during canonicalization, stay synchronized across direct session mutations, compaction/checkpoint lifecycle writes, canonical visible-key follow-ups, and plugin host-hook writes, while keeping only one visible canonical row in list/search/count.

**Real environment tested:** Source checkout on PR head `1cde6d4a5d222273ed4c9c69b5d6e4ac402282c9`, base `f07c87405c3094feceaaf2f0f19a2e765a25e78d`, Node 22, repo dependencies installed.

**Exact steps or command run after this patch:**

```text
node --import tsx /private/tmp/pr83368-proof.ts
```

Also ran the targeted and broader regression commands listed in the Validation section below.

**Evidence after fix:**

```json
{
  "primaryKey": "agent:main:conversation:pair:user_a::user_b:space:space_123",
  "preservedAliasKeys": [
    "conversation:pair:user_a::user_b:space:space_123"
  ],
  "afterWrite": {
    "canonicalSessionId": "sess-write",
    "rawSessionId": "sess-write",
    "rawSendPolicy": "deny",
    "sameEntry": true
  },
  "visible": {
    "listKeys": [
      "agent:main:conversation:pair:user_a::user_b:space:space_123"
    ],
    "listCount": 1,
    "listTotalCount": 1,
    "searchKeys": [
      "agent:main:conversation:pair:user_a::user_b:space:space_123"
    ],
    "searchCount": 1,
    "searchTotalCount": 1
  },
  "deleted": true,
  "afterDelete": {
    "canonicalSessionId": null,
    "rawSessionId": null
  },
  "canonicalVisibleKeyFlow": {
    "listedKeys": [
      "agent:main:conversation:pair:user_a::user_b:space:space_123"
    ],
    "afterWrite": {
      "visibleKey": "agent:main:conversation:pair:user_a::user_b:space:space_123",
      "primaryKey": "agent:main:conversation:pair:user_a::user_b:space:space_123",
      "preservedAliasKeys": [
        "conversation:pair:user_a::user_b:space:space_123"
      ],
      "canonicalSessionId": "sess-visible-write",
      "rawSessionId": "sess-visible-write",
      "rawSendPolicy": "deny",
      "sameEntry": true
    },
    "deleted": true,
    "afterDelete": {
      "canonicalSessionId": null,
      "rawSessionId": null
    }
  }
}
```

The command printed local stale-plugin config warnings for `multica`; they are unrelated to this PR and did not affect the session-store proof.

**Observed result after fix:** The raw alias and canonical key share the same written entry after replacement, including patched `sendPolicy`; list and search return one visible canonical row with `totalCount: 1`; delete removes both keys. Starting from the visible canonical list key also rediscovers the hidden raw alias, writes both aliases, and deletes both aliases. The plugin regressions show canonical-key plugin next-turn enqueue/drain and session-extension patch/unset update or clear the hidden raw alias too.

**What was not tested:** No full live external chat-channel round trip was run. No screenshots are attached because this is backend session-store behavior with no visual UI surface.

## Regression Coverage

- `src/gateway/session-utils.test.ts` covers raw/canonical alias collapse, mixed-case Signal opaque-ID preservation, canonical-key rediscovery, and canonical-only no-new-raw-alias behavior.
- `src/gateway/server.sessions.store-rpc.test.ts` covers list-to-patch/list-to-delete using the visible canonical key while the hidden raw alias follows.
- `src/gateway/server.sessions.reset-cleanup.test.ts` covers reset alias synchronization.
- `src/gateway/session-compaction-checkpoints.test.ts` covers checkpoint metadata persistence to both aliases.
- `src/gateway/server.sessions.compaction.test.ts` covers checkpoint restore, manual compaction metadata, and maxLines compaction metadata alias sync.
- `src/plugins/contracts/host-hooks.contract.test.ts` covers canonical-key plugin next-turn injection enqueue and drain syncing the hidden raw alias.
- `src/plugins/contracts/session-entry-projection.contract.test.ts` covers canonical-key plugin session-extension patch and unset syncing the hidden raw alias and promoted slot.

## Validation

Ran on head `1cde6d4a5d222273ed4c9c69b5d6e4ac402282c9`:

```text
node scripts/run-vitest.mjs src/gateway/session-utils.test.ts src/gateway/server.sessions.store-rpc.test.ts src/plugins/contracts/host-hooks.contract.test.ts src/plugins/contracts/session-entry-projection.contract.test.ts
Test Files  6 passed (6)
Tests       347 passed (347)
```

```text
node scripts/run-vitest.mjs src/gateway/session-utils.test.ts src/gateway/server.sessions.store-rpc.test.ts src/gateway/server.sessions.reset-cleanup.test.ts src/gateway/server-methods/agent.test.ts src/gateway/server-node-events.test.ts src/gateway/sessions-resolve.test.ts src/gateway/session-compaction-checkpoints.test.ts src/gateway/server.sessions.compaction.test.ts src/plugins/contracts/host-hooks.contract.test.ts src/plugins/contracts/session-entry-projection.contract.test.ts
Test Files  17 passed (17)
Tests       650 passed (650)
```

```text
node scripts/run-oxlint.mjs src/gateway/session-store-aliases.ts src/gateway/session-utils.ts src/gateway/server-methods/sessions.ts src/plugins/host-hook-state.ts
Found 0 warnings and 0 errors.
```

```text
./node_modules/.bin/oxfmt --check --threads=1 src/gateway/session-store-aliases.ts src/gateway/session-utils.ts src/plugins/host-hook-state.ts src/plugins/contracts/host-hooks.contract.test.ts src/plugins/contracts/session-entry-projection.contract.test.ts
All matched files use the correct format.
```

```text
git diff --check
```

`pnpm docs:list` was run before editing. Broad Testbox changed gate was not run because the `blacksmith` CLI is not installed in this environment; local validation was kept to targeted gateway/plugin proof and GitHub CI is running on the pushed head.

## Screenshots

No screenshots apply because this is backend session-store alias synchronization, not a visual UI surface.
