### PR TITLE
fix(ci): preserve Barnacle proof labels

### DIFF
--- a/scripts/github/barnacle-auto-response.mjs
+++ b/scripts/github/barnacle-auto-response.mjs
@@ -798,6 +798,9 @@ function shouldRemoveProofSufficientLabel(context, proofEvaluation, hasExactHead
   if (hasExactHeadClawSweeperProof) {
     return false;
   }
+  if (proofEvaluation.status === "override") {
+    return false;
+  }
   if (proofEvaluation.status !== "passed") {
     return true;
   }

--- a/scripts/github/barnacle-auto-response.mjs
+++ b/scripts/github/barnacle-auto-response.mjs
@@ -801,10 +801,13 @@ function shouldRemoveProofSufficientLabel(context, proofEvaluation, hasExactHead
   if (proofEvaluation.status === "override") {
     return false;
   }
+  if (!["edited", "synchronize"].includes(context.payload.action)) {
+    return false;
+  }
   if (proofEvaluation.status !== "passed") {
     return true;
   }
-  return ["edited", "synchronize"].includes(context.payload.action);
+  return true;
 }
 
 async function applyPullRequestCandidateLabels(github, context, core, pullRequest, labelSet) {

--- a/test/scripts/barnacle-auto-response.test.ts
+++ b/test/scripts/barnacle-auto-response.test.ts
@@ -872,6 +872,24 @@ describe("barnacle-auto-response", () => {
     expect(calls.removeLabel).toEqual([]);
   });
 
+  it("preserves sufficient proof on unrelated label events even without body proof", async () => {
+    const { calls, github } = barnacleGithub([file("src/gateway/server.ts")]);
+
+    await runBarnacleAutoResponse({
+      github,
+      context: barnacleContext({}, [PROOF_SUFFICIENT_LABEL], {
+        action: "labeled",
+        label: { name: "status: ready for maintainer look" },
+        sender: { login: "openclaw-clawsweeper[bot]", type: "Bot" },
+      }),
+      core: {
+        info: () => undefined,
+      },
+    });
+
+    expect(calls.removeLabel).toEqual([]);
+  });
+
   it("does not let Barnacle veto ClawSweeper's sufficient proof label add", async () => {
     const { calls, github } = barnacleGithub([file("src/gateway/server.ts")]);
 

--- a/test/scripts/barnacle-auto-response.test.ts
+++ b/test/scripts/barnacle-auto-response.test.ts
@@ -6,6 +6,7 @@ import {
   runBarnacleAutoResponse,
 } from "../../scripts/github/barnacle-auto-response.mjs";
 import {
+  PROOF_OVERRIDE_LABEL,
   PROOF_SUFFICIENT_LABEL,
   PROOF_SUPPLIED_LABEL,
 } from "../../scripts/github/real-behavior-proof-policy.mjs";
@@ -712,7 +713,7 @@ describe("barnacle-auto-response", () => {
     expect(calls.update).toStrictEqual([]);
   });
 
-  it("removes stale proof labels when override is present", async () => {
+  it("removes stale structural proof labels but preserves sufficient proof when override is present", async () => {
     const { calls, github } = barnacleGithub([file("src/gateway/server.ts")]);
 
     await runBarnacleAutoResponse({
@@ -722,7 +723,7 @@ describe("barnacle-auto-response", () => {
         candidateLabels.mockOnlyProof,
         PROOF_SUPPLIED_LABEL,
         PROOF_SUFFICIENT_LABEL,
-        "proof: override",
+        PROOF_OVERRIDE_LABEL,
       ]),
       core: {
         info: () => undefined,
@@ -733,9 +734,36 @@ describe("barnacle-auto-response", () => {
       expectedRemoveLabel(123, candidateLabels.needsRealBehaviorProof),
       expectedRemoveLabel(123, candidateLabels.mockOnlyProof),
       expectedRemoveLabel(123, PROOF_SUPPLIED_LABEL),
-      expectedRemoveLabel(123, PROOF_SUFFICIENT_LABEL),
     ]);
     expect(calls.update).toStrictEqual([]);
+  });
+
+  it("preserves manually applied sufficient proof label when override is added", async () => {
+    const { calls, github } = barnacleGithub([file("src/gateway/server.ts")]);
+
+    await runBarnacleAutoResponse({
+      github,
+      context: barnacleContext(
+        {
+          body: realBehaviorProofBody(
+            "![after](https://github.com/user-attachments/assets/gateway-ready)",
+          ),
+        },
+        [PROOF_OVERRIDE_LABEL, PROOF_SUFFICIENT_LABEL],
+        {
+          action: "labeled",
+          label: { name: PROOF_OVERRIDE_LABEL },
+          sender: { login: "maintainer", type: "User" },
+        },
+      ),
+      core: {
+        info: () => undefined,
+      },
+    });
+
+    expect(calls.removeLabel).toEqual([]);
+    expect(calls.addLabels).toEqual([]);
+    expect(calls.update).toEqual([]);
   });
 
   it("removes stale negative proof labels and adds supplied when proof is present", async () => {


### PR DESCRIPTION
## Summary

- Preserve proof: sufficient when proof: override is present.
- Keep proof: sufficient during unrelated label churn so Barnacle does not revoke ClawSweeper/manual sufficiency on status-label updates.
- Add focused Barnacle regressions for override coexistence and unrelated label events.

## Verification

- node scripts/run-vitest.mjs test/scripts/barnacle-auto-response.test.ts