### PR TITLE
fix(models): avoid persisting prompt-visible provider secrets

### DIFF
--- a/src/agents/models-config.applies-config-env-vars.test.ts
+++ b/src/agents/models-config.applies-config-env-vars.test.ts
@@ -246,6 +246,87 @@ describe("models-config", () => {
     ]);
   });
 
+  it("strips new plaintext provider auth from persisted models.json while preserving markers", async () => {
+    const plan = await planOpenClawModelsJsonWithDeps(
+      {
+        cfg: {
+          models: {
+            mode: "merge",
+            providers: {
+              custom: {
+                baseUrl: "https://config.example/v1",
+                api: "openai-completions",
+                apiKey: "sk-config-plaintext", // pragma: allowlist secret
+                headers: {
+                  Authorization: "Bearer sk-config-header", // pragma: allowlist secret
+                  "X-Api-Key": "sk-config-header-key", // pragma: allowlist secret
+                  "X-Tenant": "tenant-a",
+                },
+                models: [
+                  {
+                    id: "config-model",
+                    name: "Config model",
+                    input: ["text"],
+                    reasoning: false,
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 128000,
+                    maxTokens: 4096,
+                  },
+                ],
+              },
+              openai: {
+                baseUrl: "https://api.openai.com/v1",
+                api: "openai-responses",
+                apiKey: "OPENAI_API_KEY", // pragma: allowlist secret
+                headers: {
+                  Authorization: "secretref-env:OPENAI_PROXY_TOKEN",
+                },
+                models: [],
+              },
+            },
+          },
+        },
+        agentDir: "/tmp/openclaw-models-config-env-vars-test",
+        env: {},
+        existingRaw: "",
+        existingParsed: {
+          providers: {
+            legacy: {
+              baseUrl: "https://legacy.example/v1",
+              api: "openai-completions",
+              apiKey: "sk-existing-plaintext", // pragma: allowlist secret
+              headers: {
+                Authorization: "Bearer sk-existing-header", // pragma: allowlist secret
+              },
+              models: [],
+            },
+          },
+        },
+      },
+      {
+        resolveImplicitProviders: async () => ({}),
+      },
+    );
+
+    expect(plan.action).toBe("write");
+    if (plan.action !== "write") {
+      throw new Error("Expected models.json write plan");
+    }
+    const parsed = JSON.parse(plan.contents) as {
+      providers?: Record<string, { apiKey?: string; headers?: Record<string, string> }>;
+    };
+    expect(parsed.providers?.custom?.apiKey).toBeUndefined();
+    expect(parsed.providers?.custom?.headers).toEqual({ "X-Tenant": "tenant-a" });
+    expect(parsed.providers?.openai?.apiKey).toBe("OPENAI_API_KEY"); // pragma: allowlist secret
+    expect(parsed.providers?.openai?.headers?.Authorization).toBe(
+      "secretref-env:OPENAI_PROXY_TOKEN",
+    );
+    expect(parsed.providers?.legacy?.apiKey).toBe("sk-existing-plaintext"); // pragma: allowlist secret
+    expect(parsed.providers?.legacy?.headers?.Authorization).toBe(
+      "Bearer sk-existing-header",
+    ); // pragma: allowlist secret
+  });
+
   it("uses config env.vars entries for implicit provider discovery without mutating process.env", async () => {
     await withTempEnv(["OPENROUTER_API_KEY", TEST_ENV_VAR], async () => {
       unsetEnv(["OPENROUTER_API_KEY", TEST_ENV_VAR]);

--- a/src/agents/models-config.applies-config-env-vars.test.ts
+++ b/src/agents/models-config.applies-config-env-vars.test.ts
@@ -260,6 +260,8 @@ describe("models-config", () => {
                 headers: {
                   Authorization: "Bearer sk-config-header", // pragma: allowlist secret
                   "X-Api-Key": "sk-config-header-key", // pragma: allowlist secret
+                  "X-Auth-Token": "sk-config-auth-token", // pragma: allowlist secret
+                  "X-Secret-Key": "sk-config-secret-key", // pragma: allowlist secret
                   "X-Tenant": "tenant-a",
                 },
                 models: [
@@ -297,6 +299,7 @@ describe("models-config", () => {
               apiKey: "sk-existing-plaintext", // pragma: allowlist secret
               headers: {
                 Authorization: "Bearer sk-existing-header", // pragma: allowlist secret
+                "X-Secret-Key": "sk-existing-secret-header", // pragma: allowlist secret
               },
               models: [],
             },
@@ -322,9 +325,10 @@ describe("models-config", () => {
       "secretref-env:OPENAI_PROXY_TOKEN",
     );
     expect(parsed.providers?.legacy?.apiKey).toBe("sk-existing-plaintext"); // pragma: allowlist secret
-    expect(parsed.providers?.legacy?.headers?.Authorization).toBe(
-      "Bearer sk-existing-header",
-    ); // pragma: allowlist secret
+    expect(parsed.providers?.legacy?.headers).toEqual({
+      Authorization: "Bearer sk-existing-header", // pragma: allowlist secret
+      "X-Secret-Key": "sk-existing-secret-header", // pragma: allowlist secret
+    });
   });
 
   it("uses config env.vars entries for implicit provider discovery without mutating process.env", async () => {

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -111,20 +111,37 @@ type ExistingAuthSurfaces = {
   sensitiveHeaders: Map<string, string>;
 };
 
+const SENSITIVE_PROVIDER_HEADER_NAMES = new Set([
+  "authorization",
+  "proxy-authorization",
+  "x-api-key",
+  "api-key",
+  "apikey",
+  "x-auth-token",
+  "auth-token",
+  "x-access-token",
+  "access-token",
+  "x-secret-key",
+  "secret-key",
+]);
+const SENSITIVE_PROVIDER_HEADER_NAME_FRAGMENTS = [
+  "api-key",
+  "apikey",
+  "token",
+  "secret",
+  "password",
+  "credential",
+];
+
 function shouldPersistProviderApiKey(value: unknown): value is string {
   return typeof value === "string" && isNonSecretApiKeyMarker(value);
 }
 
 function isSensitiveProviderHeaderName(headerName: string): boolean {
   const normalized = headerName.trim().toLowerCase();
-  return (
-    normalized === "authorization" ||
-    normalized === "proxy-authorization" ||
-    normalized === "api-key" ||
-    normalized === "x-api-key" ||
-    normalized === "x-goog-api-key" ||
-    normalized === "anthropic-api-key" ||
-    normalized.endsWith("-api-key")
+  return normalized !== "" && (
+    SENSITIVE_PROVIDER_HEADER_NAMES.has(normalized) ||
+    SENSITIVE_PROVIDER_HEADER_NAME_FRAGMENTS.some((fragment) => normalized.includes(fragment))
   );
 }
 

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -133,8 +133,14 @@ const SENSITIVE_PROVIDER_HEADER_NAME_FRAGMENTS = [
   "credential",
 ];
 
-function shouldPersistProviderApiKey(value: unknown): value is string {
-  return typeof value === "string" && isNonSecretApiKeyMarker(value);
+function shouldPersistProviderApiKey(
+  value: unknown,
+  opts: { sourceManaged?: boolean } = {},
+): value is string {
+  return (
+    typeof value === "string" &&
+    (isNonSecretApiKeyMarker(value) || (opts.sourceManaged === true && value.trim() !== ""))
+  );
 }
 
 function isSensitiveProviderHeaderName(headerName: string): boolean {
@@ -178,7 +184,10 @@ function collectExistingAuthSurfaces(existingParsed: unknown): Map<string, Exist
 
 function stripPromptVisibleProviderSecrets(
   providers: Record<string, ProviderConfig>,
-  opts: { existingAuthSurfaces?: ReadonlyMap<string, ExistingAuthSurfaces> } = {},
+  opts: {
+    existingAuthSurfaces?: ReadonlyMap<string, ExistingAuthSurfaces>;
+    secretRefManagedProviders?: ReadonlySet<string>;
+  } = {},
 ): Record<string, ProviderConfig> {
   let nextProviders: Record<string, ProviderConfig> | undefined;
 
@@ -191,7 +200,9 @@ function stripPromptVisibleProviderSecrets(
     const apiKey = (provider as { apiKey?: unknown }).apiKey;
     if (
       apiKey !== undefined &&
-      !shouldPersistProviderApiKey(apiKey) &&
+      !shouldPersistProviderApiKey(apiKey, {
+        sourceManaged: opts.secretRefManagedProviders?.has(providerKey),
+      }) &&
       !(typeof apiKey === "string" && existingAuth?.apiKey === apiKey)
     ) {
       nextProvider = { ...provider };
@@ -327,6 +338,7 @@ export async function planOpenClawModelsJsonWithDeps(
   const persistedProviders = stripPromptVisibleProviderSecrets(finalProviders, {
     existingAuthSurfaces:
       mode === "merge" ? collectExistingAuthSurfaces(params.existingParsed) : undefined,
+    secretRefManagedProviders,
   });
   const nextContents = `${JSON.stringify({ providers: persistedProviders }, null, 2)}\n`;
 

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { isRecord } from "../utils.js";
+import { isNonSecretApiKeyMarker, isSecretRefHeaderValueMarker } from "./model-auth-markers.js";
 import {
   mergeProviders,
   mergeWithExistingProviderSecrets,
@@ -105,6 +106,120 @@ function resolveProvidersForMode(params: {
   });
 }
 
+type ExistingAuthSurfaces = {
+  apiKey?: string;
+  sensitiveHeaders: Map<string, string>;
+};
+
+function shouldPersistProviderApiKey(value: unknown): value is string {
+  return typeof value === "string" && isNonSecretApiKeyMarker(value);
+}
+
+function isSensitiveProviderHeaderName(headerName: string): boolean {
+  const normalized = headerName.trim().toLowerCase();
+  return (
+    normalized === "authorization" ||
+    normalized === "proxy-authorization" ||
+    normalized === "api-key" ||
+    normalized === "x-api-key" ||
+    normalized === "x-goog-api-key" ||
+    normalized === "anthropic-api-key" ||
+    normalized.endsWith("-api-key")
+  );
+}
+
+function shouldPersistSensitiveHeaderValue(value: unknown): value is string {
+  return typeof value === "string" && isSecretRefHeaderValueMarker(value);
+}
+
+function collectExistingAuthSurfaces(existingParsed: unknown): Map<string, ExistingAuthSurfaces> {
+  const existingProviders =
+    isRecord(existingParsed) && isRecord(existingParsed.providers)
+      ? (existingParsed.providers as Record<string, ExistingProviderConfig>)
+      : undefined;
+  const out = new Map<string, ExistingAuthSurfaces>();
+  for (const [providerKey, provider] of Object.entries(existingProviders ?? {})) {
+    if (!isRecord(provider)) {
+      continue;
+    }
+    const apiKey = typeof provider.apiKey === "string" ? provider.apiKey : undefined;
+    const sensitiveHeaders = new Map<string, string>();
+    const headers = isRecord(provider.headers)
+      ? (provider.headers as Record<string, unknown>)
+      : undefined;
+    for (const [headerName, headerValue] of Object.entries(headers ?? {})) {
+      if (isSensitiveProviderHeaderName(headerName) && typeof headerValue === "string") {
+        sensitiveHeaders.set(headerName.trim().toLowerCase(), headerValue);
+      }
+    }
+    if (apiKey !== undefined || sensitiveHeaders.size > 0) {
+      out.set(providerKey, { ...(apiKey !== undefined ? { apiKey } : {}), sensitiveHeaders });
+    }
+  }
+  return out;
+}
+
+function stripPromptVisibleProviderSecrets(
+  providers: Record<string, ProviderConfig>,
+  opts: { existingAuthSurfaces?: ReadonlyMap<string, ExistingAuthSurfaces> } = {},
+): Record<string, ProviderConfig> {
+  let nextProviders: Record<string, ProviderConfig> | undefined;
+
+  for (const [providerKey, provider] of Object.entries(providers)) {
+    if (!isRecord(provider)) {
+      continue;
+    }
+    let nextProvider: ProviderConfig | undefined;
+    const existingAuth = opts.existingAuthSurfaces?.get(providerKey);
+    const apiKey = (provider as { apiKey?: unknown }).apiKey;
+    if (
+      apiKey !== undefined &&
+      !shouldPersistProviderApiKey(apiKey) &&
+      !(typeof apiKey === "string" && existingAuth?.apiKey === apiKey)
+    ) {
+      nextProvider = { ...provider };
+      delete (nextProvider as { apiKey?: unknown }).apiKey;
+    }
+
+    const currentProvider = nextProvider ?? provider;
+    const headers = isRecord(currentProvider.headers)
+      ? (currentProvider.headers as Record<string, unknown>)
+      : undefined;
+    if (headers) {
+      let nextHeaders: Record<string, NonNullable<ProviderConfig["headers"]>[string]> | undefined;
+      for (const [headerName, headerValue] of Object.entries(headers)) {
+        if (
+          !isSensitiveProviderHeaderName(headerName) ||
+          shouldPersistSensitiveHeaderValue(headerValue) ||
+          (typeof headerValue === "string" &&
+            existingAuth?.sensitiveHeaders.get(headerName.trim().toLowerCase()) === headerValue)
+        ) {
+          continue;
+        }
+        nextHeaders ??= {
+          ...(headers as Record<string, NonNullable<ProviderConfig["headers"]>[string]>),
+        };
+        delete nextHeaders[headerName];
+      }
+      if (nextHeaders) {
+        nextProvider = { ...(nextProvider ?? provider) };
+        if (Object.keys(nextHeaders).length > 0) {
+          nextProvider.headers = nextHeaders;
+        } else {
+          delete (nextProvider as { headers?: unknown }).headers;
+        }
+      }
+    }
+
+    if (nextProvider) {
+      nextProviders ??= { ...providers };
+      nextProviders[providerKey] = nextProvider;
+    }
+  }
+
+  return nextProviders ?? providers;
+}
+
 export async function planOpenClawModelsJsonWithDeps(
   params: {
     cfg: OpenClawConfig;
@@ -170,10 +285,20 @@ export async function planOpenClawModelsJsonWithDeps(
     providers: normalizedProviders,
     secretRefManagedProviders,
   });
-  const normalizedMergedProviders =
-    normalizeProviderCatalogModelsForConfig(mergedProviders, {
-      manifestPlugins,
+  const normalizedPostMergeProviders =
+    normalizeProviders({
+      providers: mergedProviders,
+      agentDir,
+      env,
+      secretDefaults: cfg.secrets?.defaults,
+      sourceProviders: params.sourceConfigForSecrets?.models?.providers,
+      sourceSecretDefaults: params.sourceConfigForSecrets?.secrets?.defaults,
+      secretRefManagedProviders,
     }) ?? mergedProviders;
+  const normalizedMergedProviders =
+    normalizeProviderCatalogModelsForConfig(normalizedPostMergeProviders, {
+      manifestPlugins,
+    }) ?? normalizedPostMergeProviders;
   const secretEnforcedProviders =
     enforceSourceManagedProviderSecrets({
       providers: normalizedMergedProviders,
@@ -182,7 +307,11 @@ export async function planOpenClawModelsJsonWithDeps(
       secretRefManagedProviders,
     }) ?? normalizedMergedProviders;
   const finalProviders = applyNativeStreamingUsageCompat(secretEnforcedProviders);
-  const nextContents = `${JSON.stringify({ providers: finalProviders }, null, 2)}\n`;
+  const persistedProviders = stripPromptVisibleProviderSecrets(finalProviders, {
+    existingAuthSurfaces:
+      mode === "merge" ? collectExistingAuthSurfaces(params.existingParsed) : undefined,
+  });
+  const nextContents = `${JSON.stringify({ providers: persistedProviders }, null, 2)}\n`;
 
   if (params.existingRaw === nextContents) {
     return { action: "noop" };

--- a/src/agents/models-config.providers.normalize-keys.test.ts
+++ b/src/agents/models-config.providers.normalize-keys.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { NON_ENV_SECRETREF_MARKER } from "./model-auth-markers.js";
+import { planOpenClawModelsJsonWithDeps } from "./models-config.plan.js";
 import { normalizeProviders } from "./models-config.providers.normalize.js";
 import { resolveApiKeyFromProfiles } from "./models-config.providers.secret-helpers.js";
 import { enforceSourceManagedProviderSecrets } from "./models-config.providers.source-managed.js";
@@ -313,6 +314,110 @@ describe("normalizeProviders", () => {
 
       expect(resolved?.apiKey).toBe("MINIMAX_API_KEY"); // pragma: allowlist secret
       expect(resolved?.source).toBe("env-ref");
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not copy plaintext auth-profile keys into generated provider config", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-"));
+    const env = { ...process.env } as NodeJS.ProcessEnv;
+    delete env.OPENAI_API_KEY;
+    try {
+      await fs.writeFile(
+        path.join(agentDir, "auth-profiles.json"),
+        `${JSON.stringify(
+          {
+            version: 1,
+            profiles: {
+              "openai:default": {
+                type: "api_key",
+                provider: "openai",
+                key: "sk-profile-plaintext-secret", // pragma: allowlist secret
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+      const providers: NonNullable<NonNullable<OpenClawConfig["models"]>["providers"]> = {
+        openai: {
+          baseUrl: "https://api.openai.com/v1",
+          api: "openai-completions",
+          models: [createModel()],
+        },
+      };
+
+      const normalized = normalizeProviders({ providers, agentDir, env });
+
+      expect(normalized?.openai?.apiKey).toBeUndefined();
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("strips profile-backed plaintext keys preserved by models.json merge mode", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-agent-"));
+    const env = { ...process.env } as NodeJS.ProcessEnv;
+    delete env.OPENAI_API_KEY;
+    try {
+      await fs.writeFile(
+        path.join(agentDir, "auth-profiles.json"),
+        `${JSON.stringify(
+          {
+            version: 1,
+            profiles: {
+              "openai:default": {
+                type: "api_key",
+                provider: "openai",
+                key: "sk-profile-plaintext-secret", // pragma: allowlist secret
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+
+      const plan = await planOpenClawModelsJsonWithDeps(
+        {
+          cfg: { models: { mode: "merge", providers: {} } },
+          agentDir,
+          env,
+          existingRaw: "",
+          existingParsed: {
+            providers: {
+              openai: {
+                baseUrl: "https://api.openai.com/v1",
+                apiKey: "sk-profile-plaintext-secret", // pragma: allowlist secret
+                api: "openai-completions",
+                models: [createModel({ id: "gpt-proof" })],
+              },
+            },
+          },
+        },
+        {
+          resolveImplicitProviders: async () => ({
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              api: "openai-completions",
+              models: [createModel({ id: "gpt-proof" })],
+            },
+          }),
+        },
+      );
+
+      expect(plan.action).toBe("write");
+      if (plan.action !== "write") {
+        throw new Error("Expected models.json write plan");
+      }
+      const parsed = JSON.parse(plan.contents) as {
+        providers?: Record<string, { apiKey?: string }>;
+      };
+      expect(parsed.providers?.openai?.apiKey).toBeUndefined();
     } finally {
       await fs.rm(agentDir, { recursive: true, force: true });
     }

--- a/src/agents/models-config.providers.normalize.ts
+++ b/src/agents/models-config.providers.normalize.ts
@@ -13,6 +13,7 @@ import {
   normalizeResolvedEnvApiKey,
   resolveApiKeyFromProfiles,
   resolveMissingProviderApiKey,
+  stripProfileBackedPlaintextProviderApiKey,
 } from "./models-config.providers.secret-helpers.js";
 import { enforceSourceManagedProviderSecrets } from "./models-config.providers.source-managed.js";
 
@@ -186,9 +187,10 @@ export function normalizeProviders(params: {
       normalizedProvider = providerWithResolvedEnvApiKey;
     }
 
+    const hasProviderModels =
+      Array.isArray(normalizedProvider.models) && normalizedProvider.models.length > 0;
     const needsProfileApiKey =
-      Array.isArray(normalizedProvider.models) &&
-      normalizedProvider.models.length > 0 &&
+      hasProviderModels &&
       !(
         (typeof normalizedProvider.apiKey === "string" && normalizedProvider.apiKey.trim()) ||
         normalizedProvider.apiKey
@@ -208,6 +210,19 @@ export function normalizeProviders(params: {
     if (providerWithApiKey !== normalizedProvider) {
       mutated = true;
       normalizedProvider = providerWithApiKey;
+    }
+
+    const hasProviderApiKey =
+      typeof normalizedProvider.apiKey === "string" && normalizedProvider.apiKey.trim().length > 0;
+    const profileApiKeyForStrip =
+      hasProviderApiKey && !profileApiKey ? resolveProfileApiKey(normalizedKey) : profileApiKey;
+    const providerWithoutProfileBackedPlaintextApiKey = stripProfileBackedPlaintextProviderApiKey({
+      provider: normalizedProvider,
+      profileApiKey: profileApiKeyForStrip,
+    });
+    if (providerWithoutProfileBackedPlaintextApiKey !== normalizedProvider) {
+      mutated = true;
+      normalizedProvider = providerWithoutProfileBackedPlaintextApiKey;
     }
 
     const providerSpecificNormalized = normalizeProviderSpecificConfig(

--- a/src/agents/models-config.providers.secret-helpers.ts
+++ b/src/agents/models-config.providers.secret-helpers.ts
@@ -307,7 +307,9 @@ export function resolveMissingProviderApiKey(params: {
   }
 
   const fromEnv = resolveEnvApiKeyVarName(params.providerKey, params.env);
-  const apiKey = fromEnv ?? params.profileApiKey?.apiKey;
+  const profileApiKey =
+    params.profileApiKey?.source === "plaintext" ? undefined : params.profileApiKey?.apiKey;
+  const apiKey = fromEnv ?? profileApiKey;
   if (!apiKey?.trim()) {
     return params.provider;
   }
@@ -318,4 +320,23 @@ export function resolveMissingProviderApiKey(params: {
     ...params.provider,
     apiKey,
   };
+}
+
+export function stripProfileBackedPlaintextProviderApiKey(params: {
+  provider: ProviderConfig;
+  profileApiKey: ProfileApiKeyResolution | undefined;
+}): ProviderConfig {
+  if (params.profileApiKey?.source !== "plaintext") {
+    return params.provider;
+  }
+  const currentApiKey = normalizeOptionalSecretInput(params.provider.apiKey);
+  if (!currentApiKey || currentApiKey !== params.profileApiKey.apiKey.trim()) {
+    return params.provider;
+  }
+  if (isNonSecretApiKeyMarker(currentApiKey)) {
+    return params.provider;
+  }
+  const nextProvider = { ...params.provider };
+  delete nextProvider.apiKey;
+  return nextProvider;
 }

--- a/src/agents/models-config.runtime-source-snapshot.test.ts
+++ b/src/agents/models-config.runtime-source-snapshot.test.ts
@@ -25,6 +25,7 @@ vi.mock("../plugins/provider-runtime.js", () => ({
   applyProviderConfigDefaultsWithPlugin: (config: OpenClawConfig) => config,
   applyProviderNativeStreamingUsageCompatWithPlugin: () => undefined,
   normalizeProviderConfigWithPlugin: () => undefined,
+  resolveExternalAuthProfilesWithPlugins: () => [],
   resolveProviderConfigApiKeyWithPlugin: () => undefined,
   resolveProviderSyntheticAuthWithPlugin: () => undefined,
 }));

--- a/src/commands/doctor-legacy-config.migrations.test.ts
+++ b/src/commands/doctor-legacy-config.migrations.test.ts
@@ -34,6 +34,7 @@ vi.mock("../plugins/manifest-registry.js", () => ({
         contracts: { webSearchProviders: ["firecrawl"] },
       },
     ],
+    diagnostics: [],
   }),
   resolveManifestContractOwnerPluginId: ({ value }: { value: string }): string | undefined => {
     if (value === "gemini") {


### PR DESCRIPTION
## Summary
- stop newly generated plaintext provider apiKey values from being written to models.json
- avoid copying plaintext auth-profile keys into generated provider config, including merge-preserved rows
- strip new plaintext sensitive provider headers such as Authorization and x-api-key while preserving non-secret markers and legacy unchanged rows
- isolate the source-delivery unit test from plugin target normalization so the latest main unit-fast shard does not time out

## Real behavior proof
**Behavior or issue addressed:** Provider credentials that are needed for runtime auth should not be duplicated into the prompt-visible models.json catalog when they are new plaintext apiKey values or sensitive header values.

**Real environment tested:** Local OpenClaw checkout on Windows 11, Node v24.13.0, pnpm 11.1.0, running the patched source through tsx against a real config-shaped provider entry.

**Exact steps or command run after this patch:** Ran a tsx script that calls the patched models.json planner with a custom provider containing plaintext apiKey, Authorization, and X-Api-Key values plus an OpenAI provider using non-secret markers.

**Evidence after fix:** Copied terminal output from that local run:

```console
$ pnpm exec tsx -
{
  "action": "write",
  "customApiKeyPersisted": false,
  "customHeaders": {
    "X-Tenant": "tenant-a"
  },
  "openaiApiKey": "OPENAI_API_KEY",
  "openaiAuthorizationHeader": "secretref-env:OPENAI_PROXY_TOKEN"
}
```

**Observed result after fix:** The new plaintext provider apiKey was absent, the plaintext Authorization and X-Api-Key headers were removed, the safe X-Tenant header remained, and the non-secret env/SecretRef markers were preserved.

**What was not tested:** Full live provider request execution was not re-run; this PR only proves the persisted models.json planning path.

## Validation
- corepack pnpm exec vitest run --config test/vitest/vitest.gateway-methods.config.ts src/gateway/server-methods/config.shared-auth.test.ts
- corepack pnpm exec vitest run --config test/vitest/vitest.agents.config.ts src/agents/models-config.applies-config-env-vars.test.ts src/agents/models-config.providers.normalize-keys.test.ts src/agents/models-config.merge.test.ts
- corepack pnpm exec vitest run src/infra/outbound/source-delivery-plan.test.ts
- corepack pnpm exec oxlint src/agents/models-config.plan.ts src/agents/models-config.providers.normalize.ts src/agents/models-config.providers.secret-helpers.ts src/agents/models-config.applies-config-env-vars.test.ts src/agents/models-config.providers.normalize-keys.test.ts
- corepack pnpm exec oxlint src/infra/outbound/source-delivery-plan.test.ts
- git diff --check

Refs #11829 (Layer 1 only; does not close the broader security roadmap).