### PR TITLE
fix(image-generate): allow distinct active image requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/image generation: allow distinct `image_generate` prompts to start separate session-backed background tasks while same-prompt retries still return the active task status. (#83614) Thanks @Elarwei001.
 - Sessions: skip trailing custom transcript entries when checking tail assistant replies so embedded CLI gap-fill does not duplicate canonical assistant output. (#83635) Thanks @yaoyi1222.
 - Telegram: keep verbose tool progress visible without mirroring non-final progress into active session transcripts, preventing embedded provider replies from aborting mid-run. (#83631) Thanks @kurplunkin.
 - Cron: link isolated scheduled task runs to their stable cron session so task status and cleanup can follow the backing agent run. (#83606) Thanks @jai.

--- a/docs/automation/tasks.md
+++ b/docs/automation/tasks.md
@@ -106,7 +106,7 @@ Not every agent run creates a task. Heartbeat turns and normal interactive chat 
 
   </Accordion>
   <Accordion title="Concurrent media-generation guardrail">
-    While a session-backed media-generation task is still active, the tool also acts as a guardrail: repeated `image_generate`, `music_generate`, or `video_generate` calls in that same session return the active task status instead of starting a second concurrent generation. Use `action: "status"` when you want an explicit progress/status lookup from the agent side.
+    While a session-backed media-generation task is still active, media tools also act as guardrails for accidental retries. Repeated `image_generate` calls for the same prompt return the matching active task status, while a distinct image prompt can start its own task. `music_generate` and `video_generate` calls still return the active task status for that session instead of starting a second concurrent generation. Use `action: "status"` when you want an explicit progress/status lookup from the agent side.
   </Accordion>
   <Accordion title="What does not create tasks">
     - Heartbeat turns - main-session; see [Heartbeat](/gateway/heartbeat)

--- a/src/agents/image-generation-task-status.test.ts
+++ b/src/agents/image-generation-task-status.test.ts
@@ -115,6 +115,50 @@ describe("image generation task status", () => {
     expect(details.progressSummary).toBe("Generating image");
   });
 
+  it("can restrict active lookup to the matching image prompt", () => {
+    taskRuntimeInternalMocks.listTasksForOwnerKey.mockReturnValue([
+      {
+        taskId: "task-first",
+        runtime: "cli",
+        taskKind: IMAGE_GENERATION_TASK_KIND,
+        sourceId: "image_generate:openai",
+        requesterSessionKey: "agent:main",
+        ownerKey: "agent:main",
+        scopeKind: "session",
+        task: "First diagram prompt",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        notifyPolicy: "silent",
+        createdAt: Date.now(),
+      },
+      {
+        taskId: "task-second",
+        runtime: "cli",
+        taskKind: IMAGE_GENERATION_TASK_KIND,
+        sourceId: "image_generate:openai",
+        requesterSessionKey: "agent:main",
+        ownerKey: "agent:main",
+        scopeKind: "session",
+        task: "Second diagram prompt",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        notifyPolicy: "silent",
+        createdAt: Date.now(),
+      },
+    ]);
+
+    expect(
+      findActiveImageGenerationTaskForSession("agent:main", {
+        prompt: "Second diagram prompt",
+      })?.taskId,
+    ).toBe("task-second");
+    expect(
+      findActiveImageGenerationTaskForSession("agent:main", {
+        prompt: "Third diagram prompt",
+      }),
+    ).toBeUndefined();
+  });
+
   it("builds prompt context for active session work", () => {
     taskRuntimeInternalMocks.listTasksForOwnerKey.mockReturnValue([
       {

--- a/src/agents/image-generation-task-status.ts
+++ b/src/agents/image-generation-task-status.ts
@@ -24,11 +24,13 @@ export function getImageGenerationTaskProviderId(task: TaskRecord): string | und
 
 export function findActiveImageGenerationTaskForSession(
   sessionKey?: string,
+  params?: { prompt?: string },
 ): TaskRecord | undefined {
   return findActiveMediaGenerationTaskForSession({
     sessionKey,
     taskKind: IMAGE_GENERATION_TASK_KIND,
     sourcePrefix: IMAGE_GENERATION_SOURCE_PREFIX,
+    taskLabel: params?.prompt,
   });
 }
 

--- a/src/agents/media-generation-task-status-shared.ts
+++ b/src/agents/media-generation-task-status-shared.ts
@@ -33,11 +33,13 @@ export function findActiveMediaGenerationTaskForSession(params: {
   sessionKey?: string;
   taskKind: string;
   sourcePrefix: string;
+  taskLabel?: string;
 }): TaskRecord | undefined {
   return findActiveSessionTask({
     sessionKey: params.sessionKey,
     runtime: "cli",
     taskKind: params.taskKind,
+    task: params.taskLabel,
     sourceIdPrefix: params.sourcePrefix,
   });
 }

--- a/src/agents/session-async-task-status.ts
+++ b/src/agents/session-async-task-status.ts
@@ -8,6 +8,7 @@ export function findActiveSessionTask(params: {
   sessionKey?: string;
   runtime?: TaskRuntime;
   taskKind?: string;
+  task?: string;
   statuses?: ReadonlySet<TaskStatus>;
   sourceIdPrefix?: string;
 }): TaskRecord | undefined {
@@ -17,6 +18,7 @@ export function findActiveSessionTask(params: {
   }
   const statuses = params.statuses ?? DEFAULT_ACTIVE_STATUSES;
   const taskKind = normalizeOptionalString(params.taskKind);
+  const taskLabel = normalizeOptionalString(params.task);
   const sourceIdPrefix = normalizeOptionalString(params.sourceIdPrefix);
   const matches = listTasksForOwnerKey(normalizedSessionKey).filter((task) => {
     if (task.scopeKind !== "session") {
@@ -30,6 +32,12 @@ export function findActiveSessionTask(params: {
     }
     if (taskKind && task.taskKind !== taskKind) {
       return false;
+    }
+    if (taskLabel) {
+      const currentTaskLabel = normalizeOptionalString(task.task);
+      if (currentTaskLabel !== taskLabel) {
+        return false;
+      }
     }
     if (sourceIdPrefix) {
       const sourceId = normalizeOptionalString(task.sourceId) ?? "";

--- a/src/agents/tools/image-generate-tool.actions.ts
+++ b/src/agents/tools/image-generate-tool.actions.ts
@@ -92,6 +92,25 @@ export function createImageGenerateStatusActionResult(
 
 export function createImageGenerateDuplicateGuardResult(
   sessionKey?: string,
+  params?: { prompt?: string },
 ): ImageGenerateActionResult | undefined {
-  return imageGenerateTaskStatusActions.createDuplicateGuardResult(sessionKey);
+  const activeTask = findActiveImageGenerationTaskForSession(sessionKey, {
+    prompt: params?.prompt,
+  });
+  if (!activeTask) {
+    return undefined;
+  }
+  return {
+    content: [
+      {
+        type: "text",
+        text: buildImageGenerationTaskStatusText(activeTask, { duplicateGuard: true }),
+      },
+    ],
+    details: {
+      action: "status",
+      duplicateGuard: true,
+      ...buildImageGenerationTaskStatusDetails(activeTask),
+    },
+  };
 }

--- a/src/agents/tools/image-generate-tool.test.ts
+++ b/src/agents/tools/image-generate-tool.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
+const taskRuntimeInternalMocks = vi.hoisted(() => ({
+  listTasksForOwnerKey: vi.fn(),
+}));
+
 const taskRuntimeMocks = vi.hoisted(() => ({
   createRunningTaskRun: vi.fn(),
   recordTaskRunProgressByRunId: vi.fn(),
@@ -7,6 +11,7 @@ const taskRuntimeMocks = vi.hoisted(() => ({
   failTaskRunByRunId: vi.fn(),
 }));
 
+vi.mock("../../tasks/runtime-internal.js", () => taskRuntimeInternalMocks);
 vi.mock("../../tasks/detached-task-runtime.js", () => taskRuntimeMocks);
 
 let imageGenerationRuntime: typeof import("../../image-generation/runtime.js");
@@ -304,6 +309,8 @@ describe("createImageGenerateTool", () => {
     taskRuntimeMocks.recordTaskRunProgressByRunId.mockReset();
     taskRuntimeMocks.completeTaskRunByRunId.mockReset();
     taskRuntimeMocks.failTaskRunByRunId.mockReset();
+    taskRuntimeInternalMocks.listTasksForOwnerKey.mockReset();
+    taskRuntimeInternalMocks.listTasksForOwnerKey.mockReturnValue([]);
   });
 
   afterEach(() => {
@@ -734,6 +741,131 @@ describe("createImageGenerateTool", () => {
         progressSummary: "Queued image generation",
       }),
     );
+  });
+
+  it("allows a distinct image request while another image generation task is active", async () => {
+    stubImageGenerationProviders();
+    vi.stubEnv("OPENAI_API_KEY", "openai-test");
+    vi.spyOn(imageGenerationRuntime, "generateImage").mockResolvedValue({
+      provider: "openai",
+      model: "gpt-image-1",
+      attempts: [],
+      ignoredOverrides: [],
+      images: [
+        {
+          buffer: Buffer.from("png-out"),
+          mimeType: "image/png",
+          fileName: "second.png",
+        },
+      ],
+    });
+    taskRuntimeInternalMocks.listTasksForOwnerKey.mockReturnValue([
+      {
+        taskId: "task-first-image",
+        runtime: "cli",
+        taskKind: "image_generation",
+        sourceId: "image_generate:openai",
+        requesterSessionKey: "agent:main:discord:direct:123",
+        ownerKey: "agent:main:discord:direct:123",
+        scopeKind: "session",
+        task: "First diagram prompt",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        notifyPolicy: "silent",
+        createdAt: Date.now(),
+      },
+    ]);
+    taskRuntimeMocks.createRunningTaskRun.mockReturnValue({
+      taskId: "task-second-image",
+    });
+    const scheduled: Array<() => Promise<void>> = [];
+    const tool = requireImageGenerateTool(
+      createImageGenerateTool({
+        config: {
+          agents: {
+            defaults: {
+              imageGenerationModel: {
+                primary: "openai/gpt-image-1",
+              },
+            },
+          },
+        },
+        agentDir: "/tmp/agent",
+        agentSessionKey: "agent:main:discord:direct:123",
+        requesterOrigin: {
+          channel: "discord",
+          to: "dm:123",
+        },
+        scheduleBackgroundWork: (work) => {
+          scheduled.push(work);
+        },
+      }),
+    );
+
+    const result = await tool.execute("call-second", {
+      prompt: "Second diagram prompt",
+      filename: "second.png",
+      model: "openai/gpt-image-1",
+    });
+
+    expect(scheduled).toHaveLength(1);
+    expect(resultDetails(result).taskId).toBe("task-second-image");
+    expect(taskRuntimeMocks.createRunningTaskRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: "Second diagram prompt",
+      }),
+    );
+  });
+
+  it("returns active status for a duplicate image request with the same prompt", async () => {
+    stubImageGenerationProviders();
+    vi.stubEnv("OPENAI_API_KEY", "openai-test");
+    taskRuntimeInternalMocks.listTasksForOwnerKey.mockReturnValue([
+      {
+        taskId: "task-existing-image",
+        runtime: "cli",
+        taskKind: "image_generation",
+        sourceId: "image_generate:openai",
+        requesterSessionKey: "agent:main:discord:direct:123",
+        ownerKey: "agent:main:discord:direct:123",
+        scopeKind: "session",
+        task: "Same diagram prompt",
+        status: "running",
+        deliveryStatus: "not_applicable",
+        notifyPolicy: "silent",
+        createdAt: Date.now(),
+        progressSummary: "Generating image",
+      },
+    ]);
+    const tool = requireImageGenerateTool(
+      createImageGenerateTool({
+        config: {
+          agents: {
+            defaults: {
+              imageGenerationModel: {
+                primary: "openai/gpt-image-1",
+              },
+            },
+          },
+        },
+        agentDir: "/tmp/agent",
+        agentSessionKey: "agent:main:discord:direct:123",
+      }),
+    );
+
+    const result = await tool.execute("call-duplicate", {
+      prompt: "Same diagram prompt",
+      filename: "same.png",
+      model: "openai/gpt-image-1",
+    });
+
+    expect(taskRuntimeMocks.createRunningTaskRun).not.toHaveBeenCalled();
+    expect(resultText(result)).toContain(
+      "Image generation task task-existing-image is already running",
+    );
+    const details = resultDetails(result);
+    expect(details.duplicateGuard).toBe(true);
+    expect(details.task).toEqual({ taskId: "task-existing-image" });
   });
 
   it("uses configured timeoutMs for image generation and lets calls override it", async () => {

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -819,15 +819,16 @@ export function createImageGenerateTool(options?: {
       const effectiveCfg =
         applyImageGenerationModelConfigDefaults(cfg, imageGenerationModelConfig) ?? cfg;
       const remoteMediaSsrfPolicy = resolveRemoteMediaSsrfPolicy(effectiveCfg);
+      const prompt = readStringParam(params, "prompt", { required: true });
 
       const duplicateGuardResult = createImageGenerateDuplicateGuardResult(
         options?.agentSessionKey,
+        { prompt },
       );
       if (duplicateGuardResult) {
         return duplicateGuardResult;
       }
 
-      const prompt = readStringParam(params, "prompt", { required: true });
       const imageInputs = normalizeReferenceImages(params);
       const model = readStringParam(params, "model");
       const filename = readStringParam(params, "filename");


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `image_generate` treated any active image generation task in the same session as a duplicate, even when the next call had a distinct prompt/filename for a different image.
- Why it matters: multi-image workflows could silently drop the second image request while returning a status for the first active task, causing agents to report false progress.
- What changed: duplicate guarding now matches the active image task by prompt, so same-prompt retries still reuse active status while distinct prompts can create their own background tasks.
- Docs: the media task guardrail docs now describe the prompt-scoped `image_generate` behavior separately from music/video generation.
- What did NOT change (scope boundary): no provider behavior, image output format, media saving, completion wake delivery, or video/music generation behavior is changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #83610
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: session-backed image generation duplicate guard dropping a distinct second image request.
- Real environment tested: local macOS OpenClaw source checkout, session-backed Telegram workflow observed on an existing OpenClaw gateway. Sensitive chat/media details omitted.
- Exact steps or command run after this patch:
  1. Created one active session-scoped `image_generation` task in the production task ledger using redacted prompt A.
  2. Called the production `image_generate` duplicate guard with prompt A and prompt B.
  3. Verified prompt A returns the existing active task status.
  4. Verified prompt B is not treated as a duplicate, so the normal tool path can create a new background task.
  5. Ran the focused regression tests for the tool and active-task lookup.
- Evidence after fix (copied local output):

```text
$ pnpm exec tsx --input-type=module - <<'E O F'
import { createRunningTaskRun } from "./src/tasks/task-executor.ts";
import { resetTaskRegistryForTests } from "./src/tasks/runtime-internal.ts";
import { createImageGenerateDuplicateGuardResult } from "./src/agents/tools/image-generate-tool.actions.ts";
import { findActiveImageGenerationTaskForSession } from "./src/agents/image-generation-task-status.ts";

resetTaskRegistryForTests({ persist: false });
const sessionKey = "redacted-session";
createRunningTaskRun({
  runtime: "cli",
  taskKind: "image_generation",
  sourceId: "image_generate:openai",
  requesterSessionKey: sessionKey,
  ownerKey: sessionKey,
  scopeKind: "session",
  childSessionKey: sessionKey,
  runId: "tool:image_generate:redacted-a",
  label: "Image generation",
  task: "redacted prompt A",
  deliveryStatus: "not_applicable",
  notifyPolicy: "silent",
  startedAt: Date.now(),
  lastEventAt: Date.now(),
  progressSummary: "Generating image",
});

const samePrompt = createImageGenerateDuplicateGuardResult(sessionKey, { prompt: "redacted prompt A" });
const distinctPrompt = createImageGenerateDuplicateGuardResult(sessionKey, { prompt: "redacted prompt B" });
const activeA = findActiveImageGenerationTaskForSession(sessionKey, { prompt: "redacted prompt A" });
const activeB = findActiveImageGenerationTaskForSession(sessionKey, { prompt: "redacted prompt B" });

console.log(JSON.stringify({
  samePromptDuplicateGuard: samePrompt?.details?.duplicateGuard === true,
  samePromptExistingTask: samePrompt?.details?.existingTask === true,
  distinctPromptDuplicateGuard: distinctPrompt?.details?.duplicateGuard === true,
  distinctPromptCanStartNewTask: distinctPrompt === undefined,
  activeLookupPromptA: activeA?.runId,
  activeLookupPromptB: activeB?.runId ?? null,
}, null, 2));
E O F

{
  "samePromptDuplicateGuard": true,
  "samePromptExistingTask": true,
  "distinctPromptDuplicateGuard": false,
  "distinctPromptCanStartNewTask": true,
  "activeLookupPromptA": "tool:image_generate:redacted-a",
  "activeLookupPromptB": null
}

$ node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-tools.config.ts src/agents/tools/image-generate-tool.test.ts

 Test Files  1 passed (1)
      Tests  33 passed (33)

$ node scripts/run-vitest.mjs run --config test/vitest/vitest.agents-core.config.ts src/agents/image-generation-task-status.test.ts

 Test Files  1 passed (1)
      Tests  4 passed (4)
```

- Observed result after fix: a distinct prompt is allowed to start a second task even while another image task is active in the same session; same-prompt retries are still guarded.
- What was not tested: a live provider call after this patch that actually generates two paid images. The regression target is the task ledger / duplicate guard before provider execution, covered by the production task-ledger smoke and regression tests.
- Before evidence: in a real session-backed chat, an agent requested two distinct diagrams. The second `image_generate` call returned the first active task's status and did not create a new task for the second image. The first image completed and delivered; the second image only started after a later manual follow-up. Private media IDs and prompts are intentionally omitted.

## Root Cause (if applicable)

- Root cause: active image task lookup was scoped to session/task kind/source prefix only, and the duplicate guard ran before representing the new request as a task. It could not distinguish a same-request retry from a valid second image request.
- Missing detection / guardrail: no regression test covered two distinct image prompts in the same session while the first image task was active.
- Contributing context (if known): `count` supports multiple outputs for one prompt, but there was no representation for multiple distinct prompts/filenames in one workflow.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/agents/tools/image-generate-tool.test.ts`
  - `src/agents/image-generation-task-status.test.ts`
- Scenario the test should lock in:
  - distinct prompt while another image task is active creates a new task
  - same prompt while an image task is active returns duplicate guard status
  - active image task lookup can be restricted by prompt
- Why this is the smallest reliable guardrail: the bug happens before provider execution, at duplicate guard / task lookup time.
- Existing test that already covers this (if any): none before this PR.

## User-visible / Behavior Changes

Agents can start a second session-backed image generation task for a distinct prompt while another image generation task is still active. Repeated calls with the same prompt still return the active task status.

## Diagram (if applicable)

```text
Before:
[image A active] -> [image_generate image B] -> [status for image A] -> [image B not started]

After:
[image A active] -> [image_generate image B] -> [new task for image B] -> [both complete independently]
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local OpenClaw source checkout
- Model/provider: redacted production task-ledger smoke for after-fix guard behavior; real session observation used for before behavior
- Integration/channel (if any): session-backed chat
- Relevant config (redacted): image generation provider configured

### Steps

1. Have an active session-backed image generation task with prompt A.
2. Call `image_generate` in the same session with prompt B.
3. Observe whether a task for prompt B is created.
4. Repeat with prompt A to verify duplicate guard behavior remains intact.

### Expected

- Prompt B creates a new image generation task.
- Prompt A returns active status for the existing task.

### Actual

- Before this PR: prompt B returned active status for prompt A's task and did not start.
- After this PR: prompt B starts a new task; prompt A remains guarded.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - production task-ledger smoke for distinct prompt vs same prompt behavior
  - local tests for distinct prompt vs same prompt behavior
  - issue reproduction path by source inspection and redacted live-session observation
  - docs updated for prompt-scoped image guard behavior
- Edge cases checked:
  - active task lookup can select matching prompt among multiple active tasks
  - same-prompt retry does not create a duplicate task
- What you did **not** verify:
  - live paid image generation after patch

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: prompt-only matching may allow two very similar but not identical prompts to run concurrently.
  - Mitigation: this is the intended behavior for distinct image requests; exact same prompt retries remain guarded.

