### PR TITLE
Fix Telegram topic media completion delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram: deliver generated media completions back into forum topics by preserving topic IDs across requester-agent handoff. (#83556) Thanks @fuller-stack-dev.
 - Gateway: defer update-check startup until after readiness so package update checks no longer block sidecar-ready startup, while preserving update broadcasts and shutdown cleanup. (#83520) Thanks @samzong.
 - Agents/video: hide `video_generate` reference-audio parameters unless a registered video provider supports audio inputs.
 - Plugins/xAI: echo PKCE challenge fields during OAuth authorization-code token exchange for xAI token-endpoint compatibility. (#83499) Thanks @fuller-stack-dev.

--- a/src/agents/pi-embedded-runner/delivery-evidence.ts
+++ b/src/agents/pi-embedded-runner/delivery-evidence.ts
@@ -109,14 +109,29 @@ function hasPositiveNumber(value: unknown): boolean {
 }
 
 export function getGatewayAgentResult(response: unknown): AgentDeliveryEvidence | null {
-  if (!response || typeof response !== "object" || !("result" in response)) {
+  if (!response || typeof response !== "object") {
     return null;
   }
-  const result = (response as { result?: unknown }).result;
-  if (!result || typeof result !== "object") {
+  const candidate = hasAgentDeliveryEvidenceShape(response)
+    ? response
+    : (response as { result?: unknown }).result;
+  if (!candidate || typeof candidate !== "object" || !hasAgentDeliveryEvidenceShape(candidate)) {
     return null;
   }
-  return result as AgentDeliveryEvidence;
+  return candidate as AgentDeliveryEvidence;
+}
+
+function hasAgentDeliveryEvidenceShape(value: object): boolean {
+  return (
+    "payloads" in value ||
+    "deliveryStatus" in value ||
+    "didSendViaMessagingTool" in value ||
+    "messagingToolSentTexts" in value ||
+    "messagingToolSentMediaUrls" in value ||
+    "messagingToolSentTargets" in value ||
+    "successfulCronAdds" in value ||
+    "meta" in value
+  );
 }
 
 export function hasVisibleAgentPayload(

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -211,12 +211,21 @@ async function deliverTelegramDirectMessageCompletion(params: {
   internalEvents?: AgentInternalEvent[];
   isActive?: boolean;
   queueEmbeddedPiMessageWithOutcome?: QueueEmbeddedPiMessageWithOutcome;
+  requesterSessionKey?: string;
+  sourceTool?: string;
+  origin?: {
+    channel: "telegram";
+    to: string;
+    accountId?: string;
+    threadId?: string | number;
+  };
 }) {
-  const origin = {
+  const origin = params.origin ?? {
     channel: "telegram",
     to: "123456789",
     accountId: "bot-1",
   };
+  const requesterSessionKey = params.requesterSessionKey ?? "agent:main:telegram:123456789";
   __testing.setDepsForTest({
     callGateway: params.callGateway,
     getRequesterSessionActivity: () => ({
@@ -230,8 +239,8 @@ async function deliverTelegramDirectMessageCompletion(params: {
   });
 
   return deliverSubagentAnnouncement({
-    requesterSessionKey: "agent:main:telegram:123456789",
-    targetRequesterSessionKey: "agent:main:telegram:123456789",
+    requesterSessionKey,
+    targetRequesterSessionKey: requesterSessionKey,
     triggerMessage: "child done",
     steerMessage: "child done",
     requesterOrigin: origin,
@@ -243,6 +252,7 @@ async function deliverTelegramDirectMessageCompletion(params: {
     bestEffortDeliver: true,
     directIdempotencyKey: "announce-telegram-dm-fallback",
     internalEvents: params.internalEvents,
+    sourceTool: params.sourceTool,
   });
 }
 
@@ -1598,6 +1608,56 @@ describe("deliverSubagentAnnouncement completion delivery", () => {
       accountId: "acct-1",
       to: "dm:U123",
       threadId: undefined,
+      sourceReplyDeliveryMode: "message_tool_only",
+    });
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("stringifies Telegram topic ids for generated video completion handoff", async () => {
+    const callGateway = createGatewayMock({
+      payloads: [],
+      didSendViaMessagingTool: true,
+      messagingToolSentMediaUrls: ["/tmp/generated-corgi.mp4"],
+    });
+    const sendMessage = createSendMessageMock();
+    const result = await deliverTelegramDirectMessageCompletion({
+      callGateway,
+      sendMessage,
+      requesterSessionKey: "agent:main:telegram:group:-1003970070733:topic:1",
+      origin: {
+        channel: "telegram",
+        to: "telegram:-1003970070733",
+        accountId: "bot-1",
+        threadId: 1,
+      },
+      sourceTool: "video_generate",
+      internalEvents: [
+        {
+          type: "task_completion",
+          source: "video_generation",
+          childSessionKey: "video_generate:task-123",
+          childSessionId: "task-123",
+          announceType: "video generation task",
+          taskLabel: "anime corgi skateboard",
+          status: "ok",
+          statusLabel: "completed successfully",
+          result: "Generated 1 video.\nMEDIA:/tmp/generated-corgi.mp4",
+          mediaUrls: ["/tmp/generated-corgi.mp4"],
+          replyInstruction: "Deliver the generated video through the message tool.",
+        },
+      ],
+    });
+
+    expectRecordFields(result, {
+      delivered: true,
+      path: "direct",
+    });
+    expectGatewayAgentParams(callGateway, {
+      deliver: false,
+      channel: "telegram",
+      accountId: "bot-1",
+      to: "telegram:-1003970070733",
+      threadId: "1",
       sourceReplyDeliveryMode: "message_tool_only",
     });
     expect(sendMessage).not.toHaveBeenCalled();

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -725,6 +725,11 @@ async function sendSubagentAnnounceDirectly(params: {
         path: "none",
       };
     }
+    const directAgentThreadId = shouldDeliverAgentFinal
+      ? stringifyRouteThreadId(deliveryTarget.threadId)
+      : sessionOnlyOriginChannel
+        ? stringifyRouteThreadId(sessionOnlyOrigin?.threadId)
+        : undefined;
     const directAgentParams: Record<string, unknown> = {
       sessionKey: canonicalRequesterSessionKey,
       message: params.triggerMessage,
@@ -742,11 +747,7 @@ async function sendSubagentAnnounceDirectly(params: {
         : sessionOnlyOriginChannel
           ? sessionOnlyOrigin?.to
           : undefined,
-      threadId: shouldDeliverAgentFinal
-        ? deliveryTarget.threadId
-        : sessionOnlyOriginChannel
-          ? sessionOnlyOrigin?.threadId
-          : undefined,
+      threadId: directAgentThreadId,
       inputProvenance: {
         kind: "inter_session",
         sourceSessionKey: params.sourceSessionKey,


### PR DESCRIPTION
## Summary
- stringify Telegram/forum thread ids before requester-agent completion handoff calls the gateway `agent` method
- accept direct in-process gateway agent payloads as delivery evidence, not only wrapped `{ result }` responses
- add regression coverage for generated video completion in a Telegram topic with message-tool media evidence

## Real behavior proof
Behavior addressed: Generated video completion delivery into a Telegram forum topic failed after the video finished because requester-agent completion handoff passed numeric `threadId` to the gateway `agent` method, which requires a string.

Real environment tested: Local OpenClaw gateway connected to Telegram topic `telegram:-1003970070733`, with `xai/grok-imagine-video` generating a video completion.

Exact steps or command run after this patch: Applied the fix locally, restarted the gateway, triggered generated-video task `3c71c210-5cf0-4ad9-ace4-82c73b04eab4`, and let the requester-agent completion deliver through the Telegram message tool.

Evidence after fix: Telegram outbound log reported `telegram outbound send ok accountId=default chatId=-1003970070733 messageId=138 operation=sendVideo deliveryKind=video`; generated file `video-1---c6d8cbae-12e1-452b-b9f4-9b3c7fe631aa.mp4` probed as valid H.264 video, 1280x720, 5.041667s, 5,902,659 bytes.

Observed result after fix: Telegram delivery succeeded at `2026-05-18 04:09 MDT`; user-provided Telegram screenshot showed the video rendered in the topic with the expected caption.

What was not tested: Maintainer-controlled Telegram Desktop recording was not captured; the PR body includes runtime log and screenshot-described proof instead.

## Before-fix evidence
- Task `4a0f1eac-d323-431c-b36d-38682650c4b8` generated a video with `xai/grok-imagine-video`, but completion delivery failed with `invalid agent params: at /threadId: must be string`.

## Verification
- `pnpm test src/agents/subagent-announce-delivery.test.ts -t "stringifies Telegram topic ids for generated video completion handoff"`
- `pnpm test src/agents/pi-embedded-runner/run.incomplete-turn.test.ts src/plugin-sdk/channel-route.test.ts src/channels/conversation-resolution.test.ts src/channels/message/send.test.ts src/gateway/protocol/schema/agent.test.ts`
- `pnpm build`

## Known unrelated current-main failure
- `pnpm test src/agents/subagent-announce-delivery.test.ts` still fails one existing expectation, `requires message-tool delivery for channel subagent completions`; the same targeted test also fails on clean `main`.
