### PR TITLE
fix(codex): unwrap app-server auth token wrappers

### DIFF
--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -570,6 +570,47 @@ describe("bridgeCodexAppServerStartOptions", () => {
     }
   });
 
+  it("unwraps OpenAI Codex OAuth token wrappers before app-server login", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const request = vi.fn(async () => ({ type: "chatgptAuthTokens" }));
+    providerRuntimeMocks.formatProviderAuthProfileApiKeyWithPlugin.mockResolvedValueOnce(
+      JSON.stringify({
+        access_token: "wrapped-access-token",
+        account_id: "account-wrapped",
+      }),
+    );
+    try {
+      upsertAuthProfile({
+        agentDir,
+        profileId: "openai-codex:work",
+        credential: {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "stored-access-token",
+          refresh: "refresh-token",
+          expires: Date.now() + 24 * 60 * 60_000,
+          accountId: "account-stored",
+          email: "codex@example.test",
+        },
+      });
+
+      await applyCodexAppServerAuthProfile({
+        client: { request } as never,
+        agentDir,
+        authProfileId: "openai-codex:work",
+      });
+
+      expect(request).toHaveBeenCalledWith("account/login/start", {
+        type: "chatgptAuthTokens",
+        accessToken: "wrapped-access-token",
+        chatgptAccountId: "account-wrapped",
+        chatgptPlanType: null,
+      });
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
   it("leaves native app-server auth untouched when auth bridging is disabled", async () => {
     const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
     const request = vi.fn(async () => ({ requiresOpenaiAuth: true }));
@@ -1116,6 +1157,47 @@ describe("bridgeCodexAppServerStartOptions", () => {
         type: "chatgptAuthTokens",
         accessToken: "ref-backed-access-token",
         chatgptAccountId: "codex@example.test",
+        chatgptPlanType: null,
+      });
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("unwraps OpenAI Codex token profile wrappers before app-server login", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const request = vi.fn(async () => ({ type: "chatgptAuthTokens" }));
+    vi.stubEnv(
+      "OPENAI_CODEX_TOKEN",
+      JSON.stringify({
+        tokens: {
+          access_token: "wrapped-ref-access-token",
+          account_id: "account-wrapped-ref",
+        },
+      }),
+    );
+    try {
+      upsertAuthProfile({
+        agentDir,
+        profileId: "openai-codex:work",
+        credential: {
+          type: "token",
+          provider: "openai-codex",
+          tokenRef: { source: "env", provider: "default", id: "OPENAI_CODEX_TOKEN" },
+          email: "codex@example.test",
+        },
+      });
+
+      await applyCodexAppServerAuthProfile({
+        client: { request } as never,
+        agentDir,
+        authProfileId: "openai-codex:work",
+      });
+
+      expect(request).toHaveBeenCalledWith("account/login/start", {
+        type: "chatgptAuthTokens",
+        accessToken: "wrapped-ref-access-token",
+        chatgptAccountId: "account-wrapped-ref",
         chatgptPlanType: null,
       });
     } finally {

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -429,9 +429,12 @@ async function resolveLoginParamsForCredential(
       profileId,
       agentDir: params.agentDir,
     });
-    const accessToken = resolved?.apiKey?.trim();
-    return accessToken
-      ? buildChatgptAuthTokensParams(profileId, credential, accessToken)
+    const normalized = normalizeCodexAccessToken(resolved?.apiKey);
+    const credentialForLogin = normalized.accountId
+      ? { ...credential, accountId: normalized.accountId }
+      : credential;
+    return normalized.token
+      ? buildChatgptAuthTokensParams(profileId, credentialForLogin, normalized.token)
       : undefined;
   }
   if (credential.type !== "oauth") {
@@ -502,7 +505,14 @@ async function resolveOAuthCredentialForCodexAppServer(
           isCodexAppServerAuthProvider(storedCredential.provider, params.config)
         ? storedCredential
         : credential;
-  return resolved?.apiKey ? { ...candidate, access: resolved.apiKey } : candidate;
+  const normalized = normalizeCodexAccessToken(resolved?.apiKey);
+  return normalized.token
+    ? {
+        ...candidate,
+        access: normalized.token,
+        ...(normalized.accountId ? { accountId: normalized.accountId } : {}),
+      }
+    : candidate;
 }
 
 function isCodexAppServerAuthProvider(provider: string, config?: AuthProfileOrderConfig): boolean {
@@ -594,6 +604,52 @@ function buildChatgptAuthTokensParams(
     chatgptAccountId: resolveChatgptAccountId(profileId, credential),
     chatgptPlanType: resolveChatgptPlanType(credential),
   };
+}
+
+function normalizeCodexAccessToken(value: string | undefined): {
+  token: string | undefined;
+  accountId?: string;
+} {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return { token: undefined };
+  }
+  if (!trimmed.startsWith("{")) {
+    return { token: trimmed };
+  }
+  try {
+    const parsed = JSON.parse(trimmed) as {
+      token?: unknown;
+      access_token?: unknown;
+      accessToken?: unknown;
+      account_id?: unknown;
+      accountId?: unknown;
+      tokens?: {
+        access_token?: unknown;
+        accessToken?: unknown;
+        account_id?: unknown;
+        accountId?: unknown;
+      };
+    };
+    const token =
+      readTrimmedString(parsed.token) ??
+      readTrimmedString(parsed.access_token) ??
+      readTrimmedString(parsed.accessToken) ??
+      readTrimmedString(parsed.tokens?.access_token) ??
+      readTrimmedString(parsed.tokens?.accessToken);
+    const accountId =
+      readTrimmedString(parsed.account_id) ??
+      readTrimmedString(parsed.accountId) ??
+      readTrimmedString(parsed.tokens?.account_id) ??
+      readTrimmedString(parsed.tokens?.accountId);
+    return { token, accountId };
+  } catch {
+    return { token: trimmed };
+  }
+}
+
+function readTrimmedString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
 function resolveChatgptPlanType(credential: AuthProfileCredential): string | null {


### PR DESCRIPTION
## Summary

- unwrap JSON token wrapper strings returned from Codex auth profile resolution before calling `account/login/start`
- preserve wrapper-provided ChatGPT account ids for both OAuth and token-backed Codex profiles
- add app-server auth bridge regressions for OAuth wrapper and token-ref wrapper credentials

## Verification

- `pnpm test extensions/codex/src/app-server/auth-bridge.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/codex/src/app-server/auth-bridge.ts extensions/codex/src/app-server/auth-bridge.test.ts`
- `git diff --check`
- `pnpm check:changed --staged`

## Real behavior proof

Behavior addressed: Codex app-server login can receive profile secrets formatted as JSON token wrappers; previously OpenClaw could pass the full JSON blob as `accessToken`, which prevents the Codex app-server from using an otherwise valid ChatGPT auth profile.

Real environment tested: Focused local upstream-branch test seam for the Codex app-server auth bridge. The same downstream fix has also been live-patched and observed working on a local OpenClaw gateway, but this PR branch was not installed over that live gateway.

Exact steps or command run after this patch: `pnpm test extensions/codex/src/app-server/auth-bridge.test.ts`; `pnpm check:changed --staged`.

Evidence after fix: The new regression tests assert that `account/login/start` receives `accessToken: "wrapped-access-token"` / `"wrapped-ref-access-token"` and `chatgptAccountId` from the wrapper, not the raw serialized JSON wrapper.

Observed result after fix: The focused test file passed with 40 tests, and the staged changed-file gate completed successfully for the extension lane.

What was not tested: I did not install this PR branch over an active real gateway because doing so would disrupt a working local OpenClaw instance; live proof should be rerun by maintainers in a disposable gateway or testbox before landing if required.
