### PR TITLE
fix(transcript): skip trailing custom entries in tail assistant reader (#83427)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Sessions: skip trailing custom transcript entries when checking tail assistant replies so embedded CLI gap-fill does not duplicate canonical assistant output. (#83635) Thanks @yaoyi1222.
 - Telegram: keep verbose tool progress visible without mirroring non-final progress into active session transcripts, preventing embedded provider replies from aborting mid-run. (#83631) Thanks @kurplunkin.
 - CLI: enforce the documented Node.js 22.19 runtime floor in the source launcher.
 - Agents/replies: persist queued follow-up user messages and assistant error stubs only once across model-fallback retries, preventing repeated provider rejections from corrupted same-role session transcripts. Fixes #83404. (#83417) Thanks @yetval.

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -685,6 +685,77 @@ describe("CLI attempt execution", () => {
     expect(validEntries.filter((entry) => entry.type === "message")).toHaveLength(1);
   });
 
+  it("embedded assistant gap-fill skips trailing openclaw.cache-ttl custom entries (regression for #83427)", async () => {
+    const sessionKey = "agent:main:subagent:embedded-gap-fill-cache-ttl";
+    const sessionEntry: SessionEntry = {
+      sessionId: "session-embedded-gap-fill-cache-ttl",
+      updatedAt: Date.now(),
+    };
+    const sessionStore: Record<string, SessionEntry> = { [sessionKey]: sessionEntry };
+    await fs.writeFile(storePath, JSON.stringify(sessionStore, null, 2), "utf-8");
+
+    const result = makeCliResult("canonical answer");
+    result.meta.executionTrace = {
+      winnerProvider: "anthropic",
+      winnerModel: "claude-haiku-4-5-20251001",
+      fallbackUsed: false,
+      runner: "embedded",
+    };
+
+    const updatedFirst = await persistCliTurnTranscript({
+      body: "ignored for gap fill",
+      result,
+      sessionId: sessionEntry.sessionId,
+      sessionKey,
+      sessionEntry,
+      sessionStore,
+      storePath,
+      sessionAgentId: "main",
+      sessionCwd: tmpDir,
+      config: {},
+      embeddedAssistantGapFill: true,
+    });
+    const sessionFile = updatedFirst?.sessionFile;
+    if (typeof sessionFile !== "string") {
+      throw new Error("Expected CLI transcript session file.");
+    }
+
+    await fs.appendFile(
+      sessionFile,
+      `${JSON.stringify({
+        type: "custom",
+        customType: "openclaw.cache-ttl",
+        timestamp: new Date().toISOString(),
+        data: {
+          provider: "anthropic",
+          modelId: "claude-haiku-4-5-20251001",
+        },
+      })}\n`,
+      "utf-8",
+    );
+
+    await persistCliTurnTranscript({
+      body: "still ignored",
+      result,
+      sessionId: sessionEntry.sessionId,
+      sessionKey,
+      sessionEntry: updatedFirst,
+      sessionStore,
+      storePath,
+      sessionAgentId: "main",
+      sessionCwd: tmpDir,
+      config: {},
+      embeddedAssistantGapFill: true,
+    });
+
+    const messages = await readSessionMessages(sessionFile);
+    expect(messages).toHaveLength(1);
+    expectRecordFields(requireRecord(messages[0], "assistant message"), {
+      role: "assistant",
+      content: [{ type: "text", text: "canonical answer" }],
+    });
+  });
+
   it("embedded assistant gap-fill appends repeated replies after a user tail", async () => {
     const sessionKey = "agent:main:subagent:embedded-repeated-reply";
     const sessionEntry: SessionEntry = {

--- a/src/config/sessions/transcript.test.ts
+++ b/src/config/sessions/transcript.test.ts
@@ -381,6 +381,46 @@ describe("appendAssistantMessageToSessionTranscript", () => {
     expect(tailAssistantText?.text).toBe("Tail delivery mirror");
   });
 
+  it("scans past trailing non-assistant entries (e.g. openclaw.cache-ttl) to find the latest assistant text", async () => {
+    // Regression for openclaw/openclaw#83427: the cache-ttl custom entry was
+    // emitted after the canonical assistant turn, and the tail reader returned
+    // undefined on the first non-assistant line, so the gap-fill check in
+    // persistTextTurnTranscript wrote a duplicate `api: "cli"` assistant
+    // message — poisoning the model's own context with verbatim duplicates.
+    writeTranscriptStore();
+
+    const assistantResult = await appendExactAssistantMessageToSessionTranscript({
+      sessionKey,
+      storePath: fixture.storePath(),
+      message: createExactAssistantMessage({
+        text: "Canonical answer",
+        provider: "anthropic",
+        model: "claude-haiku-4-5-20251001",
+      }),
+    });
+    expect(assistantResult.ok).toBe(true);
+    if (!assistantResult.ok) {
+      return;
+    }
+
+    const cacheTtlEntry = `${JSON.stringify({
+      type: "custom",
+      customType: "openclaw.cache-ttl",
+      timestamp: new Date().toISOString(),
+      data: {
+        provider: "anthropic",
+        modelId: "claude-haiku-4-5-20251001",
+      },
+    })}\n`;
+    fs.appendFileSync(assistantResult.sessionFile, cacheTtlEntry, "utf-8");
+
+    const tailAssistantText = await readTailAssistantTextFromSessionTranscript(
+      assistantResult.sessionFile,
+    );
+    expect(tailAssistantText?.id).toBe(assistantResult.messageId);
+    expect(tailAssistantText?.text).toBe("Canonical answer");
+  });
+
   it("does not reuse an older matching assistant message across turns", async () => {
     writeTranscriptStore();
 

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -194,6 +194,16 @@ export async function readTailAssistantTextFromSessionTranscript(
 
   for await (const line of streamSessionTranscriptLinesReverse(sessionFile)) {
     try {
+      const parsed = JSON.parse(line) as { message?: unknown };
+      // Skip non-message entries (e.g. `openclaw.cache-ttl` custom events) so
+      // a metadata line emitted after the canonical assistant turn doesn't
+      // make the tail reader fall through to "no assistant tail" and cause
+      // persistTextTurnTranscript to append a duplicate. Stop at any real
+      // message entry — a user turn means a new turn has started and a
+      // matching reply is a legitimate repeat, not a gap-fill duplicate.
+      if (!parsed.message || typeof parsed.message !== "object") {
+        continue;
+      }
       return parseAssistantTranscriptText(line);
     } catch {
       continue;


### PR DESCRIPTION
Fixes #83427.

## Summary

The `openclaw.cache-ttl` custom event is written immediately after each assistant turn. The downstream tail reader, `readTailAssistantTextFromSessionTranscript`, was returning `undefined` on the very first line it saw — and that line was the cache-ttl entry, not the assistant turn — so `persistTextTurnTranscript`'s gap-fill check decided there was no recent reply and appended one. That's the `api: "cli"` duplicate at event 61 in the issue.

The fix is in the tail reader: skip lines that don't carry a `message` object (custom events, metadata) and keep walking back. Stop on the first real message entry — a user turn means a new turn has started and an assistant repeat there is legitimate, not a gap-fill duplicate. The canonical assistant turn at event 59 is now found correctly, gap-fill stays quiet, no duplicate gets written.

I considered the report's Option A (don't persist the mirror at all) but went with this because it's the root cause of the gap-fill misfire and keeps the delivery-mirror path intact for the cases that legitimately need it (see existing "Tail delivery mirror" coverage).

AI-assisted (Claude Code).

## Verification

- `node scripts/run-vitest.mjs src/config/sessions/transcript.test.ts src/agents/command/attempt-execution.cli.test.ts` — 79/79 pass, including two new regression tests that name #83427
- `node scripts/run-oxlint.mjs` on the three touched files — 0 warnings, 0 errors
- `oxfmt --check` on the three touched files — clean
- `pnpm tsgo:core` — clean

### Real behavior proof

- **Behavior addressed:** CLI delivery path was appending a second `role: "assistant"` (`api: "cli"`) entry after every turn, which then fed back into the next prompt's messages snapshot and produced the verbatim self-repetition documented in #83427.
- **Real environment tested:** macOS Darwin 24.6.0, Node v25.8.2, OpenClaw 2026.5.17 built locally from this PR branch (8bdba85). State isolated under `~/.openclaw-dev/` via the `--dev` profile. Provider: custom anthropic-messages endpoint at `https://api.deepseek.com/anthropic` with model `deepseek-v4-pro` (provider-agnostic — the patch only reads session JSONL). Cache-ttl mode enabled via `agents.defaults.contextPruning.mode = "cache-ttl"`. Embedded runner (`runner: "embedded"`) on every attempt — matches the issue's repro precondition.
- **Exact steps or command run after this patch:**
  1. `pnpm openclaw --dev config patch --file <deepseek-provider.json5>` — configures provider with `api: "anthropic-messages"`, `baseUrl: "https://api.deepseek.com/anthropic"`, plus `agents.defaults.contextPruning.mode = "cache-ttl"`.
  2. `pnpm openclaw --dev agents add proof83427 --workspace /tmp/openclaw-83427-ws --model deepseek/deepseek-v4-pro --non-interactive`
  3. `DEEPSEEK_API_KEY=<redacted> pnpm openclaw --dev agent --agent proof83427 --session-id proof83427-s1 --message "Reply with exactly the phrase: turn N ok" --json` — repeated for `N ∈ {one, two, three}` against the same session id.
- **Evidence after fix:** session JSONL at `~/.openclaw-dev/agents/proof83427/sessions/proof83427-s1.jsonl` (excerpt below, only `message` + `openclaw.cache-ttl` entries shown, structure preserved, ids redacted to short form):

  ```jsonl
  {"type":"message","message":{"role":"user","content":[{"type":"text","text":"Reply with exactly the phrase: turn one ok"}]}}
  {"type":"message","message":{"role":"assistant","content":[{"type":"text","text":"turn one ok"}],"api":"anthropic-messages","provider":"deepseek","model":"deepseek-v4-pro","stopReason":"stop"}}
  {"type":"custom","customType":"openclaw.cache-ttl","data":{"provider":"deepseek","modelId":"deepseek-v4-pro"}}
  {"type":"message","message":{"role":"user","content":[{"type":"text","text":"Reply with exactly the phrase: turn two ok"}]}}
  {"type":"message","message":{"role":"assistant","content":[{"type":"text","text":"turn two ok"}],"api":"anthropic-messages","provider":"deepseek","model":"deepseek-v4-pro","stopReason":"stop"}}
  {"type":"custom","customType":"openclaw.cache-ttl","data":{"provider":"deepseek","modelId":"deepseek-v4-pro"}}
  {"type":"message","message":{"role":"user","content":[{"type":"text","text":"Reply with exactly the phrase: turn three ok"}]}}
  {"type":"message","message":{"role":"assistant","content":[{"type":"text","text":"turn three ok"}],"api":"anthropic-messages","provider":"deepseek","model":"deepseek-v4-pro","stopReason":"stop"}}
  {"type":"custom","customType":"openclaw.cache-ttl","data":{"provider":"deepseek","modelId":"deepseek-v4-pro"}}
  ```

- **Observed result after fix:**
  - 3 user turns sent → 3 canonical assistant messages (all `api: "anthropic-messages"`) + 3 `openclaw.cache-ttl` custom entries.
  - **Zero** messages with `api: "cli"`. The duplicate-emit pattern reported in #83427 is absent.
  - `grep -c '"api":"cli"' proof83427-s1.jsonl` → `0`.
  - `grep -c '"role":"assistant"' proof83427-s1.jsonl` → `3` (one per user turn, no duplicates).
  - Cache-ttl path was actively exercised end-to-end: turn 2 `cacheRead=23040`, turn 3 `cacheRead=23040` (prompt cache hits), confirming the cache-ttl branch ran and emitted the custom entries that would have triggered the bug without this patch.
  - Regression tests added in this PR (`attempt-execution.cli.test.ts:687`, `transcript.test.ts`) fail on the unpatched code with `Expected: <uuid> Received: undefined` — verified during PR prep by stashing the source change and re-running.
- **What was not tested:**
  - The full 15-turn cascade described in the issue (Solarnote team's `claude-haiku-4-5-20251001` setup). Three turns are sufficient to demonstrate the per-turn write path; the in-generation 4× repetition cascade is a consequence of the per-turn duplicate, which is suppressed at the source here.
  - Direct `anthropic` provider against `api.anthropic.com` with `claude-haiku-4-5-20251001` (used a custom anthropic-messages endpoint due to local credentials); the patched tail-reader logic is provider-agnostic — it only reads the session JSONL emitted by the embedded runner.

