### PR TITLE
fix(provider-catalog): skip catalog discovery when apiKey is a non-secret auth marker

### DIFF
--- a/src/plugins/provider-catalog.ts
+++ b/src/plugins/provider-catalog.ts
@@ -1,3 +1,4 @@
+import { isNonSecretApiKeyMarker } from "../agents/model-auth-markers.js";
 import { normalizeProviderId } from "../agents/provider-id.js";
 import type { ModelProviderConfig } from "../config/types.js";
 import {
@@ -29,8 +30,12 @@ export async function buildSingleProviderApiKeyCatalog(params: {
   allowExplicitBaseUrl?: boolean;
 }): Promise<ProviderCatalogResult> {
   const providerId = normalizeProviderId(params.providerId);
-  const apiKey = params.ctx.resolveProviderApiKey(providerId).apiKey;
-  if (!apiKey) {
+  const { apiKey } = params.ctx.resolveProviderApiKey(providerId);
+  // Non-secret auth markers ("custom-local", "ollama-local", etc.) are placeholders
+  // for local providers that don't need authentication. Do not attempt catalog
+  // discovery with these — the HTTP request would be sent without a valid
+  // Authorization header (toDiscoveryApiKey already filters them to undefined).
+  if (!apiKey || isNonSecretApiKeyMarker(apiKey)) {
     return null;
   }
 
@@ -58,8 +63,8 @@ export async function buildPairedProviderApiKeyCatalog(params: {
     | Record<string, ModelProviderConfig>
     | Promise<Record<string, ModelProviderConfig>>;
 }): Promise<ProviderCatalogResult> {
-  const apiKey = params.ctx.resolveProviderApiKey(normalizeProviderId(params.providerId)).apiKey;
-  if (!apiKey) {
+  const { apiKey } = params.ctx.resolveProviderApiKey(normalizeProviderId(params.providerId));
+  if (!apiKey || isNonSecretApiKeyMarker(apiKey)) {
     return null;
   }
 

--- a/src/plugins/provider-catalog.ts
+++ b/src/plugins/provider-catalog.ts
@@ -35,7 +35,10 @@ export async function buildSingleProviderApiKeyCatalog(params: {
   // for local providers that don't need authentication. Do not attempt catalog
   // discovery with these — the HTTP request would be sent without a valid
   // Authorization header (toDiscoveryApiKey already filters them to undefined).
-  if (!apiKey || isNonSecretApiKeyMarker(apiKey)) {
+  // Only block true non-secret markers ("custom-local", "ollama-local", etc.).
+  // Env-var names ("LITELLM_API_KEY", "VLLM_API_KEY") are valid apiKey values
+  // with the actual secret riding in discoveryApiKey — preserve those.
+  if (!apiKey || isNonSecretApiKeyMarker(apiKey, { includeEnvVarName: false })) {
     return null;
   }
 
@@ -64,7 +67,7 @@ export async function buildPairedProviderApiKeyCatalog(params: {
     | Promise<Record<string, ModelProviderConfig>>;
 }): Promise<ProviderCatalogResult> {
   const { apiKey } = params.ctx.resolveProviderApiKey(normalizeProviderId(params.providerId));
-  if (!apiKey || isNonSecretApiKeyMarker(apiKey)) {
+  if (!apiKey || isNonSecretApiKeyMarker(apiKey, { includeEnvVarName: false })) {
     return null;
   }
 

--- a/src/plugins/provider-self-hosted-setup.ts
+++ b/src/plugins/provider-self-hosted-setup.ts
@@ -54,10 +54,11 @@ export async function discoverOpenAICompatibleLocalModels(params: {
     return [];
   }
 
-  // Skip discovery if no valid API key is available (including local-only markers
-  // like "custom-local" that don't represent real credentials).
+  // Skip true non-secret markers ("custom-local", etc.) but preserve
+  // undefined/no-key paths — some local servers (Ollama, etc.) serve models
+  // without authentication.
   const actualKey = normalizeOptionalString(params.apiKey);
-  if (!actualKey || isNonSecretApiKeyMarker(actualKey)) {
+  if (actualKey && isNonSecretApiKeyMarker(actualKey, { includeEnvVarName: false })) {
     return [];
   }
 
@@ -274,10 +275,10 @@ export async function discoverOpenAICompatibleSelfHostedProvider<
     return null;
   }
   const { apiKey, discoveryApiKey } = params.ctx.resolveProviderApiKey(params.providerId);
-  // Non-secret auth markers ("custom-local", etc.) are placeholders for
-  // local providers that don't need authentication. Do not attempt catalog
-  // discovery with these — toDiscoveryApiKey already filters them to undefined.
-  if (!apiKey || isNonSecretApiKeyMarker(apiKey)) {
+  // Only block true non-secret markers ("custom-local", "ollama-local", etc.).
+  // Env-var names ("LITELLM_API_KEY", "VLLM_API_KEY") are valid apiKey values
+  // with the actual secret riding in discoveryApiKey — preserve those.
+  if (!apiKey || isNonSecretApiKeyMarker(apiKey, { includeEnvVarName: false })) {
     return null;
   }
   return {

--- a/src/plugins/provider-self-hosted-setup.ts
+++ b/src/plugins/provider-self-hosted-setup.ts
@@ -1,5 +1,6 @@
 import type { ApiKeyCredential, AuthProfileCredential } from "../agents/auth-profiles/types.js";
 import { upsertAuthProfileWithLock } from "../agents/auth-profiles/upsert-with-lock.js";
+import { isNonSecretApiKeyMarker } from "../agents/model-auth-markers.js";
 import {
   SELF_HOSTED_DEFAULT_CONTEXT_WINDOW,
   SELF_HOSTED_DEFAULT_COST,
@@ -53,11 +54,18 @@ export async function discoverOpenAICompatibleLocalModels(params: {
     return [];
   }
 
+  // Skip discovery if no valid API key is available (including local-only markers
+  // like "custom-local" that don't represent real credentials).
+  const actualKey = normalizeOptionalString(params.apiKey);
+  if (!actualKey || isNonSecretApiKeyMarker(actualKey)) {
+    return [];
+  }
+
   const trimmedBaseUrl = params.baseUrl.trim().replace(/\/+$/, "");
   const url = `${trimmedBaseUrl}/models`;
 
   try {
-    const trimmedApiKey = normalizeOptionalString(params.apiKey);
+    const trimmedApiKey = actualKey;
     const response = await fetch(url, {
       headers: trimmedApiKey ? { Authorization: `Bearer ${trimmedApiKey}` } : undefined,
       signal: AbortSignal.timeout(5000),
@@ -266,7 +274,10 @@ export async function discoverOpenAICompatibleSelfHostedProvider<
     return null;
   }
   const { apiKey, discoveryApiKey } = params.ctx.resolveProviderApiKey(params.providerId);
-  if (!apiKey) {
+  // Non-secret auth markers ("custom-local", etc.) are placeholders for
+  // local providers that don't need authentication. Do not attempt catalog
+  // discovery with these — toDiscoveryApiKey already filters them to undefined.
+  if (!apiKey || isNonSecretApiKeyMarker(apiKey)) {
     return null;
   }
   return {


### PR DESCRIPTION
## Summary

`buildSingleProviderApiKeyCatalog`, `buildPairedProviderApiKeyCatalog`, `discoverOpenAICompatibleSelfHostedProvider`, and `discoverOpenAICompatibleLocalModels` all check `!apiKey` before allowing catalog/model discovery. When the resolved `apiKey` is a non-secret auth marker like `"custom-local"` or `"ollama-local"` (truthy strings), this guard passes, but `toDiscoveryApiKey()` filters these markers to `undefined`. The downstream HTTP request then sends `GET /models` **without any `Authorization` header**.

## Root Cause

`model-auth-markers.ts` defines several non-secret markers for local/self-hosted providers:
- `CUSTOM_LOCAL_AUTH_MARKER = "custom-local"`
- `OLLAMA_LOCAL_AUTH_MARKER = "ollama-local"`
- etc.

`models-config.providers.secrets.ts` → `toDiscoveryApiKey()` correctly filters these to `undefined`. But the guards in the catalog/self-hosted helpers only checked falsiness — and markers are truthy strings.

## Fix

Added `isNonSecretApiKeyMarker(apiKey, { includeEnvVarName: false })` check to all four functions. The `includeEnvVarName: false` option is critical: it preserves valid env-var names (like `LITELLM_API_KEY`, `VLLM_API_KEY`) which `resolveProviderApiKey` returns as the `apiKey` value while carrying the actual secret in `discoveryApiKey`.

### Files changed

| File | Function | Change |
|------|----------|--------|
| `src/plugins/provider-catalog.ts` | `buildSingleProviderApiKeyCatalog` | `!apiKey` → `!apiKey || isNonSecretApiKeyMarker(apiKey, { includeEnvVarName: false })` |
| `src/plugins/provider-catalog.ts` | `buildPairedProviderApiKeyCatalog` | Same |
| `src/plugins/provider-self-hosted-setup.ts` | `discoverOpenAICompatibleSelfHostedProvider` | Same |
| `src/plugins/provider-self-hosted-setup.ts` | `discoverOpenAICompatibleLocalModels` | Only block true markers (preserve undefined/no-key for authless local servers) |

## Real behavior proof

### Before-fix evidence (live LiteLLM proxy log)

LiteLLM proxy logged **61 unauthenticated `GET /models` requests** to `/Users/samson1357924/proxy.log`. Each request includes the LiteLLM auth error:

```
Exception: No api key passed in.
INFO: 127.0.0.1:58983 - "GET /models HTTP/1.1" 401 Unauthorized
INFO: 127.0.0.1:58998 - "POST /embeddings HTTP/1.1" 200 OK
```

The pattern is clear: `GET /models` (401, no API key) is always followed by successful requests with valid API keys.

Timeline from live debug:
```
16:55:36 → Cron job triggered (backup-daily)
16:55:43 → GET /models (401, NO Authorization header)    ← 7s gap
16:55:46 → POST /chat/completions (200, WITH valid API key)
```

Source ports are sequential (51450 → 51455 → 51458), confirming the same process sends both requests — the unauthenticated discovery probe before the first authenticated inference call.

### After-fix evidence (pending)

To produce after-fix proof:
1. Apply this branch to a running OpenClaw Gateway
2. Trigger a cron job (e.g. `openclaw cron run backup-daily`)
3. Check `lsof -i :4000` and LiteLLM proxy log for `GET /models`
4. The unauthenticated request should no longer appear

Expected result: After the fix, the first catalog load skips discovery when the apiKey is a non-secret marker, so no `GET /models` is sent to LiteLLM without auth.

## Related Issues

- #80732 — SSRF guard blocks private IP provider baseUrl
- #82061 — expose allowPrivateNetwork for internal-network LLM gateways
- #82191 — SSRF guard blocks Tailscale CGNAT IP
- #82259 — Cannot use local VLLM server
