### PR TITLE
fix(packaging): add sharp to optionalDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1837,6 +1837,7 @@
     "vitest": "4.1.6"
   },
   "optionalDependencies": {
+    "sharp": "^0.34.5",
     "sqlite-vec": "0.1.9"
   },
   "overrides": {


### PR DESCRIPTION
## Summary

- Problem: Fresh `npm i -g openclaw` does not install `sharp`, causing browser screenshot image resize and media-understanding image ops to fail with `"Optional dependency sharp is required for image attachment processing"`. Users must manually run `npm i sharp --no-save` inside the install directory as a workaround.
- Why it matters: Any feature that touches image processing (browser screenshots, media-understanding image tool, image attachments) is broken out of the box on a fresh install.
- What changed: Added `"sharp": "^0.34.5"` to `optionalDependencies` in root `package.json`, matching the existing pattern used for `sqlite-vec`.
- What did NOT change (scope boundary): No code changes. No behavior changes for users who already have sharp installed. The dynamic import and graceful error handling in `extensions/media-understanding-core/image-ops.ts` remain unchanged — if sharp fails to build on a given platform, the error message is the same as before.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #83401
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `extensions/media-understanding-core/image-ops.ts:57` dynamically imports `sharp` and throws when missing, but `sharp` was never declared in `package.json` under any dependency field (`dependencies`, `optionalDependencies`, or `peerDependencies`). So `npm install` never installs it.
- Missing detection / guardrail: No CI check that runtime dynamic imports have matching dependency declarations.
- Contributing context: sharp has native bindings that historically caused build issues (Homebrew libvips conflicts), which may be why it was kept out of declared dependencies. But `optionalDependencies` is the correct mechanism for exactly this scenario — npm will attempt to install but won't fail if the build errors out.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- If no new test is added, why not: This is a packaging metadata fix (1 line in package.json). The existing dynamic import + error handling in image-ops.ts already covers the runtime behavior. Verified manually that `npm install` in a directory with this change installs sharp successfully.

## User-visible / Behavior Changes

- `npm i -g openclaw` (or `npm install` in the openclaw directory) now automatically installs `sharp` as an optional dependency.
- If sharp fails to build on a given platform, `npm install` still succeeds (it's optional) and the existing error message appears at runtime when image processing is attempted.
- Users no longer need to manually run `npm i sharp --no-save` after installing openclaw.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (darwin)
- Runtime: Node 22
- OpenClaw 2026.5.16-beta.6

### Steps

1. Have a fresh openclaw install (no manual sharp installation)
2. Trigger browser screenshot or any image attachment processing
3. Observe error: `Optional dependency sharp is required for image attachment processing`

### Expected

- sharp should be installed automatically by `npm install`

### Actual (after fix)

- Patched `package.json` in the install directory, ran `npm install` → sharp 0.34.5 installed automatically (381 packages added). `import('sharp')` succeeds.

## Evidence

- [x] Manual verification: patched `~/.npm-global/lib/node_modules/openclaw/package.json`, ran `npm install`, confirmed sharp installed and importable.

## Human Verification (required)

- Verified scenarios:
  - `npm install` with patched package.json → sharp installed automatically
  - `import('sharp')` → success
  - sharp version matches declared range (0.34.5 ∈ ^0.34.5)
- Edge cases checked:
  - Existing `sqlite-vec` in optionalDependencies not affected
- What you did **not** verify:
  - Platform where sharp native build fails (expected: npm install succeeds, sharp missing at runtime, existing error message shown)
  - Docker / container builds

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: sharp native build fails on some platforms (e.g. Alpine musl, old glibc, Homebrew libvips conflict).
  - Mitigation: Using `optionalDependencies` — npm won't fail the install if sharp build errors. Runtime graceful degradation unchanged. `SHARP_IGNORE_GLOBAL_LIBVIPS=1` env var documented for Homebrew conflict.

## Real behavior proof

- Behavior addressed: `npm i -g openclaw` does not install sharp, causing `Optional dependency sharp is required for image attachment processing` at runtime for any image processing path (browser screenshots, media-understanding image ops).
- Real environment tested: macOS darwin, Node 22, OpenClaw 2026.5.16-beta.6 installed via `npm i -g openclaw`, global install at `~/.npm-global/lib/node_modules/openclaw/`.
- Exact steps or command run after this patch:
  1. Patched `~/.npm-global/lib/node_modules/openclaw/package.json` to add `"sharp": "^0.34.5"` to `optionalDependencies`
  2. Ran `SHARP_IGNORE_GLOBAL_LIBVIPS=1 npm install` in the openclaw install directory
  3. Verified sharp installed and importable
  4. Restarted gateway + openclaw-node services
  5. Triggered browser screenshot via Control UI
- Evidence after fix: terminal output from the install directory:
  ```
  $ ls node_modules/sharp
  ls: node_modules/sharp: No such file or directory     # before

  $ npm install
  added 381 packages, removed 1 package, changed 1 package, and audited 736 packages in 49s

  $ ls node_modules/sharp/package.json
  node_modules/sharp/package.json                       # after: sharp installed

  $ node -e "import('sharp').then(m => console.log('sharp OK')).catch(e => console.log('FAIL', e.message))"
  sharp OK                                              # runtime import succeeds

  $ openclaw status | grep Gateway
  Gateway | local · ws://127.0.0.1:18789 · reachable 96ms
  ```
  Browser screenshot subsequently succeeded without the `sharp is required` error.
- Observed result after fix: `npm install` automatically installs sharp 0.34.5 via optionalDependencies. Browser screenshot image resize works end-to-end. No manual `npm i sharp --no-save` workaround needed.
- What was not tested: Platform where sharp native build fails (e.g. Alpine musl). Expected: npm install succeeds (sharp skipped as optional), existing runtime error message shown when image processing attempted.
