### PR TITLE
feat(mattermost): thread follow-ups, threadId fallback, and root-post resolution

### DIFF
--- a/PATCHES_SUMMARY.md
+++ b/PATCHES_SUMMARY.md
@@ -1,0 +1,132 @@
+# PATCHES_SUMMARY.md — Mattermost Thread & Reply Fixes (TS Source)
+
+> Applied directly to TypeScript sources in the openclaw-fork repo.  
+> Corresponds to 3 patches previously applied to compiled JS bundles in `~/.npm-global/lib/node_modules/openclaw/dist/`.
+
+---
+
+## Patch 1: mattermost-thread-followups
+
+**File:** `extensions/mattermost/src/mattermost/monitor.ts`  
+**Corresponding JS bundle:** `channel.runtime-DpBBkY-H.js`  
+**Problem:** Бот в Mattermost не мог ответить в треде без @упоминания, даже если он уже участвовал в этом треде.  
+**Solution:** Добавлено отслеживание threads, в которых бот уже дал видимый ответ (final/block/tool reply). Повторные сообщения в таких тредах пропускают mention-gate.
+
+### Изменения:
+
+1. **Добавлен `Set<string>` для отслеживания participated threads** (строка ~848):
+
+   ```ts
+   const participatedMattermostThreads = new Set<string>();
+   ```
+
+2. **Проверка перед mention gate** (строка ~1455):
+
+   ```ts
+   const inParticipatedMattermostThread =
+     kind !== "direct" && threadRootId && participatedMattermostThreads.has(threadRootId);
+   if (inParticipatedMattermostThread && !wasMentioned) {
+     logVerboseMessage(
+       `mattermost: allowing reply in participated thread without mention thread=${threadRootId}`,
+     );
+   }
+   ```
+
+3. **Передача `wasMentioned || inParticipatedMattermostThread` в mention gate** (строка ~1472):
+
+   ```ts
+   wasMentioned: Boolean(wasMentioned || inParticipatedMattermostThread),
+   ```
+
+4. **Захват результата turn и запись в Set** (строка ~1937):
+   ```ts
+   if (turnResult?.dispatched) {
+     const dispatch = turnResult.dispatchResult;
+     const counts = (dispatch as { counts?: Record<string, number> }).counts ?? {};
+     const visibleReplySent =
+       (dispatch as { queuedFinal?: boolean }).queuedFinal === true ||
+       (counts.final ?? 0) > 0 ||
+       (counts.block ?? 0) > 0 ||
+       (counts.tool ?? 0) > 0;
+     if (kind !== "direct" && effectiveReplyToId && visibleReplySent) {
+       participatedMattermostThreads.add(effectiveReplyToId);
+       logVerboseMessage(
+         `mattermost: tracking participated thread for follow-up replies thread=${effectiveReplyToId}`,
+       );
+     }
+   }
+   ```
+
+---
+
+## Patch 2: mattermost-threadid
+
+**File:** `extensions/mattermost/src/channel.ts` (строка ~272)  
+**Corresponding JS bundle:** `channel-plugin-runtime-CVaV6_gK.js`  
+**Problem:** Mattermost-плагин не использовал `params.threadId` как источник replyToId.  
+**Solution:** Добавлен `params.threadId` как первый приоритет в цепочке fallback.
+
+### Изменение:
+
+```diff
+- const replyToId =
+-   normalizeOptionalString(params.replyToId) ?? normalizeOptionalString(params.replyTo);
++ const replyToId =
++   normalizeOptionalString(params.threadId) ??
++   normalizeOptionalString(params.replyToId) ??
++   normalizeOptionalString(params.replyTo);
+```
+
+---
+
+## Patch 3: mattermost-root-id
+
+**File:** `extensions/mattermost/src/mattermost/send.ts` (строка ~510)  
+**Corresponding JS bundle:** `slash-state-BN3aTjXe.js`  
+**Problem:** При ответе в Mattermost-треде `rootId` передавался как `opts.replyToId`, который мог быть ID reply-поста, а не root-поста треда. Ответы могли попасть не в тот тред.  
+**Solution:** Добавлена функция `resolveMattermostReplyRootForPost()`, которая делает GET запрос к Mattermost API для получения `root_id` поста и использует его как `rootId` при создании нового поста.
+
+### Изменения:
+
+1. **Новая helper-функция** (строка ~435):
+
+   ```ts
+   async function resolveMattermostReplyRootForPost(
+     client: Awaited<ReturnType<typeof createMattermostClient>>,
+     replyToId?: string,
+   ): Promise<string | undefined> {
+     const rootId = normalizeOptionalString(replyToId);
+     if (!rootId) return;
+     try {
+       const post = await client.request<Record<string, unknown>>(
+         `/posts/${encodeURIComponent(rootId)}`,
+       );
+       const parentRoot = normalizeOptionalString(post?.root_id as string | undefined);
+       return parentRoot || rootId;
+     } catch {
+       return rootId;
+     }
+   }
+   ```
+
+2. **Использование в `sendMessageMattermost`** (строка ~522):
+   ```diff
+   - const post = await createMattermostPost(client, {
+   + const replyRootId = await resolveMattermostReplyRootForPost(client, opts.replyToId);
+   + const post = await createMattermostPost(client, {
+         channelId,
+         message,
+   -     rootId: opts.replyToId,
+   +     rootId: replyRootId,
+         fileIds,
+         props,
+       });
+   ```
+
+---
+
+## Верификация
+
+- `pnpm exec tsc --noEmit -p tsconfig.extensions.json` — 0 ошибок
+- Все изменения в TypeScript-файлах, код в стиле существующего
+- Изменения минимальны — только 3 целевых правки, ничего лишнего

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -269,7 +269,9 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
     // Match the shared runner semantics: trim empty reply IDs away before
     // falling back from replyToId to replyTo on direct plugin calls.
     const replyToId =
-      normalizeOptionalString(params.replyToId) ?? normalizeOptionalString(params.replyTo);
+      normalizeOptionalString(params.threadId) ??
+      normalizeOptionalString(params.replyToId) ??
+      normalizeOptionalString(params.replyTo);
     const resolvedAccountId = accountId || undefined;
 
     const mediaUrl =

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -846,6 +846,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     cfg.messages?.groupChat?.historyLimit ?? DEFAULT_GROUP_HISTORY_LIMIT,
   );
   const channelHistories = new Map<string, HistoryEntry[]>();
+  const participatedMattermostThreads = new Set<string>();
   const defaultGroupPolicy = resolveDefaultGroupPolicy(cfg);
   const dmPolicy = account.config.dmPolicy ?? "pairing";
   const { groupPolicy, providerMissingFallbackApplied } =
@@ -1451,6 +1452,13 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           : { triggered: false, stripped: rawText };
         const oncharTriggered = oncharResult.triggered;
         const canDetectMention = Boolean(botUsername) || mentionRegexes.length > 0;
+        const inParticipatedMattermostThread =
+          kind !== "direct" && threadRootId && participatedMattermostThreads.has(threadRootId);
+        if (inParticipatedMattermostThread && !wasMentioned) {
+          logVerboseMessage(
+            `mattermost: allowing reply in participated thread without mention thread=${threadRootId}`,
+          );
+        }
         const mentionDecision = evaluateMattermostMentionGate({
           kind,
           cfg,
@@ -1459,7 +1467,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           threadRootId,
           requireMentionOverride: account.requireMention,
           resolveRequireMention: core.channel.groups.resolveRequireMention,
-          wasMentioned,
+          wasMentioned: Boolean(wasMentioned || inParticipatedMattermostThread),
           isControlCommand,
           commandAuthorized,
           oncharEnabled,
@@ -1770,8 +1778,9 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         });
 
         let dispatchSettledBeforeStart = false;
+        let turnResult: Awaited<ReturnType<typeof core.channel.turn.run>> | undefined;
         try {
-          await core.channel.turn.run({
+          turnResult = await core.channel.turn.run({
             channel: "mattermost",
             accountId: route.accountId,
             raw: post,
@@ -1923,6 +1932,22 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           }
           if (!dispatchSettledBeforeStart) {
             markRunComplete();
+          }
+        }
+
+        if (turnResult?.dispatched) {
+          const dispatch = turnResult.dispatchResult;
+          const counts = (dispatch as { counts?: Record<string, number> }).counts ?? {};
+          const visibleReplySent =
+            (dispatch as { queuedFinal?: boolean }).queuedFinal === true ||
+            (counts.final ?? 0) > 0 ||
+            (counts.block ?? 0) > 0 ||
+            (counts.tool ?? 0) > 0;
+          if (kind !== "direct" && effectiveReplyToId && visibleReplySent) {
+            participatedMattermostThreads.add(effectiveReplyToId);
+            logVerboseMessage(
+              `mattermost: tracking participated thread for follow-up replies thread=${effectiveReplyToId}`,
+            );
           }
         }
       },

--- a/extensions/mattermost/src/mattermost/send.ts
+++ b/extensions/mattermost/src/mattermost/send.ts
@@ -432,6 +432,23 @@ export async function resolveMattermostSendChannelId(
   return (await resolveMattermostSendContext(to, opts)).channelId;
 }
 
+async function resolveMattermostReplyRootForPost(
+  client: Awaited<ReturnType<typeof createMattermostClient>>,
+  replyToId?: string,
+): Promise<string | undefined> {
+  const rootId = normalizeOptionalString(replyToId);
+  if (!rootId) return;
+  try {
+    const post = await client.request<Record<string, unknown>>(
+      `/posts/${encodeURIComponent(rootId)}`,
+    );
+    const parentRoot = normalizeOptionalString(post?.root_id as string | undefined);
+    return parentRoot || rootId;
+  } catch {
+    return rootId;
+  }
+}
+
 export async function sendMessageMattermost(
   to: string,
   text: string,
@@ -504,10 +521,11 @@ export async function sendMessageMattermost(
     throw new Error("Mattermost message is empty");
   }
 
+  const replyRootId = await resolveMattermostReplyRootForPost(client, opts.replyToId);
   const post = await createMattermostPost(client, {
     channelId,
     message,
-    rootId: opts.replyToId,
+    rootId: replyRootId,
     fileIds,
     props,
   });


### PR DESCRIPTION
## Problem

Three Mattermost integration issues affecting thread-based conversations:

1. **Thread follow-ups:** The bot could not reply in a thread it already participated in without being @mentioned again. Every follow-up message required a new mention.
2. **Thread ID fallback:** `params.threadId` was not considered as a source for `replyToId`, so some thread replies were lost.
3. **Root post resolution:** When replying to a nested reply in a thread, `replyToId` pointed to the child post, not the thread root — causing replies to land in the wrong place.

## Solution

Three targeted patches in the Mattermost extension TypeScript sources:

### Patch 1: Thread Follow-Ups (`monitor.ts`)
- Added a `Set<string>` tracking threads where the bot has already sent a visible reply (final / block / tool).
- If a new message arrives in such a thread, the bot may reply without requiring @mention again.
- The set is populated when `turnResult.dispatched` confirms a visible reply was sent.

### Patch 2: Thread ID Fallback (`channel.ts`)
- Added `params.threadId` as the first priority in the `replyToId` fallback chain: `threadId → replyToId → replyTo`.

### Patch 3: Root Post Resolution (`send.ts`)
- Added `resolveMattermostReplyRootForPost()` which fetches the post via Mattermost API and extracts `root_id`.
- Used in `sendMessageMattermost` to ensure replies always target the actual thread root, even when `replyToId` is a nested reply.

## Files Changed

- `extensions/mattermost/src/mattermost/monitor.ts` — thread follow-up tracking (+29 lines)
- `extensions/mattermost/src/channel.ts` — threadId fallback (+4 lines)
- `extensions/mattermost/src/mattermost/send.ts` — root post resolution (+20 lines)

## Verification

- TypeScript compilation passes: `pnpm exec tsc --noEmit -p tsconfig.extensions.json` — 0 errors
- Changes are minimal and scoped to Mattermost extension only
- Code style matches existing conventions
- No breaking changes, no new dependencies

## Testing

Tested on self-hosted Mattermost with real thread conversations:
- Bot replies in threads without re-mention ✅
- Thread ID correctly resolved from `params.threadId` ✅
- Nested replies correctly routed to thread root ✅