### PR TITLE
fix(qa): use final telegram replies for rtt runs

### DIFF
--- a/scripts/e2e/npm-telegram-rtt-config.mjs
+++ b/scripts/e2e/npm-telegram-rtt-config.mjs
@@ -89,6 +89,7 @@ config.channels.telegram = {
     provider: "default",
     id: "TELEGRAM_BOT_TOKEN",
   },
+  streaming: false,
   dmPolicy: "allowlist",
   allowFrom: [driverId],
   defaultTo: driverId,

--- a/test/scripts/rtt-harness.test.ts
+++ b/test/scripts/rtt-harness.test.ts
@@ -1,7 +1,9 @@
+import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   appendJsonl,
@@ -23,6 +25,8 @@ const CREDENTIAL_SCRIPT_PATH = path.resolve(
   TEST_DIR,
   "../../scripts/e2e/npm-telegram-rtt-credentials.mjs",
 );
+const CONFIG_SCRIPT_PATH = path.resolve(TEST_DIR, "../../scripts/e2e/npm-telegram-rtt-config.mjs");
+const execFileAsync = promisify(execFile);
 const tempDirs: string[] = [];
 
 afterEach(async () => {
@@ -154,6 +158,26 @@ describe("RTT harness", () => {
     expect(script).toContain('response.ok\n        ? { status: "ok" }');
     expect(script).toContain("leaseTtlMs: acquired.leaseTtlMs ?? config.leaseTtlMs");
     expect(script).toContain("leaseTtlMs: leaseTtlMsFromLease(config, lease)");
+  });
+
+  it("generates final-only Telegram RTT delivery config for release packages", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-rtt-config-test-"));
+    tempDirs.push(tempDir);
+    const configPath = path.join(tempDir, "config.json");
+
+    await execFileAsync(process.execPath, [
+      CONFIG_SCRIPT_PATH,
+      configPath,
+      "12345",
+      "-100123",
+      "111:driver-token",
+      "222:sut-token",
+      "2026.5.16-beta.6",
+    ]);
+
+    const config = JSON.parse(await fs.readFile(configPath, "utf8"));
+    expect(config.channels.telegram.streaming).toBe(false);
+    expect(config.messages.groupChat.visibleReplies).toBe("automatic");
   });
 
   it("extracts RTT values from Telegram QA summaries", async () => {


### PR DESCRIPTION
## Summary
- disables Telegram preview streaming in the npm RTT harness config so release-package runs measure the final observed reply instead of an editable preview draft
- covers the generated config path with the existing RTT harness test suite

## Verification
- `node scripts/run-vitest.mjs test/scripts/rtt-harness.test.ts`
- `git diff --check origin/main...HEAD`
- Testbox-through-Crabbox changed gate attempted, but blocked before execution because `.github/workflows/crabbox-hydrate.yml` has no Testbox step

## Real behavior proof
Behavior addressed: Telegram RTT release-package runs should wait for final-only Telegram delivery rather than preview streaming drafts.
Real environment tested: local OpenClaw Codex worktree with generated harness config and RTT harness tests.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs test/scripts/rtt-harness.test.ts`
Evidence after fix: generated RTT config now sets `channels.telegram.streaming` to `false` while preserving `messages.groupChat.visibleReplies = "automatic"` for supported package versions.
Observed result after fix: `test/scripts/rtt-harness.test.ts` passed 12 tests.
What was not tested: live Telegram release rerun is handled by openclaw-rtt GitHub Actions after this lands.
