### PR TITLE
plugins: add Composio web search provider

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -323,6 +323,10 @@
       - any-glob-to-any-file:
           - "extensions/cerebras/**"
           - "docs/providers/cerebras.md"
+"extensions: composio":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "extensions/composio/**"
 "extensions: deepseek":
   - changed-files:
       - any-glob-to-any-file:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Agents: clarify that fixes should default to clean bounded refactors, lean internals, and explicit plugin SDK/API deprecation paths.
+- Plugins/Composio: add a bundled Composio web search provider for the standard `web_search` tool.
+- Dependencies: update `@openclaw/proxyline` to 0.3.3.
+- Dependencies: update Pi packages to 0.75.1 and raise the minimum supported Node.js 22 line to 22.19.
+- Docker/Podman: add `OPENCLAW_IMAGE_APT_PACKAGES` as the runtime-neutral image build arg for extra apt packages while keeping `OPENCLAW_DOCKER_APT_PACKAGES` as a legacy fallback. (#62431) Thanks @urtabajev.
+- Gateway/ACPX: attribute startup probe, config, runtime, and resource-count costs in restart traces without changing readiness behavior. (#83300) Thanks @samzong.
+- Gateway: overlap startup logging and plugin-service startup with channel sidecars to reduce restart ready latency while preserving `/readyz` sidecar gating. (#83301) Thanks @samzong.
+- Plugins/admin-http-rpc: allow trusted admin HTTP RPC clients to start and wait for web QR login flows. (#83259) Thanks @liorb-mountapps.
+- Mac app: redesign Settings pages with consistent card layouts, cached navigation, cleaner permissions/voice/skills/cron/exec/debug panes, and steadier spacing around the native sidebar.
+- Skills: rename the repo-local Codex closeout review skill and helper to `autoreview` while preserving the Codex-first fallback behavior.
 - Skills: add a meme-maker skill for curated template search, local SVG/PNG rendering, Imgflip hosted rendering, and Know Your Meme provenance links.
 - Agents/tools: shorten built-in tool descriptions and schema hints across media, messaging, sessions, cron, Gateway, web, image/PDF, TTS, nodes, and plan tools while preserving routing guardrails.
 - Skills: add node inspector debugging, fused diagram generation, and throwaway spike workflow skills.

--- a/extensions/composio/index.ts
+++ b/extensions/composio/index.ts
@@ -1,0 +1,11 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { createComposioWebSearchProvider } from "./src/composio-search-provider.js";
+
+export default definePluginEntry({
+  id: "composio",
+  name: "Composio Plugin",
+  description: "Bundled Composio web search plugin",
+  register(api) {
+    api.registerWebSearchProvider(createComposioWebSearchProvider());
+  },
+});

--- a/extensions/composio/openclaw.plugin.json
+++ b/extensions/composio/openclaw.plugin.json
@@ -1,0 +1,38 @@
+{
+  "id": "composio",
+  "activation": {
+    "onStartup": false
+  },
+  "providerAuthEnvVars": {
+    "composio": ["COMPOSIO_API_KEY"]
+  },
+  "uiHints": {
+    "webSearch.apiKey": {
+      "label": "Composio API Key",
+      "help": "Composio API key for web search (fallback: COMPOSIO_API_KEY env var).",
+      "sensitive": true,
+      "placeholder": "ak_..."
+    }
+  },
+  "contracts": {
+    "webSearchProviders": ["composio"]
+  },
+  "configContracts": {
+    "compatibilityRuntimePaths": ["tools.web.search.composioApiKey"]
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "webSearch": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "apiKey": {
+            "type": ["string", "object"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/extensions/composio/package.json
+++ b/extensions/composio/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/composio-plugin",
+  "version": "2026.5.18",
+  "private": true,
+  "description": "OpenClaw Composio plugin",
+  "type": "module",
+  "devDependencies": {
+    "@openclaw/plugin-sdk": "workspace:*"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/composio/src/composio-client.test.ts
+++ b/extensions/composio/src/composio-client.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { __testing } from "./composio-client.js";
+
+describe("composio client", () => {
+  it("normalizes Composio organic results into OpenClaw web search results", () => {
+    expect(
+      __testing.normalizeComposioSearchResult({
+        title: "OpenClaw",
+        link: "https://openclaw.ai/docs",
+        snippet: "Agent runtime",
+      }),
+    ).toEqual({
+      title: "OpenClaw",
+      url: "https://openclaw.ai/docs",
+      snippet: "Agent runtime",
+      siteName: "openclaw.ai",
+    });
+  });
+
+  it("bounds result counts", () => {
+    expect(__testing.resolveSearchCount(undefined)).toBe(5);
+    expect(__testing.resolveSearchCount(0)).toBe(1);
+    expect(__testing.resolveSearchCount(50)).toBe(10);
+  });
+
+  it("surfaces explicit Composio failures", () => {
+    expect(() =>
+      __testing.readComposioResults({ successful: false, error: "quota exceeded" }),
+    ).toThrow("Composio Search failed: quota exceeded");
+  });
+});

--- a/extensions/composio/src/composio-client.ts
+++ b/extensions/composio/src/composio-client.ts
@@ -1,0 +1,141 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  DEFAULT_CACHE_TTL_MINUTES,
+  normalizeCacheKey,
+  postTrustedWebToolsJson,
+  readCache,
+  resolveCacheTtlMs,
+  resolveSiteName,
+  writeCache,
+} from "openclaw/plugin-sdk/provider-web-search";
+import { wrapWebContent } from "openclaw/plugin-sdk/security-runtime";
+import { resolveComposioApiKey } from "./config.js";
+
+const COMPOSIO_SEARCH_ENDPOINT =
+  "https://backend.composio.dev/api/v3/tools/execute/COMPOSIO_SEARCH_SEARCH";
+const DEFAULT_SEARCH_COUNT = 5;
+const MAX_SEARCH_COUNT = 10;
+
+type ComposioSearchResult = {
+  title?: string;
+  link?: string;
+  snippet?: string;
+};
+
+type ComposioSearchResponse = {
+  data?: {
+    results?: {
+      organic_results?: ComposioSearchResult[];
+    };
+  };
+  error?: string | null;
+  successful?: boolean;
+};
+
+const SEARCH_CACHE = new Map<
+  string,
+  { value: Record<string, unknown>; expiresAt: number; insertedAt: number }
+>();
+
+function resolveSearchCount(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value)
+    ? Math.max(1, Math.min(MAX_SEARCH_COUNT, Math.floor(value)))
+    : DEFAULT_SEARCH_COUNT;
+}
+
+function normalizeComposioSearchResult(result: ComposioSearchResult): {
+  title: string;
+  url: string;
+  snippet: string;
+  siteName?: string;
+} {
+  const url = result.link ?? "";
+  return {
+    title: result.title ?? "",
+    url,
+    snippet: result.snippet ?? "",
+    siteName: resolveSiteName(url) || undefined,
+  };
+}
+
+function readComposioResults(payload: ComposioSearchResponse): ComposioSearchResult[] {
+  if (payload.successful === false) {
+    throw new Error(`Composio Search failed: ${payload.error || "unknown error"}`);
+  }
+  const results = payload.data?.results?.organic_results;
+  return Array.isArray(results) ? results : [];
+}
+
+export async function runComposioSearch(params: {
+  cfg?: OpenClawConfig;
+  query: string;
+  count?: number;
+}): Promise<Record<string, unknown>> {
+  const apiKey = resolveComposioApiKey(params.cfg);
+  if (!apiKey) {
+    throw new Error(
+      "web_search (composio) needs a Composio API key. Set COMPOSIO_API_KEY in the Gateway environment, or configure plugins.entries.composio.config.webSearch.apiKey.",
+    );
+  }
+
+  const count = resolveSearchCount(params.count);
+  const cacheKey = normalizeCacheKey(
+    JSON.stringify({ type: "composio-search", q: params.query, count }),
+  );
+  const cached = readCache(SEARCH_CACHE, cacheKey);
+  if (cached) {
+    return { ...cached.value, cached: true };
+  }
+
+  const start = Date.now();
+  const response = await postTrustedWebToolsJson(
+    {
+      url: COMPOSIO_SEARCH_ENDPOINT,
+      timeoutSeconds: 30,
+      apiKey,
+      body: {
+        arguments: {
+          query: params.query,
+          num_results: count,
+        },
+      },
+      errorLabel: "Composio Search",
+      extraHeaders: { "x-api-key": apiKey },
+    },
+    async (res) => (await res.json()) as Record<string, unknown>,
+  );
+  const results = readComposioResults(response as ComposioSearchResponse).map(
+    normalizeComposioSearchResult,
+  );
+  const payload: Record<string, unknown> = {
+    query: params.query,
+    provider: "composio",
+    count: results.length,
+    tookMs: Date.now() - start,
+    externalContent: {
+      untrusted: true,
+      source: "web_search",
+      provider: "composio",
+      wrapped: true,
+    },
+    results: results.map((result) => ({
+      title: result.title ? wrapWebContent(result.title, "web_search") : "",
+      url: result.url,
+      snippet: result.snippet ? wrapWebContent(result.snippet, "web_search") : "",
+      siteName: result.siteName,
+    })),
+  };
+  writeCache(
+    SEARCH_CACHE,
+    cacheKey,
+    payload,
+    resolveCacheTtlMs(undefined, DEFAULT_CACHE_TTL_MINUTES),
+  );
+  return payload;
+}
+
+export const __testing = {
+  normalizeComposioSearchResult,
+  readComposioResults,
+  resolveSearchCount,
+};

--- a/extensions/composio/src/composio-search-provider.test.ts
+++ b/extensions/composio/src/composio-search-provider.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { createComposioWebSearchProvider } from "./composio-search-provider.js";
+
+describe("composio web search provider", () => {
+  it("registers setup-visible credential metadata", () => {
+    const provider = createComposioWebSearchProvider();
+    const config = {};
+    const applied = provider.applySelectionConfig?.(config as never) as {
+      plugins?: { entries?: { composio?: { enabled?: boolean } } };
+    };
+
+    expect(provider.id).toBe("composio");
+    expect(provider.credentialPath).toBe("plugins.entries.composio.config.webSearch.apiKey");
+    expect(provider.envVars).toEqual(["COMPOSIO_API_KEY"]);
+    expect(provider.inactiveSecretPaths).toContain("tools.web.search.composioApiKey");
+    expect(applied.plugins?.entries?.composio?.enabled).toBe(true);
+  });
+
+  it("stores configured credentials in plugin webSearch config", () => {
+    const provider = createComposioWebSearchProvider();
+    const config = {};
+
+    provider.setConfiguredCredentialValue?.(config as never, "ak_test");
+
+    expect(provider.getConfiguredCredentialValue?.(config as never)).toBe("ak_test");
+    expect(config).toEqual({
+      plugins: {
+        entries: {
+          composio: {
+            enabled: true,
+            config: {
+              webSearch: {
+                apiKey: "ak_test",
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+});

--- a/extensions/composio/src/composio-search-provider.ts
+++ b/extensions/composio/src/composio-search-provider.ts
@@ -1,0 +1,59 @@
+import {
+  createWebSearchProviderContractFields,
+  type WebSearchProviderPlugin,
+} from "openclaw/plugin-sdk/provider-web-search-contract";
+import { runComposioSearch } from "./composio-client.js";
+import { resolveConfiguredComposioApiKey, setComposioApiKey } from "./config.js";
+
+const COMPOSIO_CREDENTIAL_PATH = "plugins.entries.composio.config.webSearch.apiKey";
+
+const ComposioSearchSchema = {
+  type: "object",
+  properties: {
+    query: { type: "string", description: "Search query string." },
+    count: {
+      type: "number",
+      description: "Number of results to return (1-10).",
+      minimum: 1,
+      maximum: 10,
+    },
+  },
+  additionalProperties: false,
+} satisfies Record<string, unknown>;
+
+export function createComposioWebSearchProvider(): WebSearchProviderPlugin {
+  return {
+    id: "composio",
+    label: "Composio Search",
+    hint: "Structured results via Composio Search",
+    onboardingScopes: ["text-inference"],
+    credentialLabel: "Composio API key",
+    envVars: ["COMPOSIO_API_KEY"],
+    placeholder: "ak_...",
+    signupUrl: "https://app.composio.dev/",
+    docsUrl: "https://docs.composio.dev",
+    autoDetectOrder: 80,
+    credentialPath: COMPOSIO_CREDENTIAL_PATH,
+    ...createWebSearchProviderContractFields({
+      credentialPath: COMPOSIO_CREDENTIAL_PATH,
+      searchCredential: { type: "scoped", scopeId: "composio" },
+      configuredCredential: { pluginId: "composio" },
+      selectionPluginId: "composio",
+    }),
+    inactiveSecretPaths: ["tools.web.search.composioApiKey"],
+    getConfiguredCredentialValue: resolveConfiguredComposioApiKey,
+    setConfiguredCredentialValue: setComposioApiKey,
+    createTool: (ctx) => ({
+      description:
+        "Search the web using Composio Search. Returns titles, URLs, and snippets for fast research.",
+      parameters: ComposioSearchSchema,
+      execute: async (args) => {
+        return await runComposioSearch({
+          cfg: ctx.config,
+          query: typeof args.query === "string" ? args.query : "",
+          count: typeof args.count === "number" ? args.count : undefined,
+        });
+      },
+    }),
+  };
+}

--- a/extensions/composio/src/config.ts
+++ b/extensions/composio/src/config.ts
@@ -1,0 +1,25 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import {
+  resolveProviderWebSearchPluginConfig,
+  resolveWebSearchProviderCredential,
+  setProviderWebSearchPluginConfigValue,
+} from "openclaw/plugin-sdk/provider-web-search";
+
+const COMPOSIO_CREDENTIAL_PATH = "plugins.entries.composio.config.webSearch.apiKey";
+
+export function resolveComposioApiKey(config?: OpenClawConfig): string | undefined {
+  return resolveWebSearchProviderCredential({
+    config,
+    providerId: "composio",
+    envVars: ["COMPOSIO_API_KEY"],
+    configPaths: [COMPOSIO_CREDENTIAL_PATH, "tools.web.search.composioApiKey"],
+  });
+}
+
+export function setComposioApiKey(config: OpenClawConfig, value: unknown): void {
+  setProviderWebSearchPluginConfigValue(config, "composio", "apiKey", value);
+}
+
+export function resolveConfiguredComposioApiKey(config?: OpenClawConfig): unknown {
+  return resolveProviderWebSearchPluginConfig(config, "composio")?.apiKey;
+}

--- a/extensions/composio/web-search-contract-api.ts
+++ b/extensions/composio/web-search-contract-api.ts
@@ -1,0 +1,6 @@
+import type { WebSearchProviderPlugin } from "openclaw/plugin-sdk/provider-web-search-contract";
+import { createComposioWebSearchProvider } from "./src/composio-search-provider.js";
+
+export function createComposioWebSearchContractProvider(): WebSearchProviderPlugin {
+  return createComposioWebSearchProvider();
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -510,6 +510,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/composio:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/copilot-proxy:
     devDependencies:
       '@openclaw/plugin-sdk':

--- a/src/plugin-sdk/test-helpers/plugin-registration-contract-cases.ts
+++ b/src/plugin-sdk/test-helpers/plugin-registration-contract-cases.ts
@@ -14,6 +14,10 @@ export const pluginRegistrationContractCases = {
     pluginId: "brave",
     webSearchProviderIds: ["brave"],
   },
+  composio: {
+    pluginId: "composio",
+    webSearchProviderIds: ["composio"],
+  },
   comfy: {
     pluginId: "comfy",
     providerIds: ["comfy"],

--- a/src/plugins/contracts/plugin-registration.composio.contract.test.ts
+++ b/src/plugins/contracts/plugin-registration.composio.contract.test.ts
@@ -1,0 +1,4 @@
+import { pluginRegistrationContractCases } from "openclaw/plugin-sdk/plugin-test-contracts";
+import { describePluginRegistrationContract } from "openclaw/plugin-sdk/plugin-test-contracts";
+
+describePluginRegistrationContract(pluginRegistrationContractCases.composio);

--- a/src/plugins/contracts/providers.contract.test.ts
+++ b/src/plugins/contracts/providers.contract.test.ts
@@ -16,6 +16,7 @@ for (const providerId of [
 
 for (const providerId of [
   "brave",
+  "composio",
   "duckduckgo",
   "exa",
   "firecrawl",


### PR DESCRIPTION
## Summary
- add a bundled `composio` extension that registers a standard `web_search` provider
- support `COMPOSIO_API_KEY` and plugin-scoped `plugins.entries.composio.config.webSearch.apiKey`
- add provider registration/contract coverage plus labeler and changelog entries

## Tests
- `pnpm exec vitest run extensions/composio/src/composio-client.test.ts extensions/composio/src/composio-search-provider.test.ts src/plugins/contracts/plugin-registration.composio.contract.test.ts src/plugins/contracts/providers.contract.test.ts`
