### PR TITLE
fix(auth): preserve Codex sidecar Keychain recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Docs: https://docs.openclaw.ai
 - Agents/subagents: preserve run-mode keep subagent registry entries past the session sweep TTL, so kept subagent runs remain visible after cleanup completes. Fixes #83132. (#83168) Thanks @yetval.
 - Agents/OpenAI streams: yield via `setTimeout(0)` instead of `setImmediate` between bursty Responses chunks so abort timers can fire during the yield, keeping cancel-on-timeout responsive on hot streams. Refs #82462.
 - Agents/Codex: keep legacy `oauthRef`-backed OAuth profiles usable while `openclaw doctor --fix` migrates them back to inline credentials, without creating new sidecar credentials. (#83312) Thanks @joshavant.
+- Agents/Codex: preserve read-only macOS Keychain fallback for legacy OAuth sidecar recovery and tell affected users to re-authenticate only when sidecar profiles remain undecryptable.
 - CLI/config: send SecretRef diagnostics to stderr so JSON command stdout remains parseable.
 - CLI/doctor: seed Control UI allowed origins when migrating legacy non-loopback gateway bind host aliases like `0.0.0.0`. Fixes #83286. Thanks @giodl73-repo.
 - CLI/plugins: ship the bundled memory CLI as a package entry so package-installed `openclaw memory` commands register correctly.

--- a/src/agents/auth-profiles/persisted-boundary.test.ts
+++ b/src/agents/auth-profiles/persisted-boundary.test.ts
@@ -1,12 +1,23 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { resolveOAuthDir } from "../../config/paths.js";
 import { AUTH_STORE_VERSION } from "./constants.js";
 import { legacyOAuthSidecarTestUtils } from "./legacy-oauth-sidecar.js";
 import { resolveAuthStorePath } from "./paths.js";
 import { coercePersistedAuthProfileStore, loadPersistedAuthProfileStore } from "./persisted.js";
+
+const execFileSyncMock = vi.hoisted(() =>
+  vi.fn<() => string>(() => {
+    throw new Error("legacy OAuth sidecar runtime must not read Keychain");
+  }),
+);
+
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:child_process")>()),
+  execFileSync: execFileSyncMock,
+}));
 
 function withEnvValue(key: string, value: string | undefined): () => void {
   const previous = process.env[key];
@@ -206,6 +217,100 @@ describe("persisted auth profile boundary", () => {
       });
       expect(credential).not.toHaveProperty("oauthRef");
     } finally {
+      restoreSecretKey();
+      restoreOAuthDir();
+      restoreStateDir();
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("uses macOS Keychain as a read-only fallback for legacy sidecar decryption", () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-oauthref-no-keychain-"));
+    const agentDir = path.join(stateDir, "agents", "main", "agent");
+    const restoreStateDir = withEnvValue("OPENCLAW_STATE_DIR", stateDir);
+    const restoreOAuthDir = withEnvValue("OPENCLAW_OAUTH_DIR", undefined);
+    const restoreSecretKey = withEnvValue("OPENCLAW_AUTH_PROFILE_SECRET_KEY", undefined);
+    const restoreVitest = withEnvValue("VITEST", undefined);
+    const restoreVitestWorker = withEnvValue("VITEST_WORKER_ID", undefined);
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    execFileSyncMock.mockReturnValueOnce("keychain-only-seed\n");
+    try {
+      fs.mkdirSync(agentDir, { recursive: true });
+      const profileId = "openai-codex:default";
+      const ref = {
+        source: "openclaw-credentials" as const,
+        provider: "openai-codex" as const,
+        id: "abcdefabcdefabcdefabcdefabcdefab",
+      };
+      fs.writeFileSync(
+        resolveAuthStorePath(agentDir),
+        `${JSON.stringify(
+          {
+            version: AUTH_STORE_VERSION,
+            profiles: {
+              [profileId]: {
+                type: "oauth",
+                provider: "openai-codex",
+                oauthRef: ref,
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+      );
+
+      const sidecarPath = path.join(resolveOAuthDir(), "auth-profiles", `${ref.id}.json`);
+      fs.mkdirSync(path.dirname(sidecarPath), { recursive: true });
+      fs.writeFileSync(
+        sidecarPath,
+        `${JSON.stringify(
+          {
+            version: 1,
+            profileId,
+            provider: "openai-codex",
+            encrypted: legacyOAuthSidecarTestUtils.encryptLegacyOAuthMaterial({
+              ref,
+              profileId,
+              provider: "openai-codex",
+              seed: "keychain-only-seed",
+              material: {
+                access: "legacy-access-token",
+                refresh: "legacy-refresh-token",
+              },
+            }),
+          },
+          null,
+          2,
+        )}\n`,
+      );
+
+      const credential = loadPersistedAuthProfileStore(agentDir, {
+        resolveLegacyOAuthSidecars: true,
+      })?.profiles[profileId];
+
+      expect(credential).toMatchObject({
+        type: "oauth",
+        provider: "openai-codex",
+        access: "legacy-access-token",
+        refresh: "legacy-refresh-token",
+      });
+      expect(execFileSyncMock).toHaveBeenCalledWith(
+        "security",
+        [
+          "find-generic-password",
+          "-s",
+          "OpenClaw Auth Profile Secrets",
+          "-a",
+          "oauth-profile-master-key",
+          "-w",
+        ],
+        { encoding: "utf8", timeout: 5000, stdio: ["pipe", "pipe", "pipe"] },
+      );
+    } finally {
+      platformSpy.mockRestore();
+      restoreVitestWorker();
+      restoreVitest();
       restoreSecretKey();
       restoreOAuthDir();
       restoreStateDir();

--- a/src/agents/auth-profiles/persisted.ts
+++ b/src/agents/auth-profiles/persisted.ts
@@ -805,7 +805,7 @@ function preserveLegacyOAuthRefsForDoctorMigration(
       const isRuntimeSidecarMaterial =
         options?.runtimeLegacyOAuthSidecarProfileIds?.has(profileId) === true;
       // Untracked inline material may be a real token refresh. Only reread the
-      // sidecar then, and never use Keychain from this save-path check.
+      // sidecar then, preserving the same read-only legacy decryption fallback.
       if (
         !isRuntimeSidecarMaterial &&
         !isUnchangedLegacyOAuthSidecarMaterial({ profileId, rawProfile, credential })
@@ -841,7 +841,6 @@ function isUnchangedLegacyOAuthSidecarMaterial(params: {
     ref: params.rawProfile.oauthRef,
     profileId: params.profileId,
     provider: params.credential.provider,
-    allowKeychainPrompt: false,
   });
   if (!material) {
     return false;

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -140,10 +140,7 @@ function shouldUseMainOwnerForLocalOAuthCredential(params: {
   );
 }
 
-function resolveRuntimeAuthProfileStore(
-  agentDir?: string,
-  options?: Pick<LoadAuthProfileStoreOptions, "allowKeychainPrompt">,
-): AuthProfileStore | null {
+function resolveRuntimeAuthProfileStore(agentDir?: string): AuthProfileStore | null {
   const mainKey = resolveAuthStorePath(undefined);
   const requestedKey = resolveAuthStorePath(agentDir);
   const mainStore = getRuntimeAuthProfileStoreSnapshot(undefined);
@@ -163,7 +160,6 @@ function resolveRuntimeAuthProfileStore(
     const persistedMainStore = loadAuthProfileStoreForAgent(undefined, {
       readOnly: true,
       syncExternalCli: false,
-      ...resolvePersistedLoadOptions(options),
     });
     return mergeAuthProfileStores(persistedMainStore, requestedStore);
   }
@@ -641,7 +637,7 @@ export function ensureAuthProfileStoreWithoutExternalProfiles(
   agentDir?: string,
   options?: { allowKeychainPrompt?: boolean },
 ): AuthProfileStore {
-  const runtimeStore = resolveRuntimeAuthProfileStore(agentDir, options);
+  const runtimeStore = resolveRuntimeAuthProfileStore(agentDir);
   if (runtimeStore) {
     return runtimeStore;
   }

--- a/src/commands/doctor-auth-oauth-sidecar.test.ts
+++ b/src/commands/doctor-auth-oauth-sidecar.test.ts
@@ -10,7 +10,34 @@ import {
 import { __testing, maybeRepairLegacyOAuthSidecarProfiles } from "./doctor-auth-oauth-sidecar.js";
 import type { DoctorPrompter } from "./doctor-prompter.js";
 
+const execFileSyncMock = vi.hoisted(() =>
+  vi.fn<() => string>(() => {
+    throw new Error("unexpected doctor OAuth sidecar Keychain read");
+  }),
+);
+
+vi.mock("node:child_process", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:child_process")>()),
+  execFileSync: execFileSyncMock,
+}));
+
 const states: OpenClawTestState[] = [];
+
+function withEnvValue(key: string, value: string | undefined): () => void {
+  const previous = process.env[key];
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+  return () => {
+    if (previous === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = previous;
+    }
+  };
+}
 
 function makePrompter(shouldRepair: boolean): DoctorPrompter {
   return {
@@ -74,6 +101,10 @@ function encryptLegacySidecarMaterial(params: {
     tag: cipher.getAuthTag().toString("base64url"),
     ciphertext: ciphertext.toString("base64url"),
   };
+}
+
+function expectReauthWarning(profileId: string, authPath: string): string {
+  return `Could not decrypt legacy OAuth sidecar for ${profileId} in ${authPath}. Re-authenticate with openclaw models auth login --provider openai-codex.`;
 }
 
 afterEach(async () => {
@@ -245,11 +276,89 @@ describe("maybeRepairLegacyOAuthSidecarProfiles", () => {
 
     expect(result.detected).toEqual([authPath]);
     expect(result.changes).toStrictEqual([]);
-    expect(result.warnings).toStrictEqual([
-      `Could not decrypt legacy OAuth sidecar for ${profileId} in ${authPath}; re-authenticate this profile.`,
-    ]);
+    expect(result.warnings).toStrictEqual([expectReauthWarning(profileId, authPath)]);
     expect(fs.existsSync(sidecarPath)).toBe(true);
     expect(JSON.parse(fs.readFileSync(authPath, "utf8"))).toEqual(auth);
+  });
+
+  it("uses macOS Keychain as a read-only fallback while repairing legacy sidecars", async () => {
+    const state = await makeTestState("wrong-seed");
+    const profileId = "openai-codex:default";
+    const ref = {
+      source: "openclaw-credentials" as const,
+      provider: "openai-codex" as const,
+      id: "cccccccccccccccccccccccccccccccc",
+    };
+    const auth = {
+      version: 1,
+      profiles: {
+        [profileId]: {
+          type: "oauth",
+          provider: "openai-codex",
+          oauthRef: ref,
+        },
+      },
+    };
+    const authPath = await state.writeAuthProfiles(auth);
+    await state.writeJson(path.join("credentials", "auth-profiles", `${ref.id}.json`), {
+      version: 1,
+      profileId,
+      provider: "openai-codex",
+      encrypted: encryptLegacySidecarMaterial({
+        ref,
+        profileId,
+        provider: "openai-codex",
+        seed: "keychain-only-seed",
+        material: {
+          access: "access-token",
+          refresh: "refresh-token",
+        },
+      }),
+    });
+    const restoreVitest = withEnvValue("VITEST", undefined);
+    const restoreVitestWorker = withEnvValue("VITEST_WORKER_ID", undefined);
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    execFileSyncMock.mockReturnValueOnce("keychain-only-seed\n");
+    try {
+      const result = await maybeRepairLegacyOAuthSidecarProfiles({
+        cfg: {},
+        prompter: makePrompter(true),
+        now: () => 456,
+      });
+
+      expect(result.detected).toEqual([authPath]);
+      expect(result.changes).toStrictEqual([
+        `Migrated 1 sidecar-backed Codex OAuth profile in ${authPath} to inline credentials (backup: ${authPath}.oauth-ref.456.bak).`,
+      ]);
+      expect(result.warnings).toStrictEqual([]);
+      expect(execFileSyncMock).toHaveBeenCalledWith(
+        "security",
+        [
+          "find-generic-password",
+          "-s",
+          "OpenClaw Auth Profile Secrets",
+          "-a",
+          "oauth-profile-master-key",
+          "-w",
+        ],
+        { encoding: "utf8", timeout: 5000, stdio: ["pipe", "pipe", "pipe"] },
+      );
+      expect(JSON.parse(fs.readFileSync(authPath, "utf8"))).toEqual({
+        version: 1,
+        profiles: {
+          [profileId]: {
+            type: "oauth",
+            provider: "openai-codex",
+            access: "access-token",
+            refresh: "refresh-token",
+          },
+        },
+      });
+    } finally {
+      platformSpy.mockRestore();
+      restoreVitestWorker();
+      restoreVitest();
+    }
   });
 
   it("leaves unreferenced legacy sidecar files in place because external agent dirs may still reference them", async () => {

--- a/src/commands/doctor-auth-oauth-sidecar.ts
+++ b/src/commands/doctor-auth-oauth-sidecar.ts
@@ -328,11 +328,11 @@ function readLegacyOAuthSecretKeyFile(env: NodeJS.ProcessEnv): string | undefine
   }
 }
 
-function readLegacyMacOAuthSecretKeychainKey(): string | undefined {
+function readLegacyMacOAuthSecretKeychainKey(env: NodeJS.ProcessEnv): string | undefined {
   if (
     process.platform !== "darwin" ||
-    process.env.VITEST === "true" ||
-    process.env.VITEST_WORKER_ID !== undefined
+    env.VITEST === "true" ||
+    env.VITEST_WORKER_ID !== undefined
   ) {
     return undefined;
   }
@@ -423,7 +423,7 @@ function decryptLegacyOAuthSecretMaterial(params: {
       return material;
     }
   }
-  const keychainSeed = readLegacyMacOAuthSecretKeychainKey();
+  const keychainSeed = readLegacyMacOAuthSecretKeychainKey(params.env);
   if (keychainSeed && !seeds.includes(keychainSeed)) {
     return decryptLegacyOAuthSecretMaterialWithSeed(params, keychainSeed);
   }
@@ -481,6 +481,13 @@ function applyLegacyOAuthSidecarMaterial(params: {
     entry.idToken = params.material.idToken;
   }
   return true;
+}
+
+function formatUndecryptableLegacyOAuthSidecarWarning(
+  profile: LegacyOAuthSidecarProfile,
+  authPath: string,
+): string {
+  return `Could not decrypt legacy OAuth sidecar for ${profile.profileId} in ${shortenHomePath(authPath)}. Re-authenticate with ${formatCliCommand("openclaw models auth login --provider openai-codex")}.`;
 }
 
 function backupLegacyOAuthSidecarStore(authPath: string, now: () => number): string {
@@ -553,9 +560,7 @@ export async function maybeRepairLegacyOAuthSidecarProfiles(params: {
       const material = loadLegacyOAuthSidecarMaterial(profile, env);
       if (!material) {
         unresolvedRefIds.add(profile.ref.id);
-        result.warnings.push(
-          `Could not decrypt legacy OAuth sidecar for ${profile.profileId} in ${shortenHomePath(store.authPath)}; re-authenticate this profile.`,
-        );
+        result.warnings.push(formatUndecryptableLegacyOAuthSidecarWarning(profile, store.authPath));
         continue;
       }
       if (applyLegacyOAuthSidecarMaterial({ raw: store.raw, profile, material })) {


### PR DESCRIPTION
## Summary

- preserve the read-only macOS Keychain fallback for legacy Codex `oauthRef` sidecar decryption
- keep `openclaw doctor --fix` able to migrate Keychain-only legacy sidecars back to inline OAuth credentials
- keep the re-auth path explicit only when a legacy sidecar remains undecryptable

## Split notes

This is the Keychain compatibility slice split out of #81700 so that #81700 can stay focused on the OpenAI/Codex OAuth routing bug from #83223 and the #83345 stale-order path.

This PR does not reintroduce Keychain writes. It keeps the legacy read/import fallback only for existing sidecars that were encrypted with the old macOS Keychain seed, so affected upgraded users can still be migrated instead of being forced to re-authenticate.

Related: #81700
Related: #83223
Related: #83345
Follow-up to #83312

## Verification

- `node_modules/.bin/oxfmt --threads=1 CHANGELOG.md src/agents/auth-profiles/persisted-boundary.test.ts src/agents/auth-profiles/persisted.ts src/agents/auth-profiles/store.ts src/commands/doctor-auth-oauth-sidecar.ts src/commands/doctor-auth-oauth-sidecar.test.ts`: passed
- `git diff --check`: passed
- `node scripts/run-vitest.mjs src/agents/auth-profiles/persisted-boundary.test.ts src/commands/doctor-auth-oauth-sidecar.test.ts`: passed, 3 files / 14 tests
- Testbox-through-Crabbox `check:changed`: passed on `tbx_01krwse9x059nx8ne8am0ms9hp`, Actions run `https://github.com/openclaw/openclaw/actions/runs/26015619587`

## Real behavior proof

Behavior addressed: legacy Codex OAuth sidecar profiles that can only be decrypted with the existing macOS Keychain seed remain recoverable during read-only profile loading and during `openclaw doctor --fix` migration.

Real environment tested: local Codex worktree with mocked macOS `security find-generic-password` reads for the legacy Keychain seed, plus Blacksmith Testbox via Crabbox wrapper using the OpenClaw CI check workflow.

Exact steps or command run after this patch: `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --blacksmith-workflow ci-check-testbox.yml --blacksmith-job check --keep-on-failure --shell -- "git fetch origin +refs/heads/main:refs/remotes/origin/main +refs/heads/fix-codex-keychain-sidecar-recovery:refs/remotes/origin/fix-codex-keychain-sidecar-recovery && git checkout --force refs/remotes/origin/fix-codex-keychain-sidecar-recovery && git reset --hard HEAD && git status --short && git diff --name-only origin/main...HEAD | wc -l && pnpm --config.verify-deps-before-run=false check:changed"`.

Evidence after fix: the new runtime boundary test decrypts a Keychain-seeded legacy sidecar through the read-only fallback; the new doctor test migrates a Keychain-seeded sidecar back to inline OAuth material and removes the warning path. The Testbox run checked out #83451 head `b4e325571ca`, confirmed a 6-file branch diff, and completed `check:changed` successfully.

Observed result after fix: legacy sidecar recovery succeeds when env/file seeds are insufficient but the old Keychain seed exists; undecryptable sidecars now tell users to re-authenticate with `openclaw models auth login --provider openai-codex`.

What was not tested: a live macOS user Keychain prompt against a real installed profile; the regression proof uses a mocked `security` command to avoid touching local credentials.
