### PR TITLE
Fix gateway service startup race

### DIFF
--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -2,6 +2,7 @@ import type { ClientRequest, IncomingMessage } from "node:http";
 import path from "node:path";
 import { Command } from "commander";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RespawnSupervisor } from "../../infra/supervisor-markers.js";
 import { SUPERVISOR_HINT_ENV_VARS } from "../../infra/supervisor-markers.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { withTempSecretFiles } from "../../test-utils/secret-file-fixture.js";
@@ -27,6 +28,9 @@ const runGatewayLoop = vi.fn(async ({ start }: { start: GatewayLoopStart }) => {
 });
 const httpRequest = vi.hoisted(() => vi.fn());
 const gatewayLogMessages = vi.hoisted(() => [] as string[]);
+const supervisorState = vi.hoisted(() => ({
+  value: null as RespawnSupervisor | null,
+}));
 const configState = vi.hoisted(() => ({
   cfg: {} as Record<string, unknown>,
   snapshot: { exists: false } as Record<string, unknown>,
@@ -162,7 +166,7 @@ vi.mock("../../infra/supervisor-markers.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../infra/supervisor-markers.js")>();
   return {
     ...actual,
-    detectRespawnSupervisor: () => null,
+    detectRespawnSupervisor: () => supervisorState.value,
   };
 });
 
@@ -229,6 +233,7 @@ describe("gateway run option collisions", () => {
     netState.container = false;
     readBestEffortConfig.mockClear();
     readConfigFileSnapshotWithPluginMetadata.mockClear();
+    supervisorState.value = null;
     controlUiState.root = "/tmp/openclaw-control-ui";
     gatewayLogMessages.length = 0;
     writeDiagnosticStabilityBundleForFailureSync.mockClear();
@@ -391,6 +396,55 @@ describe("gateway run option collisions", () => {
     try {
       await expect(runGatewayCli(["gateway", "run", "--allow-unconfigured"])).rejects.toThrow(
         "__exit__:0",
+      );
+    } finally {
+      if (previousMarker === undefined) {
+        delete process.env.OPENCLAW_SERVICE_MARKER;
+      } else {
+        process.env.OPENCLAW_SERVICE_MARKER = previousMarker;
+      }
+    }
+
+    expect(cleanStaleGatewayProcessesSync).not.toHaveBeenCalled();
+    expect(startGatewayServer).not.toHaveBeenCalled();
+    expect(gatewayLogMessages).toContain(
+      "service-mode: existing healthy gateway is already listening on port 18789; leaving it in control",
+    );
+  });
+
+  it("exits with systemd restart-prevent code when a healthy service-mode gateway owns the port", async () => {
+    supervisorState.value = "systemd";
+    httpRequest.mockImplementationOnce(
+      (_opts: unknown, callback: (res: Pick<IncomingMessage, "statusCode" | "resume">) => void) => {
+        const request = {
+          once() {
+            return request;
+          },
+          removeAllListeners() {
+            return request;
+          },
+          destroy() {
+            return request;
+          },
+          end() {
+            const response = {
+              statusCode: 200,
+              resume() {
+                return response as unknown as IncomingMessage;
+              },
+            };
+            callback(response);
+            return request;
+          },
+        } as unknown as ClientRequest;
+        return request;
+      },
+    );
+    const previousMarker = process.env.OPENCLAW_SERVICE_MARKER;
+    process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
+    try {
+      await expect(runGatewayCli(["gateway", "run", "--allow-unconfigured"])).rejects.toThrow(
+        "__exit__:78",
       );
     } finally {
       if (previousMarker === undefined) {

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -373,10 +373,13 @@ describe("gateway run option collisions", () => {
             return request;
           },
           end() {
-            callback({
+            const response = {
               statusCode: 200,
-              resume() {},
-            });
+              resume() {
+                return response as unknown as IncomingMessage;
+              },
+            };
+            callback(response);
             return request;
           },
         } as unknown as ClientRequest;

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -1,3 +1,4 @@
+import type { IncomingMessage } from "node:http";
 import path from "node:path";
 import { Command } from "commander";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -18,11 +19,13 @@ const forceFreePortAndWait = vi.fn(async (_port: number, _opts: unknown) => ({
   escalatedToSigkill: false,
 }));
 const waitForPortBindable = vi.fn(async (_port: number, _opts?: unknown) => 0);
+const cleanStaleGatewayProcessesSync = vi.fn((_port?: number) => [] as number[]);
 const ensureDevGatewayConfig = vi.fn(async (_opts?: unknown) => {});
 type GatewayLoopStart = (params?: { startupStartedAt?: number }) => Promise<unknown>;
 const runGatewayLoop = vi.fn(async ({ start }: { start: GatewayLoopStart }) => {
   await start();
 });
+const httpRequest = vi.hoisted(() => vi.fn());
 const gatewayLogMessages = vi.hoisted(() => [] as string[]);
 const configState = vi.hoisted(() => ({
   cfg: {} as Record<string, unknown>,
@@ -59,6 +62,10 @@ vi.mock("../../config/config.js", () => ({
   readBestEffortConfig: () => readBestEffortConfig(),
   readConfigFileSnapshot: async () => configState.snapshot,
   readConfigFileSnapshotWithPluginMetadata: () => readConfigFileSnapshotWithPluginMetadata(),
+}));
+
+vi.mock("node:http", () => ({
+  request: (...args: unknown[]) => httpRequest(...args),
 }));
 
 vi.mock("../../config/paths.js", () => ({
@@ -147,6 +154,10 @@ vi.mock("../../infra/ports.js", () => ({
   inspectPortUsage: async () => ({ status: "free" }),
 }));
 
+vi.mock("../../infra/restart-stale-pids.js", () => ({
+  cleanStaleGatewayProcessesSync: (port?: number) => cleanStaleGatewayProcessesSync(port),
+}));
+
 vi.mock("../../infra/supervisor-markers.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../infra/supervisor-markers.js")>();
   return {
@@ -227,8 +238,31 @@ describe("gateway run option collisions", () => {
     setConsoleSubsystemFilter.mockClear();
     forceFreePortAndWait.mockClear();
     waitForPortBindable.mockClear();
+    cleanStaleGatewayProcessesSync.mockClear();
     ensureDevGatewayConfig.mockClear();
     runGatewayLoop.mockClear();
+    httpRequest.mockImplementation(
+      (
+        _opts: unknown,
+        _callback: (res: Pick<IncomingMessage, "statusCode" | "resume">) => void,
+      ) => {
+        const handlers = new Map<string, (...args: unknown[]) => void>();
+        return {
+          once(event: string, handler: (...args: unknown[]) => void) {
+            handlers.set(event, handler);
+            return this;
+          },
+          removeAllListeners() {
+            handlers.clear();
+            return this;
+          },
+          destroy() {},
+          end() {
+            handlers.get("error")?.(new Error("connection refused"));
+          },
+        };
+      },
+    );
   });
 
   async function runGatewayCli(argv: string[]) {
@@ -319,6 +353,47 @@ describe("gateway run option collisions", () => {
     expect(forceFreePortAndWait).not.toHaveBeenCalled();
     expect(startGatewayServer).not.toHaveBeenCalled();
     expect(runtimeErrors.join("\n")).toContain("Refusing to start the gateway service");
+  });
+
+  it("leaves an existing healthy service-mode gateway in control before stale cleanup", async () => {
+    httpRequest.mockImplementationOnce(
+      (_opts: unknown, callback: (res: Pick<IncomingMessage, "statusCode" | "resume">) => void) => {
+        return {
+          once() {
+            return this;
+          },
+          removeAllListeners() {
+            return this;
+          },
+          destroy() {},
+          end() {
+            callback({
+              statusCode: 200,
+              resume() {},
+            });
+          },
+        };
+      },
+    );
+    const previousMarker = process.env.OPENCLAW_SERVICE_MARKER;
+    process.env.OPENCLAW_SERVICE_MARKER = "openclaw";
+    try {
+      await expect(runGatewayCli(["gateway", "run", "--allow-unconfigured"])).rejects.toThrow(
+        "__exit__:0",
+      );
+    } finally {
+      if (previousMarker === undefined) {
+        delete process.env.OPENCLAW_SERVICE_MARKER;
+      } else {
+        process.env.OPENCLAW_SERVICE_MARKER = previousMarker;
+      }
+    }
+
+    expect(cleanStaleGatewayProcessesSync).not.toHaveBeenCalled();
+    expect(startGatewayServer).not.toHaveBeenCalled();
+    expect(gatewayLogMessages).toContain(
+      "service-mode: existing healthy gateway is already listening on port 18789; leaving it in control",
+    );
   });
 
   it.each([

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -1,4 +1,4 @@
-import type { IncomingMessage } from "node:http";
+import type { ClientRequest, IncomingMessage } from "node:http";
 import path from "node:path";
 import { Command } from "commander";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -247,20 +247,24 @@ describe("gateway run option collisions", () => {
         _callback: (res: Pick<IncomingMessage, "statusCode" | "resume">) => void,
       ) => {
         const handlers = new Map<string, (...args: unknown[]) => void>();
-        return {
+        const request = {
           once(event: string, handler: (...args: unknown[]) => void) {
             handlers.set(event, handler);
-            return this;
+            return request;
           },
           removeAllListeners() {
             handlers.clear();
-            return this;
+            return request;
           },
-          destroy() {},
+          destroy() {
+            return request;
+          },
           end() {
             handlers.get("error")?.(new Error("connection refused"));
+            return request;
           },
-        };
+        } as unknown as ClientRequest;
+        return request;
       },
     );
   });
@@ -358,21 +362,25 @@ describe("gateway run option collisions", () => {
   it("leaves an existing healthy service-mode gateway in control before stale cleanup", async () => {
     httpRequest.mockImplementationOnce(
       (_opts: unknown, callback: (res: Pick<IncomingMessage, "statusCode" | "resume">) => void) => {
-        return {
+        const request = {
           once() {
-            return this;
+            return request;
           },
           removeAllListeners() {
-            return this;
+            return request;
           },
-          destroy() {},
+          destroy() {
+            return request;
+          },
           end() {
             callback({
               statusCode: 200,
               resume() {},
             });
+            return request;
           },
-        };
+        } as unknown as ClientRequest;
+        return request;
       },
     );
     const previousMarker = process.env.OPENCLAW_SERVICE_MARKER;

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -575,15 +575,6 @@ export async function runGatewayCommand(opts: GatewayRunOpts) {
     return;
   }
   const bindExplicitRaw = bindExplicitRawStr as GatewayBindMode | undefined;
-  if (process.env.OPENCLAW_SERVICE_MARKER?.trim()) {
-    const { cleanStaleGatewayProcessesSync } = await import("../../infra/restart-stale-pids.js");
-    const stale = cleanStaleGatewayProcessesSync(port);
-    if (stale.length > 0) {
-      gatewayLog.info(
-        `service-mode: cleared ${stale.length} stale gateway pid(s) before bind on port ${port}`,
-      );
-    }
-  }
   if (opts.force) {
     try {
       const { forceFreePortAndWait, waitForPortBindable } = await import("../ports.js");
@@ -662,6 +653,25 @@ export async function runGatewayCommand(opts: GatewayRunOpts) {
     | "auto"
     | "custom"
     | "tailnet";
+  const healthHost = await resolveGatewayBindHost(bind, cfg.gateway?.customBindHost);
+  const { detectRespawnSupervisor } = await import("../../infra/supervisor-markers.js");
+  const supervisor = detectRespawnSupervisor(process.env);
+  if (process.env.OPENCLAW_SERVICE_MARKER?.trim()) {
+    if (await probeGatewayHealthz({ host: healthHost, port })) {
+      gatewayLog.info(
+        `service-mode: existing healthy gateway is already listening on port ${port}; leaving it in control`,
+      );
+      defaultRuntime.exit(supervisor === "systemd" ? EXIT_CONFIG_ERROR : 0);
+      return;
+    }
+    const { cleanStaleGatewayProcessesSync } = await import("../../infra/restart-stale-pids.js");
+    const stale = cleanStaleGatewayProcessesSync(port);
+    if (stale.length > 0) {
+      gatewayLog.info(
+        `service-mode: cleared ${stale.length} stale gateway pid(s) before bind on port ${port}`,
+      );
+    }
+  }
 
   let passwordRaw: string | undefined;
   try {
@@ -817,8 +827,6 @@ export async function runGatewayCommand(opts: GatewayRunOpts) {
       },
     });
 
-  const { detectRespawnSupervisor } = await import("../../infra/supervisor-markers.js");
-  const supervisor = detectRespawnSupervisor(process.env);
   try {
     await runGatewayLoopWithSupervisedLockRecovery({
       startLoop,

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -653,11 +653,11 @@ export async function runGatewayCommand(opts: GatewayRunOpts) {
     | "auto"
     | "custom"
     | "tailnet";
-  const healthHost = await resolveGatewayBindHost(bind, cfg.gateway?.customBindHost);
+  const gatewayHealthHost = await resolveGatewayBindHost(bind, cfg.gateway?.customBindHost);
   const { detectRespawnSupervisor } = await import("../../infra/supervisor-markers.js");
   const supervisor = detectRespawnSupervisor(process.env);
   if (process.env.OPENCLAW_SERVICE_MARKER?.trim()) {
-    if (await probeGatewayHealthz({ host: healthHost, port })) {
+    if (await probeGatewayHealthz({ host: gatewayHealthHost, port })) {
       gatewayLog.info(
         `service-mode: existing healthy gateway is already listening on port ${port}; leaving it in control`,
       );
@@ -811,7 +811,7 @@ export async function runGatewayCommand(opts: GatewayRunOpts) {
     await runGatewayLoop({
       runtime: defaultRuntime,
       lockPort: port,
-      healthHost,
+      healthHost: gatewayHealthHost,
       start: async ({ startupStartedAt } = {}) => {
         const startupConfigSnapshotReadForThisStart = startupConfigSnapshotReadForNextStart;
         startupConfigSnapshotReadForNextStart = undefined;
@@ -832,7 +832,7 @@ export async function runGatewayCommand(opts: GatewayRunOpts) {
       startLoop,
       supervisor,
       port,
-      healthHost,
+      healthHost: gatewayHealthHost,
       log: gatewayLog,
     });
   } catch (err) {


### PR DESCRIPTION
## Summary
- Fix a gateway service startup race where one service-mode gateway can kill another healthy gateway listener before the normal gateway lock/startup path runs.
- Move service-mode stale listener cleanup behind bind resolution and a `/healthz` probe so duplicate boot entries leave the already healthy gateway in control.
- Add regressions covering the healthy service-mode early exit, including the systemd restart-prevent exit 78 path.

## Real behavior proof

Behavior or issue addressed: On the affected Raspberry Pi, two boot-managed OpenClaw gateway entries targeted the same port (`18789`). During startup, each service-mode gateway process treated the other gateway process as stale, killed it before the lock/startup path could arbitrate ownership, and then restarted. This produced a repeated boot/restart loop and made the gateway appear stopped or unstable.

Real environment tested: Raspberry Pi running Linux/systemd. Gateway port `18789`. Old duplicate system unit `/etc/systemd/system/openclaw-gateway.service` was enabled before cleanup and ran OpenClaw service v2026.5.5 with command shape `gateway --port 18789`. Intended user unit `~/.config/systemd/user/openclaw-gateway.service` was enabled through root linger and ran OpenClaw service v2026.5.12 with command shape `gateway run --port 18789`. `loginctl show-user root -p Linger` returned `Linger=yes`. The after-fix proof ran the patched branch via `pnpm openclaw gateway run` from this PR checkout, with `OPENCLAW_SERVICE_MARKER=openclaw`, `INVOCATION_ID=codex-proof`, and `SYSTEMD_EXEC_PID=999999` to exercise the systemd service-mode path without re-enabling the duplicate persistent service.

Exact steps or command run after this patch:
1. Checked live gateway processes with `pgrep -af '[o]penclaw.*gateway|[n]ode .*openclaw.*gateway'`.
2. Checked the gateway listener with `ss -ltnp 'sport = :18789'`.
3. Checked the system/user service state and the gateway with `openclaw gateway status --deep`.
4. Ran the patched duplicate service-mode command against the existing healthy gateway:

```bash
OPENCLAW_ALLOW_ROOT=1 OPENCLAW_SERVICE_MARKER=openclaw INVOCATION_ID=codex-proof SYSTEMD_EXEC_PID=999999 pnpm openclaw gateway run --allow-unconfigured
```

5. Rechecked process count, listener state, and `openclaw gateway status --deep` after the patched command exited.

Evidence after fix: Before cleanup, live process checks showed two gateway processes at the same time, one with command shape `gateway run --port 18789` and one with command shape `gateway --port 18789`.

The live gateway log showed repeated service-mode stale cleanup and termination. Representative redacted runtime log excerpt:

```text
killing 1 stale gateway process(es) before restart: <pid>
service-mode: cleared 1 stale gateway pid(s) before bind on port 18789
signal SIGTERM received
```

After operational cleanup, the same machine had one user-service gateway process and one listener before the patched proof command:

```text
pgrep -af '[o]penclaw.*gateway|[n]ode .*openclaw.*gateway'
253345 /usr/bin/node .../openclaw/dist/index.js gateway run --port 18789

ss -ltnp 'sport = :18789'
State  Recv-Q Send-Q Local Address:Port  Peer Address:PortProcess
LISTEN 0      511          0.0.0.0:18789      0.0.0.0:*    users:(("node",pid=253345,fd=25))
```

Patched duplicate service-mode command output:

```text
$ node scripts/run-node.mjs gateway run --allow-unconfigured
2026-05-18T04:44:17.564-03:00 [gateway] loading configuration…
2026-05-18T04:44:19.571-03:00 [gateway] service-mode: existing healthy gateway is already listening on port 18789; leaving it in control
[ELIFECYCLE] Command failed with exit code 78.
PATCHED_GATEWAY_RUN_EXIT:78
```

After that patched command exited, the original listener was still the same PID and the gateway remained reachable:

```text
pgrep -af '[o]penclaw.*gateway|[n]ode .*openclaw.*gateway'
253345 /usr/bin/node .../openclaw/dist/index.js gateway run --port 18789

ss -ltnp 'sport = :18789'
State  Recv-Q Send-Q Local Address:Port  Peer Address:PortProcess
LISTEN 0      511          0.0.0.0:18789      0.0.0.0:*    users:(("node",pid=253345,fd=25))
```

Copied live output from the OpenClaw gateway status probe after the patched proof command:

```text
Connectivity probe: ok
Capability: admin-capable
Gateway version: 2026.5.12
Listening: *:18789
```

Observed result after fix: The patched duplicate service-mode gateway hit the new healthy-listener branch, logged that an existing healthy gateway already owned port `18789`, exited with systemd restart-prevent code `78`, did not kill the existing gateway process, and did not start a second gateway listener. The original gateway process stayed on PID `253345` before and after the patched command, and `openclaw gateway status --deep` still reported `Connectivity probe: ok`.

What was not tested: I did not re-enable the old duplicate persistent system unit because that was the production hazard that caused the restart loop. Instead, I exercised the same patched service-mode/systemd branch with explicit systemd marker environment variables against the real healthy gateway. I did not run broad local gates (`pnpm check`) on the Raspberry Pi because that is too heavy for this host and previously destabilized it.

## Verification
- `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/cli/gateway-cli/run.option-collisions.test.ts -- --reporter=verbose` (21 tests passed)
- `pnpm exec oxfmt --write --threads=1 src/cli/gateway-cli/run.option-collisions.test.ts`
- `git diff --check`
