### PR TITLE
[Fix] Defer gateway update check startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway: defer update-check startup until after readiness so package update checks no longer block sidecar-ready startup, while preserving update broadcasts and shutdown cleanup. (#83520) Thanks @samzong.
 - Agents/video: hide `video_generate` reference-audio parameters unless a registered video provider supports audio inputs.
 - Plugins/xAI: echo PKCE challenge fields during OAuth authorization-code token exchange for xAI token-endpoint compatibility. (#83499) Thanks @fuller-stack-dev.
 - Codex app-server: hydrate current inbound image attachments before queued runs so Responses-backed agents receive Discord and other channel images as native vision input. Fixes #83466. Thanks @iannwu.

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -425,6 +425,102 @@ describe("startGatewayPostAttachRuntime", () => {
     expect(events).toEqual(["startup-log-start", "sidecars", "startup-log-end"]);
   });
 
+  it("starts the gateway update check after post-attach returns", async () => {
+    const events: string[] = [];
+    const stopUpdateCheck = vi.fn();
+    const scheduleGatewayUpdateCheck = vi.fn(async () => {
+      events.push("update-check");
+      return stopUpdateCheck;
+    });
+    const startGatewaySidecars = vi.fn(async () => {
+      events.push("sidecars");
+      return { pluginServices: null, postReadySidecars: [] };
+    });
+
+    const result = await startGatewayPostAttachRuntime(
+      createPostAttachParams(),
+      createPostAttachRuntimeDeps({
+        refreshLatestUpdateRestartSentinel: vi.fn(async () => null),
+        scheduleGatewayUpdateCheck,
+        startGatewaySidecars,
+      }),
+    );
+    events.push("returned");
+
+    expect(scheduleGatewayUpdateCheck).not.toHaveBeenCalled();
+    expect(events).toEqual(["sidecars", "returned"]);
+
+    await vi.waitFor(() => {
+      expect(scheduleGatewayUpdateCheck).toHaveBeenCalledTimes(1);
+    });
+    expect(events).toEqual(["sidecars", "returned", "update-check"]);
+
+    result.stopGatewayUpdateCheck();
+    expect(stopUpdateCheck).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops the gateway update check if close wins the deferred startup race", async () => {
+    let finishUpdateCheckSchedule: (() => void) | undefined;
+    const stopUpdateCheck = vi.fn();
+    const scheduleGatewayUpdateCheck = vi.fn(
+      async () =>
+        await new Promise<() => void>((resolve) => {
+          finishUpdateCheckSchedule = () => resolve(stopUpdateCheck);
+        }),
+    );
+
+    const result = await startGatewayPostAttachRuntime(
+      createPostAttachParams(),
+      createPostAttachRuntimeDeps({
+        refreshLatestUpdateRestartSentinel: vi.fn(async () => null),
+        scheduleGatewayUpdateCheck,
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(scheduleGatewayUpdateCheck).toHaveBeenCalledTimes(1);
+    });
+    result.stopGatewayUpdateCheck();
+    expect(stopUpdateCheck).not.toHaveBeenCalled();
+
+    if (!finishUpdateCheckSchedule) {
+      throw new Error("Expected update check schedule release callback to be initialized");
+    }
+    finishUpdateCheckSchedule();
+
+    await vi.waitFor(() => {
+      expect(stopUpdateCheck).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("logs deferred gateway update check startup failures without failing ready", async () => {
+    const log = { info: vi.fn(), warn: vi.fn() };
+    const scheduleGatewayUpdateCheck = vi.fn(async () => {
+      throw new Error("boom");
+    });
+
+    await expect(
+      startGatewayPostAttachRuntime(
+        {
+          ...createPostAttachParams(),
+          log,
+        },
+        createPostAttachRuntimeDeps({
+          refreshLatestUpdateRestartSentinel: vi.fn(async () => null),
+          scheduleGatewayUpdateCheck,
+        }),
+      ),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        stopGatewayUpdateCheck: expect.any(Function),
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(log.warn).toHaveBeenCalledWith("gateway update check failed to start: Error: boom");
+    });
+  });
+
   it("skips heavy restart sentinel refresh when no sentinel file exists", async () => {
     const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-no-sentinel-"));
     vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -745,6 +745,66 @@ const defaultGatewayPostAttachRuntimeDeps: GatewayPostAttachRuntimeDeps = {
     (await import("./server-tailscale.js")).startGatewayTailscaleExposure(...args),
 };
 
+function createDeferredGatewayUpdateCheck(params: {
+  startupTrace?: GatewayStartupTrace;
+  runtimeDeps: GatewayPostAttachRuntimeDeps;
+  cfg: OpenClawConfig;
+  log: {
+    info: (msg: string) => void;
+    warn: (msg: string) => void;
+  };
+  isNixMode: boolean;
+  broadcast: (event: string, payload: unknown, opts?: { dropIfSlow?: boolean }) => void;
+}): { start: () => void; stop: () => void } {
+  let started = false;
+  let stopped = false;
+  let stopUpdateCheck: (() => void) | null = null;
+
+  const stop = () => {
+    stopped = true;
+    stopUpdateCheck?.();
+    stopUpdateCheck = null;
+  };
+
+  const start = () => {
+    if (started || stopped) {
+      return;
+    }
+    started = true;
+    setImmediate(() => {
+      if (stopped) {
+        return;
+      }
+      void measureStartup(params.startupTrace, "post-attach.update-check", () =>
+        params.runtimeDeps.scheduleGatewayUpdateCheck({
+          cfg: params.cfg,
+          log: params.log,
+          isNixMode: params.isNixMode,
+          onUpdateAvailableChange: (updateAvailable) => {
+            const payload: GatewayUpdateAvailableEventPayload = { updateAvailable };
+            params.broadcast(GATEWAY_EVENT_UPDATE_AVAILABLE, payload, { dropIfSlow: true });
+          },
+        }),
+      )
+        .then((nextStop) => {
+          if (stopped) {
+            nextStop();
+            return;
+          }
+          stopUpdateCheck = nextStop;
+        })
+        .catch((err) => {
+          if (stopped) {
+            return;
+          }
+          params.log.warn(`gateway update check failed to start: ${String(err)}`);
+        });
+    });
+  };
+
+  return { start, stop };
+}
+
 export async function startGatewayPostAttachRuntime(
   params: {
     minimalTestGateway: boolean;
@@ -833,19 +893,16 @@ export async function startGatewayPostAttachRuntime(
     }),
   );
 
-  const stopGatewayUpdateCheckPromise = params.minimalTestGateway
-    ? Promise.resolve(() => {})
-    : measureStartup(params.startupTrace, "post-attach.update-check", () =>
-        runtimeDeps.scheduleGatewayUpdateCheck({
-          cfg: params.cfgAtStart,
-          log: params.log,
-          isNixMode: params.isNixMode,
-          onUpdateAvailableChange: (updateAvailable) => {
-            const payload: GatewayUpdateAvailableEventPayload = { updateAvailable };
-            params.broadcast(GATEWAY_EVENT_UPDATE_AVAILABLE, payload, { dropIfSlow: true });
-          },
-        }),
-      );
+  const updateCheck = params.minimalTestGateway
+    ? { start: () => {}, stop: () => {} }
+    : createDeferredGatewayUpdateCheck({
+        startupTrace: params.startupTrace,
+        runtimeDeps,
+        cfg: params.cfgAtStart,
+        log: params.log,
+        isNixMode: params.isNixMode,
+        broadcast: params.broadcast,
+      });
 
   const tailscaleCleanupPromise = params.minimalTestGateway
     ? Promise.resolve(null)
@@ -961,26 +1018,27 @@ export async function startGatewayPostAttachRuntime(
     });
 
   if (params.deferSidecars !== true) {
-    const [, stopGatewayUpdateCheck, tailscaleCleanup, sidecarsResult] = await Promise.all([
+    const [, tailscaleCleanup, sidecarsResult] = await Promise.all([
       startupLogPromise,
-      stopGatewayUpdateCheckPromise,
       tailscaleCleanupPromise,
       sidecarsPromise,
     ]);
+    updateCheck.start();
     return {
-      stopGatewayUpdateCheck,
+      stopGatewayUpdateCheck: updateCheck.stop,
       tailscaleCleanup,
       pluginServices: sidecarsResult.pluginServices,
     };
   }
 
-  const [, stopGatewayUpdateCheck, tailscaleCleanup] = await Promise.all([
-    startupLogPromise,
-    stopGatewayUpdateCheckPromise,
-    tailscaleCleanupPromise,
-  ]);
+  const [, tailscaleCleanup] = await Promise.all([startupLogPromise, tailscaleCleanupPromise]);
+  updateCheck.start();
 
-  return { stopGatewayUpdateCheck, tailscaleCleanup, pluginServices: reportedPluginServices };
+  return {
+    stopGatewayUpdateCheck: updateCheck.stop,
+    tailscaleCleanup,
+    pluginServices: reportedPluginServices,
+  };
 }
 
 export const __testing = {


### PR DESCRIPTION
## Summary

- Problem: Gateway post-attach startup waited for update-check scheduling before returning ready state.
- Why it matters: update-check startup should not sit on the critical ready path or delay sidecar readiness.
- What changed: Added a deferred update-check starter that runs after post-attach returns, preserves update-available broadcasts, logs startup failures, and stops late-started checks during shutdown races.
- What did NOT change (scope boundary): No update endpoint, update availability semantics, Gateway protocol, or Tailscale/startup sidecar behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes: N/A - no linked issue.
- Related: N/A - standalone Gateway startup fix.
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: A real foreground Gateway reaches ready before the deferred update-check scheduler starts; the scheduler then runs, writes update-check state, and the Gateway shuts down cleanly.
- Real environment tested: macOS 26.4.1, Node v24.14.0, pnpm 11.1.0, local OpenClaw source checkout at `a711e363`; isolated temporary `OPENCLAW_HOME`, `OPENCLAW_STATE_DIR`, and `OPENCLAW_CONFIG_PATH`; loopback port `59759`; `--auth none`; `--tailscale off`.
- Exact steps or command run after this patch:

  ```bash
  OPENCLAW_HOME=<temp>/home \
  OPENCLAW_STATE_DIR=<temp>/state \
  OPENCLAW_CONFIG_PATH=<temp>/state/openclaw.json \
  OPENCLAW_GATEWAY_STARTUP_TRACE=1 \
  OPENCLAW_SKIP_CHANNELS=1 \
  OPENCLAW_SKIP_PROVIDERS=1 \
  OPENCLAW_NO_AUTO_UPDATE=1 \
  pnpm openclaw gateway run --allow-unconfigured --auth none --bind loopback --tailscale off --port 59759 --verbose --ws-log compact
  ```

  After `post-attach.update-check` appeared, I sent `SIGTERM` to the foreground Gateway process and waited for shutdown.
- Evidence after fix (copied, redacted terminal/runtime log from the managed Gateway run):

  Copied runtime log output from a managed Gateway run:

  ```text
  2026-05-18T16:41:44.640+08:00 [gateway] http server listening (9 plugins: acpx, bonjour, browser, canvas, device-pair, file-transfer, memory-core, phone-control, talk-voice; 4.7s)
  2026-05-18T16:41:48.411+08:00 [gateway] startup trace: sidecars.total 3761.8ms total=8029.3ms eventLoopMax=0.0ms
  2026-05-18T16:41:48.414+08:00 [gateway] startup trace: sidecars.ready 2.7ms total=8032.0ms eventLoopMax=0.0ms
  2026-05-18T16:41:48.415+08:00 [gateway] ready
  2026-05-18T16:41:48.416+08:00 [gateway] startup trace: runtime.post-attach 4174.8ms total=8033.8ms eventLoopMax=0.0ms
  2026-05-18T16:41:48.473+08:00 [gateway] startup trace: post-attach.update-check 0.8ms total=8091.1ms eventLoopMax=0.0ms
  state/update-check.json after the run: { "lastCheckedAt": "2026-05-18T08:41:48.477Z" }
  2026-05-18T16:43:07.317+08:00 [gateway] signal SIGTERM received
  2026-05-18T16:43:07.324+08:00 [gateway] received SIGTERM; shutting down
  2026-05-18T16:43:07.338+08:00 [shutdown] started: gateway stopping
  2026-05-18T16:43:07.416+08:00 [shutdown] completed cleanly in 79ms
  ```
- Observed result after fix: `[gateway] ready` was logged before `post-attach.update-check`; the update-check state file was written immediately after the deferred scheduler started; SIGTERM completed a clean Gateway shutdown.
- What was not tested: A package-install update-available broadcast from the real npm registry path. This source-checkout run exercised real Gateway startup, real deferred scheduler startup, update-check state write, and shutdown cleanup; the targeted unit tests cover update-available broadcast and close-before-scheduler-resolution cleanup.
- Before evidence: N/A - this is a narrow startup-order fix covered by new regression tests plus the managed Gateway after-fix proof above.

## Performance accounting

- Managed proof run ready time: `8035.8ms` total.
- Dominant ready-path work in that run: `sidecars.total 3761.8ms`.
- Deferred update-check startup span after the patch: `post-attach.update-check 0.8ms`, logged `55.3ms` after the `ready` trace line.
- Critical-path speedup measured in this run: `0.0ms` / `0.0%`, because sidecars dominated the old `Promise.all` path.
- Upper bound moved off the ready path in this environment: `0.8ms` / `0.01%` of ready time. This PR is primarily a startup-order isolation fix, not a measured startup-speedup PR; the value is preventing update-check startup from becoming a variable readiness dependency.

## Root Cause (if applicable)

- Root cause: `startGatewayPostAttachRuntime` awaited `scheduleGatewayUpdateCheck` as part of the post-attach `Promise.all`, so update-check scheduling stayed on the ready path.
- Missing detection / guardrail: Existing tests covered startup ordering for sidecars/logging, but not update-check scheduling order or close-before-schedule-resolution cleanup.
- Contributing context (if known): Gateway startup has several post-ready/background tasks; update check behaved like a required startup dependency instead of a deferred sidecar.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/server-startup-post-attach.test.ts`
- Scenario the test should lock in: update check starts after post-attach returns, close races stop late-started checks, and scheduler startup failures warn without failing readiness.
- Why this is the smallest reliable guardrail: The behavior is isolated to `startGatewayPostAttachRuntime` scheduling and cleanup semantics.
- Existing test that already covers this (if any): N/A - this PR adds the missing coverage.
- If no new test is added, why not: N/A - new tests were added.

## User-visible / Behavior Changes

Gateway readiness can complete without waiting for update-check startup. Update availability notifications still work after readiness.

## Diagram (if applicable)

```text
Before:
post-attach -> startup log + tailscale + sidecars + update check -> return ready

After:
post-attach -> startup log + tailscale + sidecars -> return ready -> deferred update check
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS 26.4.1
- Runtime/container: Node v24.14.0, pnpm 11.1.0, local checkout at `a711e363`
- Model/provider: N/A
- Integration/channel (if any): Real foreground Gateway startup runtime on loopback with isolated temporary state/config; channel/provider startup skipped to avoid private credentials
- Relevant config (redacted): temporary `OPENCLAW_HOME`, `OPENCLAW_STATE_DIR`, and `OPENCLAW_CONFIG_PATH`; `OPENCLAW_GATEWAY_STARTUP_TRACE=1`; `OPENCLAW_NO_AUTO_UPDATE=1`

### Steps

1. Run the managed Gateway command shown in the Real behavior proof section.
2. Wait for `[gateway] ready`, `runtime.post-attach`, and `post-attach.update-check` startup trace lines.
3. Verify the temporary state wrote `update-check.json` with `lastCheckedAt`.
4. Send `SIGTERM` to the foreground Gateway process and wait for shutdown.
5. Run `node scripts/run-vitest.mjs src/gateway/server-startup-post-attach.test.ts`.
6. Run `pnpm build`.
7. Run `codex review --commit HEAD` via the local review wrapper.

### Expected

- Managed Gateway reaches ready before deferred update-check startup begins.
- Deferred update-check startup runs after ready and writes update-check state.
- Gateway shutdown completes cleanly after SIGTERM.
- Targeted Gateway startup tests and build pass.

### Actual

- Managed Gateway log showed `[gateway] ready` at 16:41:48.415 and `post-attach.update-check` at 16:41:48.473.
- Temporary `state/update-check.json` contained `lastCheckedAt: 2026-05-18T08:41:48.477Z`.
- SIGTERM shutdown completed cleanly in 79ms.
- `node scripts/run-vitest.mjs src/gateway/server-startup-post-attach.test.ts`: 37 tests passed.
- `pnpm build`: passed.
- `codex review --commit HEAD`: no actionable correctness issues.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: deferred update-check ordering, update-available broadcast, cleanup handle execution, close-before-schedule-resolution cleanup, scheduler startup failure logging, targeted Gateway startup tests, build.
- Edge cases checked: stop called before scheduler promise resolves; scheduler rejects after readiness.
- What you did **not** verify: long-running managed Gateway update polling against the real endpoint.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Deferring update-check startup could hide scheduler startup failures after readiness.
  - Mitigation: Deferred startup catches and logs failures without failing Gateway readiness, and tests assert the warning path.
- Risk: Shutdown could happen before the deferred scheduler resolves.
  - Mitigation: The deferred starter tracks `stopped` and immediately runs the returned cleanup when close wins the race; tests cover this.



