### PR TITLE
fix: linkify tool output urls

### DIFF
--- a/ui/src/ui/chat/tool-cards.test.ts
+++ b/ui/src/ui/chat/tool-cards.test.ts
@@ -63,6 +63,31 @@ describe("tool-cards", () => {
     ]);
   });
 
+  it("linkifies URL values in expanded tool output", () => {
+    const container = document.createElement("div");
+    render(
+      renderToolCard(
+        {
+          id: "msg:4c:call-4c",
+          name: "web_fetch",
+          outputText: '{\n  "url": "https://example.com/article?ref=123",\n  "status": 200\n}',
+        },
+        { expanded: true, onToggleExpanded: vi.fn() },
+      ),
+      container,
+    );
+
+    const link = container.querySelector<HTMLAnchorElement>(".chat-tool-card__block-content a");
+    expect(link).toBeInstanceOf(HTMLAnchorElement);
+    expect(link?.href).toBe("https://example.com/article?ref=123");
+    expect(link?.target).toBe("_blank");
+    expect(link?.rel).toBe("noopener noreferrer");
+    expect(link?.textContent).toBe("https://example.com/article?ref=123");
+    expect(container.querySelector("code")?.textContent).toContain(
+      '"url": "https://example.com/article?ref=123"',
+    );
+  });
+
   it("renders expanded tool calls without an inline output block when no output is present", () => {
     const container = document.createElement("div");
     render(

--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -366,6 +366,26 @@ export function renderRawOutputToggle(text: string) {
   `;
 }
 
+const TOOL_OUTPUT_URL_PATTERN = /https?:\/\/[^\s"'<>]+/g;
+
+function renderLinkifiedToolText(text: string) {
+  const parts: Array<string | ReturnType<typeof html>> = [];
+  let lastIndex = 0;
+  for (const match of text.matchAll(TOOL_OUTPUT_URL_PATTERN)) {
+    const url = match[0];
+    const index = match.index ?? 0;
+    if (index > lastIndex) {
+      parts.push(text.slice(lastIndex, index));
+    }
+    parts.push(html`<a href=${url} target="_blank" rel="noopener noreferrer">${url}</a>`);
+    lastIndex = index + url.length;
+  }
+  if (lastIndex < text.length) {
+    parts.push(text.slice(lastIndex));
+  }
+  return parts.length > 0 ? parts : [text];
+}
+
 function renderToolDataBlock(params: {
   label: string;
   text: string;
@@ -382,7 +402,7 @@ function renderToolDataBlock(params: {
       ${empty
         ? html`<div class="chat-tool-card__block-empty muted">${text}</div>`
         : expanded
-          ? html`<pre class="chat-tool-card__block-content"><code>${text}</code></pre>`
+          ? html`<pre class="chat-tool-card__block-content"><code>${renderLinkifiedToolText(text)}</code></pre>`
           : html`<div class="chat-tool-card__block-preview mono">
               ${getTruncatedPreview(text)}
             </div>`}


### PR DESCRIPTION
## Summary
- Linkify `http://` and `https://` URLs in expanded Control UI tool input/output code blocks.
- Preserve the raw displayed text while adding safe new-tab anchors with `noopener noreferrer`.
- Add a jsdom regression test for URL values in tool output cards.

## Tests
- `git diff --check` ✅
- `node --no-maglev ../node_modules/vitest/vitest.mjs run src/ui/chat/tool-cards.test.ts --config vitest.config.ts --project unit --reporter=verbose` ✅ (from `ui/`; 6 tests passed)
- `pnpm test ui/src/ui/chat/tool-cards.test.ts -- --reporter=verbose` ⚠️ blocked: pnpm dependency reconciliation attempted registry downloads and timed out
- `pnpm install` ⚠️ retry also timed out during optional/native package downloads from npm registry

Closes #8812

## Real behavior proof
Behavior addressed: Control UI expanded tool cards now render URL substrings in tool text as clickable links without changing copied/text content.
Real environment tested: Local macOS checkout, jsdom unit test under `ui/vitest.config.ts` unit project.
Exact steps or command run after this patch: `node --no-maglev ../node_modules/vitest/vitest.mjs run src/ui/chat/tool-cards.test.ts --config vitest.config.ts --project unit --reporter=verbose`
Evidence after fix: Terminal output from the local runtime command showed `ui/src/ui/chat/tool-cards.test.ts` passed 6/6, including `linkifies URL values in expanded tool output`.
Observed result after fix: The rendered tool output contains an `<a href="https://example.com/article?ref=123" target="_blank" rel="noopener noreferrer">` while `code.textContent` still includes the original JSON URL text.
What was not tested: Full `pnpm check:changed`; local pnpm dependency reconciliation repeatedly timed out while downloading optional/native npm packages.
