### PR TITLE
fix(qa): report rtt and gateway memory metrics

### DIFF
--- a/extensions/qa-lab/src/gateway-child.ts
+++ b/extensions/qa-lab/src/gateway-child.ts
@@ -937,6 +937,12 @@ export async function startQaGatewayChild(params: {
       configPath,
       runtimeEnv: runningEnv,
       logs,
+      signalProcess(signal: NodeJS.Signals) {
+        if (!activeChild.pid) {
+          throw new Error("qa gateway child has no pid");
+        }
+        process.kill(activeChild.pid, signal);
+      },
       async restart(signal: NodeJS.Signals = "SIGUSR1") {
         if (!activeChild.pid) {
           throw new Error("qa gateway child has no pid");

--- a/extensions/qa-lab/src/live-transports/discord/discord-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/discord/discord-live.runtime.test.ts
@@ -278,6 +278,16 @@ describe("discord live qa runtime", () => {
     ).toBe(false);
   });
 
+  it("computes Discord RTT from trigger and reply timestamps", () => {
+    expect(
+      __testing.computeDiscordRttMs(
+        "2026-04-22T11:59:59.125Z",
+        "2026-04-22T12:00:00.875Z",
+      ),
+    ).toBe(1750);
+    expect(__testing.computeDiscordRttMs("bad", "2026-04-22T12:00:00.875Z")).toBeUndefined();
+  });
+
   it("includes the Discord live scenarios", () => {
     expect(__testing.findScenario().map((scenario) => scenario.id)).toEqual([
       "discord-canary",

--- a/extensions/qa-lab/src/live-transports/discord/discord-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/discord/discord-live.runtime.test.ts
@@ -693,4 +693,39 @@ describe("discord live qa runtime", () => {
       },
     ]);
   });
+
+  it("preserves observed message timing when metadata is redacted", () => {
+    expect(
+      __testing.buildObservedMessagesArtifact({
+        includeContent: false,
+        redactMetadata: true,
+        observedMessages: [
+          {
+            messageId: "523456789012345678",
+            channelId: "223456789012345678",
+            guildId: "123456789012345678",
+            senderId: "323456789012345678",
+            senderIsBot: true,
+            senderUsername: "sut",
+            scenarioId: "canary",
+            scenarioTitle: "Canary",
+            matchedScenario: true,
+            text: "secret text",
+            triggerMessageId: "423456789012345678",
+            triggerTimestamp: "2026-04-22T11:59:59.000Z",
+            timestamp: "2026-04-22T12:00:00.000Z",
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        senderIsBot: true,
+        scenarioId: "canary",
+        scenarioTitle: "Canary",
+        matchedScenario: true,
+        triggerTimestamp: "2026-04-22T11:59:59.000Z",
+        timestamp: "2026-04-22T12:00:00.000Z",
+      },
+    ]);
+  });
 });

--- a/extensions/qa-lab/src/live-transports/discord/discord-live.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/discord/discord-live.runtime.ts
@@ -1422,6 +1422,8 @@ function buildObservedMessagesArtifact(params: {
       ? {
           ...scenarioContext,
           senderIsBot: message.senderIsBot,
+          triggerTimestamp: message.triggerTimestamp,
+          timestamp: message.timestamp,
         }
       : {
           ...scenarioContext,

--- a/extensions/qa-lab/src/live-transports/discord/discord-live.runtime.ts
+++ b/extensions/qa-lab/src/live-transports/discord/discord-live.runtime.ts
@@ -181,6 +181,7 @@ type DiscordQaScenarioResult = {
   title: string;
   status: "pass" | "fail";
   details: string;
+  rttMs?: number;
 };
 
 type DiscordQaRunResult = {
@@ -762,6 +763,18 @@ function normalizeDiscordReactionSnapshot(params: {
       .filter((reaction) => reaction.emoji.length > 0)
       .toSorted((a, b) => a.emoji.localeCompare(b.emoji)),
   };
+}
+
+function computeDiscordRttMs(triggerTimestamp?: string, replyTimestamp?: string) {
+  if (!triggerTimestamp || !replyTimestamp) {
+    return undefined;
+  }
+  const triggerAtMs = Date.parse(triggerTimestamp);
+  const replyAtMs = Date.parse(replyTimestamp);
+  if (!Number.isFinite(triggerAtMs) || !Number.isFinite(replyAtMs)) {
+    return undefined;
+  }
+  return Math.max(0, Math.round(replyAtMs - triggerAtMs));
 }
 
 function collectSeenReactionSequence(
@@ -1766,6 +1779,7 @@ export async function runDiscordQaLive(params: {
             expectedTextIncludes: scenarioRun.expectedTextIncludes,
             message: matched.message,
           });
+          const rttMs = computeDiscordRttMs(sent.timestamp, matched.message.timestamp);
           scenarioResults.push({
             id: scenario.id,
             title: scenario.title,
@@ -1773,6 +1787,7 @@ export async function runDiscordQaLive(params: {
             details: redactPublicMetadata
               ? "reply matched"
               : `reply message ${matched.message.messageId} matched`,
+            ...(rttMs === undefined ? {} : { rttMs }),
           });
         } catch (error) {
           if (scenarioRun.kind === "channel-message" && !scenarioRun.expectReply) {
@@ -1931,6 +1946,7 @@ export const __testing = {
   buildDiscordQaConfig,
   buildDiscordWebMessageUrl,
   buildObservedMessagesArtifact,
+  computeDiscordRttMs,
   findScenario,
   getCurrentDiscordUser,
   getChannelMessage,

--- a/extensions/qa-lab/src/suite-summary.ts
+++ b/extensions/qa-lab/src/suite-summary.ts
@@ -23,6 +23,13 @@ export type QaSuiteSummaryJson = {
     gatewayProcessRssStartBytes?: number | null;
     gatewayProcessRssEndBytes?: number | null;
     gatewayProcessRssDeltaBytes?: number | null;
+    gatewayProcessRssPeakBytes?: number | null;
+    gatewayProcessRssPeakDeltaBytes?: number | null;
+    gatewayProcessRssSamples?: Array<{
+      label: string;
+      at: string;
+      gatewayProcessRssBytes: number;
+    }>;
   };
   run: {
     startedAt: string;

--- a/extensions/qa-lab/src/suite-summary.ts
+++ b/extensions/qa-lab/src/suite-summary.ts
@@ -30,6 +30,12 @@ export type QaSuiteSummaryJson = {
       at: string;
       gatewayProcessRssBytes: number;
     }>;
+    gatewayHeapSnapshots?: Array<{
+      label: string;
+      at: string;
+      path: string;
+      bytes: number;
+    }>;
   };
   run: {
     startedAt: string;

--- a/extensions/qa-lab/src/suite.summary-json.test.ts
+++ b/extensions/qa-lab/src/suite.summary-json.test.ts
@@ -156,6 +156,20 @@ describe("buildQaSuiteSummaryJson", () => {
         gatewayProcessRssStartBytes: 100_000_000,
         gatewayProcessRssEndBytes: 125_000_000,
         gatewayProcessRssDeltaBytes: 25_000_000,
+        gatewayProcessRssPeakBytes: 140_000_000,
+        gatewayProcessRssPeakDeltaBytes: 40_000_000,
+        gatewayProcessRssSamples: [
+          {
+            label: "suite-start",
+            at: "2026-04-22T12:00:00.000Z",
+            gatewayProcessRssBytes: 100_000_000,
+          },
+          {
+            label: "scenario:canary:finish",
+            at: "2026-04-22T12:00:10.000Z",
+            gatewayProcessRssBytes: 140_000_000,
+          },
+        ],
       },
     });
     expect(json.metrics).toEqual({
@@ -165,6 +179,20 @@ describe("buildQaSuiteSummaryJson", () => {
       gatewayProcessRssStartBytes: 100_000_000,
       gatewayProcessRssEndBytes: 125_000_000,
       gatewayProcessRssDeltaBytes: 25_000_000,
+      gatewayProcessRssPeakBytes: 140_000_000,
+      gatewayProcessRssPeakDeltaBytes: 40_000_000,
+      gatewayProcessRssSamples: [
+        {
+          label: "suite-start",
+          at: "2026-04-22T12:00:00.000Z",
+          gatewayProcessRssBytes: 100_000_000,
+        },
+        {
+          label: "scenario:canary:finish",
+          at: "2026-04-22T12:00:10.000Z",
+          gatewayProcessRssBytes: 140_000_000,
+        },
+      ],
     });
   });
 });

--- a/extensions/qa-lab/src/suite.summary-json.test.ts
+++ b/extensions/qa-lab/src/suite.summary-json.test.ts
@@ -170,6 +170,14 @@ describe("buildQaSuiteSummaryJson", () => {
             gatewayProcessRssBytes: 140_000_000,
           },
         ],
+        gatewayHeapSnapshots: [
+          {
+            label: "suite-start",
+            at: "2026-04-22T12:00:01.000Z",
+            path: "artifacts/gateway-heap-snapshots/suite-start.heapsnapshot",
+            bytes: 12_345,
+          },
+        ],
       },
     });
     expect(json.metrics).toEqual({
@@ -191,6 +199,14 @@ describe("buildQaSuiteSummaryJson", () => {
           label: "scenario:canary:finish",
           at: "2026-04-22T12:00:10.000Z",
           gatewayProcessRssBytes: 140_000_000,
+        },
+      ],
+      gatewayHeapSnapshots: [
+        {
+          label: "suite-start",
+          at: "2026-04-22T12:00:01.000Z",
+          path: "artifacts/gateway-heap-snapshots/suite-start.heapsnapshot",
+          bytes: 12_345,
         },
       ],
     });

--- a/extensions/qa-lab/src/suite.test.ts
+++ b/extensions/qa-lab/src/suite.test.ts
@@ -137,6 +137,52 @@ describe("qa suite", () => {
     expect(qaSuiteProgressTesting.sanitizeQaSuiteProgressValue("\u0000\u0001")).toBe("<empty>");
   });
 
+  it("records gateway RSS peak and trace samples", () => {
+    expect(
+      qaSuiteProgressTesting.buildQaSuiteRuntimeMetrics({
+        startedAt: new Date("2026-04-22T12:00:00.000Z"),
+        finishedAt: new Date("2026-04-22T12:00:12.000Z"),
+        gatewayProcessCpuStartMs: 1_000,
+        gatewayProcessCpuEndMs: 4_000,
+        gatewayProcessRssStartBytes: 100_000_000,
+        gatewayProcessRssEndBytes: 125_000_000,
+        gatewayProcessRssSamples: [
+          {
+            label: "suite-start",
+            at: "2026-04-22T12:00:00.000Z",
+            gatewayProcessRssBytes: 100_000_000,
+          },
+          {
+            label: "scenario:canary:finish",
+            at: "2026-04-22T12:00:10.000Z",
+            gatewayProcessRssBytes: 140_000_000,
+          },
+        ],
+      }),
+    ).toEqual({
+      wallMs: 12_000,
+      gatewayProcessCpuMs: 3_000,
+      gatewayCpuCoreRatio: 0.25,
+      gatewayProcessRssStartBytes: 100_000_000,
+      gatewayProcessRssEndBytes: 125_000_000,
+      gatewayProcessRssDeltaBytes: 25_000_000,
+      gatewayProcessRssPeakBytes: 140_000_000,
+      gatewayProcessRssPeakDeltaBytes: 40_000_000,
+      gatewayProcessRssSamples: [
+        {
+          label: "suite-start",
+          at: "2026-04-22T12:00:00.000Z",
+          gatewayProcessRssBytes: 100_000_000,
+        },
+        {
+          label: "scenario:canary:finish",
+          at: "2026-04-22T12:00:10.000Z",
+          gatewayProcessRssBytes: 140_000_000,
+        },
+      ],
+    });
+  });
+
   it("builds a codex mock runtime env patch that stays on the QA mock provider", () => {
     expect(
       qaSuiteProgressTesting.buildQaRuntimeEnvPatch({

--- a/extensions/qa-lab/src/suite.test.ts
+++ b/extensions/qa-lab/src/suite.test.ts
@@ -158,6 +158,14 @@ describe("qa suite", () => {
             gatewayProcessRssBytes: 140_000_000,
           },
         ],
+        gatewayHeapSnapshots: [
+          {
+            label: "suite-start",
+            at: "2026-04-22T12:00:01.000Z",
+            path: "artifacts/gateway-heap-snapshots/suite-start.heapsnapshot",
+            bytes: 12_345,
+          },
+        ],
       }),
     ).toEqual({
       wallMs: 12_000,
@@ -180,6 +188,39 @@ describe("qa suite", () => {
           gatewayProcessRssBytes: 140_000_000,
         },
       ],
+      gatewayHeapSnapshots: [
+        {
+          label: "suite-start",
+          at: "2026-04-22T12:00:01.000Z",
+          path: "artifacts/gateway-heap-snapshots/suite-start.heapsnapshot",
+          bytes: 12_345,
+        },
+      ],
+    });
+  });
+
+  it("arms gateway heap checkpoint env only when requested", () => {
+    expect(
+      qaSuiteProgressTesting.buildQaGatewayHeapCheckpointRuntimeEnvPatch({
+        OPENCLAW_QA_GATEWAY_HEAP_CHECKPOINTS: "0",
+      }),
+    ).toBeUndefined();
+    expect(
+      qaSuiteProgressTesting.buildQaGatewayHeapCheckpointRuntimeEnvPatch({
+        OPENCLAW_QA_GATEWAY_HEAP_CHECKPOINTS: "1",
+        NODE_OPTIONS: "--max-old-space-size=4096",
+      }),
+    ).toEqual({
+      NODE_OPTIONS: "--max-old-space-size=4096 --heapsnapshot-signal=SIGUSR2",
+    });
+    expect(
+      qaSuiteProgressTesting.mergeQaRuntimeEnvPatches(
+        { OPENAI_API_KEY: "mock" },
+        { NODE_OPTIONS: "--heapsnapshot-signal=SIGUSR2" },
+      ),
+    ).toEqual({
+      OPENAI_API_KEY: "mock",
+      NODE_OPTIONS: "--heapsnapshot-signal=SIGUSR2",
     });
   });
 

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -450,6 +450,10 @@ export type QaSuiteSummaryJsonParams = {
  */
 export type { QaSuiteSummaryJson } from "./suite-summary.js";
 
+type QaSuiteGatewayRssSample = NonNullable<
+  NonNullable<QaSuiteSummaryJson["metrics"]>["gatewayProcessRssSamples"]
+>[number];
+
 /**
  * Pure-ish JSON builder for qa-suite-summary.json. Exported so the GPT-5.5
  * parity gate (agentic-parity-report.ts, #64441) and any future parity
@@ -762,8 +766,16 @@ function buildQaSuiteRuntimeMetrics(params: {
   gatewayProcessCpuEndMs: number | null;
   gatewayProcessRssStartBytes: number | null;
   gatewayProcessRssEndBytes: number | null;
+  gatewayProcessRssSamples?: QaSuiteGatewayRssSample[];
 }): QaSuiteSummaryJson["metrics"] {
   const wallMs = Math.max(1, params.finishedAt.getTime() - params.startedAt.getTime());
+  const gatewayProcessRssSamples = params.gatewayProcessRssSamples ?? [];
+  const gatewayProcessRssPeakBytes =
+    gatewayProcessRssSamples.length > 0
+      ? Math.max(...gatewayProcessRssSamples.map((sample) => sample.gatewayProcessRssBytes))
+      : params.gatewayProcessRssStartBytes === null || params.gatewayProcessRssEndBytes === null
+        ? null
+        : Math.max(params.gatewayProcessRssStartBytes, params.gatewayProcessRssEndBytes);
   const rssMetrics =
     params.gatewayProcessRssStartBytes === null || params.gatewayProcessRssEndBytes === null
       ? {}
@@ -772,6 +784,16 @@ function buildQaSuiteRuntimeMetrics(params: {
           gatewayProcessRssEndBytes: params.gatewayProcessRssEndBytes,
           gatewayProcessRssDeltaBytes:
             params.gatewayProcessRssEndBytes - params.gatewayProcessRssStartBytes,
+          ...(gatewayProcessRssPeakBytes === null
+            ? {}
+            : {
+                gatewayProcessRssPeakBytes,
+                gatewayProcessRssPeakDeltaBytes:
+                  gatewayProcessRssPeakBytes - params.gatewayProcessRssStartBytes,
+              }),
+          ...(gatewayProcessRssSamples.length === 0
+            ? {}
+            : { gatewayProcessRssSamples }),
         };
   if (params.gatewayProcessCpuStartMs === null || params.gatewayProcessCpuEndMs === null) {
     return { wallMs, ...rssMetrics };
@@ -1196,14 +1218,27 @@ export async function runQaSuite(params?: QaSuiteRunParams): Promise<QaSuiteResu
       scenarios: liveScenarioOutcomes,
     });
 
+    const gatewayProcessRssSamples: QaSuiteGatewayRssSample[] = [];
+    const sampleGatewayProcessRss = (label: string) => {
+      const gatewayProcessRssBytes = gateway.getProcessRssBytes?.() ?? null;
+      if (gatewayProcessRssBytes !== null) {
+        gatewayProcessRssSamples.push({
+          label,
+          at: new Date().toISOString(),
+          gatewayProcessRssBytes,
+        });
+      }
+      return gatewayProcessRssBytes;
+    };
     const gatewayProcessCpuStartMs = gateway.getProcessCpuMs?.() ?? null;
-    const gatewayProcessRssStartBytes = gateway.getProcessRssBytes?.() ?? null;
+    const gatewayProcessRssStartBytes = sampleGatewayProcessRss("suite-start");
     for (const [index, scenario] of selectedCatalogScenarios.entries()) {
       const scenarioIdForLog = sanitizeQaSuiteProgressValue(scenario.id);
       writeQaSuiteProgress(
         progressEnabled,
         `scenario start (${index + 1}/${selectedCatalogScenarios.length}): ${scenarioIdForLog}`,
       );
+      sampleGatewayProcessRss(`scenario:${scenario.id}:start`);
       liveScenarioOutcomes[index] = {
         id: scenario.id,
         name: scenario.title,
@@ -1218,6 +1253,7 @@ export async function runQaSuite(params?: QaSuiteRunParams): Promise<QaSuiteResu
       });
 
       const result = await runScenarioDefinition(env, scenario);
+      sampleGatewayProcessRss(`scenario:${scenario.id}:finish`);
       scenarios.push(result);
       writeQaSuiteProgress(
         progressEnabled,
@@ -1260,7 +1296,8 @@ export async function runQaSuite(params?: QaSuiteRunParams): Promise<QaSuiteResu
       gatewayProcessCpuStartMs,
       gatewayProcessCpuEndMs: gateway.getProcessCpuMs?.() ?? null,
       gatewayProcessRssStartBytes,
-      gatewayProcessRssEndBytes: gateway.getProcessRssBytes?.() ?? null,
+      gatewayProcessRssEndBytes: sampleGatewayProcessRss("suite-finish"),
+      gatewayProcessRssSamples,
     });
     const failedCount = scenarios.filter((scenario) => scenario.status === "fail").length;
     if (scenarios.some((scenario) => scenario.status === "fail")) {
@@ -1336,6 +1373,7 @@ export async function runQaSuite(params?: QaSuiteRunParams): Promise<QaSuiteResu
 }
 
 export const qaSuiteProgressTesting = {
+  buildQaSuiteRuntimeMetrics,
   buildQaRuntimeEnvPatch,
   parseQaSuiteBooleanEnv,
   remapModelRefForForcedRuntime,

--- a/extensions/qa-lab/src/suite.ts
+++ b/extensions/qa-lab/src/suite.ts
@@ -428,6 +428,39 @@ function buildQaRuntimeEnvPatch(params: {
   return patch;
 }
 
+function appendNodeOption(raw: string | undefined, option: string) {
+  const parts = (raw ?? "").split(/\s+/u).filter(Boolean);
+  return parts.includes(option) ? parts.join(" ") : [...parts, option].join(" ");
+}
+
+function shouldCaptureGatewayHeapCheckpoints(env: NodeJS.ProcessEnv = process.env) {
+  return parseQaSuiteBooleanEnv(env.OPENCLAW_QA_GATEWAY_HEAP_CHECKPOINTS) === true;
+}
+
+function buildQaGatewayHeapCheckpointRuntimeEnvPatch(
+  env: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv | undefined {
+  if (!shouldCaptureGatewayHeapCheckpoints(env)) {
+    return undefined;
+  }
+  return {
+    NODE_OPTIONS: appendNodeOption(env.NODE_OPTIONS, "--heapsnapshot-signal=SIGUSR2"),
+  };
+}
+
+function mergeQaRuntimeEnvPatches(
+  ...patches: Array<NodeJS.ProcessEnv | undefined>
+): NodeJS.ProcessEnv | undefined {
+  const merged: NodeJS.ProcessEnv = {};
+  for (const patch of patches) {
+    if (!patch) {
+      continue;
+    }
+    Object.assign(merged, patch);
+  }
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
 export type QaSuiteSummaryJsonParams = {
   scenarios: QaSuiteScenarioResult[];
   startedAt: Date;
@@ -452,6 +485,11 @@ export type { QaSuiteSummaryJson } from "./suite-summary.js";
 
 type QaSuiteGatewayRssSample = NonNullable<
   NonNullable<QaSuiteSummaryJson["metrics"]>["gatewayProcessRssSamples"]
+>[number];
+
+type QaGatewayHandle = Awaited<ReturnType<typeof startQaGatewayChild>>;
+type QaSuiteGatewayHeapSnapshot = NonNullable<
+  NonNullable<QaSuiteSummaryJson["metrics"]>["gatewayHeapSnapshots"]
 >[number];
 
 /**
@@ -767,18 +805,22 @@ function buildQaSuiteRuntimeMetrics(params: {
   gatewayProcessRssStartBytes: number | null;
   gatewayProcessRssEndBytes: number | null;
   gatewayProcessRssSamples?: QaSuiteGatewayRssSample[];
+  gatewayHeapSnapshots?: QaSuiteGatewayHeapSnapshot[];
 }): QaSuiteSummaryJson["metrics"] {
   const wallMs = Math.max(1, params.finishedAt.getTime() - params.startedAt.getTime());
   const gatewayProcessRssSamples = params.gatewayProcessRssSamples ?? [];
+  const gatewayHeapSnapshots = params.gatewayHeapSnapshots ?? [];
   const gatewayProcessRssPeakBytes =
     gatewayProcessRssSamples.length > 0
       ? Math.max(...gatewayProcessRssSamples.map((sample) => sample.gatewayProcessRssBytes))
       : params.gatewayProcessRssStartBytes === null || params.gatewayProcessRssEndBytes === null
         ? null
         : Math.max(params.gatewayProcessRssStartBytes, params.gatewayProcessRssEndBytes);
+  const gatewayHeapSnapshotMetrics =
+    gatewayHeapSnapshots.length === 0 ? {} : { gatewayHeapSnapshots };
   const rssMetrics =
     params.gatewayProcessRssStartBytes === null || params.gatewayProcessRssEndBytes === null
-      ? {}
+      ? gatewayHeapSnapshotMetrics
       : {
           gatewayProcessRssStartBytes: params.gatewayProcessRssStartBytes,
           gatewayProcessRssEndBytes: params.gatewayProcessRssEndBytes,
@@ -791,9 +833,8 @@ function buildQaSuiteRuntimeMetrics(params: {
                 gatewayProcessRssPeakDeltaBytes:
                   gatewayProcessRssPeakBytes - params.gatewayProcessRssStartBytes,
               }),
-          ...(gatewayProcessRssSamples.length === 0
-            ? {}
-            : { gatewayProcessRssSamples }),
+          ...(gatewayProcessRssSamples.length === 0 ? {} : { gatewayProcessRssSamples }),
+          ...gatewayHeapSnapshotMetrics,
         };
   if (params.gatewayProcessCpuStartMs === null || params.gatewayProcessCpuEndMs === null) {
     return { wallMs, ...rssMetrics };
@@ -807,6 +848,81 @@ function buildQaSuiteRuntimeMetrics(params: {
     gatewayProcessCpuMs,
     gatewayCpuCoreRatio: Math.round((gatewayProcessCpuMs / wallMs) * 1000) / 1000,
     ...rssMetrics,
+  };
+}
+
+function sanitizeQaHeapCheckpointLabel(label: string) {
+  return label.replace(/[^a-zA-Z0-9._-]+/gu, "-").replace(/^-+|-+$/gu, "") || "checkpoint";
+}
+
+async function listGatewayHeapSnapshotFiles(tempRoot: string) {
+  const entries = await fs.readdir(tempRoot, { withFileTypes: true }).catch(() => []);
+  const files = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".heapsnapshot")) {
+      continue;
+    }
+    const pathName = path.join(tempRoot, entry.name);
+    const stats = await fs.stat(pathName).catch(() => null);
+    if (stats) {
+      files.push({ pathName, mtimeMs: stats.mtimeMs, size: stats.size });
+    }
+  }
+  return files.toSorted((left, right) => left.mtimeMs - right.mtimeMs);
+}
+
+async function waitForStableFileSize(pathName: string) {
+  let lastSize = -1;
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    const stats = await fs.stat(pathName).catch(() => null);
+    if (stats && stats.size > 0 && stats.size === lastSize) {
+      return stats.size;
+    }
+    lastSize = stats?.size ?? -1;
+    await sleep(250);
+  }
+  const stats = await fs.stat(pathName);
+  return stats.size;
+}
+
+async function captureGatewayHeapSnapshotCheckpoint(params: {
+  gateway: QaGatewayHandle;
+  outputDir: string;
+  label: string;
+}): Promise<QaSuiteGatewayHeapSnapshot | undefined> {
+  const before = new Set(
+    (await listGatewayHeapSnapshotFiles(params.gateway.tempRoot)).map((file) => file.pathName),
+  );
+  params.gateway.signalProcess("SIGUSR2");
+  let snapshotPath: string | undefined;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    const next = (await listGatewayHeapSnapshotFiles(params.gateway.tempRoot)).filter(
+      (file) => !before.has(file.pathName),
+    );
+    snapshotPath = next.at(-1)?.pathName;
+    if (snapshotPath) {
+      break;
+    }
+    await sleep(250);
+  }
+  if (!snapshotPath) {
+    return undefined;
+  }
+
+  const bytes = await waitForStableFileSize(snapshotPath);
+  const snapshotsDir = path.join(params.outputDir, "artifacts", "gateway-heap-snapshots");
+  await fs.mkdir(snapshotsDir, { recursive: true });
+  const relativePath = path.join(
+    "artifacts",
+    "gateway-heap-snapshots",
+    `${sanitizeQaHeapCheckpointLabel(params.label)}.heapsnapshot`,
+  );
+  await fs.copyFile(snapshotPath, path.join(params.outputDir, relativePath));
+  return {
+    label: params.label,
+    at: new Date().toISOString(),
+    path: relativePath,
+    bytes,
   };
 }
 
@@ -853,6 +969,7 @@ export async function runQaSuite(params?: QaSuiteRunParams): Promise<QaSuiteResu
     defaultQaSuiteConcurrencyForTransport(transportId),
   );
   const progressEnabled = shouldLogQaSuiteProgress();
+  const gatewayHeapCheckpointsEnabled = shouldCaptureGatewayHeapCheckpoints();
   writeQaSuiteProgress(
     progressEnabled,
     `run start: scenarios=${selectedCatalogScenarios.length} concurrency=${concurrency} transport=${transportId}`,
@@ -1160,11 +1277,14 @@ export async function runQaSuite(params?: QaSuiteRunParams): Promise<QaSuiteResu
     mutateConfig: gatewayConfigPatch
       ? (cfg) => applyQaMergePatch(cfg, gatewayConfigPatch) as OpenClawConfig
       : undefined,
-    runtimeEnvPatch: buildQaRuntimeEnvPatch({
-      providerMode,
-      forcedRuntime: params?.forcedRuntime,
-      mockBaseUrl: mock?.baseUrl,
-    }),
+    runtimeEnvPatch: mergeQaRuntimeEnvPatches(
+      buildQaRuntimeEnvPatch({
+        providerMode,
+        forcedRuntime: params?.forcedRuntime,
+        mockBaseUrl: mock?.baseUrl,
+      }),
+      buildQaGatewayHeapCheckpointRuntimeEnvPatch(),
+    ),
   });
   writeQaSuiteProgress(
     progressEnabled,
@@ -1232,6 +1352,21 @@ export async function runQaSuite(params?: QaSuiteRunParams): Promise<QaSuiteResu
     };
     const gatewayProcessCpuStartMs = gateway.getProcessCpuMs?.() ?? null;
     const gatewayProcessRssStartBytes = sampleGatewayProcessRss("suite-start");
+    const gatewayHeapSnapshots: QaSuiteGatewayHeapSnapshot[] = [];
+    const captureGatewayHeapCheckpoint = async (label: string) => {
+      if (!gatewayHeapCheckpointsEnabled) {
+        return;
+      }
+      const snapshot = await captureGatewayHeapSnapshotCheckpoint({
+        gateway,
+        outputDir,
+        label,
+      });
+      if (snapshot) {
+        gatewayHeapSnapshots.push(snapshot);
+      }
+    };
+    await captureGatewayHeapCheckpoint("suite-start");
     for (const [index, scenario] of selectedCatalogScenarios.entries()) {
       const scenarioIdForLog = sanitizeQaSuiteProgressValue(scenario.id);
       writeQaSuiteProgress(
@@ -1290,6 +1425,7 @@ export async function runQaSuite(params?: QaSuiteRunParams): Promise<QaSuiteResu
           })
         : undefined;
     const finishedAt = new Date();
+    await captureGatewayHeapCheckpoint("suite-finish");
     const metrics = buildQaSuiteRuntimeMetrics({
       startedAt,
       finishedAt,
@@ -1298,6 +1434,7 @@ export async function runQaSuite(params?: QaSuiteRunParams): Promise<QaSuiteResu
       gatewayProcessRssStartBytes,
       gatewayProcessRssEndBytes: sampleGatewayProcessRss("suite-finish"),
       gatewayProcessRssSamples,
+      gatewayHeapSnapshots,
     });
     const failedCount = scenarios.filter((scenario) => scenario.status === "fail").length;
     if (scenarios.some((scenario) => scenario.status === "fail")) {
@@ -1373,8 +1510,11 @@ export async function runQaSuite(params?: QaSuiteRunParams): Promise<QaSuiteResu
 }
 
 export const qaSuiteProgressTesting = {
+  appendNodeOption,
+  buildQaGatewayHeapCheckpointRuntimeEnvPatch,
   buildQaSuiteRuntimeMetrics,
   buildQaRuntimeEnvPatch,
+  mergeQaRuntimeEnvPatches,
   parseQaSuiteBooleanEnv,
   remapModelRefForForcedRuntime,
   resolveQaSuiteTransportReadyTimeoutMs,

--- a/scripts/perf/rtt-regression-audit.md
+++ b/scripts/perf/rtt-regression-audit.md
@@ -33,7 +33,7 @@ Status: branch-local checkpoint, not release notes.
   passed 30 tests.
 - Focused local wrapper:
   `node scripts/run-vitest.mjs extensions/qa-lab/src/suite.test.ts extensions/qa-lab/src/suite.summary-json.test.ts extensions/qa-lab/src/live-transports/discord/discord-live.runtime.test.ts`
-  passed 50 tests.
+  passed 52 tests after the final rebase.
 - Testbox `tbx_01krvces8y0c99nzra2a90jg13` ran
   `pnpm openclaw qa suite --scenario channel-chat-baseline` and emitted gateway
   RSS trace fields. Observed sample: wall `15784ms`, gateway RSS
@@ -50,6 +50,12 @@ Status: branch-local checkpoint, not release notes.
   attempt on `tbx_01krwbsg15xvjdgpcz8fxq1htz` was blocked before reaching the
   changed gate: pnpm install rejected newly published
   `@earendil-works/pi-ai@0.74.1` under `minimumReleaseAge`.
+- After rebasing again, Testbox-through-Crabbox
+  `tbx_01krwcxpxx1n22t8jmvcj40228` ran
+  `pnpm check:changed` with an explicit `origin/main` fetch to repair the
+  delegated shallow checkout's merge base, and passed. The run escalated to all
+  changed-gate lanes in the delegated checkout, so it covered typecheck, lint,
+  and runtime import-cycle checks rather than only the narrow qa-lab diff.
 - Follow-up branch `perf/discord-rtt-summary-import` in `openclaw-rtt` updates
   `scripts/import-discord-rtt.mjs` to prefer the new summary `rttMs` field
   before observed-message or summary-duration fallback, and teaches Discord and

--- a/scripts/perf/rtt-regression-audit.md
+++ b/scripts/perf/rtt-regression-audit.md
@@ -41,14 +41,19 @@ Status: branch-local checkpoint, not release notes.
 - Testbox `tbx_01krwb9k7cbktytpjprxcydfbk` ran `pnpm check:changed` and the
   command exited 0. The wrapper Actions run `26008757251` still reported
   `in_progress` after the box was stopped.
+- Testbox `tbx_01krwbsg15xvjdgpcz8fxq1htz` ran
+  `OPENCLAW_QA_GATEWAY_HEAP_CHECKPOINTS=1 pnpm openclaw qa suite --scenario channel-chat-baseline`.
+  The sample passed and recorded heap checkpoints plus RSS trace: wall
+  `20112ms`, gateway RSS `655036416 -> 953790464`, peak `1051258880`, heap
+  snapshots `154M` and `165M`.
 
 ## Still weak
 
-- No retained-heap regression has been proven. Heap snapshots should be taken
-  only if the new gateway RSS samples grow across repeated warm samples.
+- No retained-heap regression has been proven. The first heap-checkpoint sample
+  grew by about 11M on disk across the scenario, which is worth comparing
+  across repeated warm samples before calling it a leak.
 - The branch fixes OpenClaw artifact quality. `openclaw-rtt` still needs an
   importer/report follow-up to prefer summary `rttMs` and optionally ingest
   gateway RSS fields.
 - Gitcrawl data was stale for the newest RTT window, so live `gh` history was
   the source of truth for 2026-05-16 and 2026-05-17 PR attribution.
-

--- a/scripts/perf/rtt-regression-audit.md
+++ b/scripts/perf/rtt-regression-audit.md
@@ -52,7 +52,8 @@ Status: branch-local checkpoint, not release notes.
   `@earendil-works/pi-ai@0.74.1` under `minimumReleaseAge`.
 - Follow-up branch `perf/discord-rtt-summary-import` in `openclaw-rtt` updates
   `scripts/import-discord-rtt.mjs` to prefer the new summary `rttMs` field
-  before observed-message or summary-duration fallback. `npm test -- scripts/import-discord-rtt.test.mjs`
+  before observed-message or summary-duration fallback, and teaches Discord and
+  live-transport importers to ingest gateway RSS summary metrics. `npm test -- scripts/import-discord-rtt.test.mjs scripts/import-live-transport-rtt.test.mjs`
   passed 19 tests and `npm run check` passed.
 
 ## Still weak
@@ -61,7 +62,7 @@ Status: branch-local checkpoint, not release notes.
   grew by about 11M on disk across the scenario, which is worth comparing
   across repeated warm samples before calling it a leak.
 - The branch fixes OpenClaw artifact quality. `openclaw-rtt` has a paired
-  importer branch for summary `rttMs`; gateway RSS import remains a later
-  schema/reporting decision.
+  importer branch for summary `rttMs` and gateway RSS metric ingestion;
+  dashboard presentation of gateway RSS remains a later reporting decision.
 - Gitcrawl data was stale for the newest RTT window, so live `gh` history was
   the source of truth for 2026-05-16 and 2026-05-17 PR attribution.

--- a/scripts/perf/rtt-regression-audit.md
+++ b/scripts/perf/rtt-regression-audit.md
@@ -1,0 +1,54 @@
+# RTT regression audit checkpoint
+
+Status: branch-local checkpoint, not release notes.
+
+## Signals
+
+- `openclaw-rtt` Discord main rows appeared to jump from about 5-7s p50 to about
+  24-27s p50 after the 2026-05-16 main window.
+- Downloaded fast/slow Discord artifacts showed the old "fast" run included
+  observed message `triggerTimestamp` and `timestamp`, while newer redacted runs
+  kept only scenario metadata.
+- `openclaw-rtt` `scripts/import-discord-rtt.mjs` falls back to whole summary
+  duration when observed-message timestamps are missing. That made a redaction
+  shape change look like transport RTT regression.
+- Slack and WhatsApp RSS rows showed recurring first-sample max RSS outliers
+  around 6-9GB while later warm samples sat far lower. That points at
+  command-level cold-start RSS measurement before retained gateway heap.
+
+## Fixes in this branch
+
+- `extensions/qa-lab/src/live-transports/discord/discord-live.runtime.ts`
+  preserves safe timing fields through metadata redaction so importers can keep
+  measuring reply RTT without exposing Discord IDs or content.
+- Discord QA scenario summaries now include `rttMs` for direct importer use.
+- `extensions/qa-lab/src/suite.ts` records gateway-process RSS start/end/peak
+  and checkpoint samples in `qa-suite-summary.json`, giving RTT importers a
+  gateway-level metric separate from `/usr/bin/time` command max RSS.
+
+## Proof so far
+
+- Focused local wrapper:
+  `node scripts/run-vitest.mjs extensions/qa-lab/src/live-transports/discord/discord-live.runtime.test.ts`
+  passed 30 tests.
+- Focused local wrapper:
+  `node scripts/run-vitest.mjs extensions/qa-lab/src/suite.test.ts extensions/qa-lab/src/suite.summary-json.test.ts extensions/qa-lab/src/live-transports/discord/discord-live.runtime.test.ts`
+  passed 50 tests.
+- Testbox `tbx_01krvces8y0c99nzra2a90jg13` ran
+  `pnpm openclaw qa suite --scenario channel-chat-baseline` and emitted gateway
+  RSS trace fields. Observed sample: wall `15784ms`, gateway RSS
+  `664403968 -> 689852416`, peak `689852416`.
+- Testbox `tbx_01krwb9k7cbktytpjprxcydfbk` ran `pnpm check:changed` and the
+  command exited 0. The wrapper Actions run `26008757251` still reported
+  `in_progress` after the box was stopped.
+
+## Still weak
+
+- No retained-heap regression has been proven. Heap snapshots should be taken
+  only if the new gateway RSS samples grow across repeated warm samples.
+- The branch fixes OpenClaw artifact quality. `openclaw-rtt` still needs an
+  importer/report follow-up to prefer summary `rttMs` and optionally ingest
+  gateway RSS fields.
+- Gitcrawl data was stale for the newest RTT window, so live `gh` history was
+  the source of truth for 2026-05-16 and 2026-05-17 PR attribution.
+

--- a/scripts/perf/rtt-regression-audit.md
+++ b/scripts/perf/rtt-regression-audit.md
@@ -46,6 +46,10 @@ Status: branch-local checkpoint, not release notes.
   The sample passed and recorded heap checkpoints plus RSS trace: wall
   `20112ms`, gateway RSS `655036416 -> 953790464`, peak `1051258880`, heap
   snapshots `154M` and `165M`.
+- After rebasing onto `b5046968f61`, a fresh Testbox `pnpm check:changed`
+  attempt on `tbx_01krwbsg15xvjdgpcz8fxq1htz` was blocked before reaching the
+  changed gate: pnpm install rejected newly published
+  `@earendil-works/pi-ai@0.74.1` under `minimumReleaseAge`.
 
 ## Still weak
 

--- a/scripts/perf/rtt-regression-audit.md
+++ b/scripts/perf/rtt-regression-audit.md
@@ -50,14 +50,18 @@ Status: branch-local checkpoint, not release notes.
   attempt on `tbx_01krwbsg15xvjdgpcz8fxq1htz` was blocked before reaching the
   changed gate: pnpm install rejected newly published
   `@earendil-works/pi-ai@0.74.1` under `minimumReleaseAge`.
+- Follow-up branch `perf/discord-rtt-summary-import` in `openclaw-rtt` updates
+  `scripts/import-discord-rtt.mjs` to prefer the new summary `rttMs` field
+  before observed-message or summary-duration fallback. `npm test -- scripts/import-discord-rtt.test.mjs`
+  passed 19 tests and `npm run check` passed.
 
 ## Still weak
 
 - No retained-heap regression has been proven. The first heap-checkpoint sample
   grew by about 11M on disk across the scenario, which is worth comparing
   across repeated warm samples before calling it a leak.
-- The branch fixes OpenClaw artifact quality. `openclaw-rtt` still needs an
-  importer/report follow-up to prefer summary `rttMs` and optionally ingest
-  gateway RSS fields.
+- The branch fixes OpenClaw artifact quality. `openclaw-rtt` has a paired
+  importer branch for summary `rttMs`; gateway RSS import remains a later
+  schema/reporting decision.
 - Gitcrawl data was stale for the newest RTT window, so live `gh` history was
   the source of truth for 2026-05-16 and 2026-05-17 PR attribution.


### PR DESCRIPTION
## Summary

- Problem: Discord QA artifacts could lose safe timing metadata during redaction, causing downstream RTT importers to fall back to whole scenario duration.
- Why it matters: `openclaw-rtt` early rows made this look like a 5-7s to 24-27s Discord RTT regression when the artifact shape was the primary fault.
- What changed: Discord redaction preserves safe timing fields, scenario summaries emit `rttMs`, QA suite summaries record gateway RSS metrics, and opt-in gateway heap checkpoints can emit start/finish heap snapshots.
- What did NOT change: no user-facing runtime behavior, no provider/channel auth behavior, and no dashboard presentation changes.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related openclaw-rtt importer PR: https://github.com/openclaw/openclaw-rtt/pull/10
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: redacted Discord QA artifacts retain timing needed for RTT import, QA summaries expose direct scenario RTT, and suite summaries expose gateway-process RSS separately from command max RSS.
- Real environment tested: Testbox-through-Crabbox on OpenClaw branch `perf/rtt-regression-audit-20260518`, plus focused local node-wrapper Vitest in the Codex worktree.
- Exact steps or command run after this patch:

```sh
node scripts/run-vitest.mjs extensions/qa-lab/src/suite.test.ts extensions/qa-lab/src/suite.summary-json.test.ts extensions/qa-lab/src/live-transports/discord/discord-live.runtime.test.ts

node scripts/crabbox-wrapper.mjs run \
  --provider blacksmith-testbox \
  --blacksmith-org openclaw \
  --blacksmith-workflow .github/workflows/ci-check-testbox.yml \
  --blacksmith-job check \
  --blacksmith-ref perf/rtt-regression-audit-20260518 \
  --idle-timeout 90m \
  --ttl 240m \
  --timing-json \
  --shell \
  -- "git fetch origin main:refs/remotes/origin/main --deepen=2000 && CI=1 NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_TEST_PROJECTS_PARALLEL=6 OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=900000 OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm check:changed"
```

- Evidence after fix: focused wrapper passed 52 tests. Testbox-through-Crabbox `tbx_01krwcxpxx1n22t8jmvcj40228` ran `pnpm check:changed` and exited 0. Actions run: https://github.com/openclaw/openclaw/actions/runs/26009521790
- Observed result after fix: changed gate passed after repairing the delegated shallow checkout merge base; it escalated to all changed-gate lanes in that checkout and covered typecheck, lint, and runtime import-cycle checks.
- What was not tested: live Discord user roundtrip was not rerun; this patch covers artifact timing preservation, summary metrics, and QA memory observability.
- Before evidence: `openclaw-rtt` Discord rows appeared to jump from about 5-7s p50 to about 24-27s p50 after newer redacted artifacts stopped carrying observed-message timing fields.

## Root Cause (if applicable)

- Root cause: redaction removed safe Discord timing metadata that downstream RTT importers needed, so importer fallback measured full scenario duration instead of reply RTT.
- Missing detection / guardrail: QA summaries lacked a direct `rttMs` field, and suite summaries lacked gateway RSS metrics to separate retained gateway memory from command-level RSS spikes.
- Contributing context (if known): gitcrawl was stale for the newest 2026-05-16/17 attribution window, so live GitHub history was used for final PR attribution.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/qa-lab/src/live-transports/discord/discord-live.runtime.test.ts`, `extensions/qa-lab/src/suite.test.ts`, `extensions/qa-lab/src/suite.summary-json.test.ts`
- Scenario the test should lock in: redacted observed Discord messages keep safe timing fields; summaries emit `rttMs`; suite metrics include gateway RSS and heap checkpoint metadata.
- Why this is the smallest reliable guardrail: it locks the artifact contract at the producer seam without requiring live Discord credentials.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None for normal users. QA and performance artifacts gain richer timing and gateway memory metrics.

## Diagram (if applicable)

```text
Before:
Discord observed timing -> redaction drops timing -> importer uses summary duration

After:
Discord observed timing -> redaction keeps safe timing + summary rttMs -> importer uses RTT
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local focused wrapper; Linux Testbox-through-Crabbox remote gate
- Runtime/container: Node 22+ local wrapper; Blacksmith Testbox CI environment for `pnpm check:changed`
- Model/provider: mock OpenAI for QA sample proof
- Integration/channel (if any): Discord QA artifact producer; QA suite summaries
- Relevant config (redacted): no secrets used

### Steps

1. Run focused QA/Discord Vitest wrapper.
2. Run Testbox-through-Crabbox `pnpm check:changed`.
3. Inspect QA sample summaries for `rttMs`, gateway RSS metrics, and heap checkpoint fields.

### Expected

- Redacted Discord artifacts retain safe timing.
- QA summaries expose direct RTT and gateway RSS.
- Changed gate passes.

### Actual

- Focused tests passed.
- Testbox-through-Crabbox changed gate passed.
- QA heap checkpoint sample recorded suite-start and suite-finish heap snapshots plus gateway RSS fields.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

Relevant numbers from branch audit:

- QA baseline sample: wall `15784ms`, gateway RSS `664403968 -> 689852416`, peak `689852416`.
- Heap checkpoint sample: wall `20112ms`, gateway RSS `655036416 -> 953790464`, peak `1051258880`, heap snapshots `154M` and `165M`.

## Human Verification (required)

- AI-assisted: yes
- Verified scenarios: focused QA/Discord tests, Testbox-through-Crabbox changed gate, QA heap checkpoint sample.
- Edge cases checked: missing observed-message timing fallback remains available through the paired importer PR.
- What you did **not** verify: live Discord account RTT after this patch.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`Yes`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: optional heap snapshots require `OPENCLAW_QA_GATEWAY_HEAP_CHECKPOINTS=1`; default behavior is unchanged.

## Risks and Mitigations

- Risk: heap snapshots are large when enabled.
  - Mitigation: snapshots are opt-in and scoped to QA suite artifacts.
- Risk: old artifacts still lack summary RTT.
  - Mitigation: paired importer PR preserves existing fallback logic and adds the new summary RTT path for new artifacts.
