### PR TITLE
docs: replace British 'behaviour' with American 'behavior'

### DIFF
--- a/docs/plugins/voice-call.md
+++ b/docs/plugins/voice-call.md
@@ -175,7 +175,7 @@ Voice-call credentials accept SecretRefs. `plugins.entries.voice-call.config.twi
     - `skipSignatureVerification` is for local testing only.
     - On ngrok free tier, set `publicUrl` to the exact ngrok URL; signature verification is always enforced.
     - `tunnel.allowNgrokFreeTierLoopbackBypass: true` allows Twilio webhooks with invalid signatures **only** when `tunnel.provider="ngrok"` and `serve.bind` is loopback (ngrok local agent). Local dev only.
-    - Ngrok free-tier URLs can change or add interstitial behaviour; if `publicUrl` drifts, Twilio signatures fail. Production: prefer a stable domain or a Tailscale funnel.
+    - Ngrok free-tier URLs can change or add interstitial behavior; if `publicUrl` drifts, Twilio signatures fail. Production: prefer a stable domain or a Tailscale funnel.
 
   </Accordion>
   <Accordion title="Streaming connection caps">
@@ -222,7 +222,7 @@ realtime transcription providers.
 audio mode per call.
 </Warning>
 
-Current runtime behaviour:
+Current runtime behavior:
 
 - `realtime.enabled` is supported for Twilio Media Streams.
 - `realtime.provider` is optional. If unset, Voice Call uses the first registered realtime voice provider.

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -527,7 +527,7 @@ Two ways to start an ACP session:
 </ParamField>
 <ParamField path="mode" type='"run" | "session"' default="run">
   `"run"` is one-shot; `"session"` is persistent. If `thread: true` and
-  `mode` is omitted, OpenClaw may default to persistent behaviour per
+  `mode` is omitted, OpenClaw may default to persistent behavior per
   runtime path. `mode: "session"` requires `thread: true`.
 </ParamField>
 <ParamField path="cwd" type="string">


### PR DESCRIPTION
## Summary

Problem: Three remaining instances of British "behaviour" in the docs violate the project's American English requirement.
Why it matters: `CONTRIBUTING.md` explicitly states "Use American English spelling and grammar in code, comments, docs, and UI strings."
What changed: Replaced "behaviour" with "behavior" in 3 prose locations across 2 files.
What did NOT change: No code, no tests, no runtime paths, no API string literals (e.g. the `"cancelled"` status enum, which appears 32 times and is intentionally kept British because it matches API contract values, is untouched).

## Change Type

- [x] Docs

## Scope

- [x] UI / DX

## Linked Issue/PR

N/A

## Real behavior proof

Behavior or issue addressed: Three docs strings used British "behaviour" instead of the project's standard American "behavior" (845 occurrences of "behavior" vs 3 of "behaviour" in `docs/` before this patch).

Real environment tested: Local clone of `openclaw/openclaw` at current `main`, on macOS (zsh terminal).

Exact steps or command run after this patch: Ran `grep -rn "behaviour" docs/` in the repo root after applying the patch, then ran `git diff main --stat` to confirm exactly 3 line changes across 2 files.

Evidence after fix: Terminal capture below shows the live console output after the patch. The `grep` returns zero matches, and `git diff --stat` confirms the scope: 2 files changed, 3 insertions, 3 deletions. Screenshot of the terminal session attached.

<img width="1708" height="418" alt="image" src="https://github.com/user-attachments/assets/cb2d4a12-751b-4a5b-a236-9c114d272caf" />


Observed result after fix: `grep -rn "behaviour" docs/` returns no matches. `git diff main --stat` reports `2 files changed, 3 insertions(+), 3 deletions(-)`. All three outliers replaced; both affected files already use "behavior" elsewhere, confirming internal consistency.

What was not tested: None. This is a markdown text-only change with no runtime, build, rendering, or API surface impact, so there is no behavioral path to exercise.

Before evidence: Before the patch, `grep -rn "behaviour" docs/` returned three matches: `docs/tools/acp-agents.md:530`, `docs/plugins/voice-call.md:178`, and `docs/plugins/voice-call.md:225`, all in prose (not code, not API literals).

## Root Cause

N/A (docs-only spelling fix, not a regression).

## Regression Test Plan

N/A.

## User-visible / Behavior Changes

None.

## Diagram

N/A

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

Environment:
- OS: macOS
- Runtime/container: N/A
- Model/provider: N/A
- Integration/channel: N/A

Steps: Apply patch, run `grep -rn "behaviour" docs/` from repo root.
Expected: Zero matches.
Actual: Zero matches.

## Human Verification

Verified scenarios: Manually inspected each of the 3 modified locations in context via `git diff`. Confirmed each occurrence is in prose (not code blocks, not API string literals, not status enum values). Confirmed both affected files already use "behavior" elsewhere.

Edge cases checked: Verified that `"cancelled"` (which appears 32 times in docs) is intentionally kept British because it matches API status enum literals. Those were left untouched. Confirmed no other British English outliers exist in `docs/`, README, CONTRIBUTING, AGENTS, VISION, SECURITY, CLAUDE, skills/, extensions/, packages/, apps/ via a comprehensive scan.

What was not verified: N/A for a text-only docs change.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

None.

AI-assisted: yes. I reviewed and verified the change manually.

Local Codex review:
- Command: `codex review --base origin/main`
- Result: no actionable regressions.
- Summary: The diff only updates British spellings to American English in documentation and does not alter documented behavior, links, or code paths.
