### PR TITLE
fix(gateway): hint missing WhatsApp web-login plugin (#83277)

### DIFF
--- a/src/gateway/server-methods/web.start.test.ts
+++ b/src/gateway/server-methods/web.start.test.ts
@@ -23,6 +23,7 @@ function createOptions(
     isWebchatConnect: () => false,
     respond: vi.fn(),
     context: {
+      getRuntimeConfig: vi.fn().mockReturnValue({}),
       stopChannel: vi.fn(),
       startChannel: vi.fn(),
       getRuntimeSnapshot: vi.fn(
@@ -55,6 +56,7 @@ function createRunningWhatsappContext() {
     startChannel,
     stopChannel,
     context: {
+      getRuntimeConfig: vi.fn().mockReturnValue({}),
       stopChannel,
       startChannel,
       getRuntimeSnapshot: vi.fn(
@@ -147,6 +149,42 @@ describe("webHandlers web.login.start", () => {
     expect(stopChannel).toHaveBeenCalledWith("whatsapp", "default");
     expect(startChannel).not.toHaveBeenCalled();
   });
+
+  it("explains how to repair a configured missing external WhatsApp plugin", async () => {
+    mocks.listChannelPlugins.mockReturnValue([]);
+    const respond = vi.fn();
+
+    await webHandlers["web.login.start"](
+      createOptions(
+        { accountId: "default" },
+        {
+          respond,
+          context: {
+            getRuntimeConfig: vi.fn().mockReturnValue({
+              channels: { whatsapp: { enabled: true } },
+            }),
+            stopChannel: vi.fn(),
+            startChannel: vi.fn(),
+            getRuntimeSnapshot: vi.fn(
+              (): ChannelRuntimeSnapshot => ({
+                channels: {},
+                channelAccounts: {},
+              }),
+            ),
+          } as unknown as GatewayRequestHandlerOptions["context"],
+        },
+      ),
+    );
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "INVALID_REQUEST",
+        message: expect.stringContaining("openclaw plugins install clawhub:@openclaw/whatsapp"),
+      }),
+    );
+  });
 });
 
 describe("webHandlers web.login.wait", () => {
@@ -205,6 +243,48 @@ describe("webHandlers web.login.wait", () => {
         qrDataUrl: "data:image/png;base64,next-qr",
       },
       undefined,
+    );
+  });
+
+  it("uses the same missing external plugin repair hint while waiting", async () => {
+    mocks.listChannelPlugins.mockReturnValue([]);
+    const respond = vi.fn();
+
+    await webHandlers["web.login.wait"](
+      createOptions(
+        { accountId: "default" },
+        {
+          req: {
+            type: "req",
+            id: "req-2",
+            method: "web.login.wait",
+            params: { accountId: "default" },
+          } as GatewayRequestHandlerOptions["req"],
+          respond,
+          context: {
+            getRuntimeConfig: vi.fn().mockReturnValue({
+              channels: { whatsapp: { enabled: true } },
+            }),
+            stopChannel: vi.fn(),
+            startChannel: vi.fn(),
+            getRuntimeSnapshot: vi.fn(
+              (): ChannelRuntimeSnapshot => ({
+                channels: {},
+                channelAccounts: {},
+              }),
+            ),
+          } as unknown as GatewayRequestHandlerOptions["context"],
+        },
+      ),
+    );
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "INVALID_REQUEST",
+        message: expect.stringContaining("openclaw doctor --fix"),
+      }),
     );
   });
 });

--- a/src/gateway/server-methods/web.start.test.ts
+++ b/src/gateway/server-methods/web.start.test.ts
@@ -4,10 +4,16 @@ import type { GatewayRequestHandlerOptions } from "./types.js";
 
 const mocks = vi.hoisted(() => ({
   listChannelPlugins: vi.fn(),
+  resolveMissingOfficialExternalChannelPluginRepairHint: vi.fn(),
 }));
 
 vi.mock("../../channels/plugins/index.js", () => ({
   listChannelPlugins: mocks.listChannelPlugins,
+}));
+
+vi.mock("../../plugins/official-external-plugin-repair-hints.js", () => ({
+  resolveMissingOfficialExternalChannelPluginRepairHint:
+    mocks.resolveMissingOfficialExternalChannelPluginRepairHint,
 }));
 
 import { webHandlers } from "./web.js";
@@ -84,6 +90,21 @@ function createRunningWhatsappContext() {
 describe("webHandlers web.login.start", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.resolveMissingOfficialExternalChannelPluginRepairHint.mockImplementation(
+      ({ channelId }: { channelId: string }) =>
+        channelId === "whatsapp"
+          ? {
+              pluginId: "whatsapp",
+              channelId: "whatsapp",
+              label: "WhatsApp",
+              installSpec: "clawhub:@openclaw/whatsapp",
+              installCommand: "openclaw plugins install clawhub:@openclaw/whatsapp",
+              doctorFixCommand: "openclaw doctor --fix",
+              repairHint:
+                "Install the official external plugin with: openclaw plugins install clawhub:@openclaw/whatsapp, or run: openclaw doctor --fix.",
+            }
+          : null,
+    );
   });
 
   it("restarts a previously running channel when login start exits early without a QR", async () => {
@@ -185,11 +206,66 @@ describe("webHandlers web.login.start", () => {
       }),
     );
   });
+
+  it("does not guess missing-plugin repair hints when channel policy suppresses them", async () => {
+    mocks.listChannelPlugins.mockReturnValue([]);
+    mocks.resolveMissingOfficialExternalChannelPluginRepairHint.mockReturnValueOnce(null);
+    const respond = vi.fn();
+
+    await webHandlers["web.login.start"](
+      createOptions(
+        { accountId: "default" },
+        {
+          respond,
+          context: {
+            getRuntimeConfig: vi.fn().mockReturnValue({
+              channels: { whatsapp: { enabled: true } },
+            }),
+            stopChannel: vi.fn(),
+            startChannel: vi.fn(),
+            getRuntimeSnapshot: vi.fn(
+              (): ChannelRuntimeSnapshot => ({
+                channels: {},
+                channelAccounts: {},
+              }),
+            ),
+          } as unknown as GatewayRequestHandlerOptions["context"],
+        },
+      ),
+    );
+
+    expect(mocks.resolveMissingOfficialExternalChannelPluginRepairHint).toHaveBeenCalledWith(
+      expect.objectContaining({ channelId: "whatsapp" }),
+    );
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "INVALID_REQUEST",
+        message: "web login provider is not available",
+      }),
+    );
+  });
 });
 
 describe("webHandlers web.login.wait", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.resolveMissingOfficialExternalChannelPluginRepairHint.mockImplementation(
+      ({ channelId }: { channelId: string }) =>
+        channelId === "whatsapp"
+          ? {
+              pluginId: "whatsapp",
+              channelId: "whatsapp",
+              label: "WhatsApp",
+              installSpec: "clawhub:@openclaw/whatsapp",
+              installCommand: "openclaw plugins install clawhub:@openclaw/whatsapp",
+              doctorFixCommand: "openclaw doctor --fix",
+              repairHint:
+                "Install the official external plugin with: openclaw plugins install clawhub:@openclaw/whatsapp, or run: openclaw doctor --fix.",
+            }
+          : null,
+    );
   });
 
   it("passes refreshed QR payloads back to the client while login is still pending", async () => {

--- a/src/gateway/server-methods/web.ts
+++ b/src/gateway/server-methods/web.ts
@@ -1,10 +1,7 @@
 import { listChannelPlugins } from "../../channels/plugins/index.js";
 import type { ChannelId } from "../../channels/plugins/types.public.js";
 import { hasExplicitChannelConfig } from "../../plugins/channel-plugin-ids.js";
-import {
-  resolveMissingOfficialExternalChannelPluginRepairHint,
-  resolveOfficialExternalPluginRepairHint,
-} from "../../plugins/official-external-plugin-repair-hints.js";
+import { resolveMissingOfficialExternalChannelPluginRepairHint } from "../../plugins/official-external-plugin-repair-hints.js";
 import {
   ErrorCodes,
   errorShape,
@@ -44,11 +41,10 @@ function resolveMissingWebLoginProviderRepairHint(
       if (!hasExplicitChannelConfig({ config, channelId })) {
         continue;
       }
-      const hint =
-        resolveMissingOfficialExternalChannelPluginRepairHint({
-          config,
-          channelId,
-        }) ?? resolveOfficialExternalPluginRepairHint(channelId);
+      const hint = resolveMissingOfficialExternalChannelPluginRepairHint({
+        config,
+        channelId,
+      });
       if (hint) {
         return `Configured official external channel ${hint.label} is missing its plugin. ${hint.repairHint}`;
       }

--- a/src/gateway/server-methods/web.ts
+++ b/src/gateway/server-methods/web.ts
@@ -1,5 +1,10 @@
 import { listChannelPlugins } from "../../channels/plugins/index.js";
 import type { ChannelId } from "../../channels/plugins/types.public.js";
+import { hasExplicitChannelConfig } from "../../plugins/channel-plugin-ids.js";
+import {
+  resolveMissingOfficialExternalChannelPluginRepairHint,
+  resolveOfficialExternalPluginRepairHint,
+} from "../../plugins/official-external-plugin-repair-hints.js";
 import {
   ErrorCodes,
   errorShape,
@@ -8,7 +13,7 @@ import {
   validateWebLoginWaitParams,
 } from "../protocol/index.js";
 import { formatForLog } from "../ws-log.js";
-import type { GatewayRequestHandlers, RespondFn } from "./types.js";
+import type { GatewayRequestContext, GatewayRequestHandlers, RespondFn } from "./types.js";
 
 const WEB_LOGIN_METHODS = new Set(["web.login.start", "web.login.wait"]);
 
@@ -26,11 +31,44 @@ function resolveAccountId(params: unknown): string | undefined {
     : undefined;
 }
 
-function respondProviderUnavailable(respond: RespondFn) {
+function resolveMissingWebLoginProviderRepairHint(
+  context: Pick<GatewayRequestContext, "getRuntimeConfig">,
+): string | undefined {
+  try {
+    const config = context.getRuntimeConfig();
+    const channels = config.channels;
+    if (!channels || typeof channels !== "object" || Array.isArray(channels)) {
+      return undefined;
+    }
+    for (const channelId of Object.keys(channels)) {
+      if (!hasExplicitChannelConfig({ config, channelId })) {
+        continue;
+      }
+      const hint =
+        resolveMissingOfficialExternalChannelPluginRepairHint({
+          config,
+          channelId,
+        }) ?? resolveOfficialExternalPluginRepairHint(channelId);
+      if (hint) {
+        return `Configured official external channel ${hint.label} is missing its plugin. ${hint.repairHint}`;
+      }
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+function respondProviderUnavailable(respond: RespondFn, repairHint?: string) {
   respond(
     false,
     undefined,
-    errorShape(ErrorCodes.INVALID_REQUEST, "web login provider is not available"),
+    errorShape(
+      ErrorCodes.INVALID_REQUEST,
+      repairHint
+        ? `web login provider is not available. ${repairHint}`
+        : "web login provider is not available",
+    ),
   );
 }
 
@@ -78,7 +116,7 @@ export const webHandlers: GatewayRequestHandlers = {
       const accountId = resolveAccountId(params);
       const provider = resolveWebLoginProvider();
       if (!provider) {
-        respondProviderUnavailable(respond);
+        respondProviderUnavailable(respond, resolveMissingWebLoginProviderRepairHint(context));
         return;
       }
       if (!provider.gateway?.loginWithQrStart) {
@@ -126,7 +164,7 @@ export const webHandlers: GatewayRequestHandlers = {
       const accountId = resolveAccountId(params);
       const provider = resolveWebLoginProvider();
       if (!provider) {
-        respondProviderUnavailable(respond);
+        respondProviderUnavailable(respond, resolveMissingWebLoginProviderRepairHint(context));
         return;
       }
       if (!provider.gateway?.loginWithQrWait) {


### PR DESCRIPTION
## Summary

- When no QR-capable web-login provider is loaded, detect explicitly configured official external channels such as WhatsApp.
- Reuse the official external plugin repair hint so `web.login.start` / `web.login.wait` tells operators to install `clawhub:@openclaw/whatsapp` or run `openclaw doctor --fix` instead of only returning the generic provider-unavailable error.
- Add regression coverage for both start and wait paths.

Fixes #83277.

## Real behavior proof

Behavior addressed: A configured WhatsApp channel with no loaded WhatsApp plugin made dashboard Show QR return only `web login provider is not available`, leaving users who already installed/authenticated `wacli` without the actual missing-plugin repair path.

Real environment tested: Local OpenClaw checkout on branch `fix-web-login-missing-whatsapp-plugin-83277`, Node/Vitest via repo scripts.

Exact steps or command run after this patch:

```bash
pnpm test src/gateway/server-methods/web.start.test.ts src/plugins/official-external-plugin-repair-hints.test.ts
git diff --check
pnpm check:changed
```

Evidence after fix:

- `src/gateway/server-methods/web.start.test.ts`: 5 tests passed, including missing WhatsApp plugin hints for `web.login.start` and `web.login.wait`.
- `src/plugins/official-external-plugin-repair-hints.test.ts`: 4 tests passed.
- `pnpm check:changed`: passed.

Observed result after fix: With `channels.whatsapp.enabled: true` and no QR-capable provider loaded, the error message includes `openclaw plugins install clawhub:@openclaw/whatsapp` and `openclaw doctor --fix`.

Not tested: Live Windows Scheduled Task gateway and real dashboard click flow; this is covered by source-level gateway handler tests for the exact RPC error path.

## Scout audits

- Existing-helper check: reused `resolveMissingOfficialExternalChannelPluginRepairHint` and `resolveOfficialExternalPluginRepairHint`; no new catalog logic.
- Shared-helper caller check: changed only the gateway web-login handler; no shared helper contract mutation.
- Broader-fix rival scan: `gh pr list --search '83390 OR 83277 in:title,body'` found no open PR for #83277.
