### PR TITLE
fix(cron): add Authorization header to provider preflight probe

### DIFF
--- a/src/cron/isolated-agent/model-preflight.runtime.ts
+++ b/src/cron/isolated-agent/model-preflight.runtime.ts
@@ -160,9 +160,20 @@ function resolveProbeApiKey(providerCfg: ModelProviderConfig | undefined, provid
   if (configKey && typeof configKey === "string" && configKey.trim()) {
     return configKey.trim();
   }
-  // Fall back to env var lookup using the provider name
-  const envResult = resolveEnvApiKey(provider, process.env);
-  return envResult?.apiKey || undefined;
+  // Try direct env var: LITELLM_API_KEY, VLLM_API_KEY, SGLANG_API_KEY, etc.
+  const upperName = provider.toUpperCase().replace(/[^A-Z0-9_]/g, "");
+  const directKey = process.env[upperName + "_API_KEY"];
+  if (directKey?.trim()) {
+    return directKey.trim();
+  }
+  // Fall back to env var lookup via provider-registered env var names
+  try {
+    const envResult = resolveEnvApiKey(provider, process.env);
+    if (envResult?.apiKey) return envResult.apiKey;
+  } catch {
+    // ignore resolution errors
+  }
+  return undefined;
 }
 
 async function probeLocalProviderEndpoint(params: {

--- a/src/cron/isolated-agent/model-preflight.runtime.ts
+++ b/src/cron/isolated-agent/model-preflight.runtime.ts
@@ -156,10 +156,14 @@ function buildUnavailableResult(params: {
 async function probeLocalProviderEndpoint(params: {
   api: PreflightApi;
   baseUrl: string;
+  apiKey?: string;
 }): Promise<void> {
+  const headers: Record<string, string> | undefined = params.apiKey
+    ? { Authorization: `Bearer ${params.apiKey}` }
+    : undefined;
   const { response, release } = await fetchWithSsrFGuard({
     url: buildProbeUrl(params.api, params.baseUrl),
-    init: { method: "GET" },
+    init: { method: "GET", ...(headers ? { headers } : {}) },
     policy: buildLocalProviderSsrFPolicy(params.baseUrl),
     timeoutMs: PREFLIGHT_TIMEOUT_MS,
     auditContext: "cron-model-provider-preflight",
@@ -207,7 +211,11 @@ export async function preflightCronModelProvider(params: {
 
   let result: EndpointPreflightResult;
   try {
-    await probeLocalProviderEndpoint({ api, baseUrl });
+    await probeLocalProviderEndpoint({
+      api,
+      baseUrl,
+      apiKey: providerConfig.apiKey,
+    });
     result = { status: "available" };
   } catch (error) {
     result = { status: "unavailable", error };

--- a/src/cron/isolated-agent/model-preflight.runtime.ts
+++ b/src/cron/isolated-agent/model-preflight.runtime.ts
@@ -1,4 +1,5 @@
-import { resolveEnvApiKey } from "../../agents/model-auth-env.js";
+import { resolveOpenClawAgentDir } from "../../agents/agent-paths.js";
+import { resolveApiKeyForProvider } from "../../agents/model-auth.js";
 import { normalizeProviderId } from "../../agents/provider-id.js";
 import type { ModelProviderConfig } from "../../config/types.models.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -154,24 +155,27 @@ function buildUnavailableResult(params: {
   };
 }
 
-function resolveProbeApiKey(providerCfg: ModelProviderConfig | undefined, provider: string): string | undefined {
-  // First try the provider config's apiKey field
-  const configKey = providerCfg?.apiKey;
-  if (configKey && typeof configKey === "string" && configKey.trim()) {
-    return configKey.trim();
-  }
-  // Try direct env var: LITELLM_API_KEY, VLLM_API_KEY, SGLANG_API_KEY, etc.
-  const upperName = provider.toUpperCase().replace(/[^A-Z0-9_]/g, "");
-  const directKey = process.env[upperName + "_API_KEY"];
-  if (directKey?.trim()) {
-    return directKey.trim();
-  }
-  // Fall back to env var lookup via provider-registered env var names
+async function resolveProbeApiKey(
+  providerCfg: ModelProviderConfig | undefined,
+  provider: string,
+  cfg: OpenClawConfig,
+): Promise<string | undefined> {
+  // Use the same API key resolution chain as normal inference calls
+  // (getApiKeyForModel → resolveApiKeyForProvider). This checks all sources:
+  // config apiKey, env vars, auth-profiles.json, OAuth tokens, plugin synthetic auth.
   try {
-    const envResult = resolveEnvApiKey(provider, process.env);
-    if (envResult?.apiKey) return envResult.apiKey;
+    const agentDir = resolveOpenClawAgentDir();
+    const result = await resolveApiKeyForProvider({
+      provider,
+      cfg,
+      agentDir,
+      env: process.env,
+    });
+    if (result.apiKey && typeof result.apiKey === "string" && result.apiKey.trim()) {
+      return result.apiKey.trim();
+    }
   } catch {
-    // ignore resolution errors
+    // If resolution fails, probe without auth (existing behavior for authless providers)
   }
   return undefined;
 }
@@ -234,7 +238,7 @@ export async function preflightCronModelProvider(params: {
 
   let result: EndpointPreflightResult;
   try {
-    const probeApiKey = resolveProbeApiKey(providerConfig, params.provider);
+    const probeApiKey = await resolveProbeApiKey(providerConfig, params.provider, params.cfg);
     await probeLocalProviderEndpoint({
       api,
       baseUrl,

--- a/src/cron/isolated-agent/model-preflight.runtime.ts
+++ b/src/cron/isolated-agent/model-preflight.runtime.ts
@@ -1,3 +1,4 @@
+import { resolveEnvApiKey } from "../../agents/model-auth-env.js";
 import { normalizeProviderId } from "../../agents/provider-id.js";
 import type { ModelProviderConfig } from "../../config/types.models.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -153,6 +154,17 @@ function buildUnavailableResult(params: {
   };
 }
 
+function resolveProbeApiKey(providerCfg: ModelProviderConfig | undefined, provider: string): string | undefined {
+  // First try the provider config's apiKey field
+  const configKey = providerCfg?.apiKey;
+  if (configKey && typeof configKey === "string" && configKey.trim()) {
+    return configKey.trim();
+  }
+  // Fall back to env var lookup using the provider name
+  const envResult = resolveEnvApiKey(provider, process.env);
+  return envResult?.apiKey || undefined;
+}
+
 async function probeLocalProviderEndpoint(params: {
   api: PreflightApi;
   baseUrl: string;
@@ -211,10 +223,11 @@ export async function preflightCronModelProvider(params: {
 
   let result: EndpointPreflightResult;
   try {
+    const probeApiKey = resolveProbeApiKey(providerConfig, params.provider);
     await probeLocalProviderEndpoint({
       api,
       baseUrl,
-      apiKey: providerConfig.apiKey,
+      apiKey: probeApiKey,
     });
     result = { status: "available" };
   } catch (error) {

--- a/src/cron/isolated-agent/model-preflight.runtime.ts
+++ b/src/cron/isolated-agent/model-preflight.runtime.ts
@@ -1,5 +1,5 @@
-import { resolveOpenClawAgentDir } from "../../agents/agent-paths.js";
 import { resolveApiKeyForProvider } from "../../agents/model-auth.js";
+import { resolveDefaultAgentDir } from "../../agents/agent-scope-config.js";
 import { normalizeProviderId } from "../../agents/provider-id.js";
 import type { ModelProviderConfig } from "../../config/types.models.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -164,12 +164,11 @@ async function resolveProbeApiKey(
   // (getApiKeyForModel → resolveApiKeyForProvider). This checks all sources:
   // config apiKey, env vars, auth-profiles.json, OAuth tokens, plugin synthetic auth.
   try {
-    const agentDir = resolveOpenClawAgentDir();
+    const agentDir = resolveDefaultAgentDir(cfg);
     const result = await resolveApiKeyForProvider({
       provider,
       cfg,
       agentDir,
-      env: process.env,
     });
     if (result.apiKey && typeof result.apiKey === "string" && result.apiKey.trim()) {
       return result.apiKey.trim();


### PR DESCRIPTION
## Summary

The cron job preflight check sends `GET {baseUrl}/models` to verify local provider connectivity before running a job, but was sending the request **without an Authorization header**. For providers behind auth middleware (LiteLLM, vLLM, etc.), this generated spurious 401 errors on every cron run.

## Root Cause

`model-preflight.runtime.ts` → `probeLocalProviderEndpoint()` called `fetchWithSsrFGuard` with `init: { method: "GET" }` — no auth header.

The probe is designed as a simple connectivity check (any HTTP response means alive). But providers behind auth still process the request through their auth middleware before the probe handler.

## Fix

Replaced the ad-hoc API key resolution with a call to **`resolveApiKeyForProvider()`** — the same function used by normal inference calls (`getApiKeyForModel → resolveApiKeyForProvider`).

This ensures the probe uses the API key from the correct source:
- `models.providers[provider].apiKey` (config)
- `auth-profiles.json` (auth profile store)
- Environment variables
- OAuth tokens
- Plugin synthetic auth

If no API key is found (authless local servers like Ollama), the probe proceeds without auth — same behavior as before.

## Real behavior proof

### Before
```http
GET /models HTTP/1.1  →  401 Unauthorized
POST /chat/completions → 200 OK
```

### After
```http
GET /models HTTP/1.1  →  200 OK
POST /chat/completions → 200 OK
```

Both requests now carry the same `Authorization: Bearer <key>` header, confirmed by same-process sequential source ports.

## Changes

`src/cron/isolated-agent/model-preflight.runtime.ts`:
- Added import for `resolveApiKeyForProvider` from `model-auth.ts`
- Added import for `resolveDefaultAgentDir` from `agent-scope-config.ts`
- Replaced `resolveProbeApiKey` with a proper async function that calls `resolveApiKeyForProvider`
- `probeLocalProviderEndpoint` now receives and uses the resolved API key

## Verification

The patch was verified by 4 independent sub-agent code reviews:
1. dist import path correctness
2. Local ↔ VPS consistency 
3. Auth resolution chain completeness
4. Final strict security review

All passed before production testing.
