### PR TITLE
fix(memory): strip markdown frontmatter from retrieval chunks

### DIFF
--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -573,6 +573,100 @@ describe("memory index", () => {
     expect(noResults.length).toBe(0);
   });
 
+  it("excludes leading YAML front matter from FTS-only memory chunks", async () => {
+    forceNoProvider = true;
+
+    const cfg = createCfg({
+      storePath: path.join(workspaceDir, "index-fts-frontmatter.sqlite"),
+      minScore: 0.35,
+      hybrid: { enabled: true },
+    });
+    const result = await getMemorySearchManager({ cfg, agentId: "main" });
+    const manager = requireManager(result);
+    managersForCleanup.add(manager);
+    resetManagerForTest(manager);
+    if (!manager.status().fts?.available) {
+      return;
+    }
+
+    await fs.writeFile(
+      path.join(memoryDir, "2026-01-12.md"),
+      [
+        "---",
+        "doc_id: YAML_ONLY_ALPHA_MARKER",
+        "title: Hidden Alpha Front Matter",
+        "tags:",
+        "  - alpha",
+        "---",
+        "# Body",
+        "Beta body visible.",
+      ].join("\n"),
+    );
+    await manager.sync({ reason: "test" });
+
+    const bodyResults = await manager.search("Beta", { maxResults: 1 });
+    expect(bodyResults.length).toBeGreaterThan(0);
+    expect(bodyResults[0]?.snippet).toContain("Beta body visible");
+    expect(bodyResults[0]?.snippet).not.toContain("YAML_ONLY_ALPHA_MARKER");
+    expect(bodyResults[0]?.startLine).toBe(7);
+
+    const frontMatterResults = await manager.search("YAML_ONLY_ALPHA_MARKER", { maxResults: 1 });
+    expect(frontMatterResults).toHaveLength(0);
+    expect(embedBatchCalls).toBe(0);
+  });
+
+  it("excludes leading YAML front matter from provider-backed indexed chunks", async () => {
+    const cfg = createCfg({
+      storePath: path.join(workspaceDir, "index-provider-frontmatter.sqlite"),
+      minScore: 0.35,
+      hybrid: { enabled: true },
+    });
+    const manager = await getPersistentManager(cfg);
+    if (!manager.status().fts?.available) {
+      return;
+    }
+
+    await fs.writeFile(
+      path.join(memoryDir, "2026-01-12.md"),
+      [
+        "---",
+        "doc_id: YAML_ONLY_ALPHA_MARKER",
+        "title: Hidden Alpha Front Matter",
+        "tags:",
+        "  - alpha",
+        "---",
+        "# Body",
+        "Beta body visible.",
+      ].join("\n"),
+    );
+    await manager.sync({ reason: "test" });
+
+    const db = (
+      manager as unknown as {
+        db: {
+          prepare: (sql: string) => {
+            all: (
+              ...params: unknown[]
+            ) => Array<{ text: string; start_line: number; end_line: number }>;
+          };
+        };
+      }
+    ).db;
+    const chunks = db
+      .prepare("SELECT text, start_line, end_line FROM chunks WHERE source = ? ORDER BY start_line")
+      .all("memory");
+
+    expect(embedBatchCalls).toBeGreaterThan(0);
+    expect(chunks.length).toBeGreaterThan(0);
+    expect(chunks[0]?.text).toContain("Beta body visible");
+    expect(chunks[0]?.text).not.toContain("YAML_ONLY_ALPHA_MARKER");
+    expect(chunks[0]?.text).not.toContain("Hidden Alpha Front Matter");
+    expect(chunks[0]?.start_line).toBe(7);
+
+    const frontMatterResults = await manager.search("YAML_ONLY_ALPHA_MARKER", { maxResults: 1 });
+    expect(frontMatterResults).toHaveLength(0);
+  });
+
   it("prefers exact session transcript hits in FTS-only mode", async () => {
     try {
       const manager = await getFtsSessionManager({

--- a/packages/memory-host-sdk/src/host/internal.test.ts
+++ b/packages/memory-host-sdk/src/host/internal.test.ts
@@ -184,4 +184,105 @@ describe("memory host SDK package internals", () => {
     expect(chunks[0].startLine).toBe(4);
     expect(chunks[chunks.length - 1].endLine).toBe(13);
   });
+
+  it("excludes leading YAML front matter from retrieval chunks while preserving source line numbers", () => {
+    const content = [
+      "---",
+      "doc_id: OPENCLAW_EXECUTION_DISCIPLINE",
+      "title: OpenClaw Execution Discipline",
+      "sensitivity: internal",
+      "---",
+      "# OpenClaw Execution Discipline",
+      "Body retrieval text.",
+    ].join("\n");
+
+    const chunks = chunkMarkdown(content, { tokens: 400, overlap: 0 });
+
+    expect(chunks[0]?.text).toBe("# OpenClaw Execution Discipline\nBody retrieval text.");
+    expect(chunks[0]?.text).not.toContain("doc_id:");
+    expect(chunks[0]?.startLine).toBe(6);
+    expect(chunks[0]?.endLine).toBe(7);
+  });
+
+  it("preserves parsed leading YAML front matter as markdown file metadata", async () => {
+    const tmpDir = getTmpDir();
+    const notePath = path.join(tmpDir, "authority.md");
+    fsSync.writeFileSync(
+      notePath,
+      [
+        "---",
+        "doc_id: OPENCLAW_EXECUTION_DISCIPLINE",
+        "title: OpenClaw Execution Discipline",
+        'quoted_numeric_id: "123"',
+        'quoted_flag: "false"',
+        "reviewed: true",
+        "revision: 3",
+        "sensitivity: internal",
+        "tags:",
+        "  - authority",
+        "inline_tags: [memory, retrieval]",
+        "nested:",
+        "  owner: OpenClaw",
+        "  priority: 2",
+        "nullable: null",
+        "---",
+        "# OpenClaw Execution Discipline",
+        "Body retrieval text.",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const note = await buildFileEntry(notePath, tmpDir);
+
+    expect(note).toMatchObject({ path: "authority.md", kind: "markdown" });
+    expect((note as { frontmatter?: unknown } | null)?.frontmatter).toMatchObject({
+      doc_id: "OPENCLAW_EXECUTION_DISCIPLINE",
+      title: "OpenClaw Execution Discipline",
+      quoted_numeric_id: "123",
+      quoted_flag: "false",
+      reviewed: true,
+      revision: 3,
+      sensitivity: "internal",
+      tags: ["authority"],
+      inline_tags: ["memory", "retrieval"],
+      nested: { owner: "OpenClaw", priority: 2 },
+      nullable: null,
+    });
+  });
+
+  it("bounds front matter normalization for cyclic aliases and unsafe keys", async () => {
+    const tmpDir = getTmpDir();
+    const notePath = path.join(tmpDir, "adversarial-authority.md");
+    fsSync.writeFileSync(
+      notePath,
+      [
+        "---",
+        "safe: retained",
+        "cycle: &cycle [*cycle]",
+        "__proto__:",
+        "  polluted: true",
+        "constructor:",
+        "  polluted: true",
+        "---",
+        "# Safe Body",
+        "Body retrieval text.",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const note = await buildFileEntry(notePath, tmpDir);
+    const frontmatter = (note as { frontmatter?: Record<string, unknown> } | null)?.frontmatter;
+
+    expect(frontmatter).toMatchObject({ safe: "retained" });
+    expect(Object.hasOwn(frontmatter ?? {}, "__proto__")).toBe(false);
+    expect(Object.hasOwn(frontmatter ?? {}, "constructor")).toBe(false);
+    expect((Object.prototype as { polluted?: unknown }).polluted).toBeUndefined();
+
+    const chunks = chunkMarkdown(fsSync.readFileSync(notePath, "utf-8"), {
+      tokens: 400,
+      overlap: 0,
+    });
+    expect(chunks[0]?.text).toBe("# Safe Body\nBody retrieval text.");
+    expect(chunks[0]?.startLine).toBe(9);
+  });
 });

--- a/packages/memory-host-sdk/src/host/internal.ts
+++ b/packages/memory-host-sdk/src/host/internal.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import YAML from "yaml";
 import { CANONICAL_ROOT_MEMORY_FILENAME } from "./config-utils.js";
 import { estimateStructuredEmbeddingInputBytes } from "./embedding-input-limits.js";
 import { buildTextEmbeddingInput, type EmbeddingInput } from "./embedding-inputs.js";
@@ -41,9 +42,20 @@ export type MemoryFileEntry = {
   dataHash?: string;
   kind?: "markdown" | "multimodal";
   contentText?: string;
+  frontmatter?: MemoryMarkdownFrontmatter;
   modality?: MemoryMultimodalModality;
   mimeType?: string;
 };
+
+export type MemoryMarkdownFrontmatterValue =
+  | string
+  | number
+  | boolean
+  | null
+  | MemoryMarkdownFrontmatterValue[]
+  | { [key: string]: MemoryMarkdownFrontmatterValue };
+
+export type MemoryMarkdownFrontmatter = Record<string, MemoryMarkdownFrontmatterValue>;
 
 export type MemoryChunk = {
   startLine: number;
@@ -63,6 +75,116 @@ const DISABLED_MULTIMODAL_SETTINGS: MemoryMultimodalSettings = {
   modalities: [],
   maxFileBytes: 0,
 };
+
+type MarkdownLineEntry = { line: string; lineNo: number };
+
+type PreparedMarkdownForMemoryIndexing = {
+  frontmatter?: MemoryMarkdownFrontmatter;
+  lines: MarkdownLineEntry[];
+};
+
+const MAX_FRONTMATTER_NORMALIZATION_DEPTH = 32;
+const MAX_FRONTMATTER_NORMALIZATION_NODES = 2_000;
+
+type FrontmatterNormalizationState = {
+  seen: WeakSet<object>;
+  nodes: number;
+};
+
+function isUnsafeFrontmatterKey(key: string): boolean {
+  return key === "__proto__" || key === "prototype" || key === "constructor";
+}
+
+function normalizeMemoryMarkdownFrontmatterValue(
+  value: unknown,
+  state: FrontmatterNormalizationState,
+  depth: number,
+): MemoryMarkdownFrontmatterValue | undefined {
+  if (value === null) {
+    return null;
+  }
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return value;
+  }
+  if (depth > MAX_FRONTMATTER_NORMALIZATION_DEPTH) {
+    return undefined;
+  }
+  if (typeof value !== "object") {
+    return undefined;
+  }
+  if (state.seen.has(value)) {
+    return undefined;
+  }
+  state.seen.add(value);
+  state.nodes += 1;
+  if (state.nodes > MAX_FRONTMATTER_NORMALIZATION_NODES) {
+    return undefined;
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => normalizeMemoryMarkdownFrontmatterValue(entry, state, depth + 1))
+      .filter((entry): entry is MemoryMarkdownFrontmatterValue => entry !== undefined);
+  }
+  const normalized = Object.create(null) as { [key: string]: MemoryMarkdownFrontmatterValue };
+  for (const [rawKey, rawValue] of Object.entries(value as Record<string, unknown>)) {
+    const key = rawKey.trim();
+    if (!key || isUnsafeFrontmatterKey(key)) {
+      continue;
+    }
+    const normalizedValue = normalizeMemoryMarkdownFrontmatterValue(rawValue, state, depth + 1);
+    if (normalizedValue !== undefined) {
+      normalized[key] = normalizedValue;
+    }
+  }
+  return normalized;
+}
+
+function parseMemoryMarkdownFrontmatter(
+  blockLines: string[],
+): MemoryMarkdownFrontmatter | undefined {
+  let parsed: unknown;
+  try {
+    parsed = YAML.parse(blockLines.join("\n"), { schema: "core" });
+  } catch {
+    return undefined;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return undefined;
+  }
+  const frontmatter = Object.create(null) as MemoryMarkdownFrontmatter;
+  const state: FrontmatterNormalizationState = { seen: new WeakSet<object>(), nodes: 0 };
+  for (const [rawKey, rawValue] of Object.entries(parsed as Record<string, unknown>)) {
+    const key = rawKey.trim();
+    if (!key || isUnsafeFrontmatterKey(key)) {
+      continue;
+    }
+    const normalizedValue = normalizeMemoryMarkdownFrontmatterValue(rawValue, state, 0);
+    if (normalizedValue !== undefined) {
+      frontmatter[key] = normalizedValue;
+    }
+  }
+  return Object.keys(frontmatter).length > 0 ? frontmatter : undefined;
+}
+
+export function prepareMarkdownForMemoryIndexing(
+  content: string,
+): PreparedMarkdownForMemoryIndexing {
+  const lines = content.split("\n");
+  if ((lines[0] ?? "").trim() !== "---") {
+    return { lines: lines.map((line, index) => ({ line, lineNo: index + 1 })) };
+  }
+  const closingIndex = lines.findIndex((line, index) => index > 0 && line.trim() === "---");
+  if (closingIndex === -1) {
+    return { lines: lines.map((line, index) => ({ line, lineNo: index + 1 })) };
+  }
+  return {
+    frontmatter: parseMemoryMarkdownFrontmatter(lines.slice(1, closingIndex)),
+    lines: lines.slice(closingIndex + 1).map((line, index) => ({
+      line,
+      lineNo: closingIndex + 2 + index,
+    })),
+  };
+}
 
 export function ensureDir(dir: string): string {
   try {
@@ -284,6 +406,7 @@ export async function buildFileEntry(
     throw err;
   }
   const hash = hashText(content);
+  const prepared = prepareMarkdownForMemoryIndexing(content);
   return {
     path: normalizedPath,
     absPath,
@@ -291,6 +414,7 @@ export async function buildFileEntry(
     size: stat.size,
     hash,
     kind: "markdown",
+    ...(prepared.frontmatter ? { frontmatter: prepared.frontmatter } : {}),
   };
 }
 
@@ -363,7 +487,7 @@ export function chunkMarkdown(
   content: string,
   chunking: { tokens: number; overlap: number },
 ): MemoryChunk[] {
-  const lines = content.split("\n");
+  const lines = prepareMarkdownForMemoryIndexing(content).lines;
   if (lines.length === 0) {
     return [];
   }
@@ -371,7 +495,7 @@ export function chunkMarkdown(
   const overlapChars = Math.max(0, chunking.overlap * CHARS_PER_TOKEN_ESTIMATE);
   const chunks: MemoryChunk[] = [];
 
-  let current: Array<{ line: string; lineNo: number }> = [];
+  let current: MarkdownLineEntry[] = [];
   let currentChars = 0;
 
   const flush = () => {
@@ -402,7 +526,7 @@ export function chunkMarkdown(
       return;
     }
     let acc = 0;
-    const kept: Array<{ line: string; lineNo: number }> = [];
+    const kept: MarkdownLineEntry[] = [];
     for (let i = current.length - 1; i >= 0; i -= 1) {
       const entry = current[i];
       if (!entry) {
@@ -418,9 +542,9 @@ export function chunkMarkdown(
     currentChars = acc;
   };
 
-  for (let i = 0; i < lines.length; i += 1) {
-    const line = lines[i] ?? "";
-    const lineNo = i + 1;
+  for (const entry of lines) {
+    const line = entry.line;
+    const lineNo = entry.lineNo;
     const segments: string[] = [];
     if (line.length === 0) {
       segments.push("");


### PR DESCRIPTION
## Summary
- Strip Markdown frontmatter from memory retrieval chunk text before embedding/indexing.
- Preserve parsed frontmatter as structured metadata.
- Add regression coverage for markdown-frontmatter chunks, embedding input, metadata normalization, unsafe keys, and recursive YAML aliases.

## Verification
- `pnpm exec oxfmt --check --threads=1 extensions/memory-core/src/memory/index.test.ts packages/memory-host-sdk/src/host/internal.test.ts packages/memory-host-sdk/src/host/internal.ts`
- `git diff --check origin/main..HEAD`
- `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test packages/memory-host-sdk/src/host/internal.test.ts`
- `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test extensions/memory-core/src/memory/index.test.ts`
- `pnpm tsgo:test:packages`
- `pnpm tsgo:extensions:test`

## Real behavior proof

Behavior addressed: memory retrieval should not include leading YAML frontmatter in chunk text or embedding input.

Real environment tested: local OpenClaw checkout using a real frontmatter-bearing authority Markdown document copied into a temporary memory index workspace; live authority and production memory paths were not modified.

Exact steps or command run after this patch: copied `OPENCLAW_DOCUMENT_METADATA_AND_RETRIEVAL_STANDARD.md` into `/tmp/mvp1g-authority-smoke-1DUT6i/memory/`, indexed it through the patched memory retrieval path, and inspected the produced chunks/embedding input.

Evidence after fix: terminal output from the staged real-authority smoke showed the body-only chunk and retained structured metadata:

```text
staged authority smoke: PASS
source document: OPENCLAW_DOCUMENT_METADATA_AND_RETRIEVAL_STANDARD.md
chunk count: 5
first chunk start/end lines: 44/524
first chunk begins with Markdown body content, not YAML frontmatter
structured metadata retained: doc_id, status, authority_tier, controlling_openclaw_authority, superseded_by, scope
forbidden leading YAML scope sequence in chunk text: absent
embedding input equals chunk text and excludes YAML frontmatter
production memory path modified: no
live authority path modified: no
```

Observed result after fix: retrieval chunk text starts at the Markdown body while parsed frontmatter remains available as structured metadata; the embedding input no longer includes the YAML frontmatter block.

What was not tested: no production memory rebuild, no live memory promotion, no authority install, and no broad remote Testbox/Crabbox gate in this PR-prep stop.
