### PR TITLE
fix(ui): render session-scoped tool events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/subagents: keep collect-mode announce queues batching unresolved-origin items with compatible same-route messages and resume collection after a true cross-channel drain when a later compatible batch remains. Fixes #83577.
+- Control UI: render live tool progress from session-scoped `session.tool` Gateway events so externally started runs show their tool cards in the active session. (#83734) Thanks @TurboTheTurtle.
 - Browser: enforce current-tab URL allowlist checks for `/act` evaluate/batch actions and `/highlight` routes while leaving tab-management actions unblocked. (#78523)
 - CI: require real-behavior-proof verdict markers to come from the ClawSweeper GitHub App before accepting exact-head proof. (#83692)
 - Models: show the effective OpenAI/Codex auth profile in `/models` provider headers instead of falling back to the OpenAI env-key label. (#83697) Thanks @yu-xin-c.

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -936,6 +936,39 @@ describe("connectGateway", () => {
     expect(loadChatHistoryMock).not.toHaveBeenCalled();
   });
 
+  it("renders session-scoped tool events for externally started runs", () => {
+    const { host, client } = connectHostGateway();
+
+    client.emitEvent({
+      event: "session.tool",
+      payload: {
+        runId: "external-run-1",
+        seq: 1,
+        stream: "tool",
+        ts: 123,
+        sessionKey: "main",
+        data: {
+          toolCallId: "session-tool-1",
+          name: "exec",
+          phase: "start",
+          args: { command: "pwd" },
+        },
+      },
+    });
+
+    expect(host.toolStreamOrder).toStrictEqual(["session-tool-1"]);
+    const entry = host.toolStreamById.get("session-tool-1") as
+      | { args?: unknown; name?: string; runId?: string; sessionKey?: string }
+      | undefined;
+    expect(entry).toMatchObject({
+      args: { command: "pwd" },
+      name: "exec",
+      runId: "external-run-1",
+      sessionKey: "main",
+    });
+    expect(loadChatHistoryMock).not.toHaveBeenCalled();
+  });
+
   it("stores BTW side results for the active session", () => {
     const { host, client } = connectHostGateway();
 

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -860,7 +860,7 @@ function handleGatewayEventUnsafe(host: GatewayHost, evt: GatewayEventFrame) {
     host.eventLog = host.eventLogBuffer;
   }
 
-  if (evt.event === "agent") {
+  if (evt.event === "agent" || evt.event === "session.tool") {
     if (host.onboarding) {
       return;
     }


### PR DESCRIPTION
Fixes #83624.

## Summary

- Route `session.tool` gateway frames through the existing UI tool-stream handler.
- Keep the existing session-key filtering in `handleAgentEvent`, so unrelated sessions are still ignored.
- Add a regression proving an externally started session run can render a live tool card from a `session.tool` frame without forcing a chat history reload.

## Real Behavior Proof

Behavior or issue addressed: Control UI receives a gateway `session.tool` event for an externally started session run.

Real environment tested: Local OpenClaw checkout using production `handleGatewayEvent` and `app-tool-stream` modules via `node_modules/.bin/tsx`; no Vitest, mocks, snapshots, lint, or typecheck path.

Exact steps or command run after this patch:

1. Created a Control UI host for active session `main`.
2. Sent a gateway event frame with `event=session.tool` and `stream=tool`.
3. Read the production tool stream state after `handleGatewayEvent` processed the frame.

Evidence after fix: copied console output from `node_modules/.bin/tsx /private/tmp/prove-83734-session-tool.mts`

```json
{
  "toolStreamOrder": ["session-tool-proof"],
  "toolEntry": {
    "toolCallId": "session-tool-proof",
    "runId": "external-run-proof",
    "sessionKey": "main",
    "name": "exec",
    "args": { "command": "pwd" },
    "message": {
      "role": "assistant",
      "toolCallId": "session-tool-proof",
      "runId": "external-run-proof",
      "content": [
        {
          "type": "toolcall",
          "name": "exec",
          "arguments": { "command": "pwd" }
        }
      ],
      "timestamp": 123
    }
  }
}
```

Observed result after fix: `session.tool` populated `toolStreamById`/`toolStreamOrder` for the active session without a history reload.

What was not tested: I did not open a browser DOM renderer; this isolates the event routing/state path that feeds the existing tool-card UI.

## Validation

- `node scripts/run-vitest.mjs ui/src/ui/app-gateway.node.test.ts` - 50 passed
- `node scripts/run-vitest.mjs ui/src/ui/app-tool-stream.node.test.ts ui/src/ui/app-gateway.node.test.ts ui/src/ui/app-gateway.sessions.node.test.ts` - 81 passed
- `node scripts/run-vitest.mjs src/gateway/server-chat.agent-events.test.ts src/gateway/server.chat.gateway-server-chat.test.ts` - 92 passed
- `git diff --check`

If this PR is squash-merged or reworked, please preserve author attribution or include:

`Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>`
