### PR TITLE
fix(twitch): register chat intent for refreshing auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ Docs: https://docs.openclaw.ai
 - Telegram: keep queued forum-topic follow-up messages from inheriting superseded source abort signals, so later same-topic user turns can still run and reply after an active turn is replaced. (#83827) Thanks @VACInc.
 - CLI/update: bypass npm freshness filters consistently during managed package and plugin installs so freshly published release plugins remain installable. Thanks @jalehman.
 - CLI/update: guide root-owned npm install EACCES recovery by stopping the managed Gateway before manual package replacement, then reinstalling and restarting the service. Fixes #83747. (#83757) Thanks @brokemac79.
+- Twitch: register refreshing chat tokens with Twurple's chat intent so automatic token refresh keeps chat access available. (#83750) Thanks @TurboTheTurtle.
 - Agents/subagents: keep collect-mode announce queues batching unresolved-origin items with compatible same-route messages and resume collection after a true cross-channel drain when a later compatible batch remains. Fixes #83577.
 - Skills: refresh existing session skill snapshots when watched skill roots change, so changed extra skill directories take effect without starting a new session. Fixes #83782. (#83800) Thanks @hclsys.
 - Providers/Anthropic: preserve native image input for current Claude model rows when stale local catalog data marks them text-only. (#83756) Thanks @TurboTheTurtle.

--- a/extensions/twitch/src/twitch-client.test.ts
+++ b/extensions/twitch/src/twitch-client.test.ts
@@ -201,6 +201,32 @@ describe("TwitchClientManager", () => {
       );
     });
 
+    it("should register refreshing tokens for Twurple chat intent", async () => {
+      const refreshingAccount: TwitchAccountConfig = {
+        ...testAccount,
+        clientSecret: "test-client-secret",
+        refreshToken: "test-refresh-token",
+        expiresIn: 3600,
+        obtainmentTimestamp: 1_700_000_000_000,
+      };
+
+      await manager.getClient(refreshingAccount);
+
+      expect(mockAddUserForToken).toHaveBeenCalledWith(
+        {
+          accessToken: "mock-token-from-tests",
+          refreshToken: "test-refresh-token",
+          expiresIn: 3600,
+          obtainmentTimestamp: 1_700_000_000_000,
+        },
+        ["chat"],
+      );
+      expect(mockAuthProvider.constructor).not.toHaveBeenCalled();
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        "Using RefreshingAuthProvider for testbot (automatic token refresh enabled)",
+      );
+    });
+
     it("should throw error when clientId is missing", async () => {
       const accountWithoutClientId: TwitchAccountConfig = {
         ...testAccount,

--- a/extensions/twitch/src/twitch-client.test.ts
+++ b/extensions/twitch/src/twitch-client.test.ts
@@ -212,6 +212,7 @@ describe("TwitchClientManager", () => {
 
       await manager.getClient(refreshingAccount);
 
+      expect(mockAddUserForToken).toHaveBeenCalledTimes(1);
       expect(mockAddUserForToken).toHaveBeenCalledWith(
         {
           accessToken: "mock-token-from-tests",

--- a/extensions/twitch/src/twitch-client.ts
+++ b/extensions/twitch/src/twitch-client.ts
@@ -6,6 +6,8 @@ import { resolveTwitchToken } from "./token.js";
 import type { ChannelLogSink, TwitchAccountConfig, TwitchChatMessage } from "./types.js";
 import { normalizeToken } from "./utils/twitch.js";
 
+const TWITCH_CHAT_AUTH_INTENTS = ["chat"];
+
 /**
  * Manages Twitch chat client connections
  */
@@ -33,12 +35,15 @@ export class TwitchClientManager {
       });
 
       await authProvider
-        .addUserForToken({
-          accessToken: normalizedToken,
-          refreshToken: account.refreshToken ?? null,
-          expiresIn: account.expiresIn ?? null,
-          obtainmentTimestamp: account.obtainmentTimestamp ?? Date.now(),
-        })
+        .addUserForToken(
+          {
+            accessToken: normalizedToken,
+            refreshToken: account.refreshToken ?? null,
+            expiresIn: account.expiresIn ?? null,
+            obtainmentTimestamp: account.obtainmentTimestamp ?? Date.now(),
+          },
+          TWITCH_CHAT_AUTH_INTENTS,
+        )
         .then((userId) => {
           this.logger.info(
             `Added user ${userId} to RefreshingAuthProvider for ${account.username}`,


### PR DESCRIPTION
Fixes #83727

## Summary
- Register Twurple's `chat` intent when the Twitch channel adds a refreshing user token.
- Add regression coverage that pins the `addUserForToken(..., ["chat"])` contract.

## Root Cause
The Twitch client used `RefreshingAuthProvider.addUserForToken(token)` without an intent list. Twurple's `ChatClient` queries the auth provider for intent `chat`, so refreshing-token accounts had no known chat intent and failed before a stable IRC connection could be established.

## Validation
- `PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node scripts/run-vitest.mjs extensions/twitch/src/twitch-client.test.ts` -> 1 file, 31 passed.
- `PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node scripts/run-vitest.mjs extensions/twitch/src/probe.test.ts extensions/twitch/src/twitch-client.test.ts extensions/twitch/src/status.test.ts extensions/twitch/src/config-schema.test.ts extensions/twitch/src/plugin.test.ts extensions/twitch/src/plugin.lifecycle.test.ts extensions/twitch/src/send.test.ts extensions/twitch/src/token.test.ts extensions/twitch/src/actions.test.ts extensions/twitch/src/outbound.test.ts extensions/twitch/src/setup-surface.test.ts extensions/twitch/src/plugin.live.test.ts extensions/twitch/src/access-control.test.ts extensions/twitch/src/config.test.ts` -> 13 files, 166 passed.
- `PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node_modules/.bin/oxfmt --check --threads=1 extensions/twitch/src/twitch-client.ts extensions/twitch/src/twitch-client.test.ts`
- `git diff --check`
- `git log --format='%h %an <%ae> %s' upstream/main..HEAD` -> `237216de3f Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com> fix(twitch): register chat intent for refreshing auth`

## Real Behavior Proof

Behavior or issue addressed:
Refreshing Twitch accounts did not bind their token to Twurple's `chat` intent, so Twurple could not retrieve a chat token for the connection path.

Real environment tested:
Local OpenClaw checkout on this branch, bundled Node.js, and the repository's real `@twurple/auth` 8.1.4 package from `node_modules`. No mocked Twurple provider was used in the direct proof.

Exact steps or command run after this patch:
```shell
PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node --input-type=module -e 'import { RefreshingAuthProvider } from "@twurple/auth"; const token={accessToken:"proof-access",refreshToken:"proof-refresh",scope:["chat:read","chat:edit"],expiresIn:3600,obtainmentTimestamp:Date.now()}; const before=new RefreshingAuthProvider({clientId:"proof-client",clientSecret:"proof-secret"}); before.addUser("123456", token); const beforeToken=await before.getAccessTokenForIntent("chat", ["chat:read","chat:edit"]); const after=new RefreshingAuthProvider({clientId:"proof-client",clientSecret:"proof-secret"}); after.addUser("123456", token, ["chat"]); const afterToken=await after.getAccessTokenForIntent("chat", ["chat:read","chat:edit"]); console.log(JSON.stringify({before: beforeToken ?? null, after:{userId: afterToken?.userId, accessToken: afterToken?.accessToken, scopes: afterToken?.scope}, afterIntents: after.getIntentsForUser("123456")}, null, 2));'
```

Evidence after fix:
```json
{
  "before": null,
  "after": {
    "userId": "123456",
    "accessToken": "proof-access",
    "scopes": [
      "chat:read",
      "chat:edit"
    ]
  },
  "afterIntents": [
    "chat"
  ]
}
```

Observed result after fix:
With `["chat"]` registered, Twurple resolves `getAccessTokenForIntent("chat", ["chat:read", "chat:edit"])` to the configured user token instead of returning `null`. The OpenClaw Twitch manager now passes that same intent list to `addUserForToken`, and the regression test asserts the exact call.

What was not tested:
I did not run a live Twitch IRC connection because no live Twitch credentials were available in this environment.
