### PR TITLE
fix(gateway): report unqueued restart continuations

### DIFF
--- a/src/agents/tools/gateway-tool.test.ts
+++ b/src/agents/tools/gateway-tool.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RestartSentinelPayload } from "../../infra/restart-sentinel.js";
-import type { scheduleGatewaySigusr1Restart } from "../../infra/restart.js";
+import type { scheduleGatewaySigusr1Restart, ScheduledRestart } from "../../infra/restart.js";
 import { createGatewayTool } from "./gateway-tool.js";
 
 type ScheduleGatewayRestartArgs = Parameters<typeof scheduleGatewaySigusr1Restart>[0];
@@ -25,10 +25,18 @@ const {
   formatDoctorNonInteractiveHintMock: vi.fn(() => "Run: openclaw doctor --non-interactive"),
   writeRestartSentinelMock: vi.fn(async (_payload: RestartSentinelPayload) => "/tmp/restart"),
   removeRestartSentinelFileMock: vi.fn(async (_path: string | null | undefined) => undefined),
-  scheduleGatewaySigusr1RestartMock: vi.fn((_opts?: ScheduleGatewayRestartArgs) => ({
-    scheduled: true,
-    delayMs: 250,
-  })),
+  scheduleGatewaySigusr1RestartMock: vi.fn(
+    (_opts?: ScheduleGatewayRestartArgs): ScheduledRestart => ({
+      ok: true,
+      pid: 123,
+      signal: "SIGUSR1",
+      delayMs: 250,
+      mode: "emit",
+      coalesced: false,
+      cooldownMsApplied: 0,
+      emitHooksQueued: true,
+    }),
+  ),
 }));
 
 vi.mock("../../config/commands.js", () => ({
@@ -103,7 +111,16 @@ describe("gateway tool restart continuation", () => {
     writeRestartSentinelMock.mockResolvedValue("/tmp/restart");
     removeRestartSentinelFileMock.mockClear();
     scheduleGatewaySigusr1RestartMock.mockReset();
-    scheduleGatewaySigusr1RestartMock.mockReturnValue({ scheduled: true, delayMs: 250 });
+    scheduleGatewaySigusr1RestartMock.mockReturnValue({
+      ok: true,
+      pid: 123,
+      signal: "SIGUSR1",
+      delayMs: 250,
+      mode: "emit",
+      coalesced: false,
+      cooldownMsApplied: 0,
+      emitHooksQueued: true,
+    });
   });
 
   it("does not expose system-event continuations to the agent tool", async () => {
@@ -162,7 +179,46 @@ describe("gateway tool restart continuation", () => {
     expect(restartArgs.reason).toBe("continue after reboot");
     expect(typeof restartArgs.emitHooks?.beforeEmit).toBe("function");
     expect(typeof restartArgs.emitHooks?.afterEmitRejected).toBe("function");
-    expect(result?.details).toEqual({ scheduled: true, delayMs: 250 });
+    expect(result?.details).toEqual({
+      ok: true,
+      pid: 123,
+      signal: "SIGUSR1",
+      delayMs: 250,
+      mode: "emit",
+      coalesced: false,
+      cooldownMsApplied: 0,
+      emitHooksQueued: true,
+      continuationQueued: true,
+    });
+  });
+
+  it("reports when a restart continuation was accepted but not queued", async () => {
+    scheduleGatewaySigusr1RestartMock.mockReturnValue({
+      ok: true,
+      pid: 123,
+      signal: "SIGUSR1",
+      delayMs: 0,
+      mode: "emit",
+      coalesced: true,
+      cooldownMsApplied: 0,
+      emitHooksQueued: false,
+    });
+    const tool = createGatewayTool({
+      agentSessionKey: "agent:main:main",
+      config: {},
+    });
+
+    const result = await tool.execute?.("tool-call-1", {
+      action: "restart",
+      continuationMessage: "Reply after restart",
+    });
+
+    expect(writeRestartSentinelMock).not.toHaveBeenCalled();
+    expect(result?.details).toMatchObject({
+      coalesced: true,
+      emitHooksQueued: false,
+      continuationQueued: false,
+    });
   });
 
   it("coerces legacy continuationKind inputs to an agentTurn", async () => {

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -428,7 +428,10 @@ export function createGatewayTool(opts?: {
             },
           },
         });
-        return jsonResult(scheduled);
+        return jsonResult({
+          ...scheduled,
+          ...(payload.continuation ? { continuationQueued: scheduled.emitHooksQueued } : {}),
+        });
       }
 
       const gatewayOpts = readGatewayCallOptions(params);

--- a/src/infra/infra-runtime.test.ts
+++ b/src/infra/infra-runtime.test.ts
@@ -288,12 +288,36 @@ describe("infra runtime", () => {
 
         expect(first.coalesced).toBe(false);
         expect(second.coalesced).toBe(true);
+        expect(second.emitHooksQueued).toBe(true);
 
         await vi.advanceTimersByTimeAsync(1_000);
 
         expect(firstBeforeEmit).not.toHaveBeenCalled();
         expect(latestBeforeEmit).toHaveBeenCalledTimes(1);
         expect(emitSpy).toHaveBeenCalledWith("SIGUSR1");
+      } finally {
+        process.removeListener("SIGUSR1", handler);
+      }
+    });
+
+    it("reports hooks as not queued when restart already emitted", () => {
+      const beforeEmit = vi.fn(async () => {});
+      const emitSpy = vi.spyOn(process, "emit");
+      const handler = () => {};
+      process.on("SIGUSR1", handler);
+      try {
+        expect(emitGatewayRestart("already-emitted")).toBe(true);
+
+        const second = scheduleGatewaySigusr1Restart({
+          delayMs: 0,
+          reason: "second",
+          emitHooks: { beforeEmit },
+        });
+
+        expect(second.coalesced).toBe(true);
+        expect(second.emitHooksQueued).toBe(false);
+        expect(beforeEmit).not.toHaveBeenCalled();
+        expect(countSigusr1Emits(emitSpy.mock.calls)).toBe(1);
       } finally {
         process.removeListener("SIGUSR1", handler);
       }

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -693,6 +693,7 @@ export type ScheduledRestart = {
   mode: "emit" | "signal" | "supervisor";
   coalesced: boolean;
   cooldownMsApplied: number;
+  emitHooksQueued: boolean;
 };
 
 export function scheduleGatewaySigusr1Restart(opts?: {
@@ -738,6 +739,7 @@ export function scheduleGatewaySigusr1Restart(opts?: {
       mode,
       coalesced: true,
       cooldownMsApplied,
+      emitHooksQueued: false,
     };
   }
 
@@ -760,6 +762,7 @@ export function scheduleGatewaySigusr1Restart(opts?: {
         mode,
         coalesced: false,
         cooldownMsApplied,
+        emitHooksQueued: opts?.emitHooks !== undefined,
       };
     }
     const shouldUpgradeToSkipDeferral = skipDeferral && !pendingRestartSkipDeferral;
@@ -789,6 +792,7 @@ export function scheduleGatewaySigusr1Restart(opts?: {
         mode,
         coalesced: true,
         cooldownMsApplied,
+        emitHooksQueued: opts?.emitHooks !== undefined,
       };
     }
   }
@@ -829,6 +833,7 @@ export function scheduleGatewaySigusr1Restart(opts?: {
     mode,
     coalesced: false,
     cooldownMsApplied,
+    emitHooksQueued: opts?.emitHooks !== undefined,
   };
 }
 


### PR DESCRIPTION
Closes #74424.

## Behavior addressed

When a gateway restart request coalesces with an in-flight restart, the caller should be told that its continuation hook was not queued. The continuation must not be silently dropped while the user-visible result implies that follow-up work will still run.

## Root cause

`scheduleGatewaySigusr1Restart` returned only the coalesced restart state. Callers could not distinguish “restart already in-flight and continuation queued” from “restart already in-flight and this continuation was not queued,” so the gateway tool could report success even though the continuation hook would never run.

## Fix

Return an explicit `emitHooksQueued` flag from restart scheduling and surface the unqueued-continuation case through the gateway restart tool. Regression coverage is in `src/infra/infra-runtime.test.ts` and `src/agents/tools/gateway-tool.test.ts`.

## Real behavior proof

**Behavior or issue addressed:** Coalesced restart requests now report that their continuation hooks were not queued when a restart has already been emitted.

**Real environment tested:** PR head `e15e7f920a95bcb257fd111c64c59534ff0ec1c8`, rebased onto `upstream/main` `3b5d30b5fdfd2d9e1e2f1c97242444467dce53c0`; source checkout with Node 22 for the targeted proof command.

**Exact steps or command run after this patch:**

```bash
node --import tsx -e 'const restart = await import("./src/infra/restart.ts"); const { scheduleGatewaySigusr1Restart, emitGatewayRestart, __testing } = restart; __testing.resetSigusr1State(); const beforeEmitCalls = []; const handler = () => {}; process.on("SIGUSR1", handler); try { const emitted = emitGatewayRestart("already-emitted"); const second = scheduleGatewaySigusr1Restart({ delayMs: 0, reason: "second", emitHooks: { beforeEmit: async () => { beforeEmitCalls.push("called"); } } }); console.log(JSON.stringify({ emitted, coalesced: second.coalesced, emitHooksQueued: second.emitHooksQueued, beforeEmitCalls: beforeEmitCalls.length }, null, 2)); } finally { process.removeListener("SIGUSR1", handler); __testing.resetSigusr1State(); }'
```

**Evidence after fix:** Terminal output from the direct after-fix command:

```text
[restart] request coalesced (already in-flight) reason=second actor=<unknown>
{
  "emitted": true,
  "coalesced": true,
  "emitHooksQueued": false,
  "beforeEmitCalls": 0
}
```

**Observed result after fix:** The first restart emits successfully. The second restart coalesces, reports `emitHooksQueued: false`, and the continuation hook is not called. That is the state the gateway tool now uses to alert the user instead of implying the continuation was queued.

**What was not tested:** I did not restart a live Gateway process because this proof intentionally avoids sending SIGUSR1 to the developer machine; there is no visual surface, so screenshots are not applicable. The terminal proof exercises the production restart scheduling seam with a process signal handler installed.

Additional checks after the rebase:

- `pnpm docs:list` ran before touching the PRs.
- `node scripts/run-vitest.mjs src/infra/infra-runtime.test.ts src/agents/tools/gateway-tool.test.ts` passed: `Test Files 3 passed (3)`, `Tests 42 passed (42)`.
- `git diff --check upstream/main...HEAD` passed.
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/tools/gateway-tool.test.ts src/agents/tools/gateway-tool.ts src/infra/infra-runtime.test.ts src/infra/restart.ts` passed.
