### PR TITLE
Fix final reply delivery after previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Replies: keep final payload delivery after live preview updates so channels can finalize or send the completed answer instead of losing preview-only drafts. (#83468)
 - Providers/Xiaomi: replay MiMo Anthropic-compatible `reasoning_content` as provider-required thinking blocks even when OpenClaw thinking is disabled, fixing follow-up tool turns for `mimo-v2-flash`. Fixes #83407. Thanks @Xgenious7.
 - Agents/exec approvals: forward approval-runtime credentials on agent-owned Gateway approval calls so approved async commands complete through the existing runtime path instead of stalling on unauthenticated follow-up calls. Thanks @IWhatsskill, @Patrick-Erichsen, and @jesse-merhi.
 - Gateway/skills: preflight remote macOS skill-bin refreshes with a WebSocket connectivity check so stale node sessions skip quickly instead of logging slow `system.which` timeout warnings.

--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -490,63 +490,6 @@ describe("buildReplyPayloads media filter integration", () => {
     expect(replyPayloads).toHaveLength(0);
   });
 
-  it("suppresses final text payloads already covered by partial preview streaming", async () => {
-    const { replyPayloads } = await buildReplyPayloads({
-      ...baseParams,
-      previewStreamedText: "First block\n\nSecond block",
-      payloads: [{ text: "First block" }, { text: "Second block" }],
-    });
-
-    expect(replyPayloads).toHaveLength(0);
-  });
-
-  it("keeps final text that was not covered by partial preview streaming", async () => {
-    const { replyPayloads } = await buildReplyPayloads({
-      ...baseParams,
-      previewStreamedText: "Working...",
-      payloads: [{ text: "Done." }],
-    });
-
-    expect(replyPayloads).toHaveLength(1);
-    expectFields(replyPayloads[0], { text: "Done." });
-  });
-
-  it("does not suppress short final text just because it appears inside preview text", async () => {
-    const { replyPayloads } = await buildReplyPayloads({
-      ...baseParams,
-      previewStreamedText: "Working on item 3",
-      payloads: [{ text: "3" }],
-    });
-
-    expect(replyPayloads).toHaveLength(1);
-    expectFields(replyPayloads[0], { text: "3" });
-  });
-
-  it("preserves media while removing duplicate preview-streamed caption text", async () => {
-    const { replyPayloads } = await buildReplyPayloads({
-      ...baseParams,
-      previewStreamedText: "Here is the chart",
-      payloads: [{ text: "Here is the chart", mediaUrl: "file:///tmp/chart.png" }],
-    });
-
-    expect(replyPayloads).toHaveLength(1);
-    expectFields(replyPayloads[0], {
-      text: undefined,
-      mediaUrl: "file:///tmp/chart.png",
-    });
-  });
-
-  it("preserves errors even when their text appears in partial preview streaming", async () => {
-    const { replyPayloads } = await buildReplyPayloads({
-      ...baseParams,
-      previewStreamedText: "Agent couldn't generate a response. Please try again.",
-      payloads: [{ text: "Agent couldn't generate a response. Please try again.", isError: true }],
-    });
-
-    expect(replyPayloads).toHaveLength(1);
-    expectFields(replyPayloads[0], { isError: true });
-  });
-
   it("drops all final payloads when block pipeline streamed successfully", async () => {
     const pipeline: Parameters<typeof buildReplyPayloads>[0]["blockReplyPipeline"] = {
       didStream: () => true,

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -163,7 +163,6 @@ export async function buildReplyPayloads(params: {
   blockStreamingEnabled: boolean;
   blockReplyPipeline: BlockReplyPipeline | null;
   /** Payload keys sent directly (not via pipeline) during tool flush. */
-  previewStreamedText?: string;
   directlySentBlockKeys?: Set<string>;
   replyToMode: ReplyToMode;
   replyToChannel?: OriginatingChannelType;
@@ -330,54 +329,6 @@ export async function buildReplyPayloads(params: {
     : mediaFilteredPayloads;
   const isDirectlySentBlockPayload = (payload: ReplyPayload) =>
     Boolean(params.directlySentBlockKeys?.has(createBlockReplyContentKey(payload)));
-  const normalizePreviewDedupeText = (value: string | undefined): string =>
-    (value ?? "").replace(/\s+/g, " ").trim();
-  const buildPreviewDedupeTextSet = (value: string | undefined): Set<string> => {
-    const dedupeText = new Set<string>();
-    const normalizedWhole = normalizePreviewDedupeText(value);
-    if (normalizedWhole) {
-      dedupeText.add(normalizedWhole);
-    }
-    for (const block of (value ?? "").split(/\n{2,}/u)) {
-      const normalizedBlock = normalizePreviewDedupeText(block);
-      if (normalizedBlock) {
-        dedupeText.add(normalizedBlock);
-      }
-    }
-    return dedupeText;
-  };
-  const previewStreamedText = buildPreviewDedupeTextSet(params.previewStreamedText);
-  const isPreviewStreamedTextPayload = (payload: ReplyPayload): boolean => {
-    if (previewStreamedText.size === 0 || payload.isError) {
-      return false;
-    }
-    const text = normalizePreviewDedupeText(payload.text);
-    return Boolean(text && previewStreamedText.has(text));
-  };
-  const preserveUnsentMediaAfterPreviewStream = (payload: ReplyPayload): ReplyPayload | null => {
-    if (!isPreviewStreamedTextPayload(payload)) {
-      return payload;
-    }
-    const reply = resolveSendableOutboundReplyParts(payload);
-    if (!reply.hasMedia) {
-      return null;
-    }
-    return copyReplyPayloadMetadata(payload, {
-      ...payload,
-      text: undefined,
-      audioAsVoice: payload.audioAsVoice || undefined,
-    });
-  };
-  const suppressPreviewStreamedPayloads = (payloads: ReplyPayload[]): ReplyPayload[] => {
-    const unsent: ReplyPayload[] = [];
-    for (const payload of payloads) {
-      const next = preserveUnsentMediaAfterPreviewStream(payload);
-      if (next) {
-        unsent.push(next);
-      }
-    }
-    return unsent;
-  };
   const preserveUnsentMediaAfterBlockStream = (payload: ReplyPayload): ReplyPayload | null => {
     if (payload.isError || payload.isFallbackNotice) {
       return payload;
@@ -438,9 +389,7 @@ export async function buildReplyPayloads(params: {
             }
             return unsent;
           })()
-        : previewStreamedText.size > 0
-          ? suppressPreviewStreamedPayloads(dedupedPayloads)
-          : dedupedPayloads;
+        : dedupedPayloads;
   const blockSentMediaUrls = params.blockStreamingEnabled
     ? await normalizeSentMediaUrlsForDedupe({
         sentMediaUrls: params.blockReplyPipeline?.getSentMediaUrls() ?? [],

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -622,7 +622,7 @@ describe("runReplyAgent typing (heartbeat)", () => {
     }
   });
 
-  it("suppresses final text blocks already delivered through partial preview streaming", async () => {
+  it("keeps final text blocks after partial preview streaming", async () => {
     const onPartialReply = vi.fn();
     state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: AgentRunParams) => {
       await params.onPartialReply?.({ text: "First block\n\nSecond block" });
@@ -640,7 +640,10 @@ describe("runReplyAgent typing (heartbeat)", () => {
     const result = await run();
 
     expect(onPartialReply).toHaveBeenCalledWith({ text: "First block\n\nSecond block" });
-    expect(result).toBeUndefined();
+    expect(result).toEqual([
+      expect.objectContaining({ text: "First block" }),
+      expect.objectContaining({ text: "Second block" }),
+    ]);
   });
 
   it("suppresses narrated silent-turn partials, block replies, and final payloads", async () => {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1278,20 +1278,6 @@ export async function runReplyAgent(params: {
       : null;
 
   const replySessionKey = sessionKey ?? followupRun.run.sessionKey;
-  let latestPreviewStreamedText: string | undefined;
-  const effectiveOpts = opts?.onPartialReply
-    ? {
-        ...opts,
-        onPartialReply: async (
-          payload: Parameters<NonNullable<GetReplyOptions["onPartialReply"]>>[0],
-        ) => {
-          if (typeof payload.text === "string" && payload.text.trim()) {
-            latestPreviewStreamedText = payload.text;
-          }
-          await opts.onPartialReply?.(payload);
-        },
-      }
-    : opts;
   let replyOperation: ReplyOperation;
   try {
     replyOperation =
@@ -1475,7 +1461,7 @@ export async function runReplyAgent(params: {
         sessionCtx,
         replyThreading: replyThreadingOverride ?? sessionCtx.ReplyThreading,
         replyOperation,
-        opts: effectiveOpts,
+        opts,
         typingSignals,
         blockReplyPipeline,
         blockStreamingEnabled,
@@ -1753,7 +1739,6 @@ export async function runReplyAgent(params: {
       silentExpected: followupRun.run.silentExpected,
       blockStreamingEnabled,
       blockReplyPipeline,
-      previewStreamedText: latestPreviewStreamedText,
       directlySentBlockKeys,
       replyToMode,
       replyToChannel,


### PR DESCRIPTION
Summary
- Stop treating partial preview text as proof that a final reply was delivered.
- Keep final payload delivery owned by the normal delivery evidence paths: block streaming, direct block sends, and message-tool sent text.
- Flip the regression test so matching final text after a preview still returns for channel delivery.

Verification
- pnpm test src/auto-reply/reply/agent-runner-payloads.test.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
- pnpm check:changed
