### PR TITLE
fix(models): label picker auth via effective provider order

### DIFF
--- a/src/agents/model-auth-label.test.ts
+++ b/src/agents/model-auth-label.test.ts
@@ -123,6 +123,38 @@ describe("resolveModelAuthLabel", () => {
     expect(label).toBe("oauth (anthropic:oauth)");
   });
 
+  it("uses accepted provider ids before falling back to provider env auth", () => {
+    mocks.ensureAuthProfileStore.mockReturnValue({
+      version: 1,
+      profiles: {
+        "openai-codex:user@example.com": {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "access-token",
+          refresh: "refresh-token",
+          expires: Date.now() + 60_000,
+        },
+      },
+    } as never);
+    mocks.resolveAuthProfileOrder.mockImplementation(({ provider }: { provider?: string }) =>
+      provider === "openai-codex" ? ["openai-codex:user@example.com"] : [],
+    );
+    mocks.resolveAuthProfileDisplayLabel.mockReturnValue("openai-codex:user@example.com");
+    mocks.resolveEnvApiKey.mockReturnValue({
+      apiKey: "env-key-placeholder",
+      source: "env: OPENAI_API_KEY",
+    });
+
+    const label = resolveModelAuthLabel({
+      provider: "openai",
+      acceptedProviderIds: ["openai-codex"],
+      cfg: {},
+    });
+
+    expect(label).toBe("oauth (openai-codex:user@example.com)");
+    expect(mocks.resolveEnvApiKey).not.toHaveBeenCalled();
+  });
+
   it("shows codex cli auth for codex provider without auth profiles", () => {
     mocks.ensureAuthProfileStore.mockReturnValue({
       version: 1,

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -658,6 +658,34 @@ describe("handleModelsCommand", () => {
     expect(authLabelParams.workspaceDir).toBe("/tmp");
   });
 
+  it("labels OpenAI provider pages with the effective Codex auth provider set", async () => {
+    modelAuthLabelMocks.resolveModelAuthLabel.mockReturnValue(
+      "oauth (openai-codex:user@example.com)",
+    );
+
+    const result = await handleModelsCommand(
+      buildParams("/models openai", {
+        auth: {
+          order: {
+            openai: ["openai-codex:user@example.com"],
+          },
+        },
+      }),
+      true,
+    );
+
+    expect(result?.reply?.text).toContain(
+      "Models (openai · 🔑 oauth (openai-codex:user@example.com))",
+    );
+    const openaiAuthCall = modelAuthLabelMocks.resolveModelAuthLabel.mock.calls.find(
+      ([params]) => (params as { provider?: string }).provider === "openai",
+    );
+    expect(openaiAuthCall?.[0]).toMatchObject({
+      provider: "openai",
+      acceptedProviderIds: ["openai-codex"],
+    });
+  });
+
   it("uses spawned workspace for direct /models provider visibility", async () => {
     modelProviderAuthMocks.authenticatedProviders = new Set(["anthropic"]);
     const params = buildParams("/models");

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -21,6 +21,7 @@ import {
   resolveModelRefFromString,
 } from "../../agents/model-selection.js";
 import { createModelVisibilityPolicy } from "../../agents/model-visibility-policy.js";
+import { listOpenAIAuthProfileProvidersForAgentRuntime } from "../../agents/openai-codex-routing.js";
 import { resolveDefaultAgentWorkspaceDir } from "../../agents/workspace.js";
 import { getChannelPlugin } from "../../channels/plugins/index.js";
 import type { SessionEntry } from "../../config/sessions.js";
@@ -387,12 +388,24 @@ function parseModelsArgs(raw: string): ParsedModelsCommand {
 function resolveProviderLabel(params: {
   provider: string;
   cfg: OpenClawConfig;
+  agentId?: string;
   agentDir?: string;
   workspaceDir?: string;
   sessionEntry?: ModelsCommandSessionEntry;
 }): string {
+  const harnessPolicy = resolveAgentHarnessPolicy({
+    config: params.cfg,
+    provider: params.provider,
+    agentId: params.agentId,
+  });
+  const acceptedProviderIds = listOpenAIAuthProfileProvidersForAgentRuntime({
+    provider: params.provider,
+    harnessRuntime: harnessPolicy.runtime,
+    config: params.cfg,
+  });
   const authLabel = resolveModelAuthLabel({
     provider: params.provider,
+    acceptedProviderIds,
     cfg: params.cfg,
     sessionEntry: params.sessionEntry,
     agentDir: params.agentDir,
@@ -408,6 +421,7 @@ export function formatModelsAvailableHeader(params: {
   provider: string;
   total: number;
   cfg: OpenClawConfig;
+  agentId?: string;
   agentDir?: string;
   workspaceDir?: string;
   sessionEntry?: ModelsCommandSessionEntry;
@@ -415,6 +429,7 @@ export function formatModelsAvailableHeader(params: {
   const providerLabel = resolveProviderLabel({
     provider: params.provider,
     cfg: params.cfg,
+    agentId: params.agentId,
     agentDir: params.agentDir,
     workspaceDir: params.workspaceDir,
     sessionEntry: params.sessionEntry,
@@ -539,6 +554,7 @@ export async function resolveModelsCommandReply(params: {
     const emptyProviderLabel = resolveProviderLabel({
       provider,
       cfg: params.cfg,
+      agentId: params.agentId,
       agentDir: params.agentDir,
       workspaceDir: params.workspaceDir,
       sessionEntry: params.sessionEntry,
@@ -571,6 +587,7 @@ export async function resolveModelsCommandReply(params: {
         provider,
         total,
         cfg: params.cfg,
+        agentId: params.agentId,
         agentDir: params.agentDir,
         workspaceDir: params.workspaceDir,
         sessionEntry: params.sessionEntry,
@@ -600,6 +617,7 @@ export async function resolveModelsCommandReply(params: {
   const providerLabel = resolveProviderLabel({
     provider,
     cfg: params.cfg,
+    agentId: params.agentId,
     agentDir: params.agentDir,
     workspaceDir: params.workspaceDir,
     sessionEntry: params.sessionEntry,


### PR DESCRIPTION
## Summary
- Pass the effective OpenAI/Codex accepted auth provider set into the shared /models provider label path.
- Keep the change display-only: model selection and dispatch routing are unchanged.
- Add regression coverage for an OpenAI picker page that should display the Codex OAuth profile instead of falling back to OPENAI_API_KEY.

Fixes #83574.

## Real behavior proof
Behavior or issue addressed: The `/models` provider header for `openai` should label the effective Codex OAuth auth profile selected by `auth.order.openai`, instead of implying an API-key fallback such as `api-key (env: OPENAI_API_KEY)`.

Real environment tested: Local OpenClaw source checkout on macOS, Node v25.9.0, with the real `src/auto-reply/reply/commands-models.ts` implementation and a real temporary `auth-profiles.json` store under `$TMP_HOME/.openclaw/agents/main/agent`. The store contained only `openai-codex:user@example.com` as an OAuth profile; there was no `openai:default` API-key profile.

Exact steps or command run after this patch: Ran the real header formatter through `node --import tsx` with `provider: "openai"`, `auth.order.openai: ["openai-codex:user@example.com"]`, and `models.providers.openai.baseUrl: "https://api.openai.com/v1"`.

```bash
TMP_HOME=$(mktemp -d)
AGENT_DIR="$TMP_HOME/.openclaw/agents/main/agent"
mkdir -p "$AGENT_DIR"
HOME="$TMP_HOME" AGENT_DIR="$AGENT_DIR" node --import tsx --eval '
  import { formatModelsAvailableHeader } from "./src/auto-reply/reply/commands-models.ts";
  const cfg = {
    auth: { order: { openai: ["openai-codex:user@example.com"] } },
    models: { providers: { openai: { baseUrl: "https://api.openai.com/v1" } } }
  };
  console.log(formatModelsAvailableHeader({
    provider: "openai",
    total: 2,
    cfg,
    agentId: "main",
    agentDir: process.env.AGENT_DIR,
    workspaceDir: process.cwd(),
  }));
'
```

Evidence after fix: Terminal output from the real OpenClaw formatter path:

```text
Models (openai · 🔑 oauth (openai-codex:user@example.com)) — 2 available
```

Observed result after fix: The provider picker header now shows `oauth (openai-codex:user@example.com)` for `openai`, proving the display follows the effective Codex OAuth auth path and does not fall back to `api-key (env: OPENAI_API_KEY)` for this configuration.

Not tested: Live Telegram button rendering was not exercised; the Telegram callback uses this same shared `formatModelsAvailableHeader` path, and the change is covered at that shared layer.

## Verification
- node scripts/run-vitest.mjs src/auto-reply/reply/commands-models.test.ts
- node scripts/run-vitest.mjs src/agents/model-auth-label.test.ts
- node scripts/run-vitest.mjs src/auto-reply/reply/commands-status.test.ts
- pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/commands-models.ts src/auto-reply/reply/commands-models.test.ts src/agents/model-auth-label.test.ts
- pnpm exec oxlint src/auto-reply/reply/commands-models.ts src/auto-reply/reply/commands-models.test.ts src/agents/model-auth-label.test.ts
