### PR TITLE
codex: log app-server startup close diagnostics

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -608,6 +608,63 @@ describe("runCodexAppServerAttempt", () => {
     await fs.rm(tempDir, { recursive: true, force: true });
   });
 
+  it("includes launch context in app-server startup close diagnostics", () => {
+    const diagnostics = __testing.buildCodexAppServerStartupCloseDiagnostics({
+      params: {
+        ...createParams(path.join(tempDir, "session.jsonl"), path.join(tempDir, "workspace")),
+        agentId: "eva",
+        authProfileId: "codex-oauth",
+        runtimePlan: {
+          ...createCodexRuntimePlanFixture(),
+          observability: {
+            resolvedRef: "openai-codex/gpt-5.5",
+            provider: "openai-codex",
+            modelId: "gpt-5.5",
+            harnessId: "codex",
+          },
+        },
+      },
+      attempt: 3,
+      maxAttempts: 3,
+      nextAttempt: undefined,
+      clearedSharedClient: true,
+      error: new Error("codex app-server exited: code=1 signal=null"),
+      startupAuthProfileId: "codex-oauth-resolved",
+      sessionAgentId: "eva",
+      effectiveWorkspace: path.join(tempDir, "sandbox"),
+      sandboxSessionKey: "eva:dm:session-1",
+      startupBinding: {
+        threadId: "thread-existing",
+        cwd: path.join(tempDir, "workspace"),
+        model: "gpt-5.4-codex",
+      },
+    });
+
+    expect(diagnostics).toMatchObject({
+      attempt: 3,
+      maxAttempts: 3,
+      clearedSharedClient: true,
+      error: "codex app-server exited: code=1 signal=null",
+      runId: "run-1",
+      sessionId: "session-1",
+      sessionKey: "agent:main:session-1",
+      sandboxSessionKey: "eva:dm:session-1",
+      sessionAgentId: "eva",
+      agentId: "eva",
+      provider: "codex",
+      modelId: "gpt-5.4-codex",
+      resolvedRef: "openai-codex/gpt-5.5",
+      resolvedProvider: "openai-codex",
+      resolvedModelId: "gpt-5.5",
+      harnessId: "codex",
+      authProfileId: "codex-oauth-resolved",
+      requestedAuthProfileId: "codex-oauth",
+      previousThreadId: "thread-existing",
+      previousThreadModel: "gpt-5.4-codex",
+    });
+    expect(diagnostics.effectiveWorkspace).toContain("sandbox");
+  });
+
   it("filters Codex-native dynamic tools from app-server tool exposure", () => {
     const tools = [
       "read",

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -743,6 +743,63 @@ async function rotateOversizedCodexAppServerStartupBinding(params: {
   return binding;
 }
 
+export type CodexAppServerStartupCloseDiagnosticsParams = {
+  params: EmbeddedRunAttemptParams;
+  attempt: number;
+  maxAttempts: number;
+  nextAttempt?: number;
+  clearedSharedClient: boolean;
+  error: unknown;
+  startupAuthProfileId?: string;
+  sessionAgentId?: string;
+  effectiveWorkspace: string;
+  sandboxSessionKey: string;
+  startupBinding?: CodexAppServerThreadBinding;
+};
+
+function buildCodexAppServerStartupCloseDiagnostics({
+  params,
+  attempt,
+  maxAttempts,
+  nextAttempt,
+  clearedSharedClient,
+  error,
+  startupAuthProfileId,
+  sessionAgentId,
+  effectiveWorkspace,
+  sandboxSessionKey,
+  startupBinding,
+}: CodexAppServerStartupCloseDiagnosticsParams): Record<string, unknown> {
+  const observability = params.runtimePlan?.observability;
+  return {
+    attempt,
+    ...(nextAttempt ? { nextAttempt } : {}),
+    maxAttempts,
+    clearedSharedClient,
+    error: formatErrorMessage(error),
+    runId: params.runId,
+    sessionId: params.sessionId,
+    sessionKey: params.sessionKey,
+    sandboxSessionKey,
+    ...(sessionAgentId ? { sessionAgentId } : {}),
+    ...(params.agentId ? { agentId: params.agentId } : {}),
+    provider: params.provider,
+    modelId: params.modelId,
+    ...(observability?.resolvedRef ? { resolvedRef: observability.resolvedRef } : {}),
+    ...(observability?.provider ? { resolvedProvider: observability.provider } : {}),
+    ...(observability?.modelId ? { resolvedModelId: observability.modelId } : {}),
+    ...(observability?.harnessId ? { harnessId: observability.harnessId } : {}),
+    ...(startupAuthProfileId ? { authProfileId: startupAuthProfileId } : {}),
+    ...(params.authProfileId ? { requestedAuthProfileId: params.authProfileId } : {}),
+    workspaceDir: params.workspaceDir,
+    effectiveWorkspace,
+    sessionFile: params.sessionFile,
+    ...(startupBinding?.threadId ? { previousThreadId: startupBinding.threadId } : {}),
+    ...(startupBinding?.model ? { previousThreadModel: startupBinding.model } : {}),
+    ...(startupBinding?.cwd ? { previousThreadCwd: startupBinding.cwd } : {}),
+  };
+}
+
 export async function runCodexAppServerAttempt(
   params: EmbeddedRunAttemptParams,
   options: {
@@ -1278,24 +1335,36 @@ export async function runCodexAppServerAttempt(
             if (attempt >= CODEX_APP_SERVER_STARTUP_CONNECTION_CLOSE_MAX_ATTEMPTS) {
               embeddedAgentLog.warn(
                 "codex app-server connection closed during startup; retries exhausted",
-                {
+                buildCodexAppServerStartupCloseDiagnostics({
+                  params,
                   attempt,
                   maxAttempts: CODEX_APP_SERVER_STARTUP_CONNECTION_CLOSE_MAX_ATTEMPTS,
                   clearedSharedClient,
-                  error: formatErrorMessage(error),
-                },
+                  error,
+                  startupAuthProfileId,
+                  sessionAgentId,
+                  effectiveWorkspace,
+                  sandboxSessionKey,
+                  startupBinding,
+                }),
               );
               throw error;
             }
             embeddedAgentLog.warn(
               "codex app-server connection closed during startup; restarting app-server and retrying",
-              {
+              buildCodexAppServerStartupCloseDiagnostics({
+                params,
                 attempt,
                 nextAttempt: attempt + 1,
                 maxAttempts: CODEX_APP_SERVER_STARTUP_CONNECTION_CLOSE_MAX_ATTEMPTS,
                 clearedSharedClient,
-                error: formatErrorMessage(error),
-              },
+                error,
+                startupAuthProfileId,
+                sessionAgentId,
+                effectiveWorkspace,
+                sandboxSessionKey,
+                startupBinding,
+              }),
             );
           }
         }
@@ -4296,6 +4365,7 @@ export const __testing = {
   rotateOversizedCodexAppServerStartupBinding,
   resolveCodexAppServerSandboxPolicyForOpenClawSandbox,
   resolveCodexAppServerForOpenClawToolPolicy,
+  buildCodexAppServerStartupCloseDiagnostics,
   resolveOpenClawCodingToolsSessionKeys,
   shouldEnableCodexAppServerNativeToolSurface,
   shouldForceMessageTool,


### PR DESCRIPTION
## Summary
- Add a structured diagnostic payload for Codex app-server startup-close retry/exhaustion logs.
- Include run/session/model/auth/workspace/thread context so startup exits can be diagnosed without guessing which agent/model/session launched the app-server.
- Add regression coverage for the diagnostic payload.

## Test Plan
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts -t "includes launch context in app-server startup close diagnostics"`
- `node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts`
- `git diff --check`
