### PR TITLE
fix(agents): preserve code mode hook context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/code mode: preserve agent, session, run, and channel context in `before_tool_call` hooks for top-level `exec`/`wait` dispatches. Fixes #83387.
 - Replies: keep final payload delivery after live preview updates so channels can finalize or send the completed answer instead of losing preview-only drafts. (#83468)
 - Providers/Xiaomi: replay MiMo Anthropic-compatible `reasoning_content` as provider-required thinking blocks even when OpenClaw thinking is disabled, fixing follow-up tool turns for `mimo-v2-flash`. Fixes #83407. Thanks @Xgenious7.
 - Agents/exec approvals: forward approval-runtime credentials on agent-owned Gateway approval calls so approved async commands complete through the existing runtime path instead of stalling on unauthenticated follow-up calls. Thanks @IWhatsskill, @Patrick-Erichsen, and @jesse-merhi.

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -1061,6 +1061,15 @@ async function compactEmbeddedPiSessionDirectOnce(
       const { customTools } = splitSdkTools({
         tools: effectiveTools,
         sandboxEnabled: !!sandbox?.enabled,
+        toolHookContext: {
+          agentId: sessionAgentId,
+          config: params.config,
+          cwd: effectiveWorkspace,
+          sessionKey: sandboxSessionKey,
+          sessionId: params.sessionId,
+          runId: params.runId,
+          channelId: params.currentChannelId,
+        },
       });
       // Pi treats `tools` as a name allowlist during session creation. Pass the
       // exact OpenClaw-managed registrations so custom tools survive startup.

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2179,6 +2179,7 @@ export async function runEmbeddedAttempt(
       const { customTools } = splitSdkTools({
         tools: effectiveTools,
         sandboxEnabled: !!sandbox?.enabled,
+        toolHookContext: catalogToolHookContext,
       });
 
       // Add client tools (OpenResponses hosted tools) to customTools.

--- a/src/agents/pi-embedded-runner/tool-split.ts
+++ b/src/agents/pi-embedded-runner/tool-split.ts
@@ -1,15 +1,20 @@
 import type { AgentTool } from "@earendil-works/pi-agent-core";
 import { toToolDefinitions } from "../pi-tool-definition-adapter.js";
+import type { HookContext } from "../pi-tools.before-tool-call.js";
 
 // We always pass tools via `customTools` so our policy filtering, sandbox integration,
 // and extended toolset remain consistent across providers.
 type AnyAgentTool = AgentTool;
 
-export function splitSdkTools(options: { tools: AnyAgentTool[]; sandboxEnabled: boolean }): {
+export function splitSdkTools(options: {
+  tools: AnyAgentTool[];
+  sandboxEnabled: boolean;
+  toolHookContext?: HookContext;
+}): {
   customTools: ReturnType<typeof toToolDefinitions>;
 } {
-  const { tools } = options;
+  const { tools, toolHookContext } = options;
   return {
-    customTools: toToolDefinitions(tools),
+    customTools: toToolDefinitions(tools, toolHookContext),
   };
 }

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -223,7 +223,10 @@ export function isClientToolNameConflictError(err: unknown): err is Error {
   return err instanceof Error && err.message.startsWith(CLIENT_TOOL_NAME_CONFLICT_PREFIX);
 }
 
-export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
+export function toToolDefinitions(
+  tools: AnyAgentTool[],
+  hookContext?: HookContext,
+): ToolDefinition[] {
   return tools.map((tool) => {
     const name = tool.name || "tool";
     const normalizedName = normalizeToolName(name);
@@ -242,6 +245,7 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
               toolName: name,
               params,
               toolCallId,
+              ctx: hookContext,
             });
             if (hookOutcome.blocked) {
               if (hookOutcome.kind === "veto") {

--- a/src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
@@ -313,6 +313,46 @@ describe("before_tool_call hook deduplication (#15502)", () => {
     expect(beforeToolCallHook).toHaveBeenCalledTimes(1);
   });
 
+  it("passes hook context for unwrapped tool definitions", async () => {
+    const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
+    const baseTool = { name: "exec", execute, description: "exec", parameters: {} } as any;
+    const [def] = toToolDefinitions([baseTool], {
+      agentId: "code-agent",
+      sessionKey: "agent:code-agent:main",
+      sessionId: "session-code",
+      runId: "run-code",
+      channelId: "channel-code",
+    });
+    const extensionContext = {} as Parameters<typeof def.execute>[4];
+
+    await def.execute(
+      "call-code-exec",
+      { code: "echo hi" },
+      undefined,
+      undefined,
+      extensionContext,
+    );
+
+    expect(beforeToolCallHook).toHaveBeenCalledTimes(1);
+    expect(beforeToolCallHook).toHaveBeenCalledWith(
+      {
+        toolName: "exec",
+        params: { code: "echo hi" },
+        runId: "run-code",
+        toolCallId: "call-code-exec",
+      },
+      {
+        toolName: "exec",
+        agentId: "code-agent",
+        sessionKey: "agent:code-agent:main",
+        sessionId: "session-code",
+        runId: "run-code",
+        toolCallId: "call-code-exec",
+        channelId: "channel-code",
+      },
+    );
+  });
+
   it("preserves the hook marker when abort wrapping a hooked tool", () => {
     const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
     const baseTool = { name: "Bash", execute, description: "bash", parameters: {} } as any;


### PR DESCRIPTION
## Summary

- Thread hook context through Pi custom tool adaptation so top-level code-mode `exec`/`wait` dispatches keep agent/session/run/channel metadata.
- Preserve the existing wrapped-tool dedupe path while adding coverage for unwrapped tool definitions.
- Add a changelog entry for the plugin hook behavior fix.

Fixes #83387

## Verification

- `node scripts/run-vitest.mjs src/agents/pi-tools.before-tool-call.integration.e2e.test.ts src/agents/code-mode.test.ts src/agents/tool-search.test.ts src/agents/pi-embedded-runner.splitsdktools.test.ts src/agents/pi-tool-definition-adapter.after-tool-call.test.ts`
- `pnpm format:fix src/agents/pi-tool-definition-adapter.ts src/agents/pi-embedded-runner/tool-split.ts src/agents/pi-embedded-runner/run/attempt.ts src/agents/pi-embedded-runner/compact.ts src/agents/pi-tools.before-tool-call.integration.e2e.test.ts CHANGELOG.md`
- `git diff --check`
- `.agents/skills/autoreview/scripts/autoreview --mode auto`

## Real behavior proof

Behavior addressed: `before_tool_call` hooks now receive agent/session/run/channel context for top-level OpenClaw code-mode `exec`/`wait` dispatches instead of seeing an undefined `ctx.agentId`.
Real environment tested: local OpenClaw checkout on macOS with targeted Vitest coverage for the code-mode/tool-search/hook adapter path.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/pi-tools.before-tool-call.integration.e2e.test.ts src/agents/code-mode.test.ts src/agents/tool-search.test.ts src/agents/pi-embedded-runner.splitsdktools.test.ts src/agents/pi-tool-definition-adapter.after-tool-call.test.ts`
Evidence after fix: the new regression executes an unwrapped `exec` tool definition with hook context and asserts the plugin hook receives `agentId`, `sessionKey`, `sessionId`, `runId`, and `channelId`; the existing dedupe tests still prove wrapped tools fire once.
Observed result after fix: 7 test files passed, 95 tests passed; autoreview reported no accepted/actionable findings.
What was not tested: no live model/gateway run; the failing boundary is covered locally at the adapter and code-mode catalog/tool-search unit level.
