### PR TITLE
fix(discord): suppress duplicate approval prompts

### DIFF
--- a/extensions/discord/src/exec-approvals.test.ts
+++ b/extensions/discord/src/exec-approvals.test.ts
@@ -4,6 +4,7 @@ import {
   getDiscordExecApprovalApprovers,
   isDiscordExecApprovalApprover,
   isDiscordExecApprovalClientEnabled,
+  shouldSuppressLocalDiscordExecApprovalPrompt,
 } from "./exec-approvals.js";
 
 function buildConfig(
@@ -84,5 +85,34 @@ describe("discord exec approvals", () => {
 
     expect(getDiscordExecApprovalApprovers({ cfg })).toEqual(["123", "456", "789"]);
     expect(isDiscordExecApprovalApprover({ cfg, senderId: "456" })).toBe(true);
+  });
+
+  it("suppresses local prompts when the Discord native client is enabled", () => {
+    const payload = {
+      channelData: {
+        execApproval: {
+          approvalId: "req-1",
+          approvalSlug: "req-1",
+          agentId: "main",
+          sessionKey: "agent:main:discord:channel:123",
+        },
+      },
+    };
+
+    expect(
+      shouldSuppressLocalDiscordExecApprovalPrompt({
+        cfg: buildConfig({ enabled: true, approvers: ["123"] }),
+        payload,
+        hint: { kind: "approval-pending", approvalKind: "exec", nativeRouteActive: false },
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldSuppressLocalDiscordExecApprovalPrompt({
+        cfg: buildConfig(),
+        payload,
+        hint: { kind: "approval-pending", approvalKind: "exec", nativeRouteActive: false },
+      }),
+    ).toBe(false);
   });
 });

--- a/extensions/discord/src/exec-approvals.test.ts
+++ b/extensions/discord/src/exec-approvals.test.ts
@@ -87,7 +87,7 @@ describe("discord exec approvals", () => {
     expect(isDiscordExecApprovalApprover({ cfg, senderId: "456" })).toBe(true);
   });
 
-  it("suppresses local prompts when the Discord native client is enabled", () => {
+  it("suppresses local prompts only when the approval request has a delivered route", () => {
     const payload = {
       channelData: {
         execApproval: {
@@ -102,15 +102,37 @@ describe("discord exec approvals", () => {
     expect(
       shouldSuppressLocalDiscordExecApprovalPrompt({
         cfg: buildConfig({ enabled: true, approvers: ["123"] }),
-        payload,
+        payload: {
+          channelData: {
+            execApproval: {
+              ...payload.channelData.execApproval,
+              suppressLocalPrompt: true,
+            },
+          },
+        },
         hint: { kind: "approval-pending", approvalKind: "exec", nativeRouteActive: false },
       }),
     ).toBe(true);
 
     expect(
       shouldSuppressLocalDiscordExecApprovalPrompt({
-        cfg: buildConfig(),
+        cfg: buildConfig({ enabled: true, approvers: ["123"] }),
         payload,
+        hint: { kind: "approval-pending", approvalKind: "exec", nativeRouteActive: false },
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldSuppressLocalDiscordExecApprovalPrompt({
+        cfg: buildConfig(),
+        payload: {
+          channelData: {
+            execApproval: {
+              ...payload.channelData.execApproval,
+              suppressLocalPrompt: true,
+            },
+          },
+        },
         hint: { kind: "approval-pending", approvalKind: "exec", nativeRouteActive: false },
       }),
     ).toBe(false);

--- a/extensions/discord/src/exec-approvals.ts
+++ b/extensions/discord/src/exec-approvals.ts
@@ -97,6 +97,7 @@ export function shouldSuppressLocalDiscordExecApprovalPrompt(params: {
     params.hint?.kind === "approval-pending" &&
     isDiscordExecApprovalClientEnabled(params) &&
     metadata !== null &&
+    metadata.suppressLocalPrompt === true &&
     matchesApprovalRequestFilters({
       request: {
         agentId: metadata.agentId,

--- a/extensions/discord/src/exec-approvals.ts
+++ b/extensions/discord/src/exec-approvals.ts
@@ -95,7 +95,6 @@ export function shouldSuppressLocalDiscordExecApprovalPrompt(params: {
   const config = resolveDiscordAccount(params).config.execApprovals;
   return (
     params.hint?.kind === "approval-pending" &&
-    params.hint.nativeRouteActive === true &&
     isDiscordExecApprovalClientEnabled(params) &&
     metadata !== null &&
     matchesApprovalRequestFilters({

--- a/src/agents/bash-tools.exec-approval-request.test.ts
+++ b/src/agents/bash-tools.exec-approval-request.test.ts
@@ -37,6 +37,7 @@ vi.mock("./tools/gateway.js", () => ({
 
 let callGatewayTool: typeof import("./tools/gateway.js").callGatewayTool;
 let requestExecApprovalDecision: typeof import("./bash-tools.exec-approval-request.js").requestExecApprovalDecision;
+let registerExecApprovalRequest: typeof import("./bash-tools.exec-approval-request.js").registerExecApprovalRequest;
 let registerExecApprovalRequestForHost: typeof import("./bash-tools.exec-approval-request.js").registerExecApprovalRequestForHost;
 
 const initialProcessPlatform = Object.getOwnPropertyDescriptor(process, "platform");
@@ -72,8 +73,11 @@ function requireApprovalRequestPayload(callIndex: number): ApprovalRequestPayloa
 describe("requestExecApprovalDecision", () => {
   beforeAll(async () => {
     ({ callGatewayTool } = await import("./tools/gateway.js"));
-    ({ requestExecApprovalDecision, registerExecApprovalRequestForHost } =
-      await import("./bash-tools.exec-approval-request.js"));
+    ({
+      requestExecApprovalDecision,
+      registerExecApprovalRequest,
+      registerExecApprovalRequestForHost,
+    } = await import("./bash-tools.exec-approval-request.js"));
   });
 
   beforeEach(() => {
@@ -146,6 +150,30 @@ describe("requestExecApprovalDecision", () => {
       { timeoutMs: DEFAULT_APPROVAL_REQUEST_TIMEOUT_MS },
       { id: "approval-id" },
     );
+  });
+
+  it("preserves local prompt suppression from registration", async () => {
+    vi.mocked(callGatewayTool).mockResolvedValueOnce({
+      status: "accepted",
+      id: "approval-id",
+      expiresAtMs: 1234,
+      suppressLocalPrompt: true,
+    });
+
+    await expect(
+      registerExecApprovalRequest({
+        id: "approval-id",
+        command: "echo hi",
+        cwd: "/tmp",
+        host: "gateway",
+        security: "allowlist",
+        ask: "always",
+      }),
+    ).resolves.toEqual({
+      id: "approval-id",
+      expiresAtMs: 1234,
+      suppressLocalPrompt: true,
+    });
   });
 
   it("returns null for missing or non-string decisions", async () => {

--- a/src/agents/bash-tools.exec-approval-request.ts
+++ b/src/agents/bash-tools.exec-approval-request.ts
@@ -111,6 +111,7 @@ export type ExecApprovalRegistration = {
   id: string;
   expiresAtMs: number;
   finalDecision?: string | null;
+  suppressLocalPrompt?: boolean;
 };
 
 export async function registerExecApprovalRequest(
@@ -128,10 +129,20 @@ export async function registerExecApprovalRequest(
   const id = parseString(registrationResult?.id) ?? params.id;
   const expiresAtMs =
     parseExpiresAtMs(registrationResult?.expiresAtMs) ?? Date.now() + DEFAULT_APPROVAL_TIMEOUT_MS;
+  const suppressLocalPrompt = registrationResult?.suppressLocalPrompt === true;
   if (decision.present) {
-    return { id, expiresAtMs, finalDecision: decision.value };
+    return {
+      id,
+      expiresAtMs,
+      finalDecision: decision.value,
+      ...(suppressLocalPrompt ? { suppressLocalPrompt: true } : {}),
+    };
   }
-  return { id, expiresAtMs };
+  return {
+    id,
+    expiresAtMs,
+    ...(suppressLocalPrompt ? { suppressLocalPrompt: true } : {}),
+  };
 }
 
 export async function waitForExecApprovalDecision(id: string): Promise<string | null> {

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -514,6 +514,7 @@ export async function processGatewayAllowlist(
       initiatingSurface,
       sentApproverDms,
       unavailableReason,
+      suppressLocalPrompt,
     } = await createAndRegisterDefaultExecApprovalRequest({
       ...requestArgs,
       register: registerGatewayApproval,
@@ -719,6 +720,7 @@ export async function processGatewayAllowlist(
         initiatingSurface,
         sentApproverDms,
         unavailableReason,
+        suppressLocalPrompt,
         allowedDecisions: resolveExecApprovalAllowedDecisions({ ask: hostAsk }),
       }),
     };

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -108,6 +108,7 @@ export async function executeNodeHostCommand(
       initiatingSurface,
       sentApproverDms,
       unavailableReason,
+      suppressLocalPrompt,
     } = await execHostShared.createAndRegisterDefaultExecApprovalRequest({
       ...requestArgs,
       register: registerNodeApproval,
@@ -274,6 +275,7 @@ export async function executeNodeHostCommand(
         initiatingSurface,
         sentApproverDms,
         unavailableReason,
+        suppressLocalPrompt,
         allowedDecisions: resolveExecApprovalAllowedDecisions({ ask: hostAsk }),
         nodeId: target.nodeId,
       });

--- a/src/agents/bash-tools.exec-host-shared.test.ts
+++ b/src/agents/bash-tools.exec-host-shared.test.ts
@@ -325,6 +325,7 @@ describe("buildExecApprovalPendingToolResult", () => {
     channel: "discord" | "telegram";
     channelLabel: "Discord" | "Telegram";
     unavailableReason: "initiating-platform-disabled" | null;
+    suppressLocalPrompt?: boolean;
     allowedDecisions?: readonly ("allow-once" | "deny")[];
   }) {
     return buildExecApprovalPendingToolResult({
@@ -343,6 +344,7 @@ describe("buildExecApprovalPendingToolResult", () => {
       },
       sentApproverDms: false,
       unavailableReason: params.unavailableReason,
+      ...(params.suppressLocalPrompt === true ? { suppressLocalPrompt: true } : {}),
       ...(params.allowedDecisions ? { allowedDecisions: params.allowedDecisions } : {}),
     });
   }
@@ -369,6 +371,22 @@ describe("buildExecApprovalPendingToolResult", () => {
     const text = result.content.find((part) => part.type === "text")?.text ?? "";
     expect(text).toContain("/approve approval-slug allow-once");
     expect(text).not.toContain("native chat exec approvals are not configured on Discord");
+  });
+
+  it("carries local prompt suppression in pending details", () => {
+    const result = buildDisabledSurfaceApprovalResult({
+      channel: "discord",
+      channelLabel: "Discord",
+      unavailableReason: null,
+      suppressLocalPrompt: true,
+    });
+
+    expect(result.details).toEqual(
+      expect.objectContaining({
+        status: "approval-pending",
+        suppressLocalPrompt: true,
+      }),
+    );
   });
 
   it("returns an unavailable reply when Discord exec approvals are disabled", () => {

--- a/src/agents/bash-tools.exec-host-shared.ts
+++ b/src/agents/bash-tools.exec-host-shared.ts
@@ -80,6 +80,7 @@ export type RegisteredExecApprovalRequestContext = {
   initiatingSurface: ExecApprovalInitiatingSurfaceState;
   sentApproverDms: boolean;
   unavailableReason: ExecApprovalUnavailableReason | null;
+  suppressLocalPrompt?: boolean;
 };
 
 export type ExecApprovalFollowupTarget = {
@@ -300,6 +301,7 @@ export async function createAndRegisterDefaultExecApprovalRequest(params: {
     initiatingSurface,
     sentApproverDms,
     unavailableReason,
+    ...(registration.suppressLocalPrompt === true ? { suppressLocalPrompt: true } : {}),
   };
 }
 
@@ -455,6 +457,7 @@ export function buildExecApprovalPendingToolResult(params: {
   initiatingSurface: ExecApprovalInitiatingSurfaceState;
   sentApproverDms: boolean;
   unavailableReason: ExecApprovalUnavailableReason | null;
+  suppressLocalPrompt?: boolean;
   allowedDecisions?: readonly ExecApprovalDecision[];
   nodeId?: string;
 }): AgentToolResult<ExecToolDetails> {
@@ -511,6 +514,7 @@ export function buildExecApprovalPendingToolResult(params: {
             cwd: params.cwd,
             nodeId: params.nodeId,
             warningText: params.warningText,
+            ...(params.suppressLocalPrompt === true ? { suppressLocalPrompt: true } : {}),
           } satisfies ExecToolDetails),
   };
 }

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -102,6 +102,7 @@ export type ExecToolDetails =
       cwd?: string;
       nodeId?: string;
       warningText?: string;
+      suppressLocalPrompt?: boolean;
     }
   | {
       status: "approval-unavailable";

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -558,6 +558,7 @@ describe("handleToolExecutionEnd exec approval prompts", () => {
             command: "npm view diver name version description",
             cwd: "/tmp/work",
             warningText: "Warning: heredoc execution requires explicit approval in allowlist mode.",
+            suppressLocalPrompt: true,
           },
         },
       } as never,
@@ -575,6 +576,7 @@ describe("handleToolExecutionEnd exec approval prompts", () => {
         approvalSlug: "12345678",
         approvalKind: "exec",
         allowedDecisions: ["allow-once", "allow-always", "deny"],
+        suppressLocalPrompt: true,
       },
     );
     expectInteractiveApprovalButtons(result, [

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -453,6 +453,7 @@ function readExecApprovalPendingDetails(result: unknown): {
   cwd?: string;
   nodeId?: string;
   warningText?: string;
+  suppressLocalPrompt?: boolean;
 } | null {
   if (!result || typeof result !== "object") {
     return null;
@@ -487,6 +488,7 @@ function readExecApprovalPendingDetails(result: unknown): {
     cwd: readStringValue(details.cwd),
     nodeId: readStringValue(details.nodeId),
     warningText: readStringValue(details.warningText),
+    suppressLocalPrompt: details.suppressLocalPrompt === true,
   };
 }
 
@@ -568,6 +570,7 @@ async function emitToolResultOutput(params: {
           nodeId: approvalPending.nodeId,
           expiresAtMs: approvalPending.expiresAtMs,
           warningText: approvalPending.warningText,
+          ...(approvalPending.suppressLocalPrompt === true ? { suppressLocalPrompt: true } : {}),
         }),
       );
       ctx.state.deterministicApprovalPromptSent = true;

--- a/src/gateway/server-methods/approval-shared.test.ts
+++ b/src/gateway/server-methods/approval-shared.test.ts
@@ -272,6 +272,59 @@ describe("handlePendingApprovalRequest", () => {
 
     await Promise.resolve();
     expect(hasApprovalTurnSourceRouteMock).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ id: record.id, suppressLocalPrompt: true }),
+      undefined,
+    );
+
+    expect(manager.resolve(record.id, "allow-once")).toBe(true);
+    await requestPromise;
+  });
+
+  it("keeps local prompts visible when only a turn-source route is inferred", async () => {
+    const manager = new ExecApprovalManager();
+    const record = manager.create(
+      {
+        command: "echo ok",
+        turnSourceChannel: "discord",
+        turnSourceAccountId: "default",
+      },
+      60_000,
+      "approval-turn-source-only",
+    );
+    const decisionPromise = manager.register(record, 60_000);
+    const respond = vi.fn();
+    const requestPromise = handlePendingApprovalRequest({
+      manager,
+      record,
+      decisionPromise,
+      respond,
+      context: {
+        broadcast: vi.fn(),
+        hasExecApprovalClients: () => false,
+      } as unknown as GatewayRequestContext,
+      requestEventName: "exec.approval.requested",
+      requestEvent: {
+        id: record.id,
+        request: record.request,
+        createdAtMs: record.createdAtMs,
+        expiresAtMs: record.expiresAtMs,
+      },
+      twoPhase: true,
+      deliverRequest: () => false,
+    });
+
+    await Promise.resolve();
+    expect(hasApprovalTurnSourceRouteMock).toHaveBeenCalledWith({
+      turnSourceChannel: "discord",
+      turnSourceAccountId: "default",
+    });
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ id: record.id, suppressLocalPrompt: false }),
+      undefined,
+    );
 
     expect(manager.resolve(record.id, "allow-once")).toBe(true);
     await requestPromise;

--- a/src/gateway/server-methods/approval-shared.ts
+++ b/src/gateway/server-methods/approval-shared.ts
@@ -342,6 +342,7 @@ export async function handlePendingApprovalRequest<
         id: params.record.id,
         createdAtMs: params.record.createdAtMs,
         expiresAtMs: params.record.expiresAtMs,
+        suppressLocalPrompt: hasApprovalClients || delivered,
       },
       undefined,
     );

--- a/src/infra/exec-approval-reply.test.ts
+++ b/src/infra/exec-approval-reply.test.ts
@@ -290,6 +290,25 @@ describe("exec approval reply helpers", () => {
     expect(payload.text).toContain("Full id: `req-1`");
   });
 
+  it("carries local prompt suppression through pending reply metadata", () => {
+    const payload = buildExecApprovalPendingReplyPayload({
+      approvalId: "req-suppressed",
+      approvalSlug: "slug-suppressed",
+      command: "echo ok",
+      host: "gateway",
+      suppressLocalPrompt: true,
+    });
+
+    expect(getExecApprovalReplyMetadata(payload)?.suppressLocalPrompt).toBe(true);
+    expect(payload.channelData).toEqual({
+      execApproval: expect.objectContaining({
+        approvalId: "req-suppressed",
+        approvalSlug: "slug-suppressed",
+        suppressLocalPrompt: true,
+      }),
+    });
+  });
+
   it("compacts structured cwd paths in pending reply payloads", () => {
     const payload = buildExecApprovalPendingReplyPayload({
       approvalId: "req-home",

--- a/src/infra/exec-approval-reply.ts
+++ b/src/infra/exec-approval-reply.ts
@@ -35,6 +35,7 @@ export type ExecApprovalReplyMetadata = {
   agentId?: string;
   allowedDecisions?: readonly ExecApprovalReplyDecision[];
   sessionKey?: string;
+  suppressLocalPrompt?: boolean;
 };
 
 export type ExecApprovalActionDescriptor = {
@@ -57,6 +58,7 @@ export type ExecApprovalPendingReplyParams = {
   host: ExecHost;
   nodeId?: string;
   sessionKey?: string | null;
+  suppressLocalPrompt?: boolean;
   expiresAtMs?: number;
   nowMs?: number;
 };
@@ -341,6 +343,7 @@ export function getExecApprovalReplyMetadata(
     agentId,
     allowedDecisions,
     sessionKey,
+    ...(record.suppressLocalPrompt === true ? { suppressLocalPrompt: true } : {}),
   };
 }
 
@@ -407,6 +410,7 @@ export function buildExecApprovalPendingReplyPayload(
         agentId: normalizeOptionalString(params.agentId),
         allowedDecisions,
         sessionKey: normalizeOptionalString(params.sessionKey),
+        ...(params.suppressLocalPrompt === true ? { suppressLocalPrompt: true } : {}),
       },
     },
   };


### PR DESCRIPTION
## Summary
- suppress Discord local approval fallback prompts only when the request metadata proves an approval client or delivered route received the approval
- propagate the request-level `suppressLocalPrompt` signal from gateway registration through exec pending details into reply metadata
- add regression coverage for delivered/native-client suppression and route-only fallback visibility

## Verification
- fnm exec --using 22.21.0 pnpm test extensions/discord/src/exec-approvals.test.ts src/infra/exec-approval-reply.test.ts src/agents/bash-tools.exec-approval-request.test.ts src/agents/bash-tools.exec-host-shared.test.ts src/agents/pi-embedded-subscribe.handlers.tools.test.ts src/gateway/server-methods/approval-shared.test.ts -- --reporter=verbose
- fnm exec --using 22.21.0 pnpm tsgo:core
- fnm exec --using 22.21.0 pnpm tsgo:core:test
- fnm exec --using 22.21.0 pnpm tsgo:extensions
- fnm exec --using 22.21.0 pnpm tsgo:extensions:test
- git diff --check
