### PR TITLE
fix(browser): allow browser.upload from managed inbound media dir [AI-assisted]

### DIFF
--- a/extensions/browser/src/browser-tool.runtime.ts
+++ b/extensions/browser/src/browser-tool.runtime.ts
@@ -39,6 +39,7 @@ export {
 export { resolveBrowserConfig, resolveProfile } from "./browser/config.js";
 export { DEFAULT_AI_SNAPSHOT_MAX_CHARS } from "./browser/constants.js";
 export { DEFAULT_UPLOAD_DIR, resolveExistingPathsWithinRoot } from "./browser/paths.js";
+export { getMediaDir } from "openclaw/plugin-sdk/media-runtime";
 export { getBrowserProfileCapabilities } from "./browser/profile-capabilities.js";
 export { applyBrowserProxyPaths, persistBrowserProxyFiles } from "./browser/proxy-files.js";
 export {

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -199,10 +199,16 @@ vi.mock("./browser-tool.runtime.js", () => {
     persistBrowserProxyFiles: vi.fn(async () => new Map<string, string>()),
     readStringParam,
     readStringValue,
-    resolveExistingPathsWithinRoot: vi.fn(async ({ requestedPaths }) => ({
-      ok: true,
-      paths: requestedPaths,
-    })),
+    getMediaDir: vi.fn(() => "/tmp/openclaw-media"),
+    resolveExistingPathsWithinRoot: vi.fn(
+      async ({ rootDir, requestedPaths }: { rootDir: string; requestedPaths: string[] }) => {
+        const allWithin = requestedPaths.every((p) => p.startsWith(rootDir));
+        if (!allWithin) {
+          return { ok: false as const, error: `Invalid path: must stay within ${rootDir}` };
+        }
+        return { ok: true as const, paths: requestedPaths };
+      },
+    ),
     resolveNodeIdFromList: (nodes: Array<Record<string, unknown>>, requested: string) => {
       const node = nodes.find(
         (entry) => entry.nodeId === requested || entry.displayName === requested,
@@ -1377,5 +1383,52 @@ describe("browser tool act stale target recovery", () => {
     ).rejects.toThrow(/Run action=tabs profile="user"/i);
 
     expect(browserActionsMocks.browserAct).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("browser tool upload", () => {
+  registerBrowserToolAfterEachReset();
+
+  it("accepts paths under the default uploads directory", async () => {
+    const tool = createBrowserTool();
+    const filePath = "/tmp/openclaw-browser-uploads/file.pdf";
+    await tool.execute?.("call-1", {
+      action: "upload",
+      ref: "input-1",
+      paths: [filePath],
+    });
+
+    const opts = lastMockCallArg<{ paths?: string[] }>(
+      browserActionsMocks.browserArmFileChooser,
+      1,
+    );
+    expect(opts.paths).toEqual([filePath]);
+  });
+
+  it("accepts paths under the managed inbound media directory", async () => {
+    const tool = createBrowserTool();
+    const filePath = "/tmp/openclaw-media/inbound/abc123.pdf";
+    await tool.execute?.("call-1", {
+      action: "upload",
+      ref: "input-1",
+      paths: [filePath],
+    });
+
+    const opts = lastMockCallArg<{ paths?: string[] }>(
+      browserActionsMocks.browserArmFileChooser,
+      1,
+    );
+    expect(opts.paths).toEqual([filePath]);
+  });
+
+  it("rejects paths outside both allowed roots", async () => {
+    const tool = createBrowserTool();
+    await expect(
+      tool.execute?.("call-1", {
+        action: "upload",
+        ref: "input-1",
+        paths: ["/etc/passwd"],
+      }),
+    ).rejects.toThrow(/uploads directory.*inbound media directory/);
   });
 });

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import path from "node:path";
 import {
   executeActAction,
   executeConsoleAction,
@@ -28,6 +29,7 @@ import {
   callGatewayTool,
   getRuntimeConfig,
   getBrowserProfileCapabilities,
+  getMediaDir,
   imageResultFromFile,
   jsonResult,
   listNodes,
@@ -823,15 +825,34 @@ export function createBrowserTool(opts?: {
           if (paths.length === 0) {
             throw new Error("paths required");
           }
-          const uploadPathsResult = await resolveExistingPathsWithinRoot({
-            rootDir: DEFAULT_UPLOAD_DIR,
-            requestedPaths: paths,
-            scopeLabel: `uploads directory (${DEFAULT_UPLOAD_DIR})`,
-          });
-          if (!uploadPathsResult.ok) {
-            throw new Error(uploadPathsResult.error);
+          // Accept paths from either the browser uploads dir or the managed
+          // inbound media dir (e.g. WebChat attachments saved by saveMediaBuffer).
+          // Both are OpenClaw-managed, path-safe roots.
+          const inboundMediaDir = path.join(getMediaDir(), "inbound");
+          const uploadsScope = `uploads directory (${DEFAULT_UPLOAD_DIR})`;
+          const inboundScope = `inbound media directory (${inboundMediaDir})`;
+          const normalizedPaths: string[] = [];
+          for (const requested of paths) {
+            const uploadsResult = await resolveExistingPathsWithinRoot({
+              rootDir: DEFAULT_UPLOAD_DIR,
+              requestedPaths: [requested],
+              scopeLabel: uploadsScope,
+            });
+            if (uploadsResult.ok) {
+              normalizedPaths.push(...uploadsResult.paths);
+              continue;
+            }
+            const inboundResult = await resolveExistingPathsWithinRoot({
+              rootDir: inboundMediaDir,
+              requestedPaths: [requested],
+              scopeLabel: inboundScope,
+            });
+            if (inboundResult.ok) {
+              normalizedPaths.push(...inboundResult.paths);
+              continue;
+            }
+            throw new Error(`Invalid path: must stay within ${uploadsScope} or ${inboundScope}`);
           }
-          const normalizedPaths = uploadPathsResult.paths;
           const ref = readStringParam(params, "ref");
           const inputRef = readStringParam(params, "inputRef");
           const element = readStringParam(params, "element");


### PR DESCRIPTION
> 🤖 AI-assisted (built with Codex via Hermes orchestration). Test level: lightly tested. Prompt summary available on request.

## Summary
- Problem: `browser.upload` rejects file paths that live under the managed inbound media directory (`$HOME/.openclaw/media/inbound/`), where WebChat attachments saved by `saveMediaBuffer` are persisted.
- Why it matters: When a user uploads a PDF/image in WebChat and the agent tries to forward it to a web form via `browser.upload`, the call fails with `"Invalid path: must stay within uploads directory"`, forcing agents to copy the file into `<tmp>/openclaw/uploads/` first.
- What changed: `case "upload":` in `browser-tool.ts` now accepts paths under either `DEFAULT_UPLOAD_DIR` or `path.join(getMediaDir(), "inbound")`. Each requested path is checked against `DEFAULT_UPLOAD_DIR` first; on miss, it is checked against the inbound media dir using the same `resolveExistingPathsWithinRoot` helper. Error message lists both allowed scopes.
- What did NOT change (scope boundary): `DEFAULT_UPLOAD_DIR` itself, the `resolveExistingPathsWithinRoot` helper, any other browser action, or any other tool. No new permissions or capabilities; both roots are existing OpenClaw-managed 0o700 directories with identical path-safety guarantees.

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [x] Extensions

## Linked Issue/PR
- Closes #83544
- [x] This PR fixes a bug or regression

## Root Cause
- Root cause: The `browser.upload` allowlist hard-coded a single root (`DEFAULT_UPLOAD_DIR`), but the WebChat ingress writes attachments into the separate managed media tree (`getMediaDir()/inbound/`). The two managed roots had no overlap, so any path the agent received via `media://inbound/<id>` was rejected on the upload path.
- Missing detection / guardrail: No unit test exercised `browser.upload` with a path outside the uploads dir, so the missing inbound-media branch went unnoticed.
- Contributing context (if known): WebChat attachment plumbing and `browser.upload` were designed independently; the upload tool was never updated when managed inbound media became a routine source for agent-driven flows.

## Regression Test Plan
- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `extensions/browser/src/browser-tool.test.ts` (new `describe("browser tool upload", ...)` block)
- Scenario the test should lock in: `browser.upload` accepts a path under the default uploads dir, accepts a path under the managed inbound media dir, and rejects a path under neither (e.g. `/etc/passwd`) with an error mentioning both scopes.
- Why this is the smallest reliable guardrail: The bug is purely in the allowlist branching inside the `case "upload":` block; a unit test that calls the tool with each of the two valid roots plus one invalid root directly covers the regression without needing a real browser or filesystem.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes
- `browser.upload` now accepts paths that resolve inside `$HOME/.openclaw/media/inbound/` in addition to the existing `<tmp>/openclaw/uploads/` root. Existing behavior for the uploads root is unchanged. The error message when both roots reject the path now lists both allowed scopes.

## Security Impact (required)
- New permissions/capabilities? No
- Both accepted roots are existing OpenClaw-managed directories (mode `0o700`, validated for size/MIME/path-safety on write by `saveMediaBuffer` / the browser uploads pipeline). The added branch uses the same `resolveExistingPathsWithinRoot` helper that already gates the original root, so symlink-escape and path-traversal protections are unchanged. No new filesystem locations are exposed and no new write surface is added.
