### PR TITLE
providers: add strict Responses compatibility flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Agents: clarify that fixes should default to clean bounded refactors, lean internals, and explicit plugin SDK/API deprecation paths.
+- Providers/OpenAI Responses: add compatibility flags for strict proxy backends that require top-level `instructions` and reject `max_output_tokens`.
+- Dependencies: update `@openclaw/proxyline` to 0.3.3.
+- Dependencies: update Pi packages to 0.75.1 and raise the minimum supported Node.js 22 line to 22.19.
+- Docker/Podman: add `OPENCLAW_IMAGE_APT_PACKAGES` as the runtime-neutral image build arg for extra apt packages while keeping `OPENCLAW_DOCKER_APT_PACKAGES` as a legacy fallback. (#62431) Thanks @urtabajev.
+- Gateway/ACPX: attribute startup probe, config, runtime, and resource-count costs in restart traces without changing readiness behavior. (#83300) Thanks @samzong.
+- Gateway: overlap startup logging and plugin-service startup with channel sidecars to reduce restart ready latency while preserving `/readyz` sidecar gating. (#83301) Thanks @samzong.
+- Plugins/admin-http-rpc: allow trusted admin HTTP RPC clients to start and wait for web QR login flows. (#83259) Thanks @liorb-mountapps.
+- Mac app: redesign Settings pages with consistent card layouts, cached navigation, cleaner permissions/voice/skills/cron/exec/debug panes, and steadier spacing around the native sidebar.
+- Skills: rename the repo-local Codex closeout review skill and helper to `autoreview` while preserving the Codex-first fallback behavior.
 - Skills: add a meme-maker skill for curated template search, local SVG/PNG rendering, Imgflip hosted rendering, and Know Your Meme provenance links.
 - Agents/tools: shorten built-in tool descriptions and schema hints across media, messaging, sessions, cron, Gateway, web, image/PDF, TTS, nodes, and plan tools while preserving routing guardrails.
 - Skills: add node inspector debugging, fused diagram generation, and throwaway spike workflow skills.

--- a/src/agents/openai-responses-payload-policy.test.ts
+++ b/src/agents/openai-responses-payload-policy.test.ts
@@ -84,6 +84,27 @@ describe("openai responses payload policy", () => {
     expect(payload).not.toHaveProperty("prompt_cache_retention");
   });
 
+  it("strips max_output_tokens when responses compat declares it unsupported", () => {
+    const policy = resolveOpenAIResponsesPayloadPolicy(
+      {
+        api: "openai-responses",
+        provider: "openai-compatible",
+        baseUrl: "https://proxy.example.com/v1",
+        compat: { supportsMaxOutputTokens: false },
+      },
+      {
+        storeMode: "provider-policy",
+      },
+    );
+    const payload = {
+      max_output_tokens: 1024,
+    } satisfies Record<string, unknown>;
+
+    applyOpenAIResponsesPayloadPolicy(payload, policy);
+
+    expect(payload).not.toHaveProperty("max_output_tokens");
+  });
+
   it("keeps disabled reasoning payloads on native OpenAI responses models that support none", () => {
     const payload = {
       reasoning: {

--- a/src/agents/openai-responses-payload-policy.ts
+++ b/src/agents/openai-responses-payload-policy.ts
@@ -46,6 +46,7 @@ type OpenAIResponsesPayloadPolicy = {
   compactThreshold: number;
   explicitStore: boolean | undefined;
   shouldStripDisabledReasoningPayload: boolean;
+  shouldStripMaxOutputTokens: boolean;
   shouldStripPromptCache: boolean;
   shouldStripStore: boolean;
   useServerCompaction: boolean;
@@ -208,7 +209,7 @@ function isOpenAIResponsesApi(api: string | undefined): boolean {
 
 function readCompatPayloadBoolean(
   compat: unknown,
-  key: "supportsPromptCacheKey" | "supportsStore",
+  key: "supportsMaxOutputTokens" | "supportsPromptCacheKey" | "supportsStore",
 ): boolean | undefined {
   if (!compat || typeof compat !== "object") {
     return undefined;
@@ -344,6 +345,8 @@ export function resolveOpenAIResponsesPayloadPolicy(
       resolveOpenAIResponsesCompactThreshold(model),
     explicitStore,
     shouldStripDisabledReasoningPayload,
+    shouldStripMaxOutputTokens:
+      isResponsesApi && readCompatPayloadBoolean(model.compat, "supportsMaxOutputTokens") === false,
     shouldStripPromptCache:
       options.enablePromptCacheStripping === true && capabilities.shouldStripResponsesPromptCache,
     shouldStripStore:
@@ -373,6 +376,9 @@ export function applyOpenAIResponsesPayloadPolicy(
   if (policy.shouldStripPromptCache) {
     delete payloadObj.prompt_cache_key;
     delete payloadObj.prompt_cache_retention;
+  }
+  if (policy.shouldStripMaxOutputTokens) {
+    delete payloadObj.max_output_tokens;
   }
   if (policy.useServerCompaction && payloadObj.context_management === undefined) {
     payloadObj.context_management = [

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1938,6 +1938,45 @@ describe("openai transport stream", () => {
     expect(params).not.toHaveProperty("top_p");
   });
 
+  it("uses top-level instructions for strict Responses-compatible providers", () => {
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "strict-responses",
+        name: "Strict Responses",
+        api: "openai-responses",
+        provider: "openai-compatible",
+        baseUrl: "https://proxy.example.com/v1",
+        compat: {
+          requiresResponsesInstructions: true,
+          supportsMaxOutputTokens: false,
+        },
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-responses">,
+      {
+        systemPrompt: `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic suffix`,
+        messages: [{ role: "user", content: "Hello", timestamp: 1 }],
+        tools: [],
+      } as never,
+      {
+        maxTokens: 1024,
+      },
+    ) as Record<string, unknown> & {
+      input?: Array<{ role?: string }>;
+      instructions?: string;
+    };
+
+    expect(params.instructions).toBe("Stable prefix\nDynamic suffix");
+    expect(params.input?.map((item) => item.role)).toEqual(["user"]);
+    expect(
+      params.input?.filter((item) => item.role === "system" || item.role === "developer"),
+    ).toStrictEqual([]);
+    expect(params).not.toHaveProperty("max_output_tokens");
+  });
+
   it("sanitizes Codex responses params after payload hooks mutate them without stripping cache identity", () => {
     const payload = {
       model: "gpt-5.4",

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -1698,6 +1698,7 @@ export function buildOpenAIResponsesParams(
   const isCodexResponses = isOpenAICodexResponsesModel(model);
   const isNativeCodexResponses = usesNativeOpenAICodexResponsesBackend(model);
   const compat = getCompat(model as OpenAIModeModel);
+  const usesTopLevelInstructions = isCodexResponses || compat.requiresResponsesInstructions;
   const supportsDeveloperRole =
     typeof compat.supportsDeveloperRole === "boolean" ? compat.supportsDeveloperRole : undefined;
   const messages = convertResponsesMessages(
@@ -1705,7 +1706,7 @@ export function buildOpenAIResponsesParams(
     context,
     new Set(["openai", "openai-codex", "opencode", "azure-openai-responses", "github-copilot"]),
     {
-      includeSystemPrompt: !isCodexResponses,
+      includeSystemPrompt: !usesTopLevelInstructions,
       supportsDeveloperRole,
       replayReasoningItems: true,
       replayResponsesItemIds: !isNativeCodexResponses,
@@ -1724,7 +1725,9 @@ export function buildOpenAIResponsesParams(
     stream: true,
     prompt_cache_key: cacheRetention === "none" ? undefined : options?.sessionId,
     prompt_cache_retention: getPromptCacheRetention(model.baseUrl, cacheRetention),
-    ...(isCodexResponses ? { instructions: buildOpenAICodexResponsesInstructions(context) } : {}),
+    ...(usesTopLevelInstructions
+      ? { instructions: buildOpenAICodexResponsesInstructions(context) }
+      : {}),
     ...(metadata ? { metadata } : {}),
   };
   const effectiveMaxTokens = options?.maxTokens || model.maxTokens;
@@ -2541,6 +2544,7 @@ function getCompat(model: OpenAIModeModel): {
   vercelGatewayRouting: Record<string, unknown>;
   supportsStrictMode: boolean;
   supportsPromptCacheKey: boolean;
+  requiresResponsesInstructions: boolean;
   requiresStringContent: boolean;
   strictMessageKeys: boolean;
   visibleReasoningDetailTypes: string[];
@@ -2572,6 +2576,7 @@ function getCompat(model: OpenAIModeModel): {
       detected.vercelGatewayRouting,
     supportsStrictMode: compat.supportsStrictMode ?? detected.supportsStrictMode,
     supportsPromptCacheKey: compat.supportsPromptCacheKey === true,
+    requiresResponsesInstructions: compat.requiresResponsesInstructions === true,
     requiresStringContent: compat.requiresStringContent ?? false,
     strictMessageKeys: compat.strictMessageKeys === true,
     visibleReasoningDetailTypes:

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -65,6 +65,8 @@ export type ModelCompatConfig = SupportedOpenAICompatFields &
     visibleReasoningDetailTypes?: string[];
     supportsTools?: boolean;
     supportsPromptCacheKey?: boolean;
+    supportsMaxOutputTokens?: boolean;
+    requiresResponsesInstructions?: boolean;
     requiresStringContent?: boolean;
     strictMessageKeys?: boolean;
     toolSchemaProfile?: string;

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -193,6 +193,8 @@ const ModelCompatSchema = z
     supportsUsageInStreaming: z.boolean().optional(),
     supportsTools: z.boolean().optional(),
     supportsStrictMode: z.boolean().optional(),
+    supportsMaxOutputTokens: z.boolean().optional(),
+    requiresResponsesInstructions: z.boolean().optional(),
     requiresStringContent: z.boolean().optional(),
     strictMessageKeys: z.boolean().optional(),
     visibleReasoningDetailTypes: z.array(z.string().min(1)).optional(),


### PR DESCRIPTION
## Summary
- add model compat flags for strict OpenAI Responses-compatible providers
- allow configs to move system prompts to top-level `instructions` without using the Codex Responses API
- allow configs to strip `max_output_tokens` for backends that reject that field

## Tests
- `pnpm exec vitest run src/agents/openai-responses-payload-policy.test.ts src/agents/openai-transport-stream.test.ts`
