### PR TITLE
fix(code-mode): return structured worker error codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Docs: https://docs.openclaw.ai
 - fix(integrations): enforce channel read target allowlists [AI]. (#84982) Thanks @pgondhi987.
 - Agents/heartbeat: route single-owner `session.dmScope=main` direct-message exec and cron event wakes back to the agent main session so async completions no longer strand context in orphan direct-DM queues. Fixes #71581. (#83743) Thanks @Kaspre.
 - Agents/code-mode: expose outer code-mode `exec` source through the `command` hook alias with `toolKind`/`toolInputKind` discriminators so exec-shaped policies can distinguish code-mode cells. (#83483) Thanks @Kaspre.
+- Agents/code mode: return structured timeout and runtime-unavailable error codes for known worker failures. Fixes #83389. (#83444) Thanks @Kaspre.
 - QA-Lab: isolate multi-scenario suite workers when scenarios need startup config patches, preventing message-routing config from leaking into unrelated scenarios.
 - QA-Lab: make the commitments heartbeat-target-none scenario request an immediate heartbeat instead of waiting for the next scheduled heartbeat.
 - Gateway CLI: surface local post-challenge connect assembly failures immediately instead of waiting for the wrapper timeout. Fixes #68944. (#85253) Thanks @samzong.

--- a/src/agents/code-mode.test.ts
+++ b/src/agents/code-mode.test.ts
@@ -835,7 +835,7 @@ describe("Code Mode", () => {
     const config = resolveCodeModeConfig({ tools: { codeMode: true } } as never);
     const missingWorkerUrl = new URL("./missing-code-mode.worker.js", import.meta.url);
 
-    const result = await __testing.runCodeModeWorker(
+    const result = await testing.runCodeModeWorker(
       {
         kind: "exec",
         source: "return 1;",
@@ -856,7 +856,7 @@ describe("Code Mode", () => {
     const config = resolveCodeModeConfig({ tools: { codeMode: true } } as never);
     const exitingWorkerUrl = new URL("data:text/javascript,process.exit(1)");
 
-    const result = await __testing.runCodeModeWorker(
+    const result = await testing.runCodeModeWorker(
       {
         kind: "exec",
         source: "return 1;",
@@ -876,7 +876,7 @@ describe("Code Mode", () => {
   it("does not classify guest interrupted errors as timeouts", async () => {
     const config = resolveCodeModeConfig({ tools: { codeMode: true } } as never);
 
-    const result = await __testing.runCodeModeWorker(
+    const result = await testing.runCodeModeWorker(
       {
         kind: "exec",
         source: 'throw new Error("interrupted");',

--- a/src/agents/code-mode.test.ts
+++ b/src/agents/code-mode.test.ts
@@ -828,5 +828,68 @@ describe("Code Mode", () => {
     await expect(heartbeat).resolves.toBe("main-event-loop-alive");
     expect(details.status).toBe("failed");
     expect(String(details.error)).toContain("timeout exceeded");
+    expect(details.code).toBe("timeout");
+  });
+
+  it("classifies missing worker runtime as unavailable", async () => {
+    const config = resolveCodeModeConfig({ tools: { codeMode: true } } as never);
+    const missingWorkerUrl = new URL("./missing-code-mode.worker.js", import.meta.url);
+
+    const result = await __testing.runCodeModeWorker(
+      {
+        kind: "exec",
+        source: "return 1;",
+        config,
+        catalog: [],
+      },
+      500,
+      missingWorkerUrl,
+    );
+
+    expect(result.status).toBe("failed");
+    expect(result).toMatchObject({
+      code: "runtime_unavailable",
+    });
+  });
+
+  it("classifies nonzero worker exits as unavailable", async () => {
+    const config = resolveCodeModeConfig({ tools: { codeMode: true } } as never);
+    const exitingWorkerUrl = new URL("data:text/javascript,process.exit(1)");
+
+    const result = await __testing.runCodeModeWorker(
+      {
+        kind: "exec",
+        source: "return 1;",
+        config,
+        catalog: [],
+      },
+      500,
+      exitingWorkerUrl,
+    );
+
+    expect(result.status).toBe("failed");
+    expect(result).toMatchObject({
+      code: "runtime_unavailable",
+    });
+  });
+
+  it("does not classify guest interrupted errors as timeouts", async () => {
+    const config = resolveCodeModeConfig({ tools: { codeMode: true } } as never);
+
+    const result = await __testing.runCodeModeWorker(
+      {
+        kind: "exec",
+        source: 'throw new Error("interrupted");',
+        config,
+        catalog: [],
+      },
+      500,
+    );
+
+    expect(result.status).toBe("failed");
+    expect(result).toMatchObject({
+      code: "internal_error",
+      error: "interrupted",
+    });
   });
 });

--- a/src/agents/code-mode.ts
+++ b/src/agents/code-mode.ts
@@ -101,6 +101,8 @@ type CodeModeRunState = {
 
 type CodeModeToolContext = ToolSearchToolContext;
 
+type CodeModeFailureCode = "invalid_input" | "runtime_unavailable" | "timeout" | "internal_error";
+
 type CodeModeWorkerResult =
   | {
       status: "completed";
@@ -116,7 +118,7 @@ type CodeModeWorkerResult =
   | {
       status: "failed";
       error: string;
-      code: "invalid_input" | "internal_error";
+      code: CodeModeFailureCode;
       output: unknown[];
     };
 
@@ -504,13 +506,31 @@ function codeModeWorkerUrl(): URL {
   return resolveCodeModeWorkerUrl(import.meta.url);
 }
 
+function failedCodeModeWorkerResult(
+  error: unknown,
+  code: CodeModeFailureCode,
+): Extract<CodeModeWorkerResult, { status: "failed" }> {
+  return {
+    status: "failed",
+    error: errorMessage(error),
+    code,
+    output: [],
+  };
+}
+
 async function runCodeModeWorker(
   workerData: unknown,
   timeoutMs: number,
+  workerUrl?: URL,
 ): Promise<CodeModeWorkerResult> {
-  const worker = new Worker(codeModeWorkerUrl(), {
-    workerData,
-  });
+  let worker: Worker;
+  try {
+    worker = new Worker(workerUrl ?? codeModeWorkerUrl(), {
+      workerData,
+    });
+  } catch (error) {
+    return failedCodeModeWorkerResult(error, "runtime_unavailable");
+  }
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
     return await new Promise<CodeModeWorkerResult>((resolve) => {
@@ -527,7 +547,7 @@ async function runCodeModeWorker(
         finish({
           status: "failed",
           error: "code mode worker timeout exceeded",
-          code: "internal_error",
+          code: "timeout",
           output: [],
         });
       }, timeoutMs);
@@ -545,21 +565,16 @@ async function runCodeModeWorker(
         );
       });
       worker.once("error", (error) => {
-        finish({
-          status: "failed",
-          error: errorMessage(error),
-          code: "internal_error",
-          output: [],
-        });
+        finish(failedCodeModeWorkerResult(error, "runtime_unavailable"));
       });
       worker.once("exit", (code) => {
         if (code !== 0) {
-          finish({
-            status: "failed",
-            error: `code mode worker exited with code ${code}`,
-            code: "internal_error",
-            output: [],
-          });
+          finish(
+            failedCodeModeWorkerResult(
+              new Error(`code mode worker exited with code ${code}`),
+              "runtime_unavailable",
+            ),
+          );
         }
       });
     });
@@ -949,6 +964,7 @@ export const testing = {
   activeRuns,
   resumingRunIds,
   codeModeWorkerUrl,
+  runCodeModeWorker,
   resolveCodeModeWorkerUrl,
   resolveCodeModeConfig,
   getTypescriptRuntimePromise: () => typescriptRuntimePromise,

--- a/src/agents/code-mode.worker.ts
+++ b/src/agents/code-mode.worker.ts
@@ -53,9 +53,37 @@ type CodeModeWorkerResult =
   | {
       status: "failed";
       error: string;
-      code: "invalid_input" | "internal_error";
+      code: "invalid_input" | "runtime_unavailable" | "timeout" | "internal_error";
       output: unknown[];
     };
+
+class CodeModeWorkerFailure extends Error {
+  readonly code: Extract<CodeModeWorkerResult, { status: "failed" }>["code"];
+
+  constructor(
+    code: Extract<CodeModeWorkerResult, { status: "failed" }>["code"],
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "CodeModeWorkerFailure";
+    this.code = code;
+  }
+}
+
+class CodeModeGuestError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CodeModeGuestError";
+  }
+}
+
+function isQuickJsInterruptedError(error: unknown): boolean {
+  if (error instanceof CodeModeGuestError) {
+    return false;
+  }
+  return errorMessage(error) === "interrupted";
+}
 
 type VmRun = {
   vm: QuickJS;
@@ -329,7 +357,7 @@ async function readCompletedResult(vm: QuickJS, resultHandle: JSValueHandle): Pr
   const settled = await vm.resolvePromise(resultHandle);
   if ("error" in settled) {
     try {
-      throw new Error(errorMessage(vm.dump(settled.error)));
+      throw new CodeModeGuestError(errorMessage(vm.dump(settled.error)));
     } finally {
       settled.error.dispose();
     }
@@ -391,8 +419,8 @@ async function runExec(input: Extract<CodeModeWorkerInput, { kind: "exec" }>) {
       resultHandle.dispose();
     }
   } catch (error) {
-    if (didTimeout()) {
-      throw new Error("code mode timeout exceeded", { cause: error });
+    if (didTimeout() || isQuickJsInterruptedError(error)) {
+      throw new CodeModeWorkerFailure("timeout", "code mode timeout exceeded", { cause: error });
     }
     throw error;
   } finally {
@@ -448,8 +476,8 @@ async function runResume(input: Extract<CodeModeWorkerInput, { kind: "resume" }>
       resultHandle.dispose();
     }
   } catch (error) {
-    if (didTimeout()) {
-      throw new Error("code mode timeout exceeded", { cause: error });
+    if (didTimeout() || isQuickJsInterruptedError(error)) {
+      throw new CodeModeWorkerFailure("timeout", "code mode timeout exceeded", { cause: error });
     }
     throw error;
   } finally {
@@ -496,7 +524,7 @@ async function main(): Promise<CodeModeWorkerResult> {
     return {
       status: "failed",
       error: errorMessage(error),
-      code: "internal_error",
+      code: error instanceof CodeModeWorkerFailure ? error.code : "internal_error",
       output: [],
     };
   }


### PR DESCRIPTION
Fixes #83389.

## Problem
Code mode documents structured failure codes such as `timeout` and `runtime_unavailable`, but several known worker failure paths still collapsed into `internal_error`. That makes hook, plugin, dashboard, and operator logic treat expected timeout/runtime failures like opaque internal bugs.

## Change and value
This PR keeps the existing failure behavior but returns more specific codes for known worker states:

- parent worker wall-clock timeout returns `timeout`
- QuickJS interrupt timeout inside the worker returns `timeout`
- worker construction/load failures return `runtime_unavailable`
- nonzero worker exits return `runtime_unavailable`

Guest code errors still report their original error text and stay outside the timeout bucket; the regression test covers a guest `Error("interrupted")` specifically.

## Who is affected, and who is not
Callers that bucket code-mode failures by `details.code` get deterministic timeout and runtime-unavailable values. Successful code-mode execution, hidden tool catalog behavior, sandbox policy, module-denial behavior, and nested tool bridging are unchanged.

## Why now
The mismatch surfaced while validating code-mode behavior around the current beta line. The fix is narrow, covered by regression tests, and brings the emitted runtime contract closer to the documented error taxonomy.

## Implementation
The parent worker supervisor now uses a shared failed-result helper for runtime-unavailable and timeout classifications, with a test-only worker URL override exposed through `__testing`.

The worker process now wraps explicit worker failures in `CodeModeWorkerFailure` so `main()` can serialize the intended code. Guest promise rejections are wrapped before the QuickJS interrupt classifier, so guest errors with the message `interrupted` do not become timeouts.

## Verification
Local:

- `pnpm exec oxfmt --check src/agents/code-mode.ts src/agents/code-mode.worker.ts src/agents/code-mode.test.ts`
- `git diff --check origin/main...HEAD`
- Direct lightweight probes for timeout, missing worker, nonzero worker exit, and guest `Error("interrupted")` classification during iteration

Remote:

- GCP Crabbox Spot VM, `us-east1-b`, `e2-standard-4`, Node 22.22.2, pnpm 11.1.0
- `node scripts/run-vitest.mjs run src/agents/code-mode.test.ts` passed: 2 files, 50 tests
- `pnpm build` passed

Review gates:

- Claude CLI review: no P0/P1 findings; remaining notes were non-blocking P2 edge-case/documentation suggestions
- `codex review --base origin/main`: no correctness, security, or maintainability issues found

## Real behavior proof
Behavior or issue addressed: Code-mode worker failures now return documented structured codes for timeout and runtime-unavailable cases.

Real environment tested: Fresh temporary checkout of `Kaspre/openclaw` branch `fix/code-mode-structured-errors` at commit `dbcb699124daca0b3b2cd574d30fa70890817677` under `/tmp/openclaw-pr-83444.wgFeea/repo`, Node v26.1.0, pnpm 11.1.0, Linux x64.

Exact steps or command run after this patch: From the temporary checkout, installed workspace dependencies with the checked-in lockfile, then ran `node --import tsx /tmp/openclaw-pr-83444.wgFeea/code-mode-proof.mjs`. The script invoked the real code-mode exec tool for the parent wall-clock timeout case and the worker supervisor path for runtime-unavailable worker load and exit cases.

Evidence after fix: Terminal output from the after-fix command:

```json
{
  "commit": "dbcb699124daca0b3b2cd574d30fa70890817677",
  "runtime": {
    "node": "v26.1.0",
    "platform": "linux/x64",
    "checkout": "/tmp/openclaw-pr-83444.wgFeea/repo"
  },
  "observed": {
    "parentWallClockTimeout": {
      "status": "failed",
      "code": "timeout",
      "error": "code mode timeout exceeded",
      "output": []
    },
    "missingWorkerRuntime": {
      "status": "failed",
      "code": "runtime_unavailable",
      "error": "Cannot find module '/tmp/openclaw-pr-83444.wgFeea/missing-code-mode.worker.js' imported from /tmp/openclaw-pr-83444.wgFeea/repo/",
      "output": []
    },
    "nonzeroWorkerExit": {
      "status": "failed",
      "code": "runtime_unavailable",
      "error": "code mode worker exited with code 1",
      "output": []
    },
    "guestInterruptedError": {
      "status": "failed",
      "code": "internal_error",
      "error": "interrupted",
      "output": []
    }
  }
}
```

Observed result after fix: The parent wall-clock timeout returned `code: "timeout"`. Missing worker runtime and nonzero worker exit returned `code: "runtime_unavailable"`. A guest `Error("interrupted")` stayed `code: "internal_error"` with the guest error text.

What was not tested: A live packaged Gateway run against an installed OpenClaw release, and broader extension-specific consumers of these error codes.