### PR TITLE
fix(models): respect auth order in picker label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Docs: https://docs.openclaw.ai
 
 - Agents/image generation: allow distinct `image_generate` prompts to start separate session-backed background tasks while same-prompt retries still return the active task status. (#83614) Thanks @Elarwei001.
 - Sessions: skip trailing custom transcript entries when checking tail assistant replies so embedded CLI gap-fill does not duplicate canonical assistant output. (#83635) Thanks @yaoyi1222.
+- Replies: show `/models openai` auth labels using Codex-first `auth.order.openai` profile preference before env API-key fallbacks. (#83581) Thanks @hclsys.
 - Telegram: keep verbose tool progress visible without mirroring non-final progress into active session transcripts, preventing embedded provider replies from aborting mid-run. (#83631) Thanks @kurplunkin.
 - Cron: link isolated scheduled task runs to their stable cron session so task status and cleanup can follow the backing agent run. (#83606) Thanks @jai.
 - CLI: enforce the documented Node.js 22.19 runtime floor in the source launcher.

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -658,6 +658,33 @@ describe("handleModelsCommand", () => {
     expect(authLabelParams.workspaceDir).toBe("/tmp");
   });
 
+  it("labels OpenAI model lists through auth.order compatible Codex profiles", async () => {
+    modelAuthLabelMocks.resolveModelAuthLabel.mockImplementation((params: unknown) => {
+      const acceptedProviderIds = (params as { acceptedProviderIds?: string[] })
+        .acceptedProviderIds;
+      return acceptedProviderIds?.[0] === "openai-codex"
+        ? "oauth (openai-codex:status)"
+        : "api-key (env: OPENAI_API_KEY)";
+    });
+
+    const result = await handleModelsCommand(
+      buildParams("/models openai", {
+        auth: {
+          order: {
+            openai: ["openai-codex:status"],
+          },
+        },
+      }),
+      true,
+    );
+
+    expect(result?.reply?.text).toContain("Models (openai · 🔑 oauth (openai-codex:status))");
+    const [[authLabelParams]] = modelAuthLabelMocks.resolveModelAuthLabel.mock
+      .calls as unknown as Array<[{ provider?: string; acceptedProviderIds?: string[] }]>;
+    expect(authLabelParams.provider).toBe("openai");
+    expect(authLabelParams.acceptedProviderIds).toEqual(["openai-codex", "openai"]);
+  });
+
   it("uses spawned workspace for direct /models provider visibility", async () => {
     modelProviderAuthMocks.authenticatedProviders = new Set(["anthropic"]);
     const params = buildParams("/models");

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -682,7 +682,25 @@ describe("handleModelsCommand", () => {
     const [[authLabelParams]] = modelAuthLabelMocks.resolveModelAuthLabel.mock
       .calls as unknown as Array<[{ provider?: string; acceptedProviderIds?: string[] }]>;
     expect(authLabelParams.provider).toBe("openai");
-    expect(authLabelParams.acceptedProviderIds).toEqual(["openai-codex", "openai"]);
+    expect(authLabelParams.acceptedProviderIds).toEqual(["openai-codex"]);
+  });
+
+  it("labels OpenAI model lists through the dispatch harness auth providers", async () => {
+    modelAuthLabelMocks.resolveModelAuthLabel.mockImplementation((params: unknown) => {
+      const acceptedProviderIds = (params as { acceptedProviderIds?: string[] })
+        .acceptedProviderIds;
+      return acceptedProviderIds?.length === 1 && acceptedProviderIds[0] === "openai-codex"
+        ? "oauth (codex-runtime)"
+        : "api-key (env: OPENAI_API_KEY)";
+    });
+
+    const result = await handleModelsCommand(buildParams("/models openai"), true);
+
+    expect(result?.reply?.text).toContain("Models (openai · 🔑 oauth (codex-runtime))");
+    const [[authLabelParams]] = modelAuthLabelMocks.resolveModelAuthLabel.mock
+      .calls as unknown as Array<[{ provider?: string; acceptedProviderIds?: string[] }]>;
+    expect(authLabelParams.provider).toBe("openai");
+    expect(authLabelParams.acceptedProviderIds).toEqual(["openai-codex"]);
   });
 
   it("uses spawned workspace for direct /models provider visibility", async () => {

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -21,6 +21,7 @@ import {
   resolveModelRefFromString,
 } from "../../agents/model-selection.js";
 import { createModelVisibilityPolicy } from "../../agents/model-visibility-policy.js";
+import { listOpenAIAuthProfileProvidersForAgentRuntime } from "../../agents/openai-codex-routing.js";
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import { getChannelPlugin } from "../../channels/plugins/index.js";
 import type { SessionEntry } from "../../config/sessions.js";
@@ -393,6 +394,10 @@ function resolveProviderLabel(params: {
 }): string {
   const authLabel = resolveModelAuthLabel({
     provider: params.provider,
+    acceptedProviderIds: listOpenAIAuthProfileProvidersForAgentRuntime({
+      provider: params.provider,
+      config: params.cfg,
+    }),
     cfg: params.cfg,
     sessionEntry: params.sessionEntry,
     agentDir: params.agentDir,

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -388,14 +388,21 @@ function parseModelsArgs(raw: string): ParsedModelsCommand {
 function resolveProviderLabel(params: {
   provider: string;
   cfg: OpenClawConfig;
+  agentId?: string;
   agentDir?: string;
   workspaceDir?: string;
   sessionEntry?: ModelsCommandSessionEntry;
 }): string {
+  const harnessPolicy = resolveAgentHarnessPolicy({
+    config: params.cfg,
+    provider: params.provider,
+    agentId: params.agentId,
+  });
   const authLabel = resolveModelAuthLabel({
     provider: params.provider,
     acceptedProviderIds: listOpenAIAuthProfileProvidersForAgentRuntime({
       provider: params.provider,
+      harnessRuntime: harnessPolicy.runtime,
       config: params.cfg,
     }),
     cfg: params.cfg,
@@ -413,6 +420,7 @@ export function formatModelsAvailableHeader(params: {
   provider: string;
   total: number;
   cfg: OpenClawConfig;
+  agentId?: string;
   agentDir?: string;
   workspaceDir?: string;
   sessionEntry?: ModelsCommandSessionEntry;
@@ -420,6 +428,7 @@ export function formatModelsAvailableHeader(params: {
   const providerLabel = resolveProviderLabel({
     provider: params.provider,
     cfg: params.cfg,
+    agentId: params.agentId,
     agentDir: params.agentDir,
     workspaceDir: params.workspaceDir,
     sessionEntry: params.sessionEntry,
@@ -544,6 +553,7 @@ export async function resolveModelsCommandReply(params: {
     const emptyProviderLabel = resolveProviderLabel({
       provider,
       cfg: params.cfg,
+      agentId: params.agentId,
       agentDir: params.agentDir,
       workspaceDir: params.workspaceDir,
       sessionEntry: params.sessionEntry,
@@ -576,6 +586,7 @@ export async function resolveModelsCommandReply(params: {
         provider,
         total,
         cfg: params.cfg,
+        agentId: params.agentId,
         agentDir: params.agentDir,
         workspaceDir: params.workspaceDir,
         sessionEntry: params.sessionEntry,
@@ -605,6 +616,7 @@ export async function resolveModelsCommandReply(params: {
   const providerLabel = resolveProviderLabel({
     provider,
     cfg: params.cfg,
+    agentId: params.agentId,
     agentDir: params.agentDir,
     workspaceDir: params.workspaceDir,
     sessionEntry: params.sessionEntry,


### PR DESCRIPTION
Fixes #83574

## Summary
- Pass the OpenAI/Codex accepted auth-provider set into shared /models provider label rendering.
- Add regression coverage so an explicit auth.order.openai Codex profile labels the picker as oauth instead of env api-key.

## Validation
- node scripts/run-vitest.mjs src/auto-reply/reply/commands-models.test.ts -> 24 passed
- node scripts/run-vitest.mjs src/agents/model-auth-label.test.ts -> 14 passed
- node scripts/run-vitest.mjs src/auto-reply/reply/commands-status.test.ts -> 21 passed
- git diff --check -> passed
- pnpm --config.verify-deps-before-run=false check:changed -> passed

Note: plain pnpm check:changed hung inside pnpm install after printing Done; reran with pnpm dependency auto-verify disabled so the actual changed checks executed.