### PR TITLE
fix: mark approval gateway calls as runtime clients

### DIFF
--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -14,6 +14,7 @@ import {
   pickPrimaryTailnetIPv4Mock as pickPrimaryTailnetIPv4,
   resolveGatewayPortMock as resolveGatewayPort,
 } from "./gateway-connection.test-mocks.js";
+import { APPROVALS_SCOPE } from "./operator-scopes.js";
 
 const deviceIdentityState = vi.hoisted(() => ({
   value: {
@@ -52,6 +53,7 @@ let lastClientOptions: {
   clientDisplayName?: string;
   mode?: string;
   scopes?: string[];
+  approvalRuntimeToken?: string;
   deviceIdentity?: unknown;
   onHelloOk?: (hello: { features?: { methods?: string[] } }) => void | Promise<void>;
   onClose?: (code: number, reason: string) => void;
@@ -88,6 +90,7 @@ vi.mock("./client.js", () => ({
       clientDisplayName?: string;
       mode?: string;
       scopes?: string[];
+      approvalRuntimeToken?: string;
       onHelloOk?: (hello: { features?: { methods?: string[] } }) => void | Promise<void>;
       onClose?: (code: number, reason: string) => void;
     }) {
@@ -153,6 +156,7 @@ class StubGatewayClient {
     clientDisplayName?: string;
     mode?: string;
     scopes?: string[];
+    approvalRuntimeToken?: string;
     onHelloOk?: (hello: { features?: { methods?: string[] } }) => void | Promise<void>;
     onClose?: (code: number, reason: string) => void;
   }) {
@@ -387,6 +391,21 @@ describe("callGateway url resolution", () => {
     expect(lastClientOptions?.clientName).toBe(GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT);
     expect(lastClientOptions?.mode).toBe(GATEWAY_CLIENT_MODES.BACKEND);
     expect(lastClientOptions?.deviceIdentity).toBeNull();
+  });
+
+  it("marks local backend approval-scope gateway calls as approval runtime clients", async () => {
+    setLocalLoopbackGatewayConfig();
+
+    await callGateway({
+      method: "exec.approval.waitDecision",
+      params: { id: "approval-1" },
+      token: "explicit-token",
+    });
+
+    expect(lastClientOptions?.clientName).toBe(GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT);
+    expect(lastClientOptions?.mode).toBe(GATEWAY_CLIENT_MODES.BACKEND);
+    expect(lastClientOptions?.scopes).toContain(APPROVALS_SCOPE);
+    expect(lastClientOptions?.approvalRuntimeToken).toEqual(expect.any(String));
   });
 
   it("keeps device identity enabled for explicit CLI loopback shared-token auth", async () => {

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -37,11 +37,13 @@ import {
 import { canSkipGatewayConfigLoad } from "./explicit-connection-policy.js";
 import { resolvePreauthHandshakeTimeoutMs } from "./handshake-timeouts.js";
 import {
+  APPROVALS_SCOPE,
   CLI_DEFAULT_OPERATOR_SCOPES,
   isGatewayMethodClassified,
   resolveLeastPrivilegeOperatorScopesForMethod,
   type OperatorScope,
 } from "./method-scopes.js";
+import { getOperatorApprovalRuntimeToken } from "./operator-approval-runtime-token.js";
 import { MIN_CLIENT_PROTOCOL_VERSION, PROTOCOL_VERSION } from "./protocol/index.js";
 export type { GatewayConnectionDetails };
 
@@ -322,6 +324,21 @@ function shouldOmitDeviceIdentityForGatewayCall(params: {
     clientName === GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT &&
     hasSharedAuth &&
     isLoopbackGatewayUrl(params.url)
+  );
+}
+
+function shouldAttachApprovalRuntimeToken(params: {
+  opts: CallGatewayBaseOptions;
+  scopes: OperatorScope[];
+  allowApprovalRuntimeToken: boolean;
+}): boolean {
+  const mode = params.opts.mode ?? GATEWAY_CLIENT_MODES.CLI;
+  const clientName = params.opts.clientName ?? GATEWAY_CLIENT_NAMES.CLI;
+  return (
+    params.allowApprovalRuntimeToken &&
+    mode === GATEWAY_CLIENT_MODES.BACKEND &&
+    clientName === GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT &&
+    params.scopes.includes(APPROVALS_SCOPE)
   );
 }
 
@@ -654,6 +671,7 @@ async function executeGatewayRequestWithScopes<T>(params: {
   timeoutMs: number;
   safeTimerTimeoutMs: number;
   connectionDetails: GatewayConnectionDetails;
+  allowApprovalRuntimeToken: boolean;
 }): Promise<T> {
   const {
     opts,
@@ -700,6 +718,13 @@ async function executeGatewayRequestWithScopes<T>(params: {
       mode: opts.mode ?? GATEWAY_CLIENT_MODES.CLI,
       role: "operator",
       scopes,
+      ...(shouldAttachApprovalRuntimeToken({
+        opts,
+        scopes,
+        allowApprovalRuntimeToken: params.allowApprovalRuntimeToken,
+      })
+        ? { approvalRuntimeToken: getOperatorApprovalRuntimeToken() }
+        : {}),
       deviceIdentity:
         opts.deviceIdentity === undefined
           ? resolveDeviceIdentityForGatewayCall({ opts, url, token, password })
@@ -814,6 +839,7 @@ async function callGatewayWithScopes<T = Record<string, unknown>>(
     timeoutMs,
     safeTimerTimeoutMs,
     connectionDetails,
+    allowApprovalRuntimeToken: !context.urlOverride,
   });
 }
 


### PR DESCRIPTION
## Summary

Fix PI/gateway-hosted exec approvals timing out after an operator approves the request.

In the beta regression, PI created an exec approval request and then called `exec.approval.waitDecision` from a separate short-lived gateway connection. The newer approval visibility filter correctly hides approvals from unrelated clients, but the PI approval waiter was not being marked as OpenClaw's trusted approval runtime client. That made the gateway return `approval expired or not found`, which surfaced to the agent as an approval timeout even after the approval was accepted.

This change attaches the process-local approval runtime token to backend `gateway-client` calls that carry `operator.approvals`, while continuing to omit that token for explicit gateway URL overrides.

## Changes

- Add a narrow helper in `src/gateway/call.ts` that detects trusted local backend approval-scope calls.
- Pass `approvalRuntimeToken` to `GatewayClient` for those calls.
- Add a regression test covering PI-style `exec.approval.waitDecision` calls.

## Validation

- `pnpm docs:list`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/call.test.ts src/gateway/server-methods/approval-shared.test.ts src/gateway/operator-approvals-client.test.ts`
- `pnpm build:strict-smoke`
- `.agents/skills/autoreview/scripts/autoreview --mode local --parallel-tests "node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/call.test.ts src/gateway/server-methods/approval-shared.test.ts src/gateway/operator-approvals-client.test.ts"` on the original beta-tag patch, which reported no accepted/actionable findings.
