### PR TITLE
fix(codex): mark contextCompaction phase=end event as completed

### DIFF
--- a/extensions/codex/src/app-server/event-projector.test.ts
+++ b/extensions/codex/src/app-server/event-projector.test.ts
@@ -1102,6 +1102,19 @@ describe("CodexAppServerEventProjector", () => {
         completed: true,
       },
     );
+    // Without `completed: true` on the end event, the auto-reply runner
+    // surfaces a misleading "\uD83E\uDDF9 Compaction incomplete" notice to
+    // users who opt into agents.defaults.compaction.notifyUser.
+    expect(onAgentEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stream: "compaction",
+        data: expect.objectContaining({
+          phase: "end",
+          itemId: "compact-1",
+          completed: true,
+        }),
+      }),
+    );
     expect(result.toolMetas).toEqual([{ toolName: "sessions_send" }]);
     expect(result.messagesSnapshot.map((message) => message.role)).toEqual([
       "user",

--- a/extensions/codex/src/app-server/event-projector.ts
+++ b/extensions/codex/src/app-server/event-projector.ts
@@ -549,6 +549,13 @@ export class CodexAppServerEventProjector {
           channelId: this.params.messageChannel ?? this.params.messageProvider ?? undefined,
         },
       });
+      // Signal completion to the runner. Without `completed: true`,
+      // src/auto-reply/reply/agent-runner-execution.ts treats this end event
+      // as a failure and emits the "\uD83E\uDDF9 Compaction incomplete" notice
+      // when agents.defaults.compaction.notifyUser is enabled. `item/completed`
+      // for a contextCompaction item is itself the Codex success signal
+      // (see compact.ts::compactCodexNativeThread), so this branch only fires
+      // on actual completion.
       this.emitAgentEvent({
         stream: "compaction",
         data: {
@@ -558,6 +565,7 @@ export class CodexAppServerEventProjector {
           threadId: this.threadId,
           turnId: this.turnId,
           itemId,
+          completed: true,
         },
       });
     }


### PR DESCRIPTION
## What

In the codex app-server event projector, when Codex's `item/completed` notification arrives for a `contextCompaction` item, the projector currently emits a `stream: "compaction"` event with `phase: "end"` but **without `completed: true`** on the payload.

`src/auto-reply/reply/agent-runner-execution.ts` (added by #67830) treats a `phase: "end"` event lacking `completed: true` as a failure and surfaces the user-facing **`🧹 Compaction incomplete`** notice when `agents.defaults.compaction.notifyUser` is enabled — even though the compaction actually finished successfully.

This PR adds `completed: true` to the codex `phase: "end"` payload so it matches the pi runtime, plus a regression test.

## Why this slipped through

The default value of `agents.defaults.compaction.notifyUser` is `false`, so most users never see the inaccurate notice. It only appears when **all three** conditions are met:

1. `agents.defaults.compaction.notifyUser = true`
2. agent runs the **codex** harness (the pi runtime is unaffected — see below)
3. Codex internally triggers a compaction during the session

The pi runtime already sets the flag correctly in `src/agents/pi-embedded-subscribe.handlers.compaction.ts`. The bug is codex-only.

## Why `completed: true` is unconditional here

Inside `handleItemCompleted`, Codex's `item/completed` for a `contextCompaction` item **is itself** the success signal:

- `compactCodexNativeThread` in `src/compaction/compact.ts` waits for this event as the completion gate.
- `readNativeCompactionCompletion` in `extensions/codex/src/app-server/run-attempt.ts` treats this branch as the success path.

If compaction had failed, the projector would never reach `handleItemCompleted` for that item. So the flag can be set unconditionally on this branch, mirroring how the pi runtime does it.

## Reproduction

```
agents:
  defaults:
    compaction:
      notifyUser: true
```

Bind the agent to a codex harness, run a long session that triggers Codex's internal compaction. Before this patch you see `🧹 Compaction incomplete`; after the patch it correctly shows the success path.

I reproduced and verified the fix locally on Telegram with the OpenClaw codex agent. Happy to attach screenshots if useful.

## Tests

Adds a regression assertion to `extensions/codex/src/app-server/event-projector.test.ts` so the `completed: true` field is asserted on the `phase: "end"` payload. The existing test already exercises the start event; this extends it to the end event.

## Risk

Tiny. One new field on one event path; pi runtime already sets it the same way. No public API change.
