### PR TITLE
feat(browser): add evaluate timeout CLI option

### DIFF
--- a/docs/cli/browser.md
+++ b/docs/cli/browser.md
@@ -191,7 +191,11 @@ openclaw browser select <ref> OptionA OptionB
 openclaw browser fill --fields '[{"ref":"1","value":"Ada"}]'
 openclaw browser wait --text "Done"
 openclaw browser evaluate --fn '(el) => el.textContent' --ref <ref>
+openclaw browser evaluate --timeout-ms 30000 --fn 'async () => { await window.ready; return true; }'
 ```
+
+Use `evaluate --timeout-ms <ms>` when the page-side function may need longer
+than the default evaluate timeout.
 
 Action responses return the current raw `targetId` after action-triggered page
 replacement when OpenClaw can prove the replacement tab. Scripts should still

--- a/docs/tools/browser-control.md
+++ b/docs/tools/browser-control.md
@@ -197,6 +197,7 @@ openclaw browser dialog --dismiss --dialog-id d1
 openclaw browser wait --text "Done"
 openclaw browser wait "#main" --url "**/dash" --load networkidle --fn "window.ready===true"
 openclaw browser evaluate --fn '(el) => el.textContent' --ref 7
+openclaw browser evaluate --timeout-ms 30000 --fn 'async () => { await window.ready; return true; }'
 openclaw browser highlight e12
 openclaw browser trace start
 openclaw browser trace stop
@@ -362,6 +363,8 @@ These are useful for "make the site behave like X" workflows:
 - `browser act kind=evaluate` / `openclaw browser evaluate` and `wait --fn`
   execute arbitrary JavaScript in the page context. Prompt injection can steer
   this. Disable it with `browser.evaluateEnabled=false` if you do not need it.
+- Use `openclaw browser evaluate --timeout-ms <ms>` when the page-side function
+  may need longer than the default evaluate timeout.
 - For logins and anti-bot notes (X/Twitter, etc.), see [Browser login + X/Twitter posting](/tools/browser-login).
 - Keep the Gateway/node host private (loopback or tailnet-only).
 - Remote CDP endpoints are powerful; tunnel and protect them.

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.test.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.test.ts
@@ -65,3 +65,28 @@ describe("browser action input wait command", () => {
     expect(options?.timeoutMs).toBeGreaterThan(21000);
   });
 });
+
+describe("browser action input evaluate command", () => {
+  beforeEach(() => {
+    mocks.callBrowserRequest.mockClear();
+    getBrowserCliRuntimeCapture().resetRuntimeCapture();
+  });
+
+  it("passes timeout-ms through to the evaluate action and outer request", async () => {
+    const program = createActionInputProgram();
+
+    await program.parseAsync(
+      ["browser", "evaluate", "--fn", "() => true", "--timeout-ms", "30000"],
+      { from: "user" },
+    );
+
+    const request = mocks.callBrowserRequest.mock.calls.at(-1)?.[1] as
+      | { body?: { timeoutMs?: number } }
+      | undefined;
+    const options = mocks.callBrowserRequest.mock.calls.at(-1)?.[2] as
+      | { timeoutMs?: number }
+      | undefined;
+    expect(request?.body?.timeoutMs).toBe(30000);
+    expect(options?.timeoutMs).toBeGreaterThan(30000);
+  });
+});

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.ts
@@ -107,6 +107,11 @@ export function registerBrowserFormWaitEvalCommands(
     .description("Evaluate a function against the page or a ref")
     .option("--fn <code>", "Function source, e.g. (el) => el.textContent")
     .option("--ref <id>", "Ref from snapshot")
+    .option(
+      "--timeout-ms <ms>",
+      "How long to allow the evaluate function to run (default: 20000)",
+      (v: string) => Number(v),
+    )
     .option("--target-id <id>", "CDP target id (or unique prefix)")
     .action(async (opts, cmd) => {
       const { parent, profile } = resolveBrowserActionContext(cmd, parentOpts);
@@ -116,6 +121,7 @@ export function registerBrowserFormWaitEvalCommands(
         return;
       }
       try {
+        const timeoutMs = Number.isFinite(opts.timeoutMs) ? opts.timeoutMs : undefined;
         const result = await callBrowserAct<{ result?: unknown }>({
           parent,
           profile,
@@ -124,7 +130,9 @@ export function registerBrowserFormWaitEvalCommands(
             fn: opts.fn,
             ref: normalizeOptionalString(opts.ref),
             targetId: normalizeOptionalString(opts.targetId),
+            timeoutMs,
           },
+          timeoutMs,
         });
         if (parent?.json) {
           defaultRuntime.writeJson(result);


### PR DESCRIPTION
## Summary

- Problem: `openclaw browser evaluate` had no command-specific way to pass an evaluate timeout, even though the browser action payload already supports `timeoutMs`.
- Why it matters: longer async evaluate functions could only use the default action timeout budget from the CLI, while `wait` already exposes `--timeout-ms` for similar long-running browser-side work.
- What changed: added `--timeout-ms <ms>` to the `browser evaluate` command and forwards it to both the evaluate action body and the outer browser action request timeout.
- What did NOT change (scope boundary): the default behavior remains unchanged when `--timeout-ms` is omitted; this PR does not change Playwright evaluate timeout clamping or server-side evaluate behavior.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes N/A
- Related N/A
- [ ] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: the browser evaluate CLI can now pass an explicit timeout for longer async evaluate functions.
- Real environment tested: macOS Darwin arm64, Node.js v24.15.0, local OpenClaw dev gateway from this checkout, channels skipped with `OPENCLAW_SKIP_CHANNELS=1`.
- Exact steps or command run after this patch:
  ```bash
  pnpm install --frozen-lockfile
  pnpm exec vitest run --config test/vitest/vitest.extension-browser.config.ts extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.test.ts
  pnpm test:extension browser
  pnpm exec oxfmt --check extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.ts extensions/browser/src/cli/browser-cli-actions-input/register.form-wait-eval.test.ts
  pnpm docs:list
  git diff --check
  pnpm build
  OPENCLAW_SKIP_CHANNELS=1 node openclaw.mjs --dev gateway run --dev --auth none --port 19001 --bind loopback
  node openclaw.mjs --dev browser --url ws://127.0.0.1:19001 --token dev open about:blank
  node openclaw.mjs --dev browser --url ws://127.0.0.1:19001 --token dev evaluate --timeout-ms 30000 --fn 'async () => { await new Promise(r => setTimeout(r, 22000)); return "ok"; }'
  ```
- Evidence after fix: terminal output from the real CLI run: `"ok"`
- Observed result after fix: the 22-second async evaluate completed successfully with `--timeout-ms 30000`.
- What was not tested: full repository `pnpm check` and `pnpm test` were not run; this PR ran the targeted browser extension lane plus build/docs/format/diff checks.

## Root Cause (if applicable)

- Root cause: the evaluate action type and Playwright helper already accept `timeoutMs`, but the CLI command did not expose or forward a command-level option for it.
- Missing detection / guardrail: the existing CLI tests covered `wait --timeout-ms` but not `evaluate` timeout forwarding.

## Regression Test Plan

- Added a CLI unit test that parses `browser evaluate --timeout-ms 30000` and asserts the timeout is forwarded to both the `/act` request body and the outer request options.
- Ran the full browser extension test lane: `pnpm test:extension browser`.

## Security Impact

- No new network, auth, or file access behavior.
- The value is only forwarded to the existing browser evaluate timeout plumbing, which already bounds evaluate execution server-side.

## Human Verification

- [x] I understand what the code does.
- [x] This PR is AI-assisted.
- [x] I ran targeted tests and real behavior proof on a local setup.
- [ ] I ran `codex review --base origin/main` locally.

