### PR TITLE
Add TrustedRouter.com provider option

### DIFF
--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -311,6 +311,7 @@ See [/providers/kilocode](/providers/kilocode) for setup details.
 | Qwen Cloud              | `qwen`                           | `QWEN_API_KEY` / `MODELSTUDIO_API_KEY` / `DASHSCOPE_API_KEY` | `qwen/qwen3.5-plus`                           |
 | StepFun                 | `stepfun` / `stepfun-plan`       | `STEPFUN_API_KEY`                                            | `stepfun/step-3.5-flash`                      |
 | Together                | `together`                       | `TOGETHER_API_KEY`                                           | `together/moonshotai/Kimi-K2.5`               |
+| TrustedRouter.com       | `trustedrouter`                  | `TRUSTEDROUTER_API_KEY`                                      | `trustedrouter/auto`                          |
 | Venice                  | `venice`                         | `VENICE_API_KEY`                                             | -                                             |
 | Vercel AI Gateway       | `vercel-ai-gateway`              | `AI_GATEWAY_API_KEY`                                         | `vercel-ai-gateway/anthropic/claude-opus-4.6` |
 | Volcano Engine (Doubao) | `volcengine` / `volcengine-plan` | `VOLCANO_ENGINE_API_KEY`                                     | `volcengine-plan/ark-code-latest`             |
@@ -322,6 +323,9 @@ See [/providers/kilocode](/providers/kilocode) for setup details.
 <AccordionGroup>
   <Accordion title="OpenRouter">
     Applies its app-attribution headers and Anthropic `cache_control` markers only on verified `openrouter.ai` routes. DeepSeek, Moonshot, and ZAI refs are cache-TTL eligible for OpenRouter-managed prompt caching but do not receive Anthropic cache markers. As a proxy-style OpenAI-compatible path, it skips native-OpenAI-only shaping (`serviceTier`, Responses `store`, prompt-cache hints, OpenAI reasoning-compat). Gemini-backed refs keep proxy-Gemini thought-signature sanitation only.
+  </Accordion>
+  <Accordion title="TrustedRouter.com">
+    Uses the OpenRouter-compatible OpenAI chat completions path at `https://api.quillrouter.com/v1`, with its own `TRUSTEDROUTER_API_KEY` and default `trustedrouter/auto` route. OpenClaw keeps it separate from OpenRouter so credentials and default model refs do not collide.
   </Accordion>
   <Accordion title="Kilo Gateway">
     Gemini-backed refs follow the same proxy-Gemini sanitation path; `kilocode/kilo/auto` and other proxy-reasoning-unsupported refs skip proxy reasoning injection.

--- a/docs/plugins/reference/openrouter.md
+++ b/docs/plugins/reference/openrouter.md
@@ -7,7 +7,7 @@ title: "OpenRouter plugin"
 
 # OpenRouter plugin
 
-Adds OpenRouter model provider support to OpenClaw.
+Adds OpenRouter and TrustedRouter.com model provider support to OpenClaw.
 
 ## Distribution
 
@@ -16,7 +16,7 @@ Adds OpenRouter model provider support to OpenClaw.
 
 ## Surface
 
-providers: openrouter; contracts: imageGenerationProviders, mediaUnderstandingProviders, musicGenerationProviders, speechProviders, videoGenerationProviders
+providers: openrouter, trustedrouter; contracts: imageGenerationProviders, mediaUnderstandingProviders, musicGenerationProviders, speechProviders, videoGenerationProviders
 
 ## Related docs
 

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -59,6 +59,7 @@ Looking for chat channel docs (WhatsApp/Telegram/Discord/Slack/Mattermost (plugi
 - [OpenCode](/providers/opencode)
 - [OpenCode Go](/providers/opencode-go)
 - [OpenRouter](/providers/openrouter)
+- [TrustedRouter.com](/providers/trustedrouter)
 - [Perplexity (web search)](/providers/perplexity-provider)
 - [Qianfan](/providers/qianfan)
 - [Qwen Cloud](/providers/qwen)

--- a/docs/providers/openrouter.md
+++ b/docs/providers/openrouter.md
@@ -12,6 +12,9 @@ title: "OpenRouter"
 OpenRouter provides a **unified API** that routes requests to many models behind a single
 endpoint and API key. It is OpenAI-compatible, so most OpenAI SDKs work by switching the base URL.
 
+For an end-to-end encrypted OpenRouter-compatible router, OpenClaw also includes
+[TrustedRouter.com](/providers/trustedrouter) as a separate provider option.
+
 ## Getting started
 
 <Steps>

--- a/docs/providers/trustedrouter.md
+++ b/docs/providers/trustedrouter.md
@@ -1,0 +1,63 @@
+---
+summary: "Use TrustedRouter.com's end-to-end encrypted OpenRouter-compatible LLM router in OpenClaw"
+read_when:
+  - You want an OpenRouter-compatible router with end-to-end encrypted prompts
+  - You want to use TrustedRouter.com as an LLM provider in OpenClaw
+title: "TrustedRouter.com"
+---
+
+TrustedRouter.com is an OpenRouter-compatible LLM router with end-to-end
+encrypted prompt handling. OpenClaw treats it as its own provider so you can keep
+OpenRouter and TrustedRouter credentials separate.
+
+## Getting started
+
+<Steps>
+  <Step title="Get your API key">
+    Create an API key at [TrustedRouter.com](https://trustedrouter.com/).
+  </Step>
+  <Step title="Run onboarding">
+    ```bash
+    openclaw onboard --auth-choice trustedrouter-api-key
+    ```
+  </Step>
+  <Step title="(Optional) Switch to a specific model">
+    Onboarding defaults to `trustedrouter/auto`. Pick a concrete model later:
+
+    ```bash
+    openclaw models set trustedrouter/<provider>/<model>
+    ```
+  </Step>
+</Steps>
+
+## Config example
+
+```json5
+{
+  env: { TRUSTEDROUTER_API_KEY: "sk-tr-v1-..." },
+  agents: {
+    defaults: {
+      model: { primary: "trustedrouter/auto" },
+    },
+  },
+}
+```
+
+## Endpoint
+
+OpenClaw uses TrustedRouter's OpenAI-compatible production endpoint:
+
+```text
+https://api.quillrouter.com/v1
+```
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="OpenRouter" href="/providers/openrouter" icon="route">
+    OpenRouter provider setup and OpenRouter-specific request behavior.
+  </Card>
+  <Card title="Model selection" href="/concepts/model-providers" icon="layers">
+    Choosing providers, model refs, and failover behavior.
+  </Card>
+</CardGroup>

--- a/extensions/openrouter/index.test.ts
+++ b/extensions/openrouter/index.test.ts
@@ -10,12 +10,13 @@ import { describe, expect, it, vi } from "vitest";
 import openrouterPlugin from "./index.js";
 import {
   buildOpenrouterProvider,
+  buildTrustedRouterProvider,
   isOpenRouterProxyReasoningUnsupportedModel,
 } from "./provider-catalog.js";
 import { resolveThinkingProfile } from "./provider-policy-api.js";
 
 describe("openrouter provider hooks", () => {
-  it("registers OpenRouter speech alongside model, media, and catalog providers", async () => {
+  it("registers OpenRouter and TrustedRouter model providers", async () => {
     const {
       providers,
       speechProviders,
@@ -36,13 +37,20 @@ describe("openrouter provider hooks", () => {
       kind: "video_generation",
     });
 
-    expect(providers.map((provider) => provider.id)).toEqual(["openrouter"]);
+    expect(providers.map((provider) => provider.id)).toEqual(["openrouter", "trustedrouter"]);
     expect(speechProviders.map((provider) => provider.id)).toEqual(["openrouter"]);
     expect(mediaProviders.map((provider) => provider.id)).toEqual(["openrouter"]);
     expect(imageProviders.map((provider) => provider.id)).toEqual(["openrouter"]);
     expect(musicProviders.map((provider) => provider.id)).toEqual(["openrouter"]);
     expect(videoProviders.map((provider) => provider.id)).toEqual(["openrouter"]);
     expect(modelCatalogProvider.liveCatalog).toBeTypeOf("function");
+  });
+
+  it("includes TrustedRouter.com as an end-to-end encrypted OpenRouter-compatible route", () => {
+    const provider = buildTrustedRouterProvider();
+
+    expect(provider.baseUrl).toBe("https://api.quillrouter.com/v1");
+    expect(provider.models?.map((model) => model.id)).toEqual(["trustedrouter/auto"]);
   });
 
   it("includes current Kimi models in the bundled catalog", () => {
@@ -197,6 +205,35 @@ describe("openrouter provider hooks", () => {
     ).toEqual({
       api: "openai-completions",
       baseUrl: "https://openrouter.ai/api/v1",
+    });
+  });
+
+  it("canonicalizes TrustedRouter.com runtime metadata", async () => {
+    const registered = await registerProviderPlugin({
+      plugin: openrouterPlugin,
+      id: "openrouter",
+      name: "OpenRouter Provider",
+    });
+    const provider = registered.providers.find((entry) => entry.id === "trustedrouter");
+
+    expect(provider?.normalizeConfig?.({
+      provider: "trustedrouter",
+      providerConfig: {
+        api: "openai-completions",
+        baseUrl: "https://api.quillrouter.com/v1/",
+        models: [],
+      },
+    } as never)?.baseUrl).toBe("https://api.quillrouter.com/v1");
+
+    expect(
+      provider?.normalizeTransport?.({
+        provider: "trustedrouter",
+        api: "openai-completions",
+        baseUrl: "https://api.quillrouter.com/v1/",
+      } as never),
+    ).toEqual({
+      api: "openai-completions",
+      baseUrl: "https://api.quillrouter.com/v1",
     });
   });
 

--- a/extensions/openrouter/index.ts
+++ b/extensions/openrouter/index.ts
@@ -15,12 +15,20 @@ import {
 import { buildOpenRouterImageGenerationProvider } from "./image-generation-provider.js";
 import { openrouterMediaUnderstandingProvider } from "./media-understanding-provider.js";
 import { buildOpenRouterMusicGenerationProvider } from "./music-generation-provider.js";
-import { applyOpenrouterConfig, OPENROUTER_DEFAULT_MODEL_REF } from "./onboard.js";
+import {
+  applyOpenrouterConfig,
+  applyTrustedRouterConfig,
+  OPENROUTER_DEFAULT_MODEL_REF,
+  TRUSTEDROUTER_DEFAULT_MODEL_REF,
+} from "./onboard.js";
 import {
   buildOpenrouterProvider,
+  buildTrustedRouterProvider,
   isOpenRouterProxyReasoningUnsupportedModel,
   normalizeOpenRouterBaseUrl,
+  normalizeTrustedRouterBaseUrl,
   OPENROUTER_BASE_URL,
+  TRUSTEDROUTER_BASE_URL,
 } from "./provider-catalog.js";
 import { buildOpenRouterSpeechProvider } from "./speech-provider.js";
 import { wrapOpenRouterProviderStream } from "./stream.js";
@@ -33,7 +41,8 @@ import {
   listOpenRouterVideoModelCatalog,
 } from "./video-generation-provider.js";
 
-const PROVIDER_ID = "openrouter";
+const OPENROUTER_PROVIDER_ID = "openrouter";
+const TRUSTEDROUTER_PROVIDER_ID = "trustedrouter";
 const OPENROUTER_DEFAULT_MAX_TOKENS = 8192;
 const OPENROUTER_CACHE_TTL_MODEL_PREFIXES = [
   "anthropic/",
@@ -59,6 +68,24 @@ function normalizeOpenRouterResolvedModel<T extends ProviderRuntimeModel>(model:
   };
 }
 
+function normalizeTrustedRouterResolvedModel<T extends ProviderRuntimeModel>(
+  model: T,
+): T | undefined {
+  const normalizedBaseUrl = normalizeTrustedRouterBaseUrl(model.baseUrl);
+  const reasoning = isOpenRouterProxyReasoningUnsupportedModel(model.id) ? false : model.reasoning;
+  if (
+    (!normalizedBaseUrl || normalizedBaseUrl === model.baseUrl) &&
+    reasoning === model.reasoning
+  ) {
+    return undefined;
+  }
+  return {
+    ...model,
+    ...(normalizedBaseUrl ? { baseUrl: normalizedBaseUrl } : {}),
+    reasoning,
+  };
+}
+
 export default definePluginEntry({
   id: "openrouter",
   name: "OpenRouter Provider",
@@ -66,14 +93,16 @@ export default definePluginEntry({
   register(api) {
     function buildDynamicOpenRouterModel(
       ctx: ProviderResolveDynamicModelContext,
+      providerId = OPENROUTER_PROVIDER_ID,
+      baseUrl = OPENROUTER_BASE_URL,
     ): ProviderRuntimeModel {
       const capabilities = getOpenRouterModelCapabilities(ctx.modelId);
       return {
         id: ctx.modelId,
         name: capabilities?.name ?? ctx.modelId,
         api: "openai-completions",
-        provider: PROVIDER_ID,
-        baseUrl: OPENROUTER_BASE_URL,
+        provider: providerId,
+        baseUrl,
         reasoning:
           (capabilities?.reasoning ?? false) &&
           !isOpenRouterProxyReasoningUnsupportedModel(ctx.modelId),
@@ -92,13 +121,13 @@ export default definePluginEntry({
     }
 
     api.registerProvider({
-      id: PROVIDER_ID,
+      id: OPENROUTER_PROVIDER_ID,
       label: "OpenRouter",
       docsPath: "/providers/models",
       envVars: ["OPENROUTER_API_KEY"],
       auth: [
         createProviderApiKeyAuthMethod({
-          providerId: PROVIDER_ID,
+          providerId: OPENROUTER_PROVIDER_ID,
           methodId: "api-key",
           label: "OpenRouter API key",
           hint: "API key",
@@ -113,7 +142,7 @@ export default definePluginEntry({
             choiceId: "openrouter-api-key",
             choiceLabel: "OpenRouter API key",
             groupId: "openrouter",
-            groupLabel: "OpenRouter",
+            groupLabel: "OpenRouter-compatible routers",
             groupHint: "API key",
             onboardingScopes: ["text-inference", "music-generation"],
           },
@@ -122,7 +151,7 @@ export default definePluginEntry({
       catalog: {
         order: "simple",
         run: async (ctx) => {
-          const apiKey = ctx.resolveProviderApiKey(PROVIDER_ID).apiKey;
+          const apiKey = ctx.resolveProviderApiKey(OPENROUTER_PROVIDER_ID).apiKey;
           if (!apiKey) {
             return null;
           }
@@ -168,12 +197,92 @@ export default definePluginEntry({
       wrapStreamFn: wrapOpenRouterProviderStream,
       isCacheTtlEligible: (ctx) => isOpenRouterCacheTtlModel(ctx.modelId),
     });
+    api.registerProvider({
+      id: TRUSTEDROUTER_PROVIDER_ID,
+      label: "TrustedRouter.com",
+      docsPath: "/providers/trustedrouter",
+      envVars: ["TRUSTEDROUTER_API_KEY"],
+      auth: [
+        createProviderApiKeyAuthMethod({
+          providerId: TRUSTEDROUTER_PROVIDER_ID,
+          methodId: "api-key",
+          label: "TrustedRouter.com API key",
+          hint: "E2EE OpenRouter-compatible API key",
+          optionKey: "trustedrouterApiKey",
+          flagName: "--trustedrouter-api-key",
+          envVar: "TRUSTEDROUTER_API_KEY",
+          promptMessage: "Enter TrustedRouter.com API key",
+          defaultModel: TRUSTEDROUTER_DEFAULT_MODEL_REF,
+          expectedProviders: ["trustedrouter"],
+          applyConfig: (cfg) => applyTrustedRouterConfig(cfg),
+          wizard: {
+            choiceId: "trustedrouter-api-key",
+            choiceLabel: "TrustedRouter.com API key",
+            choiceHint: "End-to-end encrypted OpenRouter-compatible router",
+            groupId: "openrouter",
+            groupLabel: "OpenRouter-compatible routers",
+            groupHint: "API key",
+            onboardingScopes: ["text-inference"],
+          },
+        }),
+      ],
+      catalog: {
+        order: "simple",
+        run: async (ctx) => {
+          const apiKey = ctx.resolveProviderApiKey(TRUSTEDROUTER_PROVIDER_ID).apiKey;
+          if (!apiKey) {
+            return null;
+          }
+          return {
+            provider: {
+              ...buildTrustedRouterProvider(),
+              apiKey,
+            },
+          };
+        },
+      },
+      staticCatalog: {
+        order: "simple",
+        run: async () => ({
+          provider: buildTrustedRouterProvider(),
+        }),
+      },
+      resolveDynamicModel: (ctx) =>
+        buildDynamicOpenRouterModel(ctx, TRUSTEDROUTER_PROVIDER_ID, TRUSTEDROUTER_BASE_URL),
+      prepareDynamicModel: async (ctx) => {
+        if (ctx.modelId !== TRUSTEDROUTER_DEFAULT_MODEL_REF) {
+          await loadOpenRouterModelCapabilities(ctx.modelId);
+        }
+      },
+      normalizeConfig: ({ providerConfig }) => {
+        const normalizedBaseUrl = normalizeTrustedRouterBaseUrl(providerConfig.baseUrl);
+        return normalizedBaseUrl && normalizedBaseUrl !== providerConfig.baseUrl
+          ? { ...providerConfig, baseUrl: normalizedBaseUrl }
+          : undefined;
+      },
+      normalizeResolvedModel: ({ model }) => normalizeTrustedRouterResolvedModel(model),
+      normalizeTransport: ({ api, baseUrl }) => {
+        const normalizedBaseUrl = normalizeTrustedRouterBaseUrl(baseUrl);
+        return normalizedBaseUrl && normalizedBaseUrl !== baseUrl
+          ? {
+              api,
+              baseUrl: normalizedBaseUrl,
+            }
+          : undefined;
+      },
+      ...PASSTHROUGH_GEMINI_REPLAY_HOOKS,
+      resolveReasoningOutputMode: () => "native",
+      supportsXHighThinking: ({ modelId }) => supportsOpenRouterXHighThinking(modelId),
+      resolveThinkingProfile: ({ modelId }) => resolveOpenRouterThinkingProfile(modelId),
+      isModernModelRef: () => true,
+      wrapStreamFn: wrapOpenRouterProviderStream,
+    });
     api.registerMediaUnderstandingProvider(openrouterMediaUnderstandingProvider);
     api.registerImageGenerationProvider(buildOpenRouterImageGenerationProvider());
     api.registerMusicGenerationProvider(buildOpenRouterMusicGenerationProvider());
     api.registerVideoGenerationProvider(buildOpenRouterVideoGenerationProvider());
     api.registerModelCatalogProvider({
-      provider: PROVIDER_ID,
+      provider: OPENROUTER_PROVIDER_ID,
       kinds: ["video_generation"],
       liveCatalog: listOpenRouterVideoModelCatalog,
     });

--- a/extensions/openrouter/onboard.test.ts
+++ b/extensions/openrouter/onboard.test.ts
@@ -6,7 +6,10 @@ import { describe, it } from "vitest";
 import {
   applyOpenrouterConfig,
   applyOpenrouterProviderConfig,
+  applyTrustedRouterConfig,
+  applyTrustedRouterProviderConfig,
   OPENROUTER_DEFAULT_MODEL_REF,
+  TRUSTEDROUTER_DEFAULT_MODEL_REF,
 } from "./onboard.js";
 
 describe("openrouter onboard", () => {
@@ -22,6 +25,21 @@ describe("openrouter onboard", () => {
     expectProviderOnboardPrimaryAndFallbacks({
       applyConfig: applyOpenrouterConfig,
       modelRef: OPENROUTER_DEFAULT_MODEL_REF,
+    });
+  });
+
+  it("adds TrustedRouter allowlist entry and preserves alias", () => {
+    expectProviderOnboardAllowlistAlias({
+      applyProviderConfig: applyTrustedRouterProviderConfig,
+      modelRef: TRUSTEDROUTER_DEFAULT_MODEL_REF,
+      alias: "E2EE Router",
+    });
+  });
+
+  it("sets TrustedRouter primary model and preserves existing model fallbacks", () => {
+    expectProviderOnboardPrimaryAndFallbacks({
+      applyConfig: applyTrustedRouterConfig,
+      modelRef: TRUSTEDROUTER_DEFAULT_MODEL_REF,
     });
   });
 });

--- a/extensions/openrouter/onboard.ts
+++ b/extensions/openrouter/onboard.ts
@@ -4,12 +4,17 @@ import {
 } from "openclaw/plugin-sdk/provider-onboard";
 
 export const OPENROUTER_DEFAULT_MODEL_REF = "openrouter/auto";
+export const TRUSTEDROUTER_DEFAULT_MODEL_REF = "trustedrouter/auto";
 
-export function applyOpenrouterProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
+function applyDefaultModelAlias(
+  cfg: OpenClawConfig,
+  modelRef: string,
+  alias: string,
+): OpenClawConfig {
   const models = { ...cfg.agents?.defaults?.models };
-  models[OPENROUTER_DEFAULT_MODEL_REF] = {
-    ...models[OPENROUTER_DEFAULT_MODEL_REF],
-    alias: models[OPENROUTER_DEFAULT_MODEL_REF]?.alias ?? "OpenRouter",
+  models[modelRef] = {
+    ...models[modelRef],
+    alias: models[modelRef]?.alias ?? alias,
   };
 
   return {
@@ -24,9 +29,24 @@ export function applyOpenrouterProviderConfig(cfg: OpenClawConfig): OpenClawConf
   };
 }
 
+export function applyOpenrouterProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
+  return applyDefaultModelAlias(cfg, OPENROUTER_DEFAULT_MODEL_REF, "OpenRouter");
+}
+
 export function applyOpenrouterConfig(cfg: OpenClawConfig): OpenClawConfig {
   return applyAgentDefaultModelPrimary(
     applyOpenrouterProviderConfig(cfg),
     OPENROUTER_DEFAULT_MODEL_REF,
+  );
+}
+
+export function applyTrustedRouterProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
+  return applyDefaultModelAlias(cfg, TRUSTEDROUTER_DEFAULT_MODEL_REF, "TrustedRouter.com");
+}
+
+export function applyTrustedRouterConfig(cfg: OpenClawConfig): OpenClawConfig {
+  return applyAgentDefaultModelPrimary(
+    applyTrustedRouterProviderConfig(cfg),
+    TRUSTEDROUTER_DEFAULT_MODEL_REF,
   );
 }

--- a/extensions/openrouter/openclaw.plugin.json
+++ b/extensions/openrouter/openclaw.plugin.json
@@ -4,11 +4,14 @@
     "onStartup": false
   },
   "enabledByDefault": true,
-  "providers": ["openrouter"],
+  "providers": ["openrouter", "trustedrouter"],
   "modelIdNormalization": {
     "providers": {
       "openrouter": {
         "prefixWhenBare": "openrouter"
+      },
+      "trustedrouter": {
+        "prefixWhenBare": "trustedrouter"
       }
     }
   },
@@ -26,17 +29,25 @@
     {
       "endpointClass": "openrouter",
       "hostSuffixes": ["openrouter.ai"]
+    },
+    {
+      "endpointClass": "openrouter",
+      "hostSuffixes": ["quillrouter.com", "trustedrouter.com"]
     }
   ],
   "providerRequest": {
     "providers": {
       "openrouter": {
         "family": "openrouter"
+      },
+      "trustedrouter": {
+        "family": "openrouter"
       }
     }
   },
   "providerAuthEnvVars": {
-    "openrouter": ["OPENROUTER_API_KEY"]
+    "openrouter": ["OPENROUTER_API_KEY"],
+    "trustedrouter": ["TRUSTEDROUTER_API_KEY"]
   },
   "providerAuthChoices": [
     {
@@ -45,13 +56,28 @@
       "choiceId": "openrouter-api-key",
       "choiceLabel": "OpenRouter API key",
       "groupId": "openrouter",
-      "groupLabel": "OpenRouter",
+      "groupLabel": "OpenRouter-compatible routers",
       "groupHint": "API key",
       "onboardingScopes": ["text-inference", "music-generation"],
       "optionKey": "openrouterApiKey",
       "cliFlag": "--openrouter-api-key",
       "cliOption": "--openrouter-api-key <key>",
       "cliDescription": "OpenRouter API key"
+    },
+    {
+      "provider": "trustedrouter",
+      "method": "api-key",
+      "choiceId": "trustedrouter-api-key",
+      "choiceLabel": "TrustedRouter.com API key",
+      "choiceHint": "End-to-end encrypted OpenRouter-compatible router",
+      "groupId": "openrouter",
+      "groupLabel": "OpenRouter-compatible routers",
+      "groupHint": "API key",
+      "onboardingScopes": ["text-inference"],
+      "optionKey": "trustedrouterApiKey",
+      "cliFlag": "--trustedrouter-api-key",
+      "cliOption": "--trustedrouter-api-key <key>",
+      "cliDescription": "TrustedRouter.com API key"
     }
   ],
   "contracts": {

--- a/extensions/openrouter/provider-catalog.ts
+++ b/extensions/openrouter/provider-catalog.ts
@@ -1,8 +1,10 @@
 import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
 
 export const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+export const TRUSTEDROUTER_BASE_URL = "https://api.quillrouter.com/v1";
 const OPENROUTER_LEGACY_BASE_URL = "https://openrouter.ai/v1";
 const OPENROUTER_DEFAULT_MODEL_ID = "openrouter/auto";
+const TRUSTEDROUTER_DEFAULT_MODEL_ID = "trustedrouter/auto";
 const OPENROUTER_DEFAULT_CONTEXT_WINDOW = 200000;
 const OPENROUTER_DEFAULT_MAX_TOKENS = 8192;
 const OPENROUTER_DEFAULT_COST = {
@@ -38,6 +40,14 @@ export function normalizeOpenRouterBaseUrl(baseUrl: string | undefined): string 
     return OPENROUTER_BASE_URL;
   }
   return undefined;
+}
+
+export function normalizeTrustedRouterBaseUrl(baseUrl: string | undefined): string | undefined {
+  const normalized = normalizeBaseUrl(baseUrl);
+  if (!normalized) {
+    return undefined;
+  }
+  return normalized === TRUSTEDROUTER_BASE_URL ? TRUSTEDROUTER_BASE_URL : undefined;
 }
 
 export function isOpenRouterProxyReasoningUnsupportedModel(modelId: string | undefined): boolean {
@@ -82,6 +92,24 @@ export function buildOpenrouterProvider(): ModelProviderConfig {
         cost: OPENROUTER_KIMI_K2_5_COST,
         contextWindow: 262144,
         maxTokens: 262144,
+      },
+    ],
+  };
+}
+
+export function buildTrustedRouterProvider(): ModelProviderConfig {
+  return {
+    baseUrl: TRUSTEDROUTER_BASE_URL,
+    api: "openai-completions",
+    models: [
+      {
+        id: TRUSTEDROUTER_DEFAULT_MODEL_ID,
+        name: "TrustedRouter Auto",
+        reasoning: false,
+        input: ["text"],
+        cost: OPENROUTER_DEFAULT_COST,
+        contextWindow: OPENROUTER_DEFAULT_CONTEXT_WINDOW,
+        maxTokens: OPENROUTER_DEFAULT_MAX_TOKENS,
       },
     ],
   };

--- a/extensions/openrouter/provider-contract-api.ts
+++ b/extensions/openrouter/provider-contract-api.ts
@@ -25,3 +25,30 @@ export function createOpenrouterProvider(): ProviderPlugin {
     ],
   };
 }
+
+export function createTrustedRouterProvider(): ProviderPlugin {
+  return {
+    id: "trustedrouter",
+    label: "TrustedRouter.com",
+    docsPath: "/providers/trustedrouter",
+    envVars: ["TRUSTEDROUTER_API_KEY"],
+    auth: [
+      {
+        id: "api-key",
+        kind: "api_key",
+        label: "TrustedRouter.com API key",
+        hint: "E2EE OpenRouter-compatible API key",
+        run: async () => ({ profiles: [] }),
+        wizard: {
+          choiceId: "trustedrouter-api-key",
+          choiceLabel: "TrustedRouter.com API key",
+          choiceHint: "End-to-end encrypted OpenRouter-compatible router",
+          groupId: "openrouter",
+          groupLabel: "OpenRouter-compatible routers",
+          groupHint: "API key",
+          onboardingScopes: ["text-inference"],
+        },
+      },
+    ],
+  };
+}


### PR DESCRIPTION
## Summary
- add TrustedRouter.com as a separate OpenRouter-compatible provider option
- wire onboarding, auth metadata, provider catalog, docs, and provider contract metadata
- add focused tests for TrustedRouter catalog and onboarding behavior

## Verification
- `jq . extensions/openrouter/openclaw.plugin.json`
- `node --check` on the touched TypeScript files

Full project tests were not run because this change was prepared from selected files rather than a complete repository checkout.