### PR TITLE
fix(qa): use supported telegram streaming config in rtt

### DIFF
--- a/scripts/e2e/npm-telegram-rtt-config.mjs
+++ b/scripts/e2e/npm-telegram-rtt-config.mjs
@@ -89,7 +89,7 @@ config.channels.telegram = {
     provider: "default",
     id: "TELEGRAM_BOT_TOKEN",
   },
-  streaming: false,
+  streaming: { mode: "off" },
   dmPolicy: "allowlist",
   allowFrom: [driverId],
   defaultTo: driverId,

--- a/test/scripts/rtt-harness.test.ts
+++ b/test/scripts/rtt-harness.test.ts
@@ -176,7 +176,7 @@ describe("RTT harness", () => {
     ]);
 
     const config = JSON.parse(await fs.readFile(configPath, "utf8"));
-    expect(config.channels.telegram.streaming).toBe(false);
+    expect(config.channels.telegram.streaming).toEqual({ mode: "off" });
     expect(config.messages.groupChat.visibleReplies).toBe("automatic");
   });
 


### PR DESCRIPTION
## Summary
- switches the Telegram RTT harness from legacy boolean streaming config to the supported nested `{ mode: "off" }` shape
- keeps the RTT lane final-only while remaining accepted by the 2026.5.16 beta package config schema

## Verification
- `node scripts/run-vitest.mjs test/scripts/rtt-harness.test.ts`
- `git diff --check origin/main...HEAD`

## Real behavior proof
Behavior addressed: Telegram release RTT reruns for 2026.5.16 beta packages should start the gateway with final-only Telegram delivery.
Real environment tested: local OpenClaw Codex worktree generating the RTT config shape.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs test/scripts/rtt-harness.test.ts`
Evidence after fix: generated config now sets `channels.telegram.streaming = { "mode": "off" }`, matching the package schema that rejected boolean `false`.
Observed result after fix: `test/scripts/rtt-harness.test.ts` passed 12 tests.
What was not tested: live Telegram release rerun is handled by openclaw-rtt GitHub Actions after this lands.
