### PR TITLE
feat(mattermost): add /model dialog picker

### DIFF
--- a/docs/channels/mattermost.md
+++ b/docs/channels/mattermost.md
@@ -85,6 +85,7 @@ Native slash commands are opt-in. When enabled, OpenClaw registers `oc_*` slash 
     - If `callbackUrl` is omitted, OpenClaw derives one from gateway host/port + `callbackPath`.
     - For multi-account setups, `commands` can be set at the top level or under `channels.mattermost.accounts.<id>.commands` (account values override top-level fields).
     - Command callbacks are validated with the per-command tokens returned by Mattermost when OpenClaw registers `oc_*` commands.
+    - When Mattermost includes a `trigger_id`, `/model` and `/models` open a dialog-backed picker. If the dialog cannot be opened, OpenClaw falls back to the older message-based picker.
     - OpenClaw refreshes current Mattermost command registration before accepting each callback so stale tokens from deleted or regenerated slash commands stop being accepted without a gateway restart.
     - Callback validation fails closed if the Mattermost API cannot confirm the command is still current; failed validations are cached briefly, concurrent lookups are coalesced, and fresh lookup starts are rate-limited per command to bound replay pressure.
     - Slash callbacks fail closed when registration failed, startup was partial, or the callback token does not match the resolved command's registered token (a token valid for one command cannot reach upstream validation for a different command).
@@ -371,10 +372,10 @@ When a user clicks a button:
   </Accordion>
   <Accordion title="Config and reachability">
     - `channels.mattermost.capabilities`: array of capability strings. Add `"inlineButtons"` to enable the buttons tool description in the agent system prompt.
-    - `channels.mattermost.interactions.callbackBaseUrl`: optional external base URL for button callbacks (for example `https://gateway.example.com`). Use this when Mattermost cannot reach the gateway at its bind host directly.
+    - `channels.mattermost.interactions.callbackBaseUrl`: optional external base URL for button callbacks and `/model` dialog submit/refresh callbacks (for example `https://gateway.example.com`). Use this when Mattermost cannot reach the gateway at its bind host directly.
     - In multi-account setups, you can also set the same field under `channels.mattermost.accounts.<id>.interactions.callbackBaseUrl`.
     - If `interactions.callbackBaseUrl` is omitted, OpenClaw derives the callback URL from `gateway.customBindHost` + `gateway.port`, then falls back to `http://localhost:<port>`.
-    - Reachability rule: the button callback URL must be reachable from the Mattermost server. `localhost` only works when Mattermost and OpenClaw run on the same host/network namespace.
+    - Reachability rule: the button/dialog callback URL must be reachable from the Mattermost server. `localhost` only works when Mattermost and OpenClaw run on the same host/network namespace.
     - If your callback target is private/tailnet/internal, add its host/domain to Mattermost `ServiceSettings.AllowedUntrustedInternalConnections`.
 
   </Accordion>

--- a/extensions/mattermost/src/mattermost/client.test.ts
+++ b/extensions/mattermost/src/mattermost/client.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   createMattermostClient,
+  openMattermostInteractiveDialog,
   createMattermostPost,
   normalizeMattermostBaseUrl,
   updateMattermostPost,
@@ -268,6 +269,42 @@ describe("createMattermostPost", () => {
 
     const body = parseRequestJson(calls[0].init);
     expect(body.props).toBeUndefined();
+  });
+});
+
+describe("openMattermostInteractiveDialog", () => {
+  it("posts the trigger id, callback url, and dialog to the Mattermost API", async () => {
+    const { client, calls } = createTestClient({ body: {} });
+
+    await openMattermostInteractiveDialog(client, {
+      triggerId: "trigger-1",
+      url: "https://gateway.example.com/mattermost/interactions/acct",
+      dialog: {
+        callback_id: "oc_model_picker",
+        title: "Model Picker",
+        elements: [],
+      },
+    });
+
+    const firstCall = calls[0];
+    if (!firstCall) {
+      throw new Error("expected Mattermost dialog open request");
+    }
+    expect(firstCall.url).toContain("/actions/dialogs/open");
+    if (!firstCall.init) {
+      throw new Error("expected Mattermost dialog open request init");
+    }
+    expect(firstCall.init.method).toBe("POST");
+    const body = parseRequestJson(firstCall.init);
+    expect(body).toEqual({
+      trigger_id: "trigger-1",
+      url: "https://gateway.example.com/mattermost/interactions/acct",
+      dialog: {
+        callback_id: "oc_model_picker",
+        title: "Model Picker",
+        elements: [],
+      },
+    });
   });
 });
 

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -531,6 +531,24 @@ export async function fetchMattermostUserTeams(
   return await client.request<MattermostTeam[]>(`/users/${userId}/teams`);
 }
 
+export async function openMattermostInteractiveDialog(
+  client: MattermostClient,
+  params: {
+    triggerId: string;
+    url: string;
+    dialog: Record<string, unknown>;
+  },
+): Promise<void> {
+  await client.request<void>("/actions/dialogs/open", {
+    method: "POST",
+    body: JSON.stringify({
+      trigger_id: params.triggerId,
+      url: params.url,
+      dialog: params.dialog,
+    }),
+  });
+}
+
 export async function updateMattermostPost(
   client: MattermostClient,
   postId: string,

--- a/extensions/mattermost/src/mattermost/interactions.test.ts
+++ b/extensions/mattermost/src/mattermost/interactions.test.ts
@@ -593,6 +593,30 @@ describe("createMattermostInteractionHandler", () => {
     };
   }
 
+  function createDialogSubmissionBody(params: {
+    callbackId?: string;
+    channelId?: string;
+    teamId?: string;
+    userId?: string;
+    userName?: string;
+    state?: string;
+    submission?: Record<string, unknown>;
+    type?: string;
+    cancelled?: boolean;
+  }) {
+    return {
+      user_id: params.userId ?? "user-1",
+      ...(params.userName ? { user_name: params.userName } : {}),
+      channel_id: params.channelId ?? "chan-1",
+      team_id: params.teamId ?? "team-1",
+      callback_id: params.callbackId ?? "oc_model_picker",
+      state: params.state ?? "signed-state",
+      submission: params.submission ?? { provider: "openai", model: "gpt-5" },
+      ...(params.type ? { type: params.type } : {}),
+      ...(params.cancelled !== undefined ? { cancelled: params.cancelled } : {}),
+    };
+  }
+
   async function runHandler(
     handler: ReturnType<typeof createMattermostInteractionHandler>,
     params: {
@@ -946,5 +970,58 @@ describe("createMattermostInteractionHandler", () => {
       post: originalPost,
     });
     expect(dispatchButtonClick).not.toHaveBeenCalled();
+  });
+
+  it("routes dialog submissions to the custom dialog handler without button validation", async () => {
+    const requestLog: Array<{ path: string; method?: string }> = [];
+    const handleDialogSubmission = vi.fn().mockResolvedValue({
+      type: "form",
+      form: {
+        callback_id: "oc_model_picker",
+        title: "Model Picker",
+        elements: [],
+      },
+    });
+    const handler = createMattermostInteractionHandler({
+      client: createMattermostClientMock(async (path: string, init?: { method?: string }) => {
+        requestLog.push({ path, method: init?.method });
+        return { ok: true };
+      }),
+      botUserId: "bot",
+      accountId: "acct",
+      handleDialogSubmission,
+    });
+
+    const res = await runHandler(handler, {
+      body: createDialogSubmissionBody({
+        userName: "alice",
+        type: "refresh",
+        submission: {
+          provider: "openai",
+          selected_field: "provider",
+        },
+      }),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe(
+      JSON.stringify({
+        type: "form",
+        form: {
+          callback_id: "oc_model_picker",
+          title: "Model Picker",
+          elements: [],
+        },
+      }),
+    );
+    expect(requestLog).toEqual([]);
+    expect(handleDialogSubmission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        callbackId: "oc_model_picker",
+        requestType: "refresh",
+        state: "signed-state",
+        userName: "alice",
+      }),
+    );
   });
 });

--- a/extensions/mattermost/src/mattermost/interactions.ts
+++ b/extensions/mattermost/src/mattermost/interactions.ts
@@ -35,12 +35,31 @@ type MattermostInteractionPayload = {
   context?: Record<string, unknown>;
 };
 
+type MattermostDialogSubmissionPayload = {
+  user_id: string;
+  user_name?: string;
+  channel_id: string;
+  team_id?: string;
+  callback_id?: string;
+  state?: string;
+  submission?: Record<string, unknown>;
+  cancelled?: boolean;
+  type?: string;
+};
+
 export type MattermostInteractionResponse = {
   update?: {
     message: string;
     props?: Record<string, unknown>;
   };
   ephemeral_text?: string;
+};
+
+export type MattermostDialogSubmitResponse = {
+  error?: string;
+  errors?: Record<string, string>;
+  type?: string;
+  form?: Record<string, unknown>;
 };
 
 type MattermostInteractionAuthorizationResult =
@@ -387,6 +406,14 @@ export function createMattermostInteractionHandler(params: {
     context: Record<string, unknown>;
     post: MattermostPost;
   }) => Promise<MattermostInteractionResponse | null>;
+  handleDialogSubmission?: (opts: {
+    payload: MattermostDialogSubmissionPayload;
+    userName: string;
+    callbackId: string;
+    state: string;
+    submission: Record<string, unknown>;
+    requestType: "submit" | "refresh";
+  }) => Promise<MattermostDialogSubmitResponse | null>;
   authorizeButtonClick?: (opts: {
     payload: MattermostInteractionPayload;
     post: MattermostPost;
@@ -450,6 +477,48 @@ export function createMattermostInteractionHandler(params: {
       res.setHeader("Content-Type", "application/json");
       res.end(JSON.stringify({ error: "Invalid request body" }));
       return;
+    }
+
+    const dialogPayload = payload as MattermostDialogSubmissionPayload;
+    const callbackId = normalizeOptionalString(dialogPayload.callback_id);
+    if (callbackId) {
+      if (!params.handleDialogSubmission) {
+        res.statusCode = 400;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ error: "Dialog submissions are not enabled" }));
+        return;
+      }
+      const state = normalizeOptionalString(dialogPayload.state) ?? "";
+      const submission =
+        dialogPayload.submission && typeof dialogPayload.submission === "object"
+          ? dialogPayload.submission
+          : {};
+      try {
+        const response = await params.handleDialogSubmission({
+          payload: dialogPayload,
+          userName: dialogPayload.user_name ?? dialogPayload.user_id,
+          callbackId,
+          state,
+          submission,
+          requestType: dialogPayload.type === "refresh" ? "refresh" : "submit",
+        });
+        if (response === null) {
+          res.statusCode = 400;
+          res.setHeader("Content-Type", "application/json");
+          res.end(JSON.stringify({ error: "Unknown dialog callback" }));
+          return;
+        }
+        res.statusCode = 200;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify(response));
+        return;
+      } catch (err) {
+        log?.(`mattermost interaction: dialog handler failed: ${String(err)}`);
+        res.statusCode = 500;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ error: "Dialog handler failed" }));
+        return;
+      }
     }
 
     const context = payload.context;

--- a/extensions/mattermost/src/mattermost/model-picker.test.ts
+++ b/extensions/mattermost/src/mattermost/model-picker.test.ts
@@ -3,13 +3,22 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../runtime-api.js";
+import { setInteractionSecret } from "./interactions.js";
 import {
+  buildMattermostModelPickerDialog,
+  buildMattermostModelPickerDialogState,
+  buildMattermostModelPickerSelectionCommand,
   buildMattermostAllowedModelRefs,
+  MATTERMOST_MODEL_PICKER_DIALOG_CALLBACK_ID,
+  MATTERMOST_MODEL_PICKER_RUNTIME_KEEP_CURRENT,
+  parseMattermostModelPickerDialogState,
   parseMattermostModelPickerContext,
   renderMattermostModelSummaryView,
   renderMattermostModelsPickerView,
   renderMattermostProviderPickerView,
   resolveMattermostModelPickerCurrentModel,
+  resolveMattermostModelPickerCurrentRuntime,
+  resolveMattermostModelPickerDialogValues,
   resolveMattermostModelPickerEntry,
 } from "./model-picker.js";
 
@@ -27,6 +36,52 @@ const data = {
 };
 
 describe("Mattermost model picker", () => {
+  it("round-trips signed dialog state", () => {
+    setInteractionSecret("acct", "bot-token");
+    const state = buildMattermostModelPickerDialogState({
+      ownerUserId: "user-1",
+      channelId: "chan-1",
+      teamId: "team-1",
+      accountId: "acct",
+    });
+
+    expect(
+      parseMattermostModelPickerDialogState({
+        state,
+        accountId: "acct",
+      }),
+    ).toEqual({
+      v: 1,
+      ownerUserId: "user-1",
+      channelId: "chan-1",
+      teamId: "team-1",
+    });
+  });
+
+  it("rejects tampered dialog state", () => {
+    setInteractionSecret("acct", "bot-token");
+    const state = buildMattermostModelPickerDialogState({
+      ownerUserId: "user-1",
+      channelId: "chan-1",
+      accountId: "acct",
+    });
+    const decoded = JSON.parse(Buffer.from(state, "base64url").toString("utf8")) as {
+      ownerUserId: string;
+      channelId: string;
+      _token: string;
+      v: number;
+    };
+    decoded.channelId = "chan-2";
+    const tampered = Buffer.from(JSON.stringify(decoded), "utf8").toString("base64url");
+
+    expect(
+      parseMattermostModelPickerDialogState({
+        state: tampered,
+        accountId: "acct",
+      }),
+    ).toBeNull();
+  });
+
   it("resolves bare /model and /models entry points", () => {
     expect(resolveMattermostModelPickerEntry("/model")).toEqual({ kind: "summary" });
     expect(resolveMattermostModelPickerEntry("/models")).toEqual({ kind: "providers" });
@@ -181,5 +236,120 @@ describe("Mattermost model picker", () => {
     } finally {
       fs.rmSync(testDir, { recursive: true, force: true });
     }
+  });
+
+  it("resolves the current runtime from session overrides and config", () => {
+    const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "mm-model-picker-runtime-"));
+    try {
+      const cfg: OpenClawConfig = {
+        session: {
+          store: path.join(testDir, "{agentId}.json"),
+        },
+        agents: {
+          defaults: {
+            agentRuntime: {
+              id: "pi",
+            },
+          },
+          list: [
+            {
+              id: "support",
+              agentRuntime: {
+                id: "claude-cli",
+              },
+            },
+          ],
+        },
+      };
+
+      expect(
+        resolveMattermostModelPickerCurrentRuntime({
+          cfg,
+          route: {
+            agentId: "support",
+            sessionKey: "agent:support:main",
+          },
+        }),
+      ).toBe("claude-cli");
+
+      fs.writeFileSync(
+        path.join(testDir, "support.json"),
+        JSON.stringify({
+          "agent:support:main": {
+            agentRuntimeOverride: "codex",
+          },
+        }),
+      );
+
+      expect(
+        resolveMattermostModelPickerCurrentRuntime({
+          cfg,
+          route: {
+            agentId: "support",
+            sessionKey: "agent:support:main",
+          },
+        }),
+      ).toBe("codex");
+    } finally {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it("builds a dialog-backed picker with provider, model, and runtime fields", () => {
+    setInteractionSecret("acct", "bot-token");
+    const dialog = buildMattermostModelPickerDialog({
+      accountId: "acct",
+      ownerUserId: "user-1",
+      channelId: "chan-1",
+      teamId: "team-1",
+      callbackUrl: "https://gateway.example.com/mattermost/interactions/acct",
+      data,
+      currentModel: "openai/gpt-5",
+      currentRuntime: "claude-cli",
+    });
+
+    expect(dialog.callback_id).toBe(MATTERMOST_MODEL_PICKER_DIALOG_CALLBACK_ID);
+    expect(dialog.source_url).toBe("https://gateway.example.com/mattermost/interactions/acct");
+    expect(dialog.introduction_text).toContain("Current: openai/gpt-5");
+    expect(dialog.introduction_text).toContain("Runtime: claude-cli");
+    expect(dialog.elements.map((field) => field.name)).toEqual(["provider", "model", "runtime"]);
+    expect(dialog.elements[0]?.refresh).toBe(true);
+    expect(dialog.elements[2]?.default).toBe(MATTERMOST_MODEL_PICKER_RUNTIME_KEEP_CURRENT);
+  });
+
+  it("normalizes dialog submission values and preserves keep-current runtime", () => {
+    const values = resolveMattermostModelPickerDialogValues({
+      submission: {
+        provider: "OpenAI",
+        model: "gpt-5",
+        runtime: MATTERMOST_MODEL_PICKER_RUNTIME_KEEP_CURRENT,
+        selected_field: "provider",
+      },
+      data,
+      currentModel: "openai/gpt-5",
+      currentRuntime: "claude-cli",
+    });
+
+    expect(values).toEqual({
+      provider: "openai",
+      model: "gpt-5",
+      runtimeChoice: MATTERMOST_MODEL_PICKER_RUNTIME_KEEP_CURRENT,
+      selectedField: "provider",
+    });
+  });
+
+  it("builds /model commands that only add runtime flags when needed", () => {
+    expect(
+      buildMattermostModelPickerSelectionCommand({
+        modelRef: "openai/gpt-5",
+        runtimeChoice: MATTERMOST_MODEL_PICKER_RUNTIME_KEEP_CURRENT,
+      }),
+    ).toBe("/model openai/gpt-5");
+    expect(
+      buildMattermostModelPickerSelectionCommand({
+        modelRef: "openai/gpt-5",
+        runtimeChoice: "codex",
+      }),
+    ).toBe("/model openai/gpt-5 --runtime codex");
   });
 });

--- a/extensions/mattermost/src/mattermost/model-picker.test.ts
+++ b/extensions/mattermost/src/mattermost/model-picker.test.ts
@@ -16,6 +16,7 @@ import {
   renderMattermostModelSummaryView,
   renderMattermostModelsPickerView,
   renderMattermostProviderPickerView,
+  resolveMattermostModelPickerDialogChannelInfo,
   resolveMattermostModelPickerCurrentModel,
   resolveMattermostModelPickerCurrentRuntime,
   resolveMattermostModelPickerDialogValues,
@@ -42,6 +43,13 @@ describe("Mattermost model picker", () => {
       ownerUserId: "user-1",
       channelId: "chan-1",
       teamId: "team-1",
+      channelInfo: {
+        id: "chan-1",
+        type: "O",
+        name: "secret-planning",
+        display_name: "Secret Planning",
+        team_id: "team-1",
+      },
       accountId: "acct",
     });
 
@@ -55,6 +63,11 @@ describe("Mattermost model picker", () => {
       ownerUserId: "user-1",
       channelId: "chan-1",
       teamId: "team-1",
+      channelSnapshot: {
+        type: "O",
+        name: "secret-planning",
+        displayName: "Secret Planning",
+      },
     });
   });
 
@@ -302,6 +315,13 @@ describe("Mattermost model picker", () => {
       ownerUserId: "user-1",
       channelId: "chan-1",
       teamId: "team-1",
+      channelInfo: {
+        id: "chan-1",
+        type: "D",
+        name: "user-1__user-2",
+        display_name: "DM",
+        team_id: "team-1",
+      },
       callbackUrl: "https://gateway.example.com/mattermost/interactions/acct",
       data,
       currentModel: "openai/gpt-5",
@@ -315,6 +335,18 @@ describe("Mattermost model picker", () => {
     expect(dialog.elements.map((field) => field.name)).toEqual(["provider", "model", "runtime"]);
     expect(dialog.elements[0]?.refresh).toBe(true);
     expect(dialog.elements[2]?.default).toBe(MATTERMOST_MODEL_PICKER_RUNTIME_KEEP_CURRENT);
+    const dialogState = parseMattermostModelPickerDialogState({
+      state: dialog.state,
+      accountId: "acct",
+    });
+    expect(dialogState).toBeTruthy();
+    expect(resolveMattermostModelPickerDialogChannelInfo(dialogState!)).toEqual({
+      id: "chan-1",
+      type: "D",
+      name: "user-1__user-2",
+      display_name: "DM",
+      team_id: "team-1",
+    });
   });
 
   it("normalizes dialog submission values and preserves keep-current runtime", () => {

--- a/extensions/mattermost/src/mattermost/model-picker.ts
+++ b/extensions/mattermost/src/mattermost/model-picker.ts
@@ -10,6 +10,7 @@ import {
   normalizeOptionalString,
   normalizeStringifiedOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { MattermostChannel } from "./client.js";
 import {
   generateInteractionToken,
   verifyInteractionToken,
@@ -48,16 +49,53 @@ type MattermostModelPickerDialogStatePayload = {
   ownerUserId: string;
   channelId: string;
   teamId?: string;
+  channelSnapshot?: MattermostModelPickerDialogChannelSnapshot;
 };
 
 type MattermostModelPickerDialogStateSigned = MattermostModelPickerDialogStatePayload & {
   _token: string;
 };
 
+type MattermostModelPickerDialogChannelSnapshot = {
+  type: string;
+  name?: string;
+  displayName?: string;
+};
+
 type MattermostDialogSelectOption = {
   text: string;
   value: string;
 };
+
+function normalizeMattermostModelPickerDialogChannelSnapshot(
+  value: unknown,
+): MattermostModelPickerDialogChannelSnapshot | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const typed = value as Partial<MattermostModelPickerDialogChannelSnapshot>;
+  const type = normalizeOptionalString(typed.type)?.toUpperCase();
+  if (!type) {
+    return undefined;
+  }
+  const name = normalizeOptionalString(typed.name);
+  const displayName = normalizeOptionalString(typed.displayName);
+  return {
+    type,
+    ...(name ? { name } : {}),
+    ...(displayName ? { displayName } : {}),
+  };
+}
+
+function buildMattermostModelPickerDialogChannelSnapshot(
+  channelInfo?: MattermostChannel | null,
+): MattermostModelPickerDialogChannelSnapshot | undefined {
+  return normalizeMattermostModelPickerDialogChannelSnapshot({
+    type: channelInfo?.type,
+    name: channelInfo?.name,
+    displayName: channelInfo?.display_name,
+  });
+}
 
 export type MattermostInteractiveDialogElement = {
   display_name: string;
@@ -308,6 +346,9 @@ function decodeDialogState(value: string): MattermostModelPickerDialogStateSigne
     const channelId = normalizeOptionalString(typed.channelId);
     const teamId = normalizeOptionalString(typed.teamId);
     const token = normalizeOptionalString(typed._token);
+    const channelSnapshot = normalizeMattermostModelPickerDialogChannelSnapshot(
+      typed.channelSnapshot,
+    );
     if (typed.v !== 1 || !ownerUserId || !channelId || !token) {
       return null;
     }
@@ -316,6 +357,7 @@ function decodeDialogState(value: string): MattermostModelPickerDialogStateSigne
       ownerUserId,
       channelId,
       ...(teamId ? { teamId } : {}),
+      ...(channelSnapshot ? { channelSnapshot } : {}),
       _token: token,
     };
   } catch {
@@ -327,8 +369,10 @@ export function buildMattermostModelPickerDialogState(params: {
   ownerUserId: string;
   channelId: string;
   teamId?: string;
+  channelInfo?: MattermostChannel | null;
   accountId?: string;
 }): string {
+  const channelSnapshot = buildMattermostModelPickerDialogChannelSnapshot(params.channelInfo);
   const payload: MattermostModelPickerDialogStatePayload = {
     v: 1,
     ownerUserId: normalizeOptionalString(params.ownerUserId) ?? "",
@@ -336,6 +380,7 @@ export function buildMattermostModelPickerDialogState(params: {
     ...(normalizeOptionalString(params.teamId)
       ? { teamId: normalizeOptionalString(params.teamId) }
       : {}),
+    ...(channelSnapshot ? { channelSnapshot } : {}),
   };
   if (!payload.ownerUserId || !payload.channelId) {
     throw new Error("Mattermost model picker dialog state requires ownerUserId and channelId");
@@ -360,6 +405,22 @@ export function parseMattermostModelPickerDialogState(params: {
     return null;
   }
   return unsigned;
+}
+
+export function resolveMattermostModelPickerDialogChannelInfo(
+  state: MattermostModelPickerDialogStatePayload,
+): MattermostChannel | null {
+  const snapshot = state.channelSnapshot;
+  if (!snapshot?.type) {
+    return null;
+  }
+  return {
+    id: state.channelId,
+    type: snapshot.type,
+    ...(snapshot.name ? { name: snapshot.name } : {}),
+    ...(snapshot.displayName ? { display_name: snapshot.displayName } : {}),
+    ...(state.teamId ? { team_id: state.teamId } : {}),
+  };
 }
 
 export function resolveMattermostModelPickerCurrentModel(params: {
@@ -548,6 +609,7 @@ export function buildMattermostModelPickerDialog(params: {
   ownerUserId: string;
   channelId: string;
   teamId?: string;
+  channelInfo?: MattermostChannel | null;
   callbackUrl: string;
   data: ModelsProviderData;
   currentModel?: string;
@@ -593,6 +655,7 @@ export function buildMattermostModelPickerDialog(params: {
         ownerUserId: params.ownerUserId,
         channelId: params.channelId,
         teamId: params.teamId,
+        channelInfo: params.channelInfo,
         accountId: params.accountId,
       }),
     source_url: params.callbackUrl,

--- a/extensions/mattermost/src/mattermost/model-picker.ts
+++ b/extensions/mattermost/src/mattermost/model-picker.ts
@@ -10,9 +10,15 @@ import {
   normalizeOptionalString,
   normalizeStringifiedOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import type { MattermostInteractiveButtonInput } from "./interactions.js";
+import {
+  generateInteractionToken,
+  verifyInteractionToken,
+  type MattermostInteractiveButtonInput,
+} from "./interactions.js";
 
 const MATTERMOST_MODEL_PICKER_CONTEXT_KEY = "oc_model_picker";
+export const MATTERMOST_MODEL_PICKER_DIALOG_CALLBACK_ID = "oc_model_picker";
+export const MATTERMOST_MODEL_PICKER_RUNTIME_KEEP_CURRENT = "__keep_current_runtime__";
 const MODELS_PAGE_SIZE = 8;
 const ACTION_IDS = {
   providers: "mdlprov",
@@ -35,6 +41,45 @@ type MattermostModelPickerState =
 type MattermostModelPickerRenderedView = {
   text: string;
   buttons: MattermostInteractiveButtonInput[][];
+};
+
+type MattermostModelPickerDialogStatePayload = {
+  v: 1;
+  ownerUserId: string;
+  channelId: string;
+  teamId?: string;
+};
+
+type MattermostModelPickerDialogStateSigned = MattermostModelPickerDialogStatePayload & {
+  _token: string;
+};
+
+type MattermostDialogSelectOption = {
+  text: string;
+  value: string;
+};
+
+export type MattermostInteractiveDialogElement = {
+  display_name: string;
+  name: string;
+  type: "select";
+  default?: string;
+  placeholder?: string;
+  help_text?: string;
+  optional?: boolean;
+  options?: MattermostDialogSelectOption[];
+  refresh?: boolean;
+};
+
+export type MattermostInteractiveDialog = {
+  callback_id: string;
+  title: string;
+  introduction_text?: string;
+  elements: MattermostInteractiveDialogElement[];
+  submit_label?: string;
+  notify_on_cancel?: boolean;
+  state: string;
+  source_url?: string;
 };
 
 function splitModelRef(modelRef?: string | null): { provider: string; model: string } | null {
@@ -234,6 +279,89 @@ export function buildMattermostAllowedModelRefs(data: ModelsProviderData): Set<s
   return refs;
 }
 
+function resolveConfiguredAgentRuntimeId(value: {
+  agentRuntime?: { id?: unknown };
+}): string | undefined {
+  return normalizeOptionalString(value.agentRuntime?.id);
+}
+
+function formatRuntimeLabel(runtime?: string): string {
+  const normalized = normalizeOptionalString(runtime) ?? "auto";
+  return normalized === "auto" || normalized === "default" || normalized === "pi"
+    ? "OpenClaw Pi Default"
+    : normalized;
+}
+
+function encodeDialogState(value: MattermostModelPickerDialogStateSigned): string {
+  return Buffer.from(JSON.stringify(value), "utf8").toString("base64url");
+}
+
+function decodeDialogState(value: string): MattermostModelPickerDialogStateSigned | null {
+  try {
+    const decoded = Buffer.from(value, "base64url").toString("utf8");
+    const parsed: unknown = JSON.parse(decoded);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
+    }
+    const typed = parsed as Partial<MattermostModelPickerDialogStateSigned>;
+    const ownerUserId = normalizeOptionalString(typed.ownerUserId);
+    const channelId = normalizeOptionalString(typed.channelId);
+    const teamId = normalizeOptionalString(typed.teamId);
+    const token = normalizeOptionalString(typed._token);
+    if (typed.v !== 1 || !ownerUserId || !channelId || !token) {
+      return null;
+    }
+    return {
+      v: 1,
+      ownerUserId,
+      channelId,
+      ...(teamId ? { teamId } : {}),
+      _token: token,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function buildMattermostModelPickerDialogState(params: {
+  ownerUserId: string;
+  channelId: string;
+  teamId?: string;
+  accountId?: string;
+}): string {
+  const payload: MattermostModelPickerDialogStatePayload = {
+    v: 1,
+    ownerUserId: normalizeOptionalString(params.ownerUserId) ?? "",
+    channelId: normalizeOptionalString(params.channelId) ?? "",
+    ...(normalizeOptionalString(params.teamId)
+      ? { teamId: normalizeOptionalString(params.teamId) }
+      : {}),
+  };
+  if (!payload.ownerUserId || !payload.channelId) {
+    throw new Error("Mattermost model picker dialog state requires ownerUserId and channelId");
+  }
+  const token = generateInteractionToken(payload, params.accountId);
+  return encodeDialogState({
+    ...payload,
+    _token: token,
+  });
+}
+
+export function parseMattermostModelPickerDialogState(params: {
+  state: string;
+  accountId?: string;
+}): MattermostModelPickerDialogStatePayload | null {
+  const decoded = decodeDialogState(params.state);
+  if (!decoded) {
+    return null;
+  }
+  const { _token, ...unsigned } = decoded;
+  if (!verifyInteractionToken(unsigned, _token, params.accountId)) {
+    return null;
+  }
+  return unsigned;
+}
+
 export function resolveMattermostModelPickerCurrentModel(params: {
   cfg: OpenClawConfig;
   route: { agentId: string; sessionKey: string };
@@ -263,6 +391,243 @@ export function resolveMattermostModelPickerCurrentModel(params: {
   } catch {
     return fallback;
   }
+}
+
+export function resolveMattermostModelPickerCurrentRuntime(params: {
+  cfg: OpenClawConfig;
+  route: { agentId: string; sessionKey: string };
+}): string {
+  try {
+    const storePath = resolveStorePath(params.cfg.session?.store, {
+      agentId: params.route.agentId,
+    });
+    const sessionStore = loadSessionStore(storePath, { skipCache: true });
+    const sessionRuntime = normalizeOptionalString(
+      sessionStore[params.route.sessionKey]?.agentRuntimeOverride,
+    );
+    if (sessionRuntime) {
+      return sessionRuntime;
+    }
+  } catch {
+    // Fall through to configured defaults when the session store is unavailable.
+  }
+
+  const agentRuntime = resolveConfiguredAgentRuntimeId(
+    params.cfg.agents?.list?.find(
+      (entry) => normalizeOptionalString(entry.id) === params.route.agentId,
+    ) ?? {},
+  );
+  if (agentRuntime) {
+    return agentRuntime;
+  }
+  return resolveConfiguredAgentRuntimeId(params.cfg.agents?.defaults ?? {}) ?? "auto";
+}
+
+function resolveMattermostModelPickerDialogProvider(params: {
+  data: ModelsProviderData;
+  currentModel?: string;
+  preferredProvider?: string;
+}): string {
+  const preferred = normalizeProviderId(params.preferredProvider ?? "");
+  if (preferred && params.data.byProvider.has(preferred)) {
+    return preferred;
+  }
+  const currentProvider = splitModelRef(params.currentModel)?.provider;
+  if (currentProvider && params.data.byProvider.has(currentProvider)) {
+    return currentProvider;
+  }
+  return params.data.providers[0] ?? params.data.resolvedDefault.provider;
+}
+
+function resolveMattermostModelPickerRuntimeOptions(params: {
+  data: ModelsProviderData;
+  provider: string;
+  currentRuntime?: string;
+}): MattermostDialogSelectOption[] {
+  const keepLabel = `Keep current runtime (${formatRuntimeLabel(params.currentRuntime)})`;
+  const choices = params.data.runtimeChoicesByProvider?.get(
+    normalizeProviderId(params.provider),
+  ) ?? [
+    {
+      id: "pi",
+      label: "OpenClaw Pi Default",
+      description: "Use the built-in OpenClaw Pi runtime.",
+    },
+  ];
+  const options: MattermostDialogSelectOption[] = [
+    {
+      text: keepLabel,
+      value: MATTERMOST_MODEL_PICKER_RUNTIME_KEEP_CURRENT,
+    },
+  ];
+  const seen = new Set<string>([MATTERMOST_MODEL_PICKER_RUNTIME_KEEP_CURRENT]);
+  for (const choice of choices) {
+    if (seen.has(choice.id)) {
+      continue;
+    }
+    seen.add(choice.id);
+    options.push({
+      text: choice.label,
+      value: choice.id,
+    });
+  }
+  return options;
+}
+
+function resolveMattermostModelPickerModelOptions(params: {
+  data: ModelsProviderData;
+  provider: string;
+}): MattermostDialogSelectOption[] {
+  return getProviderModels(params.data, params.provider).map((model) => ({
+    text: model,
+    value: model,
+  }));
+}
+
+export function resolveMattermostModelPickerDialogValues(params: {
+  submission: Record<string, unknown>;
+  data: ModelsProviderData;
+  currentModel?: string;
+  currentRuntime?: string;
+}): {
+  provider: string;
+  model?: string;
+  runtimeChoice: string;
+  selectedField?: string;
+} {
+  const provider = resolveMattermostModelPickerDialogProvider({
+    data: params.data,
+    currentModel: params.currentModel,
+    preferredProvider:
+      typeof params.submission.provider === "string" ? params.submission.provider : undefined,
+  });
+  const rawModel = normalizeOptionalString(
+    typeof params.submission.model === "string" ? params.submission.model : undefined,
+  );
+  const model =
+    rawModel && params.data.byProvider.get(provider)?.has(rawModel) ? rawModel : undefined;
+  const runtimeChoiceRaw = normalizeOptionalString(
+    typeof params.submission.runtime === "string" ? params.submission.runtime : undefined,
+  );
+  const validRuntimeChoices = new Set(
+    resolveMattermostModelPickerRuntimeOptions({
+      data: params.data,
+      provider,
+      currentRuntime: params.currentRuntime,
+    }).map((option) => option.value),
+  );
+  const runtimeChoice =
+    runtimeChoiceRaw && validRuntimeChoices.has(runtimeChoiceRaw)
+      ? runtimeChoiceRaw
+      : MATTERMOST_MODEL_PICKER_RUNTIME_KEEP_CURRENT;
+  const selectedField = normalizeOptionalString(
+    typeof params.submission.selected_field === "string"
+      ? params.submission.selected_field
+      : undefined,
+  );
+  return {
+    provider,
+    ...(model ? { model } : {}),
+    runtimeChoice,
+    ...(selectedField ? { selectedField } : {}),
+  };
+}
+
+export function buildMattermostModelPickerSelectionCommand(params: {
+  modelRef: string;
+  runtimeChoice?: string;
+}): string {
+  const runtime = normalizeOptionalString(params.runtimeChoice);
+  return runtime && runtime !== MATTERMOST_MODEL_PICKER_RUNTIME_KEEP_CURRENT
+    ? `/model ${params.modelRef} --runtime ${runtime}`
+    : `/model ${params.modelRef}`;
+}
+
+export function buildMattermostModelPickerDialog(params: {
+  accountId?: string;
+  ownerUserId: string;
+  channelId: string;
+  teamId?: string;
+  callbackUrl: string;
+  data: ModelsProviderData;
+  currentModel?: string;
+  currentRuntime?: string;
+  preferredProvider?: string;
+  selectedModel?: string;
+  runtimeChoice?: string;
+  state?: string;
+}): MattermostInteractiveDialog {
+  const provider = resolveMattermostModelPickerDialogProvider({
+    data: params.data,
+    currentModel: params.currentModel,
+    preferredProvider: params.preferredProvider,
+  });
+  const modelOptions = resolveMattermostModelPickerModelOptions({
+    data: params.data,
+    provider,
+  });
+  const selectedModel =
+    params.selectedModel && params.data.byProvider.get(provider)?.has(params.selectedModel)
+      ? params.selectedModel
+      : splitModelRef(params.currentModel)?.provider === provider
+        ? splitModelRef(params.currentModel)?.model
+        : undefined;
+  const currentRuntime = params.currentRuntime ?? "auto";
+  const runtimeOptions = resolveMattermostModelPickerRuntimeOptions({
+    data: params.data,
+    provider,
+    currentRuntime,
+  });
+  const runtimeChoice =
+    normalizeOptionalString(params.runtimeChoice) ?? MATTERMOST_MODEL_PICKER_RUNTIME_KEEP_CURRENT;
+
+  return {
+    callback_id: MATTERMOST_MODEL_PICKER_DIALOG_CALLBACK_ID,
+    title: "Model Picker",
+    introduction_text: `${formatCurrentModelLine(params.currentModel)}\nRuntime: ${formatRuntimeLabel(currentRuntime)}`,
+    submit_label: "Apply",
+    notify_on_cancel: false,
+    state:
+      params.state ??
+      buildMattermostModelPickerDialogState({
+        ownerUserId: params.ownerUserId,
+        channelId: params.channelId,
+        teamId: params.teamId,
+        accountId: params.accountId,
+      }),
+    source_url: params.callbackUrl,
+    elements: [
+      {
+        display_name: "Provider",
+        name: "provider",
+        type: "select",
+        default: provider,
+        refresh: true,
+        help_text: "Choose a provider to refresh the model and runtime fields.",
+        options: params.data.providers.map((entry) => ({
+          text: `${entry} (${params.data.byProvider.get(entry)?.size ?? 0})`,
+          value: entry,
+        })),
+      },
+      {
+        display_name: "Model",
+        name: "model",
+        type: "select",
+        ...(selectedModel ? { default: selectedModel } : {}),
+        placeholder: `Select ${provider} model`,
+        help_text: "Choose the model to apply for this session.",
+        options: modelOptions,
+      },
+      {
+        display_name: "Runtime",
+        name: "runtime",
+        type: "select",
+        default: runtimeChoice,
+        help_text: "Leave this on keep current runtime unless you want to switch harnesses too.",
+        options: runtimeOptions,
+      },
+    ],
+  };
 }
 
 export function renderMattermostModelSummaryView(params: {

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1068,9 +1068,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       };
     }
 
-    const channelInfo =
-      (await resolveChannelInfo(params.payload.channel_id)) ??
-      resolveMattermostModelPickerDialogChannelInfo(dialogState);
+    const channelInfo = await resolveChannelInfo(params.payload.channel_id);
     const pickerCommandText =
       pickerState.action === "select"
         ? `/model ${pickerState.provider}/${pickerState.model}`
@@ -1309,7 +1307,9 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       return {};
     }
 
-    const channelInfo = await resolveChannelInfo(params.payload.channel_id);
+    const channelInfo =
+      (await resolveChannelInfo(params.payload.channel_id)) ??
+      resolveMattermostModelPickerDialogChannelInfo(dialogState);
     const allowTextCommands = core.channel.commands.shouldHandleTextCommands({
       cfg,
       surface: "mattermost",

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -46,10 +46,16 @@ import {
 } from "./interactions.js";
 import {
   buildMattermostAllowedModelRefs,
+  buildMattermostModelPickerDialog,
+  buildMattermostModelPickerSelectionCommand,
+  MATTERMOST_MODEL_PICKER_DIALOG_CALLBACK_ID,
   parseMattermostModelPickerContext,
+  parseMattermostModelPickerDialogState,
   renderMattermostModelsPickerView,
   renderMattermostProviderPickerView,
   resolveMattermostModelPickerCurrentModel,
+  resolveMattermostModelPickerCurrentRuntime,
+  resolveMattermostModelPickerDialogValues,
 } from "./model-picker.js";
 import {
   authorizeMattermostCommandInvocation,
@@ -635,6 +641,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       trustedProxies: cfg.gateway?.trustedProxies,
       allowRealIpFallback: cfg.gateway?.allowRealIpFallback === true,
       handleInteraction: handleModelPickerInteraction,
+      handleDialogSubmission: handleModelPickerDialogSubmission,
       authorizeButtonClick: async ({ payload, post }) => {
         const channelInfo = await resolveChannelInfo(payload.channel_id);
         const allowTextCommands = core.channel.commands.shouldHandleTextCommands({
@@ -1248,6 +1255,201 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     })();
 
     return {};
+  }
+
+  async function handleModelPickerDialogSubmission(params: {
+    payload: {
+      channel_id: string;
+      team_id?: string;
+      user_id: string;
+      cancelled?: boolean;
+    };
+    userName: string;
+    callbackId: string;
+    state: string;
+    submission: Record<string, unknown>;
+    requestType: "submit" | "refresh";
+  }): Promise<import("./interactions.js").MattermostDialogSubmitResponse | null> {
+    if (params.callbackId !== MATTERMOST_MODEL_PICKER_DIALOG_CALLBACK_ID) {
+      return null;
+    }
+
+    const dialogState = parseMattermostModelPickerDialogState({
+      state: params.state,
+      accountId: account.accountId,
+    });
+    if (!dialogState) {
+      return {
+        error: "This model picker expired. Run /model again.",
+      };
+    }
+    if (dialogState.ownerUserId !== params.payload.user_id) {
+      return {
+        error: "Only the person who opened this picker can use it.",
+      };
+    }
+    if (dialogState.channelId !== params.payload.channel_id) {
+      return {
+        error: "This model picker is no longer valid for this channel.",
+      };
+    }
+    if (
+      dialogState.teamId &&
+      params.payload.team_id &&
+      dialogState.teamId !== params.payload.team_id
+    ) {
+      return {
+        error: "This model picker is no longer valid for this team.",
+      };
+    }
+    if (params.payload.cancelled) {
+      return {};
+    }
+
+    const channelInfo = await resolveChannelInfo(params.payload.channel_id);
+    const allowTextCommands = core.channel.commands.shouldHandleTextCommands({
+      cfg,
+      surface: "mattermost",
+    });
+    const auth = await authorizeMattermostCommandInvocation({
+      account,
+      cfg,
+      senderId: params.payload.user_id,
+      senderName: params.userName,
+      channelId: params.payload.channel_id,
+      channelInfo,
+      readStoreAllowFrom: pairing.readAllowFromStore,
+      allowTextCommands,
+      hasControlCommand: true,
+    });
+    if (!auth.ok) {
+      return {
+        error:
+          auth.denyReason === "dm-pairing"
+            ? "This bot requires pairing before /model can be used here."
+            : auth.denyReason === "dm-disabled"
+              ? "This bot is not accepting direct messages."
+              : auth.denyReason === "channels-disabled"
+                ? "Model picker actions are disabled in channels."
+                : auth.denyReason === "channel-no-allowlist"
+                  ? "Model picker actions are not configured for this channel."
+                  : auth.denyReason === "unknown-channel"
+                    ? "Temporary error: unable to determine channel type. Please try again."
+                    : "Unauthorized.",
+      };
+    }
+
+    const kind = auth.kind;
+    const chatType = auth.chatType;
+    const teamId = auth.channelInfo.team_id ?? params.payload.team_id ?? undefined;
+    const channelName = auth.channelName || undefined;
+    const channelDisplay = auth.channelDisplay || auth.channelName || params.payload.channel_id;
+    const roomLabel = auth.roomLabel;
+    const route = core.channel.routing.resolveAgentRoute({
+      cfg,
+      channel: "mattermost",
+      accountId: account.accountId,
+      teamId,
+      peer: {
+        kind,
+        id: kind === "direct" ? params.payload.user_id : params.payload.channel_id,
+      },
+    });
+    const modelSessionRoute = {
+      agentId: route.agentId,
+      sessionKey: route.sessionKey,
+    };
+    const data = await buildModelsProviderData(cfg, route.agentId);
+    if (data.providers.length === 0) {
+      return {
+        error: "No models available.",
+      };
+    }
+
+    const currentModel = resolveMattermostModelPickerCurrentModel({
+      cfg,
+      route: modelSessionRoute,
+      data,
+    });
+    const currentRuntime = resolveMattermostModelPickerCurrentRuntime({
+      cfg,
+      route: modelSessionRoute,
+    });
+    const values = resolveMattermostModelPickerDialogValues({
+      submission: params.submission,
+      data,
+      currentModel,
+      currentRuntime,
+    });
+
+    if (params.requestType === "refresh") {
+      return {
+        type: "form",
+        form: buildMattermostModelPickerDialog({
+          accountId: account.accountId,
+          ownerUserId: dialogState.ownerUserId,
+          channelId: dialogState.channelId,
+          teamId: dialogState.teamId,
+          callbackUrl,
+          data,
+          currentModel,
+          currentRuntime,
+          preferredProvider: values.provider,
+          selectedModel: values.model,
+          runtimeChoice: values.runtimeChoice,
+          state: params.state,
+        }) as unknown as Record<string, unknown>,
+      };
+    }
+
+    if (!values.model) {
+      return {
+        errors: {
+          model: "Select a model before applying the change.",
+        },
+      };
+    }
+
+    const targetModelRef = `${values.provider}/${values.model}`;
+    if (!buildMattermostAllowedModelRefs(data).has(targetModelRef)) {
+      return {
+        errors: {
+          model: `That model is no longer available: ${targetModelRef}`,
+        },
+      };
+    }
+
+    try {
+      await runModelPickerCommand({
+        commandText: buildMattermostModelPickerSelectionCommand({
+          modelRef: targetModelRef,
+          runtimeChoice: values.runtimeChoice,
+        }),
+        commandAuthorized: auth.commandAuthorized,
+        route,
+        sessionKey: route.sessionKey,
+        parentSessionKey: undefined,
+        channelId: params.payload.channel_id,
+        senderId: params.payload.user_id,
+        senderName: params.userName,
+        kind,
+        chatType,
+        channelName,
+        channelDisplay,
+        roomLabel,
+        teamId,
+        postId: `dialog-${Date.now()}`,
+        messageSid: `dialog:${params.payload.user_id}:${Date.now()}`,
+        effectiveReplyToId: undefined,
+        deliverReplies: true,
+      });
+      return {};
+    } catch (err) {
+      runtime.error?.(`mattermost model picker dialog submit failed: ${String(err)}`);
+      return {
+        error: `Failed to apply ${targetModelRef}. Try /model ${targetModelRef} directly.`,
+      };
+    }
   }
 
   const handlePost = async (

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -53,6 +53,7 @@ import {
   parseMattermostModelPickerDialogState,
   renderMattermostModelsPickerView,
   renderMattermostProviderPickerView,
+  resolveMattermostModelPickerDialogChannelInfo,
   resolveMattermostModelPickerCurrentModel,
   resolveMattermostModelPickerCurrentRuntime,
   resolveMattermostModelPickerDialogValues,
@@ -1067,7 +1068,9 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       };
     }
 
-    const channelInfo = await resolveChannelInfo(params.payload.channel_id);
+    const channelInfo =
+      (await resolveChannelInfo(params.payload.channel_id)) ??
+      resolveMattermostModelPickerDialogChannelInfo(dialogState);
     const pickerCommandText =
       pickerState.action === "select"
         ? `/model ${pickerState.provider}/${pickerState.model}`

--- a/extensions/mattermost/src/mattermost/slash-http.send-config.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.send-config.test.ts
@@ -5,9 +5,16 @@ import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ResolvedMattermostAccount } from "./accounts.js";
 
+type ParseSlashCommandPayload = typeof import("./slash-commands.js").parseSlashCommandPayload;
+type BuildModelsProviderData = typeof import("./runtime-api.js").buildModelsProviderData;
+type AuthorizeMattermostCommandInvocation =
+  typeof import("./monitor-auth.js").authorizeMattermostCommandInvocation;
+type FetchMattermostChannel = typeof import("./client.js").fetchMattermostChannel;
+type GetMattermostCommand = typeof import("./slash-commands.js").getMattermostCommand;
+
 const mockState = vi.hoisted(() => ({
   readRequestBodyWithLimit: vi.fn(async () => "token=valid-token"),
-  parseSlashCommandPayload: vi.fn(() => ({
+  parseSlashCommandPayload: vi.fn<ParseSlashCommandPayload>(() => ({
     token: "valid-token",
     command: "/oc_models",
     text: "models",
@@ -17,7 +24,15 @@ const mockState = vi.hoisted(() => ({
     team_id: "team-1",
   })),
   resolveCommandText: vi.fn((_trigger: string, text: string) => text),
-  buildModelsProviderData: vi.fn(async () => ({ providers: [], modelNames: new Map() })),
+  buildModelsProviderData: vi.fn<BuildModelsProviderData>(async () => ({
+    providers: [],
+    byProvider: new Map(),
+    resolvedDefault: {
+      provider: "",
+      model: "",
+    },
+    modelNames: new Map(),
+  })),
   resolveMattermostModelPickerEntry: vi.fn(() => ({ kind: "summary" })),
   buildMattermostModelPickerDialog: vi.fn(() => ({
     callback_id: "oc_model_picker",
@@ -25,7 +40,7 @@ const mockState = vi.hoisted(() => ({
     elements: [],
   })),
   resolveMattermostModelPickerCurrentRuntime: vi.fn(() => "auto"),
-  authorizeMattermostCommandInvocation: vi.fn(() => ({
+  authorizeMattermostCommandInvocation: vi.fn<AuthorizeMattermostCommandInvocation>(async () => ({
     ok: true,
     commandAuthorized: true,
     channelInfo: { id: "chan-1", type: "O", name: "town-square", display_name: "Town Square" },
@@ -37,7 +52,7 @@ const mockState = vi.hoisted(() => ({
   })),
   createMattermostClient: vi.fn(() => ({})),
   openMattermostInteractiveDialog: vi.fn(async () => undefined),
-  fetchMattermostChannel: vi.fn(async () => ({
+  fetchMattermostChannel: vi.fn<FetchMattermostChannel>(async () => ({
     id: "chan-1",
     type: "O",
     name: "town-square",
@@ -45,13 +60,14 @@ const mockState = vi.hoisted(() => ({
   })),
   sendMessageMattermost: vi.fn(async () => ({ messageId: "post-1", channelId: "chan-1" })),
   normalizeMattermostAllowList: vi.fn((value: unknown) => value),
-  getMattermostCommand: vi.fn(async () => ({
+  getMattermostCommand: vi.fn<GetMattermostCommand>(async () => ({
     id: "cmd-1",
     token: "valid-token",
     team_id: "team-1",
     trigger: "oc_models",
     method: "P",
     url: "https://gateway.example.com/slash",
+    auto_complete: true,
     delete_at: 0,
   })),
   listMattermostCommands: vi.fn(async () => []),
@@ -353,19 +369,29 @@ describe("slash-http cfg threading", () => {
       trigger: "oc_model",
       method: "P",
       url: callbackUrlFixture,
+      auto_complete: true,
       delete_at: 0,
     });
     mockState.authorizeMattermostCommandInvocation.mockImplementationOnce(
-      async ({ channelInfo }) => ({
-        ok: true,
-        commandAuthorized: true,
-        channelInfo,
-        kind: "channel",
-        chatType: "channel",
-        channelName: channelInfo?.name ?? "",
-        channelDisplay: channelInfo?.display_name ?? channelInfo?.name ?? "",
-        roomLabel: channelInfo?.name ? `#${channelInfo.name}` : "#chan-private-1",
-      }),
+      async ({ channelInfo }) => {
+        const resolvedChannelInfo = channelInfo ?? {
+          id: "chan-private-1",
+          type: "O",
+          name: "secret-planning",
+          display_name: "secret-planning",
+          team_id: "team-1",
+        };
+        return {
+          ok: true,
+          commandAuthorized: true,
+          channelInfo: resolvedChannelInfo,
+          kind: "channel",
+          chatType: "channel",
+          channelName: resolvedChannelInfo.name ?? "",
+          channelDisplay: resolvedChannelInfo.display_name ?? resolvedChannelInfo.name ?? "",
+          roomLabel: `#${resolvedChannelInfo.name ?? "chan-private-1"}`,
+        };
+      },
     );
     mockState.buildModelsProviderData.mockResolvedValueOnce({
       providers: ["openai"],
@@ -444,19 +470,29 @@ describe("slash-http cfg threading", () => {
       trigger: "oc_model",
       method: "P",
       url: callbackUrlFixture,
+      auto_complete: true,
       delete_at: 0,
     });
     mockState.authorizeMattermostCommandInvocation.mockImplementationOnce(
-      async ({ channelInfo }) => ({
-        ok: true,
-        commandAuthorized: true,
-        channelInfo,
-        kind: "direct",
-        chatType: "direct",
-        channelName: channelInfo?.name ?? "",
-        channelDisplay: channelInfo?.display_name ?? channelInfo?.name ?? "",
-        roomLabel: channelInfo?.name ? `#${channelInfo.name}` : "#chan-dm-1",
-      }),
+      async ({ channelInfo }) => {
+        const resolvedChannelInfo = channelInfo ?? {
+          id: "chan-dm-1",
+          type: "D",
+          name: "1a358pib8ffm9cwme4z8c1z5uc__tnrrznrcsj81pqdi8kwoedrfby",
+          display_name: "1a358pib8ffm9cwme4z8c1z5uc__tnrrznrcsj81pqdi8kwoedrfby",
+          team_id: "team-1",
+        };
+        return {
+          ok: true,
+          commandAuthorized: true,
+          channelInfo: resolvedChannelInfo,
+          kind: "direct",
+          chatType: "direct",
+          channelName: resolvedChannelInfo.name ?? "",
+          channelDisplay: resolvedChannelInfo.display_name ?? resolvedChannelInfo.name ?? "",
+          roomLabel: `#${resolvedChannelInfo.name ?? "chan-dm-1"}`,
+        };
+      },
     );
     mockState.buildModelsProviderData.mockResolvedValueOnce({
       providers: ["openai"],
@@ -520,6 +556,7 @@ describe("slash-http cfg threading", () => {
       trigger: "oc_models",
       method: "P",
       url: callbackUrlFixture,
+      auto_complete: true,
       delete_at: 0,
     });
 
@@ -600,6 +637,7 @@ describe("slash-http cfg threading", () => {
       trigger: "oc_models",
       method: "P",
       url: callbackUrlFixture,
+      auto_complete: true,
       delete_at: 0,
     });
 

--- a/extensions/mattermost/src/mattermost/slash-http.send-config.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.send-config.test.ts
@@ -19,6 +19,12 @@ const mockState = vi.hoisted(() => ({
   resolveCommandText: vi.fn((_trigger: string, text: string) => text),
   buildModelsProviderData: vi.fn(async () => ({ providers: [], modelNames: new Map() })),
   resolveMattermostModelPickerEntry: vi.fn(() => ({ kind: "summary" })),
+  buildMattermostModelPickerDialog: vi.fn(() => ({
+    callback_id: "oc_model_picker",
+    title: "Model Picker",
+    elements: [],
+  })),
+  resolveMattermostModelPickerCurrentRuntime: vi.fn(() => "auto"),
   authorizeMattermostCommandInvocation: vi.fn(() => ({
     ok: true,
     commandAuthorized: true,
@@ -30,6 +36,7 @@ const mockState = vi.hoisted(() => ({
     roomLabel: "#town-square",
   })),
   createMattermostClient: vi.fn(() => ({})),
+  openMattermostInteractiveDialog: vi.fn(async () => undefined),
   fetchMattermostChannel: vi.fn(async () => ({
     id: "chan-1",
     type: "O",
@@ -104,15 +111,18 @@ vi.mock("./client.js", async () => {
     createMattermostClient: mockState.createMattermostClient,
     fetchMattermostChannel: mockState.fetchMattermostChannel,
     normalizeMattermostBaseUrl: vi.fn((value: string | undefined) => value?.trim() ?? ""),
+    openMattermostInteractiveDialog: mockState.openMattermostInteractiveDialog,
     sendMattermostTyping: vi.fn(),
   };
 });
 
 vi.mock("./model-picker.js", () => ({
+  buildMattermostModelPickerDialog: mockState.buildMattermostModelPickerDialog,
   renderMattermostModelSummaryView: vi.fn(),
   renderMattermostModelsPickerView: vi.fn(),
   renderMattermostProviderPickerView: vi.fn(),
   resolveMattermostModelPickerCurrentModel: vi.fn(),
+  resolveMattermostModelPickerCurrentRuntime: mockState.resolveMattermostModelPickerCurrentRuntime,
   resolveMattermostModelPickerEntry: mockState.resolveMattermostModelPickerEntry,
 }));
 
@@ -216,9 +226,12 @@ describe("slash-http cfg threading", () => {
     mockState.parseSlashCommandPayload.mockClear();
     mockState.resolveCommandText.mockClear();
     mockState.buildModelsProviderData.mockClear();
+    mockState.buildMattermostModelPickerDialog.mockClear();
     mockState.resolveMattermostModelPickerEntry.mockClear();
+    mockState.resolveMattermostModelPickerCurrentRuntime.mockClear();
     mockState.authorizeMattermostCommandInvocation.mockClear();
     mockState.createMattermostClient.mockClear();
+    mockState.openMattermostInteractiveDialog.mockClear();
     mockState.fetchMattermostChannel.mockClear();
     mockState.sendMessageMattermost.mockClear();
     mockState.normalizeMattermostAllowList.mockClear();
@@ -264,6 +277,220 @@ describe("slash-http cfg threading", () => {
         accountId: "default",
       },
     );
+  });
+
+  it("opens the dialog-backed picker synchronously when Mattermost provides a trigger id", async () => {
+    mockState.parseSlashCommandPayload.mockReturnValueOnce({
+      token: "valid-token",
+      command: "/oc_models",
+      text: "models",
+      channel_id: "chan-1",
+      user_id: "user-1",
+      user_name: "alice",
+      team_id: "team-1",
+      trigger_id: "trigger-1",
+    });
+    mockState.buildModelsProviderData.mockResolvedValueOnce({
+      providers: ["openai"],
+      byProvider: new Map([["openai", new Set(["gpt-5"])]]),
+      resolvedDefault: {
+        provider: "openai",
+        model: "gpt-5",
+      },
+      modelNames: new Map(),
+    });
+    mockState.createMattermostClient.mockReturnValue({});
+
+    const handler = createSlashCommandHttpHandler({
+      account: accountFixture,
+      cfg: {} as OpenClawConfig,
+      runtime: {} as RuntimeEnv,
+      registeredCommands: [
+        {
+          id: "cmd-1",
+          teamId: "team-1",
+          trigger: "oc_models",
+          token: "valid-token",
+          url: callbackUrlFixture,
+          managed: false,
+        },
+      ],
+    });
+    const response = createResponse();
+
+    await handler(createRequest(), response.res);
+
+    expect(response.res.statusCode).toBe(200);
+    expect(response.getBody()).toContain('"text":""');
+    expect(mockState.openMattermostInteractiveDialog).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        triggerId: "trigger-1",
+      }),
+    );
+    expect(mockState.sendMessageMattermost).not.toHaveBeenCalled();
+  });
+
+  it("falls back to payload-derived channel info when channel lookup is forbidden", async () => {
+    mockState.parseSlashCommandPayload.mockReturnValueOnce({
+      token: "valid-token",
+      command: "/oc_model",
+      text: "",
+      channel_id: "chan-private-1",
+      channel_name: "secret-planning",
+      user_id: "1a358pib8ffm9cwme4z8c1z5uc",
+      user_name: "alice",
+      team_id: "team-1",
+      trigger_id: "trigger-private-1",
+    });
+    mockState.fetchMattermostChannel.mockRejectedValueOnce(
+      new Error("Mattermost API 403 Forbidden: You do not have the appropriate permissions."),
+    );
+    mockState.getMattermostCommand.mockResolvedValueOnce({
+      id: "cmd-1",
+      token: "valid-token",
+      team_id: "team-1",
+      trigger: "oc_model",
+      method: "P",
+      url: callbackUrlFixture,
+      delete_at: 0,
+    });
+    mockState.authorizeMattermostCommandInvocation.mockImplementationOnce(
+      async ({ channelInfo }) => ({
+        ok: true,
+        commandAuthorized: true,
+        channelInfo,
+        kind: "channel",
+        chatType: "channel",
+        channelName: channelInfo?.name ?? "",
+        channelDisplay: channelInfo?.display_name ?? channelInfo?.name ?? "",
+        roomLabel: channelInfo?.name ? `#${channelInfo.name}` : "#chan-private-1",
+      }),
+    );
+    mockState.buildModelsProviderData.mockResolvedValueOnce({
+      providers: ["openai"],
+      byProvider: new Map([["openai", new Set(["gpt-5"])]]),
+      resolvedDefault: {
+        provider: "openai",
+        model: "gpt-5",
+      },
+      modelNames: new Map(),
+    });
+    mockState.createMattermostClient.mockReturnValue({});
+
+    const handler = createSlashCommandHttpHandler({
+      account: accountFixture,
+      cfg: {} as OpenClawConfig,
+      runtime: {} as RuntimeEnv,
+      registeredCommands: [
+        {
+          id: "cmd-1",
+          teamId: "team-1",
+          trigger: "oc_model",
+          token: "valid-token",
+          url: callbackUrlFixture,
+          managed: false,
+        },
+      ],
+    });
+    const response = createResponse();
+
+    await handler(createRequest(), response.res);
+
+    expect(response.res.statusCode).toBe(200);
+    expect(response.getBody()).toContain('"text":""');
+    expect(mockState.authorizeMattermostCommandInvocation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channelInfo: expect.objectContaining({
+          id: "chan-private-1",
+          name: "secret-planning",
+          type: "O",
+          team_id: "team-1",
+        }),
+      }),
+    );
+    expect(mockState.openMattermostInteractiveDialog).toHaveBeenCalled();
+  });
+
+  it("infers direct-message slash payloads without channel lookup access", async () => {
+    mockState.parseSlashCommandPayload.mockReturnValueOnce({
+      token: "valid-token",
+      command: "/oc_model",
+      text: "",
+      channel_id: "chan-dm-1",
+      channel_name: "1a358pib8ffm9cwme4z8c1z5uc__tnrrznrcsj81pqdi8kwoedrfby",
+      user_id: "1a358pib8ffm9cwme4z8c1z5uc",
+      user_name: "alice",
+      team_id: "team-1",
+      trigger_id: "trigger-dm-1",
+    });
+    mockState.fetchMattermostChannel.mockRejectedValueOnce(
+      new Error("Mattermost API 403 Forbidden: You do not have the appropriate permissions."),
+    );
+    mockState.getMattermostCommand.mockResolvedValueOnce({
+      id: "cmd-1",
+      token: "valid-token",
+      team_id: "team-1",
+      trigger: "oc_model",
+      method: "P",
+      url: callbackUrlFixture,
+      delete_at: 0,
+    });
+    mockState.authorizeMattermostCommandInvocation.mockImplementationOnce(
+      async ({ channelInfo }) => ({
+        ok: true,
+        commandAuthorized: true,
+        channelInfo,
+        kind: "direct",
+        chatType: "direct",
+        channelName: channelInfo?.name ?? "",
+        channelDisplay: channelInfo?.display_name ?? channelInfo?.name ?? "",
+        roomLabel: channelInfo?.name ? `#${channelInfo.name}` : "#chan-dm-1",
+      }),
+    );
+    mockState.buildModelsProviderData.mockResolvedValueOnce({
+      providers: ["openai"],
+      byProvider: new Map([["openai", new Set(["gpt-5"])]]),
+      resolvedDefault: {
+        provider: "openai",
+        model: "gpt-5",
+      },
+      modelNames: new Map(),
+    });
+    mockState.createMattermostClient.mockReturnValue({});
+
+    const handler = createSlashCommandHttpHandler({
+      account: accountFixture,
+      cfg: {} as OpenClawConfig,
+      runtime: {} as RuntimeEnv,
+      registeredCommands: [
+        {
+          id: "cmd-1",
+          teamId: "team-1",
+          trigger: "oc_model",
+          token: "valid-token",
+          url: callbackUrlFixture,
+          managed: false,
+        },
+      ],
+    });
+    const response = createResponse();
+
+    await handler(createRequest(), response.res);
+
+    expect(response.res.statusCode).toBe(200);
+    expect(response.getBody()).toContain('"text":""');
+    expect(mockState.authorizeMattermostCommandInvocation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channelInfo: expect.objectContaining({
+          id: "chan-dm-1",
+          name: "1a358pib8ffm9cwme4z8c1z5uc__tnrrznrcsj81pqdi8kwoedrfby",
+          type: "D",
+          team_id: "team-1",
+        }),
+      }),
+    );
+    expect(mockState.openMattermostInteractiveDialog).toHaveBeenCalled();
   });
 
   it("rejects a callback when Mattermost reports a different current command token", async () => {

--- a/extensions/mattermost/src/mattermost/slash-http.send-config.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.send-config.test.ts
@@ -409,6 +409,16 @@ describe("slash-http cfg threading", () => {
         }),
       }),
     );
+    expect(mockState.buildMattermostModelPickerDialog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channelInfo: expect.objectContaining({
+          id: "chan-private-1",
+          name: "secret-planning",
+          type: "O",
+          team_id: "team-1",
+        }),
+      }),
+    );
     expect(mockState.openMattermostInteractiveDialog).toHaveBeenCalled();
   });
 

--- a/extensions/mattermost/src/mattermost/slash-http.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.ts
@@ -13,14 +13,18 @@ import { getMattermostRuntime } from "../runtime.js";
 import {
   createMattermostClient,
   fetchMattermostChannel,
+  openMattermostInteractiveDialog,
   sendMattermostTyping,
   type MattermostChannel,
 } from "./client.js";
+import { resolveInteractionCallbackUrl } from "./interactions.js";
 import {
+  buildMattermostModelPickerDialog,
   renderMattermostModelSummaryView,
   renderMattermostModelsPickerView,
   renderMattermostProviderPickerView,
   resolveMattermostModelPickerCurrentModel,
+  resolveMattermostModelPickerCurrentRuntime,
   resolveMattermostModelPickerEntry,
 } from "./model-picker.js";
 import {
@@ -73,6 +77,8 @@ const COMMAND_VALIDATION_LOOKUP_BURST = 20;
 const COMMAND_VALIDATION_LOOKUP_REFILL_MS = 500;
 const COMMAND_VALIDATION_LOOKUP_LIMIT_LOG_MS = 5_000;
 const COMMAND_VALIDATION_LOOKUP_RATE_LIMIT_MAX_KEYS = 2_000;
+const MATTERMOST_ENTITY_ID_REGEX = /^[A-Za-z0-9]{26}$/;
+const MATTERMOST_GROUP_DM_NAME_REGEX = /^[a-f0-9]{40}$/;
 type CommandLookupInflightEntry = {
   accountId: string;
   promise: Promise<MattermostCommandResponse | null>;
@@ -117,6 +123,140 @@ function sendJsonResponse(
   res.statusCode = status;
   res.setHeader("Content-Type", "application/json; charset=utf-8");
   res.end(JSON.stringify(body));
+}
+
+function isMattermostEntityId(value: string): boolean {
+  return MATTERMOST_ENTITY_ID_REGEX.test(value);
+}
+
+function inferSlashPayloadChannelInfo(params: {
+  channelId: string;
+  channelName?: string;
+  teamId?: string;
+}): MattermostChannel | null {
+  const channelId = params.channelId.trim();
+  if (!channelId) {
+    return null;
+  }
+
+  const channelName = params.channelName?.trim();
+  if (!channelName) {
+    return null;
+  }
+
+  const teamId = params.teamId?.trim();
+  const base: MattermostChannel = {
+    id: channelId,
+    name: channelName,
+    display_name: channelName,
+    ...(teamId ? { team_id: teamId } : {}),
+  };
+
+  if (MATTERMOST_GROUP_DM_NAME_REGEX.test(channelName)) {
+    return {
+      ...base,
+      type: "G",
+    };
+  }
+
+  const dmUserIds = channelName.split("__");
+  if (dmUserIds.length === 2 && dmUserIds.every(isMattermostEntityId)) {
+    return {
+      ...base,
+      type: "D",
+    };
+  }
+
+  return {
+    ...base,
+    type: "O",
+  };
+}
+
+async function tryOpenMattermostModelPickerDialog(params: {
+  account: ResolvedMattermostAccount;
+  cfg: OpenClawConfig;
+  client: ReturnType<typeof createMattermostClient>;
+  commandText: string;
+  senderId: string;
+  channelId: string;
+  teamId: string;
+  triggerId?: string;
+  kind: "direct" | "group" | "channel";
+  log?: (msg: string) => void;
+}): Promise<{ handled: boolean; response?: MattermostSlashCommandResponse }> {
+  const pickerEntry = resolveMattermostModelPickerEntry(params.commandText);
+  const triggerId = params.triggerId?.trim();
+  if (!pickerEntry || !triggerId) {
+    return { handled: false };
+  }
+
+  try {
+    const core = getMattermostRuntime();
+    const route = core.channel.routing.resolveAgentRoute({
+      cfg: params.cfg,
+      channel: "mattermost",
+      accountId: params.account.accountId,
+      teamId: params.teamId,
+      peer: {
+        kind: params.kind,
+        id: params.kind === "direct" ? params.senderId : params.channelId,
+      },
+    });
+    const data = await buildModelsProviderData(params.cfg, route.agentId);
+    if (data.providers.length === 0) {
+      return {
+        handled: true,
+        response: {
+          response_type: "ephemeral",
+          text: "No models available.",
+        },
+      };
+    }
+
+    const currentModel = resolveMattermostModelPickerCurrentModel({
+      cfg: params.cfg,
+      route,
+      data,
+    });
+    const currentRuntime = resolveMattermostModelPickerCurrentRuntime({
+      cfg: params.cfg,
+      route,
+    });
+    const callbackUrl = resolveInteractionCallbackUrl(params.account.accountId, {
+      gateway: params.cfg.gateway,
+      interactions: params.account.config.interactions,
+    });
+    const preferredProvider = pickerEntry.kind === "models" ? pickerEntry.provider : undefined;
+
+    await openMattermostInteractiveDialog(params.client, {
+      triggerId,
+      url: callbackUrl,
+      dialog: buildMattermostModelPickerDialog({
+        accountId: params.account.accountId,
+        ownerUserId: params.senderId,
+        channelId: params.channelId,
+        teamId: params.teamId,
+        callbackUrl,
+        data,
+        currentModel,
+        currentRuntime,
+        ...(preferredProvider ? { preferredProvider } : {}),
+      }),
+    });
+
+    return {
+      handled: true,
+      response: {
+        text: "",
+      },
+    };
+  } catch (err) {
+    params.log?.(
+      `mattermost: failed to open model picker dialog, falling back to message picker: ${sanitizeCommandLookupError(err)}`,
+    );
+    return { handled: false };
+  }
 }
 
 function findRegisteredCommandForPayload(params: {
@@ -433,11 +573,24 @@ async function authorizeSlashInvocation(params: {
   client: ReturnType<typeof createMattermostClient>;
   commandText: string;
   channelId: string;
+  channelName?: string;
+  teamId?: string;
   senderId: string;
   senderName: string;
   log?: (msg: string) => void;
 }): Promise<SlashInvocationAuth> {
-  const { account, cfg, client, commandText, channelId, senderId, senderName, log } = params;
+  const {
+    account,
+    cfg,
+    client,
+    commandText,
+    channelId,
+    channelName,
+    teamId,
+    senderId,
+    senderName,
+    log,
+  } = params;
   const core = getMattermostRuntime();
 
   // Resolve channel info so we can enforce DM vs group/channel policies.
@@ -448,6 +601,19 @@ async function authorizeSlashInvocation(params: {
     log?.(
       `mattermost: slash channel lookup failed for ${sanitizeMattermostLogValue(channelId)}: ${sanitizeCommandLookupError(err)}`,
     );
+  }
+
+  if (!channelInfo) {
+    channelInfo = inferSlashPayloadChannelInfo({
+      channelId,
+      channelName,
+      teamId,
+    });
+    if (channelInfo) {
+      log?.(
+        `mattermost: inferred slash channel kind ${sanitizeMattermostLogValue(channelInfo.type ?? "O")} from payload for ${sanitizeMattermostLogValue(channelId)}`,
+      );
+    }
   }
 
   if (!channelInfo) {
@@ -635,6 +801,8 @@ export function createSlashCommandHttpHandler(params: SlashHttpHandlerParams) {
       client,
       commandText,
       channelId,
+      channelName: payload.channel_name,
+      teamId: payload.team_id,
       senderId,
       senderName,
       log,
@@ -652,6 +820,23 @@ export function createSlashCommandHttpHandler(params: SlashHttpHandlerParams) {
     log?.(
       `mattermost: slash command /${sanitizeMattermostLogValue(trigger)} from ${sanitizeMattermostLogValue(senderName)} in ${sanitizeMattermostLogValue(channelId)}`,
     );
+
+    const immediatePickerResult = await tryOpenMattermostModelPickerDialog({
+      account,
+      cfg,
+      client,
+      commandText,
+      senderId,
+      channelId,
+      teamId: payload.team_id,
+      triggerId: payload.trigger_id,
+      kind: auth.kind,
+      log,
+    });
+    if (immediatePickerResult.handled) {
+      sendJsonResponse(res, 200, immediatePickerResult.response ?? { text: "" });
+      return;
+    }
 
     // Acknowledge immediately — we'll send the actual reply asynchronously
     sendJsonResponse(res, 200, {

--- a/extensions/mattermost/src/mattermost/slash-http.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.ts
@@ -182,6 +182,7 @@ async function tryOpenMattermostModelPickerDialog(params: {
   channelId: string;
   teamId: string;
   triggerId?: string;
+  channelInfo: MattermostChannel;
   kind: "direct" | "group" | "channel";
   log?: (msg: string) => void;
 }): Promise<{ handled: boolean; response?: MattermostSlashCommandResponse }> {
@@ -237,6 +238,7 @@ async function tryOpenMattermostModelPickerDialog(params: {
         ownerUserId: params.senderId,
         channelId: params.channelId,
         teamId: params.teamId,
+        channelInfo: params.channelInfo,
         callbackUrl,
         data,
         currentModel,
@@ -830,6 +832,7 @@ export function createSlashCommandHttpHandler(params: SlashHttpHandlerParams) {
       channelId,
       teamId: payload.team_id,
       triggerId: payload.trigger_id,
+      channelInfo: auth.channelInfo,
       kind: auth.kind,
       log,
     });

--- a/extensions/mattermost/src/mattermost/slash-http.ts
+++ b/extensions/mattermost/src/mattermost/slash-http.ts
@@ -182,7 +182,7 @@ async function tryOpenMattermostModelPickerDialog(params: {
   channelId: string;
   teamId: string;
   triggerId?: string;
-  channelInfo: MattermostChannel;
+  channelInfo: MattermostChannel | null;
   kind: "direct" | "group" | "channel";
   log?: (msg: string) => void;
 }): Promise<{ handled: boolean; response?: MattermostSlashCommandResponse }> {


### PR DESCRIPTION
## Summary

- Problem: Mattermost `/oc_model` and `/oc_models` still relied on the older message picker, so they could not use Mattermost's richer dialog flow.
- Why it matters: the Discord picker already feels native and multi-step; Mattermost needed a comparable native picker path instead of staying button-first.
- What changed: plain `/oc_model` and `/oc_models` now open a Mattermost dialog when `trigger_id` is available, dialog refresh/submit callbacks stay inside the Mattermost extension, and the final apply still routes through the existing shared `/model` command path.
- What did NOT change (scope boundary): no shared interactive-core expansion, no unrelated config/schema work, and the older message picker still remains as fallback when a dialog cannot be opened.
- Compatibility note: the provider -> model/runtime refresh path relies on Mattermost dynamic dialog refresh. Upstream documents that refresh path as a Mattermost Server `11.1+` capability, and older servers were not validated in this PR.

## Links

- Issue/PR refs: none

## Verification

- `CI=true PNPM_CONFIG_PM_ON_FAIL=ignore PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm test extensions/mattermost/src/mattermost/client.test.ts extensions/mattermost/src/mattermost/interactions.test.ts extensions/mattermost/src/mattermost/model-picker.test.ts extensions/mattermost/src/mattermost/monitor.test.ts extensions/mattermost/src/mattermost/slash-http.send-config.test.ts extensions/mattermost/src/mattermost/slash-http.test.ts`
- `CI=true PNPM_CONFIG_PM_ON_FAIL=ignore PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm exec oxfmt --check --threads=1 extensions/mattermost/src/mattermost/model-picker.ts extensions/mattermost/src/mattermost/model-picker.test.ts extensions/mattermost/src/mattermost/monitor.ts extensions/mattermost/src/mattermost/slash-http.ts extensions/mattermost/src/mattermost/slash-http.send-config.test.ts`
- `CI=true PNPM_CONFIG_PM_ON_FAIL=ignore PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm tsgo:extensions:test`
- `CI=true PNPM_CONFIG_PM_ON_FAIL=ignore PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm test src/infra/outbound/source-delivery-plan.test.ts`
- Rebased onto current `origin/main` and resolved the single overlapping `extensions/mattermost/src/mattermost/model-picker.ts` import conflict from current main.

## Real behavior proof

- Behavior or issue addressed: Mattermost native `/oc_model` slash-command routing and dialog callback reachability on the live devbox-to-vp deployment that backs this plugin test setup.
- Real environment tested: OpenClaw gateway running from this worktree on `devbox`, published through Tailscale Serve at `https://devbox.tail9cbe19.ts.net`; Mattermost running on `vp` and calling the gateway over that public tailnet URL.
- Exact steps or command run after this patch:
  1. Restart the gateway from the `codex-mm-model-dialog` worktree on `devbox`.
  2. Let Mattermost native `oc_*` commands register against `https://devbox.tail9cbe19.ts.net/api/channels/mattermost/command`.
  3. Probe the slash callback from the Mattermost host and verify it responds as a live POST-only endpoint.
  4. Run plain `/oc_model` in the Mattermost workspace tied to that deployment.
- Evidence after fix: Redacted runtime logs and copied live output from the real deployment.

```text
11:37:01 [mattermost] registered command /oc_model (id=rr9eyu8daif6p87czrtkwxb6fe)
11:37:02 [mattermost] slash commands activated for account default (8 commands)
11:37:02 [mattermost] slash commands registered (8 commands across 1 teams, callback=https://devbox.tail9cbe19.ts.net/api/channels/mattermost/command)
```

```text
$ curl -k -sS --connect-timeout 5 --max-time 10 -D - https://devbox.tail9cbe19.ts.net/api/channels/mattermost/command
HTTP/2 405
allow: POST
```

- Observed result after fix: The live deployment registered native Mattermost commands against the reachable devbox callback URL instead of the old `localhost` route, the callback was reachable from the Mattermost VPS, and the live tester on that deployment reported `/oc_model` working after the routing and channel-lookup fixes. This follow-up branch update also carries the same verified slash channel facts through dialog submit when later channel lookup is forbidden.
- What was not tested: A fresh screenshot or video of the post-rebase dialog submit flow is not attached here; the new submit-fallback behavior itself is locked by the added regression coverage in `extensions/mattermost/src/mattermost/model-picker.test.ts` and `extensions/mattermost/src/mattermost/slash-http.send-config.test.ts`, and the broader rebased Mattermost shard including `extensions/mattermost/src/mattermost/monitor.test.ts` and `extensions/mattermost/src/mattermost/slash-http.test.ts` stays green.

## Behavior Notes

- The new picker is Mattermost-owned UI: dialog open, refresh, and submit live in `extensions/mattermost/**`.
- Provider-dependent dialog refresh relies on Mattermost dynamic dialog refresh support, which upstream documents for Mattermost Server `11.1+`; this PR was validated only against the live server used in this branch testing, not against older Mattermost releases.
- If Mattermost does not provide a usable `trigger_id`, OpenClaw falls back to the existing message-based picker instead of breaking `/oc_model`.
- Slash-command authorization now falls back to channel information already present in the slash payload when `GET /channels/<id>` is forbidden, and dialog submit now reuses the signed fallback channel snapshot for the same restricted-channel case.

