### PR TITLE
fix: support m2a audio attachments

### DIFF
--- a/packages/memory-host-sdk/src/host/internal.test.ts
+++ b/packages/memory-host-sdk/src/host/internal.test.ts
@@ -117,11 +117,14 @@ describe("memory host SDK package internals", () => {
     const tmpDir = getTmpDir();
     const notePath = path.join(tmpDir, "note.md");
     const imagePath = path.join(tmpDir, "diagram.png");
+    const audioPath = path.join(tmpDir, "voice.m2a");
     fsSync.writeFileSync(notePath, "hello", "utf-8");
     fsSync.writeFileSync(imagePath, Buffer.from("png"));
+    fsSync.writeFileSync(audioPath, Buffer.from("audio"));
 
     const note = await buildFileEntry(notePath, tmpDir);
     const image = await buildFileEntry(imagePath, tmpDir, multimodal);
+    const audio = await buildFileEntry(audioPath, tmpDir, multimodal);
 
     const noteEntry = expectFileEntry(note);
     expect(noteEntry.path).toBe("note.md");
@@ -132,6 +135,12 @@ describe("memory host SDK package internals", () => {
     expect(imageEntry.modality).toBe("image");
     expect(imageEntry.mimeType).toBe("image/png");
     expect(imageEntry.contentText).toBe("Image file: diagram.png");
+    const audioEntry = expectFileEntry(audio);
+    expect(audioEntry.path).toBe("voice.m2a");
+    expect(audioEntry.kind).toBe("multimodal");
+    expect(audioEntry.modality).toBe("audio");
+    expect(audioEntry.mimeType).toBe("audio/mpeg");
+    expect(audioEntry.contentText).toBe("Audio file: voice.m2a");
   });
 
   it("builds multimodal chunks lazily and rejects changed files", async () => {

--- a/packages/memory-host-sdk/src/host/multimodal.ts
+++ b/packages/memory-host-sdk/src/host/multimodal.ts
@@ -7,7 +7,7 @@ const MEMORY_MULTIMODAL_SPECS = {
   },
   audio: {
     labelPrefix: "Audio file",
-    extensions: [".mp3", ".wav", ".ogg", ".opus", ".m4a", ".aac", ".flac"],
+    extensions: [".mp3", ".m2a", ".wav", ".ogg", ".opus", ".m4a", ".aac", ".flac"],
   },
 } as const;
 

--- a/src/auto-reply/media-note.test.ts
+++ b/src/auto-reply/media-note.test.ts
@@ -137,6 +137,25 @@ describe("buildInboundMediaNote", () => {
     );
   });
 
+  it("strips M2A attachments when transcription succeeded via MediaUnderstanding", () => {
+    const note = buildInboundMediaNote({
+      MediaPaths: ["/tmp/voice.m2a", "/tmp/image.png"],
+      MediaUrls: ["https://example.com/voice.m2a", "https://example.com/image.png"],
+      MediaTypes: ["audio/mpeg", "image/png"],
+      MediaUnderstanding: [
+        {
+          kind: "audio.transcription",
+          attachmentIndex: 0,
+          text: "Hello world",
+          provider: "whisper",
+        },
+      ],
+    });
+    expect(note).toBe(
+      "[media attached: /tmp/image.png (image/png) | https://example.com/image.png]",
+    );
+  });
+
   it("strips audio attachments when transcription succeeded via decisions", () => {
     const note = buildInboundMediaNote({
       MediaPaths: ["/tmp/voice.ogg", "/tmp/image.png"],

--- a/src/auto-reply/media-note.ts
+++ b/src/auto-reply/media-note.ts
@@ -60,6 +60,7 @@ const AUDIO_EXTENSIONS = new Set([
   ".ogg",
   ".opus",
   ".mp3",
+  ".m2a",
   ".m4a",
   ".wav",
   ".webm",

--- a/src/media/audio.test.ts
+++ b/src/media/audio.test.ts
@@ -70,6 +70,10 @@ describe("isVoiceCompatibleAudio", () => {
           opts: { contentType: "audio/mpeg", fileName: "file.wav" },
           expected: true,
         },
+        {
+          opts: { fileName: "voice.m2a" },
+          expected: true,
+        },
       ],
     },
   ])("$name", ({ cases }) => {

--- a/src/media/audio.ts
+++ b/src/media/audio.ts
@@ -1,7 +1,14 @@
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { getFileExtension, normalizeMimeType } from "./mime.js";
 
-export const VOICE_MESSAGE_AUDIO_EXTENSIONS = new Set([".oga", ".ogg", ".opus", ".mp3", ".m4a"]);
+export const VOICE_MESSAGE_AUDIO_EXTENSIONS = new Set([
+  ".oga",
+  ".ogg",
+  ".opus",
+  ".mp3",
+  ".m2a",
+  ".m4a",
+]);
 
 /**
  * MIME types compatible with voice messages.

--- a/src/media/mime.test.ts
+++ b/src/media/mime.test.ts
@@ -143,6 +143,11 @@ describe("mime detection", () => {
     expect(mime).toBe("audio/aac");
   });
 
+  it("detects M2A audio from a bare filename when buffer sniffing is inconclusive", async () => {
+    const mime = await detectMime({ buffer: Buffer.alloc(16), filePath: "voice.m2a" });
+    expect(mime).toBe("audio/mpeg");
+  });
+
   it("detects Apple CAF audio by magic bytes when file-type does not recognize the container", async () => {
     // CAF files start with the four-byte ASCII tag "caff". `file-type` v22 has
     // no native CAF detector, so without the manual magic-byte fallback the
@@ -175,6 +180,7 @@ describe("mimeTypeFromFilePath", () => {
     { filePath: "photo.jpg", expected: "image/jpeg" },
     { filePath: "photo.JPG", expected: "image/jpeg" },
     { filePath: "voice.mp3", expected: "audio/mpeg" },
+    { filePath: "voice.m2a", expected: "audio/mpeg" },
     { filePath: "voice.wav", expected: "audio/wav" },
     { filePath: "clip.avi", expected: "video/x-msvideo" },
     { filePath: "clip.mkv", expected: "video/x-matroska" },
@@ -246,6 +252,7 @@ describe("isAudioFileName", () => {
 
   it.each([
     { fileName: "voice.mp3", expected: true },
+    { fileName: "voice.m2a", expected: true },
     { fileName: "voice.caf", expected: true },
     { fileName: "voice.bin", expected: false },
   ] as const)("matches audio extension for $fileName", ({ fileName, expected }) => {

--- a/src/media/mime.ts
+++ b/src/media/mime.ts
@@ -70,6 +70,7 @@ const MIME_BY_EXT: Record<string, string> = {
   ...buildMimeByExt(),
   // Canonical extension mappings for common MIME aliases
   ".jpg": "image/jpeg",
+  ".m2a": "audio/mpeg",
   ".mp3": "audio/mpeg",
   ".wav": "audio/wav",
   ".webm": "video/webm",
@@ -85,6 +86,7 @@ const AUDIO_FILE_EXTENSIONS = new Set([
   ".aac",
   ".caf",
   ".flac",
+  ".m2a",
   ".m4a",
   ".mp3",
   ".oga",

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -180,7 +180,8 @@ function isAudioTranscriptMediaPath(path: string, mediaType: unknown): boolean {
   }
   const ext = getFileExtension(path);
   return (
-    ext !== undefined && ["aac", "flac", "m4a", "mp3", "oga", "ogg", "opus", "wav"].includes(ext)
+    ext !== undefined &&
+    ["aac", "flac", "m2a", "m4a", "mp3", "oga", "ogg", "opus", "wav"].includes(ext)
   );
 }
 

--- a/ui/src/ui/chat/message-normalizer.test.ts
+++ b/ui/src/ui/chat/message-normalizer.test.ts
@@ -299,6 +299,25 @@ describe("message-normalizer", () => {
       ]);
     });
 
+    it("infers M2A MEDIA attachments as audio", () => {
+      const result = normalizeMessage({
+        role: "assistant",
+        content: "MEDIA:https://example.com/voice.m2a",
+      });
+
+      expect(result.content).toEqual([
+        {
+          type: "attachment",
+          attachment: {
+            url: "https://example.com/voice.m2a",
+            kind: "audio",
+            label: "voice.m2a",
+            mimeType: "audio/mpeg",
+          },
+        },
+      ]);
+    });
+
     it("keeps valid local MEDIA paths as assistant attachments", () => {
       const result = normalizeMessage({
         role: "assistant",

--- a/ui/src/ui/chat/message-normalizer.ts
+++ b/ui/src/ui/chat/message-normalizer.ts
@@ -86,6 +86,7 @@ const MIME_BY_EXT: Record<string, string> = {
   ogg: "audio/ogg",
   oga: "audio/ogg",
   mp3: "audio/mpeg",
+  m2a: "audio/mpeg",
   wav: "audio/wav",
   flac: "audio/flac",
   aac: "audio/aac",


### PR DESCRIPTION
## Summary
- map `.m2a` files to `audio/mpeg` in shared MIME detection
- include `.m2a` in voice-compatible and media-note audio extension handling
- recognize `.m2a` audio attachments in memory host multimodal handling and Web UI message normalization/rendering

## Real behavior proof
- Behavior or issue addressed: `.m2a` audio attachments are now recognized as `audio/mpeg`, included in audio filename handling, and treated as voice-compatible audio instead of being unknown media.
- Real environment tested: local OpenClaw checkout at `/Users/wuyangfan/Desktop/project/openclaw-work/openclaw`, Node.js runtime with `tsx`, branch `fix/m2a-audio-support` after this patch.
- Exact steps or command run after this patch:
  ```sh
  node --import tsx --eval 'import { detectMime, isAudioFileName, mimeTypeFromFilePath } from "./src/media/mime.ts"; import { isVoiceCompatibleAudio } from "./src/media/audio.ts"; const buffer = Buffer.alloc(16); const detected = await detectMime({ buffer, filePath: "voice.m2a" }); console.log(JSON.stringify({ detected, mapped: mimeTypeFromFilePath("voice.m2a"), isAudio: isAudioFileName("voice.m2a"), isVoiceCompatible: isVoiceCompatibleAudio({ fileName: "voice.m2a" }) }, null, 2));'
  ```
- Evidence after fix: terminal output from the runtime command above:
  ```json
  {
    "detected": "audio/mpeg",
    "mapped": "audio/mpeg",
    "isAudio": true,
    "isVoiceCompatible": true
  }
  ```
- Observed result after fix: the live runtime returned `audio/mpeg` for `.m2a`, `isAudio: true`, and `isVoiceCompatible: true`.
- What was not tested: No additional gaps.

## Test Plan
- `pnpm test src/media/mime.test.ts src/media/audio.test.ts src/auto-reply/media-note.test.ts ui/src/ui/chat/message-normalizer.test.ts ui/src/ui/chat/grouped-render.test.ts packages/memory-host-sdk/src/host/internal.test.ts`
- `pnpm check:changed`

Closes #23014
