### PR TITLE
fix(agents): skip model fallback for embedded session takeover and session write-lock errors [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Docs: https://docs.openclaw.ai
 - Gateway: defer update-check startup until after readiness so package update checks no longer block sidecar-ready startup, while preserving update broadcasts and shutdown cleanup. (#83520) Thanks @samzong.
 - Telegram: keep `/btw` and read-only status commands from aborting active runs, and avoid retaining raw update payloads in timed-out spool tombstones. Refs #83272.
 - Agents: log strict-agentic execution contract diagnostics only when the planning-only retry path actually triggers.
+- Agents: stop embedded session takeover and session write-lock errors from consuming model fallbacks while preserving provider fallback metadata. Fixes #83510. Thanks @luyao618.
 - Agents/video: hide `video_generate` reference-audio parameters unless a registered video provider supports audio inputs.
 - Plugins: fall back to npm for official ClawHub updates when artifact downloads are unavailable, including beta-to-default fallback and dry-run version reporting.
 - Plugins/xAI: echo PKCE challenge fields during OAuth authorization-code token exchange for xAI token-endpoint compatibility. (#83499) Thanks @fuller-stack-dev.

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -3,6 +3,7 @@ import {
   coerceToFailoverError,
   describeFailoverError,
   FailoverError,
+  isNonProviderRuntimeCoordinationError,
   isTimeoutError,
   resolveFailoverReasonFromError,
   resolveFailoverStatus,
@@ -1111,5 +1112,47 @@ describe("failover-error", () => {
     expect(err?.sessionId).toBe("session:browser-1234");
     expect(err?.lane).toBe("draft");
     expect(err?.provider).toBe("openai");
+  });
+
+  describe("isNonProviderRuntimeCoordinationError", () => {
+    const makeSessionLockError = () =>
+      new SessionWriteLockTimeoutError({
+        timeoutMs: 10_000,
+        owner: "pid=37121",
+        lockPath: "/tmp/openclaw/session.jsonl.lock",
+      });
+    const makeEmbeddedTakeoverError = () => {
+      const err = new Error(
+        "session file changed while embedded prompt lock was released: /tmp/openclaw/session.jsonl",
+      );
+      err.name = "EmbeddedAttemptSessionTakeoverError";
+      return err;
+    };
+
+    it("returns true for direct session write-lock timeout errors", () => {
+      expect(isNonProviderRuntimeCoordinationError(makeSessionLockError())).toBe(true);
+    });
+
+    it("returns true for direct embedded attempt session takeover errors", () => {
+      expect(isNonProviderRuntimeCoordinationError(makeEmbeddedTakeoverError())).toBe(true);
+    });
+
+    it("returns true when the coordination error is nested via cause", () => {
+      const wrapped = new Error("wrapper", { cause: makeSessionLockError() });
+      expect(isNonProviderRuntimeCoordinationError(wrapped)).toBe(true);
+
+      const wrappedTakeover = new Error("wrapper", { cause: makeEmbeddedTakeoverError() });
+      expect(isNonProviderRuntimeCoordinationError(wrappedTakeover)).toBe(true);
+    });
+
+    it("returns false for plain timeouts and provider errors", () => {
+      const timeoutErr = Object.assign(new Error("operation timed out"), { name: "TimeoutError" });
+      expect(isNonProviderRuntimeCoordinationError(timeoutErr)).toBe(false);
+      expect(isNonProviderRuntimeCoordinationError({ status: 429, message: "rate limit" })).toBe(
+        false,
+      );
+      expect(isNonProviderRuntimeCoordinationError(null)).toBe(false);
+      expect(isNonProviderRuntimeCoordinationError(undefined)).toBe(false);
+    });
   });
 });

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -1151,6 +1151,14 @@ describe("failover-error", () => {
       expect(isNonProviderRuntimeCoordinationError({ status: 429, message: "rate limit" })).toBe(
         false,
       );
+      expect(
+        isNonProviderRuntimeCoordinationError({
+          status: 429,
+          code: "RESOURCE_EXHAUSTED",
+          message: "upstream quota pressure",
+          cause: makeSessionLockError(),
+        }),
+      ).toBe(false);
       expect(isNonProviderRuntimeCoordinationError(null)).toBe(false);
       expect(isNonProviderRuntimeCoordinationError(undefined)).toBe(false);
     });

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -234,6 +234,43 @@ function hasSessionWriteLockTimeout(err: unknown, seen: Set<object> = new Set())
   );
 }
 
+function isEmbeddedAttemptSessionTakeover(err: unknown): boolean {
+  // Match by name to avoid importing pi-embedded-runner here (would create a cycle).
+  return Boolean(
+    err && typeof err === "object" && readErrorName(err) === "EmbeddedAttemptSessionTakeoverError",
+  );
+}
+
+function hasEmbeddedAttemptSessionTakeover(err: unknown, seen: Set<object> = new Set()): boolean {
+  if (isEmbeddedAttemptSessionTakeover(err)) {
+    return true;
+  }
+  if (!err || typeof err !== "object") {
+    return false;
+  }
+  if (seen.has(err)) {
+    return false;
+  }
+  seen.add(err);
+  const candidate = err as { error?: unknown; cause?: unknown; reason?: unknown };
+  return (
+    hasEmbeddedAttemptSessionTakeover(candidate.error, seen) ||
+    hasEmbeddedAttemptSessionTakeover(candidate.cause, seen) ||
+    hasEmbeddedAttemptSessionTakeover(candidate.reason, seen)
+  );
+}
+
+/**
+ * True when the error is a local runtime coordination error (session write-lock
+ * timeout or embedded attempt session takeover) rather than a provider/model
+ * failure. The model fallback chain must abort on these instead of consuming
+ * candidate slots — retrying any model would hit the same local condition.
+ * See #83510.
+ */
+export function isNonProviderRuntimeCoordinationError(err: unknown): boolean {
+  return hasSessionWriteLockTimeout(err) || hasEmbeddedAttemptSessionTakeover(err);
+}
+
 function hasTimeoutHint(err: unknown): boolean {
   if (!err) {
     return false;

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -268,7 +268,13 @@ function hasEmbeddedAttemptSessionTakeover(err: unknown, seen: Set<object> = new
  * See #83510.
  */
 export function isNonProviderRuntimeCoordinationError(err: unknown): boolean {
-  return hasSessionWriteLockTimeout(err) || hasEmbeddedAttemptSessionTakeover(err);
+  if (!hasSessionWriteLockTimeout(err) && !hasEmbeddedAttemptSessionTakeover(err)) {
+    return false;
+  }
+  if (isFailoverError(err)) {
+    return false;
+  }
+  return resolveFailoverClassificationFromError(err) === null;
 }
 
 function hasTimeoutHint(err: unknown): boolean {

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -23,6 +23,7 @@ import {
 } from "./model-fallback.js";
 import { classifyEmbeddedPiRunResultForModelFallback } from "./pi-embedded-runner/result-fallback-classifier.js";
 import type { EmbeddedPiRunResult } from "./pi-embedded-runner/types.js";
+import { SessionWriteLockTimeoutError } from "./session-write-lock-error.js";
 import { makeModelFallbackCfg } from "./test-helpers/model-fallback-config-fixture.js";
 
 vi.mock("../infra/file-lock.js", () => ({
@@ -794,6 +795,78 @@ describe("runWithModelFallback", () => {
       }),
     ).rejects.toBe(takeoverError);
     expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("aborts the fallback chain on session write-lock timeout instead of trying every model (#83510)", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5.4",
+            fallbacks: ["anthropic/claude-sonnet-4-6", "openai/gpt-4.1-mini"],
+          },
+        },
+      },
+    });
+    const lockError = new SessionWriteLockTimeoutError({
+      timeoutMs: 10_000,
+      owner: "pid=37121",
+      lockPath: "/tmp/openclaw/session.jsonl.lock",
+    });
+    const run = vi.fn().mockRejectedValue(lockError);
+
+    await expect(
+      runWithModelFallback({
+        cfg,
+        provider: "openai",
+        model: "gpt-5.4",
+        run,
+      }),
+    ).rejects.toBe(lockError);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps provider failover metadata authoritative over nested session locks", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5.4",
+            fallbacks: ["anthropic/claude-sonnet-4-6"],
+          },
+        },
+      },
+    });
+    const lockError = new SessionWriteLockTimeoutError({
+      timeoutMs: 10_000,
+      owner: "pid=37121",
+      lockPath: "/tmp/openclaw/session.jsonl.lock",
+    });
+    const providerError = {
+      status: 429,
+      code: "RESOURCE_EXHAUSTED",
+      message: "upstream quota pressure",
+      cause: lockError,
+    };
+    const run = vi.fn().mockRejectedValueOnce(providerError).mockResolvedValueOnce("fallback ok");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-5.4",
+      run,
+    });
+
+    expect(result.result).toBe("fallback ok");
+    expect(result.provider).toBe("anthropic");
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(result.attempts[0]).toMatchObject({
+      provider: "openai",
+      model: "gpt-5.4",
+      reason: "rate_limit",
+      status: 429,
+      code: "RESOURCE_EXHAUSTED",
+    });
   });
 
   it("keeps raw provider schema errors in fallback summaries", async () => {

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -768,6 +768,34 @@ describe("runWithModelFallback", () => {
     expect(run).toHaveBeenCalledTimes(1);
   });
 
+  it("aborts the fallback chain on embedded session takeover instead of trying every model (#83510)", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5.4",
+            fallbacks: ["anthropic/claude-sonnet-4-6", "openai/gpt-4.1-mini"],
+          },
+        },
+      },
+    });
+    const takeoverError = new Error(
+      "session file changed while embedded prompt lock was released: /tmp/session.jsonl",
+    );
+    takeoverError.name = "EmbeddedAttemptSessionTakeoverError";
+    const run = vi.fn().mockRejectedValue(takeoverError);
+
+    await expect(
+      runWithModelFallback({
+        cfg,
+        provider: "openai",
+        model: "gpt-5.4",
+        run,
+      }),
+    ).rejects.toBe(takeoverError);
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps raw provider schema errors in fallback summaries", async () => {
     const cfg = makeCfg({
       agents: {

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -19,6 +19,7 @@ import {
   coerceToFailoverError,
   describeFailoverError,
   isFailoverError,
+  isNonProviderRuntimeCoordinationError,
   isTimeoutError,
 } from "./failover-error.js";
 import {
@@ -1197,6 +1198,14 @@ export async function runWithModelFallback<T>(
     }
     const err = attemptRun.error;
     {
+      // Local runtime coordination errors (session write-lock timeout, embedded
+      // attempt session takeover) are not provider/model failures. Aborting
+      // here prevents the fallback chain from consuming candidates retrying
+      // the same local condition and surfacing a misleading "All models
+      // failed" summary. See #83510.
+      if (isNonProviderRuntimeCoordinationError(err)) {
+        throw err;
+      }
       if (transientProbeProviderForAttempt) {
         const probeFailureReason = describeFailoverError(err).reason;
         if (!shouldPreserveTransientCooldownProbeSlot(probeFailureReason)) {


### PR DESCRIPTION
> 🤖 AI-assisted (built with Codex via Hermes orchestration). Test level: lightly tested. Prompt summary available on request.

## Summary
- Problem: When an embedded agent turn fails with `EmbeddedAttemptSessionTakeoverError` ("session file changed while embedded prompt lock was released") or `SessionWriteLockTimeoutError`, `runWithModelFallback` treats it as a candidate model failure and walks the entire fallback chain. Each model hits the same local condition (or the last one idles out after 120s), and the user sees a misleading `All models failed` summary.
- Why it matters: Interactive embedded turns fail before any reply is produced, fallback model slots are wasted on a non-provider local error, and the final error message points operators at provider/model diagnosis instead of the real cause (session lock coordination). On long-lived or maintenance-heavy sessions this repeats; the reporter saw 61 occurrences in one day.
- What changed: Add `isNonProviderRuntimeCoordinationError(err)` in `src/agents/failover-error.ts` that matches either error directly or via nested `cause` / `reason` / `error` chains. In `runWithModelFallback`'s per-attempt catch block, rethrow immediately when the predicate is true — before the candidate is recorded as failed or any fallback bookkeeping advances.
- What did NOT change (scope boundary): The error classes themselves, the session-lock acquisition/fence logic, the embedded runner's own internal retry on takeover (`attempt.session-lock.ts`), and the existing `hasSessionWriteLockTimeout` treatment in failover classification all stay as-is.

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [x] Agents

## Linked Issue/PR
- Closes #83510
- [x] This PR fixes a bug or regression

## Root Cause
- Root cause: `runWithModelFallback` only differentiates between candidate failures (advance to next model) and `FailoverError` (rethrow). Local runtime coordination errors thrown from inside the candidate run — `EmbeddedAttemptSessionTakeoverError` from the embedded prompt lock and `SessionWriteLockTimeoutError` from the session writer — fall through the generic "candidate failed" path, so the loop tries every fallback model against the same local condition.
- Missing detection / guardrail: The fallback loop has no notion of "non-provider local error, abort the chain". `failover-error.ts` already special-cases `SessionWriteLockTimeoutError` to avoid misclassifying it as a timeout, but the fallback driver never consulted that signal.
- Contributing context (if known): `EmbeddedAttemptSessionTakeoverError` is a newer (post-`SessionWriteLockTimeoutError`) error class; the embedded runner catches it locally in some paths (`google-prompt-cache.ts`, `attempt.session-lock.ts`) but it can still escape upward into the model fallback driver.

## Regression Test Plan
- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/agents/failover-error.test.ts`, `src/agents/model-fallback.test.ts`
- Scenario the test should lock in:
  - `isNonProviderRuntimeCoordinationError` returns true for direct `SessionWriteLockTimeoutError` and direct `EmbeddedAttemptSessionTakeoverError`-named errors, and for both errors wrapped via `cause`. It returns false for plain `TimeoutError`, HTTP 429 provider errors, and nullish input.
  - `runWithModelFallback` invoked with a `run` that rejects with an `EmbeddedAttemptSessionTakeoverError`-named error rethrows that exact error on the first attempt and does not invoke `run` for any fallback candidate (`run` called exactly once).
- Why this is the smallest reliable guardrail: The two assertions pin down both the classifier (which feeds the policy) and the loop behavior (which is the user-visible regression vector). Any future refactor that re-introduces the "treat coordination error as candidate failure" bug fails immediately.
- Existing test that already covers this (if any): N/A — existing `hasSessionWriteLockTimeout` tests only assert it suppresses timeout misclassification, not that the fallback chain aborts.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes
- Embedded agent turns that fail with session takeover or session write-lock timeout now surface the original coordination error instead of `Embedded agent failed before reply: All models failed (N): ...`. Provider/model fallback semantics are unchanged for actual provider failures.

## Security Impact (required)
- New permissions/capabilities? No
- This change only narrows the conditions under which the model fallback loop continues. It does not introduce new I/O, network paths, persistence, or capability grants; the error types involved are produced by the existing local session-lock subsystem.


## Verification

- `node scripts/run-vitest.mjs src/agents/failover-error.test.ts src/agents/model-fallback.test.ts` - 3 files passed, 202 tests passed.
- `git diff --check` - clean.
- `./node_modules/.bin/oxfmt --check --threads=1 src/agents/failover-error.ts src/agents/failover-error.test.ts src/agents/model-fallback.test.ts CHANGELOG.md` - clean.
- `node scripts/check-changelog-attributions.mjs` - clean.
- `codex review --uncommitted` - no blocking/actionable findings after maintainer fixup.

## Real behavior proof

Behavior addressed: embedded session takeover and session write-lock failures now abort the model fallback chain as local coordination errors, while provider-classified failures with nested session-lock causes still use normal model fallback.

Real environment tested: local macOS source checkout for the model fallback and failover classifier runtime paths.

Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/agents/failover-error.test.ts src/agents/model-fallback.test.ts`.

Evidence after fix: targeted Vitest run passed with 3 files and 202 tests, including direct embedded takeover abort, direct session write-lock abort, and a provider 429/RESOURCE_EXHAUSTED wrapper with a nested session lock cause falling through to the configured fallback model.

Observed result after fix: pure local session coordination errors are rethrown on the first candidate instead of surfacing as `All models failed`, and explicit provider failover metadata remains authoritative so provider rate-limit fallback still advances to the next candidate.

What was not tested: a live embedded-session takeover race against a real installed gateway; the proof is source-level regression coverage for the observed fallback routing bug.
