### PR TITLE
fix(status): use latest-turn usage (not aggregate) for Context % (#83526)

### DIFF
--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -12,6 +12,7 @@ import {
   readLastMessagePreviewFromTranscript,
   readLatestSessionUsageFromTranscript,
   readLatestSessionUsageFromTranscriptAsync,
+  readLatestRecentSessionUsageFromTranscript,
   readLatestRecentSessionUsageFromTranscriptAsync,
   readRecentSessionUsageFromTranscriptAsync,
   readRecentSessionUsageFromTranscript,
@@ -1041,6 +1042,38 @@ describe("readSessionMessages", () => {
       inputTokens: 42,
       outputTokens: 7,
     });
+  });
+
+  test("sync readLatestRecentSessionUsageFromTranscript returns latest turn only (#83526)", () => {
+    // Mirror of the async latest test. The Context % display in status-message
+    // uses the SYNC entrypoint and was previously calling the aggregate
+    // variant, producing `2.3m/1.0m (228%)` from cumulative cache reads.
+    const sessionId = "test-session-sync-latest-recent-usage-83526";
+    writeTranscript(tmpDir, sessionId, [
+      { type: "session", version: 1, id: sessionId },
+      { message: { role: "assistant", content: "older", usage: { input: 50, output: 5 } } },
+      { message: { role: "assistant", content: "latest", usage: { input: 70, output: 9 } } },
+    ]);
+
+    const aggregate = readRecentSessionUsageFromTranscript(
+      sessionId,
+      storePath,
+      undefined,
+      undefined,
+      2048,
+    );
+    const latest = readLatestRecentSessionUsageFromTranscript(
+      sessionId,
+      storePath,
+      undefined,
+      undefined,
+      2048,
+    );
+
+    // Aggregate sums the two turns (50+70 in, 5+9 out).
+    expectUsageFields(aggregate, { inputTokens: 120, outputTokens: 14 });
+    // Latest returns the last turn only — this is what Context % must use.
+    expectUsageFields(latest, { inputTokens: 70, outputTokens: 9 });
   });
 
   test("reads latest recent session usage separately from tail aggregates", async () => {

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -1577,6 +1577,52 @@ export function readRecentSessionUsageFromTranscript(
   });
 }
 
+/**
+ * Sync companion to {@link readLatestRecentSessionUsageFromTranscriptAsync}.
+ *
+ * Returns the LATEST per-turn usage snapshot from the session transcript,
+ * not the aggregate-across-turns sum. Used by `Context %` displays where
+ * cumulative cache-read tokens were producing nonsensical percentages
+ * like `2.3m/1.0m (228%)` even with `Compactions: 0` (#83526).
+ *
+ * Note: there is also a longer-named `readLatestSessionUsageFromTranscript`
+ * (line ~1442) but it currently calls the aggregate extractor — keep this
+ * sibling separate to avoid silently changing that function's existing
+ * contract for its other callers.
+ */
+export function readLatestRecentSessionUsageFromTranscript(
+  sessionId: string,
+  storePath: string | undefined,
+  sessionFile: string | undefined,
+  agentId: string | undefined,
+  maxBytes: number,
+): SessionTranscriptUsageSnapshot | null {
+  const filePath = findExistingTranscriptPath(sessionId, storePath, sessionFile, agentId);
+  if (!filePath) {
+    return null;
+  }
+
+  return withOpenTranscriptFd(filePath, (fd) => {
+    const stat = fs.fstatSync(fd);
+    if (stat.size === 0) {
+      return null;
+    }
+    const readLen = Math.min(stat.size, Math.max(1024, Math.floor(maxBytes)));
+    const readStart = Math.max(0, stat.size - readLen);
+    const buf = Buffer.alloc(readLen);
+    const bytesRead = fs.readSync(fd, buf, 0, readLen, readStart);
+    if (bytesRead <= 0) {
+      return null;
+    }
+    const lines = buf
+      .toString("utf-8", 0, bytesRead)
+      .split(/\r?\n/)
+      .slice(readStart > 0 ? 1 : 0)
+      .filter((line) => line.trim().length > 0);
+    return extractLatestUsageFromTranscriptLines(lines);
+  });
+}
+
 const PREVIEW_READ_SIZES = [64 * 1024, 256 * 1024, 1024 * 1024];
 const PREVIEW_MAX_LINES = 200;
 

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -107,6 +107,7 @@ export {
   readFirstUserMessageFromTranscript,
   readLastMessagePreviewFromTranscript,
   readLatestSessionUsageFromTranscriptAsync,
+  readLatestRecentSessionUsageFromTranscript,
   readLatestRecentSessionUsageFromTranscriptAsync,
   readRecentSessionUsageFromTranscriptAsync,
   readRecentSessionMessagesAsync,

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -33,7 +33,7 @@ import {
   type SessionScope,
 } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { readRecentSessionUsageFromTranscript } from "../gateway/session-utils.fs.js";
+import { readLatestRecentSessionUsageFromTranscript } from "../gateway/session-utils.fs.js";
 import { formatTimeAgo } from "../infra/format-time/format-relative.ts";
 import { resolveCommitHash } from "../infra/git-commit.js";
 import {
@@ -281,7 +281,14 @@ const readUsageFromSessionLog = (
   }
 
   try {
-    const snapshot = readRecentSessionUsageFromTranscript(
+    // #83526: use the latest-turn snapshot (not aggregate-across-turns) so
+    // the Context % display reflects the current request's prompt size
+    // rather than cumulative cache reads. The aggregate variant produced
+    // nonsensical percentages like `2.3m/1.0m (228%)` with `Compactions:
+    // 0` because it summed cacheRead across the whole session.
+    // `readRecentSessionUsageFromTranscript` (aggregate) is kept for the
+    // other callers that legitimately want cumulative tokens.
+    const snapshot = readLatestRecentSessionUsageFromTranscript(
       sessionId,
       storePath,
       sessionEntry?.sessionFile,


### PR DESCRIPTION
Fixes #83526.

The `📚 Context` line in TUI / `/status` output reported cumulative session token usage divided by the model's context window, producing nonsensical percentages like `2.3m/1.0m (228%)` even with `Compactions: 0` and no actual context overflow. Same root cause as #55217 (closed for Web UI) — the fix didn't propagate to the `status-message-*.js` path used by TUI and channel status cards.

Root cause path:

- `src/status/status-message.ts:284` called the **sync** entrypoint `readRecentSessionUsageFromTranscript`.
- That sync entrypoint routes through `extractAggregateUsageFromTranscriptChunk`, which **sums** `inputTokens` / `cacheRead` / `cacheWrite` across all tail lines.
- The prompt-tokens fallback at `status-message.ts:602` (`logUsage.promptTokens || logUsage.total`) then divided that cumulative sum by the model's context window.

## Changes

- `src/gateway/session-utils.fs.ts`: add `readLatestRecentSessionUsageFromTranscript` (sync) as a sibling to the existing async `readLatestRecentSessionUsageFromTranscriptAsync`. Routes through `extractLatestUsageFromTranscriptLines` so the returned snapshot reflects only the most recent transcript turn. 12-line comment block referencing #83526 and the misnamed `readLatestSessionUsageFromTranscript` sibling that confusingly aggregates.
- `src/gateway/session-utils.ts`: re-export the new sync function.
- `src/status/status-message.ts`: switch the transcript-usage reader to the latest variant. 7-line comment block referencing #83526. Drop the aggregate-import alias (no remaining caller in this file). The aggregate function `readRecentSessionUsageFromTranscript` is unchanged for its other production callers (`src/gateway/session-utils.ts:703`) that legitimately want cumulative tokens.
- `src/gateway/session-utils.fs.test.ts`: 1 new regression case mirroring the existing async-latest test. Asserts a two-turn transcript yields `aggregate.inputTokens=120/outputTokens=14` and `latest.inputTokens=70/outputTokens=9`.

## Real behavior proof

- **Behavior or issue addressed:** TUI/`status` `📚 Context` showed `2.3m/1.0m (228%)` etc. with `Compactions: 0` because the cumulative cache-read total was used in the numerator instead of the current request's prompt size.

- **Real environment tested:** Local Node 22.x. Probe at `/tmp/probe_83526.mjs` builds a realistic 100-turn transcript file on disk (each turn: input=16, output=5100, cacheRead=23000, cacheWrite=110 — matching the issue's example numbers) and runs both the aggregate and latest extractors verbatim. Reproduces the 228%-class symptom exactly, then verifies the latest variant returns the sensible single-turn shape.

- **Exact steps or command run after this patch:** `node /tmp/probe_83526.mjs`

- **Evidence after fix:**

```
=== Aggregate (current buggy behavior) ===
  inputTokens: 1616
  cacheRead:   2323000
  cacheWrite:  11110
  Context % :  234%   <-- nonsensical, issue's "228%" pattern

=== Latest (post-fix behavior) ===
  inputTokens: 16
  cacheRead:   23000
  cacheWrite:  110
  Context % :  2%   <-- sensible: current request prompt

PASS: aggregate cacheRead is 100x latest cacheRead (bug confirmed)
PASS: latest snapshot returns just-the-latest-turn cacheRead (fix working)
PASS: aggregate % (234%) exceeds 100, matching issue's "228%" symptom
PASS: latest % (2%) under 100, no spurious overflow

ALL CASES PASS
```

- **Observed result after fix:** The 234% aggregate value (close to the issue's 228%) is replaced by 2% with the latest-only reader. The current request's prompt size (input + cacheRead + cacheWrite of the most recent turn only) is now what the Context line shows. Other callers of the aggregate function are unchanged. The new sync function has the same signature shape as the existing async sibling, so future migration is mechanical.

- **What was not tested:** End-to-end TUI / `status` command output against a live gateway+claude-cli session. The new vitest case asserts the structural invariant against real transcript files on disk; the probe demonstrates the percentage symptom precisely.

## Audit (per CLAUDE rules — all 5 steps)

- **Existing-helper check:** Reuses `extractLatestUsageFromTranscriptLines` (existing line 1424), `findExistingTranscriptPath`, `withOpenTranscriptFd`. The new sync function mirrors the existing async `readLatestRecentSessionUsageFromTranscriptAsync` in structure. PASS
- **Shared-helper caller check:** `readRecentSessionUsageFromTranscript` (aggregate) has 2 prod callers; this PR removes ONE of them (`status-message.ts:284`). The other (`session-utils.ts:703`) intentionally wants aggregate behavior. PASS
- **Broader-fix rival scan:** No open PRs on `status-message.ts`, `readRecentSessionUsageFromTranscript`, or this issue. PASS
- **Recent-merge audit:** `git log --oneline -10 -- src/status/status-message.ts src/gateway/session-utils.fs.ts` shows no recent merges. PASS
- **Prototype-pollution scan:** N/A — no external-input key copying.
