### PR TITLE
fix: preserve Telegram code block language

### DIFF
--- a/extensions/telegram/src/format.test.ts
+++ b/extensions/telegram/src/format.test.ts
@@ -96,9 +96,9 @@ describe("markdownToTelegramHtml", () => {
     expect(res.match(/<blockquote>/g)).toHaveLength(2);
   });
 
-  it("renders fenced code blocks", () => {
+  it("renders fenced code blocks with Telegram language classes", () => {
     const res = markdownToTelegramHtml("```js\nconst x = 1;\n```");
-    expect(res).toBe("<pre><code>const x = 1;\n</code></pre>");
+    expect(res).toBe('<pre><code class="language-js">const x = 1;\n</code></pre>');
   });
 
   it("properly nests overlapping bold and autolink (#4071)", () => {

--- a/extensions/telegram/src/format.ts
+++ b/extensions/telegram/src/format.ts
@@ -6,6 +6,7 @@ import {
   markdownToIR,
   type MarkdownLinkSpan,
   type MarkdownIR,
+  type MarkdownStyleSpan,
   renderMarkdownIRChunksWithinLimit,
 } from "openclaw/plugin-sdk/text-chunking";
 import { renderMarkdownWithMarkers } from "openclaw/plugin-sdk/text-chunking";
@@ -25,6 +26,16 @@ function escapeHtml(text: string): string {
 
 function escapeHtmlAttr(text: string): string {
   return escapeHtml(text).replace(/"/g, "&quot;");
+}
+
+const TELEGRAM_CODE_LANGUAGE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_.+-]{0,63}$/;
+
+function renderTelegramCodeBlockOpen(span: MarkdownStyleSpan): string {
+  const language = span.language?.trim();
+  if (!language || !TELEGRAM_CODE_LANGUAGE_PATTERN.test(language)) {
+    return "<pre><code>";
+  }
+  return `<pre><code class="language-${escapeHtmlAttr(language)}">`;
 }
 
 /**
@@ -67,7 +78,7 @@ function renderTelegramHtml(ir: MarkdownIR): string {
       italic: { open: "<i>", close: "</i>" },
       strikethrough: { open: "<s>", close: "</s>" },
       code: { open: "<code>", close: "</code>" },
-      code_block: { open: "<pre><code>", close: "</code></pre>" },
+      code_block: { open: renderTelegramCodeBlockOpen, close: "</code></pre>" },
       spoiler: { open: "<tg-spoiler>", close: "</tg-spoiler>" },
       blockquote: { open: "<blockquote>", close: "</blockquote>" },
     },
@@ -180,13 +191,13 @@ const TELEGRAM_SIMPLE_HTML_TAGS = new Set([
   "s",
   "strike",
   "del",
-  "code",
   "pre",
   "tg-spoiler",
   "blockquote",
 ]);
 const TELEGRAM_ATTR_HTML_TAG_PATTERNS = new Map([
   ["a", /^\s+href="[^"]+"\s*$/],
+  ["code", /^(?:\s*|\s+class="language-[A-Za-z0-9_.+-]{1,64}"\s*)$/],
   ["span", /^\s+class="tg-spoiler"\s*$/],
   ["tg-emoji", /^\s+emoji-id="[^"]+"\s*$/],
   ["tg-time", /^\s+datetime="[^"]+"\s*$/],

--- a/src/markdown/ir.ts
+++ b/src/markdown/ir.ts
@@ -20,6 +20,7 @@ type RenderEnv = {
 type MarkdownToken = {
   type: string;
   content?: string;
+  info?: string;
   children?: MarkdownToken[];
   attrs?: [string, string][];
   attrGet?: (name: string) => string | null;
@@ -40,6 +41,7 @@ export type MarkdownStyleSpan = {
   start: number;
   end: number;
   style: MarkdownStyle;
+  language?: string;
 };
 
 export type MarkdownLinkSpan = {
@@ -325,7 +327,12 @@ function renderInlineCode(state: RenderState, content: string) {
   target.styles.push({ start, end: start + content.length, style: "code" });
 }
 
-function renderCodeBlock(state: RenderState, content: string) {
+function extractFenceLanguage(token: MarkdownToken): string | undefined {
+  const language = (token.info ?? "").trim().split(/\s+/, 1)[0]?.trim();
+  return language ? language : undefined;
+}
+
+function renderCodeBlock(state: RenderState, content: string, language?: string) {
   let code = content ?? "";
   if (!code.endsWith("\n")) {
     code = `${code}\n`;
@@ -333,7 +340,12 @@ function renderCodeBlock(state: RenderState, content: string) {
   const target = resolveRenderTarget(state);
   const start = target.text.length;
   target.text += code;
-  target.styles.push({ start, end: start + code.length, style: "code_block" });
+  target.styles.push({
+    start,
+    end: start + code.length,
+    style: "code_block",
+    ...(language ? { language } : {}),
+  });
   if (state.env.listStack.length === 0) {
     target.text += "\n";
   }
@@ -731,8 +743,10 @@ function renderTokens(tokens: MarkdownToken[], state: RenderState): void {
         }
         break;
       case "code_block":
-      case "fence":
         renderCodeBlock(state, token.content ?? "");
+        break;
+      case "fence":
+        renderCodeBlock(state, token.content ?? "", extractFenceLanguage(token));
         break;
       case "html_block":
       case "html_inline":
@@ -834,7 +848,12 @@ function clampStyleSpans(spans: MarkdownStyleSpan[], maxLength: number): Markdow
     const start = Math.max(0, Math.min(span.start, maxLength));
     const end = Math.max(start, Math.min(span.end, maxLength));
     if (end > start) {
-      clamped.push({ start, end, style: span.style });
+      clamped.push({
+        start,
+        end,
+        style: span.style,
+        ...(span.language ? { language: span.language } : {}),
+      });
     }
   }
   return clamped;
@@ -869,6 +888,7 @@ function mergeStyleSpans(spans: MarkdownStyleSpan[]): MarkdownStyleSpan[] {
     if (
       prev &&
       prev.style === span.style &&
+      prev.language === span.language &&
       // Blockquotes are container blocks. Adjacent blockquote spans should not merge or
       // consecutive blockquotes can "style bleed" across the paragraph boundary.
       (span.start < prev.end || (span.start === prev.end && span.style !== "blockquote"))
@@ -912,6 +932,7 @@ function sliceStyleSpans(
       start: bounds.start - start,
       end: bounds.end - start,
       style: span.style,
+      ...(span.language ? { language: span.language } : {}),
     });
   }
   return mergeStyleSpans(sliced);

--- a/src/markdown/render-aware-chunking.ts
+++ b/src/markdown/render-aware-chunking.ts
@@ -215,7 +215,12 @@ function mergeAdjacentStyleSpans(styles: MarkdownStyleSpan[]): MarkdownStyleSpan
   const merged: MarkdownStyleSpan[] = [];
   for (const span of styles) {
     const last = merged.at(-1);
-    if (last && last.style === span.style && span.start <= last.end) {
+    if (
+      last &&
+      last.style === span.style &&
+      last.language === span.language &&
+      span.start <= last.end
+    ) {
       last.end = Math.max(last.end, span.end);
       continue;
     }

--- a/src/markdown/render.ts
+++ b/src/markdown/render.ts
@@ -1,7 +1,7 @@
 import type { MarkdownIR, MarkdownLinkSpan, MarkdownStyle, MarkdownStyleSpan } from "./ir.js";
 
 export type RenderStyleMarker = {
-  open: string;
+  open: string | ((span: MarkdownStyleSpan) => string);
   close: string;
 };
 
@@ -151,9 +151,10 @@ export function renderMarkdownWithMarkers(ir: MarkdownIR, options: RenderOptions
         if (!marker) {
           continue;
         }
+        const open = typeof marker.open === "function" ? marker.open(span) : marker.open;
         openingItems.push({
           end: span.end,
-          open: marker.open,
+          open,
           close: marker.close,
           kind: "style",
           style: span.style,


### PR DESCRIPTION
## Summary
- Preserve fenced code block language metadata in the shared Markdown IR.
- Allow render markers to compute opening tags from a style span.
- Render Telegram fenced code blocks as `<pre><code class="language-X">` when the fence language is Telegram-safe, while keeping unlabelled/invalid fences unchanged.

## Tests
- RED: `OPENCLAW_VITEST_INCLUDE_FILE=.tmp-vitest-include.json node --no-maglev ./node_modules/vitest/vitest.mjs --config test/vitest/vitest.extension-telegram.config.ts --run` failed with the new Telegram language-class expectation before implementation.
- GREEN: `OPENCLAW_VITEST_INCLUDE_FILE=.tmp-vitest-include.json node --no-maglev ./node_modules/vitest/vitest.mjs --config test/vitest/vitest.extension-telegram.config.ts --run`
- `./node_modules/.bin/oxfmt --check --threads=1 extensions/telegram/src/format.ts extensions/telegram/src/format.test.ts src/markdown/ir.ts src/markdown/render.ts src/markdown/render-aware-chunking.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/markdown/ir.ts src/markdown/render.ts src/markdown/render-aware-chunking.ts`
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/telegram/src/format.ts extensions/telegram/src/format.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo`

Behavior addressed: Telegram Markdown fenced code blocks now preserve safe language identifiers in the generated HTML code tag.
Real environment tested: Local checkout on macOS with targeted Telegram extension Vitest config.
Exact steps or command run after this patch: Targeted Telegram format Vitest, oxfmt check, core/extensions oxlint, core/extensions tsgo.
Evidence after fix: `extensions/telegram/src/format.test.ts` passed 29 tests and the new assertion expects `<pre><code class="language-js">`.
Observed result after fix: Fenced ` ```js ` input renders with `class="language-js"` for Telegram native copy support.
What was not tested: Live Telegram Bot API delivery/UI rendering.

Closes #10519
