### PR TITLE
test: cover gateway exec approval runtime flow

### DIFF
--- a/src/agents/bash-tools.exec-gateway-approval.e2e.test.ts
+++ b/src/agents/bash-tools.exec-gateway-approval.e2e.test.ts
@@ -1,0 +1,171 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { clearConfigCache, clearRuntimeConfigSnapshot } from "../config/config.js";
+import { clearSessionStoreCacheForTest } from "../config/sessions/store.js";
+import { ADMIN_SCOPE } from "../gateway/method-scopes.js";
+import { startGatewayServer } from "../gateway/server.js";
+import {
+  connectGatewayClient,
+  disconnectGatewayClient,
+  getFreeGatewayPort,
+} from "../gateway/test-helpers.e2e.js";
+import { captureEnv } from "../test-utils/env.js";
+import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
+import type { ExecApprovalFollowupOutcome } from "./bash-tools.exec-types.js";
+import { createExecTool } from "./bash-tools.exec.js";
+
+const TEST_ENV_KEYS = [
+  "HOME",
+  "OPENCLAW_STATE_DIR",
+  "OPENCLAW_CONFIG_PATH",
+  "OPENCLAW_GATEWAY_TOKEN",
+  "OPENCLAW_GATEWAY_PORT",
+  "OPENCLAW_SKIP_CHANNELS",
+  "OPENCLAW_SKIP_GMAIL_WATCHER",
+  "OPENCLAW_SKIP_CRON",
+  "OPENCLAW_SKIP_CANVAS_HOST",
+  "OPENCLAW_SKIP_BROWSER_CONTROL_SERVER",
+  "OPENCLAW_SKIP_PROVIDERS",
+] as const;
+
+type Cleanup = () => Promise<void> | void;
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  let timeout: NodeJS.Timeout | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => reject(new Error(`timed out waiting for ${label}`)), timeoutMs);
+    timeout.unref();
+  });
+  try {
+    return await Promise.race([promise, timeoutPromise]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}
+
+describe("gateway-hosted exec approvals", () => {
+  const cleanup: Cleanup[] = [];
+
+  afterEach(async () => {
+    for (const step of cleanup.splice(0).toReversed()) {
+      await step();
+    }
+    clearRuntimeConfigSnapshot();
+    clearConfigCache();
+    clearSessionStoreCacheForTest();
+  });
+
+  it("lets PI-style gateway tool calls request and wait for approval over separate connections", async () => {
+    const envSnapshot = captureEnv(TEST_ENV_KEYS);
+    cleanup.push(() => envSnapshot.restore());
+
+    const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-exec-approval-e2e-"));
+    cleanup.push(() => fs.rm(tempHome, { recursive: true, force: true, maxRetries: 5 }));
+
+    const stateDir = path.join(tempHome, ".openclaw");
+    const workspaceDir = path.join(tempHome, "workspace");
+    await fs.mkdir(workspaceDir, { recursive: true });
+
+    const port = await getFreeGatewayPort();
+    const token = "exec-approval-e2e-token";
+    const configPath = path.join(stateDir, "openclaw.json");
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      `${JSON.stringify(
+        {
+          gateway: {
+            port,
+            auth: { mode: "token", token },
+          },
+          tools: {
+            exec: {
+              host: "gateway",
+              security: "allowlist",
+              ask: "always",
+            },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+      "utf8",
+    );
+
+    process.env.HOME = tempHome;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    process.env.OPENCLAW_CONFIG_PATH = configPath;
+    process.env.OPENCLAW_GATEWAY_TOKEN = token;
+    process.env.OPENCLAW_GATEWAY_PORT = String(port);
+    process.env.OPENCLAW_SKIP_CHANNELS = "1";
+    process.env.OPENCLAW_SKIP_GMAIL_WATCHER = "1";
+    process.env.OPENCLAW_SKIP_CRON = "1";
+    process.env.OPENCLAW_SKIP_CANVAS_HOST = "1";
+    process.env.OPENCLAW_SKIP_BROWSER_CONTROL_SERVER = "1";
+    process.env.OPENCLAW_SKIP_PROVIDERS = "1";
+    clearRuntimeConfigSnapshot();
+    clearConfigCache();
+    clearSessionStoreCacheForTest();
+
+    const server = await startGatewayServer(port, {
+      bind: "loopback",
+      auth: { mode: "token", token },
+      controlUiEnabled: false,
+    });
+    cleanup.push(() => server.close());
+
+    const operator = await connectGatewayClient({
+      url: `ws://127.0.0.1:${port}`,
+      token,
+      clientName: GATEWAY_CLIENT_NAMES.TEST,
+      clientDisplayName: "approval operator",
+      mode: GATEWAY_CLIENT_MODES.TEST,
+      scopes: [ADMIN_SCOPE],
+    });
+    cleanup.push(() => disconnectGatewayClient(operator));
+
+    let resolveOutcome: (outcome: ExecApprovalFollowupOutcome) => void = () => {};
+    const outcomePromise = new Promise<ExecApprovalFollowupOutcome>((resolve) => {
+      resolveOutcome = resolve;
+    });
+
+    const tool = createExecTool({
+      host: "gateway",
+      security: "allowlist",
+      ask: "always",
+      cwd: workspaceDir,
+      approvalRunningNoticeMs: 0,
+      approvalFollowupMode: "direct",
+      approvalFollowup: ({ outcome }) => {
+        resolveOutcome(outcome);
+        return undefined;
+      },
+    });
+
+    const pending = await tool.execute("exec-approval-e2e", {
+      command: "printf 'smoke\\n'",
+      workdir: workspaceDir,
+      timeout: 5,
+    });
+
+    expect(pending.details.status).toBe("approval-pending");
+    if (pending.details.status !== "approval-pending") {
+      throw new Error("expected approval-pending exec result");
+    }
+
+    await operator.request(
+      "exec.approval.resolve",
+      { id: pending.details.approvalId, decision: "allow-once" },
+      { timeoutMs: 10_000 },
+    );
+
+    const outcome = await withTimeout(outcomePromise, 15_000, "approved exec outcome");
+    expect(outcome.status).toBe("completed");
+    expect(outcome.exitCode).toBe(0);
+    expect(outcome.aggregated).toBe("smoke");
+  });
+});

--- a/src/agents/bash-tools.exec-gateway-approval.e2e.test.ts
+++ b/src/agents/bash-tools.exec-gateway-approval.e2e.test.ts
@@ -28,7 +28,7 @@ const TEST_ENV_KEYS = [
   "OPENCLAW_SKIP_CANVAS_HOST",
   "OPENCLAW_SKIP_BROWSER_CONTROL_SERVER",
   "OPENCLAW_SKIP_PROVIDERS",
-] as const;
+];
 
 type Cleanup = () => Promise<void> | void;
 


### PR DESCRIPTION
## Summary
- Add an E2E regression test for gateway-hosted exec approvals.
- Covers the PI-style runtime path where approval request/wait calls use short-lived Gateway connections and a separate operator client resolves the approval.
- Asserts the approved command completes with `smoke`.

## Real behavior proof
- **Behavior addressed:** Gateway-hosted exec approvals should continue after the operator approves, even when the PI/runtime approval request and waitDecision calls use separate short-lived Gateway connections.
- **Real environment tested:** Local disposable OpenClaw PR-test setup on macOS, running OpenClaw PR #83433 build `2026.5.17 (65ad33e)` with PI runtime, Gateway-hosted exec approvals, and a real Gateway on `127.0.0.1:18789`.
- **Exact steps or command run after this patch:** Started the disposable PR setup with `openclaw-pr-test pr 83433`, configured `tools.exec.host=gateway`, `tools.exec.security=allowlist`, `tools.exec.ask=on-miss`, sent the exact prompt asking the agent to run `printf 'smoke\n'`, resolved the resulting approval with `allow-once`, then restored the personal gateway with `openclaw-pr-test restore`.
- **Evidence after fix:** Copied live output / redacted runtime log excerpt from the real local Gateway run:

```text
connected sessionKey=agent:main:dashboard:repro-83433-1779080650138
chat.send ok=true payload={"runId":"52905525-e34e-441f-a7ef-48c97defa947","status":"started"}
EVENT approval requested id=a7ce171b-ce68-4131-943c-d3741c52c879 command=printf 'smoke\n'
approval.resolve ok=true payload={"ok":true} error=null
2026-05-17T22:04:43.456-07:00 [ws] ⇄ res ✓ exec.approval.waitDecision 429ms conn=a3aa8093…3d72 id=1ce25afc…dfc0
2026-05-17T22:04:49.214-07:00 smoke
RESULT PASS approvalId=a7ce171b-ce68-4131-943c-d3741c52c879 sessionKey=agent:main:dashboard:repro-83433-1779080650138
```

- **Observed result after fix:** The approval prompt appeared, `allow-once` was accepted, `exec.approval.waitDecision` returned successfully, and the approved command completed with stdout `smoke` instead of timing out / reporting `approval expired or not found`.
- **What was not tested:** No additional gaps for this regression guard; the PR itself adds automated coverage for the same approval lifecycle.

## Test plan
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/agents/bash-tools.exec-gateway-approval.e2e.test.ts`
