### PR TITLE
fix(memory-core): treat dreaming fence marker lines as inside-fence in promotion guard (#80613)

### DIFF
--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -1756,6 +1756,124 @@ describe("short-term promotion", () => {
       expect(testing.lineRangeOverlapsDreamingFence(lines, 8, 8)).toBe(false);
       expect(testing.lineRangeOverlapsDreamingFence(lines, 6, 6)).toBe(true);
     });
+
+    // Marker lines themselves carry managed-block content. A relocated range
+    // that includes a `<!-- openclaw:dreaming:*:start/end -->` marker would
+    // build its snippet from raw lines that contain that marker text, leaking
+    // it into MEMORY.md alongside any adjacent fenced content captured by the
+    // same window. The guard treats marker lines as inside-fence so those
+    // ranges are rejected. (#80613)
+    it("returns true when the range ends on a Light Sleep start marker", () => {
+      const lines = [
+        "## Plan",
+        "- Plan switches use exRule, not abConfig",
+        "",
+        "## Light Sleep",
+        "<!-- openclaw:dreaming:light:start -->",
+        "- Candidate: staged dream",
+        "<!-- openclaw:dreaming:light:end -->",
+      ];
+      expect(testing.lineRangeOverlapsDreamingFence(lines, 2, 5)).toBe(true);
+    });
+
+    it("returns true when the range begins on a Light Sleep end marker", () => {
+      const lines = [
+        "<!-- openclaw:dreaming:light:start -->",
+        "- Candidate: staged dream",
+        "<!-- openclaw:dreaming:light:end -->",
+        "- normal durable bullet",
+      ];
+      expect(testing.lineRangeOverlapsDreamingFence(lines, 3, 4)).toBe(true);
+    });
+
+    it("returns true when the range covers only a marker line", () => {
+      const lines = [
+        "<!-- openclaw:dreaming:light:start -->",
+        "- Candidate: staged dream",
+        "<!-- openclaw:dreaming:light:end -->",
+      ];
+      expect(testing.lineRangeOverlapsDreamingFence(lines, 1, 1)).toBe(true);
+      expect(testing.lineRangeOverlapsDreamingFence(lines, 3, 3)).toBe(true);
+    });
+
+    it("returns true for REM marker single-line ranges even with no body between markers", () => {
+      const lines = [
+        "real line 1",
+        "<!-- openclaw:dreaming:rem:start -->",
+        "<!-- openclaw:dreaming:rem:end -->",
+        "real line 4",
+      ];
+      // No content between the markers, but the marker text itself must not
+      // ride along into a promoted snippet.
+      expect(testing.lineRangeOverlapsDreamingFence(lines, 2, 2)).toBe(true);
+      expect(testing.lineRangeOverlapsDreamingFence(lines, 3, 3)).toBe(true);
+      // Real-content single lines remain unflagged.
+      expect(testing.lineRangeOverlapsDreamingFence(lines, 1, 1)).toBe(false);
+      expect(testing.lineRangeOverlapsDreamingFence(lines, 4, 4)).toBe(false);
+    });
+  });
+
+  it("does not promote rehydrated candidates whose relocated range covers a managed dreaming fence marker line (#80613)", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      // Daily note: human content + a managed Light Sleep block. The relevant
+      // surface is the marker lines (5 and 8), not the fenced content between
+      // them. The existing fence-overlap guard already blocks ranges between
+      // the markers; this test exercises the residual edge case where the
+      // relocated range covers a marker line itself.
+      await writeDailyMemoryNote(workspaceDir, "2026-05-18", [
+        "## Plan", // 1
+        "- Plan switches use exRule, not abConfig", // 2
+        "", // 3
+        "## Light Sleep", // 4
+        "<!-- openclaw:dreaming:light:start -->", // 5
+        "- Candidate: staged dream", // 6
+        "  - confidence: 0.95", // 7
+        "<!-- openclaw:dreaming:light:end -->", // 8
+      ]);
+
+      // Stored recall snippet equals the marker text exactly, so relocate's
+      // exact-match path resolves to (5, 5) with the marker as its snippet.
+      // The contamination predicate does not flag bare marker text (no
+      // Candidate/Reflections + confidence + evidence + status: staged +
+      // recalls signature), so the only line of defense is the fence-overlap
+      // guard. Pre-patch the guard returns false for a marker-only range and
+      // the marker text leaks into MEMORY.md; post-patch the range is rejected.
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "marker-line edge case",
+        results: [
+          {
+            path: "memory/2026-05-18.md",
+            startLine: 5,
+            endLine: 5,
+            score: 0.94,
+            snippet: "<!-- openclaw:dreaming:light:start -->",
+            source: "memory",
+          },
+        ],
+      });
+
+      const ranked = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+      });
+      const applied = await applyShortTermPromotions({
+        workspaceDir,
+        candidates: ranked,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+      });
+
+      expect(applied.applied).toBe(0);
+      const memoryText = await fs
+        .readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8")
+        .catch(() => "");
+      expect(memoryText).not.toContain("Promoted From Short-Term Memory");
+      expect(memoryText).not.toMatch(/openclaw:dreaming/i);
+    });
   });
 
   it("refuses to promote rehydrated candidates that land inside a managed dreaming fence", async () => {

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -2267,15 +2267,21 @@ function lineRangeOverlapsDreamingFence(
   let insideFence = false;
   for (let i = 0; i < safeEnd; i += 1) {
     const line = lines[i] ?? "";
-    if (DREAMING_FENCE_START_RE.test(line)) {
-      insideFence = true;
-      continue;
-    }
-    if (DREAMING_FENCE_END_RE.test(line)) {
-      insideFence = false;
-      continue;
-    }
     const oneIndexed = i + 1;
+    const isStart = DREAMING_FENCE_START_RE.test(line);
+    const isEnd = DREAMING_FENCE_END_RE.test(line);
+    if (isStart || isEnd) {
+      // The marker line itself is managed-block content. A relocated range
+      // that includes a `<!-- openclaw:dreaming:*:start/end -->` marker would
+      // build its snippet from raw lines that contain that marker text and
+      // leak it into MEMORY.md alongside any adjacent fenced content captured
+      // by the same window. (#80613)
+      if (oneIndexed >= safeStart && oneIndexed <= safeEnd) {
+        return true;
+      }
+      insideFence = isStart;
+      continue;
+    }
     if (insideFence && oneIndexed >= safeStart && oneIndexed <= safeEnd) {
       return true;
     }


### PR DESCRIPTION
## Summary

- **Problem.** `lineRangeOverlapsDreamingFence` in `extensions/memory-core/src/short-term-promotion.ts` tracked `insideFence` state from the fence marker lines but never flagged ranges that included the marker lines themselves. A relocated promotion range that ended on a `<!-- openclaw:dreaming:*:start -->` line, began on a `<!-- openclaw:dreaming:*:end -->` line, or covered only a marker line passed the guard, and the snippet built from those raw lines carried the marker text into `MEMORY.md`.
- **Why it matters.** The guard's contract is to refuse rehydrated ranges that overlap managed dreaming fences so dream artifacts cannot be promoted. Treating the marker lines themselves as outside-the-fence leaves a narrow but real leak: any window the relocator picks that clips a marker produces a snippet that includes the literal `<!-- openclaw:dreaming:*:start/end -->` text, and (when the window straddles content on either side of the marker) the adjacent line. This is the residual edge case noted by ClawSweeper on #80702 ("the managed-block leak half is related but should be handled by a focused memory-core promotion fix"), narrowed to the guard itself rather than a parallel sanitizer.
- **What changed.** `extensions/memory-core/src/short-term-promotion.ts`: marker lines are now checked against the range bounds; if a marker is inside the relocated range, the range is rejected. The pre-existing inside-fence tracking remains so interior lines between a start/end pair are still flagged. The contract elsewhere — the contamination predicate, the relocator, the apply path, the `MEMORY.md` writer — is untouched.
- **What did not change (scope boundary).** No change to `relocateCandidateRange`, `isContaminatedDreamingSnippet`, `applyShortTermPromotions`, `buildDailySnippetChunks`, `stripManagedDailyDreamingLines`, the CJK dedupe path (the second sub-bug of #80613 is being addressed separately by #80620), or any `MEMORY.md` rendering. No new sanitizer is introduced — this is a narrowing of the existing guard.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Refs #80613 (does not fully close; the dramatic full-Candidate leak from the issue body is already prevented by the merged fence-overlap guard in #68774. This PR narrows a residual marker-line edge case in the same guard.)
- Related: #80620 (CJK dedupe half, separate PR), #80702 (closed sanitizer approach, intentionally not duplicated here).
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior addressed: `lineRangeOverlapsDreamingFence` now flags relocated promotion ranges that include a dreaming fence marker line, preventing the marker text (and any adjacent fenced content captured by the same raw-line window) from being promoted into `MEMORY.md`.
- Real environment tested: Local OpenClaw source checkout on macOS (Apple Silicon, Node v22.14.0, pnpm 11.1.0). The fix is mechanical and exercised by Vitest unit tests against the helper directly.
- Exact steps or command run after this patch:
  - `pnpm test extensions/memory-core/src/short-term-promotion.test.ts -t "lineRangeOverlapsDreamingFence"` — targeted run of the affected describe block.
  - `pnpm test extensions/memory-core/src/short-term-promotion.test.ts` — full file regression.
  - `pnpm test extensions/memory-core/src/dreaming-phases.test.ts` — adjacent file regression.
  - `pnpm format:check extensions/memory-core/src/short-term-promotion.ts extensions/memory-core/src/short-term-promotion.test.ts` — format on changed files.
  - `pnpm lint extensions/memory-core/src/short-term-promotion.ts extensions/memory-core/src/short-term-promotion.test.ts` — lint on changed files.
  - `pnpm tsgo:extensions` and `pnpm tsgo:extensions:test` — typecheck.
- Evidence after fix:
  - Before the source change, the four added tests reproduce the gap (output captured locally):
    ```
    Tests  4 failed | 4 passed | 50 skipped (58)
    × returns true when the range ends on a Light Sleep start marker
    × returns true when the range begins on a Light Sleep end marker
    × returns true when the range covers only a marker line
    × returns true for REM marker single-line ranges even with no body between markers
    ```
    Each failure form: `expected false to be true`, confirming that the pre-patch guard returns `false` for a range that includes only a marker line.
  - After the source change:
    ```
    Tests  8 passed | 50 skipped (58)            # lineRangeOverlapsDreamingFence -t filter
    Tests  58 passed (58)                         # full short-term-promotion.test.ts
    Tests  41 passed (41)                         # full dreaming-phases.test.ts
    ```
  - Format/lint/typecheck on changed files: all clean. (Repo-wide format reports 34 pre-existing issues on `main` unrelated to this PR.)
- Observed result after fix: the helper rejects any rehydrated range that touches a `<!-- openclaw:dreaming:*:start -->` or `<!-- openclaw:dreaming:*:end -->` marker line. No regressions in the existing `lineRangeOverlapsDreamingFence` describe block or the broader test files.
- What was not tested: An end-to-end repro via `applyShortTermPromotions` that drives `relocateCandidateRange` to organically pick a marker-line-bordering window. Probe attempts on current `main` could not construct an organic trigger — the relocator's compare/quality scoring rarely prefers such windows when cleaner alternatives exist in the file — so the demonstration is at the unit level. The repo-wide format/lint/build/CI suite was not run locally; the changed files pass all relevant lanes individually.
