### PR TITLE
[AI-assisted] fix(reply): wait for block replies before tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - CLI/agents: allow `openclaw agent --session-key` to target explicit session keys, including agent-scoped legacy keys. (#85121) Thanks @Kaspre.
+- Auto-reply/ACP: wait for same-channel block reply delivery before starting tool work, while still honoring ACP dispatch aborts so stopped turns do not wait on slow channel sends. (#83722) Thanks @IWhatsskill.
 - Agents/subagents: surface blocked child-run completions as errors instead of successful subagent finishes. (#80886) Thanks @TurboTheTurtle.
 - Agents/Pi: treat accepted embedded `sessions_spawn` child-session handoffs as terminal progress so parent turns no longer report false non-deliverable failures. (#85054) Thanks @samzong.
 - WhatsApp: update Baileys to `7.0.0-rc13` and drop the obsolete logger type patch.

--- a/src/auto-reply/reply/dispatch-acp-delivery.test.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import { createAcpDispatchDeliveryCoordinator } from "./dispatch-acp-delivery.js";
-import type { ReplyDispatcher } from "./reply-dispatcher.js";
+import { createReplyDispatcher, type ReplyDispatcher } from "./reply-dispatcher.js";
 import { buildTestCtx } from "./test-ctx.js";
 import { createAcpTestConfig } from "./test-fixtures/acp-runtime.js";
 
@@ -238,6 +238,51 @@ describe("createAcpDispatchDeliveryCoordinator", () => {
     expect(coordinator.hasDeliveredVisibleText()).toBe(true);
     expect(coordinator.hasFailedVisibleTextDelivery()).toBe(false);
     expect(coordinator.getRoutedCounts().block).toBe(0);
+  });
+
+  it("waits for direct block dispatcher delivery before resolving block delivery", async () => {
+    const delivered: unknown[] = [];
+    let releaseDelivery: (() => void) | undefined;
+    let markDeliveryStarted: (() => void) | undefined;
+    const deliveryStarted = new Promise<void>((resolve) => {
+      markDeliveryStarted = resolve;
+    });
+    const deliveryGate = new Promise<void>((resolve) => {
+      releaseDelivery = resolve;
+    });
+    const dispatcher = createReplyDispatcher({
+      deliver: async (payload) => {
+        delivered.push(payload);
+        markDeliveryStarted?.();
+        await deliveryGate;
+      },
+    });
+    const coordinator = createAcpDispatchDeliveryCoordinator({
+      cfg: createAcpTestConfig(),
+      ctx: buildTestCtx({
+        Provider: "visiblechat",
+        Surface: "visiblechat",
+        SessionKey: "agent:codex-acp:session-1",
+      }),
+      dispatcher,
+      inboundAudio: false,
+      shouldRouteToOriginating: false,
+    });
+
+    let deliverySettled = false;
+    const deliveryPromise = coordinator.deliver("block", { text: "hello" }, { skipTts: true });
+    void deliveryPromise.then(() => {
+      deliverySettled = true;
+    });
+
+    await deliveryStarted;
+
+    expect(delivered).toEqual([{ text: "hello" }]);
+    expect(deliverySettled).toBe(false);
+
+    releaseDelivery?.();
+    await expect(deliveryPromise).resolves.toBe(true);
+    expect(deliverySettled).toBe(true);
   });
 
   it("strips split TTS directives from visible ACP block delivery", async () => {

--- a/src/auto-reply/reply/dispatch-acp-delivery.test.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.test.ts
@@ -285,6 +285,48 @@ describe("createAcpDispatchDeliveryCoordinator", () => {
     expect(deliverySettled).toBe(true);
   });
 
+  it("stops waiting for direct block delivery when the ACP dispatch aborts", async () => {
+    const delivered: unknown[] = [];
+    const controller = new AbortController();
+    let releaseDelivery: (() => void) | undefined;
+    let markDeliveryStarted: (() => void) | undefined;
+    const deliveryStarted = new Promise<void>((resolve) => {
+      markDeliveryStarted = resolve;
+    });
+    const deliveryGate = new Promise<void>((resolve) => {
+      releaseDelivery = resolve;
+    });
+    const dispatcher = createReplyDispatcher({
+      deliver: async (payload) => {
+        delivered.push(payload);
+        markDeliveryStarted?.();
+        await deliveryGate;
+      },
+    });
+    const coordinator = createAcpDispatchDeliveryCoordinator({
+      cfg: createAcpTestConfig(),
+      ctx: buildTestCtx({
+        Provider: "visiblechat",
+        Surface: "visiblechat",
+        SessionKey: "agent:codex-acp:session-1",
+      }),
+      dispatcher,
+      inboundAudio: false,
+      shouldRouteToOriginating: false,
+      abortSignal: controller.signal,
+    });
+
+    const deliveryPromise = coordinator.deliver("block", { text: "hello" }, { skipTts: true });
+    await deliveryStarted;
+    controller.abort();
+
+    await expect(deliveryPromise).resolves.toBe(true);
+    expect(delivered).toEqual([{ text: "hello" }]);
+
+    releaseDelivery?.();
+    await dispatcher.waitForIdle();
+  });
+
   it("strips split TTS directives from visible ACP block delivery", async () => {
     const dispatcher = createDispatcher();
     const coordinator = createAcpDispatchDeliveryCoordinator({

--- a/src/auto-reply/reply/dispatch-acp-delivery.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.ts
@@ -192,6 +192,7 @@ export function createAcpDispatchDeliveryCoordinator(params: {
   originatingChannel?: string;
   originatingTo?: string;
   onReplyStart?: () => Promise<void> | void;
+  abortSignal?: AbortSignal;
 }): AcpDispatchDeliveryCoordinator {
   const directChannel = normalizeOptionalLowercaseString(params.ctx.Provider ?? params.ctx.Surface);
   const routedChannel = normalizeOptionalLowercaseString(params.originatingChannel);
@@ -460,7 +461,7 @@ export function createAcpDispatchDeliveryCoordinator(params: {
       state.failedVisibleTextDelivery = true;
     }
     if (kind === "block" && delivered) {
-      await waitForReplyDispatcherIdle(params.dispatcher);
+      await waitForReplyDispatcherIdle(params.dispatcher, params.abortSignal);
     }
     return delivered;
   };

--- a/src/auto-reply/reply/dispatch-acp-delivery.ts
+++ b/src/auto-reply/reply/dispatch-acp-delivery.ts
@@ -13,6 +13,7 @@ import { resolveStatusTtsSnapshot } from "../../tts/status-config.js";
 import { resolveConfiguredTtsMode, shouldCleanTtsDirectiveText } from "../../tts/tts-config.js";
 import type { FinalizedMsgContext } from "../templating.js";
 import type { ReplyPayload } from "../types.js";
+import { waitForReplyDispatcherIdle } from "./reply-dispatcher.js";
 import type { ReplyDispatchKind, ReplyDispatcher } from "./reply-dispatcher.types.js";
 import { resolveRoutedDeliveryThreadId } from "./routed-delivery-thread.js";
 
@@ -457,6 +458,9 @@ export function createAcpDispatchDeliveryCoordinator(params: {
       state.settledDirectVisibleText = false;
     } else if (!delivered && tracksVisibleText) {
       state.failedVisibleTextDelivery = true;
+    }
+    if (kind === "block" && delivered) {
+      await waitForReplyDispatcherIdle(params.dispatcher);
     }
     return delivered;
   };

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -386,6 +386,7 @@ export async function tryDispatchAcpReply(params: {
     originatingChannel: params.originatingChannel,
     originatingTo: params.originatingTo,
     onReplyStart: params.onReplyStart,
+    abortSignal: params.abortSignal,
   });
 
   const identityPendingBeforeTurn = isSessionIdentityPending(

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -27,7 +27,7 @@ import { createInternalHookEventPayload } from "../../test-utils/internal-hook-e
 import type { MsgContext } from "../templating.js";
 import { setReplyPayloadMetadata, type GetReplyOptions, type ReplyPayload } from "../types.js";
 import { PROVIDER_CONVERSATION_STATE_ERROR_USER_MESSAGE } from "./provider-request-error-classifier.js";
-import type { ReplyDispatcher } from "./reply-dispatcher.js";
+import { createReplyDispatcher, type ReplyDispatcher } from "./reply-dispatcher.js";
 import { buildTestCtx } from "./test-ctx.js";
 
 type AbortResult = { handled: boolean; aborted: boolean; stoppedSubagents?: number };
@@ -4588,6 +4588,56 @@ describe("dispatchReplyFromConfig", () => {
     });
 
     expect(callOrder).toEqual(["queued:The answer is 42", "dispatch:The answer is 42"]);
+  });
+
+  it("waits for same-channel block dispatcher delivery before resolving block replies", async () => {
+    setNoAbort();
+    const ctx = buildTestCtx({ Provider: "whatsapp" });
+    const delivered: ReplyPayload[] = [];
+    let releaseDelivery: (() => void) | undefined;
+    let markDeliveryStarted: (() => void) | undefined;
+    const deliveryStarted = new Promise<void>((resolve) => {
+      markDeliveryStarted = resolve;
+    });
+    const deliveryGate = new Promise<void>((resolve) => {
+      releaseDelivery = resolve;
+    });
+    const dispatcher = createReplyDispatcher({
+      deliver: async (payload) => {
+        delivered.push(payload);
+        markDeliveryStarted?.();
+        await deliveryGate;
+      },
+    });
+    let blockReplySettled = false;
+    const replyResolver = async (
+      _ctx: MsgContext,
+      opts?: GetReplyOptions,
+    ): Promise<ReplyPayload | undefined> => {
+      const blockReplyPromise = Promise.resolve(opts?.onBlockReply?.({ text: "before tool" })).then(
+        () => {
+          blockReplySettled = true;
+        },
+      );
+
+      await deliveryStarted;
+
+      expect(delivered).toEqual([{ text: "before tool" }]);
+      expect(blockReplySettled).toBe(false);
+
+      releaseDelivery?.();
+      await blockReplyPromise;
+      return undefined;
+    };
+
+    await dispatchReplyFromConfig({
+      ctx,
+      cfg: emptyConfig,
+      dispatcher,
+      replyResolver,
+    });
+
+    expect(blockReplySettled).toBe(true);
   });
 
   it("forwards payload metadata into onBlockReplyQueued context", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -121,6 +121,7 @@ import { resolveEffectiveReplyRoute } from "./effective-reply-route.js";
 import { withFullRuntimeReplyConfig } from "./get-reply-fast-path.js";
 import { claimInboundDedupe, commitInboundDedupe, releaseInboundDedupe } from "./inbound-dedupe.js";
 import { resolveOriginMessageProvider } from "./origin-routing.js";
+import { waitForReplyDispatcherIdle } from "./reply-dispatcher.js";
 import type { ReplyDispatcher } from "./reply-dispatcher.types.js";
 import {
   createReplyOperation,
@@ -2066,7 +2067,10 @@ export async function dispatchReplyFromConfig(
                   await sendPayloadAsync(normalizedPayload, context?.abortSignal, false);
                 } else {
                   markInboundDedupeReplayUnsafe();
-                  dispatcher.sendBlockReply(normalizedPayload);
+                  const delivered = dispatcher.sendBlockReply(normalizedPayload);
+                  if (delivered) {
+                    await waitForReplyDispatcherIdle(dispatcher, context?.abortSignal);
+                  }
                 }
               };
               return run();

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -254,6 +254,30 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
   };
 }
 
+export async function waitForReplyDispatcherIdle(
+  dispatcher: Pick<ReplyDispatcher, "waitForIdle">,
+  abortSignal?: AbortSignal,
+): Promise<void> {
+  if (!abortSignal) {
+    await dispatcher.waitForIdle();
+    return;
+  }
+  if (abortSignal.aborted) {
+    return;
+  }
+  let removeAbortListener: (() => void) | undefined;
+  const aborted = new Promise<void>((resolve) => {
+    const onAbort = () => resolve();
+    abortSignal.addEventListener("abort", onAbort, { once: true });
+    removeAbortListener = () => abortSignal.removeEventListener("abort", onAbort);
+  });
+  try {
+    await Promise.race([dispatcher.waitForIdle(), aborted]);
+  } finally {
+    removeAbortListener?.();
+  }
+}
+
 export function createReplyDispatcherWithTyping(
   options: ReplyDispatcherWithTypingOptions,
 ): ReplyDispatcherWithTypingResult {

--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { HEARTBEAT_TOKEN, SILENT_REPLY_TOKEN } from "../tokens.js";
-import { createReplyDispatcher } from "./reply-dispatcher.js";
+import { createReplyDispatcher, waitForReplyDispatcherIdle } from "./reply-dispatcher.js";
 import { createReplyToModeFilter } from "./reply-threading.js";
 
 type DeliverPayload = Parameters<Parameters<typeof createReplyDispatcher>[0]["deliver"]>[0];
@@ -214,6 +214,32 @@ describe("createReplyDispatcher", () => {
     expect(deliver).toHaveBeenCalledTimes(2);
 
     vi.useRealTimers();
+  });
+});
+
+describe("waitForReplyDispatcherIdle", () => {
+  it("returns when the abort signal fires before the dispatcher becomes idle", async () => {
+    const controller = new AbortController();
+    const waitForIdle = vi.fn(
+      () =>
+        new Promise<void>(() => {
+          // Keep the dispatcher busy until the abort path wins.
+        }),
+    );
+
+    let settled = false;
+    const waitPromise = waitForReplyDispatcherIdle({ waitForIdle }, controller.signal).then(() => {
+      settled = true;
+    });
+
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    controller.abort();
+    await waitPromise;
+
+    expect(settled).toBe(true);
+    expect(waitForIdle).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
## Summary

- Problem: same-channel block replies could be queued but not delivered before tool execution continued.
- Why it matters: a user can miss the assistant's pre-tool block reply even though the tool run starts.
- What changed: successful same-channel block replies now wait for the dispatcher to drain before the block callback resolves.
- What did NOT change (scope boundary): no provider API, channel plugin, config, routing, or tool execution behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32868
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: same-channel block replies must be delivered before the tool path continues.
- Real environment tested: isolated Ubuntu OpenClaw source checkout on current `origin/main`, Node 22.22.2, no secrets, plus a local diagnostic-channel runtime adapter.
- Exact steps or command run after this patch: ran a before/after diagnostic runtime proof through the real `dispatchReplyFromConfig -> onBlockReply -> createReplyDispatcher.deliver` path, then ran focused OpenClaw source tests.
- Evidence after fix:

```text
Diagnostic runtime proof, before patch on origin/main:
verdict: FAIL
eventOrder:
dispatch_start
assistant_text_end_block_callback_invoked
diagnostic_channel_send_start
block_callback_resolved
next_tool_start
diagnostic_channel_send_complete
dispatch_done

Diagnostic runtime proof, after this patch:
verdict: PASS
eventOrder:
dispatch_start
assistant_text_end_block_callback_invoked
diagnostic_channel_send_start
diagnostic_channel_send_complete
block_callback_resolved
next_tool_start
dispatch_done

node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts src/auto-reply/reply/reply-flow.test.ts src/auto-reply/reply/dispatch-acp-delivery.test.ts src/auto-reply/reply/block-reply-pipeline.test.ts
Test Files  4 passed (4)
Tests       182 passed (182)

node scripts/run-vitest.mjs src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.calls-onblockreplyflush-before-tool-execution-start-preserve.test.ts src/agents/pi-embedded-subscribe.handlers.tools.test.ts
Test Files  4 passed (4)
Tests       78 passed (78)
```

- Observed result after fix: the diagnostic channel send completed before the block callback resolved and before the next tool started.
- What was not tested: a live Telegram/WhatsApp/Discord run with real account credentials.
- Before evidence: the same diagnostic proof on current main showed `next_tool_start` before `diagnostic_channel_send_complete`.

## Root Cause (if applicable)

- Root cause: `sendBlockReply(...)` returns only a boolean, so callers could treat "queued" as "delivered".
- Missing detection / guardrail: there was no same-channel delivery barrier around block replies before continuing into tool execution.
- Contributing context (if known): the existing pre-tool flush only covered the callback chain, not the dispatcher's async send chain.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/dispatch-from-config.test.ts`, `src/auto-reply/reply/dispatch-acp-delivery.test.ts`, existing tool-start regression tests.
- Scenario the test should lock in: block reply callbacks do not resolve while same-channel dispatcher delivery is still in flight, and abort can stop the wait.
- Why this is the smallest reliable guardrail: it covers the exact boundary where a queued block reply becomes visible before tool execution.
- Existing test that already covers this (if any): tool-start ordering tests existed, but they did not force the dispatcher delivery promise to stay pending.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Users should see same-channel pre-tool block replies before the corresponding tool execution begins.

## Diagram (if applicable)

```text
Before:
block reply -> dispatcher queued -> callback resolved -> tool can start before delivery

After:
block reply -> dispatcher queued -> wait for dispatcher delivery -> callback resolved -> tool starts
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: isolated Ubuntu test server
- Runtime/container: Node 22.22.2
- Model/provider: N/A
- Integration/channel (if any): same-channel reply dispatcher source path with a local diagnostic-channel delivery adapter
- Relevant config (redacted): no secrets used

### Steps

1. Run the diagnostic proof on current `origin/main`.
2. Observe the next tool start before diagnostic channel delivery completes.
3. Apply this PR patch.
4. Run the same diagnostic proof again.
5. Observe diagnostic channel delivery complete before the block callback resolves and before the next tool starts.

### Expected

- Diagnostic channel delivery completes before the block callback resolves and before the next tool starts.

### Actual

- Before patch: `next_tool_start` came before `diagnostic_channel_send_complete`.
- After patch: `diagnostic_channel_send_complete` came before `block_callback_resolved` and `next_tool_start`.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Focused checks:

```text
node --import tsx proof-block-reply-delivery.mjs
Before on origin/main: FAIL because next_tool_start occurred before diagnostic_channel_send_complete.
After this patch: PASS because diagnostic_channel_send_complete occurred before block_callback_resolved and next_tool_start.

node scripts/run-vitest.mjs src/auto-reply/reply/dispatch-from-config.test.ts src/auto-reply/reply/reply-flow.test.ts src/auto-reply/reply/dispatch-acp-delivery.test.ts src/auto-reply/reply/block-reply-pipeline.test.ts
Test Files  4 passed (4)
Tests       182 passed (182)

node scripts/run-vitest.mjs src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.calls-onblockreplyflush-before-tool-execution-start-preserve.test.ts src/agents/pi-embedded-subscribe.handlers.tools.test.ts
Test Files  4 passed (4)
Tests       78 passed (78)

corepack pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/reply-dispatcher.ts src/auto-reply/reply/dispatch-from-config.ts src/auto-reply/reply/dispatch-acp-delivery.ts src/auto-reply/reply/dispatch-from-config.test.ts src/auto-reply/reply/dispatch-acp-delivery.test.ts src/auto-reply/reply/reply-flow.test.ts
All matched files use the correct format.

corepack pnpm tsgo:core:test
passed

git diff --check
clean
```

## Human Verification (required)

- Verified scenarios: before/after diagnostic-channel runtime proof; same-channel block reply waits for real dispatcher delivery; direct ACP block delivery waits for real dispatcher delivery; abort signal can stop the same-channel wait; existing tool-start regression tests still pass.
- Edge cases checked: dispatcher boolean compatibility is unchanged.
- What you did **not** verify: live external provider credentials or a real Telegram/WhatsApp/Discord message.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: waiting for dispatcher delivery can keep the block callback pending longer when delivery is slow.
  - Mitigation: the wait only applies after a successful same-channel block send, and the same-channel path is abort-aware.
