### PR TITLE
fix(auth): clean refresh contention diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ Docs: https://docs.openclaw.ai
 - QA-Lab: stage Multipass transfer scripts under OpenClaw's preferred temp root instead of raw OS temp paths, keeping the VM runner inside temp-path guardrails. (#64098) Thanks @ImLukeF.
 - Agents/replies: keep surviving reply media and append a warning when other media references fail, so partial media normalization no longer drops failures silently. Thanks @Jerry-Xin.
 - Config/models: accept `thinkingFormat: "together"` in model compat config so Together routes can opt into the Together-specific thinking response shape.
+- Agents/auth: keep OAuth refresh-contention diagnostics deterministic and redact file-lock paths from user-facing refresh failures.
 - Plugins/tokenjuice: bump the bundled tokenjuice runtime to 0.7.1, bringing Codex hook approval compatibility, pre-tool command wrapping fixes, and Rolldown/Vitest output compaction improvements into the OpenClaw plugin.
 - Agents/OpenAI: stop post-processing GPT-5 final replies with hardcoded brevity caps, preserving full channel responses instead of appending synthetic ellipses, and log when strict-agentic GPT-5 execution activates. Fixes #82910.
 - Mac app: refine the Settings General and Connection panes with cleaner status panels, card rows, and a single native titlebar sidebar toggle.

--- a/src/agents/auth-profiles/oauth-manager.test.ts
+++ b/src/agents/auth-profiles/oauth-manager.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveOAuthDir } from "../../config/paths.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { FILE_LOCK_TIMEOUT_ERROR_CODE } from "../../infra/file-lock.js";
 import { captureEnv } from "../../test-utils/env.js";
 import { __testing as externalAuthTesting } from "./external-auth.js";
 import { legacyOAuthSidecarTestUtils } from "./legacy-oauth-sidecar.js";
@@ -262,6 +263,68 @@ describe("OAuthManagerRefreshError", () => {
     expect(error.message).not.toContain("abc123456");
     expect(error.message).not.toContain("[redacted]456");
     expect(error.message.match(/\[redacted\]/g)?.length).toBe(2);
+  });
+
+  it("does not flatten refresh contention lock paths into surfaced diagnostics", () => {
+    const lockPath = "/tmp/openclaw-refresh-contention.lock";
+    const lockCause = Object.assign(new Error(`file lock timeout for ${lockPath}`), {
+      code: FILE_LOCK_TIMEOUT_ERROR_CODE,
+      lockPath,
+    });
+    const error = new OAuthManagerRefreshError({
+      credential: createCredential(),
+      profileId: "openai-codex:default",
+      refreshedStore: { version: 1, profiles: {} },
+      cause: Object.assign(
+        new Error(
+          "OAuth refresh failed (refresh_contention): another process is already refreshing openai-codex for openai-codex:default. Please wait for the in-flight refresh to finish and retry.",
+          { cause: lockCause },
+        ),
+        {
+          code: "refresh_contention",
+          cause: lockCause,
+        },
+      ),
+    });
+
+    expect(error.code).toBe("refresh_contention");
+    expect(error.lockPath).toBe(lockPath);
+    expect(error.message).toContain("refresh_contention");
+    expect(error.message).not.toContain(lockPath);
+    expect(error.message).not.toContain("file lock timeout");
+    const surfacedCauseMessage = formatErrorMessage(error.cause);
+    expect(surfacedCauseMessage).toContain("refresh_contention");
+    expect(surfacedCauseMessage).not.toContain(lockPath);
+    expect(surfacedCauseMessage).not.toContain("file lock timeout");
+  });
+
+  it("does not flatten structured refresh contention causes into surfaced diagnostics", () => {
+    const lockPath = "/tmp/openclaw-refresh-contention.lock";
+    const error = new OAuthManagerRefreshError({
+      credential: createCredential(),
+      profileId: "openai-codex:default",
+      refreshedStore: { version: 1, profiles: {} },
+      cause: {
+        code: "refresh_contention",
+        message:
+          "OAuth refresh failed (refresh_contention): another process is already refreshing openai-codex for openai-codex:default. Please wait for the in-flight refresh to finish and retry.",
+        cause: {
+          code: FILE_LOCK_TIMEOUT_ERROR_CODE,
+          lockPath,
+          message: `file lock timeout for ${lockPath}`,
+        },
+      },
+    });
+
+    expect(error.code).toBe("refresh_contention");
+    expect(error.lockPath).toBe(lockPath);
+    expect(error.message).toContain("refresh_contention");
+    expect(error.message).not.toContain(lockPath);
+    expect(error.message).not.toContain("file lock timeout");
+    const surfacedCauseMessage = formatErrorMessage(error.cause);
+    expect(surfacedCauseMessage).toContain("refresh_contention");
+    expect(surfacedCauseMessage).not.toContain(lockPath);
+    expect(surfacedCauseMessage).not.toContain("file lock timeout");
   });
 });
 

--- a/src/agents/auth-profiles/oauth-manager.ts
+++ b/src/agents/auth-profiles/oauth-manager.ts
@@ -78,19 +78,22 @@ export class OAuthManagerRefreshError extends Error {
       typeof params.cause === "object" && params.cause !== null
         ? (params.cause as { code?: unknown; lockPath?: unknown; cause?: unknown })
         : undefined;
+    const isRefreshContention = structuredCause?.code === "refresh_contention";
     const delegatedCause =
-      structuredCause?.code === "refresh_contention" && structuredCause.cause
-        ? structuredCause.cause
-        : params.cause;
+      isRefreshContention && structuredCause.cause ? structuredCause : params.cause;
     const storedCredential = params.refreshedStore.profiles[params.profileId];
     const secrets = collectOAuthCredentialSecrets(
       params.credential,
       ...(params.attemptedCredentials ?? []),
       storedCredential?.type === "oauth" ? storedCredential : undefined,
     );
-    const causeMessage = formatRedactedOAuthRefreshError(params.cause, secrets);
+    const causeMessage = formatRedactedOAuthRefreshError(params.cause, secrets, {
+      includeCauses: !isRefreshContention,
+    });
     super(`OAuth token refresh failed for ${params.credential.provider}: ${causeMessage}`, {
-      cause: createRedactedOAuthRefreshCause(delegatedCause, secrets),
+      cause: createRedactedOAuthRefreshCause(delegatedCause, secrets, {
+        includeCauses: !isRefreshContention,
+      }),
     });
     this.name = "OAuthManagerRefreshError";
     this.#credential = params.credential;
@@ -184,9 +187,12 @@ function redactOAuthCredentialSecrets(message: string, secrets: string[]): strin
   return redacted;
 }
 
-function formatRawErrorMessage(error: unknown): string {
+function formatRawErrorMessage(error: unknown, options: { includeCauses?: boolean } = {}): string {
   if (error instanceof Error) {
     let formatted = error.message || error.name || "Error";
+    if (options.includeCauses === false) {
+      return formatted;
+    }
     let cause: unknown = error.cause;
     const seen = new Set<unknown>([error]);
     while (cause && !seen.has(cause)) {
@@ -205,6 +211,20 @@ function formatRawErrorMessage(error: unknown): string {
     }
     return formatted;
   }
+  if (options.includeCauses === false && typeof error === "object" && error !== null) {
+    const structured = error as Record<string, unknown>;
+    if (typeof structured.message === "string" && structured.message.length > 0) {
+      return structured.message;
+    }
+    const sanitized = Object.fromEntries(
+      Object.entries(structured).filter(([key]) => key !== "cause" && key !== "lockPath"),
+    );
+    try {
+      return JSON.stringify(sanitized);
+    } catch {
+      return "unserializable error object";
+    }
+  }
   if (
     typeof error === "string" ||
     typeof error === "number" ||
@@ -220,12 +240,22 @@ function formatRawErrorMessage(error: unknown): string {
   }
 }
 
-function formatRedactedOAuthRefreshError(error: unknown, secrets: string[]): string {
-  return redactSensitiveText(redactOAuthCredentialSecrets(formatRawErrorMessage(error), secrets));
+function formatRedactedOAuthRefreshError(
+  error: unknown,
+  secrets: string[],
+  options: { includeCauses?: boolean } = {},
+): string {
+  return redactSensitiveText(
+    redactOAuthCredentialSecrets(formatRawErrorMessage(error, options), secrets),
+  );
 }
 
-function createRedactedOAuthRefreshCause(cause: unknown, secrets: string[]): Error {
-  const redacted = formatRedactedOAuthRefreshError(cause, secrets);
+function createRedactedOAuthRefreshCause(
+  cause: unknown,
+  secrets: string[],
+  options: { includeCauses?: boolean } = {},
+): Error {
+  const redacted = formatRedactedOAuthRefreshError(cause, secrets, options);
   const sanitized = new Error(redacted);
   if (cause instanceof Error && cause.name) {
     sanitized.name = cause.name;

--- a/src/agents/auth-profiles/oauth.test.ts
+++ b/src/agents/auth-profiles/oauth.test.ts
@@ -1,5 +1,10 @@
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
+import { FILE_LOCK_TIMEOUT_ERROR_CODE } from "../../infra/file-lock.js";
+import { clearRuntimeAuthProfileStoreSnapshots, saveAuthProfileStore } from "./store.js";
 import type { AuthProfileStore } from "./types.js";
 
 vi.mock("../cli-credentials.js", () => ({
@@ -9,11 +14,15 @@ vi.mock("../cli-credentials.js", () => ({
   resetCliCredentialCachesForTest: () => undefined,
 }));
 
-vi.mock("../../plugins/provider-runtime.runtime.js", () => ({
-  formatProviderAuthProfileApiKeyWithPlugin: async (params: { context?: { access?: string } }) =>
-    params.context?.access,
-  refreshProviderOAuthCredentialWithPlugin: async () => null,
+const providerRuntimeMocks = vi.hoisted(() => ({
+  buildProviderAuthDoctorHintWithPlugin: vi.fn(async () => ""),
+  formatProviderAuthProfileApiKeyWithPlugin: vi.fn(
+    async (params: { context?: { access?: string } }) => params.context?.access,
+  ),
+  refreshProviderOAuthCredentialWithPlugin: vi.fn(async () => null),
 }));
+
+vi.mock("../../plugins/provider-runtime.runtime.js", () => providerRuntimeMocks);
 
 let resolveApiKeyForProfile: typeof import("./oauth.js").resolveApiKeyForProfile;
 
@@ -111,6 +120,14 @@ async function expectResolvedApiKey(params: {
 }
 
 beforeAll(loadOAuthModuleForTest);
+
+beforeEach(() => {
+  providerRuntimeMocks.buildProviderAuthDoctorHintWithPlugin.mockResolvedValue("");
+  providerRuntimeMocks.formatProviderAuthProfileApiKeyWithPlugin.mockImplementation(
+    async (params: { context?: { access?: string } }) => params.context?.access,
+  );
+  providerRuntimeMocks.refreshProviderOAuthCredentialWithPlugin.mockResolvedValue(null);
+});
 
 afterAll(() => {
   vi.doUnmock("../cli-credentials.js");
@@ -491,5 +508,77 @@ describe("resolveApiKeyForProfile secret refs", () => {
         process.env.GITHUB_TOKEN = previous;
       }
     }
+  });
+});
+
+describe("resolveApiKeyForProfile refresh diagnostics", () => {
+  it("surfaces refresh contention once without lock-path details", async () => {
+    const profileId = "openai-codex:default";
+    const provider = "openai-codex";
+    const lockPath = "/tmp/openclaw-refresh-contention.lock";
+    const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "oauth-refresh-contention-"));
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = tempRoot;
+    const agentDir = path.join(tempRoot, "agents", "default", "agent");
+    await fs.mkdir(agentDir, { recursive: true });
+    const lockCause = Object.assign(new Error(`file lock timeout for ${lockPath}`), {
+      code: FILE_LOCK_TIMEOUT_ERROR_CODE,
+      lockPath,
+    });
+    providerRuntimeMocks.refreshProviderOAuthCredentialWithPlugin.mockRejectedValue(
+      Object.assign(
+        new Error(
+          `OAuth refresh failed (refresh_contention): another process is already refreshing ${provider} for ${profileId}. Please wait for the in-flight refresh to finish and retry.`,
+          { cause: lockCause },
+        ),
+        {
+          code: "refresh_contention",
+          cause: lockCause,
+        },
+      ),
+    );
+
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        [profileId]: {
+          type: "oauth",
+          provider,
+          access: "expired-access",
+          refresh: "refresh-token",
+          expires: Date.now() - 60_000,
+        },
+      },
+    };
+    saveAuthProfileStore(store, agentDir, { filterExternalAuthProfiles: false });
+
+    try {
+      await resolveApiKeyForProfile({
+        cfg: cfgFor(profileId, provider, "oauth"),
+        store,
+        profileId,
+        agentDir,
+        forceRefresh: true,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      expect(message).toContain(
+        `OAuth token refresh failed for ${provider}: OAuth refresh failed (refresh_contention)`,
+      );
+      expect(message.match(/OAuth token refresh failed/g)?.length).toBe(1);
+      expect(message.match(/OAuth refresh failed \(refresh_contention\)/g)?.length).toBe(1);
+      expect(message).not.toContain(lockPath);
+      expect(message).not.toContain("file lock timeout");
+      return;
+    } finally {
+      clearRuntimeAuthProfileStoreSnapshots();
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      await fs.rm(tempRoot, { recursive: true, force: true });
+    }
+    throw new Error("expected OAuth refresh contention failure");
   });
 });

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -122,6 +122,11 @@ function extractErrorMessage(error: unknown): string {
   return formatErrorMessage(error);
 }
 
+function stripOAuthRefreshFailurePrefix(message: string, provider: string): string {
+  const prefix = `OAuth token refresh failed for ${provider}: `;
+  return message.startsWith(prefix) ? message.slice(prefix.length) : message;
+}
+
 export function isRefreshTokenReusedError(error: unknown): boolean {
   const message = normalizeLowercaseStringOrEmpty(extractErrorMessage(error));
   return (
@@ -411,7 +416,10 @@ export async function resolveApiKeyForProfile(
       }
     }
 
-    const message = extractErrorMessage(surfacedMessageError);
+    const message =
+      error instanceof OAuthManagerRefreshError && error.code === "refresh_contention"
+        ? stripOAuthRefreshFailurePrefix(error.message, cred.provider)
+        : extractErrorMessage(surfacedMessageError);
     const hint = await formatAuthDoctorHint({
       cfg,
       store: refreshedStore,


### PR DESCRIPTION
## Summary
- Keep OAuth `refresh_contention` diagnostics deterministic by avoiding nested file-lock cause flattening in user-facing refresh failures.
- Preserve programmatic `code` / `lockPath` on `OAuthManagerRefreshError` while redacting lock paths from messages and JSON-facing diagnostics, including structured non-`Error` causes.
- Add regression coverage for manager-level redaction and resolver-level single-message surfacing.

## Related PRs and Issues
- Follow-up to https://github.com/openclaw/openclaw/pull/82670, which landed the first auth refresh redaction/pass over the agents reliability slice.
- Related to https://github.com/openclaw/openclaw/pull/67876 and closed https://github.com/openclaw/openclaw/issues/26322, the original cross-agent OAuth refresh serialization/race fix.
- Adjacent to https://github.com/openclaw/openclaw/pull/82117 and https://github.com/openclaw/openclaw/pull/80738 for Codex OAuth refresh fallback/forced-refresh behavior.
- Adjacent to https://github.com/openclaw/openclaw/pull/83312 for legacy Codex OAuth sidecar compatibility.
- Related but not closing https://github.com/openclaw/openclaw/issues/42541; that issue is already closed by the prior auth-refresh work.
- Closes: none. Supersedes: none.

## Verification
- `git diff --check`
- `node scripts/run-vitest.mjs src/agents/auth-profiles/oauth-manager.test.ts src/agents/auth-profiles/oauth.test.ts`: 4 files / 76 tests passed.
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/auth-profiles/oauth-manager.ts`: 0 warnings / 0 errors.
- `.agents/skills/autoreview/scripts/autoreview --mode branch` on head `d754e783bc69e4c50dd57d79bd9db31519540ea5`: no accepted/actionable findings.
- `pnpm check:changed` through Blacksmith Testbox via `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox ...`: `tbx_01krwxe431qkbdqzyvhcbgggdq`, GitHub Actions https://github.com/openclaw/openclaw/actions/runs/26018020246, exit 0. The changed gate widened to all lanes because the rebased branch triggered a 546-file sync/change threshold, so this is broader than the five-file PR diff.
- PR head CI sanity: Real behavior proof succeeded on https://github.com/openclaw/openclaw/actions/runs/26018018362; merge state is clean.

## Real behavior proof
Behavior addressed: OAuth refresh contention failures no longer expose file-lock paths in user-facing refresh diagnostics, and the contention text is surfaced once instead of duplicated through cause-chain flattening.

Real environment tested: Fresh OpenClaw gwt branch off current `origin/main`, with focused local auth-profile tests, focused lint, branch re-review, and Blacksmith Testbox changed-gate proof on the pushed PR head.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/auth-profiles/oauth-manager.test.ts src/agents/auth-profiles/oauth.test.ts`; `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/agents/auth-profiles/oauth-manager.ts`; `.agents/skills/autoreview/scripts/autoreview --mode branch`; `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --blacksmith-org openclaw --blacksmith-workflow .github/workflows/ci-check-testbox.yml --blacksmith-job check --blacksmith-ref main --idle-timeout 90m --ttl 240m --timing-json -- CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_TEST_PROJECTS_PARALLEL=6 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm check:changed`.

Evidence after fix: Regression tests assert `refresh_contention` messages do not contain the synthetic lock path or `file lock timeout`, including structured non-`Error` causes, and that both `OAuth token refresh failed` and `OAuth refresh failed (refresh_contention)` appear only once. Autoreview found no actionable correctness issues, and Testbox-through-Crabbox passed `pnpm check:changed` with exit 0.

Observed result after fix: Focused auth-profile tests passed, focused oxlint passed, branch review passed, and Testbox changed-gate passed on the pushed head `d754e783bc69e4c50dd57d79bd9db31519540ea5`.

What was not tested: No live OAuth provider refresh was forced; this is a deterministic diagnostic/redaction hardening path covered by mocked contention errors and manager-level error construction.
