### PR TITLE
fix: tighten memory wiki link lint

### DIFF
--- a/extensions/memory-wiki/src/lint.test.ts
+++ b/extensions/memory-wiki/src/lint.test.ts
@@ -8,6 +8,87 @@ import { createMemoryWikiTestHarness } from "./test-helpers.js";
 const { createVault } = createMemoryWikiTestHarness();
 
 describe("lintMemoryWikiVault", () => {
+  it("ignores literal wikilink syntax inside markdown code and comments", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-lint-markdown-aware-links-",
+      config: {
+        vault: { renderMode: "obsidian" },
+      },
+    });
+    await fs.mkdir(path.join(rootDir, "sources"), { recursive: true });
+
+    await fs.writeFile(
+      path.join(rootDir, "sources", "transcript.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.transcript",
+          title: "Transcript",
+        },
+        body: [
+          "# Transcript",
+          "",
+          "Inline code `[[reply_to_current]]` is not a wiki link.",
+          "<!-- [[hidden-comment-target]] -->",
+          "```",
+          "assistant: [[reply_to:abc123]]",
+          "```",
+          "~~~text",
+          "[[tts:text]]",
+          "~~~",
+        ].join("\n"),
+      }),
+      "utf8",
+    );
+
+    const result = await lintMemoryWikiVault(config);
+
+    expect(result.issues.map((issue) => issue.code)).not.toContain("broken-wikilink");
+  });
+
+  it("accepts obsidian wikilinks that target page titles or aliases", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-lint-title-links-",
+      config: {
+        vault: { renderMode: "obsidian" },
+      },
+    });
+    await Promise.all(
+      ["entities", "sources"].map((dir) => fs.mkdir(path.join(rootDir, dir), { recursive: true })),
+    );
+
+    await fs.writeFile(
+      path.join(rootDir, "sources", "codex-harness-plugin-配置清单.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.codex-harness",
+          title: "Codex harness plugin 配置清单",
+          aliases: ["OpenClaw × Claude Code × Codex 共享 Memory 方案"],
+        },
+        body: "# Codex harness plugin 配置清单\n",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(rootDir, "entities", "reference.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "entity",
+          id: "entity.reference",
+          title: "Reference",
+          sourceIds: ["source.codex-harness"],
+        },
+        body: "# Reference\n\n[[Codex harness plugin 配置清单]]\n[[OpenClaw × Claude Code × Codex 共享 Memory 方案]]\n",
+      }),
+      "utf8",
+    );
+
+    const result = await lintMemoryWikiVault(config);
+
+    expect(result.issues.map((issue) => issue.code)).not.toContain("broken-wikilink");
+  });
+
   it("accepts native markdown links that include the relative .md target", async () => {
     const { rootDir, config } = await createVault({
       prefix: "memory-wiki-lint-native-links-",

--- a/extensions/memory-wiki/src/lint.ts
+++ b/extensions/memory-wiki/src/lint.ts
@@ -12,7 +12,7 @@ import {
 import { compileMemoryWikiVault } from "./compile.js";
 import type { ResolvedMemoryWikiConfig } from "./config.js";
 import { appendMemoryWikiLog } from "./log.js";
-import { renderWikiMarkdown, type WikiPageSummary } from "./markdown.js";
+import { renderWikiMarkdown, slugifyWikiSegment, type WikiPageSummary } from "./markdown.js";
 
 type MemoryWikiLintIssue = {
   severity: "error" | "warning";
@@ -50,19 +50,43 @@ function toExpectedPageType(page: WikiPageSummary): string {
   return page.kind;
 }
 
+function normalizeLinkTarget(value: string): string {
+  return value
+    .normalize("NFKC")
+    .trim()
+    .replace(/[\u2010-\u2015]/g, "-")
+    .replace(/\s+/g, " ")
+    .toLowerCase();
+}
+
+function addValidLinkTarget(validTargets: Set<string>, target: string | undefined): void {
+  const trimmed = target?.trim();
+  if (!trimmed) {
+    return;
+  }
+  validTargets.add(trimmed);
+  validTargets.add(normalizeLinkTarget(trimmed));
+}
+
 function collectBrokenLinkIssues(pages: WikiPageSummary[]): MemoryWikiLintIssue[] {
   const validTargets = new Set<string>();
   for (const page of pages) {
     const withoutExtension = page.relativePath.replace(/\.md$/i, "");
-    validTargets.add(page.relativePath);
-    validTargets.add(withoutExtension);
-    validTargets.add(path.basename(withoutExtension));
+    addValidLinkTarget(validTargets, page.relativePath);
+    addValidLinkTarget(validTargets, withoutExtension);
+    addValidLinkTarget(validTargets, path.basename(withoutExtension));
+    addValidLinkTarget(validTargets, page.title);
+    addValidLinkTarget(validTargets, slugifyWikiSegment(page.title));
+    for (const alias of page.aliases) {
+      addValidLinkTarget(validTargets, alias);
+      addValidLinkTarget(validTargets, slugifyWikiSegment(alias));
+    }
   }
 
   const issues: MemoryWikiLintIssue[] = [];
   for (const page of pages) {
     for (const linkTarget of page.linkTargets) {
-      if (!validTargets.has(linkTarget)) {
+      if (!validTargets.has(linkTarget) && !validTargets.has(normalizeLinkTarget(linkTarget))) {
         issues.push({
           severity: "warning",
           category: "links",

--- a/extensions/memory-wiki/src/markdown.ts
+++ b/extensions/memory-wiki/src/markdown.ts
@@ -107,6 +107,9 @@ const RELATED_BLOCK_PATTERN = new RegExp(
   `${WIKI_RELATED_START_MARKER}[\\s\\S]*?${WIKI_RELATED_END_MARKER}`,
   "g",
 );
+const FENCED_CODE_BLOCK_PATTERN = /(^|\n)(```|~~~)[^\n]*\n[\s\S]*?(?:\n\2(?=\n|$)|$)/g;
+const INLINE_CODE_PATTERN = /`[^`\n]*(?:`|$)/g;
+const HTML_COMMENT_PATTERN = /<!--[\s\S]*?-->/g;
 const MAX_WIKI_SEGMENT_BYTES = 240;
 const MAX_WIKI_FILENAME_COMPONENT_BYTES = 255;
 const FS_SAFE_PINNED_WRITE_TEMP_SUFFIX = ".00000000-0000-4000-8000-000000000000.fallback.tmp";
@@ -371,7 +374,12 @@ function normalizeWikiRelationships(value: unknown): WikiRelationship[] {
 }
 
 function extractWikiLinks(markdown: string): string[] {
-  const searchable = markdown.replace(RELATED_BLOCK_PATTERN, "");
+  const searchable = markdown
+    .replace(FRONTMATTER_PATTERN, "")
+    .replace(RELATED_BLOCK_PATTERN, "")
+    .replace(FENCED_CODE_BLOCK_PATTERN, "")
+    .replace(INLINE_CODE_PATTERN, "")
+    .replace(HTML_COMMENT_PATTERN, "");
   const links: string[] = [];
   for (const match of searchable.matchAll(OBSIDIAN_LINK_PATTERN)) {
     const target = match[1]?.trim();


### PR DESCRIPTION
## Summary
- Make memory wiki lint ignore wikilink-shaped text inside YAML frontmatter, fenced code blocks, inline code, and HTML comments.
- Resolve Obsidian wikilinks by page title, aliases, and their slugified/normalized forms in addition to file paths.
- Add regression coverage for transcript directive literals and natural-title wikilinks.

## Tests
- `node --no-maglev node_modules/vitest/vitest.mjs run extensions/memory-wiki/src/lint.test.ts` (RED before fix: 2 failures; GREEN after fix: 4 passed)
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/memory-wiki/src/lint.test.ts`
- `node_modules/oxfmt/bin/oxfmt --check --threads=1 extensions/memory-wiki/src/lint.ts extensions/memory-wiki/src/markdown.ts extensions/memory-wiki/src/lint.test.ts`
- `node_modules/oxlint/bin/oxlint extensions/memory-wiki/src/lint.ts extensions/memory-wiki/src/markdown.ts extensions/memory-wiki/src/lint.test.ts`
- `git diff --check`

## Real behavior proof
Behavior addressed: `openclaw wiki lint` no longer reports broken wikilinks for literal directive syntax in code/comment markdown, and accepts natural-title/alias wikilinks for indexed pages.
Real environment tested: local macOS checkout with a temporary real memory-wiki vault initialized through the memory-wiki runtime, containing on-disk `sources/` and `concepts/` pages with frontmatter titles, aliases, inline code, HTML comments, and fenced bash transcript content.
Exact steps or command run after this patch: `node --import tsx - <<'JS' ... initializeMemoryWikiVault(config); lintMemoryWikiVault(config); ... JS`
Evidence after fix: copied output from the real temporary vault run:

```text
{
  "issueCount": 3,
  "reportPath": "reports/lint.md",
  "vaultEntries": [
    ".openclaw-wiki",
    "AGENTS.md",
    "WIKI.md",
    "_attachments",
    "_views",
    "concepts",
    "entities",
    "inbox.md",
    "index.md",
    "reports",
    "sources",
    "syntheses"
  ]
}
broken-wikilink present: false
false-positive tokens present: none
```

Observed result after fix: the lint report contains no `broken-wikilink` entries for `[[inline-not-a-link]]`, `[[comment-not-a-link]]`, `[[reply_to_current]]`, `[[Codex harness plugin 配置清单]]`, or `[[Harness 配置]]`; unrelated generated vault-health lint issues remain outside this fix scope.
What was not tested: full repository test suite; local `pnpm openclaw`/`pnpm` entrypoints attempted dependency reconciliation and timed out on registry downloads, so verification used repo wrapper/direct binary commands that avoid dependency mutation.

Fixes #70986
