### PR TITLE
fix(cron): link isolated task runs to cron session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Telegram: keep verbose tool progress visible without mirroring non-final progress into active session transcripts, preventing embedded provider replies from aborting mid-run. (#83631) Thanks @kurplunkin.
+- Cron: link isolated scheduled task runs to their stable cron session so task status and cleanup can follow the backing agent run. (#83606) Thanks @jai.
 - CLI: enforce the documented Node.js 22.19 runtime floor in the source launcher.
 - Agents/replies: persist queued follow-up user messages and assistant error stubs only once across model-fallback retries, preventing repeated provider rejections from corrupted same-role session transcripts. Fixes #83404. (#83417) Thanks @yetval.
 - Slack: persist delivered inbound message IDs and fail closed when same-channel thread replies lose their thread context, preventing delayed duplicate replies and accidental channel-root posts. Fixes #83521. Thanks @shannon0430.

--- a/src/cron/service/timer.test.ts
+++ b/src/cron/service/timer.test.ts
@@ -28,6 +28,22 @@ function createDueMainJob(params: { now: number; wakeMode: CronJob["wakeMode"] }
   };
 }
 
+function createDueIsolatedAgentJob(params: { now: number }): CronJob {
+  return {
+    id: "isolated-agent-job",
+    agentId: "finn",
+    name: "isolated agent job",
+    enabled: true,
+    createdAtMs: params.now - 60_000,
+    updatedAtMs: params.now - 60_000,
+    schedule: { kind: "every", everyMs: 60_000, anchorMs: params.now - 60_000 },
+    sessionTarget: "isolated",
+    wakeMode: "now",
+    payload: { kind: "agentTurn", message: "run isolated cron" },
+    state: { nextRunAtMs: params.now - 1 },
+  };
+}
+
 afterEach(() => {
   resetTaskRegistryForTests();
 });
@@ -106,6 +122,49 @@ describe("cron service timer seam coverage", () => {
     expect(positiveDelays.length).toBeGreaterThan(0);
 
     timeoutSpy.mockRestore();
+  });
+
+  it("records isolated cron task runs against the backing cron session", async () => {
+    const { storePath } = await makeStorePath();
+    const now = Date.parse("2026-03-23T12:00:00.000Z");
+    const enqueueSystemEvent = vi.fn();
+    const requestHeartbeat = vi.fn();
+    const runIsolatedAgentJob = vi.fn(async () => ({
+      status: "ok" as const,
+      summary: "done",
+      sessionKey: "agent:finn:cron:isolated-agent-job:run:run-1",
+    }));
+
+    await writeCronStoreSnapshot({
+      storePath,
+      jobs: [createDueIsolatedAgentJob({ now })],
+    });
+
+    const state = createCronServiceState({
+      storePath,
+      cronEnabled: true,
+      log: logger,
+      nowMs: () => now,
+      enqueueSystemEvent,
+      requestHeartbeat,
+      runIsolatedAgentJob,
+    });
+
+    await onTimer(state);
+
+    expect(runIsolatedAgentJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        job: expect.objectContaining({ id: "isolated-agent-job" }),
+        message: "run isolated cron",
+      }),
+    );
+    const task = findTaskByRunId(`cron:isolated-agent-job:${now}`);
+    if (!task) {
+      throw new Error("expected isolated cron task ledger record");
+    }
+    expect(task.childSessionKey).toBe("agent:finn:cron:isolated-agent-job");
+    expect(task.status).toBe("succeeded");
+    expect(task.terminalSummary).toBe("done");
   });
 
   it("keeps scheduler progress when task ledger creation fails", async () => {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -15,6 +15,7 @@ import {
 } from "../../tasks/detached-task-runtime.js";
 import { clearCronJobActive, markCronJobActive } from "../active-jobs.js";
 import { resolveCronDeliveryPlan, resolveFailureDestination } from "../delivery-plan.js";
+import { resolveCronAgentSessionKey } from "../isolated-agent/session-key.js";
 import {
   createCronRunDiagnosticsFromError,
   normalizeCronRunDiagnostics,
@@ -419,6 +420,23 @@ export function normalizeCronRunErrorText(err: unknown): string {
   return String(err);
 }
 
+function resolveCronTaskChildSessionKey(params: {
+  state: CronServiceState;
+  job: CronJob;
+}): string | undefined {
+  const explicitSessionKey = params.job.sessionKey?.trim();
+  if (explicitSessionKey) {
+    return explicitSessionKey;
+  }
+  if (params.job.sessionTarget !== "isolated") {
+    return undefined;
+  }
+  return resolveCronAgentSessionKey({
+    sessionKey: `cron:${params.job.id}`,
+    agentId: params.job.agentId ?? params.state.deps.defaultAgentId ?? DEFAULT_AGENT_ID,
+  });
+}
+
 function tryCreateCronTaskRun(params: {
   state: CronServiceState;
   job: CronJob;
@@ -431,7 +449,7 @@ function tryCreateCronTaskRun(params: {
       sourceId: params.job.id,
       ownerKey: "",
       scopeKind: "system",
-      childSessionKey: params.job.sessionKey,
+      childSessionKey: resolveCronTaskChildSessionKey(params),
       agentId: params.job.agentId,
       runId,
       label: params.job.name,


### PR DESCRIPTION
## Summary

- Problem: isolated cron task ledger records used `job.sessionKey`, which is usually absent for isolated agent-turn cron jobs.
- Why it matters: successful isolated cron runs could appear disconnected from their backing cron session in task-status/cleanup flows.
- What changed: task ledger creation now derives the same stable backing cron session key used by isolated cron execution: `agent:<agentId>:cron:<jobId>`.
- What did NOT change (scope boundary): per-run cron transcript session keys still use the existing `:run:<sessionId>` suffix; main-session jobs still use their explicit `sessionKey`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #83605
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: isolated cron task ledger rows now point at the stable backing cron session instead of leaving `childSessionKey` unset.
- Real environment tested: local macOS OpenClaw checkout based on `openclaw/openclaw:main`, using the real cron service timer, cron store, and detached task registry modules.
- Exact steps or command run after this patch: `node --import tsx --input-type=module` with a local cron store containing an isolated agent-turn cron job and no `sessionKey`; the script invoked `onTimer(state)` and inspected the detached task registry.
- Evidence after fix: copied inline output from a local cron-service proof script; focused test output and proof output are included in [this evidence comment](https://github.com/openclaw/openclaw/pull/83606#issuecomment-4478493818). This is not operational runtime log evidence:

```text
runId=cron:isolated-agent-job:1774267200000
childSessionKey=agent:finn:cron:isolated-agent-job
status=succeeded
terminalSummary=done
```

- Observed result after fix: the copied live output shows the task row for `cron:isolated-agent-job:1774267200000` has `childSessionKey=agent:finn:cron:isolated-agent-job` and `status=succeeded`.
- What was not tested: a full live gateway UI/task-status screen.
- Before evidence: current upstream main with only the regression test applied fails with `expected undefined to be 'agent:finn:cron:isolated-agent-job'`; the focused test output is included in [this evidence comment](https://github.com/openclaw/openclaw/pull/83606#issuecomment-4478493818). This is not an operational runtime log.

## Root Cause (if applicable)

- Root cause: task ledger creation happens before isolated cron execution returns its per-run `sessionKey`, and it only copied `job.sessionKey`. Isolated cron jobs normally omit `job.sessionKey` and derive their backing cron session from `cron:<jobId>`.
- Missing detection / guardrail: existing timer tests covered main-session task ledger rows but did not cover isolated cron task ledger session linkage.
- Contributing context (if known): isolated cron execution intentionally distinguishes the stable backing session from per-run transcript session keys.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Seam / integration test
- Target test or file: `src/cron/service/timer.test.ts`
- Scenario the test should lock in: an isolated agent-turn cron job without `sessionKey` succeeds and records `childSessionKey` as `agent:<agentId>:cron:<jobId>`.
- Why this is the smallest reliable guardrail: the timer seam is where the task ledger row is created before isolated execution returns.
- Existing test that already covers this (if any): none for isolated cron task ledger session linkage.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Task-status and cleanup/reporting flows can now associate isolated cron task runs with their backing cron session.

## Diagram (if applicable)

```text
Before:
[isolated cron due] -> [task ledger row] -> [childSessionKey unset]

After:
[isolated cron due] -> [task ledger row] -> [agent:<agentId>:cron:<jobId>] -> [run succeeds]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node runtime with repo dependencies installed via pinned pnpm 11.1.0
- Model/provider: N/A
- Integration/channel (if any): cron service timer / detached task registry
- Relevant config (redacted): isolated cron job with `sessionTarget: "isolated"`, `payload.kind: "agentTurn"`, `agentId: "finn"`, and no `sessionKey`

### Steps

1. Add/run an isolated agent-turn cron job without `sessionKey`.
2. Let the cron timer execute it successfully.
3. Inspect the detached task ledger row for `cron:<jobId>:<startedAt>`.

### Expected

- `childSessionKey` points at `agent:<agentId>:cron:<jobId>`.

### Actual

- Before this PR, `childSessionKey` was unset.

## Evidence

Attached artifacts:

- [x] Failing focused test output before + passing after
- [ ] Operational trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Inline evidence included above:

- After-fix local proof output showing `childSessionKey=agent:finn:cron:isolated-agent-job` and `status=succeeded`.
- Before-fix assertion summary: `expected undefined to be 'agent:finn:cron:isolated-agent-job'`.
- No before/after operational runtime logs have been collected. The linked evidence is focused test output plus local proof-script output, not production or gateway service logs.

## Human Verification (required)

What I personally verified:

- Verified scenarios: regression test failed before the implementation and passed after it; focused cron shard passed after commit; local proof script printed the expected task ledger row.
- Edge cases checked: main-session task ledger behavior remains covered by the existing main heartbeat task test.
- What I did **not** verify: full live gateway UI/task-status rendering, or before/after operational runtime logs from a running OpenClaw service.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: deriving the wrong session key for an isolated cron job could point task-status at the wrong backing session.
  - Mitigation: reuse `resolveCronAgentSessionKey` and add seam coverage for the expected `agent:<agentId>:cron:<jobId>` shape.


