### PR TITLE
Gate QQBot channel API tool by sender ownership [AI]

### DIFF
--- a/extensions/qqbot/src/bridge/tools/channel.test.ts
+++ b/extensions/qqbot/src/bridge/tools/channel.test.ts
@@ -1,0 +1,95 @@
+import type {
+  AnyAgentTool,
+  OpenClawPluginApi,
+  OpenClawPluginToolContext,
+} from "openclaw/plugin-sdk/core";
+import { describe, expect, it, vi } from "vitest";
+import { ensurePlatformAdapter } from "../bootstrap.js";
+import { createChannelTool, registerChannelTool } from "./channel.js";
+
+const account = {
+  appId: "app-1",
+  clientSecret: "secret-1",
+};
+
+describe("bridge/tools/channel", () => {
+  it("marks qqbot_channel_api as owner-only", () => {
+    const tool = createChannelTool(account);
+    expect(tool.ownerOnly).toBe(true);
+  });
+
+  it("does not request an access token when sender ownership is missing", async () => {
+    const getAccessToken = vi.fn(async () => "token-1");
+    const executeChannelApi = vi.fn(async () => ({
+      content: [{ type: "text" as const, text: "{}" }],
+      details: { ok: true },
+    }));
+    const tool = createChannelTool(account, {}, { getAccessToken, executeChannelApi });
+
+    const result = await tool.execute("tool-call-1", {
+      method: "GET",
+      path: "/users/@me/guilds",
+    });
+
+    expect(getAccessToken).not.toHaveBeenCalled();
+    expect(executeChannelApi).not.toHaveBeenCalled();
+    expect(result.details).toEqual({
+      error: "QQBot channel API requires an owner-authorized sender.",
+    });
+  });
+
+  it("executes channel API calls for owner-authorized senders", async () => {
+    const getAccessToken = vi.fn(async () => "token-1");
+    const executeChannelApi = vi.fn(async () => ({
+      content: [{ type: "text" as const, text: '{"success":true}' }],
+      details: { success: true },
+    }));
+    const tool = createChannelTool(
+      account,
+      { senderIsOwner: true },
+      { getAccessToken, executeChannelApi },
+    );
+
+    const params = { method: "GET", path: "/users/@me/guilds" };
+    const result = await tool.execute("tool-call-1", params);
+
+    expect(getAccessToken).toHaveBeenCalledWith("app-1", "secret-1");
+    expect(executeChannelApi).toHaveBeenCalledWith(params, { accessToken: "token-1" });
+    expect(result.details).toEqual({ success: true });
+  });
+
+  it("registers a context-aware channel API tool factory", async () => {
+    const registerTool = vi.fn();
+    const api = {
+      config: {
+        channels: {
+          qqbot: {
+            appId: "app-1",
+            clientSecret: "secret-1",
+          },
+        },
+      },
+      registerTool,
+    } as unknown as OpenClawPluginApi;
+
+    ensurePlatformAdapter();
+    registerChannelTool(api);
+
+    expect(registerTool).toHaveBeenCalledWith(expect.any(Function), {
+      name: "qqbot_channel_api",
+    });
+    const factory = registerTool.mock.calls[0]?.[0] as (
+      ctx: OpenClawPluginToolContext,
+    ) => AnyAgentTool;
+    const tool = factory({});
+    const result = await tool.execute("tool-call-1", {
+      method: "GET",
+      path: "/users/@me/guilds",
+    });
+
+    expect(tool.ownerOnly).toBe(true);
+    expect(result.details).toEqual({
+      error: "QQBot channel API requires an owner-authorized sender.",
+    });
+  });
+});

--- a/extensions/qqbot/src/bridge/tools/channel.ts
+++ b/extensions/qqbot/src/bridge/tools/channel.ts
@@ -1,16 +1,80 @@
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
+import type {
+  AnyAgentTool,
+  OpenClawPluginApi,
+  OpenClawPluginToolContext,
+} from "openclaw/plugin-sdk/core";
 import { getAccessToken } from "../../engine/messaging/sender.js";
 import { ChannelApiSchema, executeChannelApi } from "../../engine/tools/channel-api.js";
 import type { ChannelApiParams } from "../../engine/tools/channel-api.js";
 import { listQQBotAccountIds, resolveQQBotAccount } from "../config.js";
 
+type ChannelToolAccount = {
+  appId: string;
+  clientSecret: string;
+};
+
+type ChannelToolDeps = {
+  getAccessToken: typeof getAccessToken;
+  executeChannelApi: typeof executeChannelApi;
+};
+
+const defaultDeps: ChannelToolDeps = {
+  getAccessToken,
+  executeChannelApi,
+};
+
 /**
- * Register the QQ channel API proxy tool.
+ * Create the QQ channel API proxy tool.
  *
  * The tool acts as an authenticated HTTP proxy for the QQ Open Platform
  * channel APIs. Agents learn endpoint details from the skill docs and
  * send requests through this proxy.
  */
+export function createChannelTool(
+  account: ChannelToolAccount,
+  toolContext: OpenClawPluginToolContext = {},
+  deps: ChannelToolDeps = defaultDeps,
+): AnyAgentTool {
+  return {
+    name: "qqbot_channel_api",
+    label: "QQBot Channel API",
+    ownerOnly: true,
+    description:
+      "Authenticated HTTP proxy for QQ Open Platform channel APIs. " +
+      "Common endpoints: " +
+      "list guilds GET /users/@me/guilds | " +
+      "list channels GET /guilds/{guild_id}/channels | " +
+      "get channel GET /channels/{channel_id} | " +
+      "create channel POST /guilds/{guild_id}/channels | " +
+      "list members GET /guilds/{guild_id}/members?after=0&limit=100 | " +
+      "get member GET /guilds/{guild_id}/members/{user_id} | " +
+      "list threads GET /channels/{channel_id}/threads | " +
+      "create thread PUT /channels/{channel_id}/threads | " +
+      "create announce POST /guilds/{guild_id}/announces | " +
+      "create schedule POST /channels/{channel_id}/schedules. " +
+      "See the qqbot-channel skill for full endpoint details.",
+    parameters: ChannelApiSchema,
+    async execute(_toolCallId, params) {
+      if (toolContext.senderIsOwner !== true) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                error: "QQBot channel API requires an owner-authorized sender.",
+              }),
+            },
+          ],
+          details: { error: "QQBot channel API requires an owner-authorized sender." },
+        };
+      }
+      const accessToken = await deps.getAccessToken(account.appId, account.clientSecret);
+      return deps.executeChannelApi(params as ChannelApiParams, { accessToken });
+    },
+  };
+}
+
+/** Register the QQ channel API proxy tool. */
 export function registerChannelTool(api: OpenClawPluginApi): void {
   const cfg = api.config;
   if (!cfg) {
@@ -29,30 +93,5 @@ export function registerChannelTool(api: OpenClawPluginApi): void {
     return;
   }
 
-  api.registerTool(
-    {
-      name: "qqbot_channel_api",
-      label: "QQBot Channel API",
-      description:
-        "Authenticated HTTP proxy for QQ Open Platform channel APIs. " +
-        "Common endpoints: " +
-        "list guilds GET /users/@me/guilds | " +
-        "list channels GET /guilds/{guild_id}/channels | " +
-        "get channel GET /channels/{channel_id} | " +
-        "create channel POST /guilds/{guild_id}/channels | " +
-        "list members GET /guilds/{guild_id}/members?after=0&limit=100 | " +
-        "get member GET /guilds/{guild_id}/members/{user_id} | " +
-        "list threads GET /channels/{channel_id}/threads | " +
-        "create thread PUT /channels/{channel_id}/threads | " +
-        "create announce POST /guilds/{guild_id}/announces | " +
-        "create schedule POST /channels/{channel_id}/schedules. " +
-        "See the qqbot-channel skill for full endpoint details.",
-      parameters: ChannelApiSchema,
-      async execute(_toolCallId, params) {
-        const accessToken = await getAccessToken(account.appId, account.clientSecret);
-        return executeChannelApi(params as ChannelApiParams, { accessToken });
-      },
-    },
-    { name: "qqbot_channel_api" },
-  );
+  api.registerTool((ctx) => createChannelTool(account, ctx), { name: "qqbot_channel_api" });
 }


### PR DESCRIPTION
## Summary

- Problem: `qqbot_channel_api` was registered without owner-only metadata and had no runtime sender-owner guard.
- Solution: Create the QQBot channel API tool from per-turn tool context, mark it owner-only, and reject non-owner sender contexts before requesting an access token.
- What changed: Added `createChannelTool`, updated registration to a context-aware factory, and added focused bridge tool tests.
- What did NOT change (scope boundary): QQ Open Platform endpoint handling, request validation, and owner-authorized execution behavior remain unchanged.
- AI-assisted: Yes.

## Change Type (select all)

- [x] Bug fix
- [x] Refactor required for the fix
- [ ] Feature
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

N/A

## Motivation

QQBot bridge tools that can perform owner-scoped operations should use both tool metadata and runtime sender context. This aligns `qqbot_channel_api` with the existing `qqbot_remind` pattern and keeps token-backed API proxy calls limited to owner-authorized sender contexts.

## Real behavior proof (required for external PRs)

- Behavior addressed: `qqbot_channel_api` now requires owner-authorized sender context before requesting a QQBot access token or proxying a channel API request.
- Real environment tested: Local OpenClaw checkout in a Codex worktree; live QQBot service was not exercised.
- Exact steps or command run after this patch: `node scripts/run-vitest.mjs extensions/qqbot/src/bridge/tools/channel.test.ts`
- Evidence after fix: `Test Files 1 passed (1)` and `Tests 4 passed (4)`.
- Observed result after fix: The focused test verifies owner-only metadata, denial before token lookup for missing sender ownership, owner-authorized execution, and context-aware registration.
- What was not tested: Live QQBot gateway/API behavior and broad changed-check lanes.

## Root Cause (if applicable)

- Root cause: The channel API tool was registered as a static descriptor, so it did not receive per-turn tool context, and it did not declare owner-only metadata.
- Missing detection / guardrail: No focused regression test covered the QQBot channel API tool descriptor or direct execute behavior for non-owner sender contexts.
- Contributing context (if known): The sibling reminder tool already had the expected metadata and runtime guard pattern.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/qqbot/src/bridge/tools/channel.test.ts`
- Scenario the test should lock in: The tool is owner-only, skips access-token lookup without owner sender context, executes for owner-authorized context, and registers through a context-aware factory.
- Why this is the smallest reliable guardrail: It exercises the bridge boundary where tool metadata and trusted sender context are attached.
- Existing test that already covers this (if any): `extensions/qqbot/src/bridge/tools/remind.test.ts` covers the sibling reminder tool only.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Non-owner sender contexts no longer receive successful `qqbot_channel_api` execution. Owner-authorized usage and request behavior are unchanged.

## Diagram (if applicable)

```text
Before:
[QQBot tool registration] -> [static tool] -> [access token lookup]

After:
[QQBot tool registration] -> [context-aware tool] -> [owner sender check] -> [access token lookup]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation: The tool now requires owner-authorized sender context before requesting a QQBot token or proxying QQ channel API calls. This narrows token-backed tool execution without adding endpoints, permissions, or network calls.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node test wrapper in local checkout
- Model/provider: N/A
- Integration/channel (if any): QQBot plugin bridge tool
- Relevant config (redacted): Test config with placeholder app id and client secret values

### Steps

1. Run `node scripts/run-vitest.mjs extensions/qqbot/src/bridge/tools/channel.test.ts`.
2. Confirm the test covers non-owner denial before token lookup.
3. Confirm the test covers owner-authorized execution and context-aware registration.

### Expected

The focused QQBot channel tool tests pass.

### Actual

The focused QQBot channel tool tests passed: `Test Files 1 passed (1)`, `Tests 4 passed (4)`.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: owner-only metadata, non-owner denial before token lookup, owner-authorized execution, and context-aware factory registration.
- Edge cases checked: missing sender ownership and configured QQBot account registration.
- What you did **not** verify: Live QQBot API calls, gateway end-to-end behavior, and broad check lanes.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes for owner-authorized usage; non-owner execution is intentionally denied.
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: A workflow that relied on non-owner senders invoking `qqbot_channel_api` will now receive a structured denial.
  - Mitigation: This follows the existing owner-authorized QQBot tool pattern, and owner-authorized execution remains covered by tests.
