### PR TITLE
Add Claude ignore rules for generated assets

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,74 @@
+# Keep coding-agent context focused on source, docs, and tests.
+# Ignored paths remain in git; ask for an exact path when an asset is needed.
+
+# Dependencies and build output
+node_modules/
+**/node_modules/
+dist/
+dist-runtime/
+dist-sea/
+coverage/
+vendor/
+bin/
+Core/
+.pnpm-store/
+.worktrees/
+.tmp/
+.cache/
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+target/
+**/.gradle/
+**/.build/
+**/.swiftpm/
+**/.derivedData/
+**/build/
+**/.next/
+**/out/
+
+# Package manager and generated locks
+pnpm-lock.yaml
+bun.lock
+bun.lockb
+package-lock.json
+skills-lock.json
+
+# Generated docs and localization baselines
+docs/.generated/
+docs/.i18n/
+ui/src/i18n/.i18n/
+dist/protocol.schema.json
+
+# Screenshots, reports, and bulky UI test artifacts
+**/__screenshots__/
+**/screenshots/
+ui/playwright-report/
+ui/test-results/
+apps/ios/fastlane/screenshots/
+apps/ios/fastlane/test_output/
+apps/ios/fastlane/logs/
+
+# Binary/media assets are rarely useful for code navigation.
+# Keep SVG visible because many tracked docs/UI SVGs are source-like text.
+*.png
+*.jpg
+*.jpeg
+*.gif
+*.webp
+*.icns
+*.ico
+*.mp4
+*.mov
+*.pdf
+*.zip
+*.tgz
+*.tar.gz
+
+# Local secrets and operator state
+.env
+*.mobileprovision
+client_secret_*.json
+/memory/
+.agent/*.json
+/local/


### PR DESCRIPTION
## Summary

- add a repo-level `.claudeignore` so Claude Code skips generated output, dependency/build directories, lockfiles, screenshots, and bulky binary media assets during normal code navigation
- keep source, docs, tests, scoped `AGENTS.md` / `CLAUDE.md`, and text SVG assets visible
- include a short note that ignored assets remain in git and can still be requested by exact path when needed

## Verification

- `git diff --check`
- `python3 ../context-os/python/agent_cost_leak_check.py --repo . --json`

## Real behavior proof

Behavior addressed: OpenClaw had repo-level `AGENTS.md` / `CLAUDE.md` guidance but no repo-level `.claudeignore`, so Claude Code could still include generated output, lockfiles, screenshots, and bulky media assets during normal repo exploration.

Real environment tested: local shallow clone of `openclaw/openclaw` on branch `add-claudeignore-cost-controls`, using a stdlib local scanner from `sravan27/context-os`.

Exact steps or command run after this patch: `git diff --check` and `python3 ../context-os/python/agent_cost_leak_check.py --repo . --json`.

Evidence after fix: copied live terminal output from the after-fix scanner run:

```json
{
  "score": 34,
  "files": 17934,
  "source": 15413,
  "ai": 3,
  "findings": [
    "Large tracked blobs increase read risk",
    "Large source tree needs a repo map",
    "Multi-language repo shape"
  ]
}
```

Before this patch, the same scanner reported score `52/100` and included `No agent ignore file found`. After this patch, that finding is gone and `ai_config_hits` increases from `2` to `3`.

Observed result after fix: `.claudeignore` is present at repo root and covers dependency/build output, package locks, generated docs/localization baselines, screenshots/reports, common binary media assets, and local secret/operator state. After review feedback, global `*.svg` is intentionally not ignored because OpenClaw tracks text-like docs/UI SVG assets.

What was not tested: direct Claude Code runtime proof. I attempted a read-only `claude -p` run with file tools only, but local Claude Code auth returned `401 Invalid authentication credentials` before any tool call, so I am not presenting that as behavior evidence. Runtime behavior, package builds, and broad CI suites were not run because this is a repo metadata change only; no application source code or lockfile content changed.
