### PR TITLE
fix: strip apiKey from models.json to prevent secret leakage (Layer 1, #11829)

### DIFF
--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -178,7 +178,14 @@ export async function planOpenClawModelsJsonWithDeps(
       secretRefManagedProviders,
     }) ?? normalizedMergedProviders;
   const finalProviders = applyNativeStreamingUsageCompat(secretEnforcedProviders);
-  const nextContents = `${JSON.stringify({ providers: finalProviders }, null, 2)}\n`;
+  // Strip apiKey from each provider before writing to models.json
+  // to prevent secret leakage into prompt context (CVE-2026-XXXX).
+  const sanitizedProviders: Record<string, unknown> = {};
+  for (const [id, provider] of Object.entries(finalProviders)) {
+    const { apiKey: _, ...rest } = provider as Record<string, unknown>;
+    sanitizedProviders[id] = rest;
+  }
+  const nextContents = `${JSON.stringify({ providers: sanitizedProviders }, null, 2)}\n`;
 
   if (params.existingRaw === nextContents) {
     return { action: "noop" };


### PR DESCRIPTION
## Description

Layer 1 quick fix for #11829: strip `apiKey` from each provider before serializing to `models.json` to prevent secret leakage into prompt context.

## Problem
The model catalog serializes resolved `apiKey` values into `models.json`, which gets included in prompt context. This can leak LLM provider keys to the agent.

## Fix
Before writing `models.json`, each provider's `apiKey` field is stripped via object destructuring. The rest of the provider config (endpoint, model list, parameters) is preserved.

## Changes
`src/agents/models-config.plan.ts`: Added sanitization step in `planOpenClawModelsJsonWithDeps()` between secret resolution and JSON serialization.

## Verification
- Existing provider resolution pipeline unchanged
- Only the serialization output is sanitized
- Runtime auth still works (apiKey is resolved at call time, not from models.json)