### PR TITLE
Reject empty CLI subprocess replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,7 @@ Docs: https://docs.openclaw.ai
 - Agents/skills: apply the full effective tool policy pipeline to inline `command-dispatch: tool` skill dispatch before owner-only filtering, preserving configured allow, deny, sandbox, sender, group, and subagent restrictions. (#78525)
 - Codex: avoid spawning native hook relay subprocesses for post-tool/finalize events with no registered hook handlers while preserving pre-tool safety and approval relays. Fixes #76552. (#78004) Thanks @evgyur.
 - Channel accounts: keep top-level default channel accounts visible when named accounts are added alongside default credential material, so mixed legacy/new account configs keep resolving `default` instead of silently dropping it.
+- Agents/CLI: reject empty successful CLI subprocess replies as `empty_response` and keep them out of shared auth-profile health, so blank Claude CLI results no longer become green no-payload turns. Fixes #83231. (#83421) Thanks @joshavant.
 - Codex/Telegram: synthesize native Codex tool progress from final turn snapshots so Telegram `/verbose` stays visible when command events arrive only at completion.
 - Codex/Telegram: deliver Codex verbose tool summaries in direct message-tool-only turns while suppressing message-send and activity-log noise. (#83186) Thanks @kurplunkin.
 - Mac app: make Channels settings open faster by deferring config-schema work, avoiding startup channel probes, caching decoded channel status rows, and showing only compact quick settings instead of the full generated channel schema.

--- a/src/agents/cli-runner.before-agent-reply-cron.test.ts
+++ b/src/agents/cli-runner.before-agent-reply-cron.test.ts
@@ -160,6 +160,7 @@ describe("runCliAgent cron before_agent_reply seam", () => {
     const { runCliAgent } = await import("./cli-runner.js");
     hasHooksMock.mockImplementation((hookName) => hookName === "before_agent_reply");
     runBeforeAgentReplyMock.mockResolvedValue(undefined);
+    executePreparedCliRunMock.mockResolvedValue({ text: "real reply" });
     const onExecutionPhase = vi.fn();
 
     await runCliAgent({
@@ -181,6 +182,19 @@ describe("runCliAgent cron before_agent_reply seam", () => {
     });
     expect(prepareCliRunContextMock).toHaveBeenCalledTimes(1);
     expect(executePreparedCliRunMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats empty CLI subprocess output as a failover failure, not a green cron run", async () => {
+    const { runCliAgent } = await import("./cli-runner.js");
+    executePreparedCliRunMock.mockResolvedValue({ text: "   " });
+
+    await expect(runCliAgent({ ...baseRunParams, trigger: "cron" })).rejects.toMatchObject({
+      name: "FailoverError",
+      reason: "empty_response",
+      provider: baseRunParams.provider,
+      model: baseRunParams.model,
+      sessionId: baseRunParams.sessionId,
+    });
   });
 
   it("returns a silent payload when a cron hook claims without a reply body", async () => {

--- a/src/agents/cli-runner.context-engine.test.ts
+++ b/src/agents/cli-runner.context-engine.test.ts
@@ -426,6 +426,48 @@ describe("runPreparedCliAgent context engine lifecycle", () => {
     expect(dispose).not.toHaveBeenCalled();
   });
 
+  it("does not finalize context-engine turns for empty successful CLI output", async () => {
+    executePreparedCliRunMock.mockResolvedValue({
+      text: "   ",
+      rawText: "   ",
+      sessionId: "external-cli-session-empty",
+      usage: { input: 11, output: 0, total: 11 },
+    });
+    const bootstrap = vi.fn<NonNullable<ContextEngine["bootstrap"]>>(async () => ({
+      bootstrapped: true,
+    }));
+    const afterTurn = vi.fn<NonNullable<ContextEngine["afterTurn"]>>(async () => {});
+    const ingestBatch = vi.fn<NonNullable<ContextEngine["ingestBatch"]>>(async () => ({
+      ingestedCount: 0,
+    }));
+    const maintain = vi.fn<NonNullable<ContextEngine["maintain"]>>(async () =>
+      createMaintenanceResult(),
+    );
+    const dispose = vi.fn(async () => {});
+    const contextEngine = createContextEngine({
+      bootstrap,
+      afterTurn,
+      ingestBatch,
+      maintain,
+      dispose,
+    });
+    const { runPreparedCliAgent } = await import("./cli-runner.js");
+
+    await expect(runPreparedCliAgent(buildPreparedContext(contextEngine))).rejects.toMatchObject({
+      name: "FailoverError",
+      reason: "empty_response",
+      provider: "claude-cli",
+      model: "sonnet-4.6",
+      sessionId: "openclaw-session-1",
+    });
+
+    expect(bootstrap).toHaveBeenCalledTimes(1);
+    expect(afterTurn).not.toHaveBeenCalled();
+    expect(ingestBatch).not.toHaveBeenCalled();
+    expect(maintain).toHaveBeenCalledTimes(1);
+    expect(dispose).not.toHaveBeenCalled();
+  });
+
   it("does not dispose context engines when CLI attempts fail", async () => {
     executePreparedCliRunMock.mockRejectedValue(new Error("cli boom"));
     const dispose = vi.fn(async () => {

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -402,6 +402,15 @@ export async function runPreparedCliAgent(
   const executeCliAttempt = async (cliSessionIdToUse?: string) => {
     const output = await executePreparedCliRun(context, cliSessionIdToUse);
     const assistantText = output.text.trim();
+    if (!assistantText) {
+      throw new FailoverError("CLI backend returned an empty response.", {
+        reason: "empty_response",
+        provider: params.provider,
+        model: context.modelId,
+        sessionId: params.sessionId,
+        lane: params.lane,
+      });
+    }
     const assistantTexts = assistantText ? [assistantText] : [];
     const lastAssistant =
       assistantText.length > 0

--- a/src/agents/pi-embedded-runner/run/auth-profile-failure-policy.test.ts
+++ b/src/agents/pi-embedded-runner/run/auth-profile-failure-policy.test.ts
@@ -45,6 +45,20 @@ describe("resolveAuthProfileFailureReason", () => {
     ).toBeNull();
   });
 
+  it("does not persist empty responses as auth-profile health", () => {
+    expect(
+      resolveAuthProfileFailureReason({
+        failoverReason: "empty_response",
+      }),
+    ).toBeNull();
+    expect(
+      resolveAuthProfileFailureReason({
+        failoverReason: "empty_response",
+        policy: "shared",
+      }),
+    ).toBeNull();
+  });
+
   it("does not persist request-shape (format) rejections as auth-profile health (#77228)", () => {
     // A format rejection (e.g. the github-copilot prefill-strict 400
     // "conversation must end with a user message" reported in #77228) is

--- a/src/agents/pi-embedded-runner/run/auth-profile-failure-policy.ts
+++ b/src/agents/pi-embedded-runner/run/auth-profile-failure-policy.ts
@@ -6,7 +6,7 @@ export function resolveAuthProfileFailureReason(params: {
   failoverReason: FailoverReason | null;
   policy?: AuthProfileFailurePolicy;
 }): AuthProfileFailureReason | null {
-  // Helper-local runs, transport/server failures, and request-shape ("format") rejections
+  // Helper-local runs, transport/server failures, empty responses, and request-shape ("format") rejections
   // should not poison shared provider auth health. A `format` failure means the
   // provider rejected the request payload (e.g. an assistant-prefill 400 from a
   // strict provider when a session transcript ends with a stream-error placeholder
@@ -20,6 +20,7 @@ export function resolveAuthProfileFailureReason(params: {
     !params.failoverReason ||
     params.failoverReason === "timeout" ||
     params.failoverReason === "server_error" ||
+    params.failoverReason === "empty_response" ||
     params.failoverReason === "format"
   ) {
     return null;


### PR DESCRIPTION
Summary
- Treat successful CLI subprocess runs with empty assistant text as a failover failure instead of a green agent turn.
- Suppress empty-response failures from shared auth-profile health so they cannot be mistaken for billing/auth cooldown evidence.
- Add regression coverage for direct runner, cron, context-engine side effects, and auth-profile policy behavior.

Verification
- node scripts/run-vitest.mjs src/agents/cli-output.test.ts src/agents/cli-runner.before-agent-reply-cron.test.ts src/agents/cli-runner.context-engine.test.ts src/agents/pi-embedded-runner/run/auth-profile-failure-policy.test.ts
- .agents/skills/autoreview/scripts/autoreview --parallel-tests "node scripts/run-vitest.mjs src/agents/cli-output.test.ts src/agents/cli-runner.before-agent-reply-cron.test.ts src/agents/cli-runner.context-engine.test.ts src/agents/pi-embedded-runner/run/auth-profile-failure-policy.test.ts"
- AWS Crabbox live proof: provider aws, lease cbx_3ed9041c344c, run run_9fc802df507f

Real behavior proof
Behavior addressed: Real Claude CLI can return a successful structured result with empty assistant text; OpenClaw now rejects that as empty_response instead of recording a successful no-payload turn.
Real environment tested: AWS Crabbox from this patched branch with real Claude Code 2.1.143 and a live ANTHROPIC_API_KEY supplied through a local env file.
Exact steps or command run after this patch: Built OpenClaw remotely, ran a direct OpenClaw CLI path and a cron-triggered runCliAgent path using a prompt that instructed Claude to return no visible text.
Evidence after fix: Direct path exited 1 with FailoverError reason=empty_response; cron path returned FailoverError reason=empty_response with provider claude-cli and model claude-sonnet-4-6.
Observed result after fix: Empty Claude CLI output is not treated as a green run, and auth-state remained clean with no billing state and no auth-state file.
What was not tested: Full repository CI before PR creation; GitHub Actions will provide the broader PR gate.

Fixes #83231
