### PR TITLE
[codex] restore QR bootstrap operator handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -307,6 +307,7 @@ Docs: https://docs.openclaw.ai
 - iOS: end Live Activities when OpenClaw is connected, idle, or disconnected, and show compact attention states for approval-required reconnects. (#83597) Thanks @ngutman.
 - Control UI: hide child nav items when collapsing the active sidebar group. Fixes #42167. (#42223) Thanks @Aroool.
 - CI/proof: skip the real-behavior-proof gate for private org maintainers by minting a least-privilege (`members: read`) GitHub App token and checking active membership in the `maintainer` team, instead of treating `author_association=CONTRIBUTOR` as definitively external. (#83418) Thanks @romneyda.
+- Gateway/mobile: restore QR setup-code handoff of bounded operator tokens for iOS and Android onboarding while keeping admin and pairing scopes out of bootstrap. (#83684) Thanks @ngutman.
 
 ## 2026.5.17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 - WhatsApp: clarify inbound group diagnostics so observed but unregistered groups point to `channels.whatsapp.groups` without changing routing or sender authorization. (#83846) Thanks @neeravmakwana.
 - WhatsApp: drain pending outbound deliveries on a 30s periodic timer in addition to the reconnect handler, so messages enqueued while the provider is already connected no longer wait for the next reconnect to send. (#79083) Thanks @Oviemudiaga.
 - CLI/TUI: include gateway plugin slash commands in TUI autocomplete, so connected sessions can suggest plugin-owned commands exposed by the running Gateway. (#83640) Thanks @se7en-agent.
+- Gateway/mobile: restore QR setup-code handoff of bounded operator tokens for iOS and Android onboarding while keeping admin and pairing scopes out of bootstrap. (#83684) Thanks @ngutman.
 
 ## 2026.5.19
 
@@ -307,7 +308,6 @@ Docs: https://docs.openclaw.ai
 - iOS: end Live Activities when OpenClaw is connected, idle, or disconnected, and show compact attention states for approval-required reconnects. (#83597) Thanks @ngutman.
 - Control UI: hide child nav items when collapsing the active sidebar group. Fixes #42167. (#42223) Thanks @Aroool.
 - CI/proof: skip the real-behavior-proof gate for private org maintainers by minting a least-privilege (`members: read`) GitHub App token and checking active membership in the `maintainer` team, instead of treating `author_association=CONTRIBUTOR` as definitively external. (#83418) Thanks @romneyda.
-- Gateway/mobile: restore QR setup-code handoff of bounded operator tokens for iOS and Android onboarding while keeping admin and pairing scopes out of bootstrap. (#83684) Thanks @ngutman.
 
 ## 2026.5.17
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -605,7 +605,6 @@ class GatewaySession(
             setOf(
               "operator.approvals",
               "operator.read",
-              "operator.talk.secrets",
               "operator.write",
             )
           scopes.filter { allowedOperatorScopes.contains(it) }.distinct().sorted()

--- a/apps/android/app/src/main/java/ai/openclaw/app/node/ConnectionManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/node/ConnectionManager.kt
@@ -162,7 +162,14 @@ class ConnectionManager(
   fun buildOperatorConnectOptions(): GatewayConnectOptions =
     GatewayConnectOptions(
       role = "operator",
-      scopes = listOf("operator.read", "operator.write", "operator.talk.secrets"),
+      // QR bootstrap hands Android a bounded operator token that includes approvals; keep the
+      // default operator reconnect request aligned so the post-bootstrap loop can approve work.
+      scopes =
+        listOf(
+          "operator.approvals",
+          "operator.read",
+          "operator.write",
+        ),
       caps = emptyList(),
       commands = emptyList(),
       permissions = emptyMap(),

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
@@ -365,7 +365,7 @@ class GatewaySessionInvokeTest {
         assertEquals(emptyList<String>(), nodeEntry?.scopes)
         assertEquals("bootstrap-operator-token", operatorEntry?.token)
         assertEquals(
-          listOf("operator.approvals", "operator.read", "operator.talk.secrets", "operator.write"),
+          listOf("operator.approvals", "operator.read", "operator.write"),
           operatorEntry?.scopes,
         )
       } finally {

--- a/apps/android/app/src/test/java/ai/openclaw/app/node/ConnectionManagerTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/node/ConnectionManagerTest.kt
@@ -369,6 +369,20 @@ class ConnectionManagerTest {
   }
 
   @Test
+  fun buildOperatorConnectOptions_requestsQrBootstrapHandoffScopes() {
+    val options = newManager().buildOperatorConnectOptions()
+
+    assertEquals(
+      listOf(
+        "operator.approvals",
+        "operator.read",
+        "operator.write",
+      ),
+      options.scopes,
+    )
+  }
+
+  @Test
   fun buildNodeConnectOptions_advertisesRequestableSmsSearchWithoutSmsCapability() {
     val options =
       newManager(

--- a/apps/ios/Sources/Onboarding/GatewayOnboardingReset.swift
+++ b/apps/ios/Sources/Onboarding/GatewayOnboardingReset.swift
@@ -1,0 +1,30 @@
+import Foundation
+import OpenClawKit
+
+enum GatewayOnboardingReset {
+    static func reset(
+        appModel: NodeAppModel,
+        instanceId: String,
+        defaults: UserDefaults = .standard)
+    {
+        appModel.disconnectGateway()
+
+        let trimmedInstanceId = instanceId.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedInstanceId.isEmpty {
+            GatewaySettingsStore.deleteGatewayCredentials(instanceId: trimmedInstanceId)
+        }
+
+        GatewaySettingsStore.clearLastGatewayConnection()
+        GatewaySettingsStore.clearPreferredGatewayStableID()
+        GatewaySettingsStore.clearLastDiscoveredGatewayStableID()
+        GatewayTLSStore.clearAllFingerprints()
+        OnboardingStateStore.reset(defaults: defaults)
+
+        defaults.set(false, forKey: "gateway.onboardingComplete")
+        defaults.set(false, forKey: "gateway.hasConnectedOnce")
+        defaults.set(false, forKey: "gateway.manual.enabled")
+        defaults.set("", forKey: "gateway.manual.host")
+        defaults.set("", forKey: "gateway.setupCode")
+        defaults.set(defaults.integer(forKey: "onboarding.requestID") + 1, forKey: "onboarding.requestID")
+    }
+}

--- a/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
+++ b/apps/ios/Sources/Onboarding/OnboardingWizardView.swift
@@ -1016,10 +1016,24 @@ struct OnboardingWizardView: View {
     }
 
     private func gatewayProblemPrimaryActionTitle(_ problem: GatewayConnectionProblem) -> String {
+        if problem.suggestsOnboardingReset { return "Scan QR again" }
         problem.canTrustRotatedCertificate ? "Trust certificate" : "Retry connection"
     }
 
     private func handleGatewayProblemPrimaryAction(_ problem: GatewayConnectionProblem) async {
+        if problem.suggestsOnboardingReset {
+            GatewayOnboardingReset.reset(appModel: self.appModel, instanceId: self.instanceId)
+            self.gatewayToken = ""
+            self.gatewayPassword = ""
+            self.connectingGatewayID = nil
+            self.connectMessage = nil
+            self.issue = .none
+            self.pairingRequestId = nil
+            self.statusLine = "Scan a fresh setup QR code from this gateway."
+            self.step = .connect
+            self.showQRScanner = true
+            return
+        }
         if problem.canTrustRotatedCertificate {
             self.connectingGatewayID = "trust-certificate"
             self.connectMessage = "Updating gateway certificate…"

--- a/apps/ios/Sources/RootCanvas.swift
+++ b/apps/ios/Sources/RootCanvas.swift
@@ -15,6 +15,7 @@ struct RootCanvas: View {
     @AppStorage("onboarding.requestID") private var onboardingRequestID: Int = 0
     @AppStorage("gateway.onboardingComplete") private var onboardingComplete: Bool = false
     @AppStorage("gateway.hasConnectedOnce") private var hasConnectedOnce: Bool = false
+    @AppStorage("node.instanceId") private var instanceId: String = UUID().uuidString
     @AppStorage("gateway.preferredStableID") private var preferredGatewayStableID: String = ""
     @AppStorage("gateway.manual.enabled") private var manualGatewayEnabled: Bool = false
     @AppStorage("gateway.manual.host") private var manualGatewayHost: String = ""
@@ -102,6 +103,9 @@ struct RootCanvas: View {
                 },
                 retryGatewayConnection: {
                     Task { await self.gatewayController.connectLastKnown() }
+                },
+                resetOnboarding: {
+                    self.resetOnboardingFromGatewayProblem()
                 })
                 .preferredColorScheme(.dark)
 
@@ -429,6 +433,13 @@ struct RootCanvas: View {
         guard shouldPresent else { return }
         self.presentedSheet = .quickSetup
     }
+
+    private func resetOnboardingFromGatewayProblem() {
+        GatewayOnboardingReset.reset(appModel: self.appModel, instanceId: self.instanceId)
+        self.presentedSheet = nil
+        self.onboardingAllowSkip = false
+        self.showOnboarding = true
+    }
 }
 
 private struct HomeCanvasPayload: Codable {
@@ -469,6 +480,7 @@ private struct CanvasContent: View {
     var openChat: () -> Void
     var openSettings: () -> Void
     var retryGatewayConnection: () -> Void
+    var resetOnboarding: () -> Void
 
     private var brightenButtons: Bool {
         self.systemColorScheme == .light
@@ -578,12 +590,15 @@ private struct CanvasContent: View {
 
     private func gatewayProblemPrimaryActionTitle(_ problem: GatewayConnectionProblem) -> String {
         if problem.canTrustRotatedCertificate { return "Trust certificate" }
+        if problem.suggestsOnboardingReset { return "Reset onboarding" }
         return problem.retryable ? "Retry" : "Open Settings"
     }
 
     private func handleGatewayProblemPrimaryAction(_ problem: GatewayConnectionProblem) {
         if problem.canTrustRotatedCertificate {
             Task { await self.gatewayController.trustRotatedGatewayCertificate(from: problem) }
+        } else if problem.suggestsOnboardingReset {
+            self.resetOnboarding()
         } else if problem.retryable {
             self.retryGatewayConnection()
         } else {

--- a/apps/ios/Sources/Settings/SettingsTab.swift
+++ b/apps/ios/Sources/Settings/SettingsTab.swift
@@ -1057,10 +1057,15 @@ struct SettingsTab: View {
     }
 
     private func gatewayProblemPrimaryActionTitle(_ problem: GatewayConnectionProblem) -> String {
+        if problem.suggestsOnboardingReset { return "Reset onboarding" }
         problem.canTrustRotatedCertificate ? "Trust certificate" : "Retry connection"
     }
 
     private func handleGatewayProblemPrimaryAction(_ problem: GatewayConnectionProblem) async {
+        if problem.suggestsOnboardingReset {
+            self.resetOnboarding()
+            return
+        }
         if problem.canTrustRotatedCertificate {
             _ = await self.gatewayController.trustRotatedGatewayCertificate(from: problem)
             return
@@ -1070,7 +1075,6 @@ struct SettingsTab: View {
 
     private func resetOnboarding() {
         // Disconnect first so RootCanvas doesn't instantly mark onboarding complete again.
-        self.appModel.disconnectGateway()
         self.connectingGatewayID = nil
         self.setupStatusText = nil
         self.setupCode = ""
@@ -1082,19 +1086,7 @@ struct SettingsTab: View {
         self.gatewayToken = ""
         self.gatewayPassword = ""
 
-        let trimmedInstanceId = self.instanceId.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !trimmedInstanceId.isEmpty {
-            GatewaySettingsStore.deleteGatewayCredentials(instanceId: trimmedInstanceId)
-        }
-
-        // Reset onboarding state + clear saved gateway connection (the two things RootCanvas checks).
-        GatewaySettingsStore.clearLastGatewayConnection()
-        GatewaySettingsStore.clearPreferredGatewayStableID()
-        GatewaySettingsStore.clearLastDiscoveredGatewayStableID()
-        // Resetting onboarding should also forget trusted gateway TLS fingerprints.
-        // Otherwise a restarted dev gateway can stay stuck in a local TLS cancel loop.
-        GatewayTLSStore.clearAllFingerprints()
-        OnboardingStateStore.reset()
+        GatewayOnboardingReset.reset(appModel: self.appModel, instanceId: self.instanceId)
 
         // RootCanvas also short-circuits onboarding when these are true.
         self.onboardingComplete = false

--- a/apps/ios/SwiftSources.input.xcfilelist
+++ b/apps/ios/SwiftSources.input.xcfilelist
@@ -35,6 +35,7 @@ Sources/Model/NodeAppModel+WatchNotifyNormalization.swift
 Sources/Model/NodeAppModel.swift
 Sources/Model/WatchReplyCoordinator.swift
 Sources/Motion/MotionService.swift
+Sources/Onboarding/GatewayOnboardingReset.swift
 Sources/Onboarding/GatewayOnboardingView.swift
 Sources/Onboarding/OnboardingStateStore.swift
 Sources/Onboarding/OnboardingWizardView.swift

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayChannel.swift
@@ -601,7 +601,6 @@ public actor GatewayChannelActor {
             let allowedOperatorScopes: Set = [
                 "operator.approvals",
                 "operator.read",
-                "operator.talk.secrets",
                 "operator.write",
             ]
             return Array(Set(scopes.filter { allowedOperatorScopes.contains($0) })).sorted()

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayConnectionProblem.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayConnectionProblem.swift
@@ -121,6 +121,10 @@ public struct GatewayConnectionProblem: Equatable, Sendable {
         }
     }
 
+    public var suggestsOnboardingReset: Bool {
+        self.kind == .gatewayAuthTokenMismatch
+    }
+
     public var statusText: String {
         switch self.kind {
         case .pairingRequired, .pairingRoleUpgradeRequired, .pairingScopeUpgradeRequired,

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayErrorsTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayErrorsTests.swift
@@ -70,6 +70,19 @@ import Testing
         #expect(problem?.needsCredentialUpdate == false)
     }
 
+    @Test func tokenMismatchSuggestsOnboardingReset() {
+        let error = GatewayConnectAuthError(
+            message: "token mismatch",
+            detailCode: GatewayConnectAuthDetailCode.authTokenMismatch.rawValue,
+            canRetryWithDeviceToken: false)
+
+        let problem = GatewayConnectionProblemMapper.map(error: error)
+
+        #expect(problem?.kind == .gatewayAuthTokenMismatch)
+        #expect(problem?.suggestsOnboardingReset == true)
+        #expect(problem?.needsCredentialUpdate == true)
+    }
+
     @Test func cancelledTransportDoesNotReplaceStructuredPairingProblem() {
         let pairing = GatewayConnectAuthError(
             message: "pairing required",

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -405,7 +405,6 @@ struct GatewayNodeSessionTests {
         #expect(operatorEntry.scopes == [
             "operator.approvals",
             "operator.read",
-            "operator.talk.secrets",
             "operator.write",
         ])
 

--- a/docs/channels/pairing.md
+++ b/docs/channels/pairing.md
@@ -123,10 +123,13 @@ The setup code is a base64-encoded JSON payload that contains:
 
 That bootstrap token carries the built-in pairing bootstrap profile:
 
-- the built-in setup profile allows only the `node` role
-- after approval, the handed-off `node` token stays `scopes: []`
-- the built-in setup-code flow does not hand off an `operator` token
-- operator access requires a separate approved operator pairing or token flow
+- the built-in setup profile allows the fresh QR/setup-code baseline only:
+  `node` plus a bounded `operator` handoff
+- the handed-off `node` token stays `scopes: []`
+- the handed-off `operator` token is limited to `operator.approvals`,
+  `operator.read`, and `operator.write`
+- `operator.admin` and `operator.pairing` are not granted by QR/setup-code
+  bootstrap; they require a separate approved operator pairing or token flow
 - later token rotation/revocation remains bounded by both the device's approved
   role contract and the caller session's operator scopes
 

--- a/docs/cli/qr.md
+++ b/docs/cli/qr.md
@@ -35,8 +35,8 @@ openclaw qr --url wss://gateway.example/ws
 
 - `--token` and `--password` are mutually exclusive.
 - The setup code itself now carries an opaque short-lived `bootstrapToken`, not the shared gateway token/password.
-- Built-in setup-code bootstrap is node-only. After approval, the primary node token lands with `scopes: []`.
-- The built-in setup-code flow does not return a handed-off operator token; operator access requires a separate approved operator pairing or token flow.
+- Built-in setup-code bootstrap returns a primary `node` token with `scopes: []` plus a bounded `operator` handoff token for trusted mobile onboarding.
+- The handed-off operator token is limited to `operator.approvals`, `operator.read`, and `operator.write`; `operator.admin`, `operator.pairing`, and `operator.talk.secrets` require a separate approved operator pairing or token flow.
 - Mobile pairing fails closed for Tailscale/public `ws://` gateway URLs. Private LAN addresses and `.local` Bonjour hosts remain supported over `ws://`, but Tailscale/public mobile routes should use Tailscale Serve/Funnel or a `wss://` gateway URL.
 - With `--remote`, OpenClaw requires either `gateway.remote.url` or
   `gateway.tailscale.mode=serve|funnel`.

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -147,24 +147,33 @@ When a device token is issued, `hello-ok` also includes:
 }
 ```
 
-Built-in QR/setup-code bootstrap is node-only. After the owner approves the
-pending node request, `hello-ok.auth` includes the primary node token:
+Built-in QR/setup-code bootstrap is a fresh mobile handoff path. A successful
+baseline setup-code connect returns a primary node token plus one bounded
+operator token:
 
 ```json
 {
   "auth": {
     "deviceToken": "…",
     "role": "node",
-    "scopes": []
+    "scopes": [],
+    "deviceTokens": [
+      {
+        "deviceToken": "…",
+        "role": "operator",
+        "scopes": ["operator.approvals", "operator.read", "operator.write"]
+      }
+    ]
   }
 }
 ```
 
-The built-in setup-code flow does not include additional `deviceTokens` entries
-or hand off an operator token. Client authors should treat the optional
-`hello-ok.auth.deviceTokens` field as legacy/custom bootstrap extension data:
-persist it only when present on a trusted transport, and do not require it for
-built-in pairing.
+The operator handoff is intentionally bounded so QR onboarding can start the
+mobile operator loop without granting `operator.admin`, `operator.pairing`, or
+`operator.talk.secrets`. Those scopes require a separate approved operator
+pairing or token flow. Clients should persist `hello-ok.auth.deviceTokens` only
+when the connect used bootstrap auth on trusted transport such as `wss://` or
+loopback/local pairing.
 
 ### Node example
 
@@ -691,17 +700,16 @@ rather than the pre-handshake defaults.
     `AUTH_TOKEN_MISMATCH` retry is gated to **trusted endpoints only** —
     loopback, or `wss://` with a pinned `tlsFingerprint`. Public `wss://`
     without pinning does not qualify.
-- Built-in setup-code bootstrap returns only the primary node
-  `hello-ok.auth.deviceToken`; clients must not expect an additional operator
-  token in `hello-ok.auth.deviceTokens`.
-- While built-in setup-code bootstrap is waiting for approval, `PAIRING_REQUIRED`
+- Built-in setup-code bootstrap returns the primary node
+  `hello-ok.auth.deviceToken` plus a bounded operator token in
+  `hello-ok.auth.deviceTokens` for trusted mobile handoff. The operator token
+  excludes `operator.admin`, `operator.pairing`, and `operator.talk.secrets`.
+- While a non-baseline setup-code bootstrap is waiting for approval, `PAIRING_REQUIRED`
   details include `recommendedNextStep: "wait_then_retry"`, `retryable: true`,
   and `pauseReconnect: false`. Clients should keep reconnecting with the same
   bootstrap token until the request is approved or the token becomes invalid.
-- If an older or custom trusted bootstrap flow includes optional
-  `hello-ok.auth.deviceTokens` entries, persist them only when the connect used
-  bootstrap auth on a trusted transport such as `wss://` or loopback/local
-  pairing.
+- Persist `hello-ok.auth.deviceTokens` only when the connect used bootstrap auth
+  on a trusted transport such as `wss://` or loopback/local pairing.
 - If a client supplies an **explicit** `deviceToken` or explicit `scopes`, that
   caller-requested scope set remains authoritative; cached scopes are only
   reused when the client is reusing the stored per-device token.

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -1028,11 +1028,11 @@ export function registerControlUiAndPairingSuite(): void {
     }
   });
 
-  test("requires approval before qr setup code returns a durable node token", async () => {
+  test("qr setup code returns node token plus bounded operator handoff", async () => {
     const { issueDeviceBootstrapToken, verifyDeviceBootstrapToken } =
       await import("../infra/device-bootstrap.js");
     const { publicKeyRawBase64UrlFromPem } = await import("../infra/device-identity.js");
-    const { approveDevicePairing, getPairedDevice, listDevicePairing, verifyDeviceToken } =
+    const { getPairedDevice, listDevicePairing, verifyDeviceToken } =
       await import("../infra/device-pairing.js");
     const { server, port, prevToken } = await startControlUiServer("secret");
 
@@ -1058,47 +1058,8 @@ export function registerControlUiAndPairingSuite(): void {
         client,
         deviceIdentityPath: identityPath,
       });
-      expect(initial.ok).toBe(false);
-      expect(initial.error?.message ?? "").toContain("pairing required");
-      const initialDetails = initial.error?.details as
-        | {
-            code?: string;
-            pauseReconnect?: boolean;
-            recommendedNextStep?: string;
-            retryable?: boolean;
-          }
-        | undefined;
-      expect(initialDetails?.code).toBe(ConnectErrorDetailCodes.PAIRING_REQUIRED);
-      expect(initialDetails?.recommendedNextStep).toBe("wait_then_retry");
-      expect(initialDetails?.retryable).toBe(true);
-      expect(initialDetails?.pauseReconnect).toBe(false);
-
-      const pendingAfterInitial = await listDevicePairing();
-      const pendingForDevice = pendingAfterInitial.pending.filter(
-        (entry) => entry.deviceId === identity.deviceId,
-      );
-      expect(pendingForDevice).toHaveLength(1);
-      expect(pendingForDevice[0]?.role).toBe("node");
-      expect(pendingForDevice[0]?.roles).toEqual(["node"]);
-      expect(await getPairedDevice(identity.deviceId)).toBeNull();
-      expect(
-        await approveDevicePairing(pendingForDevice[0]?.requestId ?? "", {
-          callerScopes: ["operator.pairing"],
-        }),
-      ).toMatchObject({ status: "approved" });
-      wsBootstrap.close();
-
-      const wsApproved = await openWs(port, REMOTE_BOOTSTRAP_HEADERS);
-      const approvedConnect = await connectReq(wsApproved, {
-        skipDefaultAuth: true,
-        bootstrapToken: issued.token,
-        role: "node",
-        scopes: [],
-        client,
-        deviceIdentityPath: identityPath,
-      });
-      expect(approvedConnect.ok).toBe(true);
-      const approvedPayload = approvedConnect.payload as
+      expect(initial.ok).toBe(true);
+      const approvedPayload = initial.payload as
         | {
             type?: string;
             auth?: {
@@ -1120,26 +1081,47 @@ export function registerControlUiAndPairingSuite(): void {
       }
       expect(approvedPayload?.auth?.role).toBe("node");
       expect(approvedPayload?.auth?.scopes ?? []).toEqual([]);
-      expect(approvedPayload?.auth?.deviceTokens ?? []).toEqual([]);
+      const operatorHandoff = approvedPayload?.auth?.deviceTokens?.find(
+        (entry) => entry.role === "operator",
+      );
+      const issuedOperatorToken = operatorHandoff?.deviceToken;
+      if (!issuedOperatorToken) {
+        throw new Error("expected handed-off operator device token");
+      }
+      expect(operatorHandoff?.scopes).toEqual([
+        "operator.approvals",
+        "operator.read",
+        "operator.write",
+      ]);
+      expect(operatorHandoff?.scopes).not.toContain("operator.admin");
+      expect(operatorHandoff?.scopes).not.toContain("operator.pairing");
+
+      const pendingAfterInitial = await listDevicePairing();
+      const pendingForDevice = pendingAfterInitial.pending.filter(
+        (entry) => entry.deviceId === identity.deviceId,
+      );
+      expect(pendingForDevice).toEqual([]);
+      wsBootstrap.close();
 
       const afterBootstrap = await listDevicePairing();
       expect(
         afterBootstrap.pending.filter((entry) => entry.deviceId === identity.deviceId),
       ).toEqual([]);
       const paired = await getPairedDevice(identity.deviceId);
-      expect(paired?.roles).toEqual(["node"]);
-      expect(paired?.approvedScopes).toEqual([]);
+      expect(paired?.roles).toEqual(["node", "operator"]);
+      expect(paired?.approvedScopes).toEqual([
+        "operator.approvals",
+        "operator.read",
+        "operator.write",
+      ]);
       expect(paired?.tokens?.node?.token).toBe(issuedDeviceToken);
-      expect(paired?.tokens?.operator).toBeUndefined();
-
-      await new Promise<void>((resolve) => {
-        if (wsApproved.readyState === WebSocket.CLOSED) {
-          resolve();
-          return;
-        }
-        wsApproved.once("close", () => resolve());
-        wsApproved.close();
-      });
+      expect(paired?.tokens?.node?.scopes).toEqual([]);
+      expect(paired?.tokens?.operator?.token).toBe(issuedOperatorToken);
+      expect(paired?.tokens?.operator?.scopes).toEqual([
+        "operator.approvals",
+        "operator.read",
+        "operator.write",
+      ]);
 
       const wsReplay = await openWs(port, REMOTE_BOOTSTRAP_HEADERS);
       const replay = await connectReq(wsReplay, {
@@ -1189,23 +1171,34 @@ export function registerControlUiAndPairingSuite(): void {
       await expect(
         verifyDeviceToken({
           deviceId: identity.deviceId,
-          token: issuedDeviceToken,
+          token: issuedOperatorToken,
           role: "operator",
-          scopes: [
-            "operator.approvals",
-            "operator.read",
-            "operator.talk.secrets",
-            "operator.write",
-          ],
+          scopes: ["operator.approvals", "operator.read", "operator.write"],
         }),
-      ).resolves.toEqual({ ok: false, reason: "token-missing" });
+      ).resolves.toEqual({ ok: true });
+      await expect(
+        verifyDeviceToken({
+          deviceId: identity.deviceId,
+          token: issuedOperatorToken,
+          role: "operator",
+          scopes: ["operator.admin"],
+        }),
+      ).resolves.toEqual({ ok: false, reason: "scope-mismatch" });
+      await expect(
+        verifyDeviceToken({
+          deviceId: identity.deviceId,
+          token: issuedOperatorToken,
+          role: "operator",
+          scopes: ["operator.pairing"],
+        }),
+      ).resolves.toEqual({ ok: false, reason: "scope-mismatch" });
     } finally {
       await server.close();
       restoreGatewayToken(prevToken);
     }
   });
 
-  test("rejected qr setup code cannot recreate pending node pairing", async () => {
+  test("rejected non-baseline bootstrap request cannot recreate pending node pairing", async () => {
     const { issueDeviceBootstrapToken } = await import("../infra/device-bootstrap.js");
     const { listDevicePairing, rejectDevicePairing } = await import("../infra/device-pairing.js");
     const { server, port, prevToken } = await startControlUiServer("secret");
@@ -1221,7 +1214,12 @@ export function registerControlUiAndPairingSuite(): void {
     };
 
     try {
-      const issued = await issueDeviceBootstrapToken();
+      const issued = await issueDeviceBootstrapToken({
+        profile: {
+          roles: ["node"],
+          scopes: [],
+        },
+      });
       const wsInitial = await openWs(port, REMOTE_BOOTSTRAP_HEADERS);
       const initial = await connectReq(wsInitial, {
         skipDefaultAuth: true,

--- a/src/gateway/server.auth.control-ui.suite.ts
+++ b/src/gateway/server.auth.control-ui.suite.ts
@@ -1198,6 +1198,94 @@ export function registerControlUiAndPairingSuite(): void {
     }
   });
 
+  test("qr bootstrap retry keeps bounded operator handoff after paired approval", async () => {
+    const { issueDeviceBootstrapToken, verifyDeviceBootstrapToken } =
+      await import("../infra/device-bootstrap.js");
+    const { publicKeyRawBase64UrlFromPem } = await import("../infra/device-identity.js");
+    const { approveBootstrapDevicePairing, requestDevicePairing } =
+      await import("../infra/device-pairing.js");
+    const { PAIRING_SETUP_BOOTSTRAP_PROFILE } =
+      await import("../shared/device-bootstrap-profile.js");
+    const { server, port, prevToken } = await startControlUiServer("secret");
+    const { identityPath, identity } = await createOperatorIdentityFixture(
+      "openclaw-bootstrap-node-retry-",
+    );
+    const client = {
+      id: "openclaw-ios",
+      version: "2026.3.30",
+      platform: "iOS 26.3.1",
+      mode: "node",
+      deviceFamily: "iPhone",
+    };
+
+    try {
+      const issued = await issueDeviceBootstrapToken();
+      const publicKey = publicKeyRawBase64UrlFromPem(identity.publicKeyPem);
+      const pending = await requestDevicePairing({
+        deviceId: identity.deviceId,
+        publicKey,
+        role: "node",
+        roles: ["node", "operator"],
+        scopes: ["operator.approvals", "operator.read", "operator.write"],
+        clientId: client.id,
+        clientMode: client.mode,
+        displayName: client.id,
+        platform: client.platform,
+        deviceFamily: client.deviceFamily,
+        silent: true,
+      });
+      await approveBootstrapDevicePairing(
+        pending.request.requestId,
+        PAIRING_SETUP_BOOTSTRAP_PROFILE,
+      );
+
+      const wsRetry = await openWs(port, REMOTE_BOOTSTRAP_HEADERS);
+      const retry = await connectReq(wsRetry, {
+        skipDefaultAuth: true,
+        bootstrapToken: issued.token,
+        role: "node",
+        scopes: [],
+        client,
+        deviceIdentityPath: identityPath,
+      });
+      expect(retry.ok).toBe(true);
+      const payload = retry.payload as
+        | {
+            auth?: {
+              deviceToken?: string;
+              deviceTokens?: Array<{ deviceToken?: string; role?: string; scopes?: string[] }>;
+            };
+          }
+        | undefined;
+      expect(payload?.auth?.deviceToken).toBeTruthy();
+      const operatorHandoff = payload?.auth?.deviceTokens?.find(
+        (entry) => entry.role === "operator",
+      );
+      expect(operatorHandoff?.deviceToken).toBeTruthy();
+      expect(operatorHandoff?.scopes).toEqual([
+        "operator.approvals",
+        "operator.read",
+        "operator.write",
+      ]);
+      expect(operatorHandoff?.scopes).not.toContain("operator.admin");
+      expect(operatorHandoff?.scopes).not.toContain("operator.pairing");
+      wsRetry.close();
+
+      await expect(
+        verifyDeviceBootstrapToken({
+          token: issued.token,
+          deviceId: identity.deviceId,
+          publicKey,
+          role: "node",
+          scopes: [],
+        }),
+      ).resolves.toEqual({ ok: false, reason: "bootstrap_token_invalid" });
+    } finally {
+      await server.close();
+      restoreGatewayToken(prevToken);
+    }
+  });
+
   test("rejected non-baseline bootstrap request cannot recreate pending node pairing", async () => {
     const { issueDeviceBootstrapToken } = await import("../infra/device-bootstrap.js");
     const { listDevicePairing, rejectDevicePairing } = await import("../infra/device-pairing.js");

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -1374,6 +1374,37 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
               }
             }
 
+            const retryBootstrapHandoffProfile =
+              authMethod === "bootstrap-token" &&
+              bootstrapTokenCandidate &&
+              role === "node" &&
+              scopes.length === 0 &&
+              !isControlUi &&
+              !isBrowserOperatorUi &&
+              !isWebchat &&
+              connectParams.client.mode === GATEWAY_CLIENT_MODES.NODE &&
+              pairedRoles.includes("operator") &&
+              roleScopesAllow({
+                role: "operator",
+                requestedScopes: BOOTSTRAP_HANDOFF_OPERATOR_SCOPES,
+                allowedScopes: pairedScopes,
+              })
+                ? await getBoundDeviceBootstrapProfile({
+                    token: bootstrapTokenCandidate,
+                    deviceId: device.id,
+                    publicKey: devicePublicKey,
+                  })
+                : null;
+            if (
+              retryBootstrapHandoffProfile &&
+              sameBootstrapProfile(retryBootstrapHandoffProfile, PAIRING_SETUP_BOOTSTRAP_PROFILE)
+            ) {
+              // If the first QR bootstrap hello-ok failed to reach mobile, the
+              // bootstrap token is restored while the paired device already has
+              // node+operator grants. Preserve the same bounded handoff on retry.
+              handoffBootstrapProfile = retryBootstrapHandoffProfile;
+            }
+
             // Metadata pinning is approval-bound. Reconnects can update access metadata
             // and same-family mobile OS version labels, but real platform/device-family
             // changes must stay on the approved pairing record.

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import type { RawData, WebSocket } from "ws";
 import { getRuntimeConfig } from "../../../config/io.js";
 import {
+  getBoundDeviceBootstrapProfile,
   getDeviceBootstrapTokenProfile,
   redeemDeviceBootstrapTokenProfile,
   revokeDeviceBootstrapToken,
@@ -14,6 +15,7 @@ import {
   normalizeDevicePublicKeyBase64Url,
 } from "../../../infra/device-identity.js";
 import {
+  approveBootstrapDevicePairing,
   approveDevicePairing,
   ensureDeviceToken,
   getPairedDevice,
@@ -41,6 +43,12 @@ import { loadVoiceWakeConfig } from "../../../infra/voicewake.js";
 import { rawDataToString } from "../../../infra/ws.js";
 import { logRejectedLargePayload } from "../../../logging/diagnostic-payload.js";
 import type { createSubsystemLogger } from "../../../logging/subsystem.js";
+import {
+  BOOTSTRAP_HANDOFF_OPERATOR_SCOPES,
+  PAIRING_SETUP_BOOTSTRAP_PROFILE,
+  resolveBootstrapProfileScopesForRole,
+  type DeviceBootstrapProfile,
+} from "../../../shared/device-bootstrap-profile.js";
 import { roleScopesAllow } from "../../../shared/operator-scope-compat.js";
 import {
   isBrowserOperatorUiClient,
@@ -145,6 +153,19 @@ import { isUnauthorizedRoleError, UnauthorizedFloodGuard } from "./unauthorized-
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 
 const DEVICE_SIGNATURE_SKEW_MS = 2 * 60 * 1000;
+
+function sameBootstrapProfile(
+  left: DeviceBootstrapProfile,
+  right: DeviceBootstrapProfile,
+): boolean {
+  if (left.roles.length !== right.roles.length || left.scopes.length !== right.scopes.length) {
+    return false;
+  }
+  return (
+    left.roles.every((role, index) => role === right.roles[index]) &&
+    left.scopes.every((scope, index) => scope === right.scopes[index])
+  );
+}
 
 export type WsOriginCheckMetrics = {
   hostHeaderFallbackAccepted: number;
@@ -957,6 +978,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           authMethod === "bootstrap-token" && bootstrapTokenCandidate
             ? await getDeviceBootstrapTokenProfile({ token: bootstrapTokenCandidate })
             : null;
+        let handoffBootstrapProfile: DeviceBootstrapProfile | null = null;
         const trustedProxyAuthOk = isTrustedProxyControlUiOperatorAuth({
           isControlUi,
           role,
@@ -1076,14 +1098,50 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
                 autoApproveCidrs: configSnapshot.gateway?.nodes?.pairing?.autoApproveCidrs,
               },
             );
+            const boundBootstrapProfile =
+              authMethod === "bootstrap-token" &&
+              bootstrapTokenCandidate &&
+              reason === "not-paired" &&
+              role === "node" &&
+              scopes.length === 0 &&
+              !existingPairedDevice &&
+              !isControlUi &&
+              !isBrowserOperatorUi &&
+              !isWebchat &&
+              connectParams.client.mode === GATEWAY_CLIENT_MODES.NODE
+                ? await getBoundDeviceBootstrapProfile({
+                    token: bootstrapTokenCandidate,
+                    deviceId: device.id,
+                    publicKey: devicePublicKey,
+                  })
+                : null;
+            const allowSilentBootstrapPairing =
+              boundBootstrapProfile !== null &&
+              sameBootstrapProfile(boundBootstrapProfile, PAIRING_SETUP_BOOTSTRAP_PROFILE);
+            // This is the native QR/setup-code onboarding seam. Mobile clients
+            // connect as node with bootstrap auth, then clear bootstrap auth and
+            // start their operator loop only if hello-ok includes the bounded
+            // operator token below. Keep this limited to the exact fresh baseline
+            // profile; admin/pairing scopes still require an explicit owner flow.
+            const bootstrapPairingRoles = allowSilentBootstrapPairing
+              ? Array.from(new Set([role, ...boundBootstrapProfile.roles]))
+              : undefined;
             const pairing = await requestDevicePairing({
               deviceId: device.id,
               publicKey: devicePublicKey,
               ...clientPairingMetadata,
+              ...(bootstrapPairingRoles
+                ? {
+                    roles: bootstrapPairingRoles,
+                    scopes: [...BOOTSTRAP_HANDOFF_OPERATOR_SCOPES],
+                  }
+                : {}),
               silent:
                 reason === "scope-upgrade"
                   ? false
-                  : allowSilentLocalPairing || allowSilentTrustedCidrsNodePairing,
+                  : allowSilentLocalPairing ||
+                    allowSilentTrustedCidrsNodePairing ||
+                    allowSilentBootstrapPairing,
             });
             const context = buildRequestContext();
             let approved: Awaited<ReturnType<typeof approveDevicePairing>> | undefined;
@@ -1104,10 +1162,19 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
               return replacementPending?.requestId;
             };
             if (pairing.request.silent === true) {
-              approved = await approveDevicePairing(pairing.request.requestId, {
-                callerScopes: scopes,
-              });
+              approved =
+                allowSilentBootstrapPairing && boundBootstrapProfile
+                  ? await approveBootstrapDevicePairing(
+                      pairing.request.requestId,
+                      boundBootstrapProfile,
+                    )
+                  : await approveDevicePairing(pairing.request.requestId, {
+                      callerScopes: scopes,
+                    });
               if (approved?.status === "approved") {
+                if (allowSilentBootstrapPairing && boundBootstrapProfile) {
+                  handoffBootstrapProfile = boundBootstrapProfile;
+                }
                 logGateway.info(
                   `device pairing auto-approved device=${approved.device.deviceId} role=${approved.device.role ?? "unknown"}`,
                 );
@@ -1324,6 +1391,51 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           shouldIssueDeviceToken && device && hasServerApprovedDeviceTokenBaseline
             ? await ensureDeviceToken({ deviceId: device.id, role, scopes })
             : null;
+        const bootstrapDeviceTokens: Array<{
+          deviceToken: string;
+          role: string;
+          scopes: string[];
+          issuedAtMs: number;
+        }> = [];
+        if (deviceToken) {
+          bootstrapDeviceTokens.push({
+            deviceToken: deviceToken.token,
+            role: deviceToken.role,
+            scopes: deviceToken.scopes,
+            issuedAtMs: deviceToken.rotatedAtMs ?? deviceToken.createdAtMs,
+          });
+        }
+        if (device && handoffBootstrapProfile) {
+          for (const bootstrapRole of handoffBootstrapProfile.roles) {
+            if (bootstrapDeviceTokens.some((entry) => entry.role === bootstrapRole)) {
+              continue;
+            }
+            // Extra hello-ok handoff tokens are only emitted for the approved
+            // setup-code profile. Operator scopes are filtered through the
+            // documented allowlist so QR bootstrap cannot grant admin/pairing.
+            const bootstrapRoleScopes =
+              bootstrapRole === "operator"
+                ? resolveBootstrapProfileScopesForRole(
+                    bootstrapRole,
+                    handoffBootstrapProfile.scopes,
+                  )
+                : [];
+            const extraToken = await ensureDeviceToken({
+              deviceId: device.id,
+              role: bootstrapRole,
+              scopes: bootstrapRoleScopes,
+            });
+            if (!extraToken) {
+              continue;
+            }
+            bootstrapDeviceTokens.push({
+              deviceToken: extraToken.token,
+              role: extraToken.role,
+              scopes: extraToken.scopes,
+              issuedAtMs: extraToken.rotatedAtMs ?? extraToken.createdAtMs,
+            });
+          }
+        }
         if (role === "node") {
           const reconciliation = await reconcileNodePairingOnConnect({
             cfg: getRuntimeConfig(),
@@ -1565,6 +1677,9 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
               ? {
                   deviceToken: deviceToken.token,
                   issuedAtMs: deviceToken.rotatedAtMs ?? deviceToken.createdAtMs,
+                  ...(bootstrapDeviceTokens.length > 1
+                    ? { deviceTokens: bootstrapDeviceTokens.slice(1) }
+                    : {}),
                 }
               : {}),
           },
@@ -1580,13 +1695,13 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
           | undefined;
         if (authMethod === "bootstrap-token" && bootstrapTokenCandidate && device) {
           try {
-            if (issuedBootstrapProfile) {
+            if (handoffBootstrapProfile || issuedBootstrapProfile) {
               const redemption = await redeemDeviceBootstrapTokenProfile({
                 token: bootstrapTokenCandidate,
                 role,
                 scopes,
               });
-              if (redemption.fullyRedeemed) {
+              if (handoffBootstrapProfile || redemption.fullyRedeemed) {
                 const revoked = await revokeDeviceBootstrapToken({
                   token: bootstrapTokenCandidate,
                 });

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -1405,8 +1405,10 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
             issuedAtMs: deviceToken.rotatedAtMs ?? deviceToken.createdAtMs,
           });
         }
-        if (device && handoffBootstrapProfile) {
-          for (const bootstrapRole of handoffBootstrapProfile.roles) {
+        const approvedHandoffBootstrapProfile =
+          handoffBootstrapProfile as DeviceBootstrapProfile | null;
+        if (device && approvedHandoffBootstrapProfile) {
+          for (const bootstrapRole of approvedHandoffBootstrapProfile.roles) {
             if (bootstrapDeviceTokens.some((entry) => entry.role === bootstrapRole)) {
               continue;
             }
@@ -1417,7 +1419,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
               bootstrapRole === "operator"
                 ? resolveBootstrapProfileScopesForRole(
                     bootstrapRole,
-                    handoffBootstrapProfile.scopes,
+                    approvedHandoffBootstrapProfile.scopes,
                   )
                 : [];
             const extraToken = await ensureDeviceToken({

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -1436,8 +1436,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
             issuedAtMs: deviceToken.rotatedAtMs ?? deviceToken.createdAtMs,
           });
         }
-        const approvedHandoffBootstrapProfile =
-          handoffBootstrapProfile as DeviceBootstrapProfile | null;
+        const approvedHandoffBootstrapProfile = handoffBootstrapProfile;
         if (device && approvedHandoffBootstrapProfile) {
           for (const bootstrapRole of approvedHandoffBootstrapProfile.roles) {
             if (bootstrapDeviceTokens.some((entry) => entry.role === bootstrapRole)) {

--- a/src/infra/device-bootstrap.test.ts
+++ b/src/infra/device-bootstrap.test.ts
@@ -71,8 +71,8 @@ describe("device bootstrap tokens", () => {
     expect(parsed[issued.token]?.ts).toBe(Date.now());
     expect(parsed[issued.token]?.issuedAtMs).toBe(Date.now());
     expect(parsed[issued.token]?.profile).toEqual({
-      roles: ["node"],
-      scopes: [],
+      roles: ["node", "operator"],
+      scopes: ["operator.approvals", "operator.read", "operator.write"],
     });
   });
 
@@ -82,6 +82,12 @@ describe("device bootstrap tokens", () => {
 
     await expect(verifyBootstrapToken(baseDir, issued.token)).resolves.toEqual({ ok: true });
     await expect(verifyBootstrapToken(baseDir, issued.token)).resolves.toEqual({ ok: true });
+    await expect(
+      verifyBootstrapToken(baseDir, issued.token, {
+        deviceId: "device-456",
+        publicKey: "public-key-456",
+      }),
+    ).resolves.toEqual({ ok: false, reason: "bootstrap_token_invalid" });
 
     const raw = await fs.readFile(resolveBootstrapPath(baseDir), "utf8");
     const parsed = JSON.parse(raw) as Record<
@@ -151,8 +157,8 @@ describe("device bootstrap tokens", () => {
 
     await expect(getDeviceBootstrapTokenProfile({ baseDir, token: issued.token })).resolves.toEqual(
       {
-        roles: ["node"],
-        scopes: [],
+        roles: ["node", "operator"],
+        scopes: ["operator.approvals", "operator.read", "operator.write"],
       },
     );
     await expect(getDeviceBootstrapTokenProfile({ baseDir, token: "invalid" })).resolves.toBeNull();
@@ -160,7 +166,13 @@ describe("device bootstrap tokens", () => {
 
   it("persists bootstrap redemption state across verification reloads", async () => {
     const baseDir = await createTempDir();
-    const issued = await issueDeviceBootstrapToken({ baseDir });
+    const issued = await issueDeviceBootstrapToken({
+      baseDir,
+      profile: {
+        roles: ["node"],
+        scopes: [],
+      },
+    });
 
     await expect(verifyBootstrapToken(baseDir, issued.token)).resolves.toEqual({ ok: true });
     await expect(
@@ -290,7 +302,7 @@ describe("device bootstrap tokens", () => {
     expect(raw).toContain(issued.token);
   });
 
-  it("rejects bootstrap verification when role or scopes exceed the issued profile", async () => {
+  it("rejects bootstrap verification when scopes exceed the issued profile", async () => {
     const baseDir = await createTempDir();
     const issued = await issueDeviceBootstrapToken({ baseDir });
 
@@ -387,7 +399,7 @@ describe("device bootstrap tokens", () => {
     await expect(getDeviceBootstrapTokenProfile({ baseDir, token: issued.token })).resolves.toEqual(
       {
         roles: ["node", "operator"],
-        scopes: ["operator.approvals", "operator.read", "operator.talk.secrets", "operator.write"],
+        scopes: ["operator.approvals", "operator.read", "operator.write"],
       },
     );
     await expect(
@@ -451,7 +463,7 @@ describe("device bootstrap tokens", () => {
     >;
     expect(parsed[issued.token]?.redeemedProfile).toEqual({
       roles: ["operator"],
-      scopes: ["operator.approvals", "operator.read", "operator.talk.secrets", "operator.write"],
+      scopes: ["operator.approvals", "operator.read", "operator.write"],
     });
   });
 
@@ -532,8 +544,8 @@ describe("device bootstrap tokens", () => {
         baseDir,
       }),
     ).resolves.toEqual({
-      roles: ["node"],
-      scopes: [],
+      roles: ["node", "operator"],
+      scopes: ["operator.approvals", "operator.read", "operator.write"],
     });
   });
 

--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -1062,15 +1062,15 @@ describe("device pairing tokens", () => {
     expect(paired?.tokens?.operator).toBeUndefined();
   });
 
-  test("default bootstrap pairing does not issue operator tokens", async () => {
+  test("baseline bootstrap pairing issues bounded operator token when requested by QR handoff", async () => {
     const baseDir = await makeDevicePairingDir();
     const request = await requestDevicePairing(
       {
         deviceId: "bootstrap-device-operator-default",
         publicKey: "bootstrap-public-key-operator-default",
         role: "node",
-        roles: ["node"],
-        scopes: [],
+        roles: ["node", "operator"],
+        scopes: ["operator.approvals", "operator.read", "operator.write"],
         silent: true,
       },
       baseDir,
@@ -1084,16 +1084,40 @@ describe("device pairing tokens", () => {
     expectRecordFields(approved, "approved result", { status: "approved" });
 
     const paired = await getPairedDevice("bootstrap-device-operator-default", baseDir);
-    const nodeToken = requireToken(paired?.tokens?.node?.token);
+    const operatorToken = requireToken(paired?.tokens?.operator?.token);
+    expect(paired?.tokens?.node?.scopes).toStrictEqual([]);
+    expect(paired?.tokens?.operator?.scopes).toStrictEqual([
+      "operator.approvals",
+      "operator.read",
+      "operator.write",
+    ]);
     await expect(
       verifyDeviceToken({
         deviceId: "bootstrap-device-operator-default",
-        token: nodeToken,
+        token: operatorToken,
         role: "operator",
         scopes: ["operator.approvals", "operator.read", "operator.write"],
         baseDir,
       }),
-    ).resolves.toEqual({ ok: false, reason: "token-missing" });
+    ).resolves.toEqual({ ok: true });
+    await expect(
+      verifyDeviceToken({
+        deviceId: "bootstrap-device-operator-default",
+        token: operatorToken,
+        role: "operator",
+        scopes: ["operator.admin"],
+        baseDir,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "scope-mismatch" });
+    await expect(
+      verifyDeviceToken({
+        deviceId: "bootstrap-device-operator-default",
+        token: operatorToken,
+        role: "operator",
+        scopes: ["operator.pairing"],
+        baseDir,
+      }),
+    ).resolves.toEqual({ ok: false, reason: "scope-mismatch" });
   });
 
   test("bootstrap node approval preserves existing operator token scopes", async () => {
@@ -1173,13 +1197,7 @@ describe("device pairing tokens", () => {
         publicKey: "bootstrap-public-key-bounded-baseline",
         role: "node",
         roles: ["node", "operator"],
-        scopes: [
-          "node.exec",
-          "operator.approvals",
-          "operator.read",
-          "operator.talk.secrets",
-          "operator.write",
-        ],
+        scopes: ["node.exec", "operator.approvals", "operator.read", "operator.write"],
         silent: true,
       },
       baseDir,
@@ -1207,13 +1225,11 @@ describe("device pairing tokens", () => {
     expect(paired?.approvedScopes).toEqual([
       "operator.approvals",
       "operator.read",
-      "operator.talk.secrets",
       "operator.write",
     ]);
     expect(paired?.tokens?.operator?.scopes).toEqual([
       "operator.approvals",
       "operator.read",
-      "operator.talk.secrets",
       "operator.write",
     ]);
     expect(paired?.tokens?.node?.scopes).toStrictEqual([]);
@@ -1231,7 +1247,7 @@ describe("device pairing tokens", () => {
     const baseDir = await makeDevicePairingDir();
     const bootstrapProfile = {
       roles: ["node", "operator"],
-      scopes: ["operator.approvals", "operator.read", "operator.talk.secrets", "operator.write"],
+      scopes: ["operator.approvals", "operator.read", "operator.write"],
     };
     const first = await requestDevicePairing(
       {

--- a/src/pairing/setup-code.test.ts
+++ b/src/pairing/setup-code.test.ts
@@ -91,8 +91,8 @@ describe("pairing setup code", () => {
     expect(issueDeviceBootstrapTokenMock).toHaveBeenCalledWith({
       baseDir: undefined,
       profile: {
-        roles: ["node"],
-        scopes: [],
+        roles: ["node", "operator"],
+        scopes: ["operator.approvals", "operator.read", "operator.write"],
       },
     });
     if (params.url) {

--- a/src/shared/device-bootstrap-profile.test.ts
+++ b/src/shared/device-bootstrap-profile.test.ts
@@ -57,10 +57,10 @@ describe("device bootstrap profile", () => {
     });
   });
 
-  test("default setup profile is node-only", () => {
+  test("default setup profile carries node plus bounded operator handoff", () => {
     expect(PAIRING_SETUP_BOOTSTRAP_PROFILE).toEqual({
-      roles: ["node"],
-      scopes: [],
+      roles: ["node", "operator"],
+      scopes: ["operator.approvals", "operator.read", "operator.write"],
     });
   });
 
@@ -68,7 +68,6 @@ describe("device bootstrap profile", () => {
     expect([...BOOTSTRAP_HANDOFF_OPERATOR_SCOPES]).toEqual([
       "operator.approvals",
       "operator.read",
-      "operator.talk.secrets",
       "operator.write",
     ]);
   });

--- a/src/shared/device-bootstrap-profile.ts
+++ b/src/shared/device-bootstrap-profile.ts
@@ -13,15 +13,17 @@ export type DeviceBootstrapProfileInput = {
 export const BOOTSTRAP_HANDOFF_OPERATOR_SCOPES = [
   "operator.approvals",
   "operator.read",
-  "operator.talk.secrets",
   "operator.write",
 ] as const;
 
 const BOOTSTRAP_HANDOFF_OPERATOR_SCOPE_SET = new Set<string>(BOOTSTRAP_HANDOFF_OPERATOR_SCOPES);
 
 export const PAIRING_SETUP_BOOTSTRAP_PROFILE: DeviceBootstrapProfile = {
-  roles: ["node"],
-  scopes: [],
+  // QR/setup-code bootstrap must hand off both tokens for native onboarding:
+  // iOS/Android suppress the operator loop while bootstrap auth is active and
+  // only start it after persisting this bounded operator token.
+  roles: ["node", "operator"],
+  scopes: [...BOOTSTRAP_HANDOFF_OPERATOR_SCOPES],
 };
 
 export function resolveBootstrapProfileScopesForRole(


### PR DESCRIPTION
## Summary
- restore QR/setup-code bootstrap handoff so native onboarding receives both the primary node token and a bounded operator token
- keep the QR operator token limited to `operator.approvals`, `operator.read`, and `operator.write`
- document the native mobile contract and cover the gateway/client handoff with focused tests

## Root Cause
PR #81292 / commit `b17e77a22b` changed the built-in setup-code bootstrap profile to node-only and removed the `hello-ok.auth.deviceTokens` handoff. That reversed the mobile onboarding behavior restored by PR #58382 / commit `69fe999373`, where iOS and Android suppress the operator loop during bootstrap auth and only start it after persisting an operator token from the trusted bootstrap handoff.

## Verification
- `pnpm docs:list`
- `git diff --check`
- `node scripts/run-vitest.mjs src/shared/device-bootstrap-profile.test.ts src/infra/device-bootstrap.test.ts src/infra/device-pairing.test.ts`
- `node scripts/run-vitest.mjs src/gateway/server.auth.control-ui.test.ts`
- `swift test --package-path apps/shared/OpenClawKit --filter GatewayNodeSessionTests`
- `CODEX_REVIEW_AUTO_TESTS=0 bash /Users/guti/.codex/skills/codex-review/scripts/codex-review --mode local`

## Real Behavior Proof
Behavior addressed: mobile QR/setup-code onboarding again receives a node token plus a minimally scoped operator token from the trusted bootstrap handoff.
Real environment tested: local Codex worktree on macOS, gateway/bootstrap Vitest suites, shared Swift package tests.
Exact steps or command run after this patch: `node scripts/run-vitest.mjs src/shared/device-bootstrap-profile.test.ts src/infra/device-bootstrap.test.ts src/infra/device-pairing.test.ts`; `node scripts/run-vitest.mjs src/gateway/server.auth.control-ui.test.ts`; `swift test --package-path apps/shared/OpenClawKit --filter GatewayNodeSessionTests`; `git diff --check`; `pnpm docs:list`; `codex-review --mode local`.
Evidence after fix: gateway tests assert `hello-ok.auth.deviceTokens` includes the operator handoff token for QR bootstrap, paired devices have node + operator tokens, allowed operator scopes are bounded, and admin/pairing replay paths still fail.
Observed result after fix: focused gateway/bootstrap tests, Swift handoff tests, docs listing, diff check, and codex-review all passed.
What was not tested: Android Gradle unit tests could not start because this worktree has no configured Android SDK location (`ANDROID_HOME` or `apps/android/local.properties`).
