### PR TITLE
fix(codex): expose plugin tools in native conversation binding

### DIFF
--- a/extensions/codex/index.ts
+++ b/extensions/codex/index.ts
@@ -59,6 +59,7 @@ export default definePluginEntry({
     api.on("inbound_claim", (event, ctx) =>
       handleCodexConversationInboundClaim(event, ctx, {
         pluginConfig: resolveCurrentPluginConfig(),
+        config: api.runtime.config?.current?.() as OpenClawConfig | undefined,
         resumeCodexCliSessionOnNode: (params) =>
           resumeCodexCliSessionOnNode({ runtime: api.runtime, ...params }),
       }),

--- a/extensions/codex/src/app-server/dynamic-tool-timeout.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-timeout.ts
@@ -1,0 +1,234 @@
+import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import type { CodexDynamicToolBridge } from "./dynamic-tools.js";
+import {
+  isJsonObject,
+  type CodexDynamicToolCallParams,
+  type CodexDynamicToolCallResponse,
+  type JsonValue,
+} from "./protocol.js";
+
+const CODEX_DYNAMIC_TOOL_TIMEOUT_MS = 30_000;
+const CODEX_DYNAMIC_TOOL_MAX_TIMEOUT_MS = 600_000;
+const CODEX_DYNAMIC_IMAGE_TOOL_TIMEOUT_MS = 60_000;
+const LOG_FIELD_MAX_LENGTH = 160;
+
+export {
+  CODEX_DYNAMIC_TOOL_TIMEOUT_MS,
+  CODEX_DYNAMIC_TOOL_MAX_TIMEOUT_MS,
+  CODEX_DYNAMIC_IMAGE_TOOL_TIMEOUT_MS,
+};
+
+export type CodexDynamicToolTimeoutConfig = OpenClawConfig | undefined;
+
+type DynamicToolTimeoutDetails = {
+  responseMessage: string;
+  consoleMessage: string;
+  meta: Record<string, unknown>;
+};
+
+function normalizeLogField(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value
+    .replaceAll(String.fromCharCode(27), " ")
+    .replaceAll("\r", " ")
+    .replaceAll("\n", " ")
+    .replaceAll("\t", " ")
+    .trim();
+  if (!normalized) {
+    return undefined;
+  }
+  return normalized.length > LOG_FIELD_MAX_LENGTH
+    ? `${normalized.slice(0, LOG_FIELD_MAX_LENGTH - 3)}...`
+    : normalized;
+}
+
+function readNumericTimeoutMs(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.max(0, Math.floor(value));
+  }
+  if (typeof value === "string") {
+    const parsed = Number.parseInt(value.trim(), 10);
+    if (Number.isFinite(parsed)) {
+      return Math.max(0, Math.floor(parsed));
+    }
+  }
+  return undefined;
+}
+
+function formatDynamicToolTimeoutDetails(params: {
+  call: CodexDynamicToolCallParams;
+  timeoutMs: number;
+}): DynamicToolTimeoutDetails {
+  const tool = normalizeLogField(params.call.tool) ?? "unknown";
+  const baseMeta: Record<string, unknown> = {
+    tool: params.call.tool,
+    toolCallId: params.call.callId,
+    threadId: params.call.threadId,
+    turnId: params.call.turnId,
+    timeoutMs: params.timeoutMs,
+    timeoutKind: "codex_dynamic_tool_rpc",
+  };
+
+  if (tool !== "process" || !isJsonObject(params.call.arguments)) {
+    return {
+      responseMessage: `OpenClaw dynamic tool call timed out after ${params.timeoutMs}ms while running tool ${tool}.`,
+      consoleMessage: `codex dynamic tool timeout: tool=${tool} toolTimeoutMs=${params.timeoutMs}; per-tool-call watchdog, not session idle`,
+      meta: baseMeta,
+    };
+  }
+
+  const action = normalizeLogField(params.call.arguments.action);
+  const sessionId = normalizeLogField(params.call.arguments.sessionId);
+  const requestedTimeoutMs = readNumericTimeoutMs(params.call.arguments.timeout);
+  const actionPart = action ? ` action=${action}` : "";
+  const sessionPart = sessionId ? ` sessionId=${sessionId}` : "";
+  const requestedPart =
+    requestedTimeoutMs === undefined ? "" : ` requestedWaitMs=${requestedTimeoutMs}`;
+  const retryHint =
+    action === "poll"
+      ? "; repeated lines usually mean process-poll retry churn, not model progress"
+      : "";
+  const responseTarget =
+    action || sessionId
+      ? ` while waiting for process${actionPart}${sessionPart}`
+      : " while waiting for the process tool";
+
+  return {
+    responseMessage: `OpenClaw dynamic tool call timed out after ${params.timeoutMs}ms${responseTarget}. This is a tool RPC timeout, not a session idle timeout.`,
+    consoleMessage: `codex process tool timeout:${actionPart}${sessionPart} toolTimeoutMs=${params.timeoutMs}${requestedPart}; per-tool-call watchdog, not session idle${retryHint}`,
+    meta: {
+      ...baseMeta,
+      processAction: action,
+      processSessionId: sessionId,
+      processRequestedTimeoutMs: requestedTimeoutMs,
+    },
+  };
+}
+
+export function failedDynamicToolResponse(message: string): CodexDynamicToolCallResponse {
+  return {
+    success: false,
+    contentItems: [{ type: "inputText", text: message }],
+  };
+}
+
+export async function handleDynamicToolCallWithTimeout(params: {
+  call: CodexDynamicToolCallParams;
+  toolBridge: Pick<CodexDynamicToolBridge, "handleToolCall">;
+  signal: AbortSignal;
+  timeoutMs: number;
+  onTimeout?: () => void;
+}): Promise<CodexDynamicToolCallResponse> {
+  if (params.signal.aborted) {
+    return failedDynamicToolResponse("OpenClaw dynamic tool call aborted before execution.");
+  }
+
+  const controller = new AbortController();
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  let timedOut = false;
+  let resolveAbort: ((response: CodexDynamicToolCallResponse) => void) | undefined;
+  const abortFromRun = () => {
+    const message = "OpenClaw dynamic tool call aborted.";
+    controller.abort(params.signal.reason ?? new Error(message));
+    resolveAbort?.(failedDynamicToolResponse(message));
+  };
+  const abortPromise = new Promise<CodexDynamicToolCallResponse>((resolve) => {
+    resolveAbort = resolve;
+  });
+  const timeoutPromise = new Promise<CodexDynamicToolCallResponse>((resolve) => {
+    const timeoutMs = clampDynamicToolTimeoutMs(params.timeoutMs);
+    timeout = setTimeout(() => {
+      timedOut = true;
+      const timeoutDetails = formatDynamicToolTimeoutDetails({ call: params.call, timeoutMs });
+      controller.abort(new Error(timeoutDetails.responseMessage));
+      params.onTimeout?.();
+      embeddedAgentLog.warn("codex dynamic tool call timed out", {
+        ...timeoutDetails.meta,
+        consoleMessage: timeoutDetails.consoleMessage,
+      });
+      resolve(failedDynamicToolResponse(timeoutDetails.responseMessage));
+    }, timeoutMs);
+    timeout.unref?.();
+  });
+
+  try {
+    params.signal.addEventListener("abort", abortFromRun, { once: true });
+    if (params.signal.aborted) {
+      abortFromRun();
+    }
+    return await Promise.race([
+      params.toolBridge.handleToolCall(params.call, { signal: controller.signal }),
+      abortPromise,
+      timeoutPromise,
+    ]);
+  } catch (error) {
+    return failedDynamicToolResponse(error instanceof Error ? error.message : String(error));
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+    params.signal.removeEventListener("abort", abortFromRun);
+    resolveAbort = undefined;
+    if (!timedOut && !controller.signal.aborted) {
+      controller.abort(new Error("OpenClaw dynamic tool call finished."));
+    }
+  }
+}
+
+export function resolveDynamicToolCallTimeoutMs(params: {
+  call: CodexDynamicToolCallParams;
+  config: CodexDynamicToolTimeoutConfig;
+}): number {
+  return clampDynamicToolTimeoutMs(
+    readDynamicToolCallTimeoutMs(params.call.arguments) ??
+      readConfiguredDynamicToolTimeoutMs(params.call.tool, params.config) ??
+      CODEX_DYNAMIC_TOOL_TIMEOUT_MS,
+  );
+}
+
+function readDynamicToolCallTimeoutMs(value: JsonValue | undefined): number | undefined {
+  if (!isJsonObject(value)) {
+    return undefined;
+  }
+  return readPositiveFiniteTimeoutMs(value.timeoutMs);
+}
+
+function readConfiguredDynamicToolTimeoutMs(
+  toolName: string,
+  config: CodexDynamicToolTimeoutConfig,
+): number | undefined {
+  if (toolName === "image_generate") {
+    const imageGenerationModel = config?.agents?.defaults?.imageGenerationModel;
+    if (!imageGenerationModel || typeof imageGenerationModel !== "object") {
+      return undefined;
+    }
+    return readPositiveFiniteTimeoutMs(imageGenerationModel.timeoutMs);
+  }
+
+  if (toolName === "image") {
+    return (
+      readTimeoutSecondsAsMs(config?.tools?.media?.image?.timeoutSeconds) ??
+      CODEX_DYNAMIC_IMAGE_TOOL_TIMEOUT_MS
+    );
+  }
+
+  return undefined;
+}
+
+function readTimeoutSecondsAsMs(value: unknown): number | undefined {
+  const seconds = readPositiveFiniteTimeoutMs(value);
+  return seconds === undefined ? undefined : seconds * 1000;
+}
+
+function readPositiveFiniteTimeoutMs(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? Math.floor(value)
+    : undefined;
+}
+
+function clampDynamicToolTimeoutMs(timeoutMs: number): number {
+  return Math.max(1, Math.min(CODEX_DYNAMIC_TOOL_MAX_TIMEOUT_MS, Math.floor(timeoutMs)));
+}

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -99,7 +99,14 @@ import {
   normalizeCodexDynamicToolName,
   resolveCodexDynamicToolsLoading,
 } from "./dynamic-tool-profile.js";
-import { createCodexDynamicToolBridge, type CodexDynamicToolBridge } from "./dynamic-tools.js";
+import {
+  CODEX_DYNAMIC_IMAGE_TOOL_TIMEOUT_MS,
+  CODEX_DYNAMIC_TOOL_MAX_TIMEOUT_MS,
+  CODEX_DYNAMIC_TOOL_TIMEOUT_MS,
+  handleDynamicToolCallWithTimeout,
+  resolveDynamicToolCallTimeoutMs,
+} from "./dynamic-tool-timeout.js";
+import { createCodexDynamicToolBridge } from "./dynamic-tools.js";
 import { handleCodexAppServerElicitationRequest } from "./elicitation-bridge.js";
 import {
   CodexAppServerEventProjector,
@@ -177,9 +184,6 @@ import {
 import { createCodexUserInputBridge } from "./user-input-bridge.js";
 import { filterToolsForVisionInputs } from "./vision-tools.js";
 
-const CODEX_DYNAMIC_TOOL_TIMEOUT_MS = 30_000;
-const CODEX_DYNAMIC_TOOL_MAX_TIMEOUT_MS = 600_000;
-const CODEX_DYNAMIC_IMAGE_TOOL_TIMEOUT_MS = 60_000;
 const CODEX_APP_SERVER_STARTUP_CONNECTION_CLOSE_MAX_ATTEMPTS = 3;
 const CODEX_APP_SERVER_STARTUP_TIMEOUT_FLOOR_MS = 100;
 const CODEX_APP_SERVER_INTERRUPT_TIMEOUT_MS = 5_000;
@@ -191,7 +195,6 @@ const CODEX_NATIVE_HOOK_RELAY_MIN_TTL_MS = 30 * 60_000;
 const CODEX_NATIVE_HOOK_RELAY_TTL_GRACE_MS = 5 * 60_000;
 const CODEX_NATIVE_HOOK_RELAY_RENEW_INTERVAL_MS = 60_000;
 const CODEX_STEER_ALL_DEBOUNCE_MS = 500;
-const LOG_FIELD_MAX_LENGTH = 160;
 const CODEX_NATIVE_PROJECT_DOC_BASENAMES = new Set(["agents.md"]);
 const CODEX_NATIVE_HOOK_RELAY_EVENTS_WITH_APP_SERVER_APPROVALS =
   CODEX_NATIVE_HOOK_RELAY_EVENTS.filter((event) => event !== "permission_request");
@@ -252,93 +255,6 @@ function collectTerminalAssistantText(result: EmbeddedRunAttemptResult): string 
 type CodexSteeringQueueOptions = {
   debounceMs?: number;
 };
-
-type DynamicToolTimeoutDetails = {
-  responseMessage: string;
-  consoleMessage: string;
-  meta: Record<string, unknown>;
-};
-
-function normalizeLogField(value: unknown): string | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const normalized = value
-    .replaceAll(String.fromCharCode(27), " ")
-    .replaceAll("\r", " ")
-    .replaceAll("\n", " ")
-    .replaceAll("\t", " ")
-    .trim();
-  if (!normalized) {
-    return undefined;
-  }
-  return normalized.length > LOG_FIELD_MAX_LENGTH
-    ? `${normalized.slice(0, LOG_FIELD_MAX_LENGTH - 3)}...`
-    : normalized;
-}
-
-function readNumericTimeoutMs(value: unknown): number | undefined {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return Math.max(0, Math.floor(value));
-  }
-  if (typeof value === "string") {
-    const parsed = Number.parseInt(value.trim(), 10);
-    if (Number.isFinite(parsed)) {
-      return Math.max(0, Math.floor(parsed));
-    }
-  }
-  return undefined;
-}
-
-function formatDynamicToolTimeoutDetails(params: {
-  call: CodexDynamicToolCallParams;
-  timeoutMs: number;
-}): DynamicToolTimeoutDetails {
-  const tool = normalizeLogField(params.call.tool) ?? "unknown";
-  const baseMeta: Record<string, unknown> = {
-    tool: params.call.tool,
-    toolCallId: params.call.callId,
-    threadId: params.call.threadId,
-    turnId: params.call.turnId,
-    timeoutMs: params.timeoutMs,
-    timeoutKind: "codex_dynamic_tool_rpc",
-  };
-
-  if (tool !== "process" || !isJsonObject(params.call.arguments)) {
-    return {
-      responseMessage: `OpenClaw dynamic tool call timed out after ${params.timeoutMs}ms while running tool ${tool}.`,
-      consoleMessage: `codex dynamic tool timeout: tool=${tool} toolTimeoutMs=${params.timeoutMs}; per-tool-call watchdog, not session idle`,
-      meta: baseMeta,
-    };
-  }
-
-  const action = normalizeLogField(params.call.arguments.action);
-  const sessionId = normalizeLogField(params.call.arguments.sessionId);
-  const requestedTimeoutMs = readNumericTimeoutMs(params.call.arguments.timeout);
-  const actionPart = action ? ` action=${action}` : "";
-  const sessionPart = sessionId ? ` sessionId=${sessionId}` : "";
-  const requestedPart =
-    requestedTimeoutMs === undefined ? "" : ` requestedWaitMs=${requestedTimeoutMs}`;
-  const retryHint =
-    action === "poll"
-      ? "; repeated lines usually mean process-poll retry churn, not model progress"
-      : "";
-  const responseTarget =
-    action || sessionId
-      ? ` while waiting for process${actionPart}${sessionPart}`
-      : " while waiting for the process tool";
-
-  return {
-    responseMessage: `OpenClaw dynamic tool call timed out after ${params.timeoutMs}ms${responseTarget}. This is a tool RPC timeout, not a session idle timeout.`,
-    consoleMessage: `codex process tool timeout:${actionPart}${sessionPart} toolTimeoutMs=${params.timeoutMs}${requestedPart}; per-tool-call watchdog, not session idle${retryHint}`,
-    meta: {
-      ...baseMeta,
-      processAction: action,
-      processSessionId: sessionId,
-      processRequestedTimeoutMs: requestedTimeoutMs,
-    },
-  };
-}
 
 function createCodexSteeringQueue(params: {
   client: CodexAppServerClient;
@@ -2833,82 +2749,6 @@ function buildCodexTurnStartFailureResult(params: {
   };
 }
 
-async function handleDynamicToolCallWithTimeout(params: {
-  call: CodexDynamicToolCallParams;
-  toolBridge: Pick<CodexDynamicToolBridge, "handleToolCall">;
-  signal: AbortSignal;
-  timeoutMs: number;
-  onTimeout?: () => void;
-}): Promise<CodexDynamicToolCallResponse> {
-  if (params.signal.aborted) {
-    return failedDynamicToolResponse("OpenClaw dynamic tool call aborted before execution.");
-  }
-
-  const controller = new AbortController();
-  let timeout: ReturnType<typeof setTimeout> | undefined;
-  let timedOut = false;
-  let resolveAbort: ((response: CodexDynamicToolCallResponse) => void) | undefined;
-  const abortFromRun = () => {
-    const message = "OpenClaw dynamic tool call aborted.";
-    controller.abort(params.signal.reason ?? new Error(message));
-    resolveAbort?.(failedDynamicToolResponse(message));
-  };
-  const abortPromise = new Promise<CodexDynamicToolCallResponse>((resolve) => {
-    resolveAbort = resolve;
-  });
-  const timeoutPromise = new Promise<CodexDynamicToolCallResponse>((resolve) => {
-    const timeoutMs = clampDynamicToolTimeoutMs(params.timeoutMs);
-    timeout = setTimeout(() => {
-      timedOut = true;
-      const timeoutDetails = formatDynamicToolTimeoutDetails({ call: params.call, timeoutMs });
-      controller.abort(new Error(timeoutDetails.responseMessage));
-      params.onTimeout?.();
-      embeddedAgentLog.warn("codex dynamic tool call timed out", {
-        ...timeoutDetails.meta,
-        consoleMessage: timeoutDetails.consoleMessage,
-      });
-      resolve(failedDynamicToolResponse(timeoutDetails.responseMessage));
-    }, timeoutMs);
-    timeout.unref?.();
-  });
-
-  try {
-    params.signal.addEventListener("abort", abortFromRun, { once: true });
-    if (params.signal.aborted) {
-      abortFromRun();
-    }
-    return await Promise.race([
-      params.toolBridge.handleToolCall(params.call, { signal: controller.signal }),
-      abortPromise,
-      timeoutPromise,
-    ]);
-  } catch (error) {
-    return failedDynamicToolResponse(error instanceof Error ? error.message : String(error));
-  } finally {
-    if (timeout) {
-      clearTimeout(timeout);
-    }
-    params.signal.removeEventListener("abort", abortFromRun);
-    resolveAbort = undefined;
-    if (!timedOut && !controller.signal.aborted) {
-      controller.abort(new Error("OpenClaw dynamic tool call finished."));
-    }
-  }
-}
-
-function failedDynamicToolResponse(message: string): CodexDynamicToolCallResponse {
-  const response: CodexDynamicToolCallResponse = {
-    contentItems: [{ type: "inputText", text: message }],
-    success: false,
-  };
-  Object.defineProperty(response, "diagnosticTerminalType", {
-    configurable: true,
-    enumerable: false,
-    value: "error",
-  });
-  return response;
-}
-
 function toCodexDynamicToolProtocolResponse(
   response: CodexDynamicToolCallResponse,
 ): CodexDynamicToolCallResponse {
@@ -2964,61 +2804,6 @@ function isMatchingDynamicToolTerminalDiagnostic(params: {
     params.event.sessionId === undefined &&
     params.event.sessionKey === undefined
   );
-}
-
-function resolveDynamicToolCallTimeoutMs(params: {
-  call: CodexDynamicToolCallParams;
-  config: EmbeddedRunAttemptParams["config"];
-}): number {
-  return clampDynamicToolTimeoutMs(
-    readDynamicToolCallTimeoutMs(params.call.arguments) ??
-      readConfiguredDynamicToolTimeoutMs(params.call.tool, params.config) ??
-      CODEX_DYNAMIC_TOOL_TIMEOUT_MS,
-  );
-}
-
-function readDynamicToolCallTimeoutMs(value: JsonValue | undefined): number | undefined {
-  if (!isJsonObject(value)) {
-    return undefined;
-  }
-  return readPositiveFiniteTimeoutMs(value.timeoutMs);
-}
-
-function readConfiguredDynamicToolTimeoutMs(
-  toolName: string,
-  config: EmbeddedRunAttemptParams["config"],
-): number | undefined {
-  if (toolName === "image_generate") {
-    const imageGenerationModel = config?.agents?.defaults?.imageGenerationModel;
-    if (!imageGenerationModel || typeof imageGenerationModel !== "object") {
-      return undefined;
-    }
-    return readPositiveFiniteTimeoutMs(imageGenerationModel.timeoutMs);
-  }
-
-  if (toolName === "image") {
-    return (
-      readTimeoutSecondsAsMs(config?.tools?.media?.image?.timeoutSeconds) ??
-      CODEX_DYNAMIC_IMAGE_TOOL_TIMEOUT_MS
-    );
-  }
-
-  return undefined;
-}
-
-function readTimeoutSecondsAsMs(value: unknown): number | undefined {
-  const seconds = readPositiveFiniteTimeoutMs(value);
-  return seconds === undefined ? undefined : seconds * 1000;
-}
-
-function readPositiveFiniteTimeoutMs(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) && value > 0
-    ? Math.floor(value)
-    : undefined;
-}
-
-function clampDynamicToolTimeoutMs(timeoutMs: number): number {
-  return Math.max(1, Math.min(CODEX_DYNAMIC_TOOL_MAX_TIMEOUT_MS, Math.floor(timeoutMs)));
 }
 
 function createCodexNativeHookRelay(params: {

--- a/extensions/codex/src/app-server/session-binding.ts
+++ b/extensions/codex/src/app-server/session-binding.ts
@@ -40,6 +40,7 @@ export type CodexAppServerThreadBinding = {
   sandbox?: CodexAppServerSandboxMode;
   serviceTier?: CodexServiceTier;
   dynamicToolsFingerprint?: string;
+  threadBindingOrigin?: "explicit" | "managed";
   userMcpServersFingerprint?: string;
   mcpServersFingerprint?: string;
   pluginAppsFingerprint?: string;
@@ -109,6 +110,10 @@ export async function readCodexAppServerBinding(
         typeof parsed.dynamicToolsFingerprint === "string"
           ? parsed.dynamicToolsFingerprint
           : undefined,
+      threadBindingOrigin:
+        parsed.threadBindingOrigin === "explicit" || parsed.threadBindingOrigin === "managed"
+          ? parsed.threadBindingOrigin
+          : undefined,
       userMcpServersFingerprint:
         typeof parsed.userMcpServersFingerprint === "string"
           ? parsed.userMcpServersFingerprint
@@ -159,6 +164,7 @@ export async function writeCodexAppServerBinding(
     sandbox: binding.sandbox,
     serviceTier: binding.serviceTier,
     dynamicToolsFingerprint: binding.dynamicToolsFingerprint,
+    threadBindingOrigin: binding.threadBindingOrigin,
     userMcpServersFingerprint: binding.userMcpServersFingerprint,
     mcpServersFingerprint: binding.mcpServersFingerprint,
     pluginAppsFingerprint: binding.pluginAppsFingerprint,

--- a/extensions/codex/src/command-handlers.ts
+++ b/extensions/codex/src/command-handlers.ts
@@ -594,6 +594,7 @@ async function resumeThread(
     cwd: readString(thread, "cwd") ?? "",
     model: isJsonObject(response) ? readString(response, "model") : undefined,
     modelProvider: isJsonObject(response) ? readString(response, "modelProvider") : undefined,
+    threadBindingOrigin: "explicit",
   });
   return `Attached this OpenClaw session to Codex thread ${formatCodexDisplayText(
     effectiveThreadId,

--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -402,6 +402,7 @@ describe("codex conversation binding", () => {
         schemaVersion: 1,
         threadId: "thread-old",
         cwd: tempDir,
+        dynamicToolsFingerprint: "[]",
       }),
     );
     const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
@@ -494,6 +495,14 @@ describe("codex conversation binding", () => {
 
     expect(result).toEqual({ handled: true, reply: { text: "done" } });
     expect(requests.map((request) => request.method)).toEqual(["thread/start", "turn/start"]);
+    const toolFactoryOptions = mockCallArg(agentHarnessMocks.createOpenClawCodingTools) as {
+      currentChannelId?: unknown;
+      messageTo?: unknown;
+      sessionId?: unknown;
+    };
+    expect(toolFactoryOptions.currentChannelId).toBe("5185575566");
+    expect(toolFactoryOptions.messageTo).toBe("5185575566");
+    expect(toolFactoryOptions.sessionId).toBe("5185575566");
     expect(execute).toHaveBeenCalledWith(
       "call-1",
       { text: "hello" },
@@ -504,6 +513,89 @@ describe("codex conversation binding", () => {
       contentItems: [{ type: "inputText", text: "echo:hello" }],
       success: true,
     });
+  });
+
+  it("preserves older native bound Codex threads without dynamic tool fingerprints", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    agentHarnessMocks.createOpenClawCodingTools.mockReturnValue([createEchoTool()] as never);
+    await fs.writeFile(
+      sessionFile + ".codex-app-server.json",
+      JSON.stringify({
+        schemaVersion: 1,
+        threadId: "thread-old",
+        cwd: tempDir,
+      }),
+    );
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    let notificationHandler: ((notification: unknown) => void) | undefined;
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
+      request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
+        requests.push({ method, params: requestParams });
+        if (method === "turn/start") {
+          setImmediate(() => {
+            notificationHandler?.({
+              method: "turn/completed",
+              params: {
+                threadId: "thread-old",
+                turn: {
+                  id: "turn-1",
+                  status: "completed",
+                  items: [{ type: "agentMessage", id: "item-1", text: "still here" }],
+                },
+              },
+            });
+          });
+          return { turn: { id: "turn-1" } };
+        }
+        throw new Error(`unexpected method: ${method}`);
+      }),
+      addNotificationHandler: vi.fn((handler: (notification: unknown) => void) => {
+        notificationHandler = handler;
+        return () => undefined;
+      }),
+      addRequestHandler: vi.fn(() => () => undefined),
+    });
+
+    const result = await handleCodexConversationInboundClaim(
+      {
+        content: "continue",
+        bodyForAgent: "continue",
+        channel: "telegram",
+        isGroup: false,
+        commandAuthorized: true,
+        conversationId: "5185575566",
+      },
+      {
+        channelId: "telegram",
+        conversationId: "5185575566",
+        sessionKey: "telegram:direct:5185575566",
+        pluginBinding: {
+          bindingId: "binding-1",
+          pluginId: "codex",
+          pluginRoot: tempDir,
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "5185575566",
+          boundAt: Date.now(),
+          data: {
+            kind: "codex-app-server-session",
+            version: 1,
+            sessionFile,
+            workspaceDir: tempDir,
+          },
+        },
+      },
+      { timeoutMs: 500 },
+    );
+
+    expect(result).toEqual({ handled: true, reply: { text: "still here" } });
+    expect(requests.map((request) => request.method)).toEqual(["turn/start"]);
+    expect(requests[0]?.params.threadId).toBe("thread-old");
+    const savedBinding = JSON.parse(
+      await fs.readFile(sessionFile + ".codex-app-server.json", "utf8"),
+    );
+    expect(savedBinding.threadId).toBe("thread-old");
+    expect(savedBinding).not.toHaveProperty("dynamicToolsFingerprint");
   });
 
   it("recreates a missing bound thread and preserves auth plus turn overrides", async () => {

--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -18,8 +18,13 @@ const agentRuntimeMocks = vi.hoisted(() => ({
   saveAuthProfileStore: vi.fn(),
 }));
 
+const agentHarnessMocks = vi.hoisted(() => ({
+  createOpenClawCodingTools: vi.fn(() => []),
+}));
+
 vi.mock("./app-server/shared-client.js", () => sharedClientMocks);
 vi.mock("openclaw/plugin-sdk/agent-runtime", () => agentRuntimeMocks);
+vi.mock("openclaw/plugin-sdk/agent-harness", () => agentHarnessMocks);
 
 import {
   handleCodexConversationBindingResolved,
@@ -37,6 +42,30 @@ function mockCallArg(mock: ReturnType<typeof vi.fn>, callIndex = 0, argIndex = 0
   return call[argIndex];
 }
 
+function createEchoTool(
+  execute = vi.fn(async (_callId: string, params: unknown) => {
+    const text =
+      params && typeof params === "object" && "text" in params
+        ? String((params as { text?: unknown }).text)
+        : "";
+    return { content: [{ type: "text" as const, text: `echo:${text}` }] };
+  }),
+) {
+  return {
+    name: "test_plugin_echo",
+    description: "Echo test plugin tool",
+    parameters: {
+      type: "object",
+      properties: {
+        text: { type: "string" },
+      },
+      required: ["text"],
+      additionalProperties: false,
+    },
+    execute,
+  };
+}
+
 describe("codex conversation binding", () => {
   beforeEach(async () => {
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-binding-"));
@@ -52,6 +81,8 @@ describe("codex conversation binding", () => {
     agentRuntimeMocks.resolvePersistedAuthProfileOwnerAgentDir.mockReset();
     agentRuntimeMocks.resolveProviderIdForAuth.mockClear();
     agentRuntimeMocks.saveAuthProfileStore.mockReset();
+    agentHarnessMocks.createOpenClawCodingTools.mockReset();
+    agentHarnessMocks.createOpenClawCodingTools.mockReturnValue([]);
     await fs.rm(tempDir, { recursive: true, force: true });
   });
 
@@ -202,6 +233,50 @@ describe("codex conversation binding", () => {
     expect(data.agentDir).toBe(agentDir);
   });
 
+  it("starts native bound Codex threads with OpenClaw plugin dynamic tools", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const pluginTool = createEchoTool();
+    agentHarnessMocks.createOpenClawCodingTools.mockReturnValue([pluginTool] as never);
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
+      request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
+        requests.push({ method, params: requestParams });
+        return {
+          thread: { id: "thread-new", sessionId: "session-1", cwd: tempDir },
+          model: "gpt-5.4-mini",
+        };
+      }),
+    });
+
+    await startCodexConversationThread({
+      sessionFile,
+      workspaceDir: tempDir,
+      model: "gpt-5.4-mini",
+    });
+
+    expect(agentHarnessMocks.createOpenClawCodingTools).toHaveBeenCalledWith(
+      expect.objectContaining({
+        includeCoreTools: false,
+        workspaceDir: tempDir,
+        spawnWorkspaceDir: tempDir,
+      }),
+    );
+    expect(requests[0]?.method).toBe("thread/start");
+    expect(requests[0]?.params.dynamicTools).toEqual([
+      expect.objectContaining({
+        name: "test_plugin_echo",
+        inputSchema: expect.objectContaining({
+          type: "object",
+          required: ["text"],
+        }),
+      }),
+    ]);
+    const savedBinding = JSON.parse(
+      await fs.readFile(sessionFile + ".codex-app-server.json", "utf8"),
+    );
+    expect(savedBinding.dynamicToolsFingerprint).toContain("test_plugin_echo");
+  });
+
   it("clears the Codex app-server sidecar when a pending bind is denied", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const sidecar = `${sessionFile}.codex-app-server.json`;
@@ -304,6 +379,130 @@ describe("codex conversation binding", () => {
       prompt: "continue the task",
       cwd: "/repo",
       timeoutMs: 1234,
+    });
+  });
+
+  it("dispatches native bound Codex dynamic tool calls to OpenClaw plugin handlers", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const execute = vi.fn(async (_callId: string, params: unknown) => ({
+      content: [
+        {
+          type: "text" as const,
+          text:
+            params && typeof params === "object" && "text" in params
+              ? `echo:${String((params as { text?: unknown }).text)}`
+              : "echo:",
+        },
+      ],
+    }));
+    agentHarnessMocks.createOpenClawCodingTools.mockReturnValue([createEchoTool(execute)] as never);
+    await fs.writeFile(
+      sessionFile + ".codex-app-server.json",
+      JSON.stringify({
+        schemaVersion: 1,
+        threadId: "thread-old",
+        cwd: tempDir,
+      }),
+    );
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    let notificationHandler: ((notification: unknown) => void) | undefined;
+    let requestHandler:
+      | ((request: { method: string; params?: unknown }) => Promise<unknown> | unknown)
+      | undefined;
+    let toolResponse: unknown;
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
+      request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
+        requests.push({ method, params: requestParams });
+        if (method === "thread/start") {
+          return {
+            thread: { id: "thread-new", sessionId: "session-1", cwd: tempDir },
+            model: "gpt-5.4-mini",
+          };
+        }
+        if (method === "turn/start") {
+          setImmediate(async () => {
+            toolResponse = await requestHandler?.({
+              method: "item/tool/call",
+              params: {
+                threadId: "thread-new",
+                turnId: "turn-1",
+                callId: "call-1",
+                namespace: null,
+                tool: "test_plugin_echo",
+                arguments: { text: "hello" },
+              },
+            });
+            notificationHandler?.({
+              method: "turn/completed",
+              params: {
+                threadId: "thread-new",
+                turn: {
+                  id: "turn-1",
+                  status: "completed",
+                  items: [{ type: "agentMessage", id: "item-1", text: "done" }],
+                },
+              },
+            });
+          });
+          return { turn: { id: "turn-1" } };
+        }
+        throw new Error(`unexpected method: ${method}`);
+      }),
+      addNotificationHandler: vi.fn((handler: (notification: unknown) => void) => {
+        notificationHandler = handler;
+        return () => undefined;
+      }),
+      addRequestHandler: vi.fn((handler) => {
+        requestHandler = handler;
+        return () => undefined;
+      }),
+    });
+
+    const result = await handleCodexConversationInboundClaim(
+      {
+        content: "call the echo tool",
+        bodyForAgent: "call the echo tool",
+        channel: "telegram",
+        isGroup: false,
+        commandAuthorized: true,
+        conversationId: "5185575566",
+        messageId: "msg-1",
+        senderId: "sender-1",
+      },
+      {
+        channelId: "telegram",
+        conversationId: "5185575566",
+        sessionKey: "telegram:direct:5185575566",
+        pluginBinding: {
+          bindingId: "binding-1",
+          pluginId: "codex",
+          pluginRoot: tempDir,
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "5185575566",
+          boundAt: Date.now(),
+          data: {
+            kind: "codex-app-server-session",
+            version: 1,
+            sessionFile,
+            workspaceDir: tempDir,
+          },
+        },
+      },
+      { timeoutMs: 500 },
+    );
+
+    expect(result).toEqual({ handled: true, reply: { text: "done" } });
+    expect(requests.map((request) => request.method)).toEqual(["thread/start", "turn/start"]);
+    expect(execute).toHaveBeenCalledWith(
+      "call-1",
+      { text: "hello" },
+      expect.any(AbortSignal),
+      undefined,
+    );
+    expect(toolResponse).toEqual({
+      contentItems: [{ type: "inputText", text: "echo:hello" }],
+      success: true,
     });
   });
 

--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -410,6 +410,8 @@ describe("codex conversation binding", () => {
     let requestHandler:
       | ((request: { method: string; params?: unknown }) => Promise<unknown>)
       | undefined;
+    let foreignThreadResponse: unknown;
+    let foreignTurnResponse: unknown;
     let toolResponse: unknown;
     sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
       request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
@@ -422,6 +424,28 @@ describe("codex conversation binding", () => {
         }
         if (method === "turn/start") {
           setImmediate(async () => {
+            foreignThreadResponse = await requestHandler?.({
+              method: "item/tool/call",
+              params: {
+                threadId: "thread-foreign",
+                turnId: "turn-1",
+                callId: "call-foreign-thread",
+                namespace: null,
+                tool: "test_plugin_echo",
+                arguments: { text: "wrong thread" },
+              },
+            });
+            foreignTurnResponse = await requestHandler?.({
+              method: "item/tool/call",
+              params: {
+                threadId: "thread-new",
+                turnId: "turn-foreign",
+                callId: "call-foreign-turn",
+                namespace: null,
+                tool: "test_plugin_echo",
+                arguments: { text: "wrong turn" },
+              },
+            });
             toolResponse = await requestHandler?.({
               method: "item/tool/call",
               params: {
@@ -503,12 +527,15 @@ describe("codex conversation binding", () => {
     expect(toolFactoryOptions.currentChannelId).toBe("5185575566");
     expect(toolFactoryOptions.messageTo).toBe("5185575566");
     expect(toolFactoryOptions.sessionId).toBe("5185575566");
+    expect(foreignThreadResponse).toBeUndefined();
+    expect(foreignTurnResponse).toBeUndefined();
     expect(execute).toHaveBeenCalledWith(
       "call-1",
       { text: "hello" },
       expect.any(AbortSignal),
       undefined,
     );
+    expect(execute).toHaveBeenCalledTimes(1);
     expect(toolResponse).toEqual({
       contentItems: [{ type: "inputText", text: "echo:hello" }],
       success: true,

--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -407,7 +407,7 @@ describe("codex conversation binding", () => {
     const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
     let notificationHandler: ((notification: unknown) => void) | undefined;
     let requestHandler:
-      | ((request: { method: string; params?: unknown }) => Promise<unknown> | unknown)
+      | ((request: { method: string; params?: unknown }) => Promise<unknown>)
       | undefined;
     let toolResponse: unknown;
     sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({

--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -739,6 +739,89 @@ describe("codex conversation binding", () => {
     expect(savedBinding.dynamicToolsFingerprint).toContain("test_plugin_echo");
   });
 
+  it("preserves older native bound Codex threads when no dynamic tools are available", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    await fs.writeFile(
+      sessionFile + ".codex-app-server.json",
+      JSON.stringify({
+        schemaVersion: 1,
+        threadId: "thread-old",
+        cwd: tempDir,
+        model: "gpt-5.4-mini",
+      }),
+    );
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    let notificationHandler: ((notification: unknown) => void) | undefined;
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
+      request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
+        requests.push({ method, params: requestParams });
+        if (method === "turn/start") {
+          setImmediate(() => {
+            notificationHandler?.({
+              method: "turn/completed",
+              params: {
+                threadId: "thread-old",
+                turn: {
+                  id: "turn-1",
+                  status: "completed",
+                  items: [{ type: "agentMessage", id: "item-1", text: "preserved" }],
+                },
+              },
+            });
+          });
+          return { turn: { id: "turn-1" } };
+        }
+        throw new Error(`unexpected method: ${method}`);
+      }),
+      addNotificationHandler: vi.fn((handler: (notification: unknown) => void) => {
+        notificationHandler = handler;
+        return () => undefined;
+      }),
+      addRequestHandler: vi.fn(() => () => undefined),
+    });
+
+    const result = await handleCodexConversationInboundClaim(
+      {
+        content: "continue",
+        bodyForAgent: "continue",
+        channel: "telegram",
+        isGroup: false,
+        commandAuthorized: true,
+        conversationId: "5185575566",
+      },
+      {
+        channelId: "telegram",
+        conversationId: "5185575566",
+        sessionKey: "telegram:direct:5185575566",
+        pluginBinding: {
+          bindingId: "binding-1",
+          pluginId: "codex",
+          pluginRoot: tempDir,
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "5185575566",
+          boundAt: Date.now(),
+          data: {
+            kind: "codex-app-server-session",
+            version: 1,
+            sessionFile,
+            workspaceDir: tempDir,
+          },
+        },
+      },
+      { timeoutMs: 500 },
+    );
+
+    expect(result).toEqual({ handled: true, reply: { text: "preserved" } });
+    expect(requests.map((request) => request.method)).toEqual(["turn/start"]);
+    expect(requests[0]?.params.threadId).toBe("thread-old");
+    const savedBinding = JSON.parse(
+      await fs.readFile(sessionFile + ".codex-app-server.json", "utf8"),
+    );
+    expect(savedBinding.threadId).toBe("thread-old");
+    expect(savedBinding.dynamicToolsFingerprint).toBe("[]");
+  });
+
   it("recreates a missing bound thread and preserves auth plus turn overrides", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     agentRuntimeMocks.ensureAuthProfileStore.mockReturnValue({

--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -550,7 +550,7 @@ describe("codex conversation binding", () => {
         schemaVersion: 1,
         threadId: "thread-1",
         cwd: tempDir,
-        dynamicToolsFingerprint: "[]",
+        threadBindingOrigin: "explicit",
       }),
     );
     let notificationHandler: ((notification: unknown) => void) | undefined;
@@ -737,6 +737,202 @@ describe("codex conversation binding", () => {
     expect(savedBinding.sandbox).toBe("workspace-write");
     expect(savedBinding.serviceTier).toBe("priority");
     expect(savedBinding.dynamicToolsFingerprint).toContain("test_plugin_echo");
+  });
+
+  it("preserves explicitly bound Codex threads without dynamic tool fingerprints", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    agentHarnessMocks.createOpenClawCodingTools.mockReturnValue([createEchoTool()] as never);
+    await fs.writeFile(
+      sessionFile + ".codex-app-server.json",
+      JSON.stringify({
+        schemaVersion: 1,
+        threadId: "thread-explicit",
+        cwd: tempDir,
+        model: "gpt-5.4-mini",
+        threadBindingOrigin: "explicit",
+      }),
+    );
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    let notificationHandler: ((notification: unknown) => void) | undefined;
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
+      request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
+        requests.push({ method, params: requestParams });
+        if (method === "turn/start") {
+          setImmediate(() => {
+            notificationHandler?.({
+              method: "turn/completed",
+              params: {
+                threadId: "thread-explicit",
+                turn: {
+                  id: "turn-1",
+                  status: "completed",
+                  items: [{ type: "agentMessage", id: "item-1", text: "preserved explicit" }],
+                },
+              },
+            });
+          });
+          return { turn: { id: "turn-1" } };
+        }
+        throw new Error(`unexpected method: ${method}`);
+      }),
+      addNotificationHandler: vi.fn((handler: (notification: unknown) => void) => {
+        notificationHandler = handler;
+        return () => undefined;
+      }),
+      addRequestHandler: vi.fn(() => () => undefined),
+    });
+
+    const result = await handleCodexConversationInboundClaim(
+      {
+        content: "continue",
+        bodyForAgent: "continue",
+        channel: "telegram",
+        isGroup: false,
+        commandAuthorized: true,
+        conversationId: "5185575566",
+      },
+      {
+        channelId: "telegram",
+        conversationId: "5185575566",
+        sessionKey: "telegram:direct:5185575566",
+        pluginBinding: {
+          bindingId: "binding-1",
+          pluginId: "codex",
+          pluginRoot: tempDir,
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "5185575566",
+          boundAt: Date.now(),
+          data: {
+            kind: "codex-app-server-session",
+            version: 1,
+            sessionFile,
+            workspaceDir: tempDir,
+          },
+        },
+      },
+      { timeoutMs: 500 },
+    );
+
+    expect(result).toEqual({ handled: true, reply: { text: "preserved explicit" } });
+    expect(requests.map((request) => request.method)).toEqual(["turn/start"]);
+    expect(requests[0]?.params.threadId).toBe("thread-explicit");
+    const savedBinding = JSON.parse(
+      await fs.readFile(sessionFile + ".codex-app-server.json", "utf8"),
+    );
+    expect(savedBinding.threadId).toBe("thread-explicit");
+    expect(savedBinding.threadBindingOrigin).toBe("explicit");
+    expect(savedBinding).not.toHaveProperty("dynamicToolsFingerprint");
+  });
+
+  it("times out bound Codex dynamic tool calls with per-call timeout budgets", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const execute = vi.fn(
+      (_callId: string, _params: unknown, signal?: AbortSignal) =>
+        new Promise<{ content: Array<{ type: "text"; text: string }> }>((resolve) => {
+          signal?.addEventListener(
+            "abort",
+            () => resolve({ content: [{ type: "text", text: "aborted by timeout" }] }),
+            { once: true },
+          );
+        }),
+    );
+    agentHarnessMocks.createOpenClawCodingTools.mockReturnValue([createEchoTool(execute)] as never);
+    await fs.writeFile(
+      sessionFile + ".codex-app-server.json",
+      JSON.stringify({
+        schemaVersion: 1,
+        threadId: "thread-1",
+        cwd: tempDir,
+        threadBindingOrigin: "explicit",
+      }),
+    );
+    let notificationHandler: ((notification: unknown) => void) | undefined;
+    let requestHandler:
+      | ((request: { method: string; params?: unknown }) => Promise<unknown>)
+      | undefined;
+    let toolResponse: unknown;
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
+      request: vi.fn(async (method: string) => {
+        if (method === "turn/start") {
+          setImmediate(async () => {
+            toolResponse = await requestHandler?.({
+              method: "item/tool/call",
+              params: {
+                threadId: "thread-1",
+                turnId: "turn-1",
+                callId: "call-1",
+                namespace: null,
+                tool: "test_plugin_echo",
+                arguments: { text: "slow", timeoutMs: 1 },
+              },
+            });
+            notificationHandler?.({
+              method: "turn/completed",
+              params: {
+                threadId: "thread-1",
+                turn: {
+                  id: "turn-1",
+                  status: "completed",
+                  items: [{ type: "agentMessage", id: "item-1", text: "done" }],
+                },
+              },
+            });
+          });
+          return { turn: { id: "turn-1" } };
+        }
+        throw new Error("unexpected method: " + method);
+      }),
+      addNotificationHandler: vi.fn((handler: (notification: unknown) => void) => {
+        notificationHandler = handler;
+        return () => undefined;
+      }),
+      addRequestHandler: vi.fn((handler) => {
+        requestHandler = handler;
+        return () => undefined;
+      }),
+    });
+
+    const result = await handleCodexConversationInboundClaim(
+      {
+        content: "call slow echo",
+        bodyForAgent: "call slow echo",
+        channel: "telegram",
+        isGroup: false,
+        commandAuthorized: true,
+      },
+      {
+        channelId: "telegram",
+        pluginBinding: {
+          bindingId: "binding-1",
+          pluginId: "codex",
+          pluginRoot: tempDir,
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "5185575566",
+          boundAt: Date.now(),
+          data: {
+            kind: "codex-app-server-session",
+            version: 1,
+            sessionFile,
+            workspaceDir: tempDir,
+          },
+        },
+      },
+      { timeoutMs: 500 },
+    );
+
+    expect(result).toEqual({ handled: true, reply: { text: "done" } });
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(toolResponse).toEqual({
+      success: false,
+      contentItems: [
+        {
+          type: "inputText",
+          text: "OpenClaw dynamic tool call timed out after 1ms while running tool test_plugin_echo.",
+        },
+      ],
+    });
   });
 
   it("preserves older native bound Codex threads when no dynamic tools are available", async () => {

--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -515,15 +515,31 @@ describe("codex conversation binding", () => {
     });
   });
 
-  it("preserves older native bound Codex threads without dynamic tool fingerprints", async () => {
+  it("upgrades older native bound Codex threads without dynamic tool fingerprints", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     agentHarnessMocks.createOpenClawCodingTools.mockReturnValue([createEchoTool()] as never);
+    agentRuntimeMocks.ensureAuthProfileStore.mockReturnValue({
+      version: 1,
+      profiles: {
+        work: {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "access-token",
+        },
+      },
+    });
     await fs.writeFile(
       sessionFile + ".codex-app-server.json",
       JSON.stringify({
         schemaVersion: 1,
         threadId: "thread-old",
         cwd: tempDir,
+        authProfileId: "work",
+        model: "gpt-5.4-mini",
+        modelProvider: "openai",
+        approvalPolicy: "on-request",
+        sandbox: "workspace-write",
+        serviceTier: "fast",
       }),
     );
     const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
@@ -531,16 +547,22 @@ describe("codex conversation binding", () => {
     sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
       request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
         requests.push({ method, params: requestParams });
+        if (method === "thread/start") {
+          return {
+            thread: { id: "thread-new", sessionId: "session-1", cwd: tempDir },
+            model: "gpt-5.4-mini",
+          };
+        }
         if (method === "turn/start") {
           setImmediate(() => {
             notificationHandler?.({
               method: "turn/completed",
               params: {
-                threadId: "thread-old",
+                threadId: "thread-new",
                 turn: {
                   id: "turn-1",
                   status: "completed",
-                  items: [{ type: "agentMessage", id: "item-1", text: "still here" }],
+                  items: [{ type: "agentMessage", id: "item-1", text: "upgraded" }],
                 },
               },
             });
@@ -588,14 +610,27 @@ describe("codex conversation binding", () => {
       { timeoutMs: 500 },
     );
 
-    expect(result).toEqual({ handled: true, reply: { text: "still here" } });
-    expect(requests.map((request) => request.method)).toEqual(["turn/start"]);
-    expect(requests[0]?.params.threadId).toBe("thread-old");
+    expect(result).toEqual({ handled: true, reply: { text: "upgraded" } });
+    expect(requests.map((request) => request.method)).toEqual(["thread/start", "turn/start"]);
+    expect(requests[0]?.params.model).toBe("gpt-5.4-mini");
+    expect(requests[0]?.params.approvalPolicy).toBe("on-request");
+    expect(requests[0]?.params.sandbox).toBe("workspace-write");
+    expect(requests[0]?.params.serviceTier).toBe("priority");
+    expect(requests[0]?.params).not.toHaveProperty("modelProvider");
+    expect(requests[0]?.params.dynamicTools).toEqual([
+      expect.objectContaining({ name: "test_plugin_echo" }),
+    ]);
+    expect(requests[1]?.params.threadId).toBe("thread-new");
     const savedBinding = JSON.parse(
       await fs.readFile(sessionFile + ".codex-app-server.json", "utf8"),
     );
-    expect(savedBinding.threadId).toBe("thread-old");
-    expect(savedBinding).not.toHaveProperty("dynamicToolsFingerprint");
+    expect(savedBinding.threadId).toBe("thread-new");
+    expect(savedBinding.authProfileId).toBe("work");
+    expect(savedBinding.model).toBe("gpt-5.4-mini");
+    expect(savedBinding.approvalPolicy).toBe("on-request");
+    expect(savedBinding.sandbox).toBe("workspace-write");
+    expect(savedBinding.serviceTier).toBe("priority");
+    expect(savedBinding.dynamicToolsFingerprint).toContain("test_plugin_echo");
   });
 
   it("recreates a missing bound thread and preserves auth plus turn overrides", async () => {
@@ -622,6 +657,7 @@ describe("codex conversation binding", () => {
         approvalPolicy: "on-request",
         sandbox: "workspace-write",
         serviceTier: "fast",
+        dynamicToolsFingerprint: "[]",
       }),
     );
     const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
@@ -739,6 +775,7 @@ describe("codex conversation binding", () => {
         threadId: "thread-1",
         cwd: tempDir,
         authProfileId: "openai-codex:work",
+        dynamicToolsFingerprint: "[]",
       }),
     );
     const unhandledRejections: unknown[] = [];
@@ -816,6 +853,7 @@ describe("codex conversation binding", () => {
         schemaVersion: 1,
         threadId: "thread-1",
         cwd: tempDir,
+        dynamicToolsFingerprint: "[]",
       }),
     );
     let notificationHandler: ((notification: unknown) => void) | undefined;

--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -621,7 +621,7 @@ describe("codex conversation binding", () => {
     expect(toolFactoryOptions.currentChannelId).toBe("conv-scoped-77");
   });
 
-  it("upgrades older native bound Codex threads without dynamic tool fingerprints", async () => {
+  it("upgrades managed native bound Codex threads without dynamic tool fingerprints", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     agentHarnessMocks.createOpenClawCodingTools.mockReturnValue([createEchoTool()] as never);
     agentRuntimeMocks.ensureAuthProfileStore.mockReturnValue({
@@ -646,6 +646,7 @@ describe("codex conversation binding", () => {
         approvalPolicy: "on-request",
         sandbox: "workspace-write",
         serviceTier: "fast",
+        threadBindingOrigin: "managed",
       }),
     );
     const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
@@ -737,6 +738,91 @@ describe("codex conversation binding", () => {
     expect(savedBinding.sandbox).toBe("workspace-write");
     expect(savedBinding.serviceTier).toBe("priority");
     expect(savedBinding.dynamicToolsFingerprint).toContain("test_plugin_echo");
+  });
+
+  it("preserves legacy no-origin Codex threads without dynamic tool fingerprints", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    agentHarnessMocks.createOpenClawCodingTools.mockReturnValue([createEchoTool()] as never);
+    await fs.writeFile(
+      sessionFile + ".codex-app-server.json",
+      JSON.stringify({
+        schemaVersion: 1,
+        threadId: "thread-legacy-explicit",
+        cwd: tempDir,
+        model: "gpt-5.4-mini",
+      }),
+    );
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = [];
+    let notificationHandler: ((notification: unknown) => void) | undefined;
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
+      request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
+        requests.push({ method, params: requestParams });
+        if (method === "turn/start") {
+          setImmediate(() => {
+            notificationHandler?.({
+              method: "turn/completed",
+              params: {
+                threadId: "thread-legacy-explicit",
+                turn: {
+                  id: "turn-1",
+                  status: "completed",
+                  items: [{ type: "agentMessage", id: "item-1", text: "legacy explicit" }],
+                },
+              },
+            });
+          });
+          return { turn: { id: "turn-1" } };
+        }
+        throw new Error(`unexpected method: ${method}`);
+      }),
+      addNotificationHandler: vi.fn((handler: (notification: unknown) => void) => {
+        notificationHandler = handler;
+        return () => undefined;
+      }),
+      addRequestHandler: vi.fn(() => () => undefined),
+    });
+
+    const result = await handleCodexConversationInboundClaim(
+      {
+        content: "continue",
+        bodyForAgent: "continue",
+        channel: "telegram",
+        isGroup: false,
+        commandAuthorized: true,
+        conversationId: "5185575566",
+      },
+      {
+        channelId: "telegram",
+        conversationId: "5185575566",
+        sessionKey: "telegram:direct:5185575566",
+        pluginBinding: {
+          bindingId: "binding-1",
+          pluginId: "codex",
+          pluginRoot: tempDir,
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "5185575566",
+          boundAt: Date.now(),
+          data: {
+            kind: "codex-app-server-session",
+            version: 1,
+            sessionFile,
+            workspaceDir: tempDir,
+          },
+        },
+      },
+      { timeoutMs: 500 },
+    );
+
+    expect(result).toEqual({ handled: true, reply: { text: "legacy explicit" } });
+    expect(requests.map((request) => request.method)).toEqual(["turn/start"]);
+    expect(requests[0]?.params.threadId).toBe("thread-legacy-explicit");
+    const savedBinding = JSON.parse(
+      await fs.readFile(sessionFile + ".codex-app-server.json", "utf8"),
+    );
+    expect(savedBinding.threadId).toBe("thread-legacy-explicit");
+    expect(savedBinding).not.toHaveProperty("threadBindingOrigin");
+    expect(savedBinding).not.toHaveProperty("dynamicToolsFingerprint");
   });
 
   it("preserves explicitly bound Codex threads without dynamic tool fingerprints", async () => {

--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -542,6 +542,85 @@ describe("codex conversation binding", () => {
     });
   });
 
+  it("scopes bound turn dynamic tools to the binding conversation, not the provider channel", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    await fs.writeFile(
+      sessionFile + ".codex-app-server.json",
+      JSON.stringify({
+        schemaVersion: 1,
+        threadId: "thread-1",
+        cwd: tempDir,
+        dynamicToolsFingerprint: "[]",
+      }),
+    );
+    let notificationHandler: ((notification: unknown) => void) | undefined;
+    sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
+      request: vi.fn(async (method: string) => {
+        if (method === "turn/start") {
+          setImmediate(() =>
+            notificationHandler?.({
+              method: "turn/completed",
+              params: {
+                threadId: "thread-1",
+                turn: {
+                  id: "turn-1",
+                  status: "completed",
+                  items: [{ type: "agentMessage", id: "item-1", text: "done" }],
+                },
+              },
+            }),
+          );
+          return { turn: { id: "turn-1" } };
+        }
+        throw new Error("unexpected method: " + method);
+      }),
+      addNotificationHandler: vi.fn((handler: (notification: unknown) => void) => {
+        notificationHandler = handler;
+        return () => undefined;
+      }),
+      addRequestHandler: vi.fn(() => () => undefined),
+    });
+
+    const result = await handleCodexConversationInboundClaim(
+      {
+        content: "scope check",
+        bodyForAgent: "scope check",
+        channel: "telegram",
+        isGroup: false,
+        commandAuthorized: true,
+      },
+      {
+        channelId: "telegram",
+        pluginBinding: {
+          bindingId: "binding-1",
+          pluginId: "codex",
+          pluginRoot: tempDir,
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "conv-scoped-77",
+          boundAt: Date.now(),
+          data: {
+            kind: "codex-app-server-session",
+            version: 1,
+            sessionFile,
+            workspaceDir: tempDir,
+          },
+        },
+      },
+      { timeoutMs: 50 },
+    );
+
+    expect(result).toEqual({ handled: true, reply: { text: "done" } });
+    const toolFactoryOptions = mockCallArg(agentHarnessMocks.createOpenClawCodingTools) as {
+      currentChannelId?: unknown;
+      messageTo?: unknown;
+      sessionId?: unknown;
+    };
+    expect(toolFactoryOptions.sessionId).toBe("conv-scoped-77");
+    expect(toolFactoryOptions.messageTo).toBe("conv-scoped-77");
+    expect(toolFactoryOptions.currentChannelId).toBe("conv-scoped-77");
+  });
+
   it("upgrades older native bound Codex threads without dynamic tool fingerprints", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     agentHarnessMocks.createOpenClawCodingTools.mockReturnValue([createEchoTool()] as never);

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -432,14 +432,31 @@ async function runBoundTurn(params: {
   });
   const dynamicToolsFingerprint = codexDynamicToolsFingerprint(toolBridge.specs);
   // Older bound sidecars predate dynamic-tool fingerprints and were started
-  // without a dynamic tool catalog, so refresh them once onto a tool-aware
-  // thread before preserving future compatible fingerprints.
+  // without a dynamic tool catalog, so refresh only when a catalog exists.
+  // Empty catalogs are recorded in place to avoid losing bound thread context.
+  if (binding.dynamicToolsFingerprint === undefined && toolBridge.specs.length === 0) {
+    await writeCodexAppServerBinding(
+      params.data.sessionFile,
+      {
+        ...binding,
+        dynamicToolsFingerprint,
+      },
+      agentLookup,
+    );
+    binding = await readCodexAppServerBinding(params.data.sessionFile, agentLookup);
+    if (!binding) {
+      throw new Error(
+        "bound Codex conversation has no sidecar binding after dynamic tool fingerprint update",
+      );
+    }
+  }
   const shouldRefreshDynamicTools =
-    binding.dynamicToolsFingerprint === undefined ||
-    !areCodexDynamicToolFingerprintsCompatible({
-      previous: binding.dynamicToolsFingerprint,
-      next: dynamicToolsFingerprint,
-    });
+    (binding.dynamicToolsFingerprint === undefined && toolBridge.specs.length > 0) ||
+    (binding.dynamicToolsFingerprint !== undefined &&
+      !areCodexDynamicToolFingerprintsCompatible({
+        previous: binding.dynamicToolsFingerprint,
+        next: dynamicToolsFingerprint,
+      }));
   if (shouldRefreshDynamicTools) {
     await createThread({
       pluginConfig: params.pluginConfig,

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -437,8 +437,10 @@ async function runBoundTurn(params: {
     signal: turnAbortController.signal,
   });
   const dynamicToolsFingerprint = codexDynamicToolsFingerprint(toolBridge.specs);
-  // Older bound sidecars predate dynamic-tool fingerprints and were started
-  // without a dynamic tool catalog, so refresh only when a catalog exists.
+  // Older bound sidecars predate dynamic-tool fingerprints and origin markers.
+  // Only known managed sidecars may be refreshed automatically; no-origin
+  // legacy bindings might be explicit /codex resume selections and must keep
+  // their selected thread until the user refreshes it deliberately.
   // Empty catalogs are recorded in place to avoid losing bound thread context.
   if (binding.dynamicToolsFingerprint === undefined && toolBridge.specs.length === 0) {
     await writeCodexAppServerBinding(
@@ -458,7 +460,7 @@ async function runBoundTurn(params: {
   }
   const shouldRefreshDynamicTools =
     (binding.dynamicToolsFingerprint === undefined &&
-      binding.threadBindingOrigin !== "explicit" &&
+      binding.threadBindingOrigin === "managed" &&
       toolBridge.specs.length > 0) ||
     (binding.dynamicToolsFingerprint !== undefined &&
       !areCodexDynamicToolFingerprintsCompatible({

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -474,18 +474,23 @@ async function runBoundTurn(params: {
     ...agentLookup,
   });
   const collector = createCodexConversationTurnCollector(threadId);
+  let activeTurnId: string | undefined;
   const notificationCleanup = client.addNotificationHandler((notification) =>
     collector.handleNotification(notification),
   );
   const requestCleanup = client.addRequestHandler(
     async (request): Promise<JsonValue | undefined> => {
       if (request.method === "item/tool/call") {
+        // Other bound turns may share this app-server client, so only dispatch
+        // tool calls that target this turn's thread and active turn id.
         const call = readCodexDynamicToolCallParams(request.params);
-        if (!call) {
-          return {
-            contentItems: [{ type: "inputText", text: "Invalid OpenClaw dynamic tool call." }],
-            success: false,
-          };
+        if (
+          !call ||
+          call.threadId !== threadId ||
+          activeTurnId === undefined ||
+          call.turnId !== activeTurnId
+        ) {
+          return undefined;
         }
         return toolBridge.handleToolCall(call, { signal: turnAbortController.signal });
       }
@@ -536,6 +541,7 @@ async function runBoundTurn(params: {
       { timeoutMs: runtime.requestTimeoutMs },
     );
     const turnId = response.turn.id;
+    activeTurnId = turnId;
     const activeCleanup = trackCodexConversationActiveTurn({
       sessionFile: params.data.sessionFile,
       threadId,

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -431,10 +431,11 @@ async function runBoundTurn(params: {
     signal: turnAbortController.signal,
   });
   const dynamicToolsFingerprint = codexDynamicToolsFingerprint(toolBridge.specs);
-  // Older bound sidecars predate dynamic-tool fingerprints. Preserve their
-  // existing thread context instead of rotating them as soon as plugins appear.
+  // Older bound sidecars predate dynamic-tool fingerprints and were started
+  // without a dynamic tool catalog, so refresh them once onto a tool-aware
+  // thread before preserving future compatible fingerprints.
   const shouldRefreshDynamicTools =
-    binding.dynamicToolsFingerprint !== undefined &&
+    binding.dynamicToolsFingerprint === undefined ||
     !areCodexDynamicToolFingerprintsCompatible({
       previous: binding.dynamicToolsFingerprint,
       next: dynamicToolsFingerprint,

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -612,8 +612,13 @@ async function buildConversationDynamicToolBridge(params: {
   const signal = params.signal ?? new AbortController().signal;
   const codexConfig = readCodexPluginConfig(params.pluginConfig);
   const { createOpenClawCodingTools } = await import("openclaw/plugin-sdk/agent-harness");
+  // The bound conversation is the security boundary for tool replies and
+  // session state. ctx.channelId is only the provider id (for example,
+  // "telegram"), so it must never be used as a conversation fallback.
   const boundConversationId =
-    params.ctx?.conversationId ?? params.event?.conversationId ?? params.ctx?.channelId;
+    params.ctx?.pluginBinding?.conversationId ??
+    params.ctx?.conversationId ??
+    params.event?.conversationId;
   const allTools = createOpenClawCodingTools({
     includeCoreTools: false,
     config: params.config,

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -431,12 +431,14 @@ async function runBoundTurn(params: {
     signal: turnAbortController.signal,
   });
   const dynamicToolsFingerprint = codexDynamicToolsFingerprint(toolBridge.specs);
-  const shouldRefreshDynamicTools = binding.dynamicToolsFingerprint
-    ? !areCodexDynamicToolFingerprintsCompatible({
-        previous: binding.dynamicToolsFingerprint,
-        next: dynamicToolsFingerprint,
-      })
-    : toolBridge.specs.length > 0;
+  // Older bound sidecars predate dynamic-tool fingerprints. Preserve their
+  // existing thread context instead of rotating them as soon as plugins appear.
+  const shouldRefreshDynamicTools =
+    binding.dynamicToolsFingerprint !== undefined &&
+    !areCodexDynamicToolFingerprintsCompatible({
+      previous: binding.dynamicToolsFingerprint,
+      next: dynamicToolsFingerprint,
+    });
   if (shouldRefreshDynamicTools) {
     await createThread({
       pluginConfig: params.pluginConfig,
@@ -603,20 +605,22 @@ async function buildConversationDynamicToolBridge(params: {
   const signal = params.signal ?? new AbortController().signal;
   const codexConfig = readCodexPluginConfig(params.pluginConfig);
   const { createOpenClawCodingTools } = await import("openclaw/plugin-sdk/agent-harness");
+  const boundConversationId =
+    params.ctx?.conversationId ?? params.event?.conversationId ?? params.ctx?.channelId;
   const allTools = createOpenClawCodingTools({
     includeCoreTools: false,
     config: params.config,
     ...(params.agentDir ? { agentDir: params.agentDir } : {}),
     workspaceDir: params.workspaceDir,
     spawnWorkspaceDir: params.workspaceDir,
-    sessionId: params.ctx?.conversationId ?? params.event?.conversationId,
+    sessionId: boundConversationId,
     sessionKey: params.ctx?.sessionKey,
     runId: params.ctx?.runId,
     messageProvider: params.event?.channel,
     agentAccountId: params.event?.accountId,
-    messageTo: params.event?.conversationId,
+    messageTo: boundConversationId,
     messageThreadId: params.event?.threadId,
-    currentChannelId: params.ctx?.channelId ?? params.event?.conversationId,
+    currentChannelId: boundConversationId,
     currentMessageId: params.event?.messageId,
     senderId: params.event?.senderId,
     senderName: params.event?.senderName,
@@ -630,10 +634,10 @@ async function buildConversationDynamicToolBridge(params: {
     signal,
     hookContext: {
       config: params.config,
-      sessionId: params.ctx?.conversationId ?? params.event?.conversationId,
+      sessionId: boundConversationId,
       sessionKey: params.ctx?.sessionKey,
       runId: params.ctx?.runId,
-      channelId: params.ctx?.channelId ?? params.event?.conversationId,
+      channelId: boundConversationId,
     },
     loading: resolveCodexDynamicToolsLoading(codexConfig),
   });

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -20,6 +20,10 @@ import {
   resolveCodexDynamicToolsLoading,
 } from "./app-server/dynamic-tool-profile.js";
 import {
+  handleDynamicToolCallWithTimeout,
+  resolveDynamicToolCallTimeoutMs,
+} from "./app-server/dynamic-tool-timeout.js";
+import {
   createCodexDynamicToolBridge,
   type CodexDynamicToolBridge,
 } from "./app-server/dynamic-tools.js";
@@ -317,6 +321,7 @@ async function attachExistingThread(params: {
       approvalPolicy: params.approvalPolicy ?? runtimeApprovalPolicy,
       sandbox: params.sandbox ?? runtime.sandbox,
       serviceTier: params.serviceTier ?? runtime.serviceTier,
+      threadBindingOrigin: "explicit",
     },
     {
       ...agentLookup,
@@ -392,6 +397,7 @@ async function createThread(params: {
       sandbox: params.sandbox ?? runtime.sandbox,
       serviceTier: params.serviceTier ?? runtime.serviceTier,
       dynamicToolsFingerprint: params.dynamicToolsFingerprint ?? codexDynamicToolsFingerprint([]),
+      threadBindingOrigin: "managed",
     },
     {
       ...agentLookup,
@@ -451,7 +457,9 @@ async function runBoundTurn(params: {
     }
   }
   const shouldRefreshDynamicTools =
-    (binding.dynamicToolsFingerprint === undefined && toolBridge.specs.length > 0) ||
+    (binding.dynamicToolsFingerprint === undefined &&
+      binding.threadBindingOrigin !== "explicit" &&
+      toolBridge.specs.length > 0) ||
     (binding.dynamicToolsFingerprint !== undefined &&
       !areCodexDynamicToolFingerprintsCompatible({
         previous: binding.dynamicToolsFingerprint,
@@ -509,7 +517,15 @@ async function runBoundTurn(params: {
         ) {
           return undefined;
         }
-        return toolBridge.handleToolCall(call, { signal: turnAbortController.signal });
+        return handleDynamicToolCallWithTimeout({
+          call,
+          toolBridge,
+          signal: turnAbortController.signal,
+          timeoutMs: resolveDynamicToolCallTimeoutMs({
+            call,
+            config: params.config,
+          }),
+        });
       }
       if (
         request.method === "item/commandExecution/requestApproval" ||

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -1,4 +1,5 @@
-import { formatErrorMessage } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { formatErrorMessage, type AnyAgentTool } from "openclaw/plugin-sdk/agent-harness-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type {
   PluginConversationBindingResolvedEvent,
   PluginHookInboundClaimContext,
@@ -9,11 +10,22 @@ import { resolveCodexAppServerAuthProfileIdForAgent } from "./app-server/auth-br
 import { CODEX_CONTROL_METHODS } from "./app-server/capabilities.js";
 import {
   codexSandboxPolicyForTurn,
+  readCodexPluginConfig,
   resolveCodexAppServerRuntimeOptions,
   type CodexAppServerApprovalPolicy,
   type CodexAppServerSandboxMode,
 } from "./app-server/config.js";
 import {
+  filterCodexDynamicTools,
+  resolveCodexDynamicToolsLoading,
+} from "./app-server/dynamic-tool-profile.js";
+import {
+  createCodexDynamicToolBridge,
+  type CodexDynamicToolBridge,
+} from "./app-server/dynamic-tools.js";
+import { readCodexDynamicToolCallParams } from "./app-server/protocol-validators.js";
+import {
+  type CodexDynamicToolSpec,
   type CodexServiceTier,
   type CodexThreadResumeResponse,
   type CodexThreadStartResponse,
@@ -29,6 +41,10 @@ import {
   type CodexAppServerAuthProfileLookup,
 } from "./app-server/session-binding.js";
 import { getSharedCodexAppServerClient } from "./app-server/shared-client.js";
+import {
+  areCodexDynamicToolFingerprintsCompatible,
+  codexDynamicToolsFingerprint,
+} from "./app-server/thread-lifecycle.js";
 import { formatCodexDisplayText } from "./command-formatters.js";
 import {
   createCodexConversationBindingData,
@@ -52,6 +68,7 @@ export {
 
 type CodexConversationRunOptions = {
   pluginConfig?: unknown;
+  config?: OpenClawConfig;
   timeoutMs?: number;
   resumeCodexCliSessionOnNode?: ResumeCodexCliSessionOnNodeFn;
 };
@@ -62,7 +79,7 @@ type ResumeCodexCliSessionOnNodeFn = (
 
 type CodexConversationStartParams = {
   pluginConfig?: unknown;
-  config?: Parameters<typeof resolveCodexAppServerAuthProfileIdForAgent>[0]["config"];
+  config?: OpenClawConfig;
   sessionFile: string;
   workspaceDir?: string;
   agentDir?: string;
@@ -123,6 +140,12 @@ export async function startCodexConversationThread(
       config: params.config,
     });
   } else {
+    const dynamicToolBridge = await buildConversationDynamicToolBridge({
+      pluginConfig: params.pluginConfig,
+      config: params.config,
+      workspaceDir,
+      ...(agentDir ? { agentDir } : {}),
+    });
     await createThread({
       pluginConfig: params.pluginConfig,
       sessionFile: params.sessionFile,
@@ -135,6 +158,8 @@ export async function startCodexConversationThread(
       sandbox: params.sandbox,
       serviceTier: params.serviceTier,
       config: params.config,
+      dynamicTools: dynamicToolBridge.specs,
+      dynamicToolsFingerprint: codexDynamicToolsFingerprint(dynamicToolBridge.specs),
     });
   }
   return createCodexConversationBindingData({
@@ -197,7 +222,9 @@ export async function handleCodexConversationInboundClaim(
         data,
         prompt,
         event,
+        ctx,
         pluginConfig: options.pluginConfig,
+        config: options.config,
         timeoutMs: options.timeoutMs,
       }),
     );
@@ -238,6 +265,8 @@ async function attachExistingThread(params: {
   sandbox?: CodexAppServerSandboxMode;
   serviceTier?: CodexServiceTier;
   config?: CodexAppServerAuthProfileLookup["config"];
+  dynamicTools?: CodexDynamicToolSpec[];
+  dynamicToolsFingerprint?: string;
 }): Promise<void> {
   const runtime = resolveCodexAppServerRuntimeOptions({
     pluginConfig: params.pluginConfig,
@@ -307,6 +336,8 @@ async function createThread(params: {
   sandbox?: CodexAppServerSandboxMode;
   serviceTier?: CodexServiceTier;
   config?: CodexAppServerAuthProfileLookup["config"];
+  dynamicTools?: CodexDynamicToolSpec[];
+  dynamicToolsFingerprint?: string;
 }): Promise<void> {
   const runtime = resolveCodexAppServerRuntimeOptions({
     pluginConfig: params.pluginConfig,
@@ -337,6 +368,7 @@ async function createThread(params: {
         : {}),
       developerInstructions:
         "This Codex thread is bound to an OpenClaw conversation. Answer normally; OpenClaw will deliver your final response back to the conversation.",
+      dynamicTools: params.dynamicTools ?? [],
       experimentalRawEvents: true,
       persistExtendedHistory: true,
     },
@@ -359,6 +391,7 @@ async function createThread(params: {
       approvalPolicy: params.approvalPolicy ?? runtimeApprovalPolicy,
       sandbox: params.sandbox ?? runtime.sandbox,
       serviceTier: params.serviceTier ?? runtime.serviceTier,
+      dynamicToolsFingerprint: params.dynamicToolsFingerprint ?? codexDynamicToolsFingerprint([]),
     },
     {
       ...agentLookup,
@@ -370,23 +403,71 @@ async function runBoundTurn(params: {
   data: CodexAppServerConversationBindingData;
   prompt: string;
   event: PluginHookInboundClaimEvent;
+  ctx: PluginHookInboundClaimContext;
   pluginConfig?: unknown;
+  config?: OpenClawConfig;
   timeoutMs?: number;
 }): Promise<BoundTurnResult> {
   const runtime = resolveCodexAppServerRuntimeOptions({
     pluginConfig: params.pluginConfig,
   });
   const agentLookup = buildAgentLookup({ agentDir: params.data.agentDir });
-  const binding = await readCodexAppServerBinding(params.data.sessionFile, agentLookup);
-  const threadId = binding?.threadId;
+  let binding = await readCodexAppServerBinding(params.data.sessionFile, agentLookup);
+  let threadId = binding?.threadId;
   if (!threadId) {
     throw new Error("bound Codex conversation has no thread binding");
+  }
+  if (!binding) {
+    throw new Error("bound Codex conversation has no sidecar binding");
+  }
+  const turnAbortController = new AbortController();
+  const toolBridge = await buildConversationDynamicToolBridge({
+    pluginConfig: params.pluginConfig,
+    config: params.config,
+    workspaceDir: binding?.cwd || params.data.workspaceDir,
+    ...(params.data.agentDir ? { agentDir: params.data.agentDir } : {}),
+    event: params.event,
+    ctx: params.ctx,
+    signal: turnAbortController.signal,
+  });
+  const dynamicToolsFingerprint = codexDynamicToolsFingerprint(toolBridge.specs);
+  const shouldRefreshDynamicTools = binding.dynamicToolsFingerprint
+    ? !areCodexDynamicToolFingerprintsCompatible({
+        previous: binding.dynamicToolsFingerprint,
+        next: dynamicToolsFingerprint,
+      })
+    : toolBridge.specs.length > 0;
+  if (shouldRefreshDynamicTools) {
+    await createThread({
+      pluginConfig: params.pluginConfig,
+      sessionFile: params.data.sessionFile,
+      workspaceDir: binding.cwd || params.data.workspaceDir,
+      ...(params.data.agentDir ? { agentDir: params.data.agentDir } : {}),
+      model: binding.model,
+      modelProvider: binding.modelProvider,
+      authProfileId: binding.authProfileId,
+      approvalPolicy: binding.approvalPolicy,
+      sandbox: binding.sandbox,
+      serviceTier: binding.serviceTier,
+      config: params.config,
+      dynamicTools: toolBridge.specs,
+      dynamicToolsFingerprint,
+    });
+    binding = await readCodexAppServerBinding(params.data.sessionFile, agentLookup);
+    threadId = binding?.threadId;
+    if (!threadId) {
+      throw new Error("bound Codex conversation has no thread binding after dynamic tool refresh");
+    }
+  }
+  const activeBinding = binding;
+  if (!activeBinding) {
+    throw new Error("bound Codex conversation has no sidecar binding after dynamic tool refresh");
   }
 
   const client = await getSharedCodexAppServerClient({
     startOptions: runtime.start,
     timeoutMs: runtime.requestTimeoutMs,
-    authProfileId: binding.authProfileId,
+    authProfileId: activeBinding.authProfileId,
     ...agentLookup,
   });
   const collector = createCodexConversationTurnCollector(threadId);
@@ -396,15 +477,14 @@ async function runBoundTurn(params: {
   const requestCleanup = client.addRequestHandler(
     async (request): Promise<JsonValue | undefined> => {
       if (request.method === "item/tool/call") {
-        return {
-          contentItems: [
-            {
-              type: "inputText",
-              text: "OpenClaw native Codex conversation binding does not expose dynamic OpenClaw tools yet.",
-            },
-          ],
-          success: false,
-        };
+        const call = readCodexDynamicToolCallParams(request.params);
+        if (!call) {
+          return {
+            contentItems: [{ type: "inputText", text: "Invalid OpenClaw dynamic tool call." }],
+            success: false,
+          };
+        }
+        return toolBridge.handleToolCall(call, { signal: turnAbortController.signal });
       }
       if (
         request.method === "item/commandExecution/requestApproval" ||
@@ -438,16 +518,16 @@ async function runBoundTurn(params: {
           prompt: params.prompt,
           event: params.event,
         }),
-        cwd: binding.cwd || params.data.workspaceDir,
-        approvalPolicy: binding.approvalPolicy ?? runtime.approvalPolicy,
+        cwd: activeBinding.cwd || params.data.workspaceDir,
+        approvalPolicy: activeBinding.approvalPolicy ?? runtime.approvalPolicy,
         approvalsReviewer: runtime.approvalsReviewer,
         sandboxPolicy: codexSandboxPolicyForTurn(
-          binding.sandbox ?? runtime.sandbox,
-          binding.cwd || params.data.workspaceDir,
+          activeBinding.sandbox ?? runtime.sandbox,
+          activeBinding.cwd || params.data.workspaceDir,
         ),
-        ...(binding.model ? { model: binding.model } : {}),
-        ...((binding.serviceTier ?? runtime.serviceTier)
-          ? { serviceTier: binding.serviceTier ?? runtime.serviceTier }
+        ...(activeBinding.model ? { model: activeBinding.model } : {}),
+        ...((activeBinding.serviceTier ?? runtime.serviceTier)
+          ? { serviceTier: activeBinding.serviceTier ?? runtime.serviceTier }
           : {}),
       },
       { timeoutMs: runtime.requestTimeoutMs },
@@ -471,6 +551,7 @@ async function runBoundTurn(params: {
       },
     };
   } finally {
+    turnAbortController.abort("codex conversation turn finished");
     notificationCleanup();
     requestCleanup();
   }
@@ -480,7 +561,9 @@ async function runBoundTurnWithMissingThreadRecovery(params: {
   data: CodexAppServerConversationBindingData;
   prompt: string;
   event: PluginHookInboundClaimEvent;
+  ctx: PluginHookInboundClaimContext;
   pluginConfig?: unknown;
+  config?: OpenClawConfig;
   timeoutMs?: number;
 }): Promise<BoundTurnResult> {
   try {
@@ -502,9 +585,58 @@ async function runBoundTurnWithMissingThreadRecovery(params: {
       approvalPolicy: binding?.approvalPolicy,
       sandbox: binding?.sandbox,
       serviceTier: binding?.serviceTier,
+      config: params.config,
     });
     return await runBoundTurn(params);
   }
+}
+
+async function buildConversationDynamicToolBridge(params: {
+  pluginConfig?: unknown;
+  config?: OpenClawConfig;
+  workspaceDir: string;
+  agentDir?: string;
+  event?: PluginHookInboundClaimEvent;
+  ctx?: PluginHookInboundClaimContext;
+  signal?: AbortSignal;
+}): Promise<CodexDynamicToolBridge> {
+  const signal = params.signal ?? new AbortController().signal;
+  const codexConfig = readCodexPluginConfig(params.pluginConfig);
+  const { createOpenClawCodingTools } = await import("openclaw/plugin-sdk/agent-harness");
+  const allTools = createOpenClawCodingTools({
+    includeCoreTools: false,
+    config: params.config,
+    ...(params.agentDir ? { agentDir: params.agentDir } : {}),
+    workspaceDir: params.workspaceDir,
+    spawnWorkspaceDir: params.workspaceDir,
+    sessionId: params.ctx?.conversationId ?? params.event?.conversationId,
+    sessionKey: params.ctx?.sessionKey,
+    runId: params.ctx?.runId,
+    messageProvider: params.event?.channel,
+    agentAccountId: params.event?.accountId,
+    messageTo: params.event?.conversationId,
+    messageThreadId: params.event?.threadId,
+    currentChannelId: params.ctx?.channelId ?? params.event?.conversationId,
+    currentMessageId: params.event?.messageId,
+    senderId: params.event?.senderId,
+    senderName: params.event?.senderName,
+    senderUsername: params.event?.senderUsername,
+    allowGatewaySubagentBinding: true,
+    abortSignal: signal,
+  });
+  const tools = filterCodexDynamicTools(allTools as AnyAgentTool[], codexConfig);
+  return createCodexDynamicToolBridge({
+    tools,
+    signal,
+    hookContext: {
+      config: params.config,
+      sessionId: params.ctx?.conversationId ?? params.event?.conversationId,
+      sessionKey: params.ctx?.sessionKey,
+      runId: params.ctx?.runId,
+      channelId: params.ctx?.channelId ?? params.event?.conversationId,
+    },
+    loading: resolveCodexDynamicToolsLoading(codexConfig),
+  });
 }
 
 function isCodexThreadNotFoundError(error: unknown): boolean {

--- a/extensions/codex/src/conversation-binding.ts
+++ b/extensions/codex/src/conversation-binding.ts
@@ -1,4 +1,4 @@
-import { formatErrorMessage, type AnyAgentTool } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { formatErrorMessage } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type {
   PluginConversationBindingResolvedEvent,
@@ -624,7 +624,7 @@ async function buildConversationDynamicToolBridge(params: {
     allowGatewaySubagentBinding: true,
     abortSignal: signal,
   });
-  const tools = filterCodexDynamicTools(allTools as AnyAgentTool[], codexConfig);
+  const tools = filterCodexDynamicTools(allTools, codexConfig);
   return createCodexDynamicToolBridge({
     tools,
     signal,


### PR DESCRIPTION
Fixes the native Codex conversation binding so plugin-registered OpenClaw tools are projected as Codex dynamic tools and dispatched back to plugin handlers.

What changed:
- builds the OpenClaw dynamic tool bridge for native bound Codex conversations
- passes plugin dynamic tool specs into `thread/start`
- refreshes stale/missing dynamic-tool bindings when plugin tools are available
- routes matching `item/tool/call` requests through the dynamic tool bridge instead of hardcoded failure
- declines foreign-thread or foreign-turn `item/tool/call` requests so shared app-server handlers cannot cross conversation/turn boundaries
- adds regression coverage for projection, handler dispatch, legacy sidecar upgrade, and foreign request scoping

Verification:
- `corepack pnpm test extensions/codex/src/conversation-binding.test.ts`
- `corepack pnpm lint:extensions:bundled`
- `corepack pnpm tsgo:extensions:test`
- `corepack pnpm tsgo:extensions`
- `git diff --check origin/main...HEAD`
- `git diff --check`

## Real behavior proof

- Behavior or issue addressed: Native bound Codex conversations could load external OpenClaw plugin tools in the runtime registry but still expose zero callable plugin tools to the Codex session. The real user evidence was Kynver AgentOS showing 25 registered `agent_os_*` runtime tools while Codex saw zero callable `agent_os_*` tools.
- Real environment tested: Local OpenClaw checkout on branch `fix/codex-plugin-dynamic-tools`, Node v22.22.1, built OpenClaw CLI from this branch on Linux. The affected user environment is macOS, but the root issue is in the shared native Codex conversation binding code path.
- Exact steps or command run after this patch: Built the branch and ran the OpenClaw CLI from the produced checkout with `node openclaw.mjs --version`; ran the native conversation-binding regression that exercises the app-server request path, dynamic tool-call dispatch, legacy sidecar upgrade, and foreign thread/turn request scoping.
- Evidence after fix: Terminal output from the patched branch:
```sh
$ node openclaw.mjs --version
OpenClaw 2026.5.17 (f66c95a)

$ corepack pnpm test extensions/codex/src/conversation-binding.test.ts
Test Files  1 passed (1)
Tests       12 passed (12)

$ corepack pnpm lint:extensions:bundled
Found 0 warnings and 0 errors.

$ corepack pnpm tsgo:extensions:test
passed

$ corepack pnpm tsgo:extensions
passed

$ git diff --check origin/main...HEAD
passed
```
- Observed result after fix: The patched native Codex binding sends plugin dynamic tool specs during `thread/start`, dispatches matching `item/tool/call` requests through the OpenClaw dynamic tool bridge, and ignores foreign thread/turn tool-call requests.
- Additional live proof requested: A redacted Mantis Telegram live proof request was posted on the PR for a real native bound Codex conversation receiving the plugin tool catalog, invoking a plugin tool, dispatching to the plugin handler, and returning the tool result. The Mantis workflow rejected our run because `Totalsolutionsync` has read permission, not maintainer/write permission.
- What was not tested: I did not run the patched OpenClaw build on the affected macOS user machine because I do not have access to that host.
