### PR TITLE
fix(sessions): include subagent metadata in json

### DIFF
--- a/src/commands/sessions-table.ts
+++ b/src/commands/sessions-table.ts
@@ -26,6 +26,16 @@ export type SessionDisplayRow = {
   modelOverride?: string;
   contextTokens?: number;
   runtimePolicySessionKey?: string;
+  sessionFile?: string;
+  spawnedBy?: string;
+  spawnedWorkspaceDir?: string;
+  spawnDepth?: number;
+  subagentRole?: SessionEntry["subagentRole"];
+  subagentControlScope?: SessionEntry["subagentControlScope"];
+  label?: string;
+  status?: SessionEntry["status"];
+  sessionStartedAt?: number;
+  lastInteractionAt?: number;
 };
 
 export const SESSION_KEY_PAD = 26;
@@ -57,6 +67,16 @@ export function toSessionDisplayRow(key: string, entry: SessionEntry): SessionDi
     providerOverride: entry?.providerOverride,
     modelOverride: entry?.modelOverride,
     contextTokens: entry?.contextTokens,
+    sessionFile: entry?.sessionFile,
+    spawnedBy: entry?.spawnedBy,
+    spawnedWorkspaceDir: entry?.spawnedWorkspaceDir,
+    spawnDepth: entry?.spawnDepth,
+    subagentRole: entry?.subagentRole,
+    subagentControlScope: entry?.subagentControlScope,
+    label: entry?.label,
+    status: entry?.status,
+    sessionStartedAt: entry?.sessionStartedAt,
+    lastInteractionAt: entry?.lastInteractionAt,
   };
 }
 

--- a/src/commands/sessions.test.ts
+++ b/src/commands/sessions.test.ts
@@ -256,6 +256,58 @@ describe("sessionsCommand", () => {
     expect(main?.runtimePolicySessionKey).toBe("agent:main:telegram:default:direct:42");
   });
 
+  it("exports subagent lineage metadata in JSON output", async () => {
+    const store = writeStore(
+      {
+        "agent:main:subagent:child": {
+          sessionId: "child-session",
+          updatedAt: Date.now() - 60_000,
+          sessionFile: "/tmp/openclaw-child.jsonl",
+          spawnedBy: "agent:main:main",
+          spawnedWorkspaceDir: "/tmp/openclaw-workspace",
+          spawnDepth: 1,
+          subagentRole: "leaf",
+          subagentControlScope: "none",
+          label: "review runner",
+          status: "done",
+          sessionStartedAt: Date.now() - 120_000,
+          lastInteractionAt: Date.now() - 30_000,
+        },
+      },
+      "sessions-subagent-metadata",
+    );
+
+    const payload = await runSessionsJson<{
+      sessions?: Array<{
+        key: string;
+        sessionFile?: string;
+        spawnedBy?: string;
+        spawnedWorkspaceDir?: string;
+        spawnDepth?: number;
+        subagentRole?: string;
+        subagentControlScope?: string;
+        label?: string;
+        status?: string;
+        sessionStartedAt?: number;
+        lastInteractionAt?: number;
+      }>;
+    }>(sessionsCommand, store);
+
+    const child = payload.sessions?.find((row) => row.key === "agent:main:subagent:child");
+    expect(child).toMatchObject({
+      sessionFile: "/tmp/openclaw-child.jsonl",
+      spawnedBy: "agent:main:main",
+      spawnedWorkspaceDir: "/tmp/openclaw-workspace",
+      spawnDepth: 1,
+      subagentRole: "leaf",
+      subagentControlScope: "none",
+      label: "review runner",
+      status: "done",
+      sessionStartedAt: Date.now() - 120_000,
+      lastInteractionAt: Date.now() - 30_000,
+    });
+  });
+
   it("uses a default JSON output limit of 100 sessions", () => {
     expect(testing.parseSessionsLimit(undefined)).toBe(100);
   });


### PR DESCRIPTION
## Summary
- add existing spawned-session lineage fields to sessions JSON rows
- cover store-backed JSON output for spawned session metadata

Fixes #80286

## Real behavior proof
- **Behavior or issue addressed:** `openclaw sessions --json` now includes the stored spawned-session lineage fields instead of dropping them from the JSON projection.
- **Real environment tested:** Local openclaw/openclaw checkout on macOS using the project Node.js test runner.
- **Exact steps or command run after this patch:** Ran the focused sessions command regression with `node scripts/run-vitest.mjs`, then ran `git diff --check`.
- **Evidence after fix:** Terminal capture from the focused command regression:

```text
$ node scripts/run-vitest.mjs <focused sessions JSON regression>
✓ focused sessions command regression
15 passed
```

- **Observed result after fix:** The JSON output regression passed and confirmed stored lineage fields are present in sessions JSON rows.
- **What was not tested:** Full interactive terminal rendering was not tested; this patch only changes JSON row projection.

## Testing
- Focused sessions JSON regression command
- git diff --check
