### PR TITLE
fix(schema): accept tools.codeMode at agent-entry scope (#83388)

### DIFF
--- a/src/config/zod-schema.agent-defaults.test.ts
+++ b/src/config/zod-schema.agent-defaults.test.ts
@@ -342,6 +342,48 @@ describe("agent defaults schema", () => {
     expect(config.agents?.list?.[0]?.contextTokens).toBe(1_048_576);
   });
 
+  it("accepts per-agent tools.codeMode.enabled (#83388)", () => {
+    // docs/reference/code-mode.md describes `tools.codeMode.enabled: true` as
+    // settable at the agent level. Pre-fix AgentToolsSchema was .strict() and
+    // didn't include codeMode, so gateway startup rejected the documented
+    // shape with `agents.list.0.tools: Unrecognized key: "codeMode"`.
+    expectSchemaSuccess(
+      AgentEntrySchema.safeParse({
+        id: "test-agent",
+        tools: { codeMode: { enabled: true } },
+      }),
+    );
+    // Boolean form should also work, mirroring the top-level CodeModeSchema union.
+    expectSchemaSuccess(
+      AgentEntrySchema.safeParse({
+        id: "test-agent",
+        tools: { codeMode: true },
+      }),
+    );
+    // Full object form with documented options.
+    expectSchemaSuccess(
+      AgentEntrySchema.safeParse({
+        id: "test-agent",
+        tools: {
+          codeMode: {
+            enabled: true,
+            runtime: "quickjs-wasi",
+            timeoutMs: 5000,
+            languages: ["javascript"],
+          },
+        },
+      }),
+    );
+    // Unknown nested key still rejected (strict() preserved on the inner schema).
+    expectSchemaFailurePath(
+      AgentEntrySchema.safeParse({
+        id: "test-agent",
+        tools: { codeMode: { unknownKey: 1 } },
+      }),
+      "tools.codeMode",
+    );
+  });
+
   it("rejects non-positive contextTokens on agent entries and defaults", () => {
     expectSchemaFailurePath(
       AgentEntrySchema.safeParse({ id: "ops", contextTokens: 0 }),

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -703,6 +703,12 @@ const MessageToolConfigSchema = z
 const AgentToolsSchema = z
   .object({
     ...CommonToolPolicyFields,
+    // #83388: per-agent code-mode enablement matches the doc surface
+    // (`docs/reference/code-mode.md` describes `tools.codeMode.enabled` as
+    // an "agent or runtime" config). The top-level ToolsSchema already
+    // accepts `codeMode`; mirror it here so a per-agent override can be
+    // tested without forcing fleet-wide behavior change.
+    codeMode: CodeModeSchema,
     elevated: z
       .object({
         enabled: z.boolean().optional(),


### PR DESCRIPTION
Fixes #83388.

`docs/reference/code-mode.md` describes `tools.codeMode.enabled: true` as settable at *"the agent or runtime config"*, but `AgentToolsSchema` in `src/config/zod-schema.agent-runtime.ts` is `.strict()` and didn't include `codeMode`. Only the top-level `ToolsSchema` accepted it. Gateway startup rejected the documented per-agent shape with `agents.list.0.tools: Unrecognized key: "codeMode"`.

This patch adds `codeMode: CodeModeSchema` to `AgentToolsSchema`, mirroring the top-level schema. `CodeModeSchema` already supports the boolean shorthand and the full options object (`enabled`/`runtime`/`mode`/`languages`/`timeoutMs`/`memoryLimitBytes`/...). `strict()` is preserved on the inner schema, so unknown nested keys still reject.

Per-agent enablement enables the testing/rollout pattern the issue requests: turn on code mode for a single agent without forcing fleet-wide behavior change.

## Changes

- `src/config/zod-schema.agent-runtime.ts`: add `codeMode: CodeModeSchema` to `AgentToolsSchema`. 5-line comment referencing #83388.
- `src/config/zod-schema.agent-defaults.test.ts`: 1 new regression case covering boolean shorthand, `{enabled: true}` shape, full options object, and a negative-control (unknown nested key still rejected).

## Real behavior proof

- **Behavior or issue addressed:** Gateway rejected the documented per-agent shape `{ id: "test-agent", tools: { codeMode: { enabled: true } } }` with `Unrecognized key: "codeMode"`.

- **Real environment tested:** Local Node 22.x with the actual `zod/v4` package from a sibling scout checkout (`/tmp/openclaw_scout/node_modules/zod/v4/index.cjs`). Probe at `/tmp/probe_83388.mjs` rebuilds the relevant pieces (`CodeModeSchema` union of boolean + strict object, an OLD `AgentToolsSchema`-shaped strict object without codeMode, and a NEW one with it) and parses 5 inputs against both.

- **Exact steps or command run after this patch:** `node /tmp/probe_83388.mjs`

- **Evidence after fix:**

```
OLD parse {codeMode:{enabled:true}}: REJECT
NEW parse {codeMode:{enabled:true}}: ACCEPT
PASS: OLD rejects per-agent codeMode (bug confirmed)
PASS: NEW accepts {enabled:true}
PASS: NEW accepts true (boolean form)
PASS: NEW rejects unknown nested key (strict preserved)
PASS: NEW accepts full object form

ALL CASES PASS
```

- **Observed result after fix:** `AgentEntrySchema.safeParse({ id: "...", tools: { codeMode: { enabled: true } } })` now returns `success: true`. The boolean shorthand `codeMode: true` and the full options object are also accepted (mirroring the top-level shape). Unknown nested keys still reject because `CodeModeSchema`'s inner object is `.strict()` — this is the negative-control assertion.

- **What was not tested:** End-to-end gateway restart against a real config file with a per-agent `codeMode` block. The new vitest case covers the schema-level public contract (`AgentEntrySchema.safeParse`); the probe covers the zod-package-level behavior in isolation; the gateway config-validation path consumes the same `AgentEntrySchema` so this fix transitively unblocks the startup path the issue describes.

## Audit (per CLAUDE rules)

- **Existing-helper check:** Reuses the existing `CodeModeSchema` declared at line 590 of the same file (the schema the top-level `ToolsSchema` already uses). No new schema definition. PASS
- **Shared-helper caller check:** `AgentToolsSchema` is file-local (no `export`). Consumed at exactly one site: `AgentEntrySchema` at line 1009. Adding an optional key doesn't break existing consumers — they continue to omit `codeMode`. PASS
- **Broader-fix rival scan:** No open PRs touching `AgentToolsSchema` / `codeMode` schema as of branch SHA. PASS
