### PR TITLE
fix(anthropic): preserve Claude image capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/subagents: keep collect-mode announce queues batching unresolved-origin items with compatible same-route messages and resume collection after a true cross-channel drain when a later compatible batch remains. Fixes #83577.
+- Providers/Anthropic: preserve native image input for current Claude model rows when stale local catalog data marks them text-only. (#83756) Thanks @TurboTheTurtle.
 - Control UI: render live tool progress from session-scoped `session.tool` Gateway events so externally started runs show their tool cards in the active session. (#83734) Thanks @TurboTheTurtle.
 - Outbound: resolve send-capable channel plugins from the active runtime registry when the pinned startup registry only has setup metadata. (#83733) Thanks @TurboTheTurtle.
 - Browser: enforce current-tab URL allowlist checks for `/act` evaluate/batch actions and `/highlight` routes while leaving tab-management actions unblocked. (#78523)

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -345,6 +345,28 @@ describe("anthropic provider replay hooks", () => {
     expect(resolved).toBeUndefined();
   });
 
+  it("normalizes stale text-only Claude vision rows to image-capable", async () => {
+    const provider = await registerSingleProviderPlugin(anthropicPlugin);
+
+    const normalized = provider.normalizeResolvedModel?.({
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-5",
+      model: {
+        id: "claude-sonnet-4-5",
+        name: "Claude Sonnet 4.5",
+        provider: "anthropic",
+        api: "anthropic-messages",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200_000,
+        maxTokens: 64_000,
+      },
+    } as never);
+
+    expect(normalized?.input).toEqual(["text", "image"]);
+  });
+
   it("normalizes exact claude opus 4.7 variants to 1M context", async () => {
     const provider = await registerSingleProviderPlugin(anthropicPlugin);
 

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -63,11 +63,17 @@ const ANTHROPIC_SONNET_46_DOT_MODEL_ID = "claude-sonnet-4.6";
 const ANTHROPIC_SONNET_TEMPLATE_MODEL_IDS = ["claude-sonnet-4-5", "claude-sonnet-4.5"] as const;
 const ANTHROPIC_MODERN_MODEL_PREFIXES = [
   "claude-opus-4-7",
+  "claude-opus-4.7",
   "claude-opus-4-6",
+  "claude-opus-4.6",
   "claude-sonnet-4-6",
+  "claude-sonnet-4.6",
   "claude-opus-4-5",
+  "claude-opus-4.5",
   "claude-sonnet-4-5",
+  "claude-sonnet-4.5",
   "claude-haiku-4-5",
+  "claude-haiku-4.5",
 ] as const;
 const ANTHROPIC_SETUP_TOKEN_NOTE_LINES = [
   "Anthropic setup-token auth is supported in OpenClaw.",
@@ -370,6 +376,50 @@ function matchesAnthropicModernModel(modelId: string): boolean {
   return ANTHROPIC_MODERN_MODEL_PREFIXES.some((prefix) => lower.startsWith(prefix));
 }
 
+function hasImageInput(input: unknown): boolean {
+  return Array.isArray(input) && input.includes("image");
+}
+
+function supportsAnthropicImageInput(modelId: string, modelName?: string): boolean {
+  const candidates = [modelId, modelName]
+    .filter((value): value is string => typeof value === "string")
+    .map((value) => normalizeLowercaseStringOrEmpty(value))
+    .filter(Boolean);
+  return candidates.some((candidate) =>
+    ANTHROPIC_MODERN_MODEL_PREFIXES.some((prefix) => candidate.startsWith(prefix)),
+  );
+}
+
+function applyAnthropicImageInputCapability(params: {
+  modelId: string;
+  model: ProviderRuntimeModel;
+}): ProviderRuntimeModel | undefined {
+  if (hasImageInput(params.model.input)) {
+    return undefined;
+  }
+  if (!supportsAnthropicImageInput(params.modelId, params.model.name)) {
+    return undefined;
+  }
+  return {
+    ...params.model,
+    input: ["text", "image"],
+  };
+}
+
+function normalizeAnthropicResolvedModel(
+  ctx: ProviderNormalizeResolvedModelContext,
+): ProviderRuntimeModel | undefined {
+  const imageCapableModel = applyAnthropicImageInputCapability(ctx) ?? ctx.model;
+  const contextWindowModel =
+    applyAnthropicOpus47ContextWindow({
+      config: ctx.config,
+      provider: ctx.provider,
+      modelId: ctx.modelId,
+      model: imageCapableModel,
+    }) ?? imageCapableModel;
+  return contextWindowModel === ctx.model ? undefined : contextWindowModel;
+}
+
 function buildAnthropicAuthDoctorHint(params: {
   config?: ProviderAuthContext["config"];
   store: AuthProfileStore;
@@ -576,16 +626,21 @@ export function buildAnthropicProvider(): ProviderPlugin {
       if (!model) {
         return undefined;
       }
+      const imageCapableModel =
+        applyAnthropicImageInputCapability({
+          modelId: ctx.modelId,
+          model,
+        }) ?? model;
       return (
         applyAnthropicOpus47ContextWindow({
           config: ctx.config,
           provider: ctx.provider,
           modelId: ctx.modelId,
-          model,
-        }) ?? model
+          model: imageCapableModel,
+        }) ?? imageCapableModel
       );
     },
-    normalizeResolvedModel: (ctx) => applyAnthropicOpus47ContextWindow(ctx),
+    normalizeResolvedModel: (ctx) => normalizeAnthropicResolvedModel(ctx),
     resolveSyntheticAuth: ({ provider }) =>
       normalizeLowercaseStringOrEmpty(provider) === CLAUDE_CLI_BACKEND_ID
         ? resolveClaudeCliSyntheticAuth()

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -381,13 +381,9 @@ function hasImageInput(input: unknown): boolean {
 }
 
 function supportsAnthropicImageInput(modelId: string, modelName?: string): boolean {
-  const candidates = [modelId, modelName]
+  return [modelId, modelName]
     .filter((value): value is string => typeof value === "string")
-    .map((value) => normalizeLowercaseStringOrEmpty(value))
-    .filter(Boolean);
-  return candidates.some((candidate) =>
-    ANTHROPIC_MODERN_MODEL_PREFIXES.some((prefix) => candidate.startsWith(prefix)),
-  );
+    .some((candidate) => matchesAnthropicModernModel(candidate));
 }
 
 function applyAnthropicImageInputCapability(params: {

--- a/src/agents/pi-embedded-runner/model.provider-runtime.test-support.ts
+++ b/src/agents/pi-embedded-runner/model.provider-runtime.test-support.ts
@@ -14,6 +14,20 @@ const GOOGLE_GEMINI_CLI_BASE_URL = "https://cloudcode-pa.googleapis.com";
 const DEFAULT_CONTEXT_WINDOW = 200_000;
 const DEFAULT_MAX_TOKENS = 8192;
 const OPENROUTER_FALLBACK_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+const ANTHROPIC_VISION_MODEL_PREFIXES = [
+  "claude-opus-4-7",
+  "claude-opus-4.7",
+  "claude-opus-4-6",
+  "claude-opus-4.6",
+  "claude-sonnet-4-6",
+  "claude-sonnet-4.6",
+  "claude-opus-4-5",
+  "claude-opus-4.5",
+  "claude-sonnet-4-5",
+  "claude-sonnet-4.5",
+  "claude-haiku-4-5",
+  "claude-haiku-4.5",
+] as const;
 
 type ModelRegistryLike = {
   find: (provider: string, modelId: string) => unknown;
@@ -88,6 +102,20 @@ function normalizeDynamicModel(params: { provider: string; model: ResolvedModelL
         : undefined;
     if (baseUrl && baseUrl !== params.model.baseUrl) {
       return { ...params.model, baseUrl };
+    }
+    return undefined;
+  }
+  if (params.provider === "anthropic" || params.provider === "claude-cli") {
+    const candidates = [params.model.id, params.model.name]
+      .filter((value): value is string => typeof value === "string")
+      .map((value) => lowercasePreservingWhitespace(value))
+      .filter(Boolean);
+    const isKnownVisionModel = candidates.some((candidate) =>
+      ANTHROPIC_VISION_MODEL_PREFIXES.some((prefix) => candidate.startsWith(prefix)),
+    );
+    const hasImageInput = Array.isArray(params.model.input) && params.model.input.includes("image");
+    if (isKnownVisionModel && !hasImageInput) {
+      return { ...params.model, input: ["text", "image"] };
     }
     return undefined;
   }

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -1533,6 +1533,31 @@ describe("resolveModel", () => {
     expect(result.model?.input).toEqual(["text", "image"]);
   });
 
+  it("repairs stale text-only Anthropic fallback rows for Claude vision models", () => {
+    const cfg = {
+      models: {
+        providers: {
+          anthropic: {
+            baseUrl: "https://api.anthropic.com",
+            api: "anthropic-messages",
+            models: [
+              {
+                ...makeModel("claude-sonnet-4-5"),
+                name: "claude-sonnet-4-5",
+                api: "anthropic-messages",
+                input: ["text"],
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("anthropic", "claude-sonnet-4-5", "/tmp/agent", cfg);
+
+    expect(result.model?.input).toEqual(["text", "image"]);
+  });
+
   it("repairs stale text-only Foundry discovered rows for GPT-family models", () => {
     const cfg = {
       models: {


### PR DESCRIPTION
Fixes #83746.

## Summary

- Normalize known Anthropic Claude 4.x resolved models back to `input: ["text", "image"]` when stale configured/runtime rows say `["text"]`.
- Keep the existing Opus 4.7 context-window normalization composed with the new image-capability normalization.
- Add regressions for the Anthropic provider hook and the configured fallback resolver path used before PI model discovery.

## Real Behavior Proof

Behavior or issue addressed:
`/v1/responses` can accept an `input_image` and pass it into the embedded runner, but a stale configured Anthropic runtime row for `anthropic/claude-sonnet-4-5` can resolve as text-only. That causes `detectAndLoadPromptImages` to drop the native image before the Anthropic request is built.

Real environment tested:
Local OpenClaw worktree on macOS using the bundled Node runtime. The proof command used the production Anthropic provider normalizer from `extensions/anthropic/register.runtime.ts`, the production model resolver, and the production embedded-runner image sanitizer. No live Anthropic credentials were used because the bug happens before the outbound Anthropic API call.

Exact steps or command run after this patch:

```sh
PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node --import tsx -e 'import { buildAnthropicProvider } from "./extensions/anthropic/register.runtime.ts"; import { resolveModelWithRegistry } from "./src/agents/pi-embedded-runner/model.ts"; import { detectAndLoadPromptImages } from "./src/agents/pi-embedded-runner/run/images.ts"; const anthropic = buildAnthropicProvider(); const runtimeHooks = { applyProviderResolvedModelCompatWithPlugins: () => undefined, applyProviderResolvedTransportWithPlugin: () => undefined, buildProviderUnknownModelHintWithPlugin: () => undefined, prepareProviderDynamicModel: async () => {}, runProviderDynamicModel: () => undefined, shouldPreferProviderRuntimeResolvedModel: () => false, normalizeProviderResolvedModelWithPlugin: (params) => params.provider === "anthropic" ? anthropic.normalizeResolvedModel?.({ provider: params.provider, modelId: params.context.modelId, model: params.context.model, config: params.context.config }) : undefined, normalizeProviderTransportWithPlugin: () => undefined }; const cfg = { models: { providers: { anthropic: { baseUrl: "https://api.anthropic.com", api: "anthropic-messages", models: [{ id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5", api: "anthropic-messages", input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 200000, maxTokens: 64000 }] } } } }; const model = resolveModelWithRegistry({ provider: "anthropic", modelId: "claude-sonnet-4-5", modelRegistry: { find: () => null }, cfg, runtimeHooks }); const image = { type: "image", mimeType: "image/png", data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=" }; const result = await detectAndLoadPromptImages({ prompt: "describe the attached image", workspaceDir: process.cwd(), model, existingImages: [image] }); console.log(JSON.stringify({ modelId: model.id, modelInput: model.input, preservedImages: result.images.length, detectedRefs: result.detectedRefs.length, loadedCount: result.loadedCount, skippedCount: result.skippedCount, preservedMimeType: result.images[0]?.mimeType }, null, 2));'
```

Evidence after fix:

```json
{
  "modelId": "claude-sonnet-4-5",
  "modelInput": ["text", "image"],
  "preservedImages": 1,
  "detectedRefs": 0,
  "loadedCount": 0,
  "skippedCount": 0,
  "preservedMimeType": "image/png"
}
```

Observed result after fix:
A stale text-only configured Anthropic `claude-sonnet-4-5` row resolves as image-capable, and the native image is preserved through `detectAndLoadPromptImages` instead of being dropped at the model-capability gate.

What was not tested:
I did not run a live Anthropic request with real credentials. This patch fixes and proves the pre-provider image-drop path; live caption quality depends on the user’s Anthropic account/model availability.

## Validation

- `PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node scripts/run-vitest.mjs src/agents/pi-embedded-runner/model.test.ts extensions/anthropic/index.test.ts -t "Anthropic fallback|stale text-only Claude"`: 3 passed, 181 skipped.
- `PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node scripts/run-vitest.mjs src/agents/pi-embedded-runner/model.test.ts src/agents/pi-embedded-runner/run/images.test.ts src/gateway/openresponses-http.test.ts extensions/anthropic/index.test.ts`: 7 files passed, 294 tests passed. This was run outside the sandbox because `openresponses-http.test.ts` binds `127.0.0.1`.
- `PATH=/Users/andy/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH node_modules/.bin/oxfmt --check --threads=1 extensions/anthropic/register.runtime.ts extensions/anthropic/index.test.ts src/agents/pi-embedded-runner/model.provider-runtime.test-support.ts src/agents/pi-embedded-runner/model.test.ts`
- `git diff --check`

Author attribution:
Please preserve commit author attribution if this PR is squashed or reworked. If that is not possible, please include:
`Co-authored-by: Andy Ye <35905412+TurboTheTurtle@users.noreply.github.com>`
