### PR TITLE
fix(memory-wiki): make wiki_lint tool output path-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Memory Wiki: keep `wiki_lint` tool output path-safe by reporting vault-internal lint reports as relative paths in tool text and details while preserving absolute report paths for CLI/file callers. (#83439) Thanks @LLagoon3.
 - Telegram: keep verbose tool progress visible without mirroring non-final progress into active session transcripts, preventing embedded provider replies from aborting mid-run. (#83631) Thanks @kurplunkin.
 - CLI: enforce the documented Node.js 22.19 runtime floor in the source launcher.
 - Agents/replies: persist queued follow-up user messages and assistant error stubs only once across model-fallback retries, preventing repeated provider rejections from corrupted same-role session transcripts. Fixes #83404. (#83417) Thanks @yetval.

--- a/extensions/memory-wiki/src/tool.test.ts
+++ b/extensions/memory-wiki/src/tool.test.ts
@@ -1,6 +1,10 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import type { ResolvedMemoryWikiConfig } from "./config.js";
-import { createWikiApplyTool } from "./tool.js";
+import { createWikiApplyTool, createWikiLintTool } from "./tool.js";
+import { lintMemoryWikiVault } from "./lint.js";
+import { createMemoryWikiTestHarness } from "./test-helpers.js";
 
 function asSchemaObject(value: unknown): Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
@@ -10,6 +14,8 @@ function asSchemaObject(value: unknown): Record<string, unknown> {
 }
 
 describe("memory-wiki tools", () => {
+  const harness = createMemoryWikiTestHarness();
+
   it("allows provenance metadata in wiki_apply claim evidence", () => {
     const tool = createWikiApplyTool({} as ResolvedMemoryWikiConfig);
     const applyProperties = asSchemaObject(asSchemaObject(tool.parameters).properties);
@@ -32,5 +38,41 @@ describe("memory-wiki tools", () => {
       "weight",
     ]);
     expect(evidenceProperties.confidence).toEqual({ type: "number", minimum: 0, maximum: 1 });
+  });
+
+  it("returns tool-safe relative report paths from wiki_lint", async () => {
+    const { rootDir, config } = await harness.createVault({ initialize: true });
+    await fs.mkdir(path.join(rootDir, "syntheses"), { recursive: true });
+    await fs.writeFile(
+      path.join(rootDir, "syntheses", "bad.md"),
+      [
+        "---",
+        "id: synth-bad",
+        "pageType: synthesis",
+        "title: Bad Page",
+        "---",
+        "",
+        "This links to [[Missing Page]].",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const tool = createWikiLintTool(config);
+    const result = await tool.execute("lint-call", {});
+    const text = result.content.find((part) => part.type === "text")?.text ?? "";
+    const details = asSchemaObject(result.details);
+
+    expect(text).toContain("Report: reports/lint.md");
+    expect(text).not.toContain(rootDir);
+    expect(details.reportPath).toBe("reports/lint.md");
+    expect(details).not.toHaveProperty("vaultRoot");
+    expect(JSON.stringify(details)).not.toContain(rootDir);
+    expect(asSchemaObject(details.issuesByCategory).links).toEqual(
+      expect.arrayContaining([expect.objectContaining({ code: "broken-wikilink" })]),
+    );
+
+    const lintResult = await lintMemoryWikiVault(config);
+    expect(path.isAbsolute(lintResult.reportPath)).toBe(true);
+    expect(lintResult.reportPath).toContain(rootDir);
   });
 });

--- a/extensions/memory-wiki/src/tool.ts
+++ b/extensions/memory-wiki/src/tool.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { Type } from "typebox";
 import type { AnyAgentTool, OpenClawConfig } from "../api.js";
 import { applyMemoryWikiMutation, normalizeMemoryWikiMutationInput } from "./apply.js";
@@ -10,6 +11,20 @@ import { lintMemoryWikiVault } from "./lint.js";
 import { getMemoryWikiPage, searchMemoryWiki, WIKI_SEARCH_MODES } from "./query.js";
 import { syncMemoryWikiImportedSources } from "./source-sync.js";
 import { renderMemoryWikiStatus, resolveMemoryWikiStatus } from "./status.js";
+
+function formatWikiToolReportPath(config: ResolvedMemoryWikiConfig, reportPath: string): string {
+  const vaultRoot = path.resolve(config.vault.path);
+  const resolvedReportPath = path.resolve(reportPath);
+  const relativeReportPath = path.relative(vaultRoot, resolvedReportPath);
+  if (
+    !relativeReportPath ||
+    relativeReportPath.startsWith("..") ||
+    path.isAbsolute(relativeReportPath)
+  ) {
+    return reportPath;
+  }
+  return relativeReportPath.replace(/\\/g, "/");
+}
 
 const WikiStatusSchema = Type.Object({}, { additionalProperties: false });
 const WikiLintSchema = Type.Object({}, { additionalProperties: false });
@@ -182,6 +197,7 @@ export function createWikiLintTool(
       const provenance = result.issuesByCategory.provenance.length;
       const errors = result.issues.filter((issue) => issue.severity === "error").length;
       const warnings = result.issues.filter((issue) => issue.severity === "warning").length;
+      const reportPath = formatWikiToolReportPath(config, result.reportPath);
       const summary =
         result.issueCount === 0
           ? "No wiki lint issues."
@@ -190,11 +206,16 @@ export function createWikiLintTool(
               `Contradictions: ${contradictions}`,
               `Open questions: ${openQuestions}`,
               `Provenance gaps: ${provenance}`,
-              `Report: ${result.reportPath}`,
+              `Report: ${reportPath}`,
             ].join("\n");
       return {
         content: [{ type: "text", text: summary }],
-        details: result,
+        details: {
+          issueCount: result.issueCount,
+          issues: result.issues,
+          issuesByCategory: result.issuesByCategory,
+          reportPath,
+        },
       };
     },
   };


### PR DESCRIPTION
## Summary

- Problem: `wiki_lint` returned the raw lint result as tool `details`, including an absolute `reportPath`, while the CLI path works normally.
- Why it matters: absolute-path-heavy tool output can interact poorly with tool-result handling and produced `unable to resolve opened file path` in the reported runtime path.
- What changed: the `wiki_lint` tool now renders vault-internal report paths relative to the wiki vault with a defensive formatter, and returns a lightweight details object instead of the raw lint result object.
- What did NOT change (scope boundary): the underlying `lintMemoryWikiVault()` result shape and CLI behavior are unchanged; CLI callers still receive the absolute report path they can read from disk.

AI-assisted PR: yes. I used OpenClaw/Codex assistance, reviewed the diff, and personally ran the verification below.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #83420
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: `wiki_lint` tool output should avoid exposing the raw absolute `reportPath` in model-visible text and should not return the raw lint result object as details.
- Real environment tested:
  - Host: Linux 6.8.0-111-generic x64
  - Container: `node:24-bookworm`
  - Source: `origin/main` plus this patch
- Exact steps or command run after this patch:

```bash
docker run --rm \
  -v /tmp/openclaw-83420-main:/repo \
  -w /repo node:24-bookworm \
  bash -lc 'corepack enable >/dev/null && pnpm test:extension memory-wiki'
```

I also ran a direct Docker harness invoking `createWikiLintTool(...).execute(...)` against an isolated test vault with lint warnings.

- Evidence after fix (copied live output):

```text
[test-extension] Running 23 test files for memory-wiki
...
Test Files  23 passed (23)
Tests       118 passed (118)
```

Direct current-head tool output after the patch (`69baeae2888b1e652740c3afbdabf08f4ae84eb3`):

```text
toolText=Issues: 3 total (0 errors, 3 warnings)\nContradictions: 0\nOpen questions: 0\nProvenance gaps: 1\nReport: reports/lint.md
detailsReportPath=reports/lint.md
detailsHasVaultRoot=false
detailsContainsVaultRoot=false
toolTextContainsVaultRoot=false
coreLintReportPathAbsolute=true
coreLintReportPathContainsVaultRoot=true
```

- Observed result after fix: the tool-visible summary reports `reports/lint.md`, `details.reportPath` is also `reports/lint.md`, and the tool details no longer include or serialize the vault root. The underlying lint core result still uses an absolute report path for file-oriented callers. If a report path is not inside the vault, the formatter leaves it unchanged instead of fabricating a misleading relative path.
- What was not tested: I did not reproduce the exact full-runtime `unable to resolve opened file path` failure path in Docker; the direct tool harness reproduced the risky output shape and confirmed the patched output shape.
- Before evidence (optional but encouraged): before the patch, the same direct harness returned `Report: /tmp/wiki-lint-repro-vault/reports/lint.md` and `details.reportPath: /tmp/wiki-lint-repro-vault/reports/lint.md`.

## Root Cause (if applicable)

- Root cause: `createWikiLintTool()` reused the raw `lintMemoryWikiVault()` result directly for both visible text and tool metadata. That raw result is appropriate for CLI/file callers but too file-path-heavy for an agent tool result.
- Missing detection / guardrail: there was no tool-level test ensuring `wiki_lint` normalizes report paths for tool output.
- Contributing context (if known): the CLI already logs a relative report path internally, but the returned result keeps the absolute path for CLI consumers.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/memory-wiki/src/tool.test.ts`
- Scenario the test should lock in: `wiki_lint` returns `reports/lint.md` in visible text and `details.reportPath`, without leaking the absolute vault path in the visible summary or details payload, while preserving categorized lint details such as broken wikilinks.
- Why this is the smallest reliable guardrail: the bug is in the tool wrapper, not the underlying linter or CLI path.
- Existing test that already covers this (if any): N/A

## User-visible / Behavior Changes

`wiki_lint` tool responses now show the lint report path relative to the vault (`reports/lint.md`) instead of an absolute local path. CLI lint output is unchanged.

## Diagram (if applicable)

```text
Before:
wiki_lint tool -> raw lint result -> absolute reportPath in text/details

After:
wiki_lint tool -> normalized tool payload -> relative reportPath in text/details
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux 6.8.0-111-generic x64
- Runtime/container: Docker `node:24-bookworm`
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): isolated memory-wiki test vault under `/tmp`

### Steps

1. Create an isolated memory-wiki vault with a lintable synthesis page.
2. Invoke `createWikiLintTool(config).execute(...)`.
3. Inspect the visible text and `details.reportPath`.

### Expected

- Tool text uses `Report: reports/lint.md` for vault-internal reports.
- Tool `details.reportPath` is `reports/lint.md` for vault-internal reports.
- The underlying CLI/linter behavior remains unchanged.

### Actual

- Matches expected after this patch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test:extension memory-wiki` passed in Docker (`23` files, `118` tests).
  - Direct `createWikiLintTool(...).execute(...)` output now uses `reports/lint.md` and omits `vaultRoot` from tool details.
- Edge cases checked:
  - The underlying CLI/linter result shape was left unchanged so existing `lint.test.ts` absolute-path file reads continue to work.
- What you did **not** verify:
  - I did not reproduce the exact full-runtime `unable to resolve opened file path` failure in Docker.

Codex review:

- Ran `codex review --base origin/main` locally as requested by the contribution guide.
- It produced one P1 finding about `scripts/e2e/telegram-user-credential.ts`, but this PR does not touch that file or any credential helper path; the changed files are only `extensions/memory-wiki/src/tool.ts` and `extensions/memory-wiki/src/tool.test.ts`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: tool consumers that expected an absolute `details.reportPath` may now see a relative path and no longer receive `vaultRoot` in the agent-tool details payload.
  - Mitigation: this is limited to the agent tool wrapper; the CLI/linter result remains unchanged for file-oriented callers, and agent-tool consumers should resolve `reports/lint.md` relative to their existing memory-wiki vault context rather than relying on a model-visible absolute path.




