### PR TITLE
fix(qqbot): respect OPENCLAW_HOME for media paths

### DIFF
--- a/extensions/qqbot/src/engine/utils/platform.test.ts
+++ b/extensions/qqbot/src/engine/utils/platform.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  getQQBotMediaPath,
   getHomeDir,
   resolveQQBotLocalMediaPath,
   resolveQQBotPayloadLocalFilePath,
@@ -39,9 +40,25 @@ describe("qqbot local media path remapping", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllEnvs();
     for (const target of createdPaths.splice(0)) {
       fs.rmSync(target, { recursive: true, force: true });
     }
+  });
+
+  it("resolves QQ Bot media storage under OPENCLAW_HOME when configured", () => {
+    const hostHome = fs.mkdtempSync(path.join(os.tmpdir(), "qqbot-platform-home-"));
+    const openclawHome = fs.mkdtempSync(path.join(os.tmpdir(), "qqbot-platform-openclaw-home-"));
+    createdPaths.push(hostHome, openclawHome);
+    vi.stubEnv("HOME", hostHome);
+    vi.stubEnv("OPENCLAW_HOME", openclawHome);
+
+    const mediaFile = path.join(openclawHome, ".openclaw", "media", "qqbot", "image.png");
+    fs.mkdirSync(path.dirname(mediaFile), { recursive: true });
+    fs.writeFileSync(mediaFile, "image", "utf8");
+
+    expect(getQQBotMediaPath("image.png")).toBe(mediaFile);
+    expect(resolveQQBotPayloadLocalFilePath(mediaFile)).toBe(fs.realpathSync(mediaFile));
   });
 
   it("remaps missing workspace media paths to the real media directory", () => {

--- a/extensions/qqbot/src/engine/utils/platform.test.ts
+++ b/extensions/qqbot/src/engine/utils/platform.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  getQQBotDataPath,
   getQQBotMediaPath,
   getHomeDir,
   resolveQQBotLocalMediaPath,
@@ -59,6 +60,29 @@ describe("qqbot local media path remapping", () => {
 
     expect(getQQBotMediaPath("image.png")).toBe(mediaFile);
     expect(resolveQQBotPayloadLocalFilePath(mediaFile)).toBe(fs.realpathSync(mediaFile));
+  });
+
+  it("keeps QQ Bot persisted data on the legacy home-derived root when OPENCLAW_HOME is configured", () => {
+    const hostHome = fs.mkdtempSync(path.join(os.tmpdir(), "qqbot-platform-home-"));
+    const openclawHome = fs.mkdtempSync(path.join(os.tmpdir(), "qqbot-platform-openclaw-home-"));
+    createdPaths.push(hostHome, openclawHome);
+    vi.stubEnv("HOME", hostHome);
+    vi.stubEnv("OPENCLAW_HOME", openclawHome);
+
+    expect(getQQBotDataPath("sessions", "main.json")).toBe(
+      path.join(getHomeDir(), ".openclaw", "qqbot", "sessions", "main.json"),
+    );
+  });
+
+  it("expands QQ Bot OPENCLAW_HOME media roots through HOME for tilde paths", () => {
+    const hostHome = fs.mkdtempSync(path.join(os.tmpdir(), "qqbot-platform-home-"));
+    createdPaths.push(hostHome);
+    vi.stubEnv("HOME", hostHome);
+    vi.stubEnv("OPENCLAW_HOME", "~/svc");
+
+    expect(getQQBotMediaPath("image.png")).toBe(
+      path.join(hostHome, "svc", ".openclaw", "media", "qqbot", "image.png"),
+    );
   });
 
   it("remaps missing workspace media paths to the real media directory", () => {

--- a/extensions/qqbot/src/engine/utils/platform.ts
+++ b/extensions/qqbot/src/engine/utils/platform.ts
@@ -39,9 +39,23 @@ export function getHomeDir(): string {
   return getPlatformAdapter().getTempDir();
 }
 
+function resolveOpenClawHomeDir(): string {
+  const explicitHome = process.env.OPENCLAW_HOME?.trim();
+  if (!explicitHome) {
+    return getHomeDir();
+  }
+  if (explicitHome === "~") {
+    return getHomeDir();
+  }
+  if (explicitHome.startsWith("~/") || explicitHome.startsWith("~\\")) {
+    return path.join(getHomeDir(), explicitHome.slice(2));
+  }
+  return path.resolve(explicitHome);
+}
+
 /** Return a path under `~/.openclaw/qqbot` without creating it. */
 export function getQQBotDataPath(...subPaths: string[]): string {
-  return path.join(getHomeDir(), ".openclaw", "qqbot", ...subPaths);
+  return path.join(resolveOpenClawHomeDir(), ".openclaw", "qqbot", ...subPaths);
 }
 
 /** Return a path under `~/.openclaw/qqbot`, creating it on demand. */
@@ -60,7 +74,7 @@ export function getQQBotDataDir(...subPaths: string[]): string {
  * downloaded images and audio can be accessed by framework media tooling.
  */
 export function getQQBotMediaPath(...subPaths: string[]): string {
-  return path.join(getHomeDir(), ".openclaw", "media", "qqbot", ...subPaths);
+  return path.join(resolveOpenClawHomeDir(), ".openclaw", "media", "qqbot", ...subPaths);
 }
 
 /** Return a path under `~/.openclaw/media/qqbot`, creating it on demand. */
@@ -83,7 +97,7 @@ export function getQQBotMediaDir(...subPaths: string[]): string {
  * the check anchored to a single, well-known directory.
  */
 function getOpenClawMediaDir(): string {
-  return path.join(getHomeDir(), ".openclaw", "media");
+  return path.join(resolveOpenClawHomeDir(), ".openclaw", "media");
 }
 
 // ---- Basic platform information ----

--- a/extensions/qqbot/src/engine/utils/platform.ts
+++ b/extensions/qqbot/src/engine/utils/platform.ts
@@ -13,6 +13,14 @@ import { getPlatformAdapter } from "../adapter/index.js";
 import { formatErrorMessage } from "./format.js";
 import { debugLog, debugWarn } from "./log.js";
 
+function normalizeEnvPath(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed || trimmed === "undefined" || trimmed === "null") {
+    return undefined;
+  }
+  return trimmed;
+}
+
 /**
  * Resolve the current user's home directory safely across platforms.
  *
@@ -39,23 +47,25 @@ export function getHomeDir(): string {
   return getPlatformAdapter().getTempDir();
 }
 
-function resolveOpenClawHomeDir(): string {
-  const explicitHome = process.env.OPENCLAW_HOME?.trim();
+function resolveOpenClawMediaHomeDir(): string {
+  const explicitHome = normalizeEnvPath(process.env.OPENCLAW_HOME);
   if (!explicitHome) {
     return getHomeDir();
   }
-  if (explicitHome === "~") {
-    return getHomeDir();
-  }
   if (explicitHome.startsWith("~/") || explicitHome.startsWith("~\\")) {
-    return path.join(getHomeDir(), explicitHome.slice(2));
+    const envHome = normalizeEnvPath(process.env.HOME) ?? normalizeEnvPath(process.env.USERPROFILE);
+    return envHome ? path.resolve(explicitHome.replace(/^~(?=$|[\\/])/, envHome)) : getHomeDir();
+  }
+  if (explicitHome === "~") {
+    const envHome = normalizeEnvPath(process.env.HOME) ?? normalizeEnvPath(process.env.USERPROFILE);
+    return envHome ? path.resolve(envHome) : getHomeDir();
   }
   return path.resolve(explicitHome);
 }
 
 /** Return a path under `~/.openclaw/qqbot` without creating it. */
 export function getQQBotDataPath(...subPaths: string[]): string {
-  return path.join(resolveOpenClawHomeDir(), ".openclaw", "qqbot", ...subPaths);
+  return path.join(getHomeDir(), ".openclaw", "qqbot", ...subPaths);
 }
 
 /** Return a path under `~/.openclaw/qqbot`, creating it on demand. */
@@ -74,7 +84,7 @@ export function getQQBotDataDir(...subPaths: string[]): string {
  * downloaded images and audio can be accessed by framework media tooling.
  */
 export function getQQBotMediaPath(...subPaths: string[]): string {
-  return path.join(resolveOpenClawHomeDir(), ".openclaw", "media", "qqbot", ...subPaths);
+  return path.join(resolveOpenClawMediaHomeDir(), ".openclaw", "media", "qqbot", ...subPaths);
 }
 
 /** Return a path under `~/.openclaw/media/qqbot`, creating it on demand. */
@@ -97,7 +107,7 @@ export function getQQBotMediaDir(...subPaths: string[]): string {
  * the check anchored to a single, well-known directory.
  */
 function getOpenClawMediaDir(): string {
-  return path.join(resolveOpenClawHomeDir(), ".openclaw", "media");
+  return path.join(resolveOpenClawMediaHomeDir(), ".openclaw", "media");
 }
 
 // ---- Basic platform information ----


### PR DESCRIPTION
Fixes #83562.

## Summary
- Make QQ Bot data/media roots resolve from `OPENCLAW_HOME` when it is configured, matching OpenClaw core state path behavior.
- Keep existing `HOME` behavior as the fallback when `OPENCLAW_HOME` is not set.
- Add regression coverage proving a QQ Bot media file under `$OPENCLAW_HOME/.openclaw/media/qqbot` is accepted by the structured payload local-file guard.

## Scout audit
- Audit A (existing helper): core has `resolveStateDir`/home resolution in `src/utils.ts`, but this extension helper avoids importing core internals; local path helper reused by existing QQ Bot data/media functions.
- Audit B (shared callers): `getQQBotDataPath`, `getQQBotMediaPath`, and shared media-root guard keep the same returned shape under `.openclaw`; only base home resolution changes when `OPENCLAW_HOME` is explicitly configured.
- Audit C (broader rival): no open rival PR found for `#83562` / `qqbot media OPENCLAW_HOME`.

## Validation
- `pnpm test extensions/qqbot/src/engine/utils/platform.test.ts` -> 9 passed
- `git diff --check` -> passed
- `pnpm check:changed` -> passed
