### PR TITLE
fix(gateway): allow mobile OS metadata refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,7 @@ Docs: https://docs.openclaw.ai
 - Agents/failover: classify Moonshot/Kimi exhausted-balance HTTP 429 payloads as billing instead of generic rate limits, preserving billing guidance and fallback behavior. Fixes #43447. (#83079) Thanks @leno23.
 - Plugin SDK: bundle `openclaw/plugin-sdk/zod` into the published package artifact and verify the packed zod subpath stays self-contained, so pnpm global installs can register plugins without a package-local `zod` symlink. Fixes #78398. (#78515) Thanks @ggzeng.
 - Providers/Google: drop compaction-truncated Gemini thought signatures before replay so malformed Base64 no longer aborts the next assistant turn. (#82995) Thanks @wAngByg.
+- Gateway/mobile: allow paired iOS and Android clients to refresh same-family OS metadata on authenticated reconnect instead of requiring a new approval. (#83490) Thanks @ngutman.
 
 ## 2026.5.17
 

--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -3962,7 +3962,7 @@ extension NodeAppModel {
         switch route {
         case let .agent(link):
             await self.handleAgentDeepLink(link, originalURL: url)
-        case .gateway:
+        case .gateway, .dashboard:
             break
         }
     }

--- a/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
@@ -444,4 +444,68 @@ describe("resolvePinnedClientMetadata", () => {
       });
     },
   );
+
+  it.each([
+    ["openclaw-ios", "iOS 26.5.0", "iOS 26.4.2", "iPhone"],
+    ["openclaw-ios", "iPadOS 26.5.0", "iPadOS 26.4.2", "iPad"],
+    ["openclaw-ios", "iPadOS 26.5.0", "iOS 26.4.2", "iPad"],
+    ["openclaw-android", "Android 16", "Android 15", "Android"],
+  ])(
+    "allows %s platform version refresh without metadata-upgrade approval",
+    (clientId, claimedPlatform, pairedPlatform, deviceFamily) => {
+      expect(
+        __testing.resolvePinnedClientMetadata({
+          clientId,
+          clientMode: "node",
+          claimedPlatform,
+          claimedDeviceFamily: deviceFamily,
+          pairedPlatform,
+          pairedDeviceFamily: deviceFamily,
+        }),
+      ).toEqual({
+        platformMismatch: false,
+        deviceFamilyMismatch: false,
+        pinnedPlatform: claimedPlatform,
+        pinnedDeviceFamily: deviceFamily,
+        refreshPairedPlatform: claimedPlatform,
+      });
+    },
+  );
+
+  it("still requires approval when an iOS device family changes", () => {
+    expect(
+      __testing.resolvePinnedClientMetadata({
+        clientId: "openclaw-ios",
+        clientMode: "node",
+        claimedPlatform: "iOS 26.5.0",
+        claimedDeviceFamily: "iPad",
+        pairedPlatform: "iOS 26.4.2",
+        pairedDeviceFamily: "iPhone",
+      }),
+    ).toEqual({
+      platformMismatch: false,
+      deviceFamilyMismatch: true,
+      pinnedPlatform: "iOS 26.5.0",
+      pinnedDeviceFamily: "iPhone",
+      refreshPairedPlatform: "iOS 26.5.0",
+    });
+  });
+
+  it("keeps non-mobile platform version changes approval-bound", () => {
+    expect(
+      __testing.resolvePinnedClientMetadata({
+        clientId: "node-host",
+        clientMode: "node",
+        claimedPlatform: "linux 6.9",
+        claimedDeviceFamily: "Linux",
+        pairedPlatform: "linux 6.8",
+        pairedDeviceFamily: "Linux",
+      }),
+    ).toEqual({
+      platformMismatch: true,
+      deviceFamilyMismatch: false,
+      pinnedPlatform: undefined,
+      pinnedDeviceFamily: "Linux",
+    });
+  });
 });

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -186,6 +186,7 @@ function resolvePinnedClientMetadata(params: {
   deviceFamilyMismatch: boolean;
   pinnedPlatform?: string;
   pinnedDeviceFamily?: string;
+  refreshPairedPlatform?: string;
 } {
   function normalizeLegacyNodeHostPlatformPin(value: string): string {
     switch (value) {
@@ -198,6 +199,16 @@ function resolvePinnedClientMetadata(params: {
       default:
         return value;
     }
+  }
+
+  function normalizeMobileAppPlatformPin(clientId: string | undefined, value: string): string {
+    if (clientId === GATEWAY_CLIENT_IDS.IOS_APP && /^(?:ios|ipados)(?:\s|$)/.test(value)) {
+      return "ios-family";
+    }
+    if (clientId === GATEWAY_CLIENT_IDS.ANDROID_APP && /^android(?:\s|$)/.test(value)) {
+      return "android";
+    }
+    return value;
   }
 
   const claimedPlatform = normalizeDeviceMetadataForAuth(params.claimedPlatform);
@@ -213,20 +224,32 @@ function resolvePinnedClientMetadata(params: {
     claimedPlatform !== "" &&
     normalizeLegacyNodeHostPlatformPin(claimedPlatform) ===
       normalizeLegacyNodeHostPlatformPin(pairedPlatform);
+  const isMobileAppPlatformVersionRefresh =
+    hasPinnedPlatform &&
+    claimedPlatform !== "" &&
+    claimedPlatform !== pairedPlatform &&
+    normalizeMobileAppPlatformPin(params.clientId, claimedPlatform) ===
+      normalizeMobileAppPlatformPin(params.clientId, pairedPlatform);
   const platformMismatch =
-    hasPinnedPlatform && claimedPlatform !== pairedPlatform && !isLegacyNodeHostPlatformPin;
+    hasPinnedPlatform &&
+    claimedPlatform !== pairedPlatform &&
+    !isLegacyNodeHostPlatformPin &&
+    !isMobileAppPlatformVersionRefresh;
   const deviceFamilyMismatch = hasPinnedDeviceFamily && claimedDeviceFamily !== pairedDeviceFamily;
   const pinnedPlatform =
     claimedPlatform === pairedPlatform
       ? params.pairedPlatform
       : isLegacyNodeHostPlatformPin
         ? normalizeLegacyNodeHostPlatformPin(pairedPlatform)
-        : undefined;
+        : isMobileAppPlatformVersionRefresh
+          ? params.claimedPlatform
+          : undefined;
   return {
     platformMismatch,
     deviceFamilyMismatch,
     pinnedPlatform: hasPinnedPlatform ? pinnedPlatform : undefined,
     pinnedDeviceFamily: hasPinnedDeviceFamily ? params.pairedDeviceFamily : undefined,
+    ...(isMobileAppPlatformVersionRefresh ? { refreshPairedPlatform: params.claimedPlatform } : {}),
   };
 }
 
@@ -1284,9 +1307,15 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
               }
             }
 
-            // Metadata pinning is approval-bound. Reconnects can update access metadata,
-            // but platform/device family must stay on the approved pairing record.
-            await updatePairedDeviceMetadata(device.id, clientAccessMetadata);
+            // Metadata pinning is approval-bound. Reconnects can update access metadata
+            // and same-family mobile OS version labels, but real platform/device-family
+            // changes must stay on the approved pairing record.
+            await updatePairedDeviceMetadata(device.id, {
+              ...clientAccessMetadata,
+              ...(metadataPinning.refreshPairedPlatform
+                ? { platform: metadataPinning.refreshPairedPlatform }
+                : {}),
+            });
           }
         }
 

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -714,7 +714,7 @@ describe("device pairing tokens", () => {
     });
   });
 
-  test("metadata refresh cannot mutate approved role and scope fields", async () => {
+  test("metadata refresh can update display metadata but not approved role and scope fields", async () => {
     const baseDir = await makeDevicePairingDir();
     await setupPairedNodeDevice(baseDir);
 
@@ -722,6 +722,7 @@ describe("device pairing tokens", () => {
       "node-1",
       {
         displayName: "renamed-node",
+        platform: "iOS 26.5.0",
         role: "operator",
         roles: ["operator"],
         scopes: ["operator.admin"],
@@ -734,6 +735,7 @@ describe("device pairing tokens", () => {
 
     const paired = await getPairedDevice("node-1", baseDir);
     expect(paired?.displayName).toBe("renamed-node");
+    expect(paired?.platform).toBe("iOS 26.5.0");
     expect(paired?.publicKey).toBe("public-key-node-1");
     expect(paired?.role).toBe("node");
     expect(paired?.roles).toEqual(["node"]);

--- a/src/infra/device-pairing.ts
+++ b/src/infra/device-pairing.ts
@@ -97,7 +97,13 @@ export type PairedDevice = {
 
 export type PairedDeviceMetadataPatch = Pick<
   PairedDevice,
-  "displayName" | "clientId" | "clientMode" | "remoteIp" | "lastSeenAtMs" | "lastSeenReason"
+  | "displayName"
+  | "platform"
+  | "clientId"
+  | "clientMode"
+  | "remoteIp"
+  | "lastSeenAtMs"
+  | "lastSeenReason"
 >;
 
 export type DevicePairingList = {
@@ -854,6 +860,9 @@ export async function updatePairedDeviceMetadata(
     const next = { ...existing };
     if ("displayName" in patch) {
       next.displayName = patch.displayName;
+    }
+    if ("platform" in patch) {
+      next.platform = patch.platform;
     }
     if ("clientId" in patch) {
       next.clientId = patch.clientId;


### PR DESCRIPTION
## Summary

Fix the iOS gateway reconnect path where a paired mobile node could be forced back through manual device approval after only the reported OS version changed, for example `iOS 26.4.2` to `iOS 26.5.0`.

The gateway now treats same-family mobile platform label changes from OpenClaw mobile clients as display metadata refreshes instead of identity-changing `metadata-upgrade` requests. Device-family changes remain approval-bound. This also keeps the paired platform label fresh after an authenticated reconnect and includes the needed iOS deep-link route handling for dashboard links.

## Verification

Behavior addressed: iOS/mobile OS-version drift no longer requires a new device approval when the device family is unchanged.

Real environment tested: local OpenClaw checkout on macOS with Node/Vitest and Xcode iOS build tooling.

Exact steps or command run after this patch:

```sh
node scripts/run-vitest.mjs src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts src/infra/device-pairing.test.ts
node scripts/run-oxlint.mjs src/gateway/server/ws-connection/message-handler.ts src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts src/infra/device-pairing.ts src/infra/device-pairing.test.ts
xcodebuild -project apps/ios/OpenClaw.xcodeproj -scheme OpenClaw -destination 'generic/platform=iOS' -configuration Debug CODE_SIGNING_ALLOWED=NO build
git diff --check
```

Evidence after fix: focused metadata pinning tests cover iOS, iPadOS, Android OS-version refresh, iOS device-family mismatch, and non-mobile platform version mismatch.

Observed result after fix: Vitest passed 4 files / 90 tests, oxlint reported 0 errors, Xcode build succeeded, and diff whitespace check was clean.

What was not tested: live iOS-to-gateway reconnect against the original physical device.