### PR TITLE
fix(codex): harden app-server timeout recovery

### DIFF
--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -245,6 +245,11 @@ function createAppServerHarness(
     requests.push({ method, params });
     return requestImpl(method, params);
   });
+  const close = vi.fn(() => {
+    for (const handler of closeHandlers) {
+      handler();
+    }
+  });
 
   setCodexAppServerClientFactoryForTest(async (_startOptions, authProfileId, agentDir) => {
     options.onStart?.(authProfileId, agentDir);
@@ -262,6 +267,7 @@ function createAppServerHarness(
         closeHandlers.add(handler);
         return () => closeHandlers.delete(handler);
       },
+      close,
     } as never;
   });
 
@@ -1925,6 +1931,7 @@ describe("runCodexAppServerAttempt", () => {
 
   it("closes the app-server client when the active turn goes idle past the attempt timeout", async () => {
     const close = vi.fn();
+    const onRunAgentEvent = vi.fn();
     const request = vi.fn(async (method: string) => {
       if (method === "thread/start") {
         return threadStartResult("thread-1");
@@ -1950,7 +1957,8 @@ describe("runCodexAppServerAttempt", () => {
       path.join(tempDir, "session.jsonl"),
       path.join(tempDir, "workspace"),
     );
-    params.timeoutMs = 250;
+    params.timeoutMs = 100;
+    params.onAgentEvent = onRunAgentEvent;
 
     const result = await runCodexAppServerAttempt(params);
 
@@ -1968,6 +1976,18 @@ describe("runCodexAppServerAttempt", () => {
       { timeoutMs: 5_000 },
     );
     expect(close).toHaveBeenCalledTimes(1);
+    expect(onRunAgentEvent).toHaveBeenCalledWith({
+      stream: "codex_app_server.lifecycle",
+      data: expect.objectContaining({
+        phase: "turn_timeout_client_retired",
+        threadId: "thread-1",
+        turnId: "turn-1",
+        reason: "turn_progress_idle_timeout",
+        timeoutMs: 100,
+        clearedSharedClient: false,
+        closedNonCurrentClient: true,
+      }),
+    });
     expect(queueActiveRunMessageForTest("session-1", "after timeout")).toBe(false);
   });
 
@@ -7469,6 +7489,115 @@ describe("runCodexAppServerAttempt", () => {
       ["thread/resume"],
       ["thread/resume", "turn/start"],
     ]);
+  });
+
+  it("reports exhausted startup close retries when the failed client is no longer shared", async () => {
+    const sessionFile = path.join(tempDir, "session.jsonl");
+    const workspaceDir = path.join(tempDir, "workspace");
+    await writeExistingBinding(sessionFile, workspaceDir, { dynamicToolsFingerprint: "[]" });
+    const warn = vi.spyOn(embeddedAgentLog, "warn").mockImplementation(() => undefined);
+    const onRunAgentEvent = vi.fn();
+    const requests: string[][] = [];
+    let closeCount = 0;
+    let starts = 0;
+    setCodexAppServerClientFactoryForTest(async () => {
+      starts += 1;
+      const methods: string[] = [];
+      requests.push(methods);
+      return {
+        request: vi.fn(async (method: string) => {
+          methods.push(method);
+          if (method === "thread/resume") {
+            throw new Error("codex app-server client is closed");
+          }
+          return {};
+        }),
+        close: () => {
+          closeCount += 1;
+        },
+        addNotificationHandler: () => () => undefined,
+        addRequestHandler: () => () => undefined,
+      } as never;
+    });
+    const params = createParams(sessionFile, workspaceDir);
+    params.onAgentEvent = onRunAgentEvent;
+
+    await expect(runCodexAppServerAttempt(params)).rejects.toThrow(
+      "codex app-server client is closed",
+    );
+
+    expect(starts).toBe(3);
+    expect(closeCount).toBe(3);
+    expect(requests).toEqual([["thread/resume"], ["thread/resume"], ["thread/resume"]]);
+    expect(warn).toHaveBeenCalledWith(
+      "codex app-server connection closed during startup; restarting app-server and retrying",
+      expect.objectContaining({
+        attempt: 1,
+        nextAttempt: 2,
+        maxAttempts: 3,
+        clearedSharedClient: false,
+        closedNonCurrentClient: true,
+      }),
+    );
+    expect(warn).toHaveBeenCalledWith(
+      "codex app-server connection closed during startup; restarting app-server and retrying",
+      expect.objectContaining({
+        attempt: 2,
+        nextAttempt: 3,
+        maxAttempts: 3,
+        clearedSharedClient: false,
+        closedNonCurrentClient: true,
+      }),
+    );
+    expect(warn).toHaveBeenCalledWith(
+      "codex app-server connection closed during startup; retries exhausted",
+      expect.objectContaining({
+        attempt: 3,
+        maxAttempts: 3,
+        clearedSharedClient: false,
+        closedNonCurrentClient: true,
+      }),
+    );
+    const lifecycleEvents = onRunAgentEvent.mock.calls.map(([event]) => event) as Array<{
+      data?: {
+        attempt?: number;
+        closedNonCurrentClient?: boolean;
+        failureClass?: string;
+        phase?: string;
+      };
+      stream?: string;
+    }>;
+    expect(lifecycleEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          stream: "codex_app_server.lifecycle",
+          data: expect.objectContaining({
+            phase: "startup_retry",
+            attempt: 1,
+            failureClass: "app_server_client_closed",
+            closedNonCurrentClient: true,
+          }),
+        }),
+        expect.objectContaining({
+          stream: "codex_app_server.lifecycle",
+          data: expect.objectContaining({
+            phase: "startup_retry",
+            attempt: 2,
+            failureClass: "app_server_client_closed",
+            closedNonCurrentClient: true,
+          }),
+        }),
+        expect.objectContaining({
+          stream: "codex_app_server.lifecycle",
+          data: expect.objectContaining({
+            phase: "startup_retries_exhausted",
+            attempt: 3,
+            failureClass: "app_server_client_closed",
+            closedNonCurrentClient: true,
+          }),
+        }),
+      ]),
+    );
   });
 
   it("passes native hook relay config on thread start and resume", async () => {

--- a/extensions/codex/src/app-server/run-attempt.ts
+++ b/extensions/codex/src/app-server/run-attempt.ts
@@ -134,7 +134,11 @@ import {
   type CodexAppServerThreadBinding,
 } from "./session-binding.js";
 import { readCodexMirroredSessionHistoryMessages } from "./session-history.js";
-import { clearSharedCodexAppServerClientIfCurrent } from "./shared-client.js";
+import {
+  createIsolatedCodexAppServerClient,
+  retainSharedCodexAppServerClient,
+  retireSharedCodexAppServerClient,
+} from "./shared-client.js";
 import {
   areCodexDynamicToolFingerprintsCompatible,
   buildDeveloperInstructions,
@@ -762,6 +766,7 @@ export async function runCodexAppServerAttempt(
   } = {},
 ): Promise<EmbeddedRunAttemptResult> {
   const attemptStartedAt = Date.now();
+  const hasCustomClientFactory = options.clientFactory !== undefined;
   const attemptClientFactory = options.clientFactory ?? defaultCodexAppServerClientFactory;
   const pluginConfig = readCodexPluginConfig(options.pluginConfig);
   const configuredAppServer = resolveCodexAppServerRuntimeOptions({ pluginConfig });
@@ -1121,6 +1126,8 @@ export async function runCodexAppServerAttempt(
   });
   let client: CodexAppServerClient;
   let thread: CodexAppServerThreadLifecycleBinding;
+  let clientIsolated = false;
+  let releaseSharedClientLease: (() => void) | undefined;
   let trajectoryEndRecorded = false;
   let nativeHookRelay: NativeHookRelayRegistrationHandle | undefined;
   let startupClientForCleanup: CodexAppServerClient | undefined;
@@ -1199,18 +1206,33 @@ export async function runCodexAppServerAttempt(
             approvalPolicy: withMcpElicitationsApprovalPolicy(appServer.approvalPolicy),
           }
         : appServer;
-    ({ client, thread } = await withCodexStartupTimeout({
+    ({
+      client,
+      thread,
+      isolated: clientIsolated,
+    } = await withCodexStartupTimeout({
       timeoutMs: startupTimeoutMs,
       signal: runAbortController.signal,
       operation: async () => {
         let attemptedClient: CodexAppServerClient | undefined;
+        let attemptedClientIsolated = false;
+        let isolateAfterStartupClose = false;
         const startupAttempt = async () => {
-          const startupClient = await attemptClientFactory(
-            appServer.start,
-            startupAuthProfileId,
-            agentDir,
-            params.config,
-          );
+          const useIsolatedRetry = isolateAfterStartupClose && !hasCustomClientFactory;
+          attemptedClientIsolated = useIsolatedRetry;
+          const startupClient = useIsolatedRetry
+            ? await createIsolatedCodexAppServerClient({
+                startOptions: appServer.start,
+                authProfileId: startupAuthProfileId,
+                agentDir,
+                config: params.config,
+              })
+            : await attemptClientFactory(
+                appServer.start,
+                startupAuthProfileId,
+                agentDir,
+                params.config,
+              );
           attemptedClient = startupClient;
           startupClientForCleanup = startupClient;
           await ensureCodexComputerUse({
@@ -1257,7 +1279,7 @@ export async function runCodexAppServerAttempt(
             }) satisfies Parameters<typeof startOrResumeThread>[0];
           restartContextEngineCodexThread = () => startOrResumeThread(buildThreadLifecycleParams());
           const startupThread = await startOrResumeThread(buildThreadLifecycleParams());
-          return { client: startupClient, thread: startupThread };
+          return { client: startupClient, thread: startupThread, isolated: useIsolatedRetry };
         };
         for (
           let attempt = 1;
@@ -1274,30 +1296,58 @@ export async function runCodexAppServerAttempt(
               throw error;
             }
             const failedClient = attemptedClient;
-            const clearedSharedClient = clearSharedCodexAppServerClientIfCurrent(failedClient);
+            const retirement = retireCodexAppServerClient(failedClient);
             if (startupClientForCleanup === failedClient) {
               startupClientForCleanup = undefined;
             }
             attemptedClient = undefined;
+            isolateAfterStartupClose = true;
             if (attempt >= CODEX_APP_SERVER_STARTUP_CONNECTION_CLOSE_MAX_ATTEMPTS) {
+              emitCodexAppServerEvent(params, {
+                stream: "codex_app_server.lifecycle",
+                data: {
+                  phase: "startup_retries_exhausted",
+                  attempt,
+                  maxAttempts: CODEX_APP_SERVER_STARTUP_CONNECTION_CLOSE_MAX_ATTEMPTS,
+                  failureClass: "app_server_client_closed",
+                  isolatedRetry: attemptedClientIsolated,
+                  ...retirement,
+                },
+              });
               embeddedAgentLog.warn(
                 "codex app-server connection closed during startup; retries exhausted",
                 {
                   attempt,
                   maxAttempts: CODEX_APP_SERVER_STARTUP_CONNECTION_CLOSE_MAX_ATTEMPTS,
-                  clearedSharedClient,
+                  isolatedRetry: attemptedClientIsolated,
+                  ...retirement,
                   error: formatErrorMessage(error),
                 },
               );
               throw error;
             }
+            emitCodexAppServerEvent(params, {
+              stream: "codex_app_server.lifecycle",
+              data: {
+                phase: "startup_retry",
+                attempt,
+                nextAttempt: attempt + 1,
+                maxAttempts: CODEX_APP_SERVER_STARTUP_CONNECTION_CLOSE_MAX_ATTEMPTS,
+                failureClass: "app_server_client_closed",
+                nextAttemptIsolated: !hasCustomClientFactory,
+                isolatedRetry: attemptedClientIsolated,
+                ...retirement,
+              },
+            });
             embeddedAgentLog.warn(
               "codex app-server connection closed during startup; restarting app-server and retrying",
               {
                 attempt,
                 nextAttempt: attempt + 1,
                 maxAttempts: CODEX_APP_SERVER_STARTUP_CONNECTION_CLOSE_MAX_ATTEMPTS,
-                clearedSharedClient,
+                nextAttemptIsolated: !hasCustomClientFactory,
+                isolatedRetry: attemptedClientIsolated,
+                ...retirement,
                 error: formatErrorMessage(error),
               },
             );
@@ -1306,6 +1356,9 @@ export async function runCodexAppServerAttempt(
         throw new Error("codex app-server startup retry loop exited unexpectedly");
       },
     }));
+    releaseSharedClientLease = clientIsolated
+      ? () => client.close()
+      : retainSharedCodexAppServerClient(client);
     startupClientForCleanup = undefined;
     emitCodexAppServerEvent(params, {
       stream: "codex_app_server.lifecycle",
@@ -1313,8 +1366,9 @@ export async function runCodexAppServerAttempt(
     });
   } catch (error) {
     nativeHookRelay?.unregister();
-    clearSharedCodexAppServerClientIfCurrent(startupClientForCleanup);
+    retireCodexAppServerClient(startupClientForCleanup);
     params.abortSignal?.removeEventListener("abort", abortFromUpstream);
+    releaseSharedClientLease?.();
     throw error;
   }
   trajectoryRecorder?.recordEvent("session.started", {
@@ -2463,10 +2517,21 @@ export async function runCodexAppServerAttempt(
       timeoutMs: shouldRetireClient ? CODEX_APP_SERVER_INTERRUPT_TIMEOUT_MS : undefined,
     });
     if (shouldRetireClient) {
-      retireCodexAppServerClientAfterTimedOutTurn(client, {
+      const retirement = retireCodexAppServerClientAfterTimedOutTurn(client, {
         threadId: thread.threadId,
         turnId: activeTurnId,
         reason: String(runAbortController.signal.reason ?? "timeout"),
+      });
+      emitCodexAppServerEvent(params, {
+        stream: "codex_app_server.lifecycle",
+        data: {
+          phase: "turn_timeout_client_retired",
+          threadId: thread.threadId,
+          turnId: activeTurnId,
+          reason: String(runAbortController.signal.reason ?? "timeout"),
+          timeoutMs: params.timeoutMs,
+          ...retirement,
+        },
       });
     }
     resolveCompletion?.();
@@ -2667,6 +2732,7 @@ export async function runCodexAppServerAttempt(
     params.abortSignal?.removeEventListener("abort", abortFromUpstream);
     steeringQueue?.cancel();
     clearActiveEmbeddedRun(params.sessionId, handle, params.sessionKey);
+    releaseSharedClientLease?.();
   }
 }
 
@@ -2987,6 +3053,19 @@ function interruptCodexTurnBestEffort(
   }
 }
 
+function retireCodexAppServerClient(client: CodexAppServerClient | undefined): {
+  clearedSharedClient: boolean;
+  closedNonCurrentClient: boolean;
+  deferredSharedClientRetirement: boolean;
+} {
+  const retirement = retireSharedCodexAppServerClient(client);
+  return {
+    clearedSharedClient: retirement.clearedSharedClient,
+    closedNonCurrentClient: !retirement.clearedSharedClient && retirement.closedClient,
+    deferredSharedClientRetirement: retirement.deferredSharedClientRetirement,
+  };
+}
+
 function retireCodexAppServerClientAfterTimedOutTurn(
   client: CodexAppServerClient,
   params: {
@@ -2994,20 +3073,19 @@ function retireCodexAppServerClientAfterTimedOutTurn(
     turnId: string;
     reason: string;
   },
-): void {
-  const clearedSharedClient = clearSharedCodexAppServerClientIfCurrent(client);
-  if (!clearedSharedClient) {
-    const close = (client as { close?: () => void }).close;
-    if (typeof close === "function") {
-      close.call(client);
-    }
-  }
+): {
+  clearedSharedClient: boolean;
+  closedNonCurrentClient: boolean;
+  deferredSharedClientRetirement: boolean;
+} {
+  const retirement = retireCodexAppServerClient(client);
   embeddedAgentLog.warn("codex app-server client retired after timed-out turn", {
     threadId: params.threadId,
     turnId: params.turnId,
     reason: params.reason,
-    clearedSharedClient,
+    ...retirement,
   });
+  return retirement;
 }
 
 type DynamicToolBuildParams = {

--- a/extensions/codex/src/app-server/shared-client.test.ts
+++ b/extensions/codex/src/app-server/shared-client.test.ts
@@ -42,6 +42,8 @@ let clearSharedCodexAppServerClientIfCurrent: typeof import("./shared-client.js"
 let clearSharedCodexAppServerClientIfCurrentAndWait: typeof import("./shared-client.js").clearSharedCodexAppServerClientIfCurrentAndWait;
 let createIsolatedCodexAppServerClient: typeof import("./shared-client.js").createIsolatedCodexAppServerClient;
 let getSharedCodexAppServerClient: typeof import("./shared-client.js").getSharedCodexAppServerClient;
+let retainSharedCodexAppServerClient: typeof import("./shared-client.js").retainSharedCodexAppServerClient;
+let retireSharedCodexAppServerClient: typeof import("./shared-client.js").retireSharedCodexAppServerClient;
 let resetSharedCodexAppServerClientForTests: typeof import("./shared-client.js").resetSharedCodexAppServerClientForTests;
 
 async function sendInitializeResult(
@@ -115,6 +117,8 @@ describe("shared Codex app-server client", () => {
       clearSharedCodexAppServerClientIfCurrentAndWait,
       createIsolatedCodexAppServerClient,
       getSharedCodexAppServerClient,
+      retainSharedCodexAppServerClient,
+      retireSharedCodexAppServerClient,
       resetSharedCodexAppServerClientForTests,
     } = await import("./shared-client.js"));
   });
@@ -173,6 +177,51 @@ describe("shared Codex app-server client", () => {
 
     await expect(secondList).resolves.toEqual({ models: [] });
     expect(startSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears a leased shared app-server immediately but defers closing it until the lease releases", async () => {
+    const first = createClientHarness();
+    const second = createClientHarness();
+    const startSpy = vi
+      .spyOn(CodexAppServerClient, "start")
+      .mockReturnValueOnce(first.client)
+      .mockReturnValueOnce(second.client);
+
+    const firstClientPromise = getSharedCodexAppServerClient({ timeoutMs: 1000 });
+    await sendInitializeResult(first, "openclaw/0.125.0 (macOS; test)");
+    const firstClient = await firstClientPromise;
+    const release = retainSharedCodexAppServerClient(firstClient);
+
+    expect(retireSharedCodexAppServerClient(firstClient)).toEqual({
+      clearedSharedClient: true,
+      closedClient: false,
+      deferredSharedClientRetirement: true,
+    });
+    expect(first.process.stdin.destroyed).toBe(false);
+
+    const secondClientPromise = getSharedCodexAppServerClient({ timeoutMs: 1000 });
+    await sendInitializeResult(second, "openclaw/0.125.0 (macOS; test)");
+    const secondClient = await secondClientPromise;
+    expect(secondClient).toBe(second.client);
+    expect(startSpy).toHaveBeenCalledTimes(2);
+
+    release();
+    expect(first.process.stdin.destroyed).toBe(true);
+    expect(second.process.stdin.destroyed).toBe(false);
+  });
+
+  it("tolerates retiring a non-current app-server client without close", () => {
+    const client = {
+      request: vi.fn(),
+      addNotificationHandler: () => () => undefined,
+      addRequestHandler: () => () => undefined,
+    } as never;
+
+    expect(retireSharedCodexAppServerClient(client)).toEqual({
+      clearedSharedClient: false,
+      closedClient: false,
+      deferredSharedClientRetirement: false,
+    });
   });
 
   it("does not wait for isolated initialize after a timeout closes the client", async () => {

--- a/extensions/codex/src/app-server/shared-client.ts
+++ b/extensions/codex/src/app-server/shared-client.ts
@@ -20,11 +20,15 @@ type SharedCodexAppServerClientEntry = {
 
 type SharedCodexAppServerClientState = {
   clients: Map<string, SharedCodexAppServerClientEntry>;
+  leases?: WeakMap<CodexAppServerClient, number>;
+  retireWhenIdle?: WeakSet<CodexAppServerClient>;
 };
 
 type LegacySharedCodexAppServerClientState = Partial<SharedCodexAppServerClientEntry> & {
   key?: string;
   clients?: unknown;
+  leases?: WeakMap<CodexAppServerClient, number>;
+  retireWhenIdle?: WeakSet<CodexAppServerClient>;
 };
 
 const SHARED_CODEX_APP_SERVER_CLIENT_STATE = Symbol.for("openclaw.codexAppServerClientState");
@@ -46,7 +50,11 @@ function getSharedCodexAppServerClientState(): SharedCodexAppServerClientState {
       clearSharedClientEntryIfCurrent(legacyKey, closedClient),
     );
   }
-  const nextState: SharedCodexAppServerClientState = { clients };
+  const nextState: SharedCodexAppServerClientState = {
+    clients,
+    leases: legacyState?.leases,
+    retireWhenIdle: legacyState?.retireWhenIdle,
+  };
   globalState[SHARED_CODEX_APP_SERVER_CLIENT_STATE] = nextState;
   return nextState;
 }
@@ -190,12 +198,16 @@ export async function createIsolatedCodexAppServerClient(options?: {
 export function resetSharedCodexAppServerClientForTests(): void {
   const state = getSharedCodexAppServerClientState();
   state.clients.clear();
+  state.leases = new WeakMap();
+  state.retireWhenIdle = new WeakSet();
 }
 
 export function clearSharedCodexAppServerClient(): void {
   const state = getSharedCodexAppServerClientState();
   const clients = collectSharedClients(state);
   state.clients.clear();
+  state.leases = new WeakMap();
+  state.retireWhenIdle = new WeakSet();
   for (const client of clients) {
     client.close();
   }
@@ -211,6 +223,8 @@ export function clearSharedCodexAppServerClientIfCurrent(
   for (const [key, entry] of state.clients) {
     if (entry.client === client) {
       state.clients.delete(key);
+      state.leases?.delete(client);
+      state.retireWhenIdle?.delete(client);
       client.close();
       return true;
     }
@@ -232,11 +246,89 @@ export async function clearSharedCodexAppServerClientIfCurrentAndWait(
   for (const [key, entry] of state.clients) {
     if (entry.client === client) {
       state.clients.delete(key);
+      state.leases?.delete(client);
+      state.retireWhenIdle?.delete(client);
       await client.closeAndWait(options);
       return true;
     }
   }
   return false;
+}
+
+export function retainSharedCodexAppServerClient(
+  client: CodexAppServerClient | undefined,
+): () => void {
+  if (!client) {
+    return () => undefined;
+  }
+  const state = getSharedCodexAppServerClientState();
+  if (!hasSharedClientEntry(state, client)) {
+    return () => undefined;
+  }
+  state.leases ??= new WeakMap();
+  state.retireWhenIdle ??= new WeakSet();
+  state.leases.set(client, (state.leases.get(client) ?? 0) + 1);
+  let released = false;
+  return () => {
+    if (released) {
+      return;
+    }
+    released = true;
+    const currentCount = state.leases?.get(client) ?? 0;
+    if (currentCount <= 1) {
+      state.leases?.delete(client);
+      if (state.retireWhenIdle?.has(client)) {
+        state.retireWhenIdle.delete(client);
+        closeCodexAppServerClientIfAvailable(client);
+      }
+      return;
+    }
+    state.leases?.set(client, currentCount - 1);
+  };
+}
+
+export function retireSharedCodexAppServerClient(client: CodexAppServerClient | undefined): {
+  clearedSharedClient: boolean;
+  closedClient: boolean;
+  deferredSharedClientRetirement: boolean;
+} {
+  if (!client) {
+    return {
+      clearedSharedClient: false,
+      closedClient: false,
+      deferredSharedClientRetirement: false,
+    };
+  }
+  const state = getSharedCodexAppServerClientState();
+  const leaseCount = state.leases?.get(client) ?? 0;
+  const deferClose = leaseCount > 0;
+  const clearedSharedClient = deleteSharedClientEntries(state, client);
+  if (deferClose) {
+    state.retireWhenIdle ??= new WeakSet();
+    state.retireWhenIdle.add(client);
+    return {
+      clearedSharedClient,
+      closedClient: false,
+      deferredSharedClientRetirement: true,
+    };
+  }
+  state.leases?.delete(client);
+  state.retireWhenIdle?.delete(client);
+  const closedClient = closeCodexAppServerClientIfAvailable(client);
+  return {
+    clearedSharedClient,
+    closedClient,
+    deferredSharedClientRetirement: false,
+  };
+}
+
+function closeCodexAppServerClientIfAvailable(client: CodexAppServerClient): boolean {
+  const close = (client as { close?: () => void }).close;
+  if (typeof close !== "function") {
+    return false;
+  }
+  close.call(client);
+  return true;
 }
 
 export async function clearSharedCodexAppServerClientAndWait(options?: {
@@ -246,6 +338,8 @@ export async function clearSharedCodexAppServerClientAndWait(options?: {
   const state = getSharedCodexAppServerClientState();
   const clients = collectSharedClients(state);
   state.clients.clear();
+  state.leases = new WeakMap();
+  state.retireWhenIdle = new WeakSet();
   await Promise.all(clients.map((client) => client.closeAndWait(options)));
 }
 
@@ -267,6 +361,10 @@ function clearSharedClientEntry(key: string, entry: SharedCodexAppServerClientEn
     return;
   }
   state.clients.delete(key);
+  if (entry.client) {
+    state.leases?.delete(entry.client);
+    state.retireWhenIdle?.delete(entry.client);
+  }
   entry.client?.close();
 }
 
@@ -275,7 +373,35 @@ function clearSharedClientEntryIfCurrent(key: string, client: CodexAppServerClie
   const entry = state.clients.get(key);
   if (entry?.client === client) {
     state.clients.delete(key);
+    state.leases?.delete(client);
+    state.retireWhenIdle?.delete(client);
   }
+}
+
+function hasSharedClientEntry(
+  state: SharedCodexAppServerClientState,
+  client: CodexAppServerClient,
+): boolean {
+  for (const entry of state.clients.values()) {
+    if (entry.client === client) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function deleteSharedClientEntries(
+  state: SharedCodexAppServerClientState,
+  client: CodexAppServerClient,
+): boolean {
+  let deleted = false;
+  for (const [key, entry] of state.clients) {
+    if (entry.client === client) {
+      state.clients.delete(key);
+      deleted = true;
+    }
+  }
+  return deleted;
 }
 
 function collectSharedClients(state: SharedCodexAppServerClientState): CodexAppServerClient[] {


### PR DESCRIPTION
## Summary
- harden Codex app-server attempt handling so startup-close and turn-timeout paths retire unsafe shared clients instead of leaking stale client state into later attempts
- add shared-client lease/retirement handling so active attempts are not closed underneath sibling attempts
- add focused coverage for startup retry isolation, deferred retirement, and timeout reason propagation

## Verification
- `git diff --cached --check`
- `NODE_PATH=/home/spryguy/openclaw-workspace/repos/openclaw/node_modules node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts extensions/codex/src/app-server/shared-client.test.ts -- --reporter=verbose`
- focused result: 2 test files passed, 185 tests passed

## Stake and Drift Disclosure
- BOR-reviewed stake base: `1b82c0e3d9b44a22793ddf14a404e6829f710c97`
- Stake branch: `tp09/openclaw-2026-5-17-stake-pr-prep`
- Commit: `bf13d02a97dd0d535bc037b2c2e326a6cfcf192e`
- Receipt: `ops/missions/agent-workforce/openclaw-2026-5-17-stake-pr-prep-receipt-20260518.md`
- At PR creation time, `upstream/main` had advanced to `f0b43bfd34c42398d3825315e4fabff7c0ab60c4`; this is intentionally disclosed per the BOR stake-in-sand rule rather than hidden.

## Changed Files
- `extensions/codex/src/app-server/run-attempt.test.ts`
- `extensions/codex/src/app-server/run-attempt.ts`
- `extensions/codex/src/app-server/shared-client.test.ts`
- `extensions/codex/src/app-server/shared-client.ts`

## Known Proof Gaps
- broad changed-check not run in this stake lane
- build proof not run
- CI had not run before PR creation
- no merge, release, publish, runtime/live retry, production proof, or TP10 closeout is claimed

## Real behavior proof
Behavior addressed: Codex app-server shared client retirement no longer closes an active leased client underneath sibling attempts. This supports the broader timeout/startup-close repair by preventing stale shared client state from being reused or closed while another attempt still owns it.

Real environment tested: Local non-production OpenClaw PR worktree for branch `tp09/openclaw-2026-5-17-stake-pr-prep` at head `bf13d02a97dd0d535bc037b2c2e326a6cfcf192e`, with existing local OpenClaw dependencies linked through `NODE_PATH`.

Exact steps or command run after this patch: `NODE_PATH=/home/spryguy/openclaw-workspace/repos/openclaw/node_modules node --import tsx --input-type=module` executed a local runtime module probe against `extensions/codex/src/app-server/shared-client.ts`.

Evidence after fix: terminal output from the local OpenClaw runtime module probe:

```text
OpenClaw local real-setup evidence capture
repo-head=bf13d02a97dd0d535bc037b2c2e326a6cfcf192e
branch=tp09/openclaw-2026-5-17-stake-pr-prep
changed-behavior=shared Codex app-server client retirement does not close an active leased client underneath sibling attempts
lease-retained closeCount=0
retire-while-leased result={"clearedSharedClient":true,"closedClient":false,"deferredSharedClientRetirement":true} closeCount=0
runtime-log leased-shared-client close invoked; closeCount=1
after-lease-release closeCount=1
runtime-log idle-shared-client close invoked; closeCount=1
retire-idle result={"clearedSharedClient":true,"closedClient":true,"deferredSharedClientRetirement":false} closeCount=1
observed-result=PASS
```

Observed result after fix: Runtime output shows a leased shared Codex app-server client was cleared from the shared map but not closed while its lease was active; it closed exactly once after release. An idle shared client closed immediately. A local dry evaluation of `scripts/github/real-behavior-proof-policy.mjs` against this proposed PR proof returned `status: passed`.

What was not tested: Broad changed-check, build, full CI, merge, release, publish, runtime/live retry, production behavior, production safety, and TP10 closeout.
