### PR TITLE
fix(feishu): preserve ACP topic conversation bindings

### DIFF
--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -206,6 +206,42 @@ describe("feishuPlugin messaging", () => {
       parentConversationCandidates: ["oc_group_chat:topic:om_topic_root", "oc_group_chat"],
     });
   });
+
+  it("resolves inbound topic conversations for ACP thread binding", () => {
+    expect(
+      feishuPlugin.messaging?.resolveInboundConversation?.({
+        to: "chat:oc_group_chat",
+        threadId: "om_topic_root",
+        isGroup: true,
+      }),
+    ).toEqual({
+      conversationId: "oc_group_chat:topic:om_topic_root",
+      parentConversationId: "oc_group_chat",
+    });
+  });
+
+  it("normalizes sender-scoped topic conversations to topic bindings", () => {
+    expect(
+      feishuPlugin.messaging?.resolveInboundConversation?.({
+        to: "chat:oc_group_chat:topic:om_topic_root:sender:ou_topic_user",
+        isGroup: true,
+      }),
+    ).toEqual({
+      conversationId: "oc_group_chat:topic:om_topic_root",
+      parentConversationId: "oc_group_chat",
+    });
+  });
+
+  it("resolves inbound direct conversations without a parent conversation", () => {
+    expect(
+      feishuPlugin.messaging?.resolveInboundConversation?.({
+        to: "user:ou_direct_user",
+        isGroup: false,
+      }),
+    ).toEqual({
+      conversationId: "ou_direct_user",
+    });
+  });
 });
 
 describe("feishuPlugin actions", () => {

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -559,6 +559,33 @@ function resolveFeishuCommandConversation(params: {
   return conversationId ? { conversationId } : null;
 }
 
+function resolveFeishuInboundConversation(params: {
+  to?: string;
+  conversationId?: string;
+  threadId?: string | number;
+}) {
+  const target = parseFeishuTargetId(params.to) ?? parseFeishuTargetId(params.conversationId);
+  if (!target) {
+    return null;
+  }
+  const parsed = parseFeishuConversationId({ conversationId: target });
+  const chatId = parsed?.chatId ?? target;
+  const explicitThreadId = params.threadId != null ? String(params.threadId).trim() : undefined;
+  const topicId = explicitThreadId || parsed?.topicId;
+  if (topicId) {
+    return {
+      conversationId: buildFeishuConversationId({
+        chatId,
+        scope: "group_topic",
+        topicId,
+      }),
+      parentConversationId: chatId,
+    };
+  }
+  const directId = parseFeishuDirectConversationId(target);
+  return directId ? { conversationId: directId } : { conversationId: chatId };
+}
+
 function jsonActionResult(details: Record<string, unknown>) {
   return {
     content: [{ type: "text" as const, text: JSON.stringify(details) }],
@@ -1252,6 +1279,8 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
       messaging: {
         targetPrefixes: ["feishu", "lark"],
         normalizeTarget: (raw) => normalizeFeishuTarget(raw) ?? undefined,
+        resolveInboundConversation: ({ to, conversationId, threadId }) =>
+          resolveFeishuInboundConversation({ to, conversationId, threadId }),
         resolveDeliveryTarget: ({ conversationId, parentConversationId }) => {
           const directId = parseFeishuDirectConversationId(conversationId);
           if (directId) {

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -2,7 +2,9 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { feishuPlugin } from "../../extensions/feishu/channel-plugin-api.js";
 import type { AcpInitializeSessionInput } from "../acp/control-plane/manager.types.js";
+import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
@@ -594,6 +596,40 @@ function enableTelegramCurrentConversationBindings(): void {
   );
   registerSessionBindingAdapter({
     channel: "telegram",
+    accountId: "default",
+    capabilities: {
+      bindSupported: true,
+      unbindSupported: true,
+      placements: ["current"] satisfies SessionBindingPlacement[],
+    },
+    bind: async (input) => await hoisted.sessionBindingBindMock(input),
+    listBySession: (targetSessionKey) => hoisted.sessionBindingListBySessionMock(targetSessionKey),
+    resolveByConversation: (ref) => hoisted.sessionBindingResolveByConversationMock(ref),
+    unbind: async (input) => await hoisted.sessionBindingUnbindMock(input),
+  });
+}
+
+function enableFeishuCurrentConversationBindings(): void {
+  replaceSpawnConfig({
+    ...hoisted.state.cfg,
+    channels: {
+      ...hoisted.state.cfg.channels,
+      feishu: {
+        threadBindings: {
+          enabled: true,
+        },
+      },
+    },
+  });
+  const plugin = feishuPlugin as ChannelPlugin;
+  hoisted.getChannelPluginMock.mockImplementation((channelId: string) =>
+    channelId === "feishu" ? plugin : undefined,
+  );
+  hoisted.getLoadedChannelPluginMock.mockImplementation((channelId: string) =>
+    channelId === "feishu" ? plugin : undefined,
+  );
+  registerSessionBindingAdapter({
+    channel: "feishu",
     accountId: "default",
     capabilities: {
       bindSupported: true,
@@ -2640,6 +2676,68 @@ describe("spawnAcpDirect", () => {
       .find((request) => request.method === "agent");
     expect(agentCall?.params?.deliver).toBe(true);
     expect(agentCall?.params?.channel).toBe("telegram");
+  });
+
+  it("binds Feishu topic ACP sessions through the plugin-owned conversation resolver", async () => {
+    enableFeishuCurrentConversationBindings();
+    hoisted.sessionBindingBindMock.mockImplementationOnce(
+      async (input: {
+        targetSessionKey: string;
+        conversation: { accountId: string; conversationId: string; parentConversationId?: string };
+        metadata?: Record<string, unknown>;
+      }) =>
+        createSessionBinding({
+          targetSessionKey: input.targetSessionKey,
+          conversation: {
+            channel: "feishu",
+            accountId: input.conversation.accountId,
+            conversationId: input.conversation.conversationId,
+            parentConversationId: input.conversation.parentConversationId,
+          },
+          metadata: {
+            boundBy:
+              typeof input.metadata?.boundBy === "string" ? input.metadata.boundBy : "system",
+            agentId: "codex",
+          },
+        }),
+    );
+
+    const result = await spawnAcpDirect(
+      {
+        task: "Investigate flaky tests",
+        agentId: "codex",
+        mode: "session",
+        thread: true,
+      },
+      {
+        agentSessionKey:
+          "agent:main:feishu:group:oc_group_chat:topic:om_topic_root:sender:ou_topic_user",
+        agentChannel: "feishu",
+        agentAccountId: "default",
+        agentTo: "chat:oc_group_chat:topic:om_topic_root:sender:ou_topic_user",
+        agentThreadId: "om_topic_root",
+        agentGroupId: "oc_group_chat",
+      },
+    );
+
+    const accepted = expectAcceptedSpawn(result);
+    expect(accepted.mode).toBe("session");
+    expectBindingCallFields({
+      placement: "current",
+      conversation: {
+        channel: "feishu",
+        accountId: "default",
+        conversationId: "oc_group_chat:topic:om_topic_root",
+        parentConversationId: "oc_group_chat",
+      },
+    });
+    const agentCall = hoisted.callGatewayMock.mock.calls
+      .map((call: unknown[]) => call[0] as { method?: string; params?: Record<string, unknown> })
+      .find((request) => request.method === "agent");
+    expect(agentCall?.params?.deliver).toBe(true);
+    expect(agentCall?.params?.channel).toBe("feishu");
+    expect(agentCall?.params?.to).toBe("chat:oc_group_chat");
+    expect(agentCall?.params?.threadId).toBe("om_topic_root");
   });
 
   it("drops self-parent Telegram current-conversation refs before binding", async () => {

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -1096,7 +1096,10 @@ function resolveAcpSpawnBootstrapDeliveryPlan(params: {
     conversationId: params.binding?.conversation.conversationId,
     parentConversationId: params.binding?.conversation.parentConversationId,
   });
+  const preferBoundDeliveryTarget =
+    bindingMatchesRequesterConversation && boundDeliveryTarget.threadId != null;
   const inferredDeliveryTo =
+    (preferBoundDeliveryTarget ? boundDeliveryTarget.to : undefined) ??
     (bindingMatchesRequesterConversation
       ? normalizeOptionalString(params.requester.origin?.to)
       : undefined) ??
@@ -1106,9 +1109,11 @@ function resolveAcpSpawnBootstrapDeliveryPlan(params: {
       channel: params.requester.origin?.channel,
       conversationId: deliveryThreadId,
     });
-  const resolvedDeliveryThreadId = bindingMatchesRequesterConversation
-    ? fallbackThreadId
-    : (boundDeliveryTarget.threadId ?? deliveryThreadId);
+  const resolvedDeliveryThreadId = preferBoundDeliveryTarget
+    ? boundDeliveryTarget.threadId
+    : bindingMatchesRequesterConversation
+      ? fallbackThreadId
+      : (boundDeliveryTarget.threadId ?? deliveryThreadId);
   const hasDeliveryTarget = Boolean(params.requester.origin?.channel && inferredDeliveryTo);
 
   // Thread-bound session spawns always deliver inline to their bound thread.


### PR DESCRIPTION
## Summary
- Refreshes #50943 onto current `openclaw/main` as a narrow Feishu plugin fix.
- Adds Feishu `messaging.resolveInboundConversation` so ACP thread binding uses plugin-owned topic conversation grammar.
- Covers topic, sender-scoped topic, and direct conversation resolution in Feishu channel tests.
- Adds ACP spawn integration coverage that imports the Feishu plugin through its public barrel and verifies topic binding plus bootstrap delivery target selection from a sender-scoped topic context.

## Verification
- `node scripts/run-vitest.mjs src/agents/acp-spawn.test.ts` — 112/112 passed on `02113a7a`
- `node scripts/run-vitest.mjs extensions/feishu/src/channel.test.ts` — 57/57 passed on `02113a7a`
- `git diff --check`
- `env PNPM_HOME=/tmp/openclaw-pnpm-home pnpm exec oxfmt --write --no-error-on-unmatched-pattern src/agents/acp-spawn.test.ts`

## Real behavior proof
Behavior addressed: ACP session thread binding now resolves Feishu/Lark topic conversations through the Feishu plugin instead of generic fallback parsing, and the ACP bootstrap delivery target is normalized back to the intended topic thread instead of the sender-scoped target.
Real environment tested: local source checkout rebased on `upstream/main` `322f0bb7`, with dependencies refreshed by `pnpm install --frozen-lockfile` using temporary `PNPM_HOME=/tmp/openclaw-pnpm-home`; the ACP coverage imports the actual `feishuPlugin` through `extensions/feishu/channel-plugin-api.ts` and exercises `spawnAcpDirect` through the production conversation-resolution/session-binding path.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/acp-spawn.test.ts`; `node scripts/run-vitest.mjs extensions/feishu/src/channel.test.ts`; `git diff --check`; `env PNPM_HOME=/tmp/openclaw-pnpm-home pnpm exec oxfmt --write --no-error-on-unmatched-pattern src/agents/acp-spawn.test.ts`.
Evidence after fix: Feishu channel tests passed 57/57. ACP spawn tests passed 112/112, including `binds Feishu topic ACP sessions through the plugin-owned conversation resolver`, which starts from `agentTo=chat:oc_group_chat:topic:om_topic_root:sender:ou_topic_user` plus `agentThreadId=om_topic_root` and routes through the actual Feishu resolver via the public plugin barrel.
Observed result after fix: the session binding call receives `conversationId=oc_group_chat:topic:om_topic_root` and `parentConversationId=oc_group_chat`; the ACP bootstrap `agent` gateway call keeps `deliver=true`, `channel=feishu`, `to=chat:oc_group_chat`, and `threadId=om_topic_root`, so the child session remains bound and delivered to the intended topic rather than the sender-scoped pseudo-conversation.
What was not tested: live Feishu/Lark network delivery was not exercised in this local pass; no external Feishu/Lark workspace was messaged.
