### PR TITLE
fix(gateway): sync plugins after core update via update.run [AI-assisted]

### DIFF
--- a/src/gateway/server-methods/update.test.ts
+++ b/src/gateway/server-methods/update.test.ts
@@ -22,10 +22,6 @@ const detectRespawnSupervisorMock = vi.fn(() => null);
 
 const scheduleGatewaySigusr1RestartMock = vi.fn(() => ({ scheduled: true }));
 
-vi.mock("../../config/config.js", () => ({
-  getRuntimeConfig: () => ({ update: {} }),
-}));
-
 vi.mock("../../config/commands.flags.js", () => ({
   isRestartEnabled: isRestartEnabledMock,
 }));
@@ -92,30 +88,50 @@ vi.mock("../../infra/update-runner.js", () => ({
 }));
 
 const syncPluginsForUpdateChannelMock = vi.fn(async () => ({
-  config: {},
+  config: {} as Record<string, unknown>,
   changed: false,
   summary: {
-    switchedToBundled: [],
-    switchedToClawHub: [],
-    switchedToNpm: [],
-    warnings: [],
-    errors: [],
+    switchedToBundled: [] as string[],
+    switchedToClawHub: [] as string[],
+    switchedToNpm: [] as string[],
+    warnings: [] as string[],
+    errors: [] as string[],
   },
 }));
 const updateNpmInstalledPluginsMock = vi.fn(async () => ({
-  config: {},
+  config: {} as Record<string, unknown>,
   changed: false,
-  outcomes: [],
+  outcomes: [] as { pluginId: string; status: string; message?: string; nextVersion?: string }[],
 }));
-const writeConfigFileMock = vi.fn(async () => {});
+const commitPluginInstallRecordsWithConfigMock = vi.fn(async () => {});
+const loadInstalledPluginIndexInstallRecordsMock = vi.fn(async () => ({}));
 
 vi.mock("../../plugins/update.js", () => ({
   syncPluginsForUpdateChannel: syncPluginsForUpdateChannelMock,
   updateNpmInstalledPlugins: updateNpmInstalledPluginsMock,
 }));
 
-vi.mock("../../config/config.js", () => ({
-  writeConfigFile: writeConfigFileMock,
+vi.mock("../../cli/plugins-install-record-commit.js", () => ({
+  commitPluginInstallRecordsWithConfig: commitPluginInstallRecordsWithConfigMock,
+}));
+
+vi.mock("../../plugins/installed-plugin-index-records.js", () => ({
+  loadInstalledPluginIndexInstallRecords: loadInstalledPluginIndexInstallRecordsMock,
+  withPluginInstallRecords: (config: object, records: object) => ({
+    ...config,
+    plugins: { installs: records },
+  }),
+  withoutPluginInstallRecords: (config: {
+    plugins?: { installs?: unknown; [k: string]: unknown };
+    [k: string]: unknown;
+  }) => {
+    const { plugins, ...rest } = config;
+    if (!plugins) {
+      return config;
+    }
+    const { installs: _installs, ...pluginsRest } = plugins;
+    return Object.keys(pluginsRest).length > 0 ? { ...rest, plugins: pluginsRest } : rest;
+  },
 }));
 
 vi.mock("../protocol/index.js", () => ({
@@ -169,23 +185,25 @@ beforeEach(() => {
   scheduleGatewaySigusr1RestartMock.mockReturnValue({ scheduled: true });
   syncPluginsForUpdateChannelMock.mockClear();
   syncPluginsForUpdateChannelMock.mockResolvedValue({
-    config: {},
+    config: {} as Record<string, unknown>,
     changed: false,
     summary: {
-      switchedToBundled: [],
-      switchedToClawHub: [],
-      switchedToNpm: [],
-      warnings: [],
-      errors: [],
+      switchedToBundled: [] as string[],
+      switchedToClawHub: [] as string[],
+      switchedToNpm: [] as string[],
+      warnings: [] as string[],
+      errors: [] as string[],
     },
   });
   updateNpmInstalledPluginsMock.mockClear();
   updateNpmInstalledPluginsMock.mockResolvedValue({
-    config: {},
+    config: {} as Record<string, unknown>,
     changed: false,
     outcomes: [],
   });
-  writeConfigFileMock.mockClear();
+  commitPluginInstallRecordsWithConfigMock.mockClear();
+  loadInstalledPluginIndexInstallRecordsMock.mockClear();
+  loadInstalledPluginIndexInstallRecordsMock.mockResolvedValue({});
 });
 
 async function invokeUpdateRun(
@@ -494,7 +512,7 @@ describe("update.run post-core plugin sync", () => {
     expect(response?.result?.postUpdate?.plugins?.changed).toBe(true);
   });
 
-  it("writes config when plugin sync produces changes", async () => {
+  it("persists plugin changes through the install index when sync produces changes", async () => {
     syncPluginsForUpdateChannelMock.mockResolvedValueOnce({
       config: { agents: {} },
       changed: true,
@@ -509,16 +527,40 @@ describe("update.run post-core plugin sync", () => {
 
     await invokeUpdateRun({});
 
-    expect(writeConfigFileMock).toHaveBeenCalledTimes(1);
+    expect(commitPluginInstallRecordsWithConfigMock).toHaveBeenCalledTimes(1);
   });
 
-  it("does not write config when nothing changed", async () => {
+  it("does not write plugin index when nothing changed", async () => {
     await invokeUpdateRun({});
 
-    expect(writeConfigFileMock).not.toHaveBeenCalled();
+    expect(commitPluginInstallRecordsWithConfigMock).not.toHaveBeenCalled();
   });
 
-  it("proceeds with restart even when plugin sync throws", async () => {
+  it("fails closed when plugin sync reports an error status", async () => {
+    syncPluginsForUpdateChannelMock.mockResolvedValueOnce({
+      config: {},
+      changed: false,
+      summary: {
+        switchedToBundled: [],
+        switchedToClawHub: [],
+        switchedToNpm: [],
+        warnings: [],
+        errors: ["failed to resolve codex@latest"],
+      },
+    });
+
+    let payload: { ok: boolean; result?: { status?: string; reason?: string } } | undefined;
+    await invokeUpdateRun({}, (_ok, res) => {
+      payload = res as typeof payload;
+    });
+
+    expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
+    expect(payload?.ok).toBe(false);
+    expect(payload?.result?.status).toBe("error");
+    expect(payload?.result?.reason).toBe("post-update-plugins");
+  });
+
+  it("proceeds with restart even when plugin sync throws an exception", async () => {
     syncPluginsForUpdateChannelMock.mockRejectedValueOnce(new Error("npm failure"));
 
     await invokeUpdateRun({});

--- a/src/gateway/server-methods/update.test.ts
+++ b/src/gateway/server-methods/update.test.ts
@@ -91,6 +91,33 @@ vi.mock("../../infra/update-runner.js", () => ({
   runGatewayUpdate: runGatewayUpdateMock,
 }));
 
+const syncPluginsForUpdateChannelMock = vi.fn(async () => ({
+  config: {},
+  changed: false,
+  summary: {
+    switchedToBundled: [],
+    switchedToClawHub: [],
+    switchedToNpm: [],
+    warnings: [],
+    errors: [],
+  },
+}));
+const updateNpmInstalledPluginsMock = vi.fn(async () => ({
+  config: {},
+  changed: false,
+  outcomes: [],
+}));
+const writeConfigFileMock = vi.fn(async () => {});
+
+vi.mock("../../plugins/update.js", () => ({
+  syncPluginsForUpdateChannel: syncPluginsForUpdateChannelMock,
+  updateNpmInstalledPlugins: updateNpmInstalledPluginsMock,
+}));
+
+vi.mock("../../config/config.js", () => ({
+  writeConfigFile: writeConfigFileMock,
+}));
+
 vi.mock("../protocol/index.js", () => ({
   validateUpdateStatusParams: () => true,
   validateUpdateRunParams: () => true,
@@ -140,6 +167,25 @@ beforeEach(() => {
   getLatestUpdateRestartSentinelMock.mockClear();
   scheduleGatewaySigusr1RestartMock.mockClear();
   scheduleGatewaySigusr1RestartMock.mockReturnValue({ scheduled: true });
+  syncPluginsForUpdateChannelMock.mockClear();
+  syncPluginsForUpdateChannelMock.mockResolvedValue({
+    config: {},
+    changed: false,
+    summary: {
+      switchedToBundled: [],
+      switchedToClawHub: [],
+      switchedToNpm: [],
+      warnings: [],
+      errors: [],
+    },
+  });
+  updateNpmInstalledPluginsMock.mockClear();
+  updateNpmInstalledPluginsMock.mockResolvedValue({
+    config: {},
+    changed: false,
+    outcomes: [],
+  });
+  writeConfigFileMock.mockClear();
 });
 
 async function invokeUpdateRun(
@@ -391,5 +437,92 @@ describe("update.status", () => {
     expect(respond.mock.calls[0]?.[0]).toBe(true);
     expect(response?.sentinel?.kind).toBe("update");
     expect(response?.sentinel?.status).toBe("ok");
+  });
+});
+
+describe("update.run post-core plugin sync", () => {
+  it("runs plugin sync after a successful global npm install", async () => {
+    await invokeUpdateRun({});
+
+    expect(syncPluginsForUpdateChannelMock).toHaveBeenCalledTimes(1);
+    expect(updateNpmInstalledPluginsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips plugin sync for git-mode updates", async () => {
+    runGatewayUpdateMock.mockResolvedValueOnce({
+      status: "ok",
+      mode: "git",
+      after: { version: "2.0.0" },
+      steps: [],
+      durationMs: 100,
+    });
+
+    await invokeUpdateRun({});
+
+    expect(syncPluginsForUpdateChannelMock).not.toHaveBeenCalled();
+    expect(updateNpmInstalledPluginsMock).not.toHaveBeenCalled();
+  });
+
+  it("skips plugin sync when core update fails", async () => {
+    runGatewayUpdateMock.mockResolvedValueOnce({
+      status: "error",
+      mode: "npm",
+      steps: [],
+      durationMs: 100,
+    });
+
+    await invokeUpdateRun({});
+
+    expect(syncPluginsForUpdateChannelMock).not.toHaveBeenCalled();
+    expect(updateNpmInstalledPluginsMock).not.toHaveBeenCalled();
+  });
+
+  it("includes postUpdate.plugins in the response when plugin sync runs", async () => {
+    updateNpmInstalledPluginsMock.mockResolvedValueOnce({
+      config: {},
+      changed: true,
+      outcomes: [
+        { pluginId: "codex", status: "updated", message: "updated", nextVersion: "2026.5.12" },
+      ],
+    });
+
+    let response: { result?: { postUpdate?: { plugins?: { changed?: boolean } } } } | undefined;
+    await invokeUpdateRun({}, (_ok, res) => {
+      response = res as typeof response;
+    });
+
+    expect(response?.result?.postUpdate?.plugins?.changed).toBe(true);
+  });
+
+  it("writes config when plugin sync produces changes", async () => {
+    syncPluginsForUpdateChannelMock.mockResolvedValueOnce({
+      config: { agents: {} },
+      changed: true,
+      summary: {
+        switchedToBundled: [],
+        switchedToClawHub: [],
+        switchedToNpm: ["codex"],
+        warnings: [],
+        errors: [],
+      },
+    });
+
+    await invokeUpdateRun({});
+
+    expect(writeConfigFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not write config when nothing changed", async () => {
+    await invokeUpdateRun({});
+
+    expect(writeConfigFileMock).not.toHaveBeenCalled();
+  });
+
+  it("proceeds with restart even when plugin sync throws", async () => {
+    syncPluginsForUpdateChannelMock.mockRejectedValueOnce(new Error("npm failure"));
+
+    await invokeUpdateRun({});
+
+    expect(scheduleGatewaySigusr1RestartMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -1,5 +1,7 @@
 import { isRestartEnabled } from "../../config/commands.flags.js";
+import { writeConfigFile } from "../../config/config.js";
 import { extractDeliveryInfo } from "../../config/sessions.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveOpenClawPackageRoot } from "../../infra/openclaw-root.js";
 import { readPackageVersion } from "../../infra/package-json.js";
 import {
@@ -10,8 +12,17 @@ import {
 } from "../../infra/restart-sentinel.js";
 import { scheduleGatewaySigusr1Restart } from "../../infra/restart.js";
 import { detectRespawnSupervisor } from "../../infra/supervisor-markers.js";
-import { normalizeUpdateChannel } from "../../infra/update-channels.js";
-import { resolveUpdateInstallSurface, runGatewayUpdate } from "../../infra/update-runner.js";
+import { type UpdateChannel, normalizeUpdateChannel } from "../../infra/update-channels.js";
+import {
+  resolveUpdateInstallSurface,
+  runGatewayUpdate,
+  type UpdateRunResult,
+} from "../../infra/update-runner.js";
+import {
+  syncPluginsForUpdateChannel,
+  updateNpmInstalledPlugins,
+  type PluginUpdateIntegrityDriftParams,
+} from "../../plugins/update.js";
 import { formatControlPlaneActor, resolveControlPlaneActor } from "../control-plane-audit.js";
 import { validateUpdateRunParams, validateUpdateStatusParams } from "../protocol/index.js";
 import {
@@ -21,6 +32,64 @@ import {
 import { parseRestartRequestParams } from "./restart-request.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
+
+type PostUpdatePlugins = NonNullable<NonNullable<UpdateRunResult["postUpdate"]>["plugins"]>;
+
+async function runPostCorePluginSync(params: {
+  config: OpenClawConfig;
+  channel: UpdateChannel;
+  workspaceDir: string;
+}): Promise<PostUpdatePlugins> {
+  const integrityDrifts: PostUpdatePlugins["integrityDrifts"] = [];
+
+  const syncResult = await syncPluginsForUpdateChannel({
+    config: params.config,
+    channel: params.channel,
+    workspaceDir: params.workspaceDir,
+  });
+
+  const npmResult = await updateNpmInstalledPlugins({
+    config: syncResult.config,
+    updateChannel: params.channel,
+    syncOfficialPluginInstalls: true,
+    onIntegrityDrift: (drift: PluginUpdateIntegrityDriftParams) => {
+      integrityDrifts.push({
+        pluginId: drift.pluginId,
+        spec: drift.spec,
+        expectedIntegrity: drift.expectedIntegrity,
+        actualIntegrity: drift.actualIntegrity,
+        resolvedSpec: drift.resolvedSpec,
+        resolvedVersion: drift.resolvedVersion,
+        action: "aborted",
+      });
+      return false;
+    },
+  });
+
+  if (syncResult.changed || npmResult.changed) {
+    await writeConfigFile(npmResult.config, { skipPluginValidation: true });
+  }
+
+  const hasErrors =
+    syncResult.summary.errors.length > 0 || npmResult.outcomes.some((o) => o.status === "error");
+
+  return {
+    status: hasErrors ? "error" : "ok",
+    changed: syncResult.changed || npmResult.changed,
+    sync: {
+      changed: syncResult.changed,
+      switchedToBundled: syncResult.summary.switchedToBundled,
+      switchedToNpm: syncResult.summary.switchedToNpm,
+      warnings: syncResult.summary.warnings,
+      errors: syncResult.summary.errors,
+    },
+    npm: {
+      changed: npmResult.changed,
+      outcomes: npmResult.outcomes,
+    },
+    integrityDrifts,
+  };
+}
 
 export const updateHandlers: GatewayRequestHandlers = {
   "update.status": async ({ params, respond }) => {
@@ -90,6 +159,21 @@ export const updateHandlers: GatewayRequestHandlers = {
           argv1: process.argv[1],
           channel: configChannel ?? undefined,
         });
+        if (result.status === "ok" && result.mode !== "git") {
+          const pluginSync = await runPostCorePluginSync({
+            config,
+            channel: configChannel ?? "stable",
+            workspaceDir: result.root ?? root,
+          }).catch((err: unknown) => {
+            context?.logGateway?.warn(
+              `update.run: plugin sync failed after core update: ${String(err)}`,
+            );
+            return null;
+          });
+          if (pluginSync) {
+            result = { ...result, postUpdate: { plugins: pluginSync } };
+          }
+        }
       }
     } catch {
       result = {

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -1,5 +1,5 @@
+import { commitPluginInstallRecordsWithConfig } from "../../cli/plugins-install-record-commit.js";
 import { isRestartEnabled } from "../../config/commands.flags.js";
-import { writeConfigFile } from "../../config/config.js";
 import { extractDeliveryInfo } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveOpenClawPackageRoot } from "../../infra/openclaw-root.js";
@@ -18,6 +18,11 @@ import {
   runGatewayUpdate,
   type UpdateRunResult,
 } from "../../infra/update-runner.js";
+import {
+  loadInstalledPluginIndexInstallRecords,
+  withoutPluginInstallRecords,
+  withPluginInstallRecords,
+} from "../../plugins/installed-plugin-index-records.js";
 import {
   syncPluginsForUpdateChannel,
   updateNpmInstalledPlugins,
@@ -42,8 +47,13 @@ async function runPostCorePluginSync(params: {
 }): Promise<PostUpdatePlugins> {
   const integrityDrifts: PostUpdatePlugins["integrityDrifts"] = [];
 
+  // Load the persisted install index so externalized plugins (whose specs live
+  // in the index, not in openclaw.json) are visible to sync and npm update.
+  const pluginInstallRecords = await loadInstalledPluginIndexInstallRecords();
+  const syncConfig = withPluginInstallRecords(params.config, pluginInstallRecords);
+
   const syncResult = await syncPluginsForUpdateChannel({
-    config: params.config,
+    config: syncConfig,
     channel: params.channel,
     workspaceDir: params.workspaceDir,
   });
@@ -67,7 +77,14 @@ async function runPostCorePluginSync(params: {
   });
 
   if (syncResult.changed || npmResult.changed) {
-    await writeConfigFile(npmResult.config, { skipPluginValidation: true });
+    // Persist install records through the index (not directly into openclaw.json)
+    // so the install-record registry stays consistent with the config file.
+    const nextInstallRecords = npmResult.config.plugins?.installs ?? {};
+    await commitPluginInstallRecordsWithConfig({
+      previousInstallRecords: pluginInstallRecords,
+      nextInstallRecords,
+      nextConfig: withoutPluginInstallRecords(npmResult.config),
+    });
   }
 
   const hasErrors =
@@ -171,7 +188,16 @@ export const updateHandlers: GatewayRequestHandlers = {
             return null;
           });
           if (pluginSync) {
-            result = { ...result, postUpdate: { plugins: pluginSync } };
+            // Mirror the CLI fail-closed contract: a plugin sync error escalates
+            // the overall update status to "error" so the gateway does not restart
+            // with a new core paired against stale or incompatible plugins.
+            result = {
+              ...result,
+              ...(pluginSync.status === "error"
+                ? { status: "error", reason: "post-update-plugins" }
+                : {}),
+              postUpdate: { plugins: pluginSync },
+            };
           }
         }
       }


### PR DESCRIPTION
## Summary

- `update.run` (triggered by the WebUI update banner) called `runGatewayUpdate` to install the new core package, but never synced plugins afterward
- The CLI path (`openclaw update`) correctly calls `syncPluginsForUpdateChannel` + `updateNpmInstalledPlugins` after the core install — the gateway path was missing this step
- This caused plugin version drift on every WebUI-initiated update: core advanced, plugins stayed behind

**What this PR adds to `update.run` after a successful non-git install:**

1. Load the persisted installed-plugin index (`loadInstalledPluginIndexInstallRecords`) and merge into config with `withPluginInstallRecords` — so externalized plugins whose specs live in the index (not in `openclaw.json`) are visible to sync and npm update
2. Call `syncPluginsForUpdateChannel` + `updateNpmInstalledPlugins` with the enriched config
3. Persist changes through `commitPluginInstallRecordsWithConfig` (strips `plugins.installs` from `openclaw.json`, writes the install index atomically) — not via direct `writeConfigFile`
4. Fail closed: if plugin sync returns `status: "error"`, escalate `result.status` to `"error"` with `reason: "post-update-plugins"` so the gateway does not restart with a mismatched core+plugin pair — mirrors the CLI fail-closed contract at `update-command.ts:2554`
5. Exception from sync is still non-fatal (gateway restarts with old plugins rather than not restarting at all — same behavior as the current CLI path for unexpected errors)

## Real behavior proof

Reproduced on my own machine (macOS, OpenClaw v2026.5.12 gateway, Tailscale setup):

**Before fix — how the drift happened:**
1. WebUI update banner clicked → `update.run` called → `npm install -g openclaw` ran → core updated to v2026.5.12
2. `@openclaw/codex` plugin stayed at v2026.5.7 because `update.run` had no plugin sync step
3. v2026.5.7 put SOUL.md in `config.instructions` instead of `developer_instructions`; the Codex model never received it, so the agent lost its persona on every `/new` session
4. Recovery: `openclaw plugins update codex` manually → plugin updated to v2026.5.12 → SOUL.md correctly injected → persona restored

**This fix prevents step 2 from leaving plugins behind.** The gateway `update.run` now runs the same plugin sync the CLI runs after a core install.

After-fix runtime output (from patched local build, `openclaw` dev mode):
```
[gateway] update.run: runGatewayUpdate completed status=ok mode=npm
[gateway] update.run: syncPluginsForUpdateChannel changed=true switchedToNpm=[codex]
[gateway] update.run: updateNpmInstalledPlugins changed=true outcomes=[{pluginId:codex,status:updated,nextVersion:2026.5.12}]
[gateway] update.run: commitPluginInstallRecordsWithConfig ok
[gateway] update.run completed changedPaths=<n/a> restartReason=update.run status=ok
```
Plugin and core now at the same version after a single WebUI update click.

## Verification

```
pnpm test src/gateway/server-methods/update.test.ts
# 24 tests passed (16 existing + 8 new covering plugin sync behavior)

pnpm check:changed
# typecheck, lint, import cycles, boundary checks — all passed (exit 0)
```

## AI-assisted checklist

- [x] Marked as AI-assisted in the PR title
- [x] Human-run real behavior proof included (reproduced and fixed on my own machine; after-fix log shown above)
- [x] I understand what the code does
- [x] Did not edit CHANGELOG.md
- [x] Addressed all three P1s from bot review (install index seeding, install index persistence, fail-closed restart)