### PR TITLE
fix(codex): preserve plugin tool auth profiles

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -942,12 +942,12 @@ describe("runCodexAppServerAttempt", () => {
     params.toolAuthProfileStore = toolAuthProfileStore;
     params.runtimePlan = createCodexRuntimePlanFixture();
     const factoryOptions: unknown[] = [];
-    __testing.setOpenClawCodingToolsFactoryForTests((options) => {
+    testing.setOpenClawCodingToolsFactoryForTests((options) => {
       factoryOptions.push(options);
       return [];
     });
 
-    await __testing.buildDynamicTools({
+    await testing.buildDynamicTools({
       params,
       resolvedWorkspace: workspaceDir,
       effectiveWorkspace: workspaceDir,

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -902,6 +902,69 @@ describe("runCodexAppServerAttempt", () => {
     );
   });
 
+  it("uses the tool auth profile store for Codex dynamic tool construction", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    const params = createParams(sessionFile, workspaceDir);
+    const transportAuthProfileStore = {
+      version: 1,
+      profiles: {
+        "openai-codex:work": {
+          provider: "openai-codex",
+          type: "oauth",
+          access: "transport-token",
+          refresh: "transport-refresh",
+          expires: Date.now() + 60_000,
+        },
+      },
+    } satisfies EmbeddedRunAttemptParams["authProfileStore"];
+    const toolAuthProfileStore = {
+      version: 1,
+      profiles: {
+        "openai-codex:work": {
+          provider: "openai-codex",
+          type: "oauth",
+          access: "transport-token",
+          refresh: "transport-refresh",
+          expires: Date.now() + 60_000,
+        },
+        "xai:work": {
+          provider: "xai",
+          type: "oauth",
+          access: "xai-token",
+          refresh: "xai-refresh",
+          expires: Date.now() + 60_000,
+        },
+      },
+    } satisfies EmbeddedRunAttemptParams["authProfileStore"];
+    params.disableTools = false;
+    params.authProfileStore = transportAuthProfileStore;
+    params.toolAuthProfileStore = toolAuthProfileStore;
+    params.runtimePlan = createCodexRuntimePlanFixture();
+    const factoryOptions: unknown[] = [];
+    __testing.setOpenClawCodingToolsFactoryForTests((options) => {
+      factoryOptions.push(options);
+      return [];
+    });
+
+    await __testing.buildDynamicTools({
+      params,
+      resolvedWorkspace: workspaceDir,
+      effectiveWorkspace: workspaceDir,
+      sandboxSessionKey: params.sessionKey!,
+      sandbox: null as never,
+      runAbortController: new AbortController(),
+      sessionAgentId: "main",
+      pluginConfig: {},
+      onYieldDetected: () => undefined,
+    });
+
+    expect(factoryOptions).toHaveLength(1);
+    expect((factoryOptions[0] as { authProfileStore?: unknown }).authProfileStore).toBe(
+      toolAuthProfileStore,
+    );
+  });
+
   it("keeps canonical OpenAI Codex runs on OpenAI dynamic tool policy", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -3219,7 +3219,7 @@ async function buildDynamicTools(input: DynamicToolBuildParams) {
       resolvedWorkspace: input.resolvedWorkspace,
     }),
     config: params.config,
-    authProfileStore: params.authProfileStore,
+    authProfileStore: params.toolAuthProfileStore ?? params.authProfileStore,
     abortSignal: input.runAbortController.signal,
     emitBeforeToolCallDiagnostics: false,
     modelProvider: params.model.provider,

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -501,7 +501,8 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
     };
     expect(harnessParams?.runtimePlan).toBe(runtimePlan);
     expect(harnessParams.authProfileStore).toBe(codexAuthStore);
-    const authProfiles = expectRecordFields(harnessParams.authProfileStore.profiles, {});
+    const forwardedAuthStore = expectRecordFields(harnessParams.authProfileStore, {});
+    const authProfiles = expectRecordFields(forwardedAuthStore.profiles, {});
     expect(Object.keys(authProfiles)).toEqual([
       "openai-codex:work",
       "openai-codex:other",
@@ -854,7 +855,9 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
       toolAuthProfileStore?: unknown;
     };
     expect(harnessParams.authProfileStore).toBe(codexAuthStore);
-    expectRecordFields(harnessParams.authProfileStore.profiles?.["xai:work"], {
+    const forwardedAuthStore = expectRecordFields(harnessParams.authProfileStore, {});
+    const authProfiles = expectRecordFields(forwardedAuthStore.profiles, {});
+    expectRecordFields(authProfiles["xai:work"], {
       provider: "xai",
     });
     expect(harnessParams.toolAuthProfileStore).toBe(codexAuthStore);

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -322,6 +322,9 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
     expect(pluginParams.runtimePlan).toBe(runtimePlan);
     const authProfileStore = expectRecordFields(pluginParams.authProfileStore, {});
     expect(authProfileStore.profiles).toEqual({});
+    expect(
+      (pluginParams as { toolAuthProfileStore?: unknown }).toolAuthProfileStore,
+    ).toBeUndefined();
   });
 
   it("forwards optional attempt params and the runtime plan into one attempt call", async () => {
@@ -441,6 +444,13 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
           provider: "anthropic",
           key: "sk-ant",
         },
+        "xai:work": {
+          type: "oauth" as const,
+          provider: "xai",
+          access: "xai-access",
+          refresh: "xai-refresh",
+          expires: Date.now() + 60_000,
+        },
       },
     };
     mockedEnsureAuthProfileStoreWithoutExternalProfiles.mockReturnValueOnce(codexAuthStore);
@@ -487,6 +497,7 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
     const harnessParams = mockCallArg(pluginRunAttempt) as {
       runtimePlan?: unknown;
       authProfileStore?: { profiles?: Record<string, unknown> };
+      toolAuthProfileStore?: unknown;
     };
     expect(harnessParams?.runtimePlan).toBe(runtimePlan);
     const authProfileStore = expectRecordFields(harnessParams.authProfileStore, {});
@@ -495,6 +506,7 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
     expectRecordFields(authProfiles["openai-codex:work"], {
       provider: "openai-codex",
     });
+    expect(harnessParams.toolAuthProfileStore).toBe(codexAuthStore);
   });
 
   it("forwards OpenAI Codex auth profiles when openai/* is forced through codex", async () => {

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -500,9 +500,14 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
       toolAuthProfileStore?: unknown;
     };
     expect(harnessParams?.runtimePlan).toBe(runtimePlan);
-    const authProfileStore = expectRecordFields(harnessParams.authProfileStore, {});
-    const authProfiles = expectRecordFields(authProfileStore.profiles, {});
-    expect(Object.keys(authProfiles)).toEqual(["openai-codex:work"]);
+    expect(harnessParams.authProfileStore).toBe(codexAuthStore);
+    const authProfiles = expectRecordFields(harnessParams.authProfileStore.profiles, {});
+    expect(Object.keys(authProfiles)).toEqual([
+      "openai-codex:work",
+      "openai-codex:other",
+      "anthropic:work",
+      "xai:work",
+    ]);
     expectRecordFields(authProfiles["openai-codex:work"], {
       provider: "openai-codex",
     });
@@ -725,6 +730,13 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
           refresh: "refresh-token",
           expires: Date.now() + 60_000,
         },
+        "xai:work": {
+          type: "oauth" as const,
+          provider: "xai",
+          access: "xai-token",
+          refresh: "xai-refresh",
+          expires: Date.now() + 60_000,
+        },
       },
     };
     clearAgentHarnesses();
@@ -837,6 +849,15 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
         forwardedAuthProfileId: "openai-codex:default",
       },
     });
+    const harnessParams = mockCallArg(pluginRunAttempt) as {
+      authProfileStore?: { profiles?: Record<string, unknown> };
+      toolAuthProfileStore?: unknown;
+    };
+    expect(harnessParams.authProfileStore).toBe(codexAuthStore);
+    expectRecordFields(harnessParams.authProfileStore.profiles?.["xai:work"], {
+      provider: "xai",
+    });
+    expect(harnessParams.toolAuthProfileStore).toBe(codexAuthStore);
   });
 
   it("refreshes bootstrapped Codex OAuth credentials when rotating profiles", async () => {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -973,14 +973,18 @@ export async function runEmbeddedPiAgent(
       }
       startupStages.mark("auth");
       notifyExecutionPhase("auth", { provider, model: modelId });
-      const runAttemptAuthProfileStore = pluginHarnessOwnsTransport
-        ? createScopedAuthProfileStore(
-            attemptAuthProfileStore,
-            pluginHarnessForwardedProfileCandidates.length > 0
-              ? pluginHarnessForwardedProfileCandidates
-              : lastProfileId,
-          )
-        : attemptAuthProfileStore;
+      const codexHarnessOwnsTransport = pluginHarnessOwnsTransport && agentHarness.id === "codex";
+      // Codex builds OpenClaw tools inside its harness. Keep the full store on
+      // the existing field so installed Codex packages can resolve tool auth.
+      const runAttemptAuthProfileStore =
+        pluginHarnessOwnsTransport && !codexHarnessOwnsTransport
+          ? createScopedAuthProfileStore(
+              attemptAuthProfileStore,
+              pluginHarnessForwardedProfileCandidates.length > 0
+                ? pluginHarnessForwardedProfileCandidates
+                : lastProfileId,
+            )
+          : attemptAuthProfileStore;
       const { sessionAgentId } = resolveSessionAgentIds({
         sessionKey: params.sessionKey,
         config: params.config,

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1444,6 +1444,7 @@ export async function runEmbeddedPiAgent(
             initialReplayState: accumulatedReplayState,
             authStorage,
             authProfileStore: runAttemptAuthProfileStore,
+            toolAuthProfileStore: agentHarness.id === "codex" ? attemptAuthProfileStore : undefined,
             modelRegistry,
             agentId: workspaceResolution.agentId,
             legacyBeforeAgentStartResult,

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -58,6 +58,11 @@ export type EmbeddedRunAttemptParams = EmbeddedRunAttemptBase & {
   authStorage: AuthStorage;
   /** Auth profile store already resolved during startup for this attempt. */
   authProfileStore: AuthProfileStore;
+  /**
+   * Full auth profile store for OpenClaw tool availability.
+   * Plugin-owned harnesses may scope `authProfileStore` to model transport credentials.
+   */
+  toolAuthProfileStore?: AuthProfileStore;
   modelRegistry: ModelRegistry;
   thinkLevel: ThinkLevel;
   legacyBeforeAgentStartResult?: PluginHookBeforeAgentStartResult;

--- a/src/agents/pi-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.test.ts
@@ -12,6 +12,7 @@ import {
   resetGlobalHookRunner,
 } from "../plugins/hook-runner-global.js";
 import { createMockPluginRegistry } from "../plugins/hooks.test-helpers.js";
+import type { AuthProfileStore } from "./auth-profiles/types.js";
 import "./test-helpers/fast-bash-tools.js";
 import "./test-helpers/fast-coding-tools.js";
 import "./test-helpers/fast-openclaw-tools.js";
@@ -517,6 +518,56 @@ describe("createOpenClawCodingTools", () => {
       const pluginToolOptions = resolvePluginToolsSpy.mock.calls[0]?.[0].options;
       expect(pluginToolOptions?.modelProvider).toBe("openrouter");
       expect(pluginToolOptions?.modelId).toBe("openrouter/auto");
+    } finally {
+      resolvePluginToolsSpy.mockRestore();
+    }
+  });
+
+  it("forwards auth profiles to plugin-only tool construction", () => {
+    const createOpenClawToolsMock = vi.mocked(createOpenClawTools);
+    createOpenClawToolsMock.mockClear();
+    const resolvePluginToolsSpy = vi
+      .spyOn(openClawPluginTools, "resolveOpenClawPluginToolsForOptions")
+      .mockReturnValue([]);
+    const authProfileStore = {
+      version: 1,
+      order: { xai: ["xai-oauth"] },
+      profiles: {
+        "xai-oauth": {
+          type: "oauth",
+          provider: "xai",
+          access: "xai-oauth-access-token", // pragma: allowlist secret
+          refresh: "xai-oauth-refresh-token", // pragma: allowlist secret
+          expires: Date.now() + 60_000,
+        },
+      },
+    } satisfies AuthProfileStore;
+
+    try {
+      createOpenClawCodingTools({
+        config: {
+          auth: {
+            order: {
+              xai: ["xai-oauth"],
+            },
+          },
+        },
+        authProfileStore,
+        includeCoreTools: false,
+        runtimeToolAllowlist: ["x_search"],
+        toolConstructionPlan: {
+          includeBaseCodingTools: false,
+          includeShellTools: false,
+          includeChannelTools: false,
+          includeOpenClawTools: false,
+          includePluginTools: true,
+        },
+      });
+
+      expect(createOpenClawToolsMock).not.toHaveBeenCalled();
+      expect(resolvePluginToolsSpy).toHaveBeenCalledTimes(1);
+      const pluginToolOptions = resolvePluginToolsSpy.mock.calls[0]?.[0].options;
+      expect(pluginToolOptions?.authProfileStore).toBe(authProfileStore);
     } finally {
       resolvePluginToolsSpy.mockRestore();
     }

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -866,6 +866,7 @@ export function createOpenClawCodingTools(options?: {
             disableMessageTool: options?.disableMessageTool,
             requesterAgentIdOverride: agentId,
             allowGatewaySubagentBinding: options?.allowGatewaySubagentBinding,
+            authProfileStore: options?.authProfileStore,
           },
           resolvedConfig: options?.config,
         });


### PR DESCRIPTION
## Summary

- Fixes Codex/GPT-5.5 runs omitting xAI OAuth-backed tools such as `x_search` when Codex scoped its model-transport auth store to OpenAI/Codex credentials.
- Keeps the full auth profile store available to Codex tool construction, including installed external Codex harness packages that only understand the existing `authProfileStore` field.
- Keeps non-Codex plugin-owned harnesses on the existing scoped transport auth behavior, and also threads an explicit `toolAuthProfileStore` for newer Codex harness code.

## Real behavior proof

Behavior addressed: Codex/GPT-5.5 sessions should expose and successfully execute enabled xAI plugin tools such as `x_search` when xAI SuperGrok/OAuth auth exists, instead of falling back to only generic `web_search`.

Real environment tested: Linux OpenClaw source checkouts, Node 22.22.2, pnpm 11.1.0, Codex harness, `openai/gpt-5.5`, refreshed xAI OAuth profile expiring `2026-05-19T06:34:29.231Z`, no `XAI_API_KEY`; foreground gateways with `OPENCLAW_SKIP_CHANNELS=1`; direct gateway agent runs plus gateway-backed `pnpm tui` sessions.

Exact steps or command run after this patch:

```bash
# Refresh xAI OAuth once, then use the same valid auth state for before/after proof
pnpm openclaw models auth login --provider xai --method oauth

# Unfixed main negative control at df8505b09d
OPENCLAW_SKIP_CHANNELS=1 OPENCLAW_GATEWAY_PORT=18907 OPENCLAW_DEBUG_MODEL_PAYLOAD=tools OPENCLAW_DEBUG_CODE_MODE=1 \
  pnpm openclaw gateway run --port 18907 --bind loopback --allow-unconfigured
OPENCLAW_GATEWAY_PORT=18907 pnpm openclaw agent --agent main \
  --session-id codex-main-auth-xsearch-negative-20260519-0038 \
  --model openai/gpt-5.5 --timeout 240 --json \
  --message "Before-fix proof on unfixed main df8505b09d. Use the x_search tool exactly once to search X for the literal query 'OpenClaw'. Do not use web_search or web_fetch. After the tool call, report whether x_search returned results or an error, and include one short non-sensitive result/title if available."

# Current PR head 6d22e47449 with the installed external Codex package active
OPENCLAW_SKIP_CHANNELS=1 OPENCLAW_GATEWAY_PORT=18904 OPENCLAW_DEBUG_MODEL_PAYLOAD=tools OPENCLAW_DEBUG_CODE_MODE=1 \
  pnpm openclaw gateway run --port 18904 --bind loopback --allow-unconfigured
OPENCLAW_GATEWAY_PORT=18904 pnpm openclaw agent --agent main \
  --session-id codex-pr-auth-xsearch-proof-20260519-0035 \
  --model openai/gpt-5.5 --timeout 240 --json \
  --message "Current-head proof on PR 83603. Use the x_search tool exactly once to search X for the literal query 'OpenClaw'. Do not use web_search or web_fetch. After the tool call, report whether x_search returned results or an error, and include one short non-sensitive result/title if available."

# Gateway-backed TUI negative control on unfixed main df8505b09d
OPENCLAW_SKIP_CHANNELS=1 OPENCLAW_GATEWAY_PORT=18913 OPENCLAW_DEBUG_MODEL_PAYLOAD=tools OPENCLAW_DEBUG_CODE_MODE=1 \
  pnpm openclaw gateway run --port 18913 --bind loopback --allow-unconfigured
OPENCLAW_GATEWAY_PORT=18913 pnpm tui \
  --session codex-main-tui-xsearch-negative-20260519-0048 \
  --timeout-ms 240000
# Prompt typed into the TUI:
# TUI before-fix proof on unfixed main df8505b09d. Use the x_search tool exactly once to search X for the literal query 'OpenClaw'. Do not use web_search or web_fetch. After the tool call, report whether x_search returned results or an error, and include one short non-sensitive result/title if available.

# Gateway-backed TUI proof on current PR head 6d22e47449
OPENCLAW_SKIP_CHANNELS=1 OPENCLAW_GATEWAY_PORT=18910 OPENCLAW_DEBUG_MODEL_PAYLOAD=tools OPENCLAW_DEBUG_CODE_MODE=1 \
  pnpm openclaw gateway run --port 18910 --bind loopback --allow-unconfigured
OPENCLAW_GATEWAY_PORT=18910 pnpm tui \
  --session codex-pr-tui-xsearch-proof-20260519-0042 \
  --timeout-ms 240000 \
  --message "TUI current-head proof on PR 83603. Use the x_search tool exactly once to search X for the literal query 'OpenClaw'. Do not use web_search or web_fetch. After the tool call, report whether x_search returned results or an error, and include one short non-sensitive result/title if available."
# When the initial --message did not visibly dispatch, the same prompt was typed into the connected TUI and submitted.
```

Evidence before fix: Unfixed main `df8505b09d` returned `agentMeta.provider=openai-codex`, `agentMeta.model=gpt-5.5`, `agentMeta.agentHarnessId=codex`, and the model-visible tool list contained `web_search`/`web_fetch` but no `x_search`; final direct-agent text was `` `x_search` is not available in this session’s tool surface, so I could not call it.`` The gateway-backed TUI negative-control session `codex-main-tui-xsearch-negative-20260519-0048` showed footer `agent main | ... | openai/gpt-5.5` and rendered: `I could not run x_search: no x_search tool is exposed in this session. I did not use web_search or web_fetch, so there are no X results or titles to report.`

Evidence after fix: Current PR head `6d22e47449` returned `agentMeta.provider=openai-codex`, `agentMeta.model=gpt-5.5`, `agentMeta.agentHarnessId=codex`, model-visible tool entries included `code_execution` and `x_search`, and `toolSummary` was `calls=1`, `tools=["x_search"]`, `failures=0`. The gateway-backed TUI session `codex-pr-tui-xsearch-proof-20260519-0042` showed footer `agent main | ... | openai/gpt-5.5` and rendered: `x_search returned results, not an error.`

Observed result after fix: `x_search` executed successfully with refreshed xAI OAuth and returned results in both the direct gateway-agent path and the real gateway-backed TUI path. The TUI result included the short non-sensitive result/title: `Here’s a summary table summarizing the OpenClaw topic.`

What was not tested: A full inbound Telegram long-polling round trip after this final proof. The TUI proof now exercises the real gateway-backed interactive channel path; Telegram delivery remains a separate channel integration proof.

## Regression tests

```bash
node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run.overflow-compaction.test.ts src/agents/pi-tools.create-openclaw-coding-tools.test.ts extensions/codex/src/app-server/run-attempt.test.ts extensions/xai/x-search.test.ts
```

Result:

```text
Test Files  6 passed (6)
Tests       379 passed (379)
```

Additional checks:

```bash
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo
git diff --check
```

Result: both passed with no output.

## Security impact

- New permissions/capabilities? No new permission; existing enabled xAI tools become visible in affected Codex runs.
- Secrets/tokens handling changed? Yes. Codex harnesses now receive the full attempt auth store through the existing harness param so installed Codex packages can construct plugin tools with provider auth. Newer Codex code also receives `toolAuthProfileStore` explicitly.
- New/changed network calls? No new endpoint.
- Command/tool execution surface changed? Yes, enabled xAI plugin tools can appear where they were previously hidden.
- Risk and mitigation: This broader store is Codex-only because Codex builds OpenClaw tools inside its harness; non-Codex plugin-owned harnesses keep the scoped store. Model auth selection still uses the resolved model auth profile/API key path, and existing plugin/tool policy gates still apply.

## Compatibility

Backward compatible. The fix intentionally supports installed external Codex packages that do not yet know about `toolAuthProfileStore` by keeping tool auth available on `authProfileStore` for the Codex harness.