### PR TITLE
fix(agents): bypass retry-after at retry cap

### DIFF
--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -990,6 +990,23 @@ describe("buildGuardedModelFetch", () => {
       expect(response.headers.get("x-should-retry")).toBe("false");
     });
 
+    it("bypasses retry-after values equal to the default max wait", async () => {
+      fetchWithSsrFGuardMock.mockResolvedValue({
+        response: new Response(null, {
+          status: 429,
+          headers: { "retry-after": "60" },
+        }),
+        finalUrl: "https://openrouter.ai/api/v1/chat/completions",
+        release: vi.fn(async () => undefined),
+      });
+      const response = await buildGuardedModelFetch(openaiModel)(
+        "https://openrouter.ai/api/v1/chat/completions",
+        { method: "POST" },
+      );
+
+      expect(response.headers.get("x-should-retry")).toBe("false");
+    });
+
     it("injects x-should-retry:false for terminal 429 responses without retry-after", async () => {
       fetchWithSsrFGuardMock.mockResolvedValue({
         response: new Response("Sorry, you've exceeded your weekly rate limit.", {

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -290,7 +290,7 @@ function shouldBypassLongSdkRetry(response: Response): boolean {
 
   const retryAfterSeconds = parseRetryAfterSeconds(response.headers);
   if (retryAfterSeconds !== undefined) {
-    return retryAfterSeconds > maxWaitSeconds;
+    return retryAfterSeconds >= maxWaitSeconds;
   }
 
   return status === 429;


### PR DESCRIPTION
## Summary
- Treat `Retry-After` values equal to `OPENCLAW_SDK_RETRY_MAX_WAIT_SECONDS` as too long for SDK-internal retry sleeps.
- Add a regression test for the OpenRouter-style `Retry-After: 60` boundary so OpenClaw surfaces the 429 immediately for fallback handling.

Fixes #83651

## Audit
- Audit A (existing helper): reused the existing retry-cap path in `provider-transport-fetch.ts`; no new classifier/helper added.
- Audit B (shared callers): `buildGuardedModelFetch` contract preserved; only the retry-cap boundary changes from `>` to `>=`.
- Audit C (broader rival): no exact #83651 PR found; broad model-fallback PRs do not overlap `src/agents/provider-transport-fetch.ts`.

## Validation
- `pnpm test -- src/agents/provider-transport-fetch.test.ts`
- `git diff --check`
- `NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit 2>&1 | rg 'src/agents/provider-transport-fetch' || true`
- `pnpm --config.verify-deps-before-run=false check:changed`
