### PR TITLE
fix(tui): bound standalone exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 - Codex app-server: preserve network access for sandboxed Codex code-mode turns when the OpenClaw sandbox allows outbound egress. Fixes #83347. Thanks @YusukeIt0.
 - QA-Lab: keep the OTLP smoke decoder independent of removed OpenTelemetry generated-root internals.
 - Messages: default group/channel visible replies to automatic final delivery again, keeping `message_tool` opt-in for ambient/shared rooms and tool-reliable models.
+- CLI/TUI: force standalone `/exit` runs to terminate after `runTui` returns so onboarding-launched TUI children do not stay alive invisibly. (#83501) Thanks @fuller-stack-dev.
 - Agents/code mode: preserve agent, session, run, and channel context in `before_tool_call` hooks for top-level `exec`/`wait` dispatches. Fixes #83387.
 - Replies: keep final payload delivery after live preview updates so channels can finalize or send the completed answer instead of losing preview-only drafts. (#83468)
 - Discord: deliver final replies in progress-mode preview streams instead of deduplicating the final visible message. (#83443) Thanks @compoodment.

--- a/src/cli/program.smoke.test.ts
+++ b/src/cli/program.smoke.test.ts
@@ -60,8 +60,12 @@ describe("cli program (smoke)", () => {
 
   it("runs tui with explicit timeout override", async () => {
     await runProgram(["tui", "--timeout-ms", "45000"]);
-    const options = firstMockArg(runTui) as { timeoutMs?: number };
+    const options = firstMockArg(runTui) as {
+      timeoutMs?: number;
+      forceProcessExitOnReturn?: boolean;
+    };
     expect(options?.timeoutMs).toBe(45000);
+    expect(options?.forceProcessExitOnReturn).toBe(true);
   });
 
   it("runs crestodian one-shot requests", async () => {

--- a/src/cli/tui-cli.ts
+++ b/src/cli/tui-cli.ts
@@ -54,6 +54,7 @@ export function registerTuiCli(program: Command) {
           message: opts.message as string | undefined,
           timeoutMs,
           historyLimit: Number.isNaN(historyLimit) ? undefined : historyLimit,
+          forceProcessExitOnReturn: true,
         });
       } catch (err) {
         defaultRuntime.error(String(err));

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -334,6 +334,17 @@ describe("tui command handlers", () => {
     });
   });
 
+  it("handles /exit without sending through the gateway", async () => {
+    const { handleCommand, requestExit, sendChat, addUser, addSystem } = createHarness();
+
+    await handleCommand("/exit");
+
+    expect(requestExit).toHaveBeenCalledTimes(1);
+    expect(sendChat).not.toHaveBeenCalled();
+    expect(addUser).not.toHaveBeenCalled();
+    expect(addSystem).not.toHaveBeenCalled();
+  });
+
   it("leaves a Crestodian breadcrumb after switching agents", async () => {
     const { handleCommand, addSystem, setSession, state } = createHarness();
 

--- a/src/tui/tui-types.ts
+++ b/src/tui/tui-types.ts
@@ -9,6 +9,11 @@ export type TuiOptions = {
   timeoutMs?: number;
   historyLimit?: number;
   message?: string;
+  /**
+   * Internal CLI guard: after the standalone TUI returns, force the child
+   * process out if imported runtime handles keep the event loop alive.
+   */
+  forceProcessExitOnReturn?: boolean;
 };
 
 export type TuiExitReason = "exit" | "return-to-crestodian";

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -420,7 +420,7 @@ describe("TUI shutdown safety", () => {
     const setTimeoutFn = vi.fn((fn: () => void, ms: number) => {
       callback = fn;
       expect(ms).toBe(2000);
-      return { unref } as ReturnType<typeof setTimeout>;
+      return { unref };
     });
     const exit = vi.fn();
     const writeStderr = vi.fn();

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -20,6 +20,7 @@ import {
   resolveLocalAuthSpawnOptions,
   resolveTuiCtrlCAction,
   resolveTuiSessionKey,
+  scheduleProcessExitAfterTuiReturn,
   stopTuiSafely,
 } from "./tui.js";
 
@@ -411,6 +412,26 @@ describe("TUI shutdown safety", () => {
 
     deferredFinish.setFinish(finish);
     expect(finish).toHaveBeenCalledTimes(1);
+  });
+
+  it("schedules a process-exit guard after standalone TUI return", () => {
+    let callback: (() => void) | undefined;
+    const unref = vi.fn();
+    const setTimeoutFn = vi.fn((fn: () => void, ms: number) => {
+      callback = fn;
+      expect(ms).toBe(2000);
+      return { unref } as ReturnType<typeof setTimeout>;
+    });
+    const exit = vi.fn();
+    const writeStderr = vi.fn();
+
+    scheduleProcessExitAfterTuiReturn({ setTimeoutFn, exit, writeStderr });
+
+    expect(setTimeoutFn).toHaveBeenCalledOnce();
+    expect(unref).toHaveBeenCalledOnce();
+    callback?.();
+    expect(writeStderr).toHaveBeenCalledWith("openclaw tui forcing process exit after return\n");
+    expect(exit).toHaveBeenCalledWith(0);
   });
 });
 

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -346,6 +346,7 @@ type DrainableTui = {
 const TUI_SHUTDOWN_DRAIN_MAX_MS = 500;
 const TUI_SHUTDOWN_DRAIN_IDLE_MS = 100;
 const TUI_SHUTDOWN_HARD_EXIT_MS = 2000;
+const TUI_PROCESS_EXIT_AFTER_RETURN_MS = 2000;
 
 export async function drainAndStopTuiSafely(tui: DrainableTui): Promise<void> {
   if (typeof tui.terminal?.drainInput === "function") {
@@ -356,6 +357,34 @@ export async function drainAndStopTuiSafely(tui: DrainableTui): Promise<void> {
     }
   }
   stopTuiSafely(() => tui.stop());
+}
+
+export function scheduleProcessExitAfterTuiReturn(
+  params: {
+    delayMs?: number;
+    setTimeoutFn?: typeof setTimeout;
+    exit?: (code?: number) => never | void;
+    writeStderr?: (text: string) => void;
+  } = {},
+): ReturnType<typeof setTimeout> {
+  const delayMs = Math.max(0, Math.floor(params.delayMs ?? TUI_PROCESS_EXIT_AFTER_RETURN_MS));
+  const setTimeoutFn = params.setTimeoutFn ?? setTimeout;
+  const exit = params.exit ?? ((code?: number) => process.exit(code));
+  const writeStderr =
+    params.writeStderr ??
+    ((text: string) => {
+      process.stderr.write(text);
+    });
+  const timer = setTimeoutFn(() => {
+    try {
+      writeStderr("openclaw tui forcing process exit after return\n");
+    } catch {
+      // Best effort only; forced exit must not depend on stderr.
+    }
+    exit(0);
+  }, delayMs);
+  timer.unref?.();
+  return timer;
 }
 
 type CtrlCAction = "clear" | "warn" | "exit";
@@ -1380,5 +1409,8 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     process.once("exit", finish);
     deferredFinish.setFinish(finish);
   });
+  if (opts.forceProcessExitOnReturn === true) {
+    scheduleProcessExitAfterTuiReturn();
+  }
   return exitResult;
 }

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -348,6 +348,12 @@ const TUI_SHUTDOWN_DRAIN_IDLE_MS = 100;
 const TUI_SHUTDOWN_HARD_EXIT_MS = 2000;
 const TUI_PROCESS_EXIT_AFTER_RETURN_MS = 2000;
 
+type TuiProcessExitTimer = {
+  unref?: () => void;
+};
+
+type TuiProcessExitTimeout = (callback: () => void, delayMs: number) => TuiProcessExitTimer;
+
 export async function drainAndStopTuiSafely(tui: DrainableTui): Promise<void> {
   if (typeof tui.terminal?.drainInput === "function") {
     try {
@@ -362,13 +368,15 @@ export async function drainAndStopTuiSafely(tui: DrainableTui): Promise<void> {
 export function scheduleProcessExitAfterTuiReturn(
   params: {
     delayMs?: number;
-    setTimeoutFn?: typeof setTimeout;
+    setTimeoutFn?: TuiProcessExitTimeout;
     exit?: (code?: number) => never | void;
     writeStderr?: (text: string) => void;
   } = {},
-): ReturnType<typeof setTimeout> {
+): TuiProcessExitTimer {
   const delayMs = Math.max(0, Math.floor(params.delayMs ?? TUI_PROCESS_EXIT_AFTER_RETURN_MS));
-  const setTimeoutFn = params.setTimeoutFn ?? setTimeout;
+  const setTimeoutFn =
+    params.setTimeoutFn ??
+    ((callback, timeoutMs) => setTimeout(callback, timeoutMs) as unknown as TuiProcessExitTimer);
   const exit = params.exit ?? ((code?: number) => process.exit(code));
   const writeStderr =
     params.writeStderr ??


### PR DESCRIPTION
## Summary
- Adds a standalone TUI post-return exit guard so `/exit` cannot leave an onboarding-launched `openclaw-tui` child alive after the visible UI stops.
- Enables the guard only for the CLI TUI command and adds regression coverage for both the `/exit` command path and the CLI option wiring.
- Narrows the injectable timer type used by the guard test so `check:test-types` accepts the fake timer without pretending it is a full Node timeout.

## Verification
- `node scripts/run-vitest.mjs src/tui/tui.test.ts src/tui/tui-command-handlers.test.ts src/cli/program.smoke.test.ts src/tui/tui-launch.test.ts`
- `git diff --check -- src/tui/tui.ts src/tui/tui.test.ts src/tui/tui-types.ts src/cli/tui-cli.ts src/tui/tui-command-handlers.test.ts src/cli/program.smoke.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

## Real behavior proof
Behavior addressed: `/exit` in the standalone TUI can no longer leave the onboarding-launched `openclaw-tui` child alive after the UI stops.
Real environment tested: Local macOS source checkout on this patched branch using a real PTY-backed standalone TUI run and a unique session id.
Exact steps or command run after this patch: Spawned `node --import tsx src/entry.ts tui --local --session pr83501-exit-proof-1779090974` in `/usr/bin/expect`, waited until the TUI printed `local ready`, sent `/exit`, waited for EOF, then ran `pgrep -fl pr83501-exit-proof-1779090974`.
Evidence after fix: Terminal transcript from the live run:

```text
proof_id=pr83501-exit-proof-1779090974
spawning node --import tsx src/entry.ts tui --local --session pr83501-exit-proof-1779090974
spawned_pid=52341
OpenClaw 2026.5.17 (92dfa38)
openclaw tui - local embedded - agent main - session pr83501-exit-proof-1779090974
local ready | idle
tui_ready=observed
sending=/exit
session agent:main:pr83501-exit-proof-1779090974
local ready | idle
openclaw tui forcing process exit after return
tui_eof=observed
wait_result=52341 exp5 0 0
expect_exit=0
matching_processes_after=
```
Observed result after fix: The TUI accepted `/exit`, returned EOF to the controlling PTY, exited with status 0, and no process matching the unique proof session id remained after the command returned.
What was not tested: Packaged onboarding wrapper replay was not rerun; the standalone TUI process path that onboarding waits on was exercised directly.
