### PR TITLE
test(channels): preserve thread origin contracts

### DIFF
--- a/src/channels/inbound-event/context.test.ts
+++ b/src/channels/inbound-event/context.test.ts
@@ -228,6 +228,31 @@ describe("buildChannelInboundEventContext", () => {
     expect(ctx.InboundEventKind).toBe("room_event");
   });
 
+  it("preserves thread-addressable origins alongside flat reply targets", () => {
+    const ctx = buildChannelInboundEventContext(
+      createBaseContextParams({
+        conversation: {
+          kind: "group",
+          id: "room-1",
+          threadId: "topic-42",
+          routePeer: {
+            kind: "group",
+            id: "room-1",
+          },
+        },
+        reply: {
+          to: "test:room:room-1",
+          originatingTo: "test:room:room-1:topic:topic-42",
+          messageThreadId: "topic-42",
+        },
+      }),
+    );
+
+    expect(ctx.To).toBe("test:room:room-1");
+    expect(ctx.OriginatingTo).toBe("test:room:room-1:topic:topic-42");
+    expect(ctx.MessageThreadId).toBe("topic-42");
+  });
+
   it("keeps legacy command authorization fallback for authorizer arrays", () => {
     const ctx = buildChannelInboundEventContext(
       createBaseContextParams({

--- a/src/hooks/message-hook-mappers.test.ts
+++ b/src/hooks/message-hook-mappers.test.ts
@@ -131,6 +131,33 @@ describe("message hook mappers", () => {
     expect(canonical.messageId).toBe("override-msg");
   });
 
+  it("uses OriginatingTo as the canonical conversation when To is flat", () => {
+    const canonical = deriveInboundMessageHookContext(
+      makeInboundCtx({
+        To: "demo-chat:chat:456",
+        OriginatingTo: "demo-chat:chat:456:topic:42",
+        MessageThreadId: 42,
+      }),
+    );
+
+    expect(canonical.to).toBe("demo-chat:chat:456");
+    expect(canonical.conversationId).toBe("demo-chat:chat:456:topic:42");
+    expect(canonical.originatingTo).toBe("demo-chat:chat:456:topic:42");
+
+    const pluginContext = toPluginMessageContext(canonical);
+    expect(pluginContext.conversationId).toBe("demo-chat:chat:456:topic:42");
+
+    const receivedEvent = toPluginMessageReceivedEvent(canonical);
+    expect(receivedEvent.metadata?.to).toBe("demo-chat:chat:456");
+    expect(receivedEvent.metadata?.originatingTo).toBe("demo-chat:chat:456:topic:42");
+    expect(receivedEvent.metadata?.threadId).toBe(42);
+
+    const internalReceived = toInternalMessageReceivedContext(canonical);
+    expect(internalReceived.conversationId).toBe("demo-chat:chat:456:topic:42");
+    expect(internalReceived.metadata?.to).toBe("demo-chat:chat:456");
+    expect(internalReceived.metadata?.threadId).toBe(42);
+  });
+
   it("preserves multi-attachment arrays for inbound claim metadata", () => {
     const canonical = deriveInboundMessageHookContext(
       makeInboundCtx({


### PR DESCRIPTION
## Summary
- Add a core inbound context contract proving thread-addressable `OriginatingTo` survives beside flat `To`.
- Add hook mapper coverage proving `OriginatingTo` remains the canonical conversation id when `To` is flat.
- Keep provider-specific target grammar in the owning plugins; this PR only hardens the shared contract after #83351.

## Verification
- `pnpm test src/channels/inbound-event/context.test.ts src/hooks/message-hook-mappers.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --mode branch`
- `pnpm check:changed`

## Real behavior proof
- Behavior addressed: core/hook regression coverage now guards the thread-origin contract that caused Telegram forum-topic follow-up delivery to flatten topic context.
- Real environment tested: local OpenClaw checkout plus Blacksmith Testbox changed-gate run on branch `harden/thread-origin-contracts`.
- Exact steps or command run after this patch: `pnpm test src/channels/inbound-event/context.test.ts src/hooks/message-hook-mappers.test.ts`; `.agents/skills/autoreview/scripts/autoreview --mode branch`; `pnpm check:changed`.
- Evidence after fix: focused Vitest passed 2 files/22 tests locally; autoreview clean; Testbox `tbx_01krwaztbwm13sx9e4sbyyz4c1` passed `coreTests` via https://github.com/openclaw/openclaw/actions/runs/26008615677.
- Observed result after fix: `OriginatingTo` remains topic-qualified while `To` can remain flat, and hook canonical conversation mapping follows `OriginatingTo`.
- What was not tested: no live provider delivery in this follow-up; live behavior was fixed in #83351 and this PR is contract/test hardening.
