### PR TITLE
[codex] Fix Discord progress mode dropping final replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Docs: https://docs.openclaw.ai
 
 - Agents/code mode: preserve agent, session, run, and channel context in `before_tool_call` hooks for top-level `exec`/`wait` dispatches. Fixes #83387.
 - Replies: keep final payload delivery after live preview updates so channels can finalize or send the completed answer instead of losing preview-only drafts. (#83468)
+- Discord: deliver final replies in progress-mode preview streams instead of deduplicating the final visible message. (#83443) Thanks @compoodment.
 - Providers/Xiaomi: replay MiMo Anthropic-compatible `reasoning_content` as provider-required thinking blocks even when OpenClaw thinking is disabled, fixing follow-up tool turns for `mimo-v2-flash`. Fixes #83407. Thanks @Xgenious7.
 - Agents/exec approvals: forward approval-runtime credentials on agent-owned Gateway approval calls so approved async commands complete through the existing runtime path instead of stalling on unauthenticated follow-up calls. Thanks @IWhatsskill, @Patrick-Erichsen, and @jesse-merhi.
 - Gateway/skills: preflight remote macOS skill-bin refreshes with a WebSocket connectivity check so stale node sessions skip quickly instead of logging slow `system.which` timeout warnings.

--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -1712,6 +1712,7 @@ describe("processDiscordMessage draft streaming", () => {
 
   it("defaults unset Discord preview streaming to progress mode without drafting text-only turns", async () => {
     await runSingleChunkFinalScenario({ maxLinesPerMessage: 5 });
+    expect(getLastDispatchReplyOptions()?.onPartialReply).toBeUndefined();
     expect(createDiscordDraftStream).toHaveBeenCalledTimes(1);
     expect(editMessageDiscord).not.toHaveBeenCalled();
     expect(deliverDiscordReply).toHaveBeenCalledTimes(1);

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -808,9 +808,10 @@ export async function processDiscordMessage(
                 (typeof resolvedBlockStreamingEnabled === "boolean"
                   ? !resolvedBlockStreamingEnabled
                   : undefined)),
-            onPartialReply: draftPreview.draftStream
-              ? (payload) => draftPreview.updateFromPartial(payload.text)
-              : undefined,
+            onPartialReply:
+              draftPreview.draftStream && !draftPreview.isProgressMode
+                ? (payload) => draftPreview.updateFromPartial(payload.text)
+                : undefined,
             onAssistantMessageStart: draftPreview.draftStream
               ? () => draftPreview.handleAssistantMessageBoundary()
               : undefined,


### PR DESCRIPTION
AI-assisted: yes. I understand this change: Discord progress mode should keep progress/block draft behavior, but it must not register a text partial preview hook because the shared reply runner treats that hook as proof that text was already streamed and can suppress matching final replies.

## Summary

- Stop Discord progress preview mode from registering onPartialReply.
- Keep onPartialReply for non-progress draft streaming modes.
- Add regression coverage that default/unset Discord progress mode leaves onPartialReply undefined while still creating a progress draft stream and delivering the final text reply.

## Root cause

processDiscordMessage registered onPartialReply whenever a Discord draft stream existed. In progress mode, the Discord draft preview ignores text partials, but the shared agent runner still wraps the presence of onPartialReply and records latestPreviewStreamedText.

That value is later passed into final reply payload construction. If the final matches the recorded preview text, the final can be deduped as already-previewed even though progress mode never displayed that text in Discord.

## Real behavior proof

Behavior or issue addressed: Discord progress streaming could generate and persist an assistant final reply in OpenClaw state while suppressing the visible Discord message, because the final was treated as already-previewed text.

Real environment tested: OpenClaw 2026.5.16-beta.6 on a VPS Discord DM bot, with the Discord channel connected/reachable and channels.discord.streaming.mode=progress.

Exact steps or command run after this patch: Applied the same one-line logic change to the active installed @openclaw/discord bundle on the VPS, restarted the OpenClaw gateway, kept channels.discord.streaming.mode=progress, then sent a new short Discord DM to the bot.

Evidence after fix: Redacted live output/runtime proof from the VPS Discord setup: before the patch, the OpenClaw session JSONL recorded assistant final replies for incoming Discord DMs, but no bot message appeared in Discord. After patching the active @openclaw/discord bundle and restarting the gateway, the tester sent another Discord DM at 2026-05-18 06:54 Europe/Amsterdam and confirmed the bot response appeared in Discord. The channel stayed in progress streaming mode for the after-fix test.

Observed result after fix: The bot delivered the visible Discord reply instead of only writing the assistant final into OpenClaw session state.

Not tested: Full repo pnpm build && pnpm check && pnpm test was not run locally. I ran the Discord extension lane plus live beta behavior proof for this draft PR.

## Validation

- git diff --check -- extensions/discord/src/monitor/message-handler.process.ts extensions/discord/src/monitor/message-handler.process.test.ts
- pnpm test:extension discord
  - 146 test files passed
  - 1464 tests passed
- codex review --base origin/main was attempted locally, but the Codex CLI failed with 401 Unauthorized before producing a review.
