### PR TITLE
fix(messages): apply TTS before message-tool sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/xAI: echo PKCE challenge fields during OAuth authorization-code token exchange for xAI token-endpoint compatibility. (#83499) Thanks @fuller-stack-dev.
 - Codex app-server: hydrate current inbound image attachments before queued runs so Responses-backed agents receive Discord and other channel images as native vision input. Fixes #83466. Thanks @iannwu.
 - Release stability: recover stale session diagnostics and Codex OAuth fallback state so stuck runs and reused refresh tokens clear without blocking follow-up work. (#83503) Thanks @100yenadmin.
+- Messages/TTS: apply TTS directives before message-tool sends reach core, gateway, or plugin delivery so opt-in message-tool rooms and proactive sends attach voice notes instead of leaking raw tags. Fixes #81598. Thanks @CG-Intelligence-Agent-Jack and @CoronovirusG10.
 - Codex app-server: preserve network access for sandboxed Codex code-mode turns when the OpenClaw sandbox allows outbound egress. Fixes #83347. Thanks @YusukeIt0.
 - QA-Lab: keep the OTLP smoke decoder independent of removed OpenTelemetry generated-root internals.
 - Messages: default group/channel visible replies to automatic final delivery again, keeping `message_tool` opt-in for ambient/shared rooms and tool-reliable models.

--- a/src/infra/outbound/message-action-runner.core-send.test.ts
+++ b/src/infra/outbound/message-action-runner.core-send.test.ts
@@ -4,6 +4,14 @@ import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { runMessageAction } from "./message-action-runner.js";
 
+const ttsMocks = vi.hoisted(() => ({
+  maybeApplyTtsToPayload: vi.fn(async (params: { payload: unknown }) => params.payload),
+}));
+
+vi.mock("../../tts/tts.runtime.js", () => ({
+  maybeApplyTtsToPayload: ttsMocks.maybeApplyTtsToPayload,
+}));
+
 function firstMockArg(
   mock: { mock: { calls: readonly unknown[][] } },
   label: string,
@@ -22,6 +30,9 @@ function firstMockArg(
 describe("runMessageAction core send routing", () => {
   afterEach(() => {
     setActivePluginRegistry(createTestRegistry([]));
+    ttsMocks.maybeApplyTtsToPayload
+      .mockReset()
+      .mockImplementation(async (params: { payload: unknown }) => params.payload);
   });
 
   it("promotes caption to message for media sends when message is empty", async () => {
@@ -183,5 +194,71 @@ describe("runMessageAction core send routing", () => {
     expect(result.to).toBe("telegram:-1001234567890:topic:42");
     expect(payload.to).toBe("telegram:-1001234567890:topic:42");
     expect(payload.dryRun).toBe(true);
+  });
+
+  it("applies TTS to message-tool sends before core outbound delivery", async () => {
+    const sendMedia = vi.fn().mockResolvedValue({
+      channel: "testchat",
+      messageId: "voice-1",
+      chatId: "c1",
+    });
+    ttsMocks.maybeApplyTtsToPayload.mockResolvedValueOnce({
+      mediaUrl: "file:///tmp/openclaw-voice.ogg",
+      audioAsVoice: true,
+      spokenText: "hello there",
+    });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "testchat",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "testchat",
+            outbound: {
+              deliveryMode: "direct",
+              sendText: vi.fn(),
+              sendMedia,
+            },
+          }),
+        },
+      ]),
+    );
+
+    await runMessageAction({
+      cfg: {
+        channels: {
+          testchat: {
+            enabled: true,
+          },
+        },
+        messages: {
+          tts: {
+            auto: "tagged",
+          },
+        },
+      } as OpenClawConfig,
+      action: "send",
+      params: {
+        channel: "testchat",
+        target: "channel:abc",
+        message: "[[tts:text]]hello there[[/tts:text]]",
+      },
+      sessionKey: "agent:main:testchat:channel:abc",
+      dryRun: false,
+    });
+
+    expect(ttsMocks.maybeApplyTtsToPayload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "final",
+        channel: "testchat",
+        payload: expect.objectContaining({
+          text: "[[tts:text]]hello there[[/tts:text]]",
+        }),
+      }),
+    );
+    expect(sendMedia).toHaveBeenCalledOnce();
+    const mediaInput = firstMockArg(sendMedia, "send media");
+    expect(mediaInput.text).toBe("");
+    expect(mediaInput.mediaUrl).toBe("file:///tmp/openclaw-voice.ogg");
   });
 });

--- a/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
+++ b/src/infra/outbound/message-action-runner.plugin-dispatch.test.ts
@@ -90,6 +90,7 @@ const mocks = vi.hoisted(() => ({
   executePollAction: vi.fn(),
   callGatewayLeastPrivilege: vi.fn(),
   randomIdempotencyKey: vi.fn(() => "idem-gateway-action"),
+  maybeApplyTtsToPayload: vi.fn(async (params: { payload: unknown }) => params.payload),
 }));
 
 vi.mock("./channel-resolution.js", () => ({
@@ -105,6 +106,10 @@ vi.mock("./outbound-send-service.js", () => ({
 vi.mock("./message.gateway.runtime.js", () => ({
   callGatewayLeastPrivilege: mocks.callGatewayLeastPrivilege,
   randomIdempotencyKey: mocks.randomIdempotencyKey,
+}));
+
+vi.mock("../../tts/tts.runtime.js", () => ({
+  maybeApplyTtsToPayload: mocks.maybeApplyTtsToPayload,
 }));
 
 vi.mock("./outbound-session.js", () => ({
@@ -268,6 +273,10 @@ describe("runMessageAction plugin dispatch", () => {
     );
     mocks.callGatewayLeastPrivilege.mockReset();
     mocks.randomIdempotencyKey.mockClear();
+    mocks.maybeApplyTtsToPayload.mockReset();
+    mocks.maybeApplyTtsToPayload.mockImplementation(
+      async (params: { payload: unknown }) => params.payload,
+    );
   });
 
   describe("alias-based plugin action dispatch", () => {
@@ -694,6 +703,151 @@ describe("runMessageAction plugin dispatch", () => {
           messageId: "gw-send-1",
         },
         "result payload",
+      );
+    });
+
+    it("applies TTS before gateway-executed plugin sends", async () => {
+      const gatewayPlugin = createGatewayActionPlugin({
+        pluginId: "gatewaychat",
+        label: "Gateway Chat",
+        blurb: "Gateway Chat send test plugin.",
+        actions: ["send"],
+        messaging: {
+          targetResolver: {
+            looksLikeId: () => true,
+          },
+        },
+        handleAction: vi.fn(async () => jsonResult({ ok: true, local: true })),
+      });
+      setActivePluginRegistry(
+        createTestRegistry([
+          {
+            pluginId: "gatewaychat",
+            source: "test",
+            plugin: gatewayPlugin,
+          },
+        ]),
+      );
+      mocks.callGatewayLeastPrivilege.mockResolvedValue({
+        ok: true,
+        messageId: "gw-send-tts",
+      });
+      mocks.maybeApplyTtsToPayload.mockResolvedValueOnce({
+        mediaUrl: "file:///tmp/openclaw-voice.ogg",
+        audioAsVoice: true,
+        spokenText: "hello there",
+      });
+
+      await runMessageAction({
+        cfg: {
+          channels: {
+            gatewaychat: {
+              enabled: true,
+            },
+          },
+          messages: {
+            tts: {
+              auto: "tagged",
+            },
+          },
+        } as OpenClawConfig,
+        action: "send",
+        params: {
+          channel: "gatewaychat",
+          target: "user-123",
+          message: "[[tts:text]]hello there[[/tts:text]]",
+        },
+        gateway: {
+          clientName: "cli",
+          mode: "cli",
+        },
+        dryRun: false,
+      });
+
+      const gatewayCall = readMockCallArg(
+        mocks.callGatewayLeastPrivilege,
+        "gateway least privilege call",
+      );
+      const gatewayParams = readRecordField(gatewayCall, "params", "gateway call params");
+      expectRecordFields(
+        readRecordField(gatewayParams, "params", "gateway message params"),
+        {
+          message: "",
+          media: "file:///tmp/openclaw-voice.ogg",
+          mediaUrl: "file:///tmp/openclaw-voice.ogg",
+          asVoice: true,
+          audioAsVoice: true,
+        },
+        "gateway message params",
+      );
+      expect(mocks.executeSendAction).not.toHaveBeenCalled();
+    });
+
+    it("applies TTS before local plugin send fallback dispatch", async () => {
+      const handleAction = vi.fn(async ({ params }: { params: Record<string, unknown> }) =>
+        jsonResult({ ok: true, params }),
+      );
+      const localPlugin = createGatewayActionPlugin({
+        pluginId: "localchat",
+        label: "Local Chat",
+        blurb: "Local Chat send test plugin.",
+        actions: ["send"],
+        gatewayActions: [],
+        messaging: {
+          targetResolver: {
+            looksLikeId: () => true,
+          },
+        },
+        handleAction,
+      });
+      setActivePluginRegistry(
+        createTestRegistry([
+          {
+            pluginId: "localchat",
+            source: "test",
+            plugin: localPlugin,
+          },
+        ]),
+      );
+      mocks.maybeApplyTtsToPayload.mockResolvedValueOnce({
+        mediaUrl: "file:///tmp/openclaw-voice.ogg",
+        audioAsVoice: true,
+        spokenText: "hello there",
+      });
+
+      await runMessageAction({
+        cfg: {
+          channels: {
+            localchat: {
+              enabled: true,
+            },
+          },
+          messages: {
+            tts: {
+              auto: "tagged",
+            },
+          },
+        } as OpenClawConfig,
+        action: "send",
+        params: {
+          channel: "localchat",
+          target: "user-123",
+          message: "[[tts:text]]hello there[[/tts:text]]",
+        },
+        dryRun: false,
+      });
+
+      const call = readFirstPluginCall(handleAction);
+      expectRecordFields(
+        readRecordField(call, "params", "local plugin params"),
+        {
+          message: "",
+          media: "file:///tmp/openclaw-voice.ogg",
+          mediaUrl: "file:///tmp/openclaw-voice.ogg",
+          asVoice: true,
+          audioAsVoice: true,
+        },
+        "local plugin params",
       );
     });
 

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -1,4 +1,5 @@
 import type { AgentToolResult } from "@earendil-works/pi-agent-core";
+import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import {
   readNumberParam,
@@ -68,6 +69,7 @@ import {
   resolveAndApplyOutboundReplyToId,
   resolveAndApplyOutboundThreadId,
 } from "./message-action-threading.js";
+import { maybeApplyTtsToMessageActionSendPayload } from "./message-action-tts.js";
 import type { MessagePollResult, MessageSendResult } from "./message.js";
 import {
   applyCrossContextDecoration,
@@ -470,6 +472,34 @@ type SendPayloadParts = {
   silent?: boolean;
 };
 
+function updateSendPayloadPartsFromReplyPayload(
+  parts: SendPayloadParts,
+  payload: ReplyPayload,
+): SendPayloadParts {
+  const sendable = resolveSendableOutboundReplyParts(payload);
+  const mediaUrls = sendable.mediaUrls.length > 0 ? sendable.mediaUrls : undefined;
+  return {
+    ...parts,
+    message: payload.text ?? "",
+    payload,
+    mediaUrl: mediaUrls?.[0],
+    mediaUrls,
+    asVoice: payload.audioAsVoice === true,
+  };
+}
+
+function applySendPayloadPartsToActionParams(
+  actionParams: Record<string, unknown>,
+  parts: SendPayloadParts,
+) {
+  actionParams.message = parts.message;
+  actionParams.media = parts.mediaUrl;
+  actionParams.mediaUrl = parts.mediaUrl;
+  actionParams.mediaUrls = parts.mediaUrls;
+  actionParams.asVoice = parts.asVoice || undefined;
+  actionParams.audioAsVoice = parts.asVoice || undefined;
+}
+
 function collectMessageAttachmentMediaHints(value: unknown): string[] {
   if (!Array.isArray(value)) {
     return [];
@@ -869,7 +899,7 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
   throwIfAborted(abortSignal);
   const action: ChannelMessageActionName = "send";
   const to = readStringParam(params, "to", { required: true });
-  const sendPayload = await buildSendPayloadParts({
+  let sendPayload = await buildSendPayloadParts({
     cfg,
     actionParams: params,
     input,
@@ -898,6 +928,21 @@ async function handleSendAction(ctx: ResolvedActionContext): Promise<MessageActi
     resolveOutboundSessionRoute,
     ensureOutboundSessionEntry,
   });
+  throwIfAborted(abortSignal);
+
+  const ttsPayload = await maybeApplyTtsToMessageActionSendPayload({
+    payload: sendPayload.payload,
+    cfg,
+    channel,
+    accountId,
+    agentId,
+    sessionKey: input.sessionKey,
+    dryRun,
+  });
+  if (ttsPayload !== sendPayload.payload) {
+    sendPayload = updateSendPayloadPartsFromReplyPayload(sendPayload, ttsPayload);
+    applySendPayloadPartsToActionParams(params, sendPayload);
+  }
   throwIfAborted(abortSignal);
 
   const gatewayPluginAction = await runGatewayPluginMessageActionOrNull({

--- a/src/infra/outbound/message-action-tts.ts
+++ b/src/infra/outbound/message-action-tts.ts
@@ -1,0 +1,76 @@
+import type { ReplyPayload } from "../../auto-reply/reply-payload.js";
+import {
+  loadSessionStore,
+  resolveSessionStoreEntry,
+  resolveStorePath,
+} from "../../config/sessions.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import type { TtsAutoMode } from "../../config/types.tts.js";
+import { shouldAttemptTtsPayload } from "../../tts/tts-config.js";
+
+let ttsRuntimePromise: Promise<typeof import("../../tts/tts.runtime.js")> | null = null;
+
+function loadMessageActionTtsRuntime() {
+  ttsRuntimePromise ??= import("../../tts/tts.runtime.js");
+  return ttsRuntimePromise;
+}
+
+export function resolveMessageActionSessionTtsAuto(params: {
+  cfg: OpenClawConfig;
+  sessionKey?: string;
+  agentId?: string;
+}): TtsAutoMode | undefined {
+  const sessionKey = params.sessionKey?.trim();
+  if (!sessionKey) {
+    return undefined;
+  }
+  try {
+    const storePath = resolveStorePath(params.cfg.session?.store, { agentId: params.agentId });
+    const store = loadSessionStore(storePath);
+    return resolveSessionStoreEntry({ store, sessionKey }).existing?.ttsAuto;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function maybeApplyTtsToMessageActionSendPayload(params: {
+  payload: ReplyPayload;
+  cfg: OpenClawConfig;
+  channel: string;
+  accountId?: string | null;
+  agentId?: string;
+  sessionKey?: string;
+  inboundAudio?: boolean;
+  dryRun: boolean;
+}): Promise<ReplyPayload> {
+  if (params.dryRun) {
+    return params.payload;
+  }
+  const ttsAuto = resolveMessageActionSessionTtsAuto({
+    cfg: params.cfg,
+    sessionKey: params.sessionKey,
+    agentId: params.agentId,
+  });
+  if (
+    !shouldAttemptTtsPayload({
+      cfg: params.cfg,
+      ttsAuto,
+      agentId: params.agentId,
+      channelId: params.channel,
+      accountId: params.accountId ?? undefined,
+    })
+  ) {
+    return params.payload;
+  }
+  const { maybeApplyTtsToPayload } = await loadMessageActionTtsRuntime();
+  return await maybeApplyTtsToPayload({
+    payload: params.payload,
+    cfg: params.cfg,
+    channel: params.channel,
+    kind: "final",
+    inboundAudio: params.inboundAudio,
+    ttsAuto,
+    agentId: params.agentId,
+    accountId: params.accountId ?? undefined,
+  });
+}


### PR DESCRIPTION
## Summary

- Apply the existing TTS directive pipeline before `message_tool` sends leave the runner, covering core outbound delivery, gateway plugin sends, and local plugin fallback sends.
- Add focused regressions for voice payload normalization across those delivery paths.
- Add changelog credit for the reporters.

Fixes #81598.

## Verification

- `node scripts/run-vitest.mjs src/infra/outbound/message-action-runner.core-send.test.ts src/infra/outbound/message-action-runner.plugin-dispatch.test.ts`
- `pnpm build`
- `pnpm check:changed` via Blacksmith Testbox `tbx_01krx6y3mdxxgxg8khc4eybqfb` / https://github.com/openclaw/openclaw/actions/runs/26025333280
- `.agents/skills/autoreview/scripts/autoreview --mode local` (clean; helper used fallback reviewer after current Codex CLI rejected its legacy `--uncommitted -` invocation)
- `git diff --check`

## Real behavior proof

Behavior addressed: message-tool sends now synthesize tagged TTS content before dispatch, so `[[tts:text]]...[[/tts:text]]` becomes an outbound voice attachment instead of raw tag text in proactive/group-room sends.
Real environment tested: source-level proof accepted by maintainer for this issue because the bug is the runner ordering boundary before core/gateway/plugin dispatch.
Exact steps or command run after this patch: targeted Vitest files, production build, changed-gate Testbox run, autoreview, and diff whitespace check listed above.
Evidence after fix: regression output shows 2 files / 24 tests passed after rebase; the tests assert `kind: "final"` TTS application before core outbound delivery, gateway plugin dispatch, and local plugin fallback dispatch.
Observed result after fix: all listed checks passed; `check:changed` exited 0 in Testbox and current-base `pnpm build` passed.
What was not tested: no live Discord/Telegram voice-note send; maintainer accepted source-level proof and this PR carries `proof: override`.
