### PR TITLE
test: fix environment sensitivity in resolveNpmCommandInvocation test

### DIFF
--- a/test/openclaw-npm-release-check.test.ts
+++ b/test/openclaw-npm-release-check.test.ts
@@ -306,7 +306,7 @@ describe("resolveNpmCommandInvocation", () => {
   });
 
   it("uses the platform npm command when npm_execpath is missing", () => {
-    expect(resolveNpmCommandInvocation({ platform: "win32" })).toEqual({
+    expect(resolveNpmCommandInvocation({ npmExecPath: "", platform: "win32" })).toEqual({
       command: "npm.cmd",
       args: [],
     });


### PR DESCRIPTION
## Summary

- Problem: The `resolveNpmCommandInvocation` test "uses the platform npm command when npm_execpath is missing" was failing locally because it implicitly read the `npm_execpath` environment variable injected by the local `npm test` runner.
- Why it matters: It causes local test failures for contributors running `npm test`, making the test suite environment-sensitive.
- What changed: Explicitly passed `npmExecPath: ""` to the function call in the test to bypass the environment variable fallback.
- What did NOT change (scope boundary): The actual implementation of `resolveNpmCommandInvocation` is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Local test failure in `test/openclaw-npm-release-check.test.ts` due to environment sensitivity.
- Real environment tested: Windows 10, Node.js, running locally via PowerShell.
- Exact steps or command run after this patch: `npm test test/openclaw-npm-release-check.test.ts`
- Evidence after fix:
Terminal output:
```
> openclaw@2026.5.17 test
> node scripts/test-projects.mjs test/openclaw-npm-release-check.test.ts

[test] starting test/vitest/vitest.tooling.config.ts

 RUN  v4.1.6 D:/openclaw

 Test Files  1 passed (1)
      Tests  57 passed (57)
   Start at  11:08:50
   Duration  1.02s
```
- Observed result after fix: The test suite passes successfully without being affected by the local `npm_execpath` environment variable.
- What was not tested: Other platforms (Linux/macOS) were not manually tested, but the fix is platform-agnostic.

## Root Cause (if applicable)

- Root cause: The test did not explicitly provide an `npmExecPath` argument, causing the function to fall back to `process.env.npm_execpath`, which is populated by the `npm test` runner.
- Missing detection / guardrail: The test was likely written and verified in an environment where `npm_execpath` was not set, or run via a different runner.
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `test/openclaw-npm-release-check.test.ts`
- Scenario the test should lock in: The function should correctly fall back to the platform npm command when `npmExecPath` is explicitly empty.
- Why this is the smallest reliable guardrail: It directly tests the fallback logic in isolation.
- Existing test that already covers this (if any): The modified test itself.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Windows 10
- Runtime/container: Node.js
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run `npm test test/openclaw-npm-release-check.test.ts` locally.

### Expected

- Test passes.

### Actual

- Test passes.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Running the specific test file locally via `npm test`.
- Edge cases checked: N/A
- What you did **not** verify: Full CI suite, as this is a localized test fix.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

None.