### PR TITLE
fix(telegram): harden spool timeout recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 - Media: install Sharp with the root package and fall back to sips, Windows native imaging, ImageMagick, GraphicsMagick, or ffmpeg for image resizing/conversion when Sharp is unavailable. Fixes #83401. Thanks @scotthuang.
 - Telegram: deliver generated media completions back into forum topics by preserving topic IDs across requester-agent handoff. (#83556) Thanks @fuller-stack-dev.
 - Gateway: defer update-check startup until after readiness so package update checks no longer block sidecar-ready startup, while preserving update broadcasts and shutdown cleanup. (#83520) Thanks @samzong.
+- Telegram: keep `/btw` and read-only status commands from aborting active runs, and avoid retaining raw update payloads in timed-out spool tombstones. Refs #83272.
 - Agents/video: hide `video_generate` reference-audio parameters unless a registered video provider supports audio inputs.
 - Plugins/xAI: echo PKCE challenge fields during OAuth authorization-code token exchange for xAI token-endpoint compatibility. (#83499) Thanks @fuller-stack-dev.
 - Codex app-server: hydrate current inbound image attachments before queued runs so Responses-backed agents receive Discord and other channel images as native vision input. Fixes #83466. Thanks @iannwu.

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2124,6 +2124,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       secondStarted = resolve;
     });
     let firstAbortSignal: AbortSignal | undefined;
+    let sideAbortSignal: AbortSignal | undefined;
     dispatchReplyWithBufferedBlockDispatcher
       .mockImplementationOnce(async ({ replyOptions }) => {
         firstAbortSignal = replyOptions?.abortSignal;
@@ -2205,7 +2206,12 @@ describe("dispatchTelegramMessage draft streaming", () => {
     const sideStartGate = new Promise<void>((resolve) => {
       sideStarted = resolve;
     });
+    let releaseSide: (() => void) | undefined;
+    const sideGate = new Promise<void>((resolve) => {
+      releaseSide = resolve;
+    });
     let firstAbortSignal: AbortSignal | undefined;
+    let sideAbortSignal: AbortSignal | undefined;
     dispatchReplyWithBufferedBlockDispatcher
       .mockImplementationOnce(async ({ replyOptions }) => {
         firstAbortSignal = replyOptions?.abortSignal;
@@ -2216,8 +2222,10 @@ describe("dispatchTelegramMessage draft streaming", () => {
           counts: { block: 0, final: 0, tool: 0 },
         };
       })
-      .mockImplementationOnce(async () => {
+      .mockImplementationOnce(async ({ replyOptions }) => {
+        sideAbortSignal = replyOptions?.abortSignal;
         sideStarted?.();
+        await sideGate;
         return {
           queuedFinal: false,
           counts: { block: 0, final: 0, tool: 0 },
@@ -2260,6 +2268,17 @@ describe("dispatchTelegramMessage draft streaming", () => {
     await sideStartGate;
 
     expect(firstAbortSignal?.aborted).toBe(false);
+    const { buildTelegramReplyFenceLaneKey, supersedeTelegramReplyFenceLane } =
+      await import("./telegram-reply-fence.js");
+    supersedeTelegramReplyFenceLane(
+      buildTelegramReplyFenceLaneKey({
+        accountId: "default",
+        sequentialKey: "telegram:-100123:btw:100",
+      }),
+    );
+    expect(sideAbortSignal?.aborted).toBe(true);
+    expect(firstAbortSignal?.aborted).toBe(false);
+    releaseSide?.();
     releaseFirst?.();
     await Promise.all([firstPromise, sidePromise]);
   });

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2124,7 +2124,6 @@ describe("dispatchTelegramMessage draft streaming", () => {
       secondStarted = resolve;
     });
     let firstAbortSignal: AbortSignal | undefined;
-    let sideAbortSignal: AbortSignal | undefined;
     dispatchReplyWithBufferedBlockDispatcher
       .mockImplementationOnce(async ({ replyOptions }) => {
         firstAbortSignal = replyOptions?.abortSignal;
@@ -2281,6 +2280,70 @@ describe("dispatchTelegramMessage draft streaming", () => {
     releaseSide?.();
     releaseFirst?.();
     await Promise.all([firstPromise, sidePromise]);
+  });
+
+  it("lets authorized /stop abort active non-interrupting side dispatch", async () => {
+    const historyKey = "telegram:group:-100123";
+    const groupHistories = new Map([[historyKey, []]]);
+    let sideStarted: (() => void) | undefined;
+    const sideStartGate = new Promise<void>((resolve) => {
+      sideStarted = resolve;
+    });
+    let releaseSide: (() => void) | undefined;
+    const sideGate = new Promise<void>((resolve) => {
+      releaseSide = resolve;
+    });
+    let sideAbortSignal: AbortSignal | undefined;
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementationOnce(async ({ replyOptions }) => {
+      sideAbortSignal = replyOptions?.abortSignal;
+      sideStarted?.();
+      await sideGate;
+      return {
+        queuedFinal: false,
+        counts: { block: 0, final: 0, tool: 0 },
+      };
+    });
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    const createGroupContext = (messageId: number, body: string) =>
+      createContext({
+        ctxPayload: {
+          SessionKey: "agent:main:telegram:group:-100123",
+          ChatType: "group",
+          MessageSid: String(messageId),
+          RawBody: body,
+          BodyForAgent: body,
+          CommandBody: body,
+          CommandAuthorized: true,
+        } as unknown as TelegramMessageContext["ctxPayload"],
+        msg: {
+          chat: { id: -100123, type: "supergroup" },
+          message_id: messageId,
+          text: body,
+        } as unknown as TelegramMessageContext["msg"],
+        chatId: -100123,
+        isGroup: true,
+        historyKey,
+        historyLimit: 10,
+        groupHistories,
+        threadSpec: { id: undefined, scope: "none" },
+      });
+
+    const sidePromise = dispatchWithContext({
+      context: createGroupContext(100, "/btw what changed?"),
+      streamMode: "off",
+    });
+    await sideStartGate;
+    expect(sideAbortSignal?.aborted).toBe(false);
+
+    await dispatchWithContext({
+      context: createGroupContext(101, "/stop"),
+      streamMode: "off",
+    });
+
+    expect(sideAbortSignal?.aborted).toBe(true);
+    releaseSide?.();
+    await sidePromise;
   });
 
   it("keeps queued room events abortable after their source dispatch returns", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2190,6 +2190,80 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(deliveredTexts).toContain("fresh request answer");
   });
 
+  it("keeps /btw side questions from aborting an active same-session dispatch", async () => {
+    const historyKey = "telegram:group:-100123";
+    const groupHistories = new Map([[historyKey, []]]);
+    let firstStarted: (() => void) | undefined;
+    const firstStartGate = new Promise<void>((resolve) => {
+      firstStarted = resolve;
+    });
+    let releaseFirst: (() => void) | undefined;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    let sideStarted: (() => void) | undefined;
+    const sideStartGate = new Promise<void>((resolve) => {
+      sideStarted = resolve;
+    });
+    let firstAbortSignal: AbortSignal | undefined;
+    dispatchReplyWithBufferedBlockDispatcher
+      .mockImplementationOnce(async ({ replyOptions }) => {
+        firstAbortSignal = replyOptions?.abortSignal;
+        firstStarted?.();
+        await firstGate;
+        return {
+          queuedFinal: false,
+          counts: { block: 0, final: 0, tool: 0 },
+        };
+      })
+      .mockImplementationOnce(async () => {
+        sideStarted?.();
+        return {
+          queuedFinal: false,
+          counts: { block: 0, final: 0, tool: 0 },
+        };
+      });
+
+    const createGroupContext = (messageId: number, body: string) =>
+      createContext({
+        ctxPayload: {
+          SessionKey: "agent:main:telegram:group:-100123",
+          ChatType: "group",
+          MessageSid: String(messageId),
+          RawBody: body,
+          BodyForAgent: body,
+          CommandBody: body,
+          CommandAuthorized: true,
+        } as unknown as TelegramMessageContext["ctxPayload"],
+        msg: {
+          chat: { id: -100123, type: "supergroup" },
+          message_id: messageId,
+          text: body,
+        } as unknown as TelegramMessageContext["msg"],
+        chatId: -100123,
+        isGroup: true,
+        historyKey,
+        historyLimit: 10,
+        groupHistories,
+        threadSpec: { id: undefined, scope: "none" },
+      });
+
+    const firstPromise = dispatchWithContext({
+      context: createGroupContext(99, "@bot first request"),
+      streamMode: "off",
+    });
+    await firstStartGate;
+    const sidePromise = dispatchWithContext({
+      context: createGroupContext(100, "/btw what changed?"),
+      streamMode: "off",
+    });
+    await sideStartGate;
+
+    expect(firstAbortSignal?.aborted).toBe(false);
+    releaseFirst?.();
+    await Promise.all([firstPromise, sidePromise]);
+  });
+
   it("keeps queued room events abortable after their source dispatch returns", async () => {
     const historyKey = "telegram:group:-100123";
     const groupHistories = new Map([[historyKey, []]]);

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -110,6 +110,7 @@ import { getTelegramSequentialKey } from "./sequential-key.js";
 import { cacheSticker, describeStickerImage } from "./sticker-cache.js";
 import {
   beginTelegramReplyFence,
+  buildTelegramNonInterruptingReplyFenceKey,
   buildTelegramReplyFenceLaneKey,
   endTelegramReplyFence,
   getTelegramReplyFenceSizeForTests,
@@ -418,6 +419,7 @@ export const dispatchTelegramMessage = async ({
     accountId: route.accountId,
     sequentialKey: replyFenceLaneKey,
   });
+  let activeReplyFenceKey = replyFenceKey.activeKey;
   let replyFenceGeneration: number | undefined;
   const replyAbortController = new AbortController();
   let replyAbortControllerQueued = false;
@@ -425,7 +427,7 @@ export const dispatchTelegramMessage = async ({
   const isDispatchSuperseded = () =>
     replyFenceGeneration !== undefined &&
     isTelegramReplyFenceSuperseded({
-      key: replyFenceKey.activeKey,
+      key: activeReplyFenceKey,
       generation: replyFenceGeneration,
     });
   const releaseReplyFence = () => {
@@ -433,7 +435,7 @@ export const dispatchTelegramMessage = async ({
       return;
     }
     endTelegramReplyFence(
-      replyFenceKey.activeKey,
+      activeReplyFenceKey,
       replyAbortControllerQueued ? undefined : replyAbortController,
     );
     replyFenceGeneration = undefined;
@@ -821,11 +823,17 @@ export const dispatchTelegramMessage = async ({
   const chunkMode = resolveChunkMode(cfg, "telegram", route.accountId);
 
   const supersedeReplyFence = shouldSupersedeTelegramReplyFence(ctxPayload);
+  activeReplyFenceKey = supersedeReplyFence
+    ? replyFenceKey.activeKey
+    : buildTelegramNonInterruptingReplyFenceKey({
+        activeKey: replyFenceKey.activeKey,
+        laneKey: scopedReplyFenceLaneKey,
+      });
   if (!isRoomEvent && supersedeReplyFence) {
     supersedeTelegramReplyFence(replyFenceKey.roomEventKey);
   }
   replyFenceGeneration = beginTelegramReplyFence({
-    key: replyFenceKey.activeKey,
+    key: activeReplyFenceKey,
     supersede: supersedeReplyFence,
     abortController: replyAbortController,
     laneKey: scopedReplyFenceLaneKey,
@@ -1468,7 +1476,7 @@ export const dispatchTelegramMessage = async ({
                         onComplete: () => {
                           replyAbortControllerQueued = false;
                           releaseTelegramReplyFenceAbortController(
-                            replyFenceKey.activeKey,
+                            activeReplyFenceKey,
                             replyAbortController,
                           );
                         },

--- a/extensions/telegram/src/sequential-key.test.ts
+++ b/extensions/telegram/src/sequential-key.test.ts
@@ -147,6 +147,14 @@ describe("getTelegramSequentialKey", () => {
     ],
     [{ message: mockMessage({ chat: mockChat({ id: 123 }), text: "/export" }) }, "telegram:123"],
     [
+      { message: mockMessage({ chat: mockChat({ id: 123 }), text: "/export-trajectory" }) },
+      "telegram:123",
+    ],
+    [
+      { message: mockMessage({ chat: mockChat({ id: 123 }), text: "/trajectory" }) },
+      "telegram:123",
+    ],
+    [
       { message: mockMessage({ chat: mockChat({ id: 123 }), text: "/btw what is the time?" }) },
       "telegram:123:btw:1",
     ],

--- a/extensions/telegram/src/sequential-key.test.ts
+++ b/extensions/telegram/src/sequential-key.test.ts
@@ -142,6 +142,19 @@ describe("getTelegramSequentialKey", () => {
       "telegram:123:control",
     ],
     [
+      { message: mockMessage({ chat: mockChat({ id: 123 }), text: "/diagnostics" }) },
+      "telegram:123",
+    ],
+    [
+      {
+        message: mockMessage({
+          chat: mockChat({ id: 123 }),
+          text: "/diagnostics confirm abc123def456",
+        }),
+      },
+      "telegram:123",
+    ],
+    [
       { message: mockMessage({ chat: mockChat({ id: 123 }), text: "/export-session" }) },
       "telegram:123",
     ],

--- a/extensions/telegram/src/sequential-key.ts
+++ b/extensions/telegram/src/sequential-key.ts
@@ -28,7 +28,7 @@ type TelegramSequentialKeyContext = {
   };
 };
 
-function resolveStatusCommandControlLane(params: {
+export function isTelegramReadOnlyControlLaneText(params: {
   rawText?: string;
   botUsername?: string;
 }): boolean {
@@ -82,7 +82,7 @@ export function isTelegramControlLaneText(params: {
   if (isTelegramTargetedStopCommand(params.rawText, params.botUsername)) {
     return true;
   }
-  return resolveStatusCommandControlLane(params);
+  return isTelegramReadOnlyControlLaneText(params);
 }
 
 export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): string {

--- a/extensions/telegram/src/sequential-key.ts
+++ b/extensions/telegram/src/sequential-key.ts
@@ -11,7 +11,15 @@ import {
 } from "openclaw/plugin-sdk/command-primitives-runtime";
 import { resolveTelegramForumThreadId } from "./bot/helpers.js";
 
-const TELEGRAM_NON_READ_ONLY_STATUS_COMMAND_KEYS = new Set(["export-session", "export-trajectory"]);
+const TELEGRAM_READ_ONLY_STATUS_COMMAND_KEYS = new Set([
+  "commands",
+  "context",
+  "help",
+  "status",
+  "tasks",
+  "tools",
+  "whoami",
+]);
 
 type TelegramSequentialKeyContext = {
   chat?: { id?: number };
@@ -34,8 +42,8 @@ export function isTelegramReadOnlyControlLaneText(params: {
   rawText?: string;
   botUsername?: string;
 }): boolean {
-  // Only read-only status commands should bypass the per-topic lane. Export
-  // commands materialize mutable session state and should not interleave with an active turn.
+  // Only read-only status commands should bypass the per-topic lane.
+  // Diagnostics and export commands materialize state and should not interleave with an active turn.
   const normalizedBody = normalizeCommandBody(
     params.rawText?.trim() ?? "",
     params.botUsername ? { botUsername: params.botUsername } : undefined,
@@ -47,9 +55,7 @@ export function isTelegramReadOnlyControlLaneText(params: {
   const command = listChatCommands().find((entry) =>
     entry.textAliases.some((candidate) => candidate.trim().toLowerCase() === alias),
   );
-  return (
-    command?.category === "status" && !TELEGRAM_NON_READ_ONLY_STATUS_COMMAND_KEYS.has(command.key)
-  );
+  return command?.category === "status" && TELEGRAM_READ_ONLY_STATUS_COMMAND_KEYS.has(command.key);
 }
 
 function isTelegramTargetedStopCommand(rawText?: string, botUsername?: string): boolean {

--- a/extensions/telegram/src/sequential-key.ts
+++ b/extensions/telegram/src/sequential-key.ts
@@ -11,6 +11,8 @@ import {
 } from "openclaw/plugin-sdk/command-primitives-runtime";
 import { resolveTelegramForumThreadId } from "./bot/helpers.js";
 
+const TELEGRAM_NON_READ_ONLY_STATUS_COMMAND_KEYS = new Set(["export-session", "export-trajectory"]);
+
 type TelegramSequentialKeyContext = {
   chat?: { id?: number };
   me?: UserFromGetMe;
@@ -32,9 +34,8 @@ export function isTelegramReadOnlyControlLaneText(params: {
   rawText?: string;
   botUsername?: string;
 }): boolean {
-  // Only read-only status commands should bypass the per-topic lane. Commands
-  // like /export-session stay on the normal lane because they materialize
-  // session state to disk and should not interleave with an active turn.
+  // Only read-only status commands should bypass the per-topic lane. Export
+  // commands materialize mutable session state and should not interleave with an active turn.
   const normalizedBody = normalizeCommandBody(
     params.rawText?.trim() ?? "",
     params.botUsername ? { botUsername: params.botUsername } : undefined,
@@ -46,7 +47,9 @@ export function isTelegramReadOnlyControlLaneText(params: {
   const command = listChatCommands().find((entry) =>
     entry.textAliases.some((candidate) => candidate.trim().toLowerCase() === alias),
   );
-  return command?.category === "status" && command.key !== "export-session";
+  return (
+    command?.category === "status" && !TELEGRAM_NON_READ_ONLY_STATUS_COMMAND_KEYS.has(command.key)
+  );
 }
 
 function isTelegramTargetedStopCommand(rawText?: string, botUsername?: string): boolean {

--- a/extensions/telegram/src/telegram-ingress-spool.test.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.test.ts
@@ -143,7 +143,13 @@ describe("Telegram ingress spool", () => {
       expect(entries).toEqual(["0000000000000032.json.failed"]);
       const failed = JSON.parse(
         await fs.readFile(path.join(spoolDir, "0000000000000032.json.failed"), "utf8"),
-      ) as { failure?: { reason?: string; message?: string; failedAt?: number } };
+      ) as {
+        update?: unknown;
+        claim?: unknown;
+        failure?: { reason?: string; message?: string; failedAt?: number };
+      };
+      expect(failed.update).toBeUndefined();
+      expect(failed.claim).toBeUndefined();
       expect(failed.failure).toEqual({
         reason: "handler-timeout",
         message: "timed out",

--- a/extensions/telegram/src/telegram-ingress-spool.ts
+++ b/extensions/telegram/src/telegram-ingress-spool.ts
@@ -28,6 +28,10 @@ type TelegramSpooledUpdatePayload = {
   };
 };
 
+type TelegramFailedSpooledUpdatePayload = Omit<TelegramSpooledUpdatePayload, "claim" | "update"> & {
+  failure: NonNullable<TelegramSpooledUpdatePayload["failure"]>;
+};
+
 export type TelegramSpooledUpdate = {
   updateId: number;
   path: string;
@@ -326,12 +330,10 @@ export async function failTelegramSpooledUpdateClaim(params: {
     if (!parsed) {
       return false;
     }
-    const payload: TelegramSpooledUpdatePayload = {
+    const payload: TelegramFailedSpooledUpdatePayload = {
       version: SPOOL_VERSION,
       updateId: parsed.updateId,
       receivedAt: parsed.receivedAt,
-      update: parsed.update,
-      ...(parsed.claim ? { claim: parsed.claim } : {}),
       failure: {
         reason: params.reason,
         message: params.message,

--- a/extensions/telegram/src/telegram-reply-fence.test.ts
+++ b/extensions/telegram/src/telegram-reply-fence.test.ts
@@ -36,5 +36,11 @@ describe("shouldSupersedeTelegramReplyFence", () => {
         CommandAuthorized: false,
       }),
     ).toBe(false);
+    expect(
+      shouldSupersedeTelegramReplyFence({
+        CommandBody: "/export-trajectory bundle",
+        CommandAuthorized: true,
+      }),
+    ).toBe(true);
   });
 });

--- a/extensions/telegram/src/telegram-reply-fence.test.ts
+++ b/extensions/telegram/src/telegram-reply-fence.test.ts
@@ -48,6 +48,12 @@ describe("shouldSupersedeTelegramReplyFence", () => {
         CommandAuthorized: true,
       }),
     ).toBe(true);
+    expect(
+      shouldSupersedeTelegramReplyFence({
+        CommandBody: "/diagnostics confirm abc123def456",
+        CommandAuthorized: true,
+      }),
+    ).toBe(true);
   });
 });
 

--- a/extensions/telegram/src/telegram-reply-fence.test.ts
+++ b/extensions/telegram/src/telegram-reply-fence.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { shouldSupersedeTelegramReplyFence } from "./telegram-reply-fence.js";
+import {
+  beginTelegramReplyFence,
+  buildTelegramNonInterruptingReplyFenceKey,
+  resetTelegramReplyFenceForTests,
+  shouldSupersedeTelegramReplyFence,
+  supersedeTelegramReplyFence,
+} from "./telegram-reply-fence.js";
 
 describe("shouldSupersedeTelegramReplyFence", () => {
   it("keeps non-interrupting side and status commands from superseding active runs", () => {
@@ -42,5 +48,32 @@ describe("shouldSupersedeTelegramReplyFence", () => {
         CommandAuthorized: true,
       }),
     ).toBe(true);
+  });
+});
+
+describe("telegram reply fence supersede", () => {
+  it("cascades base supersedes to non-interrupting child fences", () => {
+    resetTelegramReplyFenceForTests();
+    const activeKey = "agent:main:telegram:group:-100123";
+    const sideController = new AbortController();
+    const mainController = new AbortController();
+    beginTelegramReplyFence({
+      key: activeKey,
+      supersede: true,
+      abortController: mainController,
+    });
+    beginTelegramReplyFence({
+      key: buildTelegramNonInterruptingReplyFenceKey({
+        activeKey,
+        laneKey: "default\0telegram:-100123:btw:100",
+      }),
+      supersede: false,
+      abortController: sideController,
+    });
+
+    expect(supersedeTelegramReplyFence(activeKey)).toBe(true);
+    expect(mainController.signal.aborted).toBe(true);
+    expect(sideController.signal.aborted).toBe(true);
+    resetTelegramReplyFenceForTests();
   });
 });

--- a/extensions/telegram/src/telegram-reply-fence.test.ts
+++ b/extensions/telegram/src/telegram-reply-fence.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { shouldSupersedeTelegramReplyFence } from "./telegram-reply-fence.js";
+
+describe("shouldSupersedeTelegramReplyFence", () => {
+  it("keeps non-interrupting side and status commands from superseding active runs", () => {
+    expect(
+      shouldSupersedeTelegramReplyFence({
+        CommandBody: "/btw what changed?",
+        CommandAuthorized: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldSupersedeTelegramReplyFence({
+        CommandBody: "/status",
+        CommandAuthorized: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps normal turns and authorized aborts interrupting active runs", () => {
+    expect(
+      shouldSupersedeTelegramReplyFence({
+        CommandBody: "@bot answer this",
+        CommandAuthorized: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldSupersedeTelegramReplyFence({
+        CommandBody: "/stop",
+        CommandAuthorized: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldSupersedeTelegramReplyFence({
+        CommandBody: "/stop",
+        CommandAuthorized: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/extensions/telegram/src/telegram-reply-fence.ts
+++ b/extensions/telegram/src/telegram-reply-fence.ts
@@ -133,7 +133,7 @@ function supersedeTelegramReplyFenceState(key: string): boolean {
 function supersedeTelegramNonInterruptingReplyFenceChildren(key: string): boolean {
   let superseded = false;
   const childPrefix = buildTelegramNonInterruptingReplyFenceKeyPrefix(key);
-  for (const childKey of [...telegramReplyFenceByKey.keys()]) {
+  for (const childKey of telegramReplyFenceByKey.keys()) {
     if (childKey.startsWith(childPrefix)) {
       superseded = supersedeTelegramReplyFenceState(childKey) || superseded;
     }

--- a/extensions/telegram/src/telegram-reply-fence.ts
+++ b/extensions/telegram/src/telegram-reply-fence.ts
@@ -27,6 +27,13 @@ export function buildTelegramReplyFenceLaneKey(params: {
   return `${params.accountId}\0${params.sequentialKey}`;
 }
 
+export function buildTelegramNonInterruptingReplyFenceKey(params: {
+  activeKey: string;
+  laneKey: string;
+}): string {
+  return `${params.activeKey}\0non-interrupting\0${params.laneKey}`;
+}
+
 function normalizeTelegramFenceKey(value: unknown): string | undefined {
   if (typeof value !== "string") {
     return undefined;

--- a/extensions/telegram/src/telegram-reply-fence.ts
+++ b/extensions/telegram/src/telegram-reply-fence.ts
@@ -31,7 +31,11 @@ export function buildTelegramNonInterruptingReplyFenceKey(params: {
   activeKey: string;
   laneKey: string;
 }): string {
-  return `${params.activeKey}\0non-interrupting\0${params.laneKey}`;
+  return `${buildTelegramNonInterruptingReplyFenceKeyPrefix(params.activeKey)}${params.laneKey}`;
+}
+
+function buildTelegramNonInterruptingReplyFenceKeyPrefix(activeKey: string): string {
+  return `${activeKey}\0non-interrupting\0`;
 }
 
 function normalizeTelegramFenceKey(value: unknown): string | undefined {
@@ -98,6 +102,7 @@ export function beginTelegramReplyFence(params: {
   if (params.supersede) {
     state.generation += 1;
     abortTelegramReplyFenceControllers(state);
+    supersedeTelegramNonInterruptingReplyFenceChildren(params.key);
   }
   if (params.abortController) {
     (state.abortControllers ??= new Set()).add(params.abortController);
@@ -114,7 +119,7 @@ export function beginTelegramReplyFence(params: {
   return state.generation;
 }
 
-export function supersedeTelegramReplyFence(key: string): boolean {
+function supersedeTelegramReplyFenceState(key: string): boolean {
   const state = telegramReplyFenceByKey.get(key);
   if (!state) {
     return false;
@@ -123,6 +128,23 @@ export function supersedeTelegramReplyFence(key: string): boolean {
   abortTelegramReplyFenceControllers(state);
   maybeDeleteTelegramReplyFenceState(key, state);
   return true;
+}
+
+function supersedeTelegramNonInterruptingReplyFenceChildren(key: string): boolean {
+  let superseded = false;
+  const childPrefix = buildTelegramNonInterruptingReplyFenceKeyPrefix(key);
+  for (const childKey of [...telegramReplyFenceByKey.keys()]) {
+    if (childKey.startsWith(childPrefix)) {
+      superseded = supersedeTelegramReplyFenceState(childKey) || superseded;
+    }
+  }
+  return superseded;
+}
+
+export function supersedeTelegramReplyFence(key: string): boolean {
+  let superseded = supersedeTelegramReplyFenceState(key);
+  superseded = supersedeTelegramNonInterruptingReplyFenceChildren(key) || superseded;
+  return superseded;
 }
 
 export function supersedeTelegramReplyFenceLane(laneKey: string): boolean {

--- a/extensions/telegram/src/telegram-reply-fence.ts
+++ b/extensions/telegram/src/telegram-reply-fence.ts
@@ -1,4 +1,8 @@
-import { isAbortRequestText } from "openclaw/plugin-sdk/command-primitives-runtime";
+import {
+  isAbortRequestText,
+  isBtwRequestText,
+} from "openclaw/plugin-sdk/command-primitives-runtime";
+import { isTelegramReadOnlyControlLaneText } from "./sequential-key.js";
 
 type TelegramReplyFenceState = {
   generation: number;
@@ -164,7 +168,16 @@ export function shouldSupersedeTelegramReplyFence(ctxPayload: {
   CommandAuthorized: boolean;
 }): boolean {
   const dispatchText = ctxPayload.CommandBody ?? ctxPayload.RawBody ?? ctxPayload.Body ?? "";
-  return !isAbortRequestText(dispatchText) || ctxPayload.CommandAuthorized;
+  if (isAbortRequestText(dispatchText)) {
+    return ctxPayload.CommandAuthorized;
+  }
+  if (
+    isBtwRequestText(dispatchText) ||
+    isTelegramReadOnlyControlLaneText({ rawText: dispatchText })
+  ) {
+    return false;
+  }
+  return true;
 }
 
 export function getTelegramReplyFenceSizeForTests(): number {


### PR DESCRIPTION
Summary
- Keep Telegram /btw and read-only status commands from superseding active reply work.
- Keep diagnostics and export commands on the normal turn lane, and keep /stop able to abort non-interrupting side replies.
- Stop storing raw Telegram update payloads or claim owners in failed spool tombstones.

Verification
Behavior addressed: #83272 follow-up regressions after isolated spool timeout recovery.
Real environment tested: local source checkout; issue #83272 already had AWS Crabbox live repro/proof on #83505, this PR covers source-level regressions found by autoreview.
Exact steps or command run after this patch: node scripts/run-vitest.mjs extensions/telegram/src/telegram-reply-fence.test.ts extensions/telegram/src/sequential-key.test.ts extensions/telegram/src/telegram-ingress-spool.test.ts extensions/telegram/src/bot-message-dispatch.test.ts extensions/telegram/src/polling-session.test.ts
Evidence after fix: 5 test files passed, 158 tests passed; extension production and extension test tsgo checks passed; git diff --check passed; autoreview clean.
Observed result after fix: /btw/status no longer supersede active main runs; /btw lane timeout aborts only its isolated fence; /stop aborts non-interrupting side replies; diagnostics and export commands remain on normal lanes; failed tombstones omit update/claim payloads.
What was not tested: live Telegram end-to-end in this PR.

Refs #83272
