### PR TITLE
fix(control-ui): project message tool sends as chat bubbles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Docs: https://docs.openclaw.ai
 - CLI/TUI: include gateway plugin slash commands in TUI autocomplete, so connected sessions can suggest plugin-owned commands exposed by the running Gateway. (#83640) Thanks @se7en-agent.
 - Gateway/mobile: restore QR setup-code handoff of bounded operator tokens for iOS and Android onboarding while keeping admin and pairing scopes out of bootstrap. (#83684) Thanks @ngutman.
 - iOS: repair Release archive compilation for the TestFlight build. (#84255) Thanks @ngutman.
+- Control UI: show successful message-tool visible replies as assistant bubbles when tool blocks are hidden. (#83497) Thanks @Neomail2.
 - Agents/compaction: bound plugin-owned CLI transcript compaction with the host safety timeout so a hung context engine can no longer stall post-turn cleanup. (#84083) Thanks @100yenadmin.
 - Control UI/usage: truncate long context skill, tool, and file names in the usage panel while keeping the full name available on hover. (#42197) Thanks @Rain120.
 - Codex: respect explicit `models auth order set` and `config.auth.order` precedence over stale `lastGood` in `/codex account`, and show `no working credential` when every explicit-order profile is ineligible instead of marking a lower-ranked profile as active. Fixes #84386. (#84412) Thanks @openperf.

--- a/ui/src/ui/chat/build-chat-items.test.ts
+++ b/ui/src/ui/chat/build-chat-items.test.ts
@@ -387,6 +387,83 @@ describe("buildChatItems", () => {
     expect(messageRecord(requireGroup(items[1])).content).toBe("Missing timestamp.");
   });
 
+  it("projects successful message-tool sends as assistant bubbles", () => {
+    const groups = messageGroups({
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "call-message-send",
+              name: "message",
+              arguments: {
+                action: "send",
+                message: "Visible reply sent through the message tool.",
+              },
+            },
+          ],
+          timestamp: 1_000,
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call-message-send",
+          toolName: "message",
+          isError: false,
+          content: [
+            {
+              type: "toolResult",
+              name: "message",
+              text: JSON.stringify({
+                ok: true,
+                messageId: "42",
+                chatId: "chat-1",
+              }),
+            },
+          ],
+          timestamp: 1_001,
+        },
+      ],
+    });
+
+    expect(groups.map((group) => group.role)).toEqual(["tool", "assistant", "tool"]);
+    expect(messageRecord(groups[1]).content).toStrictEqual([
+      { type: "text", text: "Visible reply sent through the message tool." },
+    ]);
+  });
+
+  it("does not project failed message-tool sends as assistant bubbles", () => {
+    const groups = messageGroups({
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "call-message-send-failed",
+              name: "message",
+              arguments: {
+                action: "send",
+                message: "This should not be projected.",
+              },
+            },
+          ],
+          timestamp: 1_000,
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call-message-send-failed",
+          toolName: "message",
+          isError: true,
+          content: "send failed",
+          timestamp: 1_001,
+        },
+      ],
+    });
+
+    expect(groups.map((group) => group.role)).toEqual(["tool"]);
+  });
+
   it("attaches lifted canvas previews to the nearest assistant turn", () => {
     const groups = messageGroups({
       messages: [

--- a/ui/src/ui/chat/build-chat-items.test.ts
+++ b/ui/src/ui/chat/build-chat-items.test.ts
@@ -432,6 +432,52 @@ describe("buildChatItems", () => {
     ]);
   });
 
+  it("projects successful message-tool sends when tool calls are hidden", () => {
+    const groups = messageGroups({
+      showToolCalls: false,
+      messages: [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "call-message-send-hidden-tools",
+              name: "message",
+              arguments: {
+                action: "send",
+                message: "Readable reply without tool plumbing.",
+              },
+            },
+          ],
+          timestamp: 1_000,
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call-message-send-hidden-tools",
+          toolName: "message",
+          isError: false,
+          content: [
+            {
+              type: "toolResult",
+              name: "message",
+              text: JSON.stringify({
+                ok: true,
+                messageId: "43",
+                chatId: "chat-1",
+              }),
+            },
+          ],
+          timestamp: 1_001,
+        },
+      ],
+    });
+
+    expect(groups.map((group) => group.role)).toEqual(["assistant"]);
+    expect(messageRecord(groups[0]).content).toStrictEqual([
+      { type: "text", text: "Readable reply without tool plumbing." },
+    ]);
+  });
+
   it("does not project failed message-tool sends as assistant bubbles", () => {
     const groups = messageGroups({
       messages: [

--- a/ui/src/ui/chat/build-chat-items.ts
+++ b/ui/src/ui/chat/build-chat-items.ts
@@ -83,6 +83,162 @@ function safeNormalizeMessage(message: unknown): NormalizedMessage | null {
   }
 }
 
+function readToolCallId(value: unknown): string | null {
+  const record = asRecord(value);
+  if (!record) {
+    return null;
+  }
+  const id =
+    record.id ?? record.toolCallId ?? record.tool_call_id ?? record.toolUseId ?? record.tool_use_id;
+  return typeof id === "string" && id.trim() ? id.trim() : null;
+}
+
+function readToolName(value: unknown): string | null {
+  const record = asRecord(value);
+  if (!record) {
+    return null;
+  }
+  const name = record.name ?? record.toolName ?? record.tool_name;
+  return typeof name === "string" && name.trim() ? name.trim() : null;
+}
+
+function readTextContent(value: unknown): string | null {
+  if (typeof value === "string") {
+    return value;
+  }
+  const record = asRecord(value);
+  if (!record) {
+    return null;
+  }
+  for (const key of ["text", "content"] as const) {
+    const text = record[key];
+    if (typeof text === "string") {
+      return text;
+    }
+  }
+  return null;
+}
+
+function parseObjectText(text: string): Record<string, unknown> | null {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) {
+    return null;
+  }
+  try {
+    return asRecord(JSON.parse(trimmed));
+  } catch {
+    return null;
+  }
+}
+
+function hasSuccessfulMessageToolResult(message: unknown): boolean {
+  const record = asRecord(message);
+  if (!record || readToolName(record) !== "message" || record.isError === true) {
+    return false;
+  }
+  const content = Array.isArray(record.content) ? record.content : [record.content];
+  for (const item of content) {
+    const text = readTextContent(item);
+    if (!text) {
+      continue;
+    }
+    const parsed = parseObjectText(text);
+    if (!parsed) {
+      continue;
+    }
+    if (
+      parsed.ok === true ||
+      parsed.status === "ok" ||
+      parsed.deliveryStatus === "sent" ||
+      typeof parsed.messageId === "string"
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function collectSuccessfulMessageToolCallIds(messages: unknown[]): Set<string> {
+  const ids = new Set<string>();
+  for (const message of messages) {
+    if (!hasSuccessfulMessageToolResult(message)) {
+      continue;
+    }
+    const id = readToolCallId(message);
+    if (id) {
+      ids.add(id);
+    }
+  }
+  return ids;
+}
+
+function hasAssistantTextContent(message: unknown): boolean {
+  const content = asRecord(message)?.content;
+  if (typeof content === "string") {
+    return content.trim().length > 0;
+  }
+  if (!Array.isArray(content)) {
+    return false;
+  }
+  return content.some((block) => {
+    const record = asRecord(block);
+    return (
+      record?.type === "text" && typeof record.text === "string" && record.text.trim().length > 0
+    );
+  });
+}
+
+function extractMessageToolVisibleReply(
+  message: unknown,
+  successfulToolCallIds: Set<string>,
+): string | null {
+  const record = asRecord(message);
+  const rawRole = typeof record?.role === "string" ? record.role.toLowerCase() : "";
+  if (!record || rawRole !== "assistant") {
+    return null;
+  }
+  if (hasAssistantTextContent(message)) {
+    return null;
+  }
+  const content = Array.isArray(record.content) ? record.content : [];
+  for (const block of content) {
+    const blockRecord = asRecord(block);
+    if (!blockRecord) {
+      continue;
+    }
+    const type = typeof blockRecord.type === "string" ? blockRecord.type.toLowerCase() : "";
+    if (type !== "toolcall" && type !== "tool_call" && type !== "tooluse" && type !== "tool_use") {
+      continue;
+    }
+    if (readToolName(blockRecord) !== "message") {
+      continue;
+    }
+    const id = readToolCallId(blockRecord);
+    if (!id || !successfulToolCallIds.has(id)) {
+      continue;
+    }
+    const params =
+      asRecord(blockRecord.arguments) ?? asRecord(blockRecord.args) ?? asRecord(blockRecord.input);
+    if (!params || params.action !== "send") {
+      continue;
+    }
+    const visibleText = params.message;
+    if (typeof visibleText === "string" && visibleText.trim()) {
+      return visibleText;
+    }
+  }
+  return null;
+}
+
+function projectedMessageToolReply(message: unknown, text: string): Record<string, unknown> {
+  const record = asRecord(message) ?? {};
+  return {
+    ...record,
+    role: "assistant",
+    content: [{ type: "text", text }],
+  };
+}
+
 function extractChatMessagePreview(toolMessage: unknown): {
   preview: Extract<NonNullable<ToolCard["preview"]>, { kind: "canvas" }>;
   text: string | null;
@@ -455,6 +611,7 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
   const history = (Array.isArray(props.messages) ? props.messages : []).filter(
     (message) => !isAssistantHeartbeatAckForDisplay(message),
   );
+  const successfulMessageToolCallIds = collectSuccessfulMessageToolCallIds(history);
   const tools = Array.isArray(props.toolMessages) ? props.toolMessages : [];
   const liftedCanvasSources = tools
     .map((tool) => extractChatMessagePreview(tool))
@@ -527,6 +684,17 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
       key: messageKey(msg, i),
       message: msg,
     });
+    const visibleMessageToolReply = extractMessageToolVisibleReply(
+      msg,
+      successfulMessageToolCallIds,
+    );
+    if (visibleMessageToolReply) {
+      items.push({
+        kind: "message",
+        key: `${messageKey(msg, i)}:message-tool-visible-reply`,
+        message: projectedMessageToolReply(msg, visibleMessageToolReply),
+      });
+    }
   }
   for (const liftedCanvasSource of liftedCanvasSources) {
     const assistantIndex = findNearestAssistantMessageIndex(items, liftedCanvasSource.timestamp);

--- a/ui/src/ui/chat/build-chat-items.ts
+++ b/ui/src/ui/chat/build-chat-items.ts
@@ -565,30 +565,45 @@ function estimateMessageRenderChars(message: unknown, limit: number): number {
   return Math.max(chars, 1);
 }
 
-function isHiddenToolMessage(message: unknown, showToolCalls: boolean): boolean {
+function isHiddenToolMessage(
+  message: unknown,
+  showToolCalls: boolean,
+  successfulMessageToolCallIds: Set<string>,
+): boolean {
   if (showToolCalls) {
+    return false;
+  }
+  if (extractMessageToolVisibleReply(message, successfulMessageToolCallIds)) {
     return false;
   }
   return safeNormalizeMessage(message)?.role.toLowerCase() === "toolresult";
 }
 
-function countVisibleHistoryMessages(messages: unknown[], showToolCalls: boolean): number {
+function countVisibleHistoryMessages(
+  messages: unknown[],
+  showToolCalls: boolean,
+  successfulMessageToolCallIds: Set<string>,
+): number {
   let count = 0;
   for (const message of messages) {
-    if (!isHiddenToolMessage(message, showToolCalls)) {
+    if (!isHiddenToolMessage(message, showToolCalls, successfulMessageToolCallIds)) {
       count += 1;
     }
   }
   return count;
 }
 
-function resolveHistoryStartIndex(messages: unknown[], showToolCalls: boolean): number {
+function resolveHistoryStartIndex(
+  messages: unknown[],
+  showToolCalls: boolean,
+  successfulMessageToolCallIds: Set<string>,
+): number {
   let visibleCount = 0;
   let renderChars = 0;
   let startIndex = messages.length;
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index];
-    if (isHiddenToolMessage(message, showToolCalls)) {
+    if (isHiddenToolMessage(message, showToolCalls, successfulMessageToolCallIds)) {
       continue;
     }
     if (visibleCount >= CHAT_HISTORY_RENDER_LIMIT) {
@@ -620,14 +635,20 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
     text: string | null;
     timestamp: number | null;
   }>;
-  const historyStart = resolveHistoryStartIndex(history, props.showToolCalls);
+  const historyStart = resolveHistoryStartIndex(
+    history,
+    props.showToolCalls,
+    successfulMessageToolCallIds,
+  );
   const hiddenHistoryCount = countVisibleHistoryMessages(
     history.slice(0, historyStart),
     props.showToolCalls,
+    successfulMessageToolCallIds,
   );
   const visibleHistoryCount = countVisibleHistoryMessages(
     history.slice(historyStart),
     props.showToolCalls,
+    successfulMessageToolCallIds,
   );
   if (hiddenHistoryCount > 0) {
     items.push({
@@ -667,12 +688,22 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
       continue;
     }
 
-    if (!props.showToolCalls && normalized.role.toLowerCase() === "toolresult") {
-      continue;
-    }
-
     const searchQuery = props.searchQuery ?? "";
     if (props.searchOpen && searchQuery.trim() && !messageMatchesSearchQuery(msg, searchQuery)) {
+      continue;
+    }
+    const visibleMessageToolReply = extractMessageToolVisibleReply(
+      msg,
+      successfulMessageToolCallIds,
+    );
+    if (!props.showToolCalls && normalized.role.toLowerCase() === "toolresult") {
+      if (visibleMessageToolReply) {
+        items.push({
+          kind: "message",
+          key: `${messageKey(msg, i)}:message-tool-visible-reply`,
+          message: projectedMessageToolReply(msg, visibleMessageToolReply),
+        });
+      }
       continue;
     }
     if (!hasRenderableNormalizedMessage(msg) && normalized.role.toLowerCase() !== "assistant") {
@@ -684,10 +715,6 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
       key: messageKey(msg, i),
       message: msg,
     });
-    const visibleMessageToolReply = extractMessageToolVisibleReply(
-      msg,
-      successfulMessageToolCallIds,
-    );
     if (visibleMessageToolReply) {
       items.push({
         kind: "message",


### PR DESCRIPTION
## Summary
- Problem: Control UI history renders visible replies sent through `message(action="send")` only as tool call/tool result blocks.
- Why it matters: in WebChat direct conversations that require visible delivery through the `message` tool, the user sees implementation plumbing instead of a normal assistant bubble.
- What changed: successful `message(action="send")` tool calls are projected into a synthetic assistant text bubble while the original tool blocks remain available for debugging.
- What did NOT change (scope boundary): message delivery, channel routing, tool execution, and failed `message` sends are unchanged.

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [x] UI / DX

## Linked Issue/PR
- Closes #83494
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)
- Behavior or issue addressed: WebChat/OpenClaw Control UI showed visible assistant replies delivered through `message(action="send")` as tool plumbing instead of also showing the sent text as an assistant chat bubble.
- Real environment tested: local OpenClaw checkout from this PR on macOS 26.3, Node v25.8.1, using the Control UI chat renderer against a redacted real WebChat `message` tool payload shape observed in OpenClaw.
- Exact steps or command run after this patch: bundled the patched `ui/src/ui/chat/build-chat-items.ts` with `node_modules/.bin/esbuild`, then ran Node against a redacted successful `message(action="send")` assistant tool call plus matching successful `toolName: "message"` result.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
$ node_modules/.bin/esbuild ui/src/ui/chat/build-chat-items.ts --bundle --platform=node --format=esm --outfile="$tmpdir/build-chat-items.mjs"
.../build-chat-items.mjs  231.1kb

$ node --input-type=module
[
  {
    "kind": "group",
    "key": "group:tool:msg:assistant:0",
    "role": "tool",
    "messages": [
      {
        "message": {
          "role": "assistant",
          "content": [
            {
              "type": "toolCall",
              "id": "call_msg_1",
              "name": "message",
              "arguments": {
                "action": "send",
                "message": "Monsieur, c’est traité côté amont."
              }
            }
          ]
        }
      }
    ]
  },
  {
    "kind": "group",
    "key": "group:assistant:msg:assistant:0:message-tool-visible-reply",
    "role": "assistant",
    "messages": [
      {
        "message": {
          "role": "assistant",
          "content": [
            {
              "type": "text",
              "text": "Monsieur, c’est traité côté amont."
            }
          ]
        }
      }
    ]
  },
  {
    "kind": "group",
    "key": "group:tool:tool:tool:call_msg_1:1",
    "role": "tool",
    "messages": [
      {
        "message": {
          "role": "tool",
          "toolCallId": "call_msg_1",
          "toolName": "message",
          "content": [
            {
              "type": "text",
              "text": "{\"ok\":true,\"messageId\":\"redacted\",\"chatId\":\"redacted\"}"
            }
          ]
        }
      }
    ]
  }
]
```

- Observed result after fix: the renderer now returns a normal assistant group containing the sent text between the original `message` tool call and its successful tool result, so the chat can render a readable assistant bubble while preserving the debug blocks.
- What was not tested: a full browser screenshot against a rebuilt installed Control UI bundle was not captured in this environment.
- Before evidence (optional but encouraged): the reporter observed this exact WebChat path in OpenClaw Control UI: `message(action="send")` replies were stored/rendered as `toolCall name="message"` followed by a `messageId/chatId` tool result, without a normal assistant bubble.

## Root Cause (if applicable)
- Root cause: `buildChatItems` treated assistant `message` tool calls like ordinary tool calls and had no projection step for successful visible sends.
- Missing detection / guardrail: no chat item unit covered successful visible `message(action="send")` turns.
- Contributing context (if known): WebChat direct conversations can require visible replies through the `message` tool, which makes the tool-call-only rendering user-visible.

## Regression Test Plan (if applicable)
- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `ui/src/ui/chat/build-chat-items.test.ts`
- Scenario the test should lock in: successful `message(action="send")` tool calls with successful `message` tool results produce an assistant text bubble; failed sends do not.
- Why this is the smallest reliable guardrail: the bug is isolated to chat history item construction, before rendering.
- Existing test that already covers this (if any): none.

## User-visible / Behavior Changes
Control UI chat history shows successful visible `message(action="send")` replies as normal assistant bubbles in addition to the debug tool blocks.

## Diagram (if applicable)
```text
Before:
assistant message toolCall -> tool result -> visible tool plumbing only

After:
assistant message toolCall -> assistant text bubble -> tool result
```

## Security Impact (required)
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment
- OS: macOS 26.3
- Runtime/container: local checkout, Node v25.8.1
- Model/provider: N/A
- Integration/channel (if any): WebChat / OpenClaw `message` tool
- Relevant config (redacted): direct WebChat conversation, redacted messageId/chatId

### Steps
1. Feed `buildChatItems` an assistant `message(action="send")` tool call with `arguments.message`.
2. Feed the matching successful `toolName: "message"` result.
3. Inspect returned chat item groups.

### Expected
- The sent text appears as an assistant text bubble.
- Tool call/result blocks remain available for debugging.
- Failed sends are not projected as assistant bubbles.

### Actual
- After this patch, the expected behavior is observed.

## Tests
- `CI=1 ../node_modules/.bin/vitest run --config vitest.config.ts src/ui/chat/build-chat-items.test.ts --reporter=verbose --pool=forks --maxWorkers=1 --testTimeout=10000 --teardownTimeout=1000`
- Result: 24 tests passed.
