### PR TITLE
fix(tts): deliver trusted voice media in message-tool rooms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/TTS: deliver trusted dynamic TTS voice media in message-tool-only channel contexts while keeping ordinary final text private. Fixes #83636.
 - Agents/image generation: allow distinct `image_generate` prompts to start separate session-backed background tasks while same-prompt retries still return the active task status. (#83614) Thanks @Elarwei001.
 - Sessions: skip trailing custom transcript entries when checking tail assistant replies so embedded CLI gap-fill does not duplicate canonical assistant output. (#83635) Thanks @yaoyi1222.
 - Memory Wiki: keep `wiki_lint` tool output path-safe by reporting vault-internal lint reports as relative paths in tool text and details while preserving absolute report paths for CLI/file callers. (#83439) Thanks @LLagoon3.

--- a/src/agents/pi-embedded-runner/run/tool-media-payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/tool-media-payloads.test.ts
@@ -90,6 +90,43 @@ describe("mergeAttemptToolMediaPayloads", () => {
     ]);
   });
 
+  it("marks trusted voice tool media for message-tool-only source delivery", () => {
+    const [mergedReply] =
+      mergeAttemptToolMediaPayloads({
+        payloads: [{ text: "done" }],
+        toolMediaUrls: ["/tmp/reply.opus"],
+        toolAudioAsVoice: true,
+        toolTrustedLocalMedia: true,
+        sourceReplyDeliveryMode: "message_tool_only",
+      }) ?? [];
+
+    expect(mergedReply).toEqual({
+      text: "done",
+      mediaUrls: ["/tmp/reply.opus"],
+      mediaUrl: "/tmp/reply.opus",
+      audioAsVoice: true,
+      trustedLocalMedia: true,
+    });
+    expect(getReplyPayloadMetadata(mergedReply ?? {})).toMatchObject({
+      deliverDespiteSourceReplySuppression: true,
+      sourceReplySuppressionDeliveryMode: "media_only",
+    });
+  });
+
+  it("does not mark untrusted voice media for message-tool-only source delivery", () => {
+    const [mergedReply] =
+      mergeAttemptToolMediaPayloads({
+        payloads: [{ text: "done" }],
+        toolMediaUrls: ["https://example.com/reply.opus"],
+        toolAudioAsVoice: true,
+        sourceReplyDeliveryMode: "message_tool_only",
+      }) ?? [];
+
+    expect(getReplyPayloadMetadata(mergedReply ?? {})?.deliverDespiteSourceReplySuppression).toBe(
+      undefined,
+    );
+  });
+
   it("does not attach tool media to message-tool-only source reply mirrors", () => {
     const sourceReply = setReplyPayloadMetadata(
       { text: "sent through message tool" },

--- a/src/agents/pi-embedded-runner/run/tool-media-payloads.ts
+++ b/src/agents/pi-embedded-runner/run/tool-media-payloads.ts
@@ -2,6 +2,7 @@ import type { SourceReplyDeliveryMode } from "../../../auto-reply/get-reply-opti
 import {
   copyReplyPayloadMetadata,
   getReplyPayloadMetadata,
+  markReplyPayloadForSourceSuppressionMediaDelivery,
 } from "../../../auto-reply/reply-payload.js";
 import type { EmbeddedPiRunResult } from "../types.js";
 
@@ -22,6 +23,11 @@ export function mergeAttemptToolMediaPayloads(params: {
   }
 
   const payloads = params.payloads?.length ? [...params.payloads] : [];
+  const shouldDeliverToolMediaDespiteSourceReplySuppression =
+    params.sourceReplyDeliveryMode === "message_tool_only" &&
+    params.toolAudioAsVoice === true &&
+    params.toolTrustedLocalMedia === true &&
+    mediaUrls.length > 0;
   const payloadIndex = payloads.findIndex((payload) => !payload.isReasoning);
   if (payloadIndex >= 0) {
     const payload = payloads[payloadIndex];
@@ -32,23 +38,29 @@ export function mergeAttemptToolMediaPayloads(params: {
       return payloads;
     }
     const mergedMediaUrls = Array.from(new Set([...(payload.mediaUrls ?? []), ...mediaUrls]));
-    payloads[payloadIndex] = copyReplyPayloadMetadata(payload, {
+    const mergedPayload = copyReplyPayloadMetadata(payload, {
       ...payload,
       mediaUrls: mergedMediaUrls.length ? mergedMediaUrls : undefined,
       mediaUrl: payload.mediaUrl ?? mergedMediaUrls[0],
       audioAsVoice: payload.audioAsVoice || params.toolAudioAsVoice || undefined,
       trustedLocalMedia: payload.trustedLocalMedia || params.toolTrustedLocalMedia || undefined,
     });
+    payloads[payloadIndex] = shouldDeliverToolMediaDespiteSourceReplySuppression
+      ? markReplyPayloadForSourceSuppressionMediaDelivery(mergedPayload)
+      : mergedPayload;
     return payloads;
   }
 
+  const mediaPayload: EmbeddedRunPayload = {
+    mediaUrls: mediaUrls.length ? mediaUrls : undefined,
+    mediaUrl: mediaUrls[0],
+    audioAsVoice: params.toolAudioAsVoice || undefined,
+    trustedLocalMedia: params.toolTrustedLocalMedia || undefined,
+  };
   return [
     ...payloads,
-    {
-      mediaUrls: mediaUrls.length ? mediaUrls : undefined,
-      mediaUrl: mediaUrls[0],
-      audioAsVoice: params.toolAudioAsVoice || undefined,
-      trustedLocalMedia: params.toolTrustedLocalMedia || undefined,
-    },
+    shouldDeliverToolMediaDespiteSourceReplySuppression
+      ? markReplyPayloadForSourceSuppressionMediaDelivery(mediaPayload)
+      : mediaPayload,
   ];
 }

--- a/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { getReplyPayloadMetadata } from "../auto-reply/reply-payload.js";
 import { createStreamingDirectiveAccumulator } from "../auto-reply/reply/streaming-directives.js";
 import { createInlineCodeState } from "../markdown/code-spans.js";
 import {
@@ -485,6 +486,29 @@ describe("consumePendingToolMediaReply", () => {
     });
     expect(state.pendingToolMediaUrls).toStrictEqual([]);
     expect(state.pendingToolAudioAsVoice).toBe(false);
+  });
+
+  it("marks trusted voice tool media for source-suppression delivery", () => {
+    const state = {
+      pendingToolMediaUrls: ["/tmp/reply.opus"],
+      pendingToolAudioAsVoice: true,
+      pendingToolTrustedLocalMedia: true,
+    };
+
+    const reply = consumePendingToolMediaReply(state);
+
+    expect(reply).toEqual({
+      mediaUrls: ["/tmp/reply.opus"],
+      audioAsVoice: true,
+      trustedLocalMedia: true,
+    });
+    expect(getReplyPayloadMetadata(reply ?? {})).toMatchObject({
+      deliverDespiteSourceReplySuppression: true,
+      sourceReplySuppressionDeliveryMode: "media_only",
+    });
+    expect(state.pendingToolMediaUrls).toStrictEqual([]);
+    expect(state.pendingToolAudioAsVoice).toBe(false);
+    expect(state.pendingToolTrustedLocalMedia).toBe(false);
   });
 });
 

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -1,6 +1,7 @@
 import type { AgentEvent, AgentMessage } from "@earendil-works/pi-agent-core";
 import type { AssistantMessage } from "@earendil-works/pi-ai";
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
+import { markReplyPayloadForSourceSuppressionMediaDelivery } from "../auto-reply/reply-payload.js";
 import {
   parseReplyDirectives,
   type ReplyDirectiveParseResult,
@@ -185,6 +186,19 @@ function clearPendingToolMedia(
   state.pendingToolTrustedLocalMedia = false;
 }
 
+function shouldDeliverPendingToolMediaDespiteSourceReplySuppression(
+  state: Pick<
+    EmbeddedPiSubscribeState,
+    "pendingToolMediaUrls" | "pendingToolAudioAsVoice" | "pendingToolTrustedLocalMedia"
+  >,
+): boolean {
+  return (
+    state.pendingToolMediaUrls.length > 0 &&
+    state.pendingToolAudioAsVoice &&
+    state.pendingToolTrustedLocalMedia
+  );
+}
+
 function hasReplyMedia(payload: BlockReplyPayload): boolean {
   return (payload.mediaUrls ?? []).some((url) => url.trim().length > 0);
 }
@@ -221,6 +235,9 @@ export function consumePendingToolMediaIntoReply(
     audioAsVoice: payload.audioAsVoice || state.pendingToolAudioAsVoice || undefined,
     trustedLocalMedia: payload.trustedLocalMedia || state.pendingToolTrustedLocalMedia || undefined,
   };
+  if (shouldDeliverPendingToolMediaDespiteSourceReplySuppression(state)) {
+    markReplyPayloadForSourceSuppressionMediaDelivery(mergedPayload);
+  }
   clearPendingToolMedia(state);
   return mergedPayload;
 }
@@ -252,13 +269,17 @@ export function readPendingToolMediaReply(
   ) {
     return null;
   }
-  return {
+  const payload: BlockReplyPayload = {
     mediaUrls: state.pendingToolMediaUrls.length
       ? Array.from(new Set(state.pendingToolMediaUrls))
       : undefined,
     audioAsVoice: state.pendingToolAudioAsVoice || undefined,
     trustedLocalMedia: state.pendingToolTrustedLocalMedia || undefined,
   };
+  if (shouldDeliverPendingToolMediaDespiteSourceReplySuppression(state)) {
+    markReplyPayloadForSourceSuppressionMediaDelivery(payload);
+  }
+  return payload;
 }
 
 function hasReplyDirectiveMetadata(parsed: ReplyDirectiveParseResult | null | undefined): boolean {

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -149,6 +149,8 @@ export type ReplyPayloadMetadata = {
    * assistant source replies are message-tool-only; sendPolicy deny still wins.
    */
   deliverDespiteSourceReplySuppression?: boolean;
+  /** Limit suppression-bypass delivery to media fields while keeping ordinary text private. */
+  sourceReplySuppressionDeliveryMode?: "media_only";
   /**
    * A message-tool reply to the active internal UI source. The final payload is
    * still the live delivery vehicle; this mirror makes the reply durable for
@@ -188,5 +190,12 @@ export function copyReplyPayloadMetadata<T extends object>(source: object, paylo
 export function markReplyPayloadForSourceSuppressionDelivery<T extends object>(payload: T): T {
   return setReplyPayloadMetadata(payload, {
     deliverDespiteSourceReplySuppression: true,
+  });
+}
+
+export function markReplyPayloadForSourceSuppressionMediaDelivery<T extends object>(payload: T): T {
+  return setReplyPayloadMetadata(payload, {
+    deliverDespiteSourceReplySuppression: true,
+    sourceReplySuppressionDeliveryMode: "media_only",
   });
 }

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -25,7 +25,13 @@ import {
 } from "../../test-utils/channel-plugins.js";
 import { createInternalHookEventPayload } from "../../test-utils/internal-hook-event-payload.js";
 import type { MsgContext } from "../templating.js";
-import { setReplyPayloadMetadata, type GetReplyOptions, type ReplyPayload } from "../types.js";
+import {
+  markReplyPayloadForSourceSuppressionDelivery,
+  markReplyPayloadForSourceSuppressionMediaDelivery,
+  setReplyPayloadMetadata,
+  type GetReplyOptions,
+  type ReplyPayload,
+} from "../types.js";
 import { PROVIDER_CONVERSATION_STATE_ERROR_USER_MESSAGE } from "./provider-request-error-classifier.js";
 import type { ReplyDispatcher } from "./reply-dispatcher.js";
 import { buildTestCtx } from "./test-ctx.js";
@@ -4919,6 +4925,47 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     if (replyDispatchCall?.[1] === undefined) {
       throw new Error("Expected reply dispatch metadata");
     }
+  });
+
+  it("delivers marked trusted tool-media block replies in message-tool-only mode", async () => {
+    setNoAbort();
+    sessionStoreMocks.currentEntry = {
+      sessionId: "s1",
+      updatedAt: 0,
+      sendPolicy: "allow",
+    };
+    const dispatcher = createDispatcher();
+    const toolMediaReply = markReplyPayloadForSourceSuppressionMediaDelivery({
+      text: "ordinary final text stays private",
+      mediaUrls: ["/tmp/reply.opus"],
+      audioAsVoice: true,
+      trustedLocalMedia: true,
+    });
+    const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+      await opts?.onBlockReply?.(toolMediaReply);
+      return { text: "ordinary final confirmation" } satisfies ReplyPayload;
+    });
+
+    const result = await dispatchReplyFromConfig({
+      ctx: buildTestCtx({ SessionKey: "test:session" }),
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+      replyOptions: {
+        sourceReplyDeliveryMode: "message_tool_only",
+      },
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+    expect(result.queuedFinal).toBe(false);
+    expect(result.sourceReplyDeliveryMode).toBe("message_tool_only");
+    expect(dispatcher.sendBlockReply).toHaveBeenCalledWith({
+      mediaUrls: ["/tmp/reply.opus"],
+      audioAsVoice: true,
+      trustedLocalMedia: true,
+    });
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
   });
 
   it("preserves hook-blocked metadata when source delivery is message-tool-only", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -92,6 +92,7 @@ import {
 } from "../command-turn-context.js";
 import type { BlockReplyContext } from "../get-reply-options.types.js";
 import {
+  copyReplyPayloadMetadata,
   getReplyPayloadMetadata,
   markReplyPayloadAsTtsSupplement,
   type ReplyPayload,
@@ -181,6 +182,47 @@ function formatSuppressedReplyPayloadForLog(reply: ReplyPayload): string {
   ]
     .filter(Boolean)
     .join(" ");
+}
+
+function buildSourceSuppressionDeliveryPayload(reply: ReplyPayload): ReplyPayload {
+  if (getReplyPayloadMetadata(reply)?.sourceReplySuppressionDeliveryMode !== "media_only") {
+    return reply;
+  }
+  const mediaPayload: ReplyPayload = {};
+  if (reply.mediaUrl) {
+    mediaPayload.mediaUrl = reply.mediaUrl;
+  }
+  if (reply.mediaUrls) {
+    mediaPayload.mediaUrls = reply.mediaUrls;
+  }
+  if (reply.audioAsVoice) {
+    mediaPayload.audioAsVoice = true;
+  }
+  if (reply.trustedLocalMedia) {
+    mediaPayload.trustedLocalMedia = true;
+  }
+  if (reply.sensitiveMedia) {
+    mediaPayload.sensitiveMedia = true;
+  }
+  if (reply.spokenText) {
+    mediaPayload.spokenText = reply.spokenText;
+  }
+  if (reply.ttsSupplement) {
+    mediaPayload.ttsSupplement = reply.ttsSupplement;
+  }
+  if (reply.delivery) {
+    mediaPayload.delivery = reply.delivery;
+  }
+  if (reply.replyToId) {
+    mediaPayload.replyToId = reply.replyToId;
+  }
+  if (reply.replyToTag) {
+    mediaPayload.replyToTag = true;
+  }
+  if (reply.replyToCurrent) {
+    mediaPayload.replyToCurrent = true;
+  }
+  return copyReplyPayloadMetadata(reply, mediaPayload);
 }
 
 async function maybeApplyTtsToReplyPayload(
@@ -1699,7 +1741,12 @@ export async function dispatchReplyFromConfig(
               ) {
                 markInboundDedupeReplayUnsafe();
               }
-              if (suppressDelivery) {
+              const deliverDespiteSourceReplySuppression =
+                suppressAutomaticSourceDelivery &&
+                ctx.InboundEventKind !== "room_event" &&
+                !sendPolicyDenied &&
+                getReplyPayloadMetadata(payload)?.deliverDespiteSourceReplySuppression === true;
+              if (suppressDelivery && !deliverDespiteSourceReplySuppression) {
                 return;
               }
               // Suppress reasoning payloads — channels using this generic dispatch
@@ -1735,6 +1782,13 @@ export async function dispatchReplyFromConfig(
               if (!hasOutboundReplyContent(visiblePayload, { trimText: true })) {
                 return;
               }
+              const sourceDeliveryPayload =
+                suppressDelivery && deliverDespiteSourceReplySuppression
+                  ? buildSourceSuppressionDeliveryPayload(visiblePayload)
+                  : visiblePayload;
+              if (!hasOutboundReplyContent(sourceDeliveryPayload, { trimText: true })) {
+                return;
+              }
               // Channels that keep a live draft preview may need to rotate their
               // preview state at the logical block boundary before queued block
               // delivery drains asynchronously through the dispatcher.
@@ -1750,7 +1804,7 @@ export async function dispatchReplyFromConfig(
                 await params.replyOptions?.onBlockReplyQueued?.(visiblePayload, queuedContext);
               }
               const ttsPayload = await maybeApplyTtsToReplyPayload({
-                payload: visiblePayload,
+                payload: sourceDeliveryPayload,
                 cfg,
                 channel: deliveryChannel,
                 kind: "block",
@@ -1853,8 +1907,15 @@ export async function dispatchReplyFromConfig(
         }
         continue;
       }
+      const deliveryReply =
+        suppressDelivery && shouldDeliverDespiteSourceReplySuppression(reply)
+          ? buildSourceSuppressionDeliveryPayload(reply)
+          : reply;
+      if (!hasOutboundReplyContent(deliveryReply, { trimText: true })) {
+        continue;
+      }
       attemptedFinalDelivery = true;
-      const finalReply = await sendFinalPayload(reply);
+      const finalReply = await sendFinalPayload(deliveryReply);
       queuedFinal = finalReply.queuedFinal || queuedFinal;
       routedFinalCount += finalReply.routedFinalCount;
       if (!finalReply.queuedFinal && finalReply.routedFinalCount === 0) {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1776,7 +1776,10 @@ export async function dispatchReplyFromConfig(
                 payload.text && cleanBlockTtsDirectiveText && !isStatusNotice
                   ? (() => {
                       const text = cleanBlockTtsDirectiveText.push(payload.text);
-                      return { ...payload, text: text.trim() ? text : undefined };
+                      return copyReplyPayloadMetadata(payload, {
+                        ...payload,
+                        text: text.trim() ? text : undefined,
+                      });
                     })()
                   : payload;
               if (!hasOutboundReplyContent(visiblePayload, { trimText: true })) {

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -8,6 +8,7 @@ export type {
 export {
   copyReplyPayloadMetadata,
   markReplyPayloadForSourceSuppressionDelivery,
+  markReplyPayloadForSourceSuppressionMediaDelivery,
   setReplyPayloadMetadata,
 } from "./reply-payload.js";
 export type { ReplyPayload } from "./reply-payload.js";


### PR DESCRIPTION
## Summary

- Mark trusted local voice tool media with a media-only source-suppression bypass so dynamic TTS audio can still be delivered in `message_tool_only` channel contexts.
- Honor that bypass for block replies under the same send-policy and room-event guards already used by final replies.
- Strip ordinary assistant text from media-only bypass delivery so "sent it" confirmations stay private while the staged voice media reaches the channel.

Fixes #83636.

## Root cause

Dynamic TTS staged trusted local media, but the pending media was emitted through block/final source-reply paths. In Discord/Telegram-style `message_tool_only` contexts those paths are suppressed unless internal metadata explicitly allows delivery, so the provider send path was never reached.

## Real behavior proof

- **Behavior addressed:** Trusted local media produced by the TTS/tool-media path is now allowed through the media-only send path in `message_tool_only` rooms, while ordinary assistant text remains suppressed.
- **Real environment tested:** Local OpenClaw checkout on this PR branch with the production media payload and message subscription handlers; the after-fix verification used the same pending-media metadata and reply dispatch code paths that stage trusted local voice media before provider delivery.
- **Exact steps or command run after this patch:**
  ```bash
  PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node scripts/run-vitest.mjs src/agents/pi-embedded-runner/run/tool-media-payloads.test.ts
  PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node scripts/run-vitest.mjs src/agents/pi-embedded-subscribe.handlers.messages.test.ts
  PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node scripts/run-vitest.mjs src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
  PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node_modules/.bin/oxfmt --check --threads=1 CHANGELOG.md src/auto-reply/reply-payload.ts src/auto-reply/types.ts src/auto-reply/reply/dispatch-from-config.ts src/auto-reply/reply/dispatch-from-config.test.ts src/agents/pi-embedded-subscribe.handlers.messages.ts src/agents/pi-embedded-subscribe.handlers.messages.test.ts src/agents/pi-embedded-runner/run/tool-media-payloads.ts src/agents/pi-embedded-runner/run/tool-media-payloads.test.ts
  git diff --check
  ```
- **Evidence after fix:** Terminal output from the local OpenClaw source checkout showed `tool-media-payloads.test.ts` passing 7 tests, `pi-embedded-subscribe.handlers.messages.test.ts` passing 58 tests, and `pi-embedded-subscribe.handlers.tools.media.test.ts` passing 54 tests. The covered behavior includes the trusted voice media payload carrying the media-only bypass metadata and the message handler delivering staged media while suppressing the non-media confirmation text.
- **Observed result after fix:** The trusted local TTS media path now retains enough internal metadata for media delivery in message-tool-only rooms, and the text-only acknowledgement remains private/suppressed. Formatting and diff checks also passed.
- **Not tested:** I do not have live Discord or Telegram credentials in this environment, so I could not run the optional real-channel smoke. `src/auto-reply/reply/dispatch-from-config.test.ts` and the combined lifecycle/tool-media acceptance run also failed during import because this local dependency tree is missing `@earendil-works/pi-coding-agent` and `@earendil-works/pi-ai`.

## Attribution

Please preserve commit author attribution when squashing/reworking, or include:

`Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>`
