### PR TITLE
fix(slack): persist inbound delivery dedupe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/replies: persist queued follow-up user messages and assistant error stubs only once across model-fallback retries, preventing repeated provider rejections from corrupted same-role session transcripts. Fixes #83404. (#83417) Thanks @yetval.
+- Slack: persist delivered inbound message IDs and fail closed when same-channel thread replies lose their thread context, preventing delayed duplicate replies and accidental channel-root posts. Fixes #83521. Thanks @shannon0430.
 - Gateway/config: keep config writes from failing on unrelated unresolved auth-profile SecretRefs while preserving live auth-profile runtime snapshots.
 - Gateway/sessions: clear stored CLI provider resume bindings on non-subagent `/reset` so the next turn starts a fresh provider-side CLI conversation instead of resuming old context. (#83448) Thanks @jasonyliu.
 - Discord/OpenAI: keep realtime Discord voice sessions hearing follow-up turns with OpenAI realtime and prebuffer assistant playback to avoid choppy starts. (#80505) Thanks @Solvely-Colin.

--- a/extensions/slack/src/action-runtime.test.ts
+++ b/extensions/slack/src/action-runtime.test.ts
@@ -148,6 +148,41 @@ describe("handleSlackAction", () => {
     expectLastSlackSend("Second", params.cfg);
   }
 
+  it("fails closed for same-channel sends from thread-required contexts with no thread ts", async () => {
+    const cfg = slackConfig();
+    sendSlackMessage.mockClear();
+
+    await expect(
+      handleSlackAction(
+        { action: "sendMessage", to: "channel:C123", content: "keep private" },
+        cfg,
+        {
+          currentChannelId: "C123",
+          replyToMode: "all",
+          sameChannelThreadRequired: true,
+        },
+      ),
+    ).rejects.toThrow("Slack thread context is required");
+    expect(sendSlackMessage).not.toHaveBeenCalled();
+  });
+
+  it("allows explicit top-level sends from thread-required contexts", async () => {
+    const cfg = slackConfig();
+    sendSlackMessage.mockClear();
+
+    await handleSlackAction(
+      { action: "sendMessage", to: "channel:C123", content: "root", topLevel: true },
+      cfg,
+      {
+        currentChannelId: "C123",
+        replyToMode: "all",
+        sameChannelThreadRequired: true,
+      },
+    );
+
+    expectLastSlackSend("root", cfg);
+  });
+
   async function resolveReadToken(cfg: OpenClawConfig): Promise<string | undefined> {
     readSlackMessages.mockClear();
     readSlackMessages.mockResolvedValueOnce({ messages: [], hasMore: false });

--- a/extensions/slack/src/action-runtime.ts
+++ b/extensions/slack/src/action-runtime.ts
@@ -93,6 +93,8 @@ export type SlackActionContext = {
   replyToMode?: "off" | "first" | "all" | "batched";
   /** Mutable ref to track if a reply was sent for single-use reply modes. */
   hasRepliedRef?: { value: boolean };
+  /** True when same-channel root posting would leak a thread-originated reply. */
+  sameChannelThreadRequired?: boolean;
   /** Allowed local media directories for file uploads. */
   mediaLocalRoots?: readonly string[];
   mediaReadFile?: (filePath: string) => Promise<Buffer>;
@@ -117,13 +119,20 @@ function resolveThreadTsFromContext(
   if (opts?.suppressImplicitThread) {
     return undefined;
   }
-  // No context or missing required fields
-  if (!context?.currentThreadTs || !context?.currentChannelId) {
+  if (!context?.currentChannelId) {
     return undefined;
   }
 
   // Different channel - don't inject
   if (!sameSlackChannelTarget(targetChannel, context.currentChannelId)) {
+    return undefined;
+  }
+  if (!context.currentThreadTs) {
+    if (context.sameChannelThreadRequired) {
+      throw new Error(
+        "Slack thread context is required for same-channel replies from a threaded Slack turn. Set topLevel=true or threadId=null to post at the channel root.",
+      );
+    }
     return undefined;
   }
 

--- a/extensions/slack/src/action-threading.test.ts
+++ b/extensions/slack/src/action-threading.test.ts
@@ -6,6 +6,7 @@ type SlackThreadingToolContext = {
   currentThreadTs?: string;
   replyToMode?: "off" | "first" | "all" | "batched";
   hasRepliedRef?: { value: boolean };
+  sameChannelThreadRequired?: boolean;
 };
 
 function createToolContext(
@@ -78,5 +79,17 @@ describe("resolveSlackAutoThreadId", () => {
         toolContext: createToolContext({ currentThreadTs: undefined }),
       }),
     ).toBeUndefined();
+  });
+
+  it("fails closed for same-channel threaded replies when the thread timestamp is missing", () => {
+    expect(() =>
+      resolveSlackAutoThreadId({
+        to: "C123",
+        toolContext: createToolContext({
+          currentThreadTs: undefined,
+          sameChannelThreadRequired: true,
+        }),
+      }),
+    ).toThrow("Slack thread context is required");
   });
 });

--- a/extensions/slack/src/action-threading.ts
+++ b/extensions/slack/src/action-threading.ts
@@ -9,13 +9,11 @@ export function resolveSlackAutoThreadId(params: {
     currentThreadTs?: string;
     replyToMode?: "off" | "first" | "all" | "batched";
     hasRepliedRef?: { value: boolean };
+    sameChannelThreadRequired?: boolean;
   };
 }): string | undefined {
   const context = params.toolContext;
-  if (!context?.currentThreadTs || !context.currentChannelId) {
-    return undefined;
-  }
-  if (context.replyToMode !== "all" && !isSingleUseReplyToMode(context.replyToMode ?? "off")) {
+  if (!context?.currentChannelId) {
     return undefined;
   }
   const parsedTarget = parseSlackTarget(params.to, { defaultKind: "channel" });
@@ -26,6 +24,17 @@ export function resolveSlackAutoThreadId(params: {
     normalizeLowercaseStringOrEmpty(parsedTarget.id) !==
     normalizeLowercaseStringOrEmpty(context.currentChannelId)
   ) {
+    return undefined;
+  }
+  if (!context.currentThreadTs) {
+    if (context.sameChannelThreadRequired) {
+      throw new Error(
+        "Slack thread context is required for same-channel replies from a threaded Slack turn. Set topLevel=true or threadId=null to post at the channel root.",
+      );
+    }
+    return undefined;
+  }
+  if (context.replyToMode !== "all" && !isSingleUseReplyToMode(context.replyToMode ?? "off")) {
     return undefined;
   }
   if (isSingleUseReplyToMode(context.replyToMode ?? "off") && context.hasRepliedRef?.value) {

--- a/extensions/slack/src/monitor/inbound-delivery-state.test.ts
+++ b/extensions/slack/src/monitor/inbound-delivery-state.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { clearSlackRuntime, setSlackRuntime } from "../runtime.js";
+import type { SlackMessageEvent } from "../types.js";
+import {
+  clearSlackInboundDeliveryStateForTest,
+  hasSlackInboundMessageDelivery,
+  recordSlackInboundMessageDeliveries,
+} from "./inbound-delivery-state.js";
+
+describe("slack inbound delivery state", () => {
+  afterEach(() => {
+    clearSlackInboundDeliveryStateForTest();
+    clearSlackRuntime();
+    vi.restoreAllMocks();
+  });
+
+  function message(channel: string, ts: string): SlackMessageEvent {
+    return { type: "message", channel, ts, text: "hello" };
+  }
+
+  it("records every delivered debounced source message", async () => {
+    const register = vi.fn().mockResolvedValue(undefined);
+    setSlackRuntime({
+      state: {
+        openKeyedStore: vi.fn(() => ({
+          register,
+          lookup: vi.fn(),
+          consume: vi.fn(),
+          delete: vi.fn(),
+          entries: vi.fn(),
+          clear: vi.fn(),
+        })),
+      },
+      logging: { getChildLogger: () => ({ warn: vi.fn() }) },
+    } as never);
+
+    await recordSlackInboundMessageDeliveries({
+      accountId: "A1",
+      messages: [message("C1", "100.001"), message("C1", "100.002")],
+    });
+
+    expect(register).toHaveBeenCalledTimes(2);
+    expect(register).toHaveBeenCalledWith("A1:C1:100.001", {
+      deliveredAt: expect.any(Number),
+    });
+    expect(register).toHaveBeenCalledWith("A1:C1:100.002", {
+      deliveredAt: expect.any(Number),
+    });
+  });
+
+  it("scopes duplicate checks by account", async () => {
+    await recordSlackInboundMessageDeliveries({
+      accountId: "A1",
+      messages: [message("C1", "100.001")],
+    });
+
+    await expect(
+      hasSlackInboundMessageDelivery({
+        accountId: "A1",
+        channelId: "C1",
+        ts: "100.001",
+      }),
+    ).resolves.toBe(true);
+    await expect(
+      hasSlackInboundMessageDelivery({
+        accountId: "A2",
+        channelId: "C1",
+        ts: "100.001",
+      }),
+    ).resolves.toBe(false);
+  });
+});

--- a/extensions/slack/src/monitor/inbound-delivery-state.ts
+++ b/extensions/slack/src/monitor/inbound-delivery-state.ts
@@ -1,0 +1,148 @@
+import { resolveGlobalDedupeCache } from "openclaw/plugin-sdk/dedupe-runtime";
+import { getOptionalSlackRuntime } from "../runtime.js";
+import type { SlackMessageEvent } from "../types.js";
+
+const TTL_MS = 24 * 60 * 60 * 1000;
+const MAX_ENTRIES = 20_000;
+const PERSISTENT_MAX_ENTRIES = 20_000;
+const PERSISTENT_NAMESPACE = "slack.inbound-deliveries";
+const SLACK_INBOUND_DELIVERIES_KEY = Symbol.for("openclaw.slackInboundDeliveries");
+
+type SlackInboundDeliveryRecord = {
+  deliveredAt: number;
+};
+
+type SlackInboundDeliveryStore = {
+  register(
+    key: string,
+    value: SlackInboundDeliveryRecord,
+    opts?: { ttlMs?: number },
+  ): Promise<void>;
+  lookup(key: string): Promise<SlackInboundDeliveryRecord | undefined>;
+};
+
+const deliveredMessages = resolveGlobalDedupeCache(SLACK_INBOUND_DELIVERIES_KEY, {
+  ttlMs: TTL_MS,
+  maxSize: MAX_ENTRIES,
+});
+
+let persistentStore: SlackInboundDeliveryStore | undefined;
+let persistentStoreDisabled = false;
+
+function makeKey(accountId: string, channelId: string, ts: string): string {
+  return `${accountId}:${channelId}:${ts}`;
+}
+
+function reportPersistentInboundDeliveryError(error: unknown): void {
+  try {
+    getOptionalSlackRuntime()
+      ?.logging.getChildLogger({ plugin: "slack", feature: "inbound-delivery-state" })
+      .warn("Slack persistent inbound delivery state failed", { error: String(error) });
+  } catch {
+    // Best effort only: persistent state must never break Slack message handling.
+  }
+}
+
+function disablePersistentInboundDelivery(error: unknown): void {
+  persistentStoreDisabled = true;
+  persistentStore = undefined;
+  reportPersistentInboundDeliveryError(error);
+}
+
+function getPersistentInboundDeliveryStore(): SlackInboundDeliveryStore | undefined {
+  if (persistentStoreDisabled) {
+    return undefined;
+  }
+  if (persistentStore) {
+    return persistentStore;
+  }
+  const runtime = getOptionalSlackRuntime();
+  if (!runtime) {
+    return undefined;
+  }
+  try {
+    persistentStore = runtime.state.openKeyedStore<SlackInboundDeliveryRecord>({
+      namespace: PERSISTENT_NAMESPACE,
+      maxEntries: PERSISTENT_MAX_ENTRIES,
+      defaultTtlMs: TTL_MS,
+    });
+    return persistentStore;
+  } catch (error) {
+    disablePersistentInboundDelivery(error);
+    return undefined;
+  }
+}
+
+async function lookupPersistentInboundDelivery(key: string): Promise<boolean> {
+  const store = getPersistentInboundDeliveryStore();
+  if (!store) {
+    return false;
+  }
+  try {
+    return Boolean(await store.lookup(key));
+  } catch (error) {
+    disablePersistentInboundDelivery(error);
+    return false;
+  }
+}
+
+async function rememberPersistentInboundDelivery(key: string, deliveredAt: number): Promise<void> {
+  const store = getPersistentInboundDeliveryStore();
+  if (!store) {
+    return;
+  }
+  try {
+    await store.register(key, { deliveredAt });
+  } catch (error) {
+    disablePersistentInboundDelivery(error);
+  }
+}
+
+export async function hasSlackInboundMessageDelivery(params: {
+  accountId: string;
+  channelId: string | undefined;
+  ts: string | undefined;
+}): Promise<boolean> {
+  if (!params.accountId || !params.channelId || !params.ts) {
+    return false;
+  }
+  const key = makeKey(params.accountId, params.channelId, params.ts);
+  if (deliveredMessages.peek(key)) {
+    return true;
+  }
+  const found = await lookupPersistentInboundDelivery(key);
+  if (found) {
+    deliveredMessages.check(key);
+  }
+  return found;
+}
+
+export async function recordSlackInboundMessageDeliveries(params: {
+  accountId: string;
+  messages: readonly SlackMessageEvent[];
+}): Promise<void> {
+  if (!params.accountId || params.messages.length === 0) {
+    return;
+  }
+  const deliveredAt = Date.now();
+  const keys = new Set<string>();
+  for (const message of params.messages) {
+    if (!message.channel || !message.ts) {
+      continue;
+    }
+    keys.add(makeKey(params.accountId, message.channel, message.ts));
+  }
+  if (keys.size === 0) {
+    return;
+  }
+  for (const key of keys) {
+    deliveredMessages.check(key, deliveredAt);
+  }
+  await Promise.all(Array.from(keys, (key) => rememberPersistentInboundDelivery(key, deliveredAt)));
+}
+
+export function clearSlackInboundDeliveryStateForTest(): void {
+  deliveredMessages.clear();
+  persistentStore = undefined;
+  persistentStoreDisabled = false;
+}

--- a/extensions/slack/src/monitor/message-handler.app-mention-race.test.ts
+++ b/extensions/slack/src/monitor/message-handler.app-mention-race.test.ts
@@ -58,6 +58,9 @@ vi.mock("./message-handler/dispatch.js", () => ({
 
 let createSlackMessageHandler: typeof import("./message-handler.js").createSlackMessageHandler;
 let SlackRetryableInboundError: typeof import("./message-handler.js").SlackRetryableInboundError;
+let clearSlackInboundDeliveryStateForTest: typeof import("./inbound-delivery-state.js").clearSlackInboundDeliveryStateForTest;
+let clearSlackRuntime: typeof import("../runtime.js").clearSlackRuntime;
+let setSlackRuntime: typeof import("../runtime.js").setSlackRuntime;
 
 function createMarkMessageSeen() {
   const seen = new Set<string>();
@@ -137,11 +140,15 @@ describe("createSlackMessageHandler app_mention race handling", () => {
   beforeAll(async () => {
     ({ createSlackMessageHandler, SlackRetryableInboundError } =
       await import("./message-handler.js"));
+    ({ clearSlackInboundDeliveryStateForTest } = await import("./inbound-delivery-state.js"));
+    ({ clearSlackRuntime, setSlackRuntime } = await import("../runtime.js"));
   });
 
   beforeEach(() => {
     prepareSlackMessageMock.mockReset();
     dispatchPreparedSlackMessageMock.mockReset();
+    clearSlackInboundDeliveryStateForTest();
+    clearSlackRuntime();
   });
 
   it("allows a single app_mention retry when message event was dropped before dispatch", async () => {
@@ -228,6 +235,39 @@ describe("createSlackMessageHandler app_mention race handling", () => {
     );
     await sendMessageEvent(handler, "1700000000.000300");
 
+    expect(prepareSlackMessageMock).toHaveBeenCalledTimes(1);
+    expect(dispatchPreparedSlackMessageMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("dedupes delayed app_mention replays after in-memory seen state is gone", async () => {
+    const stored = new Map<string, unknown>();
+    const register = vi.fn(async (key: string, value: unknown) => {
+      stored.set(key, value);
+    });
+    const lookup = vi.fn(async (key: string) => stored.get(key));
+    setSlackRuntime({
+      state: {
+        openKeyedStore: vi.fn(() => ({
+          register,
+          lookup,
+          consume: vi.fn(),
+          delete: vi.fn(),
+          entries: vi.fn(),
+          clear: vi.fn(),
+        })),
+      },
+      logging: { getChildLogger: () => ({ warn: vi.fn() }) },
+    } as never);
+    prepareSlackMessageMock.mockResolvedValue({ ctxPayload: {} });
+
+    await sendMessageEvent(createTestHandler(), "1700000000.000350");
+    clearSlackInboundDeliveryStateForTest();
+    await sendMentionEvent(createTestHandler(), "1700000000.000350");
+
+    expect(register).toHaveBeenCalledWith("default:C1:1700000000.000350", {
+      deliveredAt: expect.any(Number),
+    });
+    expect(lookup).toHaveBeenCalledWith("default:C1:1700000000.000350");
     expect(prepareSlackMessageMock).toHaveBeenCalledTimes(1);
     expect(dispatchPreparedSlackMessageMock).toHaveBeenCalledTimes(1);
   });

--- a/extensions/slack/src/monitor/message-handler.ts
+++ b/extensions/slack/src/monitor/message-handler.ts
@@ -8,6 +8,10 @@ import type { SlackMessageEvent } from "../types.js";
 import { stripSlackMentionsForCommandDetection } from "./commands.js";
 import type { SlackMonitorContext } from "./context.js";
 import {
+  hasSlackInboundMessageDelivery,
+  recordSlackInboundMessageDeliveries,
+} from "./inbound-delivery-state.js";
+import {
   buildSlackDebounceKey,
   buildTopLevelSlackConversationKey,
 } from "./message-handler/debounce-key.js";
@@ -138,7 +142,21 @@ export function createSlackMessageHandler(params: {
             prepared.ctxPayload.MessageSidLast = ids[ids.length - 1];
           }
         }
-        await dispatchPreparedSlackMessage(prepared);
+        try {
+          await dispatchPreparedSlackMessage(prepared);
+          await recordSlackInboundMessageDeliveries({
+            accountId: ctx.accountId,
+            messages: entries.map((entry) => entry.message),
+          });
+        } catch (error) {
+          if (!(error instanceof SlackRetryableInboundError)) {
+            await recordSlackInboundMessageDeliveries({
+              accountId: ctx.accountId,
+              messages: entries.map((entry) => entry.message),
+            });
+          }
+          throw error;
+        }
       } catch (error) {
         if (error instanceof SlackRetryableInboundError) {
           if (seenMessageKey) {
@@ -201,6 +219,16 @@ export function createSlackMessageHandler(params: {
       return;
     }
     const seenMessageKey = buildSeenMessageKey(message.channel, message.ts);
+    if (
+      seenMessageKey &&
+      (await hasSlackInboundMessageDelivery({
+        accountId: ctx.accountId,
+        channelId: message.channel,
+        ts: message.ts,
+      }))
+    ) {
+      return;
+    }
     const wasSeen = seenMessageKey ? ctx.markMessageSeen(message.channel, message.ts) : false;
     if (seenMessageKey && opts.source === "message" && !wasSeen) {
       // Prime exactly one fallback app_mention allowance immediately so a near-simultaneous

--- a/extensions/slack/src/threading-tool-context.test.ts
+++ b/extensions/slack/src/threading-tool-context.test.ts
@@ -141,6 +141,7 @@ describe("buildSlackThreadingToolContext", () => {
 
     expect(result.currentThreadTs).toBe("1771999998.834199");
     expect(result.replyToMode).toBe("all");
+    expect(result.sameChannelThreadRequired).toBe(true);
   });
 
   it("uses TransportThreadId when ReplyToId matches the current message", () => {
@@ -164,6 +165,7 @@ describe("buildSlackThreadingToolContext", () => {
 
     expect(result.currentThreadTs).toBe("1771999998.834199");
     expect(result.replyToMode).toBe("all");
+    expect(result.sameChannelThreadRequired).toBe(true);
   });
 
   it("keeps top-level ReplyToId as an anchor without forcing configured off mode", () => {
@@ -186,6 +188,7 @@ describe("buildSlackThreadingToolContext", () => {
 
     expect(result.currentThreadTs).toBe("1771999998.834199");
     expect(result.replyToMode).toBe("off");
+    expect(result.sameChannelThreadRequired).toBe(false);
   });
 
   it("keeps top-level ReplyToId as the first-reply anchor for single-use modes", () => {

--- a/extensions/slack/src/threading-tool-context.ts
+++ b/extensions/slack/src/threading-tool-context.ts
@@ -39,5 +39,6 @@ export function buildSlackThreadingToolContext(params: {
     currentThreadTs,
     replyToMode: effectiveReplyToMode,
     hasRepliedRef: params.hasRepliedRef,
+    sameChannelThreadRequired: hasExplicitThreadTarget,
   };
 }

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -103,6 +103,8 @@ export function createOpenClawTools(
     replyToMode?: "off" | "first" | "all" | "batched";
     /** Mutable ref to track if a reply was sent (for "first" mode). */
     hasRepliedRef?: { value: boolean };
+    /** Fail closed instead of posting same-channel thread-originated replies at the root. */
+    sameChannelThreadRequired?: boolean;
     /** If true, the model has native vision capability */
     modelHasVision?: boolean;
     /** Active model provider for provider-specific tool gating. */
@@ -299,6 +301,7 @@ export function createOpenClawTools(
         currentMessageId: options?.currentMessageId,
         replyToMode: options?.replyToMode,
         hasRepliedRef: options?.hasRepliedRef,
+        sameChannelThreadRequired: options?.sameChannelThreadRequired,
         sandboxRoot: options?.sandboxRoot,
         requireExplicitTarget: options?.requireExplicitMessageTarget,
         sourceReplyDeliveryMode: options?.sourceReplyDeliveryMode,

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -551,6 +551,7 @@ type MessageToolOptions = {
   currentMessageId?: string | number;
   replyToMode?: "off" | "first" | "all" | "batched";
   hasRepliedRef?: { value: boolean };
+  sameChannelThreadRequired?: boolean;
   sandboxRoot?: string;
   requireExplicitTarget?: boolean;
   sourceReplyDeliveryMode?: SourceReplyDeliveryMode;
@@ -1008,7 +1009,8 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
         currentThreadTs ||
         hasCurrentMessageId ||
         replyToMode ||
-        options?.hasRepliedRef
+        options?.hasRepliedRef ||
+        options?.sameChannelThreadRequired
           ? {
               currentChannelId: effectiveCurrentChannel.currentChannelId,
               currentChannelProvider: effectiveCurrentChannel.currentChannelProvider,
@@ -1016,6 +1018,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
               currentMessageId: options?.currentMessageId,
               replyToMode,
               hasRepliedRef: options?.hasRepliedRef,
+              sameChannelThreadRequired: options?.sameChannelThreadRequired,
               // Direct tool invocations should not add cross-context decoration.
               // The agent is composing a message, not forwarding from another chat.
               skipCrossContextDecoration: true,

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -467,6 +467,8 @@ export type ChannelThreadingToolContext = {
   currentMessageId?: string | number;
   replyToMode?: "off" | "first" | "all" | "batched";
   hasRepliedRef?: { value: boolean };
+  /** True when posting at the parent conversation root would leak a thread-originated reply. */
+  sameChannelThreadRequired?: boolean;
   /**
    * When true, skip cross-context decoration (e.g., "[from X]" prefix).
    * Use this for direct tool invocations where the agent is composing a new message,


### PR DESCRIPTION
Summary
- add a Slack inbound delivery ledger backed by plugin state so delivered message IDs survive delayed Slack app_mention/message replays and restarts
- propagate a Slack thread-required context flag through message tools and fail closed instead of posting same-channel thread replies at the channel root when thread context is missing
- add focused Slack regression coverage and changelog entry

Fixes #83521

## Real behavior proof
Behavior addressed: Slack duplicate inbound app_mention/message replays and same-channel thread-origin sends with missing thread context.
Real environment tested: local source checkout on macOS plus Blacksmith Testbox Linux changed gate.
Exact steps or command run after this patch: node scripts/run-vitest.mjs extensions/slack/src/monitor/message-handler.app-mention-race.test.ts extensions/slack/src/monitor/inbound-delivery-state.test.ts extensions/slack/src/action-threading.test.ts extensions/slack/src/action-runtime.test.ts extensions/slack/src/threading-tool-context.test.ts src/agents/tools/message-tool.test.ts src/auto-reply/reply/agent-runner-utils.test.ts
Evidence after fix: terminal output from the focused post-patch run:
```text
Test Files 8 passed (8)
Tests 202 passed (202)
```
Blacksmith Testbox changed gate: tbx_01krxq1vbetzgqdd5f4fs5v39h exited 0 after running core, coreTests, extensions, extensionTests, and docs lanes.
Observed result after fix: delayed duplicate Slack deliveries are skipped from persistent delivery state; same-channel Slack sends from thread-required contexts throw unless topLevel/threadId null opts out.
What was not tested: live Slack Events API delivery; covered with handler/runtime regression tests and Testbox changed gate.

Additional proof
- pnpm check:changed delegated to Testbox tbx_01krxq1vbetzgqdd5f4fs5v39h, exit 0
- codex review --uncommitted: no discrete correctness issues found; its attempted nested pnpm test was blocked by sandbox EPERM, so local run-vitest and Testbox proof above are authoritative
