### PR TITLE
fix(agents): fail closed on missing Codex harness [AI-assisted]

### DIFF
--- a/src/agents/harness/errors.ts
+++ b/src/agents/harness/errors.ts
@@ -1,0 +1,22 @@
+export class AgentHarnessNotRegisteredError extends Error {
+  readonly code = "agent_harness_not_registered";
+  readonly runtime: string;
+
+  constructor(runtime: string) {
+    super(`Requested agent harness "${runtime}" is not registered.`);
+    this.name = "AgentHarnessNotRegisteredError";
+    this.runtime = runtime;
+  }
+}
+
+export function isAgentHarnessNotRegisteredError(
+  error: unknown,
+): error is AgentHarnessNotRegisteredError {
+  return (
+    error instanceof AgentHarnessNotRegisteredError ||
+    (typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      error.code === "agent_harness_not_registered")
+  );
+}

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -21,6 +21,7 @@ import {
 } from "../subagent-capabilities.js";
 import { expandToolGroups, normalizeToolName } from "../tool-policy.js";
 import { createPiAgentHarness } from "./builtin-pi.js";
+import { AgentHarnessNotRegisteredError } from "./errors.js";
 import {
   resolveAgentHarnessPolicy as resolveConfiguredAgentHarnessPolicy,
   type AgentHarnessPolicy,
@@ -170,7 +171,7 @@ function selectAgentHarnessDecision(params: {
         candidates: listHarnessCandidates(pluginHarnesses),
       });
     }
-    throw new Error(`Requested agent harness "${runtime}" is not registered.`);
+    throw new AgentHarnessNotRegisteredError(runtime);
   }
 
   const candidates = pluginHarnesses.map((harness) => ({

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -13,6 +13,7 @@ import { CommandLaneTaskTimeoutError } from "../process/command-queue.js";
 import { AUTH_STORE_VERSION } from "./auth-profiles/constants.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
 import { FailoverError } from "./failover-error.js";
+import { AgentHarnessNotRegisteredError } from "./harness/errors.js";
 import { LiveSessionModelSwitchError } from "./live-model-switch-error.js";
 import {
   FallbackSummaryError,
@@ -910,6 +911,31 @@ describe("runWithModelFallback", () => {
         fallbacksOverride: [],
       }),
     ).rejects.toThrow("something weird");
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fall back when strict agent harness selection is missing", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5.5",
+            fallbacks: ["anthropic/claude-sonnet-4-6"],
+          },
+        },
+      },
+    });
+    const missingHarness = new AgentHarnessNotRegisteredError("codex");
+    const run = vi.fn().mockRejectedValueOnce(missingHarness).mockResolvedValueOnce("ok");
+
+    await expect(
+      runWithModelFallback({
+        cfg,
+        provider: "openai",
+        model: "gpt-5.5",
+        run,
+      }),
+    ).rejects.toBe(missingHarness);
     expect(run).toHaveBeenCalledTimes(1);
   });
 

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -26,6 +26,7 @@ import {
   shouldPreserveTransientCooldownProbeSlot,
   shouldUseTransientCooldownProbeSlot,
 } from "./failover-policy.js";
+import { isAgentHarnessNotRegisteredError } from "./harness/errors.js";
 import { LiveSessionModelSwitchError } from "./live-model-switch-error.js";
 import {
   isModelFallbackDecisionLogEnabled,
@@ -1127,6 +1128,9 @@ export async function runWithModelFallback<T>(
       // that may have a smaller context window and fail worse.
       const errMessage = formatErrorMessage(err);
       if (isLikelyContextOverflowError(errMessage)) {
+        throw err;
+      }
+      if (isAgentHarnessNotRegisteredError(err)) {
         throw err;
       }
       const normalized =


### PR DESCRIPTION
## Summary

- Problem: a missing explicit Codex agent harness could be treated like a normal model failure.
- Why it matters: sessions configured for Codex could silently continue on a fallback model such as Sonnet.
- What changed: missing strict harness selection now throws a typed error, and model fallback fails closed on it.
- What did NOT change (scope boundary): no Doctor, update, Telegram, auth, or fallback ordering changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #83349
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: strict Codex harness selection must fail closed instead of falling through to a configured model fallback.
- Real environment tested: local OpenClaw source checkout on Windows, using the real `runWithModelFallback()` source path through `tsx`.
- Exact steps or command run after this patch: ran a local source-run with primary `openai/gpt-5.5`, fallback `anthropic/claude-sonnet-4-6`, and a missing Codex harness error.
- Evidence after fix:

```json
{
  "error": "Requested agent harness \"codex\" is not registered.",
  "code": "agent_harness_not_registered",
  "calls": [
    "openai/gpt-5.5"
  ]
}
```

- Observed result after fix: only the requested Codex/OpenAI candidate ran; the Anthropic fallback was not called.
- What was not tested: a live Telegram/gateway session with real provider credentials.
- Before evidence: source inspection showed the harness selector threw a plain `Error`, and `runWithModelFallback()` continued unknown errors while fallback candidates remained.

## Root Cause (if applicable)

- Root cause: strict harness selection failures were represented as plain unknown errors.
- Missing detection / guardrail: model fallback had no non-retryable signal for an explicit missing harness.
- Contributing context (if known): existing fallback logic intentionally continues unknown provider/model errors when more candidates remain.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/model-fallback.test.ts`
- Scenario the test should lock in: missing strict Codex harness does not call the configured Anthropic fallback.
- Why this is the smallest reliable guardrail: it covers the exact boundary where harness selection errors enter model fallback.
- Existing test that already covers this (if any): harness selection tests already covered the fail-closed selector behavior, but not model-fallback retry behavior.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Sessions explicitly configured for a missing Codex harness now fail with that harness error instead of silently continuing on a fallback model.

## Diagram (if applicable)

```text
Before:
missing strict Codex harness -> plain Error -> model fallback -> Sonnet can run

After:
missing strict Codex harness -> typed error -> fail closed
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows local checkout
- Runtime/container: local Node via OpenClaw test runner
- Model/provider: `openai/gpt-5.5` with fallback `anthropic/claude-sonnet-4-6`
- Integration/channel (if any): N/A
- Relevant config (redacted): no secrets used

### Steps

1. Configure primary `openai/gpt-5.5` with fallback `anthropic/claude-sonnet-4-6`.
2. Run the fallback path with a missing strict `codex` harness error.
3. Observe which candidate models are invoked.

### Expected

- The missing Codex harness error stops the run before model fallback.

### Actual

- The run stopped with `agent_harness_not_registered` after only `openai/gpt-5.5`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Focused checks:

```text
node scripts/run-vitest.mjs src/agents/model-fallback.test.ts -t "does not fall back when strict agent harness selection is missing"
Test Files  2 passed (2)
Tests  2 passed | 112 skipped (114)

node scripts/run-vitest.mjs src/agents/model-fallback.test.ts src/agents/harness/selection.test.ts
Test Files  4 passed (4)
Tests  166 passed (166)

node scripts/run-vitest.mjs src/agents/agent-command.live-model-switch.test.ts
Test Files  2 passed (2)
Tests  38 passed (38)

git diff --check origin/main...HEAD
clean
```

## Human Verification (required)

- Verified scenarios: strict missing Codex harness stops before fallback; existing harness selection behavior stays green; related agent command fallback tests stay green.
- Edge cases checked: the guard also recognizes the stable error `code` across possible boundaries, not only same-realm `instanceof`.
- What you did **not** verify: live Telegram/gateway routing with real credentials.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a missing explicit harness now stops earlier instead of using fallback.
  - Mitigation: this matches the strict runtime contract and the issue's requested fail-closed behavior.
