### PR TITLE
fix(agents): do not recreate optional bootstrap files in existing workspaces (#83593)

### DIFF
--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -141,7 +141,8 @@ describe("ensureAgentWorkspace", () => {
 
     await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
 
-    await expect(fs.access(path.join(tempDir, DEFAULT_IDENTITY_FILENAME))).resolves.toBeUndefined();
+    // Optional files are not seeded into existing (non-brand-new) workspaces (#83593).
+    await expectPathMissing(path.join(tempDir, DEFAULT_IDENTITY_FILENAME));
     await expectPathMissing(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME));
     const state = await readWorkspaceState(tempDir);
     expect(state.setupCompletedAt).toMatch(/\d{4}-\d{2}-\d{2}T/);
@@ -156,7 +157,34 @@ describe("ensureAgentWorkspace", () => {
 
     await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
 
-    await expectCompletedWithoutBootstrap(tempDir);
+    // Optional files are not seeded into existing (non-brand-new) workspaces (#83593).
+    await expectPathMissing(path.join(tempDir, DEFAULT_IDENTITY_FILENAME));
+    await expectPathMissing(path.join(tempDir, DEFAULT_BOOTSTRAP_FILENAME));
+    const state = await readWorkspaceState(tempDir);
+    expect(state.setupCompletedAt).toMatch(/\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("does not recreate optional bootstrap files removed from an initialized workspace (#83593)", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    // Simulate the reporter's setup: workspace root has AGENTS.md + .git but
+    // optional files were intentionally moved to a subdirectory.
+    await fs.mkdir(path.join(tempDir, ".git"), { recursive: true });
+    await fs.writeFile(path.join(tempDir, ".git", "HEAD"), "ref: refs/heads/main\n");
+    await fs.writeFile(path.join(tempDir, DEFAULT_AGENTS_FILENAME), "# AGENTS\n");
+
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+
+    for (const fileName of [
+      DEFAULT_SOUL_FILENAME,
+      DEFAULT_IDENTITY_FILENAME,
+      DEFAULT_USER_FILENAME,
+      DEFAULT_HEARTBEAT_FILENAME,
+    ]) {
+      await expectPathMissing(path.join(tempDir, fileName));
+    }
+    // Required files are still ensured.
+    await expect(fs.access(path.join(tempDir, DEFAULT_AGENTS_FILENAME))).resolves.toBeUndefined();
+    await expect(fs.access(path.join(tempDir, DEFAULT_TOOLS_FILENAME))).resolves.toBeUndefined();
   });
 
   it("skips configured optional bootstrap files without skipping required files", async () => {

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -526,8 +526,14 @@ export async function ensureAgentWorkspace(params?: {
   const userTemplate = await loadTemplate(DEFAULT_USER_FILENAME);
   const heartbeatTemplate = await loadTemplate(DEFAULT_HEARTBEAT_FILENAME);
   const skipOptionalBootstrapFiles = new Set(params?.skipOptionalBootstrapFiles ?? []);
-  const shouldWriteBootstrapFile = (fileName: string): boolean =>
-    !OPTIONAL_BOOTSTRAP_FILENAMES.has(fileName) || !skipOptionalBootstrapFiles.has(fileName);
+  // Optional files (SOUL, USER, HEARTBEAT, IDENTITY) are only seeded into brand-new workspaces.
+  // In existing workspaces they may have been intentionally removed or relocated; recreating them
+  // from templates on every subagent spawn is the bug reported in #83593.
+  const shouldWriteBootstrapFile = (fileName: string): boolean => {
+    if (!OPTIONAL_BOOTSTRAP_FILENAMES.has(fileName)) return true;
+    if (!isBrandNewWorkspace) return false;
+    return !skipOptionalBootstrapFiles.has(fileName);
+  };
 
   await writeFileIfMissing(agentsPath, agentsTemplate);
   if (shouldWriteBootstrapFile(DEFAULT_SOUL_FILENAME)) {

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -530,8 +530,12 @@ export async function ensureAgentWorkspace(params?: {
   // In existing workspaces they may have been intentionally removed or relocated; recreating them
   // from templates on every subagent spawn is the bug reported in #83593.
   const shouldWriteBootstrapFile = (fileName: string): boolean => {
-    if (!OPTIONAL_BOOTSTRAP_FILENAMES.has(fileName)) return true;
-    if (!isBrandNewWorkspace) return false;
+    if (!OPTIONAL_BOOTSTRAP_FILENAMES.has(fileName)) {
+      return true;
+    }
+    if (!isBrandNewWorkspace) {
+      return false;
+    }
     return !skipOptionalBootstrapFiles.has(fileName);
   };
 


### PR DESCRIPTION
## Summary

`ensureAgentWorkspace` computed `isBrandNewWorkspace` (true only when the workspace directory contains none of: AGENTS.md, SOUL.md, TOOLS.md, IDENTITY.md, USER.md, HEARTBEAT.md, `memory/`, `.git`, or a root MEMORY.md) but only used it for `ensureGitRepo`. Optional bootstrap files — SOUL.md, USER.md, HEARTBEAT.md, IDENTITY.md — were written via `writeFileIfMissing` on every call regardless of workspace state, so files intentionally removed from a workspace root were recreated from templates on the next subagent spawn.

The fix gates optional file creation on `isBrandNewWorkspace`. Required files (AGENTS.md, TOOLS.md) are always ensured and are unaffected. Closes #83593.

## Real behavior proof

Behavior addressed: optional bootstrap files recreated in workspace root after intentional removal when a subagent spawns

Real environment tested: `tsx` invocation of `ensureAgentWorkspace` against a real temp directory — no test framework, no mocks, no vitest

Exact steps or command run after this patch:
```
node_modules/.bin/tsx proof-83593.mts
```
Sets up a real temp dir with AGENTS.md + .git present and optional files absent (the reporter's exact setup), calls `ensureAgentWorkspace({ dir: tmp, ensureBootstrapFiles: true })`, then inspects the real filesystem.

Evidence after fix:
```
Workspace: /tmp/openclaw-proof-qOz6Wv
Before: AGENTS.md
After:  .openclaw, AGENTS.md, TOOLS.md

Optional files NOT created (expected): SOUL.md, USER.md, HEARTBEAT.md, IDENTITY.md
Required files present (expected):     AGENTS.md, TOOLS.md

Result: PASS
```

Observed result after fix: SOUL.md, USER.md, HEARTBEAT.md, IDENTITY.md absent from workspace root — AGENTS.md and TOOLS.md present as required

What was not tested: live subagent spawn in a configured workspace (proof exercises `ensureAgentWorkspace` directly, which is the call site in `agent-command.ts:434`)