### PR TITLE
fix(gateway): emit session_start hook on agent.send auto-rotation (#83507)

### DIFF
--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -731,8 +731,12 @@ describe("gateway agent handler", () => {
       { reqId: "test-session-start-hook-auto-rotation" },
     );
 
-    // #83507 follow-up: end-hook fires for the OLD session id with resumedFrom
-    // metadata for the rotation, matching sessions.reset's lifecycle pairing.
+    // #83507 follow-up: end-hook fires for the OLD session id with the
+    // rotation-cause-derived `reason`, matching sessions.reset's lifecycle
+    // pairing. This test exercises the client-supplied-new-sessionId path,
+    // which classifies as `"new"` (the same reason sessions.reset emits for
+    // the /new slash command). Daily-reset and transcript-missing paths
+    // produce `"daily"` and `"deleted"` respectively.
     expect(mocks.emitGatewaySessionEndPluginHook).toHaveBeenCalledTimes(1);
     expect(mocks.emitGatewaySessionEndPluginHook).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -742,7 +746,7 @@ describe("gateway agent handler", () => {
         sessionFile: "/tmp/openclaw/agents/main/sessions/old-session-id.jsonl",
         storePath: "/tmp/sessions.json",
         agentId: "main",
-        reason: "daily",
+        reason: "new",
         nextSessionId: "new-session-id",
         nextSessionKey: "agent:main:main",
       }),

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -33,6 +33,7 @@ const mocks = vi.hoisted(() => ({
   emitAgentEvent: vi.fn(),
   performGatewaySessionReset: vi.fn(),
   emitGatewaySessionStartPluginHook: vi.fn(),
+  emitGatewaySessionEndPluginHook: vi.fn(),
   getLatestSubagentRunByChildSessionKey: vi.fn(),
   replaceSubagentRunAfterSteer: vi.fn(),
   resolveExplicitAgentSessionKey: vi.fn(),
@@ -128,6 +129,8 @@ vi.mock("../session-reset-service.js", () => ({
     (mocks.performGatewaySessionReset as (...args: unknown[]) => unknown)(...args),
   emitGatewaySessionStartPluginHook: (...args: unknown[]) =>
     (mocks.emitGatewaySessionStartPluginHook as (...args: unknown[]) => unknown)(...args),
+  emitGatewaySessionEndPluginHook: (...args: unknown[]) =>
+    (mocks.emitGatewaySessionEndPluginHook as (...args: unknown[]) => unknown)(...args),
 }));
 
 vi.mock("../../infra/voicewake-routing.js", () => ({
@@ -695,7 +698,7 @@ describe("gateway agent handler", () => {
     });
   });
 
-  it("emits session_start when agent.send rotates to a caller-supplied session id", async () => {
+  it("emits session_end + session_start lifecycle pair when agent.send rotates to a caller-supplied session id", async () => {
     const cfg = { session: { mainKey: "main" } };
     const existingEntry = {
       sessionId: "old-session-id",
@@ -704,6 +707,7 @@ describe("gateway agent handler", () => {
     };
     mockMainSessionEntry(existingEntry, cfg);
     mocks.emitGatewaySessionStartPluginHook.mockClear();
+    mocks.emitGatewaySessionEndPluginHook.mockClear();
 
     mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
       const store: Record<string, unknown> = {
@@ -727,17 +731,41 @@ describe("gateway agent handler", () => {
       { reqId: "test-session-start-hook-auto-rotation" },
     );
 
+    // #83507 follow-up: end-hook fires for the OLD session id with resumedFrom
+    // metadata for the rotation, matching sessions.reset's lifecycle pairing.
+    expect(mocks.emitGatewaySessionEndPluginHook).toHaveBeenCalledTimes(1);
+    expect(mocks.emitGatewaySessionEndPluginHook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfg,
+        sessionKey: "agent:main:main",
+        sessionId: "old-session-id",
+        sessionFile: "/tmp/openclaw/agents/main/sessions/old-session-id.jsonl",
+        storePath: "/tmp/sessions.json",
+        agentId: "main",
+        reason: "daily",
+        nextSessionId: "new-session-id",
+        nextSessionKey: "agent:main:main",
+      }),
+    );
+
     expect(mocks.emitGatewaySessionStartPluginHook).toHaveBeenCalledTimes(1);
     expect(mocks.emitGatewaySessionStartPluginHook).toHaveBeenCalledWith(
       expect.objectContaining({
         cfg,
         sessionKey: "agent:main:main",
         sessionId: "new-session-id",
+        resumedFrom: "old-session-id",
         storePath: "/tmp/sessions.json",
         sessionFile: undefined,
         agentId: "main",
       }),
     );
+
+    // End must be called BEFORE start (lifecycle pair order matches
+    // session-reset-service.ts:835-844).
+    const endCallOrder = mocks.emitGatewaySessionEndPluginHook.mock.invocationCallOrder[0];
+    const startCallOrder = mocks.emitGatewaySessionStartPluginHook.mock.invocationCallOrder[0];
+    expect(endCallOrder).toBeLessThan(startCallOrder);
   });
 
   it("keeps stored group metadata when a trusted group session receives caller-supplied selectors", async () => {

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -32,6 +32,7 @@ const mocks = vi.hoisted(() => ({
   registerAgentRunContext: vi.fn(),
   emitAgentEvent: vi.fn(),
   performGatewaySessionReset: vi.fn(),
+  emitGatewaySessionStartPluginHook: vi.fn(),
   getLatestSubagentRunByChildSessionKey: vi.fn(),
   replaceSubagentRunAfterSteer: vi.fn(),
   resolveExplicitAgentSessionKey: vi.fn(),
@@ -125,6 +126,8 @@ vi.mock("../session-subagent-reactivation.runtime.js", () => ({
 vi.mock("../session-reset-service.js", () => ({
   performGatewaySessionReset: (...args: unknown[]) =>
     (mocks.performGatewaySessionReset as (...args: unknown[]) => unknown)(...args),
+  emitGatewaySessionStartPluginHook: (...args: unknown[]) =>
+    (mocks.emitGatewaySessionStartPluginHook as (...args: unknown[]) => unknown)(...args),
 }));
 
 vi.mock("../../infra/voicewake-routing.js", () => ({
@@ -690,6 +693,51 @@ describe("gateway agent handler", () => {
       expect(capturedEntry?.status).toBe("failed");
       expect(capturedEntry?.sessionFile).toBe("relative-present.jsonl");
     });
+  });
+
+  it("emits session_start when agent.send rotates to a caller-supplied session id", async () => {
+    const cfg = { session: { mainKey: "main" } };
+    const existingEntry = {
+      sessionId: "old-session-id",
+      sessionFile: "/tmp/openclaw/agents/main/sessions/old-session-id.jsonl",
+      updatedAt: Date.now(),
+    };
+    mockMainSessionEntry(existingEntry, cfg);
+    mocks.emitGatewaySessionStartPluginHook.mockClear();
+
+    mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+      const store: Record<string, unknown> = {
+        "agent:main:main": { ...existingEntry },
+      };
+      return updater(store);
+    });
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+
+    await invokeAgent(
+      {
+        message: "test",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        sessionId: "new-session-id",
+        idempotencyKey: "test-idem-session-start-hook-auto-rotation",
+      },
+      { reqId: "test-session-start-hook-auto-rotation" },
+    );
+
+    expect(mocks.emitGatewaySessionStartPluginHook).toHaveBeenCalledTimes(1);
+    expect(mocks.emitGatewaySessionStartPluginHook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cfg,
+        sessionKey: "agent:main:main",
+        sessionId: "new-session-id",
+        storePath: "/tmp/sessions.json",
+        sessionFile: undefined,
+        agentId: "main",
+      }),
+    );
   });
 
   it("keeps stored group metadata when a trusted group session receives caller-supplied selectors", async () => {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -976,6 +976,11 @@ export const agentHandlers: GatewayRequestHandlers = {
       let resolvedSessionStorePath: string | undefined;
       let resolvedSessionKey = requestedSessionKey;
       let isNewSession = false;
+      // #83507 follow-up: carry the replaced session ID across the auto-rotation
+      // branch so emitGatewaySessionStartPluginHook can pass `resumedFrom` and
+      // plugins can link the old → new session lifecycle. Defaults to undefined
+      // when no prior session was rotated.
+      let previousSessionId: string | undefined;
       let skipTimestampInjection = false;
       let shouldPrependStartupContext = false;
 
@@ -1120,6 +1125,12 @@ export const agentHandlers: GatewayRequestHandlers = {
           (!canReuseSession && !usableRequestedSessionId) ||
           Boolean(usableRequestedSessionId && entry?.sessionId !== usableRequestedSessionId);
         const rotatedSessionId = Boolean(entry?.sessionId && entry.sessionId !== sessionId);
+        // #83507 follow-up: capture the replaced session ID so the start-hook
+        // call below can pass it as `resumedFrom`, matching the canonical
+        // sessions.reset path which already carries this lifecycle linkage.
+        if (rotatedSessionId && entry?.sessionId) {
+          previousSessionId = entry.sessionId;
+        }
         const touchInteraction =
           request.bootstrapContextRunKind !== "cron" &&
           request.bootstrapContextRunKind !== "heartbeat" &&
@@ -1545,6 +1556,9 @@ export const agentHandlers: GatewayRequestHandlers = {
               cfg: resolvedSessionCfg,
               sessionKey: resolvedSessionKey,
               sessionId: resolvedSessionId,
+              // #83507 follow-up: pass the replaced session ID so plugins can
+              // link the old → new lifecycle, matching sessions.reset.
+              resumedFrom: previousSessionId,
               storePath: resolvedSessionStorePath,
               sessionFile: sessionEntry?.sessionFile,
               agentId: resolveAgentIdFromSessionKey(resolvedSessionKey),

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -1155,14 +1155,25 @@ export const agentHandlers: GatewayRequestHandlers = {
           // - Client supplied a different sessionId → "new" (matches
           //   sessions.reset's reason for the /new slash command).
           // - Previous session's transcript file disappeared → "deleted".
-          // - Otherwise the rotation came from freshness expiry, which the
-          //   policy treats as the daily-reset boundary → "daily".
+          // - Freshness expired under an idle-reset policy → "idle".
+          // - Freshness expired under a daily-reset policy → "daily".
+          //
+          // The freshness object carries `idleExpiresAt` (set only when the
+          // policy uses an idle window) and `dailyResetAt` (set only when
+          // the policy uses daily-mode). Prefer the specific reason so
+          // plugins that branch on session_end.reason see the actual cause.
           if (usableRequestedSessionId && entry.sessionId !== usableRequestedSessionId) {
             rotationReason = "new";
           } else if (failedSessionTranscriptMissing) {
             rotationReason = "deleted";
           } else if (!canReuseSession) {
-            rotationReason = "daily";
+            if (freshness?.idleExpiresAt != null && now > freshness.idleExpiresAt) {
+              rotationReason = "idle";
+            } else if (freshness?.dailyResetAt != null) {
+              rotationReason = "daily";
+            } else {
+              rotationReason = "daily";
+            }
           }
         }
         const touchInteraction =

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -972,6 +972,8 @@ export const agentHandlers: GatewayRequestHandlers = {
       let sessionEntry: SessionEntry | undefined;
       let bestEffortDeliver = requestedBestEffortDeliver ?? false;
       let cfgForAgent: OpenClawConfig | undefined;
+      let resolvedSessionCfg: OpenClawConfig | undefined;
+      let resolvedSessionStorePath: string | undefined;
       let resolvedSessionKey = requestedSessionKey;
       let isNewSession = false;
       let skipTimestampInjection = false;
@@ -1065,6 +1067,8 @@ export const agentHandlers: GatewayRequestHandlers = {
       if (requestedSessionKey) {
         const { cfg, storePath, entry, canonicalKey } = loadSessionEntry(requestedSessionKey);
         cfgForAgent = cfg;
+        resolvedSessionCfg = cfg;
+        resolvedSessionStorePath = storePath;
         const now = Date.now();
         const resetPolicy = resolveSessionResetPolicy({
           sessionCfg: cfg.session,
@@ -1517,7 +1521,13 @@ export const agentHandlers: GatewayRequestHandlers = {
             });
           }
 
-          if (requestedSessionKey && resolvedSessionKey && isNewSession) {
+          if (
+            requestedSessionKey &&
+            resolvedSessionKey &&
+            isNewSession &&
+            resolvedSessionCfg &&
+            resolvedSessionStorePath
+          ) {
             emitSessionsChanged(context, {
               sessionKey: resolvedSessionKey,
               reason: "create",
@@ -1532,10 +1542,10 @@ export const agentHandlers: GatewayRequestHandlers = {
             // after the daily boundary. Emit the hook here so the contract
             // is consistent across all session-creation paths.
             emitGatewaySessionStartPluginHook({
-              cfg,
+              cfg: resolvedSessionCfg,
               sessionKey: resolvedSessionKey,
               sessionId: resolvedSessionId,
-              storePath,
+              storePath: resolvedSessionStorePath,
               sessionFile: sessionEntry?.sessionFile,
               agentId: resolveAgentIdFromSessionKey(resolvedSessionKey),
             });

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -125,6 +125,7 @@ import {
   validateAgentWaitParams,
 } from "../protocol/index.js";
 import {
+  emitGatewaySessionEndPluginHook,
   emitGatewaySessionStartPluginHook,
   performGatewaySessionReset,
 } from "../session-reset-service.js";
@@ -976,11 +977,14 @@ export const agentHandlers: GatewayRequestHandlers = {
       let resolvedSessionStorePath: string | undefined;
       let resolvedSessionKey = requestedSessionKey;
       let isNewSession = false;
-      // #83507 follow-up: carry the replaced session ID across the auto-rotation
-      // branch so emitGatewaySessionStartPluginHook can pass `resumedFrom` and
-      // plugins can link the old → new session lifecycle. Defaults to undefined
-      // when no prior session was rotated.
+      // #83507 follow-up: carry the replaced session ID + sessionFile across
+      // the auto-rotation branch so emitGatewaySessionEndPluginHook can fire
+      // for the old session (pairing the lifecycle boundary, matching
+      // sessions.reset) and emitGatewaySessionStartPluginHook can pass
+      // `resumedFrom` (linking old → new). Both default to undefined when no
+      // prior session was rotated.
       let previousSessionId: string | undefined;
+      let previousSessionFile: string | undefined;
       let skipTimestampInjection = false;
       let shouldPrependStartupContext = false;
 
@@ -1125,11 +1129,13 @@ export const agentHandlers: GatewayRequestHandlers = {
           (!canReuseSession && !usableRequestedSessionId) ||
           Boolean(usableRequestedSessionId && entry?.sessionId !== usableRequestedSessionId);
         const rotatedSessionId = Boolean(entry?.sessionId && entry.sessionId !== sessionId);
-        // #83507 follow-up: capture the replaced session ID so the start-hook
-        // call below can pass it as `resumedFrom`, matching the canonical
-        // sessions.reset path which already carries this lifecycle linkage.
+        // #83507 follow-up: capture the replaced session ID + sessionFile
+        // so the lifecycle pair (end-hook for old + start-hook for new) can
+        // fire below, matching sessions.reset which calls both at
+        // session-reset-service.ts:835-844.
         if (rotatedSessionId && entry?.sessionId) {
           previousSessionId = entry.sessionId;
+          previousSessionFile = entry.sessionFile;
         }
         const touchInteraction =
           request.bootstrapContextRunKind !== "cron" &&
@@ -1543,6 +1549,27 @@ export const agentHandlers: GatewayRequestHandlers = {
               sessionKey: resolvedSessionKey,
               reason: "create",
             });
+            // #83507 follow-up: pair the lifecycle boundary by firing the
+            // end-hook for the replaced session BEFORE the start-hook for
+            // the rotated one, exactly matching sessions.reset at
+            // session-reset-service.ts:835-844. Without this, shutdown
+            // tracking and plugin lifecycle state become asymmetric — the
+            // old session stays "tracked" while the new one is added.
+            // Hook function's existing sessionId guard skips when no prior
+            // session was rotated (previousSessionId stays undefined).
+            if (previousSessionId) {
+              emitGatewaySessionEndPluginHook({
+                cfg: resolvedSessionCfg,
+                sessionKey: resolvedSessionKey,
+                sessionId: previousSessionId,
+                storePath: resolvedSessionStorePath,
+                sessionFile: previousSessionFile,
+                agentId: resolveAgentIdFromSessionKey(resolvedSessionKey),
+                reason: "daily",
+                nextSessionId: resolvedSessionId,
+                nextSessionKey: resolvedSessionKey,
+              });
+            }
             // #83507: every other session-creation path
             // (sessions.reset, sessions.create with emitCommandHooks=true,
             // /new and /reset slash commands) emits the session_start

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -985,6 +985,21 @@ export const agentHandlers: GatewayRequestHandlers = {
       // prior session was rotated.
       let previousSessionId: string | undefined;
       let previousSessionFile: string | undefined;
+      // #83507 follow-up: classify the rotation cause so the session_end
+      // hook's `reason` field can be derived instead of always sending
+      // `"daily"`. Plugin session-state bookkeeping branches on this field
+      // — misclassifying an idle/explicit/failed rotation as daily would
+      // corrupt plugin state. Defaults to "unknown" if we can't determine.
+      let rotationReason:
+        | "new"
+        | "reset"
+        | "idle"
+        | "daily"
+        | "compaction"
+        | "deleted"
+        | "shutdown"
+        | "restart"
+        | "unknown" = "unknown";
       let skipTimestampInjection = false;
       let shouldPrependStartupContext = false;
 
@@ -1136,6 +1151,19 @@ export const agentHandlers: GatewayRequestHandlers = {
         if (rotatedSessionId && entry?.sessionId) {
           previousSessionId = entry.sessionId;
           previousSessionFile = entry.sessionFile;
+          // Derive the rotation cause for the session_end hook reason:
+          // - Client supplied a different sessionId → "new" (matches
+          //   sessions.reset's reason for the /new slash command).
+          // - Previous session's transcript file disappeared → "deleted".
+          // - Otherwise the rotation came from freshness expiry, which the
+          //   policy treats as the daily-reset boundary → "daily".
+          if (usableRequestedSessionId && entry.sessionId !== usableRequestedSessionId) {
+            rotationReason = "new";
+          } else if (failedSessionTranscriptMissing) {
+            rotationReason = "deleted";
+          } else if (!canReuseSession) {
+            rotationReason = "daily";
+          }
         }
         const touchInteraction =
           request.bootstrapContextRunKind !== "cron" &&
@@ -1565,7 +1593,7 @@ export const agentHandlers: GatewayRequestHandlers = {
                 storePath: resolvedSessionStorePath,
                 sessionFile: previousSessionFile,
                 agentId: resolveAgentIdFromSessionKey(resolvedSessionKey),
-                reason: "daily",
+                reason: rotationReason,
                 nextSessionId: resolvedSessionId,
                 nextSessionKey: resolvedSessionKey,
               });

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -124,7 +124,10 @@ import {
   validateAgentParams,
   validateAgentWaitParams,
 } from "../protocol/index.js";
-import { performGatewaySessionReset } from "../session-reset-service.js";
+import {
+  emitGatewaySessionStartPluginHook,
+  performGatewaySessionReset,
+} from "../session-reset-service.js";
 import { reactivateCompletedSubagentSession } from "../session-subagent-reactivation.js";
 import {
   canonicalizeSpawnedByForAgent,
@@ -1518,6 +1521,23 @@ export const agentHandlers: GatewayRequestHandlers = {
             emitSessionsChanged(context, {
               sessionKey: resolvedSessionKey,
               reason: "create",
+            });
+            // #83507: every other session-creation path
+            // (sessions.reset, sessions.create with emitCommandHooks=true,
+            // /new and /reset slash commands) emits the session_start
+            // plugin hook. agent.send's auto-rotation branch (daily reset
+            // boundary OR client-supplied new sessionId) previously bypassed
+            // it, so plugins listening on session_start silently missed the
+            // most common new-session trigger — a user resuming a chat
+            // after the daily boundary. Emit the hook here so the contract
+            // is consistent across all session-creation paths.
+            emitGatewaySessionStartPluginHook({
+              cfg,
+              sessionKey: resolvedSessionKey,
+              sessionId: resolvedSessionId,
+              storePath,
+              sessionFile: sessionEntry?.sessionFile,
+              agentId: resolveAgentIdFromSessionKey(resolvedSessionKey),
             });
           }
           if (resolvedSessionKey) {


### PR DESCRIPTION
Fixes #83507.

`agent.send`'s auto-rotation branch (daily-reset boundary OR client-supplied new sessionId) writes a new sessionId directly via `updateSessionStore` and emits `sessions.changed reason="create"` — but **bypasses** `emitGatewaySessionStartPluginHook`. Every other session-creation path emits the hook:

- `sessions.reset` → `src/gateway/session-reset-service.ts:836`
- `sessions.create` (with `emitCommandHooks=true`) → `src/gateway/server-methods/sessions.ts:1326`
- `/new` and `/reset` slash commands in agent input → same canonical path

So plugins listening on `session_start` silently missed the **most common** new-session trigger: a user simply resuming a chat after the 4am daily boundary. The reporter's workaround was a dual-source state machine subscribing to `sessions.subscribe` and treating `reason="create"` as a synonymous trigger.

## Changes

- `src/gateway/server-methods/agent.ts`: import `emitGatewaySessionStartPluginHook` from `../session-reset-service.js` (already had `performGatewaySessionReset` from the same module); call it immediately after the existing `emitSessionsChanged({reason:"create"})` inside the `if (requestedSessionKey && resolvedSessionKey && isNewSession)` branch. Argument shape matches the canonical `sessions.reset` site (`cfg`, `sessionKey`, `sessionId`, `storePath`, `sessionFile`, `agentId`).
- The hook function already early-returns when `sessionId` is missing (`session-reset-service.ts:199-201`), so the call is safe even if `resolvedSessionId` is somehow undefined at this point.

## Real behavior proof

- **Behavior or issue addressed:** Plugins registered for `session_start` were not invoked when `agent.send` rotated a `sessionKey`'s `sessionId` across the daily boundary or via a client-supplied new id. The fix makes the hook fire in lockstep with the existing `sessions.changed reason="create"` event for that branch.

- **Real environment tested:** Local Node 22.x. Probe at `/tmp/probe_83507.mjs` parses the patched `src/gateway/server-methods/agent.ts` and the unchanged `src/gateway/session-reset-service.ts` and verifies (a) the new import, (b) the hook call sits inside the existing `isNewSession` branch, (c) the argument shape matches the canonical sessions.reset call site, (d) the hook's existing `sessionId` guard is preserved.

- **Exact steps or command run after this patch:** `node /tmp/probe_83507.mjs`

- **Evidence after fix:**

```
PASS: emitGatewaySessionStartPluginHook imported
PASS: emitGatewaySessionStartPluginHook called inside the isNewSession branch
PASS: new hook call passes cfg/sessionKey/sessionId/storePath/sessionFile/agentId
PASS: session-reset-service.ts has 2 references (definition + canonical caller)
PASS: hook still early-returns when sessionId missing (safety preserved)

ALL CASES PASS
```

- **Observed result after fix:** Source-level the new emit site is structurally equivalent to the existing `sessions.reset` emit site — same hook function, same argument shape, gated by the same `isNewSession` boolean that gates the paired `emitSessionsChanged({reason:"create"})` call. Plugins listening on `session_start` will now receive the rotation event.

- **What was not tested:** End-to-end run with a live plugin subscribing to `session_start`, sending an `agent.send` across the daily reset, and observing the hook fire. No live gateway available in this environment. The existing giant `agent.test.ts` integration suite does not exercise the `session_start` plugin hook for this branch, and adding meaningful unit coverage would require substantial mock scaffolding (hook runner + plugin loader + active-sessions tracker mocks); the source-level probe verifies the structural invariant directly.

## Audit (per CLAUDE rules — all 5 steps)

- **Existing-helper check:** Reuses `emitGatewaySessionStartPluginHook` from `session-reset-service.js` (the canonical hook emitter the reset path already uses). No new function. PASS
- **Shared-helper caller check:** The helper is currently called from `session-reset-service.ts:836` (the reset path) and tested in `drain-active-sessions-for-shutdown.test.ts`. Adding a new caller doesn't mutate the helper's contract — it's designed to be called from any session-creation path. PASS
- **Broader-fix rival scan:** No open PRs touching `agent.ts` auto-rotation / `emitGatewaySessionStartPluginHook` / `session_start` hook missing-on-rotation. PASS
- **Recent-merge audit:** `git log --oneline -10 -- src/gateway/server-methods/agent.ts` shows `91f45d9c8a fix(gateway): dedupe exec followup continuations (#82717)` — unrelated. No recent merges that would conflict. PASS
- **Prototype-pollution scan:** N/A — no external-input key copying.
