### PR TITLE
fix(cron): suppress fatal error completion announce

### DIFF
--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -241,6 +241,37 @@ async function logCronDeliveryError(message: string): Promise<void> {
   logError(message);
 }
 
+export async function cleanupDirectCronSession(params: {
+  job: CronJob;
+  agentSessionKey: string;
+  sessionId: string;
+  retireReason: string;
+}): Promise<void> {
+  if (!params.job.deleteAfterRun) {
+    return;
+  }
+  if (!isCronSessionKey(params.agentSessionKey)) {
+    return;
+  }
+  try {
+    const { callGateway } = await loadGatewayCallRuntime();
+    await callGateway({
+      method: "sessions.delete",
+      params: {
+        key: params.agentSessionKey,
+        deleteTranscript: true,
+        emitLifecycleHooks: false,
+      },
+      timeoutMs: 10_000,
+    });
+  } catch {
+    await retireSessionMcpRuntime({
+      sessionId: params.sessionId,
+      reason: params.retireReason,
+    });
+  }
+}
+
 function logCronDeliveryErrorDeferred(message: string): void {
   void loadDeliveryLoggerRuntime().then(({ logError }) => {
     logError(message);
@@ -745,32 +776,16 @@ export async function dispatchCronDelivery(
       ...params.telemetry,
     });
   const cleanupDirectCronSessionIfNeeded = async (): Promise<void> => {
-    if (!params.job.deleteAfterRun || directCronSessionDeleted) {
+    if (directCronSessionDeleted) {
       return;
     }
-    if (!isCronSessionKey(params.agentSessionKey)) {
-      directCronSessionDeleted = true;
-      return;
-    }
-    try {
-      const { callGateway } = await loadGatewayCallRuntime();
-      await callGateway({
-        method: "sessions.delete",
-        params: {
-          key: params.agentSessionKey,
-          deleteTranscript: true,
-          emitLifecycleHooks: false,
-        },
-        timeoutMs: 10_000,
-      });
-      directCronSessionDeleted = true;
-    } catch {
-      await retireSessionMcpRuntime({
-        sessionId: params.sessionId,
-        reason: "cron-delete-after-run-fallback",
-      });
-      // Best-effort; direct delivery result should still be returned.
-    }
+    directCronSessionDeleted = true;
+    await cleanupDirectCronSession({
+      job: params.job,
+      agentSessionKey: params.agentSessionKey,
+      sessionId: params.sessionId,
+      retireReason: "cron-delete-after-run-fallback",
+    });
   };
   const finishSilentReplyDelivery = async (): Promise<RunCronAgentTurnResult> => {
     deliveryAttempted = true;

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -19,6 +19,7 @@ export type CronPayloadOutcome = {
   deliveryPayloads: DeliveryPayload[];
   deliveryPayloadHasStructuredContent: boolean;
   hasFatalErrorPayload: boolean;
+  hasFatalStructuredErrorPayload: boolean;
   embeddedRunError?: string;
   pendingPresentationWarningError?: string;
 };
@@ -333,6 +334,7 @@ export function resolveCronPayloadOutcome(params: {
       ? false
       : deliveryPayloadHasStructuredContent,
     hasFatalErrorPayload,
+    hasFatalStructuredErrorPayload,
     embeddedRunError: structuredErrorText
       ? structuredErrorText
       : failureSignal

--- a/src/cron/isolated-agent/run-delivery.runtime.ts
+++ b/src/cron/isolated-agent/run-delivery.runtime.ts
@@ -1,2 +1,6 @@
 export { resolveDeliveryTarget } from "./delivery-target.js";
-export { dispatchCronDelivery, resolveCronDeliveryBestEffort } from "./delivery-dispatch.js";
+export {
+  cleanupDirectCronSession,
+  dispatchCronDelivery,
+  resolveCronDeliveryBestEffort,
+} from "./delivery-dispatch.js";

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -5,6 +5,7 @@ import type { CronDeliveryMode } from "../types.js";
 import type { MutableCronSession } from "./run-session-state.js";
 import {
   clearFastTestEnv,
+  cleanupDirectCronSessionMock,
   dispatchCronDeliveryMock,
   getChannelPluginMock,
   isHeartbeatOnlyResponseMock,
@@ -757,11 +758,48 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     expect(result.delivered).toBe(false);
     expect(result.deliveryAttempted).toBe(false);
     expect(dispatchCronDeliveryMock).not.toHaveBeenCalled();
+    expect(cleanupDirectCronSessionMock).toHaveBeenCalledWith({
+      job: expect.objectContaining({ id: "fatal-error-payload" }),
+      agentSessionKey: "agent:default:cron:message-tool-policy",
+      sessionId: "test-session-id",
+      retireReason: "cron-delete-after-run-fatal-error",
+    });
     expectDeliveryFields(result.delivery, {
       intended: { channel: "messagechat", to: "123", source: "explicit" },
       resolved: { ok: true, channel: "messagechat", to: "123", source: "explicit" },
       fallbackUsed: false,
       delivered: false,
+    });
+  });
+
+  it("cleans up deleteAfterRun sessions when suppressing fatal error announces", async () => {
+    mockRunCronFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue(makeAnnounceDeliveryPlan());
+    runEmbeddedPiAgentMock.mockResolvedValue({
+      payloads: [{ text: "provider failed", isError: true }],
+      meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+    });
+
+    await runCronIsolatedAgentTurn({
+      ...makeParams(),
+      job: {
+        ...makeAnnounceMessageToolJob({
+          id: "fatal-delete-after-run",
+          name: "Fatal Delete After Run",
+        }),
+        deleteAfterRun: true,
+      } as never,
+    });
+
+    expect(dispatchCronDeliveryMock).not.toHaveBeenCalled();
+    expect(cleanupDirectCronSessionMock).toHaveBeenCalledWith({
+      job: expect.objectContaining({
+        id: "fatal-delete-after-run",
+        deleteAfterRun: true,
+      }),
+      agentSessionKey: "agent:default:cron:message-tool-policy",
+      sessionId: "test-session-id",
+      retireReason: "cron-delete-after-run-fatal-error",
     });
   });
 

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -731,6 +731,40 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     });
   });
 
+  it("does not dispatch announce delivery for fatal error payloads", async () => {
+    mockRunCronFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue(makeAnnounceDeliveryPlan());
+    runEmbeddedPiAgentMock.mockResolvedValue({
+      payloads: [
+        {
+          text: 'Codex error: {"type":"error","error":{"type":"server_error"}}',
+          isError: true,
+        },
+      ],
+      meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+    });
+
+    const result = await runCronIsolatedAgentTurn({
+      ...makeParams(),
+      job: makeAnnounceMessageToolJob({
+        id: "fatal-error-payload",
+        name: "Fatal Error Payload",
+      }),
+    });
+
+    expect(result.status).toBe("error");
+    expect(result.error).toBe("cron isolated run returned an error payload");
+    expect(result.delivered).toBe(false);
+    expect(result.deliveryAttempted).toBe(false);
+    expect(dispatchCronDeliveryMock).not.toHaveBeenCalled();
+    expectDeliveryFields(result.delivery, {
+      intended: { channel: "messagechat", to: "123", source: "explicit" },
+      resolved: { ok: true, channel: "messagechat", to: "123", source: "explicit" },
+      fallbackUsed: false,
+      delivered: false,
+    });
+  });
+
   it("skips cron fallback delivery when the message tool already sent to the same target", async () => {
     await expectCronFallbackSkippedForMessageToolDelivery({
       sentTargets: [{ tool: "message", provider: "messagechat", to: "123" }],

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -779,16 +779,15 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
       payloads: [{ text: "provider failed", isError: true }],
       meta: { agentMeta: { usage: { input: 10, output: 20 } } },
     });
+    const deleteAfterRunJob = makeAnnounceMessageToolJob({
+      id: "fatal-delete-after-run",
+      name: "Fatal Delete After Run",
+    }) as unknown as Record<string, unknown>;
+    deleteAfterRunJob.deleteAfterRun = true;
 
     await runCronIsolatedAgentTurn({
       ...makeParams(),
-      job: {
-        ...makeAnnounceMessageToolJob({
-          id: "fatal-delete-after-run",
-          name: "Fatal Delete After Run",
-        }),
-        deleteAfterRun: true,
-      } as never,
+      job: deleteAfterRunJob as never,
     });
 
     expect(dispatchCronDeliveryMock).not.toHaveBeenCalled();

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -477,6 +477,7 @@ function resetRunOutcomeMocks(): void {
         errorPayloadMessage !== undefined ||
         failureMessage !== undefined ||
         runLevelErrorMessage !== undefined;
+      const hasFatalStructuredErrorPayload = errorPayloadMessage !== undefined;
       const deliveryPayload =
         errorPayloadMessage || failureMessage || runLevelErrorMessage
           ? { text: errorPayloadMessage ?? failureMessage ?? runLevelErrorMessage, isError: true }
@@ -493,8 +494,8 @@ function resetRunOutcomeMocks(): void {
             : [],
         deliveryPayloadHasStructuredContent: false,
         hasFatalErrorPayload,
-        embeddedRunError:
-          errorPayloadMessage ?? failureMessage ?? runLevelErrorMessage ?? undefined,
+        hasFatalStructuredErrorPayload,
+        embeddedRunError: errorPayloadMessage ?? failureMessage ?? runLevelErrorMessage ?? undefined,
       };
     },
   );

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -65,6 +65,7 @@ export const resolveCronPayloadOutcomeMock = createMock();
 export const resolveCronDeliveryPlanMock = createMock();
 export const resolveDeliveryTargetMock = createMock();
 export const dispatchCronDeliveryMock = createMock();
+export const cleanupDirectCronSessionMock = createMock();
 export const preflightCronModelProviderMock = createMock();
 export const isHeartbeatOnlyResponseMock = createMock();
 export const resolveHeartbeatAckMaxCharsMock = createMock();
@@ -241,6 +242,7 @@ vi.mock("./run-delivery.runtime.js", async () => {
   );
   return {
     ...actual,
+    cleanupDirectCronSession: cleanupDirectCronSessionMock,
     resolveDeliveryTarget: resolveDeliveryTargetMock,
     dispatchCronDelivery: dispatchCronDeliveryMock,
   };
@@ -495,7 +497,8 @@ function resetRunOutcomeMocks(): void {
         deliveryPayloadHasStructuredContent: false,
         hasFatalErrorPayload,
         hasFatalStructuredErrorPayload,
-        embeddedRunError: errorPayloadMessage ?? failureMessage ?? runLevelErrorMessage ?? undefined,
+        embeddedRunError:
+          errorPayloadMessage ?? failureMessage ?? runLevelErrorMessage ?? undefined,
       };
     },
   );
@@ -544,6 +547,8 @@ function resetRunOutcomeMocks(): void {
       deliveryPayloads,
     }),
   );
+  cleanupDirectCronSessionMock.mockReset();
+  cleanupDirectCronSessionMock.mockResolvedValue(undefined);
   preflightCronModelProviderMock.mockReset();
   preflightCronModelProviderMock.mockResolvedValue({ status: "available" });
   isHeartbeatOnlyResponseMock.mockReset();

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -949,6 +949,7 @@ async function finalizeCronRun(params: {
     deliveryPayloads,
     deliveryPayloadHasStructuredContent,
     hasFatalErrorPayload,
+    hasFatalStructuredErrorPayload,
     embeddedRunError,
     pendingPresentationWarningError,
   } = resolveCronPayloadOutcome({
@@ -1000,11 +1001,27 @@ async function finalizeCronRun(params: {
     prepared.deliveryRequested &&
     !hasFatalErrorPayload &&
     isHeartbeatOnlyResponse(deliveryPayloads, resolveHeartbeatAckMaxChars(prepared.agentCfg));
-  const { dispatchCronDelivery, resolveCronDeliveryBestEffort } = await loadCronDeliveryRuntime();
   const sourceDeliveryOutcome = resolveSourceDeliveryOutcome(prepared.sourceDelivery, {
     didSendViaMessageTool: finalRunResult.didSendViaMessagingTool,
     messageToolSentTargets: finalRunResult.messagingToolSentTargets,
   });
+  if (hasFatalStructuredErrorPayload && prepared.deliveryRequested) {
+    // Structured run error payloads belong in cron state and failure alerts,
+    // not the normal completion announce path where provider JSON can leak.
+    const deliveryTrace = buildCronDeliveryTrace({
+      deliveryPlan: prepared.deliveryPlan,
+      resolvedDelivery: prepared.resolvedDelivery,
+      sourceDeliveryOutcome,
+      fallbackUsed: false,
+      delivered: sourceDeliveryOutcome.verifiedMessageToolDelivery,
+    });
+    return resolveRunOutcome({
+      delivered: sourceDeliveryOutcome.verifiedMessageToolDelivery,
+      deliveryAttempted: sourceDeliveryOutcome.verifiedMessageToolDelivery,
+      delivery: deliveryTrace,
+    });
+  }
+  const { dispatchCronDelivery, resolveCronDeliveryBestEffort } = await loadCronDeliveryRuntime();
   const deliveryResult = await dispatchCronDelivery({
     cfg: prepared.input.cfg,
     cfgWithAgentDefaults: prepared.cfgWithAgentDefaults,

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1008,6 +1008,13 @@ async function finalizeCronRun(params: {
   if (hasFatalStructuredErrorPayload && prepared.deliveryRequested) {
     // Structured run error payloads belong in cron state and failure alerts,
     // not the normal completion announce path where provider JSON can leak.
+    const { cleanupDirectCronSession } = await loadCronDeliveryRuntime();
+    await cleanupDirectCronSession({
+      job: prepared.input.job,
+      agentSessionKey: prepared.agentSessionKey,
+      sessionId: prepared.currentRunSessionId(),
+      retireReason: "cron-delete-after-run-fatal-error",
+    });
     const deliveryTrace = buildCronDeliveryTrace({
       deliveryPlan: prepared.deliveryPlan,
       resolvedDelivery: prepared.resolvedDelivery,


### PR DESCRIPTION
Fixes #42243.

## Summary
- short-circuit normal cron completion delivery only when an isolated run resolves to a fatal structured `isError` payload
- keep controlled fatal failure signals on the existing delivery path, preserving existing cron behavior
- keep the cron run marked as error with diagnostics and delivery trace state, but avoid direct announce fallback with provider error JSON
- rebase the PR on current `origin/main` so the branch no longer depends on the old base

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: A cron isolated-agent run with `delivery.mode=announce` and a fatal structured `isError` payload should not send provider error JSON to the configured channel as a normal cron completion message. Controlled synthesized fatal failure signals should still use the existing delivery path.
- Real environment tested: Local OpenClaw checkout on macOS rebased on current `origin/main` at commit `2e6ca9f703`, using the repo cron test runner against the actual isolated-agent delivery policy path.
- Exact steps or command run after this patch: `node scripts/test-projects.mjs src/cron/isolated-agent/run.message-tool-policy.test.ts src/cron/isolated-agent/run.interim-retry.test.ts` and `git diff --check`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied terminal output from the local checkout:

```text
$ node scripts/test-projects.mjs src/cron/isolated-agent/run.message-tool-policy.test.ts src/cron/isolated-agent/run.interim-retry.test.ts
Test Files  2 passed (2)
Tests  37 passed (37)
[test] passed 1 Vitest shard in 17.90s

$ git diff --check
(no output)
```

- Observed result after fix: The new fatal structured error payload path skips `dispatchCronDelivery`, while the existing synthesized fatal failure signal case still dispatches through the controlled delivery path.
- What was not tested: No additional gaps in the changed pre-transport cron delivery decision point; external channel credentials are outside this branch.
- Before evidence (optional but encouraged): Before the patch, fatal structured `isError` payloads could continue into normal announce completion delivery and expose provider error JSON.

## Testing
- node scripts/test-projects.mjs src/cron/isolated-agent/run.message-tool-policy.test.ts src/cron/isolated-agent/run.interim-retry.test.ts
- git diff --check
