### PR TITLE
fix: echo xAI OAuth PKCE challenge on token exchange

### DIFF
--- a/extensions/xai/xai-oauth.test.ts
+++ b/extensions/xai/xai-oauth.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  buildXaiOAuthAuthorizationCodeTokenBody,
   buildXaiOAuthAuthorizeUrl,
   fetchXaiOAuthDiscovery,
   isTrustedXaiOAuthEndpoint,
@@ -54,6 +55,24 @@ describe("xAI OAuth", () => {
     expect(url.searchParams.get("plan")).toBe("generic");
     expect(url.searchParams.get("referrer")).toBe("openclaw");
     expect(XAI_OAUTH_REDIRECT_URI).toContain(`:${XAI_OAUTH_CALLBACK_PORT}/`);
+  });
+
+  it("echoes PKCE challenge fields when exchanging authorization codes with xAI", () => {
+    expect(
+      buildXaiOAuthAuthorizationCodeTokenBody({
+        code: "AUTHCODE",
+        codeVerifier: "verifier-1",
+        codeChallenge: "challenge-1",
+      }),
+    ).toEqual({
+      grant_type: "authorization_code",
+      code: "AUTHCODE",
+      redirect_uri: XAI_OAUTH_REDIRECT_URI,
+      client_id: XAI_OAUTH_CLIENT_ID,
+      code_verifier: "verifier-1",
+      code_challenge: "challenge-1",
+      code_challenge_method: "S256",
+    });
   });
 
   it("validates discovered endpoints before using them", async () => {

--- a/extensions/xai/xai-oauth.ts
+++ b/extensions/xai/xai-oauth.ts
@@ -145,6 +145,23 @@ export function buildXaiOAuthAuthorizeUrl(params: {
   return url.toString();
 }
 
+export function buildXaiOAuthAuthorizationCodeTokenBody(params: {
+  code: string;
+  codeVerifier: string;
+  codeChallenge: string;
+}): Record<string, string> {
+  return {
+    grant_type: "authorization_code",
+    code: params.code,
+    redirect_uri: XAI_OAUTH_REDIRECT_URI,
+    client_id: XAI_OAUTH_CLIENT_ID,
+    code_verifier: params.codeVerifier,
+    // xAI validates these PKCE fields again at token exchange for this client.
+    code_challenge: params.codeChallenge,
+    code_challenge_method: "S256",
+  };
+}
+
 function normalizeExpires(value: unknown, now: () => number): number | undefined {
   const seconds =
     typeof value === "number"
@@ -312,13 +329,11 @@ export async function loginXaiOAuth(ctx: ProviderAuthContext): Promise<ProviderA
       tokenEndpoint: discovery.tokenEndpoint,
       context: "xAI OAuth token exchange",
       requireRefreshToken: true,
-      body: {
-        grant_type: "authorization_code",
+      body: buildXaiOAuthAuthorizationCodeTokenBody({
         code: callback.code,
-        redirect_uri: XAI_OAUTH_REDIRECT_URI,
-        client_id: XAI_OAUTH_CLIENT_ID,
-        code_verifier: pkce.verifier,
-      },
+        codeVerifier: pkce.verifier,
+        codeChallenge: pkce.challenge,
+      }),
     });
     const identity = resolveXaiOAuthIdentity(tokens);
     progress.stop("xAI OAuth complete");


### PR DESCRIPTION
## Summary

- Echo `code_challenge` and `code_challenge_method=S256` in the xAI authorization-code token POST, alongside the existing `code_verifier`.
- Add focused regression coverage for the xAI token request body.
- Leave the xAI refresh-token exchange unchanged.

## Why

xAI can reject the authorization-code token exchange with `code_challenge is required` unless the original PKCE challenge is included at the token endpoint. Standard PKCE only requires `code_verifier`, but sending the challenge fields is accepted by OAuth token endpoints and fixes this xAI compatibility failure.

## Real behavior proof

- **Behavior or issue addressed**: xAI OAuth authorization-code token exchange now sends the PKCE verifier plus the echoed PKCE challenge and method expected by xAI.
- **Real environment tested**: Local OpenClaw PR worktree on macOS, branch `codex/xai-oauth-pkce-token-fields`, after `pnpm build` produced `dist/extensions/xai/xai-oauth.js`.
- **Exact steps or command run after this patch**:

```bash
pnpm build
node -e "import('./dist/extensions/xai/xai-oauth.js').then(({ buildXaiOAuthAuthorizationCodeTokenBody }) => { const body = buildXaiOAuthAuthorizationCodeTokenBody({ code: 'AUTHCODE-redacted', codeVerifier: 'VERIFIER-redacted', codeChallenge: 'CHALLENGE-redacted' }); console.log(JSON.stringify(body, null, 2)); })"
```

- **Evidence after fix**:

```json
{
  "grant_type": "authorization_code",
  "code": "AUTHCODE-redacted",
  "redirect_uri": "http://127.0.0.1:56121/callback",
  "client_id": "b1a00492-073a-47ea-816f-4c329264a828",
  "code_verifier": "VERIFIER-redacted",
  "code_challenge": "CHALLENGE-redacted",
  "code_challenge_method": "S256"
}
```

- **Observed result after fix**: The built OpenClaw xAI OAuth module returns an authorization-code token body that includes `code_verifier`, `code_challenge`, and `code_challenge_method=S256`.
- **What was not tested**: A live browser login against a real xAI account/token redemption was not completed locally.

## Testing

- `pnpm exec vitest run --config test/vitest/vitest.extension-providers.config.ts --reporter=dot`
  - `172 passed | 1 skipped` test files
  - `1555 passed | 1 skipped` tests
- `pnpm build`
