### PR TITLE
fix(auto-reply): honor webchat textChunkLimit/chunkMode config overrides [AI-assisted]

### DIFF
--- a/src/auto-reply/chunk.test.ts
+++ b/src/auto-reply/chunk.test.ts
@@ -330,6 +330,26 @@ describe("resolveTextChunkLimit", () => {
       options: undefined,
       expected: 4000,
     },
+    {
+      name: "honors webchat textChunkLimit override from config",
+      cfg: {
+        channels: {
+          webchat: { textChunkLimit: 16000 },
+        },
+      },
+      provider: "webchat" as const,
+      accountId: undefined,
+      options: undefined,
+      expected: 16000,
+    },
+    {
+      name: "falls back to default when webchat has no override",
+      cfg: { channels: {} },
+      provider: "webchat" as const,
+      accountId: undefined,
+      options: undefined,
+      expected: 4000,
+    },
   ] as const)("$name", ({ cfg, provider, accountId, options, expected }) => {
     expect(resolveTextChunkLimit(cfg as never, provider, accountId, options)).toBe(expected);
   });
@@ -584,6 +604,12 @@ describe("resolveChunkMode", () => {
     { cfg: providerCfg, provider: "discord", accountId: undefined, expected: "length" },
     { cfg: accountCfg, provider: "slack", accountId: "primary", expected: "newline" },
     { cfg: accountCfg, provider: "slack", accountId: "other", expected: "length" },
+    {
+      cfg: { channels: { webchat: { chunkMode: "newline" as const } } },
+      provider: "webchat",
+      accountId: undefined,
+      expected: "newline",
+    },
   ] as const)(
     "resolves default/provider/account/internal chunk mode for $provider $accountId",
     ({ cfg, provider, accountId, expected }) => {

--- a/src/auto-reply/chunk.ts
+++ b/src/auto-reply/chunk.ts
@@ -9,7 +9,6 @@ import { resolveChannelStreamingChunkMode } from "../plugin-sdk/channel-streamin
 import { resolveAccountEntry } from "../routing/account-lookup.js";
 import { normalizeAccountId } from "../routing/session-key.js";
 import { chunkTextByBreakResolver } from "../shared/text-chunking.js";
-import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel.js";
 
 export type TextChunkProvider = ChannelId;
 
@@ -64,7 +63,7 @@ export function resolveTextChunkLimit(
       ? opts.fallbackLimit
       : DEFAULT_CHUNK_LIMIT;
   const providerOverride = (() => {
-    if (!provider || provider === INTERNAL_MESSAGE_CHANNEL) {
+    if (!provider) {
       return undefined;
     }
     const channelsConfig = cfg?.channels as Record<string, unknown> | undefined;
@@ -102,7 +101,7 @@ export function resolveChunkMode(
   provider?: TextChunkProvider,
   accountId?: string | null,
 ): ChunkMode {
-  if (!provider || provider === INTERNAL_MESSAGE_CHANNEL) {
+  if (!provider) {
     return DEFAULT_CHUNK_MODE;
   }
   const channelsConfig = cfg?.channels as Record<string, unknown> | undefined;


### PR DESCRIPTION
> 🤖 AI-assisted (built with Codex via Hermes orchestration). Test level: lightly tested. Prompt summary available on request.

## Summary
- Problem: WebChat live responses are unconditionally truncated at ~4000 characters because `resolveTextChunkLimit` and `resolveChunkMode` explicitly short-circuit when the channel is `webchat` (`INTERNAL_MESSAGE_CHANNEL`), ignoring any user-supplied `channels.webchat.textChunkLimit` / `chunkMode` config.
- Why it matters: Long assistant replies in the Control UI silently get cut off with `...(truncated)...`, with no configuration knob to raise the limit. Other channels (Discord/Slack/Telegram/Signal) respect their `textChunkLimit` overrides, so webchat is the odd one out.
- What changed: Remove the `provider === INTERNAL_MESSAGE_CHANNEL` early-return in both `resolveTextChunkLimit` and `resolveChunkMode` in `src/auto-reply/chunk.ts`, so webchat goes through the same provider/account config lookup path as every other channel. The `DEFAULT_CHUNK_LIMIT = 4000` fallback still applies when no override is set, so existing deployments without a webchat config are unaffected.
- What did NOT change (scope boundary): No changes to non-webchat channels, no changes to the streaming pipeline, no new config keys, no schema/types changes, no UI changes. The default cap stays 4000; only the *ability* to override via `channels.webchat.textChunkLimit` / `channels.webchat.chunkMode` is unlocked.

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [x] Other (auto-reply chunking)

## Linked Issue/PR
- Closes #83658
- [x] This PR fixes a bug or regression

## Root Cause
- Root cause: `resolveTextChunkLimit` and `resolveChunkMode` were written with a guard `if (!provider || provider === INTERNAL_MESSAGE_CHANNEL) return …default…;` that bypasses the entire provider/account config resolution chain for webchat. The intent seems to have been "webchat has no API limit so just use the fallback", but the unconditional bypass also blocks user overrides through `channels.webchat.textChunkLimit`, which is the documented per-channel knob.
- Missing detection / guardrail: No unit test asserted that webchat respects `channels.webchat.textChunkLimit` / `chunkMode`. The existing `resolveTextChunkLimit` table covered telegram/discord/slack but not webchat.
- Contributing context (if known): Webchat is treated as `INTERNAL_MESSAGE_CHANNEL` throughout the codebase, and that constant is used elsewhere for legitimate "do not route as a real channel" decisions, which probably encouraged copy-pasting the bypass into the chunk resolver.

## Regression Test Plan
- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/auto-reply/chunk.test.ts` (extended `resolveTextChunkLimit` and `resolveChunkMode` table-driven blocks).
- Scenario the test should lock in: With `channels.webchat.textChunkLimit = 16000`, `resolveTextChunkLimit(cfg, "webchat")` returns `16000`; without an override it still returns the `4000` default. Same shape for `chunkMode = "newline"` via `resolveChunkMode`.
- Why this is the smallest reliable guardrail: It pins the exact public contract (`channels.<provider>.textChunkLimit` works for webchat just like for other channels) at the function boundary, which is what the regression broke. Anything broader would just be retesting the chunker.
- Existing test that already covers this (if any): N/A — coverage for webchat-specific resolution was missing.
- If no new test is added, why not: N/A — tests added.

## User-visible / Behavior Changes
- Users can now set `channels.webchat.textChunkLimit` (and `channels.webchat.chunkMode`) in their OpenClaw config and have it take effect for the WebChat/Control UI live response stream. Without any config, behavior is unchanged (still 4000-char default).

## Security Impact (required)
- New permissions/capabilities? No.
- This only unlocks an existing per-channel config knob for one more channel. There are no new code paths, no new I/O, no new auth surface. The default value is unchanged, so deployments that do not opt in see no behavior change.
