### PR TITLE
fix(update): guide EACCES manual recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Docs: https://docs.openclaw.ai
 
 - Memory/search: scan the JS-side fallback vector path (used when the sqlite-vec index is unavailable or has a mismatched dimension) in bounded rowid batches and yield to the event loop between batches so large chunk tables can no longer pin the Node.js main thread for multi-second windows. Also keeps the SQL prepared statement rooted in a local so node:sqlite cannot finalize it mid-scan under heap pressure. Fixes #81172. Thanks @dev23xyz-oss.
 - CLI/update: bypass npm freshness filters consistently during managed package and plugin installs so freshly published release plugins remain installable. Thanks @jalehman.
+- CLI/update: guide root-owned npm install EACCES recovery by stopping the managed Gateway before manual package replacement, then reinstalling and restarting the service. Fixes #83747. (#83757) Thanks @brokemac79.
 - Agents/subagents: keep collect-mode announce queues batching unresolved-origin items with compatible same-route messages and resume collection after a true cross-channel drain when a later compatible batch remains. Fixes #83577.
 - Providers/Anthropic: preserve native image input for current Claude model rows when stale local catalog data marks them text-only. (#83756) Thanks @TurboTheTurtle.
 - Control UI: render live tool progress from session-scoped `session.tool` Gateway events so externally started runs show their tool cards in the active session. (#83734) Thanks @TurboTheTurtle.

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -124,7 +124,8 @@ Then verify the service:
 openclaw --version
 curl -fsS http://127.0.0.1:18789/readyz
 openclaw plugins list --json
-openclaw doctor --deep --lint --json
+openclaw gateway status --deep --json
+openclaw doctor --lint --json
 ```
 
 When `openclaw update` manages a global npm install, it installs the target into

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -98,10 +98,34 @@ npm i -g openclaw@latest
 ```
 
 Prefer `openclaw update` for supervised installs because it can coordinate the
-package swap with the running Gateway service. If you update manually while a
-managed Gateway is running, restart the Gateway immediately after the package
-manager finishes so the old process does not keep serving from replaced package
-files.
+package swap with the running Gateway service. If you update manually on a
+supervised install, stop the managed Gateway before the package manager starts.
+Package managers replace files in place, and a running Gateway can otherwise try
+to load core or plugin files while the package tree is temporarily half-swapped.
+Restart the Gateway after the package manager finishes so the service picks up
+the new install.
+
+For a root-owned Linux system-global install, if `openclaw update` fails with
+`EACCES` and you recover with system npm, keep the Gateway stopped through the
+manual package replacement. Use the same `openclaw` profile flags or environment
+you normally use for that Gateway. Replace `/usr/bin/npm` with the system npm
+that owns the root-owned global prefix on your host:
+
+```bash
+openclaw gateway stop
+sudo /usr/bin/npm i -g openclaw@latest
+openclaw gateway install --force
+openclaw gateway restart
+```
+
+Then verify the service:
+
+```bash
+openclaw --version
+curl -fsS http://127.0.0.1:18789/readyz
+openclaw plugins list --json
+openclaw doctor --deep --lint --json
+```
 
 When `openclaw update` manages a global npm install, it installs the target into
 a temporary npm prefix first, verifies the packaged `dist` inventory, then swaps

--- a/src/cli/update-cli/progress.test.ts
+++ b/src/cli/update-cli/progress.test.ts
@@ -64,6 +64,7 @@ describe("inferUpdateFailureHints", () => {
     const hints = inferUpdateFailureHints(result);
     expect(hints.join("\n")).toContain("EACCES");
     expect(hints.join("\n")).toContain("npm config set prefix ~/.local");
+    expect(hints.join("\n")).toContain("stop the Gateway first");
   });
 
   it("returns EACCES hint for staged package permission failures", () => {
@@ -74,6 +75,9 @@ describe("inferUpdateFailureHints", () => {
     const hints = inferUpdateFailureHints(result);
     expect(hints.join("\n")).toContain("EACCES");
     expect(hints.join("\n")).toContain("npm config set prefix ~/.local");
+    expect(hints.join("\n")).toContain("<system-npm>");
+    expect(hints.join("\n")).toContain("gateway install --force");
+    expect(hints.join("\n")).toContain("gateway restart");
   });
 
   it("returns native optional dependency hint for node-gyp failures", () => {

--- a/src/cli/update-cli/progress.ts
+++ b/src/cli/update-cli/progress.ts
@@ -85,7 +85,13 @@ export function inferUpdateFailureHints(result: UpdateRunResult): string[] {
     hints.push(
       "Detected permission failure (EACCES). Re-run with a writable global prefix or sudo (for system-managed Node installs).",
     );
+    hints.push(
+      "If you recover with sudo/manual package install on a managed Gateway, stop the Gateway first so it does not load files while the package tree is being replaced.",
+    );
     hints.push("Example: npm config set prefix ~/.local && npm i -g openclaw@latest");
+    hints.push(
+      "System install outline: openclaw gateway stop -> sudo <system-npm> i -g openclaw@latest -> openclaw gateway install --force -> openclaw gateway restart.",
+    );
   }
 
   if (


### PR DESCRIPTION
﻿## Summary

- add EACCES recovery hints that tell managed-Gateway operators to stop the Gateway before sudo/manual package recovery
- document the root-owned Linux system-global recovery path: stop Gateway, run the system npm install, refresh the Gateway service, restart, then verify
- add focused coverage for staged/global install EACCES hint text

## Why

Current main can restart the old managed Gateway after a staged package update fails with EACCES. The existing recovery hint points operators toward sudo/manual package recovery, but it does not say to stop the Gateway first. That leaves a window where the running Gateway can try to load core/plugin files while npm is replacing the package tree.

This follows ClawSweeper's narrow guidance on #83747: improve recovery hints/docs and focused tests without changing the updater lifecycle policy.

Closes #83747

## Real behavior proof

- **Behavior or issue addressed:** EACCES recovery guidance for root-owned/system-global npm installs now fails closed at the operator level by instructing users to stop the managed Gateway before manual package replacement.
- **Real environment tested:** Ubuntu VPS disposable npm-global proof environment, Node `v22.22.0`, npm `10.9.4`, throwaway `OPENCLAW_PROFILE=proof83757`, throwaway `NPM_CONFIG_PREFIX` under `/tmp`. Also validated in a Windows desktop source checkout from upstream main `424c6d0a5`, Node `v24.13.0`, pnpm `11.1.0`.
- **Exact steps or command run after this patch:** Installed `openclaw@latest` into a temp npm prefix on the VPS, applied this PR's EACCES hint change to the packaged update CLI bundle in that disposable install, made only the temp prefix's `lib/node_modules` unwritable to trigger the real `global install stage` EACCES path, then ran `OPENCLAW_PROFILE=proof83757 NPM_CONFIG_PREFIX=<temp-prefix> openclaw update --no-restart --yes --tag latest --timeout 20`.
- **Evidence after fix:** Redacted terminal output from the disposable VPS OpenClaw setup:

```text
ENV: VPS disposable proof, node=v22.22.0 npm=10.9.4 profile=proof83757
PATCH: disposable install now contains PR #83757 EACCES hint text
OpenClaw 2026.5.18 (50a2481)
COMMAND: OPENCLAW_PROFILE=proof83757 NPM_CONFIG_PREFIX=<temp-prefix> openclaw update --no-restart --yes --tag latest --timeout 20
EXIT_CODE: 1

Update Result: ERROR
  Root: /tmp/openclaw-83757-proof-REDACTED/prefix/lib/node_modules/openclaw
  Reason: global install stage
  Before: 2026.5.18
  After: 2026.5.18

Steps:
  x global install stage (0ms)
      EACCES: permission denied, mkdtemp '/tmp/openclaw-83757-proof-REDACTED/prefix/lib/node_modules/.openclaw-update-stage-S2S8Ob'

Recovery hints:
  - Detected permission failure (EACCES). Re-run with a writable global prefix or sudo (for system-managed Node installs).
  - If you recover with sudo/manual package install on a managed Gateway, stop the Gateway first so it does not load files while the package tree is being replaced.
  - Example: npm config set prefix ~/.local && npm i -g openclaw@latest
  - System install outline: openclaw gateway stop -> sudo <system-npm> i -g openclaw@latest -> openclaw gateway install --force -> openclaw gateway restart.

Total time: 473ms
ASSERT: proof output contains EACCES recovery hints from patched CLI/update path
CLEANUP: removed disposable proof directory
```

- **Observed result after fix:** The real CLI/update `global install stage` EACCES path prints the new stop-before-manual-recovery guidance and the system install outline with `gateway install --force` and `gateway restart`.
- **What was not tested:** I did not perform a destructive package replacement against the live production OpenClaw install; this PR intentionally changes guidance/tests only and does not alter package-manager lifecycle behavior. The VPS proof used a disposable temp npm prefix/cache/home/profile only. The temp proof directory was removed after capture. I did not hotfix, cherry-pick into, stop, restart, or otherwise mutate the live VPS OpenClaw install/gateway.

## Validation

```text
node scripts/run-vitest.mjs src/cli/update-cli/progress.test.ts -- --reporter=verbose
Test Files  1 passed (1)
Tests       6 passed (6)
```

```text
git diff --check
# no output
```

```text
codex-review
codex-review clean: no accepted/actionable findings reported
```