### PR TITLE
fix(install): only invoke install_homebrew when Node.js needs to be installed

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2818,12 +2818,11 @@ main() {
 
     ui_stage "Preparing environment"
 
-    # Step 1: Homebrew (macOS only)
-    install_homebrew
-
     # Step 2: Node.js
     load_nvm_for_node_detection
     if ! check_node; then
+        # Step 1: Homebrew (macOS only) — only needed to bootstrap node@${NODE_DEFAULT_MAJOR}
+        install_homebrew
         install_node
     fi
     activate_supported_node_on_path || true

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -116,6 +116,18 @@ describe("install.sh", () => {
     expect(output).toContain("version=v22.22.1");
   });
 
+  it("only invokes install_homebrew when Node.js needs to be installed", () => {
+    // Regression for #83232: non-admin macOS accounts with adequate Node already
+    // on PATH were blocked by an unconditional Homebrew bootstrap. Homebrew is
+    // only required to `brew install node@...`, so it must be gated by check_node.
+    expect(script).toMatch(
+      /if ! check_node; then\s+#\s*Step 1: Homebrew[^\n]*\s+install_homebrew\s+install_node\s+fi/,
+    );
+    expect(script).not.toMatch(
+      /ui_stage "Preparing environment"\s+#\s*Step 1: Homebrew[^\n]*\s+install_homebrew\s+#\s*Step 2: Node/,
+    );
+  });
+
   it("promotes a supported Linux Node binary over stale PATH entries", () => {
     const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-node-promote-"));
     const staleBin = join(tmp, "usr-local-bin");


### PR DESCRIPTION
## Summary

`scripts/install.sh` called `install_homebrew` unconditionally in the "Preparing environment" stage before any Node detection ran. On a non-admin macOS account with adequate Node already on PATH, the installer hit `print_homebrew_admin_fix` and aborted with `exit 1`, never reaching `check_node`. Brew is only required downstream to `brew install node@${NODE_DEFAULT_MAJOR}` when Node is missing or outdated, so gate `install_homebrew` on the same `if ! check_node; then` branch that triggers `install_node`.

Fixes #83232.

## Changes

- `scripts/install.sh`: move `install_homebrew` (and its `# Step 1: Homebrew` comment) into the `if ! check_node; then` block, immediately before `install_node`. The existing `# Step 2: Node.js` / `load_nvm_for_node_detection` / `if ! check_node; then` sequence is preserved, so the `nvm-before-check_node` assertion at `test/scripts/install-sh.test.ts:55` continues to pass.
- `test/scripts/install-sh.test.ts`: add a regression assertion that `install_homebrew` lives inside the `check_node` failure branch and is no longer emitted unconditionally before `# Step 2: Node`.

## Real behavior proof

Behavior addressed: Non-admin macOS account with adequate Node already on PATH was blocked by `install_homebrew` → `print_homebrew_admin_fix` → `exit 1`, never reaching `check_node`. Repro path: steps 1-4 of #83232.

Real environment tested: Static structural verification against `scripts/install.sh` and `test/scripts/install-sh.test.ts` on macOS arm64 at `origin/main`. Behavioral repro on a real non-admin macOS account was not run; see What was not tested.

Exact steps or command run after this patch:

```
bash -n scripts/install.sh
git diff scripts/install.sh
```

Plus manual evaluation of the new `expect(script).toMatch(...)` / `not.toMatch(...)` assertions against the patched file contents.

Evidence after fix:

- `bash -n scripts/install.sh` exits 0 (no syntax errors).
- New positive regex `/if ! check_node; then\s+#\s*Step 1: Homebrew[^\n]*\s+install_homebrew\s+install_node\s+fi/` matches patched `main()`.
- New negative regex `/ui_stage "Preparing environment"\s+#\s*Step 1: Homebrew[^\n]*\s+install_homebrew\s+#\s*Step 2: Node/` does not match (unconditional pre-`check_node` call is gone).
- Existing assertion at `test/scripts/install-sh.test.ts:55` still matches.

Observed result after fix: When `check_node` succeeds, neither `install_homebrew` nor `install_node` is invoked, so a missing/inaccessible Homebrew on a non-admin macOS account no longer aborts the installer. When `check_node` fails, behavior is identical to before: `install_homebrew` runs first, then `install_node`.

What was not tested:

- The behavior was not exercised on a real macOS account without admin rights or in `scripts/docker/install-sh-nonroot/` (current Docker scenario is Ubuntu-based; the repo has no macOS non-admin sandbox).
- `pnpm test test/scripts/install-sh.test.ts` was not run locally on the contributor machine; the new assertion is a static `match` / `not.match` over the script text and is verifiable by inspection — CI is expected to cover it.
- `install_git()` on macOS (`scripts/install.sh:1721`) still calls `brew install git` unconditionally. A non-admin macOS user without Git who reaches the npm install path will now fail at `install_git` rather than at the wrong step, but the underlying "bootstrap brew on demand" gap remains. Scope kept tight to the reported issue; happy to fold a follow-up into the same PR if reviewers prefer.