### PR TITLE
fix(cli): ensure `infer model run` exits non-zero on empty gateway output

### DIFF
--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -895,6 +895,25 @@ describe("capability cli", () => {
     expect(mocks.runtime.writeJson).not.toHaveBeenCalled();
   });
 
+  it("fails gateway model probes when the provider returns no text output", async () => {
+    mocks.callGateway.mockResolvedValueOnce({
+      result: {
+        payloads: [],
+        meta: { agentMeta: { provider: "openai", model: "gpt-5.5" } },
+      },
+    });
+
+    await expect(
+      runRegisteredCli({
+        register: registerCapabilityCli as (program: Command) => void,
+        argv: ["capability", "model", "run", "--prompt", "hello", "--gateway", "--json"],
+      }),
+    ).rejects.toThrow("exit 1");
+
+    expectRuntimeErrorContains('No text output returned for provider "openai" model "gpt-5.5"');
+    expect(mocks.runtime.writeJson).not.toHaveBeenCalled();
+  });
+
   it("rejects local Codex provider probes before simple-completion dispatch", async () => {
     mocks.prepareSimpleCompletionModelForAgent.mockResolvedValueOnce({
       selection: {

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -843,6 +843,22 @@ async function runModelRun(params: {
     mode: hasModelOverride ? GATEWAY_CLIENT_MODES.BACKEND : GATEWAY_CLIENT_MODES.CLI,
     ...(hasModelOverride ? { scopes: [ADMIN_SCOPE] } : {}),
   });
+  const gatewayOutputs = (response?.result?.payloads ?? []).map((payload) => ({
+    text: payload.text,
+    mediaUrl: payload.mediaUrl,
+    mediaUrls: payload.mediaUrls,
+  }));
+  const gatewayText = gatewayOutputs
+    .map((o) => (typeof o.text === "string" ? o.text : ""))
+    .join("")
+    .trim();
+  if (!gatewayText) {
+    const gatewayProvider = response?.result?.meta?.agentMeta?.provider ?? "unknown";
+    const gatewayModel = response?.result?.meta?.agentMeta?.model ?? "unknown";
+    throw new Error(
+      `No text output returned for provider "${gatewayProvider}" model "${gatewayModel}".`,
+    );
+  }
   return {
     ok: true,
     capability: "model.run",
@@ -850,11 +866,7 @@ async function runModelRun(params: {
     provider: response?.result?.meta?.agentMeta?.provider,
     model: response?.result?.meta?.agentMeta?.model,
     attempts: response?.result?.meta?.agentMeta?.fallbackAttempts ?? [],
-    outputs: (response?.result?.payloads ?? []).map((payload) => ({
-      text: payload.text,
-      mediaUrl: payload.mediaUrl,
-      mediaUrls: payload.mediaUrls,
-    })),
+    outputs: gatewayOutputs,
     ...(imageFiles.length > 0
       ? {
           inputs: imageFiles.map((image) => ({


### PR DESCRIPTION
## Summary

Related to #83280 (this PR fixes the gateway transport path only; the default local transport path is a separate issue).

When `openclaw infer model run` routes through the **gateway transport** and the provider returns empty payloads (e.g. ChatGPT-Team usage-limit), `runModelRun()` returned `{ ok: true }` without checking whether the gateway response contained any usable text — resulting in exit code 0 despite no inference output.

The **local transport** path already had an empty-text check that throws (line 772), causing `runCommandWithRuntime` to propagate `runtime.exit(1)`. The gateway path lacked this check.

## Changes

- **`src/cli/capability-cli.ts`**: After the gateway `callGateway()` call, collect text from response payloads and throw `Error` when empty — matching the local transport's existing behavior.
- **`src/cli/capability-cli.test.ts`**: Add test `fails gateway model probes when the provider returns no text output` verifying exit 1 and the error message.

## Real behavior proof

**Behavior addressed:** `openclaw infer model run --gateway` now exits non-zero when the gateway returns empty payloads (provider usage-limit or empty response), matching the existing local transport error path.

**Real environment tested:** Ubuntu 24.04, Node v22.22.2, openclaw `main` at 9aa46843ec.

**Exact steps or command run after this patch:**
1. Applied patch to `src/cli/capability-cli.ts`
2. Ran `openclaw infer model run --gateway --prompt hello` against a gateway with no configured provider (triggers empty payloads response)

**Evidence after fix:**
Terminal output after the patch:
```
$ openclaw infer model run --gateway --prompt hello
Error: No text output returned for provider "unknown" model "unknown".
$ echo $?
1
```

Before the patch, the same command exited 0 with no error message when the gateway returned empty payloads.

Unit test confirmation (supplemental):
```
$ npx vitest run src/cli/capability-cli.test.ts -t 'fails gateway model probes'
 ✓ cli src/cli/capability-cli.test.ts (77 tests | 76 skipped) 22ms
 Test Files  1 passed (1)
```

**Observed result after fix:** The gateway transport path now throws on empty payloads, `runCommandWithRuntime` catches it and calls `runtime.exit(1)`, producing exit code 1 with the error printed to stderr — consistent with the local transport's behavior.

**What was not tested:** Live ChatGPT-Team usage-limit reproduction (requires a real account at its limit). The fix applies the same check pattern as the local transport path which is already proven in production.

---
*AI-assisted (kagura-agent)*