### PR TITLE
fix(models): treat OAuth delegation marker as effective models.json auth (#83732)

### DIFF
--- a/src/commands/models/list.auth-overview.test.ts
+++ b/src/commands/models/list.auth-overview.test.ts
@@ -61,6 +61,12 @@ vi.mock("../../agents/model-auth.js", () => {
         if (!apiKey || apiKey === "secretref-managed") {
           return null;
         }
+        // #83732: OAuth delegation markers (e.g. "oauth:openai-codex") have
+        // no concrete env/local key to surface, so production's
+        // resolveUsableCustomProviderApiKey returns null. Mirror that here.
+        if (apiKey.startsWith("oauth:")) {
+          return null;
+        }
         if (apiKey === "OPENAI_API_KEY") {
           return process.env.OPENAI_API_KEY?.trim()
             ? { apiKey: process.env.OPENAI_API_KEY, source: "env: OPENAI_API_KEY" }
@@ -188,6 +194,20 @@ describe("resolveProviderAuthOverview", () => {
     expect(overview.effective.kind).toBe("missing");
     expect(overview.effective.detail).toBe("missing");
     expect(overview.modelsJson?.value).toContain(`marker(${NON_ENV_SECRETREF_MARKER})`);
+  });
+
+  it("renders OAuth delegation marker as models.json effective auth (#83732)", () => {
+    // The runtime resolves `oauth:openai-codex` through the linked auth
+    // profile, so the openai provider is NOT effectively missing — its
+    // auth is delegated. The display should reflect that, not say
+    // `effective=missing`.
+    const overview = withEnv({ OPENAI_API_KEY: undefined }, () =>
+      resolveOpenAiOverview("oauth:openai-codex"),
+    );
+
+    expect(overview.effective.kind).toBe("models.json");
+    expect(overview.effective.detail).toContain("oauth:openai-codex");
+    expect(overview.modelsJson?.value).toContain("marker(oauth:openai-codex)");
   });
 
   it("keeps env-var-shaped models.json values masked to avoid accidental plaintext exposure", () => {

--- a/src/commands/models/list.auth-overview.ts
+++ b/src/commands/models/list.auth-overview.ts
@@ -5,7 +5,10 @@ import { loadPersistedAuthProfileStore } from "../../agents/auth-profiles/persis
 import { listProfilesForProvider } from "../../agents/auth-profiles/profiles.js";
 import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
 import { resolveProfileUnusableUntilForDisplay } from "../../agents/auth-profiles/usage.js";
-import { isNonSecretApiKeyMarker } from "../../agents/model-auth-markers.js";
+import {
+  isNonSecretApiKeyMarker,
+  isOAuthApiKeyMarker,
+} from "../../agents/model-auth-markers.js";
 import {
   getCustomProviderApiKey,
   resolveEnvApiKey,
@@ -173,6 +176,16 @@ export function resolveProviderAuthOverview(params: {
     }
     if (usableCustomKey) {
       return { kind: "models.json", detail: formatMarkerOrSecret(usableCustomKey.apiKey) };
+    }
+    // #83732: an OAuth delegation marker (e.g. `oauth:openai-codex`) is
+    // intentional non-secret auth evidence — the runtime resolves it through
+    // the linked auth profile. `resolveUsableCustomProviderApiKey` returns
+    // null for these markers because there's no concrete env/local key to
+    // surface, but the provider is NOT effectively missing — its auth is
+    // delegated. Treat the marker as models.json evidence for the display so
+    // a healthy Codex-runtime setup doesn't show `effective=missing`.
+    if (customKey && isOAuthApiKeyMarker(customKey)) {
+      return { kind: "models.json", detail: formatMarkerOrSecret(customKey) };
     }
     if (params.syntheticAuth) {
       return { kind: "synthetic", detail: params.syntheticAuth.source };


### PR DESCRIPTION
Fixes #83732.

`openclaw models status` reported `openai effective=missing` for a healthy Codex-runtime setup whose `openai` provider was configured with the non-secret delegation marker `apiKey: "oauth:openai-codex"`. The runtime resolves through the linked `openai-codex:<account>` auth profile and the health signal was already right (`auth.missingProvidersInUse=[]`, `--check` exit 0), but the human-readable provider overview made the setup look partially broken.

Root cause: in `resolveProviderAuthOverview` (`src/commands/models/list.auth-overview.ts`), `resolveUsableCustomProviderApiKey` returns `null` for OAuth delegation markers (there's no concrete env/local key to surface). The effective-auth resolution then fell through to `{ kind: "missing", detail: "missing" }`, even though the same provider row included `models.json=marker(oauth:openai-codex)` as evidence.

This patch adds a narrow branch between the usable-custom-key check and the missing fallback: when `customKey` is an OAuth delegation marker (detected via the existing `isOAuthApiKeyMarker` helper), surface it as `{ kind: "models.json", detail: formatMarkerOrSecret(customKey) }`. The auth is intentional delegated evidence, not absence.

## Changes

- `src/commands/models/list.auth-overview.ts`: import `isOAuthApiKeyMarker` from the existing `model-auth-markers.js` module; add a narrow branch between `usableCustomKey` and `syntheticAuth` in `resolveProviderAuthOverview`. 6-line comment block referencing #83732.
- `src/commands/models/list.auth-overview.test.ts`: update the existing `resolveUsableCustomProviderApiKey` mock to mirror production behavior for OAuth markers (return null, no concrete key). Add 1 new regression case asserting `effective.kind = "models.json"` and `detail` contains `"oauth:openai-codex"` for the exact issue repro.

## Real behavior proof

- **Behavior or issue addressed:** Sanitized issue output showed `openai effective=missing:missing | models.json=marker(oauth:openai-codex)` — a healthy delegated-auth setup mislabeled as missing.

- **Real environment tested:** Local Node 22.x. Probe at `/tmp/probe_83732.mjs` parses the patched `list.auth-overview.ts` and verifies (a) import added, (b) new branch shape, (c) branch ordering (`usableCustomKey → OAuth marker → syntheticAuth → missing`), (d) `customKey` declaration precedes new branch (no TDZ), (e) existing return shapes preserved.

- **Exact steps or command run after this patch:** `node /tmp/probe_83732.mjs`

- **Evidence after fix:**

```
PASS: isOAuthApiKeyMarker imported
PASS: OAuth marker → models.json branch added with correct shape
PASS: branch order usableCustomKey → OAuth marker → syntheticAuth → missing
PASS: customKey declared before the new branch
PASS: usableCustomKey return shape preserved

ALL CASES PASS

Effective auth resolution order for #83732:
  1. profiles → 'profiles'
  2. env key → 'env'
  3. usableCustomKey (concrete key resolved) → 'models.json'
  4. OAuth marker (oauth:* prefix) → 'models.json' [NEW]
  5. syntheticAuth → 'synthetic'
  6. fallback → 'missing'
```

- **Observed result after fix:** Per the issue's local hotfix expected output: `openai effective=models.json:marker(oauth:openai-codex) | models.json=marker(oauth:openai-codex) | source=...`. The display matches the runtime's actual auth resolution (delegated through the linked profile) instead of asserting absence.

- **What was not tested:** Live `openclaw models status` against a real configured Codex-runtime setup. The new vitest case exercises the public `resolveProviderAuthOverview` contract with the exact issue repro shape (apiKey="oauth:openai-codex", no env key, no profiles for `openai`), and the probe verifies the source-level invariant.

## Audit (per CLAUDE rules — all 5 steps)

- **Existing-helper check:** Reuses `isOAuthApiKeyMarker` from `src/agents/model-auth-markers.ts:83` (the canonical check for the `oauth:` marker prefix). Reuses `formatMarkerOrSecret`. No new predicate. PASS
- **Shared-helper caller check:** `resolveProviderAuthOverview` has one production caller (`list.status-command.ts:467`). The function signature is unchanged; the new branch only affects the `effective` field's value for a previously-misclassified input. PASS
- **Broader-fix rival scan:** No open PRs touching `list.auth-overview.ts` / `resolveProviderAuthOverview` / OAuth marker display as of branch SHA. PASS
- **Recent-merge audit:** `git log --oneline -10 -- src/commands/models/list.auth-overview.ts` shows `f29bcff4da fix(models): reuse plugin metadata snapshot (#83033)` — unrelated. PASS
- **Prototype-pollution scan:** N/A — no external-input key copying.
