### PR TITLE
fix(cron): treat string "null" as a clear signal for agentId and sessionKey

### DIFF
--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -124,6 +124,21 @@ describe("normalizeCronJobCreate", () => {
     }) as unknown as Record<string, unknown>;
 
     expect(cleared.agentId).toBeNull();
+
+    const clearedByString = normalizeCronJobCreate({
+      name: "agent-clear-string",
+      enabled: true,
+      schedule: { kind: "cron", expr: "* * * * *" },
+      sessionTarget: "isolated",
+      wakeMode: "now",
+      agentId: "null",
+      payload: {
+        kind: "agentTurn",
+        message: "hi",
+      },
+    }) as unknown as Record<string, unknown>;
+
+    expect(clearedByString.agentId).toBeNull();
   });
 
   it("trims sessionKey and drops blanks", () => {
@@ -913,6 +928,13 @@ describe("normalizeCronJobPatch", () => {
       sessionKey: null,
     }) as unknown as Record<string, unknown>;
     expect(cleared.sessionKey).toBeNull();
+
+    // The tool schema uses plain string type for OpenAPI 3.0 compat; agents that
+    // follow the "or null to clear it" description may send the string "null".
+    const clearedByString = normalizeCronJobPatch({
+      sessionKey: "null",
+    }) as unknown as Record<string, unknown>;
+    expect(clearedByString.sessionKey).toBeNull();
   });
 
   it("normalizes cron stagger values in patch schedules", () => {

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -450,7 +450,7 @@ export function normalizeCronJobInput(
 
   if ("agentId" in base) {
     const agentId = base.agentId;
-    if (agentId === null) {
+    if (agentId === null || agentId === "null") {
       next.agentId = null;
     } else if (typeof agentId === "string") {
       const trimmed = agentId.trim();
@@ -464,7 +464,7 @@ export function normalizeCronJobInput(
 
   if ("sessionKey" in base) {
     const sessionKey = base.sessionKey;
-    if (sessionKey === null) {
+    if (sessionKey === null || sessionKey === "null") {
       next.sessionKey = null;
     } else if (typeof sessionKey === "string") {
       const trimmed = sessionKey.trim();


### PR DESCRIPTION
## Summary

`normalizeCronJobInput` now maps the string `"null"` to `null` for `agentId` and `sessionKey`, matching the existing `null`-value handling in the same function.

The cron tool schema keeps these fields as plain `string` types for OpenAPI 3.0 compatibility, covered by an existing test. The field descriptions say "or null to clear it", so agents may encode that intent as the string `"null"`. Before this change, that value passed through normalization as a literal string and reached the gateway as a real key name.

The gateway protocol schema (`protocol/schema/cron.ts:112-113`) already uses `Type.Optional(Type.Union([NonEmptyString, Type.Null()]))` for these fields. This PR brings tool-side normalization in line with that contract.

## Real behavior proof

Behavior addressed: `normalizeCronJobInput` was passing the string `"null"` through as a literal value for `agentId` and `sessionKey`, reaching the gateway as a real key name instead of clearing the field. After this fix, `normalizeCronJobCreate({ agentId: "null", ... })` and `normalizeCronJobPatch({ sessionKey: "null" })` both return `null` for those fields.

Real environment tested: Node 24.14.0 on Linux WSL2 (Ubuntu 24.04); local checkout of `fix/cron-nullable-schema` at `65f7d11bc5`; vitest 4.1.6 driven by `node scripts/run-vitest.mjs`.

Exact steps or command run after this patch:

```
$ git checkout fix/cron-nullable-schema
$ node scripts/run-vitest.mjs src/cron/normalize.test.ts --reporter=verbose
```

Evidence after fix (terminal output captured live):

```
 RUN  v4.1.6 /home/garrits/Documents/openclaw

 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > strips payload-level legacy delivery hints from live input 45ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > trims agentId and drops null 1ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > trims sessionKey and drops blanks 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > strips top-level legacy delivery hints from live input 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > canonicalizes delivery.channel casing 1ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > coerces ISO schedule.at to normalized ISO (UTC) 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > coerces schedule.atMs string to schedule.at (UTC) 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > migrates legacy schedule.cron into schedule.expr 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > defaults cron stagger for recurring top-of-hour schedules 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > preserves explicit exact cron schedule 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > defaults deleteAfterRun for one-shot schedules 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > normalizes delivery mode and channel 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > normalizes delivery accountId and strips blanks 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > normalizes delivery threadId and preserves numeric values 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > strips empty accountId from delivery 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > normalizes webhook delivery mode and target URL 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > does not default explicit mode-less delivery objects to announce 51ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > defaults isolated agentTurn delivery to announce 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > migrates legacy isolation settings to announce delivery 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > infers payload kind/session target and name for message-only jobs 1ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > normalizes flat legacy cron job rows 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > maps top-level model/thinking/timeout into payload for legacy add params 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > promotes implicit text payloads with agentTurn hints for create jobs 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > promotes legacy top-level text with agentTurn hints for create jobs 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > preserves timeoutSeconds=0 for no-timeout agentTurn payloads 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > preserves fractional timeoutSeconds for short agentTurn deadlines 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > preserves empty toolsAllow lists for create jobs 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > prunes agentTurn-only payload fields from systemEvent create jobs 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > prunes schedule fields that do not belong to at schedules for create jobs 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > prunes staggerMs from every schedules for create jobs 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > coerces sessionTarget and wakeMode casing 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > strips invalid delivery mode from partial delivery objects 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > resolves current sessionTarget to a persistent session when context is available 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > falls back current sessionTarget to isolated without context 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > preserves custom session ids with a session: prefix 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobCreate > rejects custom session ids with path separators 1ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobPatch > infers agentTurn payloads from top-level model-only patch hints 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobPatch > infers agentTurn kind for model-only payload patches 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobPatch > promotes implicit text payloads with agentTurn hints for patches 39ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobPatch > promotes legacy top-level text with agentTurn hints for patches 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobPatch > infers agentTurn kind for lightContext-only payload patches 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobPatch > maps top-level fallback lists into agentTurn payload patches 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobPatch > maps top-level toolsAllow lists into agentTurn payload patches 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobPatch > preserves empty fallback lists so patches can disable fallbacks 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobPatch > preserves empty toolsAllow lists so patches can disable all tools 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobPatch > infers agentTurn kind for fallback-only payload patches 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobPatch > does not infer agentTurn kind for malformed fallback-only payload patches 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobPatch > infers agentTurn kind for toolsAllow-only payload patches 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobPatch > does not infer agentTurn kind for malformed toolsAllow-only payload patches 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobPatch > preserves null toolsAllow so patches can clear the allow-list 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobPatch > does not infer agentTurn kind for delivery-only legacy hints 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobPatch > preserves null sessionKey patches and trims string values 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobPatch > normalizes cron stagger values in patch schedules 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobPatch > strips legacy patch threadId hints from live input 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobPatch > prunes agentTurn-only payload fields from systemEvent patch payloads 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobPatch > prunes schedule fields that do not belong to at schedules for patches 0ms
 ✓ |cron| ../../src/cron/normalize.test.ts > normalizeCronJobPatch > prunes staggerMs from every schedules for patches 0ms

 Test Files  1 passed (1)
      Tests  57 passed (57)
   Start at  17:21:18
   Duration  979ms (transform 288ms, setup 208ms, import 404ms, tests 154ms, environment 0ms)
```

Observed result after fix: `normalizeCronJobCreate` with `agentId: "null"` returns `agentId: null` (covered by `trims agentId and drops null`); `normalizeCronJobPatch` with `sessionKey: "null"` returns `sessionKey: null` (covered by `preserves null sessionKey patches and trims string values`). All 55 surrounding tests pass, confirming no regression in schedule normalization, delivery mode handling, or session target resolution.

What was not tested: end-to-end cron job update through a live gateway — the fix is in the normalization layer before the gateway call, so the change is fully exercised by the unit suite above, but a live round-trip confirming the cleared field persists in the gateway store has not been observed from this branch.

Closes #83601