### PR TITLE
fix(onboard): fall back to fs.rm when 'trash' command is unavailable (#83459)

### DIFF
--- a/src/commands/agents.delete.test.ts
+++ b/src/commands/agents.delete.test.ts
@@ -20,6 +20,10 @@ const gatewayMocks = vi.hoisted(() => ({
   isGatewayTransportError: vi.fn(),
 }));
 
+const trashMocks = vi.hoisted(() => ({
+  movePathToTrash: vi.fn(async () => "/tmp/openclaw-trash/trashed"),
+}));
+
 vi.mock("../config/config.js", async () => ({
   ...(await vi.importActual<typeof import("../config/config.js")>("../config/config.js")),
   readConfigFileSnapshot: configMocks.readConfigFileSnapshot,
@@ -33,6 +37,10 @@ vi.mock("../gateway/call.js", () => ({
 
 vi.mock("../process/exec.js", () => ({
   runCommandWithTimeout: processMocks.runCommandWithTimeout,
+}));
+
+vi.mock("../plugin-sdk/browser-maintenance.js", () => ({
+  movePathToTrash: trashMocks.movePathToTrash,
 }));
 
 import { agentsDeleteCommand } from "./agents.js";
@@ -85,6 +93,7 @@ describe("agents delete command", () => {
     configMocks.readConfigFileSnapshot.mockReset();
     configMocks.replaceConfigFile.mockReset();
     processMocks.runCommandWithTimeout.mockClear();
+    trashMocks.movePathToTrash.mockClear();
     gatewayMocks.callGateway.mockReset();
     gatewayMocks.callGateway.mockRejectedValue(
       Object.assign(new Error("closed"), { name: "GatewayTransportError" }),
@@ -282,9 +291,9 @@ describe("agents delete command", () => {
       expect(jsonOutput[0]?.workspaceRetained).toBe(true);
       expect(jsonOutput[0]?.workspaceRetainedReason).toBe("shared");
       expect(jsonOutput[0]?.workspaceSharedWith).toEqual(["main"]);
-      expect(processMocks.runCommandWithTimeout).not.toHaveBeenCalledWith(
-        ["trash", sharedWorkspace],
-        { timeoutMs: 5000 },
+      expect(trashMocks.movePathToTrash).not.toHaveBeenCalledWith(
+        sharedWorkspace,
+        expect.anything(),
       );
     });
   });
@@ -319,9 +328,9 @@ describe("agents delete command", () => {
       const output = readJsonLogs()[0];
       expect(output?.workspaceRetained).toBe(true);
       expect(output?.workspaceSharedWith).toEqual(["main"]);
-      expect(processMocks.runCommandWithTimeout).not.toHaveBeenCalledWith(
-        ["trash", childWorkspace],
-        { timeoutMs: 5000 },
+      expect(trashMocks.movePathToTrash).not.toHaveBeenCalledWith(
+        childWorkspace,
+        expect.anything(),
       );
     });
   });
@@ -356,9 +365,9 @@ describe("agents delete command", () => {
       const output = readJsonLogs()[0];
       expect(output?.workspaceRetained).toBe(true);
       expect(output?.workspaceSharedWith).toEqual(["main"]);
-      expect(processMocks.runCommandWithTimeout).not.toHaveBeenCalledWith(
-        ["trash", sharedWorkspace],
-        { timeoutMs: 5000 },
+      expect(trashMocks.movePathToTrash).not.toHaveBeenCalledWith(
+        sharedWorkspace,
+        expect.anything(),
       );
     });
   });
@@ -396,9 +405,9 @@ describe("agents delete command", () => {
         const output = readJsonLogs()[0];
         expect(output?.workspaceRetained).toBe(true);
         expect(output?.workspaceSharedWith).toEqual(["main"]);
-        expect(processMocks.runCommandWithTimeout).not.toHaveBeenCalledWith(
-          ["trash", aliasWorkspace],
-          { timeoutMs: 5000 },
+        expect(trashMocks.movePathToTrash).not.toHaveBeenCalledWith(
+          aliasWorkspace,
+          expect.anything(),
         );
       });
     },
@@ -432,9 +441,8 @@ describe("agents delete command", () => {
 
       await agentsDeleteCommand({ id: "ops", force: true, json: true }, runtime);
 
-      // trash command should have been called for the workspace
-      expect(processMocks.runCommandWithTimeout).toHaveBeenCalledWith(["trash", opsWorkspace], {
-        timeoutMs: 5000,
+      expect(trashMocks.movePathToTrash).toHaveBeenCalledWith(opsWorkspace, {
+        allowedRoots: [path.dirname(path.resolve(opsWorkspace))],
       });
     });
   });

--- a/src/commands/onboard-helpers.test.ts
+++ b/src/commands/onboard-helpers.test.ts
@@ -6,6 +6,7 @@ import type { RuntimeEnv } from "../runtime.js";
 import { withMockedPlatform } from "../test-utils/vitest-spies.js";
 import {
   handleReset,
+  moveToTrash,
   normalizeGatewayTokenInput,
   openUrl,
   probeGatewayReachable,
@@ -98,6 +99,87 @@ describe("handleReset", () => {
       workspaceDir,
     ]);
     expect(trashedPaths).not.toContain(defaultCredentialsDir);
+  });
+});
+
+describe("moveToTrash", () => {
+  it("falls back to fs.rm when `trash` is unavailable (#83459)", async () => {
+    // Reproduces the official Docker image scenario: `trash-cli` is not
+    // installed, so the `trash` command rejects with ENOENT (or similar
+    // spawn failure). Previously this left the directory on disk and only
+    // logged a "manual delete" message — silent leak per #83459.
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-trash-fallback-"));
+    const targetDir = path.join(tmpRoot, "agent-workspace");
+    fs.mkdirSync(targetDir, { recursive: true });
+    fs.writeFileSync(path.join(targetDir, "session.jsonl"), "{}\n");
+
+    mocks.runCommandWithTimeout.mockRejectedValueOnce(
+      Object.assign(new Error("spawn trash ENOENT"), { code: "ENOENT" }),
+    );
+    const runtime = { log: vi.fn() } as unknown as RuntimeEnv;
+
+    await moveToTrash(targetDir, runtime);
+
+    expect(fs.existsSync(targetDir)).toBe(false);
+    const logMessages = (runtime.log as ReturnType<typeof vi.fn>).mock.calls
+      .map((call) => String(call[0]))
+      .join("\n");
+    expect(logMessages).toContain("Deleted (trash unavailable)");
+
+    // Cleanup
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("uses `trash` when available and does not fall back (#83459 — happy path)", async () => {
+    // Negative-control: when `trash` succeeds, the fallback must NOT run.
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-trash-ok-"));
+    const targetDir = path.join(tmpRoot, "agent-workspace-ok");
+    fs.mkdirSync(targetDir, { recursive: true });
+
+    // Default mock resolves with code:0 — simulates trash-cli present.
+    // But: trash doesn't actually move the dir in the test, so the dir
+    // still exists. We assert the log message reflects the trash path,
+    // not the fallback.
+    const runtime = { log: vi.fn() } as unknown as RuntimeEnv;
+    await moveToTrash(targetDir, runtime);
+
+    const logMessages = (runtime.log as ReturnType<typeof vi.fn>).mock.calls
+      .map((call) => String(call[0]))
+      .join("\n");
+    expect(logMessages).toContain("Moved to Trash:");
+    expect(logMessages).not.toContain("Deleted (trash unavailable)");
+
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("logs and returns when neither trash nor fs.rm succeeds (#83459 — degraded)", async () => {
+    // Extreme-degraded case: trash fails AND fs.rm fails (e.g., permission
+    // denied on a read-only mount). Should log the failure with the actual
+    // error message instead of corrupting state.
+    const fakePath = "/nonexistent/path/that/cannot/be/removed";
+    // First need fs.access to succeed (or function returns early). Use a real
+    // temp path that exists, then point fs.rm at a path we can't remove.
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-trash-fail-"));
+    const targetDir = path.join(tmpRoot, "exists");
+    fs.mkdirSync(targetDir, { recursive: true });
+
+    mocks.runCommandWithTimeout.mockRejectedValueOnce(new Error("spawn trash ENOENT"));
+    const rmSpy = vi.spyOn(fs.promises, "rm").mockRejectedValueOnce(
+      Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" }),
+    );
+    const runtime = { log: vi.fn() } as unknown as RuntimeEnv;
+
+    await moveToTrash(targetDir, runtime);
+
+    const logMessages = (runtime.log as ReturnType<typeof vi.fn>).mock.calls
+      .map((call) => String(call[0]))
+      .join("\n");
+    expect(logMessages).toContain("Failed to delete");
+    expect(logMessages).toContain("EACCES: permission denied");
+
+    rmSpy.mockRestore();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+    void fakePath;
   });
 });
 

--- a/src/commands/onboard-helpers.test.ts
+++ b/src/commands/onboard-helpers.test.ts
@@ -31,6 +31,10 @@ const mocks = vi.hoisted(() => ({
   })),
   pickPrimaryTailnetIPv4: vi.fn<() => string | undefined>(() => undefined),
   probeGateway: vi.fn(),
+  movePathToTrash: vi.fn(async (targetPath: string) => {
+    fs.rmSync(targetPath, { recursive: true, force: true });
+    return path.join(os.tmpdir(), "openclaw-trash", path.basename(targetPath));
+  }),
 }));
 
 vi.mock("../process/exec.js", () => ({
@@ -43,6 +47,10 @@ vi.mock("../infra/tailnet.js", () => ({
 
 vi.mock("../gateway/probe.js", () => ({
   probeGateway: mocks.probeGateway,
+}));
+
+vi.mock("../plugin-sdk/browser-maintenance.js", () => ({
+  movePathToTrash: mocks.movePathToTrash,
 }));
 
 afterEach(() => {
@@ -91,7 +99,7 @@ describe("handleReset", () => {
 
     await handleReset("full", workspaceDir, runtime);
 
-    const trashedPaths = mocks.runCommandWithTimeout.mock.calls.map(([argv]) => argv[1]);
+    const trashedPaths = mocks.movePathToTrash.mock.calls.map(([pathname]) => pathname);
     expect(trashedPaths).toEqual([
       profileConfigPath,
       profileCredentialsDir,
@@ -103,43 +111,35 @@ describe("handleReset", () => {
 });
 
 describe("moveToTrash", () => {
-  it("falls back to fs.rm when `trash` is unavailable (#83459)", async () => {
+  it("uses the shared fs-safe Trash helper when PATH trash is unavailable (#83459)", async () => {
     // Reproduces the official Docker image scenario: `trash-cli` is not
-    // installed, so the `trash` command rejects with ENOENT (or similar
-    // spawn failure). Previously this left the directory on disk and only
-    // logged a "manual delete" message — silent leak per #83459.
+    // installed. The command cleanup path must not depend on a PATH-resolved
+    // `trash` binary, and it must preserve Trash-style semantics.
     const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-trash-fallback-"));
     const targetDir = path.join(tmpRoot, "agent-workspace");
     fs.mkdirSync(targetDir, { recursive: true });
     fs.writeFileSync(path.join(targetDir, "session.jsonl"), "{}\n");
-
-    mocks.runCommandWithTimeout.mockRejectedValueOnce(
-      Object.assign(new Error("spawn trash ENOENT"), { code: "ENOENT" }),
-    );
     const runtime = { log: vi.fn() } as unknown as RuntimeEnv;
 
     await moveToTrash(targetDir, runtime);
 
     expect(fs.existsSync(targetDir)).toBe(false);
+    expect(mocks.runCommandWithTimeout).not.toHaveBeenCalled();
+    expect(mocks.movePathToTrash).toHaveBeenCalledWith(targetDir);
     const logMessages = (runtime.log as ReturnType<typeof vi.fn>).mock.calls
       .map((call) => String(call[0]))
       .join("\n");
-    expect(logMessages).toContain("Deleted (trash unavailable)");
+    expect(logMessages).toContain("Moved to Trash:");
 
     // Cleanup
     fs.rmSync(tmpRoot, { recursive: true, force: true });
   });
 
-  it("uses `trash` when available and does not fall back (#83459 — happy path)", async () => {
-    // Negative-control: when `trash` succeeds, the fallback must NOT run.
+  it("does not invoke a PATH-resolved trash command (#83459)", async () => {
     const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-trash-ok-"));
     const targetDir = path.join(tmpRoot, "agent-workspace-ok");
     fs.mkdirSync(targetDir, { recursive: true });
 
-    // Default mock resolves with code:0 — simulates trash-cli present.
-    // But: trash doesn't actually move the dir in the test, so the dir
-    // still exists. We assert the log message reflects the trash path,
-    // not the fallback.
     const runtime = { log: vi.fn() } as unknown as RuntimeEnv;
     await moveToTrash(targetDir, runtime);
 
@@ -147,24 +147,20 @@ describe("moveToTrash", () => {
       .map((call) => String(call[0]))
       .join("\n");
     expect(logMessages).toContain("Moved to Trash:");
-    expect(logMessages).not.toContain("Deleted (trash unavailable)");
+    expect(mocks.runCommandWithTimeout).not.toHaveBeenCalled();
 
     fs.rmSync(tmpRoot, { recursive: true, force: true });
   });
 
-  it("logs and returns when neither trash nor fs.rm succeeds (#83459 — degraded)", async () => {
-    // Extreme-degraded case: trash fails AND fs.rm fails (e.g., permission
+  it("logs and returns when the shared Trash helper fails (#83459 — degraded)", async () => {
+    // Extreme-degraded case: movePathToTrash fails (e.g., permission
     // denied on a read-only mount). Should log the failure with the actual
     // error message instead of corrupting state.
-    const fakePath = "/nonexistent/path/that/cannot/be/removed";
-    // First need fs.access to succeed (or function returns early). Use a real
-    // temp path that exists, then point fs.rm at a path we can't remove.
     const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-trash-fail-"));
     const targetDir = path.join(tmpRoot, "exists");
     fs.mkdirSync(targetDir, { recursive: true });
 
-    mocks.runCommandWithTimeout.mockRejectedValueOnce(new Error("spawn trash ENOENT"));
-    const rmSpy = vi.spyOn(fs.promises, "rm").mockRejectedValueOnce(
+    mocks.movePathToTrash.mockRejectedValueOnce(
       Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" }),
     );
     const runtime = { log: vi.fn() } as unknown as RuntimeEnv;
@@ -174,12 +170,10 @@ describe("moveToTrash", () => {
     const logMessages = (runtime.log as ReturnType<typeof vi.fn>).mock.calls
       .map((call) => String(call[0]))
       .join("\n");
-    expect(logMessages).toContain("Failed to delete");
+    expect(logMessages).toContain("Failed to move to Trash");
     expect(logMessages).toContain("EACCES: permission denied");
 
-    rmSpy.mockRestore();
     fs.rmSync(tmpRoot, { recursive: true, force: true });
-    void fakePath;
   });
 });
 

--- a/src/commands/onboard-helpers.test.ts
+++ b/src/commands/onboard-helpers.test.ts
@@ -125,7 +125,9 @@ describe("moveToTrash", () => {
 
     expect(fs.existsSync(targetDir)).toBe(false);
     expect(mocks.runCommandWithTimeout).not.toHaveBeenCalled();
-    expect(mocks.movePathToTrash).toHaveBeenCalledWith(targetDir);
+    expect(mocks.movePathToTrash).toHaveBeenCalledWith(targetDir, {
+      allowedRoots: [path.dirname(path.resolve(targetDir))],
+    });
     const logMessages = (runtime.log as ReturnType<typeof vi.fn>).mock.calls
       .map((call) => String(call[0]))
       .join("\n");

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -255,7 +255,7 @@ export async function moveToTrash(pathname: string, runtime: RuntimeEnv): Promis
     return;
   }
   try {
-    await movePathToTrash(pathname);
+    await movePathToTrash(pathname, { allowedRoots: [path.dirname(path.resolve(pathname))] });
     runtime.log(`Moved to Trash: ${shortenHomePath(pathname)}`);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -257,8 +257,25 @@ export async function moveToTrash(pathname: string, runtime: RuntimeEnv): Promis
   try {
     await runCommandWithTimeout(["trash", pathname], { timeoutMs: 5000 });
     runtime.log(`Moved to Trash: ${shortenHomePath(pathname)}`);
+    return;
   } catch {
-    runtime.log(`Failed to move to Trash (manual delete): ${shortenHomePath(pathname)}`);
+    // #83459: `trash` is not installed in every environment (notably the
+    // official Docker image, which intentionally keeps default apt packages
+    // minimal and lets operators add extras via OPENCLAW_IMAGE_APT_PACKAGES).
+    // Previously the failure path only logged and left the path on disk,
+    // producing silent leaks of `agents delete`-d workspaces and config
+    // dirs. Fall back to an unrecoverable `fs.rm({recursive,force})` so the
+    // operation completes its semantic contract; surface the fallback in
+    // the log so operators see the trash-vs-rm distinction.
+  }
+  try {
+    await fs.rm(pathname, { recursive: true, force: true });
+    runtime.log(`Deleted (trash unavailable): ${shortenHomePath(pathname)}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    runtime.log(
+      `Failed to delete ${shortenHomePath(pathname)}: ${message} (manually remove if needed)`,
+    );
   }
 }
 

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -17,7 +17,7 @@ import {
   resolveBrowserOpenCommand,
 } from "../infra/browser-open.js";
 import { detectBinary } from "../infra/detect-binary.js";
-import { runCommandWithTimeout } from "../process/exec.js";
+import { movePathToTrash } from "../plugin-sdk/browser-maintenance.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { visibleWidth } from "../terminal/ansi.js";
@@ -255,26 +255,12 @@ export async function moveToTrash(pathname: string, runtime: RuntimeEnv): Promis
     return;
   }
   try {
-    await runCommandWithTimeout(["trash", pathname], { timeoutMs: 5000 });
+    await movePathToTrash(pathname);
     runtime.log(`Moved to Trash: ${shortenHomePath(pathname)}`);
-    return;
-  } catch {
-    // #83459: `trash` is not installed in every environment (notably the
-    // official Docker image, which intentionally keeps default apt packages
-    // minimal and lets operators add extras via OPENCLAW_IMAGE_APT_PACKAGES).
-    // Previously the failure path only logged and left the path on disk,
-    // producing silent leaks of `agents delete`-d workspaces and config
-    // dirs. Fall back to an unrecoverable `fs.rm({recursive,force})` so the
-    // operation completes its semantic contract; surface the fallback in
-    // the log so operators see the trash-vs-rm distinction.
-  }
-  try {
-    await fs.rm(pathname, { recursive: true, force: true });
-    runtime.log(`Deleted (trash unavailable): ${shortenHomePath(pathname)}`);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     runtime.log(
-      `Failed to delete ${shortenHomePath(pathname)}: ${message} (manually remove if needed)`,
+      `Failed to move to Trash ${shortenHomePath(pathname)}: ${message} (manually remove if needed)`,
     );
   }
 }


### PR DESCRIPTION
Fixes #83459.

`moveToTrash` in `src/commands/onboard-helpers.ts:248` invoked the `trash` command and, on failure, logged `Failed to move to Trash (manual delete): <path>` without actually deleting the path. In the official Docker image — which intentionally keeps default apt packages minimal (extras now added via `OPENCLAW_IMAGE_APT_PACKAGES` per the recent `47b8e56e3f feat(docker): add image apt package build arg`) — `trash-cli` is not installed, so `openclaw agents delete`, the doctor reset paths, and other callers silently leaked workspace/agents/sessions directories.

This patch adds an `fs.rm({ recursive: true, force: true })` fallback inside the catch path. On systems where `trash` IS available the happy path is unchanged; on systems where it isn't, the path is now actually removed and the log message surfaces the distinction (`Deleted (trash unavailable): ...`). If `fs.rm` also fails (e.g. `EACCES` on a read-only mount), the actual error is surfaced so operators can repair manually.

Intentionally **not** modifying the Dockerfile — the recent `47b8e56e3f` change moved away from baking extras into the default image, so adding `trash-cli` to the default `apt-get install` set would fight that direction. The code-side fallback fixes the bug in every environment uniformly, including non-Docker minimal Linux installs that hit the same gap.

## Changes

- `src/commands/onboard-helpers.ts`: in `moveToTrash`, return on trash success; in the catch path, attempt `fs.rm({ recursive, force })` and log the trash-vs-rm distinction; if that also fails, surface the error message. 8-line comment block referencing #83459 + the recent Dockerfile policy direction.
- `src/commands/onboard-helpers.test.ts`: 3 new regression cases (fallback removes path when trash rejects; happy-path trash success doesn't trigger fallback log; degraded both-fail surfaces error).

## Real behavior proof

- **Behavior or issue addressed:** `openclaw agents delete bug_test --force` in the official Docker image (`v2026.5.12`) logged `Failed to move to Trash (manual delete): /tmp/bug_test` and left the directory on disk, leaving residual files in `workspace` and `agents` after the agent was "deleted" from `openclaw.json`. The fallback restores the semantic contract.

- **Real environment tested:** Local Node 22.x. Probe at `/tmp/probe_83459.mjs` exercises the OLD and NEW `moveToTrash` shapes with real `fs` operations on a `mkdtemp` scratch tree, using a stubbed `runTrash` that always rejects with `ENOENT` (the actual error shape the official Docker image produces).

- **Exact steps or command run after this patch:** `node /tmp/probe_83459.mjs`

- **Evidence after fix:**

```
=== Case A: OLD code on missing trash-cli (bug repro) ===
[OLD log] Failed to move to Trash (manual delete): /tmp/openclaw-probe-83459-.../old-agent
PASS: OLD leaves directory on disk (BUG CONFIRMED)

=== Case B: NEW code on missing trash-cli (fix) ===
[runtime.log] Deleted (trash unavailable): /tmp/openclaw-probe-83459-.../new-agent
PASS: NEW falls back to fs.rm and removes directory

=== Case C: NEW code on already-missing path (no-op) ===
PASS: NEW returns silently when path doesn't exist

ALL CASES PASS
```

- **Observed result after fix:** When `trash` is missing, the path is actually deleted (the bug surface is closed). When `trash` is present, behavior is unchanged. When neither works (e.g. read-only mount), the failure is surfaced with the actual error message instead of producing a silent leak. The pre-existing fast-return for already-missing paths is preserved.

- **What was not tested:** Live invocation through `openclaw agents delete` against the actual `openclaw/openclaw:v2026.5.12` Docker container. The new vitest cases cover the public path through `moveToTrash` directly with mocked `runCommandWithTimeout` to simulate the missing-binary failure; the probe verifies the semantic contract with real `fs` operations.

## Audit (per CLAUDE rules — including new prototype-pollution + recent-merge steps)

- **Existing-helper check:** Reuses `runCommandWithTimeout` and `fs.rm` (both already in use). No new helper. PASS
- **Shared-helper caller check:** `moveToTrash` is exported with 5 prod callers (`handleReset`, `agents.commands.delete.ts` × 3, etc.). The function signature is unchanged; the behavior is strictly improved (success cases match prior; failure cases now actually delete instead of leaking). PASS
- **Broader-fix rival scan:** No open PRs touching `moveToTrash` / `trash-cli` / Dockerfile-default-trash. PASS
- **Recent-merge audit (new):** `git log --oneline -10 -- src/commands/onboard-helpers.ts Dockerfile` shows `47b8e56e3f feat(docker): add image apt package build arg` just landed on Dockerfile — that PR's direction (operator-driven extras, not baked-in default) is *why* this code-side fix is the right shape rather than a Dockerfile change. No recent merges on `onboard-helpers.ts`. PASS
- **Prototype-pollution scan:** N/A — no external-input key copying.
