### PR TITLE
[codex] Guard doctor repairs for newer configs

### DIFF
--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -2565,6 +2565,35 @@ describe("doctor config flow", () => {
     }
   });
 
+  it("blocks doctor repair mode when config was written by a newer OpenClaw", async () => {
+    const result = await runDoctorConfigWithInput({
+      repair: true,
+      preflightMode: "fast",
+      config: {
+        meta: { lastTouchedVersion: "9999.1.1" },
+        bridge: { enabled: true },
+      },
+      run: loadAndMaybeMigrateDoctorConfig,
+    });
+
+    expect(result.repairBlockedByFutureConfig).toBe(true);
+    expect(result.futureConfigVersionSkew?.touchedVersion).toBe("9999.1.1");
+    expect(result.shouldWriteConfig).toBe(false);
+    expect((result.cfg as { bridge?: unknown }).bridge).toEqual({ enabled: true });
+    expect(
+      terminalNoteMock.mock.calls.some(
+        ([message, title]) =>
+          title === "OpenClaw version mismatch" &&
+          message.includes("Refusing to run doctor repairs"),
+      ),
+    ).toBe(true);
+    expect(
+      terminalNoteMock.mock.calls.some(
+        ([message, title]) => title === "Doctor" && message.includes('Run "openclaw doctor --fix"'),
+      ),
+    ).toBe(false);
+  });
+
   it("recovers from stale googlechat top-level allowFrom by repairing dm.allowFrom", async () => {
     const result = await runDoctorConfigWithInput({
       repair: true,

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1,5 +1,9 @@
 import path from "node:path";
 import { formatCliCommand } from "../cli/command-format.js";
+import {
+  formatFutureConfigActionBlock,
+  resolveFutureConfigActionBlock,
+} from "../config/future-version-guard.js";
 import { CONFIG_PATH } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -67,7 +71,11 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   runtime?: RuntimeEnv;
   prompter?: DoctorPrompter;
 }) {
-  const shouldRepair = params.options.repair === true || params.options.yes === true;
+  const requestedRepair =
+    params.options.repair === true ||
+    params.options.yes === true ||
+    params.options.generateGatewayToken === true;
+  let shouldRepair = requestedRepair;
   const preflight = await runDoctorConfigPreflight({ repairPrefixedConfig: shouldRepair });
   let snapshot = preflight.snapshot;
   const baseCfg = preflight.baseConfig;
@@ -79,6 +87,17 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
   const sourceMeta = (snapshot.sourceConfig as { meta?: { lastTouchedVersion?: unknown } })?.meta;
   const sourceLastTouchedVersion =
     typeof sourceMeta?.lastTouchedVersion === "string" ? sourceMeta.lastTouchedVersion : undefined;
+  const futureConfigBlock = resolveFutureConfigActionBlock({
+    action: "run doctor repairs",
+    snapshot,
+  });
+  if (futureConfigBlock) {
+    if (requestedRepair) {
+      note(formatFutureConfigActionBlock(futureConfigBlock), "OpenClaw version mismatch");
+    }
+    shouldRepair = false;
+  }
+  const confirmConfigRepair = futureConfigBlock ? async () => false : params.confirm;
 
   const legacyStep = applyLegacyCompatibilityStep({
     snapshot,
@@ -276,8 +295,8 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     candidate,
     pendingChanges,
     shouldRepair,
-    fixHints,
-    confirm: params.confirm,
+    fixHints: futureConfigBlock ? [] : fixHints,
+    confirm: confirmConfigRepair,
     note,
   });
   cfg = finalized.cfg;
@@ -289,6 +308,15 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     path: snapshot.path ?? CONFIG_PATH,
     shouldWriteConfig: finalized.shouldWriteConfig,
     sourceConfigValid: snapshot.valid,
+    ...(futureConfigBlock
+      ? {
+          repairBlockedByFutureConfig: requestedRepair,
+          futureConfigVersionSkew: {
+            currentVersion: futureConfigBlock.currentVersion,
+            touchedVersion: futureConfigBlock.touchedVersion,
+          },
+        }
+      : {}),
     ...(sourceLastTouchedVersion ? { sourceLastTouchedVersion } : {}),
     ...(legacyMigrationPartiallyValid ? { skipPluginValidationOnWrite: true } : {}),
   };

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -141,4 +141,30 @@ describe("doctor health contributions", () => {
       }),
     ).toBe(false);
   });
+
+  it("does not suggest doctor --fix when config version skew blocks repairs", async () => {
+    const contribution = requireDoctorContribution("doctor:write-config");
+    const runtime = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    };
+    const ctx = {
+      cfg: {},
+      cfgForPersistence: {},
+      configResult: {
+        cfg: {},
+        futureConfigVersionSkew: {
+          currentVersion: "2026.5.2-test",
+          touchedVersion: "9999.1.1",
+        },
+      },
+      prompter: { shouldRepair: false },
+      runtime,
+    } as unknown as Parameters<(typeof contribution)["run"]>[0];
+
+    await contribution.run(ctx);
+
+    expect(runtime.log).not.toHaveBeenCalledWith(expect.stringContaining("openclaw doctor --fix"));
+  });
 });

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -15,6 +15,11 @@ type DoctorConfigResult = {
   sourceConfigValid?: boolean;
   sourceLastTouchedVersion?: string;
   skipPluginValidationOnWrite?: boolean;
+  repairBlockedByFutureConfig?: boolean;
+  futureConfigVersionSkew?: {
+    currentVersion: string;
+    touchedVersion: string;
+  };
 };
 
 type DoctorHealthFlowContext = {
@@ -583,6 +588,23 @@ async function runWriteConfigHealth(ctx: DoctorHealthFlowContext): Promise<void>
     ctx.configResult.shouldWriteConfig ||
     JSON.stringify(ctx.cfg) !== JSON.stringify(ctx.cfgForPersistence);
   if (shouldWriteConfig) {
+    if (ctx.configResult.futureConfigVersionSkew) {
+      const { formatFutureConfigActionBlock } = await import("../config/future-version-guard.js");
+      const { note } = await import("../terminal/note.js");
+      note(
+        formatFutureConfigActionBlock({
+          action: "write doctor repairs",
+          message: `Refusing to write doctor repairs because this OpenClaw binary (${ctx.configResult.futureConfigVersionSkew.currentVersion}) is older than the config last written by OpenClaw ${ctx.configResult.futureConfigVersionSkew.touchedVersion}.`,
+          hints: [
+            "Run the newer openclaw binary on PATH, or reinstall the intended gateway service from the newer install.",
+            "Set OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS=1 only for an intentional downgrade or recovery action.",
+          ],
+          ...ctx.configResult.futureConfigVersionSkew,
+        }),
+        "OpenClaw version mismatch",
+      );
+      return;
+    }
     ctx.cfg = applyWizardMetadata(ctx.cfg, {
       command: "doctor",
       mode: resolveDoctorMode(ctx.cfg),
@@ -606,7 +628,7 @@ async function runWriteConfigHealth(ctx: DoctorHealthFlowContext): Promise<void>
     }
     return;
   }
-  if (!ctx.prompter.shouldRepair) {
+  if (!ctx.prompter.shouldRepair && !ctx.configResult.futureConfigVersionSkew) {
     ctx.runtime.log(`Run "${formatCliCommand("openclaw doctor --fix")}" to apply changes.`);
   }
 }

--- a/src/flows/doctor-health.ts
+++ b/src/flows/doctor-health.ts
@@ -55,11 +55,22 @@ export async function doctorCommand(runtime?: RuntimeEnv, options: DoctorOptions
     runtime: effectiveRuntime,
     prompter,
   });
+  const effectivePrompter =
+    configResult.repairBlockedByFutureConfig === true
+      ? {
+          ...prompter,
+          shouldRepair: false,
+          confirm: async () => false,
+          confirmAutoFix: async () => false,
+          confirmAggressiveAutoFix: async () => false,
+          confirmRuntimeRepair: async () => false,
+        }
+      : prompter;
   const { CONFIG_PATH } = await import("../config/config.js");
   const ctx = {
     runtime: effectiveRuntime,
     options,
-    prompter,
+    prompter: effectivePrompter,
     configResult,
     cfg: configResult.cfg,
     cfgForPersistence: structuredClone(configResult.cfg),


### PR DESCRIPTION
## Summary

- Block `doctor --fix`, `--yes`, and gateway-token generation from applying repairs when the config was last written by a newer OpenClaw binary.
- Downgrade the doctor prompter to read-only after that guard trips, so later health contributions do not perform repair actions.
- Suppress the generic `Run "openclaw doctor --fix"` hint while version skew is present.

## Why

Running an older checkout against a newer installed Gateway/config can produce stale or misleading repair advice. Doctor should still inspect, but repair guidance and writes should defer to the newer binary unless the existing explicit downgrade override is set.

## Validation

- `pnpm vitest run src/commands/doctor-config-flow.test.ts`
- `pnpm vitest run src/flows/doctor-health-contributions.test.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- `pnpm exec oxfmt --check src/commands/doctor-config-flow.ts src/flows/doctor-health.ts src/flows/doctor-health-contributions.ts src/commands/doctor-config-flow.test.ts src/flows/doctor-health-contributions.test.ts`
- `pnpm exec oxlint --tsconfig config/tsconfig/oxlint.core.json src/commands/doctor-config-flow.ts src/flows/doctor-health.ts src/flows/doctor-health-contributions.ts src/commands/doctor-config-flow.test.ts src/flows/doctor-health-contributions.test.ts`
- `git diff --check`

Note: `pnpm check:changed` was attempted but widened to all lanes because this worktree already has unrelated `.codex/` and `extensions/canvas/src/host/a2ui/.bundle.hash` changes. It failed in the WhatsApp extension typecheck on existing `baileys`/WhatsApp send-key errors outside this PR scope.
