### PR TITLE
fix(browser): tighten bridge diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ Docs: https://docs.openclaw.ai
 - Agents/OpenAI: stop post-processing GPT-5 final replies with hardcoded brevity caps, preserving full channel responses instead of appending synthetic ellipses, and log when strict-agentic GPT-5 execution activates. Fixes #82910.
 - Mac app: refine the Settings General and Connection panes with cleaner status panels, card rows, and a single native titlebar sidebar toggle.
 - Agents/media: deliver failed async image, music, and video generation completions directly when requester-session completion handoff fails, so channel users see provider errors instead of silent fallback stalls.
+- Browser/CDP: keep loopback proxy bypass active across both `NO_PROXY` casings and redact home-relative Chrome MCP profile paths in attach-failure diagnostics.
 - Agents/music: steer song, jingle, beat, anthem, and instrumental requests toward `music_generate` audio creation instead of lyric-only replies, and reserve `lyrics` for exact sung words.
 - Codex app-server: record native Codex tool calls and results into trajectory artifacts so debug/trajectory exports capture the full Codex-native tool history, not just OpenClaw-bridged turns. Thanks @vyctorbrzezowski.
 - Codex/app-server: keep bound conversation sessions on the owning agent runtime so native Codex control and follow-up turns do not fall back to the default agent client. Fixes #82954. (#82993)

--- a/extensions/browser/src/browser/cdp-proxy-bypass.test.ts
+++ b/extensions/browser/src/browser/cdp-proxy-bypass.test.ts
@@ -309,6 +309,30 @@ describe("withNoProxyForLocalhost preserves user-configured NO_PROXY", () => {
     }
   });
 
+  it("extends both NO_PROXY casings when only one casing already covers loopback", async () => {
+    const coveredNoProxy = "localhost,127.0.0.1,[::1],myhost.internal";
+    const staleLowerNoProxy = "myhost.internal";
+    process.env.NO_PROXY = coveredNoProxy;
+    process.env.no_proxy = staleLowerNoProxy;
+    process.env.HTTP_PROXY = "http://proxy:8080";
+
+    try {
+      const { withNoProxyForLocalhost } = await import("./cdp-proxy-bypass.js");
+
+      await withNoProxyForLocalhost(async () => {
+        expect(process.env.NO_PROXY).toBe(`${coveredNoProxy},localhost,127.0.0.1,[::1]`);
+        expect(process.env.no_proxy).toBe(`${coveredNoProxy},localhost,127.0.0.1,[::1]`);
+      });
+
+      expect(process.env.NO_PROXY).toBe(coveredNoProxy);
+      expect(process.env.no_proxy).toBe(staleLowerNoProxy);
+    } finally {
+      delete process.env.HTTP_PROXY;
+      delete process.env.NO_PROXY;
+      delete process.env.no_proxy;
+    }
+  });
+
   it("does not treat substring matches as complete loopback coverage", async () => {
     const userNoProxy = "notlocalhost,127.0.0.10,[::1].example";
     process.env.NO_PROXY = userNoProxy;
@@ -361,6 +385,25 @@ describe("withNoProxyForCdpUrl", () => {
       });
       expect(process.env.NO_PROXY).toBe("externally-set");
       expect(process.env.no_proxy).toBe("externally-set");
+    } finally {
+      delete process.env.HTTP_PROXY;
+      delete process.env.NO_PROXY;
+      delete process.env.no_proxy;
+    }
+  });
+
+  it("does not restore stale no_proxy when it was deleted during execution", async () => {
+    process.env.HTTP_PROXY = "http://proxy:8080";
+    process.env.NO_PROXY = "corp.internal";
+    process.env.no_proxy = "corp.internal";
+    try {
+      await withNoProxyForCdpUrl("http://127.0.0.1:9222", async () => {
+        expect(process.env.NO_PROXY).toBe("corp.internal,localhost,127.0.0.1,[::1]");
+        expect(process.env.no_proxy).toBe("corp.internal,localhost,127.0.0.1,[::1]");
+        delete process.env.no_proxy;
+      });
+      expect(process.env.NO_PROXY).toBe("corp.internal,localhost,127.0.0.1,[::1]");
+      expect(process.env.no_proxy).toBeUndefined();
     } finally {
       delete process.env.HTTP_PROXY;
       delete process.env.NO_PROXY;

--- a/extensions/browser/src/browser/cdp-proxy-bypass.test.ts
+++ b/extensions/browser/src/browser/cdp-proxy-bypass.test.ts
@@ -321,11 +321,58 @@ describe("withNoProxyForLocalhost preserves user-configured NO_PROXY", () => {
 
       await withNoProxyForLocalhost(async () => {
         expect(process.env.NO_PROXY).toBe(`${coveredNoProxy},localhost,127.0.0.1,[::1]`);
-        expect(process.env.no_proxy).toBe(`${coveredNoProxy},localhost,127.0.0.1,[::1]`);
+        expect(process.env.no_proxy).toBe(`${staleLowerNoProxy},localhost,127.0.0.1,[::1]`);
       });
 
       expect(process.env.NO_PROXY).toBe(coveredNoProxy);
       expect(process.env.no_proxy).toBe(staleLowerNoProxy);
+    } finally {
+      delete process.env.HTTP_PROXY;
+      delete process.env.NO_PROXY;
+      delete process.env.no_proxy;
+    }
+  });
+
+  it("mirrors lowercase-only bypass entries into uppercase during the lease", async () => {
+    const lowerNoProxy = "corp.internal";
+    delete process.env.NO_PROXY;
+    process.env.no_proxy = lowerNoProxy;
+    process.env.HTTP_PROXY = "http://proxy:8080";
+
+    try {
+      const { withNoProxyForLocalhost } = await import("./cdp-proxy-bypass.js");
+
+      await withNoProxyForLocalhost(async () => {
+        expect(process.env.NO_PROXY).toBe(`${lowerNoProxy},localhost,127.0.0.1,[::1]`);
+        expect(process.env.no_proxy).toBe(`${lowerNoProxy},localhost,127.0.0.1,[::1]`);
+      });
+
+      expect(process.env.NO_PROXY).toBeUndefined();
+      expect(process.env.no_proxy).toBe(lowerNoProxy);
+    } finally {
+      delete process.env.HTTP_PROXY;
+      delete process.env.NO_PROXY;
+      delete process.env.no_proxy;
+    }
+  });
+
+  it("restores untouched NO_PROXY casing when the lowercase value changes", async () => {
+    const userNoProxy = "internal.corp";
+    process.env.NO_PROXY = userNoProxy;
+    process.env.no_proxy = userNoProxy;
+    process.env.HTTP_PROXY = "http://proxy:8080";
+
+    try {
+      const { withNoProxyForLocalhost } = await import("./cdp-proxy-bypass.js");
+
+      await withNoProxyForLocalhost(async () => {
+        expect(process.env.NO_PROXY).toBe(`${userNoProxy},localhost,127.0.0.1,[::1]`);
+        expect(process.env.no_proxy).toBe(`${userNoProxy},localhost,127.0.0.1,[::1]`);
+        delete process.env.no_proxy;
+      });
+
+      expect(process.env.NO_PROXY).toBe(userNoProxy);
+      expect(process.env.no_proxy).toBeUndefined();
     } finally {
       delete process.env.HTTP_PROXY;
       delete process.env.NO_PROXY;
@@ -392,7 +439,7 @@ describe("withNoProxyForCdpUrl", () => {
     }
   });
 
-  it("does not restore stale no_proxy when it was deleted during execution", async () => {
+  it("restores untouched NO_PROXY when no_proxy was deleted during execution", async () => {
     process.env.HTTP_PROXY = "http://proxy:8080";
     process.env.NO_PROXY = "corp.internal";
     process.env.no_proxy = "corp.internal";
@@ -402,7 +449,7 @@ describe("withNoProxyForCdpUrl", () => {
         expect(process.env.no_proxy).toBe("corp.internal,localhost,127.0.0.1,[::1]");
         delete process.env.no_proxy;
       });
-      expect(process.env.NO_PROXY).toBe("corp.internal,localhost,127.0.0.1,[::1]");
+      expect(process.env.NO_PROXY).toBe("corp.internal");
       expect(process.env.no_proxy).toBeUndefined();
     } finally {
       delete process.env.HTTP_PROXY;

--- a/extensions/browser/src/browser/cdp-proxy-bypass.ts
+++ b/extensions/browser/src/browser/cdp-proxy-bypass.ts
@@ -62,6 +62,10 @@ function noProxyAlreadyCoversLocalhost(): boolean {
   );
 }
 
+function appendLoopbackEntries(value: string | undefined): string {
+  return value ? `${value},${LOOPBACK_ENTRIES}` : LOOPBACK_ENTRIES;
+}
+
 export async function withNoProxyForLocalhost<T>(fn: () => Promise<T>): Promise<T> {
   return await withNoProxyForCdpUrl("http://127.0.0.1", fn);
 }
@@ -77,7 +81,8 @@ function isLoopbackCdpUrl(url: string): boolean {
 type NoProxySnapshot = {
   noProxy: string | undefined;
   noProxyLower: string | undefined;
-  applied: string;
+  appliedNoProxy: string;
+  appliedNoProxyLower: string;
 };
 
 class NoProxyLeaseManager {
@@ -92,11 +97,11 @@ class NoProxyLeaseManager {
     if (this.leaseCount === 0 && !noProxyAlreadyCoversLocalhost()) {
       const noProxy = process.env.NO_PROXY;
       const noProxyLower = process.env.no_proxy;
-      const current = noProxy || noProxyLower || "";
-      const applied = current ? `${current},${LOOPBACK_ENTRIES}` : LOOPBACK_ENTRIES;
-      process.env.NO_PROXY = applied;
-      process.env.no_proxy = applied;
-      this.snapshot = { noProxy, noProxyLower, applied };
+      const appliedNoProxy = appendLoopbackEntries(noProxy || noProxyLower);
+      const appliedNoProxyLower = appendLoopbackEntries(noProxyLower || noProxy);
+      process.env.NO_PROXY = appliedNoProxy;
+      process.env.no_proxy = appliedNoProxyLower;
+      this.snapshot = { noProxy, noProxyLower, appliedNoProxy, appliedNoProxyLower };
     }
 
     this.leaseCount += 1;
@@ -119,16 +124,17 @@ class NoProxyLeaseManager {
       return;
     }
 
-    const { noProxy, noProxyLower, applied } = this.snapshot;
+    const { noProxy, noProxyLower, appliedNoProxy, appliedNoProxyLower } = this.snapshot;
     const currentNoProxy = process.env.NO_PROXY;
     const currentNoProxyLower = process.env.no_proxy;
-    const untouched = currentNoProxy === applied && currentNoProxyLower === applied;
-    if (untouched) {
+    if (currentNoProxy === appliedNoProxy) {
       if (noProxy !== undefined) {
         process.env.NO_PROXY = noProxy;
       } else {
         delete process.env.NO_PROXY;
       }
+    }
+    if (currentNoProxyLower === appliedNoProxyLower) {
       if (noProxyLower !== undefined) {
         process.env.no_proxy = noProxyLower;
       } else {

--- a/extensions/browser/src/browser/cdp-proxy-bypass.ts
+++ b/extensions/browser/src/browser/cdp-proxy-bypass.ts
@@ -45,15 +45,21 @@ export function hasProxyEnv(): boolean {
 
 const LOOPBACK_ENTRIES = "localhost,127.0.0.1,[::1]";
 
-function noProxyAlreadyCoversLocalhost(): boolean {
-  const current = process.env.NO_PROXY || process.env.no_proxy || "";
+function noProxyValueCoversLocalhost(value: string | undefined): boolean {
   const entries = new Set(
-    current
+    (value ?? "")
       .split(",")
       .map((entry) => entry.trim().toLowerCase())
       .filter(Boolean),
   );
   return entries.has("localhost") && entries.has("127.0.0.1") && entries.has("[::1]");
+}
+
+function noProxyAlreadyCoversLocalhost(): boolean {
+  return (
+    noProxyValueCoversLocalhost(process.env.NO_PROXY) &&
+    noProxyValueCoversLocalhost(process.env.no_proxy)
+  );
 }
 
 export async function withNoProxyForLocalhost<T>(fn: () => Promise<T>): Promise<T> {
@@ -116,9 +122,7 @@ class NoProxyLeaseManager {
     const { noProxy, noProxyLower, applied } = this.snapshot;
     const currentNoProxy = process.env.NO_PROXY;
     const currentNoProxyLower = process.env.no_proxy;
-    const untouched =
-      currentNoProxy === applied &&
-      (currentNoProxyLower === applied || currentNoProxyLower === undefined);
+    const untouched = currentNoProxy === applied && currentNoProxyLower === applied;
     if (untouched) {
       if (noProxy !== undefined) {
         process.env.NO_PROXY = noProxy;

--- a/extensions/browser/src/browser/chrome-mcp.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.test.ts
@@ -299,6 +299,7 @@ describe("chrome MCP page parsing", () => {
       "Chrome",
       "Profile 1",
     );
+    const attachFailureDetail = `attach failed for ${userDataDir}`;
     const fakeMcpCommand = path.join(tempDir, "fake-mcp.mjs");
     await fs.writeFile(
       fakeMcpCommand,
@@ -311,7 +312,7 @@ describe("chrome MCP page parsing", () => {
         const body = JSON.stringify({
           jsonrpc: "2.0",
           id: Number(match[1]),
-          error: { code: -32000, message: "attach failed" },
+          error: { code: -32000, message: ${JSON.stringify(attachFailureDetail)} },
         });
         process.stdout.write(body + "\\n");
       });
@@ -337,6 +338,7 @@ describe("chrome MCP page parsing", () => {
 
     expect(message).toContain("Chrome MCP existing-session attach failed");
     expect(message).toContain("~/Library/Application Support/Google/Chrome/Profile 1");
+    expect(message).toContain("attach failed for ~/Library/Application Support/Google/Chrome/Profile 1");
     expect(message).not.toContain(homeDir);
     expect(message).not.toContain(userDataDir);
   });

--- a/extensions/browser/src/browser/chrome-mcp.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.test.ts
@@ -288,6 +288,59 @@ describe("chrome MCP page parsing", () => {
     expect(message).not.toContain(secretToken);
   });
 
+  it("redacts home-relative user data dirs from attach failures", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-chrome-mcp-test-"));
+    const homeDir = os.homedir();
+    const userDataDir = path.join(
+      homeDir,
+      "Library",
+      "Application Support",
+      "Google",
+      "Chrome",
+      "Profile 1",
+    );
+    const fakeMcpCommand = path.join(tempDir, "fake-mcp.mjs");
+    await fs.writeFile(
+      fakeMcpCommand,
+      `#!/usr/bin/env node
+      let input = "";
+      process.stdin.on("data", (chunk) => {
+        input += chunk;
+        const match = input.match(/"id"\\s*:\\s*(\\d+)/);
+        if (!match) return;
+        const body = JSON.stringify({
+          jsonrpc: "2.0",
+          id: Number(match[1]),
+          error: { code: -32000, message: "attach failed" },
+        });
+        process.stdout.write(body + "\\n");
+      });
+    `,
+    );
+    await fs.chmod(fakeMcpCommand, 0o755);
+
+    let message = "";
+    try {
+      await ensureChromeMcpAvailable(
+        "home-profile",
+        {
+          userDataDir,
+          mcpCommand: fakeMcpCommand,
+        },
+        { ephemeral: true },
+      );
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+
+    expect(message).toContain("Chrome MCP existing-session attach failed");
+    expect(message).toContain("~/Library/Application Support/Google/Chrome/Profile 1");
+    expect(message).not.toContain(homeDir);
+    expect(message).not.toContain(userDataDir);
+  });
+
   it("parses new_page text responses and returns the created tab", async () => {
     const factory: ChromeMcpSessionFactory = async () => createFakeSession();
     setChromeMcpSessionFactoryForTest(factory);
@@ -792,6 +845,40 @@ describe("chrome MCP page parsing", () => {
     await vi.advanceTimersByTimeAsync(50);
 
     await expectation;
+    expect(closeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("redacts home-relative profile labels from availability timeout diagnostics", async () => {
+    vi.useFakeTimers();
+    const closeMock = vi.fn().mockResolvedValue(undefined);
+    const factory: ChromeMcpSessionFactory = async () =>
+      ({
+        client: {
+          callTool: vi.fn(),
+          listTools: vi.fn(),
+          close: closeMock,
+          connect: vi.fn(),
+        },
+        transport: {
+          pid: 123,
+        },
+        ready: new Promise<void>(() => {}),
+      }) as unknown as ChromeMcpSession;
+    setChromeMcpSessionFactoryForTest(factory);
+
+    const homeDir = os.homedir();
+    const profileName = path.join(homeDir, "Library", "Application Support", "Google", "Chrome");
+    const promise = ensureChromeMcpAvailable(profileName, undefined, {
+      ephemeral: true,
+      timeoutMs: 50,
+    });
+    void promise.catch(() => {});
+
+    await vi.advanceTimersByTimeAsync(50);
+
+    await expect(promise).rejects.toThrow(/timed out after 50ms/i);
+    await expect(promise).rejects.toThrow("~/Library/Application Support/Google/Chrome");
+    await expect(promise).rejects.not.toThrow(homeDir);
     expect(closeMock).toHaveBeenCalledTimes(1);
   });
 

--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -389,6 +389,13 @@ function redactChromeMcpDiagnosticText(text: string): string {
   );
 }
 
+function redactChromeMcpDiagnosticTextWithLocalPaths(text: string): string {
+  const homeDir = normalizeOptionalString(os.homedir());
+  const homePath = homeDir ? path.resolve(homeDir) : undefined;
+  const withHomeRedacted = homePath ? text.split(homePath).join("~") : text;
+  return redactChromeMcpDiagnosticText(withHomeRedacted);
+}
+
 function redactChromeMcpLocalPathForDiagnostic(filePath: string): string {
   const homeDir = normalizeOptionalString(os.homedir());
   if (!homeDir || !path.isAbsolute(filePath)) {
@@ -466,7 +473,7 @@ async function createRealSession(
       const stderr = getStderr();
       if (stderr) {
         log.warn(
-          `Chrome MCP attach failed for profile "${redactChromeMcpProfileLabelForDiagnostic(profileName)}". Subprocess stderr:\n${redactChromeMcpDiagnosticText(stderr)}`,
+          `Chrome MCP attach failed for profile "${redactChromeMcpProfileLabelForDiagnostic(profileName)}". Subprocess stderr:\n${redactChromeMcpDiagnosticTextWithLocalPaths(stderr)}`,
         );
       }
       const targetLabel = options.browserUrl
@@ -474,7 +481,7 @@ async function createRealSession(
         : options.userDataDir
           ? `the configured Chromium user data dir (${redactChromeMcpLocalPathForDiagnostic(options.userDataDir)})`
           : "Google Chrome's default profile";
-      const detail = redactChromeMcpDiagnosticText(
+      const detail = redactChromeMcpDiagnosticTextWithLocalPaths(
         err instanceof Error ? err.message : String(err),
       );
       throw new BrowserProfileUnavailableError(

--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
@@ -388,6 +389,28 @@ function redactChromeMcpDiagnosticText(text: string): string {
   );
 }
 
+function redactChromeMcpLocalPathForDiagnostic(filePath: string): string {
+  const homeDir = normalizeOptionalString(os.homedir());
+  if (!homeDir || !path.isAbsolute(filePath)) {
+    return redactChromeMcpDiagnosticText(filePath);
+  }
+
+  const relative = path.relative(path.resolve(homeDir), path.resolve(filePath));
+  if (relative === "") {
+    return "~";
+  }
+  if (!relative.startsWith("..") && !path.isAbsolute(relative)) {
+    return redactChromeMcpDiagnosticText(`~/${relative.split(path.sep).join("/")}`);
+  }
+  return redactChromeMcpDiagnosticText(filePath);
+}
+
+function redactChromeMcpProfileLabelForDiagnostic(profileName: string): string {
+  return path.isAbsolute(profileName)
+    ? redactChromeMcpLocalPathForDiagnostic(profileName)
+    : redactChromeMcpDiagnosticText(profileName);
+}
+
 async function withChromeMcpHandshakeTimeout<T>(task: Promise<T>): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
@@ -443,19 +466,19 @@ async function createRealSession(
       const stderr = getStderr();
       if (stderr) {
         log.warn(
-          `Chrome MCP attach failed for profile "${profileName}". Subprocess stderr:\n${redactChromeMcpDiagnosticText(stderr)}`,
+          `Chrome MCP attach failed for profile "${redactChromeMcpProfileLabelForDiagnostic(profileName)}". Subprocess stderr:\n${redactChromeMcpDiagnosticText(stderr)}`,
         );
       }
       const targetLabel = options.browserUrl
         ? `the configured Chrome endpoint (${redactToolPayloadText(redactCdpUrl(options.browserUrl) ?? options.browserUrl)})`
         : options.userDataDir
-          ? `the configured Chromium user data dir (${options.userDataDir})`
+          ? `the configured Chromium user data dir (${redactChromeMcpLocalPathForDiagnostic(options.userDataDir)})`
           : "Google Chrome's default profile";
       const detail = redactChromeMcpDiagnosticText(
         err instanceof Error ? err.message : String(err),
       );
       throw new BrowserProfileUnavailableError(
-        `Chrome MCP existing-session attach failed for profile "${profileName}". ` +
+        `Chrome MCP existing-session attach failed for profile "${redactChromeMcpProfileLabelForDiagnostic(profileName)}". ` +
           `Make sure ${targetLabel} is running locally with remote debugging enabled. ` +
           `Details: ${detail}`,
       );
@@ -494,7 +517,7 @@ async function waitForChromeMcpReady(
           timer = setTimeout(() => {
             reject(
               new BrowserProfileUnavailableError(
-                `Chrome MCP existing-session attach for profile "${profileName}" timed out after ${timeoutMs}ms.`,
+                `Chrome MCP existing-session attach for profile "${redactChromeMcpProfileLabelForDiagnostic(profileName)}" timed out after ${timeoutMs}ms.`,
               ),
             );
           }, timeoutMs);


### PR DESCRIPTION
## Summary

- Problem: browser bridge diagnostics could leave CDP loopback proxy bypass stale across `NO_PROXY` casing variants and could expose home-relative Chrome MCP profile paths in attach-failure output.
- Why it matters: local browser-control failures should preserve operator diagnostics without leaking private workstation paths or losing localhost proxy bypass coverage.
- What changed: tightened both `NO_PROXY` casings, made restore avoid clobbering concurrent env changes, and redacted home-relative Chrome MCP profile/user-data diagnostics.
- What did NOT change (scope boundary): no browser auth boundary, local binding behavior, access policy, command permissions, or network capability changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Chrome/CDP localhost proxy bypass handling and Chrome MCP attach diagnostics.
- Real environment tested: local OpenClaw checkout on macOS, branch `impact/browser-bridge-followup`.
- Exact steps or command run after this patch:
  - `OPENCLAW_LOCAL_CHECK_MODE=throttled node scripts/run-vitest.mjs extensions/browser/src/browser/cdp-proxy-bypass.test.ts extensions/browser/src/browser/chrome-mcp.test.ts`
  - `OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm --config.verify-deps-before-run=false check:changed --timed`
- Evidence after fix: targeted regression tests now cover mixed `NO_PROXY` casing, concurrent `no_proxy` deletion, home-relative user data dir redaction, and home-relative timeout profile label redaction.
- Observed result after fix: targeted browser tests passed, `2` files / `51` tests; changed gate passed.
- What was not tested: live Chrome MCP process attach against a real browser profile.
- Before evidence: existing tests did not cover mixed casing or home-relative timeout profile labels.

## Root Cause (if applicable)

- Root cause: loopback coverage checked only the preferred `NO_PROXY || no_proxy` value, and Chrome MCP timeout/attach diagnostics reused raw profile labels or user-data paths.
- Missing detection / guardrail: no regression coverage for mixed `NO_PROXY` casing, concurrent lowercase env mutation, or home-relative Chrome MCP diagnostic labels.
- Contributing context: prior browser bridge review had already landed; this follow-up stays behavior-preserving and diagnostic-focused.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/browser/src/browser/cdp-proxy-bypass.test.ts`
  - `extensions/browser/src/browser/chrome-mcp.test.ts`
- Scenario the test should lock in: keep loopback bypass across both `NO_PROXY` casings and redact home-relative Chrome MCP diagnostic paths/labels.
- Why this is the smallest reliable guardrail: these are pure env/diagnostic behaviors with deterministic unit-level seams.
- Existing test that already covers this (if any): adjacent CDP proxy bypass and Chrome MCP redaction tests existed, but did not cover these edge cases.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Browser/CDP attach diagnostics now redact home-relative Chrome profile paths, and localhost proxy bypass is more robust when both uppercase and lowercase proxy env vars exist.

## Diagram (if applicable)

N/A.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local OpenClaw checkout
- Model/provider: N/A
- Integration/channel (if any): browser / Chrome MCP
- Relevant config (redacted): N/A

### Steps

1. Run the targeted browser tests.
2. Run changed-scope validation.
3. Inspect the diff for private absolute paths or token leaks.

### Expected

- Loopback bypass covers both `NO_PROXY` casings and restores only untouched env state.
- Chrome MCP attach/timeout diagnostics do not expose home-relative paths.

### Actual

- Targeted tests passed.
- Changed-scope validation passed.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted browser tests and `check:changed` on the rebased branch.
- Edge cases checked: mixed `NO_PROXY` casing, concurrent lowercase env deletion, CDP URL secret redaction, home-relative Chrome profile/user data diagnostics.
- What you did **not** verify: live Chrome browser attach on this machine.

## Review Conversations

N/A.
