### PR TITLE
fix(ci): authenticate proof verdict markers

### DIFF
--- a/.github/workflows/real-behavior-proof.yml
+++ b/.github/workflows/real-behavior-proof.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           app-id: "2729701"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permission-issues: read
           permission-members: read
       - uses: actions/create-github-app-token@v3
         id: app-token-fallback
@@ -40,8 +41,10 @@ jobs:
         with:
           app-id: "2971289"
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY_FALLBACK }}
+          permission-issues: read
           permission-members: read
       - name: Check real behavior proof
         env:
           GH_APP_TOKEN: ${{ steps.app-token.outputs.token || steps.app-token-fallback.outputs.token }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: node scripts/github/real-behavior-proof-check.mjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CI: require real-behavior-proof verdict markers to come from the ClawSweeper GitHub App before accepting exact-head proof. (#83692)
 - Agents/image generation: allow distinct `image_generate` prompts to start separate session-backed background tasks while same-prompt retries still return the active task status. (#83614) Thanks @Elarwei001.
 - Control UI: stop the chat reading indicator from sticking after an assistant response finishes. (#83515) Thanks @njuboy11.
 - Skills: reject empty or whitespace-only skill names and descriptions during quick validation. (#27061)

--- a/scripts/github/real-behavior-proof-check.mjs
+++ b/scripts/github/real-behavior-proof-check.mjs
@@ -14,6 +14,41 @@ function escapeCommandValue(value) {
     .replace(/:/g, "%3A");
 }
 
+async function fetchProofComments({ owner, repo, issueNumber, tokens }) {
+  let lastError;
+  for (const token of tokens.filter(Boolean)) {
+    const comments = [];
+    try {
+      for (let page = 1; page <= 10; page += 1) {
+        const url = new URL(
+          `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}/comments`,
+        );
+        url.searchParams.set("per_page", "100");
+        url.searchParams.set("page", String(page));
+        const response = await fetch(url, {
+          headers: {
+            Accept: "application/vnd.github+json",
+            Authorization: `Bearer ${token}`,
+            "X-GitHub-Api-Version": "2022-11-28",
+          },
+        });
+        if (!response.ok) {
+          throw new Error(`comments API returned ${response.status}`);
+        }
+        const pageComments = await response.json();
+        comments.push(...pageComments);
+        if (pageComments.length < 100) {
+          break;
+        }
+      }
+      return comments;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError ?? new Error("No GitHub token available for proof comment lookup.");
+}
+
 const eventPath = process.env.GITHUB_EVENT_PATH;
 if (!eventPath) {
   console.error("::error title=Real behavior proof failed::GITHUB_EVENT_PATH is not set.");
@@ -51,41 +86,29 @@ if (evaluation.passed) {
   process.exit(0);
 }
 
-const token = appToken || process.env.GITHUB_TOKEN;
 const repository = process.env.GITHUB_REPOSITORY;
-if (token && repository && pullRequest.number) {
+if ((appToken || process.env.GITHUB_TOKEN) && repository && pullRequest.number) {
   const [owner, repo] = repository.split("/");
-  const comments = [];
-  for (let page = 1; page <= 10; page += 1) {
-    const url = new URL(
-      `https://api.github.com/repos/${owner}/${repo}/issues/${pullRequest.number}/comments`,
-    );
-    url.searchParams.set("per_page", "100");
-    url.searchParams.set("page", String(page));
-    const response = await fetch(url, {
-      headers: {
-        Accept: "application/vnd.github+json",
-        Authorization: `Bearer ${token}`,
-        "X-GitHub-Api-Version": "2022-11-28",
-      },
+  try {
+    const comments = await fetchProofComments({
+      owner,
+      repo,
+      issueNumber: pullRequest.number,
+      tokens: [appToken, process.env.GITHUB_TOKEN],
     });
-    if (!response.ok) {
-      throw new Error(`Failed to fetch PR comments for proof verdicts: ${response.status}`);
-    }
-    const pageComments = await response.json();
-    comments.push(...pageComments);
-    if (pageComments.length < 100) {
-      break;
-    }
-  }
 
-  const clawSweeperEvaluation = evaluateClawSweeperExactHeadProof({
-    pullRequest,
-    comments,
-  });
-  if (clawSweeperEvaluation.passed) {
-    console.log(clawSweeperEvaluation.reason);
-    process.exit(0);
+    const clawSweeperEvaluation = evaluateClawSweeperExactHeadProof({
+      pullRequest,
+      comments,
+    });
+    if (clawSweeperEvaluation.passed) {
+      console.log(clawSweeperEvaluation.reason);
+      process.exit(0);
+    }
+  } catch (error) {
+    console.warn(
+      `::warning title=Proof verdict comment lookup failed::${escapeCommandValue(error?.message ?? String(error))}`,
+    );
   }
 }
 

--- a/scripts/github/real-behavior-proof-policy.mjs
+++ b/scripts/github/real-behavior-proof-policy.mjs
@@ -242,6 +242,14 @@ function extractMarkerField(marker, name) {
   return match?.[1] ?? "";
 }
 
+function isTrustedClawSweeperComment(comment) {
+  const user = comment?.user ?? comment?.author ?? {};
+  const login = String(user?.login ?? "").toLowerCase();
+  const type = String(user?.type ?? "").toLowerCase();
+  const appSlug = String(comment?.performed_via_github_app?.slug ?? "").toLowerCase();
+  return appSlug === "clawsweeper" || (login === "clawsweeper[bot]" && type === "bot");
+}
+
 export function hasClawSweeperExactHeadProof({ pullRequest, comments = [] } = {}) {
   const pullNumber = String(pullRequest?.number ?? "");
   const headSha = String(pullRequest?.head?.sha ?? pullRequest?.head_sha ?? "").toLowerCase();
@@ -250,6 +258,9 @@ export function hasClawSweeperExactHeadProof({ pullRequest, comments = [] } = {}
   }
 
   for (const comment of comments) {
+    if (!isTrustedClawSweeperComment(comment)) {
+      continue;
+    }
     const body = String(comment?.body ?? "");
     const markers = body.match(/<!--\s*clawsweeper-verdict:pass\b[\s\S]*?-->/gi) ?? [];
     for (const marker of markers) {

--- a/scripts/github/real-behavior-proof-policy.mjs
+++ b/scripts/github/real-behavior-proof-policy.mjs
@@ -243,11 +243,10 @@ function extractMarkerField(marker, name) {
 }
 
 function isTrustedClawSweeperComment(comment) {
-  const user = comment?.user ?? comment?.author ?? {};
-  const login = String(user?.login ?? "").toLowerCase();
-  const type = String(user?.type ?? "").toLowerCase();
-  const appSlug = String(comment?.performed_via_github_app?.slug ?? "").toLowerCase();
-  return appSlug === "clawsweeper" || (login === "clawsweeper[bot]" && type === "bot");
+  const appSlug = String(
+    comment?.performed_via_github_app?.slug ?? comment?.performedViaGithubApp?.slug ?? "",
+  ).toLowerCase();
+  return appSlug === "clawsweeper";
 }
 
 export function hasClawSweeperExactHeadProof({ pullRequest, comments = [] } = {}) {

--- a/test/scripts/barnacle-auto-response.test.ts
+++ b/test/scripts/barnacle-auto-response.test.ts
@@ -135,7 +135,11 @@ function barnacleGithub(
     maintainerLogins?: string[];
     removeLabelNotFound?: string[];
     repositoryRoles?: Record<string, string>;
-    comments?: Array<{ body: string; user?: { login: string; type: string } }>;
+    comments?: Array<{
+      body: string;
+      performed_via_github_app?: { slug: string };
+      user?: { login: string; type: string };
+    }>;
   } = {},
 ) {
   const maintainerLogins = new Set(
@@ -796,6 +800,9 @@ describe("barnacle-auto-response", () => {
           user: {
             login: "clawsweeper[bot]",
             type: "Bot",
+          },
+          performed_via_github_app: {
+            slug: "clawsweeper",
           },
           body: `<!-- clawsweeper-verdict:pass item=123 sha=${headSha} confidence=high -->`,
         },

--- a/test/scripts/barnacle-auto-response.test.ts
+++ b/test/scripts/barnacle-auto-response.test.ts
@@ -135,7 +135,7 @@ function barnacleGithub(
     maintainerLogins?: string[];
     removeLabelNotFound?: string[];
     repositoryRoles?: Record<string, string>;
-    comments?: Array<{ body: string }>;
+    comments?: Array<{ body: string; user?: { login: string; type: string } }>;
   } = {},
 ) {
   const maintainerLogins = new Set(
@@ -793,6 +793,10 @@ describe("barnacle-auto-response", () => {
     const { calls, github } = barnacleGithub([file("src/gateway/server.ts")], {
       comments: [
         {
+          user: {
+            login: "clawsweeper[bot]",
+            type: "Bot",
+          },
           body: `<!-- clawsweeper-verdict:pass item=123 sha=${headSha} confidence=high -->`,
         },
       ],
@@ -816,6 +820,38 @@ describe("barnacle-auto-response", () => {
     expect(calls.removeLabel).not.toContainEqual(
       expect.objectContaining({ name: PROOF_SUFFICIENT_LABEL }),
     );
+  });
+
+  it("removes sufficient proof on synchronize when the matching marker is forged", async () => {
+    const headSha = "06ee95df6608d29a395c52ba8ab53fdd93a9dc4f";
+    const { calls, github } = barnacleGithub([file("src/gateway/server.ts")], {
+      comments: [
+        {
+          user: {
+            login: "external-contributor",
+            type: "User",
+          },
+          body: `<!-- clawsweeper-verdict:pass item=123 sha=${headSha} confidence=high -->`,
+        },
+      ],
+    });
+
+    await runBarnacleAutoResponse({
+      github,
+      context: barnacleContext(
+        {
+          body: blankTemplateBody,
+          head: { sha: headSha },
+        },
+        [PROOF_SUFFICIENT_LABEL],
+        { action: "synchronize" },
+      ),
+      core: {
+        info: () => undefined,
+      },
+    });
+
+    expect(calls.removeLabel).toEqual([expectedRemoveLabel(123, PROOF_SUFFICIENT_LABEL)]);
   });
 
   it("preserves ClawSweeper's sufficient proof label on ordinary label events", async () => {

--- a/test/scripts/real-behavior-proof-policy.test.ts
+++ b/test/scripts/real-behavior-proof-policy.test.ts
@@ -190,6 +190,9 @@ describe("real-behavior-proof-policy", () => {
           login: "clawsweeper[bot]",
           type: "Bot",
         },
+        performed_via_github_app: {
+          slug: "clawsweeper",
+        },
         body: [
           "Codex review: passed.",
           "<!-- clawsweeper-verdict:pass item=83581 sha=06ee95df6608d29a395c52ba8ab53fdd93a9dc4f confidence=high -->",
@@ -222,6 +225,27 @@ describe("real-behavior-proof-policy", () => {
         user: {
           login: "external-contributor",
           type: "User",
+        },
+        body: "<!-- clawsweeper-verdict:pass item=83581 sha=06ee95df6608d29a395c52ba8ab53fdd93a9dc4f confidence=high -->",
+      },
+    ];
+
+    expect(hasClawSweeperExactHeadProof({ pullRequest, comments })).toBe(false);
+    expect(evaluateClawSweeperExactHeadProof({ pullRequest, comments }).passed).toBe(false);
+  });
+
+  it("rejects bot-shaped ClawSweeper pass verdict markers without the GitHub App source", () => {
+    const pullRequest = {
+      number: 83581,
+      head: {
+        sha: "06ee95df6608d29a395c52ba8ab53fdd93a9dc4f",
+      },
+    };
+    const comments = [
+      {
+        user: {
+          login: "clawsweeper[bot]",
+          type: "Bot",
         },
         body: "<!-- clawsweeper-verdict:pass item=83581 sha=06ee95df6608d29a395c52ba8ab53fdd93a9dc4f confidence=high -->",
       },

--- a/test/scripts/real-behavior-proof-policy.test.ts
+++ b/test/scripts/real-behavior-proof-policy.test.ts
@@ -186,6 +186,10 @@ describe("real-behavior-proof-policy", () => {
     };
     const comments = [
       {
+        user: {
+          login: "clawsweeper[bot]",
+          type: "Bot",
+        },
         body: [
           "Codex review: passed.",
           "<!-- clawsweeper-verdict:pass item=83581 sha=06ee95df6608d29a395c52ba8ab53fdd93a9dc4f confidence=high -->",
@@ -204,6 +208,27 @@ describe("real-behavior-proof-policy", () => {
         comments,
       }),
     ).toBe(false);
+  });
+
+  it("rejects forged ClawSweeper pass verdict markers from contributor comments", () => {
+    const pullRequest = {
+      number: 83581,
+      head: {
+        sha: "06ee95df6608d29a395c52ba8ab53fdd93a9dc4f",
+      },
+    };
+    const comments = [
+      {
+        user: {
+          login: "external-contributor",
+          type: "User",
+        },
+        body: "<!-- clawsweeper-verdict:pass item=83581 sha=06ee95df6608d29a395c52ba8ab53fdd93a9dc4f confidence=high -->",
+      },
+    ];
+
+    expect(hasClawSweeperExactHeadProof({ pullRequest, comments })).toBe(false);
+    expect(evaluateClawSweeperExactHeadProof({ pullRequest, comments }).passed).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

- Problem: Follow-up review on #83688 found the new ClawSweeper proof marker path trusted any issue comment body and could prefer an app token without issue-comment read permission.
- Why it matters: A forged contributor comment could bypass the proof gate, and the intended exact-head lookup path could fail when the token lacks comment-read permission.
- What changed: Proof markers are accepted only from trusted ClawSweeper bot/app comments, the proof workflow app token now requests `issues: read`, and the check falls back across available tokens for comment lookup.
- What did NOT change (scope boundary): This keeps the exact-head proof verdict contract from #83688 and does not change PR-body proof validation, maintainer overrides, or unrelated automation.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #83688
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

External contributors must show after-fix evidence from a real OpenClaw setup. Unit tests, mocks, lint, typechecks, snapshots, and CI are supplemental only. Screenshots are encouraged even for CLI, console, text, or log changes; terminal screenshots and copied live output count. Be mindful of private information like IP addresses, API keys, phone numbers, non-public endpoints, or other private details when providing evidence.

- Behavior or issue addressed: The proof verdict marker path now rejects forged contributor comments and uses an issue-readable token path.
- Real environment tested: Local OpenClaw checkout on macOS with Node/pnpm repo test wrappers.
- Exact steps or command run after this patch: `pnpm test test/scripts/real-behavior-proof-policy.test.ts test/scripts/barnacle-auto-response.test.ts`; `pnpm exec oxfmt --check --threads=1 .github/workflows/real-behavior-proof.yml scripts/github/real-behavior-proof-policy.mjs scripts/github/real-behavior-proof-check.mjs scripts/github/barnacle-auto-response.mjs test/scripts/real-behavior-proof-policy.test.ts test/scripts/barnacle-auto-response.test.ts`; `git diff --check`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Focused tests passed: 2 Vitest shards, 2 test files, 52 tests. Format check and diff whitespace check passed.
- Observed result after fix: Tests prove trusted ClawSweeper bot markers still pass, forged contributor markers fail, and Barnacle removes `proof: sufficient` when only a forged marker exists.
- What was not tested: Live GitHub Actions token fallback behavior before opening this PR.
- Before evidence (optional but encouraged): ClawSweeper review on #83688 flagged unauthenticated marker trust and the app-token issue-read permission gap.

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: The initial exact-head marker implementation validated PR number and head SHA but not the trusted source of the comment containing the marker.
- Missing detection / guardrail: Tests covered exact-head matching but did not include a forged-comment negative case.
- Contributing context (if known): The proof workflow already had a maintainer-team app token, but that token requested only members permission while the new marker lookup also needs issue-comment reads.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `test/scripts/real-behavior-proof-policy.test.ts`; `test/scripts/barnacle-auto-response.test.ts`
- Scenario the test should lock in: Contributor-authored comments containing matching ClawSweeper markers are ignored, while trusted ClawSweeper bot markers still count.
- Why this is the smallest reliable guardrail: The trust boundary is local marker parsing and Barnacle label synchronization logic.
- Existing test that already covers this (if any): Exact-head matching existed, but not source authentication.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None for users. Maintainer automation is stricter about which proof-verdict comments can satisfy the required proof check.

## Diagram (if applicable)

```text
Before:
any comment marker + matching PR/head -> proof accepted

After:
trusted ClawSweeper bot/app marker + matching PR/head -> proof accepted
contributor marker + matching PR/head -> ignored
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) Yes
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation: The workflow app token now explicitly requests `issues: read` so it can read issue comments for proof markers. Marker trust is narrowed to ClawSweeper bot/app-authored comments, and forged contributor markers are covered by tests.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Local repo Node/pnpm test wrappers
- Model/provider: N/A
- Integration/channel (if any): GitHub Actions/Barnacle/ClawSweeper automation
- Relevant config (redacted): N/A

### Steps

1. Evaluate a matching ClawSweeper pass marker from `clawsweeper[bot]`.
2. Evaluate the same marker from a contributor comment.
3. Run Barnacle label sync with a forged matching marker on synchronize.

### Expected

- Trusted ClawSweeper markers count.
- Forged contributor markers do not count.
- Barnacle removes `proof: sufficient` when only a forged marker exists.

### Actual

- Focused tests passed with those assertions.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Focused proof-policy and Barnacle tests passed locally.
- Edge cases checked: Forged matching marker from a contributor is rejected.
- What you did **not** verify: Live GitHub Actions token fallback before opening this PR.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: The trusted identity check could reject a legitimate future ClawSweeper identity if it changes.
  - Mitigation: The current production comment has `user.login=clawsweeper[bot]`, `user.type=Bot`, and `performed_via_github_app.slug=clawsweeper`; the code accepts either app slug or bot identity.
