### PR TITLE
fix(update): harden legacy package handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ Docs: https://docs.openclaw.ai
 - CLI/doctor: seed Control UI allowed origins when migrating legacy non-loopback gateway bind host aliases like `0.0.0.0`. Fixes #83286. Thanks @giodl73-repo.
 - CLI/plugins: ship the bundled memory CLI as a package entry so package-installed `openclaw memory` commands register correctly.
 - CLI/update: defer doctor-time plugin package installs during package swaps and seed post-core repair from the updated install registry, preventing duplicate reinstall failures.
-- CLI/update: preserve old-parent-readable config metadata during legacy package handoffs, fall back to npm when ClawHub package artifacts are unavailable, and keep managed service package roots authoritative during updates.
+- CLI/update: preserve old-parent-readable config metadata during legacy package handoffs, fall back only to official `@openclaw/*` npm plugin packages when ClawHub plugin artifacts are unavailable, and keep managed service package roots authoritative during updates.
 - Feishu: detect SecretRef top-level credentials as a configured default account instead of treating object-backed app secrets as missing.
 - Gateway/restart: keep ordinary unmanaged SIGUSR1/config restarts in-process instead of detach-spawning an orphaned child, preserving custom supervisor PID tracking while leaving update restarts on the fresh-process path. Fixes #65668.
 - CLI/completion: resolve concrete PowerShell profile paths and reload commands during setup and doctor completion installation. Fixes #44296. (#83059) Thanks @yu-xin-c.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Docs: https://docs.openclaw.ai
 - CLI/doctor: seed Control UI allowed origins when migrating legacy non-loopback gateway bind host aliases like `0.0.0.0`. Fixes #83286. Thanks @giodl73-repo.
 - CLI/plugins: ship the bundled memory CLI as a package entry so package-installed `openclaw memory` commands register correctly.
 - CLI/update: defer doctor-time plugin package installs during package swaps and seed post-core repair from the updated install registry, preventing duplicate reinstall failures.
+- CLI/update: preserve old-parent-readable config metadata during legacy package handoffs, fall back to npm when ClawHub package artifacts are unavailable, and keep managed service package roots authoritative during updates.
 - Feishu: detect SecretRef top-level credentials as a configured default account instead of treating object-backed app secrets as missing.
 - Gateway/restart: keep ordinary unmanaged SIGUSR1/config restarts in-process instead of detach-spawning an orphaned child, preserving custom supervisor PID tracking while leaving update restarts on the fresh-process path. Fixes #65668.
 - CLI/completion: resolve concrete PowerShell profile paths and reload commands during setup and doctor completion installation. Fixes #44296. (#83059) Thanks @yu-xin-c.

--- a/scripts/crabbox-wrapper.mjs
+++ b/scripts/crabbox-wrapper.mjs
@@ -45,6 +45,7 @@ function configuredProvider() {
 
 const runValueOptions = new Set([
   "allow-env",
+  "artifact-glob",
   "azure-location",
   "azure-os-disk",
   "azure-resource-group",
@@ -86,6 +87,7 @@ const runValueOptions = new Set([
   "islo-vcpus",
   "islo-workdir",
   "junit",
+  "label",
   "market",
   "modal-app",
   "modal-image",
@@ -101,6 +103,7 @@ const runValueOptions = new Set([
   "network",
   "preflight-tools",
   "profile",
+  "proof-template",
   "provider",
   "proxmox-api-url",
   "proxmox-bridge",
@@ -111,6 +114,7 @@ const runValueOptions = new Set([
   "proxmox-user",
   "proxmox-work-root",
   "script",
+  "scenario",
   "semaphore-host",
   "semaphore-idle-timeout",
   "semaphore-machine",
@@ -122,6 +126,7 @@ const runValueOptions = new Set([
   "static-port",
   "static-user",
   "static-work-root",
+  "stop-after",
   "tailscale-auth-key-env",
   "tailscale-exit-node",
   "tailscale-hostname-template",
@@ -141,8 +146,36 @@ const runValueOptions = new Set([
   "tensorlake-workdir",
   "ttl",
   "type",
+  "emit-proof",
+  "preset",
+  "preset-var",
   "windows-mode",
 ]);
+
+let runValueOptionsFromHelp;
+
+function parseRunValueOptionsFromHelp(text) {
+  const names = new Set();
+  for (const line of text.split(/\r?\n/u)) {
+    const match = line.match(
+      /^\s+-{1,2}([a-z0-9][a-z0-9-]*)\s+(?:string|duration|int|float|value)\b/u,
+    );
+    if (match) {
+      names.add(match[1]);
+    }
+  }
+  return names;
+}
+
+function currentRunValueOptions() {
+  if (!runValueOptionsFromHelp) {
+    runValueOptionsFromHelp = new Set([
+      ...runValueOptions,
+      ...parseRunValueOptionsFromHelp(help.text),
+    ]);
+  }
+  return runValueOptionsFromHelp;
+}
 
 function runOptionName(arg) {
   return arg.replace(/^-+/u, "").split("=", 1)[0];
@@ -160,7 +193,7 @@ function runCommandBounds(commandArgs) {
     if (!arg.startsWith("-")) {
       return { start: index, optionEnd: index };
     }
-    if (!arg.includes("=") && runValueOptions.has(runOptionName(arg))) {
+    if (!arg.includes("=") && currentRunValueOptions().has(runOptionName(arg))) {
       index += 1;
     }
   }

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -32,6 +32,7 @@ import { GATEWAY_SERVICE_KIND, GATEWAY_SERVICE_MARKER } from "../../daemon/const
 import { resolveGatewayInstallEntrypoint } from "../../daemon/gateway-entrypoint.js";
 import { disableCurrentOpenClawUpdateLaunchdJob } from "../../daemon/launchd.js";
 import { resolveGatewayRestartLogPath } from "../../daemon/restart-logs.js";
+import { summarizeGatewayServiceLayout } from "../../daemon/service-layout.js";
 import {
   readGatewayServiceState,
   resolveGatewayService,
@@ -1208,6 +1209,35 @@ async function tryInstallShellCompletion(opts: {
   }
 }
 
+async function tryRealpathOrResolve(value: string): Promise<string> {
+  try {
+    return await fs.realpath(path.resolve(value));
+  } catch {
+    return path.resolve(value);
+  }
+}
+
+async function resolveManagedServicePackageUpdateRoot(params: {
+  root: string;
+}): Promise<{ root: string; previousRoot: string } | null> {
+  const command = await resolveGatewayService()
+    .readCommand(process.env)
+    .catch(() => null);
+  const layout = await summarizeGatewayServiceLayout(command);
+  const serviceRoot = layout?.packageRoot;
+  if (!serviceRoot || layout.entrypointSourceCheckout === true) {
+    return null;
+  }
+  const [currentRootReal, serviceRootReal] = await Promise.all([
+    tryRealpathOrResolve(params.root),
+    tryRealpathOrResolve(serviceRoot),
+  ]);
+  if (currentRootReal === serviceRootReal) {
+    return null;
+  }
+  return { root: serviceRoot, previousRoot: params.root };
+}
+
 async function runPackageInstallUpdate(params: {
   root: string;
   installKind: "git" | "package" | "unknown";
@@ -1218,6 +1248,7 @@ async function runPackageInstallUpdate(params: {
   jsonMode: boolean;
   managedServiceEnv?: NodeJS.ProcessEnv;
   invocationCwd?: string;
+  honorPackageRoot?: boolean;
 }): Promise<UpdateRunResult> {
   const manager = await resolveGlobalManager({
     root: params.root,
@@ -1231,6 +1262,7 @@ async function runPackageInstallUpdate(params: {
     runCommand,
     timeoutMs: params.timeoutMs,
     pkgRoot: params.root,
+    honorPackageRoot: params.honorPackageRoot === true,
   });
   const pkgRoot = installTarget.packageRoot;
   const packageName =
@@ -2722,7 +2754,7 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
   }
   const updateStepTimeoutMs = timeoutMs ?? DEFAULT_UPDATE_STEP_TIMEOUT_MS;
 
-  const root = await resolveUpdateRoot();
+  let root = await resolveUpdateRoot();
   if (postCoreUpdateResume) {
     if (
       postCoreUpdateChannel !== "stable" &&
@@ -2852,6 +2884,21 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
   let fallbackToLatest = false;
   let packageInstallSpec: string | null = null;
   let packageAlreadyCurrent = false;
+  let managedServiceRootRedirect: { root: string; previousRoot: string } | null = null;
+
+  if (updateInstallKind === "package") {
+    managedServiceRootRedirect = await resolveManagedServicePackageUpdateRoot({ root });
+    if (managedServiceRootRedirect) {
+      root = managedServiceRootRedirect.root;
+      if (!opts.json) {
+        defaultRuntime.log(
+          theme.muted(
+            `Targeting managed gateway service package root: ${managedServiceRootRedirect.root}`,
+          ),
+        );
+      }
+    }
+  }
 
   if (updateInstallKind !== "git") {
     currentVersion = switchToPackage ? null : await readPackageVersion(root);
@@ -2928,6 +2975,11 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
     }
     if (fallbackToLatest) {
       notes.push("Beta channel resolves to latest for this run (fallback).");
+    }
+    if (managedServiceRootRedirect) {
+      notes.push(
+        `Package update targets managed service root ${managedServiceRootRedirect.root} instead of invoking root ${managedServiceRootRedirect.previousRoot}.`,
+      );
     }
     if (explicitTag && !canResolveRegistryVersionForPackageTarget(tag)) {
       notes.push("Non-registry package specs skip npm version lookup and downgrade previews.");
@@ -3062,6 +3114,7 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
             jsonMode: Boolean(opts.json),
             managedServiceEnv: prePackageServiceStop?.serviceEnv,
             invocationCwd,
+            honorPackageRoot: managedServiceRootRedirect !== null,
           })
         : await runGitUpdate({
             root,

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -1014,6 +1014,130 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     });
   });
 
+  it("updates an existing npm target when stale baseline records miss an installed package", async () => {
+    const npmRoot = makeTempDir();
+    const packageDir = path.join(npmRoot, "node_modules", "@openclaw", "discord");
+    fs.mkdirSync(packageDir, { recursive: true });
+    mocks.resolveDefaultPluginNpmDir.mockReturnValue(npmRoot);
+    mocks.listChannelPluginCatalogEntries.mockReturnValue([
+      {
+        id: "discord",
+        pluginId: "discord",
+        meta: { label: "Discord" },
+        install: {
+          npmSpec: "@openclaw/discord",
+        },
+      },
+    ]);
+    mocks.installPluginFromNpmSpec.mockResolvedValue({
+      ok: true,
+      pluginId: "discord",
+      targetDir: packageDir,
+      version: "1.2.3",
+      npmResolution: {
+        name: "@openclaw/discord",
+        version: "1.2.3",
+        resolvedSpec: "@openclaw/discord@1.2.3",
+        integrity: "sha512-discord",
+        resolvedAt: "2026-05-01T00:00:00.000Z",
+      },
+    });
+
+    const { repairMissingConfiguredPluginInstalls } =
+      await import("./missing-configured-plugin-install.js");
+    const result = await repairMissingConfiguredPluginInstalls({
+      cfg: {
+        plugins: {
+          entries: {
+            discord: { enabled: true },
+          },
+        },
+        channels: {
+          discord: { enabled: true },
+        },
+      },
+      env: {
+        OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: "1",
+      },
+    });
+
+    expect(mocks.installPluginFromClawHub).not.toHaveBeenCalled();
+    expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec), {
+      spec: "@openclaw/discord",
+      expectedPluginId: "discord",
+      npmDir: npmRoot,
+      mode: "update",
+    });
+    expect(result.changes).toEqual([
+      'Installed missing configured plugin "discord" from @openclaw/discord.',
+    ]);
+    expect(result.warnings).toEqual([]);
+    expect(result.records.discord?.installPath).toBe(packageDir);
+  });
+
+  it("retries npm repair as an update when the install target appears stale", async () => {
+    const npmRoot = makeTempDir();
+    const packageDir = path.join(npmRoot, "node_modules", "@openclaw", "discord");
+    mocks.resolveDefaultPluginNpmDir.mockReturnValue(npmRoot);
+    mocks.listChannelPluginCatalogEntries.mockReturnValue([
+      {
+        id: "discord",
+        pluginId: "discord",
+        meta: { label: "Discord" },
+        install: {
+          npmSpec: "@openclaw/discord",
+        },
+      },
+    ]);
+    mocks.installPluginFromNpmSpec
+      .mockResolvedValueOnce({
+        ok: false,
+        error: `plugin already exists: ${packageDir} (delete it first)`,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        pluginId: "discord",
+        targetDir: packageDir,
+        version: "1.2.3",
+        npmResolution: {
+          name: "@openclaw/discord",
+          version: "1.2.3",
+          resolvedSpec: "@openclaw/discord@1.2.3",
+          integrity: "sha512-discord",
+          resolvedAt: "2026-05-01T00:00:00.000Z",
+        },
+      });
+
+    const { repairMissingConfiguredPluginInstalls } =
+      await import("./missing-configured-plugin-install.js");
+    const result = await repairMissingConfiguredPluginInstalls({
+      cfg: {
+        plugins: {
+          entries: {
+            discord: { enabled: true },
+          },
+        },
+      },
+      env: {
+        OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: "1",
+      },
+    });
+
+    expect(mocks.installPluginFromNpmSpec).toHaveBeenCalledTimes(2);
+    expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec, 0), {
+      spec: "@openclaw/discord",
+      npmDir: npmRoot,
+      mode: "install",
+    });
+    expectRecordFields(mockCallArg(mocks.installPluginFromNpmSpec, 1), {
+      spec: "@openclaw/discord",
+      npmDir: npmRoot,
+      mode: "update",
+    });
+    expect(result.warnings).toEqual([]);
+    expect(result.records.discord?.installPath).toBe(packageDir);
+  });
+
   it("repairs missing external payload during post-core convergence even with OPENCLAW_UPDATE_IN_PROGRESS=1", async () => {
     const records = {
       discord: {

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -380,6 +380,40 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     expect(result.warnings).toStrictEqual([]);
   });
 
+  it("does not fall back from ClawHub to non-OpenClaw npm packages", async () => {
+    mocks.installPluginFromClawHub.mockResolvedValueOnce({
+      ok: false,
+      code: "artifact_download_unavailable",
+      error: "ClawHub artifact download is not available yet.",
+    });
+    mocks.listChannelPluginCatalogEntries.mockReturnValue([
+      {
+        id: "matrix",
+        pluginId: "matrix",
+        meta: { label: "Matrix" },
+        install: {
+          clawhubSpec: "clawhub:@openclaw/plugin-matrix@stable",
+          npmSpec: "@someone-else/plugin-matrix@1.2.3",
+        },
+      },
+    ]);
+
+    const { repairMissingPluginInstallsForIds } =
+      await import("./missing-configured-plugin-install.js");
+    const result = await repairMissingPluginInstallsForIds({
+      cfg: {},
+      pluginIds: [],
+      channelIds: ["matrix"],
+      env: {},
+    });
+
+    expect(mocks.installPluginFromNpmSpec).not.toHaveBeenCalled();
+    expect(result.changes).toStrictEqual([]);
+    expect(result.warnings).toEqual([
+      'Failed to install missing configured plugin "matrix" from clawhub:@openclaw/plugin-matrix@stable: ClawHub artifact download is not available yet.',
+    ]);
+  });
+
   it("honors npm-first catalog metadata for missing OpenClaw channel plugins", async () => {
     mocks.installPluginFromNpmSpec.mockResolvedValueOnce({
       ok: true,

--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -116,6 +116,7 @@ vi.mock("../../../plugins/clawhub.js", () => ({
   CLAWHUB_INSTALL_ERROR_CODE: {
     PACKAGE_NOT_FOUND: "package_not_found",
     VERSION_NOT_FOUND: "version_not_found",
+    ARTIFACT_DOWNLOAD_UNAVAILABLE: "artifact_download_unavailable",
   },
   installPluginFromClawHub: mocks.installPluginFromClawHub,
 }));

--- a/src/commands/doctor/shared/missing-configured-plugin-install.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.ts
@@ -83,7 +83,8 @@ const REPAIRABLE_PACKAGE_ENTRY_DIAGNOSTIC_MARKERS = [
 function shouldFallbackClawHubToNpm(result: { ok: false; code?: string }): boolean {
   return (
     result.code === CLAWHUB_INSTALL_ERROR_CODE.PACKAGE_NOT_FOUND ||
-    result.code === CLAWHUB_INSTALL_ERROR_CODE.VERSION_NOT_FOUND
+    result.code === CLAWHUB_INSTALL_ERROR_CODE.VERSION_NOT_FOUND ||
+    result.code === CLAWHUB_INSTALL_ERROR_CODE.ARTIFACT_DOWNLOAD_UNAVAILABLE
   );
 }
 

--- a/src/commands/doctor/shared/missing-configured-plugin-install.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.ts
@@ -9,7 +9,7 @@ import { listChannelPluginCatalogEntries } from "../../../channels/plugins/catal
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../../../config/types.plugins.js";
 import { parseClawHubPluginSpec } from "../../../infra/clawhub-spec.js";
-import { parseRegistryNpmSpec } from "../../../infra/npm-registry-spec.js";
+import { isOpenClawOrgNpmSpec, parseRegistryNpmSpec } from "../../../infra/npm-registry-spec.js";
 import {
   normalizeUpdateChannel,
   resolveRegistryUpdateChannel,
@@ -80,11 +80,17 @@ const REPAIRABLE_PACKAGE_ENTRY_DIAGNOSTIC_MARKERS = [
   "requires compiled runtime output",
 ] as const;
 
-function shouldFallbackClawHubToNpm(result: { ok: false; code?: string }): boolean {
+function shouldFallbackClawHubToNpm(params: {
+  result: { ok: false; code?: string };
+  npmSpec?: string;
+}): boolean {
+  if (!isOpenClawOrgNpmSpec(params.npmSpec)) {
+    return false;
+  }
   return (
-    result.code === CLAWHUB_INSTALL_ERROR_CODE.PACKAGE_NOT_FOUND ||
-    result.code === CLAWHUB_INSTALL_ERROR_CODE.VERSION_NOT_FOUND ||
-    result.code === CLAWHUB_INSTALL_ERROR_CODE.ARTIFACT_DOWNLOAD_UNAVAILABLE
+    params.result.code === CLAWHUB_INSTALL_ERROR_CODE.PACKAGE_NOT_FOUND ||
+    params.result.code === CLAWHUB_INSTALL_ERROR_CODE.VERSION_NOT_FOUND ||
+    params.result.code === CLAWHUB_INSTALL_ERROR_CODE.ARTIFACT_DOWNLOAD_UNAVAILABLE
   );
 }
 
@@ -795,7 +801,10 @@ async function installCandidate(params: {
         warnings: [],
       };
     }
-    if (!npmInstallSpec || !shouldFallbackClawHubToNpm(clawhubResult)) {
+    if (
+      !npmInstallSpec ||
+      !shouldFallbackClawHubToNpm({ result: clawhubResult, npmSpec: npmInstallSpec })
+    ) {
       return {
         records: params.records,
         changes: [],

--- a/src/commands/doctor/shared/missing-configured-plugin-install.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.ts
@@ -748,6 +748,7 @@ function recordClawHubPackageName(value: string | undefined): string | undefined
 async function installCandidate(params: {
   candidate: DownloadableInstallCandidate;
   records: Record<string, PluginInstallRecord>;
+  env: NodeJS.ProcessEnv;
   updateChannel?: UpdateChannel;
   mode?: "install" | "update";
   preferNpm?: boolean;
@@ -758,7 +759,7 @@ async function installCandidate(params: {
   failedPluginId?: string;
 }> {
   const { candidate } = params;
-  const extensionsDir = resolveDefaultPluginExtensionsDir();
+  const extensionsDir = resolveDefaultPluginExtensionsDir(params.env);
   const changes: string[] = [];
   const clawhubSpecs = candidate.clawhubSpec
     ? resolveClawHubInstallSpecsForUpdateChannel({
@@ -774,6 +775,16 @@ async function installCandidate(params: {
     : null;
   const clawhubInstallSpec = clawhubSpecs?.installSpec ?? candidate.clawhubSpec;
   const npmInstallSpec = npmSpecs?.installSpec ?? candidate.npmSpec;
+  const npmDir = resolveDefaultPluginNpmDir(params.env);
+  const existingClawHubPackagePath = clawhubInstallSpec
+    ? resolveExistingCandidateClawHubPackagePath({
+        candidate,
+        extensionsDir,
+      })
+    : null;
+  const existingNpmPackagePath = npmInstallSpec
+    ? resolveExistingCandidateNpmPackagePath({ candidate, npmDir })
+    : null;
   const shouldTryClawHub =
     clawhubInstallSpec &&
     !(params.preferNpm && npmInstallSpec) &&
@@ -783,7 +794,7 @@ async function installCandidate(params: {
       spec: clawhubInstallSpec,
       extensionsDir,
       expectedPluginId: candidate.pluginId,
-      mode: params.mode ?? "install",
+      mode: params.mode === "update" || existingClawHubPackagePath ? "update" : "install",
     });
     if (clawhubResult.ok) {
       const pluginId = clawhubResult.pluginId;
@@ -828,16 +839,31 @@ async function installCandidate(params: {
       failedPluginId: candidate.pluginId,
     };
   }
-  const result = await installPluginFromNpmSpec({
+  const npmInstallMode = params.mode === "update" || existingNpmPackagePath ? "update" : "install";
+  let result = await installPluginFromNpmSpec({
     spec: npmInstallSpec,
     extensionsDir,
+    npmDir,
     expectedPluginId: candidate.pluginId,
     expectedIntegrity: candidate.expectedIntegrity,
     ...(candidate.trustedSourceLinkedOfficialInstall
       ? { trustedSourceLinkedOfficialInstall: true }
       : {}),
-    mode: params.mode ?? "install",
+    mode: npmInstallMode,
   });
+  if (!result.ok && npmInstallMode === "install" && isPluginAlreadyExistsError(result.error)) {
+    result = await installPluginFromNpmSpec({
+      spec: npmInstallSpec,
+      extensionsDir,
+      npmDir,
+      expectedPluginId: candidate.pluginId,
+      expectedIntegrity: candidate.expectedIntegrity,
+      ...(candidate.trustedSourceLinkedOfficialInstall
+        ? { trustedSourceLinkedOfficialInstall: true }
+        : {}),
+      mode: "update",
+    });
+  }
   if (!result.ok) {
     return {
       records: params.records,
@@ -867,6 +893,39 @@ async function installCandidate(params: {
     ],
     warnings: [],
   };
+}
+
+function isPluginAlreadyExistsError(error: string): boolean {
+  return /\bplugin already exists:/.test(error);
+}
+
+function resolveExistingCandidateNpmPackagePath(params: {
+  candidate: DownloadableInstallCandidate;
+  npmDir: string;
+}): string | null {
+  const npmName = params.candidate.npmSpec
+    ? parseRegistryNpmSpec(params.candidate.npmSpec)?.name
+    : undefined;
+  if (!npmName) {
+    return null;
+  }
+  const packagePath = resolveNpmPackageInstallPath({
+    packageName: npmName,
+    npmRoot: params.npmDir,
+  });
+  return existsSync(packagePath) ? packagePath : null;
+}
+
+function resolveExistingCandidateClawHubPackagePath(params: {
+  candidate: DownloadableInstallCandidate;
+  extensionsDir: string;
+}): string | null {
+  try {
+    const packagePath = resolvePluginInstallDir(params.candidate.pluginId, params.extensionsDir);
+    return existsSync(packagePath) ? packagePath : null;
+  } catch {
+    return null;
+  }
 }
 
 export type RepairMissingPluginInstallsResult = {
@@ -1165,6 +1224,7 @@ async function repairMissingPluginInstalls(params: {
     const installed = await installCandidate({
       candidate,
       records: nextRecords,
+      env,
       updateChannel,
       mode: shouldReplaceBrokenOfficialInstall ? "update" : "install",
       preferNpm: preferNpmInstalls,

--- a/src/commands/doctor/shared/release-configured-plugin-installs.test.ts
+++ b/src/commands/doctor/shared/release-configured-plugin-installs.test.ts
@@ -374,7 +374,7 @@ describe("configured plugin install release step", () => {
     });
   });
 
-  it("defers package-manager plugin repair when an older updater supports post-doctor config writes", async () => {
+  it("repairs package-manager plugins for legacy parents that only support doctor config writes", async () => {
     mocks.repairMissingPluginInstallsForIds.mockResolvedValue({
       changes: [],
       warnings: [],
@@ -405,8 +405,8 @@ describe("configured plugin install release step", () => {
     expect(result).toEqual({
       changes: [],
       warnings: [],
-      completed: false,
-      touchedConfig: false,
+      completed: true,
+      touchedConfig: true,
     });
   });
 

--- a/src/commands/doctor/shared/release-configured-plugin-installs.test.ts
+++ b/src/commands/doctor/shared/release-configured-plugin-installs.test.ts
@@ -374,9 +374,11 @@ describe("configured plugin install release step", () => {
     });
   });
 
-  it("repairs package-manager plugins for legacy parents that only support doctor config writes", async () => {
+  it("defers package-manager plugins for writable legacy parents without explicit deferral", async () => {
     mocks.repairMissingPluginInstallsForIds.mockResolvedValue({
-      changes: [],
+      changes: [
+        'Skipped package-manager repair for configured plugin "discord" during package update; rerun "openclaw doctor --fix" after the update completes.',
+      ],
       warnings: [],
     });
 
@@ -403,10 +405,12 @@ describe("configured plugin install release step", () => {
       OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE: "1",
     });
     expect(result).toEqual({
-      changes: [],
+      changes: [
+        'Skipped package-manager repair for configured plugin "discord" during package update; rerun "openclaw doctor --fix" after the update completes.',
+      ],
       warnings: [],
-      completed: true,
-      touchedConfig: true,
+      completed: false,
+      touchedConfig: false,
     });
   });
 

--- a/src/commands/doctor/shared/update-phase.test.ts
+++ b/src/commands/doctor/shared/update-phase.test.ts
@@ -36,7 +36,7 @@ describe("update-phase env helpers", () => {
     expect(isPostCoreConvergencePass(env)).toBe(true);
   });
 
-  it("defers configured plugin repair only when the updater explicitly opts in", () => {
+  it("defers configured plugin repair for explicit or writable-parent update handoffs", () => {
     expect(
       shouldDeferConfiguredPluginInstallRepair({
         [UPDATE_IN_PROGRESS_ENV]: "1",
@@ -53,7 +53,7 @@ describe("update-phase env helpers", () => {
         [UPDATE_IN_PROGRESS_ENV]: "1",
         [UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV]: "1",
       }),
-    ).toBe(false);
+    ).toBe(true);
     expect(
       shouldDeferConfiguredPluginInstallRepair({
         [UPDATE_IN_PROGRESS_ENV]: "1",
@@ -80,7 +80,7 @@ describe("update-phase env helpers", () => {
         [UPDATE_IN_PROGRESS_ENV]: "1",
         [UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV]: "1",
       }),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       isLegacyPackageUpdateDoctorPass({
         [UPDATE_IN_PROGRESS_ENV]: "1",
@@ -102,7 +102,7 @@ describe("update-phase env helpers", () => {
         [UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV]: "1",
         [UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV]: "1",
       }),
-    ).toBe(false);
+    ).toBe(true);
     expect(
       isLegacyParentWritableUpdateDoctorPass({
         [UPDATE_POST_CORE_CONVERGENCE_ENV]: "1",

--- a/src/commands/doctor/shared/update-phase.test.ts
+++ b/src/commands/doctor/shared/update-phase.test.ts
@@ -102,7 +102,7 @@ describe("update-phase env helpers", () => {
         [UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV]: "1",
         [UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV]: "1",
       }),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       isLegacyParentWritableUpdateDoctorPass({
         [UPDATE_POST_CORE_CONVERGENCE_ENV]: "1",

--- a/src/commands/doctor/shared/update-phase.test.ts
+++ b/src/commands/doctor/shared/update-phase.test.ts
@@ -5,6 +5,7 @@ import {
   UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV,
   UPDATE_POST_CORE_CONVERGENCE_ENV,
   isLegacyPackageUpdateDoctorPass,
+  isLegacyParentWritableUpdateDoctorPass,
   isPostCoreConvergencePass,
   isUpdatePackageSwapInProgress,
   shouldDeferConfiguredPluginInstallRepair,
@@ -52,7 +53,7 @@ describe("update-phase env helpers", () => {
         [UPDATE_IN_PROGRESS_ENV]: "1",
         [UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV]: "1",
       }),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       shouldDeferConfiguredPluginInstallRepair({
         [UPDATE_IN_PROGRESS_ENV]: "1",
@@ -79,11 +80,33 @@ describe("update-phase env helpers", () => {
         [UPDATE_IN_PROGRESS_ENV]: "1",
         [UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV]: "1",
       }),
-    ).toBe(false);
+    ).toBe(true);
     expect(
       isLegacyPackageUpdateDoctorPass({
         [UPDATE_IN_PROGRESS_ENV]: "1",
         [UPDATE_POST_CORE_CONVERGENCE_ENV]: "1",
+      }),
+    ).toBe(false);
+  });
+
+  it("identifies writable legacy parents that need old-readable config writes", () => {
+    expect(
+      isLegacyParentWritableUpdateDoctorPass({
+        [UPDATE_IN_PROGRESS_ENV]: "1",
+        [UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV]: "1",
+      }),
+    ).toBe(true);
+    expect(
+      isLegacyParentWritableUpdateDoctorPass({
+        [UPDATE_IN_PROGRESS_ENV]: "1",
+        [UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV]: "1",
+        [UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV]: "1",
+      }),
+    ).toBe(false);
+    expect(
+      isLegacyParentWritableUpdateDoctorPass({
+        [UPDATE_POST_CORE_CONVERGENCE_ENV]: "1",
+        [UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV]: "1",
       }),
     ).toBe(false);
   });

--- a/src/commands/doctor/shared/update-phase.ts
+++ b/src/commands/doctor/shared/update-phase.ts
@@ -47,8 +47,21 @@ export function isUpdatePackageSwapInProgress(env: NodeJS.ProcessEnv): boolean {
 export function shouldDeferConfiguredPluginInstallRepair(env: NodeJS.ProcessEnv): boolean {
   return (
     isUpdatePackageSwapInProgress(env) &&
-    (isTruthyEnvValue(env[UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV]) ||
-      isTruthyEnvValue(env[UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV]))
+    isTruthyEnvValue(env[UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV])
+  );
+}
+
+/**
+ * True iff a new doctor is running inside a shipped parent that can persist
+ * doctor repairs but does not understand the newer explicit deferral marker.
+ * These writes must stay old-parent-readable because that parent resumes after
+ * the candidate doctor exits.
+ */
+export function isLegacyParentWritableUpdateDoctorPass(env: NodeJS.ProcessEnv): boolean {
+  return (
+    isUpdatePackageSwapInProgress(env) &&
+    isTruthyEnvValue(env[UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV]) &&
+    !isTruthyEnvValue(env[UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV])
   );
 }
 

--- a/src/commands/doctor/shared/update-phase.ts
+++ b/src/commands/doctor/shared/update-phase.ts
@@ -55,12 +55,15 @@ export function shouldDeferConfiguredPluginInstallRepair(env: NodeJS.ProcessEnv)
 /**
  * True iff a new doctor is running inside a shipped parent that can persist
  * doctor config repairs. Config writes must stay old-parent-readable because
- * that parent resumes after the candidate doctor exits.
+ * that parent resumes after the candidate doctor exits. Modern parents also
+ * set the explicit deferral marker, so they should keep current metadata
+ * writes while still deferring payload repair.
  */
 export function isLegacyParentWritableUpdateDoctorPass(env: NodeJS.ProcessEnv): boolean {
   return (
     isUpdatePackageSwapInProgress(env) &&
-    isTruthyEnvValue(env[UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV])
+    isTruthyEnvValue(env[UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV]) &&
+    !isTruthyEnvValue(env[UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV])
   );
 }
 

--- a/src/commands/doctor/shared/update-phase.ts
+++ b/src/commands/doctor/shared/update-phase.ts
@@ -39,29 +39,28 @@ export function isUpdatePackageSwapInProgress(env: NodeJS.ProcessEnv): boolean {
 
 /**
  * True iff configured plugin install repair should be deferred because the
- * updater guarantees a later post-core convergence pass. Older updaters only
- * set `OPENCLAW_UPDATE_IN_PROGRESS`; when they run a newer doctor from the
- * swapped package, repair must proceed there or externalized plugins stay
- * missing until the operator manually runs doctor.
+ * updater guarantees a later post-core convergence pass. Shipped writable
+ * parents predate the explicit defer marker but still resume after the
+ * candidate doctor exits, so the candidate pass must not install payloads
+ * that the parent will immediately repair again from stale in-memory records.
  */
 export function shouldDeferConfiguredPluginInstallRepair(env: NodeJS.ProcessEnv): boolean {
   return (
     isUpdatePackageSwapInProgress(env) &&
-    isTruthyEnvValue(env[UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV])
+    (isTruthyEnvValue(env[UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV]) ||
+      isTruthyEnvValue(env[UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV]))
   );
 }
 
 /**
  * True iff a new doctor is running inside a shipped parent that can persist
- * doctor repairs but does not understand the newer explicit deferral marker.
- * These writes must stay old-parent-readable because that parent resumes after
- * the candidate doctor exits.
+ * doctor config repairs. Config writes must stay old-parent-readable because
+ * that parent resumes after the candidate doctor exits.
  */
 export function isLegacyParentWritableUpdateDoctorPass(env: NodeJS.ProcessEnv): boolean {
   return (
     isUpdatePackageSwapInProgress(env) &&
-    isTruthyEnvValue(env[UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV]) &&
-    !isTruthyEnvValue(env[UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV])
+    isTruthyEnvValue(env[UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV])
   );
 }
 

--- a/src/commands/onboarding-plugin-install.test.ts
+++ b/src/commands/onboarding-plugin-install.test.ts
@@ -48,6 +48,7 @@ vi.mock("../plugins/clawhub.js", () => ({
   CLAWHUB_INSTALL_ERROR_CODE: {
     PACKAGE_NOT_FOUND: "package_not_found",
     VERSION_NOT_FOUND: "version_not_found",
+    ARTIFACT_DOWNLOAD_UNAVAILABLE: "artifact_download_unavailable",
   },
   installPluginFromClawHub,
 }));

--- a/src/commands/onboarding-plugin-install.test.ts
+++ b/src/commands/onboarding-plugin-install.test.ts
@@ -809,6 +809,49 @@ describe("ensureOnboardingPluginInstalled", () => {
     expect(result.installed).toBe(true);
   });
 
+  it("does not fall back from ClawHub to non-OpenClaw npm packages", async () => {
+    const confirm = vi.fn(async () => true);
+    const runtimeError = vi.fn();
+    installPluginFromClawHub.mockResolvedValueOnce({
+      ok: false,
+      code: "artifact_download_unavailable",
+      error: "ClawHub ClawPack artifact is unavailable.",
+    });
+
+    const result = await ensureOnboardingPluginInstalled({
+      cfg: {},
+      entry: {
+        pluginId: "demo-plugin",
+        label: "Demo Plugin",
+        install: {
+          clawhubSpec: "clawhub:demo-plugin@2026.5.2",
+          npmSpec: "@someone-else/demo-plugin@2026.5.2",
+          defaultChoice: "clawhub",
+        },
+      },
+      prompter: {
+        select: vi.fn(async () => "clawhub"),
+        confirm,
+        note: vi.fn(async () => {}),
+        progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+      } as never,
+      runtime: { error: runtimeError } as never,
+      promptInstall: false,
+    });
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(installPluginFromNpmSpec).not.toHaveBeenCalled();
+    expect(runtimeError).toHaveBeenCalledWith(
+      "Plugin install failed: ClawHub ClawPack artifact is unavailable.",
+    );
+    expect(result).toStrictEqual({
+      cfg: {},
+      installed: false,
+      pluginId: "demo-plugin",
+      status: "failed",
+    });
+  });
+
   it("does not fall back from ClawHub to npm when ClawHub verification fails", async () => {
     const confirm = vi.fn(async () => true);
     const runtimeError = vi.fn();

--- a/src/commands/onboarding-plugin-install.ts
+++ b/src/commands/onboarding-plugin-install.ts
@@ -4,7 +4,7 @@ import { resolveBundledInstallPlanForCatalogEntry } from "../cli/plugin-install-
 import { assertConfigWriteAllowedInCurrentMode } from "../config/nix-mode-write-guard.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { parseClawHubPluginSpec } from "../infra/clawhub-spec.js";
-import { parseRegistryNpmSpec } from "../infra/npm-registry-spec.js";
+import { isOpenClawOrgNpmSpec, parseRegistryNpmSpec } from "../infra/npm-registry-spec.js";
 import { normalizeUpdateChannel, resolveRegistryUpdateChannel } from "../infra/update-channels.js";
 import {
   findBundledPluginSourceInMap,
@@ -62,11 +62,17 @@ export type OnboardingPluginInstallResult = {
   status: OnboardingPluginInstallStatus;
 };
 
-function shouldFallbackClawHubToNpm(result: { ok: false; code?: string }): boolean {
+function shouldFallbackClawHubToNpm(params: {
+  result: { ok: false; code?: string };
+  npmSpec?: string;
+}): boolean {
+  if (!isOpenClawOrgNpmSpec(params.npmSpec)) {
+    return false;
+  }
   return (
-    result.code === CLAWHUB_INSTALL_ERROR_CODE.PACKAGE_NOT_FOUND ||
-    result.code === CLAWHUB_INSTALL_ERROR_CODE.VERSION_NOT_FOUND ||
-    result.code === CLAWHUB_INSTALL_ERROR_CODE.ARTIFACT_DOWNLOAD_UNAVAILABLE
+    params.result.code === CLAWHUB_INSTALL_ERROR_CODE.PACKAGE_NOT_FOUND ||
+    params.result.code === CLAWHUB_INSTALL_ERROR_CODE.VERSION_NOT_FOUND ||
+    params.result.code === CLAWHUB_INSTALL_ERROR_CODE.ARTIFACT_DOWNLOAD_UNAVAILABLE
   );
 }
 
@@ -1142,7 +1148,7 @@ export async function ensureOnboardingPluginInstalled(params: {
       t("wizard.plugins.installTitle"),
     );
 
-    if (!npmInstallSpec || !shouldFallbackClawHubToNpm(result)) {
+    if (!npmInstallSpec || !shouldFallbackClawHubToNpm({ result, npmSpec: npmInstallSpec })) {
       runtime.error?.(`Plugin install failed: ${sanitizeTerminalText(result.error)}`);
       return {
         cfg: next,

--- a/src/commands/onboarding-plugin-install.ts
+++ b/src/commands/onboarding-plugin-install.ts
@@ -65,7 +65,8 @@ export type OnboardingPluginInstallResult = {
 function shouldFallbackClawHubToNpm(result: { ok: false; code?: string }): boolean {
   return (
     result.code === CLAWHUB_INSTALL_ERROR_CODE.PACKAGE_NOT_FOUND ||
-    result.code === CLAWHUB_INSTALL_ERROR_CODE.VERSION_NOT_FOUND
+    result.code === CLAWHUB_INSTALL_ERROR_CODE.VERSION_NOT_FOUND ||
+    result.code === CLAWHUB_INSTALL_ERROR_CODE.ARTIFACT_DOWNLOAD_UNAVAILABLE
   );
 }
 

--- a/src/config/io.meta.ts
+++ b/src/config/io.meta.ts
@@ -14,12 +14,13 @@ export const AUTO_MANAGED_CONFIG_META_PATHS = [
 export function stampConfigWriteMetadata(
   cfg: OpenClawConfig,
   now: string = new Date().toISOString(),
+  version: string = VERSION,
 ): OpenClawConfig {
   return {
     ...cfg,
     meta: {
       ...cfg.meta,
-      [AUTO_MANAGED_CONFIG_META_FIELDS.lastTouchedVersion]: VERSION,
+      [AUTO_MANAGED_CONFIG_META_FIELDS.lastTouchedVersion]: version,
       [AUTO_MANAGED_CONFIG_META_FIELDS.lastTouchedAt]: now,
     },
   };

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -251,6 +251,11 @@ export type ConfigWriteOptions = {
    * an unrelated plugin rule prevents the full write from succeeding.
    */
   skipPluginValidation?: boolean;
+  /**
+   * Preserve an older writer version for update handoff writes that must be
+   * readable by the parent process after a candidate doctor repair.
+   */
+  lastTouchedVersionOverride?: string;
 };
 
 export type ReadConfigFileSnapshotForWriteResult = {
@@ -912,8 +917,8 @@ function warnOnConfigMiskeys(raw: unknown, logger: Pick<typeof console, "warn">)
   }
 }
 
-function stampConfigVersion(cfg: OpenClawConfig): OpenClawConfig {
-  return stampConfigWriteMetadata(cfg);
+function stampConfigVersion(cfg: OpenClawConfig, version?: string): OpenClawConfig {
+  return stampConfigWriteMetadata(cfg, new Date().toISOString(), version);
 }
 
 function warnIfConfigFromFuture(cfg: OpenClawConfig, logger: Pick<typeof console, "warn">): void {
@@ -2135,7 +2140,10 @@ export function createConfigIO(
     const outputConfig = applyUnsetPathsForWrite(tildeRestoredOutputConfig, unsetPaths);
     // Do NOT apply runtime defaults when writing - user config should only contain
     // explicitly set values. Runtime defaults are applied when loading (issue #6070).
-    const stampedOutputConfig = stampConfigVersion(outputConfig);
+    const stampedOutputConfig = stampConfigVersion(
+      outputConfig,
+      options.lastTouchedVersionOverride,
+    );
     const json = JSON.stringify(stampedOutputConfig, null, 2).trimEnd().concat("\n");
     const nextHash = hashConfigRaw(json);
     const previousHash = resolveConfigSnapshotHash(snapshot);
@@ -2488,6 +2496,7 @@ export async function writeConfigFile(
     skipOutputLogs: options.skipOutputLogs,
     skipPluginValidation: options.skipPluginValidation,
     preservedLegacyRootKeys: options.preservedLegacyRootKeys,
+    lastTouchedVersionOverride: options.lastTouchedVersionOverride,
   });
   if (
     options.skipRuntimeSnapshotRefresh &&

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -156,6 +156,34 @@ describe("doctor health contributions", () => {
     expect(ctx.cfg.meta?.lastTouchedVersion).toBe("2026.5.2-test");
   });
 
+  it("keeps legacy parent writable release repairs old-parent-readable", async () => {
+    mocks.maybeRunConfiguredPluginInstallReleaseStep.mockResolvedValue({
+      changes: ["Installed configured plugin matrix."],
+      warnings: [],
+      touchedConfig: true,
+    });
+    const contribution = requireDoctorContribution("doctor:release-configured-plugin-installs");
+    const ctx = {
+      cfg: {},
+      configResult: { cfg: {}, sourceLastTouchedVersion: "2026.5.16-beta.4" },
+      sourceConfigValid: true,
+      prompter: buildDoctorPrompter(true),
+      runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+      options: {},
+      cfgForPersistence: {},
+      configPath: "/tmp/fake-openclaw.json",
+      env: {
+        OPENCLAW_UPDATE_IN_PROGRESS: "1",
+        OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE: "1",
+      },
+    } as Parameters<(typeof contribution)["run"]>[0];
+
+    await contribution.run(ctx);
+
+    expect(ctx.cfg.meta?.lastTouchedVersion).toBe("2026.5.16-beta.4");
+    expect(ctx.cfg.meta?.lastTouchedAt).toEqual(expect.any(String));
+  });
+
   it("checks command owner configuration before final config writes", () => {
     const ids = resolveDoctorHealthContributions().map((entry) => entry.id);
 
@@ -275,6 +303,43 @@ describe("doctor health contributions", () => {
         expect.objectContaining({
           writeOptions: expect.objectContaining({
             skipPluginValidation: true,
+          }),
+        }),
+      );
+    });
+
+    it("preserves source config version for legacy parent writable update doctor writes", async () => {
+      const ctx = buildWriteConfigCtx({
+        OPENCLAW_UPDATE_IN_PROGRESS: "1",
+        OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE: "1",
+      });
+      ctx.configResult.sourceLastTouchedVersion = "2026.5.16-beta.4";
+
+      await writeConfigContribution.run(ctx);
+
+      expect(mocks.replaceConfigFile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          writeOptions: expect.objectContaining({
+            lastTouchedVersionOverride: "2026.5.16-beta.4",
+          }),
+        }),
+      );
+    });
+
+    it("does not preserve source config version for explicit deferral update doctors", async () => {
+      const ctx = buildWriteConfigCtx({
+        OPENCLAW_UPDATE_IN_PROGRESS: "1",
+        OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR: "1",
+        OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE: "1",
+      });
+      ctx.configResult.sourceLastTouchedVersion = "2026.5.16-beta.4";
+
+      await writeConfigContribution.run(ctx);
+
+      expect(mocks.replaceConfigFile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          writeOptions: expect.not.objectContaining({
+            lastTouchedVersionOverride: expect.anything(),
           }),
         }),
       );

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -1,6 +1,10 @@
 import fs from "node:fs";
 import type { probeGatewayMemoryStatus } from "../commands/doctor-gateway-health.js";
 import type { DoctorOptions, DoctorPrompter } from "../commands/doctor-prompter.js";
+import {
+  isLegacyParentWritableUpdateDoctorPass,
+  UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV,
+} from "../commands/doctor/shared/update-phase.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { buildGatewayConnectionDetails } from "../gateway/call.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -48,9 +52,6 @@ function isUpdateDoctorRun(env: NodeJS.ProcessEnv | Record<string, string | unde
 function resolveDoctorMode(cfg: OpenClawConfig): DoctorFlowMode {
   return cfg.gateway?.mode === "remote" ? "remote" : "local";
 }
-
-const UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV =
-  "OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE";
 
 function isTruthyEnvValue(value: string | undefined): boolean {
   if (!value) {
@@ -338,11 +339,16 @@ async function runReleaseConfiguredPluginInstallsHealth(
   if (!result.touchedConfig) {
     return;
   }
+  const lastTouchedVersion = isLegacyParentWritableUpdateDoctorPass(ctx.env ?? process.env)
+    ? ctx.configResult.sourceLastTouchedVersion?.trim() ||
+      ctx.cfg.meta?.lastTouchedVersion ||
+      VERSION
+    : VERSION;
   ctx.cfg = {
     ...ctx.cfg,
     meta: {
       ...ctx.cfg.meta,
-      lastTouchedVersion: VERSION,
+      lastTouchedVersion,
       lastTouchedAt: new Date().toISOString(),
     },
   };
@@ -650,6 +656,11 @@ async function runWriteConfigHealth(ctx: DoctorHealthFlowContext): Promise<void>
       ctx.runtime.log("Skipping doctor config write during legacy update handoff.");
       return;
     }
+    const legacyParentVersionOverride = isLegacyParentWritableUpdateDoctorPass(
+      ctx.env ?? process.env,
+    )
+      ? ctx.configResult.sourceLastTouchedVersion?.trim() || ctx.cfg.meta?.lastTouchedVersion
+      : undefined;
     await replaceConfigFile({
       nextConfig: ctx.cfg,
       afterWrite: { mode: "auto" },
@@ -658,6 +669,9 @@ async function runWriteConfigHealth(ctx: DoctorHealthFlowContext): Promise<void>
         skipPluginValidation:
           ctx.configResult.skipPluginValidationOnWrite === true || updateDoctorRun,
         preservedLegacyRootKeys: ctx.configResult.preservedLegacyRootKeys,
+        ...(legacyParentVersionOverride
+          ? { lastTouchedVersionOverride: legacyParentVersionOverride }
+          : {}),
       },
     });
     logConfigUpdated(ctx.runtime);

--- a/src/infra/npm-registry-spec.test.ts
+++ b/src/infra/npm-registry-spec.test.ts
@@ -3,6 +3,7 @@ import {
   compareOpenClawReleaseVersions,
   formatPrereleaseResolutionError,
   isExactSemverVersion,
+  isOpenClawOrgNpmSpec,
   isOpenClawStableCorrectionVersion,
   isPrereleaseSemverVersion,
   isPrereleaseResolutionAllowed,
@@ -102,6 +103,17 @@ describe("npm registry spec parsing helpers", () => {
     },
   ])("parses %s", ({ spec, expected }) => {
     expect(parseRegistryNpmSpec(spec)).toEqual(expected);
+  });
+
+  it.each([
+    { spec: "@openclaw/voice-call", expected: true },
+    { spec: "@openclaw/voice-call@1.2.3", expected: true },
+    { spec: "@other/voice-call", expected: false },
+    { spec: "voice-call", expected: false },
+    { spec: "npm:@openclaw/voice-call", expected: false },
+    { spec: undefined, expected: false },
+  ])("detects OpenClaw-org npm specs for %s", ({ spec, expected }) => {
+    expect(isOpenClawOrgNpmSpec(spec)).toBe(expected);
   });
 
   it.each([

--- a/src/infra/npm-registry-spec.ts
+++ b/src/infra/npm-registry-spec.ts
@@ -117,6 +117,11 @@ export function parseRegistryNpmSpec(rawSpec: string): ParsedRegistryNpmSpec | n
   return parsed.ok ? parsed.parsed : null;
 }
 
+export function isOpenClawOrgNpmSpec(rawSpec: string | undefined): boolean {
+  const parsed = rawSpec ? parseRegistryNpmSpec(rawSpec) : null;
+  return parsed?.name.startsWith("@openclaw/") === true;
+}
+
 export function validateRegistryNpmSpec(rawSpec: string): string | null {
   const parsed = parseRegistryNpmSpecInternal(rawSpec);
   return parsed.ok ? null : parsed.error;

--- a/src/infra/package-update-steps.test.ts
+++ b/src/infra/package-update-steps.test.ts
@@ -138,6 +138,61 @@ describe("runGlobalPackageUpdateSteps", () => {
     });
   });
 
+  it("swaps staged npm updates into an explicitly selected direct node_modules root", async () => {
+    await withTempDir({ prefix: "openclaw-package-update-direct-root-" }, async (base) => {
+      const managedRoot = path.join(base, ".openclaw", "npm", "node_modules");
+      const packageRoot = path.join(managedRoot, "openclaw");
+      await writePackageRoot(packageRoot, "1.0.0");
+
+      const runStep = vi.fn(async ({ name, argv, cwd }): Promise<PackageUpdateStepResult> => {
+        if (name !== "global update") {
+          throw new Error(`unexpected step ${name}`);
+        }
+        const prefixIndex = argv.indexOf("--prefix");
+        expect(prefixIndex).toBeGreaterThan(0);
+        const stagePrefix = argv[prefixIndex + 1];
+        if (!stagePrefix) {
+          throw new Error("missing staged prefix");
+        }
+        expect(path.dirname(stagePrefix)).toBe(managedRoot);
+        await writePackageRoot(path.join(stagePrefix, "lib", "node_modules", "openclaw"), "2.0.0");
+        await fs.mkdir(path.join(stagePrefix, "bin"), { recursive: true });
+        await fs.symlink(
+          "../lib/node_modules/openclaw/dist/index.js",
+          path.join(stagePrefix, "bin", "openclaw"),
+        );
+        return {
+          name,
+          command: argv.join(" "),
+          cwd: cwd ?? process.cwd(),
+          durationMs: 1,
+          exitCode: 0,
+        };
+      });
+
+      const result = await runGlobalPackageUpdateSteps({
+        installTarget: {
+          ...createNpmTarget(managedRoot),
+          directNodeModulesRoot: true,
+        },
+        installSpec: "openclaw@2.0.0",
+        packageName: "openclaw",
+        packageRoot,
+        runCommand: createRootRunner(path.join(base, "shell", "lib", "node_modules")),
+        runStep,
+        timeoutMs: 1000,
+      });
+
+      expect(result.failedStep).toBeNull();
+      expect(result.verifiedPackageRoot).toBe(packageRoot);
+      expect(result.afterVersion).toBe("2.0.0");
+      await expect(fs.readFile(path.join(packageRoot, "package.json"), "utf8")).resolves.toContain(
+        '"version":"2.0.0"',
+      );
+      await expectPathMissing(path.join(managedRoot, ".bin", "openclaw"));
+    });
+  });
+
   it("accepts v-prefixed exact npm specs when verifying staged installs", async () => {
     await withTempDir({ prefix: "openclaw-package-update-v-prefix-" }, async (base) => {
       const prefix = path.join(base, "prefix");

--- a/src/infra/package-update-steps.ts
+++ b/src/infra/package-update-steps.ts
@@ -96,7 +96,9 @@ function isUnambiguousNpmPrefixGlobalRoot(globalRoot: string | null): boolean {
 function resolveStagedNpmTargetLayout(
   installTarget: ResolvedGlobalInstallTarget,
 ): NpmGlobalPrefixLayout | null {
-  const targetLayout = resolveNpmGlobalPrefixLayoutFromGlobalRoot(installTarget.globalRoot);
+  const targetLayout = resolveNpmGlobalPrefixLayoutFromGlobalRoot(installTarget.globalRoot, {
+    allowDirectNodeModulesRoot: installTarget.directNodeModulesRoot === true,
+  });
   if (!targetLayout) {
     return null;
   }
@@ -150,7 +152,9 @@ async function prepareStagedNpmInstall(
   } catch (err) {
     const targetLayout =
       installTarget.manager === "npm"
-        ? resolveNpmGlobalPrefixLayoutFromGlobalRoot(installTarget.globalRoot)
+        ? resolveNpmGlobalPrefixLayoutFromGlobalRoot(installTarget.globalRoot, {
+            allowDirectNodeModulesRoot: installTarget.directNodeModulesRoot === true,
+          })
         : null;
     return {
       stagedInstall: null,
@@ -264,7 +268,9 @@ async function swapStagedNpmInstall(params: {
   packageName: string;
 }): Promise<PackageUpdateStepResult> {
   const startedAt = Date.now();
-  const targetLayout = resolveNpmGlobalPrefixLayoutFromGlobalRoot(params.installTarget.globalRoot);
+  const targetLayout = resolveNpmGlobalPrefixLayoutFromGlobalRoot(params.installTarget.globalRoot, {
+    allowDirectNodeModulesRoot: params.installTarget.directNodeModulesRoot === true,
+  });
   const targetPackageRoot = params.installTarget.packageRoot;
   if (!targetLayout || !targetPackageRoot) {
     return {
@@ -297,11 +303,13 @@ async function swapStagedNpmInstall(params: {
       to: targetPackageRoot,
     });
     movedStaged = true;
-    await replaceNpmBinShims({
-      stageLayout: params.stage.layout,
-      targetLayout,
-      packageName: params.packageName,
-    });
+    if (params.installTarget.directNodeModulesRoot !== true) {
+      await replaceNpmBinShims({
+        stageLayout: params.stage.layout,
+        targetLayout,
+        packageName: params.packageName,
+      });
+    }
     if (movedExisting) {
       await removePathBestEffort(backupRoot);
     }

--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -318,6 +318,20 @@ describe("update global helpers", () => {
           globalRoot: brewRoot,
           packageRoot: pkgRoot,
         });
+        await expect(
+          resolveGlobalInstallTarget({
+            manager: "npm",
+            runCommand,
+            timeoutMs: 1000,
+            pkgRoot,
+            honorPackageRoot: true,
+          }),
+        ).resolves.toEqual({
+          manager: "npm",
+          command: brewNpm,
+          globalRoot: brewRoot,
+          packageRoot: pkgRoot,
+        });
         expect(globalInstallArgs("npm", "openclaw@latest", pkgRoot)).toEqual([
           brewNpm,
           "i",
@@ -365,6 +379,43 @@ describe("update global helpers", () => {
         "--loglevel=error",
         "--min-release-age=0",
       ]);
+    });
+  });
+
+  it("honors an explicitly selected direct npm node_modules package root", async () => {
+    await withTempDir({ prefix: "openclaw-update-managed-service-root-" }, async (base) => {
+      const managedNpmRoot = path.join(base, ".openclaw", "npm", "node_modules");
+      const pkgRoot = path.join(managedNpmRoot, "openclaw");
+      const pathNpmRoot = path.join(base, "shell", "lib", "node_modules");
+      await fs.mkdir(pkgRoot, { recursive: true });
+
+      const runCommand = createNpmRootRunner({ defaultNpmRoot: pathNpmRoot });
+
+      await expect(
+        resolveGlobalInstallTarget({
+          manager: "npm",
+          runCommand,
+          timeoutMs: 1000,
+          pkgRoot,
+          honorPackageRoot: true,
+        }),
+      ).resolves.toEqual({
+        manager: "npm",
+        command: "npm",
+        globalRoot: managedNpmRoot,
+        packageRoot: pkgRoot,
+        directNodeModulesRoot: true,
+      });
+
+      expect(
+        resolveNpmGlobalPrefixLayoutFromGlobalRoot(managedNpmRoot, {
+          allowDirectNodeModulesRoot: true,
+        }),
+      ).toEqual({
+        prefix: path.dirname(managedNpmRoot),
+        globalRoot: managedNpmRoot,
+        binDir: path.join(managedNpmRoot, ".bin"),
+      });
     });
   });
 

--- a/src/infra/update-global.test.ts
+++ b/src/infra/update-global.test.ts
@@ -387,13 +387,24 @@ describe("update global helpers", () => {
       const managedNpmRoot = path.join(base, ".openclaw", "npm", "node_modules");
       const pkgRoot = path.join(managedNpmRoot, "openclaw");
       const pathNpmRoot = path.join(base, "shell", "lib", "node_modules");
+      const otherPnpmRoot = path.join(base, "pnpm", "global", "5", "node_modules");
+      const customNpm = path.join(base, "bin", "npm");
       await fs.mkdir(pkgRoot, { recursive: true });
+      await fs.mkdir(path.join(otherPnpmRoot, "openclaw"), { recursive: true });
 
-      const runCommand = createNpmRootRunner({ defaultNpmRoot: pathNpmRoot });
+      const runCommand: CommandRunner = async (argv) => {
+        if (argv[0] === "npm" || argv[0] === customNpm) {
+          return { stdout: `${pathNpmRoot}\n`, stderr: "", code: 0 };
+        }
+        if (argv[0] === "pnpm") {
+          return { stdout: `${otherPnpmRoot}\n`, stderr: "", code: 0 };
+        }
+        throw new Error(`unexpected command: ${argv.join(" ")}`);
+      };
 
       await expect(
         resolveGlobalInstallTarget({
-          manager: "npm",
+          manager: "pnpm",
           runCommand,
           timeoutMs: 1000,
           pkgRoot,
@@ -402,6 +413,21 @@ describe("update global helpers", () => {
       ).resolves.toEqual({
         manager: "npm",
         command: "npm",
+        globalRoot: managedNpmRoot,
+        packageRoot: pkgRoot,
+        directNodeModulesRoot: true,
+      });
+      await expect(
+        resolveGlobalInstallTarget({
+          manager: { manager: "npm", command: customNpm },
+          runCommand,
+          timeoutMs: 1000,
+          pkgRoot,
+          honorPackageRoot: true,
+        }),
+      ).resolves.toEqual({
+        manager: "npm",
+        command: customNpm,
         globalRoot: managedNpmRoot,
         packageRoot: pkgRoot,
         directNodeModulesRoot: true,
@@ -415,6 +441,34 @@ describe("update global helpers", () => {
         prefix: path.dirname(managedNpmRoot),
         globalRoot: managedNpmRoot,
         binDir: path.join(managedNpmRoot, ".bin"),
+      });
+    });
+  });
+
+  it("preserves bun ownership for direct node_modules package roots", async () => {
+    await withTempDir({ prefix: "openclaw-update-managed-bun-root-" }, async (base) => {
+      envSnapshot = captureEnv(["BUN_INSTALL"]);
+      process.env.BUN_INSTALL = path.join(base, ".bun");
+      const bunRoot = path.join(process.env.BUN_INSTALL, "install", "global", "node_modules");
+      const pkgRoot = path.join(bunRoot, "openclaw");
+      const pathNpmRoot = path.join(base, "shell", "lib", "node_modules");
+      await fs.mkdir(pkgRoot, { recursive: true });
+
+      const runCommand = createNpmRootRunner({ defaultNpmRoot: pathNpmRoot });
+
+      await expect(
+        resolveGlobalInstallTarget({
+          manager: "bun",
+          runCommand,
+          timeoutMs: 1000,
+          pkgRoot,
+          honorPackageRoot: true,
+        }),
+      ).resolves.toEqual({
+        manager: "bun",
+        command: "bun",
+        globalRoot: bunRoot,
+        packageRoot: pkgRoot,
       });
     });
   });
@@ -487,14 +541,15 @@ describe("update global helpers", () => {
       );
       await expect(
         resolveGlobalInstallTarget({
-          manager: "pnpm",
+          manager: { manager: "pnpm", command: "/custom/bin/pnpm" },
           runCommand,
           timeoutMs: 1000,
           pkgRoot,
+          honorPackageRoot: true,
         }),
       ).resolves.toEqual({
         manager: "pnpm",
-        command: "pnpm",
+        command: "/custom/bin/pnpm",
         globalRoot: customGlobalRoot,
         packageRoot: pkgRoot,
       });

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -34,6 +34,7 @@ type ResolvedGlobalInstallCommand = {
 export type ResolvedGlobalInstallTarget = ResolvedGlobalInstallCommand & {
   globalRoot: string | null;
   packageRoot: string | null;
+  directNodeModulesRoot?: boolean;
 };
 
 const PRIMARY_PACKAGE_NAME = "openclaw";
@@ -419,6 +420,7 @@ function inferNpmPrefixFromPackageRoot(pkgRoot?: string | null): string | null {
 
 export function resolveNpmGlobalPrefixLayoutFromGlobalRoot(
   globalRoot?: string | null,
+  options: { allowDirectNodeModulesRoot?: boolean } = {},
 ): NpmGlobalPrefixLayout | null {
   const trimmed = globalRoot?.trim();
   if (!trimmed) {
@@ -442,6 +444,13 @@ export function resolveNpmGlobalPrefixLayoutFromGlobalRoot(
       prefix: parentDir,
       globalRoot: normalized,
       binDir: parentDir,
+    };
+  }
+  if (options.allowDirectNodeModulesRoot) {
+    return {
+      prefix: parentDir,
+      globalRoot: normalized,
+      binDir: path.join(normalized, ".bin"),
     };
   }
   return null;
@@ -481,6 +490,16 @@ function inferGlobalRootFromPackageRoot(pkgRoot?: string | null): string | null 
   const normalized = path.resolve(trimmed);
   const globalRoot = path.dirname(normalized);
   return path.basename(globalRoot) === "node_modules" ? globalRoot : null;
+}
+
+function isDirectNpmNodeModulesRoot(globalRoot: string | null): boolean {
+  return (
+    globalRoot !== null &&
+    resolveNpmGlobalPrefixLayoutFromGlobalRoot(globalRoot) === null &&
+    resolveNpmGlobalPrefixLayoutFromGlobalRoot(globalRoot, {
+      allowDirectNodeModulesRoot: true,
+    }) !== null
+  );
 }
 
 function inferPnpmGlobalRootFromPackageRoot(pkgRoot?: string | null): string | null {
@@ -602,6 +621,7 @@ export async function resolveGlobalInstallTarget(params: {
   runCommand: CommandRunner;
   timeoutMs: number;
   pkgRoot?: string | null;
+  honorPackageRoot?: boolean;
 }): Promise<ResolvedGlobalInstallTarget> {
   const command = normalizeGlobalInstallCommand(params.manager, params.pkgRoot);
   const globalRoot = await resolveGlobalRoot(
@@ -614,11 +634,20 @@ export async function resolveGlobalInstallTarget(params: {
     command.manager === "pnpm" && (await isPnpmGlobalPackageRoot(params.pkgRoot))
       ? inferPnpmGlobalRootFromPackageRoot(params.pkgRoot)
       : null;
-  const targetGlobalRoot = pkgRootGlobalRoot ?? globalRoot;
+  const honoredPackageRootGlobalRoot =
+    params.honorPackageRoot && command.manager === "npm"
+      ? inferGlobalRootFromPackageRoot(params.pkgRoot)
+      : null;
+  const targetGlobalRoot = pkgRootGlobalRoot ?? honoredPackageRootGlobalRoot ?? globalRoot;
   return {
     ...command,
     globalRoot: targetGlobalRoot,
     packageRoot: targetGlobalRoot ? path.join(targetGlobalRoot, PRIMARY_PACKAGE_NAME) : null,
+    ...(honoredPackageRootGlobalRoot &&
+    targetGlobalRoot === honoredPackageRootGlobalRoot &&
+    isDirectNpmNodeModulesRoot(honoredPackageRootGlobalRoot)
+      ? { directNodeModulesRoot: true }
+      : {}),
   };
 }
 

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -502,6 +502,16 @@ function isDirectNpmNodeModulesRoot(globalRoot: string | null): boolean {
   );
 }
 
+function inferBunGlobalRootFromPackageRoot(pkgRoot?: string | null): string | null {
+  const directGlobalRoot = inferGlobalRootFromPackageRoot(pkgRoot);
+  if (!directGlobalRoot) {
+    return null;
+  }
+  return path.resolve(directGlobalRoot) === path.resolve(resolveBunGlobalRoot())
+    ? directGlobalRoot
+    : null;
+}
+
 function inferPnpmGlobalRootFromPackageRoot(pkgRoot?: string | null): string | null {
   const directGlobalRoot = inferGlobalRootFromPackageRoot(pkgRoot);
   if (resolvePnpmGlobalDirFromGlobalRoot(directGlobalRoot)) {
@@ -584,6 +594,17 @@ function normalizeGlobalInstallCommand(
     : managerOrCommand;
 }
 
+function resolveInstallCommandForManager(
+  managerOrCommand: GlobalInstallManager | ResolvedGlobalInstallCommand,
+  manager: GlobalInstallManager,
+  pkgRoot?: string | null,
+): ResolvedGlobalInstallCommand {
+  const normalized = normalizeGlobalInstallCommand(managerOrCommand, pkgRoot);
+  return normalized.manager === manager
+    ? normalized
+    : resolveGlobalInstallCommand(manager, pkgRoot);
+}
+
 export async function resolveGlobalRoot(
   managerOrCommand: GlobalInstallManager | ResolvedGlobalInstallCommand,
   runCommand: CommandRunner,
@@ -623,29 +644,43 @@ export async function resolveGlobalInstallTarget(params: {
   pkgRoot?: string | null;
   honorPackageRoot?: boolean;
 }): Promise<ResolvedGlobalInstallTarget> {
-  const command = normalizeGlobalInstallCommand(params.manager, params.pkgRoot);
+  const honoredPackageRootGlobalRoot = params.honorPackageRoot
+    ? inferGlobalRootFromPackageRoot(params.pkgRoot)
+    : null;
+  const pnpmPackageRootGlobalRoot = (await isPnpmGlobalPackageRoot(params.pkgRoot))
+    ? inferPnpmGlobalRootFromPackageRoot(params.pkgRoot)
+    : null;
+  const bunPackageRootGlobalRoot = inferBunGlobalRootFromPackageRoot(params.pkgRoot);
+  const honoredDirectNpmRoot =
+    pnpmPackageRootGlobalRoot === null &&
+    bunPackageRootGlobalRoot === null &&
+    isDirectNpmNodeModulesRoot(honoredPackageRootGlobalRoot);
+  const command = bunPackageRootGlobalRoot
+    ? resolveInstallCommandForManager(params.manager, "bun", params.pkgRoot)
+    : pnpmPackageRootGlobalRoot
+      ? resolveInstallCommandForManager(params.manager, "pnpm", params.pkgRoot)
+      : honoredDirectNpmRoot
+        ? resolveInstallCommandForManager(params.manager, "npm", params.pkgRoot)
+        : normalizeGlobalInstallCommand(params.manager, params.pkgRoot);
   const globalRoot = await resolveGlobalRoot(
     command,
     params.runCommand,
     params.timeoutMs,
     params.pkgRoot,
   );
-  const pkgRootGlobalRoot =
-    command.manager === "pnpm" && (await isPnpmGlobalPackageRoot(params.pkgRoot))
-      ? inferPnpmGlobalRootFromPackageRoot(params.pkgRoot)
-      : null;
-  const honoredPackageRootGlobalRoot =
-    params.honorPackageRoot && command.manager === "npm"
-      ? inferGlobalRootFromPackageRoot(params.pkgRoot)
-      : null;
-  const targetGlobalRoot = pkgRootGlobalRoot ?? honoredPackageRootGlobalRoot ?? globalRoot;
+  const pkgRootGlobalRoot = command.manager === "pnpm" ? pnpmPackageRootGlobalRoot : null;
+  const targetGlobalRoot =
+    (command.manager === "bun" ? bunPackageRootGlobalRoot : null) ??
+    pkgRootGlobalRoot ??
+    (command.manager === "npm" ? honoredPackageRootGlobalRoot : null) ??
+    globalRoot;
   return {
     ...command,
     globalRoot: targetGlobalRoot,
     packageRoot: targetGlobalRoot ? path.join(targetGlobalRoot, PRIMARY_PACKAGE_NAME) : null,
     ...(honoredPackageRootGlobalRoot &&
     targetGlobalRoot === honoredPackageRootGlobalRoot &&
-    isDirectNpmNodeModulesRoot(honoredPackageRootGlobalRoot)
+    honoredDirectNpmRoot
       ? { directNodeModulesRoot: true }
       : {}),
   };

--- a/src/plugins/clawhub.test.ts
+++ b/src/plugins/clawhub.test.ts
@@ -750,6 +750,7 @@ describe("installPluginFromClawHub", () => {
     expect(failure.error).toBe(
       'ClawHub artifact download for "demo@2026.3.22" is not available yet (ClawHub /api/v1/packages/demo/versions/2026.3.22/artifact/download failed (404): Not Found). Use "npm:demo@2026.3.22" for launch installs while ClawHub artifact routing is being rolled out.',
     );
+    expect(failure.code).toBe(CLAWHUB_INSTALL_ERROR_CODE.ARTIFACT_DOWNLOAD_UNAVAILABLE);
     expect(archiveDownloadCall().artifact).toBe("clawpack");
     expect(installPluginFromArchiveMock).not.toHaveBeenCalled();
   });

--- a/src/plugins/clawhub.ts
+++ b/src/plugins/clawhub.ts
@@ -48,6 +48,7 @@ export const CLAWHUB_INSTALL_ERROR_CODE = {
   INCOMPATIBLE_PLUGIN_API: "incompatible_plugin_api",
   INCOMPATIBLE_GATEWAY: "incompatible_gateway",
   MISSING_ARCHIVE_INTEGRITY: "missing_archive_integrity",
+  ARTIFACT_DOWNLOAD_UNAVAILABLE: "artifact_download_unavailable",
   ARCHIVE_INTEGRITY_MISMATCH: "archive_integrity_mismatch",
 } as const;
 
@@ -1147,6 +1148,12 @@ export async function installPluginFromClawHub(
             version: versionState.version,
           })
         : formatErrorMessage(error),
+      expectedClawPackSha256 &&
+        error instanceof ClawHubRequestError &&
+        error.status === 404 &&
+        error.requestPath.endsWith("/artifact/download")
+        ? CLAWHUB_INSTALL_ERROR_CODE.ARTIFACT_DOWNLOAD_UNAVAILABLE
+        : undefined,
     );
   }
   try {

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -3133,6 +3133,55 @@ describe("syncPluginsForUpdateChannel", () => {
     });
   });
 
+  it("does not fall back from ClawHub to non-OpenClaw npm packages", async () => {
+    resolveBundledPluginSourcesMock.mockReturnValue(new Map());
+    installPluginFromClawHubMock.mockResolvedValue({
+      ok: false,
+      code: "package_not_found",
+      error: "Package not found on ClawHub.",
+    });
+    const config: OpenClawConfig = {
+      channels: {
+        "legacy-chat": {
+          enabled: true,
+        },
+      },
+      plugins: {
+        load: { paths: [appBundledPluginRoot("legacy-chat")] },
+        installs: {
+          "legacy-chat": {
+            source: "path",
+            sourcePath: appBundledPluginRoot("legacy-chat"),
+            installPath: appBundledPluginRoot("legacy-chat"),
+          },
+        },
+      },
+    };
+
+    const result = await syncPluginsForUpdateChannel({
+      channel: "stable",
+      externalizedBundledPluginBridges: [
+        {
+          bundledPluginId: "legacy-chat",
+          preferredSource: "clawhub",
+          clawhubSpec: "clawhub:legacy-chat@2026.5.1-beta.2",
+          npmSpec: "@someone-else/legacy-chat",
+          channelIds: ["legacy-chat"],
+        },
+      ],
+      config,
+    });
+
+    expect(installPluginFromNpmSpecMock).not.toHaveBeenCalled();
+    expect(result.changed).toBe(false);
+    expect(result.config).toBe(config);
+    expect(result.summary.switchedToNpm).toStrictEqual([]);
+    expect(result.summary.warnings).toStrictEqual([]);
+    expect(result.summary.errors).toEqual([
+      "Failed to update legacy-chat: Package not found on ClawHub. (ClawHub clawhub:legacy-chat@2026.5.1-beta.2).",
+    ]);
+  });
+
   it("marks official externalized ClawHub-to-npm fallbacks as trusted", async () => {
     resolveBundledPluginSourcesMock.mockReturnValue(new Map());
     installPluginFromClawHubMock.mockResolvedValue({

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -60,6 +60,7 @@ vi.mock("./clawhub.js", () => ({
     PACKAGE_NOT_FOUND: "package_not_found",
     VERSION_NOT_FOUND: "version_not_found",
     ARCHIVE_INTEGRITY_MISMATCH: "archive_integrity_mismatch",
+    ARTIFACT_DOWNLOAD_UNAVAILABLE: "artifact_download_unavailable",
   },
   installPluginFromClawHub: (...args: unknown[]) => installPluginFromClawHubMock(...args),
 }));
@@ -3182,12 +3183,12 @@ describe("syncPluginsForUpdateChannel", () => {
     ]);
   });
 
-  it("marks official externalized ClawHub-to-npm fallbacks as trusted", async () => {
+  it("falls back from official ClawHub artifact misses to trusted npm packages", async () => {
     resolveBundledPluginSourcesMock.mockReturnValue(new Map());
     installPluginFromClawHubMock.mockResolvedValue({
       ok: false,
-      code: "package_not_found",
-      error: "Package not found on ClawHub.",
+      code: "artifact_download_unavailable",
+      error: "ClawHub ClawPack artifact is unavailable.",
     });
     installPluginFromNpmSpecMock.mockResolvedValue(
       createSuccessfulNpmUpdateResult({

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -6,6 +6,7 @@ import type { NpmSpecResolution } from "../infra/install-source-utils.js";
 import { resolveNpmSpecMetadata } from "../infra/install-source-utils.js";
 import {
   compareOpenClawReleaseVersions,
+  isOpenClawOrgNpmSpec,
   isPrereleaseResolutionAllowed,
   parseRegistryNpmSpec,
 } from "../infra/npm-registry-spec.js";
@@ -428,15 +429,24 @@ function isExternalizedBundledPluginEnabled(params: {
   return false;
 }
 
-function shouldFallbackClawHubBridgeToNpm(result: { ok: false; code?: string }): boolean {
+function shouldFallbackClawHubBridgeToNpm(params: {
+  result: { ok: false; code?: string };
+  npmSpec?: string;
+}): boolean {
+  if (!isOpenClawOrgNpmSpec(params.npmSpec)) {
+    return false;
+  }
   return (
-    result.code === CLAWHUB_INSTALL_ERROR_CODE.PACKAGE_NOT_FOUND ||
-    result.code === CLAWHUB_INSTALL_ERROR_CODE.VERSION_NOT_FOUND
+    params.result.code === CLAWHUB_INSTALL_ERROR_CODE.PACKAGE_NOT_FOUND ||
+    params.result.code === CLAWHUB_INSTALL_ERROR_CODE.VERSION_NOT_FOUND
   );
 }
 
 function shouldFallbackBetaClawHubUpdate(result: { ok: false; code?: string }): boolean {
-  return shouldFallbackClawHubBridgeToNpm(result);
+  return (
+    result.code === CLAWHUB_INSTALL_ERROR_CODE.PACKAGE_NOT_FOUND ||
+    result.code === CLAWHUB_INSTALL_ERROR_CODE.VERSION_NOT_FOUND
+  );
 }
 
 function describeBetaNpmFallback(params: {
@@ -1741,7 +1751,7 @@ export async function syncPluginsForUpdateChannel(params: {
           expectedPluginId: targetPluginId,
           logger,
         });
-        if (!result.ok && npmSpec && shouldFallbackClawHubBridgeToNpm(result)) {
+        if (!result.ok && npmSpec && shouldFallbackClawHubBridgeToNpm({ result, npmSpec })) {
           const warning = `ClawHub ${clawhubSpec} unavailable for ${targetPluginId}; falling back to npm ${npmSpec}.`;
           summary.warnings.push(warning);
           logger.warn?.(warning);

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -438,7 +438,8 @@ function shouldFallbackClawHubBridgeToNpm(params: {
   }
   return (
     params.result.code === CLAWHUB_INSTALL_ERROR_CODE.PACKAGE_NOT_FOUND ||
-    params.result.code === CLAWHUB_INSTALL_ERROR_CODE.VERSION_NOT_FOUND
+    params.result.code === CLAWHUB_INSTALL_ERROR_CODE.VERSION_NOT_FOUND ||
+    params.result.code === CLAWHUB_INSTALL_ERROR_CODE.ARTIFACT_DOWNLOAD_UNAVAILABLE
   );
 }
 


### PR DESCRIPTION
## Summary
- Keep legacy package-update doctor repairs old-parent-readable by preserving source config metadata while still allowing modern parents to defer plugin package repair explicitly.
- Fall back to npm only for official `@openclaw/*` npm plugin packages when ClawHub package metadata exists but the ClawPack artifact download is unavailable.
- Target the managed gateway service package root during package updates and honor direct `node_modules` roots without breaking ordinary npm bin shim refreshes.
- Defer configured plugin payload repair when a shipped writable parent will resume post-core plugin update, so the candidate doctor does not double-install payloads the old parent still has queued from stale in-memory records.

## Verification
- `node scripts/run-vitest.mjs src/commands/doctor/shared/update-phase.test.ts src/commands/doctor/shared/release-configured-plugin-installs.test.ts src/flows/doctor-health-contributions.test.ts src/plugins/clawhub.test.ts src/commands/doctor/shared/missing-configured-plugin-install.test.ts src/commands/onboarding-plugin-install.test.ts src/infra/update-global.test.ts src/infra/package-update-steps.test.ts src/cli/update-cli.test.ts -- --reporter=verbose` (9 files, 322 tests)
- `node scripts/run-vitest.mjs src/infra/npm-registry-spec.test.ts src/commands/doctor/shared/missing-configured-plugin-install.test.ts src/plugins/update.test.ts src/commands/onboarding-plugin-install.test.ts -- --reporter=verbose` (4 files, 206 tests)
- `pnpm openclaw update --dry-run --json --channel stable` (live CLI dry-run; no config writes)
- `pnpm format:check src/commands/doctor/shared/missing-configured-plugin-install.ts src/commands/doctor/shared/missing-configured-plugin-install.test.ts src/commands/doctor/shared/release-configured-plugin-installs.test.ts src/commands/doctor/shared/update-phase.ts src/commands/doctor/shared/update-phase.test.ts`
- `node scripts/run-vitest.mjs src/commands/doctor/shared/missing-configured-plugin-install.test.ts src/commands/doctor/shared/release-configured-plugin-installs.test.ts src/commands/doctor/shared/update-phase.test.ts src/infra/update-runner.test.ts` (4 files, 123 tests)
- `.agents/skills/autoreview/scripts/autoreview --mode branch --reviewer codex --fallback-reviewer none` (clean on `b2257bcbd9d679ed8db20180ebb48cae9b00fd5a`)
- `pnpm check:changed` (Blacksmith Testbox `tbx_01krwf9bgences8s6jt9zv0zvd`, https://github.com/openclaw/openclaw/actions/runs/26010618814)
- Crabbox/AWS `run_e8fc8d98c386`, lease `cbx_9bad0aee0cca`: published Docker upgrade survivor from `openclaw@2026.5.16-beta.4` to candidate `2026.5.17`, scenarios `base` and `configured-plugin-installs`, both passed.

## Real behavior proof
Behavior addressed: legacy package updates from an old parent can run candidate doctor repairs without future-stamping config metadata or double-installing configured official plugin payloads; ClawHub artifact 404s fall back to npm only when the target npm package is an official `@openclaw/*` plugin package; package updates target the managed service package root instead of the invoking checkout/root.
Real environment tested: local focused Vitest for update, doctor, ClawHub, package-target, and official-only fallback contracts; live OpenClaw CLI dry-run in the repo checkout; Blacksmith Testbox changed core/coreTests/docs lanes; Crabbox/AWS Docker published-upgrade-survivor from `openclaw@2026.5.16-beta.4` to the PR candidate package.
Exact steps or command run after this patch: `pnpm openclaw update --dry-run --json --channel stable`; `node scripts/run-vitest.mjs src/commands/doctor/shared/missing-configured-plugin-install.test.ts src/commands/doctor/shared/release-configured-plugin-installs.test.ts src/commands/doctor/shared/update-phase.test.ts src/infra/update-runner.test.ts`; `.agents/skills/autoreview/scripts/autoreview --mode branch --reviewer codex --fallback-reviewer none`; Crabbox/AWS `run_e8fc8d98c386` ran `OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC=openclaw@2026.5.16-beta.4 pnpm test:docker:published-upgrade-survivor` and the same command with `OPENCLAW_UPGRADE_SURVIVOR_SCENARIO=configured-plugin-installs`.
Evidence after fix: focused tests passed with 4 files and 123 tests; branch autoreview returned no accepted/actionable findings; Testbox `tbx_01krwf9bgences8s6jt9zv0zvd` exited 0; Crabbox/AWS `run_e8fc8d98c386` exited 0 with both published-upgrade-survivor lanes passing; live CLI dry-run produced this terminal capture:

```console
$ pnpm openclaw update --dry-run --json --channel stable
{
  "dryRun": true,
  "root": "/Users/steipete/Projects/clawdbot6",
  "installKind": "git",
  "mode": "npm",
  "updateInstallKind": "package",
  "switchToGit": false,
  "switchToPackage": true,
  "restart": true,
  "requestedChannel": "stable",
  "storedChannel": "beta",
  "effectiveChannel": "stable",
  "tag": "openclaw@latest",
  "targetVersion": "2026.5.12",
  "downgradeRisk": false,
  "actions": [
    "Persist update.channel=stable in config",
    "Switch install mode from git to package manager (npm)",
    "Run plugin update sync after core update",
    "Refresh shell completion cache (if needed)",
    "Restart gateway service and run doctor checks"
  ],
  "notes": []
}
```

Observed result after fix: old published beta.4 upgrade paths that previously failed at `reason: "post-update-plugins"` now complete doctor, survival assertions, gateway start, health/ready/status probes, and configured plugin install repair without duplicate `plugin already exists` failures.
What was not tested: no cross-OS published-upgrade-survivor run; this proof is Linux Docker on AWS plus the existing changed Testbox lanes.
