### PR TITLE
clickclack: enforce inbound sender allowlist [AI]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 - Gateway: make the CPU scenario checker fail when completed Gateway runs report hot CPU observations instead of only writing them to artifacts.
 - CLI: bound startup-memory probes so a hung startup command fails with timeout guidance instead of hanging the memory gate indefinitely.
 - File transfer: wrap fetched file text and metadata as external content so untrusted contents cannot inject prompt instructions or spoof external-content markers.
+- ClickClack: apply configured `allowFrom` sender allowlists before inbound agent dispatch so blocked senders cannot trigger model requests or command-authorized turns. Thanks @mmaps.
 
 ## 2026.5.26
 

--- a/extensions/clickclack/src/access.ts
+++ b/extensions/clickclack/src/access.ts
@@ -1,0 +1,73 @@
+import {
+  resolveStableChannelMessageIngress,
+  type StableChannelIngressIdentityParams,
+} from "openclaw/plugin-sdk/channel-ingress-runtime";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { getClickClackRuntime } from "./runtime.js";
+import type { ClickClackMessage, CoreConfig, ResolvedClickClackAccount } from "./types.js";
+
+const CHANNEL_ID = "clickclack" as const;
+
+function normalizeClickClackUserId(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  return trimmed.replace(/^(clickclack|cc):/i, "").trim() || null;
+}
+
+const clickClackIngressIdentity = {
+  key: "user-id",
+  normalizeEntry: normalizeClickClackUserId,
+  normalizeSubject: normalizeClickClackUserId,
+  isWildcardEntry: (entry) => normalizeClickClackUserId(entry) === "*",
+  entryIdPrefix: "clickclack-user",
+} satisfies StableChannelIngressIdentityParams;
+
+export type ClickClackInboundAccess = {
+  shouldDispatch: boolean;
+  commandAuthorized: boolean;
+};
+
+export async function resolveClickClackInboundAccess(params: {
+  account: ResolvedClickClackAccount;
+  config: CoreConfig;
+  message: ClickClackMessage;
+}): Promise<ClickClackInboundAccess> {
+  const runtime = getClickClackRuntime();
+  const isDirect = Boolean(params.message.direct_conversation_id);
+  const cfg = params.config as OpenClawConfig;
+  const shouldCheckCommand = runtime.channel.commands.shouldComputeCommandAuthorized(
+    params.message.body,
+    cfg,
+  );
+  const resolved = await resolveStableChannelMessageIngress({
+    channelId: CHANNEL_ID,
+    accountId: params.account.accountId,
+    identity: clickClackIngressIdentity,
+    cfg,
+    subject: { stableId: params.message.author_id },
+    conversation: {
+      kind: isDirect ? "direct" : "group",
+      id: isDirect
+        ? (params.message.direct_conversation_id ?? params.message.author_id)
+        : (params.message.channel_id ?? params.message.thread_root_id),
+    },
+    allowFrom: params.account.allowFrom,
+    dmPolicy: "allowlist",
+    groupPolicy: "allowlist",
+    command: shouldCheckCommand
+      ? {
+          cfg,
+          modeWhenAccessGroupsOff: "configured",
+        }
+      : false,
+  });
+
+  return {
+    shouldDispatch: resolved.ingress.admission === "dispatch",
+    commandAuthorized: resolved.commandAccess.requested
+      ? resolved.commandAccess.authorized
+      : resolved.senderAccess.allowed,
+  };
+}

--- a/extensions/clickclack/src/access.ts
+++ b/extensions/clickclack/src/access.ts
@@ -13,7 +13,9 @@ function normalizeClickClackUserId(value: string): string | null {
   if (!trimmed) {
     return null;
   }
-  return trimmed.replace(/^(clickclack|cc):/i, "").trim() || null;
+  const withoutProvider = trimmed.replace(/^(clickclack|cc):/i, "").trim();
+  const directTarget = withoutProvider.match(/^dm:(.+)$/i);
+  return directTarget?.[1]?.trim() || withoutProvider || null;
 }
 
 const clickClackIngressIdentity = {

--- a/extensions/clickclack/src/gateway.test.ts
+++ b/extensions/clickclack/src/gateway.test.ts
@@ -19,7 +19,12 @@ const mocks = vi.hoisted(() => ({
     thread: vi.fn(),
   },
   handleClickClackInbound: vi.fn(),
+  resolveClickClackInboundAccess: vi.fn(),
   resolveWorkspaceId: vi.fn(),
+}));
+
+vi.mock("./access.js", () => ({
+  resolveClickClackInboundAccess: mocks.resolveClickClackInboundAccess,
 }));
 
 vi.mock("./http-client.js", () => ({
@@ -76,6 +81,10 @@ describe("ClickClack gateway", () => {
       created_at: "2026-01-01T00:00:00.000Z",
     });
     mocks.client.events.mockResolvedValue([]);
+    mocks.resolveClickClackInboundAccess.mockResolvedValue({
+      shouldDispatch: true,
+      commandAuthorized: true,
+    });
     mocks.resolveWorkspaceId.mockResolvedValue("workspace-1");
     mocks.client.channelMessages.mockResolvedValue([
       {
@@ -135,8 +144,47 @@ describe("ClickClack gateway", () => {
     );
 
     await vi.waitFor(() => expect(mocks.handleClickClackInbound).toHaveBeenCalledTimes(1));
+    expect(mocks.handleClickClackInbound.mock.calls[0]?.[0].access).toEqual({
+      shouldDispatch: true,
+      commandAuthorized: true,
+    });
     abort.abort();
     await run;
     expect(runError).toBeUndefined();
+  });
+
+  it("drops messages denied by ClickClack sender access before inbound handling", async () => {
+    const socket = new FakeSocket();
+    mocks.client.websocket.mockReturnValue(socket);
+    mocks.resolveClickClackInboundAccess.mockResolvedValue({
+      shouldDispatch: false,
+      commandAuthorized: false,
+    });
+    const abort = new AbortController();
+    const ctx = createGatewayContext(abort.signal);
+    const run = startClickClackGatewayAccount(ctx);
+
+    await vi.waitFor(() => expect(mocks.client.websocket).toHaveBeenCalledTimes(1));
+
+    socket.emit(
+      "message",
+      Buffer.from(
+        JSON.stringify({
+          id: "evt-1",
+          cursor: "cursor-1",
+          type: "message.created",
+          workspace_id: "workspace-1",
+          channel_id: "chan-1",
+          seq: 2,
+          created_at: "2026-01-01T00:00:00.000Z",
+          payload: { message_id: "msg-1", author_id: "human-1" },
+        }),
+      ),
+    );
+
+    await vi.waitFor(() => expect(mocks.resolveClickClackInboundAccess).toHaveBeenCalledTimes(1));
+    expect(mocks.handleClickClackInbound).not.toHaveBeenCalled();
+    abort.abort();
+    await run;
   });
 });

--- a/extensions/clickclack/src/gateway.ts
+++ b/extensions/clickclack/src/gateway.ts
@@ -1,5 +1,6 @@
 import type { ChannelGatewayContext } from "openclaw/plugin-sdk/channel-contract";
 import type { RawData } from "ws";
+import { resolveClickClackInboundAccess } from "./access.js";
 import { resolveClickClackAccount } from "./accounts.js";
 import { createClickClackClient } from "./http-client.js";
 import { handleClickClackInbound } from "./inbound.js";
@@ -93,7 +94,20 @@ async function processEvent(params: {
   if (message.author?.kind === "bot") {
     return;
   }
-  await handleClickClackInbound({ account: params.account, config: params.config, message });
+  const access = await resolveClickClackInboundAccess({
+    account: params.account,
+    config: params.config,
+    message,
+  });
+  if (!access.shouldDispatch) {
+    return;
+  }
+  await handleClickClackInbound({
+    account: params.account,
+    config: params.config,
+    message,
+    access,
+  });
 }
 
 export async function startClickClackGatewayAccount(

--- a/extensions/clickclack/src/inbound.test.ts
+++ b/extensions/clickclack/src/inbound.test.ts
@@ -3,7 +3,7 @@ import type { PluginRuntime } from "openclaw/plugin-sdk/core";
 import { describe, expect, it, vi } from "vitest";
 import { handleClickClackInbound } from "./inbound.js";
 import { setClickClackRuntime } from "./runtime.js";
-import type { CoreConfig, ResolvedClickClackAccount } from "./types.js";
+import type { ClickClackMessage, CoreConfig, ResolvedClickClackAccount } from "./types.js";
 
 const sendClickClackTextMock = vi.hoisted(() => vi.fn());
 
@@ -72,6 +72,59 @@ function createRuntime(): PluginRuntime {
   } as unknown as PluginRuntime);
 }
 
+function createAgentAccount(
+  overrides: Partial<ResolvedClickClackAccount> = {},
+): ResolvedClickClackAccount {
+  const base = {
+    accountId: "default",
+    enabled: true,
+    configured: true,
+    baseUrl: "http://127.0.0.1:8080",
+    token: "ccb_default",
+    workspace: "wsp_1",
+    replyMode: "agent",
+    senderIsOwner: false,
+    toolsAllow: [],
+    defaultTo: "channel:general",
+    allowFrom: ["*"],
+    reconnectMs: 1_500,
+    config: {
+      allowFrom: ["*"],
+    },
+  } satisfies ResolvedClickClackAccount;
+
+  return {
+    ...base,
+    ...overrides,
+    config: {
+      ...base.config,
+      ...overrides.config,
+    },
+  };
+}
+
+function createMessage(overrides: Partial<ClickClackMessage> = {}): ClickClackMessage {
+  return {
+    id: "msg_1",
+    workspace_id: "wsp_1",
+    channel_id: "chn_1",
+    author_id: "usr_owner",
+    thread_root_id: "msg_1",
+    body: "/fast on",
+    body_format: "markdown",
+    created_at: "2026-05-09T12:00:00.000Z",
+    author: {
+      id: "usr_owner",
+      kind: "human",
+      display_name: "Peter",
+      handle: "steipete",
+      avatar_url: "",
+      created_at: "2026-05-09T12:00:00.000Z",
+    },
+    ...overrides,
+  };
+}
+
 describe("handleClickClackInbound", () => {
   it("runs model-mode bot accounts without tools and posts the bot reply", async () => {
     sendClickClackTextMock.mockReset();
@@ -138,5 +191,66 @@ describe("handleClickClackInbound", () => {
     expect(sendRequest?.to).toBe("channel:chn_1");
     expect(sendRequest?.text).toBe("service bot online");
     expect(sendRequest?.replyToId).toBe("msg_1");
+  });
+
+  it("marks agent turns command-authorized for allowlisted senders", async () => {
+    const runtime = createRuntime();
+    vi.mocked(runtime.channel.commands.shouldComputeCommandAuthorized).mockReturnValue(true);
+    setClickClackRuntime(runtime);
+    const cfg = {
+      agents: {
+        defaults: {
+          model: "openai/gpt-5.4-mini",
+        },
+      },
+    } satisfies CoreConfig;
+
+    await handleClickClackInbound({
+      account: createAgentAccount({
+        allowFrom: ["usr_owner"],
+        config: { allowFrom: ["usr_owner"] },
+      }),
+      config: cfg,
+      message: createMessage(),
+    });
+
+    const runPrepared = vi.mocked(runtime.channel.turn.runPrepared);
+    expect(runPrepared).toHaveBeenCalledTimes(1);
+    expect(runPrepared.mock.calls[0]?.[0].ctxPayload.CommandAuthorized).toBe(true);
+  });
+
+  it("does not dispatch agent turns from senders outside allowFrom", async () => {
+    const runtime = createRuntime();
+    vi.mocked(runtime.channel.commands.shouldComputeCommandAuthorized).mockReturnValue(true);
+    setClickClackRuntime(runtime);
+    const cfg = {
+      agents: {
+        defaults: {
+          model: "openai/gpt-5.4-mini",
+        },
+      },
+    } satisfies CoreConfig;
+
+    await handleClickClackInbound({
+      account: createAgentAccount({
+        allowFrom: ["usr_owner"],
+        config: { allowFrom: ["usr_owner"] },
+      }),
+      config: cfg,
+      message: createMessage({
+        author_id: "usr_attacker",
+        author: {
+          id: "usr_attacker",
+          kind: "human",
+          display_name: "Attacker",
+          handle: "attacker",
+          avatar_url: "",
+          created_at: "2026-05-09T12:00:00.000Z",
+        },
+      }),
+    });
+
+    expect(runtime.channel.turn.runPrepared).not.toHaveBeenCalled();
+    expect(runtime.channel.reply.dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
   });
 });

--- a/extensions/clickclack/src/inbound.test.ts
+++ b/extensions/clickclack/src/inbound.test.ts
@@ -83,7 +83,6 @@ function createAgentAccount(
     token: "ccb_default",
     workspace: "wsp_1",
     replyMode: "agent",
-    senderIsOwner: false,
     toolsAllow: [],
     defaultTo: "channel:general",
     allowFrom: ["*"],

--- a/extensions/clickclack/src/inbound.test.ts
+++ b/extensions/clickclack/src/inbound.test.ts
@@ -219,6 +219,36 @@ describe("handleClickClackInbound", () => {
     expect(runPrepared.mock.calls[0]?.[0].ctxPayload.CommandAuthorized).toBe(true);
   });
 
+  it("accepts ClickClack DM target syntax in allowFrom", async () => {
+    const runtime = createRuntime();
+    vi.mocked(runtime.channel.commands.shouldComputeCommandAuthorized).mockReturnValue(true);
+    setClickClackRuntime(runtime);
+    const cfg = {
+      agents: {
+        defaults: {
+          model: "openai/gpt-5.4-mini",
+        },
+      },
+    } satisfies CoreConfig;
+
+    await handleClickClackInbound({
+      account: createAgentAccount({
+        allowFrom: ["dm:usr_owner"],
+        config: { allowFrom: ["dm:usr_owner"] },
+      }),
+      config: cfg,
+      message: createMessage({
+        channel_id: undefined,
+        direct_conversation_id: "dcn_1",
+      }),
+    });
+
+    const runPrepared = vi.mocked(runtime.channel.turn.runPrepared);
+    expect(runPrepared).toHaveBeenCalledTimes(1);
+    expect(runPrepared.mock.calls[0]?.[0].ctxPayload.ChatType).toBe("direct");
+    expect(runPrepared.mock.calls[0]?.[0].ctxPayload.CommandAuthorized).toBe(true);
+  });
+
   it("does not dispatch agent turns from senders outside allowFrom", async () => {
     const runtime = createRuntime();
     vi.mocked(runtime.channel.commands.shouldComputeCommandAuthorized).mockReturnValue(true);

--- a/extensions/clickclack/src/inbound.ts
+++ b/extensions/clickclack/src/inbound.ts
@@ -1,5 +1,6 @@
 import { createChannelMessageReplyPipeline } from "openclaw/plugin-sdk/channel-message";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { resolveClickClackInboundAccess, type ClickClackInboundAccess } from "./access.js";
 import { sendClickClackText } from "./outbound.js";
 import { getClickClackRuntime } from "./runtime.js";
 import { buildClickClackTarget } from "./target.js";
@@ -81,9 +82,20 @@ export async function handleClickClackInbound(params: {
   account: ResolvedClickClackAccount;
   config: CoreConfig;
   message: ClickClackMessage;
+  access?: ClickClackInboundAccess;
 }) {
   const runtime = getClickClackRuntime();
   const message = params.message;
+  const access =
+    params.access ??
+    (await resolveClickClackInboundAccess({
+      account: params.account,
+      config: params.config,
+      message,
+    }));
+  if (!access.shouldDispatch) {
+    return;
+  }
   const isDirect = Boolean(message.direct_conversation_id);
   const target = buildClickClackTarget(
     isDirect
@@ -150,7 +162,7 @@ export async function handleClickClackInbound(params: {
     Timestamp: message.created_at,
     OriginatingChannel: CHANNEL_ID,
     OriginatingTo: target,
-    CommandAuthorized: true,
+    CommandAuthorized: access.commandAuthorized,
   });
   const { onModelSelected, ...replyPipeline } = createChannelMessageReplyPipeline({
     cfg: params.config as OpenClawConfig,


### PR DESCRIPTION
## Summary

- Problem: ClickClack agent-mode inbound messages could reach command handling without applying the configured sender allowlist.
- Solution: Resolve ClickClack sender access before inbound dispatch and use that decision for `CommandAuthorized`.
- What changed: Added a ClickClack access resolver, wired it through gateway and inbound handling, and added focused gateway/inbound regression coverage.
- What did NOT change (scope boundary): No config schema, token handling, outbound delivery, or non-ClickClack channel behavior changed.
- AI-assisted: yes

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- N/A
- [x] This PR fixes a bug or regression

## Motivation

- ClickClack operators can configure `allowFrom` to limit which senders can control an agent. The inbound path should apply that boundary before preparing an agent turn or marking command authorization.

## Real behavior proof (required for external PRs)

- Behavior addressed: ClickClack inbound messages now apply configured sender allowlists before agent dispatch and command authorization.
- Real environment tested: Linux 6.14.0-37-generic x64, Node v22.21.1, built source Gateway launched with `node dist/entry.js gateway --port 45283 --bind loopback --allow-unconfigured`, a local ClickClack-compatible HTTP/WebSocket fixture, and a local OpenAI Responses-compatible mock model endpoint.
- Exact steps or command run after this patch: `env pnpm_config_verify_deps_before_run=false node scripts/tsdown-build.mjs`; `node scripts/runtime-postbuild.mjs`; `node .artifacts/clickclack-allowlist-proof.mjs`; `node scripts/run-vitest.mjs extensions/clickclack/src/inbound.test.ts extensions/clickclack/src/gateway.test.ts --reporter=verbose`.
- Evidence after fix: With `allowFrom: ["usr_allowed"]`, the fixture recorded 1 ClickClack realtime websocket. Sender `usr_allowed` produced `inboundObserved=true`, `modelRequestObserved=true`, and `replyObserved=true`. Sender `usr_denied` produced `inboundObserved=true`, `modelRequestObserved=false`, and `replyObserved=false`. The focused ClickClack Vitest command exited 0.
- Observed result after fix: The allowlisted ClickClack sender reached the model reply path and received a fixture thread reply. The denied sender was present in fixture inbound messages but did not trigger a model request or ClickClack reply, proving it was dropped before dispatch/command authorization.
- What was not tested: A hosted third-party ClickClack deployment with real user accounts, package-install Docker lanes, and full CI were not rerun in this proof step. The runtime proof used a local ClickClack-compatible HTTP/WebSocket fixture against the real built Gateway.
- Before evidence (optional but encouraged): Source inspection on current main showed ClickClack gateway dispatching non-bot messages without sender access resolution and inbound context construction setting `CommandAuthorized: true`.

## Root Cause (if applicable)

- Root cause: The ClickClack inbound context set `CommandAuthorized` to true without first checking the message author against the resolved ClickClack account allowlist.
- Missing detection / guardrail: There was no gateway or inbound regression coverage for allowed versus denied ClickClack senders.
- Contributing context (if known): The ClickClack gateway forwarded human messages directly into agent handling after bot filtering.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/clickclack/src/inbound.test.ts`, `extensions/clickclack/src/gateway.test.ts`
- Scenario the test should lock in: An allowlisted ClickClack sender is command-authorized, while a sender outside `allowFrom` is dropped before inbound handling.
- Why this is the smallest reliable guardrail: It covers the gateway handoff and inbound context construction where the access decision is made.
- Existing test that already covers this (if any): None identified.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

ClickClack `allowFrom` now gates inbound sender dispatch and command authorization. Accounts that keep the default wildcard allowlist remain open.

## Diagram (if applicable)

```text
Before:
ClickClack event -> bot filter -> inbound handler -> CommandAuthorized=true

After:
ClickClack event -> bot filter -> allowlist access decision -> allowed inbound handler -> derived CommandAuthorized
                                           |
                                           +-> denied sender dropped
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: The command surface is narrowed by applying the configured ClickClack sender allowlist before agent dispatch. Regression tests cover allowed and denied sender paths.

## Repro + Verification

### Environment

- OS: Linux 6.14.0-37-generic x64
- Runtime/container: Node v22.21.1, local source checkout, built `dist/entry.js`
- Model/provider: local OpenAI Responses-compatible mock endpoint, model `openai/gpt-5.5`
- Integration/channel (if any): ClickClack, local HTTP/WebSocket fixture
- Relevant config (redacted): `channels.clickclack.allowFrom: ["usr_allowed"]`, `replyMode: "model"`, `model: "openai/gpt-5.5"`

### Steps

1. Built source runtime output with `env pnpm_config_verify_deps_before_run=false node scripts/tsdown-build.mjs` and `node scripts/runtime-postbuild.mjs`.
2. Started a local ClickClack-compatible fixture, local mock OpenAI Responses endpoint, and the built Gateway with `node dist/entry.js gateway --port 45283 --bind loopback --allow-unconfigured`.
3. Posted a ClickClack inbound message from `usr_allowed` containing `OPENCLAW_E2E_OK_ALLOWED`.
4. Posted a ClickClack inbound message from `usr_denied` containing `OPENCLAW_E2E_OK_DENIED`.
5. Ran focused regression tests with `node scripts/run-vitest.mjs extensions/clickclack/src/inbound.test.ts extensions/clickclack/src/gateway.test.ts --reporter=verbose`.

### Expected

- `usr_allowed` reaches agent/model handling and receives a ClickClack reply.
- `usr_denied` is visible as a fixture inbound transport message but is dropped before model request, reply dispatch, and command authorization.

### Actual

- `usr_allowed`: `inboundObserved=true`, `modelRequestObserved=true`, `replyObserved=true`.
- `usr_denied`: `inboundObserved=true`, `modelRequestObserved=false`, `replyObserved=false`.
- Mock model request count was 1 and ClickClack thread reply count was 1, matching only the allowed sender path.
- Focused ClickClack Vitest command exited 0.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Proof command output:

```json
{
  "result": "passed",
  "environment": {
    "os": "Linux 6.14.0-37-generic x64",
    "runtime": "v22.21.1",
    "gatewayCommand": "node dist/entry.js gateway --port 45283 --bind loopback --allow-unconfigured",
    "clickClackFixture": "local HTTP/WebSocket ClickClack-compatible fixture",
    "mockModelEndpoint": "local OpenAI Responses-compatible fixture"
  },
  "config": {
    "allowFrom": ["usr_allowed"],
    "replyMode": "model",
    "model": "openai/gpt-5.5"
  },
  "observations": {
    "websocketConnections": 1,
    "allowedSender": {
      "id": "usr_allowed",
      "inboundObserved": true,
      "modelRequestObserved": true,
      "replyObserved": true
    },
    "deniedSender": {
      "id": "usr_denied",
      "inboundObserved": true,
      "modelRequestObserved": false,
      "replyObserved": false
    },
    "mockRequestCount": 1,
    "threadReplyCount": 1
  }
}
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Built the source Gateway, ran it against a local ClickClack-compatible HTTP/WebSocket fixture with restrictive `allowFrom`, verified an allowlisted sender reached the model reply path, and verified a denied sender did not trigger model or reply dispatch.
- Edge cases checked: Explicit allowed sender `usr_allowed`, explicit denied sender `usr_denied`, ClickClack realtime websocket delivery, model reply dispatch, and focused gateway/inbound regression tests.
- What you did **not** verify: Hosted ClickClack service behavior with real external user accounts, package-install Docker lanes, and full CI in this proof step.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Operators with a non-wildcard ClickClack `allowFrom` who expected all workspace users to reach the agent will now see denied senders dropped.
  - Mitigation: Keep `allowFrom: ["*"]` for open bot accounts, or include every intended sender in the account allowlist.
