### PR TITLE
fix: harden release stability recovery and auth fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Codex app-server: hydrate current inbound image attachments before queued runs so Responses-backed agents receive Discord and other channel images as native vision input. Fixes #83466. Thanks @iannwu.
+- Release stability: recover stale session diagnostics and Codex OAuth fallback state so stuck runs and reused refresh tokens clear without blocking follow-up work. (#83503) Thanks @100yenadmin.
 - Codex app-server: preserve network access for sandboxed Codex code-mode turns when the OpenClaw sandbox allows outbound egress. Fixes #83347. Thanks @YusukeIt0.
 - QA-Lab: keep the OTLP smoke decoder independent of removed OpenTelemetry generated-root internals.
 - Messages: default group/channel visible replies to automatic final delivery again, keeping `message_tool` opt-in for ambient/shared rooms and tool-reliable models.

--- a/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
+++ b/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
@@ -734,6 +734,55 @@ describe("resolveApiKeyForProfile openai-codex refresh fallback", () => {
     expect(getOAuthApiKeyMock).toHaveBeenCalledTimes(1);
   });
 
+  it("clears stale lastGood before selecting an alternate Codex OAuth profile", async () => {
+    const staleProfileId = "openai-codex:default";
+    const healthyProfileId = "openai-codex:user@example.test";
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          [staleProfileId]: {
+            type: "oauth",
+            provider: "openai-codex",
+            access: "stale-access-token",
+            refresh: "stale-refresh-token",
+            expires: Date.now() - 60_000,
+          },
+          [healthyProfileId]: {
+            type: "oauth",
+            provider: "openai-codex",
+            access: "healthy-access-token",
+            refresh: "healthy-refresh-token",
+            expires: Date.now() + 60 * 60_000,
+            email: "user@example.test",
+          },
+        },
+        lastGood: { "openai-codex": staleProfileId },
+      },
+      agentDir,
+    );
+    getOAuthApiKeyMock.mockImplementationOnce(async () => {
+      throw new Error(
+        '401 {"error":{"message":"Your refresh token has already been used to generate a new access token.","code":"refresh_token_reused"}}',
+      );
+    });
+
+    await expect(
+      resolveApiKeyForProfile({
+        store: ensureAuthProfileStore(agentDir),
+        profileId: staleProfileId,
+        agentDir,
+      }),
+    ).resolves.toEqual({
+      apiKey: "healthy-access-token",
+      provider: "openai-codex",
+      email: "user@example.test",
+    });
+
+    expect(getOAuthApiKeyMock).toHaveBeenCalledTimes(1);
+    expect((await readPersistedStore(agentDir)).lastGood).toBeUndefined();
+  });
+
   it("retries Codex refresh once after refresh_token_reused updates only the stored refresh token", async () => {
     const profileId = "openai-codex:default";
     saveAuthProfileStore(

--- a/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
+++ b/src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts
@@ -12,6 +12,8 @@ import {
 } from "./store.js";
 import type { AuthProfileStore, OAuthCredential } from "./types.js";
 let resolveApiKeyForProfile: typeof import("./oauth.js").resolveApiKeyForProfile;
+let resolveApiKeyForProvider: typeof import("../model-auth.js").resolveApiKeyForProvider;
+let markAuthProfileSuccess: typeof import("./profiles.js").markAuthProfileSuccess;
 type GetOAuthApiKey = typeof import("@earendil-works/pi-ai/oauth").getOAuthApiKey;
 
 const { getOAuthApiKeyMock } = vi.hoisted(() => ({
@@ -60,7 +62,10 @@ vi.mock("../../plugins/provider-runtime.runtime.js", () => ({
 }));
 
 vi.mock("../../plugins/provider-runtime.js", () => ({
+  buildProviderMissingAuthMessageWithPlugin: () => undefined,
   resolveExternalAuthProfilesWithPlugins: () => [],
+  resolveProviderSyntheticAuthWithPlugin: () => undefined,
+  shouldDeferProviderSyntheticProfileAuthWithPlugin: () => false,
 }));
 
 afterAll(() => {
@@ -134,6 +139,8 @@ describe("resolveApiKeyForProfile openai-codex refresh fallback", () => {
   beforeAll(async () => {
     tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-refresh-fallback-"));
     ({ resolveApiKeyForProfile } = await import("./oauth.js"));
+    ({ resolveApiKeyForProvider } = await import("../model-auth.js"));
+    ({ markAuthProfileSuccess } = await import("./profiles.js"));
   });
 
   beforeEach(async () => {
@@ -781,6 +788,61 @@ describe("resolveApiKeyForProfile openai-codex refresh fallback", () => {
 
     expect(getOAuthApiKeyMock).toHaveBeenCalledTimes(1);
     expect((await readPersistedStore(agentDir)).lastGood).toBeUndefined();
+  });
+
+  it("reports the alternate Codex OAuth profile after stale lastGood fallback", async () => {
+    const staleProfileId = "openai-codex:default";
+    const healthyProfileId = "openai-codex:user@example.test";
+    saveAuthProfileStore(
+      {
+        version: 1,
+        profiles: {
+          [staleProfileId]: {
+            type: "oauth",
+            provider: "openai-codex",
+            access: "stale-access-token",
+            refresh: "stale-refresh-token",
+            expires: Date.now() - 60_000,
+          },
+          [healthyProfileId]: {
+            type: "oauth",
+            provider: "openai-codex",
+            access: "healthy-access-token",
+            refresh: "healthy-refresh-token",
+            expires: Date.now() + 60 * 60_000,
+            email: "user@example.test",
+          },
+        },
+        lastGood: { "openai-codex": staleProfileId },
+      },
+      agentDir,
+    );
+    getOAuthApiKeyMock.mockImplementationOnce(async () => {
+      throw new Error(
+        '401 {"error":{"message":"Your refresh token has already been used to generate a new access token.","code":"refresh_token_reused"}}',
+      );
+    });
+
+    const resolved = await resolveApiKeyForProvider({
+      provider: "openai-codex",
+      store: ensureAuthProfileStore(agentDir),
+      agentDir,
+    });
+
+    expect(resolved).toMatchObject({
+      apiKey: "healthy-access-token",
+      profileId: healthyProfileId,
+      source: `profile:${healthyProfileId}`,
+      mode: "oauth",
+    });
+
+    await markAuthProfileSuccess({
+      store: ensureAuthProfileStore(agentDir),
+      provider: "openai-codex",
+      profileId: resolved.profileId ?? "",
+      agentDir,
+    });
+    expect(ensureAuthProfileStore(agentDir).lastGood?.["openai-codex"]).toBe(healthyProfileId);
   });
 
   it("retries Codex refresh once after refresh_token_reused updates only the stored refresh token", async () => {

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -16,6 +16,7 @@ import { resolveSecretRefString, type SecretRefResolveCache } from "../../secret
 import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
 import { normalizeOptionalSecretInput } from "../../utils/normalize-secret-input.js";
 import { refreshChutesTokens } from "../chutes-oauth.js";
+import { resolveProviderIdForAuth } from "../provider-auth-aliases.js";
 import { log } from "./constants.js";
 import { resolveTokenExpiryState } from "./credential-state.js";
 import { formatAuthDoctorHint } from "./doctor.js";
@@ -25,8 +26,17 @@ import {
 } from "./external-cli-sync.js";
 import { createOAuthManager, OAuthManagerRefreshError } from "./oauth-manager.js";
 import { assertNoOAuthSecretRefPolicyViolations } from "./policy.js";
+import { clearLastGoodProfileWithLock } from "./profiles.js";
 import { suggestOAuthProfileIdForLegacyDefault } from "./repair.js";
-import { loadAuthProfileStoreForSecretsRuntime } from "./store.js";
+import {
+  getRuntimeAuthProfileStoreSnapshot,
+  hasRuntimeAuthProfileStoreSnapshot,
+  setRuntimeAuthProfileStoreSnapshot,
+} from "./runtime-snapshots.js";
+import {
+  loadAuthProfileStoreForSecretsRuntime,
+  resolvePersistedAuthProfileOwnerAgentDir,
+} from "./store.js";
 import type { AuthProfileStore, OAuthCredential } from "./types.js";
 
 export {
@@ -378,7 +388,7 @@ export async function resolveApiKeyForProfile(
       email: resolved.credential.email ?? cred.email,
     });
   } catch (error) {
-    const refreshedStore =
+    let refreshedStore =
       error instanceof OAuthManagerRefreshError
         ? error.getRefreshedStore()
         : loadAuthProfileStoreForSecretsRuntime(params.agentDir);
@@ -388,6 +398,32 @@ export async function resolveApiKeyForProfile(
       error instanceof OAuthManagerRefreshError && error.code === "refresh_contention"
         ? error
         : surfacedCause;
+    if (isRefreshTokenReusedError(surfacedCause)) {
+      const ownerAgentDir = resolvePersistedAuthProfileOwnerAgentDir({
+        agentDir: params.agentDir,
+        profileId,
+      });
+      await clearLastGoodProfileWithLock({
+        provider: cred.provider,
+        profileId,
+        agentDir: ownerAgentDir,
+      });
+      if (
+        params.agentDir !== ownerAgentDir &&
+        hasRuntimeAuthProfileStoreSnapshot(params.agentDir)
+      ) {
+        const snapshot = getRuntimeAuthProfileStoreSnapshot(params.agentDir);
+        const providerKey = resolveProviderIdForAuth(cred.provider);
+        if (snapshot?.lastGood?.[providerKey] === profileId) {
+          delete snapshot.lastGood[providerKey];
+          if (Object.keys(snapshot.lastGood).length === 0) {
+            snapshot.lastGood = undefined;
+          }
+          setRuntimeAuthProfileStoreSnapshot(snapshot, params.agentDir);
+        }
+      }
+      refreshedStore = loadAuthProfileStoreForSecretsRuntime(params.agentDir);
+    }
     const fallbackProfileId = suggestOAuthProfileIdForLegacyDefault({
       cfg,
       store: refreshedStore,

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -37,7 +37,7 @@ import {
   loadAuthProfileStoreForSecretsRuntime,
   resolvePersistedAuthProfileOwnerAgentDir,
 } from "./store.js";
-import type { AuthProfileStore, OAuthCredential } from "./types.js";
+import type { AuthProfileCredential, AuthProfileStore, OAuthCredential } from "./types.js";
 
 export {
   isSafeToCopyOAuthIdentity,
@@ -120,12 +120,37 @@ async function buildOAuthApiKey(
   return typeof formatted === "string" && formatted.length > 0 ? formatted : credentials.access;
 }
 
-function buildApiKeyProfileResult(params: { apiKey: string; provider: string; email?: string }) {
-  return {
+type ResolveApiKeyForProfileResult = {
+  apiKey: string;
+  provider: string;
+  email?: string;
+  profileId: string;
+  profileType: AuthProfileCredential["type"];
+};
+
+function buildApiKeyProfileResult(params: {
+  apiKey: string;
+  provider: string;
+  email?: string;
+  profileId: string;
+  profileType: AuthProfileCredential["type"];
+}): ResolveApiKeyForProfileResult {
+  const result = {
     apiKey: params.apiKey,
     provider: params.provider,
     email: params.email,
   };
+  Object.defineProperties(result, {
+    profileId: {
+      value: params.profileId,
+      enumerable: false,
+    },
+    profileType: {
+      value: params.profileType,
+      enumerable: false,
+    },
+  });
+  return result as ResolveApiKeyForProfileResult;
 }
 
 function extractErrorMessage(error: unknown): string {
@@ -214,7 +239,7 @@ export function resetOAuthRefreshQueuesForTest(): void {
 
 async function tryResolveOAuthProfile(
   params: ResolveApiKeyForProfileParams,
-): Promise<{ apiKey: string; provider: string; email?: string } | null> {
+): Promise<ResolveApiKeyForProfileResult | null> {
   const { cfg, store, profileId } = params;
   const cred = store.profiles[profileId];
   if (!cred || cred.type !== "oauth") {
@@ -246,6 +271,8 @@ async function tryResolveOAuthProfile(
     apiKey: resolved.apiKey,
     provider: resolved.credential.provider,
     email: resolved.credential.email ?? cred.email,
+    profileId,
+    profileType: cred.type,
   });
 }
 
@@ -302,7 +329,7 @@ async function resolveProfileSecretString(params: {
 
 export async function resolveApiKeyForProfile(
   params: ResolveApiKeyForProfileParams,
-): Promise<{ apiKey: string; provider: string; email?: string } | null> {
+): Promise<ResolveApiKeyForProfileResult | null> {
   const { cfg, store, profileId } = params;
   const cred = store.profiles[profileId];
   if (!cred) {
@@ -346,7 +373,13 @@ export async function resolveApiKeyForProfile(
     if (!key) {
       return null;
     }
-    return buildApiKeyProfileResult({ apiKey: key, provider: cred.provider, email: cred.email });
+    return buildApiKeyProfileResult({
+      apiKey: key,
+      provider: cred.provider,
+      email: cred.email,
+      profileId,
+      profileType: cred.type,
+    });
   }
   if (cred.type === "token") {
     const expiryState = resolveTokenExpiryState(cred.expires);
@@ -367,7 +400,13 @@ export async function resolveApiKeyForProfile(
     if (!token) {
       return null;
     }
-    return buildApiKeyProfileResult({ apiKey: token, provider: cred.provider, email: cred.email });
+    return buildApiKeyProfileResult({
+      apiKey: token,
+      provider: cred.provider,
+      email: cred.email,
+      profileId,
+      profileType: cred.type,
+    });
   }
 
   try {
@@ -386,6 +425,8 @@ export async function resolveApiKeyForProfile(
       apiKey: resolved.apiKey,
       provider: resolved.credential.provider,
       email: resolved.credential.email ?? cred.email,
+      profileId,
+      profileType: cred.type,
     });
   } catch (error) {
     let refreshedStore =

--- a/src/agents/auth-profiles/profiles.test.ts
+++ b/src/agents/auth-profiles/profiles.test.ts
@@ -5,7 +5,11 @@ import { describe, expect, it } from "vitest";
 import { resolveOAuthDir } from "../../config/paths.js";
 import { AUTH_STORE_VERSION } from "./constants.js";
 import { resolveAuthStorePath } from "./paths.js";
-import { promoteAuthProfileInOrder, upsertAuthProfileWithLock } from "./profiles.js";
+import {
+  clearLastGoodProfileWithLock,
+  promoteAuthProfileInOrder,
+  upsertAuthProfileWithLock,
+} from "./profiles.js";
 import {
   clearRuntimeAuthProfileStoreSnapshots,
   loadAuthProfileStoreForRuntime,
@@ -353,6 +357,92 @@ describe("promoteAuthProfileInOrder", () => {
         newProfileId,
         staleProfileId,
       ]);
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("clears matching lastGood after a stale refresh_token_reused profile", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-clear-lastgood-"));
+    const agentDir = path.join(stateDir, "agents", "main", "agent");
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    try {
+      fs.mkdirSync(agentDir, { recursive: true });
+      const staleProfileId = "openai-codex:default";
+      saveAuthProfileStore(
+        {
+          version: AUTH_STORE_VERSION,
+          profiles: {
+            [staleProfileId]: {
+              type: "oauth",
+              provider: "openai-codex",
+              access: "stale-access-token",
+              refresh: "stale-refresh-token",
+              expires: Date.now() - 60_000,
+            },
+          },
+          lastGood: { "openai-codex": staleProfileId },
+        },
+        agentDir,
+      );
+
+      await clearLastGoodProfileWithLock({
+        agentDir,
+        provider: "openai-codex",
+        profileId: staleProfileId,
+      });
+
+      expect(loadAuthProfileStoreForRuntime(agentDir).lastGood).toBeUndefined();
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not clear lastGood when the failed profile is not the stored profile", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-auth-clear-lastgood-keep-"));
+    const agentDir = path.join(stateDir, "agents", "main", "agent");
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    try {
+      fs.mkdirSync(agentDir, { recursive: true });
+      const goodProfileId = "openai-codex:user@example.test";
+      saveAuthProfileStore(
+        {
+          version: AUTH_STORE_VERSION,
+          profiles: {
+            [goodProfileId]: {
+              type: "oauth",
+              provider: "openai-codex",
+              access: "good-access-token",
+              refresh: "good-refresh-token",
+              expires: Date.now() + 60_000,
+            },
+          },
+          lastGood: { "openai-codex": goodProfileId },
+        },
+        agentDir,
+      );
+
+      await clearLastGoodProfileWithLock({
+        agentDir,
+        provider: "openai-codex",
+        profileId: "openai-codex:default",
+      });
+
+      expect(loadAuthProfileStoreForRuntime(agentDir).lastGood?.["openai-codex"]).toBe(
+        goodProfileId,
+      );
     } finally {
       if (previousStateDir === undefined) {
         delete process.env.OPENCLAW_STATE_DIR;

--- a/src/agents/auth-profiles/profiles.ts
+++ b/src/agents/auth-profiles/profiles.ts
@@ -205,6 +205,27 @@ export async function removeProviderAuthProfilesWithLock(params: {
   });
 }
 
+export async function clearLastGoodProfileWithLock(params: {
+  provider: string;
+  profileId: string;
+  agentDir?: string;
+}): Promise<AuthProfileStore | null> {
+  const providerKey = resolveProviderIdForAuth(params.provider);
+  return await updateAuthProfileStoreWithLock({
+    agentDir: params.agentDir,
+    updater: (store) => {
+      if (store.lastGood?.[providerKey] !== params.profileId) {
+        return false;
+      }
+      delete store.lastGood[providerKey];
+      if (Object.keys(store.lastGood).length === 0) {
+        store.lastGood = undefined;
+      }
+      return true;
+    },
+  });
+}
+
 export async function markAuthProfileSuccess(params: {
   store: AuthProfileStore;
   provider: string;

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -573,11 +573,12 @@ export async function resolveApiKeyForProvider(params: {
     if (!resolved) {
       throw new Error(`No credentials found for profile "${profileId}".`);
     }
-    const mode = store.profiles[profileId]?.type;
+    const resolvedProfileId = resolved.profileId ?? profileId;
+    const mode = resolved.profileType ?? store.profiles[resolvedProfileId]?.type;
     const result: ResolvedProviderAuth = {
       apiKey: resolved.apiKey,
-      profileId,
-      source: `profile:${profileId}`,
+      profileId: resolvedProfileId,
+      source: `profile:${resolvedProfileId}`,
       mode: mode ? profileTypeToAuthMode(mode) : "api-key",
     };
     // When the resolved key is a provider-owned synthetic profile marker and
@@ -706,14 +707,15 @@ export async function resolveApiKeyForProvider(params: {
         agentDir: params.agentDir,
       });
       if (resolved) {
-        const mode = store.profiles[candidate]?.type;
+        const resolvedProfileId = resolved.profileId ?? candidate;
+        const mode = resolved.profileType ?? store.profiles[resolvedProfileId]?.type;
         const resolvedMode: ResolvedProviderAuth["mode"] = mode
           ? profileTypeToAuthMode(mode)
           : "api-key";
         const result: ResolvedProviderAuth = {
           apiKey: resolved.apiKey,
-          profileId: candidate,
-          source: `profile:${candidate}`,
+          profileId: resolvedProfileId,
+          source: `profile:${resolvedProfileId}`,
           mode: resolvedMode,
         };
         if (

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -402,12 +402,14 @@ export async function modelsStatusCommand(
     const syntheticProvidersToProbe = new Set(
       providers.map((provider) => normalizeProviderId(provider)),
     );
+    const codexRuntimeAuthProviders = new Set<string>();
     for (const usage of providerUses) {
       if (
         usage.allowCodexRuntimeFallback &&
         openAIProviderUsesCodexRuntimeByDefault({ provider: usage.provider, config: cfg })
       ) {
         const codexProvider = normalizeProviderId(OPENAI_CODEX_PROVIDER_ID);
+        codexRuntimeAuthProviders.add(codexProvider);
         syntheticProvidersToProbe.add(codexProvider);
         syntheticProvidersToProbe.add(aliasMap[codexProvider] ?? codexProvider);
         syntheticProvidersToProbe.add("codex");
@@ -453,7 +455,15 @@ export async function modelsStatusCommand(
     const shellFallbackEnabled =
       shouldEnableShellEnvFallback(process.env) || cfg.env?.shellEnv?.enabled === true;
 
-    const providerAuth = providers
+    const providerAuthProviders = new Set(providers);
+    for (const provider of codexRuntimeAuthProviders) {
+      if (syntheticAuthByProvider.has(provider)) {
+        providerAuthProviders.add(provider);
+      }
+    }
+
+    const providerAuth = Array.from(providerAuthProviders)
+      .toSorted((a, b) => a.localeCompare(b))
       .map((provider) =>
         resolveProviderAuthOverview({
           provider,
@@ -523,6 +533,33 @@ export async function modelsStatusCommand(
         hasUsableProviderAuth(OPENAI_CODEX_PROVIDER_ID)
       );
     };
+    const runtimeAuthRoutes = Array.from(
+      new Map(
+        providerUses
+          .filter(
+            (usage) =>
+              usage.allowCodexRuntimeFallback &&
+              openAIProviderUsesCodexRuntimeByDefault({ provider: usage.provider, config: cfg }),
+          )
+          .map((usage) => {
+            const authProvider = normalizeProviderId(OPENAI_CODEX_PROVIDER_ID);
+            const effective = providerAuthMap.get(authProvider)?.effective ?? {
+              kind: "missing" as const,
+              detail: "missing",
+            };
+            return [
+              `${usage.provider}:codex:${authProvider}`,
+              {
+                provider: usage.provider,
+                runtime: "codex",
+                authProvider,
+                status: hasUsableProviderAuth(authProvider) ? "usable" : "missing",
+                effective,
+              },
+            ] as const;
+          }),
+      ).values(),
+    ).toSorted((a, b) => a.provider.localeCompare(b.provider));
     const missingProvidersInUse = Array.from(
       new Set(
         providerUses
@@ -730,6 +767,7 @@ export async function modelsStatusCommand(
           },
           providersWithOAuth: providersWithOauth,
           missingProvidersInUse,
+          runtimeAuthRoutes,
           providers: providerAuth,
           unusableProfiles,
           oauth: {
@@ -913,6 +951,27 @@ export async function modelsStatusCommand(
         );
       }
       runtime.log(`- ${theme.heading(entry.provider)} ${bits.join(separator)}`);
+    }
+
+    if (runtimeAuthRoutes.length > 0) {
+      runtime.log("");
+      runtime.log(colorize(rich, theme.heading, "Runtime auth"));
+      for (const route of runtimeAuthRoutes) {
+        runtime.log(
+          `- ${theme.heading(route.provider)} via ${colorize(
+            rich,
+            theme.accentBright,
+            route.runtime,
+          )} uses ${theme.heading(route.authProvider)} ${formatKeyValue(
+            "effective",
+            `${colorize(rich, theme.accentBright, route.effective.kind)}:${colorize(
+              rich,
+              theme.muted,
+              route.effective.detail,
+            )}`,
+          )}${formatSeparator()}${formatKeyValue("status", route.status)}`,
+        );
+      }
     }
 
     if (missingProvidersInUse.length > 0) {

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -64,6 +64,7 @@ import { resolveUserPath, shortenHomePath } from "../../utils.js";
 import { resolveProviderAuthOverview } from "./list.auth-overview.js";
 import { isRich } from "./list.format.js";
 import { type AuthProbeSummary } from "./list.probe.js";
+import type { ProviderAuthOverview } from "./list.types.js";
 import { loadModelsConfig } from "./load-config.js";
 import {
   DEFAULT_MODEL,
@@ -485,8 +486,38 @@ export async function modelsStatusCommand(
         return hasAny;
       });
     const providerAuthMap = new Map(providerAuth.map((entry) => [entry.provider, entry]));
+    const missingProviderAuthEffective: ProviderAuthOverview["effective"] = {
+      kind: "missing",
+      detail: "missing",
+    };
     const resolveProviderAuthHealthId = (provider: string): string =>
       resolveProviderIdForAuth(provider, envLookupParams);
+    const resolveRuntimeAuthRouteEffective = (
+      provider: string,
+    ): ProviderAuthOverview["effective"] => {
+      const direct = providerAuthMap.get(provider)?.effective;
+      if (direct && direct.kind !== "missing") {
+        return direct;
+      }
+      const orderedProfiles = resolveAuthProfileOrder({
+        cfg,
+        store,
+        provider,
+      });
+      const profileId = orderedProfiles[0];
+      const credential = profileId ? store.profiles[profileId] : undefined;
+      if (profileId && credential) {
+        const sourceProvider = resolveProviderAuthHealthId(credential.provider);
+        const source = providerAuthMap.get(sourceProvider)?.effective;
+        return source && source.kind !== "missing"
+          ? source
+          : {
+              kind: "profiles",
+              detail: `${profileId} (${credential.provider})`,
+            };
+      }
+      return direct ?? missingProviderAuthEffective;
+    };
     const hasUsableNonProfileAuth = (provider: string): boolean => {
       const authProvider = resolveProviderAuthHealthId(provider);
       for (const candidate of new Set([provider, authProvider])) {
@@ -534,10 +565,7 @@ export async function modelsStatusCommand(
     const runtimeAuthRoutes = Array.from(
       new Map(
         codexRuntimeAuthUsages.map((usage) => {
-          const effective = providerAuthMap.get(codexProvider)?.effective ?? {
-            kind: "missing" as const,
-            detail: "missing",
-          };
+          const effective = resolveRuntimeAuthRouteEffective(codexProvider);
           return [
             `${usage.provider}:codex:${codexProvider}`,
             {

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -402,18 +402,17 @@ export async function modelsStatusCommand(
     const syntheticProvidersToProbe = new Set(
       providers.map((provider) => normalizeProviderId(provider)),
     );
-    const codexRuntimeAuthProviders = new Set<string>();
-    for (const usage of providerUses) {
-      if (
+    const codexProvider = normalizeProviderId(OPENAI_CODEX_PROVIDER_ID);
+    const codexProviderAlias = aliasMap[codexProvider] ?? codexProvider;
+    const codexRuntimeAuthUsages = providerUses.filter(
+      (usage) =>
         usage.allowCodexRuntimeFallback &&
-        openAIProviderUsesCodexRuntimeByDefault({ provider: usage.provider, config: cfg })
-      ) {
-        const codexProvider = normalizeProviderId(OPENAI_CODEX_PROVIDER_ID);
-        codexRuntimeAuthProviders.add(codexProvider);
-        syntheticProvidersToProbe.add(codexProvider);
-        syntheticProvidersToProbe.add(aliasMap[codexProvider] ?? codexProvider);
-        syntheticProvidersToProbe.add("codex");
-      }
+        openAIProviderUsesCodexRuntimeByDefault({ provider: usage.provider, config: cfg }),
+    );
+    if (codexRuntimeAuthUsages.length > 0) {
+      syntheticProvidersToProbe.add(codexProvider);
+      syntheticProvidersToProbe.add(codexProviderAlias);
+      syntheticProvidersToProbe.add("codex");
     }
     for (const provider of syntheticProvidersToProbe) {
       const normalized = normalizeProviderId(provider);
@@ -440,8 +439,7 @@ export async function modelsStatusCommand(
         expiresAt: resolved.expiresAt,
       };
       syntheticAuthByProvider.set(normalized, syntheticAuth);
-      const codexProvider = normalizeProviderId(OPENAI_CODEX_PROVIDER_ID);
-      if (normalized === "codex" || (aliasMap[codexProvider] ?? codexProvider) === normalized) {
+      if (normalized === "codex" || normalized === codexProviderAlias) {
         syntheticAuthByProvider.set(codexProvider, syntheticAuth);
       }
     }
@@ -455,14 +453,14 @@ export async function modelsStatusCommand(
     const shellFallbackEnabled =
       shouldEnableShellEnvFallback(process.env) || cfg.env?.shellEnv?.enabled === true;
 
-    const providerAuthProviders = new Set(providers);
-    for (const provider of codexRuntimeAuthProviders) {
-      if (syntheticAuthByProvider.has(provider)) {
-        providerAuthProviders.add(provider);
-      }
-    }
-
-    const providerAuth = Array.from(providerAuthProviders)
+    const providerAuth = Array.from(
+      new Set([
+        ...providers,
+        ...(codexRuntimeAuthUsages.length > 0 && syntheticAuthByProvider.has(codexProvider)
+          ? [codexProvider]
+          : []),
+      ]),
+    )
       .toSorted((a, b) => a.localeCompare(b))
       .map((provider) =>
         resolveProviderAuthOverview({
@@ -535,29 +533,22 @@ export async function modelsStatusCommand(
     };
     const runtimeAuthRoutes = Array.from(
       new Map(
-        providerUses
-          .filter(
-            (usage) =>
-              usage.allowCodexRuntimeFallback &&
-              openAIProviderUsesCodexRuntimeByDefault({ provider: usage.provider, config: cfg }),
-          )
-          .map((usage) => {
-            const authProvider = normalizeProviderId(OPENAI_CODEX_PROVIDER_ID);
-            const effective = providerAuthMap.get(authProvider)?.effective ?? {
-              kind: "missing" as const,
-              detail: "missing",
-            };
-            return [
-              `${usage.provider}:codex:${authProvider}`,
-              {
-                provider: usage.provider,
-                runtime: "codex",
-                authProvider,
-                status: hasUsableProviderAuth(authProvider) ? "usable" : "missing",
-                effective,
-              },
-            ] as const;
-          }),
+        codexRuntimeAuthUsages.map((usage) => {
+          const effective = providerAuthMap.get(codexProvider)?.effective ?? {
+            kind: "missing" as const,
+            detail: "missing",
+          };
+          return [
+            `${usage.provider}:codex:${codexProvider}`,
+            {
+              provider: usage.provider,
+              runtime: "codex",
+              authProvider: codexProvider,
+              status: hasUsableProviderAuth(codexProvider) ? "usable" : "missing",
+              effective,
+            },
+          ] as const;
+        }),
       ).values(),
     ).toSorted((a, b) => a.provider.localeCompare(b.provider));
     const missingProvidersInUse = Array.from(

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -599,6 +599,65 @@ describe("modelsStatusCommand auth overview", () => {
     }
   });
 
+  it("shows compatible OpenAI API-key profiles for Codex runtime auth routes", async () => {
+    const localRuntime = createRuntime();
+    const originalLoadConfig = mocks.loadConfig.getMockImplementation();
+    const originalProfiles = { ...mocks.store.profiles };
+    const originalOrder = mocks.store.order ? { ...mocks.store.order } : undefined;
+    const originalEnvImpl = mocks.resolveEnvApiKey.getMockImplementation();
+    mocks.loadConfig.mockReturnValue({
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.5", fallbacks: [] },
+          models: { "openai/gpt-5.5": {} },
+        },
+      },
+      models: { providers: {} },
+      env: { shellEnv: { enabled: false } },
+    });
+    mocks.store.profiles = {
+      "openai:default": {
+        type: "api_key",
+        provider: "openai",
+        key: "sk-openai-compatible-profile", // pragma: allowlist secret
+      },
+    };
+    mocks.store.order = undefined;
+    mocks.resolveEnvApiKey.mockImplementation(() => null);
+
+    try {
+      await modelsStatusCommand({ json: true, check: true }, localRuntime as never);
+      const payload = parseFirstJsonLog(localRuntime);
+      expect(payload.auth.missingProvidersInUse).toStrictEqual([]);
+      expect(payload.auth.runtimeAuthRoutes).toEqual([
+        {
+          provider: "openai",
+          runtime: "codex",
+          authProvider: "openai-codex",
+          status: "usable",
+          effective: {
+            kind: "profiles",
+            detail: "/tmp/openclaw-agent/auth-profiles.json",
+          },
+        },
+      ]);
+      expect(localRuntime.exit).not.toHaveBeenCalledWith(1);
+    } finally {
+      mocks.store.profiles = originalProfiles;
+      mocks.store.order = originalOrder;
+      if (originalLoadConfig) {
+        mocks.loadConfig.mockImplementation(originalLoadConfig);
+      }
+      if (originalEnvImpl) {
+        mocks.resolveEnvApiKey.mockImplementation(originalEnvImpl);
+      } else if (defaultResolveEnvApiKeyImpl) {
+        mocks.resolveEnvApiKey.mockImplementation(defaultResolveEnvApiKeyImpl);
+      } else {
+        mocks.resolveEnvApiKey.mockImplementation(() => null);
+      }
+    }
+  });
+
   it("does not fail --check for stale Codex inventory when ordered provider health is usable", async () => {
     const localRuntime = createRuntime();
     const originalLoadConfig = mocks.loadConfig.getMockImplementation();

--- a/src/commands/models/list.status.test.ts
+++ b/src/commands/models/list.status.test.ts
@@ -558,6 +558,18 @@ describe("modelsStatusCommand auth overview", () => {
         .slice(syntheticProbeStart)
         .map(([arg]) => (arg as { provider: string }).provider);
       expect(payload.auth.missingProvidersInUse).toStrictEqual([]);
+      expect(payload.auth.runtimeAuthRoutes).toEqual([
+        {
+          provider: "openai",
+          runtime: "codex",
+          authProvider: "openai-codex",
+          status: "usable",
+          effective: {
+            kind: "synthetic",
+            detail: "codex-app-server",
+          },
+        },
+      ]);
       expect(localRuntime.exit).not.toHaveBeenCalledWith(1);
       expect(syntheticProbeProviders).toContain("codex");
     } finally {

--- a/src/commands/sessions-table.ts
+++ b/src/commands/sessions-table.ts
@@ -25,6 +25,7 @@ export type SessionDisplayRow = {
   providerOverride?: string;
   modelOverride?: string;
   contextTokens?: number;
+  runtimePolicySessionKey?: string;
 };
 
 export const SESSION_KEY_PAD = 26;
@@ -102,6 +103,7 @@ export function formatSessionFlagsCell(
     | "systemSent"
     | "abortedLastRun"
     | "sessionId"
+    | "runtimePolicySessionKey"
   >,
   rich: boolean,
 ): string {
@@ -115,6 +117,7 @@ export function formatSessionFlagsCell(
     row.groupActivation ? `activation:${row.groupActivation}` : null,
     row.systemSent ? "system" : null,
     row.abortedLastRun ? "aborted" : null,
+    row.runtimePolicySessionKey ? `policy:${row.runtimePolicySessionKey}` : null,
     row.sessionId ? `id:${row.sessionId}` : null,
   ].filter(Boolean);
   const label = flags.join(" ");

--- a/src/commands/sessions.test.ts
+++ b/src/commands/sessions.test.ts
@@ -228,6 +228,34 @@ describe("sessionsCommand", () => {
     expect(payload.sessions?.map((row) => row.key)).toEqual(["recent"]);
   });
 
+  it("exports runtime policy aliases for collapsed external direct sessions", async () => {
+    const store = writeStore(
+      {
+        "agent:main:main": {
+          sessionId: "telegram-main",
+          updatedAt: Date.now() - 60_000,
+          origin: {
+            provider: "telegram",
+            chatType: "direct",
+            to: "telegram:42",
+            accountId: "default",
+          },
+        },
+      },
+      "sessions-runtime-policy-alias",
+    );
+
+    const payload = await runSessionsJson<{
+      sessions?: Array<{
+        key: string;
+        runtimePolicySessionKey?: string;
+      }>;
+    }>(sessionsCommand, store, { active: "10" });
+
+    const main = payload.sessions?.find((row) => row.key === "agent:main:main");
+    expect(main?.runtimePolicySessionKey).toBe("agent:main:telegram:default:direct:42");
+  });
+
   it("uses a default JSON output limit of 100 sessions", () => {
     expect(__testing.parseSessionsLimit(undefined)).toBe(100);
   });

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -1,5 +1,7 @@
 import { resolveModelAgentRuntimeMetadata } from "../agents/agent-runtime-metadata.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../agents/defaults.js";
+import { resolveRuntimePolicySessionKey } from "../auto-reply/reply/runtime-policy-session-key.js";
+import { normalizeChatType } from "../channels/chat-type.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { loadSessionStore, resolveSessionTotalTokens } from "../config/sessions.js";
 import type { SessionEntry } from "../config/sessions/types.js";
@@ -10,7 +12,10 @@ import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { classifySessionKind, type SessionKind } from "../sessions/classify-session-kind.js";
 import { isAcpSessionKey } from "../sessions/session-key-utils.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
-import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
+import {
+  normalizeOptionalLowercaseString,
+  normalizeOptionalString,
+} from "../shared/string-coerce.js";
 import { resolveAgentRuntimeLabel } from "../status/agent-runtime-label.js";
 import { isRich, theme } from "../terminal/theme.js";
 import { resolveSessionStoreTargetsOrExit } from "./session-store-targets.js";
@@ -220,6 +225,76 @@ function toJsonSessionRow(row: SessionRow): Omit<SessionRow, "runtimeLabel"> {
   return jsonRow;
 }
 
+function stripChannelRecipientPrefix(
+  value: string | undefined,
+  channel: string | undefined,
+): string | undefined {
+  const raw = normalizeOptionalString(value);
+  const normalizedChannel = normalizeOptionalLowercaseString(channel);
+  if (!raw || !normalizedChannel) {
+    return raw;
+  }
+  const prefix = `${normalizedChannel}:`;
+  if (!raw.toLowerCase().startsWith(prefix)) {
+    return raw;
+  }
+  const stripped = raw.slice(prefix.length);
+  const topicMarkerIndex = stripped.toLowerCase().indexOf(":topic:");
+  return topicMarkerIndex >= 0 ? stripped.slice(0, topicMarkerIndex) : stripped;
+}
+
+function resolveDisplayRuntimePolicySessionKey(params: {
+  cfg: OpenClawConfig;
+  key: string;
+  entry: SessionEntry;
+}): string | undefined {
+  const { cfg, entry, key } = params;
+  const origin = entry.origin;
+  const deliveryContext = entry.deliveryContext;
+  const chatType = normalizeChatType(origin?.chatType ?? entry.chatType);
+  if (chatType !== "direct") {
+    return undefined;
+  }
+
+  const channel = normalizeOptionalString(
+    origin?.provider ??
+      deliveryContext?.channel ??
+      entry.lastChannel ??
+      entry.channel ??
+      origin?.surface,
+  );
+  const to = normalizeOptionalString(origin?.to ?? deliveryContext?.to ?? entry.lastTo);
+  const from = normalizeOptionalString(origin?.from);
+  const nativeDirectUserId = normalizeOptionalString(origin?.nativeDirectUserId);
+  const peerId =
+    nativeDirectUserId ??
+    stripChannelRecipientPrefix(to, channel) ??
+    stripChannelRecipientPrefix(from, channel);
+
+  const runtimePolicySessionKey = resolveRuntimePolicySessionKey({
+    cfg,
+    sessionKey: key,
+    ctx: {
+      SessionKey: key,
+      Provider: channel,
+      Surface: normalizeOptionalString(origin?.surface),
+      AccountId: normalizeOptionalString(
+        origin?.accountId ?? deliveryContext?.accountId ?? entry.lastAccountId,
+      ),
+      ChatType: chatType,
+      NativeDirectUserId: nativeDirectUserId,
+      SenderId: peerId,
+      OriginatingTo: to,
+      From: from,
+      To: to,
+    },
+  });
+
+  return runtimePolicySessionKey && runtimePolicySessionKey !== key
+    ? runtimePolicySessionKey
+    : undefined;
+}
+
 export async function sessionsCommand(
   opts: {
     json?: boolean;
@@ -303,6 +378,11 @@ export async function sessionsCommand(
           acpRuntime,
           agentRuntime,
           kind: classifySessionKind(row.key, store[row.key]),
+          runtimePolicySessionKey: resolveDisplayRuntimePolicySessionKey({
+            cfg,
+            key: row.key,
+            entry,
+          }),
           runtimeLabel: resolveSessionRuntimeLabel({
             cfg,
             entry,

--- a/src/logging/diagnostic-run-activity.ts
+++ b/src/logging/diagnostic-run-activity.ts
@@ -26,8 +26,14 @@ type DiagnosticToolStartedActivityEvent = Pick<
   "runId" | "sessionId" | "sessionKey" | "toolName" | "toolCallId"
 >;
 
+type DiagnosticModelStartedActivityEvent = Pick<
+  Extract<DiagnosticEventPayload, { type: "model.call.started" }>,
+  "runId" | "sessionId" | "sessionKey" | "provider" | "model"
+>;
+
 export type DiagnosticSessionActivitySnapshot = {
   activeWorkKind?: DiagnosticSessionActiveWorkKind;
+  hasActiveEmbeddedRun?: boolean;
   activeToolName?: string;
   activeToolCallId?: string;
   activeToolAgeMs?: number;
@@ -194,9 +200,7 @@ function recordToolEnded(
   touchSessionActivity(activity, `tool:${event.toolName}:ended`);
 }
 
-function recordModelStarted(
-  event: Extract<DiagnosticEventPayload, { type: "model.call.started" }>,
-): void {
+function recordModelStarted(event: DiagnosticModelStartedActivityEvent): void {
   const activity = resolveSessionActivity({ ...event, create: true });
   if (!activity) {
     return;
@@ -300,6 +304,7 @@ export function getDiagnosticSessionActivitySnapshot(
 
   return {
     activeWorkKind,
+    ...(activity.activeEmbeddedRuns.size > 0 ? { hasActiveEmbeddedRun: true } : {}),
     activeToolName: activeTool?.toolName,
     activeToolCallId: activeTool?.toolCallId,
     activeToolAgeMs: activeTool ? Math.max(0, now - activeTool.startedAt) : undefined,
@@ -329,6 +334,12 @@ export function markDiagnosticToolStartedForTest(params: {
   toolCallId?: string;
 }): void {
   recordToolStarted(params);
+}
+
+export function markDiagnosticModelStartedForTest(
+  params: DiagnosticModelStartedActivityEvent,
+): void {
+  recordModelStarted(params);
 }
 
 export function resetDiagnosticRunActivityForTest(): void {

--- a/src/logging/diagnostic-session-attention.test.ts
+++ b/src/logging/diagnostic-session-attention.test.ts
@@ -56,6 +56,22 @@ describe("classifySessionAttention", () => {
       },
     },
     {
+      name: "queued behind terminal embedded progress",
+      queueDepth: 1,
+      activity: {
+        activeWorkKind: "embedded_run" as const,
+        lastProgressAgeMs: 100,
+        lastProgressReason: "codex_app_server:notification:rawResponseItem/completed",
+      },
+      expected: {
+        eventType: "session.stalled",
+        reason: "queued_behind_terminal_active_work",
+        classification: "stalled_agent_run",
+        activeWorkKind: "embedded_run",
+        recoveryEligible: false,
+      },
+    },
+    {
       name: "active work without progress",
       queueDepth: 0,
       activity: {

--- a/src/logging/diagnostic-session-attention.ts
+++ b/src/logging/diagnostic-session-attention.ts
@@ -43,6 +43,19 @@ export function classifySessionAttention(params: {
         recoveryEligible: false,
       };
     }
+    if (
+      params.queueDepth > 0 &&
+      params.activity.activeWorkKind === "embedded_run" &&
+      isTerminalDiagnosticProgressReason(params.activity.lastProgressReason)
+    ) {
+      return {
+        eventType: "session.stalled",
+        reason: "queued_behind_terminal_active_work",
+        classification: "stalled_agent_run",
+        activeWorkKind: params.activity.activeWorkKind,
+        recoveryEligible: false,
+      };
+    }
     if ((params.activity.lastProgressAgeMs ?? 0) > params.staleMs) {
       return {
         eventType: "session.stalled",
@@ -67,4 +80,18 @@ export function classifySessionAttention(params: {
     classification: "stale_session_state",
     recoveryEligible: true,
   };
+}
+
+export function isTerminalDiagnosticProgressReason(reason: string | undefined): boolean {
+  if (!reason) {
+    return false;
+  }
+  return (
+    reason === "run:completed" ||
+    reason === "embedded_run:ended" ||
+    reason.includes("response.completed") ||
+    reason.includes("rawResponseItem/completed") ||
+    reason.includes("raw_response_item.completed") ||
+    reason.includes("output_item.done")
+  );
 }

--- a/src/logging/diagnostic-session-recovery-coordinator.ts
+++ b/src/logging/diagnostic-session-recovery-coordinator.ts
@@ -11,6 +11,7 @@ import {
 import {
   getDiagnosticSessionState,
   isDiagnosticSessionStateCurrent,
+  peekDiagnosticSessionState,
 } from "./diagnostic-session-state.js";
 
 export type RecoverStuckSession = (
@@ -27,7 +28,7 @@ function emitSessionRecoveryRequested(params: {
     type: "session.recovery.requested",
     sessionId: params.request.sessionId,
     sessionKey: params.request.sessionKey,
-    state: "processing",
+    state: params.request.expectedState ?? "processing",
     stateGeneration: params.request.stateGeneration,
     ageMs: params.request.ageMs,
     queueDepth: params.request.queueDepth,
@@ -46,7 +47,7 @@ function emitSessionRecoveryCompleted(params: {
     type: "session.recovery.completed",
     sessionId: params.request.sessionId,
     sessionKey: params.request.sessionKey,
-    state: "processing",
+    state: params.request.expectedState ?? "processing",
     stateGeneration: params.request.stateGeneration,
     ageMs: params.request.ageMs,
     queueDepth: params.request.queueDepth,
@@ -75,6 +76,10 @@ function isRecoveryPromiseLike(
   );
 }
 
+function recoveryOutcomeHasQueuedLaneWork(outcome: StuckSessionRecoveryOutcome): boolean {
+  return outcome.status === "aborted" && (outcome.queuedCount ?? 0) > 0;
+}
+
 function applyRecoveryOutcomeToDiagnosticState(params: {
   request: StuckSessionRecoveryRequest;
   outcome: StuckSessionRecoveryOutcome | undefined;
@@ -86,14 +91,23 @@ function applyRecoveryOutcomeToDiagnosticState(params: {
     emitSessionRecoveryCompleted({ request: params.request, outcome: params.outcome });
     return;
   }
-  if (
-    !isDiagnosticSessionStateCurrent({
-      sessionId: params.request.sessionId,
-      sessionKey: params.request.sessionKey,
-      generation: params.request.stateGeneration,
-      state: "processing",
-    })
-  ) {
+  const expectedState = params.request.expectedState ?? "processing";
+  const currentState = peekDiagnosticSessionState(params.request);
+  const currentGeneration = currentState?.generation ?? 0;
+  const requestGeneration = params.request.stateGeneration ?? 0;
+  const stateIsCurrent =
+    expectedState === "idle" &&
+    params.request.stateGeneration !== undefined &&
+    params.outcome.action === "abort_embedded_run"
+      ? currentState?.state === "idle" &&
+        (currentGeneration === requestGeneration || currentGeneration === requestGeneration + 1)
+      : isDiagnosticSessionStateCurrent({
+          sessionId: params.request.sessionId,
+          sessionKey: params.request.sessionKey,
+          generation: params.request.stateGeneration,
+          state: expectedState,
+        });
+  if (!stateIsCurrent) {
     emitSessionRecoveryCompleted({
       request: params.request,
       outcome: params.outcome,
@@ -108,9 +122,13 @@ function applyRecoveryOutcomeToDiagnosticState(params: {
   state.generation = (state.generation ?? 0) + 1;
   state.lastStuckWarnAgeMs = undefined;
   state.lastLongRunningWarnAgeMs = undefined;
+  const preserveQueuedIdleWork =
+    params.request.expectedState === "idle" && recoveryOutcomeHasQueuedLaneWork(params.outcome);
   state.queueDepth = recoveryOutcomeClearsQueuedSessionState(params.outcome)
     ? 0
-    : Math.max(0, state.queueDepth - 1);
+    : preserveQueuedIdleWork
+      ? Math.max(state.queueDepth, params.request.queueDepth ?? 0)
+      : Math.max(0, state.queueDepth - 1);
   emitDiagnosticEvent({
     type: "session.state",
     sessionId: state.sessionId,

--- a/src/logging/diagnostic-session-recovery.ts
+++ b/src/logging/diagnostic-session-recovery.ts
@@ -1,4 +1,7 @@
-import type { DiagnosticSessionActiveWorkKind } from "../infra/diagnostic-events.js";
+import type {
+  DiagnosticSessionActiveWorkKind,
+  DiagnosticSessionState,
+} from "../infra/diagnostic-events.js";
 
 export type DiagnosticSessionRecoveryStatus =
   | "aborted"
@@ -23,6 +26,7 @@ export type StuckSessionRecoveryRequest = {
   ageMs: number;
   queueDepth?: number;
   allowActiveAbort?: boolean;
+  expectedState?: DiagnosticSessionState;
   stateGeneration?: number;
 };
 
@@ -42,6 +46,7 @@ export type StuckSessionRecoveryOutcome =
       drained: boolean;
       forceCleared: boolean;
       released: number;
+      queuedCount?: number;
     })
   | (DiagnosticSessionRecoveryBaseOutcome & {
       status: "released";
@@ -85,6 +90,7 @@ export function recoveryOutcomeClearsQueuedSessionState(
 ): boolean {
   return (
     outcome.status === "released" ||
+    (outcome.status === "aborted" && outcome.released > 0 && (outcome.queuedCount ?? 0) === 0) ||
     (outcome.status === "noop" && outcome.reason === "no_active_work")
   );
 }
@@ -122,10 +128,13 @@ export function formatRecoveryOutcome(outcome: StuckSessionRecoveryOutcome): str
   if ("released" in outcome) {
     fields.push(`released=${outcome.released}`);
   }
+  if (outcome.status === "aborted" && outcome.queuedCount !== undefined) {
+    fields.push(`queuedCount=${outcome.queuedCount}`);
+  }
   if ("activeCount" in outcome && outcome.activeCount !== undefined) {
     fields.push(`laneActive=${outcome.activeCount}`);
   }
-  if ("queuedCount" in outcome && outcome.queuedCount !== undefined) {
+  if (outcome.status === "skipped" && outcome.queuedCount !== undefined) {
     fields.push(`laneQueued=${outcome.queuedCount}`);
   }
   if ("error" in outcome) {

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.test.ts
@@ -74,7 +74,7 @@ function resetMocks() {
   mocks.getCommandLaneSnapshot.mockReset();
   mocks.getCommandLaneSnapshot.mockReturnValue({
     lane: "session:agent:main:main",
-    queuedCount: 1,
+    queuedCount: 0,
     activeCount: 0,
     maxConcurrent: 1,
     draining: false,
@@ -316,6 +316,43 @@ describe("stuck session recovery", () => {
       "stuck session recovery: sessionId=queued-reply-session sessionKey=agent:main:main age=720s action=abort_embedded_run aborted=true drained=true released=0",
       "stuck session recovery outcome: status=aborted action=abort_embedded_run sessionId=queued-reply-session sessionKey=agent:main:main activeSessionId=queued-reply-session activeWorkKind=embedded_run lane=session:agent:main:main aborted=true drained=true forceCleared=false released=0",
     ]);
+  });
+
+  it("reports queued lane work when aborting active work releases a lane", async () => {
+    mocks.resolveActiveEmbeddedRunSessionId.mockReturnValue("queued-reply-session");
+    mocks.resolveActiveEmbeddedRunHandleSessionId.mockReturnValue(undefined);
+    mocks.isEmbeddedPiRunActive.mockReturnValue(true);
+    mocks.isEmbeddedPiRunHandleActive.mockReturnValue(false);
+    mocks.abortEmbeddedPiRun.mockReturnValue(false);
+    mocks.forceClearEmbeddedPiRun.mockReturnValue(true);
+    mocks.waitForEmbeddedPiRunEnd.mockResolvedValue(false);
+    mocks.resetCommandLane.mockReturnValue(1);
+    mocks.getCommandLaneSnapshot.mockReturnValue({
+      lane: "session:agent:main:main",
+      queuedCount: 1,
+      activeCount: 1,
+      maxConcurrent: 1,
+      draining: false,
+      generation: 0,
+    });
+
+    const outcome = await recoverStuckDiagnosticSession({
+      sessionId: "queued-reply-session",
+      sessionKey: "agent:main:main",
+      ageMs: 720_000,
+      queueDepth: 1,
+      allowActiveAbort: true,
+    });
+
+    expect(outcome).toMatchObject({
+      status: "aborted",
+      action: "abort_embedded_run",
+      released: 1,
+      queuedCount: 1,
+    });
+    expect(warnLogMessages()).toContain(
+      "stuck session recovery outcome: status=aborted action=abort_embedded_run sessionId=queued-reply-session sessionKey=agent:main:main activeSessionId=queued-reply-session activeWorkKind=embedded_run lane=session:agent:main:main aborted=false drained=false forceCleared=true released=1 queuedCount=1",
+    );
   });
 
   it("does not release the session lane while unregistered lane work is active", async () => {

--- a/src/logging/diagnostic-stuck-session-recovery.runtime.ts
+++ b/src/logging/diagnostic-stuck-session-recovery.runtime.ts
@@ -74,7 +74,7 @@ export async function recoverStuckDiagnosticSession(
         sessionId: params.sessionId,
         sessionKey: params.sessionKey,
         generation: params.stateGeneration,
-        state: "processing",
+        state: params.expectedState ?? "processing",
       })
     ) {
       return {
@@ -176,6 +176,7 @@ export async function recoverStuckDiagnosticSession(
       }
     }
 
+    const queuedCount = sessionLane ? getCommandLaneSnapshot(sessionLane).queuedCount : 0;
     const released =
       sessionLane && (!activeSessionId || !aborted || !drained) ? resetCommandLane(sessionLane) : 0;
 
@@ -207,6 +208,7 @@ export async function recoverStuckDiagnosticSession(
               forceCleared,
               released,
               lane: sessionLane ?? undefined,
+              ...(queuedCount > 0 ? { queuedCount } : {}),
             }
           : {
               status: "released",

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -14,6 +14,7 @@ import {
   markDiagnosticRunProgressForTest,
   markDiagnosticEmbeddedRunEnded,
   markDiagnosticEmbeddedRunStarted,
+  markDiagnosticModelStartedForTest,
   markDiagnosticToolStartedForTest,
 } from "./diagnostic-run-activity.js";
 import {
@@ -617,6 +618,62 @@ describe("stuck session diagnostics threshold", () => {
     );
   });
 
+  it("recovers stale model calls through the active embedded-run abort path", async () => {
+    const events: DiagnosticEventPayload[] = [];
+    const recoverStuckSession = vi.fn();
+    const stuckSessionWarnMs = 30_000;
+    const stuckSessionAbortMs = 60_000;
+    const unsubscribe = onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+    try {
+      startDiagnosticHeartbeat(
+        {
+          diagnostics: {
+            enabled: true,
+            stuckSessionWarnMs,
+            stuckSessionAbortMs,
+          },
+        },
+        { recoverStuckSession },
+      );
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+      markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+      markDiagnosticModelStartedForTest({
+        sessionId: "s1",
+        sessionKey: "main",
+        runId: "run-1",
+        provider: "openai",
+        model: "gpt-5",
+      });
+
+      vi.advanceTimersByTime(stuckSessionAbortMs - 30_000);
+      expect(recoverStuckSession).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(30_000);
+    } finally {
+      unsubscribe();
+    }
+
+    expectRecordFields(
+      requireRecord(
+        events.findLast((event) => event.type === "session.stalled"),
+        "stalled event",
+      ),
+      {
+        classification: "stalled_agent_run",
+        reason: "active_work_without_progress",
+        activeWorkKind: "model_call",
+        lastProgressReason: "model_call:started",
+      },
+    );
+    expectRecoveryCall(
+      recoverStuckSession,
+      { sessionId: "s1", sessionKey: "main", queueDepth: 0, allowActiveAbort: true },
+      ["ageMs", "stateGeneration"],
+    );
+  });
+
   it("does not recover a recent native tool call just because the session is old", async () => {
     const recoverStuckSession = vi.fn();
     const stuckSessionWarnMs = 30_000;
@@ -677,6 +734,124 @@ describe("stuck session diagnostics threshold", () => {
       { sessionId: "s1", sessionKey: "main", queueDepth: 0, allowActiveAbort: true },
       ["ageMs", "stateGeneration"],
     );
+  });
+
+  it("recovers idle queued embedded-run stalls after stale progress", async () => {
+    const events: DiagnosticEventPayload[] = [];
+    const recoverStuckSession = vi.fn().mockResolvedValue({
+      status: "aborted",
+      action: "abort_embedded_run",
+      sessionId: "s1",
+      sessionKey: "main",
+      activeSessionId: "s1",
+      activeWorkKind: "embedded_run",
+      aborted: true,
+      drained: true,
+      forceCleared: false,
+      released: 0,
+    });
+    const unsubscribe = onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+    try {
+      startDiagnosticHeartbeat(
+        {
+          diagnostics: {
+            enabled: true,
+            stuckSessionWarnMs: 30_000,
+            stuckSessionAbortMs: 60_000,
+          },
+        },
+        { recoverStuckSession },
+      );
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+      markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "idle" });
+
+      vi.advanceTimersByTime(59_000);
+      logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test-followup" });
+      vi.advanceTimersByTime(1_000);
+      await Promise.resolve();
+    } finally {
+      unsubscribe();
+    }
+
+    expectRecoveryCall(
+      recoverStuckSession,
+      {
+        sessionId: "s1",
+        sessionKey: "main",
+        queueDepth: 1,
+        allowActiveAbort: true,
+        expectedState: "idle",
+      },
+      ["ageMs", "stateGeneration"],
+    );
+    requireMatchingRecord(
+      events,
+      {
+        type: "session.recovery.completed",
+        state: "idle",
+        status: "aborted",
+        action: "abort_embedded_run",
+      },
+      "idle abort recovery event",
+    );
+    expect(getDiagnosticSessionState({ sessionId: "s1", sessionKey: "main" }).queueDepth).toBe(0);
+  });
+
+  it("preserves queued idle work when abort reset releases active lane work", async () => {
+    const events: DiagnosticEventPayload[] = [];
+    const recoverStuckSession = vi.fn().mockResolvedValue({
+      status: "aborted",
+      action: "abort_embedded_run",
+      sessionId: "s1",
+      sessionKey: "main",
+      activeSessionId: "s1",
+      activeWorkKind: "embedded_run",
+      aborted: true,
+      drained: false,
+      forceCleared: true,
+      released: 1,
+      queuedCount: 1,
+    });
+    const unsubscribe = onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+    try {
+      startDiagnosticHeartbeat(
+        {
+          diagnostics: {
+            enabled: true,
+            stuckSessionWarnMs: 30_000,
+            stuckSessionAbortMs: 60_000,
+          },
+        },
+        { recoverStuckSession },
+      );
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+      markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "idle" });
+
+      vi.advanceTimersByTime(59_000);
+      logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test-followup" });
+      vi.advanceTimersByTime(1_000);
+      await Promise.resolve();
+    } finally {
+      unsubscribe();
+    }
+
+    requireMatchingRecord(
+      events,
+      {
+        type: "session.state",
+        state: "idle",
+        reason: "stuck_recovery:aborted",
+        queueDepth: 1,
+      },
+      "idle abort preserves queued work",
+    );
+    expect(getDiagnosticSessionState({ sessionId: "s1", sessionKey: "main" }).queueDepth).toBe(1);
   });
 
   it("marks diagnostic session state idle only after a mutating recovery outcome", async () => {

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -674,6 +674,54 @@ describe("stuck session diagnostics threshold", () => {
     );
   });
 
+  it("does not recover stale model calls without active embedded-run ownership", async () => {
+    const events: DiagnosticEventPayload[] = [];
+    const recoverStuckSession = vi.fn();
+    const stuckSessionWarnMs = 30_000;
+    const stuckSessionAbortMs = 60_000;
+    const unsubscribe = onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+    try {
+      startDiagnosticHeartbeat(
+        {
+          diagnostics: {
+            enabled: true,
+            stuckSessionWarnMs,
+            stuckSessionAbortMs,
+          },
+        },
+        { recoverStuckSession },
+      );
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+      markDiagnosticModelStartedForTest({
+        sessionId: "s1",
+        sessionKey: "main",
+        runId: "run-1",
+        provider: "openai",
+        model: "gpt-5",
+      });
+
+      vi.advanceTimersByTime(stuckSessionAbortMs);
+    } finally {
+      unsubscribe();
+    }
+
+    expectRecordFields(
+      requireRecord(
+        events.findLast((event) => event.type === "session.stalled"),
+        "stalled event",
+      ),
+      {
+        classification: "stalled_agent_run",
+        reason: "active_work_without_progress",
+        activeWorkKind: "model_call",
+        lastProgressReason: "model_call:started",
+      },
+    );
+    expect(recoverStuckSession).not.toHaveBeenCalled();
+  });
+
   it("does not recover a recent native tool call just because the session is old", async () => {
     const recoverStuckSession = vi.fn();
     const stuckSessionWarnMs = 30_000;
@@ -798,6 +846,58 @@ describe("stuck session diagnostics threshold", () => {
       "idle abort recovery event",
     );
     expect(getDiagnosticSessionState({ sessionId: "s1", sessionKey: "main" }).queueDepth).toBe(0);
+  });
+
+  it("recovers idle queued work when embedded ownership is surfaced as a model call", async () => {
+    const recoverStuckSession = vi.fn().mockResolvedValue({
+      status: "aborted",
+      action: "abort_embedded_run",
+      sessionId: "s1",
+      sessionKey: "main",
+      activeSessionId: "s1",
+      activeWorkKind: "embedded_run",
+      aborted: true,
+      drained: true,
+      forceCleared: false,
+      released: 0,
+    });
+    startDiagnosticHeartbeat(
+      {
+        diagnostics: {
+          enabled: true,
+          stuckSessionWarnMs: 30_000,
+          stuckSessionAbortMs: 60_000,
+        },
+      },
+      { recoverStuckSession },
+    );
+    logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+    markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+    markDiagnosticModelStartedForTest({
+      sessionId: "s1",
+      sessionKey: "main",
+      runId: "run-1",
+      provider: "openai",
+      model: "gpt-5",
+    });
+    logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "idle" });
+
+    vi.advanceTimersByTime(59_000);
+    logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test-followup" });
+    vi.advanceTimersByTime(1_000);
+    await Promise.resolve();
+
+    expectRecoveryCall(
+      recoverStuckSession,
+      {
+        sessionId: "s1",
+        sessionKey: "main",
+        queueDepth: 1,
+        allowActiveAbort: true,
+        expectedState: "idle",
+      },
+      ["ageMs", "stateGeneration"],
+    );
   });
 
   it("preserves queued idle work when abort reset releases active lane work", async () => {

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -989,6 +989,63 @@ describe("stuck session diagnostics threshold", () => {
     expect(recoverStuckSession).not.toHaveBeenCalled();
   });
 
+  it("recovers queued sessions behind terminal embedded progress after the abort threshold", () => {
+    const events: DiagnosticEventPayload[] = [];
+    const recoverStuckSession = vi.fn();
+    const stuckSessionWarnMs = 30_000;
+    const stuckSessionAbortMs = 60_000;
+    const terminalReason = "codex_app_server:notification:rawResponseItem/completed";
+    const unsubscribe = onDiagnosticEvent((event) => {
+      events.push(event);
+    });
+    try {
+      startDiagnosticHeartbeat(
+        {
+          diagnostics: {
+            enabled: true,
+            stuckSessionWarnMs,
+            stuckSessionAbortMs,
+          },
+        },
+        { recoverStuckSession },
+      );
+      logMessageQueued({ sessionId: "s1", sessionKey: "main", source: "test" });
+      logSessionStateChange({ sessionId: "s1", sessionKey: "main", state: "processing" });
+      markDiagnosticEmbeddedRunStarted({ sessionId: "s1", sessionKey: "main" });
+
+      vi.advanceTimersByTime(stuckSessionAbortMs - 1);
+      markDiagnosticRunProgressForTest({
+        sessionId: "s1",
+        sessionKey: "main",
+        reason: terminalReason,
+      });
+      vi.advanceTimersByTime(1);
+    } finally {
+      unsubscribe();
+    }
+
+    const attentionEvents = events.filter(
+      (event) =>
+        event.type === "session.long_running" ||
+        event.type === "session.stalled" ||
+        event.type === "session.stuck",
+    );
+    expectRecordFields(requireRecord(attentionEvents.at(-1), "final attention event"), {
+      type: "session.stalled",
+      classification: "stalled_agent_run",
+      reason: "queued_behind_terminal_active_work",
+      activeWorkKind: "embedded_run",
+      queueDepth: 1,
+      terminalProgressStale: true,
+      lastProgressReason: terminalReason,
+    });
+    expectRecoveryCall(
+      recoverStuckSession,
+      { sessionId: "s1", sessionKey: "main", queueDepth: 1, allowActiveAbort: true },
+      ["ageMs", "stateGeneration"],
+    );
+  });
+
   it("starts and stops the stability recorder with the heartbeat lifecycle", () => {
     startDiagnosticHeartbeat({
       diagnostics: {

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -544,10 +544,13 @@ function isIdleQueuedEmbeddedRunStall(params: {
   activity: DiagnosticSessionActivitySnapshot;
   staleMs: number;
 }): boolean {
+  const hasEmbeddedOwner =
+    params.activity.activeWorkKind === "embedded_run" ||
+    params.activity.hasActiveEmbeddedRun === true;
   return (
     params.state.state === "idle" &&
     params.state.queueDepth > 0 &&
-    params.activity.activeWorkKind === "embedded_run" &&
+    hasEmbeddedOwner &&
     (params.activity.lastProgressAgeMs ?? 0) > params.staleMs
   );
 }

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -507,13 +507,49 @@ function isBlockedToolCallRecoveryEligible(params: {
   );
 }
 
+function isStalledModelCallRecoveryEligible(params: {
+  classification: SessionAttentionClassification | undefined;
+  activity?: DiagnosticSessionActivitySnapshot;
+  stuckSessionAbortMs: number;
+}): boolean {
+  const lastProgressAgeMs = params.activity?.lastProgressAgeMs;
+  return (
+    params.classification?.eventType === "session.stalled" &&
+    params.classification.classification === "stalled_agent_run" &&
+    params.classification.activeWorkKind === "model_call" &&
+    params.activity?.hasActiveEmbeddedRun === true &&
+    typeof lastProgressAgeMs === "number" &&
+    lastProgressAgeMs >= params.stuckSessionAbortMs
+  );
+}
+
 function isActiveAbortRecoveryEligible(params: {
   classification: SessionAttentionClassification | undefined;
   activity?: DiagnosticSessionActivitySnapshot;
   ageMs: number;
   stuckSessionAbortMs: number;
 }): boolean {
-  return isStalledEmbeddedRunRecoveryEligible(params) || isBlockedToolCallRecoveryEligible(params);
+  return (
+    isStalledEmbeddedRunRecoveryEligible(params) ||
+    isBlockedToolCallRecoveryEligible(params) ||
+    isStalledModelCallRecoveryEligible(params)
+  );
+}
+
+function isIdleQueuedEmbeddedRunStall(params: {
+  state: {
+    state: SessionStateValue;
+    queueDepth: number;
+  };
+  activity: DiagnosticSessionActivitySnapshot;
+  staleMs: number;
+}): boolean {
+  return (
+    params.state.state === "idle" &&
+    params.state.queueDepth > 0 &&
+    params.activity.activeWorkKind === "embedded_run" &&
+    (params.activity.lastProgressAgeMs ?? 0) > params.staleMs
+  );
 }
 
 export function logWebhookReceived(params: {
@@ -1053,16 +1089,27 @@ export function startDiagnosticHeartbeat(
 
     for (const [, state] of diagnosticSessionStates) {
       const ageMs = now - state.lastActivity;
-      if (state.state === "processing" && ageMs > stuckSessionWarnMs) {
-        const activity = getDiagnosticSessionActivitySnapshot(
-          { sessionId: state.sessionId, sessionKey: state.sessionKey },
-          now,
-        );
+      const activity = getDiagnosticSessionActivitySnapshot(
+        { sessionId: state.sessionId, sessionKey: state.sessionKey },
+        now,
+      );
+      const idleQueuedEmbeddedRunStall = isIdleQueuedEmbeddedRunStall({
+        state,
+        activity,
+        staleMs: stuckSessionWarnMs,
+      });
+      if (
+        (state.state === "processing" && ageMs > stuckSessionWarnMs) ||
+        idleQueuedEmbeddedRunStall
+      ) {
+        const attentionAgeMs = idleQueuedEmbeddedRunStall
+          ? (activity.lastProgressAgeMs ?? ageMs)
+          : ageMs;
         const classification = logSessionAttention({
           sessionId: state.sessionId,
           sessionKey: state.sessionKey,
           state: state.state,
-          ageMs,
+          ageMs: attentionAgeMs,
           thresholdMs: stuckSessionWarnMs,
           abortThresholdMs: stuckSessionAbortMs,
         });
@@ -1073,8 +1120,9 @@ export function startDiagnosticHeartbeat(
             request: {
               sessionId: state.sessionId,
               sessionKey: state.sessionKey,
-              ageMs,
+              ageMs: attentionAgeMs,
               queueDepth: state.queueDepth,
+              expectedState: state.state,
               stateGeneration: state.generation,
             },
           });
@@ -1083,7 +1131,7 @@ export function startDiagnosticHeartbeat(
           isActiveAbortRecoveryEligible({
             classification,
             activity,
-            ageMs,
+            ageMs: attentionAgeMs,
             stuckSessionAbortMs,
           })
         ) {
@@ -1093,9 +1141,10 @@ export function startDiagnosticHeartbeat(
             request: {
               sessionId: state.sessionId,
               sessionKey: state.sessionKey,
-              ageMs,
+              ageMs: attentionAgeMs,
               queueDepth: state.queueDepth,
               allowActiveAbort: true,
+              expectedState: state.state,
               stateGeneration: state.generation,
             },
           });

--- a/src/logging/diagnostic.ts
+++ b/src/logging/diagnostic.ts
@@ -28,6 +28,7 @@ import {
 } from "./diagnostic-runtime.js";
 import {
   classifySessionAttention,
+  isTerminalDiagnosticProgressReason,
   type SessionAttentionClassification,
 } from "./diagnostic-session-attention.js";
 import {
@@ -757,20 +758,6 @@ function sessionAttentionFields(params: {
       : {}),
     ...(terminalProgressStale ? { terminalProgressStale: true } : {}),
   };
-}
-
-function isTerminalDiagnosticProgressReason(reason: string | undefined): boolean {
-  if (!reason) {
-    return false;
-  }
-  return (
-    reason === "run:completed" ||
-    reason === "embedded_run:ended" ||
-    reason.includes("response.completed") ||
-    reason.includes("rawResponseItem/completed") ||
-    reason.includes("raw_response_item.completed") ||
-    reason.includes("output_item.done")
-  );
 }
 
 function formatSessionActivityLogFields(activity: DiagnosticSessionActivitySnapshot): string {


### PR DESCRIPTION
## Why

This is a narrow release-stability bundle for operators who need a branch they can run for 1-2 weeks while the broader OpenClaw mainline settles.

It deliberately avoids a full Codex-harness migration. The patch only carries targeted recovery/visibility fixes for failures already seen in the unstable release path:

- stuck sessions queued behind terminal-looking embedded progress
- stale idle embedded-run lanes with queued work
- stale `model_call` / tool activity masking an active embedded run from idle queued recovery
- stale OpenAI Codex OAuth `lastGood` pointers after `refresh_token_reused`
- operator visibility for runtime-policy session aliases and Codex-backed runtime auth routes

LCM remains out of scope here because that fix is tracked separately in `lossless-claw`.

## Issue Links

- Fixes / complements #71127.
  - This PR includes the small safe pieces from #82733 plus the missing stale `model_call` and idle queued embedded-owner recovery gates.
  - It does not change channel/plugin startup semantics or command-lane scheduling policy.
- Fixes #79021 by clearing only the matching stale `lastGood` profile after `refresh_token_reused`, reloading the runtime store, and preserving the actual healthy fallback profile id for later success marking.
- References #83484 by exposing the runtime-policy session alias without changing session persistence.
- References #83485 by showing `auth.runtimeAuthRoutes` for Codex-backed OpenAI routes.

## What Changed

### Stuck-session recovery

- `src/logging/diagnostic.ts`
  - recovers idle queued embedded-run stalls when progress has gone stale
  - treats `hasActiveEmbeddedRun` as the ownership guard when the visible active work is `model_call` or `tool_call`
  - allows stale `model_call` activity to request active abort only when the activity snapshot still has an active embedded-run owner
  - passes the expected diagnostic state into recovery requests

- `src/logging/diagnostic-run-activity.ts`
  - exposes `hasActiveEmbeddedRun` in the activity snapshot so model-call recovery remains scoped to embedded-run work

- `src/logging/diagnostic-session-recovery*.ts`
  - accepts expected `idle` recovery state
  - records queued lane work on abort outcomes
  - preserves real queued idle work when abort/reset releases active lane work

### Auth fallback

- `src/agents/auth-profiles/oauth.ts`
  - on `refresh_token_reused`, clears only a matching stale `lastGood` pointer
  - resolves the persisted owner store for inherited profiles
  - patches the requesting runtime snapshot when needed
  - reloads the runtime store before choosing a legacy-default fallback
  - returns the actual fallback profile id/type so provider-level auth does not re-mark the stale profile as successful

- `src/agents/auth-profiles/profiles.ts`
  - adds the locked `clearLastGoodProfileWithLock` helper

### Operator visibility

- `src/commands/models/list.status-command.ts`
  - adds `auth.runtimeAuthRoutes` to JSON output
  - adds a human `Runtime auth` section for Codex-backed OpenAI text routes
  - reports compatible OpenAI API-key profile auth as the effective Codex runtime route source instead of `status=usable` plus `effective=missing`

- `src/commands/sessions.ts` and `src/commands/sessions-table.ts`
  - derives and displays a `runtimePolicySessionKey` alias for collapsed external direct sessions
  - keeps the persisted row key unchanged

## Real Behavior Proof

- Behavior or issue addressed: Release-stability operators need stuck OpenClaw sessions to become recoverable instead of requiring gateway restarts, need stale Codex OAuth `lastGood` loops to fall through to healthy profiles without re-poisoning `lastGood`, need collapsed external-DM sessions to expose their runtime-policy alias, and need `models status --json` to show trustworthy Codex-backed OpenAI auth routes.
- Real environment tested: Real OpenClaw CLI entrypoint from this checkout on local macOS, with `OPENCLAW_STATE_DIR=/Volumes/LEXAR/Codex/openclaw-release-stability-state` so existing `~/.openclaw/openclaw.json` did not affect the result. Focused diagnostic/auth/status regression commands were also run locally from `/Volumes/LEXAR/repos/openclaw-release-stability-fixes` after the adversarial-review follow-up commit `b5da773c59`.
- Exact steps or command run after this patch:

```bash
OPENCLAW_STATE_DIR=/Volumes/LEXAR/Codex/openclaw-release-stability-state \
OPENCLAW_TEST_FAST=1 \
pnpm openclaw sessions --json \
  --store /Volumes/LEXAR/Codex/openclaw-release-stability-sessions-proof.json \
  --limit 1

OPENCLAW_STATE_DIR=/Volumes/LEXAR/Codex/openclaw-release-stability-state \
OPENCLAW_TEST_FAST=1 \
pnpm openclaw models status --json

OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run \
  src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts \
  src/agents/model-auth.profiles.test.ts \
  src/commands/models/list.status.test.ts

OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.logging.config.ts \
  src/logging/diagnostic.test.ts \
  src/logging/diagnostic-stuck-session-recovery.runtime.test.ts \
  src/logging/diagnostic-stuck-session-recovery.integration.test.ts \
  src/logging/diagnostic-session-attention.test.ts \
  src/logging/diagnostic-run-activity.test.ts
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied live terminal output from the real OpenClaw CLI smoke showed the runtime-policy alias and Codex runtime auth route:

```json
{
  "path": "/Volumes/LEXAR/Codex/openclaw-release-stability-sessions-proof.json",
  "count": 1,
  "sessions": [
    {
      "key": "agent:main:main",
      "sessionId": "release-stability-proof",
      "agentRuntime": {
        "id": "codex",
        "source": "implicit"
      },
      "runtimePolicySessionKey": "agent:main:telegram:default:direct:42"
    }
  ]
}
```

```json
{
  "auth": {
    "missingProvidersInUse": ["openai"],
    "runtimeAuthRoutes": [
      {
        "provider": "openai",
        "runtime": "codex",
        "authProvider": "openai-codex",
        "status": "missing",
        "effective": {
          "kind": "missing",
          "detail": "missing"
        }
      }
    ]
  }
}
```

Focused regression output after the adversarial-review fixes:

```text
Test Files  5 passed (5)
Tests  165 passed (165)

Test Files  3 passed (3)
Tests  64 passed (64)

Checking formatting...
All matched files use the correct format.
```

- Observed result after fix: `sessions --json` returned the persisted row key `agent:main:main` plus `runtimePolicySessionKey: "agent:main:telegram:default:direct:42"`; `models status --json` returned `auth.runtimeAuthRoutes[0]` showing `provider: "openai"`, `runtime: "codex"`, `authProvider: "openai-codex"`, and `status: "missing"` for the isolated no-auth state. Focused regressions proved that idle queued embedded-run stalls request `expectedState: "idle"`, stale `model_call` recovery is gated by `hasActiveEmbeddedRun`, idle queued work still recovers when embedded ownership is surfaced as `model_call`, ordinary stale model calls without embedded ownership do not abort, queued idle work is preserved when `queuedCount > 0`, stale `openai-codex:default` `refresh_token_reused` clears matching `lastGood`, provider-level auth reports the healthy fallback profile id, and compatible OpenAI API-key profiles no longer produce contradictory runtime-auth status.
- What was not tested: No live Telegram message was sent, no LCM behavior was exercised, no channel/plugin startup semantics were changed, and no blanket auth-route rewrite for `openai/gpt-5.5` was attempted.
- Before evidence (optional but encouraged): The linked reports #71127 and #79021 contain the before-fix symptoms. #71127 shows queued sessions stuck behind terminal embedded progress with `recovery=none`; #79021 shows `openai-codex` `refresh_token_reused` loops while stale `lastGood.openai-codex` still points at the failed profile.

## Validation

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run \
  src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts \
  src/agents/model-auth.profiles.test.ts \
  src/commands/models/list.status.test.ts
```

Result: `5 passed`, `165 passed`.

```bash
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.logging.config.ts \
  src/logging/diagnostic.test.ts \
  src/logging/diagnostic-stuck-session-recovery.runtime.test.ts \
  src/logging/diagnostic-stuck-session-recovery.integration.test.ts \
  src/logging/diagnostic-session-attention.test.ts \
  src/logging/diagnostic-run-activity.test.ts
```

Result: `3 passed`, `64 passed`.

```bash
pnpm exec oxfmt --check --threads=1 \
  src/agents/auth-profiles/oauth.openai-codex-refresh-fallback.test.ts \
  src/agents/auth-profiles/oauth.ts \
  src/agents/model-auth.ts \
  src/commands/models/list.status-command.ts \
  src/commands/models/list.status.test.ts \
  src/logging/diagnostic.test.ts \
  src/logging/diagnostic.ts
```

Result: all matched files formatted.

```bash
git diff --check
```

Result: clean.

## Adversarial Review

Four read-only subagents reviewed the PR by slice: auth fallback/token-burn, diagnostic recovery/queue safety, models/sessions observability, and test/release-branch scope. Confirmed findings fixed in `b5da773c59`:

- P1: provider-level auth could return a healthy fallback token while still attributing success to stale `openai-codex:default`, re-poisoning `lastGood`.
- P1: idle queued recovery only recognized `activeWorkKind=embedded_run`, missing stale embedded-owned work surfaced as `model_call` or `tool_call`.
- P2: `models status` could show `status=usable` while `effective=missing` for compatible OpenAI API-key profiles used by Codex runtime routes.

## Non-Goals

- no LCM changes
- no Telegram/channel startup rewrite
- no command-lane scheduling rewrite
- no session persistence change
- no broad Codex-harness migration
- no blanket auth-route rewrite for `openai/gpt-5.5`

