### PR TITLE
fix(codex): hydrate queued inbound images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Codex app-server: hydrate current inbound image attachments before queued runs so Responses-backed agents receive Discord and other channel images as native vision input. Fixes #83466. Thanks @iannwu.
 - Codex app-server: preserve network access for sandboxed Codex code-mode turns when the OpenClaw sandbox allows outbound egress. Fixes #83347. Thanks @YusukeIt0.
 - QA-Lab: keep the OTLP smoke decoder independent of removed OpenTelemetry generated-root internals.
 - Messages: default group/channel visible replies to automatic final delivery again, keeping `message_tool` opt-in for ambient/shared rooms and tool-reliable models.

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1,5 +1,4 @@
 import crypto from "node:crypto";
-import type { ImageContent } from "@earendil-works/pi-ai";
 import {
   hasOutboundReplyContent,
   resolveSendableOutboundReplyParts,
@@ -95,8 +94,8 @@ import {
   resolveQueuedReplyRuntimeConfig,
   resolveModelFallbackOptions,
 } from "./agent-runner-utils.js";
-import { resolveAgentTurnAttachments } from "./agent-turn-attachments.js";
 import { type BlockReplyPipeline } from "./block-reply-pipeline.js";
+import { resolveCurrentTurnImages } from "./current-turn-images.js";
 import { resolveOriginMessageProvider } from "./origin-routing.js";
 import {
   classifyProviderRequestError,
@@ -167,80 +166,6 @@ const FALLBACK_SELECTION_STATE_KEYS = [
   "authProfileOverrideSource",
   "authProfileOverrideCompactionCount",
 ] as const satisfies ReadonlyArray<keyof FallbackSelectionState>;
-
-function countCurrentPiImageAttachmentCandidates(ctx: TemplateContext): number {
-  const pathsFromArray = Array.isArray(ctx.MediaPaths) ? ctx.MediaPaths : undefined;
-  const paths =
-    pathsFromArray && pathsFromArray.length > 0
-      ? pathsFromArray
-      : normalizeOptionalString(ctx.MediaPath)
-        ? [ctx.MediaPath]
-        : [];
-  if (paths.length === 0) {
-    return 0;
-  }
-  const types =
-    Array.isArray(ctx.MediaTypes) && ctx.MediaTypes.length === paths.length
-      ? ctx.MediaTypes
-      : undefined;
-  let count = 0;
-  for (const [index, pathValue] of paths.entries()) {
-    const mediaPath = normalizeOptionalString(pathValue);
-    const mediaType = normalizeOptionalString(types?.[index] ?? ctx.MediaType);
-    if (mediaPath && mediaType?.startsWith("image/")) {
-      count++;
-    }
-  }
-  return count;
-}
-
-async function resolveNativePiTurnImages(params: {
-  ctx: TemplateContext;
-  cfg: OpenClawConfig;
-  images?: ImageContent[];
-  imageOrder?: GetReplyOptions["imageOrder"];
-}): Promise<{
-  images?: ImageContent[];
-  imageOrder?: GetReplyOptions["imageOrder"];
-}> {
-  if (Array.isArray(params.images) && params.images.length > 0) {
-    return { images: params.images, imageOrder: params.imageOrder };
-  }
-
-  const currentImageCandidateCount = countCurrentPiImageAttachmentCandidates(params.ctx);
-  if (currentImageCandidateCount === 0) {
-    return { images: params.images, imageOrder: params.imageOrder };
-  }
-
-  try {
-    const resolved = await resolveAgentTurnAttachments({
-      ctx: params.ctx,
-      cfg: params.cfg,
-      includeRecentHistoryImages: false,
-    });
-    const images = resolved.attachments.map(
-      (attachment): ImageContent => ({
-        type: "image",
-        data: attachment.data,
-        mimeType: attachment.mediaType,
-      }),
-    );
-    if (images.length < currentImageCandidateCount) {
-      logVerbose(
-        `agent-runner: native PI media resolution produced ${images.length}/${currentImageCandidateCount} current image attachment(s); falling back to prompt image refs`,
-      );
-      return { images: params.images, imageOrder: params.imageOrder };
-    }
-    return images.length > 0
-      ? { images, imageOrder: images.map(() => "inline" as const) }
-      : { images: params.images, imageOrder: params.imageOrder };
-  } catch (error) {
-    logVerbose(
-      `agent-runner: media attachment image resolution failed, proceeding without native images: ${formatErrorMessage(error)}`,
-    );
-    return { images: params.images, imageOrder: params.imageOrder };
-  }
-}
 
 function setFallbackSelectionStateField(
   entry: SessionEntry,
@@ -1252,11 +1177,11 @@ export async function runAgentTurnWithFallback(params: {
       requesterSenderUsername: params.followupRun.run.senderUsername,
       requesterSenderE164: params.followupRun.run.senderE164,
     });
-  const nativePiTurnImages = await resolveNativePiTurnImages({
+  const currentTurnImages = await resolveCurrentTurnImages({
     ctx: params.sessionCtx,
     cfg: runtimeConfig,
-    images: params.opts?.images,
-    imageOrder: params.opts?.imageOrder,
+    images: params.followupRun.images ?? params.opts?.images,
+    imageOrder: params.followupRun.imageOrder ?? params.opts?.imageOrder,
   });
   let didNotifyAgentRunStart = false;
   const notifyAgentRunStart = () => {
@@ -1770,8 +1695,8 @@ export async function runAgentTurnWithFallback(params: {
                   bootstrapPromptWarningSignaturesSeen[
                     bootstrapPromptWarningSignaturesSeen.length - 1
                   ],
-                images: params.opts?.images,
-                imageOrder: params.opts?.imageOrder,
+                images: currentTurnImages.images,
+                imageOrder: currentTurnImages.imageOrder,
                 skillsSnapshot: params.followupRun.run.skillsSnapshot,
                 messageChannel: params.followupRun.originatingChannel ?? undefined,
                 messageProvider: hookMessageProvider,
@@ -1889,8 +1814,8 @@ export async function runAgentTurnWithFallback(params: {
                 forceHeartbeatTool: params.opts?.forceHeartbeatTool,
                 bootstrapContextMode: params.opts?.bootstrapContextMode,
                 bootstrapContextRunKind: params.opts?.isHeartbeat ? "heartbeat" : "default",
-                images: nativePiTurnImages.images,
-                imageOrder: nativePiTurnImages.imageOrder,
+                images: currentTurnImages.images,
+                imageOrder: currentTurnImages.imageOrder,
                 abortSignal: params.replyOperation?.abortSignal ?? params.opts?.abortSignal,
                 replyOperation: params.replyOperation,
                 blockReplyBreak: params.resolvedBlockStreamingBreak,

--- a/src/auto-reply/reply/current-turn-images.ts
+++ b/src/auto-reply/reply/current-turn-images.ts
@@ -1,0 +1,82 @@
+import type { ImageContent } from "@earendil-works/pi-ai";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { logVerbose } from "../../globals.js";
+import { formatErrorMessage } from "../../infra/errors.js";
+import type { PromptImageOrderEntry } from "../../media/prompt-image-order.js";
+import { normalizeOptionalString } from "../../shared/string-coerce.js";
+import type { MsgContext } from "../templating.js";
+import { resolveAgentTurnAttachments } from "./agent-turn-attachments.js";
+
+function countCurrentImageAttachmentCandidates(ctx: MsgContext): number {
+  const pathsFromArray = Array.isArray(ctx.MediaPaths) ? ctx.MediaPaths : undefined;
+  const paths =
+    pathsFromArray && pathsFromArray.length > 0
+      ? pathsFromArray
+      : normalizeOptionalString(ctx.MediaPath)
+        ? [ctx.MediaPath]
+        : [];
+  if (paths.length === 0) {
+    return 0;
+  }
+  const types =
+    Array.isArray(ctx.MediaTypes) && ctx.MediaTypes.length === paths.length
+      ? ctx.MediaTypes
+      : undefined;
+  let count = 0;
+  for (const [index, pathValue] of paths.entries()) {
+    const mediaPath = normalizeOptionalString(pathValue);
+    const mediaType = normalizeOptionalString(types?.[index] ?? ctx.MediaType);
+    if (mediaPath && mediaType?.startsWith("image/")) {
+      count++;
+    }
+  }
+  return count;
+}
+
+export async function resolveCurrentTurnImages(params: {
+  ctx: MsgContext;
+  cfg: OpenClawConfig;
+  images?: ImageContent[];
+  imageOrder?: PromptImageOrderEntry[];
+}): Promise<{
+  images?: ImageContent[];
+  imageOrder?: PromptImageOrderEntry[];
+}> {
+  if (Array.isArray(params.images) && params.images.length > 0) {
+    return { images: params.images, imageOrder: params.imageOrder };
+  }
+
+  const currentImageCandidateCount = countCurrentImageAttachmentCandidates(params.ctx);
+  if (currentImageCandidateCount === 0) {
+    return { images: params.images, imageOrder: params.imageOrder };
+  }
+
+  try {
+    const resolved = await resolveAgentTurnAttachments({
+      ctx: params.ctx,
+      cfg: params.cfg,
+      includeRecentHistoryImages: false,
+    });
+    const images = resolved.attachments.map(
+      (attachment): ImageContent => ({
+        type: "image",
+        data: attachment.data,
+        mimeType: attachment.mediaType,
+      }),
+    );
+    if (images.length < currentImageCandidateCount) {
+      logVerbose(
+        `agent-runner: native PI media resolution produced ${images.length}/${currentImageCandidateCount} current image attachment(s); falling back to prompt image refs`,
+      );
+      return { images: params.images, imageOrder: params.imageOrder };
+    }
+    return images.length > 0
+      ? { images, imageOrder: images.map(() => "inline" as const) }
+      : { images: params.images, imageOrder: params.imageOrder };
+  } catch (error) {
+    logVerbose(
+      `agent-runner: media attachment image resolution failed, proceeding without native images: ${formatErrorMessage(error)}`,
+    );
+    return { images: params.images, imageOrder: params.imageOrder };
+  }
+}

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -1,5 +1,8 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearActiveEmbeddedRun,
   setActiveEmbeddedRun,
@@ -269,6 +272,8 @@ function requireLastRunReplyAgentCall() {
 }
 
 describe("runPreparedReply media-only handling", () => {
+  const cleanupPaths: string[] = [];
+
   beforeAll(async () => {
     ({ runPreparedReply } = await import("./get-reply-run.js"));
     ({ runReplyAgent } = await import("./agent-runner.runtime.js"));
@@ -287,6 +292,11 @@ describe("runPreparedReply media-only handling", () => {
     updateSessionStore.mockReset();
     vi.clearAllMocks();
     replyRunTesting.resetReplyRunRegistry();
+  });
+
+  afterEach(() => {
+    const paths = cleanupPaths.splice(0);
+    return Promise.all(paths.map((entry) => rm(entry, { recursive: true, force: true })));
   });
 
   it("does not load session store runtime on module import", async () => {
@@ -868,6 +878,59 @@ describe("runPreparedReply media-only handling", () => {
     const call = requireRunReplyAgentCall();
     expect(call?.followupRun.currentInboundContext?.text).toContain("webchat:local");
     expect(call?.followupRun.prompt).toContain("[User sent media without caption]");
+  });
+
+  it("hydrates current MediaPaths into queued followup images", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "openclaw-followup-image-"));
+    cleanupPaths.push(tmpDir);
+    const imagePath = path.join(tmpDir, "inbound.png");
+    await writeFile(
+      imagePath,
+      Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+        "base64",
+      ),
+    );
+
+    const result = await runPreparedReply(
+      baseParams({
+        ctx: {
+          Body: "describe this",
+          RawBody: "describe this",
+          CommandBody: "describe this",
+          MediaPaths: [imagePath],
+          MediaTypes: ["image/png"],
+          MediaWorkspaceDir: tmpDir,
+          OriginatingChannel: "discord",
+          OriginatingTo: "C123",
+          ChatType: "group",
+        },
+        sessionCtx: {
+          Body: "describe this",
+          BodyStripped: "describe this",
+          Provider: "discord",
+          OriginatingChannel: "discord",
+          OriginatingTo: "C123",
+          ChatType: "group",
+          MediaPaths: [imagePath],
+          MediaTypes: ["image/png"],
+          MediaWorkspaceDir: tmpDir,
+        },
+      }),
+    );
+
+    expect(result).toEqual({ text: "ok" });
+    expect(vi.mocked(runReplyAgent)).toHaveBeenCalledOnce();
+    const call = requireRunReplyAgentCall();
+    expect(call.followupRun.images).toEqual([
+      {
+        type: "image",
+        data: expect.any(String),
+        mimeType: "image/png",
+      },
+    ]);
+    expect(call.followupRun.images?.[0]?.data).toHaveLength(92);
+    expect(call.followupRun.imageOrder).toEqual(["inline"]);
   });
 
   it("does not send a standalone reset notice for reply-producing /new turns", async () => {

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -54,6 +54,7 @@ import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { applySessionHints } from "./body.js";
 import type { buildCommandContext } from "./commands.js";
+import { resolveCurrentTurnImages } from "./current-turn-images.js";
 import type { InlineDirectives } from "./directive-handling.js";
 import { isSystemEventProvider } from "./effective-reply-route.js";
 import { shouldUseReplyFastTestRuntime } from "./get-reply-fast-path.js";
@@ -1035,6 +1036,14 @@ export async function runPreparedReply(
     ctx,
     sessionKey,
   });
+  const currentTurnImages = await traceRunPhase("reply.resolve_current_turn_images", () =>
+    resolveCurrentTurnImages({
+      ctx,
+      cfg,
+      images: opts?.images,
+      imageOrder: opts?.imageOrder,
+    }),
+  );
   const followupRun = {
     prompt: queuedBody,
     transcriptPrompt: transcriptCommandBody,
@@ -1046,8 +1055,8 @@ export async function runPreparedReply(
     messageId: sessionCtx.MessageSidFull ?? sessionCtx.MessageSid,
     summaryLine: baseBodyTrimmedRaw,
     enqueuedAt: Date.now(),
-    images: opts?.images,
-    imageOrder: opts?.imageOrder,
+    images: currentTurnImages.images,
+    imageOrder: currentTurnImages.imageOrder,
     // Originating channel for reply routing.
     originatingChannel: ctx.OriginatingChannel,
     originatingTo: ctx.OriginatingTo,


### PR DESCRIPTION
## Summary
- Extract shared current-turn image hydration for native PI and Codex app-server runs.
- Hydrate `MediaPath` / `MediaPaths` into queued followup `images` while the inbound context is still available.
- Keep direct run paths on the same helper and add regression coverage for queued image handoff.

Fixes #83466

## Verification
- `node scripts/run-vitest.mjs src/auto-reply/reply/get-reply-run.media-only.test.ts src/auto-reply/reply/agent-runner.media-paths.test.ts src/auto-reply/reply/followup-runner.test.ts extensions/codex/src/app-server/thread-lifecycle.test.ts extensions/codex/src/app-server/run-attempt.vision-tools.test.ts`
- `git diff --check origin/main...HEAD`
- `.agents/skills/autoreview/scripts/autoreview --mode local` (helper hit a Codex CLI argument incompatibility and fell back to `claude -p`; clean: no accepted/actionable findings)

## Real behavior proof
Behavior addressed: current inbound image attachments from channel `MediaPath` / `MediaPaths` reach Responses-backed Codex app-server/native PI runs as structured image input, including queued followups.
Real environment tested: local focused OpenClaw test harness with real temp PNG attachment bytes and Codex app-server serialization tests.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/auto-reply/reply/get-reply-run.media-only.test.ts src/auto-reply/reply/agent-runner.media-paths.test.ts src/auto-reply/reply/followup-runner.test.ts extensions/codex/src/app-server/thread-lifecycle.test.ts extensions/codex/src/app-server/run-attempt.vision-tools.test.ts`
Evidence after fix: `get-reply-run.media-only.test.ts` asserts `followupRun.images` contains a native image and `imageOrder: ["inline"]`; Codex app-server tests assert `params.images` serializes into `turn/start.input`.
Observed result after fix: 5 focused test files passed, 149 tests passed.
What was not tested: live Discord-to-OpenAI Responses turn; this PR proves the source-level handoff and app-server serialization path.
