### PR TITLE
fix: Preserve Telegram hooks when flushing buffered finals

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -965,6 +965,43 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
   });
 
+  it("emits hooks when flushing a buffered final answer after skipped reasoning", async () => {
+    const { answerDraftStream } = setupDraftStreams({ answerMessageId: 2001 });
+    const context = createContext();
+    context.ctxPayload.SessionKey = "agent:default:telegram:direct:123";
+    loadSessionStore.mockReturnValue({
+      "agent:default:telegram:direct:123": { sessionId: "s1" },
+    });
+    deliverInboundReplyWithMessageSendContext.mockResolvedValueOnce({
+      status: "handled_no_send",
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver(
+        { text: "<think>Hidden reasoning</think>Visible answer" },
+        { kind: "final" },
+      );
+      return { queuedFinal: true };
+    });
+
+    await dispatchWithContext({ context });
+
+    expect(answerDraftStream.update).toHaveBeenCalledWith("Visible answer");
+    expect(answerDraftStream.stop).toHaveBeenCalled();
+    expectRecordFields(mockCallArg(emitInternalMessageSentHook), {
+      content: "Visible answer",
+      messageId: 2001,
+    });
+    const transcriptCall = expectRecordFields(mockCallArg(appendSessionTranscriptMessage), {
+      transcriptPath: "/tmp/session.jsonl",
+    });
+    expectRecordFields(transcriptCall.message, {
+      role: "assistant",
+      provider: "openclaw",
+      model: "delivery-mirror",
+      content: [{ type: "text", text: "Visible answer" }],
+    });
+  });
+
   it("does not mirror non-final tool progress into the session transcript", async () => {
     const context = createContext();
     context.ctxPayload.SessionKey = "agent:default:telegram:direct:123";

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1318,11 +1318,12 @@ export const dispatchTelegramMessage = async ({
                         return;
                       }
                       const bufferedButtons = resolvePayloadTelegramInlineButtons(buffered.payload);
-                      await deliverFinalAnswerText(
+                      const result = await deliverFinalAnswerText(
                         buffered.payload,
                         buffered.text,
                         bufferedButtons,
                       );
+                      emitPreviewFinalizedHook(result);
                       reasoningStepState.resetForNextStep();
                     };
 
@@ -1384,6 +1385,9 @@ export const dispatchTelegramMessage = async ({
                     };
 
                     if (segments.length > 0) {
+                      if (info.kind === "final") {
+                        await flushBufferedFinalAnswer();
+                      }
                       trackBlockMedia(blockDelivered);
                       return;
                     }


### PR DESCRIPTION
## Summary
- flush buffered Telegram final answers before returning from segmented final delivery
- preserve the normal preview-finalized `message:sent` hook and transcript mirror when the buffered answer flushes
- add a regression test covering skipped reasoning, visible answer delivery, internal hook emission, and transcript mirroring

## Why this PR exists
This is a hook-preserving replacement for the canonical fix path in #53762. PR #53762 has the right user-visible fix direction, but ClawSweeper flagged that its `flushBufferedFinalAnswer()` path discards the `LaneDeliveryResult`, so a buffered final answer can display in Telegram while bypassing the same preview-finalized hook/transcript path used by ordinary final segment delivery.

I cannot update #53762 directly, so this branch rebases the fix onto current `main` and addresses that review finding in the replacement patch.

## Root cause
When Telegram final output is split into reasoning and answer lane segments, the reasoning segment can be handled/skipped without marking reasoning as delivered. The answer segment is then buffered, but the `segments.length > 0` branch returns before the buffered final answer is drained.

A minimal flush fixes visible Telegram delivery, but the flush also needs to route any `preview-finalized` `LaneDeliveryResult` through `emitPreviewFinalizedHook(...)`; otherwise internal `message:sent` and transcript mirroring diverge from normal final delivery.

## Real behavior proof
- **Behavior or issue addressed:** Telegram automatic direct-message delivery silently dropped the visible final answer when a final payload split into reasoning and answer lanes left the answer buffered behind a skipped reasoning segment.
- **Real environment tested:** R2/OpenClaw production-style Linux droplet, OpenClaw npm global install `2026.5.12`, systemd user gateway, Telegram channel enabled, real allowlisted direct Telegram chat, direct-message visible replies set to automatic.
- **Exact steps or command run after this patch:** Applied the equivalent installed-bundle guard to the live OpenClaw Telegram dispatcher, restarted the gateway, injected a controlled Telegram ingress asking for exact final text `R2_AUTO_OK_SIM`, then ran the live health sequence including `curl -sS http://127.0.0.1:18789/health`, `systemctl --user status openclaw-gateway.service --no-pager -l`, `openclaw gateway status`, and the downstream hotfix checker.
- **Evidence after fix:** Redacted live output: gateway `/health` returned `{"ok":true,"status":"live"}`; the downstream checker printed `OpenClaw Telegram auto-delivery hotfix present`; the Telegram sent-message cache recorded the outbound Bot API delivery at `2026-05-18T12:45:28Z`, message id `27371`; no `message.action` send tool was used.
- **Observed result after fix:** The model final was exactly `R2_AUTO_OK_SIM`, and Telegram automatic delivery sent that visible answer through the Bot API instead of leaving it buffered and unsent.
- **What was not tested:** I did not attach a screenshot or recording of the private Telegram chat; chat details are redacted. The live proof used the installed-bundle equivalent of this source patch, while the exact source branch is covered by the dispatcher regression test below.

Additional redacted proof context is posted on #53762: https://github.com/openclaw/openclaw/pull/53762#issuecomment-4478724993

## Validation
- `git diff --check`
- `OPENCLAW_VITEST_INCLUDE_FILE=/tmp/openclaw-telegram-include-v2.json node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts`
  - Result: `extensions/telegram/src/bot-message-dispatch.test.ts` passed, 68 tests

Note: I also tried `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts bot-message-dispatch.test.ts`, but that CLI-filter form reported `No test files found`, so I am not counting it as validation.

## Related
- Fixes #53384
- Supersedes/addresses the unresolved hook-preservation review finding on #53762
- Replaces closed duplicate #83616
