### PR TITLE
Strip provider api keys from generated models.json

### DIFF
--- a/src/agents/models-config.applies-config-env-vars.test.ts
+++ b/src/agents/models-config.applies-config-env-vars.test.ts
@@ -246,6 +246,63 @@ describe("models-config", () => {
     ]);
   });
 
+  it("strips provider api keys from serialized models.json", async () => {
+    const plan = await planOpenClawModelsJsonWithDeps(
+      {
+        cfg: {
+          models: {
+            mode: "merge",
+            providers: {
+              configured: {
+                baseUrl: "https://configured.example/v1",
+                api: "openai-responses",
+                apiKey: "CONFIGURED_KEY", // pragma: allowlist secret
+                models: [],
+              },
+            },
+          },
+        },
+        agentDir: "/tmp/openclaw-models-config-env-vars-test",
+        env: {},
+        existingRaw: "",
+        existingParsed: {
+          providers: {
+            existing: {
+              baseUrl: "https://existing.example/v1",
+              api: "openai-responses",
+              apiKey: "EXISTING_KEY", // pragma: allowlist secret
+              models: [],
+            },
+          },
+        },
+      },
+      {
+        resolveImplicitProviders: async () => ({
+          implicit: {
+            baseUrl: "https://implicit.example/v1",
+            api: "openai-responses",
+            apiKey: "IMPLICIT_KEY", // pragma: allowlist secret
+            models: [],
+          },
+        }),
+      },
+    );
+
+    expect(plan.action).toBe("write");
+    if (plan.action !== "write") {
+      throw new Error("Expected models.json write plan");
+    }
+    const parsed = JSON.parse(plan.contents) as {
+      providers?: Record<string, { apiKey?: string; baseUrl?: string }>;
+    };
+    expect(parsed.providers?.configured?.baseUrl).toBe("https://configured.example/v1");
+    expect(parsed.providers?.configured).not.toHaveProperty("apiKey");
+    expect(parsed.providers?.implicit?.baseUrl).toBe("https://implicit.example/v1");
+    expect(parsed.providers?.implicit).not.toHaveProperty("apiKey");
+    expect(parsed.providers?.existing?.baseUrl).toBe("https://existing.example/v1");
+    expect(parsed.providers?.existing).not.toHaveProperty("apiKey");
+  });
+
   it("uses config env.vars entries for implicit provider discovery without mutating process.env", async () => {
     await withTempEnv(["OPENROUTER_API_KEY", TEST_ENV_VAR], async () => {
       unsetEnv(["OPENROUTER_API_KEY", TEST_ENV_VAR]);

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -105,6 +105,18 @@ function resolveProvidersForMode(params: {
   });
 }
 
+function stripProviderApiKeysForModelsJson(
+  providers: Record<string, ProviderConfig>,
+): Record<string, ProviderConfig> {
+  const sanitized: Record<string, ProviderConfig> = {};
+  for (const [providerId, provider] of Object.entries(providers)) {
+    const nextProvider = { ...provider };
+    delete nextProvider.apiKey;
+    sanitized[providerId] = nextProvider;
+  }
+  return sanitized;
+}
+
 export async function planOpenClawModelsJsonWithDeps(
   params: {
     cfg: OpenClawConfig;
@@ -177,7 +189,9 @@ export async function planOpenClawModelsJsonWithDeps(
       sourceSecretDefaults: params.sourceConfigForSecrets?.secrets?.defaults,
       secretRefManagedProviders,
     }) ?? normalizedMergedProviders;
-  const finalProviders = applyNativeStreamingUsageCompat(secretEnforcedProviders);
+  const finalProviders = stripProviderApiKeysForModelsJson(
+    applyNativeStreamingUsageCompat(secretEnforcedProviders),
+  );
   const nextContents = `${JSON.stringify({ providers: finalProviders }, null, 2)}\n`;
 
   if (params.existingRaw === nextContents) {

--- a/src/agents/models-config.skips-writing-models-json-no-env-token.test.ts
+++ b/src/agents/models-config.skips-writing-models-json-no-env-token.test.ts
@@ -102,7 +102,6 @@ async function runEnvProviderCase(params: {
   envVar: "MINIMAX_API_KEY" | "SYNTHETIC_API_KEY";
   envValue: string;
   providerKey: "minimax" | "synthetic";
-  expectedApiKeyRef: string;
 }) {
   const previousValue = process.env[params.envVar];
   process.env[params.envVar] = params.envValue;
@@ -113,7 +112,8 @@ async function runEnvProviderCase(params: {
     const raw = await fs.readFile(modelPath, "utf8");
     const parsed = JSON.parse(raw) as { providers: Record<string, ParsedProviderConfig> };
     const provider = parsed.providers[params.providerKey];
-    expect(provider?.apiKey).toBe(params.expectedApiKeyRef);
+    expect(provider).toBeDefined();
+    expect(provider).not.toHaveProperty("apiKey");
   } finally {
     if (previousValue === undefined) {
       delete process.env[params.envVar];
@@ -211,7 +211,6 @@ describe("models-config", () => {
         envVar: "MINIMAX_API_KEY",
         envValue: "sk-minimax-test",
         providerKey: "minimax",
-        expectedApiKeyRef: "MINIMAX_API_KEY", // pragma: allowlist secret
       });
     });
   });
@@ -222,7 +221,6 @@ describe("models-config", () => {
         envVar: "SYNTHETIC_API_KEY",
         envValue: "sk-synthetic-test",
         providerKey: "synthetic",
-        expectedApiKeyRef: "SYNTHETIC_API_KEY", // pragma: allowlist secret
       });
     });
   });


### PR DESCRIPTION
## Summary

Addresses Layer 1 of #11829 by stripping provider-level `apiKey` values before serializing `models.json`.

This keeps provider metadata such as `baseUrl`, `api`, and model catalog entries available to the agent, while preventing auth credentials or env-var markers from being included in prompt-serialized model context.

## Tests

```text
pnpm exec vitest run src/agents/models-config.applies-config-env-vars.test.ts src/agents/models-config.skips-writing-models-json-no-env-token.test.ts
Test Files 4 passed
Tests 24 passed