### PR TITLE
fix(cron): add Authorization header to provider preflight probe (GET /models)

### DIFF
--- a/src/cron/isolated-agent/model-preflight.runtime.ts
+++ b/src/cron/isolated-agent/model-preflight.runtime.ts
@@ -160,9 +160,20 @@ function resolveProbeApiKey(providerCfg: ModelProviderConfig | undefined, provid
   if (configKey && typeof configKey === "string" && configKey.trim()) {
     return configKey.trim();
   }
-  // Fall back to env var lookup using the provider name
-  const envResult = resolveEnvApiKey(provider, process.env);
-  return envResult?.apiKey || undefined;
+  // Try direct env var: LITELLM_API_KEY, VLLM_API_KEY, SGLANG_API_KEY, etc.
+  const upperName = provider.toUpperCase().replace(/[^A-Z0-9_]/g, "");
+  const directKey = process.env[upperName + "_API_KEY"];
+  if (directKey?.trim()) {
+    return directKey.trim();
+  }
+  // Fall back to env var lookup via provider-registered env var names
+  try {
+    const envResult = resolveEnvApiKey(provider, process.env);
+    if (envResult?.apiKey) return envResult.apiKey;
+  } catch {
+    // ignore resolution errors
+  }
+  return undefined;
 }
 
 async function probeLocalProviderEndpoint(params: {

--- a/src/cron/isolated-agent/model-preflight.runtime.ts
+++ b/src/cron/isolated-agent/model-preflight.runtime.ts
@@ -156,10 +156,14 @@ function buildUnavailableResult(params: {
 async function probeLocalProviderEndpoint(params: {
   api: PreflightApi;
   baseUrl: string;
+  apiKey?: string;
 }): Promise<void> {
+  const headers: Record<string, string> | undefined = params.apiKey
+    ? { Authorization: `Bearer ${params.apiKey}` }
+    : undefined;
   const { response, release } = await fetchWithSsrFGuard({
     url: buildProbeUrl(params.api, params.baseUrl),
-    init: { method: "GET" },
+    init: { method: "GET", ...(headers ? { headers } : {}) },
     policy: buildLocalProviderSsrFPolicy(params.baseUrl),
     timeoutMs: PREFLIGHT_TIMEOUT_MS,
     auditContext: "cron-model-provider-preflight",
@@ -207,7 +211,11 @@ export async function preflightCronModelProvider(params: {
 
   let result: EndpointPreflightResult;
   try {
-    await probeLocalProviderEndpoint({ api, baseUrl });
+    await probeLocalProviderEndpoint({
+      api,
+      baseUrl,
+      apiKey: providerConfig.apiKey,
+    });
     result = { status: "available" };
   } catch (error) {
     result = { status: "unavailable", error };

--- a/src/cron/isolated-agent/model-preflight.runtime.ts
+++ b/src/cron/isolated-agent/model-preflight.runtime.ts
@@ -1,3 +1,4 @@
+import { resolveEnvApiKey } from "../../agents/model-auth-env.js";
 import { normalizeProviderId } from "../../agents/provider-id.js";
 import type { ModelProviderConfig } from "../../config/types.models.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -153,6 +154,17 @@ function buildUnavailableResult(params: {
   };
 }
 
+function resolveProbeApiKey(providerCfg: ModelProviderConfig | undefined, provider: string): string | undefined {
+  // First try the provider config's apiKey field
+  const configKey = providerCfg?.apiKey;
+  if (configKey && typeof configKey === "string" && configKey.trim()) {
+    return configKey.trim();
+  }
+  // Fall back to env var lookup using the provider name
+  const envResult = resolveEnvApiKey(provider, process.env);
+  return envResult?.apiKey || undefined;
+}
+
 async function probeLocalProviderEndpoint(params: {
   api: PreflightApi;
   baseUrl: string;
@@ -211,10 +223,11 @@ export async function preflightCronModelProvider(params: {
 
   let result: EndpointPreflightResult;
   try {
+    const probeApiKey = resolveProbeApiKey(providerConfig, params.provider);
     await probeLocalProviderEndpoint({
       api,
       baseUrl,
-      apiKey: providerConfig.apiKey,
+      apiKey: probeApiKey,
     });
     result = { status: "available" };
   } catch (error) {


### PR DESCRIPTION
## Summary

The cron job preflight check in `model-preflight.runtime.ts` sends `GET {baseUrl}/models` to local providers to verify connectivity before running the job, but includes **no Authorization header**. For providers that require authentication (e.g. LiteLLM with `allow_user_auth: true`), this generates spurious 401 errors in the proxy logs on every cron run.

## Root Cause

`src/cron/isolated-agent/model-preflight.runtime.ts` → `probeLocalProviderEndpoint()`:

```typescript
async function probeLocalProviderEndpoint(params) {
  const { response, release } = await fetchWithSsrFGuard({
    url: buildProbeUrl(params.api, params.baseUrl),  // http://127.0.0.1:4000/models
    init: { method: "GET" },                          // ← NO Authorization header
    ...
  });
}
```

The probe only runs for local providers (localhost/127.0.0.1) with `api: "openai-completions"` or `api: "ollama"`.

## Reproduction

For any cron job with a local OpenAI-compatible provider (LiteLLM, vLLM, etc.):

```
19:25:04 → GET /models (401, NO Authorization header)
19:25:04 → POST /chat/completions (200, WITH Authorization header)
```

Confirmed in this report's live LiteLLM proxy log: **61 occurrences** of `GET /models` with `401 Unauthorized`, each triggered by a cron preflight check.

## Fix

Pass the configured `apiKey` from the provider config to the probe function and include it as `Authorization: Bearer <apiKey>` header:

```typescript
async function probeLocalProviderEndpoint(params: {
  api: PreflightApi;
  baseUrl: string;
  apiKey?: string;               // ← New optional parameter
}): Promise<void> {
  const headers = params.apiKey
    ? { Authorization: `Bearer ${params.apiKey}` }
    : undefined;                  // ← Only add header when key exists
  const { response, release } = await fetchWithSsrFGuard({
    url: buildProbeUrl(params.api, params.baseUrl),
    init: { method: "GET", ...(headers ? { headers } : {}) },
    ...
  });
}
```

If no API key is configured (authless local servers like Ollama), the probe behaves exactly as before — no change in behavior.

## Real behavior proof

**Before** (live LiteLLM proxy log):
```
19:25:04 - LiteLLM Proxy:ERROR - No api key passed in.
INFO: 127.0.0.1:52932 - "GET /models HTTP/1.1" 401 Unauthorized
19:25:04 - POST /chat/completions HTTP/1.1" 200 OK
```

**After**: Apply this patch, restart Gateway, trigger cron job, verify LiteLLM proxy log shows no `GET /models 401`.

## Related

- #83461 (closed — original incorrect root cause in provider-catalog.ts)
