### PR TITLE
test(plugin-sdk): align debouncer runtime mock

### DIFF
--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.test.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.test.ts
@@ -1,0 +1,16 @@
+import { createPluginRuntimeMock } from "openclaw/plugin-sdk/channel-test-helpers";
+import { describe, expect, it, vi } from "vitest";
+
+describe("createPluginRuntimeMock", () => {
+  it("keeps the inbound debouncer mock aligned with the runtime contract", () => {
+    const runtime = createPluginRuntimeMock();
+    const debouncer = runtime.channel.debounce.createInboundDebouncer({
+      debounceMs: 0,
+      buildKey: () => "key",
+      onFlush: vi.fn(),
+    });
+
+    expect(debouncer.cancelKey("key")).toBe(false);
+    expect(vi.isMockFunction(debouncer.cancelKey)).toBe(true);
+  });
+});

--- a/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
+++ b/src/plugin-sdk/test-helpers/plugin-runtime-mock.ts
@@ -605,6 +605,7 @@ export function createPluginRuntimeMock(overrides: DeepPartial<PluginRuntime> = 
               await params.onFlush([item]);
             },
             flushKey: vi.fn(),
+            cancelKey: vi.fn(() => false),
           }),
         ) as unknown as PluginRuntime["channel"]["debounce"]["createInboundDebouncer"],
         resolveInboundDebounceMs: vi.fn((params: unknown) => {


### PR DESCRIPTION
## Summary

- add `cancelKey` to the shared plugin runtime debouncer mock so it matches the public runtime contract
- add a focused regression test for `createPluginRuntimeMock().channel.debounce.createInboundDebouncer()`

Follow-up to #83248.

## Verification

- `node_modules/.bin/oxfmt --threads=1 src/plugin-sdk/test-helpers/plugin-runtime-mock.ts src/plugin-sdk/test-helpers/plugin-runtime-mock.test.ts`: passed
- `git diff --check`: passed
- `node scripts/run-vitest.mjs src/plugin-sdk/test-helpers/plugin-runtime-mock.test.ts`: passed, 1 file / 1 test
- Testbox-through-Crabbox `check:changed`: passed on `tbx_01krwvykrzanany84vj7e598z9`, Actions run `https://github.com/openclaw/openclaw/actions/runs/26017059067`

## Real behavior proof

Behavior addressed: plugin tests using `createPluginRuntimeMock()` can call the public inbound debouncer cancellation API without failing at runtime with `cancelKey is not a function`.

Real environment tested: local Codex worktree focused Vitest test, plus Blacksmith Testbox via Crabbox wrapper using the OpenClaw CI check workflow.

Exact steps or command run after this patch: `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --blacksmith-workflow ci-check-testbox.yml --blacksmith-job check --keep-on-failure --shell -- "git fetch origin +refs/heads/main:refs/remotes/origin/main +refs/heads/fix/plugin-runtime-debouncer-cancel-mock:refs/remotes/origin/fix/plugin-runtime-debouncer-cancel-mock && git checkout --force refs/remotes/origin/fix/plugin-runtime-debouncer-cancel-mock && git reset --hard HEAD && git status --short && git diff --name-only origin/main...HEAD | wc -l && pnpm --config.verify-deps-before-run=false check:changed"`.

Evidence after fix: the focused test constructs the shared plugin runtime mock, creates an inbound debouncer, calls `cancelKey`, and verifies it is a mock function returning `false`. The Testbox run checked out branch head `3dc59903af0`, confirmed a 2-file branch diff, and completed `check:changed` successfully.

Observed result after fix: the mock exposes `enqueue`, `flushKey`, and `cancelKey`, matching the public debouncer shape used by plugin runtime tests.

What was not tested: a real plugin runtime cancellation flow; this fix only updates the shared test helper contract.
