### PR TITLE
fix(code-mode): align outer exec hook params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - fix(integrations): enforce channel read target allowlists [AI]. (#84982) Thanks @pgondhi987.
+- Agents/code-mode: expose outer code-mode `exec` source through the `command` hook alias with `toolKind`/`toolInputKind` discriminators so exec-shaped policies can distinguish code-mode cells. (#83483) Thanks @Kaspre.
 - Gateway CLI: surface local post-challenge connect assembly failures immediately instead of waiting for the wrapper timeout. Fixes #68944. (#85253) Thanks @samzong.
 - Agents/exec: treat denied exec approvals as terminal instead of feeding them back into agent follow-up work, and recognize Chinese stop phrases in abort handling. Fixes #69386. (#85194) Thanks @samzong.
 - CLI/agents: abort accepted Gateway-backed `openclaw agent` runs on SIGINT/SIGTERM so cron and supervisor timeouts do not leave remote agent work alive. Fixes #71710. (#84381) Thanks @Kaspre.

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -167,6 +167,11 @@ file.
 
 - `event.toolName`
 - `event.params`
+- optional `event.toolKind` and `event.toolInputKind`, host-authoritative
+  discriminators for tools that intentionally share names; for example, outer
+  code-mode `exec` calls use `toolKind: "code_mode_exec"` and
+  include `toolInputKind: "javascript" | "typescript"` when the input language
+  is known
 - optional `event.derivedPaths`, containing best-effort host-derived target path
   hints for well-known tool envelopes such as `apply_patch`; when present,
   these paths may be incomplete or may over-approximate what the tool will
@@ -174,7 +179,8 @@ file.
 - optional `event.runId`
 - optional `event.toolCallId`
 - context fields such as `ctx.agentId`, `ctx.sessionKey`, `ctx.sessionId`,
-  `ctx.runId`, `ctx.jobId` (set on cron-driven runs), and diagnostic `ctx.trace`
+  `ctx.runId`, `ctx.jobId` (set on cron-driven runs), `ctx.toolKind`,
+  `ctx.toolInputKind`, and diagnostic `ctx.trace`
 
 It can return:
 

--- a/docs/reference/code-mode.md
+++ b/docs/reference/code-mode.md
@@ -266,14 +266,22 @@ Input:
 
 ```typescript
 type CodeModeExecInput = {
-  code: string;
+  code?: string;
+  command?: string;
   language?: "javascript" | "typescript";
 };
 ```
 
 Input rules:
 
-- `code` is required and must be non-empty.
+- One of `code` or `command` must be non-empty.
+- `code` is the documented model-facing field.
+- `command` is accepted as an exec-compatible alias for hook policies and
+  trusted rewrites; when both are present, the values must match.
+- Outer code-mode `exec` hook events include `toolKind: "code_mode_exec"` and
+  include `toolInputKind: "javascript" | "typescript"` when the input language
+  is known, so policies can distinguish code-mode cells from shell-style `exec`
+  calls that share the same tool name.
 - `language` defaults to `"javascript"`.
 - If `language` is `"typescript"`, OpenClaw transpiles before evaluation.
 - `exec` rejects `import`, `require`, dynamic import, and module-loader patterns

--- a/src/agents/code-mode-control-tools.ts
+++ b/src/agents/code-mode-control-tools.ts
@@ -1,0 +1,144 @@
+import { isPlainObject } from "../utils.js";
+import { normalizeToolName } from "./tool-policy.js";
+import type { AnyAgentTool } from "./tools/common.js";
+
+export const CODE_MODE_EXEC_TOOL_NAME = "exec";
+export const CODE_MODE_WAIT_TOOL_NAME = "wait";
+export const CODE_MODE_EXEC_TOOL_KIND = "code_mode_exec";
+
+export type CodeModeExecToolKind = typeof CODE_MODE_EXEC_TOOL_KIND;
+export type CodeModeExecToolInputKind = "javascript" | "typescript";
+export type CodeModeExecHookMetadata = {
+  toolKind: CodeModeExecToolKind;
+  toolInputKind?: CodeModeExecToolInputKind;
+};
+
+const codeModeControlTools = new WeakSet<AnyAgentTool>();
+
+export function markCodeModeControlTool<T extends AnyAgentTool>(tool: T): T {
+  codeModeControlTools.add(tool);
+  return tool;
+}
+
+export function isCodeModeControlTool(tool: AnyAgentTool): boolean {
+  return codeModeControlTools.has(tool);
+}
+
+function isCodeModeExecTool(tool: AnyAgentTool): boolean {
+  return isCodeModeControlTool(tool) && normalizeToolName(tool.name) === CODE_MODE_EXEC_TOOL_NAME;
+}
+
+function resolveCodeModeExecToolInputKind(params: unknown): CodeModeExecToolInputKind | undefined {
+  if (!isPlainObject(params)) {
+    return undefined;
+  }
+  const language = params.language;
+  if (language === undefined || language === "javascript") {
+    return "javascript";
+  }
+  if (language === "typescript") {
+    return "typescript";
+  }
+  return undefined;
+}
+
+function normalizeCodeModeExecParams(params: unknown): unknown {
+  if (!isPlainObject(params)) {
+    return params;
+  }
+  const code = params.code;
+  const command = params.command;
+  if (typeof code === "string" && typeof command !== "string") {
+    return { ...params, command: params.code };
+  }
+  if (typeof command === "string" && typeof code !== "string") {
+    return { ...params, code: params.command };
+  }
+  return params;
+}
+
+export function getCodeModeExecBeforeHookMetadata(params: {
+  tool: AnyAgentTool;
+  params: unknown;
+}): CodeModeExecHookMetadata | undefined {
+  if (!isCodeModeExecTool(params.tool)) {
+    return undefined;
+  }
+  const toolInputKind = resolveCodeModeExecToolInputKind(params.params);
+  return {
+    toolKind: CODE_MODE_EXEC_TOOL_KIND,
+    ...(toolInputKind && { toolInputKind }),
+  };
+}
+
+export function getCodeModeExecBeforeHookMetadataForToolKind(params: {
+  toolKind: unknown;
+  params: unknown;
+}): CodeModeExecHookMetadata | undefined {
+  if (params.toolKind !== CODE_MODE_EXEC_TOOL_KIND) {
+    return undefined;
+  }
+  const toolInputKind = resolveCodeModeExecToolInputKind(params.params);
+  return {
+    toolKind: CODE_MODE_EXEC_TOOL_KIND,
+    ...(toolInputKind && { toolInputKind }),
+  };
+}
+
+export function normalizeCodeModeExecBeforeHookParams(params: {
+  tool: AnyAgentTool;
+  params: unknown;
+}): unknown {
+  if (!isCodeModeExecTool(params.tool)) {
+    return params.params;
+  }
+  return normalizeCodeModeExecParams(params.params);
+}
+
+export function normalizeCodeModeExecBeforeHookParamsForToolKind(params: {
+  toolKind: unknown;
+  params: unknown;
+}): unknown {
+  if (params.toolKind !== CODE_MODE_EXEC_TOOL_KIND) {
+    return params.params;
+  }
+  return normalizeCodeModeExecParams(params.params);
+}
+
+export function reconcileCodeModeExecBeforeHookParams(params: {
+  tool: AnyAgentTool;
+  originalParams: unknown;
+  hookParams: unknown;
+  adjustedParams: unknown;
+}): unknown {
+  if (
+    !isCodeModeExecTool(params.tool) ||
+    !isPlainObject(params.originalParams) ||
+    !isPlainObject(params.hookParams) ||
+    !isPlainObject(params.adjustedParams)
+  ) {
+    return params.adjustedParams;
+  }
+  const hookCode = params.hookParams.code;
+  const hookCommand = params.hookParams.command;
+  if (typeof hookCode !== "string" || hookCode !== hookCommand) {
+    return params.adjustedParams;
+  }
+
+  const adjustedCode = params.adjustedParams.code;
+  const adjustedCommand = params.adjustedParams.command;
+  const adjustedCodeChanged = typeof adjustedCode === "string" && adjustedCode !== hookCode;
+  const adjustedCommandChanged =
+    typeof adjustedCommand === "string" && adjustedCommand !== hookCode;
+  if (adjustedCodeChanged === adjustedCommandChanged) {
+    return params.adjustedParams;
+  }
+
+  if (adjustedCodeChanged) {
+    return { ...params.adjustedParams, command: adjustedCode };
+  }
+  if (adjustedCommandChanged) {
+    return { ...params.adjustedParams, code: adjustedCommand };
+  }
+  return params.adjustedParams;
+}

--- a/src/agents/code-mode.test.ts
+++ b/src/agents/code-mode.test.ts
@@ -293,6 +293,45 @@ describe("Code Mode", () => {
     expect(compacted.catalogToolCount).toBe(1);
   });
 
+  it("accepts command as an exec-compatible code alias", async () => {
+    const { config, catalogRef, tools } = createCodeModeHarness();
+    applyCodeModeCatalog({
+      tools: [...tools, pluginTool("fake_noop", "Noop")],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+    const result = resultDetails(
+      await tools[0].execute("code-call-command-alias", {
+        command: "return 7;",
+      }),
+    );
+
+    expect(result.status).toBe("completed");
+    expect(result.value).toBe(7);
+  });
+
+  it("rejects divergent code and command aliases", async () => {
+    const { config, catalogRef, tools } = createCodeModeHarness();
+    applyCodeModeCatalog({
+      tools: [...tools, pluginTool("fake_noop", "Noop")],
+      config,
+      sessionId: "session-code-mode",
+      sessionKey: "agent:main:main",
+      runId: "run-code-mode",
+      catalogRef,
+    });
+
+    await expect(
+      tools[0].execute("code-call-divergent-alias", {
+        code: "return 1;",
+        command: "return 2;",
+      }),
+    ).rejects.toThrow("code and command must match when both are provided");
+  });
+
   it("runs JavaScript through QuickJS-WASI and resumes nested tool calls with wait", async () => {
     const { config, catalogRef, tools: codeModeTools } = createCodeModeHarness();
     const ticket = pluginTool("fake_create_ticket", "Create a fake ticket");

--- a/src/agents/code-mode.ts
+++ b/src/agents/code-mode.ts
@@ -7,6 +7,12 @@ import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveAgentConfig } from "./agent-scope-config.js";
+import {
+  CODE_MODE_EXEC_TOOL_NAME,
+  CODE_MODE_WAIT_TOOL_NAME,
+  isCodeModeControlTool,
+  markCodeModeControlTool,
+} from "./code-mode-control-tools.js";
 import type { HookContext } from "./pi-tools.before-tool-call.js";
 import { optionalStringEnum } from "./schema/typebox.js";
 import {
@@ -27,11 +33,11 @@ import {
   ToolInputError,
   type AnyAgentTool,
 } from "./tools/common.js";
-
-export const CODE_MODE_EXEC_TOOL_NAME = "exec";
-export const CODE_MODE_WAIT_TOOL_NAME = "wait";
-
-const codeModeControlTools = new WeakSet<AnyAgentTool>();
+export {
+  CODE_MODE_EXEC_TOOL_NAME,
+  CODE_MODE_WAIT_TOOL_NAME,
+  isCodeModeControlTool,
+} from "./code-mode-control-tools.js";
 
 const DEFAULT_TIMEOUT_MS = 10_000;
 const DEFAULT_MEMORY_LIMIT_BYTES = 64 * 1024 * 1024;
@@ -222,15 +228,6 @@ function toToolSearchConfig(config: CodeModeConfig): ToolSearchConfig {
   };
 }
 
-export function isCodeModeControlTool(tool: AnyAgentTool): boolean {
-  return codeModeControlTools.has(tool);
-}
-
-function markCodeModeControlTool<T extends AnyAgentTool>(tool: T): T {
-  codeModeControlTools.add(tool);
-  return tool;
-}
-
 function removeExpiredRuns(now = Date.now()): void {
   for (const [runId, state] of activeRuns) {
     if (state.expiresAt <= now) {
@@ -298,9 +295,18 @@ function enforceResultLimit(params: {
 
 function readCode(args: unknown): { code: string; language?: CodeModeLanguage } {
   const params = asToolParamsRecord(args);
-  const code = params.code;
+  const codeParam = params.code;
+  const commandParam = params.command;
+  if (
+    typeof codeParam === "string" &&
+    typeof commandParam === "string" &&
+    codeParam !== commandParam
+  ) {
+    throw new ToolInputError("code and command must match when both are provided.");
+  }
+  const code = typeof commandParam === "string" ? commandParam : codeParam;
   if (typeof code !== "string" || !code.trim()) {
-    throw new ToolInputError("code must be a non-empty string.");
+    throw new ToolInputError("code or command must be a non-empty string.");
   }
   const language = params.language;
   if (language !== undefined && language !== "javascript" && language !== "typescript") {
@@ -828,10 +834,17 @@ export function createCodeModeTools(ctx: CodeModeToolContext): AnyAgentTool[] {
     description:
       'Run JavaScript or TypeScript in OpenClaw code mode. Node.js modules and `require`/`import` are NOT available; for any shell, file, network, or external action, use enabled catalog tools allowed by policy from inside your code: `tools.search(query)` to find catalog entries, `tools.describe(entry.id)` for the input schema, then `tools.call(entry.id, args)`. The `language` field accepts only "javascript" or "typescript"; do not pass "bash", "shell", or other values.',
     parameters: Type.Object({
-      code: Type.String({
-        description:
-          "JavaScript or TypeScript source to run. The `tools` object (search/describe/call) and `ALL_TOOLS` are available in scope; Node built-in modules are not.",
-      }),
+      code: Type.Optional(
+        Type.String({
+          description:
+            "JavaScript or TypeScript source to run. The `tools` object (search/describe/call) and `ALL_TOOLS` are available in scope; Node built-in modules are not.",
+        }),
+      ),
+      command: Type.Optional(
+        Type.String({
+          description: "Alias for code, provided for exec-compatible hook policies.",
+        }),
+      ),
       language: optionalStringEnum(["javascript", "typescript"] as const, {
         description:
           'Source language. Must be "javascript" or "typescript". Defaults to javascript.',

--- a/src/agents/pi-tool-definition-adapter.after-tool-call.fires-once.test.ts
+++ b/src/agents/pi-tool-definition-adapter.after-tool-call.fires-once.test.ts
@@ -30,6 +30,7 @@ const beforeToolCallMocks = vi.hoisted(() => ({
     }
   },
   consumeAdjustedParamsForToolCall: vi.fn((_: string): unknown => undefined),
+  recordAdjustedParamsForToolCall: vi.fn(),
   isToolWrappedWithBeforeToolCallHook: vi.fn(() => false),
   runBeforeToolCallHook: vi.fn(async ({ params }: { params: unknown }) => ({
     blocked: false,
@@ -103,6 +104,7 @@ async function loadFreshAfterToolCallModulesForTest() {
       details: { status: "blocked", deniedReason: "plugin-before-tool-call", reason },
     }),
     consumeAdjustedParamsForToolCall: beforeToolCallMocks.consumeAdjustedParamsForToolCall,
+    recordAdjustedParamsForToolCall: beforeToolCallMocks.recordAdjustedParamsForToolCall,
     isBeforeToolCallBlockedError: (error: unknown) =>
       error instanceof beforeToolCallMocks.BeforeToolCallBlockedError,
     isToolWrappedWithBeforeToolCallHook: beforeToolCallMocks.isToolWrappedWithBeforeToolCallHook,
@@ -125,6 +127,7 @@ describe("after_tool_call fires exactly once in embedded runs", () => {
     hookMocks.runner.runBeforeToolCall.mockResolvedValue(undefined);
     beforeToolCallMocks.consumeAdjustedParamsForToolCall.mockClear();
     beforeToolCallMocks.consumeAdjustedParamsForToolCall.mockReturnValue(undefined);
+    beforeToolCallMocks.recordAdjustedParamsForToolCall.mockClear();
     beforeToolCallMocks.isToolWrappedWithBeforeToolCallHook.mockClear();
     beforeToolCallMocks.isToolWrappedWithBeforeToolCallHook.mockReturnValue(false);
     beforeToolCallMocks.runBeforeToolCallHook.mockClear();

--- a/src/agents/pi-tool-definition-adapter.after-tool-call.test.ts
+++ b/src/agents/pi-tool-definition-adapter.after-tool-call.test.ts
@@ -19,6 +19,7 @@ const hookMocks = vi.hoisted(() => ({
   },
   isToolWrappedWithBeforeToolCallHook: vi.fn(() => false),
   consumeAdjustedParamsForToolCall: vi.fn((_: string) => undefined as unknown),
+  recordAdjustedParamsForToolCall: vi.fn(),
   runBeforeToolCallHook: vi.fn(async ({ params }: { params: unknown }) => ({
     blocked: false,
     params,
@@ -36,6 +37,7 @@ vi.mock("./pi-tools.before-tool-call.js", () => ({
     details: { status: "blocked", deniedReason: "plugin-before-tool-call", reason },
   }),
   consumeAdjustedParamsForToolCall: hookMocks.consumeAdjustedParamsForToolCall,
+  recordAdjustedParamsForToolCall: hookMocks.recordAdjustedParamsForToolCall,
   isBeforeToolCallBlockedError: (error: unknown) =>
     error instanceof hookMocks.BeforeToolCallBlockedError,
   isToolWrappedWithBeforeToolCallHook: hookMocks.isToolWrappedWithBeforeToolCallHook,
@@ -64,6 +66,7 @@ describe("pi tool definition adapter after_tool_call", () => {
     hookMocks.isToolWrappedWithBeforeToolCallHook.mockReturnValue(false);
     hookMocks.consumeAdjustedParamsForToolCall.mockClear();
     hookMocks.consumeAdjustedParamsForToolCall.mockReturnValue(undefined);
+    hookMocks.recordAdjustedParamsForToolCall.mockClear();
     hookMocks.runBeforeToolCallHook.mockClear();
     hookMocks.runBeforeToolCallHook.mockImplementation(async ({ params }) => ({
       blocked: false,

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -8,6 +8,11 @@ import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { logDebug, logError } from "../logger.js";
 import { redactToolDetail } from "../logging/redact.js";
 import { isPlainObject } from "../utils.js";
+import {
+  getCodeModeExecBeforeHookMetadata,
+  normalizeCodeModeExecBeforeHookParams,
+  reconcileCodeModeExecBeforeHookParams,
+} from "./code-mode-control-tools.js";
 import { sanitizeForConsole } from "./console-sanitize.js";
 import type { ClientToolDefinition } from "./pi-embedded-runner/run/params.js";
 import type { HookContext } from "./pi-tools.before-tool-call.js";
@@ -15,6 +20,7 @@ import {
   buildBlockedToolResult,
   isToolWrappedWithBeforeToolCallHook,
   isBeforeToolCallBlockedError,
+  recordAdjustedParamsForToolCall,
   runBeforeToolCallHook,
 } from "./pi-tools.before-tool-call.js";
 import { normalizeToolName } from "./tool-policy.js";
@@ -329,9 +335,12 @@ export function toToolDefinitions(
         let executeParams = params;
         try {
           if (!beforeHookWrapped) {
+            const hookParams = normalizeCodeModeExecBeforeHookParams({ tool, params });
+            const hookMetadata = getCodeModeExecBeforeHookMetadata({ tool, params });
             const hookOutcome = await runBeforeToolCallHook({
               toolName: name,
-              params,
+              params: hookParams,
+              ...hookMetadata,
               toolCallId,
               ctx: hookContext,
             });
@@ -344,7 +353,13 @@ export function toToolDefinitions(
               }
               throw new Error(hookOutcome.reason);
             }
-            executeParams = hookOutcome.params;
+            executeParams = reconcileCodeModeExecBeforeHookParams({
+              tool,
+              originalParams: params,
+              hookParams,
+              adjustedParams: hookOutcome.params,
+            });
+            recordAdjustedParamsForToolCall(toolCallId, executeParams, hookContext?.runId);
           }
           const rawResult = await tool.execute(toolCallId, executeParams, signal, onUpdate);
           const result = normalizeToolExecutionResult({

--- a/src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
+++ b/src/agents/pi-tools.before-tool-call.integration.e2e.test.ts
@@ -13,6 +13,9 @@ import { patchPluginSessionExtension } from "../plugins/host-hook-state.js";
 import { createEmptyPluginRegistry } from "../plugins/registry.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import type { PluginHookRegistration } from "../plugins/types.js";
+import { markCodeModeControlTool } from "./code-mode-control-tools.js";
+import { CODE_MODE_EXEC_TOOL_NAME, createCodeModeTools } from "./code-mode.js";
+import { splitSdkTools } from "./pi-embedded-runner.js";
 import { toClientToolDefinitions, toToolDefinitions } from "./pi-tool-definition-adapter.js";
 import { wrapToolWithAbortSignal } from "./pi-tools.abort.js";
 import {
@@ -287,6 +290,624 @@ describe("before_tool_call hook deduplication (#15502)", () => {
     );
 
     expect(beforeToolCallHook).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes agent context to outer code-mode exec hooks through Pi custom tools", async () => {
+    beforeToolCallHook = installBeforeToolCallHook({
+      runBeforeToolCallImpl: async () => ({
+        block: true,
+        blockReason: "blocked before code-mode execution",
+      }),
+    });
+    const abortController = new AbortController();
+    const codeModeTools = createCodeModeTools({
+      agentId: "main",
+      sessionKey: "agent:main:main",
+      sessionId: "session-main",
+      runId: "run-main",
+      abortSignal: abortController.signal,
+      executeTool: async () => {
+        throw new Error("catalog tool execution should not be reached");
+      },
+    });
+    const execTool = codeModeTools.find((tool) => tool.name === CODE_MODE_EXEC_TOOL_NAME);
+    if (!execTool) {
+      throw new Error("missing code-mode exec tool");
+    }
+    const { customTools } = splitSdkTools({
+      tools: [execTool],
+      sandboxEnabled: false,
+      toolHookContext: {
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        sessionId: "session-main",
+        runId: "run-main",
+      },
+    });
+    const [def] = customTools;
+    if (!def) {
+      throw new Error("missing custom tool definition");
+    }
+    const extensionContext = {} as Parameters<typeof def.execute>[4];
+
+    const result = await def.execute(
+      "call-code-mode-exec",
+      { code: "return 1;" },
+      undefined,
+      undefined,
+      extensionContext,
+    );
+
+    expect(result.details).toMatchObject({
+      status: "blocked",
+      reason: "blocked before code-mode execution",
+    });
+    expect(beforeToolCallHook).toHaveBeenCalledWith(
+      {
+        toolName: "exec",
+        params: { code: "return 1;", command: "return 1;" },
+        toolKind: "code_mode_exec",
+        toolInputKind: "javascript",
+        runId: "run-main",
+        toolCallId: "call-code-mode-exec",
+      },
+      {
+        toolName: "exec",
+        toolKind: "code_mode_exec",
+        toolInputKind: "javascript",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        sessionId: "session-main",
+        runId: "run-main",
+        toolCallId: "call-code-mode-exec",
+      },
+    );
+
+    beforeToolCallHook.mockClear();
+    const commandOnlyResult = await def.execute(
+      "call-code-mode-exec-command",
+      { command: "return 2;" },
+      undefined,
+      undefined,
+      extensionContext,
+    );
+
+    expect(commandOnlyResult.details).toMatchObject({
+      status: "blocked",
+      reason: "blocked before code-mode execution",
+    });
+    expect(beforeToolCallHook).toHaveBeenCalledWith(
+      {
+        toolName: "exec",
+        params: { code: "return 2;", command: "return 2;" },
+        toolKind: "code_mode_exec",
+        toolInputKind: "javascript",
+        runId: "run-main",
+        toolCallId: "call-code-mode-exec-command",
+      },
+      {
+        toolName: "exec",
+        toolKind: "code_mode_exec",
+        toolInputKind: "javascript",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        sessionId: "session-main",
+        runId: "run-main",
+        toolCallId: "call-code-mode-exec-command",
+      },
+    );
+
+    beforeToolCallHook.mockClear();
+    const typescriptResult = await def.execute(
+      "call-code-mode-exec-typescript",
+      {
+        code: "const value: number = 5;",
+        language: "typescript",
+      },
+      undefined,
+      undefined,
+      extensionContext,
+    );
+
+    expect(typescriptResult.details).toMatchObject({
+      status: "blocked",
+      reason: "blocked before code-mode execution",
+    });
+    expect(beforeToolCallHook).toHaveBeenCalledWith(
+      {
+        toolName: "exec",
+        params: {
+          code: "const value: number = 5;",
+          command: "const value: number = 5;",
+          language: "typescript",
+        },
+        toolKind: "code_mode_exec",
+        toolInputKind: "typescript",
+        runId: "run-main",
+        toolCallId: "call-code-mode-exec-typescript",
+      },
+      {
+        toolName: "exec",
+        toolKind: "code_mode_exec",
+        toolInputKind: "typescript",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        sessionId: "session-main",
+        runId: "run-main",
+        toolCallId: "call-code-mode-exec-typescript",
+      },
+    );
+
+    beforeToolCallHook.mockClear();
+    const malformedAliasResult = await def.execute(
+      "call-code-mode-exec-null-command",
+      { code: "return 4;", command: null },
+      undefined,
+      undefined,
+      extensionContext,
+    );
+
+    expect(malformedAliasResult.details).toMatchObject({
+      status: "blocked",
+      reason: "blocked before code-mode execution",
+    });
+    expect(beforeToolCallHook).toHaveBeenCalledWith(
+      {
+        toolName: "exec",
+        params: { code: "return 4;", command: "return 4;" },
+        toolKind: "code_mode_exec",
+        toolInputKind: "javascript",
+        runId: "run-main",
+        toolCallId: "call-code-mode-exec-null-command",
+      },
+      {
+        toolName: "exec",
+        toolKind: "code_mode_exec",
+        toolInputKind: "javascript",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        sessionId: "session-main",
+        runId: "run-main",
+        toolCallId: "call-code-mode-exec-null-command",
+      },
+    );
+  });
+
+  it("marks code-mode exec without marking plain exec hooks", async () => {
+    const observed: Array<{
+      event: Record<string, unknown>;
+      ctx: Record<string, unknown>;
+    }> = [];
+    beforeToolCallHook = installBeforeToolCallHook({
+      runBeforeToolCallImpl: async (event, ctx) => {
+        observed.push({
+          event: event as Record<string, unknown>,
+          ctx: ctx as Record<string, unknown>,
+        });
+        if ((event as Record<string, unknown>).toolKind === "code_mode_exec") {
+          return { block: true, blockReason: "blocked before code-mode execution" };
+        }
+        return { params: (event as { params: Record<string, unknown> }).params };
+      },
+    });
+    const plainExecute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
+    const [plainExecDef] = toToolDefinitions(
+      [{ name: "exec", execute: plainExecute, description: "Plain exec", parameters: {} } as any],
+      {
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        sessionId: "session-main",
+        runId: "run-main",
+      },
+    );
+    const codeModeTools = createCodeModeTools({
+      agentId: "main",
+      sessionKey: "agent:main:main",
+      sessionId: "session-main",
+      runId: "run-main",
+      abortSignal: new AbortController().signal,
+      executeTool: async () => {
+        throw new Error("catalog tool execution should not be reached");
+      },
+    });
+    const codeModeExec = codeModeTools.find((tool) => tool.name === CODE_MODE_EXEC_TOOL_NAME);
+    if (!plainExecDef || !codeModeExec) {
+      throw new Error("missing exec definitions");
+    }
+    const [codeModeExecDef] = toToolDefinitions([codeModeExec], {
+      agentId: "main",
+      sessionKey: "agent:main:main",
+      sessionId: "session-main",
+      runId: "run-main",
+    });
+    if (!codeModeExecDef) {
+      throw new Error("missing code-mode exec definition");
+    }
+    const extensionContext = {} as Parameters<typeof plainExecDef.execute>[4];
+
+    await plainExecDef.execute(
+      "call-plain-exec",
+      { command: "echo hi" },
+      undefined,
+      undefined,
+      extensionContext,
+    );
+    const codeModeResult = await codeModeExecDef.execute(
+      "call-code-mode-exec",
+      { code: "return 1;" },
+      undefined,
+      undefined,
+      extensionContext,
+    );
+
+    expect(plainExecute).toHaveBeenCalledWith(
+      "call-plain-exec",
+      { command: "echo hi" },
+      undefined,
+      undefined,
+    );
+    expect(codeModeResult.details).toMatchObject({
+      status: "blocked",
+      reason: "blocked before code-mode execution",
+    });
+    expect(observed[0]?.event).toMatchObject({
+      toolName: "exec",
+      params: { command: "echo hi" },
+    });
+    expect(observed[0]?.event).not.toHaveProperty("toolKind");
+    expect(observed[1]?.event).toMatchObject({
+      toolName: "exec",
+      params: { code: "return 1;", command: "return 1;" },
+      toolKind: "code_mode_exec",
+      toolInputKind: "javascript",
+    });
+    expect(observed[1]?.ctx).toMatchObject({
+      toolName: "exec",
+      toolKind: "code_mode_exec",
+      toolInputKind: "javascript",
+    });
+  });
+
+  it("normalizes outer code-mode exec hook params when a wrapper owns the hook", async () => {
+    beforeToolCallHook = installBeforeToolCallHook({
+      runBeforeToolCallImpl: async () => ({
+        block: true,
+        blockReason: "blocked before code-mode execution",
+      }),
+    });
+    const codeModeTools = createCodeModeTools({
+      agentId: "main",
+      sessionKey: "agent:main:main",
+      sessionId: "session-main",
+      runId: "run-main",
+      abortSignal: new AbortController().signal,
+      executeTool: async () => {
+        throw new Error("catalog tool execution should not be reached");
+      },
+    });
+    const execTool = codeModeTools.find((tool) => tool.name === CODE_MODE_EXEC_TOOL_NAME);
+    if (!execTool) {
+      throw new Error("missing code-mode exec tool");
+    }
+    const wrapped = wrapToolWithAbortSignal(
+      wrapToolWithBeforeToolCallHook(execTool, {
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        sessionId: "session-main",
+        runId: "run-main",
+      }),
+      new AbortController().signal,
+    );
+    const [def] = toToolDefinitions([wrapped]);
+    if (!def) {
+      throw new Error("missing custom tool definition");
+    }
+    const extensionContext = {} as Parameters<typeof def.execute>[4];
+
+    const result = await def.execute(
+      "call-wrapped-code-mode-exec",
+      { command: "return 3;" },
+      undefined,
+      undefined,
+      extensionContext,
+    );
+
+    expect(result.details).toMatchObject({
+      status: "blocked",
+      reason: "blocked before code-mode execution",
+    });
+    expect(beforeToolCallHook).toHaveBeenCalledTimes(1);
+    expect(beforeToolCallHook).toHaveBeenCalledWith(
+      {
+        toolName: "exec",
+        params: { command: "return 3;", code: "return 3;" },
+        toolKind: "code_mode_exec",
+        toolInputKind: "javascript",
+        runId: "run-main",
+        toolCallId: "call-wrapped-code-mode-exec",
+      },
+      {
+        toolName: "exec",
+        toolKind: "code_mode_exec",
+        toolInputKind: "javascript",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        sessionId: "session-main",
+        runId: "run-main",
+        toolCallId: "call-wrapped-code-mode-exec",
+      },
+    );
+  });
+
+  it("mirrors single-alias hook rewrites for code-mode exec aliases", async () => {
+    beforeToolCallHook = installBeforeToolCallHook({
+      runBeforeToolCallImpl: async () => ({ params: { command: "return 2;" } }),
+    });
+    const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
+    const tool = markCodeModeControlTool({
+      name: CODE_MODE_EXEC_TOOL_NAME,
+      execute,
+      description: "exec",
+      parameters: {},
+    } as any);
+    const [def] = toToolDefinitions([tool], {
+      agentId: "main",
+      sessionKey: "agent:main:main",
+      sessionId: "session-main",
+      runId: "run-main",
+    });
+    if (!def) {
+      throw new Error("missing custom tool definition");
+    }
+    const extensionContext = {} as Parameters<typeof def.execute>[4];
+
+    await def.execute(
+      "call-code-mode-exec-rewrite",
+      { code: "return 1;", command: "return 1;" },
+      undefined,
+      undefined,
+      extensionContext,
+    );
+
+    expect(execute).toHaveBeenCalledWith(
+      "call-code-mode-exec-rewrite",
+      { code: "return 2;", command: "return 2;" },
+      undefined,
+      undefined,
+    );
+    expect(beforeToolCallHook).toHaveBeenCalledWith(
+      {
+        toolName: "exec",
+        params: { code: "return 1;", command: "return 1;" },
+        toolKind: "code_mode_exec",
+        toolInputKind: "javascript",
+        runId: "run-main",
+        toolCallId: "call-code-mode-exec-rewrite",
+      },
+      {
+        toolName: "exec",
+        toolKind: "code_mode_exec",
+        toolInputKind: "javascript",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        sessionId: "session-main",
+        runId: "run-main",
+        toolCallId: "call-code-mode-exec-rewrite",
+      },
+    );
+    expect(consumeAdjustedParamsForToolCall("call-code-mode-exec-rewrite", "run-main")).toEqual({
+      code: "return 2;",
+      command: "return 2;",
+    });
+  });
+
+  it("renormalizes trusted policy rewrites before code-mode exec hooks observe params", async () => {
+    resetGlobalHookRunner();
+    const normalHook = vi.fn(async () => undefined);
+    const trustedObserver = vi.fn(async () => undefined);
+    const registry = createEmptyPluginRegistry();
+    addTestHook({
+      registry,
+      pluginId: "normal-plugin",
+      hookName: "before_tool_call",
+      handler: normalHook as PluginHookRegistration["handler"],
+    });
+    registry.trustedToolPolicies = [
+      {
+        pluginId: "trusted-plugin",
+        pluginName: "Trusted Plugin",
+        source: "test",
+        policy: {
+          id: "code-mode-rewrite-policy",
+          description: "rewrite code-mode exec params",
+          evaluate(eventValue) {
+            if (eventValue.toolCallId === "call-code-mode-trusted-command") {
+              return { params: { command: "return 2;" } };
+            }
+            if (eventValue.toolCallId === "call-code-mode-trusted-language") {
+              return {
+                params: {
+                  code: "const value: number = 3;",
+                  command: "const value: number = 3;",
+                  language: "typescript",
+                },
+              };
+            }
+            return undefined;
+          },
+        },
+      },
+      {
+        pluginId: "trusted-observer",
+        pluginName: "Trusted Observer",
+        source: "test",
+        policy: {
+          id: "code-mode-observer-policy",
+          description: "observe rewritten code-mode exec params",
+          evaluate: trustedObserver,
+        },
+      },
+    ];
+    setActivePluginRegistry(registry);
+    initializeGlobalHookRunner(registry);
+    try {
+      const execute = vi.fn().mockResolvedValue({ content: [], details: { ok: true } });
+      const tool = markCodeModeControlTool({
+        name: CODE_MODE_EXEC_TOOL_NAME,
+        execute,
+        description: "exec",
+        parameters: {},
+      } as any);
+      const [def] = toToolDefinitions([tool], {
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        sessionId: "session-main",
+        runId: "run-main",
+      });
+      if (!def) {
+        throw new Error("missing custom tool definition");
+      }
+      const extensionContext = {} as Parameters<typeof def.execute>[4];
+
+      await def.execute(
+        "call-code-mode-trusted-command",
+        { code: "return 1;", command: "return 1;" },
+        undefined,
+        undefined,
+        extensionContext,
+      );
+      await def.execute(
+        "call-code-mode-trusted-language",
+        { code: "return 3;", command: "return 3;", language: "javascript" },
+        undefined,
+        undefined,
+        extensionContext,
+      );
+
+      expect(normalHook).toHaveBeenNthCalledWith(
+        1,
+        {
+          toolName: "exec",
+          params: { command: "return 2;", code: "return 2;" },
+          toolKind: "code_mode_exec",
+          toolInputKind: "javascript",
+          runId: "run-main",
+          toolCallId: "call-code-mode-trusted-command",
+        },
+        expect.objectContaining({
+          toolName: "exec",
+          toolKind: "code_mode_exec",
+          toolInputKind: "javascript",
+          agentId: "main",
+          sessionKey: "agent:main:main",
+          sessionId: "session-main",
+          runId: "run-main",
+          toolCallId: "call-code-mode-trusted-command",
+        }),
+      );
+      expect(trustedObserver).toHaveBeenNthCalledWith(
+        1,
+        {
+          toolName: "exec",
+          params: { command: "return 2;", code: "return 2;" },
+          toolKind: "code_mode_exec",
+          toolInputKind: "javascript",
+          runId: "run-main",
+          toolCallId: "call-code-mode-trusted-command",
+        },
+        expect.objectContaining({
+          toolName: "exec",
+          toolKind: "code_mode_exec",
+          toolInputKind: "javascript",
+          agentId: "main",
+          sessionKey: "agent:main:main",
+          sessionId: "session-main",
+          runId: "run-main",
+          toolCallId: "call-code-mode-trusted-command",
+        }),
+      );
+      expect(normalHook).toHaveBeenNthCalledWith(
+        2,
+        {
+          toolName: "exec",
+          params: {
+            code: "const value: number = 3;",
+            command: "const value: number = 3;",
+            language: "typescript",
+          },
+          toolKind: "code_mode_exec",
+          toolInputKind: "typescript",
+          runId: "run-main",
+          toolCallId: "call-code-mode-trusted-language",
+        },
+        expect.objectContaining({
+          toolName: "exec",
+          toolKind: "code_mode_exec",
+          toolInputKind: "typescript",
+          agentId: "main",
+          sessionKey: "agent:main:main",
+          sessionId: "session-main",
+          runId: "run-main",
+          toolCallId: "call-code-mode-trusted-language",
+        }),
+      );
+      expect(trustedObserver).toHaveBeenNthCalledWith(
+        2,
+        {
+          toolName: "exec",
+          params: {
+            code: "const value: number = 3;",
+            command: "const value: number = 3;",
+            language: "typescript",
+          },
+          toolKind: "code_mode_exec",
+          toolInputKind: "typescript",
+          runId: "run-main",
+          toolCallId: "call-code-mode-trusted-language",
+        },
+        expect.objectContaining({
+          toolName: "exec",
+          toolKind: "code_mode_exec",
+          toolInputKind: "typescript",
+          agentId: "main",
+          sessionKey: "agent:main:main",
+          sessionId: "session-main",
+          runId: "run-main",
+          toolCallId: "call-code-mode-trusted-language",
+        }),
+      );
+      expect(execute).toHaveBeenNthCalledWith(
+        1,
+        "call-code-mode-trusted-command",
+        { command: "return 2;", code: "return 2;" },
+        undefined,
+        undefined,
+      );
+      expect(execute).toHaveBeenNthCalledWith(
+        2,
+        "call-code-mode-trusted-language",
+        {
+          code: "const value: number = 3;",
+          command: "const value: number = 3;",
+          language: "typescript",
+        },
+        undefined,
+        undefined,
+      );
+      expect(
+        consumeAdjustedParamsForToolCall("call-code-mode-trusted-command", "run-main"),
+      ).toEqual({ command: "return 2;", code: "return 2;" });
+      expect(
+        consumeAdjustedParamsForToolCall("call-code-mode-trusted-language", "run-main"),
+      ).toEqual({
+        code: "const value: number = 3;",
+        command: "const value: number = 3;",
+        language: "typescript",
+      });
+    } finally {
+      setActivePluginRegistry(createEmptyPluginRegistry());
+      resetGlobalHookRunner();
+    }
   });
 
   it("fires hook exactly once when tool goes through wrap + abort + toToolDefinitions", async () => {

--- a/src/agents/pi-tools.before-tool-call.ts
+++ b/src/agents/pi-tools.before-tool-call.ts
@@ -23,10 +23,19 @@ import {
   PluginApprovalResolutions,
   type PluginApprovalResolution,
   type PluginHookBeforeToolCallResult,
+  type PluginHookToolInputKind,
+  type PluginHookToolKind,
 } from "../plugins/types.js";
 import { createLazyRuntimeSurface } from "../shared/lazy-runtime.js";
 import { isPlainObject } from "../utils.js";
 import { copyChannelAgentToolMeta } from "./channel-tools.js";
+import {
+  getCodeModeExecBeforeHookMetadata,
+  getCodeModeExecBeforeHookMetadataForToolKind,
+  normalizeCodeModeExecBeforeHookParams,
+  normalizeCodeModeExecBeforeHookParamsForToolKind,
+  reconcileCodeModeExecBeforeHookParams,
+} from "./code-mode-control-tools.js";
 import { adjustedParamsByToolCallId } from "./pi-tools.before-tool-call.state.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 import { normalizeToolName } from "./tool-policy.js";
@@ -103,6 +112,24 @@ export class BeforeToolCallBlockedError extends Error {
   constructor(readonly reason: string) {
     super(reason);
     this.name = "BeforeToolCallBlockedError";
+  }
+}
+
+export function recordAdjustedParamsForToolCall(
+  toolCallId: string | undefined,
+  params: unknown,
+  runId?: string,
+): void {
+  if (!toolCallId) {
+    return;
+  }
+  const adjustedParamsKey = buildAdjustedParamsKey({ runId, toolCallId });
+  adjustedParamsByToolCallId.set(adjustedParamsKey, params);
+  if (adjustedParamsByToolCallId.size > MAX_TRACKED_ADJUSTED_PARAMS) {
+    const oldest = adjustedParamsByToolCallId.keys().next().value;
+    if (oldest) {
+      adjustedParamsByToolCallId.delete(oldest);
+    }
   }
 }
 
@@ -430,6 +457,8 @@ async function recordLoopOutcome(args: {
 export async function runBeforeToolCallHook(args: {
   toolName: string;
   params: unknown;
+  toolKind?: PluginHookToolKind;
+  toolInputKind?: PluginHookToolInputKind;
   toolCallId?: string;
   ctx?: HookContext;
   signal?: AbortSignal;
@@ -527,8 +556,13 @@ export async function runBeforeToolCallHook(args: {
       const derived = deriveToolParams(toolName, candidateParams, deriveOptions);
       return derived.derivedPaths ? { derivedPaths: derived.derivedPaths } : {};
     };
-    const toolContext = {
+    const toolIdentity = {
+      ...(args.toolKind && { toolKind: args.toolKind }),
+      ...(args.toolInputKind && { toolInputKind: args.toolInputKind }),
+    };
+    const buildToolContext = (identity: typeof toolIdentity) => ({
       toolName,
+      ...identity,
       ...(args.ctx?.agentId && { agentId: args.ctx.agentId }),
       ...(args.ctx?.sessionKey && { sessionKey: args.ctx.sessionKey }),
       ...(args.ctx?.sessionId && { sessionId: args.ctx.sessionId }),
@@ -536,12 +570,14 @@ export async function runBeforeToolCallHook(args: {
       ...(args.ctx?.trace && { trace: freezeDiagnosticTraceContext(args.ctx.trace) }),
       ...(args.toolCallId && { toolCallId: args.toolCallId }),
       ...(args.ctx?.channelId && { channelId: args.ctx.channelId }),
-    };
+    });
+    const toolContext = buildToolContext(toolIdentity);
     const trustedPolicyResult = shouldRunTrustedPolicies
       ? await runTrustedToolPolicies(
           {
             toolName,
             params: normalizedParams,
+            ...toolIdentity,
             ...(args.ctx?.runId && { runId: args.ctx.runId }),
             ...(args.toolCallId && { toolCallId: args.toolCallId }),
             ...(derivedToolParams.derivedPaths
@@ -552,6 +588,25 @@ export async function runBeforeToolCallHook(args: {
           {
             ...(args.ctx?.config ? { config: args.ctx.config } : {}),
             deriveEvent: deriveToolEventParams,
+            normalizeEvent(eventValue) {
+              const normalizedEventParams = normalizeCodeModeExecBeforeHookParamsForToolKind({
+                toolKind: eventValue.toolKind,
+                params: eventValue.params,
+              });
+              if (!isPlainObject(normalizedEventParams)) {
+                return undefined;
+              }
+              const normalizedEventIdentity = getCodeModeExecBeforeHookMetadataForToolKind({
+                toolKind: eventValue.toolKind,
+                params: normalizedEventParams,
+              });
+              return {
+                params: normalizedEventParams,
+                ...(normalizedEventIdentity
+                  ? { event: normalizedEventIdentity, ctx: normalizedEventIdentity }
+                  : {}),
+              };
+            },
           },
         )
       : undefined;
@@ -587,7 +642,17 @@ export async function runBeforeToolCallHook(args: {
         overrideParams: trustedPolicyResult.params,
       });
     }
-    const policyAdjustedParams = trustedPolicyResult?.params ?? params;
+    const rawPolicyAdjustedParams = trustedPolicyResult?.params ?? params;
+    const policyAdjustedParams = normalizeCodeModeExecBeforeHookParamsForToolKind({
+      toolKind: args.toolKind,
+      params: rawPolicyAdjustedParams,
+    });
+    const policyAdjustedToolIdentity =
+      getCodeModeExecBeforeHookMetadataForToolKind({
+        toolKind: args.toolKind,
+        params: policyAdjustedParams,
+      }) ?? toolIdentity;
+    const policyAdjustedToolContext = buildToolContext(policyAdjustedToolIdentity);
     const policyAdjustedDerivedToolParams =
       trustedPolicyResult?.params && isPlainObject(policyAdjustedParams)
         ? deriveToolParams(toolName, policyAdjustedParams, deriveOptions)
@@ -600,13 +665,14 @@ export async function runBeforeToolCallHook(args: {
       {
         toolName,
         params: hookEventParams,
+        ...policyAdjustedToolIdentity,
         ...(args.ctx?.runId && { runId: args.ctx.runId }),
         ...(args.toolCallId && { toolCallId: args.toolCallId }),
         ...(policyAdjustedDerivedToolParams.derivedPaths
           ? { derivedPaths: policyAdjustedDerivedToolParams.derivedPaths }
           : {}),
       },
-      toolContext,
+      policyAdjustedToolContext,
     );
 
     if (hookResult?.block) {
@@ -678,9 +744,12 @@ export function wrapToolWithBeforeToolCallHook(
   const wrappedTool: AnyAgentTool = {
     ...tool,
     execute: async (toolCallId, params, signal, onUpdate) => {
+      const hookParams = normalizeCodeModeExecBeforeHookParams({ tool, params });
+      const hookMetadata = getCodeModeExecBeforeHookMetadata({ tool, params });
       const outcome = await runBeforeToolCallHook({
         toolName,
-        params,
+        params: hookParams,
+        ...hookMetadata,
         toolCallId,
         ctx,
         signal,
@@ -700,7 +769,7 @@ export function wrapToolWithBeforeToolCallHook(
           ...(trace && { trace }),
           toolName: normalizedToolName,
           ...(toolCallId && { toolCallId }),
-          paramsSummary: summarizeToolParams(outcome.params ?? params),
+          paramsSummary: summarizeToolParams(outcome.params ?? hookParams),
         };
         if (diagnosticOptions.emitDiagnostics) {
           emitTrustedDiagnosticEvent({
@@ -717,22 +786,19 @@ export function wrapToolWithBeforeToolCallHook(
         await recordLoopOutcome({
           ctx,
           toolName: normalizedToolName,
-          toolParams: outcome.params ?? params,
+          toolParams: outcome.params ?? hookParams,
           toolCallId,
           result: blockedResult,
         });
         return blockedResult;
       }
-      if (toolCallId) {
-        const adjustedParamsKey = buildAdjustedParamsKey({ runId: ctx?.runId, toolCallId });
-        adjustedParamsByToolCallId.set(adjustedParamsKey, outcome.params);
-        if (adjustedParamsByToolCallId.size > MAX_TRACKED_ADJUSTED_PARAMS) {
-          const oldest = adjustedParamsByToolCallId.keys().next().value;
-          if (oldest) {
-            adjustedParamsByToolCallId.delete(oldest);
-          }
-        }
-      }
+      const executeParams = reconcileCodeModeExecBeforeHookParams({
+        tool,
+        originalParams: params,
+        hookParams,
+        adjustedParams: outcome.params,
+      });
+      recordAdjustedParamsForToolCall(toolCallId, executeParams, ctx?.runId);
       const normalizedToolName = normalizeToolName(toolName || "tool");
       const trace = ctx?.trace
         ? freezeDiagnosticTraceContext(createChildDiagnosticTraceContext(ctx.trace))
@@ -744,7 +810,7 @@ export function wrapToolWithBeforeToolCallHook(
         ...(trace && { trace }),
         toolName: normalizedToolName,
         ...(toolCallId && { toolCallId }),
-        paramsSummary: summarizeToolParams(outcome.params),
+        paramsSummary: summarizeToolParams(executeParams),
       };
       if (diagnosticOptions.emitDiagnostics) {
         emitTrustedDiagnosticEvent({
@@ -754,12 +820,12 @@ export function wrapToolWithBeforeToolCallHook(
       }
       const startedAt = Date.now();
       try {
-        const result = await execute(toolCallId, outcome.params, signal, onUpdate);
+        const result = await execute(toolCallId, executeParams, signal, onUpdate);
         const durationMs = Date.now() - startedAt;
         await recordLoopOutcome({
           ctx,
           toolName: normalizedToolName,
-          toolParams: outcome.params,
+          toolParams: executeParams,
           toolCallId,
           result,
         });
@@ -786,7 +852,7 @@ export function wrapToolWithBeforeToolCallHook(
         await recordLoopOutcome({
           ctx,
           toolName: normalizedToolName,
-          toolParams: outcome.params,
+          toolParams: executeParams,
           toolCallId,
           error: err,
         });

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -428,6 +428,9 @@ export type PluginHookReplyDispatchResult = {
   counts: Record<ReplyDispatchKind, number>;
 };
 
+export type PluginHookToolKind = "code_mode_exec";
+export type PluginHookToolInputKind = "javascript" | "typescript";
+
 export type PluginHookToolContext = {
   agentId?: string;
   sessionKey?: string;
@@ -435,6 +438,10 @@ export type PluginHookToolContext = {
   runId?: string;
   trace?: DiagnosticTraceContext;
   toolName: string;
+  /** Host-authoritative discriminator for tools that intentionally share names. */
+  toolKind?: PluginHookToolKind;
+  /** Host-authoritative input/runtime family for tools whose payloads need policy distinction. */
+  toolInputKind?: PluginHookToolInputKind;
   toolCallId?: string;
   getSessionExtension?: (namespace: string) => PluginJsonValue | undefined;
   channelId?: string;
@@ -443,6 +450,10 @@ export type PluginHookToolContext = {
 export type PluginHookBeforeToolCallEvent = {
   toolName: string;
   params: Record<string, unknown>;
+  /** Host-authoritative discriminator for tools that intentionally share names. */
+  toolKind?: PluginHookToolKind;
+  /** Host-authoritative input/runtime family for tools whose payloads need policy distinction. */
+  toolInputKind?: PluginHookToolInputKind;
   runId?: string;
   toolCallId?: string;
   /**

--- a/src/plugins/trusted-tool-policy.ts
+++ b/src/plugins/trusted-tool-policy.ts
@@ -5,6 +5,8 @@ import type {
   PluginHookBeforeToolCallEvent,
   PluginHookBeforeToolCallResult,
   PluginHookToolContext,
+  PluginHookToolInputKind,
+  PluginHookToolKind,
 } from "./hook-types.js";
 import { getPluginSessionExtensionStateSync } from "./host-hook-state.js";
 import type { PluginJsonValue } from "./host-hooks.js";
@@ -22,6 +24,18 @@ function normalizeDerivedEventFields(
     : {};
 }
 
+function normalizeToolIdentity(
+  value:
+    | Pick<PluginHookBeforeToolCallEvent, "toolKind" | "toolInputKind">
+    | Pick<PluginHookToolContext, "toolKind" | "toolInputKind">
+    | undefined,
+): { toolKind?: PluginHookToolKind; toolInputKind?: PluginHookToolInputKind } {
+  return {
+    ...(value?.toolKind && { toolKind: value.toolKind }),
+    ...(value?.toolInputKind && { toolInputKind: value.toolInputKind }),
+  };
+}
+
 export async function runTrustedToolPolicies(
   event: PluginHookBeforeToolCallEvent,
   ctx: PluginHookToolContext,
@@ -30,6 +44,16 @@ export async function runTrustedToolPolicies(
     deriveEvent?: (
       params: Record<string, unknown>,
     ) => Pick<PluginHookBeforeToolCallEvent, "derivedPaths">;
+    normalizeEvent?: (
+      event: PluginHookBeforeToolCallEvent,
+      ctx: PluginHookToolContext,
+    ) =>
+      | {
+          params?: Record<string, unknown>;
+          event?: Pick<PluginHookBeforeToolCallEvent, "toolKind" | "toolInputKind">;
+          ctx?: Pick<PluginHookToolContext, "toolKind" | "toolInputKind">;
+        }
+      | undefined;
   },
 ): Promise<PluginHookBeforeToolCallResult | undefined> {
   const policies = getActivePluginRegistry()?.trustedToolPolicies ?? [];
@@ -50,18 +74,26 @@ export async function runTrustedToolPolicies(
     }
     return resolvedSessionConfig;
   };
-  const { derivedPaths, ...eventWithoutDerivedPaths } = event;
+  const { derivedPaths, toolKind, toolInputKind, ...eventWithoutDerivedPaths } = event;
+  const { toolKind: ctxToolKind, toolInputKind: ctxToolInputKind, ...ctxWithoutToolIdentity } = ctx;
   let currentDerivedEvent = normalizeDerivedEventFields({ derivedPaths });
+  let currentEventToolIdentity = normalizeToolIdentity({ toolKind, toolInputKind });
+  let currentContextToolIdentity = normalizeToolIdentity({
+    toolKind: ctxToolKind,
+    toolInputKind: ctxToolInputKind,
+  });
   const buildEvent = (): PluginHookBeforeToolCallEvent => {
     return {
       ...eventWithoutDerivedPaths,
       params: adjustedParams,
+      ...currentEventToolIdentity,
       ...currentDerivedEvent,
     };
   };
   for (const registration of policies) {
     const policyCtx: PluginHookToolContext = {
-      ...ctx,
+      ...ctxWithoutToolIdentity,
+      ...currentContextToolIdentity,
       // oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Plugin callers type JSON reads by namespace.
       getSessionExtension: <T extends PluginJsonValue = PluginJsonValue>(namespace: string) => {
         const normalizedNamespace = namespace.trim();
@@ -109,7 +141,24 @@ export async function runTrustedToolPolicies(
     // approvals are remembered so later trusted policies can still inspect or
     // block the final call.
     if ("params" in decision && isPlainObject(decision.params)) {
-      adjustedParams = decision.params;
+      const normalized = options?.normalizeEvent?.(
+        {
+          ...eventWithoutDerivedPaths,
+          params: decision.params,
+          ...currentEventToolIdentity,
+          ...currentDerivedEvent,
+        },
+        policyCtx,
+      );
+      adjustedParams = normalized?.params ?? decision.params;
+      if (normalized?.event) {
+        currentEventToolIdentity = normalizeToolIdentity(normalized.event);
+      }
+      if (normalized?.ctx) {
+        currentContextToolIdentity = normalizeToolIdentity(normalized.ctx);
+      } else if (normalized?.event) {
+        currentContextToolIdentity = normalizeToolIdentity(normalized.event);
+      }
       hasAdjustedParams = true;
       currentDerivedEvent = normalizeDerivedEventFields(options?.deriveEvent?.(adjustedParams));
     }


### PR DESCRIPTION
Follow-up to #83387 after #83481 landed the active hook-context plumbing.

## Problem

Code-mode exposes its outer `exec` control tool through the Pi custom-tool adapter. On current `main`, the active hook context is already threaded into that outer dispatch via `toolHookContext`, which gives `before_tool_call` handlers the active agent/session/run identity.

The remaining gap is that the outer code-mode `exec` input is model-facing `code`, while conventional exec-shaped hook policies inspect `command`. That makes it harder for one policy to reason consistently about outer code-mode `exec` and normal exec-shaped dispatches.

## Why this matters

Several code execution surfaces can reach hook policy with similar intent but different names and payload shapes:

| Surface | Hook-facing tool name | Source field | Runtime |
| --- | --- | --- | --- |
| OpenClaw code-mode exec | `exec` | `code` today, `code` + `command` after this PR | QuickJS-WASI code mode |
| Pi shell exec | `exec` | `command` | host shell |
| Codex shell relay | `shell_command` / `unified_exec` | `command` | Codex shell tools |
| Proposed Codex code-mode hook coverage | `code_mode_exec` with `exec` alias | `command` | Codex code mode |

The important OpenClaw-specific problem is that code-mode `exec` and Pi shell `exec` share the same hook-facing tool name, but historically only shell-style exec exposed `params.command`. That makes broad `exec` / `command` policies easy to write but incomplete for code-mode cells.

This PR keeps the model-facing code-mode tool named `exec`, mirrors code-mode source into `params.command`, and adds `toolKind: "code_mode_exec"` so policy authors can choose either broad execution coverage or code-mode-specific handling.

Compatibility note: existing policies that match `event.toolName === "exec"` and inspect `event.params.command` may now also evaluate outer code-mode cells. Policies intended to apply only to shell-style exec should exclude `event.toolKind === "code_mode_exec"`.

## Change and value

This PR preserves the current active hook-context path and aligns the outer code-mode `exec` input contract with exec-shaped policy expectations:

- keeps `code` accepted as the documented model-facing field
- accepts `command` as an alias for code-mode `exec`
- mirrors `code` and `command` in `before_tool_call` hook payloads for marked code-mode control tools only
- adds hook-visible `toolKind: "code_mode_exec"` and `toolInputKind` metadata so policies can distinguish code-mode cells from shell-style `exec`
- normalizes code-mode aliases and recomputes input metadata after trusted-policy param rewrites, including between trusted policies in the same policy chain
- reconciles single-alias hook rewrites before execution
- records reconciled adapter params so `after_tool_call` observes the payload that actually executed
- rejects divergent `code` and `command` values before execution
- treats non-string counterpart values as absent so hooks still see executable source under both expected names

## Scope

Affected:
- code-mode users with `before_tool_call`, `after_tool_call`, or trusted policies that inspect outer code-mode `exec`
- policy authors who want outer code-mode `exec` to expose an exec-compatible `command` field while still being distinguishable from shell exec

Not affected:
- normal shell `exec` behavior, which remains unmarked by the code-mode discriminator
- non-code-mode tools named `exec`
- the existing code-mode `code` field, which remains accepted
- nested tool calls made from inside code mode; the discriminator applies only to the outer code-mode `exec` control tool

## Maintainer decision needed

This PR intentionally makes outer code-mode `exec` visible to policies that match `event.toolName === "exec"` and inspect `event.params.command`. The opt-out / audit shape is the additive host-authored discriminator pair: `toolKind: "code_mode_exec"` and `toolInputKind: "javascript" | "typescript"` when the language is known.

Please confirm whether `command` plus `toolKind` / `toolInputKind` is the intended outer code-mode exec hook contract. If maintainers would rather require policy authors to handle `code` directly, or rename the hook-facing tool instead of adding discriminators, this PR should change shape before merge.

## Verification

Current head: `3b40c538ccdcaff62f9a463e689e096285dab9f2`.

- Local: `git diff --check origin/main...HEAD`
- Local: `timeout 120s node_modules/.bin/oxfmt --check docs/plugins/hooks.md docs/reference/code-mode.md src/plugins/trusted-tool-policy.ts src/agents/code-mode-control-tools.ts src/agents/code-mode.ts src/agents/code-mode.test.ts src/agents/pi-tools.before-tool-call.ts src/agents/pi-tool-definition-adapter.ts src/agents/pi-tools.before-tool-call.integration.e2e.test.ts src/agents/pi-tool-definition-adapter.after-tool-call.test.ts src/agents/pi-tool-definition-adapter.after-tool-call.fires-once.test.ts src/plugins/hook-types.ts`
- Local: `timeout 120s node_modules/.bin/oxlint docs/plugins/hooks.md docs/reference/code-mode.md src/plugins/trusted-tool-policy.ts src/agents/code-mode-control-tools.ts src/agents/code-mode.ts src/agents/code-mode.test.ts src/agents/pi-tools.before-tool-call.ts src/agents/pi-tool-definition-adapter.ts src/agents/pi-tools.before-tool-call.integration.e2e.test.ts src/agents/pi-tool-definition-adapter.after-tool-call.test.ts src/agents/pi-tool-definition-adapter.after-tool-call.fires-once.test.ts src/plugins/hook-types.ts`
- Local: `timeout 180s node_modules/vitest/vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/agents/pi-tools.before-tool-call.integration.e2e.test.ts -t "agent context to outer code-mode exec|trusted policy rewrites|single-alias" --reporter verbose` passed: 3 tests passed, 16 skipped by filter
- Local: `timeout 220s node_modules/vitest/vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/agents/pi-tools.before-tool-call.integration.e2e.test.ts --reporter verbose` passed: 19 tests passed
- Local: `timeout 120s node_modules/vitest/vitest.mjs run --config test/vitest/vitest.contracts-plugin.config.ts src/plugins/contracts/host-hooks.contract.test.ts -t "trusted policy|derived paths" --reporter verbose` passed: 8 tests passed, 42 skipped by filter
- Local: `timeout 120s node_modules/vitest/vitest.mjs run --config test/vitest/vitest.agents-core.config.ts src/agents/pi-tool-definition-adapter.after-tool-call.test.ts src/agents/pi-tool-definition-adapter.after-tool-call.fires-once.test.ts --reporter verbose` passed: 7 tests passed
- Local runtime hook proof: `timeout 60s node --import tsx /tmp/openclaw-code-mode-hook-proof.mjs`

## Real behavior proof

**Behavior or issue addressed:** Outer code-mode `exec` now exposes executable source under both the model-facing `code` field and the exec-shaped `command` alias when hooks inspect the dispatch. The same outer dispatch keeps the active agent/session/run/tool-call context from the #83481 hook-context path and includes `toolKind: "code_mode_exec"` plus `toolInputKind` when the input language is known, so shell-style exec policies can deliberately distinguish code-mode cells. Trusted-policy rewrites are normalized before later trusted policies and normal hooks observe params, including command-only rewrites and language changes. Reconciled adapter params are recorded so `after_tool_call` observes the payload that actually executed.

**Real environment tested:** Local OpenClaw source worktree at head `3b40c538ccdcaff62f9a463e689e096285dab9f2`, Node v26.1.0, pnpm 11.1.0, Linux x86_64. The runtime proof registered a real global `before_tool_call` hook runner, sent the code-mode `exec` control tool through the production Pi custom-tool adapter, and compared it with an unmarked plain `exec` tool.

**Exact steps or command run after this patch:** From `/tmp/openclaw-pr-83387`, ran:

```console
$ git diff --check origin/main...HEAD
$ timeout 120s node_modules/.bin/oxfmt --check docs/plugins/hooks.md docs/reference/code-mode.md src/plugins/trusted-tool-policy.ts src/agents/code-mode-control-tools.ts src/agents/code-mode.ts src/agents/code-mode.test.ts src/agents/pi-tools.before-tool-call.ts src/agents/pi-tool-definition-adapter.ts src/agents/pi-tools.before-tool-call.integration.e2e.test.ts src/agents/pi-tool-definition-adapter.after-tool-call.test.ts src/agents/pi-tool-definition-adapter.after-tool-call.fires-once.test.ts src/plugins/hook-types.ts
$ timeout 120s node_modules/.bin/oxlint docs/plugins/hooks.md docs/reference/code-mode.md src/plugins/trusted-tool-policy.ts src/agents/code-mode-control-tools.ts src/agents/code-mode.ts src/agents/code-mode.test.ts src/agents/pi-tools.before-tool-call.ts src/agents/pi-tool-definition-adapter.ts src/agents/pi-tools.before-tool-call.integration.e2e.test.ts src/agents/pi-tool-definition-adapter.after-tool-call.test.ts src/agents/pi-tool-definition-adapter.after-tool-call.fires-once.test.ts src/plugins/hook-types.ts
$ timeout 180s node_modules/vitest/vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/agents/pi-tools.before-tool-call.integration.e2e.test.ts -t "agent context to outer code-mode exec|trusted policy rewrites|single-alias" --reporter verbose
$ timeout 220s node_modules/vitest/vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/agents/pi-tools.before-tool-call.integration.e2e.test.ts --reporter verbose
$ timeout 120s node_modules/vitest/vitest.mjs run --config test/vitest/vitest.contracts-plugin.config.ts src/plugins/contracts/host-hooks.contract.test.ts -t "trusted policy|derived paths" --reporter verbose
$ timeout 120s node_modules/vitest/vitest.mjs run --config test/vitest/vitest.agents-core.config.ts src/agents/pi-tool-definition-adapter.after-tool-call.test.ts src/agents/pi-tool-definition-adapter.after-tool-call.fires-once.test.ts --reporter verbose
$ timeout 60s node --import tsx /tmp/openclaw-code-mode-hook-proof.mjs
```

**Evidence after fix:** Formatting and lint passed on the touched docs, source, and test files:

```console
All matched files use the correct format.
Found 0 warnings and 0 errors.
```

The affected integration file completed successfully:

```console
Test Files  1 passed (1)
Tests  19 passed (19)
```

The focused post-review regression check completed successfully and covers direct TypeScript input, trusted-policy command-only rewrites, trusted-policy language rewrites, and hook single-alias rewrites:

```console
Test Files  1 passed (1)
Tests  3 passed | 16 skipped (19)
```

The focused contracts check for trusted-policy and derived-path behavior completed successfully:

```console
Test Files  1 passed (1)
Tests  8 passed | 42 skipped (50)
```

The adapter after-hook focused tests completed successfully:

```console
Test Files  2 passed (2)
Tests  7 passed (7)
```

The runtime hook proof produced this redacted live hook observation:

```json
{
  "proof": "OpenClaw runtime before_tool_call hook observation",
  "head": "3b40c538ccdcaff62f9a463e689e096285dab9f2",
  "codeModeResult": {
    "status": "blocked",
    "deniedReason": "plugin-before-tool-call",
    "reason": "runtime proof captured code_mode_exec"
  },
  "plainExecResult": {
    "status": "blocked",
    "deniedReason": "plugin-before-tool-call",
    "reason": "runtime proof captured plain_exec"
  },
  "observations": [
    {
      "event": {
        "toolName": "exec",
        "toolKind": "code_mode_exec",
        "toolInputKind": "javascript",
        "runId": "run-runtime-proof",
        "toolCallId": "proof-code-mode-exec",
        "params": {
          "hasCode": true,
          "hasCommand": true,
          "codeEqualsCommand": true,
          "code": "console.log('runtime proof');",
          "command": "console.log('runtime proof');",
          "language": "javascript"
        }
      },
      "context": {
        "toolName": "exec",
        "toolKind": "code_mode_exec",
        "toolInputKind": "javascript",
        "agentId": "main",
        "sessionKey": "agent:main:runtime-proof",
        "sessionId": "session-runtime-proof",
        "runId": "run-runtime-proof",
        "toolCallId": "proof-code-mode-exec"
      }
    },
    {
      "event": {
        "toolName": "exec",
        "toolKind": null,
        "toolInputKind": null,
        "runId": "run-runtime-proof",
        "toolCallId": "proof-plain-exec",
        "params": {
          "hasCode": false,
          "hasCommand": true,
          "codeEqualsCommand": false,
          "command": "echo runtime-proof"
        }
      },
      "context": {
        "toolName": "exec",
        "toolKind": null,
        "toolInputKind": null,
        "agentId": "main",
        "sessionKey": "agent:main:runtime-proof",
        "sessionId": "session-runtime-proof",
        "runId": "run-runtime-proof",
        "toolCallId": "proof-plain-exec"
      }
    }
  ]
}
```

**Observed result after fix:** Hooks inspecting outer code-mode `exec` see `code` and `command` mirrored for code-only, command-only, malformed-counterpart, trusted-policy command-only rewrite, and hook single-alias rewrite inputs. Trusted-policy chains see normalized params and recomputed input kind between policies. `after_tool_call` sees reconciled adapter params for rewritten code-mode exec payloads. A plain unmarked tool named `exec` still reaches hooks without `toolKind`, so existing shell-style policies can distinguish the two paths instead of relying on tool name alone.

**What was not tested:** I did not run a live model/gateway conversation. The runtime hook proof intentionally blocked before executing source so the evidence isolates the hook contract and does not depend on model output. Two earlier attempts to run these same affected standard-config tests through the top-level Vitest project config timed out during project startup, so I reran the affected files with their scoped configs instead.