### PR TITLE
Load provider owner for Codex harness runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ Docs: https://docs.openclaw.ai
 - Agents/subagents: preserve run-mode keep subagent registry entries past the session sweep TTL, so kept subagent runs remain visible after cleanup completes. Fixes #83132. (#83168) Thanks @yetval.
 - Agents/OpenAI streams: yield via `setTimeout(0)` instead of `setImmediate` between bursty Responses chunks so abort timers can fire during the yield, keeping cancel-on-timeout responsive on hot streams. Refs #82462.
 - Agents/Codex: keep legacy `oauthRef`-backed OAuth profiles usable while `openclaw doctor --fix` migrates them back to inline credentials, without creating new sidecar credentials. (#83312) Thanks @joshavant.
+- Agents/Codex: load the selected provider owner alongside the Codex harness runtime so `openai-codex` models resolve when plugin allowlists scope runtime loading. Fixes #83380. (#83519) Thanks @joshavant.
 - Telegram: fail stalled isolated-ingress handlers into tombstones and abort same-lane reply work before restarting, so later same-chat updates drain after a hung turn. Fixes #83272. (#83505) Thanks @joshavant.
 - CLI/config: send SecretRef diagnostics to stderr so JSON command stdout remains parseable.
 - CLI/doctor: seed Control UI allowed origins when migrating legacy non-loopback gateway bind host aliases like `0.0.0.0`. Fixes #83286. Thanks @giodl73-repo.

--- a/src/agents/harness/runtime-plugin.test.ts
+++ b/src/agents/harness/runtime-plugin.test.ts
@@ -3,10 +3,19 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 
 const mocks = vi.hoisted(() => ({
   ensurePluginRegistryLoaded: vi.fn(),
+  resolveActivatableProviderOwnerPluginIds: vi.fn(),
+  resolveBundledProviderCompatPluginIds: vi.fn(),
+  resolveOwningPluginIdsForProvider: vi.fn(),
 }));
 
 vi.mock("../../plugins/runtime/runtime-registry-loader.js", () => ({
   ensurePluginRegistryLoaded: mocks.ensurePluginRegistryLoaded,
+}));
+
+vi.mock("../../plugins/providers.js", () => ({
+  resolveActivatableProviderOwnerPluginIds: mocks.resolveActivatableProviderOwnerPluginIds,
+  resolveBundledProviderCompatPluginIds: mocks.resolveBundledProviderCompatPluginIds,
+  resolveOwningPluginIdsForProvider: mocks.resolveOwningPluginIdsForProvider,
 }));
 
 describe("ensureSelectedAgentHarnessPlugin", () => {
@@ -14,11 +23,23 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
 
   beforeEach(async () => {
     mocks.ensurePluginRegistryLoaded.mockReset();
+    mocks.resolveActivatableProviderOwnerPluginIds.mockReset();
+    mocks.resolveBundledProviderCompatPluginIds.mockReset();
+    mocks.resolveOwningPluginIdsForProvider.mockReset();
+    mocks.resolveOwningPluginIdsForProvider.mockImplementation(
+      ({ provider }: { provider: string }) =>
+        provider === "openai" || provider === "openai-codex" ? ["openai"] : undefined,
+    );
+    mocks.resolveBundledProviderCompatPluginIds.mockImplementation(
+      ({ onlyPluginIds }: { onlyPluginIds?: readonly string[] }) =>
+        (onlyPluginIds ?? []).filter((pluginId) => pluginId === "openai"),
+    );
+    mocks.resolveActivatableProviderOwnerPluginIds.mockReturnValue([]);
     vi.resetModules();
     ({ ensureSelectedAgentHarnessPlugin } = await import("./runtime-plugin.js"));
   });
 
-  it("loads Codex when an explicit runtime override forces the Codex harness", async () => {
+  it("loads Codex and the provider owner when an explicit runtime override forces the Codex harness", async () => {
     await ensureSelectedAgentHarnessPlugin({
       provider: "openai",
       modelId: "gpt-5.5",
@@ -40,12 +61,12 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
       expect.objectContaining({
         scope: "all",
         workspaceDir: "/tmp/workspace",
-        onlyPluginIds: ["codex"],
+        onlyPluginIds: ["codex", "openai"],
       }),
     );
   });
 
-  it("tries to load Codex for the implicit official OpenAI runtime before selection", async () => {
+  it("loads Codex and the provider owner for the implicit official OpenAI runtime before selection", async () => {
     await ensureSelectedAgentHarnessPlugin({
       provider: "openai",
       modelId: "gpt-5.5",
@@ -62,6 +83,174 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
       workspaceDir: "/tmp/workspace",
     });
 
+    expect(mocks.ensurePluginRegistryLoaded).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: "all",
+        workspaceDir: "/tmp/workspace",
+        onlyPluginIds: ["codex", "openai"],
+      }),
+    );
+  });
+
+  it("widens a scoped harness allowlist with the provider owner for openai-codex models", async () => {
+    await ensureSelectedAgentHarnessPlugin({
+      provider: "openai-codex",
+      modelId: "gpt-5.5-pro",
+      config: {
+        plugins: {
+          allow: ["codex"],
+          entries: {
+            codex: { enabled: true },
+          },
+        },
+      } as OpenClawConfig,
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(mocks.ensurePluginRegistryLoaded).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: "all",
+        workspaceDir: "/tmp/workspace",
+        onlyPluginIds: ["codex", "openai"],
+        config: expect.objectContaining({
+          plugins: expect.objectContaining({
+            allow: ["codex", "openai"],
+            entries: expect.objectContaining({
+              codex: expect.objectContaining({ enabled: true }),
+              openai: expect.objectContaining({ enabled: true }),
+            }),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("does not auto-activate untrusted provider owners for Codex harness loads", async () => {
+    mocks.resolveOwningPluginIdsForProvider.mockReturnValueOnce(["openai", "workspace-openai"]);
+    mocks.resolveBundledProviderCompatPluginIds.mockReturnValueOnce(["openai"]);
+    mocks.resolveActivatableProviderOwnerPluginIds.mockReturnValueOnce([]);
+
+    await ensureSelectedAgentHarnessPlugin({
+      provider: "openai-codex",
+      modelId: "gpt-5.5-pro",
+      config: {
+        plugins: {
+          allow: ["codex"],
+          entries: {
+            codex: { enabled: true },
+          },
+        },
+      } as OpenClawConfig,
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(mocks.resolveBundledProviderCompatPluginIds).toHaveBeenCalledWith({
+      config: expect.any(Object),
+      workspaceDir: "/tmp/workspace",
+      onlyPluginIds: ["openai", "workspace-openai"],
+    });
+    expect(mocks.resolveActivatableProviderOwnerPluginIds).toHaveBeenCalledWith({
+      pluginIds: ["openai", "workspace-openai"],
+      config: expect.any(Object),
+      workspaceDir: "/tmp/workspace",
+    });
+    expect(mocks.ensurePluginRegistryLoaded).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: "all",
+        workspaceDir: "/tmp/workspace",
+        onlyPluginIds: ["codex", "openai"],
+      }),
+    );
+  });
+
+  it("does not bypass a restrictive allowlist that omits the Codex harness", async () => {
+    await ensureSelectedAgentHarnessPlugin({
+      provider: "openai-codex",
+      modelId: "gpt-5.5-pro",
+      config: {
+        plugins: {
+          allow: ["telegram"],
+          entries: {
+            telegram: { enabled: true },
+          },
+        },
+      } as OpenClawConfig,
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(mocks.resolveOwningPluginIdsForProvider).not.toHaveBeenCalled();
+    expect(mocks.resolveBundledProviderCompatPluginIds).not.toHaveBeenCalled();
+    expect(mocks.resolveActivatableProviderOwnerPluginIds).not.toHaveBeenCalled();
+    expect(mocks.ensurePluginRegistryLoaded).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: "all",
+        workspaceDir: "/tmp/workspace",
+        onlyPluginIds: ["codex"],
+        config: expect.objectContaining({
+          plugins: expect.objectContaining({
+            allow: ["telegram"],
+            entries: expect.not.objectContaining({
+              codex: expect.anything(),
+              openai: expect.anything(),
+            }),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("honors bundled discovery compat when a legacy allowlist omits the Codex harness", async () => {
+    await ensureSelectedAgentHarnessPlugin({
+      provider: "openai-codex",
+      modelId: "gpt-5.5-pro",
+      config: {
+        plugins: {
+          allow: ["telegram"],
+          bundledDiscovery: "compat",
+          entries: {
+            telegram: { enabled: true },
+          },
+        },
+      } as OpenClawConfig,
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(mocks.resolveOwningPluginIdsForProvider).toHaveBeenCalledWith({
+      provider: "openai-codex",
+      config: expect.any(Object),
+      workspaceDir: "/tmp/workspace",
+    });
+    expect(mocks.ensurePluginRegistryLoaded).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: "all",
+        workspaceDir: "/tmp/workspace",
+        onlyPluginIds: ["codex", "openai"],
+        config: expect.objectContaining({
+          plugins: expect.objectContaining({
+            allow: ["telegram", "codex", "openai"],
+            entries: expect.objectContaining({
+              codex: expect.objectContaining({ enabled: true }),
+              openai: expect.objectContaining({ enabled: true }),
+              telegram: expect.objectContaining({ enabled: true }),
+            }),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("keeps a Codex scoped load narrow when the provider has no owner plugin", async () => {
+    mocks.resolveOwningPluginIdsForProvider.mockReturnValueOnce(undefined);
+
+    await ensureSelectedAgentHarnessPlugin({
+      provider: "custom-provider",
+      modelId: "gpt-5.5",
+      agentHarnessRuntimeOverride: "codex",
+      workspaceDir: "/tmp/workspace",
+    });
+
+    expect(mocks.resolveBundledProviderCompatPluginIds).not.toHaveBeenCalled();
+    expect(mocks.resolveActivatableProviderOwnerPluginIds).not.toHaveBeenCalled();
     expect(mocks.ensurePluginRegistryLoaded).toHaveBeenCalledWith(
       expect.objectContaining({
         scope: "all",
@@ -89,5 +278,6 @@ describe("ensureSelectedAgentHarnessPlugin", () => {
     });
 
     expect(mocks.ensurePluginRegistryLoaded).not.toHaveBeenCalled();
+    expect(mocks.resolveOwningPluginIdsForProvider).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/harness/runtime-plugin.ts
+++ b/src/agents/harness/runtime-plugin.ts
@@ -1,6 +1,92 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { withActivatedPluginIds } from "../../plugins/activation-context.js";
+import {
+  resolveActivatableProviderOwnerPluginIds,
+  resolveBundledProviderCompatPluginIds,
+  resolveOwningPluginIdsForProvider,
+} from "../../plugins/providers.js";
 import { resolveAgentHarnessPolicy } from "./policy.js";
+
+function dedupePluginIds(values: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    const pluginId = value.trim();
+    if (!pluginId || seen.has(pluginId)) {
+      continue;
+    }
+    seen.add(pluginId);
+    result.push(pluginId);
+  }
+  return result;
+}
+
+function restrictiveAllowlistOmitsPlugin(config: OpenClawConfig | undefined, pluginId: string) {
+  if (config?.plugins?.bundledDiscovery === "compat") {
+    return false;
+  }
+  const allow = config?.plugins?.allow ?? [];
+  return allow.length > 0 && !allow.includes(pluginId);
+}
+
+function resolveCodexHarnessPluginIds(params: {
+  provider: string;
+  config?: OpenClawConfig;
+  workspaceDir: string;
+}): string[] {
+  if (restrictiveAllowlistOmitsPlugin(params.config, "codex")) {
+    return ["codex"];
+  }
+  const providerOwnerPluginIds = dedupePluginIds(
+    resolveOwningPluginIdsForProvider({
+      provider: params.provider,
+      config: params.config,
+      workspaceDir: params.workspaceDir,
+    }) ?? [],
+  );
+  if (providerOwnerPluginIds.length === 0) {
+    return ["codex"];
+  }
+  const safeProviderOwnerPluginIds = dedupePluginIds([
+    ...resolveBundledProviderCompatPluginIds({
+      config: params.config,
+      workspaceDir: params.workspaceDir,
+      onlyPluginIds: providerOwnerPluginIds,
+    }),
+    ...resolveActivatableProviderOwnerPluginIds({
+      pluginIds: providerOwnerPluginIds,
+      config: params.config,
+      workspaceDir: params.workspaceDir,
+    }),
+  ]);
+  return dedupePluginIds([
+    "codex",
+    ...providerOwnerPluginIds.filter(
+      (pluginId) => pluginId !== "codex" && safeProviderOwnerPluginIds.includes(pluginId),
+    ),
+  ]);
+}
+
+function withRuntimePluginIdsAllowed(params: {
+  config?: OpenClawConfig;
+  requiredPluginId: string;
+  pluginIds: readonly string[];
+}): OpenClawConfig | undefined {
+  if (params.pluginIds.length === 0) {
+    return params.config;
+  }
+  if (restrictiveAllowlistOmitsPlugin(params.config, params.requiredPluginId)) {
+    return params.config;
+  }
+  const allow = dedupePluginIds([...(params.config?.plugins?.allow ?? []), ...params.pluginIds]);
+  return {
+    ...params.config,
+    plugins: {
+      ...params.config?.plugins,
+      allow,
+    },
+  };
+}
 
 export async function ensureSelectedAgentHarnessPlugin(params: {
   provider: string;
@@ -29,11 +115,21 @@ export async function ensureSelectedAgentHarnessPlugin(params: {
 
   const { ensurePluginRegistryLoaded } =
     await import("../../plugins/runtime/runtime-registry-loader.js");
+  const pluginIds = resolveCodexHarnessPluginIds({
+    provider: params.provider,
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+  });
+  const configWithAllowedRuntimePlugins = withRuntimePluginIdsAllowed({
+    config: params.config,
+    requiredPluginId: "codex",
+    pluginIds,
+  });
   const activatedConfig =
     withActivatedPluginIds({
-      config: params.config,
-      pluginIds: ["codex"],
-    }) ?? params.config;
+      config: configWithAllowedRuntimePlugins,
+      pluginIds,
+    }) ?? configWithAllowedRuntimePlugins;
   ensurePluginRegistryLoaded({
     scope: "all",
     ...(activatedConfig
@@ -43,6 +139,6 @@ export async function ensureSelectedAgentHarnessPlugin(params: {
         }
       : {}),
     workspaceDir: params.workspaceDir,
-    onlyPluginIds: ["codex"],
+    onlyPluginIds: pluginIds,
   });
 }

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -366,7 +366,7 @@ beforeEach(() => {
 });
 
 describe("agentCommand", () => {
-  it("enables the Codex runtime plugin for one-shot OpenAI model overrides", async () => {
+  it("enables the Codex runtime plugin and provider owner for one-shot OpenAI model overrides", async () => {
     await withTempHome(async (home) => {
       const storePath = path.join(home, "sessions.json");
       mockConfig(home, storePath, { models: undefined });
@@ -387,7 +387,7 @@ describe("agentCommand", () => {
         expect(registryLoad?.config).toBeTypeOf("object");
         expect(registryLoad?.activationSourceConfig).toBeTypeOf("object");
         expect(registryLoad?.workspaceDir).toBe(path.join(home, "openclaw"));
-        expect(registryLoad?.onlyPluginIds).toEqual(["codex"]);
+        expect(registryLoad?.onlyPluginIds).toEqual(["codex", "openai"]);
       }
       expectLastRunProviderModel("openai", "gpt-5.2");
     });


### PR DESCRIPTION
Summary
- load the selected provider's safe owner plugin when Codex harness runtime is selected
- keep restrictive plugin allowlists intact while preserving bundled discovery compat behavior
- add focused regression coverage for provider-owner activation and allowlist edge cases

Verification
- `node scripts/run-vitest.mjs src/agents/harness/runtime-plugin.test.ts`
- `.agents/skills/autoreview/scripts/autoreview --parallel-tests "node scripts/run-vitest.mjs src/agents/harness/runtime-plugin.test.ts"`
- Crabbox AWS proof: provider `aws`, lease `cbx_3cc8c699b36c`, run `run_bd73bf228302`

Behavior addressed: Codex harness runtime could fail to resolve `openai-codex/gpt-5.5-pro` when only the `codex` plugin was loaded, because the provider/catalog hooks are owned by the bundled OpenAI plugin.
Real environment tested: AWS Crabbox Linux host using the current branch patch and a live OpenAI Codex harness credential profile.
Exact steps or command run after this patch: built OpenClaw, validated config, ran a resolver probe for `openai-codex/gpt-5.5-pro`, then ran `node openclaw.mjs agent --local --agent main --session-id issue-83380-internal-loader --model openai-codex/gpt-5.5-pro --message 'Reply with exactly READY.' --thinking off --json --timeout 180`.
Evidence after fix: the resolver probe returned provider `openai-codex`, id `gpt-5.5-pro`, api `openai-codex-responses`, and ChatGPT backend base URL.
Observed result after fix: the live command no longer failed with `Unknown model`, no missing bearer/profile issue appeared, and execution reached the Codex/ChatGPT backend before stopping at the expected account/model support response for the available credential.
What was not tested: a successful full Codex model completion with a ChatGPT account that supports `gpt-5.5-pro`; the available credential was rejected upstream for that model after the OpenClaw loader path had succeeded.

Fixes #83380
