### PR TITLE
fix(code-mode): surface timeout and runtime_unavailable codes

### DIFF
--- a/src/agents/code-mode.test.ts
+++ b/src/agents/code-mode.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { pathToFileURL } from "node:url";
 import { setPluginToolMeta } from "../plugins/tools.js";
 import {
   applyCodeModeCatalog,
@@ -129,12 +130,21 @@ describe("Code Mode", () => {
   });
 
   it("resolves the packaged worker URL from stable and hashed dist modules", () => {
-    expect(
-      __testing.resolveCodeModeWorkerUrl("file:///repo/dist/agents/code-mode.js").pathname,
-    ).toBe("/repo/dist/agents/code-mode.worker.js");
-    expect(
-      __testing.resolveCodeModeWorkerUrl("file:///repo/dist/selection-abc123.js").pathname,
-    ).toBe("/repo/dist/agents/code-mode.worker.js");
+    const stableModuleUrl =
+      process.platform === "win32"
+        ? pathToFileURL("C:\\repo\\dist\\agents\\code-mode.js").href
+        : pathToFileURL("/repo/dist/agents/code-mode.js").href;
+    const hashedModuleUrl =
+      process.platform === "win32"
+        ? pathToFileURL("C:\\repo\\dist\\selection-abc123.js").href
+        : pathToFileURL("/repo/dist/selection-abc123.js").href;
+
+    expect(__testing.resolveCodeModeWorkerUrl(stableModuleUrl).href).toBe(
+      stableModuleUrl.replace(/\/code-mode\.js$/, "/code-mode.worker.js"),
+    );
+    expect(__testing.resolveCodeModeWorkerUrl(hashedModuleUrl).href).toBe(
+      hashedModuleUrl.replace(/selection-abc123\.js$/, "agents/code-mode.worker.js"),
+    );
   });
 
   it("hides all normal tools behind exec and wait", () => {
@@ -694,5 +704,14 @@ describe("Code Mode", () => {
     await expect(heartbeat).resolves.toBe("main-event-loop-alive");
     expect(details.status).toBe("failed");
     expect(String(details.error)).toContain("timeout exceeded");
+    expect(details.code).toBe("timeout");
+  });
+
+  it("classifies missing worker module failures as runtime_unavailable", () => {
+    const missingWorkerError = new Error(
+      "Cannot find module '/tmp/openclaw/dist/agents/code-mode.worker.js'",
+    );
+
+    expect(__testing.mapCodeModeWorkerErrorCode(missingWorkerError)).toBe("runtime_unavailable");
   });
 });

--- a/src/agents/code-mode.ts
+++ b/src/agents/code-mode.ts
@@ -109,7 +109,7 @@ type CodeModeWorkerResult =
   | {
       status: "failed";
       error: string;
-      code: "invalid_input" | "internal_error";
+      code: "invalid_input" | "internal_error" | "runtime_unavailable" | "timeout";
       output: unknown[];
     };
 
@@ -488,6 +488,18 @@ function codeModeWorkerUrl(): URL {
   return resolveCodeModeWorkerUrl(import.meta.url);
 }
 
+function mapCodeModeWorkerErrorCode(error: unknown): "internal_error" | "runtime_unavailable" {
+  const message = errorMessage(error).toLowerCase();
+  return message.includes("cannot find module") ||
+    message.includes("cannot find package") ||
+    message.includes("module not found") ||
+    message.includes("failed to load") ||
+    message.includes("quickjs-wasi") ||
+    message.includes("code-mode.worker")
+    ? "runtime_unavailable"
+    : "internal_error";
+}
+
 async function runCodeModeWorker(
   workerData: unknown,
   timeoutMs: number,
@@ -511,7 +523,7 @@ async function runCodeModeWorker(
         finish({
           status: "failed",
           error: "code mode worker timeout exceeded",
-          code: "internal_error",
+          code: "timeout",
           output: [],
         });
       }, timeoutMs);
@@ -532,7 +544,7 @@ async function runCodeModeWorker(
         finish({
           status: "failed",
           error: errorMessage(error),
-          code: "internal_error",
+          code: mapCodeModeWorkerErrorCode(error),
           output: [],
         });
       });
@@ -921,5 +933,6 @@ export const __testing = {
   codeModeWorkerUrl,
   resolveCodeModeWorkerUrl,
   resolveCodeModeConfig,
+  mapCodeModeWorkerErrorCode,
   getTypescriptRuntimePromise: () => typescriptRuntimePromise,
 };

--- a/src/agents/code-mode.worker.ts
+++ b/src/agents/code-mode.worker.ts
@@ -53,7 +53,7 @@ type CodeModeWorkerResult =
   | {
       status: "failed";
       error: string;
-      code: "invalid_input" | "internal_error";
+      code: "invalid_input" | "internal_error" | "runtime_unavailable" | "timeout";
       output: unknown[];
     };
 
@@ -493,10 +493,11 @@ async function main(): Promise<CodeModeWorkerResult> {
       output: [],
     };
   } catch (error) {
+    const message = errorMessage(error);
     return {
       status: "failed",
-      error: errorMessage(error),
-      code: "internal_error",
+      error: message,
+      code: message.includes("code mode timeout exceeded") ? "timeout" : "internal_error",
       output: [],
     };
   }


### PR DESCRIPTION
## Summary

- Problem: OpenClaw code mode currently collapses two documented error classes into `internal_error`: QuickJS timeout and worker runtime-unavailable/load failures.
- Why it matters: callers cannot branch on the documented `timeout` / `runtime_unavailable` codes even though the docs promise them, so known failure modes look like generic internal faults.
- What changed: the worker supervisor now returns `code: "timeout"` for the parent watchdog timeout and maps worker-load/runtime failures to `code: "runtime_unavailable"`; the worker itself now preserves `code: "timeout"` for QuickJS timeout failures.
- What did NOT change (scope boundary): no code-mode runtime semantics, no tool-search behavior, no docs wording, and no non-code-mode error handling.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #83389
- [x] This PR fixes a bug or regression

## Root Cause / Regression History

- Root cause: both the parent worker supervisor and the QuickJS worker catch-all path classified known timeout/runtime-load failures as `internal_error`.
- Missing guardrail: the timeout regression test asserted the message but not the structured `code`, and there was no regression assertion for runtime-unavailable classification.
- Prior context: `docs/reference/code-mode.md` already documents `timeout` and `runtime_unavailable` as public `CodeModeErrorCode` values.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/code-mode.test.ts`
- Scenario the test should lock in: infinite-loop QuickJS executions return `code: "timeout"`, and missing worker-module failures classify as `runtime_unavailable`.
- Why this is the smallest reliable guardrail: it covers the two exact documented failure classes without broadening unrelated code-mode behavior.

## User-visible / Behavior Changes

Code-mode callers now receive the documented structured codes for two known failures:

- QuickJS timeout -> `timeout`
- worker runtime/load failure -> `runtime_unavailable`

`internal_error` remains the fallback for unexpected failures.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Focused checks

- `node scripts/run-vitest.mjs src/agents/code-mode.test.ts`

### Result

- `src/agents/code-mode.test.ts`: 46 passed

### Notes

- I also fixed the existing packaged-worker URL regression test to use platform-correct absolute file URLs so the code-mode suite passes on Windows as well.
- `pnpm build` was attempted locally but failed in this workspace because the repo path contains a space (`C:\Users\86151\Documents\New project\...`) and a shell-true build step treats the path prefix as a command. That failure is environment-specific and not caused by this patch.

## Human Verification (required)

- Verified scenarios: structured timeout code is asserted; runtime-unavailable mapping is asserted; full code-mode test file passes after the patch.
- Edge cases checked: hashed and stable packaged worker module URL resolution test remains covered with platform-correct file URLs.
- What you did not verify: live gateway run with a physically missing packaged worker file.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: the runtime-unavailable classifier could over-match unexpected worker-load messages.
- Mitigation: matching is intentionally narrow to missing-module / failed-load / QuickJS-WASI startup signals, and everything else still falls back to `internal_error`.
