### PR TITLE
fix(qa): stream mock response text deltas

### DIFF
--- a/scripts/e2e/mock-openai-server.mjs
+++ b/scripts/e2e/mock-openai-server.mjs
@@ -27,22 +27,37 @@ function writeJson(res, status, body) {
 }
 
 function responseEvents(text) {
+  const itemId = "msg_e2e_1";
   return [
     {
       type: "response.output_item.added",
       item: {
         type: "message",
-        id: "msg_e2e_1",
+        id: itemId,
         role: "assistant",
         content: [],
         status: "in_progress",
       },
     },
     {
+      type: "response.output_text.delta",
+      item_id: itemId,
+      output_index: 0,
+      content_index: 0,
+      delta: text,
+    },
+    {
+      type: "response.output_text.done",
+      item_id: itemId,
+      output_index: 0,
+      content_index: 0,
+      text,
+    },
+    {
       type: "response.output_item.done",
       item: {
         type: "message",
-        id: "msg_e2e_1",
+        id: itemId,
         role: "assistant",
         status: "completed",
         content: [{ type: "output_text", text, annotations: [] }],
@@ -51,7 +66,17 @@ function responseEvents(text) {
     {
       type: "response.completed",
       response: {
+        id: "resp_e2e",
         status: "completed",
+        output: [
+          {
+            type: "message",
+            id: itemId,
+            role: "assistant",
+            status: "completed",
+            content: [{ type: "output_text", text, annotations: [] }],
+          },
+        ],
         usage: {
           input_tokens: 11,
           output_tokens: 7,


### PR DESCRIPTION
## Summary
- update the RTT mock OpenAI server to emit Responses API text delta/done stream events
- include final response output content on completion so the PI runtime can project visible assistant text

## Verification
- `git diff --check HEAD~1..HEAD`
- local mock stream probe against `scripts/e2e/mock-openai-server.mjs` verified `response.output_text.delta`, `response.output_text.done`, and `OPENCLAW_E2E_OK_42` in the stream

## Real behavior proof
Behavior addressed: Telegram release RTT samples can complete through the PI runtime instead of ending with no visible final response after the mock model turn.

Real environment tested: local harness mock server stream contract; release channel reruns will provide the real Telegram channel proof after this lands.

Exact steps or command run after this patch: started `scripts/e2e/mock-openai-server.mjs`, posted a streaming `/v1/responses` request containing `Reply OPENCLAW_E2E_OK_42`, and asserted the stream contained text delta/done events and the expected response text.

Evidence after fix: the probe printed `mock stream proof passed after rebase`.

Observed result after fix: the mock server now emits the text stream events consumed by the PI runtime, plus completed output content.

What was not tested: full Telegram release RTT in GitHub Actions has not been rerun yet because this fix needs to land on `main` first.
