### PR TITLE
Doctor: normalize repair checks inside runner

### DIFF
--- a/src/flows/doctor-lint-flow.test.ts
+++ b/src/flows/doctor-lint-flow.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { exitCodeFromFindings, runDoctorLintChecks } from "./doctor-lint-flow.js";
+import { normalizeHealthCheck } from "./health-check-adapter.js";
+import type { RunnableHealthCheck } from "./health-check-runner-types.js";
 import type { HealthCheck, HealthCheckContext } from "./health-checks.js";
 
 const ctx: HealthCheckContext = {
@@ -17,7 +19,7 @@ function check(id: string, detect: HealthCheck["detect"]): HealthCheck {
     id,
     kind: "core",
     description: id,
-    detect,
+    detect: detect ?? (async () => []),
   };
 }
 
@@ -34,6 +36,34 @@ describe("runDoctorLintChecks", () => {
     expect(result.checksRun).toBe(1);
     expect(result.checksSkipped).toBe(1);
     expect(result.findings.map((finding) => finding.checkId)).toEqual(["a"]);
+  });
+
+  it("supports single-run checks in lint mode", async () => {
+    const runnable: RunnableHealthCheck = {
+      id: "run-check",
+      kind: "core",
+      description: "run check",
+      async run(runCtx) {
+        expect(runCtx).toMatchObject({
+          mode: "lint",
+          repair: false,
+        });
+        return {
+          findings: [
+            {
+              checkId: "run-check",
+              severity: "warning",
+              message: "warn",
+            },
+          ],
+        };
+      },
+    };
+    const check = normalizeHealthCheck(runnable);
+
+    const result = await runDoctorLintChecks(ctx, { checks: [check] });
+
+    expect(result.findings.map((finding) => finding.checkId)).toEqual(["run-check"]);
   });
 
   it("turns thrown checks into error findings", async () => {

--- a/src/flows/doctor-repair-flow.test.ts
+++ b/src/flows/doctor-repair-flow.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { runDoctorHealthRepairs } from "./doctor-repair-flow.js";
+import { defineSplitHealthCheck, normalizeHealthCheck } from "./health-check-adapter.js";
+import type { RunnableHealthCheck } from "./health-check-runner-types.js";
 import type { HealthCheck, HealthRepairContext } from "./health-checks.js";
 
 function ctx(cfg: OpenClawConfig): HealthRepairContext {
@@ -16,10 +18,56 @@ function ctx(cfg: OpenClawConfig): HealthRepairContext {
 }
 
 describe("runDoctorHealthRepairs", () => {
+  it("repairs single-run checks and validates through lint mode", async () => {
+    const runModes: string[] = [];
+    const scopes: unknown[] = [];
+    const runnable: RunnableHealthCheck = {
+      id: "test/run-repairable",
+      kind: "core",
+      description: "run repairable",
+      async run(ctx, scope) {
+        runModes.push(ctx.mode);
+        if (scope !== undefined) {
+          scopes.push(scope);
+        }
+        const findings =
+          ctx.cfg.gateway?.mode === "local"
+            ? []
+            : [
+                {
+                  checkId: "test/run-repairable",
+                  severity: "warning" as const,
+                  message: "gateway mode missing",
+                  path: "gateway.mode",
+                },
+              ];
+        if (!ctx.repair || findings.length === 0) {
+          return { findings };
+        }
+        return {
+          findings,
+          config: { ...ctx.cfg, gateway: { ...ctx.cfg.gateway, mode: "local" } },
+          changes: ["Set gateway.mode to local."],
+        };
+      },
+    };
+    const checks: HealthCheck[] = [normalizeHealthCheck(runnable)];
+
+    const result = await runDoctorHealthRepairs(ctx({}), { checks });
+
+    expect(result.config.gateway?.mode).toBe("local");
+    expect(result.changes).toEqual(["Set gateway.mode to local."]);
+    expect(result.checksRepaired).toBe(1);
+    expect(result.checksValidated).toBe(1);
+    expect(result.remainingFindings).toEqual([]);
+    expect(runModes).toEqual(["fix", "lint"]);
+    expect(scopes).toMatchObject([{ paths: ["gateway.mode"] }]);
+  });
+
   it("repairs modern checks and threads updated config", async () => {
     const scopes: unknown[] = [];
     const checks: HealthCheck[] = [
-      {
+      defineSplitHealthCheck({
         id: "test/repairable",
         kind: "core",
         description: "repairable",
@@ -44,7 +92,7 @@ describe("runDoctorHealthRepairs", () => {
             changes: ["Set gateway.mode to local."],
           };
         },
-      },
+      }),
     ];
 
     const result = await runDoctorHealthRepairs(ctx({}), { checks });
@@ -57,9 +105,35 @@ describe("runDoctorHealthRepairs", () => {
     expect(scopes).toMatchObject([{ paths: ["gateway.mode"] }]);
   });
 
+  it("keeps repairable out of split repair result types", () => {
+    const check = defineSplitHealthCheck({
+      id: "test/repair-result-status-boundary",
+      kind: "core",
+      description: "repair result status boundary",
+      async detect() {
+        return [
+          {
+            checkId: "test/repair-result-status-boundary",
+            severity: "warning",
+            message: "needs repair",
+          },
+        ];
+      },
+      // @ts-expect-error repairable is a run-result preview status, not a split repair result.
+      async repair() {
+        return {
+          status: "repairable",
+          changes: [],
+        };
+      },
+    });
+
+    expect(check.id).toBe("test/repair-result-status-boundary");
+  });
+
   it("leaves non-repairable checks for legacy doctor behavior", async () => {
     const checks: HealthCheck[] = [
-      {
+      defineSplitHealthCheck({
         id: "test/legacy-only",
         kind: "core",
         description: "legacy only",
@@ -72,7 +146,7 @@ describe("runDoctorHealthRepairs", () => {
             },
           ];
         },
-      },
+      }),
     ];
 
     const result = await runDoctorHealthRepairs(ctx({}), { checks });
@@ -85,9 +159,44 @@ describe("runDoctorHealthRepairs", () => {
     expect(result.checksValidated).toBe(0);
   });
 
+  it("keeps split check findings when repair throws", async () => {
+    const checks: HealthCheck[] = [
+      defineSplitHealthCheck({
+        id: "test/repair-throws",
+        kind: "core",
+        description: "repair throws",
+        async detect() {
+          return [
+            {
+              checkId: "test/repair-throws",
+              severity: "warning",
+              message: "needs repair",
+              path: "gateway.mode",
+            },
+          ];
+        },
+        async repair() {
+          throw new Error("repair exploded");
+        },
+      }),
+    ];
+
+    const result = await runDoctorHealthRepairs(ctx({}), { checks });
+
+    expect(result.findings).toMatchObject([
+      {
+        checkId: "test/repair-throws",
+        path: "gateway.mode",
+      },
+    ]);
+    expect(result.warnings).toEqual(["test/repair-throws repair failed: repair exploded"]);
+    expect(result.checksRepaired).toBe(0);
+    expect(result.checksValidated).toBe(0);
+  });
+
   it("reports repair validation findings that remain after repair", async () => {
     const checks: HealthCheck[] = [
-      {
+      defineSplitHealthCheck({
         id: "test/not-fixed",
         kind: "core",
         description: "not fixed",
@@ -106,7 +215,7 @@ describe("runDoctorHealthRepairs", () => {
             changes: ["Tried repair."],
           };
         },
-      },
+      }),
     ];
 
     const result = await runDoctorHealthRepairs(ctx({}), { checks });
@@ -122,10 +231,49 @@ describe("runDoctorHealthRepairs", () => {
     expect(result.warnings).toEqual(["test/not-fixed repair left 1 finding(s)"]);
   });
 
+  it("validates successful repairs by default", async () => {
+    let detectCalls = 0;
+    const checks: HealthCheck[] = [
+      defineSplitHealthCheck({
+        id: "test/no-default-validation",
+        kind: "core",
+        description: "no default validation",
+        async detect() {
+          detectCalls++;
+          return [
+            {
+              checkId: "test/no-default-validation",
+              severity: "warning",
+              message: "needs repair",
+            },
+          ];
+        },
+        async repair() {
+          return {
+            changes: ["Ran repair."],
+          };
+        },
+      }),
+    ];
+
+    const result = await runDoctorHealthRepairs(ctx({}), { checks });
+
+    expect(detectCalls).toBe(2);
+    expect(result.checksRepaired).toBe(1);
+    expect(result.checksValidated).toBe(1);
+    expect(result.remainingFindings).toEqual([
+      {
+        checkId: "test/no-default-validation",
+        severity: "warning",
+        message: "needs repair",
+      },
+    ]);
+  });
+
   it("does not validate skipped or failed repair results", async () => {
     let validationCalls = 0;
     const checks: HealthCheck[] = [
-      {
+      defineSplitHealthCheck({
         id: "test/skipped",
         kind: "core",
         description: "skipped",
@@ -146,7 +294,7 @@ describe("runDoctorHealthRepairs", () => {
             changes: [],
           };
         },
-      },
+      }),
     ];
 
     const result = await runDoctorHealthRepairs(ctx({}), { checks });
@@ -162,7 +310,7 @@ describe("runDoctorHealthRepairs", () => {
     const repairContexts: HealthRepairContext[] = [];
     let detectCalls = 0;
     const checks: HealthCheck[] = [
-      {
+      defineSplitHealthCheck({
         id: "test/dry-run",
         kind: "core",
         description: "dry run",
@@ -202,7 +350,7 @@ describe("runDoctorHealthRepairs", () => {
             ],
           };
         },
-      },
+      }),
     ];
 
     const result = await runDoctorHealthRepairs(ctx({}), {
@@ -219,5 +367,59 @@ describe("runDoctorHealthRepairs", () => {
     expect(result.checksValidated).toBe(0);
     expect(detectCalls).toBe(1);
     expect(repairContexts[0]).toMatchObject({ dryRun: true, diff: true });
+  });
+
+  it("passes diff false and true through the repair API", async () => {
+    const repairContexts: HealthRepairContext[] = [];
+    const checks: HealthCheck[] = [
+      defineSplitHealthCheck({
+        id: "test/diff-preview",
+        kind: "core",
+        description: "diff preview",
+        async detect() {
+          return [
+            {
+              checkId: "test/diff-preview",
+              severity: "warning",
+              message: "config needs repair",
+              path: "gateway.mode",
+            },
+          ];
+        },
+        async repair(ctx) {
+          repairContexts.push(ctx);
+          return {
+            changes: ["Would set gateway.mode to local."],
+            diffs:
+              ctx.diff === true
+                ? [
+                    {
+                      kind: "config",
+                      path: "gateway.mode",
+                      before: undefined,
+                      after: "local",
+                    },
+                  ]
+                : [],
+          };
+        },
+      }),
+    ];
+
+    const withoutDiff = await runDoctorHealthRepairs(ctx({}), {
+      checks,
+      dryRun: true,
+      diff: false,
+    });
+    const withDiff = await runDoctorHealthRepairs(ctx({}), {
+      checks,
+      dryRun: true,
+      diff: true,
+    });
+
+    expect(repairContexts[0]).toMatchObject({ dryRun: true, diff: false });
+    expect(withoutDiff.diffs).toEqual([]);
+    expect(repairContexts[1]).toMatchObject({ dryRun: true, diff: true });
+    expect(withDiff.diffs).toMatchObject([{ kind: "config", path: "gateway.mode" }]);
   });
 });

--- a/src/flows/doctor-repair-flow.ts
+++ b/src/flows/doctor-repair-flow.ts
@@ -1,12 +1,15 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { scrubDoctorErrorMessage } from "./doctor-error-message.js";
+import { normalizeHealthCheck } from "./health-check-adapter.js";
 import { listHealthChecks } from "./health-check-registry.js";
+import type { HealthCheckRunResult, RegisteredHealthCheck } from "./health-check-runner-types.js";
 import type {
   HealthCheck,
   HealthFinding,
   HealthRepairContext,
   HealthRepairDiff,
   HealthRepairEffect,
+  HealthRepairResult,
 } from "./health-checks.js";
 
 export interface DoctorRepairRunOptions {
@@ -32,7 +35,9 @@ export async function runDoctorHealthRepairs(
   ctx: HealthRepairContext,
   opts: DoctorRepairRunOptions = {},
 ): Promise<DoctorRepairRunResult> {
-  const checks = opts.checks ?? listHealthChecks();
+  const checks: readonly RegisteredHealthCheck[] = (opts.checks ?? listHealthChecks()).map(
+    normalizeHealthCheck,
+  );
   const findings: HealthFinding[] = [];
   const remainingFindings: HealthFinding[] = [];
   const changes: string[] = [];
@@ -45,55 +50,16 @@ export async function runDoctorHealthRepairs(
 
   for (const check of checks) {
     const detectCtx: HealthRepairContext = { ...ctx, cfg };
-    let checkFindings: readonly HealthFinding[];
-    try {
-      checkFindings = await check.detect(detectCtx);
-    } catch (err) {
-      warnings.push(`${check.id} detect failed: ${scrubDoctorErrorMessage(err)}`);
-      continue;
-    }
-    findings.push(...checkFindings);
-    if (checkFindings.length === 0 || check.repair === undefined) {
-      continue;
-    }
-
-    try {
-      const result = await check.repair(
-        { ...ctx, cfg, dryRun: opts.dryRun === true, diff: opts.diff === true },
-        checkFindings,
-      );
-      warnings.push(...(result.warnings ?? []));
-      diffs.push(...(result.diffs ?? []));
-      effects.push(...(result.effects ?? []));
-      const status = result.status ?? "repaired";
-      if (status !== "repaired") {
-        warnings.push(`${check.id} repair ${status}${result.reason ? `: ${result.reason}` : ""}`);
-        continue;
-      }
-      if (result.config !== undefined && opts.dryRun !== true) {
-        cfg = result.config;
-      }
-      changes.push(...result.changes);
-      checksRepaired++;
-      if (opts.dryRun === true) {
-        continue;
-      }
-      try {
-        const validationFindings = await check.detect(
-          { ...ctx, cfg },
-          createValidationScope(checkFindings),
-        );
-        remainingFindings.push(...validationFindings);
-        checksValidated++;
-        if (validationFindings.length > 0) {
-          warnings.push(`${check.id} repair left ${validationFindings.length} finding(s)`);
-        }
-      } catch (err) {
-        warnings.push(`${check.id} validation failed: ${scrubDoctorErrorMessage(err)}`);
-      }
-    } catch (err) {
-      warnings.push(`${check.id} repair failed: ${scrubDoctorErrorMessage(err)}`);
-    }
+    const runResult = await runHealthCheck(check, detectCtx, opts);
+    cfg = runResult.config;
+    findings.push(...runResult.findings);
+    remainingFindings.push(...runResult.remainingFindings);
+    changes.push(...runResult.changes);
+    warnings.push(...runResult.warnings);
+    diffs.push(...runResult.diffs);
+    effects.push(...runResult.effects);
+    checksRepaired += runResult.checksRepaired;
+    checksValidated += runResult.checksValidated;
   }
 
   return {
@@ -107,6 +73,210 @@ export async function runDoctorHealthRepairs(
     checksRun: checks.length,
     checksRepaired,
     checksValidated,
+  };
+}
+
+async function runHealthCheck(
+  check: RegisteredHealthCheck,
+  ctx: HealthRepairContext,
+  opts: DoctorRepairRunOptions,
+): Promise<DoctorRepairRunResult> {
+  if (check.sourceContract === "split") {
+    return runSplitHealthCheck(check, ctx, opts);
+  }
+  return runRunnableHealthCheck(check, ctx, opts);
+}
+
+async function runSplitHealthCheck(
+  check: RegisteredHealthCheck,
+  ctx: HealthRepairContext,
+  opts: DoctorRepairRunOptions,
+): Promise<DoctorRepairRunResult> {
+  const findings: HealthFinding[] = [];
+  const remainingFindings: HealthFinding[] = [];
+  const changes: string[] = [];
+  const warnings: string[] = [];
+  const diffs: HealthRepairDiff[] = [];
+  const effects: HealthRepairEffect[] = [];
+  let cfg = ctx.cfg;
+  let checksRepaired = 0;
+  let checksValidated = 0;
+
+  let checkFindings: readonly HealthFinding[];
+  try {
+    checkFindings = await check.detect(ctx);
+  } catch (err) {
+    warnings.push(`${check.id} detect failed: ${scrubDoctorErrorMessage(err)}`);
+    return repairRunResult(cfg, findings, remainingFindings, changes, warnings, diffs, effects);
+  }
+  findings.push(...checkFindings);
+  if (checkFindings.length === 0 || check.repair === undefined) {
+    return repairRunResult(cfg, findings, remainingFindings, changes, warnings, diffs, effects);
+  }
+
+  try {
+    const result = await check.repair(
+      { ...ctx, dryRun: opts.dryRun === true, diff: opts.diff === true },
+      checkFindings,
+    );
+    warnings.push(...(result.warnings ?? []));
+    diffs.push(...(result.diffs ?? []));
+    effects.push(...(result.effects ?? []));
+    const status = result.status ?? "repaired";
+    if (status !== "repaired") {
+      warnings.push(`${check.id} repair ${status}${result.reason ? `: ${result.reason}` : ""}`);
+      return repairRunResult(cfg, findings, remainingFindings, changes, warnings, diffs, effects);
+    }
+    if (result.config !== undefined && opts.dryRun !== true) {
+      cfg = result.config;
+    }
+    changes.push(...result.changes);
+    checksRepaired++;
+    if (opts.dryRun === true) {
+      return repairRunResult(cfg, findings, remainingFindings, changes, warnings, diffs, effects, {
+        checksRepaired,
+        checksValidated,
+      });
+    }
+    try {
+      const validationFindings = await check.detect(
+        { ...ctx, cfg },
+        createValidationScope(findings),
+      );
+      remainingFindings.push(...validationFindings);
+      checksValidated++;
+      if (validationFindings.length > 0) {
+        warnings.push(`${check.id} repair left ${validationFindings.length} finding(s)`);
+      }
+    } catch (err) {
+      warnings.push(`${check.id} validation failed: ${scrubDoctorErrorMessage(err)}`);
+    }
+  } catch (err) {
+    warnings.push(`${check.id} repair failed: ${scrubDoctorErrorMessage(err)}`);
+  }
+
+  return repairRunResult(cfg, findings, remainingFindings, changes, warnings, diffs, effects, {
+    checksRepaired,
+    checksValidated,
+  });
+}
+
+async function runRunnableHealthCheck(
+  check: RegisteredHealthCheck,
+  ctx: HealthRepairContext,
+  opts: DoctorRepairRunOptions,
+): Promise<DoctorRepairRunResult> {
+  const findings: HealthFinding[] = [];
+  const remainingFindings: HealthFinding[] = [];
+  const changes: string[] = [];
+  const warnings: string[] = [];
+  const diffs: HealthRepairDiff[] = [];
+  const effects: HealthRepairEffect[] = [];
+  let cfg = ctx.cfg;
+  let checksRepaired = 0;
+  let checksValidated = 0;
+
+  let result: HealthCheckRunResult;
+  try {
+    result = await check.run({
+      ...ctx,
+      repair: opts.dryRun !== true,
+      diff: opts.diff === true,
+      previewRepair: opts.dryRun === true,
+    });
+  } catch (err) {
+    warnings.push(`${check.id} run failed: ${scrubDoctorErrorMessage(err)}`);
+    return repairRunResult(ctx.cfg, findings, remainingFindings, changes, warnings, diffs, effects);
+  }
+
+  findings.push(...(result.findings ?? []));
+  warnings.push(...(result.warnings ?? []));
+  diffs.push(...(result.diffs ?? []));
+  effects.push(...(result.effects ?? []));
+  const status = result.status ?? "repaired";
+  const hasRepairOutput = hasHealthRepairOutput(result);
+  if (status === "repairable") {
+    changes.push(...(result.changes ?? []));
+    return repairRunResult(cfg, findings, remainingFindings, changes, warnings, diffs, effects, {
+      checksRepaired: hasRepairOutput ? 1 : 0,
+      checksValidated,
+    });
+  }
+  if (status !== "repaired") {
+    warnings.push(`${check.id} repair ${status}${result.reason ? `: ${result.reason}` : ""}`);
+    return repairRunResult(ctx.cfg, findings, remainingFindings, changes, warnings, diffs, effects);
+  }
+  if (result.config !== undefined && opts.dryRun !== true) {
+    cfg = result.config;
+  }
+  changes.push(...(result.changes ?? []));
+  if (hasRepairOutput) {
+    checksRepaired++;
+  }
+  if (opts.dryRun === true || !hasRepairOutput) {
+    return repairRunResult(cfg, findings, remainingFindings, changes, warnings, diffs, effects, {
+      checksRepaired,
+      checksValidated,
+    });
+  }
+
+  try {
+    const validation = await check.run(
+      {
+        ...ctx,
+        mode: "lint",
+        cfg,
+        repair: false,
+        diff: opts.diff === true,
+        previewRepair: false,
+      },
+      createValidationScope(findings),
+    );
+    remainingFindings.push(...(validation.findings ?? []));
+    checksValidated++;
+    if (validation.findings !== undefined && validation.findings.length > 0) {
+      warnings.push(`${check.id} repair left ${validation.findings.length} finding(s)`);
+    }
+  } catch (err) {
+    warnings.push(`${check.id} validation failed: ${scrubDoctorErrorMessage(err)}`);
+  }
+
+  return repairRunResult(cfg, findings, remainingFindings, changes, warnings, diffs, effects, {
+    checksRepaired,
+    checksValidated,
+  });
+}
+
+function hasHealthRepairOutput(result: HealthRepairResult | HealthCheckRunResult): boolean {
+  return (
+    result.config !== undefined ||
+    (result.changes?.length ?? 0) > 0 ||
+    (result.diffs?.length ?? 0) > 0 ||
+    (result.effects?.length ?? 0) > 0
+  );
+}
+
+function repairRunResult(
+  config: OpenClawConfig,
+  findings: readonly HealthFinding[],
+  remainingFindings: readonly HealthFinding[],
+  changes: readonly string[],
+  warnings: readonly string[],
+  diffs: readonly HealthRepairDiff[],
+  effects: readonly HealthRepairEffect[],
+  counts: { checksRepaired?: number; checksValidated?: number } = {},
+): DoctorRepairRunResult {
+  return {
+    config,
+    findings,
+    remainingFindings,
+    changes,
+    warnings,
+    diffs,
+    effects,
+    checksRun: 1,
+    checksRepaired: counts.checksRepaired ?? 0,
+    checksValidated: counts.checksValidated ?? 0,
   };
 }
 

--- a/src/flows/health-check-adapter.ts
+++ b/src/flows/health-check-adapter.ts
@@ -1,0 +1,80 @@
+import type {
+  HealthCheckInput,
+  HealthCheckRunResult,
+  RegisteredHealthCheck,
+} from "./health-check-runner-types.js";
+import type { HealthCheck, HealthRepairContext } from "./health-checks.js";
+
+export function defineSplitHealthCheck(check: HealthCheck): RegisteredHealthCheck {
+  return {
+    id: check.id,
+    kind: check.kind,
+    description: check.description,
+    source: check.source,
+    sourceContract: "split",
+    detect: (ctx, scope) => check.detect(ctx, scope),
+    repair:
+      check.repair === undefined
+        ? undefined
+        : (ctx, findings) => check.repair?.(ctx, findings) ?? Promise.resolve({ changes: [] }),
+    async run(ctx, scope): Promise<HealthCheckRunResult> {
+      const findings = await check.detect(ctx, scope);
+      if (
+        findings.length === 0 ||
+        check.repair === undefined ||
+        (!ctx.repair && ctx.previewRepair !== true)
+      ) {
+        return { findings };
+      }
+      const repairResult = await check.repair(
+        {
+          ...ctx,
+          mode: "fix",
+          dryRun: !ctx.repair,
+          diff: ctx.diff === true,
+        } as HealthRepairContext,
+        findings,
+      );
+      return {
+        findings,
+        config: ctx.repair ? repairResult.config : undefined,
+        changes: repairResult.changes,
+        warnings: repairResult.warnings,
+        diffs: repairResult.diffs,
+        effects: repairResult.effects,
+        status: ctx.repair ? repairResult.status : (repairResult.status ?? "repairable"),
+        reason: repairResult.reason,
+      };
+    },
+  };
+}
+
+export function normalizeHealthCheck(check: HealthCheckInput): RegisteredHealthCheck {
+  if (
+    "detect" in check &&
+    check.detect !== undefined &&
+    "run" in check &&
+    check.run !== undefined &&
+    "sourceContract" in check
+  ) {
+    return check as RegisteredHealthCheck;
+  }
+  if ("detect" in check && check.detect !== undefined) {
+    return defineSplitHealthCheck(check);
+  }
+  if ("run" in check && check.run !== undefined) {
+    return {
+      id: check.id,
+      kind: check.kind,
+      description: check.description,
+      source: check.source,
+      sourceContract: "run",
+      async detect(ctx, scope) {
+        const result = await check.run({ ...ctx, repair: false }, scope);
+        return result.findings ?? [];
+      },
+      run: (ctx, scope) => check.run(ctx, scope),
+    };
+  }
+  throw new Error(`health check ${check.id} must define run() or detect()`);
+}

--- a/src/flows/health-check-runner-types.ts
+++ b/src/flows/health-check-runner-types.ts
@@ -1,0 +1,37 @@
+import type {
+  HealthCheck,
+  HealthCheckContext,
+  HealthCheckScope,
+  HealthFinding,
+  HealthRepairDiff,
+  HealthRepairEffect,
+  HealthRepairResult,
+} from "./health-checks.js";
+
+export interface HealthCheckRunContext extends HealthCheckContext {
+  readonly repair: boolean;
+  readonly diff?: boolean;
+  readonly previewRepair?: boolean;
+}
+
+export interface HealthCheckRunResult extends Omit<HealthRepairResult, "changes" | "status"> {
+  readonly findings?: readonly HealthFinding[];
+  readonly status?: "repairable" | "repaired" | "skipped" | "failed";
+  readonly changes?: readonly string[];
+  readonly diffs?: readonly HealthRepairDiff[];
+  readonly effects?: readonly HealthRepairEffect[];
+}
+
+export interface RunnableHealthCheck extends Pick<
+  HealthCheck,
+  "id" | "kind" | "description" | "source"
+> {
+  run(ctx: HealthCheckRunContext, scope?: HealthCheckScope): Promise<HealthCheckRunResult>;
+}
+
+export type HealthCheckInput = HealthCheck | RunnableHealthCheck;
+
+export interface RegisteredHealthCheck extends HealthCheck {
+  readonly sourceContract: "split" | "run";
+  run(ctx: HealthCheckRunContext, scope?: HealthCheckScope): Promise<HealthCheckRunResult>;
+}


### PR DESCRIPTION
## Summary

This PR narrows the first doctor repair migration step to the core doctor runner.

- Adds an internal normalized health-check shape so the repair runner can execute either the existing split `detect()` / `repair()` checks or an internal single-flow `run(ctx)` check.
- Keeps the public plugin SDK health contract unchanged: plugin authors still see `detect()` plus optional `repair()`, and no plugin SDK baseline is regenerated.
- Preserves the old split-check repair sequencing so detected findings are still reported if `repair()` throws.
- Threads dry-run, diff, repair effects, warnings, config updates, and post-repair validation through the normalized runner path.
- Adds focused lint and repair-flow tests covering run-mode checks, split-check adaptation, dry-run/diff preview behavior, repair status mapping, repair failure reporting, and validation after successful repair.

The goal is to make the runner easier to migrate safely without asking every existing doctor check author to split one boolean repair flow immediately. Existing split checks still work through the adapter; internal checks can move to one flow when that is clearer.

## Verification

Local/WSL proof:

- `git diff --check`
- `OPENCLAW_OXLINT_SKIP_PREPARE=1 node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/flows/doctor-lint-flow.test.ts src/flows/doctor-repair-flow.test.ts src/flows/doctor-repair-flow.ts src/flows/health-check-adapter.ts src/flows/health-check-runner-types.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-prod-83753.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test-83753-pr1-contract.tsbuildinfo`
- Earlier focused Vitest after adding the split repair-failure regression test: `node scripts/run-vitest.mjs src/flows/doctor-repair-flow.test.ts src/flows/doctor-lint-flow.test.ts` — 2 files / 14 tests passed

Crabbox real CLI proof on current head:

- Provider: AWS Crabbox
- Lease: `cbx_cb0b70795a87`
- Run: `run_85627cfd426c`
- Portal: https://crabbox.openclaw.ai/portal/runs/run_85627cfd426c
- Head: `d139d39e884019ce5de521660ba382a0499a1575`
- Command: disposable `OPENCLAW_HOME` with legacy browser residue, then `doctor --lint --only core/doctor/browser-clawd-profile-residue --json`, `doctor --fix --yes --non-interactive --no-workspace-suggestions`, and the same lint command again.

Crabbox transcript excerpt, with temp home redacted:

```text
HEAD=d139d39e884019ce5de521660ba382a0499a1575
NODE=v24.15.0
PNPM=11.2.2
CONFIG=<temp-home>/.openclaw/openclaw.json
LEGACY_BEFORE=present
== doctor --lint before ==
{"ok":false,"checksRun":1,"checksSkipped":16,"findings":[{"checkId":"core/doctor/browser-clawd-profile-residue","severity":"warning","message":"Legacy managed browser profile residue was found at <temp-home>/.openclaw/browser/clawd.","path":"<temp-home>/.openclaw/browser/clawd","ocPath":"oc://state/browser/clawd","fixHint":"Run `openclaw doctor --fix` to archive the stale clawd profile safely instead of deleting it in place."}]}
== doctor --fix ==
Archived legacy clawd managed browser profile residue.
- legacy profile: <temp-home>/.openclaw/browser/clawd
- canonical profile: <temp-home>/.openclaw/browser/openclaw/user-data
LEGACY_AFTER=absent
== doctor --lint after ==
{"ok":true,"checksRun":1,"checksSkipped":16,"findings":[]}
```

## Real behavior proof

Behavior addressed: Doctor repair runner now has one internal normalized execution path while preserving existing split-check repair error behavior, lint behavior, repair behavior, dry-run/diff previews, effects, warnings, config updates, and validation behavior.

Real environment tested: AWS Crabbox Linux VM (`cbx_cb0b70795a87`) from current PR head `d139d39e884019ce5de521660ba382a0499a1575`.

Exact steps or command run after this patch: created a disposable `OPENCLAW_HOME` with legacy `browser/clawd` residue, ran `doctor --lint --only core/doctor/browser-clawd-profile-residue --json`, ran `doctor --fix --yes --non-interactive --no-workspace-suggestions`, then reran the same lint check.

Evidence after fix: before lint reported `core/doctor/browser-clawd-profile-residue`; `doctor --fix` archived the legacy `clawd` browser profile residue; after lint returned `{"ok":true,"checksRun":1,"checksSkipped":16,"findings":[]}`.

Observed result after fix: the public plugin SDK health surface remains unchanged, the core doctor runner adapts split checks and internal run checks, and a real repair-backed converted doctor check works through CLI lint/fix/lint on the pushed head.

What was not tested: full release/package acceptance lanes; this PR does not touch package installation or plugin SDK exports.