### PR TITLE
fix(telegram): honor outbound media max bytes

### DIFF
--- a/extensions/telegram/src/bot-core.ts
+++ b/extensions/telegram/src/bot-core.ts
@@ -372,6 +372,7 @@ export function createTelegramBotCore(
     groupAllowFrom,
     replyToMode,
     textLimit,
+    mediaMaxBytes,
     useAccessGroups,
     nativeEnabled,
     nativeSkillsEnabled,

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1352,6 +1352,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
 
   it("keeps streamed final text in place when late media arrives", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    const mediaMaxBytes = 50 * 1024 * 1024;
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
       async ({ dispatcherOptions, replyOptions }) => {
         await replyOptions?.onPartialReply?.({ text: "Photo" });
@@ -1363,10 +1364,14 @@ describe("dispatchTelegramMessage draft streaming", () => {
       },
     );
 
-    await dispatchWithContext({ context: createContext() });
+    await dispatchWithContext({
+      context: createContext(),
+      telegramCfg: { mediaMaxMb: 50 },
+    });
 
     expect(answerDraftStream.clear).not.toHaveBeenCalled();
     expect(answerDraftStream.update).toHaveBeenCalledWith("Photo");
+    expectDeliverRepliesParams({ mediaMaxBytes });
     expectDeliveredReply(0, { text: undefined, mediaUrl: "https://example.com/a.png" });
   });
 

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -173,7 +173,7 @@ type DispatchTelegramMessageParams = {
   textLimit: number;
   telegramCfg: TelegramAccountConfig;
   telegramDeps?: TelegramBotDeps;
-  opts: Pick<TelegramBotOptions, "token">;
+  opts: Pick<TelegramBotOptions, "token" | "mediaMaxMb">;
 };
 
 type TelegramReasoningLevel = "off" | "on" | "stream";
@@ -1027,6 +1027,7 @@ export const dispatchTelegramMessage = async ({
     runtime,
     bot,
     mediaLocalRoots,
+    mediaMaxBytes: (opts.mediaMaxMb ?? telegramCfg.mediaMaxMb ?? 100) * 1024 * 1024,
     replyToMode,
     textLimit,
     thread: threadSpec,

--- a/extensions/telegram/src/bot-native-commands.test.ts
+++ b/extensions/telegram/src/bot-native-commands.test.ts
@@ -59,8 +59,8 @@ function registerPlugCommand(params: PlugCommandHarnessParams = {}) {
   registerTelegramNativeCommands({
     ...createNativeCommandTestParams(params.cfg ?? {}, {
       bot: botHarness.bot,
-      ...params.registerOverrides,
     }),
+    ...params.registerOverrides,
   });
   const handler = botHarness.commandHandlers.get("plug");
   if (!handler) {
@@ -371,6 +371,7 @@ describe("registerTelegramNativeCommands", () => {
   });
 
   it("passes agent-scoped media roots for plugin command replies with media", async () => {
+    const mediaMaxBytes = 50 * 1024 * 1024;
     const cfg: OpenClawConfig = {
       agents: {
         list: [{ id: "main", default: true }, { id: "work" }],
@@ -384,11 +385,15 @@ describe("registerTelegramNativeCommands", () => {
         text: "with media",
         mediaUrl: "/tmp/workspace-work/render.png",
       },
+      registerOverrides: {
+        mediaMaxBytes,
+      } as Partial<Parameters<typeof registerTelegramNativeCommands>[0]>,
     });
 
     await handler(createPrivateCommandContext());
 
     const deliverParams = firstDeliverRepliesParams();
+    expect(deliverParams.mediaMaxBytes).toBe(mediaMaxBytes);
     const mediaLocalRoots = deliverParams.mediaLocalRoots as Array<string> | undefined;
     expect(mediaLocalRoots?.some((root) => /[\\/]\.openclaw[\\/]workspace-work$/.test(root))).toBe(
       true,

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -465,6 +465,7 @@ export type RegisterTelegramNativeCommandsParams = {
   groupAllowFrom?: Array<string | number>;
   replyToMode: ReplyToMode;
   textLimit: number;
+  mediaMaxBytes?: number;
   useAccessGroups: boolean;
   nativeEnabled: boolean;
   nativeSkillsEnabled: boolean;
@@ -691,6 +692,7 @@ export const registerTelegramNativeCommands = ({
   groupAllowFrom,
   replyToMode,
   textLimit,
+  mediaMaxBytes,
   useAccessGroups,
   nativeEnabled,
   nativeSkillsEnabled,
@@ -931,6 +933,7 @@ export const registerTelegramNativeCommands = ({
     runtime,
     bot,
     mediaLocalRoots: params.mediaLocalRoots,
+    mediaMaxBytes,
     replyToMode,
     textLimit,
     thread: params.threadSpec,

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -331,6 +331,7 @@ async function deliverMediaReply(params: {
   thread?: TelegramThreadSpec | null;
   tableMode?: MarkdownTableMode;
   mediaLocalRoots?: readonly string[];
+  mediaMaxBytes?: number;
   chunkText: ChunkTextFn;
   mediaLoader: typeof loadWebMedia;
   onVoiceRecording?: () => Promise<void> | void;
@@ -353,7 +354,10 @@ async function deliverMediaReply(params: {
     const isFirstMedia = first;
     const media = await params.mediaLoader(
       mediaUrl,
-      buildOutboundMediaLoadOptions({ mediaLocalRoots: params.mediaLocalRoots }),
+      buildOutboundMediaLoadOptions({
+        mediaLocalRoots: params.mediaLocalRoots,
+        maxBytes: params.mediaMaxBytes,
+      }),
     );
     const kind = kindFromMime(media.contentType ?? undefined);
     const isGif = isGifMedia({
@@ -693,6 +697,7 @@ export async function deliverReplies(params: {
   runtime: RuntimeEnv;
   bot: Bot;
   mediaLocalRoots?: readonly string[];
+  mediaMaxBytes?: number;
   replyToMode: ReplyToMode;
   textLimit: number;
   thread?: TelegramThreadSpec | null;
@@ -879,6 +884,7 @@ export async function deliverReplies(params: {
           thread: params.thread,
           tableMode: params.tableMode,
           mediaLocalRoots: params.mediaLocalRoots,
+          mediaMaxBytes: params.mediaMaxBytes,
           chunkText,
           mediaLoader,
           onVoiceRecording: params.onVoiceRecording,

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -751,6 +751,33 @@ describe("deliverReplies", () => {
     });
   });
 
+  it("passes the configured media byte cap to media loading", async () => {
+    const runtime = createRuntime();
+    const sendPhoto = vi.fn().mockResolvedValue({
+      message_id: 13,
+      chat: { id: "123" },
+    });
+    const bot = createBot({ sendPhoto });
+    const mediaMaxBytes = 50 * 1024 * 1024;
+
+    mockMediaLoad("photo.jpg", "image/jpeg", "image");
+
+    await deliverReplies({
+      replies: [{ mediaUrl: "https://example.com/photo.jpg" }],
+      chatId: "123",
+      token: "tok",
+      runtime,
+      bot,
+      replyToMode: "off",
+      textLimit: 4000,
+      mediaMaxBytes,
+    });
+
+    expect(loadWebMedia).toHaveBeenCalledWith("https://example.com/photo.jpg", {
+      maxBytes: mediaMaxBytes,
+    });
+  });
+
   it("includes link_preview_options when linkPreview is false", async () => {
     const runtime = createRuntime();
     const sendMessage = vi.fn().mockResolvedValue({


### PR DESCRIPTION
Telegram final replies with media above the default cap can fail even when users configured a larger `channels.telegram.mediaMaxMb` limit.

Fixes #46023

## Affected surface

- `extensions/telegram/src/bot-core.ts`
- `extensions/telegram/src/bot-message-dispatch.ts`
- `extensions/telegram/src/bot-native-commands.ts`
- `extensions/telegram/src/bot/delivery.replies.ts`

## Scope

This is a narrow parameter-threading fix. It carries the existing Telegram media byte cap into final and native reply delivery, then reuses `buildOutboundMediaLoadOptions({ maxBytes })` when outbound media is loaded. No new config, policy, or media-limit strategy is introduced.

Approximate scope: 52 inserted lines / 4 removed lines including regression tests.

## Real behavior proof

- Behavior or issue addressed: Telegram final/native replies with media now thread the configured 50 MiB `mediaMaxMb` cap into outbound media loading instead of falling back to the default video cap.
- Real environment tested: Local Linux executor, branch `wolf/telegram-outbound-media-maxbytes`, head `935da229b9`, Node.js `v22.22.2`; real Telegram Bot API delivery through `sendVideo` into Telegram Desktop.
- Exact steps or command run after this patch:
  1. Started a temporary local Node/tsx harness outside the repository.
  2. Imported OpenClaw source `deliverReplies` from `extensions/telegram/src/bot/delivery.replies.ts`.
  3. Exercised the real path `deliverReplies` -> `deliverMediaReply` -> `loadWebMedia` -> Telegram Bot API `sendVideo`.
  4. Served a valid 35,462,055-byte MP4 from a local HTTP server and ran the before case without `mediaMaxBytes`.
  5. Re-ran the same delivery with `mediaMaxBytes = 52428800`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Telegram Desktop visible proof is attached at https://github.com/user-attachments/assets/ed6790f0-d4b3-431d-b333-a2bc43d9e06c and also referenced from https://github.com/openclaw/openclaw/pull/83478#issuecomment-4496035844.

  Redacted local live run log:

  ```text
  [server] local_http=started url=<local-http-url>
  [before] start file_size=35462055 maxBytes=<default> url=<local-http-url>
  [before] loadWebMedia input url=<local-http-url> maxBytes=<default>
  [before] result=error error=Media exceeds 16MB limit (got 33.82MB)
  [after] start file_size=35462055 maxBytes=52428800 url=<local-http-url>
  [after] loadWebMedia input url=<local-http-url> maxBytes=52428800
  [telegram] method=sendVideo chat_id=<redacted-chat-id> status=pending
  [telegram] method=sendVideo http_status=200 message_id=2
  [after] result=success delivered=true
  [server] local_http=stopped
  ```
- Observed result after fix: Without `mediaMaxBytes`, the same 35,462,055-byte MP4 fails in OpenClaw media loading with the default 16 MiB video cap. With `mediaMaxBytes = 52428800`, `loadWebMedia` accepts the media, Telegram Bot API `sendVideo` returns HTTP 200, and Telegram Desktop shows the delivered media.
- What was not tested: This live proof covers the Telegram video reply path on a local Linux executor with real Telegram Bot API delivery; macOS/iOS apps and non-Telegram channels are outside this PR.
- Before evidence (optional but encouraged): The before case in the same live harness failed before Telegram delivery with `Media exceeds 16MB limit (got 33.82MB)`.

Local regression/changed-check output:

```text
$ pnpm test extensions/telegram/src/bot/delivery.test.ts extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/bot-native-commands.test.ts
 Test Files  3 passed (3)
      Tests  138 passed (138)

$ pnpm check:changed --base origin/main
check:changed completed changed extension lanes, extension typecheck, extension test typecheck, oxlint, media helper guard, runtime sidecar loader guard, and import cycle check with no failures.

$ git diff --check
<no output>

$ gitleaks protect --staged --redact
no leaks found
```

## Coverage note

ClawSweeper confirmed in issue #46023 that current main still has this gap: Telegram computes `mediaMaxBytes`, but normal final replies and native-command replies do not thread a media cap into `deliverReplies`, `deliverMediaReply`, or `loadWebMedia`. I also checked open PR coverage before starting; no open PR covered #46023, `Telegram mediaMaxMb`, or `deliverReplies mediaMaxBytes`.
