### PR TITLE
fix(telegram): avoid mirroring progress into active transcripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram: keep verbose tool progress visible without mirroring non-final progress into active session transcripts, preventing embedded provider replies from aborting mid-run. (#83631) Thanks @kurplunkin.
 - CLI: enforce the documented Node.js 22.19 runtime floor in the source launcher.
 - Agents/replies: persist queued follow-up user messages and assistant error stubs only once across model-fallback retries, preventing repeated provider rejections from corrupted same-role session transcripts. Fixes #83404. (#83417) Thanks @yetval.
 - Slack: persist delivered inbound message IDs and fail closed when same-channel thread replies lose their thread context, preventing delayed duplicate replies and accidental channel-root posts. Fixes #83521. Thanks @shannon0430.

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -965,6 +965,55 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
   });
 
+  it("does not mirror non-final tool progress into the session transcript", async () => {
+    const context = createContext();
+    context.ctxPayload.SessionKey = "agent:default:telegram:direct:123";
+    loadSessionStore.mockReturnValue({
+      "agent:default:telegram:direct:123": { sessionId: "s1" },
+    });
+    deliverReplies.mockImplementation(
+      async (params: {
+        replies?: Array<{ text?: string }>;
+        transcriptMirror?: (payload: { text?: string; mediaUrls?: string[] }) => Promise<void>;
+      }) => {
+        const text = params.replies
+          ?.map((reply) => reply.text)
+          .filter(Boolean)
+          .join("\n\n");
+        await params.transcriptMirror?.({ text });
+        return { delivered: true };
+      },
+    );
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "🛠️ tool progress" }, { kind: "tool" });
+      await dispatcherOptions.deliver({ text: "Final answer" }, { kind: "final" });
+      return { queuedFinal: true };
+    });
+
+    await dispatchWithContext({
+      context,
+      streamMode: "partial",
+      cfg: { agents: { defaults: { blockStreamingDefault: "on" } } },
+      telegramCfg: { streaming: { mode: "partial", preview: { toolProgress: true } } },
+    });
+
+    expect(deliverReplies).toHaveBeenCalledTimes(2);
+    expectRecordFields(mockCallArg(deliverReplies, 0), {
+      transcriptMirror: undefined,
+    });
+    expect(typeof mockCallArg(deliverReplies, 1).transcriptMirror).toBe("function");
+    expect(appendSessionTranscriptMessage).toHaveBeenCalledTimes(1);
+    const transcriptCall = expectRecordFields(mockCallArg(appendSessionTranscriptMessage), {
+      transcriptPath: "/tmp/session.jsonl",
+    });
+    expectRecordFields(transcriptCall.message, {
+      role: "assistant",
+      provider: "openclaw",
+      model: "delivery-mirror",
+      content: [{ type: "text", text: "Final answer" }],
+    });
+  });
+
   it("mirrors the longer streamed preview when final text is truncated", async () => {
     const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
     const fullAnswer =

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1092,6 +1092,7 @@ export const dispatchTelegramMessage = async ({
       }
       const result = await (telegramDeps.deliverReplies ?? deliverReplies)({
         ...deliveryBaseOptions,
+        transcriptMirror: options?.durable ? deliveryBaseOptions.transcriptMirror : undefined,
         replies: [deliverablePayload],
         onVoiceRecording: sendRecordVoice,
         silent,


### PR DESCRIPTION
## Summary

- Problem: Telegram verbose/tool progress deliveries were mirrored into the active session transcript before the agent finished.
- Why it matters: generic embedded providers can release the prompt lock while running; those mid-run transcript writes can look like a session takeover and abort the reply before the final answer.
- What changed: non-final Telegram deliveries still go to chat, but only durable/final deliveries receive `transcriptMirror` and append to the session transcript.
- What did NOT change: final assistant replies still mirror into the transcript, Telegram verbose/tool progress still appears in the chat, and provider/runtime behavior is otherwise unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Telegram verbose/tool progress could mutate the active session transcript while an embedded provider run was in progress, producing `EmbeddedAttemptSessionTakeoverError` before the final reply.
- Real environment tested: private Linux OpenClaw Telegram gateway, wired to this branch, using `minimax/MiniMax-M2.7` in Telegram.
- Exact steps or command run after this patch:
  1. Restarted the Telegram gateway against this branch's built `dist/entry.js`.
  2. In Telegram, used `/new`, enabled verbose mode, selected `minimax/MiniMax-M2.7`.
  3. Sent a tool-heavy research prompt.
  4. Confirmed Telegram showed tool progress and then the final answer.
  5. Checked the new session transcript for `delivery-mirror` entries from tool progress.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):
  Redacted runtime log / copied live output from a private OpenClaw Telegram run:

  ```text
  2026-05-18 13:22 UTC: Telegram gateway running this PR branch handled a clean /new session.
  Session: [redacted]
  Model/provider: minimax/MiniMax-M2.7
  User prompt: [redacted tool-heavy research prompt]
  Observed Telegram output: tool progress messages delivered, then the final assistant answer delivered.
  Error check: no EmbeddedAttemptSessionTakeoverError and no "session file changed while embedded prompt lock was released" failure.
  Transcript check: rg delivery-mirror against the clean session transcript returned no non-final tool-progress delivery-mirror entries.
  Follow-up prompt in the same clean MiniMax session also completed successfully.
  ```
- Observed result after fix: non-final tool/progress messages were visible in Telegram, final assistant output was delivered, and the embedded session did not abort from a session file takeover.
- What was not tested: every embedded provider. The failure was reproduced with MiniMax and the fix is provider-agnostic at the Telegram delivery boundary.
- Before evidence (optional but encouraged): clean upstream-main Telegram test with MiniMax reproduced `Agent failed before reply: session file changed while embedded prompt lock was released ... Please try again, or use /new to start a fresh session.`

## Root Cause (if applicable)

- Root cause: Telegram's direct delivery path passed `transcriptMirror` to `deliverReplies` for non-final progress/tool payloads. In verbose mode, those payloads could append `openclaw/delivery-mirror` assistant messages into the active transcript while a generic embedded provider run had released its prompt lock.
- Missing detection / guardrail: existing Telegram dispatch coverage asserted final preview mirroring, but did not assert that non-final tool/progress deliveries must not mutate the active transcript.
- Contributing context (if known): Codex-runtime sessions did not consistently expose the issue, but MiniMax via the generic embedded runtime did.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/telegram/src/bot-message-dispatch.test.ts`
- Scenario the test should lock in: a Telegram tool/progress delivery has no `transcriptMirror`, while the final delivery still mirrors into the session transcript.
- Why this is the smallest reliable guardrail: the bug lived at the Telegram dispatch boundary where `sendPayload` chooses whether to pass `transcriptMirror` to direct delivery.
- Existing test that already covers this (if any): final preview mirroring coverage existed, but not the non-final negative case.
- If no new test is added, why not: N/A, this PR adds the missing regression test.

## User-visible / Behavior Changes

Telegram verbose/tool progress remains visible in chat, but non-final progress messages are no longer stored as assistant transcript messages. Final assistant replies continue to be mirrored.

## Diagram (if applicable)

```text
Before:
Telegram verbose tool progress -> deliverReplies(transcriptMirror) -> active transcript mutation -> embedded prompt-lock takeover

After:
Telegram verbose tool progress -> deliverReplies(no transcriptMirror) -> chat-only progress
Final assistant reply -> durable/final delivery -> transcript mirror
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux VPS
- Runtime/container: Node.js gateway from this branch's built `dist/entry.js`
- Model/provider: `minimax/MiniMax-M2.7`
- Integration/channel (if any): Telegram
- Relevant config (redacted): Telegram verbose enabled, Telegram streaming partial with tool progress previews, block streaming enabled

### Steps

1. Reproduce on upstream main with MiniMax in a fresh Telegram session and verbose mode enabled.
2. Run the same fresh-session MiniMax Telegram flow on this branch.
3. Inspect the active session transcript for non-final `delivery-mirror` entries.

### Expected

- Telegram shows verbose tool/progress messages and then the final answer.
- Non-final progress does not append transcript mirror messages.
- The embedded provider run does not fail with session takeover.

### Actual

- Matches expected on this branch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation run:

```text
node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts extensions/telegram/src/bot-message-dispatch.test.ts
corepack pnpm exec vitest run --config test/vitest/vitest.extension-telegram.config.ts extensions/telegram
corepack pnpm exec oxfmt --check --threads=1 extensions/telegram/src/bot-message-dispatch.ts extensions/telegram/src/bot-message-dispatch.test.ts
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.extensions.json extensions/telegram/src/bot-message-dispatch.ts extensions/telegram/src/bot-message-dispatch.test.ts
corepack pnpm tsgo:extensions:test
NODE_OPTIONS=--max-old-space-size=8192 corepack pnpm build
codex review --base origin/main
```

Results:

```text
Telegram extension lane: 119 test files passed, 1779 tests passed
Touched-file oxlint: 0 warnings, 0 errors
Codex review: no correctness issue found
```

Note: full `pnpm check` on this VPS reached preflight and typecheck, then `oxlint-tsgolint` was SIGKILLed during the repo-wide lint phase even with serialized lint shards. Touched-file lint and the full Telegram extension lane passed.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: MiniMax Telegram verbose flow with a clean `/new` session; tool progress plus final answer delivered without session-lock failure.
- Edge cases checked: final assistant replies still mirror into the transcript; non-final tool progress does not receive `transcriptMirror`.
- What you did **not** verify: every other embedded provider; full repo-wide `pnpm check` lint on this VPS due local SIGKILL described above.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Some debugging workflow might have implicitly relied on non-final Telegram progress being appended as assistant transcript messages.
  - Mitigation: final assistant transcript mirroring remains unchanged; verbose progress remains visible in Telegram; avoiding active transcript mutation protects provider sessions from false takeover failures.

## AI-assisted disclosure

This PR was prepared with Codex assistance. I understand the code change: it limits transcript mirroring to durable/final Telegram deliveries so UI progress does not mutate the active session while an embedded provider run is in flight.

