### PR TITLE
fix(logging): align meta date with file log time

### DIFF
--- a/src/logging/logger-timestamp.test.ts
+++ b/src/logging/logger-timestamp.test.ts
@@ -48,5 +48,6 @@ describe("logger timestamp format", () => {
     // NOT UTC format like "2026-02-27T07:04:00.000Z"
     expect(lastLine.time).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[+-]\d{2}:\d{2}$/);
     expect(lastLine.time).not.toMatch(/Z$/);
+    expect(lastLine["_meta"].date).toBe(lastLine.time);
   });
 });

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -99,6 +99,27 @@ const HOSTNAME = os.hostname() || "unknown";
 
 type DiagnosticLogAttributes = Record<string, string | number | boolean>;
 
+function buildFileLogRecord(
+  logObj: LogObj,
+  time: string,
+  structuredFields: TsLogRecord,
+  traceFields: TsLogRecord,
+): TsLogRecord {
+  const rawMeta = logObj["_meta"];
+  const recordBase = { ...logObj, time, ...structuredFields, ...traceFields };
+  if (rawMeta === null || typeof rawMeta !== "object" || Array.isArray(rawMeta)) {
+    return recordBase;
+  }
+
+  return {
+    ...recordBase,
+    _meta: {
+      ...(rawMeta as Record<string, unknown>),
+      date: time,
+    },
+  };
+}
+
 function clampDiagnosticLogText(value: string, maxChars: number): string {
   return value.length > maxChars ? `${value.slice(0, maxChars)}...(truncated)` : value;
 }
@@ -564,7 +585,7 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
       const time = formatTimestamp(logObj.date ?? new Date(), { style: "long" });
       const traceFields = buildTraceFileLogFields(logObj as TsLogRecord);
       const structuredFields = buildStructuredFileLogFields(logObj as TsLogRecord);
-      const record = { ...logObj, time, ...structuredFields, ...traceFields };
+      const record = buildFileLogRecord(logObj, time, structuredFields, traceFields);
       const line = redactSensitiveText(JSON.stringify(redactLogRecordForTransport(record)));
       const payload = `${line}\n`;
       const payloadBytes = Buffer.byteLength(payload, "utf8");


### PR DESCRIPTION
## Summary

- Align file-log `_meta.date` with the already formatted local-offset `time` field.
- Clone tslog metadata at the file transport boundary so raw JSON logs no longer mix UTC `_meta.date` with local-offset `time`.
- Add regression coverage asserting `_meta.date` and `time` match.

## Tests

- RED: `node --import tsx -e 'import fs from "node:fs"; import os from "node:os"; import path from "node:path"; import { getLogger, resetLogger, setLoggerOverride } from "./src/logging.ts"; const f=path.join(os.tmpdir(),`oc-log-red-${Date.now()}.log`); resetLogger(); setLoggerOverride({level:"info",file:f}); getLogger().info("probe"); const last=JSON.parse(fs.readFileSync(f,"utf8").trim().split("\n").at(-1)); fs.rmSync(f,{force:true}); if (last._meta.date !== last.time) { console.error(`RED: _meta.date=${last._meta.date} time=${last.time}`); process.exit(1); }'` (failed before the fix with `_meta.date` UTC and `time` local-offset)
- `node --no-maglev node_modules/vitest/vitest.mjs run --project logging src/logging/logger-timestamp.test.ts --reporter=verbose`
- `node --import tsx -e 'import fs from "node:fs"; import os from "node:os"; import path from "node:path"; import { getLogger, resetLogger, setLoggerOverride } from "./src/logging.ts"; const f=path.join(os.tmpdir(),`oc-log-green-${Date.now()}.log`); resetLogger(); setLoggerOverride({level:"info",file:f}); getLogger().info("probe"); const last=JSON.parse(fs.readFileSync(f,"utf8").trim().split("\n").at(-1)); fs.rmSync(f,{force:true}); if (last._meta.date !== last.time) { console.error(`mismatch: _meta.date=${last._meta.date} time=${last.time}`); process.exit(1); } console.log(`GREEN: _meta.date=${last._meta.date} time=${last.time}`);'`
- `node node_modules/oxfmt/bin/oxfmt --check --threads=1 src/logging/logger.ts src/logging/logger-timestamp.test.ts`
- `node node_modules/oxlint/bin/oxlint src/logging/logger.ts src/logging/logger-timestamp.test.ts`
- `git diff --check`

## Verification

Behavior addressed: Raw JSON file logs now serialize `_meta.date` with the same local-offset timestamp string as top-level `time`.
Real environment tested: Local macOS checkout, Node/Vitest logging project, temporary file-log write through `getLogger()`.
Exact steps or command run after this patch: `node --no-maglev node_modules/vitest/vitest.mjs run --project logging src/logging/logger-timestamp.test.ts --reporter=verbose`; `node --import tsx ...` file-log probe; focused oxfmt/oxlint; `git diff --check`.
Evidence after fix: Regression test passed; live file-log probe printed `GREEN: _meta.date=2026-05-19T00:38:40.929+08:00 time=2026-05-19T00:38:40.929+08:00`.
Observed result after fix: `_meta.date` and `time` match exactly for the written JSON log line.
What was not tested: Full `pnpm check:changed`; local dependency reconciliation attempted `pnpm install` and timed out on registry/network optional package fetches, so I kept verification to focused local commands that were available.

Closes #40220
