### PR TITLE
ci(proof): skip real-behavior-proof gate for private maintainers

### DIFF
--- a/.github/workflows/real-behavior-proof.yml
+++ b/.github/workflows/real-behavior-proof.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           app-id: "2729701"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permission-members: read
       - uses: actions/create-github-app-token@v3
         id: app-token-fallback
         if: steps.app-token.outcome == 'failure'
@@ -38,6 +39,7 @@ jobs:
         with:
           app-id: "2971289"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
+          permission-members: read
       - name: Check real behavior proof
         env:
           GH_APP_TOKEN: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}

--- a/.github/workflows/real-behavior-proof.yml
+++ b/.github/workflows/real-behavior-proof.yml
@@ -25,5 +25,20 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        continue-on-error: true
+        with:
+          app-id: "2729701"
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+      - uses: actions/create-github-app-token@v3
+        id: app-token-fallback
+        if: steps.app-token.outcome == 'failure'
+        continue-on-error: true
+        with:
+          app-id: "2971289"
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
       - name: Check real behavior proof
+        env:
+          GH_APP_TOKEN: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}
         run: node scripts/github/real-behavior-proof-check.mjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,7 @@ Docs: https://docs.openclaw.ai
 - WhatsApp: treat `upload-file` as a supported media send intent by lowering path/URL uploads through the channel's normal send-media transport. (#81883) Thanks @ngutman.
 - iOS: end Live Activities when OpenClaw is connected, idle, or disconnected, and show compact attention states for approval-required reconnects. (#83597) Thanks @ngutman.
 - Control UI: hide child nav items when collapsing the active sidebar group. Fixes #42167. (#42223) Thanks @Aroool.
+- CI/proof: skip the real-behavior-proof gate for private org maintainers by minting a least-privilege (`members: read`) GitHub App token and checking active membership in the `maintainer` team, instead of treating `author_association=CONTRIBUTOR` as definitively external. (#83418) Thanks @romneyda.
 
 ## 2026.5.17
 

--- a/scripts/github/real-behavior-proof-check.mjs
+++ b/scripts/github/real-behavior-proof-check.mjs
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 import { readFileSync } from "node:fs";
-import { evaluateRealBehaviorProof } from "./real-behavior-proof-policy.mjs";
+import {
+  evaluateRealBehaviorProof,
+  isMaintainerTeamMember,
+} from "./real-behavior-proof-policy.mjs";
 
 function escapeCommandValue(value) {
   return String(value)
@@ -21,6 +24,24 @@ const pullRequest = event.pull_request;
 if (!pullRequest) {
   console.log("No pull_request payload found; skipping real behavior proof gate.");
   process.exit(0);
+}
+
+const token = process.env.GH_APP_TOKEN;
+const org = event.repository?.owner?.login;
+const authorLogin = pullRequest.user?.login;
+if (token && org && authorLogin) {
+  try {
+    if (await isMaintainerTeamMember({ token, org, login: authorLogin })) {
+      console.log(
+        `PR author @${authorLogin} is an active member of the ${org}/maintainer team; skipping real behavior proof gate.`,
+      );
+      process.exit(0);
+    }
+  } catch (error) {
+    console.warn(
+      `::warning title=Maintainer membership check failed::${escapeCommandValue(error?.message ?? String(error))}`,
+    );
+  }
 }
 
 const evaluation = evaluateRealBehaviorProof({ pullRequest });

--- a/scripts/github/real-behavior-proof-policy.mjs
+++ b/scripts/github/real-behavior-proof-policy.mjs
@@ -3,7 +3,7 @@ export const PROOF_SUPPLIED_LABEL = "proof: supplied";
 export const PROOF_SUFFICIENT_LABEL = "proof: sufficient";
 export const NEEDS_REAL_BEHAVIOR_PROOF_LABEL = "triage: needs-real-behavior-proof";
 export const MOCK_ONLY_PROOF_LABEL = "triage: mock-only-proof";
-export const MAINTAINER_AUTHOR_LABEL = "maintainer";
+export const MAINTAINER_TEAM_SLUG = "maintainer";
 
 const privilegedAuthorAssociations = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
 
@@ -95,7 +95,7 @@ function isAutomationUser(user = {}, fallbackLogin = "") {
   return user?.type === "Bot" || /\[bot\]$/i.test(login) || login.startsWith("app/");
 }
 
-export function isExternalPullRequest(pullRequest, labels) {
+export function isExternalPullRequest(pullRequest) {
   if (!pullRequest) {
     return false;
   }
@@ -105,21 +105,39 @@ export function isExternalPullRequest(pullRequest, labels) {
   const authorAssociation = String(
     pullRequest.author_association ?? pullRequest.authorAssociation ?? "",
   ).toUpperCase();
-  if (privilegedAuthorAssociations.has(authorAssociation)) {
-    return false;
-  }
-  if (hasMaintainerAuthorLabel(labels ?? pullRequest.labels)) {
-    return false;
-  }
-  return true;
+  return !privilegedAuthorAssociations.has(authorAssociation);
 }
 
 export function hasProofOverride(labels) {
   return labelNames(labels).has(PROOF_OVERRIDE_LABEL);
 }
 
-export function hasMaintainerAuthorLabel(labels) {
-  return labelNames(labels).has(MAINTAINER_AUTHOR_LABEL);
+export async function isMaintainerTeamMember({
+  token,
+  org,
+  login,
+  teamSlug = MAINTAINER_TEAM_SLUG,
+  fetch = globalThis.fetch,
+} = {}) {
+  if (!token || !org || !login) {
+    return false;
+  }
+  const url = `https://api.github.com/orgs/${encodeURIComponent(org)}/teams/${encodeURIComponent(teamSlug)}/memberships/${encodeURIComponent(login)}`;
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+  if (response.status === 404) {
+    return false;
+  }
+  if (!response.ok) {
+    throw new Error(`Team membership lookup failed: ${response.status}`);
+  }
+  const body = await response.json();
+  return body?.state === "active";
 }
 
 export function extractRealBehaviorProofSection(body = "") {
@@ -222,7 +240,7 @@ export function evaluateRealBehaviorProof({ pullRequest, labels } = {}) {
   if (hasProofOverride(currentLabels)) {
     return result("override", `Maintainer override label ${PROOF_OVERRIDE_LABEL} is present.`);
   }
-  if (!isExternalPullRequest(pullRequest, currentLabels)) {
+  if (!isExternalPullRequest(pullRequest)) {
     return result("skipped", "Maintainer, collaborator, or bot PRs do not require this gate.");
   }
 

--- a/scripts/github/real-behavior-proof-policy.mjs
+++ b/scripts/github/real-behavior-proof-policy.mjs
@@ -3,6 +3,7 @@ export const PROOF_SUPPLIED_LABEL = "proof: supplied";
 export const PROOF_SUFFICIENT_LABEL = "proof: sufficient";
 export const NEEDS_REAL_BEHAVIOR_PROOF_LABEL = "triage: needs-real-behavior-proof";
 export const MOCK_ONLY_PROOF_LABEL = "triage: mock-only-proof";
+export const MAINTAINER_AUTHOR_LABEL = "maintainer";
 
 const privilegedAuthorAssociations = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
 
@@ -94,7 +95,7 @@ function isAutomationUser(user = {}, fallbackLogin = "") {
   return user?.type === "Bot" || /\[bot\]$/i.test(login) || login.startsWith("app/");
 }
 
-export function isExternalPullRequest(pullRequest) {
+export function isExternalPullRequest(pullRequest, labels) {
   if (!pullRequest) {
     return false;
   }
@@ -104,11 +105,24 @@ export function isExternalPullRequest(pullRequest) {
   const authorAssociation = String(
     pullRequest.author_association ?? pullRequest.authorAssociation ?? "",
   ).toUpperCase();
-  return !privilegedAuthorAssociations.has(authorAssociation);
+  if (privilegedAuthorAssociations.has(authorAssociation)) {
+    return false;
+  }
+  // Private org membership reports as CONTRIBUTOR in author_association. The
+  // labeler workflow applies "maintainer" via the team-membership API, which
+  // sees private members, so trust that label as an equivalent privileged signal.
+  if (hasMaintainerAuthorLabel(labels ?? pullRequest.labels)) {
+    return false;
+  }
+  return true;
 }
 
 export function hasProofOverride(labels) {
   return labelNames(labels).has(PROOF_OVERRIDE_LABEL);
+}
+
+export function hasMaintainerAuthorLabel(labels) {
+  return labelNames(labels).has(MAINTAINER_AUTHOR_LABEL);
 }
 
 export function extractRealBehaviorProofSection(body = "") {
@@ -211,7 +225,7 @@ export function evaluateRealBehaviorProof({ pullRequest, labels } = {}) {
   if (hasProofOverride(currentLabels)) {
     return result("override", `Maintainer override label ${PROOF_OVERRIDE_LABEL} is present.`);
   }
-  if (!isExternalPullRequest(pullRequest)) {
+  if (!isExternalPullRequest(pullRequest, currentLabels)) {
     return result("skipped", "Maintainer, collaborator, or bot PRs do not require this gate.");
   }
 

--- a/scripts/github/real-behavior-proof-policy.mjs
+++ b/scripts/github/real-behavior-proof-policy.mjs
@@ -108,9 +108,6 @@ export function isExternalPullRequest(pullRequest, labels) {
   if (privilegedAuthorAssociations.has(authorAssociation)) {
     return false;
   }
-  // Private org membership reports as CONTRIBUTOR in author_association. The
-  // labeler workflow applies "maintainer" via the team-membership API, which
-  // sees private members, so trust that label as an equivalent privileged signal.
   if (hasMaintainerAuthorLabel(labels ?? pullRequest.labels)) {
     return false;
   }

--- a/test/scripts/real-behavior-proof-policy.test.ts
+++ b/test/scripts/real-behavior-proof-policy.test.ts
@@ -175,10 +175,6 @@ describe("real-behavior-proof-policy", () => {
   });
 
   it("skips private maintainers identified by the maintainer label", () => {
-    // Private org membership surfaces as author_association=CONTRIBUTOR even
-    // though the user holds maintainer permissions. The labeler workflow
-    // tags the PR with the "maintainer" label via the team-membership API,
-    // which the gate should trust as an equivalent privileged signal.
     const evaluation = evaluateRealBehaviorProof({
       pullRequest: externalPr("", { labels: [{ name: "maintainer" }] }),
     });

--- a/test/scripts/real-behavior-proof-policy.test.ts
+++ b/test/scripts/real-behavior-proof-policy.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   MOCK_ONLY_PROOF_LABEL,
   NEEDS_REAL_BEHAVIOR_PROOF_LABEL,
   PROOF_OVERRIDE_LABEL,
   PROOF_SUPPLIED_LABEL,
   evaluateRealBehaviorProof,
+  isMaintainerTeamMember,
   labelsForRealBehaviorProof,
 } from "../../scripts/github/real-behavior-proof-policy.mjs";
 
@@ -173,13 +174,60 @@ describe("real-behavior-proof-policy", () => {
       }).status,
     ).toBe("override");
   });
+});
 
-  it("skips private maintainers identified by the maintainer label", () => {
-    const evaluation = evaluateRealBehaviorProof({
-      pullRequest: externalPr("", { labels: [{ name: "maintainer" }] }),
+describe("isMaintainerTeamMember", () => {
+  function jsonResponse(status: number, body: unknown = {}) {
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: () => Promise.resolve(body),
+    };
+  }
+
+  it("returns true for active members", async () => {
+    const fetch = vi.fn().mockResolvedValue(jsonResponse(200, { state: "active" }));
+    const result = await isMaintainerTeamMember({
+      token: "tok",
+      org: "openclaw",
+      login: "private-maint",
+      fetch,
     });
 
-    expect(evaluation.status).toBe("skipped");
-    expect(labelsForRealBehaviorProof(evaluation)).toEqual([]);
+    expect(result).toBe(true);
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.github.com/orgs/openclaw/teams/maintainer/memberships/private-maint",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer tok",
+          Accept: "application/vnd.github+json",
+        }),
+      }),
+    );
+  });
+
+  it("returns false for non-active membership states", async () => {
+    const fetch = vi.fn().mockResolvedValue(jsonResponse(200, { state: "pending" }));
+    expect(await isMaintainerTeamMember({ token: "t", org: "o", login: "u", fetch })).toBe(false);
+  });
+
+  it("returns false when GitHub returns 404", async () => {
+    const fetch = vi.fn().mockResolvedValue(jsonResponse(404));
+    expect(await isMaintainerTeamMember({ token: "t", org: "o", login: "u", fetch })).toBe(false);
+  });
+
+  it("returns false when the token, org, or login is missing", async () => {
+    const fetch = vi.fn();
+    expect(await isMaintainerTeamMember({ org: "o", login: "u", fetch })).toBe(false);
+    expect(await isMaintainerTeamMember({ token: "t", login: "u", fetch })).toBe(false);
+    expect(await isMaintainerTeamMember({ token: "t", org: "o", fetch })).toBe(false);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("throws on unexpected HTTP errors so the caller can warn and fall back", async () => {
+    const fetch = vi.fn().mockResolvedValue(jsonResponse(500));
+    await expect(
+      isMaintainerTeamMember({ token: "t", org: "o", login: "u", fetch }),
+    ).rejects.toThrow(/500/);
   });
 });

--- a/test/scripts/real-behavior-proof-policy.test.ts
+++ b/test/scripts/real-behavior-proof-policy.test.ts
@@ -173,4 +173,17 @@ describe("real-behavior-proof-policy", () => {
       }).status,
     ).toBe("override");
   });
+
+  it("skips private maintainers identified by the maintainer label", () => {
+    // Private org membership surfaces as author_association=CONTRIBUTOR even
+    // though the user holds maintainer permissions. The labeler workflow
+    // tags the PR with the "maintainer" label via the team-membership API,
+    // which the gate should trust as an equivalent privileged signal.
+    const evaluation = evaluateRealBehaviorProof({
+      pullRequest: externalPr("", { labels: [{ name: "maintainer" }] }),
+    });
+
+    expect(evaluation.status).toBe("skipped");
+    expect(labelsForRealBehaviorProof(evaluation)).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary

Private org memberships report `author_association=CONTRIBUTOR`, so the real-behavior-proof gate currently demands proof from private maintainers. Mint a GitHub App token in `real-behavior-proof.yml` (same pattern + same app ids as `labeler.yml`) and call `GET /orgs/{org}/teams/maintainer/memberships/{login}` directly from the check script — skip the gate when membership is active. App-token steps are `continue-on-error`, so the gate falls back to the existing author-association path when the App key secrets are absent.

## Verification

- `node scripts/run-vitest.mjs test/scripts/real-behavior-proof-policy.test.ts` -> 16 passed (5 new `isMaintainerTeamMember` cases)
- `node scripts/run-vitest.mjs test/scripts/barnacle-auto-response.test.ts` -> 32 passed