### PR TITLE
Flush buffered Telegram finals after segmented delivery

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -1587,6 +1587,46 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(answerDraftStream.update).toHaveBeenCalledWith("Answer");
   });
 
+  it("flushes buffered final answers after a skipped reasoning segment", async () => {
+    deliverInboundReplyWithMessageSendContext
+      .mockResolvedValueOnce({ status: "handled_no_send" })
+      .mockResolvedValueOnce({
+        status: "handled_visible",
+        delivery: { messageIds: ["1001"], visibleReplySent: true },
+      });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver(
+        { text: "<think>Hidden reasoning</think>Visible answer" },
+        { kind: "final" },
+      );
+      return { queuedFinal: true };
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: {
+          SessionKey: "agent:main:telegram:direct:123",
+          ChatType: "direct",
+        } as unknown as TelegramMessageContext["ctxPayload"],
+      }),
+      cfg: { agents: { defaults: { reasoningDefault: "on" } } },
+      streamMode: "off",
+      telegramDeps: telegramDepsForTest,
+    });
+
+    expect(deliverInboundReplyWithMessageSendContext).toHaveBeenCalledTimes(2);
+    expectRecordFields(mockCallArg(deliverInboundReplyWithMessageSendContext, 0), {
+      info: { kind: "final" },
+    });
+    expectRecordFields(mockCallArg(deliverInboundReplyWithMessageSendContext, 0).payload, {
+      text: "Reasoning:\n_Hidden reasoning_",
+    });
+    expectRecordFields(mockCallArg(deliverInboundReplyWithMessageSendContext, 1).payload, {
+      text: "Visible answer",
+    });
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
   it("suppresses reasoning-only finals without raw text fallback", async () => {
     setupDraftStreams({ answerMessageId: 2001, reasoningMessageId: 3001 });
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1383,6 +1383,9 @@ export const dispatchTelegramMessage = async ({
                     };
 
                     if (segments.length > 0) {
+                      if (info.kind === "final") {
+                        await flushBufferedFinalAnswer();
+                      }
                       trackBlockMedia(blockDelivered);
                       return;
                     }


### PR DESCRIPTION
## Summary
- flush buffered Telegram final answers before returning from segmented final delivery
- add a regression test for final answers split into hidden reasoning and visible answer segments

## Root cause
When Telegram final output was split into reasoning/answer lane segments, the reasoning segment could be handled without sending a visible message. The visible answer was then buffered, but the `segments.length > 0` path returned before `flushBufferedFinalAnswer()` ran, so automatic direct-message delivery could silently drop the final answer.

## Validation
- `OPENCLAW_VITEST_INCLUDE_FILE=/tmp/openclaw-telegram-include.json node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts`
- Result: `extensions/telegram/src/bot-message-dispatch.test.ts` passed, 67 tests

Note: I also attempted the broader Telegram extension suite. This dispatch test file passed there as well, but the full suite reported unrelated existing failures in `channel.gateway.test.ts` startup probe handling plus runtime/token setup errors.
