### PR TITLE
fix(agents): rethrow EmbeddedAttemptSessionTakeoverError before model fallback

### DIFF
--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -897,6 +897,29 @@ describe("runWithModelFallback", () => {
     expect(errorCall.error).toBe(unknownError);
   });
 
+  it("rethrows embedded session takeover errors instead of walking model fallbacks", async () => {
+    const cfg = makeCfg();
+    const takeoverError = Object.assign(
+      new Error("session file changed while embedded prompt lock was released: /tmp/session.jsonl"),
+      { name: "EmbeddedAttemptSessionTakeoverError" },
+    );
+    const run = vi.fn().mockRejectedValue(takeoverError);
+    const onError = vi.fn();
+
+    await expect(
+      runWithModelFallback({
+        cfg,
+        provider: "openai",
+        model: "gpt-4.1-mini",
+        run,
+        onError,
+      }),
+    ).rejects.toBe(takeoverError);
+
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
   it("throws unrecognized error on last candidate", async () => {
     const cfg = makeCfg();
     const run = vi.fn().mockRejectedValueOnce(new Error("something weird"));

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -48,6 +48,7 @@ import {
 import { isLikelyContextOverflowError } from "./pi-embedded-helpers/errors.js";
 import type { FailoverReason } from "./pi-embedded-helpers/types.js";
 import { resolveSessionSuspensionReason, suspendSession } from "./session-suspension.js";
+import { isSessionWriteLockTimeoutError } from "./session-write-lock-error.js";
 
 const log = createSubsystemLogger("model-fallback");
 
@@ -114,6 +115,23 @@ function isFallbackAbortError(err: unknown): boolean {
 
 function shouldRethrowAbort(err: unknown): boolean {
   return isFallbackAbortError(err) && !isTimeoutError(err);
+}
+
+function isEmbeddedAttemptSessionTakeoverError(err: unknown): boolean {
+  if (!err || typeof err !== "object") {
+    return false;
+  }
+  const name = "name" in err ? String(err.name) : "";
+  if (name === "EmbeddedAttemptSessionTakeoverError") {
+    return true;
+  }
+  return formatErrorMessage(err).includes(
+    "session file changed while embedded prompt lock was released",
+  );
+}
+
+function shouldRethrowSessionOwnershipError(err: unknown): boolean {
+  return isEmbeddedAttemptSessionTakeoverError(err) || isSessionWriteLockTimeoutError(err);
 }
 
 function createModelCandidateCollector(allowlist: Set<string> | null | undefined): {
@@ -229,6 +247,9 @@ async function runFallbackCandidate<T>(params: {
     };
   } catch (err) {
     if (isCommandLaneTaskTimeoutError(err)) {
+      throw err;
+    }
+    if (shouldRethrowSessionOwnershipError(err)) {
       throw err;
     }
     // Normalize abort-wrapped rate-limit errors (e.g. Google Vertex RESOURCE_EXHAUSTED)


### PR DESCRIPTION
## Summary

`EmbeddedAttemptSessionTakeoverError` (the embedded-attempt fingerprint guard that fires when the session JSONL changes during the released-lock window) is currently routed through `runWithModelFallback` as an ordinary candidate failure. Every model candidate fails with the same takeover error, the chain exhausts, the last fallback succeeds, and the session ends up effectively pinned to that fallback model — with no provider error and no normal fallback receipt.

This PR extends the existing carve-out family (`isCommandLaneTaskTimeoutError`, `shouldRethrowAbort`) to also rethrow `EmbeddedAttemptSessionTakeoverError` and `SessionWriteLockTimeoutError` before fallback classification.

## Repro

Observed on Discord-channel-bound sessions under normal traffic. journalctl shows:

```
[diagnostic] lane task error: lane=main durationMs=... error="EmbeddedAttemptSessionTakeoverError: session file changed while embedded prompt lock was released: .../sessions/<id>.jsonl"
[model-fallback/decision] decision=candidate_failed
  requested=github-copilot/claude-opus-4.7-1m-internal
  candidate=github-copilot/claude-opus-4.7-1m-internal
  reason=unknown
  next=github-copilot/claude-opus-4.6
  detail=session file changed while embedded prompt lock was released
... chain repeats for each fallback ...
[model-fallback/decision] decision=candidate_succeeded candidate=openai-codex/gpt-5.5
```

Then the successful fallback persists as `modelOverrideSource: auto`. Manual re-pins decay back to the same fallback within minutes.

Four complete chain-walks observed on one seat between 20:13 and 20:30 PDT, cadence ~5 min.

## Why this presents as silent reassertion

- `EmbeddedAttemptSessionTakeoverError` is a *local* session-state guard (introduced in #82891). It is not a provider failure.
- `describeFailoverError()` does not classify it as a provider-class failure, so `[model-fallback/decision]` logs `reason=unknown`. The clue only survives in `detail=...`.
- Manual model re-pins are not stale state — they decay because the next attempt re-hits the takeover race.
- Seats with quieter session-file write cadence (no concurrent JSONL writes during the lock-release window) do not trigger the race and hold canon.

## Relation to #66646 / #78633

Issue #66646 (`Session file lock errors cascade through model fallback chain`) was fixed by #78633, which exported `hasSessionWriteLockTimeout` and the carve-out narrative. However, the runtime intercept for `runWithModelFallback` was not retained on `main`: `hasSessionWriteLockTimeout` is only referenced from `failover-error.ts` describe/classify paths, not from the fallback runner itself. `EmbeddedAttemptSessionTakeoverError` (introduced by #82891) extends the same family but does not yet have an interceptor anywhere in the model-fallback chain. This PR adds both interceptors in `runFallbackCandidate`.

## Change

```diff
+function isEmbeddedAttemptSessionTakeoverError(err: unknown): boolean { ... }
+function shouldRethrowSessionOwnershipError(err: unknown): boolean {
+  return isEmbeddedAttemptSessionTakeoverError(err) || isSessionWriteLockTimeoutError(err);
+}

 // in runFallbackCandidate
 if (isCommandLaneTaskTimeoutError(err)) {
   throw err;
 }
+if (shouldRethrowSessionOwnershipError(err)) {
+  throw err;
+}
```

The pattern matches the existing `isCommandLaneTaskTimeoutError` carve-out exactly.

## Tests

Added regression in `src/agents/model-fallback.test.ts`:

- session takeover error rethrown before second fallback candidate is invoked
- session takeover error does **not** call `onError` (the candidate-failed receipt path)

Local verification on this branch:
- `pnpm vitest run src/agents/model-fallback.test.ts -t "session takeover|command-lane watchdog|unrecognized errors"` → 6 passed / 108 skipped (114 total)
- `pnpm vitest run src/agents/model-fallback.test.ts` → 2 files / 114 tests passed

## Search key for future operators

`session file changed while embedded prompt lock was released`

This is the signature in journalctl. With this fix it stays a session-takeover error and is handled by the embedded runner / retry path instead of poisoning model fallback.

## Out of scope (follow-up lanes)

- `[model-fallback/decision] reason=unknown` should preserve the underlying error class in the decision-line reason field. The detail string carries it, but the reason field collapses to `unknown`. Surfacing-(2) prevents the next masked-as-unknown bug from being invisible.
- Identifying which writer concurrently mutates the session JSONL during the embedded-prompt-lock-release window. The race itself is reduced (#82891 releases the lock before model I/O) but takeover still fires under traffic.

cc @sallyom (author of #78633, related fix)
