### PR TITLE
fix(migrate): use plan.summary for header conflict/sensitive counts (#83284)

### DIFF
--- a/src/commands/migrate/output.test.ts
+++ b/src/commands/migrate/output.test.ts
@@ -81,6 +81,61 @@ describe("formatMigrationPreview", () => {
     expect(output).not.toContain("codex-plugins-root");
   });
 
+  it("reports hidden-config conflicts in the header from plan.summary (#83284)", () => {
+    // Pre-fix, the header derived conflict and sensitive counts from the
+    // post-HIDDEN_KINDS filter, so a plan whose only conflicts lived in
+    // hidden 'config' items reported '0 conflicts' in the preview even
+    // though assertConflictFreePlan (which reads plan.summary.conflicts)
+    // still blocked apply. Header must reflect the same summary numbers
+    // that gate apply-time conflict checks.
+    const conflictedConfig: MigrationItem = {
+      ...configItem(),
+      status: "conflict",
+    };
+    const planWithHiddenConflict: MigrationPlan = {
+      ...plan([skillItem(1), conflictedConfig]),
+      summary: {
+        total: 2,
+        planned: 1,
+        migrated: 0,
+        skipped: 0,
+        conflicts: 1,
+        errors: 0,
+        sensitive: 0,
+      },
+    };
+    const output = formatMigrationPreview(planWithHiddenConflict)
+      .map(stripAnsi)
+      .join("\n");
+    expect(output).toContain("1 item, 1 conflict, 0 sensitive items");
+    // Hidden config item must still not appear in the body groupings.
+    expect(output).not.toContain("Config:");
+    expect(output).not.toContain("codex-plugins-root");
+  });
+
+  it("reports hidden-config sensitive count in the header from plan.summary (#83284)", () => {
+    const sensitiveConfig: MigrationItem = {
+      ...configItem(),
+      sensitive: true,
+    };
+    const planWithHiddenSensitive: MigrationPlan = {
+      ...plan([skillItem(1), sensitiveConfig]),
+      summary: {
+        total: 2,
+        planned: 2,
+        migrated: 0,
+        skipped: 0,
+        conflicts: 0,
+        errors: 0,
+        sensitive: 1,
+      },
+    };
+    const output = formatMigrationPreview(planWithHiddenSensitive)
+      .map(stripAnsi)
+      .join("\n");
+    expect(output).toContain("1 item, 0 conflicts, 1 sensitive item");
+  });
+
   it("renders migration warnings with a warning glyph", () => {
     const output = formatMigrationPreview({
       ...plan([skillItem(1)]),

--- a/src/commands/migrate/output.ts
+++ b/src/commands/migrate/output.ts
@@ -15,14 +15,19 @@ function formatPlanHeader(plan: MigrationPlan, heading: string): string[] {
   if (plan.target) {
     lines.push(`Target: ${plan.target}`);
   }
+  // #83284: previously the conflict and sensitive counts were derived from
+  // the post-HIDDEN_KINDS filter, so a plan whose only conflicts lived under
+  // hidden `config` items reported "0 conflicts" in the preview header even
+  // though assertConflictFreePlan (which reads plan.summary.conflicts) would
+  // still throw at apply time. Use plan.summary for the accuracy-critical
+  // counts; keep the item count derived from the visible list since the
+  // groupings below only render visible items.
   const visible = plan.items.filter((item) => !HIDDEN_KINDS.has(item.kind));
-  const visibleConflicts = visible.filter((item) => item.status === "conflict").length;
-  const visibleSensitive = visible.filter((item) => item.sensitive === true).length;
   lines.push(
     [
       formatCount(visible.length, "item"),
-      formatCount(visibleConflicts, "conflict"),
-      formatCount(visibleSensitive, "sensitive item"),
+      formatCount(plan.summary.conflicts, "conflict"),
+      formatCount(plan.summary.sensitive, "sensitive item"),
     ].join(", "),
   );
   return lines;


### PR DESCRIPTION
Fixes #83284.

`formatPlanHeader` derived the migration preview header's conflict and sensitive counts from the post-`HIDDEN_KINDS` filter of `plan.items`. So a plan whose only conflicts (or sensitive items) lived under hidden `config` items reported "0 conflicts" in the preview header even though `assertConflictFreePlan` — which reads `plan.summary.conflicts` directly — still blocked apply at runtime with `Migration has 1 conflict. Re-run with --overwrite...`.

This patch derives the conflict and sensitive counts in the header from `plan.summary` (the same source `assertConflictFreePlan` consults). The item count stays derived from the visible list because the groupings below only render visible items — that piece is intentionally hidden, but the gating counts must be honest.

## Changes

- `src/commands/migrate/output.ts`: replace `visibleConflicts` / `visibleSensitive` derivations with `plan.summary.conflicts` / `plan.summary.sensitive`. 7-line comment block referencing #83284.
- `src/commands/migrate/output.test.ts`: 2 new regression cases. The hidden config item must still be redacted from the body groupings.

## Real behavior proof

- **Behavior or issue addressed:** Preview header reported "0 conflicts" / "0 sensitive items" when those counts came from hidden config items. Operator saw the preview as conflict-free, ran `openclaw migrate apply`, and got `Migration has 1 conflict` at runtime.

- **Real environment tested:** Local Node 22.x. Probe at `/tmp/probe_83284.mjs` replays the exact `formatPlanHeader` count expression for OLD and NEW shapes across three scenarios (hidden-config conflict, hidden-config sensitive, all-visible-with-conflict).

- **Exact steps or command run after this patch:** `node /tmp/probe_83284.mjs`

- **Evidence after fix:**

```
OLD header: 1 item, 0 conflicts, 0 sensitive items
NEW header: 1 item, 1 conflict, 0 sensitive items

PASS: OLD shows 0 conflicts despite plan.summary.conflicts=1 (bug confirmed)
PASS: NEW surfaces hidden conflict count from plan.summary
NEW sens hdr: 1 item, 0 conflicts, 1 sensitive item
PASS: NEW surfaces hidden sensitive count from plan.summary
NEW visible-only hdr: 2 items, 1 conflict, 1 sensitive item
PASS: visible-only plan counts unchanged

ALL CASES PASS
```

- **Observed result after fix:** Header conflict / sensitive numbers now match `assertConflictFreePlan`'s view of the plan. Hidden config items remain redacted from the body (no regression on the existing `hides config items from display and excludes them from the count` test for the *visible item* count). All-visible plans (the common case) are unaffected — their `plan.summary.conflicts` already equaled the visible-conflict count.

- **What was not tested:** Full end-to-end migration with a real provider whose plan contains hidden-config conflicts. The new vitest cases cover the exact public path (`formatMigrationPreview`) with synthetic plans that mirror the issue's repro shape; the probe verifies the count expression in isolation.

## Audit (per CLAUDE rules)

- **Existing-helper check:** Reuses the existing `formatCount` helper. No new predicate. PASS
- **Shared-helper caller check:** `formatPlanHeader` is file-local with two callers (`formatMigrationPreview` + `formatMigrationResult`). Both want accurate counts — the result formatter especially, since it's shown after `assertConflictFreePlan` may have blocked. PASS
- **Broader-fix rival scan:** No open PRs touching `formatPlanHeader` / `HIDDEN_KINDS` / `assertConflictFreePlan` as of branch SHA. PASS
