### PR TITLE
fix(codex): keep owner-only tool schema stable

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -864,6 +864,10 @@ describe("runCodexAppServerAttempt", () => {
     expect((factoryOptions[0] as { authProfileStore?: unknown }).authProfileStore).toBe(
       authProfileStore,
     );
+    expect(
+      (factoryOptions[0] as { retainUnauthorizedOwnerOnlyTools?: unknown })
+        .retainUnauthorizedOwnerOnlyTools,
+    ).toBe(true);
   });
 
   it("keeps canonical OpenAI Codex runs on OpenAI dynamic tool policy", async () => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -3069,6 +3069,7 @@ async function buildDynamicTools(input: DynamicToolBuildParams) {
     senderUsername: params.senderUsername,
     senderE164: params.senderE164,
     senderIsOwner: params.senderIsOwner,
+    retainUnauthorizedOwnerOnlyTools: true,
     allowGatewaySubagentBinding:
       params.allowGatewaySubagentBinding || isForcedPrivateQaCodexRuntime(),
     ...sessionKeys,

--- a/src/agents/pi-tools.owner-only-gating.test.ts
+++ b/src/agents/pi-tools.owner-only-gating.test.ts
@@ -38,6 +38,18 @@ describe("owner-only tool gating", () => {
     expect(toolNames).toContain("nodes");
   });
 
+  it("can keep owner-only schemas stable for unauthorized runtime turns", () => {
+    const tools = createOpenClawCodingTools({
+      senderIsOwner: false,
+      retainUnauthorizedOwnerOnlyTools: true,
+    });
+    const toolNames = tools.map((tool) => tool.name);
+    expect(toolNames).toContain("plugin_login");
+    expect(toolNames).toContain("cron");
+    expect(toolNames).toContain("gateway");
+    expect(toolNames).toContain("nodes");
+  });
+
   it("keeps canvas available to unauthorized senders by current trust model", () => {
     const tools = createOpenClawCodingTools({ senderIsOwner: false });
     const toolNames = tools.map((tool) => tool.name);

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -458,6 +458,11 @@ export function createOpenClawCodingTools(options?: {
    * Keep this narrowly scoped; it is not a replacement for sender ownership.
    */
   ownerOnlyToolAllowlist?: string[];
+  /**
+   * Keep unauthorized owner-only tools visible for runtimes that need stable
+   * tool schemas across trust-level flips. Execution remains fail-closed.
+   */
+  retainUnauthorizedOwnerOnlyTools?: boolean;
   /** Auth profiles already loaded for this run; used for prompt-time tool availability. */
   authProfileStore?: AuthProfileStore;
   /** Callback invoked when sessions_yield tool is called. */
@@ -1017,6 +1022,7 @@ export function createOpenClawCodingTools(options?: {
     toolsForModelProvider,
     senderIsOwner,
     options?.ownerOnlyToolAllowlist,
+    { retainUnauthorizedOwnerOnlyTools: options?.retainUnauthorizedOwnerOnlyTools === true },
   );
   const subagentFiltered = applyToolPolicyPipeline({
     tools: toolsByAuthorization,

--- a/src/agents/tool-policy.test.ts
+++ b/src/agents/tool-policy.test.ts
@@ -131,6 +131,18 @@ describe("tool-policy", () => {
     });
   });
 
+  it("can retain unauthorized owner-only tools while keeping execution guarded", async () => {
+    const tools = createOwnerPolicyTools();
+    const filtered = applyOwnerOnlyToolPolicy(tools, false, undefined, {
+      retainUnauthorizedOwnerOnlyTools: true,
+    });
+    expect(filtered.map((t) => t.name)).toEqual(["read", "cron", "gateway", "nodes"]);
+
+    await expect(
+      filtered.find((tool) => tool.name === "cron")?.execute?.("call_1", {}),
+    ).rejects.toThrow("Tool restricted to owner senders.");
+  });
+
   it("honors ownerOnly metadata for custom tool names", () => {
     const tools = [
       {

--- a/src/agents/tool-policy.ts
+++ b/src/agents/tool-policy.ts
@@ -54,6 +54,7 @@ export function applyOwnerOnlyToolPolicy(
   tools: AnyAgentTool[],
   senderIsOwner: boolean,
   ownerOnlyToolAllowlist?: string[],
+  options?: { retainUnauthorizedOwnerOnlyTools?: boolean },
 ) {
   const allowedOwnerOnlyTools = new Set(
     ownerOnlyToolAllowlist?.map((name) => normalizeToolName(name)) ?? [],
@@ -67,6 +68,9 @@ export function applyOwnerOnlyToolPolicy(
     return wrapOwnerOnlyToolExecution(tool, isAuthorized(tool));
   });
   if (senderIsOwner) {
+    return withGuard;
+  }
+  if (options?.retainUnauthorizedOwnerOnlyTools === true) {
     return withGuard;
   }
   return withGuard.filter((tool) => !isOwnerOnlyTool(tool) || isAuthorized(tool));


### PR DESCRIPTION
Closes #76179.

## Behavior addressed

The Codex app-server should keep its native-thread tool schema stable when owner-only tool availability flips. Non-owner senders still must not be able to execute owner-only tools.

## Root cause

The shared owner-only policy removed unauthorized owner-only tools from the tool list. That default is correct for normal callers, but the Codex runtime needs a stable schema across owner-context changes; removing and re-adding those tools made the app-server restart native threads when the available tool schema changed.

## Fix

Add an explicit owner-only policy mode that retains unauthorized owner-only tools as guarded stubs, then use it in the Codex runtime path. The normal policy still filters owner-only tools for non-owner callers. Regression coverage is in the core tool-policy tests and Codex app-server schema/runtime tests.

## Real behavior proof

**Behavior or issue addressed:** Owner-only tools can be retained for a stable Codex schema while their execution remains blocked for non-owner senders.

**Real environment tested:** PR head `563ed9f1645f9586e4502dae676a9e0b90afbe66`, rebased onto `upstream/main` `3b5d30b5fdfd2d9e1e2f1c97242444467dce53c0`; source checkout with Node 22 for the targeted proof command.

**Exact steps or command run after this patch:**

```bash
node --import tsx -e 'const { applyOwnerOnlyToolPolicy } = await import("./src/agents/tool-policy.ts"); const tools = [{ name: "read", execute: async () => "read-ok" }, { name: "cron", ownerOnly: true, execute: async () => "cron-ok" }, { name: "gateway", ownerOnly: true, execute: async () => "gateway-ok" }, { name: "nodes", ownerOnly: true, execute: async () => "nodes-ok" }]; const defaultTools = applyOwnerOnlyToolPolicy(tools, false); const retainedTools = applyOwnerOnlyToolPolicy(tools, false, undefined, { retainUnauthorizedOwnerOnlyTools: true }); let guardError = "none"; try { await retainedTools.find((tool) => tool.name === "cron")?.execute?.(); } catch (err) { guardError = err instanceof Error ? err.message : String(err); } console.log(JSON.stringify({ defaultVisible: defaultTools.map((tool) => tool.name), retainedVisible: retainedTools.map((tool) => tool.name), guardError }, null, 2));'
```

**Evidence after fix:** Terminal output from the direct after-fix command:

```json
{
  "defaultVisible": [
    "read"
  ],
  "retainedVisible": [
    "read",
    "cron",
    "gateway",
    "nodes"
  ],
  "guardError": "Tool restricted to owner senders."
}
```

**Observed result after fix:** The default policy still exposes only the non-owner-safe `read` tool. The Codex schema-stability mode retains the owner-only tool names, and executing one as a non-owner fails before privileged behavior with `Tool restricted to owner senders.`

**What was not tested:** I did not run a full live Codex native-thread session restart loop; there is no visual surface, so screenshots are not applicable. The terminal proof exercises the production policy seam, and the focused Codex app-server tests cover the runtime schema contract.

Additional checks after the rebase:

- `pnpm docs:list` ran before touching the PRs.
- `node scripts/run-vitest.mjs src/agents/tool-policy.test.ts src/agents/pi-tools.owner-only-gating.test.ts extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/dynamic-tools.test.ts extensions/codex/src/app-server/schema-normalization-runtime-contract.test.ts` passed: `Test Files 6 passed (6)`, `Tests 241 passed (241)`.
- `git diff --check upstream/main...HEAD` passed.
- `./node_modules/.bin/oxfmt --check --threads=1 extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/run-attempt.ts src/agents/pi-tools.owner-only-gating.test.ts src/agents/pi-tools.ts src/agents/tool-policy.test.ts src/agents/tool-policy.ts` passed.
