### PR TITLE
fix(telegram): recover stalled isolated spool handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Docs: https://docs.openclaw.ai
 - Agents/subagents: preserve run-mode keep subagent registry entries past the session sweep TTL, so kept subagent runs remain visible after cleanup completes. Fixes #83132. (#83168) Thanks @yetval.
 - Agents/OpenAI streams: yield via `setTimeout(0)` instead of `setImmediate` between bursty Responses chunks so abort timers can fire during the yield, keeping cancel-on-timeout responsive on hot streams. Refs #82462.
 - Agents/Codex: keep legacy `oauthRef`-backed OAuth profiles usable while `openclaw doctor --fix` migrates them back to inline credentials, without creating new sidecar credentials. (#83312) Thanks @joshavant.
+- Telegram: fail stalled isolated-ingress handlers into tombstones and abort same-lane reply work before restarting, so later same-chat updates drain after a hung turn. Fixes #83272. (#83505) Thanks @joshavant.
 - CLI/config: send SecretRef diagnostics to stderr so JSON command stdout remains parseable.
 - CLI/doctor: seed Control UI allowed origins when migrating legacy non-loopback gateway bind host aliases like `0.0.0.0`. Fixes #83286. Thanks @giodl73-repo.
 - CLI/plugins: ship the bundled memory CLI as a package entry so package-installed `openclaw memory` commands register correctly.

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2108,6 +2108,88 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(deliveredTexts).not.toContain("stale ambient answer");
   });
 
+  it("lets newer user requests abort active same-session dispatch", async () => {
+    const historyKey = "telegram:group:-100123";
+    const groupHistories = new Map([[historyKey, []]]);
+    let firstStarted: (() => void) | undefined;
+    const firstStartGate = new Promise<void>((resolve) => {
+      firstStarted = resolve;
+    });
+    let releaseFirst: (() => void) | undefined;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let secondStarted: (() => void) | undefined;
+    const secondStartGate = new Promise<void>((resolve) => {
+      secondStarted = resolve;
+    });
+    let firstAbortSignal: AbortSignal | undefined;
+    dispatchReplyWithBufferedBlockDispatcher
+      .mockImplementationOnce(async ({ replyOptions }) => {
+        firstAbortSignal = replyOptions?.abortSignal;
+        firstStarted?.();
+        await firstGate;
+        return {
+          queuedFinal: false,
+          counts: { block: 0, final: 0, tool: 0 },
+        };
+      })
+      .mockImplementationOnce(async ({ dispatcherOptions }) => {
+        secondStarted?.();
+        await dispatcherOptions.deliver({ text: "fresh request answer" }, { kind: "final" });
+        return {
+          queuedFinal: true,
+          counts: { block: 0, final: 1, tool: 0 },
+        };
+      });
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    const createGroupContext = (messageId: number, body: string) =>
+      createContext({
+        ctxPayload: {
+          SessionKey: "agent:main:telegram:group:-100123",
+          ChatType: "group",
+          MessageSid: String(messageId),
+          RawBody: body,
+          BodyForAgent: body,
+          CommandBody: body,
+          CommandAuthorized: true,
+        } as unknown as TelegramMessageContext["ctxPayload"],
+        msg: {
+          chat: { id: -100123, type: "supergroup" },
+          message_id: messageId,
+        } as unknown as TelegramMessageContext["msg"],
+        chatId: -100123,
+        isGroup: true,
+        historyKey,
+        historyLimit: 10,
+        groupHistories,
+        threadSpec: { id: undefined, scope: "none" },
+      });
+
+    const firstPromise = dispatchWithContext({
+      context: createGroupContext(99, "@bot first request"),
+      streamMode: "off",
+    });
+    await firstStartGate;
+    const secondPromise = dispatchWithContext({
+      context: createGroupContext(100, "@bot second request"),
+      streamMode: "off",
+    });
+    await secondStartGate;
+
+    expect(firstAbortSignal?.aborted).toBe(true);
+    releaseFirst?.();
+    await Promise.all([firstPromise, secondPromise]);
+
+    const deliveredTexts = deliverReplies.mock.calls.flatMap((call) =>
+      ((call[0] as { replies?: Array<{ text?: string }> }).replies ?? []).map(
+        (reply) => reply.text,
+      ),
+    );
+    expect(deliveredTexts).toContain("fresh request answer");
+  });
+
   it("keeps queued room events abortable after their source dispatch returns", async () => {
     const historyKey = "telegram:group:-100123";
     const groupHistories = new Map([[historyKey, []]]);

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -28,7 +28,6 @@ import {
   resolveChannelStreamingPreviewToolProgress,
   resolveTranscriptBackedChannelFinalText,
 } from "openclaw/plugin-sdk/channel-streaming";
-import { isAbortRequestText } from "openclaw/plugin-sdk/command-primitives-runtime";
 import type {
   OpenClawConfig,
   ReplyToMode,
@@ -107,9 +106,23 @@ import {
   splitTelegramReasoningText,
 } from "./reasoning-lane-coordinator.js";
 import { editMessageTelegram } from "./send.js";
+import { getTelegramSequentialKey } from "./sequential-key.js";
 import { cacheSticker, describeStickerImage } from "./sticker-cache.js";
+import {
+  beginTelegramReplyFence,
+  buildTelegramReplyFenceLaneKey,
+  endTelegramReplyFence,
+  getTelegramReplyFenceSizeForTests,
+  isTelegramReplyFenceSuperseded,
+  releaseTelegramReplyFenceAbortController,
+  resetTelegramReplyFenceForTests,
+  resolveTelegramReplyFenceKey,
+  shouldSupersedeTelegramReplyFence,
+  supersedeTelegramReplyFence,
+} from "./telegram-reply-fence.js";
 
 export { pruneStickerMediaFromContext } from "./bot-message-dispatch.media.js";
+export { getTelegramReplyFenceSizeForTests, resetTelegramReplyFenceForTests };
 
 const EMPTY_RESPONSE_FALLBACK = "No response generated. Please try again.";
 const silentReplyDispatchLogger = createSubsystemLogger("telegram/silent-reply-dispatch");
@@ -179,140 +192,6 @@ type DispatchTelegramMessageParams = {
 type TelegramReasoningLevel = "off" | "on" | "stream";
 
 type TelegramTranscriptMirrorPayload = { text?: string; mediaUrls?: string[] };
-
-type TelegramReplyFenceState = {
-  generation: number;
-  activeDispatches: number;
-  abortControllers?: Set<AbortController>;
-};
-
-type TelegramReplyFenceKey = {
-  activeKey: string;
-  roomEventKey: string;
-};
-
-// Newer accepted turns and authorized aborts can arrive ahead of older same-session reply work.
-const telegramReplyFenceByKey = new Map<string, TelegramReplyFenceState>();
-
-function normalizeTelegramFenceKey(value: unknown): string | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : undefined;
-}
-
-function resolveTelegramReplyFenceKey(params: {
-  ctxPayload: { SessionKey?: string; CommandTargetSessionKey?: string; InboundEventKind?: string };
-  chatId: number | string;
-  threadSpec: { id?: number | string | null; scope?: string };
-}): TelegramReplyFenceKey {
-  const baseKey =
-    normalizeTelegramFenceKey(params.ctxPayload.CommandTargetSessionKey) ??
-    normalizeTelegramFenceKey(params.ctxPayload.SessionKey) ??
-    `telegram:${String(params.chatId)}:${params.threadSpec.scope ?? "default"}:${params.threadSpec.id ?? "root"}`;
-  const roomEventKey = `${baseKey}:room_event`;
-  return {
-    activeKey: params.ctxPayload.InboundEventKind === "room_event" ? roomEventKey : baseKey,
-    roomEventKey,
-  };
-}
-
-function abortTelegramReplyFenceControllers(state: TelegramReplyFenceState): void {
-  for (const controller of state.abortControllers ?? []) {
-    controller.abort();
-  }
-  state.abortControllers?.clear();
-}
-
-function beginTelegramReplyFence(params: {
-  key: string;
-  supersede: boolean;
-  abortController?: AbortController;
-}): number {
-  const existing = telegramReplyFenceByKey.get(params.key);
-  const state: TelegramReplyFenceState = existing ?? {
-    generation: 0,
-    activeDispatches: 0,
-  };
-  if (params.supersede) {
-    state.generation += 1;
-    abortTelegramReplyFenceControllers(state);
-  }
-  if (params.abortController) {
-    (state.abortControllers ??= new Set()).add(params.abortController);
-  }
-  state.activeDispatches += 1;
-  telegramReplyFenceByKey.set(params.key, state);
-  return state.generation;
-}
-
-function supersedeTelegramReplyFence(key: string): void {
-  const state = telegramReplyFenceByKey.get(key);
-  if (!state) {
-    return;
-  }
-  state.generation += 1;
-  abortTelegramReplyFenceControllers(state);
-  if (state.activeDispatches <= 0 && (state.abortControllers?.size ?? 0) === 0) {
-    telegramReplyFenceByKey.delete(key);
-  } else {
-    telegramReplyFenceByKey.set(key, state);
-  }
-}
-
-function isTelegramReplyFenceSuperseded(params: { key: string; generation: number }): boolean {
-  return (telegramReplyFenceByKey.get(params.key)?.generation ?? 0) !== params.generation;
-}
-
-function endTelegramReplyFence(key: string, abortController?: AbortController): void {
-  const state = telegramReplyFenceByKey.get(key);
-  if (!state) {
-    return;
-  }
-  if (abortController) {
-    state.abortControllers?.delete(abortController);
-  }
-  state.activeDispatches = Math.max(0, state.activeDispatches - 1);
-  if (state.activeDispatches <= 0 && (state.abortControllers?.size ?? 0) === 0) {
-    telegramReplyFenceByKey.delete(key);
-  }
-}
-
-function releaseTelegramReplyFenceAbortController(
-  key: string,
-  abortController?: AbortController,
-): void {
-  if (!abortController) {
-    return;
-  }
-  const state = telegramReplyFenceByKey.get(key);
-  if (!state) {
-    return;
-  }
-  state.abortControllers?.delete(abortController);
-  if (state.activeDispatches <= 0 && (state.abortControllers?.size ?? 0) === 0) {
-    telegramReplyFenceByKey.delete(key);
-  }
-}
-
-function shouldSupersedeTelegramReplyFence(ctxPayload: {
-  Body?: string;
-  RawBody?: string;
-  CommandBody?: string;
-  CommandAuthorized: boolean;
-}): boolean {
-  const dispatchText = ctxPayload.CommandBody ?? ctxPayload.RawBody ?? ctxPayload.Body ?? "";
-  return !isAbortRequestText(dispatchText) || ctxPayload.CommandAuthorized;
-}
-
-export function getTelegramReplyFenceSizeForTests(): number {
-  return telegramReplyFenceByKey.size;
-}
-
-export function resetTelegramReplyFenceForTests(): void {
-  telegramReplyFenceByKey.clear();
-}
 
 function resolveTelegramReasoningLevel(params: {
   cfg: OpenClawConfig;
@@ -531,9 +410,17 @@ export const dispatchTelegramMessage = async ({
     chatId,
     threadSpec,
   });
+  const replyFenceLaneKey = getTelegramSequentialKey({
+    message: msg,
+    ...(context.primaryCtx.me ? { me: context.primaryCtx.me } : {}),
+  });
+  const scopedReplyFenceLaneKey = buildTelegramReplyFenceLaneKey({
+    accountId: route.accountId,
+    sequentialKey: replyFenceLaneKey,
+  });
   let replyFenceGeneration: number | undefined;
-  const roomEventAbortController = isRoomEvent ? new AbortController() : undefined;
-  let roomEventAbortControllerQueued = false;
+  const replyAbortController = new AbortController();
+  let replyAbortControllerQueued = false;
   let dispatchWasSuperseded = false;
   const isDispatchSuperseded = () =>
     replyFenceGeneration !== undefined &&
@@ -547,7 +434,7 @@ export const dispatchTelegramMessage = async ({
     }
     endTelegramReplyFence(
       replyFenceKey.activeKey,
-      roomEventAbortControllerQueued ? undefined : roomEventAbortController,
+      replyAbortControllerQueued ? undefined : replyAbortController,
     );
     replyFenceGeneration = undefined;
   };
@@ -940,7 +827,8 @@ export const dispatchTelegramMessage = async ({
   replyFenceGeneration = beginTelegramReplyFence({
     key: replyFenceKey.activeKey,
     supersede: supersedeReplyFence,
-    abortController: roomEventAbortController,
+    abortController: replyAbortController,
+    laneKey: scopedReplyFenceLaneKey,
   });
 
   const implicitQuoteReplyTargetId =
@@ -1567,26 +1455,25 @@ export const dispatchTelegramMessage = async ({
                 replyOptions: {
                   skillFilter,
                   disableBlockStreaming,
-                  abortSignal: roomEventAbortController?.signal,
+                  abortSignal: replyAbortController.signal,
                   sourceReplyDeliveryMode: isRoomEvent ? "message_tool_only" : undefined,
                   queuedDeliveryCorrelations: isRoomEvent
                     ? [{ begin: beginDeliveryCorrelation }]
                     : undefined,
-                  queuedFollowupLifecycle:
-                    isRoomEvent && roomEventAbortController
-                      ? {
-                          onEnqueued: () => {
-                            roomEventAbortControllerQueued = true;
-                          },
-                          onComplete: () => {
-                            roomEventAbortControllerQueued = false;
-                            releaseTelegramReplyFenceAbortController(
-                              replyFenceKey.activeKey,
-                              roomEventAbortController,
-                            );
-                          },
-                        }
-                      : undefined,
+                  queuedFollowupLifecycle: isRoomEvent
+                    ? {
+                        onEnqueued: () => {
+                          replyAbortControllerQueued = true;
+                        },
+                        onComplete: () => {
+                          replyAbortControllerQueued = false;
+                          releaseTelegramReplyFenceAbortController(
+                            replyFenceKey.activeKey,
+                            replyAbortController,
+                          );
+                        },
+                      }
+                    : undefined,
                   suppressTyping: isRoomEvent,
                   onPartialReply:
                     answerLane.stream || reasoningLane.stream

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -1892,11 +1892,11 @@ describe("TelegramPollingSession", () => {
     const regularTurnDone = new Promise<void>((resolve) => {
       releaseRegularTurn = resolve;
     });
-    const originalWriteFile = fs.writeFile.bind(fs) as typeof fs.writeFile;
+    const originalWriteFile = fs.writeFile.bind(fs);
     const writeFileSpy = vi
       .spyOn(fs, "writeFile")
       .mockImplementation(async (...args: Parameters<typeof fs.writeFile>) => {
-        if (String(args[0]).includes(".json.failed.")) {
+        if (typeof args[0] === "string" && args[0].includes(".json.failed.")) {
           throw new Error("disk full");
         }
         return await originalWriteFile(...args);

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -53,9 +53,14 @@ vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
 let TelegramPollingSession: typeof import("./polling-session.js").TelegramPollingSession;
 let claimTelegramSpooledUpdate: typeof import("./telegram-ingress-spool.js").claimTelegramSpooledUpdate;
 let isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess: typeof import("./telegram-ingress-spool.js").isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess;
+let listTelegramSpooledUpdateClaims: typeof import("./telegram-ingress-spool.js").listTelegramSpooledUpdateClaims;
 let listTelegramSpooledUpdates: typeof import("./telegram-ingress-spool.js").listTelegramSpooledUpdates;
 let recoverStaleTelegramSpooledUpdateClaims: typeof import("./telegram-ingress-spool.js").recoverStaleTelegramSpooledUpdateClaims;
 let writeTelegramSpooledUpdate: typeof import("./telegram-ingress-spool.js").writeTelegramSpooledUpdate;
+let beginTelegramReplyFence: typeof import("./telegram-reply-fence.js").beginTelegramReplyFence;
+let buildTelegramReplyFenceLaneKey: typeof import("./telegram-reply-fence.js").buildTelegramReplyFenceLaneKey;
+let endTelegramReplyFence: typeof import("./telegram-reply-fence.js").endTelegramReplyFence;
+let resetTelegramReplyFenceForTests: typeof import("./telegram-reply-fence.js").resetTelegramReplyFenceForTests;
 
 type TelegramApiMiddleware = (
   prev: (...args: unknown[]) => Promise<unknown>,
@@ -336,6 +341,33 @@ function topicUpdate(updateId: number, threadId: number, text: string): TestTele
   };
 }
 
+async function waitForAbortSignal(signal: AbortSignal): Promise<void> {
+  if (signal.aborted) {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    signal.addEventListener("abort", () => resolve(), { once: true });
+  });
+}
+
+async function waitForTestReplyFenceAbort(params: { key: string; laneKey: string }): Promise<void> {
+  const controller = new AbortController();
+  beginTelegramReplyFence({
+    key: params.key,
+    laneKey: buildTelegramReplyFenceLaneKey({
+      accountId: "default",
+      sequentialKey: params.laneKey,
+    }),
+    supersede: false,
+    abortController: controller,
+  });
+  try {
+    await waitForAbortSignal(controller.signal);
+  } finally {
+    endTelegramReplyFence(params.key, controller);
+  }
+}
+
 async function writeSpooledTestUpdates(
   spoolDir: string,
   updates: readonly TestTelegramUpdate[],
@@ -347,6 +379,19 @@ async function writeSpooledTestUpdates(
 
 async function pendingUpdateIds(spoolDir: string, limit: number | "all" = 100): Promise<number[]> {
   return (await listTelegramSpooledUpdates({ spoolDir, limit })).map((update) => update.updateId);
+}
+
+async function failedUpdateIds(spoolDir: string): Promise<number[]> {
+  const entries = await fs.readdir(spoolDir).catch((err) => {
+    if ((err as { code?: string }).code === "ENOENT") {
+      return [];
+    }
+    throw err;
+  });
+  return entries
+    .filter((entry) => entry.endsWith(".json.failed"))
+    .map((entry) => Number(entry.slice(0, 16)))
+    .toSorted((a, b) => a - b);
 }
 
 async function withTempSpool<T>(fn: (spoolDir: string) => Promise<T>): Promise<T> {
@@ -385,6 +430,7 @@ function startIsolatedIngressSession(params: {
   drainIntervalMs?: number;
   log?: (message: string) => void;
   stop?: () => Promise<void>;
+  spooledUpdateHandlerTimeoutMs?: number;
 }) {
   const worker = createIdleIngressWorker();
   const bot = {
@@ -405,6 +451,9 @@ function startIsolatedIngressSession(params: {
       spoolDir: params.spoolDir,
       createWorker: worker.createWorker,
       drainIntervalMs: params.drainIntervalMs ?? 10,
+      ...(params.spooledUpdateHandlerTimeoutMs !== undefined
+        ? { spooledUpdateHandlerTimeoutMs: params.spooledUpdateHandlerTimeoutMs }
+        : {}),
     },
   });
   return {
@@ -421,10 +470,17 @@ describe("TelegramPollingSession", () => {
     ({
       claimTelegramSpooledUpdate,
       isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess,
+      listTelegramSpooledUpdateClaims,
       listTelegramSpooledUpdates,
       recoverStaleTelegramSpooledUpdateClaims,
       writeTelegramSpooledUpdate,
     } = await import("./telegram-ingress-spool.js"));
+    ({
+      beginTelegramReplyFence,
+      buildTelegramReplyFenceLaneKey,
+      endTelegramReplyFence,
+      resetTelegramReplyFenceForTests,
+    } = await import("./telegram-reply-fence.js"));
   });
 
   beforeEach(() => {
@@ -434,6 +490,7 @@ describe("TelegramPollingSession", () => {
     computeBackoffMock.mockReset().mockReturnValue(0);
     sleepWithAbortMock.mockReset().mockResolvedValue(undefined);
     drainPendingDeliveriesMock.mockReset().mockResolvedValue(undefined);
+    resetTelegramReplyFenceForTests();
   });
 
   it("uses backoff helpers for recoverable polling retries", async () => {
@@ -1575,7 +1632,365 @@ describe("TelegramPollingSession", () => {
     }
   });
 
-  it("marks isolated ingress unhealthy when a spooled backlog wedges while polling stays live", async () => {
+  it("fails a timed-out spooled handler and restarts before draining later same-lane updates", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const abort = new AbortController();
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));
+    const log = vi.fn();
+    const setStatus = vi.fn();
+    const events: string[] = [];
+    const firstBot = {
+      api: {
+        deleteWebhook: vi.fn(async () => true),
+        config: { use: vi.fn() },
+      },
+      init: vi.fn(async () => undefined),
+      handleUpdate: vi.fn(async (update: { update_id?: number }) => {
+        events.push(`first:${update.update_id}`);
+        await waitForTestReplyFenceAbort({
+          key: "test-session:topic-10",
+          laneKey: "telegram:-100:topic:10",
+        });
+      }),
+      stop: vi.fn(async () => undefined),
+    };
+    const secondBot = {
+      api: {
+        deleteWebhook: vi.fn(async () => true),
+        config: { use: vi.fn() },
+      },
+      init: vi.fn(async () => undefined),
+      handleUpdate: vi.fn(async (update: { update_id?: number }) => {
+        events.push(`second:${update.update_id}`);
+        abort.abort();
+      }),
+      stop: vi.fn(async () => undefined),
+    };
+    createTelegramBotMock.mockReturnValueOnce(firstBot).mockReturnValueOnce(secondBot);
+    await writeSpooledTestUpdates(tempDir, [
+      topicUpdate(42, 10, "wedged topic 10 turn"),
+      topicUpdate(43, 10, "later topic 10 turn"),
+    ]);
+
+    const worker = createIdleIngressWorker();
+    const session = createPollingSession({
+      abortSignal: abort.signal,
+      log,
+      isolatedIngress: {
+        enabled: true,
+        spoolDir: tempDir,
+        createWorker: worker.createWorker,
+        drainIntervalMs: 10,
+        spooledUpdateHandlerTimeoutMs: 100,
+        spooledUpdateHandlerAbortGraceMs: 100,
+      },
+    });
+
+    try {
+      const runPromise = session.runUntilAbort();
+      await vi.waitFor(() => expect(events).toEqual(["first:42"]));
+
+      await vi.advanceTimersByTimeAsync(150);
+      await vi.waitFor(() => expect(worker.createWorker).toHaveBeenCalledTimes(2));
+      await vi.waitFor(() => expect(events).toEqual(["first:42", "second:43"]));
+      await runPromise;
+
+      expect(createTelegramBotMock).toHaveBeenCalledTimes(2);
+      expect(firstBot.stop).toHaveBeenCalledTimes(1);
+      expect(secondBot.stop).toHaveBeenCalledTimes(1);
+      expect(await pendingUpdateIds(tempDir, "all")).toEqual([]);
+      expect(await failedUpdateIds(tempDir)).toEqual([42]);
+      expectLogIncludes(log, "spool handler timed out behind update 42");
+    } finally {
+      abort.abort();
+      worker.stop();
+      vi.useRealTimers();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps a timed-out lane guarded until the old handler stops", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const abort = new AbortController();
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));
+    const log = vi.fn();
+    const events: string[] = [];
+    let releaseFirstTurn: (() => void) | undefined;
+    const firstTurnDone = new Promise<void>((resolve) => {
+      releaseFirstTurn = resolve;
+    });
+    createTelegramBotMock.mockReturnValueOnce({
+      api: {
+        deleteWebhook: vi.fn(async () => true),
+        config: { use: vi.fn() },
+      },
+      init: vi.fn(async () => undefined),
+      handleUpdate: vi.fn(async (update: { update_id?: number }) => {
+        events.push(`first:${update.update_id}`);
+        await firstTurnDone;
+      }),
+      stop: vi.fn(async () => undefined),
+    });
+    await writeSpooledTestUpdates(tempDir, [
+      topicUpdate(42, 10, "wedged topic 10 turn"),
+      topicUpdate(43, 10, "later topic 10 turn"),
+    ]);
+
+    const worker = createIdleIngressWorker();
+    const session = createPollingSession({
+      abortSignal: abort.signal,
+      log,
+      isolatedIngress: {
+        enabled: true,
+        spoolDir: tempDir,
+        createWorker: worker.createWorker,
+        drainIntervalMs: 10,
+        spooledUpdateHandlerTimeoutMs: 100,
+        spooledUpdateHandlerAbortGraceMs: 100,
+      },
+    });
+
+    try {
+      const runPromise = session.runUntilAbort();
+      await vi.waitFor(() => expect(events).toEqual(["first:42"]));
+
+      await vi.advanceTimersByTimeAsync(250);
+      await vi.waitFor(() => expectLogIncludes(log, "did not stop within 100ms"));
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(worker.createWorker).toHaveBeenCalledTimes(1);
+      expect(events).toEqual(["first:42"]);
+      expect(await failedUpdateIds(tempDir)).toEqual([42]);
+      expect(await pendingUpdateIds(tempDir, "all")).toEqual([43]);
+
+      releaseFirstTurn?.();
+      abort.abort();
+      await vi.advanceTimersByTimeAsync(20_000);
+      await runPromise;
+    } finally {
+      releaseFirstTurn?.();
+      abort.abort();
+      worker.stop();
+      vi.useRealTimers();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not drain more updates on the old bot while a timeout restart is pending", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const abort = new AbortController();
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));
+    const events: string[] = [];
+    const firstBot = {
+      api: {
+        deleteWebhook: vi.fn(async () => true),
+        config: { use: vi.fn() },
+      },
+      init: vi.fn(async () => undefined),
+      handleUpdate: vi.fn(async (update: { update_id?: number }) => {
+        events.push(`first:${update.update_id}`);
+        await waitForTestReplyFenceAbort({
+          key: "test-session:topic-10",
+          laneKey: "telegram:-100:topic:10",
+        });
+      }),
+      stop: vi.fn(async () => undefined),
+    };
+    const secondBot = {
+      api: {
+        deleteWebhook: vi.fn(async () => true),
+        config: { use: vi.fn() },
+      },
+      init: vi.fn(async () => undefined),
+      handleUpdate: vi.fn(async (update: { update_id?: number }) => {
+        events.push(`second:${update.update_id}`);
+        abort.abort();
+      }),
+      stop: vi.fn(async () => undefined),
+    };
+    createTelegramBotMock.mockReturnValueOnce(firstBot).mockReturnValueOnce(secondBot);
+    await writeSpooledTestUpdates(tempDir, [
+      topicUpdate(42, 10, "wedged topic 10 turn"),
+      topicUpdate(43, 10, "later topic 10 turn"),
+    ]);
+
+    let releaseFirstWorker: (() => void) | undefined;
+    const firstWorkerDone = new Promise<void>((resolve) => {
+      releaseFirstWorker = resolve;
+    });
+    let releaseSecondWorker: (() => void) | undefined;
+    const secondWorkerDone = new Promise<void>((resolve) => {
+      releaseSecondWorker = resolve;
+    });
+    const firstWorkerStop = vi.fn(async () => undefined);
+    let workerIndex = 0;
+    const createWorker = vi.fn(() => {
+      workerIndex += 1;
+      if (workerIndex === 1) {
+        return {
+          onMessage: vi.fn(() => () => undefined),
+          stop: firstWorkerStop,
+          task: vi.fn(async () => {
+            await firstWorkerDone;
+          }),
+        };
+      }
+      return {
+        onMessage: vi.fn(() => () => undefined),
+        stop: vi.fn(async () => {
+          releaseSecondWorker?.();
+        }),
+        task: vi.fn(async () => {
+          await secondWorkerDone;
+        }),
+      };
+    });
+
+    try {
+      const session = createPollingSession({
+        abortSignal: abort.signal,
+        isolatedIngress: {
+          enabled: true,
+          spoolDir: tempDir,
+          createWorker,
+          drainIntervalMs: 10,
+          spooledUpdateHandlerTimeoutMs: 100,
+          spooledUpdateHandlerAbortGraceMs: 100,
+        },
+      });
+
+      const runPromise = session.runUntilAbort();
+      await vi.waitFor(() => expect(events).toEqual(["first:42"]));
+      await vi.advanceTimersByTimeAsync(150);
+      await vi.waitFor(() => expect(firstWorkerStop).toHaveBeenCalledTimes(1));
+
+      await vi.advanceTimersByTimeAsync(500);
+      expect(events).toEqual(["first:42"]);
+      expect(await pendingUpdateIds(tempDir, "all")).toEqual([43]);
+
+      releaseFirstWorker?.();
+      await vi.waitFor(() => expect(createWorker).toHaveBeenCalledTimes(2));
+      await vi.waitFor(() => expect(events).toEqual(["first:42", "second:43"]));
+      await runPromise;
+    } finally {
+      abort.abort();
+      releaseFirstWorker?.();
+      releaseSecondWorker?.();
+      vi.useRealTimers();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps a timed-out lane guarded when its failed tombstone cannot be written", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const abort = new AbortController();
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));
+    const log = vi.fn();
+    const setStatus = vi.fn();
+    const events: string[] = [];
+    let releaseRegularTurn: (() => void) | undefined;
+    const regularTurnDone = new Promise<void>((resolve) => {
+      releaseRegularTurn = resolve;
+    });
+    const originalWriteFile = fs.writeFile.bind(fs) as typeof fs.writeFile;
+    const writeFileSpy = vi
+      .spyOn(fs, "writeFile")
+      .mockImplementation(async (...args: Parameters<typeof fs.writeFile>) => {
+        if (String(args[0]).includes(".json.failed.")) {
+          throw new Error("disk full");
+        }
+        return await originalWriteFile(...args);
+      });
+    createTelegramBotMock.mockReturnValueOnce({
+      api: {
+        deleteWebhook: vi.fn(async () => true),
+        config: { use: vi.fn() },
+      },
+      init: vi.fn(async () => undefined),
+      handleUpdate: vi.fn(async (update: { update_id?: number }) => {
+        events.push(`handled:${update.update_id}`);
+        await regularTurnDone;
+      }),
+      stop: vi.fn(async () => undefined),
+    });
+    await writeSpooledTestUpdates(tempDir, [
+      topicUpdate(42, 10, "wedged topic 10 turn"),
+      topicUpdate(43, 10, "later topic 10 turn"),
+    ]);
+    const workerListeners: WorkerPollSuccessListener[] = [];
+    let stopWorker: (() => void) | undefined;
+    const workerDone = new Promise<void>((resolve) => {
+      stopWorker = resolve;
+    });
+    const createWorker = vi.fn(() => ({
+      onMessage: vi.fn((listener: WorkerPollSuccessListener) => {
+        workerListeners.push(listener);
+        return () => undefined;
+      }),
+      stop: vi.fn(async () => {
+        stopWorker?.();
+      }),
+      task: vi.fn(async () => {
+        await workerDone;
+      }),
+    }));
+
+    try {
+      const session = createPollingSession({
+        abortSignal: abort.signal,
+        log,
+        setStatus,
+        isolatedIngress: {
+          enabled: true,
+          spoolDir: tempDir,
+          createWorker,
+          drainIntervalMs: 10,
+          spooledUpdateHandlerTimeoutMs: 100,
+        },
+      });
+
+      const runPromise = session.runUntilAbort();
+      await vi.waitFor(() => expect(events).toEqual(["handled:42"]));
+      await vi.advanceTimersByTimeAsync(150);
+      await vi.waitFor(() => expectLogIncludes(log, "could not be marked failed: disk full"));
+
+      await vi.advanceTimersByTimeAsync(500);
+      expect(createWorker).toHaveBeenCalledTimes(1);
+      expect(events).toEqual(["handled:42"]);
+      expect(await failedUpdateIds(tempDir)).toEqual([]);
+      expect(await pendingUpdateIds(tempDir, "all")).toEqual([43]);
+      expect(
+        (await listTelegramSpooledUpdateClaims({ spoolDir: tempDir })).map(
+          (claim) => claim.updateId,
+        ),
+      ).toEqual([42]);
+      workerListeners[0]?.({
+        type: "poll-success",
+        offset: null,
+        count: 0,
+        finishedAt: Date.now(),
+      });
+      expect(statusPatches(setStatus).at(-1)?.connected).toBe(false);
+      expect(String(statusPatches(setStatus).at(-1)?.lastError)).toContain(
+        "isolated polling spool handler timed out",
+      );
+
+      releaseRegularTurn?.();
+      abort.abort();
+      stopWorker?.();
+      await vi.advanceTimersByTimeAsync(20_000);
+      await runPromise;
+    } finally {
+      writeFileSpy.mockRestore();
+      releaseRegularTurn?.();
+      abort.abort();
+      stopWorker?.();
+      vi.useRealTimers();
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("marks isolated ingress unhealthy when a spooled backlog handler times out", async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     const abort = new AbortController();
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-telegram-spool-"));
@@ -1586,7 +2001,13 @@ describe("TelegramPollingSession", () => {
       releaseRegularTurn = resolve;
     });
     const handleUpdate = vi.fn(async () => {
-      await regularTurnDone;
+      await Promise.race([
+        regularTurnDone,
+        waitForTestReplyFenceAbort({
+          key: "test-status-session:dm",
+          laneKey: "telegram:123",
+        }),
+      ]);
     });
     createTelegramBotMock.mockImplementation(() => ({
       api: {
@@ -1637,6 +2058,7 @@ describe("TelegramPollingSession", () => {
           spoolDir: tempDir,
           createWorker,
           drainIntervalMs: 100,
+          spooledUpdateHandlerAbortGraceMs: 100,
         },
       });
 
@@ -1654,41 +2076,18 @@ describe("TelegramPollingSession", () => {
 
       await vi.waitFor(() =>
         expect(log).toHaveBeenCalledWith(
-          expect.stringContaining("isolated polling spool backlog stalled"),
+          expect.stringContaining("isolated polling spool handler timed out"),
         ),
       );
       expect(
         statusPatches(setStatus).some(
           (patch) =>
             patch.connected === false &&
-            String(patch.lastError).includes("isolated polling spool backlog stalled"),
+            String(patch.lastError).includes("isolated polling spool handler timed out"),
         ),
       ).toBe(true);
-      workerListeners[0]?.({
-        type: "poll-success",
-        offset: null,
-        count: 0,
-        finishedAt: Date.now(),
-      });
-      expect(statusPatches(setStatus).at(-1)?.connected).toBe(false);
-
-      releaseRegularTurn?.();
-      await vi.advanceTimersByTimeAsync(1_000);
-      await vi.waitFor(async () =>
-        expect(
-          (await listTelegramSpooledUpdates({ spoolDir: tempDir })).map(
-            (update) => update.updateId,
-          ),
-        ).toEqual([]),
-      );
-      workerListeners[0]?.({
-        type: "poll-success",
-        offset: null,
-        count: 0,
-        finishedAt: Date.now(),
-      });
-      await vi.waitFor(() => expect(statusPatches(setStatus).at(-1)?.connected).toBe(true));
-      expect(createWorker).toHaveBeenCalledTimes(1);
+      await vi.waitFor(async () => expect(await failedUpdateIds(tempDir)).toEqual([42]));
+      expect(createWorker).toHaveBeenCalledTimes(2);
 
       abort.abort();
       await vi.advanceTimersByTimeAsync(20_000);

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -21,6 +21,7 @@ import { getTelegramSequentialKey } from "./sequential-key.js";
 import {
   claimTelegramSpooledUpdate,
   deleteTelegramSpooledUpdate,
+  failTelegramSpooledUpdateClaim,
   isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess,
   listTelegramSpooledUpdateClaims,
   listTelegramSpooledUpdates,
@@ -34,6 +35,10 @@ import {
   createTelegramIngressWorker,
   type TelegramIngressWorkerFactory,
 } from "./telegram-ingress-worker.js";
+import {
+  buildTelegramReplyFenceLaneKey,
+  supersedeTelegramReplyFenceLane,
+} from "./telegram-reply-fence.js";
 
 const TELEGRAM_POLL_RESTART_POLICY = {
   initialMs: 2000,
@@ -48,6 +53,8 @@ const MAX_POLL_STALL_THRESHOLD_MS = 600_000;
 const POLL_WATCHDOG_INTERVAL_MS = 30_000;
 const POLL_STOP_GRACE_MS = 15_000;
 const ISOLATED_INGRESS_BACKLOG_STALL_MS = 25 * 60_000;
+const TELEGRAM_SPOOLED_HANDLER_ABORT_GRACE_MS = 5_000;
+const TELEGRAM_SPOOLED_HANDLER_TIMEOUT_ENV = "OPENCLAW_TELEGRAM_SPOOLED_HANDLER_TIMEOUT_MS";
 const TELEGRAM_SPOOLED_DRAIN_START_LIMIT = 100;
 const TELEGRAM_SPOOLED_DRAIN_SCAN_LIMIT = TELEGRAM_SPOOLED_DRAIN_START_LIMIT * 10;
 const TELEGRAM_POLLING_CLIENT_TIMEOUT_FLOOR_SECONDS = Math.ceil(
@@ -74,6 +81,38 @@ const waitForGracefulStop = async (stop: () => Promise<void>) => {
     if (timer) {
       clearTimeout(timer);
     }
+  }
+};
+
+const waitForSpooledHandlerTaskSettlement = async (params: {
+  task: Promise<unknown>;
+  timeoutMs: number;
+  abortSignal?: AbortSignal;
+}): Promise<boolean> => {
+  if (params.abortSignal?.aborted) {
+    return false;
+  }
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let removeAbortListener: (() => void) | undefined;
+  try {
+    return await Promise.race([
+      params.task.then(
+        () => true,
+        () => true,
+      ),
+      new Promise<boolean>((resolve) => {
+        timer = setTimeout(() => resolve(false), params.timeoutMs);
+        timer.unref?.();
+        const abort = () => resolve(false);
+        params.abortSignal?.addEventListener("abort", abort, { once: true });
+        removeAbortListener = () => params.abortSignal?.removeEventListener("abort", abort);
+      }),
+    ]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+    removeAbortListener?.();
   }
 };
 
@@ -115,6 +154,8 @@ type TelegramPollingSessionOpts = {
     spoolDir?: string;
     createWorker?: TelegramIngressWorkerFactory;
     drainIntervalMs?: number;
+    spooledUpdateHandlerTimeoutMs?: number;
+    spooledUpdateHandlerAbortGraceMs?: number;
   };
 };
 
@@ -122,8 +163,11 @@ type SpooledUpdateHandlerState = {
   handlerKey: string;
   laneKey: string;
   task: Promise<boolean>;
+  update: ClaimedTelegramSpooledUpdate;
   updateId: number;
   startedAt: number;
+  timedOutAt?: number;
+  timeoutMessage?: string;
 };
 
 type SpooledUpdateDrainResult = {
@@ -134,6 +178,29 @@ type SpooledUpdateDrainResult = {
 // Account health restarts create a new session in the same process while an old
 // spooled handler may still be running after shutdown grace.
 const activeSpooledUpdateHandlersByLane = new Map<string, SpooledUpdateHandlerState>();
+
+function resolveSpooledUpdateHandlerTimeoutMs(params: {
+  configured?: number;
+  env?: NodeJS.ProcessEnv;
+}): number {
+  const candidates = [
+    params.configured,
+    Number(params.env?.[TELEGRAM_SPOOLED_HANDLER_TIMEOUT_ENV]),
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === "number" && Number.isFinite(candidate) && candidate > 0) {
+      return Math.floor(candidate);
+    }
+  }
+  return ISOLATED_INGRESS_BACKLOG_STALL_MS;
+}
+
+function resolvePositiveFiniteMs(value: number | undefined, fallback: number): number {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    return Math.floor(value);
+  }
+  return fallback;
+}
 
 function buildSpooledUpdateHandlerKey(params: { spoolDir: string; laneKey: string }): string {
   return `${params.spoolDir}\0${params.laneKey}`;
@@ -153,6 +220,8 @@ export class TelegramPollingSession {
   #transportState: TelegramPollingTransportState;
   #status: ReturnType<typeof createTelegramPollingStatusPublisher>;
   #stallThresholdMs: number;
+  #spooledUpdateHandlerTimeoutMs: number;
+  #spooledUpdateHandlerAbortGraceMs: number;
   #deliveryDrainInFlight = false;
 
   constructor(private readonly opts: TelegramPollingSessionOpts) {
@@ -163,6 +232,16 @@ export class TelegramPollingSession {
     });
     this.#status = createTelegramPollingStatusPublisher(opts.setStatus);
     this.#stallThresholdMs = resolvePollingStallThresholdMs(opts.stallThresholdMs);
+    this.#spooledUpdateHandlerTimeoutMs = resolveSpooledUpdateHandlerTimeoutMs({
+      ...(opts.isolatedIngress?.spooledUpdateHandlerTimeoutMs !== undefined
+        ? { configured: opts.isolatedIngress.spooledUpdateHandlerTimeoutMs }
+        : {}),
+      env: process.env,
+    });
+    this.#spooledUpdateHandlerAbortGraceMs = resolvePositiveFiniteMs(
+      opts.isolatedIngress?.spooledUpdateHandlerAbortGraceMs,
+      TELEGRAM_SPOOLED_HANDLER_ABORT_GRACE_MS,
+    );
   }
 
   get activeRunner() {
@@ -467,6 +546,7 @@ export class TelegramPollingSession {
         handlerKey,
         laneKey,
         task: handler,
+        update: claimedUpdate,
         updateId: update.updateId,
         startedAt: Date.now(),
       };
@@ -487,25 +567,95 @@ export class TelegramPollingSession {
     return { blockedByLane, started };
   }
 
-  #detectStaleSpooledHandler(
+  #detectTimedOutSpooledHandler(
     blockedHandlerKeys: Set<string>,
-  ): (SpooledUpdateHandlerState & { ageMs: number }) | null {
+  ): { handler: SpooledUpdateHandlerState; ageMs: number } | null {
     const now = Date.now();
-    let stale: (SpooledUpdateHandlerState & { ageMs: number }) | null = null;
+    let timedOut: { handler: SpooledUpdateHandlerState; ageMs: number } | null = null;
     for (const handlerKey of blockedHandlerKeys) {
       const handler = activeSpooledUpdateHandlersByLane.get(handlerKey);
-      if (!handler) {
+      if (!handler || handler.timedOutAt !== undefined) {
         continue;
       }
       const ageMs = now - handler.startedAt;
-      if (ageMs <= ISOLATED_INGRESS_BACKLOG_STALL_MS) {
+      if (ageMs <= this.#spooledUpdateHandlerTimeoutMs) {
         continue;
       }
-      if (!stale || ageMs > stale.ageMs) {
-        stale = { ...handler, ageMs };
+      if (!timedOut || ageMs > timedOut.ageMs) {
+        timedOut = { handler, ageMs };
       }
     }
-    return stale;
+    return timedOut;
+  }
+
+  async #recoverTimedOutSpooledHandler(
+    blockedHandlerKeys: Set<string>,
+  ): Promise<{ handlerKey: string; restart: boolean } | null> {
+    const timedOutHandler = this.#detectTimedOutSpooledHandler(blockedHandlerKeys);
+    if (!timedOutHandler) {
+      return null;
+    }
+    const handler = timedOutHandler.handler;
+    const activeHandler = activeSpooledUpdateHandlersByLane.get(handler.handlerKey);
+    if (!activeHandler || activeHandler !== handler) {
+      return null;
+    }
+    const age = formatDurationPrecise(timedOutHandler.ageMs);
+    activeHandler.timedOutAt = Date.now();
+    const message = `Telegram isolated polling spool handler timed out behind update ${handler.updateId} on lane ${handler.laneKey} after ${age}; marking the update failed, aborting active reply work, and restarting isolated ingress so later updates can drain.`;
+    activeHandler.timeoutMessage = message;
+    try {
+      const failed = await failTelegramSpooledUpdateClaim({
+        update: handler.update,
+        reason: "handler-timeout",
+        message,
+      });
+      if (!failed) {
+        this.opts.log(
+          `[telegram][diag] timed out spooled update ${handler.updateId} no longer had a processing marker to fail.`,
+        );
+        this.#status.notePollingError(message);
+        return { handlerKey: handler.handlerKey, restart: false };
+      }
+    } catch (err) {
+      this.opts.log(
+        `[telegram][diag] timed out spooled update ${handler.updateId} could not be marked failed: ${formatErrorMessage(err)}`,
+      );
+      this.#status.notePollingError(message);
+      return { handlerKey: handler.handlerKey, restart: false };
+    }
+    const scopedReplyFenceLaneKey = buildTelegramReplyFenceLaneKey({
+      accountId: this.opts.accountId,
+      sequentialKey: handler.laneKey,
+    });
+    const abortedReplyWork = supersedeTelegramReplyFenceLane(scopedReplyFenceLaneKey);
+    if (!abortedReplyWork) {
+      this.opts.log(
+        `[telegram][diag] timed out spooled update ${handler.updateId} had no active reply fence on lane ${handler.laneKey}; keeping the lane guarded until the handler stops.`,
+      );
+    }
+    const handlerStopped = await waitForSpooledHandlerTaskSettlement({
+      task: handler.task,
+      timeoutMs: this.#spooledUpdateHandlerAbortGraceMs,
+      abortSignal: this.opts.abortSignal,
+    });
+    if (
+      !handlerStopped &&
+      activeSpooledUpdateHandlersByLane.get(handler.handlerKey) === activeHandler
+    ) {
+      this.opts.log(
+        `[telegram][diag] timed out spooled update ${handler.updateId} did not stop within ${formatDurationPrecise(this.#spooledUpdateHandlerAbortGraceMs)} after reply abort; keeping lane ${handler.laneKey} guarded.`,
+      );
+      this.#status.notePollingError(message);
+      return { handlerKey: handler.handlerKey, restart: false };
+    }
+    if (activeSpooledUpdateHandlersByLane.get(handler.handlerKey) === activeHandler) {
+      activeSpooledUpdateHandlersByLane.delete(handler.handlerKey);
+    }
+    this.#spooledUpdateHandlerKeys.delete(handler.handlerKey);
+    this.opts.log(`[telegram] ${message}`);
+    this.#status.notePollingError(message);
+    return { handlerKey: handler.handlerKey, restart: true };
   }
 
   async #runIsolatedIngressCycle(bot: TelegramBot): Promise<"continue" | "exit"> {
@@ -547,6 +697,7 @@ export class TelegramPollingSession {
       outcome: "not-started",
     };
     let consecutiveDrainFailures = 0;
+    let restartRequested = false;
     const stalledBacklogKeys = new Set<string>();
     const unsubscribe = worker.onMessage((message) => {
       if (message.type === "poll-start") {
@@ -557,7 +708,7 @@ export class TelegramPollingSession {
         return;
       }
       if (message.type === "poll-success") {
-        if (stalledBacklogKeys.size === 0) {
+        if (!restartRequested && stalledBacklogKeys.size === 0) {
           this.#status.notePollSuccess(message.finishedAt);
         }
         this.#drainPendingDeliveriesAfterReconnect();
@@ -583,7 +734,7 @@ export class TelegramPollingSession {
         });
     };
     const drainOnce = async () => {
-      if (drainActive || this.opts.abortSignal?.aborted) {
+      if (restartRequested || drainActive || this.opts.abortSignal?.aborted) {
         return;
       }
       drainActive = true;
@@ -598,14 +749,22 @@ export class TelegramPollingSession {
             stalledBacklogKeys.delete(handlerKey);
           }
         }
-        const staleHandler = this.#detectStaleSpooledHandler(drain.blockedByLane);
-        if (staleHandler) {
-          if (!stalledBacklogKeys.has(staleHandler.handlerKey)) {
-            stalledBacklogKeys.add(staleHandler.handlerKey);
-            const message = `Telegram isolated polling spool backlog stalled behind update ${staleHandler.updateId} on lane ${staleHandler.laneKey} for ${formatDurationPrecise(staleHandler.ageMs)}; marking polling unhealthy until the backlog drains.`;
-            this.opts.log(`[telegram] ${message}`);
-            this.#status.notePollingError(message);
+        for (const handlerKey of drain.blockedByLane) {
+          const handler = activeSpooledUpdateHandlersByLane.get(handlerKey);
+          if (handler?.timedOutAt === undefined) {
+            continue;
           }
+          stalledBacklogKeys.add(handlerKey);
+          if (handler.timeoutMessage) {
+            this.#status.notePollingError(handler.timeoutMessage);
+          }
+        }
+        const timedOutRecovery = await this.#recoverTimedOutSpooledHandler(drain.blockedByLane);
+        if (timedOutRecovery?.restart) {
+          restartRequested = true;
+          void worker.stop();
+        } else if (timedOutRecovery) {
+          stalledBacklogKeys.add(timedOutRecovery.handlerKey);
         }
       } catch (err) {
         consecutiveDrainFailures += 1;
@@ -626,6 +785,9 @@ export class TelegramPollingSession {
       if (this.opts.abortSignal?.aborted) {
         return "exit";
       }
+      if (restartRequested) {
+        return "continue";
+      }
       const errorText = pollState.error ? ` error=${pollState.error}` : "";
       this.opts.log(
         `[telegram][diag] isolated polling ingress stopped outcome=${pollState.outcome} startedAt=${pollState.startedAt ?? "n/a"} offset=${pollState.offset ?? "n/a"}${errorText}`,
@@ -639,8 +801,10 @@ export class TelegramPollingSession {
       unsubscribe();
       this.opts.abortSignal?.removeEventListener("abort", stopOnAbort);
       await worker.stop();
-      await drainOnce();
-      await waitForGracefulStop(() => this.#waitForSpooledUpdateHandlers());
+      if (!restartRequested) {
+        await drainOnce();
+        await waitForGracefulStop(() => this.#waitForSpooledUpdateHandlers());
+      }
       await waitForGracefulStop(stopBot);
     }
   }

--- a/extensions/telegram/src/status-issues.ts
+++ b/extensions/telegram/src/status-issues.ts
@@ -70,7 +70,11 @@ function appendTelegramRuntimeError(message: string, lastError: unknown): string
 }
 
 function isTelegramPollingBacklogStallError(lastError: unknown): boolean {
-  return Boolean(asString(lastError)?.includes("isolated polling spool backlog stalled"));
+  const error = asString(lastError);
+  return Boolean(
+    error?.includes("isolated polling spool backlog stalled") ||
+    error?.includes("isolated polling spool handler timed out"),
+  );
 }
 
 function collectTelegramPollingRuntimeIssues(params: {

--- a/extensions/telegram/src/status.test.ts
+++ b/extensions/telegram/src/status.test.ts
@@ -144,6 +144,31 @@ describe("collectTelegramStatusIssues", () => {
     expect(issues[0]?.message).not.toContain("has not completed a successful getUpdates call");
   });
 
+  it("reports isolated polling spool handler timeouts distinctly from startup failures", () => {
+    const issues = collectTelegramStatusIssues([
+      {
+        accountId: "main",
+        enabled: true,
+        configured: true,
+        running: true,
+        mode: "polling",
+        connected: false,
+        lastStartAt: Date.now() - 121_000,
+        lastError:
+          "Telegram isolated polling spool handler timed out behind update 42 on lane telegram:123 after 1500100ms; marking the update failed and restarting isolated ingress so later updates can drain.",
+      } as ChannelAccountSnapshot,
+    ]);
+
+    expect(issues).toHaveLength(1);
+    expectIssueFields(issues[0], {
+      channel: "telegram",
+      accountId: "main",
+      kind: "runtime",
+    });
+    expect(issues[0]?.message).toContain("spool backlog is stalled");
+    expect(issues[0]?.message).not.toContain("has not completed a successful getUpdates call");
+  });
+
   it("does not report polling startup before the connect grace expires", () => {
     const issues = collectTelegramStatusIssues([
       {

--- a/extensions/telegram/src/telegram-ingress-spool.test.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import {
   claimTelegramSpooledUpdate,
   deleteTelegramSpooledUpdate,
+  failTelegramSpooledUpdateClaim,
   isTelegramSpooledUpdateClaimOwnedByOtherLiveProcess,
   listTelegramSpooledUpdateClaims,
   listTelegramSpooledUpdates,
@@ -109,6 +110,71 @@ describe("Telegram ingress spool", () => {
       const updates = await listTelegramSpooledUpdates({ spoolDir });
       expect(updates.map((entry) => entry.updateId)).toEqual([30]);
       expect(updates[0]?.path.endsWith(".json")).toBe(true);
+    });
+  });
+
+  it("marks timed out claims failed without requeueing them", async () => {
+    await withTempSpool(async (spoolDir) => {
+      await writeTelegramSpooledUpdate({
+        spoolDir,
+        update: { update_id: 32, message: { text: "poison" } },
+      });
+      const update = (await listTelegramSpooledUpdates({ spoolDir }))[0];
+      if (!update) {
+        throw new Error("Expected a spooled update");
+      }
+      const claimed = await claimTelegramSpooledUpdate(update);
+      if (!claimed) {
+        throw new Error("Expected a claimed update");
+      }
+
+      await expect(
+        failTelegramSpooledUpdateClaim({
+          update: claimed,
+          reason: "handler-timeout",
+          message: "timed out",
+          now: 123,
+        }),
+      ).resolves.toBe(true);
+
+      expect(await listTelegramSpooledUpdates({ spoolDir })).toEqual([]);
+      expect(await listTelegramSpooledUpdateClaims({ spoolDir })).toEqual([]);
+      const entries = await fs.readdir(spoolDir);
+      expect(entries).toEqual(["0000000000000032.json.failed"]);
+      const failed = JSON.parse(
+        await fs.readFile(path.join(spoolDir, "0000000000000032.json.failed"), "utf8"),
+      ) as { failure?: { reason?: string; message?: string; failedAt?: number } };
+      expect(failed.failure).toEqual({
+        reason: "handler-timeout",
+        message: "timed out",
+        failedAt: 123,
+      });
+
+      await writeTelegramSpooledUpdate({
+        spoolDir,
+        update: { update_id: 32, message: { text: "redelivered poison" } },
+      });
+      expect(await listTelegramSpooledUpdates({ spoolDir })).toEqual([]);
+      expect(await fs.readdir(spoolDir)).toEqual(["0000000000000032.json.failed"]);
+
+      const leakedProcessingPath = path.join(spoolDir, "0000000000000032.json.processing");
+      await fs.writeFile(
+        leakedProcessingPath,
+        `${JSON.stringify({
+          version: 1,
+          updateId: 32,
+          receivedAt: 100,
+          update: { update_id: 32, message: { text: "crashed poison claim" } },
+        })}\n`,
+        { mode: 0o600 },
+      );
+      const staleTime = new Date(Date.now() - TELEGRAM_SPOOLED_UPDATE_PROCESSING_STALE_MS - 1);
+      await fs.utimes(leakedProcessingPath, staleTime, staleTime);
+
+      await expect(recoverStaleTelegramSpooledUpdateClaims({ spoolDir })).resolves.toBe(0);
+      expect(await listTelegramSpooledUpdates({ spoolDir })).toEqual([]);
+      expect(await listTelegramSpooledUpdateClaims({ spoolDir })).toEqual([]);
+      expect(await fs.readdir(spoolDir)).toEqual(["0000000000000032.json.failed"]);
     });
   });
 

--- a/extensions/telegram/src/telegram-ingress-spool.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.ts
@@ -21,6 +21,11 @@ type TelegramSpooledUpdatePayload = {
   receivedAt: number;
   update: unknown;
   claim?: TelegramSpooledUpdateClaimOwner;
+  failure?: {
+    reason: string;
+    message: string;
+    failedAt: number;
+  };
 };
 
 export type TelegramSpooledUpdate = {
@@ -71,6 +76,10 @@ function processingFileName(updateId: number): string {
   return `${spoolFileName(updateId)}.processing`;
 }
 
+function failedFileName(updateId: number): string {
+  return `${spoolFileName(updateId)}.failed`;
+}
+
 function isProcessingFileName(fileName: string): boolean {
   return fileName.endsWith(".json.processing");
 }
@@ -81,6 +90,10 @@ function pendingFileNameFromProcessing(fileName: string): string {
 
 function processingPath(spoolDir: string, updateId: number): string {
   return path.join(spoolDir, processingFileName(updateId));
+}
+
+function failedPath(spoolDir: string, updateId: number): string {
+  return path.join(spoolDir, failedFileName(updateId));
 }
 
 async function pathExists(filePath: string): Promise<boolean> {
@@ -181,7 +194,8 @@ export async function writeTelegramSpooledUpdate(params: {
   await fs.mkdir(params.spoolDir, { recursive: true });
   const targetPath = path.join(params.spoolDir, spoolFileName(updateId));
   const claimedPath = processingPath(params.spoolDir, updateId);
-  if (await pathExists(claimedPath)) {
+  const tombstonePath = failedPath(params.spoolDir, updateId);
+  if ((await pathExists(claimedPath)) || (await pathExists(tombstonePath))) {
     return updateId;
   }
   const tempPath = path.join(params.spoolDir, `${spoolFileName(updateId)}.${randomUUID()}.tmp`);
@@ -192,7 +206,7 @@ export async function writeTelegramSpooledUpdate(params: {
     update: params.update,
   };
   await fs.writeFile(tempPath, `${JSON.stringify(payload)}\n`, { mode: 0o600 });
-  if (await pathExists(claimedPath)) {
+  if ((await pathExists(claimedPath)) || (await pathExists(tombstonePath))) {
     await unlinkIfPresent(tempPath);
     return updateId;
   }
@@ -213,7 +227,10 @@ export async function listTelegramSpooledUpdates(params: {
     }
     throw err;
   }
-  const files = entries.filter((entry) => entry.endsWith(".json")).toSorted();
+  const entrySet = new Set(entries);
+  const files = entries
+    .filter((entry) => entry.endsWith(".json") && !entrySet.has(`${entry}.failed`))
+    .toSorted();
   const limitedFiles =
     params.limit === "all" ? files : files.slice(0, Math.max(1, params.limit ?? 100));
   const updates: TelegramSpooledUpdate[] = [];
@@ -292,6 +309,49 @@ export async function releaseTelegramSpooledUpdateClaim(
   }
 }
 
+export async function failTelegramSpooledUpdateClaim(params: {
+  update: ClaimedTelegramSpooledUpdate;
+  reason: string;
+  message: string;
+  now?: number;
+}): Promise<boolean> {
+  const tombstonePath = failedPath(path.dirname(params.update.path), params.update.updateId);
+  const tempPath = path.join(
+    path.dirname(params.update.path),
+    `${failedFileName(params.update.updateId)}.${randomUUID()}.tmp`,
+  );
+  try {
+    const { value } = await readJsonFileWithFallback<unknown>(params.update.path, null);
+    const parsed = parseSpooledUpdate(value, params.update.path);
+    if (!parsed) {
+      return false;
+    }
+    const payload: TelegramSpooledUpdatePayload = {
+      version: SPOOL_VERSION,
+      updateId: parsed.updateId,
+      receivedAt: parsed.receivedAt,
+      update: parsed.update,
+      ...(parsed.claim ? { claim: parsed.claim } : {}),
+      failure: {
+        reason: params.reason,
+        message: params.message,
+        failedAt: params.now ?? Date.now(),
+      },
+    };
+    await fs.writeFile(tempPath, `${JSON.stringify(payload)}\n`, { mode: 0o600 });
+    await fs.rename(tempPath, tombstonePath);
+    await unlinkIfPresent(params.update.path);
+    await unlinkIfPresent(params.update.pendingPath);
+    return true;
+  } catch (err) {
+    await unlinkIfPresent(tempPath);
+    if ((err as { code?: string }).code === "ENOENT") {
+      return false;
+    }
+    throw err;
+  }
+}
+
 export async function listTelegramSpooledUpdateClaims(params: {
   spoolDir: string;
 }): Promise<ClaimedTelegramSpooledUpdate[]> {
@@ -305,7 +365,11 @@ export async function listTelegramSpooledUpdateClaims(params: {
     throw err;
   }
   const claims: ClaimedTelegramSpooledUpdate[] = [];
+  const entrySet = new Set(entries);
   for (const file of entries.filter(isProcessingFileName).toSorted()) {
+    if (entrySet.has(`${pendingFileNameFromProcessing(file)}.failed`)) {
+      continue;
+    }
     const filePath = path.join(params.spoolDir, file);
     const { value } = await readJsonFileWithFallback<unknown>(filePath, null);
     const parsed = parseSpooledUpdate(value, filePath);
@@ -340,8 +404,15 @@ export async function recoverStaleTelegramSpooledUpdateClaims(params: {
   );
   const now = params.now ?? Date.now();
   let recovered = 0;
+  const entrySet = new Set(entries);
   for (const entry of entries.filter(isProcessingFileName).toSorted()) {
     const claimedPath = path.join(params.spoolDir, entry);
+    const pendingPath = path.join(params.spoolDir, pendingFileNameFromProcessing(entry));
+    if (entrySet.has(`${pendingFileNameFromProcessing(entry)}.failed`)) {
+      await unlinkIfPresent(claimedPath);
+      await unlinkIfPresent(pendingPath);
+      continue;
+    }
     let stat;
     try {
       stat = await fs.stat(claimedPath);
@@ -354,7 +425,6 @@ export async function recoverStaleTelegramSpooledUpdateClaims(params: {
     if (now - stat.mtimeMs < staleMs) {
       continue;
     }
-    const pendingPath = path.join(params.spoolDir, pendingFileNameFromProcessing(entry));
     if (params.shouldRecover) {
       const { value } = await readJsonFileWithFallback<unknown>(claimedPath, null);
       const parsed = parseSpooledUpdate(value, claimedPath);

--- a/extensions/telegram/src/telegram-reply-fence.ts
+++ b/extensions/telegram/src/telegram-reply-fence.ts
@@ -1,0 +1,177 @@
+import { isAbortRequestText } from "openclaw/plugin-sdk/command-primitives-runtime";
+
+type TelegramReplyFenceState = {
+  generation: number;
+  activeDispatches: number;
+  abortControllers?: Set<AbortController>;
+  laneKeys?: Set<string>;
+};
+
+export type TelegramReplyFenceKey = {
+  activeKey: string;
+  roomEventKey: string;
+};
+
+// Newer accepted turns and authorized aborts can arrive ahead of older same-session reply work.
+const telegramReplyFenceByKey = new Map<string, TelegramReplyFenceState>();
+const telegramReplyFenceKeysByLane = new Map<string, Set<string>>();
+
+export function buildTelegramReplyFenceLaneKey(params: {
+  accountId: string;
+  sequentialKey: string;
+}): string {
+  return `${params.accountId}\0${params.sequentialKey}`;
+}
+
+function normalizeTelegramFenceKey(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export function resolveTelegramReplyFenceKey(params: {
+  ctxPayload: { SessionKey?: string; CommandTargetSessionKey?: string; InboundEventKind?: string };
+  chatId: number | string;
+  threadSpec: { id?: number | string | null; scope?: string };
+}): TelegramReplyFenceKey {
+  const baseKey =
+    normalizeTelegramFenceKey(params.ctxPayload.CommandTargetSessionKey) ??
+    normalizeTelegramFenceKey(params.ctxPayload.SessionKey) ??
+    `telegram:${String(params.chatId)}:${params.threadSpec.scope ?? "default"}:${params.threadSpec.id ?? "root"}`;
+  const roomEventKey = `${baseKey}:room_event`;
+  return {
+    activeKey: params.ctxPayload.InboundEventKind === "room_event" ? roomEventKey : baseKey,
+    roomEventKey,
+  };
+}
+
+function abortTelegramReplyFenceControllers(state: TelegramReplyFenceState): void {
+  for (const controller of state.abortControllers ?? []) {
+    controller.abort();
+  }
+  state.abortControllers?.clear();
+}
+
+function deleteTelegramReplyFenceState(key: string, state: TelegramReplyFenceState): void {
+  telegramReplyFenceByKey.delete(key);
+  for (const laneKey of state.laneKeys ?? []) {
+    const keys = telegramReplyFenceKeysByLane.get(laneKey);
+    keys?.delete(key);
+    if (keys?.size === 0) {
+      telegramReplyFenceKeysByLane.delete(laneKey);
+    }
+  }
+}
+
+function maybeDeleteTelegramReplyFenceState(key: string, state: TelegramReplyFenceState): void {
+  if (state.activeDispatches <= 0 && (state.abortControllers?.size ?? 0) === 0) {
+    deleteTelegramReplyFenceState(key, state);
+  } else {
+    telegramReplyFenceByKey.set(key, state);
+  }
+}
+
+export function beginTelegramReplyFence(params: {
+  key: string;
+  supersede: boolean;
+  abortController?: AbortController;
+  laneKey?: string;
+}): number {
+  const existing = telegramReplyFenceByKey.get(params.key);
+  const state: TelegramReplyFenceState = existing ?? {
+    generation: 0,
+    activeDispatches: 0,
+  };
+  if (params.supersede) {
+    state.generation += 1;
+    abortTelegramReplyFenceControllers(state);
+  }
+  if (params.abortController) {
+    (state.abortControllers ??= new Set()).add(params.abortController);
+  }
+  const laneKey = normalizeTelegramFenceKey(params.laneKey);
+  if (laneKey) {
+    (state.laneKeys ??= new Set()).add(laneKey);
+    const keys = telegramReplyFenceKeysByLane.get(laneKey) ?? new Set<string>();
+    keys.add(params.key);
+    telegramReplyFenceKeysByLane.set(laneKey, keys);
+  }
+  state.activeDispatches += 1;
+  telegramReplyFenceByKey.set(params.key, state);
+  return state.generation;
+}
+
+export function supersedeTelegramReplyFence(key: string): boolean {
+  const state = telegramReplyFenceByKey.get(key);
+  if (!state) {
+    return false;
+  }
+  state.generation += 1;
+  abortTelegramReplyFenceControllers(state);
+  maybeDeleteTelegramReplyFenceState(key, state);
+  return true;
+}
+
+export function supersedeTelegramReplyFenceLane(laneKey: string): boolean {
+  const keys = [...(telegramReplyFenceKeysByLane.get(laneKey) ?? [])];
+  let superseded = false;
+  for (const key of keys) {
+    superseded = supersedeTelegramReplyFence(key) || superseded;
+  }
+  return superseded;
+}
+
+export function isTelegramReplyFenceSuperseded(params: {
+  key: string;
+  generation: number;
+}): boolean {
+  return (telegramReplyFenceByKey.get(params.key)?.generation ?? 0) !== params.generation;
+}
+
+export function endTelegramReplyFence(key: string, abortController?: AbortController): void {
+  const state = telegramReplyFenceByKey.get(key);
+  if (!state) {
+    return;
+  }
+  if (abortController) {
+    state.abortControllers?.delete(abortController);
+  }
+  state.activeDispatches = Math.max(0, state.activeDispatches - 1);
+  maybeDeleteTelegramReplyFenceState(key, state);
+}
+
+export function releaseTelegramReplyFenceAbortController(
+  key: string,
+  abortController?: AbortController,
+): void {
+  if (!abortController) {
+    return;
+  }
+  const state = telegramReplyFenceByKey.get(key);
+  if (!state) {
+    return;
+  }
+  state.abortControllers?.delete(abortController);
+  maybeDeleteTelegramReplyFenceState(key, state);
+}
+
+export function shouldSupersedeTelegramReplyFence(ctxPayload: {
+  Body?: string;
+  RawBody?: string;
+  CommandBody?: string;
+  CommandAuthorized: boolean;
+}): boolean {
+  const dispatchText = ctxPayload.CommandBody ?? ctxPayload.RawBody ?? ctxPayload.Body ?? "";
+  return !isAbortRequestText(dispatchText) || ctxPayload.CommandAuthorized;
+}
+
+export function getTelegramReplyFenceSizeForTests(): number {
+  return telegramReplyFenceByKey.size;
+}
+
+export function resetTelegramReplyFenceForTests(): void {
+  telegramReplyFenceByKey.clear();
+  telegramReplyFenceKeysByLane.clear();
+}


### PR DESCRIPTION
## Summary

- fail stuck Telegram isolated-ingress spool claims into terminal `.failed` tombstones
- abort account-scoped same-lane Telegram reply work before restarting isolated ingress
- add regression coverage for spool tombstones, timeout recovery, guarded lanes, and reply-fence aborts

Fixes #83272.

## Verification

- `node scripts/run-vitest.mjs extensions/telegram/src/polling-session.test.ts extensions/telegram/src/telegram-ingress-spool.test.ts extensions/telegram/src/status.test.ts extensions/telegram/src/bot-message-dispatch.test.ts -- --reporter=verbose`
- `.agents/skills/autoreview/scripts/autoreview --mode local --reviewer codex --fallback-reviewer none`
- AWS Crabbox pre-fix repro: `run_326b16aa90e6`, lease `cbx_bb8cfdb430da`, slug `crimson-barnacle`
- AWS Crabbox post-fix proof: `run_903f76250ba1`, lease `cbx_fb167ebbfc53`, slug `quick-krill`

## Real behavior proof

Behavior addressed: A hung Telegram isolated-ingress update could remain stuck as `.json.processing`, blocking later same-chat updates while `/status@bot` still reported the account as running.

Real environment tested: Crabbox AWS Linux with a live Convex-leased `telegram` credential and real Telegram bot/group traffic.

Exact steps or command run after this patch: Ran the live proof harness through `node scripts/crabbox-wrapper.mjs run --provider aws --idle-timeout 90m --ttl 240m --timing-json --full-resync --env-from-profile /private/tmp/convex_pool.env --env-from-profile /private/tmp/iao.env --allow-env OPENCLAW_QA_CONVEX_SITE_URL --allow-env OPENCLAW_QA_CONVEX_SECRET_CI --allow-env OPENAI_API_KEY --script /private/tmp/openclaw-83272-fix-proof-proxy.sh`.

Evidence after fix: `OPENCLAW_83272_FIX_PROOF {"marker":"OC83272_mpavxaah","providerRequests":2,"hungProviderRequests":1,"completedProviderRequests":1,"failedEntries":["0000000240225044.json.failed"],"telegramSendMessageId":10402,"telegramRunning":true,"restartPending":false,"spoolEntries":["0000000240225044.json.failed"]}`.

Observed result after fix: The first hung Telegram update was failed into a tombstone, isolated ingress restarted, the second same-chat update completed a provider request, and the SUT sent a real Telegram reply while the account returned to running with no pending second-update spool residue.

What was not tested: Full repository CI locally; this PR relies on GitHub CI for the broad matrix.
