### PR TITLE
docs: clarify Code Mode runtime surfaces

### DIFF
--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -21,10 +21,18 @@ Do not configure `openai-codex/gpt-*` model refs. Put OpenAI agent auth order
 under `auth.order.openai`; older `openai-codex:*` profiles and
 `auth.order.openai-codex` entries remain supported for existing installs.
 
-OpenClaw starts Codex app-server threads with Codex native code mode and
-code-mode-only enabled. That keeps deferred/searchable OpenClaw dynamic tools
-inside Codex's own code execution and tool-search surface instead of adding a
-PI-style tool-search wrapper on top of Codex.
+OpenClaw starts Codex app-server threads with Codex native Code Mode and
+code-mode-only enabled when the native Codex tool surface is allowed. If a run
+narrows the Codex native tool surface through OpenClaw tool allowlists, OpenClaw
+disables native Code Mode so the run fails closed instead of widening tool
+access. That keeps deferred/searchable OpenClaw dynamic tools inside Codex's own
+code execution and tool-search surface instead of adding a PI-style tool-search
+wrapper on top of Codex.
+
+This is Codex Code Mode, not [OpenClaw code mode](/reference/code-mode). The
+names overlap, but the mechanisms are different: Codex Code Mode lives inside
+Codex app-server, while OpenClaw code mode is an opt-in QuickJS-WASI adapter for
+generic OpenClaw runs.
 
 For the broader model/provider/runtime split, start with
 [Agent runtimes](/concepts/agent-runtimes). The short version is:

--- a/docs/reference/code-mode.md
+++ b/docs/reference/code-mode.md
@@ -13,13 +13,20 @@ default. When you enable it, OpenClaw changes what the model sees for one run:
 instead of exposing every enabled tool schema directly, the model sees only
 `exec` and `wait`.
 
-This page documents OpenClaw code mode. It is not Codex Code mode. Codex Code
-mode is part of the Codex coding harness and has its own project workspace,
-runtime, tools, and execution semantics. Codex Code mode and Codex-native
-dynamic tool search are stable Codex harness surfaces. OpenClaw code mode is an
-OpenClaw-owned experimental tool-surface adapter for generic OpenClaw runs. It
-uses `quickjs-wasi`, a hidden OpenClaw tool catalog, and the normal OpenClaw
-tool executor.
+This page documents OpenClaw code mode, not Codex Code Mode. They share the
+name "code mode", but they are different runtime surfaces:
+
+| Aspect                | Codex Code Mode                                                                                                                                      | OpenClaw code mode                                                                                                     |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Owner and origin      | Codex app-server coding harness; OpenClaw configures the Codex thread.                                                                               | OpenClaw-owned experimental tool-surface adapter for generic OpenClaw runs.                                            |
+| Default state         | Enabled for Codex app-server runs when the native Codex tool surface is allowed. OpenClaw disables it when a narrow tool allowlist must fail closed. | Disabled unless `tools.codeMode.enabled: true` is set for the agent or run.                                            |
+| Model-visible work    | Codex-native shell and file operations inside Codex's own workspace runtime.                                                                         | JavaScript or TypeScript evaluated by OpenClaw through `quickjs-wasi`.                                                 |
+| `exec` input shape    | Codex app-server command payloads, such as shell-command `command` inputs.                                                                           | OpenClaw `exec` requires `code` and accepts optional `language`.                                                       |
+| Sandbox and lifecycle | Codex app-server owns process, filesystem, resume, compaction, and tool-continuation semantics.                                                      | OpenClaw owns the QuickJS-WASI worker, snapshots, limits, and wait/resume state.                                       |
+| OpenClaw tool path    | OpenClaw dynamic tools are bridged into Codex's native tool surface.                                                                                 | Nested calls go through the normal OpenClaw tool executor, policy, approvals, hooks, session context, and audit paths. |
+
+Use the [Codex harness](/plugins/codex-harness) docs for Codex Code Mode. Use
+this page for the OpenClaw QuickJS-WASI tool-surface adapter.
 
 ## What is this?
 

--- a/scripts/format-docs.mjs
+++ b/scripts/format-docs.mjs
@@ -10,6 +10,7 @@ const ROOT = path.resolve(import.meta.dirname, "..");
 const CHECK = process.argv.includes("--check");
 const OXFMT_BIN = path.join(ROOT, "node_modules", "oxfmt", "bin", "oxfmt");
 const OXFMT_CONFIG = path.join(ROOT, ".oxfmtrc.jsonc");
+const OXFMT_BATCH_SIZE = 50;
 
 function docsFiles() {
   const output = execFileSync("git", ["ls-files", "docs/**/*.md", "docs/**/*.mdx", "README.md"], {
@@ -23,19 +24,25 @@ function docsFiles() {
 }
 
 function runOxfmt(files) {
-  const result = spawnSync(
-    process.execPath,
-    [OXFMT_BIN, "--write", "--threads=1", "--config", OXFMT_CONFIG, ...files],
-    {
-      cwd: ROOT,
-      encoding: "utf8",
-      maxBuffer: 1024 * 1024 * 16,
-    },
-  );
+  for (let start = 0; start < files.length; start += OXFMT_BATCH_SIZE) {
+    const batch = files.slice(start, start + OXFMT_BATCH_SIZE);
+    const result = spawnSync(
+      process.execPath,
+      [OXFMT_BIN, "--write", "--threads=1", "--config", OXFMT_CONFIG, ...batch],
+      {
+        cwd: ROOT,
+        encoding: "utf8",
+        maxBuffer: 1024 * 1024 * 16,
+      },
+    );
 
-  if (result.status !== 0) {
-    const stderr = result.stderr.trim();
-    throw new Error(`oxfmt failed${stderr ? `:\n${stderr}` : ""}`);
+    if (result.error || result.status !== 0) {
+      const details = [result.stderr, result.stdout, result.error?.message]
+        .filter(Boolean)
+        .join("\n")
+        .trim();
+      throw new Error(`oxfmt failed${details ? `:\n${details}` : ""}`);
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #83390.

## Summary

- Adds a side-by-side comparison in `docs/reference/code-mode.md` that separates Codex Code Mode from OpenClaw code mode by owner, default state, model input shape, sandbox/lifecycle, and OpenClaw tool path.
- Adds the reverse link in `docs/plugins/codex-harness.md`, including the fail-closed nuance for narrow Codex native tool allowlists.
- Batches docs formatter input in `scripts/format-docs.mjs` so the required docs formatting check can run on Windows without exceeding command-line limits, and reports formatter spawn failures cleanly.

## Problem summary

Both Codex and OpenClaw expose features called "code mode", but they are different mechanisms. The current docs only distinguished them in prose, so bug reports and evaluations could confuse Codex app-server Code Mode with OpenClaw's opt-in QuickJS-WASI tool-surface adapter.

## Root cause

`docs/reference/code-mode.md` lacked a mechanism table for the two surfaces, and `docs/plugins/codex-harness.md` described Codex native code mode without linking back to the OpenClaw code-mode reference. While validating the docs fix locally on Windows, `scripts/format-docs.mjs` also passed the full docs file list to `oxfmt` in one process, which can exceed the Windows argument limit before `pnpm check:docs` reaches the Markdown checks.

## Architectural reasoning

This does not change runtime behavior. The docs align to the existing source contracts:

- OpenClaw code mode remains opt-in through `tools.codeMode.enabled`, uses `quickjs-wasi`, and exposes `exec` with `code` plus optional `language`.
- Codex Code Mode remains owned by Codex app-server thread config and can be disabled when OpenClaw narrows the native Codex tool surface to avoid widening access.
- Nested OpenClaw code-mode tool calls are still documented as going through the normal OpenClaw tool executor, policy, approvals, hooks, session context, and audit paths.
- The formatter change is tooling-only and keeps the existing formatting behavior, just in bounded batches.

## Testing performed

- `pnpm install --frozen-lockfile`
- `pnpm docs:list`
- `DOCS_I18N_GLOSSARY_BASE=upstream/main pnpm check:docs`
- `node scripts/format-docs.mjs --check`
- `pnpm lint:docs`
- `node --check scripts/format-docs.mjs`
- `pnpm check:changed`
- `git diff --check`

`DOCS_I18N_GLOSSARY_BASE=upstream/main` was used locally because this fork's `origin/main` remote-tracking ref is stale relative to the upstream base; CI should resolve against the upstream PR base normally.

`pnpm test:changed` was attempted, but the changed-test resolver did not finish within the local timeout and was stopped. No runtime source or Vitest-covered behavior changes are included; the relevant proof for this patch is the docs gate plus changed-surface checks above.

## Risk analysis

Risk is low. The docs change is clarifying existing contracts. The formatter change is limited to chunking `oxfmt` invocations and improving error output, with the full docs formatting check passing after the change. There are no changes to gateway/session flows, concurrency, cleanup logic, public API behavior, model routing, or plugin runtime behavior.

## Backward compatibility

No user-facing behavior or API contract changes. Existing docs URLs and root-relative links are preserved.

## Real behavior proof

Behavior addressed: Developers can now tell Codex Code Mode and OpenClaw code mode apart by mechanism, input shape, sandbox/lifecycle owner, and OpenClaw tool path.

Real environment tested: Windows checkout on Node `v22.16.0` with pnpm `11.1.0`, branch `Hemant/docs-code-mode-disambiguation`.

Exact steps or command run after this patch: `DOCS_I18N_GLOSSARY_BASE=upstream/main pnpm check:docs`.

Evidence after fix: The docs gate reported clean formatting, `markdownlint` 0 errors over 630 files, MDX check passed over 646 files, and link audit reported `checked_internal_links=4390` with `broken_links=0`.

Observed result after fix: The updated docs pass the relevant docs validation, and the formatter no longer crashes on Windows from the full docs file list.

What was not tested: Full runtime/Vitest suite, because this patch changes docs and docs-format tooling only.