### PR TITLE
fix(release): repair broad gate regressions

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.test.ts
@@ -1257,11 +1257,17 @@ describe("processDiscordMessage session routing", () => {
     });
   });
 
-  it("marks always-on guild replies as message-tool-only and disables source streaming", async () => {
+  it("marks explicit message-tool guild replies as message-tool-only and disables source streaming", async () => {
     const ctx = await createBaseContext({
       shouldRequireMention: false,
       effectiveWasMentioned: false,
       discordConfig: { streaming: "partial", blockStreaming: true },
+      cfg: {
+        messages: {
+          groupChat: { visibleReplies: "message_tool" },
+        },
+        session: { store: "/tmp/openclaw-discord-process-test-sessions.json" },
+      },
       route: BASE_CHANNEL_ROUTE,
     });
 
@@ -1283,6 +1289,7 @@ describe("processDiscordMessage session routing", () => {
         messages: {
           ackReaction: "👀",
           ackReactionScope: "all",
+          groupChat: { visibleReplies: "message_tool" },
           statusReactions: {
             timing: { debounceMs: 0 },
           },
@@ -1314,6 +1321,7 @@ describe("processDiscordMessage session routing", () => {
         messages: {
           ackReaction: "👀",
           ackReactionScope: "all",
+          groupChat: { visibleReplies: "message_tool" },
           statusReactions: {
             enabled: true,
             timing: { debounceMs: 0 },
@@ -1500,7 +1508,7 @@ describe("processDiscordMessage session routing", () => {
     });
   });
 
-  it("defaults guild replies to message-tool-only source delivery", async () => {
+  it("resolves guild source delivery from default, explicit, and room-event modes", async () => {
     await runProcessDiscordMessage(
       await createBaseContext({
         shouldRequireMention: true,
@@ -1508,7 +1516,7 @@ describe("processDiscordMessage session routing", () => {
         route: BASE_CHANNEL_ROUTE,
       }),
     );
-    expect(getLastDispatchReplyOptions()?.sourceReplyDeliveryMode).toBe("message_tool_only");
+    expect(getLastDispatchReplyOptions()?.sourceReplyDeliveryMode).toBe("automatic");
 
     dispatchInboundMessage.mockClear();
     await runProcessDiscordMessage(
@@ -1518,7 +1526,7 @@ describe("processDiscordMessage session routing", () => {
         cfg: {
           messages: {
             groupChat: {
-              visibleReplies: "automatic",
+              visibleReplies: "message_tool",
             },
           },
           session: { store: "/tmp/openclaw-discord-process-test-sessions.json" },
@@ -1526,7 +1534,7 @@ describe("processDiscordMessage session routing", () => {
         route: BASE_CHANNEL_ROUTE,
       }),
     );
-    expect(getLastDispatchReplyOptions()?.sourceReplyDeliveryMode).toBe("automatic");
+    expect(getLastDispatchReplyOptions()?.sourceReplyDeliveryMode).toBe("message_tool_only");
 
     dispatchInboundMessage.mockClear();
     await runProcessDiscordMessage(
@@ -1754,6 +1762,9 @@ describe("processDiscordMessage draft streaming", () => {
     const ctx = await createBaseContext({
       cfg: {
         tools: { profile: "coding" },
+        messages: {
+          groupChat: { visibleReplies: "message_tool" },
+        },
         session: { store: "/tmp/openclaw-discord-process-test-sessions.json" },
       },
       route: BASE_CHANNEL_ROUTE,

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -1604,7 +1604,8 @@ describe("qa mock openai server", () => {
         input: [
           {
             role: "system",
-            content: "## /workspace/MEMORY.md\nThread-hidden codename: ORBIT-22.",
+            content:
+              "Available tools include sessions_spawn.\n## /workspace/MEMORY.md\nThread-hidden codename: ORBIT-22.",
           },
           makeUserInput(
             "@openclaw Thread memory check: what is the hidden thread codename stored only in memory? Use memory tools first and reply only in this thread.",

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -916,7 +916,6 @@ function buildExplicitSessionsSpawnArgs(text: string): Record<string, unknown> |
 }
 
 function extractToolErrorForNamedCall(params: {
-  allInputText: string;
   input: ResponsesInputItem[];
   name: string;
   toolJson: Record<string, unknown> | null;
@@ -928,8 +927,7 @@ function extractToolErrorForNamedCall(params: {
   const namedFunctionCall = params.input.some(
     (item) => item.type === "function_call" && item.name === params.name,
   );
-  const namedPromptReference = new RegExp(`\\b${params.name}\\b`, "i").test(params.allInputText);
-  if (namedFunctionCall || namedPromptReference) {
+  if (namedFunctionCall) {
     return error;
   }
   return undefined;
@@ -1015,7 +1013,6 @@ function buildAssistantText(
   const activeMemorySummary = extractActiveMemorySummary(allInputText);
   const snackPreference = extractSnackPreference(activeMemorySummary ?? memorySnippet);
   const sessionsSpawnError = extractToolErrorForNamedCall({
-    allInputText,
     input,
     name: "sessions_spawn",
     toolJson,

--- a/extensions/slack/src/monitor.tool-result.test.ts
+++ b/extensions/slack/src/monitor.tool-result.test.ts
@@ -518,11 +518,12 @@ describe("monitorSlackProvider tool results", () => {
     expect(sendMock).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps always-on channel messages private by default", async () => {
+  it("keeps always-on channel messages private when group visible replies use message_tool", async () => {
     slackTestState.config = {
       messages: {
         ackReaction: "👀",
         ackReactionScope: "all",
+        groupChat: { visibleReplies: "message_tool" },
         statusReactions: {
           enabled: true,
           timing: { debounceMs: 0, doneHoldMs: 0, errorHoldMs: 0 },

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -1,4 +1,7 @@
-import { completionRequiresMessageToolDelivery } from "../auto-reply/reply/completion-delivery-policy.js";
+import {
+  completionRequiresMessageToolDelivery,
+  resolveCompletionChatType,
+} from "../auto-reply/reply/completion-delivery-policy.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ConversationRef } from "../infra/outbound/session-binding-service.js";
 import { stringifyRouteThreadId } from "../plugin-sdk/channel-route.js";
@@ -351,10 +354,10 @@ export async function resolveSubagentCompletionOrigin(params: {
   const accountId = normalizeAccountId(requesterOrigin?.accountId);
   const threadId =
     requesterOrigin?.threadId != null && requesterOrigin.threadId !== ""
-      ? stringifyRouteThreadId(requesterOrigin.threadId)
+      ? requesterOrigin.threadId
       : undefined;
   const conversationId =
-    threadId ||
+    stringifyRouteThreadId(threadId) ||
     resolveConversationIdFromTargets({
       targets: [to],
     }) ||
@@ -660,9 +663,18 @@ async function sendSubagentAnnounceDirectly(params: {
       sourceTool: params.sourceTool,
     });
     const expectedMediaUrls = collectExpectedMediaFromInternalEvents(params.internalEvents);
+    const completionChatType = resolveCompletionChatType({
+      requesterSessionKey: params.requesterSessionKey,
+      targetRequesterSessionKey: canonicalRequesterSessionKey,
+      requesterEntry,
+      directOrigin: effectiveDirectOrigin,
+      requesterSessionOrigin,
+    });
     const requiresMessageToolDelivery =
       agentMediatedCompletion &&
-      (expectedMediaUrls.length > 0 ||
+      (completionChatType === "channel" ||
+        completionChatType === "group" ||
+        expectedMediaUrls.length > 0 ||
         completionRequiresMessageToolDelivery({
           cfg,
           requesterSessionKey: params.requesterSessionKey,

--- a/src/plugins/uninstall.test.ts
+++ b/src/plugins/uninstall.test.ts
@@ -1209,7 +1209,7 @@ describe("uninstallPlugin", () => {
     const pluginDir = path.join(npmRoot, "node_modules", "missing-plugin");
     const peerPluginDir = path.join(npmRoot, "node_modules", "peer-plugin");
     const peerLink = path.join(peerPluginDir, "node_modules", "openclaw");
-    await fs.mkdir(peerLink, { recursive: true });
+    await fs.mkdir(path.dirname(peerLink), { recursive: true });
     await fs.writeFile(
       path.join(npmRoot, "package.json"),
       `${JSON.stringify(

--- a/test/openclaw-launcher.e2e.test.ts
+++ b/test/openclaw-launcher.e2e.test.ts
@@ -120,13 +120,57 @@ describe("openclaw launcher", () => {
     );
     const engineMatch = packageJson.engines?.node?.match(/^>=(\d+)\.(\d+)\.(\d+)$/u);
 
-    expect(launcherMatch).not.toBeNull();
-    expect(runtimeMatch).not.toBeNull();
-    expect(engineMatch).not.toBeNull();
-    expect(`${launcherMatch?.[1]}.${launcherMatch?.[2]}.0`).toBe(
-      `${engineMatch?.[1]}.${engineMatch?.[2]}.${engineMatch?.[3]}`,
+    if (!launcherMatch) {
+      throw new Error("openclaw.mjs MIN_NODE_* constants were not found");
+    }
+    if (!runtimeMatch) {
+      throw new Error("src/infra/runtime-guard.ts MIN_NODE constant was not found");
+    }
+    if (!engineMatch) {
+      throw new Error("package.json engines.node must use >=<major>.<minor>.<patch>");
+    }
+    const [engineMajor, engineMinor, enginePatch] = engineMatch.slice(1, 4).map(Number);
+    const launcherMinimumLabel = `${engineMajor}.${engineMinor}`;
+
+    expect(
+      [Number(launcherMatch[1]), Number(launcherMatch[2]), 0],
+      "openclaw.mjs MIN_NODE_* must match package.json engines.node",
+    ).toEqual([engineMajor, engineMinor, enginePatch]);
+    expect(
+      runtimeMatch.slice(1, 4).map(Number),
+      "src/infra/runtime-guard.ts MIN_NODE must match package.json engines.node",
+    ).toEqual([engineMajor, engineMinor, enginePatch]);
+
+    const fixtureRoot = await makeLauncherFixture(fixtureRoots);
+    const mockedNodeVersion =
+      engineMinor > 0
+        ? `${engineMajor}.${engineMinor - 1}.0`
+        : `${engineMajor - 1}.999.0`;
+    const mockNodeVersionPath = path.join(fixtureRoot, "mock-node-version.mjs");
+    await fs.writeFile(
+      mockNodeVersionPath,
+      [
+        "Object.defineProperty(process.versions, 'node', {",
+        `  value: ${JSON.stringify(mockedNodeVersion)},`,
+        "});",
+      ].join("\n"),
+      "utf8",
     );
-    expect(runtimeMatch?.slice(1, 4)).toEqual(engineMatch?.slice(1, 4));
+
+    const result = spawnSync(
+      process.execPath,
+      ["--import", mockNodeVersionPath, path.join(fixtureRoot, "openclaw.mjs"), "--help"],
+      {
+        cwd: fixtureRoot,
+        env: launcherEnv(),
+        encoding: "utf8",
+      },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      `openclaw: Node.js v${launcherMinimumLabel}+ is required (current: v${mockedNodeVersion}).`,
+    );
   });
 
   it("surfaces transitive entry import failures instead of masking them as missing dist", async () => {


### PR DESCRIPTION
## Summary

- Restore subagent completion handoff behavior for group/channel routes so completion replies go back through the requester agent with message-tool delivery, while preserving numeric thread ids.
- Align Discord/Slack visible-reply tests with the current automatic group default and keep explicit `message_tool` cases covered.
- Fix broad-gate regressions: uninstall peer fixture no longer creates a bogus non-symlink peer, qa-lab mock `sessions_spawn` errors are only attributed to real `sessions_spawn` calls, and the launcher Node-floor contract test now locks package engines, runtime guard, launcher constants, and launcher stderr together.

## Verification

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts test/openclaw-launcher.e2e.test.ts`
- `node scripts/run-vitest.mjs src/plugins/uninstall.test.ts extensions/discord/src/monitor/message-handler.process.test.ts extensions/slack/src/monitor.tool-result.test.ts src/agents/subagent-announce-delivery.test.ts extensions/qa-lab/src/providers/mock-openai/server.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.e2e.config.ts src/agents/subagent-announce.format.e2e.test.ts`
- Testbox `tbx_01krxc5dhr2jehpy1dvpzwvx4w`: `pnpm openclaw qa suite --provider-mode mock-openai --runtime-pair pi,codex --runtime-parity-tier standard --scenario thread-memory-isolation --output-dir .artifacts/qa-e2e/runtime-parity-thread-memory-fix`
- Testbox `tbx_01krxr27kjmcdsq8y5rex7npm4`: `CI=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 pnpm check:changed`

## Real behavior proof

Behavior addressed: Broad release/prerelease QA regressions found in remote sweep on `9536d66a355541df0a492f8c70a9fe8bb4ea37de`, plus launcher-contract drift prevention requested during review.

Real environment tested: Local focused Vitest in Codex worktree, plus Blacksmith Testbox `tbx_01krxc5dhr2jehpy1dvpzwvx4w` and `tbx_01krxr27kjmcdsq8y5rex7npm4`.

Exact steps or command run after this patch: Targeted local Vitest suites listed above, targeted qa-lab runtime-pair scenario for `thread-memory-isolation`, and `pnpm check:changed` inside Testbox without recursive `OPENCLAW_TESTBOX=1`.

Evidence after fix: Focused local suites passed; targeted runtime-pair scenario exited 0; Testbox changed gate exited 0.

Observed result after fix: The previously failing subagent announce, Discord/Slack visible reply, plugin uninstall fixture, qa-lab runtime parity mock-server, and launcher Node-floor drift-prevention paths are green on the patched branch.

What was not tested: Full release/prerelease workflows were not rerun on this draft PR yet; the original QA-Lab Matrix live media timeout remains classified as live/infra until rerun.
