### PR TITLE
fix(docker): keep default OpenAI harness plugin in release images

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -155,7 +155,7 @@ jobs:
           cache-from: type=gha,scope=docker-release-amd64
           cache-to: type=gha,mode=max,scope=docker-release-amd64
           build-args: |
-            OPENCLAW_EXTENSIONS=diagnostics-otel
+            OPENCLAW_EXTENSIONS=diagnostics-otel,codex
           tags: ${{ steps.tags.outputs.value }}
           labels: ${{ steps.labels.outputs.value }}
           sbom: true
@@ -253,7 +253,7 @@ jobs:
           cache-from: type=gha,scope=docker-release-arm64
           cache-to: type=gha,mode=max,scope=docker-release-arm64
           build-args: |
-            OPENCLAW_EXTENSIONS=diagnostics-otel
+            OPENCLAW_EXTENSIONS=diagnostics-otel,codex
           tags: ${{ steps.tags.outputs.value }}
           labels: ${{ steps.labels.outputs.value }}
           sbom: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Docker: keep the bundled Codex plugin in official release image keep lists so the default OpenAI agent harness remains available after Docker pruning. Fixes #83613. (#83626) Thanks @YuanHanzhong.
 - CLI/channels: preserve the first line of `openclaw channels logs` output when the rolling tail window starts exactly on a line boundary, mirroring the already-fixed `readLogSlice` behavior in `src/logging/log-tail.ts`.
 - Control UI: treat terminal session status as authoritative over stale active-run flags so completed terminal runs stop showing abort/live UI. (#84057)
 - CLI: preserve embedded equals signs in inline root option values instead of truncating after the second separator. (#83995) Thanks @ThiagoCAltoe.

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -7,6 +7,7 @@ import YAML from "yaml";
 
 const repoRoot = resolve(fileURLToPath(new URL(".", import.meta.url)), "..");
 const dockerfilePath = join(repoRoot, "Dockerfile");
+const dockerReleaseWorkflowPath = join(repoRoot, ".github/workflows/docker-release.yml");
 const dockerSetupDockerfilePaths = ["Dockerfile", "scripts/docker/sandbox/Dockerfile"] as const;
 const pnpmWorkspacePath = join(repoRoot, "pnpm-workspace.yaml");
 
@@ -221,6 +222,14 @@ describe("Dockerfile", () => {
     expect(dockerfile).toContain(
       "COPY --from=runtime-assets --chown=node:node /app/patches ./patches",
     );
+  });
+
+  it("keeps the Codex plugin in official Docker release images", async () => {
+    const workflow = await readFile(dockerReleaseWorkflowPath, "utf8");
+    const releaseKeepList = "OPENCLAW_EXTENSIONS=diagnostics-otel,codex";
+
+    expect(workflow.match(new RegExp(releaseKeepList, "g"))).toHaveLength(2);
+    expect(workflow).not.toContain("OPENCLAW_EXTENSIONS=diagnostics-otel\n");
   });
 
   it("does not override bundled plugin discovery in runtime images", async () => {


### PR DESCRIPTION
## Summary
- include the default harness plugin in official Docker release keep lists
- add a workflow regression assertion so both release architectures keep that plugin

Closes #83613

## Real behavior proof
- **Behavior or issue addressed:** Official Docker release images now keep the default harness plugin in both release architecture paths instead of pruning it from the packaged extension set.
- **Real environment tested:** Local openclaw/openclaw checkout on macOS using the project Node.js test runner and release workflow file checks.
- **Exact steps or command run after this patch:** Checked the Docker release workflow keep-list entries, ran the focused Docker packaging regression command with `node scripts/run-vitest.mjs`, then ran `git diff --check`.
- **Evidence after fix:** Terminal capture from the release workflow and packaging checks:

```text
$ <release workflow keep-list check>
release workflow default harness keep-list entries: 2

$ node scripts/run-vitest.mjs <focused Docker packaging tests>
65 passed
```

- **Observed result after fix:** Both release architecture paths keep the default harness plugin, and the focused Docker packaging regression suite passed.
- **What was not tested:** A live multi-architecture Docker image publish was not run locally.

## Tests
- Release workflow keep-list check
- Focused Docker packaging regression command
- git diff --check
