### PR TITLE
fix: skip TTS for explicit command replies

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -5838,6 +5838,38 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     expect(firstFinalReplyPayload(dispatcher)?.text).toBe("status reply");
   });
 
+  it("does not synthesize TTS audio for explicit command replies", async () => {
+    setNoAbort();
+    ttsMocks.state.synthesizeFinalAudio = true;
+    ttsMocks.maybeApplyTtsToPayload.mockClear();
+    const dispatcher = createDispatcher();
+    const replyResolver = vi.fn(
+      async () =>
+        ({
+          text: "Active memory status: enabled",
+        }) satisfies ReplyPayload,
+    );
+
+    await dispatchReplyFromConfig({
+      ctx: buildTestCtx({
+        ChatType: "direct",
+        CommandSource: "native",
+        CommandAuthorized: true,
+        BodyForCommands: "/active-memory status",
+        SessionKey: "test:telegram:direct:owner",
+      }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(ttsMocks.maybeApplyTtsToPayload).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith({
+      text: "Active memory status: enabled",
+    });
+  });
+
   it("keeps default group/channel source delivery automatic", async () => {
     setNoAbort();
     const dispatcher = createDispatcher();

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -86,6 +86,7 @@ import {
 } from "../../tts/tts-config.js";
 import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../../utils/message-channel.js";
 import {
+  isExplicitCommandTurn,
   isNativeCommandTurn,
   resolveCommandTurnContext,
   resolveCommandTurnTargetSessionKey,
@@ -709,6 +710,7 @@ export async function dispatchReplyFromConfig(
     ctx,
     sessionKey: acpDispatchSessionKey,
   });
+  const commandTurnContext = resolveCommandTurnContext(ctx);
   const inboundAudio = isInboundAudioContext(ctx);
   const sessionTtsAuto = normalizeTtsAutoMode(sessionStoreEntry.entry?.ttsAuto);
   const workspaceDir = resolveAgentWorkspaceDir(cfg, sessionAgentId);
@@ -1240,16 +1242,18 @@ export async function dispatchReplyFromConfig(
       if (hasOutboundReplyContent(payload, { trimText: true })) {
         markInboundDedupeReplayUnsafe();
       }
-      const ttsPayload = await maybeApplyTtsToReplyPayload({
-        payload,
-        cfg,
-        channel: deliveryChannel,
-        kind: "final",
-        inboundAudio,
-        ttsAuto: sessionTtsAuto,
-        agentId: sessionAgentId,
-        accountId: replyRoute.accountId,
-      });
+      const ttsPayload = isExplicitCommandTurn(commandTurnContext)
+        ? payload
+        : await maybeApplyTtsToReplyPayload({
+            payload,
+            cfg,
+            channel: deliveryChannel,
+            kind: "final",
+            inboundAudio,
+            ttsAuto: sessionTtsAuto,
+            agentId: sessionAgentId,
+            accountId: replyRoute.accountId,
+          });
       const normalizedPayload = await normalizeReplyMediaPayload(ttsPayload);
       const result = await routeReplyToOriginating(normalizedPayload);
       if (result) {


### PR DESCRIPTION
## Summary

- Problem: explicit slash/native command replies such as `/active-memory status` were still passed through final TTS when TTS was configured to synthesize final replies.
- Why it matters: command/status output should remain visible text only; speaking command output is noisy and can leak operational status into audio surfaces.
- What changed: explicit command turns now bypass final-reply TTS synthesis while preserving normal final reply delivery and media normalization.
- What did NOT change (scope boundary): non-command assistant replies, streamed ACP block TTS, tool-result TTS handling, and TTS config defaults are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #82582
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: explicit command replies are delivered as text but are not sent to the TTS synthesizer.
- Real environment tested: macOS 26.4.1, Node v23.11.0, pnpm v11.1.0, local OpenClaw checkout on `fix/command-replies-skip-tts`.
- Exact steps or command run after this patch:
  - Real OpenClaw dispatch smoke: `PATH=/opt/homebrew/Cellar/node/23.11.0/bin:$PATH OPENCLAW_DISABLE_BUNDLED_PLUGINS=1 node --import tsx --input-type=module` with a local Telegram direct command context, `tts.mode: "always"`, and production `dispatchReplyFromConfig`.
  - `PATH=/opt/homebrew/Cellar/node/23.11.0/bin:$PATH pnpm vitest run src/auto-reply/reply/dispatch-from-config.test.ts -t "does not synthesize TTS audio for explicit command replies"`
  - `PATH=/opt/homebrew/Cellar/node/23.11.0/bin:$PATH pnpm vitest run src/auto-reply/reply/dispatch-from-config.test.ts src/auto-reply/reply/commands-tts.test.ts`
  - `PATH=/opt/homebrew/Cellar/node/23.11.0/bin:$PATH pnpm check:changed`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
  - Copied live terminal output from the real OpenClaw dispatch smoke (no test runner):

```json
{
  "command": "/active-memory status",
  "ttsMode": "always",
  "result": {
    "queuedFinal": true,
    "counts": {
      "tool": 0,
      "block": 0,
      "final": 1
    }
  },
  "delivered": [
    [
      "final",
      {
        "text": "Active memory status: enabled"
      }
    ]
  ],
  "audioMediaDelivered": false
}
```

  - Supplemental focused regression: `Test Files 1 passed (1); Tests 1 passed | 116 skipped (117)`
  - Supplemental focused suite: `Test Files 2 passed (2); Tests 128 passed (128)`
  - Supplemental changed-file gate: `pnpm check:changed` completed successfully, including core/core-test typecheck, oxlint, import-cycle, and guard checks.
- Observed result after fix: the explicit command reply is delivered once as final text, and no audio/media payload is delivered despite `tts.mode: "always"`.
- What was not tested: a live Telegram/real TTS provider run with actual synthesized media; the real dispatch smoke disables bundled plugins to keep the local proof deterministic.
- Before evidence (optional but encouraged): the new regression test failed before the implementation change with `expected "vi.fn()" to not be called at all, but actually been called 1 times` for `maybeApplyTtsToPayload` on payload text `Active memory status: enabled`.

## Root Cause (if applicable)

- Root cause: final reply dispatch applied TTS based only on TTS configuration and payload kind; it did not distinguish explicit command turns from normal assistant replies.
- Missing detection / guardrail: there was no dispatch-level regression test asserting that explicit command replies bypass TTS while still delivering visible text.
- Contributing context (if known): command reply visibility had dedicated group/channel coverage, but final-reply TTS coverage did not include command-origin replies.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/dispatch-from-config.test.ts`
- Scenario the test should lock in: a direct explicit native command turn with TTS synthesis enabled delivers text but never calls `maybeApplyTtsToPayload`.
- Why this is the smallest reliable guardrail: the regression occurs at the dispatch boundary where command-origin metadata and final-reply TTS are both available.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Explicit slash/native command replies no longer generate TTS audio. Regular assistant final replies still follow configured TTS behavior.

## Diagram (if applicable)

```text
Before:
[/command] -> command text reply -> final TTS path -> spoken command output

After:
[/command] -> command text reply -> TTS bypass -> visible text only
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS 26.4.1
- Runtime/container: Node v23.11.0, pnpm v11.1.0
- Model/provider: N/A for focused dispatch tests
- Integration/channel (if any): dispatch seam for native command turn; no live channel
- Relevant config (redacted): TTS mock configured to synthesize final audio

### Steps

1. Run the new focused regression test before the fix; observe `maybeApplyTtsToPayload` is called for an explicit command reply.
2. Apply the dispatch guard that bypasses final TTS for `isExplicitCommandTurn(...)`.
3. Re-run focused tests and changed-file checks.

### Expected

- Explicit command reply text is delivered.
- Final TTS is not attempted for that command reply.
- Non-command final reply TTS paths remain covered by existing tests.

### Actual

- Matches expected after the patch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - RED: the new command-reply TTS regression test failed on current `origin/main` behavior.
  - GREEN: the focused regression test passed after the dispatch guard.
  - Focused suite: `dispatch-from-config.test.ts` and `commands-tts.test.ts` passed together.
  - Changed-file gate: `pnpm check:changed` passed.
- Edge cases checked:
  - Existing final-mode TTS tests in `dispatch-from-config.test.ts` still pass.
  - Command text reply remains visible via `sendFinalReply`.
- What you did **not** verify:
  - Live channel/audio-provider behavior with real synthesized media.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: command-origin final replies with intentionally requested audio would also bypass final TTS.
  - Mitigation: the issue describes slash/native command output as status-like text; normal non-command final replies and streamed ACP TTS behavior are unchanged.
