### PR TITLE
Filter heartbeat response-tool transcript artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents: filter silent heartbeat response-tool transcript artifacts out of embedded context snapshots so later user turns are not polluted by heartbeat no-op messages. (#83477) Thanks @fuller-stack-dev.
 - Agents/code mode: spell out the `exec` tool's JavaScript/TypeScript, no Node module, and catalog-bridge constraints in model-visible schema text so agents can use enabled tools without trial-and-error. (#84269) Thanks @Kaspre.
 - Codex: give `image_generate` dynamic-tool calls a 120s default watchdog when no per-call or configured image timeout is set, so image generation no longer falls back to the generic 30s bridge timeout. (#84254) Thanks @moritzmmayerhofer.
 - Codex: avoid duplicate dynamic tool terminal diagnostics while large diagnostic backlogs drain without blocking tool responses. (#82937) Thanks @galiniliev.

--- a/extensions/line/index.ts
+++ b/extensions/line/index.ts
@@ -2,8 +2,9 @@ import {
   defineBundledChannelEntry,
   type OpenClawPluginApi,
 } from "openclaw/plugin-sdk/channel-entry-contract";
+import type { OpenClawPluginCommandDefinition } from "openclaw/plugin-sdk/core";
 
-type RegisteredLineCardCommand = Parameters<OpenClawPluginApi["registerCommand"]>[0];
+type RegisteredLineCardCommand = OpenClawPluginCommandDefinition;
 
 let lineCardCommandPromise: Promise<RegisteredLineCardCommand> | null = null;
 

--- a/extensions/line/index.ts
+++ b/extensions/line/index.ts
@@ -1,8 +1,8 @@
 import {
   defineBundledChannelEntry,
+  type OpenClawPluginCommandDefinition,
   type OpenClawPluginApi,
 } from "openclaw/plugin-sdk/channel-entry-contract";
-import type { OpenClawPluginCommandDefinition } from "openclaw/plugin-sdk/core";
 
 type RegisteredLineCardCommand = OpenClawPluginCommandDefinition;
 

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HEARTBEAT_TRANSCRIPT_PROMPT } from "../../../auto-reply/heartbeat.js";
 import type { OpenClawConfig } from "../../../config/types.js";
 import { buildMemorySystemPromptAddition } from "../../../context-engine/delegate.js";
 import {
@@ -390,6 +391,86 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       expect(String(value)).not.toContain("OPENCLAW_INTERNAL_CONTEXT");
       expect(String(value)).not.toContain("secret runtime context");
     }
+  });
+
+  it("filters heartbeat response-tool transcript artifacts before normal prompt snapshots", async () => {
+    const contextEngine = createContextEngineBootstrapAndAssemble();
+    const sessionMessages = [
+      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT, timestamp: 1 },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_bash",
+            name: "bash",
+            arguments: { command: "cat HEARTBEAT.md" },
+          },
+        ],
+        timestamp: 2,
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_bash",
+        content: [{ type: "text", text: "HEARTBEAT.md says stay quiet" }],
+        timestamp: 3,
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_heartbeat",
+            name: "heartbeat_respond",
+            arguments: {
+              outcome: "no_change",
+              notify: false,
+              summary: "No visible update.",
+            },
+          },
+        ],
+        timestamp: 4,
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_heartbeat",
+        content: [{ type: "text", text: '{"notify":false}' }],
+        timestamp: 5,
+      },
+      { role: "assistant", content: "No visible update. notify=false", timestamp: 6 },
+    ] as AgentMessage[];
+
+    const result = await createContextEngineAttemptRunner({
+      contextEngine,
+      sessionKey,
+      tempPaths,
+      sessionMessages,
+      attemptOverrides: {
+        prompt: "what model are you",
+        transcriptPrompt: "what model are you",
+      },
+      sessionPrompt: async (session) => {
+        session.messages = [
+          ...session.messages,
+          { role: "assistant", content: "gpt-test", timestamp: 7 },
+        ];
+      },
+    });
+
+    const assembleInput = contextEngine.assemble.mock.calls.at(0)?.[0];
+    const assembledMessagesJson = JSON.stringify(assembleInput?.messages ?? []);
+    const snapshotJson = JSON.stringify(result.messagesSnapshot);
+    for (const artifact of [
+      "HEARTBEAT.md",
+      "heartbeat_respond",
+      "notify=false",
+      '"notify":false',
+      HEARTBEAT_TRANSCRIPT_PROMPT,
+    ]) {
+      expect(assembledMessagesJson).not.toContain(artifact);
+      expect(snapshotJson).not.toContain(artifact);
+    }
+    expect(result.finalPromptText).toBe("what model are you");
   });
 
   it("rebuilds skill prompt inputs from the sandbox workspace for non-rw sandbox runs", async () => {

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -473,6 +473,214 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
     expect(result.finalPromptText).toBe("what model are you");
   });
 
+  it("filters interrupted prompt-only heartbeat artifacts before normal prompt snapshots", async () => {
+    const contextEngine = createContextEngineBootstrapAndAssemble();
+    const sessionMessages = [
+      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT, timestamp: 1 },
+    ] as AgentMessage[];
+
+    const result = await createContextEngineAttemptRunner({
+      contextEngine,
+      sessionKey,
+      tempPaths,
+      sessionMessages,
+      attemptOverrides: {
+        prompt: "what model are you",
+        transcriptPrompt: "what model are you",
+      },
+      sessionPrompt: async (session) => {
+        session.messages = [
+          ...session.messages,
+          { role: "assistant", content: "gpt-test", timestamp: 2 },
+        ];
+      },
+    });
+
+    const assembleInput = contextEngine.assemble.mock.calls.at(0)?.[0];
+    const assembledMessagesJson = JSON.stringify(assembleInput?.messages ?? []);
+    const snapshotJson = JSON.stringify(result.messagesSnapshot);
+    expect(assembledMessagesJson).not.toContain(HEARTBEAT_TRANSCRIPT_PROMPT);
+    expect(snapshotJson).not.toContain(HEARTBEAT_TRANSCRIPT_PROMPT);
+    expect(result.finalPromptText).toBe("what model are you");
+  });
+
+  it("filters pending notify=true heartbeat response-tool calls before normal prompt snapshots", async () => {
+    const contextEngine = createContextEngineBootstrapAndAssemble();
+    const sessionMessages = [
+      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT, timestamp: 1 },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_heartbeat",
+            name: "heartbeat_respond",
+            arguments: {
+              outcome: "needs_attention",
+              notify: true,
+              summary: "Build is blocked.",
+              notificationText: "Build is blocked on missing credentials.",
+            },
+          },
+        ],
+        timestamp: 2,
+      },
+    ] as AgentMessage[];
+
+    const result = await createContextEngineAttemptRunner({
+      contextEngine,
+      sessionKey,
+      tempPaths,
+      sessionMessages,
+      attemptOverrides: {
+        prompt: "what model are you",
+        transcriptPrompt: "what model are you",
+      },
+      sessionPrompt: async (session) => {
+        session.messages = [
+          ...session.messages,
+          { role: "assistant", content: "gpt-test", timestamp: 3 },
+        ];
+      },
+    });
+
+    const assembleInput = contextEngine.assemble.mock.calls.at(0)?.[0];
+    const assembledMessagesJson = JSON.stringify(assembleInput?.messages ?? []);
+    const snapshotJson = JSON.stringify(result.messagesSnapshot);
+    for (const artifact of [
+      HEARTBEAT_TRANSCRIPT_PROMPT,
+      "heartbeat_respond",
+      '"notify":true',
+      "Build is blocked on missing credentials.",
+    ]) {
+      expect(assembledMessagesJson).not.toContain(artifact);
+      expect(snapshotJson).not.toContain(artifact);
+    }
+    expect(result.finalPromptText).toBe("what model are you");
+  });
+
+  it("preserves visible heartbeat alerts in normal prompt snapshots", async () => {
+    const contextEngine = createContextEngineBootstrapAndAssemble();
+    const sessionMessages = [
+      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT, timestamp: 1 },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_bash",
+            name: "bash",
+            arguments: { command: "cat HEARTBEAT.md" },
+          },
+        ],
+        timestamp: 2,
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_bash",
+        content: [{ type: "text", text: "HEARTBEAT.md says check deployment" }],
+        timestamp: 3,
+      },
+      {
+        role: "assistant",
+        content: "Build is blocked on a failing release check.",
+        timestamp: 4,
+      },
+    ] as AgentMessage[];
+
+    const result = await createContextEngineAttemptRunner({
+      contextEngine,
+      sessionKey,
+      tempPaths,
+      sessionMessages,
+      attemptOverrides: {
+        prompt: "what changed while I was away?",
+        transcriptPrompt: "what changed while I was away?",
+      },
+      sessionPrompt: async (session) => {
+        session.messages = [
+          ...session.messages,
+          { role: "assistant", content: "gpt-test", timestamp: 5 },
+        ];
+      },
+    });
+
+    const assembleInput = contextEngine.assemble.mock.calls.at(0)?.[0];
+    const assembledMessagesJson = JSON.stringify(assembleInput?.messages ?? []);
+    const snapshotJson = JSON.stringify(result.messagesSnapshot);
+    for (const visibleContext of [
+      HEARTBEAT_TRANSCRIPT_PROMPT,
+      "HEARTBEAT.md says check deployment",
+      "Build is blocked on a failing release check.",
+    ]) {
+      expect(assembledMessagesJson).toContain(visibleContext);
+      expect(snapshotJson).toContain(visibleContext);
+    }
+    expect(result.finalPromptText).toBe("what changed while I was away?");
+  });
+
+  it("preserves visible heartbeat response-tool notifications in normal prompt snapshots", async () => {
+    const contextEngine = createContextEngineBootstrapAndAssemble();
+    const sessionMessages = [
+      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT, timestamp: 1 },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_heartbeat",
+            name: "heartbeat_respond",
+            arguments: {
+              outcome: "needs_attention",
+              notify: true,
+              summary: "Build is blocked.",
+              notificationText: "Build is blocked on missing credentials.",
+            },
+          },
+        ],
+        timestamp: 2,
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_heartbeat",
+        content: [{ type: "text", text: '{"notify":true}' }],
+        timestamp: 3,
+      },
+      { role: "assistant", content: "HEARTBEAT_OK", timestamp: 4 },
+    ] as AgentMessage[];
+
+    const result = await createContextEngineAttemptRunner({
+      contextEngine,
+      sessionKey,
+      tempPaths,
+      sessionMessages,
+      attemptOverrides: {
+        prompt: "what changed while I was away?",
+        transcriptPrompt: "what changed while I was away?",
+      },
+      sessionPrompt: async (session) => {
+        session.messages = [
+          ...session.messages,
+          { role: "assistant", content: "gpt-test", timestamp: 5 },
+        ];
+      },
+    });
+
+    const assembleInput = contextEngine.assemble.mock.calls.at(0)?.[0];
+    const assembledMessagesJson = JSON.stringify(assembleInput?.messages ?? []);
+    const snapshotJson = JSON.stringify(result.messagesSnapshot);
+    for (const visibleContext of [
+      "heartbeat_respond",
+      '"notify":true',
+      "Build is blocked on missing credentials.",
+      "HEARTBEAT_OK",
+    ]) {
+      expect(assembledMessagesJson).toContain(visibleContext);
+      expect(snapshotJson).toContain(visibleContext);
+    }
+    expect(result.finalPromptText).toBe("what changed while I was away?");
+  });
+
   it("rebuilds skill prompt inputs from the sandbox workspace for non-rw sandbox runs", async () => {
     const sandboxWorkspace = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-sandbox-skills-"));
     tempPaths.push(sandboxWorkspace);

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-injection.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-injection.test.ts
@@ -1,6 +1,6 @@
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { filterHeartbeatPairs } from "../../../auto-reply/heartbeat-filter.js";
+import { filterHeartbeatTranscriptArtifacts } from "../../../auto-reply/heartbeat-filter.js";
 import { HEARTBEAT_PROMPT } from "../../../auto-reply/heartbeat.js";
 import { limitHistoryTurns } from "../history.js";
 import { buildEmbeddedMessageActionDiscoveryInput } from "../message-action-discovery-input.js";
@@ -208,7 +208,11 @@ describe("embedded attempt context injection", () => {
       { role: "assistant", content: "HEARTBEAT_OK", timestamp: 4 } as unknown as AgentMessage,
     ];
 
-    const heartbeatFiltered = filterHeartbeatPairs(sessionMessages, undefined, HEARTBEAT_PROMPT);
+    const heartbeatFiltered = filterHeartbeatTranscriptArtifacts(
+      sessionMessages,
+      undefined,
+      HEARTBEAT_PROMPT,
+    );
     const limited = limitHistoryTurns(heartbeatFiltered, 1);
     await assembleAttemptContextEngine({
       contextEngine: {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -6,7 +6,7 @@ import type { AssistantMessage } from "@earendil-works/pi-ai";
 import { createAgentSession, SessionManager } from "@earendil-works/pi-coding-agent";
 import { isAcpRuntimeSpawnAvailable } from "../../../acp/runtime/availability.js";
 import { buildHierarchyReinforcementMessage } from "../../../auto-reply/handoff-summarizer.js";
-import { filterHeartbeatPairs } from "../../../auto-reply/heartbeat-filter.js";
+import { filterHeartbeatTranscriptArtifacts } from "../../../auto-reply/heartbeat-filter.js";
 import { stripInboundMetadata } from "../../../auto-reply/reply/strip-inbound-meta.js";
 import { getRuntimeConfig } from "../../../config/config.js";
 import { resolveStorePath } from "../../../config/sessions/paths.js";
@@ -3033,7 +3033,7 @@ export async function runEmbeddedAttempt(
             params.config && sessionAgentId
               ? resolveHeartbeatSummaryForAgent(params.config, sessionAgentId)
               : undefined;
-          const heartbeatFiltered = filterHeartbeatPairs(
+          const heartbeatFiltered = filterHeartbeatTranscriptArtifacts(
             validated,
             heartbeatSummary?.ackMaxChars,
             heartbeatSummary?.prompt,
@@ -3052,7 +3052,7 @@ export async function runEmbeddedAttempt(
               })
             : truncated;
           cacheTrace?.recordStage("session:limited", { messages: limited });
-          if (limited.length > 0) {
+          if (limited.length > 0 || prior.length > 0) {
             activeSession.agent.state.messages = limited;
           }
         }
@@ -3627,7 +3627,7 @@ export async function runEmbeddedAttempt(
             : undefined;
 
         try {
-          const filteredMessages = filterHeartbeatPairs(
+          const filteredMessages = filterHeartbeatTranscriptArtifacts(
             activeSession.messages,
             heartbeatSummary?.ackMaxChars,
             heartbeatSummary?.prompt,

--- a/src/auto-reply/heartbeat-filter.test.ts
+++ b/src/auto-reply/heartbeat-filter.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from "vitest";
 import {
-  filterHeartbeatPairs,
+  filterHeartbeatTranscriptArtifacts,
   isHeartbeatOkResponse,
   isHeartbeatUserMessage,
 } from "./heartbeat-filter.js";
-import { HEARTBEAT_PROMPT, HEARTBEAT_TRANSCRIPT_PROMPT } from "./heartbeat.js";
+import {
+  HEARTBEAT_RESPONSE_TOOL_PROMPT,
+  HEARTBEAT_PROMPT,
+  HEARTBEAT_TRANSCRIPT_PROMPT,
+  resolveHeartbeatPromptForResponseTool,
+} from "./heartbeat.js";
 
 describe("isHeartbeatUserMessage", () => {
   it("matches heartbeat prompts", () => {
@@ -31,6 +36,24 @@ describe("isHeartbeatUserMessage", () => {
         role: "user",
         content: HEARTBEAT_TRANSCRIPT_PROMPT,
       }),
+    ).toBe(true);
+
+    expect(
+      isHeartbeatUserMessage({
+        role: "user",
+        content: HEARTBEAT_RESPONSE_TOOL_PROMPT,
+      }),
+    ).toBe(true);
+
+    const customHeartbeatPrompt = "Check the handoff queue.";
+    expect(
+      isHeartbeatUserMessage(
+        {
+          role: "user",
+          content: `${resolveHeartbeatPromptForResponseTool(customHeartbeatPrompt)}\n\nUse workspace notes only.`,
+        },
+        customHeartbeatPrompt,
+      ),
     ).toBe(true);
   });
 
@@ -97,7 +120,7 @@ describe("isHeartbeatOkResponse", () => {
   });
 });
 
-describe("filterHeartbeatPairs", () => {
+describe("filterHeartbeatTranscriptArtifacts", () => {
   it("removes no-op heartbeat pairs", () => {
     const messages = [
       { role: "user", content: "Hello" },
@@ -110,7 +133,7 @@ describe("filterHeartbeatPairs", () => {
       { role: "assistant", content: "It is 3pm." },
     ];
 
-    expect(filterHeartbeatPairs(messages, undefined, HEARTBEAT_PROMPT)).toEqual([
+    expect(filterHeartbeatTranscriptArtifacts(messages, undefined, HEARTBEAT_PROMPT)).toEqual([
       { role: "user", content: "Hello" },
       { role: "assistant", content: "Hi there!" },
       { role: "user", content: "What time is it?" },
@@ -118,14 +141,187 @@ describe("filterHeartbeatPairs", () => {
     ]);
   });
 
-  it("keeps meaningful heartbeat results and non-text assistant turns", () => {
+  it("removes heartbeat response-tool spans and preserves the next real user message", () => {
+    const messages = [
+      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_bash", name: "bash", arguments: {} }],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_bash",
+        content: [{ type: "text", text: "checked HEARTBEAT.md" }],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_heartbeat",
+            name: "heartbeat_respond",
+            arguments: {
+              outcome: "no_change",
+              notify: false,
+              summary: "No visible update.",
+            },
+          },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_heartbeat",
+        content: [{ type: "text", text: "HEARTBEAT_OK" }],
+      },
+      { role: "user", content: "what model are you" },
+    ];
+
+    expect(filterHeartbeatTranscriptArtifacts(messages, undefined, HEARTBEAT_PROMPT)).toEqual([
+      { role: "user", content: "what model are you" },
+    ]);
+  });
+
+  it("removes full default response-tool prompt spans", () => {
+    const messages = [
+      { role: "user", content: HEARTBEAT_RESPONSE_TOOL_PROMPT },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_heartbeat",
+            name: "heartbeat_respond",
+            arguments: {
+              outcome: "no_change",
+              notify: false,
+              summary: "No visible update.",
+            },
+          },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_heartbeat",
+        content: [{ type: "text", text: "HEARTBEAT_OK" }],
+      },
+      { role: "user", content: "what model are you" },
+    ];
+
+    expect(filterHeartbeatTranscriptArtifacts(messages, undefined, HEARTBEAT_PROMPT)).toEqual([
+      { role: "user", content: "what model are you" },
+    ]);
+  });
+
+  it("removes native OpenAI Responses heartbeat function-call spans", () => {
+    const messages = [
+      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "function_call",
+            call_id: "call_bash",
+            name: "bash",
+            arguments: '{"command":"cat HEARTBEAT.md"}',
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "function_call_output",
+            call_id: "call_bash",
+            output: "checked HEARTBEAT.md",
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "function_call",
+            call_id: "call_heartbeat",
+            name: "heartbeat_respond",
+            arguments: '{"notify":false}',
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "function_call_output",
+            call_id: "call_heartbeat",
+            output: '{"notify":false}',
+          },
+        ],
+      },
+      { role: "user", content: "what model are you" },
+    ];
+
+    expect(filterHeartbeatTranscriptArtifacts(messages, undefined, HEARTBEAT_PROMPT)).toEqual([
+      { role: "user", content: "what model are you" },
+    ]);
+  });
+
+  it("removes assistant continuations after heartbeat response-tool results", () => {
+    const messages = [
+      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_heartbeat",
+            name: "heartbeat_respond",
+            arguments: {
+              outcome: "no_change",
+              notify: false,
+              summary: "No visible update.",
+            },
+          },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_heartbeat",
+        content: [{ type: "text", text: "HEARTBEAT_OK" }],
+      },
+      { role: "assistant", content: "No visible update. notify=false" },
+      { role: "user", content: "what model are you" },
+    ];
+
+    expect(filterHeartbeatTranscriptArtifacts(messages, undefined, HEARTBEAT_PROMPT)).toEqual([
+      { role: "user", content: "what model are you" },
+    ]);
+  });
+
+  it("does not remove across a real user message", () => {
+    const messages = [
+      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_bash", name: "bash", arguments: {} }],
+      },
+      { role: "user", content: "what model are you" },
+      { role: "assistant", content: "notify=false" },
+    ];
+
+    expect(filterHeartbeatTranscriptArtifacts(messages, undefined, HEARTBEAT_PROMPT)).toEqual([
+      { role: "user", content: "what model are you" },
+      { role: "assistant", content: "notify=false" },
+    ]);
+  });
+
+  it("removes heartbeat-owned meaningful results and non-text assistant turns", () => {
     const meaningfulMessages = [
       { role: "user", content: HEARTBEAT_PROMPT },
       { role: "assistant", content: "Status HEARTBEAT_OK due to watchdog failure" },
     ];
-    expect(filterHeartbeatPairs(meaningfulMessages, undefined, HEARTBEAT_PROMPT)).toEqual(
-      meaningfulMessages,
-    );
+    expect(
+      filterHeartbeatTranscriptArtifacts(meaningfulMessages, undefined, HEARTBEAT_PROMPT),
+    ).toEqual([]);
 
     const nonTextMessages = [
       { role: "user", content: HEARTBEAT_PROMPT },
@@ -134,9 +330,9 @@ describe("filterHeartbeatPairs", () => {
         content: [{ type: "tool_use", id: "tool-1", name: "search", input: {} }],
       },
     ];
-    expect(filterHeartbeatPairs(nonTextMessages, undefined, HEARTBEAT_PROMPT)).toEqual(
-      nonTextMessages,
-    );
+    expect(
+      filterHeartbeatTranscriptArtifacts(nonTextMessages, undefined, HEARTBEAT_PROMPT),
+    ).toEqual([]);
   });
 
   it("keeps ordinary chats that mention the token", () => {
@@ -145,6 +341,8 @@ describe("filterHeartbeatPairs", () => {
       { role: "assistant", content: "HEARTBEAT_OK" },
     ];
 
-    expect(filterHeartbeatPairs(messages, undefined, HEARTBEAT_PROMPT)).toEqual(messages);
+    expect(filterHeartbeatTranscriptArtifacts(messages, undefined, HEARTBEAT_PROMPT)).toEqual(
+      messages,
+    );
   });
 });

--- a/src/auto-reply/heartbeat-filter.test.ts
+++ b/src/auto-reply/heartbeat-filter.test.ts
@@ -156,6 +156,35 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
     ]);
   });
 
+  it("removes OpenAI Responses input/output text heartbeat pairs", () => {
+    const messages = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "input_text",
+            text: `Delivery: to send a message, use the \`message\` tool. ${HEARTBEAT_TRANSCRIPT_PROMPT}`,
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [{ type: "output_text", text: "HEARTBEAT_OK" }],
+      },
+      {
+        role: "user",
+        content: [{ type: "input_text", text: "what model are you" }],
+      },
+    ];
+
+    expect(filterHeartbeatTranscriptArtifacts(messages, undefined, HEARTBEAT_PROMPT)).toEqual([
+      {
+        role: "user",
+        content: [{ type: "input_text", text: "what model are you" }],
+      },
+    ]);
+  });
+
   it("removes prompt-only interrupted heartbeat spans", () => {
     const messages = [
       { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },

--- a/src/auto-reply/heartbeat-filter.test.ts
+++ b/src/auto-reply/heartbeat-filter.test.ts
@@ -105,6 +105,21 @@ describe("isHeartbeatOkResponse", () => {
         content: [{ type: "tool_use", id: "tool-1", name: "search", input: {} }],
       }),
     ).toBe(false);
+
+    const toolCallOnlyMessage = {
+      role: "assistant",
+      content: null,
+      tool_calls: [
+        {
+          id: "call_heartbeat",
+          function: {
+            name: "heartbeat_respond",
+            arguments: '{"notify":true}',
+          },
+        },
+      ],
+    } as { role: string; content?: unknown };
+    expect(isHeartbeatOkResponse(toolCallOnlyMessage)).toBe(false);
   });
 
   it("respects ackMaxChars overrides", () => {
@@ -138,6 +153,44 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
       { role: "assistant", content: "Hi there!" },
       { role: "user", content: "What time is it?" },
       { role: "assistant", content: "It is 3pm." },
+    ]);
+  });
+
+  it("removes prompt-only interrupted heartbeat spans", () => {
+    const messages = [
+      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "user", content: "what model are you" },
+    ];
+
+    expect(filterHeartbeatTranscriptArtifacts(messages, undefined, HEARTBEAT_PROMPT)).toEqual([
+      { role: "user", content: "what model are you" },
+    ]);
+  });
+
+  it("removes interrupted helper-only heartbeat spans", () => {
+    const messages = [
+      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_bash",
+            name: "bash",
+            arguments: { command: "cat HEARTBEAT.md" },
+          },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_bash",
+        content: [{ type: "text", text: "checked HEARTBEAT.md" }],
+      },
+      { role: "user", content: "what model are you" },
+    ];
+
+    expect(filterHeartbeatTranscriptArtifacts(messages, undefined, HEARTBEAT_PROMPT)).toEqual([
+      { role: "user", content: "what model are you" },
     ]);
   });
 
@@ -297,12 +350,530 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
     ]);
   });
 
+  it("removes pre-terminal assistant text once a heartbeat ack arrives", () => {
+    const messages = [
+      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "assistant", content: "Checking heartbeat status..." },
+      { role: "assistant", content: "HEARTBEAT_OK" },
+      { role: "user", content: "what model are you" },
+    ];
+
+    expect(filterHeartbeatTranscriptArtifacts(messages, undefined, HEARTBEAT_PROMPT)).toEqual([
+      { role: "user", content: "what model are you" },
+    ]);
+  });
+
+  it("preserves structured notify=true heartbeat response-tool alerts", () => {
+    const messages = [
+      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_heartbeat",
+            name: "heartbeat_respond",
+            arguments: {
+              outcome: "needs_attention",
+              notify: true,
+              summary: "Build is blocked.",
+              notificationText: "Build is blocked on missing credentials.",
+            },
+          },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_heartbeat",
+        content: [{ type: "text", text: '{"notify":true}' }],
+      },
+      { role: "user", content: "what changed while I was away?" },
+    ];
+
+    expect(filterHeartbeatTranscriptArtifacts(messages, undefined, HEARTBEAT_PROMPT)).toEqual(
+      messages,
+    );
+  });
+
+  it("preserves notify=true heartbeat response-tool alerts followed by a final ack", () => {
+    const messages = [
+      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_heartbeat",
+            name: "heartbeat_respond",
+            arguments: {
+              outcome: "needs_attention",
+              notify: true,
+              summary: "Build is blocked.",
+              notificationText: "Build is blocked on missing credentials.",
+            },
+          },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_heartbeat",
+        content: [{ type: "text", text: '{"notify":true}' }],
+      },
+      { role: "assistant", content: "HEARTBEAT_OK" },
+      { role: "user", content: "what changed while I was away?" },
+    ];
+
+    expect(filterHeartbeatTranscriptArtifacts(messages, undefined, HEARTBEAT_PROMPT)).toEqual(
+      messages,
+    );
+  });
+
+  it("preserves top-level notify=true heartbeat response-tool calls followed by a final ack", () => {
+    const messages = [
+      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      {
+        role: "assistant",
+        content: null,
+        tool_calls: [
+          {
+            id: "call_heartbeat",
+            function: {
+              name: "heartbeat_respond",
+              arguments: JSON.stringify({
+                outcome: "needs_attention",
+                notify: true,
+                summary: "Build is blocked.",
+                notificationText: "Build is blocked on missing credentials.",
+              }),
+            },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        toolCallId: "call_heartbeat",
+        content: [{ type: "text", text: '{"notify":true}' }],
+      },
+      { role: "assistant", content: "HEARTBEAT_OK" },
+      { role: "user", content: "what changed while I was away?" },
+    ];
+
+    expect(filterHeartbeatTranscriptArtifacts(messages, undefined, HEARTBEAT_PROMPT)).toEqual(
+      messages,
+    );
+  });
+
+  it("preserves OpenAI Responses notify=true heartbeat calls keyed by call_id", () => {
+    const messages = [
+      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "function_call",
+            id: "fc_item_123",
+            call_id: "call_heartbeat",
+            name: "heartbeat_respond",
+            arguments: JSON.stringify({
+              outcome: "needs_attention",
+              notify: true,
+              summary: "Build is blocked.",
+              notificationText: "Build is blocked on missing credentials.",
+            }),
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "function_call_output",
+            call_id: "call_heartbeat",
+            output: '{"notify":true}',
+          },
+        ],
+      },
+      { role: "user", content: "what changed while I was away?" },
+    ];
+
+    expect(filterHeartbeatTranscriptArtifacts(messages, undefined, HEARTBEAT_PROMPT)).toEqual(
+      messages,
+    );
+  });
+
+  it("preserves Anthropic-style notify=true heartbeat calls keyed by tool_use_id", () => {
+    const messages = [
+      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_heartbeat",
+            name: "heartbeat_respond",
+            input: {
+              outcome: "needs_attention",
+              notify: true,
+              summary: "Build is blocked.",
+              notificationText: "Build is blocked on missing credentials.",
+            },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "toolu_heartbeat",
+            content: "recorded",
+          },
+        ],
+      },
+      { role: "user", content: "what changed while I was away?" },
+    ];
+
+    expect(filterHeartbeatTranscriptArtifacts(messages, undefined, HEARTBEAT_PROMPT)).toEqual(
+      messages,
+    );
+  });
+
+  it("preserves Anthropic-style notify=true heartbeat calls completed by mixed user turns", () => {
+    const messages = [
+      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_heartbeat",
+            name: "heartbeat_respond",
+            input: {
+              outcome: "needs_attention",
+              notify: true,
+              summary: "Build is blocked.",
+              notificationText: "Build is blocked on missing credentials.",
+            },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "toolu_heartbeat",
+            content: "recorded",
+          },
+          { type: "text", text: "heartbeat delivery recorded" },
+        ],
+      },
+      { role: "user", content: "what changed while I was away?" },
+    ];
+
+    expect(filterHeartbeatTranscriptArtifacts(messages, undefined, HEARTBEAT_PROMPT)).toEqual(
+      messages,
+    );
+  });
+
+  it("removes pending notify=true heartbeat response-tool calls without tool results", () => {
+    const messages = [
+      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_heartbeat",
+            name: "heartbeat_respond",
+            arguments: {
+              outcome: "needs_attention",
+              notify: true,
+              summary: "Build is blocked.",
+              notificationText: "Build is blocked on missing credentials.",
+            },
+          },
+        ],
+      },
+      { role: "user", content: "what changed while I was away?" },
+    ];
+
+    expect(filterHeartbeatTranscriptArtifacts(messages, undefined, HEARTBEAT_PROMPT)).toEqual([
+      { role: "user", content: "what changed while I was away?" },
+    ]);
+  });
+
+  it("removes failed notify=true heartbeat response-tool calls", () => {
+    const messages = [
+      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_heartbeat",
+            name: "heartbeat_respond",
+            arguments: {
+              outcome: "needs_attention",
+              notify: true,
+              summary: "Build is blocked.",
+              notificationText: "Build is blocked on missing credentials.",
+            },
+          },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_heartbeat",
+        isError: true,
+        content: [{ type: "text", text: "heartbeat response rejected" }],
+      },
+      { role: "user", content: "what changed while I was away?" },
+    ];
+
+    expect(filterHeartbeatTranscriptArtifacts(messages, undefined, HEARTBEAT_PROMPT)).toEqual([
+      { role: "user", content: "what changed while I was away?" },
+    ]);
+  });
+
+  it("removes Anthropic-style failed notify=true heartbeat calls keyed by tool_use_id", () => {
+    const messages = [
+      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_heartbeat",
+            name: "heartbeat_respond",
+            input: {
+              outcome: "needs_attention",
+              notify: true,
+              summary: "Build is blocked.",
+              notificationText: "Build is blocked on missing credentials.",
+            },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "toolu_heartbeat",
+            is_error: true,
+            content: "heartbeat response rejected",
+          },
+        ],
+      },
+      { role: "user", content: "what changed while I was away?" },
+    ];
+
+    expect(filterHeartbeatTranscriptArtifacts(messages, undefined, HEARTBEAT_PROMPT)).toEqual([
+      { role: "user", content: "what changed while I was away?" },
+    ]);
+  });
+
+  it("removes Anthropic-style error result heartbeat calls keyed by tool_use_id", () => {
+    const messages = [
+      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_heartbeat",
+            name: "heartbeat_respond",
+            input: {
+              outcome: "needs_attention",
+              notify: true,
+              summary: "Build is blocked.",
+              notificationText: "Build is blocked on missing credentials.",
+            },
+          },
+        ],
+      },
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result_error",
+            tool_use_id: "toolu_heartbeat",
+            content: "heartbeat response rejected",
+          },
+        ],
+      },
+      { role: "user", content: "what changed while I was away?" },
+    ];
+
+    expect(filterHeartbeatTranscriptArtifacts(messages, undefined, HEARTBEAT_PROMPT)).toEqual([
+      { role: "user", content: "what changed while I was away?" },
+    ]);
+  });
+
+  it("does not treat unrelated helper tool results as completed notify=true responses", () => {
+    const messages = [
+      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_bash",
+            name: "bash",
+            arguments: { command: "cat HEARTBEAT.md" },
+          },
+          {
+            type: "toolCall",
+            id: "call_heartbeat",
+            name: "heartbeat_respond",
+            arguments: {
+              outcome: "needs_attention",
+              notify: true,
+              summary: "Build is blocked.",
+              notificationText: "Build is blocked on missing credentials.",
+            },
+          },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_bash",
+        content: [{ type: "text", text: "checked HEARTBEAT.md" }],
+      },
+      { role: "user", content: "what changed while I was away?" },
+    ];
+
+    expect(filterHeartbeatTranscriptArtifacts(messages, undefined, HEARTBEAT_PROMPT)).toEqual([
+      { role: "user", content: "what changed while I was away?" },
+    ]);
+  });
+
+  it("removes heartbeat response-tool spans with notify=false even when alert fields are present", () => {
+    const messages = [
+      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_heartbeat",
+            name: "heartbeat_respond",
+            arguments: {
+              outcome: "needs_attention",
+              notify: false,
+              summary: "Build is blocked.",
+              notificationText: "Build is blocked on missing credentials.",
+            },
+          },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_heartbeat",
+        content: [{ type: "text", text: '{"notify":false}' }],
+      },
+      { role: "user", content: "what changed while I was away?" },
+    ];
+
+    expect(filterHeartbeatTranscriptArtifacts(messages, undefined, HEARTBEAT_PROMPT)).toEqual([
+      { role: "user", content: "what changed while I was away?" },
+    ]);
+  });
+
+  it("preserves mixed user text after silent heartbeat response-tool spans", () => {
+    const mixedUserMessage = {
+      role: "user",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "toolu_heartbeat",
+          content: "recorded",
+        },
+        { type: "text", text: "what model are you" },
+      ],
+    };
+    const assistantMessage = { role: "assistant", content: "I am OpenClaw." };
+    const messages = [
+      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_heartbeat",
+            name: "heartbeat_respond",
+            input: {
+              outcome: "no_change",
+              notify: false,
+              summary: "No visible update.",
+            },
+          },
+        ],
+      },
+      mixedUserMessage,
+      assistantMessage,
+    ];
+
+    expect(filterHeartbeatTranscriptArtifacts(messages, undefined, HEARTBEAT_PROMPT)).toEqual([
+      mixedUserMessage,
+      assistantMessage,
+    ]);
+  });
+
+  it("stops a no-op span before a later visible heartbeat alert", () => {
+    const messages = [
+      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "assistant", content: "HEARTBEAT_OK" },
+      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "assistant", content: "Build is blocked on a failing release check." },
+      { role: "user", content: "what changed while I was away?" },
+    ];
+
+    expect(filterHeartbeatTranscriptArtifacts(messages, undefined, HEARTBEAT_PROMPT)).toEqual([
+      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "assistant", content: "Build is blocked on a failing release check." },
+      { role: "user", content: "what changed while I was away?" },
+    ]);
+  });
+
+  it("stops a prompt-only span before a later visible heartbeat alert", () => {
+    const messages = [
+      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "assistant", content: "Build is blocked on a failing release check." },
+      { role: "user", content: "what changed while I was away?" },
+    ];
+
+    expect(filterHeartbeatTranscriptArtifacts(messages, undefined, HEARTBEAT_PROMPT)).toEqual([
+      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      { role: "assistant", content: "Build is blocked on a failing release check." },
+      { role: "user", content: "what changed while I was away?" },
+    ]);
+  });
+
   it("does not remove across a real user message", () => {
     const messages = [
       { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
       {
         role: "assistant",
-        content: [{ type: "toolCall", id: "call_bash", name: "bash", arguments: {} }],
+        content: [
+          {
+            type: "toolCall",
+            id: "call_heartbeat",
+            name: "heartbeat_respond",
+            arguments: {
+              outcome: "no_change",
+              notify: false,
+              summary: "No visible update.",
+            },
+          },
+        ],
+      },
+      {
+        role: "toolResult",
+        toolCallId: "call_heartbeat",
+        content: [{ type: "text", text: "HEARTBEAT_OK" }],
       },
       { role: "user", content: "what model are you" },
       { role: "assistant", content: "notify=false" },
@@ -314,25 +885,65 @@ describe("filterHeartbeatTranscriptArtifacts", () => {
     ]);
   });
 
-  it("removes heartbeat-owned meaningful results and non-text assistant turns", () => {
+  it("preserves meaningful heartbeat output without terminal artifacts", () => {
     const meaningfulMessages = [
       { role: "user", content: HEARTBEAT_PROMPT },
       { role: "assistant", content: "Status HEARTBEAT_OK due to watchdog failure" },
     ];
     expect(
       filterHeartbeatTranscriptArtifacts(meaningfulMessages, undefined, HEARTBEAT_PROMPT),
-    ).toEqual([]);
+    ).toEqual(meaningfulMessages);
+  });
 
-    const nonTextMessages = [
-      { role: "user", content: HEARTBEAT_PROMPT },
+  it("preserves helper tool turns when the heartbeat produces a visible alert", () => {
+    const messages = [
+      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
       {
         role: "assistant",
-        content: [{ type: "tool_use", id: "tool-1", name: "search", input: {} }],
+        content: [{ type: "toolCall", id: "call_bash", name: "bash", arguments: {} }],
       },
+      {
+        role: "toolResult",
+        toolCallId: "call_bash",
+        content: [{ type: "text", text: "checked HEARTBEAT.md" }],
+      },
+      { role: "assistant", content: "Build is blocked on a failing release check." },
+      { role: "user", content: "what model are you" },
     ];
-    expect(
-      filterHeartbeatTranscriptArtifacts(nonTextMessages, undefined, HEARTBEAT_PROMPT),
-    ).toEqual([]);
+
+    expect(filterHeartbeatTranscriptArtifacts(messages, undefined, HEARTBEAT_PROMPT)).toEqual(
+      messages,
+    );
+  });
+
+  it("preserves top-level helper tool turns when the heartbeat produces a visible alert", () => {
+    const messages = [
+      { role: "user", content: HEARTBEAT_TRANSCRIPT_PROMPT },
+      {
+        role: "assistant",
+        content: null,
+        tool_calls: [
+          {
+            id: "call_bash",
+            function: {
+              name: "bash",
+              arguments: '{"command":"cat HEARTBEAT.md"}',
+            },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        toolCallId: "call_bash",
+        content: [{ type: "text", text: "checked HEARTBEAT.md" }],
+      },
+      { role: "assistant", content: "Build is blocked on a failing release check." },
+      { role: "user", content: "what model are you" },
+    ];
+
+    expect(filterHeartbeatTranscriptArtifacts(messages, undefined, HEARTBEAT_PROMPT)).toEqual(
+      messages,
+    );
   });
 
   it("keeps ordinary chats that mention the token", () => {

--- a/src/auto-reply/heartbeat-filter.ts
+++ b/src/auto-reply/heartbeat-filter.ts
@@ -1,9 +1,110 @@
-import { stripHeartbeatToken } from "./heartbeat.js";
-import { HEARTBEAT_TRANSCRIPT_PROMPT } from "./heartbeat.js";
+import { HEARTBEAT_RESPONSE_TOOL_NAME } from "./heartbeat-tool-response.js";
+import {
+  HEARTBEAT_RESPONSE_TOOL_PROMPT,
+  HEARTBEAT_TRANSCRIPT_PROMPT,
+  resolveHeartbeatPromptForResponseTool,
+  stripHeartbeatToken,
+} from "./heartbeat.js";
 
 const HEARTBEAT_TASK_PROMPT_PREFIX =
   "Run the following periodic tasks (only those due based on their intervals):";
 const HEARTBEAT_TASK_PROMPT_ACK = "After completing all due tasks, reply HEARTBEAT_OK.";
+const TOOL_CALL_BLOCK_TYPES = new Set([
+  "toolCall",
+  "functionCall",
+  "toolUse",
+  "tool_call",
+  "function_call",
+  "tool_use",
+]);
+const TOOL_RESULT_BLOCK_TYPES = new Set(["toolResult", "tool_result", "function_call_output"]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readNestedString(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key];
+  if (typeof value === "string" && value.trim()) {
+    return value.trim();
+  }
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  return readString(value.name);
+}
+
+function collectToolCallBlocks(content: unknown): Array<Record<string, unknown>> {
+  if (!Array.isArray(content)) {
+    return [];
+  }
+  return content.filter(
+    (block): block is Record<string, unknown> =>
+      isRecord(block) && TOOL_CALL_BLOCK_TYPES.has(String(block.type ?? "")),
+  );
+}
+
+function readToolCallName(block: Record<string, unknown>): string | undefined {
+  return readString(block.name) ?? readNestedString(block, "function");
+}
+
+function isHeartbeatResponseToolCall(message: { role: string; content?: unknown }): boolean {
+  if (message.role !== "assistant") {
+    return false;
+  }
+  if (isRecord(message)) {
+    for (const call of Array.isArray(message.tool_calls) ? message.tool_calls : []) {
+      if (!isRecord(call)) {
+        continue;
+      }
+      const name = readToolCallName(call);
+      if (name === HEARTBEAT_RESPONSE_TOOL_NAME) {
+        return true;
+      }
+    }
+  }
+  return collectToolCallBlocks(message.content).some(
+    (block) => readToolCallName(block) === HEARTBEAT_RESPONSE_TOOL_NAME,
+  );
+}
+
+function isEmbeddedToolResultContent(content: unknown): boolean {
+  return (
+    Array.isArray(content) &&
+    content.length > 0 &&
+    content.every(
+      (block) => isRecord(block) && TOOL_RESULT_BLOCK_TYPES.has(String(block.type ?? "")),
+    )
+  );
+}
+
+function isToolResultMessage(message: { role: string; content?: unknown }): boolean {
+  return (
+    message.role === "toolResult" ||
+    message.role === "tool" ||
+    (message.role === "user" && isEmbeddedToolResultContent(message.content))
+  );
+}
+
+function isRealNonHeartbeatUserMessage(
+  message: { role: string; content?: unknown },
+  heartbeatPrompt?: string,
+): boolean {
+  return (
+    message.role === "user" &&
+    !isEmbeddedToolResultContent(message.content) &&
+    !isHeartbeatUserMessage(message, heartbeatPrompt)
+  );
+}
+
+function matchesHeartbeatPromptText(text: string, prompt: string | undefined): boolean {
+  const normalized = prompt?.trim();
+  return Boolean(normalized) && (text === normalized || text.startsWith(`${normalized}\n`));
+}
 
 function resolveMessageText(content: unknown): { text: string; hasNonTextContent: boolean } {
   if (typeof content === "string") {
@@ -49,7 +150,19 @@ export function isHeartbeatUserMessage(
   if (trimmed === HEARTBEAT_TRANSCRIPT_PROMPT) {
     return true;
   }
-  if (normalizedHeartbeatPrompt && trimmed.startsWith(normalizedHeartbeatPrompt)) {
+  if (matchesHeartbeatPromptText(trimmed, normalizedHeartbeatPrompt)) {
+    return true;
+  }
+  if (matchesHeartbeatPromptText(trimmed, HEARTBEAT_RESPONSE_TOOL_PROMPT)) {
+    return true;
+  }
+  if (
+    normalizedHeartbeatPrompt &&
+    matchesHeartbeatPromptText(
+      trimmed,
+      resolveHeartbeatPromptForResponseTool(normalizedHeartbeatPrompt),
+    )
+  ) {
     return true;
   }
   return (
@@ -71,28 +184,55 @@ export function isHeartbeatOkResponse(
   return stripHeartbeatToken(text, { mode: "heartbeat", maxAckChars: ackMaxChars }).shouldSkip;
 }
 
-export function filterHeartbeatPairs<T extends { role: string; content?: unknown }>(
+function advancePastAdjacentToolResults<T extends { role: string; content?: unknown }>(
+  messages: T[],
+  startIndex: number,
+): number {
+  let index = startIndex;
+  while (index < messages.length && isToolResultMessage(messages[index])) {
+    index++;
+  }
+  return index;
+}
+
+export function filterHeartbeatTranscriptArtifacts<T extends { role: string; content?: unknown }>(
   messages: T[],
   ackMaxChars?: number,
   heartbeatPrompt?: string,
 ): T[] {
-  if (messages.length < 2) {
+  if (messages.length === 0) {
     return messages;
   }
 
   const result: T[] = [];
   let i = 0;
   while (i < messages.length) {
-    if (
-      i + 1 < messages.length &&
-      isHeartbeatUserMessage(messages[i], heartbeatPrompt) &&
-      isHeartbeatOkResponse(messages[i + 1], ackMaxChars)
-    ) {
-      i += 2;
+    if (!isHeartbeatUserMessage(messages[i], heartbeatPrompt)) {
+      result.push(messages[i]);
+      i++;
       continue;
     }
-    result.push(messages[i]);
-    i++;
+
+    let next = i + 1;
+    while (next < messages.length) {
+      const message = messages[next];
+      if (isRealNonHeartbeatUserMessage(message, heartbeatPrompt)) {
+        break;
+      }
+      if (isHeartbeatOkResponse(message, ackMaxChars)) {
+        next = advancePastAdjacentToolResults(messages, next + 1);
+        continue;
+      }
+      if (isHeartbeatResponseToolCall(message)) {
+        next = advancePastAdjacentToolResults(messages, next + 1);
+        continue;
+      }
+      // Keep walking heartbeat-owned helper tool calls/results, assistant text,
+      // and consecutive heartbeat prompts, but never cross a real user message.
+      next++;
+    }
+
+    i = next;
   }
 
   return result;

--- a/src/auto-reply/heartbeat-filter.ts
+++ b/src/auto-reply/heartbeat-filter.ts
@@ -24,6 +24,8 @@ const TOOL_RESULT_BLOCK_TYPES = new Set([
   "function_call_output",
 ]);
 
+type HeartbeatTranscriptMessage = { role: string; content?: unknown };
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
@@ -49,7 +51,7 @@ function collectToolCallBlocks(content: unknown): Array<Record<string, unknown>>
   }
   return content.filter(
     (block): block is Record<string, unknown> =>
-      isRecord(block) && TOOL_CALL_BLOCK_TYPES.has(String(block.type ?? "")),
+      isRecord(block) && TOOL_CALL_BLOCK_TYPES.has(readString(block.type) ?? ""),
   );
 }
 
@@ -59,7 +61,7 @@ function collectToolResultBlocks(content: unknown): Array<Record<string, unknown
   }
   return content.filter(
     (block): block is Record<string, unknown> =>
-      isRecord(block) && TOOL_RESULT_BLOCK_TYPES.has(String(block.type ?? "")),
+      isRecord(block) && TOOL_RESULT_BLOCK_TYPES.has(readString(block.type) ?? ""),
   );
 }
 
@@ -176,7 +178,7 @@ function isEmbeddedToolResultOnlyContent(content: unknown): boolean {
     Array.isArray(content) &&
     content.length > 0 &&
     content.every(
-      (block) => isRecord(block) && TOOL_RESULT_BLOCK_TYPES.has(String(block.type ?? "")),
+      (block) => isRecord(block) && TOOL_RESULT_BLOCK_TYPES.has(readString(block.type) ?? ""),
     )
   );
 }
@@ -193,7 +195,7 @@ function isFailedToolResultRecord(record: Record<string, unknown>): boolean {
   return (
     record.isError === true ||
     record.is_error === true ||
-    String(record.type ?? "") === "tool_result_error"
+    readString(record.type) === "tool_result_error"
   );
 }
 
@@ -336,8 +338,8 @@ export function isHeartbeatOkResponse(
   return stripHeartbeatToken(text, { mode: "heartbeat", maxAckChars: ackMaxChars }).shouldSkip;
 }
 
-function advancePastAdjacentToolResults<T extends { role: string; content?: unknown }>(
-  messages: T[],
+function advancePastAdjacentToolResults(
+  messages: HeartbeatTranscriptMessage[],
   startIndex: number,
 ): number {
   let index = startIndex;
@@ -351,9 +353,10 @@ function isToolResultCompletionCandidate(message: { role: string; content?: unkn
   return isToolResultMessage(message) || collectToolResultBlocks(message.content).length > 0;
 }
 
-function hasCompletedVisibleHeartbeatResponseToolCall<
-  T extends { role: string; content?: unknown },
->(messages: T[], index: number): boolean {
+function hasCompletedVisibleHeartbeatResponseToolCall(
+  messages: HeartbeatTranscriptMessage[],
+  index: number,
+): boolean {
   const visibleCalls = collectVisibleHeartbeatResponseToolCalls(messages[index]);
   if (visibleCalls.length === 0) {
     return false;
@@ -380,8 +383,8 @@ function hasCompletedVisibleHeartbeatResponseToolCall<
   return false;
 }
 
-function resolveHeartbeatArtifactSpanEnd<T extends { role: string; content?: unknown }>(
-  messages: T[],
+function resolveHeartbeatArtifactSpanEnd(
+  messages: HeartbeatTranscriptMessage[],
   startIndex: number,
   ackMaxChars?: number,
   heartbeatPrompt?: string,

--- a/src/auto-reply/heartbeat-filter.ts
+++ b/src/auto-reply/heartbeat-filter.ts
@@ -23,6 +23,7 @@ const TOOL_RESULT_BLOCK_TYPES = new Set([
   "tool_result_error",
   "function_call_output",
 ]);
+const MESSAGE_TOOL_DELIVERY_PREFIX = "Delivery: to send a message, use the `message` tool.";
 
 type HeartbeatTranscriptMessage = { role: string; content?: unknown };
 
@@ -271,7 +272,7 @@ function resolveMessageText(content: unknown): { text: string; hasNonTextContent
       hasNonTextContent = true;
       continue;
     }
-    if (block.type !== "text") {
+    if (block.type !== "text" && block.type !== "input_text" && block.type !== "output_text") {
       hasNonTextContent = true;
       continue;
     }
@@ -299,6 +300,12 @@ export function isHeartbeatUserMessage(
   }
   const normalizedHeartbeatPrompt = heartbeatPrompt?.trim();
   if (trimmed === HEARTBEAT_TRANSCRIPT_PROMPT) {
+    return true;
+  }
+  if (
+    trimmed.startsWith(MESSAGE_TOOL_DELIVERY_PREFIX) &&
+    trimmed.endsWith(HEARTBEAT_TRANSCRIPT_PROMPT)
+  ) {
     return true;
   }
   if (matchesHeartbeatPromptText(trimmed, normalizedHeartbeatPrompt)) {

--- a/src/auto-reply/heartbeat-filter.ts
+++ b/src/auto-reply/heartbeat-filter.ts
@@ -17,7 +17,12 @@ const TOOL_CALL_BLOCK_TYPES = new Set([
   "function_call",
   "tool_use",
 ]);
-const TOOL_RESULT_BLOCK_TYPES = new Set(["toolResult", "tool_result", "function_call_output"]);
+const TOOL_RESULT_BLOCK_TYPES = new Set([
+  "toolResult",
+  "tool_result",
+  "tool_result_error",
+  "function_call_output",
+]);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -48,31 +53,125 @@ function collectToolCallBlocks(content: unknown): Array<Record<string, unknown>>
   );
 }
 
+function collectToolResultBlocks(content: unknown): Array<Record<string, unknown>> {
+  if (!Array.isArray(content)) {
+    return [];
+  }
+  return content.filter(
+    (block): block is Record<string, unknown> =>
+      isRecord(block) && TOOL_RESULT_BLOCK_TYPES.has(String(block.type ?? "")),
+  );
+}
+
 function readToolCallName(block: Record<string, unknown>): string | undefined {
   return readString(block.name) ?? readNestedString(block, "function");
 }
 
-function isHeartbeatResponseToolCall(message: { role: string; content?: unknown }): boolean {
-  if (message.role !== "assistant") {
+function collectToolCallIds(block: Record<string, unknown>): string[] {
+  const ids = [
+    readString(block.call_id),
+    readString(block.tool_call_id),
+    readString(block.toolCallId),
+    readString(block.tool_use_id),
+    readString(block.toolUseId),
+    readString(block.id),
+  ].filter((id): id is string => Boolean(id));
+  return [...new Set(ids)];
+}
+
+function readNestedToolCallArguments(record: Record<string, unknown>): unknown {
+  const value = record.function;
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  return value.arguments ?? value.args ?? value.input;
+}
+
+function readToolCallArguments(block: Record<string, unknown>): unknown {
+  return block.arguments ?? block.args ?? block.input ?? readNestedToolCallArguments(block);
+}
+
+function parseToolCallArguments(value: unknown): Record<string, unknown> | undefined {
+  if (isRecord(value)) {
+    return value;
+  }
+  if (typeof value !== "string" || !value.trim()) {
+    return undefined;
+  }
+  try {
+    const parsed: unknown = JSON.parse(value);
+    return isRecord(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isVisibleHeartbeatResponseToolCall(block: Record<string, unknown>): boolean {
+  const args = parseToolCallArguments(readToolCallArguments(block));
+  if (!args) {
     return false;
   }
-  if (isRecord(message)) {
-    for (const call of Array.isArray(message.tool_calls) ? message.tool_calls : []) {
-      if (!isRecord(call)) {
-        continue;
-      }
-      const name = readToolCallName(call);
-      if (name === HEARTBEAT_RESPONSE_TOOL_NAME) {
-        return true;
-      }
-    }
+  return args.notify === true || args.notify === "true";
+}
+
+function collectVisibleHeartbeatResponseToolCalls(message: {
+  role: string;
+  content?: unknown;
+}): Array<Record<string, unknown>> {
+  if (message.role !== "assistant") {
+    return [];
   }
-  return collectToolCallBlocks(message.content).some(
-    (block) => readToolCallName(block) === HEARTBEAT_RESPONSE_TOOL_NAME,
+  return [...collectMessageToolCalls(message), ...collectToolCallBlocks(message.content)].filter(
+    (block) =>
+      readToolCallName(block) === HEARTBEAT_RESPONSE_TOOL_NAME &&
+      isVisibleHeartbeatResponseToolCall(block),
   );
 }
 
-function isEmbeddedToolResultContent(content: unknown): boolean {
+function collectMessageToolCalls(message: { role: string; content?: unknown }) {
+  const toolCalls = (message as Record<string, unknown>).tool_calls;
+  if (!Array.isArray(toolCalls)) {
+    return [];
+  }
+  return toolCalls.filter((call): call is Record<string, unknown> => isRecord(call));
+}
+
+function hasAssistantToolCall(message: { role: string; content?: unknown }): boolean {
+  return (
+    message.role === "assistant" &&
+    (collectMessageToolCalls(message).length > 0 ||
+      collectToolCallBlocks(message.content).length > 0)
+  );
+}
+
+function isRemovableHeartbeatResponseToolCall(message: {
+  role: string;
+  content?: unknown;
+}): boolean {
+  if (message.role !== "assistant") {
+    return false;
+  }
+  for (const call of collectMessageToolCalls(message)) {
+    const name = readToolCallName(call);
+    if (name === HEARTBEAT_RESPONSE_TOOL_NAME && !isVisibleHeartbeatResponseToolCall(call)) {
+      return true;
+    }
+  }
+  return collectToolCallBlocks(message.content).some(
+    (block) =>
+      readToolCallName(block) === HEARTBEAT_RESPONSE_TOOL_NAME &&
+      !isVisibleHeartbeatResponseToolCall(block),
+  );
+}
+
+function hasVisibleHeartbeatResponseToolCall(message: {
+  role: string;
+  content?: unknown;
+}): boolean {
+  return collectVisibleHeartbeatResponseToolCalls(message).length > 0;
+}
+
+function isEmbeddedToolResultOnlyContent(content: unknown): boolean {
   return (
     Array.isArray(content) &&
     content.length > 0 &&
@@ -86,8 +185,58 @@ function isToolResultMessage(message: { role: string; content?: unknown }): bool
   return (
     message.role === "toolResult" ||
     message.role === "tool" ||
-    (message.role === "user" && isEmbeddedToolResultContent(message.content))
+    (message.role === "user" && isEmbeddedToolResultOnlyContent(message.content))
   );
+}
+
+function isFailedToolResultRecord(record: Record<string, unknown>): boolean {
+  return (
+    record.isError === true ||
+    record.is_error === true ||
+    String(record.type ?? "") === "tool_result_error"
+  );
+}
+
+function hasSuccessfulToolResultMessage(message: { role: string; content?: unknown }): boolean {
+  const resultBlocks = collectToolResultBlocks(message.content);
+  if (resultBlocks.length > 0) {
+    return resultBlocks.some((block) => !isFailedToolResultRecord(block));
+  }
+  if (!isToolResultMessage(message)) {
+    return false;
+  }
+  return !isFailedToolResultRecord(message as Record<string, unknown>);
+}
+
+function collectSuccessfulToolResultCallIds(message: {
+  role: string;
+  content?: unknown;
+}): string[] {
+  const record = message as Record<string, unknown>;
+  const resultBlocks = collectToolResultBlocks(message.content);
+  const ids: string[] = [];
+  if (resultBlocks.length === 0) {
+    if (!isFailedToolResultRecord(record)) {
+      ids.push(
+        ...[
+          readString(record.toolCallId),
+          readString(record.tool_call_id),
+          readString(record.toolUseId),
+          readString(record.tool_use_id),
+          readString(record.call_id),
+          readString(record.id),
+        ].filter((id): id is string => Boolean(id)),
+      );
+    }
+  } else {
+    for (const block of resultBlocks) {
+      if (isFailedToolResultRecord(block)) {
+        continue;
+      }
+      ids.push(...collectToolCallIds(block));
+    }
+  }
+  return [...new Set(ids)];
 }
 
 function isRealNonHeartbeatUserMessage(
@@ -96,7 +245,7 @@ function isRealNonHeartbeatUserMessage(
 ): boolean {
   return (
     message.role === "user" &&
-    !isEmbeddedToolResultContent(message.content) &&
+    !isEmbeddedToolResultOnlyContent(message.content) &&
     !isHeartbeatUserMessage(message, heartbeatPrompt)
   );
 }
@@ -177,6 +326,9 @@ export function isHeartbeatOkResponse(
   if (message.role !== "assistant") {
     return false;
   }
+  if (hasAssistantToolCall(message)) {
+    return false;
+  }
   const { text, hasNonTextContent } = resolveMessageText(message.content);
   if (hasNonTextContent) {
     return false;
@@ -191,6 +343,96 @@ function advancePastAdjacentToolResults<T extends { role: string; content?: unkn
   let index = startIndex;
   while (index < messages.length && isToolResultMessage(messages[index])) {
     index++;
+  }
+  return index;
+}
+
+function isToolResultCompletionCandidate(message: { role: string; content?: unknown }): boolean {
+  return isToolResultMessage(message) || collectToolResultBlocks(message.content).length > 0;
+}
+
+function hasCompletedVisibleHeartbeatResponseToolCall<
+  T extends { role: string; content?: unknown },
+>(messages: T[], index: number): boolean {
+  const visibleCalls = collectVisibleHeartbeatResponseToolCalls(messages[index]);
+  if (visibleCalls.length === 0) {
+    return false;
+  }
+  const callIds = new Set(visibleCalls.flatMap((call) => collectToolCallIds(call)));
+  for (
+    let resultIndex = index + 1;
+    resultIndex < messages.length && isToolResultCompletionCandidate(messages[resultIndex]);
+    resultIndex++
+  ) {
+    const result = messages[resultIndex];
+    if (!hasSuccessfulToolResultMessage(result)) {
+      continue;
+    }
+    if (callIds.size === 0) {
+      return true;
+    }
+    for (const resultId of collectSuccessfulToolResultCallIds(result)) {
+      if (callIds.has(resultId)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function resolveHeartbeatArtifactSpanEnd<T extends { role: string; content?: unknown }>(
+  messages: T[],
+  startIndex: number,
+  ackMaxChars?: number,
+  heartbeatPrompt?: string,
+): number | undefined {
+  let index = startIndex + 1;
+  let sawTerminalHeartbeatArtifact = false;
+  let sawNonTerminalAssistantOutput = false;
+
+  while (index < messages.length) {
+    const message = messages[index];
+    if (isRealNonHeartbeatUserMessage(message, heartbeatPrompt)) {
+      break;
+    }
+    if (isHeartbeatUserMessage(message, heartbeatPrompt)) {
+      break;
+    }
+    if (isHeartbeatOkResponse(message, ackMaxChars)) {
+      sawTerminalHeartbeatArtifact = true;
+      index = advancePastAdjacentToolResults(messages, index + 1);
+      continue;
+    }
+    if (hasVisibleHeartbeatResponseToolCall(message)) {
+      if (hasCompletedVisibleHeartbeatResponseToolCall(messages, index)) {
+        return undefined;
+      }
+      index++;
+      continue;
+    }
+    if (isRemovableHeartbeatResponseToolCall(message)) {
+      sawTerminalHeartbeatArtifact = true;
+      index = advancePastAdjacentToolResults(messages, index + 1);
+      continue;
+    }
+    if (sawTerminalHeartbeatArtifact) {
+      index++;
+      continue;
+    }
+    if (isToolResultMessage(message) || hasAssistantToolCall(message)) {
+      index++;
+      continue;
+    }
+    if (message.role === "assistant") {
+      sawNonTerminalAssistantOutput = true;
+      index++;
+      continue;
+    }
+    return undefined;
+  }
+
+  if (sawNonTerminalAssistantOutput && !sawTerminalHeartbeatArtifact) {
+    return undefined;
   }
   return index;
 }
@@ -213,23 +455,11 @@ export function filterHeartbeatTranscriptArtifacts<T extends { role: string; con
       continue;
     }
 
-    let next = i + 1;
-    while (next < messages.length) {
-      const message = messages[next];
-      if (isRealNonHeartbeatUserMessage(message, heartbeatPrompt)) {
-        break;
-      }
-      if (isHeartbeatOkResponse(message, ackMaxChars)) {
-        next = advancePastAdjacentToolResults(messages, next + 1);
-        continue;
-      }
-      if (isHeartbeatResponseToolCall(message)) {
-        next = advancePastAdjacentToolResults(messages, next + 1);
-        continue;
-      }
-      // Keep walking heartbeat-owned helper tool calls/results, assistant text,
-      // and consecutive heartbeat prompts, but never cross a real user message.
-      next++;
+    const next = resolveHeartbeatArtifactSpanEnd(messages, i, ackMaxChars, heartbeatPrompt);
+    if (next === undefined) {
+      result.push(messages[i]);
+      i++;
+      continue;
     }
 
     i = next;


### PR DESCRIPTION
## Summary
- Filters full silent heartbeat transcript spans before normal prompt assembly, including helper tool calls/results, prompt-only interrupted wakes, pre-terminal assistant status text, and `heartbeat_respond notify:false`.
- Handles the live OpenAI Responses transcript shapes (`input_text` / `output_text`) and the message-tool delivery prefix used by heartbeat polls in shared sessions.
- Preserves visible heartbeat output only when it is actually visible: free-text alerts remain, and `heartbeat_respond notify:true` is kept only after a completed successful matching response-tool result.
- Fixes bundled LINE extension lint by using the public command definition type instead of deriving it through a broad API parameter.

## Real behavior proof
Behavior addressed: Later normal prompts no longer receive stale silent heartbeat artifacts such as `[OpenClaw heartbeat poll]`, `HEARTBEAT.md`, `heartbeat_respond`, or `notify=false`; completed visible heartbeat notifications remain available to the next prompt context.
Real environment tested: Local OpenClaw checkout on this PR branch at `67bbcaa4e62283ebbab7a488d2683807c5d55e8f`, using production `runHeartbeatOnce` in heartbeat response-tool mode followed by production `getReplyFromConfig` for a normal prompt on the same temporary `agent:main:main` session. The model endpoint was a local OpenAI Responses-compatible HTTP server so the full OpenClaw session persistence and prompt assembly path ran without external credentials.
Exact steps or command run after this patch: `node --import tsx /tmp/openclaw-heartbeat-real-session-proof.mjs`
Evidence after fix: Redacted terminal transcript from the same-session proof:
```text
proof.stage heartbeat-start
localProvider.request heartbeat /v1/responses
localProvider.request heartbeat /v1/responses
proof.stage heartbeat-done ran
proof.stage normal-start
localProvider.request normal /v1/responses
proof.stage normal-done
transcriptLineSummaries ... user text Delivery: to send a message, use the `message` tool. [OpenClaw heartbeat poll] ... custom_message openclaw.runtime-context Read HEARTBEAT.md ... assistant toolCall ... heartbeat_respond ... toolResult ... assistant text HEARTBEAT_OK ... user text what model are you ... assistant text I am the local proof model.
heartbeatResult.status ran
providerRequestKinds heartbeat,heartbeat,normal
heartbeatProviderRequestContainsHeartbeatPrompt true
transcriptContainsHeartbeatArtifacts {"[OpenClaw heartbeat poll]":true,"HEARTBEAT.md":true,"heartbeat_respond":true,"notify=false":true,"\"notify\":false":true}
normalProviderRequestContainsArtifacts {"[OpenClaw heartbeat poll]":false,"HEARTBEAT.md":false,"heartbeat_respond":false,"notify=false":false,"\"notify\":false":false}
normalProviderRequestContainsUserPrompt true
```
Observed result after fix: The persisted session intentionally still contains the operational heartbeat span, including `HEARTBEAT.md`, `heartbeat_respond`, `notify:false`, `HEARTBEAT_OK`, and the prefixed `[OpenClaw heartbeat poll]` user message. The following normal provider request for `what model are you` contains the user prompt but none of those heartbeat artifacts, proving the filter removes stale heartbeat context before normal prompt dispatch.
What was not tested: No external provider or Telegram delivery. This proof used a local OpenAI Responses-compatible endpoint, but exercised OpenClaw's production heartbeat runner, session-history persistence, transcript filter, and normal prompt submission path on one shared session.

## Verification
- `node --no-maglev node_modules/vitest/vitest.mjs src/auto-reply/heartbeat-filter.test.ts --run --reporter=verbose` - `Test Files 1 passed (1)`, `Tests 34 passed (34)`.
- `node --no-maglev node_modules/vitest/vitest.mjs src/auto-reply/heartbeat-filter.test.ts src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts src/infra/heartbeat-runner.tool-response.test.ts --run --reporter=verbose` - `Test Files 4 passed (4)`, `Tests 134 passed (134)`.
- `node --import tsx /tmp/openclaw-heartbeat-real-session-proof.mjs` - real same-session heartbeat-to-normal-prompt proof above.
- `pnpm format:check -- src/auto-reply/heartbeat-filter.ts src/auto-reply/heartbeat-filter.test.ts`
- `git diff --check`
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode local --reviewer codex --fallback-reviewer none` - clean, no accepted/actionable findings.
- Earlier PR-gate proof retained from this branch: `pnpm lint --threads=8`, `pnpm tsgo:prod`, `pnpm check:test-types`, `node scripts/run-bundled-extension-oxlint.mjs`, `pnpm run test:extensions:package-boundary:compile`, `pnpm run test:extensions:package-boundary:canary`.
