### PR TITLE
fix(memory-wiki): make wiki_lint report path tool-safe

### DIFF
--- a/extensions/memory-wiki/src/tool.test.ts
+++ b/extensions/memory-wiki/src/tool.test.ts
@@ -1,6 +1,12 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import type { ResolvedMemoryWikiConfig } from "./config.js";
-import { createWikiApplyTool } from "./tool.js";
+import { renderWikiMarkdown } from "./markdown.js";
+import { createMemoryWikiTestHarness } from "./test-helpers.js";
+import { createWikiApplyTool, createWikiLintTool } from "./tool.js";
+
+const { createVault } = createMemoryWikiTestHarness();
 
 function asSchemaObject(value: unknown): Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
@@ -10,6 +16,44 @@ function asSchemaObject(value: unknown): Record<string, unknown> {
 }
 
 describe("memory-wiki tools", () => {
+  it("returns relative bounded details from wiki_lint", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-tool-lint-",
+      config: {
+        vault: { renderMode: "obsidian" },
+      },
+    });
+    await fs.mkdir(path.join(rootDir, "entities"), { recursive: true });
+    await fs.writeFile(
+      path.join(rootDir, "entities", "alpha.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "entity",
+          id: "entity.alpha",
+          title: "Alpha",
+        },
+        body: "# Alpha\n\n[[missing-page]]\n",
+      }),
+      "utf8",
+    );
+
+    const tool = createWikiLintTool(config);
+    const result = await tool.execute("call-1", {});
+    const text = result.content
+      .map((entry) => (entry.type === "text" ? entry.text : ""))
+      .join("\n");
+    const details = asSchemaObject(result.details);
+
+    expect(text).toContain("Report: reports/lint.md");
+    expect(text).not.toContain(rootDir);
+    expect(details.reportPath).toBe("reports/lint.md");
+    expect(details).not.toHaveProperty("vaultRoot");
+    expect(JSON.stringify(details)).not.toContain(rootDir);
+    expect(asSchemaObject(details.issuesByCategory).links).toEqual(
+      expect.arrayContaining([expect.objectContaining({ code: "broken-wikilink" })]),
+    );
+  });
+
   it("allows provenance metadata in wiki_apply claim evidence", () => {
     const tool = createWikiApplyTool({} as ResolvedMemoryWikiConfig);
     const applyProperties = asSchemaObject(asSchemaObject(tool.parameters).properties);

--- a/extensions/memory-wiki/src/tool.ts
+++ b/extensions/memory-wiki/src/tool.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { Type } from "typebox";
 import type { AnyAgentTool, OpenClawConfig } from "../api.js";
 import { applyMemoryWikiMutation, normalizeMemoryWikiMutationInput } from "./apply.js";
@@ -92,6 +93,20 @@ type WikiToolMemoryContext = {
   sandboxed?: boolean;
 };
 
+function formatWikiToolReportPath(config: ResolvedMemoryWikiConfig, reportPath: string): string {
+  const vaultRoot = path.resolve(config.vault.path);
+  const resolvedReportPath = path.resolve(reportPath);
+  const relativeReportPath = path.relative(vaultRoot, resolvedReportPath);
+  if (
+    !relativeReportPath ||
+    relativeReportPath.startsWith("..") ||
+    path.isAbsolute(relativeReportPath)
+  ) {
+    return reportPath;
+  }
+  return relativeReportPath.replace(/\\/g, "/");
+}
+
 export function createWikiStatusTool(
   config: ResolvedMemoryWikiConfig,
   appConfig?: OpenClawConfig,
@@ -182,6 +197,7 @@ export function createWikiLintTool(
       const provenance = result.issuesByCategory.provenance.length;
       const errors = result.issues.filter((issue) => issue.severity === "error").length;
       const warnings = result.issues.filter((issue) => issue.severity === "warning").length;
+      const reportPath = formatWikiToolReportPath(config, result.reportPath);
       const summary =
         result.issueCount === 0
           ? "No wiki lint issues."
@@ -190,11 +206,16 @@ export function createWikiLintTool(
               `Contradictions: ${contradictions}`,
               `Open questions: ${openQuestions}`,
               `Provenance gaps: ${provenance}`,
-              `Report: ${result.reportPath}`,
+              `Report: ${reportPath}`,
             ].join("\n");
       return {
         content: [{ type: "text", text: summary }],
-        details: result,
+        details: {
+          issueCount: result.issueCount,
+          issues: result.issues,
+          issuesByCategory: result.issuesByCategory,
+          reportPath,
+        },
       };
     },
   };


### PR DESCRIPTION
## Summary

- Problem: `wiki_lint` can surface the linter's absolute report path in agent-tool text/details even though CLI lint succeeds.
- Root cause: `createWikiLintTool()` reused the raw `lintMemoryWikiVault()` result for both visible text and tool metadata. That raw result is correct for CLI/file callers because they need an absolute `reportPath`, but it is too path-heavy for model-visible tool output.
- Fix: keep `lintMemoryWikiVault()` and CLI behavior unchanged, but have the `wiki_lint` tool render and return a vault-relative `reportPath` such as `reports/lint.md`.
- Scope boundary: this only changes the memory-wiki agent tool wrapper and its regression test.

AI-assisted PR: yes. I used OpenClaw/Codex assistance, reviewed the diff, and verified the behavior below.

## Compatibility note

- This intentionally changes only the `wiki_lint` agent tool result shape.
- `details.reportPath` returned by the agent tool is now vault-relative, for example `reports/lint.md`.
- The agent tool no longer returns raw `vaultRoot` in `details`, so tool output does not expose the local vault root.
- The lower-level `lintMemoryWikiVault()` result is unchanged and still returns the absolute `reportPath` plus `vaultRoot`.
- CLI and gateway callers are unchanged: `openclaw wiki lint` and `wiki.lint` gateway calls still consume the raw linter result.
- Repo search found no internal consumer reading `details.reportPath` from the `wiki_lint` agent tool outside the new regression test.
- External consumers that used the agent tool `details.reportPath` as an absolute filesystem path should resolve the relative path against the configured wiki vault root, or call the CLI/gateway/linter surface that still returns absolute paths.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

Closes #83420.

## Real Behavior Proof

- Behavior or issue addressed: `wiki_lint` tool output should not expose the raw absolute lint report path in model-visible text or return the raw linter result object as tool details.
- Real environment tested: local OpenClaw checkout on Linux arm64, branch `fix-memory-wiki-lint-tool-output`, with an isolated temporary memory-wiki vault.
- Exact steps or command run after this patch: ran a direct `node --import tsx -e ...` harness that created a temporary wiki vault, wrote a lintable page, invoked `createWikiLintTool(config).execute(...)`, inspected the tool text/details, and compared that with the underlying linter/CLI report path shape.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): copied live console output from the after-fix harness:

```text
toolText=Issues: 3 total (0 errors, 3 warnings)
Contradictions: 0
Open questions: 0
Provenance gaps: 1
Report: reports/lint.md
toolDetailsReportPath=reports/lint.md
toolTextContainsVaultRoot=false
toolDetailsContainsVaultRoot=false
cliReportPathAbsolute=true
```

- Observed result after fix: the tool-visible summary and `details.reportPath` use `reports/lint.md`, while the underlying linter/CLI path remains absolute for file-oriented callers.
- What was not tested: I did not reproduce the exact full-runtime `unable to resolve opened file path` bridge failure. The proof covers the risky output shape at the tool wrapper where this patch changes behavior.
- Before evidence (optional but encouraged): before the patch, `createWikiLintTool()` rendered `result.reportPath` directly and returned `details: result`, so the direct tool output included the absolute vault report path.

## Regression Test Plan

- Added a focused regression in `extensions/memory-wiki/src/tool.test.ts` for `wiki_lint` tool output.
- The test asserts the visible report path is `reports/lint.md`, does not include the vault root, `details.reportPath` is relative, and the details payload does not include `vaultRoot`.

## Validation

Passed locally before opening this PR:

```text
git diff --check
OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test extensions/memory-wiki/src/tool.test.ts -- --reporter=verbose
OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test:extension memory-wiki -- --reporter=verbose
pnpm build
codex review --base origin/main
```

Results:

```text
focused tool test: passed
memory-wiki extension lane: 23 files passed, 112 tests passed
pnpm build: passed
codex review: no actionable findings on this patch
```

Not run locally: full `pnpm check` and full `pnpm test`. This was intentionally left to CI/Testbox because the local host is a low-memory Raspberry Pi-class machine and repo-wide checks overloaded the session.

## User-visible / Behavior Changes

`wiki_lint` tool responses now show the lint report path relative to the vault (`reports/lint.md`) instead of an absolute local filesystem path. CLI lint behavior is unchanged.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Risks and Mitigations

- Risk: a tool consumer that treated `details.reportPath` as an absolute path will now receive a vault-relative path.
- Mitigation: this is limited to the agent tool wrapper. `lintMemoryWikiVault()` and CLI/file callers still receive the absolute report path. The agent-facing tool payload avoids exposing the local vault root in text or details.
